### PR TITLE
Add vendor-aware filament matching for Qidi Box and fix Moonraker sync

### DIFF
--- a/src/slic3r/GUI/DeviceCore/DevNozzleSystem.cpp
+++ b/src/slic3r/GUI/DeviceCore/DevNozzleSystem.cpp
@@ -140,4 +140,15 @@ void DevNozzleSystemParser::ParseV2_0(const json& nozzle_json, DevNozzleSystem* 
         system->m_nozzles[nozzle_obj.m_nozzle_id] = nozzle_obj;
     }
 }
+
+void DevNozzleSystem::SetNozzleFromPreset(int id, float diameter)
+{
+    DevNozzle nozzle;
+    nozzle.m_nozzle_id = id;
+    nozzle.m_diameter = diameter;
+    nozzle.m_nozzle_type = NozzleType::ntStainlessSteel;
+    nozzle.m_nozzle_flow = NozzleFlowType::S_FLOW;
+    m_nozzles[id] = nozzle;
+}
+
 }

--- a/src/slic3r/GUI/DeviceCore/DevNozzleSystem.h
+++ b/src/slic3r/GUI/DeviceCore/DevNozzleSystem.h
@@ -36,6 +36,9 @@ namespace Slic3r
        const std::map<int, DevNozzle>& GetNozzles() const { return m_nozzles;}
        bool                            IsRefreshing() const { return m_state == 1; }
 
+       // Set nozzle data directly for printers that don't report nozzle info (e.g. Moonraker)
+       void SetNozzleFromPreset(int id, float diameter);
+
    private:
        void Reset();
 

--- a/src/slic3r/Utils/MoonrakerPrinterAgent.cpp
+++ b/src/slic3r/Utils/MoonrakerPrinterAgent.cpp
@@ -7,6 +7,7 @@
 #include "slic3r/GUI/DeviceCore/DevManager.h"
 #include "../GUI/DeviceCore/DevStorage.h"
 #include "../GUI/DeviceCore/DevFirmware.h"
+#include "../GUI/DeviceCore/DevNozzleSystem.h"
 #include "nlohmann/json.hpp"
 #include <boost/algorithm/string.hpp>
 #include <boost/asio/connect.hpp>
@@ -542,6 +543,18 @@ void MoonrakerPrinterAgent::build_ams_payload(int ams_count, int max_lane_index,
     // Set printer_type so update_sync_status() can match it against the preset's printer type.
     // Without this, the comparison fails and all sync badges are cleared.
     obj->printer_type = device_info.model_id;
+
+    // Set nozzle diameter from preset config so get_printer_preset() can match.
+    // Moonraker printers don't report nozzle size via API.
+    auto* preset_bundle = GUI::wxGetApp().preset_bundle;
+    if (preset_bundle) {
+        auto* nozzle_opt = preset_bundle->printers.get_edited_preset()
+            .config.option<ConfigOptionFloats>("nozzle_diameter");
+        if (nozzle_opt && nozzle_opt->size() > 0) {
+            obj->GetNozzleSystem()->SetNozzleFromPreset(0,
+                static_cast<float>(nozzle_opt->get_at(0)));
+        }
+    }
 
     // Set push counters so is_info_ready() returns true for pull-mode agents.
     if (obj->m_push_count == 0) {

--- a/src/slic3r/Utils/QidiPrinterAgent.cpp
+++ b/src/slic3r/Utils/QidiPrinterAgent.cpp
@@ -25,6 +25,22 @@ bool has_visible_base_preset(const PresetCollection& filaments, const std::strin
     return false;
 }
 
+// Find a visible, compatible base preset whose name contains both the vendor and filament name.
+// Case-sensitive — user must enter vendor names matching Orca's profiles exactly.
+std::string find_preset_by_vendor_and_name(const PresetCollection& filaments,
+                                           const std::string&      vendor_name,
+                                           const std::string&      filament_name)
+{
+    for (const auto& p : filaments.get_presets()) {
+        if (p.is_visible && p.is_compatible
+            && filaments.get_preset_base(p) == &p
+            && p.name.find(vendor_name) != std::string::npos
+            && p.name.find(filament_name) != std::string::npos)
+            return p.filament_id;
+    }
+    return "";
+}
+
 } // anonymous namespace
 
 const std::string QidiPrinterAgent_VERSION = "0.0.1";
@@ -172,21 +188,44 @@ bool QidiPrinterAgent::fetch_slot_info(const std::string&        base_url,
         }
 
         if (tray.has_filament) {
-            // Look up filament type name from dictionary
+            // Look up filament name from dictionary (e.g. "PLA+") — used for vendor+name matching
             std::string filament_name = "PLA";
             auto filament_it = dict.filaments.find(filament_type);
             if (filament_it != dict.filaments.end()) {
                 filament_name = filament_it->second;
             }
-            tray.tray_type = normalize_filament_type(filament_name);
 
-            // Try Qidi-specific setting ID first; fall back to visible preset by type
+            // Use base type from "type" field (e.g. "PLA") for tray_type / fallback matching
+            auto type_it = dict.filament_types.find(filament_type);
+            if (type_it != dict.filament_types.end()) {
+                tray.tray_type = normalize_filament_type(type_it->second);
+            } else {
+                tray.tray_type = normalize_filament_type(filament_name);
+            }
+
+            // Resolve vendor name from vendor_list
+            std::string vendor_name;
+            auto vendor_it = dict.vendors.find(vendor_type);
+            if (vendor_it != dict.vendors.end()) {
+                vendor_name = vendor_it->second;
+            }
+
+            // Try Qidi-specific setting ID first
             std::string setting_id = build_setting_id(filament_type, vendor_type, tray.tray_type);
             auto* bundle = GUI::wxGetApp().preset_bundle;
             if (!bundle) {
                 tray.tray_info_idx = setting_id;
             } else if (!setting_id.empty() && has_visible_base_preset(bundle->filaments, setting_id)) {
                 tray.tray_info_idx = setting_id;
+            } else if (!vendor_name.empty()) {
+                // Try vendor+name match (e.g. "eSUN" + "PLA+" → "eSUN PLA+ @base")
+                std::string vendor_match = find_preset_by_vendor_and_name(
+                    bundle->filaments, vendor_name, filament_name);
+                if (!vendor_match.empty()) {
+                    tray.tray_info_idx = vendor_match;
+                } else {
+                    tray.tray_info_idx = bundle->filaments.filament_id_by_type(tray.tray_type);
+                }
             } else {
                 tray.tray_info_idx = bundle->filaments.filament_id_by_type(tray.tray_type);
             }
@@ -246,8 +285,11 @@ bool QidiPrinterAgent::fetch_filament_dict(const std::string& base_url,
 
     dict.colors.clear();
     dict.filaments.clear();
+    dict.filament_types.clear();
+    dict.vendors.clear();
     parse_ini_section(response_body, "colordict", dict.colors);
-    parse_filament_sections(response_body, dict.filaments);
+    parse_filament_sections(response_body, dict.filaments, dict.filament_types);
+    parse_ini_section(response_body, "vendor_list", dict.vendors);
 
     return !dict.colors.empty();
 }
@@ -284,7 +326,7 @@ void QidiPrinterAgent::parse_ini_section(const std::string& content, const std::
     }
 }
 
-void QidiPrinterAgent::parse_filament_sections(const std::string& content, std::map<int, std::string>& result)
+void QidiPrinterAgent::parse_filament_sections(const std::string& content, std::map<int, std::string>& filaments, std::map<int, std::string>& filament_types)
 {
     std::istringstream stream(content);
     std::string        line;
@@ -315,7 +357,9 @@ void QidiPrinterAgent::parse_filament_sections(const std::string& content, std::
                 boost::trim(key);
                 boost::trim(value);
                 if (key == "filament") {
-                    result[current_fila_index] = value;
+                    filaments[current_fila_index] = value;
+                } else if (key == "type") {
+                    filament_types[current_fila_index] = value;
                 }
             }
         }

--- a/src/slic3r/Utils/QidiPrinterAgent.hpp
+++ b/src/slic3r/Utils/QidiPrinterAgent.hpp
@@ -25,7 +25,9 @@ private:
     struct QidiFilamentDict
     {
         std::map<int, std::string> colors;
-        std::map<int, std::string> filaments;
+        std::map<int, std::string> filaments;       // [fila] "filament" field (e.g. "PLA+")
+        std::map<int, std::string> filament_types;   // [fila] "type" field (e.g. "PLA")
+        std::map<int, std::string> vendors;          // [vendor_list] section
     };
 
     // Qidi-specific methods
@@ -43,7 +45,7 @@ private:
 
     // Static helpers
     static void parse_ini_section(const std::string& content, const std::string& section_name, std::map<int, std::string>& result);
-    static void parse_filament_sections(const std::string& content, std::map<int, std::string>& result);
+    static void parse_filament_sections(const std::string& content, std::map<int, std::string>& filaments, std::map<int, std::string>& filament_types);
     static std::string map_filament_type_to_setting_id(const std::string& filament_type);
 };
 


### PR DESCRIPTION
## Summary

- Vendor-aware filament subtype matching for the Qidi printer agent — filament subtypes
like "PLA+" are now matched to the correct OrcaSlicer profile using both vendor name and
filament name from the Qidi Box config file (e.g., "eSUN" + "PLA+" → eSUN PLA+ @base)
- Fix filament sync silently failing for all Moonraker-based printers — nozzle diameter
was defaulting to 0 (Moonraker doesn't report it), which caused get_printer_preset() to
fail matching and silently abort the sync

## Details

### Vendor-aware matching

The Qidi Box config file (officiall_filas_list.cfg) has two fields per filament entry:
filament (specific name like "PLA+") and type (base category like "PLA"). The agent now
parses both fields plus the [vendor_list] section, and uses a 3-tier matching strategy:

1. Try Qidi-specific QD_ setting ID
2. If vendor is known, search for a visible base preset whose name contains both vendor
and filament name
3. Fall back to filament_id_by_type using the base type

This follows OrcaSlicer's convention where PLA subtypes (Silk, Matte, PLA+) all use
filament_type: "PLA" and are distinguished by profile name only. Applies to all Qidi
printers that use the Qidi Box filament system.

### Nozzle diameter fix (all Moonraker printers)

Moonraker printers don't report nozzle size, so MachineObject's nozzle diameter defaults
to 0. This caused get_printer_preset() to never match (it requires both model ID and
nozzle diameter), making is_same_printer_for_connected_and_selected() return false and
silently abort sync. Fixed by setting the nozzle diameter from the selected printer
preset config in build_ams_payload(). This fix benefits all Moonraker-based printers, not
  just Qidi.

### Files changed

- [src/slic3r/Utils/QidiPrinterAgent.hpp](src/slic3r/Utils/QidiPrinterAgent.hpp) — added filament_types and vendors maps to
QidiFilamentDict, updated parse_filament_sections signature
- [src/slic3r/Utils/QidiPrinterAgent.cpp](src/slic3r/Utils/QidiPrinterAgent.cpp) — vendor+name matching helper, type field
parsing, vendor resolution in fetch_slot_info
- [src/slic3r/Utils/MoonrakerPrinterAgent.cpp](src/slic3r/Utils/MoonrakerPrinterAgent.cpp) — set nozzle diameter on DevNozzleSystem
from preset config in build_ams_payload

### Test plan

- Tested with Qidi Q2 + Qidi Box running 4 filament slots: 3x Generic PLA + 1x eSUN PLA+
- Slots correctly show "Generic PLA" for plain PLA and "eSUN PLA+" for vendor-matched
slot
- Sync toast message appears: "Successfully synchronized color and type of filament from
printer"
- Verify no regression on other Moonraker-based printers (Snapmaker, other Qidi models)
- Verify no regression on Bambu Lab printers