### PR TITLE
Extend short-travel smoothing to external overhang walls

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -7091,9 +7091,16 @@ std::string GCode::travel_to(const Point& point, ExtrusionRole role, std::string
         if (m_config.default_jerk.value > 0 && m_config.initial_layer_jerk.value > 0) {
             jerk_to_set = m_config.initial_layer_jerk.value;
         }
-    } else {
+    } else { // ORCA: Handle short-travel acceleration and jerk for outer perimeters (if applicable)
+        const bool is_short_travel = travel.length() < scale_(EXTRUDER_CONFIG(retraction_minimum_travel));
+
         if (m_config.default_acceleration.value > 0) {
-            if (role == erExternalPerimeter && travel.length() < scale_(EXTRUDER_CONFIG(retraction_minimum_travel))) {
+            if (role == erOverhangPerimeter && is_short_travel) {
+                const double bridge_acceleration  = m_config.get_abs_value("bridge_acceleration");
+
+                if (bridge_acceleration > 0)
+                    acceleration_to_set = (unsigned int) floor(bridge_acceleration + 0.5);
+            } else if (role == erExternalPerimeter && is_short_travel) {
                 if (m_config.outer_wall_acceleration.value > 0)
                     acceleration_to_set = (unsigned int) floor(m_config.outer_wall_acceleration.value + 0.5);
             } else {
@@ -7103,7 +7110,7 @@ std::string GCode::travel_to(const Point& point, ExtrusionRole role, std::string
         }
 
         if (m_config.default_jerk.value > 0) {
-            if (role == erExternalPerimeter && travel.length() < scale_(EXTRUDER_CONFIG(retraction_minimum_travel))) {
+            if ((role == erExternalPerimeter || role == erOverhangPerimeter) && is_short_travel) {
                 if (m_config.outer_wall_jerk.value > 0)
                     jerk_to_set = m_config.outer_wall_jerk.value;
             } else {


### PR DESCRIPTION
### Summary
Short micro-travels immediately before a perimeter can cause a sudden acceleration impulse, which leads to vibration and ringing on visible surfaces.

Acceleration and jerk for short travels before standard external walls were already reduced. However, external overhang walls were not included and still used full travel acceleration/jerk.

This PR extends the same short-travel smoothing to external overhang walls.

### What this PR does
- Enables short-travel smoothing for **external overhang walls**, which previously behaved like regular travel.
- Uses the configuration’s overhang-wall acceleration (internally `bridge_acceleration`) for short travels leading into overhang walls.
- Applies consistent jerk handling for these external overhang transitions.
- Leaves existing external-wall behavior untouched.

### Overview
- **Only external overhang walls gain new behavior.**
- External walls were already handled and remain unchanged.
- Internal walls, infill, supports, and regular travel moves are not affected.
- No modifications to path planning or move generation.

This PR completes the original smoothing logic and improves consistency across all external-facing perimeter types.

>Although this change improves consistency in how short travels are handled, its practical impact may be limited. External overhang walls are typically single-layer features and do not accumulate ringing artifacts the way multi-layer external walls do. Because of this, the real-world benefit may be marginal. I leave it to the reviewers to decide whether extending this logic to external overhang walls is desirable or if it adds complexity and slicing overhead without meaningful print quality improvement.

### Screenshots
- **Before:**
<img width="1191" height="495" alt="image" src="https://github.com/user-attachments/assets/738a5a63-80d0-43a9-bb21-868a6e2622c7" />

&nbsp;

- **After:**
<img width="1180" height="437" alt="image" src="https://github.com/user-attachments/assets/99bfe421-0bf0-4e53-8b36-ecd31e031c2e" />
