### PR TITLE
Fix: tool position window glitch on Linux

### DIFF
--- a/src/slic3r/GUI/GCodeViewer.cpp
+++ b/src/slic3r/GUI/GCodeViewer.cpp
@@ -600,6 +600,7 @@ void GCodeViewer::SequentialView::Marker::render_position_window(const libvgcode
                 case libvgcode::EViewType::ActualVolumetricFlowRate: {
                     // Don't display the actual flow, since it only gives data for the end of a segment
                     // sprintf(buf, "%s %s%.2f", buf, _u8L("Actual Flow: ").c_str(), vertex.actual_volumetric_rate());
+                    sprintf(buf, "%s %s", buf, " ");
                     break;
                 }
                 case libvgcode::EViewType::ActualSpeed: {


### PR DESCRIPTION
<img width="359" height="77" alt="Screenshot-20260207025203" src="https://github.com/user-attachments/assets/289a6986-dbd7-48e1-9f22-2999897caa02" />

Probably issue caused by empty buffer and somehow linux preferred to fill with random characters
this only happens on Actual Flow see https://github.com/OrcaSlicer/OrcaSlicer/pull/12068#issuecomment-3856678794

Fix confirmed in here https://github.com/OrcaSlicer/OrcaSlicer/pull/12068#issuecomment-3868013765
