### PR TITLE
Improve button measurements on macOS and Linux

### DIFF
--- a/src/slic3r/GUI/Notebook.cpp
+++ b/src/slic3r/GUI/Notebook.cpp
@@ -121,10 +121,10 @@ void ButtonsListCtrl::UpdateMode()
 void ButtonsListCtrl::Rescale()
 {
     //m_mode_sizer->msw_rescale();
-    int em = em_unit(this);
+    //int em = em_unit(this);
     for (Button* btn : m_pageButtons) {
-        //BBS
-        btn->SetMinSize({(btn->GetLabel().empty() ? 40 : 132) * em / 10, 36 * em / 10});
+        //btn->SetMinSize({(btn->GetLabel().empty() ? 40 : 132) * em / 10, 36 * em / 10});
+        btn->SetMinSize(FromDIP(wxSize((btn->GetLabel().empty() ? 40 : 136), 36))); // ORCA
         btn->Rescale();
     }
 
@@ -175,9 +175,10 @@ bool ButtonsListCtrl::InsertPage(size_t n, const wxString &text, bool bSelect /*
     Button * btn = new Button(this, text.empty() ? text : " " + text, bmp_name, wxNO_BORDER);
     btn->SetCornerRadius(0);
 
-    int em = em_unit(this);
+    //int em = em_unit(this);
     //BBS set size for button
-    btn->SetMinSize({(text.empty() ? 40 : 136) * em / 10, 36 * em / 10});
+    //btn->SetMinSize({(text.empty() ? 40 : 136) * em / 10, 36 * em / 10});
+    btn->SetMinSize(FromDIP(wxSize((text.empty() ? 40 : 136), 36))); // ORCA
 
     StateColor bg_color = StateColor(
         std::pair{wxColour(107, 107, 107), (int) StateColor::Hovered},
@@ -247,9 +248,9 @@ void ButtonsListCtrl::SetPageText(size_t n, const wxString& strText)
 // ORCA
 void ButtonsListCtrl::SetCompact(size_t n, bool compact)
 {
-    int em = em_unit(this);
+    //int em = em_unit(this);
     Button* btn = m_pageButtons[n];
-    btn->SetMinSize({(compact ? 40 : 136) * em / 10, 36 * em / 10});
+    btn->SetMinSize(FromDIP(wxSize((compact ? 40 : 136), 36)));
     btn->SetLabel(compact ? "" : (" " +  m_pageLabels[n]));
 }
 

--- a/src/slic3r/GUI/Preferences.cpp
+++ b/src/slic3r/GUI/Preferences.cpp
@@ -1328,6 +1328,69 @@ void PreferencesDialog::create_items()
     g_sizer = f_sizers.back();
     g_sizer->AddGrowableCol(0, 1);
 
+    wxBoxSizer*test_sizer_1 = new wxBoxSizer(wxHORIZONTAL);
+    auto test_btn_1 = new Button(m_parent, _L("Regular"));
+    test_btn_1->SetStyle(ButtonStyle::Regular, ButtonType::Parameter);
+    test_sizer_1->Add(test_btn_1);
+
+    auto test_btn_2 = new Button(m_parent, _L("Test ÜÇĞ with long text"));
+    test_btn_2->SetStyle(ButtonStyle::Regular, ButtonType::Parameter);
+    test_sizer_1->Add(test_btn_2, 0, wxLEFT, FromDIP(10));
+
+    auto test_btn_3 = new Button(m_parent, _L("IconTest"), "add", 0, 16);
+    test_btn_3->SetStyle(ButtonStyle::Regular, ButtonType::Parameter);
+    test_sizer_1->Add(test_btn_3, 0, wxLEFT, FromDIP(10));
+
+    auto test_btn_4 = new Button(m_parent, _L("LeftTest"), "add", 0, 16);
+    test_btn_4->SetStyle(ButtonStyle::Regular, ButtonType::Parameter);
+    test_btn_4->SetCenter(false);
+    test_sizer_1->Add(test_btn_4, 0, wxLEFT, FromDIP(10));
+
+    g_sizer->Add(test_sizer_1, 0, wxALL, FromDIP(10));
+
+    wxBoxSizer*test_sizer_3 = new wxBoxSizer(wxHORIZONTAL);
+    auto test_btn_11 = new Button(m_parent, _L("Regular with long text"));
+    test_btn_11->SetStyle(ButtonStyle::Regular, ButtonType::Parameter);
+    test_sizer_3->Add(test_btn_11);
+
+    auto test_btn_21 = new Button(m_parent, _L("Test ÜÇĞ with long text"));
+    test_btn_21->SetStyle(ButtonStyle::Regular, ButtonType::Parameter);
+    test_sizer_3->Add(test_btn_21, 0, wxLEFT, FromDIP(10));
+
+    auto test_btn_31 = new Button(m_parent, _L("IconTest with long text"), "add", 0, 16);
+    test_btn_31->SetStyle(ButtonStyle::Regular, ButtonType::Parameter);
+    test_sizer_3->Add(test_btn_31, 0, wxLEFT, FromDIP(10));
+
+    auto test_btn_41 = new Button(m_parent, _L("LeftTest with long text"), "add", 0, 16);
+    test_btn_41->SetStyle(ButtonStyle::Regular, ButtonType::Parameter);
+    test_btn_41->SetCenter(false);
+    test_sizer_3->Add(test_btn_41, 0, wxLEFT, FromDIP(10));
+
+    g_sizer->Add(test_sizer_3, 0, wxALL, FromDIP(10));
+
+    wxBoxSizer*test_sizer_2 = new wxBoxSizer(wxHORIZONTAL);
+
+    auto test_btn_5 = new Button(m_parent, _L("NonVertical\nNonIcon"));
+    test_btn_5->SetStyle(ButtonStyle::Regular, ButtonType::Parameter);
+    test_btn_5->SetMinSize(FromDIP(wxSize(120,90)));
+    test_btn_5->SetSize(FromDIP(wxSize(120,90)));
+    test_sizer_2->Add(test_btn_5);
+
+    auto test_btn_6 = new Button(m_parent, _L("Vertical\n& Icon"), "add", 0, 16);
+    test_btn_6->SetStyle(ButtonStyle::Regular, ButtonType::Parameter);
+    test_btn_6->SetMinSize(FromDIP(wxSize(120,90)));
+    test_btn_6->SetSize(FromDIP(wxSize(120,90)));
+    test_btn_6->SetVertical(true);
+    test_sizer_2->Add(test_btn_6, 0, wxLEFT, FromDIP(10));
+
+    auto test_btn_7 = new Button(m_parent, _L("NonVertical\n& Icon"), "add", 0, 16);
+    test_btn_7->SetStyle(ButtonStyle::Regular, ButtonType::Parameter);
+    test_btn_7->SetMinSize(FromDIP(wxSize(120,90)));
+    test_btn_7->SetSize(FromDIP(wxSize(120,90)));
+    test_sizer_2->Add(test_btn_7, 0, wxLEFT, FromDIP(10));
+
+    g_sizer->Add(test_sizer_2, 0, wxALL, FromDIP(10));
+
     //// GENERAL > Settings
     g_sizer->Add(create_item_title(_L("Settings")), 1, wxEXPAND);
 

--- a/src/slic3r/GUI/Preferences.cpp
+++ b/src/slic3r/GUI/Preferences.cpp
@@ -1328,69 +1328,6 @@ void PreferencesDialog::create_items()
     g_sizer = f_sizers.back();
     g_sizer->AddGrowableCol(0, 1);
 
-    wxBoxSizer*test_sizer_1 = new wxBoxSizer(wxHORIZONTAL);
-    auto test_btn_1 = new Button(m_parent, _L("Regular"));
-    test_btn_1->SetStyle(ButtonStyle::Regular, ButtonType::Parameter);
-    test_sizer_1->Add(test_btn_1);
-
-    auto test_btn_2 = new Button(m_parent, _L("Test ÜÇĞ with long text"));
-    test_btn_2->SetStyle(ButtonStyle::Regular, ButtonType::Parameter);
-    test_sizer_1->Add(test_btn_2, 0, wxLEFT, FromDIP(10));
-
-    auto test_btn_3 = new Button(m_parent, _L("IconTest"), "add", 0, 16);
-    test_btn_3->SetStyle(ButtonStyle::Regular, ButtonType::Parameter);
-    test_sizer_1->Add(test_btn_3, 0, wxLEFT, FromDIP(10));
-
-    auto test_btn_4 = new Button(m_parent, _L("LeftTest"), "add", 0, 16);
-    test_btn_4->SetStyle(ButtonStyle::Regular, ButtonType::Parameter);
-    test_btn_4->SetCenter(false);
-    test_sizer_1->Add(test_btn_4, 0, wxLEFT, FromDIP(10));
-
-    g_sizer->Add(test_sizer_1, 0, wxALL, FromDIP(10));
-
-    wxBoxSizer*test_sizer_3 = new wxBoxSizer(wxHORIZONTAL);
-    auto test_btn_11 = new Button(m_parent, _L("Regular with long text"));
-    test_btn_11->SetStyle(ButtonStyle::Regular, ButtonType::Parameter);
-    test_sizer_3->Add(test_btn_11);
-
-    auto test_btn_21 = new Button(m_parent, _L("Test ÜÇĞ with long text"));
-    test_btn_21->SetStyle(ButtonStyle::Regular, ButtonType::Parameter);
-    test_sizer_3->Add(test_btn_21, 0, wxLEFT, FromDIP(10));
-
-    auto test_btn_31 = new Button(m_parent, _L("IconTest with long text"), "add", 0, 16);
-    test_btn_31->SetStyle(ButtonStyle::Regular, ButtonType::Parameter);
-    test_sizer_3->Add(test_btn_31, 0, wxLEFT, FromDIP(10));
-
-    auto test_btn_41 = new Button(m_parent, _L("LeftTest with long text"), "add", 0, 16);
-    test_btn_41->SetStyle(ButtonStyle::Regular, ButtonType::Parameter);
-    test_btn_41->SetCenter(false);
-    test_sizer_3->Add(test_btn_41, 0, wxLEFT, FromDIP(10));
-
-    g_sizer->Add(test_sizer_3, 0, wxALL, FromDIP(10));
-
-    wxBoxSizer*test_sizer_2 = new wxBoxSizer(wxHORIZONTAL);
-
-    auto test_btn_5 = new Button(m_parent, _L("NonVertical\nNonIcon"));
-    test_btn_5->SetStyle(ButtonStyle::Regular, ButtonType::Parameter);
-    test_btn_5->SetMinSize(FromDIP(wxSize(120,90)));
-    test_btn_5->SetSize(FromDIP(wxSize(120,90)));
-    test_sizer_2->Add(test_btn_5);
-
-    auto test_btn_6 = new Button(m_parent, _L("Vertical\n& Icon"), "add", 0, 16);
-    test_btn_6->SetStyle(ButtonStyle::Regular, ButtonType::Parameter);
-    test_btn_6->SetMinSize(FromDIP(wxSize(120,90)));
-    test_btn_6->SetSize(FromDIP(wxSize(120,90)));
-    test_btn_6->SetVertical(true);
-    test_sizer_2->Add(test_btn_6, 0, wxLEFT, FromDIP(10));
-
-    auto test_btn_7 = new Button(m_parent, _L("NonVertical\n& Icon"), "add", 0, 16);
-    test_btn_7->SetStyle(ButtonStyle::Regular, ButtonType::Parameter);
-    test_btn_7->SetMinSize(FromDIP(wxSize(120,90)));
-    test_btn_7->SetSize(FromDIP(wxSize(120,90)));
-    test_sizer_2->Add(test_btn_7, 0, wxLEFT, FromDIP(10));
-
-    g_sizer->Add(test_sizer_2, 0, wxALL, FromDIP(10));
-
     //// GENERAL > Settings
     g_sizer->Add(create_item_title(_L("Settings")), 1, wxEXPAND);
 

--- a/src/slic3r/GUI/Widgets/Button.cpp
+++ b/src/slic3r/GUI/Widgets/Button.cpp
@@ -200,6 +200,7 @@ void Button::SetStyle(const ButtonStyle style, const ButtonType type)
     else if (type == ButtonType::Parameter) {
         this->SetMinSize(FromDIP(wxSize(120,26)));
         this->SetSize(FromDIP(wxSize(120,26)));
+        this->SetMaxSize(FromDIP(wxSize(120,26)));
         this->SetCornerRadius(this->FromDIP(4));
         this->SetFont(Label::Body_14);
     }

--- a/src/slic3r/GUI/Widgets/Button.cpp
+++ b/src/slic3r/GUI/Widgets/Button.cpp
@@ -362,10 +362,11 @@ void Button::render(wxDC& dc)
             // GetTextExtent and GetMultiLineTextExtent returns a height that includes external leading 
             // On Mac, external leading value is significantly larger than on Windows/Linux due to how CoreText reports font metrics.
             wxFontMetrics fm = dc.GetFontMetrics();
-            int lineHeight = fm.ascent + fm.descent;
-            int lineCount = text.IsEmpty() ? 0 : (text.Freq('\n') + 1);
-            int textBlockHeight = lineCount > 0 ? lineHeight * lineCount + fm.externalLeading * (lineCount - 1) : 0;
-            pt.y += (rcContent.height - textBlockHeight) / 2;
+            int lineHeight   = fm.ascent + fm.descent;
+            int lineCount    = text.IsEmpty() ? 0 : (text.Freq('\n') + 1);
+            int blockHeight  = lineCount > 0 ? lineHeight * lineCount + fm.externalLeading * (lineCount - 1) : 0;
+            pt.y += (rcContent.height - blockHeight) / 2;
+            pt.y -= fm.externalLeading;
         }
         dc.SetTextForeground(text_color.colorForStates(states));
         dc.DrawText(text, pt);
@@ -375,7 +376,26 @@ void Button::render(wxDC& dc)
 void Button::messureSize()
 {
     wxClientDC dc(this);
-    dc.GetTextExtent(GetLabel(), &textSize.width, &textSize.height, &textSize.x, &textSize.y);
+    const wxString text = GetLabel();
+
+    dc.GetTextExtent(text, &textSize.width, &textSize.height, &textSize.x, &textSize.y);
+
+    wxFontMetrics fm = dc.GetFontMetrics();
+    int lineHeight   = fm.ascent + fm.descent;
+    int lineCount    = text.IsEmpty() ? 0 : (text.Freq('\n') + 1);
+    int blockHeight  = lineCount > 0 ? lineHeight * lineCount + fm.externalLeading * (lineCount - 1) : 0;
+    textSize.SetHeight(blockHeight);
+
+    if(lineCount > 1) {
+        int ml_width = 0;
+        for (const wxString& line : wxSplit(text, '\n')) {
+            int lineWidth = 0;
+            dc.GetTextExtent(line, &lineWidth, nullptr);
+            ml_width = wxMax(lineWidth, ml_width);
+        }
+        textSize.SetWidth(ml_width);
+    }
+
     wxSize szContent = textSize.GetSize();
     if (this->active_icon.bmp().IsOk()) {
         if (szContent.y > 0) {

--- a/src/slic3r/GUI/Widgets/Button.cpp
+++ b/src/slic3r/GUI/Widgets/Button.cpp
@@ -297,7 +297,7 @@ void Button::render(wxDC& dc)
 
     // Wrap text
     auto text = GetLabel();
-    int spacing = text.IsEmpty() ? 0 : 5;
+    int spacing = text.IsEmpty() ? 0 : 5; // ORCA dont add spacing when no text in use. fixes aligning on Linux
 
     if (vertical && textSize.x + padding.x * 2 > size.x) {
         Label::split_lines(dc, size.x - padding.x * 2, text, text, 2);
@@ -380,7 +380,7 @@ void Button::messureSize()
 {
     wxClientDC dc(this);
     const wxString text = GetLabel();
-    int spacing = text.IsEmpty() ? 0 : 5;
+    int spacing = text.IsEmpty() ? 0 : 5;  // ORCA dont add spacing when no text in use. fixes aligning on Linux
 
     dc.GetTextExtent(text, &textSize.width, &textSize.height, &textSize.x, &textSize.y);
 
@@ -406,9 +406,9 @@ void Button::messureSize()
         if (szContent.y > 0) {
             //BBS norrow size between text and icon
             if (vertical)
-                szContent.y += spacing;
+                szContent.y += spacing; // ORCA use spacing instead static value
             else
-                szContent.x += spacing;
+                szContent.x += spacing; // ORCA use spacing instead static value
         }
         wxSize szIcon = this->active_icon.GetBmpSize();
         if (vertical) {

--- a/src/slic3r/GUI/Widgets/Button.cpp
+++ b/src/slic3r/GUI/Widgets/Button.cpp
@@ -293,9 +293,11 @@ void Button::render(wxDC& dc)
     else
         icon = inactive_icon;
     wxSize padding = this->paddingSize;
-    int spacing = 5;
+
     // Wrap text
     auto text = GetLabel();
+    int spacing = text.IsEmpty() ? 0 : 5;
+
     if (vertical && textSize.x + padding.x * 2 > size.x) {
         Label::split_lines(dc, size.x - padding.x * 2, text, text, 2);
         textSize = dc.GetMultiLineTextExtent(text);
@@ -377,9 +379,11 @@ void Button::messureSize()
 {
     wxClientDC dc(this);
     const wxString text = GetLabel();
+    int spacing = text.IsEmpty() ? 0 : 5;
 
     dc.GetTextExtent(text, &textSize.width, &textSize.height, &textSize.x, &textSize.y);
 
+    // ORCA exclude external leading from calculations
     wxFontMetrics fm = dc.GetFontMetrics();
     int lineHeight   = fm.ascent + fm.descent;
     int lineCount    = text.IsEmpty() ? 0 : (text.Freq('\n') + 1);
@@ -401,9 +405,9 @@ void Button::messureSize()
         if (szContent.y > 0) {
             //BBS norrow size between text and icon
             if (vertical)
-                szContent.y += 5;
+                szContent.y += spacing;
             else
-                szContent.x += 5;
+                szContent.x += spacing;
         }
         wxSize szIcon = this->active_icon.GetBmpSize();
         if (vertical) {

--- a/src/slic3r/GUI/Widgets/Button.cpp
+++ b/src/slic3r/GUI/Widgets/Button.cpp
@@ -305,18 +305,7 @@ void Button::render(wxDC& dc)
         }
     }
 
-    // ORCA Compute accurate text block height using font metrics
-    // GetTextExtent and GetMultiLineTextExtent returns a height that includes external leading 
-    // On Mac, external leading value is significantly larger than on Windows/Linux due to how CoreText reports font metrics.
-    wxFontMetrics fm = dc.GetFontMetrics();
-    int lineHeight = fm.ascent + fm.descent;
-    int lineCount = text.IsEmpty() ? 0 : (text.Freq('\n') + 1);
-    int textBlockHeight = lineCount > 0 ? lineHeight * lineCount + fm.externalLeading * (lineCount - 1) : 0;
-
     auto szContent = textSize;
-    if (!text.IsEmpty())
-        szContent.y = textBlockHeight;
-
     if (icon.bmp().IsOk()) {
         if (szContent.y > 0) {
             //BBS norrow size between text and icon
@@ -369,9 +358,20 @@ void Button::render(wxDC& dc)
         } else {
             if (pt.x + textSize.x > size.x)
                 text = wxControl::Ellipsize(text, dc, wxELLIPSIZE_END, size.x - pt.x);
-            pt.y += (rcContent.height - textBlockHeight) / 2;
+            pt.y += (rcContent.height - textSize.y) / 2;
         }
         dc.SetTextForeground(text_color.colorForStates(states));
+
+        #ifdef __WXOSX__
+            // ORCA Compute accurate text block height using font metrics
+            // GetTextExtent and GetMultiLineTextExtent returns a height that includes external leading 
+            // On Mac, external leading value is significantly larger than on Windows/Linux due to how CoreText reports font metrics.
+            wxFontMetrics fm = dc.GetFontMetrics();
+            int lineHeight = fm.ascent + fm.descent;
+            int lineCount = text.IsEmpty() ? 0 : (text.Freq('\n') + 1);
+            int textBlockHeight = lineCount > 0 ? lineHeight * lineCount + fm.externalLeading * (lineCount - 1) : 0;
+            pt.y = (rcContent.height - textBlockHeight) / 2;
+        #endif
         dc.DrawText(text, pt);
     }
 }
@@ -381,18 +381,7 @@ void Button::messureSize()
     wxClientDC dc(this);
     dc.GetTextExtent(GetLabel(), &textSize.width, &textSize.height, &textSize.x, &textSize.y);
 
-    // ORCA Use font metrics for consistent height measurement matching render()
-    wxFontMetrics fm = dc.GetFontMetrics();
-    int lineHeight = fm.ascent + fm.descent;
-    const wxString label = GetLabel();
-    int lineCount = label.IsEmpty() ? 0 : (label.Freq('\n') + 1);
-    int textBlockHeight = lineCount > 0
-        ? lineHeight * lineCount + fm.externalLeading * (lineCount - 1)
-        : 0;
-
     wxSize szContent = textSize.GetSize();
-    if (!label.IsEmpty())
-        szContent.y = textBlockHeight;
 
     if (this->active_icon.bmp().IsOk()) {
         if (szContent.y > 0) {

--- a/src/slic3r/GUI/Widgets/Button.cpp
+++ b/src/slic3r/GUI/Widgets/Button.cpp
@@ -304,7 +304,6 @@ void Button::render(wxDC& dc)
             textSize = dc.GetMultiLineTextExtent(text);
         }
     }
-
     auto szContent = textSize;
     if (icon.bmp().IsOk()) {
         if (szContent.y > 0) {
@@ -380,9 +379,7 @@ void Button::messureSize()
 {
     wxClientDC dc(this);
     dc.GetTextExtent(GetLabel(), &textSize.width, &textSize.height, &textSize.x, &textSize.y);
-
     wxSize szContent = textSize.GetSize();
-
     if (this->active_icon.bmp().IsOk()) {
         if (szContent.y > 0) {
             //BBS norrow size between text and icon

--- a/src/slic3r/GUI/Widgets/Button.cpp
+++ b/src/slic3r/GUI/Widgets/Button.cpp
@@ -357,11 +357,7 @@ void Button::render(wxDC& dc)
         } else {
             if (pt.x + textSize.x > size.x)
                 text = wxControl::Ellipsize(text, dc, wxELLIPSIZE_END, size.x - pt.x);
-            pt.y += (rcContent.height - textSize.y) / 2;
-        }
-        dc.SetTextForeground(text_color.colorForStates(states));
 
-        #ifdef __WXOSX__
             // ORCA Compute accurate text block height using font metrics
             // GetTextExtent and GetMultiLineTextExtent returns a height that includes external leading 
             // On Mac, external leading value is significantly larger than on Windows/Linux due to how CoreText reports font metrics.
@@ -369,8 +365,9 @@ void Button::render(wxDC& dc)
             int lineHeight = fm.ascent + fm.descent;
             int lineCount = text.IsEmpty() ? 0 : (text.Freq('\n') + 1);
             int textBlockHeight = lineCount > 0 ? lineHeight * lineCount + fm.externalLeading * (lineCount - 1) : 0;
-            pt.y = (rcContent.height - textBlockHeight) / 2;
-        #endif
+            pt.y += (rcContent.height - textBlockHeight) / 2;
+        }
+        dc.SetTextForeground(text_color.colorForStates(states));
         dc.DrawText(text, pt);
     }
 }

--- a/src/slic3r/GUI/Widgets/Button.cpp
+++ b/src/slic3r/GUI/Widgets/Button.cpp
@@ -304,7 +304,19 @@ void Button::render(wxDC& dc)
             textSize = dc.GetMultiLineTextExtent(text);
         }
     }
+
+    // ORCA Compute accurate text block height using font metrics
+    // GetTextExtent and GetMultiLineTextExtent returns a height that includes external leading 
+    // On Mac, external leading value is significantly larger than on Windows/Linux due to how CoreText reports font metrics.
+    wxFontMetrics fm = dc.GetFontMetrics();
+    int lineHeight = fm.ascent + fm.descent;
+    int lineCount = text.IsEmpty() ? 0 : (text.Freq('\n') + 1);
+    int textBlockHeight = lineCount > 0 ? lineHeight * lineCount + fm.externalLeading * (lineCount - 1) : 0;
+
     auto szContent = textSize;
+    if (!text.IsEmpty())
+        szContent.y = textBlockHeight;
+
     if (icon.bmp().IsOk()) {
         if (szContent.y > 0) {
             //BBS norrow size between text and icon
@@ -357,22 +369,9 @@ void Button::render(wxDC& dc)
         } else {
             if (pt.x + textSize.x > size.x)
                 text = wxControl::Ellipsize(text, dc, wxELLIPSIZE_END, size.x - pt.x);
-            pt.y += (rcContent.height - textSize.y) / 2;
+            pt.y += (rcContent.height - textBlockHeight) / 2;
         }
         dc.SetTextForeground(text_color.colorForStates(states));
-#if 0
-        dc.SetBrush(*wxLIGHT_GREY);
-        dc.SetPen(wxPen(*wxLIGHT_GREY));
-        dc.DrawRectangle(pt, textSize.GetSize());
-#endif
-#ifdef __WXOSX__
-        pt.y -= this->textSize.x / 2;
-#endif
-#ifdef __APPLE__
-        if (Slic3r::is_mac_version_15()) {
-        pt.y -= FromDIP(1);
-    }
-#endif
         dc.DrawText(text, pt);
     }
 }
@@ -381,7 +380,20 @@ void Button::messureSize()
 {
     wxClientDC dc(this);
     dc.GetTextExtent(GetLabel(), &textSize.width, &textSize.height, &textSize.x, &textSize.y);
+
+    // ORCA Use font metrics for consistent height measurement matching render()
+    wxFontMetrics fm = dc.GetFontMetrics();
+    int lineHeight = fm.ascent + fm.descent;
+    const wxString label = GetLabel();
+    int lineCount = label.IsEmpty() ? 0 : (label.Freq('\n') + 1);
+    int textBlockHeight = lineCount > 0
+        ? lineHeight * lineCount + fm.externalLeading * (lineCount - 1)
+        : 0;
+
     wxSize szContent = textSize.GetSize();
+    if (!label.IsEmpty())
+        szContent.y = textBlockHeight;
+
     if (this->active_icon.bmp().IsOk()) {
         if (szContent.y > 0) {
             //BBS norrow size between text and icon

--- a/src/slic3r/GUI/Widgets/SideButton.cpp
+++ b/src/slic3r/GUI/Widgets/SideButton.cpp
@@ -283,8 +283,7 @@ void SideButton::dorender(wxDC& dc, wxDC& text_dc)
         text_dc.SetFont(GetFont());
         wxFontMetrics fm = text_dc.GetFontMetrics();
         int textBlockHeight = fm.ascent + fm.descent;
-        pt.y += (rcContent.height - textBlockHeight) / 2;
-        pt.y -= fm.externalLeading;
+        pt.y += (rcContent.height - textBlockHeight) / 2 - fm.externalLeading;
         text_dc.SetTextForeground(text_color.colorForStates(states));
         text_dc.DrawText(text, pt);
     }
@@ -296,8 +295,10 @@ void SideButton::messureSize()
     textSize = GetTextExtent(GetLabel());
 
     // ORCA exclude external leading from calculations
-    wxFontMetrics fm = dc.GetFontMetrics();
-    textSize.SetHeight(fm.ascent + fm.descent);
+    if(!GetLabel().IsEmpty()){
+        wxFontMetrics fm = dc.GetFontMetrics();
+        textSize.SetHeight(fm.ascent + fm.descent);
+    }
 
     if (minSize.GetWidth() > 0) {
         wxWindow::SetMinSize(minSize);

--- a/src/slic3r/GUI/Widgets/SideButton.cpp
+++ b/src/slic3r/GUI/Widgets/SideButton.cpp
@@ -277,11 +277,14 @@ void SideButton::dorender(wxDC& dc, wxDC& text_dc)
 
     auto text = GetLabel();
     if (!text.IsEmpty()) {
-        pt.y += (rcContent.height - textSize.y) / 2;
-#ifdef __APPLE__
-        pt.y -= FromDIP(2);
-#endif
+        // ORCA Compute accurate text block height using font metrics
+        // GetTextExtent and GetMultiLineTextExtent returns a height that includes external leading 
+        // On Mac, external leading value is significantly larger than on Windows/Linux due to how CoreText reports font metrics.
         text_dc.SetFont(GetFont());
+        wxFontMetrics fm = text_dc.GetFontMetrics();
+        int textBlockHeight = fm.ascent + fm.descent;
+        pt.y += (rcContent.height - textBlockHeight) / 2;
+        pt.y -= fm.externalLeading;
         text_dc.SetTextForeground(text_color.colorForStates(states));
         text_dc.DrawText(text, pt);
     }
@@ -289,7 +292,13 @@ void SideButton::dorender(wxDC& dc, wxDC& text_dc)
 
 void SideButton::messureSize()
 {
+    wxClientDC dc(this);
     textSize = GetTextExtent(GetLabel());
+
+    // ORCA exclude external leading from calculations
+    wxFontMetrics fm = dc.GetFontMetrics();
+    textSize.SetHeight(fm.ascent + fm.descent);
+
     if (minSize.GetWidth() > 0) {
         wxWindow::SetMinSize(minSize);
         return;


### PR DESCRIPTION
tested on Windows, Linux (debian gnome, mint cinnamon, fedora kde), macOS (Ventura)

# MACOS
### Text not properly aligned vertically
GetTextExtent and GetMultiLineTextExtent returns a height that includes external leading 
On Mac, external leading value is significantly larger than on Windows/Linux due to how CoreText reports font metrics.

**Solution: Excluded external leading from calculation to get proper height**
Font metrics works on all platforms properly

**Before-After Tab buttons**
![Screenshot 2026-03-17 at 09 59 24](https://github.com/user-attachments/assets/0df5c0e7-e9ae-4d9c-a424-7a72d5d65932)

**Before-After Flushing volumes button**
![Screenshot 2026-03-18 at 16 29 07](https://github.com/user-attachments/assets/d7719487-780d-410a-b04a-6630584be9fa)

**Before-After Regular buttons**
![Screenshot 2026-03-18 at 16 30 02](https://github.com/user-attachments/assets/e38523f6-2b11-41c4-a6ab-698caacd1f95)

**Before-After Print / Slice buttons**
![Screenshot 2026-03-18 at 16 30 24](https://github.com/user-attachments/assets/637c7b8b-0ce5-4b74-9b7e-3c0c1ebd8e1d)

# LINUX
### Misaligned icons
**Before-After**
Fixed misaligned icons while using compact size
<img width="264" height="187" alt="Screenshot-20260317101442" src="https://github.com/user-attachments/assets/901490a5-7e8c-4714-b5aa-59e3cc908942" />

### Oversized main tab buttons
Used FromDIP like on most of UI instead em_unit. em unit returns different values on linus (12 to 14) compared to 10 on windows and macOS
**Before-After button sizes matched with windows**
left ones are windows
<img width="437" height="102" alt="Screenshot-20260318161812" src="https://github.com/user-attachments/assets/af271dfc-0a09-4259-bb5d-efa7b8ee83dd" />
<img width="364" height="90" alt="Screenshot-20260318161612" src="https://github.com/user-attachments/assets/e83258ca-d254-4b35-8cdc-920734406acc" />

# FURTHER TESTING
<img width="537" height="260" alt="Screenshot-20260318172746" src="https://github.com/user-attachments/assets/b67f5eec-4e47-4ed7-9201-1599f5523588" />

here is what i found included to this PR
• Parameter style doesnt respect max size (fixed in this PR with adding SetMaxSize)
• Multiline texts was not properly centered (fixed in this PR). Calculation made from whole text instead line with max line width

Didnt included to this PR
• SetCenter(false) doesnt use padding on left. 
• Padding not applied properly when text ellipsized
• Padding has to applied first to draw rectangle for **proper fix but requires a lot of changes**

Notes
• Multiline feature is not important much because its not used on code
• SetCenter(false) used only on BBL multi device pages without button background. so issue not visible
• SetVertical() only used on CalibrationWizardPresetPage.cpp

<details><summary>created a test block on preferences to test</summary>
    wxBoxSizer*test_sizer_1 = new wxBoxSizer(wxHORIZONTAL);
    auto test_btn_1 = new Button(m_parent, _L("Regular"));
    test_btn_1->SetStyle(ButtonStyle::Regular, ButtonType::Parameter);
    test_sizer_1->Add(test_btn_1);

    auto test_btn_2 = new Button(m_parent, _L("Test ÜÇĞ with long text"));
    test_btn_2->SetStyle(ButtonStyle::Regular, ButtonType::Parameter);
    test_sizer_1->Add(test_btn_2, 0, wxLEFT, FromDIP(10));

    auto test_btn_3 = new Button(m_parent, _L("CentTest"), "add", 0, 16);
    test_btn_3->SetStyle(ButtonStyle::Regular, ButtonType::Parameter);
    test_sizer_1->Add(test_btn_3, 0, wxLEFT, FromDIP(10));

    auto test_btn_4 = new Button(m_parent, _L("LeftTest"), "add", 0, 16);
    test_btn_4->SetStyle(ButtonStyle::Regular, ButtonType::Parameter);
    test_btn_4->SetCenter(false);
    test_sizer_1->Add(test_btn_4, 0, wxLEFT, FromDIP(10));

    g_sizer->Add(test_sizer_1, 0, wxALL, FromDIP(10));

    wxBoxSizer*test_sizer_3 = new wxBoxSizer(wxHORIZONTAL);
    auto test_btn_11 = new Button(m_parent, _L("Regular with long text"));
    test_btn_11->SetStyle(ButtonStyle::Regular, ButtonType::Parameter);
    test_sizer_3->Add(test_btn_11);

    auto test_btn_21 = new Button(m_parent, _L("Test ÜÇĞ with long text"));
    test_btn_21->SetStyle(ButtonStyle::Regular, ButtonType::Parameter);
    test_sizer_3->Add(test_btn_21, 0, wxLEFT, FromDIP(10));

    auto test_btn_31 = new Button(m_parent, _L("CentTest with long text"), "add", 0, 16);
    test_btn_31->SetStyle(ButtonStyle::Regular, ButtonType::Parameter);
    test_sizer_3->Add(test_btn_31, 0, wxLEFT, FromDIP(10));

    auto test_btn_41 = new Button(m_parent, _L("LeftTest with long text"), "add", 0, 16);
    test_btn_41->SetStyle(ButtonStyle::Regular, ButtonType::Parameter);
    test_btn_41->SetCenter(false);
    test_sizer_3->Add(test_btn_41, 0, wxLEFT, FromDIP(10));

    g_sizer->Add(test_sizer_3, 0, wxALL, FromDIP(10));

    wxBoxSizer*test_sizer_2 = new wxBoxSizer(wxHORIZONTAL);

    wxBoxSizer*test_sizer_5 = new wxBoxSizer(wxHORIZONTAL);
    auto test_btn_12 = new Button(m_parent, _L("Regular"));
    test_btn_12->SetStyle(ButtonStyle::Regular, ButtonType::Window);
    test_sizer_5->Add(test_btn_12);

    auto test_btn_22 = new Button(m_parent, _L("Test ÜÇĞ with long text"));
    test_btn_22->SetStyle(ButtonStyle::Regular, ButtonType::Window);
    test_sizer_5->Add(test_btn_22, 0, wxLEFT, FromDIP(10));

    auto test_btn_32 = new Button(m_parent, _L("CentTest"), "add", 0, 16);
    test_btn_32->SetStyle(ButtonStyle::Regular, ButtonType::Window);
    test_sizer_5->Add(test_btn_32, 0, wxLEFT, FromDIP(10));

    auto test_btn_42 = new Button(m_parent, _L("LeftTest"), "add", 0, 16);
    test_btn_42->SetStyle(ButtonStyle::Regular, ButtonType::Window);
    test_btn_42->SetCenter(false);
    test_sizer_5->Add(test_btn_42, 0, wxLEFT, FromDIP(10));

    g_sizer->Add(test_sizer_5, 0, wxALL, FromDIP(10));

    auto test_btn_5 = new Button(m_parent, _L("NonVertical\nNonIcon"));
    test_btn_5->SetStyle(ButtonStyle::Regular, ButtonType::Parameter);
    test_btn_5->SetMinSize(FromDIP(wxSize(120,90)));
    test_btn_5->SetSize(FromDIP(wxSize(120,90)));
    test_sizer_2->Add(test_btn_5);

    auto test_btn_6 = new Button(m_parent, _L("Vertical\n& Icon"), "add", 0, 16);
    test_btn_6->SetStyle(ButtonStyle::Regular, ButtonType::Parameter);
    test_btn_6->SetMinSize(FromDIP(wxSize(120,90)));
    test_btn_6->SetSize(FromDIP(wxSize(120,90)));
    test_btn_6->SetVertical(true);
    test_sizer_2->Add(test_btn_6, 0, wxLEFT, FromDIP(10));

    auto test_btn_7 = new Button(m_parent, _L("NonVertical\n& Icon"), "add", 0, 16);
    test_btn_7->SetStyle(ButtonStyle::Regular, ButtonType::Parameter);
    test_btn_7->SetMinSize(FromDIP(wxSize(120,90)));
    test_btn_7->SetSize(FromDIP(wxSize(120,90)));
    test_sizer_2->Add(test_btn_7, 0, wxLEFT, FromDIP(10));

    g_sizer->Add(test_sizer_2, 0, wxALL, FromDIP(10));
</details>