### PR TITLE
Fix extrusion of some support layers at wrong Z height

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -6199,11 +6199,13 @@ std::string GCode::_extrude(const ExtrusionPath &path, std::string description, 
             "move to first " + description + " point",
             sloped == nullptr ? DBL_MAX : get_sloped_z(sloped->slope_begin.z_ratio)
         );
-        m_need_change_layer_lift_z = false;
         // Orca: ensure Z matches planned layer height
-        if (_last_pos_undefined && !slope_need_z_travel) {
-            gcode += this->writer().travel_to_z(m_nominal_z, "ensure Z matches planned layer height", true);
+        if (!slope_need_z_travel && (_last_pos_undefined || m_need_change_layer_lift_z)) {
+            const std::string z_sync_comment = _last_pos_undefined ?
+                "ensure Z matches planned layer height" : ""; // no comment for normal layer-Z lift
+            gcode += this->writer().travel_to_z(m_nominal_z, z_sync_comment, true);
         }
+        m_need_change_layer_lift_z = false;
     }
 
 


### PR DESCRIPTION
## Issue

In some **rare cases with supports**, Orca could create **two support layers right after each other** where the next layer started exactly where the previous one ended.

When this happened, the printer could start **extruding the new layer before moving to the correct height**, effectively causing a **missing printed support layer**.

## Cause

Orca keeps track of when it needs to move to the next layer height.

In this situation, that information was **cleared too early**, so Orca “forgot” it still needed to move up before starting the next layer.

This usually didn’t cause problems, because most layer changes include a move that naturally updates the height first.

But in certain support setups, there was **no such move**, so the extrusion of the new layer could happen at the **previous height**.

## Impact

This could lead to **missing support layers**, **incorrectly placed support material**, or **reduced print quality**. In worst cases, the support may fail, which can result in a **failed print**.

## Fix

Make sure Orca always **moves to the correct height before the first extrusion of a new layer**, if that move is still pending.

## Result

The extrusion of **every layer now always happens at the correct height**.

This fixes the **missing / incorrect support layers** seen in those edge cases.

---

## Screenshots
- **Before:**
<img width="1836" height="548" alt="image" src="https://github.com/user-attachments/assets/5c392be6-ee6d-4e20-83be-e573ec768208" />

<br><br>

- **After:**
<img width="1850" height="552" alt="image" src="https://github.com/user-attachments/assets/0871c52a-4221-4317-8e4c-2f13aca188c5" />
