### PR TITLE
Fix/fixed unicode preset name issue

### DIFF
--- a/src/slic3r/GUI/PresetComboBoxes.cpp
+++ b/src/slic3r/GUI/PresetComboBoxes.cpp
@@ -1175,8 +1175,8 @@ void PlaterPresetComboBox::update()
         }
 
         bool single_bar = false;
-        wxString name = preset.name;
-        preset_aliases[name] = get_preset_name(preset).ToStdString(); // ORCA
+        wxString name = from_u8(preset.name);
+        preset_aliases[name] = get_preset_name(preset).utf8_string(); // ORCA
 
         // Track bundle names for bundled presets
         if (preset.is_from_bundle()) {
@@ -1232,7 +1232,7 @@ void PlaterPresetComboBox::update()
                 name = from_u8(is_selected && preset.is_dirty ? Preset::suffix_modified() + printer_model : printer_model);
 
                 if (system_printer_models.count(printer_model) == 0) {
-                    preset_aliases[name] = name.ToStdString(); // ORCA
+                    preset_aliases[name] = name.utf8_string(); // ORCA
                     system_presets.emplace(name, bmp);
                     system_printer_models.insert(printer_model);
                 }
@@ -1676,8 +1676,8 @@ void TabPresetComboBox::update()
         wxBitmap* bmp = get_bmp(preset);
         assert(bmp);
 
-        const wxString name = preset.name;
-        preset_aliases[name] = get_preset_name(preset).ToStdString();
+        const wxString name = from_u8(preset.name);
+        preset_aliases[name] = get_preset_name(preset).utf8_string();
         if (preset.is_system)
             preset_descriptions.emplace(name, from_u8(preset.description));
 

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -6808,10 +6808,10 @@ wxSizer* Tab::compatible_widget_create(wxWindow* parent, PresetDependencies &dep
         // Collect and set indices of depending_presets marked as compatible.
         wxArrayInt selections;
         auto *compatible_printers = dynamic_cast<const ConfigOptionStrings*>(m_config->option(deps.key_list));
-        if (compatible_printers != nullptr || !compatible_printers->values.empty())
+        if (compatible_printers != nullptr && !compatible_printers->values.empty())
             for (auto preset_name : compatible_printers->values)
                 for (size_t idx = 0; idx < presets.GetCount(); ++idx)
-                    if (presets[idx] == preset_name) {
+                    if (presets[idx] == from_u8(preset_name)) {
                         selections.Add(idx);
                         break;
                     }


### PR DESCRIPTION
# Description

Fixes crash issues that occur when the preset name contains Unicode characters.

# Screenshots/Recordings/Graphs

<!--
> Please attach relevant screenshots to showcase the UI changes.
> Please attach images that can help explain the changes.
-->

## Tests

<!--
> Please describe the tests that you have conducted to verify the changes made in this PR.
-->
