### PR TITLE
Tell cmake it's targeting ARM64 on an ARM64 host

### DIFF
--- a/build_release_vs.bat
+++ b/build_release_vs.bat
@@ -9,6 +9,13 @@ for %%a in (%*) do (
     if "%%a"=="-x" set USE_NINJA=1
 )
 
+@REM Configure target architecture
+if "%PROCESSOR_ARCHITECTURE%"=="ARM64" (
+    set CMAKE_TARGET_ARCH="ARM64"
+) else (
+    set CMAKE_TARGET_ARCH="x64"
+)
+
 if "%USE_NINJA%"=="1" (
     echo Using Ninja Multi-Config generator
     set CMAKE_GENERATOR="Ninja Multi-Config"
@@ -116,7 +123,7 @@ if "%USE_NINJA%"=="1" (
     cmake ../ -G %CMAKE_GENERATOR% -DCMAKE_BUILD_TYPE=%build_type%
     cmake --build . --config %build_type% --target deps
 ) else (
-    cmake ../ -G %CMAKE_GENERATOR% -A x64 -DCMAKE_BUILD_TYPE=%build_type%
+    cmake ../ -G %CMAKE_GENERATOR% -A %CMAKE_TARGET_ARCH% -DCMAKE_BUILD_TYPE=%build_type%
     cmake --build . --config %build_type% --target deps -- -m
 )
 @echo off
@@ -135,7 +142,7 @@ if "%USE_NINJA%"=="1" (
     cmake .. -G %CMAKE_GENERATOR% -DORCA_TOOLS=ON %SIG_FLAG% -DCMAKE_BUILD_TYPE=%build_type%
     cmake --build . --config %build_type% --target ALL_BUILD
 ) else (
-    cmake .. -G %CMAKE_GENERATOR% -A x64 -DORCA_TOOLS=ON %SIG_FLAG% -DCMAKE_BUILD_TYPE=%build_type%
+    cmake .. -G %CMAKE_GENERATOR% -A %CMAKE_TARGET_ARCH% -DORCA_TOOLS=ON %SIG_FLAG% -DCMAKE_BUILD_TYPE=%build_type%
     cmake --build . --config %build_type% --target ALL_BUILD -- -m
 )
 @echo off


### PR DESCRIPTION
# Description

All dependencies are (attempted to be) compiled against ARM64 for Windows on ARM hosts.

Follow-up to https://github.com/OrcaSlicer/OrcaSlicer/pull/13424

Affects https://github.com/OrcaSlicer/OrcaSlicer/issues/5783

# Screenshots/Recordings/Graphs

N/A

## Tests

Kicked off `build_release_vs.bat` on my Windows ARM machine. Observed
progress in the build process!

<!--
> A guide for users on how to download the artifacts from this PR.
-->

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
