### PR TITLE
Enable manual filament change for Ender-3 S1 Pro

### DIFF
--- a/resources/profiles/Creality/machine/Creality Ender-3 S1 Pro 0.4 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality Ender-3 S1 Pro 0.4 nozzle.json
@@ -107,6 +107,7 @@
 	],
 	"single_extruder_multi_material": "1",
 	"change_filament_gcode": "M600",
+	"manual_filament_change": "1",
 	"machine_pause_gcode": "M25",
 	"default_filament_profile": [
 		"Creality Generic PLA"


### PR DESCRIPTION
# Description

Enable `manual_filament_change` in the Creality Ender-3 S1 Pro 0.4 nozzle profile.

The Ender-3 S1 Pro already has `change_filament_gcode` set to `M600`, but the `manual_filament_change` flag was missing. This prevented users from using the manual filament change feature in OrcaSlicer with this printer.

This is a one-line profile fix adding `"manual_filament_change": "1"` to the machine JSON config.

# Screenshots/Recordings/Graphs

N/A — profile-only change, no UI modifications.

## Tests

- Load the Creality Ender-3 S1 Pro 0.4 nozzle profile in OrcaSlicer
- Verify the manual filament change option is available in the printer settings
- Slice a model with a filament change at a specific layer and confirm `M600` is present in the generated G-code