### PR TITLE
Change PrintParams struct to define the values of boolean attributes explicitly

### DIFF
--- a/src/slic3r/Utils/bambu_networking.hpp
+++ b/src/slic3r/Utils/bambu_networking.hpp
@@ -215,18 +215,18 @@ struct PrintParams_Legacy {
 
     /* access options */
     std::string     dev_ip;
-    bool            use_ssl_for_ftp;
-    bool            use_ssl_for_mqtt;
+    bool            use_ssl_for_ftp{ false };
+    bool            use_ssl_for_mqtt{ false };
     std::string     username;
     std::string     password;
 
     /*user options */
-    bool            task_bed_leveling;      /* bed leveling of task */
-    bool            task_flow_cali;         /* flow calibration of task */
-    bool            task_vibration_cali;    /* vibration calibration of task */
-    bool            task_layer_inspect;     /* first layer inspection of task */
-    bool            task_record_timelapse;  /* record timelapse of task */
-    bool            task_use_ams;
+    bool            task_bed_leveling{ false };      /* bed leveling of task */
+    bool            task_flow_cali{ false };         /* flow calibration of task */
+    bool            task_vibration_cali{ false };    /* vibration calibration of task */
+    bool            task_layer_inspect{ false };     /* first layer inspection of task */
+    bool            task_record_timelapse{ false };  /* record timelapse of task */
+    bool            task_use_ams{ false };
     std::string     task_bed_type;
     std::string     extra_options;
 };
@@ -260,25 +260,25 @@ struct PrintParams {
 
     /* access options */
     std::string     dev_ip;
-    bool            use_ssl_for_ftp;
-    bool            use_ssl_for_mqtt;
+    bool            use_ssl_for_ftp{ false };
+    bool            use_ssl_for_mqtt{ false };
     std::string     username;
     std::string     password;
 
     /*user options */
-    bool            task_bed_leveling;      /* bed leveling of task */
-    bool            task_flow_cali;         /* flow calibration of task */
-    bool            task_vibration_cali;    /* vibration calibration of task */
-    bool            task_layer_inspect;     /* first layer inspection of task */
-    bool            task_record_timelapse;  /* record timelapse of task */
-    bool            task_use_ams;
+    bool            task_bed_leveling{ false };      /* bed leveling of task */
+    bool            task_flow_cali{ false };         /* flow calibration of task */
+    bool            task_vibration_cali{ false };    /* vibration calibration of task */
+    bool            task_layer_inspect{ false };     /* first layer inspection of task */
+    bool            task_record_timelapse{ false };  /* record timelapse of task */
+    bool            task_use_ams{ false };
     std::string     task_bed_type;
     std::string     extra_options;
     int             auto_bed_leveling{ 0 };
     int             auto_flow_cali{ 0 };
     int             auto_offset_cali{ 0 };
-    bool            task_ext_change_assist;
-    bool            try_emmc_print;
+    bool            task_ext_change_assist{ false };
+    bool            try_emmc_print{ false };
 };
 
 struct TaskQueryParams


### PR DESCRIPTION
# Description

When a struct contains `bool` attributes without an explicit default value, the value may become uninitialized.
The `PrintParams` gets passed as a value in may places (using `const &` instead is probably the right thing to do, but the fix would be relatively large) and that triggers creating a copy. I'm not sure how the compiler behaves in this case.

This may cause crashes such as:
- https://github.com/OrcaSlicer/OrcaSlicer/issues/12382 
- https://github.com/OrcaSlicer/OrcaSlicer/issues/12250
- https://github.com/OrcaSlicer/OrcaSlicer/issues/12348
- https://github.com/OrcaSlicer/OrcaSlicer/issues/12342

I haven't tested the change, because OrcaSlicer doesn't compile on my system (the libs are too new),
but I'm confident that this change is generally a move in the right direction and should be merged regardless if it fixes the problem or not.
