### PR TITLE
feature: move plate to any position by user input

### DIFF
--- a/src/slic3r/GUI/GUI_Factories.hpp
+++ b/src/slic3r/GUI/GUI_Factories.hpp
@@ -165,6 +165,7 @@ private:
     void        append_menu_item_locked(wxMenu* menu);
     void        append_menu_item_fill_bed(wxMenu *menu);
     void        append_menu_item_plate_name(wxMenu *menu);
+    void        append_menu_item_move_plate(wxMenu* menu);
 };
 
 }}

--- a/src/slic3r/GUI/PlateSettingsDialog.hpp
+++ b/src/slic3r/GUI/PlateSettingsDialog.hpp
@@ -195,6 +195,38 @@ public:
 protected:
     TextInput *m_ti_plate_name;
 };
+
+class MovePlateDialog : public DPIDialog
+{
+public:
+    enum ButtonStyle { ONLY_CONFIRM = 0, CONFIRM_AND_CANCEL = 1, MAX_STYLE_NUM = 2 };
+    MovePlateDialog(wxWindow*       parent,
+                    int             current_plate_index,
+                    int             total_plate_count,
+                    wxWindowID      id    = wxID_ANY,
+                    const wxString& title = wxEmptyString,
+                    const wxPoint&  pos   = wxDefaultPosition,
+                    const wxSize&   size  = wxDefaultSize,
+                    long            style = wxCLOSE_BOX | wxCAPTION);
+
+    ~MovePlateDialog();
+    void on_dpi_changed(const wxRect& suggested_rect) override;
+
+    int  get_target_position() const;
+    bool is_valid_input() const { return m_valid_input; }
+
+protected:
+    void validate_input();
+
+private:
+    TextInput*    m_ti_position;
+    int           m_current_plate_index;
+    int           m_total_plate_count;
+    int           m_target_position;
+    bool          m_valid_input;
+    wxStaticText* m_info_text;
+};
+
 }} // namespace Slic3r::GUI
 
 #endif


### PR DESCRIPTION
# Description
Fixes #9763 and hopefully no more comments on #3508 lol. Drag n drop is too much work. This workflow follows the existing "edit plate name" dialog structure. I combined it with how I implemented the "move to the front" feature, plus a input validation check. It should be simple feature addition.

1. Right click on a plate
2. Click "move plate"
3. Enter a valid postion
4. Hit OK

# Screenshots/Recordings/Graphs

<img width="1181" height="816" alt="image" src="https://github.com/user-attachments/assets/344d5119-42ce-45d0-ba47-611126eea8d5" />
<img width="1218" height="808" alt="image" src="https://github.com/user-attachments/assets/0c961c47-cb17-4161-b85a-df2e211cd54a" />
<img width="1200" height="813" alt="image" src="https://github.com/user-attachments/assets/7a28ea97-86a1-4c3a-88a2-f35fcb9f8140" />





## Tests

tested locally on windows
