### PR TITLE
No first layer acceleration/jerk for travel

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -5711,21 +5711,13 @@ std::string GCode::travel_to(const Point& point, ExtrusionRole role, std::string
     // Orca: we don't need to optimize the Klipper as only set once
     double jerk_to_set = 0.0;
     unsigned int acceleration_to_set = 0;
-    if (this->on_first_layer()) {
-        if (m_config.default_acceleration.value > 0 && m_config.initial_layer_acceleration.value > 0) {
-            acceleration_to_set = (unsigned int) floor(m_config.initial_layer_acceleration.value + 0.5);
-        }
-        if (m_config.default_jerk.value > 0 && m_config.initial_layer_jerk.value > 0) {
-            jerk_to_set = m_config.initial_layer_jerk.value;
-        }
-    } else {
-        if (m_config.default_acceleration.value > 0 && m_config.travel_acceleration.value > 0) {
-            acceleration_to_set = (unsigned int) floor(m_config.travel_acceleration.value + 0.5);
-        }
-        if (m_config.default_jerk.value > 0 && m_config.travel_jerk.value > 0) {
-            jerk_to_set = m_config.travel_jerk.value;
-        }
+    if (m_config.default_acceleration.value > 0 && m_config.travel_acceleration.value > 0) {
+        acceleration_to_set = (unsigned int) floor(m_config.travel_acceleration.value + 0.5);
     }
+    if (m_config.default_jerk.value > 0 && m_config.travel_jerk.value > 0) {
+        jerk_to_set = m_config.travel_jerk.value;
+    }
+
     if (m_writer.get_gcode_flavor() == gcfKlipper) {
         gcode += m_writer.set_accel_and_jerk(acceleration_to_set, jerk_to_set);
     } else {


### PR DESCRIPTION
Use travel acceleration/jerk also on first layer. Limiting these values could assist bed adhesion, but it seems no meaning to use it for travel.

![image](https://github.com/user-attachments/assets/e063619f-88b5-4e24-bdda-8953e107c481)
