### PR TITLE
Fix first layer speed and layer slow down handling with rafts

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -6361,14 +6361,17 @@ std::string GCode::_extrude(const ExtrusionPath &path, std::string description, 
 
     if (speed == 0)
         speed = filament_max_volumetric_speed / _mm3_per_mm;
-    if (this->on_first_layer()) {
+    
+    const auto _layer = layer_id();
+    if (this->on_first_layer() || object_layer_over_raft()) {
         //BBS: for solid infill of first layer, speed can be higher as long as
         //wall lines have be attached
-        if (path.role() != erBottomSurface)
-            speed = m_config.get_abs_value("initial_layer_speed");
-    }
-    else if(m_config.slow_down_layers > 1){
-        const auto _layer = layer_id();
+        if (path.role() != erBottomSurface) {
+            speed = is_perimeter(path.role()) ? m_config.get_abs_value("initial_layer_speed") :
+                                                m_config.get_abs_value("initial_layer_infill_speed");
+        }
+    } else if (m_config.slow_down_layers > 1 && !m_config.raft_layers > 0) {
+        
         if (_layer > 0 && _layer < m_config.slow_down_layers) {
             const auto first_layer_speed =
                 is_perimeter(path.role())
@@ -6378,7 +6381,18 @@ std::string GCode::_extrude(const ExtrusionPath &path, std::string description, 
                 speed = std::min(
                     speed,
                     Slic3r::lerp(first_layer_speed, speed,
-                                 (double)_layer / m_config.slow_down_layers));
+                                (double) (_layer) / m_config.slow_down_layers));
+            }
+        }
+    } else if (m_config.slow_down_layers > 1 && m_config.raft_layers > 0 ) {
+        
+        if (_layer > m_config.raft_layers && (_layer - m_config.raft_layers) < m_config.slow_down_layers) {
+            const auto first_layer_speed 
+                = is_perimeter(path.role()) ? m_config.get_abs_value("initial_layer_speed") :
+                                                                       m_config.get_abs_value("initial_layer_infill_speed");
+            if (first_layer_speed < speed) {
+                speed = std::min(speed, Slic3r::lerp(first_layer_speed, speed,
+                                                     (double) (_layer - m_config.raft_layers) / m_config.slow_down_layers));
             }
         }
     }
@@ -6441,7 +6455,7 @@ std::string GCode::_extrude(const ExtrusionPath &path, std::string description, 
     bool variable_speed = false;
     std::vector<ProcessedPoint> new_points {};
 
-    if (m_config.enable_overhang_speed && !this->on_first_layer() &&
+    if (m_config.enable_overhang_speed && !this->on_first_layer() && !object_layer_over_raft() &&
         (is_bridge(path.role()) || is_perimeter(path.role()))) {
             bool is_external = is_external_perimeter(path.role());
             double ref_speed   = is_external ? m_config.get_abs_value("outer_wall_speed") : m_config.get_abs_value("inner_wall_speed");


### PR DESCRIPTION


# Description

Adjust initial layer speed and slow down layer speed logic to correctly account for raft layers. 

- improved the previous layer checks with object_layer_over_raft() function
- make sure that the first layer infill speed actually applies
- split the slow_down_layers interpolation into separate branches for configurations with and without rafts so the lerp uses the correct layer offset. 
- with the raft turned on, the slowdown layers only apply to the object layers not the raft layers
- the first base layer of the raft is actually an "infill" layer so the speed is set by the first layer infill speed.

Also added a check for raft on the overhang speed slow down that was applying to the object layer that is directly over raft so that it is now excluded. This way the first layer above raft (which is actually a overhang as technically unsupported) doesn't revert to the slow down for overhangs speed limits and instead uses the first layer & first layer infill speed settings. 

# Screenshots/Recordings/Graphs

Without raft (works as expected):
<img width="2009" height="1066" alt="image" src="https://github.com/user-attachments/assets/69303360-f52a-4e3c-a354-96179e70888f" />

With raft using previous code (didn't apply to layers above raft):
<img width="2043" height="1057" alt="image" src="https://github.com/user-attachments/assets/2405945e-ecae-44c0-8583-9af295eb9d2b" />


With raft using this change (now applies to layers above raft):
<img width="2017" height="1040" alt="image" src="https://github.com/user-attachments/assets/3a129da4-a6a2-409b-be92-2f5f7a68ef10" />

## Tests

Test various extremes of number of raft layers and the number of slow down layers. Checked that speed for first layer and first layer infill work as expected.
