### PR TITLE
feature: Add granular print time placeholders for days, hours, minutes, and seconds

### DIFF
--- a/resources/profiles/Creality/machine/Creality Ender-3 V3 SE 0.2 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality Ender-3 V3 SE 0.2 nozzle.json
@@ -120,6 +120,7 @@
 	"default_filament_profile": [
 		"Creality Generic PLA @Ender-3V3-all"
 	],
+    "file_start_gcode": ";FLAVOR:Marlin\\n;TIME:{print_time_total_sec}\\n;Filament used:{used_filament_length}m\\n;Layer height:{layer_height}",
 	"machine_start_gcode": "M220 S100 ;Reset Feedrate \nM221 S100 ;Reset Flowrate \n \nM104 S[nozzle_temperature_initial_layer] ;Set final nozzle temp \nM190 S[bed_temperature_initial_layer_single] ;Set and wait for bed temp to stabilize \nG28 ;Home \nG92 E0 ;Reset Extruder \nG1 Z2.0 F3000 ;Move Z Axis up \nG1 X-2.1 Y20 Z0.28 F5000.0 ;Move to start position \nM109 S[nozzle_temperature_initial_layer] ;Wait for nozzle temp to stabilize \nG1 X-2.1 Y145.0 Z0.28 F1500.0 E15 ;Draw the first line \nG1 X-2.4 Y145.0 Z0.28 F5000.0 ;Move to side a little \nG1 X-2.4 Y20 Z0.28 F1500.0 E30 ;Draw the second line \nG92 E0  ;Reset Extruder \nG1 E-1.0000 F1800 ;Retract a bit \nG1 Z2.0 F3000 ;Move Z Axis up \nG1 E0.0000 F1800",
 	"machine_end_gcode": "G91 ;Relative positionning \nG1 E-2 F2700 ;Retract a bit \nG1 E-2 Z0.2 F2400 ;Retract and raise Z \nG1 X5 Y5 F3000 ;Wipe out \nG1 Z10 ;Raise Z more \nG90 ;Absolute positionning \n \nG1 X0 Y220 ;Present print \nM106 S0 ;Turn-off fan \nM104 S0 ;Turn-off hotend \nM140 S0 ;Turn-off bed \n \nM84 X Y E ;Disable all steppers but Z",
 	"scan_first_layer": "0",

--- a/resources/profiles/Creality/machine/Creality Ender-3 V3 SE 0.2 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality Ender-3 V3 SE 0.2 nozzle.json
@@ -120,7 +120,7 @@
 	"default_filament_profile": [
 		"Creality Generic PLA @Ender-3V3-all"
 	],
-    "file_start_gcode": ";FLAVOR:Marlin\\n;TIME:{print_time_total_sec}\\n;Filament used:{used_filament_length}m\\n;Layer height:{layer_height}",
+	"file_start_gcode": ";FLAVOR:Marlin\\n;TIME:{print_time_total_sec}\\n;Filament used:{used_filament_length}m\\n;Layer height:{layer_height}",
 	"machine_start_gcode": "M220 S100 ;Reset Feedrate \nM221 S100 ;Reset Flowrate \n \nM104 S[nozzle_temperature_initial_layer] ;Set final nozzle temp \nM190 S[bed_temperature_initial_layer_single] ;Set and wait for bed temp to stabilize \nG28 ;Home \nG92 E0 ;Reset Extruder \nG1 Z2.0 F3000 ;Move Z Axis up \nG1 X-2.1 Y20 Z0.28 F5000.0 ;Move to start position \nM109 S[nozzle_temperature_initial_layer] ;Wait for nozzle temp to stabilize \nG1 X-2.1 Y145.0 Z0.28 F1500.0 E15 ;Draw the first line \nG1 X-2.4 Y145.0 Z0.28 F5000.0 ;Move to side a little \nG1 X-2.4 Y20 Z0.28 F1500.0 E30 ;Draw the second line \nG92 E0  ;Reset Extruder \nG1 E-1.0000 F1800 ;Retract a bit \nG1 Z2.0 F3000 ;Move Z Axis up \nG1 E0.0000 F1800",
 	"machine_end_gcode": "G91 ;Relative positionning \nG1 E-2 F2700 ;Retract a bit \nG1 E-2 Z0.2 F2400 ;Retract and raise Z \nG1 X5 Y5 F3000 ;Wipe out \nG1 Z10 ;Raise Z more \nG90 ;Absolute positionning \n \nG1 X0 Y220 ;Present print \nM106 S0 ;Turn-off fan \nM104 S0 ;Turn-off hotend \nM140 S0 ;Turn-off bed \n \nM84 X Y E ;Disable all steppers but Z",
 	"scan_first_layer": "0",

--- a/resources/profiles/Creality/machine/Creality Ender-3 V3 SE 0.2 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality Ender-3 V3 SE 0.2 nozzle.json
@@ -120,7 +120,6 @@
 	"default_filament_profile": [
 		"Creality Generic PLA @Ender-3V3-all"
 	],
-	"file_start_gcode": ";FLAVOR:Marlin\\n;TIME:{print_time_sec}\\n;Filament used:{used_filament_length}m\\n;Layer height:{layer_height}",
 	"machine_start_gcode": "M220 S100 ;Reset Feedrate \nM221 S100 ;Reset Flowrate \n \nM104 S[nozzle_temperature_initial_layer] ;Set final nozzle temp \nM190 S[bed_temperature_initial_layer_single] ;Set and wait for bed temp to stabilize \nG28 ;Home \nG92 E0 ;Reset Extruder \nG1 Z2.0 F3000 ;Move Z Axis up \nG1 X-2.1 Y20 Z0.28 F5000.0 ;Move to start position \nM109 S[nozzle_temperature_initial_layer] ;Wait for nozzle temp to stabilize \nG1 X-2.1 Y145.0 Z0.28 F1500.0 E15 ;Draw the first line \nG1 X-2.4 Y145.0 Z0.28 F5000.0 ;Move to side a little \nG1 X-2.4 Y20 Z0.28 F1500.0 E30 ;Draw the second line \nG92 E0  ;Reset Extruder \nG1 E-1.0000 F1800 ;Retract a bit \nG1 Z2.0 F3000 ;Move Z Axis up \nG1 E0.0000 F1800",
 	"machine_end_gcode": "G91 ;Relative positionning \nG1 E-2 F2700 ;Retract a bit \nG1 E-2 Z0.2 F2400 ;Retract and raise Z \nG1 X5 Y5 F3000 ;Wipe out \nG1 Z10 ;Raise Z more \nG90 ;Absolute positionning \n \nG1 X0 Y220 ;Present print \nM106 S0 ;Turn-off fan \nM104 S0 ;Turn-off hotend \nM140 S0 ;Turn-off bed \n \nM84 X Y E ;Disable all steppers but Z",
 	"scan_first_layer": "0",

--- a/resources/profiles/Creality/machine/Creality Ender-3 V3 SE 0.4 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality Ender-3 V3 SE 0.4 nozzle.json
@@ -120,6 +120,7 @@
 	"default_filament_profile": [
 		"Creality Generic PLA @Ender-3V3-all"
 	],
+    "file_start_gcode": ";FLAVOR:Marlin\\n;TIME:{print_time_total_sec}\\n;Filament used:{used_filament_length}m\\n;Layer height:{layer_height}",
 	"machine_start_gcode": "M220 S100 ;Reset Feedrate \nM221 S100 ;Reset Flowrate \n \nM104 S[nozzle_temperature_initial_layer] ;Set final nozzle temp \nM190 S[bed_temperature_initial_layer_single] ;Set and wait for bed temp to stabilize \nG28 ;Home \nG92 E0 ;Reset Extruder \nG1 Z2.0 F3000 ;Move Z Axis up \nG1 X-2.1 Y20 Z0.28 F5000.0 ;Move to start position \nM109 S[nozzle_temperature_initial_layer] ;Wait for nozzle temp to stabilize \nG1 X-2.1 Y145.0 Z0.28 F1500.0 E15 ;Draw the first line \nG1 X-2.4 Y145.0 Z0.28 F5000.0 ;Move to side a little \nG1 X-2.4 Y20 Z0.28 F1500.0 E30 ;Draw the second line \nG92 E0  ;Reset Extruder \nG1 E-1.0000 F1800 ;Retract a bit \nG1 Z2.0 F3000 ;Move Z Axis up \nG1 E0.0000 F1800",
 	"machine_end_gcode": "G91 ;Relative positionning \nG1 E-2 F2700 ;Retract a bit \nG1 E-2 Z0.2 F2400 ;Retract and raise Z \nG1 X5 Y5 F3000 ;Wipe out \nG1 Z10 ;Raise Z more \nG90 ;Absolute positionning \n \nG1 X0 Y220 ;Present print \nM106 S0 ;Turn-off fan \nM104 S0 ;Turn-off hotend \nM140 S0 ;Turn-off bed \n \nM84 X Y E ;Disable all steppers but Z",
 	"scan_first_layer": "0",

--- a/resources/profiles/Creality/machine/Creality Ender-3 V3 SE 0.4 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality Ender-3 V3 SE 0.4 nozzle.json
@@ -120,7 +120,7 @@
 	"default_filament_profile": [
 		"Creality Generic PLA @Ender-3V3-all"
 	],
-    "file_start_gcode": ";FLAVOR:Marlin\\n;TIME:{print_time_total_sec}\\n;Filament used:{used_filament_length}m\\n;Layer height:{layer_height}",
+	"file_start_gcode": ";FLAVOR:Marlin\\n;TIME:{print_time_total_sec}\\n;Filament used:{used_filament_length}m\\n;Layer height:{layer_height}",
 	"machine_start_gcode": "M220 S100 ;Reset Feedrate \nM221 S100 ;Reset Flowrate \n \nM104 S[nozzle_temperature_initial_layer] ;Set final nozzle temp \nM190 S[bed_temperature_initial_layer_single] ;Set and wait for bed temp to stabilize \nG28 ;Home \nG92 E0 ;Reset Extruder \nG1 Z2.0 F3000 ;Move Z Axis up \nG1 X-2.1 Y20 Z0.28 F5000.0 ;Move to start position \nM109 S[nozzle_temperature_initial_layer] ;Wait for nozzle temp to stabilize \nG1 X-2.1 Y145.0 Z0.28 F1500.0 E15 ;Draw the first line \nG1 X-2.4 Y145.0 Z0.28 F5000.0 ;Move to side a little \nG1 X-2.4 Y20 Z0.28 F1500.0 E30 ;Draw the second line \nG92 E0  ;Reset Extruder \nG1 E-1.0000 F1800 ;Retract a bit \nG1 Z2.0 F3000 ;Move Z Axis up \nG1 E0.0000 F1800",
 	"machine_end_gcode": "G91 ;Relative positionning \nG1 E-2 F2700 ;Retract a bit \nG1 E-2 Z0.2 F2400 ;Retract and raise Z \nG1 X5 Y5 F3000 ;Wipe out \nG1 Z10 ;Raise Z more \nG90 ;Absolute positionning \n \nG1 X0 Y220 ;Present print \nM106 S0 ;Turn-off fan \nM104 S0 ;Turn-off hotend \nM140 S0 ;Turn-off bed \n \nM84 X Y E ;Disable all steppers but Z",
 	"scan_first_layer": "0",

--- a/resources/profiles/Creality/machine/Creality Ender-3 V3 SE 0.4 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality Ender-3 V3 SE 0.4 nozzle.json
@@ -120,7 +120,6 @@
 	"default_filament_profile": [
 		"Creality Generic PLA @Ender-3V3-all"
 	],
-	"file_start_gcode": ";FLAVOR:Marlin\\n;TIME:{print_time_sec}\\n;Filament used:{used_filament_length}m\\n;Layer height:{layer_height}",
 	"machine_start_gcode": "M220 S100 ;Reset Feedrate \nM221 S100 ;Reset Flowrate \n \nM104 S[nozzle_temperature_initial_layer] ;Set final nozzle temp \nM190 S[bed_temperature_initial_layer_single] ;Set and wait for bed temp to stabilize \nG28 ;Home \nG92 E0 ;Reset Extruder \nG1 Z2.0 F3000 ;Move Z Axis up \nG1 X-2.1 Y20 Z0.28 F5000.0 ;Move to start position \nM109 S[nozzle_temperature_initial_layer] ;Wait for nozzle temp to stabilize \nG1 X-2.1 Y145.0 Z0.28 F1500.0 E15 ;Draw the first line \nG1 X-2.4 Y145.0 Z0.28 F5000.0 ;Move to side a little \nG1 X-2.4 Y20 Z0.28 F1500.0 E30 ;Draw the second line \nG92 E0  ;Reset Extruder \nG1 E-1.0000 F1800 ;Retract a bit \nG1 Z2.0 F3000 ;Move Z Axis up \nG1 E0.0000 F1800",
 	"machine_end_gcode": "G91 ;Relative positionning \nG1 E-2 F2700 ;Retract a bit \nG1 E-2 Z0.2 F2400 ;Retract and raise Z \nG1 X5 Y5 F3000 ;Wipe out \nG1 Z10 ;Raise Z more \nG90 ;Absolute positionning \n \nG1 X0 Y220 ;Present print \nM106 S0 ;Turn-off fan \nM104 S0 ;Turn-off hotend \nM140 S0 ;Turn-off bed \n \nM84 X Y E ;Disable all steppers but Z",
 	"scan_first_layer": "0",

--- a/resources/profiles/Creality/machine/Creality Ender-3 V3 SE 0.6 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality Ender-3 V3 SE 0.6 nozzle.json
@@ -120,6 +120,7 @@
 	"default_filament_profile": [
 		"Creality Generic PLA @Ender-3V3-all"
 	],
+    "file_start_gcode": ";FLAVOR:Marlin\\n;TIME:{print_time_total_sec}\\n;Filament used:{used_filament_length}m\\n;Layer height:{layer_height}",
 	"machine_start_gcode": "M220 S100 ;Reset Feedrate \nM221 S100 ;Reset Flowrate \n \nM104 S[nozzle_temperature_initial_layer] ;Set final nozzle temp \nM190 S[bed_temperature_initial_layer_single] ;Set and wait for bed temp to stabilize \nG28 ;Home \nG92 E0 ;Reset Extruder \nG1 Z2.0 F3000 ;Move Z Axis up \nG1 X-2.1 Y20 Z0.28 F5000.0 ;Move to start position \nM109 S[nozzle_temperature_initial_layer] ;Wait for nozzle temp to stabilize \nG1 X-2.1 Y145.0 Z0.28 F1500.0 E15 ;Draw the first line \nG1 X-2.4 Y145.0 Z0.28 F5000.0 ;Move to side a little \nG1 X-2.4 Y20 Z0.28 F1500.0 E30 ;Draw the second line \nG92 E0  ;Reset Extruder \nG1 E-1.0000 F1800 ;Retract a bit \nG1 Z2.0 F3000 ;Move Z Axis up \nG1 E0.0000 F1800",
 	"machine_end_gcode": "G91 ;Relative positionning \nG1 E-2 F2700 ;Retract a bit \nG1 E-2 Z0.2 F2400 ;Retract and raise Z \nG1 X5 Y5 F3000 ;Wipe out \nG1 Z10 ;Raise Z more \nG90 ;Absolute positionning \n \nG1 X0 Y220 ;Present print \nM106 S0 ;Turn-off fan \nM104 S0 ;Turn-off hotend \nM140 S0 ;Turn-off bed \n \nM84 X Y E ;Disable all steppers but Z",
 	"scan_first_layer": "0",

--- a/resources/profiles/Creality/machine/Creality Ender-3 V3 SE 0.6 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality Ender-3 V3 SE 0.6 nozzle.json
@@ -120,7 +120,7 @@
 	"default_filament_profile": [
 		"Creality Generic PLA @Ender-3V3-all"
 	],
-    "file_start_gcode": ";FLAVOR:Marlin\\n;TIME:{print_time_total_sec}\\n;Filament used:{used_filament_length}m\\n;Layer height:{layer_height}",
+	"file_start_gcode": ";FLAVOR:Marlin\\n;TIME:{print_time_total_sec}\\n;Filament used:{used_filament_length}m\\n;Layer height:{layer_height}",
 	"machine_start_gcode": "M220 S100 ;Reset Feedrate \nM221 S100 ;Reset Flowrate \n \nM104 S[nozzle_temperature_initial_layer] ;Set final nozzle temp \nM190 S[bed_temperature_initial_layer_single] ;Set and wait for bed temp to stabilize \nG28 ;Home \nG92 E0 ;Reset Extruder \nG1 Z2.0 F3000 ;Move Z Axis up \nG1 X-2.1 Y20 Z0.28 F5000.0 ;Move to start position \nM109 S[nozzle_temperature_initial_layer] ;Wait for nozzle temp to stabilize \nG1 X-2.1 Y145.0 Z0.28 F1500.0 E15 ;Draw the first line \nG1 X-2.4 Y145.0 Z0.28 F5000.0 ;Move to side a little \nG1 X-2.4 Y20 Z0.28 F1500.0 E30 ;Draw the second line \nG92 E0  ;Reset Extruder \nG1 E-1.0000 F1800 ;Retract a bit \nG1 Z2.0 F3000 ;Move Z Axis up \nG1 E0.0000 F1800",
 	"machine_end_gcode": "G91 ;Relative positionning \nG1 E-2 F2700 ;Retract a bit \nG1 E-2 Z0.2 F2400 ;Retract and raise Z \nG1 X5 Y5 F3000 ;Wipe out \nG1 Z10 ;Raise Z more \nG90 ;Absolute positionning \n \nG1 X0 Y220 ;Present print \nM106 S0 ;Turn-off fan \nM104 S0 ;Turn-off hotend \nM140 S0 ;Turn-off bed \n \nM84 X Y E ;Disable all steppers but Z",
 	"scan_first_layer": "0",

--- a/resources/profiles/Creality/machine/Creality Ender-3 V3 SE 0.6 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality Ender-3 V3 SE 0.6 nozzle.json
@@ -120,7 +120,6 @@
 	"default_filament_profile": [
 		"Creality Generic PLA @Ender-3V3-all"
 	],
-	"file_start_gcode": ";FLAVOR:Marlin\\n;TIME:{print_time_sec}\\n;Filament used:{used_filament_length}m\\n;Layer height:{layer_height}",
 	"machine_start_gcode": "M220 S100 ;Reset Feedrate \nM221 S100 ;Reset Flowrate \n \nM104 S[nozzle_temperature_initial_layer] ;Set final nozzle temp \nM190 S[bed_temperature_initial_layer_single] ;Set and wait for bed temp to stabilize \nG28 ;Home \nG92 E0 ;Reset Extruder \nG1 Z2.0 F3000 ;Move Z Axis up \nG1 X-2.1 Y20 Z0.28 F5000.0 ;Move to start position \nM109 S[nozzle_temperature_initial_layer] ;Wait for nozzle temp to stabilize \nG1 X-2.1 Y145.0 Z0.28 F1500.0 E15 ;Draw the first line \nG1 X-2.4 Y145.0 Z0.28 F5000.0 ;Move to side a little \nG1 X-2.4 Y20 Z0.28 F1500.0 E30 ;Draw the second line \nG92 E0  ;Reset Extruder \nG1 E-1.0000 F1800 ;Retract a bit \nG1 Z2.0 F3000 ;Move Z Axis up \nG1 E0.0000 F1800",
 	"machine_end_gcode": "G91 ;Relative positionning \nG1 E-2 F2700 ;Retract a bit \nG1 E-2 Z0.2 F2400 ;Retract and raise Z \nG1 X5 Y5 F3000 ;Wipe out \nG1 Z10 ;Raise Z more \nG90 ;Absolute positionning \n \nG1 X0 Y220 ;Present print \nM106 S0 ;Turn-off fan \nM104 S0 ;Turn-off hotend \nM140 S0 ;Turn-off bed \n \nM84 X Y E ;Disable all steppers but Z",
 	"scan_first_layer": "0",

--- a/resources/profiles/Creality/machine/Creality Ender-3 V3 SE 0.8 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality Ender-3 V3 SE 0.8 nozzle.json
@@ -120,6 +120,7 @@
 	"default_filament_profile": [
 		"Creality Generic PLA @Ender-3V3-all"
 	],
+    "file_start_gcode": ";FLAVOR:Marlin\\n;TIME:{print_time_total_sec}\\n;Filament used:{used_filament_length}m\\n;Layer height:{layer_height}",
 	"machine_start_gcode": "M220 S100 ;Reset Feedrate \nM221 S100 ;Reset Flowrate \n \nM104 S[nozzle_temperature_initial_layer] ;Set final nozzle temp \nM190 S[bed_temperature_initial_layer_single] ;Set and wait for bed temp to stabilize \nG28 ;Home \nG92 E0 ;Reset Extruder \nG1 Z2.0 F3000 ;Move Z Axis up \nG1 X-2.1 Y20 Z0.28 F5000.0 ;Move to start position \nM109 S[nozzle_temperature_initial_layer] ;Wait for nozzle temp to stabilize \nG1 X-2.1 Y145.0 Z0.28 F1500.0 E15 ;Draw the first line \nG1 X-2.4 Y145.0 Z0.28 F5000.0 ;Move to side a little \nG1 X-2.4 Y20 Z0.28 F1500.0 E30 ;Draw the second line \nG92 E0  ;Reset Extruder \nG1 E-1.0000 F1800 ;Retract a bit \nG1 Z2.0 F3000 ;Move Z Axis up \nG1 E0.0000 F1800",
 	"machine_end_gcode": "G91 ;Relative positionning \nG1 E-2 F2700 ;Retract a bit \nG1 E-2 Z0.2 F2400 ;Retract and raise Z \nG1 X5 Y5 F3000 ;Wipe out \nG1 Z10 ;Raise Z more \nG90 ;Absolute positionning \n \nG1 X0 Y220 ;Present print \nM106 S0 ;Turn-off fan \nM104 S0 ;Turn-off hotend \nM140 S0 ;Turn-off bed \n \nM84 X Y E ;Disable all steppers but Z",
 	"scan_first_layer": "0",

--- a/resources/profiles/Creality/machine/Creality Ender-3 V3 SE 0.8 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality Ender-3 V3 SE 0.8 nozzle.json
@@ -120,7 +120,7 @@
 	"default_filament_profile": [
 		"Creality Generic PLA @Ender-3V3-all"
 	],
-    "file_start_gcode": ";FLAVOR:Marlin\\n;TIME:{print_time_total_sec}\\n;Filament used:{used_filament_length}m\\n;Layer height:{layer_height}",
+	"file_start_gcode": ";FLAVOR:Marlin\\n;TIME:{print_time_total_sec}\\n;Filament used:{used_filament_length}m\\n;Layer height:{layer_height}",
 	"machine_start_gcode": "M220 S100 ;Reset Feedrate \nM221 S100 ;Reset Flowrate \n \nM104 S[nozzle_temperature_initial_layer] ;Set final nozzle temp \nM190 S[bed_temperature_initial_layer_single] ;Set and wait for bed temp to stabilize \nG28 ;Home \nG92 E0 ;Reset Extruder \nG1 Z2.0 F3000 ;Move Z Axis up \nG1 X-2.1 Y20 Z0.28 F5000.0 ;Move to start position \nM109 S[nozzle_temperature_initial_layer] ;Wait for nozzle temp to stabilize \nG1 X-2.1 Y145.0 Z0.28 F1500.0 E15 ;Draw the first line \nG1 X-2.4 Y145.0 Z0.28 F5000.0 ;Move to side a little \nG1 X-2.4 Y20 Z0.28 F1500.0 E30 ;Draw the second line \nG92 E0  ;Reset Extruder \nG1 E-1.0000 F1800 ;Retract a bit \nG1 Z2.0 F3000 ;Move Z Axis up \nG1 E0.0000 F1800",
 	"machine_end_gcode": "G91 ;Relative positionning \nG1 E-2 F2700 ;Retract a bit \nG1 E-2 Z0.2 F2400 ;Retract and raise Z \nG1 X5 Y5 F3000 ;Wipe out \nG1 Z10 ;Raise Z more \nG90 ;Absolute positionning \n \nG1 X0 Y220 ;Present print \nM106 S0 ;Turn-off fan \nM104 S0 ;Turn-off hotend \nM140 S0 ;Turn-off bed \n \nM84 X Y E ;Disable all steppers but Z",
 	"scan_first_layer": "0",

--- a/resources/profiles/Creality/machine/Creality Ender-3 V3 SE 0.8 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality Ender-3 V3 SE 0.8 nozzle.json
@@ -120,7 +120,6 @@
 	"default_filament_profile": [
 		"Creality Generic PLA @Ender-3V3-all"
 	],
-	"file_start_gcode": ";FLAVOR:Marlin\\n;TIME:{print_time_sec}\\n;Filament used:{used_filament_length}m\\n;Layer height:{layer_height}",
 	"machine_start_gcode": "M220 S100 ;Reset Feedrate \nM221 S100 ;Reset Flowrate \n \nM104 S[nozzle_temperature_initial_layer] ;Set final nozzle temp \nM190 S[bed_temperature_initial_layer_single] ;Set and wait for bed temp to stabilize \nG28 ;Home \nG92 E0 ;Reset Extruder \nG1 Z2.0 F3000 ;Move Z Axis up \nG1 X-2.1 Y20 Z0.28 F5000.0 ;Move to start position \nM109 S[nozzle_temperature_initial_layer] ;Wait for nozzle temp to stabilize \nG1 X-2.1 Y145.0 Z0.28 F1500.0 E15 ;Draw the first line \nG1 X-2.4 Y145.0 Z0.28 F5000.0 ;Move to side a little \nG1 X-2.4 Y20 Z0.28 F1500.0 E30 ;Draw the second line \nG92 E0  ;Reset Extruder \nG1 E-1.0000 F1800 ;Retract a bit \nG1 Z2.0 F3000 ;Move Z Axis up \nG1 E0.0000 F1800",
 	"machine_end_gcode": "G91 ;Relative positionning \nG1 E-2 F2700 ;Retract a bit \nG1 E-2 Z0.2 F2400 ;Retract and raise Z \nG1 X5 Y5 F3000 ;Wipe out \nG1 Z10 ;Raise Z more \nG90 ;Absolute positionning \n \nG1 X0 Y220 ;Present print \nM106 S0 ;Turn-off fan \nM104 S0 ;Turn-off hotend \nM140 S0 ;Turn-off bed \n \nM84 X Y E ;Disable all steppers but Z",
 	"scan_first_layer": "0",

--- a/resources/profiles/Creality/machine/fdm_creality_common.json
+++ b/resources/profiles/Creality/machine/fdm_creality_common.json
@@ -1,139 +1,139 @@
 {
-    "type": "machine",
-    "name": "fdm_creality_common",
-    "inherits": "fdm_machine_common",
-    "from": "system",
-    "instantiation": "false",
-    "gcode_flavor": "marlin",
-    "machine_max_acceleration_e": [
-        "5000",
-        "5000"
-    ],
-    "machine_max_acceleration_extruding": [
-        "500",
-        "500"
-    ],
-    "machine_max_acceleration_retracting": [
-        "1000",
-        "1000"
-    ],
-    "machine_max_acceleration_travel": [
-        "500",
-        "500"
-    ],
-    "machine_max_acceleration_x": [
-        "500",
-        "500"
-    ],
-    "machine_max_acceleration_y": [
-        "500",
-        "500"
-    ],
-    "machine_max_acceleration_z": [
-        "500",
-        "500"
-    ],
-    "machine_max_speed_e": [
-        "60",
-        "60"
-    ],
-    "machine_max_speed_x": [
-        "500",
-        "500"
-    ],
-    "machine_max_speed_y": [
-        "500",
-        "500"
-    ],
-    "machine_max_speed_z": [
-        "10",
-        "10"
-    ],
-    "machine_max_jerk_e": [
-        "5",
-        "5"
-    ],
-    "machine_max_jerk_x": [
-        "8",
-        "8"
-    ],
-    "machine_max_jerk_y": [
-        "8",
-        "8"
-    ],
-    "machine_max_jerk_z": [
-        "0.4",
-        "0.4"
-    ],
-    "machine_min_extruding_rate": [
-        "0",
-        "0"
-    ],
-    "machine_min_travel_rate": [
-        "0",
-        "0"
-    ],
-    "max_layer_height": [
-        "0.32"
-    ],
-    "min_layer_height": [
-        "0.08"
-    ],
-    "printable_height": "250",
-    "extruder_clearance_radius": "47",
-    "extruder_clearance_height_to_rod": "34",
-    "extruder_clearance_height_to_lid": "34",
-    "printer_settings_id": "",
-    "printer_technology": "FFF",
-    "printer_variant": "0.4",
-    "retraction_minimum_travel": [
-        "2"
-    ],
-    "retract_before_wipe": [
-        "70%"
-    ],
-    "retract_when_changing_layer": [
-        "1"
-    ],
-    "retraction_length": [
-        "5"
-    ],
-    "retract_length_toolchange": [
-        "2"
-    ],
-    "z_hop": [
-        "0.4"
-    ],
-    "retract_restart_extra": [
-        "0"
-    ],
-    "retract_restart_extra_toolchange": [
-        "0"
-    ],
-    "retraction_speed": [
-        "60"
-    ],
-    "deretraction_speed": [
-        "40"
-    ],
-    "silent_mode": "0",
-    "single_extruder_multi_material": "1",
-    "change_filament_gcode": "",
-    "machine_pause_gcode": "M25 ;pause print",
-    "wipe": [
-        "1"
-    ],
-    "default_filament_profile": [
-        "Creality Generic PLA"
-    ],
-    "default_print_profile": "0.20mm Standard @Creality",
-    "bed_exclude_area": [
-        "0x0"
-    ],
-    "machine_start_gcode": "G90 ; use absolute coordinates\nM83 ; extruder relative mode\nM140 S[bed_temperature_initial_layer] ; set final bed temp\nM104 S150 ; set temporary nozzle temp to prevent oozing during homing\nG4 S10 ; allow partial nozzle warmup\nG28 ; home all axis\nG1 Z50 F240\nG1 X2 Y10 F3000\nM104 S[nozzle_temperature_initial_layer] ; set final nozzle temp\nM190 S[bed_temperature_initial_layer] ; wait for bed temp to stabilize\nM109 S[nozzle_temperature_initial_layer] ; wait for nozzle temp to stabilize\nG1 Z0.28 F240\nG92 E0\nG1 Y140 E10 F1500 ; prime the nozzle\nG1 X2.3 F5000\nG92 E0\nG1 Y10 E10 F1200 ; prime the nozzle\nG92 E0",
-    "machine_end_gcode": "{if max_layer_z < printable_height}G1 Z{min(max_layer_z+2, printable_height)} F600 ; Move print head up{endif}\nG1 X5 Y{print_bed_max[1]*0.8} F{travel_speed*60} ; present print\n{if max_layer_z < printable_height-10}G1 Z{min(max_layer_z+70, printable_height-10)} F600 ; Move print head further up{endif}\n{if max_layer_z < printable_height*0.6}G1 Z{printable_height*0.6} F600 ; Move print head further up{endif}\nM140 S0 ; turn off heatbed\nM104 S0 ; turn off temperature\nM107 ; turn off fan\nM84 X Y E ; disable motors",
-    "layer_change_gcode": "",
-    "scan_first_layer": "0",
-    "nozzle_type": "undefine",
-    "auxiliary_fan": "0"
+	"type": "machine",
+	"name": "fdm_creality_common",
+	"inherits": "fdm_machine_common",
+	"from": "system",
+	"instantiation": "false",
+	"gcode_flavor": "marlin",
+	"machine_max_acceleration_e": [
+		"5000",
+		"5000"
+	],
+	"machine_max_acceleration_extruding": [
+		"500",
+		"500"
+	],
+	"machine_max_acceleration_retracting": [
+		"1000",
+		"1000"
+	],
+	"machine_max_acceleration_travel": [
+		"500",
+		"500"
+	],
+	"machine_max_acceleration_x": [
+		"500",
+		"500"
+	],
+	"machine_max_acceleration_y": [
+		"500",
+		"500"
+	],
+	"machine_max_acceleration_z": [
+		"500",
+		"500"
+	],
+	"machine_max_speed_e": [
+		"60",
+		"60"
+	],
+	"machine_max_speed_x": [
+		"500",
+		"500"
+	],
+	"machine_max_speed_y": [
+		"500",
+		"500"
+	],
+	"machine_max_speed_z": [
+		"10",
+		"10"
+	],
+	"machine_max_jerk_e": [
+		"5",
+		"5"
+	],
+	"machine_max_jerk_x": [
+		"8",
+		"8"
+	],
+	"machine_max_jerk_y": [
+		"8",
+		"8"
+	],
+	"machine_max_jerk_z": [
+		"0.4",
+		"0.4"
+	],
+	"machine_min_extruding_rate": [
+		"0",
+		"0"
+	],
+	"machine_min_travel_rate": [
+		"0",
+		"0"
+	],
+	"max_layer_height": [
+		"0.32"
+	],
+	"min_layer_height": [
+		"0.08"
+	],
+	"printable_height": "250",
+	"extruder_clearance_radius": "47",
+	"extruder_clearance_height_to_rod": "34",
+	"extruder_clearance_height_to_lid": "34",
+	"printer_settings_id": "",
+	"printer_technology": "FFF",
+	"printer_variant": "0.4",
+	"retraction_minimum_travel": [
+		"2"
+	],
+	"retract_before_wipe": [
+		"70%"
+	],
+	"retract_when_changing_layer": [
+		"1"
+	],
+	"retraction_length": [
+		"5"
+	],
+	"retract_length_toolchange": [
+		"2"
+	],
+	"z_hop": [
+		"0.4"
+	],
+	"retract_restart_extra": [
+		"0"
+	],
+	"retract_restart_extra_toolchange": [
+		"0"
+	],
+	"retraction_speed": [
+		"60"
+	],
+	"deretraction_speed": [
+		"40"
+	],
+	"silent_mode": "0",
+	"single_extruder_multi_material": "1",
+	"change_filament_gcode": "",
+	"machine_pause_gcode": "M25 ;pause print",
+	"wipe": [
+		"1"
+	],
+	"default_filament_profile": [
+		"Creality Generic PLA"
+	],
+	"default_print_profile": "0.20mm Standard @Creality",
+	"bed_exclude_area": [
+		"0x0"
+	],
+	"machine_start_gcode": "G90 ; use absolute coordinates\nM83 ; extruder relative mode\nM140 S[bed_temperature_initial_layer] ; set final bed temp\nM104 S150 ; set temporary nozzle temp to prevent oozing during homing\nG4 S10 ; allow partial nozzle warmup\nG28 ; home all axis\nG1 Z50 F240\nG1 X2 Y10 F3000\nM104 S[nozzle_temperature_initial_layer] ; set final nozzle temp\nM190 S[bed_temperature_initial_layer] ; wait for bed temp to stabilize\nM109 S[nozzle_temperature_initial_layer] ; wait for nozzle temp to stabilize\nG1 Z0.28 F240\nG92 E0\nG1 Y140 E10 F1500 ; prime the nozzle\nG1 X2.3 F5000\nG92 E0\nG1 Y10 E10 F1200 ; prime the nozzle\nG92 E0",
+	"machine_end_gcode": "{if max_layer_z < printable_height}G1 Z{min(max_layer_z+2, printable_height)} F600 ; Move print head up{endif}\nG1 X5 Y{print_bed_max[1]*0.8} F{travel_speed*60} ; present print\n{if max_layer_z < printable_height-10}G1 Z{min(max_layer_z+70, printable_height-10)} F600 ; Move print head further up{endif}\n{if max_layer_z < printable_height*0.6}G1 Z{printable_height*0.6} F600 ; Move print head further up{endif}\nM140 S0 ; turn off heatbed\nM104 S0 ; turn off temperature\nM107 ; turn off fan\nM84 X Y E ; disable motors",
+	"layer_change_gcode": "",
+	"scan_first_layer": "0",
+	"nozzle_type": "undefine",
+	"auxiliary_fan": "0"
 }

--- a/resources/profiles/Creality/machine/fdm_creality_common.json
+++ b/resources/profiles/Creality/machine/fdm_creality_common.json
@@ -1,139 +1,140 @@
 {
-	"type": "machine",
-	"name": "fdm_creality_common",
-	"inherits": "fdm_machine_common",
-	"from": "system",
-	"instantiation": "false",
-	"gcode_flavor": "marlin",
-	"machine_max_acceleration_e": [
-		"5000",
-		"5000"
-	],
-	"machine_max_acceleration_extruding": [
-		"500",
-		"500"
-	],
-	"machine_max_acceleration_retracting": [
-		"1000",
-		"1000"
-	],
-	"machine_max_acceleration_travel": [
-		"500",
-		"500"
-	],
-	"machine_max_acceleration_x": [
-		"500",
-		"500"
-	],
-	"machine_max_acceleration_y": [
-		"500",
-		"500"
-	],
-	"machine_max_acceleration_z": [
-		"500",
-		"500"
-	],
-	"machine_max_speed_e": [
-		"60",
-		"60"
-	],
-	"machine_max_speed_x": [
-		"500",
-		"500"
-	],
-	"machine_max_speed_y": [
-		"500",
-		"500"
-	],
-	"machine_max_speed_z": [
-		"10",
-		"10"
-	],
-	"machine_max_jerk_e": [
-		"5",
-		"5"
-	],
-	"machine_max_jerk_x": [
-		"8",
-		"8"
-	],
-	"machine_max_jerk_y": [
-		"8",
-		"8"
-	],
-	"machine_max_jerk_z": [
-		"0.4",
-		"0.4"
-	],
-	"machine_min_extruding_rate": [
-		"0",
-		"0"
-	],
-	"machine_min_travel_rate": [
-		"0",
-		"0"
-	],
-	"max_layer_height": [
-		"0.32"
-	],
-	"min_layer_height": [
-		"0.08"
-	],
-	"printable_height": "250",
-	"extruder_clearance_radius": "47",
-	"extruder_clearance_height_to_rod": "34",
-	"extruder_clearance_height_to_lid": "34",
-	"printer_settings_id": "",
-	"printer_technology": "FFF",
-	"printer_variant": "0.4",
-	"retraction_minimum_travel": [
-		"2"
-	],
-	"retract_before_wipe": [
-		"70%"
-	],
-	"retract_when_changing_layer": [
-		"1"
-	],
-	"retraction_length": [
-		"5"
-	],
-	"retract_length_toolchange": [
-		"2"
-	],
-	"z_hop": [
-		"0.4"
-	],
-	"retract_restart_extra": [
-		"0"
-	],
-	"retract_restart_extra_toolchange": [
-		"0"
-	],
-	"retraction_speed": [
-		"60"
-	],
-	"deretraction_speed": [
-		"40"
-	],
-	"silent_mode": "0",
-	"single_extruder_multi_material": "1",
-	"change_filament_gcode": "",
-	"machine_pause_gcode": "M25 ;pause print",
-	"wipe": [
-		"1"
-	],
-	"default_filament_profile": [
-		"Creality Generic PLA"
-	],
-	"default_print_profile": "0.20mm Standard @Creality",
-	"bed_exclude_area": [
-		"0x0"
-	],
-	"machine_start_gcode": "G90 ; use absolute coordinates\nM83 ; extruder relative mode\nM140 S[bed_temperature_initial_layer] ; set final bed temp\nM104 S150 ; set temporary nozzle temp to prevent oozing during homing\nG4 S10 ; allow partial nozzle warmup\nG28 ; home all axis\nG1 Z50 F240\nG1 X2 Y10 F3000\nM104 S[nozzle_temperature_initial_layer] ; set final nozzle temp\nM190 S[bed_temperature_initial_layer] ; wait for bed temp to stabilize\nM109 S[nozzle_temperature_initial_layer] ; wait for nozzle temp to stabilize\nG1 Z0.28 F240\nG92 E0\nG1 Y140 E10 F1500 ; prime the nozzle\nG1 X2.3 F5000\nG92 E0\nG1 Y10 E10 F1200 ; prime the nozzle\nG92 E0",
-	"machine_end_gcode": "{if max_layer_z < printable_height}G1 Z{min(max_layer_z+2, printable_height)} F600 ; Move print head up{endif}\nG1 X5 Y{print_bed_max[1]*0.8} F{travel_speed*60} ; present print\n{if max_layer_z < printable_height-10}G1 Z{min(max_layer_z+70, printable_height-10)} F600 ; Move print head further up{endif}\n{if max_layer_z < printable_height*0.6}G1 Z{printable_height*0.6} F600 ; Move print head further up{endif}\nM140 S0 ; turn off heatbed\nM104 S0 ; turn off temperature\nM107 ; turn off fan\nM84 X Y E ; disable motors",
-	"layer_change_gcode": "",
-	"scan_first_layer": "0",
-	"nozzle_type": "undefine",
-	"auxiliary_fan": "0"
+    "type": "machine",
+    "name": "fdm_creality_common",
+    "inherits": "fdm_machine_common",
+    "from": "system",
+    "instantiation": "false",
+    "gcode_flavor": "marlin",
+    "machine_max_acceleration_e": [
+        "5000",
+        "5000"
+    ],
+    "machine_max_acceleration_extruding": [
+        "500",
+        "500"
+    ],
+    "machine_max_acceleration_retracting": [
+        "1000",
+        "1000"
+    ],
+    "machine_max_acceleration_travel": [
+        "500",
+        "500"
+    ],
+    "machine_max_acceleration_x": [
+        "500",
+        "500"
+    ],
+    "machine_max_acceleration_y": [
+        "500",
+        "500"
+    ],
+    "machine_max_acceleration_z": [
+        "500",
+        "500"
+    ],
+    "machine_max_speed_e": [
+        "60",
+        "60"
+    ],
+    "machine_max_speed_x": [
+        "500",
+        "500"
+    ],
+    "machine_max_speed_y": [
+        "500",
+        "500"
+    ],
+    "machine_max_speed_z": [
+        "10",
+        "10"
+    ],
+    "machine_max_jerk_e": [
+        "5",
+        "5"
+    ],
+    "machine_max_jerk_x": [
+        "8",
+        "8"
+    ],
+    "machine_max_jerk_y": [
+        "8",
+        "8"
+    ],
+    "machine_max_jerk_z": [
+        "0.4",
+        "0.4"
+    ],
+    "machine_min_extruding_rate": [
+        "0",
+        "0"
+    ],
+    "machine_min_travel_rate": [
+        "0",
+        "0"
+    ],
+    "max_layer_height": [
+        "0.32"
+    ],
+    "min_layer_height": [
+        "0.08"
+    ],
+    "printable_height": "250",
+    "extruder_clearance_radius": "47",
+    "extruder_clearance_height_to_rod": "34",
+    "extruder_clearance_height_to_lid": "34",
+    "printer_settings_id": "",
+    "printer_technology": "FFF",
+    "printer_variant": "0.4",
+    "retraction_minimum_travel": [
+        "2"
+    ],
+    "retract_before_wipe": [
+        "70%"
+    ],
+    "retract_when_changing_layer": [
+        "1"
+    ],
+    "retraction_length": [
+        "5"
+    ],
+    "retract_length_toolchange": [
+        "2"
+    ],
+    "z_hop": [
+        "0.4"
+    ],
+    "retract_restart_extra": [
+        "0"
+    ],
+    "retract_restart_extra_toolchange": [
+        "0"
+    ],
+    "retraction_speed": [
+        "60"
+    ],
+    "deretraction_speed": [
+        "40"
+    ],
+    "silent_mode": "0",
+    "single_extruder_multi_material": "1",
+    "change_filament_gcode": "",
+    "machine_pause_gcode": "M25 ;pause print",
+    "wipe": [
+        "1"
+    ],
+    "default_filament_profile": [
+        "Creality Generic PLA"
+    ],
+    "default_print_profile": "0.20mm Standard @Creality",
+    "bed_exclude_area": [
+        "0x0"
+    ],
+    "file_start_gcode": ";FLAVOR:Marlin\\n;TIME:{print_time_total_sec}\\n;Filament used:{used_filament_length}m\\n;Layer height:{layer_height}",
+    "machine_start_gcode": "G90 ; use absolute coordinates\nM83 ; extruder relative mode\nM140 S[bed_temperature_initial_layer] ; set final bed temp\nM104 S150 ; set temporary nozzle temp to prevent oozing during homing\nG4 S10 ; allow partial nozzle warmup\nG28 ; home all axis\nG1 Z50 F240\nG1 X2 Y10 F3000\nM104 S[nozzle_temperature_initial_layer] ; set final nozzle temp\nM190 S[bed_temperature_initial_layer] ; wait for bed temp to stabilize\nM109 S[nozzle_temperature_initial_layer] ; wait for nozzle temp to stabilize\nG1 Z0.28 F240\nG92 E0\nG1 Y140 E10 F1500 ; prime the nozzle\nG1 X2.3 F5000\nG92 E0\nG1 Y10 E10 F1200 ; prime the nozzle\nG92 E0",
+    "machine_end_gcode": "{if max_layer_z < printable_height}G1 Z{min(max_layer_z+2, printable_height)} F600 ; Move print head up{endif}\nG1 X5 Y{print_bed_max[1]*0.8} F{travel_speed*60} ; present print\n{if max_layer_z < printable_height-10}G1 Z{min(max_layer_z+70, printable_height-10)} F600 ; Move print head further up{endif}\n{if max_layer_z < printable_height*0.6}G1 Z{printable_height*0.6} F600 ; Move print head further up{endif}\nM140 S0 ; turn off heatbed\nM104 S0 ; turn off temperature\nM107 ; turn off fan\nM84 X Y E ; disable motors",
+    "layer_change_gcode": "",
+    "scan_first_layer": "0",
+    "nozzle_type": "undefine",
+    "auxiliary_fan": "0"
 }

--- a/resources/profiles/Creality/machine/fdm_creality_common.json
+++ b/resources/profiles/Creality/machine/fdm_creality_common.json
@@ -130,7 +130,6 @@
     "bed_exclude_area": [
         "0x0"
     ],
-    "file_start_gcode": ";FLAVOR:Marlin\\n;TIME:{print_time_total_sec}\\n;Filament used:{used_filament_length}m\\n;Layer height:{layer_height}",
     "machine_start_gcode": "G90 ; use absolute coordinates\nM83 ; extruder relative mode\nM140 S[bed_temperature_initial_layer] ; set final bed temp\nM104 S150 ; set temporary nozzle temp to prevent oozing during homing\nG4 S10 ; allow partial nozzle warmup\nG28 ; home all axis\nG1 Z50 F240\nG1 X2 Y10 F3000\nM104 S[nozzle_temperature_initial_layer] ; set final nozzle temp\nM190 S[bed_temperature_initial_layer] ; wait for bed temp to stabilize\nM109 S[nozzle_temperature_initial_layer] ; wait for nozzle temp to stabilize\nG1 Z0.28 F240\nG92 E0\nG1 Y140 E10 F1500 ; prime the nozzle\nG1 X2.3 F5000\nG92 E0\nG1 Y10 E10 F1200 ; prime the nozzle\nG92 E0",
     "machine_end_gcode": "{if max_layer_z < printable_height}G1 Z{min(max_layer_z+2, printable_height)} F600 ; Move print head up{endif}\nG1 X5 Y{print_bed_max[1]*0.8} F{travel_speed*60} ; present print\n{if max_layer_z < printable_height-10}G1 Z{min(max_layer_z+70, printable_height-10)} F600 ; Move print head further up{endif}\n{if max_layer_z < printable_height*0.6}G1 Z{printable_height*0.6} F600 ; Move print head further up{endif}\nM140 S0 ; turn off heatbed\nM104 S0 ; turn off temperature\nM107 ; turn off fan\nM84 X Y E ; disable motors",
     "layer_change_gcode": "",

--- a/resources/profiles/Flashforge/machine/fdm_adventurer5m_common.json
+++ b/resources/profiles/Flashforge/machine/fdm_adventurer5m_common.json
@@ -1,123 +1,123 @@
 {
-    "type": "machine",
-    "name": "fdm_adventurer5m_common",
-    "inherits": "fdm_flashforge_common",
-    "from": "system",
-    "instantiation": "false",
-    "gcode_flavor": "klipper",
-    "printable_area": [
-        "-110x-110",
-        "110x-110",
-        "110x110",
-        "-110x110"
-    ],
-    "printable_height": "220",
-    "auxiliary_fan": "1",
-    "machine_max_acceleration_e": [
-        "5000",
-        "5000"
-    ],
-    "machine_max_acceleration_extruding": [
-        "20000",
-        "20000"
-    ],
-    "machine_max_acceleration_retracting": [
-        "5000",
-        "5000"
-    ],
-    "machine_max_acceleration_travel": [
-        "20000",
-        "20000"
-    ],
-    "machine_max_acceleration_x": [
-        "20000",
-        "20000"
-    ],
-    "machine_max_acceleration_y": [
-        "20000",
-        "20000"
-    ],
-    "machine_max_acceleration_z": [
-        "500",
-        "500"
-    ],
-    "machine_max_speed_e": [
-        "30",
-        "30"
-    ],
-    "machine_max_speed_x": [
-        "600",
-        "600"
-    ],
-    "machine_max_speed_y": [
-        "600",
-        "600"
-    ],
-    "machine_max_speed_z": [
-        "20",
-        "20"
-    ],
-    "machine_max_jerk_e": [
-        "2.5",
-        "2.5"
-    ],
-    "machine_max_jerk_x": [
-        "9",
-        "9"
-    ],
-    "machine_max_jerk_y": [
-        "9",
-        "9"
-    ],
-    "machine_max_jerk_z": [
-        "3",
-        "3"
-    ],
-    "printer_settings_id": "Flashforge",
-    "retraction_minimum_travel": [
-        "1"
-    ],
-    "retract_before_wipe": [
-        "100%"
-    ],
-    "retract_length_toolchange": [
-        "2"
-    ],
-    "deretraction_speed": [
-        "35"
-    ],
-    "z_hop": [
-        "0.4"
-    ],
-    "single_extruder_multi_material": "0",
-    "change_filament_gcode": "",
-    "machine_pause_gcode": "M25",
-    "support_multi_bed_types": "1",
-    "default_filament_profile": [
-        "Flashforge Generic PLA"
-    ],
-    "file_start_gcode": "; estimated printing time (normal mode) = {print_time_day}d {print_time_hour}h {print_time_minute}m {print_time_sec}s",
-    "machine_start_gcode": "M190 S[bed_temperature_initial_layer_single]\nM104 S[nozzle_temperature_initial_layer]\nG90\nM83\nG1 Z5 F6000\nG1 E-0.2 F800\nG1 X110 Y-110 F6000\nG1 E2 F800\nG1 Y-110 X55 Z0.25 F4800\nG1 X-55 E8 F2400\nG1 Y-109.6 F2400\nG1 X55 E5 F2400\nG1 Y-110 X55 Z0.45 F4800\nG1 X-55 E8 F2400\nG1 Y-109.6 F2400\nG1 X55 E5 F2400\nG92 E0",
-    "machine_end_gcode": "G1 E-3 F3600\nG0 X50 Y50 F30000\nM104 S0 ; turn off temperature",
-    "before_layer_change_gcode": ";BEFORE_LAYER_CHANGE\n;[layer_z]",
-    "layer_change_gcode": ";AFTER_LAYER_CHANGE\n;[layer_z]",
-    "scan_first_layer": "0",
-    "thumbnails": [
-        "140x110"
-    ],
-    "use_relative_e_distances": "1",
-    "z_hop_types": "Auto Lift",
-    "retraction_speed": [
-        "35"
-    ],
-    "wipe_distance": "2",
-    "extruder_clearance_radius": [
-        "76"
-    ],
-    "extruder_clearance_height_to_rod": [
-        "27"
-    ],
-    "extruder_clearance_height_to_lid": [
-        "150"
-    ]
+	"type": "machine",
+	"name": "fdm_adventurer5m_common",
+	"inherits": "fdm_flashforge_common",
+	"from": "system",
+	"instantiation": "false",
+	"gcode_flavor": "klipper",
+	"printable_area": [
+		"-110x-110",
+		"110x-110",
+		"110x110",
+		"-110x110"
+	],
+	"printable_height": "220",
+	"auxiliary_fan": "1",
+	"machine_max_acceleration_e": [
+		"5000",
+		"5000"
+	],
+	"machine_max_acceleration_extruding": [
+		"20000",
+		"20000"
+	],
+	"machine_max_acceleration_retracting": [
+		"5000",
+		"5000"
+	],
+	"machine_max_acceleration_travel": [
+		"20000",
+		"20000"
+	],
+	"machine_max_acceleration_x": [
+		"20000",
+		"20000"
+	],
+	"machine_max_acceleration_y": [
+		"20000",
+		"20000"
+	],
+	"machine_max_acceleration_z": [
+		"500",
+		"500"
+	],
+	"machine_max_speed_e": [
+		"30",
+		"30"
+	],
+	"machine_max_speed_x": [
+		"600",
+		"600"
+	],
+	"machine_max_speed_y": [
+		"600",
+		"600"
+	],
+	"machine_max_speed_z": [
+		"20",
+		"20"
+	],
+	"machine_max_jerk_e": [
+		"2.5",
+		"2.5"
+	],
+	"machine_max_jerk_x": [
+		"9",
+		"9"
+	],
+	"machine_max_jerk_y": [
+		"9",
+		"9"
+	],
+	"machine_max_jerk_z": [
+		"3",
+		"3"
+	],
+	"printer_settings_id": "Flashforge",
+	"retraction_minimum_travel": [
+		"1"
+	],
+	"retract_before_wipe": [
+		"100%"
+	],
+	"retract_length_toolchange": [
+		"2"
+	],
+	"deretraction_speed": [
+		"35"
+	],
+	"z_hop": [
+		"0.4"
+	],
+	"single_extruder_multi_material": "0",
+	"change_filament_gcode": "",
+	"machine_pause_gcode": "M25",
+	"support_multi_bed_types": "1",
+	"default_filament_profile": [
+		"Flashforge Generic PLA"
+	],
+	"file_start_gcode": "; estimated printing time (normal mode) = {print_time_day}d {print_time_hour}h {print_time_minute}m {print_time_sec}s",
+	"machine_start_gcode": "M190 S[bed_temperature_initial_layer_single]\nM104 S[nozzle_temperature_initial_layer]\nG90\nM83\nG1 Z5 F6000\nG1 E-0.2 F800\nG1 X110 Y-110 F6000\nG1 E2 F800\nG1 Y-110 X55 Z0.25 F4800\nG1 X-55 E8 F2400\nG1 Y-109.6 F2400\nG1 X55 E5 F2400\nG1 Y-110 X55 Z0.45 F4800\nG1 X-55 E8 F2400\nG1 Y-109.6 F2400\nG1 X55 E5 F2400\nG92 E0",
+	"machine_end_gcode": "G1 E-3 F3600\nG0 X50 Y50 F30000\nM104 S0 ; turn off temperature",
+	"before_layer_change_gcode": ";BEFORE_LAYER_CHANGE\n;[layer_z]",
+	"layer_change_gcode": ";AFTER_LAYER_CHANGE\n;[layer_z]",
+	"scan_first_layer": "0",
+	"thumbnails": [
+		"140x110"
+	],
+	"use_relative_e_distances": "1",
+	"z_hop_types": "Auto Lift",
+	"retraction_speed": [
+		"35"
+	],
+	"wipe_distance": "2",
+	"extruder_clearance_radius": [
+		"76"
+	],
+	"extruder_clearance_height_to_rod": [
+		"27"
+	],
+	"extruder_clearance_height_to_lid": [
+		"150"
+	]
 }

--- a/resources/profiles/Flashforge/machine/fdm_adventurer5m_common.json
+++ b/resources/profiles/Flashforge/machine/fdm_adventurer5m_common.json
@@ -1,122 +1,123 @@
 {
-	"type": "machine",
-	"name": "fdm_adventurer5m_common",
-	"inherits": "fdm_flashforge_common",
-	"from": "system",
-	"instantiation": "false",
-	"gcode_flavor": "klipper",
-	"printable_area": [
-		"-110x-110",
-		"110x-110",
-		"110x110",
-		"-110x110"
-	],
-	"printable_height": "220",
-	"auxiliary_fan": "1",
-	"machine_max_acceleration_e": [
-		"5000",
-		"5000"
-	],
-	"machine_max_acceleration_extruding": [
-		"20000",
-		"20000"
-	],
-	"machine_max_acceleration_retracting": [
-		"5000",
-		"5000"
-	],
-	"machine_max_acceleration_travel": [
-		"20000",
-		"20000"
-	],
-	"machine_max_acceleration_x": [
-		"20000",
-		"20000"
-	],
-	"machine_max_acceleration_y": [
-		"20000",
-		"20000"
-	],
-	"machine_max_acceleration_z": [
-		"500",
-		"500"
-	],
-	"machine_max_speed_e": [
-		"30",
-		"30"
-	],
-	"machine_max_speed_x": [
-		"600",
-		"600"
-	],
-	"machine_max_speed_y": [
-		"600",
-		"600"
-	],
-	"machine_max_speed_z": [
-		"20",
-		"20"
-	],
-	"machine_max_jerk_e": [
-		"2.5",
-		"2.5"
-	],
-	"machine_max_jerk_x": [
-		"9",
-		"9"
-	],
-	"machine_max_jerk_y": [
-		"9",
-		"9"
-	],
-	"machine_max_jerk_z": [
-		"3",
-		"3"
-	],
-	"printer_settings_id": "Flashforge",
-	"retraction_minimum_travel": [
-		"1"
-	],
-	"retract_before_wipe": [
-		"100%"
-	],
-	"retract_length_toolchange": [
-		"2"
-	],
-	"deretraction_speed": [
-		"35"
-	],
-	"z_hop": [
-		"0.4"
-	],
-	"single_extruder_multi_material": "0",
-	"change_filament_gcode": "",
-	"machine_pause_gcode": "M25",
-	"support_multi_bed_types": "1",
-	"default_filament_profile": [
-		"Flashforge Generic PLA"
-	],
-	"machine_start_gcode": "M190 S[bed_temperature_initial_layer_single]\nM104 S[nozzle_temperature_initial_layer]\nG90\nM83\nG1 Z5 F6000\nG1 E-0.2 F800\nG1 X110 Y-110 F6000\nG1 E2 F800\nG1 Y-110 X55 Z0.25 F4800\nG1 X-55 E8 F2400\nG1 Y-109.6 F2400\nG1 X55 E5 F2400\nG1 Y-110 X55 Z0.45 F4800\nG1 X-55 E8 F2400\nG1 Y-109.6 F2400\nG1 X55 E5 F2400\nG92 E0",
-	"machine_end_gcode": "G1 E-3 F3600\nG0 X50 Y50 F30000\nM104 S0 ; turn off temperature",
-	"before_layer_change_gcode": ";BEFORE_LAYER_CHANGE\n;[layer_z]",
-	"layer_change_gcode": ";AFTER_LAYER_CHANGE\n;[layer_z]",
-	"scan_first_layer": "0",
-	"thumbnails": [
-		"140x110"
-	],
-	"use_relative_e_distances": "1",
-	"z_hop_types": "Auto Lift",
-	"retraction_speed": [
-		"35"
-	],
-	"wipe_distance": "2",
-	"extruder_clearance_radius": [
-		"76"
-	],
-	"extruder_clearance_height_to_rod": [
-		"27"
-	],
-	"extruder_clearance_height_to_lid": [
-		"150"
-	]
+    "type": "machine",
+    "name": "fdm_adventurer5m_common",
+    "inherits": "fdm_flashforge_common",
+    "from": "system",
+    "instantiation": "false",
+    "gcode_flavor": "klipper",
+    "printable_area": [
+        "-110x-110",
+        "110x-110",
+        "110x110",
+        "-110x110"
+    ],
+    "printable_height": "220",
+    "auxiliary_fan": "1",
+    "machine_max_acceleration_e": [
+        "5000",
+        "5000"
+    ],
+    "machine_max_acceleration_extruding": [
+        "20000",
+        "20000"
+    ],
+    "machine_max_acceleration_retracting": [
+        "5000",
+        "5000"
+    ],
+    "machine_max_acceleration_travel": [
+        "20000",
+        "20000"
+    ],
+    "machine_max_acceleration_x": [
+        "20000",
+        "20000"
+    ],
+    "machine_max_acceleration_y": [
+        "20000",
+        "20000"
+    ],
+    "machine_max_acceleration_z": [
+        "500",
+        "500"
+    ],
+    "machine_max_speed_e": [
+        "30",
+        "30"
+    ],
+    "machine_max_speed_x": [
+        "600",
+        "600"
+    ],
+    "machine_max_speed_y": [
+        "600",
+        "600"
+    ],
+    "machine_max_speed_z": [
+        "20",
+        "20"
+    ],
+    "machine_max_jerk_e": [
+        "2.5",
+        "2.5"
+    ],
+    "machine_max_jerk_x": [
+        "9",
+        "9"
+    ],
+    "machine_max_jerk_y": [
+        "9",
+        "9"
+    ],
+    "machine_max_jerk_z": [
+        "3",
+        "3"
+    ],
+    "printer_settings_id": "Flashforge",
+    "retraction_minimum_travel": [
+        "1"
+    ],
+    "retract_before_wipe": [
+        "100%"
+    ],
+    "retract_length_toolchange": [
+        "2"
+    ],
+    "deretraction_speed": [
+        "35"
+    ],
+    "z_hop": [
+        "0.4"
+    ],
+    "single_extruder_multi_material": "0",
+    "change_filament_gcode": "",
+    "machine_pause_gcode": "M25",
+    "support_multi_bed_types": "1",
+    "default_filament_profile": [
+        "Flashforge Generic PLA"
+    ],
+    "file_start_gcode": "; estimated printing time (normal mode) = {print_time_day}d {print_time_hour}h {print_time_minute}m {print_time_sec}s",
+    "machine_start_gcode": "M190 S[bed_temperature_initial_layer_single]\nM104 S[nozzle_temperature_initial_layer]\nG90\nM83\nG1 Z5 F6000\nG1 E-0.2 F800\nG1 X110 Y-110 F6000\nG1 E2 F800\nG1 Y-110 X55 Z0.25 F4800\nG1 X-55 E8 F2400\nG1 Y-109.6 F2400\nG1 X55 E5 F2400\nG1 Y-110 X55 Z0.45 F4800\nG1 X-55 E8 F2400\nG1 Y-109.6 F2400\nG1 X55 E5 F2400\nG92 E0",
+    "machine_end_gcode": "G1 E-3 F3600\nG0 X50 Y50 F30000\nM104 S0 ; turn off temperature",
+    "before_layer_change_gcode": ";BEFORE_LAYER_CHANGE\n;[layer_z]",
+    "layer_change_gcode": ";AFTER_LAYER_CHANGE\n;[layer_z]",
+    "scan_first_layer": "0",
+    "thumbnails": [
+        "140x110"
+    ],
+    "use_relative_e_distances": "1",
+    "z_hop_types": "Auto Lift",
+    "retraction_speed": [
+        "35"
+    ],
+    "wipe_distance": "2",
+    "extruder_clearance_radius": [
+        "76"
+    ],
+    "extruder_clearance_height_to_rod": [
+        "27"
+    ],
+    "extruder_clearance_height_to_lid": [
+        "150"
+    ]
 }

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -2552,6 +2552,10 @@ void GCode::_do_export(Print& print, GCodeOutputStream &file, ThumbnailsGenerato
             // file_start_gcode runs before the parser copy that normally restores these, so set them here.
             PlaceholderParser::update_timestamp(top_config);
             PlaceholderParser::update_user_name(top_config);
+            top_config.set_key_value("print_time_total_sec", new ConfigOptionString(GCodeProcessor::reserved_tag(GCodeProcessor::ETags::Print_Time_Total_Sec_Placeholder)));
+            top_config.set_key_value("print_time_day", new ConfigOptionString(GCodeProcessor::reserved_tag(GCodeProcessor::ETags::Print_Time_Day_Placeholder)));
+            top_config.set_key_value("print_time_hour", new ConfigOptionString(GCodeProcessor::reserved_tag(GCodeProcessor::ETags::Print_Time_Hour_Placeholder)));
+            top_config.set_key_value("print_time_minute", new ConfigOptionString(GCodeProcessor::reserved_tag(GCodeProcessor::ETags::Print_Time_Minute_Placeholder)));
             top_config.set_key_value("print_time_sec", new ConfigOptionString(GCodeProcessor::reserved_tag(GCodeProcessor::ETags::Print_Time_Sec_Placeholder)));
             top_config.set_key_value("used_filament_length", new ConfigOptionString(GCodeProcessor::reserved_tag(GCodeProcessor::ETags::Used_Filament_Length_Placeholder)));
             std::string top_gcode = print.placeholder_parser().process(top_gcode_template, 0, &top_config);
@@ -3107,6 +3111,10 @@ void GCode::_do_export(Print& print, GCodeOutputStream &file, ThumbnailsGenerato
         this->placeholder_parser().set("hold_chamber_temp_for_flat_print", new ConfigOptionBool(hold_chamber_temp_for_flat_print));
     }
 
+    this->placeholder_parser().set("print_time_total_sec", new ConfigOptionString(GCodeProcessor::reserved_tag(GCodeProcessor::ETags::Print_Time_Total_Sec_Placeholder)));
+    this->placeholder_parser().set("print_time_day", new ConfigOptionString(GCodeProcessor::reserved_tag(GCodeProcessor::ETags::Print_Time_Day_Placeholder)));
+    this->placeholder_parser().set("print_time_hour", new ConfigOptionString(GCodeProcessor::reserved_tag(GCodeProcessor::ETags::Print_Time_Hour_Placeholder)));
+    this->placeholder_parser().set("print_time_minute", new ConfigOptionString(GCodeProcessor::reserved_tag(GCodeProcessor::ETags::Print_Time_Minute_Placeholder)));
     this->placeholder_parser().set("print_time_sec", new ConfigOptionString(GCodeProcessor::reserved_tag(GCodeProcessor::ETags::Print_Time_Sec_Placeholder)));
     this->placeholder_parser().set("used_filament_length", new ConfigOptionString(GCodeProcessor::reserved_tag(GCodeProcessor::ETags::Used_Filament_Length_Placeholder)));
 

--- a/src/libslic3r/GCode/GCodeProcessor.cpp
+++ b/src/libslic3r/GCode/GCodeProcessor.cpp
@@ -74,6 +74,10 @@ const std::vector<std::string> GCodeProcessor::Reserved_Tags = {
     " WIPE_TOWER_START",
     " WIPE_TOWER_END",
     " PA_CHANGE:",
+    "@PRINT_TIME_TOTAL_SEC@",
+    "@PRINT_TIME_DAY@",
+    "@PRINT_TIME_HOUR@",
+    "@PRINT_TIME_MINUTE@",
     "@PRINT_TIME_SEC@",
     "@USED_FILAMENT_LENGTH@"
 };
@@ -97,6 +101,10 @@ const std::vector<std::string> GCodeProcessor::Reserved_Tags_compatible = {
     " WIPE_TOWER_START",
     " WIPE_TOWER_END",
     " PA_CHANGE:",
+    "@PRINT_TIME_TOTAL_SEC@",
+    "@PRINT_TIME_DAY@",
+    "@PRINT_TIME_HOUR@",
+    "@PRINT_TIME_MINUTE@",
     "@PRINT_TIME_SEC@",
     "@USED_FILAMENT_LENGTH@"
 };
@@ -1105,22 +1113,76 @@ void GCodeProcessor::run_post_process()
         return ret;
     };
 
-    // Process inline placeholders (print_time_sec and used_filament_length)
+    // Process inline placeholders (print_time_total_sec, print_time_day, print_time_hour, print_time_minute, print_time_sec and used_filament_length)
     auto process_inline_placeholders = [&](std::string& gcode_line) {
         bool processed = false;
 
-        const std::string& print_time_placeholder = reserved_tag(ETags::Print_Time_Sec_Placeholder);
+        const std::string& print_time_total_placeholder = reserved_tag(ETags::Print_Time_Total_Sec_Placeholder);
+        const std::string& print_time_day_placeholder = reserved_tag(ETags::Print_Time_Day_Placeholder);
+        const std::string& print_time_hour_placeholder = reserved_tag(ETags::Print_Time_Hour_Placeholder);
+        const std::string& print_time_minute_placeholder = reserved_tag(ETags::Print_Time_Minute_Placeholder);
+        const std::string& print_time_sec_placeholder = reserved_tag(ETags::Print_Time_Sec_Placeholder);
         const std::string& used_filament_placeholder = reserved_tag(ETags::Used_Filament_Length_Placeholder);
 
-        // Replace print_time_sec
-        size_t pos = gcode_line.find(print_time_placeholder);
+        double print_time_total_sec = m_time_processor.machines[static_cast<size_t>(PrintEstimatedStatistics::ETimeMode::Normal)].time;
+        if (print_time_total_sec < 0.0)
+            print_time_total_sec = 0.0;
+
+        int total_seconds = static_cast<int>(print_time_total_sec);
+        int print_time_day = total_seconds / 86400;
+        int day_remainder_seconds = total_seconds % 86400;
+        int print_time_hour = day_remainder_seconds / 3600;
+        int print_time_minute = (day_remainder_seconds % 3600) / 60;
+        int print_time_sec = day_remainder_seconds % 60;
+
+        // Replace print_time_total_sec
+        size_t pos = gcode_line.find(print_time_total_placeholder);
         while (pos != std::string::npos) {
-            double print_time_sec = m_time_processor.machines[static_cast<size_t>(PrintEstimatedStatistics::ETimeMode::Normal)].time;
             char buf[64];
-            sprintf(buf, "%.2f", print_time_sec);
-            gcode_line.replace(pos, print_time_placeholder.length(), buf);
+            sprintf(buf, "%.2f", print_time_total_sec);
+            gcode_line.replace(pos, print_time_total_placeholder.length(), buf);
             processed = true;
-            pos = gcode_line.find(print_time_placeholder, pos + strlen(buf));
+            pos = gcode_line.find(print_time_total_placeholder, pos + strlen(buf));
+        }
+
+        // Replace print_time_day
+        pos = gcode_line.find(print_time_day_placeholder);
+        while (pos != std::string::npos) {
+            char buf[64];
+            sprintf(buf, "%d", print_time_day);
+            gcode_line.replace(pos, print_time_day_placeholder.length(), buf);
+            processed = true;
+            pos = gcode_line.find(print_time_day_placeholder, pos + strlen(buf));
+        }
+
+        // Replace print_time_hour
+        pos = gcode_line.find(print_time_hour_placeholder);
+        while (pos != std::string::npos) {
+            char buf[64];
+            sprintf(buf, "%d", print_time_hour);
+            gcode_line.replace(pos, print_time_hour_placeholder.length(), buf);
+            processed = true;
+            pos = gcode_line.find(print_time_hour_placeholder, pos + strlen(buf));
+        }
+
+        // Replace print_time_minute
+        pos = gcode_line.find(print_time_minute_placeholder);
+        while (pos != std::string::npos) {
+            char buf[64];
+            sprintf(buf, "%d", print_time_minute);
+            gcode_line.replace(pos, print_time_minute_placeholder.length(), buf);
+            processed = true;
+            pos = gcode_line.find(print_time_minute_placeholder, pos + strlen(buf));
+        }
+
+        // Replace print_time_sec
+        pos = gcode_line.find(print_time_sec_placeholder);
+        while (pos != std::string::npos) {
+            char buf[64];
+            sprintf(buf, "%d", print_time_sec);
+            gcode_line.replace(pos, print_time_sec_placeholder.length(), buf);
+            processed = true;
+            pos = gcode_line.find(print_time_sec_placeholder, pos + strlen(buf));
         }
 
         // Replace used_filament_length

--- a/src/libslic3r/GCode/GCodeProcessor.hpp
+++ b/src/libslic3r/GCode/GCodeProcessor.hpp
@@ -368,6 +368,10 @@ class Print;
             Wipe_Tower_Start,
             Wipe_Tower_End,
             PA_Change,
+            Print_Time_Total_Sec_Placeholder,
+            Print_Time_Day_Placeholder,
+            Print_Time_Hour_Placeholder,
+            Print_Time_Minute_Placeholder,
             Print_Time_Sec_Placeholder,
             Used_Filament_Length_Placeholder,
         };
@@ -1138,5 +1142,3 @@ class Print;
 } /* namespace Slic3r */
 
 #endif /* slic3r_GCodeProcessor_hpp_ */
-
-

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -5923,7 +5923,7 @@ void PrintConfigDef::init_fff_params()
     def->tooltip = L("G-code written at the very top of the output file, before any other content. "
                      "Useful for adding metadata that printer firmware reads from the first lines of the file "
                      "(e.g. estimated print time, filament usage). "
-                     "Supports placeholders like {print_time_sec} and {used_filament_length}.");
+                     "Supports placeholders like {print_time_total_sec}, {print_time_day}, {print_time_hour}, {print_time_minute}, {print_time_sec} and {used_filament_length}.");
     def->multiline = true;
     def->full_width = true;
     def->height = 8;
@@ -11211,9 +11211,25 @@ PrintStatisticsConfigDef::PrintStatisticsConfigDef()
     def->label = L("Used filament");
     def->tooltip = L("Total length of filament used in the print.");
 
-    def = this->add("print_time_sec", coString);
-    def->label = L("Print time (seconds)");
+    def = this->add("print_time_total_sec", coString);
+    def->label = L("Print time (total seconds)");
     def->tooltip = L("Total estimated print time in seconds. Replaced with actual value during post-processing.");
+
+    def = this->add("print_time_day", coString);
+    def->label = L("Print time (days component)");
+    def->tooltip = L("Estimated print time day component (normal mode). Replaced with actual value during post-processing.");
+
+    def = this->add("print_time_hour", coString);
+    def->label = L("Print time (hours component)");
+    def->tooltip = L("Estimated print time hour component (normal mode). Replaced with actual value during post-processing.");
+
+    def = this->add("print_time_minute", coString);
+    def->label = L("Print time (minutes component)");
+    def->tooltip = L("Estimated print time minute component (normal mode). Replaced with actual value during post-processing.");
+
+    def = this->add("print_time_sec", coString);
+    def->label = L("Print time (seconds component)");
+    def->tooltip = L("Estimated print time second component (normal mode). Replaced with actual value during post-processing.");
 
     def = this->add("used_filament_length", coString);
     def->label = L("Filament length (meters)");


### PR DESCRIPTION
# Description

<!--
> Please provide a summary of the changes made in this PR. Include details such as:
  > * What issue does this PR address or fix?
  > * What new features or enhancements does this PR introduce?
  > * Are there any breaking changes or dependencies that need to be considered?
-->

This PR extends the work from https://github.com/OrcaSlicer/OrcaSlicer/pull/12186 by adding and updating the following placeholders:

- Updated `print_time_sec` to `print_time_total_sec` to reflect that it represents the total time in seconds for the print.
- Added `print_time_day`, `print_time_hour`, `print_time_min`, `print_time_sec` as the integer components for days, hours, minutes and seconds respectively.

This is motivated by using the expected format by Flashforge AD5M/AD5MP/AD5X printers that expect the file header to contain the following line for estimated time:

```text
; estimated printing time (normal mode) = 11d 22h 25m 19s
```

The only difference between the implementation for this in the official Orca-Flashforge and this PR is that Orca-Flashforge will trim the leading units when they're zero but this implementation keeps those, as referenced in the "Tests" section.

# Tests

<!--
> Please describe the tests that you have conducted to verify the changes made in this PR.
-->

Generated G-code in both Orca-Flashforge and OrcaSlicer with the current changes to compare the outputs. I had no issues having the leading zero units with the latest firmware, and the printer started showing the remaining time just fine.

Line generated by Orca-Flashforge:
```text
; estimated printing time (normal mode) = 8m 13s
```

Line generated by current implementation:
```text
; estimated printing time (normal mode) = 0d 0h 8m 13s
```