### PR TITLE
Fix FanMover and thus filament purge on Bambu Lab P and X series when the "filament speed-up time" feature is used

### DIFF
--- a/src/libslic3r/GCode/FanMover.cpp
+++ b/src/libslic3r/GCode/FanMover.cpp
@@ -1,6 +1,7 @@
 #include "FanMover.hpp"
 
 #include "GCodeReader.hpp"
+#include "GCodeProcessor.hpp"
 
 #include <iomanip>
 /*
@@ -16,8 +17,10 @@
 #include <boost/log/trivial.hpp>
 */
 
-
 namespace Slic3r {
+
+const std::string& FanMover::custom_gcode_start_marker = "; custom gcode";
+const std::string& FanMover::custom_gcode_end_marker = "; custom gcode end";
 
 const std::string& FanMover::process_gcode(const std::string& gcode, bool flush)
 {
@@ -33,8 +36,7 @@ const std::string& FanMover::process_gcode(const std::string& gcode, bool flush)
 
     if (flush) {
         while (!m_buffer.empty()) {
-            m_process_output += m_buffer.front().raw + "\n";
-            remove_from_buffer(m_buffer.begin());
+            write_buffer_data();
         }
     }
 
@@ -95,12 +97,18 @@ int16_t get_fan_speed(const std::string &line, GCodeFlavor flavor) {
 
 }
 
-void FanMover::_put_in_middle_G1(std::list<BufferData>::iterator item_to_split, float nb_sec_since_itemtosplit_start, BufferData &&line_to_write) {
+void FanMover::_put_in_middle_G1(std::list<BufferData>::iterator item_to_split, float nb_sec_since_itemtosplit_start, BufferData &&line_to_write, float max_time) {
     assert(item_to_split != m_buffer.end());
-    if (nb_sec_since_itemtosplit_start > item_to_split->time * 0.9) {
+    // if the fan is at the end of the g1 and the diff is less than 10% of the delay, then don't bother
+    if (nb_sec_since_itemtosplit_start > item_to_split->time * 0.9 && (item_to_split->time - nb_sec_since_itemtosplit_start) < max_time * 0.1) {
         // doesn't really need to be split, print it after
         m_buffer.insert(next(item_to_split), line_to_write);
-    } else if (nb_sec_since_itemtosplit_start < item_to_split->time * 0.1) {
+    } else
+        // does it need to be split?
+        // if it's almost at the start of the g1, and the time "lost" is less than 10%
+        if (nb_sec_since_itemtosplit_start < item_to_split->time * 0.1 && nb_sec_since_itemtosplit_start < max_time * 0.1 &&
+        // and the previous isn't a fan value
+        (item_to_split == m_buffer.begin() || std::prev(item_to_split)->fan_speed < 0)) {
         // doesn't really need to be split, print it before
         //will also print before if line_to_split.time == 0
         m_buffer.insert(item_to_split, line_to_write);
@@ -263,7 +271,7 @@ void FanMover::_process_gcode_line(GCodeReader& reader, const GCodeReader::GCode
     std::string cmd(line.cmd());
     double time = 0;
     int16_t fan_speed = -1;
-    if (cmd.length() > 1) {
+    if (cmd.length() > 1 && !m_is_custom_gcode) {
         if (line.has_f())
             m_current_speed = line.f() / 60.0f;
         switch (::toupper(cmd[0])) {
@@ -282,6 +290,15 @@ void FanMover::_process_gcode_line(GCodeReader& reader, const GCodeReader::GCode
                     dist = std::sqrt(dist);
                     time = dist / m_current_speed;
                 }
+            } else if (::atoi(&cmd[1]) == 2 || ::atoi(&cmd[1]) == 3) {
+                // TODO: compute real dist
+                double distx = line.dist_X(reader);
+                double disty = line.dist_Y(reader);
+                double dist = distx * distx + disty * disty;
+                if (dist > 0) {
+                    dist = std::sqrt(dist);
+                    time = dist / m_current_speed;
+                }
             }
             break;
         }
@@ -291,110 +308,112 @@ void FanMover::_process_gcode_line(GCodeReader& reader, const GCodeReader::GCode
             if (fan_speed >= 0) {
                 const auto fan_baseline = 255.0;
                 fan_speed = 100 * fan_speed / fan_baseline;
-                //speed change: stop kickstart reverting if any
-                m_current_kickstart.time = -1;
-                if (!m_is_custom_gcode) {
-                    // if slow down => put in the queue. if not =>
-                    if (m_back_buffer_fan_speed < fan_speed) {
-                        if (nb_seconds_delay > 0 && (!only_overhangs || current_role == ExtrusionRole::erOverhangPerimeter)) {
-                            //don't put this command in the queue
-                            time = -1;
-                            // this M106 need to go in the past
-                            //check if we have ( kickstart and not in slowdown )
-                            if (kickstart > 0 && fan_speed > m_front_buffer_fan_speed) {
-                                //stop current kickstart , it's not relevant anymore
-                                if (m_current_kickstart.time > 0) {
-                                    m_current_kickstart.time = (-1);
-                                }
-
-                                //if kickstart
-                                // first erase everything lower that that value
-                                _remove_slow_fan(fan_speed, m_buffer_time_size + 1);
-                                // then erase everything lower that kickstart
-                                _remove_slow_fan(fan_baseline, kickstart);
-                                // print me
-                                if (!m_buffer.empty() && (m_buffer_time_size - m_buffer.front().time * 0.1) > nb_seconds_delay) {
-                                    _print_in_middle_G1(m_buffer.front(), m_buffer_time_size - nb_seconds_delay, _set_fan(100));//m_writer.set_fan(100, true)); //FIXME extruder id (or use the gcode writer, but then you have to disable the multi-thread thing
-                                    remove_from_buffer(m_buffer.begin());
-                                } else {
-                                    m_process_output += _set_fan(100);//m_writer.set_fan(100, true)); //FIXME extruder id (or use the gcode writer, but then you have to disable the multi-thread thing
-                                }
-                                //write it in the queue if possible
-                                const float kickstart_duration = kickstart * float(fan_speed - m_front_buffer_fan_speed) / 100.f;
-                                float time_count = kickstart_duration;
-                                auto it = m_buffer.begin();
-                                while (it != m_buffer.end() && time_count > 0) {
-                                    time_count -= it->time;
-                                    if (time_count< 0) {
-                                        //found something that is lower than us
-                                        _put_in_middle_G1(it, it->time + time_count, BufferData(std::string(line.raw()), 0, fan_speed, true));
-                                        //found, stop
-                                        break;
-                                    }
-                                    ++it;
-                                }
-                                if (time_count > 0) {
-                                    //can't place it in the buffer, use m_current_kickstart
-                                    m_current_kickstart.fan_speed = fan_speed;
-                                    m_current_kickstart.time = time_count;
-                                    m_current_kickstart.raw = line.raw();
-                                }
-                                m_front_buffer_fan_speed = fan_speed;
-                            } else {
-                                // first erase everything lower that that value
-                                _remove_slow_fan(fan_speed, m_buffer_time_size + 1);
-                                // then write the fan command
-                                if (!m_buffer.empty() && (m_buffer_time_size - m_buffer.front().time * 0.1) > nb_seconds_delay) {
-                                    _print_in_middle_G1(m_buffer.front(), m_buffer_time_size - nb_seconds_delay, line.raw());
-                                    remove_from_buffer(m_buffer.begin());
-                                } else {
-                                    m_process_output += line.raw() + "\n";
-                                }
-                                m_front_buffer_fan_speed = fan_speed;
+                // if slow down => put in the queue. if not =>
+                if (m_current_kickstart.time > 0) {
+                    assert(m_back_buffer_fan_speed == m_current_kickstart.fan_speed);
+                }
+                if (m_back_buffer_fan_speed >= fan_speed) {
+                    if (m_current_kickstart.time > 0) {
+                        // stop kiskstart, and slow down
+                        m_current_kickstart.time = -1;
+                        //this fan speed will be printed, to make and end to the kickstart
+                    }
+                } else {
+                    if (nb_seconds_delay > 0) {
+                        //don't put this command in the queue
+                        time = -1;
+                        // this M106 need to go in the past
+                        //check if we have ( kickstart and not in slowdown )
+                        if (kickstart > 0 && fan_speed > m_front_buffer_fan_speed) {
+                            //stop current kickstart , it's not relevant anymore
+                            if (m_current_kickstart.time > 0) {
+                                m_current_kickstart.time = (-1);
                             }
-                        } else {
-                            if (kickstart <= 0) {
-                                //nothing to do
-                                //we don't put time = -1; so it will printed in the buffer as other line are done
-                            } else if (m_current_kickstart.time > 0) {
-                                //cherry-pick this one
-                                if (m_back_buffer_fan_speed >= fan_speed) {
-                                    //stop kickstart
-                                    m_current_kickstart.time = -1;
-                                    //this will print me just after as time >=0
-                                } else {
-                                    // add some duration to the kickstart and use it for me.
-                                    float kickstart_duration = kickstart * float(fan_speed - m_back_buffer_fan_speed) / 100.f;
-                                    m_current_kickstart.fan_speed = fan_speed;
-                                    m_current_kickstart.time += kickstart_duration;
-                                    m_current_kickstart.raw = line.raw();
-                                    //i'm printed by the m_current_kickstart
-                                    time = -1;
+
+                            //if kickstart
+                            // first erase everything lower that that value
+                            _remove_slow_fan(fan_speed, m_buffer_time_size + 1);
+                            // then erase everything lower that kickstart
+                            _remove_slow_fan(fan_baseline, kickstart);
+                            // print me
+                            if (!m_buffer.empty() && (m_buffer_time_size - m_buffer.front().time * 0.1) > nb_seconds_delay) {
+                                _print_in_middle_G1(m_buffer.front(), m_buffer_time_size - nb_seconds_delay, _set_fan(100));//m_writer.set_fan(100, true)); //FIXME extruder id (or use the gcode writer, but then you have to disable the multi-thread thing
+                                remove_from_buffer(m_buffer.begin());
+                            } else {
+                                m_process_output += _set_fan(100);//m_writer.set_fan(100, true)); //FIXME extruder id (or use the gcode writer, but then you have to disable the multi-thread thing
+                            }
+                            //write it in the queue if possible
+                            const float kickstart_duration = kickstart * float(fan_speed - m_front_buffer_fan_speed) / 100.f;
+                            float time_count = kickstart_duration;
+                            auto it = m_buffer.begin();
+                            while (it != m_buffer.end() && time_count > 0) {
+                                time_count -= it->time;
+                                if (time_count< 0) {
+                                    //found something that is lower than us
+                                    _put_in_middle_G1(it, it->time + time_count, BufferData(std::string(line.raw()), 0, fan_speed, true), nb_seconds_delay);
+                                    //found, stop
+                                    break;
                                 }
-                            } else if(m_back_buffer_fan_speed < fan_speed - 10){ //only kickstart if more than 10% change
-                                //don't write this line, as it will need to be delayed
-                                time = -1;
-                                //get the duration of kickstart
-                                float kickstart_duration = kickstart * float(fan_speed - m_back_buffer_fan_speed) / 100.f;
-                                //if kickstart, write the M106 S[fan_baseline] first
-                                //set the target speed and set the kickstart flag
-                                put_in_buffer(BufferData(_set_fan(100)//m_writer.set_fan(100, true)); //FIXME extruder id (or use the gcode writer, but then you have to disable the multi-thread thing
-                                    , 0, fan_speed, true));
-                                //kickstart!
-                                //m_process_output += m_writer.set_fan(100, true);
-                                //add the normal speed line for the future
+                                ++it;
+                            }
+                            if (time_count > 0) {
+                                //can't place it in the buffer, use m_current_kickstart
                                 m_current_kickstart.fan_speed = fan_speed;
-                                m_current_kickstart.time = kickstart_duration;
+                                m_current_kickstart.time = time_count;
                                 m_current_kickstart.raw = line.raw();
                             }
+                            m_front_buffer_fan_speed = fan_speed;
+                        } else {
+                            // first erase everything lower that that value
+                            _remove_slow_fan(fan_speed, m_buffer_time_size + 1);
+                            // then write the fan command
+                            if (!m_buffer.empty() && (m_buffer_time_size - m_buffer.front().time * 0.1) > nb_seconds_delay) {
+                                _print_in_middle_G1(m_buffer.front(), m_buffer_time_size - nb_seconds_delay, line.raw());
+                                remove_from_buffer(m_buffer.begin());
+                            } else {
+                                m_process_output += line.raw() + "\n";
+                            }
+                            m_front_buffer_fan_speed = fan_speed;
+                        }
+                    } else {
+                        if (kickstart <= 0) {
+                            //nothing to do
+                            //we don't put time = -1; so it will printed in the buffer as other line are done
+                        } else if (m_current_kickstart.time > 0) {
+                            //cherry-pick this one
+                            if (m_back_buffer_fan_speed >= fan_speed) {
+                                //stop kickstart
+                                m_current_kickstart.time = -1;
+                                //this will print me just after as time >=0
+                            } else {
+                                // add some duration to the kickstart and use it for me.
+                                float kickstart_duration = kickstart * float(fan_speed - m_back_buffer_fan_speed) / 100.f;
+                                m_current_kickstart.fan_speed = fan_speed;
+                                m_current_kickstart.time += kickstart_duration;
+                                m_current_kickstart.raw = line.raw();
+                                //i'm printed by the m_current_kickstart
+                                time = -1;
+                            }
+                        } else if(m_back_buffer_fan_speed < fan_speed - 10){ //only kickstart if more than 10% change
+                            //don't write this line, as it will need to be delayed
+                            time = -1;
+                            //get the duration of kickstart
+                            float kickstart_duration = kickstart * float(fan_speed - m_back_buffer_fan_speed) / 100.f;
+                            //if kickstart, write the M106 S[fan_baseline] first
+                            //set the target speed and set the kickstart flag
+                            put_in_buffer(BufferData(_set_fan(100)//m_writer.set_fan(100, true)); //FIXME extruder id (or use the gcode writer, but then you have to disable the multi-thread thing
+                                , 0, fan_speed, true));
+                            //kickstart!
+                            //m_process_output += m_writer.set_fan(100, true);
+                            //add the normal speed line for the future
+                            m_current_kickstart.fan_speed = fan_speed;
+                            m_current_kickstart.time = kickstart_duration;
+                            m_current_kickstart.raw = line.raw();
                         }
                     }
-                    //update back buffer fan speed
-                    m_back_buffer_fan_speed = fan_speed;
-                } else {
-                    // have to flush the buffer to avoid erasing a fan command.
-                    need_flush = true;
                 }
+                //update back buffer fan speed
+                m_back_buffer_fan_speed = fan_speed;
             }
             break;
         }
@@ -402,17 +421,13 @@ void FanMover::_process_gcode_line(GCodeReader& reader, const GCodeReader::GCode
     } else {
         if(!line.raw().empty() && line.raw().front() == ';')
         {
-            if (line.raw().size() > 10 && line.raw().rfind(";TYPE:", 0) == 0) {
-                // get the type of the next extrusions
-                std::string extrusion_string = line.raw().substr(6, line.raw().size() - 6);
-                current_role = ExtrusionEntity::string_to_role(extrusion_string);
-            }
-            if (line.raw().size() > 16) {
-                if (line.raw().rfind("; custom gcode", 0) != std::string::npos)
-                    if (line.raw().rfind("; custom gcode end", 0) != std::string::npos)
+            if (line.raw().size() > 13) {
+                if (line.raw().rfind(custom_gcode_start_marker, 0) != std::string::npos) {
+                    if (line.raw().rfind(custom_gcode_end_marker, 0) != std::string::npos)
                         m_is_custom_gcode = false;
                     else
                         m_is_custom_gcode = true;
+                }
             }
         }
     }
@@ -433,17 +448,24 @@ void FanMover::_process_gcode_line(GCodeReader& reader, const GCodeReader::GCode
         }
         if (line.has(Axis::E)) {
             new_data.e = reader.e();
-            if (relative_e)
+            if (relative_e) {
+                assert(new_data.e == 0);
                 new_data.de = line.e();
-            else
+            } else
                 new_data.de = line.dist_E(reader);
         }
+        assert(new_data.dx == 0 || reader.x() == new_data.x);
+        assert(new_data.dx == 0 || reader.x() + new_data.dx == line.x());
+        assert(new_data.dy == 0 ||reader.y() == new_data.y);
+        assert(new_data.dy == 0 || reader.y() + new_data.dy == line.y());
+        assert(new_data.de == 0 || reader.e() == new_data.e);
+        assert(new_data.de == 0 || reader.e() + new_data.de == line.e());
 
         if (m_current_kickstart.time > 0 && time > 0) {
             m_current_kickstart.time -= time;
             if (m_current_kickstart.time < 0) {
                 //prev is possible because we just do a emplace_back.
-                _put_in_middle_G1(prev(m_buffer.end()), time + m_current_kickstart.time, BufferData{ m_current_kickstart.raw, 0, m_current_kickstart.fan_speed, true });
+                _put_in_middle_G1(prev(m_buffer.end()), time + m_current_kickstart.time, BufferData{ m_current_kickstart.raw, 0, m_current_kickstart.fan_speed, true }, kickstart);
             }
         }
     }/* else {
@@ -471,24 +493,8 @@ void FanMover::_process_gcode_line(GCodeReader& reader, const GCodeReader::GCode
     // puts the line back into the gcode
     //if buffer too big, flush it.
     if (time >= 0) {
-        while (!m_buffer.empty() && (need_flush || m_buffer_time_size - m_buffer.front().time > nb_seconds_delay - EPSILON) ){
-            BufferData& frontdata = m_buffer.front();
-            if (frontdata.fan_speed < 0 || frontdata.fan_speed != m_front_buffer_fan_speed || frontdata.is_kickstart) {
-                if (frontdata.is_kickstart && frontdata.fan_speed < m_front_buffer_fan_speed) {
-                    //you have to slow down! not kickstart! rewrite the fan speed.
-                    m_process_output += _set_fan(frontdata.fan_speed);//m_writer.set_fan(frontdata.fan_speed,true); //FIXME extruder id (or use the gcode writer, but then you have to disable the multi-thread thing
-                        
-                    m_front_buffer_fan_speed = frontdata.fan_speed;
-                } else {
-                    m_process_output += frontdata.raw + "\n";
-                    if (frontdata.fan_speed >= 0) {
-                        //note that this is the only place where the fan_speed is set and we print from the buffer, as if the fan_speed >= 0 => time == 0
-                        //and as this flush all time == 0 lines from the back of the queue...
-                        m_front_buffer_fan_speed = frontdata.fan_speed;
-                    }
-                }
-            }
-            remove_from_buffer(m_buffer.begin());
+        while (!m_buffer.empty() && (m_is_custom_gcode || m_buffer_time_size - m_buffer.front().time > nb_seconds_delay - EPSILON) ){
+            write_buffer_data();
         }
     }
     double sum = 0;
@@ -496,5 +502,24 @@ void FanMover::_process_gcode_line(GCodeReader& reader, const GCodeReader::GCode
     assert( std::abs(m_buffer_time_size - sum) < 0.01);
 }
 
-} // namespace Slic3r
+void FanMover::write_buffer_data()
+{
+    BufferData &frontdata = m_buffer.front();
+    if (frontdata.fan_speed < 0 || frontdata.fan_speed != m_front_buffer_fan_speed || frontdata.is_kickstart) {
+        if (frontdata.is_kickstart && frontdata.fan_speed < m_front_buffer_fan_speed) {
+            // you have to slow down! not kickstart! rewrite the fan speed.
+            m_process_output += _set_fan(frontdata.fan_speed) + "\n";
+            m_front_buffer_fan_speed = frontdata.fan_speed;
+        } else {
+            m_process_output += frontdata.raw + "\n";
+            if (frontdata.fan_speed >= 0 || frontdata.is_kickstart) {
+                // note that this is the only place where the fan_speed is set and we print from the buffer, as if the
+                // fan_speed >= 0 => time == 0 and as this flush all time == 0 lines from the back of the queue...
+                m_front_buffer_fan_speed = frontdata.is_kickstart ? 100 : frontdata.fan_speed;
+            }
+        }
+    }
+    remove_from_buffer(m_buffer.begin());
+}
 
+} // namespace Slic3r

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -796,7 +796,7 @@ static std::vector<std::string> s_Preset_print_options {
      "detect_narrow_internal_solid_infill",
      "gcode_add_line_number", "enable_arc_fitting", "precise_z_height", "infill_combination","infill_combination_max_layer_height", /*"adaptive_layer_height",*/
      "support_bottom_interface_spacing", "enable_overhang_speed", "slowdown_for_curled_perimeters", "overhang_1_4_speed", "overhang_2_4_speed", "overhang_3_4_speed", "overhang_4_4_speed",
-     "initial_layer_infill_speed", "only_one_wall_top", 
+     "initial_layer_infill_speed", "only_one_wall_top",
      "timelapse_type",
      "wall_generator", "wall_transition_length", "wall_transition_filter_deviation", "wall_transition_angle",
      "wall_distribution_count", "min_feature_size", "min_bead_width", "post_process", "min_length_factor",
@@ -805,7 +805,7 @@ static std::vector<std::string> s_Preset_print_options {
      "top_solid_infill_flow_ratio","bottom_solid_infill_flow_ratio","only_one_wall_first_layer", "print_flow_ratio", "seam_gap",
      "role_based_wipe_speed", "wipe_speed", "accel_to_decel_enable", "accel_to_decel_factor", "wipe_on_loops", "wipe_before_external_loop",
      "bridge_density", "precise_outer_wall", "overhang_speed_classic", "bridge_acceleration",
-     "sparse_infill_acceleration", "internal_solid_infill_acceleration", "tree_support_adaptive_layer_height", "tree_support_auto_brim", 
+     "sparse_infill_acceleration", "internal_solid_infill_acceleration", "tree_support_adaptive_layer_height", "tree_support_auto_brim",
      "tree_support_brim_width", "gcode_comments", "gcode_label_objects",
      "initial_layer_travel_speed", "exclude_object", "slow_down_layers", "infill_anchor", "infill_anchor_max","initial_layer_min_bead_width",
      "make_overhang_printable", "make_overhang_printable_angle", "make_overhang_printable_hole_size" ,"notes",
@@ -859,7 +859,7 @@ static std::vector<std::string> s_Preset_machine_limits_options {
 static std::vector<std::string> s_Preset_printer_options {
     "printer_technology",
     "printable_area", "bed_exclude_area","bed_custom_texture", "bed_custom_model", "gcode_flavor",
-    "fan_kickstart", "fan_speedup_time", "fan_speedup_overhangs",
+    "fan_kickstart", "fan_speedup_time",
     "single_extruder_multi_material", "manual_filament_change", "machine_start_gcode", "machine_end_gcode", "before_layer_change_gcode", "printing_by_object_gcode", "layer_change_gcode", "time_lapse_gcode", "change_filament_gcode", "change_extrusion_role_gcode",
     "printer_model", "printer_variant", "printable_height", "extruder_clearance_radius", "extruder_clearance_height_to_lid", "extruder_clearance_height_to_rod",
     "nozzle_height",
@@ -2465,7 +2465,7 @@ const std::string& PresetCollection::get_preset_name_by_alias(const std::string&
             it_preset->is_visible && (it_preset->is_compatible || size_t(it_preset - m_presets.begin()) == m_idx_selected))
 	        return it_preset->name;
         }
-		
+
     return alias;
 }
 
@@ -3578,7 +3578,7 @@ namespace PresetUtils {
             if (!boost::filesystem::exists(boost::filesystem::path(out)))
                 out = Slic3r::resources_dir() + "/profiles/" + preset.vendor->id + "/" + pm->hotend_model;
         }
-        
+
         if (out.empty() ||!boost::filesystem::exists(boost::filesystem::path(out)))
             out = Slic3r::resources_dir() + "/profiles/hotend.stl";
         return out;

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -112,7 +112,6 @@ bool Print::invalidate_state_by_config_options(const ConfigOptionResolver & /* n
         "fan_cooling_layer_time",
         "full_fan_speed_layer",
         "fan_kickstart",
-        "fan_speedup_overhangs",
         "fan_speedup_time",
         "filament_colour",
         "default_filament_colour",
@@ -154,7 +153,7 @@ bool Print::invalidate_state_by_config_options(const ConfigOptionResolver & /* n
         "z_hop",
         "travel_slope",
         "retract_lift_above",
-        "retract_lift_below", 
+        "retract_lift_below",
         "retract_lift_enforce",
         "retract_restart_extra",
         "retract_restart_extra_toolchange",
@@ -188,7 +187,7 @@ bool Print::invalidate_state_by_config_options(const ConfigOptionResolver & /* n
         "accel_to_decel_factor",
         "wipe_on_loops",
         "gcode_comments",
-        "gcode_label_objects", 
+        "gcode_label_objects",
         "exclude_object",
         "support_material_interface_fan_speed",
         "single_extruder_multi_material_priming",
@@ -280,7 +279,7 @@ bool Print::invalidate_state_by_config_options(const ConfigOptionResolver & /* n
             || opt_key == "prime_tower_brim_width"
             || opt_key == "first_layer_print_sequence"
             || opt_key == "other_layers_print_sequence"
-            || opt_key == "other_layers_print_sequence_nums" 
+            || opt_key == "other_layers_print_sequence_nums"
             || opt_key == "wipe_tower_bridging"
             || opt_key == "wipe_tower_extra_flow"
             || opt_key == "wipe_tower_no_sparse_layers"
@@ -1132,7 +1131,7 @@ StringObjectException Print::validate(StringObjectException *warning, Polygons* 
 
             Vec3d test =this->shrinkage_compensation();
             const double shrinkage_compensation_z = this->shrinkage_compensation().z();
-            
+
             if (shrinkage_compensation_z != 1. && layers.back() > (this->config().printable_height / shrinkage_compensation_z + EPSILON)) {
                 // The object exceeds the maximum build volume height because of shrinkage compensation.
                 return StringObjectException{
@@ -1155,14 +1154,14 @@ StringObjectException Print::validate(StringObjectException *warning, Polygons* 
     }
 
     // Some of the objects has variable layer height applied by painting or by a table.
-    bool has_custom_layering = std::find_if(m_objects.begin(), m_objects.end(), 
-        [](const PrintObject *object) { return object->model_object()->has_custom_layering(); }) 
+    bool has_custom_layering = std::find_if(m_objects.begin(), m_objects.end(),
+        [](const PrintObject *object) { return object->model_object()->has_custom_layering(); })
         != m_objects.end();
 
     // Custom layering is not allowed for tree supports as of now.
     for (size_t print_object_idx = 0; print_object_idx < m_objects.size(); ++ print_object_idx)
         if (const PrintObject &print_object = *m_objects[print_object_idx];
-            print_object.has_support_material() && is_tree(print_object.config().support_type.value) && (print_object.config().support_style.value == smsOrganic || 
+            print_object.has_support_material() && is_tree(print_object.config().support_type.value) && (print_object.config().support_style.value == smsOrganic ||
                 // Orca: use organic as default
                 print_object.config().support_style.value == smsDefault) &&
             print_object.model_object()->has_custom_layering()) {
@@ -1193,7 +1192,7 @@ StringObjectException Print::validate(StringObjectException *warning, Polygons* 
 
         if (m_config.ooze_prevention && m_config.single_extruder_multi_material)
             return {L("Ooze prevention is only supported with the wipe tower when 'single_extruder_multi_material' is off.")};
-            
+
 #if 0
         if (m_config.gcode_flavor != gcfRepRapSprinter && m_config.gcode_flavor != gcfRepRapFirmware &&
             m_config.gcode_flavor != gcfRepetier && m_config.gcode_flavor != gcfMarlinLegacy && m_config.gcode_flavor != gcfMarlinFirmware)
@@ -1251,7 +1250,7 @@ StringObjectException Print::validate(StringObjectException *warning, Polygons* 
             if (has_custom_layering) {
                 std::vector<std::vector<coordf_t>> layer_z_series;
                 layer_z_series.assign(m_objects.size(), std::vector<coordf_t>());
-               
+
                 for (size_t idx_object = 0; idx_object < m_objects.size(); ++idx_object) {
                     layer_z_series[idx_object] = generate_object_layers(m_objects[idx_object]->slicing_parameters(), layer_height_profiles[idx_object], m_objects[idx_object]->config().precise_z_height.value);
                 }
@@ -2455,7 +2454,7 @@ std::vector<Point> Print::first_layer_wipe_tower_corners(bool check_wipe_tower_e
         double width = m_config.prime_tower_width + 2*m_wipe_tower_data.brim_width;
         double depth = m_wipe_tower_data.depth + 2*m_wipe_tower_data.brim_width;
         Vec2d pt0(-m_wipe_tower_data.brim_width, -m_wipe_tower_data.brim_width);
-        
+
         // First the corners.
         std::vector<Vec2d> pts = { pt0,
                                    Vec2d(pt0.x()+width, pt0.y()),
@@ -2601,9 +2600,9 @@ const WipeTowerData &Print::wipe_tower_data(size_t filaments_cnt) const
                 max_wipe_volumes.emplace_back(*std::max_element(v.begin(), v.end()));
             float maximum = std::accumulate(max_wipe_volumes.begin(), max_wipe_volumes.end(), 0.f);
             maximum       = maximum * filaments_cnt / max_wipe_volumes.size();
-            
+
             // Orca: it's overshooting a bit, so let's reduce it a bit
-            maximum *= 0.6; 
+            maximum *= 0.6;
             const_cast<Print *>(this)->m_wipe_tower_data.depth = maximum / (layer_height * width);
         } else {
             double wipe_volume = m_config.prime_volume;
@@ -2956,7 +2955,7 @@ std::tuple<float, float> Print::object_skirt_offset(double margin_height) const
 {
     if (config().skirt_loops == 0 || config().skirt_type != stPerObject)
         return std::make_tuple(0, 0);
-    
+
     float max_nozzle_diameter = *std::max_element(m_config.nozzle_diameter.values.begin(), m_config.nozzle_diameter.values.end());
     float max_layer_height    = *std::max_element(config().max_layer_height.values.begin(), config().max_layer_height.values.end());
     float line_width = m_config.initial_layer_line_width.get_abs_value(max_nozzle_diameter);

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -496,7 +496,7 @@ void PrintConfigDef::init_common_params()
     def->sidetext = L("layers");
     def->min      = 1;
     def->mode     = comAdvanced;
-    def->set_default_value(new ConfigOptionInt(1));	
+    def->set_default_value(new ConfigOptionInt(1));
 
     def = this->add("layer_height", coFloat);
     def->label = L("Layer height");
@@ -622,7 +622,7 @@ void PrintConfigDef::init_common_params()
     def->mode = comAdvanced;
     def->cli = ConfigOptionDef::nocli;
     def->set_default_value(new ConfigOptionEnum<AuthorizationType>(atKeyPassword));
-    
+
     // temporary workaround for compatibility with older Slicer
     {
         def = this->add("preset_name", coString);
@@ -761,7 +761,7 @@ void PrintConfigDef::init_fff_params()
     def->tooltip = L("Bed types supported by the printer");
     def->mode = comSimple;
     def->enum_keys_map = &s_keys_map_BedType;
-    // Orca: make sure the order of the values is the same as the BedType enum 
+    // Orca: make sure the order of the values is the same as the BedType enum
     def->enum_values.emplace_back("Cool Plate");
     def->enum_values.emplace_back("Engineering Plate");
     def->enum_values.emplace_back("High Temp Plate");
@@ -843,7 +843,7 @@ void PrintConfigDef::init_fff_params()
     def->sidetext = L("mm");
     def->min = 0;
     def->set_default_value(new ConfigOptionFloat(0.));
-    
+
     def = this->add("gap_fill_target", coEnum);
     def->label = L("Apply gap fill");
     def->category = L("Strength");
@@ -872,7 +872,7 @@ void PrintConfigDef::init_fff_params()
     def->enum_labels.push_back(L("Nowhere"));
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionEnum<GapFillTarget>(gftNowhere));
-    
+
 
     def = this->add("enable_overhang_bridge_fan", coBools);
     def->label = L("Force cooling for overhang and bridge");
@@ -981,7 +981,7 @@ void PrintConfigDef::init_fff_params()
     def->tooltip  = L("Improve shell precision by adjusting outer wall spacing. This also improves layer consistency.\nNote: This setting "
                        "will only take effect if the wall sequence is configured to Inner-Outer");
     def->set_default_value(new ConfigOptionBool{false});
-    
+
     def = this->add("only_one_wall_top", coBool);
     def->label = L("Only one wall on top surfaces");
     def->category = L("Quality");
@@ -1024,7 +1024,7 @@ void PrintConfigDef::init_fff_params()
     def->tooltip = L("Extrude perimeters that have a part over an overhang in the reverse direction on even layers. This alternating pattern can drastically improve steep overhangs.\n\nThis setting can also help reduce part warping due to the reduction of stresses in the part walls.");
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionBool(false));
-    
+
     def = this->add("overhang_reverse_internal_only", coBool);
     def->label = L("Reverse only internal perimeters");
     def->full_label = L("Reverse only internal perimeters");
@@ -1080,7 +1080,7 @@ void PrintConfigDef::init_fff_params()
     def->tooltip = L("Enable this option to slow printing down for different overhang degree");
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionBool{ true });
-    
+
     def = this->add("slowdown_for_curled_perimeters", coBool);
     def->label = L("Slow down for curled perimeters");
     def->category = L("Speed");
@@ -1479,7 +1479,7 @@ void PrintConfigDef::init_fff_params()
     def->enum_labels.push_back(L("All"));
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionEnum<EnsureVerticalShellThickness>(EnsureVerticalShellThickness::evstAll));
-    
+
     auto def_top_fill_pattern = def = this->add("top_surface_pattern", coEnum);
     def->label = L("Top surface pattern");
     def->category = L("Strength");
@@ -1520,7 +1520,7 @@ void PrintConfigDef::init_fff_params()
     def->enum_values   = def_top_fill_pattern->enum_values;
     def->enum_labels   = def_top_fill_pattern->enum_labels;
     def->set_default_value(new ConfigOptionEnum<InfillPattern>(ipMonotonic));
-    
+
     def = this->add("outer_wall_line_width", coFloatOrPercent);
     def->label = L("Outer wall");
     def->category = L("Quality");
@@ -1740,7 +1740,7 @@ void PrintConfigDef::init_fff_params()
     def->max = 2;
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionFloats { 0.02 });
-    
+
     // Orca: Adaptive pressure advance option and calibration values
     def = this->add("adaptive_pressure_advance", coBools);
     def->label = L("Enable adaptive pressure advance (beta)");
@@ -1756,7 +1756,7 @@ void PrintConfigDef::init_fff_params()
                      "strongly recommended to act as a fallback and for when tool changing.\n\n");
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionBools{ false });
-    
+
     // Orca: Adaptive pressure advance option and calibration values
     def = this->add("adaptive_pressure_advance_model", coStrings);
     def->label = L("Adaptive pressure advance measurements (beta)");
@@ -1781,7 +1781,7 @@ void PrintConfigDef::init_fff_params()
     def->full_width = true;
     def->height = 15;
     def->set_default_value(new ConfigOptionStrings{"0,0,0\n0,0,0"});
-    
+
     // xgettext:no-c-format, no-boost-format
     def = this->add("adaptive_pressure_advance_overhangs", coBools);
     def->label = L("Enable adaptive pressure advance for overhangs (beta)");
@@ -1789,7 +1789,7 @@ void PrintConfigDef::init_fff_params()
                      "as if the PA profile is not set accurately, it will cause uniformity issues on the external surfaces before and after overhangs.\n");
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionBools{ false });
-    
+
     def = this->add("adaptive_pressure_advance_bridges", coFloats);
     def->label = L("Pressure advance for bridges");
     def->tooltip = L("Pressure advance value for bridges. Set to 0 to disable. \n\n A lower PA value when printing bridges helps reduce the appearance of slight under extrusion "
@@ -1815,7 +1815,7 @@ void PrintConfigDef::init_fff_params()
     def->tooltip = L("If enable this setting, part cooling fan will never be stopped and will run at least "
                      "at minimum speed to reduce the frequency of starting and stopping");
     def->set_default_value(new ConfigOptionBools { false });
-    
+
     def = this->add("dont_slow_down_outer_wall", coBools);
     def->label = L("Don't slow down outer walls");
     def->tooltip = L("If enabled, this setting will ensure external perimeters are not slowed down to meet the minimum layer time. "
@@ -1912,20 +1912,20 @@ void PrintConfigDef::init_fff_params()
 
     /*
         Large format printers with print volumes in the order of 1m^3 generally use pellets for printing.
-        The overall tech is very similar to FDM printing. 
+        The overall tech is very similar to FDM printing.
         It is FDM printing, but instead of filaments, it uses pellets.
 
-        The difference here is that where filaments have a filament_diameter that is used to calculate 
-        the volume of filament ingested, pellets have a particular flow_coefficient that is empirically 
+        The difference here is that where filaments have a filament_diameter that is used to calculate
+        the volume of filament ingested, pellets have a particular flow_coefficient that is empirically
         devised for that particular pellet.
 
         pellet_flow_coefficient is basically a measure of the packing density of a particular pellet.
         Shape, material and density of an individual pellet will determine the packing density and
-        the only thing that matters for 3d printing is how much of that pellet material is extruded by 
+        the only thing that matters for 3d printing is how much of that pellet material is extruded by
         one turn of whatever feeding mehcanism/gear your printer uses. You can emperically derive that
         for your own pellets for a particular printer model.
 
-        We are translating the pellet_flow_coefficient into filament_diameter so that everything works just like it 
+        We are translating the pellet_flow_coefficient into filament_diameter so that everything works just like it
         does already with very minor adjustments.
 
         filament_diameter = sqrt( (4 * pellet_flow_coefficient) / PI )
@@ -1954,7 +1954,7 @@ void PrintConfigDef::init_fff_params()
     def->min = 10;
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionPercents{ 100 });
-    
+
     def = this->add("filament_shrinkage_compensation_z", coPercents);
     def->label = L("Shrinkage (Z)");
     // xgettext:no-c-format, no-boost-format
@@ -2090,7 +2090,7 @@ void PrintConfigDef::init_fff_params()
     def->min = 0;
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionFloats { 10. });
-    
+
     def = this->add("filament_density", coFloats);
     def->label = L("Density");
     def->tooltip = L("Filament density. For statistics only");
@@ -2317,7 +2317,7 @@ void PrintConfigDef::init_fff_params()
     def->enum_labels.push_back(L("1000 (unlimited)"));
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionFloatOrPercent(20, false));
-    
+
     def = this->add("outer_wall_acceleration", coFloat);
     def->label = L("Outer wall");
     def->tooltip = L("Acceleration of outer walls");
@@ -2398,7 +2398,7 @@ void PrintConfigDef::init_fff_params()
     def->tooltip = L("Klipper's max_accel_to_decel will be adjusted automatically");
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionBool(true));
-    
+
     def = this->add("accel_to_decel_factor", coPercent);
     def->label = L("accel_to_decel");
     def->tooltip = L("Klipper's max_accel_to_decel will be adjusted to this %% of acceleration");
@@ -2407,7 +2407,7 @@ void PrintConfigDef::init_fff_params()
     def->max = 100;
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionPercent(50));
-    
+
     def = this->add("default_jerk", coFloat);
     def->label = L("Default");
     def->tooltip = L("Default");
@@ -2549,7 +2549,7 @@ void PrintConfigDef::init_fff_params()
     def->max = 1000;
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionInts { 0 });
-    
+
     def = this->add("support_material_interface_fan_speed", coInts);
     def->label = L("Support interface fan speed");
     def->tooltip = L("This fan speed is enforced during all support interfaces, to be able to weaken their bonding with a high fan speed."
@@ -2560,7 +2560,7 @@ void PrintConfigDef::init_fff_params()
     def->max = 100;
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionInts{ -1 });
-    
+
 
     def = this->add("fuzzy_skin", coEnum);
     def->label = L("Fuzzy Skin");
@@ -2614,7 +2614,7 @@ void PrintConfigDef::init_fff_params()
     def->sidetext = L("mm");
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionFloat(0));
-    
+
     def = this->add("gap_infill_speed", coFloat);
     def->label = L("Gap infill");
     def->category = L("Speed");
@@ -2735,12 +2735,6 @@ void PrintConfigDef::init_fff_params()
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionFloat(0));
 
-    def = this->add("fan_speedup_overhangs", coBool);
-    def->label = L("Only overhangs");
-    def->tooltip = L("Will only take into account the delay for the cooling of overhangs.");
-    def->mode = comAdvanced;
-    def->set_default_value(new ConfigOptionBool(true));
-
     def = this->add("fan_kickstart", coFloat);
     def->label = L("Fan kick-start time");
     def->tooltip = L("Emit a max fan speed command for this amount of seconds before reducing to target speed to kick-start the cooling fan."
@@ -2841,7 +2835,7 @@ void PrintConfigDef::init_fff_params()
                    "slow down.");
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionBool(0));
-    
+
     //BBS
     def = this->add("infill_combination", coBool);
     def->label = L("Infill combination");
@@ -2850,7 +2844,7 @@ void PrintConfigDef::init_fff_params()
                      "with original layer height.");
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionBool(false));
-    
+
     // Orca: max layer height for combined infill
     def = this->add("infill_combination_max_layer_height", coFloatOrPercent);
     def->label = L("Infill combination - Max layer height");
@@ -2863,7 +2857,7 @@ void PrintConfigDef::init_fff_params()
     def->min = 0;
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionFloatOrPercent(100., true));
-    
+
     def = this->add("sparse_infill_filament", coInt);
     def->gui_type = ConfigOptionDef::GUIType::i_enum_open;
     def->label = L("Infill");
@@ -2894,7 +2888,7 @@ void PrintConfigDef::init_fff_params()
     def->ratio_over = "inner_wall_line_width";
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionPercent(15));
-    
+
     def = this->add("top_bottom_infill_wall_overlap", coPercent);
     def->label = L("Top/Bottom solid infill/wall overlap");
     def->category = L("Strength");
@@ -2954,7 +2948,7 @@ void PrintConfigDef::init_fff_params()
     def->tooltip  = L("Interlocking depth of a segmented region. It will be ignored if "
                     "\"mmu_segmented_region_max_width\" is zero or if \"mmu_segmented_region_interlocking_depth\""
                     "is bigger then \"mmu_segmented_region_max_width\". Zero disables this feature.");
-    def->sidetext = L("mm"); 
+    def->sidetext = L("mm");
     def->min      = 0;
     def->category = L("Advanced");
     def->mode     = comAdvanced;
@@ -3038,7 +3032,7 @@ void PrintConfigDef::init_fff_params()
     def->enum_labels.push_back(L("Rectilinear"));
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionEnum<InfillPattern>(ipRectilinear));
-    
+
     def = this->add("ironing_flow", coPercent);
     def->label = L("Ironing flow");
     def->category = L("Quality");
@@ -3303,11 +3297,11 @@ void PrintConfigDef::init_fff_params()
 
     def = this->add("max_volumetric_extrusion_rate_slope", coFloat);
     def->label = L("Extrusion rate smoothing");
-    def->tooltip = L("This parameter smooths out sudden extrusion rate changes that happen when " 
+    def->tooltip = L("This parameter smooths out sudden extrusion rate changes that happen when "
     				 "the printer transitions from printing a high flow (high speed/larger width) "
     				 "extrusion to a lower flow (lower speed/smaller width) extrusion and vice versa.\n\n"
     				 "It defines the maximum rate by which the extruded volumetric flow in mm3/sec can change over time. "
-    				 "Higher values mean higher extrusion rate changes are allowed, resulting in faster speed transitions.\n\n" 
+    				 "Higher values mean higher extrusion rate changes are allowed, resulting in faster speed transitions.\n\n"
     				 "A value of 0 disables the feature. \n\n"
     				 "For a high speed, high flow direct drive printer (like the Bambu lab or Voron) this value is usually not needed. "
     				 "However it can provide some marginal benefit in certain cases where feature speeds vary greatly. For example, "
@@ -3321,7 +3315,7 @@ void PrintConfigDef::init_fff_params()
     def->min = 0;
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionFloat(0));
-    
+
     def = this->add("max_volumetric_extrusion_rate_slope_segment_length", coInt);
     def->label = L("Smoothing segment length");
     def->tooltip = L("A lower value results in smoother extrusion rate transitions. However, this results in a significantly larger gcode file "
@@ -3422,7 +3416,7 @@ void PrintConfigDef::init_fff_params()
     def->mode = comAdvanced;
     def->cli = ConfigOptionDef::nocli;
     def->set_default_value(new ConfigOptionEnum<PrintHostType>(htOctoPrint));
-    
+
 
     def = this->add("nozzle_volume", coFloat);
     def->label = L("Nozzle volume");
@@ -3578,14 +3572,14 @@ void PrintConfigDef::init_fff_params()
     def->min = 0;
     def->max = 1000;
     def->set_default_value(new ConfigOptionInt(2));
-    
+
     def = this->add("alternate_extra_wall", coBool);
     def->label = L("Alternate extra wall");
     def->category = L("Strength");
     def->tooltip = L("This setting adds an extra wall to every other layer. This way the infill gets wedged vertically between the walls, resulting in stronger prints. \n\nWhen this option is enabled, the ensure vertical shell thickness option needs to be disabled. \n\nUsing lightning infill together with this option is not recommended as there is limited infill to anchor the extra perimeters to.");
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionBool(false));
-    
+
     def = this->add("post_process", coStrings);
     def->label = L("Post-processing Scripts");
     def->tooltip = L("If you want to process the output G-code through custom scripts, "
@@ -3598,7 +3592,7 @@ void PrintConfigDef::init_fff_params()
     def->height = 6;
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionStrings());
-    
+
     def = this->add("printer_model", coString);
     //def->label = L("Printer type");
     //def->tooltip = L("Type of the printer");
@@ -3615,7 +3609,7 @@ void PrintConfigDef::init_fff_params()
     def->height = 13;
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionString(""));
-    
+
     def = this->add("printer_variant", coString);
     //def->label = L("Printer variant");
     def->label = L("Printer variant");
@@ -3909,7 +3903,7 @@ void PrintConfigDef::init_fff_params()
     def->tooltip = L("This option causes the inner seams to be shifted backwards based on their depth, forming a zigzag pattern.");
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionBool(false));
-    
+
     def = this->add("seam_gap", coFloatOrPercent);
     def->label = L("Seam gap");
     def->tooltip = L("In order to reduce the visibility of the seam in a closed loop extrusion, the loop is interrupted and shortened by a specified amount.\n"
@@ -4025,13 +4019,13 @@ void PrintConfigDef::init_fff_params()
                      "e.g. if a wipe action is executed immediately following an outer wall extrusion, the speed of the outer wall extrusion will be utilized for the wipe action.");
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionBool(true));
-    
+
     def = this->add("wipe_on_loops", coBool);
     def->label = L("Wipe on loops");
     def->tooltip = L("To minimize the visibility of the seam in a closed loop extrusion, a small inward movement is executed before the extruder leaves the loop.");
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionBool(false));
-    
+
     def = this->add("wipe_before_external_loop", coBool);
     def->label = L("Wipe before external loop");
     def->tooltip = L("To minimize visibility of potential overextrusion at the start of an external perimeter when printing with "
@@ -4052,7 +4046,7 @@ void PrintConfigDef::init_fff_params()
     def->min = 0;
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionFloatOrPercent(80,true));
-    
+
     def = this->add("skirt_distance", coFloat);
     def->label = L("Skirt distance");
     def->tooltip = L("Distance from skirt to brim or object");
@@ -4106,7 +4100,7 @@ void PrintConfigDef::init_fff_params()
     def->enum_labels.push_back(L("Per object"));
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionEnum<SkirtType>(stCombined));
-    
+
     def = this->add("skirt_loops", coInt);
     def->label = L("Skirt loops");
     def->full_label = L("Skirt loops");
@@ -4124,7 +4118,7 @@ void PrintConfigDef::init_fff_params()
     def->sidetext = L("mm/s");
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionFloat(50.0));
-    
+
     def = this->add("min_skirt_length", coFloat);
     def->label = L("Skirt minimum extrusion length");
     def->full_label = L("Skirt minimum extrusion length");
@@ -4353,7 +4347,7 @@ void PrintConfigDef::init_fff_params()
     def->sidetext = L("mm");
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionFloat(0));
-    
+
     def = this->add("enable_support", coBool);
     //BBS: remove material behind support
     def->label = L("Enable support");
@@ -4755,13 +4749,13 @@ void PrintConfigDef::init_fff_params()
     def->category = L("Quality");
     def->tooltip = L("Enabling this option means the height of  tree support layer except the first will be automatically calculated ");
     def->set_default_value(new ConfigOptionBool(1));
-    
+
     def = this->add("tree_support_auto_brim", coBool);
     def->label = L("Auto brim width");
     def->category = L("Quality");
     def->tooltip = L("Enabling this option means the width of the brim for tree support will be automatically calculated");
     def->set_default_value(new ConfigOptionBool(1));
-    
+
     def = this->add("tree_support_brim_width", coFloat);
     def->label = L("Tree support brim width");
     def->category = L("Quality");
@@ -4801,7 +4795,7 @@ void PrintConfigDef::init_fff_params()
     def->set_default_value(new ConfigOptionFloat(2.));
 
     def = this->add("tree_support_branch_diameter_angle", coFloat);
-    // TRN PrintSettings: #lmFIXME 
+    // TRN PrintSettings: #lmFIXME
     def->label = L("Branch Diameter Angle");
     def->category = L("Support");
     // TRN PrintSettings: "Organic supports" > "Branch Diameter Angle"
@@ -5087,7 +5081,7 @@ void PrintConfigDef::init_fff_params()
     def->min = 0.;
     def->max = 90.;
     def->set_default_value(new ConfigOptionFloat(0.));
-    
+
     def = this->add("wipe_tower_max_purge_speed", coFloat);
     def->label = L("Maximum wipe tower print speed");
     def->tooltip = L("The maximum print speed when purging in the wipe tower and printing the wipe tower sparse layers. "
@@ -6220,7 +6214,7 @@ void PrintConfigDef::handle_legacy(t_config_option_key &opt_key, std::string &va
     }
     else if (opt_key == "sparse_infill_anchor") {
         opt_key = "infill_anchor";
-    } 
+    }
     else if (opt_key == "sparse_infill_anchor_max") {
         opt_key = "infill_anchor_max";
     }
@@ -6253,7 +6247,7 @@ void PrintConfigDef::handle_legacy(t_config_option_key &opt_key, std::string &va
     static std::set<std::string> ignore = {
         "acceleration", "scale", "rotate", "duplicate", "duplicate_grid",
         "bed_size",
-        "print_center", "g0", "wipe_tower_per_color_wipe", 
+        "print_center", "g0", "wipe_tower_per_color_wipe",
         "support_sharp_tails","support_remove_small_overhangs", "support_with_sheath",
         "tree_support_collision_resolution", "tree_support_with_infill",
         "max_volumetric_speed", "max_print_speed",
@@ -6761,7 +6755,7 @@ std::map<std::string, std::string> validate(const FullPrintConfig &cfg, bool und
         for (unsigned char wipe : cfg.wipe.values)
              if (wipe)
                 error_message.emplace("use_firmware_retraction", "--use-firmware-retraction is not compatible with --wipe");
-                
+
     // --gcode-flavor
     if (! print_config_def.get("gcode_flavor")->has_enum_value(cfg.gcode_flavor.serialize())) {
         error_message.emplace("gcode_flavor", L("invalid value ") + cfg.gcode_flavor.serialize());
@@ -6796,7 +6790,7 @@ std::map<std::string, std::string> validate(const FullPrintConfig &cfg, bool und
     if (cfg.bridge_flow <= 0) {
         error_message.emplace("bridge_flow", L("invalid value ") + std::to_string(cfg.bridge_flow));
     }
-    
+
     // --bridge-flow-ratio
     if (cfg.bridge_flow <= 0) {
         error_message.emplace("internal_bridge_flow", L("invalid value ") + std::to_string(cfg.internal_bridge_flow));
@@ -7299,7 +7293,7 @@ CLIMiscConfigDef::CLIMiscConfigDef()
     def->tooltip = "the machine settings list need to do downward checking";
     def->cli_params = "\"machine1.json;machine2.json;...\"";
     def->set_default_value(new ConfigOptionStrings());
-    
+
     def = this->add("load_assemble_list", coString);
     def->label = "Load assemble list";
     def->tooltip = "Load assemble object list from config file";

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -264,7 +264,7 @@ enum BedType {
 
 // BBS
 enum LayerSeq {
-    flsAuto, 
+    flsAuto,
     flsCutomize
 };
 
@@ -870,7 +870,7 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionFloat,              initial_layer_jerk))
     ((ConfigOptionFloat,              travel_jerk))
     ((ConfigOptionBool,               precise_z_height))
-        
+
     ((ConfigOptionBool, interlocking_beam))
     ((ConfigOptionFloat,interlocking_beam_width))
     ((ConfigOptionFloat,interlocking_orientation))
@@ -1039,8 +1039,8 @@ PRINT_CONFIG_CLASS_DEFINE(
 PRINT_CONFIG_CLASS_DEFINE(
     GCodeConfig,
 
-    ((ConfigOptionString,              before_layer_change_gcode)) 
-    ((ConfigOptionString,              printing_by_object_gcode)) 
+    ((ConfigOptionString,              before_layer_change_gcode))
+    ((ConfigOptionString,              printing_by_object_gcode))
     ((ConfigOptionFloats,              deretraction_speed))
     //BBS
     ((ConfigOptionBool,                enable_arc_fitting))
@@ -1056,7 +1056,6 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionFloats,              adaptive_pressure_advance_bridges))
     //
     ((ConfigOptionFloat,               fan_kickstart))
-    ((ConfigOptionBool,                fan_speedup_overhangs))
     ((ConfigOptionFloat,               fan_speedup_time))
     ((ConfigOptionFloats,              filament_diameter))
     ((ConfigOptionFloats,              filament_density))
@@ -1076,7 +1075,7 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionBool,                bbl_bed_temperature_gcode))
     ((ConfigOptionEnum<GCodeFlavor>,   gcode_flavor))
 
-    ((ConfigOptionFloat,               time_cost)) 
+    ((ConfigOptionFloat,               time_cost))
     ((ConfigOptionString,              layer_change_gcode))
     ((ConfigOptionString,              time_lapse_gcode))
 
@@ -1309,7 +1308,7 @@ PRINT_CONFIG_CLASS_DERIVED_DEFINE(
 
     ((ConfigOptionBools,               activate_chamber_temp_control))
     ((ConfigOptionInts ,               chamber_temperature))
-    
+
     // Orca: support adaptive bed mesh
     ((ConfigOptionFloat,               preferred_orientation))
     ((ConfigOptionPoint,               bed_mesh_min))

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -1413,7 +1413,7 @@ void Tab::on_value_change(const std::string& opt_key, const boost::any& value)
     }
 
 
-    if (opt_key == "pellet_flow_coefficient") 
+    if (opt_key == "pellet_flow_coefficient")
     {
         double double_value = Preset::convert_pellet_flow_to_filament_diameter(boost::any_cast<double>(value));
         m_config->set_key_value("filament_diameter", new ConfigOptionFloats{double_value});
@@ -1423,7 +1423,7 @@ void Tab::on_value_change(const std::string& opt_key, const boost::any& value)
         double double_value = Preset::convert_filament_diameter_to_pellet_flow(boost::any_cast<double>(value));
         m_config->set_key_value("pellet_flow_coefficient", new ConfigOptionFloats{double_value});
     }
-    
+
 
     if (opt_key == "single_extruder_multi_material"  ){
         const auto bSEMM = m_config->opt_bool("single_extruder_multi_material");
@@ -1570,7 +1570,7 @@ void Tab::on_value_change(const std::string& opt_key, const boost::any& value)
             }
         }
     }
-    
+
     if(opt_key=="layer_height"){
         auto min_layer_height_from_nozzle=wxGetApp().preset_bundle->full_config().option<ConfigOptionFloats>("min_layer_height")->values;
         auto max_layer_height_from_nozzle=wxGetApp().preset_bundle->full_config().option<ConfigOptionFloats>("max_layer_height")->values;
@@ -1638,7 +1638,7 @@ void Tab::on_value_change(const std::string& opt_key, const boost::any& value)
     if (opt_key == "filament_long_retractions_when_cut"){
         unsigned char activate = boost::any_cast<unsigned char>(value);
         if (activate == 1) {
-            MessageDialog dialog(wxGetApp().plater(), 
+            MessageDialog dialog(wxGetApp().plater(),
             _L("Experimental feature: Retracting and cutting off the filament at a greater distance during filament changes to minimize flush."
             "Although it can notably reduce flush, it may also elevate the risk of nozzle clogs or other printing complications.Please use with the latest printer firmware."), "", wxICON_WARNING | wxOK);
             dialog.ShowModal();
@@ -2096,7 +2096,7 @@ void TabPrint::build()
         option.opt.is_code = true;
         option.opt.height = 15;
         optgroup->append_single_option_line(option, "small-area-infill-flow-compensation");
-        
+
         optgroup = page->new_optgroup(L("Bridging"), L"param_bridge");
         optgroup->append_single_option_line("bridge_flow");
 	    optgroup->append_single_option_line("internal_bridge_flow");
@@ -2105,7 +2105,7 @@ void TabPrint::build()
         optgroup->append_single_option_line("thick_internal_bridges");
         optgroup->append_single_option_line("dont_filter_internal_bridges");
         optgroup->append_single_option_line("counterbore_hole_bridging","counterbore-hole-bridging");
-    
+
         optgroup = page->new_optgroup(L("Overhangs"), L"param_overhang");
         optgroup->append_single_option_line("detect_overhang_wall");
         optgroup->append_single_option_line("make_overhang_printable");
@@ -2211,7 +2211,7 @@ void TabPrint::build()
         optgroup->append_single_option_line("top_surface_jerk");
         optgroup->append_single_option_line("initial_layer_jerk");
         optgroup->append_single_option_line("travel_jerk");
-        
+
         optgroup = page->new_optgroup(L("Advanced"), L"param_advanced", 15);
         optgroup->append_single_option_line("max_volumetric_extrusion_rate_slope", "extrusion-rate-smoothing");
         optgroup->append_single_option_line("max_volumetric_extrusion_rate_slope_segment_length", "extrusion-rate-smoothing");
@@ -2240,7 +2240,7 @@ void TabPrint::build()
 
         //optgroup = page->new_optgroup(L("Options for support material and raft"));
 
-        // Support 
+        // Support
         optgroup = page->new_optgroup(L("Advanced"), L"param_advanced");
         optgroup->append_single_option_line("support_top_z_distance", "support#top-z-distance");
         optgroup->append_single_option_line("support_bottom_z_distance", "support#bottom-z-distance");
@@ -2276,7 +2276,7 @@ void TabPrint::build()
         optgroup->append_single_option_line("tree_support_adaptive_layer_height");
         optgroup->append_single_option_line("tree_support_auto_brim");
         optgroup->append_single_option_line("tree_support_brim_width");
-        
+
     page = add_options_page(L("Multimaterial"), "custom-gcode_multi_material"); // ORCA: icon only visible on placeholders
         optgroup = page->new_optgroup(L("Prime tower"), L"param_tower");
         optgroup->append_single_option_line("enable_prime_tower");
@@ -2328,7 +2328,7 @@ page = add_options_page(L("Others"), "custom-gcode_other"); // ORCA: icon only v
         optgroup->append_single_option_line("skirt_height");
         optgroup->append_single_option_line("skirt_speed");
         optgroup->append_single_option_line("draft_shield");
-        
+
         optgroup = page->new_optgroup(L("Brim"), L"param_adhension");
         optgroup->append_single_option_line("brim_type", "auto-brim");
         optgroup->append_single_option_line("brim_width", "auto-brim#manual");
@@ -2362,7 +2362,7 @@ page = add_options_page(L("Others"), "custom-gcode_other"); // ORCA: icon only v
         option.opt.multiline = true;
         // option.opt.height = 5;
         optgroup->append_single_option_line(option);
-    
+
         optgroup = page->new_optgroup(L("Post-processing Scripts"), L"param_gcode", 0);
         option = optgroup->get_option("post_process");
         option.opt.full_width = true;
@@ -2375,7 +2375,7 @@ page = add_options_page(L("Others"), "custom-gcode_other"); // ORCA: icon only v
         option.opt.full_width = true;
         option.opt.height = 25;//250;
         optgroup->append_single_option_line(option);
-        
+
 #if 0
     //page = add_options_page(L("Dependencies"), "advanced.png");
     //    optgroup = page->new_optgroup(L("Profile dependencies"));
@@ -2793,7 +2793,7 @@ void TabPrintPlate::build()
     auto page = add_options_page(L("Plate Settings"), "empty");
     auto optgroup = page->new_optgroup("");
     optgroup->append_single_option_line("curr_bed_type");
-    optgroup->append_single_option_line("skirt_start_angle");        
+    optgroup->append_single_option_line("skirt_start_angle");
     optgroup->append_single_option_line("print_sequence");
     optgroup->append_single_option_line("spiral_mode");
     optgroup->append_single_option_line("first_layer_sequence_choice");
@@ -2944,7 +2944,7 @@ void TabPrintPlate::notify_changed(ObjectBase* object)
     for (auto item : items) {
         if (objects_list->GetModel()->GetItemType(item) == itPlate) {
             ObjectDataViewModelNode* node = static_cast<ObjectDataViewModelNode*>(item.GetID());
-            if (node) 
+            if (node)
                 node->set_action_icon(!m_all_keys.empty());
         }
     }
@@ -2952,7 +2952,7 @@ void TabPrintPlate::notify_changed(ObjectBase* object)
 
 void TabPrintPlate::update_custom_dirty()
 {
-    for (auto k : m_null_keys) 
+    for (auto k : m_null_keys)
         m_options_list[k] = 0;
     for (auto k : m_all_keys) {
         if (k == "first_layer_sequence_choice" || k == "other_layers_sequence_choice") {
@@ -3197,9 +3197,9 @@ void TabFilament::update_filament_overrides_page(const DynamicPrintConfig* print
 
     std::vector<std::string> opt_keys = {   "filament_retraction_length",
                                             "filament_z_hop",
-                                            "filament_z_hop_types", 
+                                            "filament_z_hop_types",
                                             "filament_retract_lift_above",
-                                            "filament_retract_lift_below", 
+                                            "filament_retract_lift_below",
                                             "filament_retract_lift_enforce",
                                             "filament_retraction_speed",
                                             "filament_deretraction_speed",
@@ -3313,7 +3313,7 @@ void TabFilament::build()
         optgroup->append_single_option_line("adaptive_pressure_advance");
         optgroup->append_single_option_line("adaptive_pressure_advance_overhangs");
         optgroup->append_single_option_line("adaptive_pressure_advance_bridges");
-    
+
         option = optgroup->get_option("adaptive_pressure_advance_model");
         option.opt.full_width = true;
         option.opt.is_code = true;
@@ -3597,7 +3597,7 @@ void TabFilament::toggle_options()
             toggle_option(el, has_enable_overhang_bridge_fan);
 
       toggle_option("additional_cooling_fan_speed", cfg.opt_bool("auxiliary_fan"));
-        
+
       // Orca: toggle dont slow down for external perimeters if
       bool has_slow_down_for_layer_cooling = m_config->opt_bool("slow_down_for_layer_cooling", 0);
       toggle_option("dont_slow_down_outer_wall", has_slow_down_for_layer_cooling);
@@ -3611,7 +3611,7 @@ void TabFilament::toggle_options()
         toggle_line("textured_cool_plate_temp_initial_layer", support_multi_bed_types);
         toggle_line("eng_plate_temp_initial_layer", support_multi_bed_types);
         toggle_line("textured_plate_temp_initial_layer", support_multi_bed_types);
-        
+
         // Orca: adaptive pressure advance and calibration model
         // If PA is not enabled, disable adaptive pressure advance and hide the model section
         // If adaptive PA is not enabled, hide the adaptive PA model section
@@ -3791,11 +3791,10 @@ void TabPrinter::build_fff()
         optgroup->append_single_option_line("use_firmware_retraction");
         // optgroup->append_single_option_line("spaghetti_detector");
         optgroup->append_single_option_line("time_cost");
-        
+
         optgroup  = page->new_optgroup(L("Cooling Fan"), "param_cooling_fan");
         Line line = Line{ L("Fan speed-up time"), optgroup->get_option("fan_speedup_time").opt.tooltip };
         line.append_option(optgroup->get_option("fan_speedup_time"));
-        line.append_option(optgroup->get_option("fan_speedup_overhangs"));
         optgroup->append_line(line);
         optgroup->append_single_option_line("fan_kickstart");
 
@@ -3854,8 +3853,8 @@ void TabPrinter::build_fff()
         option.opt.is_code    = true;
         option.opt.height     = gcode_field_height; // 150;
         optgroup->append_single_option_line(option);
-        
-        
+
+
         optgroup = page->new_optgroup(L("Before layer change G-code"),"param_gcode", 0);
         optgroup->m_on_change = [this, &optgroup_title = optgroup->title](const t_config_option_key& opt_key, const boost::any& value) {
             validate_custom_gcode_cb(this, optgroup_title, opt_key, value);
@@ -3877,7 +3876,7 @@ void TabPrinter::build_fff()
         option.opt.is_code = true;
         option.opt.height = gcode_field_height;//150;
         optgroup->append_single_option_line(option);
-        
+
         optgroup = page->new_optgroup(L("Time lapse G-code"), L"param_gcode", 0);
         optgroup->m_on_change = [this, &optgroup_title = optgroup->title](const t_config_option_key& opt_key, const boost::any& value) {
             validate_custom_gcode_cb(this, optgroup_title, opt_key, value);
@@ -4597,7 +4596,7 @@ void TabPrinter::toggle_options()
         toggle_option("long_retractions_when_cut", !use_firmware_retraction && m_config->opt_int("enable_long_retraction_when_cut"),i);
         toggle_line("retraction_distances_when_cut#0", m_config->opt_bool("long_retractions_when_cut", i));
         //toggle_option("retraction_distances_when_cut", m_config->opt_bool("long_retractions_when_cut",i),i);
-        
+
         toggle_option("travel_slope", m_config->opt_enum("z_hop_types", i) != ZHopType::zhtNormal, i);
     }
 
@@ -5002,13 +5001,13 @@ bool Tab::select_preset(std::string preset_name, bool delete_current /*=false*/,
         try {
             //BBS delete preset
             Preset &current_preset = m_presets->get_selected_preset();
-            
+
             // Obtain compatible filament and process presets for printers
             if (m_preset_bundle && m_presets->get_preset_base(current_preset) == &current_preset && printer_tab && !current_preset.is_system) {
                 delete_third_printer = true;
                 for (const Preset &preset : m_preset_bundle->filaments.get_presets()) {
                     if (preset.is_compatible && !preset.is_default) {
-                        if (preset.inherits() != "") 
+                        if (preset.inherits() != "")
                             filament_presets.push_front(preset);
                         else
                             filament_presets.push_back(preset);
@@ -5138,7 +5137,7 @@ bool Tab::select_preset(std::string preset_name, bool delete_current /*=false*/,
 
             });
         }
-        
+
     }
 
     if (technology_changed)
@@ -5735,7 +5734,7 @@ void Tab::delete_preset()
         //wxID_YES != wxMessageDialog(parent(), msg, title, wxYES_NO | wxNO_DEFAULT | wxICON_QUESTION).ShowModal())
         wxID_YES == MessageDialog(parent(), msg, title, wxYES_NO | wxNO_DEFAULT | wxICON_QUESTION).ShowModal()))
         return;
-    
+
     // if we just delete preset from the physical printer
     if (m_presets_choice->is_selected_physical_printer()) {
         PhysicalPrinter& printer = physical_printers.get_selected_printer();
@@ -5944,7 +5943,7 @@ void TabPrinter::cache_extruder_cnt(const DynamicPrintConfig* config/* = nullptr
     if (Preset::printer_technology(cached_config) == ptSLA)
         return;
 
-    // get extruders count 
+    // get extruders count
     auto* nozzle_diameter = dynamic_cast<const ConfigOptionFloats*>(cached_config.option("nozzle_diameter"));
     m_cache_extruder_count = nozzle_diameter->values.size(); //m_extruders_count;
 }


### PR DESCRIPTION
# Description

Fixes "fan speed-up time" and "fan kick-start time" and the problem with FanMover removing the fan stop commands from the filament profiles filament change g-code.
Removes the "only overhangs" option from "fan speed-up time" since IMHO it does not make sense to correct fan speed-up latency only for overhangs. Fan latency is fan latency, regardless of extrusion role.
The implementation that had been merged in from SuperSlicer couldn't have worked anyway, since the overhang markers checked by FanMover, which is implemented as a g-code filter, are not written into the g-code by OrcaSlicer.

Fixes issues #7639 and #2144.

## Tests

I verifyed the produced G-Code by reading it, examined the fan speed view in the layer preview and checked if the filament change g-code from the filament profile is now working correctly.
