### PR TITLE
Feature/slow_down_before_seam

### DIFF
--- a/src/libslic3r/GCode/PressureEqualizer.cpp
+++ b/src/libslic3r/GCode/PressureEqualizer.cpp
@@ -63,6 +63,9 @@ PressureEqualizer::PressureEqualizer(const Slic3r::GCodeConfig &config) : m_use_
     	m_max_volumetric_extrusion_rate_slope_negative = float(config.max_volumetric_extrusion_rate_slope.value) * 60.f * 60.f;
     	m_max_segment_length = float(config.max_volumetric_extrusion_rate_slope_segment_length.value);
         m_extrusion_rate_smoothing_external_perimeter_only = bool(config.extrusion_rate_smoothing_external_perimeter_only.value);
+        PRE_RETRACT_REDUCTION_DISTANCE = float(config.pressure_release_before_retraction_length.value);
+        PRE_RETRACT_MIN_FEED_MM_S = float(config.pressure_release_before_retraction_speed.value);
+        //ENABLE_PRE_RETRACT_REDUCTION= bool(config.enable_pressure_release_before_retraction.value);
     }
 
     for (ExtrusionRateSlope &extrusion_rate_slope : m_max_volumetric_extrusion_rate_slopes) {
@@ -106,9 +109,10 @@ void PressureEqualizer::process_layer(const std::string &gcode)
             if (*gcode_begin == '\n')
                 ++gcode_begin;
         }
+        apply_pre_retract_pressure_reduction();
         assert(!this->opened_extrude_set_speed_block);
     }
-    
+
     // at this point, we have an entire layer of gcode lines loaded into m_gcode_lines
     // now we will split the mix of travels and extrudes into segments of continous extrusion and process those
     // We skip over large travels, and pretend small ones are part of a continous extrusion segment
@@ -720,6 +724,143 @@ void PressureEqualizer::adjust_volumetric_rate(const size_t fist_line_idx, const
                 feedrate_per_extrusion_role[iRole] = line.volumetric_extrusion_rate_end;
         }
     }
+}
+
+void PressureEqualizer::apply_pre_retract_pressure_reduction()
+{
+    constexpr float EPS = 1e-6f;
+    if (PRE_RETRACT_REDUCTION_DISTANCE <= EPS || PRE_RETRACT_MIN_FEED_MM_S <= EPS) {
+        return;
+    }
+
+    // Define minimum volumetric rate in mm^3/min
+    float MIN_VOLUMETRIC_RATE = PRE_RETRACT_MIN_FEED_MM_S * 6;
+
+#ifdef PRESSURE_EQUALIZER_DEBUG
+    int retracts_found      = 0;
+    int lines_modified      = 0;
+    int outer_wall_retracts = 0;
+#endif
+
+    for (size_t line_idx = 0; line_idx < m_gcode_lines.size(); ++line_idx) {
+        GCodeLine& line = m_gcode_lines[line_idx];
+
+        // Found a retract
+        if (line.type == GCODELINETYPE_RETRACT) {
+#ifdef PRESSURE_EQUALIZER_DEBUG
+            retracts_found++;
+#endif
+            // Look ahead to see if next feature is outer wall
+            bool         next_is_outer_wall = false;
+            const size_t look_ahead_limit   = std::min(line_idx + 30, m_gcode_lines.size());
+
+            for (size_t ahead_idx = line_idx + 1; ahead_idx < look_ahead_limit; ++ahead_idx) {
+                const GCodeLine& ahead_line = m_gcode_lines[ahead_idx];
+
+                // Check if this line contains a TYPE comment
+                if (ahead_line.raw_length > 0) {
+                    std::string line_str(ahead_line.raw.data(), ahead_line.raw_length);
+
+                    // Check if this is a TYPE comment
+                    if (line_str.find(";TYPE:") != std::string::npos) {
+                        // Check if it's specifically an outer wall
+                        if (line_str.find(";TYPE:Outer wall") != std::string::npos) {
+                            next_is_outer_wall = true;
+                        }
+                        // Found a TYPE comment (whether outer wall or not), stop looking
+                        break;
+                    }
+                }
+
+                // Optional: stop at next extrude to avoid looking too far
+                if (ahead_line.type == GCODELINETYPE_EXTRUDE) {
+                    break;
+                }
+            }
+
+            // Only apply pressure reduction if next feature is outer wall
+            if (!next_is_outer_wall) {
+#ifdef PRESSURE_EQUALIZER_DEBUG
+                printf("Skipping retract at line %zu - next feature is not outer wall\n", line_idx);
+#endif
+                continue;
+            }
+
+#ifdef PRESSURE_EQUALIZER_DEBUG
+            outer_wall_retracts++;
+            printf("Found retract before outer wall at line %zu\n", line_idx);
+#endif
+
+            // Track accumulated extrusion distance going backwards
+            float  accumulated_extrusion_distance = 0.0f;
+            size_t look_back_start                = (line_idx > max_look_back_limit) ? line_idx - max_look_back_limit : 0;
+
+            // NEW: Track which lines we've already modified to avoid double-processing
+            std::unordered_set<size_t> already_modified;
+
+            // Look backwards from the retract - IMPORTANT: Start from line_idx - 1
+            for (size_t back_idx = line_idx - 1; back_idx != size_t(-1) && back_idx >= look_back_start; --back_idx) {
+                GCodeLine& back_line = m_gcode_lines[back_idx];
+
+                if (back_line.type == GCODELINETYPE_EXTRUDE) {
+                    float line_distance = back_line.dist_xyz();
+                    accumulated_extrusion_distance += line_distance;
+
+                    // Check if we're still within the reduction distance
+                    if (accumulated_extrusion_distance <= PRE_RETRACT_REDUCTION_DISTANCE) {
+                        // Only modify if we haven't already processed this line
+                        if (already_modified.find(back_idx) == already_modified.end()) {
+                            // Set to minimum speed if currently higher
+                            if (back_line.volumetric_extrusion_rate_start > MIN_VOLUMETRIC_RATE) {
+                                back_line.volumetric_extrusion_rate_start = MIN_VOLUMETRIC_RATE;
+                            }
+                            if (back_line.volumetric_extrusion_rate_end > MIN_VOLUMETRIC_RATE) {
+                                back_line.volumetric_extrusion_rate_end = MIN_VOLUMETRIC_RATE;
+                            }
+
+                            // Mark as modified
+                            back_line.modified = true;
+                            already_modified.insert(back_idx);
+
+#ifdef PRESSURE_EQUALIZER_DEBUG
+                            lines_modified++;
+                            printf("  Modified line %zu: distance %.2f mm, total %.2f mm, rates set to min: %.2f\n", back_idx,
+                                   line_distance, accumulated_extrusion_distance, MIN_VOLUMETRIC_RATE);
+#endif
+                        }
+                    } else {
+                        // We've exceeded the reduction distance, stop looking back
+#ifdef PRESSURE_EQUALIZER_DEBUG
+                        printf("  Stopped at line %zu - exceeded reduction distance (%.2f mm)\n", back_idx, accumulated_extrusion_distance);
+#endif
+                        break;
+                    }
+                } else if (back_line.type == GCODELINETYPE_MOVE) {
+                    // Travel move - don't accumulate distance but keep looking back
+                    continue;
+                } else if (back_line.type == GCODELINETYPE_RETRACT || back_line.type == GCODELINETYPE_UNRETRACT) {
+                    // CHANGED: Continue through retracts and unretracts instead of stopping
+                    // This allows us to accumulate distance across multiple retract cycles
+#ifdef PRESSURE_EQUALIZER_DEBUG
+                    printf("  Continuing through retract/unretract at line %zu (accumulated distance: %.2f mm)\n", back_idx,
+                           accumulated_extrusion_distance);
+#endif
+                    continue;
+                } else if (back_line.type == GCODELINETYPE_TOOL_CHANGE) {
+                    // Still stop at tool changes as these represent a complete pressure reset
+#ifdef PRESSURE_EQUALIZER_DEBUG
+                    printf("  Stopped at tool change (line %zu)\n", back_idx);
+#endif
+                    break;
+                }
+            }
+        }
+    }
+
+#ifdef PRESSURE_EQUALIZER_DEBUG
+    printf("Pre-retract pressure reduction: Found %d retracts (%d before outer walls), modified %d lines (min rate: %.2f mm^3/min)\n",
+           retracts_found, outer_wall_retracts, lines_modified, MIN_VOLUMETRIC_RATE);
+#endif
 }
 
 inline void PressureEqualizer::push_to_output(GCodeG1Formatter &formatter)

--- a/src/libslic3r/GCode/PressureEqualizer.cpp
+++ b/src/libslic3r/GCode/PressureEqualizer.cpp
@@ -63,8 +63,8 @@ PressureEqualizer::PressureEqualizer(const Slic3r::GCodeConfig &config) : m_use_
     	m_max_volumetric_extrusion_rate_slope_negative = float(config.max_volumetric_extrusion_rate_slope.value) * 60.f * 60.f;
     	m_max_segment_length = float(config.max_volumetric_extrusion_rate_slope_segment_length.value);
         m_extrusion_rate_smoothing_external_perimeter_only = bool(config.extrusion_rate_smoothing_external_perimeter_only.value);
-        PRE_RETRACT_REDUCTION_DISTANCE = float(config.pressure_release_before_retraction_length.value);
-        PRE_RETRACT_MIN_FEED_MM_S = float(config.pressure_release_before_retraction_speed.value);
+        PRE_RETRACT_REDUCTION_DISTANCE = float(config.slow_down_before_retraction_length.value);
+        PRE_RETRACT_MIN_FEED_MM_S = float(config.slow_down_before_retraction_speed.value);
         //ENABLE_PRE_RETRACT_REDUCTION= bool(config.enable_pressure_release_before_retraction.value);
     }
 

--- a/src/libslic3r/GCode/PressureEqualizer.hpp
+++ b/src/libslic3r/GCode/PressureEqualizer.hpp
@@ -30,7 +30,12 @@ public:
     LayerResult process_layer(LayerResult &&input);
 private:
 
+    // Pre-retract pressure reduction settings (hardcoded for now)
+    float PRE_RETRACT_REDUCTION_DISTANCE; // mm of extrusion to decelerate over
+    float PRE_RETRACT_MIN_FEED_MM_S;  // 0.3 = reduce to 30% of original speed at retract point
+    
     void process_layer(const std::string &gcode);
+    void apply_pre_retract_pressure_reduction();
 
 #ifdef PRESSURE_EQUALIZER_STATISTIC
     struct Statistics

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -833,7 +833,7 @@ static std::vector<std::string> s_Preset_print_options {
      "wall_distribution_count", "min_feature_size", "min_bead_width", "post_process", "min_length_factor",
      "small_perimeter_speed", "small_perimeter_threshold","bridge_angle","internal_bridge_angle", "filter_out_gap_fill", "travel_acceleration","inner_wall_acceleration", "min_width_top_surface",
      "default_jerk", "outer_wall_jerk", "inner_wall_jerk", "infill_jerk", "top_surface_jerk", "initial_layer_jerk","travel_jerk","default_junction_deviation",
-     "top_solid_infill_flow_ratio","bottom_solid_infill_flow_ratio","only_one_wall_first_layer", "print_flow_ratio","pressure_release_before_retraction_speed","pressure_release_before_retraction_length", "seam_gap",
+     "top_solid_infill_flow_ratio","bottom_solid_infill_flow_ratio","only_one_wall_first_layer", "print_flow_ratio","slow_down_before_retraction_speed","slow_down_before_retraction_length", "seam_gap",
      "role_based_wipe_speed", "wipe_speed", "accel_to_decel_enable", "accel_to_decel_factor", "wipe_on_loops", "wipe_before_external_loop",
      "bridge_density","internal_bridge_density", "precise_outer_wall", "bridge_acceleration",
      "sparse_infill_acceleration", "internal_solid_infill_acceleration", "tree_support_adaptive_layer_height", "tree_support_auto_brim", 

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -833,7 +833,7 @@ static std::vector<std::string> s_Preset_print_options {
      "wall_distribution_count", "min_feature_size", "min_bead_width", "post_process", "min_length_factor",
      "small_perimeter_speed", "small_perimeter_threshold","bridge_angle","internal_bridge_angle", "filter_out_gap_fill", "travel_acceleration","inner_wall_acceleration", "min_width_top_surface",
      "default_jerk", "outer_wall_jerk", "inner_wall_jerk", "infill_jerk", "top_surface_jerk", "initial_layer_jerk","travel_jerk","default_junction_deviation",
-     "top_solid_infill_flow_ratio","bottom_solid_infill_flow_ratio","only_one_wall_first_layer", "print_flow_ratio", "seam_gap",
+     "top_solid_infill_flow_ratio","bottom_solid_infill_flow_ratio","only_one_wall_first_layer", "print_flow_ratio","pressure_release_before_retraction_speed","pressure_release_before_retraction_length", "seam_gap",
      "role_based_wipe_speed", "wipe_speed", "accel_to_decel_enable", "accel_to_decel_factor", "wipe_on_loops", "wipe_before_external_loop",
      "bridge_density","internal_bridge_density", "precise_outer_wall", "bridge_acceleration",
      "sparse_infill_acceleration", "internal_solid_infill_acceleration", "tree_support_adaptive_layer_height", "tree_support_auto_brim", 

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -3832,6 +3832,32 @@ void PrintConfigDef::init_fff_params()
     def->set_default_value(new ConfigOptionBool(false));
 
 
+    def = this->add("pressure_release_before_retraction_speed", coFloat);
+    def->label   = L("Slow down to this speed before retraction");
+    def->tooltip = L(
+        "A lower value results in smoother extrusion rate transitions. However, this results in a significantly larger gcode file "
+        "and more instructions for the printer to process. \n\n"
+        "Default value of 3 works well for most cases. If your printer is stuttering, increase this value to reduce the number of "
+        "adjustments made\n\n"
+        "Allowed values: 1-5");
+    def->sidetext = L("mm/s²");
+    def->min      = 0;
+    def->mode     = comAdvanced;
+    def->set_default_value(new ConfigOptionFloat(0));
+
+    def = this->add("pressure_release_before_retraction_length", coFloat);
+    def->label   = L("The slowdown distance before retraction");
+    def->tooltip = L(
+        "A lower value results in smoother extrusion rate transitions. However, this results in a significantly larger gcode file "
+        "and more instructions for the printer to process. \n\n"
+        "Default value of 3 works well for most cases. If your printer is stuttering, increase this value to reduce the number of "
+        "adjustments made\n\n"
+        "Allowed values: 1-5");
+    def->sidetext = L("mm");
+    def->min      = 0;
+    def->mode     = comAdvanced;
+    def->set_default_value(new ConfigOptionFloat(0));
+
     def = this->add("fan_min_speed", coFloats);
     def->label = L("Fan speed");
     def->tooltip = L("Minimum speed for part cooling fan.");

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -3833,11 +3833,11 @@ void PrintConfigDef::init_fff_params()
 
 
     def = this->add("slow_down_before_retraction_speed", coFloat);
-    def->label   = L("Slow down before seam");
+    def->label   = L("Slow down to this speed before seam");
     def->tooltip = L(
         "Slowing down before the seam can help releasing the pressure build-up in the nozzle, results in better seam quality. \n\n"
         "10 is recommended. 0 will disable this feature.");
-    def->sidetext = L("mm/s²");
+    def->sidetext = L("mm/s");
     def->min      = 0;
     def->mode     = comAdvanced;
     def->set_default_value(new ConfigOptionFloat(0));

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -3832,27 +3832,21 @@ void PrintConfigDef::init_fff_params()
     def->set_default_value(new ConfigOptionBool(false));
 
 
-    def = this->add("pressure_release_before_retraction_speed", coFloat);
-    def->label   = L("Slow down to this speed before retraction");
+    def = this->add("slow_down_before_retraction_speed", coFloat);
+    def->label   = L("Slow down before seam");
     def->tooltip = L(
-        "A lower value results in smoother extrusion rate transitions. However, this results in a significantly larger gcode file "
-        "and more instructions for the printer to process. \n\n"
-        "Default value of 3 works well for most cases. If your printer is stuttering, increase this value to reduce the number of "
-        "adjustments made\n\n"
-        "Allowed values: 1-5");
+        "Slowing down before the seam can help releasing the pressure build-up in the nozzle, results in better seam quality. \n\n"
+        "10 is recommended. 0 will disable this feature.");
     def->sidetext = L("mm/s²");
     def->min      = 0;
     def->mode     = comAdvanced;
     def->set_default_value(new ConfigOptionFloat(0));
 
-    def = this->add("pressure_release_before_retraction_length", coFloat);
-    def->label   = L("The slowdown distance before retraction");
+    def = this->add("slow_down_before_retraction_length", coFloat);
+    def->label   = L("The slowdown distance before seam");
     def->tooltip = L(
-        "A lower value results in smoother extrusion rate transitions. However, this results in a significantly larger gcode file "
-        "and more instructions for the printer to process. \n\n"
-        "Default value of 3 works well for most cases. If your printer is stuttering, increase this value to reduce the number of "
-        "adjustments made\n\n"
-        "Allowed values: 1-5");
+        "Slowing down before the seam can help releasing the pressure build-up in the nozzle, results in better seam quality. \n\n"
+        "30 is usually enough. 0 will disable this feature.");
     def->sidetext = L("mm");
     def->min      = 0;
     def->mode     = comAdvanced;

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -1183,7 +1183,8 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionFloat,               max_volumetric_extrusion_rate_slope))
     ((ConfigOptionFloat,               max_volumetric_extrusion_rate_slope_segment_length))
     ((ConfigOptionBool,               extrusion_rate_smoothing_external_perimeter_only))
-
+    ((ConfigOptionFloat,               pressure_release_before_retraction_speed))
+    ((ConfigOptionFloat,               pressure_release_before_retraction_length))
     
     ((ConfigOptionPercents,            retract_before_wipe))
     ((ConfigOptionFloats,              retraction_length))

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -1183,8 +1183,8 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionFloat,               max_volumetric_extrusion_rate_slope))
     ((ConfigOptionFloat,               max_volumetric_extrusion_rate_slope_segment_length))
     ((ConfigOptionBool,               extrusion_rate_smoothing_external_perimeter_only))
-    ((ConfigOptionFloat,               pressure_release_before_retraction_speed))
-    ((ConfigOptionFloat,               pressure_release_before_retraction_length))
+    ((ConfigOptionFloat,               slow_down_before_retraction_speed))
+    ((ConfigOptionFloat,               slow_down_before_retraction_length))
     
     ((ConfigOptionPercents,            retract_before_wipe))
     ((ConfigOptionFloats,              retraction_length))

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -2337,8 +2337,8 @@ void TabPrint::build()
         optgroup->append_single_option_line("max_volumetric_extrusion_rate_slope", "speed_settings_advanced");
         optgroup->append_single_option_line("max_volumetric_extrusion_rate_slope_segment_length", "speed_settings_advanced");
         optgroup->append_single_option_line("extrusion_rate_smoothing_external_perimeter_only", "speed_settings_advanced");
-        optgroup->append_single_option_line("pressure_release_before_retraction_speed");
-        optgroup->append_single_option_line("pressure_release_before_retraction_length");
+        optgroup->append_single_option_line("slow_down_before_retraction_speed");
+        optgroup->append_single_option_line("slow_down_before_retraction_length");
     page = add_options_page(L("Support"), "custom-gcode_support"); // ORCA: icon only visible on placeholders
         optgroup = page->new_optgroup(L("Support"), L"param_support");
     optgroup->append_single_option_line("enable_support", "support_settings_support");

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -2337,7 +2337,8 @@ void TabPrint::build()
         optgroup->append_single_option_line("max_volumetric_extrusion_rate_slope", "speed_settings_advanced");
         optgroup->append_single_option_line("max_volumetric_extrusion_rate_slope_segment_length", "speed_settings_advanced");
         optgroup->append_single_option_line("extrusion_rate_smoothing_external_perimeter_only", "speed_settings_advanced");
-
+        optgroup->append_single_option_line("pressure_release_before_retraction_speed");
+        optgroup->append_single_option_line("pressure_release_before_retraction_length");
     page = add_options_page(L("Support"), "custom-gcode_support"); // ORCA: icon only visible on placeholders
         optgroup = page->new_optgroup(L("Support"), L"param_support");
     optgroup->append_single_option_line("enable_support", "support_settings_support");


### PR DESCRIPTION
# Description
In short, slowing down before the seam helps releasing the pressure in the nozzle and improving the seam quality. Usually the seam looks the worst after printing solid infill and/or printing at high speed(lots of pressure build up).
Here is a good explaination I found from #4264.@HakunMatat4 had the right idea, but this feature specifically target the seam and does it better than the current pressure equalizer.
<img width="983" height="632" alt="Screenshot 2025-10-17 160053" src="https://github.com/user-attachments/assets/006019e3-651d-4a56-add7-e29be17fdf3b" />

Here is the test result printing the same stick, without this feature; with 30mm slow down to 10mm/s; and with 200mm slow down to 10mm/s
<img width="1643" height="467" alt="Screenshot 2025-10-17 161343" src="https://github.com/user-attachments/assets/34438a61-739e-413c-b5c7-6e8883310236" />
![IMG_3936](https://github.com/user-attachments/assets/43b6c921-5273-4cd7-a1c4-bc3d3bfbcba7)
![IMG_3937](https://github.com/user-attachments/assets/8a6a8386-227e-4036-9d1d-63a76cf925e5)
![IMG_3941](https://github.com/user-attachments/assets/1b59fb23-d596-4b50-bb63-f92c260a5b63)

# Screenshots/Recordings/Graphs
I implemented it as part of extrusion rate smooting, so we have to turn on extrusion rate smoothing to use it. Set it to 1000 mm3/s2(basically disabling it without turning it off). Then you can set the slow down speed and slow down distance.
<img width="344" height="280" alt="Screenshot 2025-10-17 162011" src="https://github.com/user-attachments/assets/21ded282-3be6-4b4e-88d4-627e889f02a7" />


## Tests
The initial results look promising.

This is a feature requested by my colleague and I implemented it for our fork of orcaslicer. We will continue to test this internally for our printers. Just putting it out here so anyone can try it