### PR TITLE
feat: show sequential print order in object list (front-to-back)

### DIFF
--- a/src/slic3r/GUI/GUI_ObjectList.cpp
+++ b/src/slic3r/GUI/GUI_ObjectList.cpp
@@ -874,6 +874,11 @@ void ObjectList::update_name_for_items()
     wxGetApp().plater()->update();
 }
 
+void ObjectList::update_sequential_print_order()
+{
+    m_objects_model->UpdateSequentialPrintOrder();
+}
+
 void ObjectList::object_config_options_changed(const ObjectVolumeID& ov_id)
 {
     if (ov_id.object == nullptr)
@@ -3997,6 +4002,9 @@ void ObjectList::add_object_to_list(size_t obj_idx, bool call_selection_changed,
         selection_changed();
     }
 #endif //__WXMSW__
+
+    // Update sequential print order for all objects after adding a new one
+    m_objects_model->UpdateSequentialPrintOrder();
 }
 
 static bool can_add_volumes_to_object(const ModelObject *object)

--- a/src/slic3r/GUI/GUI_ObjectList.hpp
+++ b/src/slic3r/GUI/GUI_ObjectList.hpp
@@ -244,6 +244,7 @@ public:
     //BBS: update plate
     void                update_plate_values_for_items();
     void                update_name_for_items();
+    void                update_sequential_print_order();
 
     // Get obj_idx and vol_idx values for the selected (by default) or an adjusted item
     void                get_selected_item_indexes(int& obj_idx, int& vol_idx, const wxDataViewItem& item = wxDataViewItem(0));

--- a/src/slic3r/GUI/ObjectDataViewModel.hpp
+++ b/src/slic3r/GUI/ObjectDataViewModel.hpp
@@ -86,6 +86,7 @@ class ObjectDataViewModelNode
     t_layer_height_range            m_layer_range = { 0.0f, 0.0f };
 
     wxString				        m_name;
+    wxString                        m_seq_prefix;  // Sequential print order prefix, e.g. "[1] "
     wxBitmap&                       m_bmp = m_empty_bmp;
     ItemType				        m_type;
     int                             m_idx = -1;
@@ -235,6 +236,8 @@ public:
         return m_children.GetCount();
     }
     void            SetName(const wxString &);
+    void            SetSeqPrefix(const wxString& prefix) { m_seq_prefix = prefix; }
+    const wxString& GetSeqPrefix() const { return m_seq_prefix; }
     bool            SetValue(const wxVariant &variant, unsigned int col);
     void            SetVolumeType(ModelVolumeType type) { m_volume_type = type; }
     void            SetBitmap(const wxBitmap &icon) { m_bmp = icon; }
@@ -531,6 +534,7 @@ public:
 
     // BBS
     void        UpdateItemNames();
+    void        UpdateSequentialPrintOrder();
 
     void        assembly_name(ObjectDataViewModelNode* item, wxString name);
     void        assembly_name();

--- a/src/slic3r/GUI/PartPlate.cpp
+++ b/src/slic3r/GUI/PartPlate.cpp
@@ -5895,8 +5895,24 @@ int PartPlateList::rebuild_plates_after_arrangement(bool recycle_plates, bool ex
 
 	BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << boost::format(":before rebuild, plates count %1%, recycle_plates %2%") % m_plate_list.size() % recycle_plates;
 
-	// sort by arrange_order
-	std::sort(m_model->objects.begin(), m_model->objects.end(), [](auto a, auto b) {return a->instances[0]->arrange_order < b->instances[0]->arrange_order; });
+	// For sequential printing, sort by Y position (front-to-back) so print order
+	// matches spatial layout and avoids fan collisions with printed objects.
+	// Otherwise sort by arrange_order from the placement algorithm.
+	PartPlate* curr_plate = get_curr_plate();
+	bool is_sequential = curr_plate &&
+		(curr_plate->get_real_print_seq() == PrintSequence::ByObject);
+
+	if (is_sequential) {
+		std::sort(m_model->objects.begin(), m_model->objects.end(),
+			[](auto a, auto b) {
+				return a->instances[0]->get_offset(Y) < b->instances[0]->get_offset(Y);
+			});
+	} else {
+		std::sort(m_model->objects.begin(), m_model->objects.end(),
+			[](auto a, auto b) {
+				return a->instances[0]->arrange_order < b->instances[0]->arrange_order;
+			});
+	}
 	//for (auto object : m_model->objects)
 	//	std::sort(object->instances.begin(), object->instances.end(), [](auto a, auto b) {return a->arrange_order < b->arrange_order; });
 

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -7619,6 +7619,9 @@ unsigned int Plater::priv::update_background_process(bool force_validation, bool
         return_state |= UPDATE_BACKGROUND_PROCESS_INVALID;
     }
 
+    // Update sequential print order display in object list after validation
+    sidebar->obj_list()->update_sequential_print_order();
+
     //actualizate warnings
     if (invalidated != Print::APPLY_STATUS_UNCHANGED || background_process.empty()) {
         if (background_process.empty())


### PR DESCRIPTION
## Summary
- Display [1] [2] [3] sequence number prefixes on object names in the sidebar when sequential printing (By Object) is enabled
- Sort objects by Y position (lowest Y = front of bed = printed first) to indicate fan-safe print order
- Fix auto-arrange to order print sequence front-to-back in sequential mode

## Motivation
Printers with rear-mounted part cooling fans (e.g., Neptune 4 Max) need objects to print front-to-back to avoid the fan hitting previously printed parts. This feature makes the print order visible before slicing and ensures auto-arrange respects this ordering.

## Changes
- **ObjectDataViewModel.hpp/cpp**: Added display-only prefix (m_seq_prefix) to object list items, with Y-position sorting
- **GUI_ObjectList.hpp/cpp**: Added update_sequential_print_order() for triggering refreshes
- **Plater.cpp**: Triggers order update after background validation
- **PartPlate.cpp**: Sort model objects by Y position after auto-arrange in sequential mode

## Test plan
- [ ] Enable By Object print sequence, add 3+ objects at different Y positions
- [ ] Verify [1] [2] [3] appear in sidebar ordered front-to-back
- [ ] Click Auto-arrange, verify order matches spatial layout
- [ ] Move objects, verify numbers update
- [ ] Switch to By Layer mode, verify prefixes disappear