### PR TITLE
fix: Exclude external spool from 16-material AMS limit

### DIFF
--- a/src/slic3r/GUI/SelectMachine.cpp
+++ b/src/slic3r/GUI/SelectMachine.cpp
@@ -3322,7 +3322,7 @@ void SelectMachineDialog::update_show_status(MachineObject* obj_)
         show_status(PrintDialogStatus::PrintStatusNoSdcard);
         return;
     }
-    if (wxGetApp().preset_bundle->filament_presets.size() > 16 && m_print_type != PrintFromType::FROM_SDCARD_VIEW) { 
+    if (wxGetApp().preset_bundle->filament_presets.size() > (16 + obj_->vt_slot.size()) && m_print_type != PrintFromType::FROM_SDCARD_VIEW) {
         if (!obj_->is_enable_ams_np && !obj_->is_enable_np)
         {
             show_status(PrintDialogStatus::PrintStatusColorQuantityExceed);


### PR DESCRIPTION
## Summary

- External spools (virtual trays) are not AMS slots and should not count toward the firmware's 16-material limit
- Fixes blocking error when using 4 AMS units (16 slots) plus an external spool (17 total)

Fixes #12135

## Test plan

- [ ] Configure 4 AMS units (16 slots) + 1 external spool
- [ ] Verify send-to-printer dialog no longer shows material count exceeded error
- [ ] Confirm normal AMS limit enforcement still works without external spool