### PR TITLE
Perimeter overlap parameter (in tab Strength)

### DIFF
--- a/src/libslic3r/PerimeterGenerator.cpp
+++ b/src/libslic3r/PerimeterGenerator.cpp
@@ -559,6 +559,10 @@ void PerimeterGenerator::split_top_surfaces(const ExPolygons &orig_polygons, ExP
     coord_t ext_perimeter_width = this->ext_perimeter_flow.scaled_width();
     coord_t ext_perimeter_spacing = this->ext_perimeter_flow.scaled_spacing();
 
+    // Adjusts perimeter spacing according to the configured overlap percentage
+    perimeter_spacing *= (1.0 - (this->config->perimeter_overlap / 100.0f));
+    ext_perimeter_spacing *= (1.0 - (this->config->perimeter_overlap / 100.0f));
+
     bool has_gap_fill = this->config->gap_infill_speed.value > 0;
 
     // split the polygons with top/not_top
@@ -1134,6 +1138,11 @@ void PerimeterGenerator::process_classic()
     else
         ext_perimeter_spacing2 = scaled<coord_t>(0.5f * (this->ext_perimeter_flow.spacing() + this->perimeter_flow.spacing()));
     
+    // Adjusts perimeter spacing according to the configured overlap percentage
+    perimeter_spacing *= (1.0 - (this->config->perimeter_overlap / 100.0f));
+    ext_perimeter_spacing *= (1.0 - (this->config->perimeter_overlap / 100.0f));
+    ext_perimeter_spacing2 *= (1.0 - (this->config->perimeter_overlap / 100.0f));
+
     // overhang perimeters
     m_mm3_per_mm_overhang      		= this->overhang_flow.mm3_per_mm();
     

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -849,6 +849,7 @@ static std::vector<std::string> s_Preset_print_options {
      "small_area_infill_flow_compensation", "small_area_infill_flow_compensation_model",
      "seam_slope_type", "seam_slope_conditional", "scarf_angle_threshold", "scarf_joint_speed", "scarf_joint_flow_ratio", "seam_slope_start_height", "seam_slope_entire_loop", "seam_slope_min_length", "seam_slope_steps", "seam_slope_inner_walls", "scarf_overhang_threshold",
      "interlocking_beam", "interlocking_orientation", "interlocking_beam_layer_count", "interlocking_depth", "interlocking_boundary_avoidance", "interlocking_beam_width","calib_flowrate_topinfill_special_order",
+     "perimeter_overlap"
 };
 
 static std::vector<std::string> s_Preset_filament_options {

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -1725,7 +1725,7 @@ void PrintConfigDef::init_fff_params()
     def           = this->add("perimeter_overlap", coPercent);
     def->label    = L("Extra wall overlap");
     def->category = L("Advanced");
-    def->tooltip  = L("This parameter increases the default wall overlap by a percentage. The percentage value is relative to wall line width."
+    def->tooltip  = L("This parameter increases the default wall overlap by a percentage. The percentage value is relative to wall line width. "
                       "Increasing this value improves wall adhesion, especially when using small nozzles that struggle to bond walls consistently across some directions.\n"
                       "Works only with classic wall generator.");
 

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -1721,7 +1721,20 @@ void PrintConfigDef::init_fff_params()
     def->enum_labels.push_back(L("All"));
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionEnum<EnsureVerticalShellThickness>(EnsureVerticalShellThickness::evstAll));
-    
+
+    def           = this->add("perimeter_overlap", coPercent);
+    def->label    = L("Extra wall overlap");
+    def->category = L("Advanced");
+    def->tooltip  = L("This parameter increases the default wall overlap by a percentage. The percentage value is relative to wall line width."
+                      "Increasing this value improves wall adhesion, especially when using small nozzles that struggle to bond walls consistently across some directions.\n"
+                      "Works only with classic wall generator.");
+
+    def->sidetext = "%";
+    def->min      = 0;
+    def->max      = 50;
+    def->mode     = comAdvanced;
+    def->set_default_value(new ConfigOptionPercent(0.0f));
+
     auto def_top_fill_pattern = def = this->add("top_surface_pattern", coEnum);
     def->label = L("Top surface pattern");
     def->category = L("Strength");

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -966,6 +966,7 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionFloat,                bridge_speed))
     ((ConfigOptionFloatOrPercent,       internal_bridge_speed))
     ((ConfigOptionEnum<EnsureVerticalShellThickness>,   ensure_vertical_shell_thickness))
+    ((ConfigOptionPercent,              perimeter_overlap))
     ((ConfigOptionPercent,              top_surface_density))
     ((ConfigOptionPercent,               bottom_surface_density))
     ((ConfigOptionEnum<InfillPattern>,  top_surface_pattern))

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -9933,6 +9933,7 @@ void adjust_settings_for_flowrate_calib(ModelObjectPtrs& objects, bool linear, i
         _obj->config.set_key_value("gap_fill_target", new ConfigOptionEnum<GapFillTarget>(GapFillTarget::gftNowhere));
         print_config->set_key_value("max_volumetric_extrusion_rate_slope", new ConfigOptionFloat(0));
         _obj->config.set_key_value("calib_flowrate_topinfill_special_order", new ConfigOptionBool(true));
+        _obj->config.set_key_value("perimeter_overlap", new ConfigOptionPercent(0.0f));
 
         // extract flowrate from name, filename format: flowrate_xxx
         std::string obj_name = _obj->name;

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -2281,6 +2281,8 @@ void TabPrint::build()
         optgroup->append_single_option_line("infill_combination_max_layer_height", "strength_settings_advanced#max-layer-height");
         optgroup->append_single_option_line("detect_narrow_internal_solid_infill", "strength_settings_advanced#detect-narrow-internal-solid-infill");
         optgroup->append_single_option_line("ensure_vertical_shell_thickness", "strength_settings_advanced#ensure-vertical-shell-thickness");
+        optgroup->append_single_option_line("perimeter_overlap", "strength_settings_advanced#perimeter_overlap");
+
 
     page = add_options_page(L("Speed"), "custom-gcode_speed"); // ORCA: icon only visible on placeholders
         optgroup = page->new_optgroup(L("Initial layer speed"), L"param_speed_first", 15);


### PR DESCRIPTION
# Description
A new perimeter-overlap setting has been introduced to enhance wall bonding by increasing the default overlap between walls by a specified percentage. This percentage is calculated relative to the wall line width. Boosting this value improves adhesion, particularly when using small nozzles that may struggle to maintain consistent wall bonding across different directions.

This feature is compatible only with the classic wall generator.

Its primary benefit is maintaining dimensional accuracy more effectively than simply increasing the overall flow rate. For optimal results, a slight increase in the internal wall flow ratio (see #10641) combined with this perimeter-overlap setting can further improve wall bonding quality.

Note : the term "perimeter" is used internally within the C++ codebase, whereas "wall" is the terminology presented to end users

# Screenshots/Recordings/Graphs
Parameter named "Extra wall overlap" in the strength tab :
<img width="448" height="551" alt="image" src="https://github.com/user-attachments/assets/b3be83dd-1520-4057-b27d-a5851e70a619" />

Default wall overlap :
<img width="392" height="278" alt="image" src="https://github.com/user-attachments/assets/fb371869-d539-4b6f-b7d6-896afaa71e86" />

10% extra overlap :
<img width="398" height="281" alt="image" src="https://github.com/user-attachments/assets/e729ccc4-f1dc-4463-a261-9d8ff177cea3" />

20% extra overlap :
<img width="398" height="282" alt="image" src="https://github.com/user-attachments/assets/6cf90919-454e-426a-81ff-6b7fe58a820e" />

Max overlap is set to 50%

Naturally, increasing the overlap too much can lead to visible artifacts that compromise surface finish. However, if—like in my case—structural strength takes priority over visual perfection, this trade-off can be well worth it.

## Tests
Extensive testing was conducted using a 0.20 mm nozzle on a printer (brand intentionally omitted) that consistently failed to achieve proper perimeter bonding when printing in the +X+Y direction.

Note: This pull request is a replacement of PR #10816, originally submitted in September. That earlier PR also introduced internal perimeter flow ratio adjustments but overlapped (an overlapping overlap feature, sic) with PR #10641. In contrast, this new perimeter-overlap PR focuses solely on wall overlap and does not include any parameters for internal perimeter flow ratio, which are now fully covered by PR #10641.