### PR TITLE
Bug and PR Template enhancements

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -13,6 +13,13 @@ body:
         Before filing, please check if the issue already exists (either open or closed) by using the search bar on the issues page. If it does, comment there. Even if it's closed, we can reopen it based on your comment.
   - type: checkboxes
     attributes:
+      label: Is this issue reproducible in the latest nightly build?
+      description: Please verify this issue still happens in the latest nightly build first. It may already be fixed there: [Nightly builds](https://github.com/OrcaSlicer/OrcaSlicer/releases/tag/nightly-builds).
+      options:
+        - label: I have checked the latest nightly build and the issue is still reproducible
+          required: true
+  - type: checkboxes
+    attributes:
       label: Is there an existing issue for this problem?
       description: Please search to see if an issue already exists for the bug you encountered.
       options:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,3 +19,9 @@
 <!--
 > Please describe the tests that you have conducted to verify the changes made in this PR.
 -->
+
+<!--
+> A guide for users on how to download the artifacts from this PR.
+-->
+
+[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)


### PR DESCRIPTION
### Bug Template

Add a required checkbox to the bug report template prompting reporters to verify the issue is reproducible in the latest nightly build (links to the nightly builds release).
This helps catch issues already fixed in nightly releases and reduces duplicate reports.

### PR Template

Update the pull request template to include a commented section and a link to the OrcaSlicer wiki explaining how to download artifacts from a PR.