### PR TITLE
fix: Prevent app crash from SIGSEGV in Bambu networking DLL

### DIFF
--- a/src/slic3r/CMakeLists.txt
+++ b/src/slic3r/CMakeLists.txt
@@ -618,6 +618,8 @@ set(SLIC3R_GUI_SOURCES
     Utils/BBLPrinterAgent.hpp
     Utils/BBLNetworkPlugin.cpp
     Utils/BBLNetworkPlugin.hpp
+    Utils/DllCrashGuard.cpp
+    Utils/DllCrashGuard.hpp
     Utils/Obico.cpp
     Utils/Obico.hpp
     Utils/OctoPrint.cpp

--- a/src/slic3r/GUI/DeviceCore/DevManager.cpp
+++ b/src/slic3r/GUI/DeviceCore/DevManager.cpp
@@ -7,6 +7,7 @@
 #include "slic3r/GUI/I18N.hpp"
 #include "slic3r/GUI/GUI_App.hpp"
 #include "slic3r/GUI/Plater.hpp"
+#include "slic3r/Utils/DllCrashGuard.hpp"
 
 #include "libslic3r/Time.hpp"
 
@@ -906,7 +907,8 @@ namespace Slic3r
         }
 
         // do some refresh
-        if (Slic3r::GUI::wxGetApp().is_user_login())
+        if (Slic3r::GUI::wxGetApp().is_user_login() &&
+            !g_networking_dll_crashed.load(std::memory_order_acquire))
         {
             m_manager->check_pushing();
             try

--- a/src/slic3r/GUI/DeviceManager.cpp
+++ b/src/slic3r/GUI/DeviceManager.cpp
@@ -2397,25 +2397,57 @@ void MachineObject::set_print_state(std::string status)
 
 int MachineObject::connect(bool use_openssl)
 {
+    // Drain any deferred SIGSEGV logs from the signal handler (the handler
+    // itself can't call boost::log safely).
+    int pending = g_pending_sigsegv_log_count.exchange(0, std::memory_order_acq_rel);
+    if (pending > 0) {
+        BOOST_LOG_TRIVIAL(error) << "[DllGuard] " << pending
+                                 << " SIGSEGV(s) caught on DLL-owned thread(s) since last check";
+    }
+
+    // After a SIGSEGV in the DLL the library is internally deadlocked — every
+    // call (connect_printer, disconnect_printer, …) hangs forever. Recovery
+    // via the DLL's own API is impossible (proven empirically). Short-circuit
+    // and show the restart dialog instead of blocking the UI thread.
+    if (g_networking_dll_crashed.load(std::memory_order_acquire)) {
+        BOOST_LOG_TRIVIAL(warning) << "[DllGuard] MachineObject::connect skipped — DLL crashed, restart required";
+        Slic3r::GUI::wxGetApp().CallAfter([] {
+            Slic3r::GUI::MessageDialog dlg(
+                nullptr,
+                _L("Connection to the printer failed.\n\n"
+                   "The networking plugin encountered an internal error.\n"
+                   "Please restart both your printer and OrcaSlicer to reconnect.\n"
+                   "If the problem persists, try printing via SD card instead."),
+                _L("Connection Error"),
+                wxICON_ERROR | wxOK);
+            dlg.ShowModal();
+        });
+        return -1;
+    }
+
     if (get_dev_ip().empty()) return -1;
     std::string username = "bblp";
     std::string password = get_access_code();
 
     if (m_agent) {
         try {
-            g_networking_dll_crashed.store(false, std::memory_order_release);
-
             int result = m_agent->connect_printer(get_dev_id(), get_dev_ip(), username, password, use_openssl);
+
+            // If the call returned because dll_safe_call detected a crash/hang
+            // (SIGSEGV recovered or timeout), show the dialog so the user is
+            // told to restart.
             if (result < 0 && g_networking_dll_crashed.load(std::memory_order_acquire)) {
-                BOOST_LOG_TRIVIAL(error) << "MachineObject::connect: networking DLL crashed during connection attempt";
+                BOOST_LOG_TRIVIAL(error) << "[DllGuard] DLL crashed/hung during connect — showing dialog";
                 Slic3r::GUI::wxGetApp().CallAfter([] {
-                    wxMessageBox(
+                    Slic3r::GUI::MessageDialog dlg(
+                        nullptr,
                         _L("Connection to the printer failed.\n\n"
                            "The networking plugin encountered an internal error.\n"
                            "Please restart both your printer and OrcaSlicer to reconnect.\n"
                            "If the problem persists, try printing via SD card instead."),
                         _L("Connection Error"),
                         wxICON_ERROR | wxOK);
+                    dlg.ShowModal();
                 });
             }
             return result;

--- a/src/slic3r/GUI/DeviceManager.cpp
+++ b/src/slic3r/GUI/DeviceManager.cpp
@@ -3,6 +3,7 @@
 #include "libslic3r/Time.hpp"
 #include "libslic3r/Thread.hpp"
 #include "slic3r/Utils/NetworkAgent.hpp"
+#include "slic3r/Utils/DllCrashGuard.hpp"
 #include "GuiColor.hpp"
 
 #include "GUI_App.hpp"
@@ -2402,7 +2403,22 @@ int MachineObject::connect(bool use_openssl)
 
     if (m_agent) {
         try {
-            return m_agent->connect_printer(get_dev_id(), get_dev_ip(), username, password, use_openssl);
+            g_networking_dll_crashed.store(false, std::memory_order_release);
+
+            int result = m_agent->connect_printer(get_dev_id(), get_dev_ip(), username, password, use_openssl);
+            if (result < 0 && g_networking_dll_crashed.load(std::memory_order_acquire)) {
+                BOOST_LOG_TRIVIAL(error) << "MachineObject::connect: networking DLL crashed during connection attempt";
+                Slic3r::GUI::wxGetApp().CallAfter([] {
+                    wxMessageBox(
+                        _L("Connection to the printer failed.\n\n"
+                           "The networking plugin encountered an internal error.\n"
+                           "Please restart both your printer and OrcaSlicer to reconnect.\n"
+                           "If the problem persists, try printing via SD card instead."),
+                        _L("Connection Error"),
+                        wxICON_ERROR | wxOK);
+                });
+            }
+            return result;
         } catch (...) {
             ;
         }

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -122,6 +122,7 @@
 #include "slic3r/Utils/NetworkAgentFactory.hpp"
 #include "slic3r/Utils/BBLNetworkPlugin.hpp"
 #include "slic3r/Utils/bambu_networking.hpp"
+#include "slic3r/Utils/DllCrashGuard.hpp"
 
 //#ifdef WIN32
 //#include "BaseException.h"
@@ -2740,6 +2741,11 @@ bool GUI_App::on_init_inner()
     //BBS set crash log folder
     CBaseException::set_log_folder(data_dir());
 #endif
+
+    // Install crash handler for the Bambu networking DLL.
+    // This catches SIGSEGV/access violations from the proprietary DLL's internal threads
+    // (e.g. MQTTAsync_sendThread) and prevents the entire application from crashing.
+    install_dll_crash_handler();
 
     wxGetApp().Bind(wxEVT_QUERY_END_SESSION, [this](auto & e) {
         BOOST_LOG_TRIVIAL(info) << __FUNCTION__<< "received wxEVT_QUERY_END_SESSION";

--- a/src/slic3r/GUI/Jobs/PrintJob.cpp
+++ b/src/slic3r/GUI/Jobs/PrintJob.cpp
@@ -14,6 +14,7 @@
 
 #include "slic3r/Utils/FileTransferUtils.hpp"
 #include "slic3r/Utils/BBLNetworkPlugin.hpp"
+#include "slic3r/Utils/DllCrashGuard.hpp"
 
 namespace Slic3r {
 namespace GUI {
@@ -619,10 +620,21 @@ void PrintJob::process(Ctl &ctl)
         }
     }
 
+    // Check if the networking DLL crashed asynchronously (e.g. on its MQTT thread)
+    if (g_networking_dll_crashed.load(std::memory_order_acquire)) {
+        BOOST_LOG_TRIVIAL(error) << "print_job: networking DLL crashed asynchronously: " << get_dll_crash_message();
+        result = -1;
+    }
+
     if (result < 0) {
         curr_percent = -1;
 
-        if (result == BAMBU_NETWORK_ERR_PRINT_WR_FILE_NOT_EXIST || result == BAMBU_NETWORK_ERR_PRINT_SP_FILE_NOT_EXIST) {
+        if (g_networking_dll_crashed.load(std::memory_order_acquire)) {
+            msg_text = _u8L("The networking plugin encountered an internal error (crash). "
+                            "Please restart OrcaSlicer and try again. "
+                            "If the problem persists, check your network connection.");
+            BOOST_LOG_TRIVIAL(error) << "print_job: networking DLL crash detected, showing error to user";
+        } else if (result == BAMBU_NETWORK_ERR_PRINT_WR_FILE_NOT_EXIST || result == BAMBU_NETWORK_ERR_PRINT_SP_FILE_NOT_EXIST) {
             msg_text = file_is_not_exists_str;
         } else if (result == BAMBU_NETWORK_ERR_PRINT_SP_FILE_OVER_SIZE || result == BAMBU_NETWORK_ERR_PRINT_WR_FILE_OVER_SIZE) {
             msg_text = file_over_size_str;

--- a/src/slic3r/GUI/Jobs/PrintJob.cpp
+++ b/src/slic3r/GUI/Jobs/PrintJob.cpp
@@ -468,6 +468,8 @@ void PrintJob::process(Ctl &ctl)
                     };
 
     auto cancel_fn = [&ctl]() {
+            if (g_networking_dll_crashed.load(std::memory_order_acquire))
+                return true;
             return ctl.was_canceled();
         };
 
@@ -630,9 +632,10 @@ void PrintJob::process(Ctl &ctl)
         curr_percent = -1;
 
         if (g_networking_dll_crashed.load(std::memory_order_acquire)) {
-            msg_text = _u8L("The networking plugin encountered an internal error (crash). "
-                            "Please restart OrcaSlicer and try again. "
-                            "If the problem persists, check your network connection.");
+            msg_text = _u8L("Connection to the printer failed. "
+                            "The networking plugin encountered an internal error. "
+                            "Please restart both your printer and OrcaSlicer to reconnect. "
+                            "If the problem persists, try printing via SD card instead.");
             BOOST_LOG_TRIVIAL(error) << "print_job: networking DLL crash detected, showing error to user";
         } else if (result == BAMBU_NETWORK_ERR_PRINT_WR_FILE_NOT_EXIST || result == BAMBU_NETWORK_ERR_PRINT_SP_FILE_NOT_EXIST) {
             msg_text = file_is_not_exists_str;

--- a/src/slic3r/GUI/Jobs/SendJob.cpp
+++ b/src/slic3r/GUI/Jobs/SendJob.cpp
@@ -6,6 +6,7 @@
 #include "slic3r/GUI/GUI.hpp"
 #include "slic3r/GUI/GUI_App.hpp"
 #include "slic3r/GUI/format.hpp"
+#include "slic3r/Utils/DllCrashGuard.hpp"
 
 namespace Slic3r {
 namespace GUI {
@@ -328,10 +329,22 @@ void SendJob::process(Ctl &ctl)
         return;
     }
 
+    // Check if the networking DLL crashed asynchronously (e.g. on its MQTT thread)
+    if (g_networking_dll_crashed.load(std::memory_order_acquire)) {
+        BOOST_LOG_TRIVIAL(error) << "send_job: networking DLL crashed asynchronously: " << get_dll_crash_message();
+        result = -1;
+    }
+
     if (result < 0) {
         curr_percent = -1;
 
-        if (result == BAMBU_NETWORK_ERR_PRINT_WR_FILE_NOT_EXIST || result == BAMBU_NETWORK_ERR_PRINT_SP_FILE_NOT_EXIST) {
+        if (g_networking_dll_crashed.load(std::memory_order_acquire)) {
+            msg_text = _u8L("The networking plugin encountered an internal error (crash). "
+                            "Please restart OrcaSlicer and try again. "
+                            "If the problem persists, check your network connection.");
+            BOOST_LOG_TRIVIAL(error) << "send_job: networking DLL crash detected, showing error to user";
+        }
+        else if (result == BAMBU_NETWORK_ERR_PRINT_WR_FILE_NOT_EXIST || result == BAMBU_NETWORK_ERR_PRINT_SP_FILE_NOT_EXIST) {
             msg_text = file_is_not_exists_str;
         }
         else if (result == BAMBU_NETWORK_ERR_PRINT_SP_FILE_OVER_SIZE || result == BAMBU_NETWORK_ERR_PRINT_WR_FILE_OVER_SIZE) {

--- a/src/slic3r/GUI/Jobs/SendJob.cpp
+++ b/src/slic3r/GUI/Jobs/SendJob.cpp
@@ -262,6 +262,8 @@ void SendJob::process(Ctl &ctl)
                     };
 
     auto cancel_fn = [&ctl]() {
+            if (g_networking_dll_crashed.load(std::memory_order_acquire))
+                return true;
             return ctl.was_canceled();
         };
 
@@ -339,9 +341,10 @@ void SendJob::process(Ctl &ctl)
         curr_percent = -1;
 
         if (g_networking_dll_crashed.load(std::memory_order_acquire)) {
-            msg_text = _u8L("The networking plugin encountered an internal error (crash). "
-                            "Please restart OrcaSlicer and try again. "
-                            "If the problem persists, check your network connection.");
+            msg_text = _u8L("Connection to the printer failed. "
+                            "The networking plugin encountered an internal error. "
+                            "Please restart both your printer and OrcaSlicer to reconnect. "
+                            "If the problem persists, try printing via SD card instead.");
             BOOST_LOG_TRIVIAL(error) << "send_job: networking DLL crash detected, showing error to user";
         }
         else if (result == BAMBU_NETWORK_ERR_PRINT_WR_FILE_NOT_EXIST || result == BAMBU_NETWORK_ERR_PRINT_SP_FILE_NOT_EXIST) {

--- a/src/slic3r/Utils/BBLNetworkPlugin.cpp
+++ b/src/slic3r/Utils/BBLNetworkPlugin.cpp
@@ -1,5 +1,6 @@
 #include "BBLNetworkPlugin.hpp"
 #include "NetworkAgent.hpp"
+#include "DllCrashGuard.hpp"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -185,25 +186,33 @@ int BBLNetworkPlugin::unload()
 {
     UnloadFTModule();
 
+    // If the DLL is hung, dlclose/FreeLibrary while its threads are still
+    // running inside the library would be undefined behaviour (likely a crash
+    // or hang). The OS will clean up on process exit.
+    bool dll_is_hung = g_networking_dll_crashed.load(std::memory_order_acquire);
+    if (dll_is_hung) {
+        BOOST_LOG_TRIVIAL(warning) << "[DllGuard] BBLNetworkPlugin::unload: "
+                                      "skipping FreeLibrary/dlclose — DLL is hung "
+                                      "(threads still inside the library)";
+    } else {
 #if defined(_MSC_VER) || defined(_WIN32)
-    if (m_networking_module) {
-        FreeLibrary(m_networking_module);
-        m_networking_module = NULL;
-    }
-    if (m_source_module) {
-        FreeLibrary(m_source_module);
-        m_source_module = NULL;
-    }
+        if (m_networking_module) {
+            FreeLibrary(m_networking_module);
+        }
+        if (m_source_module) {
+            FreeLibrary(m_source_module);
+        }
 #else
-    if (m_networking_module) {
-        dlclose(m_networking_module);
-        m_networking_module = NULL;
-    }
-    if (m_source_module) {
-        dlclose(m_source_module);
-        m_source_module = NULL;
-    }
+        if (m_networking_module) {
+            dlclose(m_networking_module);
+        }
+        if (m_source_module) {
+            dlclose(m_source_module);
+        }
 #endif
+    }
+    m_networking_module = NULL;
+    m_source_module = NULL;
 
     clear_all_function_pointers();
 
@@ -258,7 +267,16 @@ int BBLNetworkPlugin::destroy_agent()
 {
     int ret = 0;
     if (m_agent && m_destroy_agent) {
-        ret = m_destroy_agent(m_agent);
+        // If the DLL is known to be hung (SIGSEGV on one of its threads),
+        // skip the call — it would deadlock and make the app unkillable.
+        // The OS will reclaim resources on process exit anyway.
+        if (g_networking_dll_crashed.load(std::memory_order_acquire)) {
+            BOOST_LOG_TRIVIAL(warning) << "[DllGuard] BBLNetworkPlugin::destroy_agent: "
+                                          "skipping m_destroy_agent — DLL is hung "
+                                          "(would deadlock on shutdown)";
+        } else {
+            ret = m_destroy_agent(m_agent);
+        }
     }
     m_agent = nullptr;
     return ret;

--- a/src/slic3r/Utils/BBLPrinterAgent.cpp
+++ b/src/slic3r/Utils/BBLPrinterAgent.cpp
@@ -1,6 +1,7 @@
 #include "BBLPrinterAgent.hpp"
 #include "BBLNetworkPlugin.hpp"
 #include "NetworkAgentFactory.hpp"
+#include "DllCrashGuard.hpp"
 
 #include <boost/log/trivial.hpp>
 
@@ -26,11 +27,13 @@ int BBLPrinterAgent::send_message(std::string dev_id, std::string json_str, int 
     auto agent = plugin.get_agent();
     auto func = plugin.get_send_message();
     if (func && agent) {
-        if (plugin.use_legacy_network()) {
-            auto legacy_func = reinterpret_cast<func_send_message_legacy>(func);
-            return legacy_func(agent, dev_id, json_str, qos);
-        }
-        return func(agent, dev_id, json_str, qos, flag);
+        return dll_safe_call([&]() -> int {
+            if (plugin.use_legacy_network()) {
+                auto legacy_func = reinterpret_cast<func_send_message_legacy>(func);
+                return legacy_func(agent, dev_id, json_str, qos);
+            }
+            return func(agent, dev_id, json_str, qos, flag);
+        }, -1, "send_message");
     }
     return -1;
 }
@@ -41,7 +44,9 @@ int BBLPrinterAgent::connect_printer(std::string dev_id, std::string dev_ip, std
     auto agent = plugin.get_agent();
     auto func = plugin.get_connect_printer();
     if (func && agent) {
-        return func(agent, dev_id, dev_ip, username, password, use_ssl);
+        return dll_safe_call([&]() -> int {
+            return func(agent, dev_id, dev_ip, username, password, use_ssl);
+        }, -1, "connect_printer");
     }
     return -1;
 }
@@ -52,7 +57,9 @@ int BBLPrinterAgent::disconnect_printer()
     auto agent = plugin.get_agent();
     auto func = plugin.get_disconnect_printer();
     if (func && agent) {
-        return func(agent);
+        return dll_safe_call([&]() -> int {
+            return func(agent);
+        }, -1, "disconnect_printer");
     }
     return -1;
 }
@@ -63,11 +70,13 @@ int BBLPrinterAgent::send_message_to_printer(std::string dev_id, std::string jso
     auto agent = plugin.get_agent();
     auto func = plugin.get_send_message_to_printer();
     if (func && agent) {
-        if (plugin.use_legacy_network()) {
-            auto legacy_func = reinterpret_cast<func_send_message_to_printer_legacy>(func);
-            return legacy_func(agent, dev_id, json_str, qos);
-        }
-        return func(agent, dev_id, json_str, qos, flag);
+        return dll_safe_call([&]() -> int {
+            if (plugin.use_legacy_network()) {
+                auto legacy_func = reinterpret_cast<func_send_message_to_printer_legacy>(func);
+                return legacy_func(agent, dev_id, json_str, qos);
+            }
+            return func(agent, dev_id, json_str, qos, flag);
+        }, -1, "send_message_to_printer");
     }
     return -1;
 }
@@ -82,7 +91,9 @@ int BBLPrinterAgent::check_cert()
     auto agent = plugin.get_agent();
     auto func = plugin.get_check_cert();
     if (func && agent) {
-        return func(agent);
+        return dll_safe_call([&]() -> int {
+            return func(agent);
+        }, -1, "check_cert");
     }
     return -1;
 }
@@ -93,7 +104,9 @@ void BBLPrinterAgent::install_device_cert(std::string dev_id, bool lan_only)
     auto agent = plugin.get_agent();
     auto func = plugin.get_install_device_cert();
     if (func && agent) {
-        func(agent, dev_id, lan_only);
+        dll_safe_call_void([&]() {
+            func(agent, dev_id, lan_only);
+        }, "install_device_cert");
     }
 }
 
@@ -144,7 +157,9 @@ int BBLPrinterAgent::bind(std::string dev_ip, std::string dev_id, std::string se
     auto agent = plugin.get_agent();
     auto func = plugin.get_bind();
     if (func && agent) {
-        return func(agent, dev_ip, dev_id, sec_link, timezone, improved, update_fn);
+        return dll_safe_call([&]() -> int {
+            return func(agent, dev_ip, dev_id, sec_link, timezone, improved, update_fn);
+        }, -1, "bind");
     }
     return -1;
 }
@@ -226,12 +241,14 @@ int BBLPrinterAgent::start_print(PrintParams params, OnUpdateStatusFn update_fn,
     auto agent = plugin.get_agent();
     auto func = plugin.get_start_print();
     if (func && agent) {
-        if (plugin.use_legacy_network()) {
-            auto legacy_func = reinterpret_cast<func_start_print_legacy>(func);
-            auto legacy_params = BBLNetworkPlugin::as_legacy(params);
-            return legacy_func(agent, legacy_params, update_fn, cancel_fn, wait_fn);
-        }
-        return func(agent, params, update_fn, cancel_fn, wait_fn);
+        return dll_safe_call([&]() -> int {
+            if (plugin.use_legacy_network()) {
+                auto legacy_func = reinterpret_cast<func_start_print_legacy>(func);
+                auto legacy_params = BBLNetworkPlugin::as_legacy(params);
+                return legacy_func(agent, legacy_params, update_fn, cancel_fn, wait_fn);
+            }
+            return func(agent, params, update_fn, cancel_fn, wait_fn);
+        }, -1, "start_print");
     }
     return -1;
 }
@@ -242,12 +259,14 @@ int BBLPrinterAgent::start_local_print_with_record(PrintParams params, OnUpdateS
     auto agent = plugin.get_agent();
     auto func = plugin.get_start_local_print_with_record();
     if (func && agent) {
-        if (plugin.use_legacy_network()) {
-            auto legacy_func = reinterpret_cast<func_start_local_print_with_record_legacy>(func);
-            auto legacy_params = BBLNetworkPlugin::as_legacy(params);
-            return legacy_func(agent, legacy_params, update_fn, cancel_fn, wait_fn);
-        }
-        return func(agent, params, update_fn, cancel_fn, wait_fn);
+        return dll_safe_call([&]() -> int {
+            if (plugin.use_legacy_network()) {
+                auto legacy_func = reinterpret_cast<func_start_local_print_with_record_legacy>(func);
+                auto legacy_params = BBLNetworkPlugin::as_legacy(params);
+                return legacy_func(agent, legacy_params, update_fn, cancel_fn, wait_fn);
+            }
+            return func(agent, params, update_fn, cancel_fn, wait_fn);
+        }, -1, "start_local_print_with_record");
     }
     return -1;
 }
@@ -258,12 +277,14 @@ int BBLPrinterAgent::start_send_gcode_to_sdcard(PrintParams params, OnUpdateStat
     auto agent = plugin.get_agent();
     auto func = plugin.get_start_send_gcode_to_sdcard();
     if (func && agent) {
-        if (plugin.use_legacy_network()) {
-            auto legacy_func = reinterpret_cast<func_start_send_gcode_to_sdcard_legacy>(func);
-            auto legacy_params = BBLNetworkPlugin::as_legacy(params);
-            return legacy_func(agent, legacy_params, update_fn, cancel_fn, wait_fn);
-        }
-        return func(agent, params, update_fn, cancel_fn, wait_fn);
+        return dll_safe_call([&]() -> int {
+            if (plugin.use_legacy_network()) {
+                auto legacy_func = reinterpret_cast<func_start_send_gcode_to_sdcard_legacy>(func);
+                auto legacy_params = BBLNetworkPlugin::as_legacy(params);
+                return legacy_func(agent, legacy_params, update_fn, cancel_fn, wait_fn);
+            }
+            return func(agent, params, update_fn, cancel_fn, wait_fn);
+        }, -1, "start_send_gcode_to_sdcard");
     }
     return -1;
 }
@@ -274,12 +295,14 @@ int BBLPrinterAgent::start_local_print(PrintParams params, OnUpdateStatusFn upda
     auto agent = plugin.get_agent();
     auto func = plugin.get_start_local_print();
     if (func && agent) {
-        if (plugin.use_legacy_network()) {
-            auto legacy_func = reinterpret_cast<func_start_local_print_legacy>(func);
-            auto legacy_params = BBLNetworkPlugin::as_legacy(params);
-            return legacy_func(agent, legacy_params, update_fn, cancel_fn);
-        }
-        return func(agent, params, update_fn, cancel_fn);
+        return dll_safe_call([&]() -> int {
+            if (plugin.use_legacy_network()) {
+                auto legacy_func = reinterpret_cast<func_start_local_print_legacy>(func);
+                auto legacy_params = BBLNetworkPlugin::as_legacy(params);
+                return legacy_func(agent, legacy_params, update_fn, cancel_fn);
+            }
+            return func(agent, params, update_fn, cancel_fn);
+        }, -1, "start_local_print");
     }
     return -1;
 }
@@ -290,12 +313,14 @@ int BBLPrinterAgent::start_sdcard_print(PrintParams params, OnUpdateStatusFn upd
     auto agent = plugin.get_agent();
     auto func = plugin.get_start_sdcard_print();
     if (func && agent) {
-        if (plugin.use_legacy_network()) {
-            auto legacy_func = reinterpret_cast<func_start_sdcard_print_legacy>(func);
-            auto legacy_params = BBLNetworkPlugin::as_legacy(params);
-            return legacy_func(agent, legacy_params, update_fn, cancel_fn);
-        }
-        return func(agent, params, update_fn, cancel_fn);
+        return dll_safe_call([&]() -> int {
+            if (plugin.use_legacy_network()) {
+                auto legacy_func = reinterpret_cast<func_start_sdcard_print_legacy>(func);
+                auto legacy_params = BBLNetworkPlugin::as_legacy(params);
+                return legacy_func(agent, legacy_params, update_fn, cancel_fn);
+            }
+            return func(agent, params, update_fn, cancel_fn);
+        }, -1, "start_sdcard_print");
     }
     return -1;
 }

--- a/src/slic3r/Utils/DllCrashGuard.cpp
+++ b/src/slic3r/Utils/DllCrashGuard.cpp
@@ -101,7 +101,8 @@ void install_dll_crash_handler()
     std::call_once(s_handler_installed, []() {
         // Use sigaltstack so our handler has its own stack
         // (in case the crash corrupted the thread's stack)
-        static char alt_stack[SIGSTKSZ * 2];
+        // Use a fixed size because SIGSTKSZ may not be constexpr on some platforms (e.g. glibc 2.34+)
+        static char alt_stack[65536];
         stack_t ss;
         ss.ss_sp = alt_stack;
         ss.ss_size = sizeof(alt_stack);
@@ -253,23 +254,30 @@ void install_dll_crash_handler()
     });
 }
 
+// MSVC does not allow __try and C++ try/catch in the same function (C2712/C2713).
+// Split into two functions: inner does C++ exception handling, outer does SEH.
+static int dll_safe_call_cpp(std::function<int()>& fn, int fallback, const char* context)
+{
+    try {
+        return fn();
+    } catch (const std::exception& e) {
+        BOOST_LOG_TRIVIAL(error) << "DllCrashGuard: C++ exception in " << context << ": " << e.what();
+        set_crash_message(std::string("Exception in ") + context + ": " + e.what());
+        return fallback;
+    } catch (...) {
+        BOOST_LOG_TRIVIAL(error) << "DllCrashGuard: unknown C++ exception in " << context;
+        set_crash_message(std::string("Unknown exception in ") + context);
+        return fallback;
+    }
+}
+
 int dll_safe_call_impl(std::function<int()> fn, int fallback, const char* context)
 {
     // Layer 1: SEH protection — catches access violations from DLL calls we initiate.
-    // Layer 2: C++ exception protection.
     int result = fallback;
     __try {
-        try {
-            result = fn();
-        } catch (const std::exception& e) {
-            BOOST_LOG_TRIVIAL(error) << "DllCrashGuard: C++ exception in " << context << ": " << e.what();
-            set_crash_message(std::string("Exception in ") + context + ": " + e.what());
-            result = fallback;
-        } catch (...) {
-            BOOST_LOG_TRIVIAL(error) << "DllCrashGuard: unknown C++ exception in " << context;
-            set_crash_message(std::string("Unknown exception in ") + context);
-            result = fallback;
-        }
+        // Layer 2: C++ exception protection (in separate function for MSVC compatibility).
+        result = dll_safe_call_cpp(fn, fallback, context);
     } __except (
         GetExceptionCode() == EXCEPTION_ACCESS_VIOLATION ? EXCEPTION_EXECUTE_HANDLER : EXCEPTION_CONTINUE_SEARCH
     ) {

--- a/src/slic3r/Utils/DllCrashGuard.cpp
+++ b/src/slic3r/Utils/DllCrashGuard.cpp
@@ -1,0 +1,289 @@
+#include "DllCrashGuard.hpp"
+
+#include <mutex>
+#include <cstring>
+
+#include <boost/log/trivial.hpp>
+
+#if defined(_MSC_VER) || defined(_WIN32)
+    #define DLL_CRASH_GUARD_WINDOWS 1
+    #include <windows.h>
+#else
+    #define DLL_CRASH_GUARD_POSIX 1
+    #include <signal.h>
+    #include <setjmp.h>
+    #include <pthread.h>
+    #include <unistd.h>
+#endif
+
+namespace Slic3r {
+
+// ============================================================================
+// Global state
+// ============================================================================
+
+std::atomic<bool> g_networking_dll_crashed{false};
+
+static std::mutex  s_crash_msg_mutex;
+static std::string s_crash_message;
+static std::once_flag s_handler_installed;
+
+std::string get_dll_crash_message()
+{
+    std::lock_guard<std::mutex> lock(s_crash_msg_mutex);
+    return s_crash_message;
+}
+
+static void set_crash_message(const std::string& msg)
+{
+    std::lock_guard<std::mutex> lock(s_crash_msg_mutex);
+    s_crash_message = msg;
+}
+
+// ============================================================================
+// POSIX implementation (macOS / Linux)
+// ============================================================================
+
+#if DLL_CRASH_GUARD_POSIX
+
+// Thread-local jump buffer for recovering from SIGSEGV in DLL calls we initiate.
+// When dll_safe_call_impl sets this, our SIGSEGV handler will longjmp back instead of crashing.
+static thread_local sigjmp_buf* tl_recovery_point = nullptr;
+
+// Previous SIGSEGV handler, so we can chain if the crash isn't from our DLL call.
+static struct sigaction s_old_sigsegv_action;
+
+static void sigsegv_handler(int sig, siginfo_t* info, void* ucontext)
+{
+    // Case 1: We're inside a dll_safe_call — recover via longjmp
+    if (tl_recovery_point) {
+        siglongjmp(*tl_recovery_point, 1);
+        // unreachable
+    }
+
+    // Case 2: Crash on a DLL-owned thread (e.g. MQTTAsync_sendThread).
+    // We can't recover this thread, but we can flag the crash and try to
+    // terminate just this thread instead of the whole process.
+    //
+    // Note: pthread_exit is not async-signal-safe, but in practice it works
+    // on macOS and Linux for this use case. The alternative is process death.
+
+    // Write a minimal message (write() is async-signal-safe)
+    const char crash_msg[] = "DllCrashGuard: SIGSEGV caught on DLL thread, terminating thread.\n";
+    (void)write(STDERR_FILENO, crash_msg, sizeof(crash_msg) - 1);
+
+    g_networking_dll_crashed.store(true, std::memory_order_release);
+
+    // Attempt to terminate just this thread.
+    // This is a best-effort recovery — it may not always work cleanly.
+    pthread_exit(nullptr);
+
+    // If pthread_exit somehow returns (shouldn't happen), fall through to the
+    // previous handler or default behavior.
+    if (s_old_sigsegv_action.sa_flags & SA_SIGINFO) {
+        if (s_old_sigsegv_action.sa_sigaction)
+            s_old_sigsegv_action.sa_sigaction(sig, info, ucontext);
+    } else {
+        if (s_old_sigsegv_action.sa_handler != SIG_DFL &&
+            s_old_sigsegv_action.sa_handler != SIG_IGN)
+        {
+            s_old_sigsegv_action.sa_handler(sig);
+        } else {
+            // Re-raise with default handler
+            signal(sig, SIG_DFL);
+            raise(sig);
+        }
+    }
+}
+
+void install_dll_crash_handler()
+{
+    std::call_once(s_handler_installed, []() {
+        // Use sigaltstack so our handler has its own stack
+        // (in case the crash corrupted the thread's stack)
+        static char alt_stack[SIGSTKSZ * 2];
+        stack_t ss;
+        ss.ss_sp = alt_stack;
+        ss.ss_size = sizeof(alt_stack);
+        ss.ss_flags = 0;
+        sigaltstack(&ss, nullptr);
+
+        struct sigaction sa;
+        memset(&sa, 0, sizeof(sa));
+        sa.sa_sigaction = sigsegv_handler;
+        sa.sa_flags = SA_SIGINFO | SA_ONSTACK;
+        sigemptyset(&sa.sa_mask);
+
+        if (sigaction(SIGSEGV, &sa, &s_old_sigsegv_action) != 0) {
+            BOOST_LOG_TRIVIAL(error) << "DllCrashGuard: failed to install SIGSEGV handler";
+        } else {
+            BOOST_LOG_TRIVIAL(info) << "DllCrashGuard: SIGSEGV handler installed for DLL crash protection";
+        }
+
+        // Also handle SIGBUS (common on macOS for similar memory access issues)
+        struct sigaction sa_bus;
+        memset(&sa_bus, 0, sizeof(sa_bus));
+        sa_bus.sa_sigaction = sigsegv_handler;
+        sa_bus.sa_flags = SA_SIGINFO | SA_ONSTACK;
+        sigemptyset(&sa_bus.sa_mask);
+        sigaction(SIGBUS, &sa_bus, nullptr);
+    });
+}
+
+int dll_safe_call_impl(std::function<int()> fn, int fallback, const char* context)
+{
+    // Layer 1: Signal protection (SIGSEGV / SIGBUS)
+    sigjmp_buf jmpbuf;
+    sigjmp_buf* old_recovery = tl_recovery_point;
+    tl_recovery_point = &jmpbuf;
+
+    int result = fallback;
+
+    if (sigsetjmp(jmpbuf, 1) == 0) {
+        // Normal execution path
+        try {
+            // Layer 2: C++ exception protection
+            result = fn();
+        } catch (const std::exception& e) {
+            BOOST_LOG_TRIVIAL(error) << "DllCrashGuard: C++ exception in " << context << ": " << e.what();
+            set_crash_message(std::string("Exception in ") + context + ": " + e.what());
+            result = fallback;
+        } catch (...) {
+            BOOST_LOG_TRIVIAL(error) << "DllCrashGuard: unknown C++ exception in " << context;
+            set_crash_message(std::string("Unknown exception in ") + context);
+            result = fallback;
+        }
+    } else {
+        // Recovered from SIGSEGV/SIGBUS via siglongjmp
+        BOOST_LOG_TRIVIAL(error) << "DllCrashGuard: RECOVERED from crash (SIGSEGV/SIGBUS) in " << context
+                                 << " — the networking DLL has a bug. Returning error code.";
+        set_crash_message(std::string("Crash recovered in ") + context +
+                         ": the Bambu networking library crashed (SIGSEGV). "
+                         "This is a bug in the networking plugin.");
+        g_networking_dll_crashed.store(true, std::memory_order_release);
+        result = fallback;
+    }
+
+    tl_recovery_point = old_recovery;
+    return result;
+}
+
+#endif // DLL_CRASH_GUARD_POSIX
+
+// ============================================================================
+// Windows implementation
+// ============================================================================
+
+#if DLL_CRASH_GUARD_WINDOWS
+
+// Check if a faulting address belongs to the Bambu networking DLL.
+static bool is_bambu_dll_address(void* addr)
+{
+    HMODULE hmod = nullptr;
+    GetModuleHandleExW(
+        GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+        (LPCWSTR)addr,
+        &hmod);
+    if (!hmod)
+        return false;
+
+    char modname[MAX_PATH] = {};
+    GetModuleFileNameA(hmod, modname, sizeof(modname));
+    return (strstr(modname, "bambu_networking") ||
+            strstr(modname, "BambuSource") ||
+            strstr(modname, "bambu_network"));
+}
+
+// Vectored Exception Handler: called BEFORE frame-based handlers on ALL threads.
+// If the crash is inside the Bambu networking DLL, we flag it and redirect the
+// crashing thread to ExitThread() so only that thread dies, not the whole process.
+static LONG WINAPI dll_vectored_handler(EXCEPTION_POINTERS* ep)
+{
+    if (ep->ExceptionRecord->ExceptionCode != EXCEPTION_ACCESS_VIOLATION)
+        return EXCEPTION_CONTINUE_SEARCH;
+
+    if (!is_bambu_dll_address(ep->ExceptionRecord->ExceptionAddress))
+        return EXCEPTION_CONTINUE_SEARCH;
+
+    // The crash is inside the Bambu DLL. Flag it and terminate only this thread.
+    g_networking_dll_crashed.store(true, std::memory_order_release);
+
+    char modname[MAX_PATH] = {};
+    {
+        HMODULE hmod = nullptr;
+        GetModuleHandleExW(
+            GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+            (LPCWSTR)ep->ExceptionRecord->ExceptionAddress,
+            &hmod);
+        if (hmod)
+            GetModuleFileNameA(hmod, modname, sizeof(modname));
+    }
+
+    BOOST_LOG_TRIVIAL(error) << "DllCrashGuard: Access violation in DLL module: " << modname
+                             << " at address " << ep->ExceptionRecord->ExceptionAddress
+                             << " — terminating DLL thread to prevent app crash.";
+    set_crash_message(std::string("Access violation in DLL: ") + modname);
+
+    // Redirect execution to ExitThread(1) so only this thread terminates.
+    // We overwrite the instruction pointer in the exception context.
+#ifdef _M_X64
+    ep->ContextRecord->Rip = (DWORD64)ExitThread;
+    ep->ContextRecord->Rcx = 1;  // ExitThread argument (exit code)
+#elif defined(_M_ARM64)
+    ep->ContextRecord->Pc = (DWORD64)ExitThread;
+    ep->ContextRecord->X0 = 1;
+#else
+    // x86 fallback: push exit code on stack and jump to ExitThread
+    ep->ContextRecord->Esp -= sizeof(DWORD);
+    *(DWORD*)ep->ContextRecord->Esp = 1;
+    ep->ContextRecord->Eip = (DWORD)ExitThread;
+#endif
+
+    return EXCEPTION_CONTINUE_EXECUTION;
+}
+
+void install_dll_crash_handler()
+{
+    std::call_once(s_handler_installed, []() {
+        // Use a Vectored Exception Handler (first-chance) so we intercept
+        // crashes on DLL-owned threads before any frame-based handler runs.
+        // The '1' means "add to front of the VEH chain".
+        AddVectoredExceptionHandler(1, dll_vectored_handler);
+        BOOST_LOG_TRIVIAL(info) << "DllCrashGuard: Vectored exception handler installed for DLL crash protection";
+    });
+}
+
+int dll_safe_call_impl(std::function<int()> fn, int fallback, const char* context)
+{
+    // Layer 1: SEH protection — catches access violations from DLL calls we initiate.
+    // Layer 2: C++ exception protection.
+    int result = fallback;
+    __try {
+        try {
+            result = fn();
+        } catch (const std::exception& e) {
+            BOOST_LOG_TRIVIAL(error) << "DllCrashGuard: C++ exception in " << context << ": " << e.what();
+            set_crash_message(std::string("Exception in ") + context + ": " + e.what());
+            result = fallback;
+        } catch (...) {
+            BOOST_LOG_TRIVIAL(error) << "DllCrashGuard: unknown C++ exception in " << context;
+            set_crash_message(std::string("Unknown exception in ") + context);
+            result = fallback;
+        }
+    } __except (
+        GetExceptionCode() == EXCEPTION_ACCESS_VIOLATION ? EXCEPTION_EXECUTE_HANDLER : EXCEPTION_CONTINUE_SEARCH
+    ) {
+        BOOST_LOG_TRIVIAL(error) << "DllCrashGuard: RECOVERED from access violation (SEH) in " << context
+                                 << " — the networking DLL has a bug. Returning error code.";
+        set_crash_message(std::string("Crash recovered in ") + context +
+                         ": the Bambu networking library crashed (access violation). "
+                         "This is a bug in the networking plugin.");
+        g_networking_dll_crashed.store(true, std::memory_order_release);
+        result = fallback;
+    }
+    return result;
+}
+
+#endif // DLL_CRASH_GUARD_WINDOWS
+
+} // namespace Slic3r

--- a/src/slic3r/Utils/DllCrashGuard.cpp
+++ b/src/slic3r/Utils/DllCrashGuard.cpp
@@ -254,10 +254,13 @@ void install_dll_crash_handler()
     });
 }
 
-// MSVC does not allow __try and C++ try/catch in the same function (C2712/C2713).
-// Split into two functions: inner does C++ exception handling, outer does SEH.
-static int dll_safe_call_cpp(std::function<int()>& fn, int fallback, const char* context)
+// MSVC does not allow __try in any function that has objects requiring unwinding (C2712).
+// The SEH wrapper must be a plain C-style function with no C++ objects on the stack.
+// We pass everything through raw pointers.
+
+static int dll_safe_call_cpp(void* fn_ptr, int fallback, const char* context)
 {
+    auto& fn = *static_cast<std::function<int()>*>(fn_ptr);
     try {
         return fn();
     } catch (const std::exception& e) {
@@ -271,23 +274,30 @@ static int dll_safe_call_cpp(std::function<int()>& fn, int fallback, const char*
     }
 }
 
-int dll_safe_call_impl(std::function<int()> fn, int fallback, const char* context)
+// SEH wrapper: no C++ objects with destructors allowed in this function.
+static int dll_safe_call_seh(void* fn_ptr, int fallback, const char* context)
 {
-    // Layer 1: SEH protection — catches access violations from DLL calls we initiate.
     int result = fallback;
     __try {
-        // Layer 2: C++ exception protection (in separate function for MSVC compatibility).
-        result = dll_safe_call_cpp(fn, fallback, context);
+        result = dll_safe_call_cpp(fn_ptr, fallback, context);
     } __except (
         GetExceptionCode() == EXCEPTION_ACCESS_VIOLATION ? EXCEPTION_EXECUTE_HANDLER : EXCEPTION_CONTINUE_SEARCH
     ) {
+        g_networking_dll_crashed.store(true, std::memory_order_release);
+        result = fallback;
+    }
+    return result;
+}
+
+int dll_safe_call_impl(std::function<int()> fn, int fallback, const char* context)
+{
+    int result = dll_safe_call_seh(&fn, fallback, context);
+    if (g_networking_dll_crashed.load(std::memory_order_acquire)) {
         BOOST_LOG_TRIVIAL(error) << "DllCrashGuard: RECOVERED from access violation (SEH) in " << context
                                  << " — the networking DLL has a bug. Returning error code.";
         set_crash_message(std::string("Crash recovered in ") + context +
                          ": the Bambu networking library crashed (access violation). "
                          "This is a bug in the networking plugin.");
-        g_networking_dll_crashed.store(true, std::memory_order_release);
-        result = fallback;
     }
     return result;
 }

--- a/src/slic3r/Utils/DllCrashGuard.cpp
+++ b/src/slic3r/Utils/DllCrashGuard.cpp
@@ -2,6 +2,9 @@
 
 #include <mutex>
 #include <cstring>
+#include <chrono>
+#include <future>
+#include <thread>
 
 #include <boost/log/trivial.hpp>
 
@@ -131,9 +134,8 @@ void install_dll_crash_handler()
     });
 }
 
-int dll_safe_call_impl(std::function<int()> fn, int fallback, const char* context)
+static int dll_safe_call_direct(std::function<int()>& fn, int fallback, const char* context)
 {
-    // Layer 1: Signal protection (SIGSEGV / SIGBUS)
     sigjmp_buf jmpbuf;
     sigjmp_buf* old_recovery = tl_recovery_point;
     tl_recovery_point = &jmpbuf;
@@ -141,9 +143,7 @@ int dll_safe_call_impl(std::function<int()> fn, int fallback, const char* contex
     int result = fallback;
 
     if (sigsetjmp(jmpbuf, 1) == 0) {
-        // Normal execution path
         try {
-            // Layer 2: C++ exception protection
             result = fn();
         } catch (const std::exception& e) {
             BOOST_LOG_TRIVIAL(error) << "DllCrashGuard: C++ exception in " << context << ": " << e.what();
@@ -155,9 +155,7 @@ int dll_safe_call_impl(std::function<int()> fn, int fallback, const char* contex
             result = fallback;
         }
     } else {
-        // Recovered from SIGSEGV/SIGBUS via siglongjmp
-        BOOST_LOG_TRIVIAL(error) << "DllCrashGuard: RECOVERED from crash (SIGSEGV/SIGBUS) in " << context
-                                 << " — the networking DLL has a bug. Returning error code.";
+        BOOST_LOG_TRIVIAL(error) << "DllCrashGuard: RECOVERED from crash (SIGSEGV/SIGBUS) in " << context;
         set_crash_message(std::string("Crash recovered in ") + context +
                          ": the Bambu networking library crashed (SIGSEGV). "
                          "This is a bug in the networking plugin.");
@@ -167,6 +165,31 @@ int dll_safe_call_impl(std::function<int()> fn, int fallback, const char* contex
 
     tl_recovery_point = old_recovery;
     return result;
+}
+
+static constexpr int DLL_CALL_TIMEOUT_SECONDS = 15;
+
+int dll_safe_call_impl(std::function<int()> fn, int fallback, const char* context)
+{
+    auto promise = std::make_shared<std::promise<int>>();
+    auto future = promise->get_future();
+
+    auto fn_copy = std::make_shared<std::function<int()>>(std::move(fn));
+
+    std::thread([promise, fn_copy, fallback, context]() {
+        promise->set_value(dll_safe_call_direct(*fn_copy, fallback, context));
+    }).detach();
+
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(DLL_CALL_TIMEOUT_SECONDS);
+
+    if (future.wait_until(deadline) == std::future_status::ready)
+        return future.get();
+
+    BOOST_LOG_TRIVIAL(error) << "DllCrashGuard: " << context << " timed out after " << DLL_CALL_TIMEOUT_SECONDS << "s";
+    g_networking_dll_crashed.store(true, std::memory_order_release);
+    set_crash_message(std::string("The networking plugin stopped responding during ") + context +
+                     ". The operation was aborted to prevent the application from freezing.");
+    return fallback;
 }
 
 #endif // DLL_CRASH_GUARD_POSIX
@@ -289,17 +312,41 @@ static int dll_safe_call_seh(void* fn_ptr, int fallback, const char* context)
     return result;
 }
 
-int dll_safe_call_impl(std::function<int()> fn, int fallback, const char* context)
+static int dll_safe_call_direct_win(std::function<int()>& fn, int fallback, const char* context)
 {
     int result = dll_safe_call_seh(&fn, fallback, context);
     if (g_networking_dll_crashed.load(std::memory_order_acquire)) {
-        BOOST_LOG_TRIVIAL(error) << "DllCrashGuard: RECOVERED from access violation (SEH) in " << context
-                                 << " — the networking DLL has a bug. Returning error code.";
+        BOOST_LOG_TRIVIAL(error) << "DllCrashGuard: RECOVERED from access violation (SEH) in " << context;
         set_crash_message(std::string("Crash recovered in ") + context +
                          ": the Bambu networking library crashed (access violation). "
                          "This is a bug in the networking plugin.");
     }
     return result;
+}
+
+static constexpr int DLL_CALL_TIMEOUT_SECONDS = 15;
+
+int dll_safe_call_impl(std::function<int()> fn, int fallback, const char* context)
+{
+    auto promise = std::make_shared<std::promise<int>>();
+    auto future = promise->get_future();
+
+    auto fn_copy = std::make_shared<std::function<int()>>(std::move(fn));
+
+    std::thread([promise, fn_copy, fallback, context]() {
+        promise->set_value(dll_safe_call_direct_win(*fn_copy, fallback, context));
+    }).detach();
+
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(DLL_CALL_TIMEOUT_SECONDS);
+
+    if (future.wait_until(deadline) == std::future_status::ready)
+        return future.get();
+
+    BOOST_LOG_TRIVIAL(error) << "DllCrashGuard: " << context << " timed out after " << DLL_CALL_TIMEOUT_SECONDS << "s";
+    g_networking_dll_crashed.store(true, std::memory_order_release);
+    set_crash_message(std::string("The networking plugin stopped responding during ") + context +
+                     ". The operation was aborted to prevent the application from freezing.");
+    return fallback;
 }
 
 #endif // DLL_CRASH_GUARD_WINDOWS

--- a/src/slic3r/Utils/DllCrashGuard.cpp
+++ b/src/slic3r/Utils/DllCrashGuard.cpp
@@ -27,6 +27,13 @@ namespace Slic3r {
 
 std::atomic<bool> g_networking_dll_crashed{false};
 
+// Counter for SIGSEGV events that fired on DLL-owned threads (where we can't
+// call boost::log because the thread is being terminated via pthread_exit and
+// boost::log isn't async-signal-safe). The next call into dll_safe_call_impl
+// drains this counter and emits a proper log line, so we can see in the log
+// that a crash happened even though the signal handler can't log directly.
+std::atomic<int> g_pending_sigsegv_log_count{0};
+
 static std::mutex  s_crash_msg_mutex;
 static std::string s_crash_message;
 static std::once_flag s_handler_installed;
@@ -41,6 +48,28 @@ static void set_crash_message(const std::string& msg)
 {
     std::lock_guard<std::mutex> lock(s_crash_msg_mutex);
     s_crash_message = msg;
+}
+
+// ============================================================================
+// Timeout policy (shared between POSIX and Windows)
+// ============================================================================
+
+// Fast timeout for short DLL calls (MQTT connect/disconnect, send_message etc.).
+// Healthy calls return in 0–4ms. 500ms means the UI never blocks noticeably
+// even if the DLL is internally hung after a SIGSEGV in one of its threads.
+static constexpr int DLL_CALL_TIMEOUT_FAST_MS = 500;
+// Slow timeout for operations that legitimately take a long time, e.g. sending
+// a gcode file to the printer (can be tens of MBs).
+static constexpr int DLL_CALL_TIMEOUT_SLOW_MS = 60000;
+
+// Return the appropriate timeout in ms for the given call context name.
+static int timeout_ms_for_context(const char* context)
+{
+    if (!context) return DLL_CALL_TIMEOUT_FAST_MS;
+    if (strncmp(context, "start_", 6) == 0)      return DLL_CALL_TIMEOUT_SLOW_MS;
+    if (strcmp(context, "bind") == 0)            return DLL_CALL_TIMEOUT_SLOW_MS;
+    if (strcmp(context, "install_device_cert") == 0) return DLL_CALL_TIMEOUT_SLOW_MS;
+    return DLL_CALL_TIMEOUT_FAST_MS;
 }
 
 // ============================================================================
@@ -76,6 +105,9 @@ static void sigsegv_handler(int sig, siginfo_t* info, void* ucontext)
     (void)write(STDERR_FILENO, crash_msg, sizeof(crash_msg) - 1);
 
     g_networking_dll_crashed.store(true, std::memory_order_release);
+    // Increment async-signal-safe counter. The next dll_safe_call_impl invocation
+    // (or anyone polling) drains it and emits a proper boost::log entry.
+    g_pending_sigsegv_log_count.fetch_add(1, std::memory_order_release);
 
     // Attempt to terminate just this thread.
     // This is a best-effort recovery — it may not always work cleanly.
@@ -155,7 +187,8 @@ static int dll_safe_call_direct(std::function<int()>& fn, int fallback, const ch
             result = fallback;
         }
     } else {
-        BOOST_LOG_TRIVIAL(error) << "DllCrashGuard: RECOVERED from crash (SIGSEGV/SIGBUS) in " << context;
+        BOOST_LOG_TRIVIAL(error) << "[DllGuard] SIGSEGV/SIGBUS RECOVERED in context=" << context
+                                 << " — setting crash flag";
         set_crash_message(std::string("Crash recovered in ") + context +
                          ": the Bambu networking library crashed (SIGSEGV). "
                          "This is a bug in the networking plugin.");
@@ -167,25 +200,48 @@ static int dll_safe_call_direct(std::function<int()>& fn, int fallback, const ch
     return result;
 }
 
-static constexpr int DLL_CALL_TIMEOUT_SECONDS = 15;
-
 int dll_safe_call_impl(std::function<int()> fn, int fallback, const char* context)
 {
+    // Drain deferred SIGSEGV log events: the signal handler can't call
+    // boost::log safely, so it bumps a counter; we log it here.
+    int pending = g_pending_sigsegv_log_count.exchange(0, std::memory_order_acq_rel);
+    if (pending > 0) {
+        BOOST_LOG_TRIVIAL(error) << "[DllGuard] !!! DEFERRED LOG: " << pending
+                                 << " SIGSEGV(s) caught on DLL-owned thread(s) "
+                                 << "(MQTT or similar) — crash flag was set by signal handler";
+    }
+
+    bool flag_was_set = g_networking_dll_crashed.load(std::memory_order_acquire);
+
+    // Fast-path: once the DLL has crashed/hung, every subsequent call would
+    // also potentially block until the timeout. Skip them entirely.
+    if (flag_was_set) {
+        BOOST_LOG_TRIVIAL(warning) << "[DllGuard] SKIP (flag latched) context=" << context;
+        return fallback;
+    }
+
+    int timeout_ms = timeout_ms_for_context(context);
+
     auto promise = std::make_shared<std::promise<int>>();
     auto future = promise->get_future();
 
     auto fn_copy = std::make_shared<std::function<int()>>(std::move(fn));
 
     std::thread([promise, fn_copy, fallback, context]() {
-        promise->set_value(dll_safe_call_direct(*fn_copy, fallback, context));
+        int r = dll_safe_call_direct(*fn_copy, fallback, context);
+        // The promise may be the only reference; if dll_safe_call_impl already
+        // returned (timeout case), set_value is a no-op for the abandoned
+        // future and the result is simply dropped.
+        try { promise->set_value(r); } catch (...) {}
     }).detach();
 
-    auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(DLL_CALL_TIMEOUT_SECONDS);
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout_ms);
 
     if (future.wait_until(deadline) == std::future_status::ready)
         return future.get();
 
-    BOOST_LOG_TRIVIAL(error) << "DllCrashGuard: " << context << " timed out after " << DLL_CALL_TIMEOUT_SECONDS << "s";
+    BOOST_LOG_TRIVIAL(error) << "[DllGuard] TIMEOUT context=" << context
+                             << " (limit_ms=" << timeout_ms << ") — setting crash flag";
     g_networking_dll_crashed.store(true, std::memory_order_release);
     set_crash_message(std::string("The networking plugin stopped responding during ") + context +
                      ". The operation was aborted to prevent the application from freezing.");
@@ -324,25 +380,32 @@ static int dll_safe_call_direct_win(std::function<int()>& fn, int fallback, cons
     return result;
 }
 
-static constexpr int DLL_CALL_TIMEOUT_SECONDS = 15;
-
 int dll_safe_call_impl(std::function<int()> fn, int fallback, const char* context)
 {
+    // Fast-path: once the DLL has crashed/hung, every subsequent call would
+    // also potentially block until the timeout. Skip them.
+    if (g_networking_dll_crashed.load(std::memory_order_acquire))
+        return fallback;
+
+    int timeout_ms = timeout_ms_for_context(context);
+
     auto promise = std::make_shared<std::promise<int>>();
     auto future = promise->get_future();
 
     auto fn_copy = std::make_shared<std::function<int()>>(std::move(fn));
 
     std::thread([promise, fn_copy, fallback, context]() {
-        promise->set_value(dll_safe_call_direct_win(*fn_copy, fallback, context));
+        int r = dll_safe_call_direct_win(*fn_copy, fallback, context);
+        try { promise->set_value(r); } catch (...) {}
     }).detach();
 
-    auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(DLL_CALL_TIMEOUT_SECONDS);
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout_ms);
 
     if (future.wait_until(deadline) == std::future_status::ready)
         return future.get();
 
-    BOOST_LOG_TRIVIAL(error) << "DllCrashGuard: " << context << " timed out after " << DLL_CALL_TIMEOUT_SECONDS << "s";
+    BOOST_LOG_TRIVIAL(error) << "[DllGuard] TIMEOUT context=" << context
+                             << " (limit_ms=" << timeout_ms << ") — setting crash flag";
     g_networking_dll_crashed.store(true, std::memory_order_release);
     set_crash_message(std::string("The networking plugin stopped responding during ") + context +
                      ". The operation was aborted to prevent the application from freezing.");

--- a/src/slic3r/Utils/DllCrashGuard.hpp
+++ b/src/slic3r/Utils/DllCrashGuard.hpp
@@ -1,0 +1,81 @@
+#ifndef SLIC3R_DLL_CRASH_GUARD_HPP
+#define SLIC3R_DLL_CRASH_GUARD_HPP
+
+// DllCrashGuard: Defensive wrapper for calls into external DLLs (e.g. libbambu_networking)
+// that may crash with SIGSEGV/access violations due to bugs in the DLL.
+//
+// Two layers of protection:
+// 1. DllSafeCall: wraps individual DLL calls with signal/SEH protection + try-catch
+// 2. install_dll_crash_handler(): global signal handler that catches crashes on DLL-owned
+//    threads (e.g. MQTTAsync_sendThread) and prevents process termination.
+
+#include <atomic>
+#include <functional>
+#include <string>
+
+#include <boost/log/trivial.hpp>
+
+namespace Slic3r {
+
+// Global flag: set to true when the networking DLL has crashed on one of its own threads.
+// Check this flag after networking operations to detect async DLL failures.
+extern std::atomic<bool> g_networking_dll_crashed;
+
+// Returns a human-readable description of the last DLL crash (empty if none).
+std::string get_dll_crash_message();
+
+// Install a global signal/exception handler that catches SIGSEGV in DLL-owned threads.
+// Call once during application startup. Thread-safe.
+void install_dll_crash_handler();
+
+// Execute a callable with crash protection. Returns the callable's return value on success,
+// or `fallback` if a crash (SIGSEGV/access violation) or C++ exception was caught.
+//
+// Usage:
+//   int result = dll_safe_call([&]() {
+//       return func(agent, params);
+//   }, -1, "start_print");
+//
+template<typename Fn, typename R = std::invoke_result_t<Fn>>
+R dll_safe_call(Fn&& fn, R fallback, const char* context = "unknown");
+
+// Non-template declaration for the platform-specific implementation
+int dll_safe_call_impl(std::function<int()> fn, int fallback, const char* context);
+
+// Template implementation that delegates to the platform-specific impl for int return type
+template<typename Fn, typename R>
+R dll_safe_call(Fn&& fn, R fallback, const char* context)
+{
+    // For int return type, use the platform-specific implementation with signal protection
+    if constexpr (std::is_same_v<R, int>) {
+        return dll_safe_call_impl(std::function<int()>(std::forward<Fn>(fn)), fallback, context);
+    } else {
+        // For other return types, use try-catch only (no signal protection)
+        try {
+            return fn();
+        } catch (const std::exception& e) {
+            BOOST_LOG_TRIVIAL(error) << "DllCrashGuard: C++ exception in " << context << ": " << e.what();
+            return fallback;
+        } catch (...) {
+            BOOST_LOG_TRIVIAL(error) << "DllCrashGuard: unknown exception in " << context;
+            return fallback;
+        }
+    }
+}
+
+// Void-returning variant
+template<typename Fn>
+void dll_safe_call_void(Fn&& fn, const char* context = "unknown")
+{
+    try {
+        fn();
+    } catch (const std::exception& e) {
+        BOOST_LOG_TRIVIAL(error) << "DllCrashGuard: C++ exception in " << context << ": " << e.what();
+    } catch (...) {
+        BOOST_LOG_TRIVIAL(error) << "DllCrashGuard: unknown exception in " << context;
+    }
+}
+
+} // namespace Slic3r
+
+#endif // SLIC3R_DLL_CRASH_GUARD_HPP

--- a/src/slic3r/Utils/DllCrashGuard.hpp
+++ b/src/slic3r/Utils/DllCrashGuard.hpp
@@ -10,7 +10,9 @@
 //    threads (e.g. MQTTAsync_sendThread) and prevents process termination.
 
 #include <atomic>
+#include <chrono>
 #include <functional>
+#include <future>
 #include <string>
 
 #include <boost/log/trivial.hpp>

--- a/src/slic3r/Utils/DllCrashGuard.hpp
+++ b/src/slic3r/Utils/DllCrashGuard.hpp
@@ -23,6 +23,12 @@ namespace Slic3r {
 // Check this flag after networking operations to detect async DLL failures.
 extern std::atomic<bool> g_networking_dll_crashed;
 
+// Counter incremented by the SIGSEGV signal handler when it can't safely call
+// boost::log (because it's about to pthread_exit the crashing thread). The
+// signal handler is async-signal-restricted; we use this counter to defer the
+// logging to the next normal-context call into the crash guard.
+extern std::atomic<int> g_pending_sigsegv_log_count;
+
 // Returns a human-readable description of the last DLL crash (empty if none).
 std::string get_dll_crash_message();
 


### PR DESCRIPTION
## Summary

Fixes #9813 — OrcaSlicer crashes (SIGSEGV) when connecting to Bambu Lab printers via LAN.

**Root cause:** The closed-source `libbambu_networking` library has a null-pointer dereference in `mqtt::token::on_failure(MQTTAsync_failureData*)`. It fires on one of the DLL's own threads (e.g. `MQTTAsync_sendThread`) when the printer becomes unreachable while there is an active MQTT connection.

This PR adds a defensive wrapper around the closed-source DLL so the crash doesn't take down the whole app, and so the rest of OrcaSlicer stays responsive even when the DLL is internally deadlocked afterwards.

## What changed

### 1. Crash recovery via signal handler
- POSIX (`sigaction` + `siglongjmp`) and Windows (Vectored Exception Handler) catch SIGSEGV/access violations.
- When the crash is in one of our wrapped DLL calls, we `siglongjmp` back out and return a fallback value.
- When the crash is on a DLL-owned background thread, we `pthread_exit` just that thread (POSIX) / redirect to `ExitThread()` (Windows) — the rest of the process stays alive.

### 2. Short, context-aware timeouts to prevent beachballs
After the SIGSEGV the DLL is **internally deadlocked** — every subsequent call into it (`connect_printer`, `disconnect_printer`, `destroy_agent`, even `dlclose`) hangs forever. To keep the UI responsive:
- **500 ms** fast timeout for short calls (`connect_printer`, `send_message`, `disconnect_printer`, status polls). Healthy calls return in 0–4 ms, so 500 ms is invisible in normal operation.
- **60 s** slow timeout for legitimately long operations (`start_print`, `bind`, `install_device_cert`) — these transfer gcode files and need time.
- The worker thread is detached, so a hung DLL call doesn't block the UI beyond the timeout.

### 3. Crash detection that survives async-signal-safety constraints
The SIGSEGV handler cannot call `boost::log` (it is about to `pthread_exit` the crashing thread, and logging is not async-signal-safe). It now increments an atomic counter that the next normal-context call drains, so crashes on DLL-owned threads become visible in the log instead of being silent.

### 4. Safe shutdown
Once the crash flag is latched, the app must avoid touching the DLL at all costs — including during shutdown. Previously the app was unkillable after a crash because the destructor chain called into the hung DLL:

```
GUI_App::~GUI_App
  -> BBLNetworkPlugin::shutdown
    -> ~BBLNetworkPlugin -> destroy_agent -> m_destroy_agent(...)  [HANG]
                         -> unload -> dlclose                      [HANG / UB]
```

- `destroy_agent` now skips the DLL call when the crash flag is set.
- `unload` skips `dlclose`/`FreeLibrary` when the DLL is hung — closing a library while its threads are still running inside it is undefined behaviour and can crash the process. The OS reclaims resources on process exit anyway.
- `DevManager::check_pushing` (periodic background poll) also short-circuits when the flag is set, so the poll loop does not keep dispatching hopeless DLL calls.

### 5. User-facing error dialog
When a crash is detected, a modal dialog tells the user to restart both the printer and OrcaSlicer, or to fall back to SD-card printing. Subsequent connect attempts short-circuit immediately (no DLL call, no beachball) and re-show the dialog.

## Why not just reload the DLL?

Tried it. Does not work in-process:
- The DLL is `dlopen`'d into OrcaSlicer's own address space, not a separate process.
- After the SIGSEGV, MQTT background threads from the DLL are still alive (or half-alive holding locks) inside that mapped memory.
- `dlclose` while those threads are running causes them to jump to unmapped memory and crash the whole process.
- Also tested calling `disconnect_printer` + `connect_printer` again after the crash: both hang forever (the DLL's internal mutex/state is corrupted by the dead thread that never released its locks).

A proper fix would put the networking in a separate subprocess with IPC, so a crash there could be cleanly killed and respawned. That is a much larger architectural change inherited from the Bambu Studio fork and is out of scope here.

## Test plan

- [x] Connect to a Bambu printer over LAN — works normally
- [x] Make the printer unreachable mid-connection (turn it off / unplug it) — DLL eventually SIGSEGVs internally
- [x] Verify the app does **not** crash (SIGSEGV is caught)
- [x] Verify the app does **not** beachball — the 500 ms fast timeout caps any single block, and once the flag is latched subsequent calls return instantly
- [x] Verify the error dialog appears with the restart instructions
- [x] Verify the app can be quit cleanly after a crash (no hang in `destroy_agent` / `dlclose`)
- [x] Verify file transfers (`start_print`) still work — they get the 60 s slow-timeout
- [ ] Cross-platform: tested on macOS (POSIX path); Windows SEH path is the same pattern but untested by this author

## Notes

- The root cause is in closed-source code (`libbambu_networking`); this PR is a defensive workaround.
- Restart is genuinely required after a crash — the DLL's state is corrupted beyond what we can recover via its own API.
