### PR TITLE
Ripple Wiki and Improvements

### DIFF
--- a/src/libslic3r/Feature/FuzzySkin/FuzzySkin.cpp
+++ b/src/libslic3r/Feature/FuzzySkin/FuzzySkin.cpp
@@ -79,7 +79,7 @@ static std::unique_ptr<noise::module::Module> get_noise_module(const FuzzySkinCo
 //
 // Per-layer-group phase shifting works as follows:
 //   period_index  = floor(layer_id / layers_between_ripple_offset)
-//   phase_shift   = period_index * ripple_offset * 2π  [radians]
+//   phase_shift   = period_index * (ripple_offset / 100) * 2π  [radians]
 //
 // Setting layers_between_ripple_offset = 1 shifts the phase on every layer;
 // setting it to N makes N consecutive layers share the same pattern.
@@ -93,7 +93,7 @@ static double ripple_phase_shift_rad(const FuzzySkinConfig& cfg)
 
     const int    effective_layer = std::max(cfg.layer_id, 0);
     const int    period_index    = effective_layer / std::max(cfg.layers_between_ripple_offset, 1);
-    const double raw_shift       = period_index * cfg.ripple_offset * (2.0 * M_PI);
+    const double raw_shift       = period_index * (cfg.ripple_offset/100) * (2.0 * M_PI);
     return fmod(raw_shift, 2.0 * M_PI);
 }
 

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -3472,7 +3472,7 @@ void PrintConfigDef::init_fff_params()
     def = this->add("fuzzy_skin_ripples_per_layer", coInt);
     def->label = L("Number of ripples per layer");
     def->category = L("Others");
-    def->tooltip  = L("When using the Ripple noise type, this controls how many full cycles of ripples will be added per layer.");
+    def->tooltip  = L("Controls how many full cycles of ripples will be added per layer.");
     def->min = 1;
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionInt(15));
@@ -3480,11 +3480,11 @@ void PrintConfigDef::init_fff_params()
     def = this->add("fuzzy_skin_ripple_offset", coFloat);
     def->label = L("Ripple offset");
     def->category = L("Others");
-    def->tooltip = L("When using the Ripple noise type, shifts the ripple pattern forward along the print path by this amount each Layer-period.\n"
-                     "- A value of 0 keeps every layer identical.\n"
-                     "- A value equal to 0.5 shifts by a full half-wavelength, inverting the pattern.\n"
-                     "The shift is applied once per 'Layers between Ripple offset' layers, "
-                      "so consecutive layers within a period are printed identically on top of each other.");
+    def->tooltip = L("Shifts the ripple phase forward along the print path by the specified fraction of a wavelength each layer period.\n"
+                     "- 0 keeps every layer identical.\n"
+                     "- 0.5 shifts the pattern by half a wavelength, effectively inverting the phase.\n"
+                     "- 1 shifts the pattern by a full wavelength, returning to the original phase.\n\n"
+                     "The shift is applied once every number of layers set by Layers between ripple offset, so layers within the same group are printed identically.");
     def->min = 0;
     def->max = 1;
     def->mode = comAdvanced;
@@ -3493,11 +3493,10 @@ void PrintConfigDef::init_fff_params()
     def = this->add("fuzzy_skin_layers_between_ripple_offset", coInt);
     def->label = L("Layers between ripple offset");
     def->category = L("Others");
-    def->tooltip = L("When using the Ripple noise type with a non-zero layer offset, this controls how "
-                       "many consecutive layers share the same ripple phase before the offset is applied.\n"
-                       "For example, a period of 3 means layers 0, 1 and 2 are identical, then layers 3, 4 "
-                       "and 5 are shifted by one full 'Ripple layer offset', and so on.\n"
-                       "Set to 1 to shift on every layer.");
+    def->tooltip = L("Specifies how many consecutive layers share the same ripple phase before the offset is applied.\n"
+                     "For example:\n"
+                     "- 1 = Layer 1 is printed with the base ripple pattern, then layer 2 is shifted by the configured offset, then layer 3 returns to the base pattern, and so on.\n"
+                     "- 3 = Layers 1 to 3 are printed with the base ripple pattern, then layers 4 to 6 are shifted by the configured offset, then layers 7 to 9 return to the base pattern, etc.");
     def->min = 1;
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionInt(1));

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -3477,18 +3477,19 @@ void PrintConfigDef::init_fff_params()
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionInt(15));
 
-    def = this->add("fuzzy_skin_ripple_offset", coFloat);
+    def = this->add("fuzzy_skin_ripple_offset", coPercent);
     def->label = L("Ripple offset");
     def->category = L("Others");
-    def->tooltip = L("Shifts the ripple phase forward along the print path by the specified fraction of a wavelength each layer period.\n"
-                     "- 0 keeps every layer identical.\n"
-                     "- 0.5 shifts the pattern by half a wavelength, effectively inverting the phase.\n"
-                     "- 1 shifts the pattern by a full wavelength, returning to the original phase.\n\n"
+    def->tooltip = L("Shifts the ripple phase forward along the print path by the specified percentage of a wavelength each layer period.\n"
+                     "- 0% keeps every layer identical.\n"
+                     "- 50% shifts the pattern by half a wavelength, effectively inverting the phase.\n"
+                     "- 100% shifts the pattern by a full wavelength, returning to the original phase.\n\n"
                      "The shift is applied once every number of layers set by Layers between ripple offset, so layers within the same group are printed identically.");
     def->min = 0;
-    def->max = 1;
+    def->max = 100;
+    def->sidetext = ("%");
     def->mode = comAdvanced;
-    def->set_default_value(new ConfigOptionFloat(0.5));
+    def->set_default_value(new ConfigOptionPercent(50));
 
     def = this->add("fuzzy_skin_layers_between_ripple_offset", coInt);
     def->label = L("Layers between ripple offset");

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -3480,9 +3480,10 @@ void PrintConfigDef::init_fff_params()
     def = this->add("fuzzy_skin_ripple_offset", coFloat);
     def->label = L("Ripple offset");
     def->category = L("Others");
-    def->tooltip = L("When using the Ripple noise type, shifts the ripple pattern forward along the print path by this amount each "
-                     "layer-period. A value of 0 keeps every layer identical. A value equal to 0.5 shifts by a full "
-                     "half-wavelength, inverting the pattern. The shift is applied once per 'Layers between Ripple offset' layers, "
+    def->tooltip = L("When using the Ripple noise type, shifts the ripple pattern forward along the print path by this amount each Layer-period.\n"
+                     "- A value of 0 keeps every layer identical.\n"
+                     "- A value equal to 0.5 shifts by a full half-wavelength, inverting the pattern.\n"
+                     "The shift is applied once per 'Layers between Ripple offset' layers, "
                       "so consecutive layers within a period are printed identically on top of each other.");
     def->min = 0;
     def->max = 1;
@@ -3493,9 +3494,9 @@ void PrintConfigDef::init_fff_params()
     def->label = L("Layers between ripple offset");
     def->category = L("Others");
     def->tooltip = L("When using the Ripple noise type with a non-zero layer offset, this controls how "
-                       "many consecutive layers share the same ripple phase before the offset is applied. "
+                       "many consecutive layers share the same ripple phase before the offset is applied.\n"
                        "For example, a period of 3 means layers 0, 1 and 2 are identical, then layers 3, 4 "
-                       "and 5 are shifted by one full 'Ripple layer offset', and so on. "
+                       "and 5 are shifted by one full 'Ripple layer offset', and so on.\n"
                        "Set to 1 to shift on every layer.");
     def->min = 1;
     def->mode = comAdvanced;

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -1086,7 +1086,7 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionInt,                  fuzzy_skin_octaves))
     ((ConfigOptionFloat,                fuzzy_skin_persistence))
     ((ConfigOptionInt,                  fuzzy_skin_ripples_per_layer))
-    ((ConfigOptionFloat,                fuzzy_skin_ripple_offset))
+    ((ConfigOptionPercent,              fuzzy_skin_ripple_offset))
     ((ConfigOptionInt,                  fuzzy_skin_layers_between_ripple_offset))
     ((ConfigOptionFloat,                gap_infill_speed))
     ((ConfigOptionInt,                  sparse_infill_filament))


### PR DESCRIPTION
- Reformat and expand the tooltip text for ripple-related settings to improve readability.
- Change Ripple offset to be % instead of a `0.X` value

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
