### PR TITLE
Update SelectMachine.cpp to partially address unknown nozzles

### DIFF
--- a/src/slic3r/GUI/SelectMachine.cpp
+++ b/src/slic3r/GUI/SelectMachine.cpp
@@ -2655,7 +2655,7 @@ wxString SelectMachineDialog::format_steel_name(std::string name)
         return _L("Stainless Steel");
     }
 
-    return wxEmptyString;
+    return wxString::Format(_L("Unknown nozzle type: '%s'"), name);
 }
 
 void SelectMachineDialog::Enable_Auto_Refill(bool enable)


### PR DESCRIPTION
# Description

Changed the final return string in `format_steel_name` from `return wxEmptyString;` to `return wxString::Format(_L("Unknown nozzle type: '%s'"), name);`. This is on line ~2658 in src/slic3r/GUI/SelectMachine.cpp

This was to partially address, but not fix bugs https://github.com/SoftFever/OrcaSlicer/issues/9967 and https://github.com/SoftFever/OrcaSlicer/issues/9938 . While not a full fix, it does prevent an empty string from appearing in the error dialog containing the text "may cause nozzle damage". This may make future diagnosis easier and I think is a reasonable change regardless.

To further address it, you can also comment out `is_printing_block = true;` on line ~2577, the block containing the `may cause nozzle damage` error text. This will prevent the slicer from hiding the "confirm" button and allow a user to continue the print. In my testing, this worked. However, I don't know why that particular warning isn't bypassable by default and I'm not positive that it won't cause damage to something.

# Screenshots/Recordings/Graphs

Before change:
![image](https://github.com/user-attachments/assets/11b5c083-74c2-474c-9767-0d833dfc86c8)

After change with the confirm button allowed (not part of this PR):
![image](https://github.com/user-attachments/assets/6efb68ab-a632-42e5-ab01-c45caec72725)

## Tests

- Made the change to both the nozzle name string (this PR) and commented out the line blocking the confirm button (not included in this PR). 
- Built the package for linux with the -disrc flags. 
- Launched the app and printed a 1/3rd benchy on ludicrous speed with no issues.
