### PR TITLE
Fix printer selection cursor on Mac

### DIFF
--- a/resources/web/guide/css/common.css
+++ b/resources/web/guide/css/common.css
@@ -5,6 +5,7 @@
 	margin: 0;		
     font-family: "system-ui", "Segoe UI", Roboto, Oxygen, Ubuntu, "Fira Sans", "Droid Sans", "Helvetica Neue", sans-sans;
 	user-select: none;
+	-webkit-user-select: none;
 }
 
 html


### PR DESCRIPTION
# Description

Continuation of https://github.com/OrcaSlicer/OrcaSlicer/pull/12172 fixing pointer displayed as cursor for remaining web dialogs in macOS.