### PR TITLE
Fix: Hiding the `ironing_angle_fixed` setting in the UI if the ironing is disabled

### DIFF
--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -780,7 +780,7 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig *config, co
         toggle_field(el, have_support_material && !(support_is_normal_tree && !have_raft));
 
     bool has_ironing = (config->opt_enum<IroningType>("ironing_type") != IroningType::NoIroning);
-    for (auto el : { "ironing_pattern", "ironing_flow", "ironing_spacing", "ironing_angle", "ironing_inset"})
+    for (auto el : { "ironing_pattern", "ironing_flow", "ironing_spacing", "ironing_angle", "ironing_inset", "ironing_angle_fixed" })
         toggle_line(el, has_ironing);
     
     toggle_line("ironing_speed", has_ironing || has_support_ironing);


### PR DESCRIPTION
# Description

Fixing a minor bug in UI after https://github.com/SoftFever/OrcaSlicer/pull/11195

# Screenshots

### Before:

<img width="390" height="107" alt="ironing_ui_bug" src="https://github.com/user-attachments/assets/cf6e22d4-226b-42a4-be50-a1a944d57d27" />

### After:

<img width="395" height="113" alt="ironing_ui_fix" src="https://github.com/user-attachments/assets/e7f1ae4e-1464-44e0-bdd2-0e9a4ad7ac91" />
