### PR TITLE
[Linux] Fix scrollbar appears while 1 filament exist on filament area

### DIFF
--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -2364,7 +2364,7 @@ void Sidebar::init_filament_combo(PlaterPresetComboBox **combo, const int filame
 
     (*combo)->clr_picker->SetLabel(wxString::Format("%d", filament_idx + 1));
     combo_and_btn_sizer->Add((*combo)->clr_picker, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(SidebarProps::ElementSpacing()) - FromDIP(2)); // ElementSpacing - 2 (from combo box))
-    combo_and_btn_sizer->Add(*combo, 1, wxALL | wxEXPAND, FromDIP(2))->SetMinSize({-1, FromDIP(30)});
+    combo_and_btn_sizer->Add(*combo, 1, wxALL | wxEXPAND, FromDIP(2))->SetMinSize({-1, 30 * wxGetApp().em_unit() / 10}); // ORCA ensure height matches with PlaterPresetComboBox
 
     /* BBS hide del_btn
     ScalableButton* del_btn = new ScalableButton(p->m_panel_filament_content, wxID_ANY, "delete_filament");


### PR DESCRIPTION
fixes scrollbar appears on filaments area on linux while 1 filament in use
matched combo box height value as solution

before
<img width="478" height="93" alt="Screenshot-20260426203718" src="https://github.com/user-attachments/assets/eb5639bd-a7a7-4275-8d4a-0340eea1bbfa" />

after
<img width="477" height="95" alt="Screenshot-20260426204138" src="https://github.com/user-attachments/assets/8c745cd6-6be9-45a0-84b7-d48da8c0aba6" />
