### PR TITLE
Migrate Anycubic filament profiles to OrcaFilamentLibrary

### DIFF
--- a/resources/profiles/Anycubic/filament/Anycubic Generic ABS.json
+++ b/resources/profiles/Anycubic/filament/Anycubic Generic ABS.json
@@ -1,17 +1,11 @@
 {
     "type": "filament",
     "name": "Anycubic Generic ABS",
-    "inherits": "fdm_filament_abs",
+    "inherits": "Anycubic ABS @base",
     "from": "system",
     "setting_id": "GFSA04",
     "filament_id": "GFB99",
     "instantiation": "true",
-    "filament_flow_ratio": [
-        "0.926"
-    ],
-    "filament_max_volumetric_speed": [
-        "12"
-    ],
     "compatible_printers": [
         "Anycubic i3 Mega S 0.4 nozzle",
         "Anycubic Chiron 0.4 nozzle",

--- a/resources/profiles/Anycubic/filament/Anycubic Generic ASA.json
+++ b/resources/profiles/Anycubic/filament/Anycubic Generic ASA.json
@@ -1,17 +1,11 @@
 {
     "type": "filament",
     "name": "Anycubic Generic ASA",
-    "inherits": "fdm_filament_asa",
+    "inherits": "Anycubic ASA @base",
     "from": "system",
     "setting_id": "GFSA04",
     "filament_id": "GFB98",
     "instantiation": "true",
-    "filament_flow_ratio": [
-        "0.93"
-    ],
-    "filament_max_volumetric_speed": [
-        "12"
-    ],
     "compatible_printers": [
         "Anycubic i3 Mega S 0.4 nozzle",
         "Anycubic Chiron 0.4 nozzle",

--- a/resources/profiles/Anycubic/filament/Anycubic Generic PA-CF.json
+++ b/resources/profiles/Anycubic/filament/Anycubic Generic PA-CF.json
@@ -1,23 +1,11 @@
 {
     "type": "filament",
     "name": "Anycubic Generic PA-CF",
-    "inherits": "fdm_filament_pa",
+    "inherits": "Anycubic PA-CF @base",
     "from": "system",
     "setting_id": "GFSA04",
     "filament_id": "GFN98",
     "instantiation": "true",
-    "filament_type": [
-        "PA-CF"
-    ],
-    "nozzle_temperature_initial_layer": [
-        "280"
-    ],
-    "nozzle_temperature": [
-        "280"
-    ],
-    "filament_max_volumetric_speed": [
-        "8"
-    ],
     "compatible_printers": [
         "Anycubic i3 Mega S 0.4 nozzle",
         "Anycubic Chiron 0.4 nozzle",

--- a/resources/profiles/Anycubic/filament/Anycubic Generic PA.json
+++ b/resources/profiles/Anycubic/filament/Anycubic Generic PA.json
@@ -1,20 +1,11 @@
 {
     "type": "filament",
     "name": "Anycubic Generic PA",
-    "inherits": "fdm_filament_pa",
+    "inherits": "Anycubic PA @base",
     "from": "system",
     "setting_id": "GFSA04",
     "filament_id": "GFN99",
     "instantiation": "true",
-    "nozzle_temperature_initial_layer": [
-        "280"
-    ],
-    "nozzle_temperature": [
-        "280"
-    ],
-    "filament_max_volumetric_speed": [
-        "12"
-    ],
     "compatible_printers": [
         "Anycubic i3 Mega S 0.4 nozzle",
         "Anycubic Chiron 0.4 nozzle",

--- a/resources/profiles/Anycubic/filament/Anycubic Generic PC.json
+++ b/resources/profiles/Anycubic/filament/Anycubic Generic PC.json
@@ -1,17 +1,11 @@
 {
     "type": "filament",
     "name": "Anycubic Generic PC",
-    "inherits": "fdm_filament_pc",
+    "inherits": "Anycubic PC @base",
     "from": "system",
     "setting_id": "GFSA04",
     "filament_id": "GFC99",
     "instantiation": "true",
-    "filament_max_volumetric_speed": [
-        "12"
-    ],
-    "filament_flow_ratio": [
-        "0.94"
-    ],
     "compatible_printers": [
         "Anycubic i3 Mega S 0.4 nozzle",
         "Anycubic Chiron 0.4 nozzle",

--- a/resources/profiles/Anycubic/filament/Anycubic Generic PETG.json
+++ b/resources/profiles/Anycubic/filament/Anycubic Generic PETG.json
@@ -1,47 +1,11 @@
 {
     "type": "filament",
     "name": "Anycubic Generic PETG",
-    "inherits": "fdm_filament_pet",
+    "inherits": "Anycubic PETG @base",
     "from": "system",
     "setting_id": "GFSA04",
     "filament_id": "GFG99",
     "instantiation": "true",
-    "reduce_fan_stop_start_freq": [
-        "1"
-    ],
-    "slow_down_for_layer_cooling": [
-        "1"
-    ],
-    "fan_cooling_layer_time": [
-        "30"
-    ],
-    "overhang_fan_speed": [
-        "90"
-    ],
-    "overhang_fan_threshold": [
-        "25%"
-    ],
-    "fan_max_speed": [
-        "90"
-    ],
-    "fan_min_speed": [
-        "40"
-    ],
-    "slow_down_min_speed": [
-        "10"
-    ],
-    "slow_down_layer_time": [
-        "8"
-    ],
-    "filament_flow_ratio": [
-        "0.95"
-    ],
-    "filament_max_volumetric_speed": [
-        "10"
-    ],
-    "filament_start_gcode": [
-        "; filament start gcode\n"
-    ],
     "compatible_printers": [
         "Anycubic i3 Mega S 0.4 nozzle",
         "Anycubic Chiron 0.4 nozzle",

--- a/resources/profiles/Anycubic/filament/Anycubic Generic PLA-CF.json
+++ b/resources/profiles/Anycubic/filament/Anycubic Generic PLA-CF.json
@@ -1,23 +1,11 @@
 {
     "type": "filament",
     "name": "Anycubic Generic PLA-CF",
-    "inherits": "fdm_filament_pla",
+    "inherits": "Anycubic PLA-CF @base",
     "from": "system",
     "setting_id": "GFSA04",
     "filament_id": "GFL98",
     "instantiation": "true",
-    "filament_flow_ratio": [
-        "0.95"
-    ],
-    "filament_type": [
-        "PLA-CF"
-    ],
-    "filament_max_volumetric_speed": [
-        "12"
-    ],
-    "slow_down_layer_time": [
-        "7"
-    ],
     "compatible_printers": [
         "Anycubic i3 Mega S 0.4 nozzle",
         "Anycubic Chiron 0.4 nozzle",

--- a/resources/profiles/Anycubic/filament/Anycubic Generic PLA.json
+++ b/resources/profiles/Anycubic/filament/Anycubic Generic PLA.json
@@ -1,20 +1,11 @@
 {
     "type": "filament",
     "name": "Anycubic Generic PLA",
-    "inherits": "fdm_filament_pla",
+    "inherits": "Anycubic PLA @base",
     "from": "system",
     "setting_id": "GFSA04",
     "filament_id": "GFL99",
     "instantiation": "true",
-    "filament_flow_ratio": [
-        "0.98"
-    ],
-    "filament_max_volumetric_speed": [
-        "12"
-    ],
-    "slow_down_layer_time": [
-        "8"
-    ],
     "compatible_printers": [
         "Anycubic i3 Mega S 0.4 nozzle",
         "Anycubic Chiron 0.4 nozzle",

--- a/resources/profiles/Anycubic/filament/Anycubic Generic PVA.json
+++ b/resources/profiles/Anycubic/filament/Anycubic Generic PVA.json
@@ -1,23 +1,11 @@
 {
     "type": "filament",
     "name": "Anycubic Generic PVA",
-    "inherits": "fdm_filament_pva",
+    "inherits": "Anycubic PVA @base",
     "from": "system",
     "setting_id": "GFSA04",
     "filament_id": "GFS99",
     "instantiation": "true",
-    "filament_flow_ratio": [
-        "0.95"
-    ],
-    "filament_max_volumetric_speed": [
-        "12"
-    ],
-    "slow_down_layer_time": [
-        "7"
-    ],
-    "slow_down_min_speed": [
-        "10"
-    ],
     "compatible_printers": [
         "Anycubic i3 Mega S 0.4 nozzle",
         "Anycubic Chiron 0.4 nozzle",

--- a/resources/profiles/Anycubic/filament/Anycubic Generic TPU.json
+++ b/resources/profiles/Anycubic/filament/Anycubic Generic TPU.json
@@ -1,14 +1,11 @@
 {
     "type": "filament",
     "name": "Anycubic Generic TPU",
-    "inherits": "fdm_filament_tpu",
+    "inherits": "Anycubic TPU @base",
     "from": "system",
     "setting_id": "GFSA04",
     "filament_id": "GFU99",
     "instantiation": "true",
-    "filament_max_volumetric_speed": [
-        "3.2"
-    ],
     "compatible_printers": [
         "Anycubic i3 Mega S 0.4 nozzle",
         "Anycubic Chiron 0.4 nozzle",

--- a/resources/profiles/OrcaFilamentLibrary.json
+++ b/resources/profiles/OrcaFilamentLibrary.json
@@ -97,6 +97,10 @@
             "sub_path": "filament/FusRock/FusRock ABS-GF @System.json"
         },
         {
+            "name": "Anycubic ABS @base",
+            "sub_path": "filament/Anycubic/Anycubic ABS @base.json"
+        },
+        {
             "name": "Bambu ABS @base",
             "sub_path": "filament/Bambu/Bambu ABS @base.json"
         },
@@ -143,6 +147,10 @@
         {
             "name": "PolyLite ABS @base",
             "sub_path": "filament/Polymaker/PolyLite ABS @base.json"
+        },
+        {
+            "name": "Anycubic ASA @base",
+            "sub_path": "filament/Anycubic/Anycubic ASA @base.json"
         },
         {
             "name": "Bambu ASA @base",
@@ -209,6 +217,14 @@
             "sub_path": "filament/AliZ/AliZ PA-CF @base.json"
         },
         {
+            "name": "Anycubic PA @base",
+            "sub_path": "filament/Anycubic/Anycubic PA @base.json"
+        },
+        {
+            "name": "Anycubic PA-CF @base",
+            "sub_path": "filament/Anycubic/Anycubic PA-CF @base.json"
+        },
+        {
             "name": "Bambu PA-CF @base",
             "sub_path": "filament/Bambu/Bambu PA-CF @base.json"
         },
@@ -269,6 +285,10 @@
             "sub_path": "filament/Elegoo/Elegoo PAHT @base.json"
         },
         {
+            "name": "Anycubic PC @base",
+            "sub_path": "filament/Anycubic/Anycubic PC @base.json"
+        },
+        {
             "name": "Bambu PC @base",
             "sub_path": "filament/Bambu/Bambu PC @base.json"
         },
@@ -303,6 +323,10 @@
         {
             "name": "AliZ PETG @base",
             "sub_path": "filament/AliZ/AliZ PETG @base.json"
+        },
+        {
+            "name": "Anycubic PETG @base",
+            "sub_path": "filament/Anycubic/Anycubic PETG @base.json"
         },
         {
             "name": "Bambu PET-CF @base",
@@ -411,6 +435,14 @@
         {
             "name": "AliZ PLA @base",
             "sub_path": "filament/AliZ/AliZ PLA @base.json"
+        },
+        {
+            "name": "Anycubic PLA @base",
+            "sub_path": "filament/Anycubic/Anycubic PLA @base.json"
+        },
+        {
+            "name": "Anycubic PLA-CF @base",
+            "sub_path": "filament/Anycubic/Anycubic PLA-CF @base.json"
         },
         {
             "name": "Bambu PLA Aero @base",
@@ -797,6 +829,10 @@
             "sub_path": "filament/Bambu/Bambu PPS-CF @base.json"
         },
         {
+            "name": "Anycubic PVA @base",
+            "sub_path": "filament/Anycubic/Anycubic PVA @base.json"
+        },
+        {
             "name": "Bambu PVA @base",
             "sub_path": "filament/Bambu/Bambu PVA @base.json"
         },
@@ -811,6 +847,10 @@
         {
             "name": "Generic SBS @System",
             "sub_path": "filament/Generic SBS @System.json"
+        },
+        {
+            "name": "Anycubic TPU @base",
+            "sub_path": "filament/Anycubic/Anycubic TPU @base.json"
         },
         {
             "name": "Bambu TPU 95A @base",
@@ -873,6 +913,10 @@
             "sub_path": "filament/Overture/Overture TPU @base.json"
         },
         {
+            "name": "Anycubic ABS @System",
+            "sub_path": "filament/Anycubic/Anycubic ABS @System.json"
+        },
+        {
             "name": "Bambu ABS @System",
             "sub_path": "filament/Bambu/Bambu ABS @System.json"
         },
@@ -907,6 +951,10 @@
         {
             "name": "PolyLite ABS @System",
             "sub_path": "filament/Polymaker/PolyLite ABS @System.json"
+        },
+        {
+            "name": "Anycubic ASA @System",
+            "sub_path": "filament/Anycubic/Anycubic ASA @System.json"
         },
         {
             "name": "Bambu ASA @System",
@@ -947,6 +995,14 @@
         {
             "name": "AliZ PA-CF @System",
             "sub_path": "filament/AliZ/AliZ PA-CF @System.json"
+        },
+        {
+            "name": "Anycubic PA @System",
+            "sub_path": "filament/Anycubic/Anycubic PA @System.json"
+        },
+        {
+            "name": "Anycubic PA-CF @System",
+            "sub_path": "filament/Anycubic/Anycubic PA-CF @System.json"
         },
         {
             "name": "Bambu PA-CF @System",
@@ -993,6 +1049,10 @@
             "sub_path": "filament/Polymaker/Fiberon PA612-CF @System.json"
         },
         {
+            "name": "Anycubic PC @System",
+            "sub_path": "filament/Anycubic/Anycubic PC @System.json"
+        },
+        {
             "name": "Bambu PC @System",
             "sub_path": "filament/Bambu/Bambu PC @System.json"
         },
@@ -1015,6 +1075,10 @@
         {
             "name": "AliZ PETG-Metal @base",
             "sub_path": "filament/AliZ/AliZ PETG-Metal @base.json"
+        },
+        {
+            "name": "Anycubic PETG @System",
+            "sub_path": "filament/Anycubic/Anycubic PETG @System.json"
         },
         {
             "name": "Bambu PET-CF @System",
@@ -1091,6 +1155,14 @@
         {
             "name": "AliZ PLA @System",
             "sub_path": "filament/AliZ/AliZ PLA @System.json"
+        },
+        {
+            "name": "Anycubic PLA @System",
+            "sub_path": "filament/Anycubic/Anycubic PLA @System.json"
+        },
+        {
+            "name": "Anycubic PLA-CF @System",
+            "sub_path": "filament/Anycubic/Anycubic PLA-CF @System.json"
         },
         {
             "name": "Bambu PLA Aero @System",
@@ -1397,12 +1469,20 @@
             "sub_path": "filament/Bambu/Bambu PPA-CF @System.json"
         },
         {
+            "name": "Anycubic PVA @System",
+            "sub_path": "filament/Anycubic/Anycubic PVA @System.json"
+        },
+        {
             "name": "Bambu PVA @System",
             "sub_path": "filament/Bambu/Bambu PVA @System.json"
         },
         {
             "name": "FDplast SBS @System",
             "sub_path": "filament/FDplast/FDplast SBS @System.json"
+        },
+        {
+            "name": "Anycubic TPU @System",
+            "sub_path": "filament/Anycubic/Anycubic TPU @System.json"
         },
         {
             "name": "Bambu TPU 95A @System",

--- a/resources/profiles/OrcaFilamentLibrary/filament/Anycubic/Anycubic ABS @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Anycubic/Anycubic ABS @System.json
@@ -1,0 +1,9 @@
+{
+    "type": "filament",
+    "name": "Anycubic ABS @System",
+    "inherits": "Anycubic ABS @base",
+    "from": "system",
+    "setting_id": "OGFSA01_00",
+    "instantiation": "true",
+    "compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Anycubic/Anycubic ABS @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Anycubic/Anycubic ABS @base.json
@@ -1,0 +1,17 @@
+{
+    "type": "filament",
+    "name": "Anycubic ABS @base",
+    "inherits": "fdm_filament_abs",
+    "from": "system",
+    "filament_id": "ACABSB00",
+    "instantiation": "false",
+    "filament_vendor": [
+        "Anycubic"
+    ],
+    "filament_flow_ratio": [
+        "0.926"
+    ],
+    "filament_max_volumetric_speed": [
+        "12"
+    ]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Anycubic/Anycubic ASA @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Anycubic/Anycubic ASA @System.json
@@ -1,0 +1,9 @@
+{
+    "type": "filament",
+    "name": "Anycubic ASA @System",
+    "inherits": "Anycubic ASA @base",
+    "from": "system",
+    "setting_id": "OGFSA02_00",
+    "instantiation": "true",
+    "compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Anycubic/Anycubic ASA @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Anycubic/Anycubic ASA @base.json
@@ -1,0 +1,17 @@
+{
+    "type": "filament",
+    "name": "Anycubic ASA @base",
+    "inherits": "fdm_filament_asa",
+    "from": "system",
+    "filament_id": "ACASAB00",
+    "instantiation": "false",
+    "filament_vendor": [
+        "Anycubic"
+    ],
+    "filament_flow_ratio": [
+        "0.93"
+    ],
+    "filament_max_volumetric_speed": [
+        "12"
+    ]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Anycubic/Anycubic PA @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Anycubic/Anycubic PA @System.json
@@ -1,0 +1,9 @@
+{
+    "type": "filament",
+    "name": "Anycubic PA @System",
+    "inherits": "Anycubic PA @base",
+    "from": "system",
+    "setting_id": "OGFSA03_00",
+    "instantiation": "true",
+    "compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Anycubic/Anycubic PA @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Anycubic/Anycubic PA @base.json
@@ -1,0 +1,20 @@
+{
+    "type": "filament",
+    "name": "Anycubic PA @base",
+    "inherits": "fdm_filament_pa",
+    "from": "system",
+    "filament_id": "ACPAB00",
+    "instantiation": "false",
+    "filament_vendor": [
+        "Anycubic"
+    ],
+    "filament_max_volumetric_speed": [
+        "12"
+    ],
+    "nozzle_temperature": [
+        "280"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "280"
+    ]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Anycubic/Anycubic PA-CF @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Anycubic/Anycubic PA-CF @System.json
@@ -1,0 +1,9 @@
+{
+    "type": "filament",
+    "name": "Anycubic PA-CF @System",
+    "inherits": "Anycubic PA-CF @base",
+    "from": "system",
+    "setting_id": "OGFSA04_00",
+    "instantiation": "true",
+    "compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Anycubic/Anycubic PA-CF @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Anycubic/Anycubic PA-CF @base.json
@@ -1,0 +1,23 @@
+{
+    "type": "filament",
+    "name": "Anycubic PA-CF @base",
+    "inherits": "fdm_filament_pa",
+    "from": "system",
+    "filament_id": "ACPACFB0",
+    "instantiation": "false",
+    "filament_type": [
+        "PA-CF"
+    ],
+    "filament_vendor": [
+        "Anycubic"
+    ],
+    "filament_max_volumetric_speed": [
+        "8"
+    ],
+    "nozzle_temperature": [
+        "280"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "280"
+    ]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Anycubic/Anycubic PC @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Anycubic/Anycubic PC @System.json
@@ -1,0 +1,9 @@
+{
+    "type": "filament",
+    "name": "Anycubic PC @System",
+    "inherits": "Anycubic PC @base",
+    "from": "system",
+    "setting_id": "OGFSA05_00",
+    "instantiation": "true",
+    "compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Anycubic/Anycubic PC @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Anycubic/Anycubic PC @base.json
@@ -1,0 +1,17 @@
+{
+    "type": "filament",
+    "name": "Anycubic PC @base",
+    "inherits": "fdm_filament_pc",
+    "from": "system",
+    "filament_id": "ACPCB00",
+    "instantiation": "false",
+    "filament_vendor": [
+        "Anycubic"
+    ],
+    "filament_flow_ratio": [
+        "0.94"
+    ],
+    "filament_max_volumetric_speed": [
+        "12"
+    ]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Anycubic/Anycubic PETG @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Anycubic/Anycubic PETG @System.json
@@ -1,0 +1,9 @@
+{
+    "type": "filament",
+    "name": "Anycubic PETG @System",
+    "inherits": "Anycubic PETG @base",
+    "from": "system",
+    "setting_id": "OGFSA06_00",
+    "instantiation": "true",
+    "compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Anycubic/Anycubic PETG @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Anycubic/Anycubic PETG @base.json
@@ -1,0 +1,47 @@
+{
+    "type": "filament",
+    "name": "Anycubic PETG @base",
+    "inherits": "fdm_filament_pet",
+    "from": "system",
+    "filament_id": "ACPETGB0",
+    "instantiation": "false",
+    "fan_cooling_layer_time": [
+        "30"
+    ],
+    "fan_max_speed": [
+        "90"
+    ],
+    "fan_min_speed": [
+        "40"
+    ],
+    "filament_flow_ratio": [
+        "0.95"
+    ],
+    "filament_max_volumetric_speed": [
+        "10"
+    ],
+    "filament_vendor": [
+        "Anycubic"
+    ],
+    "overhang_fan_speed": [
+        "90"
+    ],
+    "overhang_fan_threshold": [
+        "25%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "slow_down_for_layer_cooling": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "8"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
+    "filament_start_gcode": [
+        "; filament start gcode\n"
+    ]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Anycubic/Anycubic PLA @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Anycubic/Anycubic PLA @System.json
@@ -1,0 +1,9 @@
+{
+    "type": "filament",
+    "name": "Anycubic PLA @System",
+    "inherits": "Anycubic PLA @base",
+    "from": "system",
+    "setting_id": "OGFSA07_00",
+    "instantiation": "true",
+    "compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Anycubic/Anycubic PLA @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Anycubic/Anycubic PLA @base.json
@@ -1,0 +1,20 @@
+{
+    "type": "filament",
+    "name": "Anycubic PLA @base",
+    "inherits": "fdm_filament_pla",
+    "from": "system",
+    "filament_id": "ACPLAB00",
+    "instantiation": "false",
+    "filament_vendor": [
+        "Anycubic"
+    ],
+    "filament_flow_ratio": [
+        "0.98"
+    ],
+    "filament_max_volumetric_speed": [
+        "12"
+    ],
+    "slow_down_layer_time": [
+        "8"
+    ]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Anycubic/Anycubic PLA-CF @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Anycubic/Anycubic PLA-CF @System.json
@@ -1,0 +1,9 @@
+{
+    "type": "filament",
+    "name": "Anycubic PLA-CF @System",
+    "inherits": "Anycubic PLA-CF @base",
+    "from": "system",
+    "setting_id": "OGFSA08_00",
+    "instantiation": "true",
+    "compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Anycubic/Anycubic PLA-CF @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Anycubic/Anycubic PLA-CF @base.json
@@ -1,0 +1,23 @@
+{
+    "type": "filament",
+    "name": "Anycubic PLA-CF @base",
+    "inherits": "fdm_filament_pla",
+    "from": "system",
+    "filament_id": "ACPLCFB0",
+    "instantiation": "false",
+    "filament_type": [
+        "PLA-CF"
+    ],
+    "filament_vendor": [
+        "Anycubic"
+    ],
+    "filament_flow_ratio": [
+        "0.95"
+    ],
+    "filament_max_volumetric_speed": [
+        "12"
+    ],
+    "slow_down_layer_time": [
+        "7"
+    ]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Anycubic/Anycubic PVA @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Anycubic/Anycubic PVA @System.json
@@ -1,0 +1,9 @@
+{
+    "type": "filament",
+    "name": "Anycubic PVA @System",
+    "inherits": "Anycubic PVA @base",
+    "from": "system",
+    "setting_id": "OGFSA09_00",
+    "instantiation": "true",
+    "compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Anycubic/Anycubic PVA @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Anycubic/Anycubic PVA @base.json
@@ -1,0 +1,23 @@
+{
+    "type": "filament",
+    "name": "Anycubic PVA @base",
+    "inherits": "fdm_filament_pva",
+    "from": "system",
+    "filament_id": "ACPVAB00",
+    "instantiation": "false",
+    "filament_vendor": [
+        "Anycubic"
+    ],
+    "filament_flow_ratio": [
+        "0.95"
+    ],
+    "filament_max_volumetric_speed": [
+        "12"
+    ],
+    "slow_down_layer_time": [
+        "7"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Anycubic/Anycubic TPU @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Anycubic/Anycubic TPU @System.json
@@ -1,0 +1,9 @@
+{
+    "type": "filament",
+    "name": "Anycubic TPU @System",
+    "inherits": "Anycubic TPU @base",
+    "from": "system",
+    "setting_id": "OGFSA10_00",
+    "instantiation": "true",
+    "compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Anycubic/Anycubic TPU @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Anycubic/Anycubic TPU @base.json
@@ -1,0 +1,14 @@
+{
+    "type": "filament",
+    "name": "Anycubic TPU @base",
+    "inherits": "fdm_filament_tpu",
+    "from": "system",
+    "filament_id": "ACTPUB00",
+    "instantiation": "false",
+    "filament_vendor": [
+        "Anycubic"
+    ],
+    "filament_max_volumetric_speed": [
+        "3.2"
+    ]
+}


### PR DESCRIPTION
## Summary

Migrates 10 Anycubic base filament profiles into OrcaFilamentLibrary, making them available to all printers. Follows the migration pattern established by @SoftFever in #13148 (Elegoo).

### Materials migrated
| Material | Library @base | Library @System | Vendor file updated |
|---|---|---|---|
| PLA | `Anycubic PLA @base` | `Anycubic PLA @System` | `Anycubic Generic PLA` |
| PETG | `Anycubic PETG @base` | `Anycubic PETG @System` | `Anycubic Generic PETG` |
| ABS | `Anycubic ABS @base` | `Anycubic ABS @System` | `Anycubic Generic ABS` |
| ASA | `Anycubic ASA @base` | `Anycubic ASA @System` | `Anycubic Generic ASA` |
| PA | `Anycubic PA @base` | `Anycubic PA @System` | `Anycubic Generic PA` |
| PA-CF | `Anycubic PA-CF @base` | `Anycubic PA-CF @System` | `Anycubic Generic PA-CF` |
| PC | `Anycubic PC @base` | `Anycubic PC @System` | `Anycubic Generic PC` |
| PLA-CF | `Anycubic PLA-CF @base` | `Anycubic PLA-CF @System` | `Anycubic Generic PLA-CF` |
| PVA | `Anycubic PVA @base` | `Anycubic PVA @System` | `Anycubic Generic PVA` |
| TPU | `Anycubic TPU @base` | `Anycubic TPU @System` | `Anycubic Generic TPU` |

### What changed
- **20 new files** in `OrcaFilamentLibrary/filament/Anycubic/` — 10 `@base` (minimal deltas) + 10 `@System` (universal availability)
- **10 modified vendor files** — `Anycubic Generic *.json` now inherit from library `@base`, duplicated settings stripped
- **OrcaFilamentLibrary.json** — 20 new manifest entries in correct alphabetical positions
- **Machine-specific profiles unchanged** — Kobra 2/3/S1 variants continue inheriting through vendor Generic files

### Validation
- `orca_extra_profile_check.py`: 0 errors
- All JSON files validated
- No filament name collisions
- No filament_id collisions

Contributes to #12162

🤖 Generated with [Claude Code](https://claude.com/claude-code)