### PR TITLE
Convert draft_shield from enum to checkbox

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -5072,7 +5072,7 @@ LayerResult GCode::process_layer(
         if (print.config().skirt_type == stPerObject &&
             print.config().print_sequence == PrintSequence::ByObject &&
             !layer.object()->object_skirt().empty() &&
-            ((layer.id() < print.config().skirt_height || print.config().draft_shield == DraftShield::dsEnabled))
+            ((layer.id() < print.config().skirt_height || print.config().draft_shield.value))
            )
         {
             for (InstanceToPrint& instance_to_print : instances_to_print) {
@@ -5109,7 +5109,7 @@ LayerResult GCode::process_layer(
                     !instance_to_print.print_object.object_skirt().empty() &&
                     print.config().print_sequence == PrintSequence::ByLayer
                     &&
-                    (layer.id() < print.config().skirt_height || print.config().draft_shield == DraftShield::dsEnabled))
+                    (layer.id() < print.config().skirt_height || print.config().draft_shield.value))
                 {
                     if (first_layer)
                         m_skirt_done.clear();

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -567,7 +567,7 @@ bool Print::has_infinite_skirt() const
     // Orca: unclear why (m_config.ooze_prevention && this->extruders().size() > 1) logic is here, removed.
     // return (m_config.draft_shield == dsEnabled && m_config.skirt_loops > 0) || (m_config.ooze_prevention && this->extruders().size() > 1);
 
-    return (m_config.draft_shield == dsEnabled && m_config.skirt_loops > 0);
+    return (m_config.draft_shield.value && m_config.skirt_loops > 0);
 }
 
 bool Print::has_skirt() const
@@ -2293,7 +2293,7 @@ void Print::process(long long *time_cost_with_cache, bool use_cache)
         m_first_layer_convex_hull.points.clear();
         for (PrintObject *object : m_objects)  object->m_skirt.clear();
 
-        const bool draft_shield = config().draft_shield != dsDisabled;
+        const bool draft_shield = config().draft_shield.value;
 
         if (this->has_skirt() && draft_shield) {
             // In case that draft shield is active, generate skirt first so brim
@@ -2541,7 +2541,7 @@ void Print::_make_skirt()
     append(points, this->first_layer_wipe_tower_corners());
 
     // Unless draft shield is enabled, include all brims as well.
-    if (config().draft_shield == dsDisabled)
+    if (!config().draft_shield.value)
         append(points, m_first_layer_convex_hull.points);
 
     if (points.size() < 3)
@@ -3488,7 +3488,7 @@ std::tuple<float, float> Print::object_skirt_offset(double margin_height) const
 
     if (is_all_objects_are_short())
         object_skirt_offset = config().skirt_distance + object_skirt_witdh;
-    else if (config().draft_shield == dsEnabled || config().skirt_height * max_layer_height > config().nozzle_height - margin_height)
+    else if (config().draft_shield.value || config().skirt_height * max_layer_height > config().nozzle_height - margin_height)
         object_skirt_offset = config().skirt_distance + line_width;
     else if (config().skirt_distance + object_skirt_witdh > config().extruder_clearance_radius/2)
         object_skirt_offset = (config().skirt_distance + object_skirt_witdh - config().extruder_clearance_radius/2);

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -413,11 +413,6 @@ static const t_config_enum_values s_keys_map_SkirtType = {
 };
 CONFIG_OPTION_ENUM_DEFINE_STATIC_MAPS(SkirtType)
 
-static const t_config_enum_values s_keys_map_DraftShield = {
-    { "disabled", dsDisabled },
-    { "enabled",  dsEnabled  }
-};
-CONFIG_OPTION_ENUM_DEFINE_STATIC_MAPS(DraftShield)
 
 static const t_config_enum_values s_keys_map_ForwardCompatibilitySubstitutionRule = {
     { "disable",        ForwardCompatibilitySubstitutionRule::Disable },
@@ -5235,20 +5230,15 @@ void PrintConfigDef::init_fff_params()
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionBool(false));
 
-    def = this->add("draft_shield", coEnum);
+    def = this->add("draft_shield", coBool);
     def->label = L("Draft shield");
     def->tooltip = L("A draft shield is useful to protect an ABS or ASA print from warping and detaching from print bed due to wind draft. "
                      "It is usually needed only with open frame printers, i.e. without an enclosure.\n\n"
                      "Enabled = skirt is as tall as the highest printed object. Otherwise 'Skirt height' is used.\n"
                      "Note: With the draft shield active, the skirt will be printed at skirt distance from the object. "
                      "Therefore, if brims are active it may intersect with them. To avoid this, increase the skirt distance value.\n");
-    def->enum_keys_map = &ConfigOptionEnum<DraftShield>::get_enum_values();
-    def->enum_values.push_back("disabled");
-    def->enum_values.push_back("enabled");
-    def->enum_labels.push_back(L("Disabled"));
-    def->enum_labels.push_back(L("Enabled"));
     def->mode = comAdvanced;
-    def->set_default_value(new ConfigOptionEnum<DraftShield>(dsDisabled));
+    def->set_default_value(new ConfigOptionBool(false));
 
     def = this->add("skirt_type", coEnum);
     def->label = L("Skirt type");
@@ -7612,8 +7602,11 @@ void PrintConfigDef::handle_legacy(t_config_option_key &opt_key, std::string &va
         value = "0";
     } else if (opt_key == "counterbole_hole_bridging") {
         opt_key = "counterbore_hole_bridging";
-    } else if (opt_key == "draft_shield" && value == "limited") {
-        value = "disabled";
+    } else if (opt_key == "draft_shield") {
+        if (value == "disabled" || value == "limited")
+            value = "0";
+        else if (value == "enabled")
+            value = "1";
     } else if ((opt_key == "sparse_infill_pattern"         ||
                 opt_key == "top_surface_pattern"           ||
                 opt_key == "bottom_surface_pattern"        ||
@@ -10808,7 +10801,7 @@ bool has_skirt(const DynamicPrintConfig& cfg)
     auto opt_skirt_loops = cfg.option("skirt_loops");
     auto opt_draft_shield = cfg.option("draft_shield");
     return (opt_skirt_height && opt_skirt_height->getInt() > 0 && opt_skirt_loops && opt_skirt_loops->getInt() > 0)
-        || (opt_draft_shield && opt_draft_shield->getInt() != dsDisabled);
+        || (opt_draft_shield && opt_draft_shield->getBool());
 }
 float get_real_skirt_dist(const DynamicPrintConfig& cfg) {
     return has_skirt(cfg) ? cfg.opt_float("skirt_distance") : 0;

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -270,9 +270,6 @@ enum SkirtType {
     stCombined, stPerObject
 };
 
-enum DraftShield {
-    dsDisabled, dsEnabled
-};
 
 enum class PerimeterGeneratorType
 {
@@ -507,7 +504,7 @@ CONFIG_OPTION_ENUM_DECLARE_STATIC_MAPS(BrimType)
 CONFIG_OPTION_ENUM_DECLARE_STATIC_MAPS(TimelapseType)
 CONFIG_OPTION_ENUM_DECLARE_STATIC_MAPS(BedType)
 CONFIG_OPTION_ENUM_DECLARE_STATIC_MAPS(SkirtType)
-CONFIG_OPTION_ENUM_DECLARE_STATIC_MAPS(DraftShield)
+
 CONFIG_OPTION_ENUM_DECLARE_STATIC_MAPS(ForwardCompatibilitySubstitutionRule)
 CONFIG_OPTION_ENUM_DECLARE_STATIC_MAPS(GCodeThumbnailsFormat)
 CONFIG_OPTION_ENUM_DECLARE_STATIC_MAPS(CounterboreHoleBridgingOption)
@@ -1438,7 +1435,7 @@ PRINT_CONFIG_CLASS_DERIVED_DEFINE(
     ((ConfigOptionInt,                other_layers_print_sequence_nums))
     ((ConfigOptionBools,              slow_down_for_layer_cooling))
     ((ConfigOptionInts,               close_fan_the_first_x_layers))
-    ((ConfigOptionEnum<DraftShield>,  draft_shield))
+    ((ConfigOptionBool,              draft_shield))
     ((ConfigOptionFloat,              extruder_clearance_height_to_rod))//BBs
     ((ConfigOptionFloat,              extruder_clearance_height_to_lid))//BBS
     ((ConfigOptionFloat,              extruder_clearance_radius))

--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -698,7 +698,7 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig *config, co
     }
 
     bool have_skirt = config->opt_int("skirt_loops") > 0;
-    toggle_field("skirt_height", have_skirt && config->opt_enum<DraftShield>("draft_shield") != dsEnabled);
+    toggle_field("skirt_height", have_skirt && !config->opt_bool("draft_shield"));
     toggle_line("single_loop_draft_shield", have_skirt); // ORCA: Display one wall if skirt enabled
     for (auto el : {"skirt_type", "min_skirt_length", "skirt_distance", "skirt_start_angle", "skirt_speed", "draft_shield"})
         toggle_field(el, have_skirt);


### PR DESCRIPTION
## Summary
- Convert `draft_shield` from a two-value enum (`disabled`/`enabled`) to a simple `coBool` checkbox
- Removes unnecessary enum machinery (`DraftShield` enum, static maps)
- Adds legacy migration in `handle_legacy()`: `"disabled"`/`"limited"` -> `"0"`, `"enabled"` -> `"1"`

## Changes
- `PrintConfig.hpp`: Remove `DraftShield` enum, change config option type to `ConfigOptionBool`
- `PrintConfig.cpp`: Remove enum static maps, update definition from `coEnum` to `coBool`, update legacy handler, update `has_skirt()` helper
- `Print.cpp`: Replace all `== dsEnabled` / `!= dsDisabled` comparisons with `.value` / `!.value`
- `GCode.cpp`: Same enum-to-bool replacements
- `ConfigManipulation.cpp`: Replace `opt_enum<DraftShield>` with `opt_bool`

## Test plan
- [ ] CI build passes
- [ ] Draft shield checkbox toggles correctly in UI
- [ ] Loading legacy projects with `draft_shield: "disabled"` / `"enabled"` / `"limited"` migrates correctly
- [ ] Skirt height field disables when draft shield is checked

🤖 Generated with [Claude Code](https://claude.com/claude-code)