### PR TITLE
Add action that runs clang-format

### DIFF
--- a/.devcontainer/postCreate.sh
+++ b/.devcontainer/postCreate.sh
@@ -13,3 +13,17 @@ echo "------------------------------"
 echo "Installing missing packages..."
 echo "------------------------------"
 apt install -y libgl1-mesa-dev m4 autoconf libtool
+
+echo "----------------------------------------------------------------"
+echo "Installing clang-format 18 (matches CI; Ubuntu 22.04 default repo only ships 14)"
+echo "----------------------------------------------------------------"
+apt install -y --no-install-recommends wget gnupg ca-certificates
+wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key \
+  | gpg --dearmor \
+  | tee /usr/share/keyrings/llvm-archive-keyring.gpg > /dev/null
+echo "deb [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] http://apt.llvm.org/jammy/ llvm-toolchain-jammy-18 main" \
+  > /etc/apt/sources.list.d/llvm-18.list
+apt update
+apt install -y --no-install-recommends clang-format-18
+update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-18 100
+update-alternatives --install /usr/bin/git-clang-format git-clang-format /usr/bin/git-clang-format-18 100

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -68,5 +68,5 @@ jobs:
         if: steps.linter.outputs.checks-failed > 0
         run: |
           echo "::error::clang-format violations detected. See the file annotations or the job step summary above for details."
-          echo "::error::To fix locally, install clang-format 18 and run: git clang-format origin/${{ github.base_ref }}"
+          echo "::error::To fix locally, run `git clang-format origin/main` in the devcontainer."
           exit 1

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -67,6 +67,17 @@ jobs:
       - name: Fail if formatting violations were found
         if: steps.linter.outputs.checks-failed > 0
         run: |
-          echo "::error::clang-format violations detected. See the file annotations or the job step summary above for details."
-          echo "::error::To fix locally, run `git clang-format origin/${{ github.base_ref }}` in the devcontainer."
+          echo "::error::clang-format violations detected. See file annotations or the job summary below."
+          cat >> "$GITHUB_STEP_SUMMARY" <<'EOF'
+
+          ### How to fix
+
+          Inside the devcontainer:
+
+          ```bash
+          git clang-format origin/${{ github.base_ref }}
+          ```
+
+          Then commit the changes and push.
+          EOF
           exit 1

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -68,5 +68,5 @@ jobs:
         if: steps.linter.outputs.checks-failed > 0
         run: |
           echo "::error::clang-format violations detected. See the file annotations or the job step summary above for details."
-          echo "::error::To fix locally, run `git clang-format origin/main` in the devcontainer."
+          echo "::error::To fix locally, run `git clang-format origin/${{ github.base_ref }}` in the devcontainer."
           exit 1

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,0 +1,72 @@
+name: Clang Format
+
+on:
+  pull_request:
+    branches:
+      - main
+      - release/*
+    paths:
+      - 'src/**/*.c'
+      - 'src/**/*.cc'
+      - 'src/**/*.cpp'
+      - 'src/**/*.cxx'
+      - 'src/**/*.h'
+      - 'src/**/*.hpp'
+      - 'src/**/*.hxx'
+      - 'tests/**/*.c'
+      - 'tests/**/*.cc'
+      - 'tests/**/*.cpp'
+      - 'tests/**/*.cxx'
+      - 'tests/**/*.h'
+      - 'tests/**/*.hpp'
+      - 'tests/**/*.hxx'
+      - 'sandboxes/**/*.c'
+      - 'sandboxes/**/*.cc'
+      - 'sandboxes/**/*.cpp'
+      - 'sandboxes/**/*.cxx'
+      - 'sandboxes/**/*.h'
+      - 'sandboxes/**/*.hpp'
+      - 'sandboxes/**/*.hxx'
+      - '.clang-format'
+      - '.github/workflows/clang-format.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  clang-format:
+    name: Clang Format
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Run clang-format on changed lines
+        id: linter
+        uses: cpp-linter/cpp-linter-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          style: file
+          version: '18'
+          tidy-checks: '-*'
+          ignore: 'deps_src|deps|resources|localization|cmake|scripts|tools|SoftFever_doc'
+          files-changed-only: true
+          lines-changed-only: true
+          file-annotations: true
+          step-summary: true
+          thread-comments: false
+          format-review: false
+          tidy-review: false
+
+      - name: Fail if formatting violations were found
+        if: steps.linter.outputs.checks-failed > 0
+        run: |
+          echo "::error::clang-format violations detected. See the file annotations or the job step summary above for details."
+          echo "::error::To fix locally, install clang-format 18 and run: git clang-format origin/${{ github.base_ref }}"
+          exit 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,15 @@ ctest --test-dir ./tests/fff_print
 - `#pragma once` for headers. Smart pointers and RAII preferred
 - Parallelization via TBB — be mindful of shared state
 
+## Formatting
+
+`.clang-format` (clang-format 18), enforced on PR-changed lines by `.github/workflows/clang-format.yml`. Untouched code is left alone.
+
+```bash
+git clang-format --diff origin/main    # preview
+git clang-format origin/main           # apply
+```
+
 ## Key Entry Points
 
 - App startup: `src/OrcaSlicer.cpp`


### PR DESCRIPTION
# Description

Hi! I'm interested in adding **Infrastructure of Quality** to the project. I noticed that this project is getting larger but its developer infrastructure is not super thorough. I hope I can contribute a little bit to this with some PRs and discussions.

This PR focuses on `clang-format`.

1. It adds a Github action that goes red when formatting fails in a PR. Means that formatting will never get worse from this point on
2. It adds clang-format into the dev container
3. It documents how to run `clang-format` for agents in `AGENTS.md`

To be clear, this only flags formatting in **added or changed code**. Not existing code. This prevents formatting standards drift, it doesn't format the entire repository (which would be great! But difficult to pull off in a repository this size and with this many contributors)

## Tests

### Current state of the repository's formatting

I ran clang format to see how large the drift was in this repository and it's uhh.. not pretty!

```bash
# drift.log contains the clang-format violations
$ wc drift.log
  904949  5338601 70249134 drift.log
```

### Devcontainer

<!--
> Please describe the tests that you have conducted to verify the changes made in this PR.
-->

## Considerations

### Version

- [ ] What version should `clang-format` target, and where is the single-source-of-truth for this version?

Where do I specify what version clang-format should even target? The current `.clang-format` file has a CPP version target, but it does't specify a `clang-format` target. There should be a single-source-of-truth for devtool versions somewhere.

I think it's probably best to treat the CI infrastructure as the single-source-of-truth, so the version in the github actions is the target version for anything else. The devcontainer version should match it, users running custom IDEs and tools should use it etc. That makes the most sense because it decides what passes and fails the check anyway, so..

Note, even though I'm deliberately installing clang-format-18 in the devcontainer, it _still_ differs from the clang-format version ran in the actions, the versions are different builds of clang-format-18. I don't think this should matter too much, but it's worth keeping in the back of your mind if there are any deprecations or feature differences that exist between different builds of clang-format-18

### Clang-format-18 installation is verbose

I install clang-format-18 in the devcontainer using `postCreate.sh`, but this is a bit verbose. If the container was bumped to a more recent version of Ubuntu, then it can be installed with `apt` directly without any verbose nonsense.

I think it would be good to introduce a PR that improves the devcontainer next, but I wanted to note it here directly.

Secondly, the container is currently running Ubuntu version 22.04, so even if you install 

### Clang-tidy

The action also included `clang-tidy`, but I have disabled it for now since there is no precedence for clang-tidy in this project. Is this desirable in the longer term?

### Documentation

- [ ] Where should user-facing clang-format documentation live?

Is there a good place in the developer part of the wiki where I can document how to run `clang format` specifically for the files changed using the devcontainer? Ideally this is something that can be linked to so it can be included in the format action error message

This is the short form of the documentation, but user-facing documentation should be a little more verbose. I'm more than happy to write the documentation once I'm supplied with a pointer of where it should live.

```bash
  # Preview what would change (dry-run, unified diff to stdout)                                                              
  git clang-format --diff origin/main                                                                                        
  
  # Apply the changes to your working tree                                                                                   
  git clang-format origin/main
                                                                                                                             
  # Review with `git diff`, then commit
  git add -u                                                                                                                 
  git commit --amend --no-edit    # if folding into your last commit
  # or:  git commit -m "Apply clang-format"             
```

Note that when the clang-format step fails, the user is presented with a summary provided by the action itself, and is then shown the following rendered as markdown for the failed check:

```md
### How to fix

Inside the devcontainer:

`git clang-format origin/${{ github.base_ref }}`

Then commit the changes and push.
```
Close #10917