### PR TITLE
New Feature: Filament mapping to physical Tools/Extruders

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -426,7 +426,12 @@ if (NOT MSVC AND ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_CXX_COMP
 
     if((${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang" OR ${CMAKE_CXX_COMPILER_ID} STREQUAL "AppleClang") AND ${CMAKE_CXX_COMPILER_VERSION} VERSION_GREATER 15)
         include(CheckCXXCompilerFlag)
+        unset(HAS_WNO_ERROR_ENUM_CONSTEXPR_CONV CACHE)
+        set(_OLD_CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS}")
+        set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} -Werror=unknown-warning-option")
         check_cxx_compiler_flag(-Wno-error=enum-constexpr-conversion HAS_WNO_ERROR_ENUM_CONSTEXPR_CONV)
+        set(CMAKE_REQUIRED_FLAGS "${_OLD_CMAKE_REQUIRED_FLAGS}")
+        unset(_OLD_CMAKE_REQUIRED_FLAGS)
         if(HAS_WNO_ERROR_ENUM_CONSTEXPR_CONV)
             add_compile_options(-Wno-error=enum-constexpr-conversion)
         endif()

--- a/src/libslic3r/Extruder.cpp
+++ b/src/libslic3r/Extruder.cpp
@@ -21,10 +21,10 @@ Extruder::Extruder(unsigned int id, GCodeConfig *config, bool share_extruder) :
 unsigned int Extruder::extruder_id() const
 {
     assert(m_config);
-    if (m_id < m_config->filament_map.size()) {
+    if (m_config->use_physical_extruder_ids_only && !m_config->single_extruder_multi_material && m_id < m_config->filament_map.size()) {
         return m_config->filament_map.get_at(m_id) - 1;
     }
-    return 0;
+    return m_id;
 }
 
 double Extruder::extrude(double dE)

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -31,6 +31,7 @@
 #include <string>
 #include <utility>
 #include <string_view>
+#include <functional>
 
 #include <regex>
 #include <boost/algorithm/string.hpp>
@@ -78,6 +79,8 @@ using namespace std::literals::string_view_literals;
 #endif
 
 #include <assert.h>
+#include <cctype>
+#include <limits>
 
 namespace Slic3r {
 
@@ -223,6 +226,84 @@ static std::vector<Vec2d> get_path_of_change_filament(const Print& print)
             gcode += '\n';
     }
 
+    static std::string_view trim_left_view(std::string_view text)
+    {
+        size_t pos = 0;
+        while (pos < text.size() && std::isspace(static_cast<unsigned char>(text[pos])))
+            ++pos;
+        return text.substr(pos);
+    }
+
+    static bool parse_unsigned_suffix(std::string_view text, size_t start, unsigned int &value, size_t &digits_begin, size_t &digits_end)
+    {
+        digits_begin = start;
+        while (digits_begin < text.size() && std::isspace(static_cast<unsigned char>(text[digits_begin])))
+            ++digits_begin;
+        if (digits_begin >= text.size() || !std::isdigit(static_cast<unsigned char>(text[digits_begin])))
+            return false;
+
+        digits_end = digits_begin;
+        while (digits_end < text.size() && std::isdigit(static_cast<unsigned char>(text[digits_end])))
+            ++digits_end;
+
+        unsigned int parsed = 0;
+        const std::string digits(text.substr(digits_begin, digits_end - digits_begin));
+        std::istringstream ss(digits);
+        if (!(ss >> parsed))
+            return false;
+
+        value = parsed;
+        return true;
+    }
+
+    static bool rewrite_command_suffix_tool_id(std::string &code, std::string_view command_prefix, const std::function<unsigned int(unsigned int)> &mapper)
+    {
+        const std::string_view trimmed = trim_left_view(code);
+        if (!boost::starts_with(std::string(trimmed), std::string(command_prefix)))
+            return false;
+
+        const size_t prefix_offset = static_cast<size_t>(trimmed.data() - code.data());
+        unsigned int tool_id = 0;
+        size_t digits_begin = 0;
+        size_t digits_end   = 0;
+        if (!parse_unsigned_suffix(code, prefix_offset + command_prefix.size(), tool_id, digits_begin, digits_end))
+            return false;
+
+        code.replace(digits_begin, digits_end - digits_begin, std::to_string(mapper(tool_id)));
+        return true;
+    }
+
+    static bool rewrite_command_parameter_tool_id(std::string &code, std::string_view command, char parameter_name, const std::function<unsigned int(unsigned int)> &mapper)
+    {
+        const std::string_view trimmed = trim_left_view(code);
+        if (!boost::starts_with(std::string(trimmed), std::string(command)))
+            return false;
+
+        size_t pos = static_cast<size_t>(trimmed.data() - code.data()) + command.size();
+        while (pos < code.size()) {
+            while (pos < code.size() && std::isspace(static_cast<unsigned char>(code[pos])))
+                ++pos;
+            if (pos >= code.size())
+                break;
+
+            if (code[pos] == parameter_name) {
+                unsigned int tool_id = 0;
+                size_t digits_begin = 0;
+                size_t digits_end   = 0;
+                if (!parse_unsigned_suffix(code, pos + 1, tool_id, digits_begin, digits_end))
+                    return false;
+
+                code.replace(digits_begin, digits_end - digits_begin, std::to_string(mapper(tool_id)));
+                return true;
+            }
+
+            while (pos < code.size() && !std::isspace(static_cast<unsigned char>(code[pos])))
+                ++pos;
+        }
+
+        return false;
+    }
+
 
     // Return true if tch_prefix is found in custom_gcode
     static bool custom_gcode_changes_tool(const std::string& custom_gcode, const std::string& tch_prefix, unsigned next_extruder)
@@ -249,6 +330,59 @@ static std::vector<Vec2d> get_path_of_change_filament(const Print& print)
         NEXT:;
         }
         return ok;
+    }
+
+    static std::string virtual_toolchange_comment(unsigned int filament_id)
+    {
+        return ";VT T" + std::to_string(filament_id) + "\n";
+    }
+
+    static bool line_changes_tool(const std::string_view line, const std::string& tch_prefix, unsigned int tool_id)
+    {
+        size_t pos = 0;
+        while (pos < line.size() && std::isspace(static_cast<unsigned char>(line[pos])))
+            ++pos;
+        if (pos >= line.size() || line.compare(pos, tch_prefix.size(), tch_prefix) != 0)
+            return false;
+
+        std::string suffix(line.substr(pos + tch_prefix.size()));
+        std::istringstream ss(suffix);
+        unsigned int parsed_tool_id = std::numeric_limits<unsigned int>::max();
+        return (ss >> parsed_tool_id) && parsed_tool_id == tool_id;
+    }
+
+    static void annotate_toolchange_gcode_with_virtual_tool(std::string& custom_gcode, const std::string& tch_prefix, unsigned int tool_id, unsigned int filament_id)
+    {
+        if (custom_gcode.empty())
+            return;
+
+        const std::string marker = virtual_toolchange_comment(filament_id);
+        std::string annotated;
+        annotated.reserve(custom_gcode.size() + marker.size());
+
+        size_t line_start = 0;
+        while (line_start < custom_gcode.size()) {
+            size_t line_end = custom_gcode.find('\n', line_start);
+            if (line_end == std::string::npos)
+                line_end = custom_gcode.size();
+            else
+                ++line_end;
+
+            std::string_view line(custom_gcode.data() + line_start, line_end - line_start);
+            std::string_view line_without_newline = line;
+            if (!line_without_newline.empty() && line_without_newline.back() == '\n')
+                line_without_newline.remove_suffix(1);
+            if (!line_without_newline.empty() && line_without_newline.back() == '\r')
+                line_without_newline.remove_suffix(1);
+
+            if (line_changes_tool(line_without_newline, tch_prefix, tool_id))
+                annotated += marker;
+
+            annotated.append(line.data(), line.size());
+            line_start = line_end;
+        }
+
+        custom_gcode.swap(annotated);
     }
 
     std::string OozePrevention::pre_toolchange(GCode& gcodegen)
@@ -830,8 +964,8 @@ static std::vector<Vec2d> get_path_of_change_filament(const Print& print)
             int old_filament_id = gcodegen.writer().filament() ? (int)gcodegen.writer().filament()->id() : -1;
             int old_extruder_id = gcodegen.writer().filament() ? (int)gcodegen.writer().filament()->extruder_id() : -1;
 
-            config.set_key_value("previous_extruder", new ConfigOptionInt(old_filament_id));
-            config.set_key_value("next_extruder", new ConfigOptionInt(new_filament_id));
+            config.set_key_value("previous_extruder", new ConfigOptionInt(old_extruder_id));
+            config.set_key_value("next_extruder", new ConfigOptionInt(int(gcodegen.get_toolchange_id(new_filament_id))));
             config.set_key_value("layer_num", new ConfigOptionInt(gcodegen.m_layer_index));
             config.set_key_value("layer_z", new ConfigOptionFloat(tcr.print_z));
             config.set_key_value("toolchange_z", new ConfigOptionFloat(z));
@@ -948,6 +1082,9 @@ static std::vector<Vec2d> get_path_of_change_filament(const Print& print)
             toolchange_gcode_str = gcodegen.placeholder_parser_process("change_filament_gcode", change_filament_gcode, new_filament_id, &config);
 
             check_add_eol(toolchange_gcode_str);
+            if (gcodegen.uses_physical_tool_ids())
+                annotate_toolchange_gcode_with_virtual_tool(toolchange_gcode_str, gcodegen.writer().toolchange_prefix(),
+                    gcodegen.get_toolchange_id(new_filament_id), new_filament_id);
 
             //BBS
             {
@@ -969,7 +1106,8 @@ static std::vector<Vec2d> get_path_of_change_filament(const Print& print)
         std::string toolchange_command;
         if (tcr.priming || (new_filament_id >= 0 && gcodegen.writer().need_toolchange(new_filament_id)))
             toolchange_command = gcodegen.writer().toolchange(new_filament_id);
-        if (!custom_gcode_changes_tool(toolchange_gcode_str, gcodegen.writer().toolchange_prefix(), new_filament_id))
+        const bool custom_gcode_has_toolchange = custom_gcode_changes_tool(toolchange_gcode_str, gcodegen.writer().toolchange_prefix(), gcodegen.get_toolchange_id(new_filament_id));
+        if (!custom_gcode_has_toolchange)
             toolchange_gcode_str += toolchange_command;
         else {
             // We have informed the m_writer about the current extruder_id, we can ignore the generated G-code.
@@ -1028,7 +1166,7 @@ static std::vector<Vec2d> get_path_of_change_filament(const Print& print)
         std::string toolchange_unretract_str = gcodegen.unretract();
         check_add_eol(toolchange_unretract_str);
 
-        gcodegen.placeholder_parser().set("current_extruder", new_filament_id);
+        gcodegen.placeholder_parser().set("current_extruder", gcodegen.get_toolchange_id(new_filament_id));
         gcodegen.placeholder_parser().set("retraction_distance_when_cut", gcodegen.m_config.retraction_distances_when_cut.get_at(new_filament_id));
         gcodegen.placeholder_parser().set("long_retraction_when_cut", gcodegen.m_config.long_retractions_when_cut.get_at(new_filament_id));
         gcodegen.placeholder_parser().set("retraction_distance_when_ec", gcodegen.m_config.retraction_distances_when_ec.get_at(new_filament_id));
@@ -1040,7 +1178,7 @@ static std::vector<Vec2d> get_path_of_change_filament(const Print& print)
         if (!filament_start_gcode.empty()) {
             // Process the filament_start_gcode for the active filament only.
             DynamicConfig config;
-            config.set_key_value("filament_extruder_id", new ConfigOptionInt(new_filament_id));
+            config.set_key_value("filament_extruder_id", new ConfigOptionInt(int(gcodegen.get_toolchange_id(new_filament_id))));
             start_filament_gcode_str = gcodegen.placeholder_parser_process("filament_start_gcode", filament_start_gcode, new_filament_id, &config);
             if (add_change_filament_624) {
                 start_filament_gcode_str += "M625\n";
@@ -1976,7 +2114,7 @@ namespace DoExport {
     }
 } // namespace DoExport
 
-bool GCode::is_BBL_Printer()
+bool GCode::is_BBL_Printer() const
 {
     if (m_curr_print)
         return m_curr_print->is_BBL_printer();
@@ -2247,60 +2385,254 @@ namespace DoExport {
         const bool                   has_wipe_tower,
 	    const WipeTowerData         &wipe_tower_data,
 	    const std::vector<Extruder> &extruders,
-		PrintStatistics 		    &print_statistics)
+		PrintStatistics 		    &print_statistics,
+        const std::vector<int>      *strict_filament_map = nullptr,
+        size_t                       strict_physical_extruder_count = 0)
     {
 		std::string filament_stats_string_out;
 
 	    print_statistics.clear();
         print_statistics.total_toolchanges = std::max(0, wipe_tower_data.number_of_toolchanges);
 	    if (! extruders.empty()) {
-	        std::pair<std::string, unsigned int> out_filament_used_mm ("; filament used [mm] = ", 0);
-	        std::pair<std::string, unsigned int> out_filament_used_cm3("; filament used [cm3] = ", 0);
-	        std::pair<std::string, unsigned int> out_filament_used_g  ("; filament used [g] = ", 0);
-	        std::pair<std::string, unsigned int> out_filament_cost    ("; filament cost = ", 0);
-	        for (const Extruder &extruder : extruders) {
-	            double used_filament   = extruder.used_filament() + (has_wipe_tower ? wipe_tower_data.used_filament[extruder.id()] : 0.f);
-	            double extruded_volume = extruder.extruded_volume() + (has_wipe_tower ? wipe_tower_data.used_filament[extruder.id()] * 2.4052f : 0.f); // assumes 1.75mm filament diameter
-	            double filament_weight = extruded_volume * extruder.filament_density() * 0.001;
-	            double filament_cost   = filament_weight * extruder.filament_cost()    * 0.001;
-                auto append = [&extruder](std::pair<std::string, unsigned int> &dst, const char *tmpl, double value) {
-                    assert(is_decimal_separator_point());
-	                while (dst.second < extruder.id()) {
-	                    // Fill in the non-printing extruders with zeros.
-	                    dst.first += (dst.second > 0) ? ", 0" : "0";
+            const bool use_strict_physical_stats = strict_filament_map != nullptr && strict_physical_extruder_count > 0;
+            if (!use_strict_physical_stats) {
+	            std::pair<std::string, unsigned int> out_filament_used_mm ("; filament used [mm] = ", 0);
+	            std::pair<std::string, unsigned int> out_filament_used_cm3("; filament used [cm3] = ", 0);
+	            std::pair<std::string, unsigned int> out_filament_used_g  ("; filament used [g] = ", 0);
+	            std::pair<std::string, unsigned int> out_filament_cost    ("; filament cost = ", 0);
+	            for (const Extruder &extruder : extruders) {
+	                double used_filament   = extruder.used_filament() + (has_wipe_tower ? wipe_tower_data.used_filament[extruder.id()] : 0.f);
+	                double extruded_volume = extruder.extruded_volume() + (has_wipe_tower ? wipe_tower_data.used_filament[extruder.id()] * 2.4052f : 0.f); // assumes 1.75mm filament diameter
+	                double filament_weight = extruded_volume * extruder.filament_density() * 0.001;
+	                double filament_cost   = filament_weight * extruder.filament_cost()    * 0.001;
+                    auto append = [&extruder](std::pair<std::string, unsigned int> &dst, const char *tmpl, double value) {
+                        assert(is_decimal_separator_point());
+	                    while (dst.second < extruder.id()) {
+	                        // Fill in the non-printing extruders with zeros.
+	                        dst.first += (dst.second > 0) ? ", 0" : "0";
+	                        ++ dst.second;
+	                    }
+	                    if (dst.second > 0)
+	                        dst.first += ", ";
+	                    char buf[64];
+						sprintf(buf, tmpl, value);
+	                    dst.first += buf;
 	                    ++ dst.second;
+	                };
+	                append(out_filament_used_mm,  "%.2lf", used_filament);
+	                append(out_filament_used_cm3, "%.2lf", extruded_volume * 0.001);
+	                if (filament_weight > 0.) {
+	                    print_statistics.total_weight = print_statistics.total_weight + filament_weight;
+	                    append(out_filament_used_g, "%.2lf", filament_weight);
+	                    if (filament_cost > 0.) {
+	                        print_statistics.total_cost = print_statistics.total_cost + filament_cost;
+	                        append(out_filament_cost, "%.2lf", filament_cost);
+	                    }
 	                }
-	                if (dst.second > 0)
-	                    dst.first += ", ";
-	                char buf[64];
-					sprintf(buf, tmpl, value);
-	                dst.first += buf;
-	                ++ dst.second;
-	            };
-	            append(out_filament_used_mm,  "%.2lf", used_filament);
-	            append(out_filament_used_cm3, "%.2lf", extruded_volume * 0.001);
-	            if (filament_weight > 0.) {
-	                print_statistics.total_weight = print_statistics.total_weight + filament_weight;
-	                append(out_filament_used_g, "%.2lf", filament_weight);
-	                if (filament_cost > 0.) {
-	                    print_statistics.total_cost = print_statistics.total_cost + filament_cost;
-	                    append(out_filament_cost, "%.2lf", filament_cost);
-	                }
+	                print_statistics.total_used_filament += used_filament;
+	                print_statistics.total_extruded_volume += extruded_volume;
+	                print_statistics.total_wipe_tower_filament += has_wipe_tower ? used_filament - extruder.used_filament() : 0.;
+	                print_statistics.total_wipe_tower_cost += has_wipe_tower ? (extruded_volume - extruder.extruded_volume())* extruder.filament_density() * 0.001 * extruder.filament_cost() * 0.001 : 0.;
 	            }
-	            print_statistics.total_used_filament += used_filament;
-	            print_statistics.total_extruded_volume += extruded_volume;
-	            print_statistics.total_wipe_tower_filament += has_wipe_tower ? used_filament - extruder.used_filament() : 0.;
-	            print_statistics.total_wipe_tower_cost += has_wipe_tower ? (extruded_volume - extruder.extruded_volume())* extruder.filament_density() * 0.001 * extruder.filament_cost() * 0.001 : 0.;
-	        }
-	        filament_stats_string_out += out_filament_used_mm.first;
-            filament_stats_string_out += "\n" + out_filament_used_cm3.first;
-            if (out_filament_used_g.second)
-                filament_stats_string_out += "\n" + out_filament_used_g.first;
-            if (out_filament_cost.second)
-               filament_stats_string_out += "\n" + out_filament_cost.first;
-            filament_stats_string_out += "\n";
+	            filament_stats_string_out += out_filament_used_mm.first;
+                filament_stats_string_out += "\n" + out_filament_used_cm3.first;
+                if (out_filament_used_g.second)
+                    filament_stats_string_out += "\n" + out_filament_used_g.first;
+                if (out_filament_cost.second)
+                   filament_stats_string_out += "\n" + out_filament_cost.first;
+                filament_stats_string_out += "\n";
+            } else {
+                std::vector<double> used_mm(strict_physical_extruder_count, 0.0);
+                std::vector<double> used_cm3(strict_physical_extruder_count, 0.0);
+                std::vector<double> used_g(strict_physical_extruder_count, 0.0);
+                std::vector<double> cost(strict_physical_extruder_count, 0.0);
+                bool has_weight = false;
+                bool has_cost = false;
+
+                for (const Extruder &extruder : extruders) {
+                    double used_filament   = extruder.used_filament() + (has_wipe_tower ? wipe_tower_data.used_filament[extruder.id()] : 0.f);
+                    double extruded_volume = extruder.extruded_volume() + (has_wipe_tower ? wipe_tower_data.used_filament[extruder.id()] * 2.4052f : 0.f); // assumes 1.75mm filament diameter
+                    double filament_weight = extruded_volume * extruder.filament_density() * 0.001;
+                    double filament_cost   = filament_weight * extruder.filament_cost() * 0.001;
+
+                    size_t physical_extruder_id = extruder.id();
+                    if (extruder.id() < strict_filament_map->size()) {
+                        const int mapped_tool = strict_filament_map->at(extruder.id()) - 1;
+                        if (mapped_tool >= 0)
+                            physical_extruder_id = static_cast<size_t>(mapped_tool);
+                    }
+                    if (physical_extruder_id >= strict_physical_extruder_count)
+                        continue;
+
+                    used_mm[physical_extruder_id] += used_filament;
+                    used_cm3[physical_extruder_id] += extruded_volume * 0.001;
+                    used_g[physical_extruder_id] += filament_weight;
+                    cost[physical_extruder_id] += filament_cost;
+
+                    has_weight |= filament_weight > 0.;
+                    has_cost |= filament_cost > 0.;
+                    print_statistics.total_weight += filament_weight;
+                    print_statistics.total_cost += filament_cost;
+                    print_statistics.total_used_filament += used_filament;
+                    print_statistics.total_extruded_volume += extruded_volume;
+                    print_statistics.total_wipe_tower_filament += has_wipe_tower ? used_filament - extruder.used_filament() : 0.;
+                    print_statistics.total_wipe_tower_cost += has_wipe_tower ? (extruded_volume - extruder.extruded_volume()) * extruder.filament_density() * 0.001 * extruder.filament_cost() * 0.001 : 0.;
+                }
+
+                auto append_values = [](const char *prefix, const std::vector<double> &values) {
+                    std::string out = prefix;
+                    for (size_t i = 0; i < values.size(); ++i) {
+                        if (i != 0)
+                            out += ", ";
+                        char buf[64];
+                        sprintf(buf, "%.2lf", values[i]);
+                        out += buf;
+                    }
+                    return out;
+                };
+
+                filament_stats_string_out += append_values("; filament used [mm] = ", used_mm);
+                filament_stats_string_out += "\n" + append_values("; filament used [cm3] = ", used_cm3);
+                if (has_weight)
+                    filament_stats_string_out += "\n" + append_values("; filament used [g] = ", used_g);
+                if (has_cost)
+                    filament_stats_string_out += "\n" + append_values("; filament cost = ", cost);
+                filament_stats_string_out += "\n";
+            }
         }
         return filament_stats_string_out;
+    }
+
+    static std::string format_strict_physical_filament_stats(
+        const bool                   has_wipe_tower,
+        const WipeTowerData         &wipe_tower_data,
+        const std::vector<Extruder> &extruders,
+        PrintStatistics             &print_statistics,
+        const std::vector<int>      &strict_filament_map,
+        size_t                       strict_physical_extruder_count)
+    {
+        return update_print_stats_and_format_filament_stats(
+            has_wipe_tower,
+            wipe_tower_data,
+            extruders,
+            print_statistics,
+            &strict_filament_map,
+            strict_physical_extruder_count);
+    }
+
+    static size_t physical_extruder_count(const DynamicPrintConfig &cfg)
+    {
+        const ConfigOptionFloats *nozzle_diameter = cfg.option<ConfigOptionFloats>("nozzle_diameter");
+        return nozzle_diameter ? nozzle_diameter->values.size() : 0;
+    }
+
+    static bool uses_strict_physical_metadata(const Print &print, const DynamicPrintConfig &cfg)
+    {
+        const bool single_extruder_multi_material =
+            cfg.has("single_extruder_multi_material") &&
+            cfg.opt_bool("single_extruder_multi_material");
+        const bool use_physical_extruder_ids_only =
+            cfg.has("use_physical_extruder_ids_only") &&
+            cfg.opt_bool("use_physical_extruder_ids_only");
+        return physical_extruder_count(cfg) > 1 &&
+               !single_extruder_multi_material &&
+               !print.is_BBL_printer() &&
+               use_physical_extruder_ids_only;
+    }
+
+    static void compact_filament_vector_options(DynamicPrintConfig &cfg, size_t target_filament_count)
+    {
+        for (const std::string &key : cfg.keys()) {
+            if (key.rfind("filament_", 0) != 0)
+                continue;
+            if (key == "filament_map" || key == "filament_self_index")
+                continue;
+
+            ConfigOption *opt = cfg.option(key, false);
+            if (opt == nullptr || !opt->is_vector())
+                continue;
+
+            if (ConfigOptionVectorBase *vector_opt = dynamic_cast<ConfigOptionVectorBase *>(opt);
+                vector_opt != nullptr && vector_opt->size() > target_filament_count)
+                vector_opt->resize(target_filament_count);
+        }
+    }
+
+    static void normalize_flush_volumes_matrix_for_filament_count(DynamicPrintConfig &cfg, size_t target_filament_count)
+    {
+        ConfigOptionFloats *flush_multiplier = cfg.option<ConfigOptionFloats>("flush_multiplier", false);
+        ConfigOptionFloats *flush_matrix = cfg.option<ConfigOptionFloats>("flush_volumes_matrix", false);
+        if (flush_multiplier == nullptr || flush_matrix == nullptr || target_filament_count == 0)
+            return;
+
+        const size_t heads_count = flush_multiplier->values.size();
+        if (heads_count == 0)
+            return;
+
+        const size_t expected_size = heads_count * target_filament_count * target_filament_count;
+        if (flush_matrix->values.size() == expected_size)
+            return;
+
+        if (flush_matrix->values.size() % heads_count == 0) {
+            const size_t per_head_values = flush_matrix->values.size() / heads_count;
+            const size_t source_filament_count = static_cast<size_t>(std::sqrt(static_cast<double>(per_head_values)));
+            if (source_filament_count * source_filament_count == per_head_values && source_filament_count >= target_filament_count) {
+                std::vector<double> compact_matrix(expected_size, 0.0);
+                for (size_t head = 0; head < heads_count; ++head) {
+                    for (size_t from = 0; from < target_filament_count; ++from) {
+                        for (size_t to = 0; to < target_filament_count; ++to) {
+                            compact_matrix[head * target_filament_count * target_filament_count + from * target_filament_count + to] =
+                                flush_matrix->values[head * source_filament_count * source_filament_count + from * source_filament_count + to];
+                        }
+                    }
+                }
+                flush_matrix->values = std::move(compact_matrix);
+                return;
+            }
+        }
+
+        if (flush_matrix->values.size() > expected_size)
+            flush_matrix->values.resize(expected_size);
+        else
+            flush_matrix->values.resize(expected_size, 0.0);
+    }
+
+    static void compact_strict_physical_metadata(const Print &print, DynamicPrintConfig &cfg)
+    {
+        if (!uses_strict_physical_metadata(print, cfg))
+            return;
+
+        const size_t extruder_count = physical_extruder_count(cfg);
+        const std::vector<double> original_flush_vector =
+            cfg.option<ConfigOptionFloats>("flush_volumes_vector", false) ?
+            cfg.option<ConfigOptionFloats>("flush_volumes_vector")->values :
+            std::vector<double>();
+
+        cfg.set_num_filaments(static_cast<unsigned int>(extruder_count));
+        compact_filament_vector_options(cfg, extruder_count);
+
+        if (ConfigOptionInts *filament_map = cfg.option<ConfigOptionInts>("filament_map", false)) {
+            filament_map->values.resize(extruder_count, 1);
+            for (size_t i = 0; i < extruder_count; ++i)
+                filament_map->values[i] = static_cast<int>(i + 1);
+        }
+
+        if (ConfigOptionInts *filament_self_index = cfg.option<ConfigOptionInts>("filament_self_index", false)) {
+            filament_self_index->values.resize(extruder_count, 1);
+            for (size_t i = 0; i < extruder_count; ++i)
+                filament_self_index->values[i] = static_cast<int>(i + 1);
+        }
+
+        if (ConfigOptionFloats *flush_vector = cfg.option<ConfigOptionFloats>("flush_volumes_vector", false)) {
+            flush_vector->values = original_flush_vector;
+            const size_t compact_size = extruder_count * 2;
+            if (flush_vector->values.size() > compact_size)
+                flush_vector->values.resize(compact_size);
+        }
+
+        if (ConfigOptionFloats *flush_matrix = cfg.option<ConfigOptionFloats>("flush_volumes_matrix", false)) {
+            normalize_flush_volumes_matrix_for_filament_count(cfg, extruder_count);
+        }
     }
 }
 
@@ -2401,6 +2733,11 @@ void GCode::_do_export(Print& print, GCodeOutputStream &file, ThumbnailsGenerato
     DoExport::init_gcode_processor(print.config(), m_processor, m_silent_time_estimator_enabled);
     const bool is_bbl_printers = print.is_BBL_printer();
     const WipeTowerType wipe_tower_type = print.wipe_tower_type();
+    DynamicPrintConfig header_export_config = print.full_print_config();
+    DoExport::compact_strict_physical_metadata(print, header_export_config);
+    const bool strict_physical_metadata = DoExport::uses_strict_physical_metadata(print, header_export_config);
+    const size_t strict_physical_extruder_count = DoExport::physical_extruder_count(header_export_config);
+    const std::vector<int> strict_filament_map = print.get_filament_maps();
     m_calib_config.clear();
     // resets analyzer's tracking data
     m_last_height  = 0.f;
@@ -2531,11 +2868,11 @@ void GCode::_do_export(Print& print, GCodeOutputStream &file, ThumbnailsGenerato
 
     {
         std::string filament_density_list = "; filament_density: ";
-        (filament_density_list+=m_config.filament_density.serialize()) +='\n';
+        (filament_density_list += header_export_config.opt_serialize("filament_density")) += '\n';
         file.writeln(filament_density_list);
 
         std::string filament_diameter_list = "; filament_diameter: ";
-        (filament_diameter_list += m_config.filament_diameter.serialize()) += '\n';
+        (filament_diameter_list += header_export_config.opt_serialize("filament_diameter")) += '\n';
         file.writeln(filament_diameter_list);
 
         coordf_t max_height_z = -1;
@@ -2549,6 +2886,21 @@ void GCode::_do_export(Print& print, GCodeOutputStream &file, ThumbnailsGenerato
 
     {
         auto used_filaments = print.get_slice_used_filaments(false);
+        if (strict_physical_metadata) {
+            std::vector<unsigned int> used_physical_filaments;
+            used_physical_filaments.reserve(used_filaments.size());
+            for (unsigned int filament_id : used_filaments) {
+                unsigned int physical_filament_id = filament_id;
+                if (filament_id < strict_filament_map.size()) {
+                    const int mapped_filament = strict_filament_map[filament_id] - 1;
+                    if (mapped_filament >= 0)
+                        physical_filament_id = static_cast<unsigned int>(mapped_filament);
+                }
+                if (std::find(used_physical_filaments.begin(), used_physical_filaments.end(), physical_filament_id) == used_physical_filaments.end())
+                    used_physical_filaments.push_back(physical_filament_id);
+            }
+            used_filaments = std::move(used_physical_filaments);
+        }
         std::ostringstream out;
         out << "; filament: ";
         for (size_t idx = 0; idx < used_filaments.size(); ++idx) {
@@ -2736,7 +3088,7 @@ void GCode::_do_export(Print& print, GCodeOutputStream &file, ThumbnailsGenerato
     print.throw_if_canceled();
 
     m_cooling_buffer = make_unique<CoolingBuffer>(*this);
-    m_cooling_buffer->set_current_extruder(initial_extruder_id);
+    m_cooling_buffer->set_current_extruder(get_toolchange_id(initial_extruder_id));
 
     int extruder_id = get_extruder_id(initial_extruder_id);
 
@@ -2770,16 +3122,16 @@ void GCode::_do_export(Print& print, GCodeOutputStream &file, ThumbnailsGenerato
     match_physical_extruder_for_each_filament(first_filaments, m_config);
     this->placeholder_parser().set("first_tools", new ConfigOptionInts(first_filaments));
     this->placeholder_parser().set("first_filaments", new ConfigOptionInts(first_filaments));
-    this->placeholder_parser().set("initial_tool", initial_extruder_id);
-    this->placeholder_parser().set("initial_extruder", initial_extruder_id);
+    this->placeholder_parser().set("initial_tool", get_toolchange_id(initial_extruder_id));
+    this->placeholder_parser().set("initial_extruder", get_toolchange_id(initial_extruder_id));
     //BBS
     match_physical_extruder_for_each_filament(first_non_support_filaments, m_config);
 
     this->placeholder_parser().set("first_non_support_tools", new ConfigOptionInts(first_non_support_filaments));
     this->placeholder_parser().set("first_non_support_filaments", new ConfigOptionInts(first_non_support_filaments));
-    this->placeholder_parser().set("initial_no_support_tool", initial_non_support_extruder_id);
-    this->placeholder_parser().set("initial_no_support_extruder", initial_non_support_extruder_id);
-    this->placeholder_parser().set("current_extruder", initial_extruder_id);
+    this->placeholder_parser().set("initial_no_support_tool", get_toolchange_id(initial_non_support_extruder_id));
+    this->placeholder_parser().set("initial_no_support_extruder", get_toolchange_id(initial_non_support_extruder_id));
+    this->placeholder_parser().set("current_extruder", get_toolchange_id(initial_extruder_id));
     //Orca: set the key for compatibilty
     this->placeholder_parser().set("retraction_distance_when_cut", m_config.retraction_distances_when_cut.get_at(initial_extruder_id));
     this->placeholder_parser().set("long_retraction_when_cut", m_config.long_retractions_when_cut.get_at(initial_extruder_id));
@@ -3054,6 +3406,9 @@ void GCode::_do_export(Print& print, GCodeOutputStream &file, ThumbnailsGenerato
             file.write(m_writer.set_chamber_temperature(max_chamber_temp, true)); // set chamber_temperature
     }
 
+    if (uses_physical_tool_ids())
+        file.write(virtual_toolchange_comment(initial_extruder_id));
+
     // Write the custom start G-code
     file.writeln(machine_start_gcode);
 
@@ -3066,12 +3421,12 @@ void GCode::_do_export(Print& print, GCodeOutputStream &file, ThumbnailsGenerato
         // add the missing filament start gcode in machine start gcode
         {
             DynamicConfig config;
-            config.set_key_value("filament_extruder_id", new ConfigOptionInt((int)(initial_non_support_extruder_id)));
+            config.set_key_value("filament_extruder_id", new ConfigOptionInt(int(get_toolchange_id(initial_non_support_extruder_id))));
             config.set_key_value("layer_num", new ConfigOptionInt(m_layer_index));
             std::string filament_start_gcode = this->placeholder_parser_process("filament_start_gcode", print.config().filament_start_gcode.values.at(initial_non_support_extruder_id), initial_non_support_extruder_id,&config);
             file.writeln(filament_start_gcode);
-            // mark the first filament used in print
-            file.write_format(";VT%d\n", initial_extruder_id);
+            // Mark the initial logical filament for the preview parser.
+            file.write(virtual_toolchange_comment(initial_extruder_id));
         }
         // Orca: add missing PA settings for initial filament
         if (m_config.enable_pressure_advance.get_at(initial_non_support_extruder_id)) {
@@ -3091,7 +3446,7 @@ void GCode::_do_export(Print& print, GCodeOutputStream &file, ThumbnailsGenerato
         // Wipe tower will control the extruder switching, it will call the filament_start_gcode.
     } else {
             DynamicConfig config;
-            config.set_key_value("filament_extruder_id", new ConfigOptionInt(int(initial_extruder_id)));
+            config.set_key_value("filament_extruder_id", new ConfigOptionInt(int(get_toolchange_id(initial_extruder_id))));
             file.writeln(this->placeholder_parser_process("filament_start_gcode", print.config().filament_start_gcode.values[initial_extruder_id], initial_extruder_id, &config));
     }
 */
@@ -3244,7 +3599,7 @@ void GCode::_do_export(Print& print, GCodeOutputStream &file, ThumbnailsGenerato
                 }
                 // Reset the cooling buffer internal state (the current position, feed rate, accelerations).
                 m_cooling_buffer->reset(this->writer().get_position());
-                m_cooling_buffer->set_current_extruder(initial_extruder_id);
+                m_cooling_buffer->set_current_extruder(get_toolchange_id(initial_extruder_id));
                 // Process all layers of a single object instance (sequential mode) with a parallel pipeline:
                 // Generate G-code, run the filters (vase mode, cooling buffer), run the G-code analyser
                 // and export G-code into file.
@@ -3390,12 +3745,12 @@ void GCode::_do_export(Print& print, GCodeOutputStream &file, ThumbnailsGenerato
         if (print.config().single_extruder_multi_material) {
             // Process the filament_end_gcode for the active filament only.
             int extruder_id = m_writer.filament()->id();
-            config.set_key_value("filament_extruder_id", new ConfigOptionInt(extruder_id));
+            config.set_key_value("filament_extruder_id", new ConfigOptionInt(int(get_toolchange_id(extruder_id))));
             file.writeln(this->placeholder_parser_process("filament_end_gcode", print.config().filament_end_gcode.get_at(extruder_id), extruder_id, &config));
         } else {
             for (const std::string &end_gcode : print.config().filament_end_gcode.values) {
                 int extruder_id = (unsigned int)(&end_gcode - &print.config().filament_end_gcode.values.front());
-                config.set_key_value("filament_extruder_id", new ConfigOptionInt(extruder_id));
+                config.set_key_value("filament_extruder_id", new ConfigOptionInt(int(get_toolchange_id(extruder_id))));
                 file.writeln(this->placeholder_parser_process("filament_end_gcode", end_gcode, extruder_id, &config));
             }
         }
@@ -3421,12 +3776,21 @@ void GCode::_do_export(Print& print, GCodeOutputStream &file, ThumbnailsGenerato
     print.throw_if_canceled();
 
     // Get filament stats.
-    file.write(DoExport::update_print_stats_and_format_filament_stats(
-    	// Const inputs
-        has_wipe_tower, print.wipe_tower_data(),
-        m_writer.extruders(),
-        // Modifies
-        print.m_print_statistics));
+    if (strict_physical_metadata) {
+        file.write(DoExport::format_strict_physical_filament_stats(
+            has_wipe_tower,
+            print.wipe_tower_data(),
+            m_writer.extruders(),
+            print.m_print_statistics,
+            strict_filament_map,
+            strict_physical_extruder_count));
+    } else {
+        file.write(DoExport::update_print_stats_and_format_filament_stats(
+            has_wipe_tower,
+            print.wipe_tower_data(),
+            m_writer.extruders(),
+            print.m_print_statistics));
+    }
     print.m_print_statistics.initial_tool = initial_extruder_id;
     if (!is_bbl_printers) {
         file.write_format("; total filament used [g] = %.2lf\n",
@@ -3473,7 +3837,7 @@ void GCode::export_layer_filaments(GCodeProcessorResult* result)
     if (result == nullptr)
         return;
 
-    const std::vector<int>filament_map = m_config.filament_map.values; // 1 based
+    const std::vector<int> filament_map = m_print ? m_print->get_filament_maps() : m_config.filament_map.values; // 1 based
     std::vector<int>prev_filament(m_config.nozzle_diameter.size(), -1);
     for (size_t idx = 0; idx < m_sorted_layer_filaments.size(); ++idx) {
         for (auto f : m_sorted_layer_filaments[idx]) {
@@ -3525,6 +3889,88 @@ size_t GCode::get_extruder_id(unsigned int filament_id) const
         return m_print->get_extruder_id(filament_id);
     }
     return 0;
+}
+
+bool GCode::uses_physical_tool_ids() const
+{
+    return m_writer.multiple_extruders &&
+           !m_config.single_extruder_multi_material &&
+           !is_BBL_Printer() &&
+           m_config.use_physical_extruder_ids_only;
+}
+
+bool GCode::uses_strict_physical_tool_ids() const
+{
+    return uses_physical_tool_ids();
+}
+
+unsigned int GCode::get_strict_physical_tool_id(unsigned int tool_id) const
+{
+    if (!uses_strict_physical_tool_ids())
+        return tool_id;
+
+    if (tool_id < m_config.filament_map.size()) {
+        const int mapped_tool_id = m_config.filament_map.get_at(tool_id) - 1;
+        if (mapped_tool_id >= 0)
+            return static_cast<unsigned int>(mapped_tool_id);
+    }
+
+    return tool_id;
+}
+
+unsigned int GCode::get_toolchange_id(unsigned int filament_id) const
+{
+    return uses_physical_tool_ids() ? static_cast<unsigned int>(get_extruder_id(filament_id)) : filament_id;
+}
+
+std::string GCode::rewrite_tool_related_gcode_to_physical(const std::string &gcode) const
+{
+    if (!uses_strict_physical_tool_ids() || gcode.empty())
+        return gcode;
+
+    const auto map_tool_id = [this](unsigned int tool_id) {
+        return this->get_strict_physical_tool_id(tool_id);
+    };
+
+    std::string out;
+    out.reserve(gcode.size());
+    const std::string toolchange_prefix = m_writer.toolchange_prefix();
+
+    size_t line_start = 0;
+    while (line_start < gcode.size()) {
+        size_t line_end = gcode.find('\n', line_start);
+        const bool has_newline = line_end != std::string::npos;
+        if (!has_newline)
+            line_end = gcode.size();
+
+        std::string line = gcode.substr(line_start, line_end - line_start);
+        const size_t comment_pos = line.find(';');
+        std::string code = line.substr(0, comment_pos);
+
+        bool rewritten = false;
+        if (!toolchange_prefix.empty() && toolchange_prefix.front() != ';')
+            rewritten = rewrite_command_suffix_tool_id(code, toolchange_prefix, map_tool_id);
+        if (!rewritten)
+            rewritten = rewrite_command_parameter_tool_id(code, "M104", 'T', map_tool_id);
+        if (!rewritten)
+            rewritten = rewrite_command_parameter_tool_id(code, "M109", 'T', map_tool_id);
+        if (!rewritten)
+            rewritten = rewrite_command_parameter_tool_id(code, "M104.1", 'T', map_tool_id);
+        if (!rewritten)
+            rewritten = rewrite_command_parameter_tool_id(code, "M109.1", 'T', map_tool_id);
+        if (!rewritten)
+            rewritten = rewrite_command_parameter_tool_id(code, "G10", 'P', map_tool_id);
+
+        out += code;
+        if (comment_pos != std::string::npos)
+            out.append(line, comment_pos, std::string::npos);
+        if (has_newline)
+            out += '\n';
+
+        line_start = has_newline ? line_end + 1 : line_end;
+    }
+
+    return out;
 }
 
 // Process all layers of all objects (non-sequential mode) with a parallel pipeline:
@@ -3788,7 +4234,7 @@ PlaceholderParserIntegration &ppi = m_placeholder_parser_integration;
             }
         }
 
-        return output;
+        return rewrite_tool_related_gcode_to_physical(output);
     } 
     catch (std::runtime_error &err) 
     {
@@ -5440,6 +5886,12 @@ void GCode::apply_print_config(const PrintConfig &print_config)
 void GCode::append_full_config(const Print &print, std::string &str)
 {
     DynamicPrintConfig cfg = print.full_print_config();
+    DoExport::compact_strict_physical_metadata(print, cfg);
+    if (DoExport::uses_strict_physical_metadata(print, cfg)) {
+        const ConfigOptionStrings *filament_colours = cfg.option<ConfigOptionStrings>("filament_colour", false);
+        if (filament_colours != nullptr)
+            DoExport::normalize_flush_volumes_matrix_for_filament_count(cfg, filament_colours->values.size());
+    }
     { // correct the flush_volumes_matrix with flush_multiplier values
         std::vector<double> temp_cfg_flush_multiplier = cfg.option<ConfigOptionFloats>("flush_multiplier")->values;
         std::vector<double> temp_flush_volumes_matrix = cfg.option<ConfigOptionFloats>("flush_volumes_matrix")->values;
@@ -7422,7 +7874,7 @@ std::string GCode::set_extruder(unsigned int new_filament_id, double print_z, bo
 
     // if we are running a single-extruder setup, just set the extruder and return nothing
     if (!m_writer.multiple_extruders) {
-        this->placeholder_parser().set("current_extruder", new_filament_id);
+        this->placeholder_parser().set("current_extruder", get_toolchange_id(new_filament_id));
         this->placeholder_parser().set("retraction_distance_when_ec", m_config.retraction_distances_when_ec.get_at(new_filament_id));
         this->placeholder_parser().set("long_retraction_when_ec", m_config.long_retractions_when_ec.get_at(new_filament_id));
 
@@ -7435,7 +7887,7 @@ std::string GCode::set_extruder(unsigned int new_filament_id, double print_z, bo
             config.set_key_value("layer_num", new ConfigOptionInt(m_layer_index));
             config.set_key_value("layer_z", new ConfigOptionFloat(this->writer().get_position().z() - m_config.z_offset.value));
             config.set_key_value("max_layer_z", new ConfigOptionFloat(m_max_layer_z));
-            config.set_key_value("filament_extruder_id", new ConfigOptionInt(int(new_filament_id)));
+            config.set_key_value("filament_extruder_id", new ConfigOptionInt(int(get_toolchange_id(new_filament_id))));
             config.set_key_value("retraction_distance_when_cut",
                                  new ConfigOptionFloat(m_config.retraction_distances_when_cut.get_at(new_filament_id)));
             config.set_key_value("long_retraction_when_cut", new ConfigOptionBool(m_config.long_retractions_when_cut.get_at(new_filament_id)));
@@ -7538,8 +7990,7 @@ std::string GCode::set_extruder(unsigned int new_filament_id, double print_z, bo
                 wipe_volume = flush_matrix[old_filament_id_in_new_extruder * number_of_extruders + new_filament_id];
                 wipe_volume *= m_config.flush_multiplier.get_at(new_extruder_id);
             }
-        }
-        else {
+        } else {
             wipe_volume = flush_matrix[old_filament_id * number_of_extruders + new_filament_id];
             wipe_volume *= m_config.flush_multiplier.get_at(new_extruder_id);  // if is multi_extruder only use the fist extruder matrix
         }
@@ -7565,8 +8016,8 @@ std::string GCode::set_extruder(unsigned int new_filament_id, double print_z, bo
     float         wipe_avoid_pos_x            = 110.f;
     DynamicConfig dyn_config;
     dyn_config.set_key_value("outer_wall_volumetric_speed", new ConfigOptionFloat(outer_wall_volumetric_speed));
-    dyn_config.set_key_value("previous_extruder", new ConfigOptionInt(old_filament_id));
-    dyn_config.set_key_value("next_extruder", new ConfigOptionInt((int)new_filament_id));
+    dyn_config.set_key_value("previous_extruder", new ConfigOptionInt(old_filament_id >= 0 ? int(get_toolchange_id(old_filament_id)) : -1));
+    dyn_config.set_key_value("next_extruder", new ConfigOptionInt(int(get_toolchange_id(new_filament_id))));
     dyn_config.set_key_value("layer_num", new ConfigOptionInt(m_layer_index));
     dyn_config.set_key_value("layer_z", new ConfigOptionFloat(print_z));
     dyn_config.set_key_value("max_layer_z", new ConfigOptionFloat(m_max_layer_z));
@@ -7660,6 +8111,9 @@ std::string GCode::set_extruder(unsigned int new_filament_id, double print_z, bo
 
         toolchange_gcode_parsed = placeholder_parser_process("change_filament_gcode", change_filament_gcode, new_filament_id, &dyn_config);
         check_add_eol(toolchange_gcode_parsed);
+        if (uses_physical_tool_ids())
+            annotate_toolchange_gcode_with_virtual_tool(toolchange_gcode_parsed, m_writer.toolchange_prefix(),
+                get_toolchange_id(new_filament_id), new_filament_id);
         gcode += toolchange_gcode_parsed;
 
         //BBS
@@ -7687,7 +8141,8 @@ std::string GCode::set_extruder(unsigned int new_filament_id, double print_z, bo
     //BBS: don't add T[next extruder] if there is no T cmd on filament change
      //We inform the writer about what is happening, but we may not use the resulting gcode.
     std::string toolchange_command = m_writer.toolchange(new_filament_id);
-    if (!custom_gcode_changes_tool(toolchange_gcode_parsed, m_writer.toolchange_prefix(), new_filament_id))
+    const bool custom_gcode_has_toolchange = custom_gcode_changes_tool(toolchange_gcode_parsed, m_writer.toolchange_prefix(), get_toolchange_id(new_filament_id));
+    if (!custom_gcode_has_toolchange)
         gcode += toolchange_command;
     else {
         // user provided his own toolchange gcode, no need to do anything
@@ -7701,7 +8156,7 @@ std::string GCode::set_extruder(unsigned int new_filament_id, double print_z, bo
         gcode += m_writer.set_temperature(temp, false);
     }
 
-    this->placeholder_parser().set("current_extruder", new_filament_id);
+    this->placeholder_parser().set("current_extruder", get_toolchange_id(new_filament_id));
     this->placeholder_parser().set("retraction_distance_when_cut", m_config.retraction_distances_when_cut.get_at(new_filament_id));
     this->placeholder_parser().set("long_retraction_when_cut", m_config.long_retractions_when_cut.get_at(new_filament_id));
     this->placeholder_parser().set("retraction_distance_when_ec", m_config.retraction_distances_when_ec.get_at(new_filament_id));
@@ -7716,7 +8171,7 @@ std::string GCode::set_extruder(unsigned int new_filament_id, double print_z, bo
         config.set_key_value("layer_num", new ConfigOptionInt(m_layer_index));
         config.set_key_value("layer_z", new ConfigOptionFloat(this->writer().get_position().z() - m_config.z_offset.value));
         config.set_key_value("max_layer_z", new ConfigOptionFloat(m_max_layer_z));
-        config.set_key_value("filament_extruder_id", new ConfigOptionInt(int(new_filament_id)));
+        config.set_key_value("filament_extruder_id", new ConfigOptionInt(int(get_toolchange_id(new_filament_id))));
         if (toolchange_temp_override > 0) {
             auto temps = m_config.nozzle_temperature.values;
             if (new_filament_id < temps.size())

--- a/src/libslic3r/GCode.hpp
+++ b/src/libslic3r/GCode.hpp
@@ -250,7 +250,7 @@ public:
     std::string     retract(bool toolchange = false, bool is_last_retraction = false, LiftType lift_type = LiftType::NormalLift, bool apply_instantly = false, ExtrusionRole role = erNone);
     std::string     unretract() { return m_writer.unlift() + m_writer.unretract(); }
     std::string     set_extruder(unsigned int extruder_id, double print_z, bool by_object=false, int toolchange_temp_override = -1);
-    bool is_BBL_Printer();
+    bool is_BBL_Printer() const;
     WipeTowerType wipe_tower_type();
 
     // SoftFever
@@ -380,6 +380,11 @@ private:
     //BBS
     void check_placeholder_parser_failed();
     size_t get_extruder_id(unsigned int filament_id) const;
+    unsigned int get_toolchange_id(unsigned int filament_id) const;
+    bool uses_physical_tool_ids() const;
+    bool uses_strict_physical_tool_ids() const;
+    unsigned int get_strict_physical_tool_id(unsigned int tool_id) const;
+    std::string rewrite_tool_related_gcode_to_physical(const std::string &gcode) const;
 
     void            set_last_pos(const Point &pos) { m_last_pos = pos; m_last_pos_defined = true; }
     bool            last_pos_defined() const { return m_last_pos_defined; }

--- a/src/libslic3r/GCode/GCodeProcessor.cpp
+++ b/src/libslic3r/GCode/GCodeProcessor.cpp
@@ -20,6 +20,7 @@
 
 #include <float.h>
 #include <assert.h>
+#include <cctype>
 #include <regex>
 #include <charconv>
 #include <string>
@@ -921,21 +922,50 @@ void GCodeProcessor::run_post_process()
     if (out.f == nullptr)
         throw Slic3r::RuntimeError(std::string("GCode processor post process export failed.\nCannot open file for writing.\n"));
 
-    std::vector<double> filament_mm(m_result.filaments_count, 0.0);
-    std::vector<double> filament_cm3(m_result.filaments_count, 0.0);
-    std::vector<double> filament_g(m_result.filaments_count, 0.0);
-    std::vector<double> filament_cost(m_result.filaments_count, 0.0);
+    const bool compact_to_physical_extruders = uses_physical_tool_ids() && !m_filament_maps.empty();
+    size_t     exported_filament_count = m_result.filaments_count;
+    if (compact_to_physical_extruders) {
+        exported_filament_count = 0;
+        for (int mapped_extruder_id : m_filament_maps) {
+            if (mapped_extruder_id >= 0)
+                exported_filament_count = std::max(exported_filament_count, static_cast<size_t>(mapped_extruder_id + 1));
+        }
+        if (exported_filament_count == 0)
+            exported_filament_count = m_result.filaments_count;
+    }
+
+    std::vector<double> filament_mm(exported_filament_count, 0.0);
+    std::vector<double> filament_cm3(exported_filament_count, 0.0);
+    std::vector<double> filament_g(exported_filament_count, 0.0);
+    std::vector<double> filament_cost(exported_filament_count, 0.0);
 
     double filament_total_g = 0.0;
     double filament_total_cost = 0.0;
 
     for (const auto& [id, volume] : m_result.print_statistics.total_volumes_per_extruder) {
-        filament_mm[id] = volume / (static_cast<double>(M_PI) * sqr(0.5 * m_result.filament_diameters[id]));
-        filament_cm3[id] = volume * 0.001;
-        filament_g[id] = filament_cm3[id] * double(m_result.filament_densities[id]);
-        filament_cost[id] = filament_g[id] * double(m_result.filament_costs[id]) * 0.001;
-        filament_total_g += filament_g[id];
-        filament_total_cost += filament_cost[id];
+        if (id >= m_result.filament_diameters.size() ||
+            id >= m_result.filament_densities.size() ||
+            id >= m_result.filament_costs.size())
+            continue;
+
+        const size_t output_id =
+            compact_to_physical_extruders && id < m_filament_maps.size() && m_filament_maps[id] >= 0 ?
+            static_cast<size_t>(m_filament_maps[id]) :
+            id;
+        if (output_id >= exported_filament_count)
+            continue;
+
+        const double used_mm = volume / (static_cast<double>(M_PI) * sqr(0.5 * m_result.filament_diameters[id]));
+        const double used_cm3 = volume * 0.001;
+        const double used_g = used_cm3 * double(m_result.filament_densities[id]);
+        const double cost = used_g * double(m_result.filament_costs[id]) * 0.001;
+
+        filament_mm[output_id] += used_mm;
+        filament_cm3[output_id] += used_cm3;
+        filament_g[output_id] += used_g;
+        filament_cost[output_id] += cost;
+        filament_total_g += used_g;
+        filament_total_cost += cost;
     }
 
     double total_g_wipe_tower = m_print->print_statistics().total_wipe_tower_filament;
@@ -1736,6 +1766,7 @@ void GCodeProcessor::register_commands()
         {"M572", [this](const GCodeReader::GCodeLine& line) { process_M572(line); }}, // RepRapFirmware/Duet: Set pressure advance
 
         {"T", [this](const GCodeReader::GCodeLine& line) { process_T(line); }}, // Select Tool
+        {"VT", [this](const GCodeReader::GCodeLine& line) { process_VT(line); }},
         {"SYNC", [this](const GCodeReader::GCodeLine& line) { process_SYNC(line); }}, // SYNC TIME
 
         {"VG1", [this](const GCodeReader::GCodeLine& line) { process_VG1(line); }},
@@ -1932,6 +1963,8 @@ void GCodeProcessor::apply_config(const PrintConfig& config)
     m_flavor = config.gcode_flavor;
 
     m_single_extruder_multi_material = config.single_extruder_multi_material;
+    m_orca_managed_extruder_mapping  = config.option<ConfigOptionBool>("use_physical_extruder_ids_only") != nullptr &&
+                                       config.use_physical_extruder_ids_only;
 
     size_t filament_count = config.filament_diameter.values.size();
     m_result.filaments_count = filament_count;
@@ -2062,6 +2095,12 @@ void GCodeProcessor::apply_config(const PrintConfig& config)
 void GCodeProcessor::apply_config(const DynamicPrintConfig& config)
 {
     m_parser.apply_config(config);
+
+    const ConfigOptionBool* single_extruder_multi_material = config.option<ConfigOptionBool>("single_extruder_multi_material");
+    m_single_extruder_multi_material = single_extruder_multi_material != nullptr && single_extruder_multi_material->getBool();
+
+    const ConfigOptionBool* use_physical_extruder_ids_only = config.option<ConfigOptionBool>("use_physical_extruder_ids_only");
+    m_orca_managed_extruder_mapping = use_physical_extruder_ids_only != nullptr && use_physical_extruder_ids_only->getBool();
 
     //BBS
     const ConfigOptionFloatsNullable* nozzle_volume = config.option<ConfigOptionFloatsNullable>("nozzle_volume");
@@ -2195,7 +2234,6 @@ void GCodeProcessor::apply_config(const DynamicPrintConfig& config)
     }
 
     const ConfigOptionPoints* extruder_offset = config.option<ConfigOptionPoints>("extruder_offset");
-    const ConfigOptionBool* single_extruder_multi_material = config.option<ConfigOptionBool>("single_extruder_multi_material");
     if (extruder_offset != nullptr) {
         //BBS: for single extruder multi material, only use the offset of first extruder
         if (single_extruder_multi_material != nullptr && single_extruder_multi_material->getBool()) {
@@ -2450,6 +2488,8 @@ void GCodeProcessor::reset()
     m_g1_line_id = 0;
     m_layer_id = 0;
     m_cp_color.reset();
+    m_pending_logical_filament_id = -1;
+    m_orca_managed_extruder_mapping = false;
 
     m_producer = EProducer::Unknown;
 
@@ -2814,6 +2854,11 @@ void GCodeProcessor::process_gcode_line(const GCodeReader::GCodeLine& line, bool
         {
             std::string comment_content = comment.substr(1); // only format like ";V{cmd}" is valid
             if (comment_content[0] == 'V' || comment_content[0] == 'v') {
+                if (comment_content.size() > 2 && (comment_content[1] == 'T' || comment_content[1] == 't') &&
+                    std::isdigit(static_cast<unsigned char>(comment_content[2]))) {
+                    process_VT(comment_content);
+                    return;
+                }
                 GCodeReader reader;
                 GCodeReader::GCodeLine new_line;
                 reader.parse_line(comment_content, [&new_line](const auto& greader, const auto& gline) {
@@ -5341,6 +5386,32 @@ void GCodeProcessor::process_T(const GCodeReader::GCodeLine& line)
     process_T(line.cmd());
 }
 
+void GCodeProcessor::process_VT(const GCodeReader::GCodeLine& line)
+{
+    process_VT(line.raw());
+}
+
+void GCodeProcessor::process_VT(const std::string_view command)
+{
+    if (command.size() < 2 || std::toupper(static_cast<unsigned char>(command[0])) != 'V' || std::toupper(static_cast<unsigned char>(command[1])) != 'T')
+        return;
+
+    std::string_view payload = command.substr(2);
+    while (!payload.empty() && std::isspace(static_cast<unsigned char>(payload.front())))
+        payload.remove_prefix(1);
+    if (!payload.empty() && (payload.front() == 'T' || payload.front() == 't'))
+        payload.remove_prefix(1);
+    while (!payload.empty() && std::isspace(static_cast<unsigned char>(payload.front())))
+        payload.remove_prefix(1);
+
+    unsigned int filament_id = 0;
+    auto [end, ec] = std::from_chars(payload.data(), payload.data() + payload.size(), filament_id);
+    if (ec != std::errc() || end == payload.data() || filament_id >= m_result.filaments_count)
+        return;
+
+    m_pending_logical_filament_id = static_cast<int>(filament_id);
+}
+
 void GCodeProcessor::process_M1020(const GCodeReader::GCodeLine &line)
 {
     int curr_filament_id = get_filament_id(false);
@@ -5373,10 +5444,6 @@ void GCodeProcessor::process_T(const std::string_view command)
     auto         ret          = std::from_chars(command.data() + 1, command.data()+command.size(), eid);
     if (std::errc::invalid_argument == ret.ec)
         return;
-
-    int curr_filament_id = get_filament_id(false);
-    int curr_extruder_id = get_extruder_id(false);
-    //TODO: multi switch
     if (command.length() > 1) {
         if (eid < 0 || eid > 254) {
             //BBS: T255, T1000 and T1100 is used as special command for BBL machine and does not cost time. return directly
@@ -5389,11 +5456,27 @@ void GCodeProcessor::process_T(const std::string_view command)
                 BOOST_LOG_TRIVIAL(error) << "Invalid T command (" << command << ").";
         }
         else {
-            if (eid >= m_result.filaments_count) {
+            int target_filament_id = -1;
+            if (uses_physical_tool_ids()) {
+                if (m_pending_logical_filament_id >= 0 &&
+                    m_pending_logical_filament_id < static_cast<int>(m_filament_maps.size()) &&
+                    m_filament_maps[m_pending_logical_filament_id] == static_cast<int>(eid)) {
+                    target_filament_id = m_pending_logical_filament_id;
+                } else {
+                    target_filament_id = resolve_filament_for_tool_id(eid);
+                }
+            } else {
+                target_filament_id = (eid < m_result.filaments_count) ? static_cast<int>(eid) : -1;
+            }
+            if (target_filament_id == -1) {
                 BOOST_LOG_TRIVIAL(error) << "Invalid T command (" << command << ").";
                 return;
             }
-            process_filament_change(eid);
+            if (uses_physical_tool_ids() &&
+                target_filament_id < static_cast<int>(m_filament_maps.size()) &&
+                m_filament_maps[target_filament_id] == static_cast<int>(eid))
+                m_pending_logical_filament_id = -1;
+            process_filament_change(target_filament_id);
         }
     }
 }
@@ -5472,9 +5555,43 @@ void GCodeProcessor::process_filament_change(int id)
         }
     }
     m_cp_color.current = m_extruder_colors[next_filament_id];
+    if (m_pending_logical_filament_id == next_filament_id)
+        m_pending_logical_filament_id = -1;
     simulate_st_synchronize(extra_time);
     // store tool change move
     store_move_vertex(EMoveType::Tool_change);
+}
+
+bool GCodeProcessor::uses_physical_tool_ids() const
+{
+    return m_orca_managed_extruder_mapping &&
+           !s_IsBBLPrinter &&
+           !m_single_extruder_multi_material;
+}
+
+int GCodeProcessor::resolve_filament_for_tool_id(unsigned int tool_id) const
+{
+    const int physical_extruder_id = static_cast<int>(tool_id);
+    if (physical_extruder_id < 0 || physical_extruder_id >= static_cast<int>(m_filament_id.size()))
+        return -1;
+
+    const int current_filament_id = get_filament_id(false);
+    if (current_filament_id >= 0 && current_filament_id < static_cast<int>(m_filament_maps.size()) &&
+        m_filament_maps[current_filament_id] == physical_extruder_id)
+        return current_filament_id;
+
+    if (m_filament_id[physical_extruder_id] != static_cast<unsigned char>(-1))
+        return static_cast<int>(m_filament_id[physical_extruder_id]);
+
+    if (m_last_filament_id[physical_extruder_id] != static_cast<unsigned char>(-1))
+        return static_cast<int>(m_last_filament_id[physical_extruder_id]);
+
+    for (size_t filament_id = 0; filament_id < m_filament_maps.size(); ++filament_id) {
+        if (m_filament_maps[filament_id] == physical_extruder_id)
+            return static_cast<int>(filament_id);
+    }
+
+    return physical_extruder_id < static_cast<int>(m_result.filaments_count) ? physical_extruder_id : -1;
 }
 
 void GCodeProcessor::store_move_vertex(EMoveType type, EMovePathType path_type, bool internal_only)

--- a/src/libslic3r/GCode/GCodeProcessor.hpp
+++ b/src/libslic3r/GCode/GCodeProcessor.hpp
@@ -797,6 +797,7 @@ class Print;
         unsigned int m_g1_line_id;
         unsigned int m_layer_id;
         CpColor m_cp_color;
+        int m_pending_logical_filament_id{-1};
         SeamsDetector m_seams_detector;
         OptionsZCorrector m_options_z_corrector;
         size_t m_last_default_color_id;
@@ -804,6 +805,7 @@ class Print;
         int m_seams_count;
         bool m_measure_g29_time {false};
         bool m_single_extruder_multi_material;
+        bool m_orca_managed_extruder_mapping { false };
         float m_preheat_time;
         int m_preheat_steps;
         bool m_disable_m73;
@@ -923,6 +925,8 @@ class Print;
         void process_G2_G3(const GCodeReader::GCodeLine& line, bool clockwise);
 
         void process_VG1(const GCodeReader::GCodeLine& line);
+        void process_VT(const GCodeReader::GCodeLine& line);
+        void process_VT(const std::string_view command);
 
 
         // BBS: handle delay command
@@ -1056,6 +1060,8 @@ class Print;
         void process_M623(const GCodeReader::GCodeLine &line);
 
         void process_filament_change(int id);
+        bool uses_physical_tool_ids() const;
+        int resolve_filament_for_tool_id(unsigned int tool_id) const;
 
         // post process the file with the given filename to:
         // 1) add remaining time lines M73 and update moves' gcode ids accordingly
@@ -1113,5 +1119,3 @@ class Print;
 } /* namespace Slic3r */
 
 #endif /* slic3r_GCodeProcessor_hpp_ */
-
-

--- a/src/libslic3r/GCodeWriter.cpp
+++ b/src/libslic3r/GCodeWriter.cpp
@@ -28,6 +28,7 @@ void GCodeWriter::apply_print_config(const PrintConfig &print_config)
 {
     this->config.apply(print_config, true);
     m_single_extruder_multi_material = print_config.single_extruder_multi_material.value;
+    m_use_physical_extruder_ids_only = print_config.use_physical_extruder_ids_only.value;
     bool use_mach_limits = print_config.gcode_flavor.value == gcfMarlinLegacy || print_config.gcode_flavor.value == gcfMarlinFirmware ||
                            print_config.gcode_flavor.value == gcfKlipper || print_config.gcode_flavor.value == gcfRepRapFirmware;
     if (use_mach_limits) {
@@ -160,7 +161,29 @@ std::string GCodeWriter::set_temperature(unsigned int temperature, bool wait, in
     // set tool to -1 to make sure we won't emit T parameter for single extruder or SEMM
     if (!this->multiple_extruders || m_single_extruder_multi_material)
         tool = -1;
+    else
+        tool = get_output_tool_id(tool);
     return set_temperature(temperature, this->config.gcode_flavor, wait, tool);
+}
+
+bool GCodeWriter::uses_strict_physical_tool_ids() const
+{
+    return multiple_extruders && !m_single_extruder_multi_material && !m_is_bbl_printers && m_use_physical_extruder_ids_only;
+}
+
+int GCodeWriter::get_output_tool_id(int tool) const
+{
+    if (tool < 0 || !uses_strict_physical_tool_ids())
+        return tool;
+
+    const size_t logical_tool_id = static_cast<size_t>(tool);
+    if (logical_tool_id < config.filament_map.size()) {
+        const int mapped_tool = config.filament_map.get_at(logical_tool_id) - 1;
+        if (mapped_tool >= 0)
+            return mapped_tool;
+    }
+
+    return tool;
 }
 
 // BBS
@@ -518,16 +541,22 @@ std::string GCodeWriter::toolchange(unsigned int filament_id)
     assert(filament_extruder_iter != m_filament_extruders.end() && filament_extruder_iter->id() == filament_id);
     m_curr_extruder_id = filament_extruder_iter->extruder_id();
     m_curr_filament_extruder[m_curr_extruder_id] = &*filament_extruder_iter;
+    const unsigned int toolchange_id = uses_strict_physical_tool_ids() ?
+        filament_extruder_iter->extruder_id() :
+        filament_id;
 
     // return the toolchange command
     // if we are running a single-extruder setup, just set the extruder and return nothing
     std::ostringstream gcode;
     if (this->multiple_extruders || (this->config.filament_diameter.values.size() > 1 && !is_bbl_printers())) {
         // BBS
+        if (uses_strict_physical_tool_ids())
+            gcode << ";VT T" << filament_id << "\n";
+
         if (this->m_is_bbl_printers)
             gcode << "M1020 S" << filament_id;
         else
-            gcode << this->toolchange_prefix() << filament_id;
+            gcode << this->toolchange_prefix() << toolchange_id;
         //BBS
         if (GCodeWriter::full_gcode_comment)
             gcode << " ; change extruder";

--- a/src/libslic3r/GCodeWriter.hpp
+++ b/src/libslic3r/GCodeWriter.hpp
@@ -20,6 +20,7 @@ public:
         multiple_extruders(false), m_curr_filament_extruder(MAXIMUM_EXTRUDER_NUMBER, nullptr),
         m_curr_extruder_id (-1),
         m_single_extruder_multi_material(false),
+        m_use_physical_extruder_ids_only(false),
         m_last_acceleration(0), m_max_acceleration(0),m_last_travel_acceleration(0), m_max_travel_acceleration(0),
         m_last_jerk(0), m_max_jerk_x(0), m_max_jerk_y(0),
         m_last_bed_temperature(0), m_last_bed_temperature_reached(true),
@@ -131,6 +132,7 @@ public:
 	// Extruders are sorted by their ID, so that binary search is possible.
     std::vector<Extruder> m_filament_extruders;
     bool            m_single_extruder_multi_material;
+    bool            m_use_physical_extruder_ids_only;
     std::vector<Extruder*> m_curr_filament_extruder;
     int        m_curr_extruder_id;
     unsigned int    m_last_acceleration;
@@ -189,6 +191,8 @@ public:
     std::string _spiral_travel_to_z(double z, const Vec2d &ij_offset, const std::string &comment);
     std::string _retract(double length, double restart_extra, const std::string &comment);
     std::string set_acceleration_internal(Acceleration type, unsigned int acceleration);
+    bool        uses_strict_physical_tool_ids() const;
+    int         get_output_tool_id(int tool) const;
 
 };
 

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -2907,8 +2907,45 @@ void Print::finalize_first_layer_convex_hull()
     m_first_layer_convex_hull = Geometry::convex_hull(m_first_layer_convex_hull.points);
 }
 
+static bool uses_orca_managed_extruder_mapping(const PrintConfig &config)
+{
+    return config.use_physical_extruder_ids_only &&
+           !config.single_extruder_multi_material &&
+           config.nozzle_diameter.values.size() > 1;
+}
+
+static std::vector<int> normalize_filament_maps(const std::vector<int> &maps, size_t filament_count, size_t physical_extruder_count, bool use_orca_mapping)
+{
+    const int max_extruder_id = std::max(1, int(physical_extruder_count));
+
+    std::vector<int> normalized = maps;
+    normalized.resize(filament_count, 1);
+    for (size_t filament_idx = 0; filament_idx < normalized.size(); ++filament_idx) {
+        int &mapped_extruder = normalized[filament_idx];
+        if (filament_idx < physical_extruder_count) {
+            mapped_extruder = int(filament_idx) + 1;
+            continue;
+        }
+
+        if (!use_orca_mapping) {
+            mapped_extruder = 1;
+            continue;
+        }
+
+        if (mapped_extruder < 1 || mapped_extruder > max_extruder_id)
+            mapped_extruder = 1;
+    }
+
+    return normalized;
+}
+
 void Print::update_filament_maps_to_config(std::vector<int> f_maps)
 {
+    const bool use_orca_mapping = uses_orca_managed_extruder_mapping(m_config);
+    f_maps = normalize_filament_maps(f_maps,
+                                     m_config.filament_colour.values.size(),
+                                     m_config.nozzle_diameter.values.size(),
+                                     use_orca_mapping);
     if (m_config.filament_map.values != f_maps)
     {
         BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << boost::format(": filament maps changed after pre-slicing.");
@@ -2949,7 +2986,10 @@ void Print::apply_config_for_render(const DynamicConfig &config)
 
 std::vector<int> Print::get_filament_maps() const
 {
-    return m_config.filament_map.values;
+    return normalize_filament_maps(m_config.filament_map.values,
+                                   m_config.filament_colour.values.size(),
+                                   m_config.nozzle_diameter.values.size(),
+                                   uses_orca_managed_extruder_mapping(m_config));
 }
 
 FilamentMapMode Print::get_filament_map_mode() const

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -5486,6 +5486,12 @@ void PrintConfigDef::init_fff_params()
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionBool(true));
 
+    def = this->add("use_physical_extruder_ids_only", coBool);
+    def->label = L("Enable Orca-managed extruder mapping");
+    def->tooltip = L("When enabled, Orca maps logical filaments to physical extruders, shows the per-filament extruder mapping UI, and exports only physical extruder IDs and slots. When disabled, Orca keeps vanilla logical-filament behavior and the printer may remap them at print start. Extra virtual filaments use Extruder 1 as the fallback basis for nozzle-limited settings such as layer-height and line-width constraints.");
+    def->mode = comAdvanced;
+    def->set_default_value(new ConfigOptionBool(false));
+
     def = this->add("manual_filament_change", coBool);
     def->label = L("Manual Filament Change");
     def->tooltip = L("Enable this option to omit the custom Change filament G-code only at the beginning of the print. "

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -1330,6 +1330,7 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionString,              machine_start_gcode))
     ((ConfigOptionStrings,             filament_start_gcode))
     ((ConfigOptionBool,                single_extruder_multi_material))
+    ((ConfigOptionBool,                use_physical_extruder_ids_only))
     ((ConfigOptionBool,                manual_filament_change))
     ((ConfigOptionBool,                single_extruder_multi_material_priming))
     ((ConfigOptionBool,                wipe_tower_no_sparse_layers))

--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -9879,8 +9879,9 @@ void GLCanvas3D::_set_warning_notification(EWarning warning, bool state)
 
 bool GLCanvas3D::is_flushing_matrix_error() {
 
-    // Flushing volumes only apply to single-extruder multi-material (SEMM) and BBL printers
-    if (!Sidebar::should_show_SEMM_buttons())
+    // Flushing-volume warnings are only relevant for single-extruder multi-material workflows.
+    const auto &printer_config = wxGetApp().preset_bundle->printers.get_edited_preset().config;
+    if (!printer_config.opt_bool("single_extruder_multi_material"))
         return false;
 
     const auto                &project_config = wxGetApp().preset_bundle->project_config;

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -7120,12 +7120,14 @@ void GUI_App::load_current_presets(bool active_preset_combox/*= false*/, bool ch
 
     auto& edited_printer_preset = preset_bundle->printers.get_edited_preset();
     PrinterTechnology printer_technology = edited_printer_preset.printer_technology();
-    // ORCA: Sync filament count with the printer's nozzle count before loading presets for multi-tool printers.
-    // This ensures filament_presets vector is properly sized when combo boxes are created/updated.
+    // ORCA: Ensure the logical filament count is never smaller than the physical nozzle count.
+    // Extra logical filaments may intentionally exist and be remapped onto the available tools.
     if (printer_technology == ptFFF && !edited_printer_preset.config.opt_bool("single_extruder_multi_material")) {
         auto* nozzle_diameter = edited_printer_preset.config.option<ConfigOptionFloats>("nozzle_diameter");
         if (nozzle_diameter) {
-            preset_bundle->set_num_filaments(nozzle_diameter->values.size());
+            const auto* filament_colours = preset_bundle->project_config.option<ConfigOptionStrings>("filament_colour");
+            const size_t logical_filament_count = filament_colours ? filament_colours->values.size() : 0;
+            preset_bundle->set_num_filaments(std::max(logical_filament_count, nozzle_diameter->values.size()));
         }
     }
 	this->plater()->set_printer_technology(printer_technology);

--- a/src/slic3r/GUI/GUI_Factories.cpp
+++ b/src/slic3r/GUI/GUI_Factories.cpp
@@ -1599,6 +1599,12 @@ void MenuFactory::create_filament_action_menu(bool init, int active_filament_men
             }, m_parent);
     }
 
+    // During menu-factory initialization the Sidebar has not been constructed yet.
+    // Build only the static items above here; the dynamic filament-specific submenus
+    // are rebuilt on demand when the menu is actually opened.
+    if (init)
+        return;
+
     const int item_id = menu->FindItem(_L("Merge with"));
     if (item_id != wxNOT_FOUND)
         menu->Destroy(item_id);
@@ -1619,6 +1625,33 @@ void MenuFactory::create_filament_action_menu(bool init, int active_filament_men
     }
     append_submenu(menu, sub_menu, wxID_ANY, _L("Merge with"), "", "",
         [filaments_cnt]() { return filaments_cnt > 1; }, m_parent);
+
+    const int physical_extruder_cnt = wxGetApp().preset_bundle->get_printer_extruder_count();
+    const bool can_use_filament_mapping = plater()->sidebar().uses_filament_mapping_badges();
+    const int mapping_item_id       = menu->FindItem(_L("Extruder Mapping"));
+    if (mapping_item_id != wxNOT_FOUND)
+        menu->Destroy(mapping_item_id);
+
+    const bool can_remap_filament    = can_use_filament_mapping && active_filament_menu_id >= physical_extruder_cnt;
+    if (can_remap_filament) {
+        wxMenu *mapping_menu      = new wxMenu();
+        const int current_mapping = plater()->sidebar().get_current_plate_filament_mapping(active_filament_menu_id);
+        for (int extruder_id = 1; extruder_id <= physical_extruder_cnt; ++extruder_id) {
+            const wxString item_name = wxString::Format(_L("Extruder %d"), extruder_id);
+            wxMenuItem *item = append_menu_check_item(
+                mapping_menu, wxID_ANY, item_name, "",
+                [active_filament_menu_id, extruder_id](wxCommandEvent &) {
+                    plater()->sidebar().set_current_plate_filament_mapping(size_t(active_filament_menu_id), extruder_id);
+                },
+                mapping_menu,
+                []() { return true; },
+                [current_mapping, extruder_id]() { return current_mapping == extruder_id; },
+                m_parent);
+            item->Check(current_mapping == extruder_id);
+        }
+        append_submenu(menu, mapping_menu, wxID_ANY, _L("Extruder Mapping"), "", "",
+            [physical_extruder_cnt]() { return physical_extruder_cnt > 1; }, m_parent);
+    }
 }
 
 //BBS: add part plate related logic
@@ -1952,6 +1985,7 @@ void MenuFactory::append_menu_items_instance_manipulation(wxMenu* menu)
 }
 
 wxMenu *MenuFactory::filament_action_menu(int active_filament_menu_id) {
+    plater()->sidebar().update_filament_mapping_labels();
     create_filament_action_menu(false, active_filament_menu_id);
     return &m_filament_action_menu;
 }

--- a/src/slic3r/GUI/OptionsGroup.cpp
+++ b/src/slic3r/GUI/OptionsGroup.cpp
@@ -945,6 +945,26 @@ boost::any ConfigOptionsGroup::get_config_value(const DynamicPrintConfig& config
 	boost::any ret;
 	wxString text_value = wxString("");
 	const ConfigOptionDef* opt = config.def()->get(opt_key);
+    if (opt == nullptr)
+        return ret;
+
+    const ConfigOption *config_opt = config.option(opt_key);
+    if (config_opt == nullptr && bool(opt->default_value)) {
+        switch (opt->type) {
+        case coBool:
+            return static_cast<const ConfigOptionBool*>(opt->default_value.get())->value != 0;
+        case coInt:
+            return static_cast<const ConfigOptionInt*>(opt->default_value.get())->value;
+        case coFloat:
+            return double_to_string(static_cast<const ConfigOptionFloat*>(opt->default_value.get())->value);
+        case coString:
+            return from_u8(static_cast<const ConfigOptionString*>(opt->default_value.get())->value);
+        case coEnum:
+            return opt->default_value->getInt();
+        default:
+            break;
+        }
+    }
 
     if (opt->nullable)
     {

--- a/src/slic3r/GUI/PartPlate.cpp
+++ b/src/slic3r/GUI/PartPlate.cpp
@@ -58,6 +58,61 @@ static const int PARTPLATE_EDIT_PLATE_NAME_ICON_SIZE = 9; // ORCA this also scal
 static const int PARTPLATE_ICON_GAP_TOP = 3;
 static const int PARTPLATE_ICON_GAP_LEFT = 3;
 static const int PARTPLATE_ICON_GAP_Y = 5;
+
+static bool orca_managed_extruder_mapping_enabled()
+{
+    Slic3r::PresetBundle *preset_bundle = Slic3r::GUI::wxGetApp().preset_bundle;
+    if (preset_bundle == nullptr)
+        return false;
+
+    const Slic3r::Preset &edited_printer_preset = preset_bundle->printers.get_edited_preset();
+    const Slic3r::DynamicPrintConfig &printer_config = edited_printer_preset.config;
+    const bool single_extruder_multi_material = printer_config.has("single_extruder_multi_material") &&
+                                                printer_config.opt_bool("single_extruder_multi_material");
+    const bool use_physical_extruder_ids_only = printer_config.has("use_physical_extruder_ids_only") &&
+                                                printer_config.opt_bool("use_physical_extruder_ids_only");
+    return edited_printer_preset.printer_technology() == Slic3r::ptFFF &&
+           !preset_bundle->is_bbl_vendor() &&
+           !single_extruder_multi_material &&
+           preset_bundle->get_printer_extruder_count() > 1 &&
+           use_physical_extruder_ids_only;
+}
+
+static std::vector<int> normalize_filament_maps(const std::vector<int> &maps, size_t filament_count, int physical_extruder_count, bool use_orca_mapping)
+{
+    const int max_extruder_id = std::max(1, physical_extruder_count);
+
+    std::vector<int> normalized = maps;
+    normalized.resize(filament_count, 1);
+    for (size_t filament_idx = 0; filament_idx < normalized.size(); ++filament_idx) {
+        int &mapped_extruder = normalized[filament_idx];
+        if (filament_idx < size_t(physical_extruder_count)) {
+            mapped_extruder = int(filament_idx) + 1;
+            continue;
+        }
+
+        if (!use_orca_mapping) {
+            mapped_extruder = 1;
+            continue;
+        }
+
+        if (mapped_extruder < 1 || mapped_extruder > max_extruder_id)
+            mapped_extruder = 1;
+    }
+
+    return normalized;
+}
+
+static Slic3r::DynamicPrintConfig full_config_for_current_mapping_mode(Slic3r::PresetBundle *preset_bundle, Slic3r::GUI::PartPlate *part_plate, const Slic3r::DynamicConfig &project_config)
+{
+    if (preset_bundle == nullptr)
+        return Slic3r::DynamicPrintConfig();
+
+    if (!orca_managed_extruder_mapping_enabled() || part_plate == nullptr)
+        return preset_bundle->full_config(false);
+
+    return preset_bundle->full_config(false, part_plate->get_real_filament_maps(project_config));
+}
 static const int PARTPLATE_TEXT_OFFSET_X1 = 3;
 static const int PARTPLATE_TEXT_OFFSET_X2 = 1;
 static const int PARTPLATE_TEXT_OFFSET_Y = 1;
@@ -305,13 +360,16 @@ PrintSequence PartPlate::get_real_print_seq(bool* plate_same_as_global) const
 std::vector<int> PartPlate::get_real_filament_maps(const DynamicConfig& g_config, bool* use_global_param) const
 {
 	auto maps = get_filament_maps();
+    const size_t filament_count = wxGetApp().preset_bundle->filament_presets.size();
+    const int    physical_extruder_count = wxGetApp().preset_bundle->get_printer_extruder_count();
+    const bool   use_orca_mapping = orca_managed_extruder_mapping_enabled();
 	if (!maps.empty()) {
 		if (use_global_param) { *use_global_param = false; }
-		return maps;
+		return normalize_filament_maps(maps, filament_count, physical_extruder_count, use_orca_mapping);
 	}
 	auto g_maps = g_config.option<ConfigOptionInts>("filament_map")->values;
 	if (use_global_param) { *use_global_param = true; }
-	return g_maps;
+	return normalize_filament_maps(g_maps, filament_count, physical_extruder_count, use_orca_mapping);
 }
 
 FilamentMapMode PartPlate::get_real_filament_map_mode(const DynamicConfig& g_config, bool* use_global_param) const
@@ -1851,13 +1909,18 @@ bool PartPlate::check_filament_printable(const DynamicPrintConfig &config, wxStr
     if (mode != fmmManual)
         return true;
 
+    const auto *filament_printable = config.option<ConfigOptionInts>("filament_printable");
+    const auto *physical_extruder_map = config.option<ConfigOptionInts>("physical_extruder_map");
+    if (filament_printable == nullptr || physical_extruder_map == nullptr || physical_extruder_map->values.size() != 2)
+        return true;
+
     std::vector<int> used_filaments = get_extruders(true);  // 1 base
     if (!used_filaments.empty()) {
+        std::vector<int> filament_map = get_real_filament_maps(config);
         for (auto filament_idx : used_filaments) {
             int filament_id = filament_idx - 1;
             std::string filament_type = config.option<ConfigOptionStrings>("filament_type")->values.at(filament_id);
-            int filament_printable_status = config.option<ConfigOptionInts>("filament_printable")->values.at(filament_id);
-            std::vector<int> filament_map  = get_real_filament_maps(config);
+            int filament_printable_status = filament_printable->values.at(filament_id);
             int extruder_idx = filament_map[filament_id] - 1;
             if (!(filament_printable_status >> extruder_idx & 1)) {
                 wxString extruder_name = extruder_idx == 0 ? _L("left") : _L("right");
@@ -3704,15 +3767,23 @@ void PartPlate::set_filament_map_mode(const FilamentMapMode& mode)
 std::vector<int> PartPlate::get_filament_maps() const
 {
     std::string key = "filament_map";
+    const bool  use_orca_mapping = orca_managed_extruder_mapping_enabled();
     if (m_config.has(key))
-        return m_config.option<ConfigOptionInts>(key)->values;
+        return normalize_filament_maps(m_config.option<ConfigOptionInts>(key)->values,
+                                       wxGetApp().preset_bundle->filament_presets.size(),
+                                       wxGetApp().preset_bundle->get_printer_extruder_count(),
+                                       use_orca_mapping);
 
     return {};
 }
 
 void PartPlate::set_filament_maps(const std::vector<int>& f_maps)
 {
-    m_config.option<ConfigOptionInts>("filament_map", true)->values = f_maps;
+    m_config.option<ConfigOptionInts>("filament_map", true)->values =
+        normalize_filament_maps(f_maps,
+                                wxGetApp().preset_bundle->filament_presets.size(),
+                                wxGetApp().preset_bundle->get_printer_extruder_count(),
+                                true);
 }
 
 void PartPlate::clear_filament_map()
@@ -4143,8 +4214,7 @@ void PartPlateList::set_default_wipe_tower_pos_for_plate(int plate_idx, bool ini
     coordf_t plate_bbox_x_max_local_coord = plate_bbox_2d.max(0) - plate_origin(0);
     coordf_t plate_bbox_y_max_local_coord = plate_bbox_2d.max(1) - plate_origin(1);
 
-    std::vector<int> filament_maps = part_plate->get_real_filament_maps(proj_cfg);
-    DynamicPrintConfig full_config = wxGetApp().preset_bundle->full_config(false, filament_maps);
+    DynamicPrintConfig full_config = full_config_for_current_mapping_mode(wxGetApp().preset_bundle, part_plate, proj_cfg);
     const DynamicPrintConfig &print_cfg = wxGetApp().preset_bundle->prints.get_edited_preset().config;
     float w = dynamic_cast<const ConfigOptionFloat *>(print_cfg.option("prime_tower_width"))->value;
     float v = dynamic_cast<const ConfigOptionFloat *>(full_config.option("prime_volume"))->value;

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -203,6 +203,93 @@ wxDEFINE_EVENT(EVT_REPAIR_MODEL,                    wxCommandEvent);
 wxDEFINE_EVENT(EVT_FILAMENT_COLOR_CHANGED,          wxCommandEvent);
 wxDEFINE_EVENT(EVT_INSTALL_PLUGIN_NETWORKING,       wxCommandEvent);
 wxDEFINE_EVENT(EVT_UPDATE_PLUGINS_WHEN_LAUNCH,       wxCommandEvent);
+
+static bool orca_managed_extruder_mapping_enabled(PresetBundle* preset_bundle)
+{
+    if (preset_bundle == nullptr)
+        return false;
+
+    const Preset& edited_printer_preset = preset_bundle->printers.get_edited_preset();
+    const DynamicPrintConfig& printer_config = edited_printer_preset.config;
+    const bool single_extruder_multi_material = printer_config.has("single_extruder_multi_material") &&
+                                                printer_config.opt_bool("single_extruder_multi_material");
+    const bool use_physical_extruder_ids_only = printer_config.has("use_physical_extruder_ids_only") &&
+                                                printer_config.opt_bool("use_physical_extruder_ids_only");
+    return edited_printer_preset.printer_technology() == ptFFF &&
+           !preset_bundle->is_bbl_vendor() &&
+           !single_extruder_multi_material &&
+           preset_bundle->get_printer_extruder_count() > 1 &&
+           use_physical_extruder_ids_only;
+}
+
+bool filament_mapping_badges_enabled(PresetBundle* preset_bundle)
+{
+    return orca_managed_extruder_mapping_enabled(preset_bundle);
+}
+
+static DynamicPrintConfig full_config_for_current_mapping_mode(PresetBundle* preset_bundle, PartPlate* plate)
+{
+    if (preset_bundle == nullptr)
+        return DynamicPrintConfig();
+
+    if (!orca_managed_extruder_mapping_enabled(preset_bundle) || plate == nullptr)
+        return preset_bundle->full_config(false);
+
+    return preset_bundle->full_config(false, plate->get_real_filament_maps(preset_bundle->project_config));
+}
+
+int filament_badge_number(PresetBundle* preset_bundle, Plater* plater, size_t filament_id)
+{
+    if (!filament_mapping_badges_enabled(preset_bundle))
+        return int(filament_id) + 1;
+
+    const int physical_extruder_count = std::max(1, preset_bundle->get_printer_extruder_count());
+    if (filament_id < size_t(physical_extruder_count))
+        return int(filament_id) + 1;
+
+    if (plater == nullptr)
+        return 1;
+
+    std::vector<int> filament_map;
+    PartPlate* current_plate = plater->get_partplate_list().get_curr_plate();
+    if (current_plate != nullptr)
+        filament_map = current_plate->get_real_filament_maps(preset_bundle->project_config);
+    else
+        filament_map = plater->get_global_filament_map();
+
+    if (filament_id >= filament_map.size())
+        return 1;
+
+    const int mapped_extruder = filament_map[filament_id];
+    if (mapped_extruder < 1 || mapped_extruder > physical_extruder_count)
+        return 1;
+
+    return mapped_extruder;
+}
+
+wxBitmap* filament_badge_bitmap(Plater* plater, size_t filament_idx, int badge_number, int icon_width, int icon_height)
+{
+    if (plater == nullptr)
+        return nullptr;
+
+    const std::string label = std::to_string(badge_number);
+    const auto filament_color_info = plater->get_filament_colors_render_info();
+    const auto filament_color_type = plater->get_filament_color_render_type();
+    const auto fallback_colors     = plater->get_extruder_colors_from_plater_config();
+
+    if (filament_idx < filament_color_info.size() && filament_idx < filament_color_type.size() && !filament_color_info[filament_idx].empty()) {
+        std::vector<std::string> colors = Slic3r::split_string(filament_color_info[filament_idx], ' ');
+        if (colors.size() <= 1)
+            return get_extruder_color_icon(colors.empty() ? "#636363" : colors.front(), label, icon_width, icon_height);
+
+        return get_extruder_color_icon(colors, filament_color_type[filament_idx] == "0", label, icon_width, icon_height);
+    }
+
+    if (filament_idx < fallback_colors.size())
+        return get_extruder_color_icon(fallback_colors[filament_idx], label, icon_width, icon_height);
+
+    return nullptr;
+}
 wxDEFINE_EVENT(EVT_INSTALL_PLUGIN_HINT,             wxCommandEvent);
 wxDEFINE_EVENT(EVT_PREVIEW_ONLY_MODE_HINT,          wxCommandEvent);
 //BBS: change light/dark mode
@@ -2363,7 +2450,8 @@ void Sidebar::init_filament_combo(PlaterPresetComboBox **combo, const int filame
     if ((filament_idx % 2) == 0) // Dont add right column item. this one create equal spacing on left, right & middle
         combo_and_btn_sizer->AddSpacer(FromDIP((filament_idx % 2) == 0 ? 12 : 3)); // Content Margin
 
-    (*combo)->clr_picker->SetLabel(wxString::Format("%d", filament_idx + 1));
+    const int badge_number = filament_badge_number(wxGetApp().preset_bundle, p->plater, size_t(filament_idx));
+    (*combo)->clr_picker->SetLabel(wxString::Format("%d", badge_number));
     combo_and_btn_sizer->Add((*combo)->clr_picker, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(SidebarProps::ElementSpacing()) - FromDIP(2)); // ElementSpacing - 2 (from combo box))
     combo_and_btn_sizer->Add(*combo, 1, wxALL | wxEXPAND, FromDIP(2))->SetMinSize({-1, FromDIP(30)});
 
@@ -2386,6 +2474,7 @@ void Sidebar::init_filament_combo(PlaterPresetComboBox **combo, const int filame
 
     PlaterPresetComboBox* combobox = (*combo);
     edit_btn->Bind(wxEVT_BUTTON, [this, edit_btn, filament_idx](wxCommandEvent) {
+        update_filament_mapping_labels();
         auto menu = p->plater->filament_action_menu(filament_idx);
         wxPoint pt { 0, edit_btn->GetSize().GetHeight() + 10 };
         pt = edit_btn->ClientToScreen(pt);
@@ -2495,6 +2584,7 @@ void Sidebar::update_all_preset_comboboxes()
     }
 
     show_SEMM_buttons(should_show_SEMM_buttons());
+    update_filament_mapping_labels();
 
     //p->m_staticText_filament_settings->Update();
 
@@ -2586,6 +2676,7 @@ void Sidebar::update_presets(Preset::Type preset_type)
         for (size_t i = 0; i < filament_cnt; i++)
             p->combos_filament[i]->update();
 
+        update_filament_mapping_labels();
         update_dynamic_filament_list();
         break;
     }
@@ -2611,6 +2702,7 @@ void Sidebar::update_presets(Preset::Type preset_type)
     case Preset::TYPE_PRINTER:
     {
         update_all_preset_comboboxes();
+        update_filament_mapping_labels();
         p->show_preset_comboboxes();
 
         /* update bed shape */
@@ -3108,6 +3200,7 @@ void Sidebar::on_filament_count_change(size_t num_filaments)
 
     Layout();
     p->m_panel_filament_title->Refresh();
+    update_filament_mapping_labels();
     update_ui_from_settings();
     update_dynamic_filament_list();
 }
@@ -3168,6 +3261,7 @@ void Sidebar::on_filaments_delete(size_t filament_id)
 
     Layout();
     p->m_panel_filament_title->Refresh();
+    update_filament_mapping_labels();
     update_ui_from_settings();
     dynamic_filament_list.update();
 }
@@ -3221,6 +3315,72 @@ void Sidebar::edit_filament()
     if (p->m_menu_filament_id >= 0 && p->m_menu_filament_id < p->combos_filament.size()
             && p->combos_filament[p->m_menu_filament_id]->switch_to_tab())
         p->editing_filament = p->m_menu_filament_id; // sync with TabPresetComboxBox's m_filament_idx
+}
+
+void Sidebar::set_current_plate_filament_mapping(size_t filament_id, int extruder_id)
+{
+    if (!uses_filament_mapping_badges())
+        return;
+
+    PartPlate *curr_plate = wxGetApp().plater()->get_partplate_list().get_curr_plate();
+    if (curr_plate == nullptr)
+        return;
+
+    const int physical_extruder_count = wxGetApp().preset_bundle->get_printer_extruder_count();
+    if (physical_extruder_count <= 0 || extruder_id < 1 || extruder_id > physical_extruder_count)
+        return;
+    if (filament_id < size_t(physical_extruder_count))
+        return;
+
+    const auto &project_config = wxGetApp().preset_bundle->project_config;
+    auto        filament_maps  = curr_plate->get_real_filament_maps(project_config);
+    filament_maps.resize(wxGetApp().preset_bundle->filament_presets.size(), 1);
+    if (filament_id >= filament_maps.size())
+        return;
+
+    if (curr_plate->get_filament_map_mode() == fmmManual && filament_maps[filament_id] == extruder_id)
+        return;
+
+    wxGetApp().plater()->take_snapshot("Set Filament Extruder Mapping");
+    curr_plate->set_filament_map_mode(fmmManual);
+    filament_maps[filament_id] = extruder_id;
+    curr_plate->set_filament_maps(filament_maps);
+    curr_plate->update_slice_result_valid_state(false);
+
+    wxGetApp().plater()->update_project_dirty_from_presets();
+    wxGetApp().plater()->set_plater_dirty(true);
+    wxGetApp().get_tab(Preset::TYPE_PRINT)->update();
+    update_filament_mapping_labels();
+    wxGetApp().plater()->update();
+}
+
+bool Sidebar::uses_filament_mapping_badges() const
+{
+    return filament_mapping_badges_enabled(wxGetApp().preset_bundle);
+}
+
+int Sidebar::get_current_plate_filament_mapping(size_t filament_id) const
+{
+    return filament_badge_number(wxGetApp().preset_bundle, p != nullptr ? p->plater : nullptr, filament_id);
+}
+
+void Sidebar::update_filament_mapping_labels()
+{
+    if (p == nullptr)
+        return;
+
+    const int icon_width  = FromDIP(20);
+    const int icon_height = FromDIP(20);
+
+    for (size_t filament_idx = 0; filament_idx < p->combos_filament.size(); ++filament_idx) {
+        const int badge_number = filament_badge_number(wxGetApp().preset_bundle, p->plater, filament_idx);
+        wxBitmap* bitmap = filament_badge_bitmap(p->plater, filament_idx, badge_number, icon_width, icon_height);
+
+        if (bitmap != nullptr)
+            p->combos_filament[filament_idx]->clr_picker->SetBitmap(*bitmap);
+        p->combos_filament[filament_idx]->clr_picker->SetLabel(wxString::Format("%d", badge_number));
+        p->combos_filament[filament_idx]->clr_picker->Refresh();
+    }
 }
 
 void Sidebar::add_custom_filament(wxColour new_col) {
@@ -3714,7 +3874,7 @@ bool Sidebar::should_show_SEMM_buttons()
     bool is_bbl_vendor = preset_bundle.is_bbl_vendor();
     auto cfg = preset_bundle.printers.get_edited_preset().config;
 
-    return cfg.opt_bool("single_extruder_multi_material") || is_bbl_vendor;
+    return cfg.opt_bool("single_extruder_multi_material") || is_bbl_vendor || preset_bundle.get_printer_extruder_count() > 1;
 }
 
 void Sidebar::show_SEMM_buttons(bool bshow)
@@ -3790,6 +3950,12 @@ wxButton* Sidebar::get_wiping_dialog_button()
 
 void Sidebar::set_flushing_volume_warning(const bool flushing_volume_modify)
 {
+    const auto &printer_config = wxGetApp().preset_bundle->printers.get_edited_preset().config;
+    if (!printer_config.opt_bool("single_extruder_multi_material")) {
+        p->m_flushing_volume_btn->SetStyle(ButtonStyle::Confirm, ButtonType::Compact);
+        return;
+    }
+
     if(flushing_volume_modify){
         p->m_flushing_volume_btn->SetStyle(ButtonStyle::Regular, ButtonType::Compact);
         p->m_flushing_volume_btn->SetBorderColor(wxColour("#FF6F00"));
@@ -7810,8 +7976,7 @@ unsigned int Plater::priv::update_background_process(bool force_validation, bool
     const auto& preset_bundle = wxGetApp().preset_bundle;
     if (preset_bundle->get_printer_extruder_count() > 1) {
         PartPlate* cur_plate = background_process.get_current_plate();
-        std::vector<int> f_maps = cur_plate->get_real_filament_maps(preset_bundle->project_config);
-        invalidated = background_process.apply(this->model, preset_bundle->full_config(false, f_maps));
+        invalidated = background_process.apply(this->model, full_config_for_current_mapping_mode(preset_bundle, cur_plate));
         background_process.fff_print()->set_extruder_filament_info(get_extruder_filament_info());
     }
     else
@@ -16614,16 +16779,37 @@ void Plater::set_global_filament_map_mode(FilamentMapMode mode)
     mode_ptr->value = mode;
 }
 
+static std::vector<int> normalize_global_filament_map(const std::vector<int> &filament_map)
+{
+    const size_t filament_count = wxGetApp().preset_bundle->filament_presets.size();
+    const int    physical_extruder_count = std::max(1, wxGetApp().preset_bundle->get_printer_extruder_count());
+
+    std::vector<int> normalized = filament_map;
+    normalized.resize(filament_count, 1);
+    for (size_t filament_idx = 0; filament_idx < normalized.size(); ++filament_idx) {
+        int &mapped_extruder = normalized[filament_idx];
+        if (filament_idx < size_t(physical_extruder_count)) {
+            mapped_extruder = int(filament_idx) + 1;
+            continue;
+        }
+
+        if (mapped_extruder < 1 || mapped_extruder > physical_extruder_count)
+            mapped_extruder = 1;
+    }
+
+    return normalized;
+}
+
 void Plater::set_global_filament_map(const std::vector<int>& filament_map)
 {
     auto& project_config = wxGetApp().preset_bundle->project_config;
-    project_config.option<ConfigOptionInts>("filament_map")->values = filament_map;
+    project_config.option<ConfigOptionInts>("filament_map")->values = normalize_global_filament_map(filament_map);
 }
 
 std::vector<int> Plater::get_global_filament_map() const
 {
     auto& project_config = wxGetApp().preset_bundle->project_config;
-    return project_config.option<ConfigOptionInts>("filament_map")->values;
+    return normalize_global_filament_map(project_config.option<ConfigOptionInts>("filament_map")->values);
 }
 
 
@@ -17147,8 +17333,7 @@ void Plater::apply_background_progress()
     //always apply the current plate's print
     Print::ApplyStatus invalidated;
     if (preset_bundle->get_printer_extruder_count() > 1) {
-        std::vector<int> f_maps = part_plate->get_real_filament_maps(preset_bundle->project_config);
-        invalidated = p->background_process.apply(this->model(), preset_bundle->full_config(false, f_maps));
+        invalidated = p->background_process.apply(this->model(), full_config_for_current_mapping_mode(preset_bundle, part_plate));
     }
     else
         invalidated = p->background_process.apply(this->model(), preset_bundle->full_config(false));
@@ -17192,8 +17377,7 @@ int Plater::select_plate(int plate_index, bool need_slice)
 
         //always apply the current plate's print
         if (preset_bundle->get_printer_extruder_count() > 1) {
-            std::vector<int> f_maps = part_plate->get_real_filament_maps(preset_bundle->project_config);
-            invalidated = p->background_process.apply(this->model(), preset_bundle->full_config(false, f_maps));
+            invalidated = p->background_process.apply(this->model(), full_config_for_current_mapping_mode(preset_bundle, part_plate));
         }
         else
             invalidated = p->background_process.apply(this->model(), preset_bundle->full_config(false));
@@ -17614,8 +17798,7 @@ int Plater::select_plate_by_hover_id(int hover_id, bool right_click, bool isModi
             part_plate->get_print(&print, &gcode_result, NULL);
             //always apply the current plate's print
             if (preset_bundle->get_printer_extruder_count() > 1) {
-                std::vector<int> f_maps = part_plate->get_real_filament_maps(preset_bundle->project_config);
-                invalidated = p->background_process.apply(this->model(), preset_bundle->full_config(false, f_maps));
+                invalidated = p->background_process.apply(this->model(), full_config_for_current_mapping_mode(preset_bundle, part_plate));
             }
             else
                 invalidated = p->background_process.apply(this->model(), preset_bundle->full_config(false));

--- a/src/slic3r/GUI/Plater.hpp
+++ b/src/slic3r/GUI/Plater.hpp
@@ -32,6 +32,7 @@
 #define FILAMENT_SYSTEM_COLORS_NUM      16
 
 class wxButton;
+class wxBitmap;
 class ScalableButton;
 class wxScrolledWindow;
 class wxString;
@@ -84,6 +85,10 @@ using t_optgroups = std::vector <std::shared_ptr<ConfigOptionsGroup>>;
 
 class Plater;
 enum class ActionButtonType : int;
+
+bool      filament_mapping_badges_enabled(PresetBundle* preset_bundle);
+int       filament_badge_number(PresetBundle* preset_bundle, Plater* plater, size_t filament_id);
+wxBitmap* filament_badge_bitmap(Plater* plater, size_t filament_idx, int badge_number, int icon_width, int icon_height);
 
 #define EVT_PUBLISHING_START        1
 #define EVT_PUBLISHING_STOP         2
@@ -186,6 +191,10 @@ public:
     void delete_filament(size_t filament_id = size_t(-1), int replace_filament_id = -1);  // 0 base, -1 means default
     void change_filament(size_t from_id, size_t to_id);  // 0 base
     void edit_filament();
+    void set_current_plate_filament_mapping(size_t filament_id, int extruder_id);
+    bool uses_filament_mapping_badges() const;
+    int  get_current_plate_filament_mapping(size_t filament_id) const;
+    void update_filament_mapping_labels();
     void add_custom_filament(wxColour new_col);
     bool is_new_project_in_gcode3mf();
     // BBS

--- a/src/slic3r/GUI/PresetComboBoxes.cpp
+++ b/src/slic3r/GUI/PresetComboBoxes.cpp
@@ -1106,11 +1106,22 @@ void PlaterPresetComboBox::update()
     const Preset* selected_filament_preset = nullptr;
     if (m_type == Preset::TYPE_FILAMENT)
     {
-        std::vector<wxBitmap *> bitmaps = get_extruder_color_icons(true);
-        if (m_filament_idx < bitmaps.size()) {
-            clr_picker->SetBitmap(*bitmaps[m_filament_idx]);
+        if (filament_mapping_badges_enabled(m_preset_bundle)) {
+            const int mapped_extruder = filament_badge_number(m_preset_bundle, wxGetApp().plater(), size_t(m_filament_idx));
+            const int icon_width = FromDIP(20);
+            const int icon_height = FromDIP(20);
+            wxBitmap* bitmap = filament_badge_bitmap(wxGetApp().plater(), size_t(m_filament_idx), mapped_extruder, icon_width, icon_height);
+
+            if (bitmap != nullptr)
+                clr_picker->SetBitmap(*bitmap);
+            clr_picker->SetLabel(wxString::Format("%d", mapped_extruder));
         } else {
-            return;
+            std::vector<wxBitmap *> bitmaps = get_extruder_color_icons(true);
+            if (m_filament_idx < bitmaps.size()) {
+                clr_picker->SetBitmap(*bitmaps[m_filament_idx]);
+            } else {
+                return;
+            }
         }
 #ifdef __WXOSX__
         clr_picker->SetLabel(clr_picker->GetLabel()); // Let setBezelStyle: be called

--- a/src/slic3r/GUI/Selection.cpp
+++ b/src/slic3r/GUI/Selection.cpp
@@ -34,6 +34,66 @@ static const Slic3r::ColorRGBA TRANSPARENT_PLANE_COLOR = { 0.8f, 0.8f, 0.8f, 0.5
 namespace Slic3r {
 namespace GUI {
 
+namespace {
+
+constexpr int WIPE_TOWER_OBJECT_IDX_BASE = 1000;
+
+bool is_wipe_tower_proxy_object_idx(int obj_idx)
+{
+    Plater *plater = wxGetApp().plater();
+    if (plater == nullptr)
+        return false;
+
+    const int plate_count = plater->get_partplate_list().get_plate_count();
+    return obj_idx >= WIPE_TOWER_OBJECT_IDX_BASE && obj_idx < WIPE_TOWER_OBJECT_IDX_BASE + plate_count;
+}
+
+ModelObject *checked_model_object(Model *model, int obj_idx, const char *caller)
+{
+    if (model == nullptr) {
+        BOOST_LOG_TRIVIAL(error) << caller << ": selection has no model";
+        return nullptr;
+    }
+
+    if (obj_idx < 0 || size_t(obj_idx) >= model->objects.size()) {
+        BOOST_LOG_TRIVIAL(error) << caller << ": selection references invalid object index " << obj_idx
+                                 << " while model contains " << model->objects.size() << " objects";
+        return nullptr;
+    }
+
+    ModelObject *object = model->objects[obj_idx];
+    if (object == nullptr) {
+        BOOST_LOG_TRIVIAL(error) << caller << ": selection references null object at index " << obj_idx;
+        return nullptr;
+    }
+
+    return object;
+}
+
+const ModelObject *checked_model_object(const Model *model, int obj_idx, const char *caller)
+{
+    if (model == nullptr) {
+        BOOST_LOG_TRIVIAL(error) << caller << ": selection has no model";
+        return nullptr;
+    }
+
+    if (obj_idx < 0 || size_t(obj_idx) >= model->objects.size()) {
+        BOOST_LOG_TRIVIAL(error) << caller << ": selection references invalid object index " << obj_idx
+                                 << " while model contains " << model->objects.size() << " objects";
+        return nullptr;
+    }
+
+    const ModelObject *object = model->objects[obj_idx];
+    if (object == nullptr) {
+        BOOST_LOG_TRIVIAL(error) << caller << ": selection references null object at index " << obj_idx;
+        return nullptr;
+    }
+
+    return object;
+}
+
+} // namespace
+
 Selection::VolumeCache::TransformCache::TransformCache()
     : position(Vec3d::Zero())
     , rotation_matrix(Transform3d::Identity())
@@ -586,7 +646,11 @@ void Selection::set_printable(bool printable)
     // set printable value for all instances in object
     for (const auto& [obj_idx, inst_idx] : instances_idxs)
     {
-        ModelObject* object = m_model->objects[obj_idx];
+        if (is_wipe_tower_proxy_object_idx(obj_idx))
+            continue;
+        ModelObject* object = checked_model_object(m_model, obj_idx, __FUNCTION__);
+        if (object == nullptr)
+            continue;
         for (auto inst : object->instances)
             inst->printable = printable;
         wxGetApp().obj_list()->update_printable_state(obj_idx, inst_idx);
@@ -612,7 +676,11 @@ bool Selection::get_auto_drop() const {
 
     // return false, if one of the instances in the selection has auto_drop disabled, otherwise return true
     for (const auto& [obj_idx, inst_idx] : instances_idxs) {
-        ModelObject* object = m_model->objects[obj_idx];
+        if (is_wipe_tower_proxy_object_idx(obj_idx))
+            continue;
+        const ModelObject* object = checked_model_object(m_model, obj_idx, __FUNCTION__);
+        if (object == nullptr)
+            return false;
         for (const auto* inst : object->instances) {
             if (!inst->auto_drop) {
                 return false;
@@ -640,7 +708,11 @@ void Selection::set_auto_drop(bool enabled)
 
     // set auto_drop value for all instances in object
     for (const auto& [obj_idx, inst_idx] : instances_idxs) {
-        ModelObject* object = m_model->objects[obj_idx];
+        if (is_wipe_tower_proxy_object_idx(obj_idx))
+            continue;
+        ModelObject* object = checked_model_object(m_model, obj_idx, __FUNCTION__);
+        if (object == nullptr)
+            continue;
         for (auto* inst : object->instances) {
             inst->auto_drop = enabled;
         }
@@ -2290,6 +2362,10 @@ void Selection::update_type()
         const GLVolume* volume = (*m_volumes)[i];
         int obj_idx = volume->object_idx();
         int inst_idx = volume->instance_idx();
+        if (!volume->is_wipe_tower && checked_model_object(m_model, obj_idx, __FUNCTION__) == nullptr) {
+            m_type = Invalid;
+            return;
+        }
         ObjectIdxsToInstanceIdxsMap::iterator obj_it = m_cache.content.find(obj_idx);
         if (obj_it == m_cache.content.end())
             obj_it = m_cache.content.insert(ObjectIdxsToInstanceIdxsMap::value_type(obj_idx, InstanceIdxsList())).first;
@@ -2317,7 +2393,11 @@ void Selection::update_type()
             }
             else
             {
-                const ModelObject* model_object = m_model->objects[first->object_idx()];
+                const ModelObject* model_object = checked_model_object(m_model, first->object_idx(), __FUNCTION__);
+                if (model_object == nullptr) {
+                    m_type = Invalid;
+                    return;
+                }
                 unsigned int volumes_count = (unsigned int)model_object->volumes.size();
                 unsigned int instances_count = (unsigned int)model_object->instances.size();
                 if (volumes_count * instances_count == 1)
@@ -2350,7 +2430,11 @@ void Selection::update_type()
 
             if (m_cache.content.size() == 1) // single object
             {
-                const ModelObject* model_object = m_model->objects[m_cache.content.begin()->first];
+                const ModelObject* model_object = checked_model_object(m_model, m_cache.content.begin()->first, __FUNCTION__);
+                if (model_object == nullptr) {
+                    m_type = Invalid;
+                    return;
+                }
                 unsigned int model_volumes_count = (unsigned int)model_object->volumes.size();
 
                 unsigned int instances_count = (unsigned int)model_object->instances.size();

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -69,6 +69,18 @@ namespace GUI {
 
 static const std::vector<std::string> plate_keys = { "curr_bed_type", "skirt_start_angle", "first_layer_print_sequence", "first_layer_sequence_choice", "other_layers_print_sequence", "other_layers_sequence_choice", "print_sequence", "spiral_mode"};
 
+static void materialize_config_option_if_missing(DynamicPrintConfig &config, const std::string &opt_key)
+{
+    if (config.has(opt_key))
+        return;
+
+    const ConfigOptionDef *opt_def = config.def()->get(opt_key);
+    if (opt_def == nullptr || !opt_def->default_value)
+        return;
+
+    config.set_key_value(opt_key, opt_def->default_value->clone());
+}
+
 void Tab::Highlighter::set_timer_owner(wxEvtHandler* owner, int timerid/* = wxID_ANY*/)
 {
     m_timer.SetOwner(owner, timerid);
@@ -1534,8 +1546,10 @@ void Tab::on_value_change(const std::string& opt_key, const boost::any& value)
         }
     }
 
-    if (opt_key == "single_extruder_multi_material" || opt_key == "extruders_count" )
+    if (opt_key == "single_extruder_multi_material" || opt_key == "extruders_count" ) {
         update_wiping_button_visibility();
+        wxGetApp().sidebar().update_filament_mapping_labels();
+    }
 
 
     if (opt_key == "pellet_flow_coefficient")
@@ -1551,8 +1565,8 @@ void Tab::on_value_change(const std::string& opt_key, const boost::any& value)
 
 
     if (opt_key == "single_extruder_multi_material"  ){
-        const auto bSEMM = m_config->opt_bool("single_extruder_multi_material");
-        wxGetApp().sidebar().show_SEMM_buttons(bSEMM);
+        wxGetApp().sidebar().show_SEMM_buttons(Sidebar::should_show_SEMM_buttons());
+        wxGetApp().sidebar().update_filament_mapping_labels();
         wxGetApp().get_tab(Preset::TYPE_PRINT)->update();
     }
 
@@ -1603,8 +1617,8 @@ void Tab::on_value_change(const std::string& opt_key, const boost::any& value)
 
 
     if (opt_key == "single_extruder_multi_material"  ){
-        const auto bSEMM = m_config->opt_bool("single_extruder_multi_material");
-        wxGetApp().sidebar().show_SEMM_buttons(bSEMM);
+        wxGetApp().sidebar().show_SEMM_buttons(Sidebar::should_show_SEMM_buttons());
+        wxGetApp().sidebar().update_filament_mapping_labels();
         wxGetApp().get_tab(Preset::TYPE_PRINT)->update();
     }
 
@@ -4825,6 +4839,8 @@ if (is_marlin_flavor)
         // create a page, but pretend it's an extruder page, so we can add it to m_pages ourselves
         auto page     = add_options_page(L("Multimaterial"), "custom-gcode_multi_material", true); // ORCA: icon only visible on placeholders
         auto optgroup = page->new_optgroup(L("Single extruder multi-material setup"), "param_multi_material");
+        materialize_config_option_if_missing(*m_config, "use_physical_extruder_ids_only");
+        materialize_config_option_if_missing(m_presets->get_selected_preset().config, "use_physical_extruder_ids_only");
         optgroup->append_single_option_line("single_extruder_multi_material", "printer_multimaterial_setup#single-extruder-multi-material");
         ConfigOptionDef def;
         def.type    = coInt, def.set_default_value(new ConfigOptionInt((int) m_extruders_count));
@@ -4835,6 +4851,7 @@ if (is_marlin_flavor)
         def.mode    = comAdvanced;
         Option option(def, "extruders_count");
         optgroup->append_single_option_line(option, "printer_multimaterial_setup#extruders");
+        optgroup->append_single_option_line("use_physical_extruder_ids_only");
 
         // Orca: rebuild missed extruder pages
         optgroup->m_on_change = [this, optgroup_wk = ConfigOptionsGroupWkp(optgroup)](t_config_option_key opt_key, boost::any value) {
@@ -5253,6 +5270,7 @@ void TabPrinter::toggle_options()
             load_config(new_conf);
         }
         toggle_option("extruders_count", !bSEMM);
+        toggle_line("use_physical_extruder_ids_only", !bSEMM);
         toggle_option("manual_filament_change", bSEMM);
         toggle_option("purge_in_prime_tower", bSEMM && supports_wipe_tower_2);
     }
@@ -5389,6 +5407,10 @@ void TabPrinter::update()
 
 void TabPrinter::update_fff()
 {
+    materialize_config_option_if_missing(*m_config, "use_physical_extruder_ids_only");
+    materialize_config_option_if_missing(m_presets->get_edited_preset().config, "use_physical_extruder_ids_only");
+    materialize_config_option_if_missing(m_presets->get_selected_preset().config, "use_physical_extruder_ids_only");
+
     if (m_use_silent_mode != m_config->opt_bool("silent_mode"))	{
         m_rebuild_kinematics_page = true;
         m_use_silent_mode = m_config->opt_bool("silent_mode");


### PR DESCRIPTION
# Description:

This PR adds a machine setting toggle switch that lets Orca either keep "vanilla" logical filament behaviour or manage filament -> physical extruder mapping itself. In Orca-managed mode, the UI exposes per filament mapping for extra filaments and both executable G-code and exported metadata are reduced to physical extruder IDs only.
The preview always shows the color of the virtual filament regardless of the physical existence or mapping.


**Examples why this is useful:**

**Scenario 1)** "Orca managed extruder mapping = OFF" (Vanilla behaviour)
You have a printer with 4 tool heads (e.g. Snapmaker U1) and load a 3mf file from Makerworld which contains 6 filaments / colors. "Vanilla" behaviour is that it'll generate a gcode with 6 tools. The Snapmaker U1 can handle this as you can map T5 and T6 to physical Tools / Extruders.

**Scenario 2)** "Orca managed extruder mapping = ON" (new feature)
You have a printer with 4 tool heads and use RRF which does not have a mapping override.
If gcode wants to use a tool that does not exist it will throw an error " „Invalid tool number“ and not change the tool at all.
With Orca managed extruder mapping = ON" you can remap the virtual filaments to actual physical extruders in Orca.
In this mode it does not allow to emit T commands into the gcode that do not exist.

For both scenarios you still see the actual color of the virtual filament. This is useful for example if you want plan to change the filament (color) with a pause. 

With Bondtech INDX around the corner and Prusa's Buddy Firmware most likely won't have a remapping feature as well because the Marlin based FW does not even have a proper web interface, this feature might there be useful as well.



# Screenshots and further descriptions:

Here you can toggle it on/off. Default is off. This option is only visible when "Single Extruder Multi Material" is not selected.
<img width="831" height="628" alt="setting" src="https://github.com/user-attachments/assets/d1df81e5-9050-4e06-a4b6-d6e856a87799" />

**The usual view of the filament tab with a 4 extruder tool changer and after opening a 3mf file with more than 4 filaments.
 "Orca managed extruder mapping = OFF"**

<img width="535" height="258" alt="Screenshot 2026-04-19 at 20 07 54" src="https://github.com/user-attachments/assets/2f8ed172-a9ce-4942-87ca-92963e025938" />

-
**Here with the new mapping context menu. Only visible with "Orca managed extruder mapping = ON". The number on the color box represents the physical extruder in this mode:**
<img width="1325" height="892" alt="Screenshot 2026-04-19 at 20 07 24" src="https://github.com/user-attachments/assets/edc88efd-5026-4add-ac2e-dd21ce3af895" />


# Tests

I did compare the gcode files and checked wether the Snapmaker U1 still recognises the virtual tools with the setting ON. 
I also compared the gcode files. As of now I don't see any remaining bugs but testers are very much welcome as this is not just a small feature...
