### PR TITLE
Move Generic vendor above Bambu vendor in AMS material setting.

### DIFF
--- a/src/slic3r/GUI/AMSMaterialsSetting.cpp
+++ b/src/slic3r/GUI/AMSMaterialsSetting.cpp
@@ -1025,7 +1025,7 @@ void AMSMaterialsSetting::Popup(wxString filament, wxString sn, wxString temp_mi
             {"Bambu ABS-GF",           11}
         };
 
-        static std::vector<wxString> sorted_vendors { "Bambu Lab", "Generic" };
+        static std::vector<wxString> sorted_vendors{ "Generic", "Bambu Lab" };
         static std::vector<wxString> sorted_types { "PLA", "PETG", "ABS", "TPU" };
         auto _filament_sorter = [&query_filament_vendors, &query_filament_types](const wxString& left, const wxString& right) -> bool
         {

--- a/src/slic3r/GUI/AMSMaterialsSetting.cpp
+++ b/src/slic3r/GUI/AMSMaterialsSetting.cpp
@@ -4,6 +4,8 @@
 #include "GUI_App.hpp"
 #include "libslic3r/Preset.hpp"
 #include "I18N.hpp"
+#include <algorithm>
+#include <iterator>
 #include <boost/log/trivial.hpp>
 #include <wx/colordlg.h>
 #include <wx/dcgraph.h>
@@ -1092,7 +1094,7 @@ void AMSMaterialsSetting::Popup(wxString filament, wxString sn, wxString temp_mi
         const auto& preset_names = bundle->filament_presets;
         for (size_t i = preset_names.size(); i-- > 0; ) {
             std::string wanted = preset_names[i];
-            const int sort_rank = -((int)preset_names.size() - i);
+            const int sort_rank = -static_cast<int>(preset_names.size() - i);
             
             const Preset* match = nullptr;
 
@@ -1126,9 +1128,15 @@ void AMSMaterialsSetting::Popup(wxString filament, wxString sn, wxString temp_mi
             selected_filament_ranks.insert_or_assign(match->alias, sort_rank);
         }
         
-        static std::vector<wxString> sorted_vendors{ "Generic" };
-        static std::vector<wxString> sorted_types { "PLA", "PETG", "ABS", "TPU" };
-        auto _filament_sorter = [&query_filament_vendors, &query_filament_types, &selected_filament_ranks](const wxString& left, const wxString& right) -> bool
+        static const std::vector<wxString> sorted_vendors { "Generic" };
+        static const std::vector<wxString> sorted_types { "PLA", "PETG", "ABS", "TPU" };
+        auto priority_rank = [](const std::vector<wxString>& priorities, const wxString& value) {
+            const auto iter = std::find_if(priorities.begin(), priorities.end(), [&value](const wxString& priority) {
+                return priority.CmpNoCase(value) == 0;
+            });
+            return std::distance(priorities.begin(), iter);
+        };
+        auto _filament_sorter = [&query_filament_vendors, &query_filament_types, &selected_filament_ranks, &priority_rank](const wxString& left, const wxString& right) -> bool
         {
             { // Compare selected filament order
                 const auto& iter1 = selected_filament_ranks.find(left);
@@ -1142,23 +1150,32 @@ void AMSMaterialsSetting::Popup(wxString filament, wxString sn, wxString temp_mi
                 }
             }
             { // Compare vendor
-                auto iter1 = std::find(sorted_vendors.begin(), sorted_vendors.end(), query_filament_vendors[left]);
-                auto iter2 = std::find(sorted_vendors.begin(), sorted_vendors.end(), query_filament_vendors[right]);
-                if (iter1 != iter2)
-                {
-                    return iter1 < iter2;
-                };
+                const wxString& vendor1 = query_filament_vendors.at(left);
+                const wxString& vendor2 = query_filament_vendors.at(right);
+                const auto      rank1   = priority_rank(sorted_vendors, vendor1);
+                const auto      rank2   = priority_rank(sorted_vendors, vendor2);
+                if (rank1 != rank2)
+                    return rank1 < rank2;
+
+                const int vendor_compare = vendor1.CmpNoCase(vendor2);
+                if (vendor_compare != 0)
+                    return vendor_compare < 0;
             }
             { // Compare type
-                auto iter1 = std::find(sorted_types.begin(), sorted_types.end(), query_filament_types[left]);
-                auto iter2 = std::find(sorted_types.begin(), sorted_types.end(), query_filament_types[right]);
-                if (iter1 != iter2)
-                {
-                    return iter1 < iter2;
-                }
+                const wxString& type1 = query_filament_types.at(left);
+                const wxString& type2 = query_filament_types.at(right);
+                const auto      rank1 = priority_rank(sorted_types, type1);
+                const auto      rank2 = priority_rank(sorted_types, type2);
+                if (rank1 != rank2)
+                    return rank1 < rank2;
+
+                const int type_compare = type1.CmpNoCase(type2);
+                if (type_compare != 0)
+                    return type_compare < 0;
             }
 
-            return left < right;
+            const int name_compare = left.CmpNoCase(right);
+            return name_compare != 0 ? name_compare < 0 : left < right;
         };
 
         std::sort(filament_items.begin(), filament_items.end(), _filament_sorter);

--- a/src/slic3r/GUI/AMSMaterialsSetting.cpp
+++ b/src/slic3r/GUI/AMSMaterialsSetting.cpp
@@ -1139,7 +1139,7 @@ void AMSMaterialsSetting::Popup(wxString filament, wxString sn, wxString temp_mi
             sorted_names.insert_or_assign(match->alias, sort_rank);
         }
         
-        static std::vector<wxString> sorted_vendors { "Bambu Lab", "Generic" };
+        static std::vector<wxString> sorted_vendors{ "Generic", "Bambu Lab" };
         static std::vector<wxString> sorted_types { "PLA", "PETG", "ABS", "TPU" };
         auto _filament_sorter = [&query_filament_vendors, &query_filament_types, &sorted_names](const wxString& left, const wxString& right) -> bool
         {

--- a/src/slic3r/GUI/AMSMaterialsSetting.cpp
+++ b/src/slic3r/GUI/AMSMaterialsSetting.cpp
@@ -5,7 +5,6 @@
 #include "libslic3r/Preset.hpp"
 #include "I18N.hpp"
 #include <algorithm>
-#include <iterator>
 #include <boost/log/trivial.hpp>
 #include <wx/colordlg.h>
 #include <wx/dcgraph.h>
@@ -1134,7 +1133,7 @@ void AMSMaterialsSetting::Popup(wxString filament, wxString sn, wxString temp_mi
             const auto iter = std::find_if(priorities.begin(), priorities.end(), [&value](const wxString& priority) {
                 return priority.CmpNoCase(value) == 0;
             });
-            return std::distance(priorities.begin(), iter);
+            return iter - priorities.begin();
         };
         auto _filament_sorter = [&query_filament_vendors, &query_filament_types, &selected_filament_ranks, &priority_rank](const wxString& left, const wxString& right) -> bool
         {

--- a/src/slic3r/GUI/AMSMaterialsSetting.cpp
+++ b/src/slic3r/GUI/AMSMaterialsSetting.cpp
@@ -1075,20 +1075,7 @@ void AMSMaterialsSetting::Popup(wxString filament, wxString sn, wxString temp_mi
 
     // Sort the filaments
     {
-        std::unordered_map<wxString, int> sorted_names =
-        {   {"Bambu PLA Basic",        0},
-            {"Bambu PLA Matte",        1},
-            {"Bambu PETG HF",          2},
-            {"Bambu ABS",              3},
-            {"Bambu PLA Silk",         4},
-            {"Bambu PLA-CF" ,          5},
-            {"Bambu PLA Galaxy",       6},
-            {"Bambu PLA Metal",        7},
-            {"Bambu PLA Marble",       8},
-            {"Bambu PETG-CF",          9},
-            {"Bambu PETG Translucent", 10},
-            {"Bambu ABS-GF",           11}
-        };
+        std::unordered_map<wxString, int> selected_filament_ranks;
 
         // Helper lambda to find a filament Preset by name. We can call this multiple times to walk the inheritance chain and find the base filament.
         auto find_filament_by_name = [](const std::string& wanted, const PresetCollection& filaments) -> const Preset* {
@@ -1100,7 +1087,7 @@ void AMSMaterialsSetting::Popup(wxString filament, wxString sn, wxString temp_mi
             return nullptr;
         };
 
-        // For each active filament preset, find matching Preset in bundle->filaments and add the base filament alias to sorted_names in highest rank in extruder order
+        // For each active filament preset, find its base filament alias and promote it in extruder order.
         auto        bundle       = wxGetApp().preset_bundle;
         const auto& preset_names = bundle->filament_presets;
         for (size_t i = preset_names.size(); i-- > 0; ) {
@@ -1136,22 +1123,22 @@ void AMSMaterialsSetting::Popup(wxString filament, wxString sn, wxString temp_mi
 
             BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << " Update filament rank to " + std::to_string(sort_rank) + " for preset Name: "
                                     << match->name << " - Alias: " << match->alias;
-            sorted_names.insert_or_assign(match->alias, sort_rank);
+            selected_filament_ranks.insert_or_assign(match->alias, sort_rank);
         }
         
-        static std::vector<wxString> sorted_vendors{ "Generic", "Bambu Lab" };
+        static std::vector<wxString> sorted_vendors{ "Generic" };
         static std::vector<wxString> sorted_types { "PLA", "PETG", "ABS", "TPU" };
-        auto _filament_sorter = [&query_filament_vendors, &query_filament_types, &sorted_names](const wxString& left, const wxString& right) -> bool
+        auto _filament_sorter = [&query_filament_vendors, &query_filament_types, &selected_filament_ranks](const wxString& left, const wxString& right) -> bool
         {
-            { // Compare name order
-                const auto& iter1 = sorted_names.find(left);
-                int name_order1 = (iter1 != sorted_names.end()) ? iter1->second : INT_MAX;
+            { // Compare selected filament order
+                const auto& iter1 = selected_filament_ranks.find(left);
+                int selected_order1 = (iter1 != selected_filament_ranks.end()) ? iter1->second : INT_MAX;
 
-                const auto& iter2 = sorted_names.find(right);
-                int name_order2 = (iter2 != sorted_names.end()) ? iter2->second : INT_MAX;
-                if (name_order1 != name_order2)
+                const auto& iter2 = selected_filament_ranks.find(right);
+                int selected_order2 = (iter2 != selected_filament_ranks.end()) ? iter2->second : INT_MAX;
+                if (selected_order1 != selected_order2)
                 {
-                    return name_order1 < name_order2;
+                    return selected_order1 < selected_order2;
                 }
             }
             { // Compare vendor


### PR DESCRIPTION
# Description

OrcaSlicer is an open source slicer that tries to be vendor agnostic when it makes sense. `Generic` filament vendor is the "base" filament that most custom filaments profiles are created from so it would reflect the open nature of OrcaSlicer to position `Generic` above `Bambu` filaments in the AMS Material Settings. 

Currently `Bambu` vendor is explicitly sorted above `Generic` from BBS and a hardcoded list of some Bambu filament will always show at the very top no matter what:

## **If the user's current filaments are automatically shown at the top of the AMS filament list in #11293 , this PR might not be needed since the user's active filaments will always be at the top.**

```
static std::unordered_map<wxString, int> sorted_names
{   {"Bambu PLA Basic",        0},
    {"Bambu PLA Matte",        1},
    {"Bambu PETG HF",          2},
    {"Bambu ABS",              3},
    {"Bambu PLA Silk",         4},
    {"Bambu PLA-CF" ,          5},
    {"Bambu PLA Galaxy",       6},
    {"Bambu PLA Metal",        7},
    {"Bambu PLA Marble",       8},
    {"Bambu PETG-CF",          9},
    {"Bambu PETG Translucent", 10},
    {"Bambu ABS-GF",           11}
};
```

Bambu has over 30 extra uncommon filaments listed below which show up before `Generic`. This is over 2 complete dropdown list windows of filament to scroll past.
<img width="476" height="681" alt="image" src="https://github.com/user-attachments/assets/20f7de29-a3df-49e6-ad99-45d0f4ba8031" />
<img width="485" height="693" alt="image" src="https://github.com/user-attachments/assets/1bf62bf0-657c-4cd3-abaa-e0277b613cfe" />

Moving `Generic` above these will cater to more users who have custom filament settings to show the `Generic` filament above the 30 extra Bambu filaments but under the existing Bambu filament names hardcoded above. 

# Screenshots/Recordings/Graphs

New arrangement shows `Generic` filament under the hardcoded top Bambu filaments and below

<img width="893" height="884" alt="image" src="https://github.com/user-attachments/assets/63dc447c-0950-4a39-8b5a-825274f45f33" />

## Tests

I can view the Generic vendor at the top instead of Bambu and select the filament. 
