### PR TITLE
Restore Z zoom-to-selection shortcut and document it in keyboard shortcuts

### DIFF
--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -3479,18 +3479,18 @@ void GLCanvas3D::on_char(wxKeyEvent& evt)
                     post_event(SimpleEvent(EVT_GLCANVAS_ORIENT));
                 break;
             }
-        //case 'Z':
-        //case 'z': {
-        //    if (!m_selection.is_empty())
-        //        zoom_to_selection();
-        //    else {
-        //        if (!m_volumes.empty())
-        //            zoom_to_volumes();
-        //        else
-        //            _zoom_to_box(m_gcode_viewer.get_paths_bounding_box());
-        //    }
-        //    break;
-        //}
+        case 'Z':
+        case 'z': {
+            if (!m_selection.is_empty())
+                zoom_to_selection();
+            else {
+                if (!m_volumes.empty())
+                    zoom_to_volumes();
+                else
+                    _zoom_to_box(m_gcode_viewer.get_paths_bounding_box());
+            }
+            break;
+        }
         case 'v':
         case 'V': { post_event(SimpleEvent(EVT_GLCANVAS_PRINTABLE)); break; }
         default:  { evt.Skip(); break; }

--- a/src/slic3r/GUI/KBShortcutsDialog.cpp
+++ b/src/slic3r/GUI/KBShortcutsDialog.cpp
@@ -257,6 +257,7 @@ void KBShortcutsDialog::fill_shortcuts()
             { "U", L("Gizmo measure") },
             { "Y", L("Gizmo assemble") },
             { "E", L("Gizmo brim ears") },
+            { "Z", L("Zoom to objects or selection") },
             { "I", L("Zoom in") },
             { "O", L("Zoom out") },
             { "V", L("Toggle printable for object/part") },


### PR DESCRIPTION
## Description

Restore the plain `Z`/`z` shortcut for zoom-to-selection behavior in the 3D canvas, and document this shortcut in the keyboard shortcuts dialog.

- Re-enables `Z`/`z` in `GLCanvas3D::on_char`:
  - selection exists -> `zoom_to_selection()`
  - no selection + volumes exist -> `zoom_to_volumes()`
  - otherwise -> `_zoom_to_box(m_gcode_viewer.get_paths_bounding_box())`
- Keeps `Ctrl/Cmd + Z` unchanged for Undo.
- Adds `Z` shortcut documentation to `KBShortcutsDialog`.

Issue relation:
- Partially addresses #13331 (adds the `Z` behavior and in-app shortcut docs; does not add `B` or view-menu entries).

Breaking changes / dependencies:
- None.

## Screenshots/Recordings/Graphs

N/A (keyboard shortcut behavior + shortcut list text update only).

## Tests

- Build on macOS arm64: `./build_release_macos.sh` completed successfully.
- Manual tests in app:
  - `Z` with selected object -> zoom to selection.
  - `Z` with no selection -> zoom to volumes (or G-code bounds fallback when no volumes).
  - `Cmd/Ctrl + Z` -> Undo still works.
  - `I` and `O` -> still zoom in/out.
  - `Ctrl + 0` -> still camera default view.

Made with [Cursor](https://cursor.com)