### PR TITLE
Non-Crossing  Tri-hexagon multiline

### DIFF
--- a/src/libslic3r/Fill/FillRectilinear.cpp
+++ b/src/libslic3r/Fill/FillRectilinear.cpp
@@ -3068,12 +3068,10 @@ bool FillRectilinear::fill_surface_trapezoidal(
         // Grid pattern parameters
         period     = coord_t((2.0 * d1 / params.density) * std::sqrt(2.0));
         base_angle = rotate_vector.first + M_PI_4; // 45
-    } else if (Pattern_type == 1 || Pattern_type == 2) {
-        // Triangular-family pattern parameters (triangles / stars WIP)
-        period     = coord_t(( 2.0 * d1 / params.density) * std::sqrt(3.0));
-        base_angle = rotate_vector.first + M_PI_2; //90
     } else {
-        return false;
+        // Triangular-family pattern parameters (triangles / stars)
+        period     = coord_t((2.0 * d1 / params.density) * std::sqrt(3.0));
+        base_angle = rotate_vector.first + M_PI_2; // 90
     }
 
     // Obtain the expolygon and rotate to align with pattern base angle

--- a/src/libslic3r/Fill/FillRectilinear.cpp
+++ b/src/libslic3r/Fill/FillRectilinear.cpp
@@ -3262,11 +3262,13 @@ bool FillRectilinear::fill_surface_trapezoidal(
     case 2: // Tri-hexagon / FillStars
     {
         // Pattern parameters
-        const coord_t hex_height = coord_t(0.5 * std::sqrt(3.0) * period);
-        const coord_t tri_height = hex_height / 2;
-        const coord_t d1_half = d1 / 2;
+        const coord_t hex_height     = coord_t(0.5 * std::sqrt(3.0) * period);
+        const coord_t tri_height     = hex_height / 2;
+        const coord_t d1_half        = d1 / 2;
         const coord_t chamfer_height = std::sqrt(3.0) * d1_half;
-        const coord_t d1_half_base = d1_half / std::sqrt(3.0);
+        const coord_t d1_half_base   = d1_half / std::sqrt(3.0);
+        const coord_t half_period    = period / 2;
+        const coord_t quarter_period = period / 4;
 
         bb.merge(align_to_grid(bb.center(), Point(period, tri_height)));
         const size_t layer_mod = infill_layer_id % 3;
@@ -3276,33 +3278,32 @@ bool FillRectilinear::fill_surface_trapezoidal(
         const coord_t half_h = bb.size().y() / 2;
 
         const coord_t num_periods_x = coord_t(std::ceil(half_w / double(period)));
-        coord_t num_periods_y = coord_t(std::ceil(half_h / double(hex_height)));
+        coord_t num_periods_y       = coord_t(std::ceil(half_h / double(hex_height)));
         if ((num_periods_y % 2) != 0)
             ++num_periods_y;
 
-        const coord_t x_alignment_shift = period / 2;
+        const coord_t x_alignment_shift = half_period;
         const coord_t y_alignment_shift = (2 * tri_height) / 3;
-        const coord_t x_min_aligned = -num_periods_x * period - x_alignment_shift;
-        const coord_t x_max_aligned =  num_periods_x * period - x_alignment_shift;
-        const coord_t y_min_aligned = -num_periods_y * hex_height - y_alignment_shift;
-        const coord_t y_max_aligned =  num_periods_y * hex_height - y_alignment_shift;
+        const coord_t x_min_aligned     = -num_periods_x * period - x_alignment_shift;
+        const coord_t x_max_aligned     = num_periods_x * period - x_alignment_shift;
+        const coord_t y_min_aligned     = -num_periods_y * hex_height - y_alignment_shift;
+        const coord_t y_max_aligned     = num_periods_y * hex_height - y_alignment_shift;
 
-        const size_t estimated_rows = (y_max_aligned - y_min_aligned) / hex_height + 2;
+        const size_t estimated_rows      = (y_max_aligned - y_min_aligned) / hex_height + 2;
         const size_t estimated_polylines = (estimated_rows + 1) * 2;
         polylines.reserve(estimated_polylines);
 
-        constexpr size_t k_points_per_star_cell = 7;
         Polyline star_row_normal;
-        star_row_normal.points.reserve(((x_max_aligned - x_min_aligned) / period + 1) * k_points_per_star_cell);
+        star_row_normal.points.reserve(((x_max_aligned - x_min_aligned) / period + 1) * 7);
         Polyline star_row_mirrored;
-        star_row_mirrored.points.reserve(((x_max_aligned - x_min_aligned) / period + 1) * k_points_per_star_cell);
+        star_row_mirrored.points.reserve(((x_max_aligned - x_min_aligned) / period + 1) * 7);
 
         for (coord_t x = x_min_aligned; x < x_max_aligned; x += period) {
             star_row_normal.points.emplace_back(Point(x, hex_height));                                               // P0
-            star_row_normal.points.emplace_back(Point(x + period / 4 - d1, hex_height));                             // P1
-            star_row_normal.points.emplace_back(Point(x + period / 4 + d1_half, hex_height - chamfer_height));       // P2
-            star_row_normal.points.emplace_back(Point(x + period / 2 - d1_half_base, tri_height + d1_half));         // P3
-            star_row_normal.points.emplace_back(Point(x + period / 2 + d1_half_base, tri_height + d1_half));         // P4
+            star_row_normal.points.emplace_back(Point(x + quarter_period - d1, hex_height));                         // P1
+            star_row_normal.points.emplace_back(Point(x + quarter_period + d1_half, hex_height - chamfer_height));   // P2
+            star_row_normal.points.emplace_back(Point(x + half_period - d1_half_base, tri_height + d1_half));        // P3
+            star_row_normal.points.emplace_back(Point(x + half_period + d1_half_base, tri_height + d1_half));        // P4
             star_row_normal.points.emplace_back(Point(x + (period * 3) / 4 - d1_half, hex_height - chamfer_height)); // P5
             star_row_normal.points.emplace_back(Point(x + (period * 3) / 4 + d1, hex_height));                       // P6
         }
@@ -3311,10 +3312,10 @@ bool FillRectilinear::fill_surface_trapezoidal(
         for (auto& p : star_row_mirrored.points)
             p.y() = hex_height - p.y();
 
-        size_t pair_idx = 0;
-        const coord_t global_x_shift = period / 2;
+        size_t pair_idx              = 0;
+        const coord_t global_x_shift = half_period;
         const coord_t global_y_shift = tri_height;
-        auto append_row_with_shift = [&polylines](const Polyline& row_template, coord_t x_shift, coord_t y_shift) {
+        auto append_row_with_shift   = [&polylines](const Polyline& row_template, coord_t x_shift, coord_t y_shift) {
             Polyline row = row_template;
             for (Point& p : row.points) {
                 p.x() += x_shift;
@@ -3325,7 +3326,7 @@ bool FillRectilinear::fill_surface_trapezoidal(
         };
 
         for (coord_t y = y_min_aligned; y < y_max_aligned; y += hex_height, ++pair_idx) {
-            const coord_t x_shift = (pair_idx % 2 == 0) ? 0 : period / 2;
+            const coord_t x_shift = (pair_idx % 2 == 0) ? 0 : half_period;
             append_row_with_shift(star_row_normal, x_shift + global_x_shift, y + global_y_shift);
             append_row_with_shift(star_row_mirrored, x_shift + global_x_shift, y + global_y_shift);
         }

--- a/src/libslic3r/Fill/FillRectilinear.cpp
+++ b/src/libslic3r/Fill/FillRectilinear.cpp
@@ -3259,13 +3259,11 @@ bool FillRectilinear::fill_surface_trapezoidal(
         break;
     }
 
-    case 2: // Stars (basic scaffold, point layout to be refined)
+    case 2: // Stars
     {
         // Keep period and layer rotation behavior aligned with triangular infill.
-        // TODO: Replace row point templates with the final star points.
-        
         const coord_t hex_height = coord_t(0.5 * std::sqrt(3.0) * period);
-        const coord_t tri_height = hex_height/2;
+        const coord_t tri_height = hex_height / 2;
         const coord_t d1_half = d1 / 2;
         const coord_t chamfer_height = std::sqrt(3.0) * d1_half;
         const coord_t d1_half_base = d1_half / std::sqrt(3.0);
@@ -3278,7 +3276,7 @@ bool FillRectilinear::fill_surface_trapezoidal(
         const coord_t half_h = bb.size().y() / 2;
 
         const coord_t num_periods_x = coord_t(std::ceil(half_w / double(period)));
-        coord_t num_periods_y = coord_t(std::ceil(half_h / double(hex_height )));
+        coord_t num_periods_y = coord_t(std::ceil(half_h / double(hex_height)));
         if ((num_periods_y % 2) != 0)
             ++num_periods_y;
 
@@ -3291,10 +3289,11 @@ bool FillRectilinear::fill_surface_trapezoidal(
         const size_t estimated_polylines = (estimated_rows + 1) * 2;
         polylines.reserve(estimated_polylines);
 
+        constexpr size_t k_points_per_star_cell = 7;
         Polyline star_row_normal;
-        star_row_normal.points.reserve(((x_max_aligned - x_min_aligned) / period + 1) * 7);
-        Polyline star_row_shifted;
-        star_row_shifted.points.reserve(((x_max_aligned - x_min_aligned) / period + 1) * 7);
+        star_row_normal.points.reserve(((x_max_aligned - x_min_aligned) / period + 1) * k_points_per_star_cell);
+        Polyline star_row_mirrored;
+        star_row_mirrored.points.reserve(((x_max_aligned - x_min_aligned) / period + 1) * k_points_per_star_cell);
 
         for (coord_t x = x_min_aligned; x < x_max_aligned; x += period) {
             star_row_normal.points.emplace_back(Point(x, hex_height));                                               // P0
@@ -3306,31 +3305,30 @@ bool FillRectilinear::fill_surface_trapezoidal(
             star_row_normal.points.emplace_back(Point(x + (period * 3) / 4 + d1, hex_height));                       // P6
         }
 
-        star_row_shifted.points = star_row_normal.points;
-        for (auto& p : star_row_shifted.points)
+        star_row_mirrored.points = star_row_normal.points;
+        for (auto& p : star_row_mirrored.points)
             p.y() = hex_height - p.y();
 
         size_t pair_idx = 0;
         const coord_t global_x_shift = period / 2;
         const coord_t global_y_shift = tri_height;
+        auto append_row_with_shift = [&polylines](const Polyline& row_template, coord_t x_shift, coord_t y_shift) {
+            Polyline row = row_template;
+            for (Point& p : row.points) {
+                p.x() += x_shift;
+                p.y() += y_shift;
+            }
+            if (!row.points.empty())
+                polylines.emplace_back(std::move(row));
+        };
+
         for (coord_t y = y_min_aligned; y < y_max_aligned; y += hex_height, ++pair_idx) {
             const coord_t x_shift = (pair_idx % 2 == 0) ? 0 : period / 2;
+            const coord_t x_offset = x_shift + global_x_shift;
+            const coord_t y_offset = y + global_y_shift;
 
-            Polyline star_line_normal = star_row_normal;
-            for (Point& p : star_line_normal.points) {
-                p.x() += x_shift + global_x_shift;
-                p.y() += y + global_y_shift;
-            }
-            if (!star_line_normal.points.empty())
-                polylines.emplace_back(std::move(star_line_normal));
-
-            Polyline star_line_mirrored = star_row_shifted;
-            for (Point& p : star_line_mirrored.points) {
-                p.x() += x_shift + global_x_shift;
-                p.y() += y + global_y_shift;
-            }
-            if (!star_line_mirrored.points.empty())
-                polylines.emplace_back(std::move(star_line_mirrored));
+            append_row_with_shift(star_row_normal, x_offset, y_offset);
+            append_row_with_shift(star_row_mirrored, x_offset, y_offset);
         }
 
         if (layer_mod)

--- a/src/libslic3r/Fill/FillRectilinear.cpp
+++ b/src/libslic3r/Fill/FillRectilinear.cpp
@@ -3050,7 +3050,7 @@ bool FillRectilinear::fill_surface_trapezoidal(
     FillParams                                params,
     const std::initializer_list<SweepParams>& sweep_params,
     Polylines&                                polylines_out,
-    int                                       Pattern_type) // 0=grid, 1=triangular
+    int                                       Pattern_type) // 0=grid, 1=triangular, 2=stars (WIP)
 {
     assert(params.multiline > 1);
 
@@ -3068,10 +3068,12 @@ bool FillRectilinear::fill_surface_trapezoidal(
         // Grid pattern parameters
         period     = coord_t((2.0 * d1 / params.density) * std::sqrt(2.0));
         base_angle = rotate_vector.first + M_PI_4; // 45
-    } else {
-        // Triangular pattern parameters
+    } else if (Pattern_type == 1 || Pattern_type == 2) {
+        // Triangular-family pattern parameters (triangles / stars WIP)
         period     = coord_t(( 2.0 * d1 / params.density) * std::sqrt(3.0));
         base_angle = rotate_vector.first + M_PI_2; //90
+    } else {
+        return false;
     }
 
     // Obtain the expolygon and rotate to align with pattern base angle
@@ -3257,6 +3259,87 @@ bool FillRectilinear::fill_surface_trapezoidal(
         break;
     }
 
+    case 2: // Stars (basic scaffold, point layout to be refined)
+    {
+        // Keep period and layer rotation behavior aligned with triangular infill.
+        // TODO: Replace row point templates with the final star points.
+        
+        const coord_t hex_height = coord_t(0.5 * std::sqrt(3.0) * period);
+        const coord_t tri_height = hex_height/2;
+        const coord_t d1_half = d1 / 2;
+        const coord_t chamfer_height = std::sqrt(3.0) * d1_half;
+        const coord_t d1_half_base = d1_half / std::sqrt(3.0);
+
+        bb.merge(align_to_grid(bb.center(), Point(period, tri_height)));
+        const size_t layer_mod = infill_layer_id % 3;
+        const double angle     = layer_mod * 2.0 * M_PI / 3.0;
+
+        const coord_t half_w = bb.size().x() / 2;
+        const coord_t half_h = bb.size().y() / 2;
+
+        const coord_t num_periods_x = coord_t(std::ceil(half_w / double(period)));
+        coord_t num_periods_y = coord_t(std::ceil(half_h / double(hex_height )));
+        if ((num_periods_y % 2) != 0)
+            ++num_periods_y;
+
+        const coord_t x_min_aligned = -num_periods_x * period;
+        const coord_t x_max_aligned =  num_periods_x * period;
+        const coord_t y_min_aligned = -num_periods_y * hex_height;
+        const coord_t y_max_aligned =  num_periods_y * hex_height;
+
+        const size_t estimated_rows = (y_max_aligned - y_min_aligned) / hex_height + 2;
+        const size_t estimated_polylines = (estimated_rows + 1) * 2;
+        polylines.reserve(estimated_polylines);
+
+        Polyline star_row_normal;
+        star_row_normal.points.reserve(((x_max_aligned - x_min_aligned) / period + 1) * 7);
+        Polyline star_row_shifted;
+        star_row_shifted.points.reserve(((x_max_aligned - x_min_aligned) / period + 1) * 7);
+
+        for (coord_t x = x_min_aligned; x < x_max_aligned; x += period) {
+            star_row_normal.points.emplace_back(Point(x, hex_height));                                               // P0
+            star_row_normal.points.emplace_back(Point(x + period / 4 - d1, hex_height));                             // P1
+            star_row_normal.points.emplace_back(Point(x + period / 4 + d1_half, hex_height - chamfer_height));       // P2
+            star_row_normal.points.emplace_back(Point(x + period / 2 - d1_half_base, tri_height + d1_half));         // P3
+            star_row_normal.points.emplace_back(Point(x + period / 2 + d1_half_base, tri_height + d1_half));         // P4
+            star_row_normal.points.emplace_back(Point(x + (period * 3) / 4 - d1_half, hex_height - chamfer_height)); // P5
+            star_row_normal.points.emplace_back(Point(x + (period * 3) / 4 + d1, hex_height));                       // P6
+        }
+
+        star_row_shifted.points = star_row_normal.points;
+        for (auto& p : star_row_shifted.points)
+            p.y() = hex_height - p.y();
+
+        size_t pair_idx = 0;
+        const coord_t global_x_shift = period / 2;
+        const coord_t global_y_shift = tri_height;
+        for (coord_t y = y_min_aligned; y < y_max_aligned; y += hex_height, ++pair_idx) {
+            const coord_t x_shift = (pair_idx % 2 == 0) ? 0 : period / 2;
+
+            Polyline star_line_normal = star_row_normal;
+            for (Point& p : star_line_normal.points) {
+                p.x() += x_shift + global_x_shift;
+                p.y() += y + global_y_shift;
+            }
+            if (!star_line_normal.points.empty())
+                polylines.emplace_back(std::move(star_line_normal));
+
+            Polyline star_line_mirrored = star_row_shifted;
+            for (Point& p : star_line_mirrored.points) {
+                p.x() += x_shift + global_x_shift;
+                p.y() += y + global_y_shift;
+            }
+            if (!star_line_mirrored.points.empty())
+                polylines.emplace_back(std::move(star_line_mirrored));
+        }
+
+        if (layer_mod)
+            for (auto& pl : polylines)
+                pl.rotate(angle, Point(0, 0));
+
+        break;
+    }
+
     default:
         // Handle unknown pattern type
         break;
@@ -3408,11 +3491,19 @@ Polylines FillTriangles::fill_surface(const Surface *surface, const FillParams &
 Polylines FillStars::fill_surface(const Surface *surface, const FillParams &params)
 {
     Polylines polylines_out;
-    if (! this->fill_surface_by_multilines(
-            surface, params,
-            { { 0.f, 0.f }, { float(M_PI / 3.), 0.f }, { float(2. * M_PI / 3.), float((3./2.) * this->spacing * params.multiline / params.density) } },
-            polylines_out))
-        BOOST_LOG_TRIVIAL(error) << "FillStars::fill_surface() failed to fill a region.";
+    if (params.multiline > 1) {
+        if (!this->fill_surface_trapezoidal(
+                 surface, params,
+                 {{0.f, 0.f}, {float(M_PI / 3.), 0.f}, {float(2. * M_PI / 3.), float((3. / 2.) * this->spacing * params.multiline / params.density)}},
+                 polylines_out, 2))
+            BOOST_LOG_TRIVIAL(error) << "FillStars::fill_surface_trapezoidal() failed.";
+    } else {
+        if (! this->fill_surface_by_multilines(
+                surface, params,
+                { { 0.f, 0.f }, { float(M_PI / 3.), 0.f }, { float(2. * M_PI / 3.), float((3./2.) * this->spacing * params.multiline / params.density) } },
+                polylines_out))
+            BOOST_LOG_TRIVIAL(error) << "FillStars::fill_surface() failed to fill a region.";
+    }
     return polylines_out;
 }
 

--- a/src/libslic3r/Fill/FillRectilinear.cpp
+++ b/src/libslic3r/Fill/FillRectilinear.cpp
@@ -3280,10 +3280,12 @@ bool FillRectilinear::fill_surface_trapezoidal(
         if ((num_periods_y % 2) != 0)
             ++num_periods_y;
 
-        const coord_t x_min_aligned = -num_periods_x * period - period /2;
-        const coord_t x_max_aligned =  num_periods_x * period - period / 2;
-        const coord_t y_min_aligned = -num_periods_y * hex_height - tri_height * 2 / 3;
-        const coord_t y_max_aligned =  num_periods_y * hex_height - tri_height * 2 / 3;
+        const coord_t x_alignment_shift = period / 2;
+        const coord_t y_alignment_shift = (2 * tri_height) / 3;
+        const coord_t x_min_aligned = -num_periods_x * period - x_alignment_shift;
+        const coord_t x_max_aligned =  num_periods_x * period - x_alignment_shift;
+        const coord_t y_min_aligned = -num_periods_y * hex_height - y_alignment_shift;
+        const coord_t y_max_aligned =  num_periods_y * hex_height - y_alignment_shift;
 
         const size_t estimated_rows = (y_max_aligned - y_min_aligned) / hex_height + 2;
         const size_t estimated_polylines = (estimated_rows + 1) * 2;
@@ -3324,11 +3326,8 @@ bool FillRectilinear::fill_surface_trapezoidal(
 
         for (coord_t y = y_min_aligned; y < y_max_aligned; y += hex_height, ++pair_idx) {
             const coord_t x_shift = (pair_idx % 2 == 0) ? 0 : period / 2;
-            const coord_t x_offset = x_shift + global_x_shift;
-            const coord_t y_offset = y + global_y_shift;
-
-            append_row_with_shift(star_row_normal, x_offset, y_offset);
-            append_row_with_shift(star_row_mirrored, x_offset, y_offset);
+            append_row_with_shift(star_row_normal, x_shift + global_x_shift, y + global_y_shift);
+            append_row_with_shift(star_row_mirrored, x_shift + global_x_shift, y + global_y_shift);
         }
 
         if (layer_mod)

--- a/src/libslic3r/Fill/FillRectilinear.cpp
+++ b/src/libslic3r/Fill/FillRectilinear.cpp
@@ -3050,7 +3050,7 @@ bool FillRectilinear::fill_surface_trapezoidal(
     FillParams                                params,
     const std::initializer_list<SweepParams>& sweep_params,
     Polylines&                                polylines_out,
-    int                                       Pattern_type) // 0=grid, 1=triangular, 2=stars (WIP)
+    int                                       Pattern_type) // 0=grid, 1=triangular, 2=stars
 {
     assert(params.multiline > 1);
 
@@ -3259,9 +3259,9 @@ bool FillRectilinear::fill_surface_trapezoidal(
         break;
     }
 
-    case 2: // Stars
+    case 2: // Tri-hexagon / FillStars
     {
-        // Keep period and layer rotation behavior aligned with triangular infill.
+        // Pattern parameters
         const coord_t hex_height = coord_t(0.5 * std::sqrt(3.0) * period);
         const coord_t tri_height = hex_height / 2;
         const coord_t d1_half = d1 / 2;

--- a/src/libslic3r/Fill/FillRectilinear.cpp
+++ b/src/libslic3r/Fill/FillRectilinear.cpp
@@ -3280,10 +3280,10 @@ bool FillRectilinear::fill_surface_trapezoidal(
         if ((num_periods_y % 2) != 0)
             ++num_periods_y;
 
-        const coord_t x_min_aligned = -num_periods_x * period;
-        const coord_t x_max_aligned =  num_periods_x * period;
-        const coord_t y_min_aligned = -num_periods_y * hex_height;
-        const coord_t y_max_aligned =  num_periods_y * hex_height;
+        const coord_t x_min_aligned = -num_periods_x * period - period /2;
+        const coord_t x_max_aligned =  num_periods_x * period - period / 2;
+        const coord_t y_min_aligned = -num_periods_y * hex_height - tri_height * 2 / 3;
+        const coord_t y_max_aligned =  num_periods_y * hex_height - tri_height * 2 / 3;
 
         const size_t estimated_rows = (y_max_aligned - y_min_aligned) / hex_height + 2;
         const size_t estimated_polylines = (estimated_rows + 1) * 2;


### PR DESCRIPTION
# Description
I’ve added a trihexagon to the trapezoidal fill to prevent intersections and make the infill stronger; in the current infill, the strength is determined by the adhesion between the walls, and this improvement prevents the creation of concentric polygons.
Each layer is rotated by 120 degrees to ensure isotropy along the x and y axes.

 # Before:
<img width="961" height="974" alt="image" src="https://github.com/user-attachments/assets/33608086-dcad-4fda-b33a-aa14991e8402" />

# After:
<img width="995" height="964" alt="image" src="https://github.com/user-attachments/assets/71c9b5b3-f3d8-474a-8dc1-d0be2af2c08a" />
<img width="1280" height="1280" alt="image" src="https://github.com/user-attachments/assets/54021835-fe35-4083-8df0-ce05880587e1" />



[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
