### PR TITLE
Fix generating walls instead bridges for multiple filaments printing

### DIFF
--- a/src/libslic3r/Layer.cpp
+++ b/src/libslic3r/Layer.cpp
@@ -190,6 +190,30 @@ void Layer::make_perimeters()
     // keep track of regions whose perimeters we have already generated
     std::vector<unsigned char> done(m_regions.size(), false);
 
+    // ORCA: Fix for issue #11207 - pre-pass to detect cross-region bridge areas.
+    // When a region (e.g. painted face) sits entirely on a different region below,
+    // it will be treated as a bridge. We must subtract those areas from other
+    // regions at the same layer so those regions don't generate perimeters in
+    // the space claimed by the bridge.
+    ExPolygons cross_region_bridge_areas;
+    if (this->object()->num_printing_regions() > 1 && this->lower_layer != nullptr) {
+        for (size_t ri = 0; ri < m_regions.size(); ++ri) {
+            LayerRegion *lm = m_regions[ri];
+            if (lm->slices.empty()) continue;
+            ExPolygons region_expolys = to_expolygons(lm->slices.surfaces);
+            if (region_expolys.empty()) continue;
+
+            // If the supported area is negligible (< 0.01 mm²), the region hangs in air - it's a bridge.
+            ExPolygons supported = intersection_ex(region_expolys, this->lower_layer->lslices);
+            if (area(supported) < sqr(scale_(0.1))) {
+                cross_region_bridge_areas.insert(cross_region_bridge_areas.end(),
+                    region_expolys.begin(), region_expolys.end());
+            }
+        }
+        if (!cross_region_bridge_areas.empty())
+            cross_region_bridge_areas = union_ex(cross_region_bridge_areas);
+    }
+
     for (LayerRegionPtrs::iterator layerm = m_regions.begin(); layerm != m_regions.end(); ++ layerm)
     	if ((*layerm)->slices.empty()) {
  			(*layerm)->perimeters.clear();
@@ -228,8 +252,65 @@ void Layer::make_perimeters()
 
 	        if (layerms.size() == 1) {  // optimization
 	            (*layerm)->fill_surfaces.surfaces.clear();
-                (*layerm)->make_perimeters((*layerm)->slices, {*layerm}, &(*layerm)->fill_surfaces, &(*layerm)->fill_no_overlap_expolygons);
+
+	            // ORCA: Fix for issue #11207 - detect MMU cross-region bridges
+	            // Mark surfaces as stBottomBridge BEFORE make_perimeters so PerimeterGenerator can skip them
+	            if (this->object()->num_printing_regions() > 1 && this->lower_layer != nullptr) {
+	                ExPolygons current_expolys = to_expolygons((*layerm)->slices.surfaces);
+	                ExPolygons supported = intersection_ex(current_expolys, this->lower_layer->lslices);
+	                if (area(supported) < sqr(scale_(0.1))) {
+	                    for (Surface &s : (*layerm)->slices.surfaces)
+	                        s.surface_type = stBottomBridge;
+	                }
+	            }
+
+	            // ORCA: Fix for issue #11207 - for non-bridge regions, union bridge areas into
+	            // slices before perimeter generation so that holes don't get inner perimeter walls.
+	            // After perimeters are generated, subtract bridge areas from fill so the parent
+	            // region doesn't print infill inside the bridge zone.
+	            SurfaceCollection slices_for_perimeters;
+	            bool is_cross_region_bridge = std::any_of((*layerm)->slices.surfaces.begin(), (*layerm)->slices.surfaces.end(),
+	                [](const Surface &s) { return s.surface_type == stBottomBridge; });
+	            if (!is_cross_region_bridge && !cross_region_bridge_areas.empty()) {
+	                // Fill bridge holes in this region's slices so make_perimeters
+	                // won't generate inner perimeter walls around them.
+	                ExPolygons bridge_outer_only;
+	                for (const ExPolygon &b : cross_region_bridge_areas)
+	                    bridge_outer_only.emplace_back(b.contour);
+	                ExPolygons filled = union_ex(to_expolygons((*layerm)->slices.surfaces), bridge_outer_only);
+	                for (ExPolygon &ex : filled)
+	                    slices_for_perimeters.surfaces.emplace_back(stInternal, std::move(ex));
+	            } else {
+	                slices_for_perimeters = (*layerm)->slices;
+	            }
+
+                (*layerm)->make_perimeters(slices_for_perimeters, {*layerm}, &(*layerm)->fill_surfaces, &(*layerm)->fill_no_overlap_expolygons);
+
+	            // After make_perimeters, remove bridge areas from fill_surfaces
+	            if (!is_cross_region_bridge && !cross_region_bridge_areas.empty()) {
+	                Polygons bridge_polys = to_polygons(cross_region_bridge_areas);
+	                SurfaceCollection new_fill;
+	                for (const Surface &s : (*layerm)->fill_surfaces.surfaces) {
+	                    ExPolygons clipped = diff_ex(s.expolygon, bridge_polys);
+	                    for (ExPolygon &ex : clipped) {
+	                        Surface ns = s;
+	                        ns.expolygon = std::move(ex);
+	                        new_fill.surfaces.push_back(ns);
+	                    }
+	                }
+	                (*layerm)->fill_surfaces = std::move(new_fill);
+	            }
 	            (*layerm)->fill_expolygons = to_expolygons((*layerm)->fill_surfaces.surfaces);
+
+	            // ORCA: Fix for issue #11207 - expand fill_expolygons for cross-region bridges
+	            // fill_expolygons determines fill_boundaries which limits bridge expansion
+	            if (std::any_of((*layerm)->fill_surfaces.surfaces.begin(), (*layerm)->fill_surfaces.surfaces.end(),
+	                    [](const Surface &s) { return s.surface_type == stBottomBridge; })) {
+	                auto nozzle_diameter = (*layerm)->region().nozzle_dmr_avg(this->object()->print()->config());
+	                float anchor_expansion = std::min(float(scale_(BRIDGE_INFILL_MARGIN)),
+	                    float(scale_(nozzle_diameter * BRIDGE_INFILL_MARGIN / 0.4)));
+	                (*layerm)->fill_expolygons = offset_ex((*layerm)->fill_expolygons, anchor_expansion);
+	            }
 	        } else {
 	            SurfaceCollection new_slices;
 	            // Use the region with highest infill rate, as the make_perimeters() function below decides on the gap fill based on the infill existence.

--- a/src/libslic3r/LayerRegion.cpp
+++ b/src/libslic3r/LayerRegion.cpp
@@ -528,8 +528,42 @@ void LayerRegion::process_external_surfaces(const Layer *lower_layer, const Poly
     std::vector<ExpansionZone> expansion_zones{
         ExpansionZone{std::move(shells), expansion_params_into_solid_infill},
         ExpansionZone{std::move(sparse), expansion_params_into_sparse_infill},
-        ExpansionZone{std::move(top_expolygons), expansion_params_into_solid_infill},
     };
+
+    // ORCA: Fix for issue #11207 - add same-layer adjacent regions' surfaces to expansion zones
+    // for cross-region bridges (a region entirely unsupported by ANY material below).
+    if (std::any_of(this->fill_surfaces.surfaces.begin(), this->fill_surfaces.surfaces.end(),
+            [](const Surface &s) { return s.surface_type == stBottomBridge; })) {
+        const Layer *lower = this->layer()->lower_layer;
+        bool is_cross_region = false;
+        if (lower != nullptr) {
+            // Find our region index to check same-region area in the lower layer
+            size_t region_id = 0;
+            for (const LayerRegion *lr : this->layer()->regions()) {
+                if (lr == this) break;
+                region_id++;
+            }
+            if (region_id < lower->regions().size()) {
+                double current_area_val = area(to_expolygons(this->slices.surfaces));
+                double lower_same_area  = area(to_expolygons(lower->get_region(region_id)->slices.surfaces));
+                is_cross_region = current_area_val > 0 && lower_same_area < sqr(scale_(0.1));
+            }
+        }
+        if (is_cross_region) {
+            ExPolygons adjacent_surfaces;
+            for (const LayerRegion *other : this->layer()->regions()) {
+                if (other == this) continue;
+                for (const ExPolygon &ep : other->fill_expolygons)
+                    adjacent_surfaces.push_back(ep);
+            }
+            adjacent_surfaces = union_ex(adjacent_surfaces);
+            if (!adjacent_surfaces.empty())
+                expansion_zones.push_back(ExpansionZone{std::move(adjacent_surfaces), expansion_params_into_solid_infill});
+        }
+    }
+
+    // Add top surfaces zone LAST (will be popped at line 558)
+    expansion_zones.push_back(ExpansionZone{std::move(top_expolygons), expansion_params_into_solid_infill});
 
     SurfaceCollection bridges;
     {
@@ -754,8 +788,12 @@ void LayerRegion::process_external_surfaces(const Layer *lower_layer, const Poly
                 if (idx_island == -1) {
 				    BOOST_LOG_TRIVIAL(trace) << "Bridge did not fall into the source region!";
                 } else {
-                    // Found an island, to which this bridge region belongs. Trim it,
-                    polys = intersection(polys, fill_boundaries_ex[idx_island]);
+                    // ORCA: Fix for issue #11207 - don't trim cross-region bridges to current region
+                    // Cross-region bridges (stBottomBridge) need to extend into adjacent region for anchoring
+                    if (bridges[i].surface_type != stBottomBridge) {
+                        // Found an island, to which this bridge region belongs. Trim it,
+                        polys = intersection(polys, fill_boundaries_ex[idx_island]);
+                    }
                 }
                 bridge_bboxes.push_back(get_extents(polys));
                 bridges_grown.push_back(std::move(polys));
@@ -896,11 +934,18 @@ void LayerRegion::process_external_surfaces(const Layer *lower_layer, const Poly
             if (s1.is_top())
                 // Trim the top surfaces by the bottom surfaces. This gives the priority to the bottom surfaces.
                 polys = diff(polys, bottom_polygons);
-            surfaces_append(
-                new_surfaces,
-                // Don't use a safety offset as fill_boundaries were already united using the safety offset.
-                intersection_ex(polys, fill_boundaries),
-                s1);
+
+            // ORCA: Fix for issue #11207 - don't clip cross-region bridges to fill_boundaries
+            // Cross-region bridges need to extend beyond current region to anchor on lower layer
+            ExPolygons final_polys;
+            if (s1.surface_type == stBottomBridge) {
+                // Cross-region bridge - don't clip, keep full expanded area
+                final_polys = to_expolygons(polys);
+            } else {
+                // Normal surface - clip to fill_boundaries
+                final_polys = intersection_ex(polys, fill_boundaries);
+            }
+            surfaces_append(new_surfaces, std::move(final_polys), s1);
         }
     }
     
@@ -955,7 +1000,9 @@ void LayerRegion::prepare_fill_surfaces()
     }
     if (this->region().config().bottom_shell_layers == 0) {
         for (Surface &surface : this->fill_surfaces.surfaces)
-            if (surface.is_bottom()) // (surface.surface_type == stBottom)
+            // ORCA: Fix for issue #11207 - preserve stBottomBridge even when bottom_shell_layers=0
+            // Cross-region bridges need to stay as bridges for proper anchoring
+            if (surface.surface_type == stBottom)  // Only convert stBottom, not stBottomBridge
                 surface.surface_type = stInternal;
     }
 

--- a/src/libslic3r/LayerRegion.cpp
+++ b/src/libslic3r/LayerRegion.cpp
@@ -590,6 +590,20 @@ void LayerRegion::process_external_surfaces(const Layer *lower_layer, const Poly
             }
         }
         BOOST_LOG_TRIVIAL(trace) << "Processing external surface, detecting bridges - done";
+        // Clip bridge surfaces to the model boundary to prevent void extension
+        // from the closing_ex operation in merge_bridges/expand_merge_surfaces.
+        // Only cross-region (MMU) bridges can grow past the model outline, so leave
+        // single-region prints untouched: clipping ordinary bridges to lslices eats
+        // their legitimate anchor area.
+        if (this->layer()->object()->num_printing_regions() > 1) {
+            Surfaces clipped;
+            for (const Surface &s : bridges.surfaces) {
+                ExPolygons trimmed = intersection_ex(ExPolygons{s.expolygon}, this->layer()->lslices);
+                for (ExPolygon &ep : trimmed)
+                    clipped.emplace_back(s, std::move(ep));
+            }
+            bridges.surfaces = std::move(clipped);
+        }
 #ifdef SLIC3R_DEBUG_SLICE_PROCESSING
         {
             static int iRun = 0;

--- a/src/libslic3r/PerimeterGenerator.cpp
+++ b/src/libslic3r/PerimeterGenerator.cpp
@@ -1388,6 +1388,8 @@ void PerimeterGenerator::process_classic()
     // extra perimeters for each one
     Surfaces all_surfaces = this->slices->surfaces;
 
+    bypass_cross_region_bridges(all_surfaces);
+
     process_no_bridge(all_surfaces, perimeter_spacing, ext_perimeter_width);
     // BBS: don't simplify too much which influence arc fitting when export gcode if arc_fitting is enabled
     double surface_simplify_resolution = (print_config->enable_arc_fitting && !this->has_fuzzy_skin) ? 0.2 * m_scaled_resolution : m_scaled_resolution;
@@ -1975,6 +1977,25 @@ void PerimeterGenerator::add_infill_contour_for_arachne( ExPolygons        infil
     append(*this->fill_no_overlap, offset2_ex(union_ex(inner_pp), float(-min_perimeter_infill_spacing / 2.), float(+min_perimeter_infill_spacing / 2.)));
 }
 
+// ORCA: Fix for issue #11207 - handle cross-region bridges
+// Skip perimeter generation for stBottomBridge surfaces, output directly to fill_surfaces
+// with expansion for anchor space (~1 external perimeter width).
+void PerimeterGenerator::bypass_cross_region_bridges(Surfaces &all_surfaces)
+{
+    Surfaces surfaces_to_process;
+    for (const Surface &surface : all_surfaces) {
+        if (surface.surface_type == stBottomBridge) {
+            float anchor_expansion = this->ext_perimeter_flow.scaled_width();
+            ExPolygons expanded = offset_ex(surface.expolygon, anchor_expansion);
+            for (ExPolygon &ex : expanded)
+                this->fill_surfaces->surfaces.emplace_back(surface, std::move(ex));
+        } else {
+            surfaces_to_process.push_back(surface);
+        }
+    }
+    all_surfaces = std::move(surfaces_to_process);
+}
+
 // Orca: sacrificial bridge layer algorithm ported from SuperSlicer
 void PerimeterGenerator::process_no_bridge(Surfaces& all_surfaces, coord_t perimeter_spacing, coord_t ext_perimeter_width)
 {
@@ -2375,6 +2396,8 @@ void PerimeterGenerator::process_arachne()
     }
 
     Surfaces all_surfaces = this->slices->surfaces;
+
+    bypass_cross_region_bridges(all_surfaces);
 
     process_no_bridge(all_surfaces, perimeter_spacing, ext_perimeter_width);
     // BBS: don't simplify too much which influence arc fitting when export gcode if arc_fitting is enabled

--- a/src/libslic3r/PerimeterGenerator.hpp
+++ b/src/libslic3r/PerimeterGenerator.hpp
@@ -155,6 +155,7 @@ private:
     void split_top_surfaces(const ExPolygons &orig_polygons, ExPolygons &top_fills, ExPolygons &non_top_polygons, ExPolygons &fill_clip) const;
     void apply_extra_perimeters(ExPolygons& infill_area);
     void process_no_bridge(Surfaces& all_surfaces, coord_t perimeter_spacing, coord_t ext_perimeter_width);
+    void bypass_cross_region_bridges(Surfaces &all_surfaces);
 
 private:
     bool        m_spiral_vase;

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -1953,7 +1953,11 @@ void PrintObject::detect_surfaces_type()
             // Phase 2: write pass — each iteration mutates only m_layers[i+1]->slices.surfaces
             // and reads its bridge polygons from the precomputed cache. Different iterations
             // never share a write target, so there is no aliasing between worker threads.
-            tbb::parallel_for( tbb::blocked_range<size_t>(0, last), [this, region_id, &bridge_polys_per_layer](const tbb::blocked_range<size_t> &range) {
+            //
+            // Record the (layer, region) pairs the cross-region fallback reclassifies, so only
+            // those get re-clipped later, not every layer of every other region.
+            tbb::concurrent_vector<std::pair<size_t, size_t>> cross_region_dirty;
+            tbb::parallel_for( tbb::blocked_range<size_t>(0, last), [this, region_id, &bridge_polys_per_layer, &cross_region_dirty](const tbb::blocked_range<size_t> &range) {
                 for (size_t i = range.begin(); i < range.end(); ++i) {
                     m_print->throw_if_canceled();
 
@@ -1983,6 +1987,12 @@ void PrintObject::detect_surfaces_type()
                     // Also applies the same-layer-top guard (see ORCA comment inside the lambda)
                     // to avoid spurious second bridge layers on top surfaces.
                     auto apply_extra_bridge = [&](Surfaces &target_surfs) -> bool {
+                        // No stInternal here: return before touching target_surfs so the
+                        // cross-region fallback still sees the original surfaces.
+                        if (std::none_of(target_surfs.begin(), target_surfs.end(),
+                                         [](const Surface &s) { return s.surface_type == stInternal; }))
+                            return false;
+
                         // ORCA: Same-layer-top guard.
                         //
                         // Collect every stTop polygon present in this target region and expand
@@ -2016,7 +2026,6 @@ void PrintObject::detect_surfaces_type()
                                 same_layer_top_expanded = offset_ex(same_layer_top, offset_distance);
                         }
 
-                        bool found_internal = false;
                         Surfaces new_surfaces;
                         new_surfaces.reserve(target_surfs.size());
                         for (Surface &s_up : target_surfs) {
@@ -2024,7 +2033,6 @@ void PrintObject::detect_surfaces_type()
                                 new_surfaces.push_back(std::move(s_up));
                                 continue;
                             }
-                            found_internal = true;
                             Polygons p_up = to_polygons(s_up);
                             ExPolygons overlap = intersection_ex(p_up, polygons_bridge, ApplySafetyOffset::Yes);
                             overlap = offset_ex(shrink_ex(overlap, offset_distance), offset_distance);
@@ -2042,9 +2050,8 @@ void PrintObject::detect_surfaces_type()
                             for (auto &ex_overlap : unified_overlap)
                                 new_surfaces.emplace_back(stInternalAfterExternalBridge, ex_overlap);
                         }
-                        if (found_internal)
-                            target_surfs = std::move(new_surfaces);
-                        return found_internal;
+                        target_surfs = std::move(new_surfaces);
+                        return true;
                     };
 
                     // Try same region first (the common single-material case).
@@ -2057,8 +2064,10 @@ void PrintObject::detect_surfaces_type()
                             if (other_id == region_id)
                                 continue;
                             Surfaces &other_top = m_layers[i + 1]->m_regions[other_id]->slices.surfaces;
-                            if (apply_extra_bridge(other_top))
+                            if (apply_extra_bridge(other_top)) {
+                                cross_region_dirty.emplace_back(i + 1, other_id);
                                 break;
+                            }
                         }
                     }
                 }
@@ -2082,17 +2091,17 @@ void PrintObject::detect_surfaces_type()
                 }
               );
             }
-            // Cross-region modifications may have changed other regions' slices.surfaces
-            // after their slices_to_fill_surfaces_clipped() already ran. Re-clip those
-            // regions so fill_surfaces reflects the new stBottomBridge surfaces.
-            if (this->num_printing_regions() > 1) {
+            // The cross-region fallback changed other regions after their fill_surfaces were
+            // already clipped. Re-clip just the touched (layer, region) pairs; each is distinct,
+            // so running them in parallel is race-free.
+            if (!cross_region_dirty.empty()) {
                 tbb::parallel_for(
-                    tbb::blocked_range<size_t>(0, m_layers.size()),
-                    [this, region_id](const tbb::blocked_range<size_t> &range) {
-                        for (size_t idx = range.begin(); idx < range.end(); ++idx)
-                            for (size_t rid = 0; rid < m_layers[idx]->region_count(); ++rid)
-                                if (rid != region_id)
-                                    m_layers[idx]->m_regions[rid]->slices_to_fill_surfaces_clipped();
+                    tbb::blocked_range<size_t>(0, cross_region_dirty.size()),
+                    [this, &cross_region_dirty](const tbb::blocked_range<size_t> &range) {
+                        for (size_t k = range.begin(); k < range.end(); ++k)
+                            m_layers[cross_region_dirty[k].first]
+                                ->m_regions[cross_region_dirty[k].second]
+                                ->slices_to_fill_surfaces_clipped();
                     }
                 );
             }

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -1964,12 +1964,8 @@ void PrintObject::detect_surfaces_type()
                     // No bridge polygons found, continue to the next layer
                     if (polygons_bridge.empty())
                         continue;
-                    
+
                     // Step 4: Bottom bridge polygons found - scan and create layer+1 bridge polygon
-                    Surfaces &top_surfs = m_layers[i + 1]->m_regions[region_id]->slices.surfaces;
-                    Surfaces new_surfaces;
-                    new_surfaces.reserve(top_surfs.size());
-                    
                     //filtering parameters here. Filter bridges that are less than 2x external walls and 2xN internal perimeters wide.
                     LayerRegion *layerm = m_layers[i]->m_regions[region_id];
                     int number_of_internal_walls = std::max(0, layerm->m_region->config().wall_loops - 1); // number of internal walls, clamped to a minimum of 0 as a safety precaution
@@ -1981,87 +1977,90 @@ void PrintObject::detect_surfaces_type()
                     // We could reduce this slightly to account for innacurcies in the clipping operation.
                     // TODO: Monitor GitHub issues to check whether second bridge layers are ommited where they should be generated. If yes, reduce the filtering distance
 
-                    // ORCA: Same-layer-top guard.
-                    //
-                    // Collect every stTop polygon present at layer i+1 (this region) and
-                    // expand it by the same `offset_distance` used by the bridge filter
-                    // above. Note that `offset_distance` here is the full wall-band
-                    // distance for the region (external wall width + all configured
-                    // internal wall widths, i.e. external + (wall_loops - 1) × internal),
-                    // not a single perimeter width. Any candidate second-bridge area that
-                    // falls under this expanded mask will be subtracted out below.
-                    //
-                    // Why this exists: detect_surfaces_type() classifies a layer's "top"
-                    // surfaces as the geometry that is not covered by the layer above. Those
-                    // stTop regions often have small stInternal islands embedded in them.
-                    // The pre-existing wall-band filter (shrink_ex/offset_ex by
-                    // offset_distance) is supposed to throw those tiny islands away, but
-                    // its result is sensitive to Clipper's floating-point order of
-                    // operations: on macOS ARM the filter eats them, on Windows/Intel it
-                    // doesn't. Visible bridges then show up scattered across the printed
-                    // top surface.
-                    //
-                    // Expanding stTop by offset_distance and subtracting it from the
-                    // overlap makes the decision platform-independent: an island fully
-                    // surrounded by stTop disappears regardless of which Clipper happens
-                    // to be doing the math, while large stInternal regions away from the
-                    // top survive intact (the expansion only nibbles the wall-band depth
-                    // inward).
-                    //
-                    // Keep ExPolygons throughout so that any holes inside an stTop surface
-                    // are offset with the correct sign (positive offset shrinks holes /
-                    // grows the solid region). Using Polygons + expand() would treat the
-                    // contour and each hole as independent polygons and could distort the
-                    // mask.
-                    ExPolygons same_layer_top_expanded;
-                    {
-                        ExPolygons same_layer_top;
-                        for (const Surface &s : top_surfs) {
-                            if (s.surface_type == stTop)
-                                same_layer_top.push_back(s.expolygon);
+                    // Lambda: apply extra bridge layer reclassification to target surfaces.
+                    // Finds stInternal surfaces overlapping the bridge polygons and reclassifies
+                    // the overlapping portion as stInternalAfterExternalBridge.
+                    // Also applies the same-layer-top guard (see ORCA comment inside the lambda)
+                    // to avoid spurious second bridge layers on top surfaces.
+                    auto apply_extra_bridge = [&](Surfaces &target_surfs) -> bool {
+                        // ORCA: Same-layer-top guard.
+                        //
+                        // Collect every stTop polygon present in this target region and expand
+                        // it by the same `offset_distance` used by the bridge filter above.
+                        // Any candidate second-bridge area that falls under this expanded mask
+                        // will be subtracted out below, making the decision platform-independent.
+                        //
+                        // Why this exists: detect_surfaces_type() classifies a layer's "top"
+                        // surfaces as the geometry that is not covered by the layer above. Those
+                        // stTop regions often have small stInternal islands embedded in them.
+                        // The pre-existing wall-band filter (shrink_ex/offset_ex by
+                        // offset_distance) is supposed to throw those tiny islands away, but
+                        // its result is sensitive to Clipper's floating-point order of
+                        // operations: on macOS ARM the filter eats them, on Windows/Intel it
+                        // doesn't. Visible bridges then show up scattered across the printed
+                        // top surface.
+                        //
+                        // Keep ExPolygons throughout so that any holes inside an stTop surface
+                        // are offset with the correct sign (positive offset shrinks holes /
+                        // grows the solid region). Using Polygons + expand() would treat the
+                        // contour and each hole as independent polygons and could distort the
+                        // mask.
+                        ExPolygons same_layer_top_expanded;
+                        {
+                            ExPolygons same_layer_top;
+                            for (const Surface &s : target_surfs) {
+                                if (s.surface_type == stTop)
+                                    same_layer_top.push_back(s.expolygon);
+                            }
+                            if (!same_layer_top.empty())
+                                same_layer_top_expanded = offset_ex(same_layer_top, offset_distance);
                         }
-                        if (! same_layer_top.empty())
-                            same_layer_top_expanded = offset_ex(same_layer_top, offset_distance);
+
+                        bool found_internal = false;
+                        Surfaces new_surfaces;
+                        new_surfaces.reserve(target_surfs.size());
+                        for (Surface &s_up : target_surfs) {
+                            if (s_up.surface_type != stInternal) {
+                                new_surfaces.push_back(std::move(s_up));
+                                continue;
+                            }
+                            found_internal = true;
+                            Polygons p_up = to_polygons(s_up);
+                            ExPolygons overlap = intersection_ex(p_up, polygons_bridge, ApplySafetyOffset::Yes);
+                            overlap = offset_ex(shrink_ex(overlap, offset_distance), offset_distance);
+
+                            // ORCA: subtract the expanded same-layer stTop mask. Drops stInternal
+                            // islands fully surrounded by stTop without affecting real bridges.
+                            if (!same_layer_top_expanded.empty() && !overlap.empty())
+                                overlap = diff_ex(overlap, same_layer_top_expanded, ApplySafetyOffset::Yes);
+
+                            ExPolygons remainder = diff_ex(p_up, overlap, ApplySafetyOffset::Yes);
+                            ExPolygons unified_remainder = union_safety_offset_ex(remainder);
+                            for (auto &ex_remainder : unified_remainder)
+                                new_surfaces.emplace_back(stInternal, ex_remainder);
+                            ExPolygons unified_overlap = union_safety_offset_ex(overlap);
+                            for (auto &ex_overlap : unified_overlap)
+                                new_surfaces.emplace_back(stInternalAfterExternalBridge, ex_overlap);
+                        }
+                        if (found_internal)
+                            target_surfs = std::move(new_surfaces);
+                        return found_internal;
+                    };
+
+                    // Try same region first (the common single-material case).
+                    Surfaces &top_surfs = m_layers[i + 1]->m_regions[region_id]->slices.surfaces;
+                    if (!apply_extra_bridge(top_surfs) && this->num_printing_regions() > 1) {
+                        // Cross-region fallback: for face-painted MMU bridges the painted
+                        // region only exists at the bridge layer; layer i+1 has the geometry
+                        // in a different region. Search other regions at layer i+1.
+                        for (size_t other_id = 0; other_id < m_layers[i + 1]->region_count(); ++other_id) {
+                            if (other_id == region_id)
+                                continue;
+                            Surfaces &other_top = m_layers[i + 1]->m_regions[other_id]->slices.surfaces;
+                            if (apply_extra_bridge(other_top))
+                                break;
+                        }
                     }
-
-                    // For each surface in the layer above
-                    for (Surface &s_up : top_surfs) {
-                        // Only reclassify stInternal polygons (i.e. what will become later solid and sparse infill)
-                        // Leave the rest unaffected
-                        if (s_up.surface_type != stInternal) {
-                            new_surfaces.push_back(std::move(s_up)); // do not modify them
-                            continue; // continue to the next surface
-                        }
-                        // Identify stInternal polygons that overlap with the bridging polygons on the layer underneath.
-                        Polygons p_up = to_polygons(s_up);
-                        ExPolygons overlap   = intersection_ex(p_up, polygons_bridge , ApplySafetyOffset::Yes);
-                        // Filter out the resulting candidate bridges based on size. First perform a shrink operation...
-                        // ...followed by an expand operation to bring them back to the original size (positive offset)
-                        overlap = offset_ex(shrink_ex(overlap, offset_distance), offset_distance);
-
-                        // ORCA: subtract the expanded same-layer stTop mask (see comment above
-                        // the mask construction). Drops stInternal islands fully surrounded by
-                        // stTop at i+1 without affecting bridges that lie away from the top.
-                        if (! same_layer_top_expanded.empty() && ! overlap.empty())
-                            overlap = diff_ex(overlap, same_layer_top_expanded, ApplySafetyOffset::Yes);
-
-                        // Now subtract the filtered new bridge layer from the remaining internal surfaces to create the new internal surface
-                        ExPolygons remainder = diff_ex(p_up, overlap, ApplySafetyOffset::Yes);
-                        
-                        // Remainder stays as stInternal
-                        ExPolygons unified_remainder = union_safety_offset_ex(remainder);
-                        for (auto &ex_remainder : unified_remainder) {
-                            Surface s(stInternal, ex_remainder);
-                            new_surfaces.push_back(std::move(s));
-                        }
-                        // Overlap portion becomes the new polygon type - stInternalAfterExternalBridge
-                        ExPolygons unified_overlap = union_safety_offset_ex(overlap);
-                        for (auto &ex_overlap : unified_overlap) {
-                            Surface s(stInternalAfterExternalBridge, ex_overlap);
-                            new_surfaces.push_back(std::move(s));
-                        }
-                    }
-                    top_surfs = std::move(new_surfaces);
                 }
             }
             );
@@ -2082,6 +2081,20 @@ void PrintObject::detect_surfaces_type()
                     }
                 }
               );
+            }
+            // Cross-region modifications may have changed other regions' slices.surfaces
+            // after their slices_to_fill_surfaces_clipped() already ran. Re-clip those
+            // regions so fill_surfaces reflects the new stBottomBridge surfaces.
+            if (this->num_printing_regions() > 1) {
+                tbb::parallel_for(
+                    tbb::blocked_range<size_t>(0, m_layers.size()),
+                    [this, region_id](const tbb::blocked_range<size_t> &range) {
+                        for (size_t idx = range.begin(); idx < range.end(); ++idx)
+                            for (size_t rid = 0; rid < m_layers[idx]->region_count(); ++rid)
+                                if (rid != region_id)
+                                    m_layers[idx]->m_regions[rid]->slices_to_fill_surfaces_clipped();
+                    }
+                );
             }
         }
         // ==============================================================================================================

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -1671,6 +1671,17 @@ void PrintObject::detect_surfaces_type()
                     // BOOST_LOG_TRIVIAL(trace) << "Detecting solid surfaces for region " << region_id << " and layer " << layer->print_z;
                     Layer       *layer  = m_layers[idx_layer];
                     LayerRegion *layerm = layer->m_regions[region_id];
+
+                    // ORCA: Fix for issue #11207 - preserve cross-region bridges from make_perimeters
+                    Surfaces preserved_bridges;
+                    if (this->num_printing_regions() > 1) {
+                        for (const Surface &s : layerm->fill_surfaces.surfaces) {
+                            if (s.surface_type == stBottomBridge) {
+                                preserved_bridges.push_back(s);
+                            }
+                        }
+                    }
+
                     // comparison happens against the *full* slices (considering all regions)
                     // unless internal shells are requested
                     Layer       *upper_layer = (idx_layer + 1 < this->layer_count()) ? m_layers[idx_layer + 1] : nullptr;
@@ -1729,7 +1740,7 @@ void PrintObject::detect_surfaces_type()
                                 opening_ex(
                                     diff_ex(
                                         intersection(layerm_slices_surfaces, lower_layer->lslices), // supported
-                                        lower_layer->m_regions[region_id]->slices.surfaces,
+                                        to_expolygons(lower_layer->m_regions[region_id]->slices.surfaces),
                                         ApplySafetyOffset::Yes),
                                     offset),
                                 stBottom);
@@ -1870,6 +1881,18 @@ void PrintObject::detect_surfaces_type()
 
                     surfaces_append(surfaces_out, std::move(top));
                     surfaces_append(surfaces_out, std::move(bottom));
+
+                    // ORCA: Fix for issue #11207 - restore cross-region bridges that were marked in make_perimeters
+                    if (!preserved_bridges.empty()) {
+                        // Remove any overlapping bottom surfaces and replace with our preserved bridges
+                        Surfaces surfaces_without_bottom;
+                        for (const Surface &s : surfaces_out) {
+                            if (s.surface_type != stBottom && s.surface_type != stBottomBridge)
+                                surfaces_without_bottom.push_back(s);
+                        }
+                        surfaces_out = std::move(surfaces_without_bottom);
+                        surfaces_append(surfaces_out, std::move(preserved_bridges));
+                    }
 
         //            Slic3r::debugf "  layer %d has %d bottom, %d top and %d internal surfaces\n",
         //                $layerm->layer->id, scalar(@bottom), scalar(@top), scalar(@internal) if $Slic3r::debug;

--- a/tests/fff_print/CMakeLists.txt
+++ b/tests/fff_print/CMakeLists.txt
@@ -10,6 +10,7 @@ add_executable(${_TEST_NAME}_tests
 	test_flow.cpp
 	test_gcode_timing.cpp
 	test_gcodewriter.cpp
+	test_mmu_bridge.cpp
 	test_model.cpp
 	test_multifilament.cpp
 	test_perimeters.cpp

--- a/tests/fff_print/test_mmu_bridge.cpp
+++ b/tests/fff_print/test_mmu_bridge.cpp
@@ -60,6 +60,20 @@ static int count_surface_type(const PrintObject &obj, SurfaceType type)
     return count;
 }
 
+// Helper: verify bridge surfaces do not extend into void at the given layer.
+static void check_bridge_within_model(const Layer *bridge_layer)
+{
+    for (const LayerRegion *lr : bridge_layer->regions()) {
+        for (const Surface &s : lr->fill_surfaces.surfaces) {
+            if (s.surface_type != stBottomBridge)
+                continue;
+            ExPolygons void_overflow = diff_ex(ExPolygons{s.expolygon}, bridge_layer->lslices);
+            double overflow_mm2 = std::abs(unscale<double>(unscale<double>(area(void_overflow))));
+            CHECK(overflow_mm2 < 0.1);
+        }
+    }
+}
+
 // ============================================================================
 // Test 1: A painted region spanning a gap (true bridge) should be stBottomBridge
 // ============================================================================
@@ -100,8 +114,10 @@ TEST_CASE("MMU cross-region bridge over void is stBottomBridge", "[MMUBridge]") 
             for (const Surface &s : lr->fill_surfaces.surfaces)
                 if (s.surface_type == stBottomBridge)
                     layer_has_bridge = true;
-        if (layer_has_bridge)
+        if (layer_has_bridge) {
             bridge_layer_count++;
+            check_bridge_within_model(layer);
+        }
     }
     REQUIRE(bridge_layer_count == 1);
 }
@@ -174,8 +190,10 @@ TEST_CASE("MMU bridge preserved with bottom_shell_layers=0", "[MMUBridge]") {
             for (const Surface &s : lr->fill_surfaces.surfaces)
                 if (s.surface_type == stBottomBridge)
                     layer_has_bridge = true;
-        if (layer_has_bridge)
+        if (layer_has_bridge) {
             bridge_layer_count++;
+            check_bridge_within_model(layer);
+        }
     }
     REQUIRE(bridge_layer_count == 1);
 }
@@ -226,6 +244,7 @@ TEST_CASE("MMU bridge fill covers the gap area", "[MMUBridge]") {
         }
     }
     REQUIRE(bridge_layer != nullptr);
+    check_bridge_within_model(bridge_layer);
 
     // At the bridge layer, check bridge fill covers the gap.
     // Note: ensure_on_bed() centers the object. With y spanning 0..50, the center
@@ -301,7 +320,8 @@ TEST_CASE("Normal single-material bridge still works", "[MMUBridge]") {
 // Two pillars (20x20x6) at y=0..20 and y=30..50 with a 10mm gap, merged with a
 // slab (20x50x1) at z=6..7. Only bottom face triangles of the slab are painted as
 // extruder 2. Caller owns Print and Model (must outlive returned reference).
-static const PrintObject &init_face_painted_bridge_print(Print &print, Model &model)
+static const PrintObject &init_face_painted_bridge_print(Print &print, Model &model,
+    const DynamicPrintConfig &extra_overrides = DynamicPrintConfig())
 {
     TriangleMesh pillars = make_cube(20, 20, 6);
     TriangleMesh pillar2 = make_cube(20, 20, 6);
@@ -347,6 +367,7 @@ static const PrintObject &init_face_painted_bridge_print(Print &print, Model &mo
         { "bottom_shell_layers",    "1" },
         { "top_shell_layers",       "1" },
     });
+    config.apply(extra_overrides);
 
     ModelObject *object = model.add_object();
     object->name = "painted_bridge";
@@ -408,8 +429,10 @@ TEST_CASE("MMU face-painted bridge full pipeline", "[MMUBridge]") {
                         found_overhang_perimeter = true;
             }
         }
-        if (layer_has_bridge)
+        if (layer_has_bridge) {
             bridge_layer_count++;
+            check_bridge_within_model(layer);
+        }
     }
     REQUIRE(bridge_layer_count == 1);
     // With the fix, the gap region gets bridge fills - no overhang perimeters.
@@ -446,17 +469,7 @@ TEST_CASE("MMU face-painted bridge does not extend into void", "[MMUBridge]") {
         }
     }
     REQUIRE(bridge_layer != nullptr);
-
-    // Bridge surfaces must not extend beyond the model boundary (void).
-    for (const LayerRegion *lr : bridge_layer->regions()) {
-        for (const Surface &s : lr->fill_surfaces.surfaces) {
-            if (s.surface_type != stBottomBridge)
-                continue;
-            ExPolygons void_overflow = diff_ex(ExPolygons{s.expolygon}, bridge_layer->lslices);
-            double overflow_mm2 = std::abs(unscale<double>(unscale<double>(area(void_overflow))));
-            CHECK(overflow_mm2 < 0.1);  // less than 0.1mm² overflow into void
-        }
-    }
+    check_bridge_within_model(bridge_layer);
 
     // Bridge extrusion paths must stay within the model boundary.
     BoundingBox model_bb = get_extents(bridge_layer->lslices);
@@ -471,5 +484,94 @@ TEST_CASE("MMU face-painted bridge does not extend into void", "[MMUBridge]") {
             CHECK(extr_bb.max.y() <= model_bb.max.y());
         }
     }
+}
+
+// ============================================================================
+// Test 8: Two-volume bridge with enable_extra_bridge_layer = "apply_to_all"
+// ============================================================================
+TEST_CASE("MMU two-volume bridge with extra bridge layer", "[MMUBridge]") {
+    // Same geometry as Test 1 (pillars + slab, separate volumes).
+    // With enable_extra_bridge_layer, the bridge should span TWO layers.
+    TriangleMesh pillar1 = make_cube(20, 20, 6);
+    TriangleMesh pillar2 = make_cube(20, 20, 6);
+    pillar2.translate(0, 30, 0);
+    pillar1.merge(pillar2);
+
+    TriangleMesh slab = make_cube(20, 50, 1);
+    slab.translate(0, 0, 6);
+
+    Print print;
+    Model model;
+    DynamicPrintConfig overrides;
+    overrides.set_deserialize_strict({
+        { "layer_height",             "0.3" },
+        { "first_layer_height",       "0.3" },
+        { "bottom_shell_layers",      "1" },
+        { "top_shell_layers",         "1" },
+        { "enable_extra_bridge_layer", "apply_to_all" },
+    });
+    init_mmu_print(std::move(pillar1), std::move(slab), print, model, overrides);
+    print.process();
+
+    const PrintObject &obj = *print.objects().front();
+    REQUIRE(obj.num_printing_regions() > 1);
+
+    // Count layers with stBottomBridge surfaces — should be exactly 2.
+    int bridge_layer_count = 0;
+    std::vector<const Layer *> bridge_layers;
+    for (const Layer *layer : obj.layers()) {
+        bool layer_has_bridge = false;
+        for (const LayerRegion *lr : layer->regions())
+            for (const Surface &s : lr->fill_surfaces.surfaces)
+                if (s.surface_type == stBottomBridge)
+                    layer_has_bridge = true;
+        if (layer_has_bridge) {
+            bridge_layer_count++;
+            bridge_layers.push_back(layer);
+        }
+    }
+    REQUIRE(bridge_layer_count == 2);
+
+    // Both bridge layers must not extend into void.
+    for (const Layer *bl : bridge_layers)
+        check_bridge_within_model(bl);
+}
+
+// ============================================================================
+// Test 9: Face-painted bridge with enable_extra_bridge_layer = "apply_to_all"
+// ============================================================================
+TEST_CASE("MMU face-painted bridge with extra bridge layer", "[MMUBridge]") {
+    // Same face-painted geometry as Test 6, but with extra bridge layer enabled.
+    // The painted region only exists at the bridge layer; at layer i+1 the geometry
+    // is in a different region. The cross-region fallback must find and reclassify
+    // the stInternal surface in the other region.
+    Print print;
+    Model model;
+    DynamicPrintConfig extra;
+    extra.set_deserialize_strict({
+        { "enable_extra_bridge_layer", "apply_to_all" },
+    });
+    const PrintObject &obj = init_face_painted_bridge_print(print, model, extra);
+    REQUIRE(obj.num_printing_regions() > 1);
+
+    // Count layers with stBottomBridge — should be exactly 2.
+    int bridge_layer_count = 0;
+    std::vector<const Layer *> bridge_layers;
+    for (const Layer *layer : obj.layers()) {
+        bool layer_has_bridge = false;
+        for (const LayerRegion *lr : layer->regions())
+            for (const Surface &s : lr->fill_surfaces.surfaces)
+                if (s.surface_type == stBottomBridge)
+                    layer_has_bridge = true;
+        if (layer_has_bridge) {
+            bridge_layer_count++;
+            bridge_layers.push_back(layer);
+        }
+    }
+    REQUIRE(bridge_layer_count == 2);
+
+    // Both bridge layers must not extend into void.
+    for (const Layer *bl : bridge_layers)
+        check_bridge_within_model(bl);
 }
 

--- a/tests/fff_print/test_mmu_bridge.cpp
+++ b/tests/fff_print/test_mmu_bridge.cpp
@@ -417,3 +417,59 @@ TEST_CASE("MMU face-painted bridge full pipeline", "[MMUBridge]") {
     CHECK_FALSE(found_overhang_perimeter);
 }
 
+// ============================================================================
+// Test 7: Face-painted bridge does not extend beyond model boundary (void)
+// ============================================================================
+TEST_CASE("MMU face-painted bridge does not extend into void", "[MMUBridge]") {
+    // Same face-painted pillars+slab geometry as Test 6.
+    // Bridge surfaces may expand anchors into supported pillar material - that is
+    // normal and acceptable.  What must NOT happen is extension beyond the model
+    // boundary (into void / outside the mesh entirely).
+    Print print;
+    Model model;
+    const PrintObject &obj = init_face_painted_bridge_print(print, model);
+    REQUIRE(obj.num_printing_regions() > 1);
+
+    // Find the bridge layer.
+    const Layer *bridge_layer = nullptr;
+    for (const Layer *layer : obj.layers()) {
+        if (bridge_layer)
+            break;
+        for (const LayerRegion *lr : layer->regions()) {
+            if (bridge_layer)
+                break;
+            for (const Surface &s : lr->fill_surfaces.surfaces)
+                if (s.surface_type == stBottomBridge) {
+                    bridge_layer = layer;
+                    break;
+                }
+        }
+    }
+    REQUIRE(bridge_layer != nullptr);
+
+    // Bridge surfaces must not extend beyond the model boundary (void).
+    for (const LayerRegion *lr : bridge_layer->regions()) {
+        for (const Surface &s : lr->fill_surfaces.surfaces) {
+            if (s.surface_type != stBottomBridge)
+                continue;
+            ExPolygons void_overflow = diff_ex(ExPolygons{s.expolygon}, bridge_layer->lslices);
+            double overflow_mm2 = std::abs(unscale<double>(unscale<double>(area(void_overflow))));
+            CHECK(overflow_mm2 < 0.1);  // less than 0.1mm² overflow into void
+        }
+    }
+
+    // Bridge extrusion paths must stay within the model boundary.
+    BoundingBox model_bb = get_extents(bridge_layer->lslices);
+    for (const LayerRegion *lr : bridge_layer->regions()) {
+        for (const ExtrusionEntity *ee : lr->fills.flatten().entities) {
+            if (ee->role() != erBridgeInfill)
+                continue;
+            BoundingBox extr_bb = get_extents(ee->as_polyline());
+            CHECK(extr_bb.min.x() >= model_bb.min.x());
+            CHECK(extr_bb.max.x() <= model_bb.max.x());
+            CHECK(extr_bb.min.y() >= model_bb.min.y());
+            CHECK(extr_bb.max.y() <= model_bb.max.y());
+        }
+    }
+}
+

--- a/tests/fff_print/test_mmu_bridge.cpp
+++ b/tests/fff_print/test_mmu_bridge.cpp
@@ -1,0 +1,419 @@
+#include <catch2/catch_all.hpp>
+
+#include "libslic3r/libslic3r.h"
+#include "libslic3r/Model.hpp"
+#include "libslic3r/Print.hpp"
+#include "libslic3r/Layer.hpp"
+#include "libslic3r/TriangleMesh.hpp"
+#include "libslic3r/PrintConfig.hpp"
+#include "libslic3r/Geometry.hpp"
+#include "libslic3r/ClipperUtils.hpp"
+#include "libslic3r/ExtrusionEntityCollection.hpp"
+
+#include "test_helpers.hpp"
+
+using namespace Slic3r;
+
+// Helper: Create a single ModelObject with two volumes on different extruders.
+// This simulates MMU color painting where different regions of one body are
+// assigned to different filaments.
+static void init_mmu_print(TriangleMesh &&mesh1, TriangleMesh &&mesh2,
+                           Print &print, Model &model,
+                           const DynamicPrintConfig &config_overrides)
+{
+    DynamicPrintConfig config = DynamicPrintConfig::full_print_config();
+    config.set_deserialize_strict({
+        { "filament_diameter", "1.75,1.75" },
+        { "line_width",        "0.45" },
+    });
+    config.apply(config_overrides);
+
+    ModelObject *object = model.add_object();
+    object->name = "mmu_test_object";
+
+    ModelVolume *v1 = object->add_volume(std::move(mesh1));
+    v1->name = "base_volume";
+    v1->config.set("extruder", 1);
+
+    ModelVolume *v2 = object->add_volume(std::move(mesh2));
+    v2->name = "bridge_volume";
+    v2->config.set("extruder", 2);
+
+    object->add_instance();
+    object->ensure_on_bed();
+
+    print.is_BBL_printer() = false;
+    print.apply(model, config);
+    print.validate();
+    print.set_status_silent();
+}
+
+// Count surfaces of a given type across all layers/regions.
+static int count_surface_type(const PrintObject &obj, SurfaceType type)
+{
+    int count = 0;
+    for (const Layer *layer : obj.layers())
+        for (const LayerRegion *lr : layer->regions())
+            for (const Surface &s : lr->fill_surfaces.surfaces)
+                if (s.surface_type == type)
+                    ++count;
+    return count;
+}
+
+// ============================================================================
+// Test 1: A painted region spanning a gap (true bridge) should be stBottomBridge
+// ============================================================================
+TEST_CASE("MMU cross-region bridge over void is stBottomBridge", "[MMUBridge]") {
+    // Geometry:
+    //   Two pillars (extruder 1): 20x20x6mm at y=0..20 and y=30..50
+    //   10mm gap at y=20..30
+    //   Slab (extruder 2): 20x50x1mm at z=6..7, spanning both pillars + gap
+    TriangleMesh pillar1 = make_cube(20, 20, 6);
+    TriangleMesh pillar2 = make_cube(20, 20, 6);
+    pillar2.translate(0, 30, 0);
+    pillar1.merge(pillar2);
+
+    TriangleMesh slab = make_cube(20, 50, 1);
+    slab.translate(0, 0, 6);
+
+    Print print;
+    Model model;
+    DynamicPrintConfig overrides;
+    overrides.set_deserialize_strict({
+        { "layer_height",       "0.3" },
+        { "first_layer_height", "0.3" },
+        { "bottom_shell_layers", "1" },
+        { "top_shell_layers",   "1" },
+    });
+    init_mmu_print(std::move(pillar1), std::move(slab), print, model, overrides);
+    print.process();
+
+    const PrintObject &obj = *print.objects().front();
+    REQUIRE(obj.num_printing_regions() > 1);
+
+    // Count layers that have stBottomBridge surfaces.
+    // Bridges should appear in exactly one layer (the first slab layer over the gap).
+    int bridge_layer_count = 0;
+    for (const Layer *layer : obj.layers()) {
+        bool layer_has_bridge = false;
+        for (const LayerRegion *lr : layer->regions())
+            for (const Surface &s : lr->fill_surfaces.surfaces)
+                if (s.surface_type == stBottomBridge)
+                    layer_has_bridge = true;
+        if (layer_has_bridge)
+            bridge_layer_count++;
+    }
+    REQUIRE(bridge_layer_count == 1);
+}
+
+// ============================================================================
+// Test 2: A painted region fully supported by different material is NOT stBottomBridge
+// ============================================================================
+TEST_CASE("MMU region on solid support is not stBottomBridge", "[MMUBridge]") {
+    // Geometry:
+    //   Base (extruder 1): 20x20x2mm
+    //   Small patch (extruder 2): 8x8x1mm sitting on top of base at z=2mm
+    // Patch is fully supported by base below -> NOT a bridge.
+    TriangleMesh base = make_cube(20, 20, 2);
+    TriangleMesh patch = make_cube(8, 8, 1);
+    patch.translate(6, 6, 2);
+
+    Print print;
+    Model model;
+    DynamicPrintConfig overrides;
+    overrides.set_deserialize_strict({
+        { "layer_height",       "0.3" },
+        { "first_layer_height", "0.3" },
+    });
+    init_mmu_print(std::move(base), std::move(patch), print, model, overrides);
+    print.process();
+
+    const PrintObject &obj = *print.objects().front();
+    REQUIRE(obj.num_printing_regions() > 1);
+
+    int bridge_count = count_surface_type(obj, stBottomBridge);
+    // There should be no cross-region bridges (patch is fully supported)
+    CHECK(bridge_count == 0);
+}
+
+// ============================================================================
+// Test 3: stBottomBridge survives when bottom_shell_layers=0
+// ============================================================================
+TEST_CASE("MMU bridge preserved with bottom_shell_layers=0", "[MMUBridge]") {
+    // Same bridge geometry as Test 1, but with bottom_shell_layers=0.
+    // The fix in prepare_fill_surfaces should preserve stBottomBridge (not convert to stInternal).
+    TriangleMesh pillar1 = make_cube(20, 20, 6);
+    TriangleMesh pillar2 = make_cube(20, 20, 6);
+    pillar2.translate(0, 30, 0);
+    pillar1.merge(pillar2);
+
+    TriangleMesh slab = make_cube(20, 50, 1);
+    slab.translate(0, 0, 6);
+
+    Print print;
+    Model model;
+    DynamicPrintConfig overrides;
+    overrides.set_deserialize_strict({
+        { "layer_height",        "0.3" },
+        { "first_layer_height",  "0.3" },
+        { "bottom_shell_layers", "0" },
+        { "top_shell_layers",    "1" },
+    });
+    init_mmu_print(std::move(pillar1), std::move(slab), print, model, overrides);
+    print.process();
+
+    const PrintObject &obj = *print.objects().front();
+    REQUIRE(obj.num_printing_regions() > 1);
+
+    // stBottomBridge should survive prepare_fill_surfaces even with bottom_shell_layers=0.
+    // Count layers with bridges - should be exactly one.
+    int bridge_layer_count = 0;
+    for (const Layer *layer : obj.layers()) {
+        bool layer_has_bridge = false;
+        for (const LayerRegion *lr : layer->regions())
+            for (const Surface &s : lr->fill_surfaces.surfaces)
+                if (s.surface_type == stBottomBridge)
+                    layer_has_bridge = true;
+        if (layer_has_bridge)
+            bridge_layer_count++;
+    }
+    REQUIRE(bridge_layer_count == 1);
+}
+
+// ============================================================================
+// Test 4: Bridge fill covers the gap
+// ============================================================================
+TEST_CASE("MMU bridge fill covers the gap area", "[MMUBridge]") {
+    // Same geometry as Test 1. Verify stBottomBridge surfaces at the bridge layer
+    // have their bounding box within the gap region (y~20..30) and area is
+    // approximately the gap area (20x10 = 200mm2).
+    TriangleMesh pillar1 = make_cube(20, 20, 6);
+    TriangleMesh pillar2 = make_cube(20, 20, 6);
+    pillar2.translate(0, 30, 0);
+    pillar1.merge(pillar2);
+
+    TriangleMesh slab = make_cube(20, 50, 1);
+    slab.translate(0, 0, 6);
+
+    Print print;
+    Model model;
+    DynamicPrintConfig overrides;
+    overrides.set_deserialize_strict({
+        { "layer_height",       "0.3" },
+        { "first_layer_height", "0.3" },
+        { "bottom_shell_layers", "1" },
+        { "top_shell_layers",   "1" },
+    });
+    init_mmu_print(std::move(pillar1), std::move(slab), print, model, overrides);
+    print.process();
+
+    const PrintObject &obj = *print.objects().front();
+    REQUIRE(obj.num_printing_regions() > 1);
+
+    // Find the bridge layer.
+    const Layer *bridge_layer = nullptr;
+    for (const Layer *layer : obj.layers()) {
+        if (bridge_layer)
+            break;
+        for (const LayerRegion *lr : layer->regions()) {
+            if (bridge_layer)
+                break;
+            for (const Surface &s : lr->fill_surfaces.surfaces)
+                if (s.surface_type == stBottomBridge) {
+                    bridge_layer = layer;
+                    break;
+                }
+        }
+    }
+    REQUIRE(bridge_layer != nullptr);
+
+    // At the bridge layer, check bridge fill covers the gap.
+    // Note: ensure_on_bed() centers the object. With y spanning 0..50, the center
+    // is at y=25, so the gap at y=20..30 becomes y=-5..5 in print coordinates.
+    bool found_gap_bridge = false;
+    for (const LayerRegion *lr : bridge_layer->regions()) {
+        for (const Surface &s : lr->fill_surfaces.surfaces) {
+            if (s.surface_type != stBottomBridge)
+                continue;
+            BoundingBox bb = get_extents(s.expolygon);
+            double area_mm2 = unscale<double>(unscale<double>(s.expolygon.area()));
+            // Bridge should be in the gap region (y=-5..5 after centering)
+            CHECK(unscale<double>(bb.min.y()) >= -6.0);
+            CHECK(unscale<double>(bb.max.y()) <= 6.0);
+            // Bridge area should be close to gap area (200mm2)
+            CHECK(area_mm2 > 100.0);  // at least half the gap
+            found_gap_bridge = true;
+        }
+    }
+    REQUIRE(found_gap_bridge);
+}
+
+// ============================================================================
+// Test 5: Normal same-color bridge still works (regression test)
+// ============================================================================
+TEST_CASE("Normal single-material bridge still works", "[MMUBridge]") {
+    // Single material: two pillars + bridge slab, all same extruder.
+    // Same geometry as MMU tests but everything in one volume/region.
+    // Standard bridge detection should find stBottomBridge surfaces.
+    TriangleMesh left_pillar  = make_cube(5, 20, 4);
+    TriangleMesh right_pillar = make_cube(5, 20, 4);
+    right_pillar.translate(15, 0, 0);
+    left_pillar.merge(right_pillar);
+
+    TriangleMesh bridge_slab = make_cube(20, 20, 0.6);
+    bridge_slab.translate(0, 0, 4);
+    left_pillar.merge(bridge_slab);
+
+    Print print;
+    Model model;
+    DynamicPrintConfig config = DynamicPrintConfig::full_print_config();
+    config.set_deserialize_strict({
+        { "layer_height",       "0.3" },
+        { "first_layer_height", "0.3" },
+        { "bottom_shell_layers", "1" },
+        { "top_shell_layers",   "1" },
+    });
+
+    ModelObject *object = model.add_object();
+    object->name = "single_material_bridge";
+    object->add_volume(std::move(left_pillar));
+    object->add_instance();
+    object->ensure_on_bed();
+
+    print.apply(model, config);
+    print.validate();
+    print.set_status_silent();
+    print.process();
+
+    const PrintObject &obj = *print.objects().front();
+
+    bool found_bridge = false;
+    for (const Layer *layer : obj.layers())
+        for (const LayerRegion *lr : layer->regions())
+            for (const Surface &s : lr->fill_surfaces.surfaces)
+                if (s.surface_type == stBottomBridge)
+                    found_bridge = true;
+
+    CHECK(found_bridge);
+}
+
+// Helper: Create face-painted pillars+slab geometry and process through full MMU pipeline.
+// Two pillars (20x20x6) at y=0..20 and y=30..50 with a 10mm gap, merged with a
+// slab (20x50x1) at z=6..7. Only bottom face triangles of the slab are painted as
+// extruder 2. Caller owns Print and Model (must outlive returned reference).
+static const PrintObject &init_face_painted_bridge_print(Print &print, Model &model)
+{
+    TriangleMesh pillars = make_cube(20, 20, 6);
+    TriangleMesh pillar2 = make_cube(20, 20, 6);
+    pillar2.translate(0, 30, 0);
+    pillars.merge(pillar2);
+
+    TriangleMesh bridge_slab = make_cube(20, 50, 1);
+
+    // Before translation, find bottom face triangles (all 3 vertices have z ≈ 0).
+    std::vector<int> bottom_face_indices;
+    for (int i = 0; i < (int)bridge_slab.its.indices.size(); ++i) {
+        const auto &tri = bridge_slab.its.indices[i];
+        bool all_bottom = true;
+        for (int j = 0; j < 3; ++j)
+            if (bridge_slab.its.vertices[tri[j]].z() > 0.01f)
+                all_bottom = false;
+        if (all_bottom)
+            bottom_face_indices.push_back(i);
+    }
+    assert(bottom_face_indices.size() > 0);
+
+    bridge_slab.translate(0, 0, 6);
+
+    // Remember where pillar triangles end and slab triangles begin.
+    int pillar_tri_count = pillars.facets_count();
+    pillars.merge(bridge_slab);
+    int total_tri_count = pillars.facets_count();
+
+    // Face-painted tests need ALL config keys (PrintConfig + PrintObjectConfig + PrintRegionConfig)
+    // because apply_mm_segmentation() accesses PrintConfig keys like nozzle_diameter,
+    // outer_wall_line_width, and filament_colour (used as num_facets_states = filament_colour.size()+1).
+    // full_print_config() only includes PrintRegionConfig keys.
+    DynamicPrintConfig config = DynamicPrintConfig::full_print_config();
+    config.apply((const PrintConfig &)FullPrintConfig::defaults());
+    config.apply((const PrintObjectConfig &)FullPrintConfig::defaults());
+    config.set_deserialize_strict({
+        { "filament_diameter",      "1.75,1.75" },
+        { "filament_colour",        "#FFFFFF;#FFFFFF" },
+        { "line_width",             "0.45" },
+        { "outer_wall_line_width",  "0.45" },
+        { "layer_height",           "0.3" },
+        { "first_layer_height",     "0.3" },
+        { "bottom_shell_layers",    "1" },
+        { "top_shell_layers",       "1" },
+    });
+
+    ModelObject *object = model.add_object();
+    object->name = "painted_bridge";
+
+    ModelVolume *vol = object->add_volume(std::move(pillars));
+    vol->config.set("extruder", 1);
+
+    // Paint ONLY bottom face triangles of the slab as extruder 2.
+    // Bitstream encoding: nibble = (state << 2) | split_sides.  For leaf state 2:
+    // nibble = 0b1000 = 8 hex.  (NOT "2" - that encodes split_sides=2, not state=2.)
+    // set_triangle_from_string requires strictly increasing triangle IDs.
+    vol->mmu_segmentation_facets.reserve(total_tri_count);
+    for (int idx : bottom_face_indices)
+        vol->mmu_segmentation_facets.set_triangle_from_string(pillar_tri_count + idx, "8");
+    vol->mmu_segmentation_facets.shrink_to_fit();
+
+    object->add_instance();
+    object->ensure_on_bed();
+
+    print.is_BBL_printer() = false;
+    print.apply(model, config);
+    print.validate();
+    print.set_status_silent();
+    print.process();
+
+    return *print.objects().front();
+}
+
+// ============================================================================
+// Test 6: Face-painted bridge through full MMU segmentation pipeline
+// ============================================================================
+TEST_CASE("MMU face-painted bridge full pipeline", "[MMUBridge]") {
+    // Single ModelVolume with mmu_segmentation_facets - the actual face painting path.
+    // Geometry: two pillars + slab merged into one mesh.
+    // Only the BOTTOM FACE triangles of the slab are painted as extruder 2.
+    // This is the realistic scenario: painting the hanging face a different color.
+    // Without the fix, the face-painted bottom region gets overhanging walls
+    // instead of proper bridges.
+    Print print;
+    Model model;
+    const PrintObject &obj = init_face_painted_bridge_print(print, model);
+    REQUIRE(obj.num_printing_regions() > 1);
+
+    // The painted bottom-face region over the gap must get proper bridge fills,
+    // NOT overhanging walls.  On main (without the fix), the region gets
+    // erOverhangPerimeter extrusions instead of stBottomBridge fills.
+    int bridge_layer_count = 0;
+    bool found_overhang_perimeter = false;
+    for (const Layer *layer : obj.layers()) {
+        bool layer_has_bridge = false;
+        for (const LayerRegion *lr : layer->regions()) {
+            for (const Surface &s : lr->fill_surfaces.surfaces)
+                if (s.surface_type == stBottomBridge)
+                    layer_has_bridge = true;
+            // Check for overhang perimeters in the bridge z-range.
+            if (layer->print_z > 5.5 && layer->print_z < 7.0) {
+                for (const ExtrusionEntity *ee : lr->perimeters.flatten().entities)
+                    if (ee->role() == erOverhangPerimeter)
+                        found_overhang_perimeter = true;
+            }
+        }
+        if (layer_has_bridge)
+            bridge_layer_count++;
+    }
+    REQUIRE(bridge_layer_count == 1);
+    // With the fix, the gap region gets bridge fills - no overhang perimeters.
+    // Without the fix (main), the painted region produces overhang walls instead.
+    CHECK_FALSE(found_overhang_perimeter);
+}
+


### PR DESCRIPTION
# Description

Fixes the long-standing issue where color-painting a bridge area causes the slicer to generate overhang perimeters instead of proper bridge infill. When a bridge surface is painted with a different filament color (via face painting, multi-body, or color painting tools), MMU segmentation splits it into a separate region. The per-region bridge detection then fails because the new region has no same-region geometry below — so instead of recognizing it as a bridge, the slicer prints unsupported perimeter walls in thin air.

This has been reported across multiple issues over several OrcaSlicer versions:
- Fixes (not sure though, could be a different issue) OrcaSlicer/OrcaSlicer#11207
- Fixes OrcaSlicer/OrcaSlicer#2845
- Fixes OrcaSlicer/OrcaSlicer#4234
- Fixes OrcaSlicer/OrcaSlicer#6328
- Fixes OrcaSlicer/OrcaSlicer#7352

# Screenshots/Recordings/Graphs

<!--
> Please attach relevant screenshots to showcase the UI changes.
> Please attach images that can help explain the changes.
-->
Current broken version:

<img width="2741" height="1954" alt="Screenshot_20260315_215306" src="https://github.com/user-attachments/assets/abf417f6-d861-4abe-8d35-128de5e2fb2a" />

<img width="2814" height="1901" alt="Screenshot_20260315_215400" src="https://github.com/user-attachments/assets/0b395067-b8a1-4c19-bed1-2eb0e82252c0" />

Fixed version:

<img width="2741" height="1954" alt="Screenshot_20260315_215239" src="https://github.com/user-attachments/assets/d589bf32-0695-4218-b739-c4a8a9038b42" />

<img width="2814" height="1901" alt="Screenshot_20260315_215340" src="https://github.com/user-attachments/assets/f0ba32a5-1973-4cf9-93b8-ff30d40cbebc" />

## Tests

<!--
> Please describe the tests that you have conducted to verify the changes made in this PR.
-->
Added MMU tests.

`MMU bridge preserved with bottom_shell_layers=0` and `MMU face-painted bridge full pipeline` check that the painted overhang surfaces are generated as bridges.

## Example

Exampes of an affected project with upstream and fixed code is in [Project.zip](https://github.com/user-attachments/files/26022978/Project.zip)
