### PR TITLE
Fix missing "inherits" property items on profiles

### DIFF
--- a/resources/profiles/BBL.json
+++ b/resources/profiles/BBL.json
@@ -962,84 +962,8 @@
     ],
     "filament_list": [
         {
-            "name": "COEX PCTG PRIME @BBL X1C",
-            "sub_path": "filament/COEX/COEX PCTG PRIME @BBL X1C.json"
-        },
-        {
-            "name": "COEX PCTG PRIME @BBL X1C 0.2 nozzle",
-            "sub_path": "filament/COEX/COEX PCTG PRIME @BBL X1C 0.2 nozzle.json"
-        },
-        {
-            "name": "COEX PCTG PRIME @BBL X1C 0.8 nozzle",
-            "sub_path": "filament/COEX/COEX PCTG PRIME @BBL X1C 0.8 nozzle.json"
-        },
-        {
-            "name": "COEX PETG @BBL X1C",
-            "sub_path": "filament/COEX/COEX PETG @BBL X1C.json"
-        },
-        {
-            "name": "COEX PETG @BBL X1C 0.2 nozzle",
-            "sub_path": "filament/COEX/COEX PETG @BBL X1C 0.2 nozzle.json"
-        },
-        {
-            "name": "COEX PETG @BBL X1C 0.8 nozzle",
-            "sub_path": "filament/COEX/COEX PETG @BBL X1C 0.8 nozzle.json"
-        },
-        {
-            "name": "COEX PLA @BBL A1M",
-            "sub_path": "filament/COEX/COEX PLA @BBL A1M.json"
-        },
-        {
-            "name": "COEX PLA @BBL P1P",
-            "sub_path": "filament/COEX/COEX PLA @BBL P1P.json"
-        },
-        {
-            "name": "COEX PLA @BBL X1C",
-            "sub_path": "filament/COEX/COEX PLA @BBL X1C.json"
-        },
-        {
             "name": "fdm_filament_common",
             "sub_path": "filament/fdm_filament_common.json"
-        },
-        {
-            "name": "COEX PCTG PRIME @BBL A1M 0.4 nozzle",
-            "sub_path": "filament/COEX/COEX PCTG PRIME @BBL A1M.json"
-        },
-        {
-            "name": "COEX PCTG PRIME @BBL A1M 0.2 nozzle",
-            "sub_path": "filament/COEX/COEX PCTG PRIME @BBL A1M 0.2 nozzle.json"
-        },
-        {
-            "name": "COEX PCTG PRIME @BBL A1M 0.8 nozzle",
-            "sub_path": "filament/COEX/COEX PCTG PRIME @BBL A1M 0.8 nozzle.json"
-        },
-        {
-            "name": "COEX PETG @BBL A1M 0.4 nozzle",
-            "sub_path": "filament/COEX/COEX PETG @BBL A1M.json"
-        },
-        {
-            "name": "COEX PETG @BBL A1M 0.2 nozzle",
-            "sub_path": "filament/COEX/COEX PETG @BBL A1M 0.2 nozzle.json"
-        },
-        {
-            "name": "COEX PETG @BBL A1M 0.8 nozzle",
-            "sub_path": "filament/COEX/COEX PETG @BBL A1M 0.8 nozzle.json"
-        },
-        {
-            "name": "COEX PLA @BBL A1M 0.2 nozzle",
-            "sub_path": "filament/COEX/COEX PLA @BBL A1M 0.2 nozzle.json"
-        },
-        {
-            "name": "COEX PLA @BBL P1P 0.2 nozzle",
-            "sub_path": "filament/COEX/COEX PLA @BBL P1P 0.2 nozzle.json"
-        },
-        {
-            "name": "COEX PLA @BBL X1C 0.2 nozzle",
-            "sub_path": "filament/COEX/COEX PLA @BBL X1C 0.2 nozzle.json"
-        },
-        {
-            "name": "FusRock ABS-GF @base",
-            "sub_path": "filament/FusRock/FusRock ABS-GF @base.json"
         },
         {
             "name": "fdm_filament_abs",
@@ -1090,6 +1014,10 @@
             "sub_path": "filament/fdm_filament_pla.json"
         },
         {
+            "name": "fdm_filament_pla_silk",
+            "sub_path": "filament/fdm_filament_pla_silk.json"
+        },
+        {
             "name": "fdm_filament_pp",
             "sub_path": "filament/fdm_filament_pp.json"
         },
@@ -1112,6 +1040,162 @@
         {
             "name": "fdm_filament_tpu",
             "sub_path": "filament/fdm_filament_tpu.json"
+        },
+        {
+            "name": "AliZ PA-CF @base",
+            "sub_path": "filament/AliZ/AliZ PA-CF @base.json"
+        },
+        {
+            "name": "AliZ PETG @base",
+            "sub_path": "filament/AliZ/AliZ PETG @base.json"
+        },
+        {
+            "name": "AliZ PETG-CF @base",
+            "sub_path": "filament/AliZ/AliZ PETG-CF @base.json"
+        },
+        {
+            "name": "AliZ PETG-Metal @base",
+            "sub_path": "filament/AliZ/AliZ PETG-Metal @base.json"
+        },
+        {
+            "name": "AliZ PLA @base",
+            "sub_path": "filament/AliZ/AliZ PLA @base.json"
+        }, 
+        {
+            "name": "COEX ABS @base",
+            "sub_path": "filament/COEX/COEX ABS @base.json"
+        },
+        {
+            "name": "COEX ABS PRIME @base",
+            "sub_path": "filament/COEX/COEX ABS PRIME @base.json"
+        },
+        {
+            "name": "COEX ASA PRIME @base",
+            "sub_path": "filament/COEX/COEX ASA PRIME @base.json"
+        },
+        {
+            "name": "COEX NYLEX PA6-CF @base",
+            "sub_path": "filament/COEX/COEX NYLEX PA6-CF @base.json"
+        },
+        {
+            "name": "COEX NYLEX UNFILLED @base",
+            "sub_path": "filament/COEX/COEX NYLEX UNFILLED @base.json"
+        },
+        {
+            "name": "COEX PCTG PRIME @base",
+            "sub_path": "filament/COEX/COEX PCTG PRIME @base.json"
+        },
+        {
+            "name": "COEX PETG @base",
+            "sub_path": "filament/COEX/COEX PETG @base.json"
+        },
+        {
+            "name": "COEX PLA @base",
+            "sub_path": "filament/COEX/COEX PLA @base.json"
+        },
+        {
+            "name": "COEX PLA PRIME @base",
+            "sub_path": "filament/COEX/COEX PLA PRIME @base.json"
+        },
+        {
+            "name": "COEX PLA+Silk @base",
+            "sub_path": "filament/COEX/COEX PLA+Silk @base.json"
+        },
+        {
+            "name": "COEX TPE 30D @base",
+            "sub_path": "filament/COEX/COEX TPE 30D @base.json"
+        },
+        {
+            "name": "COEX TPE 40D @base",
+            "sub_path": "filament/COEX/COEX TPE 40D @base.json"
+        },
+        {
+            "name": "COEX TPE 60D @base",
+            "sub_path": "filament/COEX/COEX TPE 60D @base.json"
+        },
+        {
+            "name": "Overture TPU @base",
+            "sub_path": "filament/Overture/Overture TPU @base.json"
+        },    
+        {
+            "name": "COEX TPU 60A @base",
+            "sub_path": "filament/COEX/COEX TPU 60A @base.json"
+        },
+        {
+            "name": "COEX PCTG PRIME @BBL X1C",
+            "sub_path": "filament/COEX/COEX PCTG PRIME @BBL X1C.json"
+        },
+        {
+            "name": "COEX PCTG PRIME @BBL X1C 0.2 nozzle",
+            "sub_path": "filament/COEX/COEX PCTG PRIME @BBL X1C 0.2 nozzle.json"
+        },
+        {
+            "name": "COEX PCTG PRIME @BBL X1C 0.8 nozzle",
+            "sub_path": "filament/COEX/COEX PCTG PRIME @BBL X1C 0.8 nozzle.json"
+        },
+        {
+            "name": "COEX PETG @BBL X1C",
+            "sub_path": "filament/COEX/COEX PETG @BBL X1C.json"
+        },
+        {
+            "name": "COEX PETG @BBL X1C 0.2 nozzle",
+            "sub_path": "filament/COEX/COEX PETG @BBL X1C 0.2 nozzle.json"
+        },
+        {
+            "name": "COEX PETG @BBL X1C 0.8 nozzle",
+            "sub_path": "filament/COEX/COEX PETG @BBL X1C 0.8 nozzle.json"
+        },
+        {
+            "name": "COEX PLA @BBL A1M",
+            "sub_path": "filament/COEX/COEX PLA @BBL A1M.json"
+        },
+        {
+            "name": "COEX PLA @BBL P1P",
+            "sub_path": "filament/COEX/COEX PLA @BBL P1P.json"
+        },
+        {
+            "name": "COEX PLA @BBL X1C",
+            "sub_path": "filament/COEX/COEX PLA @BBL X1C.json"
+        },
+        {
+            "name": "COEX PCTG PRIME @BBL A1M 0.4 nozzle",
+            "sub_path": "filament/COEX/COEX PCTG PRIME @BBL A1M.json"
+        },
+        {
+            "name": "COEX PCTG PRIME @BBL A1M 0.2 nozzle",
+            "sub_path": "filament/COEX/COEX PCTG PRIME @BBL A1M 0.2 nozzle.json"
+        },
+        {
+            "name": "COEX PCTG PRIME @BBL A1M 0.8 nozzle",
+            "sub_path": "filament/COEX/COEX PCTG PRIME @BBL A1M 0.8 nozzle.json"
+        },
+        {
+            "name": "COEX PETG @BBL A1M 0.4 nozzle",
+            "sub_path": "filament/COEX/COEX PETG @BBL A1M.json"
+        },
+        {
+            "name": "COEX PETG @BBL A1M 0.2 nozzle",
+            "sub_path": "filament/COEX/COEX PETG @BBL A1M 0.2 nozzle.json"
+        },
+        {
+            "name": "COEX PETG @BBL A1M 0.8 nozzle",
+            "sub_path": "filament/COEX/COEX PETG @BBL A1M 0.8 nozzle.json"
+        },
+        {
+            "name": "COEX PLA @BBL A1M 0.2 nozzle",
+            "sub_path": "filament/COEX/COEX PLA @BBL A1M 0.2 nozzle.json"
+        },
+        {
+            "name": "COEX PLA @BBL P1P 0.2 nozzle",
+            "sub_path": "filament/COEX/COEX PLA @BBL P1P 0.2 nozzle.json"
+        },
+        {
+            "name": "COEX PLA @BBL X1C 0.2 nozzle",
+            "sub_path": "filament/COEX/COEX PLA @BBL X1C 0.2 nozzle.json"
+        },
+        {
+            "name": "FusRock ABS-GF @base",
+            "sub_path": "filament/FusRock/FusRock ABS-GF @base.json"
         },
         {
             "name": "FusRock ABS-GF @BBL A1",
@@ -1406,8 +1490,8 @@
             "sub_path": "filament/Generic PLA-CF @base.json"
         },
         {
-            "name": "Overture Matte PLA @base",
-            "sub_path": "filament/Overture/Overture Matte PLA @base.json"
+            "name": "Overture ASA @base",
+            "sub_path": "filament/Overture/Overture ASA @base.json"
         },
         {
             "name": "Overture PLA @base",
@@ -1416,6 +1500,30 @@
         {
             "name": "Overture PLA Pro @base",
             "sub_path": "filament/Overture/Overture PLA Pro @base.json"
+        },
+        {
+            "name": "Overture Matte PLA @base",
+            "sub_path": "filament/Overture/Overture Matte PLA @base.json"
+        },
+        {
+            "name": "Overture Air PLA @base",
+            "sub_path": "filament/Overture/Overture Air PLA @base.json"
+        },
+        {
+            "name": "Overture Easy PLA @base",
+            "sub_path": "filament/Overture/Overture Easy PLA @base.json"
+        },
+        {
+            "name": "Overture Rock PLA @base",
+            "sub_path": "filament/Overture/Overture Rock PLA @base.json"
+        },
+        {
+            "name": "Overture Silk PLA @base",
+            "sub_path": "filament/Overture/Overture Silk PLA @base.json"
+        },
+        {
+            "name": "Overture Super PLA+ @base",
+            "sub_path": "filament/Overture/Overture Super PLA+ @base.json"
         },
         {
             "name": "Panchroma CoPE @base",

--- a/resources/profiles/BBL.json
+++ b/resources/profiles/BBL.json
@@ -1,7 +1,7 @@
 {
     "name": "Bambulab",
     "url": "http://www.bambulab.com/Parameters/vendor/BBL.json",
-    "version": "02.00.00.56",
+    "version": "02.00.00.57",
     "force_update": "0",
     "description": "the initial version of BBL configurations",
     "machine_model_list": [

--- a/resources/profiles/BBL/filament/AliZ/AliZ PA-CF @base.json
+++ b/resources/profiles/BBL/filament/AliZ/AliZ PA-CF @base.json
@@ -1,0 +1,77 @@
+{
+    "type": "filament",
+    "name": "AliZ PA-CF @base",
+    "inherits": "fdm_filament_pa",
+    "from": "system",
+    "filament_id": "AliZ003",
+    "instantiation": "false",
+    "filament_type": [
+        "PA-CF"
+    ],
+    "complete_print_exhaust_fan_speed": [
+        "80"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "60"
+    ],
+    "enable_pressure_advance": [
+        "0"
+    ],
+    "eng_plate_temp": [
+        "80"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "80"
+    ],
+    "fan_cooling_layer_time": [
+        "5"
+    ],
+    "fan_max_speed": [
+        "30"
+    ],
+    "fan_min_speed": [
+        "10"
+    ],
+    "filament_cost": [
+        "49.9"
+    ],
+    "filament_flow_ratio": [
+        "1"
+    ],
+    "filament_max_volumetric_speed": [
+        "8"
+    ],
+    "filament_vendor": [
+        "Aliz"
+    ],
+    "full_fan_speed_layer": [
+        "2"
+    ],
+    "nozzle_temperature": [
+        "290"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "290"
+    ],
+    "nozzle_temperature_range_high": [
+        "300"
+    ],
+    "nozzle_temperature_range_low": [
+        "260"
+    ],
+    "overhang_fan_speed": [
+        "40"
+    ],
+    "overhang_fan_threshold": [
+        "0%"
+    ],
+    "pressure_advance": [
+        "0.026"
+    ],
+    "slow_down_layer_time": [
+        "2"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ]
+}

--- a/resources/profiles/BBL/filament/AliZ/AliZ PETG @base.json
+++ b/resources/profiles/BBL/filament/AliZ/AliZ PETG @base.json
@@ -1,0 +1,56 @@
+{
+    "type": "filament",
+    "name": "AliZ PETG @base",
+    "inherits": "fdm_filament_pet",
+    "from": "system",
+    "filament_id": "AliZ001",
+    "instantiation": "false",
+    "close_fan_the_first_x_layers": [
+        "2"
+    ],
+    "enable_pressure_advance": [
+        "0"
+    ],
+    "fan_max_speed": [
+        "80"
+    ],
+    "fan_min_speed": [
+        "30"
+    ],
+    "filament_cost": [
+        "49.9"
+    ],
+    "filament_flow_ratio": [
+        "1"
+    ],
+    "filament_max_volumetric_speed": [
+        "15"
+    ],
+    "filament_vendor": [
+        "Aliz"
+    ],
+    "hot_plate_temp": [
+        "79"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "79"
+    ],
+    "nozzle_temperature": [
+        "250"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "250"
+    ],
+    "overhang_fan_threshold": [
+        "25%"
+    ],
+    "pressure_advance": [
+        "0.036"
+    ],
+    "textured_plate_temp": [
+        "70"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "70"
+    ]
+}

--- a/resources/profiles/BBL/filament/AliZ/AliZ PETG-CF @base.json
+++ b/resources/profiles/BBL/filament/AliZ/AliZ PETG-CF @base.json
@@ -1,0 +1,74 @@
+{
+    "type": "filament",
+    "name": "AliZ PETG-CF @base",
+    "inherits": "AliZ PETG @base",
+    "from": "system",
+    "filament_id": "AZ01-1",
+    "instantiation": "false",
+    "fan_cooling_layer_time": [
+        "30"
+    ],
+    "overhang_fan_speed": [
+        "100"
+    ],
+    "close_fan_the_first_x_layers": [
+        "2"
+    ],
+    "enable_pressure_advance": [
+        "0"
+    ],
+    "pressure_advance": [
+        "0.033"
+    ],
+    "fan_max_speed": [
+        "35"
+    ],
+    "fan_min_speed": [
+        "10"
+    ],
+    "filament_cost": [
+        "49.9"
+    ],
+    "filament_flow_ratio": [
+        "1"
+    ],
+    "filament_max_volumetric_speed": [
+        "10"
+    ],
+    "filament_type": [
+        "PETG-CF"
+    ],
+    "filament_vendor": [
+        "Aliz"
+    ],
+    "hot_plate_temp": [
+        "79"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "79"
+    ],
+    "nozzle_temperature": [
+        "275"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "275"
+    ],
+    "nozzle_temperature_range_high": [
+        "290"
+    ],
+    "nozzle_temperature_range_low": [
+        "260"
+    ],
+    "overhang_fan_threshold": [
+        "25%"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
+    "textured_plate_temp": [
+        "70"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "70"
+    ]
+}

--- a/resources/profiles/BBL/filament/AliZ/AliZ PETG-Metal @base.json
+++ b/resources/profiles/BBL/filament/AliZ/AliZ PETG-Metal @base.json
@@ -1,0 +1,65 @@
+{
+    "type": "filament",
+    "name": "AliZ PETG-Metal @base",
+    "inherits": "AliZ PETG @base",
+    "from": "system",
+    "filament_id": "AZ01-2",
+    "instantiation": "false",
+    "fan_cooling_layer_time": [
+        "30"
+    ],
+    "overhang_fan_speed": [
+        "100"
+    ],
+    "close_fan_the_first_x_layers": [
+        "2"
+    ],
+    "enable_pressure_advance": [
+        "0"
+    ],
+    "fan_max_speed": [
+        "80"
+    ],
+    "fan_min_speed": [
+        "30"
+    ],
+    "filament_cost": [
+        "49.9"
+    ],
+    "filament_flow_ratio": [
+        "1"
+    ],
+    "filament_max_volumetric_speed": [
+        "13"
+    ],
+    "filament_vendor": [
+        "Aliz"
+    ],
+    "hot_plate_temp": [
+        "79"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "79"
+    ],
+    "nozzle_temperature": [
+        "260"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "260"
+    ],
+    "overhang_fan_threshold": [
+        "25%"
+    ],
+    "pressure_advance": [
+        "0.036"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
+    "textured_plate_temp": [
+        "70"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "70"
+    ]
+}

--- a/resources/profiles/BBL/filament/AliZ/AliZ PLA @base.json
+++ b/resources/profiles/BBL/filament/AliZ/AliZ PLA @base.json
@@ -1,0 +1,44 @@
+{
+    "type": "filament",
+    "name": "AliZ PLA @base",
+    "inherits": "fdm_filament_pla",
+    "from": "system",
+    "filament_id": "AliZ002",
+    "instantiation": "false",
+    "enable_pressure_advance": [
+        "0"
+    ],
+    "fan_cooling_layer_time": [
+        "100"
+    ],
+    "filament_cost": [
+        "69"
+    ],
+    "filament_density": [
+        "1.27"
+    ],
+    "filament_vendor": [
+        "Aliz"
+    ],
+    "filament_wipe_distance": [
+        "0"
+    ],
+    "hot_plate_temp": [
+        "55"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "55"
+    ],
+    "pressure_advance": [
+        "0.025"
+    ],
+    "slow_down_layer_time": [
+        "4"
+    ],
+    "textured_plate_temp": [
+        "55"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "55"
+    ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX ABS @base.json
+++ b/resources/profiles/BBL/filament/COEX/COEX ABS @base.json
@@ -1,0 +1,96 @@
+{
+    "type": "filament",
+    "name": "COEX ABS @base",
+    "inherits": "fdm_filament_abs",
+    "from": "system",
+    "filament_id": "CXABSB01",
+    "instantiation": "false",
+    "filament_vendor": [
+        "COEX 3D"
+    ],
+    "filament_cost": [
+        "30.00"
+    ],
+    "filament_density": [
+        "1.04"
+    ],
+    "filament_type": [
+        "ABS"
+    ],
+    "nozzle_temperature": [
+        "255"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "255"
+    ],
+    "bed_temperature": [
+        "100"
+    ],
+    "bed_temperature_initial_layer": [
+        "100"
+    ],
+    "temperature_vitrification": [
+        "100"
+    ],
+    "chamber_temperature": [
+        "0"
+    ],
+    "filament_max_volumetric_speed": [
+        "16"
+    ],
+    "filament_retraction_minimum_travel": [
+        "2"
+    ],
+    "filament_retract_before_wipe": [
+        "70%"
+    ],
+    "filament_retract_layer_change": [
+        "1"
+    ],
+    "filament_retract_when_changing_layer": [
+        "1"
+    ],
+    "filament_retraction_length": [
+        "2.5"
+    ],
+    "filament_retraction_speed": [
+        "40"
+    ],
+    "filament_deretraction_speed": [
+        "40"
+    ],
+    "filament_wipe": [
+        "1"
+    ],
+    "filament_wipe_distance": [
+        "2"
+    ],
+    "fan_min_speed": [
+        "0"
+    ],
+    "fan_max_speed": [
+        "30"
+    ],
+    "disable_fan_first_layers": [
+        "3"
+    ],
+    "full_fan_speed_layer": [
+        "0"
+    ],
+    "slow_down_layer_time": [
+        "5"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
+    "enable_pressure_advance": [
+        "1"
+    ],
+    "pressure_advance": [
+        "0.04"
+    ],
+    "compatible_printers": [],
+    "compatible_printers_condition": "",
+    "compatible_prints": [],
+    "compatible_prints_condition": ""
+}

--- a/resources/profiles/BBL/filament/COEX/COEX ABS PRIME @base.json
+++ b/resources/profiles/BBL/filament/COEX/COEX ABS PRIME @base.json
@@ -1,0 +1,96 @@
+{
+    "type": "filament",
+    "name": "COEX ABS PRIME @base",
+    "inherits": "fdm_filament_abs",
+    "from": "system",
+    "filament_id": "CXABPB09",
+    "instantiation": "false",
+    "filament_vendor": [
+        "COEX 3D"
+    ],
+    "filament_cost": [
+        "39.00"
+    ],
+    "filament_density": [
+        "1.04"
+    ],
+    "filament_type": [
+        "ABS"
+    ],
+    "nozzle_temperature": [
+        "255"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "255"
+    ],
+    "bed_temperature": [
+        "100"
+    ],
+    "bed_temperature_initial_layer": [
+        "100"
+    ],
+    "temperature_vitrification": [
+        "100"
+    ],
+    "chamber_temperature": [
+        "0"
+    ],
+    "filament_max_volumetric_speed": [
+        "16"
+    ],
+    "filament_retraction_minimum_travel": [
+        "2"
+    ],
+    "filament_retract_before_wipe": [
+        "70%"
+    ],
+    "filament_retract_layer_change": [
+        "1"
+    ],
+    "filament_retract_when_changing_layer": [
+        "1"
+    ],
+    "filament_retraction_length": [
+        "2.5"
+    ],
+    "filament_retraction_speed": [
+        "40"
+    ],
+    "filament_deretraction_speed": [
+        "40"
+    ],
+    "filament_wipe": [
+        "1"
+    ],
+    "filament_wipe_distance": [
+        "2"
+    ],
+    "fan_min_speed": [
+        "0"
+    ],
+    "fan_max_speed": [
+        "30"
+    ],
+    "disable_fan_first_layers": [
+        "3"
+    ],
+    "full_fan_speed_layer": [
+        "0"
+    ],
+    "slow_down_layer_time": [
+        "5"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
+    "enable_pressure_advance": [
+        "1"
+    ],
+    "pressure_advance": [
+        "0.04"
+    ],
+    "compatible_printers": [],
+    "compatible_printers_condition": "",
+    "compatible_prints": [],
+    "compatible_prints_condition": ""
+}

--- a/resources/profiles/BBL/filament/COEX/COEX ASA PRIME @base.json
+++ b/resources/profiles/BBL/filament/COEX/COEX ASA PRIME @base.json
@@ -1,0 +1,97 @@
+{
+    "type": "filament",
+    "name": "COEX ASA PRIME @base",
+    "inherits": "fdm_filament_asa",
+    "from": "system",
+    "filament_id": "CXASAB04",
+    "instantiation": "false",
+    "filament_vendor": [
+        "COEX 3D"
+    ],
+    "filament_cost": [
+        "34.00"
+    ],
+    "filament_density": [
+        "1.07"
+    ],
+    "filament_type": [
+        "ASA"
+    ],
+    "filament_notes": "UV and weather resistant - requires good ventilation",
+    "nozzle_temperature": [
+        "265"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "265"
+    ],
+    "bed_temperature": [
+        "100"
+    ],
+    "bed_temperature_initial_layer": [
+        "100"
+    ],
+    "temperature_vitrification": [
+        "95"
+    ],
+    "chamber_temperature": [
+        "0"
+    ],
+    "filament_max_volumetric_speed": [
+        "16"
+    ],
+    "filament_retraction_minimum_travel": [
+        "2"
+    ],
+    "filament_retract_before_wipe": [
+        "70%"
+    ],
+    "filament_retract_layer_change": [
+        "1"
+    ],
+    "filament_retract_when_changing_layer": [
+        "1"
+    ],
+    "filament_retraction_length": [
+        "2.5"
+    ],
+    "filament_retraction_speed": [
+        "40"
+    ],
+    "filament_deretraction_speed": [
+        "40"
+    ],
+    "filament_wipe": [
+        "1"
+    ],
+    "filament_wipe_distance": [
+        "2"
+    ],
+    "fan_min_speed": [
+        "0"
+    ],
+    "fan_max_speed": [
+        "30"
+    ],
+    "disable_fan_first_layers": [
+        "3"
+    ],
+    "full_fan_speed_layer": [
+        "0"
+    ],
+    "slow_down_layer_time": [
+        "5"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
+    "enable_pressure_advance": [
+        "1"
+    ],
+    "pressure_advance": [
+        "0.04"
+    ],
+    "compatible_printers": [],
+    "compatible_printers_condition": "",
+    "compatible_prints": [],
+    "compatible_prints_condition": ""
+}

--- a/resources/profiles/BBL/filament/COEX/COEX NYLEX PA6-CF @base.json
+++ b/resources/profiles/BBL/filament/COEX/COEX NYLEX PA6-CF @base.json
@@ -1,0 +1,96 @@
+{
+    "type": "filament",
+    "name": "COEX NYLEX PA6-CF @base",
+    "inherits": "fdm_filament_pa",
+    "from": "system",
+    "filament_id": "CXPACB23",
+    "instantiation": "false",
+    "filament_vendor": [
+        "COEX 3D"
+    ],
+    "filament_cost": [
+        "85.00"
+    ],
+    "filament_density": [
+        "1.24"
+    ],
+    "filament_type": [
+        "PA-CF"
+    ],
+    "nozzle_temperature": [
+        "285"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "285"
+    ],
+    "bed_temperature": [
+        "100"
+    ],
+    "bed_temperature_initial_layer": [
+        "100"
+    ],
+    "temperature_vitrification": [
+        "170"
+    ],
+    "chamber_temperature": [
+        "60"
+    ],
+    "filament_max_volumetric_speed": [
+        "11"
+    ],
+    "filament_retraction_minimum_travel": [
+        "2"
+    ],
+    "filament_retract_before_wipe": [
+        "70%"
+    ],
+    "filament_retract_layer_change": [
+        "1"
+    ],
+    "filament_retract_when_changing_layer": [
+        "1"
+    ],
+    "filament_retraction_length": [
+        "2.5"
+    ],
+    "filament_retraction_speed": [
+        "40"
+    ],
+    "filament_deretraction_speed": [
+        "40"
+    ],
+    "filament_wipe": [
+        "1"
+    ],
+    "filament_wipe_distance": [
+        "2"
+    ],
+    "fan_min_speed": [
+        "0"
+    ],
+    "fan_max_speed": [
+        "30"
+    ],
+    "disable_fan_first_layers": [
+        "4"
+    ],
+    "full_fan_speed_layer": [
+        "0"
+    ],
+    "slow_down_layer_time": [
+        "5"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
+    "enable_pressure_advance": [
+        "1"
+    ],
+    "pressure_advance": [
+        "0.02"
+    ],
+    "compatible_printers": [],
+    "compatible_printers_condition": "",
+    "compatible_prints": [],
+    "compatible_prints_condition": ""
+}

--- a/resources/profiles/BBL/filament/COEX/COEX NYLEX UNFILLED @base.json
+++ b/resources/profiles/BBL/filament/COEX/COEX NYLEX UNFILLED @base.json
@@ -1,0 +1,96 @@
+{
+    "type": "filament",
+    "name": "COEX NYLEX UNFILLED @base",
+    "inherits": "fdm_filament_pa",
+    "from": "system",
+    "filament_id": "CXPAUB21",
+    "instantiation": "false",
+    "filament_vendor": [
+        "COEX 3D"
+    ],
+    "filament_cost": [
+        "85.00"
+    ],
+    "filament_density": [
+        "1.08"
+    ],
+    "filament_type": [
+        "PA"
+    ],
+    "nozzle_temperature": [
+        "260"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "260"
+    ],
+    "bed_temperature": [
+        "100"
+    ],
+    "bed_temperature_initial_layer": [
+        "100"
+    ],
+    "temperature_vitrification": [
+        "100"
+    ],
+    "chamber_temperature": [
+        "0"
+    ],
+    "filament_max_volumetric_speed": [
+        "11"
+    ],
+    "filament_retraction_minimum_travel": [
+        "2"
+    ],
+    "filament_retract_before_wipe": [
+        "70%"
+    ],
+    "filament_retract_layer_change": [
+        "1"
+    ],
+    "filament_retract_when_changing_layer": [
+        "1"
+    ],
+    "filament_retraction_length": [
+        "2.5"
+    ],
+    "filament_retraction_speed": [
+        "40"
+    ],
+    "filament_deretraction_speed": [
+        "40"
+    ],
+    "filament_wipe": [
+        "1"
+    ],
+    "filament_wipe_distance": [
+        "2"
+    ],
+    "fan_min_speed": [
+        "0"
+    ],
+    "fan_max_speed": [
+        "30"
+    ],
+    "disable_fan_first_layers": [
+        "4"
+    ],
+    "full_fan_speed_layer": [
+        "0"
+    ],
+    "slow_down_layer_time": [
+        "5"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
+    "enable_pressure_advance": [
+        "1"
+    ],
+    "pressure_advance": [
+        "0.02"
+    ],
+    "compatible_printers": [],
+    "compatible_printers_condition": "",
+    "compatible_prints": [],
+    "compatible_prints_condition": ""
+}

--- a/resources/profiles/BBL/filament/COEX/COEX PCTG PRIME @base.json
+++ b/resources/profiles/BBL/filament/COEX/COEX PCTG PRIME @base.json
@@ -1,0 +1,97 @@
+{
+    "type": "filament",
+    "name": "COEX PCTG PRIME @base",
+    "inherits": "fdm_filament_pctg",
+    "from": "system",
+    "filament_id": "CXPCTB15",
+    "instantiation": "false",
+    "filament_vendor": [
+        "COEX 3D"
+    ],
+    "filament_cost": [
+        "38.00"
+    ],
+    "filament_density": [
+        "1.27"
+    ],
+    "filament_type": [
+        "PCTG"
+    ],
+    "filament_notes": "High clarity and chemical resistance copolyester",
+    "nozzle_temperature": [
+        "275"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "275"
+    ],
+    "bed_temperature": [
+        "80"
+    ],
+    "bed_temperature_initial_layer": [
+        "85"
+    ],
+    "temperature_vitrification": [
+        "80"
+    ],
+    "filament_max_volumetric_speed": [
+        "12"
+    ],
+    "filament_retraction_minimum_travel": [
+        "2"
+    ],
+    "filament_retract_before_wipe": [
+        "70%"
+    ],
+    "filament_retract_layer_change": [
+        "1"
+    ],
+    "filament_retract_when_changing_layer": [
+        "1"
+    ],
+    "filament_retraction_length": [
+        "3.5"
+    ],
+    "filament_retraction_speed": [
+        "35"
+    ],
+    "filament_deretraction_speed": [
+        "35"
+    ],
+    "filament_z_hop": [
+        "0.4"
+    ],
+    "filament_wipe": [
+        "1"
+    ],
+    "filament_wipe_distance": [
+        "2"
+    ],
+    "fan_min_speed": [
+        "30"
+    ],
+    "fan_max_speed": [
+        "50"
+    ],
+    "disable_fan_first_layers": [
+        "2"
+    ],
+    "full_fan_speed_layer": [
+        "4"
+    ],
+    "slow_down_layer_time": [
+        "5"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
+    "enable_pressure_advance": [
+        "1"
+    ],
+    "pressure_advance": [
+        "0.045"
+    ],
+    "compatible_printers": [],
+    "compatible_printers_condition": "",
+    "compatible_prints": [],
+    "compatible_prints_condition": ""
+}

--- a/resources/profiles/BBL/filament/COEX/COEX PETG @base.json
+++ b/resources/profiles/BBL/filament/COEX/COEX PETG @base.json
@@ -1,0 +1,97 @@
+{
+    "type": "filament",
+    "name": "COEX PETG @base",
+    "inherits": "fdm_filament_pet",
+    "from": "system",
+    "filament_id": "CXPETB13",
+    "instantiation": "false",
+    "filament_vendor": [
+        "COEX 3D"
+    ],
+    "filament_cost": [
+        "33.00"
+    ],
+    "filament_density": [
+        "1.27"
+    ],
+    "filament_type": [
+        "PETG"
+    ],
+    "filament_notes": "IMPORTANT: Set travel speed to maximum your machine allows (200-500mm/s) to reduce stringing",
+    "nozzle_temperature": [
+        "245"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "250"
+    ],
+    "bed_temperature": [
+        "80"
+    ],
+    "bed_temperature_initial_layer": [
+        "85"
+    ],
+    "temperature_vitrification": [
+        "70"
+    ],
+    "filament_max_volumetric_speed": [
+        "12"
+    ],
+    "filament_retraction_minimum_travel": [
+        "2"
+    ],
+    "filament_retract_before_wipe": [
+        "70%"
+    ],
+    "filament_retract_layer_change": [
+        "1"
+    ],
+    "filament_retract_when_changing_layer": [
+        "1"
+    ],
+    "filament_retraction_length": [
+        "4"
+    ],
+    "filament_retraction_speed": [
+        "30"
+    ],
+    "filament_deretraction_speed": [
+        "30"
+    ],
+    "filament_z_hop": [
+        "0.4"
+    ],
+    "filament_wipe": [
+        "1"
+    ],
+    "filament_wipe_distance": [
+        "2"
+    ],
+    "fan_min_speed": [
+        "30"
+    ],
+    "fan_max_speed": [
+        "50"
+    ],
+    "disable_fan_first_layers": [
+        "2"
+    ],
+    "full_fan_speed_layer": [
+        "4"
+    ],
+    "slow_down_layer_time": [
+        "5"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
+    "enable_pressure_advance": [
+        "1"
+    ],
+    "pressure_advance": [
+        "0.045"
+    ],
+    "compatible_printers": [],
+    "compatible_printers_condition": "",
+    "compatible_prints": [],
+    "compatible_prints_condition": ""
+}

--- a/resources/profiles/BBL/filament/COEX/COEX PLA @base.json
+++ b/resources/profiles/BBL/filament/COEX/COEX PLA @base.json
@@ -1,0 +1,87 @@
+{
+    "type": "filament",
+    "name": "COEX PLA @base",
+    "inherits": "fdm_filament_pla",
+    "from": "system",
+    "filament_id": "CXPLAB02",
+    "instantiation": "false",
+    "filament_vendor": [
+        "COEX 3D"
+    ],
+    "filament_cost": [
+        "24.00"
+    ],
+    "filament_density": [
+        "1.24"
+    ],
+    "filament_type": [
+        "PLA"
+    ],
+    "nozzle_temperature": [
+        "230"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "235"
+    ],
+    "bed_temperature": [
+        "60"
+    ],
+    "bed_temperature_initial_layer": [
+        "60"
+    ],
+    "temperature_vitrification": [
+        "55"
+    ],
+    "filament_max_volumetric_speed": [
+        "18"
+    ],
+    "filament_retraction_minimum_travel": [
+        "2"
+    ],
+    "filament_retract_before_wipe": [
+        "70%"
+    ],
+    "filament_retract_layer_change": [
+        "1"
+    ],
+    "filament_retract_when_changing_layer": [
+        "1"
+    ],
+    "filament_retraction_length": [
+        "1.5"
+    ],
+    "filament_retraction_speed": [
+        "45"
+    ],
+    "filament_deretraction_speed": [
+        "40"
+    ],
+    "filament_wipe": [
+        "1"
+    ],
+    "filament_wipe_distance": [
+        "2"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "disable_fan_first_layers": [
+        "1"
+    ],
+    "full_fan_speed_layer": [
+        "3"
+    ],
+    "slow_down_layer_time": [
+        "5"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
+    "compatible_printers": [],
+    "compatible_printers_condition": "",
+    "compatible_prints": [],
+    "compatible_prints_condition": ""
+}

--- a/resources/profiles/BBL/filament/COEX/COEX PLA PRIME @base.json
+++ b/resources/profiles/BBL/filament/COEX/COEX PLA PRIME @base.json
@@ -1,0 +1,88 @@
+{
+    "type": "filament",
+    "name": "COEX PLA PRIME @base",
+    "inherits": "fdm_filament_pla",
+    "from": "system",
+    "filament_id": "CXPLAB08",
+    "instantiation": "false",
+    "filament_vendor": [
+        "COEX 3D"
+    ],
+    "filament_cost": [
+        "32.00"
+    ],
+    "filament_density": [
+        "1.24"
+    ],
+    "filament_type": [
+        "PLA"
+    ],
+    "filament_notes": "Made with NatureWorks Ingeo 3D850 - improved heat resistance and toughness",
+    "nozzle_temperature": [
+        "235"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "240"
+    ],
+    "bed_temperature": [
+        "60"
+    ],
+    "bed_temperature_initial_layer": [
+        "60"
+    ],
+    "temperature_vitrification": [
+        "60"
+    ],
+    "filament_max_volumetric_speed": [
+        "15"
+    ],
+    "filament_retraction_minimum_travel": [
+        "2"
+    ],
+    "filament_retract_before_wipe": [
+        "70%"
+    ],
+    "filament_retract_layer_change": [
+        "1"
+    ],
+    "filament_retract_when_changing_layer": [
+        "1"
+    ],
+    "filament_retraction_length": [
+        "1.2"
+    ],
+    "filament_retraction_speed": [
+        "50"
+    ],
+    "filament_deretraction_speed": [
+        "40"
+    ],
+    "filament_wipe": [
+        "1"
+    ],
+    "filament_wipe_distance": [
+        "2"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "disable_fan_first_layers": [
+        "1"
+    ],
+    "full_fan_speed_layer": [
+        "3"
+    ],
+    "slow_down_layer_time": [
+        "5"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
+    "compatible_printers": [],
+    "compatible_printers_condition": "",
+    "compatible_prints": [],
+    "compatible_prints_condition": ""
+}

--- a/resources/profiles/BBL/filament/COEX/COEX PLA+Silk @base.json
+++ b/resources/profiles/BBL/filament/COEX/COEX PLA+Silk @base.json
@@ -1,0 +1,91 @@
+{
+    "type": "filament",
+    "name": "COEX PLA+Silk @base",
+    "inherits": "fdm_filament_pla_silk",
+    "from": "system",
+    "filament_id": "CXPLSB03",
+    "instantiation": "false",
+    "filament_vendor": [
+        "COEX 3D"
+    ],
+    "filament_cost": [
+        "30.00"
+    ],
+    "filament_density": [
+        "1.24"
+    ],
+    "filament_type": [
+        "PLA"
+    ],
+    "filament_notes": "Silk finish for aesthetic prints - slightly higher temperature than regular PLA",
+    "nozzle_temperature": [
+        "240"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "245"
+    ],
+    "bed_temperature": [
+        "60"
+    ],
+    "bed_temperature_initial_layer": [
+        "60"
+    ],
+    "temperature_vitrification": [
+        "55"
+    ],
+    "filament_max_volumetric_speed": [
+        "15"
+    ],
+    "filament_retraction_minimum_travel": [
+        "2"
+    ],
+    "filament_retract_before_wipe": [
+        "70%"
+    ],
+    "filament_retract_layer_change": [
+        "1"
+    ],
+    "filament_retract_when_changing_layer": [
+        "1"
+    ],
+    "filament_retraction_length": [
+        "1.5"
+    ],
+    "filament_retraction_speed": [
+        "45"
+    ],
+    "filament_deretraction_speed": [
+        "40"
+    ],
+    "filament_wipe": [
+        "1"
+    ],
+    "filament_wipe_distance": [
+        "2"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "disable_fan_first_layers": [
+        "1"
+    ],
+    "full_fan_speed_layer": [
+        "3"
+    ],
+    "slow_down_layer_time": [
+        "5"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
+    "external_perimeter_speed": [
+        "50%"
+    ],
+    "compatible_printers": [],
+    "compatible_printers_condition": "",
+    "compatible_prints": [],
+    "compatible_prints_condition": ""
+}

--- a/resources/profiles/BBL/filament/COEX/COEX TPE 30D @base.json
+++ b/resources/profiles/BBL/filament/COEX/COEX TPE 30D @base.json
@@ -1,0 +1,91 @@
+{
+    "type": "filament",
+    "name": "COEX TPE 30D @base",
+    "inherits": "fdm_filament_tpu",
+    "from": "system",
+    "filament_id": "CX30DB20",
+    "instantiation": "false",
+    "filament_vendor": [
+        "COEX 3D"
+    ],
+    "filament_cost": [
+        "80.00"
+    ],
+    "filament_density": [
+        "1.15"
+    ],
+    "filament_type": [
+        "TPU"
+    ],
+    "filament_notes": "Flexible filament - print slowly with minimal retraction",
+    "nozzle_temperature": [
+        "240"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "240"
+    ],
+    "bed_temperature": [
+        "30"
+    ],
+    "bed_temperature_initial_layer": [
+        "35"
+    ],
+    "temperature_vitrification": [
+        "60"
+    ],
+    "filament_max_volumetric_speed": [
+        "3.5"
+    ],
+    "filament_retraction_minimum_travel": [
+        "3"
+    ],
+    "filament_retract_before_wipe": [
+        "0%"
+    ],
+    "filament_retract_layer_change": [
+        "0"
+    ],
+    "filament_retract_when_changing_layer": [
+        "0"
+    ],
+    "filament_retraction_length": [
+        "0.4"
+    ],
+    "filament_retraction_speed": [
+        "20"
+    ],
+    "filament_deretraction_speed": [
+        "20"
+    ],
+    "filament_wipe": [
+        "0"
+    ],
+    "filament_wipe_distance": [
+        "0"
+    ],
+    "fan_min_speed": [
+        "80"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "disable_fan_first_layers": [
+        "1"
+    ],
+    "full_fan_speed_layer": [
+        "2"
+    ],
+    "slow_down_layer_time": [
+        "10"
+    ],
+    "slow_down_min_speed": [
+        "5"
+    ],
+    "enable_pressure_advance": [
+        "0"
+    ],
+    "compatible_printers": [],
+    "compatible_printers_condition": "",
+    "compatible_prints": [],
+    "compatible_prints_condition": ""
+}

--- a/resources/profiles/BBL/filament/COEX/COEX TPE 40D @base.json
+++ b/resources/profiles/BBL/filament/COEX/COEX TPE 40D @base.json
@@ -1,0 +1,91 @@
+{
+    "type": "filament",
+    "name": "COEX TPE 40D @base",
+    "inherits": "fdm_filament_tpu",
+    "from": "system",
+    "filament_id": "CX40DB20",
+    "instantiation": "false",
+    "filament_vendor": [
+        "COEX 3D"
+    ],
+    "filament_cost": [
+        "80.00"
+    ],
+    "filament_density": [
+        "1.18"
+    ],
+    "filament_type": [
+        "TPU"
+    ],
+    "filament_notes": "Flexible filament - print slowly with minimal retraction",
+    "nozzle_temperature": [
+        "240"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "240"
+    ],
+    "bed_temperature": [
+        "30"
+    ],
+    "bed_temperature_initial_layer": [
+        "35"
+    ],
+    "temperature_vitrification": [
+        "60"
+    ],
+    "filament_max_volumetric_speed": [
+        "5.5"
+    ],
+    "filament_retraction_minimum_travel": [
+        "3"
+    ],
+    "filament_retract_before_wipe": [
+        "0%"
+    ],
+    "filament_retract_layer_change": [
+        "0"
+    ],
+    "filament_retract_when_changing_layer": [
+        "0"
+    ],
+    "filament_retraction_length": [
+        "0.4"
+    ],
+    "filament_retraction_speed": [
+        "20"
+    ],
+    "filament_deretraction_speed": [
+        "20"
+    ],
+    "filament_wipe": [
+        "0"
+    ],
+    "filament_wipe_distance": [
+        "0"
+    ],
+    "fan_min_speed": [
+        "80"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "disable_fan_first_layers": [
+        "1"
+    ],
+    "full_fan_speed_layer": [
+        "2"
+    ],
+    "slow_down_layer_time": [
+        "10"
+    ],
+    "slow_down_min_speed": [
+        "5"
+    ],
+    "enable_pressure_advance": [
+        "0"
+    ],
+    "compatible_printers": [],
+    "compatible_printers_condition": "",
+    "compatible_prints": [],
+    "compatible_prints_condition": ""
+}

--- a/resources/profiles/BBL/filament/COEX/COEX TPE 60D @base.json
+++ b/resources/profiles/BBL/filament/COEX/COEX TPE 60D @base.json
@@ -1,0 +1,91 @@
+{
+    "type": "filament",
+    "name": "COEX TPE 60D @base",
+    "inherits": "fdm_filament_tpu",
+    "from": "system",
+    "filament_id": "CX60DB19",
+    "instantiation": "false",
+    "filament_vendor": [
+        "COEX 3D"
+    ],
+    "filament_cost": [
+        "80.00"
+    ],
+    "filament_density": [
+        "1.20"
+    ],
+    "filament_type": [
+        "TPU"
+    ],
+    "filament_notes": "Flexible filament - print slowly with minimal retraction",
+    "nozzle_temperature": [
+        "240"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "240"
+    ],
+    "bed_temperature": [
+        "30"
+    ],
+    "bed_temperature_initial_layer": [
+        "35"
+    ],
+    "temperature_vitrification": [
+        "60"
+    ],
+    "filament_max_volumetric_speed": [
+        "6.5"
+    ],
+    "filament_retraction_minimum_travel": [
+        "3"
+    ],
+    "filament_retract_before_wipe": [
+        "0%"
+    ],
+    "filament_retract_layer_change": [
+        "0"
+    ],
+    "filament_retract_when_changing_layer": [
+        "0"
+    ],
+    "filament_retraction_length": [
+        "0.4"
+    ],
+    "filament_retraction_speed": [
+        "20"
+    ],
+    "filament_deretraction_speed": [
+        "20"
+    ],
+    "filament_wipe": [
+        "0"
+    ],
+    "filament_wipe_distance": [
+        "0"
+    ],
+    "fan_min_speed": [
+        "80"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "disable_fan_first_layers": [
+        "1"
+    ],
+    "full_fan_speed_layer": [
+        "2"
+    ],
+    "slow_down_layer_time": [
+        "10"
+    ],
+    "slow_down_min_speed": [
+        "5"
+    ],
+    "enable_pressure_advance": [
+        "0"
+    ],
+    "compatible_printers": [],
+    "compatible_printers_condition": "",
+    "compatible_prints": [],
+    "compatible_prints_condition": ""
+}

--- a/resources/profiles/BBL/filament/COEX/COEX TPU 60A @base.json
+++ b/resources/profiles/BBL/filament/COEX/COEX TPU 60A @base.json
@@ -1,0 +1,91 @@
+{
+    "type": "filament",
+    "name": "COEX TPU 60A @base",
+    "inherits": "fdm_filament_tpu",
+    "from": "system",
+    "filament_id": "CX60AB17",
+    "instantiation": "false",
+    "filament_vendor": [
+        "COEX 3D"
+    ],
+    "filament_cost": [
+        "95.00"
+    ],
+    "filament_density": [
+        "1.14"
+    ],
+    "filament_type": [
+        "TPU"
+    ],
+    "filament_notes": "Flexible filament - print slowly with minimal retraction",
+    "nozzle_temperature": [
+        "225"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "225"
+    ],
+    "bed_temperature": [
+        "0"
+    ],
+    "bed_temperature_initial_layer": [
+        "0"
+    ],
+    "temperature_vitrification": [
+        "60"
+    ],
+    "filament_max_volumetric_speed": [
+        "1"
+    ],
+    "filament_retraction_minimum_travel": [
+        "3"
+    ],
+    "filament_retract_before_wipe": [
+        "0%"
+    ],
+    "filament_retract_layer_change": [
+        "0"
+    ],
+    "filament_retract_when_changing_layer": [
+        "0"
+    ],
+    "filament_retraction_length": [
+        "0"
+    ],
+    "filament_retraction_speed": [
+        "20"
+    ],
+    "filament_deretraction_speed": [
+        "20"
+    ],
+    "filament_wipe": [
+        "0"
+    ],
+    "filament_wipe_distance": [
+        "0"
+    ],
+    "fan_min_speed": [
+        "80"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "disable_fan_first_layers": [
+        "1"
+    ],
+    "full_fan_speed_layer": [
+        "2"
+    ],
+    "slow_down_layer_time": [
+        "10"
+    ],
+    "slow_down_min_speed": [
+        "5"
+    ],
+    "enable_pressure_advance": [
+        "0"
+    ],
+    "compatible_printers": [],
+    "compatible_printers_condition": "",
+    "compatible_prints": [],
+    "compatible_prints_condition": ""
+}

--- a/resources/profiles/BBL/filament/Overture/Overture ASA @base.json
+++ b/resources/profiles/BBL/filament/Overture/Overture ASA @base.json
@@ -1,0 +1,62 @@
+{
+    "type": "filament",
+    "name": "Overture ASA @base",
+    "inherits": "fdm_filament_asa",
+    "from": "system",
+    "filament_id": "GFOT009",
+    "instantiation": "false",
+    "fan_cooling_layer_time": [
+        "45"
+    ],
+    "fan_max_speed": [
+        "60"
+    ],
+    "fan_min_speed": [
+        "10"
+    ],
+    "filament_cost": [
+        "29.99"
+    ],
+    "filament_density": [
+        "1.14"
+    ],
+    "filament_flow_ratio": [
+        "0.95"
+    ],
+    "filament_max_volumetric_speed": [
+        "10"
+    ],
+    "filament_vendor": [
+        "Overture"
+    ],
+    "hot_plate_temp": [
+        "100"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "100"
+    ],
+    "nozzle_temperature": [
+        "270"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "270"
+    ],
+    "nozzle_temperature_range_high": [
+        "270"
+    ],
+    "nozzle_temperature_range_low": [
+        "240"
+    ],
+    "slow_down_layer_time": [
+        "2"
+    ],
+    "temperature_vitrification": [
+        "106"
+    ],
+    "textured_plate_temp": [
+        "100"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "100"
+    ]
+}

--- a/resources/profiles/BBL/filament/Overture/Overture Air PLA @base.json
+++ b/resources/profiles/BBL/filament/Overture/Overture Air PLA @base.json
@@ -1,0 +1,41 @@
+{
+    "type": "filament",
+    "name": "Overture Air PLA @base",
+    "inherits": "fdm_filament_pla",
+    "from": "system",
+    "filament_id": "GFOT006",
+    "instantiation": "false",
+    "filament_cost": [
+        "27.99"
+    ],
+    "filament_density": [
+        "0.82"
+    ],
+    "filament_flow_ratio": [
+        "0.95"
+    ],
+    "filament_max_volumetric_speed": [
+        "8"
+    ],
+    "filament_vendor": [
+        "Overture"
+    ],
+    "nozzle_temperature": [
+        "220"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "220"
+    ],
+    "nozzle_temperature_range_high": [
+        "220"
+    ],
+    "nozzle_temperature_range_low": [
+        "190"
+    ],
+    "slow_down_layer_time": [
+        "4"
+    ],
+    "temperature_vitrification": [
+        "64"
+    ]
+}

--- a/resources/profiles/BBL/filament/Overture/Overture Easy PLA @base.json
+++ b/resources/profiles/BBL/filament/Overture/Overture Easy PLA @base.json
@@ -1,0 +1,41 @@
+{
+    "type": "filament",
+    "name": "Overture Easy PLA @base",
+    "inherits": "fdm_filament_pla",
+    "from": "system",
+    "filament_id": "GFOT003",
+    "instantiation": "false",
+    "filament_cost": [
+        "17.99"
+    ],
+    "filament_density": [
+        "1.2"
+    ],
+    "filament_flow_ratio": [
+        "0.98"
+    ],
+    "filament_max_volumetric_speed": [
+        "16"
+    ],
+    "filament_vendor": [
+        "Overture"
+    ],
+    "nozzle_temperature": [
+        "220"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "220"
+    ],
+    "nozzle_temperature_range_high": [
+        "220"
+    ],
+    "nozzle_temperature_range_low": [
+        "190"
+    ],
+    "slow_down_layer_time": [
+        "4"
+    ],
+    "temperature_vitrification": [
+        "66"
+    ]
+}

--- a/resources/profiles/BBL/filament/Overture/Overture Rock PLA @base.json
+++ b/resources/profiles/BBL/filament/Overture/Overture Rock PLA @base.json
@@ -1,0 +1,41 @@
+{
+    "type": "filament",
+    "name": "Overture Rock PLA @base",
+    "inherits": "fdm_filament_pla",
+    "from": "system",
+    "filament_id": "GFOT004",
+    "instantiation": "false",
+    "filament_cost": [
+        "24.99"
+    ],
+    "filament_density": [
+        "1.3"
+    ],
+    "filament_flow_ratio": [
+        "0.98"
+    ],
+    "filament_max_volumetric_speed": [
+        "20"
+    ],
+    "filament_vendor": [
+        "Overture"
+    ],
+    "nozzle_temperature": [
+        "220"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "220"
+    ],
+    "nozzle_temperature_range_high": [
+        "230"
+    ],
+    "nozzle_temperature_range_low": [
+        "190"
+    ],
+    "slow_down_layer_time": [
+        "4"
+    ],
+    "temperature_vitrification": [
+        "63"
+    ]
+}

--- a/resources/profiles/BBL/filament/Overture/Overture Silk PLA @base.json
+++ b/resources/profiles/BBL/filament/Overture/Overture Silk PLA @base.json
@@ -1,0 +1,41 @@
+{
+    "type": "filament",
+    "name": "Overture Silk PLA @base",
+    "inherits": "fdm_filament_pla",
+    "from": "system",
+    "filament_id": "GFOT002",
+    "instantiation": "false",
+    "filament_cost": [
+        "25.99"
+    ],
+    "filament_density": [
+        "1.19"
+    ],
+    "filament_flow_ratio": [
+        "0.95"
+    ],
+    "filament_max_volumetric_speed": [
+        "16"
+    ],
+    "filament_vendor": [
+        "Overture"
+    ],
+    "nozzle_temperature": [
+        "220"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "220"
+    ],
+    "nozzle_temperature_range_high": [
+        "220"
+    ],
+    "nozzle_temperature_range_low": [
+        "200"
+    ],
+    "slow_down_layer_time": [
+        "4"
+    ],
+    "temperature_vitrification": [
+        "58"
+    ]
+}

--- a/resources/profiles/BBL/filament/Overture/Overture Super PLA+ @base.json
+++ b/resources/profiles/BBL/filament/Overture/Overture Super PLA+ @base.json
@@ -1,0 +1,41 @@
+{
+    "type": "filament",
+    "name": "Overture Super PLA+ @base",
+    "inherits": "fdm_filament_pla",
+    "from": "system",
+    "filament_id": "GFOT005",
+    "instantiation": "false",
+    "filament_cost": [
+        "28.99"
+    ],
+    "filament_density": [
+        "1.21"
+    ],
+    "filament_flow_ratio": [
+        "0.98"
+    ],
+    "filament_max_volumetric_speed": [
+        "16"
+    ],
+    "filament_vendor": [
+        "Overture"
+    ],
+    "nozzle_temperature": [
+        "220"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "220"
+    ],
+    "nozzle_temperature_range_high": [
+        "230"
+    ],
+    "nozzle_temperature_range_low": [
+        "190"
+    ],
+    "slow_down_layer_time": [
+        "4"
+    ],
+    "temperature_vitrification": [
+        "63"
+    ]
+}

--- a/resources/profiles/BBL/filament/Overture/Overture TPU @base.json
+++ b/resources/profiles/BBL/filament/Overture/Overture TPU @base.json
@@ -1,0 +1,50 @@
+{
+    "type": "filament",
+    "name": "Overture TPU @base",
+    "inherits": "fdm_filament_tpu",
+    "from": "system",
+    "filament_id": "GFOT008",
+    "instantiation": "false",
+    "fan_cooling_layer_time": [
+        "100"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
+    "filament_cost": [
+        "29.99"
+    ],
+    "filament_density": [
+        "1.18"
+    ],
+    "filament_flow_ratio": [
+        "1"
+    ],
+    "filament_max_volumetric_speed": [
+        "10"
+    ],
+    "filament_vendor": [
+        "Overture"
+    ],
+    "nozzle_temperature": [
+        "220"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "220"
+    ],
+    "nozzle_temperature_range_high": [
+        "230"
+    ],
+    "nozzle_temperature_range_low": [
+        "210"
+    ],
+    "slow_down_layer_time": [
+        "15"
+    ],
+    "temperature_vitrification": [
+        "30"
+    ]
+}

--- a/resources/profiles/BBL/filament/fdm_filament_pla_silk.json
+++ b/resources/profiles/BBL/filament/fdm_filament_pla_silk.json
@@ -1,0 +1,15 @@
+{
+    "type": "filament",
+    "name": "fdm_filament_pla_silk",
+    "inherits": "fdm_filament_pla",
+    "from": "system",
+    "filament_id": "OGFL96",
+    "instantiation": "false",
+    "description": "To make the prints get higher gloss, please dry the filament before use, and set the outer wall speed to be 40 to 60 mm/s when slicing.",
+    "filament_flow_ratio": [
+        "0.98"
+    ],
+    "slow_down_layer_time": [
+        "8"
+    ]
+}

--- a/resources/profiles/Chuanying.json
+++ b/resources/profiles/Chuanying.json
@@ -46,6 +46,34 @@
     ],
     "filament_list": [
         {
+            "name": "fdm_filament_common",
+            "sub_path": "filament/fdm_filament_common.json"
+        },
+        {
+            "name": "fdm_filament_abs",
+            "sub_path": "filament/fdm_filament_abs.json"
+        },
+        {
+            "name": "fdm_filament_asa",
+            "sub_path": "filament/fdm_filament_asa.json"
+        },
+        {
+            "name": "fdm_filament_pet",
+            "sub_path": "filament/fdm_filament_pet.json"
+        },
+        {
+            "name": "fdm_filament_pla",
+            "sub_path": "filament/fdm_filament_pla.json"
+        },
+        {
+            "name": "fdm_filament_pva",
+            "sub_path": "filament/fdm_filament_pva.json"
+        },
+        {
+            "name": "fdm_filament_tpu",
+            "sub_path": "filament/fdm_filament_tpu.json"
+        },
+        {
             "name": "Chuanying Generic ABS",
             "sub_path": "filament/Chuanying Generic ABS.json"
         },

--- a/resources/profiles/Chuanying.json
+++ b/resources/profiles/Chuanying.json
@@ -1,7 +1,7 @@
 {
     "name": "Chuanying",
     "url": "",
-    "version": "02.03.01.10",
+    "version": "02.03.02.10",
     "force_update": "0",
     "description": "Chuanying configurations",
     "machine_model_list": [

--- a/resources/profiles/Chuanying/filament/Chuanying Generic ABS.json
+++ b/resources/profiles/Chuanying/filament/Chuanying Generic ABS.json
@@ -1,6 +1,7 @@
 {
     "type": "filament",
     "name": "Chuanying Generic ABS",
+    "inherits": "fdm_filament_abs",
     "from": "system",
     "setting_id": "GFSA04",
     "filament_id": "GFB99",

--- a/resources/profiles/Chuanying/filament/Chuanying Generic ABS.json
+++ b/resources/profiles/Chuanying/filament/Chuanying Generic ABS.json
@@ -1,7 +1,6 @@
 {
     "type": "filament",
     "name": "Chuanying Generic ABS",
-    "inherits": "fdm_filament_abs",
     "from": "system",
     "setting_id": "GFSA04",
     "filament_id": "GFB99",

--- a/resources/profiles/Chuanying/filament/Chuanying Generic ASA.json
+++ b/resources/profiles/Chuanying/filament/Chuanying Generic ASA.json
@@ -1,7 +1,6 @@
 {
     "type": "filament",
     "name": "Chuanying Generic ASA",
-    "inherits": "fdm_filament_asa",
     "from": "system",
     "setting_id": "GFSA04",
     "filament_id": "GFL99",

--- a/resources/profiles/Chuanying/filament/Chuanying Generic ASA.json
+++ b/resources/profiles/Chuanying/filament/Chuanying Generic ASA.json
@@ -1,6 +1,7 @@
 {
     "type": "filament",
     "name": "Chuanying Generic ASA",
+    "inherits": "fdm_filament_asa",
     "from": "system",
     "setting_id": "GFSA04",
     "filament_id": "GFL99",

--- a/resources/profiles/Chuanying/filament/Chuanying Generic HS PLA.json
+++ b/resources/profiles/Chuanying/filament/Chuanying Generic HS PLA.json
@@ -1,7 +1,6 @@
 {
     "type": "filament",
     "name": "Chuanying Generic HS PLA",
-    "inherits": "fdm_filament_pla",
     "from": "system",
     "setting_id": "GFSA04",
     "filament_id": "GFL99",

--- a/resources/profiles/Chuanying/filament/Chuanying Generic HS PLA.json
+++ b/resources/profiles/Chuanying/filament/Chuanying Generic HS PLA.json
@@ -1,6 +1,7 @@
 {
     "type": "filament",
     "name": "Chuanying Generic HS PLA",
+    "inherits": "fdm_filament_pla",
     "from": "system",
     "setting_id": "GFSA04",
     "filament_id": "GFL99",

--- a/resources/profiles/Chuanying/filament/Chuanying Generic PETG-CF10.json
+++ b/resources/profiles/Chuanying/filament/Chuanying Generic PETG-CF10.json
@@ -1,7 +1,6 @@
 {
     "type": "filament",
     "name": "Chuanying Generic PETG-CF10",
-    "inherits": "fdm_filament_pet",
     "from": "system",
     "setting_id": "GFSA04",
     "filament_id": "GFG99",

--- a/resources/profiles/Chuanying/filament/Chuanying Generic PETG-CF10.json
+++ b/resources/profiles/Chuanying/filament/Chuanying Generic PETG-CF10.json
@@ -1,6 +1,7 @@
 {
     "type": "filament",
     "name": "Chuanying Generic PETG-CF10",
+    "inherits": "fdm_filament_pet",
     "from": "system",
     "setting_id": "GFSA04",
     "filament_id": "GFG99",

--- a/resources/profiles/Chuanying/filament/Chuanying Generic PETG.json
+++ b/resources/profiles/Chuanying/filament/Chuanying Generic PETG.json
@@ -1,6 +1,7 @@
 {
     "type": "filament",
     "name": "Chuanying Generic PETG",
+    "inherits": "fdm_filament_pet",
     "from": "system",
     "setting_id": "GFSA04",
     "filament_id": "GFG99",

--- a/resources/profiles/Chuanying/filament/Chuanying Generic PETG.json
+++ b/resources/profiles/Chuanying/filament/Chuanying Generic PETG.json
@@ -1,7 +1,6 @@
 {
     "type": "filament",
     "name": "Chuanying Generic PETG",
-    "inherits": "fdm_filament_pet",
     "from": "system",
     "setting_id": "GFSA04",
     "filament_id": "GFG99",

--- a/resources/profiles/Chuanying/filament/Chuanying Generic PLA-CF10.json
+++ b/resources/profiles/Chuanying/filament/Chuanying Generic PLA-CF10.json
@@ -1,6 +1,7 @@
 {
     "type": "filament",
     "name": "Chuanying Generic PLA-CF10",
+    "inherits": "fdm_filament_pla",
     "from": "system",
     "setting_id": "GFSA04",
     "filament_id": "GFL99",

--- a/resources/profiles/Chuanying/filament/Chuanying Generic PLA-CF10.json
+++ b/resources/profiles/Chuanying/filament/Chuanying Generic PLA-CF10.json
@@ -1,7 +1,6 @@
 {
     "type": "filament",
     "name": "Chuanying Generic PLA-CF10",
-    "inherits": "fdm_filament_pla",
     "from": "system",
     "setting_id": "GFSA04",
     "filament_id": "GFL99",

--- a/resources/profiles/Chuanying/filament/Chuanying Generic PLA-Silk.json
+++ b/resources/profiles/Chuanying/filament/Chuanying Generic PLA-Silk.json
@@ -1,6 +1,7 @@
 {
     "type": "filament",
     "name": "Chuanying Generic PLA-Silk",
+    "inherits": "fdm_filament_pla",
     "from": "system",
     "setting_id": "GFSA04",
     "filament_id": "GFL99",

--- a/resources/profiles/Chuanying/filament/Chuanying Generic PLA-Silk.json
+++ b/resources/profiles/Chuanying/filament/Chuanying Generic PLA-Silk.json
@@ -1,7 +1,6 @@
 {
     "type": "filament",
     "name": "Chuanying Generic PLA-Silk",
-    "inherits": "fdm_filament_pla",
     "from": "system",
     "setting_id": "GFSA04",
     "filament_id": "GFL99",

--- a/resources/profiles/Chuanying/filament/Chuanying Generic PLA.json
+++ b/resources/profiles/Chuanying/filament/Chuanying Generic PLA.json
@@ -1,7 +1,6 @@
 {
     "type": "filament",
     "name": "Chuanying Generic PLA",
-    "inherits": "fdm_filament_pla",
     "from": "system",
     "setting_id": "GFSA04",
     "filament_id": "GFL99",

--- a/resources/profiles/Chuanying/filament/Chuanying Generic PLA.json
+++ b/resources/profiles/Chuanying/filament/Chuanying Generic PLA.json
@@ -1,6 +1,7 @@
 {
     "type": "filament",
     "name": "Chuanying Generic PLA",
+    "inherits": "fdm_filament_pla",
     "from": "system",
     "setting_id": "GFSA04",
     "filament_id": "GFL99",

--- a/resources/profiles/Chuanying/filament/Chuanying Generic TPU.json
+++ b/resources/profiles/Chuanying/filament/Chuanying Generic TPU.json
@@ -1,7 +1,6 @@
 {
     "type": "filament",
     "name": "Chuanying Generic TPU",
-    "inherits": "fdm_filament_tpu",
     "from": "system",
     "setting_id": "GFSA04",
     "filament_id": "GFG99",
@@ -19,13 +18,7 @@
     "compatible_printers": [
         "Chuanying X1 0.4 Nozzle",
         "Chuanying X1 0.6 Nozzle",
-        "Chuanying X1 0.8 Nozzle",
-        "Chuanying Adventurer 5M 0.4 Nozzle",
-        "Chuanying Adventurer 5M 0.6 Nozzle",
-        "Chuanying Adventurer 5M 0.8 Nozzle",
-        "Chuanying Adventurer 5M Pro 0.4 Nozzle",
-        "Chuanying Adventurer 5M Pro 0.6 Nozzle",
-        "Chuanying Adventurer 5M Pro 0.8 Nozzle"
+        "Chuanying X1 0.8 Nozzle"
     ],
     "compatible_printers_condition": "",
     "compatible_prints": [],

--- a/resources/profiles/Chuanying/filament/Chuanying Generic TPU.json
+++ b/resources/profiles/Chuanying/filament/Chuanying Generic TPU.json
@@ -19,13 +19,7 @@
     "compatible_printers": [
         "Chuanying X1 0.4 Nozzle",
         "Chuanying X1 0.6 Nozzle",
-        "Chuanying X1 0.8 Nozzle",
-        "Chuanying Adventurer 5M 0.4 Nozzle",
-        "Chuanying Adventurer 5M 0.6 Nozzle",
-        "Chuanying Adventurer 5M 0.8 Nozzle",
-        "Chuanying Adventurer 5M Pro 0.4 Nozzle",
-        "Chuanying Adventurer 5M Pro 0.6 Nozzle",
-        "Chuanying Adventurer 5M Pro 0.8 Nozzle"
+        "Chuanying X1 0.8 Nozzle"
     ],
     "compatible_printers_condition": "",
     "compatible_prints": [],

--- a/resources/profiles/Chuanying/filament/Chuanying Generic TPU.json
+++ b/resources/profiles/Chuanying/filament/Chuanying Generic TPU.json
@@ -1,6 +1,7 @@
 {
     "type": "filament",
     "name": "Chuanying Generic TPU",
+    "inherits": "fdm_filament_tpu",
     "from": "system",
     "setting_id": "GFSA04",
     "filament_id": "GFG99",
@@ -18,7 +19,13 @@
     "compatible_printers": [
         "Chuanying X1 0.4 Nozzle",
         "Chuanying X1 0.6 Nozzle",
-        "Chuanying X1 0.8 Nozzle"
+        "Chuanying X1 0.8 Nozzle",
+        "Chuanying Adventurer 5M 0.4 Nozzle",
+        "Chuanying Adventurer 5M 0.6 Nozzle",
+        "Chuanying Adventurer 5M 0.8 Nozzle",
+        "Chuanying Adventurer 5M Pro 0.4 Nozzle",
+        "Chuanying Adventurer 5M Pro 0.6 Nozzle",
+        "Chuanying Adventurer 5M Pro 0.8 Nozzle"
     ],
     "compatible_printers_condition": "",
     "compatible_prints": [],

--- a/resources/profiles/Chuanying/filament/fdm_filament_abs.json
+++ b/resources/profiles/Chuanying/filament/fdm_filament_abs.json
@@ -1,0 +1,94 @@
+{
+    "type": "filament",
+    "name": "fdm_filament_abs",
+    "inherits": "fdm_filament_common",
+    "from": "system",
+    "instantiation": "false",
+    "activate_air_filtration": [
+        "0"
+    ],
+    "supertack_plate_temp": [
+        "0"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "0"
+    ],
+    "cool_plate_temp": [
+        "0"
+    ],
+    "cool_plate_temp_initial_layer": [
+        "0"
+    ],
+    "eng_plate_temp": [
+        "100"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "105"
+    ],
+    "fan_cooling_layer_time": [
+        "30"
+    ],
+    "fan_max_speed": [
+        "80"
+    ],
+    "fan_min_speed": [
+        "10"
+    ],
+    "filament_cost": [
+        "20"
+    ],
+    "filament_density": [
+        "1.04"
+    ],
+    "filament_max_volumetric_speed": [
+        "12"
+    ],
+    "filament_type": [
+        "ABS"
+    ],
+    "hot_plate_temp": [
+        "100"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "105"
+    ],
+    "nozzle_temperature": [
+        "260"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "260"
+    ],
+    "nozzle_temperature_range_high": [
+        "280"
+    ],
+    "nozzle_temperature_range_low": [
+        "240"
+    ],
+    "overhang_fan_speed": [
+        "80"
+    ],
+    "overhang_fan_threshold": [
+        "25%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "3"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
+    "textured_plate_temp": [
+        "100"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "105"
+    ],
+    "filament_flow_ratio": [
+        "0.926"
+    ],
+    "temperature_vitrification": [
+        "110"
+    ]
+}

--- a/resources/profiles/Chuanying/filament/fdm_filament_asa.json
+++ b/resources/profiles/Chuanying/filament/fdm_filament_asa.json
@@ -1,0 +1,94 @@
+{
+    "type": "filament",
+    "name": "fdm_filament_asa",
+    "inherits": "fdm_filament_common",
+    "from": "system",
+    "instantiation": "false",
+    "activate_air_filtration": [
+        "0"
+    ],
+    "supertack_plate_temp": [
+        "0"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "0"
+    ],
+    "cool_plate_temp": [
+        "0"
+    ],
+    "cool_plate_temp_initial_layer": [
+        "0"
+    ],
+    "eng_plate_temp": [
+        "100"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "105"
+    ],
+    "fan_cooling_layer_time": [
+        "35"
+    ],
+    "fan_max_speed": [
+        "80"
+    ],
+    "fan_min_speed": [
+        "10"
+    ],
+    "filament_cost": [
+        "20"
+    ],
+    "filament_density": [
+        "1.04"
+    ],
+    "filament_max_volumetric_speed": [
+        "12"
+    ],
+    "filament_type": [
+        "ASA"
+    ],
+    "hot_plate_temp": [
+        "100"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "105"
+    ],
+    "nozzle_temperature": [
+        "260"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "260"
+    ],
+    "nozzle_temperature_range_high": [
+        "280"
+    ],
+    "nozzle_temperature_range_low": [
+        "240"
+    ],
+    "overhang_fan_speed": [
+        "80"
+    ],
+    "overhang_fan_threshold": [
+        "25%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "3"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
+    "textured_plate_temp": [
+        "100"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "105"
+    ],
+    "filament_flow_ratio": [
+        "0.926"
+    ],
+    "temperature_vitrification": [
+        "110"
+    ]
+}

--- a/resources/profiles/Chuanying/filament/fdm_filament_common.json
+++ b/resources/profiles/Chuanying/filament/fdm_filament_common.json
@@ -1,0 +1,187 @@
+{
+    "type": "filament",
+    "name": "fdm_filament_common",
+    "from": "system",
+    "instantiation": "false",
+    "activate_air_filtration": [
+        "0"
+    ],
+    "chamber_temperatures": [
+        "0"
+    ],
+    "close_fan_the_first_x_layers": [
+        "3"
+    ],
+    "complete_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "cool_plate_temp": [
+        "60"
+    ],
+    "cool_plate_temp_initial_layer": [
+        "60"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "eng_plate_temp": [
+        "60"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "60"
+    ],
+    "fan_cooling_layer_time": [
+        "60"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "35"
+    ],
+    "filament_cost": [
+        "0"
+    ],
+    "filament_density": [
+        "0"
+    ],
+    "filament_deretraction_speed": [
+        "nil"
+    ],
+    "filament_diameter": [
+        "1.75"
+    ],
+    "filament_flow_ratio": [
+        "1"
+    ],
+    "filament_is_support": [
+        "0"
+    ],
+    "filament_long_retractions_when_cut": [
+        "nil"
+    ],
+    "filament_max_volumetric_speed": [
+        "0"
+    ],
+    "filament_minimal_purge_on_wipe_tower": [
+        "15"
+    ],
+    "filament_retract_before_wipe": [
+        "nil"
+    ],
+    "filament_retract_restart_extra": [
+        "nil"
+    ],
+    "filament_retract_when_changing_layer": [
+        "nil"
+    ],
+    "filament_retraction_distances_when_cut": [
+        "nil"
+    ],
+    "filament_retraction_length": [
+        "nil"
+    ],
+    "filament_retraction_minimum_travel": [
+        "nil"
+    ],
+    "filament_retraction_speed": [
+        "nil"
+    ],
+    "filament_settings_id": [
+        ""
+    ],
+    "filament_soluble": [
+        "0"
+    ],
+    "filament_type": [
+        "PLA"
+    ],
+    "filament_vendor": [
+        "Generic"
+    ],
+    "filament_wipe": [
+        "nil"
+    ],
+    "filament_wipe_distance": [
+        "nil"
+    ],
+    "filament_z_hop": [
+        "nil"
+    ],
+    "filament_z_hop_types": [
+        "nil"
+    ],
+    "full_fan_speed_layer": [
+        "0"
+    ],
+    "filament_scarf_seam_type": [
+        "none"
+    ],
+    "filament_scarf_height": [
+        "10%"
+    ],
+    "filament_scarf_gap": [
+        "0%"
+    ],
+    "filament_scarf_length": [
+        "10"
+    ],
+    "filament_shrink": [
+        "100%"
+    ],
+    "hot_plate_temp": [
+        "60"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "60"
+    ],
+    "nozzle_temperature": [
+        "200"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "200"
+    ],
+    "overhang_fan_speed": [
+        "100"
+    ],
+    "overhang_fan_threshold": [
+        "95%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "0"
+    ],
+    "required_nozzle_HRC": [
+        "3"
+    ],
+    "supertack_plate_temp": [
+        "45"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "45"
+    ],
+    "slow_down_for_layer_cooling": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "8"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
+    "temperature_vitrification": [
+        "100"
+    ],
+    "textured_plate_temp": [
+        "60"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "60"
+    ],
+    "filament_start_gcode": [
+        "; Filament gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode\n"
+    ],
+    "compatible_printers": []
+}

--- a/resources/profiles/Chuanying/filament/fdm_filament_pet.json
+++ b/resources/profiles/Chuanying/filament/fdm_filament_pet.json
@@ -1,0 +1,68 @@
+{
+    "type": "filament",
+    "name": "fdm_filament_pet",
+    "inherits": "fdm_filament_common",
+    "from": "system",
+    "filament_id": "OGFG99",
+    "instantiation": "false",
+    "eng_plate_temp": [
+        "0"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "0"
+    ],
+    "fan_cooling_layer_time": [
+        "20"
+    ],
+    "fan_min_speed": [
+        "20"
+    ],
+    "filament_cost": [
+        "30"
+    ],
+    "filament_density": [
+        "1.27"
+    ],
+    "filament_max_volumetric_speed": [
+        "12"
+    ],
+    "filament_type": [
+        "PETG"
+    ],
+    "hot_plate_temp": [
+        "80"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "80"
+    ],
+    "nozzle_temperature": [
+        "255"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "255"
+    ],
+    "nozzle_temperature_range_high": [
+        "260"
+    ],
+    "nozzle_temperature_range_low": [
+        "220"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "supertack_plate_temp": [
+        "70"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "70"
+    ],
+    "temperature_vitrification": [
+        "70"
+    ],
+    "textured_plate_temp": [
+        "80"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "80"
+    ]
+}

--- a/resources/profiles/Chuanying/filament/fdm_filament_pla.json
+++ b/resources/profiles/Chuanying/filament/fdm_filament_pla.json
@@ -1,0 +1,89 @@
+{
+    "type": "filament",
+    "name": "fdm_filament_pla",
+    "inherits": "fdm_filament_common",
+    "from": "system",
+    "filament_id": "OGFL99",
+    "instantiation": "false",
+    "additional_cooling_fan_speed": [
+        "70"
+    ],
+    "close_fan_the_first_x_layers": [
+        "1"
+    ],
+    "cool_plate_temp": [
+        "35"
+    ],
+    "cool_plate_temp_initial_layer": [
+        "35"
+    ],
+    "eng_plate_temp": [
+        "0"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "0"
+    ],
+    "fan_cooling_layer_time": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
+    "filament_cost": [
+        "20"
+    ],
+    "filament_density": [
+        "1.24"
+    ],
+    "filament_max_volumetric_speed": [
+        "12"
+    ],
+    "filament_scarf_seam_type": [
+        "none"
+    ],
+    "filament_scarf_gap": [
+        "15%"
+    ],
+    "hot_plate_temp": [
+        "55"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "55"
+    ],
+    "nozzle_temperature": [
+        "220"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "220"
+    ],
+    "nozzle_temperature_range_low": [
+        "190"
+    ],
+    "nozzle_temperature_range_high": [
+        "240"
+    ],
+    "overhang_fan_threshold": [
+        "50%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "4"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
+    "temperature_vitrification": [
+        "45"
+    ],
+    "textured_plate_temp": [
+        "55"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "55"
+    ],
+    "filament_flow_ratio": [
+        "0.98"
+    ]
+}

--- a/resources/profiles/Chuanying/filament/fdm_filament_pva.json
+++ b/resources/profiles/Chuanying/filament/fdm_filament_pva.json
@@ -1,0 +1,97 @@
+{
+    "type": "filament",
+    "name": "fdm_filament_pva",
+    "inherits": "fdm_filament_common",
+    "from": "system",
+    "instantiation": "false",
+    "additional_cooling_fan_speed": [
+        "70"
+    ],
+    "close_fan_the_first_x_layers": [
+        "1"
+    ],
+    "cool_plate_temp": [
+        "45"
+    ],
+    "cool_plate_temp_initial_layer": [
+        "45"
+    ],
+    "eng_plate_temp": [
+        "0"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "0"
+    ],
+    "fan_cooling_layer_time": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
+    "filament_cost": [
+        "20"
+    ],
+    "filament_density": [
+        "1.24"
+    ],
+    "filament_is_support": [
+        "1"
+    ],
+    "filament_max_volumetric_speed": [
+        "12"
+    ],
+    "filament_soluble": [
+        "1"
+    ],
+    "filament_type": [
+        "PVA"
+    ],
+    "hot_plate_temp": [
+        "55"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "55"
+    ],
+    "nozzle_temperature": [
+        "220"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "220"
+    ],
+    "nozzle_temperature_range_high": [
+        "240"
+    ],
+    "nozzle_temperature_range_low": [
+        "190"
+    ],
+    "overhang_fan_threshold": [
+        "50%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "supertack_plate_temp": [
+        "35"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "35"
+    ],
+    "slow_down_layer_time": [
+        "4"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
+    "temperature_vitrification": [
+        "45"
+    ],
+    "textured_plate_temp": [
+        "55"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "55"
+    ],
+    "filament_flow_ratio": [
+        "0.95"
+    ]
+}

--- a/resources/profiles/Chuanying/filament/fdm_filament_tpu.json
+++ b/resources/profiles/Chuanying/filament/fdm_filament_tpu.json
@@ -1,0 +1,82 @@
+{
+    "type": "filament",
+    "name": "fdm_filament_tpu",
+    "inherits": "fdm_filament_common",
+    "from": "system",
+    "instantiation": "false",
+    "additional_cooling_fan_speed": [
+        "70"
+    ],
+    "close_fan_the_first_x_layers": [
+        "1"
+    ],
+    "supertack_plate_temp": [
+        "0"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "0"
+    ],
+    "cool_plate_temp": [
+        "30"
+    ],
+    "cool_plate_temp_initial_layer": [
+        "30"
+    ],
+    "eng_plate_temp": [
+        "30"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "30"
+    ],
+    "fan_cooling_layer_time": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
+    "filament_cost": [
+        "20"
+    ],
+    "filament_density": [
+        "1.24"
+    ],
+    "filament_max_volumetric_speed": [
+        "3.2"
+    ],
+    "filament_retraction_length": [
+        "0.4"
+    ],
+    "filament_type": [
+        "TPU"
+    ],
+    "hot_plate_temp": [
+        "35"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "35"
+    ],
+    "nozzle_temperature": [
+        "240"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "240"
+    ],
+    "nozzle_temperature_range_high": [
+        "250"
+    ],
+    "nozzle_temperature_range_low": [
+        "200"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "temperature_vitrification": [
+        "30"
+    ],
+    "textured_plate_temp": [
+        "35"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "35"
+    ]
+}

--- a/resources/profiles/Lulzbot.json
+++ b/resources/profiles/Lulzbot.json
@@ -62,6 +62,22 @@
     ],
     "filament_list": [
         {
+            "name": "fdm_filament_common",
+            "sub_path": "filament/fdm_filament_common.json"
+        },
+        {
+            "name": "fdm_filament_abs",
+            "sub_path": "filament/fdm_filament_abs.json"
+        },
+        {
+            "name": "fdm_filament_pet",
+            "sub_path": "filament/fdm_filament_pet.json"
+        },
+        {
+            "name": "fdm_filament_pla",
+            "sub_path": "filament/fdm_filament_pla.json"
+        },
+        {
             "name": "Lulzbot 2.85mm ABS",
             "sub_path": "filament/Lulzbot 2.85mm ABS.json"
         },

--- a/resources/profiles/Lulzbot/filament/Lulzbot 2.85mm ABS.json
+++ b/resources/profiles/Lulzbot/filament/Lulzbot 2.85mm ABS.json
@@ -1,7 +1,7 @@
 {
     "type": "filament",
     "name": "Lulzbot 2.85mm ABS",
-    "inherits": "Generic ABS @System",
+    "inherits": "fdm_filament_abs",
     "from": "system",
     "setting_id": "GFSA04",
     "filament_id": "GFB99",

--- a/resources/profiles/Lulzbot/filament/Lulzbot 2.85mm PETG.json
+++ b/resources/profiles/Lulzbot/filament/Lulzbot 2.85mm PETG.json
@@ -1,7 +1,7 @@
 {
     "type": "filament",
     "name": "Lulzbot 2.85mm PETG",
-    "inherits": "Generic PETG @System",
+    "inherits": "fdm_filament_pet",
     "from": "system",
     "setting_id": "GFSG99",
     "filament_id": "GFG99",

--- a/resources/profiles/Lulzbot/filament/Lulzbot 2.85mm PLA.json
+++ b/resources/profiles/Lulzbot/filament/Lulzbot 2.85mm PLA.json
@@ -1,7 +1,7 @@
 {
     "type": "filament",
     "name": "Lulzbot 2.85mm PLA",
-    "inherits": "Generic PLA @System",
+    "inherits": "fdm_filament_pla",
     "from": "system",
     "setting_id": "GFSL99",
     "filament_id": "GFL99",

--- a/resources/profiles/Lulzbot/filament/fdm_filament_abs.json
+++ b/resources/profiles/Lulzbot/filament/fdm_filament_abs.json
@@ -1,0 +1,94 @@
+{
+    "type": "filament",
+    "name": "fdm_filament_abs",
+    "inherits": "fdm_filament_common",
+    "from": "system",
+    "instantiation": "false",
+    "activate_air_filtration": [
+        "0"
+    ],
+    "supertack_plate_temp": [
+        "0"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "0"
+    ],
+    "cool_plate_temp": [
+        "0"
+    ],
+    "cool_plate_temp_initial_layer": [
+        "0"
+    ],
+    "eng_plate_temp": [
+        "100"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "105"
+    ],
+    "fan_cooling_layer_time": [
+        "30"
+    ],
+    "fan_max_speed": [
+        "80"
+    ],
+    "fan_min_speed": [
+        "10"
+    ],
+    "filament_cost": [
+        "20"
+    ],
+    "filament_density": [
+        "1.04"
+    ],
+    "filament_max_volumetric_speed": [
+        "12"
+    ],
+    "filament_type": [
+        "ABS"
+    ],
+    "hot_plate_temp": [
+        "100"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "105"
+    ],
+    "nozzle_temperature": [
+        "260"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "260"
+    ],
+    "nozzle_temperature_range_high": [
+        "280"
+    ],
+    "nozzle_temperature_range_low": [
+        "240"
+    ],
+    "overhang_fan_speed": [
+        "80"
+    ],
+    "overhang_fan_threshold": [
+        "25%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "3"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
+    "textured_plate_temp": [
+        "100"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "105"
+    ],
+    "filament_flow_ratio": [
+        "0.926"
+    ],
+    "temperature_vitrification": [
+        "110"
+    ]
+}

--- a/resources/profiles/Lulzbot/filament/fdm_filament_common.json
+++ b/resources/profiles/Lulzbot/filament/fdm_filament_common.json
@@ -1,0 +1,187 @@
+{
+    "type": "filament",
+    "name": "fdm_filament_common",
+    "from": "system",
+    "instantiation": "false",
+    "activate_air_filtration": [
+        "0"
+    ],
+    "chamber_temperatures": [
+        "0"
+    ],
+    "close_fan_the_first_x_layers": [
+        "3"
+    ],
+    "complete_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "cool_plate_temp": [
+        "60"
+    ],
+    "cool_plate_temp_initial_layer": [
+        "60"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "eng_plate_temp": [
+        "60"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "60"
+    ],
+    "fan_cooling_layer_time": [
+        "60"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "35"
+    ],
+    "filament_cost": [
+        "0"
+    ],
+    "filament_density": [
+        "0"
+    ],
+    "filament_deretraction_speed": [
+        "nil"
+    ],
+    "filament_diameter": [
+        "1.75"
+    ],
+    "filament_flow_ratio": [
+        "1"
+    ],
+    "filament_is_support": [
+        "0"
+    ],
+    "filament_long_retractions_when_cut": [
+        "nil"
+    ],
+    "filament_max_volumetric_speed": [
+        "0"
+    ],
+    "filament_minimal_purge_on_wipe_tower": [
+        "15"
+    ],
+    "filament_retract_before_wipe": [
+        "nil"
+    ],
+    "filament_retract_restart_extra": [
+        "nil"
+    ],
+    "filament_retract_when_changing_layer": [
+        "nil"
+    ],
+    "filament_retraction_distances_when_cut": [
+        "nil"
+    ],
+    "filament_retraction_length": [
+        "nil"
+    ],
+    "filament_retraction_minimum_travel": [
+        "nil"
+    ],
+    "filament_retraction_speed": [
+        "nil"
+    ],
+    "filament_settings_id": [
+        ""
+    ],
+    "filament_soluble": [
+        "0"
+    ],
+    "filament_type": [
+        "PLA"
+    ],
+    "filament_vendor": [
+        "Generic"
+    ],
+    "filament_wipe": [
+        "nil"
+    ],
+    "filament_wipe_distance": [
+        "nil"
+    ],
+    "filament_z_hop": [
+        "nil"
+    ],
+    "filament_z_hop_types": [
+        "nil"
+    ],
+    "full_fan_speed_layer": [
+        "0"
+    ],
+    "filament_scarf_seam_type": [
+        "none"
+    ],
+    "filament_scarf_height": [
+        "10%"
+    ],
+    "filament_scarf_gap": [
+        "0%"
+    ],
+    "filament_scarf_length": [
+        "10"
+    ],
+    "filament_shrink": [
+        "100%"
+    ],
+    "hot_plate_temp": [
+        "60"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "60"
+    ],
+    "nozzle_temperature": [
+        "200"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "200"
+    ],
+    "overhang_fan_speed": [
+        "100"
+    ],
+    "overhang_fan_threshold": [
+        "95%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "0"
+    ],
+    "required_nozzle_HRC": [
+        "3"
+    ],
+    "supertack_plate_temp": [
+        "45"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "45"
+    ],
+    "slow_down_for_layer_cooling": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "8"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
+    "temperature_vitrification": [
+        "100"
+    ],
+    "textured_plate_temp": [
+        "60"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "60"
+    ],
+    "filament_start_gcode": [
+        "; Filament gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode\n"
+    ],
+    "compatible_printers": []
+}

--- a/resources/profiles/Lulzbot/filament/fdm_filament_pet.json
+++ b/resources/profiles/Lulzbot/filament/fdm_filament_pet.json
@@ -1,0 +1,68 @@
+{
+    "type": "filament",
+    "name": "fdm_filament_pet",
+    "inherits": "fdm_filament_common",
+    "from": "system",
+    "filament_id": "OGFG99",
+    "instantiation": "false",
+    "eng_plate_temp": [
+        "0"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "0"
+    ],
+    "fan_cooling_layer_time": [
+        "20"
+    ],
+    "fan_min_speed": [
+        "20"
+    ],
+    "filament_cost": [
+        "30"
+    ],
+    "filament_density": [
+        "1.27"
+    ],
+    "filament_max_volumetric_speed": [
+        "12"
+    ],
+    "filament_type": [
+        "PETG"
+    ],
+    "hot_plate_temp": [
+        "80"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "80"
+    ],
+    "nozzle_temperature": [
+        "255"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "255"
+    ],
+    "nozzle_temperature_range_high": [
+        "260"
+    ],
+    "nozzle_temperature_range_low": [
+        "220"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "supertack_plate_temp": [
+        "70"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "70"
+    ],
+    "temperature_vitrification": [
+        "70"
+    ],
+    "textured_plate_temp": [
+        "80"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "80"
+    ]
+}

--- a/resources/profiles/Lulzbot/filament/fdm_filament_pla.json
+++ b/resources/profiles/Lulzbot/filament/fdm_filament_pla.json
@@ -1,0 +1,89 @@
+{
+    "type": "filament",
+    "name": "fdm_filament_pla",
+    "inherits": "fdm_filament_common",
+    "from": "system",
+    "filament_id": "OGFL99",
+    "instantiation": "false",
+    "additional_cooling_fan_speed": [
+        "70"
+    ],
+    "close_fan_the_first_x_layers": [
+        "1"
+    ],
+    "cool_plate_temp": [
+        "35"
+    ],
+    "cool_plate_temp_initial_layer": [
+        "35"
+    ],
+    "eng_plate_temp": [
+        "0"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "0"
+    ],
+    "fan_cooling_layer_time": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
+    "filament_cost": [
+        "20"
+    ],
+    "filament_density": [
+        "1.24"
+    ],
+    "filament_max_volumetric_speed": [
+        "12"
+    ],
+    "filament_scarf_seam_type": [
+        "none"
+    ],
+    "filament_scarf_gap": [
+        "15%"
+    ],
+    "hot_plate_temp": [
+        "55"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "55"
+    ],
+    "nozzle_temperature": [
+        "220"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "220"
+    ],
+    "nozzle_temperature_range_low": [
+        "190"
+    ],
+    "nozzle_temperature_range_high": [
+        "240"
+    ],
+    "overhang_fan_threshold": [
+        "50%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "4"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
+    "temperature_vitrification": [
+        "45"
+    ],
+    "textured_plate_temp": [
+        "55"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "55"
+    ],
+    "filament_flow_ratio": [
+        "0.98"
+    ]
+}

--- a/resources/profiles/MagicMaker.json
+++ b/resources/profiles/MagicMaker.json
@@ -1,6 +1,6 @@
 {
     "name": "MagicMaker",
-    "version": "02.03.01.10",
+    "version": "02.03.02.10",
     "force_update": "0",
     "description": "MagicMaker configurations",
     "machine_model_list": [

--- a/resources/profiles/MagicMaker/filament/fdm_filament_peek.json
+++ b/resources/profiles/MagicMaker/filament/fdm_filament_peek.json
@@ -1,7 +1,6 @@
 {
     "type": "filament",
     "name": "fdm_filament_peek",
-    "inherits": "fdm_filament_common",
     "from": "system",
     "instantiation": "false",
     "cool_plate_temp": [

--- a/resources/profiles/Snapmaker.json
+++ b/resources/profiles/Snapmaker.json
@@ -461,6 +461,10 @@
     ],
     "filament_list": [
         {
+            "name": "PolyTerra PLA @base",
+            "sub_path": "filament/PolyTerra PLA @base.json"
+        },
+        {
             "name": "PolyTerra PLA @0.2 nozzle",
             "sub_path": "filament/PolyTerra PLA @0.2 nozzle.json"
         },

--- a/resources/profiles/Snapmaker.json
+++ b/resources/profiles/Snapmaker.json
@@ -1,6 +1,6 @@
 {
     "name": "Snapmaker",
-    "version": "02.03.01.10",
+    "version": "02.03.02.10",
     "force_update": "0",
     "description": "Snapmaker configurations",
     "machine_model_list": [

--- a/resources/profiles/Snapmaker.json
+++ b/resources/profiles/Snapmaker.json
@@ -461,48 +461,8 @@
     ],
     "filament_list": [
         {
-            "name": "PolyTerra PLA @base",
-            "sub_path": "filament/PolyTerra PLA @base.json"
-        },
-        {
-            "name": "PolyTerra PLA @0.2 nozzle",
-            "sub_path": "filament/PolyTerra PLA @0.2 nozzle.json"
-        },
-        {
-            "name": "Snapmaker PLA Lite @U1 base",
-            "sub_path": "filament/Snapmaker PLA Lite @U1 base.json"
-        },
-        {
-            "name": "Snapmaker PLA SnapSpeed @U1 base",
-            "sub_path": "filament/Snapmaker PLA SnapSpeed @U1 base.json"
-        },
-        {
-            "name": "Snapmaker TPU 95A @U1 base",
-            "sub_path": "filament/Snapmaker TPU 95A @U1 base.json"
-        },
-        {
             "name": "fdm_filament_common",
             "sub_path": "filament/fdm_filament_common.json"
-        },
-        {
-            "name": "PolyTerra Dual PLA @0.2 nozzle",
-            "sub_path": "filament/PolyTerra Dual PLA @0.2 nozzle.json"
-        },
-        {
-            "name": "PolyTerra J1 PLA @0.2 nozzle",
-            "sub_path": "filament/PolyTerra J1 PLA @0.2 nozzle.json"
-        },
-        {
-            "name": "Snapmaker PLA Lite @U1",
-            "sub_path": "filament/Snapmaker PLA Lite @U1.json"
-        },
-        {
-            "name": "Snapmaker PLA SnapSpeed @U1",
-            "sub_path": "filament/Snapmaker PLA SnapSpeed @U1.json"
-        },
-        {
-            "name": "Snapmaker TPU 95A @U1",
-            "sub_path": "filament/Snapmaker TPU 95A @U1.json"
         },
         {
             "name": "fdm_filament_abs",
@@ -539,6 +499,46 @@
         {
             "name": "fdm_filament_tpu",
             "sub_path": "filament/fdm_filament_tpu.json"
+        },
+        {
+            "name": "PolyTerra PLA @base",
+            "sub_path": "filament/PolyTerra PLA @base.json"
+        },
+        {
+            "name": "PolyTerra PLA @0.2 nozzle",
+            "sub_path": "filament/PolyTerra PLA @0.2 nozzle.json"
+        },
+        {
+            "name": "Snapmaker PLA Lite @U1 base",
+            "sub_path": "filament/Snapmaker PLA Lite @U1 base.json"
+        },
+        {
+            "name": "Snapmaker PLA SnapSpeed @U1 base",
+            "sub_path": "filament/Snapmaker PLA SnapSpeed @U1 base.json"
+        },
+        {
+            "name": "Snapmaker TPU 95A @U1 base",
+            "sub_path": "filament/Snapmaker TPU 95A @U1 base.json"
+        },
+        {
+            "name": "PolyTerra Dual PLA @0.2 nozzle",
+            "sub_path": "filament/PolyTerra Dual PLA @0.2 nozzle.json"
+        },
+        {
+            "name": "PolyTerra J1 PLA @0.2 nozzle",
+            "sub_path": "filament/PolyTerra J1 PLA @0.2 nozzle.json"
+        },
+        {
+            "name": "Snapmaker PLA Lite @U1",
+            "sub_path": "filament/Snapmaker PLA Lite @U1.json"
+        },
+        {
+            "name": "Snapmaker PLA SnapSpeed @U1",
+            "sub_path": "filament/Snapmaker PLA SnapSpeed @U1.json"
+        },
+        {
+            "name": "Snapmaker TPU 95A @U1",
+            "sub_path": "filament/Snapmaker TPU 95A @U1.json"
         },
         {
             "name": "Snapmaker ABS @U1 base",

--- a/resources/profiles/Snapmaker/filament/PolyTerra PLA @base.json
+++ b/resources/profiles/Snapmaker/filament/PolyTerra PLA @base.json
@@ -1,0 +1,20 @@
+{
+    "type": "filament",
+    "name": "PolyTerra PLA @base",
+    "inherits": "fdm_filament_pla",
+    "from": "system",
+    "filament_id": "OGFL01",
+    "instantiation": "false",
+    "filament_cost": [
+        "25.4"
+    ],
+    "filament_density": [
+        "1.31"
+    ],
+    "filament_flow_ratio": [
+        "0.98"
+    ],
+    "filament_vendor": [
+        "Polymaker"
+    ]
+}

--- a/resources/profiles/Sovol.json
+++ b/resources/profiles/Sovol.json
@@ -202,6 +202,30 @@
     ],
     "filament_list": [
         {
+            "name": "fdm_filament_common",
+            "sub_path": "filament/fdm_filament_common.json"
+        },
+        {
+            "name": "fdm_filament_abs",
+            "sub_path": "filament/fdm_filament_abs.json"
+        },
+        {
+            "name": "fdm_filament_pc",
+            "sub_path": "filament/fdm_filament_pc.json"
+        },
+        {
+            "name": "fdm_filament_pet",
+            "sub_path": "filament/fdm_filament_pet.json"
+        },
+        {
+            "name": "fdm_filament_pla",
+            "sub_path": "filament/fdm_filament_pla.json"
+        },
+        {
+            "name": "fdm_filament_tpu",
+            "sub_path": "filament/fdm_filament_tpu.json"
+        },
+        {
             "name": "Sovol SV06 ACE ABS",
             "sub_path": "filament/Sovol SV06 ACE ABS.json"
         },

--- a/resources/profiles/Sovol.json
+++ b/resources/profiles/Sovol.json
@@ -1,7 +1,7 @@
 {
     "name": "Sovol",
     "url": "",
-    "version": "02.03.01.10",
+    "version": "02.03.02.10",
     "force_update": "0",
     "description": "Sovol configurations",
     "machine_model_list": [

--- a/resources/profiles/Sovol/filament/Generic ABS @Sovol SV08 MAX.json
+++ b/resources/profiles/Sovol/filament/Generic ABS @Sovol SV08 MAX.json
@@ -5,7 +5,7 @@
     "name": "Generic ABS @Sovol SV08 MAX",
     "from": "system",
     "instantiation": "true",
-    "inherits": "Generic ABS @System",
+    "inherits": "fdm_filament_abs",
     "filament_flow_ratio": ["0.98"],
     "filament_max_volumetric_speed": ["20"],
     "nozzle_temperature_initial_layer": [

--- a/resources/profiles/Sovol/filament/Generic PC @Sovol SV08 MAX.json
+++ b/resources/profiles/Sovol/filament/Generic PC @Sovol SV08 MAX.json
@@ -5,7 +5,7 @@
     "name": "Generic PC @Sovol SV08 MAX",
     "from": "system",
     "instantiation": "true",
-    "inherits": "Generic PC @System",
+    "inherits": "fdm_filament_pc",
     "filament_flow_ratio": ["0.98"],
     "filament_max_volumetric_speed": ["18"],
     "compatible_printers": [

--- a/resources/profiles/Sovol/filament/Generic PETG @Sovol SV08 MAX.json
+++ b/resources/profiles/Sovol/filament/Generic PETG @Sovol SV08 MAX.json
@@ -5,7 +5,7 @@
     "name": "Generic PETG @Sovol SV08 MAX",
     "from": "system",
     "instantiation": "true",
-    "inherits": "Generic PETG @System",
+    "inherits": "fdm_filament_pet",
     "filament_flow_ratio": ["0.98"],
     "filament_max_volumetric_speed": [
         "15"

--- a/resources/profiles/Sovol/filament/Generic PLA @Sovol SV08 MAX.json
+++ b/resources/profiles/Sovol/filament/Generic PLA @Sovol SV08 MAX.json
@@ -5,7 +5,7 @@
     "name": "Generic PLA @Sovol SV08 MAX",
     "from": "system",
     "instantiation": "true",
-    "inherits": "Generic PLA @System",
+    "inherits": "fdm_filament_pla",
     "filament_flow_ratio": ["0.98"],
     "filament_max_volumetric_speed": ["21"],
     "compatible_printers": [

--- a/resources/profiles/Sovol/filament/Generic PLA Silk @Sovol SV08 MAX.json
+++ b/resources/profiles/Sovol/filament/Generic PLA Silk @Sovol SV08 MAX.json
@@ -5,7 +5,7 @@
     "name": "Generic PLA Silk @Sovol SV08 MAX",
     "from": "system",
     "instantiation": "true",
-    "inherits": "Generic PLA @System",
+    "inherits": "fdm_filament_pla",
     "filament_flow_ratio": ["0.98"],
     "filament_max_volumetric_speed": ["15"],
     "compatible_printers": [

--- a/resources/profiles/Sovol/filament/Generic TPU @Sovol SV08 MAX.json
+++ b/resources/profiles/Sovol/filament/Generic TPU @Sovol SV08 MAX.json
@@ -5,7 +5,7 @@
     "name": "Generic TPU @Sovol SV08 MAX",
     "from": "system",
     "instantiation": "true",
-    "inherits": "Generic TPU @System",
+    "inherits": "fdm_filament_tpu",
     "filament_flow_ratio": ["0.98"],
     "filament_max_volumetric_speed": [
         "3"

--- a/resources/profiles/Sovol/filament/Polymaker PETG @Sovol SV08 MAX.json
+++ b/resources/profiles/Sovol/filament/Polymaker PETG @Sovol SV08 MAX.json
@@ -5,7 +5,7 @@
     "name": "Polymaker PETG @Sovol SV08 MAX",
     "from": "system",
     "instantiation": "true",
-    "inherits": "Generic PETG @System",
+    "inherits": "fdm_filament_pet",
     "filament_flow_ratio": ["0.98"],
     "filament_max_volumetric_speed": [
         "12"

--- a/resources/profiles/Sovol/filament/SUNLU PETG @Sovol SV08 MAX.json
+++ b/resources/profiles/Sovol/filament/SUNLU PETG @Sovol SV08 MAX.json
@@ -5,7 +5,7 @@
     "name": "SUNLU PETG @Sovol SV08 MAX",
     "from": "system",
     "instantiation": "true",
-    "inherits": "Generic PETG @System",
+    "inherits": "fdm_filament_pet",
     "filament_flow_ratio": ["0.98"],
     "filament_max_volumetric_speed": [
         "13"

--- a/resources/profiles/Sovol/filament/Sovol SV06 ACE ABS.json
+++ b/resources/profiles/Sovol/filament/Sovol SV06 ACE ABS.json
@@ -1,7 +1,7 @@
 {
     "type": "filament",
     "name": "Sovol SV06 ACE ABS",
-    "inherits": "Generic ABS @System",
+    "inherits": "fdm_filament_abs",
     "from": "system",
     "setting_id": "GFSA04",
     "filament_id": "GFL99",

--- a/resources/profiles/Sovol/filament/Sovol SV06 ACE PETG.json
+++ b/resources/profiles/Sovol/filament/Sovol SV06 ACE PETG.json
@@ -1,7 +1,7 @@
 {
     "type": "filament",
     "name": "Sovol SV06 ACE PETG",
-    "inherits": "Generic PETG @System",
+    "inherits": "fdm_filament_pet",
     "from": "system",
     "setting_id": "GFSA04",
     "filament_id": "GFL99",

--- a/resources/profiles/Sovol/filament/Sovol SV06 ACE PLA.json
+++ b/resources/profiles/Sovol/filament/Sovol SV06 ACE PLA.json
@@ -1,7 +1,7 @@
 {
     "type": "filament",
     "name": "Sovol SV06 ACE PLA",
-    "inherits": "Generic PLA @System",
+    "inherits": "fdm_filament_pla",
     "from": "system",
     "setting_id": "GFSA04",
     "filament_id": "GFL99",

--- a/resources/profiles/Sovol/filament/Sovol SV06 ACE TPU.json
+++ b/resources/profiles/Sovol/filament/Sovol SV06 ACE TPU.json
@@ -1,7 +1,7 @@
 {
     "type": "filament",
     "name": "Sovol SV06 ACE TPU",
-    "inherits": "Generic TPU @System",
+    "inherits": "fdm_filament_tpu",
     "from": "system",
     "setting_id": "GFSA04",
     "filament_id": "GFL99",

--- a/resources/profiles/Sovol/filament/Sovol SV06 Plus ACE ABS.json
+++ b/resources/profiles/Sovol/filament/Sovol SV06 Plus ACE ABS.json
@@ -1,7 +1,7 @@
 {
     "type": "filament",
     "name": "Sovol SV06 Plus ACE ABS",
-    "inherits": "Generic ABS @System",
+    "inherits": "fdm_filament_abs",
     "from": "system",
     "setting_id": "GFSA04",
     "filament_id": "GFL99",

--- a/resources/profiles/Sovol/filament/Sovol SV06 Plus ACE PETG.json
+++ b/resources/profiles/Sovol/filament/Sovol SV06 Plus ACE PETG.json
@@ -1,7 +1,7 @@
 {
     "type": "filament",
     "name": "Sovol SV06 Plus ACE PETG",
-    "inherits": "Generic PETG @System",
+    "inherits": "fdm_filament_pet",
     "from": "system",
     "setting_id": "GFSA04",
     "filament_id": "GFL99",

--- a/resources/profiles/Sovol/filament/Sovol SV06 Plus ACE PLA.json
+++ b/resources/profiles/Sovol/filament/Sovol SV06 Plus ACE PLA.json
@@ -1,7 +1,7 @@
 {
     "type": "filament",
     "name": "Sovol SV06 Plus ACE PLA",
-    "inherits": "Generic PLA @System",
+    "inherits": "fdm_filament_pla",
     "from": "system",
     "setting_id": "GFSA04",
     "filament_id": "GFL99",

--- a/resources/profiles/Sovol/filament/Sovol SV06 Plus ACE TPU.json
+++ b/resources/profiles/Sovol/filament/Sovol SV06 Plus ACE TPU.json
@@ -1,7 +1,7 @@
 {
     "type": "filament",
     "name": "Sovol SV06 Plus ACE TPU",
-    "inherits": "Generic TPU @System",
+    "inherits": "fdm_filament_tpu",
     "from": "system",
     "setting_id": "GFSA04",
     "filament_id": "GFL99",

--- a/resources/profiles/Sovol/filament/Sovol SV07 PLA.json
+++ b/resources/profiles/Sovol/filament/Sovol SV07 PLA.json
@@ -1,7 +1,7 @@
 {
     "type": "filament",
     "name": "Sovol SV07 PLA",
-    "inherits": "Generic PLA @System",
+    "inherits": "fdm_filament_pla",
     "from": "system",
     "setting_id": "GFSA04",
     "filament_id": "GFL99",

--- a/resources/profiles/Sovol/filament/Sovol SV08 ABS.json
+++ b/resources/profiles/Sovol/filament/Sovol SV08 ABS.json
@@ -1,7 +1,7 @@
 {
     "type": "filament",
     "name": "Sovol SV08 ABS",
-    "inherits": "Generic ABS @System",
+    "inherits": "fdm_filament_abs",
     "from": "system",
     "setting_id": "GFSA04",
     "filament_id": "GFL99",

--- a/resources/profiles/Sovol/filament/Sovol SV08 PETG.json
+++ b/resources/profiles/Sovol/filament/Sovol SV08 PETG.json
@@ -1,7 +1,7 @@
 {
     "type": "filament",
     "name": "Sovol SV08 PETG",
-    "inherits": "Generic PETG @System",
+    "inherits": "fdm_filament_pet",
     "from": "system",
     "setting_id": "GFSA04",
     "filament_id": "GFL99",

--- a/resources/profiles/Sovol/filament/Sovol SV08 PLA @SV08 0.2 nozzle.json
+++ b/resources/profiles/Sovol/filament/Sovol SV08 PLA @SV08 0.2 nozzle.json
@@ -1,7 +1,7 @@
 {
     "type": "filament",
     "name": "Sovol SV08 PLA @SV08 0.2 nozzle",
-    "inherits": "Generic PLA @System",
+    "inherits": "fdm_filament_pla",
     "from": "system",
     "setting_id": "GFSA04",
     "filament_id": "GFL99",

--- a/resources/profiles/Sovol/filament/Sovol SV08 PLA.json
+++ b/resources/profiles/Sovol/filament/Sovol SV08 PLA.json
@@ -1,7 +1,7 @@
 {
     "type": "filament",
     "name": "Sovol SV08 PLA",
-    "inherits": "Generic PLA @System",
+    "inherits": "fdm_filament_pla",
     "from": "system",
     "setting_id": "GFSA04",
     "filament_id": "GFL99",

--- a/resources/profiles/Sovol/filament/Sovol SV08 TPU.json
+++ b/resources/profiles/Sovol/filament/Sovol SV08 TPU.json
@@ -1,7 +1,7 @@
 {
     "type": "filament",
     "name": "Sovol SV08 TPU",
-    "inherits": "Generic TPU @System",
+    "inherits": "fdm_filament_tpu",
     "from": "system",
     "setting_id": "GFSA04",
     "filament_id": "GFL99",

--- a/resources/profiles/Sovol/filament/Sovol Zero ABS.json
+++ b/resources/profiles/Sovol/filament/Sovol Zero ABS.json
@@ -1,7 +1,7 @@
 {
     "type": "filament",
     "name": "Sovol Zero ABS",
-    "inherits": "Generic ABS @System",
+    "inherits": "fdm_filament_abs",
     "from": "system",
     "setting_id": "GFSA04",
     "filament_id": "GFL99",

--- a/resources/profiles/Sovol/filament/Sovol Zero PC.json
+++ b/resources/profiles/Sovol/filament/Sovol Zero PC.json
@@ -1,7 +1,7 @@
 {
     "type": "filament",
     "name": "Sovol Zero PC",
-    "inherits": "Generic PC @System",
+    "inherits": "fdm_filament_pc",
     "from": "system",
     "setting_id": "GFSA04",
     "filament_id": "GFL99",

--- a/resources/profiles/Sovol/filament/Sovol Zero PETG HS Nozzle.json
+++ b/resources/profiles/Sovol/filament/Sovol Zero PETG HS Nozzle.json
@@ -1,7 +1,7 @@
 {
     "type": "filament",
     "name": "Sovol Zero PETG HS Nozzle",
-    "inherits": "Generic PETG @System",
+    "inherits": "fdm_filament_pet",
     "from": "system",
     "setting_id": "GFSA04",
     "filament_id": "GFL99",

--- a/resources/profiles/Sovol/filament/Sovol Zero PETG.json
+++ b/resources/profiles/Sovol/filament/Sovol Zero PETG.json
@@ -1,7 +1,7 @@
 {
     "type": "filament",
     "name": "Sovol Zero PETG",
-    "inherits": "Generic PETG @System",
+    "inherits": "fdm_filament_pet",
     "from": "system",
     "setting_id": "GFSA04",
     "filament_id": "GFL99",

--- a/resources/profiles/Sovol/filament/Sovol Zero PLA Basic HS Nozzle.json
+++ b/resources/profiles/Sovol/filament/Sovol Zero PLA Basic HS Nozzle.json
@@ -1,7 +1,7 @@
 {
     "type": "filament",
     "name": "Sovol Zero PLA Basic HS Nozzle",
-    "inherits": "Generic PLA @System",
+    "inherits": "fdm_filament_pla",
     "from": "system",
     "setting_id": "GFSA04",
     "filament_id": "GFL99",

--- a/resources/profiles/Sovol/filament/Sovol Zero PLA Basic.json
+++ b/resources/profiles/Sovol/filament/Sovol Zero PLA Basic.json
@@ -1,7 +1,7 @@
 {
     "type": "filament",
     "name": "Sovol Zero PLA Basic",
-    "inherits": "Generic PLA @System",
+    "inherits": "fdm_filament_pla",
     "from": "system",
     "setting_id": "GFSA04",
     "filament_id": "GFL99",

--- a/resources/profiles/Sovol/filament/Sovol Zero PLA Silk HS Nozzle.json
+++ b/resources/profiles/Sovol/filament/Sovol Zero PLA Silk HS Nozzle.json
@@ -1,7 +1,7 @@
 {
     "type": "filament",
     "name": "Sovol Zero PLA Silk HS Nozzle",
-    "inherits": "Generic PLA @System",
+    "inherits": "fdm_filament_pla",
     "from": "system",
     "setting_id": "GFSA04",
     "filament_id": "GFL99",

--- a/resources/profiles/Sovol/filament/Sovol Zero PLA Silk.json
+++ b/resources/profiles/Sovol/filament/Sovol Zero PLA Silk.json
@@ -1,7 +1,7 @@
 {
     "type": "filament",
     "name": "Sovol Zero PLA Silk",
-    "inherits": "Generic PLA @System",
+    "inherits": "fdm_filament_pla",
     "from": "system",
     "setting_id": "GFSA04",
     "filament_id": "GFL99",

--- a/resources/profiles/Sovol/filament/Sovol Zero TPU.json
+++ b/resources/profiles/Sovol/filament/Sovol Zero TPU.json
@@ -1,7 +1,7 @@
 {
     "type": "filament",
     "name": "Sovol Zero TPU",
-    "inherits": "Generic TPU @System",
+    "inherits": "fdm_filament_tpu",
     "from": "system",
     "setting_id": "GFSA04",
     "filament_id": "GFL99",

--- a/resources/profiles/Sovol/filament/fdm_filament_abs.json
+++ b/resources/profiles/Sovol/filament/fdm_filament_abs.json
@@ -1,0 +1,94 @@
+{
+    "type": "filament",
+    "name": "fdm_filament_abs",
+    "inherits": "fdm_filament_common",
+    "from": "system",
+    "instantiation": "false",
+    "activate_air_filtration": [
+        "0"
+    ],
+    "supertack_plate_temp": [
+        "0"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "0"
+    ],
+    "cool_plate_temp": [
+        "0"
+    ],
+    "cool_plate_temp_initial_layer": [
+        "0"
+    ],
+    "eng_plate_temp": [
+        "100"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "105"
+    ],
+    "fan_cooling_layer_time": [
+        "30"
+    ],
+    "fan_max_speed": [
+        "80"
+    ],
+    "fan_min_speed": [
+        "10"
+    ],
+    "filament_cost": [
+        "20"
+    ],
+    "filament_density": [
+        "1.04"
+    ],
+    "filament_max_volumetric_speed": [
+        "12"
+    ],
+    "filament_type": [
+        "ABS"
+    ],
+    "hot_plate_temp": [
+        "100"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "105"
+    ],
+    "nozzle_temperature": [
+        "260"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "260"
+    ],
+    "nozzle_temperature_range_high": [
+        "280"
+    ],
+    "nozzle_temperature_range_low": [
+        "240"
+    ],
+    "overhang_fan_speed": [
+        "80"
+    ],
+    "overhang_fan_threshold": [
+        "25%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "3"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
+    "textured_plate_temp": [
+        "100"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "105"
+    ],
+    "filament_flow_ratio": [
+        "0.926"
+    ],
+    "temperature_vitrification": [
+        "110"
+    ]
+}

--- a/resources/profiles/Sovol/filament/fdm_filament_common.json
+++ b/resources/profiles/Sovol/filament/fdm_filament_common.json
@@ -1,0 +1,187 @@
+{
+    "type": "filament",
+    "name": "fdm_filament_common",
+    "from": "system",
+    "instantiation": "false",
+    "activate_air_filtration": [
+        "0"
+    ],
+    "chamber_temperatures": [
+        "0"
+    ],
+    "close_fan_the_first_x_layers": [
+        "3"
+    ],
+    "complete_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "cool_plate_temp": [
+        "60"
+    ],
+    "cool_plate_temp_initial_layer": [
+        "60"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "eng_plate_temp": [
+        "60"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "60"
+    ],
+    "fan_cooling_layer_time": [
+        "60"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "35"
+    ],
+    "filament_cost": [
+        "0"
+    ],
+    "filament_density": [
+        "0"
+    ],
+    "filament_deretraction_speed": [
+        "nil"
+    ],
+    "filament_diameter": [
+        "1.75"
+    ],
+    "filament_flow_ratio": [
+        "1"
+    ],
+    "filament_is_support": [
+        "0"
+    ],
+    "filament_long_retractions_when_cut": [
+        "nil"
+    ],
+    "filament_max_volumetric_speed": [
+        "0"
+    ],
+    "filament_minimal_purge_on_wipe_tower": [
+        "15"
+    ],
+    "filament_retract_before_wipe": [
+        "nil"
+    ],
+    "filament_retract_restart_extra": [
+        "nil"
+    ],
+    "filament_retract_when_changing_layer": [
+        "nil"
+    ],
+    "filament_retraction_distances_when_cut": [
+        "nil"
+    ],
+    "filament_retraction_length": [
+        "nil"
+    ],
+    "filament_retraction_minimum_travel": [
+        "nil"
+    ],
+    "filament_retraction_speed": [
+        "nil"
+    ],
+    "filament_settings_id": [
+        ""
+    ],
+    "filament_soluble": [
+        "0"
+    ],
+    "filament_type": [
+        "PLA"
+    ],
+    "filament_vendor": [
+        "Generic"
+    ],
+    "filament_wipe": [
+        "nil"
+    ],
+    "filament_wipe_distance": [
+        "nil"
+    ],
+    "filament_z_hop": [
+        "nil"
+    ],
+    "filament_z_hop_types": [
+        "nil"
+    ],
+    "full_fan_speed_layer": [
+        "0"
+    ],
+    "filament_scarf_seam_type": [
+        "none"
+    ],
+    "filament_scarf_height": [
+        "10%"
+    ],
+    "filament_scarf_gap": [
+        "0%"
+    ],
+    "filament_scarf_length": [
+        "10"
+    ],
+    "filament_shrink": [
+        "100%"
+    ],
+    "hot_plate_temp": [
+        "60"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "60"
+    ],
+    "nozzle_temperature": [
+        "200"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "200"
+    ],
+    "overhang_fan_speed": [
+        "100"
+    ],
+    "overhang_fan_threshold": [
+        "95%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "0"
+    ],
+    "required_nozzle_HRC": [
+        "3"
+    ],
+    "supertack_plate_temp": [
+        "45"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "45"
+    ],
+    "slow_down_for_layer_cooling": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "8"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
+    "temperature_vitrification": [
+        "100"
+    ],
+    "textured_plate_temp": [
+        "60"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "60"
+    ],
+    "filament_start_gcode": [
+        "; Filament gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode\n"
+    ],
+    "compatible_printers": []
+}

--- a/resources/profiles/Sovol/filament/fdm_filament_pc.json
+++ b/resources/profiles/Sovol/filament/fdm_filament_pc.json
@@ -1,0 +1,92 @@
+{
+    "type": "filament",
+    "name": "fdm_filament_pc",
+    "inherits": "fdm_filament_common",
+    "from": "system",
+    "filament_id": "OGFC99",
+    "instantiation": "false",
+    "supertack_plate_temp": [
+        "0"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "0"
+    ],
+    "cool_plate_temp": [
+        "0"
+    ],
+    "cool_plate_temp_initial_layer": [
+        "0"
+    ],
+    "eng_plate_temp": [
+        "110"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "110"
+    ],
+    "fan_cooling_layer_time": [
+        "30"
+    ],
+    "fan_max_speed": [
+        "60"
+    ],
+    "fan_min_speed": [
+        "10"
+    ],
+    "filament_cost": [
+        "20"
+    ],
+    "filament_density": [
+        "1.04"
+    ],
+    "filament_type": [
+        "PC"
+    ],
+    "hot_plate_temp": [
+        "110"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "110"
+    ],
+    "nozzle_temperature": [
+        "280"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "270"
+    ],
+    "nozzle_temperature_range_high": [
+        "290"
+    ],
+    "nozzle_temperature_range_low": [
+        "260"
+    ],
+    "overhang_fan_speed": [
+        "60"
+    ],
+    "overhang_fan_threshold": [
+        "25%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "2"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
+    "temperature_vitrification": [
+        "120"
+    ],
+    "textured_plate_temp": [
+        "110"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "110"
+    ],
+    "filament_max_volumetric_speed": [
+        "12"
+    ],
+    "filament_flow_ratio": [
+        "0.94"
+    ]
+}

--- a/resources/profiles/Sovol/filament/fdm_filament_pet.json
+++ b/resources/profiles/Sovol/filament/fdm_filament_pet.json
@@ -1,0 +1,68 @@
+{
+    "type": "filament",
+    "name": "fdm_filament_pet",
+    "inherits": "fdm_filament_common",
+    "from": "system",
+    "filament_id": "OGFG99",
+    "instantiation": "false",
+    "eng_plate_temp": [
+        "0"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "0"
+    ],
+    "fan_cooling_layer_time": [
+        "20"
+    ],
+    "fan_min_speed": [
+        "20"
+    ],
+    "filament_cost": [
+        "30"
+    ],
+    "filament_density": [
+        "1.27"
+    ],
+    "filament_max_volumetric_speed": [
+        "12"
+    ],
+    "filament_type": [
+        "PETG"
+    ],
+    "hot_plate_temp": [
+        "80"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "80"
+    ],
+    "nozzle_temperature": [
+        "255"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "255"
+    ],
+    "nozzle_temperature_range_high": [
+        "260"
+    ],
+    "nozzle_temperature_range_low": [
+        "220"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "supertack_plate_temp": [
+        "70"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "70"
+    ],
+    "temperature_vitrification": [
+        "70"
+    ],
+    "textured_plate_temp": [
+        "80"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "80"
+    ]
+}

--- a/resources/profiles/Sovol/filament/fdm_filament_pla.json
+++ b/resources/profiles/Sovol/filament/fdm_filament_pla.json
@@ -1,0 +1,89 @@
+{
+    "type": "filament",
+    "name": "fdm_filament_pla",
+    "inherits": "fdm_filament_common",
+    "from": "system",
+    "filament_id": "OGFL99",
+    "instantiation": "false",
+    "additional_cooling_fan_speed": [
+        "70"
+    ],
+    "close_fan_the_first_x_layers": [
+        "1"
+    ],
+    "cool_plate_temp": [
+        "35"
+    ],
+    "cool_plate_temp_initial_layer": [
+        "35"
+    ],
+    "eng_plate_temp": [
+        "0"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "0"
+    ],
+    "fan_cooling_layer_time": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
+    "filament_cost": [
+        "20"
+    ],
+    "filament_density": [
+        "1.24"
+    ],
+    "filament_max_volumetric_speed": [
+        "12"
+    ],
+    "filament_scarf_seam_type": [
+        "none"
+    ],
+    "filament_scarf_gap": [
+        "15%"
+    ],
+    "hot_plate_temp": [
+        "55"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "55"
+    ],
+    "nozzle_temperature": [
+        "220"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "220"
+    ],
+    "nozzle_temperature_range_low": [
+        "190"
+    ],
+    "nozzle_temperature_range_high": [
+        "240"
+    ],
+    "overhang_fan_threshold": [
+        "50%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "4"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
+    "temperature_vitrification": [
+        "45"
+    ],
+    "textured_plate_temp": [
+        "55"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "55"
+    ],
+    "filament_flow_ratio": [
+        "0.98"
+    ]
+}

--- a/resources/profiles/Sovol/filament/fdm_filament_tpu.json
+++ b/resources/profiles/Sovol/filament/fdm_filament_tpu.json
@@ -1,0 +1,82 @@
+{
+    "type": "filament",
+    "name": "fdm_filament_tpu",
+    "inherits": "fdm_filament_common",
+    "from": "system",
+    "instantiation": "false",
+    "additional_cooling_fan_speed": [
+        "70"
+    ],
+    "close_fan_the_first_x_layers": [
+        "1"
+    ],
+    "supertack_plate_temp": [
+        "0"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "0"
+    ],
+    "cool_plate_temp": [
+        "30"
+    ],
+    "cool_plate_temp_initial_layer": [
+        "30"
+    ],
+    "eng_plate_temp": [
+        "30"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "30"
+    ],
+    "fan_cooling_layer_time": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
+    "filament_cost": [
+        "20"
+    ],
+    "filament_density": [
+        "1.24"
+    ],
+    "filament_max_volumetric_speed": [
+        "3.2"
+    ],
+    "filament_retraction_length": [
+        "0.4"
+    ],
+    "filament_type": [
+        "TPU"
+    ],
+    "hot_plate_temp": [
+        "35"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "35"
+    ],
+    "nozzle_temperature": [
+        "240"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "240"
+    ],
+    "nozzle_temperature_range_high": [
+        "250"
+    ],
+    "nozzle_temperature_range_low": [
+        "200"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "temperature_vitrification": [
+        "30"
+    ],
+    "textured_plate_temp": [
+        "35"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "35"
+    ]
+}

--- a/resources/profiles/TwoTrees.json
+++ b/resources/profiles/TwoTrees.json
@@ -81,6 +81,18 @@
     ],
     "filament_list": [
         {
+            "name": "fdm_filament_common",
+            "sub_path": "filament/fdm_filament_common.json"
+        },
+        {
+            "name": "fdm_filament_pla",
+            "sub_path": "filament/fdm_filament_pla.json"
+        },
+        {
+            "name": "fdm_filament_tpu",
+            "sub_path": "filament/fdm_filament_tpu.json"
+        },
+        {
             "name": "TwoTrees Generic 95A TPU @SK1",
             "sub_path": "filament/TwoTrees Generic 95A TPU @SK1.json"
         },

--- a/resources/profiles/TwoTrees.json
+++ b/resources/profiles/TwoTrees.json
@@ -1,6 +1,6 @@
 {
     "name": "TwoTrees",
-    "version": "02.03.01.10",
+    "version": "02.03.02.10",
     "force_update": "1",
     "description": "TwoTrees configurations",
     "machine_model_list": [

--- a/resources/profiles/TwoTrees/filament/fdm_filament_common.json
+++ b/resources/profiles/TwoTrees/filament/fdm_filament_common.json
@@ -1,0 +1,187 @@
+{
+    "type": "filament",
+    "name": "fdm_filament_common",
+    "from": "system",
+    "instantiation": "false",
+    "activate_air_filtration": [
+        "0"
+    ],
+    "chamber_temperatures": [
+        "0"
+    ],
+    "close_fan_the_first_x_layers": [
+        "3"
+    ],
+    "complete_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "cool_plate_temp": [
+        "60"
+    ],
+    "cool_plate_temp_initial_layer": [
+        "60"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "eng_plate_temp": [
+        "60"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "60"
+    ],
+    "fan_cooling_layer_time": [
+        "60"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "35"
+    ],
+    "filament_cost": [
+        "0"
+    ],
+    "filament_density": [
+        "0"
+    ],
+    "filament_deretraction_speed": [
+        "nil"
+    ],
+    "filament_diameter": [
+        "1.75"
+    ],
+    "filament_flow_ratio": [
+        "1"
+    ],
+    "filament_is_support": [
+        "0"
+    ],
+    "filament_long_retractions_when_cut": [
+        "nil"
+    ],
+    "filament_max_volumetric_speed": [
+        "0"
+    ],
+    "filament_minimal_purge_on_wipe_tower": [
+        "15"
+    ],
+    "filament_retract_before_wipe": [
+        "nil"
+    ],
+    "filament_retract_restart_extra": [
+        "nil"
+    ],
+    "filament_retract_when_changing_layer": [
+        "nil"
+    ],
+    "filament_retraction_distances_when_cut": [
+        "nil"
+    ],
+    "filament_retraction_length": [
+        "nil"
+    ],
+    "filament_retraction_minimum_travel": [
+        "nil"
+    ],
+    "filament_retraction_speed": [
+        "nil"
+    ],
+    "filament_settings_id": [
+        ""
+    ],
+    "filament_soluble": [
+        "0"
+    ],
+    "filament_type": [
+        "PLA"
+    ],
+    "filament_vendor": [
+        "Generic"
+    ],
+    "filament_wipe": [
+        "nil"
+    ],
+    "filament_wipe_distance": [
+        "nil"
+    ],
+    "filament_z_hop": [
+        "nil"
+    ],
+    "filament_z_hop_types": [
+        "nil"
+    ],
+    "full_fan_speed_layer": [
+        "0"
+    ],
+    "filament_scarf_seam_type": [
+        "none"
+    ],
+    "filament_scarf_height": [
+        "10%"
+    ],
+    "filament_scarf_gap": [
+        "0%"
+    ],
+    "filament_scarf_length": [
+        "10"
+    ],
+    "filament_shrink": [
+        "100%"
+    ],
+    "hot_plate_temp": [
+        "60"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "60"
+    ],
+    "nozzle_temperature": [
+        "200"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "200"
+    ],
+    "overhang_fan_speed": [
+        "100"
+    ],
+    "overhang_fan_threshold": [
+        "95%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "0"
+    ],
+    "required_nozzle_HRC": [
+        "3"
+    ],
+    "supertack_plate_temp": [
+        "45"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "45"
+    ],
+    "slow_down_for_layer_cooling": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "8"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
+    "temperature_vitrification": [
+        "100"
+    ],
+    "textured_plate_temp": [
+        "60"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "60"
+    ],
+    "filament_start_gcode": [
+        "; Filament gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode\n"
+    ],
+    "compatible_printers": []
+}

--- a/resources/profiles/TwoTrees/filament/fdm_filament_pla.json
+++ b/resources/profiles/TwoTrees/filament/fdm_filament_pla.json
@@ -1,0 +1,89 @@
+{
+    "type": "filament",
+    "name": "fdm_filament_pla",
+    "inherits": "fdm_filament_common",
+    "from": "system",
+    "filament_id": "OGFL99",
+    "instantiation": "false",
+    "additional_cooling_fan_speed": [
+        "70"
+    ],
+    "close_fan_the_first_x_layers": [
+        "1"
+    ],
+    "cool_plate_temp": [
+        "35"
+    ],
+    "cool_plate_temp_initial_layer": [
+        "35"
+    ],
+    "eng_plate_temp": [
+        "0"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "0"
+    ],
+    "fan_cooling_layer_time": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
+    "filament_cost": [
+        "20"
+    ],
+    "filament_density": [
+        "1.24"
+    ],
+    "filament_max_volumetric_speed": [
+        "12"
+    ],
+    "filament_scarf_seam_type": [
+        "none"
+    ],
+    "filament_scarf_gap": [
+        "15%"
+    ],
+    "hot_plate_temp": [
+        "55"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "55"
+    ],
+    "nozzle_temperature": [
+        "220"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "220"
+    ],
+    "nozzle_temperature_range_low": [
+        "190"
+    ],
+    "nozzle_temperature_range_high": [
+        "240"
+    ],
+    "overhang_fan_threshold": [
+        "50%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "4"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
+    "temperature_vitrification": [
+        "45"
+    ],
+    "textured_plate_temp": [
+        "55"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "55"
+    ],
+    "filament_flow_ratio": [
+        "0.98"
+    ]
+}

--- a/resources/profiles/TwoTrees/filament/fdm_filament_tpu.json
+++ b/resources/profiles/TwoTrees/filament/fdm_filament_tpu.json
@@ -1,0 +1,82 @@
+{
+    "type": "filament",
+    "name": "fdm_filament_tpu",
+    "inherits": "fdm_filament_common",
+    "from": "system",
+    "instantiation": "false",
+    "additional_cooling_fan_speed": [
+        "70"
+    ],
+    "close_fan_the_first_x_layers": [
+        "1"
+    ],
+    "supertack_plate_temp": [
+        "0"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "0"
+    ],
+    "cool_plate_temp": [
+        "30"
+    ],
+    "cool_plate_temp_initial_layer": [
+        "30"
+    ],
+    "eng_plate_temp": [
+        "30"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "30"
+    ],
+    "fan_cooling_layer_time": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
+    "filament_cost": [
+        "20"
+    ],
+    "filament_density": [
+        "1.24"
+    ],
+    "filament_max_volumetric_speed": [
+        "3.2"
+    ],
+    "filament_retraction_length": [
+        "0.4"
+    ],
+    "filament_type": [
+        "TPU"
+    ],
+    "hot_plate_temp": [
+        "35"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "35"
+    ],
+    "nozzle_temperature": [
+        "240"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "240"
+    ],
+    "nozzle_temperature_range_high": [
+        "250"
+    ],
+    "nozzle_temperature_range_low": [
+        "200"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "temperature_vitrification": [
+        "30"
+    ],
+    "textured_plate_temp": [
+        "35"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "35"
+    ]
+}

--- a/resources/profiles/Z-Bolt.json
+++ b/resources/profiles/Z-Bolt.json
@@ -438,6 +438,26 @@
     ],
     "filament_list": [
         {
+            "name": "fdm_filament_common",
+            "sub_path": "filament/fdm_filament_common.json"
+        },
+        {
+            "name": "fdm_filament_abs",
+            "sub_path": "filament/fdm_filament_abs.json"
+        },
+        {
+            "name": "fdm_filament_pa",
+            "sub_path": "filament/fdm_filament_pa.json"
+        },
+        {
+            "name": "fdm_filament_pet",
+            "sub_path": "filament/fdm_filament_pet.json"
+        },
+        {
+            "name": "fdm_filament_pla",
+            "sub_path": "filament/fdm_filament_pla.json"
+        },
+        {
             "name": "Z-Bolt ABS @base",
             "sub_path": "filament/Z-Bolt ABS @base.json"
         },

--- a/resources/profiles/Z-Bolt.json
+++ b/resources/profiles/Z-Bolt.json
@@ -1,7 +1,7 @@
 {
     "name": "Z-Bolt",
     "url": "",
-    "version": "02.03.01.10",
+    "version": "02.03.02.10",
     "force_update": "0",
     "description": "Z-Bolt configurations",
     "machine_model_list": [

--- a/resources/profiles/Z-Bolt/filament/fdm_filament_abs.json
+++ b/resources/profiles/Z-Bolt/filament/fdm_filament_abs.json
@@ -1,0 +1,94 @@
+{
+    "type": "filament",
+    "name": "fdm_filament_abs",
+    "inherits": "fdm_filament_common",
+    "from": "system",
+    "instantiation": "false",
+    "activate_air_filtration": [
+        "0"
+    ],
+    "supertack_plate_temp": [
+        "0"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "0"
+    ],
+    "cool_plate_temp": [
+        "0"
+    ],
+    "cool_plate_temp_initial_layer": [
+        "0"
+    ],
+    "eng_plate_temp": [
+        "100"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "105"
+    ],
+    "fan_cooling_layer_time": [
+        "30"
+    ],
+    "fan_max_speed": [
+        "80"
+    ],
+    "fan_min_speed": [
+        "10"
+    ],
+    "filament_cost": [
+        "20"
+    ],
+    "filament_density": [
+        "1.04"
+    ],
+    "filament_max_volumetric_speed": [
+        "12"
+    ],
+    "filament_type": [
+        "ABS"
+    ],
+    "hot_plate_temp": [
+        "100"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "105"
+    ],
+    "nozzle_temperature": [
+        "260"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "260"
+    ],
+    "nozzle_temperature_range_high": [
+        "280"
+    ],
+    "nozzle_temperature_range_low": [
+        "240"
+    ],
+    "overhang_fan_speed": [
+        "80"
+    ],
+    "overhang_fan_threshold": [
+        "25%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "3"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
+    "textured_plate_temp": [
+        "100"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "105"
+    ],
+    "filament_flow_ratio": [
+        "0.926"
+    ],
+    "temperature_vitrification": [
+        "110"
+    ]
+}

--- a/resources/profiles/Z-Bolt/filament/fdm_filament_common.json
+++ b/resources/profiles/Z-Bolt/filament/fdm_filament_common.json
@@ -1,0 +1,187 @@
+{
+    "type": "filament",
+    "name": "fdm_filament_common",
+    "from": "system",
+    "instantiation": "false",
+    "activate_air_filtration": [
+        "0"
+    ],
+    "chamber_temperatures": [
+        "0"
+    ],
+    "close_fan_the_first_x_layers": [
+        "3"
+    ],
+    "complete_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "cool_plate_temp": [
+        "60"
+    ],
+    "cool_plate_temp_initial_layer": [
+        "60"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "eng_plate_temp": [
+        "60"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "60"
+    ],
+    "fan_cooling_layer_time": [
+        "60"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "35"
+    ],
+    "filament_cost": [
+        "0"
+    ],
+    "filament_density": [
+        "0"
+    ],
+    "filament_deretraction_speed": [
+        "nil"
+    ],
+    "filament_diameter": [
+        "1.75"
+    ],
+    "filament_flow_ratio": [
+        "1"
+    ],
+    "filament_is_support": [
+        "0"
+    ],
+    "filament_long_retractions_when_cut": [
+        "nil"
+    ],
+    "filament_max_volumetric_speed": [
+        "0"
+    ],
+    "filament_minimal_purge_on_wipe_tower": [
+        "15"
+    ],
+    "filament_retract_before_wipe": [
+        "nil"
+    ],
+    "filament_retract_restart_extra": [
+        "nil"
+    ],
+    "filament_retract_when_changing_layer": [
+        "nil"
+    ],
+    "filament_retraction_distances_when_cut": [
+        "nil"
+    ],
+    "filament_retraction_length": [
+        "nil"
+    ],
+    "filament_retraction_minimum_travel": [
+        "nil"
+    ],
+    "filament_retraction_speed": [
+        "nil"
+    ],
+    "filament_settings_id": [
+        ""
+    ],
+    "filament_soluble": [
+        "0"
+    ],
+    "filament_type": [
+        "PLA"
+    ],
+    "filament_vendor": [
+        "Generic"
+    ],
+    "filament_wipe": [
+        "nil"
+    ],
+    "filament_wipe_distance": [
+        "nil"
+    ],
+    "filament_z_hop": [
+        "nil"
+    ],
+    "filament_z_hop_types": [
+        "nil"
+    ],
+    "full_fan_speed_layer": [
+        "0"
+    ],
+    "filament_scarf_seam_type": [
+        "none"
+    ],
+    "filament_scarf_height": [
+        "10%"
+    ],
+    "filament_scarf_gap": [
+        "0%"
+    ],
+    "filament_scarf_length": [
+        "10"
+    ],
+    "filament_shrink": [
+        "100%"
+    ],
+    "hot_plate_temp": [
+        "60"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "60"
+    ],
+    "nozzle_temperature": [
+        "200"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "200"
+    ],
+    "overhang_fan_speed": [
+        "100"
+    ],
+    "overhang_fan_threshold": [
+        "95%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "0"
+    ],
+    "required_nozzle_HRC": [
+        "3"
+    ],
+    "supertack_plate_temp": [
+        "45"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "45"
+    ],
+    "slow_down_for_layer_cooling": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "8"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
+    "temperature_vitrification": [
+        "100"
+    ],
+    "textured_plate_temp": [
+        "60"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "60"
+    ],
+    "filament_start_gcode": [
+        "; Filament gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode\n"
+    ],
+    "compatible_printers": []
+}

--- a/resources/profiles/Z-Bolt/filament/fdm_filament_pa.json
+++ b/resources/profiles/Z-Bolt/filament/fdm_filament_pa.json
@@ -1,0 +1,89 @@
+{
+    "type": "filament",
+    "name": "fdm_filament_pa",
+    "inherits": "fdm_filament_common",
+    "from": "system",
+    "filament_id": "OGFN99",
+    "instantiation": "false",
+    "activate_air_filtration": [
+        "0"
+    ],
+    "supertack_plate_temp": [
+        "0"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "0"
+    ],
+    "cool_plate_temp": [
+        "0"
+    ],
+    "cool_plate_temp_initial_layer": [
+        "0"
+    ],
+    "eng_plate_temp": [
+        "100"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "100"
+    ],
+    "fan_cooling_layer_time": [
+        "4"
+    ],
+    "fan_max_speed": [
+        "60"
+    ],
+    "fan_min_speed": [
+        "0"
+    ],
+    "filament_cost": [
+        "20"
+    ],
+    "filament_density": [
+        "1.04"
+    ],
+    "filament_max_volumetric_speed": [
+        "8"
+    ],
+    "filament_type": [
+        "PA"
+    ],
+    "hot_plate_temp": [
+        "100"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "100"
+    ],
+    "nozzle_temperature": [
+        "280"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "280"
+    ],
+    "nozzle_temperature_range_high": [
+        "300"
+    ],
+    "nozzle_temperature_range_low": [
+        "260"
+    ],
+    "overhang_fan_speed": [
+        "30"
+    ],
+    "required_nozzle_HRC": [
+        "40"
+    ],
+    "slow_down_layer_time": [
+        "2"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
+    "temperature_vitrification": [
+        "108"
+    ],
+    "textured_plate_temp": [
+        "100"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "100"
+    ]
+}

--- a/resources/profiles/Z-Bolt/filament/fdm_filament_pet.json
+++ b/resources/profiles/Z-Bolt/filament/fdm_filament_pet.json
@@ -1,0 +1,68 @@
+{
+    "type": "filament",
+    "name": "fdm_filament_pet",
+    "inherits": "fdm_filament_common",
+    "from": "system",
+    "filament_id": "OGFG99",
+    "instantiation": "false",
+    "eng_plate_temp": [
+        "0"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "0"
+    ],
+    "fan_cooling_layer_time": [
+        "20"
+    ],
+    "fan_min_speed": [
+        "20"
+    ],
+    "filament_cost": [
+        "30"
+    ],
+    "filament_density": [
+        "1.27"
+    ],
+    "filament_max_volumetric_speed": [
+        "12"
+    ],
+    "filament_type": [
+        "PETG"
+    ],
+    "hot_plate_temp": [
+        "80"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "80"
+    ],
+    "nozzle_temperature": [
+        "255"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "255"
+    ],
+    "nozzle_temperature_range_high": [
+        "260"
+    ],
+    "nozzle_temperature_range_low": [
+        "220"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "supertack_plate_temp": [
+        "70"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "70"
+    ],
+    "temperature_vitrification": [
+        "70"
+    ],
+    "textured_plate_temp": [
+        "80"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "80"
+    ]
+}

--- a/resources/profiles/Z-Bolt/filament/fdm_filament_pla.json
+++ b/resources/profiles/Z-Bolt/filament/fdm_filament_pla.json
@@ -1,0 +1,89 @@
+{
+    "type": "filament",
+    "name": "fdm_filament_pla",
+    "inherits": "fdm_filament_common",
+    "from": "system",
+    "filament_id": "OGFL99",
+    "instantiation": "false",
+    "additional_cooling_fan_speed": [
+        "70"
+    ],
+    "close_fan_the_first_x_layers": [
+        "1"
+    ],
+    "cool_plate_temp": [
+        "35"
+    ],
+    "cool_plate_temp_initial_layer": [
+        "35"
+    ],
+    "eng_plate_temp": [
+        "0"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "0"
+    ],
+    "fan_cooling_layer_time": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
+    "filament_cost": [
+        "20"
+    ],
+    "filament_density": [
+        "1.24"
+    ],
+    "filament_max_volumetric_speed": [
+        "12"
+    ],
+    "filament_scarf_seam_type": [
+        "none"
+    ],
+    "filament_scarf_gap": [
+        "15%"
+    ],
+    "hot_plate_temp": [
+        "55"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "55"
+    ],
+    "nozzle_temperature": [
+        "220"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "220"
+    ],
+    "nozzle_temperature_range_low": [
+        "190"
+    ],
+    "nozzle_temperature_range_high": [
+        "240"
+    ],
+    "overhang_fan_threshold": [
+        "50%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "4"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
+    "temperature_vitrification": [
+        "45"
+    ],
+    "textured_plate_temp": [
+        "55"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "55"
+    ],
+    "filament_flow_ratio": [
+        "0.98"
+    ]
+}


### PR DESCRIPTION
### TODO

- [x] `Chuanying   - added missing "fdm_..." profiles from system)`
- [x] `Lulzbot     - added missing "fdm_..." profiles from system)`
- [x] `MagicMaker  - removed "inherited" since its a single file)`
- [x] `Snapmaker   - added missing PolyTerra PLA @base from system)`
- [x] `Sovol       - added missing "fdm_..." profiles from system)`
- [x] `TwoTrees    - added missing "fdm_..." profiles from system)`
- [x] `Z-Bolt      - added missing "fdm_..." profiles from system)`
- [x] `Bambulab    - added missing "fdm_..." and "...@base" profiles from system). this one was very messy. changed order of some for fix`
> - [x] `Aliz`
> - [x] `Coax`
> - [x] `Overture`
- [x] Bump versions
- [ ] Check changes

### FIXES
• Probably fixes related issues https://github.com/OrcaSlicer/OrcaSlicer/issues/8800 https://github.com/OrcaSlicer/OrcaSlicer/issues/11704 https://github.com/OrcaSlicer/OrcaSlicer/issues/4371

• Fixes printer cannot be selected on second step creation dialog https://github.com/OrcaSlicer/OrcaSlicer/issues/11704
before - throws error because config files are invalid
<img width="742" height="384" alt="Screenshot-20251227134048" src="https://github.com/user-attachments/assets/02c6b95f-a0d2-4c8e-b699-75019e28ec7b" />

after
<img width="745" height="557" alt="Screenshot-20251227133927" src="https://github.com/user-attachments/assets/47038cc4-208a-4cb3-927a-961823934bb0" />