### PR TITLE
Fix OrcaSlicer_profile_validator link error with undefined nsvg symbols

### DIFF
--- a/src/dev-utils/OrcaSlicer_profile_validator.cpp
+++ b/src/dev-utils/OrcaSlicer_profile_validator.cpp
@@ -1,3 +1,5 @@
+#define NANOSVG_IMPLEMENTATION
+#include "nanosvg/nanosvg.h"
 #include "libslic3r/GCode.hpp"
 #include "libslic3r/Preset.hpp"
 #include "libslic3r/Config.hpp"


### PR DESCRIPTION
When ORCA_TOOLS is enabled, the profile_validator target links libslic3r which uses nsvg functions, but no translation unit in its link set defines NANOSVG_IMPLEMENTATION. Add it to the validator source file.

# Screenshots/Recordings/Graphs

<!--
> Please attach relevant screenshots to showcase the UI changes.
> Please attach images that can help explain the changes.
-->

## Tests

<!--
> Please describe the tests that you have conducted to verify the changes made in this PR.
-->
