### PR TITLE
Fix role-based fan speeds being lost on layer change

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -2416,6 +2416,7 @@ void GCode::_do_export(Print& print, GCodeOutputStream &file, ThumbnailsGenerato
     m_max_layer_z  = 0.f;
     m_last_width = 0.f;
     m_is_role_based_fan_on.fill(false);
+    m_role_based_fan_marker_layer.fill(-1);
 
     m_fan_mover.release();
     
@@ -6709,11 +6710,14 @@ std::string GCode::_extrude(const ExtrusionPath &path, std::string description, 
         assert(m_enable_cooling_markers);
 
         if (fan_on) {
-            if (!m_is_role_based_fan_on[role]) {
+            // Orca: CoolingBuffer consumes role fan markers per layer, so continuing
+            // role-based fan regions need a fresh START marker on each new layer.
+            if (!m_is_role_based_fan_on[role] || m_role_based_fan_marker_layer[role] != m_layer_index) {
                 gcode += ";";
                 gcode += marker_prefix;
                 gcode += "_FAN_START\n";
                 m_is_role_based_fan_on[role] = true;
+                m_role_based_fan_marker_layer[role] = m_layer_index;
             }
         } else {
             if (m_is_role_based_fan_on[role]) {
@@ -6721,6 +6725,7 @@ std::string GCode::_extrude(const ExtrusionPath &path, std::string description, 
                 gcode += marker_prefix;
                 gcode += "_FAN_END\n";
                 m_is_role_based_fan_on[role] = false;
+                m_role_based_fan_marker_layer[role] = -1;
             }
         }
     };

--- a/src/libslic3r/GCode.hpp
+++ b/src/libslic3r/GCode.hpp
@@ -549,6 +549,7 @@ private:
     std::string _encode_label_ids_to_base64(std::vector<size_t> ids);
     // ORCA: Add support for role based fan speed control
     std::array<bool, ExtrusionRole::erCount> m_is_role_based_fan_on;
+    std::array<int, ExtrusionRole::erCount>  m_role_based_fan_marker_layer;
     // Markers for the Pressure Equalizer to recognize the extrusion type.
     // The Pressure Equalizer removes the markers from the final G-code.
     bool                                m_enable_extrusion_role_markers;


### PR DESCRIPTION
## What it is about

Feature-specific fan overrides could be lost when the same fan-controlled feature continued across a layer boundary.

For example, if one layer ended while the overhang fan override was still active, and the next layer also started with an overhang section, the new layer could miss the overhang fan override and fall back to the normal layer fan speed.

The same could happen independently for other fan-controlled feature types, such as external bridges.

## What could be observed

- Overhangs starting a new layer with weaker cooling than expected  
- Inconsistent cooling across layers for the same feature

## Why this happened

Orca tracks whether a feature-specific fan override is already active for each feature type.

When the same feature type continued across a layer boundary (layer change), Orca could think the fan override was already active and skip adding a new start marker for the new layer.

However, fan markers are processed per layer, so the new layer still needed its own marker. Without it, that layer could fall back to the normal layer fan speed.

## What's the fix for it

Feature-specific fan override markers are now layer-aware.

If the same fan-controlled feature type continues onto a new layer, Orca emits a fresh marker for that layer while still avoiding unnecessary duplicate markers within the same layer.

This keeps feature-specific fan speeds applied correctly across layer transitions.

Fixes #8143

## Screenshots
- **Before:**
<img width="1430" height="1103" alt="image" src="https://github.com/user-attachments/assets/0f6dcbf1-e400-4239-a842-cfcce0706f2f" />

<br>

- **After:**
<img width="1462" height="1086" alt="image" src="https://github.com/user-attachments/assets/86807c3b-94ee-44a6-9bd2-1e6f4b5778b1" />
