### PR TITLE
Fix hybrid tree first-layer support base behavior and expose density setting

### DIFF
--- a/src/libslic3r/Support/TreeSupport.cpp
+++ b/src/libslic3r/Support/TreeSupport.cpp
@@ -1593,13 +1593,20 @@ void TreeSupport::generate_toolpaths()
                     }
                     else {
                         // base_areas
-                        Flow flow               = (layer_id == 0 && m_raft_layers == 0) ? m_object->print()->brim_flow() : support_flow;
+                        bool support_base_on_bed = (layer_id == 0 && m_raft_layers == 0);
+                        Flow flow = support_base_on_bed ? m_support_params.first_layer_flow : support_flow;
                         bool need_infill = with_infill;
                         if(m_object_config->support_base_pattern==smpDefault)
                             need_infill &= area_group.need_infill;
-                        std::shared_ptr<Fill> filler_support = std::shared_ptr<Fill>(Fill::new_from_type(layer_id == 0 ? ipConcentric : m_support_params.base_fill_pattern));
+                        // Orca: Use rectilinear for support base on the bed
+                        const InfillPattern base_fill_pattern = support_base_on_bed ? ipRectilinear : m_support_params.base_fill_pattern;
+                        std::shared_ptr<Fill> filler_support = std::shared_ptr<Fill>(Fill::new_from_type(base_fill_pattern));
                         filler_support->set_bounding_box(bbox_object);
-                        filler_support->spacing = support_spacing * support_density; // constant spacing to align support infill lines
+
+                        filler_support->spacing =
+                            support_base_on_bed ?
+                            flow.spacing() : // Orca: On the bed-contacting support base layer, use first-layer flow spacing directly.
+                            support_spacing * support_density; // constant spacing to align support infill lines
                         filler_support->angle = Geometry::deg2rad(object_config.support_angle.value);
 
                         Polygons loops = to_polygons(poly);
@@ -1639,7 +1646,7 @@ void TreeSupport::generate_toolpaths()
                     // strengthen lightnings while it may make support harder. decide to enable it or not. if yes, proper values for params are remained to be tested
                     auto& lightning_layer = generator->getTreesForLayer(printZ_to_lightninglayer[print_z]);
 
-                    Flow       flow  = (layer_id == 0 && m_raft_layers == 0) ? m_object->print()->brim_flow() :support_flow;
+                    Flow       flow  = (layer_id == 0 && m_raft_layers == 0) ? m_support_params.first_layer_flow : support_flow;
                     ExPolygons areas = offset_ex(ts_layer->base_areas, -flow.scaled_spacing());
 
                     for (auto& area : areas)
@@ -2340,6 +2347,31 @@ void TreeSupport::draw_circles()
 
                     base_areas  = std::move(new_base_areas);
                     floor_areas = std::move(new_floor_areas);
+                }
+
+                // Orca: Hybrid tree first-layer expansion belongs only to the normal-support
+                // part. area_poly is collected from ePolygon nodes above, which are the normal
+                // support nodes in Hybrid mode. Apply the expansion before area_groups and
+                // lslices are built so toolpaths and brim avoidance use the same footprint.
+                if (layer_nr == 0 && m_raft_layers == 0 && m_support_params.support_style == smsTreeHybrid &&
+                    m_object_config->raft_first_layer_expansion.value > 0.f) {
+                    ExPolygons expanded_base_areas;
+                    const float inflate_factor_1st_layer = float(scale_(m_object_config->raft_first_layer_expansion.value));
+                    Polygons trimming = offset(m_object->layers().front()->lslices, float(scale_(m_support_params.gap_xy_first_layer)),
+                                               SUPPORT_SURFACES_OFFSET_PARAMETERS);
+                    // Orca: Match normal support expansion: grow in steps and re-trim against the object each time.
+                    const int nsteps = std::max(5, int(ceil(inflate_factor_1st_layer / m_support_params.first_layer_flow.scaled_width())));
+                    const float step = inflate_factor_1st_layer / nsteps;
+                    for (const ExPolygon &expoly : ts_layer->base_areas) {
+                        if (overlaps({ expoly }, area_poly)) { // normal support in Hybrid mode
+                            Polygons expanded = to_polygons(expoly);
+                            for (int i = 0; i < nsteps; ++i)
+                                expanded = diff(expand(expanded, step), trimming);
+                            append(expanded_base_areas, union_ex(expanded));
+                        } else
+                            expanded_base_areas.emplace_back(expoly);
+                    }
+                    ts_layer->base_areas = std::move(expanded_base_areas);
                 }
 
                 auto &area_groups = ts_layer->area_groups;

--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -788,9 +788,12 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig *config, co
 
     toggle_line("raft_contact_distance", have_raft && !have_support_soluble);
 
-    // Orca: Raft, grid, snug and organic supports use these two parameters to control the size & density of the "brim"/flange
-    for (auto el : { "raft_first_layer_expansion", "raft_first_layer_density"})
-        toggle_field(el, have_support_material && !(support_is_normal_tree && !have_raft));
+    // Orca: First-layer density is available for supports broadly.
+    toggle_field("raft_first_layer_density", have_support_material);
+    // Orca: For regular tree (Slim/Strong) without raft, hide first-layer expansion.
+    // Keep it enabled for non-tree supports, organic tree, hybrid tree, and any raft case.
+    toggle_field("raft_first_layer_expansion",
+                 have_support_material && ((!support_is_normal_tree || support_style == smsTreeHybrid) || have_raft));
 
     bool has_ironing = (config->opt_enum<IroningType>("ironing_type") != IroningType::NoIroning);
     for (auto el : { "ironing_pattern", "ironing_flow", "ironing_spacing", "ironing_angle", "ironing_inset", "ironing_angle_fixed" })


### PR DESCRIPTION
## The problems

Hybrid tree supports behaved incorrectly on the first layer.

Two separate issues affected the support base on the build plate:

- The first support layer used **brim flow** instead of **support material flow**.
- The regular support part of hybrid supports used incorrect first-layer spacing and density **when the first-layer line width differed from the regular support line width**.

This could lead to:

- over-extrusion or collisions on the first support layer
- incorrect spacing of the support base
- inconsistent results in multi-material prints, where brim and supports may use different materials

The interface was also misleading:

- the first-layer support density **affected** hybrid supports
- but the setting was **diabled** for this support style

---

## What changed

- The first layer of supports that touch the build plate now uses **support material flow** instead of brim flow.
- First-layer spacing on bed-contacting support base is now derived from the actual first-layer support flow.

**Hybrid tree supports:**
- The regular support part now uses correct first-layer spacing and density.
- First-layer expansion is applied only to the regular support part, not to tree-only regions.
- Tree-only regions use the existing brim expansion settings.
- The first-layer support pattern is aligned with normal and organic tree supports, ensuring consistent and meaningful density behavior.

**UI:**
- The first-layer expansion and density controls are now visible whenever supports are enabled.

---

## Notes

- The first-layer support density was already influencing hybrid supports before, but was not exposed in the UI.
- This change makes the behavior consistent and controllable.
- It also fixes incorrect behavior in multi-material prints, where supports and brim may use different materials.
- Fixes #13430

## Screenshots
- **Disabled density affecting hybrid first layer**
<img width="1496" height="563" alt="image" src="https://github.com/user-attachments/assets/d53b49c1-4aac-43e8-adfe-40d45d2bfcfb" />

<br><br>

- **Meaningless density for circular base pattern:**
<img width="1361" height="514" alt="image" src="https://github.com/user-attachments/assets/d7ade618-4b5a-497b-b40c-c6545f282698" />

<br><br>

- **Meaningfull density foir rectilinear base pattern:**
<img width="1195" height="559" alt="image" src="https://github.com/user-attachments/assets/e3496c35-8a8d-412b-abb7-766e3d48f2a1" />

<br><br>

- **First layer line width not taken into account**
<img width="1567" height="619" alt="image" src="https://github.com/user-attachments/assets/20aa42fe-1f23-4f05-a2a3-2371039244b4" />
<br>
<img width="1569" height="620" alt="image" src="https://github.com/user-attachments/assets/66221812-36aa-4dce-bd2f-bd2d1fad4caa" />

<br><br>

- **First layer line width taken into account**
<img width="1524" height="627" alt="image" src="https://github.com/user-attachments/assets/c159a76b-9d00-487c-969b-ba9f3d67ce5a" />
<br>
<img width="1516" height="626" alt="image" src="https://github.com/user-attachments/assets/107c627a-0e97-4891-8463-8f07e350c53e" />
