### PR TITLE
Fix missing layers with independent support layer height

### DIFF
--- a/src/libslic3r/Support/SupportMaterial.cpp
+++ b/src/libslic3r/Support/SupportMaterial.cpp
@@ -2886,6 +2886,14 @@ SupportGeneratorLayersPtr PrintObjectSupportMaterial::raft_and_intermediate_supp
             size_t        n_layers_extra = size_t(ceil(dist / m_slicing_params.max_suport_layer_height)); 
             assert(n_layers_extra > 0);
             coordf_t      step   = dist / coordf_t(n_layers_extra);
+            // Snap to multiples of the object layer height to reduce accumulated z drift
+            // while keeping support layers coarse (faster) when independent_support_layer_height is enabled.
+            const coordf_t q = m_slicing_params.layer_height;
+            if (q > 0) {
+                const coordf_t snapped = std::round(step / q) * q;
+                if (snapped >= q - EPSILON)
+                    step = std::min(snapped, m_slicing_params.max_suport_layer_height);
+            }
             if (extr1 != nullptr && extr1->layer_type == SupporLayerType::TopContact &&
                 extr1->print_z + m_support_params.support_layer_height_min > extr1->bottom_z + step) {
                 // The bottom extreme is a bottom of a top surface. Ensure that the gap 
@@ -2903,6 +2911,14 @@ SupportGeneratorLayersPtr PrintObjectSupportMaterial::raft_and_intermediate_supp
                     continue;
                 // Continue printing the other layers up to extr2z.
                 step = dist / coordf_t(n_layers_extra);
+                {
+                    const coordf_t q = m_slicing_params.layer_height;
+                    if (q > 0) {
+                        const coordf_t snapped = std::round(step / q) * q;
+                        if (snapped >= q - EPSILON)
+                            step = std::min(snapped, m_slicing_params.max_suport_layer_height);
+                    }
+                }
             }
             if (! m_slicing_params.soluble_interface && extr2->layer_type == SupporLayerType::TopContact) {
                 // This is a top interface layer, which does not have a height assigned yet. Do it now.


### PR DESCRIPTION
# Description

Adjusts intermediate support layer Z stepping when independent_support_layer_height is enabled, aiming to prevent skipped/missing support layers by reducing accumulated Z drift.

# Before

<img width="2560" height="1392" alt="image" src="https://github.com/user-attachments/assets/718142a0-920c-411b-9e3c-62e853a5d000" />

<img width="2560" height="1392" alt="image" src="https://github.com/user-attachments/assets/4c9ebb55-c347-46c9-ae72-ed12d9bdfc1b" />

# After
<img width="2560" height="1392" alt="image" src="https://github.com/user-attachments/assets/cff6345c-95dd-4cd7-91e7-5413af22f1ed" />

<img width="2560" height="1392" alt="image" src="https://github.com/user-attachments/assets/6c4f7172-6eb7-4384-a03f-3db760755bd6" />

## Tests


[CoreXY_PETG_04_Err.zip](https://github.com/user-attachments/files/26163284/CoreXY_PETG_04_Err.zip)

Fix #12846