### PR TITLE
[Linux] Fix Black borders on checkbox and switch button

### DIFF
--- a/src/slic3r/GUI/GUI_Utils.cpp
+++ b/src/slic3r/GUI/GUI_Utils.cpp
@@ -13,6 +13,10 @@
     #include <wx/msw/registry.h>
 #endif // _WIN32
 
+#ifdef __WXGTK__
+#include <gtk/gtk.h>
+#endif 
+
 #include <wx/toplevel.h>
 #include <wx/sizer.h>
 #include <wx/checkbox.h>
@@ -495,6 +499,60 @@ void fit_in_display(wxTopLevelWindow& window, wxSize desired_size)
 
     window.SetSize(desired_size);
 }
+
+#ifdef __WXGTK__
+void RemoveButtonBorder(wxWindow* win)
+{
+    GtkWidget* widget = win->GetHandle();
+    if (!widget) return;
+
+#if GTK_CHECK_VERSION(3, 0, 0)
+    // GTK3+: use CSS provider
+    GtkCssProvider* provider = gtk_css_provider_new();
+
+    const char* css =
+        "button {"
+        "  border: none;"
+        "  outline: none;"
+        "  box-shadow: none;"
+        "  padding: 0px;"
+        "  margin: 0px;"
+        "  min-height: 0px;"
+        "  min-width: 0px;"
+        "  background: none;"
+        "}";
+
+#if GTK_CHECK_VERSION(4, 0, 0)
+    // GTK4: no GError argument
+    gtk_css_provider_load_from_data(provider, css, -1);
+#else
+    // GTK3: has GError argument
+    gtk_css_provider_load_from_data(provider, css, -1, nullptr);
+#endif
+
+    GtkStyleContext* ctx = gtk_widget_get_style_context(widget);
+    gtk_style_context_add_provider(
+        ctx,
+        GTK_STYLE_PROVIDER(provider),
+        GTK_STYLE_PROVIDER_PRIORITY_USER
+    );
+    g_object_unref(provider);
+
+#else
+    // GTK2: use rc string, no CSS
+    gtk_rc_parse_string(
+        "style \"no-border\" {"
+        "  GtkButton::inner-border = { 0, 0, 0, 0 }"
+        "  GtkWidget::focus-line-width = 0"
+        "  GtkWidget::focus-padding = 0"
+        "  xthickness = 0"
+        "  ythickness = 0"
+        "}"
+        "widget \"*.GtkBitmapToggleButton\" style \"no-border\""
+    );
+#endif
+}
+#endif // __WXGTK__
 
 #ifdef __linux__
 // Detect if the application is running inside a debugger.

--- a/src/slic3r/GUI/GUI_Utils.hpp
+++ b/src/slic3r/GUI/GUI_Utils.hpp
@@ -461,6 +461,10 @@ void dataview_remove_insets(wxDataViewCtrl* dv);
 void staticbox_remove_margin(wxStaticBox* sb);
 #endif
 
+#ifdef __WXGTK3__
+void RemoveButtonBorder(wxWindow* win);
+#endif
+
 #if defined(__WXOSX__) || defined(__linux__)
 bool is_debugger_present();
 #endif

--- a/src/slic3r/GUI/Widgets/CheckBox.cpp
+++ b/src/slic3r/GUI/Widgets/CheckBox.cpp
@@ -2,6 +2,10 @@
 
 #include "../wxExtensions.hpp"
 
+#ifdef __WXGTK3__
+#include "../GUI_Utils.hpp"
+#endif
+
 CheckBox::CheckBox(wxWindow *parent, int id)
     : wxBitmapToggleButton(parent, id, wxNullBitmap, wxDefaultPosition, wxDefaultSize, wxBORDER_NONE)
     , m_on(this, "check_on", 18)
@@ -24,16 +28,12 @@ CheckBox::CheckBox(wxWindow *parent, int id)
     Bind(wxEVT_ENTER_WINDOW, &CheckBox::updateBitmap, this);
     Bind(wxEVT_LEAVE_WINDOW, &CheckBox::updateBitmap, this);
 #endif
-	update();
-#ifdef __WXGTK__
-	wxSize bestSize = GetBestSize();
-	bestSize.IncTo(m_on.GetBmpSize());
-	SetSize(bestSize);
-	SetMinSize(bestSize);
-#else
-	SetSize(m_on.GetBmpSize());
-	SetMinSize(m_on.GetBmpSize());
+
+#ifdef __WXGTK3__
+    Slic3r::GUI::RemoveButtonBorder(this);
 #endif
+
+    Rescale();
 }
 
 void CheckBox::SetValue(bool value)
@@ -61,16 +61,9 @@ void CheckBox::Rescale()
     m_on_focused.msw_rescale();
     m_half_focused.msw_rescale();
     m_off_focused.msw_rescale();
-    update();
-#ifdef __WXGTK__
-    wxSize bestSize = GetBestSize();
-    bestSize.IncTo(m_on.GetBmpSize());
-    SetSize(bestSize);
-    SetMinSize(bestSize);
-#else
     SetSize(m_on.GetBmpSize());
     SetMinSize(m_on.GetBmpSize());
-#endif
+    update();
 }
 
 void CheckBox::update()

--- a/src/slic3r/GUI/Widgets/SwitchButton.cpp
+++ b/src/slic3r/GUI/Widgets/SwitchButton.cpp
@@ -11,6 +11,10 @@
 #include "libslic3r/MacUtils.hpp"
 #endif
 
+#ifdef __WXGTK3__
+#include "../GUI_Utils.hpp"
+#endif
+
 #include <wx/dcmemory.h>
 #include <wx/dcclient.h>
 #include <wx/dcgraph.h>
@@ -28,6 +32,11 @@ SwitchButton::SwitchButton(wxWindow* parent, wxWindowID id)
 	SetBackgroundColour(StaticBox::GetParentBackgroundColor(parent));
 	Bind(wxEVT_TOGGLEBUTTON, [this](auto& e) { update(); e.Skip(); });
 	SetFont(Label::Body_12);
+
+#ifdef __WXGTK3__
+    Slic3r::GUI::RemoveButtonBorder(this);
+#endif
+
 	Rescale();
 }
 


### PR DESCRIPTION
Removes min size limitation and black borders on checkbox and switch button (Global / object toggle)

Before
<img width="476" height="264" alt="Screenshot-20260426201043" src="https://github.com/user-attachments/assets/b39ca843-3b6d-49d5-ad0b-278de4f73c1e" />

After
<img width="485" height="262" alt="Screenshot-20260426202726" src="https://github.com/user-attachments/assets/17069eb6-2e8d-4faa-8100-6b401fdf7bef" />
