### PR TITLE
Fix AMS default filament colour assignment

### DIFF
--- a/src/slic3r/GUI/AMSMaterialsSetting.cpp
+++ b/src/slic3r/GUI/AMSMaterialsSetting.cpp
@@ -35,6 +35,24 @@ static std::string float_to_string_with_precision(float value, int precision = 3
     return stream.str();
 }
 
+static std::string normalize_preset_colour_for_ams(std::string color)
+{
+    if (!color.empty() && color.front() == '#')
+        color.erase(color.begin());
+
+    if (color.size() == 6)
+        color += "FF";
+
+    if (color.size() != 8)
+        return std::string();
+
+    for (char c : color)
+        if (!((c >= '0' && c <= '9') || (c >= 'A' && c <= 'F') || (c >= 'a' && c <= 'f')))
+            return std::string();
+
+    return color;
+}
+
 AMSMaterialsSetting::AMSMaterialsSetting(wxWindow *parent, wxWindowID id)
     : DPIDialog(parent, id, _L("AMS Materials Setting"), wxDefaultPosition, wxDefaultSize, wxCAPTION | wxCLOSE_BOX)
     , m_color_picker_popup(ColorPickerPopup(this))
@@ -1216,8 +1234,9 @@ void AMSMaterialsSetting::on_select_filament(wxCommandEvent &evt)
     }
 
     std::string default_color = filament_default_colour(selected_filament_preset);
-    if (!default_color.empty()) {
-        wxColour color = DevAmsTray::decode_color(default_color);
+    std::string ams_color     = normalize_preset_colour_for_ams(default_color);
+    if (!ams_color.empty()) {
+        wxColour color = DevAmsTray::decode_color(ams_color);
         set_color(color);
         set_colors({ color });
     }

--- a/src/slic3r/GUI/AMSMaterialsSetting.cpp
+++ b/src/slic3r/GUI/AMSMaterialsSetting.cpp
@@ -2,6 +2,7 @@
 #include "ExtrusionCalibration.hpp"
 #include "MsgDialog.hpp"
 #include "GUI_App.hpp"
+#include "FilamentPresetUtils.hpp"
 #include "libslic3r/Preset.hpp"
 #include "I18N.hpp"
 #include <boost/log/trivial.hpp>
@@ -1099,6 +1100,7 @@ void AMSMaterialsSetting::on_select_filament(wxCommandEvent &evt)
 
     m_filament_type = "";
     PresetBundle* preset_bundle = wxGetApp().preset_bundle;
+    const Preset* selected_filament_preset = nullptr;
     if (preset_bundle) {
         std::ostringstream stream;
         if (obj)
@@ -1121,6 +1123,7 @@ void AMSMaterialsSetting::on_select_filament(wxCommandEvent &evt)
                         }
                     }
                     if (!it->is_system && !has_compatible_printer) continue;
+                    selected_filament_preset = &(*it);
                     // ) if nozzle_temperature_range is found
                     ConfigOption* opt_min = it->config.option("nozzle_temperature_range_low");
                     if (opt_min) {
@@ -1200,9 +1203,23 @@ void AMSMaterialsSetting::on_select_filament(wxCommandEvent &evt)
             if (it->alias.compare(m_comboBox_filament->GetValue().ToStdString()) == 0) {
                 ams_filament_id = it->filament_id;
                 ams_setting_id = it->setting_id;
+                if (!selected_filament_preset) {
+                    selected_filament_preset = &(*it);
+                }
                 break;
             }
         }
+    }
+
+    if (!selected_filament_preset && preset_bundle && !ams_filament_id.empty()) {
+        selected_filament_preset = find_filament_preset_by_id(preset_bundle, ams_filament_id);
+    }
+
+    std::string default_color = filament_default_colour(selected_filament_preset);
+    if (!default_color.empty()) {
+        wxColour color = DevAmsTray::decode_color(default_color);
+        set_color(color);
+        set_colors({ color });
     }
 
     wxArrayString items;

--- a/src/slic3r/GUI/FilamentPresetUtils.hpp
+++ b/src/slic3r/GUI/FilamentPresetUtils.hpp
@@ -1,0 +1,46 @@
+#ifndef slic3r_GUI_FilamentPresetUtils_hpp_
+#define slic3r_GUI_FilamentPresetUtils_hpp_
+
+#include <string>
+
+#include "libslic3r/Preset.hpp"
+#include "libslic3r/PresetBundle.hpp"
+
+namespace Slic3r { namespace GUI {
+
+inline std::string filament_default_colour(const Preset* preset)
+{
+    return preset ? preset->config.opt_string("default_filament_colour", 0u) : std::string();
+}
+
+inline const Preset* find_preset_by_name_or_alias(
+    const PresetBundle* preset_bundle,
+    Preset::Type preset_type,
+    const PresetCollection* collection,
+    const std::string& name_or_alias)
+{
+    if (!collection || name_or_alias.empty())
+        return nullptr;
+
+    std::string preset_name = Preset::remove_suffix_modified(name_or_alias);
+    if (preset_bundle)
+        preset_name = preset_bundle->get_preset_name_by_alias(preset_type, preset_name);
+
+    return collection->find_preset(preset_name);
+}
+
+inline const Preset* find_filament_preset_by_id(const PresetBundle* preset_bundle, const std::string& filament_id)
+{
+    if (!preset_bundle || filament_id.empty())
+        return nullptr;
+
+    for (auto it = preset_bundle->filaments.begin(); it != preset_bundle->filaments.end(); ++it)
+        if (it->filament_id == filament_id)
+            return &(*it);
+
+    return nullptr;
+}
+
+}} // namespace Slic3r::GUI
+
+#endif // slic3r_GUI_FilamentPresetUtils_hpp_

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -73,6 +73,7 @@
 
 #include "GUI.hpp"
 #include "GUI_App.hpp"
+#include "FilamentPresetUtils.hpp"
 #include "GuiColor.hpp"
 #include "GUI_ObjectList.hpp"
 #ifdef __WXGTK__
@@ -9322,6 +9323,19 @@ void Plater::priv::on_select_preset(wxCommandEvent &evt)
 
     if (preset_type == Preset::TYPE_FILAMENT) {
         wxGetApp().preset_bundle->set_filament_preset(idx, preset_name);
+        if (idx >= 0) {
+            auto* preset = find_preset_by_name_or_alias(wxGetApp().preset_bundle, Preset::TYPE_FILAMENT, &wxGetApp().preset_bundle->filaments, preset_name);
+            std::string color = filament_default_colour(preset);
+            if (!color.empty()) {
+                auto& project_config = wxGetApp().preset_bundle->project_config;
+                if (auto* color_opt = project_config.option<ConfigOptionStrings>("filament_colour");
+                    color_opt && static_cast<size_t>(idx) < color_opt->values.size())
+                    color_opt->values[idx] = color;
+                if (auto* multi_color_opt = project_config.option<ConfigOptionStrings>("filament_multi_colour");
+                    multi_color_opt && static_cast<size_t>(idx) < multi_color_opt->values.size())
+                    multi_color_opt->values[idx] = color;
+            }
+        }
         wxGetApp().plater()->update_project_dirty_from_presets();
         wxGetApp().preset_bundle->export_selections(*wxGetApp().app_config);
         sidebar->update_dynamic_filament_list();

--- a/src/slic3r/GUI/PresetComboBoxes.cpp
+++ b/src/slic3r/GUI/PresetComboBoxes.cpp
@@ -43,6 +43,7 @@
 #include "MsgDialog.hpp"
 #include "ParamsDialog.hpp"
 #include "FilamentPickerDialog.hpp"
+#include "FilamentPresetUtils.hpp"
 #include "wxExtensions.hpp"
 
 #include "DeviceCore/DevManager.h"
@@ -234,11 +235,10 @@ int PresetComboBox::update_ams_color()
     std::string color;
     std::string ctype;
     std::vector<std::string> colors;
+    auto* preset = find_preset_by_name_or_alias(wxGetApp().preset_bundle, m_type, m_collection, GetValue().ToUTF8().data());
+    color = filament_default_colour(preset);
+    bool use_preset_default_color = !color.empty();
     if (idx < 0) {
-        auto  name   = Preset::remove_suffix_modified(GetValue().ToUTF8().data());
-        auto *preset = m_collection->find_preset(name);
-        if (preset)
-            color = preset->config.opt_string("default_filament_colour", 0u);
         if (color.empty()) return -1;
     } else {
         auto &ams_list = wxGetApp().preset_bundle->filament_ams_list;
@@ -247,9 +247,11 @@ int PresetComboBox::update_ams_color()
             BOOST_LOG_TRIVIAL(warning) << __FUNCTION__ << boost::format(": ams %1% out of range %2%") % idx % ams_list.size();
             return -1;
         }
-        color = iter->second.opt_string("filament_colour", 0u);
+        if (color.empty())
+            color = iter->second.opt_string("filament_colour", 0u);
         ctype = iter->second.opt_string("filament_colour_type", 0u);
-        colors = iter->second.opt<ConfigOptionStrings>("filament_multi_colour")->values;
+        if (!use_preset_default_color)
+            colors = iter->second.opt<ConfigOptionStrings>("filament_multi_colour")->values;
     }
     DynamicPrintConfig *cfg        = &wxGetApp().preset_bundle->project_config;
     auto color_head = static_cast<ConfigOptionStrings*>(cfg->option("filament_colour")->clone()); // single color (the first color if multi-color filament)


### PR DESCRIPTION
# Description

This PR applies filament profile default colors consistently when selecting filament presets.

Some filament profiles define `default_filament_colour`, but the selected filament color was not always propagated into the active project/AMS state. This could make Prepare and Device AMS behave differently, and Device AMS could show no assigned color even when the selected filament profile had a default color.

Changes:
- Add shared helper functions for resolving filament presets and reading `default_filament_colour`.
- Apply preset default color when selecting filament presets in Prepare.
- Prefer preset default color when updating AMS colors from filament combo boxes.
- Apply preset default color in Device AMS material settings.
- Normalize preset color format (`#RRGGBB` / `#RRGGBBAA`) to AMS/device color format (`RRGGBBAA`) before decoding.

Profiles without `default_filament_colour`, such as some basic Bambu filament profiles, remain unchanged and still require manual color selection.

No breaking changes or dependency changes.

# Screenshots/Recordings/Graphs

No visual layout changes.

# Tests

Tested locally with a rebuilt Windows app.

Verified:
- Selecting a generated filament profile with `default_filament_colour` applies the expected color in Prepare.
- Selecting the same profile in Device AMS assigns the expected color.
- Manual color changes after selecting a filament still work.
- Clearing a slot and selecting a Bambu/basic filament without `default_filament_colour` still leaves the color unassigned, as expected.

