### PR TITLE
fix gaps between walls and sparse infill, issue #12304

### DIFF
--- a/src/libslic3r/Fill/Fill.cpp
+++ b/src/libslic3r/Fill/Fill.cpp
@@ -808,8 +808,10 @@ void split_solid_surface(size_t layer_id, const SurfaceFill &fill, ExPolygons &n
         return;
     }
 
-    // Expand the normal infills a little bit to avoid gaps between normal and narrow infills
-    normal_infill = intersection_ex(offset_ex(normal_fill_areas_ex, scaled_spacing * 0.1), fill.expolygons);
+    // Expand the normal infills to avoid gaps between normal and narrow infills.
+    // The inner_area was shrunk by scaled_spacing * 0.5, so we need to expand
+    // by at least that amount to ensure proper coverage and avoid gaps.
+    normal_infill = intersection_ex(offset_ex(normal_fill_areas_ex, scaled_spacing * 0.5), fill.expolygons);
     narrow_infill = narrow_fill_areas;
 
 #ifdef DEBUG_SURFACE_SPLIT


### PR DESCRIPTION
# Description

This fixes issue #12304: gaps between walls and sparse infill.
When "Detect Narrow Infill" is enabled, sparse infill (Grid pattern) shows gaps between the infill lines and the walls.

**Root Cause:** In the `split_solid_surface()` function in `src/libslic3r/Fill/Fill.cpp`:
Line 656: The `inner_area` is shrunk by `scaled_spacing * 0.5` (minus overlap)
Line 813 (original): The normal infill is expanded by only `scaled_spacing * 0.1`

This creates a net inward shift of 0.4 * spacing, leaving a gap

**Solution:** Increase the expansion amount from scaled_spacing * 0.1 to scaled_spacing * 0.5 to match the shrinkage applied earlier. This ensures the normal infill properly covers the area and connects seamlessly with the narrow infill.

**Additional Context**
When "Ensure vertical shell thickness" triggers on sloping walls (e.g., spheres), it generates a Solid Infill band. This function separates the thin sections of that band. Expanding normal_infill by `scaled_spacing * 0.5` ensures the zig-zag paths physically overlap the concentric narrow lines by half a line width. This welds the plastic together during printing and prevents shrinkage gaps inside the shell.

# Screenshots/Recordings/Graphs

**Before fix:**

<img width="1499" height="792" alt="Screenshot 2026-03-15 о 2 54 26 пп" src="https://github.com/user-attachments/assets/6bad4da1-d74d-4321-b853-48c9fba9ba5b" />
<img width="1504" height="814" alt="Screenshot 2026-03-15 о 2 54 35 пп" src="https://github.com/user-attachments/assets/2ccbea06-1c4c-4289-9633-cdd012b3296d" />

**After fix:**
When "Detect narrow internal solid infill" is **enabled**:
<img width="1512" height="982" alt="Screenshot 2026-03-15 о 3 51 00 пп" src="https://github.com/user-attachments/assets/c65c2d87-732f-4c03-975f-fe3d2b9e7404" />

When "Detect narrow internal solid infill" is **disabled**:
<img width="1512" height="982" alt="Screenshot 2026-03-15 о 3 53 22 пп" src="https://github.com/user-attachments/assets/4449e26e-8deb-4562-9d0e-7307bc9f68ff" />


## Tests

See attached screenshots.

**NOTE**:
This PR addresses the gaps between sparse infill and walls that occur when both `Detect narrow internal solid infill` and `Ensure vertical shell thickness` are enabled. While a gap remains when `Detect narrow internal solid infill` is disabled (where a zig-zag line is expected), this fix improves print quality for the primary use case. 
Additionally, these changes bring the output closer to the behaviour seen in Bambu Studio. Given the partial improvement, I believe this is ready for merge

Fix #12304