### PR TITLE
ZAA: Add safety check and logic to avoid creating degenerate polygons in CountourZ

### DIFF
--- a/src/libslic3r/ContourZ.cpp
+++ b/src/libslic3r/ContourZ.cpp
@@ -51,7 +51,7 @@ static bool contour_extrusion_path(LayerRegion *region, const sla::IndexedMesh &
 	bool was_contoured = false;
 
     if (points.size() < 2) {
-        // Safety check. The loop below does handle handle paths with less than two points correctly.
+        // Safety check. The loop below does not handle paths with less than two points correctly.
         return false;
     }
 

--- a/src/libslic3r/ContourZ.cpp
+++ b/src/libslic3r/ContourZ.cpp
@@ -50,7 +50,12 @@ static bool contour_extrusion_path(LayerRegion *region, const sla::IndexedMesh &
 	Pointf3s contoured_points;
 	bool was_contoured = false;
 
-	for (Points3::const_iterator it = points.begin(); it != points.end()-1; ++it) {
+    if (points.size() < 2) {
+        // Safety check. The loop below does handle handle paths with less than two points correctly.
+        return false;
+    }
+
+    for (Points3::const_iterator it = points.begin(); it != points.end()-1; ++it) {
 		Vec2d p1d(unscale_(it->x()), unscale_(it->y()));
 		Vec2d p2d(unscale_((it+1)->x()), unscale_((it+1)->y()));
 		Linef line(p1d, p2d);
@@ -123,7 +128,14 @@ static bool contour_extrusion_path(LayerRegion *region, const sla::IndexedMesh &
 
             Vec3d new_point = {p.x(), p.y(), d};
 
-            if (contoured_points.size() >= 2) {
+            if (contoured_points.size() >= 2 && i != 0) {
+                // Normally, if the new point is collinear with the last two points, we do not add
+                // it to the list of contoured points. Instead we update the last point to be the
+                // new point. This is to avoid creating a large number of very short segments.
+                //
+                // However, if the new point corresponds to a point in the original path (i == 0),
+                // even if it is collinear, we add it anyway. This is to avoid creating a degenerate
+                // polygon with only two points, which may cause issues in downstream code.
                 double dist = Linef3::distance_to_infinite_squared(new_point, contoured_points[contoured_points.size() - 2],
                                                                    contoured_points[contoured_points.size() - 1]);
                 if (dist < EPSILON * EPSILON) {


### PR DESCRIPTION
This PR is meant to addresses the crash seen https://github.com/OrcaSlicer/OrcaSlicer/pull/13450.

The ZAA processing step could in some cases reduce the number of points in a polyline from three to two. Downstream processing further reduced the number of points to zero (not sure how) and this resulted in a crash. 

In ZAA, a three point polyline could be reduced to two points if all three points are collinear or almost collinear.

As a fix, we make sure to preserver all original points in a polyline when creating a contoured polyline.

# Description

## Tests

Tested with [framebaroque.zip](https://github.com/user-attachments/files/27307267/framebaroque.zip) from https://github.com/OrcaSlicer/OrcaSlicer/pull/13450 and ZAA test plate files.

<!--
> A guide for users on how to download the artifacts from this PR.
-->

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
