### PR TITLE
Fix CLI multi-color slicing crash for single-extruder AMS printers

### DIFF
--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -9115,8 +9115,9 @@ void DynamicPrintConfig::update_values_to_printer_extruders(DynamicPrintConfig& 
 
         if (extruder_id > 0 && extruder_id <= static_cast<unsigned> (extruder_count)) {
             variant_index.resize(1);
-            ExtruderType extruder_type = (ExtruderType)(opt_extruder_type->get_at(extruder_id - 1));
-            NozzleVolumeType nozzle_volume_type = (NozzleVolumeType)(opt_nozzle_volume_type->get_at(extruder_id - 1));
+            int eid = std::clamp((int)(extruder_id - 1), 0, (int)opt_extruder_type->size() - 1);
+            ExtruderType extruder_type = (ExtruderType)(opt_extruder_type->get_at(eid));
+            NozzleVolumeType nozzle_volume_type = (NozzleVolumeType)(opt_nozzle_volume_type->get_at(std::clamp((int)(extruder_id - 1), 0, (int)opt_nozzle_volume_type->size() - 1)));
 
             //variant index
             variant_index[0] = get_index_for_extruder(extruder_id, id_name, extruder_type, nozzle_volume_type, variant_name);
@@ -9293,11 +9294,16 @@ void DynamicPrintConfig::update_values_to_printer_extruders_for_multiple_filamen
         std::vector<int> variant_index;
 
         variant_index.resize(filament_count, -1);
+        int extruder_type_size = (int)opt_extruder_type->size();
+        int nozzle_vol_type_size = (int)opt_nozzle_volume_type->size();
 
         for (int f_index = 0; f_index < filament_count; f_index++)
         {
-            ExtruderType extruder_type = (ExtruderType)(opt_extruder_type->get_at(filament_maps[f_index] - 1));
-            NozzleVolumeType nozzle_volume_type = (NozzleVolumeType)(opt_nozzle_volume_type->get_at(filament_maps[f_index] - 1));
+            // Clamp index to valid range - filament_maps may contain AMS slot numbers
+            // that exceed the extruder_type array size on single-extruder AMS printers
+            int ext_idx = std::clamp(filament_maps[f_index] - 1, 0, extruder_type_size - 1);
+            ExtruderType extruder_type = (ExtruderType)(opt_extruder_type->get_at(ext_idx));
+            NozzleVolumeType nozzle_volume_type = (NozzleVolumeType)(opt_nozzle_volume_type->get_at(std::clamp(filament_maps[f_index] - 1, 0, nozzle_vol_type_size - 1)));
 
             //variant index
             variant_index[f_index] = get_index_for_extruder(f_index+1, id_name, extruder_type, nozzle_volume_type, variant_name);


### PR DESCRIPTION
## Summary

Fixes a crash in CLI multi-color slicing when using `--load-assemble-list` with single-extruder AMS printers (P1S, P1P, X1C).

## Root Cause

`update_values_to_printer_extruders_for_multiple_filaments()` and `update_values_to_printer_extruders()` in `PrintConfig.cpp` access `extruder_type` and `nozzle_volume_type` arrays using `filament_maps[f_index] - 1` as the index. On single-extruder AMS printers:

- `filament_maps` contains AMS slot numbers like `[3, 4, 1]`
- `extruder_type` and `nozzle_volume_type` arrays have only 1-2 entries
- `get_at(3)` on a 2-element array → out-of-bounds access → crash

## Fix

Clamp the extruder index to the valid range before accessing the arrays:

```cpp
int ext_idx = std::clamp(filament_maps[f_index] - 1, 0, extruder_type_size - 1);
ExtruderType extruder_type = (ExtruderType)(opt_extruder_type->get_at(ext_idx));
```

Applied to both functions. 10 lines changed, minimal and safe.

## Testing

Tested CLI command that previously crashed:
```bash
orca-slicer \
  --load-settings "machine/Bambu Lab P1S 0.4 nozzle.json;process/0.20mm Standard @BBL X1C.json" \
  --load-filaments "filament.json;filament.json;filament.json;filament.json" \
  --load-assemble-list assemble.json \
  --slice 0 --export-3mf sliced.3mf
```

Where `assemble.json` uses `"filaments": [3]`, `[4]`, `[1]` with `"assemble_index": [1]` to merge parts into a multi-color object.

Crash trace before fix:
```
update_values_to_printer_extruders_for_multiple_filaments, Line 9275: extruder_count=1, different_extruder=1
[Segfault / Access Violation]
```

## Related Issues

- Fixes #13405
- Related: bambulab/BambuStudio#10465 (same bug in BambuStudio)