### PR TITLE
Restructure Text/Emboss Tool UI

### DIFF
--- a/src/slic3r/GUI/Gizmos/GLGizmoEmboss.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoEmboss.cpp
@@ -1378,7 +1378,9 @@ void GLGizmoEmboss::draw_window()
     if (m_is_unknown_font && m_is_advanced_edit_style) 
         ImGui::SetNextTreeNodeOpen(false);
 
-    if (ImGui::TreeNode(_u8L("Advanced").c_str())) {
+    // ImGui Bug: After switching to another window and switching back, clicking the text doesnt open/close the TreeNode anymore
+    ImGuiTreeNodeFlags flags = ImGuiTreeNodeFlags_SpanAvailWidth | ImGuiTreeNodeFlags_FramePadding;
+    if (ImGui::TreeNodeEx(_u8L("Advanced").c_str(), flags)) {
         if (!m_is_advanced_edit_style) {
             m_is_advanced_edit_style = true;
             m_imgui->set_requires_extra_frame();

--- a/src/slic3r/GUI/Gizmos/GLGizmoEmboss.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoEmboss.cpp
@@ -1846,7 +1846,8 @@ void GLGizmoEmboss::draw_font_list()
 
 void GLGizmoEmboss::draw_model_type()
 {
-    ImGui::AlignTextToFramePadding();
+    ImGui::Spacing();
+
     bool is_last_solid_part = m_volume->is_the_only_one_part();
     std::string title = _u8L("Operation");
     if (is_last_solid_part) {
@@ -1863,13 +1864,18 @@ void GLGizmoEmboss::draw_model_type()
     ModelVolumeType type = m_volume->type();
 
     //TRN EmbossOperation
+    float minimum_spacing_x = 8.0f;
+    float minimum_offset_x  = ImGui::GetCursorPosX() + minimum_spacing_x;
+    float offset_x          = std::max(m_gui_cfg->input_offset, minimum_offset_x);
+    ImGui::SameLine(offset_x);
+    
     ImGuiWrapper::push_radio_style(m_parent.get_scale()); // ORCA
     if (ImGui::RadioButton(_u8L("Join").c_str(), type == part))
         new_type = part;
     else if (ImGui::IsItemHovered())
         m_imgui->tooltip(_u8L("Click to change text into object part."), m_gui_cfg->max_tooltip_width);
-    ImGui::SameLine();
 
+    ImGui::SameLine();
     std::string last_solid_part_hint = _u8L("You can't change a type of the last solid part of the object.");
     if (ImGui::RadioButton(_CTX_utf8(L_CONTEXT("Cut", "EmbossOperation"), "EmbossOperation").c_str(), type == negative))
         new_type = negative;

--- a/src/slic3r/GUI/Gizmos/GLGizmoEmboss.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoEmboss.cpp
@@ -1357,15 +1357,22 @@ void GLGizmoEmboss::draw_window()
 
     draw_text_input();
 
-    ImGui::Indent();
-        // When unknown font is inside .3mf only font selection is allowed
-        m_imgui->disabled_end(/*m_is_unknown_font*/);
-        draw_font_list_line();
-        m_imgui->disabled_begin(m_is_unknown_font);
-        bool use_inch = wxGetApp().app_config->get_bool("use_inches");
-        draw_height(use_inch);
-        draw_depth(use_inch);
-    ImGui::Unindent();
+    // subtract 4.0f to counteract weird additional spacing/padding of the revert buttons
+    ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(10.0f, 10.0f - 4.0f));
+    ScopeGuard spacing_sc([](){ ImGui::PopStyleVar(/*ImGuiStyleVar_ItemSpacing*/); });
+
+    draw_style_list();
+
+    // When unknown font is inside .3mf only font selection is allowed
+    m_imgui->disabled_end(/*m_is_unknown_font*/);
+    draw_font_list_line();
+    m_imgui->disabled_begin(m_is_unknown_font);
+
+    bool use_inch = wxGetApp().app_config->get_bool("use_inches");
+    draw_height(use_inch);
+    draw_depth(use_inch);
+
+    ImGui::Spacing();
 
     // close advanced style property when unknown font is selected
     if (m_is_unknown_font && m_is_advanced_edit_style) 
@@ -1384,9 +1391,7 @@ void GLGizmoEmboss::draw_window()
         m_imgui->set_requires_extra_frame();
     }
 
-    ImGui::Separator();
-
-    draw_style_list();
+    ImGui::Spacing();
 
     // Do not select volume type, when it is text object
     if (!m_volume->is_the_only_one_part()) {
@@ -1671,21 +1676,29 @@ void GLGizmoEmboss::draw_font_list_line()
     }
 
     EmbossStyle &style = m_style_manager.get_style();
-    if (exist_change_in_font) {
-        ImGui::SameLine(ImGui::GetStyle().WindowPadding.x);
-        auto r_icon = get_icon(m_icons, IconType::undo, IconState::hovered);
-        if (Slic3r::GUI::button(r_icon, r_icon, r_icon)) { // ORCA draw bottom with same orange color
-            const EmbossStyle *stored_style = m_style_manager.get_stored_style();
+    auto r_icon = get_icon(m_icons, IconType::undo, IconState::hovered);
+    if (exist_change_in_font == false) {
+        ImGui::PushStyleVar(ImGuiStyleVar_Alpha, 0.0f);
+        m_imgui->disabled_begin(true);
+    }
 
-            style.path          = stored_style->path;
-            style.prop.boldness = stored_style->prop.boldness;
-            style.prop.skew     = stored_style->prop.skew;
+    ImGui::SameLine();
+    if (Slic3r::GUI::button(r_icon, r_icon, r_icon)) { // ORCA draw bottom with same orange color
+        const EmbossStyle *stored_style = m_style_manager.get_stored_style();
 
-            wxFont new_wx_font = WxFontUtils::load_wxFont(style.path);
-            if (new_wx_font.IsOk() && m_style_manager.set_wx_font(new_wx_font))
-                exist_change = true;
+        style.path          = stored_style->path;
+        style.prop.boldness = stored_style->prop.boldness;
+        style.prop.skew     = stored_style->prop.skew;
+
+        wxFont new_wx_font = WxFontUtils::load_wxFont(style.path);
+        if (new_wx_font.IsOk() && m_style_manager.set_wx_font(new_wx_font))
+            exist_change = true;
         } else if (ImGui::IsItemHovered())
-            m_imgui->tooltip(_u8L("Revert font changes."), m_gui_cfg->max_tooltip_width);
+        m_imgui->tooltip(_u8L("Revert font changes."), m_gui_cfg->max_tooltip_width);
+
+    if (exist_change_in_font == false) {
+        ImGui::PopStyleVar();
+        m_imgui->disabled_end();
     }
 
     if (exist_change) {
@@ -1741,6 +1754,7 @@ void GLGizmoEmboss::draw_font_list()
         ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(0, 0));
         ImGui::PushStyleVar(ImGuiStyleVar_ItemInnerSpacing, ImVec2(0, 0));
         ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 0);
+        ImGui::PushStyleVar(ImGuiStyleVar_SelectableTextAlign, ImVec2(0.0f, 0.5f)); // vertically align label
 
         for (int i = 0; i < show_items_count; i++) {
             int idx = is_filtered ? filtered_items_idx[i] : i;
@@ -1774,7 +1788,7 @@ void GLGizmoEmboss::draw_font_list()
             ::draw_font_preview(face, m_text, *m_face_names, *m_gui_cfg, ImGui::IsItemVisible());
         }
         
-        ImGui::PopStyleVar(3);
+        ImGui::PopStyleVar(4); // ImGuiStyleVar_ItemSpacing, ImGuiStyleVar_ItemInnerSpacing, ImGuiStyleVar_FrameRounding, ImGuiStyleVar_SelectableTextAlign
         ImGui::EndListBox();
         ImGui::EndPopup();
     } else if (m_face_names->is_init) {
@@ -2172,13 +2186,17 @@ void GLGizmoEmboss::draw_style_list() {
         trunc_name = ImGuiWrapper::trunc(current_name, max_style_name_width);
     }
 
+    ImGui::AlignTextToFramePadding();
+
     std::string title = _u8L("Style");
     if (m_style_manager.exist_stored_style())
         ImGui::Text("%s", title.c_str());
     else
         ImGui::TextColored(ImGuiWrapper::COL_ORCA, "%s", title.c_str());
         
-    ImGui::SetNextItemWidth(m_gui_cfg->input_width);
+    ImGui::SameLine(m_gui_cfg->input_offset);
+
+    ImGui::SetNextItemWidth(2 * m_gui_cfg->input_width);
     auto add_text_modify = [&is_modified](const std::string& name) {
         if (!is_modified) return name;
         return name + Preset::suffix_modified();
@@ -2190,6 +2208,14 @@ void GLGizmoEmboss::draw_style_list() {
         m_style_manager.init_style_images(m_gui_cfg->max_style_image_size, m_text);
         m_style_manager.init_trunc_names(max_style_name_width);
         std::optional<std::pair<size_t,size_t>> swap_indexes;
+
+        ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(0, 0));
+        ImGui::PushStyleVar(ImGuiStyleVar_ItemInnerSpacing, ImVec2(0, 0));
+        ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 0);
+        ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0, 0)); 
+        ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(0, 0));
+        ImGui::PushStyleVar(ImGuiStyleVar_SelectableTextAlign, ImVec2(0.0f, 0.5f)); // vertically align label
+
         const StyleManager::Styles &styles = m_style_manager.get_styles();
         for (const StyleManager::Style &style : styles) {
             size_t index = &style - &styles.front();
@@ -2197,12 +2223,10 @@ void GLGizmoEmboss::draw_style_list() {
             ImGui::PushID(actual_style_name.c_str());
             bool is_selected = (index == m_style_manager.get_style_index());
 
-            float select_height = static_cast<float>(m_gui_cfg->max_style_image_size.y());
-            ImVec2 select_size(0.f, select_height); // 0,0 --> calculate in draw
-            const std::optional<StyleManager::StyleImage> &img = style.image;            
+            ImVec2 selectable_size(0, m_imgui->scaled(32.f / 15.f)); // 0.0f -> calculated during draw
             // allow click delete button
             ImGuiSelectableFlags_ flags = ImGuiSelectableFlags_AllowItemOverlap; 
-            if (ImGui::BBLSelectable(style.truncated_name.c_str(), is_selected, flags, select_size)) {
+            if (ImGui::BBLSelectable(style.truncated_name.c_str(), is_selected, flags, selectable_size)) {
                 selected_style_index = index;
             } else if (ImGui::IsItemHovered())
                 tooltip = actual_style_name;
@@ -2218,6 +2242,7 @@ void GLGizmoEmboss::draw_style_list() {
                     ImGui::ResetMouseDragDelta();
             }
 
+            const std::optional<StyleManager::StyleImage> &img = style.image;            
             // draw style name
             if (img.has_value()) {
                 ImGui::SameLine(max_style_name_width);
@@ -2230,6 +2255,10 @@ void GLGizmoEmboss::draw_style_list() {
         if (swap_indexes.has_value()) 
             m_style_manager.swap(swap_indexes->first,
                                 swap_indexes->second);
+
+        // ImGuiStyleVar_ItemSpacing, ImGuiStyleVar_ItemInnerSpacing, ImGuiStyleVar_FrameRounding, 
+        // ImGuiStyleVar_WindowPadding, ImGuiStyleVar_FramePadding, ImGuiStyleVar_SelectableTextAlign
+        ImGui::PopStyleVar(6); 
         ImGui::EndCombo();
     } else {
         // do not keep in memory style images when no combo box open
@@ -2404,30 +2433,43 @@ bool GLGizmoEmboss::revertible(const std::string &name,
                                Draw               draw) const
 {
     ImGui::AlignTextToFramePadding();
-    bool changed = exist_change(value, default_value);
-    if (changed || default_value == nullptr)
+    bool changed_from_default = exist_change(value, default_value);
+    if (changed_from_default || default_value == nullptr)
         ImGuiWrapper::text_colored(ImGuiWrapper::COL_MODIFIED, name); // ORCA Match color
     else
         ImGuiWrapper::text(name);
 
-    // render revert changes button
-    if (changed) {
-        ImGuiWindow *window = ImGui::GetCurrentWindow();
-        float prev_x = window->DC.CursorPosPrevLine.x;
-        ImGui::SameLine(undo_offset); // change cursor postion
-        auto r_icon = get_icon(m_icons, IconType::undo, IconState::hovered);
-        if (Slic3r::GUI::button(r_icon, r_icon, r_icon)) { // ORCA draw bottom with same orange color
-            value = *default_value;
+    bool changed = draw();
 
-            // !! Fix to detect change of value after revert of float-slider
-            m_imgui->get_last_slider_status().deactivated_after_edit = true;
-
-            return true;
-        } else if (ImGui::IsItemHovered())
-            m_imgui->tooltip(undo_tooltip, m_gui_cfg->max_tooltip_width);
-        window->DC.CursorPosPrevLine.x = prev_x; // set back previous position
+    if (changed_from_default == false) {
+        ImGui::PushStyleVar(ImGuiStyleVar_Alpha, 0.0f);
+        m_imgui->disabled_begin(true);
     }
-    return draw();
+
+    // render revert changes button
+    auto r_icon = get_icon(m_icons, IconType::undo, IconState::hovered);
+    ImGuiWindow *window = ImGui::GetCurrentWindow();
+    float prev_x = window->DC.CursorPosPrevLine.x;
+    ImGui::SameLine(undo_offset); // change cursor postion
+    if (Slic3r::GUI::button(r_icon, r_icon, r_icon)) { // ORCA draw bottom with same orange color
+        value = *default_value;
+
+        // !! Fix to detect change of value after revert of float-slider
+        m_imgui->get_last_slider_status().deactivated_after_edit = true;
+
+        return true;
+    } else if (ImGui::IsItemHovered()) 
+        m_imgui->tooltip(undo_tooltip, m_gui_cfg->max_tooltip_width);
+
+    if (undo_offset != 0.0f)
+        window->DC.CursorPosPrevLine.x = prev_x; // set back previous position
+
+    if (changed_from_default == false) {
+        ImGui::PopStyleVar();
+        m_imgui->disabled_end();
+    }
+
+    return changed;
 }
 // May be move to ImGuiWrapper
 template<typename T> bool imgui_input(const char *label, T *v, T step, T step_fast, const char *format, ImGuiInputTextFlags flags);
@@ -2448,8 +2490,8 @@ bool GLGizmoEmboss::rev_input(const std::string &name, T &value, const T *defaul
         return imgui_input(("##" + name).c_str(),
             &value, step, step_fast, format, flags);
     };
-    float undo_offset = ImGui::GetStyle().WindowPadding.x;
-    return revertible(name, value, default_value, undo_tooltip, undo_offset, draw_offseted_input);
+    return revertible(name, value, default_value, undo_tooltip, 
+                      0.0f, draw_offseted_input);
 }
 
 template<typename T>
@@ -2500,9 +2542,8 @@ bool GLGizmoEmboss::rev_checkbox(const std::string &name,
         ImGui::SameLine(offset);
         return m_imgui->bbl_checkbox(wxString::FromUTF8("##" + name), value);
     };
-    float undo_offset  = ImGui::GetStyle().WindowPadding.x;
     return revertible(name, value, default_value, undo_tooltip,
-                      undo_offset, draw_offseted_input);
+                      0.0f, draw_offseted_input);
 }
 
 bool GLGizmoEmboss::set_height() {
@@ -2583,9 +2624,8 @@ bool GLGizmoEmboss::rev_slider(const std::string &name,
         return m_imgui->slider_optional_int( ("##" + name).c_str(), value, 
             v_min, v_max, format.c_str(), 1.f, false, tooltip);
     };
-    float undo_offset = ImGui::GetStyle().WindowPadding.x;
     return revertible(name, value, default_value,
-        undo_tooltip, undo_offset, draw_slider_optional_int);
+        undo_tooltip, 0.0f, draw_slider_optional_int);
 }
 
 bool GLGizmoEmboss::rev_slider(const std::string &name,
@@ -2605,9 +2645,8 @@ bool GLGizmoEmboss::rev_slider(const std::string &name,
         return m_imgui->slider_optional_float(("##" + name).c_str(), value,
             v_min, v_max, format.c_str(), 1.f, false, tooltip);
     };
-    float undo_offset = ImGui::GetStyle().WindowPadding.x;
     return revertible(name, value, default_value,
-        undo_tooltip, undo_offset, draw_slider_optional_float);
+        undo_tooltip, 0.0f, draw_slider_optional_float);
 }
 
 bool GLGizmoEmboss::rev_slider(const std::string &name,
@@ -2627,9 +2666,8 @@ bool GLGizmoEmboss::rev_slider(const std::string &name,
         return m_imgui->slider_float("##" + name, &value, v_min, v_max,
             format.c_str(), 1.f, false, tooltip);
     };
-    float undo_offset = ImGui::GetStyle().WindowPadding.x;
     return revertible(name, value, default_value,
-        undo_tooltip, undo_offset, draw_slider_float);
+        undo_tooltip, 0.0f, draw_slider_float);
 }
 
 void GLGizmoEmboss::draw_advanced()
@@ -2658,6 +2696,8 @@ void GLGizmoEmboss::draw_advanced()
     }
     m_imgui->text_colored(ImGuiWrapper::COL_GREY_DARK, ff_property);
 #endif // SHOW_FONT_FILE_PROPERTY
+
+    ImGui::Spacing();
 
     auto &tr = m_gui_cfg->translations;
 
@@ -2735,8 +2775,7 @@ void GLGizmoEmboss::draw_advanced()
         return is_change;
     };
     const FontProp::Align * def_align = stored_style ? &stored_style->prop.align : nullptr;
-    float undo_offset = ImGui::GetStyle().WindowPadding.x;
-    if (revertible(tr.alignment, font_prop.align, def_align, _u8L("Revert alignment."), undo_offset, draw_align)) {
+    if (revertible(tr.alignment, font_prop.align, def_align, _u8L("Revert alignment."), 0.0f, draw_align)) {
         if (font_prop.per_glyph)
             reinit_text_lines(m_text_lines.get_lines().size());
         // TODO: move with text in finalize to not change position
@@ -3632,7 +3671,7 @@ GuiCfg create_gui_configuration()
         ImGui::CalcTextSize(tr.font.c_str()).x,
         ImGui::CalcTextSize(tr.height.c_str()).x,
         ImGui::CalcTextSize(tr.depth.c_str()).x});
-    cfg.indent       = static_cast<float>(cfg.icon_width);
+    cfg.indent       = 20.0f;
     cfg.input_offset = style.WindowPadding.x + cfg.indent + max_text_width + space;
 
     // TRN - Input label. Be short as possible
@@ -3699,8 +3738,7 @@ GuiCfg create_gui_configuration()
     cfg.height_of_volume_type_selector = separator_height + line_height_with_spacing + input_height;
 
     int max_style_image_width = static_cast<int>(std::round(cfg.max_style_name_width - 2 * style.FramePadding.x));
-    int max_style_image_height = static_cast<int>(std::round(input_height));
-    cfg.max_style_image_size = Vec2i32(max_style_image_width, line_height);
+    cfg.max_style_image_size = Vec2i32(max_style_image_width, line_height_with_spacing);
     cfg.face_name_size = Vec2i32(cfg.input_width, line_height_with_spacing);
     cfg.face_name_texture_offset_x = cfg.face_name_size.x() + style.WindowPadding.x + space;
 


### PR DESCRIPTION
# Description

While i was implementing a unified tool footer (#12741), @Felix14-v2 made some interesting suggestions on how to improve the text tool UI. 
Especially the "Style" setting should semantically be at the top before the "Font" setting, as it dictates the rest of the settings.

I have also found that the UI is structured very differently in comparison to the rest of the tool UIs. One such example is the placement of the "Revert" button in front of the setting, instead of after it. This also meant that there needed to be an awkward gap left of the setting. 
One positive though was that it was relatively easy to reset multiple settings at once, because they were all vertically aligned. Though I don't think this is worth it having to reserve that space and deviating from the rest of the UI. 
In #12850 i am also introducing a "Reset" button that makes resetting multiple settings at once easy.

There were also different spacing between elements that just looked off.

This PR tries to address those issues by restructuring the placement of UI elements and making them more harmonious.

P.S.: These changes were started in #12741, but i decided to break up the changes into more reviewable chunks.

## Summary
- Move "Style" setting in front of "Font" setting.
- Matches "Style" and "Font" Combobox popup (`BBLSelectable`) general appearance.
   - vertically align label 
   - match height of "Style "selectables to "Font" selectables
   - reduce padding in "Style" selectables
   - fix "Style" preview image
- Moves "Revert" buttons after the settings, matching rest of UI.
- Move "Operation" setting to single-line, matching rest of the settings.
- Match "Advanced" TreeNode button styling to BambuStudio .
- Fix varying spacings.

# Screenshots

_The "revert" button and text styling change (teal -> orange) is not part of this PR.
It is an unrelated change between 2.3.1 and the current main branch._

| Before          | After     |
| ------------- | ------------- |
| <img width="468" height="447" alt="image" src="https://github.com/user-attachments/assets/6c2a5ad3-0a3a-4dcd-a7ed-1c9e73c2ae23" /> | <img width="501" height="379" alt="image" src="https://github.com/user-attachments/assets/dffceac7-d44d-4719-93b5-a51123c541d7" /> |
| <img width="470" height="452" alt="image" src="https://github.com/user-attachments/assets/ec1a9196-77d2-456b-9e6f-eaba1e46941e" /> | <img width="494" height="389" alt="image" src="https://github.com/user-attachments/assets/fbbd837c-1df5-4173-a37b-0e1e543a6cec" /> |
| <img width="470" height="811" alt="image" src="https://github.com/user-attachments/assets/af1782ef-202a-43cc-b720-c50b4248105f" /> | <img width="506" height="733" alt="image" src="https://github.com/user-attachments/assets/a1f1901b-a508-4b0c-b80d-22e7a4cac386" /> |
| <img width="473" height="822" alt="image" src="https://github.com/user-attachments/assets/c05d99f9-3884-4d59-a9d2-d3052020b017" /> | <img width="509" height="739" alt="image" src="https://github.com/user-attachments/assets/3255146e-eac7-496a-b016-9258146f2e32" /> |
| <img width="493" height="237" alt="image" src="https://github.com/user-attachments/assets/f803a42d-542c-4c49-9856-fb2c896a488e" /> | <img width="511" height="231" alt="image" src="https://github.com/user-attachments/assets/30d8eca1-ad4c-44ca-8949-5cfc4628d244" /> |
| <img width="492" height="325" alt="image" src="https://github.com/user-attachments/assets/13679636-f8de-4254-a6aa-ed4b8f6f24ac" /> | <img width="500" height="344" alt="image" src="https://github.com/user-attachments/assets/aec52ac2-6585-4e48-8a53-77d85ca6c228" /> |
