### PR TITLE
Linux: scope Bambu liveview fix to sink timing

### DIFF
--- a/src/slic3r/GUI/wxMediaCtrl2.cpp
+++ b/src/slic3r/GUI/wxMediaCtrl2.cpp
@@ -52,18 +52,6 @@ static void tune_live_preview_sink(GstElement *element)
     set_int64_property_if_present(obj, "max-lateness", -1);
 }
 
-static bool has_avdec_h264_decoder()
-{
-    static const bool has_decoder = []() {
-        GstElementFactory *factory = gst_element_factory_find("avdec_h264");
-        if (!factory)
-            return false;
-        gst_object_unref(factory);
-        return true;
-    }();
-    return has_decoder;
-}
-
 static bool is_bambu_uri_for_playbin(GstElement *playbin)
 {
     if (!playbin)
@@ -81,58 +69,6 @@ static bool is_bambu_uri_for_playbin(GstElement *playbin)
     return is_bambu;
 }
 
-static gint on_uridecodebin_autoplug_select(GstElement * /*decodebin*/, GstPad * /*pad*/, GstCaps * /*caps*/, GstElementFactory *factory, gpointer user_data)
-{
-    auto *playbin = GST_ELEMENT(user_data);
-    if (!factory)
-        return 0; // GST_AUTOPLUG_SELECT_TRY
-
-    const gchar *factory_name = gst_plugin_feature_get_name(GST_PLUGIN_FEATURE(factory));
-    const bool is_bambu = is_bambu_uri_for_playbin(playbin);
-    if (!is_bambu)
-        return 0; // GST_AUTOPLUG_SELECT_TRY
-    if (!factory_name)
-        return 0;
-
-    // Only skip NVIDIA HW decode if a robust software fallback (libav) exists in this runtime.
-    const bool can_fallback_to_sw = has_avdec_h264_decoder();
-
-    // For Bambu live preview, skip NVIDIA HW decoders to avoid CUDAMemory-only output negotiation.
-    if (g_strcmp0(factory_name, "nvh264dec") == 0 || g_strcmp0(factory_name, "nvh265dec") == 0) {
-        if (!can_fallback_to_sw)
-            return 0; // Keep stream working rather than black video.
-        return 2; // GST_AUTOPLUG_SELECT_SKIP
-    }
-
-    return 0;
-}
-
-static void maybe_attach_bambu_decoder_filter(GstElement *playbin, GstElement *element)
-{
-    if (!playbin || !element)
-        return;
-
-    auto *factory = gst_element_get_factory(element);
-    if (!factory)
-        return;
-    const gchar *factory_name = gst_plugin_feature_get_name(GST_PLUGIN_FEATURE(factory));
-    if (!factory_name)
-        return;
-    const bool is_uri_decodebin = g_str_has_prefix(factory_name, "uridecodebin");
-    const bool is_decodebin = g_str_has_prefix(factory_name, "decodebin");
-    if (!is_uri_decodebin && !is_decodebin)
-        return;
-
-    static GQuark attached_quark = 0;
-    if (attached_quark == 0)
-        attached_quark = g_quark_from_static_string("orca-bambu-autoplug-filter-attached");
-    if (g_object_get_qdata(G_OBJECT(element), attached_quark) != nullptr)
-        return;
-
-    g_signal_connect(element, "autoplug-select", G_CALLBACK(on_uridecodebin_autoplug_select), playbin);
-    g_object_set_qdata(G_OBJECT(element), attached_quark, GINT_TO_POINTER(1));
-}
-
 static void on_playbin_deep_element_added(GstBin *playbin, GstBin * /*sub_bin*/, GstElement *element, gpointer /*user_data*/)
 {
     auto *playbin_element = GST_ELEMENT(playbin);
@@ -141,7 +77,6 @@ static void on_playbin_deep_element_added(GstBin *playbin, GstBin * /*sub_bin*/,
 
     if (GST_IS_BASE_SINK(element))
         tune_live_preview_sink(element);
-    maybe_attach_bambu_decoder_filter(playbin_element, element);
 }
 #endif
 

--- a/src/slic3r/GUI/wxMediaCtrl2.cpp
+++ b/src/slic3r/GUI/wxMediaCtrl2.cpp
@@ -19,6 +19,119 @@ class WXDLLIMPEXP_MEDIA
 public:
     GstElement *m_playbin; // GStreamer media element
 };
+
+static bool has_gobject_property(GObject *obj, const char *property_name)
+{
+    if (!obj || !property_name)
+        return false;
+    return g_object_class_find_property(G_OBJECT_GET_CLASS(obj), property_name) != nullptr;
+}
+
+static void set_bool_property_if_present(GObject *obj, const char *property_name, gboolean value)
+{
+    if (has_gobject_property(obj, property_name))
+        g_object_set(obj, property_name, value, NULL);
+}
+
+static void set_int64_property_if_present(GObject *obj, const char *property_name, gint64 value)
+{
+    if (has_gobject_property(obj, property_name))
+        g_object_set(obj, property_name, value, NULL);
+}
+
+static void tune_live_preview_sink(GstElement *element)
+{
+    if (!element)
+        return;
+
+    GObject *obj = G_OBJECT(element);
+    // Live preview should not accumulate lateness or drop frames for A/V sync.
+    set_bool_property_if_present(obj, "sync", FALSE);
+    set_bool_property_if_present(obj, "qos", FALSE);
+    set_int64_property_if_present(obj, "max-lateness", -1);
+}
+
+static bool has_avdec_h264_decoder()
+{
+    GstElementFactory *factory = gst_element_factory_find("avdec_h264");
+    if (!factory)
+        return false;
+    gst_object_unref(factory);
+    return true;
+}
+
+static bool is_bambu_uri_for_playbin(GstElement *playbin)
+{
+    if (!playbin)
+        return false;
+    static GQuark is_bambu_quark = 0;
+    if (is_bambu_quark == 0)
+        is_bambu_quark = g_quark_from_static_string("orca-is-bambu-uri");
+    if (g_object_get_qdata(G_OBJECT(playbin), is_bambu_quark) != nullptr)
+        return true;
+
+    gchar *uri = nullptr;
+    g_object_get(G_OBJECT(playbin), "uri", &uri, NULL);
+    const bool is_bambu = (uri != nullptr) && g_str_has_prefix(uri, "bambu://");
+    g_free(uri);
+    return is_bambu;
+}
+
+static gint on_uridecodebin_autoplug_select(GstElement * /*decodebin*/, GstPad * /*pad*/, GstCaps * /*caps*/, GstElementFactory *factory, gpointer user_data)
+{
+    auto *playbin = GST_ELEMENT(user_data);
+    if (!factory)
+        return 0; // GST_AUTOPLUG_SELECT_TRY
+
+    const gchar *factory_name = gst_plugin_feature_get_name(GST_PLUGIN_FEATURE(factory));
+    const bool is_bambu = is_bambu_uri_for_playbin(playbin);
+    if (!is_bambu)
+        return 0; // GST_AUTOPLUG_SELECT_TRY
+    if (!factory_name)
+        return 0;
+
+    // Only skip NVIDIA HW decode if a robust software fallback (libav) exists in this runtime.
+    const bool can_fallback_to_sw = has_avdec_h264_decoder();
+
+    // For Bambu live preview, skip NVIDIA HW decoders to avoid CUDAMemory-only output negotiation.
+    if (g_strcmp0(factory_name, "nvh264dec") == 0 || g_strcmp0(factory_name, "nvh265dec") == 0) {
+        if (!can_fallback_to_sw)
+            return 0; // Keep stream working rather than black video.
+        return 2; // GST_AUTOPLUG_SELECT_SKIP
+    }
+
+    return 0;
+}
+
+static void maybe_attach_bambu_decoder_filter(GstElement *playbin, GstElement *element)
+{
+    if (!playbin || !element)
+        return;
+
+    auto *factory = gst_element_get_factory(element);
+    if (!factory)
+        return;
+    const gchar *factory_name = gst_plugin_feature_get_name(GST_PLUGIN_FEATURE(factory));
+    const bool is_uri_decodebin = g_str_has_prefix(factory_name, "uridecodebin");
+    const bool is_decodebin = g_str_has_prefix(factory_name, "decodebin");
+    if (!is_uri_decodebin && !is_decodebin)
+        return;
+
+    static GQuark attached_quark = 0;
+    if (attached_quark == 0)
+        attached_quark = g_quark_from_static_string("orca-bambu-autoplug-filter-attached");
+    if (g_object_get_qdata(G_OBJECT(element), attached_quark) != nullptr)
+        return;
+
+    g_signal_connect(element, "autoplug-select", G_CALLBACK(on_uridecodebin_autoplug_select), playbin);
+    g_object_set_qdata(G_OBJECT(element), attached_quark, GINT_TO_POINTER(1));
+}
+
+static void on_playbin_deep_element_added(GstBin *playbin, GstBin * /*sub_bin*/, GstElement *element, gpointer /*user_data*/)
+{
+    tune_live_preview_sink(element);
+    maybe_attach_bambu_decoder_filter(GST_ELEMENT(playbin), element);
+}
 #endif
 
 wxDEFINE_EVENT(EVT_MEDIA_CTRL_STAT, wxCommandEvent);
@@ -46,6 +159,13 @@ wxMediaCtrl2::wxMediaCtrl2(wxWindow *parent)
     g_object_set (G_OBJECT (playbin),
                   "audio-sink", NULL,
                    NULL);
+    g_signal_connect(playbin, "deep-element-added", G_CALLBACK(on_playbin_deep_element_added), nullptr);
+    GstElement *video_sink = nullptr;
+    g_object_get(G_OBJECT(playbin), "video-sink", &video_sink, NULL);
+    if (video_sink) {
+        tune_live_preview_sink(video_sink);
+        gst_object_unref(video_sink);
+    }
     gstbambusrc_register();
     Bind(wxEVT_MEDIA_LOADED, [this](auto & e) {
         m_loaded = true;
@@ -161,6 +281,17 @@ void wxMediaCtrl2::Load(wxURI url)
         boost::lexical_cast<std::string>(GetCurrentThreadId())));
 #endif
 #ifdef __WXGTK3__
+    if (m_imp != nullptr) {
+        auto playbin = reinterpret_cast<wxGStreamerMediaBackend *>(m_imp)->m_playbin;
+        if (playbin) {
+            static GQuark is_bambu_quark = 0;
+            if (is_bambu_quark == 0)
+                is_bambu_quark = g_quark_from_static_string("orca-is-bambu-uri");
+            const bool is_bambu = (url.GetScheme() == "bambu");
+            g_object_set_qdata(G_OBJECT(playbin), is_bambu_quark, is_bambu ? GINT_TO_POINTER(1) : nullptr);
+        }
+    }
+
     GstElementFactory *factory;
     int hasplugins = 1;
     

--- a/src/slic3r/GUI/wxMediaCtrl2.cpp
+++ b/src/slic3r/GUI/wxMediaCtrl2.cpp
@@ -13,6 +13,7 @@
 #ifdef __LINUX__
 #include "Printer/gstbambusrc.h"
 #include <gst/gst.h> // main gstreamer header
+#include <gst/base/gstbasesink.h>
 class WXDLLIMPEXP_MEDIA
     wxGStreamerMediaBackend : public wxMediaBackendCommonBase
 {
@@ -53,11 +54,14 @@ static void tune_live_preview_sink(GstElement *element)
 
 static bool has_avdec_h264_decoder()
 {
-    GstElementFactory *factory = gst_element_factory_find("avdec_h264");
-    if (!factory)
-        return false;
-    gst_object_unref(factory);
-    return true;
+    static const bool has_decoder = []() {
+        GstElementFactory *factory = gst_element_factory_find("avdec_h264");
+        if (!factory)
+            return false;
+        gst_object_unref(factory);
+        return true;
+    }();
+    return has_decoder;
 }
 
 static bool is_bambu_uri_for_playbin(GstElement *playbin)
@@ -112,6 +116,8 @@ static void maybe_attach_bambu_decoder_filter(GstElement *playbin, GstElement *e
     if (!factory)
         return;
     const gchar *factory_name = gst_plugin_feature_get_name(GST_PLUGIN_FEATURE(factory));
+    if (!factory_name)
+        return;
     const bool is_uri_decodebin = g_str_has_prefix(factory_name, "uridecodebin");
     const bool is_decodebin = g_str_has_prefix(factory_name, "decodebin");
     if (!is_uri_decodebin && !is_decodebin)
@@ -129,8 +135,13 @@ static void maybe_attach_bambu_decoder_filter(GstElement *playbin, GstElement *e
 
 static void on_playbin_deep_element_added(GstBin *playbin, GstBin * /*sub_bin*/, GstElement *element, gpointer /*user_data*/)
 {
-    tune_live_preview_sink(element);
-    maybe_attach_bambu_decoder_filter(GST_ELEMENT(playbin), element);
+    auto *playbin_element = GST_ELEMENT(playbin);
+    if (!is_bambu_uri_for_playbin(playbin_element))
+        return;
+
+    if (GST_IS_BASE_SINK(element))
+        tune_live_preview_sink(element);
+    maybe_attach_bambu_decoder_filter(playbin_element, element);
 }
 #endif
 
@@ -160,12 +171,6 @@ wxMediaCtrl2::wxMediaCtrl2(wxWindow *parent)
                   "audio-sink", NULL,
                    NULL);
     g_signal_connect(playbin, "deep-element-added", G_CALLBACK(on_playbin_deep_element_added), nullptr);
-    GstElement *video_sink = nullptr;
-    g_object_get(G_OBJECT(playbin), "video-sink", &video_sink, NULL);
-    if (video_sink) {
-        tune_live_preview_sink(video_sink);
-        gst_object_unref(video_sink);
-    }
     gstbambusrc_register();
     Bind(wxEVT_MEDIA_LOADED, [this](auto & e) {
         m_loaded = true;


### PR DESCRIPTION
# Description

Fixes #9280 (Linux Bambu liveview stream stops after a few seconds).

This PR narrows the Linux Bambu liveview workaround to sink timing only.

A source-side fix in `gstbambusrc` would be the preferred long-term solution, because it corrects timing before the rest of the pipeline sees the stream. This PR should therefore be understood as a conservative workaround in `wxMediaCtrl2`: a minimal mitigation for the observed freeze/stall behavior until a source-side fix is fixed, reviewed, and validated across hardware.

## What this PR changes

In Linux `wxMediaCtrl2.cpp`:

- marks Bambu playback context on the playbin
- applies sink timing settings only for Bambu liveview sinks:
  - `sync=false`
  - `qos=false`
  - `max-lateness=-1`

This revision intentionally removes the earlier decoder-selection logic from the branch to keep the scope small and reviewable.

## Why this approach

- scoped to Linux Bambu liveview only
- keeps the workaround local to `wxMediaCtrl2`
- avoids broader decoder policy changes
- mitigates the observed Linux freeze/stall behavior with a very small patch
- not intended to replace a proper source-side timing fix in `gstbambusrc`

## Expected result

- fewer early liveview freezes/stalls on Linux
- lower regression risk than a broader decoder/sink patch
- no protocol, auth, or tunnel-path changes

# Screenshots/Recordings/Graphs

N/A (runtime pipeline behavior change).

## Tests

Original branch testing date: March 1, 2026  
Platform: Arch Linux, kernel 6.18.13-arch1-1, GStreamer 1.28.1.

### Previously verified on this branch family

- Full project build: passed
- Automated tests: 146/146 passed
- Verified liveview start/stop/re-enable behavior on both Bambu H2D and X1C.
- Verified sink timing flags are applied and liveview remains stable under repeated stream control actions.

### Scope note for this revision

- This reduced revision removes the decoder hook and keeps only the sink-timing workaround.
- No new behavior was added relative to the previously tested sink path; the change is a scope reduction.

### Notes / known limitation

- This is a workaround, not a root-cause fix.
- If a source-side timestamp fix lands in `gstbambusrc`, that would likely be the better long-term place to solve this.

