### PR TITLE
WIP: Nonplanar fuzzy skin

### DIFF
--- a/src/libslic3r/ExtrusionEntityCollection.cpp
+++ b/src/libslic3r/ExtrusionEntityCollection.cpp
@@ -78,6 +78,12 @@ void ExtrusionEntityCollection::replace(size_t i, const ExtrusionEntity &entity)
     this->entities[i] = entity.clone();
 }
 
+void ExtrusionEntityCollection::replace(size_t i, ExtrusionEntity&& entity)
+{
+    delete this->entities[i];
+    this->entities[i] = entity.clone_move();
+}
+
 void ExtrusionEntityCollection::remove(size_t i)
 {
     delete this->entities[i];

--- a/src/libslic3r/ExtrusionEntityCollection.hpp
+++ b/src/libslic3r/ExtrusionEntityCollection.hpp
@@ -113,6 +113,7 @@ public:
             this->entities.emplace_back(new ExtrusionPath(std::move(path)));
     }
     void replace(size_t i, const ExtrusionEntity &entity);
+    void replace(size_t i, ExtrusionEntity&& entity);
     void remove(size_t i);
     static ExtrusionEntityCollection chained_path_from(const ExtrusionEntitiesPtr &extrusion_entities, const Point &start_near, ExtrusionRole role = erMixed);
     ExtrusionEntityCollection chained_path_from(const Point &start_near, ExtrusionRole role = erMixed) const 

--- a/src/libslic3r/Feature/FuzzySkin/FuzzySkin.cpp
+++ b/src/libslic3r/Feature/FuzzySkin/FuzzySkin.cpp
@@ -67,7 +67,7 @@ static std::unique_ptr<noise::module::Module> get_noise_module(const FuzzySkinCo
 }
 
 // Thanks Cura developers for this function.
-void fuzzy_polyline(Points& poly, bool closed, coordf_t slice_z, const FuzzySkinConfig& cfg)
+static void fuzzy_polyline(Points& poly, bool closed, coordf_t slice_z, const FuzzySkinConfig& cfg)
 {
     std::unique_ptr<noise::module::Module> noise = get_noise_module(cfg);
 
@@ -111,7 +111,7 @@ void fuzzy_polyline(Points& poly, bool closed, coordf_t slice_z, const FuzzySkin
 }
 
 // Thanks Cura developers for this function.
-void fuzzy_extrusion_line(Arachne::ExtrusionJunctions& ext_lines, coordf_t slice_z, const FuzzySkinConfig& cfg)
+static void fuzzy_extrusion_line(Arachne::ExtrusionJunctions& ext_lines, coordf_t slice_z, const FuzzySkinConfig& cfg)
 {
     std::unique_ptr<noise::module::Module> noise = get_noise_module(cfg);
 
@@ -211,7 +211,7 @@ void group_region_by_fuzzify(PerimeterGenerator& g)
     }
 }
 
-bool should_fuzzify(const FuzzySkinConfig& config, const int layer_id, const size_t loop_idx, const bool is_contour)
+static bool should_fuzzify(const FuzzySkinConfig& config, const int layer_id, const size_t loop_idx, const bool is_contour)
 {
     const auto fuzziy_type = config.type;
 

--- a/src/libslic3r/Feature/FuzzySkin/FuzzySkin.cpp
+++ b/src/libslic3r/Feature/FuzzySkin/FuzzySkin.cpp
@@ -438,8 +438,10 @@ static void nonplanar_fuzzy_polyline(Points& poly, std::vector<double>& deviatio
     out.reserve(poly.size());
     for (Point& p1 : poly) {
         if (p0 == nullptr) {
+            // Skip the first point
             p0 = &p1;
-            put_next_point(p1);
+            out.emplace_back(p1);
+            deviation.emplace_back(0);
             continue;
         }
 
@@ -453,13 +455,13 @@ static void nonplanar_fuzzy_polyline(Points& poly, std::vector<double>& deviatio
             put_next_point(pa);
         }
         dist_left_over = p0pa_dist - p0p1_size;
-        if (dist_left_over > EPSILON) {
-            put_next_point(p1);
-        }
         p0 = &p1;
     }
     if (out.back() != poly.back()) {
-        put_next_point(poly.back());
+        out.emplace_back(poly.back());
+        deviation.emplace_back(0);
+    } else {
+        deviation.back() = 0;
     }
     poly = std::move(out);
 }

--- a/src/libslic3r/Feature/FuzzySkin/FuzzySkin.cpp
+++ b/src/libslic3r/Feature/FuzzySkin/FuzzySkin.cpp
@@ -188,12 +188,16 @@ void group_region_by_fuzzify(PerimeterGenerator& g)
                                   region_config.fuzzy_skin_octaves,
                                   region_config.fuzzy_skin_persistence,
                                   region_config.fuzzy_skin_mode};
-        auto&                 surfaces = regions[cfg];
-        for (const auto& surface : region->slices.surfaces) {
-            surfaces.push_back(&surface);
+        // Important: this line cannot be moved into the `if`, otherwise we have missing regions
+        auto& surfaces = regions[cfg];
+        if (cfg.fuzzify()) {
+            // We only keep the shape of regions that will be fuzzified
+            for (const auto& surface : region->slices.surfaces) {
+                surfaces.push_back(&surface);
+            }
         }
 
-        if (cfg.type != FuzzySkinType::None) {
+        if (cfg.fuzzify()) {
             g.has_fuzzy_skin = true;
             if (cfg.type != FuzzySkinType::External) {
                 g.has_fuzzy_hole = true;

--- a/src/libslic3r/Feature/FuzzySkin/FuzzySkin.cpp
+++ b/src/libslic3r/Feature/FuzzySkin/FuzzySkin.cpp
@@ -67,7 +67,7 @@ static std::unique_ptr<noise::module::Module> get_noise_module(const FuzzySkinCo
 }
 
 // Thanks Cura developers for this function.
-static void fuzzy_polyline(Points& poly, bool closed, coordf_t slice_z, const FuzzySkinConfig& cfg)
+static void fuzzy_polyline(Points& poly, bool closed, const coordf_t slice_z, const FuzzySkinConfig& cfg)
 {
     std::unique_ptr<noise::module::Module> noise = get_noise_module(cfg);
 
@@ -233,6 +233,24 @@ static bool should_fuzzify(const FuzzySkinConfig& config, const int layer_id, co
     return is_contour ? fuzzify_contours : fuzzify_holes;
 }
 
+static std::vector<std::pair<const FuzzySkinConfig&, const ExPolygons&>> find_affective_regions(
+    const std::unordered_map<FuzzySkinConfig, ExPolygons>& regions, const int layer_id, const size_t loop_idx, const bool is_contour)
+{
+    std::vector<std::pair<const FuzzySkinConfig&, const ExPolygons&>> fuzzified_regions;
+    fuzzified_regions.reserve(regions.size());
+    for (const auto& region : regions) {
+        if (should_fuzzify(region.first, layer_id, loop_idx, is_contour)) {
+            fuzzified_regions.emplace_back(region.first, region.second);
+        }
+    }
+    return fuzzified_regions;
+}
+
+static bool is_fully_clipped(const Algorithm::SplittedLine& l)
+{
+    return std::all_of(l.begin(), l.end(), [](const Algorithm::SplitLineJunction& j) { return j.clipped; });
+}
+
 Polygon apply_fuzzy_skin(const Polygon& polygon, const PerimeterGenerator& perimeter_generator, const size_t loop_idx, const bool is_contour)
 {
     Polygon fuzzified;
@@ -252,13 +270,7 @@ Polygon apply_fuzzy_skin(const Polygon& polygon, const PerimeterGenerator& perim
     }
 
     // Find all affective regions
-    std::vector<std::pair<const FuzzySkinConfig&, const ExPolygons&>> fuzzified_regions;
-    fuzzified_regions.reserve(regions.size());
-    for (const auto& region : regions) {
-        if (should_fuzzify(region.first, perimeter_generator.layer_id, loop_idx, is_contour)) {
-            fuzzified_regions.emplace_back(region.first, region.second);
-        }
-    }
+    const auto fuzzified_regions = find_affective_regions(regions, perimeter_generator.layer_id, loop_idx, is_contour);
     if (fuzzified_regions.empty()) {
         return polygon;
     }
@@ -293,13 +305,14 @@ Polygon apply_fuzzy_skin(const Polygon& polygon, const PerimeterGenerator& perim
         }
 
         // Fuzzy splitted polygon
-        if (std::all_of(splitted.begin(), splitted.end(), [](const Algorithm::SplitLineJunction& j) { return j.clipped; })) {
+        if (is_fully_clipped(splitted)) {
             // The entire polygon is fuzzified
             fuzzy_polyline(fuzzified.points, true, slice_z, r.first);
         } else {
+            fuzzified.points.clear();
+
             Points segment;
             segment.reserve(splitted.size());
-            fuzzified.points.clear();
 
             const auto fuzzy_current_segment = [&segment, &fuzzified, &r, slice_z]() {
                 fuzzified.points.push_back(segment.front());
@@ -344,13 +357,7 @@ void apply_fuzzy_skin(Arachne::ExtrusionLine* extrusion, const PerimeterGenerato
             fuzzy_extrusion_line(extrusion->junctions, slice_z, config);
     } else {
         // Find all affective regions
-        std::vector<std::pair<const FuzzySkinConfig&, const ExPolygons&>> fuzzified_regions;
-        fuzzified_regions.reserve(regions.size());
-        for (const auto& region : regions) {
-            if (should_fuzzify(region.first, perimeter_generator.layer_id, extrusion->inset_idx, is_contour)) {
-                fuzzified_regions.emplace_back(region.first, region.second);
-            }
-        }
+        const auto fuzzified_regions = find_affective_regions(regions, perimeter_generator.layer_id, extrusion->inset_idx, is_contour);
         if (!fuzzified_regions.empty()) {
             // Split the loops into lines with different config, and fuzzy them separately
             for (const auto& r : fuzzified_regions) {
@@ -361,14 +368,15 @@ void apply_fuzzy_skin(Arachne::ExtrusionLine* extrusion, const PerimeterGenerato
                 }
 
                 // Fuzzy splitted extrusion
-                if (std::all_of(splitted.begin(), splitted.end(), [](const Algorithm::SplitLineJunction& j) { return j.clipped; })) {
+                if (is_fully_clipped(splitted)) {
                     // The entire polygon is fuzzified
                     fuzzy_extrusion_line(extrusion->junctions, slice_z, r.first);
                 } else {
-                    const auto                              current_ext = extrusion->junctions;
+                    std::vector<Arachne::ExtrusionJunction> current_ext;
+                    std::swap(current_ext, extrusion->junctions);
+
                     std::vector<Arachne::ExtrusionJunction> segment;
                     segment.reserve(current_ext.size());
-                    extrusion->junctions.clear();
 
                     const auto fuzzy_current_segment = [&segment, &extrusion, &r, slice_z]() {
                         extrusion->junctions.push_back(segment.front());
@@ -402,6 +410,157 @@ void apply_fuzzy_skin(Arachne::ExtrusionLine* extrusion, const PerimeterGenerato
                     if (!segment.empty()) {
                         fuzzy_current_segment();
                     }
+                }
+            }
+        }
+    }
+}
+
+static void nonplanar_fuzzy_polyline(Points& poly, std::vector<double>& deviation, const coordf_t slice_z, const FuzzySkinConfig& cfg)
+{
+    std::unique_ptr<noise::module::Module> noise = get_noise_module(cfg);
+
+    const double min_dist_between_points = cfg.point_distance * 3. / 4.; // hardcoded: the point distance may vary between 3/4 and 5/4 the supplied value
+    const double range_random_point_dist = cfg.point_distance / 2.;
+    double dist_left_over = random_value() * (min_dist_between_points / 2.); // the distance to be traversed on the line before making the first new point
+
+    deviation.clear();
+    deviation.reserve(poly.size());
+
+    Points out;
+    const auto put_next_point = [&out, &deviation, &noise, &cfg, slice_z](Point& p) {
+        out.emplace_back(p);
+        double r = noise->GetValue(unscale_(p.x()), unscale_(p.y()), slice_z) * cfg.thickness;
+        deviation.emplace_back(r);
+    };
+
+    Point* p0 = nullptr;
+    out.reserve(poly.size());
+    for (Point& p1 : poly) {
+        if (p0 == nullptr) {
+            p0 = &p1;
+            put_next_point(p1);
+            continue;
+        }
+
+        // 'a' is the (next) new point between p0 and p1
+        Vec2d  p0p1      = (p1 - *p0).cast<double>();
+        double p0p1_size = p0p1.norm();
+        double p0pa_dist = dist_left_over;
+        for (; p0pa_dist < p0p1_size;
+            p0pa_dist += min_dist_between_points + random_value() * range_random_point_dist) {
+            Point pa = *p0 + (p0p1 * (p0pa_dist / p0p1_size)).cast<coord_t>();
+            put_next_point(pa);
+        }
+        dist_left_over = p0pa_dist - p0p1_size;
+        if (dist_left_over > EPSILON) {
+            put_next_point(p1);
+        }
+        p0 = &p1;
+    }
+    if (out.back() != poly.back()) {
+        put_next_point(poly.back());
+    }
+    poly = std::move(out);
+}
+
+void apply_nonplanar_fuzzy_skin(Layer* layer)
+{
+    const auto& fuzzy_regions     = layer->regions_by_fuzzify;
+    const auto  fuzzified_regions = find_affective_regions(fuzzy_regions, layer->id(), 0, true);
+    if (fuzzified_regions.empty())
+        return;
+
+    const auto region_cnt = layer->region_count();
+    for (size_t i = 0; i < region_cnt; i++) {
+        const auto region = layer->get_region(i);
+
+        // Find out fills that can be fuzzified
+        for (auto entity : region->fills.entities) {
+            // Every fill should be ExtrusionEntityCollection
+            auto fill = static_cast<ExtrusionEntityCollection*>(entity);
+
+            for (size_t j = 0; j < fill->size(); j++) {
+                const auto single_entity = fill->entities[j];
+                // For each fill collection, we process the top surfaces only
+                if (single_entity->role() != erTopSolidInfill) {
+                    continue;
+                }
+
+                // And top surface fills should only be either `ExtrusionLoop` or `ExtrusionPath`
+                if (ExtrusionPath* path = dynamic_cast<ExtrusionPath*>(single_entity)) {
+
+                    Points poly = std::move(path->polyline.points);
+                    std::vector<double> deviation(poly.size(), 0);
+
+                    // Start fuzzifying the path
+                    if (fuzzy_regions.size() == 1) { // optimization
+                        // Fuzzy the entire path
+                        nonplanar_fuzzy_polyline(poly, deviation, layer->slice_z, fuzzy_regions.begin()->first);
+                    } else {
+                        // Split the path into lines with different config, and fuzzy them separately
+                        for (const auto& r : fuzzified_regions) {
+                            const auto splitted = Algorithm::split_line(poly, r.second, false);
+                            if (splitted.empty()) {
+                                // No intersection, skip
+                                continue;
+                            }
+
+                            // Fuzzy splitted extrusion
+                            if (is_fully_clipped(splitted)) {
+                                // The entire extrusion is fuzzified
+                                nonplanar_fuzzy_polyline(poly, deviation, layer->slice_z, r.first);
+                            } else {
+                                poly.clear();
+                                std::vector<double> current_deviation;
+                                std::swap(deviation, current_deviation);
+
+                                Points segment;
+                                segment.reserve(splitted.size());
+
+                                const auto fuzzy_current_segment = [&poly, &deviation, &segment, &r, slice_z = layer->slice_z]() {
+                                    std::vector<double> tmp;
+                                    nonplanar_fuzzy_polyline(segment, tmp, slice_z, r.first);
+                                    poly.insert(poly.end(), segment.begin(), segment.end());
+                                    deviation.insert(deviation.end(), tmp.begin(), tmp.end());
+                                    segment.clear();
+                                };
+
+                                for (const auto& p : splitted) {
+                                    if (p.clipped) {
+                                        segment.push_back(p.p);
+                                    } else {
+                                        if (segment.empty()) {
+                                            poly.push_back(p.p);
+                                            deviation.push_back(current_deviation[p.get_src_index()]);
+                                        } else {
+                                            segment.push_back(p.p);
+                                            fuzzy_current_segment();
+                                        }
+                                    }
+                                }
+                                if (!segment.empty()) {
+                                    // Finalize the extrusion
+                                    fuzzy_current_segment();
+                                }
+                            }
+                        }
+                    }
+
+                    // Convert deviation to ratio
+                    ExtrusionPathSloped::Slopes slopes;
+                    slopes.reserve(deviation.size());
+                    const double layer_height = scale_(path->height);
+                    for (double d : deviation) {
+                        const double ratio = d / layer_height + 1;
+                        slopes.emplace_back(ratio, ratio);
+                    }
+
+                    ExtrusionPathSloped sloped(Polyline(std::move(poly)), *path, std::move(slopes));
+                    fill->replace(j, std::move(sloped));
+                } else if (ExtrusionLoop* loop = dynamic_cast<ExtrusionLoop*>(single_entity)) {
+                } else {
+                    throw Slic3r::InvalidArgument("Unsupported extrusion entity type to fuzzify");
                 }
             }
         }

--- a/src/libslic3r/Feature/FuzzySkin/FuzzySkin.hpp
+++ b/src/libslic3r/Feature/FuzzySkin/FuzzySkin.hpp
@@ -12,6 +12,8 @@ void group_region_by_fuzzify(PerimeterGenerator& g);
 Polygon apply_fuzzy_skin(const Polygon& polygon, const PerimeterGenerator& perimeter_generator, size_t loop_idx, bool is_contour);
 void    apply_fuzzy_skin(Arachne::ExtrusionLine* extrusion, const PerimeterGenerator& perimeter_generator, bool is_contour);
 
+void apply_nonplanar_fuzzy_skin(Layer* layer);
+
 } // namespace Slic3r::Feature::FuzzySkin
 
 #endif // libslic3r_FuzzySkin_hpp_

--- a/src/libslic3r/Feature/FuzzySkin/FuzzySkin.hpp
+++ b/src/libslic3r/Feature/FuzzySkin/FuzzySkin.hpp
@@ -7,13 +7,7 @@
 
 namespace Slic3r::Feature::FuzzySkin {
 
-void fuzzy_polyline(Points& poly, bool closed, coordf_t slice_z, const FuzzySkinConfig& cfg);
-
-void fuzzy_extrusion_line(Arachne::ExtrusionJunctions& ext_lines, coordf_t slice_z, const FuzzySkinConfig& cfg);
-
 void group_region_by_fuzzify(PerimeterGenerator& g);
-
-bool should_fuzzify(const FuzzySkinConfig& config, int layer_id, size_t loop_idx, bool is_contour);
 
 Polygon apply_fuzzy_skin(const Polygon& polygon, const PerimeterGenerator& perimeter_generator, size_t loop_idx, bool is_contour);
 void    apply_fuzzy_skin(Arachne::ExtrusionLine* extrusion, const PerimeterGenerator& perimeter_generator, bool is_contour);

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -2211,6 +2211,7 @@ void GCode::_do_export(Print& print, GCodeOutputStream &file, ThumbnailsGenerato
 
     // modifies m_silent_time_estimator_enabled
     DoExport::init_gcode_processor(print.config(), m_processor, m_silent_time_estimator_enabled);
+    m_processor.detect_layer_based_on_tag(true);
     const bool is_bbl_printers = print.is_BBL_printer();
     const bool is_qidi_printers = print.is_QIDI_printer();
     m_calib_config.clear();

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -5537,7 +5537,7 @@ std::string GCode::extrude_loop(ExtrusionLoop loop, std::string description, dou
     return gcode;
 }
 
-std::string GCode::extrude_multi_path(ExtrusionMultiPath multipath, std::string description, double speed)
+std::string GCode::extrude_multi_path(const ExtrusionMultiPath& multipath, std::string description, double speed)
 {
     // extrude along the path
     std::string gcode;
@@ -5559,7 +5559,7 @@ std::string GCode::extrude_multi_path(ExtrusionMultiPath multipath, std::string 
         m_multi_flow_segment_path_average_mm3_per_mm = weighted_sum_mm3_per_mm / total_multipath_length;
     // Orca: end of multipath average mm3_per_mm value calculation
     
-    for (ExtrusionPath path : multipath.paths){
+    for (const ExtrusionPath& path : multipath.paths){
         gcode += this->_extrude(path, description, speed);
         // Orca: Adaptive PA - dont adapt PA after the first pultipath extrusion is completed
         // as we have already set the PA value to the average flow over the totality of the path
@@ -5570,7 +5570,7 @@ std::string GCode::extrude_multi_path(ExtrusionMultiPath multipath, std::string 
     // BBS
     if (m_wipe.enable && FILAMENT_CONFIG(wipe)) {
         m_wipe.path = Polyline();
-        for (ExtrusionPath &path : multipath.paths) {
+        for (const ExtrusionPath &path : multipath.paths) {
             //BBS: Don't need to save duplicated point into wipe path
             if (!m_wipe.path.empty() && !path.empty() &&
                 m_wipe.path.last_point() == path.first_point())
@@ -5597,7 +5597,7 @@ std::string GCode::extrude_entity(const ExtrusionEntity &entity, std::string des
     return "";
 }
 
-std::string GCode::extrude_path(ExtrusionPath path, std::string description, double speed)
+std::string GCode::extrude_path(const ExtrusionPath& path, std::string description, double speed)
 {
     // Orca: Reset average multipath flow as this is a single line, single extrude volumetric speed path
     m_multi_flow_segment_path_pa_set = false;
@@ -5853,7 +5853,7 @@ std::string GCode::_extrude(const ExtrusionPath &path, std::string description, 
 
     bool slope_need_z_travel = false;
     if (sloped != nullptr && !sloped->is_flat()) {
-        auto target_z = get_sloped_z(sloped->slope_begin.z_ratio);
+        auto target_z = get_sloped_z(sloped->slope_begin().z_ratio);
         slope_need_z_travel = m_writer.will_move_z(target_z);
     }
     // Move to first point of extrusion path
@@ -5865,7 +5865,7 @@ std::string GCode::_extrude(const ExtrusionPath &path, std::string description, 
             path.first_point(),
             path.role(),
             "move to first " + description + " point",
-            sloped == nullptr ? DBL_MAX : get_sloped_z(sloped->slope_begin.z_ratio)
+            sloped == nullptr ? DBL_MAX : get_sloped_z(sloped->slope_begin().z_ratio)
         );
         m_need_change_layer_lift_z = false;
         // Orca: ensure Z matches planned layer height
@@ -6433,14 +6433,13 @@ std::string GCode::_extrude(const ExtrusionPath &path, std::string description, 
             // BBS: use G1 if not enable arc fitting or has no arc fitting result or in spiral_mode mode or we are doing sloped extrusion
             // Attention: G2 and G3 is not supported in spiral_mode mode
             if (!m_config.enable_arc_fitting || path.polyline.fitting_result.empty() || m_config.spiral_mode || sloped != nullptr) {
-                double path_length = 0.;
-                double total_length = sloped == nullptr ? 0. : path.polyline.length() * SCALING_FACTOR;
+                int segment_idx = 0;
                 for (const Line& line : path.polyline.lines()) {
+                    segment_idx++;
                     std::string tempDescription = description;
                     const double line_length = line.length() * SCALING_FACTOR;
                     if (line_length < EPSILON)
                         continue;
-                    path_length += line_length;
                     auto dE = e_per_mm * line_length;
                     if (_needSAFC(path)) {
                         auto oldE = dE;
@@ -6458,7 +6457,7 @@ std::string GCode::_extrude(const ExtrusionPath &path, std::string description, 
                             GCodeWriter::full_gcode_comment ? tempDescription : "", path.is_force_no_extrusion());
                     } else {
                         // Sloped extrusion
-                        const auto [z_ratio, e_ratio] = sloped->interpolate(path_length / total_length);
+                        const auto [z_ratio, e_ratio] = sloped->interpolate(segment_idx);
                         Vec2d dest2d = this->point_to_gcode(line.b);
                         Vec3d dest3d(dest2d(0), dest2d(1), get_sloped_z(z_ratio));
                         gcode += m_writer.extrude_to_xyz(

--- a/src/libslic3r/GCode.hpp
+++ b/src/libslic3r/GCode.hpp
@@ -392,8 +392,8 @@ private:
     // Orca: pass the complete collection of region perimeters to the extrude loop to check whether the wipe before external loop
     // should be executed
     std::string     extrude_loop(ExtrusionLoop loop, std::string description, double speed = -1., const ExtrusionEntitiesPtr& region_perimeters = ExtrusionEntitiesPtr(), const Point* start_point = nullptr);
-    std::string     extrude_multi_path(ExtrusionMultiPath multipath, std::string description = "", double speed = -1.);
-    std::string     extrude_path(ExtrusionPath path, std::string description = "", double speed = -1.);
+    std::string     extrude_multi_path(const ExtrusionMultiPath& multipath, std::string description = "", double speed = -1.);
+    std::string     extrude_path(const ExtrusionPath& path, std::string description = "", double speed = -1.);
     
     // Orca: Adaptive PA variables
     // Used for adaptive PA when extruding paths with multiple, varying flow segments.

--- a/src/libslic3r/GCode/GCodeProcessor.cpp
+++ b/src/libslic3r/GCode/GCodeProcessor.cpp
@@ -2447,6 +2447,9 @@ void GCodeProcessor::process_file(const std::string& filename, std::function<voi
             }
 
             apply_config(config);
+
+            // Orca: for orca generated files, always use tag based layer detection
+            detect_layer_based_on_tag(true);
         }
         else if (m_producer == EProducer::Simplify3D)
             apply_config_simplify3d(filename);

--- a/src/libslic3r/Layer.cpp
+++ b/src/libslic3r/Layer.cpp
@@ -253,6 +253,12 @@ void Layer::make_perimeters()
 	            }
 	        }
 	    }
+
+    // Union fuzzy regions
+    for (auto & fuzzify : this->regions_by_fuzzify) {
+        fuzzify.second = offset_ex(fuzzify.second, ClipperSafetyOffset);
+    }
+
     BOOST_LOG_TRIVIAL(trace) << "Generating perimeters for layer " << this->id() << " - Done";
 }
 

--- a/src/libslic3r/Layer.cpp
+++ b/src/libslic3r/Layer.cpp
@@ -179,6 +179,8 @@ void Layer::make_perimeters()
 {
     BOOST_LOG_TRIVIAL(trace) << "Generating perimeters for layer " << this->id();
 
+    regions_by_fuzzify.clear();
+
     // keep track of regions whose perimeters we have already generated
     std::vector<unsigned char> done(m_regions.size(), false);
 

--- a/src/libslic3r/Layer.cpp
+++ b/src/libslic3r/Layer.cpp
@@ -256,6 +256,12 @@ void Layer::make_perimeters()
 
     // Union fuzzy regions
     for (auto fuzzify = regions_by_fuzzify.begin(); fuzzify != regions_by_fuzzify.end();) {
+        // Remove region that should not be fuzzified on first layer
+        if (this->id() <= 0 && !fuzzify->first.fuzzy_first_layer) {
+            fuzzify = regions_by_fuzzify.erase(fuzzify);
+            continue;
+        }
+
         fuzzify->second = intersection_ex(offset_ex(fuzzify->second, ClipperSafetyOffset), this->lslices);
         if (this->upper_layer && !this->upper_layer->lslices.empty()) {
             // Clip the fuzzy region by upper layer, so the top surface that is covered by upper layer is not fuzzified

--- a/src/libslic3r/Layer.hpp
+++ b/src/libslic3r/Layer.hpp
@@ -7,6 +7,8 @@
 #include "SurfaceCollection.hpp"
 #include "ExtrusionEntityCollection.hpp"
 #include "BoundingBox.hpp"
+#include "PrintConfig.hpp"
+
 namespace Slic3r {
 
 class ExPolygon;
@@ -152,6 +154,9 @@ public:
     ExPolygons 				 lslices;
     ExPolygons 				 lslices_extrudable;  // BBS: the extrudable part of lslices used for tree support
     std::vector<BoundingBox> lslices_bboxes;
+
+    // Regions that is fuzzified, used for generating top surface fuzzify
+    std::unordered_map<FuzzySkinConfig, ExPolygons> regions_by_fuzzify;
 
     // BBS
     ExPolygons              loverhangs;

--- a/src/libslic3r/Layer.hpp
+++ b/src/libslic3r/Layer.hpp
@@ -156,6 +156,7 @@ public:
     std::vector<BoundingBox> lslices_bboxes;
 
     // Regions that is fuzzified, used for generating top surface fuzzify
+    // for config that does not have fuzzy skin, the corresponding ExPolygons will be empty
     std::unordered_map<FuzzySkinConfig, ExPolygons> regions_by_fuzzify;
 
     // BBS

--- a/src/libslic3r/LayerRegion.cpp
+++ b/src/libslic3r/LayerRegion.cpp
@@ -121,6 +121,16 @@ void LayerRegion::make_perimeters(const SurfaceCollection &slices, const LayerRe
         g.process_arachne();
     else
         g.process_classic();
+
+    // Merge fuzzy regions to layer
+    auto& fuzzify_regions = this->layer()->regions_by_fuzzify;
+    for (auto& fuzzify : g.regions_by_fuzzify) {
+        const auto& cfg = fuzzify.first;
+        if (cfg.type == FuzzySkinType::None) continue; // Ignore non-fuzzified regions
+
+        // Merge regions by config
+        expolygons_append(fuzzify_regions[cfg], std::move(fuzzify.second));
+    }
 }
 
 #if 1

--- a/src/libslic3r/LayerRegion.cpp
+++ b/src/libslic3r/LayerRegion.cpp
@@ -456,11 +456,14 @@ Surfaces expand_merge_surfaces(
         append(expansions, std::move(zone_expansions));
     }
 
+    ExPolygons cpy = src;
     std::vector<ExPolygon> expanded = merge_expansions_into_expolygons(std::move(src), std::move(expansions));
     //NOTE: The current regularization of the shells can create small unasigned regions in the object (E.G. benchy)
     // without the following closing operation, those regions will stay unfilled and cause small holes in the expanded surface.
     // look for narrow_ensure_vertical_wall_thickness_region_radius filter.
     expanded = closing_ex(expanded, closing_radius);
+    // Make sure the expanded surface fully covers the original region, otherwise we leave holes in surfaces
+    expanded = union_ex(expanded, std::move(cpy));
     // Trim the zones by the expanded expolygons.
     for (ExpansionZone& expansion_zone : expansion_zones)
         if (expansion_zone.expanded_into)

--- a/src/libslic3r/LayerRegion.cpp
+++ b/src/libslic3r/LayerRegion.cpp
@@ -125,11 +125,8 @@ void LayerRegion::make_perimeters(const SurfaceCollection &slices, const LayerRe
     // Merge fuzzy regions to layer
     auto& fuzzify_regions = this->layer()->regions_by_fuzzify;
     for (auto& fuzzify : g.regions_by_fuzzify) {
-        const auto& cfg = fuzzify.first;
-        if (cfg.type == FuzzySkinType::None) continue; // Ignore non-fuzzified regions
-
         // Merge regions by config
-        expolygons_append(fuzzify_regions[cfg], std::move(fuzzify.second));
+        expolygons_append(fuzzify_regions[fuzzify.first], std::move(fuzzify.second));
     }
 }
 

--- a/src/libslic3r/MultiMaterialSegmentation.cpp
+++ b/src/libslic3r/MultiMaterialSegmentation.cpp
@@ -2223,7 +2223,7 @@ std::vector<std::vector<ExPolygons>> fuzzy_skin_segmentation_by_painting(const P
         max_external_perimeter_width = std::max<float>(max_external_perimeter_width, region.flow(print_object, frExternalPerimeter, print_object.config().layer_height).width());
     }
 
-    return segmentation_by_painting(print_object, extract_facets_info, num_facets_states, max_external_perimeter_width, 0.f, false, IncludeTopAndBottomLayers::No, throw_on_cancel_callback);
+    return segmentation_by_painting(print_object, extract_facets_info, num_facets_states, max_external_perimeter_width, 0.f, false, IncludeTopAndBottomLayers::Yes, throw_on_cancel_callback);
 }
 
 } // namespace Slic3r

--- a/src/libslic3r/PerimeterGenerator.hpp
+++ b/src/libslic3r/PerimeterGenerator.hpp
@@ -10,54 +10,6 @@
 #include "SurfaceCollection.hpp"
 
 namespace Slic3r {
-struct FuzzySkinConfig
-{
-    FuzzySkinType type;
-    coord_t       thickness;
-    coord_t       point_distance;
-    bool          fuzzy_first_layer;
-    NoiseType     noise_type;
-    double        noise_scale;
-    int           noise_octaves;
-    double        noise_persistence;
-    FuzzySkinMode mode;
-
-    bool operator==(const FuzzySkinConfig& r) const
-    {
-        return type == r.type
-            && thickness == r.thickness
-            && point_distance == r.point_distance
-            && fuzzy_first_layer == r.fuzzy_first_layer
-            && noise_type == r.noise_type
-            && noise_scale == r.noise_scale
-            && noise_octaves == r.noise_octaves
-            && noise_persistence == r.noise_persistence
-            && mode == r.mode;
-    }
-
-    bool operator!=(const FuzzySkinConfig& r) const { return !(*this == r); }
-};
-}
-
-namespace std {
-template<> struct hash<Slic3r::FuzzySkinConfig>
-{
-    size_t operator()(const Slic3r::FuzzySkinConfig& c) const noexcept
-    {
-        std::size_t seed = std::hash<Slic3r::FuzzySkinType>{}(c.type);
-        boost::hash_combine(seed, std::hash<coord_t>{}(c.thickness));
-        boost::hash_combine(seed, std::hash<coord_t>{}(c.point_distance));
-        boost::hash_combine(seed, std::hash<bool>{}(c.fuzzy_first_layer));
-        boost::hash_combine(seed, std::hash<Slic3r::NoiseType>{}(c.noise_type));
-        boost::hash_combine(seed, std::hash<double>{}(c.noise_scale));
-        boost::hash_combine(seed, std::hash<int>{}(c.noise_octaves));
-        boost::hash_combine(seed, std::hash<double>{}(c.noise_persistence));
-        return seed;
-    }
-};
-} // namespace std
-
-namespace Slic3r {
 
 class PerimeterGenerator {
 public:

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -891,7 +891,7 @@ static std::vector<std::string> s_Preset_print_options {
     "ironing_type", "ironing_pattern", "ironing_flow", "ironing_speed", "ironing_spacing", "ironing_angle", "ironing_angle_fixed", "ironing_inset",
     "support_ironing", "support_ironing_pattern", "support_ironing_flow", "support_ironing_spacing",
     "max_travel_detour_distance",
-    "fuzzy_skin", "fuzzy_skin_thickness", "fuzzy_skin_point_distance", "fuzzy_skin_first_layer", "fuzzy_skin_noise_type", "fuzzy_skin_mode", "fuzzy_skin_scale", "fuzzy_skin_octaves", "fuzzy_skin_persistence",
+    "fuzzy_skin", "fuzzy_skin_thickness", "fuzzy_skin_point_distance", "fuzzy_skin_first_layer", "fuzzy_skin_nonplanar", "fuzzy_skin_noise_type", "fuzzy_skin_mode", "fuzzy_skin_scale", "fuzzy_skin_octaves", "fuzzy_skin_persistence",
     "max_volumetric_extrusion_rate_slope", "max_volumetric_extrusion_rate_slope_segment_length","extrusion_rate_smoothing_external_perimeter_only",
     "inner_wall_speed", "outer_wall_speed", "sparse_infill_speed", "internal_solid_infill_speed",
     "top_surface_speed", "support_speed", "support_object_xy_distance", "support_object_first_layer_gap", "support_interface_speed",

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -3191,6 +3191,13 @@ void PrintConfigDef::init_fff_params()
     def->mode = comSimple;
     def->set_default_value(new ConfigOptionBool(0));
 
+    def = this->add("fuzzy_skin_nonplanar", coBool);
+    def->label = L("Nonplanar fuzzy skin");
+    def->category = L("Others");
+    def->tooltip = L("Apply fuzzy skin height variation to top surfaces. Disable to keep top surfaces flat even when fuzzy skin is enabled.");
+    def->mode = comSimple;
+    def->set_default_value(new ConfigOptionBool(0));
+
     def = this->add("fuzzy_skin_mode", coEnum);
     def->label = L("Fuzzy skin generator mode");
     def->category = L("Others");

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -1054,6 +1054,7 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionFloat,                fuzzy_skin_thickness))
     ((ConfigOptionFloat,                fuzzy_skin_point_distance))
     ((ConfigOptionBool,                 fuzzy_skin_first_layer))
+    ((ConfigOptionBool,                 fuzzy_skin_nonplanar))
     ((ConfigOptionEnum<NoiseType>,      fuzzy_skin_noise_type))
     ((ConfigOptionEnum<FuzzySkinMode>,  fuzzy_skin_mode))
     ((ConfigOptionFloat,                fuzzy_skin_scale))
@@ -2084,6 +2085,7 @@ struct FuzzySkinConfig
     coord_t       thickness;
     coord_t       point_distance;
     bool          fuzzy_first_layer;
+    bool          enable_nonplanar;
     NoiseType     noise_type;
     double        noise_scale;
     int           noise_octaves;
@@ -2104,6 +2106,7 @@ struct FuzzySkinConfig
             && thickness == r.thickness
             && point_distance == r.point_distance
             && fuzzy_first_layer == r.fuzzy_first_layer
+            && enable_nonplanar == r.enable_nonplanar
             && noise_type == r.noise_type
             && noise_scale == r.noise_scale
             && noise_octaves == r.noise_octaves
@@ -2128,6 +2131,7 @@ template<> struct hash<Slic3r::FuzzySkinConfig>
         boost::hash_combine(seed, std::hash<coord_t>{}(c.thickness));
         boost::hash_combine(seed, std::hash<coord_t>{}(c.point_distance));
         boost::hash_combine(seed, std::hash<bool>{}(c.fuzzy_first_layer));
+        boost::hash_combine(seed, std::hash<bool>{}(c.enable_nonplanar));
         boost::hash_combine(seed, std::hash<Slic3r::NoiseType>{}(c.noise_type));
         boost::hash_combine(seed, std::hash<double>{}(c.noise_scale));
         boost::hash_combine(seed, std::hash<int>{}(c.noise_octaves));

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -2090,8 +2090,16 @@ struct FuzzySkinConfig
     double        noise_persistence;
     FuzzySkinMode mode;
 
+    bool fuzzify() const { return type != FuzzySkinType::None; }
+
     bool operator==(const FuzzySkinConfig& r) const
     {
+        // All configs that does not fuzzy are the same despite other options
+        // TODO: find other situations that configs are the same (such as ignoring options that won't take effect)
+        if (!fuzzify() && !r.fuzzify()) {
+            return true;
+        }
+
         return type == r.type
             && thickness == r.thickness
             && point_distance == r.point_distance
@@ -2112,6 +2120,10 @@ template<> struct hash<Slic3r::FuzzySkinConfig>
 {
     size_t operator()(const Slic3r::FuzzySkinConfig& c) const noexcept
     {
+        // All configs that does not fuzzy are the same despite other options
+        // TODO: find other situations that configs are the same (such as ignoring options that won't take effect)
+        if (!c.fuzzify()) return 0;
+
         std::size_t seed = std::hash<Slic3r::FuzzySkinType>{}(c.type);
         boost::hash_combine(seed, std::hash<coord_t>{}(c.thickness));
         boost::hash_combine(seed, std::hash<coord_t>{}(c.point_distance));

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -2077,4 +2077,52 @@ namespace cereal {
     }
 }
 
+namespace Slic3r {
+struct FuzzySkinConfig
+{
+    FuzzySkinType type;
+    coord_t       thickness;
+    coord_t       point_distance;
+    bool          fuzzy_first_layer;
+    NoiseType     noise_type;
+    double        noise_scale;
+    int           noise_octaves;
+    double        noise_persistence;
+    FuzzySkinMode mode;
+
+    bool operator==(const FuzzySkinConfig& r) const
+    {
+        return type == r.type
+            && thickness == r.thickness
+            && point_distance == r.point_distance
+            && fuzzy_first_layer == r.fuzzy_first_layer
+            && noise_type == r.noise_type
+            && noise_scale == r.noise_scale
+            && noise_octaves == r.noise_octaves
+            && noise_persistence == r.noise_persistence
+            && mode == r.mode;
+    }
+
+    bool operator!=(const FuzzySkinConfig& r) const { return !(*this == r); }
+};
+}
+
+namespace std {
+template<> struct hash<Slic3r::FuzzySkinConfig>
+{
+    size_t operator()(const Slic3r::FuzzySkinConfig& c) const noexcept
+    {
+        std::size_t seed = std::hash<Slic3r::FuzzySkinType>{}(c.type);
+        boost::hash_combine(seed, std::hash<coord_t>{}(c.thickness));
+        boost::hash_combine(seed, std::hash<coord_t>{}(c.point_distance));
+        boost::hash_combine(seed, std::hash<bool>{}(c.fuzzy_first_layer));
+        boost::hash_combine(seed, std::hash<Slic3r::NoiseType>{}(c.noise_type));
+        boost::hash_combine(seed, std::hash<double>{}(c.noise_scale));
+        boost::hash_combine(seed, std::hash<int>{}(c.noise_octaves));
+        boost::hash_combine(seed, std::hash<double>{}(c.noise_persistence));
+        return seed;
+    }
+};
+} // namespace std
+
 #endif

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -1262,6 +1262,7 @@ bool PrintObject::invalidate_state_by_config_options(
             || opt_key == "fuzzy_skin_thickness"
             || opt_key == "fuzzy_skin_point_distance"
             || opt_key == "fuzzy_skin_first_layer"
+            || opt_key == "fuzzy_skin_nonplanar"
             || opt_key == "fuzzy_skin_mode"
             || opt_key == "fuzzy_skin_noise_type"
             || opt_key == "fuzzy_skin_scale"

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -672,19 +672,17 @@ void PrintObject::infill()
         const auto& support_fill_octree = this->m_adaptive_fill_octrees.second;
 
         BOOST_LOG_TRIVIAL(debug) << "Filling layers in parallel - start";
-        // tbb::parallel_for(
-        //     tbb::blocked_range<size_t>(0, m_layers.size()),
-        //     [this, &adaptive_fill_octree = adaptive_fill_octree, &support_fill_octree = support_fill_octree](const tbb::blocked_range<size_t>& range) {
-
-        tbb::blocked_range<size_t>range(0, m_layers.size());
+        tbb::parallel_for(
+            tbb::blocked_range<size_t>(0, m_layers.size()),
+            [this, &adaptive_fill_octree = adaptive_fill_octree, &support_fill_octree = support_fill_octree](const tbb::blocked_range<size_t>& range) {
                 for (size_t layer_idx = range.begin(); layer_idx < range.end(); ++ layer_idx) {
                     m_print->throw_if_canceled();
                     m_layers[layer_idx]->make_fills(adaptive_fill_octree.get(), support_fill_octree.get(), this->m_lightning_generator.get());
 
                     Feature::FuzzySkin::apply_nonplanar_fuzzy_skin(m_layers[layer_idx]);
                 }
-            // }
-        // );
+            }
+        );
         m_print->throw_if_canceled();
         BOOST_LOG_TRIVIAL(debug) << "Filling layers in parallel - end";
         /*  we could free memory now, but this would make this step not idempotent

--- a/src/libslic3r/libslic3r.h
+++ b/src/libslic3r/libslic3r.h
@@ -299,7 +299,7 @@ inline bool is_zero(Number value)
 template <typename T, typename Number>
 constexpr inline T lerp(const T& a, const T& b, Number t)
 {
-    assert((t >= Number(-EPSILON)) && (t <= Number(1) + Number(EPSILON)));
+    //assert((t >= Number(-EPSILON)) && (t <= Number(1) + Number(EPSILON)));
     return (Number(1) - t) * a + t * b;
 }
 

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -2682,6 +2682,7 @@ optgroup->append_single_option_line("skirt_loops", "others_settings_skirt#loops"
         optgroup->append_single_option_line("fuzzy_skin_octaves", "others_settings_fuzzy_skin#skin-noise-octaves");
         optgroup->append_single_option_line("fuzzy_skin_persistence", "others_settings_fuzzy_skin#skin-noise-persistence");
         optgroup->append_single_option_line("fuzzy_skin_first_layer", "others_settings_fuzzy_skin#apply-fuzzy-skin-to-first-layer");
+        optgroup->append_single_option_line("fuzzy_skin_nonplanar");
 
         optgroup = page->new_optgroup(L("G-code output"), L"param_gcode");
         optgroup->append_single_option_line("reduce_infill_retraction", "others_settings_g_code_output#reduce-infill-retraction");


### PR DESCRIPTION
An native impl of the nonplanar fuzzy skin, thanks @TengerTechnologies for their awesome work https://github.com/TengerTechnologies/Fuzzyficator

<img width="2315" height="1245" alt="e0cd59c9bfde1b0640733ab8e63fdf44" src="https://github.com/user-attachments/assets/b68de48b-de1a-4929-a6fb-b9a1a6cc1291" />

![aa53411cac12101b207c1a30208649e2](https://github.com/user-attachments/assets/c039578a-d0c2-456c-8cb7-7d401f46a1b0)



TODOs:

- [ ] Support different fuzzy skin mode (currently it always uses combined mode, though I think this makes sence otherwise you will have nozzle digging into extrusions or floating extrusions, maybe I'll impl this first so ppl could test with different modes and see which one works the best)
- [x] Add option for turning this on & off
- [ ] Impl connectWalls option
- [ ] Maybe add new options to set the thickness
- [ ] Protect against nozzle scrapping (such as clamping the thickness between -layer height to z-hop; force z-hop when traveling above the fills etc)
close #7152