### PR TITLE
Fix P2S max z acceleration for high flow nozzle

### DIFF
--- a/resources/profiles/BBL/machine/Bambu Lab P2S 0.4 nozzle.json
+++ b/resources/profiles/BBL/machine/Bambu Lab P2S 0.4 nozzle.json
@@ -100,9 +100,9 @@
     ],
     "machine_max_acceleration_z": [
         "500",
-        "200",
-        "200",
-        "200"
+        "500",
+        "500",
+        "500"
     ],
     "machine_max_jerk_e": [
         "2.5",


### PR DESCRIPTION
# Description

This change corrects the maximum z-acceleration for the high-flow nozzle variant. The value for the standard nozzle is 500, while the high-flow nozzle is set to 200. I cannot see any reason the value should differ between these nozzles since z motion has nothing to do with the nozzle (especially on the P2S where the gantry is fixed in the z-direction...)

Note: It's not obvious to me how to actually use the high-flow variant in OrcaSlicer, but regardless, the value is still wrong and should be corrected.

# Screenshots/Recordings/Graphs
 
 NA

## Tests

The standard nozzle uses this value without issue. I'm not sure how to test this in OrcaSlicer, but I have manually edited the value in Bambu Studio, and it has caused no print issues and marginally sped up some prints with the high flow-nozzle (particularly those with many z-hops)