### PR TITLE
Fix Bambu LAN printing with legacy network plugin

### DIFF
--- a/src/slic3r/GUI/Jobs/PrintJob.cpp
+++ b/src/slic3r/GUI/Jobs/PrintJob.cpp
@@ -13,6 +13,7 @@
 #include "slic3r/GUI/DeviceCore/DevUtil.h"
 
 #include "slic3r/Utils/FileTransferUtils.hpp"
+#include "slic3r/Utils/BBLNetworkPlugin.hpp"
 
 namespace Slic3r {
 namespace GUI {
@@ -228,7 +229,15 @@ void PrintJob::process(Ctl &ctl)
             ftp_ok = result == 0;
         }
         if (!emmc_ok && !ftp_ok) {
-            BOOST_LOG_TRIVIAL(error) << "access code is invalid";
+            bool legacy_mode = BBLNetworkPlugin::instance().use_legacy_network();
+            BOOST_LOG_TRIVIAL(error) << "LAN connection verification failed:"
+                << " emmc_ok=" << emmc_ok
+                << ", ftp_ok=" << ftp_ok
+                << ", ftp_result=" << result
+                << ", dev_ip=" << m_dev_ip
+                << ", dev_id=" << m_dev_id
+                << ", password_length=" << m_access_code.size()
+                << ", legacy_mode=" << (legacy_mode ? "true" : "false");
             m_enter_ip_address_fun_fail();
             m_job_finished = true;
             return;

--- a/src/slic3r/Utils/BBLNetworkPlugin.cpp
+++ b/src/slic3r/Utils/BBLNetworkPlugin.cpp
@@ -1,4 +1,5 @@
 #include "BBLNetworkPlugin.hpp"
+#include "NetworkAgent.hpp"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -161,9 +162,21 @@ int BBLNetworkPlugin::initialize(bool using_backup, const std::string& version)
     // Load all function pointers
     load_all_function_pointers();
 
+    // Sync legacy network flag from NetworkAgent (set during GUI_App initialization)
+    m_use_legacy_network = NetworkAgent::use_legacy_network;
+
+    std::string loaded_version;
     if (m_get_version) {
-        (void) m_get_version();
+        loaded_version = m_get_version();
     }
+
+    BOOST_LOG_TRIVIAL(info) << "BBLNetworkPlugin::initialize: legacy_mode="
+        << (m_use_legacy_network ? "true" : "false")
+        << ", library=" << library
+        << ", version=" << (loaded_version.empty() ? "unknown" : loaded_version)
+        << ", send_message=" << (m_send_message ? "loaded" : "null")
+        << ", start_print=" << (m_start_print ? "loaded" : "null")
+        << ", start_local_print=" << (m_start_local_print ? "loaded" : "null");
 
     return 0;
 }

--- a/src/slic3r/Utils/BBLPrinterAgent.cpp
+++ b/src/slic3r/Utils/BBLPrinterAgent.cpp
@@ -26,6 +26,10 @@ int BBLPrinterAgent::send_message(std::string dev_id, std::string json_str, int 
     auto agent = plugin.get_agent();
     auto func = plugin.get_send_message();
     if (func && agent) {
+        if (plugin.use_legacy_network()) {
+            auto legacy_func = reinterpret_cast<func_send_message_legacy>(func);
+            return legacy_func(agent, dev_id, json_str, qos);
+        }
         return func(agent, dev_id, json_str, qos, flag);
     }
     return -1;
@@ -59,6 +63,10 @@ int BBLPrinterAgent::send_message_to_printer(std::string dev_id, std::string jso
     auto agent = plugin.get_agent();
     auto func = plugin.get_send_message_to_printer();
     if (func && agent) {
+        if (plugin.use_legacy_network()) {
+            auto legacy_func = reinterpret_cast<func_send_message_to_printer_legacy>(func);
+            return legacy_func(agent, dev_id, json_str, qos);
+        }
         return func(agent, dev_id, json_str, qos, flag);
     }
     return -1;
@@ -218,6 +226,11 @@ int BBLPrinterAgent::start_print(PrintParams params, OnUpdateStatusFn update_fn,
     auto agent = plugin.get_agent();
     auto func = plugin.get_start_print();
     if (func && agent) {
+        if (plugin.use_legacy_network()) {
+            auto legacy_func = reinterpret_cast<func_start_print_legacy>(func);
+            auto legacy_params = BBLNetworkPlugin::as_legacy(params);
+            return legacy_func(agent, legacy_params, update_fn, cancel_fn, wait_fn);
+        }
         return func(agent, params, update_fn, cancel_fn, wait_fn);
     }
     return -1;
@@ -229,6 +242,11 @@ int BBLPrinterAgent::start_local_print_with_record(PrintParams params, OnUpdateS
     auto agent = plugin.get_agent();
     auto func = plugin.get_start_local_print_with_record();
     if (func && agent) {
+        if (plugin.use_legacy_network()) {
+            auto legacy_func = reinterpret_cast<func_start_local_print_with_record_legacy>(func);
+            auto legacy_params = BBLNetworkPlugin::as_legacy(params);
+            return legacy_func(agent, legacy_params, update_fn, cancel_fn, wait_fn);
+        }
         return func(agent, params, update_fn, cancel_fn, wait_fn);
     }
     return -1;
@@ -240,6 +258,11 @@ int BBLPrinterAgent::start_send_gcode_to_sdcard(PrintParams params, OnUpdateStat
     auto agent = plugin.get_agent();
     auto func = plugin.get_start_send_gcode_to_sdcard();
     if (func && agent) {
+        if (plugin.use_legacy_network()) {
+            auto legacy_func = reinterpret_cast<func_start_send_gcode_to_sdcard_legacy>(func);
+            auto legacy_params = BBLNetworkPlugin::as_legacy(params);
+            return legacy_func(agent, legacy_params, update_fn, cancel_fn, wait_fn);
+        }
         return func(agent, params, update_fn, cancel_fn, wait_fn);
     }
     return -1;
@@ -251,6 +274,11 @@ int BBLPrinterAgent::start_local_print(PrintParams params, OnUpdateStatusFn upda
     auto agent = plugin.get_agent();
     auto func = plugin.get_start_local_print();
     if (func && agent) {
+        if (plugin.use_legacy_network()) {
+            auto legacy_func = reinterpret_cast<func_start_local_print_legacy>(func);
+            auto legacy_params = BBLNetworkPlugin::as_legacy(params);
+            return legacy_func(agent, legacy_params, update_fn, cancel_fn);
+        }
         return func(agent, params, update_fn, cancel_fn);
     }
     return -1;
@@ -262,6 +290,11 @@ int BBLPrinterAgent::start_sdcard_print(PrintParams params, OnUpdateStatusFn upd
     auto agent = plugin.get_agent();
     auto func = plugin.get_start_sdcard_print();
     if (func && agent) {
+        if (plugin.use_legacy_network()) {
+            auto legacy_func = reinterpret_cast<func_start_sdcard_print_legacy>(func);
+            auto legacy_params = BBLNetworkPlugin::as_legacy(params);
+            return legacy_func(agent, legacy_params, update_fn, cancel_fn);
+        }
         return func(agent, params, update_fn, cancel_fn);
     }
     return -1;


### PR DESCRIPTION
# Description

BBLPrinterAgent was always calling modern DLL signatures, causing ABI                                                                                                                                                                                                                                                                                                                                   
  mismatches when the legacy network plugin is loaded:                                                      
                                               
  - send_message/send_message_to_printer called with 5 args (flag param)
    but legacy DLL expects 4 args, causing stack corruption
  - Print functions passed PrintParams (with nozzle_mapping, ams_mapping2,
    nozzles_info fields) but legacy DLL expects PrintParams_Legacy, shifting
    the password field offset and producing "access code is invalid" errors

  Add legacy branching to all 7 affected methods in BBLPrinterAgent,
  matching the pattern from the original NetworkAgent implementation.
  Sync the legacy flag from NetworkAgent::use_legacy_network during
  plugin initialization and improve LAN connection failure diagnostics.

  Fixes #12514, #12537, #12472, #12563

# Screenshots/Recordings/Graphs

<!--
> Please attach relevant screenshots to showcase the UI changes.
> Please attach images that can help explain the changes.
-->

## Tests

<!--
> Please describe the tests that you have conducted to verify the changes made in this PR.
-->
