### PR TITLE
Add Multiline and focus background support for TextInput

### DIFF
--- a/src/slic3r/GUI/Auxiliary.cpp
+++ b/src/slic3r/GUI/Auxiliary.cpp
@@ -1100,8 +1100,7 @@ void AuxiliaryPanel::update_all_cover()
      m_text_description->SetForegroundColour(*wxBLACK);
      m_text_description->Wrap(-1);
      m_sizer_description->Add(m_text_description, 0, wxALIGN_TOP | wxRIGHT, FromDIP(10));
-     m_input_description = new wxTextCtrl(this, wxID_ANY, wxEmptyString, wxDefaultPosition, 
-                                          wxSize(FromDIP(450), FromDIP(300)), wxTE_MULTILINE | wxTE_PROCESS_ENTER);
+     m_input_description = new TextInput(this, "", "", "", wxDefaultPosition, wxSize(FromDIP(450), FromDIP(300)), wxTE_MULTILINE | wxTE_PROCESS_ENTER);
      m_input_description->SetFont(::Label::Body_14);
      m_sizer_description->Add(m_input_description, 0, wxALIGN_CENTER, 0);
 
@@ -1181,13 +1180,13 @@ void DesignerPanel::update_info()
 
     if (wxGetApp().plater()->model().model_info != nullptr) {
         m_input_model_name->GetTextCtrl()->SetValue(wxString::FromUTF8(wxGetApp().plater()->model().model_info->model_name));
-        m_input_description->ChangeValue(wxString::FromUTF8(wxGetApp().plater()->model().model_info->description));
+        m_input_description->GetTextCtrl()->ChangeValue(wxString::FromUTF8(wxGetApp().plater()->model().model_info->description));
         if (!m_combo_license->SetStringSelection(wxString::FromUTF8(wxGetApp().plater()->model().model_info->license))) {
             m_combo_license->SetSelection(0);
         }
     } else {
         m_input_model_name->GetTextCtrl()->SetValue(wxEmptyString);
-        m_input_description->ChangeValue(wxEmptyString);
+        m_input_description->GetTextCtrl()->ChangeValue(wxEmptyString);
         m_combo_license->SetSelection(0);
     }
 }

--- a/src/slic3r/GUI/Auxiliary.hpp
+++ b/src/slic3r/GUI/Auxiliary.hpp
@@ -181,7 +181,7 @@ public:
 
     ::TextInput*        m_input_designer {nullptr};
     ::TextInput*        m_input_model_name {nullptr};
-    wxTextCtrl*         m_input_description {nullptr};
+    ::TextInput*        m_input_description {nullptr};
     ComboBox*           m_combo_license {nullptr};
     bool Show(bool show) override;
     void                init_license_list();

--- a/src/slic3r/GUI/Field.cpp
+++ b/src/slic3r/GUI/Field.cpp
@@ -750,13 +750,13 @@ void TextCtrl::BUILD() {
 
 	// BBS: new param ui style
     // const long style = m_opt.multiline ? wxTE_MULTILINE : wxTE_PROCESS_ENTER/*0*/;
-    static Builder<wxTextCtrl> builder1;
+    static Builder<::TextInput> builder1; // ORCA Text input with multiline support
     static Builder<::TextInput> builder2;
     auto temp = m_opt.multiline
-        ? (wxWindow*)builder1.build(m_parent, wxID_ANY, "", wxDefaultPosition, size, wxTE_MULTILINE)
+        ? builder1.build(m_parent, "", "", "", wxDefaultPosition, size, wxTE_MULTILINE)
         : builder2.build(m_parent, "", "", "", wxDefaultPosition, size, wxTE_PROCESS_ENTER);
     temp->SetLabel(_L(m_opt.sidetext));
-	auto text_ctrl = m_opt.multiline ? (wxTextCtrl *)temp : ((TextInput *) temp)->GetTextCtrl();
+	auto text_ctrl = temp->GetTextCtrl();
     text_ctrl->SetLabel(text_value);
     temp->SetSize(size);
     m_combine_side_text = !m_opt.multiline;
@@ -791,11 +791,11 @@ void TextCtrl::BUILD() {
         }), text_ctrl->GetId());
     } else {
         // Orca: adds logic that scrolls the parent if the text control doesn't have focus
-        text_ctrl->Bind(wxEVT_MOUSEWHEEL, [text_ctrl](wxMouseEvent& event) {
+        text_ctrl->Bind(wxEVT_MOUSEWHEEL, [text_ctrl, temp](wxMouseEvent& event) {
             if (text_ctrl->HasFocus() && text_ctrl->GetScrollRange(wxVERTICAL) != 1)
                 event.Skip(); // don't consume the event so that the text control will scroll
             else
-                text_ctrl->GetParent()->ScrollLines((event.GetWheelRotation() > 0 ? -1 : 1) * event.GetLinesPerAction());
+                temp->GetParent()->ScrollLines((event.GetWheelRotation() > 0 ? -1 : 1) * event.GetLinesPerAction());
         });
     }
 

--- a/src/slic3r/GUI/NetworkTestDialog.cpp
+++ b/src/slic3r/GUI/NetworkTestDialog.cpp
@@ -180,7 +180,8 @@ wxBoxSizer* NetworkTestDialog::create_result_sizer(wxWindow* parent)
 	text_result->Wrap(-1);
 	sizer->Add(text_result, 0, wxALL, 5);
 
-	txt_log = new wxTextCtrl(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTE_MULTILINE);
+	txt_log = new TextInput(this, "", "", "", wxDefaultPosition, wxDefaultSize, wxTE_MULTILINE | wxTE_READONLY);
+    txt_log->SetCanFocus(false);
 	sizer->Add(txt_log, 1, wxALL | wxEXPAND, 5);
 	return sizer;
 }
@@ -205,7 +206,7 @@ void NetworkTestDialog::init_bind()
 		buf << std::put_time(now_time, "%a %b %d %H:%M:%S");
 		wxString info = wxString::Format("%s:", buf.str()) + evt.GetString() + "\n";
 		try {
-			txt_log->AppendText(info);
+			txt_log->GetTextCtrl()->AppendText(info);
 		}
 		catch (std::exception& e) {
 			BOOST_LOG_TRIVIAL(error) << "Unkown Exception in print_log, exception=" << e.what();

--- a/src/slic3r/GUI/NetworkTestDialog.cpp
+++ b/src/slic3r/GUI/NetworkTestDialog.cpp
@@ -181,7 +181,6 @@ wxBoxSizer* NetworkTestDialog::create_result_sizer(wxWindow* parent)
 	sizer->Add(text_result, 0, wxALL, 5);
 
 	txt_log = new TextInput(this, "", "", "", wxDefaultPosition, wxDefaultSize, wxTE_MULTILINE | wxTE_READONLY);
-    txt_log->SetCanFocus(false);
 	sizer->Add(txt_log, 1, wxALL | wxEXPAND, 5);
 	return sizer;
 }

--- a/src/slic3r/GUI/NetworkTestDialog.hpp
+++ b/src/slic3r/GUI/NetworkTestDialog.hpp
@@ -7,6 +7,7 @@
 #include "GUI_Utils.hpp"
 #include "wxExtensions.hpp"
 #include <slic3r/GUI/Widgets/Button.hpp>
+#include <slic3r/GUI/Widgets/TextInput.hpp>
 #include <wx/artprov.h>
 #include <wx/xrc/xmlres.h>
 #include <wx/button.h>
@@ -62,7 +63,7 @@ protected:
 	wxStaticText* text_ping_title;
 	wxStaticText* text_ping_value;
 	wxStaticText* text_result;
-	wxTextCtrl* txt_log;
+	TextInput* txt_log;
 
 	wxBoxSizer* create_top_sizer(wxWindow* parent);
 	wxBoxSizer* create_info_sizer(wxWindow* parent);

--- a/src/slic3r/GUI/Preferences.cpp
+++ b/src/slic3r/GUI/Preferences.cpp
@@ -516,8 +516,6 @@ wxBoxSizer *PreferencesDialog::create_item_input(wxString title, wxString title2
     input_title->Wrap(DESIGN_TITLE_SIZE.x);
 
     auto       input = new ::TextInput(m_parent, wxEmptyString, wxEmptyString, wxEmptyString, wxDefaultPosition, DESIGN_INPUT_SIZE, wxTE_PROCESS_ENTER);
-    StateColor input_bg(std::pair<wxColour, int>(wxColour("#F0F0F1"), StateColor::Disabled), std::pair<wxColour, int>(*wxWHITE, StateColor::Enabled));
-    input->SetBackgroundColor(input_bg);
     input->GetTextCtrl()->SetValue(app_config->get(param));
     wxTextValidator validator(wxFILTER_DIGITS);
     input->SetToolTip(tooltip);
@@ -563,8 +561,6 @@ wxBoxSizer *PreferencesDialog::create_camera_orbit_mult_input(wxString title, wx
     auto param = "camera_orbit_mult";
 
     auto       input = new ::TextInput(m_parent, wxEmptyString, wxEmptyString, wxEmptyString, wxDefaultPosition, DESIGN_INPUT_SIZE, wxTE_PROCESS_ENTER);
-    StateColor input_bg(std::pair<wxColour, int>(wxColour("#F0F0F1"), StateColor::Disabled), std::pair<wxColour, int>(*wxWHITE, StateColor::Enabled));
-    input->SetBackgroundColor(input_bg);
     input->GetTextCtrl()->SetValue(app_config->get(param));
     wxTextValidator validator(wxFILTER_NUMERIC);
     input->SetToolTip(tooltip);
@@ -635,8 +631,6 @@ wxBoxSizer *PreferencesDialog::create_item_backup(wxString title, wxString toolt
     m_backup_interval_time = app_config->get("backup_interval");
 
     auto input = new ::TextInput(m_parent, wxEmptyString, _L("sec"), "loop", wxDefaultPosition, wxSize(FromDIP(97), -1), wxTE_PROCESS_ENTER);
-    StateColor input_bg(std::pair<wxColour, int>(wxColour("#F0F0F1"), StateColor::Disabled), std::pair<wxColour, int>(*wxWHITE, StateColor::Enabled));
-    input->SetBackgroundColor(input_bg);
     input->GetTextCtrl()->SetValue(m_backup_interval_time);
     wxTextValidator validator(wxFILTER_DIGITS);
     input->SetToolTip(_L("The period of backup in seconds."));

--- a/src/slic3r/GUI/Widgets/TextInput.cpp
+++ b/src/slic3r/GUI/Widgets/TextInput.cpp
@@ -28,7 +28,11 @@ TextInput::TextInput()
     border_width = 1;
     border_color = StateColor(std::make_pair(0xDBDBDB, (int) StateColor::Disabled), std::make_pair(0x009688, (int) StateColor::Hovered),
                               std::make_pair(0xDBDBDB, (int) StateColor::Normal));
-    background_color = StateColor(std::make_pair(0xF0F0F1, (int) StateColor::Disabled), std::make_pair(*wxWHITE, (int) StateColor::Normal));
+    background_color = StateColor(
+        std::make_pair(0xF0F0F1, (int) StateColor::Disabled),
+        std::make_pair(0xE5F0EE, (int) StateColor::Focused),
+        std::make_pair(*wxWHITE, (int) StateColor::Normal)
+    );
     SetFont(Label::Body_12);
 }
 
@@ -57,15 +61,23 @@ void TextInput::Create(wxWindow *     parent,
     wxWindow::SetLabel(label);
     assert((style & wxRIGHT) == 0);
     style &= ~wxALIGN_MASK;
+    bool is_multiline = style & wxTE_MULTILINE;
+    if(!is_multiline)
+        style &= ~wxRIGHT;
     state_handler.attach({&label_color, & text_color});
     state_handler.update_binds();
-    text_ctrl = new TextCtrl(this, wxID_ANY, text, {4, 4}, wxDefaultSize, style | wxBORDER_NONE | wxTE_PROCESS_ENTER);
+    text_ctrl = new TextCtrl(this, wxID_ANY, text, wxPoint(1,1) * (is_multiline ? border_width : 4), wxDefaultSize, style | wxBORDER_NONE);
     text_ctrl->SetFont(Label::Body_14);
     text_ctrl->SetInitialSize(text_ctrl->GetBestSize());
     text_ctrl->SetBackgroundColour(background_color.colorForStates(state_handler.states()));
     text_ctrl->SetForegroundColour(text_color.colorForStates(state_handler.states()));
     state_handler.attach_child(text_ctrl);
+    text_ctrl->Bind(wxEVT_SET_FOCUS, [this](auto &e) {
+        text_ctrl->SetBackgroundColour(background_color.colorForStates(state_handler.states()));
+        e.Skip();
+    });
     text_ctrl->Bind(wxEVT_KILL_FOCUS, [this](auto &e) {
+        text_ctrl->SetBackgroundColour(background_color.colorForStates(state_handler.states()));
         OnEdit();
         e.SetId(GetId());
         ProcessEventLocally(e);
@@ -76,7 +88,8 @@ void TextInput::Create(wxWindow *     parent,
         e.SetId(GetId());
         ProcessEventLocally(e);
     });
-    text_ctrl->Bind(wxEVT_RIGHT_DOWN, [this](auto &e) {}); // disable context menu
+    if(!is_multiline) // dont block right click on multiline
+        text_ctrl->Bind(wxEVT_RIGHT_DOWN, [this](auto &e) {}); // disable context menu
     if (!icon.IsEmpty()) {
         this->icon = ScalableBitmap(this, icon.ToStdString(), 16);
     }
@@ -194,7 +207,10 @@ void TextInput::DoSetSize(int x, int y, int width, int height, int sizeFlags)
     bool align_right = GetWindowStyle() & wxALIGN_RIGHT;
     if (align_right)
         textPos.x += labelSize.x;
-    if (text_ctrl) {
+    if (text_ctrl->IsMultiLine()) {
+        text_ctrl->SetSize(wxSize(size.x - border_width * 2, size.y - border_width * 2));
+        text_ctrl->SetPosition({border_width, border_width});
+    }else{
         wxSize textSize = text_ctrl->GetSize();
         textSize.x = size.x - textPos.x - labelSize.x - 10;
         text_ctrl->SetSize(textSize);

--- a/src/slic3r/GUI/Widgets/TextInput.cpp
+++ b/src/slic3r/GUI/Widgets/TextInput.cpp
@@ -66,7 +66,8 @@ void TextInput::Create(wxWindow *     parent,
         style &= ~wxRIGHT;
     state_handler.attach({&label_color, & text_color});
     state_handler.update_binds();
-    text_ctrl = new TextCtrl(this, wxID_ANY, text, wxPoint(1,1) * (is_multiline ? border_width : 4), wxDefaultSize, style | wxBORDER_NONE);
+    text_ctrl = is_multiline ? new TextCtrl(this, wxID_ANY, text, wxPoint(1,1) * border_width, wxDefaultSize, style | wxBORDER_NONE)
+                             : new TextCtrl(this, wxID_ANY, text, wxPoint(4,4)               , wxDefaultSize, style | wxBORDER_NONE | wxTE_PROCESS_ENTER);
     text_ctrl->SetFont(Label::Body_14);
     text_ctrl->SetInitialSize(text_ctrl->GetBestSize());
     text_ctrl->SetBackgroundColour(background_color.colorForStates(state_handler.states()));


### PR DESCRIPTION
Tested on windows 11. requires test on macOS and Linux. probably macOS will add extra padding on frame

### CHANGES
• Adds multiline support.  This makes UI more consistent and fixes removes borders on windows
• Adds focus background color
• Fixed colors not applies on preferences
• Upgraded multiline text input on these dialogs
---- Project page > Descriptions
---- Network Dialog > Log box. also made it readonly

### COMPARISON
**Dark Mode**
<img width="858" height="612" alt="Screenshot-20251124233324" src="https://github.com/user-attachments/assets/780d8428-731b-40bf-826c-9f768829819c" />

**Light Mode**
<img width="865" height="610" alt="Screenshot-20251124233301" src="https://github.com/user-attachments/assets/916ac464-727c-4bb4-a393-3a4a9a6788ea" />

**Dark Mode - machine gcodes**
<img width="1476" height="853" alt="Screenshot-20251125001711" src="https://github.com/user-attachments/assets/f3f1c179-cf4c-4778-ba0c-e156fd1fddd4" />

• Focus events looks more consistent between controls. will add same background color to other controls as well
![vivaldi_DK5WSCtAsN](https://github.com/user-attachments/assets/fc3a1ab5-0f48-4827-9a9f-b70114a04b18)

• Focused multiline
<img width="723" height="246" alt="Screenshot-20251124235131" src="https://github.com/user-attachments/assets/cb88c786-5c25-4524-a55c-56d3e4685b00" />

