### PR TITLE
Extract shared FilamentMatcher with multi-tier preset resolution

### DIFF
--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -1739,7 +1739,8 @@ void PresetCollection::load_presets(
                     const Preset& default_preset = this->default_preset_for(config);
                     if (inherit_preset) {
                         preset.config = inherit_preset->config;
-                        preset.filament_id = inherit_preset->filament_id;
+                        if (preset.filament_id.empty())
+                            preset.filament_id = inherit_preset->filament_id;
                         extend_default_config_length(config, false, {});
                         preset.config.update_diff_values_to_child_config(config, extruder_id_name, extruder_variant_name, *key_set1, *key_set2);
                     }

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -1311,7 +1311,8 @@ void PresetCollection::load_presets(
                     const Preset& default_preset = this->default_preset_for(config);
                     if (inherit_preset) {
                         preset.config = inherit_preset->config;
-                        preset.filament_id = inherit_preset->filament_id;
+                        if (preset.filament_id.empty())
+                            preset.filament_id = inherit_preset->filament_id;
                         extend_default_config_length(config, false, {});
                         preset.config.update_diff_values_to_child_config(config, extruder_id_name, extruder_variant_name, *key_set1, *key_set2);
                     }

--- a/src/libslic3r/PresetBundle.cpp
+++ b/src/libslic3r/PresetBundle.cpp
@@ -3304,9 +3304,20 @@ unsigned int PresetBundle::sync_ams_list(std::vector<std::pair<DynamicPrintConfi
         }
         bool has_type = false;
         auto filament_type = ams.opt_string("filament_type", 0u);
-        auto iter = std::find_if(filaments.begin(), filaments.end(), [this, &filament_id, &has_type, filament_type](auto &f) {
-            has_type |= f.config.opt_string("filament_type", 0u) == filament_type;
-            return f.is_compatible && filaments.get_preset_base(f) == &f && f.filament_id == filament_id; });
+        // Orca: the filament matcher may have identified one specific preset.
+        // Prefer it over the filament_id lookup below, which can only return the
+        // first preset carrying that id -- and ids are shared, both across
+        // unrelated products in shipped profiles and between every GUI-created
+        // preset and the parent it inherits from.
+        auto matched_preset_name = ams.has("matched_preset_name") ? ams.opt_string("matched_preset_name", 0u) : std::string();
+        auto iter = filaments.end();
+        if (!matched_preset_name.empty())
+            iter = std::find_if(filaments.begin(), filaments.end(), [&matched_preset_name](auto &f) {
+                return f.is_compatible && f.name == matched_preset_name; });
+        if (iter == filaments.end())
+            iter = std::find_if(filaments.begin(), filaments.end(), [this, &filament_id, &has_type, filament_type](auto &f) {
+                has_type |= f.config.opt_string("filament_type", 0u) == filament_type;
+                return f.is_compatible && boost::iequals(f.filament_id, filament_id); });
         if (iter == filaments.end()) {
             BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << boost::format(": filament_id %1% not found or system or compatible") % filament_id;
             if (!filament_type.empty()) {

--- a/src/libslic3r/PresetBundle.cpp
+++ b/src/libslic3r/PresetBundle.cpp
@@ -2422,7 +2422,7 @@ unsigned int PresetBundle::sync_ams_list(std::vector<std::pair<DynamicPrintConfi
         auto filament_type = ams.opt_string("filament_type", 0u);
         auto iter = std::find_if(filaments.begin(), filaments.end(), [this, &filament_id, &has_type, filament_type](auto &f) {
             has_type |= f.config.opt_string("filament_type", 0u) == filament_type;
-            return f.is_compatible && filaments.get_preset_base(f) == &f && f.filament_id == filament_id; });
+            return f.is_compatible && boost::iequals(f.filament_id, filament_id); });
         if (iter == filaments.end()) {
             BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << boost::format(": filament_id %1% not found or system or compatible") % filament_id;
             if (!filament_type.empty()) {

--- a/src/slic3r/CMakeLists.txt
+++ b/src/slic3r/CMakeLists.txt
@@ -701,6 +701,8 @@ set(SLIC3R_GUI_SOURCES
     Utils/NetworkAgentFactory.cpp
     Utils/ICloudServiceAgent.hpp
     Utils/IPrinterAgent.hpp
+    Utils/FilamentMatcher.cpp
+    Utils/FilamentMatcher.hpp
     Utils/OrcaCloudServiceAgent.cpp
     Utils/OrcaCloudServiceAgent.hpp
     Utils/OrcaPrinterAgent.cpp

--- a/src/slic3r/CMakeLists.txt
+++ b/src/slic3r/CMakeLists.txt
@@ -604,6 +604,8 @@ set(SLIC3R_GUI_SOURCES
     Utils/NetworkAgentFactory.cpp
     Utils/ICloudServiceAgent.hpp
     Utils/IPrinterAgent.hpp
+    Utils/FilamentMatcher.cpp
+    Utils/FilamentMatcher.hpp
     Utils/OrcaCloudServiceAgent.cpp
     Utils/OrcaCloudServiceAgent.hpp
     Utils/OrcaPrinterAgent.cpp

--- a/src/slic3r/GUI/DeviceCore/DevFilaSystem.cpp
+++ b/src/slic3r/GUI/DeviceCore/DevFilaSystem.cpp
@@ -47,6 +47,7 @@ void DevAmsTray::reset()
     filament_setting_id = "";
     m_fila_type         = "";
     sub_brands          = "";
+    matched_preset_name = "";
     color               = "";
     weight              = "";
     diameter            = "";
@@ -676,6 +677,11 @@ void DevFilaSystemParser::ParseV1_0(const json& jj, MachineObject* obj, DevFilaS
                                 curr_tray->sub_brands = (*tray_it)["tray_sub_brands"].get<std::string>();
                             else
                                 curr_tray->sub_brands = "";
+                            // Orca extension, emitted by pull-mode agents only.
+                            if (tray_it->contains("orca_preset_name"))
+                                curr_tray->matched_preset_name = (*tray_it)["orca_preset_name"].get<std::string>();
+                            else
+                                curr_tray->matched_preset_name = "";
                             if (tray_it->contains("tray_weight"))
                                 curr_tray->weight = (*tray_it)["tray_weight"].get<std::string>();
                             else

--- a/src/slic3r/GUI/DeviceCore/DevFilaSystem.h
+++ b/src/slic3r/GUI/DeviceCore/DevFilaSystem.h
@@ -62,6 +62,9 @@ public:
     std::string              filament_setting_id; // setting_id
     std::string              m_fila_type;
     std::string              sub_brands;
+    // Orca: preset the filament matcher identified for this tray, when it
+    // identified one.  Empty for BBL devices and for generic/type-only matches.
+    std::string              matched_preset_name;
     std::string              color;
     std::vector<std::string> cols;
     std::string              weight;

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -4204,6 +4204,7 @@ std::map<int, DynamicPrintConfig> Sidebar::build_filament_ams_list(MachineObject
         tray_config.set_key_value("ams_id", new ConfigOptionStrings{ams_id});
         tray_config.set_key_value("slot_id", new ConfigOptionStrings{slot_id});
         tray_config.set_key_value("filament_type", new ConfigOptionStrings{tray.m_fila_type});
+        tray_config.set_key_value("matched_preset_name", new ConfigOptionStrings{tray.matched_preset_name});
         tray_config.set_key_value("tray_name", new ConfigOptionStrings{ name });
         tray_config.set_key_value("filament_colour", new ConfigOptionStrings{into_u8(wxColour("#" + tray.color).GetAsString(wxC2S_HTML_SYNTAX))});
         tray_config.set_key_value("filament_multi_colour", new ConfigOptionStrings{});

--- a/src/slic3r/Utils/CrealityPrintAgent.cpp
+++ b/src/slic3r/Utils/CrealityPrintAgent.cpp
@@ -2,6 +2,7 @@
 #include "CrealityPrint.hpp"
 #include "libslic3r/PresetBundle.hpp"
 #include "libslic3r/PrintConfig.hpp"
+#include "FilamentMatcher.hpp"
 #include "slic3r/GUI/GUI_App.hpp"
 
 #include <boost/log/trivial.hpp>
@@ -16,106 +17,8 @@ namespace {
 
 constexpr const char* CrealityPrintAgent_VERSION = "0.1.0";
 
-bool has_visible_base_preset(const PresetCollection& filaments, const std::string& filament_id)
-{
-    for (const auto& p : filaments.get_presets()) {
-        if (p.is_visible && p.is_compatible
-            && filaments.get_preset_base(p) == &p
-            && p.filament_id == filament_id)
-            return true;
-    }
-    return false;
-}
 
 } // namespace
-
-// Score visible compatible filament presets against the CFS spool metadata and
-// return the best-matching filament_id. Scoring:
-//   +20  preset name contains brand_name as a substring
-//        (e.g. "Hyper PLA" in "Hyper PLA @Creality K2 0.4 nozzle")
-//   +10  preset name contains the vendor substring (e.g. "Creality")
-//   Tiebreak: prefer the SYSTEM (shipped) preset over user copies. Brand-
-//   specific system presets carry their own filament_id; user copies of
-//   generic presets inherit a generic filament_id from their parent, so
-//   preferring the user copy can collapse a brand-specific match back to
-//   "Generic PLA" via the inherited id. Plus: this code targets upstream
-//   OrcaSlicer where shipping the user's local tuning would be wrong.
-// Requires the preset's declared filament_type to equal the spool's base type
-// (PLA/PETG/ABS/...) so we never auto-pick a PETG preset for a PLA spool.
-// Falls back to filaments.filament_id_by_type(base_type) when nothing scores.
-std::string CrealityPrintAgent::match_filament_preset(const PresetCollection& filaments,
-                                                      const std::string&      vendor,
-                                                      const std::string&      brand_name,
-                                                      const std::string&      base_type)
-{
-    auto to_lower = [](std::string s) {
-        for (auto& c : s) c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
-        return s;
-    };
-
-    const std::string vendor_lower = to_lower(vendor);
-    const std::string brand_lower  = to_lower(brand_name);
-    const std::string type_lower   = to_lower(base_type);
-
-    struct Match {
-        const Preset* preset;
-        int           score;
-        bool          is_user;
-    };
-    std::vector<Match> matches;
-
-    int considered = 0;
-    for (const auto& p : filaments.get_presets()) {
-        if (!p.is_visible || !p.is_compatible) continue;
-        // Note: we deliberately do NOT filter on get_preset_base(p) == &p.
-        // K2 owners frequently keep tweaked copies of system presets
-        // (e.g. "Creality Hyper PLA @K2 (Harky)" with their per-spool PA),
-        // which are derived presets — filtering to bases-only would skip
-        // exactly the presets users care about most.
-        ++considered;
-
-        std::string preset_type;
-        if (const auto* ft = p.config.option<ConfigOptionStrings>("filament_type"))
-            if (!ft->values.empty()) preset_type = ft->values.front();
-        if (to_lower(preset_type) != type_lower) continue;
-
-        const std::string name_lower = to_lower(p.name);
-        int score = 0;
-        if (!brand_lower.empty() && name_lower.find(brand_lower) != std::string::npos)
-            score += 20;
-        if (!vendor_lower.empty() && name_lower.find(vendor_lower) != std::string::npos)
-            score += 10;
-
-        if (score > 0)
-            matches.push_back({&p, score, !p.is_system && !p.is_default});
-    }
-
-    if (matches.empty()) {
-        const std::string fallback = filaments.filament_id_by_type(base_type);
-        const bool        fallback_ok = has_visible_base_preset(filaments, fallback);
-        BOOST_LOG_TRIVIAL(info)
-            << "CrealityPrintAgent: no preset scored for spool {" << vendor << " "
-            << brand_name << " (" << base_type << ")} after considering " << considered
-            << " presets; falling back to generic preset id \"" << fallback << "\""
-            << (fallback_ok ? "" : " (NOT visible — returning empty)");
-        return fallback_ok ? fallback : std::string();
-    }
-
-    std::sort(matches.begin(), matches.end(),
-              [](const Match& a, const Match& b) {
-                  if (a.score   != b.score)   return a.score > b.score;
-                  if (a.is_user != b.is_user) return !a.is_user; // prefer system over user
-                  return false;
-              });
-
-    BOOST_LOG_TRIVIAL(info)
-        << "CrealityPrintAgent: matched spool {" << vendor << " " << brand_name
-        << " (" << base_type << ")} -> preset \"" << matches.front().preset->name
-        << "\" (score=" << matches.front().score
-        << ", " << matches.size() << " candidate(s) of " << considered << " considered)";
-
-    return matches.front().preset->filament_id;
-}
 
 CrealityPrintAgent::CrealityPrintAgent(std::string log_dir)
     : MoonrakerPrinterAgent(std::move(log_dir))
@@ -315,13 +218,33 @@ bool CrealityPrintAgent::fetch_filament_info(std::string dev_id)
 
             const CFSSlot& s = *it->second;
             tray.has_filament = true;
-            tray.tray_type    = normalize_filament_type(s.filament_type);
             tray.tray_color   = s.color_hex;
 
-            if (bundle) {
-                tray.tray_info_idx = match_filament_preset(
-                    bundle->filaments, s.vendor, s.brand_name, tray.tray_type);
-            }
+            // Prefer a filament_type the loaded profiles actually define, so a
+            // composite survives ("PLA-CF" stays PLA-CF instead of collapsing
+            // onto PLA and being excluded from its own profiles).  The static
+            // ladder is the fallback for an unrecognized material and for early
+            // init before any bundle exists.
+            tray.tray_type = bundle ? FilamentMatcher::resolve_filament_type(
+                                          bundle->filaments, s.filament_type)
+                                    : std::string();
+            if (tray.tray_type.empty())
+                tray.tray_type = normalize_filament_type(s.filament_type);
+
+            // CFS reports a vendor and a product name ("Hyper PLA") alongside
+            // the base type and color, so the vendor-bearing config rungs carry
+            // this printer: vendor+type narrowed by the reported product name,
+            // then color.  There is no numeric id or agent prefix to supply.
+            FilamentMatchInput match_input;
+            match_input.vendor_name   = FilamentMatcher::sanitize_for_id(s.vendor);
+            match_input.filament_name = FilamentMatcher::sanitize_for_id(s.brand_name);
+            match_input.tray_type     = tray.tray_type;
+            match_input.color         = s.color_hex;
+
+            auto match = FilamentMatcher::resolve(bundle ? &bundle->filaments : nullptr,
+                                                  match_input);
+            tray.tray_info_idx       = match.filament_id;
+            tray.matched_preset_name = match.preset_name;
 
             trays.push_back(std::move(tray));
         }

--- a/src/slic3r/Utils/CrealityPrintAgent.hpp
+++ b/src/slic3r/Utils/CrealityPrintAgent.hpp
@@ -53,13 +53,6 @@ public:
     // Strip PLA/PETG/... subtype suffixes ("PLA Silk", "PLA+", "ABS Pro") to base
     // type so the preset_bundle->filaments.filament_id_by_type() lookup succeeds.
     static std::string normalize_filament_type(const std::string& filament_type);
-
-    // Score visible compatible filament presets against the CFS spool metadata and
-    // return the best-matching filament_id. See implementation for scoring details.
-    static std::string match_filament_preset(const PresetCollection& filaments,
-                                             const std::string&      vendor,
-                                             const std::string&      brand_name,
-                                             const std::string&      base_type);
 };
 
 } // namespace Slic3r

--- a/src/slic3r/Utils/FilamentMatcher.cpp
+++ b/src/slic3r/Utils/FilamentMatcher.cpp
@@ -1,0 +1,488 @@
+#include "FilamentMatcher.hpp"
+#include "libslic3r/Preset.hpp"
+
+#include <boost/algorithm/string.hpp>
+#include <boost/log/trivial.hpp>
+#include <algorithm>
+#include <cctype>
+#include <limits>
+#include <vector>
+
+namespace Slic3r {
+namespace FilamentMatcher {
+
+// Sanitize filament vendor or filament name for use in preset IDs.
+// "Acme Inc" -> "Acme_Inc", "PLA Plus" -> "PLA_Plus", "PLA-AERO" -> "PLA_AERO"
+std::string sanitize_for_id(const std::string& name)
+{
+    std::string result;
+    result.reserve(name.size());
+    for (char c : name) {
+        if (std::isalnum(static_cast<unsigned char>(c)))
+            result.push_back(c);
+        else if (!result.empty() && result.back() != '_')
+            result.push_back('_');
+    }
+    if (!result.empty() && result.back() == '_')
+        result.pop_back();
+    return result;
+}
+
+const Preset* find_visible_preset(const PresetCollection& filaments, const std::string& filament_id)
+{
+    for (const auto& p : filaments.get_presets()) {
+        if (p.is_visible && p.is_compatible
+            && boost::iequals(p.filament_id, filament_id))
+            return &p;
+    }
+    return nullptr;
+}
+
+static std::string trim_and_upper(const std::string& input)
+{
+    std::string result = input;
+    boost::trim(result);
+    std::transform(result.begin(), result.end(), result.begin(),
+                   [](unsigned char c) { return static_cast<char>(std::toupper(c)); });
+    return result;
+}
+
+// Split a name into uppercase alphanumeric tokens, dropping any " @printer"
+// suffix.  Splitting on non-alphanumerics is what lets a reported "PLA" line up
+// with a preset named "PLA+", and what makes word order irrelevant, so
+// "PLA Matte" matches both "eSun PLA Matte" and "eSun Matte PLA".
+//   "eSun Matte PLA Black @Qidi X-Plus 4" -> [ESUN, MATTE, PLA, BLACK]
+//   "PLA_Matte"                           -> [PLA, MATTE]
+static std::vector<std::string> name_tokens_of(const std::string& name)
+{
+    const size_t      at   = name.find(" @");
+    const std::string base = (at == std::string::npos) ? name : name.substr(0, at);
+
+    std::vector<std::string> tokens;
+    std::string              cur;
+    for (char c : base) {
+        if (std::isalnum(static_cast<unsigned char>(c)))
+            cur.push_back(static_cast<char>(std::toupper(static_cast<unsigned char>(c))));
+        else if (!cur.empty()) {
+            tokens.push_back(cur);
+            cur.clear();
+        }
+    }
+    if (!cur.empty())
+        tokens.push_back(cur);
+    return tokens;
+}
+
+// Does `preset_name` contain every token of the reported product name?  Extra
+// tokens in the preset (vendor, colour, nozzle) are fine -- this asks only that
+// nothing the printer reported is missing.
+static bool name_covers(const std::string& preset_name, const std::vector<std::string>& wanted)
+{
+    const std::vector<std::string> have = name_tokens_of(preset_name);
+    for (const auto& w : wanted)
+        if (std::find(have.begin(), have.end(), w) == have.end())
+            return false;
+    return true;
+}
+
+std::string map_type_to_generic_id(const std::string& filament_type)
+{
+    const std::string upper = trim_and_upper(filament_type);
+
+    // PLA variants
+    if (upper == "PLA")           return "OGFL99";
+    if (upper == "PLA-CF")        return "OGFL98";
+    if (upper == "PLA SILK" || upper == "PLA-SILK") return "OGFL96";
+    if (upper == "PLA HIGH SPEED" || upper == "PLA-HS" || upper == "PLA HS") return "OGFL95";
+
+    // ABS/ASA variants
+    if (upper == "ABS")           return "OGFB99";
+    if (upper == "ASA")           return "OGFB98";
+
+    // PETG/PET variants
+    if (upper == "PETG" || upper == "PET") return "OGFG99";
+    if (upper == "PCTG")          return "OGFG97";
+
+    // PA/Nylon variants
+    if (upper == "PA" || upper == "NYLON") return "OGFN99";
+    if (upper == "PA-CF")         return "OGFN98";
+    if (upper == "PPA" || upper == "PPA-CF") return "OGFN97";
+    if (upper == "PPA-GF")        return "OGFN96";
+
+    // PC variants
+    if (upper == "PC")            return "OGFC99";
+
+    // PP/PE variants
+    if (upper == "PE")            return "OGFP99";
+    if (upper == "PP")            return "OGFP97";
+
+    // Support materials
+    if (upper == "PVA")           return "OGFS99";
+    if (upper == "HIPS")          return "OGFS98";
+    if (upper == "BVOH")          return "OGFS97";
+
+    // TPU variants
+    if (upper == "TPU")           return "OGFU99";
+
+    // Other materials
+    if (upper == "EVA")           return "OGFR99";
+    if (upper == "PHA")           return "OGFR98";
+    if (upper == "COPE")          return "OGFLC99";
+    if (upper == "SBS")           return "OFLSBS99";
+
+    return UNKNOWN_FILAMENT_ID;
+}
+
+std::string resolve_filament_type(const PresetCollection& filaments, const std::string& reported)
+{
+    std::vector<std::string> want = name_tokens_of(reported);
+    if (want.empty())
+        return {};
+
+    // The one synonym the profiles do not spell out for themselves.
+    for (auto& t : want)
+        if (t == "NYLON")
+            t = "PA";
+
+    std::string best;
+    size_t      best_tokens = 0;
+    size_t      best_len    = 0;
+
+    for (const auto& p : filaments.get_presets()) {
+        if (!(p.is_visible && p.is_compatible))
+            continue;
+        const std::string type = p.config.opt_string("filament_type", 0u);
+        if (type.empty() || type == best)
+            continue;
+
+        const std::vector<std::string> have = name_tokens_of(type);
+        if (have.empty())
+            continue;
+        bool qualifies = true;
+        for (const auto& t : have)
+            if (std::find(want.begin(), want.end(), t) == want.end()) {
+                qualifies = false;
+                break;
+            }
+        if (!qualifies)
+            continue;
+
+        // Most specific wins: more tokens, then longer text, then name order so
+        // the result never depends on collection order.
+        const bool better = have.size() != best_tokens ? have.size() > best_tokens
+                          : type.size() != best_len    ? type.size() > best_len
+                                                       : (best.empty() || type < best);
+        if (better) {
+            best        = type;
+            best_tokens = have.size();
+            best_len    = type.size();
+        }
+    }
+    return best;
+}
+
+// Parse an "RRGGBB" or "RRGGBBAA" hex color (optional leading '#') into a
+// 24-bit 0xRRGGBB value, ignoring any trailing alpha.  Returns false when the
+// string does not start with at least six hex digits.
+static bool parse_rgb_hex(const std::string& color, unsigned int& rgb_out)
+{
+    const size_t start = (!color.empty() && color.front() == '#') ? 1 : 0;
+    if (color.size() < start + 6)
+        return false;
+    const std::string rgb = color.substr(start, 6);
+    if (rgb.find_first_not_of("0123456789abcdefABCDEF") != std::string::npos)
+        return false;
+    rgb_out = static_cast<unsigned int>(std::stoul(rgb, nullptr, 16));
+    return true;
+}
+
+// Squared Euclidean distance between two 0xRRGGBB colors.
+static unsigned int rgb_distance(unsigned int a, unsigned int b)
+{
+    const int dr = static_cast<int>(a & 0xff)         - static_cast<int>(b & 0xff);
+    const int dg = static_cast<int>((a >> 8) & 0xff)  - static_cast<int>((b >> 8) & 0xff);
+    const int db = static_cast<int>((a >> 16) & 0xff) - static_cast<int>((b >> 16) & 0xff);
+    return static_cast<unsigned int>(dr * dr + dg * dg + db * db);
+}
+
+// id closest-color match: among visible, compatible presets whose filament_id is
+// `group` + "_" + a 6-digit hex color, return the id nearest (RGB) to target_rgb.
+// The bare `group` (no color suffix) belongs to the exact-id matches, not here.
+//
+// The strict 6-hex suffix is what makes this name-safe: group "..._PLA_Plus"
+// matches "..._PLA_Plus_FF0000" but never "..._PLA_Plus_Matte_FF0000" or a bare
+// "..._PLA".  There is deliberately no distance floor -- the vendor+filament
+// group is the scope limit and color only breaks ties, so a single authored
+// color still applies to every color of that vendor+filament.
+static const Preset* id_closest_color(const PresetCollection& filaments,
+                                      const std::string&      group,
+                                      unsigned int            target_rgb)
+{
+    const Preset* best          = nullptr;
+    unsigned int  best_distance = std::numeric_limits<unsigned int>::max();
+
+    for (const auto& p : filaments.get_presets()) {
+        if (!(p.is_visible && p.is_compatible))
+            continue;
+        const std::string& id = p.filament_id;
+        if (id.size() != group.size() + 7 || id[group.size()] != '_'
+            || !boost::iequals(id.substr(0, group.size()), group))
+            continue;
+        unsigned int cand_rgb = 0;
+        if (!parse_rgb_hex(id.substr(group.size() + 1), cand_rgb)) // 6-char suffix
+            continue;
+        const unsigned int distance = rgb_distance(target_rgb, cand_rgb);
+        if (distance < best_distance) {
+            best_distance = distance;
+            best          = &p;
+        }
+    }
+    return best;
+}
+
+// config-field match: among visible, compatible presets whose config
+// filament_type equals `type` (and, when vendor_norm is non-empty, whose
+// normalized filament_vendor equals it case-insensitively), return a preset.
+// When have_color, the nearest default_filament_colour to target_rgb wins;
+// otherwise the first match is returned.  Empty vendor_norm means "any vendor".
+//
+// The vendor is normalized with sanitize_for_id() on both sides and compared
+// case-insensitively, so "SUNLU" matches a preset's "Sunlu", and a separator
+// difference matches once both sides collapse to the same token ("Acme Inc" and
+// "Acme-Inc" both become "Acme_Inc").  It does not bridge a separator that only
+// one side has: a reported "eSUN" will not match a preset's "e-Sun", because
+// only the latter gains an underscore.
+//
+// Derived presets are eligible, not just bases.  This is the path a GUI user
+// has -- they save a preset from a vendor profile, which makes it derived, and
+// set filament_vendor/default_filament_colour on it.  Restricting the match to
+// bases excluded exactly those presets while admitting the hand-authored
+// user-root ones, so whether a preset could be matched came down to whether its
+// JSON happened to carry an "inherits" key.
+// When `name_tokens` is non-empty, only presets whose name carries every token
+// of the reported product qualify.  This is the signal that separates two
+// profiles of the same vendor and type -- the printer says "PLA Matte", and
+// nothing in filament_vendor/filament_type/default_filament_colour can tell an
+// "eSun PLA Matte" profile from an "eSun PLA+" one.
+static const Preset* config_match(const PresetCollection&         filaments,
+                                  const std::string&              vendor_norm,
+                                  const std::string&              type,
+                                  const std::vector<std::string>& name_tokens,
+                                  bool                            have_color,
+                                  unsigned int                    target_rgb)
+{
+    const Preset* best          = nullptr;
+    unsigned int  best_distance = std::numeric_limits<unsigned int>::max();
+
+    for (const auto& p : filaments.get_presets()) {
+        if (!(p.is_visible && p.is_compatible))
+            continue;
+        if (p.config.opt_string("filament_type", 0u) != type)
+            continue;
+        if (!vendor_norm.empty()
+            && !boost::iequals(sanitize_for_id(p.config.opt_string("filament_vendor", 0u)), vendor_norm))
+            continue;
+        if (!name_tokens.empty() && !name_covers(p.name, name_tokens))
+            continue;
+        if (!have_color)
+            return &p; // first match
+
+        // Presets store color as "#RRGGBB".  A preset that declares no usable
+        // color sits this level out: it has no color evidence to offer, and
+        // scoring it as some default would let it compete on a color it never
+        // claimed.  It stays eligible on the colorless levels below.
+        unsigned int p_rgb = 0;
+        if (!parse_rgb_hex(p.config.opt_string("default_filament_colour", 0u), p_rgb))
+            continue;
+        const unsigned int distance = rgb_distance(target_rgb, p_rgb);
+        if (distance < best_distance) {
+            best_distance = distance;
+            best          = &p;
+        }
+    }
+    return best;
+}
+
+// Resolve the best filament_id for `input` by walking the V/F/C/P cascade
+// documented in FilamentMatcher.hpp, from most to least specific.
+FilamentMatchResult resolve(const PresetCollection* filaments, const FilamentMatchInput& input)
+{
+    const bool have_prefix = !input.prefix.empty();
+    const bool have_name   = !input.filament_name.empty();
+
+    // C: parse the reported color once (used by every closest-color match).
+    unsigned int target_rgb = 0;
+    const bool   have_color = parse_rgb_hex(input.color, target_rgb);
+
+    BOOST_LOG_TRIVIAL(info) << "FilamentMatcher::resolve: prefix=\"" << input.prefix
+                            << "\" vendor=\"" << input.vendor_name << "\" name=\""
+                            << input.filament_name << "\" type=\"" << input.tray_type
+                            << "\" color=\"" << input.color << "\"";
+
+    // V[]: vendor identities, most specific first.
+    std::vector<std::string> vendors;
+    if (!input.vendor_name.empty()) vendors.push_back(input.vendor_name);
+    if (input.vendor_type >= 0)     vendors.push_back(std::to_string(input.vendor_type));
+
+    // F[] for the vendor-bearing levels (1 & 2).  Per the name-safety rule, the
+    // coarse base type is excluded here whenever a specific filament name exists,
+    // so e.g. "PLA Plus" never collapses onto a bare "PLA" profile.
+    std::vector<std::string> fil_vf;
+    if (have_name)               fil_vf.push_back(input.filament_name);
+    if (input.filament_idx > 0)  fil_vf.push_back(std::to_string(input.filament_idx));
+    if (!have_name && !input.tray_type.empty()) fil_vf.push_back(input.tray_type);
+
+    // F[] for the vendor-less levels (3 & 4): all filament identities, base type
+    // included.
+    std::vector<std::string> fil_f = fil_vf;
+    if (have_name && !input.tray_type.empty()) fil_f.push_back(input.tray_type);
+
+    // Config-field matching uses only the string forms and never a prefix.
+    //
+    // The vendor+type variants run even when a filament_name is present.  They
+    // are coarser than an id match -- they can only key F on the base type --
+    // but they already sit below every id match in the cascade, so a reported
+    // name gets its chance first.  Skipping them outright whenever a name
+    // existed switched vendor matching off for every printer that reports one,
+    // which handed those slots to the vendor-less level 3 instead: a strictly
+    // worse answer, since it drops the vendor rather than the name.
+    const bool cfg_vf = filaments && !input.vendor_name.empty() && !input.tray_type.empty();
+    const bool cfg_f  = filaments && !input.tray_type.empty();
+
+    // Tokens of the reported product name, used to narrow the config rungs.
+    // Empty when the printer reports no name, which leaves those rungs exactly
+    // as they were for vendor+type-only printers such as Snapmaker.
+    const std::vector<std::string> name_tokens = have_name ? name_tokens_of(input.filament_name)
+                                                           : std::vector<std::string>{};
+    const bool                     have_names  = !name_tokens.empty();
+
+    auto matched = [](const Preset* p, const char* label) {
+        BOOST_LOG_TRIVIAL(info) << "  -> matched at " << label << ": \"" << p->filament_id
+                                << "\" (preset \"" << p->name << "\")";
+        return FilamentMatchResult{p->filament_id, p->name};
+    };
+    auto matched_id = [](const std::string& id, const char* label) {
+        BOOST_LOG_TRIVIAL(info) << "  -> matched at " << label << ": \"" << id << "\"";
+        return FilamentMatchResult{id, std::string()};
+    };
+
+    if (filaments) {
+        // ---- Level 1: V + F + closest color ----
+        if (have_color) {
+            for (const auto& v : vendors)
+                for (const auto& f : fil_vf) {
+                    if (have_prefix) {
+                        const Preset* p = id_closest_color(*filaments, input.prefix + "_" + v + "_" + f, target_rgb);
+                        if (p) return matched(p, "1a id");
+                    }
+                    const Preset* p = id_closest_color(*filaments, v + "_" + f, target_rgb);
+                    if (p) return matched(p, "1b id");
+                }
+        }
+        // Config-field rungs for the vendor+type scope, most specific first.
+        //
+        // The product name outranks the color.  A preset that matches what the
+        // printer said the filament *is* beats one that merely matches what
+        // color it is: keying these rungs on color alone let an "eSun PLA+
+        // Black" profile (#000000) win an "eSun PLA Matte" spool reported as
+        // 060606, because it sits nearer than the matte profile's #202020.  No
+        // amount of color precision fixes that -- color was never an identity.
+        if (cfg_vf) {
+            if (have_names && have_color) {
+                const Preset* p = config_match(*filaments, input.vendor_name, input.tray_type, name_tokens, true, target_rgb);
+                if (p) return matched(p, "1c cfg V+T+name+color");
+            }
+            if (have_names) {
+                const Preset* p = config_match(*filaments, input.vendor_name, input.tray_type, name_tokens, false, 0);
+                if (p) return matched(p, "1d cfg V+T+name");
+            }
+        }
+
+        // ---- Level 2: V + F ----
+        for (const auto& v : vendors)
+            for (const auto& f : fil_vf) {
+                if (have_prefix) {
+                    const Preset* p = find_visible_preset(*filaments, input.prefix + "_" + v + "_" + f);
+                    if (p) return matched(p, "2a id");
+                }
+                const Preset* p = find_visible_preset(*filaments, v + "_" + f);
+                if (p) return matched(p, "2b id");
+            }
+        // The color-only rungs wait until every identity-bearing rung above has
+        // had its turn -- an authored filament_id states what a preset *is*, so
+        // it outranks a match that only knows the vendor, the type and a nearby
+        // color.  Identity first, then color, in that order throughout.
+        if (cfg_vf) {
+            if (have_color) {
+                const Preset* p = config_match(*filaments, input.vendor_name, input.tray_type, {}, true, target_rgb);
+                if (p) return matched(p, "2c cfg V+T+color");
+            }
+            const Preset* p = config_match(*filaments, input.vendor_name, input.tray_type, {}, false, 0);
+            if (p) return matched(p, "2d cfg V+T");
+        }
+
+        // ---- Level 3: F + closest color ----
+        if (have_color) {
+            for (const auto& f : fil_f) {
+                if (have_prefix) {
+                    const Preset* p = id_closest_color(*filaments, input.prefix + "_" + f, target_rgb);
+                    if (p) return matched(p, "3a id");
+                }
+                const Preset* p = id_closest_color(*filaments, f, target_rgb);
+                if (p) return matched(p, "3b id");
+            }
+        }
+        // Same rung order as level 1, with the vendor dropped.
+        if (cfg_f) {
+            if (have_names && have_color) {
+                const Preset* p = config_match(*filaments, "", input.tray_type, name_tokens, true, target_rgb);
+                if (p) return matched(p, "3c cfg T+name+color");
+            }
+            if (have_names) {
+                const Preset* p = config_match(*filaments, "", input.tray_type, name_tokens, false, 0);
+                if (p) return matched(p, "3d cfg T+name");
+            }
+        }
+
+        // ---- Level 4: F ----
+        for (const auto& f : fil_f) {
+            if (have_prefix) {
+                const Preset* p = find_visible_preset(*filaments, input.prefix + "_" + f);
+                if (p) return matched(p, "4a id");
+            }
+            const Preset* p = find_visible_preset(*filaments, f);
+            if (p) return matched(p, "4b id");
+        }
+        if (cfg_f) {
+            // Color-only rung, after the vendor-less id rungs above.
+            if (have_color) {
+                const Preset* p = config_match(*filaments, "", input.tray_type, {}, true, target_rgb);
+                if (p) return matched(p, "4c cfg T+color");
+            }
+            // filament_id_by_type() answers with a type's generic id rather than
+            // one particular preset, so this level names no preset.
+            std::string id = filaments->filament_id_by_type(input.tray_type);
+            if (!id.empty() && id != UNKNOWN_FILAMENT_ID) return matched_id(id, "4d cfg T");
+        }
+    }
+    // No preset bundle (early init): fall back to the constructed numeric id when
+    // the printer supplied numeric indices, preserving the previous offline path.
+    else if (have_prefix && input.vendor_type >= 0 && input.filament_idx > 0) {
+        return matched_id(input.prefix + "_" + std::to_string(input.vendor_type) + "_"
+                          + std::to_string(input.filament_idx), "no-bundle numeric");
+    }
+
+    // ---- Level 5: static generic ID mapping (built-in codes) ----
+    if (!input.tray_type.empty()) {
+        std::string id = map_type_to_generic_id(input.tray_type);
+        BOOST_LOG_TRIVIAL(info) << "  Level 5: map_type_to_generic_id(\"" << input.tray_type
+                                << "\") -> \"" << id << "\"";
+        return FilamentMatchResult{id, std::string()};
+    }
+
+    BOOST_LOG_TRIVIAL(info) << "  -> no match, returning UNKNOWN";
+    return FilamentMatchResult{UNKNOWN_FILAMENT_ID, std::string()};
+}
+
+} // namespace FilamentMatcher
+} // namespace Slic3r

--- a/src/slic3r/Utils/FilamentMatcher.cpp
+++ b/src/slic3r/Utils/FilamentMatcher.cpp
@@ -1,0 +1,223 @@
+#include "FilamentMatcher.hpp"
+#include "libslic3r/Preset.hpp"
+#include "libslic3r/PresetBundle.hpp"
+#include "slic3r/GUI/GUI_App.hpp"
+
+#include <boost/algorithm/string.hpp>
+#include <boost/log/trivial.hpp>
+#include <algorithm>
+#include <cctype>
+
+namespace Slic3r {
+namespace FilamentMatcher {
+
+// Sanitize filament vendor or filament name for use in preset IDs.
+// "Acme Inc" -> "Acme_Inc", "PLA Plus" -> "PLA_Plus", "PLA-AERO" -> "PLA_AERO"
+std::string sanitize_for_id(const std::string& name)
+{
+    std::string result;
+    result.reserve(name.size());
+    for (char c : name) {
+        if (std::isalnum(static_cast<unsigned char>(c)))
+            result.push_back(c);
+        else if (!result.empty() && result.back() != '_')
+            result.push_back('_');
+    }
+    if (!result.empty() && result.back() == '_')
+        result.pop_back();
+    return result;
+}
+
+bool has_visible_preset(const PresetCollection& filaments, const std::string& filament_id)
+{
+    for (const auto& p : filaments.get_presets()) {
+        if (p.is_visible && p.is_compatible
+            && boost::iequals(p.filament_id, filament_id))
+            return true;
+    }
+    return false;
+}
+
+static std::string trim_and_upper(const std::string& input)
+{
+    std::string result = input;
+    boost::trim(result);
+    std::transform(result.begin(), result.end(), result.begin(),
+                   [](unsigned char c) { return static_cast<char>(std::toupper(c)); });
+    return result;
+}
+
+std::string map_type_to_generic_id(const std::string& filament_type)
+{
+    const std::string upper = trim_and_upper(filament_type);
+
+    // PLA variants
+    if (upper == "PLA")           return "OGFL99";
+    if (upper == "PLA-CF")        return "OGFL98";
+    if (upper == "PLA SILK" || upper == "PLA-SILK") return "OGFL96";
+    if (upper == "PLA HIGH SPEED" || upper == "PLA-HS" || upper == "PLA HS") return "OGFL95";
+
+    // ABS/ASA variants
+    if (upper == "ABS")           return "OGFB99";
+    if (upper == "ASA")           return "OGFB98";
+
+    // PETG/PET variants
+    if (upper == "PETG" || upper == "PET") return "OGFG99";
+    if (upper == "PCTG")          return "OGFG97";
+
+    // PA/Nylon variants
+    if (upper == "PA" || upper == "NYLON") return "OGFN99";
+    if (upper == "PA-CF")         return "OGFN98";
+    if (upper == "PPA" || upper == "PPA-CF") return "OGFN97";
+    if (upper == "PPA-GF")        return "OGFN96";
+
+    // PC variants
+    if (upper == "PC")            return "OGFC99";
+
+    // PP/PE variants
+    if (upper == "PE")            return "OGFP99";
+    if (upper == "PP")            return "OGFP97";
+
+    // Support materials
+    if (upper == "PVA")           return "OGFS99";
+    if (upper == "HIPS")          return "OGFS98";
+    if (upper == "BVOH")          return "OGFS97";
+
+    // TPU variants
+    if (upper == "TPU")           return "OGFU99";
+
+    // Other materials
+    if (upper == "EVA")           return "OGFR99";
+    if (upper == "PHA")           return "OGFR98";
+    if (upper == "COPE")          return "OGFLC99";
+    if (upper == "SBS")           return "OFLSBS99";
+
+    return UNKNOWN_FILAMENT_ID;
+}
+
+// Multi-tier preset matching: most specific to least specific.
+// Agents build their prefix from agent ID + model (e.g. "QD_3", "SM_J1").
+//
+// Example with prefix="QD_3" (QIDI X-Max 4):
+//
+//   [fila52]               filament = PLA Plus
+//   [colordict]            52       = #FAFAFA
+//   [vendor_list]          7        = Acme Inc
+//
+//   Tier 1: QD_3_Acme_Inc_PLA_Plus_FAFAFA  (filament vendor + name + color)
+//   Tier 2: QD_3_Acme_Inc_PLA_Plus         (filament vendor + name)
+//   Tier 3: QD_3_7_52                      (numeric vendor + filament index)
+//   Tier 4: filament_id_by_type("PLA")
+//   Tier 5: map_type_to_generic_id("PLA") -> "OGFL99"
+std::string resolve(const FilamentMatchInput& input)
+{
+    auto* bundle = GUI::wxGetApp().preset_bundle;
+
+    const bool have_prefix = !input.prefix.empty();
+    const bool have_names  = !input.vendor_name.empty() && !input.filament_name.empty();
+
+    BOOST_LOG_TRIVIAL(info) << "FilamentMatcher::resolve: tray_type=\"" << input.tray_type
+                            << "\" prefix=\"" << input.prefix << "\"";
+
+    // Track whether the printer gave us enough data to attempt precise tiers.
+    // If it did but none matched, we warn the user so they can create a
+    // filament profile with one of the candidate IDs.
+    bool tried_precise = false;
+    std::string tier1_id, tier2_id, tier3_id;
+
+    if (bundle && have_prefix && have_names) {
+        // Tier 1: {prefix}_{FilamentVendor}_{FilamentName}_{ColorHex}
+        // e.g. QD_3_Acme_Inc_PLA_Plus_FAFAFA
+        // Matches a preset for a specific filament vendor + material + color.
+        if (!input.color_hex.empty()) {
+            tier1_id = input.prefix + "_" + input.vendor_name + "_"
+                     + input.filament_name + "_" + input.color_hex;
+            tried_precise = true;
+            BOOST_LOG_TRIVIAL(info) << "  Tier 1: trying filament_id=\"" << tier1_id << "\"";
+            if (has_visible_preset(bundle->filaments, tier1_id)) {
+                BOOST_LOG_TRIVIAL(info) << "  -> matched at Tier 1";
+                return tier1_id;
+            }
+        }
+
+        // Tier 2: {prefix}_{FilamentVendor}_{FilamentName}
+        // e.g. QD_3_Acme_Inc_PLA_Plus
+        // Matches any color of a specific filament vendor + material.
+        tier2_id = input.prefix + "_" + input.vendor_name + "_" + input.filament_name;
+        tried_precise = true;
+        BOOST_LOG_TRIVIAL(info) << "  Tier 2: trying filament_id=\"" << tier2_id << "\"";
+        if (has_visible_preset(bundle->filaments, tier2_id)) {
+            BOOST_LOG_TRIVIAL(info) << "  -> matched at Tier 2";
+            return tier2_id;
+        }
+    }
+
+    // Tier 3: {prefix}_{vendor_num}_{filament_idx}
+    // e.g. QD_3_7_52
+    // Numeric lookup using raw vendor and filament indices from the printer.
+    // This is the format used by existing QIDI filament profiles.
+    if (have_prefix && input.filament_idx > 0) {
+        tier3_id = input.prefix + "_" + std::to_string(input.vendor_type) + "_"
+                 + std::to_string(input.filament_idx);
+        tried_precise = true;
+        BOOST_LOG_TRIVIAL(info) << "  Tier 3: trying filament_id=\"" << tier3_id << "\"";
+        if (!bundle || has_visible_preset(bundle->filaments, tier3_id)) {
+            BOOST_LOG_TRIVIAL(info) << "  -> matched at Tier 3";
+            return tier3_id;
+        }
+    }
+
+    // If the printer reported enough data for precise matching but none of
+    // the candidate IDs matched an installed preset, warn the user.  This
+    // tells them exactly what filament_id to set in a custom filament profile
+    // to get an exact match next time.
+    //
+    // We only warn when precise tiers were attempted -- agents that only
+    // provide tray_type (e.g. generic Moonraker, Snapmaker) can't do any
+    // better, so warning them would be noise.
+    if (tried_precise) {
+        std::string candidates;
+        if (!tier1_id.empty())
+            candidates += "\"" + tier1_id + "\", ";
+        if (!tier2_id.empty())
+            candidates += "\"" + tier2_id + "\", ";
+        if (!tier3_id.empty())
+            candidates += "\"" + tier3_id + "\"";
+        BOOST_LOG_TRIVIAL(warning)
+            << "FilamentMatcher: no precise preset found for \""
+            << input.filament_name << "\" (type " << input.tray_type
+            << ").  Falling back to generic type match.  "
+            << "To get an exact match, create a filament profile with "
+            << "filament_id set to one of: " << candidates;
+    }
+
+    // Tier 4: preset bundle type-based lookup
+    // Searches installed presets for one whose filament_type matches tray_type
+    // (e.g. "PLA").  This is the path taken by agents that only report a material
+    // type without vendor/color data (Moonraker, Snapmaker today).
+    if (bundle && !input.tray_type.empty()) {
+        std::string id = bundle->filaments.filament_id_by_type(input.tray_type);
+        BOOST_LOG_TRIVIAL(info) << "  Tier 4: filament_id_by_type(\"" << input.tray_type
+                                << "\") -> \"" << id << "\"";
+        if (!id.empty() && id != UNKNOWN_FILAMENT_ID) {
+            BOOST_LOG_TRIVIAL(info) << "  -> matched at Tier 4";
+            return id;
+        }
+    }
+
+    // Tier 5: static generic ID mapping
+    // Last resort when no preset bundle is loaded.  Maps type strings to
+    // OrcaFilamentLibrary IDs, e.g. "PLA" -> "OGFL99", "ABS" -> "OGFB99".
+    if (!input.tray_type.empty()) {
+        std::string id = map_type_to_generic_id(input.tray_type);
+        BOOST_LOG_TRIVIAL(info) << "  Tier 5: map_type_to_generic_id(\"" << input.tray_type
+                                << "\") -> \"" << id << "\"";
+        return id;
+    }
+
+    BOOST_LOG_TRIVIAL(info) << "  -> no match, returning UNKNOWN";
+    return UNKNOWN_FILAMENT_ID;
+}
+
+} // namespace FilamentMatcher
+} // namespace Slic3r

--- a/src/slic3r/Utils/FilamentMatcher.hpp
+++ b/src/slic3r/Utils/FilamentMatcher.hpp
@@ -1,0 +1,183 @@
+#ifndef __FILAMENT_MATCHER_HPP__
+#define __FILAMENT_MATCHER_HPP__
+
+#include <string>
+
+namespace Slic3r {
+
+class Preset;
+class PresetCollection;
+
+// Shared filament-to-preset matching for all printer agents.
+//
+// Each agent populates a FilamentMatchInput with whatever data the printer
+// provides, then calls FilamentMatcher::resolve().  The matcher works from three
+// pieces of information -- and does not care whether a given printer reports a
+// name or a numeric code or a base type for each:
+//
+//   V  vendor info    : vendor_name and/or vendor_type
+//   F  filament info  : filament_name and/or filament_idx and/or tray_type
+//   C  color          : color
+//   P  prefix         : optional agent+model tag, tried as both "P_..." and "..."
+//
+// A printer that fills more than one form of V or F (QIDI reports a vendor name
+// *and* a numeric id, a filament name *and* an index *and* a base type) produces
+// a V[]/F[] list, and every id match tries each V x F combination.
+//
+// Cascade (most specific -> least specific; C-hat = closest color, exact wins
+// at distance 0 so no separate exact-color level is needed). Each level has an
+// id-string match and a config-field match; the "a" variants add the prefix:
+//
+//   Level 1  V + F + Chat   1a id  [P_]V_F_<hex>, nearest       e.g. QD_3_Acme_Inc_PLA_Plus_F0F0F0
+//                           1b id  V_F_<hex>, nearest
+//                           1c cfg filament_vendor=V & filament_type=T & name, nearest color
+//                           1d cfg filament_vendor=V & filament_type=T & name (any color)
+//   Level 2  V + F          2a id  [P_]V_F                       e.g. QD_3_Acme_Inc_PLA_Plus  /  QD_3_7_52
+//                           2b id  V_F
+//                           2c cfg filament_vendor=V & filament_type=T, nearest color
+//                           2d cfg filament_vendor=V & filament_type=T (any color)
+//   Level 3  F + Chat       3a/3b id [P_]F_<hex>, nearest
+//                           3c cfg filament_type=T & name, nearest color
+//                           3d cfg filament_type=T & name (any color)
+//   Level 4  F              4a/4b id [P_]F
+//                           4c cfg filament_type=T, nearest color
+//                           4d cfg filament_type=T   (== filament_id_by_type)
+//   Level 5  generic        map_type_to_generic_id(tray_type)   e.g. "PLA" -> "OGFL99"
+//
+// "& name" narrows to presets whose *preset name* carries every token of the
+// reported filament name, compared as uppercase alphanumeric tokens with any
+// " @printer" suffix dropped.  Tokenizing this way makes word order irrelevant
+// ("PLA Matte" matches both "eSun PLA Matte" and "eSun Matte PLA") and lets a
+// reported "PLA" line up with a preset named "PLA+".
+//
+// The id levels and the config levels serve different authors.  filament_id is
+// not a PrintConfig option -- there is no GUI field for it, and a preset saved
+// from the GUI inherits its parent's id -- so the id levels are reachable only
+// by hand-editing profile JSON.  filament_vendor, filament_type and
+// default_filament_colour are all GUI-editable, which makes the config levels
+// the only matching mechanism available to a user who has not edited files by
+// hand.  Both must work; neither may switch the other off.
+//
+// Rules that keep a coarse base type from masquerading as a specific filament:
+//  - tray_type is excluded from the vendor-bearing levels (1 & 2) whenever a
+//    filament_name is present, so "Acme PLA Plus" never lands on an "Acme PLA"
+//    profile.  It still drives the vendor-less levels 3/4 and the generic 5.
+//  - config-field matching only ever keys F on filament_type (profiles carry no
+//    "name" field), uses only the string forms of V/F, and carries no prefix.
+//    That makes it coarser than an id match, which is why it sits below every id
+//    match in the cascade -- a reported filament name is honoured there first.
+//
+// Color is evidence, never a substitute for it.  Two rules follow from that:
+//
+//  - A preset that declares no default_filament_colour sits out the
+//    closest-color rungs rather than being scored as some default color, and
+//    stays eligible on the colorless rungs below.  Scoring colorless presets as
+//    black made every preset in a color-less vendor profile set tie at the same
+//    distance, so the winner fell out of collection order and the reported color
+//    changed nothing at all.
+//
+//  - Identity outranks color everywhere.  Every rung that knows what a filament
+//    *is* -- a reported product name, or an authored filament_id -- is tried
+//    before any rung that only knows what color it is.  Color cannot separate
+//    two profiles of the same vendor and type, and letting it try makes it pick
+//    by the wrong criterion: an "eSun PLA+ Black" profile (#000000) would take
+//    an "eSun PLA Matte" spool reported as 060606 away from the matte profile
+//    at #202020, purely because black sits nearer.  That is why the color-only
+//    config rungs (2c, 4c) wait until after the id rungs at levels 2 and 4.
+//
+// Examples: QIDI X-Max 4 -> prefix "QD_3", V=[Acme_Inc, 7], F=[PLA_Plus, 52];
+//           Snapmaker    -> no prefix, V=[eSUN], F=[PLA-CF] (its config match at
+//                           level 1c is the vendor+type closest-color path);
+//           Moonraker    -> F=[PLA] only -> config 4c / generic 5.
+
+struct FilamentMatchInput {
+    std::string prefix;            // P: agent+model prefix, e.g. "QD_3" (optional)
+
+    // V: vendor info (either or both forms).
+    std::string vendor_name;       // Sanitized vendor name, e.g. "Acme_Inc"
+    int         vendor_type = -1;  // Numeric vendor id (>= 0 when provided)
+
+    // F: filament info (any subset).
+    std::string filament_name;     // Sanitized filament name, e.g. "PLA_Plus"
+    int         filament_idx = -1; // Numeric filament index (> 0 when provided)
+    std::string tray_type;         // Base material type, e.g. "PLA" / "PLA-CF"
+
+    // C: reported color as RRGGBB or RRGGBBAA hex (optional leading '#').
+    std::string color;             // e.g. "FAFAFA" or "1A2B3CFF"
+};
+
+namespace FilamentMatcher {
+
+// What a resolve() call concluded.
+//
+// filament_id is always set; it is what the AMS payload carries as
+// tray_info_idx and what every consumer understood before preset_name existed.
+//
+// preset_name is set only when the match identified one specific preset, and is
+// how that preset survives the trip to PresetBundle::sync_ams_list().  A
+// filament_id cannot carry the answer on its own: ids are shared in real profile
+// data (in one shipped vendor set a single id covers dozens of products across
+// several filament types), and every GUI-created preset inherits its parent's
+// id, so resolving an id back to a preset can only pick the first of many.  When
+// preset_name is empty -- generic fallbacks, or no preset bundle -- consumers
+// fall back to looking up filament_id, which is the right behavior for an answer
+// that was never about one particular preset.
+struct FilamentMatchResult {
+    std::string filament_id;
+    std::string preset_name;
+};
+
+// Resolve the best matching filament preset for the given input, walking the
+// cascade above from most to least specific and skipping any level whose inputs
+// are missing.
+//
+// `filaments` is the collection to match against (the caller passes the GUI
+// preset bundle's filament collection, or nullptr when none is loaded yet).
+// Taking it as a parameter -- rather than reaching for the GUI singleton -- keeps
+// the matcher free of GUI state and lets it be unit tested against a synthetic
+// collection.
+FilamentMatchResult resolve(const PresetCollection* filaments, const FilamentMatchInput& input);
+
+// Sanitize a filament vendor or filament name for use in preset IDs.
+// Non-alphanumeric characters become underscores; consecutive underscores
+// are collapsed and trailing underscores are stripped.
+//   "Acme Inc"     -> "Acme_Inc"      (filament vendor name)
+//   "PLA Plus"     -> "PLA_Plus"      (filament name)
+//   "PLA-AERO"     -> "PLA_AERO"      (filament name)
+//   "TPU-AERO 64D" -> "TPU_AERO_64D"  (filament name)
+std::string sanitize_for_id(const std::string& name);
+
+// Find a visible, compatible preset with the given filament_id, or nullptr.
+// Matches both system base presets and user presets with custom filament_id.
+// Uses case-insensitive comparison so profile authors don't need to match
+// exact casing from the printer's filament config.
+const Preset* find_visible_preset(const PresetCollection& filaments, const std::string& filament_id);
+
+// Map a filament type string (e.g. "PLA", "ABS") to an OrcaFilamentLibrary
+// generic preset ID (e.g. "OGFL99").  Used as the last-resort fallback when
+// no preset bundle is available.
+std::string map_type_to_generic_id(const std::string& filament_type);
+
+// Resolve a filament name the printer reported ("PLA-CF", "PLA Matte",
+// "PAHT-CF") to the most specific filament_type that actually exists in
+// `filaments`, or "" when nothing matches.
+//
+// A candidate type qualifies when every one of its tokens appears in the
+// reported name, and the most specific qualifying type wins -- so "PLA-CF"
+// resolves to PLA-CF rather than PLA, while "PLA Matte" still resolves to PLA
+// because no "Matte" type exists.  Reading the vocabulary out of the collection
+// rather than hardcoding it means a material added to the profiles works with no
+// code change, and a composite degrades to its base ("PLA-CF" -> "PLA") for a
+// user who has no CF profiles installed.
+//
+// This exists because a hardcoded substring ladder cannot express the
+// vocabulary: it returned on the first hit, so "PLA-CF" became "PLA",
+// "PAHT-CF" became "PA" and "PC-ABS-FR" became "ABS" -- and since the config
+// rungs gate on filament_type, every one of those spools was excluded from its
+// own profiles before matching began.
+std::string resolve_filament_type(const PresetCollection& filaments, const std::string& reported);
+
+} // namespace FilamentMatcher
+} // namespace Slic3r
+
+#endif

--- a/src/slic3r/Utils/FilamentMatcher.hpp
+++ b/src/slic3r/Utils/FilamentMatcher.hpp
@@ -1,0 +1,83 @@
+#ifndef __FILAMENT_MATCHER_HPP__
+#define __FILAMENT_MATCHER_HPP__
+
+#include <string>
+
+namespace Slic3r {
+
+class PresetCollection;
+
+// Shared filament-to-preset matching for all printer agents.
+//
+// Each agent populates a FilamentMatchInput with whatever data the printer
+// provides, then calls FilamentMatcher::resolve() to find the best matching
+// OrcaSlicer filament preset.  Tiers that lack data are skipped automatically.
+//
+// Tier cascade (most specific -> least specific):
+//
+//   Tier 1: {prefix}_{FilamentVendor}_{FilamentName}_{ColorHex}
+//           e.g. QD_3_Acme_Inc_PLA_Plus_FAFAFA
+//
+//   Tier 2: {prefix}_{FilamentVendor}_{FilamentName}
+//           e.g. QD_3_Acme_Inc_PLA_Plus
+//
+//   Tier 3: {prefix}_{vendor_num}_{filament_idx}
+//           e.g. QD_3_7_52
+//
+//   Tier 4: filament_id_by_type(tray_type)
+//           Searches installed presets by material type, e.g. "PLA"
+//
+//   Tier 5: map_type_to_generic_id(tray_type)
+//           Static fallback to OrcaFilamentLibrary IDs, e.g. "PLA" -> "OGFL99"
+//
+// The prefix encodes both the agent and the printer model so that filament
+// profiles can target a specific printer.  Examples:
+//   QIDI X-Max 4:   prefix = "QD_3"
+//   Snapmaker J1:   prefix = "SM_J1"
+//   Generic Klipper: prefix = "MK"
+//
+// An agent with only tray_type (e.g. "PLA") skips tiers 1-3 and still gets
+// a correct match via tiers 4/5.  This is the current behavior for Moonraker
+// and Snapmaker agents.
+
+struct FilamentMatchInput {
+    std::string prefix;            // Agent + printer model prefix, e.g. "QD_3", "SM_J1", "MK"
+    std::string vendor_name;       // Sanitized filament vendor name, e.g. "Acme_Inc"
+    std::string filament_name;     // Sanitized filament name, e.g. "PLA_Plus"
+    std::string color_hex;         // Color hex without #, e.g. "FAFAFA"
+    int         vendor_type = -1;  // Numeric vendor ID
+    int         filament_idx = -1; // Numeric filament index
+    std::string tray_type;         // Base material type for fallback, e.g. "PLA"
+};
+
+namespace FilamentMatcher {
+
+// Resolve the best matching filament preset ID for the given input.
+// Tries tiers 1-5 from most specific to least specific, skipping tiers
+// where required fields are missing.
+std::string resolve(const FilamentMatchInput& input);
+
+// Sanitize a filament vendor or filament name for use in preset IDs.
+// Non-alphanumeric characters become underscores; consecutive underscores
+// are collapsed and trailing underscores are stripped.
+//   "Acme Inc"     -> "Acme_Inc"      (filament vendor name)
+//   "PLA Plus"     -> "PLA_Plus"      (filament name)
+//   "PLA-AERO"     -> "PLA_AERO"      (filament name)
+//   "TPU-AERO 64D" -> "TPU_AERO_64D"  (filament name)
+std::string sanitize_for_id(const std::string& name);
+
+// Check whether any visible, compatible preset has the given filament_id.
+// Matches both system base presets and user presets with custom filament_id.
+// Uses case-insensitive comparison so profile authors don't need to match
+// exact casing from the printer's filament config.
+bool has_visible_preset(const PresetCollection& filaments, const std::string& filament_id);
+
+// Map a filament type string (e.g. "PLA", "ABS") to an OrcaFilamentLibrary
+// generic preset ID (e.g. "OGFL99").  Used as the last-resort fallback when
+// no preset bundle is available.
+std::string map_type_to_generic_id(const std::string& filament_type);
+
+} // namespace FilamentMatcher
+} // namespace Slic3r
+
+#endif

--- a/src/slic3r/Utils/MoonrakerPrinterAgent.cpp
+++ b/src/slic3r/Utils/MoonrakerPrinterAgent.cpp
@@ -1,4 +1,5 @@
 #include "MoonrakerPrinterAgent.hpp"
+#include "FilamentMatcher.hpp"
 #include "Http.hpp"
 #include "libslic3r/Preset.hpp"
 #include "libslic3r/PresetBundle.hpp"
@@ -511,6 +512,14 @@ void MoonrakerPrinterAgent::build_ams_payload(int ams_count, int max_lane_index,
                 tray_json["tray_type"] = tray->tray_type;
                 tray_json["tray_color"] = normalize_color_value(tray->tray_color);
 
+                // Orca extension to the BBL tray format: the preset the matcher
+                // identified, when it identified one.  Carried alongside
+                // tray_info_idx rather than in it, because a filament_id can be
+                // shared by many presets and so cannot name one.
+                if (!tray->matched_preset_name.empty()) {
+                    tray_json["orca_preset_name"] = tray->matched_preset_name;
+                }
+
                 // Add temperature data if provided
                 if (tray->bed_temp > 0) {
                     tray_json["bed_temp"] = std::to_string(tray->bed_temp);
@@ -613,58 +622,6 @@ std::string MoonrakerPrinterAgent::trim_and_upper(const std::string& input)
     std::transform(result.begin(), result.end(), result.begin(),
                    [](unsigned char c) { return static_cast<char>(std::toupper(c)); });
     return result;
-}
-
-std::string MoonrakerPrinterAgent::map_filament_type_to_generic_id(const std::string& filament_type)
-{
-    const std::string upper = trim_and_upper(filament_type);
-
-    // Map to OrcaFilamentLibrary preset IDs (compatible with all printers)
-    // Source: resources/profiles/OrcaFilamentLibrary/filament/
-
-    // PLA variants
-    if (upper == "PLA")           return "OGFL99";
-    if (upper == "PLA-CF")        return "OGFL98";
-    if (upper == "PLA SILK" || upper == "PLA-SILK") return "OGFL96";
-    if (upper == "PLA HIGH SPEED" || upper == "PLA-HS" || upper == "PLA HS") return "OGFL95";
-
-    // ABS/ASA variants
-    if (upper == "ABS")           return "OGFB99";
-    if (upper == "ASA")           return "OGFB98";
-
-    // PETG/PET variants
-    if (upper == "PETG" || upper == "PET") return "OGFG99";
-    if (upper == "PCTG")          return "OGFG97";
-
-    // PA/Nylon variants
-    if (upper == "PA" || upper == "NYLON") return "OGFN99";
-    if (upper == "PA-CF")         return "OGFN98";
-    if (upper == "PPA" || upper == "PPA-CF") return "OGFN97";
-    if (upper == "PPA-GF")        return "OGFN96";
-
-    // PC variants
-    if (upper == "PC")            return "OGFC99";
-
-    // PP/PE variants
-    if (upper == "PE")            return "OGFP99";
-    if (upper == "PP")            return "OGFP97";
-
-    // Support materials
-    if (upper == "PVA")           return "OGFS99";
-    if (upper == "HIPS")          return "OGFS98";
-    if (upper == "BVOH")          return "OGFS97";
-
-    // TPU variants
-    if (upper == "TPU")           return "OGFU99";
-
-    // Other materials
-    if (upper == "EVA")           return "OGFR99";
-    if (upper == "PHA")           return "OGFR98";
-    if (upper == "COPE")          return "OGFLC99";
-    if (upper == "SBS")           return "OFLSBS99";
-
-    // Unknown material
-    return UNKNOWN_FILAMENT_ID;
 }
 
 // JSON helper methods - null-safe accessors
@@ -814,10 +771,17 @@ bool MoonrakerPrinterAgent::fetch_moonraker_filament_data(std::vector<AmsTrayDat
         tray.bed_temp = safe_json_int(lane_obj, "bed_temp");
         tray.nozzle_temp = safe_json_int(lane_obj, "nozzle_temp");
         tray.has_filament = !tray.tray_type.empty();
-        auto* bundle = GUI::wxGetApp().preset_bundle;
-        tray.tray_info_idx = bundle
-            ? bundle->filaments.filament_id_by_type(tray.tray_type)
-            : map_filament_type_to_generic_id(tray.tray_type);
+        // Moonraker reports only a material type (e.g. "PLA", "ABS"), so the
+        // vendor/color levels are skipped and matching falls through to the
+        // type-based levels.  If it later reports vendor/color, populate those
+        // fields here to get richer matching for free.
+        FilamentMatchInput match_input;
+        match_input.tray_type = tray.tray_type;
+        auto* preset_bundle = GUI::wxGetApp().preset_bundle;
+        auto  match         = FilamentMatcher::resolve(
+            preset_bundle ? &preset_bundle->filaments : nullptr, match_input);
+        tray.tray_info_idx       = match.filament_id;
+        tray.matched_preset_name = match.preset_name;
 
         max_lane_index = std::max(max_lane_index, lane_index);
         trays.push_back(tray);
@@ -942,10 +906,16 @@ bool MoonrakerPrinterAgent::fetch_hh_filament_info(std::vector<AmsTrayData>& tra
         tray.bed_temp = 0;  // HH doesn't provide bed temp in gate arrays
         tray.has_filament = true;
 
-        auto* bundle = GUI::wxGetApp().preset_bundle;
-        tray.tray_info_idx = bundle
-            ? bundle->filaments.filament_id_by_type(tray.tray_type)
-            : map_filament_type_to_generic_id(tray.tray_type);
+        // Happy Hare reports only a material type (e.g. "PLA"), so the
+        // vendor/color levels are skipped.  Populate more fields here if HH
+        // gains vendor/color reporting.
+        FilamentMatchInput match_input;
+        match_input.tray_type = tray.tray_type;
+        auto* preset_bundle = GUI::wxGetApp().preset_bundle;
+        auto  match         = FilamentMatcher::resolve(
+            preset_bundle ? &preset_bundle->filaments : nullptr, match_input);
+        tray.tray_info_idx       = match.filament_id;
+        tray.matched_preset_name = match.preset_name;
 
         max_lane_index = std::max(max_lane_index, gate_idx);
         trays.push_back(tray);

--- a/src/slic3r/Utils/MoonrakerPrinterAgent.cpp
+++ b/src/slic3r/Utils/MoonrakerPrinterAgent.cpp
@@ -1,4 +1,5 @@
 #include "MoonrakerPrinterAgent.hpp"
+#include "FilamentMatcher.hpp"
 #include "Http.hpp"
 #include "libslic3r/Preset.hpp"
 #include "libslic3r/PresetBundle.hpp"
@@ -605,58 +606,6 @@ std::string MoonrakerPrinterAgent::trim_and_upper(const std::string& input)
     return result;
 }
 
-std::string MoonrakerPrinterAgent::map_filament_type_to_generic_id(const std::string& filament_type)
-{
-    const std::string upper = trim_and_upper(filament_type);
-
-    // Map to OrcaFilamentLibrary preset IDs (compatible with all printers)
-    // Source: resources/profiles/OrcaFilamentLibrary/filament/
-
-    // PLA variants
-    if (upper == "PLA")           return "OGFL99";
-    if (upper == "PLA-CF")        return "OGFL98";
-    if (upper == "PLA SILK" || upper == "PLA-SILK") return "OGFL96";
-    if (upper == "PLA HIGH SPEED" || upper == "PLA-HS" || upper == "PLA HS") return "OGFL95";
-
-    // ABS/ASA variants
-    if (upper == "ABS")           return "OGFB99";
-    if (upper == "ASA")           return "OGFB98";
-
-    // PETG/PET variants
-    if (upper == "PETG" || upper == "PET") return "OGFG99";
-    if (upper == "PCTG")          return "OGFG97";
-
-    // PA/Nylon variants
-    if (upper == "PA" || upper == "NYLON") return "OGFN99";
-    if (upper == "PA-CF")         return "OGFN98";
-    if (upper == "PPA" || upper == "PPA-CF") return "OGFN97";
-    if (upper == "PPA-GF")        return "OGFN96";
-
-    // PC variants
-    if (upper == "PC")            return "OGFC99";
-
-    // PP/PE variants
-    if (upper == "PE")            return "OGFP99";
-    if (upper == "PP")            return "OGFP97";
-
-    // Support materials
-    if (upper == "PVA")           return "OGFS99";
-    if (upper == "HIPS")          return "OGFS98";
-    if (upper == "BVOH")          return "OGFS97";
-
-    // TPU variants
-    if (upper == "TPU")           return "OGFU99";
-
-    // Other materials
-    if (upper == "EVA")           return "OGFR99";
-    if (upper == "PHA")           return "OGFR98";
-    if (upper == "COPE")          return "OGFLC99";
-    if (upper == "SBS")           return "OFLSBS99";
-
-    // Unknown material
-    return UNKNOWN_FILAMENT_ID;
-}
-
 // JSON helper methods - null-safe accessors
 std::string MoonrakerPrinterAgent::safe_json_string(const nlohmann::json& obj, const char* key)
 {
@@ -804,10 +753,13 @@ bool MoonrakerPrinterAgent::fetch_moonraker_filament_data(std::vector<AmsTrayDat
         tray.bed_temp = safe_json_int(lane_obj, "bed_temp");
         tray.nozzle_temp = safe_json_int(lane_obj, "nozzle_temp");
         tray.has_filament = !tray.tray_type.empty();
-        auto* bundle = GUI::wxGetApp().preset_bundle;
-        tray.tray_info_idx = bundle
-            ? bundle->filaments.filament_id_by_type(tray.tray_type)
-            : map_filament_type_to_generic_id(tray.tray_type);
+        // AFC only reports material type (e.g. "PLA", "ABS"), so tiers 1-3
+        // are skipped and matching falls through to type-based tiers 4/5.
+        // If AFC later reports vendor/color, populate those fields here to
+        // get richer matching for free.
+        FilamentMatchInput match_input;
+        match_input.tray_type = tray.tray_type;
+        tray.tray_info_idx = FilamentMatcher::resolve(match_input);
 
         max_lane_index = std::max(max_lane_index, lane_index);
         trays.push_back(tray);
@@ -932,10 +884,12 @@ bool MoonrakerPrinterAgent::fetch_hh_filament_info(std::vector<AmsTrayData>& tra
         tray.bed_temp = 0;  // HH doesn't provide bed temp in gate arrays
         tray.has_filament = true;
 
-        auto* bundle = GUI::wxGetApp().preset_bundle;
-        tray.tray_info_idx = bundle
-            ? bundle->filaments.filament_id_by_type(tray.tray_type)
-            : map_filament_type_to_generic_id(tray.tray_type);
+        // Happy Hare only reports material type (e.g. "PLA"), so tiers 1-3
+        // are skipped.  Same as AFC above -- populate more fields here if
+        // HH gains vendor/color reporting.
+        FilamentMatchInput match_input;
+        match_input.tray_type = tray.tray_type;
+        tray.tray_info_idx = FilamentMatcher::resolve(match_input);
 
         max_lane_index = std::max(max_lane_index, gate_idx);
         trays.push_back(tray);

--- a/src/slic3r/Utils/MoonrakerPrinterAgent.hpp
+++ b/src/slic3r/Utils/MoonrakerPrinterAgent.hpp
@@ -95,6 +95,10 @@ protected:
         std::string tray_type;           // Material type (e.g., "PLA", "ASA")
         std::string tray_color;          // Raw color (#RRGGBB, 0xRRGGBB, or RRGGBBAA)
         std::string tray_info_idx;       // Setting ID (optional)
+        // Name of the preset the matcher settled on, when it identified one.
+        // tray_info_idx alone cannot name a preset: filament_id is shared across
+        // presets in real profile data, and GUI-created presets inherit theirs.
+        std::string matched_preset_name; // Optional
         int         bed_temp = 0;        // Optional
         int         nozzle_temp = 0;     // Optional
     };
@@ -117,9 +121,6 @@ protected:
 
     // Trim whitespace and convert to uppercase
     static std::string trim_and_upper(const std::string& input);
-
-    // Map filament type to OrcaFilamentLibrary preset ID for AMS sync compatibility
-    static std::string map_filament_type_to_generic_id(const std::string& filament_type);
 
 private:
     int handle_request(const std::string& dev_id, const std::string& json_str);

--- a/src/slic3r/Utils/MoonrakerPrinterAgent.hpp
+++ b/src/slic3r/Utils/MoonrakerPrinterAgent.hpp
@@ -117,9 +117,6 @@ protected:
     // Trim whitespace and convert to uppercase
     static std::string trim_and_upper(const std::string& input);
 
-    // Map filament type to OrcaFilamentLibrary preset ID for AMS sync compatibility
-    static std::string map_filament_type_to_generic_id(const std::string& filament_type);
-
 private:
     int handle_request(const std::string& dev_id, const std::string& json_str);
     int send_version_info(const std::string& dev_id);

--- a/src/slic3r/Utils/QidiPrinterAgent.cpp
+++ b/src/slic3r/Utils/QidiPrinterAgent.cpp
@@ -1,4 +1,5 @@
 #include "QidiPrinterAgent.hpp"
+#include "FilamentMatcher.hpp"
 #include "Http.hpp"
 #include "libslic3r/PresetBundle.hpp"
 #include "slic3r/GUI/GUI_App.hpp"
@@ -10,22 +11,6 @@
 #include <sstream>
 
 namespace Slic3r {
-
-namespace {
-
-// Check whether any visible, compatible base preset in the collection has the given filament_id.
-bool has_visible_base_preset(const PresetCollection& filaments, const std::string& filament_id)
-{
-    for (const auto& p : filaments.get_presets()) {
-        if (p.is_visible && p.is_compatible
-            && filaments.get_preset_base(p) == &p
-            && p.filament_id == filament_id)
-            return true;
-    }
-    return false;
-}
-
-} // anonymous namespace
 
 const std::string QidiPrinterAgent_VERSION = "0.0.1";
 
@@ -142,25 +127,14 @@ bool QidiPrinterAgent::fetch_slot_info(const std::string&        base_url,
     trays.clear();
     trays.reserve(max_slots);
 
-    // Lambda to build setting_id from slot data
-    auto build_setting_id = [&](int filament_type_idx, int vendor_type, const std::string& tray_type) {
-        const int vendor = (vendor_type == 1) ? 1 : 0;
-        if (is_numeric(series_id) && filament_type_idx > 0) {
-            return "QD_" + series_id + "_" + std::to_string(vendor) + "_" + std::to_string(filament_type_idx);
-        }
-        return map_filament_type_to_setting_id(tray_type);
-    };
-
     for (int i = 0; i < max_slots; ++i) {
         AmsTrayData tray;
         tray.slot_index = i;
 
-        // Read slot variables
         const int color_index     = variables.value("color_slot" + std::to_string(i), 1);
         const int filament_type   = variables.value("filament_slot" + std::to_string(i), 1);
         const int vendor_type     = variables.value("vendor_slot" + std::to_string(i), 0);
 
-        // Check filament presence via runout sensor
         std::string box_stepper_key = "box_stepper slot" + std::to_string(i);
         tray.has_filament = false;
         if (status.contains(box_stepper_key)) {
@@ -172,32 +146,63 @@ bool QidiPrinterAgent::fetch_slot_info(const std::string&        base_url,
         }
 
         if (tray.has_filament) {
-            // Look up filament type name from dictionary
             std::string filament_name = "PLA";
             auto filament_it = dict.filaments.find(filament_type);
             if (filament_it != dict.filaments.end()) {
                 filament_name = filament_it->second;
             }
-            tray.tray_type = normalize_filament_type(filament_name);
+            // Prefer a filament_type the loaded profiles actually define, so a
+            // composite survives ("PLA-CF" stays PLA-CF instead of collapsing
+            // onto PLA and being excluded from its own profiles).  The static
+            // ladder below is the fallback for an unrecognized material, and for
+            // early init before any bundle exists.
+            auto* preset_bundle = GUI::wxGetApp().preset_bundle;
+            tray.tray_type      = preset_bundle ? FilamentMatcher::resolve_filament_type(
+                                                      preset_bundle->filaments, filament_name)
+                                                : std::string();
+            if (tray.tray_type.empty())
+                tray.tray_type = normalize_filament_type(filament_name);
 
-            // Try Qidi-specific setting ID first; fall back to visible preset by type
-            std::string setting_id = build_setting_id(filament_type, vendor_type, tray.tray_type);
-            auto* bundle = GUI::wxGetApp().preset_bundle;
-            if (!bundle) {
-                tray.tray_info_idx = setting_id;
-            } else if (!setting_id.empty() && has_visible_base_preset(bundle->filaments, setting_id)) {
-                tray.tray_info_idx = setting_id;
-            } else {
-                tray.tray_info_idx = bundle->filaments.filament_id_by_type(tray.tray_type);
-            }
-
-            // Look up color from dictionary
+            // Look up color hex from dictionary
+            std::string color_hex;
             auto color_it = dict.colors.find(color_index);
             if (color_it != dict.colors.end()) {
                 tray.tray_color = color_it->second;
+                color_hex = color_it->second;
+                if (!color_hex.empty() && color_hex[0] == '#')
+                    color_hex = color_hex.substr(1);
             } else {
                 tray.tray_color = "FFFFFFFF";
             }
+
+            // Populate every piece of data QIDI reports for the shared matcher.
+            // QIDI gives both forms of the vendor (name + numeric id) and the
+            // filament (name + numeric index) plus the base type and color, so
+            // all of V/F/C/P participate.
+            //
+            // Example: X-Max 4, filament vendor 7 = "Acme Inc",
+            //          fila 52 = "PLA Plus", color 52 = "#FAFAFA"
+            //   prefix        = "QD_3"
+            //   vendor_name   = "Acme_Inc",  vendor_type  = 7
+            //   filament_name = "PLA_Plus",  filament_idx = 52
+            //   tray_type     = "PLA",       color        = "FAFAFA"
+            FilamentMatchInput match_input;
+            match_input.prefix        = series_id.empty() ? "QD" : ("QD_" + series_id);
+            match_input.color         = color_hex;
+            match_input.vendor_type   = vendor_type;
+            match_input.filament_idx  = filament_type;
+            match_input.tray_type     = tray.tray_type;
+
+            auto vendor_it = dict.vendors.find(vendor_type);
+            if (vendor_it != dict.vendors.end())
+                match_input.vendor_name = FilamentMatcher::sanitize_for_id(vendor_it->second);
+
+            match_input.filament_name = FilamentMatcher::sanitize_for_id(filament_name);
+
+            auto match = FilamentMatcher::resolve(
+                preset_bundle ? &preset_bundle->filaments : nullptr, match_input);
+            tray.tray_info_idx       = match.filament_id;
+            tray.matched_preset_name = match.preset_name;
         }
 
         trays.push_back(tray);
@@ -246,8 +251,10 @@ bool QidiPrinterAgent::fetch_filament_dict(const std::string& base_url,
 
     dict.colors.clear();
     dict.filaments.clear();
+    dict.vendors.clear();
     parse_ini_section(response_body, "colordict", dict.colors);
     parse_filament_sections(response_body, dict.filaments);
+    parse_ini_section(response_body, "vendor_list", dict.vendors);
 
     return !dict.colors.empty();
 }
@@ -320,25 +327,6 @@ void QidiPrinterAgent::parse_filament_sections(const std::string& content, std::
             }
         }
     }
-}
-
-std::string QidiPrinterAgent::map_filament_type_to_setting_id(const std::string& filament_type)
-{
-    const std::string upper = trim_and_upper(filament_type);
-
-    if (upper == "PLA") {
-        return "QD_1_0_1";
-    }
-    if (upper == "ABS") {
-        return "QD_1_0_11";
-    }
-    if (upper == "PETG") {
-        return "QD_1_0_41";
-    }
-    if (upper == "TPU") {
-        return "QD_1_0_50";
-    }
-    return "";
 }
 
 std::string QidiPrinterAgent::normalize_model_key(std::string value)

--- a/src/slic3r/Utils/QidiPrinterAgent.cpp
+++ b/src/slic3r/Utils/QidiPrinterAgent.cpp
@@ -1,4 +1,5 @@
 #include "QidiPrinterAgent.hpp"
+#include "FilamentMatcher.hpp"
 #include "Http.hpp"
 #include "libslic3r/PresetBundle.hpp"
 #include "slic3r/GUI/GUI_App.hpp"
@@ -10,22 +11,6 @@
 #include <sstream>
 
 namespace Slic3r {
-
-namespace {
-
-// Check whether any visible, compatible base preset in the collection has the given filament_id.
-bool has_visible_base_preset(const PresetCollection& filaments, const std::string& filament_id)
-{
-    for (const auto& p : filaments.get_presets()) {
-        if (p.is_visible && p.is_compatible
-            && filaments.get_preset_base(p) == &p
-            && p.filament_id == filament_id)
-            return true;
-    }
-    return false;
-}
-
-} // anonymous namespace
 
 const std::string QidiPrinterAgent_VERSION = "0.0.1";
 
@@ -142,25 +127,14 @@ bool QidiPrinterAgent::fetch_slot_info(const std::string&        base_url,
     trays.clear();
     trays.reserve(max_slots);
 
-    // Lambda to build setting_id from slot data
-    auto build_setting_id = [&](int filament_type_idx, int vendor_type, const std::string& tray_type) {
-        const int vendor = (vendor_type == 1) ? 1 : 0;
-        if (is_numeric(series_id) && filament_type_idx > 0) {
-            return "QD_" + series_id + "_" + std::to_string(vendor) + "_" + std::to_string(filament_type_idx);
-        }
-        return map_filament_type_to_setting_id(tray_type);
-    };
-
     for (int i = 0; i < max_slots; ++i) {
         AmsTrayData tray;
         tray.slot_index = i;
 
-        // Read slot variables
         const int color_index     = variables.value("color_slot" + std::to_string(i), 1);
         const int filament_type   = variables.value("filament_slot" + std::to_string(i), 1);
         const int vendor_type     = variables.value("vendor_slot" + std::to_string(i), 0);
 
-        // Check filament presence via runout sensor
         std::string box_stepper_key = "box_stepper slot" + std::to_string(i);
         tray.has_filament = false;
         if (status.contains(box_stepper_key)) {
@@ -172,7 +146,6 @@ bool QidiPrinterAgent::fetch_slot_info(const std::string&        base_url,
         }
 
         if (tray.has_filament) {
-            // Look up filament type name from dictionary
             std::string filament_name = "PLA";
             auto filament_it = dict.filaments.find(filament_type);
             if (filament_it != dict.filaments.end()) {
@@ -180,24 +153,44 @@ bool QidiPrinterAgent::fetch_slot_info(const std::string&        base_url,
             }
             tray.tray_type = normalize_filament_type(filament_name);
 
-            // Try Qidi-specific setting ID first; fall back to visible preset by type
-            std::string setting_id = build_setting_id(filament_type, vendor_type, tray.tray_type);
-            auto* bundle = GUI::wxGetApp().preset_bundle;
-            if (!bundle) {
-                tray.tray_info_idx = setting_id;
-            } else if (!setting_id.empty() && has_visible_base_preset(bundle->filaments, setting_id)) {
-                tray.tray_info_idx = setting_id;
-            } else {
-                tray.tray_info_idx = bundle->filaments.filament_id_by_type(tray.tray_type);
-            }
-
-            // Look up color from dictionary
+            // Look up color hex from dictionary
+            std::string color_hex;
             auto color_it = dict.colors.find(color_index);
             if (color_it != dict.colors.end()) {
                 tray.tray_color = color_it->second;
+                color_hex = color_it->second;
+                if (!color_hex.empty() && color_hex[0] == '#')
+                    color_hex = color_hex.substr(1);
             } else {
                 tray.tray_color = "FFFFFFFF";
             }
+
+            // Populate all available data from officiall_filas_list.cfg and
+            // save_variables for the shared multi-tier filament matcher.
+            // QIDI printers provide filament vendor, filament name, color,
+            // and numeric indices, so all five tiers can participate.
+            //
+            // Example: X-Max 4, filament vendor 7 = "Acme Inc",
+            //          fila 52 = "PLA Plus", color 52 = "#FAFAFA"
+            //   prefix       = "QD_3"
+            //   vendor_name  = "Acme_Inc"
+            //   filament_name = "PLA_Plus"
+            //   color_hex    = "FAFAFA"
+            //   vendor_type  = 7,  filament_idx = 52,  tray_type = "PLA"
+            FilamentMatchInput match_input;
+            match_input.prefix        = series_id.empty() ? "QD" : ("QD_" + series_id);
+            match_input.color_hex     = color_hex;
+            match_input.vendor_type   = vendor_type;
+            match_input.filament_idx  = filament_type;
+            match_input.tray_type     = tray.tray_type;
+
+            auto vendor_it = dict.vendors.find(vendor_type);
+            if (vendor_it != dict.vendors.end())
+                match_input.vendor_name = FilamentMatcher::sanitize_for_id(vendor_it->second);
+
+            match_input.filament_name = FilamentMatcher::sanitize_for_id(filament_name);
+
+            tray.tray_info_idx = FilamentMatcher::resolve(match_input);
         }
 
         trays.push_back(tray);
@@ -246,8 +239,10 @@ bool QidiPrinterAgent::fetch_filament_dict(const std::string& base_url,
 
     dict.colors.clear();
     dict.filaments.clear();
+    dict.vendors.clear();
     parse_ini_section(response_body, "colordict", dict.colors);
     parse_filament_sections(response_body, dict.filaments);
+    parse_ini_section(response_body, "vendor_list", dict.vendors);
 
     return !dict.colors.empty();
 }
@@ -320,25 +315,6 @@ void QidiPrinterAgent::parse_filament_sections(const std::string& content, std::
             }
         }
     }
-}
-
-std::string QidiPrinterAgent::map_filament_type_to_setting_id(const std::string& filament_type)
-{
-    const std::string upper = trim_and_upper(filament_type);
-
-    if (upper == "PLA") {
-        return "QD_1_0_1";
-    }
-    if (upper == "ABS") {
-        return "QD_1_0_11";
-    }
-    if (upper == "PETG") {
-        return "QD_1_0_41";
-    }
-    if (upper == "TPU") {
-        return "QD_1_0_50";
-    }
-    return "";
 }
 
 std::string QidiPrinterAgent::normalize_model_key(std::string value)

--- a/src/slic3r/Utils/QidiPrinterAgent.hpp
+++ b/src/slic3r/Utils/QidiPrinterAgent.hpp
@@ -24,8 +24,9 @@ public:
 private:
     struct QidiFilamentDict
     {
-        std::map<int, std::string> colors;
-        std::map<int, std::string> filaments;
+        std::map<int, std::string> colors;      // [colordict]
+        std::map<int, std::string> filaments;    // [filaN] -> "filament" value
+        std::map<int, std::string> vendors;      // [vendor_list]
     };
 
     // Qidi-specific methods
@@ -44,7 +45,6 @@ private:
     // Static helpers
     static void parse_ini_section(const std::string& content, const std::string& section_name, std::map<int, std::string>& result);
     static void parse_filament_sections(const std::string& content, std::map<int, std::string>& result);
-    static std::string map_filament_type_to_setting_id(const std::string& filament_type);
 };
 
 } // namespace Slic3r

--- a/src/slic3r/Utils/SnapmakerPrinterAgent.cpp
+++ b/src/slic3r/Utils/SnapmakerPrinterAgent.cpp
@@ -1,4 +1,5 @@
 #include "SnapmakerPrinterAgent.hpp"
+#include "FilamentMatcher.hpp"
 #include "Http.hpp"
 #include "libslic3r/PresetBundle.hpp"
 #include "slic3r/GUI/GUI_App.hpp"
@@ -17,50 +18,6 @@ template<typename T>
 T safe_at(const std::vector<T>& vec, int index, const T& fallback)
 {
     return (index >= 0 && index < static_cast<int>(vec.size())) ? vec[index] : fallback;
-}
-
-std::string find_closest_color_preset_by_vendor_and_type(const PresetCollection& filaments,
-                                                         const std::string&      vendor_name,
-                                                         const std::string&      filament_type,
-                                                         const std::string&      color_rgba)
-{
-    std::string best_match_id       = "";
-    int         best_color_distance = 0xffffffff;
-
-    for (const auto& p : filaments.get_presets()) {
-        if (p.is_visible && p.is_compatible &&
-            // Filament profile must be detached from parent to be considered for matching
-            filaments.get_preset_base(p) == &p && p.config.opt_string("filament_vendor", 0u) == vendor_name &&
-            p.config.opt_string("filament_type", 0u) == filament_type) {
-            // The printer returns RGBA in the format RRGGBBAA, but profiles store color as #RRGGBB,
-            // so we must remove # and ignore alpha channel for distance calculation
-            unsigned int target_color_value = std::stoul(color_rgba.substr(0, color_rgba.length() - 2), nullptr, 16);
-
-            std::string  p_color = p.config.opt_string("default_filament_colour", 0u);
-            unsigned int p_color_value;
-            if (!p_color.empty()) {
-                unsigned int hash_pos = p_color.find("#");
-                p_color_value         = std::stoul(p_color.substr(hash_pos != std::string::npos ? hash_pos + 1 : 0), nullptr, 16);
-            } else {
-                // Default to black if no color specified in profile. Assume other profiles might be a closer color match.
-                // Could be a problem if the target color is also black and there exist a specific profile for that type, vendor and color
-                // combination.
-                p_color_value = 0;
-            }
-
-            // Calculate Euclidean color distance in RGB space
-            int dr = ((target_color_value & 0xff) - (p_color_value & 0xff));
-            int dg = (((target_color_value >> 8) & 0xff) - ((p_color_value >> 8) & 0xff));
-            int db = (((target_color_value >> 16) & 0xff) - ((p_color_value >> 16) & 0xff));
-            unsigned int distance = dr * dr + dg * dg + db * db;
-
-            if (distance < best_color_distance) {
-                best_color_distance = distance;
-                best_match_id       = p.filament_id;
-            }
-        }
-    }
-    return best_match_id;
 }
 
 } // anonymous namespace
@@ -188,24 +145,23 @@ bool SnapmakerPrinterAgent::fetch_filament_info(std::string dev_id)
                                                        safe_at(filament_sub_type, i, empty_str));
             tray.tray_color    = safe_at(filament_color, i, default_color);
 
-            auto* bundle = GUI::wxGetApp().preset_bundle;
-            // Try to find a matching preset for this filament based on vendor, type and color.
-            // If not found, default to traditional search by type only or generic type mapping.
-            if (bundle) {
-                std::string vendor      = safe_at(filament_vendor, i, empty_str);
-                std::string filament_id = find_closest_color_preset_by_vendor_and_type(bundle->filaments, vendor, tray.tray_type,
-                                                                                       tray.tray_color);
-
-                if (!filament_id.empty()) {
-                    tray.tray_info_idx = filament_id;
-                    BOOST_LOG_TRIVIAL(warning) << "Filament sync: Found manufacturer-specific profile for slot " << i << ": "
-                                               << filament_id;
-                } else {
-                    tray.tray_info_idx = bundle->filaments.filament_id_by_type(tray.tray_type);
-                }
-            } else {
-                tray.tray_info_idx = map_filament_type_to_generic_id(tray.tray_type);
-            }
+            // Snapmaker reports a vendor and an RRGGBBAA color alongside the
+            // material type, but no distinct filament name -- so its filament
+            // info is the type, and matching runs through the config
+            // vendor+type closest-color path (level 1c), which picks the nearest
+            // vendor+type profile before falling back to type-only levels.
+            // combine_filament_type() already normalized type + sub_type
+            // (e.g. "PLA" + "CF" -> "PLA-CF"); the vendor is run through the
+            // matcher's shared sanitizer so it lines up with how presets compare.
+            FilamentMatchInput match_input;
+            match_input.tray_type   = tray.tray_type;
+            match_input.vendor_name = FilamentMatcher::sanitize_for_id(safe_at(filament_vendor, i, empty_str));
+            match_input.color       = tray.tray_color;
+            auto* preset_bundle = GUI::wxGetApp().preset_bundle;
+            auto  match         = FilamentMatcher::resolve(
+                preset_bundle ? &preset_bundle->filaments : nullptr, match_input);
+            tray.tray_info_idx       = match.filament_id;
+            tray.matched_preset_name = match.preset_name;
 
             // Extract NFC temperature data if available
             if (nfc_info.is_array() && i < static_cast<int>(nfc_info.size()) && nfc_info[i].is_object()) {

--- a/src/slic3r/Utils/SnapmakerPrinterAgent.cpp
+++ b/src/slic3r/Utils/SnapmakerPrinterAgent.cpp
@@ -1,4 +1,5 @@
 #include "SnapmakerPrinterAgent.hpp"
+#include "FilamentMatcher.hpp"
 #include "Http.hpp"
 #include "libslic3r/PresetBundle.hpp"
 #include "slic3r/GUI/GUI_App.hpp"
@@ -141,10 +142,14 @@ bool SnapmakerPrinterAgent::fetch_filament_info(std::string dev_id)
         if (tray.has_filament) {
             tray.tray_type     = combine_filament_type(safe_at(filament_type, i, empty_str),
                                                        safe_at(filament_sub_type, i, empty_str));
-            auto* bundle = GUI::wxGetApp().preset_bundle;
-            tray.tray_info_idx = bundle
-                ? bundle->filaments.filament_id_by_type(tray.tray_type)
-                : map_filament_type_to_generic_id(tray.tray_type);
+            // Snapmaker reports type + sub_type (e.g. "PLA" + "CF" -> "PLA-CF")
+            // but no vendor name or color, so tiers 1-3 are skipped.
+            // If Snapmaker NFC data gains vendor/filament name fields, populate
+            // prefix (e.g. "SM_J1") and vendor_name/filament_name here to
+            // enable richer matching.
+            FilamentMatchInput match_input;
+            match_input.tray_type = tray.tray_type;
+            tray.tray_info_idx = FilamentMatcher::resolve(match_input);
             tray.tray_color    = safe_at(filament_color, i, default_color);
 
             // Extract NFC temperature data if available

--- a/tests/slic3rutils/CMakeLists.txt
+++ b/tests/slic3rutils/CMakeLists.txt
@@ -2,6 +2,7 @@ get_filename_component(_TEST_NAME ${CMAKE_CURRENT_LIST_DIR} NAME)
 add_executable(${_TEST_NAME}_tests
     ${_TEST_NAME}_tests_main.cpp
     test_dev_mapping.cpp
+    test_filament_matcher.cpp
     test_network_versions.cpp
     test_action_source.cpp
     test_plugin_host_api.cpp

--- a/tests/slic3rutils/test_filament_matcher.cpp
+++ b/tests/slic3rutils/test_filament_matcher.cpp
@@ -1,0 +1,468 @@
+#include <catch2/catch_all.hpp>
+
+#include "libslic3r/Preset.hpp"
+#include "libslic3r/PrintConfig.hpp"
+#include "slic3r/Utils/FilamentMatcher.hpp"
+
+#include <string>
+#include <vector>
+
+using namespace Slic3r;
+
+namespace {
+
+// A filament PresetCollection built in memory, matching how PresetBundle builds
+// its own (PresetBundle.cpp). PresetCollection holds a mutex, so it is neither
+// copyable nor movable -- the fixture owns it in place and hands out a
+// reference rather than returning one by value.
+struct Filaments
+{
+    PresetCollection coll;
+
+    Filaments()
+        : coll(Preset::TYPE_FILAMENT,
+               Preset::filament_options(),
+               static_cast<const PrintRegionConfig &>(FullPrintConfig::defaults()),
+               "Default Filament")
+    {}
+
+    // `colour` is the preset's declared default_filament_colour ("#RRGGBB"), or
+    // "" for a preset that declares none. `inherits` names a parent so the test
+    // can build a derived preset, which is what every GUI-created preset is.
+    Preset &add(const std::string &name,
+                const std::string &filament_id,
+                const std::string &type,
+                const std::string &vendor,
+                const std::string &colour,
+                const std::string &inherits = "")
+    {
+        DynamicPrintConfig cfg;
+        cfg.set_key_value("filament_type", new ConfigOptionStrings{type});
+        cfg.set_key_value("filament_vendor", new ConfigOptionStrings{vendor});
+        cfg.set_key_value("default_filament_colour", new ConfigOptionStrings{colour});
+        if (!inherits.empty())
+            cfg.set_key_value("inherits", new ConfigOptionString(inherits));
+
+        Preset &p = coll.load_preset("", name, cfg, /*select=*/false);
+        p.filament_id   = filament_id;
+        p.is_visible    = true;
+        p.is_compatible = true;
+        return p;
+    }
+
+    // filament_id_by_type() (the level 4d rung) only considers system base
+    // presets, so a test that exercises it has to mark its presets as system.
+    Preset &add_system(const std::string &name,
+                       const std::string &filament_id,
+                       const std::string &type)
+    {
+        Preset &p   = add(name, filament_id, type, "", "");
+        p.is_system = true;
+        return p;
+    }
+};
+
+// The six eSun PLA presets from the reported case, with their real colours.
+// "PLA+ Black" is #000000 and so sits nearest a reported 060606; the matte
+// profile it must not displace is #202020.
+void add_esun_pla(Filaments &f)
+{
+    f.add("eSun Matte PLA Almond", "GFL99", "PLA", "eSun", "#E9E795");
+    f.add("eSun Matte PLA Black", "GFL99", "PLA", "eSun", "#202020");
+    f.add("eSun PLA Matte @Qidi X-Plus 4 0.4 nozzle", "GFL99", "PLA", "eSun", "#404040");
+    f.add("eSun PLA+ Black", "GFL99", "PLA", "eSun", "#000000");
+    f.add("eSun PLA+ Brown", "GFL99", "PLA", "eSun", "#4A2500");
+}
+
+FilamentMatchInput qidi_slot(const std::string &vendor,
+                             const std::string &name,
+                             const std::string &type,
+                             const std::string &colour)
+{
+    FilamentMatchInput in;
+    in.prefix        = "QD_0";
+    in.vendor_name   = vendor;
+    in.filament_name = name;
+    in.tray_type     = type;
+    in.color         = colour;
+    return in;
+}
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// The reported defect: colour must not be allowed to select identity.
+// ---------------------------------------------------------------------------
+
+TEST_CASE("A reported product name outranks a nearer colour", "[FilamentMatcher]")
+{
+    Filaments f;
+    add_esun_pla(f);
+
+    // Reported: eSUN "PLA Matte", colour 060606. By colour alone "eSun PLA+
+    // Black" (#000000, distance 108) beats "eSun Matte PLA Black" (#202020,
+    // distance 2028) by 19x -- the name is the only thing that separates them.
+    const auto r = FilamentMatcher::resolve(&f.coll, qidi_slot("eSUN", "PLA_Matte", "PLA", "060606"));
+
+    REQUIRE(r.preset_name == "eSun Matte PLA Black");
+}
+
+TEST_CASE("Name matching ignores word order", "[FilamentMatcher]")
+{
+    // "PLA Matte" must match a preset named "Matte PLA" just as well.
+    Filaments f;
+    f.add("eSun Matte PLA Black", "GFL99", "PLA", "eSun", "#202020");
+    f.add("eSun PLA+ Black", "GFL99", "PLA", "eSun", "#000000");
+
+    const auto r = FilamentMatcher::resolve(&f.coll, qidi_slot("eSUN", "PLA_Matte", "PLA", "060606"));
+
+    REQUIRE(r.preset_name == "eSun Matte PLA Black");
+}
+
+TEST_CASE("A name match with no colour beats a colour match with the wrong name",
+          "[FilamentMatcher]")
+{
+    // The generalized form of the defect: if the name rung ran only inside the
+    // colour pass, the colourless matte profile would lose to the coloured PLA+.
+    Filaments f;
+    f.add("eSun PLA Matte Black", "GFL99", "PLA", "eSun", ""); // declares no colour
+    f.add("eSun PLA+ Black", "GFL99", "PLA", "eSun", "#000000");
+
+    const auto r = FilamentMatcher::resolve(&f.coll, qidi_slot("eSUN", "PLA_Matte", "PLA", "060606"));
+
+    REQUIRE(r.preset_name == "eSun PLA Matte Black");
+}
+
+TEST_CASE("A reported PLA matches a preset named PLA+", "[FilamentMatcher]")
+{
+    // Tokens split on non-alphanumerics, so "PLA+" yields [PLA] and a bare
+    // reported "PLA" still narrows to it rather than falling through.
+    Filaments f;
+    f.add("Sunlu PLA+ White @Qidi X-Plus 4", "GFL99", "PLA", "Sunlu", "#FFFFFF");
+
+    const auto r = FilamentMatcher::resolve(&f.coll, qidi_slot("SUNLU", "PLA", "PLA", "FAFAFA"));
+
+    REQUIRE(r.preset_name == "Sunlu PLA+ White @Qidi X-Plus 4");
+}
+
+TEST_CASE("Vendor matching ignores case", "[FilamentMatcher]")
+{
+    // The printer says "SUNLU", the preset says "Sunlu".
+    Filaments f;
+    f.add("Sunlu PLA White", "GFL99", "PLA", "Sunlu", "#FFFFFF");
+
+    REQUIRE(FilamentMatcher::resolve(&f.coll, qidi_slot("SUNLU", "PLA", "PLA", "FFFFFF")).preset_name
+            == "Sunlu PLA White");
+}
+
+TEST_CASE("Vendor matching bridges a separator difference", "[FilamentMatcher]")
+{
+    // Both sides run through sanitize_for_id(), so "Acme Inc" and "Acme-Inc"
+    // collapse to the same token. Note this only works when both sides have a
+    // separator: a reported "eSUN" does NOT reach a preset's "e-Sun", because
+    // only the preset gains an underscore. Agents sanitize what the printer
+    // reports, so the two sides normalize identically in practice.
+    Filaments f;
+    f.add("Acme Inc PLA White", "GFL99", "PLA", "Acme-Inc", "#FFFFFF");
+
+    const auto r = FilamentMatcher::resolve(
+        &f.coll, qidi_slot(FilamentMatcher::sanitize_for_id("Acme Inc"), "PLA", "PLA", "FFFFFF"));
+
+    REQUIRE(r.preset_name == "Acme Inc PLA White");
+}
+
+// ---------------------------------------------------------------------------
+// Colour is evidence, not a default.
+// ---------------------------------------------------------------------------
+
+TEST_CASE("A preset declaring no colour sits out the closest-colour rung", "[FilamentMatcher]")
+{
+    // Scoring a colourless preset as black would make it win a black spool
+    // outright, and make every colourless preset tie so collection order
+    // decided the winner. The coloured profile must take a black spool.
+    Filaments f;
+    f.add("Acme PLA Unspecified", "GFL99", "PLA", "Acme", "");
+    f.add("Acme PLA Black", "GFL99", "PLA", "Acme", "#000000");
+
+    const auto r = FilamentMatcher::resolve(&f.coll, qidi_slot("Acme", "PLA", "PLA", "000000"));
+
+    REQUIRE(r.preset_name == "Acme PLA Black");
+}
+
+TEST_CASE("A colourless preset is still reachable when nothing declares a colour",
+          "[FilamentMatcher]")
+{
+    // Sitting out the colour rung must not mean being excluded entirely --
+    // vendor profiles overwhelmingly declare no default_filament_colour.
+    Filaments f;
+    f.add("Acme PLA Unspecified", "GFL99", "PLA", "Acme", "");
+
+    const auto r = FilamentMatcher::resolve(&f.coll, qidi_slot("Acme", "PLA", "PLA", "123456"));
+
+    REQUIRE(r.preset_name == "Acme PLA Unspecified");
+}
+
+TEST_CASE("Closest colour picks the nearest of several same-vendor profiles", "[FilamentMatcher]")
+{
+    // An exact colour is not required; the nearest wins.
+    Filaments f;
+    f.add("Acme PLA White", "GFL99", "PLA", "Acme", "#FFFFFF");
+    f.add("Acme PLA Red", "GFL99", "PLA", "Acme", "#FF0000");
+    f.add("Acme PLA Black", "GFL99", "PLA", "Acme", "#000000");
+
+    const auto r = FilamentMatcher::resolve(&f.coll, qidi_slot("Acme", "PLA", "PLA", "EE1111"));
+
+    REQUIRE(r.preset_name == "Acme PLA Red");
+}
+
+// ---------------------------------------------------------------------------
+// Which presets are eligible at all.
+// ---------------------------------------------------------------------------
+
+TEST_CASE("A derived preset is eligible for config matching", "[FilamentMatcher]")
+{
+    // Every GUI-created preset inherits from the profile it was saved off, so
+    // restricting config matching to base presets excluded exactly the presets
+    // that have no other way to be matched.
+    Filaments f;
+    f.add("Qidi Generic PLA", "GFL99", "PLA", "Qidi", "");
+    f.add("Flashforge Red HS PLA @Qidi X-Plus 4 0.4 nozzle", "GFL99", "PLA", "Flashforge",
+          "#800000", /*inherits=*/"Qidi Generic PLA");
+
+    const auto r = FilamentMatcher::resolve(&f.coll, qidi_slot("Flashforge", "PLA_HS", "PLA", "FF362D"));
+
+    REQUIRE(r.preset_name == "Flashforge Red HS PLA @Qidi X-Plus 4 0.4 nozzle");
+}
+
+TEST_CASE("Invisible and incompatible presets are never matched", "[FilamentMatcher]")
+{
+    Filaments f;
+    Preset &hidden = f.add("Acme PLA Hidden", "GFL99", "PLA", "Acme", "#FF0000");
+    hidden.is_visible = false;
+    Preset &incompatible = f.add("Acme PLA Incompatible", "GFL99", "PLA", "Acme", "#FF0000");
+    incompatible.is_compatible = false;
+    f.add("Acme PLA Visible", "GFL99", "PLA", "Acme", "#0000FF");
+
+    const auto r = FilamentMatcher::resolve(&f.coll, qidi_slot("Acme", "PLA", "PLA", "FF0000"));
+
+    REQUIRE(r.preset_name == "Acme PLA Visible");
+}
+
+// ---------------------------------------------------------------------------
+// The id levels: hand-authored filament_ids still win.
+// ---------------------------------------------------------------------------
+
+TEST_CASE("An authored vendor+filament id outranks a config-field match", "[FilamentMatcher]")
+{
+    Filaments f;
+    f.add("Acme PLA By Config", "GFL99", "PLA", "Acme", "#FF0000");
+    f.add("Acme PLA By Id", "Acme_PLA_Matte", "PLA", "SomeoneElse", "");
+
+    const auto r = FilamentMatcher::resolve(&f.coll, qidi_slot("Acme", "PLA_Matte", "PLA", "FF0000"));
+
+    REQUIRE(r.preset_name == "Acme PLA By Id");
+}
+
+TEST_CASE("An authored id with a colour suffix picks the nearest colour", "[FilamentMatcher]")
+{
+    Filaments f;
+    f.add("Acme PLA Red", "Acme_PLA_FF0000", "PLA", "Acme", "");
+    f.add("Acme PLA Blue", "Acme_PLA_0000FF", "PLA", "Acme", "");
+
+    const auto r = FilamentMatcher::resolve(&f.coll, qidi_slot("Acme", "PLA", "PLA", "EE1111"));
+
+    REQUIRE(r.preset_name == "Acme PLA Red");
+}
+
+TEST_CASE("A colour-suffixed id group never matches a longer name", "[FilamentMatcher]")
+{
+    // The suffix must be exactly six hex digits, so group "Acme_PLA" matches
+    // "Acme_PLA_FF0000" but never "Acme_PLA_Matte_FF0000" -- otherwise a bare
+    // "PLA" spool would be captured by a "PLA Matte" profile.
+    //
+    // The preset is given a different vendor and an unrelated name so that the
+    // id group is the *only* rung that could reach it. A named result would
+    // therefore mean the group matched; falling through leaves preset_name
+    // empty, since the remaining rungs answer with a type's generic id.
+    // The fallback preset is deliberately named without a "PLA" token, so the
+    // name rung cannot claim it and level 4d stays the only route.
+    Filaments f;
+    f.add("Unrelated Profile", "Acme_PLA_Matte_FF0000", "PLA", "SomeoneElse", "");
+    f.add_system("Basic Filament", "OGFL99", "PLA");
+
+    const auto r = FilamentMatcher::resolve(&f.coll, qidi_slot("Acme", "PLA", "PLA", "FF0000"));
+
+    REQUIRE(r.preset_name.empty());
+}
+
+// ---------------------------------------------------------------------------
+// The result must be able to name a preset, not just an id.
+// ---------------------------------------------------------------------------
+
+TEST_CASE("A matched preset is named even when its filament_id is shared", "[FilamentMatcher]")
+{
+    // Five presets share GFL99 here, as they do in the shipped profiles, so an
+    // id alone cannot identify the match. sync_ams_list resolves the id by
+    // first-match, which is why the preset name has to travel with it.
+    Filaments f;
+    add_esun_pla(f);
+
+    const auto r = FilamentMatcher::resolve(&f.coll, qidi_slot("eSUN", "PLA_Matte", "PLA", "060606"));
+
+    REQUIRE(r.filament_id == "GFL99");
+    REQUIRE(r.preset_name == "eSun Matte PLA Black");
+}
+
+TEST_CASE("A generic fallback names no preset", "[FilamentMatcher]")
+{
+    // Rungs that answer with a type's generic id rather than one particular
+    // preset must leave preset_name empty, so PresetBundle::sync_ams_list falls
+    // back to looking the id up -- which is the right behaviour for an answer
+    // that was never about one specific preset.
+    // Named without a "PLA" token so the name rung cannot claim it: an unknown
+    // vendor AND an unmatchable name leave the generic rung as the only answer.
+    Filaments f;
+    f.add_system("Basic Filament", "OGFL99", "PLA");
+
+    const auto r = FilamentMatcher::resolve(&f.coll, qidi_slot("Nobody", "PLA", "PLA", "FF0000"));
+
+    REQUIRE(r.preset_name.empty());
+    REQUIRE(r.filament_id == "OGFL99");
+}
+
+TEST_CASE("Resolving without a preset collection still yields an id", "[FilamentMatcher]")
+{
+    FilamentMatchInput in = qidi_slot("Acme", "PLA", "PLA", "FF0000");
+    in.vendor_type   = 7;
+    in.filament_idx  = 52;
+
+    const auto r = FilamentMatcher::resolve(nullptr, in);
+
+    REQUIRE(r.preset_name.empty());
+    REQUIRE(r.filament_id == "QD_0_7_52");
+}
+
+// ---------------------------------------------------------------------------
+// Printers that report no filament name (Snapmaker, Moonraker).
+// ---------------------------------------------------------------------------
+
+TEST_CASE("Vendor and type still match when no filament name is reported", "[FilamentMatcher]")
+{
+    // Snapmaker reports vendor + type + colour and no product name. Those rungs
+    // must behave exactly as before the name signal was added.
+    Filaments f;
+    f.add("eSun PLA-CF Black", "GFL98", "PLA-CF", "eSUN", "#000000");
+    f.add("eSun PLA-CF White", "GFL98", "PLA-CF", "eSUN", "#FFFFFF");
+
+    FilamentMatchInput in;
+    in.vendor_name = "eSUN";
+    in.tray_type   = "PLA-CF";
+    in.color       = "F0F0F0FF"; // Snapmaker reports RRGGBBAA
+
+    const auto r = FilamentMatcher::resolve(&f.coll, in);
+
+    REQUIRE(r.preset_name == "eSun PLA-CF White");
+}
+
+TEST_CASE("A type-only report falls through to the generic for that type", "[FilamentMatcher]")
+{
+    // Moonraker reports only a material type: no vendor, no name, no colour.
+    Filaments f;
+    f.add_system("Generic PLA", "OGFL99", "PLA");
+    f.add_system("Generic ABS", "OGFB99", "ABS");
+
+    FilamentMatchInput in;
+    in.tray_type = "PLA";
+
+    const auto r = FilamentMatcher::resolve(&f.coll, in);
+
+    REQUIRE(r.filament_id == "OGFL99");
+}
+
+// ---------------------------------------------------------------------------
+// filament_type resolution, read out of the collection rather than hardcoded.
+// ---------------------------------------------------------------------------
+
+TEST_CASE("A composite filament type is not flattened to its base", "[FilamentMatcher]")
+{
+    // A substring ladder returned on the first hit, so "PLA-CF" became "PLA"
+    // and the spool was then excluded from its own PLA-CF profiles by the type
+    // gate. The most specific type present must win.
+    Filaments f;
+    f.add("Generic PLA", "OGFL99", "PLA", "", "");
+    f.add("Generic PLA-CF", "OGFL98", "PLA-CF", "", "");
+
+    REQUIRE(FilamentMatcher::resolve_filament_type(f.coll, "PLA-CF") == "PLA-CF");
+    REQUIRE(FilamentMatcher::resolve_filament_type(f.coll, "PLA") == "PLA");
+}
+
+TEST_CASE("A finish word does not create a composite type", "[FilamentMatcher]")
+{
+    // "Matte" is a finish, not a material -- no such type exists, so the
+    // reported "PLA Matte" is still a PLA.
+    Filaments f;
+    f.add("Generic PLA", "OGFL99", "PLA", "", "");
+    f.add("Generic PLA-CF", "OGFL98", "PLA-CF", "", "");
+
+    REQUIRE(FilamentMatcher::resolve_filament_type(f.coll, "PLA Matte") == "PLA");
+}
+
+TEST_CASE("A composite degrades to its base when no composite profile exists",
+          "[FilamentMatcher]")
+{
+    // A user with no CF profiles installed should still land on plain PLA
+    // rather than nothing at all.
+    Filaments f;
+    f.add("Generic PLA", "OGFL99", "PLA", "", "");
+
+    REQUIRE(FilamentMatcher::resolve_filament_type(f.coll, "PLA-CF") == "PLA");
+}
+
+TEST_CASE("Multi-word and prefix-colliding types resolve to the right one", "[FilamentMatcher]")
+{
+    Filaments f;
+    f.add("Generic PA", "OGFN99", "PA", "", "");
+    f.add("Generic PA-CF", "OGFN98", "PA-CF", "", "");
+    f.add("Generic PAHT-CF", "x1", "PAHT-CF", "", "");
+    f.add("Generic ABS", "OGFB99", "ABS", "", "");
+    f.add("Generic PC", "OGFC99", "PC", "", "");
+    f.add("Generic PC-ABS-FR", "x2", "PC-ABS-FR", "", "");
+
+    // "PAHT" is its own token, so PA-CF must not claim a PAHT-CF spool.
+    REQUIRE(FilamentMatcher::resolve_filament_type(f.coll, "PAHT-CF") == "PAHT-CF");
+    // The ladder returned "ABS" here, on the first substring hit.
+    REQUIRE(FilamentMatcher::resolve_filament_type(f.coll, "PC-ABS-FR") == "PC-ABS-FR");
+    REQUIRE(FilamentMatcher::resolve_filament_type(f.coll, "PA-CF") == "PA-CF");
+}
+
+TEST_CASE("Nylon resolves to PA", "[FilamentMatcher]")
+{
+    Filaments f;
+    f.add("Generic PA", "OGFN99", "PA", "", "");
+
+    REQUIRE(FilamentMatcher::resolve_filament_type(f.coll, "Nylon") == "PA");
+}
+
+TEST_CASE("An unrecognized material resolves to no type", "[FilamentMatcher]")
+{
+    // Empty is the signal for the caller to fall back rather than to invent one.
+    Filaments f;
+    f.add("Generic PLA", "OGFL99", "PLA", "", "");
+
+    REQUIRE(FilamentMatcher::resolve_filament_type(f.coll, "Unobtanium").empty());
+    REQUIRE(FilamentMatcher::resolve_filament_type(f.coll, "").empty());
+}
+
+// ---------------------------------------------------------------------------
+// sanitize_for_id, which agents use to build the reported name and vendor.
+// ---------------------------------------------------------------------------
+
+TEST_CASE("Names are sanitized into id-safe tokens", "[FilamentMatcher]")
+{
+    CHECK(FilamentMatcher::sanitize_for_id("Acme Inc") == "Acme_Inc");
+    CHECK(FilamentMatcher::sanitize_for_id("PLA Plus") == "PLA_Plus");
+    CHECK(FilamentMatcher::sanitize_for_id("PLA-AERO") == "PLA_AERO");
+    CHECK(FilamentMatcher::sanitize_for_id("TPU-AERO 64D") == "TPU_AERO_64D");
+    // Consecutive separators collapse and trailing ones are stripped.
+    CHECK(FilamentMatcher::sanitize_for_id("  Acme -- Inc  ") == "Acme_Inc");
+}


### PR DESCRIPTION
# Description

This PR extracts filament-to-preset matching into a shared `FilamentMatcher` utility so the QIDI, Creality, Snapmaker, and Moonraker agents use the same resolution logic, and introduces a multi-level matching scheme that lets printers with rich filament metadata (vendor, name, color) get progressively more precise preset matches.

Today, when a printer reports what filament is loaded in each slot, OrcaSlicer needs to map that to an installed filament preset. Different agents do this differently -- QIDI has a numeric ID scheme, Snapmaker, as of late, matches by vendor + type + closest color, and Moonraker just matches by type string. All of these are hardcoded inline with duplicated fallback logic.

This PR consolidates everything into a single `FilamentMatcher::resolve()` call that accepts a `FilamentMatchInput` struct. Agents fill in whatever fields their printer provides, and the resolver tries progressively less specific levels, skipping any level where data is missing.

The matcher does not care *how* a printer identifies a filament. It works from three pieces of information, plus an optional prefix:

- **V** -- vendor info: a vendor name and/or a numeric vendor id
- **F** -- filament info: a filament name and/or a numeric index and/or a base material type
- **C** -- color
- **P** -- an optional agent+model prefix (e.g. `QD_3`)

A printer that reports more than one form of V or F (QIDI gives a vendor name and a numeric id; a filament name, an index, and a type) yields a `V[]`/`F[]` list, and every id match tries each `V × F` combination.

The two kinds of match consume these differently. The id matches treat a name, an index and a type as interchangeable forms of the same bucket, since any of them can appear in a `filament_id`. The config matches cannot: profiles carry no name field, so they key F on `filament_type` and use the reported filament name to narrow which presets qualify by their *preset* name. A numeric index therefore reaches only the id levels, while a name reaches both.

## Cascade

Each level has an **id-string** match (against `filament_id`) and a **config-field** match (against `filament_vendor` / `filament_type` / `default_filament_colour`). Closest-color levels pick the nearest color, so an exact color is never required and one authored profile covers every color of a vendor+filament. In the id column, `[P_]` means the id is tried both with the prefix (`P_V_F`) and without it (`V_F`), prefix first.

| Order | Kind | Match |
|---|---|---|
| 1a/1b | id | `[P_]V_F_<hex>`, nearest color |
| 1c | config | `filament_vendor=V ∧ filament_type=T ∧ name`, nearest color |
| 1d | config | `filament_vendor=V ∧ filament_type=T ∧ name`, any color |
| 2a/2b | id | `[P_]V_F` |
| 2c | config | `filament_vendor=V ∧ filament_type=T`, nearest color |
| 2d | config | `filament_vendor=V ∧ filament_type=T`, any color |
| 3a/3b | id | `[P_]F_<hex>`, nearest color |
| 3c | config | `filament_type=T ∧ name`, nearest color |
| 3d | config | `filament_type=T ∧ name`, any color |
| 4a/4b | id | `[P_]F` |
| 4c | config | `filament_type=T`, nearest color |
| 4d | config | `filament_type=T` (= `filament_id_by_type`) |
| 5 | generic | `map_type_to_generic_id(type)` → `OGFLxx` |

Rows are tried in order, skipping any whose inputs are missing. `[P_]` means the id is tried both with the prefix (`P_V_F`) and without it (`V_F`), prefix first. These labels are what the matcher logs on a match, so a slot that resolved oddly can be traced to a row.

## Name safety, and what outranks what

The id matches and the config matches serve different authors, and both have to work. `filament_id` is not a `PrintConfig` option because there is no GUI field for it, and a preset saved from the GUI inherits its parent's id, so the id levels are reachable only by hand-editing profile JSON. `filament_vendor`, `filament_type` and `default_filament_colour` are all GUI-editable, which makes the config levels the only matching mechanism available to a user who has not edited files by hand. The goal is for neither to switch the other off.

**Identity outranks color:** Every level that knows what a filament *is*, a reported product name or an authored `filament_id`, is tried before any level that only knows what color it is. Color cannot separate two profiles of the same vendor and type, and letting it try picks by the wrong criterion: an `eSun PLA+ Black` profile (`#000000`) takes an `eSun PLA Matte` spool reported as `060606` away from the matte profile at `#202020`, purely because black sits nearer.

**Color is evidence, not a default:** A preset that declares no `default_filament_colour` sits out the closest-color levels rather than being scored as some default color, and stays eligible on the levels below. Scoring colorless presets as black made every preset in a color-less vendor profile set tie at the same distance, so the winner fell out of collection order and the reported color changed nothing.

**A coarse type never stands in for a specific filament:** `Acme PLA` never matches `Acme PLA Plus` or `PLA Matte`. The base type is excluded from the vendor-bearing levels whenever a filament name is present; it only drives the vendor-less levels and the generic. Names are compared as uppercase alphanumeric tokens with any ` @printer` suffix dropped, which makes word order irrelevant (`PLA Matte` matches both `eSun PLA Matte` and `eSun Matte PLA`) and lets a reported `PLA` line up with a preset named `PLA+`.

## A filament_id cannot name a preset

`resolve()` returns the matched preset's name alongside its `filament_id`, and `PresetBundle::sync_ams_list()` prefers the name. An id cannot carry the answer on its own: in one shipped vendor profile set a single id covers dozens of products across several filament types, and every GUI-created preset inherits its parent's id, so resolving an id back to a preset can only ever pick the first of many. The name travels the AMS payload as an `orca_preset_name` tray field that pull-mode agents emit and BBL devices do not, so BBL sync is unaffected. The levels that answer with a type's generic id rather than one particular preset name no preset, and consumers fall back to the id lookup.

## Filament type read from the profiles

`resolve_filament_type()` derives the type from the `filament_type` values present in the preset collection instead of a hardcoded ladder: a candidate type qualifies when every one of its tokens appears in the reported name, and the most specific qualifying type wins. A substring ladder returned on the first hit, so `PLA-CF` became `PLA`, `PAHT-CF` became `PA` and `PC-ABS-FR` became `ABS`, and since the config levels gate on `filament_type`, every one of those spools was excluded from its own profiles before matching began. Reading the vocabulary from the collection also means a material added to the profiles works with no code change, and a composite degrades to its base (`PLA-CF` to `PLA`) for a user who has no CF profiles installed.

## Why this matters

If a user loads a third-party filament into a QIDI Box, OrcaSlicer can now land on the right profile. Say the box reports eSUN "PLA Matte" in near-black. Before, every PLA collapsed to one generic preset, and `PLA Matte` could be matched as plain `PLA`. Matching on vendor and color alone is not enough either: among a user's eSUN PLA profiles, `eSun PLA+ Black` at `#000000` sits nearer to the reported `060606` than `eSun Matte PLA Black` at `#202020`, so color picks the wrong product by a factor of nineteen. The reported product name is what separates them, which is why it is tried before color.

## What changes for each agent

| Agent | Before | After |
|-------|--------|-------|
| **QIDI** | Inline numeric-ID scheme (`build_setting_id` / `map_filament_type_to_setting_id`) with a local `has_visible_base_preset` check | Fills V (name+id), F (name+index+type), C, P and calls `resolve()` |
| **Snapmaker** | Inline `find_closest_color_preset_by_vendor_and_type` (vendor+type+closest color) | That strategy is absorbed into the shared matcher as the config match at level 1; Snapmaker normalizes and calls `resolve()`. One deliberate difference: a preset that declares no `default_filament_colour` now sits out the closest-color level instead of being scored as black, and is picked up by the level below |
| **Moonraker** (AFC / Happy Hare) | `bundle ? filament_id_by_type : map_...` duplicated | Reports only a type → falls through to config level 4 / generic 5. Same result, now with a generic fallback when the type has no installed preset |
| **Creality** | Inline scoring (`+20` brand name in preset name, `+10` vendor, prefer system over user copies), returning a `filament_id` | Fills V (vendor), F (brand name), C and calls `resolve()` |

The Creality change is worth calling out because its previous behavior was self-defeating. Its own comment noted that user copies of generic presets inherit a generic `filament_id` from their parent, so a brand-specific match could collapse back to "Generic PLA", and it preferred system presets to avoid that. But the preset it scored highest still could not be selected, because only the id was returned. Returning the preset name fixes the underlying problem, so a K2 owner's tweaked copy (`Creality Hyper PLA @K2 (Harky)`) is now matchable, which is what that code wanted in the first place.

## Testability

`resolve()` takes the filament `PresetCollection*` as a parameter (agents pass the preset bundle's filaments, or `nullptr`) instead of reaching for the GUI singleton, so the matcher carries no GUI state and is unit-tested headlessly against a synthetic collection.

`tests/slic3rutils/test_filament_matcher.cpp` covers the cascade level by level: the name-over-color ordering and its generalized form, the colorless-preset rules, derived-preset eligibility, the id levels including the strict six-hex-digit color suffix, a matched preset surviving a shared `filament_id`, the vendor+type and type-only paths used by Snapmaker and Moonraker, and the `filament_type` resolution. 26 cases, 37 assertions.

## Graceful degradation

- Existing numeric profiles (e.g. `QD_3_1_1`) still match via the numeric `V × F` combination.
- Agents that report only a type keep their previous behavior, since the vendor and color levels are skipped when their inputs are missing. The one change: a type with no installed preset now falls back to the generic id instead of returning unknown.

## Discussion points

1. **Prefix registry.** This uses `QD_<series>` for QIDI; should OrcaSlicer define a registry of known agent/model prefixes so profile authors have a documented target?
2. **ID format ownership.** `resolve()` builds the candidate `filament_id`s internally from the raw fields. Should agents instead pass an ordered list of candidate ids, giving them control of the format? Which leads to better standardization?
3. **Directly-loaded spools (outside the AMS).** Some printers (e.g. QIDI boxes) report a spool loaded directly into the toolhead in addition to the AMS box slots (not through the AMS; QIDI exposes it at a fixed `slot16`). OrcaSlicer already models this as the external / virtual tray (`vt_slot` / `VIRTUAL_TRAY_MAIN_ID`), which `build_filament_ams_list()` renders as an **`Ext`** entry in the sync list. But the Moonraker agent path feeds `DevFilaSystemParser::ParseV1_0` (which only builds AMS units) and never populates `vt_slot`, so that spool is currently dropped. Should the agent path populate `vt_slot` (+ `ams_support_virtual_tray`) to surface it as a true external spool, reusing the existing rendering, at the cost of toggling a flag the device status panel also reads? Or emit a distinct single-slot AMS unit, which needs changes to the shared, uniform-4-slot `build_ams_payload`?
4. **Where the tests live.** They are in `slic3rutils`, which `tests/AGENTS.md` scopes to the Python plugin system. That suite is the only one linking `libslic3r_gui`, where `FilamentMatcher` lives, so the alternatives are leaving them there, giving the GUI utils their own suite, or moving `FilamentMatcher` into `libslic3r`. It has no GUI dependency, so the last option is feasible if maintainers prefer it.

# Screenshots/Recordings/Graphs

## Before

https://github.com/user-attachments/assets/de476412-b49c-46c4-9673-608fb565ccf9

## After

https://github.com/user-attachments/assets/e567e0d9-02a0-49a3-8d2e-2c585381e91f

# Tests

26 headless unit tests against a synthetic collection, plus daily use on a QIDI Plus 4 with a QidiBox.
