### PR TITLE
Opensuse tumbleweed dependency script

### DIFF
--- a/build_linux.sh
+++ b/build_linux.sh
@@ -146,6 +146,8 @@ DISTRIBUTION_LIKE=$(awk -F= '/^ID_LIKE=/ {print $2}' /etc/os-release | tr -d '"'
 # Check for direct distribution match to Ubuntu/Debian
 if [ "${DISTRIBUTION}" == "ubuntu" ] || [ "${DISTRIBUTION}" == "linuxmint" ] ; then
     DISTRIBUTION="debian"
+elif [ "${DISTRIBUTION}" == "opensuse-tumbleweed" ] ; then
+    DISTRIBUTION="opensuse-tumbleweed"
 # Check if distribution is Debian/Ubuntu-like based on ID_LIKE
 elif [[ "${DISTRIBUTION_LIKE}" == *"debian"* ]] || [[ "${DISTRIBUTION_LIKE}" == *"ubuntu"* ]] ; then
     DISTRIBUTION="debian"

--- a/scripts/linux.d/opensuse-tumbleweed
+++ b/scripts/linux.d/opensuse-tumbleweed
@@ -1,8 +1,10 @@
 #!/bin/bash
-# these are the Arch Linux specific build functions
+# these are the openSUSE Tumbleweed Linux specific build functions
 
 # Additional Dev packages for OrcaSlicer
 export REQUIRED_DEV_PACKAGES=(
+    autoconf
+    automake
     cmake
     curl
     dbus-1
@@ -17,15 +19,17 @@ export REQUIRED_DEV_PACKAGES=(
     gtk3-devel
     libcurl-devel
     libmspack-devel
-    libsecret-devel
-    libspnav-devel
     libopenssl-devel
     libquadmath-devel
+    libsecret-devel
+    libspnav-devel
+    libtool
+    nanum-fonts
     ninja
     texinfo
-    wget
     webkit2gtk3-minibrowser
     webkit2gtk3-devel
+    wget
     wayland-protocols-devel
 )
 
@@ -38,11 +42,11 @@ then
     done
 
     if [[ "${#NEEDED_PKGS[*]}" -gt 0 ]]; then
-        sudo zypper refresh && zypper in -y "${NEEDED_PKGS[@]}"
+        sudo zypper refresh && sudo zypper in -y "${NEEDED_PKGS[@]}"
     fi
     echo -e "done\n"
     exit 0
 fi
 
 export FOUND_GTK3_DEV
-FOUND_GTK3_DEV=$(zypper se -ix gtk3-devel)
+FOUND_GTK3_DEV=$(sudo zypper se -ix gtk3-devel)

--- a/scripts/linux.d/opensuse-tumbleweed
+++ b/scripts/linux.d/opensuse-tumbleweed
@@ -1,0 +1,48 @@
+#!/bin/bash
+# these are the Arch Linux specific build functions
+
+# Additional Dev packages for OrcaSlicer
+export REQUIRED_DEV_PACKAGES=(
+    cmake
+    curl
+    dbus-1
+    eglexternalplatform-devel
+    kf6-extra-cmake-modules
+    file
+    gettext-runtime
+    git
+    glew-devel
+    gstreamer-devel
+    gstreamermm-devel
+    gtk3-devel
+    libcurl-devel
+    libmspack-devel
+    libsecret-devel
+    libspnav-devel
+    libopenssl-devel
+    libquadmath-devel
+    ninja
+    texinfo
+    wget
+    webkit2gtk3-minibrowser
+    webkit2gtk3-devel
+    wayland-protocols-devel
+)
+
+if [[ -n "$UPDATE_LIB" ]]
+then
+    echo -n -e "Updating linux ...\n"
+    NEEDED_PKGS=()
+    for PKG in "${REQUIRED_DEV_PACKAGES[@]}"; do
+        sudo zypper se -ix "${PKG}" > /dev/null || NEEDED_PKGS+=("${PKG}")
+    done
+
+    if [[ "${#NEEDED_PKGS[*]}" -gt 0 ]]; then
+        sudo zypper refresh && zypper in -y "${NEEDED_PKGS[@]}"
+    fi
+    echo -e "done\n"
+    exit 0
+fi
+
+export FOUND_GTK3_DEV
+FOUND_GTK3_DEV=$(zypper se -ix gtk3-devel)


### PR DESCRIPTION
# Description

The official AppImage was crashing constantly on my openSUSE tumbleweed system which necessitated building from source. This is literally my first PR ever, so apologies if I've done it incorrectly.
- Added dependency script for building on opensuse-tumbleweed in /scripts/linux.d
- Modified build_linux.sh to target new script on opensuse-tumbleweed systems

## Tests

Have successfully built on two of my personal systems, as well as a fresh install of tumbleweed.

## Quirks

The `-i` option to build the appimage didn't work on either system I tested, due to an issue where the appimagetool hangs while downloading the runtime. I was able to manually download the runtime and build the appimage using the `--runtime-file` option.
