### PR TITLE
Feature: Add support for mold (arg) and ccache (default)

### DIFF
--- a/build_linux.sh
+++ b/build_linux.sh
@@ -25,6 +25,7 @@ function usage() {
     echo "   -u: install system dependencies (asks for sudo password; build prerequisite)"
     echo "   -l: use Clang instead of GCC (default: GCC)"
     echo "   -L: use ld.lld as linker (if available)"
+    echo "   -m: use mold as linker (if available)"
     echo "For a first use, you want to './${SCRIPT_NAME} -u'"
     echo "   and then './${SCRIPT_NAME} -dsi'"
 }
@@ -34,7 +35,7 @@ SLIC3R_PRECOMPILED_HEADERS="ON"
 unset name
 BUILD_DIR=build
 BUILD_CONFIG=Release
-while getopts ":1j:bcCdDehiprstulL" opt ; do
+while getopts ":1j:bcCdDehiprstulLm" opt ; do
   case ${opt} in
     1 )
         export CMAKE_BUILD_PARALLEL_LEVEL=1
@@ -88,6 +89,9 @@ while getopts ":1j:bcCdDehiprstulL" opt ; do
         ;;
     L )
         USE_LLD="1"
+        ;;
+    m )
+        USE_MOLD="1"
         ;;
     * )
 	echo "Unknown argument '${opt}', aborting."
@@ -199,6 +203,22 @@ if [[ -n "${USE_LLD}" ]] ; then
     fi
 fi
 
+if [[ -n "${USE_MOLD}" ]] ; then
+    if command -v mold >/dev/null 2>&1 ; then
+        MOLD_BIN=$(command -v mold)
+        export CMAKE_LLD_LINKER_ARGS=(-DCMAKE_LINKER="${MOLD_BIN}" -DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=mold -DCMAKE_SHARED_LINKER_FLAGS=-fuse-ld=mold -DCMAKE_MODULE_LINKER_FLAGS=-fuse-ld=mold)
+    else
+        echo "Error: mold not found. Please install the 'mold' package (e.g., sudo apt install mold) or omit -m."
+        exit 1
+    fi
+fi
+
+export CMAKE_CACHE_ARGS=()
+if command -v ccache >/dev/null 2>&1 ; then
+        CMAKE_CACHE=$(command -v ccache)
+        export CMAKE_CACHE_ARGS=(-DCMAKE_CXX_COMPILER_LAUNCHER="${CMAKE_CACHE}")
+fi
+
 if [[ -n "${BUILD_DEPS}" ]] ; then
     echo "Configuring dependencies..."
     read -r -a BUILD_ARGS <<< "${DEPS_EXTRA_BUILD_ARGS}"
@@ -211,7 +231,7 @@ if [[ -n "${BUILD_DEPS}" ]] ; then
         BUILD_ARGS+=(-DCMAKE_BUILD_TYPE="${BUILD_CONFIG}")
     fi
 
-    print_and_run cmake -S deps -B deps/$BUILD_DIR "${CMAKE_C_CXX_COMPILER_CLANG[@]}" "${CMAKE_LLD_LINKER_ARGS[@]}" -G Ninja "${COLORED_OUTPUT}" "${BUILD_ARGS[@]}"
+    print_and_run cmake -S deps -B deps/$BUILD_DIR "${CMAKE_C_CXX_COMPILER_CLANG[@]}" "${CMAKE_LLD_LINKER_ARGS[@]}" "${CMAKE_CACHE_ARGS[@]}" -G Ninja "${COLORED_OUTPUT}" "${BUILD_ARGS[@]}"
     print_and_run cmake --build deps/$BUILD_DIR
 fi
 
@@ -231,7 +251,7 @@ if [[ -n "${BUILD_ORCA}" ]] || [[ -n "${BUILD_TESTS}" ]] ; then
         BUILD_ARGS+=(-DORCA_UPDATER_SIG_KEY="${ORCA_UPDATER_SIG_KEY}")
     fi
 
-    print_and_run cmake -S . -B $BUILD_DIR "${CMAKE_C_CXX_COMPILER_CLANG[@]}" "${CMAKE_LLD_LINKER_ARGS[@]}" -G "Ninja Multi-Config" \
+    print_and_run cmake -S . -B $BUILD_DIR "${CMAKE_C_CXX_COMPILER_CLANG[@]}" "${CMAKE_LLD_LINKER_ARGS[@]}" "${CMAKE_CACHE_ARGS[@]}" -G "Ninja Multi-Config" \
 -DSLIC3R_PCH=${SLIC3R_PRECOMPILED_HEADERS} \
 -DORCA_TOOLS=ON \
 "${COLORED_OUTPUT}" \


### PR DESCRIPTION
# Description

Adds support for mold linker (using the `-m` flag).
Adds support for ccache by default (looks for ccache path and adds it as an argument to the deps and slicer build).

# Screenshots/Recordings/Graphs

no ui changes

Does not modify builds. Mold is technically slightly faster, by may only save seconds as it is a linker. The use of ccache allows for much faster "recompilations" where ninja may want to recompile the project (due to makefile changes or etc.) but the actual project files have not changed much.