### PR TITLE
wip: incomplete alpine linux support

### DIFF
--- a/build_linux.sh
+++ b/build_linux.sh
@@ -202,7 +202,6 @@ if [[ -n "${BUILD_DEPS}" ]] ; then
 	  -DSLIC3R_PCH="${SLIC3R_PRECOMPILED_HEADERS}" \
 	  -DDESTDIR="${SCRIPT_PATH}/deps/build/destdir" \
 	  -DDEP_DOWNLOAD_DIR="${SCRIPT_PATH}/deps/DL_CACHE" \
-	  "${COLORED_OUTPUT}" \
 	  "${BUILD_ARGS[@]}"
     set +x
     cmake --build deps/build

--- a/scripts/linux.d/alpine
+++ b/scripts/linux.d/alpine
@@ -1,0 +1,51 @@
+#!/bin/sh
+# these are the alpine linux specific build functions
+
+if apk info --installed gtk+3.0-dev >/dev/null; then
+  FOUND_GTK3=1
+  export FOUND_GTK3
+fi
+
+# !   eglexternalplatform
+# !   ninja
+# Addtional Dev packages for OrcaSlicer
+dep='
+    cmake
+    curl-dev
+    dbus-dev
+    extra-cmake-modules
+    file-dev
+    gettext-dev
+    git
+    glew-dev
+    gstreamer-dev
+    gstreamermm-dev
+    gtk+3.0-dev
+    libmspack-dev
+    libsecret-dev
+    libspnav-dev
+    mesa-dev
+    mesa-egl
+    openssl-dev
+    samurai
+    texinfo
+    wayland-protocols-dev
+    webkit2gtk-6.0-dev
+    wget
+'
+
+if [ "$UPDATE_LIB" ]; then
+    echo "Updating packages ..."
+    for pkg in $dep; do
+        apk info --installed "$pkg" > /dev/null || req="$req $pkg"
+    done
+
+    if [ "$req" ]; then
+        doas apk add $req
+    fi
+    echo "done"
+    exit 0
+fi
+
+FOUND_GTK3_DEV="$FOUND_GTK3"
+export FOUND_GTK3_DEV


### PR DESCRIPTION
Naïve attempt at allow build for alpine linux. It is obvious that this software is targeting platforms where vendoring the world is the norm. Building deps fails with errors such as mismatches between signed and unsigned integers. I did not even bother looking at the exact details, as the path to successfully building this sure looks like a deep rabbit hole of chores.

It seems like some quality work has been started with #10309 and related pull requests. Once test runners are in place, lets hope that allows for an overhaul of the buildsystem, previously blocked by the maintainer due insufficient bandwidth for reviews. After that, maybe some decoupling of dependencies and the use of proper system libraries and sound software engineering principles may follow?

For now, I'm leaving this as a draft pull request. Primarily to document the current state for the next sucker attempting to build for alpine.