### PR TITLE
Fix air filtration settings hidden on printers that support that feature

### DIFF
--- a/resources/profiles/BBL.json
+++ b/resources/profiles/BBL.json
@@ -1,9 +1,9 @@
 {
 	"name": "Bambulab",
 	"url": "http://www.bambulab.com/Parameters/vendor/BBL.json",
-	"version": "02.01.00.12",
+	"version": "02.01.00.13",
 	"force_update": "0",
-	"description": "the initial version of BBL configurations",
+	"description": "BBL configurations",
 	"machine_model_list": [
 		{
 			"name": "Bambu Lab A1",

--- a/resources/profiles/BBL/machine/Bambu Lab H2D 0.4 nozzle.json
+++ b/resources/profiles/BBL/machine/Bambu Lab H2D 0.4 nozzle.json
@@ -97,6 +97,7 @@
 		"10",
 		"10"
 	],
+	"support_air_filtration": "1",
 	"support_chamber_temp_control": "1",
 	"support_object_skip_flush": "1",
 	"wrapping_exclude_area": [

--- a/resources/profiles/BBL/machine/Bambu Lab H2D Pro 0.4 nozzle.json
+++ b/resources/profiles/BBL/machine/Bambu Lab H2D Pro 0.4 nozzle.json
@@ -101,6 +101,7 @@
 		"10",
 		"10"
 	],
+	"support_air_filtration": "1",
 	"support_chamber_temp_control": "1",
 	"support_object_skip_flush": "1",
 	"wrapping_exclude_area": [

--- a/resources/profiles/BBL/machine/Bambu Lab H2S 0.4 nozzle.json
+++ b/resources/profiles/BBL/machine/Bambu Lab H2S 0.4 nozzle.json
@@ -208,6 +208,7 @@
 		"18",
 		"18"
 	],
+	"support_air_filtration": "1",
 	"support_chamber_temp_control": "1",
 	"support_object_skip_flush": "1",
 	"wipe_distance": [

--- a/resources/profiles/BBL/machine/Bambu Lab P1S 0.4 nozzle.json
+++ b/resources/profiles/BBL/machine/Bambu Lab P1S 0.4 nozzle.json
@@ -190,6 +190,7 @@
 		"18",
 		"18"
 	],
+	"support_air_filtration": "1",
 	"wipe_distance": [
 		"2",
 		"2"

--- a/resources/profiles/BBL/machine/Bambu Lab X1 0.4 nozzle.json
+++ b/resources/profiles/BBL/machine/Bambu Lab X1 0.4 nozzle.json
@@ -197,6 +197,7 @@
 		"18"
 	],
 	"scan_first_layer": "1",
+	"support_air_filtration": "1",
 	"wipe_distance": [
 		"2",
 		"2"

--- a/resources/profiles/BBL/machine/Bambu Lab X1 Carbon 0.4 nozzle.json
+++ b/resources/profiles/BBL/machine/Bambu Lab X1 Carbon 0.4 nozzle.json
@@ -192,6 +192,7 @@
 		"18"
 	],
 	"scan_first_layer": "1",
+	"support_air_filtration": "1",
 	"wipe_distance": [
 		"2",
 		"2"

--- a/resources/profiles/Elegoo.json
+++ b/resources/profiles/Elegoo.json
@@ -1,6 +1,6 @@
 {
 	"name": "Elegoo",
-	"version": "02.03.02.70",
+	"version": "02.03.02.71",
 	"force_update": "0",
 	"description": "Elegoo configurations",
 	"machine_model_list": [

--- a/resources/profiles/Elegoo/machine/EC/Elegoo Centauri 0.4 nozzle.json
+++ b/resources/profiles/Elegoo/machine/EC/Elegoo Centauri 0.4 nozzle.json
@@ -46,6 +46,7 @@
 	"machine_unload_filament_time": "28",
 	"nozzle_type": "hardened_steel",
 	"scan_first_layer": "1",
+	"support_air_filtration": "1",
 	"default_bed_type": "4",
 	"upward_compatible_machine": [],
 	"gcode_flavor": "klipper",

--- a/resources/profiles/Elegoo/machine/ECC/Elegoo Centauri Carbon 0.4 nozzle.json
+++ b/resources/profiles/Elegoo/machine/ECC/Elegoo Centauri Carbon 0.4 nozzle.json
@@ -47,6 +47,7 @@
 	"machine_unload_filament_time": "28",
 	"nozzle_type": "hardened_steel",
 	"scan_first_layer": "1",
+	"support_air_filtration": "1",
 	"upward_compatible_machine": [],
 	"gcode_flavor": "klipper",
 	"change_filament_gcode": "M600",


### PR DESCRIPTION
Some system printer profiles for printers that support air filtration had the feature **incorrectly disabled** in the printer settings.

This caused the related filament settings to be **hidden**, making the feature **unavailable** to users even though **it is supported** by the printer.

Fix:
- Enable "Support air filtration" in affected system printer profiles
- Bump profile version thus forcing Orca to refresh cached settings

This **ensures** air filtration settings are **visible** and **usable** on printers that support that feature.

Affected printers:
- Bambu
    - H2D
    - H2D Pro
    - H2S
    - P1S
    - ~~P2S~~
    - X1
    - X1 Carbon
- Elegoo
    - Centauri
    - Centauri Carbon

Fixes #13378

> Note
> In case I might have missed other printers with this issue please let me know to include those too into the fix.