### PR TITLE
Migrate clipper to clipper2 functions for sparse Infill

### DIFF
--- a/src/libslic3r/Clipper2Utils.cpp
+++ b/src/libslic3r/Clipper2Utils.cpp
@@ -348,4 +348,39 @@ Slic3r::Polygons offset_2(const Slic3r::ExPolygon& expolygon, double delta, Clip
     return Paths64_to_Slic3rPolygons(offset_paths_2<Clipper2Lib::Paths64>(paths, delta, joinType, miterLimit));
 }
 
+
+static void traverse_pt_outside_in_2(const Clipper2Lib::PolyPath64* node, Polygons *retval)
+{
+    if (!node) return;
+    
+    // Add current polygon
+    retval->push_back(Path64_to_Slic3rPolygon(node->Polygon()));
+    
+    // Process children recursively
+    for (size_t i = 0; i < node->Count(); ++i) {
+        traverse_pt_outside_in_2((*node)[i], retval);
+    }
+}
+
+Polygons union_pt_chained_outside_in_2(const Polygons &subject)
+{
+    Polygons retval;
+    
+    // Perform union with EvenOdd fill rule
+    Clipper2Lib::Clipper64 clipper;
+    clipper.AddSubject(Slic3rPolygons_to_Paths64(subject));
+    
+    Clipper2Lib::PolyTree64 polytree;
+    clipper.Execute(Clipper2Lib::ClipType::Union, 
+                    Clipper2Lib::FillRule::EvenOdd, 
+                    polytree);
+    
+    // Traverse the polytree
+    for (size_t i = 0; i < polytree.Count(); ++i) {
+        traverse_pt_outside_in_2(polytree[i], &retval);
+    }
+    
+    return retval;
+}
+
 } // namespace Slic3r

--- a/src/libslic3r/Clipper2Utils.cpp
+++ b/src/libslic3r/Clipper2Utils.cpp
@@ -213,4 +213,139 @@ ExPolygons offset2_ex_2(const ExPolygons& expolygons, double delta1, double delt
     return results;
 }
 
+// Helper function for raw offset
+static Clipper2Lib::Paths64 raw_offset_2(const Clipper2Lib::Paths64 &paths, double delta, 
+                                         Clipper2Lib::JoinType joinType, double miterLimit, 
+                                         Clipper2Lib::EndType endType = Clipper2Lib::EndType::Polygon)
+{
+    Clipper2Lib::ClipperOffset co(miterLimit, std::abs(delta * 0.005)); // Using same factor as Clipper1
+    Clipper2Lib::Paths64 out;
+    
+    for (const auto &path : paths) {
+        Clipper2Lib::Paths64 out_this;
+        co.Clear();
+        co.AddPath(path, joinType, endType);
+        co.Execute(delta, out_this);
+        out.insert(out.end(), out_this.begin(), out_this.end());
+    }
+    return out;
 }
+
+// Helper function for union
+template<class TResult, class TSubj>
+static TResult clipper_union_2(TSubj &&subject, Clipper2Lib::FillRule fillRule = Clipper2Lib::FillRule::NonZero)
+{
+    Clipper2Lib::Clipper64 clipper;
+    clipper.AddSubject(std::forward<TSubj>(subject));
+    TResult retval;
+    clipper.Execute(Clipper2Lib::ClipType::Union, fillRule, retval);
+    return retval;
+}
+
+// Helper function to remove outermost polygon
+template<typename Container>
+static void remove_outermost_polygon_2(Container &solution)
+{
+    if (!solution.empty()) solution.erase(solution.begin());
+}
+
+template<>
+void remove_outermost_polygon_2<Clipper2Lib::Paths64>(Clipper2Lib::Paths64 &solution)
+{
+    if (!solution.empty()) solution.erase(solution.begin());
+}
+
+// Expand paths function
+template<class TResult, typename PathsProvider>
+static TResult expand_paths_2(PathsProvider &&paths, double delta, 
+                               Clipper2Lib::JoinType joinType, double miterLimit)
+{
+    auto raw = raw_offset_2(std::forward<PathsProvider>(paths), delta, joinType, miterLimit);
+    return clipper_union_2<TResult>(raw);
+}
+
+// Shrink paths function
+template<class TResult, typename PathsProvider>
+static TResult shrink_paths_2(PathsProvider &&paths, double delta, 
+                               Clipper2Lib::JoinType joinType, double miterLimit)
+{
+    TResult out;
+    auto raw = raw_offset_2(std::forward<PathsProvider>(paths), -delta, joinType, miterLimit);
+    if (!raw.empty()) {
+        Clipper2Lib::Clipper64 clipper;
+        clipper.AddSubject(raw);
+        
+        auto rect = Clipper2Lib::GetBounds(raw);
+        Clipper2Lib::Path64 rect_path = {
+            Clipper2Lib::Point64(rect.left - 10, rect.bottom + 10),
+            Clipper2Lib::Point64(rect.right + 10, rect.bottom + 10),
+            Clipper2Lib::Point64(rect.right + 10, rect.top - 10),
+            Clipper2Lib::Point64(rect.left - 10, rect.top - 10)
+        };
+        clipper.AddSubject(Clipper2Lib::Paths64{rect_path});
+        
+        clipper.ReverseSolution(true);
+        clipper.Execute(Clipper2Lib::ClipType::Union, Clipper2Lib::FillRule::Negative, out);
+        remove_outermost_polygon_2(out);
+    }
+    return out;
+}
+
+// Offset paths function (main template)
+template<class TResult, typename PathsProvider>
+static TResult offset_paths_2(PathsProvider &&paths, double delta, Clipper2Lib::JoinType joinType, double miterLimit)
+{
+    return delta > 0 ?
+        expand_paths_2<TResult>(std::forward<PathsProvider>(paths), delta, joinType, miterLimit) :
+        shrink_paths_2<TResult>(std::forward<PathsProvider>(paths), -delta, joinType, miterLimit);
+}
+
+Polygons Paths64_to_Slic3rPolygons(const Clipper2Lib::Paths64& paths)
+{
+    Polygons polygons;
+    polygons.reserve(paths.size());
+    for (const auto& path : paths)
+        polygons.push_back(Path64_to_Slic3rPolygon(path));
+    return polygons;
+}
+
+Polygon Path64_to_Slic3rPolygon(const Clipper2Lib::Path64& path)
+{
+    Polygon poly;
+    poly.points.reserve(path.size());
+    for (const auto& p : path)
+        poly.points.emplace_back(coord_t(p.x), coord_t(p.y));
+    return poly;
+}
+
+Clipper2Lib::Paths64 Slic3rExPolygon_to_Paths64(const ExPolygon& expolygon)
+{
+    Clipper2Lib::Paths64 paths;
+    paths.reserve(1 + expolygon.holes.size());
+    
+    // Convert contour directly to avoid temporary vector
+    Clipper2Lib::Path64 contour_path;
+    contour_path.reserve(expolygon.contour.points.size());
+    for (const auto& p : expolygon.contour.points)
+        contour_path.emplace_back(p.x(), p.y());
+    paths.push_back(std::move(contour_path));
+    
+    // Convert holes directly
+    for (const auto& hole : expolygon.holes) {
+        Clipper2Lib::Path64 hole_path;
+        hole_path.reserve(hole.points.size());
+        for (const auto& p : hole.points)
+            hole_path.emplace_back(p.x(), p.y());
+        paths.push_back(std::move(hole_path));
+    }
+    
+    return paths;
+}
+
+Slic3r::Polygons offset_2(const Slic3r::ExPolygon& expolygon, double delta, Clipper2Lib::JoinType joinType, double miterLimit)
+{
+    auto paths = Slic3rExPolygon_to_Paths64(expolygon);
+    return Paths64_to_Slic3rPolygons(offset_paths_2<Clipper2Lib::Paths64>(paths, delta, joinType, miterLimit));
+}
+
+} // namespace Slic3r

--- a/src/libslic3r/Clipper2Utils.cpp
+++ b/src/libslic3r/Clipper2Utils.cpp
@@ -309,6 +309,20 @@ Polygons Paths64_to_Slic3rPolygons(const Clipper2Lib::Paths64& paths)
     return polygons;
 }
 
+Polygons offset_2(const Polygons &polygons, double delta, 
+                  Clipper2Lib::JoinType joinType, double miterLimit)
+{
+    auto paths = Slic3rPolygons_to_Paths64(polygons);
+    return Paths64_to_Slic3rPolygons(offset_paths_2<Clipper2Lib::Paths64>(paths, delta, joinType, miterLimit));
+}
+
+Polygons offset_2(const ExPolygon &expolygon, double delta, 
+                  Clipper2Lib::JoinType joinType, double miterLimit)
+{
+    auto paths = Slic3rExPolygon_to_Paths64(expolygon);
+    return Paths64_to_Slic3rPolygons(offset_paths_2<Clipper2Lib::Paths64>(paths, delta, joinType, miterLimit));
+}
+
 Polygon Path64_to_Slic3rPolygon(const Clipper2Lib::Path64& path)
 {
     Polygon poly;
@@ -341,13 +355,6 @@ Clipper2Lib::Paths64 Slic3rExPolygon_to_Paths64(const ExPolygon& expolygon)
     
     return paths;
 }
-
-Slic3r::Polygons offset_2(const Slic3r::ExPolygon& expolygon, double delta, Clipper2Lib::JoinType joinType, double miterLimit)
-{
-    auto paths = Slic3rExPolygon_to_Paths64(expolygon);
-    return Paths64_to_Slic3rPolygons(offset_paths_2<Clipper2Lib::Paths64>(paths, delta, joinType, miterLimit));
-}
-
 
 static void traverse_pt_outside_in_2(const Clipper2Lib::PolyPath64* node, Polygons *retval)
 {

--- a/src/libslic3r/Clipper2Utils.hpp
+++ b/src/libslic3r/Clipper2Utils.hpp
@@ -47,6 +47,8 @@ Polygons offset_2(const ExPolygon &expolygon, double delta,
                   Clipper2Lib::JoinType joinType = DefaultJoinType2, 
                   double miterLimit = DefaultMiterLimit2);
 
+Polygons union_pt_chained_outside_in_2(const Polygons &subject);
+
 // PolyTree utilities
 void SimplifyPolyTree(const Clipper2Lib::PolyPath64 *polytree, double epsilon, Clipper2Lib::PolyPath64 *result);
 

--- a/src/libslic3r/Clipper2Utils.hpp
+++ b/src/libslic3r/Clipper2Utils.hpp
@@ -8,14 +8,48 @@
 
 namespace Slic3r {
 
-Clipper2Lib::Paths64 Slic3rPolylines_to_Paths64(const Slic3r::Polylines& in);
-Slic3r::Polylines  Paths64_to_polylines(const Clipper2Lib::Paths64& in);
-Slic3r::Polylines  intersection_pl_2(const Slic3r::Polylines& subject, const Slic3r::Polygons& clip);
-Slic3r::Polylines  diff_pl_2(const Slic3r::Polylines& subject, const Slic3r::Polygons& clip);
-ExPolygons         union_ex_2(const Polygons &expolygons);
-ExPolygons         union_ex_2(const ExPolygons &expolygons);
-ExPolygons         offset_ex_2(const ExPolygons &expolygons, double delta);
-ExPolygons         offset2_ex_2(const ExPolygons &expolygons, double delta1, double delta2);
-}
+// Constants for Clipper2
+static constexpr const double                         Clipper2SafetyOffset     = 10.0;
+static constexpr const Clipper2Lib::JoinType         DefaultJoinType2         = Clipper2Lib::JoinType::Miter;
+static constexpr const Clipper2Lib::EndType          DefaultEndType2          = Clipper2Lib::EndType::Polygon;
+static constexpr const double                         DefaultMiterLimit2       = 3.0;
+static constexpr const Clipper2Lib::JoinType         DefaultLineJoinType2     = Clipper2Lib::JoinType::Square;
+static constexpr const double                         DefaultLineMiterLimit2   = 0.0;
 
-#endif
+// Polylines conversion and operations
+Clipper2Lib::Paths64 Slic3rPolylines_to_Paths64(const Slic3r::Polylines& in);
+Slic3r::Polylines    Paths64_to_polylines(const Clipper2Lib::Paths64& in);
+Slic3r::Polylines    intersection_pl_2(const Slic3r::Polylines& subject, const Slic3r::Polygons& clip);
+Slic3r::Polylines    diff_pl_2(const Slic3r::Polylines& subject, const Slic3r::Polygons& clip);
+
+// Polygon conversion functions
+Clipper2Lib::Path64   Slic3rPolygon_to_Path64(const Polygon &polygon);
+Clipper2Lib::Paths64  Slic3rPolygon_to_Paths64(const Polygon &polygon);
+Clipper2Lib::Paths64  Slic3rPolygons_to_Paths64(const Polygons &polygons);
+Clipper2Lib::Paths64  Slic3rExPolygon_to_Paths64(const ExPolygon &expolygon);
+Clipper2Lib::Paths64  Slic3rExPolygons_to_Paths64(const ExPolygons &expolygons);
+
+// Reverse conversion functions
+Polygon         Path64_to_Slic3rPolygon(const Clipper2Lib::Path64 &path);
+Polygons        Paths64_to_Slic3rPolygons(const Clipper2Lib::Paths64 &paths);
+Points          Path64ToPoints(const Clipper2Lib::Path64& path64);
+
+// Union operations
+ExPolygons union_ex_2(const Polygons &polygons);
+ExPolygons union_ex_2(const ExPolygons &expolygons);
+
+// Offset operations
+ExPolygons offset_ex_2(const ExPolygons &expolygons, double delta);
+ExPolygons offset2_ex_2(const ExPolygons &expolygons, double delta1, double delta2);
+
+// Offset functions for ExPolygon (returns Polygons)
+Polygons offset_2(const ExPolygon &expolygon, double delta, 
+                  Clipper2Lib::JoinType joinType = DefaultJoinType2, 
+                  double miterLimit = DefaultMiterLimit2);
+
+// PolyTree utilities
+void SimplifyPolyTree(const Clipper2Lib::PolyPath64 *polytree, double epsilon, Clipper2Lib::PolyPath64 *result);
+
+} // namespace Slic3r
+
+#endif // slic3r_Clipper2Utils_hpp_

--- a/src/libslic3r/Clipper2Utils.hpp
+++ b/src/libslic3r/Clipper2Utils.hpp
@@ -42,12 +42,26 @@ ExPolygons union_ex_2(const ExPolygons &expolygons);
 ExPolygons offset_ex_2(const ExPolygons &expolygons, double delta);
 ExPolygons offset2_ex_2(const ExPolygons &expolygons, double delta1, double delta2);
 
-// Offset functions for ExPolygon (returns Polygons)
+// Offset functions (returns Polygons)
 Polygons offset_2(const ExPolygon &expolygon, double delta, 
                   Clipper2Lib::JoinType joinType = DefaultJoinType2, 
                   double miterLimit = DefaultMiterLimit2);
 
+Polygons offset_2(const Polygons &polygons, double delta, 
+                  Clipper2Lib::JoinType joinType = DefaultJoinType2, 
+                  double miterLimit = DefaultMiterLimit2);
+
+// PolyTree utilities and chained ordering
 Polygons union_pt_chained_outside_in_2(const Polygons &subject);
+
+// Input polygons for shrinking shall be "normalized": There must be no overlap / intersections between the input polygons.
+inline Polygons shrink_2(const Polygons &polygons, double delta, 
+                         Clipper2Lib::JoinType joinType = DefaultJoinType2, 
+                         double miterLimit = DefaultMiterLimit2)
+{
+    assert(delta > 0);
+    return offset_2(polygons, -delta, joinType, miterLimit);
+}
 
 // PolyTree utilities
 void SimplifyPolyTree(const Clipper2Lib::PolyPath64 *polytree, double epsilon, Clipper2Lib::PolyPath64 *result);

--- a/src/libslic3r/Fill/Fill3DHoneycomb.cpp
+++ b/src/libslic3r/Fill/Fill3DHoneycomb.cpp
@@ -1,4 +1,4 @@
-#include "../ClipperUtils.hpp"
+#include "../Clipper2Utils.hpp"
 #include "../ShortestPath.hpp"
 #include "../Surface.hpp"
 #include "FillBase.hpp"
@@ -277,7 +277,7 @@ void Fill3DHoneycomb::_fill_surface_single(
     multiline_fill(polylines, params, spacing);
 
     // clip pattern to boundaries, chain the clipped polylines
-    polylines = intersection_pl(std::move(polylines), to_polygons(expolygon));
+    polylines = intersection_pl_2(std::move(polylines), to_polygons(expolygon));
 
     if (! polylines.empty()) {
     // Remove very small bits, but be careful to not remove infill lines connecting thin walls!

--- a/src/libslic3r/Fill/FillAdaptive.cpp
+++ b/src/libslic3r/Fill/FillAdaptive.cpp
@@ -1,4 +1,4 @@
-#include "../ClipperUtils.hpp"
+#include "../Clipper2Utils.hpp"
 #include "../ExPolygon.hpp"
 #include "../Surface.hpp"
 #include "../Geometry.hpp"
@@ -1354,7 +1354,7 @@ void Filler::_fill_surface_single(
                 if (l.a.x() != std::numeric_limits<coord_t>::max())
                     lines.push_back({ l.a, l.b });
             // Crop all polylines
-            append(all_polylines, intersection_pl(std::move(lines), boundary));
+            append(all_polylines, intersection_pl_2(std::move(lines), boundary));
         }
 //        assert(has_no_collinear_lines(all_polylines));        
 #else
@@ -1375,12 +1375,12 @@ void Filler::_fill_surface_single(
         multiline_fill(all_polylines, params, spacing);
 
         // Crop all polylines
-        all_polylines = intersection_pl(std::move(all_polylines), expolygon);
+        all_polylines = intersection_pl_2(std::move(all_polylines), to_polygons(expolygon));
 #endif
     }
 
     if (params.multiline == 1) {
-        // After intersection_pl some polylines with only one line are split into more lines
+        // After intersection_pl_2 some polylines with only one line are split into more lines
         for (Polyline& polyline : all_polylines) {
             // FIXME assert that all the points are collinear and in between the start and end point.
             if (polyline.points.size() > 2)

--- a/src/libslic3r/Fill/FillBase.cpp
+++ b/src/libslic3r/Fill/FillBase.cpp
@@ -2,6 +2,7 @@
 #include <numeric>
 
 #include <cmath>
+#include "../ClipperUtils.hpp"
 #include "../Clipper2Utils.hpp"
 #include "../EdgeGrid.hpp"
 #include "../Geometry.hpp"
@@ -203,8 +204,8 @@ void Fill::_create_gap_fill(const Surface* surface, const FillParams& params, Ex
 
     Flow new_flow = params.flow;
     ExPolygons unextruded_areas;
-    unextruded_areas = diff_ex(this->no_overlap_expolygons, union_ex(out->polygons_covered_by_spacing(10)));
-    ExPolygons gapfill_areas = union_ex(unextruded_areas);
+    unextruded_areas = diff_ex(this->no_overlap_expolygons, union_ex_2(out->polygons_covered_by_spacing(10)));
+    ExPolygons gapfill_areas = union_ex_2(unextruded_areas);
     if (!this->no_overlap_expolygons.empty())
         gapfill_areas = intersection_ex(gapfill_areas, this->no_overlap_expolygons);
 
@@ -213,7 +214,7 @@ void Fill::_create_gap_fill(const Surface* surface, const FillParams& params, Ex
         double max = 2. * new_flow.scaled_spacing();
         ExPolygons gaps_ex = diff_ex(
                                      opening_ex(gapfill_areas, float(min / 2.)),
-                                     offset2_ex(gapfill_areas, -float(max / 2.), float(max / 2. + ClipperSafetyOffset)));
+                                     offset2_ex_2(gapfill_areas, -float(max / 2.), float(max / 2. + ClipperSafetyOffset)));
         //BBS: sort the gap_ex to avoid mess travel
         Points ordering_points;
         ordering_points.reserve(gaps_ex.size());
@@ -883,7 +884,7 @@ static void export_infill_to_svg(
 {
     Polygons    polygons;
     std::transform(boundary.begin(), boundary.end(), std::back_inserter(polygons), [](auto &pts) { return Polygon(pts); });
-    ExPolygons  expolygons = union_ex(polygons);
+    ExPolygons  expolygons = union_ex_2(polygons);
     BoundingBox bbox = get_extents(polygons);
     bbox.offset(scale_(3.));
 
@@ -2144,7 +2145,7 @@ static void export_partial_infill_to_svg(const std::string &path, const Boundary
     BoundingBox bbox = get_extents(polygons);
     bbox.merge(get_extents(infill));
     ::Slic3r::SVG svg(path, bbox);
-    svg.draw(union_ex(polygons));
+    svg.draw(union_ex_2(polygons));
     svg.draw(infill, "blue");
     svg.draw(emitted, "darkblue");
     for (const ContourIntersectionPoint &cp : graph.map_infill_end_point_to_boundary)

--- a/src/libslic3r/Fill/FillBase.cpp
+++ b/src/libslic3r/Fill/FillBase.cpp
@@ -2,7 +2,6 @@
 #include <numeric>
 
 #include <cmath>
-#include "../ClipperUtils.hpp"
 #include "../Clipper2Utils.hpp"
 #include "../EdgeGrid.hpp"
 #include "../Geometry.hpp"
@@ -105,7 +104,7 @@ bool Fill::use_bridge_flow(const InfillPattern type)
 Polylines Fill::fill_surface(const Surface *surface, const FillParams &params)
 {
     // Perform offset.
-    Slic3r::ExPolygons expp = offset_ex(surface->expolygon, float(scale_(this->overlap - 0.5 * this->spacing)));
+    Slic3r::ExPolygons expp = offset_ex_2(ExPolygons{surface->expolygon}, float(scale_(this->overlap - 0.5 * this->spacing)));
     // Create the infills for each of the regions.
     Polylines polylines_out;
     for (size_t i = 0; i < expp.size(); ++ i)
@@ -121,7 +120,7 @@ Polylines Fill::fill_surface(const Surface *surface, const FillParams &params)
 ThickPolylines Fill::fill_surface_arachne(const Surface* surface, const FillParams& params)
 {
     // Perform offset.
-    Slic3r::ExPolygons expp = offset_ex(surface->expolygon, float(scale_(this->overlap - 0.5 * this->spacing)));
+    Slic3r::ExPolygons expp = offset_ex_2(ExPolygons{surface->expolygon}, float(scale_(this->overlap - 0.5 * this->spacing)));
     // Create the infills for each of the regions.
     ThickPolylines thick_polylines_out;
     for (ExPolygon& expoly : expp)

--- a/src/libslic3r/Fill/FillConcentric.cpp
+++ b/src/libslic3r/Fill/FillConcentric.cpp
@@ -1,4 +1,3 @@
-#include "../ClipperUtils.hpp"
 #include "../Clipper2Utils.hpp"
 #include "../ExPolygon.hpp"
 #include "../Surface.hpp"
@@ -35,13 +34,13 @@ void FillConcentric::_fill_surface_single(
 
     ExPolygons last { std::move(contracted) };
     while (! last.empty()) {
-        last = offset2_ex(last, -(distance + min_spacing/2), +min_spacing/2);
+        last = offset2_ex_2(last, -(distance + min_spacing/2), +min_spacing/2);
         append(loops, to_polygons(last));
     }
 
     // generate paths from the outermost to the innermost, to avoid
     // adhesion problems of the first central tiny loops
-    loops = union_pt_chained_outside_in(loops);
+    loops = union_pt_chained_outside_in_2(loops);
     
     // split paths using a nearest neighbor search
     size_t iPathFirst = polylines_out.size();

--- a/src/libslic3r/Fill/FillConcentric.cpp
+++ b/src/libslic3r/Fill/FillConcentric.cpp
@@ -1,3 +1,4 @@
+#include "../ClipperUtils.hpp"
 #include "../Clipper2Utils.hpp"
 #include "../ExPolygon.hpp"
 #include "../Surface.hpp"

--- a/src/libslic3r/Fill/FillConcentric.cpp
+++ b/src/libslic3r/Fill/FillConcentric.cpp
@@ -1,4 +1,4 @@
-#include "../ClipperUtils.hpp"
+#include "../Clipper2Utils.hpp"
 #include "../ExPolygon.hpp"
 #include "../Surface.hpp"
 #include "../VariableWidth.hpp"
@@ -28,7 +28,7 @@ void FillConcentric::_fill_surface_single(
     }
 
     // Contract surface polygon by half line width to avoid excesive overlap with perimeter
-    ExPolygons contracted = offset_ex(expolygon, -float(scale_(0.5 * (params.multiline - 1) * this->spacing )));
+    ExPolygons contracted = offset_ex_2(ExPolygons{expolygon}, -float(scale_(0.5 * (params.multiline - 1) * this->spacing )));
 
     Polygons loops = to_polygons(contracted);
 

--- a/src/libslic3r/Fill/FillConcentric.cpp
+++ b/src/libslic3r/Fill/FillConcentric.cpp
@@ -87,7 +87,7 @@ void FillConcentric::_fill_surface_single(const FillParams& params,
 
     if (params.density > 0.9999f && !params.dont_adjust) {
         coord_t                loops_count = std::max(bbox_size.x(), bbox_size.y()) / min_spacing + 1;
-        Polygons               polygons = offset(expolygon, float(min_spacing) / 2.f);
+        Polygons               polygons = offset_2(expolygon, float(min_spacing) / 2.f);
 
         double min_nozzle_diameter = *std::min_element(print_config->nozzle_diameter.values.begin(), print_config->nozzle_diameter.values.end());
         Arachne::WallToolPathsParams input_params;

--- a/src/libslic3r/Fill/FillCrossHatch.cpp
+++ b/src/libslic3r/Fill/FillCrossHatch.cpp
@@ -1,4 +1,4 @@
-#include "../ClipperUtils.hpp"
+#include "../Clipper2Utils.hpp"
 #include "../ShortestPath.hpp"
 #include "../Surface.hpp"
 #include <cmath>
@@ -208,7 +208,7 @@ void FillCrossHatch ::_fill_surface_single(
     // Apply multiline offset if needed
     multiline_fill(polylines, params, spacing);
 
-    polylines = intersection_pl(std::move(polylines), to_polygons(expolygon));
+    polylines = intersection_pl_2(std::move(polylines), to_polygons(expolygon));
 
     // --- remove small remains from gyroid infill
     if (!polylines.empty()) {

--- a/src/libslic3r/Fill/FillGyroid.cpp
+++ b/src/libslic3r/Fill/FillGyroid.cpp
@@ -1,4 +1,4 @@
-#include "../ClipperUtils.hpp"
+#include "../Clipper2Utils.hpp"
 #include "../ShortestPath.hpp"
 #include "../Surface.hpp"
 #include <cmath>
@@ -187,7 +187,7 @@ void FillGyroid::_fill_surface_single(
     // Apply multiline offset if needed
     multiline_fill(polylines, params, spacing);
 
-	polylines = intersection_pl(std::move(polylines), expolygon);
+	polylines = intersection_pl_2(std::move(polylines),to_polygons(expolygon));
 
     if (! polylines.empty()) {
 		// Remove very small bits, but be careful to not remove infill lines connecting thin walls!

--- a/src/libslic3r/Fill/FillHoneycomb.cpp
+++ b/src/libslic3r/Fill/FillHoneycomb.cpp
@@ -1,4 +1,4 @@
-#include "../ClipperUtils.hpp"
+#include "../Clipper2Utils.hpp"
 #include "../ShortestPath.hpp"
 #include "../Surface.hpp"
 
@@ -76,7 +76,7 @@ void FillHoneycomb::_fill_surface_single(
     // Apply multiline offset if needed
     multiline_fill(all_polylines, params, spacing);
 
-    all_polylines = intersection_pl(std::move(all_polylines), expolygon);
+    all_polylines = intersection_pl_2(std::move(all_polylines), to_polygons(expolygon));
     chain_or_connect_infill(std::move(all_polylines), expolygon, polylines_out, this->spacing, params);
 }
 

--- a/src/libslic3r/Fill/FillLightning.cpp
+++ b/src/libslic3r/Fill/FillLightning.cpp
@@ -1,4 +1,4 @@
-#include "../ClipperUtils.hpp"
+#include "../Clipper2Utils.hpp"
 #include "../Print.hpp"
 #include "../ShortestPath.hpp"
 #include "FillBase.hpp"
@@ -20,7 +20,7 @@ void Filler::_fill_surface_single(
     // Apply multiline offset if needed
     multiline_fill(fill_lines, params, spacing);
 
-    fill_lines = Slic3r::intersection_pl(std::move(fill_lines), expolygon);
+    fill_lines = Slic3r::intersection_pl_2(std::move(fill_lines), to_polygons(expolygon));
 
     chain_or_connect_infill(std::move(fill_lines), expolygon, polylines_out, this->spacing, params);
 }

--- a/src/libslic3r/Fill/FillLine.cpp
+++ b/src/libslic3r/Fill/FillLine.cpp
@@ -1,4 +1,4 @@
-#include "../ClipperUtils.hpp"
+#include "../Clipper2Utils.hpp"
 #include "../ExPolygon.hpp"
 #include "../ShortestPath.hpp"
 #include "../Surface.hpp"
@@ -58,7 +58,7 @@ void FillLine::_fill_surface_single(
         pts.push_back(it->a);
         pts.push_back(it->b);
     }
-    Polylines polylines = intersection_pl(std::move(polylines_src), offset(expolygon, scale_(0.02)));
+    Polylines polylines = intersection_pl_2(std::move(polylines_src), offset(expolygon, scale_(0.02)));
 
     // FIXME Vojtech: This is only performed for horizontal lines, not for the vertical lines!
     const float INFILL_OVERLAP_OVER_SPACING = 0.3f;
@@ -80,7 +80,7 @@ void FillLine::_fill_surface_single(
         // offset the expolygon by max(min_spacing/2, extra)
         ExPolygon expolygon_off;
         {
-            ExPolygons expolygons_off = offset_ex(expolygon, this->_min_spacing/2);
+            ExPolygons expolygons_off = offset_ex_2(ExPolygons{expolygon}, this->_min_spacing/2);
             if (! expolygons_off.empty()) {
                 // When expanding a polygon, the number of islands could only shrink. Therefore the offset_ex shall generate exactly one expanded island for one input island.
                 assert(expolygons_off.size() == 1);

--- a/src/libslic3r/Fill/FillLine.cpp
+++ b/src/libslic3r/Fill/FillLine.cpp
@@ -58,7 +58,7 @@ void FillLine::_fill_surface_single(
         pts.push_back(it->a);
         pts.push_back(it->b);
     }
-    Polylines polylines = intersection_pl_2(std::move(polylines_src), offset(expolygon, scale_(0.02)));
+    Polylines polylines = intersection_pl_2(std::move(polylines_src), offset_2(expolygon, scale_(0.02)));
 
     // FIXME Vojtech: This is only performed for horizontal lines, not for the vertical lines!
     const float INFILL_OVERLAP_OVER_SPACING = 0.3f;

--- a/src/libslic3r/Fill/FillPlanePath.cpp
+++ b/src/libslic3r/Fill/FillPlanePath.cpp
@@ -1,4 +1,4 @@
-#include "../ClipperUtils.hpp"
+#include "../Clipper2Utils.hpp"
 #include "../ShortestPath.hpp"
 #include "../Surface.hpp"
 
@@ -126,7 +126,7 @@ void FillPlanePath::_fill_surface_single(
     multiline_fill(polylines, params, spacing);
 
     if (polyline.size() >= 2) {
-        polylines = intersection_pl(std::move(polylines), expolygon);
+        polylines = intersection_pl_2(std::move(polylines), to_polygons(expolygon));
         if (!polylines.empty()) {
             Polylines chained;
             if (params.dont_connect() || params.density > 0.5) {

--- a/src/libslic3r/Fill/FillRectilinear.cpp
+++ b/src/libslic3r/Fill/FillRectilinear.cpp
@@ -12,6 +12,7 @@
 #include <boost/math/constants/constants.hpp>
 
 #include "../ClipperUtils.hpp"
+#include "../Clipper2Utils.hpp"
 #include "../ExPolygon.hpp"
 #include "../Geometry.hpp"
 #include "../Surface.hpp"
@@ -3021,13 +3022,13 @@ bool FillRectilinear::fill_surface_by_multilines(const Surface *surface, FillPar
     multiline_fill(fill_lines, params, spacing);
  
     // Contract surface polygon by half line width to avoid excesive overlap with perimeter
-    ExPolygons contracted = offset_ex(surface->expolygon, -float(scale_(0.5 * this->spacing)));
+    ExPolygons contracted = offset_ex_2(ExPolygons{surface->expolygon}, -float(scale_(0.5 * this->spacing)));
     
     // if contraction results in empty polygon, use original surface
     const ExPolygon &intersection_surface = contracted.empty() ? surface->expolygon : contracted.front();
 
     // Intersect polylines with perimeter
-    fill_lines = intersection_pl(std::move(fill_lines), intersection_surface);
+    fill_lines = intersection_pl_2(std::move(fill_lines), to_polygons(intersection_surface));
 
     if ((params.pattern == ipLateralLattice || params.pattern == ipLateralHoneycomb ) && params.multiline >1 )
     remove_overlapped(fill_lines, line_width);
@@ -3265,13 +3266,13 @@ bool FillRectilinear::fill_surface_trapezoidal(
     multiline_fill(polylines, params, spacing);
 
     // Contract surface polygon by half line width to avoid excesive overlap with perimeter
-    ExPolygons contracted = offset_ex(expolygon, -float(scale_(0.5 * this->spacing)));
+    ExPolygons contracted = offset_ex_2(ExPolygons{expolygon}, -float(scale_(0.5 * this->spacing)));
 
     // if contraction results in empty polygon, use original surface
     const ExPolygon &intersection_surface = contracted.empty() ? expolygon : contracted.front();
 
     // Intersect polylines with offset expolygon
-    polylines = intersection_pl(std::move(polylines), intersection_surface);
+    polylines = intersection_pl_2(std::move(polylines), to_polygons(intersection_surface));
 
     // Remove very short segments that may cause connection issues
     const double minlength = scale_(0.8 * this->spacing);
@@ -3573,7 +3574,7 @@ Points sample_grid_pattern(const ExPolygons& expolygons, coord_t spacing, const 
 
 Points sample_grid_pattern(const Polygons& polygons, coord_t spacing, const BoundingBox& global_bounding_box)
 {
-    return sample_grid_pattern(union_ex(polygons), spacing, global_bounding_box);
+    return sample_grid_pattern(union_ex_2(polygons), spacing, global_bounding_box);
 }
 
 // Orca: Introduced FillMonotonicLines from Prusa slicer, inhereting from FillRectilinear
@@ -3782,7 +3783,7 @@ void FillLockedZag::fill_surface_locked_zag (const Surface *                    
     Surface   zig_surface       = *surface;
     // inner exps
     // inner union exps
-    ExPolygons zig_expas   = offset_ex({surface->expolygon}, -offset_threshold);
+    ExPolygons zig_expas   = offset_ex_2(ExPolygons{surface->expolygon}, -offset_threshold);
     ExPolygons cross_expas = diff_ex(surface->expolygon, zig_expas);
 
     bool       zig_get    = false;
@@ -3794,7 +3795,7 @@ void FillLockedZag::fill_surface_locked_zag (const Surface *                    
         while (it != flow_params.end()) {
             ExPolygons region_exp = union_safety_offset_ex(it->second);
 
-            Polylines polys = intersection_pl(polylines, region_exp);
+            Polylines polys = intersection_pl_2(polylines, to_polygons(region_exp));
             multi_width_polyline.emplace_back(polys, it->first);
             it++;
         }
@@ -3805,7 +3806,7 @@ void FillLockedZag::fill_surface_locked_zag (const Surface *                    
         ExPolygons region_exp = union_safety_offset_ex(it->second);
         ExPolygons exps       = intersection_ex(region_exp, zig_expas);
         zig_params.density    = it->first;
-        exps                  = intersection_ex(offset_ex(exps, overlap_threshold), surface->expolygon);
+        exps                  = intersection_ex(offset_ex_2(ExPolygons{exps}, overlap_threshold), surface->expolygon);
         for (ExPolygon &exp : exps) {
             zig_surface.expolygon = exp;
 

--- a/src/libslic3r/Fill/FillRectilinear.cpp
+++ b/src/libslic3r/Fill/FillRectilinear.cpp
@@ -405,7 +405,7 @@ public:
                 hole.rotate(angle);
         }
 
-        double miterLimit = DefaultMiterLimit;
+        double miterLimit = DefaultMiterLimit2;
         // for the infill pattern, don't cut the corners.
         // default miterLimt = 3
         //double miterLimit = 10.;
@@ -417,9 +417,9 @@ public:
 //        bool sticks_removed = 
         remove_sticks(polygons_src);
 //        if (sticks_removed) BOOST_LOG_TRIVIAL(error) << "Sticks removed!";
-        polygons_outer = aoffset1 == 0 ? to_polygons(polygons_src) : offset(polygons_src, float(aoffset1), ClipperLib::jtMiter, miterLimit);
+        polygons_outer = aoffset1 == 0 ? to_polygons(polygons_src) : offset_2(polygons_src, float(aoffset1), Clipper2Lib::JoinType::Miter, miterLimit);
         if (aoffset2 < 0)
-            polygons_inner = shrink(polygons_outer, float(aoffset1 - aoffset2), ClipperLib::jtMiter, miterLimit);
+            polygons_inner = shrink_2(polygons_outer, float(aoffset1 - aoffset2), Clipper2Lib::JoinType::Miter, miterLimit);
 		// Filter out contours with zero area or small area, contours with 2 points only.
         const double min_area_threshold = 0.01 * aoffset2 * aoffset2;
         remove_small(polygons_outer, min_area_threshold);

--- a/src/libslic3r/Fill/FillTpmsD.cpp
+++ b/src/libslic3r/Fill/FillTpmsD.cpp
@@ -3,7 +3,7 @@
 #include <vector>
 //#include <cstddef>
 
-#include "../ClipperUtils.hpp"
+#include "../Clipper2Utils.hpp"
 #include "../ShortestPath.hpp"
 #include "libslic3r/BoundingBox.hpp"
 #include "libslic3r/Fill/FillBase.hpp"
@@ -133,7 +133,7 @@ void FillTpmsD::_fill_surface_single(
 	    // Apply multiline offset if needed
     multiline_fill(polylines, params, spacing);
 
-	polylines = intersection_pl(std::move(polylines), expolygon);
+	polylines = intersection_pl_2(std::move(polylines), to_polygons(expolygon));
 
     if (! polylines.empty()) {
 		// Remove very small bits, but be careful to not remove infill lines connecting thin walls!

--- a/src/libslic3r/Fill/FillTpmsFK.cpp
+++ b/src/libslic3r/Fill/FillTpmsFK.cpp
@@ -1,4 +1,4 @@
-#include "../ClipperUtils.hpp"
+#include "../Clipper2Utils.hpp"
 #include "../MarchingSquares.hpp"
 #include "FillTpmsFK.hpp"
 #include <cmath>
@@ -139,7 +139,7 @@ void FillTpmsFK::_fill_surface_single(const FillParams&              params,
     multiline_fill(polylines, params, spacing);
 
     // Prune the lines within the expolygon.
-    polylines = intersection_pl(std::move(polylines), expolygon);
+    polylines = intersection_pl_2(std::move(polylines), to_polygons(expolygon));
 
     if (!polylines.empty()) {
         // Remove very small bits, but be careful to not remove infill lines connecting thin walls!


### PR DESCRIPTION
 # Migrate polygon clipping from Clipper to Clipper2 for sparse infill

This PR updates the sparse infill implementation to use Clipper2 polygon clipping and offsetting functions instead of the legacy Clipper (Clipper1) utilities. The goal is to improve performance and robustness during sparse infill generation by leveraging the newer, faster Clipper2.

🔧 What’s being replaced

The following legacy functions used throughout sparse infill patterns have been replaced with their Clipper2-based counterparts:

offset → offset_2

offset_ex → offset_ex_2

intersection_pl → intersection_pl_2

union_ex → union_ex_2

shrink → shrink_2

union_pt_chained_outside_in → union_pt_chained_outside_in_2

The purpose of this PR is to improve performance and expand the use of Clipper2, which is currently only used in the multiline function.
No functional changes are introduced.
