### PR TITLE
Check filament compatibility by temp ranges

### DIFF
--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -1049,41 +1049,69 @@ FilamentCompatibilityType Print::check_multi_filaments_compatibility(
     const std::vector<int>& nozzle_temperature_range_low,
     const std::vector<int>& nozzle_temperature_range_high)
 {
-    const size_t count = std::min(print_temperatures.size(), std::min(nozzle_temperature_range_low.size(), nozzle_temperature_range_high.size()));
+    if (print_temperatures.size() != nozzle_temperature_range_low.size() ||
+        print_temperatures.size() != nozzle_temperature_range_high.size())
+        return FilamentCompatibilityType::HighLowMixed;
+
+    const size_t count = print_temperatures.size();
     if (count < 2)
         return FilamentCompatibilityType::Compatible;
 
     bool has_too_hot_mismatch = false;
     bool has_too_cold_mismatch = false;
 
-    auto is_range_unset = [](int low, int high) {
-        return low <= 0 && high <= 0;
+    struct TempRangeConstraint {
+        bool has_low = false;
+        bool has_high = false;
+        int low = 0;
+        int high = 0;
+    };
+
+    auto make_constraint = [](int low_raw, int high_raw) {
+        TempRangeConstraint constraint;
+        const bool low_set = low_raw > 0;
+        const bool high_set = high_raw > 0;
+
+        if (low_set && high_set) {
+            constraint.has_low = true;
+            constraint.has_high = true;
+            constraint.low = std::min(low_raw, high_raw);
+            constraint.high = std::max(low_raw, high_raw);
+        } else if (low_set) {
+            constraint.has_low = true;
+            constraint.low = low_raw;
+        } else if (high_set) {
+            constraint.has_high = true;
+            constraint.high = high_raw;
+        }
+
+        return constraint;
     };
 
     for (size_t i = 0; i < count; ++i) {
         const int temp_i = print_temperatures[i];
-        const int low_i  = std::min(nozzle_temperature_range_low[i], nozzle_temperature_range_high[i]);
-        const int high_i = std::max(nozzle_temperature_range_low[i], nozzle_temperature_range_high[i]);
-        const bool range_i_unset = is_range_unset(low_i, high_i);
+        const TempRangeConstraint range_i = make_constraint(nozzle_temperature_range_low[i], nozzle_temperature_range_high[i]);
 
         for (size_t j = i + 1; j < count; ++j) {
             const int temp_j = print_temperatures[j];
-            const int low_j  = std::min(nozzle_temperature_range_low[j], nozzle_temperature_range_high[j]);
-            const int high_j = std::max(nozzle_temperature_range_low[j], nozzle_temperature_range_high[j]);
-            const bool range_j_unset = is_range_unset(low_j, high_j);
+            const TempRangeConstraint range_j = make_constraint(nozzle_temperature_range_low[j], nozzle_temperature_range_high[j]);
 
             // Each material's print temperature should fit every other selected
             // material's recommended nozzle temperature range.
-            if (!range_j_unset) {
-                if (temp_i < low_j)
+            if (range_j.has_low) {
+                if (temp_i < range_j.low)
                     has_too_cold_mismatch = true;
-                if (temp_i > high_j)
+            }
+            if (range_j.has_high) {
+                if (temp_i > range_j.high)
                     has_too_hot_mismatch = true;
             }
-            if (!range_i_unset) {
-                if (temp_j < low_i)
+            if (range_i.has_low) {
+                if (temp_j < range_i.low)
                     has_too_cold_mismatch = true;
-                if (temp_j > high_i)
+            }
+            if (range_i.has_high) {
+                if (temp_j > range_i.high)
                     has_too_hot_mismatch = true;
             }
 
@@ -1155,18 +1183,35 @@ static void collect_filament_temperature_data(
     const size_t temp_count = print_config.nozzle_temperature.size();
     const size_t low_count  = print_config.nozzle_temperature_range_low.size();
     const size_t high_count = print_config.nozzle_temperature_range_high.size();
-
-    auto has_temp_range_data = [temp_count, low_count, high_count](unsigned int extruder_id) {
-        return extruder_id < temp_count && extruder_id < low_count && extruder_id < high_count;
-    };
+    const size_t filament_type_count = print_config.filament_type.size();
 
     for (const unsigned int extruder_id : extruders) {
-        if (!has_temp_range_data(extruder_id))
-            continue;
+        int temp = 0;
+        if (extruder_id < temp_count)
+            temp = print_config.nozzle_temperature.get_at(extruder_id);
+        else if (!print_temperatures.empty())
+            temp = print_temperatures.back();
 
-        print_temperatures.push_back(print_config.nozzle_temperature.get_at(extruder_id));
-        range_lows.push_back(print_config.nozzle_temperature_range_low.get_at(extruder_id));
-        range_highs.push_back(print_config.nozzle_temperature_range_high.get_at(extruder_id));
+        int low = extruder_id < low_count ? print_config.nozzle_temperature_range_low.get_at(extruder_id) : 0;
+        int high = extruder_id < high_count ? print_config.nozzle_temperature_range_high.get_at(extruder_id) : 0;
+
+        if (temp <= 0 || low <= 0 || high <= 0) {
+            int fallback_low = 0;
+            int fallback_high = 0;
+            const std::string filament_type = extruder_id < filament_type_count ? print_config.filament_type.get_at(extruder_id) : std::string();
+            MaterialType::get_temperature_range(filament_type, fallback_low, fallback_high);
+
+            if (temp <= 0)
+                temp = fallback_low;
+            if (low <= 0)
+                low = fallback_low;
+            if (high <= 0)
+                high = fallback_high;
+        }
+
+        print_temperatures.push_back(temp);
+        range_lows.push_back(low);
+        range_highs.push_back(high);
     }
 }
 

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -1044,29 +1044,45 @@ static StringObjectException layered_print_cleareance_valid(const Print &print, 
     return {};
 }
 
-FilamentCompatibilityType Print::check_multi_filaments_compatibility(const std::vector<std::string>& filament_types)
+FilamentCompatibilityType Print::check_multi_filaments_compatibility(
+    const std::vector<int>& print_temperatures,
+    const std::vector<int>& nozzle_temperature_range_low,
+    const std::vector<int>& nozzle_temperature_range_high)
 {
-    bool has_high_temperature_filament = false;
-    bool has_low_temperature_filament = false;
-    bool has_mid_temperature_filament = false;
+    const size_t count = std::min(print_temperatures.size(), std::min(nozzle_temperature_range_low.size(), nozzle_temperature_range_high.size()));
+    if (count < 2)
+        return FilamentCompatibilityType::Compatible;
 
-    for (const auto& type : filament_types) {
-        if (get_filament_temp_type(type) ==FilamentTempType::HighTemp)
-            has_high_temperature_filament = true;
-        else if (get_filament_temp_type(type) == FilamentTempType::LowTemp)
-            has_low_temperature_filament = true;
-        else if (get_filament_temp_type(type) == FilamentTempType::HighLowCompatible)
-            has_mid_temperature_filament = true;
+    bool has_too_hot_mismatch = false;
+    bool has_too_cold_mismatch = false;
+
+    for (size_t i = 0; i < count; ++i) {
+        const int temp_i = print_temperatures[i];
+        const int low_i  = std::min(nozzle_temperature_range_low[i], nozzle_temperature_range_high[i]);
+        const int high_i = std::max(nozzle_temperature_range_low[i], nozzle_temperature_range_high[i]);
+
+        for (size_t j = i + 1; j < count; ++j) {
+            const int temp_j = print_temperatures[j];
+            const int low_j  = std::min(nozzle_temperature_range_low[j], nozzle_temperature_range_high[j]);
+            const int high_j = std::max(nozzle_temperature_range_low[j], nozzle_temperature_range_high[j]);
+
+            // Each material's print temperature should fit every other selected
+            // material's recommended nozzle temperature range.
+            if (temp_i < low_j || temp_j < low_i)
+                has_too_cold_mismatch = true;
+            if (temp_i > high_j || temp_j > high_i)
+                has_too_hot_mismatch = true;
+
+            if (has_too_hot_mismatch && has_too_cold_mismatch)
+                return FilamentCompatibilityType::HighLowMixed;
+        }
     }
 
-    if (has_high_temperature_filament && has_low_temperature_filament)
-        return FilamentCompatibilityType::HighLowMixed;
-    else if (has_high_temperature_filament && has_mid_temperature_filament)
+    if (has_too_hot_mismatch)
         return FilamentCompatibilityType::HighMidMixed;
-    else if (has_low_temperature_filament && has_mid_temperature_filament)
+    if (has_too_cold_mismatch)
         return FilamentCompatibilityType::LowMidMixed;
-    else
-        return FilamentCompatibilityType::Compatible;
+    return FilamentCompatibilityType::Compatible;
 }
 
 bool Print::is_filaments_compatible(const std::vector<int>& filament_types)
@@ -1107,6 +1123,39 @@ int Print::get_compatible_filament_type(const std::set<int>& filament_types)
     return HighLowCompatible;
 }
 
+static void collect_filament_temperature_data(
+    const PrintConfig &print_config,
+    const std::vector<unsigned int> &extruders,
+    std::vector<int> &print_temperatures,
+    std::vector<int> &range_lows,
+    std::vector<int> &range_highs)
+{
+    print_temperatures.clear();
+    range_lows.clear();
+    range_highs.clear();
+
+    print_temperatures.reserve(extruders.size());
+    range_lows.reserve(extruders.size());
+    range_highs.reserve(extruders.size());
+
+    const size_t temp_count = print_config.nozzle_temperature.size();
+    const size_t low_count  = print_config.nozzle_temperature_range_low.size();
+    const size_t high_count = print_config.nozzle_temperature_range_high.size();
+
+    auto has_temp_range_data = [temp_count, low_count, high_count](unsigned int extruder_id) {
+        return extruder_id < temp_count && extruder_id < low_count && extruder_id < high_count;
+    };
+
+    for (const unsigned int extruder_id : extruders) {
+        if (!has_temp_range_data(extruder_id))
+            continue;
+
+        print_temperatures.push_back(print_config.nozzle_temperature.get_at(extruder_id));
+        range_lows.push_back(print_config.nozzle_temperature_range_low.get_at(extruder_id));
+        range_highs.push_back(print_config.nozzle_temperature_range_high.get_at(extruder_id));
+    }
+}
+
 //BBS: this function is used to check whether multi filament can be printed
 StringObjectException Print::check_multi_filament_valid(const Print& print)
 {
@@ -1135,57 +1184,64 @@ StringObjectException Print::check_multi_filament_valid(const Print& print)
                 if (print_object->config().support_interface_filament >= 1 && (unsigned int)print_object->config().support_interface_filament < num_extruders + 1)
                     obj_used_extruder_ids.insert((unsigned int) print_object->config().support_interface_filament - 1);
             }
-            std::vector<std::string> filament_types;
-            filament_types.reserve(obj_used_extruder_ids.size());
-            for (const auto &extruder_idx : obj_used_extruder_ids) filament_types.push_back(print_config.filament_type.get_at(extruder_idx));
+            std::vector<unsigned int> obj_used_extruders;
+            obj_used_extruders.reserve(obj_used_extruder_ids.size());
+            for (const int extruder_idx : obj_used_extruder_ids)
+                if (extruder_idx >= 0)
+                    obj_used_extruders.push_back(static_cast<unsigned int>(extruder_idx));
 
-            auto                  compatibility       = check_multi_filaments_compatibility(filament_types);// check for each object
+            std::vector<int> print_temperatures;
+            std::vector<int> range_lows;
+            std::vector<int> range_highs;
+            collect_filament_temperature_data(print_config, obj_used_extruders, print_temperatures, range_lows, range_highs);
+
+            auto                  compatibility       = check_multi_filaments_compatibility(print_temperatures, range_lows, range_highs); // check for each object
             Compatibility_each_obj.insert(compatibility);
         }
         StringObjectException ret;
         std::string           hypertext = "filament_mix_print";
         if (Compatibility_each_obj.count(FilamentCompatibilityType::HighLowMixed)){// at least one object has HighLowMixed
             if (enable_mix_printing) {
-                ret.string     = L("Printing high-temp and low-temp filaments together may cause nozzle clogging or printer damage.");
+                ret.string     = L("Some selected materials have print temperatures outside each other's recommended nozzle temperature ranges, which may cause nozzle clogging or printer damage.");
                 ret.is_warning = true;
                 // ret.hypetext   = hypertext;
             } else
-                ret.string = L("Printing high-temp and low-temp filaments together may cause nozzle clogging or printer damage. If you still want to print, you can enable the option in Preferences.");
+                ret.string = L("Some selected materials have print temperatures outside each other's recommended nozzle temperature ranges, which may cause nozzle clogging or printer damage. If you still want to print, you can enable the option in Preferences.");
         }else if (Compatibility_each_obj.count(FilamentCompatibilityType::LowMidMixed) || Compatibility_each_obj.count(FilamentCompatibilityType::HighMidMixed)){// at least one object has other Mixed
             ret.is_warning = true;
             // ret.hypetext   = hypertext;
-            ret.string     = L("Printing different-temp filaments together may cause nozzle clogging or printer damage.");
+            ret.string     = L("Some selected materials have print temperatures outside the recommended nozzle temperature range of other selected materials, which may cause nozzle clogging or printer damage.");
         }
         return ret;
     }
     std::vector<unsigned int> extruders = print.extruders();
-    std::vector<std::string> filament_types;
-    filament_types.reserve(extruders.size());
-    for (const auto& extruder_idx : extruders)
-        filament_types.push_back(print_config.filament_type.get_at(extruder_idx));
+    std::vector<int> print_temperatures;
+    std::vector<int> range_lows;
+    std::vector<int> range_highs;
+    collect_filament_temperature_data(print_config, extruders, print_temperatures, range_lows, range_highs);
 
-    auto compatibility = check_multi_filaments_compatibility(filament_types);
+    auto compatibility = check_multi_filaments_compatibility(print_temperatures, range_lows, range_highs);
     bool enable_mix_printing = !print.need_check_multi_filaments_compatibility();
 
     StringObjectException ret;
 
     if(compatibility == FilamentCompatibilityType::HighLowMixed){
         if(enable_mix_printing){
-            ret.string =L("Printing high-temp and low-temp filaments together may cause nozzle clogging or printer damage.");
+            ret.string =L("Some selected materials have print temperatures outside each other's recommended nozzle temperature ranges, which may cause nozzle clogging or printer damage.");
             ret.is_warning = true;
         }
         else{
-            ret.string =L("Printing high-temp and low-temp filaments together may cause nozzle clogging or printer damage. If you still want to print, you can enable the option in Preferences.");
+            ret.string =L("Some selected materials have print temperatures outside each other's recommended nozzle temperature ranges, which may cause nozzle clogging or printer damage. If you still want to print, you can enable the option in Preferences.");
         }
     }
     else if (compatibility == FilamentCompatibilityType::HighMidMixed) {
         ret.is_warning = true;
-        ret.string =L("Printing high-temp and mid-temp filaments together may cause nozzle clogging or printer damage.");
+        ret.string =L("Some selected materials have print temperatures outside the recommended nozzle temperature range of other selected materials, which may cause nozzle clogging or printer damage.");
 
     }
     else if (compatibility == FilamentCompatibilityType::LowMidMixed) {
         ret.is_warning = true;
-        ret.string = L("Printing mid-temp and low-temp filaments together may cause nozzle clogging or printer damage.");
+        ret.string = L("Some selected materials have print temperatures outside the recommended nozzle temperature range of other selected materials, which may cause nozzle clogging or printer damage.");
     }
 
     return ret;

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -1056,22 +1056,36 @@ FilamentCompatibilityType Print::check_multi_filaments_compatibility(
     bool has_too_hot_mismatch = false;
     bool has_too_cold_mismatch = false;
 
+    auto is_range_unset = [](int low, int high) {
+        return low <= 0 && high <= 0;
+    };
+
     for (size_t i = 0; i < count; ++i) {
         const int temp_i = print_temperatures[i];
         const int low_i  = std::min(nozzle_temperature_range_low[i], nozzle_temperature_range_high[i]);
         const int high_i = std::max(nozzle_temperature_range_low[i], nozzle_temperature_range_high[i]);
+        const bool range_i_unset = is_range_unset(low_i, high_i);
 
         for (size_t j = i + 1; j < count; ++j) {
             const int temp_j = print_temperatures[j];
             const int low_j  = std::min(nozzle_temperature_range_low[j], nozzle_temperature_range_high[j]);
             const int high_j = std::max(nozzle_temperature_range_low[j], nozzle_temperature_range_high[j]);
+            const bool range_j_unset = is_range_unset(low_j, high_j);
 
             // Each material's print temperature should fit every other selected
             // material's recommended nozzle temperature range.
-            if (temp_i < low_j || temp_j < low_i)
-                has_too_cold_mismatch = true;
-            if (temp_i > high_j || temp_j > high_i)
-                has_too_hot_mismatch = true;
+            if (!range_j_unset) {
+                if (temp_i < low_j)
+                    has_too_cold_mismatch = true;
+                if (temp_i > high_j)
+                    has_too_hot_mismatch = true;
+            }
+            if (!range_i_unset) {
+                if (temp_j < low_i)
+                    has_too_cold_mismatch = true;
+                if (temp_j > high_i)
+                    has_too_hot_mismatch = true;
+            }
 
             if (has_too_hot_mismatch && has_too_cold_mismatch)
                 return FilamentCompatibilityType::HighLowMixed;
@@ -1165,12 +1179,11 @@ StringObjectException Print::check_multi_filament_valid(const Print& print)
         bool enable_mix_printing = !print.need_check_multi_filaments_compatibility();
 
         for (const auto &objectID_t : print.print_object_ids()) {
-            std::set<int> obj_used_extruder_ids;
+            std::set<unsigned int> obj_used_extruder_ids;
             auto                     print_object = print.get_object(objectID_t);// current object
             if (print_object){
                 auto object_extruders_t = print_object->object_extruders(); // object used extruder
-                for (int extruder : object_extruders_t) {
-                    assert(extruder > 0);
+                for (unsigned int extruder : object_extruders_t) {
                     obj_used_extruder_ids.insert(extruder);
                 }
             }
@@ -1186,9 +1199,8 @@ StringObjectException Print::check_multi_filament_valid(const Print& print)
             }
             std::vector<unsigned int> obj_used_extruders;
             obj_used_extruders.reserve(obj_used_extruder_ids.size());
-            for (const int extruder_idx : obj_used_extruder_ids)
-                if (extruder_idx >= 0)
-                    obj_used_extruders.push_back(static_cast<unsigned int>(extruder_idx));
+            for (const unsigned int extruder_idx : obj_used_extruder_ids)
+                obj_used_extruders.push_back(extruder_idx);
 
             std::vector<int> print_temperatures;
             std::vector<int> range_lows;

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -1060,60 +1060,36 @@ FilamentCompatibilityType Print::check_multi_filaments_compatibility(
     bool has_too_hot_mismatch = false;
     bool has_too_cold_mismatch = false;
 
-    struct TempRangeConstraint {
-        bool has_low = false;
-        bool has_high = false;
-        int low = 0;
-        int high = 0;
+    auto normalize_bounds = [](int &low, int &high) {
+        low = low > 0 ? low : 0;
+        high = high > 0 ? high : 0;
+        if (low > 0 && high > 0 && low > high)
+            std::swap(low, high);
     };
 
-    auto make_constraint = [](int low_raw, int high_raw) {
-        TempRangeConstraint constraint;
-        const bool low_set = low_raw > 0;
-        const bool high_set = high_raw > 0;
-
-        if (low_set && high_set) {
-            constraint.has_low = true;
-            constraint.has_high = true;
-            constraint.low = std::min(low_raw, high_raw);
-            constraint.high = std::max(low_raw, high_raw);
-        } else if (low_set) {
-            constraint.has_low = true;
-            constraint.low = low_raw;
-        } else if (high_set) {
-            constraint.has_high = true;
-            constraint.high = high_raw;
-        }
-
-        return constraint;
+    auto update_mismatch = [&has_too_cold_mismatch, &has_too_hot_mismatch](int temp, int low, int high) {
+        if (low > 0 && temp < low)
+            has_too_cold_mismatch = true;
+        if (high > 0 && temp > high)
+            has_too_hot_mismatch = true;
     };
 
     for (size_t i = 0; i < count; ++i) {
         const int temp_i = print_temperatures[i];
-        const TempRangeConstraint range_i = make_constraint(nozzle_temperature_range_low[i], nozzle_temperature_range_high[i]);
+        int low_i = nozzle_temperature_range_low[i];
+        int high_i = nozzle_temperature_range_high[i];
+        normalize_bounds(low_i, high_i);
 
         for (size_t j = i + 1; j < count; ++j) {
             const int temp_j = print_temperatures[j];
-            const TempRangeConstraint range_j = make_constraint(nozzle_temperature_range_low[j], nozzle_temperature_range_high[j]);
+            int low_j = nozzle_temperature_range_low[j];
+            int high_j = nozzle_temperature_range_high[j];
+            normalize_bounds(low_j, high_j);
 
             // Each material's print temperature should fit every other selected
             // material's recommended nozzle temperature range.
-            if (range_j.has_low) {
-                if (temp_i < range_j.low)
-                    has_too_cold_mismatch = true;
-            }
-            if (range_j.has_high) {
-                if (temp_i > range_j.high)
-                    has_too_hot_mismatch = true;
-            }
-            if (range_i.has_low) {
-                if (temp_j < range_i.low)
-                    has_too_cold_mismatch = true;
-            }
-            if (range_i.has_high) {
-                if (temp_j > range_i.high)
-                    has_too_hot_mismatch = true;
-            }
+            update_mismatch(temp_i, low_j, high_j);
+            update_mismatch(temp_j, low_i, high_i);
 
             if (has_too_hot_mismatch && has_too_cold_mismatch)
                 return FilamentCompatibilityType::HighLowMixed;
@@ -1222,6 +1198,9 @@ StringObjectException Print::check_multi_filament_valid(const Print& print)
     if(print_config.print_sequence == PrintSequence::ByObject) {// use ByObject valid under ByObject print sequence
         std::set<FilamentCompatibilityType> Compatibility_each_obj;
         bool enable_mix_printing = !print.need_check_multi_filaments_compatibility();
+        std::vector<int> print_temperatures;
+        std::vector<int> range_lows;
+        std::vector<int> range_highs;
 
         for (const auto &objectID_t : print.print_object_ids()) {
             std::set<unsigned int> obj_used_extruder_ids;
@@ -1242,31 +1221,21 @@ StringObjectException Print::check_multi_filament_valid(const Print& print)
                 if (print_object->config().support_interface_filament >= 1 && (unsigned int)print_object->config().support_interface_filament < num_extruders + 1)
                     obj_used_extruder_ids.insert((unsigned int) print_object->config().support_interface_filament - 1);
             }
-            std::vector<unsigned int> obj_used_extruders;
-            obj_used_extruders.reserve(obj_used_extruder_ids.size());
-            for (const unsigned int extruder_idx : obj_used_extruder_ids)
-                obj_used_extruders.push_back(extruder_idx);
-
-            std::vector<int> print_temperatures;
-            std::vector<int> range_lows;
-            std::vector<int> range_highs;
+            std::vector<unsigned int> obj_used_extruders(obj_used_extruder_ids.begin(), obj_used_extruder_ids.end());
             collect_filament_temperature_data(print_config, obj_used_extruders, print_temperatures, range_lows, range_highs);
 
             auto                  compatibility       = check_multi_filaments_compatibility(print_temperatures, range_lows, range_highs); // check for each object
             Compatibility_each_obj.insert(compatibility);
         }
         StringObjectException ret;
-        std::string           hypertext = "filament_mix_print";
         if (Compatibility_each_obj.count(FilamentCompatibilityType::HighLowMixed)){// at least one object has HighLowMixed
             if (enable_mix_printing) {
                 ret.string     = L("Some selected materials have print temperatures outside each other's recommended nozzle temperature ranges, which may cause nozzle clogging or printer damage.");
                 ret.is_warning = true;
-                // ret.hypetext   = hypertext;
             } else
                 ret.string = L("Some selected materials have print temperatures outside each other's recommended nozzle temperature ranges, which may cause nozzle clogging or printer damage. If you still want to print, you can enable the option in Preferences.");
         }else if (Compatibility_each_obj.count(FilamentCompatibilityType::LowMidMixed) || Compatibility_each_obj.count(FilamentCompatibilityType::HighMidMixed)){// at least one object has other Mixed
             ret.is_warning = true;
-            // ret.hypetext   = hypertext;
             ret.string     = L("Some selected materials have print temperatures outside the recommended nozzle temperature range of other selected materials, which may cause nozzle clogging or printer damage.");
         }
         return ret;
@@ -1291,12 +1260,7 @@ StringObjectException Print::check_multi_filament_valid(const Print& print)
             ret.string =L("Some selected materials have print temperatures outside each other's recommended nozzle temperature ranges, which may cause nozzle clogging or printer damage. If you still want to print, you can enable the option in Preferences.");
         }
     }
-    else if (compatibility == FilamentCompatibilityType::HighMidMixed) {
-        ret.is_warning = true;
-        ret.string =L("Some selected materials have print temperatures outside the recommended nozzle temperature range of other selected materials, which may cause nozzle clogging or printer damage.");
-
-    }
-    else if (compatibility == FilamentCompatibilityType::LowMidMixed) {
+    else if (compatibility == FilamentCompatibilityType::HighMidMixed || compatibility == FilamentCompatibilityType::LowMidMixed) {
         ret.is_warning = true;
         ret.string = L("Some selected materials have print temperatures outside the recommended nozzle temperature range of other selected materials, which may cause nozzle clogging or printer damage.");
     }

--- a/src/libslic3r/Print.hpp
+++ b/src/libslic3r/Print.hpp
@@ -1087,7 +1087,10 @@ public:
     static FilamentTempType get_filament_temp_type(const std::string& filament_type);
     static int get_hrc_by_nozzle_type(const NozzleType& type);
     static std::vector<std::string> get_incompatible_filaments_by_nozzle(const float nozzle_diameter, const std::optional<NozzleVolumeType> nozzle_volume_type = std::nullopt);
-    static FilamentCompatibilityType check_multi_filaments_compatibility(const std::vector<std::string>& filament_types);
+    static FilamentCompatibilityType check_multi_filaments_compatibility(
+        const std::vector<int>& print_temperatures,
+        const std::vector<int>& nozzle_temperature_range_low,
+        const std::vector<int>& nozzle_temperature_range_high);
     // similar to check_multi_filaments_compatibility, but the input is int, and may be negative (means unset)
     static bool is_filaments_compatible(const std::vector<int>& types);
     // get the compatible filament type of a multi-material object

--- a/src/slic3r/GUI/CalibrationWizardPresetPage.cpp
+++ b/src/slic3r/GUI/CalibrationWizardPresetPage.cpp
@@ -1504,7 +1504,9 @@ bool CalibrationPresetPage::is_filaments_compatiable(const std::map<int, Preset*
     if (prests.empty()) return true;
 
     bed_temp = 0;
-    std::vector<std::string> filament_types;
+    std::vector<int> print_temperatures;
+    std::vector<int> range_lows;
+    std::vector<int> range_highs;
     for (auto &item : prests) {
         const auto& item_preset = item.second;
         if (!item_preset)
@@ -1530,15 +1532,22 @@ bool CalibrationPresetPage::is_filaments_compatiable(const std::map<int, Preset*
             if (bed_temp == 0)
                 bed_temp = bed_temp_int;
         }
-        std::string display_filament_type;
-        filament_types.push_back(item_preset->config.get_filament_type(display_filament_type, 0));
+
+        const ConfigOptionInts *opt_nozzle_temp = item_preset->config.option<ConfigOptionInts>("nozzle_temperature");
+        const ConfigOptionInts *opt_range_low   = item_preset->config.option<ConfigOptionInts>("nozzle_temperature_range_low");
+        const ConfigOptionInts *opt_range_high  = item_preset->config.option<ConfigOptionInts>("nozzle_temperature_range_high");
+        if (opt_nozzle_temp && opt_range_low && opt_range_high) {
+            print_temperatures.push_back(opt_nozzle_temp->get_at(0));
+            range_lows.push_back(opt_range_low->get_at(0));
+            range_highs.push_back(opt_range_high->get_at(0));
+        }
 
         // check is it in the filament blacklist
         if (!is_filament_in_blacklist(item.first, item_preset, error_tips))
             return false;
     }
 
-    if (Print::check_multi_filaments_compatibility(filament_types) == FilamentCompatibilityType::HighLowMixed) {
+    if (Print::check_multi_filaments_compatibility(print_temperatures, range_lows, range_highs) == FilamentCompatibilityType::HighLowMixed) {
         error_tips = _u8L("Cannot print multiple filaments which have large difference of temperature together. Otherwise, the extruder and nozzle may be blocked or damaged during printing");
         return false;
     }

--- a/src/slic3r/GUI/CalibrationWizardPresetPage.cpp
+++ b/src/slic3r/GUI/CalibrationWizardPresetPage.cpp
@@ -1537,22 +1537,24 @@ bool CalibrationPresetPage::is_filaments_compatiable(const std::map<int, Preset*
         const ConfigOptionInts *opt_nozzle_temp = item_preset->config.option<ConfigOptionInts>("nozzle_temperature");
         const ConfigOptionInts *opt_range_low   = item_preset->config.option<ConfigOptionInts>("nozzle_temperature_range_low");
         const ConfigOptionInts *opt_range_high  = item_preset->config.option<ConfigOptionInts>("nozzle_temperature_range_high");
-        const int nozzle_temp = opt_nozzle_temp ? opt_nozzle_temp->get_at(0) : 0;
+        int nozzle_temp = opt_nozzle_temp ? opt_nozzle_temp->get_at(0) : 0;
         int range_low = opt_range_low ? opt_range_low->get_at(0) : 0;
         int range_high = opt_range_high ? opt_range_high->get_at(0) : 0;
 
-        if (range_low <= 0 || range_high <= 0) {
+        if (nozzle_temp <= 0 || range_low <= 0 || range_high <= 0) {
             std::string filament_type;
             item_preset->get_filament_type(filament_type);
 
             int fallback_low = 0;
             int fallback_high = 0;
-            if (MaterialType::get_temperature_range(filament_type, fallback_low, fallback_high)) {
-                if (range_low <= 0)
-                    range_low = fallback_low;
-                if (range_high <= 0)
-                    range_high = fallback_high;
-            }
+            MaterialType::get_temperature_range(filament_type, fallback_low, fallback_high);
+
+            if (nozzle_temp <= 0)
+                nozzle_temp = fallback_low;
+            if (range_low <= 0)
+                range_low = fallback_low;
+            if (range_high <= 0)
+                range_high = fallback_high;
         }
 
         print_temperatures.push_back(nozzle_temp);

--- a/src/slic3r/GUI/CalibrationWizardPresetPage.cpp
+++ b/src/slic3r/GUI/CalibrationWizardPresetPage.cpp
@@ -1548,7 +1548,7 @@ bool CalibrationPresetPage::is_filaments_compatiable(const std::map<int, Preset*
     }
 
     if (Print::check_multi_filaments_compatibility(print_temperatures, range_lows, range_highs) == FilamentCompatibilityType::HighLowMixed) {
-        error_tips = _u8L("Cannot print multiple filaments which have large difference of temperature together. Otherwise, the extruder and nozzle may be blocked or damaged during printing");
+        error_tips = _u8L("Cannot print multiple filaments whose print temperatures are outside each other's recommended nozzle temperature ranges. Otherwise, the extruder and nozzle may be blocked or damaged during printing");
         return false;
     }
 

--- a/src/slic3r/GUI/CalibrationWizardPresetPage.cpp
+++ b/src/slic3r/GUI/CalibrationWizardPresetPage.cpp
@@ -4,6 +4,7 @@
 #include "Widgets/Label.hpp"
 #include "MsgDialog.hpp"
 #include "libslic3r/Print.hpp"
+#include "libslic3r/MaterialType.hpp"
 
 #include "DeviceCore/DevConfig.h"
 #include "DeviceCore/DevExtruderSystem.h"
@@ -1536,11 +1537,27 @@ bool CalibrationPresetPage::is_filaments_compatiable(const std::map<int, Preset*
         const ConfigOptionInts *opt_nozzle_temp = item_preset->config.option<ConfigOptionInts>("nozzle_temperature");
         const ConfigOptionInts *opt_range_low   = item_preset->config.option<ConfigOptionInts>("nozzle_temperature_range_low");
         const ConfigOptionInts *opt_range_high  = item_preset->config.option<ConfigOptionInts>("nozzle_temperature_range_high");
-        if (opt_nozzle_temp && opt_range_low && opt_range_high) {
-            print_temperatures.push_back(opt_nozzle_temp->get_at(0));
-            range_lows.push_back(opt_range_low->get_at(0));
-            range_highs.push_back(opt_range_high->get_at(0));
+        const int nozzle_temp = opt_nozzle_temp ? opt_nozzle_temp->get_at(0) : 0;
+        int range_low = opt_range_low ? opt_range_low->get_at(0) : 0;
+        int range_high = opt_range_high ? opt_range_high->get_at(0) : 0;
+
+        if (range_low <= 0 || range_high <= 0) {
+            std::string filament_type;
+            item_preset->get_filament_type(filament_type);
+
+            int fallback_low = 0;
+            int fallback_high = 0;
+            if (MaterialType::get_temperature_range(filament_type, fallback_low, fallback_high)) {
+                if (range_low <= 0)
+                    range_low = fallback_low;
+                if (range_high <= 0)
+                    range_high = fallback_high;
+            }
         }
+
+        print_temperatures.push_back(nozzle_temp);
+        range_lows.push_back(range_low);
+        range_highs.push_back(range_high);
 
         // check is it in the filament blacklist
         if (!is_filament_in_blacklist(item.first, item_preset, error_tips))


### PR DESCRIPTION
Closes #10543
Replace filament-type based compatibility checks with explicit temperature/range comparisons.

check_multi_filaments_compatibility now accepts vectors of print temperatures and nozzle range lows/highs and evaluates whether each material's print temperature fits within the others' recommended nozzle ranges.
Added collect_filament_temperature_data to gather per-extruder temperature and range data from PrintConfig.
Updated call sites (Print.cpp, Print.hpp and CalibrationWizardPresetPage.cpp) and adjusted user-facing warning text to reference mismatched temperature ranges rather than filament type categories.


[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
