### PR TITLE
Display number of tool changes after slicing #12464

### DIFF
--- a/src/slic3r/GUI/GCodeViewer.cpp
+++ b/src/slic3r/GUI/GCodeViewer.cpp
@@ -3875,6 +3875,14 @@ void GCodeViewer::render_legend(float &legend_height, int canvas_width, int canv
         ::sprintf(buf, "%d", m_print_statistics.total_filament_changes);
         imgui.text(buf);
 
+        //display tool change times
+        ImGui::Dummy({window_padding, window_padding});
+        ImGui::SameLine();
+        imgui.text(_u8L("Tool changes") + ":");
+        ImGui::SameLine();
+        ::sprintf(buf, "%d", m_print_statistics.total_extruder_changes);
+        imgui.text(buf);
+
         //BBS display cost
         ImGui::Dummy({ window_padding, window_padding });
         ImGui::SameLine();


### PR DESCRIPTION
# Description

Implemented enhancement #12464 to show number of tool changes after slicing

# Screenshots/Recordings/Graphs

<img width="292" height="262" alt="image" src="https://github.com/user-attachments/assets/015b73d8-9938-4887-81c8-3f7cfe67c390" />

## Tests

Sliced a model for a tool changer and reviewed the count is displayed
