### PR TITLE
💥Fix crash svg use surface

### DIFF
--- a/src/libslic3r/CutSurface.cpp
+++ b/src/libslic3r/CutSurface.cpp
@@ -2556,7 +2556,6 @@ void priv::create_face_types(FaceTypeMap           &map,
 
 #include <CGAL/Polygon_mesh_processing/clip.h>
 #include <CGAL/Polygon_mesh_processing/corefinement.h>
-//#include <CGAL/Polygon_mesh_processing/self_intersections.h>
 bool priv::clip_cut(SurfacePatch &cut, CutMesh clipper)
 {
     CutMesh& tm = cut.mesh; 

--- a/src/libslic3r/CutSurface.cpp
+++ b/src/libslic3r/CutSurface.cpp
@@ -2556,9 +2556,25 @@ void priv::create_face_types(FaceTypeMap           &map,
 
 #include <CGAL/Polygon_mesh_processing/clip.h>
 #include <CGAL/Polygon_mesh_processing/corefinement.h>
+//#include <CGAL/Polygon_mesh_processing/self_intersections.h>
 bool priv::clip_cut(SurfacePatch &cut, CutMesh clipper)
 {
     CutMesh& tm = cut.mesh; 
+    auto is_mesh_usable_for_clip = [](const CutMesh &mesh) {
+        return !mesh.is_empty() &&
+               mesh.number_of_vertices() >= 3 &&
+               mesh.number_of_faces() > 0 &&
+               mesh.is_valid(false);
+    };
+
+    if (!is_mesh_usable_for_clip(tm) || !is_mesh_usable_for_clip(clipper))
+        return false;
+
+    // Hard-stop pathological inputs before entering corefinement internals.
+    if (CGAL::Polygon_mesh_processing::does_self_intersect(tm) ||
+        CGAL::Polygon_mesh_processing::does_self_intersect(clipper))
+        return false;
+
     // create backup for case that there is no intersection
     CutMesh backup_copy = tm; 
 


### PR DESCRIPTION
# Description
This PR addresses a reported crash when applying “use surface” to an SVG modifier by adding preflight validation checks before running CGAL corefinement/clip operations in the cut-surface pipeline.

Changes:

Adds basic mesh validity/emptiness checks before attempting CGAL clipping.
Adds a self-intersection rejection check to hard-stop pathological meshes before entering CGAL corefinement internals.

<img width="2560" height="1392" alt="image" src="https://github.com/user-attachments/assets/0a7e2374-e345-4b1a-ba7b-5433733c1a5c" />

Note: The order in which the SVG elements are combined matters
Fix #13167

