### PR TITLE
WIP: Bundle system profiles to speed up loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ src/OrcaSlicer-doc/
 **/.flatpak-builder/
 resources/profiles/user/default
 *.code-workspace
+resources/profiles/*.bundle.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -771,15 +771,20 @@ endif()
 
 
 # Resources install target, configure fhs.hpp on UNIX
+set (ORCA_PROFILE_BUNDLE_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/resources/profiles")
 if (WIN32)
-    install(DIRECTORY "${SLIC3R_RESOURCES_DIR}/" DESTINATION "./resources")
+    install(DIRECTORY "${SLIC3R_RESOURCES_DIR}/" DESTINATION "./resources"
+        REGEX "profiles/.*\\.json" EXCLUDE
+    )
     set(CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP TRUE)
     include(InstallRequiredSystemLibraries) 
     install (PROGRAMS ${CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS} DESTINATION ".")
 elseif (SLIC3R_FHS)
     # CMAKE_INSTALL_FULL_DATAROOTDIR: read-only architecture-independent data root (share)
     set(SLIC3R_FHS_RESOURCES "${CMAKE_INSTALL_FULL_DATAROOTDIR}/OrcaSlicer")
+    set (ORCA_PROFILE_BUNDLE_INSTALL_DIR "${SLIC3R_FHS_RESOURCES}/profiles")
     install(DIRECTORY ${SLIC3R_RESOURCES_DIR}/ DESTINATION ${SLIC3R_FHS_RESOURCES}
+        REGEX "profiles/.*\\.json" EXCLUDE
         PATTERN "*/udev" EXCLUDE
     )
     install(FILES src/platform/unix/OrcaSlicer.desktop DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/applications)
@@ -792,8 +797,23 @@ elseif (CMAKE_MACOSX_BUNDLE)
     # install(DIRECTORY "${SLIC3R_RESOURCES_DIR}/" DESTINATION "${CMAKE_INSTALL_PREFIX}/OrcaSlicer.app/Contents/resources")
 else ()
     install(FILES src/platform/unix/OrcaSlicer.desktop DESTINATION ${CMAKE_INSTALL_PREFIX}/resources/applications)
-    install(DIRECTORY "${SLIC3R_RESOURCES_DIR}/" DESTINATION "${CMAKE_INSTALL_PREFIX}/resources")
+    install(DIRECTORY "${SLIC3R_RESOURCES_DIR}/" DESTINATION "${CMAKE_INSTALL_PREFIX}/resources"
+        REGEX "profiles/.*\\.json" EXCLUDE
+    )
 endif ()
+
+include(FindPythonInterpreter)
+find_python_interpreter(
+	VERSION 3
+	INTERPRETER_OUT_VAR PYTHON_INTERPRETER
+	REQUIRED
+)
+install(CODE "execute_process( \
+    COMMAND ${PYTHON_INTERPRETER} ${CMAKE_CURRENT_SOURCE_DIR}/scripts/bundle_profiles.py \
+    -s ${SLIC3R_RESOURCES_DIR}/profiles \
+    -d ${ORCA_PROFILE_BUNDLE_INSTALL_DIR} \
+    )"
+)
 
 install(FILES ${CMAKE_SOURCE_DIR}/LICENSE.txt DESTINATION ".")
 configure_file(${LIBDIR}/platform/unix/fhs.hpp.in ${LIBDIR_BIN}/platform/unix/fhs.hpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -771,20 +771,15 @@ endif()
 
 
 # Resources install target, configure fhs.hpp on UNIX
-set (ORCA_PROFILE_BUNDLE_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/resources/profiles")
 if (WIN32)
-    install(DIRECTORY "${SLIC3R_RESOURCES_DIR}/" DESTINATION "./resources"
-        REGEX "profiles/.*\\.json" EXCLUDE
-    )
+    install(DIRECTORY "${SLIC3R_RESOURCES_DIR}/" DESTINATION "./resources")
     set(CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP TRUE)
     include(InstallRequiredSystemLibraries) 
     install (PROGRAMS ${CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS} DESTINATION ".")
 elseif (SLIC3R_FHS)
     # CMAKE_INSTALL_FULL_DATAROOTDIR: read-only architecture-independent data root (share)
     set(SLIC3R_FHS_RESOURCES "${CMAKE_INSTALL_FULL_DATAROOTDIR}/OrcaSlicer")
-    set (ORCA_PROFILE_BUNDLE_INSTALL_DIR "${SLIC3R_FHS_RESOURCES}/profiles")
     install(DIRECTORY ${SLIC3R_RESOURCES_DIR}/ DESTINATION ${SLIC3R_FHS_RESOURCES}
-        REGEX "profiles/.*\\.json" EXCLUDE
         PATTERN "*/udev" EXCLUDE
     )
     install(FILES src/platform/unix/OrcaSlicer.desktop DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/applications)
@@ -797,23 +792,8 @@ elseif (CMAKE_MACOSX_BUNDLE)
     # install(DIRECTORY "${SLIC3R_RESOURCES_DIR}/" DESTINATION "${CMAKE_INSTALL_PREFIX}/OrcaSlicer.app/Contents/resources")
 else ()
     install(FILES src/platform/unix/OrcaSlicer.desktop DESTINATION ${CMAKE_INSTALL_PREFIX}/resources/applications)
-    install(DIRECTORY "${SLIC3R_RESOURCES_DIR}/" DESTINATION "${CMAKE_INSTALL_PREFIX}/resources"
-        REGEX "profiles/.*\\.json" EXCLUDE
-    )
+    install(DIRECTORY "${SLIC3R_RESOURCES_DIR}/" DESTINATION "${CMAKE_INSTALL_PREFIX}/resources")
 endif ()
-
-include(FindPythonInterpreter)
-find_python_interpreter(
-	VERSION 3
-	INTERPRETER_OUT_VAR PYTHON_INTERPRETER
-	REQUIRED
-)
-install(CODE "execute_process( \
-    COMMAND ${PYTHON_INTERPRETER} ${CMAKE_CURRENT_SOURCE_DIR}/scripts/bundle_profiles.py \
-    -s ${SLIC3R_RESOURCES_DIR}/profiles \
-    -d ${ORCA_PROFILE_BUNDLE_INSTALL_DIR} \
-    )"
-)
 
 install(FILES ${CMAKE_SOURCE_DIR}/LICENSE.txt DESTINATION ".")
 configure_file(${LIBDIR}/platform/unix/fhs.hpp.in ${LIBDIR_BIN}/platform/unix/fhs.hpp)

--- a/cmake/modules/FindPythonInterpreter.cmake
+++ b/cmake/modules/FindPythonInterpreter.cmake
@@ -1,0 +1,135 @@
+# Copyright 2021, Robert Adam. All rights reserved.
+# Use of this source code is governed by a BSD-style license
+# that can be found in the LICENSE file at the root of the
+# source tree.
+
+cmake_minimum_required(VERSION 3.5)
+
+function(find_python_interpreter)
+	set(options REQUIRED EXACT)
+	set(oneValueArgs VERSION INTERPRETER_OUT_VAR VERSION_OUT_VAR)
+	set(multiValueArgs HINTS)
+	cmake_parse_arguments(FIND_PYTHON_INTERPRETER "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+
+	# Error handling
+	if (FIND_PYTHON_INTERPRETER_UNPARSED_ARGUMENTS)
+		message(FATAL_ERROR "Unrecognized arguments to find_python_interpreter: \"${FIND_PYTHON_INTERPRETER_UNPARSED_ARGUMENTS}\"")
+	endif()
+	if (NOT FIND_PYTHON_INTERPRETER_INTERPRETER_OUT_VAR)
+		message(FATAL_ERROR "Called find_python_interpreter without the INTERPRETER_OUT_VAR parameter!")
+	endif()
+	if (FIND_PYTHON_INTERPRETER_EXACT AND NOT FIND_PYTHON_INTERPRETER_VERSION)
+		message(FATAL_ERROR "Specified EXACT but did not specify VERSION!")
+	endif()
+
+
+	# Defaults
+	if (NOT FIND_PYTHON_INTERPRETER_VERSION)
+		set(FIND_PYTHON_INTERPRETER_VERSION "0.0.0")
+	endif()
+	if (NOT FIND_PYTHON_INTERPRETER_HINTS)
+		set(FIND_PYTHON_INTERPRETER_HINTS "")
+	endif()
+
+
+	# Validate
+	if (NOT FIND_PYTHON_INTERPRETER_VERSION MATCHES "^[0-9]+(\.[0-9]+(\.[0-9]+)?)?$")
+		message(FATAL_ERROR "Invalid VERSION \"FIND_PYTHON_INTERPRETER_VERSION\" - must follow RegEx \"^[0-9]+(\.[0-9]+(\.[0-9]+)?)?$\"")
+	endif()
+
+
+	# "parse" version (first append 0.0.0 in case only a part of the version scheme was set by the user)
+	string(CONCAT VERSION_HELPER "${FIND_PYTHON_INTERPRETER_VERSION}" ".0.0.0")
+	string(REPLACE "." ";" VERSION_LIST "${VERSION_HELPER}")
+	list(GET VERSION_LIST 0 FIND_PYTHON_INTERPRETER_VERSION_MAJOR)
+	list(GET VERSION_LIST 1 FIND_PYTHON_INTERPRETER_VERSION_MINOR)
+	list(GET VERSION_LIST 1 FIND_PYTHON_INTERPRETER_VERSION_PATCH)
+
+
+	# Create names for the interpreter to search for
+	set(INTERPRETER_NAMES "")
+	# Orca: Support pyenv-windows
+	if(WIN32)
+		list(APPEND INTERPRETER_NAMES "python.bat")
+	endif()
+	if (FIND_PYTHON_INTERPRETER_VERSION_MAJOR STREQUAL "0")
+		# Search for either Python 2 or 3
+		list(APPEND INTERPRETER_NAMES "python3")
+		list(APPEND INTERPRETER_NAMES "python")
+		list(APPEND INTERPRETER_NAMES "python2")
+	else()
+		# Search for specified version
+		list(APPEND INTERPRETER_NAMES "python${FIND_PYTHON_INTERPRETER_VERSION_MAJOR}")
+		list(APPEND INTERPRETER_NAMES "python")
+
+		if (NOT FIND_PYTHON_INTERPRETER_VERSION_MINOR EQUAL 0)
+			list(PREPEND INTERPRETER_NAMES "python${FIND_PYTHON_INTERPRETER_VERSION_MAJOR}.${FIND_PYTHON_INTERPRETER_VERSION_MINOR}")
+
+			if (NOT FIND_PYTHON_INTERPRETER_VERSION_PATCH EQUAL 0)
+				list(PREPEND INTERPRETER_NAMES
+					"python${FIND_PYTHON_INTERPRETER_VERSION_MAJOR}.${FIND_PYTHON_INTERPRETER_VERSION_MINOR}.${FIND_PYTHON_INTERPRETER_VERSION_PATCH}")
+			endif()
+		endif()
+	endif()
+
+
+	# Start by trying to search for a python executable in PATH and HINTS
+	find_program(PYTHON_INTERPRETER NAMES ${INTERPRETER_NAMES} HINTS ${FIND_PYTHON_INTERPRETER_HINTS})
+	message(STATUS "Python found: ${PYTHON_INTERPRETER}")
+
+	if (NOT PYTHON_INTERPRETER)
+		# Fall back to find_package
+		message(VERBOSE "Can't find Python interpreter in PATH -> Falling back to find_package")
+		if (FIND_PYTHON_INTERPRETER_VERSION_MAJOR EQUAL 0)
+			# Search arbitrary version
+			find_package(Python COMPONENTS Interpreter QUIET)
+			set(PYTHON_INTERPRETER "${Python_EXECUTABLE}")
+		else()
+			# Search specific version (Python 2 or 3)
+			find_package(Python${FIND_PYTHON_INTERPRETER_VERSION_MAJOR} COMPONENTS Interpreter QUIET)
+			set(PYTHON_INTERPRETER "${Python${FIND_PYTHON_INTERPRETER_VERSION_MAJOR}_EXECUTABLE}")
+		endif()
+	endif()
+
+
+	if (PYTHON_INTERPRETER)
+		# Verify that the version found is the one that is wanted
+		execute_process(
+			COMMAND ${PYTHON_INTERPRETER} "--version"
+			OUTPUT_VARIABLE PYTHON_INTERPRETER_VERSION
+			ERROR_VARIABLE PYTHON_INTERPRETER_VERSION # Python 2 reports the version on stderr
+		)
+
+		# Remove leading "Python " from version information
+		string(REPLACE "Python " "" PYTHON_INTERPRETER_VERSION "${PYTHON_INTERPRETER_VERSION}")
+		string(STRIP "${PYTHON_INTERPRETER_VERSION}" PYTHON_INTERPRETER_VERSION)
+
+
+		if (PYTHON_INTERPRETER_VERSION VERSION_LESS FIND_PYTHON_INTERPRETER_VERSION)
+			message(STATUS "Found Python version ${PYTHON_INTERPRETER_VERSION} but required at least ${FIND_PYTHON_INTERPRETER_VERSION}")
+			set(PYTHON_INTERPRETER "NOTFOUND")
+			set(PYTHON_INTERPRETER_VERSION "NOTFOUND")
+		elseif(PYTHON_INTERPRETER_VERSION VERSION_GREATER FIND_PYTHON_INTERPRETER_VERSION AND FIND_PYTHON_INTERPRETER_EXACT)
+			message(STATUS "Found Python interpreter version ${PYTHON_INTERPRETER_VERSION} but required exactly ${FIND_PYTHON_INTERPRETER_VERSION}")
+			set(PYTHON_INTERPRETER "NOTFOUND")
+			set(PYTHON_INTERPRETER_VERSION "NOTFOUND")
+		else()
+			message(STATUS "Found Python interpreter version ${PYTHON_INTERPRETER_VERSION}")
+		endif()
+	else()
+		set(PYTHON_INTERPRETER_VERSION "NOTFOUND")
+	endif()
+
+
+	# Set "return" values
+	set(${FIND_PYTHON_INTERPRETER_INTERPRETER_OUT_VAR} "${PYTHON_INTERPRETER}" PARENT_SCOPE)
+	if (FIND_PYTHON_INTERPRETER_VERSION_OUT_VAR)
+		set(${FIND_PYTHON_INTERPRETER_VERSION_OUT_VAR} "${PYTHON_INTERPRETER_VERSION}" PARENT_SCOPE)
+	endif()
+
+	if (NOT PYTHON_INTERPRETER AND FIND_PYTHON_INTERPRETER_REQUIRED)
+		message(FATAL_ERROR "Did NOT find Python interpreter")
+	endif()
+endfunction()
+

--- a/scripts/bundle_profiles.py
+++ b/scripts/bundle_profiles.py
@@ -28,8 +28,6 @@ def process_vendor(path, dest):
 
     # Make sure it's vendor profile
     if 'name' not in vendor_profile or 'version' not in vendor_profile:
-        # Copy non-profile file as-is
-        shutil.copy2(path, dest)
         return
     
     vendor_name = os.path.splitext(os.path.basename(path))[0]

--- a/scripts/bundle_profiles.py
+++ b/scripts/bundle_profiles.py
@@ -37,6 +37,7 @@ def process_vendor(path, dest):
         bundle_category(base_dir, vendor_profile, category)
 
     # Save bundle file
+    vendor_profile['bundle'] = True
     dest_path = os.path.join(dest, f'{vendor_name}.bundle.json')
     with open(dest_path, 'w', encoding='utf-8') as f:
         json.dump(vendor_profile, f, indent=4, ensure_ascii=False)

--- a/scripts/bundle_profiles.py
+++ b/scripts/bundle_profiles.py
@@ -3,6 +3,7 @@
 import json
 import argparse
 import os
+import shutil
 
 def bundle_profile(base_dir, item):
     # Read the file content specified by 'sub_path' then store them into 'content' field
@@ -27,7 +28,8 @@ def process_vendor(path, dest):
 
     # Make sure it's vendor profile
     if 'name' not in vendor_profile or 'version' not in vendor_profile:
-        print('Not a vendor profile, ignored')
+        # Copy non-profile file as-is
+        shutil.copy2(path, dest)
         return
     
     vendor_name = os.path.splitext(os.path.basename(path))[0]

--- a/scripts/bundle_profiles.py
+++ b/scripts/bundle_profiles.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+
+import json
+import argparse
+import os
+
+def bundle_profile(base_dir, item):
+    # Read the file content specified by 'sub_path' then store them into 'content' field
+    sub_profile_path = os.path.join(base_dir, item['sub_path'])
+    with open(sub_profile_path, 'r', encoding='utf-8') as f:
+        item['content'] = json.load(f)
+
+
+def bundle_category(base_dir, vendor_profile, category):
+    if category not in vendor_profile:
+        return
+    
+    cat = vendor_profile[category]
+    for item in cat:
+        bundle_profile(base_dir, item)
+
+
+def process_vendor(path, dest):
+    print('Bundling', path)
+    with open(path, 'r', encoding='utf-8') as f:
+        vendor_profile = json.load(f)
+
+    # Make sure it's vendor profile
+    if 'name' not in vendor_profile or 'version' not in vendor_profile:
+        print('Not a vendor profile, ignored')
+        return
+    
+    vendor_name = os.path.splitext(os.path.basename(path))[0]
+    base_dir = os.path.join(os.path.dirname(path), vendor_name)
+    
+    for category in ['machine_model_list', 'process_list', 'filament_list', 'machine_list']:
+        bundle_category(base_dir, vendor_profile, category)
+
+    # Save bundle file
+    dest_path = os.path.join(dest, f'{vendor_name}.bundle.json')
+    with open(dest_path, 'w', encoding='utf-8') as f:
+        json.dump(vendor_profile, f, indent=4, ensure_ascii=False)
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Bundle system profile json files into single bundle file')
+    parser.add_argument('-s', '--src', required=True, type=str, help='path to the folder contains all system profiles, usually the "resources\profiles" folder')
+    parser.add_argument('-d', '--dest', required=True, type=str, help='path to the folder where bundled profiles are stored')
+
+    args = parser.parse_args()
+
+    os.makedirs(args.dest, exist_ok=True)
+
+    for root, dirs, files in os.walk(args.src):
+        for file in files:
+            if file.lower().endswith('.json') and not file.lower().endswith('.bundle.json'):
+                full_path = os.path.join(root, file)
+                try:
+                    process_vendor(full_path, args.dest)
+                except Exception as e:
+                    print(f"Error processing {full_path}")
+                    raise
+                
+        break
+
+if __name__ == '__main__':
+    main()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -286,3 +286,18 @@ if (WIN32)
 else ()
     install(TARGETS OrcaSlicer RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}" BUNDLE DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif ()
+
+
+# Profile bundle
+include(FindPythonInterpreter)
+find_python_interpreter(
+	VERSION 3
+	INTERPRETER_OUT_VAR PYTHON_INTERPRETER
+	REQUIRED
+)
+add_custom_command(TARGET OrcaSlicer PRE_BUILD
+    COMMAND "${PYTHON_INTERPRETER}" "${CMAKE_CURRENT_SOURCE_DIR}/../scripts/bundle_profiles.py"
+        -s "${SLIC3R_RESOURCES_DIR}/profiles"
+        -d "${SLIC3R_RESOURCES_DIR}/profiles"
+    VERBATIM
+)

--- a/src/libslic3r/Config.cpp
+++ b/src/libslic3r/Config.cpp
@@ -800,6 +800,7 @@ int ConfigBase::load_from_json(const std::string &file, ConfigSubstitutionContex
         reason = std::string("JsonParseError: ") + err.what();
         // throw ConfigurationError(format("Failed loading configuration file \"%1%\": %2%", file, err.what()));
     }
+    return -1;
 }
 
 int ConfigBase::load_from_json(const std::string &file, const json &j, ConfigSubstitutionContext& substitution_context, bool load_inherits_to_config, std::map<std::string, std::string>& key_values, std::string& reason)

--- a/src/libslic3r/Config.cpp
+++ b/src/libslic3r/Config.cpp
@@ -784,7 +784,26 @@ ConfigSubstitutions ConfigBase::load_from_json(const std::string &file, ForwardC
 
 int ConfigBase::load_from_json(const std::string &file, ConfigSubstitutionContext& substitution_context, bool load_inherits_to_config, std::map<std::string, std::string>& key_values, std::string& reason)
 {
-    json j;
+    try {
+        json j;
+        boost::nowide::ifstream ifs(file);
+        ifs >> j;
+        ifs.close();
+
+        return load_from_json(file, j, substitution_context, load_inherits_to_config, key_values, reason);
+    } catch (const std::ifstream::failure& err) {
+        BOOST_LOG_TRIVIAL(error) << __FUNCTION__ << ": parse " << file << " got a ifstream error, reason = " << err.what();
+        reason = std::string("ifstreamError: ") + err.what();
+        // throw ConfigurationError(format("Failed loading configuration file \"%1%\": %2%", file, e.what()));
+    } catch (nlohmann::detail::parse_error& err) {
+        BOOST_LOG_TRIVIAL(error) << __FUNCTION__ << ": parse " << file << " got a nlohmann::detail::parse_error, reason = " << err.what();
+        reason = std::string("JsonParseError: ") + err.what();
+        // throw ConfigurationError(format("Failed loading configuration file \"%1%\": %2%", file, err.what()));
+    }
+}
+
+int ConfigBase::load_from_json(const std::string &file, const json &j, ConfigSubstitutionContext& substitution_context, bool load_inherits_to_config, std::map<std::string, std::string>& key_values, std::string& reason)
+{
     std::list<std::string> different_settings_append;
     std::string new_support_style;
     std::string is_infill_first;
@@ -794,10 +813,6 @@ int ConfigBase::load_from_json(const std::string &file, ConfigSubstitutionContex
     CNumericLocalesSetter locales_setter;
 
     try {
-        boost::nowide::ifstream ifs(file);
-        ifs >> j;
-        ifs.close();
-
         const ConfigDef* config_def = this->def();
         if (config_def == nullptr) {
             BOOST_LOG_TRIVIAL(error) << __FUNCTION__ << ": no config defs!";
@@ -1020,16 +1035,6 @@ int ConfigBase::load_from_json(const std::string &file, ConfigSubstitutionContex
         // Perform composite conversions, for example merging multiple keys into one key.
         this->handle_legacy_composite();
         return 0;
-    }
-    catch (const std::ifstream::failure &err)  {
-        BOOST_LOG_TRIVIAL(error) << __FUNCTION__<< ": parse "<<file<<" got a ifstream error, reason = " << err.what();
-        reason = std::string("ifstreamError: ") + err.what();
-        //throw ConfigurationError(format("Failed loading configuration file \"%1%\": %2%", file, e.what()));
-    }
-    catch(nlohmann::detail::parse_error &err) {
-        BOOST_LOG_TRIVIAL(error) << __FUNCTION__<< ": parse "<<file<<" got a nlohmann::detail::parse_error, reason = " << err.what();
-        reason = std::string("JsonParseError: ") + err.what();
-        //throw ConfigurationError(format("Failed loading configuration file \"%1%\": %2%", file, err.what()));
     }
     catch(std::exception &err) {
         BOOST_LOG_TRIVIAL(error) << __FUNCTION__<< ": parse "<<file<<" got a generic exception, reason = " << err.what();

--- a/src/libslic3r/Config.hpp
+++ b/src/libslic3r/Config.hpp
@@ -15,6 +15,7 @@
 #include "clonable_ptr.hpp"
 #include "Exception.hpp"
 #include "Point.hpp"
+#include <nlohmann/json_fwd.hpp>
 
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/algorithm/string/trim.hpp>
@@ -2157,6 +2158,7 @@ public:
     ConfigSubstitutions load_string_map(std::map<std::string, std::string> &key_values, ForwardCompatibilitySubstitutionRule compatibility_rule);
     //BBS: add json support
     int load_from_json(const std::string &file, ConfigSubstitutionContext& substitutions, bool load_inherits_in_config, std::map<std::string, std::string>& key_values, std::string& reason);
+    int load_from_json(const std::string &file, const nlohmann::json &j, ConfigSubstitutionContext& substitutions, bool load_inherits_in_config, std::map<std::string, std::string>& key_values, std::string& reason);
     ConfigSubstitutions load_from_json(const std::string &file, ForwardCompatibilitySubstitutionRule compatibility_rule, std::map<std::string, std::string>& key_values, std::string& reason);
 
     ConfigSubstitutions load_from_ini(const std::string &file, ForwardCompatibilitySubstitutionRule compatibility_rule);

--- a/src/libslic3r/Preset.hpp
+++ b/src/libslic3r/Preset.hpp
@@ -66,6 +66,8 @@
 
 // Orca extension
 #define ORCA_JSON_KEY_RENAMED_FROM              "renamed_from"
+#define ORCA_JSON_KEY_CONTENT                   "content"
+#define ORCA_JSON_KEY_BUNDLE                    "bundle"
 
 
 namespace Slic3r {

--- a/src/libslic3r/Technologies.hpp
+++ b/src/libslic3r/Technologies.hpp
@@ -62,5 +62,8 @@
 // Enable picking using raytracing
 #define ENABLE_RAYCAST_PICKING_DEBUG 0
 
+// Whether to create the same file structure in vendor profile folders,
+// so old Orca can still read them.
+#define PRESET_BUNDLE_COMPATIBLE 1
 
 #endif // _prusaslicer_technologies_h_

--- a/src/libslic3r/Utils.hpp
+++ b/src/libslic3r/Utils.hpp
@@ -215,6 +215,7 @@ extern bool is_gallery_file(const std::string& path, char const* type);
 extern bool is_shapes_dir(const std::string& dir);
 //BBS: add json support
 extern bool is_json_file(const std::string& path);
+extern bool is_preset_bundle_file(const std::string& path);
 
 // Orca: custom protocal support utils
 inline bool is_orca_open(const std::string& url) { return boost::starts_with(url, "orcaslicer://open"); }

--- a/src/libslic3r/utils.cpp
+++ b/src/libslic3r/utils.cpp
@@ -982,6 +982,11 @@ bool is_json_file(const std::string& path)
 	return boost::iends_with(path, ".json");
 }
 
+bool is_preset_bundle_file(const std::string& path)
+{
+	return boost::iends_with(path, ".bundle.json");
+}
+
 bool is_img_file(const std::string &path)
 {
 	return boost::iends_with(path, ".png") || boost::iends_with(path, ".svg");
@@ -1531,7 +1536,7 @@ void copy_directory_recursively(const boost::filesystem::path &source, const boo
 
         if (boost::filesystem::is_directory(dir_entry)) {
             const auto target_path = target / name;
-            copy_directory_recursively(dir_entry, target_path);
+            copy_directory_recursively(dir_entry, target_path, filter);
         }
         else {
 			if(filter && filter(name))

--- a/src/slic3r/GUI/CreatePresetsDialog.cpp
+++ b/src/slic3r/GUI/CreatePresetsDialog.cpp
@@ -2108,9 +2108,9 @@ bool CreatePrinterPresetDialog::load_system_and_user_presets_with_curr_model(Pre
     } else {
         selected_vendor_id = m_printer_preset_vendor_selected.id;
 
-        if (boost::filesystem::exists(boost::filesystem::path(Slic3r::data_dir()) / PRESET_SYSTEM_DIR / selected_vendor_id)) {
+        if (boost::filesystem::exists(boost::filesystem::path(Slic3r::data_dir()) / PRESET_SYSTEM_DIR / (selected_vendor_id + ".json"))) {
             preset_path = (boost::filesystem::path(Slic3r::data_dir()) / PRESET_SYSTEM_DIR).string();
-        } else if (boost::filesystem::exists(boost::filesystem::path(Slic3r::resources_dir()) / "profiles" / selected_vendor_id)) {
+        } else if (boost::filesystem::exists(boost::filesystem::path(Slic3r::resources_dir()) / "profiles" / (selected_vendor_id + ".bundle.json"))) {
             preset_path = (boost::filesystem::path(Slic3r::resources_dir()) / "profiles").string();
         }
 
@@ -2175,7 +2175,7 @@ bool CreatePrinterPresetDialog::load_system_and_user_presets_with_curr_model(Pre
     } else {
         selected_vendor_id = PRESET_TEMPLATE_DIR;
         preset_path.clear();
-        if (boost::filesystem::exists(boost::filesystem::path(Slic3r::resources_dir()) / PRESET_PROFILES_TEMOLATE_DIR / selected_vendor_id)) {
+        if (boost::filesystem::exists(boost::filesystem::path(Slic3r::resources_dir()) / PRESET_PROFILES_TEMOLATE_DIR / (selected_vendor_id + ".bundle.json"))) {
             preset_path = (boost::filesystem::path(Slic3r::resources_dir()) / PRESET_PROFILES_TEMOLATE_DIR).string();
         }
         if (preset_path.empty()) {

--- a/src/slic3r/GUI/WebGuideDialog.hpp
+++ b/src/slic3r/GUI/WebGuideDialog.hpp
@@ -76,16 +76,16 @@ public:
     int LoadProfile();
     int LoadProfileFamily(std::string strVendor, std::string strFilePath);
     int SaveProfile();
-    int GetFilamentInfo( std::string VendorDirectory,json & pFilaList, std::string filepath, std::string &sVendor, std::string &sType);
+    int GetFilamentInfo(const std::string& VendorDirectory,const json& pFilaList, const std::string& name, std::string &sVendor, std::string &sType) const;
 
 
     bool apply_config(AppConfig *app_config, PresetBundle *preset_bundle, const PresetUpdater *updater, bool& apply_keeped_changes);
     bool run();
 
     void        StrReplace(std::string &strBase, std::string strSrc, std::string strDes);
-    std::string w2s(wxString sSrc);
+    static std::string w2s(wxString sSrc);
     void        GetStardardFilePath(std::string &FilePath);
-    bool LoadFile(std::string jPath, std::string & sContent);
+    static bool LoadFile(std::string jPath, std::string & sContent);
 
     // install plugin
     int DownloadPlugin();

--- a/src/slic3r/Utils/PresetUpdater.cpp
+++ b/src/slic3r/Utils/PresetUpdater.cpp
@@ -1052,6 +1052,21 @@ bool PresetUpdater::priv::install_bundles_rsrc(const std::vector<std::string>& b
 		auto path_in_rsrc = (this->rsrc_path / bundle).replace_extension(".bundle.json");
 		auto path_in_vendors = (this->vendor_path / bundle).replace_extension(".json");
 		updates.updates.emplace_back(std::move(path_in_rsrc), std::move(path_in_vendors), Version(), bundle, "", "");
+
+#if PRESET_BUNDLE_COMPATIBLE
+        //BBS: add directory support
+        auto print_in_rsrc = this->rsrc_path / bundle;
+		auto print_in_vendors = this->vendor_path / bundle;
+        fs::path print_folder(print_in_vendors);
+        if (fs::exists(print_folder))
+            fs::remove_all(print_folder);
+        fs::create_directories(print_folder);
+		updates.updates.emplace_back(std::move(print_in_rsrc), std::move(print_in_vendors), Version(), bundle, "", "",[](const std::string name){
+        // return false if name is end with .stl, case insensitive
+        return boost::iends_with(name, ".stl") || boost::iends_with(name, ".png") || boost::iends_with(name, ".svg") ||
+               boost::iends_with(name, ".jpeg") || boost::iends_with(name, ".jpg") || boost::iends_with(name, ".3mf");
+        }, false, true);
+#endif
 	}
 
 	return perform_updates(std::move(updates), snapshot);

--- a/src/slic3r/Utils/PresetUpdater.cpp
+++ b/src/slic3r/Utils/PresetUpdater.cpp
@@ -1049,22 +1049,9 @@ bool PresetUpdater::priv::install_bundles_rsrc(const std::vector<std::string>& b
 	BOOST_LOG_TRIVIAL(info) << format("Installing %1% bundles from resources ...", bundles.size());
 
 	for (const auto &bundle : bundles) {
-		auto path_in_rsrc = (this->rsrc_path / bundle).replace_extension(".json");
+		auto path_in_rsrc = (this->rsrc_path / bundle).replace_extension(".bundle.json");
 		auto path_in_vendors = (this->vendor_path / bundle).replace_extension(".json");
 		updates.updates.emplace_back(std::move(path_in_rsrc), std::move(path_in_vendors), Version(), bundle, "", "");
-
-        //BBS: add directory support
-        auto print_in_rsrc = this->rsrc_path / bundle;
-		auto print_in_vendors = this->vendor_path / bundle;
-        fs::path print_folder(print_in_vendors);
-        if (fs::exists(print_folder))
-            fs::remove_all(print_folder);
-        fs::create_directories(print_folder);
-		updates.updates.emplace_back(std::move(print_in_rsrc), std::move(print_in_vendors), Version(), bundle, "", "",[](const std::string name){
-        // return false if name is end with .stl, case insensitive
-        return boost::iends_with(name, ".stl") || boost::iends_with(name, ".png") || boost::iends_with(name, ".svg") ||
-               boost::iends_with(name, ".jpeg") || boost::iends_with(name, ".jpg") || boost::iends_with(name, ".3mf");
-        }, false, true);
 	}
 
 	return perform_updates(std::move(updates), snapshot);
@@ -1085,11 +1072,10 @@ void PresetUpdater::priv::check_installed_vendor_profiles() const
     for (auto &dir_entry : boost::filesystem::directory_iterator(rsrc_path)) {
         const auto &path = dir_entry.path();
         std::string file_path = path.string();
-        if (is_json_file(file_path)) {
-            const auto path_in_vendor = vendor_path / path.filename();
-            std::string vendor_name = path.filename().string();
-            // Remove the .json suffix.
-            vendor_name.erase(vendor_name.size() - 5);
+        if (is_preset_bundle_file(file_path)) {
+            // Remove the .bundle.json suffix.
+            std::string vendor_name = path.filename().stem().stem().string();
+            const auto  path_in_vendor = vendor_path / (vendor_name + ".json");
             if (bundles.find(vendor_name) != bundles.end())continue;
 
             const auto is_vendor_enabled = (vendor_name == PresetBundle::ORCA_DEFAULT_BUNDLE) // always update configs from resource to vendor for ORCA_DEFAULT_BUNDLE


### PR DESCRIPTION
This create bundle.json files for each vendor that contains all information fron individual process/machine/filament jsons, so it no longer need to load tons of small files during app startup.

![image](https://github.com/user-attachments/assets/8e7b9444-ddce-4c9d-84ac-c8c4542a954f)

This also makes the loading of machine & filament selection screen 10x+ faster (3s vs 40s on my machine when cold started)!

Note: Profile bundles are generated by a python script during the build process, and should not be included in git and should not be manually edited!

To keep the profiles backward compatible, the individual profiles are also shipped with the app and will be copied to app data folder; and also the profile file will still be called `<vendor name>.json` instead of `.bundle.json` onces installed into app data folder. This shouldn't create extra runtime overhead because they won't be loaded by this version anyway. It just make switching to older Orca versions easier (so you don't need to delete the cached system profiles in app data folder manually).

There are still a lot to be done at the moment, due to the complexity of our profile system. Tests are welcomed!

**Important:** you will need to delete everything under `<appdata>\OrcaSlicer\system` before using this PR for the first time, because I haven't bumped the profile version at the moment so existing installed profiles won't be updated to the bundled version.

I developed this on Windows at the moment, so I haven't test other platforms yet. Please check if the `.bundle.json`s exist in the artifact you downloaded and report back if they don't, thanks.