### PR TITLE
Bug fix: Display max_junction_deviation warning dialogue only on marlin printers

### DIFF
--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -1657,7 +1657,9 @@ StringObjectException Print::validate(StringObjectException *warning, Polygons* 
 
             // Check junction deviation
             const auto max_junction_deviation = m_config.machine_max_junction_deviation.values[0];
-            if (warning_key.empty() && m_default_object_config.default_junction_deviation.value > max_junction_deviation) {
+            // Orca: Only marlin FW supports max junction deviation. Dont display warning if firmware is not supporting it.
+            const bool support_max_junction_deviation = ( m_config.gcode_flavor == gcfMarlinFirmware);
+            if (warning_key.empty() && m_default_object_config.default_junction_deviation.value > max_junction_deviation && support_max_junction_deviation) {
                 warning->string  = L( "Junction deviation setting exceeds the printer's maximum value "
                                       "(machine_max_junction_deviation).\nOrca will "
                                       "automatically cap the junction deviation to ensure it doesn't surpass the printer's "


### PR DESCRIPTION
# Description

max_junction_deviation value is only available for marlin2 printers. Update warning dialogue conditions to only display it for Marlin 2 printers.

Fixes #11889

# Screenshots/Recordings/Graphs

Before:
![image](https://github.com/user-attachments/assets/62f5bbf0-b726-43b0-9c89-7aaee65e35ce)

After:
![image](https://github.com/user-attachments/assets/ec9b83d6-b07d-4885-ba5a-a723387838f5)


