### PR TITLE
Fixes 1 Technical Debt and 3 Compiler Warnings [-Wclass-memaccess]

### DIFF
--- a/src/libslic3r/Orient.hpp
+++ b/src/libslic3r/Orient.hpp
@@ -40,100 +40,50 @@ struct OrientMesh {
 
 };
 
-// params for minimizing support area
-struct OrientParamsArea {
-    float TAR_A = 0.015f;
-    float TAR_B = 0.177f;
-    float RELATIVE_F = 20;
-    float CONTOUR_F = 0.5f;
-    float BOTTOM_F = 2.5f;
-    float BOTTOM_HULL_F = 0.1f;
-    float TAR_C = 0.1f;
-    float TAR_D = 1;
-    float TAR_E = 0.0115f;
-    float FIRST_LAY_H = 0.2f;//0.0475;
-    float VECTOR_TOL = -0.00083f;
-    float NEGL_FACE_SIZE = 0.01f;
-    float ASCENT = -0.5f;
-    float PLAFOND_ADV = 0.0599f;
-    float CONTOUR_AMOUNT = 0.0182427f;
-    float OV_H = 2.574f;
-    float height_offset = 2.3728f;
-    float height_log = 0.041375f;
-    float height_log_k = 1.9325457f;
-    float LAF_MAX = 0.999f; // cos(1.4\degree) for low angle face 0.9997f
-    float LAF_MIN = 0.97f;  // cos(14\degree) 0.9703f
-    float TAR_LAF = 0.001f; //0.01f
-    float TAR_PROJ_AREA = 0.1f;
-    float BOTTOM_MIN = 0.1f;  // min bottom area. If lower than it the object may be unstable
-    float BOTTOM_MAX = 2000;  // max bottom area. If get to it the object is stable enough (further increase bottom area won't do more help)
-    float height_to_bottom_hull_ratio_MIN = 1;
-    float BOTTOM_HULL_MAX = 2000;// max bottom hull area
-    float APPERANCE_FACE_SUPP=3; // penalty of generating supports on appearance face
-
-    float overhang_angle = 60.f;
-    bool use_low_angle_face = true;
-    bool min_volume = false;
-    Eigen::Vector3f fun_dir;
-
-    /// Allow parallel execution.
-    bool parallel = true;
-
-    /// Progress indicator callback called when an object gets packed.
-    /// The unsigned argument is the number of items remaining to pack.
-    std::function<void(unsigned, std::string)> progressind = {};
-
-    /// A predicate returning true if abort is needed.
-    std::function<bool(void)>     stopcondition = {};
-
-    OrientParamsArea() = default;
-};
-
 struct OrientParams {
-    float TAR_A = 0.01f;//0.128f;
-    float TAR_B = 0.177f;
-    float RELATIVE_F= 6.610621027964314f;
-    float CONTOUR_F = 0.23228623269775997f;
-    float BOTTOM_F = 1.167152017941474f;
-    float BOTTOM_HULL_F = 0.1f;
-    float TAR_C = 0.24308070476924726f;
-    float TAR_D = 0.6284515508160871f;
-    float TAR_E = 0;//0.032157292647062234;
-    float FIRST_LAY_H = 0.2f;//0.029;
-    float VECTOR_TOL = -0.0011163303070972383f;
-    float NEGL_FACE_SIZE = 0.1f;
-    float ASCENT= -0.5f;
-    float PLAFOND_ADV = 0.04079208948120519f;
-    float CONTOUR_AMOUNT = 0.0101472219892684f;
-    float OV_H = 1.0370178217794535f;
-    float height_offset = 2.7417608343142073f;
-    float height_log = 0.06442030687034085f;
-    float height_log_k = 0.3933594673063997f;
-    float LAF_MAX = 0.999f; // cos(1.4\degree) for low angle face //0.9997f;
-    float LAF_MIN= 0.9703f;  // cos(14\degree) 0.9703f;
-    float TAR_LAF = 0.01f; //0.1f
-    float TAR_PROJ_AREA = 0.1f;
-    float BOTTOM_MIN = 0.1f;  // min bottom area. If lower than it the objects may be unstable
-    float BOTTOM_MAX = 2000; //400
-    float height_to_bottom_hull_ratio_MIN = 1;
-    float BOTTOM_HULL_MAX = 2000;// max bottom hull area to clip //600
-    float APPERANCE_FACE_SUPP=3; // penalty of generating supports on appearance face
+    float TAR_A               { 0.01f };     // 0.128f;
+    float TAR_B               { 0.177f };
+    float RELATIVE_F          { 6.610621027964314f };
+    float CONTOUR_F           { 0.23228623269775997f };
+    float BOTTOM_F            { 1.167152017941474f };
+    float BOTTOM_HULL_F       { 0.1f };
+    float TAR_C               { 0.24308070476924726f };
+    float TAR_D               { 0.6284515508160871f };
+    float TAR_E               { 0};         // 0.032157292647062234;
+    float FIRST_LAY_H         { 0.2f};      // 0.029;
+    float VECTOR_TOL          { -0.0011163303070972383f };
+    float NEGL_FACE_SIZE      { 0.1f };
+    float ASCENT              { -0.5f };
+    float PLAFOND_ADV         { 0.04079208948120519f };
+    float CONTOUR_AMOUNT      { 0.0101472219892684f };
+    float OV_H                { 1.0370178217794535f };
+    float height_offset       { 2.7417608343142073f };
+    float height_log          { 0.06442030687034085f };
+    float height_log_k        { 0.3933594673063997f };
+    float LAF_MAX             { 0.999f };    // cos(1.4\degree) for low angle face //0.9997f;
+    float LAF_MIN             { 0.9703f };   // cos(14\degree) 0.9703f;
+    float TAR_LAF             { 0.01f };     // 0.1f
+    float TAR_PROJ_AREA       { 0.1f };
+    float BOTTOM_MIN          { 0.1f };      // min bottom area. If lower than it the objects may be unstable
+    float BOTTOM_MAX          { 2000 };      // 400
+    float height_to_bottom_hull_ratio_MIN { 1 };
+    float BOTTOM_HULL_MAX     { 2000 };      // max bottom hull area to clip //600
+    float APPERANCE_FACE_SUPP { 3 };         // penalty of generating supports on appearance face
 
-    float overhang_angle = 60.f;
-    bool use_low_angle_face = true;
-    bool min_volume = false;
-    Eigen::Vector3f fun_dir;
-
+    float overhang_angle     { 60.f };
+    bool  use_low_angle_face { true };
+    bool  min_volume         { false };
+    Eigen::Vector3f fun_dir  {};
 
     /// Allow parallel execution.
-    bool parallel = false;
+    bool parallel { false };
 
     /// Progress indicator callback called when an object gets packed.
     /// The unsigned argument is the number of items remaining to pack.
-    std::function<void(unsigned, std::string)> progressind = {};
+    std::function<void(unsigned, std::string)> progressind {};
 
     /// A predicate returning true if abort is needed.
-    std::function<bool(void)>     stopcondition = {};
+    std::function<bool(void)> stopcondition {};
 
     OrientParams() = default;
 };

--- a/src/libslic3r/Orient.hpp
+++ b/src/libslic3r/Orient.hpp
@@ -48,100 +48,50 @@ struct OrientMesh {
 
 };
 
-// params for minimizing support area
-struct OrientParamsArea {
-    float TAR_A = 0.015f;
-    float TAR_B = 0.177f;
-    float RELATIVE_F = 20;
-    float CONTOUR_F = 0.5f;
-    float BOTTOM_F = 2.5f;
-    float BOTTOM_HULL_F = 0.1f;
-    float TAR_C = 0.1f;
-    float TAR_D = 1;
-    float TAR_E = 0.0115f;
-    float FIRST_LAY_H = 0.2f;//0.0475;
-    float VECTOR_TOL = -0.00083f;
-    float NEGL_FACE_SIZE = 0.01f;
-    float ASCENT = -0.5f;
-    float PLAFOND_ADV = 0.0599f;
-    float CONTOUR_AMOUNT = 0.0182427f;
-    float OV_H = 2.574f;
-    float height_offset = 2.3728f;
-    float height_log = 0.041375f;
-    float height_log_k = 1.9325457f;
-    float LAF_MAX = 0.999f; // cos(1.4\degree) for low angle face 0.9997f
-    float LAF_MIN = 0.97f;  // cos(14\degree) 0.9703f
-    float TAR_LAF = 0.001f; //0.01f
-    float TAR_PROJ_AREA = 0.1f;
-    float BOTTOM_MIN = 0.1f;  // min bottom area. If lower than it the object may be unstable
-    float BOTTOM_MAX = 2000;  // max bottom area. If get to it the object is stable enough (further increase bottom area won't do more help)
-    float height_to_bottom_hull_ratio_MIN = 1;
-    float BOTTOM_HULL_MAX = 2000;// max bottom hull area
-    float APPERANCE_FACE_SUPP=3; // penalty of generating supports on appearance face
-
-    float overhang_angle = 60.f;
-    bool use_low_angle_face = true;
-    bool min_volume = false;
-    Eigen::Vector3f fun_dir;
-
-    /// Allow parallel execution.
-    bool parallel = true;
-
-    /// Progress indicator callback called when an object gets packed.
-    /// The unsigned argument is the number of items remaining to pack.
-    std::function<void(unsigned, std::string)> progressind = {};
-
-    /// A predicate returning true if abort is needed.
-    std::function<bool(void)>     stopcondition = {};
-
-    OrientParamsArea() = default;
-};
-
 struct OrientParams {
-    float TAR_A = 0.01f;//0.128f;
-    float TAR_B = 0.177f;
-    float RELATIVE_F= 6.610621027964314f;
-    float CONTOUR_F = 0.23228623269775997f;
-    float BOTTOM_F = 1.167152017941474f;
-    float BOTTOM_HULL_F = 0.1f;
-    float TAR_C = 0.24308070476924726f;
-    float TAR_D = 0.6284515508160871f;
-    float TAR_E = 0;//0.032157292647062234;
-    float FIRST_LAY_H = 0.2f;//0.029;
-    float VECTOR_TOL = -0.0011163303070972383f;
-    float NEGL_FACE_SIZE = 0.1f;
-    float ASCENT= -0.5f;
-    float PLAFOND_ADV = 0.04079208948120519f;
-    float CONTOUR_AMOUNT = 0.0101472219892684f;
-    float OV_H = 1.0370178217794535f;
-    float height_offset = 2.7417608343142073f;
-    float height_log = 0.06442030687034085f;
-    float height_log_k = 0.3933594673063997f;
-    float LAF_MAX = 0.999f; // cos(1.4\degree) for low angle face //0.9997f;
-    float LAF_MIN= 0.9703f;  // cos(14\degree) 0.9703f;
-    float TAR_LAF = 0.01f; //0.1f
-    float TAR_PROJ_AREA = 0.1f;
-    float BOTTOM_MIN = 0.1f;  // min bottom area. If lower than it the objects may be unstable
-    float BOTTOM_MAX = 2000; //400
-    float height_to_bottom_hull_ratio_MIN = 1;
-    float BOTTOM_HULL_MAX = 2000;// max bottom hull area to clip //600
-    float APPERANCE_FACE_SUPP=3; // penalty of generating supports on appearance face
+    float TAR_A               { 0.01f };     // 0.128f;
+    float TAR_B               { 0.177f };
+    float RELATIVE_F          { 6.610621027964314f };
+    float CONTOUR_F           { 0.23228623269775997f };
+    float BOTTOM_F            { 1.167152017941474f };
+    float BOTTOM_HULL_F       { 0.1f };
+    float TAR_C               { 0.24308070476924726f };
+    float TAR_D               { 0.6284515508160871f };
+    float TAR_E               { 0};         // 0.032157292647062234;
+    float FIRST_LAY_H         { 0.2f};      // 0.029;
+    float VECTOR_TOL          { -0.0011163303070972383f };
+    float NEGL_FACE_SIZE      { 0.1f };
+    float ASCENT              { -0.5f };
+    float PLAFOND_ADV         { 0.04079208948120519f };
+    float CONTOUR_AMOUNT      { 0.0101472219892684f };
+    float OV_H                { 1.0370178217794535f };
+    float height_offset       { 2.7417608343142073f };
+    float height_log          { 0.06442030687034085f };
+    float height_log_k        { 0.3933594673063997f };
+    float LAF_MAX             { 0.999f };    // cos(1.4\degree) for low angle face //0.9997f;
+    float LAF_MIN             { 0.9703f };   // cos(14\degree) 0.9703f;
+    float TAR_LAF             { 0.01f };     // 0.1f
+    float TAR_PROJ_AREA       { 0.1f };
+    float BOTTOM_MIN          { 0.1f };      // min bottom area. If lower than it the objects may be unstable
+    float BOTTOM_MAX          { 2000 };      // 400
+    float height_to_bottom_hull_ratio_MIN { 1 };
+    float BOTTOM_HULL_MAX     { 2000 };      // max bottom hull area to clip //600
+    float APPERANCE_FACE_SUPP { 3 };         // penalty of generating supports on appearance face
 
-    float overhang_angle = 60.f;
-    bool use_low_angle_face = true;
-    bool min_volume = false;
-    Eigen::Vector3f fun_dir;
-
+    float overhang_angle     { 60.f };
+    bool  use_low_angle_face { true };
+    bool  min_volume         { false };
+    Eigen::Vector3f fun_dir  {};
 
     /// Allow parallel execution.
-    bool parallel = false;
+    bool parallel { false };
 
     /// Progress indicator callback called when an object gets packed.
     /// The unsigned argument is the number of items remaining to pack.
-    std::function<void(unsigned, std::string)> progressind = {};
+    std::function<void(unsigned, std::string)> progressind {};
 
     /// A predicate returning true if abort is needed.
-    std::function<bool(void)>     stopcondition = {};
+    std::function<bool(void)> stopcondition {};
 
     OrientParams() = default;
 };

--- a/src/slic3r/GUI/Jobs/OrientJob.cpp
+++ b/src/slic3r/GUI/Jobs/OrientJob.cpp
@@ -149,6 +149,48 @@ void OrientJob::prepare()
     }
 }
 
+namespace {
+/// parameters to minimize support area
+void setMinimalSupportAreaPrams(Slic3r::orientation::OrientParams &out)
+{
+    out.TAR_A               = 0.015f;
+    out.TAR_B               = 0.177f;
+    out.RELATIVE_F          = 20;
+    out.CONTOUR_F           = 0.5f;
+    out.BOTTOM_F            = 2.5f;
+    out.BOTTOM_HULL_F       = 0.1f;
+    out.TAR_C               = 0.1f;
+    out.TAR_D               = 1;
+    out.TAR_E               = 0.0115f;
+    out.FIRST_LAY_H         = 0.2f;      // 0.0475;
+    out.VECTOR_TOL          = -0.00083f;
+    out.NEGL_FACE_SIZE      = 0.01f;
+    out.ASCENT              = -0.5f;
+    out.PLAFOND_ADV         = 0.0599f;
+    out.CONTOUR_AMOUNT      = 0.0182427f;
+    out.OV_H                = 2.574f;
+    out.height_offset       = 2.3728f;
+    out.height_log          = 0.041375f;
+    out.height_log_k        = 1.9325457f;
+    out.LAF_MAX             = 0.999f;    // cos(1.4\degree) for low angle face 0.9997f
+    out.LAF_MIN             = 0.97f;     // cos(14\degree) 0.9703f
+    out.TAR_LAF             = 0.001f;    // 0.01f
+    out.TAR_PROJ_AREA       = 0.1f;
+    out.BOTTOM_MIN          = 0.1f;      // min bottom area. If lower than it the object may be unstable
+    out.BOTTOM_MAX          = 2000;      // max bottom area. If get to it the object is stable enough (further increase bottom area won't do more help)
+    out.height_to_bottom_hull_ratio_MIN = 1,
+    out.BOTTOM_HULL_MAX     = 2000;      // max bottom hull area
+    out.APPERANCE_FACE_SUPP = 3;         // penalty of generating supports on appearance face
+    out.overhang_angle      = 60.f;
+    out.use_low_angle_face  = true;
+    out.min_volume          = false;
+    out.fun_dir             = {};
+    out.parallel            = true;
+    out.progressind         = {};
+    out.stopcondition       = {};
+}
+} // namespace
+
 void OrientJob::process(Ctl &ctl)
 {
     static const auto arrangestr = _u8L("Orienting...");
@@ -161,9 +203,8 @@ void OrientJob::process(Ctl &ctl)
     const GLCanvas3D::OrientSettings& settings = m_plater->canvas3D()->get_orient_settings();
 
     orientation::OrientParams params;
-    orientation::OrientParamsArea params_area;
     if (settings.min_area) {
-        memcpy(&params, &params_area, sizeof(params));
+        setMinimalSupportAreaPrams(params);
         params.min_volume = false;
     }
     else {

--- a/src/slic3r/GUI/Jobs/OrientJob.cpp
+++ b/src/slic3r/GUI/Jobs/OrientJob.cpp
@@ -149,9 +149,8 @@ void OrientJob::prepare()
     }
 }
 
-namespace {
 /// parameters to minimize support area
-void setMinimalSupportAreaPrams(Slic3r::orientation::OrientParams &out)
+static void setMinimalSupportAreaPrams(Slic3r::orientation::OrientParams &out)
 {
     out.TAR_A               = 0.015f;
     out.TAR_B               = 0.177f;
@@ -189,7 +188,6 @@ void setMinimalSupportAreaPrams(Slic3r::orientation::OrientParams &out)
     out.progressind         = {};
     out.stopcondition       = {};
 }
-} // namespace
 
 void OrientJob::process(Ctl &ctl)
 {


### PR DESCRIPTION
# Description

This PR
- Fixes https://github.com/OrcaSlicer/OrcaSlicer/issues/15081
- Fixes 3 compiler Warnings and 1 Technical Debt:
  1. fixes: memcpy(...) writing to an object of type OrientParams with no trivial copy-assignment; use copy-assignment or copy-initialization instead [-Wclass-memaccess] :fish:
  1. fixes: SetSashSize() is deprecated [-Wdeprecated-declarations]; doesn't do anything and shouldn't be used
  1. fixes: wxPlatformInfo::GetArchName() is deprecated: Use GetBitnessName() instead [-Wdeprecated-declarations]

**Regarding i.) :fish: `memcpy(...)[-Wclass-memaccess]`:**

The authors intention was to crate a new type `OrientParamsArea` holding a different parameter-set other than `OrientParams` default values to be later assigned to `OrientParams`. In the program flow it was "assigned" by `memcpy(orient_params, orient_params_area, sizeof(orient_params))`. Both types were incompatible; had no common base - just same members.

First attempt to introduce a `const static OrientParams` holding the parameter set of `OrientParamsArea` that could be `operator=` assigned, failed due to old M$VC compiler `/std` in pipeline: `error C7555: use of designated initializers requires at least '/std:c++20'`

The fix removes the incompatible, redundant type `OrientParamsArea` and moves the parameter-set to a `void setMinimalSupportAreaPrams(Slic3r::orientation::OrientParams &out)` function.

In short: instead of 
`memcpy(&params_type, &incompatible_params_area_type, sizeof(params_type));`
it updates to
`setMinimalSupportAreaPrams(params_type);`
