### PR TITLE
Fix: Fixed the values comparison for Float-based config options

### DIFF
--- a/src/slic3r/GUI/Field.cpp
+++ b/src/slic3r/GUI/Field.cpp
@@ -883,13 +883,18 @@ bool TextCtrl::value_was_changed()
     case coInt:
         return boost::any_cast<int>(m_value) != boost::any_cast<int>(val);
     case coPercent:
-    case coPercents:
+    case coPercents: {
+        if (m_opt.nullable && std::isnan(boost::any_cast<double>(m_value)) &&
+                              std::isnan(boost::any_cast<double>(val)))
+            return false;
+        return boost::any_cast<double>(m_value) != boost::any_cast<double>(val);
+    }
     case coFloats:
     case coFloat: {
         if (m_opt.nullable && std::isnan(boost::any_cast<double>(m_value)) &&
                               std::isnan(boost::any_cast<double>(val)))
             return false;
-        return boost::any_cast<double>(m_value) != boost::any_cast<double>(val);
+        return !is_approx(boost::any_cast<double>(m_value), boost::any_cast<double>(val));
     }
     case coString:
     case coStrings:


### PR DESCRIPTION
# Description

Continuation of https://github.com/OrcaSlicer/OrcaSlicer/pull/11915

Fixes this UI bug (no issue created) - https://github.com/OrcaSlicer/OrcaSlicer/pull/11925#issuecomment-3954837625

The problem is that float values in config options are being compared as-is, which is the wrong approach due to rounding errors. So their values should be compared by using the `is_approx` function. The issue can only be noticed in UI.

Changes in this PR cover all float-based config option types. One overridden function was missing; it was added and made the same way as in the `ConfigOptionFloatOrPercent` class.

# Recordings

## Before

![ui_float_values_bug](https://github.com/user-attachments/assets/6b0035a5-ab40-4a9b-9d96-a297ae9ff92c)

## After

![ui_float_values_fixed](https://github.com/user-attachments/assets/f0dac89b-ea36-4f72-9243-e2b7964b803f)

# Tests

The best way to test it is to use this PR with https://github.com/OrcaSlicer/OrcaSlicer/pull/11925, since there is a new setting with a very small default float value.

@RF47 FYI