### PR TITLE
Fix dropdown popup immediately disappearing in Qubes OS

### DIFF
--- a/src/slic3r/GUI/Widgets/PopupWindow.cpp
+++ b/src/slic3r/GUI/Widgets/PopupWindow.cpp
@@ -86,7 +86,6 @@ void PopupWindow::OnMouseEvent2(wxMouseEvent &evt)
 void PopupWindow::topWindowActiavate(wxActivateEvent &event)
 {
     event.Skip();
-    if (!event.GetActive() && IsShown()) DismissAndNotify();
 }
 #endif
 


### PR DESCRIPTION
# Description

This PR fixes an issue in Qubes OS and some other window managers where all dropdowns in Orca immediately close again. This makes Orca effectively unusable. This problem has been reported in several issues that have so far been auto closed without a fix: #8615 #2101 #6005 #3881

The problem has been fixed in Bambu Studio (issue https://github.com/bambulab/BambuStudio/issues/4201, PR https://github.com/bambulab/BambuStudio/pull/5704) and this PR is based on their fix.

