### PR TITLE
feat(viewer): Display travel distance and move count in G-code summary

### DIFF
--- a/src/libslic3r/GCode/GCodeProcessor.cpp
+++ b/src/libslic3r/GCode/GCodeProcessor.cpp
@@ -3752,9 +3752,10 @@ void GCodeProcessor::process_G1(const GCodeReader::GCodeLine& line, const std::o
         return;
 
     EMoveType type = move_type(delta_pos);
+    const float delta_xyz = std::sqrt(sqr(delta_pos[X]) + sqr(delta_pos[Y]) + sqr(delta_pos[Z]));
+    m_travel_dist = delta_xyz;
+
     if (type == EMoveType::Extrude) {
-        const float delta_xyz = std::sqrt(sqr(delta_pos[X]) + sqr(delta_pos[Y]) + sqr(delta_pos[Z]));
-        m_travel_dist = delta_xyz;
         float volume_extruded_filament = area_filament_cross_section * delta_pos[E];
         float area_toolpath_cross_section = volume_extruded_filament / delta_xyz;
 
@@ -5628,6 +5629,11 @@ void GCodeProcessor::store_move_vertex(EMoveType type, EMovePathType path_type)
     m_last_line_id = (type == EMoveType::Color_change || type == EMoveType::Pause_Print || type == EMoveType::Custom_GCode) ?
         m_line_id + 1 :
         ((type == EMoveType::Seam) ? m_last_line_id : m_line_id);
+
+    if (type == EMoveType::Travel) {
+        m_result.print_statistics.total_travel_moves++;
+        m_result.print_statistics.total_travel_distance += m_travel_dist;
+    }
 
     //BBS: apply plate's and extruder's offset to arc interpolation points
     if (path_type == EMovePathType::Arc_move_cw ||

--- a/src/libslic3r/GCode/GCodeProcessor.hpp
+++ b/src/libslic3r/GCode/GCodeProcessor.hpp
@@ -87,6 +87,8 @@ class Print;
         std::array<Mode, static_cast<size_t>(ETimeMode::Count)> modes;
         unsigned int                                        total_filament_changes;
         unsigned int                                        total_extruder_changes;
+        float                                               total_travel_distance;
+        unsigned int                                        total_travel_moves;
 
         PrintEstimatedStatistics() { reset(); }
 
@@ -104,6 +106,8 @@ class Print;
             used_filaments_per_role.clear();
             total_filament_changes = 0;
             total_extruder_changes = 0;
+            total_travel_distance = 0.0f;
+            total_travel_moves = 0;
         }
     };
 


### PR DESCRIPTION
# Description

This PR implements the idea proposed in #5269 for a Tool path odometer. 

This PR introduces a new feature that enhances the G-code viewer by displaying the total travel distance and the total number of independent travel segments (moves) in the 'Line Type' summary.

This provides users with more detailed statistics about their prints, helping them to better understand the printer's behavior and identify opportunities to optimize travel moves for faster print times.

It could be very helpful for any future implementations of different Travel path optimization algorithms, such as the Traveling Salesperson Problem (TSP), so that each can be compared.

This PR also fixes a bug in the G-code processor that caused the travel distance to be calculated incorrectly in `GCodeProcessor::process_G1` of `src/libslic3r/GCode/GCodeProcessor.cpp`. The distance variable was not updated for non-extruding travel moves, resulting in inaccurate statistics. The calculation has been corrected to ensure it is performed for all relevant move types, resulting in accurate travel distance reporting. The same issue exists in `GCodeProcessor::process_VG1`, but it doesn't contribute to the travel path calculations, so it was left alone.

The G-Code processor bug manifested as a total travel distance exceeding 7 metres for a 20mm x 20mm x 20mm Cube on a plate, which seemed excessive under the slicer's default settings. Analysis of the G-code indicated we should expect closer to 4m. With the fix to `GCodeProcessor::process_G1`, the total distance for the same 20mm x 20mm x 20mm Cube is ~4m, as expected (see screenshot below). 

OrcaSlicers travel distance calculations now correctly match those of the exported `.gcode` file. Minor differences in how C++ and Python handle floating-point arithmetic can lead to small variations in the final calculated distance. The results are within the margin of acceptable difference (~4cm over 333m == 0.012%).

# Screenshots/Recordings/Graphs

The screenshot shows the new additional travel distance and number of segments (travel moves)

<img width="1606" height="912" alt="Screenshot 2025-10-28 at 10 17 11 PM" src="https://github.com/user-attachments/assets/c6fa6919-2f88-411d-b9aa-c0a9bfdb3fdd" />

<img width="1606" height="912" alt="Screenshot 2025-10-28 at 10 05 00 PM" src="https://github.com/user-attachments/assets/040e8e5c-220c-499b-9d2e-f97433c70209" />

## Tests

- Tested with various numbers of objects. 
  - 1 x Cube
    - Create a new plate
    - Right Click -> Add Primative -> Cube
    - Slice Plate
    - Select "Line Type"
    - Observe the "Travel" row
  - Full Plate
    - Create a new plate
    - Right Click -> Add Primative -> Cube
    - Left Click the Cube to select it
    - Right Click -> Fill bed with instances
    - Slice Plate
    - Select "Line Type"
    - Observe the "Travel" row
- Compared the OrcaSlicer Travel results with a Python implementation of the OrcaSlicer calculations and the necesary G-Code operations.
