### PR TITLE
Add flathub readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,9 +137,25 @@ winget install --id=SoftFever.OrcaSlicer -e
             ![mac_security_setting](./SoftFever_doc/mac_security_setting.png)
     </details>
 
-## Linux (Ubuntu)
+## Linux         
 
- 1. If you run into trouble executing it, try this command in the terminal:
+### Flathub (Recommended)
+OrcaSlicer is available on [Flathub](https://github.com/flathub/com.orcaslicer.OrcaSlicer).
+
+Install from the command line:
+
+```shell
+flatpak install flathub com.orcaslicer.OrcaSlicer
+flatpak run com.orcaslicer.OrcaSlicer
+```
+
+It can also be installed through graphical software managers (KDE Discover, GNOME Software, etc.) when Flathub is enabled. Search for **OrcaSlicer** in your software center.
+
+### AppImage (Ubuntu Only)
+ 1. Download App image from the [releases page](https://github.com/OrcaSlicer/OrcaSlicer/releases).
+ 2. Double click the downloaded file to run it.
+
+ 3. If you run into trouble executing it, try this command in the terminal:
     `chmod +x /path_to_appimage/OrcaSlicer_Linux.AppImage`
 
 # How to Compile

--- a/README.md
+++ b/README.md
@@ -140,7 +140,9 @@ winget install --id=SoftFever.OrcaSlicer -e
 ## Linux         
 
 ### Flathub (Recommended)
-OrcaSlicer is available on [Flathub](https://github.com/flathub/com.orcaslicer.OrcaSlicer).
+OrcaSlicer is available through FlatHub:
+
+<a href='https://flathub.org/apps/com.orcaslicer.OrcaSlicer'><img width='240' alt='Download on Flathub' src='https://dl.flathub.org/assets/badges/flathub-badge-en.png'/></a>
 
 Install from the command line:
 

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ flatpak run com.orcaslicer.OrcaSlicer
 
 It can also be installed through graphical software managers (KDE Discover, GNOME Software, etc.) when Flathub is enabled. Search for **OrcaSlicer** in your software center.
 
-### AppImage (Ubuntu Only)
+### AppImage
  1. Download App image from the [releases page](https://github.com/OrcaSlicer/OrcaSlicer/releases).
  2. Double click the downloaded file to run it.
 


### PR DESCRIPTION

## Summary

Update the Linux installation section in `README.md` to mention that OrcaSlicer is now available on Flathub.

## Changes

- add Flathub as the recommended Linux installation method
- add download from FlatHub button
- include the `flatpak install` command
- mention that OrcaSlicer can also be installed through graphical software managers on many distributions when Flathub is enabled
- keep the existing AppImage instructions as an alternative installation method

## Why

Now that OrcaSlicer is available on Flathub, the README should reflect the easiest and most discoverable installation method for many Linux users.
<img width="1021" height="601" alt="image" src="https://github.com/user-attachments/assets/2e21057f-89ad-4a14-a921-a7b6bbd8c8e3" />
