### PR TITLE
Set the layer height of the temperature tower to be a multiple of 10 mm.

### DIFF
--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -12734,6 +12734,17 @@ void Plater::calib_temp(const Calib_Params& params) {
     auto printer_config = &wxGetApp().preset_bundle->printers.get_edited_preset().config;
     auto filament_config = &wxGetApp().preset_bundle->filaments.get_edited_preset().config;
     auto start_temp = lround(params.start);
+    float nozzle_diameter = printer_config->option<ConfigOptionFloats>("nozzle_diameter")->get_at(0);
+    float layer_height;
+    //Orca: layer hieght must be divisor of 10mm 
+    if (nozzle_diameter <= 0.1f) {
+        layer_height = 0.05f;
+    } else if (nozzle_diameter <= 0.2f) {
+        layer_height = 0.1f;
+    } else {
+        layer_height = 0.2f;
+    }
+    
     printer_config->set_key_value("resonance_avoidance", new ConfigOptionBool{false});
     filament_config->set_key_value("nozzle_temperature_initial_layer", new ConfigOptionInts(1,(int)start_temp));
     filament_config->set_key_value("nozzle_temperature", new ConfigOptionInts(1,(int)start_temp));
@@ -12746,7 +12757,7 @@ void Plater::calib_temp(const Calib_Params& params) {
 
     auto print_config = &wxGetApp().preset_bundle->prints.get_edited_preset().config;
     print_config->set_key_value("enable_wrapping_detection", new ConfigOptionBool(false));
-
+    print_config->set_key_value("layer_height", new ConfigOptionFloat(layer_height));
     changed_objects({ 0 });
     wxGetApp().get_tab(Preset::TYPE_PRINT)->update_dirty();
     wxGetApp().get_tab(Preset::TYPE_FILAMENT)->update_dirty();


### PR DESCRIPTION
# Description

For a correct transition, the layer height for the temperature calibration tower must be a multiple of 10 mm, which is the height of each block. This PR sets appropriate layer heights.

# Screenshots/Recordings/Graphs
Before:
<img width="1092" height="1162" alt="image" src="https://github.com/user-attachments/assets/001d86d8-95aa-4fad-bcd3-fdecbde1f07a" />
After:
<img width="1182" height="1122" alt="image" src="https://github.com/user-attachments/assets/2133aa8d-3800-4a65-8e70-58cbacdfcea8" />




Fix #12281