### PR TITLE
Parse placeholder tokens in the post-processing script

### DIFF
--- a/doc/print_settings/others/others_settings_post_processing_scripts.md
+++ b/doc/print_settings/others/others_settings_post_processing_scripts.md
@@ -2,11 +2,15 @@
 
 Here you can set up post-processing scripts that will be executed after slicing.  
 This allows you to modify the G-code output or perform additional tasks.
+Placeholder tokens are supported and will be replaced before scripts are executed.
 
 Check the script's documentation for dependencies, available parameters and usage instructions.
 
 Example Python script:
 
 ```shell
-"C:\Your\Path\To\Python\python.exe" "C:\Your\Path\To\Script\pythonScript.py" -parameterToScript 1994;
+"C:\Your\Path\To\Python\python.exe" "C:\Your\Path\To\Script\pythonScript.py" -parameterToScript 1994 -layerHeight {layer_height};
 ```
+
+> [!TIP]
+> Check [Built in placeholders variables](built-in-placeholders-variables) for available tokens and their meanings.

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -4094,7 +4094,8 @@ void PrintConfigDef::init_fff_params()
     def->tooltip = L("If you want to process the output G-code through custom scripts, "
                    "just list their absolute paths here. Separate multiple scripts with a semicolon. "
                    "Scripts will be passed the absolute path to the G-code file as the first argument, "
-                   "and they can access the Orca Slicer config settings by reading environment variables.");
+                   "and they can access the Orca Slicer config settings by reading environment variables. "
+                   "Filename formatting placeholders are applied.");
     def->gui_flags = "serialized";
     def->multiline = true;
     def->full_width = true;


### PR DESCRIPTION
# Description

Pass each non-empty line of post-processing script through the placeholder token parser.  Many post processing scripts are unaware of the environment variables that are set, and instead provide parameters that should be set to those values.  This change lets you use slicer variables with those scripts as written, to help eliminate crashes and other errors caused by mismatched parameters.

- Uses the existing placeholder parser used by the filename format setting
- Tooltip and wiki updated

# Screenshots/Recordings/Graphs

<img width="433" height="225" alt="image" src="https://github.com/user-attachments/assets/91cb800d-8422-430a-949d-37d26d987fa1" alt="a screenshot of the post-processing setting and tooltip in orcaslicer, showing off this new feature with a -layerHeight parameter followed by a layer_height in braces." />

## Tests

- [x] {layer_height} on windows