### PR TITLE
Temp Tower Nozzle based adjustment

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -4478,22 +4478,37 @@ LayerResult GCode::process_layer(
             break;
         }
         case CalibMode::Calib_Temp_Tower: {
-            constexpr double base_temp_tower_nozzle_diameter = 0.4;
-            constexpr double base_temp_tower_step_height = 10.001;
-            constexpr int base_temp_tower_temp_step = 5;
-
-            double nozzle_diameter = base_temp_tower_nozzle_diameter;
-            if (writer().filament() && !m_config.nozzle_diameter.values.empty()) {
-                const size_t nozzle_id = std::min<size_t>(writer().filament()->extruder_id(), m_config.nozzle_diameter.values.size() - 1);
-                nozzle_diameter = m_config.nozzle_diameter.values[nozzle_id];
+            // Adapt the temperature steps to current tower height (including any additional resize):
+            // split the full height into equal segments, one for each 5C step.
+            coordf_t max_print_z = 0.0;
+            for (ObjectID print_object_id : print.print_object_ids()) {
+                const PrintObject* print_object = print.get_object(print_object_id);
+                if (print_object != nullptr && !print_object->layers().empty())
+                    max_print_z = std::max(max_print_z, print_object->layers().back()->print_z);
             }
-            if (nozzle_diameter <= 0.0)
-                nozzle_diameter = base_temp_tower_nozzle_diameter;
 
-            const double nozzle_scale = nozzle_diameter / base_temp_tower_nozzle_diameter;
-            const double step_height = base_temp_tower_step_height * nozzle_scale;
-            auto offset = static_cast<unsigned int>(print_z / step_height) * base_temp_tower_temp_step;
-            gcode += writer().set_temperature(print.calib_params().start - offset);
+            const double start_temp = print.calib_params().start;
+            const double end_temp = print.calib_params().end;
+            constexpr int temp_step_celsius = 5;
+            const int temp_low = static_cast<int>(std::floor(std::min(start_temp, end_temp)));
+            const int temp_high = static_cast<int>(std::ceil(std::max(start_temp, end_temp)));
+
+            const int start_temp_int = static_cast<int>(std::lround(start_temp));
+            const int end_temp_int = static_cast<int>(std::lround(end_temp));
+            const int direction = (end_temp_int >= start_temp_int) ? 1 : -1;
+            const unsigned int total_temp_steps = static_cast<unsigned int>(std::max(1, std::abs(end_temp_int - start_temp_int) / temp_step_celsius));
+            const unsigned int total_temp_levels = total_temp_steps + 1;
+
+            const double step_height = max_print_z > EPSILON ? (static_cast<double>(max_print_z) / static_cast<double>(total_temp_levels)) : 1.0;
+            const unsigned int level_index = std::min(total_temp_steps, static_cast<unsigned int>(std::floor(print_z / step_height)));
+
+            int target_temp = start_temp_int + direction * static_cast<int>(level_index * temp_step_celsius);
+            if (level_index >= total_temp_steps)
+                target_temp = end_temp_int;
+
+            const int bounded_temp = std::clamp(target_temp, temp_low, temp_high);
+
+            gcode += writer().set_temperature(bounded_temp);
             break;
         }
         case CalibMode::Calib_VFA_Tower: {

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -4495,14 +4495,13 @@ LayerResult GCode::process_layer(
 
             const int start_temp_int = static_cast<int>(std::lround(start_temp));
             const int end_temp_int = static_cast<int>(std::lround(end_temp));
-            const int direction = (end_temp_int >= start_temp_int) ? 1 : -1;
             const unsigned int total_temp_steps = static_cast<unsigned int>(std::max(1, std::abs(end_temp_int - start_temp_int) / temp_step_celsius));
             const unsigned int total_temp_levels = total_temp_steps + 1;
 
             const double step_height = max_print_z > EPSILON ? (static_cast<double>(max_print_z) / static_cast<double>(total_temp_levels)) : 1.0;
             const unsigned int level_index = std::min(total_temp_steps, static_cast<unsigned int>(std::floor(print_z / step_height)));
 
-            int target_temp = start_temp_int + direction * static_cast<int>(level_index * temp_step_celsius);
+            int target_temp = start_temp_int - static_cast<int>(level_index * temp_step_celsius);
             if (level_index >= total_temp_steps)
                 target_temp = end_temp_int;
 

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -7020,7 +7020,8 @@ std::string GCode::extrusion_role_to_string_for_parser(const ExtrusionRole & rol
 }
 
 // Calculate the interpolated value for the current layer between start_value and end_value.
-// Step rounding value to make changes visible by generating layer groups with a value until the range is exceeded and it moves on to the next one.
+// Step will create equal layers steps from first to last value.
+// Step = 0 means gradual interpolation finishing at last value.
 float GCode::interpolate_value_across_layers(float start_value, float end_value, float step) const
 {
     if (m_layer_index <= 1) {

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -4478,36 +4478,7 @@ LayerResult GCode::process_layer(
             break;
         }
         case CalibMode::Calib_Temp_Tower: {
-            // Adapt the temperature steps to current tower height (including any additional resize):
-            // split the full height into equal segments, one for each 5C step.
-            coordf_t max_print_z = 0.0;
-            for (ObjectID print_object_id : print.print_object_ids()) {
-                const PrintObject* print_object = print.get_object(print_object_id);
-                if (print_object != nullptr && !print_object->layers().empty())
-                    max_print_z = std::max(max_print_z, print_object->layers().back()->print_z);
-            }
-
-            const double start_temp = print.calib_params().start;
-            const double end_temp = print.calib_params().end;
-            constexpr int temp_step_celsius = 5;
-            const int temp_low = static_cast<int>(std::floor(std::min(start_temp, end_temp)));
-            const int temp_high = static_cast<int>(std::ceil(std::max(start_temp, end_temp)));
-
-            const int start_temp_int = static_cast<int>(std::lround(start_temp));
-            const int end_temp_int = static_cast<int>(std::lround(end_temp));
-            const unsigned int total_temp_steps = static_cast<unsigned int>(std::max(1, std::abs(end_temp_int - start_temp_int) / temp_step_celsius));
-            const unsigned int total_temp_levels = total_temp_steps + 1;
-
-            const double step_height = max_print_z > EPSILON ? (static_cast<double>(max_print_z) / static_cast<double>(total_temp_levels)) : 1.0;
-            const unsigned int level_index = std::min(total_temp_steps, static_cast<unsigned int>(std::floor(print_z / step_height)));
-
-            int target_temp = start_temp_int - static_cast<int>(level_index * temp_step_celsius);
-            if (level_index >= total_temp_steps)
-                target_temp = end_temp_int;
-
-            const int bounded_temp = std::clamp(target_temp, temp_low, temp_high);
-
-            gcode += writer().set_temperature(bounded_temp);
+            gcode += writer().set_temperature(this->interpolate_value_across_layers(static_cast<float>(print.calib_params().start), static_cast<float>(print.calib_params().end), 5.0f));
             break;
         }
         case CalibMode::Calib_VFA_Tower: {
@@ -7048,14 +7019,28 @@ std::string GCode::extrusion_role_to_string_for_parser(const ExtrusionRole & rol
     }
 }
 
-// Calculate the interpolated value for the current layer between start_value and end_value
-float GCode::interpolate_value_across_layers(float start_value, float end_value) const {
-    if (m_layer_index == 1) {
+// Calculate the interpolated value for the current layer between start_value and end_value.
+// Step rounding value to make changes visible by generating layer groups with a value until the range is exceeded and it moves on to the next one.
+float GCode::interpolate_value_across_layers(float start_value, float end_value, float step) const
+{
+    if (m_layer_index <= 1) {
         return start_value;
-    } else {
-        float ratio = (m_layer_index - 2.0f) / (m_layer_count - 3.0f);
-        ratio = std::max(0.0f, std::min(1.0f, ratio)); // clamp
-        return start_value + ratio * (end_value - start_value);
+    }
+    else {
+        bool use_steps = step > 0;
+        if (use_steps) {
+            if (start_value > end_value) {
+                start_value += step;
+            } else {
+                end_value += step;
+            }
+        }
+        float ratio = (m_layer_index + 1.0f) / m_layer_count;
+        float value = start_value + ratio * (end_value - start_value);
+        if (use_steps) {
+            value = trunc(value / step) * step;
+        }
+        return value;
     }
 }
 

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -7027,7 +7027,7 @@ float GCode::interpolate_value_across_layers(float start_value, float end_value,
         return start_value;
     }
     else {
-        bool use_steps = step > 0;
+        bool use_steps = step > 0.f;
         if (use_steps) {
             if (start_value > end_value) {
                 start_value += step;
@@ -7035,7 +7035,7 @@ float GCode::interpolate_value_across_layers(float start_value, float end_value,
                 end_value += step;
             }
         }
-        float ratio = (m_layer_index + 1.0f) / m_layer_count;
+        float ratio = m_layer_index / (m_layer_count - 1.f);
         float value = start_value + ratio * (end_value - start_value);
         if (use_steps) {
             value = trunc(value / step) * step;

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -4478,7 +4478,21 @@ LayerResult GCode::process_layer(
             break;
         }
         case CalibMode::Calib_Temp_Tower: {
-            auto offset = static_cast<unsigned int>(print_z / 10.001) * 5;
+            constexpr double base_temp_tower_nozzle_diameter = 0.4;
+            constexpr double base_temp_tower_step_height = 10.001;
+            constexpr int base_temp_tower_temp_step = 5;
+
+            double nozzle_diameter = base_temp_tower_nozzle_diameter;
+            if (writer().filament() && !m_config.nozzle_diameter.values.empty()) {
+                const size_t nozzle_id = std::min<size_t>(writer().filament()->extruder_id(), m_config.nozzle_diameter.values.size() - 1);
+                nozzle_diameter = m_config.nozzle_diameter.values[nozzle_id];
+            }
+            if (nozzle_diameter <= 0.0)
+                nozzle_diameter = base_temp_tower_nozzle_diameter;
+
+            const double nozzle_scale = nozzle_diameter / base_temp_tower_nozzle_diameter;
+            const double step_height = base_temp_tower_step_height * nozzle_scale;
+            auto offset = static_cast<unsigned int>(print_z / step_height) * base_temp_tower_temp_step;
             gcode += writer().set_temperature(print.calib_params().start - offset);
             break;
         }

--- a/src/libslic3r/GCode.hpp
+++ b/src/libslic3r/GCode.hpp
@@ -237,8 +237,9 @@ public:
     bool            enable_cooling_markers() const { return m_enable_cooling_markers; }
     std::string     extrusion_role_to_string_for_parser(const ExtrusionRole &);
 
-    // Calculate the interpolated value for the current layer between start_value and end_value
-    float interpolate_value_across_layers(float start_value, float end_value) const;
+    // Calculate the interpolated value for the current layer between start_value and end_value.
+    // Step rounding value to make changes visible by generating layer groups with a value until the range is exceeded and it moves on to the next one.
+    float interpolate_value_across_layers(float start_value, float end_value, float step = 0.0f) const;
 
     // For Perl bindings, to be used exclusively by unit tests.
     unsigned int    layer_count() const { return m_layer_count; }

--- a/src/libslic3r/GCode.hpp
+++ b/src/libslic3r/GCode.hpp
@@ -238,7 +238,8 @@ public:
     std::string     extrusion_role_to_string_for_parser(const ExtrusionRole &);
 
     // Calculate the interpolated value for the current layer between start_value and end_value.
-    // Step rounding value to make changes visible by generating layer groups with a value until the range is exceeded and it moves on to the next one.
+    // Step will create equal layers steps from first to last value.
+    // Step = 0 means gradual interpolation finishing at last value.
     float interpolate_value_across_layers(float start_value, float end_value, float step = 0.0f) const;
 
     // For Perl bindings, to be used exclusively by unit tests.

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -12946,15 +12946,19 @@ void Plater::calib_temp(const Calib_Params& params) {
     printer_config->set_key_value("resonance_avoidance", new ConfigOptionBool{false});
     filament_config->set_key_value("nozzle_temperature_initial_layer", new ConfigOptionInts(1,(int)start_temp));
     filament_config->set_key_value("nozzle_temperature", new ConfigOptionInts(1,(int)start_temp));
+    model().objects[0]->config.set_key_value("layer_height", new ConfigOptionFloat(nozzle_diameter/2));
     model().objects[0]->config.set_key_value("brim_type", new ConfigOptionEnum<BrimType>(btOuterOnly));
     model().objects[0]->config.set_key_value("brim_width", new ConfigOptionFloat(5.0));
     model().objects[0]->config.set_key_value("brim_object_gap", new ConfigOptionFloat(0.0));
     model().objects[0]->config.set_key_value("alternate_extra_wall", new ConfigOptionBool(false));
     model().objects[0]->config.set_key_value("seam_slope_type", new ConfigOptionEnum<SeamScarfType>(SeamScarfType::None));
     model().objects[0]->config.set_key_value("overhang_reverse", new ConfigOptionBool(false));
+    model().objects[0]->config.set_key_value("precise_z_height", new ConfigOptionBool(false));
 
     auto print_config = &wxGetApp().preset_bundle->prints.get_edited_preset().config;
     print_config->set_key_value("enable_wrapping_detection", new ConfigOptionBool(false));
+    print_config->set_key_value("initial_layer_print_height", new ConfigOptionFloat(nozzle_diameter/2));
+
 
     changed_objects({ 0 });
     wxGetApp().get_tab(Preset::TYPE_PRINT)->update_dirty();

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -12915,10 +12915,33 @@ void Plater::calib_temp(const Calib_Params& params) {
         nozzle_diameter = base_temp_tower_nozzle_diameter;
 
     const double nozzle_scale = nozzle_diameter / base_temp_tower_nozzle_diameter;
-    const double block_height = base_temp_tower_block_height * nozzle_scale;
+    const double block_height = base_temp_tower_block_height;
+
+    // cut upper
+    auto obj_bb = model().objects[0]->bounding_box_exact();
+    auto block_count = lround((500 - params.end) / base_temp_tower_temp_step + 1);
+    if (block_count > 0) {
+        // subtract EPSILON offset to avoid cutting at the exact location where the flat surface is
+        auto new_height = block_count * block_height - EPSILON;
+        if (new_height < obj_bb.size().z()) {
+            cut_horizontal(0, 0, new_height, ModelObjectCutAttribute::KeepLower);
+        }
+    }
+
+    // cut bottom
+    obj_bb = model().objects[0]->bounding_box_exact();
+    block_count = lround((500 - params.start) / base_temp_tower_temp_step);
+    if (block_count > 0) {
+        auto new_height = block_count * block_height + EPSILON;
+        if (new_height < obj_bb.size().z()) {
+            cut_horizontal(0, 0, new_height, ModelObjectCutAttribute::KeepUpper);
+        }
+    }
 
     if (std::abs(nozzle_scale - 1.0) > EPSILON)
         model().objects[0]->scale(nozzle_scale, nozzle_scale, nozzle_scale);
+
+    model().objects[0]->ensure_on_bed();
 
     printer_config->set_key_value("resonance_avoidance", new ConfigOptionBool{false});
     filament_config->set_key_value("nozzle_temperature_initial_layer", new ConfigOptionInts(1,(int)start_temp));
@@ -12939,27 +12962,6 @@ void Plater::calib_temp(const Calib_Params& params) {
     wxGetApp().get_tab(Preset::TYPE_PRINT)->reload_config();
     wxGetApp().get_tab(Preset::TYPE_FILAMENT)->reload_config();
 
-    // cut upper
-    auto obj_bb = model().objects[0]->bounding_box_exact();
-    auto block_count = lround((500 - params.end) / base_temp_tower_temp_step + 1);
-    if(block_count > 0){
-        // subtract EPSILON offset to avoid cutting at the exact location where the flat surface is
-        auto new_height = block_count * block_height - EPSILON;
-        if (new_height < obj_bb.size().z()) {
-            cut_horizontal(0, 0, new_height, ModelObjectCutAttribute::KeepLower);
-        }
-    }
-    
-    // cut bottom
-    obj_bb = model().objects[0]->bounding_box_exact();
-    block_count = lround((500 - params.start) / base_temp_tower_temp_step);
-    if(block_count > 0){
-        auto new_height = block_count * block_height + EPSILON;
-        if (new_height < obj_bb.size().z()) {
-            cut_horizontal(0, 0, new_height, ModelObjectCutAttribute::KeepUpper);
-        }
-    }
-    
     p->background_process.fff_print()->set_calib_params(params);
 }
 

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -12386,6 +12386,7 @@ void Plater::calib_pa(const Calib_Params& params)
     auto print_config = &wxGetApp().preset_bundle->prints.get_edited_preset().config;
     auto printer_config = &wxGetApp().preset_bundle->printers.get_edited_preset().config;
     print_config->set_key_value("overhang_reverse", new ConfigOptionBool(false));
+    print_config->set_key_value("precise_z_height", new ConfigOptionBool(false));
     printer_config->set_key_value("resonance_avoidance", new ConfigOptionBool{false});
     switch (params.mode) {
         case CalibMode::Calib_PA_Line:
@@ -13014,6 +13015,7 @@ void Plater::calib_max_vol_speed(const Calib_Params& params)
     obj_cfg.set_key_value("brim_type", new ConfigOptionEnum<BrimType>(btOuterAndInner));
     obj_cfg.set_key_value("brim_width", new ConfigOptionFloat(5.0));
     obj_cfg.set_key_value("brim_object_gap", new ConfigOptionFloat(0.0));
+    obj_cfg.set_key_value("precise_z_height", new ConfigOptionBool(false));
     print_config->set_key_value("timelapse_type", new ConfigOptionEnum<TimelapseType>(tlTraditional));
     print_config->set_key_value("spiral_mode", new ConfigOptionBool(true));
     print_config->set_key_value("max_volumetric_extrusion_rate_slope", new ConfigOptionFloat(0));
@@ -13086,6 +13088,7 @@ void Plater::calib_retraction(const Calib_Params& params)
     obj->config.set_key_value("seam_position", new ConfigOptionEnum<SeamPosition>(spAligned));
     obj->config.set_key_value("wall_sequence", new ConfigOptionEnum<WallSequence>(WallSequence::InnerOuter));
     obj->config.set_key_value("overhang_reverse", new ConfigOptionBool(false));
+    obj->config.set_key_value("precise_z_height", new ConfigOptionBool(false));
 
 
     changed_objects({ 0 });
@@ -13124,6 +13127,7 @@ void Plater::calib_VFA(const Calib_Params& params)
     print_config->set_key_value("detect_thin_wall", new ConfigOptionBool(false));
     print_config->set_key_value("spiral_mode", new ConfigOptionBool(true));
     print_config->set_key_value("enable_wrapping_detection", new ConfigOptionBool(false));
+    print_config->set_key_value("precise_z_height", new ConfigOptionBool(false));
     model().objects[0]->config.set_key_value("brim_type", new ConfigOptionEnum<BrimType>(btOuterOnly));
     model().objects[0]->config.set_key_value("brim_width", new ConfigOptionFloat(3.0));
     model().objects[0]->config.set_key_value("brim_object_gap", new ConfigOptionFloat(0.0));
@@ -13191,6 +13195,7 @@ void Plater::calib_input_shaping_freq(const Calib_Params& params)
     print_config->set_key_value("outer_wall_speed", new ConfigOptionFloat(200));
     print_config->set_key_value("default_acceleration", new ConfigOptionFloat(20000));
     print_config->set_key_value("outer_wall_acceleration", new ConfigOptionFloat(20000));
+    print_config->set_key_value("precise_z_height", new ConfigOptionBool(false));
     model().objects[0]->config.set_key_value("brim_type", new ConfigOptionEnum<BrimType>(btOuterOnly));
     model().objects[0]->config.set_key_value("brim_width", new ConfigOptionFloat(3.0));
     model().objects[0]->config.set_key_value("brim_object_gap", new ConfigOptionFloat(0.0));
@@ -13251,6 +13256,7 @@ void Plater::calib_input_shaping_damp(const Calib_Params& params)
     print_config->set_key_value("outer_wall_speed", new ConfigOptionFloat(200));
     print_config->set_key_value("default_acceleration", new ConfigOptionFloat(20000));
     print_config->set_key_value("outer_wall_acceleration", new ConfigOptionFloat(20000));
+    print_config->set_key_value("precise_z_height", new ConfigOptionBool(false));
     model().objects[0]->config.set_key_value("brim_type", new ConfigOptionEnum<BrimType>(btOuterOnly));
     model().objects[0]->config.set_key_value("brim_width", new ConfigOptionFloat(3.0));
     model().objects[0]->config.set_key_value("brim_object_gap", new ConfigOptionFloat(0.0));
@@ -13313,6 +13319,7 @@ void Plater::Calib_Cornering(const Calib_Params& params)
     print_config->set_key_value("outer_wall_speed", new ConfigOptionFloat(200));
     print_config->set_key_value("default_acceleration", new ConfigOptionFloat(2000));
     print_config->set_key_value("outer_wall_acceleration", new ConfigOptionFloat(2000));
+    print_config->set_key_value("precise_z_height", new ConfigOptionBool(false));
     model().objects[0]->config.set_key_value("brim_type", new ConfigOptionEnum<BrimType>(btOuterOnly));
     model().objects[0]->config.set_key_value("brim_width", new ConfigOptionFloat(3.0));
     model().objects[0]->config.set_key_value("brim_object_gap", new ConfigOptionFloat(0.0));

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -12890,6 +12890,10 @@ void Plater::calib_flowrate(bool is_linear, int pass) {
 
 
 void Plater::calib_temp(const Calib_Params& params) {
+    constexpr double base_temp_tower_nozzle_diameter = 0.4;
+    constexpr double base_temp_tower_block_height = 10.0;
+    constexpr int base_temp_tower_temp_step = 5;
+
     const auto calib_temp_name = wxString::Format(L"Nozzle temperature test");
     new_project(false, false, calib_temp_name);
     wxGetApp().mainframe->select_tab(size_t(MainFrame::tp3DEditor));
@@ -12900,6 +12904,22 @@ void Plater::calib_temp(const Calib_Params& params) {
     auto printer_config = &wxGetApp().preset_bundle->printers.get_edited_preset().config;
     auto filament_config = &wxGetApp().preset_bundle->filaments.get_edited_preset().config;
     auto start_temp = lround(params.start);
+    const ConfigOptionFloats* nozzle_diameter_config = printer_config->option<ConfigOptionFloats>("nozzle_diameter");
+    size_t nozzle_id = static_cast<size_t>(std::max(params.extruder_id, 0));
+    double nozzle_diameter = base_temp_tower_nozzle_diameter;
+    if (nozzle_diameter_config && !nozzle_diameter_config->values.empty()) {
+        nozzle_id = std::min(nozzle_id, nozzle_diameter_config->values.size() - 1);
+        nozzle_diameter = nozzle_diameter_config->values[nozzle_id];
+    }
+    if (nozzle_diameter <= 0.0)
+        nozzle_diameter = base_temp_tower_nozzle_diameter;
+
+    const double nozzle_scale = nozzle_diameter / base_temp_tower_nozzle_diameter;
+    const double block_height = base_temp_tower_block_height * nozzle_scale;
+
+    if (std::abs(nozzle_scale - 1.0) > EPSILON)
+        model().objects[0]->scale(nozzle_scale, nozzle_scale, nozzle_scale);
+
     printer_config->set_key_value("resonance_avoidance", new ConfigOptionBool{false});
     filament_config->set_key_value("nozzle_temperature_initial_layer", new ConfigOptionInts(1,(int)start_temp));
     filament_config->set_key_value("nozzle_temperature", new ConfigOptionInts(1,(int)start_temp));
@@ -12921,10 +12941,10 @@ void Plater::calib_temp(const Calib_Params& params) {
 
     // cut upper
     auto obj_bb = model().objects[0]->bounding_box_exact();
-    auto block_count = lround((500 - params.end) / 5 + 1);
+    auto block_count = lround((500 - params.end) / base_temp_tower_temp_step + 1);
     if(block_count > 0){
         // subtract EPSILON offset to avoid cutting at the exact location where the flat surface is
-        auto new_height = block_count * 10.0 - EPSILON;
+        auto new_height = block_count * block_height - EPSILON;
         if (new_height < obj_bb.size().z()) {
             cut_horizontal(0, 0, new_height, ModelObjectCutAttribute::KeepLower);
         }
@@ -12932,9 +12952,9 @@ void Plater::calib_temp(const Calib_Params& params) {
     
     // cut bottom
     obj_bb = model().objects[0]->bounding_box_exact();
-    block_count = lround((500 - params.start) / 5);
+    block_count = lround((500 - params.start) / base_temp_tower_temp_step);
     if(block_count > 0){
-        auto new_height = block_count * 10.0 + EPSILON;
+        auto new_height = block_count * block_height + EPSILON;
         if (new_height < obj_bb.size().z()) {
             cut_horizontal(0, 0, new_height, ModelObjectCutAttribute::KeepUpper);
         }

--- a/src/slic3r/Utils/CalibUtils.cpp
+++ b/src/slic3r/Utils/CalibUtils.cpp
@@ -1095,9 +1095,7 @@ void CalibUtils::calib_temptue(const CalibInfo &calib_info, wxString &error_mess
         nozzle_diameter = base_temp_tower_nozzle_diameter;
 
     const double nozzle_scale = nozzle_diameter / base_temp_tower_nozzle_diameter;
-    const double block_height = base_temp_tower_block_height * nozzle_scale;
-    if (std::abs(nozzle_scale - 1.0) > EPSILON)
-        model.objects[0]->scale(nozzle_scale, nozzle_scale, nozzle_scale);
+    const double block_height = base_temp_tower_block_height;
 
     // cut upper
     auto obj_bb      = model.objects[0]->bounding_box_exact();
@@ -1119,6 +1117,11 @@ void CalibUtils::calib_temptue(const CalibInfo &calib_info, wxString &error_mess
             cut_model(model, new_height, ModelObjectCutAttribute::KeepUpper);
         }
     }
+
+    if (std::abs(nozzle_scale - 1.0) > EPSILON)
+        model.objects[0]->scale(nozzle_scale, nozzle_scale, nozzle_scale);
+
+    model.objects[0]->ensure_on_bed();
 
     // edit preset
     DynamicPrintConfig print_config    = calib_info.print_prest->config;

--- a/src/slic3r/Utils/CalibUtils.cpp
+++ b/src/slic3r/Utils/CalibUtils.cpp
@@ -1072,6 +1072,10 @@ bool CalibUtils::calib_generic_PA(const CalibInfo &calib_info, wxString &error_m
 
 void CalibUtils::calib_temptue(const CalibInfo &calib_info, wxString &error_message)
 {
+    constexpr double base_temp_tower_nozzle_diameter = 0.4;
+    constexpr double base_temp_tower_block_height = 10.0;
+    constexpr int base_temp_tower_temp_step = 5;
+
     const Calib_Params &params = calib_info.params;
     if (params.mode != CalibMode::Calib_Temp_Tower)
         return;
@@ -1080,12 +1084,27 @@ void CalibUtils::calib_temptue(const CalibInfo &calib_info, wxString &error_mess
     std::string               input_file = Slic3r::resources_dir() + "/calib/temperature_tower/temperature_tower.stl";
     read_model_from_file(input_file, model);
 
+    const ConfigOptionFloats* nozzle_diameter_config = calib_info.printer_prest->config.option<ConfigOptionFloats>("nozzle_diameter");
+    size_t nozzle_id = static_cast<size_t>(std::max(params.extruder_id, 0));
+    double nozzle_diameter = base_temp_tower_nozzle_diameter;
+    if (nozzle_diameter_config && !nozzle_diameter_config->values.empty()) {
+        nozzle_id = std::min(nozzle_id, nozzle_diameter_config->values.size() - 1);
+        nozzle_diameter = nozzle_diameter_config->values[nozzle_id];
+    }
+    if (nozzle_diameter <= 0.0)
+        nozzle_diameter = base_temp_tower_nozzle_diameter;
+
+    const double nozzle_scale = nozzle_diameter / base_temp_tower_nozzle_diameter;
+    const double block_height = base_temp_tower_block_height * nozzle_scale;
+    if (std::abs(nozzle_scale - 1.0) > EPSILON)
+        model.objects[0]->scale(nozzle_scale, nozzle_scale, nozzle_scale);
+
     // cut upper
     auto obj_bb      = model.objects[0]->bounding_box_exact();
-    auto block_count = lround((350 - params.start) / 5 + 1);
+    auto block_count = lround((350 - params.start) / base_temp_tower_temp_step + 1);
     if (block_count > 0) {
         // add EPSILON offset to avoid cutting at the exact location where the flat surface is
-        auto new_height = block_count * 10.0 + EPSILON;
+        auto new_height = block_count * block_height + EPSILON;
         if (new_height < obj_bb.size().z()) {
             cut_model(model, new_height, ModelObjectCutAttribute::KeepLower);
         }
@@ -1093,9 +1112,9 @@ void CalibUtils::calib_temptue(const CalibInfo &calib_info, wxString &error_mess
 
     // cut bottom
     obj_bb      = model.objects[0]->bounding_box_exact();
-    block_count = lround((350 - params.end) / 5);
+    block_count = lround((350 - params.end) / base_temp_tower_temp_step);
     if (block_count > 0) {
-        auto new_height = block_count * 10.0 + EPSILON;
+        auto new_height = block_count * block_height + EPSILON;
         if (new_height < obj_bb.size().z()) {
             cut_model(model, new_height, ModelObjectCutAttribute::KeepUpper);
         }

--- a/src/slic3r/Utils/CalibUtils.cpp
+++ b/src/slic3r/Utils/CalibUtils.cpp
@@ -1072,10 +1072,6 @@ bool CalibUtils::calib_generic_PA(const CalibInfo &calib_info, wxString &error_m
 
 void CalibUtils::calib_temptue(const CalibInfo &calib_info, wxString &error_message)
 {
-    constexpr double base_temp_tower_nozzle_diameter = 0.4;
-    constexpr double base_temp_tower_block_height = 10.0;
-    constexpr int base_temp_tower_temp_step = 5;
-
     const Calib_Params &params = calib_info.params;
     if (params.mode != CalibMode::Calib_Temp_Tower)
         return;
@@ -1084,25 +1080,12 @@ void CalibUtils::calib_temptue(const CalibInfo &calib_info, wxString &error_mess
     std::string               input_file = Slic3r::resources_dir() + "/calib/temperature_tower/temperature_tower.stl";
     read_model_from_file(input_file, model);
 
-    const ConfigOptionFloats* nozzle_diameter_config = calib_info.printer_prest->config.option<ConfigOptionFloats>("nozzle_diameter");
-    size_t nozzle_id = static_cast<size_t>(std::max(params.extruder_id, 0));
-    double nozzle_diameter = base_temp_tower_nozzle_diameter;
-    if (nozzle_diameter_config && !nozzle_diameter_config->values.empty()) {
-        nozzle_id = std::min(nozzle_id, nozzle_diameter_config->values.size() - 1);
-        nozzle_diameter = nozzle_diameter_config->values[nozzle_id];
-    }
-    if (nozzle_diameter <= 0.0)
-        nozzle_diameter = base_temp_tower_nozzle_diameter;
-
-    const double nozzle_scale = nozzle_diameter / base_temp_tower_nozzle_diameter;
-    const double block_height = base_temp_tower_block_height;
-
     // cut upper
     auto obj_bb      = model.objects[0]->bounding_box_exact();
-    auto block_count = lround((350 - params.start) / base_temp_tower_temp_step + 1);
+    auto block_count = lround((350 - params.start) / 5 + 1);
     if (block_count > 0) {
         // add EPSILON offset to avoid cutting at the exact location where the flat surface is
-        auto new_height = block_count * block_height + EPSILON;
+        auto new_height = block_count * 10.0 + EPSILON;
         if (new_height < obj_bb.size().z()) {
             cut_model(model, new_height, ModelObjectCutAttribute::KeepLower);
         }
@@ -1110,18 +1093,13 @@ void CalibUtils::calib_temptue(const CalibInfo &calib_info, wxString &error_mess
 
     // cut bottom
     obj_bb      = model.objects[0]->bounding_box_exact();
-    block_count = lround((350 - params.end) / base_temp_tower_temp_step);
+    block_count = lround((350 - params.end) / 5);
     if (block_count > 0) {
-        auto new_height = block_count * block_height + EPSILON;
+        auto new_height = block_count * 10.0 + EPSILON;
         if (new_height < obj_bb.size().z()) {
             cut_model(model, new_height, ModelObjectCutAttribute::KeepUpper);
         }
     }
-
-    if (std::abs(nozzle_scale - 1.0) > EPSILON)
-        model.objects[0]->scale(nozzle_scale, nozzle_scale, nozzle_scale);
-
-    model.objects[0]->ensure_on_bed();
 
     // edit preset
     DynamicPrintConfig print_config    = calib_info.print_prest->config;


### PR DESCRIPTION
Closes #6978
Closes #12281

<img width="1183" height="975" alt="imagen" src="https://github.com/user-attachments/assets/d89d0e77-c1b2-4b44-8e97-fab88c3a43f6" />

Scale the tower temp based in the nozzle size plus readapts it's values depending on the resized height.
Adjust layer height for optimal value while if using a different one it will adapt the best it can.

Also disabled precise_z_height for calibs.