### PR TITLE
Fix support preview artifacts (missing layers)

### DIFF
--- a/src/libslic3r/Support/SupportMaterial.cpp
+++ b/src/libslic3r/Support/SupportMaterial.cpp
@@ -2882,8 +2882,9 @@ SupportGeneratorLayersPtr PrintObjectSupportMaterial::raft_and_intermediate_supp
                 intermediate_layers.push_back(&layer_new);
             }
         } else {
-            // Insert intermediate layers.
-            size_t        n_layers_extra = size_t(ceil(dist / m_slicing_params.max_suport_layer_height)); 
+            // ORCA: Bias by EPSILON so a gap effectively equal to
+            // max_suport_layer_height is not split by floating-point noise.
+            size_t n_layers_extra = size_t(ceil((dist - EPSILON) / m_slicing_params.max_suport_layer_height));
             assert(n_layers_extra > 0);
             coordf_t      step   = dist / coordf_t(n_layers_extra);
             if (extr1 != nullptr && extr1->layer_type == SupporLayerType::TopContact &&
@@ -2898,7 +2899,9 @@ SupportGeneratorLayersPtr PrintObjectSupportMaterial::raft_and_intermediate_supp
                 layer_new.height   = extr1->height;
                 intermediate_layers.push_back(&layer_new);
                 dist = extr2z - extr1z;
-                n_layers_extra = size_t(ceil(dist / m_slicing_params.max_suport_layer_height));
+                // ORCA: Recalculate with the same EPSILON bias after re-anchoring at the top
+                // contact layer so near-equal gaps do not gain an extra split here either.
+                n_layers_extra = size_t(ceil((dist - EPSILON) / m_slicing_params.max_suport_layer_height));
                 if (n_layers_extra == 0)
                     continue;
                 // Continue printing the other layers up to extr2z.

--- a/src/libslic3r/Support/TreeSupport.cpp
+++ b/src/libslic3r/Support/TreeSupport.cpp
@@ -1157,12 +1157,17 @@ void TreeSupport::create_tree_support_layers()
 
         // Layers between the raft contacts and bottom of the object.
         double dist_to_go = m_slicing_params.object_print_z_min - raft_print_z;
-        auto nsteps = int(ceil(dist_to_go / m_slicing_params.max_suport_layer_height));
-        double height = dist_to_go / nsteps;
-        for (int i = 0; i < nsteps; ++i) {
-            raft_print_z += height;
-            raft_slice_z = raft_print_z - height / 2;
-            m_object->add_tree_support_layer(layer_id++, height, raft_print_z, raft_slice_z);
+        // ORCA: Guard tiny residual raft-to-object gaps so the EPSILON-biased ceil()
+        // below cannot turn them into zero steps after floating-point accumulation.
+        if (dist_to_go > EPSILON) {
+            // ORCA: Bias by EPSILON so near-equal gaps do not get an extra split from FP noise.
+            auto nsteps = int(ceil((dist_to_go - EPSILON) / m_slicing_params.max_suport_layer_height));
+            double height = dist_to_go / nsteps;
+            for (int i = 0; i < nsteps; ++i) {
+                raft_print_z += height;
+                raft_slice_z = raft_print_z - height / 2;
+                m_object->add_tree_support_layer(layer_id++, height, raft_print_z, raft_slice_z);
+            }
         }
         m_raft_layers = layer_id;
     }

--- a/src/libslic3r/Support/TreeSupportCommon.hpp
+++ b/src/libslic3r/Support/TreeSupportCommon.hpp
@@ -343,7 +343,8 @@ public:
             }
             if (double dist_to_go = slicing_params.object_print_z_min - z; dist_to_go > EPSILON) {
                 // Layers between the raft contacts and bottom of the object.
-                auto nsteps = int(ceil(dist_to_go / slicing_params.max_suport_layer_height));
+                // ORCA: Bias by EPSILON so near-equal gaps do not get an extra split from FP noise.
+                auto nsteps = int(ceil((dist_to_go - EPSILON) / slicing_params.max_suport_layer_height));
                 double step = dist_to_go / nsteps;
                 for (int i = 0; i < nsteps; ++ i) {
                     z += step;


### PR DESCRIPTION
## Issue

Support generation could sometimes insert an **extra intermediate layer** even though the gap should fit exactly into a **single step**.

This was most noticeable when the **maximum support layer height was equal to the print layer height** (for example both at **0.2 mm**).

Instead of keeping one step, the gap could be split into two smaller ones. This resulted in **incorrect support layering** and, in some cases, **visible artifacts in preview**.

---

## Root cause

Support gap subdivision used:

    ceil(dist / max_suport_layer_height)

When `dist` was only **microscopically above the configured limit** due to floating-point accumulation, it could be treated as requiring an extra split.

Example:
- max_suport_layer_height = **0.2**
- dist ≈ **0.20000001**

This results in:

    ceil(1.00000005) = 2

instead of staying as a **single step**.

This could introduce **unnecessary extra support sublayers** and, in some cases, **visible low-Z artifacts in preview**.

This also explains why small changes avoided the issue:
- **0.2 → reproduces**
- **0.2001 → no issue**
- **0.1999 → no issue**

---

## Fix

Adjust the calculation so values that are **effectively equal to the configured maximum** are no longer split due to **floating-point inaccuracies**.

---

## Affected areas

- Normal supports
- Tree supports

---

## Testing

- Reproduced with **max support layer height = layer height (0.2 mm)**
- Verified the artifact is **no longer present**
- Confirmed **no change** for other values

---

## Screenshots

 - **Before:**

<img width="2466" height="922" alt="image" src="https://github.com/user-attachments/assets/8c5464fb-adfe-4494-a703-1ebe20008b26" />

<br><br>

- **After:**

<img width="2445" height="1014" alt="image" src="https://github.com/user-attachments/assets/6f4a1c99-0149-4f41-bc0c-3637e6746ab0" />

---

Fixes #12846