### PR TITLE
Show hidden settings in dev mode

### DIFF
--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -41,17 +41,56 @@ void ConfigManipulation::toggle_field(const std::string &opt_key, const bool tog
     if (local_config) {
         if (local_config->option(opt_key) == nullptr) return;
     }
-    cb_toggle_field(opt_key, toggle, opt_index);
+    
+    if (wxGetApp().get_mode() == comDevelop) {
+        // DEVELOPER MODE: Always show, but disable if toggle is false
+        cb_toggle_field(opt_key, true, opt_index);  // Always show
+        
+        // Enable or disable based on the original toggle value
+        if (cb_enable_field) {
+            cb_enable_field(opt_key, toggle, opt_index);
+        }
+    } else {
+        // NORMAL MODE: Hide/show as usual
+        cb_toggle_field(opt_key, toggle, opt_index);
+    }
 }
 
 void ConfigManipulation::toggle_line(const std::string& opt_key, const bool toggle, int opt_index)
 {
-    if (local_config) {
-        if (local_config->option(opt_key) == nullptr)
-            return;
+    try {
+        if (local_config) {
+            if (local_config->option(opt_key) == nullptr)
+                return;
+        }
+        
+        if (wxGetApp().get_mode() == comDevelop) {
+            // DEVELOPER MODE: Always show, but disable if toggle is false
+            if (cb_toggle_line) {
+                cb_toggle_line(opt_key, true, opt_index);  // Always show
+            }
+            
+            // Enable or disable based on the original toggle value
+            if (cb_enable_line) {
+                cb_enable_line(opt_key, toggle);
+            }
+        } else {
+            // NORMAL MODE: Hide/show as usual
+            if (cb_toggle_line) {
+                try {
+                    cb_toggle_line(opt_key, toggle, opt_index);
+                } catch (const std::exception& e) {
+                    std::cerr << "Exception in cb_toggle_line: " << e.what() << std::endl;
+                } catch (...) {
+                    std::cerr << "Unknown exception in cb_toggle_line." << std::endl;
+                }
+            }
+        }
+    } catch (const std::exception& e) {
+        std::cerr << "Exception in toggle_line: " << e.what() << std::endl;
+    } catch (...) {
+        std::cerr << "Unknown exception in toggle_line." << std::endl;
     }
-    if (cb_toggle_line)
-        cb_toggle_line(opt_key, toggle, opt_index);
 }
 
 void ConfigManipulation::check_nozzle_recommended_temperature_range(DynamicPrintConfig *config) {

--- a/src/slic3r/GUI/ConfigManipulation.hpp
+++ b/src/slic3r/GUI/ConfigManipulation.hpp
@@ -29,7 +29,11 @@ class ConfigManipulation
     std::function<void()>                                       load_config = nullptr;
     std::function<void (const std::string&, bool toggle, int opt_index)>   cb_toggle_field = nullptr;
     std::function<void(const std::string &, bool toggle, int opt_index)> cb_toggle_line  = nullptr;
-    // callback to propagation of changed value, if needed
+
+    std::function<void (const std::string&, bool enable, int opt_index)>   cb_enable_field = nullptr;
+    std::function<void (const std::string&, bool enable)>   cb_enable_line = nullptr;
+    
+    // callback to propagation of changed value, if needed 
     std::function<void(const std::string&, const boost::any&)>  cb_value_change = nullptr;
     //BBS: change local config to const DynamicPrintConfig
     const DynamicPrintConfig* local_config = nullptr;
@@ -58,6 +62,8 @@ public:
         load_config = nullptr;
         cb_toggle_field = nullptr;
         cb_toggle_line = nullptr;
+        cb_enable_field = nullptr;
+        cb_enable_line = nullptr;
         cb_value_change = nullptr;
     }
 
@@ -92,6 +98,14 @@ public:
         m_support_material_overhangs_queried = queried;
     }
     int    show_spiral_mode_settings_dialog(bool is_object_config = false);
+
+    void set_cb_enable_field(std::function<void(const std::string&, bool, int)> cb) {
+        cb_enable_field = cb;
+    }
+    
+    void set_cb_enable_line(std::function<void(const std::string&, bool)> cb) {
+        cb_enable_line = cb;
+    }
 
 private:
     bool get_temperature_range(DynamicPrintConfig *config, int &range_low, int &range_high);

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -7573,8 +7573,32 @@ ConfigManipulation Tab::get_config_manipulation()
     auto cb_value_change = [this](const std::string& opt_key, const boost::any& value) {
         return on_value_change(opt_key, value);
     };
-
-    return ConfigManipulation(load_config, cb_toggle_field, cb_toggle_line, cb_value_change, nullptr, this);
+    
+    // Create the ConfigManipulation object
+    ConfigManipulation config_manipulation(load_config, cb_toggle_field, cb_toggle_line, cb_value_change, nullptr, this);
+    
+    // ADD THESE NEW CALLBACKS for developer mode enable/disable functionality
+    config_manipulation.set_cb_enable_field([this](const std::string& opt_key, bool enable, int opt_index) {
+        Field* field = get_field(opt_key);
+        if (field) {
+            enable ? field->enable() : field->disable();
+        }
+    });
+    
+    config_manipulation.set_cb_enable_line([this](const std::string& opt_key, bool enable) {
+        Line* line = get_line(opt_key);
+        if (line) {
+            // Enable/disable all fields in the line
+            for (const auto& opt : line->get_options()) {
+                Field* field = get_field(opt.opt_id);
+                if (field) {
+                    enable ? field->enable() : field->disable();
+                }
+            }
+        }
+    });
+    
+    return config_manipulation;
 }
 
 


### PR DESCRIPTION
# Description
I have seen this conversation comes a lot in discord, so I took a quick look at how we can improve this. The 3 proposed solutions are:

1. **Ability to toggle visibility of individual settings like Cura**. This requires a rewrite of the whole config system plus additional UI for managing the settings. I dont think any of the devs here cares about this issue enough to do this.
2. **Make hidden options in search result more clear**. Currently, when the user searches and finds a hidden setting, and then clicks on it, orca brings the panel up but it doesnt show the setting. I would love that if the user clicks on a hidden setting in search result, it tells the user why this setting is hidden, but this also requires quite a bit of work to go through every single setting, manage the search messages plus UI work. I think there might be an easier to implement solution: when a user searches and clicks on a setting from the search result, it forces the setting to show up(if it were hidden, then show it as disabled).
3. **Show all options, if an option is depended on another that is currently off, show as disabled**. This is the easiest solution to implement, but it makes the UI super crowded. 


I am going with solution 3 for now. and maybe try solution 2 if I get back to this. But I want to create this PR so that if people really want to see all settings, they can grab it in the artifact here. 

Bug: togggling dev mode doesnt auto refresh the settings panel. You have to switch to another tab to update the UI.

This is my attempt to address #11001 
# Screenshots/Recordings/Graphs

<img width="392" height="599" alt="image" src="https://github.com/user-attachments/assets/babc5933-4c02-4996-895e-70102a4a1f5f" />

## Tests

<!--
> Please describe the tests that you have conducted to verify the changes made in this PR.
-->
