### PR TITLE
Fix uninitialized first_layer_time on CLI-sliced 3MF

### DIFF
--- a/src/libslic3r/GCode/ThumbnailData.hpp
+++ b/src/libslic3r/GCode/ThumbnailData.hpp
@@ -78,7 +78,7 @@ struct PlateBBoxData
     int first_extruder = 0;
     float nozzle_diameter = 0.4;
     std::string bed_type;
-    float first_layer_time;
+    float first_layer_time = 0.0f;
     // version 1: use view type ColorPrint (filament color)
     // version 2: use view type FilamentId (filament id)
     int version = 2;

--- a/src/slic3r/GUI/PartPlate.cpp
+++ b/src/slic3r/GUI/PartPlate.cpp
@@ -6198,7 +6198,7 @@ int PartPlateList::store_to_3mf_structure(PlateDataPtrs& plate_data_list, bool w
                     plate_data_item->filament_change_sequence = m_plate_list[i]->m_gcode_result->filament_change_sequence;
                     plate_data_item->nozzle_change_sequence = m_plate_list[i]->m_gcode_result->nozzle_change_sequence;
                     plate_data_item->optimal_assignment = m_plate_list[i]->m_gcode_result->optimal_assignment;
-                    plate_data_item->first_layer_time = std::to_string(m_plate_list[i]->cali_bboxes_data.first_layer_time);
+                    plate_data_item->first_layer_time = std::to_string(m_plate_list[i]->get_slice_result()->initial_layer_time);
 					Print *print                      = nullptr;
 					m_plate_list[i]->get_print((PrintBase **) &print, nullptr, nullptr);
 					if (print) {


### PR DESCRIPTION
# Description

PartPlate::store_to_3mf_structure read first_layer_time from the indirect cali_bboxes_data struct, which the GUI populates at Plater.cpp:10600 but the CLI never writes to. The result was uninitialized memory leaking into slice_info.config

Read directly from get_slice_result()->initial_layer_time, which is populated by GCodeProcessor::finalize() in both code paths and matches the pattern already used a few lines above for gcode_prediction.

Also default-initialize PlateBBoxData::first_layer_time to 0.0f as a defense against any other consumer reading it without an explicit write.

## Tests

Sliced the same benchy through the GUI and the CLI. `first_layer_time` would always have an invalid value on the CLI code path.