### PR TITLE
Fix crash on launch caused by ref of tmp object

### DIFF
--- a/src/slic3r/GUI/GUI.cpp
+++ b/src/slic3r/GUI/GUI.cpp
@@ -80,7 +80,8 @@ void break_to_debugger()
 
 const std::string& shortkey_shift_prefix()
 {
-    return _u8L("Shift+");
+	static const std::string str = _u8L("Shift+");
+    return str;
 }
 
 const std::string& shortkey_ctrl_prefix()


### PR DESCRIPTION
See https://github.com/OrcaSlicer/OrcaSlicer/pull/12848#discussion_r3138861278