### PR TITLE
Enhancement: Enabling base patterns (infill) for Organic supports

### DIFF
--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -5775,7 +5775,12 @@ void PrintConfigDef::init_fff_params()
     def = this->add("support_base_pattern", coEnum);
     def->label = L("Base pattern");
     def->category = L("Support");
-    def->tooltip = L("Line pattern of support.");
+    def->tooltip = L("Line pattern of support.\n\n"
+                     "The Default option for Tree supports is Hollow, which means no base pattern. "
+                     "For other support types, the Default option is the Rectilinear pattern.\n\n"
+                     "NOTE: For Organic supports, the two walls are supported only with the Hollow/Default base pattern. "
+                     "The Lightning base pattern is supported only by Tree Slim/Strong/Hybrid supports. "
+                     "For the other support types, the Rectilinear will be used instead of Lightning.");
     def->enum_keys_map = &ConfigOptionEnum<SupportMaterialPattern>::get_enum_values();
     def->enum_values.push_back("default");
     def->enum_values.push_back("rectilinear");

--- a/src/libslic3r/Support/SupportCommon.cpp
+++ b/src/libslic3r/Support/SupportCommon.cpp
@@ -1745,8 +1745,10 @@ void generate_support_toolpaths(
                     filler->link_max_length = coord_t(scale_(filler->spacing * link_max_length_factor / density));
                     sheath  = true;
                     no_sort = true;
-                } else if (support_params.support_style == SupportMaterialStyle::smsTreeOrganic) {
-                    // if the tree supports are too tall, use double wall to make it stronger
+                } else if (support_params.support_style == SupportMaterialStyle::smsTreeOrganic &&
+                           (config.support_base_pattern == smpNone || config.support_base_pattern == smpDefault)) {
+                    // Orca: A special case for the hollow Organic supports
+                    // Orca: If the tree supports are too tall, use a double wall to make it stronger
                     SupportParameters support_params2 = support_params;
                     if (support_layer.print_z > 100.0)
                         support_params2.tree_branch_diameter_double_wall_area_scaled = 0.1;

--- a/src/libslic3r/Support/TreeSupport3D.cpp
+++ b/src/libslic3r/Support/TreeSupport3D.cpp
@@ -3549,7 +3549,6 @@ static void generate_support_areas(Print &print, TreeSupport* tree_support, cons
             if (layer) layer->polygons = intersection(layer->polygons, volumes.m_bed_area);
         });
 
-        // Don't fill in the tree supports, make them hollow with just a single sheath line.
         print.set_status(69, _L("Generating support"));
         generate_support_toolpaths(print_object.support_layers(), print_object.config(), support_params, print_object.slicing_parameters(),
             raft_layers, bottom_contacts, top_contacts, intermediate_layers, interface_layers, base_interface_layers);


### PR DESCRIPTION
# Description

Workaround for #11362, #9330, and other similar issues that appear from time to time.

In short, Orcanic supports can be generated in the air.

This problem drives me crazy because it makes miniature printing difficult.

This issue exists in BBS and Prusa Slicer as well. It's really hard to fix because the code is too messy and hard to read and understand. Too many hacks, code duplication, a lot of solutions mixed, etc. So, this PR introduces a workaround to enable the base patterns (infill) for Organic supports.

Organic Tree supports were intentionally implemented as hollow, and I don't understand why. Three out of four infills work very well for Organic (according to my tests).

This PR is small and does not introduce any big changes.

**Known issues:**

- Lightning infill is not supported - some code is missing, and it's crashing if I try to enable it.
- Double walls are supported only for the hollow type. If the base pattern is not hollow, only one wall will be used.

Both of these issues require significant code changes, which I don't want to make (it's a trap).

Instead, I described them as limitations via tooltips and/or warning messages.

I'd appreciate it if you could share your opinions and thoughts.

**Now problematic supports can have at least something under them. It will save so much time and stress for many people.**

![support_infill_enc](https://github.com/user-attachments/assets/69971b42-d41c-4e10-864c-2e8cdf592d82)

# Screenshots

### Hollow (same as Default)

<img width="1230" height="514" alt="image" src="https://github.com/user-attachments/assets/e177ca61-e4be-4059-9531-9720bb00fc39" />

### Rectilinear

<img width="1223" height="545" alt="image" src="https://github.com/user-attachments/assets/9b7ec72c-f8b2-4cee-96d5-e60e62cf3ff2" />

### Rectilinear Grid

<img width="1255" height="571" alt="image" src="https://github.com/user-attachments/assets/b55daf05-6b83-43bc-9ad1-d0248b4060ac" />

### Honeycomb

<img width="1236" height="566" alt="image" src="https://github.com/user-attachments/assets/54aa398f-113e-4e6b-afd9-2db9278b693e" />

### Instead of Lightning (Rectilinear is being used)

<img width="1231" height="558" alt="image" src="https://github.com/user-attachments/assets/0bbae46c-d98d-473e-8cc6-214d39dfa30b" />

### Warnings and tooltips

<img width="587" height="165" alt="image" src="https://github.com/user-attachments/assets/1dce84b7-4422-462f-acc5-b558b739bb27" />

<img width="616" height="190" alt="image" src="https://github.com/user-attachments/assets/921d7a0e-be12-4fea-9f0b-83f571ec2525" />

<img width="791" height="545" alt="image" src="https://github.com/user-attachments/assets/6cdb9900-700c-41fb-a2db-05ba56a4a35b" />