### PR TITLE
Disable arc fitting for Qidi processes

### DIFF
--- a/resources/profiles/Qidi/process/0.06mm Standard @Qidi Q2 0.2 nozzle.json
+++ b/resources/profiles/Qidi/process/0.06mm Standard @Qidi Q2 0.2 nozzle.json
@@ -5,7 +5,7 @@
     "from": "system",
     "setting_id": "GP024",
     "instantiation": "true",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "compatible_printers": [
         "Qidi Q2 0.2 nozzle"
     ]

--- a/resources/profiles/Qidi/process/0.06mm Standard @Qidi Q2C 0.2 nozzle.json
+++ b/resources/profiles/Qidi/process/0.06mm Standard @Qidi Q2C 0.2 nozzle.json
@@ -5,7 +5,7 @@
     "from": "system",
     "setting_id": "GP024",
     "instantiation": "true",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "compatible_printers": [
         "Qidi Q2C 0.2 nozzle"
     ]

--- a/resources/profiles/Qidi/process/0.06mm Standard @Qidi XPlus4 0.2 nozzle.json
+++ b/resources/profiles/Qidi/process/0.06mm Standard @Qidi XPlus4 0.2 nozzle.json
@@ -5,7 +5,7 @@
     "from": "system",
     "setting_id": "GP024",
     "instantiation": "true",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "compatible_printers": [
         "Qidi X-Plus 4 0.2 nozzle"
     ]

--- a/resources/profiles/Qidi/process/0.08mm Extra Fine @X-Max 4 0.2 nozzle.json
+++ b/resources/profiles/Qidi/process/0.08mm Extra Fine @X-Max 4 0.2 nozzle.json
@@ -10,7 +10,7 @@
     "bridge_flow": "1",
     "default_acceleration": ["4000"],
     "elefant_foot_compensation": "0.15",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "initial_layer_infill_speed": ["70"],
     "initial_layer_line_width": "0.25",
     "initial_layer_print_height": "0.1",

--- a/resources/profiles/Qidi/process/0.08mm Extra Fine @X-Max 4.json
+++ b/resources/profiles/Qidi/process/0.08mm Extra Fine @X-Max 4.json
@@ -10,7 +10,7 @@
     "bridge_flow": "1",
     "default_acceleration": ["10000"],
     "elefant_foot_compensation": "0.15",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "gap_infill_speed": ["350"],
     "initial_layer_infill_speed": ["105"],
     "initial_layer_speed": ["50"],

--- a/resources/profiles/Qidi/process/0.08mm Standard @Qidi Q2 0.2 nozzle.json
+++ b/resources/profiles/Qidi/process/0.08mm Standard @Qidi Q2 0.2 nozzle.json
@@ -5,7 +5,7 @@
     "from": "system",
     "setting_id": "GP025",
     "instantiation": "true",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "compatible_printers": [
         "Qidi Q2 0.2 nozzle"
     ]

--- a/resources/profiles/Qidi/process/0.08mm Standard @Qidi Q2C 0.2 nozzle.json
+++ b/resources/profiles/Qidi/process/0.08mm Standard @Qidi Q2C 0.2 nozzle.json
@@ -5,7 +5,7 @@
     "from": "system",
     "setting_id": "GP025",
     "instantiation": "true",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "compatible_printers": [
         "Qidi Q2C 0.2 nozzle"
     ]

--- a/resources/profiles/Qidi/process/0.08mm Standard @Qidi XPlus4 0.2 nozzle.json
+++ b/resources/profiles/Qidi/process/0.08mm Standard @Qidi XPlus4 0.2 nozzle.json
@@ -5,7 +5,7 @@
     "from": "system",
     "setting_id": "GP025",
     "instantiation": "true",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "compatible_printers": [
         "Qidi X-Plus 4 0.2 nozzle"
     ]

--- a/resources/profiles/Qidi/process/0.10mm Standard @Qidi Q2 0.2 nozzle.json
+++ b/resources/profiles/Qidi/process/0.10mm Standard @Qidi Q2 0.2 nozzle.json
@@ -5,7 +5,7 @@
     "from": "system",
     "setting_id": "GP007",
     "instantiation": "true",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "compatible_printers": [
         "Qidi Q2 0.2 nozzle"
     ]

--- a/resources/profiles/Qidi/process/0.10mm Standard @Qidi Q2C 0.2 nozzle.json
+++ b/resources/profiles/Qidi/process/0.10mm Standard @Qidi Q2C 0.2 nozzle.json
@@ -5,7 +5,7 @@
     "from": "system",
     "setting_id": "GP007",
     "instantiation": "true",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "compatible_printers": [
         "Qidi Q2C 0.2 nozzle"
     ]

--- a/resources/profiles/Qidi/process/0.10mm Standard @Qidi XPlus4 0.2 nozzle.json
+++ b/resources/profiles/Qidi/process/0.10mm Standard @Qidi XPlus4 0.2 nozzle.json
@@ -5,7 +5,7 @@
     "from": "system",
     "setting_id": "GP007",
     "instantiation": "true",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "compatible_printers": [
         "Qidi X-Plus 4 0.2 nozzle"
     ]

--- a/resources/profiles/Qidi/process/0.10mm Standard @X-Max 4 0.2 nozzle.json
+++ b/resources/profiles/Qidi/process/0.10mm Standard @X-Max 4 0.2 nozzle.json
@@ -10,7 +10,7 @@
     "bridge_flow": "1",
     "default_acceleration": ["10000"],
     "elefant_foot_compensation": "0.15",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "initial_layer_infill_speed": ["70"],
     "initial_layer_line_width": "0.25",
     "initial_layer_print_height": "0.1",

--- a/resources/profiles/Qidi/process/0.12mm Balanced Quality @X-Max 4 0.2 nozzle.json
+++ b/resources/profiles/Qidi/process/0.12mm Balanced Quality @X-Max 4 0.2 nozzle.json
@@ -10,7 +10,7 @@
     "bridge_flow": "1",
     "default_acceleration": ["10000"],
     "elefant_foot_compensation": "0.15",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "initial_layer_infill_speed": ["70"],
     "initial_layer_line_width": "0.25",
     "initial_layer_print_height": "0.1",

--- a/resources/profiles/Qidi/process/0.12mm Fine @Qidi Q2.json
+++ b/resources/profiles/Qidi/process/0.12mm Fine @Qidi Q2.json
@@ -5,7 +5,7 @@
     "from": "system",
     "setting_id": "GP004",
     "instantiation": "true",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "compatible_printers": [
         "Qidi Q2 0.4 nozzle"
     ]

--- a/resources/profiles/Qidi/process/0.12mm Fine @Qidi Q2C.json
+++ b/resources/profiles/Qidi/process/0.12mm Fine @Qidi Q2C.json
@@ -5,7 +5,7 @@
     "from": "system",
     "setting_id": "GP004",
     "instantiation": "true",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "compatible_printers": [
         "Qidi Q2C 0.4 nozzle"
     ]

--- a/resources/profiles/Qidi/process/0.12mm Fine @Qidi XPlus4.json
+++ b/resources/profiles/Qidi/process/0.12mm Fine @Qidi XPlus4.json
@@ -5,7 +5,7 @@
     "from": "system",
     "setting_id": "GP004",
     "instantiation": "true",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "compatible_printers": [
         "Qidi X-Plus 4 0.4 nozzle"
     ]

--- a/resources/profiles/Qidi/process/0.12mm Fine @X-Max 4.json
+++ b/resources/profiles/Qidi/process/0.12mm Fine @X-Max 4.json
@@ -10,7 +10,7 @@
     "bridge_flow": "1",
     "default_acceleration": ["10000"],
     "elefant_foot_compensation": "0.15",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "gap_infill_speed": ["350"],
     "initial_layer_infill_speed": ["105"],
     "initial_layer_speed": ["50"],

--- a/resources/profiles/Qidi/process/0.12mm Standard @Qidi Q2 0.2 nozzle.json
+++ b/resources/profiles/Qidi/process/0.12mm Standard @Qidi Q2 0.2 nozzle.json
@@ -5,7 +5,7 @@
     "from": "system",
     "setting_id": "GP026",
     "instantiation": "true",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "compatible_printers": [
         "Qidi Q2 0.2 nozzle"
     ]

--- a/resources/profiles/Qidi/process/0.12mm Standard @Qidi Q2C 0.2 nozzle.json
+++ b/resources/profiles/Qidi/process/0.12mm Standard @Qidi Q2C 0.2 nozzle.json
@@ -5,7 +5,7 @@
     "from": "system",
     "setting_id": "GP026",
     "instantiation": "true",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "compatible_printers": [
         "Qidi Q2C 0.2 nozzle"
     ]

--- a/resources/profiles/Qidi/process/0.12mm Standard @Qidi XPlus4 0.2 nozzle.json
+++ b/resources/profiles/Qidi/process/0.12mm Standard @Qidi XPlus4 0.2 nozzle.json
@@ -5,7 +5,7 @@
     "from": "system",
     "setting_id": "GP026",
     "instantiation": "true",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "compatible_printers": [
         "Qidi X-Plus 4 0.2 nozzle"
     ]

--- a/resources/profiles/Qidi/process/0.14mm Standard @Qidi Q2 0.2 nozzle.json
+++ b/resources/profiles/Qidi/process/0.14mm Standard @Qidi Q2 0.2 nozzle.json
@@ -5,7 +5,7 @@
     "from": "system",
     "setting_id": "GP027",
     "instantiation": "true",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "compatible_printers": [
         "Qidi Q2 0.2 nozzle"
     ]

--- a/resources/profiles/Qidi/process/0.14mm Standard @Qidi Q2C 0.2 nozzle.json
+++ b/resources/profiles/Qidi/process/0.14mm Standard @Qidi Q2C 0.2 nozzle.json
@@ -5,7 +5,7 @@
     "from": "system",
     "setting_id": "GP027",
     "instantiation": "true",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "compatible_printers": [
         "Qidi Q2C 0.2 nozzle"
     ]

--- a/resources/profiles/Qidi/process/0.14mm Standard @Qidi XPlus4 0.2 nozzle.json
+++ b/resources/profiles/Qidi/process/0.14mm Standard @Qidi XPlus4 0.2 nozzle.json
@@ -5,7 +5,7 @@
     "from": "system",
     "setting_id": "GP027",
     "instantiation": "true",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "compatible_printers": [
         "Qidi X-Plus 4 0.2 nozzle"
     ]

--- a/resources/profiles/Qidi/process/0.16mm Balanced Quality @X-Max 4.json
+++ b/resources/profiles/Qidi/process/0.16mm Balanced Quality @X-Max 4.json
@@ -10,7 +10,7 @@
     "bridge_flow": "1",
     "default_acceleration": ["4000"],
     "elefant_foot_compensation": "0.15",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "gap_infill_speed": ["250"],
     "inner_wall_acceleration": ["5000"],
     "internal_solid_infill_speed": ["200"],

--- a/resources/profiles/Qidi/process/0.16mm Optimal @Qidi Q2.json
+++ b/resources/profiles/Qidi/process/0.16mm Optimal @Qidi Q2.json
@@ -5,7 +5,7 @@
     "from": "system",
     "setting_id": "GP004",
     "instantiation": "true",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "compatible_printers": [
         "Qidi Q2 0.4 nozzle"
     ]

--- a/resources/profiles/Qidi/process/0.16mm Optimal @Qidi Q2C.json
+++ b/resources/profiles/Qidi/process/0.16mm Optimal @Qidi Q2C.json
@@ -5,7 +5,7 @@
     "from": "system",
     "setting_id": "GP004",
     "instantiation": "true",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "compatible_printers": [
         "Qidi Q2C 0.4 nozzle"
     ]

--- a/resources/profiles/Qidi/process/0.16mm Optimal @Qidi XPlus4.json
+++ b/resources/profiles/Qidi/process/0.16mm Optimal @Qidi XPlus4.json
@@ -5,7 +5,7 @@
     "from": "system",
     "setting_id": "GP004",
     "instantiation": "true",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "compatible_printers": [
         "Qidi X-Plus 4 0.4 nozzle"
     ]

--- a/resources/profiles/Qidi/process/0.16mm Standard @X-Max 4.json
+++ b/resources/profiles/Qidi/process/0.16mm Standard @X-Max 4.json
@@ -10,7 +10,7 @@
     "bridge_flow": "1",
     "default_acceleration": ["10000"],
     "elefant_foot_compensation": "0.15",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "gap_infill_speed": ["300"],
     "inner_wall_acceleration": ["5000"],
     "inner_wall_speed": ["300"],

--- a/resources/profiles/Qidi/process/0.18mm Balanced Quality @X-Max 4 0.6 nozzle.json
+++ b/resources/profiles/Qidi/process/0.18mm Balanced Quality @X-Max 4 0.6 nozzle.json
@@ -9,7 +9,7 @@
     "bridge_speed": ["30"],
     "default_acceleration": ["10000"],
     "elefant_foot_compensation": "0.15",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "gap_infill_speed": ["50"],
     "initial_layer_infill_speed": ["55"],
     "initial_layer_line_width": "0.62",

--- a/resources/profiles/Qidi/process/0.18mm Standard @Qidi Q2 0.6 nozzle.json
+++ b/resources/profiles/Qidi/process/0.18mm Standard @Qidi Q2 0.6 nozzle.json
@@ -5,7 +5,7 @@
     "from": "system",
     "setting_id": "GP028",
     "instantiation": "true",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "compatible_printers": [
         "Qidi Q2 0.6 nozzle"
     ]

--- a/resources/profiles/Qidi/process/0.18mm Standard @Qidi Q2C 0.6 nozzle.json
+++ b/resources/profiles/Qidi/process/0.18mm Standard @Qidi Q2C 0.6 nozzle.json
@@ -5,7 +5,7 @@
     "from": "system",
     "setting_id": "GP028",
     "instantiation": "true",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "compatible_printers": [
         "Qidi Q2C 0.6 nozzle"
     ]

--- a/resources/profiles/Qidi/process/0.18mm Standard @Qidi XPlus4 0.6 nozzle.json
+++ b/resources/profiles/Qidi/process/0.18mm Standard @Qidi XPlus4 0.6 nozzle.json
@@ -5,7 +5,7 @@
     "from": "system",
     "setting_id": "GP028",
     "instantiation": "true",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "compatible_printers": [
         "Qidi X-Plus 4 0.6 nozzle"
     ]

--- a/resources/profiles/Qidi/process/0.20mm Balanced Strength @X-Max 4.json
+++ b/resources/profiles/Qidi/process/0.20mm Balanced Strength @X-Max 4.json
@@ -9,7 +9,7 @@
     "bridge_flow": "1",
     "default_acceleration": ["10000"],
     "elefant_foot_compensation": "0.15",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "gap_infill_speed": ["250"],
     "inner_wall_acceleration": ["5000"],
     "inner_wall_speed": ["300"],

--- a/resources/profiles/Qidi/process/0.20mm Standard @Qidi Q2.json
+++ b/resources/profiles/Qidi/process/0.20mm Standard @Qidi Q2.json
@@ -5,7 +5,7 @@
     "from": "system",
     "setting_id": "GP004",
     "instantiation": "true",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "compatible_printers": [
         "Qidi Q2 0.4 nozzle"
     ]

--- a/resources/profiles/Qidi/process/0.20mm Standard @Qidi Q2C.json
+++ b/resources/profiles/Qidi/process/0.20mm Standard @Qidi Q2C.json
@@ -5,7 +5,7 @@
     "from": "system",
     "setting_id": "GP004",
     "instantiation": "true",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "compatible_printers": [
         "Qidi Q2C 0.4 nozzle"
     ]

--- a/resources/profiles/Qidi/process/0.20mm Standard @Qidi XPlus4.json
+++ b/resources/profiles/Qidi/process/0.20mm Standard @Qidi XPlus4.json
@@ -5,7 +5,7 @@
     "from": "system",
     "setting_id": "GP004",
     "instantiation": "true",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "compatible_printers": [
         "Qidi X-Plus 4 0.4 nozzle"
     ]

--- a/resources/profiles/Qidi/process/0.20mm Standard @X-Max 4.json
+++ b/resources/profiles/Qidi/process/0.20mm Standard @X-Max 4.json
@@ -8,7 +8,7 @@
     "bridge_flow": "1",
     "default_acceleration": ["10000"],
     "elefant_foot_compensation": "0.15",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "gap_infill_speed": ["250"],
     "inner_wall_speed": ["300"],
     "inner_wall_acceleration": ["5000"],

--- a/resources/profiles/Qidi/process/0.24mm Balanced Quality @X-Max 4 0.8 nozzle.json
+++ b/resources/profiles/Qidi/process/0.24mm Balanced Quality @X-Max 4 0.8 nozzle.json
@@ -9,7 +9,7 @@
     "bridge_speed": ["30"],
     "default_acceleration": ["10000"],
     "elefant_foot_compensation": "0.15",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "gap_infill_speed": ["50"],
     "initial_layer_infill_speed": ["55"],
     "initial_layer_line_width": "0.82",

--- a/resources/profiles/Qidi/process/0.24mm Balanced Strength @X-Max 4 0.6 nozzle.json
+++ b/resources/profiles/Qidi/process/0.24mm Balanced Strength @X-Max 4 0.6 nozzle.json
@@ -9,7 +9,7 @@
     "bridge_speed": ["30"],
     "default_acceleration": ["10000"],
     "elefant_foot_compensation": "0.15",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "gap_infill_speed": ["50"],
     "initial_layer_infill_speed": ["55"],
     "initial_layer_line_width": "0.62",

--- a/resources/profiles/Qidi/process/0.24mm Draft @Qidi Q2.json
+++ b/resources/profiles/Qidi/process/0.24mm Draft @Qidi Q2.json
@@ -5,7 +5,7 @@
     "from": "system",
     "setting_id": "GP004",
     "instantiation": "true",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "compatible_printers": [
         "Qidi Q2 0.4 nozzle"
     ]

--- a/resources/profiles/Qidi/process/0.24mm Draft @Qidi Q2C.json
+++ b/resources/profiles/Qidi/process/0.24mm Draft @Qidi Q2C.json
@@ -5,7 +5,7 @@
     "from": "system",
     "setting_id": "GP004",
     "instantiation": "true",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "compatible_printers": [
         "Qidi Q2C 0.4 nozzle"
     ]

--- a/resources/profiles/Qidi/process/0.24mm Draft @Qidi XPlus4.json
+++ b/resources/profiles/Qidi/process/0.24mm Draft @Qidi XPlus4.json
@@ -5,7 +5,7 @@
     "from": "system",
     "setting_id": "GP004",
     "instantiation": "true",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "compatible_printers": [
         "Qidi X-Plus 4 0.4 nozzle"
     ]

--- a/resources/profiles/Qidi/process/0.24mm Standard @Qidi Q2 0.6 nozzle.json
+++ b/resources/profiles/Qidi/process/0.24mm Standard @Qidi Q2 0.6 nozzle.json
@@ -5,7 +5,7 @@
     "from": "system",
     "setting_id": "GP029",
     "instantiation": "true",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "compatible_printers": [
         "Qidi Q2 0.6 nozzle"
     ]

--- a/resources/profiles/Qidi/process/0.24mm Standard @Qidi Q2 0.8 nozzle.json
+++ b/resources/profiles/Qidi/process/0.24mm Standard @Qidi Q2 0.8 nozzle.json
@@ -5,7 +5,7 @@
     "from": "system",
     "setting_id": "GP032",
     "instantiation": "true",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "compatible_printers": [
         "Qidi Q2 0.8 nozzle"
     ]

--- a/resources/profiles/Qidi/process/0.24mm Standard @Qidi Q2C 0.6 nozzle.json
+++ b/resources/profiles/Qidi/process/0.24mm Standard @Qidi Q2C 0.6 nozzle.json
@@ -5,7 +5,7 @@
     "from": "system",
     "setting_id": "GP029",
     "instantiation": "true",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "compatible_printers": [
         "Qidi Q2C 0.6 nozzle"
     ]

--- a/resources/profiles/Qidi/process/0.24mm Standard @Qidi Q2C 0.8 nozzle.json
+++ b/resources/profiles/Qidi/process/0.24mm Standard @Qidi Q2C 0.8 nozzle.json
@@ -5,7 +5,7 @@
     "from": "system",
     "setting_id": "GP032",
     "instantiation": "true",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "compatible_printers": [
         "Qidi Q2C 0.8 nozzle"
     ]

--- a/resources/profiles/Qidi/process/0.24mm Standard @Qidi XPlus4 0.6 nozzle.json
+++ b/resources/profiles/Qidi/process/0.24mm Standard @Qidi XPlus4 0.6 nozzle.json
@@ -5,7 +5,7 @@
     "from": "system",
     "setting_id": "GP029",
     "instantiation": "true",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "compatible_printers": [
         "Qidi X-Plus 4 0.6 nozzle"
     ]

--- a/resources/profiles/Qidi/process/0.24mm Standard @Qidi XPlus4 0.8 nozzle.json
+++ b/resources/profiles/Qidi/process/0.24mm Standard @Qidi XPlus4 0.8 nozzle.json
@@ -5,7 +5,7 @@
     "from": "system",
     "setting_id": "GP032",
     "instantiation": "true",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "compatible_printers": [
         "Qidi X-Plus 4 0.8 nozzle"
     ]

--- a/resources/profiles/Qidi/process/0.24mm Standard @X-Max 4.json
+++ b/resources/profiles/Qidi/process/0.24mm Standard @X-Max 4.json
@@ -8,7 +8,7 @@
     "bridge_flow": "1",
     "default_acceleration": ["10000"],
     "elefant_foot_compensation": "0.15",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "gap_infill_speed": ["230"],
     "inner_wall_acceleration": ["5000"],
     "inner_wall_speed": ["230"],

--- a/resources/profiles/Qidi/process/0.25mm Draft @Qidi Q2.json
+++ b/resources/profiles/Qidi/process/0.25mm Draft @Qidi Q2.json
@@ -6,7 +6,7 @@
     "setting_id": "GP004",
     "instantiation": "true",
     "adaptive_layer_height": "1",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "reduce_crossing_wall": "0",
     "layer_height": "0.25",
     "max_travel_detour_distance": "0",

--- a/resources/profiles/Qidi/process/0.25mm Draft @Qidi Q2C.json
+++ b/resources/profiles/Qidi/process/0.25mm Draft @Qidi Q2C.json
@@ -6,7 +6,7 @@
     "setting_id": "GP004",
     "instantiation": "true",
     "adaptive_layer_height": "1",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "reduce_crossing_wall": "0",
     "layer_height": "0.25",
     "max_travel_detour_distance": "0",

--- a/resources/profiles/Qidi/process/0.25mm Draft @Qidi XPlus4.json
+++ b/resources/profiles/Qidi/process/0.25mm Draft @Qidi XPlus4.json
@@ -6,7 +6,7 @@
     "setting_id": "GP004",
     "instantiation": "true",
     "adaptive_layer_height": "1",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "reduce_crossing_wall": "0",
     "layer_height": "0.25",
     "max_travel_detour_distance": "0",

--- a/resources/profiles/Qidi/process/0.28mm Extra Draft @Qidi Q2.json
+++ b/resources/profiles/Qidi/process/0.28mm Extra Draft @Qidi Q2.json
@@ -5,7 +5,7 @@
     "from": "system",
     "setting_id": "GP004",
     "instantiation": "true",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "compatible_printers": [
         "Qidi Q2 0.4 nozzle"
     ]

--- a/resources/profiles/Qidi/process/0.28mm Extra Draft @Qidi Q2C.json
+++ b/resources/profiles/Qidi/process/0.28mm Extra Draft @Qidi Q2C.json
@@ -5,7 +5,7 @@
     "from": "system",
     "setting_id": "GP004",
     "instantiation": "true",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "compatible_printers": [
         "Qidi Q2C 0.4 nozzle"
     ]

--- a/resources/profiles/Qidi/process/0.28mm Extra Draft @Qidi XPlus4.json
+++ b/resources/profiles/Qidi/process/0.28mm Extra Draft @Qidi XPlus4.json
@@ -5,7 +5,7 @@
     "from": "system",
     "setting_id": "GP004",
     "instantiation": "true",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "compatible_printers": [
         "Qidi X-Plus 4 0.4 nozzle"
     ]

--- a/resources/profiles/Qidi/process/0.30mm Extra Draft @Qidi Q2.json
+++ b/resources/profiles/Qidi/process/0.30mm Extra Draft @Qidi Q2.json
@@ -6,7 +6,7 @@
     "setting_id": "GP004",
     "instantiation": "true",
     "adaptive_layer_height": "1",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "reduce_crossing_wall": "0",
     "layer_height": "0.3",
     "max_travel_detour_distance": "0",

--- a/resources/profiles/Qidi/process/0.30mm Extra Draft @Qidi Q2C.json
+++ b/resources/profiles/Qidi/process/0.30mm Extra Draft @Qidi Q2C.json
@@ -6,7 +6,7 @@
     "setting_id": "GP004",
     "instantiation": "true",
     "adaptive_layer_height": "1",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "reduce_crossing_wall": "0",
     "layer_height": "0.3",
     "max_travel_detour_distance": "0",

--- a/resources/profiles/Qidi/process/0.30mm Extra Draft @Qidi XPlus4.json
+++ b/resources/profiles/Qidi/process/0.30mm Extra Draft @Qidi XPlus4.json
@@ -6,7 +6,7 @@
     "setting_id": "GP004",
     "instantiation": "true",
     "adaptive_layer_height": "1",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "reduce_crossing_wall": "0",
     "layer_height": "0.3",
     "max_travel_detour_distance": "0",

--- a/resources/profiles/Qidi/process/0.30mm Standard @Qidi Q2 0.6 nozzle.json
+++ b/resources/profiles/Qidi/process/0.30mm Standard @Qidi Q2 0.6 nozzle.json
@@ -5,7 +5,7 @@
     "from": "system",
     "setting_id": "GP010",
     "instantiation": "true",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "compatible_printers": [
         "Qidi Q2 0.6 nozzle"
     ]

--- a/resources/profiles/Qidi/process/0.30mm Standard @Qidi Q2C 0.6 nozzle.json
+++ b/resources/profiles/Qidi/process/0.30mm Standard @Qidi Q2C 0.6 nozzle.json
@@ -5,7 +5,7 @@
     "from": "system",
     "setting_id": "GP010",
     "instantiation": "true",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "compatible_printers": [
         "Qidi Q2C 0.6 nozzle"
     ]

--- a/resources/profiles/Qidi/process/0.30mm Standard @Qidi XPlus4 0.6 nozzle.json
+++ b/resources/profiles/Qidi/process/0.30mm Standard @Qidi XPlus4 0.6 nozzle.json
@@ -5,7 +5,7 @@
     "from": "system",
     "setting_id": "GP010",
     "instantiation": "true",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "compatible_printers": [
         "Qidi X-Plus 4 0.6 nozzle"
     ]

--- a/resources/profiles/Qidi/process/0.30mm Standard @X-Max 4 0.6 nozzle.json
+++ b/resources/profiles/Qidi/process/0.30mm Standard @X-Max 4 0.6 nozzle.json
@@ -9,7 +9,7 @@
     "bridge_speed": ["30"],
     "default_acceleration": ["10000"],
     "elefant_foot_compensation": "0.15",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "gap_infill_speed": ["50"],
     "initial_layer_infill_speed": ["55"],
     "initial_layer_line_width": "0.62",

--- a/resources/profiles/Qidi/process/0.32mm Balanced Strength @X-Max 4 0.8 nozzle.json
+++ b/resources/profiles/Qidi/process/0.32mm Balanced Strength @X-Max 4 0.8 nozzle.json
@@ -9,7 +9,7 @@
     "bridge_speed": ["50"],
     "default_acceleration": ["10000"],
     "elefant_foot_compensation": "0.15",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "gap_infill_speed": ["50"],
     "initial_layer_infill_speed": ["55"],
     "initial_layer_line_width": "0.82",

--- a/resources/profiles/Qidi/process/0.32mm Standard @Qidi Q2 0.8 nozzle.json
+++ b/resources/profiles/Qidi/process/0.32mm Standard @Qidi Q2 0.8 nozzle.json
@@ -5,7 +5,7 @@
     "from": "system",
     "setting_id": "GP033",
     "instantiation": "true",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "compatible_printers": [
         "Qidi Q2 0.8 nozzle"
     ]

--- a/resources/profiles/Qidi/process/0.32mm Standard @Qidi Q2C 0.8 nozzle.json
+++ b/resources/profiles/Qidi/process/0.32mm Standard @Qidi Q2C 0.8 nozzle.json
@@ -5,7 +5,7 @@
     "from": "system",
     "setting_id": "GP033",
     "instantiation": "true",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "compatible_printers": [
         "Qidi Q2C 0.8 nozzle"
     ]

--- a/resources/profiles/Qidi/process/0.32mm Standard @Qidi XPlus4 0.8 nozzle.json
+++ b/resources/profiles/Qidi/process/0.32mm Standard @Qidi XPlus4 0.8 nozzle.json
@@ -5,7 +5,7 @@
     "from": "system",
     "setting_id": "GP033",
     "instantiation": "true",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "compatible_printers": [
         "Qidi X-Plus 4 0.8 nozzle"
     ]

--- a/resources/profiles/Qidi/process/0.36mm Standard @Qidi Q2 0.6 nozzle.json
+++ b/resources/profiles/Qidi/process/0.36mm Standard @Qidi Q2 0.6 nozzle.json
@@ -5,7 +5,7 @@
     "from": "system",
     "setting_id": "GP030",
     "instantiation": "true",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "compatible_printers": [
         "Qidi Q2 0.6 nozzle"
     ]

--- a/resources/profiles/Qidi/process/0.36mm Standard @Qidi Q2C 0.6 nozzle.json
+++ b/resources/profiles/Qidi/process/0.36mm Standard @Qidi Q2C 0.6 nozzle.json
@@ -5,7 +5,7 @@
     "from": "system",
     "setting_id": "GP030",
     "instantiation": "true",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "compatible_printers": [
         "Qidi Q2C 0.6 nozzle"
     ]

--- a/resources/profiles/Qidi/process/0.36mm Standard @Qidi XPlus4 0.6 nozzle.json
+++ b/resources/profiles/Qidi/process/0.36mm Standard @Qidi XPlus4 0.6 nozzle.json
@@ -5,7 +5,7 @@
     "from": "system",
     "setting_id": "GP030",
     "instantiation": "true",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "compatible_printers": [
         "Qidi X-Plus 4 0.6 nozzle"
     ]

--- a/resources/profiles/Qidi/process/0.40mm Standard @Qidi Q2 0.8 nozzle.json
+++ b/resources/profiles/Qidi/process/0.40mm Standard @Qidi Q2 0.8 nozzle.json
@@ -5,7 +5,7 @@
     "from": "system",
     "setting_id": "GP009",
     "instantiation": "true",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "compatible_printers": [
         "Qidi Q2 0.8 nozzle"
     ]

--- a/resources/profiles/Qidi/process/0.40mm Standard @Qidi Q2C 0.8 nozzle.json
+++ b/resources/profiles/Qidi/process/0.40mm Standard @Qidi Q2C 0.8 nozzle.json
@@ -5,7 +5,7 @@
     "from": "system",
     "setting_id": "GP009",
     "instantiation": "true",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "compatible_printers": [
         "Qidi Q2C 0.8 nozzle"
     ]

--- a/resources/profiles/Qidi/process/0.40mm Standard @Qidi XPlus4 0.8 nozzle.json
+++ b/resources/profiles/Qidi/process/0.40mm Standard @Qidi XPlus4 0.8 nozzle.json
@@ -5,7 +5,7 @@
     "from": "system",
     "setting_id": "GP009",
     "instantiation": "true",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "compatible_printers": [
         "Qidi X-Plus 4 0.8 nozzle"
     ]

--- a/resources/profiles/Qidi/process/0.40mm Standard @X-Max 4 0.8 nozzle.json
+++ b/resources/profiles/Qidi/process/0.40mm Standard @X-Max 4 0.8 nozzle.json
@@ -9,7 +9,7 @@
     "bridge_speed": ["30"],
     "default_acceleration": ["10000"],
     "elefant_foot_compensation": "0.15",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "gap_infill_speed": ["50"],
     "initial_layer_infill_speed": ["55"],
     "initial_layer_line_width": "0.82",

--- a/resources/profiles/Qidi/process/0.42mm Standard @Qidi Q2 0.6 nozzle.json
+++ b/resources/profiles/Qidi/process/0.42mm Standard @Qidi Q2 0.6 nozzle.json
@@ -5,7 +5,7 @@
     "from": "system",
     "setting_id": "GP031",
     "instantiation": "true",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "compatible_printers": [
         "Qidi Q2 0.6 nozzle"
     ]

--- a/resources/profiles/Qidi/process/0.42mm Standard @Qidi Q2C 0.6 nozzle.json
+++ b/resources/profiles/Qidi/process/0.42mm Standard @Qidi Q2C 0.6 nozzle.json
@@ -5,7 +5,7 @@
     "from": "system",
     "setting_id": "GP031",
     "instantiation": "true",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "compatible_printers": [
         "Qidi Q2C 0.6 nozzle"
     ]

--- a/resources/profiles/Qidi/process/0.42mm Standard @Qidi XPlus4 0.6 nozzle.json
+++ b/resources/profiles/Qidi/process/0.42mm Standard @Qidi XPlus4 0.6 nozzle.json
@@ -5,7 +5,7 @@
     "from": "system",
     "setting_id": "GP031",
     "instantiation": "true",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "compatible_printers": [
         "Qidi X-Plus 4 0.6 nozzle"
     ]

--- a/resources/profiles/Qidi/process/0.48mm Standard @Qidi Q2 0.8 nozzle.json
+++ b/resources/profiles/Qidi/process/0.48mm Standard @Qidi Q2 0.8 nozzle.json
@@ -5,7 +5,7 @@
     "from": "system",
     "setting_id": "GP034",
     "instantiation": "true",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "compatible_printers": [
         "Qidi Q2 0.8 nozzle"
     ]

--- a/resources/profiles/Qidi/process/0.48mm Standard @Qidi Q2C 0.8 nozzle.json
+++ b/resources/profiles/Qidi/process/0.48mm Standard @Qidi Q2C 0.8 nozzle.json
@@ -5,7 +5,7 @@
     "from": "system",
     "setting_id": "GP034",
     "instantiation": "true",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "compatible_printers": [
         "Qidi Q2C 0.8 nozzle"
     ]

--- a/resources/profiles/Qidi/process/0.48mm Standard @Qidi XPlus4 0.8 nozzle.json
+++ b/resources/profiles/Qidi/process/0.48mm Standard @Qidi XPlus4 0.8 nozzle.json
@@ -5,7 +5,7 @@
     "from": "system",
     "setting_id": "GP034",
     "instantiation": "true",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "compatible_printers": [
         "Qidi X-Plus 4 0.8 nozzle"
     ]

--- a/resources/profiles/Qidi/process/0.56mm Standard @Qidi Q2 0.8 nozzle.json
+++ b/resources/profiles/Qidi/process/0.56mm Standard @Qidi Q2 0.8 nozzle.json
@@ -5,7 +5,7 @@
     "from": "system",
     "setting_id": "GP035",
     "instantiation": "true",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "compatible_printers": [
         "Qidi Q2 0.8 nozzle"
     ]

--- a/resources/profiles/Qidi/process/0.56mm Standard @Qidi Q2C 0.8 nozzle.json
+++ b/resources/profiles/Qidi/process/0.56mm Standard @Qidi Q2C 0.8 nozzle.json
@@ -5,7 +5,7 @@
     "from": "system",
     "setting_id": "GP035",
     "instantiation": "true",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "compatible_printers": [
         "Qidi Q2C 0.8 nozzle"
     ]

--- a/resources/profiles/Qidi/process/0.56mm Standard @Qidi XPlus4 0.8 nozzle.json
+++ b/resources/profiles/Qidi/process/0.56mm Standard @Qidi XPlus4 0.8 nozzle.json
@@ -5,7 +5,7 @@
     "from": "system",
     "setting_id": "GP035",
     "instantiation": "true",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "compatible_printers": [
         "Qidi X-Plus 4 0.8 nozzle"
     ]

--- a/resources/profiles/Qidi/process/fdm_process_n_common.json
+++ b/resources/profiles/Qidi/process/fdm_process_n_common.json
@@ -24,7 +24,7 @@
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0",
     "embedding_wall_into_infill": "0",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "enable_height_slowdown": ["0"],
     "enable_overhang_speed": ["1"],
     "enable_prime_tower": "1",


### PR DESCRIPTION
# Description

Qidi printers run Klipper and we don't want arc fitting enabled for these.

This is wrongly enabled in QidiStudio as well, likely where these profiles originated.


