### PR TITLE
Add 'Reload from directory' option for batch reloading parts

### DIFF
--- a/src/slic3r/GUI/GUI_Factories.cpp
+++ b/src/slic3r/GUI/GUI_Factories.cpp
@@ -862,6 +862,13 @@ void MenuFactory::append_menu_item_reload_from_disk(wxMenu* menu)
         []() { return plater()->can_reload_from_disk(); }, m_parent);
 }
 
+void MenuFactory::append_menu_item_reload_from_directory(wxMenu* menu)
+{
+    append_menu_item(menu, wxID_ANY, _L("Reload from directory") + dots, _L("Reload selected parts from a chosen directory"),
+        [](wxCommandEvent&) { plater()->reload_from_directory(); }, "", menu,
+        []() { return plater()->can_reload_from_directory(); }, m_parent);
+}
+
 void MenuFactory::append_menu_item_replace_with_stl(wxMenu *menu)
 {
     append_menu_item(menu, wxID_ANY, _L("Replace with STL") + dots, _L("Replace the selected part with new STL"),
@@ -1273,6 +1280,7 @@ void MenuFactory::create_common_object_menu(wxMenu* menu)
     menu->AppendSeparator();
 
     append_menu_item_reload_from_disk(menu);
+    append_menu_item_reload_from_directory(menu);
     append_menu_item_export_stl(menu);
     // "Scale to print volume" makes a sense just for whole object
     append_menu_item_scale_selection_to_fit_print_volume(menu);
@@ -1356,6 +1364,7 @@ void MenuFactory::create_extra_object_menu()
     append_menu_item_per_object_settings(&m_object_menu);
     m_object_menu.AppendSeparator();
     append_menu_item_reload_from_disk(&m_object_menu);
+    append_menu_item_reload_from_directory(&m_object_menu);
     append_menu_item_replace_with_stl(&m_object_menu);
     append_menu_item_replace_all_with_stl(&m_object_menu);
     append_menu_item_export_stl(&m_object_menu);
@@ -1392,6 +1401,7 @@ void MenuFactory::create_part_menu()
     append_menu_item_rename(menu);
     append_menu_item_delete(menu);
     append_menu_item_reload_from_disk(menu);
+    append_menu_item_reload_from_directory(menu);
     append_menu_item_export_stl(menu);
     append_menu_item_fix_through_netfabb(menu);
     append_menu_items_mirror(menu);
@@ -1472,6 +1482,7 @@ void MenuFactory::create_bbl_part_menu()
     append_menu_item_per_object_settings(menu);
     append_menu_item_change_type(menu);
     append_menu_item_reload_from_disk(menu);
+    append_menu_item_reload_from_directory(menu);
     append_menu_item_replace_with_stl(menu);
     append_menu_item_replace_all_with_stl(menu);
 }
@@ -1770,6 +1781,7 @@ wxMenu* MenuFactory::multi_selection_menu()
         menu->AppendSeparator();
         append_menu_items_convert_unit(menu);
         append_menu_item_replace_all_with_stl(menu);
+        append_menu_item_reload_from_directory(menu);
         //BBS
         append_menu_item_change_filament(menu);
         menu->AppendSeparator();
@@ -1783,6 +1795,7 @@ wxMenu* MenuFactory::multi_selection_menu()
         append_menu_item_delete(menu);
         append_menu_items_convert_unit(menu);
         append_menu_item_replace_all_with_stl(menu);
+        append_menu_item_reload_from_directory(menu);
         append_menu_item_change_filament(menu);
         wxMenu* split_menu = new wxMenu();
         if (split_menu) {

--- a/src/slic3r/GUI/GUI_Factories.hpp
+++ b/src/slic3r/GUI/GUI_Factories.hpp
@@ -142,6 +142,7 @@ private:
     //wxMenuItem* append_menu_item_simplify(wxMenu* menu);
     void        append_menu_item_export_stl(wxMenu* menu, bool is_mulity_menu = false);
     void        append_menu_item_reload_from_disk(wxMenu* menu);
+    void        append_menu_item_reload_from_directory(wxMenu* menu);
     void        append_menu_item_replace_with_stl(wxMenu* menu);
     void        append_menu_item_replace_all_with_stl(wxMenu* menu);
     void        append_menu_item_change_extruder(wxMenu* menu);

--- a/src/slic3r/GUI/Plater.hpp
+++ b/src/slic3r/GUI/Plater.hpp
@@ -495,6 +495,7 @@ public:
     void publish_project();
 
     void reload_from_disk();
+    void reload_from_directory();
     void replace_with_stl();
     void replace_all_with_stl();
     void reload_all_from_disk();
@@ -672,6 +673,7 @@ public:
     bool can_undo() const;
     bool can_redo() const;
     bool can_reload_from_disk() const;
+    bool can_reload_from_directory() const;
     bool can_replace_with_stl() const;
     bool can_replace_all_with_stl() const;
     bool can_mirror() const;


### PR DESCRIPTION
# Description

**What does this PR address?**
This PR addresses #10657: "Add the ability to use relative filepaths when clicking 'reload from disk'"

Users who work with template-based workflows (e.g., duplicating a folder containing CAD files, STLs, and 3MF projects) currently cannot easily reload all parts from disk because the 3MF stores absolute file paths. When the folder is duplicated or moved, the "Reload from disk" option points to the original location, requiring manual replacement of each part individually. 

**What new features does this PR introduce?**
Adds a new right-click menu option: "Reload from directory..."
This option allows users to:
1. Select multiple objects/parts (or an assembly containing multiple parts)
2. Choose a directory via a folder picker dialog
3. Automatically reload all selected parts by matching their original source filenames within the chosen directory

This is particularly useful for:
- Template-based workflows where folders are duplicated
- Projects that have been moved to a different location
- Batch updating multiple STL files that share a common directory

The menu option appears in:
- Object context menu (when multiple parts are selected)
- Part context menu
- Multi-selection context menu

Note: The option is only enabled when 2 or more reloadable volumes are selected, as it's designed for batch operations rather than single-file reloads (where "Reload from disk" already serves this purpose). 

**Any breaking changes or dependencies?**
No. This does not modify existing behavior. The existing "Reload from disk" functionality remains unchanged. 

# Screenshots/Recordings/Graphs

See here:
https://github.com/user-attachments/assets/96e5a966-f220-4721-92c7-50440a822b74

## Tests
Test 1: Selecting a single assembly with multiple parts
- Opened a 3MF containing an object that was an assembly of multiple parts
- Selected it, right clicked, "Reload from directory..." appeared. Clicked it
- Selected a directory containing the updated STL file for each part in the assembled object. The filenames of the updated STLs were the same as the filenames of the STLs to be replaced
- All parts successfully reloaded from the new directory and the assembly structure & print settings were preserved

Test 2: Multiple separate objects selected
- Imported 2 separate STL files as individual objects
- Selected both objects (tried this both in the 3D view and in the list view in the "Objects" tab)
- Again, selected a directory containing the updated STL file for both parts 
- Both parts successfully reloaded from the new directory, preserving their print settings

Test 3: Separate objects + assemblies at the same time
- Opened a 3MF containing an object that was an assembly of multiple parts, as well as some individual (non-assembled) parts 
- Selected all of them
- Again, selected a directory containing updated STLs for all the parts (both those that comprise the assembled object and the individual parts)
- All parts successfully reloaded from the new directory and the assembly structure & print settings were preserved

Test 4: Single part
- Selected a single STL file on a build plate
- Right clicked, "Reload from directory..." appeared but was greyed out (as intended)

Test 5: Files missing
- Same procedure as Test 2, but one of the part's updated file was missing in the new directory
- Onscreen warning appeared, asking whether I'd like to proceed (only updating the part that had a match, leaving the other part alone) or if I'd like to cancel the operation
- Tried both options. Both options worked as expected. 

Test 6: Existing functionality preserved
- Verified that "Reload from disk" still works as it did before