### PR TITLE
Fix: Globally fixing the "milisecond" typo in the code

### DIFF
--- a/src/libslic3r/Timer.hpp
+++ b/src/libslic3r/Timer.hpp
@@ -71,8 +71,8 @@ namespace Timing {
         static TimeLimitAlarm new_nanos(uint64_t time_limit_nanoseconds, std::string_view limit_exceeded_message) {
             return TimeLimitAlarm(time_limit_nanoseconds, limit_exceeded_message);
         }
-        static TimeLimitAlarm new_milis(uint64_t time_limit_milis, std::string_view limit_exceeded_message) {
-            return TimeLimitAlarm(uint64_t(time_limit_milis) * 1000000l, limit_exceeded_message);
+        static TimeLimitAlarm new_millis(uint64_t time_limit_millis, std::string_view limit_exceeded_message) {
+            return TimeLimitAlarm(uint64_t(time_limit_millis) * 1000000l, limit_exceeded_message);
         }
         static TimeLimitAlarm new_seconds(uint64_t time_limit_seconds, std::string_view limit_exceeded_message) {
             return TimeLimitAlarm(uint64_t(time_limit_seconds) * 1000000000l, limit_exceeded_message);

--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -3993,14 +3993,14 @@ void GLCanvas3D::on_set_color_timer(wxTimerEvent& evt)
 }
 
 
-void GLCanvas3D::schedule_extra_frame(int miliseconds)
+void GLCanvas3D::schedule_extra_frame(int milliseconds)
 {
     // Schedule idle event right now
-    if (miliseconds == 0)
+    if (milliseconds == 0)
     {
         // We want to wakeup idle evnt but most likely this is call inside render cycle so we need to wait
         if (m_in_render)
-            miliseconds = 33;
+            milliseconds = 33;
         else {
             m_dirty = true;
             wxWakeUpIdle();
@@ -4010,12 +4010,12 @@ void GLCanvas3D::schedule_extra_frame(int miliseconds)
     int remaining_time = m_render_timer.GetInterval();
     // Timer is not running
     if (!m_render_timer.IsRunning()) {
-        m_render_timer.StartOnce(miliseconds);
+        m_render_timer.StartOnce(milliseconds);
     // Timer is running - restart only if new period is shorter than remaning period
     } else {
-        if (miliseconds + 20 < remaining_time) {
+        if (milliseconds + 20 < remaining_time) {
             m_render_timer.Stop();
-            m_render_timer.StartOnce(miliseconds);
+            m_render_timer.StartOnce(milliseconds);
         }
     }
 }

--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -3998,7 +3998,7 @@ void GLCanvas3D::schedule_extra_frame(int milliseconds)
     // Schedule idle event right now
     if (milliseconds == 0)
     {
-        // We want to wakeup idle evnt but most likely this is call inside render cycle so we need to wait
+        // We want to wakeup idle event but most likely this is call inside render cycle so we need to wait
         if (m_in_render)
             milliseconds = 33;
         else {
@@ -4011,7 +4011,7 @@ void GLCanvas3D::schedule_extra_frame(int milliseconds)
     // Timer is not running
     if (!m_render_timer.IsRunning()) {
         m_render_timer.StartOnce(milliseconds);
-    // Timer is running - restart only if new period is shorter than remaning period
+    // Timer is running - restart only if new period is shorter than remaining period
     } else {
         if (milliseconds + 20 < remaining_time) {
             m_render_timer.Stop();

--- a/src/slic3r/GUI/GLCanvas3D.hpp
+++ b/src/slic3r/GUI/GLCanvas3D.hpp
@@ -1114,7 +1114,7 @@ public:
 
     void request_extra_frame() { m_extra_frame_requested = true; }
 
-    void schedule_extra_frame(int miliseconds);
+    void schedule_extra_frame(int milliseconds);
 
     int get_main_toolbar_item_id(const std::string& name) const { return m_main_toolbar.get_item_id(name); }
     void force_main_toolbar_left_action(int item_id) { m_main_toolbar.force_left_action(item_id, *this); }

--- a/src/slic3r/GUI/NotificationManager.cpp
+++ b/src/slic3r/GUI/NotificationManager.cpp
@@ -32,7 +32,7 @@
 static constexpr float GAP_WIDTH = 10.0f;
 static constexpr float SPACE_RIGHT_PANEL = 10.0f;
 static constexpr float FADING_OUT_DURATION = 2.0f;
-// Time in Miliseconds after next render when fading out is requested
+// Time in Milliseconds after next render when fading out is requested
 static constexpr int   FADING_OUT_TIMEOUT = 100;
 
 namespace Slic3r {

--- a/src/slic3r/Utils/EmbossStyleManager.cpp
+++ b/src/slic3r/Utils/EmbossStyleManager.cpp
@@ -401,7 +401,7 @@ void StyleManager::init_style_images(const Vec2i32 &max_size,
     auto mf = wxGetApp().mainframe;
     // dot per inch for monitor
     int dpi = get_dpi_for_window(mf);
-    // pixel per milimeter
+    // pixel per millimeter
     double ppm = dpi / GizmoObjectManipulation::in_to_mm;
 
     auto &worker = wxGetApp().plater()->get_ui_job_worker();

--- a/src/slic3r/Utils/EmbossStyleManager.hpp
+++ b/src/slic3r/Utils/EmbossStyleManager.hpp
@@ -309,7 +309,7 @@ private:
         // place to store result in main thread in Finalize
         std::shared_ptr<StyleImages> result;
                 
-        // pixel per milimeter (scaled DPI)
+        // pixel per millimeter (scaled DPI)
         double ppm;
     };
     std::shared_ptr<StyleImagesData::StyleImages> m_temp_style_images = nullptr;


### PR DESCRIPTION
# Description
Fixing a typo in the code: `milisecond` to `millisecond`.