### PR TITLE
feat: Add printer "ams" filaments to filament dropdown

### DIFF
--- a/src/slic3r/GUI/DeviceCore/DevManager.cpp
+++ b/src/slic3r/GUI/DeviceCore/DevManager.cpp
@@ -858,7 +858,9 @@ namespace Slic3r
     {
         if (MachineObject* obj_ = get_selected_machine()) {
             GUI::wxGetApp().sidebar().update_sync_status(obj_);
-            if(m_agent->get_filament_sync_mode() == FilamentSyncMode::subscription)
+            // Load AMS list for both subscription and pull-mode agents
+            auto sync_mode = m_agent->get_filament_sync_mode();
+            if(sync_mode == FilamentSyncMode::subscription || sync_mode == FilamentSyncMode::pull)
             {
                 GUI::wxGetApp().sidebar().load_ams_list(obj_);
             }

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -484,6 +484,7 @@ struct Sidebar::priv
     ScalableButton* m_printer_icon = nullptr;
     ScalableButton* m_printer_connect = nullptr;
     ScalableButton* m_printer_bbl_sync = nullptr;
+    ScalableButton* m_printer_sync = nullptr;  // Sync button for non-BBL printers with pull-mode
     ScalableButton* m_printer_setting = nullptr;
     wxStaticText *  m_text_printer_settings = nullptr;
     wxPanel* m_panel_printer_content = nullptr;
@@ -576,6 +577,15 @@ void Sidebar::priv::layout_printer(bool isBBL, bool isDual)
     m_printer_connect->Show(!isBBL);
     //btn_sync_printer->Show(isBBL);
     m_printer_bbl_sync->Show(isBBL);
+
+    // Show sync button for non-BBL printers with pull-mode filament sync
+    bool has_pull_mode_agent = false;
+    if (auto* dev_manager = GUI::wxGetApp().getDeviceManager()) {
+        if (auto* agent = dev_manager->get_agent()) {
+            has_pull_mode_agent = agent->get_filament_sync_mode() == FilamentSyncMode::pull;
+        }
+    }
+    m_printer_sync->Show(!isBBL && has_pull_mode_agent);
 
     // ORCA show plate type combo box only when its supported
     PresetBundle &preset_bundle = *wxGetApp().preset_bundle;
@@ -1645,6 +1655,18 @@ Sidebar::Sidebar(Plater *parent)
             deal_btn_sync();
         });
 
+        // Sync button for non-BBL printers with pull-mode filament sync
+        p->m_printer_sync = new ScalableButton(p->m_panel_printer_title, wxID_ANY, "printer_sync");
+        p->m_printer_sync->SetToolTip(_L("Refresh filament information from printer"));
+        p->m_printer_sync->Bind(wxEVT_BUTTON, [this](wxCommandEvent &e) {
+            // Reload AMS list from currently selected device
+            if (auto* dev_manager = GUI::wxGetApp().getDeviceManager()) {
+                if (MachineObject* obj = dev_manager->get_selected_machine()) {
+                    load_ams_list(obj);
+                }
+            }
+        });
+
         p->m_printer_setting = new ScalableButton(p->m_panel_printer_title, wxID_ANY, "settings");
         p->m_printer_setting->Bind(wxEVT_BUTTON, [this](wxCommandEvent &e) {
             // p->editing_filament = -1;
@@ -1660,6 +1682,7 @@ Sidebar::Sidebar(Plater *parent)
         h_sizer_title->AddStretchSpacer();
         h_sizer_title->Add(p->m_printer_connect , 0, wxALIGN_CENTER | wxRIGHT, FromDIP(SidebarProps::WideSpacing())); // used larger margin to prevent accidental clicks
         h_sizer_title->Add(p->m_printer_bbl_sync, 0, wxALIGN_CENTER | wxRIGHT, FromDIP(SidebarProps::WideSpacing())); // used larger margin to prevent accidental clicks
+        h_sizer_title->Add(p->m_printer_sync, 0, wxALIGN_CENTER | wxRIGHT, FromDIP(SidebarProps::WideSpacing())); // sync for non-BBL printers
         h_sizer_title->Add(p->m_printer_setting, 0, wxALIGN_CENTER);
         h_sizer_title->AddSpacer(FromDIP(SidebarProps::TitlebarMargin()));
         h_sizer_title->SetMinSize(-1, 3 * em);
@@ -2638,6 +2661,26 @@ void Sidebar::update_presets(Preset::Type preset_type)
         if (GUI::wxGetApp().plater())
             GUI::wxGetApp().plater()->update_machine_sync_status();
 
+        // Reload AMS filament list for non-BBL devices with pull-mode when switching presets
+        // BBL devices handle their own sync, but non-BBL devices need explicit reload
+        if (auto* dev_manager = GUI::wxGetApp().getDeviceManager()) {
+            MachineObject* selected_device = dev_manager->get_selected_machine();
+            if (selected_device && dev_manager->get_agent()) {
+                // Keep filaments for non-BBL (pull-mode) devices
+                if (dev_manager->get_agent()->get_filament_sync_mode() == FilamentSyncMode::pull) {
+                    load_ams_list(selected_device);
+                } else {
+                    // BBL device (subscription mode), clear list
+                    load_ams_list(nullptr);
+                }
+            } else {
+                // No device selected, clear AMS list
+                load_ams_list(nullptr);
+            }
+        } else {
+            load_ams_list(nullptr);
+        }
+
         Layout();
 
         break;
@@ -2780,6 +2823,7 @@ void Sidebar::msw_rescale()
     p->m_printer_icon->msw_rescale();
     p->m_printer_connect->msw_rescale();
     p->m_printer_bbl_sync->msw_rescale();
+    p->m_printer_sync->msw_rescale();
     p->m_printer_icon->msw_rescale();
     p->m_printer_setting->msw_rescale();
 
@@ -2886,6 +2930,7 @@ void Sidebar::sys_color_changed()
 #endif
     //p->btn_sync_printer->SetIcon("printer_sync");
     p->m_printer_bbl_sync->msw_rescale();
+    p->m_printer_sync->msw_rescale();
     p->m_printer_connect->msw_rescale();
     // for (wxWindow* btn : std::vector<wxWindow*>{ p->btn_reslice, p->btn_export_gcode })
     //    wxGetApp().UpdateDarkUI(btn, true);

--- a/src/slic3r/GUI/PresetComboBoxes.cpp
+++ b/src/slic3r/GUI/PresetComboBoxes.cpp
@@ -46,6 +46,7 @@
 #include "wxExtensions.hpp"
 
 #include "DeviceCore/DevManager.h"
+#include "../Utils/IPrinterAgent.hpp"
 
 // A workaround for a set of issues related to text fitting into gtk widgets:
 #if defined(__WXGTK20__) || defined(__WXGTK3__)
@@ -498,7 +499,18 @@ bool PresetComboBox::add_ams_filaments(std::string selected, bool alias_name)
 {
     bool selected_in_ams      = false;
     bool is_bbl_vendor_preset = m_preset_bundle->is_bbl_vendor();
-    if (is_bbl_vendor_preset && !m_preset_bundle->filament_ams_list.empty()) {
+
+    // Also allow pull-mode printer agents (e.g., Moonraker) to show AMS filaments
+    bool has_pull_mode_agent = false;
+    auto* dev_manager = wxGetApp().getDeviceManager();
+    if (dev_manager) {
+        auto* agent = dev_manager->get_agent();
+        if (agent && agent->get_filament_sync_mode() == FilamentSyncMode::pull) {
+            has_pull_mode_agent = true;
+        }
+    }
+
+    if ((is_bbl_vendor_preset || has_pull_mode_agent) && !m_preset_bundle->filament_ams_list.empty()) {
         bool dual_extruder   = (m_preset_bundle->filament_ams_list.begin()->first & 0x10000) == 0;
         set_label_marker(Append(dual_extruder ? _L("Left filaments") : _L("AMS filaments"), wxNullBitmap, DD_ITEM_STYLE_SPLIT_ITEM));
         m_first_ams_filament = GetCount();


### PR DESCRIPTION
# Description

Enables the filaments pulled from moonraker to display in the filaments drop down same as bambu has.

# Screenshots/Recordings/Graphs

![Screen Recording 2026-02-16 at 8 51 08 AM](https://github.com/user-attachments/assets/b97baa82-8f3c-43e3-bdc7-ac3ecb4bb1e2)


## Tests

As shown in recording, verified filaments are displayed and can be sync'd by pressing the refresh button.

Also tested switching between different printers and I had initially observed the "ams filaments" would remain while switching presets, so there were some additional fixes i needed to do to get those to clear out when switching.