### PR TITLE
MultiTool RepRap, wait for active tool temperature to normalize only.

### DIFF
--- a/src/libslic3r/GCodeWriter.cpp
+++ b/src/libslic3r/GCodeWriter.cpp
@@ -138,7 +138,7 @@ std::string GCodeWriter::set_temperature(unsigned int temperature, GCodeFlavor f
                 gcode << " P" << tool;
             }
         }
-        gcode << "; wait for temperature to be reached\n ";
+        gcode << "; wait for temperature to be reached\n";
     }
 
 

--- a/src/libslic3r/GCodeWriter.cpp
+++ b/src/libslic3r/GCodeWriter.cpp
@@ -131,8 +131,16 @@ std::string GCodeWriter::set_temperature(unsigned int temperature, GCodeFlavor f
     }
     gcode << " ; " << comment << "\n";
 
-    if ((flavor == gcfTeacup || flavor == gcfRepRapFirmware) && wait)
-        gcode << "M116 ; wait for temperature to be reached\n";
+    if ((flavor == gcfTeacup || flavor == gcfRepRapFirmware) && wait) {
+        gcode << "M116";
+        if (tool != -1) {
+            if (flavor == gcfRepRapFirmware) {
+                gcode << " P" << tool;
+            }
+        }
+        gcode << "; wait for temperature to be reached\n ";
+    }
+
 
     return gcode.str();
 }


### PR DESCRIPTION
With Multi Tool RepRap printers, _set_temperature_ is using `M116` without arguments  which results in waiting for inactive heater temperatures to normalise. This makes for excessive idle time as inactive tools are affecting the resumption of printing with the active tool. 

The wait time is exacerbated in setups where inactive extruders use different temperatures when IDLE vs ACTIVE to prevent oozing. 

# Description

For single tool setups or when no indexed tool is set, it will just use M116 as before.
If a tool is active, append the tool heater to the M116 command so the printer only waits for the active tool to reach operating temperature.

# Screenshots/Recordings/Graphs

N/A

## Tests

I have generated Gcode for my RRF based machine with multi tools and with single tools to see that it falls back accordingly. 
