### PR TITLE
Fix system dependencies on Arch Linux (remove gstreamermm)

### DIFF
--- a/scripts/linux.d/arch
+++ b/scripts/linux.d/arch
@@ -13,7 +13,6 @@ export REQUIRED_DEV_PACKAGES=(
     git
     glew
     gstreamer
-    gstreamermm
     gtk3
     libmspack
     libsecret


### PR DESCRIPTION
# Description

* gstreamermm is no longer required to build OrcaSlicer on Arch-like systems
* gstreamermm no longer exists in the Arch repos: https://archlinux.org/packages/?sort=&q=gstreamermm
* running `./build_linux.sh -u` on Arch-like systems fails with `error: target not found: gstreamermm`

This commit removes the unnecessary dependency.

# Screenshots/Recordings/Graphs

## Tests

**Before**:

```fish
❯ ./build_linux.sh -u
resolving system dependencies for distribution "arch" ...
Updating linux ...
error: package 'gstreamermm' was not found
```

**After**:

```fish
❯ ./build_linux.sh -u
resolving system dependencies for distribution "arch" ...
Updating linux ...
done
```

I've successfully built an run v2.3.1 and v2.3.2-dev many times without the dependency installed.