### PR TITLE
Fixes 2 Bugs and 13 Compiler Warnings

### DIFF
--- a/src/OrcaSlicer.cpp
+++ b/src/OrcaSlicer.cpp
@@ -7054,7 +7054,7 @@ int CLI::run(int argc, char **argv)
             gcode_viewer.render_calibration_thumbnail(*calibration_data, cali_thumbnail_width, cali_thumbnail_height,
                 calibration_params, partplate_list, opengl_mgr);
             //generate_calibration_thumbnail(*calibration_data, thumbnail_width, thumbnail_height, calibration_params);
-            //*plate_bboxes[index] = p->generate_first_layer_bbox();
+            // *plate_bboxes[index] = p->generate_first_layer_bbox();
             calibration_thumbnails.push_back(calibration_data);*/
 
             PlateBBoxData* plate_bbox = new PlateBBoxData();

--- a/src/OrcaSlicer.cpp
+++ b/src/OrcaSlicer.cpp
@@ -6852,7 +6852,7 @@ int CLI::run(int argc, char **argv)
             gcode_viewer.render_calibration_thumbnail(*calibration_data, cali_thumbnail_width, cali_thumbnail_height,
                 calibration_params, partplate_list, opengl_mgr);
             //generate_calibration_thumbnail(*calibration_data, thumbnail_width, thumbnail_height, calibration_params);
-            //*plate_bboxes[index] = p->generate_first_layer_bbox();
+            //plate_bboxes[index] = p->generate_first_layer_bbox();
             calibration_thumbnails.push_back(calibration_data);*/
 
             PlateBBoxData* plate_bbox = new PlateBBoxData();

--- a/src/libslic3r/AppConfig.cpp
+++ b/src/libslic3r/AppConfig.cpp
@@ -883,7 +883,7 @@ std::string AppConfig::load()
                 }
             }
         }
-    } catch(std::exception err) {
+    } catch(const std::exception &err) {
         BOOST_LOG_TRIVIAL(info) << format("parse app config \"%1%\", error: %2%", AppConfig::loading_path(), err.what());
 
         return err.what();

--- a/src/libslic3r/AppConfig.cpp
+++ b/src/libslic3r/AppConfig.cpp
@@ -770,7 +770,7 @@ std::string AppConfig::load()
                 }
             }
         }
-    } catch(std::exception err) {
+    } catch(const std::exception &err) {
         BOOST_LOG_TRIVIAL(info) << format("parse app config \"%1%\", error: %2%", AppConfig::loading_path(), err.what());
 
         return err.what();

--- a/src/libslic3r/Fill/FillRectilinear.cpp
+++ b/src/libslic3r/Fill/FillRectilinear.cpp
@@ -3576,7 +3576,7 @@ Polylines FillLateralHoneycomb::fill_surface(const Surface *surface, const FillP
     //     |
     //     |
     // 0 --+--
-    //    / \
+    //    ⟋ ⟍
     // why inverted?
     // it makes determining some of the properties easier
     // and the two angled legs provide additional horizontal stiffness

--- a/src/libslic3r/Fill/FillRectilinear.cpp
+++ b/src/libslic3r/Fill/FillRectilinear.cpp
@@ -3467,7 +3467,7 @@ Polylines FillLateralHoneycomb::fill_surface(const Surface *surface, const FillP
     //     |
     //     |
     // 0 --+--
-    //    / \
+    //    ⟋ ⟍
     // why inverted?
     // it makes determining some of the properties easier
     // and the two angled legs provide additional horizontal stiffness

--- a/src/libslic3r/Format/STEP.cpp
+++ b/src/libslic3r/Format/STEP.cpp
@@ -712,7 +712,7 @@ unsigned int Step::get_triangle_num(double linear_defletion, double angle_deflet
                 return 0;
             }
         }
-    } catch(Exception e) {
+    } catch(const Exception &e) {
         return 0;
     }
     

--- a/src/libslic3r/Format/STEP.cpp
+++ b/src/libslic3r/Format/STEP.cpp
@@ -712,7 +712,7 @@ unsigned int Step::get_triangle_num(double linear_deflection, double angle_defle
                 return 0;
             }
         }
-    } catch(Exception e) {
+    } catch(const Exception &e) {
         return 0;
     }
     

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -5511,7 +5511,7 @@ LayerResult GCode::process_layer(
     // add tag for processor
     gcode += ";" + GCodeProcessor::reserved_tag(GCodeProcessor::ETags::Layer_Change) + "\n";
     // export layer z
-    char buf[64];
+    char buf[80];
     sprintf(buf, print.is_BBL_printer() ? "; Z_HEIGHT: %g\n" : ";Z:%g\n", print_z);
     gcode += buf;
     // export layer height

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -4400,7 +4400,7 @@ LayerResult GCode::process_layer(
     // add tag for processor
     gcode += ";" + GCodeProcessor::reserved_tag(GCodeProcessor::ETags::Layer_Change) + "\n";
     // export layer z
-    char buf[64];
+    char buf[80];
     sprintf(buf, print.is_BBL_printer() ? "; Z_HEIGHT: %g\n" : ";Z:%g\n", print_z);
     gcode += buf;
     // export layer height

--- a/src/libslic3r/Model.cpp
+++ b/src/libslic3r/Model.cpp
@@ -2311,7 +2311,7 @@ unsigned int ModelObject::update_instances_print_volume_state(const BuildVolume 
     unsigned int num_printable = 0;
     //BBS: add logs for build_volume
     //const BoundingBoxf3& print_volume = build_volume.bounding_volume();
-    //BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << boost::format(", print_volume {%1%, %2%, %3%} to {%4%, %5%, %6%}")\
+    //BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << boost::format(", print_volume {%1%, %2%, %3%} to {%4%, %5%, %6%}")
     //    %print_volume.min.x() %print_volume.min.y() %print_volume.min.z()%print_volume.max.x() %print_volume.max.y() %print_volume.max.z();
     for (ModelInstance* model_instance : this->instances) {
         if (model_instance->update_print_volume_state(build_volume) == ModelInstancePVS_Inside) {

--- a/src/slic3r/GUI/DeviceTab/uiAmsHumidityPopup.cpp
+++ b/src/slic3r/GUI/DeviceTab/uiAmsHumidityPopup.cpp
@@ -1,9 +1,9 @@
-//**********************************************************/
-/* File: uiAmsHumidityPopup.cpp
+/**********************************************************
+* File: uiAmsHumidityPopup.cpp
 *  Description: The popup with DevAms Humidity
 *
 * \n class uiAmsHumidityPopup
-//**********************************************************/
+**********************************************************/
 
 #include "uiAmsHumidityPopup.h"
 
@@ -32,7 +32,7 @@ void uiAmsPercentHumidityDryPopup::Create()
     idle_img = ScalableBitmap(this, "ams_drying", 16);
     drying_img = ScalableBitmap(this, "ams_is_drying", 16);
 
-    // background 
+    // background
     SetBackgroundColour(*wxWHITE);
 
     // create title sizer
@@ -191,3 +191,4 @@ void uiAmsPercentHumidityDryPopup::msw_rescale()
 } // namespace GUI
 
 } // namespace Slic3r
+

--- a/src/slic3r/GUI/DeviceTab/uiAmsHumidityPopup.cpp
+++ b/src/slic3r/GUI/DeviceTab/uiAmsHumidityPopup.cpp
@@ -1,9 +1,9 @@
-//**********************************************************/
-/* File: uiAmsHumidityPopup.cpp
+/**********************************************************
+* File: uiAmsHumidityPopup.cpp
 *  Description: The popup with DevAms Humidity
 *
 * \n class uiAmsHumidityPopup
-//**********************************************************/
+**********************************************************/
 
 #include "uiAmsHumidityPopup.h"
 

--- a/src/slic3r/GUI/DeviceTab/uiAmsHumidityPopup.h
+++ b/src/slic3r/GUI/DeviceTab/uiAmsHumidityPopup.h
@@ -1,9 +1,9 @@
-//**********************************************************/
-/* File: uiAmsHumidityPopup.h
-*  Description: The popup with DevAms Humidity
+/**********************************************************
+* File: uiAmsHumidityPopup.h
+* Description: The popup with DevAms Humidity
 *
 *  \n class uiAmsHumidityPopup
-//**********************************************************/
+**********************************************************/
 
 #pragma once
 #include "slic3r/GUI/Widgets/AMSItem.hpp"
@@ -68,7 +68,7 @@ private:
 
     wxStaticBitmap* m_dry_state_img;
     Label*          m_dry_state;
-    
+
     Label* m_humidity_header;
     Label* m_humidity_label;
 
@@ -82,3 +82,4 @@ private:
 };
 
 }} // namespace Slic3r::GUI
+

--- a/src/slic3r/GUI/DeviceTab/uiAmsHumidityPopup.h
+++ b/src/slic3r/GUI/DeviceTab/uiAmsHumidityPopup.h
@@ -1,9 +1,9 @@
-//**********************************************************/
-/* File: uiAmsHumidityPopup.h
+/**********************************************************
+* File: uiAmsHumidityPopup.h
 *  Description: The popup with DevAms Humidity
 *
 *  \n class uiAmsHumidityPopup
-//**********************************************************/
+**********************************************************/
 
 #pragma once
 #include "slic3r/GUI/Widgets/AMSItem.hpp"
@@ -68,7 +68,7 @@ private:
 
     wxStaticBitmap* m_dry_state_img;
     Label*          m_dry_state;
-    
+
     Label* m_humidity_header;
     Label* m_humidity_label;
 

--- a/src/slic3r/GUI/DeviceTab/uiDeviceUpdateVersion.cpp
+++ b/src/slic3r/GUI/DeviceTab/uiDeviceUpdateVersion.cpp
@@ -1,9 +1,9 @@
-//**********************************************************/
-/* File: uiDeviceUpdateVersion.cpp
+/**********************************************************
+* File: uiDeviceUpdateVersion.cpp
 *  Description: The panel with firmware info
 *
 * \n class uiDeviceUpdateVersion
-//**********************************************************/
+**********************************************************/
 
 #include "uiDeviceUpdateVersion.h"
 

--- a/src/slic3r/GUI/DeviceTab/uiDeviceUpdateVersion.h
+++ b/src/slic3r/GUI/DeviceTab/uiDeviceUpdateVersion.h
@@ -1,9 +1,9 @@
-//**********************************************************/
-/* File: uiDeviceUpdateVersion.h
+/**********************************************************
+* File: uiDeviceUpdateVersion.h
 *  Description: The panel with firmware info
 * 
 *  \n class uiDeviceUpdateVersion
-//**********************************************************/
+**********************************************************/
 
 #pragma once
 #include <wx/panel.h>

--- a/src/slic3r/GUI/GUI_ObjectList.cpp
+++ b/src/slic3r/GUI/GUI_ObjectList.cpp
@@ -3213,7 +3213,7 @@ void ObjectList::merge(bool to_multipart_object)
         //changed_object(obj_idx);
         //remove();
     }
-   /* wxGetApp().plater()->load_model_objects(objects);
+   // wxGetApp().plater()->load_model_objects(objects);
 
     Selection& selection = p->view3D->get_canvas3d()->get_selection();
     size_t last_obj_idx = p->model.objects.size() - 1;

--- a/src/slic3r/GUI/GUI_ObjectList.cpp
+++ b/src/slic3r/GUI/GUI_ObjectList.cpp
@@ -3146,7 +3146,7 @@ void ObjectList::merge(bool to_multipart_object)
         //changed_object(obj_idx);
         //remove();
     }
-   /* wxGetApp().plater()->load_model_objects(objects);
+   // wxGetApp().plater()->load_model_objects(objects);
 
     Selection& selection = p->view3D->get_canvas3d()->get_selection();
     size_t last_obj_idx = p->model.objects.size() - 1;

--- a/src/slic3r/GUI/IMSlider.cpp
+++ b/src/slic3r/GUI/IMSlider.cpp
@@ -1733,7 +1733,7 @@ std::string IMSlider::get_label(int tick, LabelType label_type)
         ::sprintf(layer_height, "%.2f", m_values.empty() ? m_label_koef * value : m_values[value]);
         if (label_type == ltHeight) return std::string(layer_height);
         if (label_type == ltHeightWithLayer) {
-            char   buffer[64];
+            char   buffer[72];
             size_t layer_number;
             layer_number = m_draw_mode == dmSequentialFffPrint ? (m_values.empty() ? value : value + 1) : m_is_wipe_tower ? get_layer_number(value, label_type) + 1 : (m_values.empty() ? value : value + 1);
             ::sprintf(buffer, "%5s\n%5s", std::to_string(layer_number).c_str(), layer_height);

--- a/src/slic3r/GUI/IMSlider.cpp
+++ b/src/slic3r/GUI/IMSlider.cpp
@@ -1733,7 +1733,7 @@ std::string IMSlider::get_label(int tick, LabelType label_type)
         ::sprintf(layer_height, "%.2f", m_values.empty() ? m_label_koef * value : m_values[value]);
         if (label_type == ltHeight) return std::string(layer_height);
         if (label_type == ltHeightWithLayer) {
-            char   buffer[72];
+            char   buffer[90];
             size_t layer_number;
             layer_number = m_draw_mode == dmSequentialFffPrint ? (m_values.empty() ? value : value + 1) : m_is_wipe_tower ? get_layer_number(value, label_type) + 1 : (m_values.empty() ? value : value + 1);
             ::sprintf(buffer, "%5s\n%5s", std::to_string(layer_number).c_str(), layer_height);

--- a/src/slic3r/GUI/IMSlider.cpp
+++ b/src/slic3r/GUI/IMSlider.cpp
@@ -1589,7 +1589,7 @@ std::string IMSlider::get_label(int tick, LabelType label_type)
         ::sprintf(layer_height, "%.2f", m_values.empty() ? m_label_koef * value : m_values[value]);
         if (label_type == ltHeight) return std::string(layer_height);
         if (label_type == ltHeightWithLayer) {
-            char   buffer[64];
+            char   buffer[72];
             size_t layer_number;
             layer_number = m_draw_mode == dmSequentialFffPrint ? (m_values.empty() ? value : value + 1) : m_is_wipe_tower ? get_layer_number(value, label_type) + 1 : (m_values.empty() ? value : value + 1);
             ::sprintf(buffer, "%5s\n%5s", std::to_string(layer_number).c_str(), layer_height);

--- a/src/slic3r/GUI/SelectMachine.cpp
+++ b/src/slic3r/GUI/SelectMachine.cpp
@@ -3629,7 +3629,7 @@ void SelectMachineDialog::on_send_print()
         BOOST_LOG_TRIVIAL(error) << "build_nozzle_info errors";
     }
 
-    m_print_job->sdcard_state = obj_->GetStorage()->get_sdcard_state();    
+    m_print_job->sdcard_state = obj_->GetStorage()->get_sdcard_state();
     m_print_job->has_sdcard =  wxGetApp().app_config->get("allow_abnormal_storage") == "true"
             ? (m_print_job->sdcard_state == DevStorage::SdcardState::HAS_SDCARD_NORMAL
                || m_print_job->sdcard_state == DevStorage::SdcardState::HAS_SDCARD_ABNORMAL)
@@ -3868,12 +3868,11 @@ _compare_obj_names(MachineObject* obj1, MachineObject* obj2)
 }
 
 /*******************************************************************
-*@note   _collect_machine_list
-*@param  dev_manager -- the device manager
-*@param  sorted_machine_objs -- return the sorted machine objects
-*@param  best_one -- return the best one
-*/
-/*******************************************************************/
+* @note   _collect_machine_list
+* @param  dev_manager -- the device manager
+* @param  sorted_machine_objs -- return the sorted machine objects
+* @param  best_one -- return the best one
+*******************************************************************/
 static void
 _collect_sorted_machines(Slic3r::DeviceManager* dev_manager,
                          std::vector<MachineObject*>& sorted_machine_objs)

--- a/src/slic3r/GUI/SelectMachine.cpp
+++ b/src/slic3r/GUI/SelectMachine.cpp
@@ -1793,11 +1793,11 @@ static bool _is_nozzle_data_valid(MachineObject* obj_, const DevExtderSystem &ex
 }
 
 
-/**************************************************************//*
- * @param tag_nozzle_type -- return the mismatch nozzle type
- * @param tag_nozzle_diameter -- return the target nozzle_diameter but mismatch
- * @return is same or not
-/*************************************************************/
+/***************************************************************
+* @param tag_nozzle_type -- return the mismatch nozzle type
+* @param tag_nozzle_diameter -- return the target nozzle_diameter but mismatch
+* @return is same or not
+***************************************************************/
 static bool _is_same_nozzle_diameters(MachineObject* obj, float &tag_nozzle_diameter, int& mismatch_nozzle_id)
 {
     if (obj == nullptr) return false;
@@ -2527,13 +2527,13 @@ void SelectMachineDialog::on_send_print()
         BOOST_LOG_TRIVIAL(error) << "build_nozzle_info errors";
     }
 
-    m_print_job->sdcard_state = obj_->GetStorage()->get_sdcard_state();    
+    m_print_job->sdcard_state = obj_->GetStorage()->get_sdcard_state();
     m_print_job->has_sdcard =  wxGetApp().app_config->get("allow_abnormal_storage") == "true"
             ? (m_print_job->sdcard_state == DevStorage::SdcardState::HAS_SDCARD_NORMAL
                || m_print_job->sdcard_state == DevStorage::SdcardState::HAS_SDCARD_ABNORMAL)
             : m_print_job->sdcard_state == DevStorage::SdcardState::HAS_SDCARD_NORMAL;
 
-    m_print_job->could_emmc_print = obj_->is_support_print_with_emmc;
+m_print_job->could_emmc_print = obj_->is_support_print_with_emmc;
 
 
     bool timelapse_option = m_checkbox_list["timelapse"]->IsShown()?true:false;
@@ -3322,7 +3322,7 @@ void SelectMachineDialog::update_show_status(MachineObject* obj_)
         show_status(PrintDialogStatus::PrintStatusNoSdcard);
         return;
     }
-    if (wxGetApp().preset_bundle->filament_presets.size() > 16 && m_print_type != PrintFromType::FROM_SDCARD_VIEW) { 
+    if (wxGetApp().preset_bundle->filament_presets.size() > 16 && m_print_type != PrintFromType::FROM_SDCARD_VIEW) {
         if (!obj_->is_enable_ams_np && !obj_->is_enable_np)
         {
             show_status(PrintDialogStatus::PrintStatusColorQuantityExceed);


### PR DESCRIPTION
# Description

This PR:
- Fixes https://github.com/OrcaSlicer/OrcaSlicer/issues/15081
- Fixes 13 compiler warnings and 2 bugs:
  1. fixes: %g directive writing between 1 and 13 bytes into a region of size between 6 and 18 [-Wformat-overflow=] :lady_beetle: 
  2. fixes: %5s directive writing between 5 and 63 bytes into a region of size 58 [-Wformat-overflow=] :lady_beetle: 
  3. fixes: catching polymorphic type by value [-Wcatch-value=]
  4. fixes: [-Wcomment]
