### PR TITLE
WIP: preset selection improve

### DIFF
--- a/src/slic3r/GUI/WebGuideDialog.hpp
+++ b/src/slic3r/GUI/WebGuideDialog.hpp
@@ -77,7 +77,7 @@ public:
     int SaveProfileData();
     int LoadProfileFamily(std::string strVendor, std::string strFilePath);
     int SaveProfile();
-    int GetFilamentInfo( std::string VendorDirectory,json & pFilaList, std::string filepath, std::string &sVendor, std::string &sType);
+    int GetFilamentInfo( std::string VendorDirectory,json & pFilaList, const std::string& filepath, const json& content, std::string &sVendor, std::string &sType);
 
 
     bool apply_config(AppConfig *app_config, PresetBundle *preset_bundle, const PresetUpdater *updater, bool& apply_keeped_changes);


### PR DESCRIPTION
Improves the filament profile name handling, now the filament selection works properly even after filament renaming, as long as the old name presents in `renamed_from` field.

Also slightly improves the filament selection page loading speed by not reading the same profile json twice.
