### PR TITLE
Prohibit Z move before the very first travel move

### DIFF
--- a/src/libslic3r/GCodeWriter.cpp
+++ b/src/libslic3r/GCodeWriter.cpp
@@ -669,11 +669,11 @@ std::string GCodeWriter::travel_to_xyz(const Vec3d &point, const std::string &co
         Vec3d target = { dest_point(0) - m_x_offset, dest_point(1) - m_y_offset, dest_point(2) };
         Vec3d delta = target - source;
         Vec2d delta_no_z = { delta(0), delta(1) };
-        //BBS: don'need slope travel because we don't know where is the source position the first time
+        //Orca: Only attempt slope/spiral/normal lift if current position is known
         //BBS: Also don't need to do slope move or spiral lift if x-y distance is absolute zero
-        if (delta(2) > 0 && delta_no_z.norm() != 0.0f)    {
+        if (delta(2) > 0 && delta_no_z.norm() != 0.0f && this->is_current_position_clear()) {
             //BBS: SpiralLift
-            if (m_to_lift_type == LiftType::SpiralLift && this->is_current_position_clear()) {
+            if (m_to_lift_type == LiftType::SpiralLift) {
                 //BBS: todo: check the arc move all in bed area, if not, then use lazy lift
                 double radius = delta(2) / (2 * PI * atan(this->filament()->travel_slope()));
                 Vec2d ij_offset = radius * delta_no_z.normalized();


### PR DESCRIPTION
# Description

If Z hop is active and set to `Normal` than Orca would create a Z move before the very first travel move. It could lower the nozzle too close to the bed. The setting of Z height before the start of print is the responsibility of the user to set in the start gcode.
This PR fixes it, preventing Z moves if the nozzle height is not known by the slicer.

Fixes #10964

# Screenshots/Recordings/Graphs

Before:
```
;_SET_FAN_SPEED_CHANGING_LAYER
G1 Z.6 F9000 ; normal lift Z
G1 X112.64 Y98.866 ; move to first skirt point
G1 Z.6 ; move to first skirt point
```

After:
```
;_SET_FAN_SPEED_CHANGING_LAYER
G1 X112.64 Y98.866 F9000 ; move to first skirt point
G1 Z.6 ; move to first skirt point
```

## Tests

Local build, slicing the test object from #10964
