### PR TITLE
CrealityPrint: multi-color print support for K2 Plus/K2/K2 Pro

### DIFF
--- a/src/slic3r/GUI/PrintHostDialogs.cpp
+++ b/src/slic3r/GUI/PrintHostDialogs.cpp
@@ -1942,6 +1942,8 @@ void CrealityPrintHostSendDialog::init()
                         if (box_type == 0 && box.value("state", 0) != 1)
                             continue;
                         for (auto& mat : box["materials"]) {
+                            if (mat.value("type", "").empty())
+                                continue;
                             int slot_id = mat["id"].get<int>();
                             std::string tool_id = "T" + std::to_string(box_id) + std::string(1, 'A' + slot_id);
                             // Creality uses "#0RRGGBB" (7 hex digits), normalize to "#RRGGBB"

--- a/src/slic3r/GUI/PrintHostDialogs.cpp
+++ b/src/slic3r/GUI/PrintHostDialogs.cpp
@@ -1964,6 +1964,11 @@ void CrealityPrintHostSendDialog::init()
         }
     }
 
+    // Determine which filaments are actually used in the print
+    std::vector<int> used_filaments;
+    if (auto* plate = wxGetApp().plater()->get_partplate_list().get_curr_plate())
+        used_filaments = plate->get_used_filaments();
+
     if (gcode_filament_count > 0 && !m_printer_slots.empty()) {
         auto* label = new wxStaticText(this, wxID_ANY, _L("Filament Mapping:"));
         label->SetFont(::Label::Body_13);
@@ -1972,6 +1977,10 @@ void CrealityPrintHostSendDialog::init()
         group_sizer->AddSpacer(4);
 
         for (int i = 0; i < gcode_filament_count; i++) {
+            if (!used_filaments.empty() &&
+                std::find(used_filaments.begin(), used_filaments.end(), i + 1) == used_filaments.end())
+                continue;
+
             auto* row_sizer = new wxBoxSizer(wxHORIZONTAL);
 
             // Left side: gcode filament color swatch + type
@@ -2039,6 +2048,7 @@ void CrealityPrintHostSendDialog::init()
             group_sizer->Add(row_sizer);
             group_sizer->AddSpacer(4);
             m_slot_combos.push_back(combo);
+            m_combo_filament_idx.push_back(i);
         }
 
         int ext_slot_idx = -1;
@@ -2096,7 +2106,8 @@ std::map<std::string, std::string> CrealityPrintHostSendDialog::extendedInfo() c
             auto& slot = m_printer_slots[sel];
             // id = gcode tool index (T1A for first filament, T1B for second, ...),
             // not the destination CFS slot — firmware matches by gcode tool.
-            std::string gcode_tool = "T1" + std::string(1, 'A' + i);
+            int fi = m_combo_filament_idx[i];
+            std::string gcode_tool = "T1" + std::string(1, 'A' + fi);
             info["colorMatch_" + std::to_string(i)] =
                 gcode_tool + "\t" + slot.type + "\t" + slot.color + "\t" +
                 std::to_string(slot.box_id) + "\t" + std::to_string(slot.material_id);

--- a/src/slic3r/GUI/PrintHostDialogs.cpp
+++ b/src/slic3r/GUI/PrintHostDialogs.cpp
@@ -2047,10 +2047,20 @@ void CrealityPrintHostSendDialog::init()
             combo->SetSelection(default_sel);
             row_sizer->Add(combo, 0, wxALIGN_CENTER_VERTICAL);
 
+            auto* warn_label = new wxStaticText(this, wxID_ANY, _L("type mismatch"));
+            warn_label->SetFont(::Label::Body_12);
+            warn_label->SetForegroundColour(wxColour(255, 111, 0));
+            row_sizer->Add(warn_label, 0, wxALIGN_CENTER_VERTICAL | wxLEFT, FromDIP(8));
+            bool type_match = default_sel >= 0 && default_sel < (int)m_printer_slots.size() &&
+                              m_printer_slots[default_sel].type == gc_type;
+            warn_label->Show(!type_match);
+
             group_sizer->Add(row_sizer);
             group_sizer->AddSpacer(4);
             m_slot_combos.push_back(combo);
             m_combo_filament_idx.push_back(i);
+            m_warn_labels.push_back(warn_label);
+            m_gcode_types.push_back(gc_type);
         }
 
         int ext_slot_idx = -1;
@@ -2073,8 +2083,8 @@ void CrealityPrintHostSendDialog::init()
                 }
             }
 
-            for (auto* c : m_slot_combos) {
-                c->Bind(wxEVT_COMBOBOX, [this, ext_slot_idx](wxCommandEvent& e) {
+            for (int ci = 0; ci < (int)m_slot_combos.size(); ci++) {
+                m_slot_combos[ci]->Bind(wxEVT_COMBOBOX, [this, ci, ext_slot_idx](wxCommandEvent& e) {
                     int sel = e.GetSelection();
                     if (sel >= 0 && sel < (int)m_printer_slots.size() &&
                         m_printer_slots[sel].box_id == 0) {
@@ -2086,6 +2096,10 @@ void CrealityPrintHostSendDialog::init()
                         for (auto* c2 : m_slot_combos)
                             c2->Enable(true);
                     }
+                    bool match = sel >= 0 && sel < (int)m_printer_slots.size() &&
+                                 m_printer_slots[sel].type == m_gcode_types[ci];
+                    m_warn_labels[ci]->Show(!match);
+                    this->Layout();
                     e.Skip();
                 });
             }

--- a/src/slic3r/GUI/PrintHostDialogs.cpp
+++ b/src/slic3r/GUI/PrintHostDialogs.cpp
@@ -1884,8 +1884,17 @@ void CrealityPrintHostSendDialog::init()
         if (multi_color)
             printer_name = creality_host->model_name();
     }
-    if (!multi_color)
+    if (!multi_color) {
+        if (creality_host->model_query_failed()) {
+            auto* warn = new wxStaticText(this, wxID_ANY,
+                _L("Warning: could not detect printer model. Try reopening this dialog."));
+            warn->SetForegroundColour(wxColour(255, 111, 0));
+            content_sizer->Add(warn, 0, wxEXPAND | wxALL, FromDIP(5));
+            this->Layout();
+            this->Fit();
+        }
         return;
+    }
 
     auto* group_box = new wxStaticBox(this, wxID_ANY,
         wxString::Format(_L("Printer: %s"), printer_name));

--- a/src/slic3r/GUI/PrintHostDialogs.hpp
+++ b/src/slic3r/GUI/PrintHostDialogs.hpp
@@ -217,6 +217,7 @@ private:
     };
     std::vector<SlotInfo>   m_printer_slots;
     std::vector<BitmapComboBox*> m_slot_combos; // one per gcode filament
+    std::vector<int>        m_combo_filament_idx; // original gcode filament index for each combo
 };
 
 class FlashforgePrintHostSendDialog : public PrintHostSendDialog

--- a/src/slic3r/GUI/PrintHostDialogs.hpp
+++ b/src/slic3r/GUI/PrintHostDialogs.hpp
@@ -218,6 +218,8 @@ private:
     std::vector<SlotInfo>   m_printer_slots;
     std::vector<BitmapComboBox*> m_slot_combos; // one per gcode filament
     std::vector<int>        m_combo_filament_idx; // original gcode filament index for each combo
+    std::vector<wxStaticText*> m_warn_labels; // type mismatch warning per combo
+    std::vector<std::string> m_gcode_types;  // gcode filament type per combo
 };
 
 class FlashforgePrintHostSendDialog : public PrintHostSendDialog

--- a/src/slic3r/Utils/CrealityPrint.cpp
+++ b/src/slic3r/Utils/CrealityPrint.cpp
@@ -106,6 +106,7 @@ bool CrealityPrint::test(wxString& msg) const
                 }
             } catch (const json::exception& e) {
                 BOOST_LOG_TRIVIAL(warning) << boost::format("%1%: Failed to parse /info response: %2%") % name % e.what();
+                m_model_query_failed = true;
             }
         })
 #ifdef WIN32

--- a/src/slic3r/Utils/CrealityPrint.hpp
+++ b/src/slic3r/Utils/CrealityPrint.hpp
@@ -31,6 +31,7 @@ public:
     PrintHostPostUploadActions         get_post_upload_actions() const;
     bool upload(PrintHostUpload upload_data, ProgressFn prorgess_fn, ErrorFn error_fn, InfoFn info_fn) const override;
     bool supports_multi_color_print() const;
+    bool model_query_failed() const { return m_model_query_failed; }
     std::string query_boxes_info() const;
     std::string model_name() const;
 
@@ -48,6 +49,7 @@ private:
     std::string m_web_ui;
     bool        m_ssl_revoke_best_effort;
     mutable std::string m_model;
+    mutable bool        m_model_query_failed = false;
 
     std::string make_url(const std::string& path) const;
     bool start_print(wxString& msg, const std::string& filename, const std::map<std::string, std::string>& extended_info) const;


### PR DESCRIPTION
## CrealityPrint: filament mapping UI improvements for K2 Plus

### Summary

Follow-up to #13752 — incremental improvements to the CrealityPrint filament mapping dialog:

- **Hide unused filaments**: skip gcode filaments with no extruder assignment, so the mapping UI only shows filaments actually used in the print
- **Filter empty CFS slots**: exclude unloaded/inactive CFS slots from the dropdown, preventing accidental selection of empty positions
- **Warn on type mismatch**: show inline warning when the selected CFS slot's filament type doesn't match the gcode filament (e.g. PLA mapped to PETG slot)
- **Graceful /info fallback**: warn instead of crashing when the printer's `/info` endpoint returns non-JSON (e.g. HTML error page)

### Test plan

- [ ] Print with unused filament slots in gcode — verify they don't appear in mapping UI
- [ ] Print with partially loaded CFS — verify empty slots are hidden from dropdowns
- [ ] Map a PLA filament to a PETG slot — verify mismatch warning appears
- [ ] Test with printer returning non-JSON from /info — verify warning logged, no crash