### PR TITLE
Fix Windows test linking: use main() instead of wmain()

### DIFF
--- a/tests/catch2/src/CMakeLists.txt
+++ b/tests/catch2/src/CMakeLists.txt
@@ -385,6 +385,10 @@ target_include_directories(Catch2
 add_library(Catch2WithMain
   ${SOURCES_DIR}/internal/catch_main.cpp
 )
+# Force standard main() entry point instead of wmain() on Windows.
+# wxWidgets defines _UNICODE globally, which causes Catch2 to use wmain,
+# but test executables expect a standard main() entry point.
+target_compile_definitions(Catch2WithMain PRIVATE DO_NOT_USE_WMAIN)
 if(CATCH_ENABLE_REPRODUCIBLE_BUILD)
   add_build_reproducibility_settings(Catch2WithMain)
 endif()


### PR DESCRIPTION
## Summary

- wxWidgets defines `_UNICODE` globally, which causes Catch2's `catch_main.cpp` to provide `wmain()` instead of `main()`
- This leads to `LNK2001: unresolved external symbol "main"` for all test executables when building with `BUILD_TESTS=ON` on MSVC
- Adds `DO_NOT_USE_WMAIN` compile definition to `Catch2WithMain` target

## Test plan

- [x] Build with `BUILD_TESTS=ON` on Windows VS2022
- [x] Verify all test executables link successfully
- [ ] No-op on Linux/macOS (`_UNICODE` is not defined there)