### PR TITLE
Fix: Dirty-state marker ("*") not shown for edited system printer presets

### DIFF
--- a/src/slic3r/GUI/PresetComboBoxes.cpp
+++ b/src/slic3r/GUI/PresetComboBoxes.cpp
@@ -1210,14 +1210,24 @@ void PlaterPresetComboBox::update()
             //BBS: move system to the end
             if (m_type == Preset::TYPE_PRINTER) {
                 auto printer_model = preset.config.opt_string("printer_model");
-                name = from_u8(printer_model);
+
+                // ORCA: Make system printer presets display the dirty "*" prefix when edited.
+                name = from_u8(is_selected && preset.is_dirty ? Preset::suffix_modified() + printer_model : printer_model);
+
                 if (system_printer_models.count(printer_model) == 0) {
                     system_presets.emplace(name, bmp);
                     system_printer_models.insert(printer_model);
                 }
+                else if (is_selected) {
+                    const wxString alternate_name = from_u8(preset.is_dirty ? printer_model : Preset::suffix_modified() + printer_model);
+                    // Remove the old preset name if exists, and add the new one with the same name but with modified suffix if needed.
+                    if (system_presets.erase(alternate_name))
+                        system_presets.emplace(name, bmp);
+                }
             } else {
                 system_presets.emplace(name, bmp);
             }
+
             if (is_selected) {
                 tooltip = get_tooltip(preset);
                 selected_system_preset = name;


### PR DESCRIPTION
### Summary
When editing a system printer preset, the sidebar **did not show** the usual “*” marker that indicates **the preset has changes**. All other preset types filament, process, etc.) already show this marker correctly.

### What this PR does
This PR ensures that system printer presets display the modified (“*”) prefix when:
- the preset is system or default, and  
- it is the currently selected preset, and  
- it is marked dirty (edited)

### Why this matters
Without this fix, users receive **no visual indication** that a system printer **preset has been edited**.  
This is inconsistent with how all other presets behave and can cause confusion.

### Result
System printer presets now **correctly display the “*” dirty-state indicator** when edited, matching the behavior of all other preset types.

### Notes
- Affects only sidebar display of system printer presets  
- No changes to selection behavior, preset storage, or underlying preset logic  
- No impact on user-created printer presets  

Fixes #11705

## Screenshots
- __Before:__
<img width="403" height="375" alt="image" src="https://github.com/user-attachments/assets/cd8070bd-30ce-4a4f-b6b4-c5d34944173a" />

- __After:__
<img width="403" height="370" alt="image" src="https://github.com/user-attachments/assets/611d157f-6d27-4d0a-b58d-8f3cf92312da" />
