### PR TITLE
Fix to raft checking logic for slow down layers

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -6387,7 +6387,7 @@ std::string GCode::_extrude(const ExtrusionPath &path, std::string description, 
             speed = is_perimeter(path.role()) ? m_config.get_abs_value("initial_layer_speed") :
                                                 m_config.get_abs_value("initial_layer_infill_speed");
         }
-    } else if (m_config.slow_down_layers > 1 && !m_config.raft_layers > 0) {
+    } else if (m_config.slow_down_layers > 1 && m_config.raft_layers == 0) {
         
         if (_layer > 0 && _layer < m_config.slow_down_layers) {
             const auto first_layer_speed =


### PR DESCRIPTION
# Description

Thanks to valerii-bokhan for picking this up issue when reviewing the previous pull requested (already merged): https://github.com/OrcaSlicer/OrcaSlicer/pull/13224

expression use this to detect when no raft was this (worked but not right):
} else if (m_config.slow_down_layers > 1 && !m_config.raft_layers > 0) {

corrected to use this logic:
} else if (m_config.slow_down_layers > 1 && m_config.raft_layers == 0) {

# Screenshots/Recordings/Graphs

No change to the previous slowdown functions including the slowing down of layers over raft 

## Tests

Compiled locally and check that logic works