### PR TITLE
Fix/config vector size crash

### DIFF
--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -9643,7 +9643,46 @@ void DynamicPrintConfig::update_diff_values_to_child_config(DynamicPrintConfig& 
                 int stride = 1;
                 if (key_set2.find(opt) != key_set2.end())
                     stride = 2;
-                opt_vec_src->set_only_diff(opt_vec_dest, variant_index, stride);
+
+                const size_t restore_n     = variant_index.size();
+                const size_t expected_size = restore_n * size_t(stride);
+
+                if (stride == 2) {
+                    // Options in key_set2 are machine limits stored as (normal,silent) pairs per printer variant.
+                    if (opt_src->type() != coFloats || opt_target->type() != coFloats)
+                        throw ConfigurationError((boost::format("%1%: key '%2%' is expected to be ConfigOptionFloats for stride=2.") % __FUNCTION__ % opt).str());
+
+                    auto *src_f = static_cast<ConfigOptionFloats*>(opt_src);
+                    ConfigOptionFloats rhs_tmp(*static_cast<const ConfigOptionFloats*>(opt_target));
+
+                    const size_t src_size  = src_f->values.size();
+                    const size_t dest_size = rhs_tmp.values.size();
+                    if (src_size != expected_size || dest_size != expected_size)
+                        log_normalize_legacy_vector_size(__FUNCTION__, opt, stride, src_size, dest_size, expected_size, restore_n, cur_variant_count,
+                                                         target_variant_count, cur_extruder_ids.size(), target_extruder_ids.size(), opt_src, opt_target);
+
+                    normalize_stride2_floats(*src_f, expected_size);
+                    normalize_stride2_floats(rhs_tmp, expected_size);
+                    src_f->set_only_diff(&rhs_tmp, variant_index, stride);
+                } else {
+                    const size_t src_size  = opt_vec_src->size();
+                    const size_t dest_size = static_cast<const ConfigOptionVectorBase*>(opt_target)->size();
+                    if (src_size != expected_size || dest_size != expected_size)
+                        log_normalize_legacy_vector_size(__FUNCTION__, opt, stride, src_size, dest_size, expected_size, restore_n, cur_variant_count,
+                                                         target_variant_count, cur_extruder_ids.size(), target_extruder_ids.size(), opt_src, opt_target);
+
+                    if (opt_vec_src->size() != expected_size)
+                        opt_vec_src->resize(expected_size, opt_target);
+
+                    ConfigOptionUniquePtr rhs_owner(opt_target->clone());
+                    ConfigOptionVectorBase *rhs_vec = dynamic_cast<ConfigOptionVectorBase*>(rhs_owner.get());
+                    if (rhs_vec == nullptr)
+                        throw ConfigurationError((boost::format("%1%: key '%2%' is expected to be a vector option.") % __FUNCTION__ % opt).str());
+                    if (rhs_vec->size() != expected_size)
+                        rhs_vec->resize(expected_size, opt_target);
+
+                    opt_vec_src->set_only_diff(rhs_vec, variant_index, stride);
+                }
             }
         }
     }


### PR DESCRIPTION
# Description
This PR fixes a critical bug where user-defined printer configuration files for multi-extruder printers (such as the Snapmaker U1 or Prusa XL 5T) were incorrectly validated during loading, resulting in a `ConfigurationError` and the subsequent deletion of the "invalid" profile by the application.

### Key Changes:
*   **Vector Size Normalization:** Implemented vector size normalization in `DynamicPrintConfig::update_diff_values_to_child_config`. 
*   **Stride Handling:** Added specific handling for `stride=2` (used for machine limits like `machine_max_acceleration_z`) and `stride=1` (used for per-extruder settings like `retraction_length`).
*   **Consistency:** This patch mirrors the normalization logic already present in `update_non_diff_values_to_base_config`, which was previously updated to handle similar stride-based mismatches but missed this specific configuration loading path.

### Fixes:
*   Addresses issue #11780.
*   Prevents the crash: `ConfigOptionVector::set_only_diff(): Assigning from an vector with invalid diff_index size`.
*   Ensures custom multi-extruder profiles persist correctly across application restarts.

## Tests
I have conducted the following tests to verify the changes:
1.  **Multi-Extruder Loading Test:** Verified that a Snapmaker U1 profile (4 extruders) that previously triggered the "Failed loading user-config" error now loads successfully without any errors or file deletion.
2.  **Log Verification:** Confirmed via debug logs that the specific `set_only_diff` exception is no longer thrown during the startup sequence.

***


**Note:** This patch was **Vibe Coded** using an AI coding assistant. The agent analyzed the core configuration vector system, identified the missing normalization logic in the child-config loading path, and implemented the fix based on existing patterns found in the OrcaSlicer codebase.
Fix #11780