### PR TITLE
Add runtime and compiletime option to disable version checks in gui (…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,6 +166,13 @@ endif ()
 option(SLIC3R_BUILD_SANDBOXES   "Build development sandboxes" OFF)
 option(BUILD_TESTS       "Build unit tests" OFF)
 option(ORCA_TOOLS       "Build Orca tools" OFF)
+option(ORCA_VERSION_CHECK_DEFAULT "Whether to check for new versions on startup by default" ON)
+
+if (ORCA_VERSION_CHECK_DEFAULT)
+  add_definitions(-DORCA_VERSION_CHECK_DEFAULT=true)
+else ()
+  add_definitions(-DORCA_VERSION_CHECK_DEFAULT=false)
+endif ()
 
 if (FLATPAK)
     set(SLIC3R_FHS ON CACHE BOOL "" FORCE)

--- a/README.md
+++ b/README.md
@@ -188,6 +188,10 @@ If you're running Klipper, it's recommended to add the following configuration t
 resolution: 0.1
 ```
 
+# Note if building for a package manager
+
+If you're building this as a package for a package manager (`apt`, `brew`, `pacman`, `nix`, `chocolatey`, etc.) where the user is not going to be manually updating the software, you should disable the version check with `-DORCA_VERSION_CHECK_DEFAULT=OFF` flag to cmake
+
 # Supports
 
 **OrcaSlicer** is an open-source project and I'm deeply grateful to all my sponsors and backers.  

--- a/src/libslic3r/AppConfig.cpp
+++ b/src/libslic3r/AppConfig.cpp
@@ -575,6 +575,12 @@ void AppConfig::set_defaults()
     if (get("print", "timelapse").empty()) {
         set_str("print", "timelapse", "1");
     }
+    if (get("do_version_check").empty()) {
+#ifndef ORCA_VERSION_CHECK_DEFAULT
+#define ORCA_VERSION_CHECK_DEFAULT true
+#endif
+      set_bool("do_version_check", ORCA_VERSION_CHECK_DEFAULT);
+    }
 
     if (get("enable_step_mesh_setting").empty()) {
         set_bool("enable_step_mesh_setting", true);

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -940,7 +940,9 @@ void GUI_App::post_init()
                 this->preset_updater->sync(http_url, language, network_ver, sys_preset ? preset_bundle : nullptr);
             }
 
-            this->check_new_version_sf();
+            if (this->preset_updater->version_check_enabled()) {
+                this->check_new_version_sf();
+            }
             const auto cloud_provider = get_printer_cloud_provider();
             if (is_user_login(cloud_provider) && !app_config->get_stealth_mode()) {
               // this->check_privacy_version(0);
@@ -2425,14 +2427,14 @@ void GUI_App::init_app_config()
     BOOST_LOG_TRIVIAL(info) << boost::format("gui mode, Current OrcaSlicer Version %1% build %2%") % SoftFever_VERSION % GIT_COMMIT_HASH;
 
     //BBS: remove GCodeViewer as seperate APP logic
-	if (!app_config)
+    if (!app_config)
         app_config = new AppConfig();
         //app_config = new AppConfig(is_editor() ? AppConfig::EAppMode::Editor : AppConfig::EAppMode::GCodeViewer);
 
     m_config_corrupted = false;
-	// load settings
-	m_app_conf_exists = app_config->exists();
-	if (m_app_conf_exists) {
+    // load settings
+    m_app_conf_exists = app_config->exists();
+    if (m_app_conf_exists) {
         std::string error = app_config->load();
         if (!error.empty()) {
             // Orca: if the config file is corrupted, we will show a error dialog and create a default config file.

--- a/src/slic3r/Utils/PresetUpdater.cpp
+++ b/src/slic3r/Utils/PresetUpdater.cpp
@@ -251,7 +251,6 @@ PresetUpdater::priv::priv()
 	, cancel(false)
 {
 	//BBS: refine preset updater logic
-	enabled_version_check = true;
 	set_download_prefs(GUI::wxGetApp().app_config);
 	// Install indicies from resources. Only installs those that are either missing or older than in resources.
 	check_installed_vendor_profiles();
@@ -264,6 +263,7 @@ PresetUpdater::priv::priv()
 void PresetUpdater::priv::set_download_prefs(AppConfig *app_config)
 {
 	version_check_url = app_config->version_check_url();
+	enabled_version_check = app_config->get_bool("do_version_check");
 
 	auto profile_update_url = app_config->profile_update_url();
 	if (!profile_update_url.empty())


### PR DESCRIPTION
# Description

This only partially addresses #7291. There is still no option in the gui for this.

# Screenshots/Recordings/Graphs

Not sure what screenshots I could take that would be helpful here

## Tests

(ran on d10a06ae11089cd1f63705e87f558e9392f7a167)

- rebased on old version (so that the update dialog would trigger)
- deleted config dir (`~/.config/OrcaSlicer`)
- compiled and ran with default options. Confirmed that the update dialog shows up and `"do_version_check": true` in config file.
- edited config to `"do_version_check": false`, update dialog does not show.
- deleted config dir again
- compiled and ran, this time passing `-DORCA_VERSION_CHECK_DEFAULT=OFF` to cmake. Confirmed that the update dialog does not show.
