### PR TITLE
Feat: Add Tangential Sacrificial Bridging for counterbore holes

### DIFF
--- a/src/libslic3r/CMakeLists.txt
+++ b/src/libslic3r/CMakeLists.txt
@@ -435,6 +435,8 @@ set(lisbslic3r_sources
     Surface.cpp
     Surface.hpp
     SurfaceMesh.hpp
+    TangentialHoleBridging.cpp
+    TangentialHoleBridging.hpp
     SVG.cpp
     SVG.hpp
     Technologies.hpp

--- a/src/libslic3r/LayerRegion.cpp
+++ b/src/libslic3r/LayerRegion.cpp
@@ -123,8 +123,7 @@ void LayerRegion::make_perimeters(const SurfaceCollection &slices, const LayerRe
     else
         g.process_classic();
 
-    // ORCA: Generate tangential struts for vertical holes in bridging areas
-    TangentialHoleBridging::apply_to_bridges(this);
+
 }
 
 

--- a/src/libslic3r/LayerRegion.cpp
+++ b/src/libslic3r/LayerRegion.cpp
@@ -8,7 +8,6 @@
 #include "BoundingBox.hpp"
 #include "SVG.hpp"
 #include "Algorithm/RegionExpansion.hpp"
-#include "TangentialHoleBridging.hpp"
 
 #include <string>
 #include <map>
@@ -122,10 +121,7 @@ void LayerRegion::make_perimeters(const SurfaceCollection &slices, const LayerRe
         g.process_arachne();
     else
         g.process_classic();
-
-
 }
-
 
 #if 1
 

--- a/src/libslic3r/LayerRegion.cpp
+++ b/src/libslic3r/LayerRegion.cpp
@@ -8,6 +8,7 @@
 #include "BoundingBox.hpp"
 #include "SVG.hpp"
 #include "Algorithm/RegionExpansion.hpp"
+#include "TangentialHoleBridging.hpp"
 
 #include <string>
 #include <map>
@@ -121,7 +122,11 @@ void LayerRegion::make_perimeters(const SurfaceCollection &slices, const LayerRe
         g.process_arachne();
     else
         g.process_classic();
+
+    // ORCA: Generate tangential struts for vertical holes in bridging areas
+    TangentialHoleBridging::apply_to_bridges(this);
 }
+
 
 #if 1
 

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -1415,15 +1415,18 @@ void PrintConfigDef::init_fff_params()
         "This option creates bridges for counterbore holes, allowing them to be printed without support. Available modes include:\n"
          "1. None: No bridge is created\n"
          "2. Partially Bridged: Only a part of the unsupported area will be bridged\n"
-         "3. Sacrificial Layer: A full sacrificial bridge layer is created");
+         "3. Sacrificial Layer: A full sacrificial bridge layer is created\n"
+         "4. Tangential bridge: Generates crossed struts under the hole, providing a solid anchor with minimal extra material");
     def->mode = comAdvanced;
     def->enum_keys_map = &ConfigOptionEnum<CounterboreHoleBridgingOption>::get_enum_values();
     def->enum_values.emplace_back("none");
     def->enum_values.emplace_back("partiallybridge");
     def->enum_values.emplace_back("sacrificiallayer");
+    def->enum_values.emplace_back("tangential");
     def->enum_labels.emplace_back(L("None"));
     def->enum_labels.emplace_back(L("Partially bridged"));
     def->enum_labels.emplace_back(L("Sacrificial layer"));
+    def->enum_labels.emplace_back(L("Tangential bridge"));
     def->set_default_value(new ConfigOptionEnum<CounterboreHoleBridgingOption>(chbNone));
 
     def = this->add("overhang_reverse_threshold", coFloatOrPercent);

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -366,7 +366,7 @@ enum class GCodeThumbnailsFormat {
 };
 
 enum CounterboreHoleBridgingOption {
-    chbNone, chbBridges, chbFilled
+    chbNone, chbBridges, chbFilled, chbTangential
 };
 
  enum WipeTowerWallType {

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -1046,6 +1046,15 @@ bool PrintObject::invalidate_state_by_config_options(
             || opt_key == "wipe_on_loops"
             || opt_key == "wipe_speed") {
             steps.emplace_back(posPerimeters);
+            // ORCA: Tangential bridging logic uses wall_loops and line widths during slicing
+            if (opt_key == "wall_loops" || opt_key == "inner_wall_line_width") {
+                for (size_t i = 0; i < this->num_printing_regions(); ++i) {
+                    if (this->printing_region(i).config().counterbore_hole_bridging == chbTangential) {
+                        steps.emplace_back(posSlice);
+                        break;
+                    }
+                }
+            }
         } else if (
             opt_key == "small_area_infill_flow_compensation_model") {
             steps.emplace_back(posSlice);
@@ -1275,6 +1284,15 @@ bool PrintObject::invalidate_state_by_config_options(
             || opt_key == "precise_outer_wall") {
             steps.emplace_back(posPerimeters);
             steps.emplace_back(posSupportMaterial);
+            // ORCA: Tangential bridging logic uses line widths during slicing
+            if (opt_key == "outer_wall_line_width") {
+                for (size_t i = 0; i < this->num_printing_regions(); ++i) {
+                    if (this->printing_region(i).config().counterbore_hole_bridging == chbTangential) {
+                        steps.emplace_back(posSlice);
+                        break;
+                    }
+                }
+            }
         } else if (opt_key == "bridge_flow" || opt_key == "internal_bridge_flow") {
             if (m_config.support_top_z_distance > 0.) {
             	// Only invalidate due to bridging if bridging is enabled.

--- a/src/libslic3r/PrintObjectSlice.cpp
+++ b/src/libslic3r/PrintObjectSlice.cpp
@@ -8,6 +8,7 @@
 #include "Layer.hpp"
 #include "MultiMaterialSegmentation.hpp"
 #include "Print.hpp"
+#include "TangentialHoleBridging.hpp"
 //BBS
 #include "ShortestPath.hpp"
 #include "libslic3r/Feature/Interlocking/InterlockingGenerator.hpp"
@@ -820,6 +821,9 @@ void PrintObject::slice()
 
     // BBS: the actual first layer slices stored in layers are re-sorted by volume group and will be used to generate brim
     groupingVolumesForBrim(this, m_layers, firstLayerReplacedBy);
+
+    // ORCA: Apply tangential sacrificial bridging pre-processing
+    TangentialHoleBridging::apply(this);
 
     // Update bounding boxes, back up raw slices of complex models.
     tbb::parallel_for(

--- a/src/libslic3r/TangentialHoleBridging.cpp
+++ b/src/libslic3r/TangentialHoleBridging.cpp
@@ -186,14 +186,6 @@ void TangentialHoleBridging::apply(PrintObject* object)
                         s_top.points = { Point(l_x, inner_bbox.max.y()), Point(r_x, inner_bbox.max.y()), Point(r_x, t_y), Point(l_x, t_y) };
                         raw_struts_n1.push_back(s_bottom);
                         raw_struts_n1.push_back(s_top);
-                        
-                        Polygon s_left_n1;
-                        s_left_n1.points = { Point(inner_bbox.min.x() - strut_w, b_y), Point(inner_bbox.min.x(), b_y), Point(inner_bbox.min.x(), t_y), Point(inner_bbox.min.x() - strut_w, t_y) };
-                        Polygon s_right_n1;
-                        s_right_n1.points = { Point(inner_bbox.max.x(), b_y), Point(inner_bbox.max.x() + strut_w, b_y), Point(inner_bbox.max.x() + strut_w, t_y), Point(inner_bbox.max.x(), t_y) };
-                        raw_struts_n1.push_back(s_left_n1);
-                        raw_struts_n1.push_back(s_right_n1);
-                        
                     }
                 }
 

--- a/src/libslic3r/TangentialHoleBridging.cpp
+++ b/src/libslic3r/TangentialHoleBridging.cpp
@@ -20,7 +20,6 @@ void TangentialHoleBridging::apply(PrintObject* object)
         return;
 
     const double nozzle_diameter = object->print()->config().nozzle_diameter.get_at(0);
-    const coord_t strut_w = scale_(nozzle_diameter * 2.0);
     const coord_t margin = scale_(nozzle_diameter * 2.0); // anchor margin
 
     for (size_t i = 2; i < object->layer_count(); ++i) {
@@ -68,9 +67,8 @@ void TangentialHoleBridging::apply(PrintObject* object)
                     // ORCA: Check the distance from the hole to the bounding box of the unsupported area.
                     // If the distance is small (e.g. <= 8mm), it's a counterbore lip, so we fill the entire space
                     // to the contour to make a solid block (user preferred behavior).
-                    // If the distance is large (e.g. a huge bridge with a small hole), we DO NOT generate struts
-                    // in layer N-1 and N-2 to avoid massive blocks spanning the whole bridge. We rely on apply_to_bridges
-                    // for that instead.
+                    // If the distance is large (e.g. a normal hole in a large bridge contour), we generate thin tangential
+                    // struts of fixed width (strut_w) to provide a solid crossing for native wall_loops, without filling the whole void.
                     const coord_t max_lip = scale_(8.0);
                     
                     coord_t dist_left   = inner_bbox.min.x() - bbox.min.x();
@@ -78,56 +76,127 @@ void TangentialHoleBridging::apply(PrintObject* object)
                     coord_t dist_bottom = inner_bbox.min.y() - bbox.min.y();
                     coord_t dist_top    = bbox.max.y() - inner_bbox.max.y();
 
-                    // If it is NOT a small counterbore lip, SKIP generation on N-1 and N-2 layers!
-                    if (dist_left > max_lip || dist_right > max_lip || dist_bottom > max_lip || dist_top > max_lip) {
-                        continue;
-                    }
+                    bool is_small_lip = (dist_left <= max_lip && dist_right <= max_lip && dist_bottom <= max_lip && dist_top <= max_lip);
+
+                    // ORCA: Dynamically calculate strut width based on configured wall_loops
+                    int wall_loops = object->printing_region(region_id).config().wall_loops.value;
+                    if (wall_loops <= 0) wall_loops = 2; // Fallback if 0 perimeters are configured
+                    
+                    // Width is roughly loops * nozzle_diameter * 1.125 (flow magic)
+                    coord_t strut_w = scale_(nozzle_diameter * 1.125 * wall_loops);
 
                     coord_t left_x   = bbox.min.x() - margin;
                     coord_t right_x  = bbox.max.x() + margin;
                     coord_t bottom_y = bbox.min.y() - margin;
                     coord_t top_y    = bbox.max.y() + margin;
 
-                    // Strut Left (Y direction) - for N-2
-                    Polygon strut_left;
-                    strut_left.points = {
-                        Point(left_x,             bbox.min.y() - margin),
-                        Point(inner_bbox.min.x(), bbox.min.y() - margin),
-                        Point(inner_bbox.min.x(), bbox.max.y() + margin),
-                        Point(left_x,             bbox.max.y() + margin)
-                    };
-                    
-                    // Strut Right (Y direction) - for N-2
-                    Polygon strut_right;
-                    strut_right.points = {
-                        Point(inner_bbox.max.x(), bbox.min.y() - margin),
-                        Point(right_x,            bbox.min.y() - margin),
-                        Point(right_x,            bbox.max.y() + margin),
-                        Point(inner_bbox.max.x(), bbox.max.y() + margin)
-                    };
+                    // If it is a large hole, we need a cross over N-1 and N-2. 
+                    // To prevent mid-air collisions, put X-struts on N-1 and Y-struts on N-2.
+                    if (!is_small_lip) {
+                        // Strut Left (Y direction) - for N-2
+                        Polygon strut_left;
+                        strut_left.points = {
+                            Point(inner_bbox.min.x() - strut_w, bottom_y),
+                            Point(inner_bbox.min.x(),           bottom_y),
+                            Point(inner_bbox.min.x(),           top_y),
+                            Point(inner_bbox.min.x() - strut_w, top_y)
+                        };
+                        
+                        // Strut Right (Y direction) - for N-2
+                        Polygon strut_right;
+                        strut_right.points = {
+                            Point(inner_bbox.max.x(),           bottom_y),
+                            Point(inner_bbox.max.x() + strut_w, bottom_y),
+                            Point(inner_bbox.max.x() + strut_w, top_y),
+                            Point(inner_bbox.max.x(),           top_y)
+                        };
+                        raw_struts_n2.push_back(strut_left);
+                        raw_struts_n2.push_back(strut_right);
+                    } else {
+                        // Small lip - solid base on N-2
+                        Polygon strut_left;
+                        strut_left.points = {
+                            Point(left_x,             bbox.min.y() - margin),
+                            Point(inner_bbox.min.x(), bbox.min.y() - margin),
+                            Point(inner_bbox.min.x(), bbox.max.y() + margin),
+                            Point(left_x,             bbox.max.y() + margin)
+                        };
+                        
+                        Polygon strut_right;
+                        strut_right.points = {
+                            Point(inner_bbox.max.x(), bbox.min.y() - margin),
+                            Point(right_x,            bbox.min.y() - margin),
+                            Point(right_x,            bbox.max.y() + margin),
+                            Point(inner_bbox.max.x(), bbox.max.y() + margin)
+                        };
+                        raw_struts_n2.push_back(strut_left);
+                        raw_struts_n2.push_back(strut_right);
+                    }
 
                     // Strut Bottom (X direction) - for N-1
                     Polygon strut_bottom;
-                    strut_bottom.points = {
-                        Point(bbox.min.x() - margin, bottom_y),
-                        Point(bbox.max.x() + margin, bottom_y),
-                        Point(bbox.max.x() + margin, inner_bbox.min.y()),
-                        Point(bbox.min.x() - margin, inner_bbox.min.y())
-                    };
+                    if (is_small_lip) {
+                        strut_bottom.points = {
+                            Point(left_x, bottom_y),
+                            Point(right_x, bottom_y),
+                            Point(right_x, inner_bbox.min.y()),
+                            Point(left_x, inner_bbox.min.y())
+                        };
+                    } else {
+                        strut_bottom.points = {
+                            Point(left_x, inner_bbox.min.y() - strut_w),
+                            Point(right_x, inner_bbox.min.y() - strut_w),
+                            Point(right_x, inner_bbox.min.y()),
+                            Point(left_x, inner_bbox.min.y())
+                        };
+                    }
 
                     // Strut Top (X direction) - for N-1
                     Polygon strut_top;
-                    strut_top.points = {
-                        Point(bbox.min.x() - margin, inner_bbox.max.y()),
-                        Point(bbox.max.x() + margin, inner_bbox.max.y()),
-                        Point(bbox.max.x() + margin, top_y),
-                        Point(bbox.min.x() - margin, top_y)
-                    };
+                    if (is_small_lip) {
+                        strut_top.points = {
+                            Point(left_x, inner_bbox.max.y()),
+                            Point(right_x, inner_bbox.max.y()),
+                            Point(right_x, top_y),
+                            Point(left_x, top_y)
+                        };
+                    } else {
+                        strut_top.points = {
+                            Point(left_x, inner_bbox.max.y()),
+                            Point(right_x, inner_bbox.max.y()),
+                            Point(right_x, inner_bbox.max.y() + strut_w),
+                            Point(left_x, inner_bbox.max.y() + strut_w)
+                        };
+                    }
 
-                    raw_struts_n2.push_back(strut_left);
-                    raw_struts_n2.push_back(strut_right);
-                    raw_struts_n1.push_back(strut_bottom);
-                    raw_struts_n1.push_back(strut_top);
+                    // For small lips, we use all four sides to make a solid anchor.
+                    // For large holes, we put X on N-1 and Y on N-2 to create a structural cross without layer intersections.
+                    if (is_small_lip) {
+                        raw_struts_n1.push_back(strut_bottom);
+                        raw_struts_n1.push_back(strut_top);
+                        
+                        Polygon strut_left;
+                        strut_left.points = {
+                            Point(inner_bbox.min.x() - strut_w, bottom_y),
+                            Point(inner_bbox.min.x(), bottom_y),
+                            Point(inner_bbox.min.x(), top_y),
+                            Point(inner_bbox.min.x() - strut_w, top_y)
+                        };
+                        
+                        Polygon strut_right;
+                        strut_right.points = {
+                            Point(inner_bbox.max.x(), bottom_y),
+                            Point(inner_bbox.max.x() + strut_w, bottom_y),
+                            Point(inner_bbox.max.x() + strut_w, top_y),
+                            Point(inner_bbox.max.x(), top_y)
+                        };
+                        raw_struts_n1.push_back(strut_left);
+                        raw_struts_n1.push_back(strut_right);
+                    } else {
+                        // Large hole: X direction on N-1
+                        raw_struts_n1.push_back(strut_bottom);
+                        raw_struts_n1.push_back(strut_top);
+                    }
                 }
 
                 // ORCA: Intersect struts with the unsupported area to prevent them from shooting into mid-air
@@ -137,9 +206,27 @@ void TangentialHoleBridging::apply(PrintObject* object)
 
                 // ORCA: Subtract all holes of this unsupported area from the generated struts
                 // so we don't accidentally cover other holes in a multi-hole bridge.
-                Polygons all_holes = poly_unsupp.holes;
-                final_struts_n1 = diff(final_struts_n1, all_holes);
-                final_struts_n2 = diff(final_struts_n2, all_holes);
+                // IMPORTANT: For large holes (!is_small_lip), we do NOT subtract the hole itself,
+                // because we WANT our narrow strut to pass perfectly straight THROUGH the hole space,
+                // without curving around its boundaries. (This prevents "curving in the air").
+                Polygons all_holes_small_lips;
+                for (const Polygon& hole : poly_unsupp.holes) {
+                    BoundingBox inner_bbox = get_extents(hole);
+                    coord_t dist_left   = inner_bbox.min.x() - bbox.min.x();
+                    coord_t dist_right  = bbox.max.x() - inner_bbox.max.x();
+                    coord_t dist_bottom = inner_bbox.min.y() - bbox.min.y();
+                    coord_t dist_top    = bbox.max.y() - inner_bbox.max.y();
+                    const coord_t max_lip = scale_(8.0);
+                    if (dist_left <= max_lip && dist_right <= max_lip && dist_bottom <= max_lip && dist_top <= max_lip) {
+                        all_holes_small_lips.push_back(hole);
+                    }
+                }
+
+                // Normal subtraction for small lips where we fill the volume completely
+                if (!all_holes_small_lips.empty()) {
+                    final_struts_n1 = diff(final_struts_n1, all_holes_small_lips);
+                    final_struts_n2 = diff(final_struts_n2, all_holes_small_lips);
+                }
 
                 if (final_struts_n1.empty() && final_struts_n2.empty()) continue;
 
@@ -191,111 +278,6 @@ void TangentialHoleBridging::apply(PrintObject* object)
     }
 }
 
-void TangentialHoleBridging::apply_to_bridges(LayerRegion* region)
-{
-    if (region->region().config().counterbore_hole_bridging != chbTangential)
-        return;
 
-    Layer* layer_n1 = region->layer();
-    Layer* layer_n = layer_n1->upper_layer;
-    if (!layer_n) return;
-
-    // Identify overhangs on the UPPER layer (layer_n) over the current layer (layer_n1)
-    // Old code commented out
-    // LayerRegion* upper_region = layer_n->get_region(region->region().print_region_id());
-
-    // ORCA: use print_object_region_id instead of print_region_id to avoid out-of-bounds crash with multiple objects on the plate
-    LayerRegion* upper_region = layer_n->get_region(region->region().print_object_region_id());
-    if (!upper_region || upper_region->slices.empty()) return;
-
-    ExPolygons upper_slices = to_expolygons(upper_region->slices.surfaces);
-    ExPolygons overhangs = diff_ex(upper_slices, layer_n1->lslices, ApplySafetyOffset::Yes);
-    if (overhangs.empty()) return;
-
-    const double nozzle_diameter = layer_n1->object()->print()->config().nozzle_diameter.get_at(0);
-    const coord_t margin = scale_(nozzle_diameter * 2.0);
-
-    ExtrusionEntityCollection* bridge_island = new ExtrusionEntityCollection();
-
-    for (const ExPolygon& poly_unsupp : overhangs) {
-        if (poly_unsupp.holes.empty()) continue;
-
-        BoundingBox bbox = get_extents(poly_unsupp);
-        Polygons contour_bigger = offset(poly_unsupp.contour, margin);
-        Polygons anchors = intersection(contour_bigger, to_polygons(layer_n1->lslices));
-        if (anchors.empty()) continue;
-
-        for (const Polygon& hole : poly_unsupp.holes) {
-            BoundingBox inner_bbox = get_extents(hole);
-            
-            // Check if this is a small counterbore lip (which already gets filled by apply())
-            const coord_t max_lip = scale_(8.0);
-            coord_t dist_left   = inner_bbox.min.x() - bbox.min.x();
-            coord_t dist_right  = bbox.max.x() - inner_bbox.max.x();
-            coord_t dist_bottom = inner_bbox.min.y() - bbox.min.y();
-            coord_t dist_top    = bbox.max.y() - inner_bbox.max.y();
-            
-            // If ALL distances are small, it's a counterbore lip that already got a solid block in N-1/N-2 via apply.
-            if (dist_left <= max_lip && dist_right <= max_lip && dist_bottom <= max_lip && dist_top <= max_lip) {
-                continue; // Skip, apply() handled it
-            }
-
-            // Use the anchor bounding box to ensure lines span entirely across the available anchored space
-            BoundingBox full_bbox = get_extents(anchors);
-            full_bbox.merge(inner_bbox);
-
-            coord_t left_x = inner_bbox.min.x();
-            coord_t right_x = inner_bbox.max.x();
-            coord_t bottom_y = inner_bbox.min.y();
-            coord_t top_y = inner_bbox.max.y();
-
-            coord_t offset1 = scale_(nozzle_diameter) / 2.0;
-
-            Polylines lines;
-
-            // Generate two adjacent lines on each side to make the strut twice as wide
-            // Left side
-            lines.push_back({ Point(left_x + offset1, full_bbox.min.y() - margin), Point(left_x + offset1, full_bbox.max.y() + margin) });
-            lines.push_back({ Point(left_x - offset1, full_bbox.min.y() - margin), Point(left_x - offset1, full_bbox.max.y() + margin) });
-            
-            // Right side
-            lines.push_back({ Point(right_x - offset1, full_bbox.min.y() - margin), Point(right_x - offset1, full_bbox.max.y() + margin) });
-            lines.push_back({ Point(right_x + offset1, full_bbox.min.y() - margin), Point(right_x + offset1, full_bbox.max.y() + margin) });
-
-            // Bottom side
-            lines.push_back({ Point(full_bbox.min.x() - margin, bottom_y + offset1), Point(full_bbox.max.x() + margin, bottom_y + offset1) });
-            lines.push_back({ Point(full_bbox.min.x() - margin, bottom_y - offset1), Point(full_bbox.max.x() + margin, bottom_y - offset1) });
-
-            // Top side
-            lines.push_back({ Point(full_bbox.min.x() - margin, top_y - offset1), Point(full_bbox.max.x() + margin, top_y - offset1) });
-            lines.push_back({ Point(full_bbox.min.x() - margin, top_y + offset1), Point(full_bbox.max.x() + margin, top_y + offset1) });
-
-            // Trim lines to the solid anchors of the bridge PLUS the unsupported area
-            // We use the outer contour of the unsupported area, IGNORING its holes. 
-            // Otherwise, intersection_pl would cut out the strut where it crosses the hole!
-            Polygons unsupp_solid;
-            unsupp_solid.push_back(poly_unsupp.contour);
-            Polygons clipping_area = union_(unsupp_solid, anchors);
-
-            Polylines clipped_lines = intersection_pl(lines, clipping_area);
-
-            Flow flow = region->bridging_flow(frPerimeter);
-            for (const Polyline& pl : clipped_lines) {
-                // Ignore tiny segments
-                if (pl.length() < margin) continue;
-
-                ExtrusionPath path(erOverhangPerimeter, flow.mm3_per_mm(), flow.width(), layer_n1->height);
-                path.polyline = pl;
-                bridge_island->append(std::move(path));
-            }
-        }
-    }
-
-    if (!bridge_island->entities.empty()) {
-        region->perimeters.entities.push_back(bridge_island);
-    } else {
-        delete bridge_island;
-    }
-}
 
 } // namespace Slic3r

--- a/src/libslic3r/TangentialHoleBridging.cpp
+++ b/src/libslic3r/TangentialHoleBridging.cpp
@@ -1,0 +1,188 @@
+//ORCA: Tangential sacrificial bridging for counterbore holes
+#include "TangentialHoleBridging.hpp"
+#include "Print.hpp"
+#include "Layer.hpp"
+#include "ClipperUtils.hpp"
+
+namespace Slic3r {
+
+void TangentialHoleBridging::apply(PrintObject* object)
+{
+    // check if ANY region has chbTangential enabled
+    bool has_tangential = false;
+    for (size_t region_id = 0; region_id < object->num_printing_regions(); ++region_id) {
+        if (object->printing_region(region_id).config().counterbore_hole_bridging == chbTangential) {
+            has_tangential = true;
+            break;
+        }
+    }
+    if (!has_tangential || object->layer_count() < 3)
+        return;
+
+    const double nozzle_diameter = object->print()->config().nozzle_diameter.get_at(0);
+    const coord_t strut_w = scale_(nozzle_diameter * 2.0);
+    const coord_t margin = scale_(nozzle_diameter * 2.0); // anchor margin
+
+    for (size_t i = 2; i < object->layer_count(); ++i) {
+        Layer* layer_n = object->get_layer(i);
+        Layer* layer_n1 = object->get_layer(i - 1);
+        Layer* layer_n2 = object->get_layer(i - 2);
+
+        for (size_t region_id = 0; region_id < object->num_printing_regions(); ++region_id) {
+            if (object->printing_region(region_id).config().counterbore_hole_bridging != chbTangential) {
+                continue;
+            }
+
+            LayerRegion* region_n = layer_n->get_region(region_id);
+            if (!region_n || region_n->slices.empty()) continue;
+
+            // Find unsupported areas specifically for this region
+            ExPolygons unsupported = diff_ex(region_n->slices.surfaces, layer_n1->lslices, ApplySafetyOffset::Yes);
+            if (unsupported.empty()) continue;
+
+            for (const ExPolygon& poly_unsupp : unsupported) {
+                // A counterbore overhang must have a hole in the middle (it's a ring or a bridge with holes)
+                if (poly_unsupp.holes.empty()) {
+                    continue; 
+                }
+
+                BoundingBox bbox = get_extents(poly_unsupp);
+
+                // We must ensure the struts will anchor to something in N-1 and N-2.
+                // ORCA: Expand contour to ensure anchoring into the solid walls
+                Polygons contour_bigger = offset(poly_unsupp.contour, margin);
+                Polygons anchors = intersection(contour_bigger, to_polygons(layer_n1->lslices));
+                
+                if (anchors.empty()) {
+                    continue;
+                }
+
+                Polygons raw_struts_n1;
+                Polygons raw_struts_n2;
+
+                // ORCA: Process ALL holes instead of just the largest one
+                // This allows bridging areas with multiple holes to be supported properly.
+                for (const Polygon& hole : poly_unsupp.holes) {
+                    BoundingBox inner_bbox = get_extents(hole);
+
+                    // ORCA: Check the distance from the hole to the bounding box of the unsupported area.
+                    // If the distance is small (e.g. <= 8mm), it's a counterbore lip, so we fill the entire space
+                    // to the contour to make a solid block (user preferred behavior).
+                    // If the distance is large (e.g. a huge bridge with a small hole), we limit the strut width
+                    // to 'strut_w' to avoid filling the entire bridge with massive blocks.
+                    const coord_t max_lip = scale_(8.0);
+                    
+                    coord_t dist_left   = inner_bbox.min.x() - bbox.min.x();
+                    coord_t dist_right  = bbox.max.x() - inner_bbox.max.x();
+                    coord_t dist_bottom = inner_bbox.min.y() - bbox.min.y();
+                    coord_t dist_top    = bbox.max.y() - inner_bbox.max.y();
+
+                    coord_t left_x   = (dist_left <= max_lip)   ? (bbox.min.x() - margin) : (inner_bbox.min.x() - strut_w);
+                    coord_t right_x  = (dist_right <= max_lip)  ? (bbox.max.x() + margin) : (inner_bbox.max.x() + strut_w);
+                    coord_t bottom_y = (dist_bottom <= max_lip) ? (bbox.min.y() - margin) : (inner_bbox.min.y() - strut_w);
+                    coord_t top_y    = (dist_top <= max_lip)    ? (bbox.max.y() + margin) : (inner_bbox.max.y() + strut_w);
+
+                    // Strut Left (Y direction) - for N-2
+                    Polygon strut_left;
+                    strut_left.points = {
+                        Point(left_x,             bbox.min.y() - margin),
+                        Point(inner_bbox.min.x(), bbox.min.y() - margin),
+                        Point(inner_bbox.min.x(), bbox.max.y() + margin),
+                        Point(left_x,             bbox.max.y() + margin)
+                    };
+                    
+                    // Strut Right (Y direction) - for N-2
+                    Polygon strut_right;
+                    strut_right.points = {
+                        Point(inner_bbox.max.x(), bbox.min.y() - margin),
+                        Point(right_x,            bbox.min.y() - margin),
+                        Point(right_x,            bbox.max.y() + margin),
+                        Point(inner_bbox.max.x(), bbox.max.y() + margin)
+                    };
+
+                    // Strut Bottom (X direction) - for N-1
+                    Polygon strut_bottom;
+                    strut_bottom.points = {
+                        Point(bbox.min.x() - margin, bottom_y),
+                        Point(bbox.max.x() + margin, bottom_y),
+                        Point(bbox.max.x() + margin, inner_bbox.min.y()),
+                        Point(bbox.min.x() - margin, inner_bbox.min.y())
+                    };
+
+                    // Strut Top (X direction) - for N-1
+                    Polygon strut_top;
+                    strut_top.points = {
+                        Point(bbox.min.x() - margin, inner_bbox.max.y()),
+                        Point(bbox.max.x() + margin, inner_bbox.max.y()),
+                        Point(bbox.max.x() + margin, top_y),
+                        Point(bbox.min.x() - margin, top_y)
+                    };
+
+                    raw_struts_n2.push_back(strut_left);
+                    raw_struts_n2.push_back(strut_right);
+                    raw_struts_n1.push_back(strut_bottom);
+                    raw_struts_n1.push_back(strut_top);
+                }
+
+                // ORCA: Intersect struts with the unsupported area to prevent them from shooting into mid-air
+                // on L-shaped or diagonal bridges, guaranteeing they find an anchor in the surrounding wall.
+                Polygons final_struts_n1 = intersection(raw_struts_n1, contour_bigger);
+                Polygons final_struts_n2 = intersection(raw_struts_n2, contour_bigger);
+
+                // ORCA: Subtract all holes of this unsupported area from the generated struts
+                // so we don't accidentally cover other holes in a multi-hole bridge.
+                Polygons all_holes = poly_unsupp.holes;
+                final_struts_n1 = diff(final_struts_n1, all_holes);
+                final_struts_n2 = diff(final_struts_n2, all_holes);
+
+                if (final_struts_n1.empty() && final_struts_n2.empty()) continue;
+
+                // Add to lslices (overall layer boundary)
+                layer_n2->lslices = union_ex(layer_n2->lslices, final_struts_n2);
+                layer_n1->lslices = union_ex(layer_n1->lslices, final_struts_n1);
+                
+                // --- INTEGRATE INTO LAYER N-1 ---
+                if (!layer_n1->regions().empty() && !final_struts_n1.empty()) {
+                    // Subtract struts from all OTHER regions to prevent multicolor overlap
+                    for (size_t r = 0; r < layer_n1->regions().size(); ++r) {
+                        if (r == region_id) continue;
+                        LayerRegion* other_region = layer_n1->get_region(r);
+                        if (!other_region || other_region->slices.empty()) continue;
+                        ExPolygons cut_polys = diff_ex(other_region->slices.surfaces, final_struts_n1);
+                        other_region->slices.set(cut_polys, stInternal);
+                    }
+
+                    // Add struts specifically to the correct region
+                    LayerRegion* target_region = layer_n1->get_region(region_id);
+                    if (target_region) {
+                        Polygons polys_1 = to_polygons(target_region->slices.surfaces);
+                        for (const Polygon& p : final_struts_n1) polys_1.push_back(p);
+                        target_region->slices.set(union_ex(polys_1), stInternal);
+                    }
+                }
+                
+                // --- INTEGRATE INTO LAYER N-2 ---
+                if (!layer_n2->regions().empty() && !final_struts_n2.empty()) {
+                    // Subtract struts from all OTHER regions to prevent multicolor overlap
+                    for (size_t r = 0; r < layer_n2->regions().size(); ++r) {
+                        if (r == region_id) continue;
+                        LayerRegion* other_region = layer_n2->get_region(r);
+                        if (!other_region || other_region->slices.empty()) continue;
+                        ExPolygons cut_polys = diff_ex(other_region->slices.surfaces, final_struts_n2);
+                        other_region->slices.set(cut_polys, stInternal);
+                    }
+
+                    // Add struts specifically to the correct region
+                    LayerRegion* target_region = layer_n2->get_region(region_id);
+                    if (target_region) {
+                        Polygons polys_2 = to_polygons(target_region->slices.surfaces);
+                        for (const Polygon& p : final_struts_n2) polys_2.push_back(p);
+                        target_region->slices.set(union_ex(polys_2), stInternal);
+                    }
+                }
+            }
+        }
+    }
+}
+
+} // namespace Slic3r

--- a/src/libslic3r/TangentialHoleBridging.cpp
+++ b/src/libslic3r/TangentialHoleBridging.cpp
@@ -4,6 +4,7 @@
 #include "Layer.hpp"
 #include "ClipperUtils.hpp"
 #include "BridgeDetector.hpp"
+#include "Flow.hpp"
 
 namespace Slic3r {
 
@@ -86,7 +87,23 @@ void TangentialHoleBridging::apply(PrintObject* object)
 
                     int wall_loops = object->printing_region(region_id).config().wall_loops.value;
                     if (wall_loops <= 0) wall_loops = 2;
-                    coord_t strut_w = scale_(nozzle_diameter * 1.125 * wall_loops);
+                    
+                    // ORCA: Ensure even number of wall loops for normal holes to improve anchor points
+                    if (!is_small_lip && wall_loops % 2 != 0) {
+                        wall_loops += 1;
+                    }
+                    
+                    // ORCA: Compute strut width properly using actual configured wall line widths.
+                    // The bridging strut has empty space on BOTH its left and right sides (the small hole and the rest of the large hole gap).
+                    // Therefore, it will be traced with outer loops on both sides. We need width for 2 outer walls + (wall_loops - 2) inner walls.
+                    const auto &reg_config = object->printing_region(region_id).config();
+                    Flow outer_flow = Flow::new_from_config_width(frExternalPerimeter, reg_config.outer_wall_line_width, nozzle_diameter, layer_n1->height);
+                    Flow inner_flow = Flow::new_from_config_width(frPerimeter, reg_config.inner_wall_line_width, nozzle_diameter, layer_n1->height);
+                    
+                    coord_t strut_w = outer_flow.scaled_width();
+                    if (wall_loops > 1) {
+                        strut_w = 2 * outer_flow.scaled_width() + inner_flow.scaled_spacing() * (wall_loops - 2);
+                    }
 
                     if (!is_small_lip) {
                         // LARGE HOLE: Generate rotated '#' struts aligned with the bridge angle
@@ -176,6 +193,7 @@ void TangentialHoleBridging::apply(PrintObject* object)
                         s_right_n1.points = { Point(inner_bbox.max.x(), b_y), Point(inner_bbox.max.x() + strut_w, b_y), Point(inner_bbox.max.x() + strut_w, t_y), Point(inner_bbox.max.x(), t_y) };
                         raw_struts_n1.push_back(s_left_n1);
                         raw_struts_n1.push_back(s_right_n1);
+                        
                     }
                 }
 

--- a/src/libslic3r/TangentialHoleBridging.cpp
+++ b/src/libslic3r/TangentialHoleBridging.cpp
@@ -3,6 +3,7 @@
 #include "Print.hpp"
 #include "Layer.hpp"
 #include "ClipperUtils.hpp"
+#include "BridgeDetector.hpp"
 
 namespace Slic3r {
 
@@ -39,6 +40,8 @@ void TangentialHoleBridging::apply(PrintObject* object)
             ExPolygons unsupported = diff_ex(region_n->slices.surfaces, layer_n1->lslices, ApplySafetyOffset::Yes);
             if (unsupported.empty()) continue;
 
+            const coord_t max_lip = scale_(8.0);
+
             for (const ExPolygon& poly_unsupp : unsupported) {
                 // A counterbore overhang must have a hole in the middle (it's a ring or a bridge with holes)
                 if (poly_unsupp.holes.empty()) {
@@ -59,18 +62,21 @@ void TangentialHoleBridging::apply(PrintObject* object)
                 Polygons raw_struts_n1;
                 Polygons raw_struts_n2;
 
+                // ORCA: Detect the bridging direction for the entire unsupported area.
+                // This ensures all holes in the same bridge use a consistent and optimal angle.
+                BridgeDetector bd(poly_unsupp, layer_n1->lslices, scale_(nozzle_diameter));
+                bd.detect_angle();
+                double bridge_angle = bd.angle;
+                
+                // Snap to 90-degree increments to avoid noisy angles on axis-aligned models
+                double snap_tol = Geometry::deg2rad(3.0);
+                if (std::abs(bridge_angle) < snap_tol || std::abs(bridge_angle - PI) < snap_tol || std::abs(bridge_angle - 2.0*PI) < snap_tol) bridge_angle = 0.0;
+                else if (std::abs(bridge_angle - PI/2.0) < snap_tol || std::abs(bridge_angle - 1.5*PI) < snap_tol) bridge_angle = PI/2.0;
+
                 // ORCA: Process ALL holes instead of just the largest one
-                // This allows bridging areas with multiple holes to be supported properly.
                 for (const Polygon& hole : poly_unsupp.holes) {
                     BoundingBox inner_bbox = get_extents(hole);
 
-                    // ORCA: Check the distance from the hole to the bounding box of the unsupported area.
-                    // If the distance is small (e.g. <= 8mm), it's a counterbore lip, so we fill the entire space
-                    // to the contour to make a solid block (user preferred behavior).
-                    // If the distance is large (e.g. a normal hole in a large bridge contour), we generate thin tangential
-                    // struts of fixed width (strut_w) to provide a solid crossing for native wall_loops, without filling the whole void.
-                    const coord_t max_lip = scale_(8.0);
-                    
                     coord_t dist_left   = inner_bbox.min.x() - bbox.min.x();
                     coord_t dist_right  = bbox.max.x() - inner_bbox.max.x();
                     coord_t dist_bottom = inner_bbox.min.y() - bbox.min.y();
@@ -78,151 +84,116 @@ void TangentialHoleBridging::apply(PrintObject* object)
 
                     bool is_small_lip = (dist_left <= max_lip && dist_right <= max_lip && dist_bottom <= max_lip && dist_top <= max_lip);
 
-                    // ORCA: Dynamically calculate strut width based on configured wall_loops
                     int wall_loops = object->printing_region(region_id).config().wall_loops.value;
-                    if (wall_loops <= 0) wall_loops = 2; // Fallback if 0 perimeters are configured
-                    
-                    // Width is roughly loops * nozzle_diameter * 1.125 (flow magic)
+                    if (wall_loops <= 0) wall_loops = 2;
                     coord_t strut_w = scale_(nozzle_diameter * 1.125 * wall_loops);
 
-                    coord_t left_x   = bbox.min.x() - margin;
-                    coord_t right_x  = bbox.max.x() + margin;
-                    coord_t bottom_y = bbox.min.y() - margin;
-                    coord_t top_y    = bbox.max.y() + margin;
-
-                    // If it is a large hole, we need a cross over N-1 and N-2. 
-                    // To prevent mid-air collisions, put X-struts on N-1 and Y-struts on N-2.
                     if (!is_small_lip) {
-                        // Strut Left (Y direction) - for N-2
-                        Polygon strut_left;
-                        strut_left.points = {
-                            Point(inner_bbox.min.x() - strut_w, bottom_y),
-                            Point(inner_bbox.min.x(),           bottom_y),
-                            Point(inner_bbox.min.x(),           top_y),
-                            Point(inner_bbox.min.x() - strut_w, top_y)
-                        };
+                        // LARGE HOLE: Generate rotated '#' struts aligned with the bridge angle
+                        Point center = inner_bbox.center();
+                        Polygon rotated_hole = hole;
+                        rotated_hole.rotate(-bridge_angle, center);
+                        BoundingBox rot_inner_bbox = get_extents(rotated_hole);
                         
-                        // Strut Right (Y direction) - for N-2
-                        Polygon strut_right;
-                        strut_right.points = {
-                            Point(inner_bbox.max.x(),           bottom_y),
-                            Point(inner_bbox.max.x() + strut_w, bottom_y),
-                            Point(inner_bbox.max.x() + strut_w, top_y),
-                            Point(inner_bbox.max.x(),           top_y)
-                        };
-                        raw_struts_n2.push_back(strut_left);
-                        raw_struts_n2.push_back(strut_right);
-                    } else {
-                        // Small lip - solid base on N-2
-                        Polygon strut_left;
-                        strut_left.points = {
-                            Point(left_x,             bbox.min.y() - margin),
-                            Point(inner_bbox.min.x(), bbox.min.y() - margin),
-                            Point(inner_bbox.min.x(), bbox.max.y() + margin),
-                            Point(left_x,             bbox.max.y() + margin)
-                        };
-                        
-                        Polygon strut_right;
-                        strut_right.points = {
-                            Point(inner_bbox.max.x(), bbox.min.y() - margin),
-                            Point(right_x,            bbox.min.y() - margin),
-                            Point(right_x,            bbox.max.y() + margin),
-                            Point(inner_bbox.max.x(), bbox.max.y() + margin)
-                        };
-                        raw_struts_n2.push_back(strut_left);
-                        raw_struts_n2.push_back(strut_right);
-                    }
+                        Polygon rotated_contour = poly_unsupp.contour;
+                        rotated_contour.rotate(-bridge_angle, center);
+                        BoundingBox rot_bbox = get_extents(rotated_contour);
 
-                    // Strut Bottom (X direction) - for N-1
-                    Polygon strut_bottom;
-                    if (is_small_lip) {
-                        strut_bottom.points = {
-                            Point(left_x, bottom_y),
-                            Point(right_x, bottom_y),
-                            Point(right_x, inner_bbox.min.y()),
-                            Point(left_x, inner_bbox.min.y())
-                        };
-                    } else {
-                        strut_bottom.points = {
-                            Point(left_x, inner_bbox.min.y() - strut_w),
-                            Point(right_x, inner_bbox.min.y() - strut_w),
-                            Point(right_x, inner_bbox.min.y()),
-                            Point(left_x, inner_bbox.min.y())
-                        };
-                    }
+                        coord_t r_left_x   = rot_bbox.min.x() - margin;
+                        coord_t r_right_x  = rot_bbox.max.x() + margin;
+                        coord_t r_bottom_y = rot_bbox.min.y() - margin;
+                        coord_t r_top_y    = rot_bbox.max.y() + margin;
 
-                    // Strut Top (X direction) - for N-1
-                    Polygon strut_top;
-                    if (is_small_lip) {
-                        strut_top.points = {
-                            Point(left_x, inner_bbox.max.y()),
-                            Point(right_x, inner_bbox.max.y()),
-                            Point(right_x, top_y),
-                            Point(left_x, top_y)
+                        // Strut Left (vertical in rotated space) -> Layer N-2
+                        Polygon s_left;
+                        s_left.points = {
+                            Point(rot_inner_bbox.min.x() - strut_w, r_bottom_y),
+                            Point(rot_inner_bbox.min.x(),           r_bottom_y),
+                            Point(rot_inner_bbox.min.x(),           r_top_y),
+                            Point(rot_inner_bbox.min.x() - strut_w, r_top_y)
                         };
-                    } else {
-                        strut_top.points = {
-                            Point(left_x, inner_bbox.max.y()),
-                            Point(right_x, inner_bbox.max.y()),
-                            Point(right_x, inner_bbox.max.y() + strut_w),
-                            Point(left_x, inner_bbox.max.y() + strut_w)
+                        s_left.rotate(bridge_angle, center);
+                        
+                        // Strut Right (vertical in rotated space) -> Layer N-2
+                        Polygon s_right;
+                        s_right.points = {
+                            Point(rot_inner_bbox.max.x(),           r_bottom_y),
+                            Point(rot_inner_bbox.max.x() + strut_w, r_bottom_y),
+                            Point(rot_inner_bbox.max.x() + strut_w, r_top_y),
+                            Point(rot_inner_bbox.max.x(),           r_top_y)
                         };
-                    }
+                        s_right.rotate(bridge_angle, center);
+                        
+                        raw_struts_n2.push_back(s_left);
+                        raw_struts_n2.push_back(s_right);
 
-                    // For small lips, we use all four sides to make a solid anchor.
-                    // For large holes, we put X on N-1 and Y on N-2 to create a structural cross without layer intersections.
-                    if (is_small_lip) {
-                        raw_struts_n1.push_back(strut_bottom);
-                        raw_struts_n1.push_back(strut_top);
-                        
-                        Polygon strut_left;
-                        strut_left.points = {
-                            Point(inner_bbox.min.x() - strut_w, bottom_y),
-                            Point(inner_bbox.min.x(), bottom_y),
-                            Point(inner_bbox.min.x(), top_y),
-                            Point(inner_bbox.min.x() - strut_w, top_y)
+                        // Strut Bottom (horizontal in rotated space) -> Layer N-1
+                        Polygon s_bottom;
+                        s_bottom.points = {
+                            Point(r_left_x,  rot_inner_bbox.min.y() - strut_w),
+                            Point(r_right_x, rot_inner_bbox.min.y() - strut_w),
+                            Point(r_right_x, rot_inner_bbox.min.y()),
+                            Point(r_left_x,  rot_inner_bbox.min.y())
                         };
-                        
-                        Polygon strut_right;
-                        strut_right.points = {
-                            Point(inner_bbox.max.x(), bottom_y),
-                            Point(inner_bbox.max.x() + strut_w, bottom_y),
-                            Point(inner_bbox.max.x() + strut_w, top_y),
-                            Point(inner_bbox.max.x(), top_y)
+                        s_bottom.rotate(bridge_angle, center);
+
+                        // Strut Top (horizontal in rotated space) -> Layer N-1
+                        Polygon s_top;
+                        s_top.points = {
+                            Point(r_left_x,  rot_inner_bbox.max.y()),
+                            Point(r_right_x, rot_inner_bbox.max.y()),
+                            Point(r_right_x, rot_inner_bbox.max.y() + strut_w),
+                            Point(r_left_x,  rot_inner_bbox.max.y() + strut_w)
                         };
-                        raw_struts_n1.push_back(strut_left);
-                        raw_struts_n1.push_back(strut_right);
+                        s_top.rotate(bridge_angle, center);
+
+                        raw_struts_n1.push_back(s_bottom);
+                        raw_struts_n1.push_back(s_top);
                     } else {
-                        // Large hole: X direction on N-1
-                        raw_struts_n1.push_back(strut_bottom);
-                        raw_struts_n1.push_back(strut_top);
+                        // SMALL LIP: Original axis-aligned behavior for solid filling
+                        coord_t l_x = bbox.min.x() - margin;
+                        coord_t r_x = bbox.max.x() + margin;
+                        coord_t b_y = bbox.min.y() - margin;
+                        coord_t t_y = bbox.max.y() + margin;
+
+                        Polygon s_left;
+                        s_left.points = { Point(l_x, b_y), Point(inner_bbox.min.x(), b_y), Point(inner_bbox.min.x(), t_y), Point(l_x, t_y) };
+                        Polygon s_right;
+                        s_right.points = { Point(inner_bbox.max.x(), b_y), Point(r_x, b_y), Point(r_x, t_y), Point(inner_bbox.max.x(), t_y) };
+                        raw_struts_n2.push_back(s_left);
+                        raw_struts_n2.push_back(s_right);
+
+                        Polygon s_bottom;
+                        s_bottom.points = { Point(l_x, b_y), Point(r_x, b_y), Point(r_x, inner_bbox.min.y()), Point(l_x, inner_bbox.min.y()) };
+                        Polygon s_top;
+                        s_top.points = { Point(l_x, inner_bbox.max.y()), Point(r_x, inner_bbox.max.y()), Point(r_x, t_y), Point(l_x, t_y) };
+                        raw_struts_n1.push_back(s_bottom);
+                        raw_struts_n1.push_back(s_top);
+                        
+                        Polygon s_left_n1;
+                        s_left_n1.points = { Point(inner_bbox.min.x() - strut_w, b_y), Point(inner_bbox.min.x(), b_y), Point(inner_bbox.min.x(), t_y), Point(inner_bbox.min.x() - strut_w, t_y) };
+                        Polygon s_right_n1;
+                        s_right_n1.points = { Point(inner_bbox.max.x(), b_y), Point(inner_bbox.max.x() + strut_w, b_y), Point(inner_bbox.max.x() + strut_w, t_y), Point(inner_bbox.max.x(), t_y) };
+                        raw_struts_n1.push_back(s_left_n1);
+                        raw_struts_n1.push_back(s_right_n1);
                     }
                 }
 
-                // ORCA: Intersect struts with the unsupported area to prevent them from shooting into mid-air
-                // on L-shaped or diagonal bridges, guaranteeing they find an anchor in the surrounding wall.
                 Polygons final_struts_n1 = intersection(raw_struts_n1, contour_bigger);
                 Polygons final_struts_n2 = intersection(raw_struts_n2, contour_bigger);
 
-                // ORCA: Subtract all holes of this unsupported area from the generated struts
-                // so we don't accidentally cover other holes in a multi-hole bridge.
-                // IMPORTANT: For large holes (!is_small_lip), we do NOT subtract the hole itself,
-                // because we WANT our narrow strut to pass perfectly straight THROUGH the hole space,
-                // without curving around its boundaries. (This prevents "curving in the air").
                 Polygons all_holes_small_lips;
                 for (const Polygon& hole : poly_unsupp.holes) {
-                    BoundingBox inner_bbox = get_extents(hole);
-                    coord_t dist_left   = inner_bbox.min.x() - bbox.min.x();
-                    coord_t dist_right  = bbox.max.x() - inner_bbox.max.x();
-                    coord_t dist_bottom = inner_bbox.min.y() - bbox.min.y();
-                    coord_t dist_top    = bbox.max.y() - inner_bbox.max.y();
-                    const coord_t max_lip = scale_(8.0);
-                    if (dist_left <= max_lip && dist_right <= max_lip && dist_bottom <= max_lip && dist_top <= max_lip) {
+                    BoundingBox h_bbox = get_extents(hole);
+                    coord_t d_l = h_bbox.min.x() - bbox.min.x();
+                    coord_t d_r = bbox.max.x() - h_bbox.max.x();
+                    coord_t d_b = h_bbox.min.y() - bbox.min.y();
+                    coord_t d_t = bbox.max.y() - h_bbox.max.y();
+                    if (d_l <= max_lip && d_r <= max_lip && d_b <= max_lip && d_t <= max_lip) {
                         all_holes_small_lips.push_back(hole);
                     }
                 }
 
-                // Normal subtraction for small lips where we fill the volume completely
                 if (!all_holes_small_lips.empty()) {
                     final_struts_n1 = diff(final_struts_n1, all_holes_small_lips);
                     final_struts_n2 = diff(final_struts_n2, all_holes_small_lips);
@@ -230,54 +201,41 @@ void TangentialHoleBridging::apply(PrintObject* object)
 
                 if (final_struts_n1.empty() && final_struts_n2.empty()) continue;
 
-                // Add to lslices (overall layer boundary)
                 layer_n2->lslices = union_ex(layer_n2->lslices, final_struts_n2);
                 layer_n1->lslices = union_ex(layer_n1->lslices, final_struts_n1);
                 
-                // --- INTEGRATE INTO LAYER N-1 ---
                 if (!layer_n1->regions().empty() && !final_struts_n1.empty()) {
-                    // Subtract struts from all OTHER regions to prevent multicolor overlap
                     for (size_t r = 0; r < layer_n1->regions().size(); ++r) {
                         if (r == region_id) continue;
                         LayerRegion* other_region = layer_n1->get_region(r);
                         if (!other_region || other_region->slices.empty()) continue;
-                        ExPolygons cut_polys = diff_ex(other_region->slices.surfaces, final_struts_n1);
-                        other_region->slices.set(cut_polys, stInternal);
+                        other_region->slices.set(diff_ex(other_region->slices.surfaces, final_struts_n1), stInternal);
                     }
-
-                    // Add struts specifically to the correct region
                     LayerRegion* target_region = layer_n1->get_region(region_id);
                     if (target_region) {
-                        Polygons polys_1 = to_polygons(target_region->slices.surfaces);
-                        for (const Polygon& p : final_struts_n1) polys_1.push_back(p);
-                        target_region->slices.set(union_ex(polys_1), stInternal);
+                        Polygons p1 = to_polygons(target_region->slices.surfaces);
+                        for (const Polygon& p : final_struts_n1) p1.push_back(p);
+                        target_region->slices.set(union_ex(p1), stInternal);
                     }
                 }
                 
-                // --- INTEGRATE INTO LAYER N-2 ---
                 if (!layer_n2->regions().empty() && !final_struts_n2.empty()) {
-                    // Subtract struts from all OTHER regions to prevent multicolor overlap
                     for (size_t r = 0; r < layer_n2->regions().size(); ++r) {
                         if (r == region_id) continue;
                         LayerRegion* other_region = layer_n2->get_region(r);
                         if (!other_region || other_region->slices.empty()) continue;
-                        ExPolygons cut_polys = diff_ex(other_region->slices.surfaces, final_struts_n2);
-                        other_region->slices.set(cut_polys, stInternal);
+                        other_region->slices.set(diff_ex(other_region->slices.surfaces, final_struts_n2), stInternal);
                     }
-
-                    // Add struts specifically to the correct region
                     LayerRegion* target_region = layer_n2->get_region(region_id);
                     if (target_region) {
-                        Polygons polys_2 = to_polygons(target_region->slices.surfaces);
-                        for (const Polygon& p : final_struts_n2) polys_2.push_back(p);
-                        target_region->slices.set(union_ex(polys_2), stInternal);
+                        Polygons p2 = to_polygons(target_region->slices.surfaces);
+                        for (const Polygon& p : final_struts_n2) p2.push_back(p);
+                        target_region->slices.set(union_ex(p2), stInternal);
                     }
                 }
             }
         }
     }
 }
-
-
 
 } // namespace Slic3r

--- a/src/libslic3r/TangentialHoleBridging.cpp
+++ b/src/libslic3r/TangentialHoleBridging.cpp
@@ -68,8 +68,9 @@ void TangentialHoleBridging::apply(PrintObject* object)
                     // ORCA: Check the distance from the hole to the bounding box of the unsupported area.
                     // If the distance is small (e.g. <= 8mm), it's a counterbore lip, so we fill the entire space
                     // to the contour to make a solid block (user preferred behavior).
-                    // If the distance is large (e.g. a huge bridge with a small hole), we limit the strut width
-                    // to 'strut_w' to avoid filling the entire bridge with massive blocks.
+                    // If the distance is large (e.g. a huge bridge with a small hole), we DO NOT generate struts
+                    // in layer N-1 and N-2 to avoid massive blocks spanning the whole bridge. We rely on apply_to_bridges
+                    // for that instead.
                     const coord_t max_lip = scale_(8.0);
                     
                     coord_t dist_left   = inner_bbox.min.x() - bbox.min.x();
@@ -77,10 +78,15 @@ void TangentialHoleBridging::apply(PrintObject* object)
                     coord_t dist_bottom = inner_bbox.min.y() - bbox.min.y();
                     coord_t dist_top    = bbox.max.y() - inner_bbox.max.y();
 
-                    coord_t left_x   = (dist_left <= max_lip)   ? (bbox.min.x() - margin) : (inner_bbox.min.x() - strut_w);
-                    coord_t right_x  = (dist_right <= max_lip)  ? (bbox.max.x() + margin) : (inner_bbox.max.x() + strut_w);
-                    coord_t bottom_y = (dist_bottom <= max_lip) ? (bbox.min.y() - margin) : (inner_bbox.min.y() - strut_w);
-                    coord_t top_y    = (dist_top <= max_lip)    ? (bbox.max.y() + margin) : (inner_bbox.max.y() + strut_w);
+                    // If it is NOT a small counterbore lip, SKIP generation on N-1 and N-2 layers!
+                    if (dist_left > max_lip || dist_right > max_lip || dist_bottom > max_lip || dist_top > max_lip) {
+                        continue;
+                    }
+
+                    coord_t left_x   = bbox.min.x() - margin;
+                    coord_t right_x  = bbox.max.x() + margin;
+                    coord_t bottom_y = bbox.min.y() - margin;
+                    coord_t top_y    = bbox.max.y() + margin;
 
                     // Strut Left (Y direction) - for N-2
                     Polygon strut_left;
@@ -182,6 +188,113 @@ void TangentialHoleBridging::apply(PrintObject* object)
                 }
             }
         }
+    }
+}
+
+void TangentialHoleBridging::apply_to_bridges(LayerRegion* region)
+{
+    if (region->region().config().counterbore_hole_bridging != chbTangential)
+        return;
+
+    Layer* layer_n1 = region->layer();
+    Layer* layer_n = layer_n1->upper_layer;
+    if (!layer_n) return;
+
+    // Identify overhangs on the UPPER layer (layer_n) over the current layer (layer_n1)
+    // Old code commented out
+    // LayerRegion* upper_region = layer_n->get_region(region->region().print_region_id());
+
+    // ORCA: use print_object_region_id instead of print_region_id to avoid out-of-bounds crash with multiple objects on the plate
+    LayerRegion* upper_region = layer_n->get_region(region->region().print_object_region_id());
+    if (!upper_region || upper_region->slices.empty()) return;
+
+    ExPolygons upper_slices = to_expolygons(upper_region->slices.surfaces);
+    ExPolygons overhangs = diff_ex(upper_slices, layer_n1->lslices, ApplySafetyOffset::Yes);
+    if (overhangs.empty()) return;
+
+    const double nozzle_diameter = layer_n1->object()->print()->config().nozzle_diameter.get_at(0);
+    const coord_t margin = scale_(nozzle_diameter * 2.0);
+
+    ExtrusionEntityCollection* bridge_island = new ExtrusionEntityCollection();
+
+    for (const ExPolygon& poly_unsupp : overhangs) {
+        if (poly_unsupp.holes.empty()) continue;
+
+        BoundingBox bbox = get_extents(poly_unsupp);
+        Polygons contour_bigger = offset(poly_unsupp.contour, margin);
+        Polygons anchors = intersection(contour_bigger, to_polygons(layer_n1->lslices));
+        if (anchors.empty()) continue;
+
+        for (const Polygon& hole : poly_unsupp.holes) {
+            BoundingBox inner_bbox = get_extents(hole);
+            
+            // Check if this is a small counterbore lip (which already gets filled by apply())
+            const coord_t max_lip = scale_(8.0);
+            coord_t dist_left   = inner_bbox.min.x() - bbox.min.x();
+            coord_t dist_right  = bbox.max.x() - inner_bbox.max.x();
+            coord_t dist_bottom = inner_bbox.min.y() - bbox.min.y();
+            coord_t dist_top    = bbox.max.y() - inner_bbox.max.y();
+            
+            // If ALL distances are small, it's a counterbore lip that already got a solid block in N-1/N-2 via apply.
+            if (dist_left <= max_lip && dist_right <= max_lip && dist_bottom <= max_lip && dist_top <= max_lip) {
+                continue; // Skip, apply() handled it
+            }
+
+            // Use the anchor bounding box to ensure lines span entirely across the available anchored space
+            BoundingBox full_bbox = get_extents(anchors);
+            full_bbox.merge(inner_bbox);
+
+            coord_t left_x = inner_bbox.min.x();
+            coord_t right_x = inner_bbox.max.x();
+            coord_t bottom_y = inner_bbox.min.y();
+            coord_t top_y = inner_bbox.max.y();
+
+            coord_t offset1 = scale_(nozzle_diameter) / 2.0;
+
+            Polylines lines;
+
+            // Generate two adjacent lines on each side to make the strut twice as wide
+            // Left side
+            lines.push_back({ Point(left_x + offset1, full_bbox.min.y() - margin), Point(left_x + offset1, full_bbox.max.y() + margin) });
+            lines.push_back({ Point(left_x - offset1, full_bbox.min.y() - margin), Point(left_x - offset1, full_bbox.max.y() + margin) });
+            
+            // Right side
+            lines.push_back({ Point(right_x - offset1, full_bbox.min.y() - margin), Point(right_x - offset1, full_bbox.max.y() + margin) });
+            lines.push_back({ Point(right_x + offset1, full_bbox.min.y() - margin), Point(right_x + offset1, full_bbox.max.y() + margin) });
+
+            // Bottom side
+            lines.push_back({ Point(full_bbox.min.x() - margin, bottom_y + offset1), Point(full_bbox.max.x() + margin, bottom_y + offset1) });
+            lines.push_back({ Point(full_bbox.min.x() - margin, bottom_y - offset1), Point(full_bbox.max.x() + margin, bottom_y - offset1) });
+
+            // Top side
+            lines.push_back({ Point(full_bbox.min.x() - margin, top_y - offset1), Point(full_bbox.max.x() + margin, top_y - offset1) });
+            lines.push_back({ Point(full_bbox.min.x() - margin, top_y + offset1), Point(full_bbox.max.x() + margin, top_y + offset1) });
+
+            // Trim lines to the solid anchors of the bridge PLUS the unsupported area
+            // We use the outer contour of the unsupported area, IGNORING its holes. 
+            // Otherwise, intersection_pl would cut out the strut where it crosses the hole!
+            Polygons unsupp_solid;
+            unsupp_solid.push_back(poly_unsupp.contour);
+            Polygons clipping_area = union_(unsupp_solid, anchors);
+
+            Polylines clipped_lines = intersection_pl(lines, clipping_area);
+
+            Flow flow = region->bridging_flow(frPerimeter);
+            for (const Polyline& pl : clipped_lines) {
+                // Ignore tiny segments
+                if (pl.length() < margin) continue;
+
+                ExtrusionPath path(erOverhangPerimeter, flow.mm3_per_mm(), flow.width(), layer_n1->height);
+                path.polyline = pl;
+                bridge_island->append(std::move(path));
+            }
+        }
+    }
+
+    if (!bridge_island->entities.empty()) {
+        region->perimeters.entities.push_back(bridge_island);
+    } else {
+        delete bridge_island;
     }
 }
 

--- a/src/libslic3r/TangentialHoleBridging.cpp
+++ b/src/libslic3r/TangentialHoleBridging.cpp
@@ -141,10 +141,7 @@ void TangentialHoleBridging::apply(PrintObject* object)
                         };
                         s_right.rotate(bridge_angle, center);
                         
-                        raw_struts_n2.push_back(s_left);
-                        raw_struts_n2.push_back(s_right);
-
-                        // Strut Bottom (horizontal in rotated space) -> Layer N-1
+                        // Strut Bottom (horizontal in rotated space) -> normally Layer N-1
                         Polygon s_bottom;
                         s_bottom.points = {
                             Point(r_left_x,  rot_inner_bbox.min.y() - strut_w),
@@ -154,7 +151,7 @@ void TangentialHoleBridging::apply(PrintObject* object)
                         };
                         s_bottom.rotate(bridge_angle, center);
 
-                        // Strut Top (horizontal in rotated space) -> Layer N-1
+                        // Strut Top (horizontal in rotated space) -> normally Layer N-1
                         Polygon s_top;
                         s_top.points = {
                             Point(r_left_x,  rot_inner_bbox.max.y()),
@@ -164,8 +161,30 @@ void TangentialHoleBridging::apply(PrintObject* object)
                         };
                         s_top.rotate(bridge_angle, center);
 
-                        raw_struts_n1.push_back(s_bottom);
-                        raw_struts_n1.push_back(s_top);
+                        Polygons s_A = {s_left, s_right};
+                        Polygons s_B = {s_bottom, s_top};
+
+                        Polygons anchors_n2 = to_polygons(layer_n2->lslices);
+                        double area_A = 0;
+                        for (const Polygon& p : intersection(s_A, anchors_n2)) {
+                            area_A += std::abs(p.area());
+                        }
+                        
+                        double area_B = 0;
+                        for (const Polygon& p : intersection(s_B, anchors_n2)) {
+                            area_B += std::abs(p.area());
+                        }
+
+                        // ORCA: If the default first layer (A) has significantly less anchoring 
+                        // than the second layer (B), swap them. This ensures the first printed 
+                        // struts are securely anchored to the walls (especially useful for custom modifiers).
+                        if (area_A < area_B * 0.5) {
+                            for (const Polygon& p : s_B) raw_struts_n2.push_back(p);
+                            for (const Polygon& p : s_A) raw_struts_n1.push_back(p);
+                        } else {
+                            for (const Polygon& p : s_A) raw_struts_n2.push_back(p);
+                            for (const Polygon& p : s_B) raw_struts_n1.push_back(p);
+                        }
                     } else {
                         // SMALL LIP: Original axis-aligned behavior for solid filling
                         coord_t l_x = bbox.min.x() - margin;

--- a/src/libslic3r/TangentialHoleBridging.hpp
+++ b/src/libslic3r/TangentialHoleBridging.hpp
@@ -1,0 +1,17 @@
+#ifndef slic3r_TangentialHoleBridging_hpp_
+#define slic3r_TangentialHoleBridging_hpp_
+
+namespace Slic3r {
+
+class PrintObject;
+
+class TangentialHoleBridging {
+public:
+    // ORCA: Main entry point to apply the tangential sacrificial bridging
+    // Generates crossed struts for counterbore holes.
+    static void apply(PrintObject* print_object);
+};
+
+} // namespace Slic3r
+
+#endif // slic3r_TangentialHoleBridging_hpp_

--- a/src/libslic3r/TangentialHoleBridging.hpp
+++ b/src/libslic3r/TangentialHoleBridging.hpp
@@ -12,11 +12,8 @@ public:
     // Generates crossed struts for counterbore holes.
     static void apply(PrintObject* print_object);
     
-    // ORCA: Generate tangential crossed struts for holes in bridge layers
-    // to support the perimeter of the hole from falling down.
-    static void apply_to_bridges(LayerRegion* region);
-};
 
+};
 
 } // namespace Slic3r
 

--- a/src/libslic3r/TangentialHoleBridging.hpp
+++ b/src/libslic3r/TangentialHoleBridging.hpp
@@ -4,13 +4,19 @@
 namespace Slic3r {
 
 class PrintObject;
+class LayerRegion;
 
 class TangentialHoleBridging {
 public:
     // ORCA: Main entry point to apply the tangential sacrificial bridging
     // Generates crossed struts for counterbore holes.
     static void apply(PrintObject* print_object);
+    
+    // ORCA: Generate tangential crossed struts for holes in bridge layers
+    // to support the perimeter of the hole from falling down.
+    static void apply_to_bridges(LayerRegion* region);
 };
+
 
 } // namespace Slic3r
 


### PR DESCRIPTION
# Description

This PR introduces a new feature: Tangential Sacrificial Bridging for counterbore holes.
inspired by:
https://www.baysingersadditivemanufacturing.com/design-floating-holes/

### Problem
When printing counterbore holes (or upside-down stepped holes) that start "in mid-air" (overhangs).

### Solution
This feature detects these specific "shelf overhangs" (where a hole narrows upwards) and generates a specialized support structure in the two layers below the overhang:
1.  **Layer N-2:** Tangential bars in one direction (e.g., Horizontal).
2.  **Layer N-1:** Tangential bars in the orthogonal direction (e.g., Vertical).

This creates a woven grid that:
- Is anchored firmly into the surrounding walls.
- Provides a perfect circular foundation for the overhang to be printed on.


### Technical Implementation
- **Logic:** `TangentialHoleBridging.cpp` calculates the tangent lines based on the inner hole diameter.



Feel free to test.

# Screenshots:
<img width="427" height="64" alt="grafik" src="https://github.com/user-attachments/assets/4e2fefa5-a080-4911-a82e-def209367b7b" />


![20260122_125606](https://github.com/user-attachments/assets/656b3246-0e08-4c61-b04c-c64f7924a0ce)

Bottom View:
<img width="824" height="203" alt="Screenshot 2026-01-29 172730" src="https://github.com/user-attachments/assets/8be16915-6513-42c5-936e-d0a4d95a13ff" />

Top view:
![cbh](https://github.com/user-attachments/assets/d9a39672-e9c2-40d0-9339-3fc5eaabcead)


