### PR TITLE
Restructure Painting Tool UI Hierarchy - Follow Up

### DIFF
--- a/localization/i18n/OrcaSlicer.pot
+++ b/localization/i18n/OrcaSlicer.pot
@@ -162,7 +162,7 @@ msgstr ""
 msgid "Smart fill angle"
 msgstr ""
 
-msgid "On overhangs only"
+msgid "On highlighted overhangs only"
 msgstr ""
 
 msgid "Auto support threshold angle: "

--- a/localization/i18n/ca/OrcaSlicer_ca.po
+++ b/localization/i18n/ca/OrcaSlicer_ca.po
@@ -177,8 +177,8 @@ msgstr "Tipus d'eina"
 msgid "Smart fill angle"
 msgstr "Angle de farciment intel·ligent"
 
-msgid "On overhangs only"
-msgstr "Només als voladissos"
+msgid "On highlighted overhangs only"
+msgstr "Només als voladissos ressaltats"
 
 msgid "Auto support threshold angle: "
 msgstr "Angle llindar de suport automàtic: "

--- a/localization/i18n/cs/OrcaSlicer_cs.po
+++ b/localization/i18n/cs/OrcaSlicer_cs.po
@@ -170,8 +170,8 @@ msgstr "Typ nástroje"
 msgid "Smart fill angle"
 msgstr "Úhel chytrého vyplnění"
 
-msgid "On overhangs only"
-msgstr "Pouze na převisy"
+msgid "On highlighted overhangs only"
+msgstr "Pouze na zvýrazněné převisy"
 
 msgid "Auto support threshold angle: "
 msgstr "Automatický prahový úhel podpěr: "

--- a/localization/i18n/de/OrcaSlicer_de.po
+++ b/localization/i18n/de/OrcaSlicer_de.po
@@ -172,8 +172,8 @@ msgstr "Werkzeugtyp"
 msgid "Smart fill angle"
 msgstr "Intelligenter Füllwinkel"
 
-msgid "On overhangs only"
-msgstr "Nur an Überhängen"
+msgid "On highlighted overhangs only"
+msgstr "Nur an hervorgehobenen Überhängen"
 
 msgid "Auto support threshold angle: "
 msgstr "Winkel für automatische Supports: "

--- a/localization/i18n/en/OrcaSlicer_en.po
+++ b/localization/i18n/en/OrcaSlicer_en.po
@@ -158,7 +158,7 @@ msgstr ""
 msgid "Smart fill angle"
 msgstr ""
 
-msgid "On overhangs only"
+msgid "On highlighted overhangs only"
 msgstr ""
 
 msgid "Auto support threshold angle: "

--- a/localization/i18n/es/OrcaSlicer_es.po
+++ b/localization/i18n/es/OrcaSlicer_es.po
@@ -172,8 +172,8 @@ msgstr "Tipo de herramienta"
 msgid "Smart fill angle"
 msgstr "Ángulo de relleno en puente"
 
-msgid "On overhangs only"
-msgstr "Solo en voladizos"
+msgid "On highlighted overhangs only"
+msgstr "Solo en voladizos resaltados"
 
 msgid "Auto support threshold angle: "
 msgstr "Ángulo del umbral de soporte automático: "

--- a/localization/i18n/fr/OrcaSlicer_fr.po
+++ b/localization/i18n/fr/OrcaSlicer_fr.po
@@ -176,8 +176,8 @@ msgstr "Type d'outil"
 msgid "Smart fill angle"
 msgstr "Angle de remplissage intelligent"
 
-msgid "On overhangs only"
-msgstr "Sur les surplombs uniquement"
+msgid "On highlighted overhangs only"
+msgstr "Uniquement sur les surplombs mis en évidence"
 
 msgid "Auto support threshold angle: "
 msgstr "Angle de seuil de support automatique : "

--- a/localization/i18n/hu/OrcaSlicer_hu.po
+++ b/localization/i18n/hu/OrcaSlicer_hu.po
@@ -169,8 +169,8 @@ msgstr "Eszköz típusa"
 msgid "Smart fill angle"
 msgstr "Okos kitöltési szög"
 
-msgid "On overhangs only"
-msgstr "Csak túlnyúlásokon"
+msgid "On highlighted overhangs only"
+msgstr "Csak a kiemelt túlnyúlásokon"
 
 msgid "Auto support threshold angle: "
 msgstr "Automatikus támasz szögének határértéke: "

--- a/localization/i18n/it/OrcaSlicer_it.po
+++ b/localization/i18n/it/OrcaSlicer_it.po
@@ -172,8 +172,8 @@ msgstr "Tipo di strumento"
 msgid "Smart fill angle"
 msgstr "Angolo di riempimento intelligente"
 
-msgid "On overhangs only"
-msgstr "Solo sulle sporgenze"
+msgid "On highlighted overhangs only"
+msgstr "Solo sulle sporgenze evidenziate"
 
 msgid "Auto support threshold angle: "
 msgstr "Angolo di soglia per supporto automatico: "

--- a/localization/i18n/ja/OrcaSlicer_ja.po
+++ b/localization/i18n/ja/OrcaSlicer_ja.po
@@ -171,8 +171,8 @@ msgstr "ツールタイプ"
 msgid "Smart fill angle"
 msgstr "自動充填角度"
 
-msgid "On overhangs only"
-msgstr "オーバーハングのみ"
+msgid "On highlighted overhangs only"
+msgstr "強調表示されたオーバーハングのみ"
 
 msgid "Auto support threshold angle: "
 msgstr "自動サポート角度閾値"

--- a/localization/i18n/ko/OrcaSlicer_ko.po
+++ b/localization/i18n/ko/OrcaSlicer_ko.po
@@ -173,8 +173,8 @@ msgstr "도구 유형"
 msgid "Smart fill angle"
 msgstr "스마트 채우기 각도"
 
-msgid "On overhangs only"
-msgstr "오버행에만 칠하기"
+msgid "On highlighted overhangs only"
+msgstr "강조된 오버행에만 칠하기"
 
 msgid "Auto support threshold angle: "
 msgstr "자동 서포트 임계값 각도: "

--- a/localization/i18n/lt/OrcaSlicer_lt.po
+++ b/localization/i18n/lt/OrcaSlicer_lt.po
@@ -172,8 +172,8 @@ msgstr "Įrankio tipas"
 msgid "Smart fill angle"
 msgstr "Išmanaus užpildymo kampas"
 
-msgid "On overhangs only"
-msgstr "Tik kabantiems"
+msgid "On highlighted overhangs only"
+msgstr "Tik paryškintiems kabantiems"
 
 msgid "Auto support threshold angle: "
 msgstr "Automatinių atramų generavimo kampas: "

--- a/localization/i18n/nl/OrcaSlicer_nl.po
+++ b/localization/i18n/nl/OrcaSlicer_nl.po
@@ -166,8 +166,8 @@ msgstr "Hulpmiddel type"
 msgid "Smart fill angle"
 msgstr "Slim vullen hoek"
 
-msgid "On overhangs only"
-msgstr "Alleen op overhangen"
+msgid "On highlighted overhangs only"
+msgstr "Alleen op gemarkeerde overhangen"
 
 msgid "Auto support threshold angle: "
 msgstr "Maximale hoek automatische ondersteuning: "

--- a/localization/i18n/pl/OrcaSlicer_pl.po
+++ b/localization/i18n/pl/OrcaSlicer_pl.po
@@ -164,8 +164,8 @@ msgstr "Typ narzędzia"
 msgid "Smart fill angle"
 msgstr "Kąt inteligentnego wypełniania"
 
-msgid "On overhangs only"
-msgstr "Tylko na nawisach"
+msgid "On highlighted overhangs only"
+msgstr "Tylko na podświetlonych nawisach"
 
 msgid "Auto support threshold angle: "
 msgstr "Automatyczny kąt progowy podpory: "

--- a/localization/i18n/pt_BR/OrcaSlicer_pt_BR.po
+++ b/localization/i18n/pt_BR/OrcaSlicer_pt_BR.po
@@ -178,8 +178,8 @@ msgstr "Tipo de ferramenta"
 msgid "Smart fill angle"
 msgstr "Ângulo de preenchimento inteligente"
 
-msgid "On overhangs only"
-msgstr "Apenas em saliências"
+msgid "On highlighted overhangs only"
+msgstr "Apenas em saliências destacadas"
 
 msgid "Auto support threshold angle: "
 msgstr "Ângulo limiar de suporte automático: "

--- a/localization/i18n/ru/OrcaSlicer_ru.po
+++ b/localization/i18n/ru/OrcaSlicer_ru.po
@@ -185,8 +185,8 @@ msgstr "Инструмент"
 msgid "Smart fill angle"
 msgstr "Угол для умной заливки"
 
-msgid "On overhangs only"
-msgstr "Только на нависаниях"
+msgid "On highlighted overhangs only"
+msgstr "Только на подсвеченных нависаниях"
 
 msgid "Auto support threshold angle: "
 msgstr "Пороговый угол автоподдержки: "

--- a/localization/i18n/sv/OrcaSlicer_sv.po
+++ b/localization/i18n/sv/OrcaSlicer_sv.po
@@ -163,8 +163,8 @@ msgstr "Verktygs typ"
 msgid "Smart fill angle"
 msgstr "Smart fyllningsvinkel"
 
-msgid "On overhangs only"
-msgstr "Endast på överhäng"
+msgid "On highlighted overhangs only"
+msgstr "Endast på markerade överhäng"
 
 msgid "Auto support threshold angle: "
 msgstr "Automatisk support tröskelsvinkel: "

--- a/localization/i18n/tr/OrcaSlicer_tr.po
+++ b/localization/i18n/tr/OrcaSlicer_tr.po
@@ -157,8 +157,8 @@ msgstr "Araç türü"
 msgid "Smart fill angle"
 msgstr "Akıllı doldurma açısı"
 
-msgid "On overhangs only"
-msgstr "Yalnızca çıkıntılarda"
+msgid "On highlighted overhangs only"
+msgstr "Yalnızca vurgulanan çıkıntılarda"
 
 msgid "Auto support threshold angle: "
 msgstr "Otomatik destek eşik açısı: "

--- a/localization/i18n/uk/OrcaSlicer_uk.po
+++ b/localization/i18n/uk/OrcaSlicer_uk.po
@@ -168,8 +168,8 @@ msgstr "Тип інструменту"
 msgid "Smart fill angle"
 msgstr "Кут розумного заповнення"
 
-msgid "On overhangs only"
-msgstr "Тільки на нависаннях"
+msgid "On highlighted overhangs only"
+msgstr "Тільки на підсвічених нависанняхх"
 
 msgid "Auto support threshold angle: "
 msgstr "Поріг кута автоматичної підтримки: "

--- a/localization/i18n/vi/OrcaSlicer_vi.po
+++ b/localization/i18n/vi/OrcaSlicer_vi.po
@@ -167,8 +167,8 @@ msgstr "Loại công cụ"
 msgid "Smart fill angle"
 msgstr "Góc tô thông minh"
 
-msgid "On overhangs only"
-msgstr "Chỉ trên overhang"
+msgid "On highlighted overhangs only"
+msgstr "Chỉ trên các overhang được làm nổi bật"
 
 msgid "Auto support threshold angle: "
 msgstr "Góc ngưỡng tự động support: "

--- a/localization/i18n/zh_CN/OrcaSlicer_zh_CN.po
+++ b/localization/i18n/zh_CN/OrcaSlicer_zh_CN.po
@@ -161,8 +161,8 @@ msgstr "工具类型"
 msgid "Smart fill angle"
 msgstr "智能填充角度"
 
-msgid "On overhangs only"
-msgstr "仅对悬垂区生效"
+msgid "On highlighted overhangs only"
+msgstr "仅对高亮悬垂区生效"
 
 msgid "Auto support threshold angle: "
 msgstr "自动支撑角度阈值："

--- a/localization/i18n/zh_TW/OrcaSlicer_zh_TW.po
+++ b/localization/i18n/zh_TW/OrcaSlicer_zh_TW.po
@@ -166,8 +166,8 @@ msgstr "筆刷類型"
 msgid "Smart fill angle"
 msgstr "智慧填充角度"
 
-msgid "On overhangs only"
-msgstr "僅對懸空區生效"
+msgid "On highlighted overhangs only"
+msgstr "僅對高亮懸空區生效"
 
 msgid "Auto support threshold angle: "
 msgstr "自動支撐角度臨界值："

--- a/src/slic3r/GUI/Gizmos/GLGizmoFdmSupports.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoFdmSupports.cpp
@@ -81,14 +81,14 @@ bool GLGizmoFdmSupports::on_init()
     m_shortcut_key = WXK_CONTROL_L;
 
     m_desc["perform"]            = _L("Perform");
-    m_desc["on_overhangs_only"]  = _L("On overhangs only");
+    m_desc["on_overhangs_only"]  = _L("On highlighted overhangs only");
     m_desc["remove_all"]         = _L("Erase all painting");
     m_desc["highlight_by_angle"] = _L("Highlight overhang areas");
     m_desc["tool_type"]          = _L("Tool type");
     m_desc["gap_fill"]           = _L("Gap fill");
     m_desc["reset_direction"]    = _L("Reset direction");
     m_desc["clipping_of_view"]   = _L("Section view");
-    m_desc["cursor_size"]        = _L("Pen size");
+    m_desc["cursor_size"]        = _L("Brush size");
     m_desc["smart_fill_angle"]   = _L("Smart fill angle");
     m_desc["gap_area"]           = _L("Gap area");
 
@@ -360,6 +360,12 @@ void GLGizmoFdmSupports::on_render_input_window(float x, float y, float bottom_l
         ImGui::BBLDragFloat("##gap_area_input", &TriangleSelectorPatch::gap_area, 0.05f, 0.0f, 0.0f, "%.2f");
     }
 
+     m_imgui->bbl_checkbox(m_desc["on_overhangs_only"], m_paint_on_overhangs_only);
+    if (ImGui::IsItemHovered())
+        m_imgui->tooltip(format_wxstr(_L("Allows painting only on facets selected by: \"%1%\""), m_desc["highlight_by_angle"]),
+                         max_tooltip_width);
+
+
     ImGui::Separator();
     float position_before_text_y = ImGui::GetCursorPos().y;
     ImGui::AlignTextToFramePadding();
@@ -397,11 +403,6 @@ void GLGizmoFdmSupports::on_render_input_window(float x, float y, float bottom_l
     ImGui::SameLine(drag_left_width + sliders_left_width);
     ImGui::PushItemWidth(1.5 * slider_icon_width);
     ImGui::BBLDragFloat("##angle_threshold_deg_input", &m_highlight_by_angle_threshold_deg, 0.05f, 0.0f, 0.0f, "%.2f");
-
-    m_imgui->bbl_checkbox(m_desc["on_overhangs_only"], m_paint_on_overhangs_only);
-    if (ImGui::IsItemHovered())
-        m_imgui->tooltip(format_wxstr(_L("Allows painting only on facets selected by: \"%1%\""), m_desc["highlight_by_angle"]),
-                         max_tooltip_width);
 
     ImGui::Separator();
     if (m_c->object_clipper()->get_position() == 0.f) {

--- a/src/slic3r/GUI/Gizmos/GLGizmoFuzzySkin.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoFuzzySkin.cpp
@@ -45,7 +45,7 @@ bool GLGizmoFuzzySkin::on_init()
     m_desc["tool_brush"]        = _L("Brush");
     m_desc["tool_smart_fill"]   = _L("Smart fill");
     m_desc["clipping_of_view"]  = _L("Section view");
-    m_desc["cursor_size"]       = _L("Pen size");
+    m_desc["cursor_size"]       = _L("Brush size");
     m_desc["add_fuzzy_skin"]    = _L("Add fuzzy skin");
     m_desc["remove_fuzzy_skin"] = _L("Remove fuzzy skin");
     m_desc["smart_fill_angle"]  = _L("Smart fill angle");

--- a/src/slic3r/GUI/Gizmos/GLGizmoMmuSegmentation.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoMmuSegmentation.cpp
@@ -95,8 +95,8 @@ bool GLGizmoMmuSegmentation::on_init()
 
     m_desc["clipping_of_view"] = _L("Section view");
     m_desc["reset_direction"]  = _L("Reset direction");
-    m_desc["cursor_size"]      = _L("Pen size");
-    m_desc["cursor_type"]      = _L("Pen shape");
+    m_desc["cursor_size"]      = _L("Brush size");
+    m_desc["cursor_type"]      = _L("Brush shape");
     m_desc["paint"]            = _L("Paint");
     m_desc["erase"]            = _L("Erase");
     m_desc["shortcut_key"]     = _L("Choose filament");

--- a/src/slic3r/GUI/Gizmos/GLGizmoSeam.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoSeam.cpp
@@ -36,7 +36,7 @@ bool GLGizmoSeam::on_init()
 
     m_desc["clipping_of_view"] = _L("Section view");
     m_desc["reset_direction"]  = _L("Reset direction");
-    m_desc["cursor_size"]      = _L("Pen size");
+    m_desc["cursor_size"]      = _L("Brush size");
     m_desc["tool_type"]        = _L("Tool type");
     m_desc["enforce"]          = _L("Enforce seam");
     m_desc["block"]            = _L("Block seam");


### PR DESCRIPTION
follow up to #12852 

Implements feedback by @discip 

## Changes
- changes "Pen size" to "Brush size" in all painting tools to match icons and semantic better
- moves "On overhangs only" underneath "Brush Size" and rephrases as "On highlighted overhangs only" in all translations
   - better communicates that it restricts where to paint and that it uses the value of "Highlight Overhangs"


<img width="415" height="397" alt="image" src="https://github.com/user-attachments/assets/a07f4cd0-8b4b-4b19-88f7-8fc1a8f8a994" />

   
## Translation
I have used AI to translate it for every language using the following prompt:

> Hi i am updating the translation of orcaslicer, i want to change "On overhangs only" to "On highlighted overhangs only". I am going to give you a list of the language with its current translation and you will give me the updated translation.
> 
> ca - Només als voladissos
> cs - Pouze na převisy
> de - Nur an Überhängen
> es - Solo en voladizos
> fr - Sur les surplombs uniquement
> hu - Csak túlnyúlásokon
> it - Solo sulle sporgenze
> ja - オーバーハングのみ
> ko - 오버행에만 칠하기
> lt - Tik kabantiems
> nl - Alleen op overhangen
> pl - Tylko na nawisach
> pt_BR - Apenas em saliências
> ru - Только на нависаниях
> sv - Endast på överhäng
> tr - Yalnızca çıkıntılarda
> uk - Тільки на нависання
> vi - Chỉ trên overhang
> zh_CN - 仅对悬垂区生效
> zh_TW - 僅對懸空區生效

Response:

> Updating the terminology from "On overhangs" to "On highlighted overhangs" requires ensuring that the word for "highlighted" (or "marked/indicated") fits naturally within the UI of each language. Here are the updated translations for OrcaSlicer:
> Code | Updated Translation
> -- | --
> ca | Només als voladissos ressaltats
> cs | Pouze na zvýrazněné převisy
> de | Nur an hervorgehobenen Überhängen
> es | Solo en voladizos resaltados
> fr | Uniquement sur les surplombs mis en évidence
> hu | Csak a kiemelt túlnyúlásokon
> it | Solo sulle sporgenze evidenziate
> ja | 強調表示されたオーバーハングのみ
> ko | 강조된 오버행에만 칠하기
> lt | Tik paryškintiems kabantiems
> nl | Alleen op gemarkeerde overhangen
> pl | Tylko na podświetlonych nawisach
> pt_BR | Apenas em saliências destacadas
> ru | Только на подсвеченных нависаниях
> sv | Endast på markerade överhäng
> tr | Yalnızca vurgulanan çıkıntılarda
> uk | Тільки на підсвічених нависаннях
> vi | Chỉ trên các overhang được làm nổi bật
> zh_CN | 仅对高亮悬垂区生效
> zh_TW | 僅對高亮懸空區生效
> 
> Notes on specific adjustments:
> 
> - French/Italian/Spanish: Used "mis en évidence," "evidenziate," and "resaltados" as they are the standard UI terms for items highlighted by a selection tool.
> 
>  - Asian Languages (ZH/JA/KO): Used terms like "高亮" and "강조" which specifically refer to UI highlighting/glow effects.
> 
>  - German: "Hervorgehobenen" is the most precise fit for a visual highlight in a CAD/Slicer context.
> 

I checked the used vocabulary in "Highlight Overhangs" for each language and it matched the vocabulary that the AI gave me.
Therefore i am reasonably sure that it is correct, but i can only confirm german, english and halfway russian/ukranian.
