### PR TITLE
fix(preset): don't truncate child variant vectors to parent size on load

### DIFF
--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -9452,6 +9452,13 @@ void DynamicPrintConfig::update_non_diff_values_to_base_config(DynamicPrintConfi
                     //nothing to do, keep the original one
                 }
                 else {
+                    // Guard: set_with_restore is parent-shaped and would truncate the child's
+                    // vector when the child has more extruders than the parent (e.g. an IDEX
+                    // preset inheriting from a single-nozzle base). The child's saved value is
+                    // authoritative for its own extruder count, so skip the merge for this key.
+                    if (cur_variant_count > target_variant_count)
+                        continue;
+
                     int stride = 1;
                     if (key_set2.find(opt) != key_set2.end())
                         stride = 2;

--- a/tests/libslic3r/test_config.cpp
+++ b/tests/libslic3r/test_config.cpp
@@ -265,6 +265,56 @@ SCENARIO("DynamicPrintConfig serialization", "[Config]") {
     }
 }
 
+SCENARIO("update_non_diff_values_to_base_config preserves child vectors when child has more extruders than parent",
+         "[Config][Variant]") {
+    GIVEN("A 2-extruder child printer config inheriting from a 1-extruder parent") {
+        Slic3r::DynamicPrintConfig child;
+        Slic3r::DynamicPrintConfig parent;
+
+        child.set_key_value("nozzle_diameter",           new Slic3r::ConfigOptionFloats({0.4, 0.4}));
+        child.set_key_value("printer_extruder_id",       new Slic3r::ConfigOptionInts({1, 2}));
+        child.set_key_value("printer_extruder_variant",  new Slic3r::ConfigOptionStrings({"Direct Drive Standard", "Direct Drive Standard"}));
+        child.set_key_value("retraction_length",         new Slic3r::ConfigOptionFloats({1.5, 1.5}));
+
+        parent.set_key_value("nozzle_diameter",          new Slic3r::ConfigOptionFloats({0.4}));
+        parent.set_key_value("printer_extruder_id",      new Slic3r::ConfigOptionInts({1}));
+        parent.set_key_value("printer_extruder_variant", new Slic3r::ConfigOptionStrings({"Direct Drive Standard"}));
+        parent.set_key_value("retraction_length",        new Slic3r::ConfigOptionFloats({0.8}));
+
+        const Slic3r::t_config_option_keys keys = {
+            "retraction_length", "printer_extruder_id", "printer_extruder_variant"
+        };
+        const std::set<std::string> different_keys = {
+            "retraction_length", "printer_extruder_id", "printer_extruder_variant"
+        };
+
+        WHEN("update_non_diff_values_to_base_config is called") {
+            std::string id_name  = "printer_extruder_id";
+            std::string var_name = "printer_extruder_variant";
+            child.update_non_diff_values_to_base_config(
+                parent, keys, different_keys, id_name, var_name,
+                Slic3r::printer_options_with_variant_1,
+                Slic3r::printer_options_with_variant_2);
+
+            THEN("printer_extruder_id retains size 2") {
+                REQUIRE(child.option<Slic3r::ConfigOptionInts>("printer_extruder_id")->values.size() == 2);
+            }
+            THEN("printer_extruder_variant retains size 2") {
+                REQUIRE(child.option<Slic3r::ConfigOptionStrings>("printer_extruder_variant")->values.size() == 2);
+            }
+            THEN("retraction_length retains size 2") {
+                REQUIRE(child.option<Slic3r::ConfigOptionFloats>("retraction_length")->values.size() == 2);
+            }
+            THEN("printer_extruder_id values are preserved for both extruders") {
+                auto* pe_id = child.option<Slic3r::ConfigOptionInts>("printer_extruder_id");
+                REQUIRE(pe_id->values.size() == 2);
+                REQUIRE(pe_id->values[0] == 1);
+                REQUIRE(pe_id->values[1] == 2);
+            }
+        }
+    }
+}
+
 // SCENARIO("DynamicPrintConfig JSON serialization", "[Config]") {
 //     WHEN("DynamicPrintConfig is serialized and deserialized") {
 // 	auto now = std::chrono::high_resolution_clock::now();


### PR DESCRIPTION
# PR: fix(preset): don't truncate child variant vectors to parent size on project load

Fixes #12085.

## Summary

When a printer preset has more extruders than the preset it inherits from (for example, a user-made 2-extruder profile duplicated from a single-nozzle base), saving a project and then reopening it silently drops every per-extruder setting for extruders beyond the parent's count. `printer_extruder_id`, `printer_extruder_variant`, `nozzle_type`, retraction, wipe, z-hop, etc. are all truncated to size 1 on load. The `.3mf` on disk is fine — corruption happens purely during project load.

The visible consequences are exactly what #12085 reports: only one filament/toolhead is selectable for the extra extruders, and the printer preset carries a dirty asterisk that never clears.

## The fix

Seven lines in `DynamicPrintConfig::update_non_diff_values_to_base_config` (`src/libslic3r/PrintConfig.cpp`). Skip the parent-shaped merge when the child has more extruders than the parent — the child's saved value is already authoritative for its own extruder count:

```diff
                 else {
+                    // Guard: set_with_restore is parent-shaped and would truncate the child's
+                    // vector when the child has more extruders than the parent (e.g. a multi-
+                    // extruder preset inheriting from a single-nozzle base). The child's saved
+                    // value is authoritative for its own extruder count, so skip the merge for
+                    // this key.
+                    if (cur_variant_count > target_variant_count)
+                        continue;
+
                     int stride = 1;
                     if (key_set2.find(opt) != key_set2.end())
                         stride = 2;
```

No behavior change for the child ≤ parent path. Both callers (`Preset.cpp:2107` and `Preset.cpp:2117`) are covered because the fix lives inside the callee.

## Root cause

`update_non_diff_values_to_base_config` sizes `variant_index` to the **parent's** extruder count:

```cpp
int cur_variant_count    = cur_extruder_variants.size();      // child
int target_variant_count = target_extruder_variants.size();   // parent

variant_index.resize(target_variant_count, -1);
```

It then calls `ConfigOptionVector::set_with_restore`, which replaces the child's vector wholesale with the parent's:

```cpp
virtual void set_with_restore(const ConfigOptionVectorBase* rhs,
                              std::vector<int>& restore_index, int stride) override {
    std::vector<T> backup_values = this->values;
    auto other = static_cast<const ConfigOptionVector<T>*>(rhs);
    this->values = other->values;   // <-- child now parent-sized

    if (other->values.size() != (restore_index.size()*stride))
        throw ConfigurationError(...);

    for (size_t i = 0; i < restore_index.size(); i++) {
        if (restore_index[i] != -1) {
            for (size_t j = 0; j < stride; j++)
                this->values[i * stride + j] = backup_values[restore_index[i] * stride + j];
        }
    }
}
```

Result is always parent-sized. When the child is wider than the parent, the child's entries beyond the parent's count are silently destroyed. Diff against the installed preset (still correctly sized) then flags those keys as modified, yielding the permanent dirty-asterisk.

The function was designed for the reverse case — a child with **fewer** variants than its parent (e.g. legacy presets saved against multi-variant systems) — where the parent-shaped restore is correct. It simply wasn't written with child > parent in mind.

## Reproduction

1. Duplicate a single-nozzle system printer preset (any `nozzle_diameter: ["0.4"]` profile).
2. Bump the extruder count to 2 in the printer editor. Leave `single_extruder_multi_material` at 0. Save.
3. Create a project with that printer, drop a model on the plate, save as `.3mf`.
4. Close and reopen the `.3mf`.

**Expected:** project reopens exactly as saved.

**Actual:** printer preset shows a dirty asterisk that never clears, per-extruder settings for extruder 2 are dropped. Inspecting `Metadata/project_settings.config` inside the `.3mf` confirms on-disk data is correct — the corruption is on load.

Not multi-material- or parallel-print-specific. Affects any preset where child extruder count > parent (inherits-target) count.

## Verification

Instrumented the resize site with an `INFO` log. Before the fix, reloading a repro `.3mf` emitted 24 truncation lines (one per variant-keyed option in `different_settings_list`):

```
update_non_diff_values_to_base_config DIAG key=printer_extruder_id
    child_size=2 parent_size=1 restore_n=1 expected=1
    cur_variants=2 target_variants=1 [TRUNCATING]
... (23 more keys)
```

After the fix: zero truncation lines, `profile_print_params_same` reports no diff on reload, printer preset is clean.

## Context — #12009

#12009 (merged, Jan 2026) addressed the same symptom at the profile layer: it changed the `inherits` field on seven Ratrig IDEX process profiles from `fdm_process_ratrig_common` (single-nozzle base) to `fdm_process_ratrig_idex` (2-nozzle base), sidestepping the bug by ensuring child extruder count never exceeds parent. The author noted the change was speculative ("I only asked copilot about it, so not tested if that is the reason").

That workaround patched Ratrig specifically; any other multi-extruder profile inheriting from a single-nozzle base still hits the same trap. This PR fixes the root cause — if desired the Ratrig profiles could be reverted to their original inheritance, though there's no need to.

## Related downstream work

This fix is already carried on an in-development feature branch where it also resolves a secondary rendering symptom produced by additional per-tool state that branch introduces. That branch is expected to be in review for some time, so submitting this small, self-contained fix independently makes sense — the data-corruption and dirty-asterisk behavior affect multi-extruder preset users today, with no dependency on the feature branch.

---

**File touched:** `src/libslic3r/PrintConfig.cpp` — single function. No test changes (happy to add a regression test if requested).
