### PR TITLE
WIP fix sacrificial layer.cpp

### DIFF
--- a/src/libslic3r/PerimeterGenerator.cpp
+++ b/src/libslic3r/PerimeterGenerator.cpp
@@ -1758,11 +1758,9 @@ void PerimeterGenerator::process_no_bridge(Surfaces& all_surfaces, coord_t perim
                                         unsupported_filtered.erase(unsupported_filtered.begin() + i);
                                     }
                                 }
+                                unsupported_filtered = intersection_ex(last,
+                                                                       offset_ex(unsupported_filtered, 0.9 * double((bridged_infill_margin + perimeter_spacing) / 2)));
                                 if (this->config->counterbore_hole_bridging.value == chbFilled) {
-                                    // Expand sacrificial layer bridge area to ensure proper anchoring of the bridge infill.
-                                    unsupported_filtered = offset_ex(unsupported_filtered, double(perimeter_spacing));
-                                    // Clip expanded unsupported regions back to the current surface to avoid fill outside the part.
-                                    unsupported_filtered = intersection_ex(unsupported_filtered, ExPolygons() = { surface->expolygon });
                                     for (ExPolygon& expol : unsupported_filtered) {
                                         //check if the holes won't be covered by the upper layer
                                         //TODO: if we want to do that, we must modify the geometry before making perimeters.

--- a/src/libslic3r/PerimeterGenerator.cpp
+++ b/src/libslic3r/PerimeterGenerator.cpp
@@ -1711,8 +1711,12 @@ void PerimeterGenerator::process_no_bridge(Surfaces& all_surfaces, coord_t perim
             //compute our unsupported surface
             ExPolygons unsupported = diff_ex(last, *this->lower_slices, ApplySafetyOffset::Yes);
             if (!unsupported.empty()) {
-                //remove small overhangs
-                ExPolygons unsupported_filtered = offset2_ex(unsupported, double(-perimeter_spacing), double(perimeter_spacing));
+                // remove small overhangs (when using chbFilled we need to be less agresive un removing small ovehangs, to avoid affect
+                // bridging detection.)
+                const int  expansion_factor     = this->config->counterbore_hole_bridging.value == chbFilled ? 2 : 1;
+                ExPolygons unsupported_filtered = offset2_ex(unsupported, double(-perimeter_spacing),
+                                                             double(perimeter_spacing) / expansion_factor);
+
                 if (!unsupported_filtered.empty()) {
                     //to_draw.insert(to_draw.end(), last.begin(), last.end());
                     //extract only the useful part of the lower layer. The safety offset is really needed here.
@@ -1754,9 +1758,9 @@ void PerimeterGenerator::process_no_bridge(Surfaces& all_surfaces, coord_t perim
                                         unsupported_filtered.erase(unsupported_filtered.begin() + i);
                                     }
                                 }
-                                unsupported_filtered = intersection_ex(last,
-                                                                       offset2_ex(unsupported_filtered, double(-perimeter_spacing / 2), double(bridged_infill_margin + perimeter_spacing / 2)));
                                 if (this->config->counterbore_hole_bridging.value == chbFilled) {
+                                    // Expand sacrificial layer bridge area to ensure proper anchoring of the bridge infill.
+                                    unsupported_filtered = offset_ex(unsupported_filtered, double(perimeter_spacing));
                                     for (ExPolygon& expol : unsupported_filtered) {
                                         //check if the holes won't be covered by the upper layer
                                         //TODO: if we want to do that, we must modify the geometry before making perimeters.

--- a/src/libslic3r/PerimeterGenerator.cpp
+++ b/src/libslic3r/PerimeterGenerator.cpp
@@ -1711,11 +1711,11 @@ void PerimeterGenerator::process_no_bridge(Surfaces& all_surfaces, coord_t perim
             //compute our unsupported surface
             ExPolygons unsupported = diff_ex(last, *this->lower_slices, ApplySafetyOffset::Yes);
             if (!unsupported.empty()) {
-                // remove small overhangs (when using chbFilled we need to be less agresive un removing small ovehangs, to avoid affect
-                // bridging detection.)
-                const int  expansion_factor     = this->config->counterbore_hole_bridging.value == chbFilled ? 2 : 1;
+                // remove small overhangs (when using chbFilled we need to be less aggressive in removing small overhangs,
+                // to avoid affecting bridging detection.)
+                const int  outset_divisor       = this->config->counterbore_hole_bridging.value == chbFilled ? 2 : 1;
                 ExPolygons unsupported_filtered = offset2_ex(unsupported, double(-perimeter_spacing),
-                                                             double(perimeter_spacing) / expansion_factor);
+                                                             double(perimeter_spacing) / outset_divisor);
 
                 if (!unsupported_filtered.empty()) {
                     //to_draw.insert(to_draw.end(), last.begin(), last.end());
@@ -1761,6 +1761,8 @@ void PerimeterGenerator::process_no_bridge(Surfaces& all_surfaces, coord_t perim
                                 if (this->config->counterbore_hole_bridging.value == chbFilled) {
                                     // Expand sacrificial layer bridge area to ensure proper anchoring of the bridge infill.
                                     unsupported_filtered = offset_ex(unsupported_filtered, double(perimeter_spacing));
+                                    // Clip expanded unsupported regions back to the current surface to avoid fill outside the part.
+                                    unsupported_filtered = intersection_ex(unsupported_filtered, ExPolygons() = { surface->expolygon });
                                     for (ExPolygon& expol : unsupported_filtered) {
                                         //check if the holes won't be covered by the upper layer
                                         //TODO: if we want to do that, we must modify the geometry before making perimeters.

--- a/src/libslic3r/PerimeterGenerator.cpp
+++ b/src/libslic3r/PerimeterGenerator.cpp
@@ -1759,7 +1759,7 @@ void PerimeterGenerator::process_no_bridge(Surfaces& all_surfaces, coord_t perim
                                     }
                                 }
                                 unsupported_filtered = intersection_ex(last,
-                                                                       offset_ex(unsupported_filtered, 0.9 * double((bridged_infill_margin + perimeter_spacing) / 2)));
+                                                                       offset_ex(unsupported_filtered, 0.5 * double(bridged_infill_margin)));
                                 if (this->config->counterbore_hole_bridging.value == chbFilled) {
                                     for (ExPolygon& expol : unsupported_filtered) {
                                         //check if the holes won't be covered by the upper layer


### PR DESCRIPTION
# Fix sacrificial layer edgecase , with 2 perimeters only
Adjusts the sacrificial bridge layer (“counterbore hole bridging”) geometry handling to address an edge case where walls disappear when only 2 perimeters are present 
Is no longer needed a modifier to proper bridge detection.

Known issues (see comments below)
the one perimeter case is not adressed.

root cause:
When there are only two perimeters, this filter consumes the entire ExPolygon, which is why the bridges are not generated

https://github.com/OrcaSlicer/OrcaSlicer/blob/f72de427cb4920285fa7b4f3e6e4e5e7f7b6dddc/src/libslic3r/PerimeterGenerator.cpp#L1714-L1715


# Screenshots/Recordings/Graphs
Before:
<img width="1188" height="985" alt="image" src="https://github.com/user-attachments/assets/cd927360-2b15-4a79-8d55-991f415b0b49" />
<img width="1047" height="1001" alt="image" src="https://github.com/user-attachments/assets/73fa2131-624e-4900-bf6b-4fa5f8da2b66" />

After:
<img width="1203" height="909" alt="image" src="https://github.com/user-attachments/assets/6e584eba-612e-4421-ad63-245fdae176c6" />
<img width="1093" height="850" alt="image" src="https://github.com/user-attachments/assets/7476f653-a7a9-439d-aabd-33df84d71932" />
<img width="1057" height="1061" alt="image" src="https://github.com/user-attachments/assets/d6dd600d-158e-47d5-b11f-25875ed829bb" />


## Tests

[test sacrificial layer.zip](https://github.com/user-attachments/files/26335429/test.sacrificial.layer.zip)

Fix #12953

