### PR TITLE
Partial sacrificial bridge anchor fix

### DIFF
--- a/src/libslic3r/PerimeterGenerator.cpp
+++ b/src/libslic3r/PerimeterGenerator.cpp
@@ -1873,13 +1873,13 @@ void PerimeterGenerator::process_no_bridge(Surfaces& all_surfaces, coord_t perim
 
                                     // Normalize anchor size for partial bridges:
                                     // derive the bridge core first, then add a fixed overlap into support.
-                                    const coord_t anchor_overlap = coord_t(bridged_infill_margin);
+                                    const coordf_t anchor_overlap = bridged_infill_margin;
                                     ExPolygons bridge_core = diff_ex(unsupported_filtered, support, ApplySafetyOffset::Yes);
                                     if (bridge_core.empty()) {
                                         bridge_core = unsupported_filtered;
                                     }
                                     ExPolygons anchor_overlap_area = intersection_ex(
-                                        offset_ex(bridge_core, double(anchor_overlap)),
+                                        offset_ex(bridge_core, anchor_overlap),
                                         support,
                                         ApplySafetyOffset::Yes);
                                     unsupported_filtered = union_ex(bridge_core, anchor_overlap_area);

--- a/src/libslic3r/PerimeterGenerator.cpp
+++ b/src/libslic3r/PerimeterGenerator.cpp
@@ -1870,6 +1870,20 @@ void PerimeterGenerator::process_no_bridge(Surfaces& all_surfaces, coord_t perim
                                     bridges_temp = diff_ex(bridges_temp, unbridgeable);
                                     unsupported_filtered = offset_ex(bridges_temp, offset_to_do);
                                     unsupported_filtered = intersection_ex(unsupported_filtered, reference);
+
+                                    // Normalize anchor size for partial bridges:
+                                    // derive the bridge core first, then add a fixed overlap into support.
+                                    const coord_t anchor_overlap = coord_t(bridged_infill_margin);
+                                    ExPolygons bridge_core = diff_ex(unsupported_filtered, support, ApplySafetyOffset::Yes);
+                                    if (bridge_core.empty()) {
+                                        bridge_core = unsupported_filtered;
+                                    }
+                                    ExPolygons anchor_overlap_area = intersection_ex(
+                                        offset_ex(bridge_core, double(anchor_overlap)),
+                                        support,
+                                        ApplySafetyOffset::Yes);
+                                    unsupported_filtered = union_ex(bridge_core, anchor_overlap_area);
+                                    unsupported_filtered = intersection_ex(unsupported_filtered, reference);
                                 // } else {
                                 //     ExPolygons unbridgeable = intersection_ex(unsupported, diff_ex(unsupported_filtered, offset_ex(bridgeable_simplified, ext_perimeter_width / 2)));
                                 //     unbridgeable = offset2_ex(unbridgeable, -ext_perimeter_width, ext_perimeter_width);


### PR DESCRIPTION
Yet another Bridge PR (#12055 #11255 #12568)

Fix the bridge anchor generation logic.
The main change is the normalization of anchor sizes for partial bridges, ensuring a consistent overlap into support material. This helps create more reliable bridge perimeters and improves print quality for overhanging regions.

## After/Before

See how after the partial bridge was nor anchoring in some parts and now it does.

<img width="847" height="456" alt="imagen" src="https://github.com/user-attachments/assets/eefcc18c-4223-4cc1-bf3b-54307070af1f" />

<img width="908" height="600" alt="imagen" src="https://github.com/user-attachments/assets/37701545-8f87-4ba0-b738-6e805af930f6" />

## Test file:

[test sacrificial layer.3mf.zip](https://github.com/user-attachments/files/26362264/test.sacrificial.layer.3mf.zip)

