### PR TITLE
Fix second CLI segfault during --slice in extruder variant config

### DIFF
--- a/src/libslic3r/PrintApply.cpp
+++ b/src/libslic3r/PrintApply.cpp
@@ -1163,7 +1163,8 @@ Print::ApplyStatus Print::apply(const Model &model, DynamicPrintConfig new_full_
 
     m_ori_full_print_config = new_full_config;
     new_full_config.update_values_to_printer_extruders_for_multiple_filaments(new_full_config, filament_options_with_variant,  "filament_self_index", "filament_extruder_variant");
-    std::vector<int> filament_maps =  new_full_config.option<ConfigOptionInts>("filament_map")->values;
+    auto opt_filament_map = new_full_config.option<ConfigOptionInts>("filament_map");
+    std::vector<int> filament_maps = opt_filament_map ? opt_filament_map->values : std::vector<int>{1};
 
     // Find modified keys of the various configs. Resolve overrides extruder retract values by filament profiles.
     DynamicPrintConfig   filament_overrides;

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -9000,6 +9000,10 @@ void DynamicPrintConfig::update_values_to_printer_extruders(DynamicPrintConfig& 
         //int extruder_count = opt_nozzle_diameters->size();
         auto opt_extruder_type = dynamic_cast<const ConfigOptionEnumsGeneric*>(printer_config.option("extruder_type"));
         auto opt_nozzle_volume_type = dynamic_cast<const ConfigOptionEnumsGeneric*>(printer_config.option("nozzle_volume_type"));
+        if (!opt_extruder_type || !opt_nozzle_volume_type) {
+            BOOST_LOG_TRIVIAL(warning) << __FUNCTION__ << boost::format(", Line %1%: extruder_type or nozzle_volume_type not found, skipping")%__LINE__;
+            return;
+        }
         std::vector<int> variant_index;
 
         if (extruder_id > 0 && extruder_id <= static_cast<unsigned> (extruder_count)) {
@@ -9055,6 +9059,7 @@ void DynamicPrintConfig::update_values_to_printer_extruders(DynamicPrintConfig& 
                 case coStrings:
                 {
                     ConfigOptionStrings * opt = this->option<ConfigOptionStrings>(key);
+                    if (!opt) continue;
                     std::vector<std::string> new_values;
 
                     new_values.resize(extruder_count * stride);
@@ -9069,6 +9074,7 @@ void DynamicPrintConfig::update_values_to_printer_extruders(DynamicPrintConfig& 
                 case coInts:
                 {
                     ConfigOptionInts * opt = this->option<ConfigOptionInts>(key);
+                    if (!opt) continue;
                     std::vector<int> new_values;
 
                     new_values.resize(extruder_count * stride);
@@ -9083,6 +9089,7 @@ void DynamicPrintConfig::update_values_to_printer_extruders(DynamicPrintConfig& 
                 case coFloats:
                 {
                     ConfigOptionFloats * opt = this->option<ConfigOptionFloats>(key);
+                    if (!opt) continue;
                     std::vector<double> new_values;
 
                     new_values.resize(extruder_count * stride);
@@ -9097,6 +9104,7 @@ void DynamicPrintConfig::update_values_to_printer_extruders(DynamicPrintConfig& 
                 case coPercents:
                 {
                     ConfigOptionPercents * opt = this->option<ConfigOptionPercents>(key);
+                    if (!opt) continue;
                     std::vector<double> new_values;
 
                     new_values.resize(extruder_count * stride);
@@ -9111,6 +9119,7 @@ void DynamicPrintConfig::update_values_to_printer_extruders(DynamicPrintConfig& 
                 case coFloatsOrPercents:
                 {
                     ConfigOptionFloatsOrPercents * opt = this->option<ConfigOptionFloatsOrPercents>(key);
+                    if (!opt) continue;
                     std::vector<FloatOrPercent> new_values;
 
                     new_values.resize(extruder_count * stride);
@@ -9125,6 +9134,7 @@ void DynamicPrintConfig::update_values_to_printer_extruders(DynamicPrintConfig& 
                 case coBools:
                 {
                     ConfigOptionBools * opt = this->option<ConfigOptionBools>(key);
+                    if (!opt) continue;
                     std::vector<unsigned char> new_values;
 
                     new_values.resize(extruder_count * stride);
@@ -9139,6 +9149,7 @@ void DynamicPrintConfig::update_values_to_printer_extruders(DynamicPrintConfig& 
                 case coEnums:
                 {
                     ConfigOptionEnumsGeneric * opt = this->option<ConfigOptionEnumsGeneric>(key);
+                    if (!opt) continue;
                     std::vector<int> new_values;
 
                     new_values.resize(extruder_count * stride);
@@ -9165,13 +9176,22 @@ void DynamicPrintConfig::update_values_to_printer_extruders_for_multiple_filamen
     if ((extruder_count > 1) || different_extruder)
     {
         BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << boost::format(", Line %1%:  extruder_count=%2%, different_extruder=%3%")%__LINE__ %extruder_count %different_extruder;
-        std::vector<int> filament_maps =  printer_config.option<ConfigOptionInts>("filament_map")->values;
+        auto opt_filament_map = printer_config.option<ConfigOptionInts>("filament_map");
+        if (!opt_filament_map) {
+            BOOST_LOG_TRIVIAL(warning) << __FUNCTION__ << boost::format(", Line %1%: filament_map not found, skipping")%__LINE__;
+            return;
+        }
+        std::vector<int> filament_maps = opt_filament_map->values;
         size_t filament_count = filament_maps.size();
         //apply process settings
         //auto opt_nozzle_diameters = this->option<ConfigOptionFloats>("nozzle_diameter");
         //int extruder_count = opt_nozzle_diameters->size();
         auto opt_extruder_type = dynamic_cast<const ConfigOptionEnumsGeneric*>(printer_config.option("extruder_type"));
         auto opt_nozzle_volume_type = dynamic_cast<const ConfigOptionEnumsGeneric*>(printer_config.option("nozzle_volume_type"));
+        if (!opt_extruder_type || !opt_nozzle_volume_type) {
+            BOOST_LOG_TRIVIAL(warning) << __FUNCTION__ << boost::format(", Line %1%: extruder_type or nozzle_volume_type not found, skipping")%__LINE__;
+            return;
+        }
         auto opt_ids = id_name.empty()? nullptr: dynamic_cast<const ConfigOptionInts*>(this->option(id_name));
         std::vector<int> variant_index;
 
@@ -9217,6 +9237,7 @@ void DynamicPrintConfig::update_values_to_printer_extruders_for_multiple_filamen
                 case coStrings:
                 {
                     ConfigOptionStrings * opt = this->option<ConfigOptionStrings>(key);
+                    if (!opt) continue;
                     std::vector<std::string> new_values;
 
                     new_values.resize(filament_count);
@@ -9230,6 +9251,7 @@ void DynamicPrintConfig::update_values_to_printer_extruders_for_multiple_filamen
                 case coInts:
                 {
                     ConfigOptionInts * opt = this->option<ConfigOptionInts>(key);
+                    if (!opt) continue;
                     std::vector<int> new_values;
 
                     new_values.resize(filament_count);
@@ -9243,6 +9265,7 @@ void DynamicPrintConfig::update_values_to_printer_extruders_for_multiple_filamen
                 case coFloats:
                 {
                     ConfigOptionFloats * opt = this->option<ConfigOptionFloats>(key);
+                    if (!opt) continue;
                     std::vector<double> new_values;
 
                     new_values.resize(filament_count);
@@ -9256,6 +9279,7 @@ void DynamicPrintConfig::update_values_to_printer_extruders_for_multiple_filamen
                 case coPercents:
                 {
                     ConfigOptionPercents * opt = this->option<ConfigOptionPercents>(key);
+                    if (!opt) continue;
                     std::vector<double> new_values;
 
                     new_values.resize(filament_count);
@@ -9269,6 +9293,7 @@ void DynamicPrintConfig::update_values_to_printer_extruders_for_multiple_filamen
                 case coFloatsOrPercents:
                 {
                     ConfigOptionFloatsOrPercents * opt = this->option<ConfigOptionFloatsOrPercents>(key);
+                    if (!opt) continue;
                     std::vector<FloatOrPercent> new_values;
 
                     new_values.resize(filament_count);
@@ -9282,6 +9307,7 @@ void DynamicPrintConfig::update_values_to_printer_extruders_for_multiple_filamen
                 case coBools:
                 {
                     ConfigOptionBools * opt = this->option<ConfigOptionBools>(key);
+                    if (!opt) continue;
                     std::vector<unsigned char> new_values;
 
                     new_values.resize(filament_count);
@@ -9295,6 +9321,7 @@ void DynamicPrintConfig::update_values_to_printer_extruders_for_multiple_filamen
                 case coEnums:
                 {
                     ConfigOptionEnumsGeneric * opt = this->option<ConfigOptionEnumsGeneric>(key);
+                    if (!opt) continue;
                     std::vector<int> new_values;
 
                     new_values.resize(filament_count);


### PR DESCRIPTION
## Summary

Fixes a **second CLI segfault** discovered after #12719. While #12719 fixed the NULL `m_plater` dereference in `PartPlate::set_shape()` (which crashed during model arrangement), this PR fixes a separate SIGSEGV that occurs later during `Print::apply()` when the slicer processes extruder variant configurations.

In CLI mode, config options like `filament_map`, `extruder_type`, and `nozzle_volume_type` may not be present in the merged config when loading individual JSON profile files. The code unconditionally dereferences these without NULL checks, causing a segfault at address `0x8` (NULL + struct member offset).

Additionally, option lookups in the switch/case blocks (e.g., `this->option<ConfigOptionInts>(key)`) can return `nullptr` for keys that exist in the config *definition* but not in the actual config values.

Zero impact on GUI mode where these options are always populated.

## Steps to reproduce

Requires #12719 to be applied first (otherwise the earlier segfault masks this one).

```bash
OrcaSlicer \
  --load-settings "machine/Bambu Lab P2S 0.4 nozzle.json;process/0.20mm Standard @BBL P2S.json" \
  --load-filaments "filament/Bambu PLA Basic @BBL P2S.json" \
  --slice 0 \
  --export-3mf output.3mf \
  model.stl
# Crashes with exit code 139 (SIGSEGV)
```

## After fix

```
$ OrcaSlicer \
  --load-settings "machine/Bambu Lab P2S 0.4 nozzle.json;process/0.20mm Standard @BBL P2S.json" \
  --load-filaments "filament/Bambu PLA Basic @BBL P2S.json" \
  --slice 0 \
  --export-3mf 3DBenchy_P2S.3mf \
  3DBenchy.stl

$ echo $?
0
```

## Changes

**`src/libslic3r/PrintConfig.cpp`:**
- Add NULL guard for `opt_extruder_type` / `opt_nozzle_volume_type` in both `update_values_to_printer_extruders()` and `update_values_to_printer_extruders_for_multiple_filaments()` — return early if missing
- Add NULL guard for `filament_map` option in `update_values_to_printer_extruders_for_multiple_filaments()`
- Add `if (!opt) continue;` for all option type cases in the switch blocks of both functions, preventing NULL dereference when a config key is defined but has no value

**`src/libslic3r/PrintApply.cpp`:**
- Add NULL guard for `filament_map` in `Print::apply()` with fallback to `{1}` (matching the config definition default)