### PR TITLE
Fix outer wall for bridges

### DIFF
--- a/src/libslic3r/PerimeterGenerator.cpp
+++ b/src/libslic3r/PerimeterGenerator.cpp
@@ -1829,6 +1829,12 @@ void PerimeterGenerator::process_no_bridge(Surfaces& all_surfaces, coord_t perim
                                 }
                                 //TODO: add other polys as holes inside this one (-margin)
                             } else if (/*this->config->counterbore_hole_bridging.value == chbBridgesOverhangs || */this->config->counterbore_hole_bridging.value == chbBridges) {
+                                // Partially bridged counterbore handling should not rewrite generic bridge islands
+                                // because by doing so regular bridges will lose their overhang-wall perimeters.
+                                if (surface->expolygon.holes.empty()) {
+                                    unsupported_filtered.clear(); // "Partially bridged" only applies to hole-bearing bridge islands. 
+                                    continue;
+                                }
                                 //simplify to avoid most of artefacts from printing lines.
                                 ExPolygons bridgeable_simplified;
                                 for (ExPolygon& poly : bridgeable) {


### PR DESCRIPTION
## Summary

Fix a **regression** where enabling "Bridge counterbore holes" by "Partially bridged" **affected ordinary bridges** and caused them to **lose** their overhang-wall generation.

## The issue

When "Partially bridged" was enabled, regular bridges that had nothing to do with counterbore holes **could lose** their overhang walls / outer wall behavior. In preview this showed up as bridge regions being sliced differently than expected, with missing overhang-wall perimeters on normal bridge spans.

## Cause

The "Partially bridged" path was rewriting generic unsupported bridge islands, not just counterbore-like bridge surfaces.
That geometry rewrite happened **before** later perimeter classification, so ordinary bridge islands **could lose** the unsupported perimeter regions that are normally turned into overhang walls.

## Fix

Restrict Partially bridged processing to hole-bearing bridge islands only.
If the current bridge surface has no holes, skip the partial-bridge rewrite entirely.

## Result

Ordinary bridges **keep** their expected overhang walls even when Bridge counterbore holes is set to "Partially bridged".
Actual counterbore-like bridge islands **continue** to use partial-bridge processing.
**The setting no longer changes unrelated regular bridges.**

Fixes #13344

## Screenshots
- **Before:**
<img width="1755" height="428" alt="image" src="https://github.com/user-attachments/assets/36f8664f-fa97-41ce-be9c-4a892bea8131" />

<br>

- **After:**
<img width="1771" height="471" alt="image" src="https://github.com/user-attachments/assets/1bfce032-61b3-46dc-a0c5-319dbdfcf229" />
