### PR TITLE
Preserve project filament config across printer changes

### DIFF
--- a/src/libslic3r/PresetBundle.hpp
+++ b/src/libslic3r/PresetBundle.hpp
@@ -225,6 +225,31 @@ public:
     // and they are being used by slicing core.
     DynamicPrintConfig          project_config;
 
+    // BBS: Track whether we have project-embedded filament configuration that should be preserved
+    // across printer changes. When true, load_selections() will not overwrite filament colors.
+    bool                        m_has_project_filament_config = false;
+    // Store the project's original filament colors to preserve across printer switches
+    std::vector<std::string>    m_project_filament_colours;
+    // Store the project's original filament presets to preserve across printer switches
+    std::vector<std::string>    m_project_filament_presets;
+    // Store the project's original filament count to preserve across printer switches
+    size_t                      m_project_filament_count = 0;
+    
+    // Set when loading a 3MF with embedded filament config, cleared on new project
+    void set_project_filament_config(const std::vector<std::string>& colors, const std::vector<std::string>& presets) {
+        m_has_project_filament_config = true;
+        m_project_filament_colours = colors;
+        m_project_filament_presets = presets;
+        m_project_filament_count = presets.size();
+    }
+    void clear_project_filament_config() {
+        m_has_project_filament_config = false;
+        m_project_filament_colours.clear();
+        m_project_filament_presets.clear();
+        m_project_filament_count = 0;
+    }
+    bool has_project_filament_config() const { return m_has_project_filament_config; }
+
     // There will be an entry for each system profile loaded,
     // and the system profiles will point to the VendorProfile instances owned by PresetBundle::vendors.
     VendorMap                   vendors;


### PR DESCRIPTION
# Description

This PR changes the default behavior for multi-material filament settings.
Current: When switching printers or loading a project, OrcaSlicer restores the last-used filament presets/colors for the selected printer, often overwriting imported color regions from 3MF files.
New: If a project or 3MF file includes explicit filament color/preset assignments, those are now preserved and take priority over the printer’s saved configuration. This ensures imported color regions and filament assignments remain consistent across printer changes. 

No breaking changes. Only affects how filament presets/colors are restored when project data is present. If the user has not imported a project with color regions set then the program will behave exactly as before and switch to the last used filaments for a given printer. 

**Changes:**
- Added `PresetBundle` tracking for project filament configuration (colors, presets, count)
- Modified `load_selections()` and `update_selections()` to restore project filament data when present
- Caps filament slots to printer's physical extruder count (multi-extruder) or preserves all slots (SEMM/AMS)
- Integrated with `Plater` to set/clear project config on 3MF load and project reset
- Safe null-checking for config options to prevent crashes

**New Behavior:**
- On 3MF import: Filament colors and presets are stored and persist across printer switches
- With "Remember printer configuration": Project filaments take precedence over saved printer config
- Multi-filament detection handles both multiple extruders and single-extruder multi-material systems

Inspired by Snapmaker's OrcaSlicer fork implementation.

Note:
This logic is independent of the global “ignore printer settings” preference. Users may still want their printer settings (bed size, extruder count, etc.) to update automatically, but filament color/preset assignments from the project should be preserved separately. This keeps filament configuration distinct from general printer settings, providing more predictable and user-friendly multi-material workflows.

# Screenshots/Recordings/Graphs

N/A - Internal preset management logic, no UI changes.

## Tests

Manually tested 10 scenarios:
1. Import 3MF with custom colors → switch printer → colors preserved ✓
2. "Remember printer configuration" enabled → project colors still preserved ✓
3. Multi-extruder printer (3 extruders) → all slots populated ✓
4. SEMM/AMS printer → multi-filament support detected ✓
5. Switch from 5-filament project to 3-extruder printer → capped to 3 slots ✓
6. Switch from 3-filament project to 5-extruder printer → expands to 5 slots ✓
7. Project reset → clears filament tracking ✓
8. Unknown filament presets → appears in "Unsupported" category (expected) ✓
9. Single-extruder non-SEMM printer → single filament only ✓
10. Config option null-checks → no crashes ✓