### PR TITLE
Support >16 filaments in MMU painting

### DIFF
--- a/src/libslic3r/Format/bbs_3mf.cpp
+++ b/src/libslic3r/Format/bbs_3mf.cpp
@@ -322,6 +322,10 @@ static constexpr const char* CUSTOM_SUPPORTS_ATTR = "paint_supports";
 static constexpr const char* CUSTOM_FUZZY_SKIN_ATTR  = "paint_fuzzy_skin";
 static constexpr const char* CUSTOM_SEAM_ATTR = "paint_seam";
 static constexpr const char* MMU_SEGMENTATION_ATTR = "paint_color";
+// Companion to paint_color carrying overrides for high-index extruders that don't fit in
+// the 6-bit legacy encoding. Comma-separated decimal integers, one per NONE-encoded leaf
+// in tree-traversal order. Absent when the triangle has no high-index colors.
+static constexpr const char* MMU_SEGMENTATION_EXT_ATTR = "paint_color_ext";
 // BBS
 static constexpr const char* FACE_PROPERTY_ATTR = "face_property";
 
@@ -722,6 +726,7 @@ void PlateData::parse_filament_info(GCodeProcessorResult *result)
             std::vector<std::string> custom_supports;
             std::vector<std::string> custom_seam;
             std::vector<std::string> mmu_segmentation;
+            std::vector<std::string> mmu_segmentation_ext;
             std::vector<std::string> fuzzy_skin;
             // BBS
             std::vector<std::string> face_properties;
@@ -742,6 +747,7 @@ void PlateData::parse_filament_info(GCodeProcessorResult *result)
                 custom_supports.clear();
                 custom_seam.clear();
                 mmu_segmentation.clear();
+                mmu_segmentation_ext.clear();
                 fuzzy_skin.clear();
             }
         };
@@ -3700,6 +3706,7 @@ void PlateData::parse_filament_info(GCodeProcessorResult *result)
             m_curr_object->geometry.custom_supports.push_back(bbs_get_attribute_value_string(attributes, num_attributes, CUSTOM_SUPPORTS_ATTR));
             m_curr_object->geometry.custom_seam.push_back(bbs_get_attribute_value_string(attributes, num_attributes, CUSTOM_SEAM_ATTR));
             m_curr_object->geometry.mmu_segmentation.push_back(bbs_get_attribute_value_string(attributes, num_attributes, MMU_SEGMENTATION_ATTR));
+            m_curr_object->geometry.mmu_segmentation_ext.push_back(bbs_get_attribute_value_string(attributes, num_attributes, MMU_SEGMENTATION_EXT_ATTR));
             m_curr_object->geometry.fuzzy_skin.push_back(bbs_get_attribute_value_string(attributes, num_attributes, CUSTOM_FUZZY_SKIN_ATTR));
             // BBS
             m_curr_object->geometry.face_properties.push_back(bbs_get_attribute_value_string(attributes, num_attributes, FACE_PROPERTY_ATTR));
@@ -4907,6 +4914,9 @@ void PlateData::parse_filament_info(GCodeProcessorResult *result)
                 volume->seam_facets.reserve(triangles_count);
                 volume->mmu_segmentation_facets.reserve(triangles_count);
                 volume->fuzzy_skin_facets.reserve(triangles_count);
+                // mmu_segmentation_ext is only populated for files written by an OrcaSlicer
+                // build that supports >16 filaments; older files have an empty vector.
+                const bool has_mmu_ext = sub_object->geometry.mmu_segmentation_ext.size() == triangles_count;
                 for (size_t i=0; i<triangles_count; ++i) {
                     assert(i < sub_object->geometry.custom_supports.size());
                     assert(i < sub_object->geometry.custom_seam.size());
@@ -4916,8 +4926,11 @@ void PlateData::parse_filament_info(GCodeProcessorResult *result)
                         volume->supported_facets.set_triangle_from_string(i, sub_object->geometry.custom_supports[i]);
                     if (! sub_object->geometry.custom_seam[i].empty())
                         volume->seam_facets.set_triangle_from_string(i, sub_object->geometry.custom_seam[i]);
-                    if (! sub_object->geometry.mmu_segmentation[i].empty())
+                    if (! sub_object->geometry.mmu_segmentation[i].empty()) {
                         volume->mmu_segmentation_facets.set_triangle_from_string(i, sub_object->geometry.mmu_segmentation[i]);
+                        if (has_mmu_ext && ! sub_object->geometry.mmu_segmentation_ext[i].empty())
+                            volume->mmu_segmentation_facets.set_triangle_ext_from_string(i, sub_object->geometry.mmu_segmentation_ext[i]);
+                    }
                     if (!sub_object->geometry.fuzzy_skin[i].empty())
                         volume->fuzzy_skin_facets.set_triangle_from_string(i, sub_object->geometry.fuzzy_skin[i]);
                 }
@@ -5068,6 +5081,7 @@ void PlateData::parse_filament_info(GCodeProcessorResult *result)
             volume->supported_facets.reserve(triangles_count);
             volume->seam_facets.reserve(triangles_count);
             volume->mmu_segmentation_facets.reserve(triangles_count);
+            const bool has_mmu_ext = geometry.mmu_segmentation_ext.size() == geometry.mmu_segmentation.size();
             for (size_t i=0; i<triangles_count; ++i) {
                 size_t index = volume_data.first_triangle_id + i;
                 assert(index < geometry.custom_supports.size());
@@ -5077,8 +5091,11 @@ void PlateData::parse_filament_info(GCodeProcessorResult *result)
                     volume->supported_facets.set_triangle_from_string(i, geometry.custom_supports[index]);
                 if (! geometry.custom_seam[index].empty())
                     volume->seam_facets.set_triangle_from_string(i, geometry.custom_seam[index]);
-                if (! geometry.mmu_segmentation[index].empty())
+                if (! geometry.mmu_segmentation[index].empty()) {
                     volume->mmu_segmentation_facets.set_triangle_from_string(i, geometry.mmu_segmentation[index]);
+                    if (has_mmu_ext && ! geometry.mmu_segmentation_ext[index].empty())
+                        volume->mmu_segmentation_facets.set_triangle_ext_from_string(i, geometry.mmu_segmentation_ext[index]);
+                }
             }
             volume->supported_facets.shrink_to_fit();
             volume->seam_facets.shrink_to_fit();
@@ -5385,6 +5402,7 @@ void PlateData::parse_filament_info(GCodeProcessorResult *result)
             current_object->geometry.custom_supports.push_back(bbs_get_attribute_value_string(attributes, num_attributes, CUSTOM_SUPPORTS_ATTR));
             current_object->geometry.custom_seam.push_back(bbs_get_attribute_value_string(attributes, num_attributes, CUSTOM_SEAM_ATTR));
             current_object->geometry.mmu_segmentation.push_back(bbs_get_attribute_value_string(attributes, num_attributes, MMU_SEGMENTATION_ATTR));
+            current_object->geometry.mmu_segmentation_ext.push_back(bbs_get_attribute_value_string(attributes, num_attributes, MMU_SEGMENTATION_EXT_ATTR));
             current_object->geometry.fuzzy_skin.push_back(bbs_get_attribute_value_string(attributes, num_attributes, CUSTOM_FUZZY_SKIN_ATTR));
             // BBS
             current_object->geometry.face_properties.push_back(bbs_get_attribute_value_string(attributes, num_attributes, FACE_PROPERTY_ATTR));
@@ -7179,6 +7197,19 @@ void PlateData::parse_filament_info(GCodeProcessorResult *result)
                     output_buffer += "=\"";
                     output_buffer += mmu_painting_data_string;
                     output_buffer += "\"";
+
+                    // Emit the ext attribute only when the triangle has at least one
+                    // high-index extruder leaf; older slicers lacking ext support will
+                    // ignore this attribute and render the paint with high-index leaves
+                    // dropped to NONE (the lossy-but-coherent fallback).
+                    std::string mmu_ext_string = volume->mmu_segmentation_facets.get_triangle_ext_as_string(i);
+                    if (! mmu_ext_string.empty()) {
+                        output_buffer += " ";
+                        output_buffer += MMU_SEGMENTATION_EXT_ATTR;
+                        output_buffer += "=\"";
+                        output_buffer += mmu_ext_string;
+                        output_buffer += "\"";
+                    }
                 }
 
                 std::string fuzzy_skin_painting_data_string = volume->fuzzy_skin_facets.get_triangle_as_string(i);

--- a/src/libslic3r/Model.cpp
+++ b/src/libslic3r/Model.cpp
@@ -3503,7 +3503,7 @@ void FacetsAnnotation::set_triangle_from_string(int triangle_id, const std::stri
 {
     assert(! str.empty());
     assert(m_data.triangles_to_split.empty() || m_data.triangles_to_split.back().triangle_idx < triangle_id);
-    m_data.triangles_to_split.emplace_back(triangle_id, int(m_data.bitstream.size()));
+    m_data.triangles_to_split.emplace_back(triangle_id, int(m_data.bitstream.size()), int(m_data.ext_overrides.size()));
 
     const size_t bitstream_start_idx = m_data.bitstream.size();
     for (auto it = str.crbegin(); it != str.crend(); ++it) {
@@ -3522,6 +3522,72 @@ void FacetsAnnotation::set_triangle_from_string(int triangle_id, const std::stri
     }
 
     m_data.update_used_states(bitstream_start_idx);
+}
+
+// Serialize the per-NONE-leaf ext-override list of one triangle as a comma-separated
+// list of decimal integers (in tree-traversal order). Returns an empty string when
+// the triangle has no ext-overrides, in which case the caller should omit the XML
+// attribute entirely.
+std::string FacetsAnnotation::get_triangle_ext_as_string(int triangle_idx) const
+{
+    auto triangle_it = std::lower_bound(m_data.triangles_to_split.begin(), m_data.triangles_to_split.end(), triangle_idx,
+        [](const TriangleSelector::TriangleBitStreamMapping &l, const int r) { return l.triangle_idx < r; });
+    if (triangle_it == m_data.triangles_to_split.end() || triangle_it->triangle_idx != triangle_idx)
+        return {};
+
+    const size_t k     = std::distance(m_data.triangles_to_split.begin(), triangle_it);
+    const auto [start, end] = m_data.ext_overrides_range(k);
+    if (start == end)
+        return {};
+
+    std::string out;
+    out.reserve(size_t(end - start) * 3);
+    for (int i = start; i < end; ++i) {
+        if (i != start) out += ',';
+        out += std::to_string(static_cast<int>(m_data.ext_overrides[i]));
+    }
+    return out;
+}
+
+// Companion to set_triangle_from_string. Parses a comma-separated list of decimal
+// integers and attaches them as ext-overrides to the most-recently-added triangle.
+void FacetsAnnotation::set_triangle_ext_from_string(int triangle_id, const std::string& str)
+{
+    assert(! str.empty());
+    // The base paint_color must have been loaded first (set_triangle_from_string),
+    // so the matching triangle entry is the last one.
+    assert(! m_data.triangles_to_split.empty());
+    assert(m_data.triangles_to_split.back().triangle_idx == triangle_id);
+    (void)triangle_id;
+
+    // Each comma-separated token is a non-negative decimal extruder index (or 0 for
+    // genuinely-NONE leaves). Tokens above ExtruderMax are clamped to NONE on the
+    // assumption that the file references states the current build cannot represent.
+    const auto                            ext_max = static_cast<int>(EnforcerBlockerType::ExtruderMax);
+    using EBT_t                                   = std::underlying_type_t<EnforcerBlockerType>;
+    size_t                                pos     = 0;
+    while (pos < str.size()) {
+        size_t comma = str.find(',', pos);
+        if (comma == std::string::npos) comma = str.size();
+
+        int value = 0;
+        for (size_t i = pos; i < comma; ++i) {
+            const char ch = str[i];
+            if (ch >= '0' && ch <= '9')
+                value = value * 10 + (ch - '0');
+            else if (ch != ' ' && ch != '\t')
+                assert(false);
+        }
+        if (value < 0 || value > ext_max)
+            value = 0;
+
+        const auto state = static_cast<EnforcerBlockerType>(static_cast<EBT_t>(value));
+        m_data.ext_overrides.push_back(state);
+        if (state != EnforcerBlockerType::NONE)
+            m_data.used_states[size_t(value)] = true;
+
+        pos = comma + 1;
+    }
 }
 
 bool FacetsAnnotation::equals(const FacetsAnnotation &other) const

--- a/src/libslic3r/Model.hpp
+++ b/src/libslic3r/Model.hpp
@@ -749,13 +749,23 @@ public:
 
     // Serialize triangle into string, for serialization into 3MF/AMF.
     std::string get_triangle_as_string(int i) const;
+    // Companion to get_triangle_as_string for high-index extruders. Returns a comma-separated
+    // list of decimal integers, one per NONE-encoded leaf in tree-traversal order; a 0 entry
+    // means the leaf is genuinely unpainted, a non-zero entry overrides the leaf to that
+    // extruder. Returns an empty string if the triangle has no high-index overrides.
+    std::string get_triangle_ext_as_string(int i) const;
 
     // Before deserialization, reserve space for n_triangles.
     void reserve(int n_triangles) { m_data.triangles_to_split.reserve(n_triangles); }
     // Deserialize triangles one by one, with strictly increasing triangle_id.
     void set_triangle_from_string(int triangle_id, const std::string& str);
+    // Companion to set_triangle_from_string. Must be called only after the triangle's
+    // base paint_color string has been set. Parses a comma-separated list of decimal
+    // integers (the format produced by get_triangle_ext_as_string) and attaches them
+    // as overrides on the most-recently-added triangle.
+    void set_triangle_ext_from_string(int triangle_id, const std::string& str);
     // After deserializing the last triangle, shrink data to fit.
-    void shrink_to_fit() { m_data.triangles_to_split.shrink_to_fit(); m_data.bitstream.shrink_to_fit(); }
+    void shrink_to_fit() { m_data.triangles_to_split.shrink_to_fit(); m_data.bitstream.shrink_to_fit(); m_data.ext_overrides.shrink_to_fit(); }
     bool equals(const FacetsAnnotation &other) const;
 
 private:

--- a/src/libslic3r/TriangleSelector.cpp
+++ b/src/libslic3r/TriangleSelector.cpp
@@ -1443,29 +1443,36 @@ indexed_triangle_set TriangleSelector::get_facets(EnforcerBlockerType state) con
     return out;
 }
 
-// BBS
+// Bucket leaves by their state in a single pass over m_triangles. Per-type vertex
+// deduplication maps are lazily allocated only for types that actually appear.
 void TriangleSelector::get_facets(std::vector<indexed_triangle_set>& facets_per_type) const
 {
+    const size_t num_types = static_cast<size_t>(EnforcerBlockerType::ExtruderMax) + 1;
     facets_per_type.clear();
+    facets_per_type.resize(num_types);
 
-    for (int type = (int)EnforcerBlockerType::NONE; type <= (int)EnforcerBlockerType::ExtruderMax; type++) {
-        facets_per_type.emplace_back();
-        indexed_triangle_set& its = facets_per_type.back();
-        std::vector<int> vertex_map(m_vertices.size(), -1);
+    std::vector<std::vector<int>> vertex_maps(num_types);
 
-        for (const Triangle& tr : m_triangles) {
-            if (tr.valid() && !tr.is_split() && tr.get_state() == (EnforcerBlockerType)type) {
-                stl_triangle_vertex_indices indices;
-                for (int i = 0; i < 3; ++i) {
-                    int j = tr.verts_idxs[i];
-                    if (vertex_map[j] == -1) {
-                        vertex_map[j] = int(its.vertices.size());
-                        its.vertices.emplace_back(m_vertices[j].v);
-                    }
-                    indices[i] = vertex_map[j];
-                }
-                its.indices.emplace_back(indices);
+    for (const Triangle& tr : m_triangles) {
+        if (! tr.valid() || tr.is_split())
+            continue;
+        const int type = static_cast<int>(tr.get_state());
+        if (type < 0 || size_t(type) >= num_types)
+            continue;
+
+        auto& vertex_map = vertex_maps[type];
+        if (vertex_map.empty())
+            vertex_map.assign(m_vertices.size(), -1);
+
+        indexed_triangle_set& its = facets_per_type[type];
+        auto& indices = its.indices.emplace_back();
+        for (int i = 0; i < 3; ++i) {
+            const int j = tr.verts_idxs[i];
+            if (vertex_map[j] == -1) {
+                vertex_map[j] = int(its.vertices.size());
+                its.vertices.emplace_back(m_vertices[j].v);
             }
+            indices[i] = vertex_map[j];
         }
     }
 }
@@ -1654,9 +1661,21 @@ TriangleSelector::TriangleSplittingData TriangleSelector::serialize() const {
     // Using an explicit function object to support recursive call of Serializer::serialize().
     // This is cheaper than the previous implementation using a recursive call of type erased std::function.
     // (std::function calls using a pointer, while this implementation calls directly).
+    //
+    // The bit stream encodes states 0..16 directly. States above 16 cannot fit in the 6-bit
+    // form, so they are written as NONE (0) in the bit stream and the real state is recorded
+    // in a per-triangle ext-override list. The list contains one entry per NONE-encoded leaf
+    // (in tree-traversal order). A NONE entry means "leaf is genuinely unpainted"; a non-NONE
+    // entry overrides the leaf to the recorded extruder value during deserialization.
     struct Serializer {
         const TriangleSelector* triangle_selector;
         TriangleSplittingData data;
+        // Accumulator for the current triangle's ext-override list. Committed to
+        // data.ext_overrides at the end of each top-level triangle, but only if
+        // current_has_high_index is set (otherwise the triangle has no high-index
+        // colors and the ext attribute is unnecessary).
+        std::vector<EnforcerBlockerType> current_ext;
+        bool current_has_high_index = false;
 
         void serialize(int facet_idx) {
             const Triangle& tr = triangle_selector->m_triangles[facet_idx];
@@ -1681,25 +1700,38 @@ TriangleSelector::TriangleSplittingData TriangleSelector::serialize() const {
                 for (int child_idx = split_sides; child_idx >= 0; -- child_idx)
                     this->serialize(tr.children[child_idx]);
             } else {
-                // In case this is leaf, we better save information about its state.
-                int n = int(tr.get_state());
-                if (n <= static_cast<size_t>(EnforcerBlockerType::ExtruderMax))
-                    data.used_states[n] = true;
+                // Leaf state. Track the real (post-substitution) state in used_states; the
+                // bit stream gets at most 16, with anything higher pushed into ext_overrides.
+                int real_state = int(tr.get_state());
+                if (real_state >= 0 && real_state <= int(EnforcerBlockerType::ExtruderMax))
+                    data.used_states[real_state] = true;
 
-                if (n >= 3) {
-                    assert(n <= 16);
-                    if (n <= 16) {
-                        // Store "11" plus 4 bits of (n-3).
-                        data.bitstream.insert(data.bitstream.end(), { true, true });
-                        n -= 3;
-                        for (size_t bit_idx = 0; bit_idx < 4; ++bit_idx)
-                            data.bitstream.push_back(n & (uint64_t(0b0001) << bit_idx));
-                    }
+                int encoded_state;
+                if (real_state > 16) {
+                    // High-index extruder: encode as NONE in the bit stream, record real value in ext.
+                    encoded_state = 0;
+                    current_ext.push_back(static_cast<EnforcerBlockerType>(real_state));
+                    current_has_high_index = true;
                 } else {
-                    // Simple case, compatible with PrusaSlicer 2.3.1 and older for storing paint on supports and seams.
-                    // Store 2 bits of n.
-                    data.bitstream.push_back(n & 0b01);
-                    data.bitstream.push_back(n & 0b10);
+                    encoded_state = real_state;
+                    if (real_state == 0) {
+                        // Genuinely-NONE leaf — placeholder so the ext list stays aligned with
+                        // the tree's NONE-leaves in traversal order.
+                        current_ext.push_back(EnforcerBlockerType::NONE);
+                    }
+                }
+
+                if (encoded_state >= 3) {
+                    // Store "11" plus 4 bits of (encoded_state - 3). Compatible with
+                    // PrusaSlicer 2.3.1 and older for the values it could itself produce.
+                    data.bitstream.insert(data.bitstream.end(), { true, true });
+                    int v = encoded_state - 3;
+                    for (size_t bit_idx = 0; bit_idx < 4; ++bit_idx)
+                        data.bitstream.push_back(v & (uint64_t(0b0001) << bit_idx));
+                } else {
+                    // Store 2 bits of encoded_state.
+                    data.bitstream.push_back(encoded_state & 0b01);
+                    data.bitstream.push_back(encoded_state & 0b10);
                 }
             }
         }
@@ -1708,15 +1740,27 @@ TriangleSelector::TriangleSplittingData TriangleSelector::serialize() const {
     out.data.triangles_to_split.reserve(m_orig_size_indices);
     for (int i=0; i<m_orig_size_indices; ++i)
         if (const Triangle& tr = m_triangles[i]; tr.is_split() || tr.get_state() != EnforcerBlockerType::NONE) {
-            // Store index of the first bit assigned to ith triangle.
-            out.data.triangles_to_split.emplace_back(i, int(out.data.bitstream.size()));
-            // out the triangle bits.
+            // Store index of the first bit assigned to ith triangle, and the start of its
+            // (currently empty) ext-override range.
+            out.data.triangles_to_split.emplace_back(i, int(out.data.bitstream.size()), int(out.data.ext_overrides.size()));
+            // Reset per-triangle ext accumulator.
+            out.current_ext.clear();
+            out.current_has_high_index = false;
+            // Serialize the triangle bits (and possibly populate current_ext).
             out.serialize(i);
+            // Commit the ext-override range only if this triangle actually has a high-index leaf;
+            // otherwise the placeholder zeros for genuinely-NONE leaves are wasteful and we
+            // leave the range zero-length.
+            if (out.current_has_high_index) {
+                out.data.ext_overrides.insert(out.data.ext_overrides.end(),
+                                              out.current_ext.begin(), out.current_ext.end());
+            }
         }
 
     // May be stored onto Undo / Redo stack, thus conserve memory.
     out.data.triangles_to_split.shrink_to_fit();
     out.data.bitstream.shrink_to_fit();
+    out.data.ext_overrides.shrink_to_fit();
     return out.data;
 }
 
@@ -1728,8 +1772,8 @@ void TriangleSelector::deserialize(const TriangleSplittingData &data,
 {
     if (needs_reset)
         reset(); // dump any current state
-    for (auto [triangle_id, ibit] : data.triangles_to_split) {
-        if (triangle_id >= int(m_triangles.size())) {
+    for (const auto &mapping : data.triangles_to_split) {
+        if (mapping.triangle_idx >= int(m_triangles.size())) {
             BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << "array bound:error:triangle_id >= int(m_triangles.size())";
             return;
         }
@@ -1752,10 +1796,16 @@ void TriangleSelector::deserialize(const TriangleSplittingData &data,
     // kept outside of the loop to avoid re-allocating inside the loop.
     std::vector<ProcessingInfo> parents;
 
-    for (auto [triangle_id, ibit] : data.triangles_to_split) {
+    for (size_t k = 0; k < data.triangles_to_split.size(); ++k) {
+        const auto &mapping     = data.triangles_to_split[k];
+        const int   triangle_id = mapping.triangle_idx;
+        int         ibit        = mapping.bitstream_start_idx;
+        const auto [ext_start, ext_end] = data.ext_overrides_range(k);
+        int         ext_cursor  = ext_start;
+
         assert(triangle_id < int(m_triangles.size()));
         assert(ibit < int(data.bitstream.size()));
-        auto next_nibble = [&data, &ibit = ibit]() {
+        auto next_nibble = [&data, &ibit]() {
             int n = 0;
             for (int i = 0; i < 4; ++ i)
                 n |= data.bitstream[ibit ++] << i;
@@ -1772,17 +1822,23 @@ void TriangleSelector::deserialize(const TriangleSplittingData &data,
             // Only valid if not is_split. Value of the second nibble was subtracted by 3, so it is added back.
             auto state = is_split ? EnforcerBlockerType::NONE : EnforcerBlockerType((code & 0b1100) == 0b1100 ? next_nibble() + 3 : code >> 2);
 
-            // BBS
+            // For leaves encoded as NONE in the bit stream, consume the next ext-override
+            // entry (if any) and use it as the real state. A NONE entry there means the leaf
+            // is genuinely unpainted; a non-NONE entry overrides it to a high-index extruder.
+            if (!is_split && state == EnforcerBlockerType::NONE && ext_cursor < ext_end)
+                state = data.ext_overrides[ext_cursor++];
+
+            // Apply user-driven filament-list edits (delete/replace), then clamp anything
+            // that still exceeds the runtime maximum. The fallback to NONE on overflow is
+            // not an invariant violation: a file may legitimately reference a state above
+            // max_ebt after the user reduces the configured filament count.
+            using EBT_t = std::underlying_type_t<EnforcerBlockerType>;
             if (state == to_delete_filament)
                 state = replace_filament;
-            else if (to_delete_filament != EnforcerBlockerType::NONE && state != EnforcerBlockerType::NONE) {
-                state = state > to_delete_filament ? EnforcerBlockerType((int)state - 1) : state;
-            }
-
-            if (state > max_ebt) {
-                assert(false);
+            else if (to_delete_filament != EnforcerBlockerType::NONE && state != EnforcerBlockerType::NONE && state > to_delete_filament)
+                state = static_cast<EnforcerBlockerType>(static_cast<EBT_t>(state) - 1);
+            if (state > max_ebt)
                 state = EnforcerBlockerType::NONE;
-            }
 
             // Only valid if is_split.
             int special_side = code >> 2;

--- a/src/libslic3r/TriangleSelector.hpp
+++ b/src/libslic3r/TriangleSelector.hpp
@@ -17,24 +17,12 @@ enum class EnforcerBlockerType : int8_t {
     BLOCKER   = 2,
     // For the fuzzy skin, we use just two values (NONE and FUZZY_SKIN).
     FUZZY_SKIN = ENFORCER,
-    // Maximum is 15. The value is serialized in TriangleSelector into 6 bits using a 2 bit prefix code.
+    // For multi-material painting, values 1..16 are serialized in TriangleSelector
+    // into 6 bits using a 2-bit prefix code. Values above 16 cannot be represented
+    // in that bit stream and are written as NONE in the paint_color attribute,
+    // overridden per-leaf via the paint_color_ext attribute.
     Extruder1 = ENFORCER,
-    Extruder2 = BLOCKER,
-    Extruder3,
-    Extruder4,
-    Extruder5,
-    Extruder6,
-    Extruder7,
-    Extruder8,
-    Extruder9,
-    Extruder10,
-    Extruder11,
-    Extruder12,
-    Extruder13,
-    Extruder14,
-    Extruder15,
-    Extruder16,
-    ExtruderMax = Extruder16
+    ExtruderMax = 127
 };
 
 // Type alias for the state mapping array to improve code readability
@@ -243,16 +231,21 @@ public:
         int triangle_idx        = -1;
         // Index of the first bit of the bitstream assigned to this triangle.
         int bitstream_start_idx = -1;
+        // Index of the first entry in TriangleSplittingData::ext_overrides for this triangle.
+        // The range ends at the next entry's ext_overrides_start_idx (or at ext_overrides.size()
+        // for the last entry); a zero-length range means this triangle has no ext-override data.
+        int ext_overrides_start_idx = 0;
 
         TriangleBitStreamMapping() = default;
         explicit TriangleBitStreamMapping(int triangleIdx, int bitstreamStartIdx) : triangle_idx(triangleIdx), bitstream_start_idx(bitstreamStartIdx) {}
+        TriangleBitStreamMapping(int triangleIdx, int bitstreamStartIdx, int extOverridesStartIdx) : triangle_idx(triangleIdx), bitstream_start_idx(bitstreamStartIdx), ext_overrides_start_idx(extOverridesStartIdx) {}
 
-        friend bool operator==(const TriangleBitStreamMapping &lhs, const TriangleBitStreamMapping &rhs) { return lhs.triangle_idx == rhs.triangle_idx && lhs.bitstream_start_idx == rhs.bitstream_start_idx; }
+        friend bool operator==(const TriangleBitStreamMapping &lhs, const TriangleBitStreamMapping &rhs) { return lhs.triangle_idx == rhs.triangle_idx && lhs.bitstream_start_idx == rhs.bitstream_start_idx && lhs.ext_overrides_start_idx == rhs.ext_overrides_start_idx; }
         friend bool operator!=(const TriangleBitStreamMapping &lhs, const TriangleBitStreamMapping &rhs) { return !(lhs == rhs); }
 
     private:
         friend class cereal::access;
-        template<class Archive> void serialize(Archive &ar) { ar(triangle_idx, bitstream_start_idx); }
+        template<class Archive> void serialize(Archive &ar) { ar(triangle_idx, bitstream_start_idx, ext_overrides_start_idx); }
     };
 
     struct TriangleSplittingData {
@@ -260,7 +253,14 @@ public:
         std::vector<TriangleBitStreamMapping> triangles_to_split;
         // Bit stream containing splitting information.
         std::vector<bool>                     bitstream;
-        // Array indicating which triangle state types are used (encoded inside bitstream).
+        // Flat list of override values for NONE leaves whose real state could not be
+        // encoded in the bit stream (i.e. extruder index above 16). Per-triangle ranges
+        // are demarcated by TriangleBitStreamMapping::ext_overrides_start_idx; the
+        // sequence within a range corresponds to the triangle's NONE leaves in
+        // tree-traversal order. A NONE entry means "leaf is genuinely unpainted";
+        // a non-NONE entry overrides the leaf to that extruder value.
+        std::vector<EnforcerBlockerType>      ext_overrides;
+        // Array indicating which triangle state types are used.
         std::vector<bool>                     used_states { std::vector<bool>(static_cast<size_t>(EnforcerBlockerType::ExtruderMax) + 1, false) };
 
         TriangleSplittingData() = default;
@@ -268,6 +268,7 @@ public:
         friend bool operator==(const TriangleSplittingData &lhs, const TriangleSplittingData &rhs) {
             return lhs.triangles_to_split == rhs.triangles_to_split
                 && lhs.bitstream          == rhs.bitstream
+                && lhs.ext_overrides      == rhs.ext_overrides
                 && lhs.used_states        == rhs.used_states;
         }
 
@@ -282,9 +283,18 @@ public:
         // Update used states based on the bitstream. It just iterated over the bitstream from the bitstream_start_idx till the end.
         void update_used_states(size_t bitstream_start_idx);
 
+        // Returns the [start, end) ext-override range for the k-th entry in triangles_to_split.
+        std::pair<int, int> ext_overrides_range(size_t k) const {
+            const int start = triangles_to_split[k].ext_overrides_start_idx;
+            const int end   = (k + 1 < triangles_to_split.size())
+                ? triangles_to_split[k + 1].ext_overrides_start_idx
+                : int(ext_overrides.size());
+            return {start, end};
+        }
+
     private:
         friend class cereal::access;
-        template<class Archive> void serialize(Archive &ar) { ar(triangles_to_split, bitstream, used_states); }
+        template<class Archive> void serialize(Archive &ar) { ar(triangles_to_split, bitstream, ext_overrides, used_states); }
     };
 
     std::pair<std::vector<Vec3i32>, std::vector<Vec3i32>> precompute_all_neighbors() const;

--- a/src/slic3r/GUI/Gizmos/GLGizmoMmuSegmentation.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoMmuSegmentation.cpp
@@ -27,12 +27,12 @@ static inline void show_notification_extruders_limit_exceeded()
         ->get_notification_manager()
         ->push_notification(NotificationType::MmSegmentationExceededExtrudersLimit, NotificationManager::NotificationLevel::PrintInfoNotificationLevel,
                             GUI::format(_L("Filament count exceeds the maximum number that painting tool supports. Only the "
-                                           "first %1% filaments will be available in painting tool."), GLGizmoMmuSegmentation::EXTRUDERS_LIMIT));
+                                           "first %1% filaments will be available in painting tool."), int(EnforcerBlockerType::ExtruderMax)));
 }
 
 void GLGizmoMmuSegmentation::on_opening()
 {
-    if (wxGetApp().filaments_cnt() > int(GLGizmoMmuSegmentation::EXTRUDERS_LIMIT))
+    if (wxGetApp().filaments_cnt() > int(EnforcerBlockerType::ExtruderMax))
         show_notification_extruders_limit_exceeded();
 }
 
@@ -180,7 +180,7 @@ void GLGizmoMmuSegmentation::data_changed(bool is_serializing)
     ModelObject* model_object = m_c->selection_info()->model_object();
     int prev_extruders_count = int(m_extruders_colors.size());
     if (prev_extruders_count != wxGetApp().filaments_cnt()) {
-        if (wxGetApp().filaments_cnt() > int(GLGizmoMmuSegmentation::EXTRUDERS_LIMIT))
+        if (wxGetApp().filaments_cnt() > int(EnforcerBlockerType::ExtruderMax))
             show_notification_extruders_limit_exceeded();
 
         this->init_extruders_data();
@@ -247,7 +247,7 @@ static void render_extruders_combo(const std::string& label,
     ImGui::BeginGroup();
     ImVec2 combo_pos = ImGui::GetCursorScreenPos();
     if (ImGui::BeginCombo(label.c_str(), "")) {
-        for (size_t extruder_idx = 0; extruder_idx < std::min(extruders.size(), GLGizmoMmuSegmentation::EXTRUDERS_LIMIT); ++extruder_idx) {
+        for (size_t extruder_idx = 0; extruder_idx < std::min(extruders.size(), static_cast<size_t>(EnforcerBlockerType::ExtruderMax)); ++extruder_idx) {
             ImGui::PushID(int(extruder_idx));
             ImVec2 start_position = ImGui::GetCursorScreenPos();
 
@@ -412,7 +412,7 @@ void GLGizmoMmuSegmentation::on_render_input_window(float x, float y, float bott
         color_button_high = ImGui::GetCursorPos().y - color_button - 2.0;
         if (color_picked) { m_selected_extruder_idx = extruder_idx; }
 
-        if (extruder_idx < 16 && ImGui::IsItemHovered()) m_imgui->tooltip(_L("Shortcut Key ") + std::to_string(extruder_idx + 1), max_tooltip_width);
+        if (extruder_idx < 9 && ImGui::IsItemHovered()) m_imgui->tooltip(_L("Shortcut Key ") + std::to_string(extruder_idx + 1), max_tooltip_width);
 
         // draw filament id
         float gray = 0.299 * extruder_color.r() + 0.587 * extruder_color.g() + 0.114 * extruder_color.b();

--- a/src/slic3r/GUI/Gizmos/GLGizmoMmuSegmentation.hpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoMmuSegmentation.hpp
@@ -72,12 +72,6 @@ public:
 
     void data_changed(bool is_serializing) override;
 
-    // TriangleSelector::serialization/deserialization has a limit to store 19 different states.
-    // EXTRUDER_LIMIT + 1 states are used to storing the painting because also uncolored triangles are stored.
-    // When increasing EXTRUDER_LIMIT, it needs to ensure that TriangleSelector::serialization/deserialization
-    // will be also extended to support additional states, requiring at least one state to remain free out of 19 states.
-    static const constexpr size_t EXTRUDERS_LIMIT = 16;
-
     const float get_cursor_radius_min() const override { return CursorRadiusMin; }
 
     // BBS


### PR DESCRIPTION
The color painting tool has been hardcoded to 16 filaments for a very long time, with the limit baked into both the gizmo UI (EXTRUDERS_LIMIT) and the on-disk paint_color encoding (whose 6-bit form maxes out at state 18 -- though has never actually used or allowed higher than 16).  Users with MMUs such as TradRack where exceeding 16 is relatively easy simply could not paint anything beyond the 16th extruder.

This fixes #7172 (which was auto-closed by a bot with no real justification, without being actually fixed or closed).

This PR extends the 3MF format with a companion attribute, paint_color_ext, that carries override values for high-index extruders that don't fit in the legacy encoding, and raises the runtime cap to 127 (the int8_t bound of EnforcerBlockerType, which is where paint overrides are crammed).

File format design
------------------

The existing `paint_color` attribute encodes a per-triangle binary subdivision tree, with each leaf carrying a state in 0..16 (0 means no specific colour is set; 1 to 16 mean that indexed colour).  The new paint_color_ext attribute is a comma-separated list of decimal integers, one per NONE-state leaf in tree-traversal order:

0    -> leaf is genuinely unpainted (i.e. NONE means NONE)
N>0  -> leaf is actually ExtruderN (i.e. NONE means N)

The 3mf writer then substitutes high-index leaves with NONE in the `paint_color` field, and records the real value in `paint_color_ext`. `paint_color_ext` is only emitted for triangles that actually use high-index colors; every other triangle's encoding is byte-identical to what an unmodified slicer produces, so using this with 16 or fewer filaments doesn't change the resulting 3mf output at all.

Backward / forward compatibility

| File contents                         | Old slicers               | New slicer |
|---------------------------------------|---------------------------|------------|
| <=16 extruder paint                   | ok                        | ok         |
| Mixed paint, low-index filaments only | ok                        | ok         |
| Triangles with high-index filaments   | high-index leaves -> NONE | ok         |

Old slicers ignore the unknown paint_color_ext attribute and read the remaining paint_color (which carries NONE for high-index leaves), giving a lossy-but-coherent fallback - no crashes, no corruption.  They lose the high-index painting, but they don't support that to begin with.

OrcaSlicer with this PR applied that see NONE in the paint color check to see if the extended attribute is present, and if so read the attribute value from it, preserving the full range of painted filament colours in a backwards compatible way.

Other changes in this PR to make it work:

- EnforcerBlockerType: drop the unused named Extruder3..16 entries, bump ExtruderMax from 16 to 127.  In theory nothing prevents this from going higher, but 127 is the largest value we can hold in the current enum underlying value (int8_t).
- Remove an assert(false) in TriangleSelector::deserialize that would crash debug builds when a file legitimately referenced a state above max_ebt (e.g. after the user reduces the configured filament count). The silent NONE fallback that follows the assert (and would be applied by release builds) was already correct.
- Rewrote TriangleSelector::get_facets(per_type) as a single pass over m_triangles, with per-type vertex maps allocated lazily for types that actually appear. The previous loop walked the triangle list once per state and allocated a vertex_map per state up front, doing redundant work proportional to ExtruderMax even when most states were unused. Bumping ExtruderMax to 127 made the redundancy more visible; the rewrite avoids the dependency entirely.
- GLGizmoMmuSegmentation:
  - drop the redundant EXTRUDERS_LIMIT constant and just use EnforcerBlockerType::ExtruderMax directly rather than having two constants for the same thing.
  - Tighten the shortcut tooltip range from <16 to <9 to match what the direct-key shortcut handler actually covers: that is the tooltip has been showing "Shortcut Key 14" but that is nonsense.  Now the tooltip is only shown for 1-9, where there actually is a shortcut available.

# Screenshots

<img width="1305" height="524" alt="Screenshot From 2026-04-28 19-53-22" src="https://github.com/user-attachments/assets/aa9439ca-a135-406a-a27e-6751c749cce6" />


Sliced:

<img width="1357" height="767" alt="image" src="https://github.com/user-attachments/assets/c2df78c6-567a-4471-9501-aa324a0a7646" />


# Tests

I did various manual testing on this:
- loading existing MMU files - worked
- saving painted MMU with all indices <= 16 - worked
  - loaded this PR output file in OrcaSlicer stable release.  As designed, it loses the high index painting, but is otherwise fine: 
<img width="820" height="183" alt="image" src="https://github.com/user-attachments/assets/4dfcd58e-fab5-4c2e-bbb0-a7d48528d7b0" />
  - Verified that the 3mf XML contains paint_color_ext attributes only when filaments with index > 16 colours are painted.
- Inspected the resulting gcode files to ensure all T* tool changes are present (All of T0 through T17 for my 18 colour test).

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
