### PR TITLE
feat: native Wayland support with EGL/GLX runtime selection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -703,15 +703,7 @@ if(APPLE AND CMAKE_VERSION VERSION_GREATER_EQUAL "4.0")
     set(OPENGL_LIBRARIES "-framework OpenGL" CACHE STRING "OpenGL framework" FORCE)
 endif()
 
-set(GLEW_ROOT "${CMAKE_PREFIX_PATH}")
-message("GLEW_ROOT: ${GLEW_ROOT}")
-# Find glew or use bundled version
-if (SLIC3R_STATIC AND NOT SLIC3R_STATIC_EXCLUDE_GLEW)
-    set(GLEW_USE_STATIC_LIBS ON)
-    set(GLEW_VERBOSE ON)
-endif()
-
-find_package(GLEW REQUIRED)
+find_package(Epoxy REQUIRED)
 
 find_package(glfw3 REQUIRED)
 

--- a/cmake/modules/FindEpoxy.cmake
+++ b/cmake/modules/FindEpoxy.cmake
@@ -1,0 +1,67 @@
+#[=======================================================================[.rst:
+FindEpoxy
+---------
+
+Find the libepoxy OpenGL function loader library.
+
+Imported Targets
+^^^^^^^^^^^^^^^^
+
+``epoxy::epoxy``
+  The libepoxy library (static).
+
+Result Variables
+^^^^^^^^^^^^^^^^
+
+``EPOXY_FOUND``
+  True if libepoxy was found.
+``EPOXY_INCLUDE_DIRS``
+  Include directories for libepoxy.
+``EPOXY_LIBRARIES``
+  Libraries to link against.
+
+#]=======================================================================]
+
+include(FindPackageHandleStandardArgs)
+
+find_path(EPOXY_INCLUDE_DIR epoxy/gl.h)
+mark_as_advanced(EPOXY_INCLUDE_DIR)
+
+find_library(EPOXY_LIBRARY
+    NAMES epoxy
+    PATH_SUFFIXES lib lib64
+)
+mark_as_advanced(EPOXY_LIBRARY)
+
+# Read version from epoxy/gl.h if available
+if (EXISTS "${EPOXY_INCLUDE_DIR}/epoxy/gl.h")
+    file(STRINGS "${EPOXY_INCLUDE_DIR}/epoxy/gl.h" _epoxy_version_line
+         REGEX "^#define[ \t]+EPOXY_GL_VERSION[ \t]+")
+    if (_epoxy_version_line)
+        string(REGEX REPLACE ".*EPOXY_GL_VERSION[ \t]+([0-9]+).*" "\\1" EPOXY_VERSION "${_epoxy_version_line}")
+    endif ()
+endif ()
+
+find_package_handle_standard_args(Epoxy
+    REQUIRED_VARS EPOXY_LIBRARY EPOXY_INCLUDE_DIR
+    VERSION_VAR EPOXY_VERSION
+)
+
+if (EPOXY_FOUND)
+    set(EPOXY_INCLUDE_DIRS ${EPOXY_INCLUDE_DIR})
+    set(EPOXY_LIBRARIES    ${EPOXY_LIBRARY})
+
+    if (NOT TARGET epoxy::epoxy)
+        add_library(epoxy::epoxy UNKNOWN IMPORTED)
+        set_target_properties(epoxy::epoxy PROPERTIES
+            IMPORTED_LOCATION             "${EPOXY_LIBRARY}"
+            INTERFACE_INCLUDE_DIRECTORIES "${EPOXY_INCLUDE_DIR}"
+        )
+        # libepoxy uses dlopen() to load GL libraries at runtime
+        if (UNIX AND NOT APPLE)
+            set_property(TARGET epoxy::epoxy APPEND PROPERTY
+                INTERFACE_LINK_LIBRARIES ${CMAKE_DL_LIBS}
+            )
+        endif ()
+    endif ()
+endif ()

--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -323,7 +323,6 @@ include(Boost/Boost.cmake)
 # The order of includes respects the dependencies between libraries
 include(Cereal/Cereal.cmake)
 include(Qhull/Qhull.cmake)
-include(GLEW/GLEW.cmake)
 include(libepoxy/libepoxy.cmake)
 
 include(GLFW/GLFW.cmake)

--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -324,6 +324,7 @@ include(Boost/Boost.cmake)
 include(Cereal/Cereal.cmake)
 include(Qhull/Qhull.cmake)
 include(GLEW/GLEW.cmake)
+include(libepoxy/libepoxy.cmake)
 
 include(GLFW/GLFW.cmake)
 include(OpenCSG/OpenCSG.cmake)

--- a/deps/GLEW/GLEW.cmake
+++ b/deps/GLEW/GLEW.cmake
@@ -6,7 +6,7 @@ orcaslicer_add_cmake_project(
   GLEW
   SOURCE_DIR  ${CMAKE_CURRENT_LIST_DIR}/glew
   CMAKE_ARGS
-    -DGLEW_USE_EGL=OFF
+    -DGLEW_USE_EGL=ON
 )
 
 if (MSVC)

--- a/deps/OpenCSG/CMakeLists.txt.in
+++ b/deps/OpenCSG/CMakeLists.txt.in
@@ -2,16 +2,12 @@ cmake_minimum_required(VERSION 3.0)
 
 project(OpenCSG)
 
-if (NOT BUILD_SHARED_LIBS)
-  set(GLEW_USE_STATIC_LIBS ON)
-elseif (MSVC)
+if (BUILD_SHARED_LIBS AND MSVC)
   set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 endif()
 
 find_package(OpenGL REQUIRED)
-
-set(GLEW_VERBOSE ON)
-find_package(GLEW 1.13.0 REQUIRED)
+find_package(Epoxy REQUIRED)
 
 set(_srcfiles 
     src/area.cpp
@@ -54,7 +50,7 @@ set(_srcfiles
 add_library(opencsg ${_srcfiles})
 target_include_directories(opencsg PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>)
 target_include_directories(opencsg PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>)
-target_link_libraries(opencsg PRIVATE GLEW::GLEW OpenGL::GL)
+target_link_libraries(opencsg PRIVATE epoxy::epoxy OpenGL::GL)
 
 include(CMakePackageConfigHelpers)
 

--- a/deps/OpenCSG/OpenCSG.cmake
+++ b/deps/OpenCSG/OpenCSG.cmake
@@ -4,8 +4,8 @@ orcaslicer_add_cmake_project(OpenCSG
     # GIT_TAG 83e274457b46c9ad11a4ee599203250b1618f3b9 #v1.4.2
     URL https://github.com/floriankirsch/OpenCSG/archive/refs/tags/opencsg-1-4-2-release.zip
     URL_HASH SHA256=51afe0db79af8386e2027d56d685177135581e0ee82ade9d7f2caff8deab5ec5
-    PATCH_COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt.in ./CMakeLists.txt
-    DEPENDS dep_GLEW
+    PATCH_COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt.in ./CMakeLists.txt COMMAND ${PATCH_CMD} ${CMAKE_CURRENT_LIST_DIR}/opencsg-epoxy.patch
+    DEPENDS dep_libepoxy
 )
 
 if (TARGET ${ZLIB_PKG})

--- a/deps/OpenCSG/opencsg-epoxy.patch
+++ b/deps/OpenCSG/opencsg-epoxy.patch
@@ -1,0 +1,395 @@
+diff --git a/src/channelManager.cpp b/src/channelManager.cpp
+index 5c22857..1f69a4b 100644
+--- a/src/channelManager.cpp
++++ b/src/channelManager.cpp
+@@ -24,11 +24,9 @@
+ #include "opencsgConfig.h"
+ #include "channelManager.h"
+ 
+-#include <GL/glew.h>
++#include <epoxy/gl.h>
+ #ifdef _WIN32
+ #include <GL/wglew.h>
+-#elif !defined(__APPLE__)
+-#include <GL/glxew.h>
+ #endif
+ 
+ #include "context.h"
+@@ -105,10 +103,10 @@ namespace OpenCSG {
+         glDisable(GL_LIGHTING);
+         glDisable(GL_TEXTURE_1D);
+         glDisable(GL_TEXTURE_2D);
+-        if (GLEW_ARB_texture_rectangle || GLEW_EXT_texture_rectangle || GLEW_NV_texture_rectangle)
++        if (epoxy_has_gl_extension("GL_ARB_texture_rectangle") || epoxy_has_gl_extension("GL_EXT_texture_rectangle") || epoxy_has_gl_extension("GL_NV_texture_rectangle"))
+             glDisable(GL_TEXTURE_RECTANGLE_ARB);
+         glDisable(GL_TEXTURE_3D); // OpenGL 1.2 - take this as given
+-        if (GLEW_ARB_texture_cube_map)
++        if (epoxy_has_gl_extension("GL_ARB_texture_cube_map"))
+             glDisable(GL_TEXTURE_CUBE_MAP_ARB);
+         glDisable(GL_BLEND);
+ 
+@@ -142,12 +140,12 @@ namespace OpenCSG {
+         if (   newOffscreenType == OpenCSG::AutomaticOffscreenType
+             || newOffscreenType == OpenCSG::FrameBufferObject
+         ) {
+-            if (GLEW_ARB_framebuffer_object) {
++            if (epoxy_has_gl_extension("GL_ARB_framebuffer_object")) {
+                 newOffscreenType = OpenCSG::FrameBufferObjectARB;
+             }
+             else
+-            if (   GLEW_EXT_framebuffer_object
+-                && GLEW_EXT_packed_depth_stencil
++            if (   epoxy_has_gl_extension("GL_EXT_framebuffer_object")
++                && epoxy_has_gl_extension("GL_EXT_packed_depth_stencil")
+             ) {
+                 newOffscreenType = OpenCSG::FrameBufferObjectEXT;
+             }
+@@ -160,8 +158,8 @@ namespace OpenCSG {
+                 && WGLEW_ARB_pbuffer
+                 && WGLEW_ARB_pixel_format
+ #elif !defined(__APPLE__)
+-                && GLXEW_SGIX_pbuffer
+-                && GLXEW_SGIX_fbconfig
++                && epoxy_has_gl_extension("GLX_SGIX_pbuffer")
++                && epoxy_has_gl_extension("GLX_SGIX_fbconfig")
+ #else
+                 && false
+ #endif
+@@ -198,12 +196,12 @@ namespace OpenCSG {
+         // - any of the texture rectangle extensions is supported
+         //   (texture rectangle is no problem for FBO; for pbuffers we fallback to copy-to-texture
+         //    if the required WGL-extensions for texture rectangle are missing - always on Linux)
+-        // - Otherwise for FBO, if we have the GLEW_ARB_texture_non_power_of_two extension
++        // - Otherwise for FBO, if we have the epoxy_has_gl_extension("GL_ARB_texture_non_power_of_two") extension
+         // Negating this gives the following expression from hell:
+-        if (   !GLEW_ARB_texture_rectangle
+-            && !GLEW_EXT_texture_rectangle
+-            && !GLEW_NV_texture_rectangle
+-            && (newOffscreenType == OpenCSG::PBuffer || !GLEW_ARB_texture_non_power_of_two)
++        if (   !epoxy_has_gl_extension("GL_ARB_texture_rectangle")
++            && !epoxy_has_gl_extension("GL_EXT_texture_rectangle")
++            && !epoxy_has_gl_extension("GL_NV_texture_rectangle")
++            && (newOffscreenType == OpenCSG::PBuffer || !epoxy_has_gl_extension("GL_ARB_texture_non_power_of_two"))
+         ) {
+             // blow up the texture to legal power-of-two size :-(
+             tx = nextPow2(dx);
+@@ -289,7 +287,7 @@ namespace OpenCSG {
+         // find free channel
+         if ((mOccupiedChannels & Alpha) == 0) {
+             channel = Alpha;
+-        }  else if (GLEW_ARB_texture_env_dot3) {
++        }  else if (epoxy_has_gl_extension("GL_ARB_texture_env_dot3")) {
+             if ((mOccupiedChannels & Red) == 0)   {
+                 channel = Red;
+             } else if ((mOccupiedChannels & Green) == 0) {
+@@ -485,7 +483,7 @@ namespace OpenCSG {
+             glTexEnvi(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_REPLACE);
+         } else {
+             // replicate color into alpha
+-            if (GLEW_ARB_texture_env_dot3) {
++            if (epoxy_has_gl_extension("GL_ARB_texture_env_dot3")) {
+                 switch (channel) {
+                 case Red: 
+                     glColor3f(1.0f, 0.5f, 0.5f); 
+diff --git a/src/channelManager.h b/src/channelManager.h
+index 3578ac5..70107f7 100644
+--- a/src/channelManager.h
++++ b/src/channelManager.h
+@@ -27,7 +27,7 @@
+ #define __OpenCSG__channel_manager_h__
+ 
+ #include "opencsgConfig.h"
+-#include <GL/glew.h>
++#include <epoxy/gl.h>
+ #include <utility>
+ #include <vector>
+ 
+diff --git a/src/context.cpp b/src/context.cpp
+index 118e610..066e646 100644
+--- a/src/context.cpp
++++ b/src/context.cpp
+@@ -26,7 +26,7 @@
+ #include "frameBufferObject.h"
+ #include "frameBufferObjectExt.h"
+ #include "pBufferTexture.h"
+-#include <GL/glew.h>
++#include <epoxy/gl.h>
+ #include <map>
+ 
+ namespace OpenCSG {
+diff --git a/src/context.h b/src/context.h
+index b4e3750..9930be2 100644
+--- a/src/context.h
++++ b/src/context.h
+@@ -27,7 +27,7 @@
+ 
+ #include "opencsgConfig.h"
+ #include <opencsg.h>
+-#include <GL/glew.h>
++#include <epoxy/gl.h>
+ 
+ namespace OpenCSG {
+ 
+diff --git a/src/frameBufferObject.cpp b/src/frameBufferObject.cpp
+index 620bd68..d929159 100644
+--- a/src/frameBufferObject.cpp
++++ b/src/frameBufferObject.cpp
+@@ -45,7 +45,7 @@ namespace OpenCSG {
+ 
+         bool FrameBufferObject::ReadCurrent()
+         {
+-            bool haveFBO = GLEW_ARB_framebuffer_object != 0;
++            bool haveFBO = epoxy_has_gl_extension("GL_ARB_framebuffer_object") != 0;
+ 
+             if (haveFBO)
+                 glGetIntegerv(GL_FRAMEBUFFER_BINDING, &oldFramebufferID);
+@@ -57,7 +57,7 @@ namespace OpenCSG {
+         // shareObjects and copyContext do not make sense here, context remains the same.
+         bool FrameBufferObject::Initialize(int width, int height, bool /* shareObjects */, bool /* copyContext */ )
+         {
+-            bool haveFBO = GLEW_ARB_framebuffer_object != 0;
++            bool haveFBO = epoxy_has_gl_extension("GL_ARB_framebuffer_object") != 0;
+             if (!haveFBO)
+                 return false;
+ 
+@@ -70,7 +70,7 @@ namespace OpenCSG {
+ 
+             glBindFramebuffer(GL_FRAMEBUFFER, framebufferID);
+ 
+-            GLenum target = (GLEW_ARB_texture_rectangle || GLEW_EXT_texture_rectangle || GLEW_NV_texture_rectangle)
++            GLenum target = (epoxy_has_gl_extension("GL_ARB_texture_rectangle") || epoxy_has_gl_extension("GL_EXT_texture_rectangle") || epoxy_has_gl_extension("GL_NV_texture_rectangle"))
+                 ? GL_TEXTURE_RECTANGLE_ARB
+                 : GL_TEXTURE_2D; // implicitely asks for GL_ARB_texture_non_power_of_two.
+                                  // this should have been checked in channelManager.cpp
+diff --git a/src/frameBufferObject.h b/src/frameBufferObject.h
+index 4096ab9..63b6925 100644
+--- a/src/frameBufferObject.h
++++ b/src/frameBufferObject.h
+@@ -27,7 +27,7 @@
+ 
+ #include "opencsgConfig.h"
+ #include "offscreenBuffer.h"
+-#include <GL/glew.h>
++#include <epoxy/gl.h>
+ 
+ namespace OpenCSG {
+ 
+diff --git a/src/frameBufferObjectExt.cpp b/src/frameBufferObjectExt.cpp
+index 683af93..2e8660c 100644
+--- a/src/frameBufferObjectExt.cpp
++++ b/src/frameBufferObjectExt.cpp
+@@ -45,8 +45,8 @@ namespace OpenCSG {
+ 
+         bool FrameBufferObjectExt::ReadCurrent()
+         {
+-            bool haveFBO = GLEW_EXT_framebuffer_object != 0
+-                        && GLEW_EXT_packed_depth_stencil != 0;
++            bool haveFBO = epoxy_has_gl_extension("GL_EXT_framebuffer_object") != 0
++                        && epoxy_has_gl_extension("GL_EXT_packed_depth_stencil") != 0;
+ 
+             if (haveFBO)
+                 glGetIntegerv(GL_FRAMEBUFFER_BINDING_EXT, &oldFramebufferID);
+@@ -58,8 +58,8 @@ namespace OpenCSG {
+         // shareObjects and copyContext do not make sense here, context remains the same.
+         bool FrameBufferObjectExt::Initialize(int width, int height, bool /* shareObjects */, bool /* copyContext */ )
+         {
+-            bool haveFBO =    GLEW_EXT_framebuffer_object != 0 
+-                           && GLEW_EXT_packed_depth_stencil != 0;
++            bool haveFBO =    epoxy_has_gl_extension("GL_EXT_framebuffer_object") != 0 
++                           && epoxy_has_gl_extension("GL_EXT_packed_depth_stencil") != 0;
+             if (!haveFBO)
+                 return false;
+ 
+@@ -72,7 +72,7 @@ namespace OpenCSG {
+ 
+             glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, framebufferID);
+ 
+-            GLenum target = (GLEW_ARB_texture_rectangle || GLEW_EXT_texture_rectangle || GLEW_NV_texture_rectangle)
++            GLenum target = (epoxy_has_gl_extension("GL_ARB_texture_rectangle") || epoxy_has_gl_extension("GL_EXT_texture_rectangle") || epoxy_has_gl_extension("GL_NV_texture_rectangle"))
+                 ? GL_TEXTURE_RECTANGLE_ARB
+                 : GL_TEXTURE_2D; // implicitely asks for GL_ARB_texture_non_power_of_two.
+                                  // this should have been checked in channelManager.cpp
+diff --git a/src/frameBufferObjectExt.h b/src/frameBufferObjectExt.h
+index af6b64c..5ec3e87 100644
+--- a/src/frameBufferObjectExt.h
++++ b/src/frameBufferObjectExt.h
+@@ -27,7 +27,7 @@
+ 
+ #include "opencsgConfig.h"
+ #include "offscreenBuffer.h"
+-#include <GL/glew.h>
++#include <epoxy/gl.h>
+ 
+ namespace OpenCSG {
+ 
+diff --git a/src/occlusionQuery.cpp b/src/occlusionQuery.cpp
+index 360ea61..59012be 100644
+--- a/src/occlusionQuery.cpp
++++ b/src/occlusionQuery.cpp
+@@ -22,7 +22,7 @@
+ //
+ 
+ #include "opencsgConfig.h"
+-#include <GL/glew.h>
++#include <epoxy/gl.h>
+ #include "occlusionQuery.h"
+ 
+ namespace OpenCSG {
+@@ -107,19 +107,19 @@ namespace OpenCSG {
+ 
+         OcclusionQuery* getOcclusionQuery(bool exactNumberNeeded) {
+ 
+-            if (!exactNumberNeeded && GLEW_ARB_occlusion_query2) {
++            if (!exactNumberNeeded && epoxy_has_gl_extension("GL_ARB_occlusion_query2")) {
+                 OcclusionQueryARB* occlusionQuery = new OcclusionQueryARB;
+                 occlusionQuery->mQueryType = GL_ANY_SAMPLES_PASSED;
+                 return occlusionQuery;
+             }
+ 
+-            if (GLEW_ARB_occlusion_query) {
++            if (epoxy_has_gl_extension("GL_ARB_occlusion_query")) {
+                 OcclusionQueryARB* occlusionQuery = new OcclusionQueryARB;
+                 occlusionQuery->mQueryType = GL_SAMPLES_PASSED_ARB;
+                 return occlusionQuery;
+             }
+ 
+-            if (GLEW_NV_occlusion_query) {
++            if (epoxy_has_gl_extension("GL_NV_occlusion_query")) {
+                 return new OcclusionQueryNV;
+             }
+ 
+diff --git a/src/opencsgRender.cpp b/src/opencsgRender.cpp
+index 2fc1d56..957b533 100644
+--- a/src/opencsgRender.cpp
++++ b/src/opencsgRender.cpp
+@@ -23,7 +23,7 @@
+ 
+ #include "opencsgConfig.h"
+ #include <opencsg.h>
+-#include <GL/glew.h>
++#include <epoxy/gl.h>
+ #include "opencsgRender.h"
+ #include "primitiveHelper.h"
+ #include "settings.h"
+@@ -33,7 +33,7 @@ namespace OpenCSG {
+     namespace {
+ 
+         bool haveHardwareOcclusionQueries() {
+-            return GLEW_ARB_occlusion_query || GLEW_NV_occlusion_query;
++            return epoxy_has_gl_extension("GL_ARB_occlusion_query") || epoxy_has_gl_extension("GL_NV_occlusion_query");
+         }
+ 
+         Algorithm chooseAlgorithm(const std::vector<Primitive*>& primitives) {
+diff --git a/src/openglHelper.cpp b/src/openglHelper.cpp
+index f9b00dc..7155263 100644
+--- a/src/openglHelper.cpp
++++ b/src/openglHelper.cpp
+@@ -22,7 +22,7 @@
+ //
+ 
+ #include "opencsgConfig.h"
+-#include <GL/glew.h>
++#include <epoxy/gl.h>
+ #include "openglHelper.h"
+ 
+ namespace OpenCSG {
+diff --git a/src/openglHelper.h b/src/openglHelper.h
+index 3f4e6d4..971632d 100644
+--- a/src/openglHelper.h
++++ b/src/openglHelper.h
+@@ -27,7 +27,7 @@
+ #define __OpenCSG__opengl_helper_h__
+ 
+ #include "opencsgConfig.h"
+-#include <GL/glew.h>
++#include <epoxy/gl.h>
+ #include "area.h"
+ 
+ namespace OpenCSG {
+diff --git a/src/pBufferTexture.cpp b/src/pBufferTexture.cpp
+index c20af60..b8b580f 100644
+--- a/src/pBufferTexture.cpp
++++ b/src/pBufferTexture.cpp
+@@ -26,7 +26,7 @@
+ 
+ #include "pBufferTexture.h"
+ #include "RenderTexture/RenderTexture.h"
+-#include <GL/glew.h>
++#include <epoxy/gl.h>
+ #ifdef _WIN32
+ #include <GL/wglew.h>
+ #endif
+@@ -36,7 +36,7 @@ namespace OpenCSG {
+     namespace OpenGL {
+ 
+         PBufferTexture::PBufferTexture() : r(0), s(0) {
+-            if (GLEW_ARB_texture_rectangle || GLEW_EXT_texture_rectangle || GLEW_NV_texture_rectangle) {
++            if (epoxy_has_gl_extension("GL_ARB_texture_rectangle") || epoxy_has_gl_extension("GL_EXT_texture_rectangle") || epoxy_has_gl_extension("GL_NV_texture_rectangle")) {
+ #ifdef _WIN32
+                 if (WGLEW_ARB_render_texture && (WGLEW_ATI_render_texture_rectangle || WGLEW_NV_render_texture_rectangle)) {
+                     s = "rgba texRECT depth=24 stencil=8 single rtt";
+diff --git a/src/primitiveHelper.cpp b/src/primitiveHelper.cpp
+index 848835f..6a330de 100644
+--- a/src/primitiveHelper.cpp
++++ b/src/primitiveHelper.cpp
+@@ -23,7 +23,7 @@
+ 
+ #include "opencsgConfig.h"
+ #include <opencsg.h>
+-#include <GL/glew.h>
++#include <epoxy/gl.h>
+ #include "openglHelper.h"
+ #include "primitiveHelper.h"
+ #include <algorithm>
+diff --git a/src/renderSCS.cpp b/src/renderSCS.cpp
+index d73947d..840b81d 100644
+--- a/src/renderSCS.cpp
++++ b/src/renderSCS.cpp
+@@ -271,7 +271,7 @@ namespace OpenCSG {
+ 
+         ChannelManagerForBatches* getChannelManager() {
+ 
+-            if (GLEW_ARB_vertex_program && GLEW_ARB_fragment_program) {
++            if (epoxy_has_gl_extension("GL_ARB_vertex_program") && epoxy_has_gl_extension("GL_ARB_fragment_program")) {
+                 return new SCSChannelManagerFragmentProgram;
+             }
+ 
+diff --git a/src/scissorMemo.cpp b/src/scissorMemo.cpp
+index ee0f99b..e0243bd 100644
+--- a/src/scissorMemo.cpp
++++ b/src/scissorMemo.cpp
+@@ -23,7 +23,7 @@
+ 
+ #include "opencsgConfig.h"
+ #include <opencsg.h>
+-#include <GL/glew.h>
++#include <epoxy/gl.h>
+ #include "openglHelper.h"
+ #include "scissorMemo.h"
+ 
+@@ -45,7 +45,7 @@ namespace OpenCSG {
+                  || optimizationSetting == OptimizationOff)
+             mUseDepthBoundsTest = false;
+         else if (optimizationSetting == OptimizationOn)
+-            mUseDepthBoundsTest = (GLEW_EXT_depth_bounds_test != 0);
++            mUseDepthBoundsTest = (epoxy_has_gl_extension("GL_EXT_depth_bounds_test") != 0);
+     }
+ 
+     void ScissorMemo::store(Channel ch) {
+diff --git a/src/stencilManager.cpp b/src/stencilManager.cpp
+index 8fbddfa..8cb29d3 100644
+--- a/src/stencilManager.cpp
++++ b/src/stencilManager.cpp
+@@ -22,11 +22,9 @@
+ //
+ 
+ #include "opencsgConfig.h"
+-#include <GL/glew.h>
++#include <epoxy/gl.h>
+ #ifdef _WIN32
+ #include <GL/wglew.h>
+-#elif !defined(__APPLE__)
+-#include <GL/glxew.h>
+ #endif
+ #include "area.h"
+ #include "openglHelper.h"

--- a/deps/libepoxy/libepoxy.cmake
+++ b/deps/libepoxy/libepoxy.cmake
@@ -1,0 +1,27 @@
+# libepoxy -- GL function loader with runtime EGL/GLX dispatch
+# Uses Meson build system, so we use raw ExternalProject_Add
+# instead of orcaslicer_add_cmake_project.
+
+include(ExternalProject)
+
+ExternalProject_Add(
+    dep_libepoxy
+    EXCLUDE_FROM_ALL  ON
+    INSTALL_DIR       ${DESTDIR}
+    DOWNLOAD_DIR      ${DEP_DOWNLOAD_DIR}/libepoxy
+    URL               https://github.com/anholt/libepoxy/archive/refs/tags/1.5.10.tar.gz
+    URL_HASH          SHA256=a7ced37f4102b745ac86d6a70a9c427c215e49a7e75e97e4b7862a22068d40a9
+    CONFIGURE_COMMAND meson setup
+        --prefix=<INSTALL_DIR>
+        --default-library=static
+        --buildtype=release
+        -Dtests=false
+        -Dx11=true
+        -Degl=yes
+        -Dglx=yes
+        -Dc_args=-fPIC
+        <SOURCE_DIR>
+        <BINARY_DIR>
+    BUILD_COMMAND     ninja -C <BINARY_DIR> -j${NPROC}
+    INSTALL_COMMAND   ninja -C <BINARY_DIR> install
+)

--- a/deps/libepoxy/libepoxy.cmake
+++ b/deps/libepoxy/libepoxy.cmake
@@ -10,7 +10,7 @@ ExternalProject_Add(
     INSTALL_DIR       ${DESTDIR}
     DOWNLOAD_DIR      ${DEP_DOWNLOAD_DIR}/libepoxy
     URL               https://github.com/anholt/libepoxy/archive/refs/tags/1.5.10.tar.gz
-    URL_HASH          SHA256=a7ced37f4102b745ac86d6a70a9c427c215e49a7e75e97e4b7862a22068d40a9
+    URL_HASH          SHA256=a7ced37f4102b745ac86d6a70a9da399cc139ff168ba6b8002b4d8d43c900c15
     CONFIGURE_COMMAND meson setup
         --prefix=<INSTALL_DIR>
         --default-library=static

--- a/deps/wxWidgets/wxWidgets.cmake
+++ b/deps/wxWidgets/wxWidgets.cmake
@@ -38,7 +38,7 @@ orcaslicer_add_cmake_project(
         -DwxUSE_DETECT_SM=OFF
         -DwxUSE_PRIVATE_FONTS=ON
         -DwxUSE_OPENGL=ON
-        -DwxUSE_GLCANVAS_EGL=OFF
+        -DwxUSE_GLCANVAS_EGL=ON
         -DwxUSE_WEBREQUEST=ON
         -DwxUSE_WEBVIEW=ON
         ${_wx_edge}

--- a/doc/Linux-EGL-Build.md
+++ b/doc/Linux-EGL-Build.md
@@ -1,0 +1,121 @@
+# Linux EGL Build and Runtime Guide
+
+## Overview
+
+OrcaSlicer's Linux build uses EGL instead of GLX for OpenGL context creation. This enables
+native Wayland support alongside X11 with a single binary -- the application detects the
+display server at runtime and creates the appropriate OpenGL context automatically.
+
+EGL is the platform-agnostic API for managing rendering contexts and surfaces. By using EGL,
+OrcaSlicer can render its 3D viewport on both X11 (via EGL-on-X11) and Wayland without
+requiring XWayland.
+
+## Build Flags
+
+Two CMake flags enable EGL in the dependency build. Both must be set together; a compile-time
+guard in `src/slic3r/GUI/OpenGLManager.cpp` enforces consistency.
+
+### wxWidgets: `wxUSE_GLCANVAS_EGL=ON`
+
+Location: `deps/wxWidgets/wxWidgets.cmake`
+
+Tells wxWidgets to build its `wxGLCanvas` widget using EGL instead of GLX on Linux. This is
+the primary flag that switches the GL context backend.
+
+```cmake
+-DwxUSE_GLCANVAS_EGL=ON
+```
+
+### GLEW: `GLEW_USE_EGL=ON`
+
+Location: `deps/GLEW/GLEW.cmake`
+
+Builds GLEW with EGL support so that OpenGL extension loading works with EGL contexts.
+
+```cmake
+-DGLEW_USE_EGL=ON
+```
+
+**Important:** If one flag is enabled without the other, the build will produce a binary that
+cannot initialize OpenGL correctly. Always set both flags to the same value.
+
+## Build Dependencies
+
+The following system packages are required for an EGL-enabled build, in addition to the
+standard OrcaSlicer build dependencies.
+
+### Debian / Ubuntu
+
+```bash
+sudo apt install libegl1-mesa-dev libwayland-dev
+```
+
+### Fedora
+
+```bash
+sudo dnf install mesa-libEGL-devel wayland-devel
+```
+
+### Arch Linux
+
+```bash
+sudo pacman -S mesa wayland
+```
+
+(Arch's `mesa` package includes EGL development files.)
+
+**Note:** The existing `build_linux.sh -u` script installs system dependencies but may not
+include the EGL/Wayland development packages listed above. Verify these are installed before
+building.
+
+## Runtime Requirements
+
+### Mesa / AMD / Intel GPUs
+
+No additional runtime packages are needed. EGL support is built into the Mesa driver stack.
+
+### NVIDIA GPUs (Wayland)
+
+NVIDIA users running Wayland need the `egl-wayland` library, which provides the
+`EGL_WL_bind_wayland_display` extension required for EGL to create surfaces on Wayland
+compositors.
+
+| Distribution    | Package                      | Install Command                          |
+|-----------------|------------------------------|------------------------------------------|
+| Arch Linux      | `egl-wayland`                | `sudo pacman -S egl-wayland`             |
+| Fedora          | `egl-wayland`                | `sudo dnf install egl-wayland`           |
+| Debian / Ubuntu | `libnvidia-egl-wayland1`     | `sudo apt install libnvidia-egl-wayland1`|
+
+**Minimum NVIDIA driver version:** 535 or later is recommended. The `nvidia-open` kernel
+module is compatible with EGL and has been tested with OrcaSlicer. Earlier driver versions
+may work but are untested.
+
+NVIDIA users on X11 do not need the `egl-wayland` package -- the NVIDIA driver provides
+EGL-on-X11 support directly.
+
+## Verifying EGL
+
+### Check EGL availability
+
+```bash
+eglinfo | head -20
+```
+
+This should list an EGL platform, vendor, and version. If the command is not found, install
+`mesa-utils` (Debian/Ubuntu/Arch) or `mesa-demos` (Fedora).
+
+### NVIDIA PRIME offload verification
+
+If using NVIDIA PRIME render offload (e.g., laptop with integrated + discrete GPU):
+
+```bash
+__NV_PRIME_RENDER_OFFLOAD=1 eglinfo | head -20
+```
+
+This should show the NVIDIA EGL platform rather than the integrated GPU's.
+
+### Verify OrcaSlicer is using EGL
+
+Launch OrcaSlicer and check stderr output. On a Wayland session the log should show EGL
+context creation messages from wxWidgets rather than GLX. No environment variable overrides
+(such as `MESA_LOADER_DRIVER_OVERRIDE` or `GALLIUM_DRIVER`) should be needed.

--- a/src/OrcaSlicer.cpp
+++ b/src/OrcaSlicer.cpp
@@ -1183,30 +1183,38 @@ int CLI::run(int argc, char **argv)
     save_main_thread_id();
 
 #ifdef __WXGTK__
-    // On Linux, wxGTK has no support for Wayland, and the app crashes on
-    // startup if gtk3 is used. This env var has to be set explicitly to
-    // instruct the window manager to fall back to X server mode.
-    ::setenv("GDK_BACKEND", "x11", /* replace */ true);
+    // Detect display server at runtime.
+    // GTK3 auto-detects Wayland vs X11 -- we do NOT force GDK_BACKEND.
+    // wxWidgets 3.3.2 with EGL support creates EGL contexts on both
+    // Wayland and X11, matching our EGL-enabled GLEW build.
+    const char* wayland_display = ::getenv("WAYLAND_DISPLAY");
+    const char* session_type = ::getenv("XDG_SESSION_TYPE");
+    const bool is_wayland = (wayland_display && *wayland_display) ||
+                            (session_type && strcmp(session_type, "wayland") == 0);
 
-    // WebKit2GTK's compositing mode can fail under XWayland, causing WebViews
-    // (like the Setup Wizard) to render blank or freeze. Disabling compositing
-    // mode forces software rendering, which works reliably on all backends.
+    // WebKit2GTK compositing workaround -- keep for stability.
+    // Safe on both X11 and Wayland; forces software rendering for WebViews.
     ::setenv("WEBKIT_DISABLE_COMPOSITING_MODE", "1", /* replace */ false);
 
-    // On Linux dual-GPU systems, request the high-performance discrete GPU.
-    // DRI_PRIME=1 handles AMD and nouveau (open-source NVIDIA) PRIME setups.
+    // Request discrete GPU on dual-GPU systems (works on both X11 and Wayland).
     ::setenv("DRI_PRIME", "1", /* replace */ false);
 
-    // For NVIDIA proprietary driver PRIME render offload, set additional variables.
-    // Only set if the NVIDIA kernel module is loaded to avoid breaking systems without NVIDIA.
+    // NVIDIA PRIME render offload for proprietary driver.
     if (::access("/proc/driver/nvidia/version", F_OK) == 0) {
         ::setenv("__NV_PRIME_RENDER_OFFLOAD", "1", /* replace */ false);
-        ::setenv("__GLX_VENDOR_LIBRARY_NAME", "nvidia", /* replace */ false);
+        if (!is_wayland) {
+            // __GLX_VENDOR_LIBRARY_NAME is GLX-specific; skip on Wayland EGL.
+            ::setenv("__GLX_VENDOR_LIBRARY_NAME", "nvidia", /* replace */ false);
+        }
     }
 
-    // Also on Linux, we need to tell Xlib that we will be using threads,
-    // lest we crash when we fire up GStreamer.
-    XInitThreads();
+    if (!is_wayland) {
+        // XInitThreads() is for X11 thread safety (GStreamer).
+        // On Wayland, X11 threads are not used.
+        XInitThreads();
+    }
+
+    BOOST_LOG_TRIVIAL(info) << "Display server: " << (is_wayland ? "Wayland" : "X11");
 #endif
 
 	// Switch boost::filesystem to utf8.

--- a/src/OrcaSlicer.cpp
+++ b/src/OrcaSlicer.cpp
@@ -1190,8 +1190,13 @@ int CLI::run(int argc, char **argv)
     // Wayland and X11; libepoxy handles EGL/GLX dispatch at runtime.
     const char* wayland_display = ::getenv("WAYLAND_DISPLAY");
     const char* session_type = ::getenv("XDG_SESSION_TYPE");
-    const bool is_wayland = (wayland_display && *wayland_display) ||
-                            (session_type && strcmp(session_type, "wayland") == 0);
+    const char* gdk_backend = ::getenv("GDK_BACKEND");
+    // Wayland if GDK_BACKEND=wayland explicitly, or if GDK_BACKEND is unset
+    // and the session environment indicates Wayland.
+    const bool is_wayland = (gdk_backend != nullptr && strcmp(gdk_backend, "wayland") == 0) ||
+                            (gdk_backend == nullptr &&
+                             ((wayland_display && *wayland_display) ||
+                              (session_type && strcmp(session_type, "wayland") == 0)));
 
     // WebKit2GTK compositing workaround -- keep for stability.
     // Safe on both X11 and Wayland; forces software rendering for WebViews.

--- a/src/OrcaSlicer.cpp
+++ b/src/OrcaSlicer.cpp
@@ -75,6 +75,7 @@ using namespace nlohmann;
 #include "OrcaSlicer.hpp"
 //BBS: add exception handler for win32
 #include <wx/stdpaths.h>
+#include <wx/glcanvas.h>
 #ifdef WIN32
 #include "dev-utils/BaseException.h"
 #endif
@@ -1186,7 +1187,7 @@ int CLI::run(int argc, char **argv)
     // Detect display server at runtime.
     // GTK3 auto-detects Wayland vs X11 -- we do NOT force GDK_BACKEND.
     // wxWidgets 3.3.2 with EGL support creates EGL contexts on both
-    // Wayland and X11, matching our EGL-enabled GLEW build.
+    // Wayland and X11; libepoxy handles EGL/GLX dispatch at runtime.
     const char* wayland_display = ::getenv("WAYLAND_DISPLAY");
     const char* session_type = ::getenv("XDG_SESSION_TYPE");
     const bool is_wayland = (wayland_display && *wayland_display) ||
@@ -1212,6 +1213,9 @@ int CLI::run(int argc, char **argv)
         // XInitThreads() is for X11 thread safety (GStreamer).
         // On Wayland, X11 threads are not used.
         XInitThreads();
+        // Force GLX backend for wxGLCanvas on X11.
+        // Must be called before any wxGLCanvas is created.
+        wxGLCanvas::PreferGLX();
     }
 
     BOOST_LOG_TRIVIAL(info) << "Display server: " << (is_wayland ? "Wayland" : "X11");
@@ -6461,7 +6465,7 @@ int CLI::run(int argc, char **argv)
                     BOOST_LOG_TRIVIAL(error) << "init opengl failed! skip thumbnail generating" << std::endl;
                 }
                 else {
-                    BOOST_LOG_TRIVIAL(info) << "glewInit Success." << std::endl;
+                    BOOST_LOG_TRIVIAL(info) << "OpenGL loader ready." << std::endl;
                     GLVolumeCollection glvolume_collection;
                     Model &model = m_models[0];
                     int obj_extruder_id = 1, volume_extruder_id = 1;

--- a/src/dev-utils/platform/unix/build_linux_image.sh.in
+++ b/src/dev-utils/platform/unix/build_linux_image.sh.in
@@ -57,25 +57,6 @@ export LD_LIBRARY_PATH="\$DIR/bin:\$LD_LIBRARY_PATH"
 # 1) OrcaSlicer will segfault on systems where locale info is not as expected (i.e. Holo-ISO arch-based distro)
 export LC_ALL=C
 
-if [ "\$XDG_SESSION_TYPE" = "wayland" ] && [ "\$ZINK_DISABLE_OVERRIDE" != "1" ]; then
-    if command -v glxinfo >/dev/null 2>&1; then
-        RENDERER=\$(glxinfo | grep "OpenGL renderer string:" | sed 's/.*: //')
-        if echo "\$RENDERER" | grep -qi "NVIDIA"; then
-            if command -v nvidia-smi >/dev/null 2>&1; then
-                DRIVER_VERSION=\$(nvidia-smi --query-gpu=driver_version --format=csv,noheader | head -n1)
-                DRIVER_MAJOR=\$(echo "\$DRIVER_VERSION" | cut -d. -f1)
-                [ "\$DRIVER_MAJOR" -gt 555 ] && ZINK_FORCE_OVERRIDE=1
-            fi
-            if [ "\$ZINK_FORCE_OVERRIDE" = "1" ]; then
-                export __GLX_VENDOR_LIBRARY_NAME=mesa
-                export __EGL_VENDOR_LIBRARY_FILENAMES=/usr/share/glvnd/egl_vendor.d/50_mesa.json
-                export MESA_LOADER_DRIVER_OVERRIDE=zink
-                export GALLIUM_DRIVER=zink
-                export WEBKIT_DISABLE_DMABUF_RENDERER=1
-            fi
-        fi
-    fi
-fi
 exec "\$DIR/bin/@SLIC3R_APP_CMD@" "\$@"
 EOF
 

--- a/src/slic3r/CMakeLists.txt
+++ b/src/slic3r/CMakeLists.txt
@@ -736,7 +736,7 @@ else()
     set(_opengl_link_lib OpenGL::GL)
 endif()
 
-target_link_libraries(libslic3r_gui libslic3r cereal::cereal imgui imguizmo minilzo libvgcode md4c-html GLEW::GLEW OpenGL::GL hidapi ${wxWidgets_LIBRARIES} glfw libcurl OpenSSL::SSL OpenSSL::Crypto noise::noise)
+target_link_libraries(libslic3r_gui libslic3r cereal::cereal imgui imguizmo minilzo libvgcode md4c-html epoxy::epoxy OpenGL::GL hidapi ${wxWidgets_LIBRARIES} glfw libcurl OpenSSL::SSL OpenSSL::Crypto noise::noise)
 
 
 if (MSVC)

--- a/src/slic3r/GUI/3DBed.cpp
+++ b/src/slic3r/GUI/3DBed.cpp
@@ -15,7 +15,7 @@
 #include "Plater.hpp"
 #include "Camera.hpp"
 
-#include <GL/glew.h>
+#include <epoxy/gl.h>
 
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/filesystem/operations.hpp>

--- a/src/slic3r/GUI/3DScene.cpp
+++ b/src/slic3r/GUI/3DScene.cpp
@@ -1,4 +1,4 @@
-#include <GL/glew.h>
+#include <epoxy/gl.h>
 
 #include "3DScene.hpp"
 #include "GLShader.hpp"

--- a/src/slic3r/GUI/AboutDialog.cpp
+++ b/src/slic3r/GUI/AboutDialog.cpp
@@ -94,7 +94,7 @@ void CopyrightsDialog::fill_entries()
         { "Eigen3",                                         "",      "http://eigen.tuxfamily.org" },
         { "Expat",                                          "",      "http://www.libexpat.org" },
         { "fast_float",                                     "",      "https://github.com/fastfloat/fast_float" },
-        { "GLEW (The OpenGL Extension Wrangler Library)",   "",      "http://glew.sourceforge.net" },
+        { "libepoxy",                                       "",      "https://github.com/anholt/libepoxy" },
         { "GLFW",                                           "",      "https://www.glfw.org" },
         { "GNU gettext",                                    "",      "https://www.gnu.org/software/gettext" },
         { "ImGUI",                                          "",      "https://github.com/ocornut/imgui" },

--- a/src/slic3r/GUI/BitmapCache.cpp
+++ b/src/slic3r/GUI/BitmapCache.cpp
@@ -13,7 +13,7 @@
     #include <wx/mstream.h>
     #include <wx/rawbmp.h>
 #endif /* __WXGTK2__ */
-#include <GL/glew.h>
+#include <epoxy/gl.h>
 #define NANOSVG_IMPLEMENTATION
 #include "nanosvg/nanosvg.h"
 #define NANOSVGRAST_IMPLEMENTATION

--- a/src/slic3r/GUI/Camera.cpp
+++ b/src/slic3r/GUI/Camera.cpp
@@ -8,7 +8,7 @@
 #include "Plater.hpp"
 #endif // ENABLE_CAMERA_STATISTICS
 
-#include <GL/glew.h>
+#include <epoxy/gl.h>
 
 namespace Slic3r {
 namespace GUI {

--- a/src/slic3r/GUI/GCodeViewer.cpp
+++ b/src/slic3r/GUI/GCodeViewer.cpp
@@ -32,7 +32,7 @@
 #endif // ENABLE_ACTUAL_SPEED_DEBUG
 #include <imgui/imgui_internal.h>
 
-#include <GL/glew.h>
+#include <epoxy/gl.h>
 #include <boost/log/trivial.hpp>
 #include <boost/algorithm/string/split.hpp>
 #include <boost/nowide/cstdio.hpp>

--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -1949,8 +1949,19 @@ void GLCanvas3D::render(bool only_init)
     if (!_is_shown_on_screen() || !_set_current() || !wxGetApp().init_opengl())
         return;
 
-    if (!is_initialized() && !init())
-        return;
+    if (!is_initialized()) {
+        if (!init())
+            return;
+        // On Wayland, GL init is deferred until the EGL surface is ready.
+        // Flag a deferred reload so models loaded before GL init get proper VBOs.
+        m_needs_deferred_reload = true;
+    }
+
+    // Deferred reload: runs on the first render AFTER init, when gizmos etc. are ready.
+    if (m_needs_deferred_reload && m_model && !m_model->objects.empty()) {
+        m_needs_deferred_reload = false;
+        reload_scene(true, true);
+    }
     if (m_canvas_type == ECanvasType::CanvasView3D  && m_gizmos.get_current_type() == GLGizmosManager::Undefined) {
         enable_return_toolbar(false);
     }

--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -44,7 +44,7 @@
 #include "slic3r/Utils/RetinaHelper.hpp"
 #endif
 
-#include <GL/glew.h>
+#include <epoxy/gl.h>
 
 #include <wx/glcanvas.h>
 #include <wx/bitmap.h>

--- a/src/slic3r/GUI/GLCanvas3D.hpp
+++ b/src/slic3r/GUI/GLCanvas3D.hpp
@@ -575,6 +575,7 @@ private:
     //BBS: add flag to controll rendering
     bool m_render_preview{ true };
     bool m_enable_render { true };
+    bool m_needs_deferred_reload { false };
     bool m_apply_zoom_to_volumes_filter;
     bool m_picking_enabled;
     bool m_moving_enabled;

--- a/src/slic3r/GUI/GLCanvas3D.hpp
+++ b/src/slic3r/GUI/GLCanvas3D.hpp
@@ -955,7 +955,7 @@ public:
                                              Camera::ViewAngleType              camera_view_angle_type = Camera::ViewAngleType::Iso,
                                              bool                               for_picking  = false,
                                              bool                               ban_light    = false);
-    // render thumbnail using an off-screen framebuffer when GLEW_EXT_framebuffer_object is supported
+    // render thumbnail using an off-screen framebuffer when GL_EXT_framebuffer_object is supported
     static void render_thumbnail_framebuffer_ext(ThumbnailData& thumbnail_data, unsigned int w, unsigned int h, const ThumbnailsParams& thumbnail_params,
         PartPlateList& partplate_list, ModelObjectPtrs& model_objects, const GLVolumeCollection& volumes, std::vector<ColorRGBA>& extruder_colors,
                                                  GLShaderProgram *                  shader,

--- a/src/slic3r/GUI/GLModel.cpp
+++ b/src/slic3r/GUI/GLModel.cpp
@@ -20,7 +20,7 @@
 #include <igl/per_vertex_normals.h>
 #endif // ENABLE_SMOOTH_NORMALS
 
-#include <GL/glew.h>
+#include <epoxy/gl.h>
 
 namespace Slic3r {
 namespace GUI {

--- a/src/slic3r/GUI/GLSelectionRectangle.cpp
+++ b/src/slic3r/GUI/GLSelectionRectangle.cpp
@@ -7,7 +7,7 @@
 #include "Plater.hpp"
 #include <igl/project.h>
 
-#include <GL/glew.h>
+#include <epoxy/gl.h>
 
 namespace Slic3r {
 namespace GUI {

--- a/src/slic3r/GUI/GLShader.cpp
+++ b/src/slic3r/GUI/GLShader.cpp
@@ -7,7 +7,7 @@
 #include "libslic3r/Color.hpp"
 
 #include <boost/nowide/fstream.hpp>
-#include <GL/glew.h>
+#include <epoxy/gl.h>
 #include <cassert>
 
 #include <boost/log/trivial.hpp>

--- a/src/slic3r/GUI/GLShadersManager.cpp
+++ b/src/slic3r/GUI/GLShadersManager.cpp
@@ -9,7 +9,7 @@
 #include <string_view>
 using namespace std::literals;
 
-#include <GL/glew.h>
+#include <epoxy/gl.h>
 
 namespace Slic3r {
 

--- a/src/slic3r/GUI/GLTexture.cpp
+++ b/src/slic3r/GUI/GLTexture.cpp
@@ -11,7 +11,7 @@
 #include "GUI_App.hpp"
 #include "GLModel.hpp"
 
-#include <GL/glew.h>
+#include <epoxy/gl.h>
 
 #include <wx/image.h>
 #include <boost/filesystem.hpp>

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -310,6 +310,10 @@ public:
 
         // draw logo and constant info text
         Decorate(m_main_bitmap);
+        // Push the decorated bitmap to the splash window immediately.
+        // On Wayland, the first paint may fire before SetText() is called,
+        // so the splash would show the original blank bitmap without this.
+        set_bitmap(m_main_bitmap);
         wxGetApp().UpdateFrameDarkUI(this);
     }
 

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -909,6 +909,10 @@ void GUI_App::post_init()
         }
         else {
             BOOST_LOG_TRIVIAL(warning) << __FUNCTION__ << "Found glcontext not ready, postpone the init";
+            // On Wayland, IsShownOnScreen() may return false during boot because
+            // EGL surfaces are created lazily. Re-enable rendering so the canvas
+            // can initialise on its first actual paint event.
+            plater_->canvas3D()->enable_render(true);
         }
 //#endif
         if (is_editor())

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -282,12 +282,8 @@ class SplashScreen : public wxSplashScreen
 {
 public:
     SplashScreen(const wxBitmap& bitmap, long splashStyle, int milliseconds, wxPoint pos = wxDefaultPosition)
-        : wxSplashScreen(bitmap, splashStyle, milliseconds, static_cast<wxWindow*>(wxGetApp().mainframe), wxID_ANY, wxDefaultPosition, wxDefaultSize,
-#ifdef __APPLE__
+        : wxSplashScreen(bitmap, splashStyle, milliseconds, nullptr, wxID_ANY, wxDefaultPosition, wxDefaultSize,
             wxBORDER_NONE | wxFRAME_NO_TASKBAR | wxSTAY_ON_TOP
-#else
-            wxBORDER_NONE | wxFRAME_NO_TASKBAR
-#endif // !__APPLE__
         )
     {
         int init_dpi = get_dpi_for_window(this);

--- a/src/slic3r/GUI/Gizmos/GLGizmoAdvancedCut.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoAdvancedCut.cpp
@@ -2,7 +2,7 @@
 #include "GLGizmoAdvancedCut.hpp"
 #include "slic3r/GUI/GLCanvas3D.hpp"
 
-#include <GL/glew.h>
+#include <epoxy/gl.h>
 
 #include <wx/button.h>
 #include <wx/checkbox.h>

--- a/src/slic3r/GUI/Gizmos/GLGizmoAssembly.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoAssembly.cpp
@@ -12,7 +12,7 @@
 
 #include <numeric>
 
-#include <GL/glew.h>
+#include <epoxy/gl.h>
 
 #include <tbb/parallel_for.h>
 #include <future>

--- a/src/slic3r/GUI/Gizmos/GLGizmoBase.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoBase.cpp
@@ -1,7 +1,7 @@
 #include "GLGizmoBase.hpp"
 #include "slic3r/GUI/GLCanvas3D.hpp"
 
-#include <GL/glew.h>
+#include <epoxy/gl.h>
 
 #include "slic3r/GUI/GUI_App.hpp"
 #include "slic3r/GUI/Plater.hpp"

--- a/src/slic3r/GUI/Gizmos/GLGizmoBrimEars.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoBrimEars.cpp
@@ -1,5 +1,5 @@
 #include "GLGizmoBrimEars.hpp"
-#include <GL/glew.h>
+#include <epoxy/gl.h>
 #include "slic3r/GUI/GLCanvas3D.hpp"
 #include "slic3r/GUI/Camera.hpp"
 #include "slic3r/GUI/Gizmos/GLGizmosCommon.hpp"

--- a/src/slic3r/GUI/Gizmos/GLGizmoCut.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoCut.cpp
@@ -1,7 +1,7 @@
 #include "GLGizmoCut.hpp"
 #include "slic3r/GUI/GLCanvas3D.hpp"
 
-#include <GL/glew.h>
+#include <epoxy/gl.h>
 
 #include <algorithm>
 

--- a/src/slic3r/GUI/Gizmos/GLGizmoEmboss.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoEmboss.cpp
@@ -50,7 +50,7 @@
 #include <cereal/types/string.hpp>
 #include <cereal/archives/binary.hpp>
 
-#include <GL/glew.h>
+#include <epoxy/gl.h>
 #include <chrono> // measure enumeration of fonts
 
 // uncomment for easier debug

--- a/src/slic3r/GUI/Gizmos/GLGizmoEmboss.hpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoEmboss.hpp
@@ -19,7 +19,7 @@
 #include "libslic3r/TextConfiguration.hpp"
 
 #include <imgui/imgui.h>
-#include <GL/glew.h>
+#include <epoxy/gl.h>
 
 class wxFont;
 namespace Slic3r{

--- a/src/slic3r/GUI/Gizmos/GLGizmoFaceDetector.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoFaceDetector.cpp
@@ -9,7 +9,7 @@
 #include "slic3r/GUI/ImGuiWrapper.hpp"
 #include "slic3r/GUI/Plater.hpp"
 
-#include <GL/glew.h>
+#include <epoxy/gl.h>
 
 #ifdef __WINDOWS__
 #include <windows.h>

--- a/src/slic3r/GUI/Gizmos/GLGizmoFdmSupports.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoFdmSupports.cpp
@@ -15,7 +15,7 @@
 #include "slic3r/GUI/GUI.hpp"
 #include "slic3r/Utils/UndoRedo.hpp"
 
-#include <GL/glew.h>
+#include <epoxy/gl.h>
 
 #include <boost/log/trivial.hpp>
 

--- a/src/slic3r/GUI/Gizmos/GLGizmoFlatten.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoFlatten.cpp
@@ -9,7 +9,7 @@
 
 #include <numeric>
 
-#include <GL/glew.h>
+#include <epoxy/gl.h>
 
 namespace Slic3r {
 namespace GUI {

--- a/src/slic3r/GUI/Gizmos/GLGizmoFuzzySkin.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoFuzzySkin.cpp
@@ -11,7 +11,7 @@
 #include "slic3r/GUI/Plater.hpp"
 #include "slic3r/Utils/UndoRedo.hpp"
 
-#include <GL/glew.h>
+#include <epoxy/gl.h>
 #include <algorithm>
 
 namespace Slic3r::GUI {

--- a/src/slic3r/GUI/Gizmos/GLGizmoHollow.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoHollow.cpp
@@ -3,7 +3,7 @@
 #include "slic3r/GUI/Camera.hpp"
 #include "slic3r/GUI/Gizmos/GLGizmosCommon.hpp"
 
-#include <GL/glew.h>
+#include <epoxy/gl.h>
 
 #include "slic3r/GUI/GUI_App.hpp"
 #include "slic3r/GUI/GUI_ObjectSettings.hpp"

--- a/src/slic3r/GUI/Gizmos/GLGizmoMeasure.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoMeasure.cpp
@@ -12,7 +12,7 @@
 
 #include <numeric>
 
-#include <GL/glew.h>
+#include <epoxy/gl.h>
 
 #include <tbb/parallel_for.h>
 

--- a/src/slic3r/GUI/Gizmos/GLGizmoMmuSegmentation.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoMmuSegmentation.cpp
@@ -15,7 +15,7 @@
 #include "slic3r/Utils/UndoRedo.hpp"
 
 
-#include <GL/glew.h>
+#include <epoxy/gl.h>
 
 namespace Slic3r::GUI {
 

--- a/src/slic3r/GUI/Gizmos/GLGizmoMove.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoMove.cpp
@@ -6,7 +6,7 @@
 #include "libslic3r/AppConfig.hpp"
 
 
-#include <GL/glew.h>
+#include <epoxy/gl.h>
 
 #include <wx/utils.h>
 

--- a/src/slic3r/GUI/Gizmos/GLGizmoPainterBase.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoPainterBase.cpp
@@ -2,7 +2,7 @@
 #include "slic3r/GUI/GLCanvas3D.hpp"
 #include "slic3r/GUI/Gizmos/GLGizmosCommon.hpp"
 
-#include <GL/glew.h>
+#include <epoxy/gl.h>
 
 #include "slic3r/GUI/GUI_App.hpp"
 #include "slic3r/GUI/Camera.hpp"

--- a/src/slic3r/GUI/Gizmos/GLGizmoPainterBase.hpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoPainterBase.hpp
@@ -10,7 +10,7 @@
 #include "libslic3r/Model.hpp"
 
 #include <cereal/types/vector.hpp>
-#include <GL/glew.h>
+#include <epoxy/gl.h>
 
 #include <memory>
 

--- a/src/slic3r/GUI/Gizmos/GLGizmoRotate.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoRotate.cpp
@@ -9,7 +9,7 @@
 
 #include "libslic3r/PresetBundle.hpp"
 
-#include <GL/glew.h>
+#include <epoxy/gl.h>
 
 namespace Slic3r {
 namespace GUI {

--- a/src/slic3r/GUI/Gizmos/GLGizmoSVG.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoSVG.cpp
@@ -32,7 +32,7 @@
 #include <wx/display.h> // detection of change DPI
 #include <boost/log/trivial.hpp>
 
-#include <GL/glew.h>
+#include <epoxy/gl.h>
 #include <chrono> // measure enumeration of fonts
 #include <sstream> // save for svg
 #include <array>

--- a/src/slic3r/GUI/Gizmos/GLGizmoSVG.hpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoSVG.hpp
@@ -19,7 +19,7 @@
 #include "libslic3r/Model.hpp"
 
 #include <imgui/imgui.h>
-#include <GL/glew.h>
+#include <epoxy/gl.h>
 
 namespace Slic3r{
 class ModelVolume;

--- a/src/slic3r/GUI/Gizmos/GLGizmoScale.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoScale.cpp
@@ -3,7 +3,7 @@
 #include "slic3r/GUI/GUI_App.hpp"
 #include "slic3r/GUI/Plater.hpp"
 
-#include <GL/glew.h>
+#include <epoxy/gl.h>
 
 #include <wx/utils.h>
 

--- a/src/slic3r/GUI/Gizmos/GLGizmoSeam.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoSeam.cpp
@@ -11,7 +11,7 @@
 #include "slic3r/GUI/GUI.hpp"
 #include "slic3r/Utils/UndoRedo.hpp"
 
-#include <GL/glew.h>
+#include <epoxy/gl.h>
 
 
 namespace Slic3r::GUI {

--- a/src/slic3r/GUI/Gizmos/GLGizmoSimplify.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoSimplify.cpp
@@ -11,7 +11,7 @@
 #include "libslic3r/Model.hpp"
 #include "libslic3r/QuadricEdgeCollapse.hpp"
 
-#include <GL/glew.h>
+#include <epoxy/gl.h>
 
 #include <thread>
 

--- a/src/slic3r/GUI/Gizmos/GLGizmoSlaSupports.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoSlaSupports.cpp
@@ -6,7 +6,7 @@
 #include "slic3r/GUI/MainFrame.hpp"
 #include "slic3r/Utils/UndoRedo.hpp"
 
-#include <GL/glew.h>
+#include <epoxy/gl.h>
 
 #include <wx/msgdlg.h>
 #include <wx/settings.h>

--- a/src/slic3r/GUI/Gizmos/GLGizmoText.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoText.cpp
@@ -16,7 +16,7 @@
 
 #include <boost/log/trivial.hpp>
 
-#include <GL/glew.h>
+#include <epoxy/gl.h>
 
 #ifndef IMGUI_DEFINE_MATH_OPERATORS
 #define IMGUI_DEFINE_MATH_OPERATORS

--- a/src/slic3r/GUI/Gizmos/GLGizmosCommon.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmosCommon.cpp
@@ -10,7 +10,7 @@
 
 #include "libslic3r/PresetBundle.hpp"
 
-#include <GL/glew.h>
+#include <epoxy/gl.h>
 
 namespace Slic3r {
 namespace GUI {

--- a/src/slic3r/GUI/Gizmos/GLGizmosManager.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmosManager.cpp
@@ -1365,7 +1365,9 @@ void GLGizmosManager::update_hover_state(const EType &type)
 
 bool GLGizmosManager::activate_gizmo(EType type)
 {
-    assert(!m_gizmos.empty());
+    // On Wayland, GL init is deferred and gizmos may not be populated yet.
+    if (m_gizmos.empty())
+        return type == Undefined;
 
     // already activated
     if (m_current == type) return true;

--- a/src/slic3r/GUI/IMToolbar.cpp
+++ b/src/slic3r/GUI/IMToolbar.cpp
@@ -9,6 +9,7 @@
 #include "nanosvg/nanosvgrast.h"
 #include "libslic3r/GCode/ThumbnailData.hpp"
 #include "ImGuiWrapper.hpp"
+#include "OpenGLManager.hpp"
 
 namespace Slic3r {
 namespace GUI {
@@ -87,7 +88,7 @@ bool IMReturnToolbar::init()
     glsafe(::glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR));
     glsafe(::glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR));
     glsafe(::glPixelStorei(GL_UNPACK_ROW_LENGTH, 0));
-    if (compress && GLEW_EXT_texture_compression_s3tc)
+    if (compress && Slic3r::GUI::OpenGLManager::are_compressed_textures_supported())
         glsafe(::glTexImage2D(GL_TEXTURE_2D, 0, GL_COMPRESSED_RGBA_S3TC_DXT5_EXT, data.width, data.height, 0, GL_RGBA, GL_UNSIGNED_BYTE, pixels));
     else
         glsafe(::glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, data.width, data.height, 0, GL_RGBA, GL_UNSIGNED_BYTE, pixels));

--- a/src/slic3r/GUI/IMToolbar.cpp
+++ b/src/slic3r/GUI/IMToolbar.cpp
@@ -1,7 +1,7 @@
 #include "IMToolbar.hpp"
 
 #include "3DScene.hpp"
-#include <GL/glew.h>
+#include <epoxy/gl.h>
 #include <imgui/imgui_internal.h>
 #include <imgui/imgui.h>
 

--- a/src/slic3r/GUI/IconManager.cpp
+++ b/src/slic3r/GUI/IconManager.cpp
@@ -9,7 +9,7 @@
 #include "libslic3r/Utils.hpp" // ScopeGuard   
 
 #include "3DScene.hpp" // glsafe
-#include "GL/glew.h"
+#include <epoxy/gl.h>
 
 #define STB_RECT_PACK_IMPLEMENTATION
 #include "imgui/imstb_rectpack.h" // distribute rectangles

--- a/src/slic3r/GUI/ImGuiWrapper.cpp
+++ b/src/slic3r/GUI/ImGuiWrapper.cpp
@@ -18,7 +18,7 @@
 #include <wx/clipbrd.h>
 #include <wx/debug.h>
 
-#include <GL/glew.h>
+#include <epoxy/gl.h>
 
 #ifndef IMGUI_DEFINE_MATH_OPERATORS
 #define IMGUI_DEFINE_MATH_OPERATORS

--- a/src/slic3r/GUI/ImGuiWrapper.cpp
+++ b/src/slic3r/GUI/ImGuiWrapper.cpp
@@ -2839,7 +2839,7 @@ void ImGuiWrapper::init_font(bool compress)
     glsafe(::glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR));
     glsafe(::glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR));
     glsafe(::glPixelStorei(GL_UNPACK_ROW_LENGTH, 0));
-    if (compress && GLEW_EXT_texture_compression_s3tc)
+    if (compress && Slic3r::GUI::OpenGLManager::are_compressed_textures_supported())
         glsafe(::glTexImage2D(GL_TEXTURE_2D, 0, GL_COMPRESSED_RGBA_S3TC_DXT5_EXT, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, pixels));
     else
         glsafe(::glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, pixels));

--- a/src/slic3r/GUI/Jobs/CreateFontNameImageJob.hpp
+++ b/src/slic3r/GUI/Jobs/CreateFontNameImageJob.hpp
@@ -3,7 +3,7 @@
 
 #include <vector>
 #include <string>
-#include <GL/glew.h>
+#include <epoxy/gl.h>
 #include <wx/string.h>
 #include <wx/fontenc.h>
 #include "Job.hpp"

--- a/src/slic3r/GUI/MeshUtils.cpp
+++ b/src/slic3r/GUI/MeshUtils.cpp
@@ -14,7 +14,7 @@
 #include "slic3r/GUI/CameraUtils.hpp"
 
 
-#include <GL/glew.h>
+#include <epoxy/gl.h>
 
 #include <igl/unproject.h>
 

--- a/src/slic3r/GUI/OpenGLManager.cpp
+++ b/src/slic3r/GUI/OpenGLManager.cpp
@@ -7,7 +7,7 @@
 
 #include "libslic3r/Platform.hpp"
 
-#include <GL/glew.h>
+#include <epoxy/gl.h>
 
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/classification.hpp>
@@ -22,17 +22,7 @@
 #include "../Utils/MacDarkMode.hpp"
 #endif // __APPLE__
 
-// Verify GLEW and wxWidgets use the same OpenGL backend (EGL vs GLX).
-// A mismatch causes rendering failures: GLEW's function loading must match
-// the context type created by wxWidgets.
-#if defined(__linux__)
-    #if defined(GLEW_EGL) && (!defined(wxUSE_GLCANVAS_EGL) || !wxUSE_GLCANVAS_EGL)
-        #error "OpenGL backend mismatch: GLEW has EGL support enabled but wxWidgets does not. Ensure GLEW_USE_EGL and wxUSE_GLCANVAS_EGL are both ON or both OFF."
-    #endif
-    #if !defined(GLEW_EGL) && defined(wxUSE_GLCANVAS_EGL) && wxUSE_GLCANVAS_EGL
-        #error "OpenGL backend mismatch: wxWidgets has EGL support enabled but GLEW does not. Ensure GLEW_USE_EGL and wxUSE_GLCANVAS_EGL are both ON or both OFF."
-    #endif
-#endif
+// libepoxy detects EGL/GLX at runtime -- no compile-time backend check needed.
 
 namespace Slic3r {
 namespace GUI {

--- a/src/slic3r/GUI/OpenGLManager.cpp
+++ b/src/slic3r/GUI/OpenGLManager.cpp
@@ -111,12 +111,12 @@ void OpenGLManager::GLInfo::detect() const
     if (Slic3r::total_physical_memory() / (1024 * 1024 * 1024) < 6)
         *max_tex_size /= 2;
 
-    if (GLEW_EXT_texture_filter_anisotropic) {
+    if (epoxy_has_gl_extension("GL_EXT_texture_filter_anisotropic")) {
         float* max_anisotropy = const_cast<float*>(&m_max_anisotropy);
         glsafe(::glGetFloatv(GL_MAX_TEXTURE_MAX_ANISOTROPY_EXT, max_anisotropy));
     }
 
-    if (!GLEW_ARB_compatibility)
+    if (!epoxy_has_gl_extension("GL_ARB_compatibility"))
         *const_cast<bool*>(&m_core_profile) = true;
 
     *const_cast<bool*>(&m_detected) = true;
@@ -235,24 +235,18 @@ OpenGLManager::~OpenGLManager()
 bool OpenGLManager::init_gl(bool popup_error)
 {
     if (!m_gl_initialized) {
-        glewExperimental = true;
-        GLenum result = glewInit();
-        if (result != GLEW_OK) {
-            BOOST_LOG_TRIVIAL(error) << "Unable to init glew library, Error: " << glewGetErrorString(result);
-            return false;
-        }
-	//BOOST_LOG_TRIVIAL(info) << "glewInit Success."<< std::endl;
+        // libepoxy loads GL functions lazily -- no explicit initialization needed.
         m_gl_initialized = true;
-        if (GLEW_EXT_texture_compression_s3tc)
+        if (epoxy_has_gl_extension("GL_EXT_texture_compression_s3tc"))
             s_compressed_textures_supported = true;
         else
             s_compressed_textures_supported = false;
 
-        if (GLEW_ARB_framebuffer_object) {
+        if (epoxy_has_gl_extension("GL_ARB_framebuffer_object")) {
             s_framebuffers_type = EFramebufferType::Arb;
             BOOST_LOG_TRIVIAL(info) << "Found Framebuffer Type ARB."<< std::endl;
         }
-        else if (GLEW_EXT_framebuffer_object) {
+        else if (epoxy_has_gl_extension("GL_EXT_framebuffer_object")) {
             BOOST_LOG_TRIVIAL(info) << "Found Framebuffer Type Ext."<< std::endl;
             s_framebuffers_type = EFramebufferType::Ext;
         }

--- a/src/slic3r/GUI/PartPlate.cpp
+++ b/src/slic3r/GUI/PartPlate.cpp
@@ -5,7 +5,7 @@
 #include <string>
 #include <regex>
 #include <future>
-#include <GL/glew.h>
+#include <epoxy/gl.h>
 #include <boost/algorithm/string.hpp>
 #include <boost/optional.hpp>
 #include <boost/filesystem/path.hpp>

--- a/src/slic3r/GUI/Selection.cpp
+++ b/src/slic3r/GUI/Selection.cpp
@@ -18,7 +18,7 @@
 #include "libslic3r/BuildVolume.hpp"
 #endif // ENABLE_ENHANCED_PRINT_VOLUME_FIT
 
-#include <GL/glew.h>
+#include <epoxy/gl.h>
 
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/log/trivial.hpp>

--- a/src/slic3r/GUI/SendSystemInfoDialog.cpp
+++ b/src/slic3r/GUI/SendSystemInfoDialog.cpp
@@ -28,7 +28,7 @@
 #include <boost/property_tree/json_parser.hpp>
 #include <boost/uuid/detail/md5.hpp>
 
-#include "GL/glew.h"
+#include <epoxy/gl.h>
 
 #include <wx/display.h>
 #include <wx/htmllbox.h>

--- a/src/slic3r/GUI/SkipPartCanvas.cpp
+++ b/src/slic3r/GUI/SkipPartCanvas.cpp
@@ -1,4 +1,4 @@
-#include <GL/glew.h>
+#include <epoxy/gl.h>
 #include "SkipPartCanvas.hpp"
 
 #include <opencv2/opencv.hpp>

--- a/src/slic3r/GUI/TextLines.cpp
+++ b/src/slic3r/GUI/TextLines.cpp
@@ -1,6 +1,6 @@
 #include "TextLines.hpp"
 
-#include <GL/glew.h>
+#include <epoxy/gl.h>
 
 #include "libslic3r/Model.hpp"
 

--- a/src/slic3r/Utils/EmbossStyleManager.cpp
+++ b/src/slic3r/Utils/EmbossStyleManager.cpp
@@ -1,6 +1,6 @@
 #include "EmbossStyleManager.hpp"
 #include <optional>
-#include <GL/glew.h> // Imgui texture
+#include <epoxy/gl.h> // Imgui texture
 #include <imgui/imgui_internal.h> // ImTextCharFromUtf8
 #include <libslic3r/AppConfig.hpp>
 #include <libslic3r/Utils.hpp> // ScopeGuard

--- a/src/slic3r/Utils/EmbossStyleManager.hpp
+++ b/src/slic3r/Utils/EmbossStyleManager.hpp
@@ -7,7 +7,7 @@
 #include <functional>
 #include <imgui/imgui.h>
 #include <wx/font.h>
-#include <GL/glew.h>
+#include <epoxy/gl.h>
 #include <libslic3r/BoundingBox.hpp>
 #include <libslic3r/Emboss.hpp>
 #include <libslic3r/TextConfiguration.hpp>


### PR DESCRIPTION
## Summary

- **Native Wayland 3D viewport** — OrcaSlicer runs on Wayland without XWayland, with fully functional 3D viewport (Prepare + Preview)
- **X11 backward compatible** — Same binary works on X11 via GLX (PreferGLX) and Wayland via EGL
- **GLEW replaced with libepoxy** — Runtime EGL/GLX dispatch instead of GLEW's compile-time lock

Closes #8145
Closes #6433
Closes #10059
Closes #11698

## Changes

### Build System
- Enable `wxUSE_GLCANVAS_EGL=ON` and `GLEW_USE_EGL=ON` in dependency builds
- Add libepoxy 1.5.10 as vendored dependency (Meson ExternalProject)
- Patch OpenCSG to use libepoxy instead of GLEW (17 source files)
- Remove GLEW from dependency chain
- Add `FindEpoxy.cmake` find module

### Source
- Replace `GL/glew.h` with `epoxy/gl.h` across 50 source files
- Migrate GLEW API calls (glewInit, extension checks) to libepoxy equivalents
- Add `wxGLCanvas::PreferGLX()` for X11 GLX backend selection
- Runtime Wayland/X11 detection via `WAYLAND_DISPLAY`, `XDG_SESSION_TYPE`, `GDK_BACKEND`
- Remove hardcoded `GDK_BACKEND=x11` forcing

### Bug Fixes
- Re-enable canvas rendering when GL context not ready at Wayland boot (EGL lazy surface creation)
- Deferred scene reload for models loaded before GL init
- Guard `activate_gizmo()` against empty gizmo vector during deferred init
- Remove Zink workaround from Linux launch wrapper (conflicts with native EGL)
- Robust display server detection respecting `GDK_BACKEND` override

## Test plan

- [x] OrcaSlicer launches on native Wayland (Cosmic DE) with working 3D viewport
- [x] Models load and display correctly in Prepare tab
- [x] Slice preview renders in Preview tab
- [x] OrcaSlicer launches on X11 (via `GDK_BACKEND=x11`) with working 3D viewport
- [x] Same binary works on both without recompilation
- [ ] Test on GNOME Wayland
- [ ] Test on KDE Plasma Wayland
- [ ] Test on AMD/Intel GPU

**Tested on:** Arch Linux, Cosmic DE, NVIDIA nvidia-open 590.48.01, egl-wayland 1.1.21

## Known limitations

- Menus/popups may not work correctly on some Wayland compositors (upstream wxWidgets issues [#24174](https://github.com/wxWidgets/wxWidgets/issues/24174), [#23942](https://github.com/wxWidgets/wxWidgets/issues/23942))
- Splash screen skipped on Wayland (requires parent window that doesn't exist yet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)