### PR TITLE
Fix: Added a warning if the Hollow base pattern is selected for the non-tree supports

### DIFF
--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -1526,6 +1526,10 @@ StringObjectException Print::validate(StringObjectException *warning, Polygons* 
                     // Orca: check if the Lightning base pattern selected
                     warning->string  = L("The Lightning base pattern is not supported by this support type; Rectilinear will be used instead.");
                     warning->opt_key = "support_base_pattern";
+                } else if (object->config().support_base_pattern == SupportMaterialPattern::smpNone && warning) {
+                    // Orca: check if the Hollow base pattern selected
+                    warning->string  = L("The Hollow base pattern is not supported by this support type; Rectilinear will be used instead.");
+                    warning->opt_key = "support_base_pattern";
                 }
             }
 


### PR DESCRIPTION
# Description

Fixes point 4 of #12684

Added a warning if the Hollow base pattern is selected for the non-tree supports.
Warning "says" that the Rectilinear will be used instead.

# Screenshots

<img width="1909" height="823" alt="image" src="https://github.com/user-attachments/assets/87789148-fec9-4eff-b3f7-d3dfda7b491b" />