### PR TITLE
tests: regression test that every PrintRegion/Object field is in a preset key list

### DIFF
--- a/tests/libslic3r/CMakeLists.txt
+++ b/tests/libslic3r/CMakeLists.txt
@@ -18,6 +18,7 @@ add_executable(${_TEST_NAME}_tests
     test_preset_setting_id.cpp
     test_preset_diff.cpp
     test_vendor_cache.cpp
+    test_preset_options.cpp
     test_elephant_foot_compensation.cpp
     test_fill_corner_smoothing.cpp
     test_filament_mixer.cpp

--- a/tests/libslic3r/test_preset_options.cpp
+++ b/tests/libslic3r/test_preset_options.cpp
@@ -1,0 +1,84 @@
+// Regression test for the "option in def + UI but missing from preset key list"
+// crash class.
+//
+// Background: the print preset's DynamicPrintConfig is seeded with only the
+// keys returned by Preset::print_options() (PresetBundle.cpp). If a new field
+// is added to PrintRegionConfig / PrintObjectConfig and registered via
+// print_config_def + a TabPrint optgroup, but forgotten from print_options(),
+// the option's CheckBox/SpinCtrl will still get built (because
+// append_single_option_line resolves the def), and on tab activation
+// reload_config -> get_config_value will dispatch to opt_bool/opt_int on a
+// DynamicPrintConfig that has no entry for the key. The accessor then null-
+// derefs the result of option<T>(key), and the process exits with no
+// recoverable error. We hit this on a feature branch when an option was added
+// to print_config_def + an optgroup but missed in s_Preset_print_options; the
+// crash signature was an opaque ACCESS_VIOLATION at offset 8 from null inside
+// inlined opt_bool, with no log line naming the key.
+//
+// We assert the inverse invariant: every key declared on PrintRegionConfig and
+// PrintObjectConfig must appear in Preset::print_options() or
+// Preset::filament_options() (the two preset key lists that seed a print
+// preset's DynamicConfig). Adding a new field to either macro list without
+// the corresponding s_Preset_print_options / s_Preset_filament_options entry
+// now fails this test instead of shipping as a runtime null-deref.
+
+#include <catch2/catch_all.hpp>
+
+#include "libslic3r/Preset.hpp"
+#include "libslic3r/PrintConfig.hpp"
+
+#include <set>
+
+using namespace Slic3r;
+
+namespace {
+
+// Region-level fields that are intentionally NOT in Preset::print_options() and
+// NOT in Preset::filament_options() — they are slicing-internal and have no
+// preset/UI exposure today. Listing them here keeps the invariant test honest
+// about the carve-out: if you add a new option, do NOT just add it here to
+// silence the test; add it to the appropriate preset key list.
+const std::set<std::string> kKnownOrphanRegionFields = {
+    "ironing_direction",
+    "wall_infill_order",
+};
+
+void check_keys_are_in_a_preset(const t_config_option_keys &keys,
+                                const std::string          &class_name)
+{
+    const auto &print_options    = Preset::print_options();
+    const auto &filament_options = Preset::filament_options();
+    const std::set<std::string> in_print(print_options.begin(),    print_options.end());
+    const std::set<std::string> in_fila (filament_options.begin(), filament_options.end());
+    for (const std::string &key : keys) {
+        DYNAMIC_SECTION(class_name << "::" << key) {
+            INFO("Field '" << key << "' on " << class_name
+                 << " is registered in print_config_def but NOT in "
+                    "Preset::print_options() OR Preset::filament_options(). "
+                    "If a TabPrint/TabFilament optgroup adds an option_line for "
+                    "this key, opt_bool/opt_int will null-deref on tab "
+                    "activation. Add it to s_Preset_print_options in "
+                    "src/libslic3r/Preset.cpp (or s_Preset_filament_options for "
+                    "per-filament overrides).");
+            const bool registered = in_print.count(key) || in_fila.count(key)
+                                 || kKnownOrphanRegionFields.count(key);
+            REQUIRE(registered);
+        }
+    }
+}
+
+} // namespace
+
+TEST_CASE("Every PrintRegionConfig field is registered in a preset key list",
+          "[Config][Preset]")
+{
+    check_keys_are_in_a_preset(PrintRegionConfig::defaults().keys(),
+                               "PrintRegionConfig");
+}
+
+TEST_CASE("Every PrintObjectConfig field is registered in a preset key list",
+          "[Config][Preset]")
+{
+    check_keys_are_in_a_preset(PrintObjectConfig::defaults().keys(),
+                               "PrintObjectConfig");
+}

--- a/tests/libslic3r/test_preset_options.cpp
+++ b/tests/libslic3r/test_preset_options.cpp
@@ -1,26 +1,18 @@
 // Regression test for the "option in def + UI but missing from preset key list"
 // crash class.
 //
-// Background: the print preset's DynamicPrintConfig is seeded with only the
-// keys returned by Preset::print_options() (PresetBundle.cpp). If a new field
-// is added to PrintRegionConfig / PrintObjectConfig and registered via
-// print_config_def + a TabPrint optgroup, but forgotten from print_options(),
-// the option's CheckBox/SpinCtrl will still get built (because
-// append_single_option_line resolves the def), and on tab activation
-// reload_config -> get_config_value will dispatch to opt_bool/opt_int on a
-// DynamicPrintConfig that has no entry for the key. The accessor then null-
-// derefs the result of option<T>(key), and the process exits with no
-// recoverable error. We hit this on a feature branch when an option was added
-// to print_config_def + an optgroup but missed in s_Preset_print_options; the
-// crash signature was an opaque ACCESS_VIOLATION at offset 8 from null inside
-// inlined opt_bool, with no log line naming the key.
+// The print preset's DynamicPrintConfig is seeded with only the keys returned by
+// Preset::print_options() (PresetBundle.cpp). A field added to PrintRegionConfig
+// or PrintObjectConfig and registered via print_config_def plus a TabPrint
+// optgroup, but left out of print_options(), still gets its control built; on tab
+// activation reload_config -> get_config_value dispatches to opt_bool/opt_int on a
+// DynamicPrintConfig with no entry for the key, and the accessor null-derefs the
+// result of option<T>(key).
 //
-// We assert the inverse invariant: every key declared on PrintRegionConfig and
-// PrintObjectConfig must appear in Preset::print_options() or
-// Preset::filament_options() (the two preset key lists that seed a print
-// preset's DynamicConfig). Adding a new field to either macro list without
-// the corresponding s_Preset_print_options / s_Preset_filament_options entry
-// now fails this test instead of shipping as a runtime null-deref.
+// The invariant asserted here is the inverse: every key declared on
+// PrintRegionConfig and PrintObjectConfig appears in Preset::print_options() or
+// Preset::filament_options(), the two preset key lists that seed a print preset's
+// DynamicConfig.
 
 #include <catch2/catch_all.hpp>
 
@@ -33,35 +25,28 @@ using namespace Slic3r;
 
 namespace {
 
-// Region-level fields that are intentionally NOT in Preset::print_options() and
-// NOT in Preset::filament_options() — they are slicing-internal and have no
-// preset/UI exposure today. Listing them here keeps the invariant test honest
-// about the carve-out: if you add a new option, do NOT just add it here to
-// silence the test; add it to the appropriate preset key list.
-const std::set<std::string> kKnownOrphanRegionFields = {
+// Deprecated keys renamed in handle_legacy() (ironing_direction ->
+// ironing_angle, wall_infill_order -> wall_sequence); neither is in a
+// preset list. Register new options in a preset list, not here.
+const std::set<std::string> kDeprecatedRegionFields = {
     "ironing_direction",
     "wall_infill_order",
 };
 
-void check_keys_are_in_a_preset(const t_config_option_keys &keys,
-                                const std::string          &class_name)
+void check_keys_are_in_a_preset(const t_config_option_keys& keys, const std::string& class_name)
 {
-    const auto &print_options    = Preset::print_options();
-    const auto &filament_options = Preset::filament_options();
-    const std::set<std::string> in_print(print_options.begin(),    print_options.end());
-    const std::set<std::string> in_fila (filament_options.begin(), filament_options.end());
-    for (const std::string &key : keys) {
-        DYNAMIC_SECTION(class_name << "::" << key) {
-            INFO("Field '" << key << "' on " << class_name
-                 << " is registered in print_config_def but NOT in "
-                    "Preset::print_options() OR Preset::filament_options(). "
-                    "If a TabPrint/TabFilament optgroup adds an option_line for "
-                    "this key, opt_bool/opt_int will null-deref on tab "
-                    "activation. Add it to s_Preset_print_options in "
-                    "src/libslic3r/Preset.cpp (or s_Preset_filament_options for "
-                    "per-filament overrides).");
-            const bool registered = in_print.count(key) || in_fila.count(key)
-                                 || kKnownOrphanRegionFields.count(key);
+    const auto& print_options    = Preset::print_options();
+    const auto& filament_options = Preset::filament_options();
+    const std::set<std::string> in_print(print_options.begin(), print_options.end());
+    const std::set<std::string> in_filament(filament_options.begin(), filament_options.end());
+    for (const std::string& key : keys) {
+        DYNAMIC_SECTION(class_name << "::" << key)
+        {
+            INFO("'" << key << "' on " << class_name
+                     << " is missing from "
+                        "Preset::print_options()/filament_options(); add it to "
+                        "s_Preset_print_options (or s_Preset_filament_options) in Preset.cpp.");
+            const bool registered = in_print.count(key) || in_filament.count(key) || kDeprecatedRegionFields.count(key);
             REQUIRE(registered);
         }
     }
@@ -69,16 +54,8 @@ void check_keys_are_in_a_preset(const t_config_option_keys &keys,
 
 } // namespace
 
-TEST_CASE("Every PrintRegionConfig field is registered in a preset key list",
-          "[Config][Preset]")
-{
-    check_keys_are_in_a_preset(PrintRegionConfig::defaults().keys(),
-                               "PrintRegionConfig");
-}
+TEST_CASE("Every PrintRegionConfig field is registered in a preset key list", "[Preset][Config]")
+{ check_keys_are_in_a_preset(PrintRegionConfig::defaults().keys(), "PrintRegionConfig"); }
 
-TEST_CASE("Every PrintObjectConfig field is registered in a preset key list",
-          "[Config][Preset]")
-{
-    check_keys_are_in_a_preset(PrintObjectConfig::defaults().keys(),
-                               "PrintObjectConfig");
-}
+TEST_CASE("Every PrintObjectConfig field is registered in a preset key list", "[Preset][Config]")
+{ check_keys_are_in_a_preset(PrintObjectConfig::defaults().keys(), "PrintObjectConfig"); }

--- a/tests/libslic3r/test_preset_options.cpp
+++ b/tests/libslic3r/test_preset_options.cpp
@@ -54,8 +54,16 @@ void check_keys_are_in_a_preset(const t_config_option_keys& keys, const std::str
 
 } // namespace
 
+// Bodies are laid out like the rest of the test suite rather than collapsed
+// onto the brace line.
+// clang-format off
 TEST_CASE("Every PrintRegionConfig field is registered in a preset key list", "[Preset][Config]")
-{ check_keys_are_in_a_preset(PrintRegionConfig::defaults().keys(), "PrintRegionConfig"); }
+{
+    check_keys_are_in_a_preset(PrintRegionConfig::defaults().keys(), "PrintRegionConfig");
+}
 
 TEST_CASE("Every PrintObjectConfig field is registered in a preset key list", "[Preset][Config]")
-{ check_keys_are_in_a_preset(PrintObjectConfig::defaults().keys(), "PrintObjectConfig"); }
+{
+    check_keys_are_in_a_preset(PrintObjectConfig::defaults().keys(), "PrintObjectConfig");
+}
+// clang-format on

--- a/tests/libslic3r/test_preset_options.cpp
+++ b/tests/libslic3r/test_preset_options.cpp
@@ -35,6 +35,7 @@ const std::set<std::string> kDeprecatedRegionFields = {
 
 void check_keys_are_in_a_preset(const t_config_option_keys& keys, const std::string& class_name)
 {
+    REQUIRE_FALSE(keys.empty());
     const auto& print_options    = Preset::print_options();
     const auto& filament_options = Preset::filament_options();
     const std::set<std::string> in_print(print_options.begin(), print_options.end());


### PR DESCRIPTION
## Summary

Test-only PR. Adds `tests/libslic3r/test_preset_options.cpp` — an invariant guard against a real crash class we tripped on a feature branch.

The print preset's `DynamicPrintConfig` is seeded by `PresetBundle` from the keys returned by `Preset::print_options()` (`Preset.cpp`). When a new field is added to `PrintRegionConfig` or `PrintObjectConfig` and registered via `print_config_def` + a `TabPrint` optgroup, but the maintainer forgets to add the key to `s_Preset_print_options`:

- The option's CheckBox/SpinCtrl still gets built — `append_single_option_line` resolves the def successfully.
- On tab activation, `Page::activate` → `reload_config` → `get_config_value` dispatches by type to `opt_bool` / `opt_int` / `opt_*` on a `DynamicPrintConfig` that has no entry for the key.
- The inlined accessor null-derefs `option<T>(key)` and the process exits with no recoverable error.

The crash signature is opaque: `ACCESS_VIOLATION` at offset 8 from null inside inlined `opt_bool`, no log line naming the missing key. Easy to introduce, hard to diagnose post-hoc.

The test asserts the inverse invariant: every `PrintRegionConfig` and `PrintObjectConfig` field key must appear in `Preset::print_options()` *or* `Preset::filament_options()` (the two preset key lists that seed a print preset's `DynamicConfig`). A new field added to either macro list without the corresponding `s_Preset_print_options` / `s_Preset_filament_options` entry now fails this test at build time instead of shipping as a runtime null-deref.

There's a small carve-out — `ironing_direction` and `wall_infill_order` are slicing-internal with no preset/UI exposure today, listed explicitly in `kKnownOrphanRegionFields`. The comment frames it as a tripwire, not an escape hatch: new options should land in the right preset key list, not the carve-out set.

## What changed since the previous version of this PR

The earlier revision also routed `opt_*` accessors through `option_throw<T>` so missing-key access raised `UnknownOptionException` instead of null-dereffing. We pulled that out: in real-world startup paths it converted previously-survivable accesses into uncaught exceptions and silently killed the slicer on Windows. The runtime-side change is gone; the test invariant — which catches the same failure class earlier and more cheaply — stays.

## Test plan

- [x] `tests/libslic3r/libslic3r_tests` — both new test cases pass on `main` (verified locally; only the 2 explicitly-carved-out orphans are missing from preset key lists).
- [ ] CI: full Linux/macOS/Windows/Flatpak build matrix + Unit Tests job.