### PR TITLE
Fix issue that filament combobox not working after adding extruder

### DIFF
--- a/src/libslic3r/PresetBundle.cpp
+++ b/src/libslic3r/PresetBundle.cpp
@@ -2197,16 +2197,32 @@ void PresetBundle::set_num_filaments(unsigned int n, std::vector<std::string> ne
         filament_presets.resize(n);
     }
     ConfigOptionStrings* filament_color = project_config.option<ConfigOptionStrings>("filament_colour");
+    ConfigOptionStrings *filament_multi_color = project_config.option<ConfigOptionStrings>("filament_multi_colour");
+    ConfigOptionStrings* filament_color_type = project_config.option<ConfigOptionStrings>("filament_colour_type");
+    ConfigOptionInts* filament_map = project_config.option<ConfigOptionInts>("filament_map");
+
+
     filament_color->resize(n);
+    // Sync filament multi colour
+    filament_multi_color->values.resize(n);
+    for (size_t i = 0; i < n; i++) {
+        filament_multi_color->values[i] = filament_color->values[i];
+    }
+    filament_color_type->resize(n);
+    filament_map->values.resize(n, 1);
     ams_multi_color_filment.resize(n);
+
     // BBS set new filament color to new_color
     if (old_filament_count < n) {
         if (!new_colors.empty()) {
             for (int i = old_filament_count; i < n; i++) {
                 filament_color->values[i] = new_colors[i - old_filament_count];
+                filament_multi_color->values[i] = new_colors[i - old_filament_count];
+                filament_color_type->values[i]  = "1";  // default color type
             }
         }
     }
+
     update_multi_material_filament_presets();
 }
 void PresetBundle::set_num_filaments(unsigned int n, std::string new_color)


### PR DESCRIPTION
This fix issue that the filament combobox not working after adding new extruder for multi-tool printers:
<img width="1365" height="1009" alt="image" src="https://github.com/user-attachments/assets/fe69b5cf-c914-485c-ba6a-08a6180ce0c2" />


With this PR:
<img width="1365" height="1012" alt="image" src="https://github.com/user-attachments/assets/e860b4fc-a571-46da-8bcf-fedb5d2c9932" />
