### PR TITLE
Machine Input Shaping

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -3928,9 +3928,10 @@ void GCode::print_machine_envelope(GCodeOutputStream &file, Print &print)
 
         // Orca: Override input shaping values
         if (print.config().input_shaping_emit.value && flavor != gcfMarlinLegacy) {
+            const bool input_shaping_disable = print.config().input_shaping_type.value == InputShaperType::Disable;
             file.write_format(writer().set_input_shaping('X', print.config().input_shaping_damp_x.value,
                 print.config().input_shaping_freq_x.value, print.config().opt_serialize("input_shaping_type")).c_str());
-            if (flavor != gcfRepRapFirmware){
+            if (flavor != gcfRepRapFirmware && !input_shaping_disable) {
                 file.write_format(writer().set_input_shaping('Y', print.config().input_shaping_damp_y.value,
                     print.config().input_shaping_freq_y.value, "").c_str());
             }

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -3923,7 +3923,11 @@ void GCode::print_machine_envelope(GCodeOutputStream &file, Print &print)
             print.config().machine_max_jerk_z.values.front() * factor,
             print.config().machine_max_jerk_e.values.front() * factor);
 
-        if (print.config().input_shaping_enable.value && flavor != gcfMarlinLegacy) {
+        // New Marlin uses M205 J[mm] for junction deviation (only apply if it is > 0)
+        file.write_format(writer().set_junction_deviation(config().machine_max_junction_deviation.values.front()).c_str());
+
+        // Orca: Override input shaping values
+        if (print.config().input_shaping_emit.value && flavor != gcfMarlinLegacy) {
             file.write_format(writer().set_input_shaping('X', print.config().input_shaping_damp_x.value,
                 print.config().input_shaping_freq_x.value, print.config().opt_serialize("input_shaping_type")).c_str());
             if (flavor != gcfRepRapFirmware){
@@ -3931,8 +3935,6 @@ void GCode::print_machine_envelope(GCodeOutputStream &file, Print &print)
                     print.config().input_shaping_freq_y.value, "").c_str());
             }
         }
-        // New Marlin uses M205 J[mm] for junction deviation (only apply if it is > 0)
-        file.write_format(writer().set_junction_deviation(config().machine_max_junction_deviation.values.front()).c_str());
     }
 }
 

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -3923,6 +3923,14 @@ void GCode::print_machine_envelope(GCodeOutputStream &file, Print &print)
             print.config().machine_max_jerk_z.values.front() * factor,
             print.config().machine_max_jerk_e.values.front() * factor);
 
+        if (print.config().input_shaping_enable.value && flavor != gcfMarlinLegacy) {
+            file.write_format(writer().set_input_shaping('X', print.config().input_shaping_damp_x.value,
+                print.config().input_shaping_freq_x.value, print.config().opt_serialize("input_shaping_type")).c_str());
+            if (flavor != gcfRepRapFirmware){
+                file.write_format(writer().set_input_shaping('Y', print.config().input_shaping_damp_y.value,
+                    print.config().input_shaping_freq_y.value, "").c_str());
+            }
+        }
         // New Marlin uses M205 J[mm] for junction deviation (only apply if it is > 0)
         file.write_format(writer().set_junction_deviation(config().machine_max_junction_deviation.values.front()).c_str());
     }

--- a/src/libslic3r/GCodeWriter.cpp
+++ b/src/libslic3r/GCodeWriter.cpp
@@ -350,7 +350,7 @@ std::string GCodeWriter::set_accel_and_jerk(unsigned int acceleration, double je
 
 std::string GCodeWriter::set_junction_deviation(double junction_deviation){
     std::ostringstream gcode;
-    if (FLAVOR_IS(gcfMarlinFirmware) && junction_deviation > 0 && m_max_junction_deviation > 0) {
+    if (FLAVOR_IS(gcfMarlinFirmware) && m_max_junction_deviation > 0 && junction_deviation > 0) {
         // Clamp the junction deviation to the allowed maximum.
         gcode << "M205 J";
         if (junction_deviation <= m_max_junction_deviation) {

--- a/src/libslic3r/GCodeWriter.cpp
+++ b/src/libslic3r/GCodeWriter.cpp
@@ -390,6 +390,7 @@ std::string GCodeWriter::set_pressure_advance(double pa) const
     return gcode.str();
 }
 
+// Orca: input shaping support
 std::string GCodeWriter::set_input_shaping(char axis, float damp, float freq, std::string type) const
 {
     bool disable = type == "Disable";

--- a/src/libslic3r/GCodeWriter.cpp
+++ b/src/libslic3r/GCodeWriter.cpp
@@ -399,7 +399,7 @@ std::string GCodeWriter::set_input_shaping(char axis, float damp, float freq, st
         axis = 'A';
         type = "Default";
     } else if (freq < 0.0f || damp < 0.f || damp > 1.0f || (axis != 'X' && axis != 'Y' && axis != 'Z' && axis != 'A')) { // A = all axis
-        throw std::runtime_error("Invalid input shaping parameters: freq=" + std::to_string(freq) + ", damp=" + std::to_string(damp));
+        throw std::runtime_error("Invalid input shaping parameters: axis=" + std::string(1, axis) + ", freq=" + std::to_string(freq) + ", damp=" + std::to_string(damp));
     }
     std::ostringstream gcode;
     std::ostringstream params;

--- a/src/libslic3r/GCodeWriter.cpp
+++ b/src/libslic3r/GCodeWriter.cpp
@@ -392,66 +392,85 @@ std::string GCodeWriter::set_pressure_advance(double pa) const
 
 std::string GCodeWriter::set_input_shaping(char axis, float damp, float freq, std::string type) const
 {
-    if (FLAVOR_IS(gcfMarlinLegacy))
-        throw std::runtime_error("Input shaping is not supported by Marlin < 2.1.2.\nCheck your firmware version and update your G-code flavor to ´Marlin 2´");
-    if (freq < 0.0f || damp < 0.f || damp > 1.0f || (axis != 'X' && axis != 'Y' && axis != 'Z' && axis != 'A'))// A = all axis
-    {
-    throw std::runtime_error("Invalid input shaping parameters: freq=" + std::to_string(freq) + ", damp=" + std::to_string(damp));
+    bool disable = type == "Disable";
+    if (disable){
+        freq = 0.0f;
+        damp = 0.0f;
+        axis = 'A';
+        type = "Default";
+    } else if (freq < 0.0f || damp < 0.f || damp > 1.0f || (axis != 'X' && axis != 'Y' && axis != 'Z' && axis != 'A')) { // A = all axis
+        throw std::runtime_error("Invalid input shaping parameters: freq=" + std::to_string(freq) + ", damp=" + std::to_string(damp));
     }
     std::ostringstream gcode;
-    if (FLAVOR_IS(gcfKlipper)) {
-        gcode << "SET_INPUT_SHAPER";
+    std::ostringstream params;
+    switch (this->config.gcode_flavor) {
+    case gcfKlipper: {
         if (!type.empty() && type != "Default") {
-                gcode << " SHAPER_TYPE=" << type;
+            params << " SHAPER_TYPE=" << type;
         }
         if (axis != 'A')
         {
             if (freq > 0.0f) {
-                gcode << " SHAPER_FREQ_" << axis << "=" << std::fixed << std::setprecision(2) << freq;
-            }
-            if (damp > 0.0f){
-                gcode  << " DAMPING_RATIO_" << axis << "=" << std::fixed << std::setprecision(3) << damp;
-            }
-        } else {
-            if (freq > 0.0f) {
-                gcode << " SHAPER_FREQ_X=" << std::fixed << std::setprecision(2) << freq << " SHAPER_FREQ_Y=" << std::fixed << std::setprecision(2) << freq;
+                params << " SHAPER_FREQ_" << axis << "=" << std::fixed << std::setprecision(2) << freq;
             }
             if (damp > 0.0f) {
-                gcode << " DAMPING_RATIO_X=" << std::fixed << std::setprecision(3) << damp << " DAMPING_RATIO_Y=" << std::fixed << std::setprecision(3) << damp;
+                params << " DAMPING_RATIO_" << axis << "=" << std::fixed << std::setprecision(3) << damp;
+            }
+        } else {
+            if (freq > 0.0f || disable) {
+                params << " SHAPER_FREQ_X=" << std::fixed << std::setprecision(2) << freq << " SHAPER_FREQ_Y=" << std::fixed << std::setprecision(2) << freq;
+            }
+            if (damp > 0.0f || disable) {
+                params << " DAMPING_RATIO_X=" << std::fixed << std::setprecision(3) << damp << " DAMPING_RATIO_Y=" << std::fixed << std::setprecision(3) << damp;
             }
         }
-    } else if (FLAVOR_IS(gcfRepRapFirmware)) {
-        gcode << "M593";
+        if (!params.str().empty()) {
+            gcode << "SET_INPUT_SHAPER" << params.str();
+        }
+        break;
+    }
+    case gcfRepRapFirmware: {
         if (!type.empty() && type != "Default" && type != "DAA") {
-            gcode << " P\"" << type << "\"";
+            params << " P\"" << type << "\"";
         }
-        if (freq > 0.0f) {
-            gcode << " F" << std::fixed << std::setprecision(2) << freq;
+        if (freq > 0.0f || disable) {
+            params << " F" << std::fixed << std::setprecision(2) << freq;
         }
-        if (damp > 0.0f){
-            gcode  << " S" << std::fixed << std::setprecision(3) << damp;
+        if (damp > 0.0f || disable) {
+            params << " S" << std::fixed << std::setprecision(3) << damp;
         }
-    } else if (FLAVOR_IS(gcfMarlinFirmware)) {
-        gcode << "M593";
-        if (axis != 'A')
-        {
-            gcode << " " << axis;
+        if (!params.str().empty()) {
+            gcode << "M593" << params.str();
         }
-        if (freq > 0.0f)
-        {
-            gcode << " F" << std::fixed << std::setprecision(2) << freq;
+        break;
+    }
+    case gcfMarlinFirmware: {
+        if (axis != 'A') {
+            params << " " << axis;
         }
-        if (damp > 0.0f)
-        {
-            gcode << " D" << std::fixed << std::setprecision(3) << damp;
+        if (freq > 0.0f || disable) {
+            params << " F" << std::fixed << std::setprecision(2) << freq;
         }
-    } else {
+        if (damp > 0.0f || disable) {
+            params << " D" << std::fixed << std::setprecision(3) << damp;
+        }
+        if (!params.str().empty()) {
+            gcode << "M593" << params.str();
+        }
+        break;
+    }
+    case gcfMarlinLegacy: {
+        throw std::runtime_error("Input shaping is not supported by Marlin < 2.1.2.\nCheck your firmware version and update your G-code flavor to ´Marlin 2´");
+    }
+    default:
         throw std::runtime_error("Input shaping is only supported by Klipper, RepRapFirmware and Marlin 2");
     }
-    if (GCodeWriter::full_gcode_comment){
-        gcode << " ; Override input shaping";
+    if (!gcode.str().empty()) {
+        if (GCodeWriter::full_gcode_comment) {
+            gcode << " ; Override input shaping";
+        }
+        gcode << "\n";
     }
-    gcode << "\n";
     return gcode.str();
 }
 

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -1319,7 +1319,7 @@ static std::vector<std::string> s_Preset_machine_limits_options {
     //resonance avoidance ported from qidi slicer
     "resonance_avoidance", "min_resonance_avoidance_speed", "max_resonance_avoidance_speed",
     // Orca: input shaping
-    "input_shaping_enable", "input_shaping_type", "input_shaping_freq_x", "input_shaping_freq_y", "input_shaping_damp_x", "input_shaping_damp_y",
+    "input_shaping_emit", "input_shaping_type", "input_shaping_freq_x", "input_shaping_freq_y", "input_shaping_damp_x", "input_shaping_damp_y",
 };
 
 static std::vector<std::string> s_Preset_printer_options {

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -1318,6 +1318,7 @@ static std::vector<std::string> s_Preset_machine_limits_options {
     "machine_max_junction_deviation",
     //resonance avoidance ported from qidi slicer
     "resonance_avoidance", "min_resonance_avoidance_speed", "max_resonance_avoidance_speed",
+    // Orca: input shaping
     "input_shaping_enable", "input_shaping_type", "input_shaping_freq_x", "input_shaping_freq_y", "input_shaping_damp_x", "input_shaping_damp_y",
 };
 

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -1318,6 +1318,7 @@ static std::vector<std::string> s_Preset_machine_limits_options {
     "machine_max_junction_deviation",
     //resonance avoidance ported from qidi slicer
     "resonance_avoidance", "min_resonance_avoidance_speed", "max_resonance_avoidance_speed",
+    "input_shaping_enable", "input_shaping_type", "input_shaping_freq_x", "input_shaping_freq_y", "input_shaping_damp_x", "input_shaping_damp_y",
 };
 
 static std::vector<std::string> s_Preset_printer_options {

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -4495,7 +4495,7 @@ void PrintConfigDef::init_fff_params()
     def          = this->add("input_shaping_emit", coBool);
     def->label   = L("Emit input shaping");
     def->tooltip = L("Override firmware input shaping settings.\nIf disabled, firmware settings are used.");
-    def->mode    = comAdvanced;
+    def->mode    = comExpert;
     def->set_default_value(new ConfigOptionBool(false));
 
     def               = this->add("input_shaping_type", coEnum);
@@ -4504,7 +4504,7 @@ void PrintConfigDef::init_fff_params()
     def->enum_keys_map = &ConfigOptionEnum<InputShaperType>::get_enum_values();
     def->enum_values  = {"Default", "MZV", "ZV", "ZVD", "ZVDD", "ZVDDD", "EI", "EI2", "2HUMP_EI", "EI3", "3HUMP_EI", "DAA", "Disable"};
     def->enum_labels  = {L("Default"), L("MZV"), L("ZV"), L("ZVD"), L("ZVDD"), L("ZVDDD"), L("EI"), L("EI2"), L("2HUMP_EI"), L("EI3"), L("3HUMP_EI"), L("DAA"), L("Disable")};
-    def->mode         = comAdvanced;
+    def->mode         = comExpert;
     def->set_default_value(new ConfigOptionEnum<InputShaperType>(InputShaperType::Default));
 
     def           = this->add("input_shaping_freq_x", coFloat);
@@ -4513,7 +4513,7 @@ void PrintConfigDef::init_fff_params()
     def->sidetext = "Hz";
     def->min      = 0;
     def->max      = 1000;
-    def->mode     = comAdvanced;
+    def->mode     = comExpert;
     def->set_default_value(new ConfigOptionFloat(0));
 
     def           = this->add("input_shaping_freq_y", coFloat);
@@ -4522,7 +4522,7 @@ void PrintConfigDef::init_fff_params()
     def->sidetext = "Hz";
     def->min      = 0;
     def->max      = 1000;
-    def->mode     = comAdvanced;
+    def->mode     = comExpert;
     def->set_default_value(new ConfigOptionFloat(0));
 
     def          = this->add("input_shaping_damp_x", coFloat);
@@ -4530,7 +4530,7 @@ void PrintConfigDef::init_fff_params()
     def->tooltip = L("Damping ratio for the X axis input shaper.\nZero will use the firmware damping ratio.\nTo disable input shaping, use the Disable type.\nRRF: X and Y values are equal.");
     def->min     = 0;
     def->max     = 1;
-    def->mode    = comAdvanced;
+    def->mode    = comExpert;
     def->set_default_value(new ConfigOptionFloat(0.1));
 
     def          = this->add("input_shaping_damp_y", coFloat);
@@ -4538,7 +4538,7 @@ void PrintConfigDef::init_fff_params()
     def->tooltip = L("Damping ratio for the Y axis input shaper.\nZero will use the firmware damping ratio.\nTo disable input shaping, use the Disable type.");
     def->min     = 0;
     def->max     = 1;
-    def->mode    = comAdvanced;
+    def->mode    = comExpert;
     def->set_default_value(new ConfigOptionFloat(0.1));
 
     def = this->add("fan_max_speed", coFloats);

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -487,8 +487,11 @@ static t_config_enum_values s_keys_map_InputShaperType {
     {"zvd",     int(InputShaperType::ZVD)},
     {"zvdd",    int(InputShaperType::ZVDD)},
     {"zvddd",   int(InputShaperType::ZVDDD)},
+    {"ei",     int(InputShaperType::EI)},
     {"ei2",     int(InputShaperType::EI2)},
+    {"2hump_ei",int(InputShaperType::TwoHumpEI)},
     {"ei3",     int(InputShaperType::EI3)},
+    {"3hump_ei",int(InputShaperType::ThreeHumpEI)},
     {"daa",     int(InputShaperType::DAA)},
     {"disable", int(InputShaperType::Disable)}
 };
@@ -4478,8 +4481,8 @@ void PrintConfigDef::init_fff_params()
     def->label        = L("Input shaper type");
     def->tooltip      = L("Choose the input shaper algorithm to use when generating SET_INPUT_SHAPER commands.");
     def->enum_keys_map = &ConfigOptionEnum<InputShaperType>::get_enum_values();
-    def->enum_values  = {"default", "mzv", "zvd", "zvdd", "zvddd", "ei2", "ei3", "daa", "disable"};
-    def->enum_labels  = {L("Default"), L("MZV"), L("ZVD"), L("ZVDD"), L("ZVDDD"), L("EI2"), L("EI3"), L("DAA"), L("Disable")};
+    def->enum_values  = {"default", "mzv", "zvd", "zvdd", "zvddd", "ei", "ei2", "2hump_ei", "ei3", "3hump_ei", "daa", "disable"};
+    def->enum_labels  = {L("Default"), L("MZV"), L("ZVD"), L("ZVDD"), L("ZVDDD"), L("EI"), L("EI2"), L("2HumpEI"), L("EI3"), L("3HumpEI"), L("DAA"), L("Disable")};
     def->mode         = comAdvanced;
     def->set_default_value(new ConfigOptionEnum<InputShaperType>(InputShaperType::Default));
 

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -4528,7 +4528,7 @@ void PrintConfigDef::init_fff_params()
     def->min     = 0;
     def->max     = 1;
     def->mode    = comAdvanced;
-    def->set_default_value(new ConfigOptionFloat(0));
+    def->set_default_value(new ConfigOptionFloat(0.1));
 
     def          = this->add("input_shaping_damp_y", coFloat);
     def->label   = L("Y");
@@ -4536,7 +4536,7 @@ void PrintConfigDef::init_fff_params()
     def->min     = 0;
     def->max     = 1;
     def->mode    = comAdvanced;
-    def->set_default_value(new ConfigOptionFloat(0));
+    def->set_default_value(new ConfigOptionFloat(0.1));
 
     def = this->add("fan_max_speed", coFloats);
     def->label = L("Fan speed");

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -499,19 +499,19 @@ static t_config_enum_values s_keys_map_PrinterStructure {
 CONFIG_OPTION_ENUM_DEFINE_STATIC_MAPS(PrinterStructure)
 
 static t_config_enum_values s_keys_map_InputShaperType {
-    {"default", int(InputShaperType::Default)},
-    {"mzv",     int(InputShaperType::MZV)},
-    {"zv",      int(InputShaperType::ZV)},
-    {"zvd",     int(InputShaperType::ZVD)},
-    {"zvdd",    int(InputShaperType::ZVDD)},
-    {"zvddd",   int(InputShaperType::ZVDDD)},
-    {"ei",     int(InputShaperType::EI)},
-    {"ei2",     int(InputShaperType::EI2)},
-    {"2hump_ei",int(InputShaperType::TwoHumpEI)},
-    {"ei3",     int(InputShaperType::EI3)},
-    {"3hump_ei",int(InputShaperType::ThreeHumpEI)},
-    {"daa",     int(InputShaperType::DAA)},
-    {"disable", int(InputShaperType::Disable)}
+    {"Default", int(InputShaperType::Default)},
+    {"MZV",     int(InputShaperType::MZV)},
+    {"ZV",      int(InputShaperType::ZV)},
+    {"ZVD",     int(InputShaperType::ZVD)},
+    {"ZVDD",    int(InputShaperType::ZVDD)},
+    {"ZVDDD",   int(InputShaperType::ZVDDD)},
+    {"EI",     int(InputShaperType::EI)},
+    {"EI2",     int(InputShaperType::EI2)},
+    {"2HUMP_EI",int(InputShaperType::TwoHumpEI)},
+    {"EI3",     int(InputShaperType::EI3)},
+    {"3HUMP_EI",int(InputShaperType::ThreeHumpEI)},
+    {"DAA",     int(InputShaperType::DAA)},
+    {"Disable", int(InputShaperType::Disable)}
 };
 CONFIG_OPTION_ENUM_DEFINE_STATIC_MAPS(InputShaperType)
 
@@ -4499,8 +4499,8 @@ void PrintConfigDef::init_fff_params()
     def->label        = L("Input shaper type");
     def->tooltip      = L("Choose the input shaper algorithm to use when generating SET_INPUT_SHAPER commands.");
     def->enum_keys_map = &ConfigOptionEnum<InputShaperType>::get_enum_values();
-    def->enum_values  = {"default", "mzv", "zv", "zvd", "zvdd", "zvddd", "ei", "ei2", "2hump_ei", "ei3", "3hump_ei", "daa", "disable"};
-    def->enum_labels  = {L("Default"), L("MZV"), L("ZV"), L("ZVD"), L("ZVDD"), L("ZVDDD"), L("EI"), L("EI2"), L("2HumpEI"), L("EI3"), L("3HumpEI"), L("DAA"), L("Disable")};
+    def->enum_values  = {"Default", "MZV", "ZV", "ZVD", "ZVDD", "ZVDDD", "EI", "EI2", "2HUMP_EI", "EI3", "3HUMP_EI", "DAA", "Disable"};
+    def->enum_labels  = {L("Default"), L("MZV"), L("ZV"), L("ZVD"), L("ZVDD"), L("ZVDDD"), L("EI"), L("EI2"), L("2HUMP_EI"), L("EI3"), L("3HUMP_EI"), L("DAA"), L("Disable")};
     def->mode         = comAdvanced;
     def->set_default_value(new ConfigOptionEnum<InputShaperType>(InputShaperType::Default));
 

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -92,7 +92,7 @@ size_t get_extruder_index(const GCodeConfig& config, unsigned int filament_id)
 }
 
 
-// Orca: input shaping values typs by flavor
+// Orca: input shaping values types by flavor
 std::vector<std::string> get_shaper_type_values_for_flavor(GCodeFlavor flavor)
 {
     switch (flavor) {

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -91,6 +91,23 @@ size_t get_extruder_index(const GCodeConfig& config, unsigned int filament_id)
     return 0;
 }
 
+std::vector<std::string> get_shaper_type_values_for_flavor(GCodeFlavor flavor)
+{
+    switch (flavor) {
+    case GCodeFlavor::gcfKlipper:
+        return {"Default", "MZV", "ZV", "ZVD", "EI", "2HUMP_EI", "3HUMP_EI"};
+    case GCodeFlavor::gcfRepRapFirmware:
+        return {"Default", "MZV", "ZV", "ZVD", "ZVDD", "ZVDDD", "EI2", "EI3", "DAA"};
+    case GCodeFlavor::gcfMarlinFirmware:
+        return {"ZV"};
+    case GCodeFlavor::gcfMarlinLegacy:
+        return {};
+    default:
+        break;
+    }
+    return {"Default"};
+}
+
 static t_config_enum_names enum_names_from_keys_map(const t_config_enum_values &enum_keys_map)
 {
     t_config_enum_names names;
@@ -484,6 +501,7 @@ CONFIG_OPTION_ENUM_DEFINE_STATIC_MAPS(PrinterStructure)
 static t_config_enum_values s_keys_map_InputShaperType {
     {"default", int(InputShaperType::Default)},
     {"mzv",     int(InputShaperType::MZV)},
+    {"zv",      int(InputShaperType::ZV)},
     {"zvd",     int(InputShaperType::ZVD)},
     {"zvdd",    int(InputShaperType::ZVDD)},
     {"zvddd",   int(InputShaperType::ZVDDD)},
@@ -4481,8 +4499,8 @@ void PrintConfigDef::init_fff_params()
     def->label        = L("Input shaper type");
     def->tooltip      = L("Choose the input shaper algorithm to use when generating SET_INPUT_SHAPER commands.");
     def->enum_keys_map = &ConfigOptionEnum<InputShaperType>::get_enum_values();
-    def->enum_values  = {"default", "mzv", "zvd", "zvdd", "zvddd", "ei", "ei2", "2hump_ei", "ei3", "3hump_ei", "daa", "disable"};
-    def->enum_labels  = {L("Default"), L("MZV"), L("ZVD"), L("ZVDD"), L("ZVDDD"), L("EI"), L("EI2"), L("2HumpEI"), L("EI3"), L("3HumpEI"), L("DAA"), L("Disable")};
+    def->enum_values  = {"default", "mzv", "zv", "zvd", "zvdd", "zvddd", "ei", "ei2", "2hump_ei", "ei3", "3hump_ei", "daa", "disable"};
+    def->enum_labels  = {L("Default"), L("MZV"), L("ZV"), L("ZVD"), L("ZVDD"), L("ZVDDD"), L("EI"), L("EI2"), L("2HumpEI"), L("EI3"), L("3HumpEI"), L("DAA"), L("Disable")};
     def->mode         = comAdvanced;
     def->set_default_value(new ConfigOptionEnum<InputShaperType>(InputShaperType::Default));
 

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -4491,13 +4491,13 @@ void PrintConfigDef::init_fff_params()
 
     def          = this->add("input_shaping_enable", coBool);
     def->label   = L("Enable input shaping");
-    def->tooltip = L("Emit SET_INPUT_SHAPER commands before printing moves.");
+    def->tooltip = L("Override firmware input shaping settings.\nIf disabled, firmware settings are used.");
     def->mode    = comAdvanced;
     def->set_default_value(new ConfigOptionBool(false));
 
     def               = this->add("input_shaping_type", coEnum);
     def->label        = L("Input shaper type");
-    def->tooltip      = L("Choose the input shaper algorithm to use when generating SET_INPUT_SHAPER commands.");
+    def->tooltip      = L("Choose the input shaper algorithm.\nDefault uses the firmware default settings.\nDisable turns off input shaping in the firmware.");
     def->enum_keys_map = &ConfigOptionEnum<InputShaperType>::get_enum_values();
     def->enum_values  = {"Default", "MZV", "ZV", "ZVD", "ZVDD", "ZVDDD", "EI", "EI2", "2HUMP_EI", "EI3", "3HUMP_EI", "DAA", "Disable"};
     def->enum_labels  = {L("Default"), L("MZV"), L("ZV"), L("ZVD"), L("ZVDD"), L("ZVDDD"), L("EI"), L("EI2"), L("2HUMP_EI"), L("EI3"), L("3HUMP_EI"), L("DAA"), L("Disable")};
@@ -4506,7 +4506,7 @@ void PrintConfigDef::init_fff_params()
 
     def           = this->add("input_shaping_freq_x", coFloat);
     def->label    = L("X");
-    def->tooltip  = L("Resonant frequency for the X axis input shaper.\nRRF: X and Y values are equal.");
+    def->tooltip  = L("Resonant frequency for the X axis input shaper.\nZero will use the firmware frequency.\nTo disable input shaping, use the Disable type.\nRRF: X and Y values are equal.");
     def->sidetext = "Hz";
     def->min      = 0;
     def->mode     = comAdvanced;
@@ -4514,7 +4514,7 @@ void PrintConfigDef::init_fff_params()
 
     def           = this->add("input_shaping_freq_y", coFloat);
     def->label    = L("Y");
-    def->tooltip  = L("Resonant frequency for the Y axis input shaper.");
+    def->tooltip  = L("Resonant frequency for the Y axis input shaper.\nZero will use the firmware frequency.\nTo disable input shaping, use the Disable type.");
     def->sidetext = "Hz";
     def->min      = 0;
     def->mode     = comAdvanced;
@@ -4522,14 +4522,14 @@ void PrintConfigDef::init_fff_params()
 
     def          = this->add("input_shaping_damp_x", coFloat);
     def->label   = L("X");
-    def->tooltip = L("Damping ratio for the X axis input shaper.\nRRF: X and Y values are equal.");
+    def->tooltip = L("Damping ratio for the X axis input shaper.\nZero will use the firmware frequency.\nTo disable input shaping, use the Disable type.\nRRF: X and Y values are equal.");
     def->min     = 0;
     def->mode    = comAdvanced;
     def->set_default_value(new ConfigOptionFloat(0));
 
     def          = this->add("input_shaping_damp_y", coFloat);
     def->label   = L("Y");
-    def->tooltip = L("Damping ratio for the Y axis input shaper.");
+    def->tooltip = L("Damping ratio for the Y axis input shaper.\nZero will use the firmware frequency.\nTo disable input shaping, use the Disable type.");
     def->min     = 0;
     def->mode    = comAdvanced;
     def->set_default_value(new ConfigOptionFloat(0));

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -481,6 +481,19 @@ static t_config_enum_values s_keys_map_PrinterStructure {
 };
 CONFIG_OPTION_ENUM_DEFINE_STATIC_MAPS(PrinterStructure)
 
+static t_config_enum_values s_keys_map_InputShaperType {
+    {"default", int(InputShaperType::Default)},
+    {"mzv",     int(InputShaperType::MZV)},
+    {"zvd",     int(InputShaperType::ZVD)},
+    {"zvdd",    int(InputShaperType::ZVDD)},
+    {"zvddd",   int(InputShaperType::ZVDDD)},
+    {"ei2",     int(InputShaperType::EI2)},
+    {"ei3",     int(InputShaperType::EI3)},
+    {"daa",     int(InputShaperType::DAA)},
+    {"disable", int(InputShaperType::Disable)}
+};
+CONFIG_OPTION_ENUM_DEFINE_STATIC_MAPS(InputShaperType)
+
 static t_config_enum_values s_keys_map_PerimeterGeneratorType{
     { "classic", int(PerimeterGeneratorType::Classic) },
     { "arachne", int(PerimeterGeneratorType::Arachne) }
@@ -4454,6 +4467,51 @@ void PrintConfigDef::init_fff_params()
     def->min      = 0;
     def->mode     = comAdvanced;
     def->set_default_value(new ConfigOptionFloat(120));
+
+    def          = this->add("input_shaping_enable", coBool);
+    def->label   = L("Enable input shaping");
+    def->tooltip = L("Emit SET_INPUT_SHAPER commands before printing moves.");
+    def->mode    = comAdvanced;
+    def->set_default_value(new ConfigOptionBool(false));
+
+    def               = this->add("input_shaping_type", coEnum);
+    def->label        = L("Input shaper type");
+    def->tooltip      = L("Choose the input shaper algorithm to use when generating SET_INPUT_SHAPER commands.");
+    def->enum_keys_map = &ConfigOptionEnum<InputShaperType>::get_enum_values();
+    def->enum_values  = {"default", "mzv", "zvd", "zvdd", "zvddd", "ei2", "ei3", "daa", "disable"};
+    def->enum_labels  = {L("Default"), L("MZV"), L("ZVD"), L("ZVDD"), L("ZVDDD"), L("EI2"), L("EI3"), L("DAA"), L("Disable")};
+    def->mode         = comAdvanced;
+    def->set_default_value(new ConfigOptionEnum<InputShaperType>(InputShaperType::Default));
+
+    def           = this->add("input_shaping_freq_x", coFloat);
+    def->label    = L("X");
+    def->tooltip  = L("Resonant frequency for the X axis input shaper.\nRRF: X and Y values are equal.");
+    def->sidetext = "Hz";
+    def->min      = 0;
+    def->mode     = comAdvanced;
+    def->set_default_value(new ConfigOptionFloat(0));
+
+    def           = this->add("input_shaping_freq_y", coFloat);
+    def->label    = L("Y");
+    def->tooltip  = L("Resonant frequency for the Y axis input shaper.");
+    def->sidetext = "Hz";
+    def->min      = 0;
+    def->mode     = comAdvanced;
+    def->set_default_value(new ConfigOptionFloat(0));
+
+    def          = this->add("input_shaping_damp_x", coFloat);
+    def->label   = L("X");
+    def->tooltip = L("Damping ratio for the X axis input shaper.\nRRF: X and Y values are equal.");
+    def->min     = 0;
+    def->mode    = comAdvanced;
+    def->set_default_value(new ConfigOptionFloat(0));
+
+    def          = this->add("input_shaping_damp_y", coFloat);
+    def->label   = L("Y");
+    def->tooltip = L("Damping ratio for the Y axis input shaper.");
+    def->min     = 0;
+    def->mode    = comAdvanced;
+    def->set_default_value(new ConfigOptionFloat(0));
 
     def = this->add("fan_max_speed", coFloats);
     def->label = L("Fan speed");

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -4279,8 +4279,8 @@ void PrintConfigDef::init_fff_params()
     def = this->add("emit_machine_limits_to_gcode", coBool);
     def->label = L("Emit limits to G-code");
     def->category = L("Machine limits");
-    def->tooltip  = L("If enabled, the machine limits will be emitted to G-code file.\nThis option will be ignored if the G-code flavor is "
-                       "set to Klipper.");
+    def->tooltip = L("If enabled, the machine limits will be emitted to G-code file.\nThis option will be ignored if the G-code flavor is "
+        "set to Klipper.");
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionBool(true));
 
@@ -4492,8 +4492,8 @@ void PrintConfigDef::init_fff_params()
     def->set_default_value(new ConfigOptionFloat(120));
 
     // Orca: Input Shaping support
-    def          = this->add("input_shaping_enable", coBool);
-    def->label   = L("Enable input shaping");
+    def          = this->add("input_shaping_emit", coBool);
+    def->label   = L("Emit input shaping");
     def->tooltip = L("Override firmware input shaping settings.\nIf disabled, firmware settings are used.");
     def->mode    = comAdvanced;
     def->set_default_value(new ConfigOptionBool(false));

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -4509,6 +4509,7 @@ void PrintConfigDef::init_fff_params()
     def->tooltip  = L("Resonant frequency for the X axis input shaper.\nZero will use the firmware frequency.\nTo disable input shaping, use the Disable type.\nRRF: X and Y values are equal.");
     def->sidetext = "Hz";
     def->min      = 0;
+    def->max      = 1000;
     def->mode     = comAdvanced;
     def->set_default_value(new ConfigOptionFloat(0));
 
@@ -4517,6 +4518,7 @@ void PrintConfigDef::init_fff_params()
     def->tooltip  = L("Resonant frequency for the Y axis input shaper.\nZero will use the firmware frequency.\nTo disable input shaping, use the Disable type.");
     def->sidetext = "Hz";
     def->min      = 0;
+    def->max      = 1000;
     def->mode     = comAdvanced;
     def->set_default_value(new ConfigOptionFloat(0));
 
@@ -4524,6 +4526,7 @@ void PrintConfigDef::init_fff_params()
     def->label   = L("X");
     def->tooltip = L("Damping ratio for the X axis input shaper.\nZero will use the firmware frequency.\nTo disable input shaping, use the Disable type.\nRRF: X and Y values are equal.");
     def->min     = 0;
+    def->max     = 1;
     def->mode    = comAdvanced;
     def->set_default_value(new ConfigOptionFloat(0));
 
@@ -4531,6 +4534,7 @@ void PrintConfigDef::init_fff_params()
     def->label   = L("Y");
     def->tooltip = L("Damping ratio for the Y axis input shaper.\nZero will use the firmware frequency.\nTo disable input shaping, use the Disable type.");
     def->min     = 0;
+    def->max     = 1;
     def->mode    = comAdvanced;
     def->set_default_value(new ConfigOptionFloat(0));
 

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -4527,7 +4527,7 @@ void PrintConfigDef::init_fff_params()
 
     def          = this->add("input_shaping_damp_x", coFloat);
     def->label   = L("X");
-    def->tooltip = L("Damping ratio for the X axis input shaper.\nZero will use the firmware frequency.\nTo disable input shaping, use the Disable type.\nRRF: X and Y values are equal.");
+    def->tooltip = L("Damping ratio for the X axis input shaper.\nZero will use the firmware damping ratio.\nTo disable input shaping, use the Disable type.\nRRF: X and Y values are equal.");
     def->min     = 0;
     def->max     = 1;
     def->mode    = comAdvanced;
@@ -4535,7 +4535,7 @@ void PrintConfigDef::init_fff_params()
 
     def          = this->add("input_shaping_damp_y", coFloat);
     def->label   = L("Y");
-    def->tooltip = L("Damping ratio for the Y axis input shaper.\nZero will use the firmware frequency.\nTo disable input shaping, use the Disable type.");
+    def->tooltip = L("Damping ratio for the Y axis input shaper.\nZero will use the firmware damping ratio.\nTo disable input shaping, use the Disable type.");
     def->min     = 0;
     def->max     = 1;
     def->mode    = comAdvanced;

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -91,6 +91,8 @@ size_t get_extruder_index(const GCodeConfig& config, unsigned int filament_id)
     return 0;
 }
 
+
+// Orca: input shaping values typs by flavor
 std::vector<std::string> get_shaper_type_values_for_flavor(GCodeFlavor flavor)
 {
     switch (flavor) {
@@ -4489,6 +4491,7 @@ void PrintConfigDef::init_fff_params()
     def->mode     = comAdvanced;
     def->set_default_value(new ConfigOptionFloat(120));
 
+    // Orca: Input Shaping support
     def          = this->add("input_shaping_enable", coBool);
     def->label   = L("Enable input shaping");
     def->tooltip = L("Override firmware input shaping settings.\nIf disabled, firmware settings are used.");

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -1276,7 +1276,8 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionBool,                 resonance_avoidance))
     ((ConfigOptionFloat,                min_resonance_avoidance_speed))
     ((ConfigOptionFloat,                max_resonance_avoidance_speed))
-    //Input shaping
+
+    //Orca: Input shaping
     ((ConfigOptionBool,                 input_shaping_enable))
     ((ConfigOptionEnum<InputShaperType>, input_shaping_type))
     ((ConfigOptionFloat,                input_shaping_freq_x))

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -365,6 +365,7 @@ enum PrinterStructure {
 enum class InputShaperType : unsigned char {
     Default = 0,
     MZV,
+    ZV,
     ZVD,
     ZVDD,
     ZVDDD,

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -1278,7 +1278,7 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionFloat,                max_resonance_avoidance_speed))
 
     //Orca: Input shaping
-    ((ConfigOptionBool,                 input_shaping_enable))
+    ((ConfigOptionBool,                 input_shaping_emit))
     ((ConfigOptionEnum<InputShaperType>, input_shaping_type))
     ((ConfigOptionFloat,                input_shaping_freq_x))
     ((ConfigOptionFloat,                input_shaping_freq_y))

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -362,6 +362,18 @@ enum PrinterStructure {
     psDelta
 };
 
+enum class InputShaperType : unsigned char {
+    Default = 0,
+    MZV,
+    ZVD,
+    ZVDD,
+    ZVDDD,
+    EI2,
+    EI3,
+    DAA,
+    Disable
+};
+
 // BBS
 enum ZHopType {
     zhtAuto = 0,
@@ -525,6 +537,7 @@ CONFIG_OPTION_ENUM_DECLARE_STATIC_MAPS(BrimType)
 CONFIG_OPTION_ENUM_DECLARE_STATIC_MAPS(TimelapseType)
 CONFIG_OPTION_ENUM_DECLARE_STATIC_MAPS(BedType)
 CONFIG_OPTION_ENUM_DECLARE_STATIC_MAPS(SkirtType)
+CONFIG_OPTION_ENUM_DECLARE_STATIC_MAPS(InputShaperType)
 CONFIG_OPTION_ENUM_DECLARE_STATIC_MAPS(DraftShield)
 CONFIG_OPTION_ENUM_DECLARE_STATIC_MAPS(ForwardCompatibilitySubstitutionRule)
 CONFIG_OPTION_ENUM_DECLARE_STATIC_MAPS(GCodeThumbnailsFormat)
@@ -1259,6 +1272,13 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionBool,                 resonance_avoidance))
     ((ConfigOptionFloat,                min_resonance_avoidance_speed))
     ((ConfigOptionFloat,                max_resonance_avoidance_speed))
+    //Input shaping
+    ((ConfigOptionBool,                 input_shaping_enable))
+    ((ConfigOptionEnum<InputShaperType>, input_shaping_type))
+    ((ConfigOptionFloat,                input_shaping_freq_x))
+    ((ConfigOptionFloat,                input_shaping_freq_y))
+    ((ConfigOptionFloat,                input_shaping_damp_x))
+    ((ConfigOptionFloat,                input_shaping_damp_y))
 )
 
 // This object is mapped to Perl as Slic3r::Config::GCode.

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -368,8 +368,11 @@ enum class InputShaperType : unsigned char {
     ZVD,
     ZVDD,
     ZVDDD,
+    EI,
     EI2,
+    TwoHumpEI,
     EI3,
+    ThreeHumpEI,
     DAA,
     Disable
 };

--- a/src/slic3r/GUI/Field.cpp
+++ b/src/slic3r/GUI/Field.cpp
@@ -11,6 +11,7 @@
 #include "libslic3r/PrintConfig.hpp"
 
 #include <regex>
+#include <cstdint>
 #include <wx/numformatter.h>
 #include <wx/tooltip.h>
 #include <wx/notebook.h>
@@ -1626,18 +1627,45 @@ void Choice::set_value(const boost::any& value, bool change_event)
 	}
 	case coEnum:
     // BBS
-    case coEnums: {
+	case coEnums: {
 		int val = boost::any_cast<int>(value);
+		int selection = val;
 
-        // Support ThirdPartyPrinter
-        if (m_opt_id.compare("host_type") == 0 && val != 0 &&
-			m_opt.enum_values.size() > field->GetCount()) // for case, when PrusaLink isn't used as a HostType
-			val--;
-        if (m_opt_id == "top_surface_pattern" || m_opt_id == "bottom_surface_pattern" ||
-            m_opt_id == "internal_solid_infill_pattern" || m_opt_id == "sparse_infill_pattern" ||
-            m_opt_id == "support_base_pattern" || m_opt_id == "support_interface_pattern" ||
-            m_opt_id == "ironing_pattern" || m_opt_id == "support_ironing_pattern" ||
-            m_opt_id == "support_style" || m_opt_id == "curr_bed_type" || m_opt_id == "wipe_tower_wall_type")
+        if (m_opt_id == "input_shaping_type") {
+            if (field != nullptr) {
+                const unsigned int count = field->GetCount();
+                int match_index = -1;
+                for (unsigned int idx = 0; idx < count; ++idx) {
+                    if (void* data = field->GetClientData(idx)) {
+                        int stored = static_cast<int>(reinterpret_cast<uintptr_t>(data));
+                        if (stored == val) {
+                            match_index = static_cast<int>(idx);
+                            break;
+                        }
+                    }
+                }
+                if (match_index >= 0)
+                    selection = match_index;
+                else if (val >= 0 && val < static_cast<int>(count))
+                    selection = val;
+                else if (count > 0)
+                    selection = 0;
+                else
+                    selection = -1;
+            }
+        } else {
+            // Support ThirdPartyPrinter
+            if (m_opt_id.compare("host_type") == 0 && val != 0 &&
+                m_opt.enum_values.size() > field->GetCount()) // for case, when PrusaLink isn't used as a HostType
+                selection = val - 1;
+            else
+                selection = val;
+
+            if (m_opt_id == "top_surface_pattern" || m_opt_id == "bottom_surface_pattern" ||
+                m_opt_id == "internal_solid_infill_pattern" || m_opt_id == "sparse_infill_pattern" ||
+                m_opt_id == "support_base_pattern" || m_opt_id == "support_interface_pattern" ||
+                m_opt_id == "ironing_pattern" || m_opt_id == "support_ironing_pattern" ||
+                m_opt_id == "support_style" || m_opt_id == "curr_bed_type" || m_opt_id == "wipe_tower_wall_type")
 		{
 			std::string key;
 			const t_config_enum_values& map_names = *m_opt.enum_keys_map;
@@ -1649,15 +1677,16 @@ void Choice::set_value(const boost::any& value, bool change_event)
 
 			const std::vector<std::string>& values = m_opt.enum_values;
 			auto it = std::find(values.begin(), values.end(), key);
-			val = it == values.end() ? 0 : it - values.begin();
+			selection = it == values.end() ? 0 : static_cast<int>(it - values.begin());
 		}
+        }
         if (m_opt.nullable) {
             if (val != ConfigOptionEnumsGenericNullable::nil_value())
                 m_last_meaningful_value = value;
             else
-                val = -1;
+                selection = -1;
         }
-		field->SetSelection(val);
+		field->SetSelection(selection);
 		break;
 	}
 	default:
@@ -1724,6 +1753,17 @@ boost::any& Choice::get_value()
     {
         if (m_opt.nullable && field->GetSelection() == -1)
             m_value = ConfigOptionEnumsGenericNullable::nil_value();
+        else if (m_opt_id == "input_shaping_type")
+        {
+            int selection = field->GetSelection();
+            if (selection >= 0) {
+                if (void* data = field->GetClientData(selection))
+                    m_value = static_cast<int>(reinterpret_cast<uintptr_t>(data));
+                else
+                    m_value = selection;
+            } else
+                m_value = 0;
+        }
         else if (   m_opt_id == "top_surface_pattern" || m_opt_id == "bottom_surface_pattern" ||
                     m_opt_id == "internal_solid_infill_pattern" || m_opt_id == "sparse_infill_pattern" ||
                     m_opt_id == "support_base_pattern" || m_opt_id == "support_interface_pattern" ||

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -13296,6 +13296,8 @@ void Plater::calib_VFA(const Calib_Params& params)
     auto filament_config = &wxGetApp().preset_bundle->filaments.get_edited_preset().config;
     auto printer_config  = &wxGetApp().preset_bundle->printers.get_edited_preset().config;
     printer_config->set_key_value("resonance_avoidance", new ConfigOptionBool{false});
+    printer_config->set_key_value("input_shaping_enable", new ConfigOptionBool{true});
+    printer_config->set_key_value("input_shaping_type", new ConfigOptionEnum<InputShaperType>(InputShaperType::Disable));
     filament_config->set_key_value("slow_down_layer_time", new ConfigOptionFloats { 0.0 });
     print_config->set_key_value("enable_overhang_speed", new ConfigOptionBool { false });
     print_config->set_key_value("timelapse_type", new ConfigOptionEnum<TimelapseType>(tlTraditional));
@@ -13359,10 +13361,12 @@ void Plater::calib_input_shaping_freq(const Calib_Params& params)
     }
 
     printer_config->set_key_value("resonance_avoidance", new ConfigOptionBool{false});
+    printer_config->set_key_value("input_shaping_enable", new ConfigOptionBool{false});
     filament_config->set_key_value("slow_down_layer_time", new ConfigOptionFloats { 0.0 });
     filament_config->set_key_value("slow_down_min_speed", new ConfigOptionFloats { 0.0 });
     filament_config->set_key_value("slow_down_for_layer_cooling", new ConfigOptionBools{false});
-    print_config->set_key_value("enable_overhang_speed", new ConfigOptionBool { false });
+    print_config->set_key_value("layer_height", new ConfigOptionFloat(0.2));
+    print_config->set_key_value("enable_overhang_speed", new ConfigOptionBool{false});
     print_config->set_key_value("timelapse_type", new ConfigOptionEnum<TimelapseType>(tlTraditional));
     print_config->set_key_value("wall_loops", new ConfigOptionInt(1));
     print_config->set_key_value("top_shell_layers", new ConfigOptionInt(0));
@@ -13420,6 +13424,7 @@ void Plater::calib_input_shaping_damp(const Calib_Params& params)
     }
 
     printer_config->set_key_value("resonance_avoidance", new ConfigOptionBool{false});
+    printer_config->set_key_value("input_shaping_enable", new ConfigOptionBool{false});
     filament_config->set_key_value("slow_down_layer_time", new ConfigOptionFloats { 0.0 });
     filament_config->set_key_value("slow_down_min_speed", new ConfigOptionFloats { 0.0 });
     filament_config->set_key_value("slow_down_for_layer_cooling", new ConfigOptionBools{false});
@@ -13482,6 +13487,8 @@ void Plater::Calib_Cornering(const Calib_Params& params)
     }
 
     printer_config->set_key_value("resonance_avoidance", new ConfigOptionBool{false});
+    printer_config->set_key_value("input_shaping_enable", new ConfigOptionBool{true});
+    printer_config->set_key_value("input_shaping_type", new ConfigOptionEnum<InputShaperType>(InputShaperType::Disable));
     filament_config->set_key_value("slow_down_layer_time", new ConfigOptionFloats { 0.0 });
     filament_config->set_key_value("slow_down_min_speed", new ConfigOptionFloats { 0.0 });
     filament_config->set_key_value("slow_down_for_layer_cooling", new ConfigOptionBools{false});

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -13296,7 +13296,7 @@ void Plater::calib_VFA(const Calib_Params& params)
     auto filament_config = &wxGetApp().preset_bundle->filaments.get_edited_preset().config;
     auto printer_config  = &wxGetApp().preset_bundle->printers.get_edited_preset().config;
     printer_config->set_key_value("resonance_avoidance", new ConfigOptionBool{false});
-    printer_config->set_key_value("input_shaping_enable", new ConfigOptionBool{true});
+    printer_config->set_key_value("input_shaping_emit", new ConfigOptionBool{true});
     printer_config->set_key_value("input_shaping_type", new ConfigOptionEnum<InputShaperType>(InputShaperType::Disable));
     filament_config->set_key_value("slow_down_layer_time", new ConfigOptionFloats { 0.0 });
     print_config->set_key_value("enable_overhang_speed", new ConfigOptionBool { false });
@@ -13361,7 +13361,7 @@ void Plater::calib_input_shaping_freq(const Calib_Params& params)
     }
 
     printer_config->set_key_value("resonance_avoidance", new ConfigOptionBool{false});
-    printer_config->set_key_value("input_shaping_enable", new ConfigOptionBool{false});
+    printer_config->set_key_value("input_shaping_emit", new ConfigOptionBool{false});
     filament_config->set_key_value("slow_down_layer_time", new ConfigOptionFloats { 0.0 });
     filament_config->set_key_value("slow_down_min_speed", new ConfigOptionFloats { 0.0 });
     filament_config->set_key_value("slow_down_for_layer_cooling", new ConfigOptionBools{false});
@@ -13424,7 +13424,7 @@ void Plater::calib_input_shaping_damp(const Calib_Params& params)
     }
 
     printer_config->set_key_value("resonance_avoidance", new ConfigOptionBool{false});
-    printer_config->set_key_value("input_shaping_enable", new ConfigOptionBool{false});
+    printer_config->set_key_value("input_shaping_emit", new ConfigOptionBool{false});
     filament_config->set_key_value("slow_down_layer_time", new ConfigOptionFloats { 0.0 });
     filament_config->set_key_value("slow_down_min_speed", new ConfigOptionFloats { 0.0 });
     filament_config->set_key_value("slow_down_for_layer_cooling", new ConfigOptionBools{false});
@@ -13487,7 +13487,7 @@ void Plater::Calib_Cornering(const Calib_Params& params)
     }
 
     printer_config->set_key_value("resonance_avoidance", new ConfigOptionBool{false});
-    printer_config->set_key_value("input_shaping_enable", new ConfigOptionBool{true});
+    printer_config->set_key_value("input_shaping_emit", new ConfigOptionBool{true});
     printer_config->set_key_value("input_shaping_type", new ConfigOptionEnum<InputShaperType>(InputShaperType::Disable));
     filament_config->set_key_value("slow_down_layer_time", new ConfigOptionFloats { 0.0 });
     filament_config->set_key_value("slow_down_min_speed", new ConfigOptionFloats { 0.0 });

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -48,6 +48,7 @@
 #include "Widgets/Label.hpp"
 #include "Widgets/SwitchButton.hpp"
 #include "Widgets/TabCtrl.hpp"
+#include "Widgets/ComboBox.hpp"
 #include "MarkdownTip.hpp"
 #include "Search.hpp"
 #include "BedShapeDialog.hpp"
@@ -1492,6 +1493,11 @@ void Tab::on_value_change(const std::string& opt_key, const boost::any& value)
 {
     if (wxGetApp().plater() == nullptr) {
         return;
+    }
+
+    if (opt_key == "gcode_flavor" && m_type == Preset::TYPE_PRINTER) {
+        if (auto printer_tab = dynamic_cast<TabPrinter*>(this))
+            printer_tab->on_gcode_flavor_changed();
     }
 
     if (opt_key == "compatible_prints")
@@ -5262,6 +5268,107 @@ void TabPrinter::clear_pages()
     m_reset_to_filament_color = nullptr;
 }
 
+std::vector<InputShaperType> TabPrinter::input_shaper_types_for_flavor(GCodeFlavor flavor)
+{
+    switch (flavor) {
+    case GCodeFlavor::gcfKlipper:
+        return {
+            InputShaperType::Default,
+            InputShaperType::ZV,
+            InputShaperType::MZV,
+            InputShaperType::ZVD,
+            InputShaperType::EI,
+            InputShaperType::TwoHumpEI,
+            InputShaperType::ThreeHumpEI
+        };
+    case GCodeFlavor::gcfRepRapFirmware:
+        return {
+            InputShaperType::Default,
+            InputShaperType::MZV,
+            InputShaperType::ZVD,
+            InputShaperType::ZVDD,
+            InputShaperType::ZVDDD,
+            InputShaperType::EI2,
+            InputShaperType::EI3,
+            InputShaperType::DAA
+        };
+    case GCodeFlavor::gcfMarlinFirmware:
+        return { InputShaperType::ZV };
+    default:
+        return { InputShaperType::Default };
+    }
+}
+
+void TabPrinter::update_input_shaper_menu(GCodeFlavor flavor)
+{
+    if (m_presets->get_edited_preset().printer_technology() != ptFFF)
+        return;
+
+    const std::vector<InputShaperType> allowed = input_shaper_types_for_flavor(flavor);
+    if (allowed.empty())
+        return;
+
+    const InputShaperType current = m_config->opt_enum<InputShaperType>("input_shaping_type");
+    const bool needs_reset = std::find(allowed.begin(), allowed.end(), current) == allowed.end();
+    const InputShaperType desired = needs_reset ? allowed.front() : current;
+
+    if (needs_reset && current != desired) {
+        DynamicPrintConfig new_conf = *m_config;
+        new_conf.set_key_value("input_shaping_type", new ConfigOptionEnum<InputShaperType>(desired));
+        m_config_manipulation.apply(m_config, &new_conf);
+    }
+
+    Page* owning_page = nullptr;
+    Field* field = get_field("input_shaping_type", &owning_page);
+    if (field == nullptr)
+        return;
+
+    auto choice_field = dynamic_cast<Choice*>(field);
+    if (choice_field == nullptr)
+        return;
+
+    auto combo = dynamic_cast<ComboBox*>(choice_field->getWindow());
+    if (combo == nullptr)
+        return;
+
+    const ConfigOptionDef* def = m_config->def()->get("input_shaping_type");
+    if (def == nullptr)
+        return;
+
+    const auto& labels = def->enum_labels;
+    const auto& values = def->enum_values;
+
+    wxWindowUpdateLocker locker(combo);
+    combo->Clear();
+
+    for (InputShaperType type : allowed) {
+        const size_t idx = static_cast<size_t>(type);
+        wxString label;
+        if (idx < labels.size() && !labels[idx].empty())
+            label = _(labels[idx]);
+        else if (idx < values.size())
+            label = wxString::FromUTF8(values[idx].c_str());
+        else
+            label = wxString::Format("%d", static_cast<int>(type));
+
+        combo->Append(label, wxNullBitmap,
+            reinterpret_cast<void*>(static_cast<uintptr_t>(static_cast<int>(type))));
+    }
+
+    if (combo->GetCount() == 0)
+        return;
+
+    choice_field->set_value(static_cast<int>(desired), false);
+}
+
+void TabPrinter::on_gcode_flavor_changed()
+{
+    auto* flavor_option = m_config->option<ConfigOptionEnum<GCodeFlavor>>("gcode_flavor");
+    if (!flavor_option)
+        return;
+    update_input_shaper_menu(flavor_option->value);
+}
+
 void TabPrinter::toggle_options()
 {
     if (!m_active_page || m_presets->get_edited_preset().printer_technology() == ptSLA)
@@ -5414,6 +5521,7 @@ void TabPrinter::toggle_options()
 
     if (m_active_page->title() == L("Motion ability")) {
         auto gcf = m_config->option<ConfigOptionEnum<GCodeFlavor>>("gcode_flavor")->value;
+        update_input_shaper_menu(gcf);
         bool silent_mode = m_config->opt_bool("silent_mode");
         int  max_field   = silent_mode ? 2 : 1;
         for (int i = 0; i < max_field; ++i)

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -5561,14 +5561,16 @@ void TabPrinter::toggle_options()
         toggle_option("min_resonance_avoidance_speed", resonance_avoidance);
         toggle_option("max_resonance_avoidance_speed", resonance_avoidance);
 
-        bool input_shaping_compatible = m_config->opt_enum<GCodeFlavor>("gcode_flavor") != GCodeFlavor::gcfMarlinLegacy && m_config->opt_enum<GCodeFlavor>("gcode_flavor") != GCodeFlavor::gcfKlipper;
+        bool input_shaping_compatible = m_config->opt_enum<GCodeFlavor>("gcode_flavor") == GCodeFlavor::gcfMarlinFirmware || m_config->opt_enum<GCodeFlavor>("gcode_flavor") == GCodeFlavor::gcfRepRapFirmware;
 
         for (auto is : {"input_shaping_emit", "input_shaping_type", "input_shaping_freq_x", "input_shaping_freq_y",
                             "input_shaping_damp_x", "input_shaping_damp_y"})
                 toggle_line(is, input_shaping_compatible);
 
         if (input_shaping_compatible) {
-            bool input_shaping_emit = m_config->opt_bool("input_shaping_emit");
+            bool emit_machine_limits_to_gcode = m_config->opt_bool("emit_machine_limits_to_gcode");
+            toggle_option("input_shaping_emit", emit_machine_limits_to_gcode);
+            bool input_shaping_emit = emit_machine_limits_to_gcode && m_config->opt_bool("input_shaping_emit");
             bool reprap = m_config->opt_enum<GCodeFlavor>("gcode_flavor") == GCodeFlavor::gcfRepRapFirmware;
             toggle_option("input_shaping_type", input_shaping_emit);
             toggle_option("input_shaping_freq_x", input_shaping_emit);

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -5459,7 +5459,6 @@ void TabPrinter::toggle_options()
                 toggle_line(is, false);
         }
 
-        s_input_shaper_type_list.refresh();
     }
 }
 

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -5561,18 +5561,20 @@ void TabPrinter::toggle_options()
         toggle_option("min_resonance_avoidance_speed", resonance_avoidance);
         toggle_option("max_resonance_avoidance_speed", resonance_avoidance);
 
-        if (m_config->opt_enum<GCodeFlavor>("gcode_flavor") != GCodeFlavor::gcfMarlinLegacy && m_config->opt_enum<GCodeFlavor>("gcode_flavor") != GCodeFlavor::gcfKlipper) {
-            bool input_shaping_emitd = m_config->opt_bool("input_shaping_emit");
-            bool reprap = m_config->opt_enum<GCodeFlavor>("gcode_flavor") == GCodeFlavor::gcfRepRapFirmware;
-            toggle_option("input_shaping_type", input_shaping_emitd);
-            toggle_option("input_shaping_freq_x", input_shaping_emitd);
-            toggle_option("input_shaping_freq_y", input_shaping_emitd && !reprap);
-            toggle_option("input_shaping_damp_x", input_shaping_emitd);
-            toggle_option("input_shaping_damp_y", input_shaping_emitd && !reprap);
-        } else {
-            for (auto is : {"input_shaping_emit", "input_shaping_type", "input_shaping_freq_x", "input_shaping_freq_y",
+        bool input_shaping_compatible = m_config->opt_enum<GCodeFlavor>("gcode_flavor") != GCodeFlavor::gcfMarlinLegacy && m_config->opt_enum<GCodeFlavor>("gcode_flavor") != GCodeFlavor::gcfKlipper;
+
+        for (auto is : {"input_shaping_emit", "input_shaping_type", "input_shaping_freq_x", "input_shaping_freq_y",
                             "input_shaping_damp_x", "input_shaping_damp_y"})
-                toggle_line(is, false);
+                toggle_line(is, input_shaping_compatible);
+
+        if (input_shaping_compatible) {
+            bool input_shaping_emit = m_config->opt_bool("input_shaping_emit");
+            bool reprap = m_config->opt_enum<GCodeFlavor>("gcode_flavor") == GCodeFlavor::gcfRepRapFirmware;
+            toggle_option("input_shaping_type", input_shaping_emit);
+            toggle_option("input_shaping_freq_x", input_shaping_emit);
+            toggle_option("input_shaping_freq_y", input_shaping_emit && !reprap);
+            toggle_option("input_shaping_damp_x", input_shaping_emit);
+            toggle_option("input_shaping_damp_y", input_shaping_emit && !reprap);
         }
 
     }

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -4812,7 +4812,7 @@ PageShp TabPrinter::build_kinematics_page()
         resonance_line.append_option(optgroup->get_option("max_resonance_avoidance_speed"));
         optgroup->append_line(resonance_line);
     }
-    optgroup->append_single_option_line("input_shaping_enable", "input-shaping-calib");
+    optgroup->append_single_option_line("input_shaping_emit", "input-shaping-calib");
     optgroup->append_single_option_line("input_shaping_type", "input-shaping-calib");
     {
         Line freq_line = {L("Frequency"), L("The frequency of the anti-vibration signal will correspond to the natural frequency of the frame.")};
@@ -5561,16 +5561,16 @@ void TabPrinter::toggle_options()
         toggle_option("min_resonance_avoidance_speed", resonance_avoidance);
         toggle_option("max_resonance_avoidance_speed", resonance_avoidance);
 
-        if (m_config->opt_enum<GCodeFlavor>("gcode_flavor") != GCodeFlavor::gcfMarlinLegacy) {
-            bool input_shaping_enabled = m_config->opt_bool("input_shaping_enable");
+        if (m_config->opt_enum<GCodeFlavor>("gcode_flavor") != GCodeFlavor::gcfMarlinLegacy && m_config->opt_enum<GCodeFlavor>("gcode_flavor") != GCodeFlavor::gcfKlipper) {
+            bool input_shaping_emitd = m_config->opt_bool("input_shaping_emit");
             bool reprap = m_config->opt_enum<GCodeFlavor>("gcode_flavor") == GCodeFlavor::gcfRepRapFirmware;
-            toggle_option("input_shaping_type", input_shaping_enabled);
-            toggle_option("input_shaping_freq_x", input_shaping_enabled);
-            toggle_option("input_shaping_freq_y", input_shaping_enabled && !reprap);
-            toggle_option("input_shaping_damp_x", input_shaping_enabled);
-            toggle_option("input_shaping_damp_y", input_shaping_enabled && !reprap);
+            toggle_option("input_shaping_type", input_shaping_emitd);
+            toggle_option("input_shaping_freq_x", input_shaping_emitd);
+            toggle_option("input_shaping_freq_y", input_shaping_emitd && !reprap);
+            toggle_option("input_shaping_damp_x", input_shaping_emitd);
+            toggle_option("input_shaping_damp_y", input_shaping_emitd && !reprap);
         } else {
-            for (auto is : {"input_shaping_enable", "input_shaping_type", "input_shaping_freq_x", "input_shaping_freq_y",
+            for (auto is : {"input_shaping_emit", "input_shaping_type", "input_shaping_freq_x", "input_shaping_freq_y",
                             "input_shaping_damp_x", "input_shaping_damp_y"})
                 toggle_line(is, false);
         }

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -4806,6 +4806,20 @@ PageShp TabPrinter::build_kinematics_page()
         resonance_line.append_option(optgroup->get_option("max_resonance_avoidance_speed"));
         optgroup->append_line(resonance_line);
     }
+    optgroup->append_single_option_line("input_shaping_enable");
+    optgroup->append_single_option_line("input_shaping_type");
+    {
+        Line freq_line = {L("Frequency"), L("")};
+        freq_line.append_option(optgroup->get_option("input_shaping_freq_x"));
+        freq_line.append_option(optgroup->get_option("input_shaping_freq_y"));
+        optgroup->append_line(freq_line);
+    }
+    {
+        Line damping_line = {L("Damping"), L("")};
+        damping_line.append_option(optgroup->get_option("input_shaping_damp_x"));
+        damping_line.append_option(optgroup->get_option("input_shaping_damp_y"));
+        optgroup->append_line(damping_line);
+    }
 
     const std::vector<std::string> speed_axes{
         "machine_max_speed_x",
@@ -5430,6 +5444,13 @@ void TabPrinter::toggle_options()
         bool resonance_avoidance = m_config->opt_bool("resonance_avoidance");
         toggle_option("min_resonance_avoidance_speed", resonance_avoidance);
         toggle_option("max_resonance_avoidance_speed", resonance_avoidance);
+
+        bool input_shaping_enabled = m_config->opt_bool("input_shaping_enable");
+        toggle_option("input_shaping_type", input_shaping_enabled);
+        toggle_option("input_shaping_freq_x", input_shaping_enabled);
+        toggle_option("input_shaping_freq_y", input_shaping_enabled);
+        toggle_option("input_shaping_damp_x", input_shaping_enabled);
+        toggle_option("input_shaping_damp_y", input_shaping_enabled);
     }
 }
 

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -5445,12 +5445,21 @@ void TabPrinter::toggle_options()
         toggle_option("min_resonance_avoidance_speed", resonance_avoidance);
         toggle_option("max_resonance_avoidance_speed", resonance_avoidance);
 
-        bool input_shaping_enabled = m_config->opt_bool("input_shaping_enable");
-        toggle_option("input_shaping_type", input_shaping_enabled);
-        toggle_option("input_shaping_freq_x", input_shaping_enabled);
-        toggle_option("input_shaping_freq_y", input_shaping_enabled);
-        toggle_option("input_shaping_damp_x", input_shaping_enabled);
-        toggle_option("input_shaping_damp_y", input_shaping_enabled);
+        if (m_config->opt_enum<GCodeFlavor>("gcode_flavor") != GCodeFlavor::gcfMarlinLegacy) {
+            bool input_shaping_enabled = m_config->opt_bool("input_shaping_enable");
+            bool reprap = m_config->opt_enum<GCodeFlavor>("gcode_flavor") == GCodeFlavor::gcfRepRapFirmware;
+            toggle_option("input_shaping_type", input_shaping_enabled);
+            toggle_option("input_shaping_freq_x", input_shaping_enabled);
+            toggle_option("input_shaping_freq_y", input_shaping_enabled && !reprap);
+            toggle_option("input_shaping_damp_x", input_shaping_enabled);
+            toggle_option("input_shaping_damp_y", input_shaping_enabled && !reprap);
+        } else {
+            for (auto is : {"input_shaping_enable", "input_shaping_type", "input_shaping_freq_x", "input_shaping_freq_y",
+                            "input_shaping_damp_x", "input_shaping_damp_y"})
+                toggle_line(is, false);
+        }
+
+        s_input_shaper_type_list.refresh();
     }
 }
 

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -5557,6 +5557,9 @@ void TabPrinter::toggle_options()
             toggle_option("machine_max_jerk_e", enable_jerk, i);
         }
 
+        bool emittable_limits = m_config->opt_enum<GCodeFlavor>("gcode_flavor") == GCodeFlavor::gcfMarlinLegacy || m_config->opt_enum<GCodeFlavor>("gcode_flavor") == GCodeFlavor::gcfMarlinFirmware || m_config->opt_enum<GCodeFlavor>("gcode_flavor") == GCodeFlavor::gcfRepRapFirmware;
+        toggle_option("emit_machine_limits_to_gcode", emittable_limits);
+
         bool resonance_avoidance = m_config->opt_bool("resonance_avoidance");
         toggle_option("min_resonance_avoidance_speed", resonance_avoidance);
         toggle_option("max_resonance_avoidance_speed", resonance_avoidance);

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -5268,7 +5268,7 @@ void TabPrinter::clear_pages()
     m_reset_to_filament_color = nullptr;
 }
 
-std::vector<InputShaperType> TabPrinter::input_shaper_types_for_flavor(GCodeFlavor flavor)
+std::vector<InputShaperType> input_shaper_types_for_flavor(GCodeFlavor flavor)
 {
     switch (flavor) {
     case GCodeFlavor::gcfKlipper:
@@ -5279,7 +5279,8 @@ std::vector<InputShaperType> TabPrinter::input_shaper_types_for_flavor(GCodeFlav
             InputShaperType::ZVD,
             InputShaperType::EI,
             InputShaperType::TwoHumpEI,
-            InputShaperType::ThreeHumpEI
+            InputShaperType::ThreeHumpEI,
+            InputShaperType::Disable
         };
     case GCodeFlavor::gcfRepRapFirmware:
         return {
@@ -5290,12 +5291,19 @@ std::vector<InputShaperType> TabPrinter::input_shaper_types_for_flavor(GCodeFlav
             InputShaperType::ZVDDD,
             InputShaperType::EI2,
             InputShaperType::EI3,
-            InputShaperType::DAA
+            InputShaperType::DAA,
+            InputShaperType::Disable
         };
     case GCodeFlavor::gcfMarlinFirmware:
-        return { InputShaperType::ZV };
+        return {
+            InputShaperType::ZV,
+            InputShaperType::Disable
+        };
     default:
-        return { InputShaperType::Default };
+        return {
+            InputShaperType::Default,
+            InputShaperType::Disable
+        };
     }
 }
 

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -4796,7 +4796,7 @@ PageShp TabPrinter::build_kinematics_page()
     optgroup->append_single_option_line("emit_machine_limits_to_gcode", "printer_motion_ability#emit-limits-to-g-code");
 
     // resonance avoidance ported over from qidi slicer
-    optgroup = page->new_optgroup(L("Resonance Avoidance"), "param_resonance_avoidance");
+    optgroup = page->new_optgroup(L("Resonance Compensation"), "param_resonance_avoidance");
     optgroup->append_single_option_line("resonance_avoidance", "printer_motion_ability#resonance-avoidance");
     // Resonance‑avoidance speed inputs
     {
@@ -4806,16 +4806,16 @@ PageShp TabPrinter::build_kinematics_page()
         resonance_line.append_option(optgroup->get_option("max_resonance_avoidance_speed"));
         optgroup->append_line(resonance_line);
     }
-    optgroup->append_single_option_line("input_shaping_enable");
-    optgroup->append_single_option_line("input_shaping_type");
+    optgroup->append_single_option_line("input_shaping_enable", "input-shaping-calib");
+    optgroup->append_single_option_line("input_shaping_type", "input-shaping-calib");
     {
-        Line freq_line = {L("Frequency"), L("")};
+        Line freq_line = {L("Frequency"), L("The frequency of the anti-vibration signal will correspond to the natural frequency of the frame.")};
         freq_line.append_option(optgroup->get_option("input_shaping_freq_x"));
         freq_line.append_option(optgroup->get_option("input_shaping_freq_y"));
         optgroup->append_line(freq_line);
     }
     {
-        Line damping_line = {L("Damping"), L("")};
+        Line damping_line = {L("Damping"), L("Damping ratio for the input shaping filter.")};
         damping_line.append_option(optgroup->get_option("input_shaping_damp_x"));
         damping_line.append_option(optgroup->get_option("input_shaping_damp_y"));
         optgroup->append_line(damping_line);

--- a/src/slic3r/GUI/Tab.hpp
+++ b/src/slic3r/GUI/Tab.hpp
@@ -57,6 +57,8 @@ namespace GUI {
 class TabPresetComboBox;
 class OG_CustomCtrl;
 
+std::vector<InputShaperType> input_shaper_types_for_flavor(GCodeFlavor flavor);
+
 // Single Tab page containing a{ vsizer } of{ optgroups }
 // package Slic3r::GUI::Tab::Page;
 using ConfigOptionsGroupShp = std::shared_ptr<ConfigOptionsGroup>;
@@ -601,7 +603,6 @@ private:
 	void		append_option_line(ConfigOptionsGroupShp optgroup, const std::string opt_key, const std::string& label_path = "");
 	bool		m_rebuild_kinematics_page = false;
 	void        update_input_shaper_menu(GCodeFlavor flavor);
-	static std::vector<InputShaperType> input_shaper_types_for_flavor(GCodeFlavor flavor);
 
 	ogStaticText*	m_fff_print_host_upload_description_line {nullptr};
 	ogStaticText*	m_sla_print_host_upload_description_line {nullptr};

--- a/src/slic3r/GUI/Tab.hpp
+++ b/src/slic3r/GUI/Tab.hpp
@@ -600,6 +600,8 @@ private:
 	bool		m_use_silent_mode = false;
 	void		append_option_line(ConfigOptionsGroupShp optgroup, const std::string opt_key, const std::string& label_path = "");
 	bool		m_rebuild_kinematics_page = false;
+	void        update_input_shaper_menu(GCodeFlavor flavor);
+	static std::vector<InputShaperType> input_shaper_types_for_flavor(GCodeFlavor flavor);
 
 	ogStaticText*	m_fff_print_host_upload_description_line {nullptr};
 	ogStaticText*	m_sla_print_host_upload_description_line {nullptr};
@@ -637,6 +639,7 @@ public:
     void		update_fff();
     void		update_sla();
     void        update_pages(); // update m_pages according to printer technology
+	void        on_gcode_flavor_changed();
 	void		extruders_count_changed(size_t extruders_count);
 	PageShp		build_kinematics_page();
 	void		build_unregular_pages(bool from_initial_build = false);

--- a/src/slic3r/GUI/calib_dlg.cpp
+++ b/src/slic3r/GUI/calib_dlg.cpp
@@ -13,6 +13,8 @@
 
 namespace Slic3r { namespace GUI {
 
+std::vector<InputShaperType> input_shaper_types_for_flavor(GCodeFlavor flavor);
+
 namespace {
 
 void ParseStringValues(std::string str, std::vector<double> &vec)
@@ -36,18 +38,29 @@ std::vector<std::string> get_shaper_type_values()
 {
     if (auto* preset_bundle = wxGetApp().preset_bundle) {
         auto printer_config = &preset_bundle->printers.get_edited_preset().config;
-        if (auto* gcode_flavor_option = printer_config->option<ConfigOptionEnum<GCodeFlavor>>("gcode_flavor")) {
-            switch (gcode_flavor_option->value) {
-            case GCodeFlavor::gcfKlipper:
-                return {"Default", "ZV", "MZV", "ZVD", "EI", "2HUMP_EI", "3HUMP_EI"};
-            case GCodeFlavor::gcfRepRapFirmware:
-                return {"Default", "MZV", "ZVD", "ZVDD", "ZVDDD", "EI2", "EI3", "DAA"};
-            case GCodeFlavor::gcfMarlinFirmware:
-                return {"ZV"};
-            default:
-                break;
+        const auto* gcode_flavor_option = printer_config->option<ConfigOptionEnum<GCodeFlavor>>("gcode_flavor");
+        const ConfigOptionDef* def = printer_config->def()->get("input_shaping_type");
+        if (gcode_flavor_option) {
+            auto types = input_shaper_types_for_flavor(gcode_flavor_option->value);
+            if (!types.empty()) {
+                std::vector<std::string> values;
+                values.reserve(types.size());
+                for (InputShaperType type : types) {
+                    if (type == InputShaperType::Disable)
+                        continue;
+                    const size_t idx = static_cast<size_t>(type);
+                    if (def && idx < def->enum_values.size())
+                        values.push_back(def->enum_values[idx]);
+                    else
+                        values.push_back(std::to_string(static_cast<int>(type)));
+                }
+                if (!values.empty())
+                    return values;
             }
         }
+
+        if (def && !def->enum_values.empty())
+            return {def->enum_values.front()};
     }
     return {"Default"};
 }


### PR DESCRIPTION
# Description

Added Resonance Compensation override to set your printer Freq and Damp values.
This is a good improvement for Marlin printers that have their IS menu disabled (here is an example of people asking to add it to the FW for Ender 3v3 SE https://github.com/CrealityOfficial/Ender-3V3-SE/pull/8)

- Types
  - Adaptive Klipper, RRF or Marlin 2
  - Disable: Override the Firmware with 0 freq and 0 Damp.
- X
  - Freq
  - Damp
- Y (Disables in RRF)
  - Ferq
  - Damp
- ~~Mod: Print machine envelope to add IS values in klipper~~.
- Mod: Disable "Emit limits to G-code" for klipper.
- [Wiki](https://github.com/OrcaSlicer/OrcaSlicer_WIKI/pull/8)

<img width="697" height="206" alt="imagen" src="https://github.com/user-attachments/assets/2964d917-95ce-4ee6-81d6-79cfde0bea2a" />


https://github.com/user-attachments/assets/05294ca9-bd36-4ed1-9fcb-342f1290fc37



