### PR TITLE
Added filament setting: max acceleration limit

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -3155,8 +3155,8 @@ void GCode::_do_export(Print& print, GCodeOutputStream &file, ThumbnailsGenerato
     if (print.calib_params().mode == CalibMode::Calib_PA_Line) {
         std::string gcode;
         gcode += ";" + GCodeProcessor::reserved_tag(GCodeProcessor::ETags::Layer_Change) + "\n";
-        if ((print.default_object_config().outer_wall_acceleration.value > 0 && print.default_object_config().outer_wall_acceleration.value > 0)) {
-            gcode += m_writer.set_print_acceleration((unsigned int)floor(print.default_object_config().outer_wall_acceleration.value + 0.5));
+        if (print.default_object_config().outer_wall_acceleration.value > 0) {
+            gcode += m_writer.set_print_acceleration(this->rounded_filament_acceleration(print.default_object_config().outer_wall_acceleration.value));
         }
 
         if (print.default_object_config().outer_wall_jerk.value > 0) {
@@ -4547,7 +4547,7 @@ LayerResult GCode::process_layer(
     if (first_layer) {
         // Orca: we don't need to optimize the Klipper as only set once
         if (m_config.default_acceleration.value > 0 && m_config.initial_layer_acceleration.value > 0) {
-            gcode += m_writer.set_print_acceleration((unsigned int)floor(m_config.initial_layer_acceleration.value + 0.5));
+            gcode += m_writer.set_print_acceleration(this->rounded_filament_acceleration(m_config.initial_layer_acceleration.value));
         }
 
         if (m_config.default_jerk.value > 0 && m_config.initial_layer_jerk.value > 0) {
@@ -4577,7 +4577,7 @@ LayerResult GCode::process_layer(
       // Reset acceleration at sencond layer
       // Orca: only set once, don't need to call set_accel_and_jerk
       if (m_config.default_acceleration.value > 0 && m_config.initial_layer_acceleration.value > 0) {
-        gcode += m_writer.set_print_acceleration((unsigned int) floor(m_config.default_acceleration.value + 0.5));
+        gcode += m_writer.set_print_acceleration(this->rounded_filament_acceleration(m_config.default_acceleration.value));
       }
 
       if (m_config.default_jerk.value > 0 && m_config.initial_layer_jerk.value > 0) {
@@ -6111,6 +6111,23 @@ double GCode::calc_max_volumetric_speed(const double layer_height, const double 
     return res;
 }
 
+unsigned int GCode::rounded_filament_acceleration(double acceleration) const
+{
+    if (acceleration <= 0.0)
+        return 0;
+
+    const Extruder *filament = m_writer.filament();
+    if (filament != nullptr) {
+        const size_t filament_id = filament->id();
+        if (filament_id < m_config.enable_filament_acceleration_limit.values.size() &&
+            filament_id < m_config.filament_max_acceleration.values.size() &&
+            m_config.enable_filament_acceleration_limit.get_at(filament_id))
+            acceleration = std::min(acceleration, std::max(0.0, m_config.filament_max_acceleration.get_at(filament_id)));
+    }
+
+    return static_cast<unsigned int>(std::floor(acceleration + 0.5));
+}
+
 std::string GCode::_extrude(const ExtrusionPath &path, std::string description, double speed)
 {
     std::string gcode;
@@ -6184,7 +6201,7 @@ std::string GCode::_extrude(const ExtrusionPath &path, std::string description, 
         } else {
             acceleration = m_config.default_acceleration.value;
         }
-        acceleration_i = (unsigned int)floor(acceleration + 0.5);
+        acceleration_i = this->rounded_filament_acceleration(acceleration);
     }
 
     // adjust X Y jerk
@@ -7031,7 +7048,7 @@ std::string GCode::travel_to(const Point& point, ExtrusionRole role, std::string
     
     if (this->on_first_layer()) {
         if (m_config.default_acceleration.value > 0 && m_config.initial_layer_acceleration.value > 0) {
-            acceleration_to_set = (unsigned int) floor(m_config.initial_layer_acceleration.value + 0.5);
+            acceleration_to_set = this->rounded_filament_acceleration(m_config.initial_layer_acceleration.value);
         }
         
         if (m_config.default_jerk.value > 0 && m_config.initial_layer_jerk.value > 0) {
@@ -7041,10 +7058,10 @@ std::string GCode::travel_to(const Point& point, ExtrusionRole role, std::string
         if (m_config.default_acceleration.value > 0) {
             if (role == erExternalPerimeter && travel.length() < scale_(EXTRUDER_CONFIG(retraction_minimum_travel))) {
                 if (m_config.outer_wall_acceleration.value > 0)
-                    acceleration_to_set = (unsigned int) floor(m_config.outer_wall_acceleration.value + 0.5);
+                    acceleration_to_set = this->rounded_filament_acceleration(m_config.outer_wall_acceleration.value);
             } else {
                 if (m_config.travel_acceleration.value > 0)
-                    acceleration_to_set = (unsigned int) floor(m_config.travel_acceleration.value + 0.5);
+                    acceleration_to_set = this->rounded_filament_acceleration(m_config.travel_acceleration.value);
             }
         }
 

--- a/src/libslic3r/GCode.hpp
+++ b/src/libslic3r/GCode.hpp
@@ -638,6 +638,7 @@ private:
     int get_highest_bed_temperature(const bool is_first_layer,const Print &print) const;
 
     double      calc_max_volumetric_speed(const double layer_height, const double line_width, const std::string co_str);
+    unsigned int rounded_filament_acceleration(double acceleration) const;
     std::string _extrude(const ExtrusionPath &path, std::string description = "", double speed = -1);
     bool _needSAFC(const ExtrusionPath &path);
     void print_machine_envelope(GCodeOutputStream& file, Print& print);

--- a/src/libslic3r/GCodeWriter.cpp
+++ b/src/libslic3r/GCodeWriter.cpp
@@ -198,8 +198,26 @@ std::string GCodeWriter::set_chamber_temperature(int temperature, bool wait)
 }
 
 // copied from PrusaSlicer
+unsigned int GCodeWriter::limit_to_filament_max_acceleration(unsigned int acceleration) const
+{
+    const Extruder *current_filament = this->filament();
+    if (current_filament == nullptr)
+        return acceleration;
+
+    const size_t filament_id = current_filament->id();
+    if (filament_id >= this->config.enable_filament_acceleration_limit.values.size() ||
+        filament_id >= this->config.filament_max_acceleration.values.size() ||
+        !this->config.enable_filament_acceleration_limit.get_at(filament_id))
+        return acceleration;
+
+    const auto filament_max_acceleration = static_cast<unsigned int>(std::round(this->config.filament_max_acceleration.get_at(filament_id)));
+    return filament_max_acceleration > 0 ? std::min(acceleration, filament_max_acceleration) : acceleration;
+}
+
 std::string GCodeWriter::set_acceleration_internal(Acceleration type, unsigned int acceleration)
 {
+    acceleration = this->limit_to_filament_max_acceleration(acceleration);
+
     // Clamp the acceleration to the allowed maximum.
     if (type == Acceleration::Print && m_max_acceleration > 0 && acceleration > m_max_acceleration)
         acceleration = m_max_acceleration;
@@ -280,6 +298,8 @@ std::string GCodeWriter::set_accel_and_jerk(unsigned int acceleration, double je
     // Only Klipper supports setting acceleration and jerk at the same time. Throw an error if we try to do this on other flavours.
     if(FLAVOR_IS_NOT(gcfKlipper))
         throw std::runtime_error("set_accel_and_jerk() is only supported by Klipper");
+
+    acceleration = this->limit_to_filament_max_acceleration(acceleration);
 
     // Clamp the acceleration to the allowed maximum.
     if (m_max_acceleration > 0 && acceleration > m_max_acceleration)

--- a/src/libslic3r/GCodeWriter.hpp
+++ b/src/libslic3r/GCodeWriter.hpp
@@ -188,6 +188,7 @@ public:
     std::string _travel_to_z(double z, const std::string &comment);
     std::string _spiral_travel_to_z(double z, const Vec2d &ij_offset, const std::string &comment);
     std::string _retract(double length, double restart_extra, const std::string &comment);
+    unsigned int limit_to_filament_max_acceleration(unsigned int acceleration) const;
     std::string set_acceleration_internal(Acceleration type, unsigned int acceleration);
 
 };

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -960,6 +960,7 @@ static std::vector<std::string> s_Preset_print_options {
 static std::vector<std::string> s_Preset_filament_options {/*"filament_colour", */ "default_filament_colour", "required_nozzle_HRC", "filament_diameter", "pellet_flow_coefficient", "volumetric_speed_coefficients", "filament_type",
                                                           "filament_soluble", "filament_is_support", "filament_printable",
     "filament_max_volumetric_speed", "filament_adaptive_volumetric_speed",
+    "enable_filament_acceleration_limit", "filament_max_acceleration",
     "filament_flow_ratio", "filament_density", "filament_adhesiveness_category", "filament_cost", "filament_minimal_purge_on_wipe_tower",
     "filament_tower_interface_pre_extrusion_dist", "filament_tower_interface_pre_extrusion_length", "filament_tower_ironing_area", "filament_tower_interface_purge_volume",
     "filament_tower_interface_print_temp",

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -128,6 +128,8 @@ bool Print::invalidate_state_by_config_options(const ConfigOptionResolver & /* n
         "extruder_colour",
         "extruder_offset",
         "filament_flow_ratio",
+        "enable_filament_acceleration_limit",
+        "filament_max_acceleration",
         "reduce_fan_stop_start_freq",
         "dont_slow_down_outer_wall",
         "fan_cooling_layer_time",

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -2377,6 +2377,20 @@ void PrintConfigDef::init_fff_params()
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionFloats { 2. });
 
+    def = this->add("enable_filament_acceleration_limit", coBools);
+    def->label = L("Enable max acceleration");
+    def->tooltip = L("Limit print and travel acceleration settings from the process profile so they never exceed this filament's maximum acceleration.");
+    def->mode = comAdvanced;
+    def->set_default_value(new ConfigOptionBools { false });
+
+    def = this->add("filament_max_acceleration", coFloats);
+    def->label = L("Max acceleration");
+    def->tooltip = L("Maximum acceleration allowed for this filament. Process acceleration values above this limit will be reduced during slicing.");
+    def->sidetext = L(u8"mm/s²");	// milimeters per second per second, CIS languages need translation
+    def->min = 1;
+    def->mode = comAdvanced;
+    def->set_default_value(new ConfigOptionFloats { 1000. });
+
     def = this->add("machine_load_filament_time", coFloat);
     def->label = L("Filament load time");
     def->tooltip = L("Time to load new filament when switch filament. It's usually applicable for single-extruder multi-material machines. "
@@ -7807,6 +7821,8 @@ std::set<std::string> print_options_with_variant = {
 std::set<std::string> filament_options_with_variant = {
     "filament_flow_ratio",
     "filament_max_volumetric_speed",
+    "enable_filament_acceleration_limit",
+    "filament_max_acceleration",
     //"filament_extruder_id",
     "filament_extruder_variant",
     "filament_retraction_length",
@@ -9625,6 +9641,12 @@ std::map<std::string, std::string> validate(const FullPrintConfig &cfg, bool und
     for (double fd : cfg.filament_diameter.values)
         if (fd < 1) {
             error_message.emplace("filament_diameter", L("invalid value ") + cfg.filament_diameter.serialize());
+            break;
+        }
+
+    for (size_t i = 0; i < cfg.enable_filament_acceleration_limit.values.size() && i < cfg.filament_max_acceleration.values.size(); ++i)
+        if (cfg.enable_filament_acceleration_limit.get_at(i) && cfg.filament_max_acceleration.get_at(i) < 1) {
+            error_message.emplace("filament_max_acceleration", L("invalid value ") + cfg.filament_max_acceleration.serialize());
             break;
         }
 

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -1276,6 +1276,8 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionStrings,             default_filament_colour))
     ((ConfigOptionInts,                temperature_vitrification))  //BBS
     ((ConfigOptionFloats,              filament_max_volumetric_speed))
+    ((ConfigOptionBools,               enable_filament_acceleration_limit))
+    ((ConfigOptionFloats,              filament_max_acceleration))
     ((ConfigOptionInts,                required_nozzle_HRC))
     ((ConfigOptionEnum<FilamentMapMode>, filament_map_mode))
     ((ConfigOptionInts,                filament_map))

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -3964,9 +3964,11 @@ void TabFilament::build()
         };
 
         //BBS
-        optgroup = page->new_optgroup(L("Volumetric speed limitation"), L"param_volumetric_speed");
+        optgroup = page->new_optgroup(L("Volumetric speed and acceleration limitation"), L"param_volumetric_speed");
         optgroup->append_single_option_line("filament_adaptive_volumetric_speed", "material_volumetric_speed_limitation#adaptive-volumetric-speed", 0);
         optgroup->append_single_option_line("filament_max_volumetric_speed", "material_volumetric_speed_limitation#max-volumetric-speed", 0);
+        optgroup->append_single_option_line("enable_filament_acceleration_limit", "material_volumetric_speed_limitation#limit-max-print-and-travel-acceleration", 0);
+        optgroup->append_single_option_line("filament_max_acceleration", "material_volumetric_speed_limitation#max-acceleration", 0);
 
         //line = { "", "" };
         //line.full_width = 1;
@@ -4200,6 +4202,8 @@ void TabFilament::toggle_options()
     {
         bool pa = m_config->opt_bool("enable_pressure_advance", 0);
         toggle_option("pressure_advance", pa);
+        bool filament_acceleration_limit = m_config->opt_bool("enable_filament_acceleration_limit", 0);
+        toggle_option("filament_max_acceleration", filament_acceleration_limit, 256 + 0u);
 
         //Orca: Enable the plates that should be visible when multi bed support is enabled or a BBL printer is selected; otherwise, enable only the plate visible for the selected bed type.
         DynamicConfig& proj_cfg               = m_preset_bundle->project_config;

--- a/tests/libslic3r/test_config.cpp
+++ b/tests/libslic3r/test_config.cpp
@@ -33,6 +33,14 @@ SCENARIO("Generic config validation performs as expected.", "[Config]") {
                 REQUIRE_FALSE(config.validate().empty());
             }
         }
+
+        WHEN("filament acceleration limiting is enabled with a non-positive max acceleration") {
+            config.set_key_value("enable_filament_acceleration_limit", new ConfigOptionBools { true });
+            config.set_key_value("filament_max_acceleration", new ConfigOptionFloats { 0.0 });
+            THEN("Validate returns error") {
+                REQUIRE_FALSE(config.validate().empty());
+            }
+        }
     }
 }
 


### PR DESCRIPTION
# Description
- add filament-level Enable max acceleration and Max acceleration settings in the Filament tab
- rename the section to Volumetric speed and acceleration limitation
- clamp effective print and travel acceleration values to the filament cap during G-code generation
- apply the clamp early enough that Adaptive Pressure Advance uses the capped acceleration values too

Useful why? TPU for example does not like high acceleration values and I didn't like to edit the process settings just for this case. 

# Screenshots

<img width="836" height="326" alt="Screenshot 2026-03-29 at 13 04 26" src="https://github.com/user-attachments/assets/617389ca-a0d3-4701-887a-143c777a258c" />


## Tests

Tested on ARM macOS. Checked gcode. 
