### PR TITLE
Fix crash ZAA

### DIFF
--- a/src/libslic3r/ExtrusionEntity.hpp
+++ b/src/libslic3r/ExtrusionEntity.hpp
@@ -491,7 +491,11 @@ public:
         { Polygons out; this->polygons_covered_by_spacing(out, scaled_epsilon); return out; }
     // Minimum volumetric velocity of this extrusion entity. Used by the constant nozzle pressure algorithm.
     double min_mm3_per_mm() const override;
-    Polyline as_polyline() const override { return this->polygon().split_at_first_point(); }
+    Polyline as_polyline() const override {
+        if (this->paths.empty() || this->length() <= 0.)
+            return Polyline();
+        return this->polygon().split_at_first_point();
+    }
     void   collect_polylines(Polylines &dst) const override { Polyline pl = this->as_polyline(); if (! pl.empty()) dst.emplace_back(std::move(pl)); }
     void   collect_points(Points &dst) const override {
         size_t n = std::accumulate(paths.begin(), paths.end(), 0, [](const size_t n, const ExtrusionPath &p){ return n + p.polyline.size(); });

--- a/src/libslic3r/Polygon.cpp
+++ b/src/libslic3r/Polygon.cpp
@@ -38,6 +38,9 @@ Polyline Polygon::split_at_vertex(const Point &point) const
 Polyline Polygon::split_at_index(int index) const
 {
     Polyline polyline;
+    if (this->points.empty())
+        return polyline;
+
     polyline.points.reserve(this->points.size() + 1);
     for (Points::const_iterator it = this->points.begin() + index; it != this->points.end(); ++it)
         polyline.points.push_back(*it);


### PR DESCRIPTION
# Description

When using ZAA, in some cases the first layer may be altered, creating degenerate polylines; I have added a safeguard for such cases to prevent the crash.


## Tests
[framebaroque.zip](https://github.com/user-attachments/files/27307267/framebaroque.zip)

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
