### PR TITLE
Fix unreadable overlay elements in 3D view on XWayland/Intel

### DIFF
--- a/src/slic3r/GUI/ImGuiWrapper.cpp
+++ b/src/slic3r/GUI/ImGuiWrapper.cpp
@@ -2720,6 +2720,11 @@ void ImGuiWrapper::init_font(bool compress)
     builder.BuildRanges(&ranges); // Build the final result (ordered ranges with all the unique characters submitted)
 
     io.Fonts->Flags |= ImFontAtlasFlags_NoPowerOfTwoHeight;
+    // TexDesiredWidth will be increased adaptively below if the built height
+    // exceeds GL_MAX_TEXTURE_SIZE. Leave it at 0 so ImGui picks the minimum
+    // width for small glyph sets and we only widen when actually necessary.
+    io.Fonts->TexDesiredWidth = 0;
+
     ImFontConfig cfg = ImFontConfig();
     cfg.OversampleH = cfg.OversampleV = 1;
     //FIXME replace with io.Fonts->AddFontFromMemoryTTF(buf_decompressed_data, (int)buf_decompressed_size, m_font_size, nullptr, ranges.Data);
@@ -2783,7 +2788,23 @@ void ImGuiWrapper::init_font(bool compress)
         io.Fonts->AddCustomRectFontGlyph(default_font, icon.first, icon_sz * 4, icon_sz * 4, 3.0 * font_scale + icon_sz * 4);
     }
 
-    // Build texture atlas
+    // Build texture atlas, widening it if the height would exceed GL_MAX_TEXTURE_SIZE.
+    // Increasing the width allows the packing algorithm to grow more horizontally which reduces the height.
+    io.Fonts->Build();
+    GLint gl_max_tex_size = 0;
+    glsafe(::glGetIntegerv(GL_MAX_TEXTURE_SIZE, &gl_max_tex_size));
+    constexpr int max_retries = 6;
+    for (int attempt = 0; attempt < max_retries && io.Fonts->TexHeight > gl_max_tex_size; ++attempt) {
+        io.Fonts->TexDesiredWidth = (io.Fonts->TexDesiredWidth > 0 ? io.Fonts->TexDesiredWidth : io.Fonts->TexWidth) * 2;
+        io.Fonts->Build();
+    }
+    if (io.Fonts->TexHeight > gl_max_tex_size) {
+        // Shouldn't really happen
+        BOOST_LOG_TRIVIAL(error) << "Font atlas height " << io.Fonts->TexHeight
+            << " still exceeds GL_MAX_TEXTURE_SIZE (" << gl_max_tex_size << ")"
+            << " after " << max_retries << " attempts; rendering may be incomplete";
+    }
+
     unsigned char* pixels;
     int width, height;
     io.Fonts->GetTexDataAsRGBA32(&pixels, &width, &height);   // Load as RGBA 32-bits (75% of the memory is wasted, but default font is so small) because it is more likely to be compatible with user's existing shaders. If your ImTextureId represent a higher-level concept than just a GL texture id, consider calling GetTexDataAsAlpha8() instead to save on GPU memory.


### PR DESCRIPTION
# Description

I think what is happening is that the texture is too narrow so the font rendering stacks up and makes it larger than GL_MAX_TEXTURE_SIZE height (attempting 4096x20650). If I'm understanding correctly, it seems that `glTexImage2D` was failing with GL_INVALID_VALUE but it wasn't being handled.

The proposed fix is to increase the texture width.

Note that I really have no idea what I am doing with any of this but it seems to fix the issue on my machine.

Note that XWayland + Nvidia doesn't have this problem nor very old Intel machines.

Closes #10287

# Screenshots/Recordings/Graphs

Screenshot of prepare tab:
<img width="2605" height="1832" alt="Screenshot From 2025-12-03 22-35-30" src="https://github.com/user-attachments/assets/2f97e87f-5c9c-457c-844b-d293901293d9" />

Screenshot of preview tab:
<img width="2605" height="1832" alt="Screenshot From 2025-12-03 22-35-41" src="https://github.com/user-attachments/assets/e5d1ada7-e395-442d-bcc1-c3da1943f9bf" />

## Tests

I made the change, built and re-ran it.