### PR TITLE
Fix the OnText handler in ObjectTableDialog to close on Esc.

### DIFF
--- a/localization/i18n/en/OrcaSlicer_en.po
+++ b/localization/i18n/en/OrcaSlicer_en.po
@@ -2614,7 +2614,7 @@ msgid "Brim"
 msgstr ""
 
 msgid "Object/Part Setting"
-msgstr "Object/part setting"
+msgstr "Object/part settings"
 
 msgid "Reset parameter"
 msgstr ""

--- a/src/slic3r/GUI/GUI_ObjectTable.cpp
+++ b/src/slic3r/GUI/GUI_ObjectTable.cpp
@@ -3282,7 +3282,7 @@ void ObjectTablePanel::msw_rescale() {
 // ObjectTableDialog
 // ----------------------------------------------------------------------------
 ObjectTableDialog::ObjectTableDialog(wxWindow* parent, Plater* platerObj, Model *modelObj, wxSize maxSize)
-    : GUI::DPIDialog(parent, wxID_ANY, _L("Object/Part Setting"), wxDefaultPosition, wxDefaultSize, wxCAPTION | wxCLOSE_BOX | wxRESIZE_BORDER)
+    : GUI::DPIDialog(parent, wxID_ANY, _L("Object/Part Settings"), wxDefaultPosition, wxDefaultSize, wxCAPTION | wxCLOSE_BOX | wxRESIZE_BORDER)
     ,
     m_model(modelObj), m_plater(platerObj)
 {
@@ -3415,7 +3415,9 @@ void ObjectTableDialog::OnClose(wxCloseEvent &evt)
 
 void ObjectTableDialog::OnText(wxKeyEvent &evt)
 {
-	if (evt.GetKeyCode() != WXK_ESCAPE) {
+	if (evt.GetKeyCode() == WXK_ESCAPE) {
+		Close();
+	} else {
 		evt.Skip();
 	}
 }


### PR DESCRIPTION
# Description
The OnText handler in ObjectTableDialog catches WXK_ESCAPE but swallows it.  Invert the logic to call Close() on Esc, and pass anything else to evt.Skip().

While at it, fix a typo in the dialog's title.

## Tests
None.  I haven't been able to build OrcaSlicer on macOS due to an error building "dep_GMP".