### PR TITLE
Fixes 4 Compiler Warnings

### DIFF
--- a/src/libslic3r/BoundingBox.hpp
+++ b/src/libslic3r/BoundingBox.hpp
@@ -25,7 +25,7 @@ public:
         min(p1), max(p1), defined(false) { merge(p2); merge(p3); }
 
     template<class It, class = IteratorOnly<It>>
-    BoundingBoxBase(It from, It to)
+    BoundingBoxBase(It from, It to) : BoundingBoxBase()
         { construct(*this, from, to); }
 
     BoundingBoxBase(const PointsType &points)

--- a/src/libslic3r/Fill/FillBase.cpp
+++ b/src/libslic3r/Fill/FillBase.cpp
@@ -1845,18 +1845,18 @@ static inline void base_support_extend_infill_lines(Polylines &infill, BoundaryI
     const auto      dist_min_y      = coord_t(line_spacing * 0.5);
 
     for (ContourIntersectionPoint &cp : graph.map_infill_end_point_to_boundary) {
-        const Points                &contour         = graph.boundary[cp.contour_idx];
-        const std::vector<double>   &contour_param   = graph.boundary_params[cp.contour_idx];
-        const Point                 &pt              = contour[cp.point_idx];
-        const bool                   first           = graph.first(cp);
-        int                          extend_next_idx = -1;
-        int                          extend_prev_idx = -1;
-        coord_t                      dist_y_prev;
-        coord_t                      dist_y_next;
-        double                       arc_len_prev;
-        double                       arc_len_next;
+        const Points                &contour         { graph.boundary[cp.contour_idx] };
+        const std::vector<double>   &contour_param   { graph.boundary_params[cp.contour_idx] };
+        const Point                 &pt              { contour[cp.point_idx] };
+        const bool                   first           { graph.first(cp) };
+        int                          extend_next_idx { -1 };
+        int                          extend_prev_idx { -1 };
+        coord_t                      dist_y_prev     { 0 };
+        coord_t                      dist_y_next     { 0 };
+        double                       arc_len_prev    { 0 };
+        double                       arc_len_next    { 0 };
 
-        if (! graph.next_vertical(cp)){
+        if (! graph.next_vertical(cp)) {
             size_t i = cp.point_idx;
             size_t j = next_idx_modulo(i, contour);
             while (j != cp.next_on_contour->point_idx) {

--- a/src/libslic3r/Fill/FillBase.cpp
+++ b/src/libslic3r/Fill/FillBase.cpp
@@ -1851,18 +1851,18 @@ static inline void base_support_extend_infill_lines(Polylines &infill, BoundaryI
     const auto      dist_min_y      = coord_t(line_spacing * 0.5);
 
     for (ContourIntersectionPoint &cp : graph.map_infill_end_point_to_boundary) {
-        const Points                &contour         = graph.boundary[cp.contour_idx];
-        const std::vector<double>   &contour_param   = graph.boundary_params[cp.contour_idx];
-        const Point                 &pt              = contour[cp.point_idx];
-        const bool                   first           = graph.first(cp);
-        int                          extend_next_idx = -1;
-        int                          extend_prev_idx = -1;
-        coord_t                      dist_y_prev;
-        coord_t                      dist_y_next;
-        double                       arc_len_prev;
-        double                       arc_len_next;
+        const Points                &contour         { graph.boundary[cp.contour_idx] };
+        const std::vector<double>   &contour_param   { graph.boundary_params[cp.contour_idx] };
+        const Point                 &pt              { contour[cp.point_idx] };
+        const bool                   first           { graph.first(cp) };
+        int                          extend_next_idx { -1 };
+        int                          extend_prev_idx { -1 };
+        coord_t                      dist_y_prev     { 0 };
+        coord_t                      dist_y_next     { 0 };
+        double                       arc_len_prev    { 0 };
+        double                       arc_len_next    { 0 };
 
-        if (! graph.next_vertical(cp)){
+        if (! graph.next_vertical(cp)) {
             size_t i = cp.point_idx;
             size_t j = next_idx_modulo(i, contour);
             while (j != cp.next_on_contour->point_idx) {

--- a/src/libslic3r/Fill/FillBase.cpp
+++ b/src/libslic3r/Fill/FillBase.cpp
@@ -1851,16 +1851,16 @@ static inline void base_support_extend_infill_lines(Polylines &infill, BoundaryI
     const auto      dist_min_y      = coord_t(line_spacing * 0.5);
 
     for (ContourIntersectionPoint &cp : graph.map_infill_end_point_to_boundary) {
-        const Points                &contour         { graph.boundary[cp.contour_idx] };
-        const std::vector<double>   &contour_param   { graph.boundary_params[cp.contour_idx] };
-        const Point                 &pt              { contour[cp.point_idx] };
-        const bool                   first           { graph.first(cp) };
-        int                          extend_next_idx { -1 };
-        int                          extend_prev_idx { -1 };
-        coord_t                      dist_y_prev     { 0 };
-        coord_t                      dist_y_next     { 0 };
-        double                       arc_len_prev    { 0 };
-        double                       arc_len_next    { 0 };
+        const Points                &contour         = graph.boundary[cp.contour_idx];
+        const std::vector<double>   &contour_param   = graph.boundary_params[cp.contour_idx];
+        const Point                 &pt              = contour[cp.point_idx];
+        const bool                   first           = graph.first(cp);
+        int                          extend_next_idx = -1;
+        int                          extend_prev_idx = -1;
+        coord_t                      dist_y_prev     = 0;
+        coord_t                      dist_y_next     = 0;
+        double                       arc_len_prev    = 0;
+        double                       arc_len_next    = 0;
 
         if (! graph.next_vertical(cp)) {
             size_t i = cp.point_idx;


### PR DESCRIPTION
# Description

This PR
- Fixes #10652
- Fixes 3 compiler Warnings:
  - fixes: arc_len_next may be used uninitialized [-Wmaybe-uninitialized]
  - fixes: may be used uninitialized [-Wmaybe-uninitialized]
