### PR TITLE
Fix: Right Edge of G-code Viewer Legend Rows Not Interactive

### DIFF
--- a/src/slic3r/GUI/GCodeViewer.hpp
+++ b/src/slic3r/GUI/GCodeViewer.hpp
@@ -33,7 +33,8 @@ class OpenGLManager;
 static const float GCODE_VIEWER_SLIDER_SCALE = 0.6f;
 static const float SLIDER_DEFAULT_RIGHT_MARGIN  = 10.0f;
 static const float SLIDER_DEFAULT_BOTTOM_MARGIN = 10.0f;
-static const float SLIDER_RIGHT_MARGIN = 124.0f;
+// ORCA: match right margin to the vertical slider window width to prevent overlap.
+static inline const float SLIDER_RIGHT_MARGIN = IMSlider::vertical_slider_window_width();
 static const float SLIDER_BOTTOM_MARGIN = 64.0f;
 class GCodeViewer
 {

--- a/src/slic3r/GUI/IMSlider.hpp
+++ b/src/slic3r/GUI/IMSlider.hpp
@@ -128,6 +128,8 @@ public:
 
     float m_scale = 1.0;
     void set_scale(float scale = 1.0);
+    // ORCA: expose vertical slider width for right-margin alignment in the preview UI.
+    static float vertical_slider_window_width();
     void on_change_color_mode(bool is_dark);
     void set_menu_enable(bool enable = true) { m_menu_enable = enable; }
 


### PR DESCRIPTION
### Summary

This PR fixes:
- an issue where the **right edge of each legend row** in the G-code Viewer — including the part of the eye-icon visibility toggle located there — **did not respond to mouse hover or clicks** of the viewer
The rest of the row behaved normally.
After switching to any other view type (e.g., Line Type, Layer Height, Speed, etc.), the entire row became interactive as expected unless the vertical layer slider was used.
- an issue of vertical slider label that can overlap with the window on its left side

### What Was Happening

The vertical layer slider stole the focus area, it was overlapping with the windows on its left side.
Because of this, in the legend window the mouse interaction was ignored specifically on the right portion of each row, even though the UI looked correct.
Switching view types caused the legend panel to refresh and become active, which is why the issue disappeared immediately afterward until the vertical slider was used. It was a race for focus.

### Fix

- The legend panel (and not only) is now explicitly placed correctly beside the slider without any overlapping.
This ensures the right-side hover/click region of each legend row (including the visibility toggle) works immediately without requiring any user workaround.
- Vertical slide width was slightly enlarged ensuring 999999 layers and 9999.99 mm height can still be displayed even in single layer view mode (that shifts the label box to the left). I highly doubt a real print can go over those numbers.
- Vertical slide label boxes were changed to a fixed width to not have gaps on their left to the neighboring window (kept a few pixels thou)

### User Impact
- The eye icon and right-edge interaction now work
- No need to switch view types to “wake up” the legend
- Vertical slider label not overlapping with any window beside it
- No other behavior changes

### Notes

This change affects only the alignment of the legend, gcode text, notification and daily tip window in the Preview panel to not overlap with the vertical slide and sit right beside it.
Rendering, legend layout, and view-type logic remain unchanged.

> Special thanks to @yw4z for the help given for this PR

## Screenshots

### The affected area:
![Legend](https://github.com/user-attachments/assets/62dfe29e-38e3-42ed-8aca-33c30d22942b)

### Overlap
- __Before__
![Overlap](https://github.com/user-attachments/assets/d2d4a738-f382-4ae8-9171-d29cfa435833)

- __After__
![999999](https://github.com/user-attachments/assets/f464ab38-e3ff-4f79-89b7-bef51971eb1f)
