### PR TITLE
Fix extrusion of some support layers at wrong Z height (again)

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -6232,7 +6232,6 @@ std::string GCode::_extrude(const ExtrusionPath &path, std::string description, 
 
         gcode += this->travel_to(first_point, path.role(), "move to first " + description + " point", z);
 
-        m_need_change_layer_lift_z = false;
         // Orca: ensure Z matches planned layer height
         if (!slope_need_z_travel && (_last_pos_undefined || m_need_change_layer_lift_z)) {
             const std::string z_sync_comment = _last_pos_undefined ?


### PR DESCRIPTION
## The issue
PR #12736 reverted (made it not effective) the changes of PR #13327.

<img width="1462" height="461" alt="image" src="https://github.com/user-attachments/assets/e65b1383-4a29-4572-bbec-7d142132096a" />

## Fix
This PR recreates the intention of PR #13327.