### PR TITLE
Fix bug template: Wrap nightly build link in bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -14,7 +14,9 @@ body:
   - type: checkboxes
     attributes:
       label: Is this issue reproducible in the latest nightly build?
-      description: Please verify this issue still happens in the latest nightly build first. It may already be fixed there: [Nightly builds](https://github.com/OrcaSlicer/OrcaSlicer/releases/tag/nightly-builds).
+      description: >
+        Please verify this issue still happens in the latest nightly build first. It may already be fixed there:
+        [Nightly builds](https://github.com/OrcaSlicer/OrcaSlicer/releases/tag/nightly-builds).
       options:
         - label: I have checked the latest nightly build and the issue is still reproducible
           required: true


### PR DESCRIPTION
Change the 'Is this issue reproducible...' description to a YAML folded scalar (>) so the long line is wrapped and the Nightly builds link is placed on its own line. This improves readability of the issue template without altering its options or behavior.