### PR TITLE
Fix Z-before-XY movement in multi-extruder prints with wipe tower

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -3106,8 +3106,13 @@ void GCode::_do_export(Print& print, GCodeOutputStream &file, ThumbnailsGenerato
                 m_wipe_tower->set_wipe_tower_depth(print.get_wipe_tower_depth());
                 m_wipe_tower->set_wipe_tower_bbx(print.get_wipe_tower_bbx());
                 m_wipe_tower->set_rib_offset(print.get_rib_offset());
-                //BBS
-                file.write(m_writer.travel_to_z(initial_layer_print_height + m_config.z_offset.value, "Move to the first layer height"));
+                //BBS: Update Z position without emitting standalone Z move
+                // Mark position unclear and just update internal state. Z movement will happen
+                // with first travel_to() which moves XY first, preventing nozzle drag.
+                m_writer.set_current_position_clear(false);
+                Vec3d pos = m_writer.get_position();
+                pos(2) = initial_layer_print_height + m_config.z_offset.value;
+                m_writer.set_position(pos);
 
                 if (!is_bbl_printers && print.config().single_extruder_multi_material_priming) {
                     file.write(m_wipe_tower->prime(*this));


### PR DESCRIPTION


# Description
When wipe tower is enabled, OrcaSlicer generates a standalone Z move before any XY positioning after PRINT_START. This causes the nozzle to travel horizontally at first layer height, potentially dragging across the bed or hitting clips.

Root cause: travel_to_z() was called when initializing the wipe tower, emitting G1 Z before any XY moves.

Solution: Update the writer's internal Z position and mark it unclear instead of calling travel_to_z(). The Z movement is deferred to the first travel_to() which moves XY first, then Z.



# Screenshots/Recordings/Graphs

Before:
<img width="813" height="742" alt="Screenshot 2026-01-17 110330" src="https://github.com/user-attachments/assets/4cff59dc-46fb-402e-833f-901bbbab5f9a" />

After:
<img width="777" height="681" alt="Screenshot 2026-01-17 152714" src="https://github.com/user-attachments/assets/8b850617-5ab9-4028-ab37-bcb557f8d4da" />


## Tests

Sliced SEMM object with multi color and inspected gcode file.
