### PR TITLE
More Controlled 3MF Import: Printer Preset Handling & Filament Mapping For Color Zones

### DIFF
--- a/src/libslic3r/AppConfig.hpp
+++ b/src/libslic3r/AppConfig.hpp
@@ -23,6 +23,8 @@ using namespace nlohmann;
 #define OPTION_PROJECT_LOAD_BEHAVIOUR_ASK_WHEN_RELEVANT "ask_when_relevant"
 #define OPTION_PROJECT_LOAD_BEHAVIOUR_ALWAYS_ASK "always_ask"
 #define OPTION_PROJECT_LOAD_BEHAVIOUR_LOAD_GEOMETRY "load_geometry_only"
+#define SETTING_PROJECT_SKIP_PRINTER "project_skip_printer"
+#define SETTING_PROJECT_SKIP_FILAMENT "project_skip_filament"
 
 #define SETTING_NETWORK_PLUGIN_VERSION "network_plugin_version"
 #define SETTING_NETWORK_PLUGIN_SKIPPED_VERSIONS "network_plugin_skipped_versions"

--- a/src/libslic3r/Format/bbs_3mf.cpp
+++ b/src/libslic3r/Format/bbs_3mf.cpp
@@ -8721,7 +8721,8 @@ bool bbs_3mf_preparse_project_info(const char* path, Bbs3mfProjectInfo& info)
         }
     }
     
-    // If no filament colors found from project_settings, check for model config
+    // If no filament colors found from project_settings.config, try model_settings.config as fallback.
+    // Older 3MF files or non-BBS exports may store filament info in model_settings instead.
     if (info.filament_count == 0) {
         if (mz_zip_reader_locate_file_v2(&archive, "Metadata/model_settings.config", nullptr, 0, &file_index) != MZ_FALSE) {
             mz_zip_archive_file_stat stat;

--- a/src/libslic3r/Format/bbs_3mf.hpp
+++ b/src/libslic3r/Format/bbs_3mf.hpp
@@ -168,8 +168,8 @@ enum class LoadStrategy
     Silence = 32,
     ImperialUnits = 64,
     SkipPainting = 128,       // Skip loading mmu_segmentation, custom_supports, seam, fuzzy_skin data
-    SkipPrinterConfig = 256,  // Skip loading printer settings (keep current printer)
-    SkipFilamentConfig = 512, // Skip loading filament settings (keep current filaments)
+    SkipPrinterConfig = 256,  // Skip loading printer preset (keep user's current printer)
+    SkipFilamentConfig = 512, // Skip loading filament presets (keep user's current filaments)
 
     Restore = 0x10000 | LoadModel | LoadConfig | LoadAuxiliary | Silence,
 };

--- a/src/libslic3r/Model.cpp
+++ b/src/libslic3r/Model.cpp
@@ -370,7 +370,8 @@ Model Model::read_from_file(const std::string&                                  
 // BBS: backup & restore
 // Loading model from a file (3MF or AMF), not from a simple geometry file (STL or OBJ).
 Model Model::read_from_archive(const std::string& input_file, DynamicPrintConfig* config, ConfigSubstitutionContext* config_substitutions, En3mfType& out_file_type, LoadStrategy options,
-        PlateDataPtrs* plate_data, std::vector<Preset*>* project_presets, Semver* file_version, Import3mfProgressFn proFn, BBLProject *project)
+        PlateDataPtrs* plate_data, std::vector<Preset*>* project_presets, Semver* file_version, Import3mfProgressFn proFn, BBLProject *project,
+        const std::map<int, int>* filament_remap)
 {
     assert(config != nullptr);
     assert(config_substitutions != nullptr);
@@ -388,7 +389,7 @@ Model Model::read_from_archive(const std::string& input_file, DynamicPrintConfig
         } else {
             // BBS: add part plate related logic
             // BBS: backup & restore
-            result = load_bbs_3mf(input_file.c_str(), config, config_substitutions, &model, plate_data, project_presets, &is_bbl_3mf, file_version, proFn, options, project);
+            result = load_bbs_3mf(input_file.c_str(), config, config_substitutions, &model, plate_data, project_presets, &is_bbl_3mf, file_version, proFn, options, project, 0, filament_remap);
         }
     }
     else if (boost::algorithm::iends_with(input_file, ".zip.amf"))

--- a/src/libslic3r/Model.hpp
+++ b/src/libslic3r/Model.hpp
@@ -1603,10 +1603,9 @@ public:
     static void setExtruderParams(const DynamicPrintConfig& config, int extruders_count);
 
     // BBS: backup
-    static Model read_from_archive(
-        const std::string& input_file,
-        DynamicPrintConfig* config, ConfigSubstitutionContext* config_substitutions, En3mfType& out_file_type,
-        LoadStrategy options = LoadStrategy::AddDefaultInstances, PlateDataPtrs* plate_data = nullptr, std::vector<Preset*>* project_presets = nullptr, Semver* file_version = nullptr, Import3mfProgressFn proFn = nullptr, BBLProject* project = nullptr);
+    static Model read_from_archive(const std::string& input_file, DynamicPrintConfig* config, ConfigSubstitutionContext* config_substitutions, En3mfType& out_file_type, LoadStrategy options = LoadStrategy::AddDefaultInstances,
+        PlateDataPtrs* plate_data = nullptr, std::vector<Preset*>* project_presets = nullptr, Semver* file_version = nullptr, Import3mfProgressFn proFn = nullptr, BBLProject* project = nullptr,
+        const std::map<int, int>* filament_remap = nullptr);
 
     // Add a new ModelObject to this Model, generate a new ID for this ModelObject.
     ModelObject* add_object();

--- a/src/libslic3r/PresetBundle.hpp
+++ b/src/libslic3r/PresetBundle.hpp
@@ -264,6 +264,11 @@ public:
     void                        load_config_model(const std::string &name, DynamicPrintConfig config, Semver file_version = Semver())
         { this->load_config_file_config(name, true, std::move(config), file_version); }
 
+    // Load configuration from model file with options to skip printer/filament settings
+    void                        load_config_model(const std::string &name, DynamicPrintConfig config, Semver file_version,
+                                                  bool skip_printer, bool skip_filament)
+        { this->load_config_file_config(name, true, std::move(config), file_version, false, skip_printer, skip_filament); }
+
     // Load an external config file containing the print, filament and printer presets.
     // Instead of a config file, a G-code may be loaded containing the full set of parameters.
     // In the future the configuration will likely be read from an AMF file as well.
@@ -378,6 +383,8 @@ private:
     // and the external config is just referenced, not stored into user profile directory.
     // If it is not an external config, then the config will be stored into the user profile directory.
     void                        load_config_file_config(const std::string &name_or_path, bool is_external, DynamicPrintConfig &&config, Semver file_version = Semver(), bool selected = false);
+    void                        load_config_file_config(const std::string &name_or_path, bool is_external, DynamicPrintConfig &&config, Semver file_version, bool selected,
+                                                        bool skip_printer, bool skip_filament);
     /*ConfigSubstitutions         load_config_file_config_bundle(
         const std::string &path, const boost::property_tree::ptree &tree, ForwardCompatibilitySubstitutionRule compatibility_rule);*/
 

--- a/src/slic3r/CMakeLists.txt
+++ b/src/slic3r/CMakeLists.txt
@@ -370,6 +370,8 @@ set(SLIC3R_GUI_SOURCES
     GUI/Plater.cpp
     GUI/Plater.hpp
     GUI/PlateSettingsDialog.cpp
+    GUI/Import3mfDialog.cpp
+    GUI/Import3mfDialog.hpp
     GUI/PlateSettingsDialog.hpp
     GUI/Preferences.cpp
     GUI/Preferences.hpp

--- a/src/slic3r/GUI/Import3mfDialog.cpp
+++ b/src/slic3r/GUI/Import3mfDialog.cpp
@@ -330,16 +330,20 @@ Import3mfDialog::Import3mfDialog(const std::string& filename)
 
 wxColour Import3mfDialog::hex_to_colour(const std::string& hex)
 {
-    if (hex.empty()) return wxColour(128, 128, 128);
+    if (hex.empty()) return wxColour(128, 128, 128);  // Default gray
     
     std::string h = hex;
     if (h[0] == '#') h = h.substr(1);
     
-    if (h.length() >= 6) {
-        unsigned long val = 0;
-        if (sscanf(h.c_str(), "%lx", &val) == 1) {
-            return wxColour((val >> 16) & 0xFF, (val >> 8) & 0xFF, val & 0xFF);
-        }
+    // Validate hex string length
+    if (h.length() < 6) {
+        BOOST_LOG_TRIVIAL(warning) << "Invalid hex color string: " << hex;
+        return wxColour(128, 128, 128);
+    }
+    
+    unsigned long val = 0;
+    if (sscanf(h.c_str(), "%lx", &val) == 1) {
+        return wxColour((val >> 16) & 0xFF, (val >> 8) & 0xFF, val & 0xFF);
     }
     return wxColour(128, 128, 128);
 }
@@ -764,7 +768,10 @@ Import3mfSettings Import3mfDialog::get_import_settings() const
 }
 
 //------------------------------------------------------------------------------
-// Global functions
+// Global state for passing import settings from dialog to loader
+// Note: This pattern is used because determine_3mf_load_type() is called
+// before load_files() and we need to pass the user's choices to the loader.
+// The settings are cleared after use in Plater::open_3mf_file().
 //------------------------------------------------------------------------------
 
 static Import3mfSettings g_pending_3mf_import_settings;

--- a/src/slic3r/GUI/Import3mfDialog.cpp
+++ b/src/slic3r/GUI/Import3mfDialog.cpp
@@ -1,0 +1,867 @@
+#include "Import3mfDialog.hpp"
+
+#include "GUI_App.hpp"
+#include "Plater.hpp"
+#include "MainFrame.hpp"
+#include "I18N.hpp"
+#include "Widgets/Label.hpp"
+#include "Widgets/RadioGroup.hpp"
+#include "Widgets/DialogButtons.hpp"
+#include "Widgets/DropDown.hpp"
+
+#include "libslic3r/AppConfig.hpp"
+#include "libslic3r/Preset.hpp"
+#include "libslic3r/PresetBundle.hpp"
+#include "libslic3r/Format/bbs_3mf.hpp"
+
+#include <boost/format.hpp>
+#include <boost/log/trivial.hpp>
+
+#include <wx/dcbuffer.h>
+#include <wx/graphics.h>
+
+#include <algorithm>
+
+namespace Slic3r {
+namespace GUI {
+
+//------------------------------------------------------------------------------
+// FilamentMappingRow implementation
+//------------------------------------------------------------------------------
+
+FilamentMappingRow::FilamentMappingRow(wxWindow* parent, int filament_index, const wxColour& color,
+                                       const std::vector<std::string>& available_filaments)
+    : wxPanel(parent, wxID_ANY)
+    , m_filament_index(filament_index)
+    , m_color(color)
+{
+    SetBackgroundColour(parent->GetBackgroundColour());
+    
+    wxBoxSizer* sizer = new wxBoxSizer(wxHORIZONTAL);
+    
+    // Color swatch (custom painted panel) - shows project's filament color
+    m_color_swatch = new wxPanel(this, wxID_ANY, wxDefaultPosition, wxSize(FromDIP(24), FromDIP(24)));
+    m_color_swatch->SetMinSize(wxSize(FromDIP(24), FromDIP(24)));
+    m_color_swatch->Bind(wxEVT_PAINT, &FilamentMappingRow::on_paint_swatch, this);
+    sizer->Add(m_color_swatch, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(6));
+    
+    // Slot dropdown - maps project filament to user's filament preset
+    m_slot_dropdown = new ComboBox(this, wxID_ANY, wxEmptyString, wxDefaultPosition, 
+                                   wxSize(FromDIP(180), -1), 0, NULL, wxCB_READONLY);
+    
+    populate_slot_dropdown(available_filaments);
+    
+    // Default to first actual item (skip separator at index 0 if present)
+    if (m_slot_dropdown->GetCount() > 0) {
+        int first_item = m_separator_indices.empty() ? 0 : 1;
+        if (first_item < (int)m_slot_dropdown->GetCount()) {
+            m_slot_dropdown->SetSelection(first_item);
+        }
+    }
+    
+    sizer->Add(m_slot_dropdown, 1, wxALIGN_CENTER_VERTICAL);
+    
+    SetSizer(sizer);
+}
+
+void FilamentMappingRow::populate_slot_dropdown(const std::vector<std::string>& available_filaments)
+{
+    if (!m_slot_dropdown) return;
+    
+    m_slot_dropdown->Clear();
+    m_filament_names.clear();
+    m_separator_indices.clear();
+    
+    PresetBundle* preset_bundle = wxGetApp().preset_bundle;
+    if (!preset_bundle) return;
+    
+    // Group filaments similar to sidebar: User presets first (no submenu), then system by vendor
+    // Using the same approach as PlaterPresetComboBox::update()
+    struct PresetInfo {
+        std::string name;       // Internal preset name
+        std::string label;      // Display label
+        std::string vendor;     // Vendor for grouping
+        std::string type;       // Filament type for sorting
+    };
+    
+    std::vector<PresetInfo> user_presets;
+    std::vector<PresetInfo> system_presets;
+    
+    for (const std::string& preset_name : available_filaments) {
+        const Preset* preset = preset_bundle->filaments.find_preset(preset_name, false);
+        if (!preset) continue;
+        
+        PresetInfo info;
+        info.name = preset_name;
+        info.label = preset->label(false);  // Use alias if available
+        
+        // Get vendor from config
+        const ConfigOptionStrings* vendor_opt = preset->config.option<ConfigOptionStrings>("filament_vendor");
+        if (vendor_opt && !vendor_opt->values.empty() && !vendor_opt->values[0].empty()) {
+            info.vendor = vendor_opt->values[0];
+            // Normalize "Bambu Lab" to "Bambu" like sidebar does
+            if (info.vendor == "Bambu Lab") info.vendor = "Bambu";
+        } else {
+            info.vendor = "Other";
+        }
+        
+        // Get filament type for sorting
+        const ConfigOptionStrings* type_opt = preset->config.option<ConfigOptionStrings>("filament_type");
+        if (type_opt && !type_opt->values.empty()) {
+            info.type = type_opt->values[0];
+        }
+        
+        if (!preset->is_system) {
+            user_presets.push_back(info);
+        } else {
+            system_presets.push_back(info);
+        }
+    }
+    
+    // Sort user presets alphabetically by label
+    std::sort(user_presets.begin(), user_presets.end(), 
+              [](const auto& a, const auto& b) { return a.label < b.label; });
+    
+    // Sort system presets by vendor priority, then type priority, then alphabetically
+    // Same priority as sidebar: Bambu first, then Generic, then others
+    std::vector<std::string> priority_vendors = {"Bambu", "Generic"};
+    std::vector<std::string> priority_types = {"PLA", "PETG", "ABS", "TPU"};
+    
+    std::sort(system_presets.begin(), system_presets.end(), 
+              [&priority_vendors, &priority_types](const auto& a, const auto& b) {
+        // Compare vendor priority
+        auto vendor_idx_a = std::find(priority_vendors.begin(), priority_vendors.end(), a.vendor);
+        auto vendor_idx_b = std::find(priority_vendors.begin(), priority_vendors.end(), b.vendor);
+        if (vendor_idx_a != vendor_idx_b)
+            return vendor_idx_a < vendor_idx_b;
+        
+        // Compare type priority  
+        auto type_idx_a = std::find(priority_types.begin(), priority_types.end(), a.type);
+        auto type_idx_b = std::find(priority_types.begin(), priority_types.end(), b.type);
+        if (type_idx_a != type_idx_b)
+            return type_idx_a < type_idx_b;
+        
+        // Alphabetical by label
+        return a.label < b.label;
+    });
+    
+    // Add user presets at top level (no submenu, just a separator header like sidebar)
+    if (!user_presets.empty()) {
+        // Add separator header for user presets
+        m_separator_indices.push_back(m_slot_dropdown->GetCount());
+        m_slot_dropdown->Append(_L("User presets"), wxNullBitmap, wxEmptyString, nullptr, DD_ITEM_STYLE_SPLIT_ITEM);
+        
+        for (const auto& info : user_presets) {
+            m_slot_dropdown->Append(from_u8(info.label), wxNullBitmap);
+            m_filament_names.push_back(info.name);
+        }
+    }
+    
+    // Add system presets separator header, then grouped by vendor in submenus
+    if (!system_presets.empty()) {
+        m_separator_indices.push_back(m_slot_dropdown->GetCount());
+        m_slot_dropdown->Append(_L("System presets"), wxNullBitmap, wxEmptyString, nullptr, DD_ITEM_STYLE_SPLIT_ITEM);
+        
+        for (const auto& info : system_presets) {
+            m_slot_dropdown->Append(from_u8(info.label), wxNullBitmap, from_u8(info.vendor));
+            m_filament_names.push_back(info.name);
+        }
+    }
+}
+
+void FilamentMappingRow::on_paint_swatch(wxPaintEvent& evt)
+{
+    wxPaintDC dc(m_color_swatch);
+    wxSize size = m_color_swatch->GetClientSize();
+    
+    // Fill with color
+    dc.SetBrush(wxBrush(m_color));
+    dc.SetPen(*wxTRANSPARENT_PEN);
+    dc.DrawRoundedRectangle(0, 0, size.x, size.y, 3);
+    
+    // Border
+    wxColour border_color = wxGetApp().dark_mode() ? wxColour(80, 80, 80) : wxColour(180, 180, 180);
+    dc.SetBrush(*wxTRANSPARENT_BRUSH);
+    dc.SetPen(wxPen(border_color, 1));
+    dc.DrawRoundedRectangle(0, 0, size.x, size.y, 3);
+}
+
+std::string FilamentMappingRow::get_selected_filament() const
+{
+    if (!m_slot_dropdown) return "";
+    
+    int sel = m_slot_dropdown->GetSelection();
+    if (sel == wxNOT_FOUND || sel < 0) return "";
+    
+    // Count how many separators are before this selection index
+    int separator_count = 0;
+    for (int sep_idx : m_separator_indices) {
+        if (sep_idx < sel) {
+            separator_count++;
+        }
+    }
+    
+    // The actual filament index is selection minus separators before it
+    int filament_idx = sel - separator_count;
+    
+    if (filament_idx >= 0 && filament_idx < (int)m_filament_names.size()) {
+        return m_filament_names[filament_idx];
+    }
+    
+    return "";
+}
+
+//------------------------------------------------------------------------------
+// Import3mfDialog implementation
+//------------------------------------------------------------------------------
+
+Import3mfDialog::Import3mfDialog(const std::string& filename)
+    : DPIDialog(static_cast<wxWindow*>(wxGetApp().mainframe),
+                wxID_ANY,
+                _L("Import 3MF File"),
+                wxDefaultPosition,
+                wxDefaultSize,
+                wxCAPTION | wxCLOSE_BOX)
+    , m_action(1)  // Default to "Open as project"
+{
+    // Background color
+    SetBackgroundColour(wxGetApp().dark_mode() ? wxColour(45, 45, 49) : wxColour(255, 255, 255));
+    m_def_color = GetBackgroundColour();
+
+    // Icon
+    std::string icon_path = (boost::format("%1%/images/OrcaSlicerTitle.ico") % resources_dir()).str();
+    SetIcon(wxIcon(encode_path(icon_path.c_str()), wxBITMAP_TYPE_ICO));
+
+    // Collect available filament presets for mapping dropdowns
+    collect_available_filaments();
+
+    // Main sizer
+    m_main_sizer = new wxBoxSizer(wxVERTICAL);
+
+    // Top accent line
+    m_top_line = new wxPanel(this, wxID_ANY, wxDefaultPosition, wxSize(-1, FromDIP(2)));
+    m_top_line->SetBackgroundColour(wxColour(0, 150, 136));  // Teal accent
+    m_main_sizer->Add(m_top_line, 0, wxEXPAND);
+
+    m_main_sizer->AddSpacer(FromDIP(16));
+
+    // Title and filename section
+    wxBoxSizer* title_sizer = new wxBoxSizer(wxVERTICAL);
+    
+    m_fname_title = new wxStaticText(this, wxID_ANY, _L("Please select an action"));
+    m_fname_title->SetFont(::Label::Body_14);
+    m_fname_title->SetForegroundColour(wxGetApp().dark_mode() ? wxColour(180, 180, 180) : wxColour(107, 107, 107));
+    title_sizer->Add(m_fname_title, 0, wxBOTTOM, FromDIP(4));
+
+    // Filename display (may wrap to two lines)
+    wxBoxSizer* fname_sizer = new wxBoxSizer(wxHORIZONTAL);
+    m_fname_f = new wxStaticText(this, wxID_ANY, wxEmptyString);
+    m_fname_f->SetFont(::Label::Head_14);
+    m_fname_f->SetForegroundColour(wxGetApp().dark_mode() ? wxColour(220, 220, 220) : wxColour(38, 46, 48));
+    fname_sizer->Add(m_fname_f, 1);
+    title_sizer->Add(fname_sizer, 0, wxEXPAND);
+
+    m_fname_s = new wxStaticText(this, wxID_ANY, wxEmptyString);
+    m_fname_s->SetFont(::Label::Head_14);
+    m_fname_s->SetForegroundColour(wxGetApp().dark_mode() ? wxColour(220, 220, 220) : wxColour(38, 46, 48));
+    title_sizer->Add(m_fname_s, 0, wxEXPAND);
+
+    m_main_sizer->Add(title_sizer, 0, wxEXPAND | wxLEFT | wxRIGHT, FromDIP(20));
+
+    m_main_sizer->AddSpacer(FromDIP(12));
+
+    // Radio buttons for main action
+    // Index 0 = "Open as project" (m_action = 1 = LoadType::OpenProject)
+    // Index 1 = "Import geometry only" (m_action = 2 = LoadType::LoadGeometry)
+    auto* radio_group = new RadioGroup(this, {
+        _L("Open as project"),
+        _L("Import geometry only")
+    }, wxVERTICAL);
+    radio_group->SetSelection(get_action() - 1);
+    radio_group->Bind(wxEVT_COMMAND_RADIOBOX_SELECTED, [this, radio_group](wxCommandEvent& e) {
+        int selection = radio_group->GetSelection();
+        set_action(selection + 1);
+        on_action_changed(selection);
+    });
+    m_main_sizer->Add(radio_group, 0, wxEXPAND | wxLEFT | wxRIGHT, FromDIP(20));
+
+    // Create conditional project settings sections
+    create_printer_settings_section(m_main_sizer);
+    create_filament_settings_section(m_main_sizer);
+
+    m_main_sizer->AddSpacer(FromDIP(12));
+
+    // Dialog buttons
+    auto* dlg_btns = new DialogButtons(this, {"OK", "Cancel"});
+    dlg_btns->GetOK()->Bind(wxEVT_BUTTON, &Import3mfDialog::on_select_ok, this);
+    dlg_btns->GetCANCEL()->Bind(wxEVT_BUTTON, &Import3mfDialog::on_select_cancel, this);
+    m_main_sizer->Add(dlg_btns, 0, wxEXPAND);
+
+    SetSizer(m_main_sizer);
+
+    // Set initial size and state
+    update_dialog_size();
+    on_action_changed(get_action() - 1);
+
+    // Process filename for display
+    wxString file_name(filename);
+    int max_width = FromDIP(WIDTH_SMALL - 60);
+    wxString first_line, second_line;
+    int current_width = 0;
+    
+    for (size_t i = 0; i < file_name.length(); ++i) {
+        int char_width = m_fname_f->GetTextExtent(file_name[i]).GetWidth();
+        if (current_width + char_width > max_width && second_line.empty()) {
+            second_line = file_name.Mid(i);
+            break;
+        }
+        first_line += file_name[i];
+        current_width += char_width;
+    }
+    
+    m_fname_f->SetLabel(first_line);
+    m_fname_s->SetLabel(second_line);
+
+    // Apply dark mode styling
+    wxGetApp().UpdateDlgDarkUI(this);
+
+    Centre(wxBOTH);
+}
+
+wxColour Import3mfDialog::hex_to_colour(const std::string& hex)
+{
+    if (hex.empty()) return wxColour(128, 128, 128);
+    
+    std::string h = hex;
+    if (h[0] == '#') h = h.substr(1);
+    
+    if (h.length() >= 6) {
+        unsigned long val = 0;
+        if (sscanf(h.c_str(), "%lx", &val) == 1) {
+            return wxColour((val >> 16) & 0xFF, (val >> 8) & 0xFF, val & 0xFF);
+        }
+    }
+    return wxColour(128, 128, 128);
+}
+
+void Import3mfDialog::collect_available_filaments()
+{
+    m_available_filaments.clear();
+    
+    PresetBundle* preset_bundle = wxGetApp().preset_bundle;
+    if (!preset_bundle) return;
+    
+    // Collect filaments exactly like PlaterPresetComboBox::update() does:
+    // Only include presets that are:
+    // 1. Visible (user has configured/installed them)
+    // 2. Compatible with current printer
+    for (const Preset& preset : preset_bundle->filaments) {
+        if (preset.is_default)
+            continue;
+        
+        // Skip invisible presets
+        if (!preset.is_visible)
+            continue;
+        
+        // Skip incompatible presets (like sidebar does)
+        if (!preset.is_compatible)
+            continue;
+            
+        m_available_filaments.push_back(preset.name);
+    }
+    
+    // Ensure at least one filament is available
+    if (m_available_filaments.empty()) {
+        // Get whatever is currently selected
+        const Preset& current = preset_bundle->filaments.get_selected_preset();
+        if (!current.is_default) {
+            m_available_filaments.push_back(current.name);
+        }
+    }
+}
+
+void Import3mfDialog::create_printer_settings_section(wxBoxSizer* parent_sizer)
+{
+    // Container panel (for show/hide)
+    m_printer_settings_panel = new wxPanel(this);
+    m_printer_settings_panel->SetBackgroundColour(GetBackgroundColour());
+    wxBoxSizer* panel_sizer = new wxBoxSizer(wxVERTICAL);
+
+    // Checkbox row with styled CheckBox
+    wxBoxSizer* cb_sizer = new wxBoxSizer(wxHORIZONTAL);
+    cb_sizer->AddSpacer(FromDIP(20));  // Indent
+
+    m_cb_printer_settings = new CheckBox(m_printer_settings_panel);
+    m_cb_printer_settings->SetValue(m_import_printer_settings);
+    cb_sizer->Add(m_cb_printer_settings, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(8));
+
+    m_cb_printer_label = new wxStaticText(m_printer_settings_panel, wxID_ANY, _L("Import project printer settings"));
+    m_cb_printer_label->SetFont(::Label::Body_13);
+    cb_sizer->Add(m_cb_printer_label, 0, wxALIGN_CENTER_VERTICAL);
+
+    panel_sizer->Add(cb_sizer, 0, wxEXPAND | wxTOP, FromDIP(10));
+
+    // Printer reassign panel (shown when checkbox is unchecked)
+    m_printer_reassign_panel = new wxPanel(m_printer_settings_panel);
+    m_printer_reassign_panel->SetBackgroundColour(GetBackgroundColour());
+    wxBoxSizer* reassign_sizer = new wxBoxSizer(wxHORIZONTAL);
+    reassign_sizer->AddSpacer(FromDIP(48));  // Further indent
+
+    m_printer_reassign_label = new wxStaticText(m_printer_reassign_panel, wxID_ANY, _L("Use printer:"));
+    m_printer_reassign_label->SetFont(::Label::Body_13);
+    m_printer_reassign_label->SetForegroundColour(wxGetApp().dark_mode() ? wxColour(180, 180, 180) : wxColour(107, 107, 107));
+    reassign_sizer->Add(m_printer_reassign_label, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(8));
+
+    m_printer_dropdown = new ComboBox(m_printer_reassign_panel, wxID_ANY, wxEmptyString,
+                                      wxDefaultPosition, wxSize(FromDIP(200), -1), 0, NULL, wxCB_READONLY);
+    populate_printer_dropdown();
+    reassign_sizer->Add(m_printer_dropdown, 1, wxALIGN_CENTER_VERTICAL);
+
+    m_printer_reassign_panel->SetSizer(reassign_sizer);
+    panel_sizer->Add(m_printer_reassign_panel, 0, wxEXPAND | wxTOP, FromDIP(6));
+
+    // Warning label (shown if project printer not found)
+    m_printer_warning_label = new wxStaticText(m_printer_settings_panel, wxID_ANY, wxEmptyString);
+    m_printer_warning_label->SetFont(::Label::Body_12);
+    m_printer_warning_label->SetForegroundColour(wxColour(255, 150, 0));  // Orange warning
+    m_printer_warning_label->Hide();
+    panel_sizer->Add(m_printer_warning_label, 0, wxLEFT | wxTOP, FromDIP(48));
+
+    m_printer_settings_panel->SetSizer(panel_sizer);
+    parent_sizer->Add(m_printer_settings_panel, 0, wxEXPAND | wxLEFT | wxRIGHT, FromDIP(20));
+
+    // Bind checkbox events
+    m_cb_printer_settings->Bind(wxEVT_TOGGLEBUTTON, [this](wxCommandEvent& e) {
+        m_import_printer_settings = m_cb_printer_settings->GetValue();
+        update_conditional_sections();
+        update_dialog_size();
+        e.Skip();
+    });
+    
+    // Also bind click on label
+    m_cb_printer_label->Bind(wxEVT_LEFT_DOWN, [this](wxMouseEvent& e) {
+        m_cb_printer_settings->SetValue(!m_cb_printer_settings->GetValue());
+        m_import_printer_settings = m_cb_printer_settings->GetValue();
+        update_conditional_sections();
+        update_dialog_size();
+    });
+}
+
+void Import3mfDialog::populate_printer_dropdown()
+{
+    if (!m_printer_dropdown) return;
+    
+    m_printer_dropdown->Clear();
+    
+    PresetBundle* preset_bundle = wxGetApp().preset_bundle;
+    if (!preset_bundle) return;
+
+    // Group printers by type: System vs User  
+    std::vector<std::string> system_printers;
+    std::vector<std::string> user_printers;
+    
+    const Preset& current = preset_bundle->printers.get_selected_preset();
+    std::string selected_name = current.name;
+    
+    for (const Preset& preset : preset_bundle->printers) {
+        if (!preset.is_visible || preset.is_default)
+            continue;
+        
+        if (preset.is_system) {
+            system_printers.push_back(preset.name);
+        } else {
+            user_printers.push_back(preset.name);
+        }
+    }
+    
+    // Sort alphabetically
+    std::sort(system_printers.begin(), system_printers.end());
+    std::sort(user_printers.begin(), user_printers.end());
+    
+    int selected_idx = -1;
+    int current_idx = 0;
+    
+    // Add user presets with native grouping
+    for (const auto& name : user_printers) {
+        m_printer_dropdown->Append(from_u8(name), wxNullBitmap, _L("User presets"));
+        if (name == selected_name) selected_idx = current_idx;
+        current_idx++;
+    }
+    
+    // Add system presets with native grouping
+    for (const auto& name : system_printers) {
+        m_printer_dropdown->Append(from_u8(name), wxNullBitmap, _L("System presets"));
+        if (name == selected_name) selected_idx = current_idx;
+        current_idx++;
+    }
+    
+    // Select current printer or first item
+    if (selected_idx >= 0) {
+        m_printer_dropdown->SetSelection(selected_idx);
+    } else if (m_printer_dropdown->GetCount() > 0) {
+        m_printer_dropdown->SetSelection(0);
+    }
+}
+
+void Import3mfDialog::create_filament_settings_section(wxBoxSizer* parent_sizer)
+{
+    // Container panel (for show/hide)
+    m_filament_settings_panel = new wxPanel(this);
+    m_filament_settings_panel->SetBackgroundColour(GetBackgroundColour());
+    wxBoxSizer* panel_sizer = new wxBoxSizer(wxVERTICAL);
+
+    // Checkbox row with styled CheckBox
+    wxBoxSizer* cb_sizer = new wxBoxSizer(wxHORIZONTAL);
+    cb_sizer->AddSpacer(FromDIP(20));  // Indent
+
+    m_cb_filament_settings = new CheckBox(m_filament_settings_panel);
+    m_cb_filament_settings->SetValue(m_import_filament_settings);
+    cb_sizer->Add(m_cb_filament_settings, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(8));
+
+    m_cb_filament_label = new wxStaticText(m_filament_settings_panel, wxID_ANY, _L("Import project filament settings"));
+    m_cb_filament_label->SetFont(::Label::Body_13);
+    cb_sizer->Add(m_cb_filament_label, 0, wxALIGN_CENTER_VERTICAL);
+
+    panel_sizer->Add(cb_sizer, 0, wxEXPAND | wxTOP, FromDIP(8));
+
+    // Filament mapping panel (shown when checkbox is unchecked)
+    m_filament_mapping_panel = new wxPanel(m_filament_settings_panel);
+    m_filament_mapping_panel->SetBackgroundColour(GetBackgroundColour());
+    wxBoxSizer* mapping_outer_sizer = new wxBoxSizer(wxVERTICAL);
+    
+    // Info label
+    auto* info_label = new wxStaticText(m_filament_mapping_panel, wxID_ANY, 
+        _L("Map project colors to your filaments:"));
+    info_label->SetFont(::Label::Body_12);
+    info_label->SetForegroundColour(wxGetApp().dark_mode() ? wxColour(150, 150, 150) : wxColour(120, 120, 120));
+    mapping_outer_sizer->Add(info_label, 0, wxLEFT | wxBOTTOM, FromDIP(28));
+
+    // Scrolled window for filament rows (in case of many filaments)
+    m_filament_scroll = new wxScrolledWindow(m_filament_mapping_panel, wxID_ANY, 
+                                             wxDefaultPosition, wxSize(-1, FromDIP(140)));
+    m_filament_scroll->SetScrollRate(0, FromDIP(20));
+    m_filament_scroll->SetBackgroundColour(GetBackgroundColour());
+    
+    // Use a 2-column FlexGridSizer for the filament mapping grid
+    wxFlexGridSizer* grid_sizer = new wxFlexGridSizer(2, FromDIP(16), FromDIP(12));  // 2 cols, hgap, vgap
+    grid_sizer->AddGrowableCol(0, 1);
+    grid_sizer->AddGrowableCol(1, 1);
+    m_filament_scroll->SetSizer(grid_sizer);
+    
+    mapping_outer_sizer->Add(m_filament_scroll, 1, wxEXPAND | wxLEFT | wxRIGHT, FromDIP(28));
+
+    m_filament_mapping_panel->SetSizer(mapping_outer_sizer);
+    panel_sizer->Add(m_filament_mapping_panel, 0, wxEXPAND | wxTOP, FromDIP(6));
+
+    m_filament_settings_panel->SetSizer(panel_sizer);
+    parent_sizer->Add(m_filament_settings_panel, 0, wxEXPAND | wxLEFT | wxRIGHT, FromDIP(20));
+
+    // Bind checkbox events
+    m_cb_filament_settings->Bind(wxEVT_TOGGLEBUTTON, [this](wxCommandEvent& e) {
+        m_import_filament_settings = m_cb_filament_settings->GetValue();
+        update_conditional_sections();
+        update_dialog_size();
+        e.Skip();
+    });
+    
+    // Also bind click on label
+    m_cb_filament_label->Bind(wxEVT_LEFT_DOWN, [this](wxMouseEvent& e) {
+        m_cb_filament_settings->SetValue(!m_cb_filament_settings->GetValue());
+        m_import_filament_settings = m_cb_filament_settings->GetValue();
+        update_conditional_sections();
+        update_dialog_size();
+    });
+}
+
+void Import3mfDialog::populate_filament_mapping()
+{
+    if (!m_filament_scroll) return;
+    
+    // Clear existing rows
+    for (auto* row : m_filament_rows) {
+        row->Destroy();
+    }
+    m_filament_rows.clear();
+    
+    wxFlexGridSizer* grid_sizer = dynamic_cast<wxFlexGridSizer*>(m_filament_scroll->GetSizer());
+    if (!grid_sizer) return;
+    
+    grid_sizer->Clear(false);  // Don't delete windows, we already destroyed them
+    
+    // Create a row for each project filament in 2-column layout
+    for (size_t i = 0; i < m_project_filament_colors.size(); ++i) {
+        wxColour color = hex_to_colour(m_project_filament_colors[i]);
+        
+        auto* row = new FilamentMappingRow(m_filament_scroll, (int)(i + 1), color, m_available_filaments);
+        m_filament_rows.push_back(row);
+        grid_sizer->Add(row, 1, wxEXPAND);
+    }
+    
+    // If odd number of filaments, add an empty spacer to keep grid balanced
+    if (m_project_filament_colors.size() % 2 == 1) {
+        grid_sizer->AddSpacer(0);
+    }
+    
+    m_filament_scroll->FitInside();
+    m_filament_scroll->Layout();
+}
+
+void Import3mfDialog::set_project_info(const Slic3r::Bbs3mfProjectInfo& info)
+{
+    m_has_printer_settings = info.has_printer_settings;
+    m_has_filament_settings = info.has_filament_settings;
+    m_project_filament_colors = info.filament_colors;
+    
+    // Update printer warning if project printer not found
+    if (m_printer_warning_label && !info.printer_preset_name.empty()) {
+        PresetBundle* preset_bundle = wxGetApp().preset_bundle;
+        if (preset_bundle) {
+            bool found = false;
+            for (const Preset& preset : preset_bundle->printers) {
+                if (preset.name == info.printer_preset_name) {
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) {
+                m_printer_warning_label->SetLabel(
+                    wxString::Format(_L("Project printer '%s' not found"), from_u8(info.printer_preset_name)));
+                m_printer_warning_label->Show();
+            }
+        }
+    }
+    
+    // Populate filament mapping rows
+    populate_filament_mapping();
+    
+    // Update visibility
+    update_conditional_sections();
+    update_dialog_size();
+}
+
+void Import3mfDialog::on_action_changed(int selection)
+{
+    update_conditional_sections();
+    update_dialog_size();
+}
+
+void Import3mfDialog::on_printer_checkbox_changed()
+{
+    if (m_cb_printer_settings)
+        m_import_printer_settings = m_cb_printer_settings->GetValue();
+    update_conditional_sections();
+    update_dialog_size();
+}
+
+void Import3mfDialog::on_filament_checkbox_changed()
+{
+    if (m_cb_filament_settings)
+        m_import_filament_settings = m_cb_filament_settings->GetValue();
+    update_conditional_sections();
+    update_dialog_size();
+}
+
+void Import3mfDialog::update_conditional_sections()
+{
+    bool is_open_project = (get_action() == 1);
+
+    // Show/hide main panels based on radio selection
+    if (m_printer_settings_panel)
+        m_printer_settings_panel->Show(is_open_project);
+    if (m_filament_settings_panel)
+        m_filament_settings_panel->Show(is_open_project);
+
+    // Show/hide printer reassign panel based on checkbox
+    if (m_printer_reassign_panel)
+        m_printer_reassign_panel->Show(!m_import_printer_settings);
+    if (m_printer_warning_label && m_import_printer_settings)
+        m_printer_warning_label->Hide();
+
+    // Show/hide filament mapping panel based on checkbox
+    if (m_filament_mapping_panel)
+        m_filament_mapping_panel->Show(!m_import_filament_settings);
+
+    Layout();
+}
+
+int Import3mfDialog::get_required_width() const
+{
+    bool is_open_project = (get_action() == 1);
+    
+    if (!is_open_project) {
+        return WIDTH_SMALL;
+    }
+    
+    // If either checkbox is unchecked, we need more space
+    if (!m_import_printer_settings || !m_import_filament_settings) {
+        return WIDTH_LARGE;
+    }
+    
+    return WIDTH_SMALL;
+}
+
+void Import3mfDialog::update_dialog_size()
+{
+    int width = FromDIP(get_required_width());
+    
+    SetMinSize(wxSize(width, -1));
+    SetMaxSize(wxSize(width, -1));
+    
+    Layout();
+    Fit();
+    
+    // Keep width fixed after fit
+    wxSize size = GetSize();
+    size.SetWidth(width);
+    SetSize(size);
+}
+
+void Import3mfDialog::on_select_ok(wxCommandEvent& event)
+{
+    EndModal(wxID_OK);
+}
+
+void Import3mfDialog::on_select_cancel(wxCommandEvent& event)
+{
+    EndModal(wxID_CANCEL);
+}
+
+void Import3mfDialog::on_dpi_changed(const wxRect& suggested_rect)
+{
+    if (m_cb_printer_settings) m_cb_printer_settings->Rescale();
+    if (m_cb_filament_settings) m_cb_filament_settings->Rescale();
+    
+    update_dialog_size();
+    Refresh();
+}
+
+Import3mfSettings Import3mfDialog::get_import_settings() const
+{
+    Import3mfSettings settings;
+    settings.import_printer_settings = m_import_printer_settings;
+    settings.import_filament_settings = m_import_filament_settings;
+
+    // Get reassign printer name if not importing printer settings
+    if (!m_import_printer_settings && m_printer_dropdown) {
+        int sel = m_printer_dropdown->GetSelection();
+        if (sel != wxNOT_FOUND && sel >= 0) {
+            settings.reassign_printer = m_printer_dropdown->GetStringSelection().ToStdString();
+        }
+    }
+
+    // Collect filament remapping from rows
+    if (!m_import_filament_settings) {
+        for (const auto* row : m_filament_rows) {
+            int filament_idx = row->get_filament_index();
+            std::string preset_name = row->get_selected_filament();
+            if (!preset_name.empty()) {
+                settings.filament_color_remapping[filament_idx] = preset_name;
+            }
+        }
+    }
+
+    return settings;
+}
+
+//------------------------------------------------------------------------------
+// Global functions
+//------------------------------------------------------------------------------
+
+static Import3mfSettings g_pending_3mf_import_settings;
+static bool g_has_pending_3mf_import_settings = false;
+
+LoadType determine_3mf_load_type(std::string filename, std::string override_setting)
+{
+    std::string setting;
+
+    if (!override_setting.empty()) {
+        setting = override_setting;
+    } else {
+        setting = wxGetApp().app_config->get(SETTING_PROJECT_LOAD_BEHAVIOUR);
+    }
+
+    // Pre-parse the 3MF to get project info
+    Slic3r::Bbs3mfProjectInfo project_info;
+    bool pre_parsed = Slic3r::bbs_3mf_preparse_project_info(filename.c_str(), project_info);
+
+    if (setting == OPTION_PROJECT_LOAD_BEHAVIOUR_LOAD_GEOMETRY) {
+        // Even for geometry-only, we need filament count for expansion
+        g_pending_3mf_import_settings = Import3mfSettings();
+        g_pending_3mf_import_settings.project_filament_count = project_info.filament_count;
+        g_pending_3mf_import_settings.project_filament_colors = project_info.filament_colors;
+        g_pending_3mf_import_settings.import_printer_settings = false;
+        g_pending_3mf_import_settings.import_filament_settings = false;
+        g_has_pending_3mf_import_settings = pre_parsed;
+        return LoadType::LoadGeometry;
+        
+    } else if (setting == OPTION_PROJECT_LOAD_BEHAVIOUR_ALWAYS_ASK) {
+        Import3mfDialog dlg(filename);
+        if (pre_parsed) {
+            dlg.set_project_info(project_info);
+        }
+        
+        if (dlg.ShowModal() == wxID_OK) {
+            int choice = dlg.get_action();
+            LoadType load_type = static_cast<LoadType>(choice);
+            wxGetApp().app_config->set("import_project_action", std::to_string(choice));
+
+            // Store user's import settings
+            g_pending_3mf_import_settings = dlg.get_import_settings();
+            
+            // Copy pre-parsed project info
+            g_pending_3mf_import_settings.project_filament_count = project_info.filament_count;
+            g_pending_3mf_import_settings.project_filament_colors = project_info.filament_colors;
+            g_pending_3mf_import_settings.project_printer_name = project_info.printer_preset_name;
+            g_pending_3mf_import_settings.project_filament_preset_names = project_info.filament_preset_names;
+            g_pending_3mf_import_settings.project_has_printer_settings = project_info.has_printer_settings;
+            g_pending_3mf_import_settings.project_has_filament_settings = project_info.has_filament_settings;
+            
+            g_has_pending_3mf_import_settings = true;
+
+            wxGetApp().mainframe->select_tab(MainFrame::tp3DEditor);
+            return load_type;
+        }
+
+        g_has_pending_3mf_import_settings = false;
+        return LoadType::Unknown;  // Cancelled
+        
+    } else {
+        // Default: Open as Project
+        g_pending_3mf_import_settings = Import3mfSettings();
+        g_pending_3mf_import_settings.project_filament_count = project_info.filament_count;
+        g_pending_3mf_import_settings.project_filament_colors = project_info.filament_colors;
+        g_pending_3mf_import_settings.project_printer_name = project_info.printer_preset_name;
+        g_pending_3mf_import_settings.project_filament_preset_names = project_info.filament_preset_names;
+        g_pending_3mf_import_settings.project_has_printer_settings = project_info.has_printer_settings;
+        g_pending_3mf_import_settings.project_has_filament_settings = project_info.has_filament_settings;
+        g_has_pending_3mf_import_settings = pre_parsed;
+        return LoadType::OpenProject;
+    }
+}
+
+bool has_pending_3mf_import_settings()
+{
+    return g_has_pending_3mf_import_settings;
+}
+
+Import3mfSettings get_pending_3mf_import_settings()
+{
+    return g_pending_3mf_import_settings;
+}
+
+void clear_pending_3mf_import_settings()
+{
+    g_has_pending_3mf_import_settings = false;
+    g_pending_3mf_import_settings = Import3mfSettings();
+}
+
+const std::map<int, int>* get_pending_3mf_filament_remap()
+{
+    // Note: filament_color_remapping is now std::map<int, std::string> for preset name assignment
+    // Geometry extruder remapping is not needed - we keep original extruder IDs and just assign
+    // different presets to slots in Plater.cpp after loading
+    return nullptr;
+}
+
+} // namespace GUI
+} // namespace Slic3r

--- a/src/slic3r/GUI/Import3mfDialog.hpp
+++ b/src/slic3r/GUI/Import3mfDialog.hpp
@@ -20,11 +20,13 @@ struct Bbs3mfProjectInfo;
 
 namespace GUI {
 
-// Fixed dialog widths (in DIP)
+// Dialog widths in DIP (device-independent pixels)
+// SMALL: Basic dialog without filament mapping
+// LARGE: Extended dialog with 2-column filament mapping grid
 constexpr int IMPORT_DIALOG_WIDTH_SMALL = 380;
 constexpr int IMPORT_DIALOG_WIDTH_LARGE = 560;
 
-// Load type for 3MF/project files
+// Load type returned by determine_3mf_load_type()
 enum class LoadType : unsigned char
 {
     Unknown,
@@ -33,7 +35,9 @@ enum class LoadType : unsigned char
     LoadConfig
 };
 
-// Structure to hold user's 3MF import preferences
+// Structure to hold user's 3MF import preferences.
+// Populated by Import3mfDialog when user makes import choices,
+// consumed by Plater::load_files() to apply those choices.
 struct Import3mfSettings
 {
     // User choices
@@ -163,7 +167,9 @@ protected:
     void on_dpi_changed(const wxRect& suggested_rect) override;
 };
 
-// Functions to determine load type and access pending 3MF import settings
+// Main entry point: Shows import dialog and returns user's choice.
+// If override_setting is provided, skips dialog and uses that setting directly.
+// Stores import settings in global state accessible via get_pending_3mf_import_settings().
 LoadType determine_3mf_load_type(std::string filename, std::string override_setting = "");
 
 bool has_pending_3mf_import_settings();

--- a/src/slic3r/GUI/Import3mfDialog.hpp
+++ b/src/slic3r/GUI/Import3mfDialog.hpp
@@ -1,0 +1,177 @@
+#ifndef slic3r_GUI_Import3mfDialog_hpp_
+#define slic3r_GUI_Import3mfDialog_hpp_
+
+#include "GUI_Utils.hpp"
+#include "Widgets/CheckBox.hpp"
+#include "Widgets/ComboBox.hpp"
+
+#include <wx/sizer.h>
+#include <wx/stattext.h>
+#include <wx/panel.h>
+#include <wx/scrolwin.h>
+
+#include <map>
+#include <string>
+#include <vector>
+
+namespace Slic3r {
+// Forward declaration
+struct Bbs3mfProjectInfo;
+
+namespace GUI {
+
+// Fixed dialog widths (in DIP)
+constexpr int IMPORT_DIALOG_WIDTH_SMALL = 380;
+constexpr int IMPORT_DIALOG_WIDTH_LARGE = 560;
+
+// Load type for 3MF/project files
+enum class LoadType : unsigned char
+{
+    Unknown,
+    OpenProject,
+    LoadGeometry,
+    LoadConfig
+};
+
+// Structure to hold user's 3MF import preferences
+struct Import3mfSettings
+{
+    // User choices
+    bool import_printer_settings{true};
+    bool import_filament_settings{true};
+    std::string reassign_printer;                       // Printer preset name if not importing printer settings
+    std::map<int, std::string> filament_color_remapping; // filament_index (1-based) -> preset name
+    
+    // Pre-parsed project info (filled before dialog is shown)
+    int project_filament_count{0};
+    std::vector<std::string> project_filament_colors;   // Hex color strings
+    std::string project_printer_name;
+    std::vector<std::string> project_filament_preset_names;
+    bool project_has_printer_settings{false};
+    bool project_has_filament_settings{false};
+};
+
+// A row widget for filament mapping: [ColorSwatch] → [Slot ComboBox]
+class FilamentMappingRow : public wxPanel
+{
+public:
+    FilamentMappingRow(wxWindow* parent, int filament_index, const wxColour& color, 
+                       const std::vector<std::string>& available_filaments);
+    
+    int get_filament_index() const { return m_filament_index; }
+    std::string get_selected_filament() const;  // Returns selected preset name
+    
+private:
+    int         m_filament_index;  // 1-based
+    wxPanel*    m_color_swatch{nullptr};
+    wxColour    m_color;
+    ComboBox*   m_slot_dropdown{nullptr};
+    std::vector<std::string> m_filament_names;  // Preset names for selectable items only
+    std::vector<int> m_separator_indices;       // Indices of separator items in the dropdown
+    
+    void on_paint_swatch(wxPaintEvent& evt);
+    void populate_slot_dropdown(const std::vector<std::string>& available_filaments);
+};
+
+class Import3mfDialog : public DPIDialog
+{
+private:
+    // Dialog sizing
+    static constexpr int WIDTH_SMALL = IMPORT_DIALOG_WIDTH_SMALL;
+    static constexpr int WIDTH_LARGE = IMPORT_DIALOG_WIDTH_LARGE;
+    
+    wxColour          m_def_color = wxColour(255, 255, 255);
+    int               m_action{1};
+    bool              m_remember_choice{false};
+
+    // Project settings import options
+    bool              m_import_printer_settings{true};
+    bool              m_import_filament_settings{true};
+    std::string       m_reassign_printer;
+    std::map<int, std::string> m_filament_color_remapping;  // filament_index -> preset name
+
+    // 3MF color data (passed in from pre-parse)
+    std::vector<std::string> m_project_filament_colors; // Hex color strings from 3MF
+    
+    // Available filament presets for mapping dropdowns (preset name)
+    std::vector<std::string> m_available_filaments;  // All visible filament preset names
+    
+    // Flags for what the 3MF actually contains
+    bool              m_has_printer_settings{false};
+    bool              m_has_filament_settings{false};
+    
+    // Main sizer for size control
+    wxBoxSizer*       m_main_sizer{nullptr};
+
+    // UI components - printer settings section
+    wxPanel*          m_printer_settings_panel{nullptr};
+    CheckBox*         m_cb_printer_settings{nullptr};        // Styled checkbox
+    wxStaticText*     m_cb_printer_label{nullptr};           // Label next to checkbox
+    wxPanel*          m_printer_reassign_panel{nullptr};     // Panel for reassign row (show/hide)
+    wxStaticText*     m_printer_reassign_label{nullptr};
+    ComboBox*         m_printer_dropdown{nullptr};           // Grouped by manufacturer
+    wxStaticText*     m_printer_warning_label{nullptr};      // Warning if printer not found
+
+    // UI components - filament settings section  
+    wxPanel*          m_filament_settings_panel{nullptr};
+    CheckBox*         m_cb_filament_settings{nullptr};       // Styled checkbox
+    wxStaticText*     m_cb_filament_label{nullptr};          // Label next to checkbox
+    wxPanel*          m_filament_mapping_panel{nullptr};     // Panel for mapping rows (show/hide)
+    wxScrolledWindow* m_filament_scroll{nullptr};            // Scrollable container for many filaments
+    std::vector<FilamentMappingRow*> m_filament_rows;        // One per project filament
+
+public:
+    Import3mfDialog(const std::string& filename);
+    
+    // Set pre-parsed project info (call before ShowModal)
+    void set_project_info(const Slic3r::Bbs3mfProjectInfo& info);
+
+    wxPanel*      m_top_line{nullptr};
+    wxStaticText* m_fname_title{nullptr};
+    wxStaticText* m_fname_f{nullptr};
+    wxStaticText* m_fname_s{nullptr};
+
+    void      on_select_ok(wxCommandEvent& event);
+    void      on_select_cancel(wxCommandEvent& event);
+
+    int       get_action() const { return m_action; }
+    void      set_action(int index) { m_action = index; }
+
+    // Getters for import settings
+    Import3mfSettings get_import_settings() const;
+
+private:
+    void create_printer_settings_section(wxBoxSizer* parent_sizer);
+    void create_filament_settings_section(wxBoxSizer* parent_sizer);
+    void populate_printer_dropdown();
+    void populate_filament_mapping();
+    void collect_available_filaments();
+    
+    void on_action_changed(int selection);
+    void on_printer_checkbox_changed();
+    void on_filament_checkbox_changed();
+    void update_conditional_sections();
+    void update_dialog_size();
+    
+    // Get current dialog width based on state
+    int get_required_width() const;
+    
+    // Helper to parse hex color
+    static wxColour hex_to_colour(const std::string& hex);
+
+protected:
+    void on_dpi_changed(const wxRect& suggested_rect) override;
+};
+
+// Functions to determine load type and access pending 3MF import settings
+LoadType determine_3mf_load_type(std::string filename, std::string override_setting = "");
+
+bool has_pending_3mf_import_settings();
+Import3mfSettings get_pending_3mf_import_settings();
+void clear_pending_3mf_import_settings();
+const std::map<int, int>* get_pending_3mf_filament_remap();
+
+} // namespace GUI
+} // namespace Slic3r
+
+#endif // slic3r_GUI_Import3mfDialog_hpp_

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -6053,8 +6053,16 @@ std::vector<size_t> Plater::priv::load_files(const std::vector<fs::path>& input_
                             }
                         }
 
+                        // =========================================================
+                        // Determine skip flags early for validation checks
+                        // =========================================================
+                        bool skip_printer = (strategy & LoadStrategy::SkipPrinterConfig) != 0;
+                        bool skip_filament = (strategy & LoadStrategy::SkipFilamentConfig) != 0;
+
+                        // Only validate presets if we're actually loading them
+                        // Skip validation if user chose to skip both printer and filament presets
                         auto choise = wxGetApp().app_config->get("no_warn_when_modified_gcodes");
-                        if (choise.empty() || choise != "true") {
+                        if ((choise.empty() || choise != "true") && !(skip_printer && skip_filament)) {
                             // BBS: first validate the printer
                             // validate the system profiles
                             std::set<std::string> modified_gcodes;
@@ -6099,9 +6107,11 @@ std::vector<size_t> Plater::priv::load_files(const std::vector<fs::path>& input_
                             if (wipe_tower_y_opt)
                                 file_wipe_tower_y = *wipe_tower_y_opt;
 
-                            // Pass skip flags to load_config_model based on user's import choices
-                            bool skip_printer = (strategy & LoadStrategy::SkipPrinterConfig) != 0;
-                            bool skip_filament = (strategy & LoadStrategy::SkipFilamentConfig) != 0;
+                            // =========================================================
+                            // User's Import Choices Processing
+                            // =========================================================
+                            // Skip flags determined earlier (before validation)
+                            // If skipping, we save current presets before loading and restore after.
                             
                             // Get the user's import settings from the dialog (if any)
                             Import3mfSettings import_settings;

--- a/src/slic3r/GUI/Preferences.cpp
+++ b/src/slic3r/GUI/Preferences.cpp
@@ -1262,6 +1262,12 @@ void PreferencesDialog::create_items()
     auto item_project_load     = create_item_combobox(_L("Load behaviour"), _L("Should printer/filament/process settings be loaded when opening a 3MF file?"), SETTING_PROJECT_LOAD_BEHAVIOUR, projectLoadSettingsBehaviourOptions, projectLoadSettingsConfigOptions);
     g_sizer->Add(item_project_load);
 
+    auto item_skip_printer     = create_item_checkbox(_L("Skip loading project printer profiles"), _L("When 'Load All' is selected, skip loading printer presets from 3MF files"), SETTING_PROJECT_SKIP_PRINTER);
+    g_sizer->Add(item_skip_printer);
+
+    auto item_skip_filament    = create_item_checkbox(_L("Skip loading project filament settings"), _L("When 'Load All' is selected, skip loading filament presets from 3MF files"), SETTING_PROJECT_SKIP_FILAMENT);
+    g_sizer->Add(item_skip_filament);
+
     auto item_max_recent_count = create_item_input(_L("Maximum recent files"), "", _L("Maximum count of recent files"), "max_recent_count", [](wxString value) {
         long max = 0;
         if (value.ToLong(&max))

--- a/src/slic3r/GUI/WebViewDialog.cpp
+++ b/src/slic3r/GUI/WebViewDialog.cpp
@@ -555,7 +555,11 @@ void WebViewPanel::OnNavigationRequest(wxWebViewEvent& evt)
             else
                 file = "//" + file; // When file from network location
 #endif
-            wxGetApp().plater()->load_files(wxArrayString{1, &file});
+            // Use CallAfter to avoid WebView2 reentrancy issue when showing modal dialogs
+            wxString file_copy = file;
+            CallAfter([file_copy]() {
+                wxGetApp().plater()->load_files(wxArrayString{1, &file_copy});
+            });
             evt.Veto();
             return;
         }


### PR DESCRIPTION
Multi-color FDM projects can be frustrating to import because original printer and filament presets often overwrite a user’s setup, causing color zones to be lost. This PR adds flexible import modes and filament color mapping so users can preserve their workspace while retaining multi-color designs. Optional dialog checkboxes and preference settings give control over which project settings are applied, improving usability for shared 3MF files and complex multi-color prints.

### Main Points

**Flexible Import Modes**
- **Open as Project**: Import geometry, printer, and filament settings (original behavior)
- **Import Geometry Only**: Load models without touching any presets
- **Selective Preset Import**: Skip printer settings, filament settings, or both via dialog checkboxes
- Print settings automatically skip when printer is skipped to maintain preset compatibility

**Filament Color Mapping**
- Visual mapping interface displays project colors alongside user's compatible filament presets
- Dropdowns filtered by visibility and compatibility (matches sidebar behavior)
- Grouped by vendor with split headers for better organization
- Hex color validation and robust fallback handling

**Preferences Integration**
- New checkboxes under Preferences → Project to skip printer/filament presets when "Load All" is selected
- Dialog respects preference defaults while remaining fully interactive
- Per-import overrides available for workflow flexibility

### More details
**Modified Files**
- Import3mfDialog.hpp / .cpp: New import dialog with radio options, checkboxes, and filament mapping UI
- Plater.cpp: Skip logic, preset save/restore, validation gating, bed recentering
- PresetBundle.cpp: Config loading with skip flags; embedded preset filtering
- bbs_3mf.cpp: Pre-parse project info (filament colors, preset names)
- Preferences.cpp: Added skip checkboxes in Project section
- WebViewDialog.cpp: Deferred file loading to avoid modal reentrancy

**LoadStrategy Flags**
- `SkipPrinterConfig` (256): Skip printer and print presets
- `SkipFilamentConfig` (512): Skip filament presets; enables color mapping

**Testing**
- Manual testing across all import modes and preference combinations
- Verified filament mapping with multi-color projects
- Confirmed preset save/restore and validation suppression
- Tested WebView-driven imports (no reentrancy warnings)

**Screenshots/Videos**
<!-- Add screenshots of the dialog (main options, mapping interface, dark mode), preferences section, and sample workflow -->
<img width="379" height="318" alt="image" src="https://github.com/user-attachments/assets/6185eb9c-3836-4419-8fc9-6f7c78df8729" />
<img width="718" height="599" alt="image" src="https://github.com/user-attachments/assets/5b57b9eb-e67d-4ff4-909a-4c4393cbdab4" />
<img width="479" height="137" alt="image" src="https://github.com/user-attachments/assets/22105025-3fa2-439f-8b9d-423c459201c1" />

[3mfImportOverhaul.webm](https://github.com/user-attachments/assets/818b05fc-72f5-4f18-9693-811360295158)
