### PR TITLE
Windows accessibility support for GLCanvas tools and BBLTopbar

### DIFF
--- a/src/slic3r/GUI/BBLTopbar.cpp
+++ b/src/slic3r/GUI/BBLTopbar.cpp
@@ -13,6 +13,43 @@
 
 #include <boost/log/trivial.hpp>
 
+#ifdef _WIN32
+// Windows accessibility headers and COM interface support
+#undef WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#include <oleacc.h>
+#include <comdef.h>
+#include <winerror.h>
+#include <objbase.h>
+
+// Defines Windows accessibility constants
+#ifndef STATE_SYSTEM_NORMAL
+#define STATE_SYSTEM_NORMAL 0x00000000
+#endif
+
+#ifndef CHILDID_SELF
+#define CHILDID_SELF 0
+#endif
+
+// Defines COM constants
+#ifndef S_OK
+#define S_OK ((HRESULT)0L)
+#endif
+
+#ifndef E_FAIL
+#define E_FAIL ((HRESULT)0x80004005L)
+#endif
+
+#ifndef E_NOTIMPL
+#define E_NOTIMPL ((HRESULT)0x80004001L)
+#endif
+
+#ifndef E_NOINTERFACE
+#define E_NOINTERFACE ((HRESULT)0x80004002L)
+#endif
+
+#endif
+
 #define TOPBAR_ICON_SIZE  18
 #define TOPBAR_TITLE_WIDTH  300
 
@@ -180,92 +217,302 @@ void BBLTopbarArt::DrawButton(wxDC& dc, wxWindow* wnd, const wxAuiToolBarItem& i
     }
 }
 
+#ifdef _WIN32
+// Windows accessibility COM interface implementation for BBL toolbar
+class BBLTopbarAccessible : public IAccessible
+{
+private:
+    ULONG m_refCount;
+    wxAuiToolBar* m_pToolBar;
+    BBLTopbar* m_pBBLTopbar;
+    long m_currentFocusedChild;
+
+public:
+    BBLTopbarAccessible(wxAuiToolBar* pToolBar, BBLTopbar* pBBLTopbar)
+        : m_refCount(1), m_pToolBar(pToolBar), m_pBBLTopbar(pBBLTopbar), m_currentFocusedChild(CHILDID_SELF)
+    {
+        printf("BBLTopbarAccessible object created\n");
+        fflush(stdout);
+    }
+
+    virtual ~BBLTopbarAccessible()
+    {
+        printf("BBLTopbarAccessible object destroyed\n");
+        fflush(stdout);
+    }
+
+    // COM interface methods for reference counting and interface querying
+    STDMETHODIMP QueryInterface(REFIID riid, void** ppv)
+    {
+        if (riid == IID_IUnknown || riid == IID_IDispatch || riid == IID_IAccessible)
+        {
+            *ppv = static_cast<IAccessible*>(this);
+            AddRef();
+            return S_OK;
+        }
+        *ppv = NULL;
+        return E_NOINTERFACE;
+    }
+
+    STDMETHODIMP_(ULONG) AddRef()
+    {
+        return InterlockedIncrement(&m_refCount);
+    }
+
+    STDMETHODIMP_(ULONG) Release()
+    {
+        ULONG refCount = InterlockedDecrement(&m_refCount);
+        if (refCount == 0)
+            delete this;
+        return refCount;
+    }
+
+    // IDispatch methods
+    STDMETHODIMP GetTypeInfoCount(UINT* pctinfo) { *pctinfo = 0; return S_OK; }
+    STDMETHODIMP GetTypeInfo(UINT iTInfo, LCID lcid, ITypeInfo** ppTInfo) { return E_NOTIMPL; }
+    STDMETHODIMP GetIDsOfNames(REFIID riid, LPOLESTR* rgszNames, UINT cNames, LCID lcid, DISPID* rgDispId) { return E_NOTIMPL; }
+    STDMETHODIMP Invoke(DISPID dispIdMember, REFIID riid, LCID lcid, WORD wFlags, DISPPARAMS* pDispParams, VARIANT* pVarResult, EXCEPINFO* pExcepInfo, UINT* puArgErr) { return E_NOTIMPL; }
+
+    // IAccessible interface implementation for screen reader support
+    STDMETHODIMP get_accParent(IDispatch** ppdispParent) { *ppdispParent = NULL; return S_FALSE; }
+    STDMETHODIMP get_accChildCount(long* pcountChildren) { *pcountChildren = 9; return S_OK; }
+    STDMETHODIMP get_accChild(VARIANT varChild, IDispatch** ppdispChild) { *ppdispChild = NULL; return S_FALSE; }
+    
+    // Provides accessible names for toolbar elements to screen readers
+    STDMETHODIMP get_accName(VARIANT varChild, BSTR* pszName)
+    {
+        if (varChild.vt == VT_I4)
+        {
+            // Maps child index to toolbar element names
+            switch (varChild.lVal)
+            {
+                case 1: *pszName = SysAllocString(L"File"); break;
+                case 2: *pszName = SysAllocString(L"Menu"); break;
+                case 3: *pszName = SysAllocString(L"Save"); break;
+                case 4: *pszName = SysAllocString(L"Undo"); break;
+                case 5: *pszName = SysAllocString(L"Redo"); break;
+                case 6: *pszName = SysAllocString(L"Calibration"); break;
+                case 7: *pszName = SysAllocString(L"Minimize"); break;
+                case 8: *pszName = SysAllocString(L"Maximize"); break;
+                case 9: *pszName = SysAllocString(L"Close"); break;
+                default: *pszName = SysAllocString(L"BBLTopbar"); break;
+            }
+        }
+        else
+        {
+            *pszName = SysAllocString(L"BBLTopbar");
+        }
+        return S_OK;
+    }
+
+    STDMETHODIMP get_accValue(VARIANT varChild, BSTR* pszValue) { *pszValue = NULL; return S_FALSE; }
+    STDMETHODIMP get_accDescription(VARIANT varChild, BSTR* pszDescription) { *pszDescription = NULL; return S_FALSE; }
+    STDMETHODIMP get_accRole(VARIANT varChild, VARIANT* pvarRole) 
+    { 
+        pvarRole->vt = VT_I4; 
+        pvarRole->lVal = ROLE_SYSTEM_TOOLBAR; 
+        return S_OK; 
+    }
+    STDMETHODIMP get_accState(VARIANT varChild, VARIANT* pvarState) 
+    { 
+        pvarState->vt = VT_I4; 
+        pvarState->lVal = STATE_SYSTEM_NORMAL; 
+        return S_OK; 
+    }
+    STDMETHODIMP get_accHelp(VARIANT varChild, BSTR* pszHelp) { *pszHelp = NULL; return S_FALSE; }
+    STDMETHODIMP get_accHelpTopic(BSTR* pszHelpFile, VARIANT varChild, long* pidTopic) { return E_NOTIMPL; }
+    STDMETHODIMP get_accKeyboardShortcut(VARIANT varChild, BSTR* pszKeyboardShortcut) { *pszKeyboardShortcut = NULL; return S_FALSE; }
+    
+    // Returns currently focused toolbar element to screen readers
+    STDMETHODIMP get_accFocus(VARIANT* pvarChild)
+    {
+        printf("BBLTopbarAccessible::get_accFocus returning focused child %ld\n", m_currentFocusedChild);
+        fflush(stdout);
+        pvarChild->vt = VT_I4;
+        pvarChild->lVal = m_currentFocusedChild;
+        return S_OK;
+    }
+
+    STDMETHODIMP get_accSelection(VARIANT* pvarChildren) { pvarChildren->vt = VT_EMPTY; return S_FALSE; }
+    STDMETHODIMP get_accDefaultAction(VARIANT varChild, BSTR* pszDefaultAction) { *pszDefaultAction = SysAllocString(L"Click"); return S_OK; }
+    STDMETHODIMP accSelect(long flagsSelect, VARIANT varChild) { return S_OK; }
+    // Provides screen coordinates of toolbar for screen reader positioning
+    STDMETHODIMP accLocation(long* pxLeft, long* pyTop, long* pcxWidth, long* pcyHeight, VARIANT varChild) 
+    { 
+        if (m_pToolBar) {
+            wxRect rect = m_pToolBar->GetRect();
+            *pxLeft = rect.x;
+            *pyTop = rect.y;
+            *pcxWidth = rect.width;
+            *pcyHeight = rect.height;
+        }
+        return S_OK; 
+    }
+    STDMETHODIMP accNavigate(long navDir, VARIANT varStart, VARIANT* pvarEndUpAt) { pvarEndUpAt->vt = VT_EMPTY; return S_FALSE; }
+    STDMETHODIMP accHitTest(long xLeft, long yTop, VARIANT* pvarChild) { pvarChild->vt = VT_EMPTY; return S_FALSE; }
+    STDMETHODIMP accDoDefaultAction(VARIANT varChild) { return S_OK; }
+    STDMETHODIMP put_accName(VARIANT varChild, BSTR szName) { return E_NOTIMPL; }
+    STDMETHODIMP put_accValue(VARIANT varChild, BSTR szValue) { return E_NOTIMPL; }
+
+    // Updates the currently focused child element
+    void SetCurrentFocusedChild(long childId)
+    {
+        m_currentFocusedChild = childId;
+        printf("BBLTopbarAccessible focused child set to %ld\n", childId);
+        fflush(stdout);
+    }
+};
+#endif
+
 BBLTopbar::BBLTopbar(wxFrame* parent) 
     : wxAuiToolBar(parent, ID_TOOL_BAR, wxDefaultPosition, wxDefaultSize, wxAUI_TB_TEXT | wxAUI_TB_HORZ_TEXT)
 { 
+    FILE* debugFile = fopen("C:\\temp\\bbltopbar_debug.txt", "a");
+    if (debugFile) { fprintf(debugFile, "BBLTopbar constructor (wxFrame*) called - this=%p\n", this); fflush(debugFile); fclose(debugFile); }
     Init(parent);
+    debugFile = fopen("C:\\temp\\bbltopbar_debug.txt", "a");
+    if (debugFile) { fprintf(debugFile, "BBLTopbar constructor (wxFrame*) completed\n"); fflush(debugFile); fclose(debugFile); }
 }
 
 BBLTopbar::BBLTopbar(wxWindow* pwin, wxFrame* parent)
     : wxAuiToolBar(pwin, ID_TOOL_BAR, wxDefaultPosition, wxDefaultSize, wxAUI_TB_TEXT | wxAUI_TB_HORZ_TEXT) 
 { 
+    FILE* debugFile = fopen("C:\\temp\\bbltopbar_debug.txt", "a");
+    if (debugFile) { fprintf(debugFile, "BBLTopbar constructor (wxWindow*, wxFrame*) called - this=%p\n", this); fflush(debugFile); fclose(debugFile); }
     Init(parent);
+    debugFile = fopen("C:\\temp\\bbltopbar_debug.txt", "a");
+    if (debugFile) { fprintf(debugFile, "BBLTopbar constructor (wxWindow*, wxFrame*) completed\n"); fflush(debugFile); fclose(debugFile); }
 }
 
 void BBLTopbar::Init(wxFrame* parent) 
 {
+    // Write debug information to file to track crash location
+    FILE* debugFile = fopen("C:\\temp\\bbltopbar_debug.txt", "w");
+    if (debugFile) {
+        fprintf(debugFile, "BBLTopbar::Init() START - parent=%p, this=%p\n", parent, this);
+        fflush(debugFile);
+    }
+    
+    if (debugFile) { fprintf(debugFile, "Setting art provider\n"); fflush(debugFile); }
     SetArtProvider(new BBLTopbarArt());
+    
+    if (debugFile) { fprintf(debugFile, "Setting member variables\n"); fflush(debugFile); }
     m_frame = parent;
     m_skip_popup_file_menu = false;
     m_skip_popup_dropdown_menu = false;
     m_skip_popup_calib_menu    = false;
 
+    if (debugFile) { fprintf(debugFile, "Calling wxInitAllImageHandlers()\n"); fflush(debugFile); }
     wxInitAllImageHandlers();
 
+    if (debugFile) { fprintf(debugFile, "Adding initial spacer\n"); fflush(debugFile); }
     this->AddSpacer(5);
 
-    /*wxBitmap logo_bitmap = create_scaled_bitmap("topbar_logo", nullptr, TOPBAR_ICON_SIZE);
-    wxAuiToolBarItem* logo_item = this->AddTool(ID_LOGO, "", logo_bitmap);
-    logo_item->SetHoverBitmap(logo_bitmap);
-    logo_item->SetActive(false);*/
-
+    if (debugFile) { fprintf(debugFile, "Creating logo bitmap\n"); fflush(debugFile); }
+    // Logo bitmap creation occurs at silent crash
+    // wxBitmap logo_bitmap = create_scaled_bitmap("topbar_logo", nullptr, TOPBAR_ICON_SIZE);
+    if (debugFile) { fprintf(debugFile, "Adding logo tool\n"); fflush(debugFile); }
+    // wxAuiToolBarItem* logo_item = this->AddTool(ID_LOGO, "", logo_bitmap);
+    // logo_item->SetHoverBitmap(logo_bitmap);
+    // logo_item->SetActive(false);
+    
+    if (debugFile) { fprintf(debugFile, "About to call create_scaled_bitmap for file\n"); fflush(debugFile); }
     wxBitmap file_bitmap = create_scaled_bitmap("topbar_file", nullptr, TOPBAR_ICON_SIZE);
+    
+    if (debugFile) { fprintf(debugFile, "Adding file tool\n"); fflush(debugFile); }
     m_file_menu_item = this->AddTool(ID_TOP_FILE_MENU, _L("File"), file_bitmap, wxEmptyString, wxITEM_NORMAL);
-
+    
+    if (debugFile) { fprintf(debugFile, "Setting foreground color\n"); fflush(debugFile); }
     this->SetForegroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_HIGHLIGHTTEXT));
-
+    
+    if (debugFile) { fprintf(debugFile, "Adding spacer\n"); fflush(debugFile); }
     this->AddSpacer(FromDIP(5));
-
+    
+    if (debugFile) { fprintf(debugFile, "Creating dropdown bitmap\n"); fflush(debugFile); }
     wxBitmap dropdown_bitmap = create_scaled_bitmap("topbar_dropdown", nullptr, TOPBAR_ICON_SIZE);
-    m_dropdown_menu_item = this->AddTool(ID_TOP_DROPDOWN_MENU, "",
-        dropdown_bitmap, wxEmptyString);
+    
+    if (debugFile) { fprintf(debugFile, "Adding dropdown tool\n"); fflush(debugFile); }
+    m_dropdown_menu_item = this->AddTool(ID_TOP_DROPDOWN_MENU, "", dropdown_bitmap, wxEmptyString);
 
+    if (debugFile) { fprintf(debugFile, "Adding spacer, separator, spacer sequence\n"); fflush(debugFile); }
+    
     this->AddSpacer(FromDIP(5));
     this->AddSeparator();
     this->AddSpacer(FromDIP(5));
+    
+    wxBitmap open_bitmap = create_scaled_bitmap("topbar_open", nullptr, TOPBAR_ICON_SIZE);
+    wxAuiToolBarItem* tool_item = this->AddTool(wxID_OPEN, "", open_bitmap);
 
-    //wxBitmap open_bitmap = create_scaled_bitmap("topbar_open", nullptr, TOPBAR_ICON_SIZE);
-    //wxAuiToolBarItem* tool_item = this->AddTool(wxID_OPEN, "", open_bitmap);
-
+    if (debugFile) { fprintf(debugFile, "Adding 10 DIP spacer\n"); fflush(debugFile); }
     this->AddSpacer(FromDIP(10));
-
+    
+    if (debugFile) { fprintf(debugFile, "Creating save bitmap\n"); fflush(debugFile); }
     wxBitmap save_bitmap = create_scaled_bitmap("topbar_save", nullptr, TOPBAR_ICON_SIZE);
+    
+    if (debugFile) { fprintf(debugFile, "Adding save tool\n"); fflush(debugFile); }
     wxAuiToolBarItem* save_btn = this->AddTool(wxID_SAVE, "", save_bitmap);
-
+    
+    if (debugFile) { fprintf(debugFile, "Adding 10 DIP spacer before undo\n"); fflush(debugFile); }
     this->AddSpacer(FromDIP(10));
-
+    
+    if (debugFile) { fprintf(debugFile, "Creating undo bitmap\n"); fflush(debugFile); }
     wxBitmap undo_bitmap = create_scaled_bitmap("topbar_undo", nullptr, TOPBAR_ICON_SIZE);
+    
+    if (debugFile) { fprintf(debugFile, "create_scaled_bitmap for undo completed\n"); fflush(debugFile); }
+    
+    if (debugFile) { fprintf(debugFile, "Adding undo tool\n"); fflush(debugFile); }
     m_undo_item = this->AddTool(wxID_UNDO, "", undo_bitmap);
+    
+    if (debugFile) { fprintf(debugFile, "Creating undo inactive bitmap\n"); fflush(debugFile); }
     wxBitmap undo_inactive_bitmap = create_scaled_bitmap("topbar_undo_inactive", nullptr, TOPBAR_ICON_SIZE);
+    
+    if (debugFile) { fprintf(debugFile, "Setting undo disabled bitmap\n"); fflush(debugFile); }
     m_undo_item->SetDisabledBitmap(undo_inactive_bitmap);
-
+    
+    if (debugFile) { fprintf(debugFile, "Adding spacer before redo\n"); fflush(debugFile); }
     this->AddSpacer(FromDIP(10));
 
+    if (debugFile) { fprintf(debugFile, "Creating redo bitmap\n"); fflush(debugFile); }
     wxBitmap redo_bitmap = create_scaled_bitmap("topbar_redo", nullptr, TOPBAR_ICON_SIZE);
+    if (debugFile) { fprintf(debugFile, "Adding redo tool\n"); fflush(debugFile); }
     m_redo_item = this->AddTool(wxID_REDO, "", redo_bitmap);
+    if (debugFile) { fprintf(debugFile, "Creating redo inactive bitmap\n"); fflush(debugFile); }
     wxBitmap redo_inactive_bitmap = create_scaled_bitmap("topbar_redo_inactive", nullptr, TOPBAR_ICON_SIZE);
+    if (debugFile) { fprintf(debugFile, "Setting redo disabled bitmap\n"); fflush(debugFile); }
     m_redo_item->SetDisabledBitmap(redo_inactive_bitmap);
 
+    if (debugFile) { fprintf(debugFile, "Adding spacer before calib\n"); fflush(debugFile); }
     this->AddSpacer(FromDIP(10));
 
+    if (debugFile) { fprintf(debugFile, "Creating calibration bitmaps\n"); fflush(debugFile); }
     wxBitmap calib_bitmap          = create_scaled_bitmap("calib_sf", nullptr, TOPBAR_ICON_SIZE);
     wxBitmap calib_bitmap_inactive = create_scaled_bitmap("calib_sf_inactive", nullptr, TOPBAR_ICON_SIZE);
+    if (debugFile) { fprintf(debugFile, "Adding calibration tool\n"); fflush(debugFile); }
     m_calib_item                   = this->AddTool(ID_CALIB, _L("Calibration"), calib_bitmap);
+    if (debugFile) { fprintf(debugFile, "Setting calibration disabled bitmap\n"); fflush(debugFile); }
     m_calib_item->SetDisabledBitmap(calib_bitmap_inactive);
 
+    if (debugFile) { fprintf(debugFile, "Adding spacer and stretch spacer\n"); fflush(debugFile); }
     this->AddSpacer(FromDIP(10));
     this->AddStretchSpacer(1);
 
+    if (debugFile) { fprintf(debugFile, "Adding title label\n"); fflush(debugFile); }
     m_title_item = this->AddLabel(ID_TITLE, "", FromDIP(TOPBAR_TITLE_WIDTH));
     m_title_item->SetAlignment(wxALIGN_CENTRE);
 
+    if (debugFile) { fprintf(debugFile, "Adding spacer and stretch spacer after title\n"); fflush(debugFile); }
     this->AddSpacer(FromDIP(10));
     this->AddStretchSpacer(1);
 
+    if (debugFile) { fprintf(debugFile, "Creating publish bitmaps\n"); fflush(debugFile); }
     m_publish_bitmap = create_scaled_bitmap("topbar_publish", nullptr, TOPBAR_ICON_SIZE);
+    if (debugFile) { fprintf(debugFile, "Adding publish tool\n"); fflush(debugFile); }
     m_publish_item = this->AddTool(ID_PUBLISH, "", m_publish_bitmap);
+    if (debugFile) { fprintf(debugFile, "Creating publish disable bitmap\n"); fflush(debugFile); }
     m_publish_disable_bitmap = create_scaled_bitmap("topbar_publish_disable", nullptr, TOPBAR_ICON_SIZE);
+    if (debugFile) { fprintf(debugFile, "Setting publish disabled bitmap\n"); fflush(debugFile); }
     m_publish_item->SetDisabledBitmap(m_publish_disable_bitmap);
+    if (debugFile) { fprintf(debugFile, "Enabling/disabling publish tool\n"); fflush(debugFile); }
     this->EnableTool(m_publish_item->GetId(), false);
     this->AddSpacer(FromDIP(4));
 
@@ -275,15 +522,21 @@ void BBLTopbar::Init(wxFrame* parent)
     */
 
     //this->AddSeparator();
+    if (debugFile) { fprintf(debugFile, "Adding final spacer\n"); fflush(debugFile); }
     this->AddSpacer(FromDIP(4));
 
+    if (debugFile) { fprintf(debugFile, "Creating iconize bitmap\n"); fflush(debugFile); }
     wxBitmap iconize_bitmap = create_scaled_bitmap("topbar_min", nullptr, TOPBAR_ICON_SIZE);
+    if (debugFile) { fprintf(debugFile, "Adding iconize tool\n"); fflush(debugFile); }
     wxAuiToolBarItem* iconize_btn = this->AddTool(wxID_ICONIZE_FRAME, "", iconize_bitmap);
 
+    if (debugFile) { fprintf(debugFile, "Adding spacer before maximize\n"); fflush(debugFile); }
     this->AddSpacer(FromDIP(4));
 
+    if (debugFile) { fprintf(debugFile, "Creating maximize/window bitmaps\n"); fflush(debugFile); }
     maximize_bitmap = create_scaled_bitmap("topbar_max", nullptr, TOPBAR_ICON_SIZE);
     window_bitmap = create_scaled_bitmap("topbar_win", nullptr, TOPBAR_ICON_SIZE);
+    if (debugFile) { fprintf(debugFile, "Adding maximize tool (checking frame state)\n"); fflush(debugFile); }
     if (m_frame->IsMaximized()) {
         maximize_btn = this->AddTool(wxID_MAXIMIZE_FRAME, "", window_bitmap);
     }
@@ -291,40 +544,93 @@ void BBLTopbar::Init(wxFrame* parent)
         maximize_btn = this->AddTool(wxID_MAXIMIZE_FRAME, "", maximize_bitmap);
     }
 
+    if (debugFile) { fprintf(debugFile, "Adding spacer before close\n"); fflush(debugFile); }
     this->AddSpacer(FromDIP(4));
 
+    if (debugFile) { fprintf(debugFile, "Creating close bitmap\n"); fflush(debugFile); }
     wxBitmap close_bitmap = create_scaled_bitmap("topbar_close", nullptr, TOPBAR_ICON_SIZE);
+    
+    if (debugFile) { fprintf(debugFile, "Adding close tool\n"); fflush(debugFile); }
     wxAuiToolBarItem* close_btn = this->AddTool(wxID_CLOSE_FRAME, "", close_bitmap);
-
+    
+    if (debugFile) { fprintf(debugFile, "Calling Realize()\n"); fflush(debugFile); }
     Realize();
-    // m_toolbar_h = this->GetSize().GetHeight();
+    
+    if (debugFile) { fprintf(debugFile, "Setting toolbar dimensions\n"); fflush(debugFile); }
+    // Sets toolbar dimensions
     m_toolbar_h = FromDIP(30);
-
     int client_w = parent->GetClientSize().GetWidth();
     this->SetSize(client_w, m_toolbar_h);
 
+    if (debugFile) { fprintf(debugFile, "Binding mouse events\n"); fflush(debugFile); }
+    // Binds mouse events for window dragging
     this->Bind(wxEVT_MOTION, &BBLTopbar::OnMouseMotion, this);
     this->Bind(wxEVT_MOUSE_CAPTURE_LOST, &BBLTopbar::OnMouseCaptureLost, this);
     this->Bind(wxEVT_MENU_CLOSE, &BBLTopbar::OnMenuClose, this);
+    
+    if (debugFile) { fprintf(debugFile, "Binding toolbar tool events\n"); fflush(debugFile); }
+    // Binds toolbar tool events
     this->Bind(wxEVT_AUITOOLBAR_TOOL_DROPDOWN, &BBLTopbar::OnFileToolItem, this, ID_TOP_FILE_MENU);
     this->Bind(wxEVT_AUITOOLBAR_TOOL_DROPDOWN, &BBLTopbar::OnDropdownToolItem, this, ID_TOP_DROPDOWN_MENU);
     this->Bind(wxEVT_AUITOOLBAR_TOOL_DROPDOWN, &BBLTopbar::OnCalibToolItem, this, ID_CALIB);
     this->Bind(wxEVT_AUITOOLBAR_TOOL_DROPDOWN, &BBLTopbar::OnIconize, this, wxID_ICONIZE_FRAME);
     this->Bind(wxEVT_AUITOOLBAR_TOOL_DROPDOWN, &BBLTopbar::OnFullScreen, this, wxID_MAXIMIZE_FRAME);
     this->Bind(wxEVT_AUITOOLBAR_TOOL_DROPDOWN, &BBLTopbar::OnCloseFrame, this, wxID_CLOSE_FRAME);
+    
+    if (debugFile) { fprintf(debugFile, "Binding mouse click events\n"); fflush(debugFile); }
+    // Binds mouse click events
     this->Bind(wxEVT_LEFT_DCLICK, &BBLTopbar::OnMouseLeftDClock, this);
     this->Bind(wxEVT_LEFT_DOWN, &BBLTopbar::OnMouseLeftDown, this);
     this->Bind(wxEVT_LEFT_UP, &BBLTopbar::OnMouseLeftUp, this);
+    
+    if (debugFile) { fprintf(debugFile, "Binding remaining toolbar events\n"); fflush(debugFile); }
+    // Binds remaining toolbar events  
     this->Bind(wxEVT_AUITOOLBAR_TOOL_DROPDOWN, &BBLTopbar::OnOpenProject, this, wxID_OPEN);
     this->Bind(wxEVT_AUITOOLBAR_TOOL_DROPDOWN, &BBLTopbar::OnSaveProject, this, wxID_SAVE);
     this->Bind(wxEVT_AUITOOLBAR_TOOL_DROPDOWN, &BBLTopbar::OnRedo, this, wxID_REDO);
     this->Bind(wxEVT_AUITOOLBAR_TOOL_DROPDOWN, &BBLTopbar::OnUndo, this, wxID_UNDO);
-    //this->Bind(wxEVT_AUITOOLBAR_TOOL_DROPDOWN, &BBLTopbar::OnModelStoreClicked, this, ID_MODEL_STORE);
     this->Bind(wxEVT_AUITOOLBAR_TOOL_DROPDOWN, &BBLTopbar::OnPublishClicked, this, ID_PUBLISH);
+
+    if (debugFile) { fprintf(debugFile, "Event binding completed, initializing accessibility\n"); fflush(debugFile); }
+
+#ifdef _WIN32
+    // Initializes Windows accessibility support for screen readers
+    if (debugFile) { fprintf(debugFile, "Setting accessibility variables\n"); fflush(debugFile); }
+    m_screenReaderDetected = false;
+    m_focusedToolIndex = 1;
+    /*
+    if (debugFile) { fprintf(debugFile, "BBLTopbar screen reader detection initialized\n"); fflush(debugFile); }
+    
+    // Setup Windows accessibility interface
+    if (debugFile) { fprintf(debugFile, "About to call SetupAccessibility()\n"); fflush(debugFile); }
+    SetupAccessibility();
+    if (debugFile) { fprintf(debugFile, "SetupAccessibility() completed\n"); fflush(debugFile); }
+    
+    // Binds keyboard event for accessibility Tab navigatoin
+    this->Bind(wxEVT_CHAR_HOOK, &BBLTopbar::OnCharHook, this);
+    if (debugFile) { fprintf(debugFile, "wxEVT_CHAR_HOOK event bound successfully\n"); fflush(debugFile); }
+    */
+#endif
+    if (debugFile) { fprintf(debugFile, "BBLTopbar::Init() COMPLETED\n"); fflush(debugFile); }
+    if (debugFile) { fclose(debugFile); }
 }
 
 BBLTopbar::~BBLTopbar()
 {
+#ifdef _WIN32
+    // Clean up Windows accessibility resources
+    if (m_pAccessible) {
+        delete m_pAccessible;
+        m_pAccessible = nullptr;
+    }
+    
+    // Restores original window procedure and cleans up accessibility properties
+    if (m_originalWndProc && GetHWND()) {
+        SetWindowLongPtr((HWND)GetHWND(), GWLP_WNDPROC, (LONG_PTR)m_originalWndProc);
+        RemoveProp((HWND)GetHWND(), L"AccessibleObjectFromWindow");
+    }
+#endif
+    
     m_file_menu_item = nullptr;
     m_dropdown_menu_item = nullptr;
     m_file_menu = nullptr;
@@ -696,3 +1002,199 @@ wxAuiToolBarItem* BBLTopbar::FindToolByCurrentPosition()
     wxPoint client_pos = this->ScreenToClient(mouse_pos);
     return this->FindToolByPosition(client_pos.x, client_pos.y);
 }
+
+#ifdef _WIN32
+// Windows message handler override for accessibility support
+WXLRESULT BBLTopbar::MSWWindowProc(WXUINT nMsg, WXWPARAM wParam, WXLPARAM lParam)
+{
+    // Detects screen reader activity through WM_GETOBJECT messages
+    if (nMsg == WM_GETOBJECT) {
+        if (!m_screenReaderDetected) {
+            m_screenReaderDetected = true;
+            printf("BBLTopbar - Screen reader detected via WM_GETOBJECT\n");
+            fflush(stdout);
+        }
+    }
+    
+    return wxAuiToolBar::MSWWindowProc(nMsg, wParam, lParam);
+}
+
+// Handles keyboard input for accessibility navigation
+void BBLTopbar::OnCharHook(wxKeyEvent& event)
+{
+    printf("BBLTopbar::OnCharHook called with key code: %d\n", event.GetKeyCode());
+    printf("BBLTopbar m_screenReaderDetected = %s\n", m_screenReaderDetected ? "true" : "false");
+    fflush(stdout);
+    
+    // Only process accessibility navigation when hte screen reader is active
+    if (!m_screenReaderDetected) {
+        printf("BBLTopbar OnCharHook - Screen reader not detected, skipping\n");
+        fflush(stdout);
+        event.Skip();
+        return;
+    }
+    
+    // Handles Tab key for toolbar navigation
+    if (event.GetKeyCode() == WXK_TAB) {
+        bool reverse = event.ShiftDown();
+        printf("BBLTopbar Tab key detected, reverse=%s\n", reverse ? "true" : "false");
+        fflush(stdout);
+        
+        if (HandleAccessibilityTabNavigation(reverse)) {
+            printf("BBLTopbar OnCharHook - Tab navigation handled successfully\n");
+            fflush(stdout);
+            return;  // Events handled, don't propagate
+        } else {
+            printf("BBLTopbar OnCharHook - Tab navigation failed\n");
+            fflush(stdout);
+        }
+    }
+    
+    // Passes through unhandled events
+    printf("BBLTopbar OnCharHook - Skipping event (key not handled or Tab navigation failed)\n");
+    fflush(stdout);
+    event.Skip();
+    printf("BBLTopbar OnCharHook COMPLETED\n");
+    fflush(stdout);
+}
+
+// Handles Tab navigation between toolbar elements for accessibility
+bool BBLTopbar::HandleAccessibilityTabNavigation(bool reverse)
+{
+    printf("BBLTopbar HandleAccessibilityTabNavigation called, current focus: %d, reverse: %s\n", 
+           m_focusedToolIndex, reverse ? "true" : "false");
+    fflush(stdout);
+    
+    // Calculates next focus index with wrapping
+    int nextIndex;
+    if (reverse) {
+        // Navigates to previous tool (Shift+Tab)
+        nextIndex = (m_focusedToolIndex <= 1) ? 9 : m_focusedToolIndex - 1;
+        printf("Shift+Tab navigation: %d -> %d\n", m_focusedToolIndex, nextIndex);
+    } else {
+        // Navigates to next tool (Tab)
+        nextIndex = (m_focusedToolIndex >= 9) ? 1 : m_focusedToolIndex + 1;
+        printf("Tab navigation: %d -> %d\n", m_focusedToolIndex, nextIndex);
+    }
+    
+    m_focusedToolIndex = nextIndex;
+    
+    // Tool names for debugging output
+    const char* toolNames[] = {
+        "", "File", "Menu", "Save", "Undo", "Redo", "Calibration", "Minimize", "Maximize", "Exit"
+    };
+    
+    printf("BBLTopbar focused on tool %d: %s\n", m_focusedToolIndex, 
+           m_focusedToolIndex >= 1 && m_focusedToolIndex <= 9 ? toolNames[m_focusedToolIndex] : "Unknown");
+    fflush(stdout);
+    
+    // Updatea accessibility object and notifies Windows accessibility system
+    if (m_pAccessible) {
+        m_pAccessible->SetCurrentFocusedChild(m_focusedToolIndex);
+        
+        if (GetHWND()) {
+            NotifyWinEvent(EVENT_OBJECT_FOCUS, (HWND)GetHWND(), OBJID_CLIENT, m_focusedToolIndex);
+        }
+    } else {
+        printf("ERROR - BBLTopbar m_pAccessible is NULL!\n");
+        fflush(stdout);
+    }
+    
+    printf("BBLTopbar HandleAccessibilityTabNavigation COMPLETED successfully\n");
+    fflush(stdout);
+    return true;
+}
+
+// Initializes Windows accessibility interface for screen reader support
+void BBLTopbar::SetupAccessibility()
+{
+    printf("BBLTopbar::SetupAccessibility() called\n");
+    fflush(stdout);
+    
+    // Initializes accessibility state
+    m_screenReaderDetected = false;
+    m_pAccessible = NULL;
+    m_originalWndProc = NULL;
+    
+    // Creates COM accessibility object
+    m_pAccessible = new BBLTopbarAccessible(this, this);
+    
+    printf("BBLTopbarAccessible object created at %p\n", m_pAccessible);
+    fflush(stdout);
+    
+    // Subclasses window to intercept accessibility messages
+    HWND hwnd = (HWND)GetHWND();
+    if (hwnd)
+    {
+        printf("BBLTopbar HWND: %p\n", hwnd);
+        fflush(stdout);
+        
+        // Installs custom window procedure for WM_GETOBJECT handling
+        m_originalWndProc = (WNDPROC)SetWindowLongPtr(hwnd, GWLP_WNDPROC, (LONG_PTR)BBLTopbarWndProc);
+        
+        printf("Window subclassed, original WndProc: %p\n", m_originalWndProc);
+        fflush(stdout);
+        
+        // Stores object pointer for window procedure access
+        SetWindowLongPtr(hwnd, GWLP_USERDATA, (LONG_PTR)this);
+        
+        // Marks window as accessibility-enabled
+        SetProp(hwnd, L"AccessibleObjectFromWindow", (HANDLE)1);
+        printf("Window property set for accessibility\n");
+        fflush(stdout);
+    } else {
+        printf("ERROR - Could not get HWND for BBLTopbar\n");
+        fflush(stdout);
+    }
+    
+    printf("BBLTopbar::SetupAccessibility() COMPLETED\n");
+    fflush(stdout);
+}
+
+// Custom window procedure for handling accessibility messages
+LRESULT CALLBACK BBLTopbar::BBLTopbarWndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
+{
+    // Retrieves BBLTopbar object from window user data
+    BBLTopbar* pThis = (BBLTopbar*)GetWindowLongPtr(hwnd, GWLP_USERDATA);
+    
+    if (msg == WM_GETOBJECT)
+    {
+        printf("BBLTopbarWndProc received WM_GETOBJECT\n");
+        fflush(stdout);
+        
+        // Sets screen reader detection flag on first accessibility request
+        if (pThis && !pThis->m_screenReaderDetected) {
+            pThis->m_screenReaderDetected = true;
+            printf("BBLTopbar - Screen reader detected via WM_GETOBJECT in WndProc\n");
+            fflush(stdout);
+        }
+        
+        // Returns accessibility object for client area requests
+        if (lParam == OBJID_CLIENT && pThis && pThis->m_pAccessible)
+        {
+            printf("OBJID_CLIENT requested, returning IAccessible object\n");
+            fflush(stdout);
+            
+            LRESULT result = LresultFromObject(IID_IAccessible, wParam, pThis->m_pAccessible);
+            printf("LresultFromObject returned: %lld\n", (long long)result);
+            fflush(stdout);
+            
+            return result;
+        }
+        else
+        {
+            printf("Non-OBJID_CLIENT request, returning 0\n");
+            fflush(stdout);
+            return 0;
+        }
+    }
+    
+    // Forwards all other messages to original window procedure
+    if (pThis && pThis->m_originalWndProc)
+    {
+        return CallWindowProc(pThis->m_originalWndProc, hwnd, msg, wParam, lParam);
+    }
+    
+    return DefWindowProc(hwnd, msg, wParam, lParam);
+}
+#endif

--- a/src/slic3r/GUI/BBLTopbar.hpp
+++ b/src/slic3r/GUI/BBLTopbar.hpp
@@ -31,6 +31,12 @@ public:
     void OnMouseCaptureLost(wxMouseCaptureLostEvent& event);
     void OnMenuClose(wxMenuEvent& event);
     void OnOpenProject(wxAuiToolBarEvent& event);
+
+#ifdef _WIN32
+    // Accessibility keyboard navigation
+    void OnCharHook(wxKeyEvent& event);
+    bool HandleAccessibilityTabNavigation(bool reverse);
+#endif
     void show_publish_button(bool show);
     void OnSaveProject(wxAuiToolBarEvent& event);
     void OnUndo(wxAuiToolBarEvent& event);
@@ -55,6 +61,14 @@ public:
     void SaveNormalRect();
 
     void ShowCalibrationButton(bool show = true);
+
+#ifdef _WIN32
+    // Windows message handling for screen reader detection
+    virtual WXLRESULT MSWWindowProc(WXUINT nMsg, WXWPARAM wParam, WXLPARAM lParam) override;
+    // Accessibility setup and management
+    void SetupAccessibility();
+    static LRESULT CALLBACK BBLTopbarWndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);
+#endif
 
 private:
     wxFrame* m_frame;
@@ -85,4 +99,16 @@ private:
     bool m_skip_popup_file_menu;
     bool m_skip_popup_dropdown_menu;
     bool m_skip_popup_calib_menu;
+
+#ifdef _WIN32
+    // Screen reader detection
+    bool m_screenReaderDetected;
+    
+    // Accessibility focus management
+    int m_focusedToolIndex;
+
+    // Accessibility object and window subclassing
+    class BBLTopbarAccessible* m_pAccessible;
+    WNDPROC m_originalWndProc;
+#endif
 };

--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -76,6 +76,42 @@
 
 #include <imguizmo/ImGuizmo.h>
 
+#ifdef _WIN32
+// Windows accessibility support
+// Ensures COM support is available despite TBB interference
+#undef WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#include <oleacc.h>
+#include <comdef.h>
+#include <winerror.h>
+#include <objbase.h>
+
+#ifndef STATE_SYSTEM_NORMAL
+#define STATE_SYSTEM_NORMAL 0x00000000
+#endif
+
+#ifndef CHILDID_SELF
+#define CHILDID_SELF 0
+#endif
+
+#ifndef S_OK
+#define S_OK ((HRESULT)0L)
+#endif
+
+#ifndef E_FAIL
+#define E_FAIL ((HRESULT)0x80004005L)
+#endif
+
+#ifndef E_NOTIMPL
+#define E_NOTIMPL ((HRESULT)0x80004001L)
+#endif
+
+#ifndef E_NOINTERFACE
+#define E_NOINTERFACE ((HRESULT)0x80004002L)
+#endif
+
+#endif // _WIN32
+
 static constexpr const float TRACKBALLSIZE = 0.8f;
 
 static Slic3r::ColorRGBA DEFAULT_BG_LIGHT_COLOR      = { 0.906f, 0.906f, 0.906f, 1.0f };
@@ -100,6 +136,591 @@ static constexpr const size_t MAX_VERTEX_BUFFER_SIZE     = 131072 * 6; // 3.15MB
 
 namespace Slic3r {
 namespace GUI {
+
+#ifdef _WIN32
+// Tool accessibility info structure
+struct GLCanvas3DToolInfo {
+    std::wstring name;
+    std::wstring description;
+    std::wstring shortcut;
+    long childId;
+    bool enabled;
+    
+    GLCanvas3DToolInfo(const std::wstring& n, const std::wstring& d, const std::wstring& s, long id, bool e = true)
+        : name(n), description(d), shortcut(s), childId(id), enabled(e) {}
+};
+
+// IAccessible COM interface implementation for 3D canvas tools
+class GLCanvas3DAccessible : public IAccessible
+{
+private:
+    ULONG m_refCount;
+    wxGLCanvas* m_pGLCanvas;
+    GLCanvas3D* m_pCanvas3D;  // Reference to parent GLCanvas3D for toolbar methods
+    std::vector<GLCanvas3DToolInfo> m_tools;
+    long m_currentFocusedChild;
+
+public:
+    GLCanvas3DAccessible(wxGLCanvas* pGLCanvas, GLCanvas3D* pCanvas3D)
+        : m_refCount(1), m_pGLCanvas(pGLCanvas), m_pCanvas3D(pCanvas3D), m_currentFocusedChild(CHILDID_SELF)
+    {
+        // Initializes all tools in the 3D canvas with proper accessible names and shortcuts
+        InitializeToolList();
+        printf("GLCanvas3DAccessible object created with %zu tools\n", m_tools.size());
+        fflush(stdout);
+    }
+
+    virtual ~GLCanvas3DAccessible()
+    {
+        printf("GLCanvas3DAccessible object destroyed\n");
+        fflush(stdout);
+    }
+
+private:
+    void InitializeToolList()
+    {
+        // Main toolbar functions
+        m_tools.push_back(GLCanvas3DToolInfo(L"Add", L"Add models to the 3D scene", L"Ctrl+I", 1));
+        m_tools.push_back(GLCanvas3DToolInfo(L"Add Plate", L"Add a new build plate", L"", 2));
+        m_tools.push_back(GLCanvas3DToolInfo(L"Auto Orient", L"Auto orient all/selected objects", L"Q", 3));
+        m_tools.push_back(GLCanvas3DToolInfo(L"Arrange", L"Arrange all objects on the plate", L"A", 4));
+        m_tools.push_back(GLCanvas3DToolInfo(L"Split to Objects", L"Split selected object into separate objects", L"", 5));
+        m_tools.push_back(GLCanvas3DToolInfo(L"Split to Parts", L"Split selected object into separate parts", L"", 6));
+        m_tools.push_back(GLCanvas3DToolInfo(L"Variable Layer Height", L"Edit layer heights for selected object", L"", 7));
+        
+        // Gizmo functions
+        m_tools.push_back(GLCanvas3DToolInfo(L"Move", L"Move selected objects in 3D space", L"", 8));
+        m_tools.push_back(GLCanvas3DToolInfo(L"Rotate", L"Rotate selected objects", L"", 9));
+        m_tools.push_back(GLCanvas3DToolInfo(L"Scale", L"Scale selected objects", L"", 10));
+        m_tools.push_back(GLCanvas3DToolInfo(L"Lay on Face", L"Place selected objects flat on build plate", L"", 11));
+        m_tools.push_back(GLCanvas3DToolInfo(L"Cut", L"Cut selected objects with a plane", L"", 12));
+        m_tools.push_back(GLCanvas3DToolInfo(L"Mesh Boolean", L"Perform boolean operations on meshes", L"", 13));
+        m_tools.push_back(GLCanvas3DToolInfo(L"Support Painting", L"Paint support areas on objects", L"", 14));
+        m_tools.push_back(GLCanvas3DToolInfo(L"Seam Painting", L"Paint seam locations on objects", L"", 15));
+        m_tools.push_back(GLCanvas3DToolInfo(L"Color Painting", L"Paint colors on object surfaces", L"", 16));
+        m_tools.push_back(GLCanvas3DToolInfo(L"Emboss", L"Emboss text or shapes on objects", L"", 17));
+        m_tools.push_back(GLCanvas3DToolInfo(L"Measure", L"Measure distances and angles", L"", 18));
+        m_tools.push_back(GLCanvas3DToolInfo(L"Assemble", L"Assemble multiple objects", L"", 19));
+        m_tools.push_back(GLCanvas3DToolInfo(L"Brim Ears", L"Add brim ears to objects", L"", 20));
+        m_tools.push_back(GLCanvas3DToolInfo(L"Assembly View", L"View object assembly and parts", L"", 21));
+        
+        printf("Initialized %zu tools for accessibility\n", m_tools.size());
+        fflush(stdout);
+    }
+    
+    const GLCanvas3DToolInfo* GetToolInfo(long childId) const
+    {
+        for (const auto& tool : m_tools) {
+            if (tool.childId == childId) {
+                return &tool;
+            }
+        }
+        return nullptr;
+    }
+
+public:
+    // IUnknown methods
+    STDMETHODIMP QueryInterface(REFIID riid, void** ppvObject)
+    {
+        if (riid == IID_IUnknown || riid == IID_IAccessible)
+        {
+            *ppvObject = this;
+            AddRef();
+            return S_OK;
+        }
+        *ppvObject = NULL;
+        return E_NOINTERFACE;
+    }
+
+    STDMETHODIMP_(ULONG) AddRef()
+    {
+        return InterlockedIncrement(&m_refCount);
+    }
+
+    STDMETHODIMP_(ULONG) Release()
+    {
+        ULONG count = InterlockedDecrement(&m_refCount);
+        if (count == 0)
+        {
+            delete this;
+        }
+        return count;
+    }
+
+    // IDispatch methods (required since IAccessible inherits from IDispatch)
+    STDMETHODIMP GetTypeInfoCount(UINT* pctinfo)
+    {
+        *pctinfo = 0;
+        return S_OK;
+    }
+
+    STDMETHODIMP GetTypeInfo(UINT iTInfo, LCID lcid, ITypeInfo** ppTInfo)
+    {
+        *ppTInfo = NULL;
+        return E_NOTIMPL;
+    }
+
+    STDMETHODIMP GetIDsOfNames(REFIID riid, LPOLESTR* rgszNames, UINT cNames, LCID lcid, DISPID* rgDispId)
+    {
+        return E_NOTIMPL;
+    }
+
+    STDMETHODIMP Invoke(DISPID dispIdMember, REFIID riid, LCID lcid, WORD wFlags, DISPPARAMS* pDispParams, VARIANT* pVarResult, EXCEPINFO* pExcepInfo, UINT* puArgErr)
+    {
+        return E_NOTIMPL;
+    }
+
+    // IAccessible methods
+    STDMETHODIMP get_accChildCount(long* pcountChildren)
+    {
+        *pcountChildren = static_cast<long>(m_tools.size());
+        printf("GLCanvas3DAccessible::get_accChildCount returning %ld children\n", *pcountChildren);
+        fflush(stdout);
+        return S_OK;
+    }
+    
+    STDMETHODIMP get_accChild(VARIANT varChild, IDispatch** ppdispChild)
+    {
+        *ppdispChild = NULL;
+        if (varChild.vt == VT_I4 && varChild.lVal >= 1 && varChild.lVal <= static_cast<long>(m_tools.size()))
+        {
+            // Return NULL for simple child elements (use child IDs instead of child objects)
+            return S_FALSE;
+        }
+        return E_INVALIDARG;
+    }
+
+    STDMETHODIMP get_accName(VARIANT varChild, BSTR* pszName)
+    {
+        if (varChild.vt == VT_I4)
+        {
+            if (varChild.lVal == CHILDID_SELF)
+            {
+                *pszName = SysAllocString(L"3D Canvas Tools");
+                printf("GLCanvas3DAccessible::get_accName returning container name='3D Canvas Tools'\n");
+                fflush(stdout);
+                return S_OK;
+            }
+            else
+            {
+                const GLCanvas3DToolInfo* tool = GetToolInfo(varChild.lVal);
+                if (tool)
+                {
+                    std::wstring fullName = tool->name;
+                    if (!tool->shortcut.empty()) {
+                        fullName += L" [" + tool->shortcut + L"]";
+                    }
+                    *pszName = SysAllocString(fullName.c_str());
+                    printf("GLCanvas3DAccessible::get_accName returning tool name='%ls'\n", fullName.c_str());
+                    fflush(stdout);
+                    return S_OK;
+                }
+            }
+        }
+        return E_INVALIDARG;
+    }
+
+    STDMETHODIMP get_accDescription(VARIANT varChild, BSTR* pszDescription)
+    {
+        if (varChild.vt == VT_I4)
+        {
+            if (varChild.lVal == CHILDID_SELF)
+            {
+                *pszDescription = SysAllocString(L"3D canvas containing tools for manipulating 3D objects. Use Tab to navigate between tools.");
+                printf("GLCanvas3DAccessible::get_accDescription returning container description\n");
+                fflush(stdout);
+                return S_OK;
+            }
+            else
+            {
+                const GLCanvas3DToolInfo* tool = GetToolInfo(varChild.lVal);
+                if (tool)
+                {
+                    *pszDescription = SysAllocString(tool->description.c_str());
+                    printf("GLCanvas3DAccessible::get_accDescription returning tool description='%ls'\n", tool->description.c_str());
+                    fflush(stdout);
+                    return S_OK;
+                }
+            }
+        }
+        return E_INVALIDARG;
+    }
+
+    STDMETHODIMP get_accRole(VARIANT varChild, VARIANT* pvarRole)
+    {
+        if (varChild.vt == VT_I4)
+        {
+            pvarRole->vt = VT_I4;
+            if (varChild.lVal == CHILDID_SELF)
+            {
+                pvarRole->lVal = ROLE_SYSTEM_GROUPING;
+                printf("GLCanvas3DAccessible::get_accRole returning container role=ROLE_SYSTEM_GROUPING\n");
+            }
+            else
+            {
+                pvarRole->lVal = ROLE_SYSTEM_PUSHBUTTON;
+                printf("GLCanvas3DAccessible::get_accRole returning tool role=ROLE_SYSTEM_PUSHBUTTON\n");
+            }
+            fflush(stdout);
+            return S_OK;
+        }
+        return E_INVALIDARG;
+    }
+    
+    STDMETHODIMP get_accState(VARIANT varChild, VARIANT* pvarState)
+    {
+        if (varChild.vt == VT_I4)
+        {
+            pvarState->vt = VT_I4;
+            if (varChild.lVal == CHILDID_SELF)
+            {
+                pvarState->lVal = STATE_SYSTEM_NORMAL;
+            }
+            else
+            {
+                const GLCanvas3DToolInfo* tool = GetToolInfo(varChild.lVal);
+                if (tool)
+                {
+                    pvarState->lVal = STATE_SYSTEM_NORMAL;
+                    if (!tool->enabled) {
+                        pvarState->lVal |= STATE_SYSTEM_UNAVAILABLE;
+                    }
+                    if (varChild.lVal == m_currentFocusedChild) {
+                        pvarState->lVal |= STATE_SYSTEM_FOCUSED;
+                    }
+                }
+                else
+                {
+                    return E_INVALIDARG;
+                }
+            }
+            return S_OK;
+        }
+        return E_INVALIDARG;
+    }
+    
+    STDMETHODIMP get_accFocus(VARIANT* pvarChild)
+    {
+        pvarChild->vt = VT_I4;
+        pvarChild->lVal = m_currentFocusedChild;
+        printf("GLCanvas3DAccessible::get_accFocus returning focused child %ld\n", m_currentFocusedChild);
+        fflush(stdout);
+        return S_OK;
+    }
+    
+    STDMETHODIMP accNavigate(long navDir, VARIANT varStart, VARIANT* pvarEndUpAt)
+    {
+        if (varStart.vt != VT_I4) {
+            return E_INVALIDARG;
+        }
+        
+        pvarEndUpAt->vt = VT_EMPTY;
+        
+        switch (navDir)
+        {
+            case NAVDIR_NEXT:
+            case NAVDIR_RIGHT:
+            {
+                if (varStart.lVal == CHILDID_SELF)
+                {
+                    // Navigates to first child
+                    if (!m_tools.empty())
+                    {
+                        pvarEndUpAt->vt = VT_I4;
+                        pvarEndUpAt->lVal = 1;
+                        m_currentFocusedChild = 1;
+                        printf("GLCanvas3DAccessible::accNavigate NEXT from container to child 1\n");
+                        fflush(stdout);
+                        return S_OK;
+                    }
+                }
+                else if (varStart.lVal < static_cast<long>(m_tools.size()))
+                {
+                    // Navigates to next child
+                    pvarEndUpAt->vt = VT_I4;
+                    pvarEndUpAt->lVal = varStart.lVal + 1;
+                    m_currentFocusedChild = pvarEndUpAt->lVal;
+                    printf("GLCanvas3DAccessible::accNavigate NEXT from child %ld to child %ld\n", varStart.lVal, pvarEndUpAt->lVal);
+                    fflush(stdout);
+                    return S_OK;
+                }
+                break;
+            }
+            
+            case NAVDIR_PREVIOUS:
+            case NAVDIR_LEFT:
+            {
+                if (varStart.lVal > 1)
+                {
+                    // Navigates to previous child
+                    pvarEndUpAt->vt = VT_I4;
+                    pvarEndUpAt->lVal = varStart.lVal - 1;
+                    m_currentFocusedChild = pvarEndUpAt->lVal;
+                    printf("GLCanvas3DAccessible::accNavigate PREVIOUS from child %ld to child %ld\n", varStart.lVal, pvarEndUpAt->lVal);
+                    fflush(stdout);
+                    return S_OK;
+                }
+                else if (varStart.lVal == 1)
+                {
+                    // Navigates back to container
+                    pvarEndUpAt->vt = VT_I4;
+                    pvarEndUpAt->lVal = CHILDID_SELF;
+                    m_currentFocusedChild = CHILDID_SELF;
+                    printf("GLCanvas3DAccessible::accNavigate PREVIOUS from child 1 to container\n");
+                    fflush(stdout);
+                    return S_OK;
+                }
+                break;
+            }
+            
+            case NAVDIR_FIRSTCHILD:
+            {
+                if (varStart.lVal == CHILDID_SELF && !m_tools.empty())
+                {
+                    pvarEndUpAt->vt = VT_I4;
+                    pvarEndUpAt->lVal = 1;
+                    m_currentFocusedChild = 1;
+                    printf("GLCanvas3DAccessible::accNavigate FIRSTCHILD to child 1\n");
+                    fflush(stdout);
+                    return S_OK;
+                }
+                break;
+            }
+            
+            case NAVDIR_LASTCHILD:
+            {
+                if (varStart.lVal == CHILDID_SELF && !m_tools.empty())
+                {
+                    pvarEndUpAt->vt = VT_I4;
+                    pvarEndUpAt->lVal = static_cast<long>(m_tools.size());
+                    m_currentFocusedChild = pvarEndUpAt->lVal;
+                    printf("GLCanvas3DAccessible::accNavigate LASTCHILD to child %ld\n", pvarEndUpAt->lVal);
+                    fflush(stdout);
+                    return S_OK;
+                }
+                break;
+            }
+        }
+        
+        return S_FALSE; // No more elements in that direction
+    }
+    
+    STDMETHODIMP accSelect(long flagsSelect, VARIANT varChild)
+    {
+        if (varChild.vt == VT_I4 && varChild.lVal >= 1 && varChild.lVal <= static_cast<long>(m_tools.size()))
+        {
+            if (flagsSelect & SELFLAG_TAKEFOCUS)
+            {
+                m_currentFocusedChild = varChild.lVal;
+                printf("GLCanvas3DAccessible::accSelect focusing child %ld\n", varChild.lVal);
+                fflush(stdout);
+                return S_OK;
+            }
+        }
+        return S_OK;
+    }
+    
+    STDMETHODIMP get_accKeyboardShortcut(VARIANT varChild, BSTR* pszKeyboardShortcut)
+    {
+        if (varChild.vt == VT_I4 && varChild.lVal >= 1 && varChild.lVal <= static_cast<long>(m_tools.size()))
+        {
+            const GLCanvas3DToolInfo* tool = GetToolInfo(varChild.lVal);
+            if (tool && !tool->shortcut.empty())
+            {
+                *pszKeyboardShortcut = SysAllocString(tool->shortcut.c_str());
+                printf("GLCanvas3DAccessible::get_accKeyboardShortcut returning '%ls'\n", tool->shortcut.c_str());
+                fflush(stdout);
+                return S_OK;
+            }
+        }
+        return S_FALSE;
+    }
+    
+    // Other IAccessible methods not implemented
+    STDMETHODIMP get_accParent(IDispatch** ppdispParent) { return E_NOTIMPL; }
+    STDMETHODIMP get_accValue(VARIANT varChild, BSTR* pszValue) { return E_NOTIMPL; }
+    STDMETHODIMP put_accName(VARIANT varChild, BSTR szName) { return E_NOTIMPL; }
+    STDMETHODIMP put_accValue(VARIANT varChild, BSTR szValue) { return E_NOTIMPL; }
+    STDMETHODIMP get_accHelp(VARIANT varChild, BSTR* pszHelp) { return E_NOTIMPL; }
+    STDMETHODIMP get_accHelpTopic(BSTR* pszHelpFile, VARIANT varChild, long* pidTopic) { return E_NOTIMPL; }
+    STDMETHODIMP get_accSelection(VARIANT* pvarChildren) { return E_NOTIMPL; }
+    STDMETHODIMP get_accDefaultAction(VARIANT varChild, BSTR* pszDefaultAction) { return E_NOTIMPL; }
+    STDMETHODIMP accLocation(long* pxLeft, long* pyTop, long* pcxWidth, long* pcyHeight, VARIANT varChild) 
+    { 
+        if (varChild.vt == VT_I4)
+        {
+            if (varChild.lVal == CHILDID_SELF)
+            {
+                // Returns the location of the entire canvas
+                HWND hwnd = (HWND)m_pGLCanvas->GetHandle();
+                RECT rect;
+                if (GetWindowRect(hwnd, &rect))
+                {
+                    *pxLeft = rect.left;
+                    *pyTop = rect.top;
+                    *pcxWidth = rect.right - rect.left;
+                    *pcyHeight = rect.bottom - rect.top;
+                    printf("GLCanvas3DAccessible::accLocation container: left=%ld, top=%ld, width=%ld, height=%ld\n", 
+                           *pxLeft, *pyTop, *pcxWidth, *pcyHeight);
+                    fflush(stdout);
+                    return S_OK;
+                }
+            }
+            else if (varChild.lVal >= 1 && varChild.lVal <= static_cast<long>(m_tools.size()))
+            {
+                // Returns location for individual tool
+                HWND hwnd = (HWND)m_pGLCanvas->GetHandle();
+                RECT canvasRect;
+                if (GetWindowRect(hwnd, &canvasRect))
+                {
+                    int toolIndex = varChild.lVal - 1;
+                    
+                    // Get real toolbar dimensions from GLCanvas3D
+                    int toolbarStartX = m_pCanvas3D->get_main_toolbar_offset();        // X offset from canvas left
+                    int toolbarY = 0;                                                 // Y = 0, touching top edge
+                    float totalToolbarWidth = m_pCanvas3D->get_total_toolbar_width();  // Total width of all toolbar sections
+                    int toolbarHeight = m_pCanvas3D->get_main_toolbar_height();       // toolbar height
+                    
+                    // For comparison, I made the mistake of calling this to get the total toolbar width without knowing what it represents
+                    int oldMainToolbarWidth = m_pCanvas3D->get_main_toolbar_width();
+                    printf("TOOLBAR DIMENSIONS - Start X: %d, Y: %d, Total Width: %.0f, Height: %d\n", 
+                           toolbarStartX, toolbarY, totalToolbarWidth, toolbarHeight);
+                    printf("OLD vs NEW - Main toolbar width: %d, Total toolbar width: %.0f\n", 
+                           oldMainToolbarWidth, totalToolbarWidth);
+                    printf("Canvas screen position: left=%d, top=%d, right=%d, bottom=%d\n", 
+                           canvasRect.left, canvasRect.top, canvasRect.right, canvasRect.bottom);
+                    fflush(stdout);
+                    
+                    // Calculates context window dimensions based on real total toolbar
+                    int contextWidth = (int)(totalToolbarWidth / 21);
+                    int contextHeight = toolbarHeight;
+                    
+                    // Position context window: toolbar start + (tool index * context width)
+                    int contextX = toolbarStartX + (toolIndex * contextWidth);
+                    int contextY = toolbarY;
+                    
+                    int oldContextWidth = oldMainToolbarWidth / 21;  // What it would have been with old method
+                    printf("Tool %d calculation: OLD contextWidth=%d, NEW contextWidth=%d, contextHeight=%d, contextX=%d, contextY=%d\n", 
+                           toolIndex + 1, oldContextWidth, contextWidth, contextHeight, contextX, contextY);
+                    fflush(stdout);
+                    
+                    // Returns coordinates relative to screen (Narrator expects screen coordinates)
+                    *pxLeft = canvasRect.left + contextX;
+                    *pyTop = canvasRect.top + contextY;
+                    *pcxWidth = contextWidth;
+                    *pcyHeight = contextHeight;
+                    
+                    printf("FINAL SCREEN COORDINATES for tool %d: left=%d, top=%d, width=%d, height=%d\n", 
+                           toolIndex + 1, *pxLeft, *pyTop, *pcxWidth, *pcyHeight);
+                    fflush(stdout);
+                    
+                    const GLCanvas3DToolInfo* toolInfo = GetToolInfo(varChild.lVal);
+                    printf("accLocation tool %d (%ls): left=%d, top=%d, width=%d, height=%d\n", 
+                           (int)varChild.lVal, 
+                           toolInfo ? toolInfo->name.c_str() : L"Unknown",
+                           *pxLeft, *pyTop, *pcxWidth, *pcyHeight);
+                    fflush(stdout);
+                    return S_OK;
+                }
+            }
+        }
+        return E_FAIL;
+    }
+
+    STDMETHODIMP accHitTest(long xLeft, long yTop, VARIANT* pvarChild) { return E_NOTIMPL; }
+
+    STDMETHODIMP accDoDefaultAction(VARIANT varChild) {
+        printf("GLCanvas3DAccessible::accDoDefaultAction called with childId=%ld\n", varChild.lVal);
+        fflush(stdout);
+        
+        if (varChild.vt == VT_I4 && varChild.lVal >= 1 && varChild.lVal <= static_cast<long>(m_tools.size()))
+        {
+            int toolIndex = varChild.lVal - 1;
+            
+            std::wstring wideToolName = m_tools[toolIndex].name;
+            std::string narrowToolName(wideToolName.begin(), wideToolName.end());
+            printf("Attempting to activate tool %d (%s)\n", toolIndex + 1, narrowToolName.c_str());
+            fflush(stdout);
+            
+            // Gets hte tool's spatial coordinates that we already calculated for accessibility
+            std::string toolName = narrowToolName;
+            long buttonLeft, buttonTop, buttonWidth, buttonHeight;
+            VARIANT varChildForLocation;
+            varChildForLocation.vt = VT_I4;
+            varChildForLocation.lVal = varChild.lVal;
+            
+            HRESULT locationResult = accLocation(&buttonLeft, &buttonTop, &buttonWidth, &buttonHeight, varChildForLocation);
+            
+            if (locationResult == S_OK) {
+                // center point of the button
+                long clickX = buttonLeft + (buttonWidth / 2);
+                long clickY = buttonTop + (buttonHeight / 2);
+                
+                printf("Activating %s via button click simulation at (%ld, %ld)\n", toolName.c_str(), clickX, clickY);
+                fflush(stdout);
+                
+                // Finds the window at these coordinates to send the click message to
+                POINT clickPoint = { clickX, clickY };
+                HWND targetWindow = WindowFromPoint(clickPoint);
+                
+                if (targetWindow) {
+                    // Gets window class name to understand what type of UI element is being targeted
+                    char windowClass[256];
+                    GetClassNameA(targetWindow, windowClass, sizeof(windowClass));
+                    
+                    // Gets window text/title 
+                    char windowText[256];
+                    GetWindowTextA(targetWindow, windowText, sizeof(windowText));
+                    
+                    printf("Found target window %p (class: %s, text: '%s') for tool %s\n", 
+                           targetWindow, windowClass, windowText, toolName.c_str());
+                    fflush(stdout);
+                    
+                    // Uses direct screen coordinates with mouse_event instead of SendMessage
+                    SetCursorPos(clickX, clickY);
+                    Sleep(10); // ensures cursor position is set
+                    
+                    // Simulates mouse click at current cursor position
+                    mouse_event(MOUSEEVENTF_LEFTDOWN, 0, 0, 0, 0);
+                    Sleep(10);
+                    mouse_event(MOUSEEVENTF_LEFTUP, 0, 0, 0, 0);
+                    
+                    printf("Simulated mouse click at screen coordinates (%ld, %ld)\n", 
+                           clickX, clickY);
+                    fflush(stdout);
+                    
+                    return S_OK;
+                } else {
+                    printf("Could not find target window at coordinates (%ld, %ld) for tool %s\n", 
+                           clickX, clickY, toolName.c_str());
+                    fflush(stdout);
+                    return S_OK;
+                }
+            } else {
+                printf("Could not get location for tool %s, activation failed\n", toolName.c_str());
+                fflush(stdout);
+                return S_OK;
+            }
+        }
+        
+        return E_FAIL;
+    }
+    
+    // Additional methods for focus management
+public:
+    int GetCurrentFocusedChild() const
+    {
+        return static_cast<int>(m_currentFocusedChild);
+    }
+    
+    void SetCurrentFocusedChild(int childId)
+    {
+        m_currentFocusedChild = static_cast<long>(childId);
+        printf("GLCanvas3DAccessible::SetCurrentFocusedChild set to %d\n", childId);
+        fflush(stdout);
+    }
+};
+#endif
 
 #ifdef __WXGTK3__
 // wxGTK3 seems to simulate OSX behavior in regard to HiDPI scaling support.
@@ -1174,6 +1795,12 @@ GLCanvas3D::GLCanvas3D(wxGLCanvas* canvas, Bed3D &bed)
     m_assembly_view_desc["part_selection"]         = _L("part selectiont");
     m_assembly_view_desc["number_key_caption"]       = "1~16 " + _L("number keys");
     m_assembly_view_desc["number_key"]       = _L("number keys can quickly change the color of objects");
+    
+#ifdef _WIN32
+    // Initializes accessibility
+    m_pAccessible = NULL;
+    SetupAccessibility();
+#endif
 }
 
 GLCanvas3D::~GLCanvas3D()
@@ -1182,7 +1809,246 @@ GLCanvas3D::~GLCanvas3D()
 
     m_sel_plate_toolbar.del_all_item();
     m_sel_plate_toolbar.del_stats_item();
+    
+#ifdef _WIN32
+    // Restores the original window procedure
+    if (m_canvas && m_originalWndProc)
+    {
+        HWND hwnd = (HWND)m_canvas->GetHandle();
+        SetWindowLongPtr(hwnd, GWLP_WNDPROC, (LONG_PTR)m_originalWndProc);
+    }
+    
+    // Cleans up accessibility object
+    if (m_pAccessible)
+    {
+        m_pAccessible->Release();
+        m_pAccessible = NULL;
+    }
+#endif
 }
+
+#ifdef _WIN32
+// Static window procedure for subclassing the wxGLCanvas
+long long GLCanvas3D::GLCanvas3DWndProc(void* hwnd, unsigned int msg, unsigned long long wParam, long long lParam)
+{
+    // Gets the GLCanvas3D instance from the window's user data
+    GLCanvas3D* pThis = (GLCanvas3D*)GetWindowLongPtr((HWND)hwnd, GWLP_USERDATA);
+    
+    if (pThis && msg == WM_GETOBJECT)
+    {
+        printf("GLCanvas3DWndProc received WM_GETOBJECT\n");
+        fflush(stdout);
+        
+        LRESULT result = (LRESULT)pThis->HandleGetObject(wParam, lParam);
+        if (result != 0)
+        {
+            return result;
+        }
+    }
+    
+    // Handles Enter key press on focused element
+    if (pThis && msg == WM_KEYDOWN && wParam == VK_RETURN)
+    {
+        printf("GLCanvas3DWndProc received Enter key\n");
+        fflush(stdout);
+        
+        // Gets the focused child and trigger its default action
+        if (pThis->m_pAccessible)
+        {
+            int focusedChild = pThis->m_pAccessible->GetCurrentFocusedChild();
+            printf("Current focused child: %d\n", focusedChild);
+            fflush(stdout);
+            
+            // Adds bounds checking and more detailed debugging
+            printf("Checking bounds: focusedChild=%d, (>0)=%s, (<=21)=%s\n", 
+                   focusedChild, 
+                   (focusedChild > 0) ? "true" : "false",
+                   (focusedChild <= 21) ? "true" : "false");
+            fflush(stdout);
+            
+            if (focusedChild > 0 && focusedChild <= 21)
+            {
+                printf("Triggering accDoDefaultAction for child %d (valid range)\n", focusedChild);
+                fflush(stdout);
+                
+                VARIANT varChild;
+                varChild.vt = VT_I4;
+                varChild.lVal = focusedChild;
+                
+                printf("About to call accDoDefaultAction with childId=%ld\n", varChild.lVal);
+                fflush(stdout);
+                
+                HRESULT result = pThis->m_pAccessible->accDoDefaultAction(varChild);
+                printf("accDoDefaultAction returned HRESULT=0x%lx\n", result);
+                fflush(stdout);
+                
+                return 0;
+            }
+            else
+            {
+                printf("Invalid focused child %d - not triggering accDoDefaultAction\n", focusedChild);
+                fflush(stdout);
+            }
+        }
+        else
+        {
+            printf("No accessibility object available for Enter key handling\n");
+            fflush(stdout);
+        }
+    }
+    
+    // Calls the original window procedure for all other messages
+    if (pThis && pThis->m_originalWndProc)
+    {
+        return CallWindowProc((WNDPROC)pThis->m_originalWndProc, (HWND)hwnd, msg, wParam, lParam);
+    }
+    
+    return DefWindowProc((HWND)hwnd, msg, wParam, lParam);
+}
+
+void GLCanvas3D::SetupAccessibility()
+{
+    // Allocates a console for debug output
+    AllocConsole();
+    freopen_s((FILE**)stdout, "CONOUT$", "w", stdout);
+    
+    printf("GLCanvas3D::SetupAccessibility() called\n");
+    fflush(stdout);
+    
+    // Initializes accessibility variables
+    m_screenReaderDetected = false;
+    
+    // Creates the accessibility object
+    m_pAccessible = new GLCanvas3DAccessible(m_canvas, this);
+    
+    printf("GLCanvas3DAccessible object created at %p\n", m_pAccessible);
+    fflush(stdout);
+    
+    // Subclasses the wxGLCanvas window to intercept WM_GETOBJECT messages
+    if (m_canvas)
+    {
+        HWND hwnd = (HWND)m_canvas->GetHandle();
+        printf("GLCanvas HWND: %p\n", hwnd);
+        fflush(stdout);
+        
+        // Stores the original window procedure
+        m_originalWndProc = (WNDPROC)SetWindowLongPtr(hwnd, GWLP_WNDPROC, (LONG_PTR)(WNDPROC)GLCanvas3DWndProc);
+        
+        // Stores the GLCanvas3D instance in the window's user data
+        SetWindowLongPtr(hwnd, GWLP_USERDATA, (LONG_PTR)this);
+        
+        printf("Window subclassed, original WndProc: %p\n", m_originalWndProc);
+        fflush(stdout);
+    }
+}
+
+// Handles WM_GETOBJECT message for accessibility  
+long long GLCanvas3D::HandleGetObject(unsigned long long wParam, long long lParam)
+{
+    printf("GLCanvas3D::HandleGetObject called with wParam=%llu, lParam=%lld\n", wParam, lParam);
+    fflush(stdout);
+    
+    // Tracks screen reader activity, any WM_GETOBJECT indicates screen reader is active
+    if (!m_screenReaderDetected) {
+        m_screenReaderDetected = true;
+        printf("Screen reader detected via WM_GETOBJECT activity\n");
+        fflush(stdout);
+    }
+    
+    DWORD dwObjId = (DWORD)lParam;
+    
+    if (dwObjId == OBJID_CLIENT)
+    {
+        printf("OBJID_CLIENT requested, returning IAccessible object\n");
+        fflush(stdout);
+        
+        if (m_pAccessible == NULL)
+        {
+            printf("m_pAccessible is NULL, creating new object\n");
+            fflush(stdout);
+            SetupAccessibility();
+        }
+        
+        if (m_pAccessible)
+        {
+            printf("GLCanvas3DAccessible object created\n");
+            fflush(stdout);
+            
+            LRESULT result = LresultFromObject(IID_IAccessible, (WPARAM)wParam, static_cast<IAccessible*>(m_pAccessible));
+            printf("LresultFromObject returned: %lld\n", (long long)result);
+            fflush(stdout);
+            return (long long)result;
+        }
+    }
+    else
+    {
+        printf("Non-OBJID_CLIENT request, returning 0\n");
+        fflush(stdout);
+        return 0;
+    }
+    
+    return 0;
+}
+#endif // _WIN32
+
+#ifdef _WIN32
+bool GLCanvas3D::HandleAccessibilityTabNavigation(bool reverse)
+{
+    printf("GLCanvas3D::HandleAccessibilityTabNavigation called, reverse=%s\n", reverse ? "true" : "false");
+    fflush(stdout);
+    
+    // Checks if screen reader is inactive
+    if (!m_screenReaderDetected) {
+        printf("No screen reader active, using default OrcaSlicer Tab behavior\n");
+        fflush(stdout);
+        return false;
+    }
+    
+    printf("Screen reader detected, handling accessibility Tab navigation\n");
+    fflush(stdout);
+    
+    // If accessibility object exists, handle navigation between tools
+    if (m_pAccessible) {
+        GLCanvas3DAccessible* accessible = static_cast<GLCanvas3DAccessible*>(m_pAccessible);
+        
+        // Gets current focused child
+        int currentChild = accessible->GetCurrentFocusedChild();
+        printf("Current focused child: %d\n", currentChild);
+        fflush(stdout);
+        
+        // Calculates next child based on navigation direction
+        int nextChild;
+        if (reverse) {
+            // Shift+Tab: go to previous tool
+            nextChild = (currentChild <= 1) ? 21 : currentChild - 1;
+            printf("Shift+Tab navigation: currentChild %d -> nextChild %d\n", currentChild, nextChild);
+        } else {
+            // Tab: go to next tool
+            nextChild = (currentChild >= 21) ? 1 : currentChild + 1;
+            printf("Tab navigation: currentChild %d -> nextChild %d\n", currentChild, nextChild);
+        }
+        
+        printf("Navigating to child: %d\n", nextChild);
+        fflush(stdout);
+        
+        // Updates focus to the next child
+        accessible->SetCurrentFocusedChild(nextChild);
+        
+        // Notifeis system of focus change
+        HWND hwnd = (HWND)m_canvas->GetHandle();
+        NotifyWinEvent(EVENT_OBJECT_FOCUS, hwnd, OBJID_CLIENT, nextChild);
+        
+        printf("Focus change notification sent for child %d\n", nextChild);
+        fflush(stdout);
+        
+        return true;
+    }
+    
+    printf("No accessibility object available\n");
+    fflush(stdout);
+    return false;
+}
+#endif
 
 void GLCanvas3D::post_event(wxEvent &&event)
 {
@@ -3522,13 +4388,34 @@ void GLCanvas3D::on_key(wxKeyEvent& evt)
                     m_dirty = true;
                 }
                 else if (m_tab_down && keyCode == WXK_TAB && !evt.HasAnyModifiers()) {
-                    // Enable switching between 3D and Preview with Tab
-                    // m_canvas->HandleAsNavigationKey(evt);   // XXX: Doesn't work in some cases / on Linux
+#ifdef _WIN32
+                    // Handle Tab navigation between tools on Windows
+                    if (m_pAccessible && HandleAccessibilityTabNavigation(false)) {
+                        printf("Tab navigation handled by accessibility\n");
+                        fflush(stdout);
+                    } else {
+                        // Fallback enables switching between 3D and Preview with Tab
+                        post_event(SimpleEvent(EVT_GLCANVAS_TAB));
+                    }
+#else
+                    // Enables switching between 3D and Preview with Tab for non-windows
                     post_event(SimpleEvent(EVT_GLCANVAS_TAB));
+#endif
                 }
                 else if (keyCode == WXK_TAB && evt.ShiftDown() && !evt.ControlDown() && ! wxGetApp().is_gcode_viewer()) {
-                    // Collapse side-panel with Shift+Tab
+#ifdef _WIN32
+                    // Handle Shift+Tab reverse navigation between tools on Windows
+                    if (m_pAccessible && HandleAccessibilityTabNavigation(true)) {
+                        printf("Shift+Tab navigation handled by accessibility\n");
+                        fflush(stdout);
+                    } else {
+                        // Fallback collapses side-panel with Shift+Tab
+                        post_event(SimpleEvent(EVT_GLCANVAS_COLLAPSE_SIDEBAR));
+                    }
+#else
+                    // Collapses side-panel with Shift+Tab non-windows
                     post_event(SimpleEvent(EVT_GLCANVAS_COLLAPSE_SIDEBAR));
+#endif
                 }
                 else if (keyCode == WXK_SHIFT) {
                     translationProcessor.process(evt);
@@ -7786,16 +8673,18 @@ void GLCanvas3D::_render_current_gizmo() const
 //move the size calc to GLCanvas
 void GLCanvas3D::_render_gizmos_overlay()
 {
-/*#if ENABLE_RETINA_GL
-//     m_gizmos.set_overlay_scale(m_retina_helper->get_scale_factor());
+/*
+#if ENABLE_RETINA_GL
+     m_gizmos.set_overlay_scale(m_retina_helper->get_scale_factor());
     const float scale = m_retina_helper->get_scale_factor()*wxGetApp().toolbar_icon_scale();
     m_gizmos.set_overlay_scale(scale); //! #ys_FIXME_experiment
 #else
-//     m_gizmos.set_overlay_scale(m_canvas->GetContentScaleFactor());
-//     m_gizmos.set_overlay_scale(wxGetApp().em_unit()*0.1f);
+     m_gizmos.set_overlay_scale(m_canvas->GetContentScaleFactor());
+     m_gizmos.set_overlay_scale(wxGetApp().em_unit()*0.1f);
     const float size = int(GLGizmosManager::Default_Icons_Size * wxGetApp().toolbar_icon_scale());
     m_gizmos.set_overlay_icon_size(size); //! #ys_FIXME_experiment
-#endif */ /* __WXMSW__ */
+#endif
+*/
     m_gizmos.render_overlay();
 
     if (m_gizmo_highlighter.m_render_arrow)
@@ -7819,6 +8708,15 @@ int GLCanvas3D::get_main_toolbar_offset() const
         const float offset = (cnv_width - toolbar_total_width) / 2;
         return is_collapse_toolbar_on_left() ? offset + collapse_toolbar_width : offset;
     }
+}
+
+float GLCanvas3D::get_total_toolbar_width() const
+{
+    // Calculates total width of all toolbar sections for accessibility
+    const float gizmo_width = m_gizmos.get_scaled_total_width();
+    const float assemble_width = m_assemble_view_toolbar.get_width();
+    const float separator_width = m_separator_toolbar.get_width();
+    return m_main_toolbar.get_width() + separator_width + gizmo_width + assemble_width;
 }
 
 //BBS: GUI refactor: GLToolbar adjust

--- a/src/slic3r/GUI/GLCanvas3D.hpp
+++ b/src/slic3r/GUI/GLCanvas3D.hpp
@@ -195,6 +195,11 @@ wxDECLARE_EVENT(EVT_GLCANVAS_RESET_LAYER_HEIGHT_PROFILE, SimpleEvent);
 wxDECLARE_EVENT(EVT_GLCANVAS_ADAPTIVE_LAYER_HEIGHT_PROFILE, Event<float>);
 wxDECLARE_EVENT(EVT_GLCANVAS_SMOOTH_LAYER_HEIGHT_PROFILE, HeightProfileSmoothEvent);
 
+#ifdef _WIN32
+// Forward declaration for Windows accessibility support
+class GLCanvas3DAccessible;
+#endif
+
 class GLCanvas3D
 {
     static const double DefaultCameraZoomToBoxMarginFactor;
@@ -709,6 +714,22 @@ public:
     CameraTarget m_camera_target;
 #endif // ENABLE_SHOW_CAMERA_TARGET
     GLModel m_background;
+    
+#ifdef _WIN32
+    // Windows accessibility member variables
+    GLCanvas3DAccessible* m_pAccessible;
+    void* m_originalWndProc;
+    bool m_screenReaderDetected;  // Tracks if screen reader is actively querying accessibility
+    
+    // Static window procedure for subclassing
+    static long long GLCanvas3DWndProc(void* hwnd, unsigned int msg, unsigned long long wParam, long long lParam);
+    
+    // Accessibility methods
+    void SetupAccessibility();
+    long long HandleGetObject(unsigned long long wParam, long long lParam);
+    bool HandleAccessibilityTabNavigation(bool reverse);
+#endif
+
 public:
     explicit GLCanvas3D(wxGLCanvas* canvas, Bed3D &bed);
     ~GLCanvas3D();
@@ -857,6 +878,7 @@ public:
     int get_main_toolbar_offset() const;
     int get_main_toolbar_height() const { return m_main_toolbar.get_height(); }
     int get_main_toolbar_width() const { return m_main_toolbar.get_width(); }
+    float get_total_toolbar_width() const;  // Returns combined width of all toolbar sections
     float get_assemble_view_toolbar_width() const { return m_assemble_view_toolbar.get_width(); }
     float get_assemble_view_toolbar_height() const { return m_assemble_view_toolbar.get_height(); }
     float get_assembly_paint_toolbar_width() const { return m_paint_toolbar_width; }

--- a/src/slic3r/GUI/MainFrame.cpp
+++ b/src/slic3r/GUI/MainFrame.cpp
@@ -212,6 +212,15 @@ DPIFrame(NULL, wxID_ANY, "", wxDefaultPosition, wxDefaultSize, BORDERLESS_FRAME_
 
 #ifndef __APPLE__
     m_topbar         = new BBLTopbar(this);
+
+    // The BBLTopbar accessibility requires Init() to be called to set up Windows MSAA support.
+    // Init() creates the COM IAccessible interface, sets up window subclassing for WM_GETOBJECT 
+    // messages, and binds keyboard events for Tab navigation between toolbar elements. Because the
+    // BBLTopbar constructor already calls Init(parent) internally, doing so in the MainFrame integration
+    // causes a silent crash, so the BBLTopbar accessibility is currently dormant. Accessibility setup for
+    // BBLTopbar may need to be moved to a separate method called after construction.
+
+    // m_topbar->Init(this);
 #else
     auto panel_topbar = new wxPanel(this, wxID_ANY);
     panel_topbar->SetBackgroundColour(wxColour(38, 46, 48));


### PR DESCRIPTION
# Description
This commit implements Windows accessibility through Microsoft Active Accessibility (MSAA) APIs to support screen readers like Windows Narrator, JAWS, and NVDA. The implementation includes GLCanvas3D accessibility, keyboard navigation using Tab/Shift+Tab, screen reader detection with conditional activation, and a COM interface implementation for broad compatibility. Includes window subclassing for WM_GETOBJECT message handling, IAccessible interface, screen coordinate calculation for positioning, and resource cleanup and error handling. The implementation uses Windows-only conditional compilation and includes a debugging window for troubleshooting accessibility integration. BBLTopbar accessibility infrastructure is implemented but currently dormant and requires additional integration work to be fully functional.

# Screenshots/Recordings/Graphs
![glcanvas_windows_accessibility_demonstration](https://github.com/user-attachments/assets/a6bde8d9-7b9c-42f8-81e6-466266a3f00b)

## Tests
* Platform compatibility: Built and ran on Windows 11 Home using Visual Studio 2022
* Screen reader integration: Launched Windows Narrator and navigated GLCanvas3D tools to verify audio announcements
* Keyboard navigation: Pressed Tab/Shift+Tab keys to cycle through tools and confirmed focus movement
* Screen reader detection: Started/stopped Narrator to verify accessibility features enable/disable automatically
* Tool announcements: Selected different GLCanvas3D tools while Narrator was active to test name/state reporting
* Coordinate mapping: Used Narrator's "read cursor position" feature to verify tool locations are reported correctly
* Debugging verification: Opened accessibility debug window to inspect internal state during screen reader interactions
* Message handling: Checked debug output to verify WM_GETOBJECT messages are intercepted and processed