### PR TITLE
Linux: Fix GTK splash rendering during startup

### DIFF
--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -310,6 +310,7 @@ public:
         // draw logo and constant info text
         Decorate(m_main_bitmap);
         wxGetApp().UpdateFrameDarkUI(this);
+        set_bitmap(m_main_bitmap);
     }
 
     void SetText(const wxString& text)


### PR DESCRIPTION
## Problem

On Linux/GTK, the startup splash screen may not visibly render while OrcaSlicer is starting.

The splash window is created during startup, but on affected GTK environments the bitmap may not paint before startup continues into the next initialization steps. This leaves users without visible startup feedback.

<img width="400" height="395" alt="screenshot-2026-05-01_21-52-19_crop" src="https://github.com/user-attachments/assets/19048cda-74dc-4091-9647-0681ebf25103" />

## Root Cause

The splash bitmap is decorated during construction, but the updated bitmap is not explicitly applied to the splash window immediately.

Splash text updates also rely on pending paint events being processed while startup is still running synchronously. macOS already handles this by yielding after splash bitmap updates; GTK needs the same repaint opportunity.

## Fix

- Apply the decorated splash bitmap immediately after constructing it.
- Move splash repaint processing into a small helper.
- Use that repaint processing for GTK in addition to the existing macOS path.

<img width="400" height="393" alt="screenshot-2026-05-01_21-55-05_crop" src="https://github.com/user-attachments/assets/f5534deb-c413-4506-994e-4ac4a9d27c59" />

## Scope / Risk

Linux/GTK and macOS splash repaint behavior.

Windows is not affected. The change is limited to splash bitmap updates during startup and does not alter startup ordering or application initialization logic.

## Testing

- Built on Linux from current upstream `main`.
- Tested on Omarchy/Arch Linux with GTK under native Wayland on Hyprland.
- Before: the splash screen did not visibly render during startup.
- After: the splash screen renders during startup.
- Not tested: X11 / Windows / macOS.

<!--
> A guide for users on how to download the artifacts from this PR.
-->

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
