### PR TITLE
Port CrealityPrint Overhang Optimization

### DIFF
--- a/src/libslic3r/CMakeLists.txt
+++ b/src/libslic3r/CMakeLists.txt
@@ -319,6 +319,8 @@ set(lisbslic3r_sources
     Optimize/Optimizer.hpp
     Orient.cpp
     Orient.hpp
+    OverhangOptimization.cpp
+    OverhangOptimization.hpp
     ParameterUtils.cpp
     ParameterUtils.hpp
     pchheader.cpp

--- a/src/libslic3r/Flow.cpp
+++ b/src/libslic3r/Flow.cpp
@@ -108,7 +108,7 @@ double Flow::extrusion_width(const std::string& opt_key, const ConfigOptionResol
 
 // This constructor builds a Flow object from an extrusion width config setting
 // and other context properties.
-Flow Flow::new_from_config_width(FlowRole role, const ConfigOptionFloatOrPercent &width, float nozzle_diameter, float height)
+Flow Flow::new_from_config_width(FlowRole role, const ConfigOptionFloatOrPercent& width, float nozzle_diameter, float height, float adaptive_width)
 {
     if (height <= 0)
         throw Slic3r::InvalidArgument("Invalid flow height supplied to new_from_config_width()");
@@ -119,7 +119,9 @@ Flow Flow::new_from_config_width(FlowRole role, const ConfigOptionFloatOrPercent
         w = auto_extrusion_width(role, nozzle_diameter);
     } else {
         // If user set a manual value, use it.
-      w = float(width.get_abs_value(nozzle_diameter));
+        w = float(width.get_abs_value(nozzle_diameter));
+        if (role == frExternalPerimeter && (adaptive_width > EPSILON))
+            w = adaptive_width;
     }
     
     return Flow(w, height, rounded_rectangle_extrusion_spacing(w, height), nozzle_diameter, false);

--- a/src/libslic3r/Flow.hpp
+++ b/src/libslic3r/Flow.hpp
@@ -105,7 +105,7 @@ public:
 
     static Flow bridging_flow(float dmr, float nozzle_diameter) { return Flow { dmr, dmr, bridge_extrusion_spacing(dmr), nozzle_diameter, true }; }
 
-    static Flow new_from_config_width(FlowRole role, const ConfigOptionFloatOrPercent &width, float nozzle_diameter, float height);
+    static Flow new_from_config_width(FlowRole role, const ConfigOptionFloatOrPercent &width, float nozzle_diameter, float height, float adaptive_width = 0.0f);
 
     // Spacing of extrusions with rounded extrusion model.
     static float rounded_rectangle_extrusion_spacing(float width, float height);

--- a/src/libslic3r/Layer.hpp
+++ b/src/libslic3r/Layer.hpp
@@ -243,15 +243,17 @@ public:
 
     size_t get_extruder_id(unsigned int filament_id) const;
 
+    coordf_t outer_perimeter_width() const { return m_outer_perimeter_width; }
+
 protected:
     friend class PrintObject;
-    friend std::vector<Layer*> new_layers(PrintObject*, const std::vector<coordf_t>&);
+    friend std::vector<Layer*> new_layers(PrintObject*, const std::vector<coordf_t>&, const std::vector<coordf_t>&);
     friend std::string fix_slicing_errors(PrintObject* object, LayerPtrs&, const std::function<void()>&, int &);
 
-    Layer(size_t id, PrintObject *object, coordf_t height, coordf_t print_z, coordf_t slice_z) :
+    Layer(size_t id, PrintObject *object, coordf_t height, coordf_t print_z, coordf_t slice_z, coordf_t outer_perimeter_width = 0.0) :
         upper_layer(nullptr), lower_layer(nullptr), slicing_errors(false),
         slice_z(slice_z), print_z(print_z), height(height),
-        m_id(id), m_object(object) {}
+        m_id(id), m_object(object), m_outer_perimeter_width(outer_perimeter_width) {}
     virtual ~Layer();
 
 //BBS: method to simplify support path
@@ -265,6 +267,8 @@ private:
     size_t              m_id;
     PrintObject        *m_object;
     LayerRegionPtrs     m_regions;
+
+    float m_outer_perimeter_width;
 };
 
 enum SupportInnerType {

--- a/src/libslic3r/LayerRegion.cpp
+++ b/src/libslic3r/LayerRegion.cpp
@@ -24,7 +24,7 @@ Flow LayerRegion::flow(FlowRole role) const
 
 Flow LayerRegion::flow(FlowRole role, double layer_height) const
 {
-    return m_region->flow(*m_layer->object(), role, layer_height, m_layer->id() == 0);
+    return m_region->flow(*m_layer->object(), role, layer_height, m_layer->id() == 0, m_layer->outer_perimeter_width());
 }
 
 Flow LayerRegion::bridging_flow(FlowRole role, bool thick_bridge) const

--- a/src/libslic3r/OverhangOptimization.cpp
+++ b/src/libslic3r/OverhangOptimization.cpp
@@ -1,0 +1,460 @@
+#include "OverhangOptimization.hpp"
+#include "TriangleMesh.hpp"
+#include "Model.hpp"
+#include "TriangleMeshSlicer.hpp"
+//--output-----
+//#include <iostream>
+//#include <fstream>
+//#include <iomanip>
+
+
+#define EPS 1e-4
+#define THRESHOLD 0.02f
+namespace Slic3r {
+
+	void OverhangOptimization::init(
+        const ModelObject&          object,
+        float                       layer_height,
+        const std::vector<double>&  layer_height_profile,
+        Transform3d                 m_trafo)
+	{
+		TriangleMesh mesh                   = object.raw_mesh();
+        TriangleMesh mesh_copy              = mesh;
+		init_layer_height = layer_height;
+		input_layer_height = layer_height_profile;
+		const ModelInstance &first_instance = *object.instances.front();
+		mesh.transform(first_instance.get_matrix(), first_instance.is_left_handed());
+
+		face_layer.reserve(mesh.facets_count());
+		for (stl_triangle_vertex_indices face : mesh.its.indices) {
+			stl_vertex vertex[3] = { mesh.its.vertices[face[0]], mesh.its.vertices[face[1]], mesh.its.vertices[face[2]] };
+			stl_vertex n         = face_normal_normalized(vertex);
+			std::pair<float, float> face_z_span {
+				std::min(std::min(vertex[0].z(), vertex[1].z()), vertex[2].z()),
+				std::max(std::max(vertex[0].z(), vertex[1].z()), vertex[2].z())
+			};
+			face_layer.emplace_back(Face_Layer({ face_z_span, n }));
+			if (face_z_span.first < height_min)
+				height_min = face_z_span.first;
+			if (face_z_span.second > height_max)
+				height_max = face_z_span.second;
+		}
+
+		float obj_height = height_max - height_min;
+		MeshSlicingParamsEx slicing_params_ex;
+		slicing_params_ex.trafo = m_trafo;
+		std::vector<float> z_values;
+		int layerNum = obj_height / 0.1f;
+		for (int i = 0; i < layerNum; i++)
+		{
+			z_values.push_back((i+1)*0.1f);
+		}
+		overhang_ratio = get_mesh_overhang(mesh_copy.its, z_values, slicing_params_ex);
+       
+        //std::ofstream outfile_input("input_overhang.txt");
+        for (int i = 0; i < overhang_ratio.size(); i++) {
+            if (overhang_ratio[i] > THRESHOLD) 
+			{
+                is_quick = false;
+                break;
+			}
+           // outfile_input << overhang_ratio[i] << std::endl;
+        }
+        //outfile_input.close();*/
+		//std::sort(face_layer.begin(), face_layer.end(), [](const Face_Layer &f1, const Face_Layer &f2) { return f1.z_span < f2.z_span; });
+	}
+
+	std::vector<double> OverhangOptimization::get_layer_height()
+	{
+        // std::vector<float> result_b;
+        float obj_height = height_max - height_min;
+        // int layer_n = (int)(obj_height / init_layer_height);
+        // result_b.resize(layer_n,init_layer_height);
+        std::vector<double> result;
+       /* if (is_quick) {
+            double first_temp_height = 0;
+            while (first_temp_height <= obj_height) {
+                result.push_back(first_temp_height);
+                result.push_back(init_layer_height);
+                first_temp_height += init_layer_height;
+            }
+            return result;
+        }*/
+        std::vector<std::pair<float, float>> change_height;
+
+        stl_vertex up_nor = Vec3f(0.f, 0.f, -1.f);
+        // 0.3420 cos70
+        for (Face_Layer& fl : face_layer) {
+            // float arc_zeor = up_nor.dot(Vec3f(0.f,0.f,-1.f));
+
+            float arc = fl.nor.dot(up_nor);
+            if (arc < 0.998f && arc >= 0.866f) {
+                // change_height.push_back(fl.span);
+                // int bot_z = (int)(fl.z_span.first / init_layer_height) ;
+                // int up_z = (int)(fl.z_span.second / init_layer_height) ;
+                if (change_height.empty()) {
+                    change_height.push_back(fl.z_span);
+                    continue;
+                }
+
+                bool pass = false;
+                for (int ci = 0; ci < change_height.size(); ci++) {
+                    if (fl.z_span.first >= change_height[ci].first && fl.z_span.first <= change_height[ci].second) {
+                        if (fl.z_span.second > change_height[ci].second) {
+                            change_height[ci].second = fl.z_span.second;
+                            pass                     = true;
+                        }
+                    }
+
+                    if (fl.z_span.second >= change_height[ci].first && fl.z_span.second <= change_height[ci].second) {
+                        if (fl.z_span.first < change_height[ci].first) {
+                            change_height[ci].first = fl.z_span.first;
+                            pass                    = true;
+                        }
+                    }
+
+                    if (fl.z_span.first >= change_height[ci].first && fl.z_span.second <= change_height[ci].second)
+                        pass = true;
+
+                    if (pass)
+                        break;
+                }
+
+                if (!pass)
+                    change_height.push_back(fl.z_span);
+
+                // for (int i = bot_z; i <= up_z; i++)
+                //{
+                //	result_b[i] = 0.1f;
+                //	//result_b.insert(result_b.begin() + i,0.1f);
+                // }
+            }
+        }
+
+        //---next work
+       
+#if 0
+		bool is_filter = false;
+		if (input_layer_height.size() < (obj_height / (10.f * init_layer_height)))
+		{
+			float print_z = 0.f;
+			std::vector<bool> ch_mark(change_height.size(),false);
+			while (print_z + EPS < obj_height)
+			{
+				float current_z = print_z + init_layer_height;
+				int layer_z = current_z / 0.1f;				
+				//if(1)
+			
+				if (overhang_ratio[layer_z] > THRESHOLD)
+				{
+					for (int ci = 0; ci < change_height.size(); ci++)
+					{
+						if (current_z > change_height[ci].first && current_z < change_height[ci].second)
+						{
+							if(!ch_mark[ci]/*&&print_z <= change_height[ci].first*/)
+							//if (print_z <= change_height[ci].first)
+							{
+								double sz = (double)(change_height[ci].first - print_z);
+								print_z = change_height[ci].first;
+								result.push_back(print_z);
+								result.push_back(sz);
+
+
+								while ((print_z + 0.1f + EPS) <= change_height[ci].second)
+								{
+									print_z += 0.1f;
+									result.push_back(print_z);
+									result.push_back(0.1f);
+								}
+
+								double szz = (double)(change_height[ci].second - print_z);
+								print_z = change_height[ci].second;
+								result.push_back(print_z);
+								result.push_back(szz);
+								ch_mark[ci] = true;
+							}
+						}
+					}
+				}
+				else
+				{
+					is_filter = true;
+				}
+				result.push_back(print_z);
+				result.push_back(init_layer_height);
+				print_z += init_layer_height;
+			}
+		}
+		else
+		{
+			std::vector<std::pair<int, int>> enter_area;
+			for (int ci = 0; ci < change_height.size(); ci++)
+			{				
+				int begin = -1;
+				int end = -1;
+				int current_ci = -1;
+				for (int i = 0; i < input_layer_height.size(); i += 2)
+				{
+					if (begin != -1 && current_ci!=-1&&input_layer_height[i]>=change_height[current_ci].second)
+					{
+						end = i;
+					}
+					if (begin == -1 && input_layer_height[i] > change_height[ci].first && input_layer_height[i] < change_height[ci].second)
+					{						
+						begin = i;
+						current_ci = ci;
+					}
+					if (end != -1 && begin != -1)
+					{
+						break;
+					}
+				}
+				if (end != -1 && begin != -1)
+					enter_area.push_back(std::make_pair(begin,end));
+			}
+
+
+			std::sort(enter_area.begin(), enter_area.end(), [&](std::pair<int, int> a, std::pair<int, int> b) { return a.first < b.first; });
+			std::vector<bool> mark_h(input_layer_height.size(),false);
+			for (int i = 0; i < enter_area.size(); i++)
+			{
+				for (int ei = enter_area[i].first; ei <= enter_area[i].second; ei++)
+				{
+					mark_h[ei] = true;
+				}
+			}
+
+			enter_area.clear();
+			int begin = -1;
+			int end = -1;
+			for (int i = 0; i < mark_h.size(); i++)
+			{
+				if (i != 0)
+				{
+					if (mark_h[i] && !mark_h[i - 1])
+					{
+						begin = i;
+					}
+					if (!mark_h[i] && mark_h[i - 1])
+					{
+						end = i-1;
+					}
+				}
+				if (begin != -1 && end != -1)
+				{
+					enter_area.push_back(std::make_pair(begin,end));
+					begin = -1;
+					end = -1;
+				}
+			}
+
+			
+			for (int i = 0; i < input_layer_height.size(); i+=1)
+			{
+				bool is_pass = false;
+				for (int ei = 0; ei < enter_area.size(); ei++)
+				{
+					int f_index = enter_area[ei].first;
+					int e_index = enter_area[ei].second;
+					if (i >= f_index && i < e_index&&(i%2)==0)
+					{						
+						//overhang_ratio[layer_z];
+						//int index = f_index;
+						for (float current_z = input_layer_height[f_index]; current_z < input_layer_height[e_index]; /*current_z += 0.1f*/)
+						{			
+							int layer_z = current_z / 0.1f;
+							if (overhang_ratio[layer_z] < THRESHOLD&&(i%2)==0)
+							{								
+								//int end_index = input_layer_height[e_index] / 0.1f;
+								//int span = end_index - layer_z;
+								//float equal_height = input_layer_height[index];
+								///*if (span > 0 && span <= 5 && (index % 2) == 0)
+								//{
+								//	equal_height = 0.1f+(input_layer_height[index+1] - 0.1f) / (span*1.0f);
+								//}*/
+								//result.push_back(equal_height);
+								//result.push_back(input_layer_height[index+1]);
+								//current_z += input_layer_height[index+1];
+								//current_z -= 0.1f;
+								//index += 2;
+								
+								int qi = -1;
+								for (int hi = f_index-2; hi < e_index; hi += 2)
+								{
+									if (current_z >= input_layer_height[hi] /*&& current_z < input_layer_height[hi + 2]*/)
+									{
+										qi = hi;
+										break;
+									}
+								}
+
+								result.push_back(current_z);
+								result.push_back(input_layer_height[qi+1]);
+								current_z += input_layer_height[qi + 1];
+								is_filter = true;
+								continue;						
+							}
+
+							result.push_back(current_z);
+							result.push_back(0.1f);
+							current_z += 0.1f;
+						}
+						i = e_index-1;
+						is_pass = true;
+						break;
+					}
+				}
+				if (!is_pass)
+				{
+					result.push_back(input_layer_height[i]);
+				}
+			}
+		}
+#else
+        for (int ci = 0; ci < change_height.size(); ci++) {
+            if ((change_height[ci].second - change_height[ci].first) < init_layer_height) {
+                change_height.erase(change_height.begin() + ci);
+                ci--;
+            }
+        }
+
+        std::vector<std::pair<int, int>> mark_overhang_beginAndend_index;
+        for (int ci = 0; ci < change_height.size(); ci++) {
+            int index_b = -1;
+            int index_e = -1;
+            for (int i = 0; i < input_layer_height.size(); i += 2) {
+                if (input_layer_height[i] > (change_height[ci].first - init_layer_height) && input_layer_height[i] < change_height[ci].first) {
+                    index_b = i;
+                }
+                if (input_layer_height[i] > change_height[ci].second && input_layer_height[i] < change_height[ci].second + init_layer_height) {
+                    index_e = i;
+                }
+                if (index_b != -1 && index_e != -1) {
+                    mark_overhang_beginAndend_index.push_back(std::make_pair(index_b, index_e));
+                    break;
+                }
+            }
+        }
+
+        if (input_layer_height.size() < (obj_height / (10.f * init_layer_height))) {
+            float print_z = 0.f;
+            while (print_z + EPS < obj_height) {
+                bool is_change = false;
+                for (int ci = 0; ci < change_height.size(); ci++) {
+                    if (print_z > change_height[ci].first - init_layer_height && print_z < change_height[ci].second + init_layer_height) {
+                        is_change = true;
+                        for (; print_z < change_height[ci].second + init_layer_height; /*print_z += 0.1f*/) {
+                            int layer_z = print_z / 0.1f;
+                            if (overhang_ratio[layer_z] < THRESHOLD) {
+                                result.push_back(print_z);
+                                result.push_back(init_layer_height);
+                                print_z += init_layer_height;
+                                continue;
+                            }
+                            result.push_back(print_z);
+                            result.push_back(0.1f);
+                            print_z += 0.1f;
+                        }
+                    }
+                    if (is_change)
+                        break;
+                }
+
+                if (!is_change) {
+                    result.push_back(print_z);
+                    result.push_back(init_layer_height);
+                    print_z += init_layer_height;
+                }
+            }			
+        } else {
+            std::vector<std::pair<int, int>> enter_area;
+            for (int ci = 0; ci < change_height.size(); ci++) {
+                int begin      = -1;
+                int end        = -1;
+                int current_ci = -1;
+                for (int i = 0; i < input_layer_height.size(); i += 2) {
+                    if (begin != -1 && current_ci != -1 && input_layer_height[i] >= change_height[current_ci].second) {
+                        end = i;
+                    }
+                    if (begin == -1 && input_layer_height[i] > change_height[ci].first && input_layer_height[i] < change_height[ci].second) {
+                        begin      = i;
+                        current_ci = ci;
+                    }
+                    if (end != -1 && begin != -1) {
+                        break;
+                    }
+                }
+                if (end != -1 && begin != -1)
+                    enter_area.push_back(std::make_pair(begin, end));
+            }
+
+            std::sort(enter_area.begin(), enter_area.end(), [&](std::pair<int, int> a, std::pair<int, int> b) { return a.first < b.first; });
+            std::vector<bool> mark_h(input_layer_height.size(), false);
+            for (int i = 0; i < enter_area.size(); i++) {
+                for (int ei = enter_area[i].first; ei <= enter_area[i].second; ei++) {
+                    mark_h[ei] = true;
+                }
+            }
+
+            enter_area.clear();
+            int begin = -1;
+            int end   = -1;
+            for (int i = 0; i < mark_h.size(); i++) {
+                if (i != 0) {
+                    if (mark_h[i] && !mark_h[i - 1]) {
+                        begin = i;
+                    }
+                    if (!mark_h[i] && mark_h[i - 1]) {
+                        end = i - 1;
+                    }
+                }
+                if (begin != -1 && end != -1) {
+                    enter_area.push_back(std::make_pair(begin, end));
+                    begin = -1;
+                    end   = -1;
+                }
+            }
+
+            for (int i = 0; i < input_layer_height.size(); i += 1) {
+                bool is_pass = false;
+                for (int ei = 0; ei < enter_area.size(); ei++) {
+                    int f_index = enter_area[ei].first;
+                    int e_index = enter_area[ei].second;
+                    if (i >= f_index && i < e_index && (i % 2) == 0) {
+                        for (float current_z = input_layer_height[f_index]; current_z < input_layer_height[e_index]; /*current_z += 0.1f*/) {
+                            int layer_z = current_z / 0.1f;
+                            if (overhang_ratio[layer_z] < THRESHOLD && (i % 2) == 0) {
+                                int qi = -1;
+                                for (int hi = f_index - 2; hi < e_index; hi += 2) {
+                                    if (current_z >= input_layer_height[hi] /*&& current_z < input_layer_height[hi + 2]*/) {
+                                        qi = hi;
+                                        break;
+                                    }
+                                }
+
+                                result.push_back(current_z);
+                                result.push_back(input_layer_height[qi + 1]);
+                                current_z += input_layer_height[qi + 1];
+                                // is_filter = true;
+                                continue;
+                            }
+
+                            result.push_back(current_z);
+                            result.push_back(0.1f);
+                            current_z += 0.1f;
+                        }
+                        i       = e_index - 1;
+                        is_pass = true;
+                        break;
+                    }
+                }
+                if (!is_pass) {
+                    result.push_back(input_layer_height[i]);
+                }
+            }
+        }
+
+#endif
+        return result;
+	}
+}

--- a/src/libslic3r/OverhangOptimization.hpp
+++ b/src/libslic3r/OverhangOptimization.hpp
@@ -1,0 +1,33 @@
+#ifndef OVERHANGOPTIMIZATION_HPP
+#define OVERHANGOPTIMIZATION_HPP
+
+#include "Model.hpp"
+#include "admesh/stl.h"
+#include <vector>
+#include <utility>
+
+namespace Slic3r {
+
+class OverhangOptimization
+{
+public:
+    void init(const ModelObject& object, float layer_height, const std::vector<double>& input_layer_height, Transform3d m_trafo);
+	std::vector<double> get_layer_height();
+
+private:
+	struct Face_Layer {
+		std::pair<float, float> z_span;
+
+		stl_vertex nor;
+	};
+	std::vector<Face_Layer> face_layer;
+	std::vector<double>     input_layer_height;
+    std::vector<float>      overhang_ratio;
+	float                   init_layer_height;
+	float                   height_max = -10000.f;
+	float                   height_min = 10000.f;
+    bool                    is_quick   = true;
+};
+}
+
+#endif

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -898,7 +898,7 @@ static std::vector<std::string> s_Preset_print_options {
     "ironing_type", "ironing_pattern", "ironing_flow", "ironing_speed", "ironing_spacing", "ironing_angle", "ironing_angle_fixed", "ironing_inset",
     "support_ironing", "support_ironing_pattern", "support_ironing_flow", "support_ironing_spacing",
     "max_travel_detour_distance",
-    "overhang_optimization",
+    "overhang_outer_wall_optimization", "overhang_layer_height_optimization",
     "fuzzy_skin", "fuzzy_skin_thickness", "fuzzy_skin_point_distance", "fuzzy_skin_first_layer", "fuzzy_skin_noise_type", "fuzzy_skin_mode", "fuzzy_skin_scale", "fuzzy_skin_octaves", "fuzzy_skin_persistence",
     "max_volumetric_extrusion_rate_slope", "max_volumetric_extrusion_rate_slope_segment_length","extrusion_rate_smoothing_external_perimeter_only",
     "inner_wall_speed", "outer_wall_speed", "sparse_infill_speed", "internal_solid_infill_speed",

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -898,6 +898,7 @@ static std::vector<std::string> s_Preset_print_options {
     "ironing_type", "ironing_pattern", "ironing_flow", "ironing_speed", "ironing_spacing", "ironing_angle", "ironing_angle_fixed", "ironing_inset",
     "support_ironing", "support_ironing_pattern", "support_ironing_flow", "support_ironing_spacing",
     "max_travel_detour_distance",
+    "overhang_optimization",
     "fuzzy_skin", "fuzzy_skin_thickness", "fuzzy_skin_point_distance", "fuzzy_skin_first_layer", "fuzzy_skin_noise_type", "fuzzy_skin_mode", "fuzzy_skin_scale", "fuzzy_skin_octaves", "fuzzy_skin_persistence",
     "max_volumetric_extrusion_rate_slope", "max_volumetric_extrusion_rate_slope_segment_length","extrusion_rate_smoothing_external_perimeter_only",
     "inner_wall_speed", "outer_wall_speed", "sparse_infill_speed", "internal_solid_infill_speed",

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -1319,9 +1319,9 @@ StringObjectException Print::validate(StringObjectException *warning, Polygons* 
         }
 
         if (print_object.has_support_material() && is_tree(print_object.config().support_type.value)
-            && (print_object.config().support_style.value == smsTreeOrganic) && print_object.config().overhang_optimization.value) {
+            && (print_object.config().support_style.value == smsTreeOrganic) && print_object.config().overhang_layer_height_optimization.value) {
             if (const std::vector<coordf_t>& layers = layer_height_profile(print_object_idx); !layers.empty())
-                return {_u8L("Overhang Optimization is not supported with Organic supports.")};
+                return {_u8L("Overhang Layer Height Optimization is not supported with Organic supports.")};
         }
     }
 

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -1303,16 +1303,27 @@ StringObjectException Print::validate(StringObjectException *warning, Polygons* 
         != m_objects.end();
 
     // Custom layering is not allowed for tree supports as of now.
-    for (size_t print_object_idx = 0; print_object_idx < m_objects.size(); ++ print_object_idx)
-        if (const PrintObject &print_object = *m_objects[print_object_idx];
-            print_object.has_support_material() && is_tree(print_object.config().support_type.value) && (print_object.config().support_style.value == smsTreeOrganic || 
-                // Orca: use organic as default
-                print_object.config().support_style.value == smsDefault) &&
-            print_object.model_object()->has_custom_layering()) {
-            if (const std::vector<coordf_t> &layers = layer_height_profile(print_object_idx); ! layers.empty())
-                if (! check_object_layers_fixed(print_object.slicing_parameters(), layers))
-                    return {_u8L("Variable layer height is not supported with Organic supports.") };
+    for (size_t print_object_idx = 0; print_object_idx < m_objects.size(); ++ print_object_idx) {
+        PrintObject &print_object = *m_objects[print_object_idx];
+        print_object.has_variable_layer_heights = false;
+        // use TreeHybrid as default
+        if (print_object.has_support_material() && is_tree(print_object.config().support_type.value) &&
+             print_object.model_object()->has_custom_layering()) {
+            if (const std::vector<coordf_t>& layers = layer_height_profile(print_object_idx); !layers.empty())
+                if (!check_object_layers_fixed(print_object.slicing_parameters(), layers)) {
+                    print_object.has_variable_layer_heights = true;
+                    BOOST_LOG_TRIVIAL(warning) << "print_object: " << print_object.model_object()->name
+                                               << " has_variable_layer_heights: " << print_object.has_variable_layer_heights;
+                    if (print_object.config().support_style.value == smsTreeOrganic) return {_u8L("Variable layer height is not supported with Organic supports.")};
+                }
         }
+
+        if (print_object.has_support_material() && is_tree(print_object.config().support_type.value)
+            && (print_object.config().support_style.value == smsTreeOrganic) && print_object.config().overhang_optimization.value) {
+            if (const std::vector<coordf_t>& layers = layer_height_profile(print_object_idx); !layers.empty())
+                return {_u8L("Overhang Optimization is not supported with Organic supports.")};
+        }
+    }
 
     if (this->has_wipe_tower() && ! m_objects.empty()) {
         // Make sure all extruders use same diameter filament and have the same nozzle diameter

--- a/src/libslic3r/Print.hpp
+++ b/src/libslic3r/Print.hpp
@@ -120,7 +120,7 @@ public:
     int                         print_object_region_id() const throw() { return m_print_object_region_id; }
 	// 1-based extruder identifier for this region and role.
 	unsigned int 				extruder(FlowRole role) const;
-    Flow                        flow(const PrintObject &object, FlowRole role, double layer_height, bool first_layer = false) const;
+    Flow                        flow(const PrintObject &object, FlowRole role, double layer_height, bool first_layer = false, float width = 0.0f) const;
     // Average diameter of nozzles participating on extruding this region.
     coordf_t                    nozzle_dmr_avg(const PrintConfig &print_config) const;
     // Average diameter of nozzles participating on extruding this region.
@@ -463,6 +463,8 @@ public:
 
     // BBS: returns 1-based indices of extruders used to print the first layer wall of objects
     std::vector<int>            object_first_layer_wall_extruders;
+
+    bool                        has_variable_layer_heights = false;
 
     // SoftFever
     size_t get_id() const { return m_id; }

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -4513,6 +4513,14 @@ void PrintConfigDef::init_fff_params()
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionBool(true));
 
+    //yy
+    def = this->add("overhang_optimization", coBool);
+    def->label = L("Overhang Optimization(Beta)");
+    def->category = L("Quality");
+    def->tooltip = L("Adaptive height and line width for each layer. ");
+    def->mode = comAdvanced;
+    def->set_default_value(new ConfigOptionBool(false));
+
     def = this->add("wall_filament", coInt);
     def->gui_type = ConfigOptionDef::GUIType::i_enum_open;
     def->label = L("Walls");

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -4513,11 +4513,17 @@ void PrintConfigDef::init_fff_params()
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionBool(true));
 
-    //yy
-    def = this->add("overhang_optimization", coBool);
-    def->label = L("Overhang Optimization(Beta)");
+    def = this->add("overhang_outer_wall_optimization", coBool);
+    def->label = L("Overhang Outer Wall Optimization(Beta)");
     def->category = L("Quality");
-    def->tooltip = L("Adaptive height and line width for each layer. ");
+    def->tooltip = L("Adaptive outer wall line width for overhangs. ");
+    def->mode = comAdvanced;
+    def->set_default_value(new ConfigOptionBool(false));
+    
+    def = this->add("overhang_layer_height_optimization", coBool);
+    def->label = L("Overhang Layer Height Optimization(Beta)");
+    def->category = L("Quality");
+    def->tooltip = L("Adaptive layer height for overhangs. ");
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionBool(false));
 

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -998,9 +998,8 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionFloat,              tree_support_branch_angle_organic))
     ((ConfigOptionEnum<GapFillTarget>,gap_fill_target))
     ((ConfigOptionFloat,              min_length_factor))
-
-    //yy
-    ((ConfigOptionBool, overhang_optimization))
+    ((ConfigOptionBool,               overhang_outer_wall_optimization))
+    ((ConfigOptionBool,               overhang_layer_height_optimization))
 
     // Move all acceleration and jerk settings to object
     ((ConfigOptionFloat,              default_acceleration))

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -999,6 +999,9 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionEnum<GapFillTarget>,gap_fill_target))
     ((ConfigOptionFloat,              min_length_factor))
 
+    //yy
+    ((ConfigOptionBool, overhang_optimization))
+
     // Move all acceleration and jerk settings to object
     ((ConfigOptionFloat,              default_acceleration))
     ((ConfigOptionFloat,              outer_wall_acceleration))

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -669,7 +669,7 @@ void PrintObject::infill()
     const PrintObjectRegions::LayerRangeRegions layer_range = m_shared_regions->layer_ranges.front();
     auto                                        it          = layer_range.volume_regions.begin();
     temp_region_config                                      = it->region->config();
-    if (m_config.overhang_optimization.value) {
+    if (m_config.overhang_layer_height_optimization.value) {
         temp_region_config = it->region->config();       
         PrintRegionConfig new_config            = temp_region_config;
         new_config.bottom_shell_thickness.value = BOTTOM_SHELL_THICKNESS;
@@ -704,7 +704,7 @@ void PrintObject::infill()
     }
 
     // Reset the region config after infill
-    if (m_config.overhang_optimization.value) {
+    if (m_config.overhang_layer_height_optimization.value) {
         const PrintObjectRegions::LayerRangeRegions layer_range = m_shared_regions->layer_ranges.front();
         auto                                        it          = layer_range.volume_regions.begin();
         it->region->set_config(temp_region_config);

--- a/src/libslic3r/PrintObjectSlice.cpp
+++ b/src/libslic3r/PrintObjectSlice.cpp
@@ -806,7 +806,7 @@ void PrintObject::slice()
         out_wall_width = 0.42 * out_wall_width / 100.f;
 
 
-    if (m_config.overhang_optimization.value) {
+    if (m_config.overhang_layer_height_optimization.value) {
         this->update_layer_height_profile(*this->model_object(), m_slicing_params, layer_height_profile);
         layer_height_profile = layer_height_overhang(m_slicing_params, *this->model_object(), m_slicing_params.layer_height,
                                                     layer_height_profile, trafo);
@@ -814,7 +814,7 @@ void PrintObject::slice()
 
     this->update_layer_height_profile(*this->model_object(), m_slicing_params, layer_height_profile);
     
-    if (m_config.overhang_optimization.value) {
+    if (m_config.overhang_outer_wall_optimization.value) {
         layer_width_profile = layer_width_profile_adaptive(m_slicing_params, *this->model_object(), layer_height_profile,
                                                            out_wall_width, trafo);      
     }

--- a/src/libslic3r/PrintRegion.cpp
+++ b/src/libslic3r/PrintRegion.cpp
@@ -18,7 +18,7 @@ unsigned int PrintRegion::extruder(FlowRole role) const
     return extruder;
 }
 
-Flow PrintRegion::flow(const PrintObject &object, FlowRole role, double layer_height, bool first_layer) const
+Flow PrintRegion::flow(const PrintObject &object, FlowRole role, double layer_height, bool first_layer, float width) const
 {
     const PrintConfig          &print_config = object.print()->config();
     ConfigOptionFloatOrPercent config_width;
@@ -46,7 +46,7 @@ Flow PrintRegion::flow(const PrintObject &object, FlowRole role, double layer_he
     // Get the configured nozzle_diameter for the extruder associated to the flow role requested.
     // Here this->extruder(role) - 1 may underflow to MAX_INT, but then the get_at() will follback to zero'th element, so everything is all right.
     auto nozzle_diameter = float(print_config.nozzle_diameter.get_at(this->extruder(role) - 1));
-    return Flow::new_from_config_width(role, config_width, nozzle_diameter, float(layer_height));
+    return Flow::new_from_config_width(role, config_width, nozzle_diameter, float(layer_height), width);
 }
 
 coordf_t PrintRegion::nozzle_dmr_avg(const PrintConfig &print_config) const

--- a/src/libslic3r/Slicing.hpp
+++ b/src/libslic3r/Slicing.hpp
@@ -155,6 +155,13 @@ std::vector<double> layer_height_profile_adaptive(
     const SlicingParameters& slicing_params,
     const ModelObject& object, float quality_factor);
 
+std::vector<double> layer_height_overhang(
+    const SlicingParameters& slicing_params,
+    const ModelObject&       object,
+    float                    height,
+    std::vector<double>      input_height,
+    Transform3d              trafo = {});
+
 struct HeightProfileSmoothingParams
 {
     unsigned int radius;
@@ -183,6 +190,13 @@ void adjust_layer_height_profile(
     coordf_t                     layer_thickness_delta, 
     coordf_t                     band_width,
     LayerHeightEditActionType    action);
+    
+std::vector<double> layer_width_profile_adaptive(
+    const SlicingParameters& slicing_params,
+    const ModelObject&       object,
+    std::vector<coordf_t>    layer_height_profile,
+    const double             ow_width,
+    Transform3d              trafo = {});
 
 // Produce object layers as pairs of low / high layer boundaries, stored into a linear vector.
 // The object layers are based at z=0, ignoring the raft layers.

--- a/src/libslic3r/SlicingAdaptive.hpp
+++ b/src/libslic3r/SlicingAdaptive.hpp
@@ -15,12 +15,18 @@ class SlicingAdaptive
 {
 public:
     void  clear();
-    void  set_slicing_parameters(SlicingParameters params) { m_slicing_params = params; }
+    void set_slicing_parameters(SlicingParameters params, double ow_width = 0.0f, Transform3d trafo = Transform3d::Identity())
+    {
+        m_slicing_params = params;
+        m_trafo          = trafo;
+        m_outwall_width  = ow_width;
+    }
     void  prepare(const ModelObject &object);
     // Return next layer height starting from the last print_z, using a quality measure
     // (quality in range from 0 to 1, 0 - highest quality at low layer heights, 1 - lowest print quality at high layer heights).
     // The layer height curve shall be centered roughly around the default profile's layer height for quality 0.5.
 	float next_layer_height(const float print_z, float quality, size_t &current_facet);
+    float next_layer_width(const float print_z, float layer_height, size_t& current_facet);
     float horizontal_facet_distance(float z);
 
 	struct FaceZ {
@@ -29,12 +35,17 @@ public:
 		float					n_cos;
 		// Sine of the normal vector towards the Z axis.
 		float					n_sin;
+		bool					up;
 	};
 
 protected:
 	SlicingParameters 		m_slicing_params;
 
 	std::vector<FaceZ>		m_faces;
+
+    double             		m_outwall_width;
+    Transform3d        		m_trafo;
+    std::vector<float> 		m_overhang_ratio;
 };
 
 }; // namespace Slic3r

--- a/src/libslic3r/Support/SupportParameters.hpp
+++ b/src/libslic3r/Support/SupportParameters.hpp
@@ -179,8 +179,17 @@ struct SupportParameters {
         }
         if (support_style == smsDefault) {
             if (is_tree(object_config.support_type)) {
-                // Orca: use organic as default
-                support_style = smsTreeOrganic;
+                // organic support doesn't work with variable layer heights (including adaptive layer height and height range modifier, see #4313)
+                if (!object.has_variable_layer_heights && !object_config.overhang_optimization.getBool() && !slicing_params.soluble_interface)
+                {
+                    BOOST_LOG_TRIVIAL(warning) << "tree support default to organic support";
+                    support_style = smsTreeOrganic;
+                }
+                else
+                {
+                    BOOST_LOG_TRIVIAL(warning) << "tree support default to hybrid tree due to adaptive layer height";
+                    support_style = smsTreeHybrid;
+                }
             } else {
                 support_style = smsGrid;
             }

--- a/src/libslic3r/Support/SupportParameters.hpp
+++ b/src/libslic3r/Support/SupportParameters.hpp
@@ -180,7 +180,7 @@ struct SupportParameters {
         if (support_style == smsDefault) {
             if (is_tree(object_config.support_type)) {
                 // organic support doesn't work with variable layer heights (including adaptive layer height and height range modifier, see #4313)
-                if (!object.has_variable_layer_heights && !object_config.overhang_optimization.getBool() && !slicing_params.soluble_interface)
+                if (!object.has_variable_layer_heights && !object_config.overhang_layer_height_optimization.getBool() && !slicing_params.soluble_interface)
                 {
                     BOOST_LOG_TRIVIAL(warning) << "tree support default to organic support";
                     support_style = smsTreeOrganic;

--- a/src/libslic3r/TriangleMeshSlicer.hpp
+++ b/src/libslic3r/TriangleMeshSlicer.hpp
@@ -94,6 +94,11 @@ inline std::vector<ExPolygons>  slice_mesh_ex(
     return slice_mesh_ex(mesh, zs, params, throw_on_cancel);
 }
 
+std::vector<float> get_mesh_overhang(
+    const indexed_triangle_set& mesh,
+    const std::vector<float>&   zs,
+    const MeshSlicingParams&    params);
+
 // Slice a triangle set with a set of Z slabs (thick layers).
 // The effect is similar to producing the usual top / bottom layers from a sliced mesh by 
 // subtracting layer[i] from layer[i - 1] for the top surfaces resp.

--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -350,28 +350,6 @@ void GLCanvas3D::LayersEditing::render_variable_layer_height_dialog(const GLCanv
 
     ImGui::Separator();
 
-    // add the overhang-optimization related logic
-    bool overhang_optimization_check_state = false;
-    auto object_tab = dynamic_cast<TabPrintModel*>(wxGetApp().get_model_tab());
-    auto object_cfg = object_tab->get_config();
-    overhang_optimization_check_state = object_cfg->opt_bool("overhang_optimization");
-
-    ImGui::SameLine();
-    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + 20);
-    if (imgui.bbl_checkbox("##overhang_optimization", overhang_optimization_check_state)) {
-
-        PageShp quality_page = object_tab->get_page(L("Quality"));
-        if (quality_page) {
-            quality_page->set_value("overhang_optimization", overhang_optimization_check_state);
-            ConfigOptionsGroupShp optgroup = quality_page->get_optgroup(L("Overhangs"));
-            if (optgroup) {
-                optgroup->on_change_OG("overhang_optimization", overhang_optimization_check_state);
-            }
-        }
-    }
-    ImGui::SameLine();
-    imgui.text(_L("Enable Overhang Optimization"));
-
     float get_cur_y = ImGui::GetContentRegionMax().y + ImGui::GetFrameHeight() + canvas.m_main_toolbar.get_height();
     std::map<wxString, wxString> captions_texts = {
         {_L("Left mouse button") + ":" , _L("Add detail")},

--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -350,6 +350,28 @@ void GLCanvas3D::LayersEditing::render_variable_layer_height_dialog(const GLCanv
 
     ImGui::Separator();
 
+    // add the overhang-optimization related logic
+    bool overhang_optimization_check_state = false;
+    auto object_tab = dynamic_cast<TabPrintModel*>(wxGetApp().get_model_tab());
+    auto object_cfg = object_tab->get_config();
+    overhang_optimization_check_state = object_cfg->opt_bool("overhang_optimization");
+
+    ImGui::SameLine();
+    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + 20);
+    if (imgui.bbl_checkbox("##overhang_optimization", overhang_optimization_check_state)) {
+
+        PageShp quality_page = object_tab->get_page(L("Quality"));
+        if (quality_page) {
+            quality_page->set_value("overhang_optimization", overhang_optimization_check_state);
+            ConfigOptionsGroupShp optgroup = quality_page->get_optgroup(L("Overhangs"));
+            if (optgroup) {
+                optgroup->on_change_OG("overhang_optimization", overhang_optimization_check_state);
+            }
+        }
+    }
+    ImGui::SameLine();
+    imgui.text(_L("Enable Overhang Optimization"));
+
     float get_cur_y = ImGui::GetContentRegionMax().y + ImGui::GetFrameHeight() + canvas.m_main_toolbar.get_height();
     std::map<wxString, wxString> captions_texts = {
         {_L("Left mouse button") + ":" , _L("Add detail")},

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -633,6 +633,16 @@ Slic3r::GUI::PageShp Tab::add_options_page(const wxString& title, const std::str
     return page;
 }
 
+PageShp Tab::get_page(const wxString& title)
+{
+    for (PageShp page : m_pages) {
+        if (page->title() == title)
+            return page;
+    }
+
+    return nullptr;
+}
+
 // Names of categories is save in English always. We translate them only for UI.
 // But category "Extruder n" can't be translated regularly (using _()), so
 // just for this category we should splite the title and translate "Extruder" word separately
@@ -1843,6 +1853,13 @@ void Tab::on_value_change(const std::string& opt_key, const boost::any& value)
         }
     }
 
+    if (opt_key == "overhang_optimization") {
+        DynamicPrintConfig new_conf = *m_config;
+        new_conf.set_key_value("overhang_optimization", new ConfigOptionBool(m_config->opt_bool("overhang_optimization")));
+        m_config_manipulation.apply(m_config, &new_conf);
+        wxGetApp().plater()->update();
+    }
+
     string opt_key_without_idx = opt_key.substr(0, opt_key.find('#'));
 
     if (opt_key_without_idx == "long_retractions_when_cut") {
@@ -2409,6 +2426,8 @@ void TabPrint::build()
         optgroup->append_single_option_line("overhang_reverse", "quality_settings_overhangs#reverse-on-even");
         optgroup->append_single_option_line("overhang_reverse_internal_only", "quality_settings_overhangs#reverse-internal-only");
         optgroup->append_single_option_line("overhang_reverse_threshold", "quality_settings_overhangs#reverse-threshold");
+        //yy
+        optgroup->append_single_option_line("overhang_optimization");
 
     page = add_options_page(L("Strength"), "custom-gcode_strength"); // ORCA: icon only visible on placeholders
         optgroup = page->new_optgroup(L("Walls"), L"param_wall");

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -1853,9 +1853,16 @@ void Tab::on_value_change(const std::string& opt_key, const boost::any& value)
         }
     }
 
-    if (opt_key == "overhang_optimization") {
+    if (opt_key == "overhang_outer_wall_optimization") {
         DynamicPrintConfig new_conf = *m_config;
-        new_conf.set_key_value("overhang_optimization", new ConfigOptionBool(m_config->opt_bool("overhang_optimization")));
+        new_conf.set_key_value("overhang_outer_wall_optimization", new ConfigOptionBool(m_config->opt_bool("overhang_outer_wall_optimization")));
+        m_config_manipulation.apply(m_config, &new_conf);
+        wxGetApp().plater()->update();
+    }
+
+    if (opt_key == "overhang_layer_height_optimization") {
+        DynamicPrintConfig new_conf = *m_config;
+        new_conf.set_key_value("overhang_layer_height_optimization", new ConfigOptionBool(m_config->opt_bool("overhang_layer_height_optimization")));
         m_config_manipulation.apply(m_config, &new_conf);
         wxGetApp().plater()->update();
     }
@@ -2426,8 +2433,8 @@ void TabPrint::build()
         optgroup->append_single_option_line("overhang_reverse", "quality_settings_overhangs#reverse-on-even");
         optgroup->append_single_option_line("overhang_reverse_internal_only", "quality_settings_overhangs#reverse-internal-only");
         optgroup->append_single_option_line("overhang_reverse_threshold", "quality_settings_overhangs#reverse-threshold");
-        //yy
-        optgroup->append_single_option_line("overhang_optimization");
+        optgroup->append_single_option_line("overhang_outer_wall_optimization");
+        optgroup->append_single_option_line("overhang_layer_height_optimization");
 
     page = add_options_page(L("Strength"), "custom-gcode_strength"); // ORCA: icon only visible on placeholders
         optgroup = page->new_optgroup(L("Walls"), L"param_wall");

--- a/src/slic3r/GUI/Tab.hpp
+++ b/src/slic3r/GUI/Tab.hpp
@@ -363,6 +363,7 @@ public:
 	void		on_roll_back_value(const bool to_sys = false);
 
 	PageShp		add_options_page(const wxString& title, const std::string& icon, bool is_extruder_pages = false);
+	PageShp		get_page(const wxString& title);
 	static wxString translate_category(const wxString& title, Preset::Type preset_type);
 
 	virtual void	OnActivate();


### PR DESCRIPTION
# Description
This PR adds the overhang optimization feature from CrealityPrint to OrcaSlicer. The purpose of this feature is to adjust the outer wall line width and layer height of overhangs to improve the quality of the print.

The feature works by adding new logic to slicing that creates width profiles that are saved into Layers, which then create Flow objects that apply the width to outer perimeters. Some of the code was cleaned up, though there are some hardcoded values that could probably be implemented as config options. I also noticed that while there is a OverhangOptimization class, some of the logic is done in Slicing.cpp.

I have split the feature control into 2 separate bools, for enabling variable width and height. To get the same results as CrealityPrint, enable both toggles, and use the same wall generator.

There is also currently a bug that causes it to apply to non-overhang layers, see screenshots.

Resolves #12029

# Screenshots/Recordings/Graphs
<img width="2560" height="1395" alt="image" src="https://github.com/user-attachments/assets/21913576-ce17-4664-8384-fb0c63e97ff1" />
<img width="2560" height="1393" alt="image" src="https://github.com/user-attachments/assets/ac0b219a-2159-4f71-9828-896c32d20e44" />
<img width="2559" height="1399" alt="image" src="https://github.com/user-attachments/assets/86c4a338-5202-4896-9740-29dde88de6fa" />

Example of setting affecting non-overhang walls:
<img width="2560" height="1401" alt="Pasted image 20260123161757" src="https://github.com/user-attachments/assets/15eab7a6-7d8a-4d1f-95b5-3df7d0c5431f" />

## Tests
[OverhangOptimizationTest.zip](https://github.com/user-attachments/files/24816878/OverhangOptimizationTest.zip)
I used this project file for testing, comparing the results between my branch and CrealityPrint 7.0.0. You will need to enable Overhang Optimization on CrealityPrint yourself if you wish to test it there as well.
