### PR TITLE
Bridge Line Width + Improve bridge density

### DIFF
--- a/src/libslic3r/Flow.cpp
+++ b/src/libslic3r/Flow.cpp
@@ -49,6 +49,8 @@ static inline FlowRole opt_key_to_flow_role(const std::string &opt_key)
         return frInfill;
     else if (opt_key == "internal_solid_infill_line_width")
         return frSolidInfill;
+    else if (opt_key == "bridge_line_width")
+        return frSolidInfill;
 	else if (opt_key == "top_surface_line_width")
 		return frTopSolidInfill;
 	else if (opt_key == "support_line_width")
@@ -67,6 +69,26 @@ double Flow::extrusion_width(const std::string& opt_key, const ConfigOptionFloat
 {
 	assert(opt != nullptr);
 
+    auto opt_nozzle_diameters = config.option<ConfigOptionFloats>("nozzle_diameter");
+    if (opt_nozzle_diameters == nullptr)
+        throw_on_missing_variable(opt_key, "nozzle_diameter");
+    const float nozzle_diameter = float(opt_nozzle_diameters->get_at(first_printing_extruder));
+
+    if (opt_key == "bridge_line_width") {
+        if (opt->percent) {
+            const double bridge_width = opt->get_abs_value(nozzle_diameter);
+            if (bridge_width > 0.)
+                return bridge_width;
+        } else if (opt->value > 0.) {
+            return opt->value;
+        }
+
+        opt = config.option<ConfigOptionFloatOrPercent>("internal_solid_infill_line_width");
+        if (opt == nullptr)
+            throw_on_missing_variable(opt_key, "internal_solid_infill_line_width");
+        return extrusion_width("internal_solid_infill_line_width", opt, config, first_printing_extruder);
+    }
+
 #if 0
 // This is the logic used for skit / brim, but not for the rest of the 1st layer.
 	if (opt->value == 0. && first_layer) {
@@ -84,17 +106,13 @@ double Flow::extrusion_width(const std::string& opt_key, const ConfigOptionFloat
     		throw_on_missing_variable(opt_key, "line_width");
 	}
 
-    auto opt_nozzle_diameters = config.option<ConfigOptionFloats>("nozzle_diameter");
-    if (opt_nozzle_diameters == nullptr)
-        throw_on_missing_variable(opt_key, "nozzle_diameter");
-
     if (opt->percent) {
-		return opt->get_abs_value(float(opt_nozzle_diameters->get_at(first_printing_extruder)));
+        return opt->get_abs_value(nozzle_diameter);
 	}
 
 	if (opt->value == 0.) {
         // If user left option to 0, calculate a sane default width.
-        return auto_extrusion_width(opt_key_to_flow_role(opt_key), float(opt_nozzle_diameters->get_at(first_printing_extruder)));
+        return auto_extrusion_width(opt_key_to_flow_role(opt_key), nozzle_diameter);
     }
 
 	return opt->value;

--- a/src/libslic3r/LayerRegion.cpp
+++ b/src/libslic3r/LayerRegion.cpp
@@ -33,6 +33,7 @@ Flow LayerRegion::bridging_flow(FlowRole role, bool thick_bridge) const
     const PrintRegionConfig &region_config  = region.config();
     const PrintObject       &print_object   = *this->layer()->object();
     Flow bridge_flow;
+    // Here this->extruder(role) - 1 may underflow to MAX_INT, but then the get_at() will fall back to zero'th element, so everything is all right.
     auto nozzle_diameter = float(print_object.print()->config().nozzle_diameter.get_at(region.extruder(role) - 1));
     const ConfigOptionFloatOrPercent& bridge_width_opt = region_config.bridge_line_width;
     const bool                        has_bridge_width = bridge_width_opt.percent || bridge_width_opt.value > 0.;
@@ -41,7 +42,6 @@ Flow LayerRegion::bridging_flow(FlowRole role, bool thick_bridge) const
     if (thick_bridge) {
         // The old Slic3r way (different from all other slicers): Use rounded extrusions.
         // Get the configured nozzle_diameter for the extruder associated to the flow role requested.
-        // Here this->extruder(role) - 1 may underflow to MAX_INT, but then the get_at() will fall back to zero'th element, so everything is all right.
         float thread_diameter = has_bridge_width ? float(bridge_width_opt.get_abs_value(nozzle_diameter)) : nozzle_diameter;
         if (bridge_flow_ratio > 0.)
             thread_diameter *= float(sqrt(bridge_flow_ratio));

--- a/src/libslic3r/LayerRegion.cpp
+++ b/src/libslic3r/LayerRegion.cpp
@@ -44,6 +44,9 @@ Flow LayerRegion::bridging_flow(FlowRole role, bool thick_bridge) const
         // The same way as other slicers: Use normal extrusions. Apply bridge_flow while maintaining the original spacing.
         bridge_flow = this->flow(role).with_flow_ratio(region_config.bridge_flow);
     }
+    const float line_width_ratio = region_config.bridge_line_width;
+    if (line_width_ratio > 0.f && line_width_ratio != 1.f)
+        bridge_flow = bridge_flow.with_spacing(bridge_flow.spacing() * line_width_ratio);
     return bridge_flow;
 
 }

--- a/src/libslic3r/LayerRegion.cpp
+++ b/src/libslic3r/LayerRegion.cpp
@@ -11,7 +11,6 @@
 
 #include <string>
 #include <map>
-#include <cmath>
 
 #include <boost/log/trivial.hpp>
 #include <boost/algorithm/clamp.hpp>
@@ -45,7 +44,7 @@ Flow LayerRegion::bridging_flow(FlowRole role, bool thick_bridge) const
         // Here this->extruder(role) - 1 may underflow to MAX_INT, but then the get_at() will fall back to zero'th element, so everything is all right.
         float thread_diameter = has_bridge_width ? float(bridge_width_opt.get_abs_value(nozzle_diameter)) : nozzle_diameter;
         if (bridge_flow_ratio > 0.)
-            thread_diameter *= float(std::sqrt(bridge_flow_ratio));
+            thread_diameter *= float(sqrt(bridge_flow_ratio));
         bridge_flow = Flow::bridging_flow(thread_diameter, nozzle_diameter);
     } else {
         // The same way as other slicers: Use normal extrusions. Apply bridge_flow while maintaining the original spacing.

--- a/src/libslic3r/LayerRegion.cpp
+++ b/src/libslic3r/LayerRegion.cpp
@@ -36,13 +36,14 @@ Flow LayerRegion::bridging_flow(FlowRole role, bool thick_bridge) const
     // Here this->extruder(role) - 1 may underflow to MAX_INT, but then the get_at() will fall back to zero'th element, so everything is all right.
     auto nozzle_diameter = float(print_object.print()->config().nozzle_diameter.get_at(region.extruder(role) - 1));
     const ConfigOptionFloatOrPercent& bridge_width_opt = region_config.bridge_line_width;
-    const bool                        has_bridge_width = bridge_width_opt.percent || bridge_width_opt.value > 0.;
+    const double                      bridge_width      = bridge_width_opt.get_abs_value(nozzle_diameter);
+    const bool                        has_bridge_width  = bridge_width > 0.;
     const double                      bridge_flow_ratio = region_config.bridge_flow;
 
     if (thick_bridge) {
         // The old Slic3r way (different from all other slicers): Use rounded extrusions.
         // Get the configured nozzle_diameter for the extruder associated to the flow role requested.
-        float thread_diameter = has_bridge_width ? float(bridge_width_opt.get_abs_value(nozzle_diameter)) : nozzle_diameter;
+        float thread_diameter = has_bridge_width ? float(bridge_width) : nozzle_diameter;
         if (bridge_flow_ratio > 0.)
             thread_diameter *= float(sqrt(bridge_flow_ratio));
         bridge_flow = Flow::bridging_flow(thread_diameter, nozzle_diameter);
@@ -50,7 +51,7 @@ Flow LayerRegion::bridging_flow(FlowRole role, bool thick_bridge) const
         // The same way as other slicers: Use normal extrusions. Apply bridge_flow while maintaining the original spacing.
         Flow base_flow = this->flow(role);
         if (has_bridge_width)
-            base_flow = Flow(float(bridge_width_opt.get_abs_value(nozzle_diameter)), base_flow.height(), nozzle_diameter);
+            base_flow = Flow(float(bridge_width), base_flow.height(), nozzle_diameter);
         bridge_flow = base_flow.with_flow_ratio(bridge_flow_ratio);
     }
     return bridge_flow;

--- a/src/libslic3r/LayerRegion.cpp
+++ b/src/libslic3r/LayerRegion.cpp
@@ -45,6 +45,9 @@ Flow LayerRegion::bridging_flow(FlowRole role, bool thick_bridge) const
         // The same way as other slicers: Use normal extrusions. Apply bridge_flow while maintaining the original spacing.
         bridge_flow = this->flow(role).with_flow_ratio(region_config.bridge_flow);
     }
+    const float line_width_ratio = region_config.bridge_line_width;
+    if (line_width_ratio > 0.f && line_width_ratio != 1.f)
+        bridge_flow = bridge_flow.with_spacing(bridge_flow.spacing() * line_width_ratio);
     return bridge_flow;
 
 }

--- a/src/libslic3r/LayerRegion.cpp
+++ b/src/libslic3r/LayerRegion.cpp
@@ -37,13 +37,14 @@ Flow LayerRegion::bridging_flow(FlowRole role, bool thick_bridge) const
     // Here this->extruder(role) - 1 may underflow to MAX_INT, but then the get_at() will fall back to zero'th element, so everything is all right.
     auto nozzle_diameter = float(print_object.print()->config().nozzle_diameter.get_at(region.extruder(role) - 1));
     const ConfigOptionFloatOrPercent& bridge_width_opt = region_config.bridge_line_width;
-    const bool                        has_bridge_width = bridge_width_opt.percent || bridge_width_opt.value > 0.;
+    const double                      bridge_width      = bridge_width_opt.get_abs_value(nozzle_diameter);
+    const bool                        has_bridge_width  = bridge_width > 0.;
     const double                      bridge_flow_ratio = region_config.bridge_flow;
 
     if (thick_bridge) {
         // The old Slic3r way (different from all other slicers): Use rounded extrusions.
         // Get the configured nozzle_diameter for the extruder associated to the flow role requested.
-        float thread_diameter = has_bridge_width ? float(bridge_width_opt.get_abs_value(nozzle_diameter)) : nozzle_diameter;
+        float thread_diameter = has_bridge_width ? float(bridge_width) : nozzle_diameter;
         if (bridge_flow_ratio > 0.)
             thread_diameter *= float(sqrt(bridge_flow_ratio));
         bridge_flow = Flow::bridging_flow(thread_diameter, nozzle_diameter);
@@ -51,7 +52,7 @@ Flow LayerRegion::bridging_flow(FlowRole role, bool thick_bridge) const
         // The same way as other slicers: Use normal extrusions. Apply bridge_flow while maintaining the original spacing.
         Flow base_flow = this->flow(role);
         if (has_bridge_width)
-            base_flow = Flow(float(bridge_width_opt.get_abs_value(nozzle_diameter)), base_flow.height(), nozzle_diameter);
+            base_flow = Flow(float(bridge_width), base_flow.height(), nozzle_diameter);
         bridge_flow = base_flow.with_flow_ratio(bridge_flow_ratio);
     }
     return bridge_flow;

--- a/src/libslic3r/LayerRegion.cpp
+++ b/src/libslic3r/LayerRegion.cpp
@@ -34,6 +34,7 @@ Flow LayerRegion::bridging_flow(FlowRole role, bool thick_bridge) const
     const PrintRegionConfig &region_config  = region.config();
     const PrintObject       &print_object   = *this->layer()->object();
     Flow bridge_flow;
+    // Here this->extruder(role) - 1 may underflow to MAX_INT, but then the get_at() will fall back to zero'th element, so everything is all right.
     auto nozzle_diameter = float(print_object.print()->config().nozzle_diameter.get_at(region.extruder(role) - 1));
     const ConfigOptionFloatOrPercent& bridge_width_opt = region_config.bridge_line_width;
     const bool                        has_bridge_width = bridge_width_opt.percent || bridge_width_opt.value > 0.;
@@ -42,7 +43,6 @@ Flow LayerRegion::bridging_flow(FlowRole role, bool thick_bridge) const
     if (thick_bridge) {
         // The old Slic3r way (different from all other slicers): Use rounded extrusions.
         // Get the configured nozzle_diameter for the extruder associated to the flow role requested.
-        // Here this->extruder(role) - 1 may underflow to MAX_INT, but then the get_at() will fall back to zero'th element, so everything is all right.
         float thread_diameter = has_bridge_width ? float(bridge_width_opt.get_abs_value(nozzle_diameter)) : nozzle_diameter;
         if (bridge_flow_ratio > 0.)
             thread_diameter *= float(sqrt(bridge_flow_ratio));

--- a/src/libslic3r/LayerRegion.cpp
+++ b/src/libslic3r/LayerRegion.cpp
@@ -12,6 +12,7 @@
 
 #include <string>
 #include <map>
+#include <cmath>
 
 #include <boost/log/trivial.hpp>
 #include <boost/algorithm/clamp.hpp>
@@ -35,19 +36,25 @@ Flow LayerRegion::bridging_flow(FlowRole role, bool thick_bridge) const
     const PrintObject       &print_object   = *this->layer()->object();
     Flow bridge_flow;
     auto nozzle_diameter = float(print_object.print()->config().nozzle_diameter.get_at(region.extruder(role) - 1));
+    const ConfigOptionFloatOrPercent& bridge_width_opt = region_config.bridge_line_width;
+    const bool                        has_bridge_width = bridge_width_opt.percent || bridge_width_opt.value > 0.;
+    const double                      bridge_flow_ratio = region_config.bridge_flow;
+
     if (thick_bridge) {
         // The old Slic3r way (different from all other slicers): Use rounded extrusions.
         // Get the configured nozzle_diameter for the extruder associated to the flow role requested.
-        // Here this->extruder(role) - 1 may underflow to MAX_INT, but then the get_at() will follback to zero'th element, so everything is all right.
-        // Applies default bridge spacing.
-        bridge_flow = Flow::bridging_flow(float(sqrt(region_config.bridge_flow)) * nozzle_diameter, nozzle_diameter);
+        // Here this->extruder(role) - 1 may underflow to MAX_INT, but then the get_at() will fall back to zero'th element, so everything is all right.
+        float thread_diameter = has_bridge_width ? float(bridge_width_opt.get_abs_value(nozzle_diameter)) : nozzle_diameter;
+        if (bridge_flow_ratio > 0.)
+            thread_diameter *= float(std::sqrt(bridge_flow_ratio));
+        bridge_flow = Flow::bridging_flow(thread_diameter, nozzle_diameter);
     } else {
         // The same way as other slicers: Use normal extrusions. Apply bridge_flow while maintaining the original spacing.
-        bridge_flow = this->flow(role).with_flow_ratio(region_config.bridge_flow);
+        Flow base_flow = this->flow(role);
+        if (has_bridge_width)
+            base_flow = Flow(float(bridge_width_opt.get_abs_value(nozzle_diameter)), base_flow.height(), nozzle_diameter);
+        bridge_flow = base_flow.with_flow_ratio(bridge_flow_ratio);
     }
-    const float line_width_ratio = region_config.bridge_line_width;
-    if (line_width_ratio > 0.f && line_width_ratio != 1.f)
-        bridge_flow = bridge_flow.with_spacing(bridge_flow.spacing() * line_width_ratio);
     return bridge_flow;
 
 }

--- a/src/libslic3r/LayerRegion.cpp
+++ b/src/libslic3r/LayerRegion.cpp
@@ -12,7 +12,6 @@
 
 #include <string>
 #include <map>
-#include <cmath>
 
 #include <boost/log/trivial.hpp>
 #include <boost/algorithm/clamp.hpp>
@@ -46,7 +45,7 @@ Flow LayerRegion::bridging_flow(FlowRole role, bool thick_bridge) const
         // Here this->extruder(role) - 1 may underflow to MAX_INT, but then the get_at() will fall back to zero'th element, so everything is all right.
         float thread_diameter = has_bridge_width ? float(bridge_width_opt.get_abs_value(nozzle_diameter)) : nozzle_diameter;
         if (bridge_flow_ratio > 0.)
-            thread_diameter *= float(std::sqrt(bridge_flow_ratio));
+            thread_diameter *= float(sqrt(bridge_flow_ratio));
         bridge_flow = Flow::bridging_flow(thread_diameter, nozzle_diameter);
     } else {
         // The same way as other slicers: Use normal extrusions. Apply bridge_flow while maintaining the original spacing.

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -918,7 +918,7 @@ static std::vector<std::string> s_Preset_print_options {
     "ooze_prevention", "standby_temperature_delta", "preheat_time","preheat_steps", "interface_shells", "line_width", "initial_layer_line_width", "inner_wall_line_width",
     "outer_wall_line_width", "sparse_infill_line_width", "internal_solid_infill_line_width",
     "skin_infill_line_width","skeleton_infill_line_width",
-    "top_surface_line_width", "support_line_width", "infill_wall_overlap","top_bottom_infill_wall_overlap", "bridge_flow", "internal_bridge_flow",
+    "top_surface_line_width", "support_line_width", "infill_wall_overlap","top_bottom_infill_wall_overlap", "bridge_flow", "bridge_line_width", "internal_bridge_flow",
     "elefant_foot_compensation", "elefant_foot_compensation_layers", "xy_contour_compensation", "xy_hole_compensation", "resolution", "enable_prime_tower", "prime_tower_enable_framework",
     "prime_tower_width", "prime_tower_brim_width", "prime_tower_skip_points", "prime_volume",
     "prime_tower_infill_gap",

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -1094,6 +1094,7 @@ static std::vector<std::string> s_Preset_print_options{
     "infill_wall_overlap",
     "top_bottom_infill_wall_overlap",
     "bridge_flow",
+    "bridge_line_width",
     "internal_bridge_flow",
     "elefant_foot_compensation",
     "elefant_foot_compensation_layers",

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -1470,12 +1470,12 @@ StringObjectException Print::validate(StringObjectException *warning, Polygons* 
             double extrusion_width_min = config.get_abs_value(opt_key, min_nozzle_diameter);
             double extrusion_width_max = config.get_abs_value(opt_key, max_nozzle_diameter);
             double allowed_max = is_bridge_width ? max_nozzle_diameter : max_nozzle_diameter * MAX_LINE_WIDTH_MULTIPLIER;
-        	if (extrusion_width_min == 0) {
-        		// Default "auto-generated" extrusion width is always valid.
-        	} else if (extrusion_width_min <= layer_height) {
-                err_msg = L("Too small line width");
-				return false;
-            } else if (extrusion_width_max > allowed_max) {
+            if (extrusion_width_min == 0) {
+                // Default "auto-generated" extrusion width is always valid.
+            } else if (!is_bridge_width && extrusion_width_min <= layer_height) {
+                    err_msg = L("Too small line width");
+                    return false;
+                } else if (extrusion_width_max > allowed_max) {
                 err_msg = is_bridge_width ? L("Bridge line width must not exceed nozzle diameter") : L("Too large line width");
 				return false;
 			}

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -1590,7 +1590,7 @@ StringObjectException Print::validate(StringObjectException *warning, Polygons* 
                 if (!validate_extrusion_width(object->config(), "support_line_width", layer_height, err_msg))
                     return {err_msg, object, "support_line_width"};
             }
-            for (const char *opt_key : { "inner_wall_line_width", "outer_wall_line_width", "sparse_infill_line_width", "internal_solid_infill_line_width", "top_surface_line_width","skin_infill_line_width" ,"skeleton_infill_line_width"})
+            for (const char *opt_key : { "inner_wall_line_width", "outer_wall_line_width", "sparse_infill_line_width", "internal_solid_infill_line_width", "top_surface_line_width","skin_infill_line_width" ,"skeleton_infill_line_width", "bridge_line_width"})
 				for (const PrintRegion &region : object->all_regions())
                     if (!validate_extrusion_width(region.config(), opt_key, layer_height, err_msg))
 		            	return  {err_msg, object, opt_key};

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -22,6 +22,7 @@
 #include <float.h>
 
 #include <algorithm>
+#include <cstring>
 #include <limits>
 #include <unordered_set>
 #include <boost/filesystem/path.hpp>
@@ -1465,15 +1466,17 @@ StringObjectException Print::validate(StringObjectException *warning, Polygons* 
 #endif
 
         auto validate_extrusion_width = [min_nozzle_diameter, max_nozzle_diameter](const ConfigBase &config, const char *opt_key, double layer_height, std::string &err_msg) -> bool {
+            const bool is_bridge_width = std::strcmp(opt_key, "bridge_line_width") == 0;
             double extrusion_width_min = config.get_abs_value(opt_key, min_nozzle_diameter);
             double extrusion_width_max = config.get_abs_value(opt_key, max_nozzle_diameter);
+            double allowed_max = is_bridge_width ? max_nozzle_diameter : max_nozzle_diameter * MAX_LINE_WIDTH_MULTIPLIER;
         	if (extrusion_width_min == 0) {
         		// Default "auto-generated" extrusion width is always valid.
         	} else if (extrusion_width_min <= layer_height) {
                 err_msg = L("Too small line width");
 				return false;
-			} else if (extrusion_width_max > max_nozzle_diameter * MAX_LINE_WIDTH_MULTIPLIER) {
-                err_msg = L("Too large line width");
+            } else if (extrusion_width_max > allowed_max) {
+                err_msg = is_bridge_width ? L("Bridge line width must not exceed nozzle diameter") : L("Too large line width");
 				return false;
 			}
 			return true;

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -22,7 +22,6 @@
 #include <float.h>
 
 #include <algorithm>
-#include <cstring>
 #include <limits>
 #include <unordered_set>
 #include <boost/filesystem/path.hpp>
@@ -1466,17 +1465,15 @@ StringObjectException Print::validate(StringObjectException *warning, Polygons* 
 #endif
 
         auto validate_extrusion_width = [min_nozzle_diameter, max_nozzle_diameter](const ConfigBase &config, const char *opt_key, double layer_height, std::string &err_msg) -> bool {
-            const bool is_bridge_width = std::strcmp(opt_key, "bridge_line_width") == 0;
             double extrusion_width_min = config.get_abs_value(opt_key, min_nozzle_diameter);
             double extrusion_width_max = config.get_abs_value(opt_key, max_nozzle_diameter);
-            double allowed_max = is_bridge_width ? max_nozzle_diameter : max_nozzle_diameter * MAX_LINE_WIDTH_MULTIPLIER;
             if (extrusion_width_min == 0) {
                 // Default "auto-generated" extrusion width is always valid.
-            } else if (!is_bridge_width && extrusion_width_min <= layer_height) {
+            } else if (extrusion_width_min <= layer_height) {
                     err_msg = L("Too small line width");
                     return false;
-                } else if (extrusion_width_max > allowed_max) {
-                err_msg = is_bridge_width ? L("Bridge line width must not exceed nozzle diameter") : L("Too large line width");
+                } else if (extrusion_width_max > max_nozzle_diameter * MAX_LINE_WIDTH_MULTIPLIER) {
+                err_msg = L("Too large line width");
 				return false;
 			}
 			return true;
@@ -1593,10 +1590,29 @@ StringObjectException Print::validate(StringObjectException *warning, Polygons* 
                 if (!validate_extrusion_width(object->config(), "support_line_width", layer_height, err_msg))
                     return {err_msg, object, "support_line_width"};
             }
-            for (const char *opt_key : { "inner_wall_line_width", "outer_wall_line_width", "sparse_infill_line_width", "internal_solid_infill_line_width", "top_surface_line_width","skin_infill_line_width" ,"skeleton_infill_line_width", "bridge_line_width"})
+            for (const char *opt_key : { "inner_wall_line_width", "outer_wall_line_width", "sparse_infill_line_width", "internal_solid_infill_line_width", "top_surface_line_width","skin_infill_line_width" ,"skeleton_infill_line_width"})
 				for (const PrintRegion &region : object->all_regions())
                     if (!validate_extrusion_width(region.config(), opt_key, layer_height, err_msg))
 		            	return  {err_msg, object, opt_key};
+
+            const bool allow_thin_bridge_width = object->config().thick_bridges && object->config().thick_internal_bridges;
+            for (const PrintRegion &region : object->all_regions()) {
+                const auto &bridge_width_opt = region.config().bridge_line_width;
+                for (FlowRole bridge_role : { frPerimeter, frInfill, frSolidInfill, frTopSolidInfill }) {
+                    const double nozzle_diameter = m_config.nozzle_diameter.get_at(region.extruder(bridge_role) - 1);
+                    const double bridge_width    = bridge_width_opt.get_abs_value(nozzle_diameter);
+                    if (bridge_width <= 0.)
+                        continue;
+                    if (bridge_width > nozzle_diameter) {
+                        err_msg = L("Bridge line width must not exceed nozzle diameter");
+                        return { err_msg, object, "bridge_line_width" };
+                    }
+                    if (!allow_thin_bridge_width && bridge_width <= layer_height) {
+                        err_msg = L("Too small line width");
+                        return { err_msg, object, "bridge_line_width" };
+                    }
+                }
+            }
         }
     }
 

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -22,7 +22,6 @@
 #include <float.h>
 
 #include <algorithm>
-#include <cstring>
 #include <limits>
 #include <unordered_set>
 #include <boost/filesystem/path.hpp>
@@ -1543,17 +1542,15 @@ StringObjectException Print::validate(StringObjectException *warning, Polygons* 
 #endif
 
         auto validate_extrusion_width = [min_nozzle_diameter, max_nozzle_diameter](const ConfigBase &config, const char *opt_key, double layer_height, std::string &err_msg) -> bool {
-            const bool is_bridge_width = std::strcmp(opt_key, "bridge_line_width") == 0;
             double extrusion_width_min = config.get_abs_value(opt_key, min_nozzle_diameter);
             double extrusion_width_max = config.get_abs_value(opt_key, max_nozzle_diameter);
-            double allowed_max = is_bridge_width ? max_nozzle_diameter : max_nozzle_diameter * MAX_LINE_WIDTH_MULTIPLIER;
             if (extrusion_width_min == 0) {
                 // Default "auto-generated" extrusion width is always valid.
-            } else if (!is_bridge_width && extrusion_width_min <= layer_height) {
+            } else if (extrusion_width_min <= layer_height) {
                     err_msg = L("Too small line width");
                     return false;
-                } else if (extrusion_width_max > allowed_max) {
-                err_msg = is_bridge_width ? L("Bridge line width must not exceed nozzle diameter") : L("Too large line width");
+                } else if (extrusion_width_max > max_nozzle_diameter * MAX_LINE_WIDTH_MULTIPLIER) {
+                err_msg = L("Too large line width");
 				return false;
 			}
 			return true;
@@ -1670,10 +1667,29 @@ StringObjectException Print::validate(StringObjectException *warning, Polygons* 
                 if (!validate_extrusion_width(object->config(), "support_line_width", layer_height, err_msg))
                     return {err_msg, object, "support_line_width"};
             }
-            for (const char *opt_key : { "inner_wall_line_width", "outer_wall_line_width", "sparse_infill_line_width", "internal_solid_infill_line_width", "top_surface_line_width","skin_infill_line_width" ,"skeleton_infill_line_width", "bridge_line_width"})
+            for (const char *opt_key : { "inner_wall_line_width", "outer_wall_line_width", "sparse_infill_line_width", "internal_solid_infill_line_width", "top_surface_line_width","skin_infill_line_width" ,"skeleton_infill_line_width"})
 				for (const PrintRegion &region : object->all_regions())
                     if (!validate_extrusion_width(region.config(), opt_key, layer_height, err_msg))
 		            	return  {err_msg, object, opt_key};
+
+            const bool allow_thin_bridge_width = object->config().thick_bridges && object->config().thick_internal_bridges;
+            for (const PrintRegion &region : object->all_regions()) {
+                const auto &bridge_width_opt = region.config().bridge_line_width;
+                for (FlowRole bridge_role : { frPerimeter, frInfill, frSolidInfill, frTopSolidInfill }) {
+                    const double nozzle_diameter = m_config.nozzle_diameter.get_at(region.extruder(bridge_role) - 1);
+                    const double bridge_width    = bridge_width_opt.get_abs_value(nozzle_diameter);
+                    if (bridge_width <= 0.)
+                        continue;
+                    if (bridge_width > nozzle_diameter) {
+                        err_msg = L("Bridge line width must not exceed nozzle diameter");
+                        return { err_msg, object, "bridge_line_width" };
+                    }
+                    if (!allow_thin_bridge_width && bridge_width <= layer_height) {
+                        err_msg = L("Too small line width");
+                        return { err_msg, object, "bridge_line_width" };
+                    }
+                }
+            }
         }
     }
 

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -22,6 +22,7 @@
 #include <float.h>
 
 #include <algorithm>
+#include <cstring>
 #include <limits>
 #include <unordered_set>
 #include <boost/filesystem/path.hpp>
@@ -1542,15 +1543,17 @@ StringObjectException Print::validate(StringObjectException *warning, Polygons* 
 #endif
 
         auto validate_extrusion_width = [min_nozzle_diameter, max_nozzle_diameter](const ConfigBase &config, const char *opt_key, double layer_height, std::string &err_msg) -> bool {
+            const bool is_bridge_width = std::strcmp(opt_key, "bridge_line_width") == 0;
             double extrusion_width_min = config.get_abs_value(opt_key, min_nozzle_diameter);
             double extrusion_width_max = config.get_abs_value(opt_key, max_nozzle_diameter);
+            double allowed_max = is_bridge_width ? max_nozzle_diameter : max_nozzle_diameter * MAX_LINE_WIDTH_MULTIPLIER;
         	if (extrusion_width_min == 0) {
         		// Default "auto-generated" extrusion width is always valid.
         	} else if (extrusion_width_min <= layer_height) {
                 err_msg = L("Too small line width");
 				return false;
-			} else if (extrusion_width_max > max_nozzle_diameter * MAX_LINE_WIDTH_MULTIPLIER) {
-                err_msg = L("Too large line width");
+            } else if (extrusion_width_max > allowed_max) {
+                err_msg = is_bridge_width ? L("Bridge line width must not exceed nozzle diameter") : L("Too large line width");
 				return false;
 			}
 			return true;

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -1547,12 +1547,12 @@ StringObjectException Print::validate(StringObjectException *warning, Polygons* 
             double extrusion_width_min = config.get_abs_value(opt_key, min_nozzle_diameter);
             double extrusion_width_max = config.get_abs_value(opt_key, max_nozzle_diameter);
             double allowed_max = is_bridge_width ? max_nozzle_diameter : max_nozzle_diameter * MAX_LINE_WIDTH_MULTIPLIER;
-        	if (extrusion_width_min == 0) {
-        		// Default "auto-generated" extrusion width is always valid.
-        	} else if (extrusion_width_min <= layer_height) {
-                err_msg = L("Too small line width");
-				return false;
-            } else if (extrusion_width_max > allowed_max) {
+            if (extrusion_width_min == 0) {
+                // Default "auto-generated" extrusion width is always valid.
+            } else if (!is_bridge_width && extrusion_width_min <= layer_height) {
+                    err_msg = L("Too small line width");
+                    return false;
+                } else if (extrusion_width_max > allowed_max) {
                 err_msg = is_bridge_width ? L("Bridge line width must not exceed nozzle diameter") : L("Too large line width");
 				return false;
 			}

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -1667,7 +1667,7 @@ StringObjectException Print::validate(StringObjectException *warning, Polygons* 
                 if (!validate_extrusion_width(object->config(), "support_line_width", layer_height, err_msg))
                     return {err_msg, object, "support_line_width"};
             }
-            for (const char *opt_key : { "inner_wall_line_width", "outer_wall_line_width", "sparse_infill_line_width", "internal_solid_infill_line_width", "top_surface_line_width","skin_infill_line_width" ,"skeleton_infill_line_width"})
+            for (const char *opt_key : { "inner_wall_line_width", "outer_wall_line_width", "sparse_infill_line_width", "internal_solid_infill_line_width", "top_surface_line_width","skin_infill_line_width" ,"skeleton_infill_line_width", "bridge_line_width"})
 				for (const PrintRegion &region : object->all_regions())
                     if (!validate_extrusion_width(region.config(), opt_key, layer_height, err_msg))
 		            	return  {err_msg, object, opt_key};

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -1223,9 +1223,9 @@ void PrintConfigDef::init_fff_params()
     def->set_default_value(new ConfigOptionFloat(1));
 
     def = this->add("bridge_line_width", coFloatOrPercent);
-    def->label = L("Bridge line width");
+    def->label = L("Bridge");
     def->category = L("Quality");
-    def->tooltip = L("Override the bridge line width. Leave at 0 to use the automatic value, set an absolute width in millimeters, or provide a percentage of the nozzle diameter.");
+    def->tooltip = L("Bridge line width. Leave at 0 to ignore. If expressed as a %, it will be computed over the nozzle diameter.");
     def->sidetext = L("mm or %");
     def->ratio_over = "nozzle_diameter";
     def->min = 0;

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -1230,12 +1230,12 @@ void PrintConfigDef::init_fff_params()
     def = this->add("bridge_line_width", coFloatOrPercent);
     def->label = L("Bridge");
     def->category = L("Quality");
-    def->tooltip = L("Bridge line width. Recommended value 100% along with a higher External bridge density or Bridge flow ratio.\n"
-                     "Leave at 0 to ignore. If expressed as a %, it will be computed over the nozzle diameter.");
+    def->tooltip = L("Bridge line width expressed either as an absolute value or as a percentage of the active nozzle diameter (percentages are computed from the nozzle diameter). Recommended value 100% along with a higher External bridge density or Bridge flow ratio.\n"
+                     "Leave at 0 to use the automatic width.");
     def->sidetext = L("mm or %");
     def->ratio_over = "nozzle_diameter";
     def->min = 0;
-    def->max = 1000;
+    def->max = 100;
     def->max_literal = 10;
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionFloatOrPercent(100., true));
@@ -9808,8 +9808,13 @@ std::map<std::string, std::string> validate(const FullPrintConfig &cfg, bool und
             "skeleton_infill_line_width"};
         for (size_t i = 0; i < sizeof(widths) / sizeof(widths[i]); ++ i) {
             std::string key(widths[i]);
-            if (cfg.get_abs_value(key, max_nozzle_diameter) > MAX_LINE_WIDTH_MULTIPLIER * max_nozzle_diameter) {
-                error_message.emplace(key, L("too large line width ") + std::to_string(cfg.get_abs_value(key)));
+            double abs_width = cfg.get_abs_value(key, max_nozzle_diameter);
+            double allowed_max = (key == "bridge_line_width") ? max_nozzle_diameter : MAX_LINE_WIDTH_MULTIPLIER * max_nozzle_diameter;
+            if (abs_width > allowed_max) {
+                if (key == "bridge_line_width")
+                    error_message.emplace(key, L("Bridge line width must not exceed nozzle diameter: ") + std::to_string(abs_width));
+                else
+                    error_message.emplace(key, L("too large line width ") + std::to_string(abs_width));
                 //return std::string("Too Large line width: ") + key;
             }
         }

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -1222,7 +1222,7 @@ void PrintConfigDef::init_fff_params()
     def = this->add("bridge_flow", coFloat);
     def->label = L("Bridge flow ratio");
     def->category = L("Quality");
-    def->tooltip = L("This value governs the thickness of the external (visible) bridge layer."
+    def->tooltip = L("This value governs the thickness of the external (visible) bridge layer.\n"
                      "Values above 1.0: Increase the amount of material while maintaining line spacing. This can improve line contact and strength.\n"
                      "Values below 1.0: Reduce the amount of material while adjusting line spacing to maintain contact. This can improve sagging.\n\n"
                      "The actual bridge flow used is calculated by multiplying this value with the filament flow ratio, and if set, the object's flow ratio.");
@@ -9803,8 +9803,12 @@ std::map<std::string, std::string> validate(const FullPrintConfig &cfg, bool und
     // extrusion widths
     {
         double max_nozzle_diameter = 0.;
+        double min_nozzle_diameter = std::numeric_limits<double>::max();
         for (double dmr : cfg.nozzle_diameter.values)
+        {
             max_nozzle_diameter = std::max(max_nozzle_diameter, dmr);
+            min_nozzle_diameter = std::min(min_nozzle_diameter, dmr);
+        }
         const char *widths[] = {
             "outer_wall_line_width",
             "inner_wall_line_width",
@@ -9819,7 +9823,7 @@ std::map<std::string, std::string> validate(const FullPrintConfig &cfg, bool und
         for (size_t i = 0; i < sizeof(widths) / sizeof(widths[i]); ++ i) {
             std::string key(widths[i]);
             double abs_width = cfg.get_abs_value(key, max_nozzle_diameter);
-            double allowed_max = (key == "bridge_line_width") ? max_nozzle_diameter : MAX_LINE_WIDTH_MULTIPLIER * max_nozzle_diameter;
+            double allowed_max = (key == "bridge_line_width") ? min_nozzle_diameter : MAX_LINE_WIDTH_MULTIPLIER * max_nozzle_diameter;
             if (abs_width > allowed_max) {
                 if (key == "bridge_line_width")
                     error_message.emplace(key, L("Bridge line width must not exceed nozzle diameter: ") + std::to_string(abs_width));

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -1186,9 +1186,11 @@ void PrintConfigDef::init_fff_params()
     def = this->add("bridge_density", coPercent);
     def->label = L("External bridge density");
     def->category = L("Strength");
-    def->tooltip = L("Controls the density (spacing) of external bridge lines. Default is 100%.\n\n"
+    def->tooltip = L("Controls the density (spacing) of external bridge lines. 100% means solid bridge. Default is 100%.\n\n"
+                     "Due to the tendency for bridge extrusions to sag, a value of 100% may not be sufficient for proper welding between them,\n"
+                     "so it is recommended to increase it slightly while using 100% Bridge Line Width.\n"
                      "Lower density external bridges can help improve reliability as there is more space for air to circulate "
-                     "around the extruded bridge, improving its cooling speed. Minimum is 10%.\n\n"
+                     "around the extruded bridge, improving its cooling speed. Minimum is 10%.\n"
                      "Higher densities can produce smoother bridge surfaces, as overlapping lines provide "
                      "additional support during printing. Maximum is 120%.\n"
                      "Note: Bridge density that is too high can cause warping or overextrusion.");
@@ -1215,9 +1217,12 @@ void PrintConfigDef::init_fff_params()
     def = this->add("bridge_flow", coFloat);
     def->label = L("Bridge flow ratio");
     def->category = L("Quality");
-    def->tooltip = L("Increasing this value (~1.5) when using a Bridge Line Width of 100% (equal to the nozzle size) improves lateral contact between bridge lines, which significantly enhances bridging performance and reduces sagging.\n\n"
-                     "Slightly decreasing this value (e.g., to 0.9) lowers the amount of material used for bridges, which can help reduce sagging, but will prevent adjacent bridge lines from making lateral contact.\n\n"
-                     "The actual bridge flow used is calculated by multiplying this value with the filament flow ratio, and if set, the object's flow ratio.");
+    def->tooltip = L("Values above 1.0 add material:\n"
+                     "  - Regular bridges: Keep spacing and thicken the filament for stronger line contact when paired with a <= 100% Bridge line width.\n"
+                     "  - Thick bridges: Increase spacing and increase width, height and spacing.\n"
+                     "Values below 1.0 remove material:\n"
+                     "  - Regular bridges: eventually tighten spacing as the thread thins—potentially adding passes or altering paths—whereas.\n"
+                     "  - Thick bridges: shrink both diameter and spacing, cutting sagging at the cost of lateral bonding.");
     def->min = 0;
     def->max = 2.0;
     def->mode = comAdvanced;
@@ -1226,7 +1231,7 @@ void PrintConfigDef::init_fff_params()
     def = this->add("bridge_line_width", coFloatOrPercent);
     def->label = L("Bridge");
     def->category = L("Quality");
-    def->tooltip = L("Bridge line width. Recommended value 100% along with a higher Bridge flow ratio.\n"
+    def->tooltip = L("Bridge line width. Recommended value 100% along with a higher External bridge density or Bridge flow ratio.\n"
                      "Leave at 0 to ignore. If expressed as a %, it will be computed over the nozzle diameter.");
     def->sidetext = L("mm or %");
     def->ratio_over = "nozzle_diameter";

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -1187,41 +1187,47 @@ void PrintConfigDef::init_fff_params()
     def->label = L("External bridge density");
     def->category = L("Strength");
     def->tooltip = L("Controls the density (spacing) of external bridge lines. Default is 100%.\n"
-                     "Theoretically, 100% means a solid bridge, but due to the tendency of bridge extrusions to sag, 100% may not be sufficient."
-                     "Higher densities can produce smoother bridge surfaces, as overlapping lines provide "
-                     "additional support during printing. Maximum is 120%.\n"
-                     "Note: Bridge density that is too high can cause warping or overextrusion.\n\n"
-                     "Lower density external bridges can help improve reliability as there is more space for air to circulate "
-                     "around the extruded bridge, improving its cooling speed. Minimum is 10%.");
+                     "Theoretically, 100% means a solid bridge, but due to the tendency of bridge extrusions to sag, 100% may not be sufficient.\n\n"
+                     "- Higher than 100% density (Recommended Max 125%):\n"
+                     "  - Pros: Produces smoother bridge surfaces, as overlapping lines provide additional support during printing.\n"
+                     "  - Cons: Can cause overextrusion, which may reduce lower and upper surface quality and increase risk of warping.\n\n"
+                     "- Lower than 100% density (Min 10%):\n"
+                     "  - Pros: Can create a string-like first layer. Faster and with better cooling because there is more space for air to circulate around the extruded bridge.\n"
+                     "  - Cons: May lead to sagging and poorer surface finish.\n\n"
+                     "Recommended range: Minimum 10% - Maximum 125%.");
     def->sidetext = "%";
     def->min = 10;
-    def->max = 120;
+    def->max = 125;
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionPercent(100));
 
     def = this->add("internal_bridge_density", coPercent);
     def->label = L("Internal bridge density");
     def->category = L("Strength");
-    def->tooltip = L("Controls the density (spacing) of internal bridge lines. 100% means solid bridge. Default is 100%.\n\n"
-                     "Lower density internal bridges can help reduce top surface pillowing and improve internal bridge reliability as there is more space for "
-                     "air to circulate around the extruded bridge, improving its cooling speed.\n\n"
-                     "This option works particularly well when combined with the second internal bridge over infill option, "
-                     "further improving internal bridging structure before solid infill is extruded.");
+    def->tooltip = L("Controls the density (spacing) of internal bridge lines. Default is 100%. 100% means a solid internal bridge.\n\n"
+                     "Internal bridges act as intermediate support between sparse infill and top solid infill and can strongly affect top surface quality.\n\n"
+                     "- Higher than 100% density (Recommended Max 125%):\n"
+                     "  - Pros: Improves internal bridge strength and support under top layers, reducing sagging and improving top-surface finish.\n"
+                     "  - Cons: Increases material use and print time; excessive density may cause overextrusion and internal stresses.\n\n"
+                     "- Lower than 100% density (Min 10%):\n"
+                     "  - Pros: Can reduce pillowing and improve cooling (more airflow through the bridge), and may speed up printing.\n"
+                     "  - Cons: May reduce internal support, increasing the risk of sagging and top surface defects.\n\n"
+                     "This option works particularly well when combined with the second internal bridge over infill option to further improve bridging before solid infill is extruded.");
     def->sidetext = "%";
     def->min = 10;
-    def->max = 100;
+    def->max = 125;
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionPercent(100));
 
     def = this->add("bridge_flow", coFloat);
     def->label = L("Bridge flow ratio");
     def->category = L("Quality");
-    def->tooltip = L("Values above 1.0 add material:\n"
-                     "  - Regular bridges: Keep spacing and thicken the filament for stronger line contact when paired with a <= 100% Bridge line width.\n"
-                     "  - Thick bridges: Increase spacing and increase width, height and spacing.\n"
-                     "Values below 1.0 remove material:\n"
-                     "  - Regular bridges: eventually tighten spacing as the thread thins—potentially adding passes or altering paths—whereas.\n"
-                     "  - Thick bridges: shrink both diameter and spacing, cutting sagging at the cost of lateral bonding.");
+    def->tooltip = L("Values above 1.0:\n"
+                     "  - Regular bridges: Keep spacing and thicken the filament. If Bridge line width is <= 100%, this can improve line contact and strength.\n"
+                     "  - Thick bridges: Increase width, height, and spacing. May be stronger but increases the risk of sagging.\n"
+                     "Values below 1.0:\n"
+                     "  - Regular bridges: Reduce spacing; this can potentially add extra passes or alter paths.\n"
+                     "  - Thick bridges: Decrease width, height, and spacing. Reduces sagging at the cost of lateral bonding.");
     def->min = 0;
     def->max = 2.0;
     def->mode = comAdvanced;

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -1186,14 +1186,13 @@ void PrintConfigDef::init_fff_params()
     def = this->add("bridge_density", coPercent);
     def->label = L("External bridge density");
     def->category = L("Strength");
-    def->tooltip = L("Controls the density (spacing) of external bridge lines. 100% means solid bridge. Default is 100%.\n\n"
-                     "Due to the tendency for bridge extrusions to sag, a value of 100% may not be sufficient for proper welding between them,\n"
-                     "so it is recommended to increase it slightly while using 100% Bridge Line Width.\n"
-                     "Lower density external bridges can help improve reliability as there is more space for air to circulate "
-                     "around the extruded bridge, improving its cooling speed. Minimum is 10%.\n"
+    def->tooltip = L("Controls the density (spacing) of external bridge lines. Default is 100%.\n"
+                     "Theoretically, 100% means a solid bridge, but due to the tendency of bridge extrusions to sag, 100% may not be sufficient."
                      "Higher densities can produce smoother bridge surfaces, as overlapping lines provide "
                      "additional support during printing. Maximum is 120%.\n"
-                     "Note: Bridge density that is too high can cause warping or overextrusion.");
+                     "Note: Bridge density that is too high can cause warping or overextrusion.\n\n"
+                     "Lower density external bridges can help improve reliability as there is more space for air to circulate "
+                     "around the extruded bridge, improving its cooling speed. Minimum is 10%.")
     def->sidetext = "%";
     def->min = 10;
     def->max = 120;

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -1190,7 +1190,7 @@ void PrintConfigDef::init_fff_params()
                      "Theoretically, 100% means a solid bridge, but due to the tendency of bridge extrusions to sag, 100% may not be sufficient.\n\n"
                      "- Higher than 100% density (Recommended Max 125%):\n"
                      "  - Pros: Produces smoother bridge surfaces, as overlapping lines provide additional support during printing.\n"
-                     "  - Cons: Can cause overextrusion, which may reduce lower and upper surface quality and increase risk of warping.\n\n"
+                     "  - Cons: Can cause overextrusion, which may reduce lower and upper surface quality and increase the risk of warping.\n\n"
                      "- Lower than 100% density (Min 10%):\n"
                      "  - Pros: Can create a string-like first layer. Faster and with better cooling because there is more space for air to circulate around the extruded bridge.\n"
                      "  - Cons: May lead to sagging and poorer surface finish.\n\n"
@@ -1212,7 +1212,7 @@ void PrintConfigDef::init_fff_params()
                      "- Lower than 100% density (Min 10%):\n"
                      "  - Pros: Can reduce pillowing and improve cooling (more airflow through the bridge), and may speed up printing.\n"
                      "  - Cons: May reduce internal support, increasing the risk of sagging and top surface defects.\n\n"
-                     "This option works particularly well when combined with the second internal bridge over infill option to further improve bridging before solid infill is extruded.");
+                     "This option works particularly well when combined with the second internal bridge over infill option to improve bridging further before solid infill is extruded.");
     def->sidetext = "%";
     def->min = 10;
     def->max = 125;
@@ -1223,8 +1223,8 @@ void PrintConfigDef::init_fff_params()
     def->label = L("Bridge flow ratio");
     def->category = L("Quality");
     def->tooltip = L("Values above 1.0:\n"
-                     "  - Regular bridges: Keep spacing and thicken the filament. If Bridge line width is <= 100%, this can improve line contact and strength.\n"
-                     "  - Thick bridges: Increase width, height, and spacing. May be stronger but increases the risk of sagging.\n"
+                     "  - Regular bridges: Keep spacing and thicken the filament. If the Bridge line width is <= 100%, this can improve line contact and strength.\n"
+                     "  - Thick bridges: Increase width, height, and spacing. It may be stronger, but it increases the risk of sagging.\n"
                      "Values below 1.0:\n"
                      "  - Regular bridges: Reduce spacing; this can potentially add extra passes or alter paths.\n"
                      "  - Thick bridges: Decrease width, height, and spacing. Reduces sagging at the cost of lateral bonding.");
@@ -1236,10 +1236,10 @@ void PrintConfigDef::init_fff_params()
     def = this->add("bridge_line_width", coFloatOrPercent);
     def->label = L("Bridge");
     def->category = L("Quality");
-    def->tooltip = L("Bridge line width expressed either as an absolute value or as a percentage of the active nozzle diameter (percentages are computed from the nozzle diameter).\n"
+    def->tooltip = L("Bridge line width is expressed either as an absolute value or as a percentage of the active nozzle diameter (percentages are computed from the nozzle diameter).\n"
                      "Recommended to use with a higher Bridge density or Bridge flow ratio.\n\n"
-                     "Maximum value is 100% or nozzle diameter.\n"
-                     "If set to 0, the line width will be equal to Internal solid infill width.");
+                     "The maximum value is 100% or the nozzle diameter.\n"
+                     "If set to 0, the line width will match the Internal solid infill width.");
     def->sidetext = L("mm or %");
     def->ratio_over = "nozzle_diameter";
     def->min = 0;

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -1222,12 +1222,10 @@ void PrintConfigDef::init_fff_params()
     def = this->add("bridge_flow", coFloat);
     def->label = L("Bridge flow ratio");
     def->category = L("Quality");
-    def->tooltip = L("Values above 1.0:\n"
-                     "  - Regular bridges: Keep spacing and thicken the filament. If the Bridge line width is <= 100%, this can improve line contact and strength.\n"
-                     "  - Thick bridges: Increase width, height, and spacing. It may be stronger, but it increases the risk of sagging.\n"
-                     "Values below 1.0:\n"
-                     "  - Regular bridges: Reduce spacing; this can potentially add extra passes or alter paths.\n"
-                     "  - Thick bridges: Decrease width, height, and spacing. Reduces sagging at the cost of lateral bonding.");
+    def->tooltip = L("This value governs the thickness of the external (visible) bridge layer."
+                     "Values above 1.0: Increase the amount of material while maintaining line spacing. This can improve line contact and strength.\n"
+                     "Values below 1.0: Reduce the amount of material while adjusting line spacing to maintain contact. This can improve sagging.\n\n"
+                     "The actual bridge flow used is calculated by multiplying this value with the filament flow ratio, and if set, the object's flow ratio.");
     def->min = 0;
     def->max = 2.0;
     def->mode = comAdvanced;
@@ -1251,8 +1249,10 @@ void PrintConfigDef::init_fff_params()
     def = this->add("internal_bridge_flow", coFloat);
     def->label = L("Internal bridge flow ratio");
     def->category = L("Quality");
-    def->tooltip = L("This value governs the thickness of the internal bridge layer. This is the first layer over sparse infill. Decrease this value slightly (for example 0.9) to improve surface quality over sparse infill."
-                     "\n\nThe actual internal bridge flow used is calculated by multiplying this value with the bridge flow ratio, the filament flow ratio, and if set, the object's flow ratio.");
+    def->tooltip = L("This value governs the thickness of the internal bridge layer. This is the first layer over sparse infill so increasing it may increase strength and upper layer quality.\n"
+                     "Values above 1.0: Increase the amount of material while maintaining line spacing. This can improve line contact and strength.\n"
+                     "Values below 1.0: Reduce the amount of material while adjusting line spacing to maintain contact. This can improve sagging.\n\n"
+                     "The actual bridge flow used is calculated by multiplying this value with the filament flow ratio, and if set, the object's flow ratio.");
     def->min = 0;
     def->max = 2.0;
     def->mode = comAdvanced;

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -1192,7 +1192,7 @@ void PrintConfigDef::init_fff_params()
                      "additional support during printing. Maximum is 120%.\n"
                      "Note: Bridge density that is too high can cause warping or overextrusion.\n\n"
                      "Lower density external bridges can help improve reliability as there is more space for air to circulate "
-                     "around the extruded bridge, improving its cooling speed. Minimum is 10%.")
+                     "around the extruded bridge, improving its cooling speed. Minimum is 10%.");
     def->sidetext = "%";
     def->min = 10;
     def->max = 120;

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -1222,14 +1222,17 @@ void PrintConfigDef::init_fff_params()
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionFloat(1));
 
-    def = this->add("bridge_line_width", coFloat);
-    def->label = L("Bridge line width ratio");
+    def = this->add("bridge_line_width", coFloatOrPercent);
+    def->label = L("Bridge line width");
     def->category = L("Quality");
-    def->tooltip = L("Scale the spacing between bridge lines. Values above 1.0 increase the spacing, while values below 1.0 pack the bridge lines closer together.");
-    def->min = 0.1;
-    def->max = 3.0;
+    def->tooltip = L("Override the bridge line width. Leave at 0 to use the automatic value, set an absolute width in millimeters, or provide a percentage of the nozzle diameter.");
+    def->sidetext = L("mm or %");
+    def->ratio_over = "nozzle_diameter";
+    def->min = 0;
+    def->max = 1000;
+    def->max_literal = 10;
     def->mode = comAdvanced;
-    def->set_default_value(new ConfigOptionFloat(1));
+    def->set_default_value(new ConfigOptionFloatOrPercent(0., false));
 
     def = this->add("internal_bridge_flow", coFloat);
     def->label = L("Internal bridge flow ratio");
@@ -9730,10 +9733,6 @@ std::map<std::string, std::string> validate(const FullPrintConfig &cfg, bool und
         error_message.emplace("internal_bridge_flow", L("invalid value ") + std::to_string(cfg.internal_bridge_flow));
     }
 
-    if (cfg.bridge_line_width <= 0) {
-        error_message.emplace("bridge_line_width", L("invalid value ") + std::to_string(cfg.bridge_line_width));
-    }
-
     // extruder clearance
     if (cfg.extruder_clearance_radius <= 0) {
         error_message.emplace("extruder_clearance_radius", L("invalid value ") + std::to_string(cfg.extruder_clearance_radius));
@@ -9795,6 +9794,7 @@ std::map<std::string, std::string> validate(const FullPrintConfig &cfg, bool und
             "inner_wall_line_width",
             "sparse_infill_line_width",
             "internal_solid_infill_line_width",
+            "bridge_line_width",
             "top_surface_line_width",
             "support_line_width",
             "initial_layer_line_width",

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -1222,6 +1222,15 @@ void PrintConfigDef::init_fff_params()
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionFloat(1));
 
+    def = this->add("bridge_line_width", coFloat);
+    def->label = L("Bridge line width ratio");
+    def->category = L("Quality");
+    def->tooltip = L("Scale the spacing between bridge lines. Values above 1.0 increase the spacing, while values below 1.0 pack the bridge lines closer together.");
+    def->min = 0.1;
+    def->max = 3.0;
+    def->mode = comAdvanced;
+    def->set_default_value(new ConfigOptionFloat(1));
+
     def = this->add("internal_bridge_flow", coFloat);
     def->label = L("Internal bridge flow ratio");
     def->category = L("Quality");
@@ -9716,9 +9725,13 @@ std::map<std::string, std::string> validate(const FullPrintConfig &cfg, bool und
         error_message.emplace("bridge_flow", L("invalid value ") + std::to_string(cfg.bridge_flow));
     }
     
-    // --bridge-flow-ratio
-    if (cfg.bridge_flow <= 0) {
+    // --internal-bridge-flow-ratio
+    if (cfg.internal_bridge_flow <= 0) {
         error_message.emplace("internal_bridge_flow", L("invalid value ") + std::to_string(cfg.internal_bridge_flow));
+    }
+
+    if (cfg.bridge_line_width <= 0) {
+        error_message.emplace("bridge_line_width", L("invalid value ") + std::to_string(cfg.bridge_line_width));
     }
 
     // extruder clearance

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -1806,16 +1806,18 @@ void PrintConfigDef::init_fff_params()
     def = this->add("thick_bridges", coBool);
     def->label = L("Thick external bridges");
     def->category = L("Quality");
-    def->tooltip = L("If enabled, bridges are more reliable, can bridge longer distances, but may look worse. "
-        "If disabled, bridges look better but are reliable just for shorter bridged distances.");
+    def->tooltip = L("If enabled, bridge extrusion uses a line height equal to the nozzle diameter.\n"
+                     "This increases bridge strength and reliability, allowing longer spans, but may worsen appearance.\n"
+                     "If disabled, bridges may look better but are generally reliable only for shorter spans.");
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionBool(false));
 
     def = this->add("thick_internal_bridges", coBool);
     def->label = L("Thick internal bridges");
     def->category = L("Quality");
-    def->tooltip  = L("If enabled, thick internal bridges will be used. It's usually recommended to have this feature turned on. However, "
-                       "consider turning it off if you are using large nozzles.");
+    def->tooltip  = L("If enabled, internal bridge extrusion uses a line height equal to the nozzle diameter.\n"
+                       "This increases internal bridge strength and reliability when printed over sparse infill, but may worsen appearance.\n"
+                       "If disabled, internal bridges may look better but can be less reliable over sparse infill.");
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionBool(true));
     

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -1239,7 +1239,7 @@ void PrintConfigDef::init_fff_params()
     def->max = 1000;
     def->max_literal = 10;
     def->mode = comAdvanced;
-    def->set_default_value(new ConfigOptionFloatOrPercent(0., false));
+    def->set_default_value(new ConfigOptionFloatOrPercent(100., true));
 
     def = this->add("internal_bridge_flow", coFloat);
     def->label = L("Internal bridge flow ratio");

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -1215,7 +1215,8 @@ void PrintConfigDef::init_fff_params()
     def = this->add("bridge_flow", coFloat);
     def->label = L("Bridge flow ratio");
     def->category = L("Quality");
-    def->tooltip = L("Decrease this value slightly (for example 0.9) to reduce the amount of material for bridge, to improve sag.\n\n"
+    def->tooltip = L("Increasing this value (~1.5) when using a Bridge Line Width of 100% (equal to the nozzle size) improves lateral contact between bridge lines, which significantly enhances bridging performance and reduces sagging.\n\n"
+                     "Slightly decreasing this value (e.g., to 0.9) lowers the amount of material used for bridges, which can help reduce sagging, but will prevent adjacent bridge lines from making lateral contact.\n\n"
                      "The actual bridge flow used is calculated by multiplying this value with the filament flow ratio, and if set, the object's flow ratio.");
     def->min = 0;
     def->max = 2.0;
@@ -1225,7 +1226,8 @@ void PrintConfigDef::init_fff_params()
     def = this->add("bridge_line_width", coFloatOrPercent);
     def->label = L("Bridge");
     def->category = L("Quality");
-    def->tooltip = L("Bridge line width. Leave at 0 to ignore. If expressed as a %, it will be computed over the nozzle diameter.");
+    def->tooltip = L("Bridge line width. Recommended value 100% along with a higher Bridge flow ratio.\n"
+                     "Leave at 0 to ignore. If expressed as a %, it will be computed over the nozzle diameter.");
     def->sidetext = L("mm or %");
     def->ratio_over = "nozzle_diameter";
     def->min = 0;

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -1230,8 +1230,10 @@ void PrintConfigDef::init_fff_params()
     def = this->add("bridge_line_width", coFloatOrPercent);
     def->label = L("Bridge");
     def->category = L("Quality");
-    def->tooltip = L("Bridge line width expressed either as an absolute value or as a percentage of the active nozzle diameter (percentages are computed from the nozzle diameter). Recommended value 100% along with a higher External bridge density or Bridge flow ratio.\n"
-                     "Leave at 0 to use the automatic width.");
+    def->tooltip = L("Bridge line width expressed either as an absolute value or as a percentage of the active nozzle diameter (percentages are computed from the nozzle diameter).\n"
+                     "Recommended to use with a higher Bridge density or Bridge flow ratio.\n\n"
+                     "Maximum value is 100% or nozzle diameter.\n"
+                     "If set to 0, the line width will be equal to Internal solid infill width.");
     def->sidetext = L("mm or %");
     def->ratio_over = "nozzle_diameter";
     def->min = 0;

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -1273,6 +1273,15 @@ void PrintConfigDef::init_fff_params()
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionFloat(1));
 
+    def = this->add("bridge_line_width", coFloat);
+    def->label = L("Bridge line width ratio");
+    def->category = L("Quality");
+    def->tooltip = L("Scale the spacing between bridge lines. Values above 1.0 increase the spacing, while values below 1.0 pack the bridge lines closer together.");
+    def->min = 0.1;
+    def->max = 3.0;
+    def->mode = comAdvanced;
+    def->set_default_value(new ConfigOptionFloat(1));
+
     def = this->add("internal_bridge_flow", coFloat);
     def->label = L("Internal bridge flow ratio");
     def->category = L("Quality");
@@ -10179,9 +10188,13 @@ std::map<std::string, std::string> validate(const FullPrintConfig &cfg, bool und
         error_message.emplace("bridge_flow", L("invalid value ") + std::to_string(cfg.bridge_flow));
     }
     
-    // --bridge-flow-ratio
-    if (cfg.bridge_flow <= 0) {
+    // --internal-bridge-flow-ratio
+    if (cfg.internal_bridge_flow <= 0) {
         error_message.emplace("internal_bridge_flow", L("invalid value ") + std::to_string(cfg.internal_bridge_flow));
+    }
+
+    if (cfg.bridge_line_width <= 0) {
+        error_message.emplace("bridge_line_width", L("invalid value ") + std::to_string(cfg.bridge_line_width));
     }
 
     // extruder clearance

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -1274,9 +1274,9 @@ void PrintConfigDef::init_fff_params()
     def->set_default_value(new ConfigOptionFloat(1));
 
     def = this->add("bridge_line_width", coFloatOrPercent);
-    def->label = L("Bridge line width");
+    def->label = L("Bridge");
     def->category = L("Quality");
-    def->tooltip = L("Override the bridge line width. Leave at 0 to use the automatic value, set an absolute width in millimeters, or provide a percentage of the nozzle diameter.");
+    def->tooltip = L("Bridge line width. Leave at 0 to ignore. If expressed as a %, it will be computed over the nozzle diameter.");
     def->sidetext = L("mm or %");
     def->ratio_over = "nozzle_diameter";
     def->min = 0;

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -1290,7 +1290,7 @@ void PrintConfigDef::init_fff_params()
     def->max = 1000;
     def->max_literal = 10;
     def->mode = comAdvanced;
-    def->set_default_value(new ConfigOptionFloatOrPercent(0., false));
+    def->set_default_value(new ConfigOptionFloatOrPercent(100., true));
 
     def = this->add("internal_bridge_flow", coFloat);
     def->label = L("Internal bridge flow ratio");

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -1281,12 +1281,12 @@ void PrintConfigDef::init_fff_params()
     def = this->add("bridge_line_width", coFloatOrPercent);
     def->label = L("Bridge");
     def->category = L("Quality");
-    def->tooltip = L("Bridge line width. Recommended value 100% along with a higher External bridge density or Bridge flow ratio.\n"
-                     "Leave at 0 to ignore. If expressed as a %, it will be computed over the nozzle diameter.");
+    def->tooltip = L("Bridge line width expressed either as an absolute value or as a percentage of the active nozzle diameter (percentages are computed from the nozzle diameter). Recommended value 100% along with a higher External bridge density or Bridge flow ratio.\n"
+                     "Leave at 0 to use the automatic width.");
     def->sidetext = L("mm or %");
     def->ratio_over = "nozzle_diameter";
     def->min = 0;
-    def->max = 1000;
+    def->max = 100;
     def->max_literal = 10;
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionFloatOrPercent(100., true));
@@ -10271,8 +10271,13 @@ std::map<std::string, std::string> validate(const FullPrintConfig &cfg, bool und
             "skeleton_infill_line_width"};
         for (size_t i = 0; i < sizeof(widths) / sizeof(widths[i]); ++ i) {
             std::string key(widths[i]);
-            if (cfg.get_abs_value(key, max_nozzle_diameter) > MAX_LINE_WIDTH_MULTIPLIER * max_nozzle_diameter) {
-                error_message.emplace(key, L("too large line width ") + std::to_string(cfg.get_abs_value(key)));
+            double abs_width = cfg.get_abs_value(key, max_nozzle_diameter);
+            double allowed_max = (key == "bridge_line_width") ? max_nozzle_diameter : MAX_LINE_WIDTH_MULTIPLIER * max_nozzle_diameter;
+            if (abs_width > allowed_max) {
+                if (key == "bridge_line_width")
+                    error_message.emplace(key, L("Bridge line width must not exceed nozzle diameter: ") + std::to_string(abs_width));
+                else
+                    error_message.emplace(key, L("too large line width ") + std::to_string(abs_width));
                 //return std::string("Too Large line width: ") + key;
             }
         }

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -1237,9 +1237,11 @@ void PrintConfigDef::init_fff_params()
     def = this->add("bridge_density", coPercent);
     def->label = L("External bridge density");
     def->category = L("Strength");
-    def->tooltip = L("Controls the density (spacing) of external bridge lines. Default is 100%.\n\n"
+    def->tooltip = L("Controls the density (spacing) of external bridge lines. 100% means solid bridge. Default is 100%.\n\n"
+                     "Due to the tendency for bridge extrusions to sag, a value of 100% may not be sufficient for proper welding between them,\n"
+                     "so it is recommended to increase it slightly while using 100% Bridge Line Width.\n"
                      "Lower density external bridges can help improve reliability as there is more space for air to circulate "
-                     "around the extruded bridge, improving its cooling speed. Minimum is 10%.\n\n"
+                     "around the extruded bridge, improving its cooling speed. Minimum is 10%.\n"
                      "Higher densities can produce smoother bridge surfaces, as overlapping lines provide "
                      "additional support during printing. Maximum is 120%.\n"
                      "Note: Bridge density that is too high can cause warping or overextrusion.");
@@ -1266,9 +1268,12 @@ void PrintConfigDef::init_fff_params()
     def = this->add("bridge_flow", coFloat);
     def->label = L("Bridge flow ratio");
     def->category = L("Quality");
-    def->tooltip = L("Increasing this value (~1.5) when using a Bridge Line Width of 100% (equal to the nozzle size) improves lateral contact between bridge lines, which significantly enhances bridging performance and reduces sagging.\n\n"
-                     "Slightly decreasing this value (e.g., to 0.9) lowers the amount of material used for bridges, which can help reduce sagging, but will prevent adjacent bridge lines from making lateral contact.\n\n"
-                     "The actual bridge flow used is calculated by multiplying this value with the filament flow ratio, and if set, the object's flow ratio.");
+    def->tooltip = L("Values above 1.0 add material:\n"
+                     "  - Regular bridges: Keep spacing and thicken the filament for stronger line contact when paired with a <= 100% Bridge line width.\n"
+                     "  - Thick bridges: Increase spacing and increase width, height and spacing.\n"
+                     "Values below 1.0 remove material:\n"
+                     "  - Regular bridges: eventually tighten spacing as the thread thins—potentially adding passes or altering paths—whereas.\n"
+                     "  - Thick bridges: shrink both diameter and spacing, cutting sagging at the cost of lateral bonding.");
     def->min = 0;
     def->max = 2.0;
     def->mode = comAdvanced;
@@ -1277,7 +1282,7 @@ void PrintConfigDef::init_fff_params()
     def = this->add("bridge_line_width", coFloatOrPercent);
     def->label = L("Bridge");
     def->category = L("Quality");
-    def->tooltip = L("Bridge line width. Recommended value 100% along with a higher Bridge flow ratio.\n"
+    def->tooltip = L("Bridge line width. Recommended value 100% along with a higher External bridge density or Bridge flow ratio.\n"
                      "Leave at 0 to ignore. If expressed as a %, it will be computed over the nozzle diameter.");
     def->sidetext = L("mm or %");
     def->ratio_over = "nozzle_diameter";

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -1241,7 +1241,7 @@ void PrintConfigDef::init_fff_params()
                      "Theoretically, 100% means a solid bridge, but due to the tendency of bridge extrusions to sag, 100% may not be sufficient.\n\n"
                      "- Higher than 100% density (Recommended Max 125%):\n"
                      "  - Pros: Produces smoother bridge surfaces, as overlapping lines provide additional support during printing.\n"
-                     "  - Cons: Can cause overextrusion, which may reduce lower and upper surface quality and increase risk of warping.\n\n"
+                     "  - Cons: Can cause overextrusion, which may reduce lower and upper surface quality and increase the risk of warping.\n\n"
                      "- Lower than 100% density (Min 10%):\n"
                      "  - Pros: Can create a string-like first layer. Faster and with better cooling because there is more space for air to circulate around the extruded bridge.\n"
                      "  - Cons: May lead to sagging and poorer surface finish.\n\n"
@@ -1263,7 +1263,7 @@ void PrintConfigDef::init_fff_params()
                      "- Lower than 100% density (Min 10%):\n"
                      "  - Pros: Can reduce pillowing and improve cooling (more airflow through the bridge), and may speed up printing.\n"
                      "  - Cons: May reduce internal support, increasing the risk of sagging and top surface defects.\n\n"
-                     "This option works particularly well when combined with the second internal bridge over infill option to further improve bridging before solid infill is extruded.");
+                     "This option works particularly well when combined with the second internal bridge over infill option to improve bridging further before solid infill is extruded.");
     def->sidetext = "%";
     def->min = 10;
     def->max = 125;
@@ -1274,8 +1274,8 @@ void PrintConfigDef::init_fff_params()
     def->label = L("Bridge flow ratio");
     def->category = L("Quality");
     def->tooltip = L("Values above 1.0:\n"
-                     "  - Regular bridges: Keep spacing and thicken the filament. If Bridge line width is <= 100%, this can improve line contact and strength.\n"
-                     "  - Thick bridges: Increase width, height, and spacing. May be stronger but increases the risk of sagging.\n"
+                     "  - Regular bridges: Keep spacing and thicken the filament. If the Bridge line width is <= 100%, this can improve line contact and strength.\n"
+                     "  - Thick bridges: Increase width, height, and spacing. It may be stronger, but it increases the risk of sagging.\n"
                      "Values below 1.0:\n"
                      "  - Regular bridges: Reduce spacing; this can potentially add extra passes or alter paths.\n"
                      "  - Thick bridges: Decrease width, height, and spacing. Reduces sagging at the cost of lateral bonding.");
@@ -1287,10 +1287,10 @@ void PrintConfigDef::init_fff_params()
     def = this->add("bridge_line_width", coFloatOrPercent);
     def->label = L("Bridge");
     def->category = L("Quality");
-    def->tooltip = L("Bridge line width expressed either as an absolute value or as a percentage of the active nozzle diameter (percentages are computed from the nozzle diameter).\n"
+    def->tooltip = L("Bridge line width is expressed either as an absolute value or as a percentage of the active nozzle diameter (percentages are computed from the nozzle diameter).\n"
                      "Recommended to use with a higher Bridge density or Bridge flow ratio.\n\n"
-                     "Maximum value is 100% or nozzle diameter.\n"
-                     "If set to 0, the line width will be equal to Internal solid infill width.");
+                     "The maximum value is 100% or the nozzle diameter.\n"
+                     "If set to 0, the line width will match the Internal solid infill width.");
     def->sidetext = L("mm or %");
     def->ratio_over = "nozzle_diameter";
     def->min = 0;

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -1237,14 +1237,13 @@ void PrintConfigDef::init_fff_params()
     def = this->add("bridge_density", coPercent);
     def->label = L("External bridge density");
     def->category = L("Strength");
-    def->tooltip = L("Controls the density (spacing) of external bridge lines. 100% means solid bridge. Default is 100%.\n\n"
-                     "Due to the tendency for bridge extrusions to sag, a value of 100% may not be sufficient for proper welding between them,\n"
-                     "so it is recommended to increase it slightly while using 100% Bridge Line Width.\n"
-                     "Lower density external bridges can help improve reliability as there is more space for air to circulate "
-                     "around the extruded bridge, improving its cooling speed. Minimum is 10%.\n"
+    def->tooltip = L("Controls the density (spacing) of external bridge lines. Default is 100%.\n"
+                     "Theoretically, 100% means a solid bridge, but due to the tendency of bridge extrusions to sag, 100% may not be sufficient."
                      "Higher densities can produce smoother bridge surfaces, as overlapping lines provide "
                      "additional support during printing. Maximum is 120%.\n"
-                     "Note: Bridge density that is too high can cause warping or overextrusion.");
+                     "Note: Bridge density that is too high can cause warping or overextrusion.\n\n"
+                     "Lower density external bridges can help improve reliability as there is more space for air to circulate "
+                     "around the extruded bridge, improving its cooling speed. Minimum is 10%.")
     def->sidetext = "%";
     def->min = 10;
     def->max = 120;

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -1273,7 +1273,7 @@ void PrintConfigDef::init_fff_params()
     def = this->add("bridge_flow", coFloat);
     def->label = L("Bridge flow ratio");
     def->category = L("Quality");
-    def->tooltip = L("This value governs the thickness of the external (visible) bridge layer."
+    def->tooltip = L("This value governs the thickness of the external (visible) bridge layer.\n"
                      "Values above 1.0: Increase the amount of material while maintaining line spacing. This can improve line contact and strength.\n"
                      "Values below 1.0: Reduce the amount of material while adjusting line spacing to maintain contact. This can improve sagging.\n\n"
                      "The actual bridge flow used is calculated by multiplying this value with the filament flow ratio, and if set, the object's flow ratio.");
@@ -10266,8 +10266,12 @@ std::map<std::string, std::string> validate(const FullPrintConfig &cfg, bool und
     // extrusion widths
     {
         double max_nozzle_diameter = 0.;
+        double min_nozzle_diameter = std::numeric_limits<double>::max();
         for (double dmr : cfg.nozzle_diameter.values)
+        {
             max_nozzle_diameter = std::max(max_nozzle_diameter, dmr);
+            min_nozzle_diameter = std::min(min_nozzle_diameter, dmr);
+        }
         const char *widths[] = {
             "outer_wall_line_width",
             "inner_wall_line_width",
@@ -10282,7 +10286,7 @@ std::map<std::string, std::string> validate(const FullPrintConfig &cfg, bool und
         for (size_t i = 0; i < sizeof(widths) / sizeof(widths[i]); ++ i) {
             std::string key(widths[i]);
             double abs_width = cfg.get_abs_value(key, max_nozzle_diameter);
-            double allowed_max = (key == "bridge_line_width") ? max_nozzle_diameter : MAX_LINE_WIDTH_MULTIPLIER * max_nozzle_diameter;
+            double allowed_max = (key == "bridge_line_width") ? min_nozzle_diameter : MAX_LINE_WIDTH_MULTIPLIER * max_nozzle_diameter;
             if (abs_width > allowed_max) {
                 if (key == "bridge_line_width")
                     error_message.emplace(key, L("Bridge line width must not exceed nozzle diameter: ") + std::to_string(abs_width));

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -1243,7 +1243,7 @@ void PrintConfigDef::init_fff_params()
                      "additional support during printing. Maximum is 120%.\n"
                      "Note: Bridge density that is too high can cause warping or overextrusion.\n\n"
                      "Lower density external bridges can help improve reliability as there is more space for air to circulate "
-                     "around the extruded bridge, improving its cooling speed. Minimum is 10%.")
+                     "around the extruded bridge, improving its cooling speed. Minimum is 10%.");
     def->sidetext = "%";
     def->min = 10;
     def->max = 120;

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -1881,16 +1881,18 @@ void PrintConfigDef::init_fff_params()
     def = this->add("thick_bridges", coBool);
     def->label = L("Thick external bridges");
     def->category = L("Quality");
-    def->tooltip = L("If enabled, bridges are more reliable, can bridge longer distances, but may look worse. "
-        "If disabled, bridges look better but are reliable just for shorter bridged distances.");
+    def->tooltip = L("If enabled, bridge extrusion uses a line height equal to the nozzle diameter.\n"
+                     "This increases bridge strength and reliability, allowing longer spans, but may worsen appearance.\n"
+                     "If disabled, bridges may look better but are generally reliable only for shorter spans.");
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionBool(false));
 
     def = this->add("thick_internal_bridges", coBool);
     def->label = L("Thick internal bridges");
     def->category = L("Quality");
-    def->tooltip  = L("If enabled, thick internal bridges will be used. It's usually recommended to have this feature turned on. However, "
-                       "consider turning it off if you are using large nozzles.");
+    def->tooltip  = L("If enabled, internal bridge extrusion uses a line height equal to the nozzle diameter.\n"
+                       "This increases internal bridge strength and reliability when printed over sparse infill, but may worsen appearance.\n"
+                       "If disabled, internal bridges may look better but can be less reliable over sparse infill.");
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionBool(true));
     

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -1266,7 +1266,8 @@ void PrintConfigDef::init_fff_params()
     def = this->add("bridge_flow", coFloat);
     def->label = L("Bridge flow ratio");
     def->category = L("Quality");
-    def->tooltip = L("Decrease this value slightly (for example 0.9) to reduce the amount of material for bridge, to improve sag.\n\n"
+    def->tooltip = L("Increasing this value (~1.5) when using a Bridge Line Width of 100% (equal to the nozzle size) improves lateral contact between bridge lines, which significantly enhances bridging performance and reduces sagging.\n\n"
+                     "Slightly decreasing this value (e.g., to 0.9) lowers the amount of material used for bridges, which can help reduce sagging, but will prevent adjacent bridge lines from making lateral contact.\n\n"
                      "The actual bridge flow used is calculated by multiplying this value with the filament flow ratio, and if set, the object's flow ratio.");
     def->min = 0;
     def->max = 2.0;
@@ -1276,7 +1277,8 @@ void PrintConfigDef::init_fff_params()
     def = this->add("bridge_line_width", coFloatOrPercent);
     def->label = L("Bridge");
     def->category = L("Quality");
-    def->tooltip = L("Bridge line width. Leave at 0 to ignore. If expressed as a %, it will be computed over the nozzle diameter.");
+    def->tooltip = L("Bridge line width. Recommended value 100% along with a higher Bridge flow ratio.\n"
+                     "Leave at 0 to ignore. If expressed as a %, it will be computed over the nozzle diameter.");
     def->sidetext = L("mm or %");
     def->ratio_over = "nozzle_diameter";
     def->min = 0;

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -1273,14 +1273,17 @@ void PrintConfigDef::init_fff_params()
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionFloat(1));
 
-    def = this->add("bridge_line_width", coFloat);
-    def->label = L("Bridge line width ratio");
+    def = this->add("bridge_line_width", coFloatOrPercent);
+    def->label = L("Bridge line width");
     def->category = L("Quality");
-    def->tooltip = L("Scale the spacing between bridge lines. Values above 1.0 increase the spacing, while values below 1.0 pack the bridge lines closer together.");
-    def->min = 0.1;
-    def->max = 3.0;
+    def->tooltip = L("Override the bridge line width. Leave at 0 to use the automatic value, set an absolute width in millimeters, or provide a percentage of the nozzle diameter.");
+    def->sidetext = L("mm or %");
+    def->ratio_over = "nozzle_diameter";
+    def->min = 0;
+    def->max = 1000;
+    def->max_literal = 10;
     def->mode = comAdvanced;
-    def->set_default_value(new ConfigOptionFloat(1));
+    def->set_default_value(new ConfigOptionFloatOrPercent(0., false));
 
     def = this->add("internal_bridge_flow", coFloat);
     def->label = L("Internal bridge flow ratio");
@@ -10193,10 +10196,6 @@ std::map<std::string, std::string> validate(const FullPrintConfig &cfg, bool und
         error_message.emplace("internal_bridge_flow", L("invalid value ") + std::to_string(cfg.internal_bridge_flow));
     }
 
-    if (cfg.bridge_line_width <= 0) {
-        error_message.emplace("bridge_line_width", L("invalid value ") + std::to_string(cfg.bridge_line_width));
-    }
-
     // extruder clearance
     if (cfg.extruder_clearance_radius <= 0) {
         error_message.emplace("extruder_clearance_radius", L("invalid value ") + std::to_string(cfg.extruder_clearance_radius));
@@ -10258,6 +10257,7 @@ std::map<std::string, std::string> validate(const FullPrintConfig &cfg, bool und
             "inner_wall_line_width",
             "sparse_infill_line_width",
             "internal_solid_infill_line_width",
+            "bridge_line_width",
             "top_surface_line_width",
             "support_line_width",
             "initial_layer_line_width",

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -1238,41 +1238,47 @@ void PrintConfigDef::init_fff_params()
     def->label = L("External bridge density");
     def->category = L("Strength");
     def->tooltip = L("Controls the density (spacing) of external bridge lines. Default is 100%.\n"
-                     "Theoretically, 100% means a solid bridge, but due to the tendency of bridge extrusions to sag, 100% may not be sufficient."
-                     "Higher densities can produce smoother bridge surfaces, as overlapping lines provide "
-                     "additional support during printing. Maximum is 120%.\n"
-                     "Note: Bridge density that is too high can cause warping or overextrusion.\n\n"
-                     "Lower density external bridges can help improve reliability as there is more space for air to circulate "
-                     "around the extruded bridge, improving its cooling speed. Minimum is 10%.");
+                     "Theoretically, 100% means a solid bridge, but due to the tendency of bridge extrusions to sag, 100% may not be sufficient.\n\n"
+                     "- Higher than 100% density (Recommended Max 125%):\n"
+                     "  - Pros: Produces smoother bridge surfaces, as overlapping lines provide additional support during printing.\n"
+                     "  - Cons: Can cause overextrusion, which may reduce lower and upper surface quality and increase risk of warping.\n\n"
+                     "- Lower than 100% density (Min 10%):\n"
+                     "  - Pros: Can create a string-like first layer. Faster and with better cooling because there is more space for air to circulate around the extruded bridge.\n"
+                     "  - Cons: May lead to sagging and poorer surface finish.\n\n"
+                     "Recommended range: Minimum 10% - Maximum 125%.");
     def->sidetext = "%";
     def->min = 10;
-    def->max = 120;
+    def->max = 125;
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionPercent(100));
 
     def = this->add("internal_bridge_density", coPercent);
     def->label = L("Internal bridge density");
     def->category = L("Strength");
-    def->tooltip = L("Controls the density (spacing) of internal bridge lines. 100% means solid bridge. Default is 100%.\n\n"
-                     "Lower density internal bridges can help reduce top surface pillowing and improve internal bridge reliability as there is more space for "
-                     "air to circulate around the extruded bridge, improving its cooling speed.\n\n"
-                     "This option works particularly well when combined with the second internal bridge over infill option, "
-                     "further improving internal bridging structure before solid infill is extruded.");
+    def->tooltip = L("Controls the density (spacing) of internal bridge lines. Default is 100%. 100% means a solid internal bridge.\n\n"
+                     "Internal bridges act as intermediate support between sparse infill and top solid infill and can strongly affect top surface quality.\n\n"
+                     "- Higher than 100% density (Recommended Max 125%):\n"
+                     "  - Pros: Improves internal bridge strength and support under top layers, reducing sagging and improving top-surface finish.\n"
+                     "  - Cons: Increases material use and print time; excessive density may cause overextrusion and internal stresses.\n\n"
+                     "- Lower than 100% density (Min 10%):\n"
+                     "  - Pros: Can reduce pillowing and improve cooling (more airflow through the bridge), and may speed up printing.\n"
+                     "  - Cons: May reduce internal support, increasing the risk of sagging and top surface defects.\n\n"
+                     "This option works particularly well when combined with the second internal bridge over infill option to further improve bridging before solid infill is extruded.");
     def->sidetext = "%";
     def->min = 10;
-    def->max = 100;
+    def->max = 125;
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionPercent(100));
 
     def = this->add("bridge_flow", coFloat);
     def->label = L("Bridge flow ratio");
     def->category = L("Quality");
-    def->tooltip = L("Values above 1.0 add material:\n"
-                     "  - Regular bridges: Keep spacing and thicken the filament for stronger line contact when paired with a <= 100% Bridge line width.\n"
-                     "  - Thick bridges: Increase spacing and increase width, height and spacing.\n"
-                     "Values below 1.0 remove material:\n"
-                     "  - Regular bridges: eventually tighten spacing as the thread thins—potentially adding passes or altering paths—whereas.\n"
-                     "  - Thick bridges: shrink both diameter and spacing, cutting sagging at the cost of lateral bonding.");
+    def->tooltip = L("Values above 1.0:\n"
+                     "  - Regular bridges: Keep spacing and thicken the filament. If Bridge line width is <= 100%, this can improve line contact and strength.\n"
+                     "  - Thick bridges: Increase width, height, and spacing. May be stronger but increases the risk of sagging.\n"
+                     "Values below 1.0:\n"
+                     "  - Regular bridges: Reduce spacing; this can potentially add extra passes or alter paths.\n"
+                     "  - Thick bridges: Decrease width, height, and spacing. Reduces sagging at the cost of lateral bonding.");
     def->min = 0;
     def->max = 2.0;
     def->mode = comAdvanced;

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -1273,12 +1273,10 @@ void PrintConfigDef::init_fff_params()
     def = this->add("bridge_flow", coFloat);
     def->label = L("Bridge flow ratio");
     def->category = L("Quality");
-    def->tooltip = L("Values above 1.0:\n"
-                     "  - Regular bridges: Keep spacing and thicken the filament. If the Bridge line width is <= 100%, this can improve line contact and strength.\n"
-                     "  - Thick bridges: Increase width, height, and spacing. It may be stronger, but it increases the risk of sagging.\n"
-                     "Values below 1.0:\n"
-                     "  - Regular bridges: Reduce spacing; this can potentially add extra passes or alter paths.\n"
-                     "  - Thick bridges: Decrease width, height, and spacing. Reduces sagging at the cost of lateral bonding.");
+    def->tooltip = L("This value governs the thickness of the external (visible) bridge layer."
+                     "Values above 1.0: Increase the amount of material while maintaining line spacing. This can improve line contact and strength.\n"
+                     "Values below 1.0: Reduce the amount of material while adjusting line spacing to maintain contact. This can improve sagging.\n\n"
+                     "The actual bridge flow used is calculated by multiplying this value with the filament flow ratio, and if set, the object's flow ratio.");
     def->min = 0;
     def->max = 2.0;
     def->mode = comAdvanced;
@@ -1302,8 +1300,10 @@ void PrintConfigDef::init_fff_params()
     def = this->add("internal_bridge_flow", coFloat);
     def->label = L("Internal bridge flow ratio");
     def->category = L("Quality");
-    def->tooltip = L("This value governs the thickness of the internal bridge layer. This is the first layer over sparse infill. Decrease this value slightly (for example 0.9) to improve surface quality over sparse infill."
-                     "\n\nThe actual internal bridge flow used is calculated by multiplying this value with the bridge flow ratio, the filament flow ratio, and if set, the object's flow ratio.");
+    def->tooltip = L("This value governs the thickness of the internal bridge layer. This is the first layer over sparse infill so increasing it may increase strength and upper layer quality.\n"
+                     "Values above 1.0: Increase the amount of material while maintaining line spacing. This can improve line contact and strength.\n"
+                     "Values below 1.0: Reduce the amount of material while adjusting line spacing to maintain contact. This can improve sagging.\n\n"
+                     "The actual bridge flow used is calculated by multiplying this value with the filament flow ratio, and if set, the object's flow ratio.");
     def->min = 0;
     def->max = 2.0;
     def->mode = comAdvanced;

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -1281,8 +1281,10 @@ void PrintConfigDef::init_fff_params()
     def = this->add("bridge_line_width", coFloatOrPercent);
     def->label = L("Bridge");
     def->category = L("Quality");
-    def->tooltip = L("Bridge line width expressed either as an absolute value or as a percentage of the active nozzle diameter (percentages are computed from the nozzle diameter). Recommended value 100% along with a higher External bridge density or Bridge flow ratio.\n"
-                     "Leave at 0 to use the automatic width.");
+    def->tooltip = L("Bridge line width expressed either as an absolute value or as a percentage of the active nozzle diameter (percentages are computed from the nozzle diameter).\n"
+                     "Recommended to use with a higher Bridge density or Bridge flow ratio.\n\n"
+                     "Maximum value is 100% or nozzle diameter.\n"
+                     "If set to 0, the line width will be equal to Internal solid infill width.");
     def->sidetext = L("mm or %");
     def->ratio_over = "nozzle_diameter";
     def->min = 0;

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -1047,6 +1047,7 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionFloat,                bridge_angle))
     ((ConfigOptionFloat,                internal_bridge_angle)) // ORCA: Internal bridge angle override
     ((ConfigOptionFloat,                bridge_flow))
+    ((ConfigOptionFloat,                bridge_line_width))
     ((ConfigOptionFloat,                internal_bridge_flow))
     ((ConfigOptionFloat,                bridge_speed))
     ((ConfigOptionFloatOrPercent,       internal_bridge_speed))

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -1047,7 +1047,7 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionFloat,                bridge_angle))
     ((ConfigOptionFloat,                internal_bridge_angle)) // ORCA: Internal bridge angle override
     ((ConfigOptionFloat,                bridge_flow))
-    ((ConfigOptionFloat,                bridge_line_width))
+    ((ConfigOptionFloatOrPercent,       bridge_line_width))
     ((ConfigOptionFloat,                internal_bridge_flow))
     ((ConfigOptionFloat,                bridge_speed))
     ((ConfigOptionFloatOrPercent,       internal_bridge_speed))

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -1081,6 +1081,7 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionFloat,                bridge_angle))
     ((ConfigOptionFloat,                internal_bridge_angle)) // ORCA: Internal bridge angle override
     ((ConfigOptionFloat,                bridge_flow))
+    ((ConfigOptionFloat,                bridge_line_width))
     ((ConfigOptionFloat,                internal_bridge_flow))
     ((ConfigOptionFloat,                bridge_speed))
     ((ConfigOptionFloatOrPercent,       internal_bridge_speed))

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -1081,7 +1081,7 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionFloat,                bridge_angle))
     ((ConfigOptionFloat,                internal_bridge_angle)) // ORCA: Internal bridge angle override
     ((ConfigOptionFloat,                bridge_flow))
-    ((ConfigOptionFloat,                bridge_line_width))
+    ((ConfigOptionFloatOrPercent,       bridge_line_width))
     ((ConfigOptionFloat,                internal_bridge_flow))
     ((ConfigOptionFloat,                bridge_speed))
     ((ConfigOptionFloatOrPercent,       internal_bridge_speed))

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -1209,6 +1209,7 @@ bool PrintObject::invalidate_state_by_config_options(
             || opt_key == "bridge_angle"
             || opt_key == "internal_bridge_angle" // ORCA: Internal bridge angle override
             //BBS
+            || opt_key == "bridge_line_width"
             || opt_key == "bridge_density"
             || opt_key == "internal_bridge_density") {
             steps.emplace_back(posPrepareInfill);

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -1276,6 +1276,7 @@ bool PrintObject::invalidate_state_by_config_options(
             || opt_key == "bridge_angle"
             || opt_key == "internal_bridge_angle" // ORCA: Internal bridge angle override
             //BBS
+            || opt_key == "bridge_line_width"
             || opt_key == "bridge_density"
             || opt_key == "internal_bridge_density") {
             steps.emplace_back(posPrepareInfill);

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -2288,14 +2288,14 @@ void TabPrint::build()
 
         optgroup = page->new_optgroup(L("Line width"), L"param_line_width");
         optgroup->append_single_option_line("line_width","quality_settings_line_width");
-        optgroup->append_single_option_line("initial_layer_line_width","quality_settings_line_width");
-        optgroup->append_single_option_line("outer_wall_line_width","quality_settings_line_width");
-        optgroup->append_single_option_line("inner_wall_line_width","quality_settings_line_width");
-        optgroup->append_single_option_line("top_surface_line_width","quality_settings_line_width");
-        optgroup->append_single_option_line("sparse_infill_line_width","quality_settings_line_width");
-        optgroup->append_single_option_line("internal_solid_infill_line_width","quality_settings_line_width");
-        optgroup->append_single_option_line("support_line_width","quality_settings_line_width");
-        optgroup->append_single_option_line("bridge_line_width","quality_settings_line_width");
+        optgroup->append_single_option_line("initial_layer_line_width","quality_settings_line_width#first-layer");
+        optgroup->append_single_option_line("outer_wall_line_width","quality_settings_line_width#outer-wall");
+        optgroup->append_single_option_line("inner_wall_line_width","quality_settings_line_width#inner-wall");
+        optgroup->append_single_option_line("top_surface_line_width","quality_settings_line_width#top-surface");
+        optgroup->append_single_option_line("sparse_infill_line_width","quality_settings_line_width#sparse-infill");
+        optgroup->append_single_option_line("internal_solid_infill_line_width","quality_settings_line_width#internal-solid-infill");
+        optgroup->append_single_option_line("support_line_width","quality_settings_line_width#support");
+        optgroup->append_single_option_line("bridge_line_width","quality_settings_line_width#bridge");
 
         optgroup = page->new_optgroup(L("Seam"), L"param_seam");
         optgroup->append_single_option_line("seam_position", "quality_settings_seam#seam-position");

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -2383,7 +2383,8 @@ void TabPrint::build()
 
         optgroup = page->new_optgroup(L("Bridging"), L"param_bridge");
         optgroup->append_single_option_line("bridge_flow", "quality_settings_bridging#flow-ratio");
-	    optgroup->append_single_option_line("internal_bridge_flow", "quality_settings_bridging#flow-ratio");
+        optgroup->append_single_option_line("bridge_line_width", "quality_settings_bridging#flow-ratio");
+        optgroup->append_single_option_line("internal_bridge_flow", "quality_settings_bridging#flow-ratio");
         optgroup->append_single_option_line("bridge_density", "quality_settings_bridging#bridge-density");
         optgroup->append_single_option_line("internal_bridge_density", "quality_settings_bridging#bridge-density");
         optgroup->append_single_option_line("thick_bridges", "quality_settings_bridging#thick-bridges");

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -2295,6 +2295,7 @@ void TabPrint::build()
         optgroup->append_single_option_line("sparse_infill_line_width","quality_settings_line_width");
         optgroup->append_single_option_line("internal_solid_infill_line_width","quality_settings_line_width");
         optgroup->append_single_option_line("support_line_width","quality_settings_line_width");
+        optgroup->append_single_option_line("bridge_line_width","quality_settings_line_width");
 
         optgroup = page->new_optgroup(L("Seam"), L"param_seam");
         optgroup->append_single_option_line("seam_position", "quality_settings_seam#seam-position");
@@ -2383,7 +2384,6 @@ void TabPrint::build()
 
         optgroup = page->new_optgroup(L("Bridging"), L"param_bridge");
         optgroup->append_single_option_line("bridge_flow", "quality_settings_bridging#flow-ratio");
-        optgroup->append_single_option_line("bridge_line_width", "quality_settings_bridging#flow-ratio");
         optgroup->append_single_option_line("internal_bridge_flow", "quality_settings_bridging#flow-ratio");
         optgroup->append_single_option_line("bridge_density", "quality_settings_bridging#bridge-density");
         optgroup->append_single_option_line("internal_bridge_density", "quality_settings_bridging#bridge-density");

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -2308,6 +2308,7 @@ void TabPrint::build()
         optgroup->append_single_option_line("sparse_infill_line_width","quality_settings_line_width");
         optgroup->append_single_option_line("internal_solid_infill_line_width","quality_settings_line_width");
         optgroup->append_single_option_line("support_line_width","quality_settings_line_width");
+        optgroup->append_single_option_line("bridge_line_width","quality_settings_line_width");
 
         optgroup = page->new_optgroup(L("Seam"), L"param_seam");
         optgroup->append_single_option_line("seam_position", "quality_settings_seam#seam-position");
@@ -2407,7 +2408,6 @@ void TabPrint::build()
 
         optgroup = page->new_optgroup(L("Bridging"), L"param_bridge");
         optgroup->append_single_option_line("bridge_flow", "quality_settings_bridging#flow-ratio");
-        optgroup->append_single_option_line("bridge_line_width", "quality_settings_bridging#flow-ratio");
         optgroup->append_single_option_line("internal_bridge_flow", "quality_settings_bridging#flow-ratio");
         optgroup->append_single_option_line("bridge_density", "quality_settings_bridging#bridge-density");
         optgroup->append_single_option_line("internal_bridge_density", "quality_settings_bridging#bridge-density");

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -2407,7 +2407,8 @@ void TabPrint::build()
 
         optgroup = page->new_optgroup(L("Bridging"), L"param_bridge");
         optgroup->append_single_option_line("bridge_flow", "quality_settings_bridging#flow-ratio");
-	    optgroup->append_single_option_line("internal_bridge_flow", "quality_settings_bridging#flow-ratio");
+        optgroup->append_single_option_line("bridge_line_width", "quality_settings_bridging#flow-ratio");
+        optgroup->append_single_option_line("internal_bridge_flow", "quality_settings_bridging#flow-ratio");
         optgroup->append_single_option_line("bridge_density", "quality_settings_bridging#bridge-density");
         optgroup->append_single_option_line("internal_bridge_density", "quality_settings_bridging#bridge-density");
         optgroup->append_single_option_line("thick_bridges", "quality_settings_bridging#thick-bridges");

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -2301,14 +2301,14 @@ void TabPrint::build()
 
         optgroup = page->new_optgroup(L("Line width"), L"param_line_width");
         optgroup->append_single_option_line("line_width","quality_settings_line_width");
-        optgroup->append_single_option_line("initial_layer_line_width","quality_settings_line_width");
-        optgroup->append_single_option_line("outer_wall_line_width","quality_settings_line_width");
-        optgroup->append_single_option_line("inner_wall_line_width","quality_settings_line_width");
-        optgroup->append_single_option_line("top_surface_line_width","quality_settings_line_width");
-        optgroup->append_single_option_line("sparse_infill_line_width","quality_settings_line_width");
-        optgroup->append_single_option_line("internal_solid_infill_line_width","quality_settings_line_width");
-        optgroup->append_single_option_line("support_line_width","quality_settings_line_width");
-        optgroup->append_single_option_line("bridge_line_width","quality_settings_line_width");
+        optgroup->append_single_option_line("initial_layer_line_width","quality_settings_line_width#first-layer");
+        optgroup->append_single_option_line("outer_wall_line_width","quality_settings_line_width#outer-wall");
+        optgroup->append_single_option_line("inner_wall_line_width","quality_settings_line_width#inner-wall");
+        optgroup->append_single_option_line("top_surface_line_width","quality_settings_line_width#top-surface");
+        optgroup->append_single_option_line("sparse_infill_line_width","quality_settings_line_width#sparse-infill");
+        optgroup->append_single_option_line("internal_solid_infill_line_width","quality_settings_line_width#internal-solid-infill");
+        optgroup->append_single_option_line("support_line_width","quality_settings_line_width#support");
+        optgroup->append_single_option_line("bridge_line_width","quality_settings_line_width#bridge");
 
         optgroup = page->new_optgroup(L("Seam"), L"param_seam");
         optgroup->append_single_option_line("seam_position", "quality_settings_seam#seam-position");


### PR DESCRIPTION
Closes #11209, #11412 and #11954

# The Issue

Currently, bridges calculate their path with a line width equal to “Internal Solid Infill” or, if this is not defined, to the general setting.
Most of the time, these have a value greater than the nozzle size, since when pressed against the previous layer they can generate a greater width and improve the bond between layers.

The problem here is that bridges have nothing to press against, as they are printed in mid-air.

# The solution

Separate the line width value for bridges in order to correctly use 100% (line width) so that each bridge line is welded to the adjacent line without compromising printing time (if the overall line width were reduced).

Capped at 100% or equal nozzle size.

![bridge_line_width_1](https://github.com/user-attachments/assets/fb69c60a-dd1e-4329-891b-08a04bb3dbd7)
![bridge_line_width_2](https://github.com/user-attachments/assets/d0c4ce05-3062-444e-8551-f976b64f7f74)

<img width="1584" height="813" alt="imagen" src="https://github.com/user-attachments/assets/7bd9e37e-0d2d-467c-bc34-294620bb44f8" />

## Flow and bond

Perform various tests considering the following points:

- Connection of lines in the short section
- Connection of lines in the long section
- Quality of the bottom layer (how even it is, penalizes under- and over-extrusion)
- Quality of the top layer (penalizes over-extrusion)

On average, the following conclusions can be drawn:

- Width > nozzle (CURRENT) is a mistake and has the most negative impact. Compensating for the flow or density to counteract the effect is feasible but not precise. It varies greatly depending on the shape and length of the extrusion.
- Width = nozzle (This PR default) is beneficial, but even more so if it is compensated for by either slightly increasing the density or increasing the flow.
- Width < nozzle (This PR) also produces a good finish with or without compensation.
- Increasing the flow can be an excellent way to compensate, but if you exceed it, you may get poor finishes.
- Reducing the flow because it further reduces spacing can help, but you will not get the best results.
- Increasing the density of internal and external bridges to 125% to increase bonding in smaller pieces and avoid ironing: Thanks @valerii-bokhan !!!
<img width="4032" height="3024" alt="imagen" src="https://github.com/user-attachments/assets/416d48d6-84b0-4f74-b838-79fa6ca7ea3d" />


<img width="885" height="401" alt="imagen" src="https://github.com/user-attachments/assets/432226d1-8fd9-43f6-827f-20855b4037ba" />

### Bridge Flow Density

BRIDGE FLOW < 1 CHANGE THE SPACING.
BRIDGE FLOW > 1 CHANGE THE FLOW IN THE SAME PATTERN.

Previously, it was recommended to reduce the Bridge Flow or density to compensate the spacing between lines and generate a thinner first bridge layer with better cooling, which would then serve as a base for the next layers.

With this new setting, the idea is the opposite: to maximize contact and bonding between the lines, so increasing the Bridge Flow or using Thick Bridges further improves the finish surface.

### Bridge Density

Due to the erratic behavior of flow compensation (depending on whether it is greater or less than one and whether thick bridges are enabled or not), increasing the density of the bridging pattern seems to be a more effective way to compensate.
REMOVED FROM THIS PR, @MakeSometh1ngWonderful implemented it here #11283 

### Thick Bridges

Clarification how it changes layer high to match nozzle diameter.

#### Tests

My personal test data is in the table here and discord chat.
<img width="1354" height="849" alt="imagen" src="https://github.com/user-attachments/assets/30bad6bc-be6f-4adf-8474-b0c34ded19b5" />

Similar results where found by @RF47 tests, the best results are achieved with:
Line width = 100% of nozzle size
Bridge flow of 150%
Bridge speed of 10 mm/s

<img width="2992" height="2992" alt="509235257-7a7c292a-1605-4243-9fc4-aff23c2ca3c4" src="https://github.com/user-attachments/assets/06556e91-206f-4802-8e0c-ad0c27c47305" />

# Credits

- @RF47 's width main idea and testing
- [Slic3r Bridge Flow Math](https://manual.slic3r.org/advanced/flow-math) 
- @MakeSometh1ngWonderful density idea and videos ([The BEST settings for bridges](https://youtu.be/xQBLv3cPUbo?si=8dj4Rq8cKriL6k-e) and [Absolutely PERFECT Unsupported 3D Printed Bridges](https://youtu.be/eaasEkFULKE?si=SO-9Xr-_1t6p3sMy)).
- @valerii-bokhan his ultra small bridge testing.
- THIS BEAUTIFUL COMMUNITY!!! Thanks all for your participation.

close #10516
close #11412 
close  #11954
close #13106