### PR TITLE
Add option to place window buttons on left side for Linux

### DIFF
--- a/src/libslic3r/AppConfig.cpp
+++ b/src/libslic3r/AppConfig.cpp
@@ -523,6 +523,11 @@ void AppConfig::set_defaults()
         set_bool("installed_networking", false);
     }
 
+#ifdef __linux__
+    if (get("window_buttons_on_left").empty())
+        set_bool("window_buttons_on_left", false);
+#endif
+
     // Remove legacy window positions/sizes
     erase("app", "main_frame_maximized");
     erase("app", "main_frame_pos");

--- a/src/slic3r/GUI/BBLTopbar.cpp
+++ b/src/slic3r/GUI/BBLTopbar.cpp
@@ -231,7 +231,37 @@ void BBLTopbar::Init(wxFrame* parent)
 
     wxInitAllImageHandlers();
 
-    this->AddSpacer(5);
+    bool window_btns_on_left = false;
+
+#ifdef __linux__
+    window_btns_on_left = wxGetApp().app_config->get("window_buttons_on_left")  == "true";
+
+    if(window_btns_on_left){
+        wxBitmap close_bitmap = create_scaled_bitmap("topbar_close", nullptr, TOPBAR_ICON_SIZE);
+        wxAuiToolBarItem* close_btn = this->AddTool(wxID_CLOSE_FRAME, "", close_bitmap);
+
+        this->AddSpacer(FromDIP(4));
+
+        maximize_bitmap = create_scaled_bitmap("topbar_max", nullptr, TOPBAR_ICON_SIZE);
+        window_bitmap = create_scaled_bitmap("topbar_win", nullptr, TOPBAR_ICON_SIZE);
+        if (m_frame->IsMaximized()) {
+            maximize_btn = this->AddTool(wxID_MAXIMIZE_FRAME, "", window_bitmap);
+        }
+        else {
+            maximize_btn = this->AddTool(wxID_MAXIMIZE_FRAME, "", maximize_bitmap);
+        }
+
+        this->AddSpacer(FromDIP(4));
+
+        wxBitmap iconize_bitmap = create_scaled_bitmap("topbar_min", nullptr, TOPBAR_ICON_SIZE);
+        wxAuiToolBarItem* iconize_btn = this->AddTool(wxID_ICONIZE_FRAME, "", iconize_bitmap);
+
+        this->AddSpacer(15);
+    }
+#endif
+
+    if(!window_btns_on_left)
+        this->AddSpacer(5);
 
     /*wxBitmap logo_bitmap = create_scaled_bitmap("topbar_logo", nullptr, TOPBAR_ICON_SIZE);
     wxAuiToolBarItem* logo_item = this->AddTool(ID_LOGO, "", logo_bitmap);
@@ -307,6 +337,7 @@ void BBLTopbar::Init(wxFrame* parent)
     //this->AddSeparator();
     //this->AddSpacer(FromDIP(4));
 
+    if(!window_btns_on_left){
     wxBitmap iconize_bitmap = create_scaled_bitmap("topbar_min", nullptr, TOPBAR_ICON_SIZE);
     wxAuiToolBarItem* iconize_btn = this->AddTool(wxID_ICONIZE_FRAME, "", iconize_bitmap);
 
@@ -325,6 +356,7 @@ void BBLTopbar::Init(wxFrame* parent)
 
     wxBitmap close_bitmap = create_scaled_bitmap("topbar_close", nullptr, TOPBAR_ICON_SIZE);
     wxAuiToolBarItem* close_btn = this->AddTool(wxID_CLOSE_FRAME, "", close_bitmap);
+    }
 
     Realize();
     // m_toolbar_h = this->GetSize().GetHeight();

--- a/src/slic3r/GUI/Preferences.cpp
+++ b/src/slic3r/GUI/Preferences.cpp
@@ -1360,6 +1360,11 @@ void PreferencesDialog::create_items()
     auto item_show_splash_scr  = create_item_checkbox(_L("Show splash screen"), _L("Show the splash screen during startup."), "show_splash_screen");
     g_sizer->Add(item_show_splash_scr);
 
+#ifdef __linux__
+    auto item_window_button_pos  = create_item_checkbox(_L("Use window buttons on left side"), "", "window_buttons_on_left", _L("(Requires restart)"));
+    g_sizer->Add(item_window_button_pos);
+#endif
+
     //auto item_hints            = create_item_checkbox(_L("Show \"Daily Tips\" after start"), page, _L("If enabled, useful hints are displayed at startup."), "show_daily_tips");
     //g_sizer->Add(item_hints);
 


### PR DESCRIPTION
tested on debian gnome, mint cinnamon, fedora kde

adds an option to move windows buttons to left side

preference
<img width="468" height="152" alt="Screenshot-20260318211824" src="https://github.com/user-attachments/assets/37358a73-7581-4b4d-aed3-acdfc9e205a9" />

window buttons on left
<img width="940" height="110" alt="Screenshot-20260318211717" src="https://github.com/user-attachments/assets/3f8f3c26-3d31-48f5-badf-a9da83b6d168" />

**Note**
menus opening on left side. previously solved in this PR https://github.com/OrcaSlicer/OrcaSlicer/pull/12513
