### PR TITLE
Add Mesa3D software renderer for Windows build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -834,6 +834,9 @@ function(orcaslicer_copy_dlls target config postfix output_dlls)
             ${CMAKE_PREFIX_PATH}/bin/freetype.dll
          DESTINATION ${_out_dir})
 
+    file(COPY ${CMAKE_PREFIX_PATH}/bin/mesa/opengl32.dll
+        DESTINATION ${_out_dir}/mesa/)
+
     set(${output_dlls}
         ${_out_dir}/libgmp-10.dll
         ${_out_dir}/libmpfr-4.dll
@@ -901,6 +904,9 @@ if (WIN32)
     set(CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP TRUE)
     include(InstallRequiredSystemLibraries)
     install (PROGRAMS ${CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS} DESTINATION ".")
+
+    # install Mesa3D
+    install(FILES "${CMAKE_PREFIX_PATH}/bin/mesa/opengl32.dll" DESTINATION "./mesa")
 elseif (SLIC3R_FHS)
     # CMAKE_INSTALL_FULL_DATAROOTDIR: read-only architecture-independent data root (share)
     set(SLIC3R_FHS_RESOURCES "${CMAKE_INSTALL_FULL_DATAROOTDIR}/OrcaSlicer")

--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -408,6 +408,9 @@ set(_dep_list
     )
 
 if (MSVC)
+    include(mesa/mesa.cmake) # Add Mesa3D OpenGL software renderer
+    list(APPEND _dep_list "dep_mesa")
+
     # Experimental
     #list(APPEND _dep_list "dep_qhull")
 else()

--- a/deps/mesa/mesa.cmake
+++ b/deps/mesa/mesa.cmake
@@ -1,0 +1,8 @@
+# Prebuilt Mesa3D binary from https://download.qt.io/development_releases/prebuilt/llvmpipe/windows/
+ExternalProject_Add(dep_mesa
+    URL "${CMAKE_CURRENT_LIST_DIR}/opengl32sw-64-mesa_11_2_2-signed_sha256.7z"
+    URL_HASH SHA256=c61f801c1760aa24b02c7a8354323cddf368b86f8f5c34b50b3b224f7d728afd
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND ""
+    INSTALL_COMMAND ${CMAKE_COMMAND} -E copy "<SOURCE_DIR>/opengl32sw.dll" ${DESTDIR}/bin/mesa/opengl32.dll # Copy the dll to dist
+)

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -9866,10 +9866,10 @@ CLIMiscConfigDef::CLIMiscConfigDef()
     def->set_default_value(new ConfigOptionBool(false));
 
 #if (defined(_MSC_VER) || defined(__MINGW32__)) && defined(SLIC3R_GUI)
-    /*def = this->add("sw_renderer", coBool);
+    def = this->add("sw_renderer", coBool);
     def->label = L("Render with a software renderer");
     def->tooltip = L("Render with a software renderer. The bundled MESA software renderer is loaded instead of the default OpenGL driver.");
-    def->min = 0;*/
+    def->min = 0;
 #endif /* _MSC_VER */
 
     def = this->add("load_custom_gcodes", coString);


### PR DESCRIPTION
Add Mesa3D software renderer for Windows build in case system opengl doesn't work properly, this mostly happen in a remote desktop environment.

Also one can force using sw renderer by passing cmd arg '--sw-renderer' when launching the app.

Fix #2928