### PR TITLE
Improve readability of "Only one wall on.." parameters

### DIFF
--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -2368,9 +2368,9 @@ void TabPrint::build()
         optgroup->append_single_option_line("gap_fill_flow_ratio", "quality_settings_wall_and_surfaces#surface-flow-ratio");
         optgroup->append_single_option_line("support_flow_ratio", "quality_settings_wall_and_surfaces#surface-flow-ratio");
         optgroup->append_single_option_line("support_interface_flow_ratio", "quality_settings_wall_and_surfaces#surface-flow-ratio");
+        optgroup->append_single_option_line("only_one_wall_first_layer", "quality_settings_wall_and_surfaces#only-one-wall");
         optgroup->append_single_option_line("only_one_wall_top", "quality_settings_wall_and_surfaces#only-one-wall");
         optgroup->append_single_option_line("min_width_top_surface", "quality_settings_wall_and_surfaces#threshold");
-        optgroup->append_single_option_line("only_one_wall_first_layer", "quality_settings_wall_and_surfaces#only-one-wall");
         optgroup->append_single_option_line("reduce_crossing_wall", "quality_settings_wall_and_surfaces#avoid-crossing-walls");
         optgroup->append_single_option_line("max_travel_detour_distance", "quality_settings_wall_and_surfaces#max-detour-length");
 


### PR DESCRIPTION
Used Top surfaces on bottom because it also hides "One wall threshold" when its disabled
both related options and using "One wall threshold" between them reduces readability imo

**BEFORE**
<img width="385" height="170" alt="Screenshot-20260405223745" src="https://github.com/user-attachments/assets/7ce73739-af9c-45a5-a53b-57057e0d5f76" />

**AFTER**
<img width="378" height="171" alt="Screenshot-20260405224823" src="https://github.com/user-attachments/assets/531cbbb6-45c9-44b7-ac62-2e0741319020" />
