### PR TITLE
External bridge fix

### DIFF
--- a/src/libslic3r/Algorithm/RegionExpansion.cpp
+++ b/src/libslic3r/Algorithm/RegionExpansion.cpp
@@ -284,7 +284,7 @@ std::vector<WaveSeed> wave_seeds(
             for (const ClipperLib_Z::IntPoint &point : path) {
                 if (point.z() >= idx_boundary_end && point.z() < idx_src_end && src_z < 0)
                     src_z = point.z();
-                else if (point.z() >= 1 && point.z() < idx_boundary_end && boundary_z < 0)
+                else if (point.z() >= idx_boundary_begin && point.z() < idx_boundary_end && boundary_z < 0)
                     boundary_z = point.z();
                 if (src_z >= 0 && boundary_z >= 0)
                     break;

--- a/src/libslic3r/Algorithm/RegionExpansion.cpp
+++ b/src/libslic3r/Algorithm/RegionExpansion.cpp
@@ -278,7 +278,7 @@ std::vector<WaveSeed> wave_seeds(
             // this is common because source and boundary contours share many
             // vertices.  Determine src_id / boundary_id from Z coordinates
             // (and fall back to an AABB-tree point-in-polygon test when a
-            // boundary or source ID is not directly available).
+            // boundary ID is not directly available).
             coord_t src_z = -1, boundary_z = -1;
             // Scan all path points for the information we need.
             for (const ClipperLib_Z::IntPoint &point : path) {

--- a/src/libslic3r/Algorithm/RegionExpansion.cpp
+++ b/src/libslic3r/Algorithm/RegionExpansion.cpp
@@ -266,13 +266,12 @@ std::vector<WaveSeed> wave_seeds(
             //(front.z() < 0 && back.z() < 0));
             // Hope that at least one end of an open polyline is clipped by the boundary, thus an intersection point is created.
             (front.z() < 0 || back.z() < 0));
-        // Thus as long as the seed contour is not closed, it should be open at a boundary point.
         // However, with complex geometry, both endpoints may coincide with existing polygon
         // vertices (z >= 0), which is handled below.
 
         if (front != back && front.z() >= 0 && back.z() >= 0) {
-            //// Very rare case when both endpoints intersect boundary ExPolygons in existing points.
-            //// So the ZFillFunction callback hasn't been called.
+            // Very rare case when both endpoints intersect boundary ExPolygons in existing points.
+            // So the ZFillFunction callback hasn't been called.
             // Both endpoints coincide with existing polygon vertices, so the
             // ZFillFunction callback was never called.  With complex geometry
             // this is common because source and boundary contours share many

--- a/src/libslic3r/Algorithm/RegionExpansion.cpp
+++ b/src/libslic3r/Algorithm/RegionExpansion.cpp
@@ -41,7 +41,10 @@ RegionExpansionParameters RegionExpansionParameters::build(
     // The expansion should not be too tiny, but also small enough, so the following expansion will
     // compensate for tiny_expansion and bring the wave back to the boundary without producing
     // ugly cusps where it touches the boundary.
-    out.tiny_expansion = std::min(0.25f * full_expansion, scaled<float>(0.05f));
+    // Increase the cap to 0.1 mm so that micro-gaps between adjacent
+    // surface types (bridge vs. shell) produced by earlier clipping
+    // operations on complex geometry are reliably bridged.
+    out.tiny_expansion = std::min(0.25f * full_expansion, scaled<float>(0.1f));
     size_t nsteps = size_t(ceil((full_expansion - out.tiny_expansion) / expansion_step));
     if (max_nr_expansion_steps > 0)
         nsteps = std::min(nsteps, max_nr_expansion_steps);
@@ -261,15 +264,49 @@ std::vector<WaveSeed> wave_seeds(
         ClipperLib_Z::IntPoint front = path.front();
         ClipperLib_Z::IntPoint back  = path.back();
         // Both ends of a seed segment are supposed to be inside a single boundary expolygon.
-        // Thus as long as the seed contour is not closed, it should be open at a boundary point.
-        assert((front == back && front.z() >= idx_boundary_end && front.z() < idx_src_end) || 
+        //assert((front == back && front.z() >= idx_boundary_end && front.z() < idx_src_end) || 
             //(front.z() < 0 && back.z() < 0));
             // Hope that at least one end of an open polyline is clipped by the boundary, thus an intersection point is created.
-            (front.z() < 0 || back.z() < 0));
+        //    (front.z() < 0 || back.z() < 0));
+        // Thus as long as the seed contour is not closed, it should be open at a boundary point.
+        // However, with complex geometry, both endpoints may coincide with existing polygon
+        // vertices (z >= 0), which is handled below.
 
         if (front != back && front.z() >= 0 && back.z() >= 0) {
-            // Very rare case when both endpoints intersect boundary ExPolygons in existing points.
-            // So the ZFillFunction callback hasn't been called.
+            //// Very rare case when both endpoints intersect boundary ExPolygons in existing points.
+            //// So the ZFillFunction callback hasn't been called.
+            // Both endpoints coincide with existing polygon vertices, so the
+            // ZFillFunction callback was never called.  With complex geometry
+            // this is common because source and boundary contours share many
+            // vertices.  Determine src_id / boundary_id from Z coordinates
+            // (and fall back to an AABB-tree point-in-polygon test when a
+            // boundary or source ID is not directly available).
+            coord_t src_z = -1, boundary_z = -1;
+            // Scan all path points for the information we need.
+            for (const ClipperLib_Z::IntPoint &point : path) {
+                if (point.z() >= idx_boundary_end && point.z() < idx_src_end && src_z < 0)
+                    src_z = point.z();
+                else if (point.z() >= 1 && point.z() < idx_boundary_end && boundary_z < 0)
+                    boundary_z = point.z();
+                if (src_z >= 0 && boundary_z >= 0)
+                    break;
+            }
+            if (src_z >= 0) {
+                uint32_t src_id = uint32_t(src_z - idx_boundary_end);
+                if (boundary_z >= 0) {
+                    out.push_back({ src_id, uint32_t(boundary_z - 1), ClipperZUtils::from_zpath(path) });
+                } else {
+                    // Source ID known but boundary unknown – use AABB tree.
+                    if (aabb_tree.empty())
+                        aabb_tree = build_aabb_tree_over_expolygons(boundary);
+                    int boundary_id = sample_in_expolygons(aabb_tree, boundary, Point(front.x(), front.y()));
+                    if (boundary_id >= 0)
+                        out.push_back({ src_id, uint32_t(boundary_id), ClipperZUtils::from_zpath(path) });
+                }
+                ++ iseed;
+                continue;
+            }
+            // Unable to determine source ID – drop the segment.
             continue;
         } else
         if (front == back && (front.z() < idx_boundary_end)) {

--- a/src/libslic3r/Algorithm/RegionExpansion.cpp
+++ b/src/libslic3r/Algorithm/RegionExpansion.cpp
@@ -261,10 +261,11 @@ std::vector<WaveSeed> wave_seeds(
         ClipperLib_Z::IntPoint front = path.front();
         ClipperLib_Z::IntPoint back  = path.back();
         // Both ends of a seed segment are supposed to be inside a single boundary expolygon.
-        //assert((front == back && front.z() >= idx_boundary_end && front.z() < idx_src_end) || 
+        // Thus as long as the seed contour is not closed, it should be open at a boundary point.
+        assert((front == back && front.z() >= idx_boundary_end && front.z() < idx_src_end) || 
             //(front.z() < 0 && back.z() < 0));
             // Hope that at least one end of an open polyline is clipped by the boundary, thus an intersection point is created.
-        //    (front.z() < 0 || back.z() < 0));
+            (front.z() < 0 || back.z() < 0));
         // Thus as long as the seed contour is not closed, it should be open at a boundary point.
         // However, with complex geometry, both endpoints may coincide with existing polygon
         // vertices (z >= 0), which is handled below.

--- a/src/libslic3r/Algorithm/RegionExpansion.cpp
+++ b/src/libslic3r/Algorithm/RegionExpansion.cpp
@@ -41,10 +41,7 @@ RegionExpansionParameters RegionExpansionParameters::build(
     // The expansion should not be too tiny, but also small enough, so the following expansion will
     // compensate for tiny_expansion and bring the wave back to the boundary without producing
     // ugly cusps where it touches the boundary.
-    // Increase the cap to 0.1 mm so that micro-gaps between adjacent
-    // surface types (bridge vs. shell) produced by earlier clipping
-    // operations on complex geometry are reliably bridged.
-    out.tiny_expansion = std::min(0.25f * full_expansion, scaled<float>(0.1f));
+    out.tiny_expansion = std::min(0.25f * full_expansion, scaled<float>(0.05f));
     size_t nsteps = size_t(ceil((full_expansion - out.tiny_expansion) / expansion_step));
     if (max_nr_expansion_steps > 0)
         nsteps = std::min(nsteps, max_nr_expansion_steps);


### PR DESCRIPTION
Fix #11558

Yet another Bridge PR (#12055 #11255)

Improve the region expansion algorithm targeting better handling of complex geometries.
The changes focus on making gap bridging more reliable and enhancing the robustness of seed segment identification when **contours share vertices**.

- ~~Algorithm parameter improvements: Increased the cap for `tiny_expansion` from 0.05mm to 0.1mm to ensure micro-gaps between adjacent surface types are reliably bridged, especially after clipping operations on complex geometries.~~
- Robustness for complex geometry: Enhanced the logic for identifying source and boundary IDs when both endpoints of a seed segment coincide with existing polygon vertices. The new approach scans all path points for necessary information and uses an AABB-tree point-in-polygon test as a fallback, improving reliability when contours share vertices.

 # Before:
<img width="2560" height="1392" alt="image" src="https://github.com/user-attachments/assets/0484c849-a277-4f0b-a96f-2e3703d9f5fe" />

 # After: 
<img width="2560" height="1392" alt="image" src="https://github.com/user-attachments/assets/77c750f1-139f-4cd6-815c-c659f34480e6" />
