### PR TITLE
Fix fan stuck at wrong speed

### DIFF
--- a/src/libslic3r/GCode/FanMover.cpp
+++ b/src/libslic3r/GCode/FanMover.cpp
@@ -33,7 +33,11 @@ const std::string& FanMover::process_gcode(const std::string& gcode, bool flush)
 
     if (flush) {
         while (!m_buffer.empty()) {
-            m_process_output += m_buffer.front().raw + "\n";
+            BufferData &front = m_buffer.front();
+            m_process_output += front.raw + "\n";
+            // Orca: Keep the emitted fan state in sync when flushing buffered fan commands.
+            if (front.fan_speed >= 0)
+                m_front_buffer_fan_speed = front.fan_speed;
             remove_from_buffer(m_buffer.begin());
         }
     }


### PR DESCRIPTION
## The bug

With **fan speed-up time** enabled, the fan could stay stuck at a **higher speed longer than intended**.

This was most noticeable after layers ending with **role-based fan overrides**, especially with <**Only overhangs**> enabled. For example, a bridge could raise the fan to 90%, and the following layers would incorrectly continue using that speed.

## Cause of it

When a layer ended with a **role-driven fan change**, Orca could **lose track of that final fan speed**.

As a result, the next layer started from the wrong fan state and stood that way.

## The fix

Ensure Orca always keeps track of the **actual fan speed it outputs**.

## Result

Fan speed now correctly returns to the expected value and no longer stays **stuck at a previous speed** after role-based overrides.

## Screenshots

> Note: colors represent the fan speed

- **Before:**
<img width="1929" height="639" alt="image" src="https://github.com/user-attachments/assets/3f49eef6-228b-41e9-9c18-8bee2b21e443" />

<br><br>

- **After:**
<img width="1974" height="643" alt="image" src="https://github.com/user-attachments/assets/17d368f3-c913-4276-8892-7b3a695a5d50" />
