### PR TITLE
ZAA: Fix Z-contouring raycast reference plane and Eigen UB

### DIFF
--- a/src/libslic3r/ContourZ.cpp
+++ b/src/libslic3r/ContourZ.cpp
@@ -37,7 +37,6 @@ static bool contour_extrusion_path(LayerRegion *region, const sla::IndexedMesh &
 	}
 	
 	Layer *layer = region->layer();
-	// coordf_t mesh_z = layer->print_z + mesh.ground_level();
 	coordf_t mesh_slice_z = layer->slice_z + mesh.ground_level();
 	coordf_t min_z = region->region().config().zaa_min_z;
 

--- a/src/libslic3r/ContourZ.cpp
+++ b/src/libslic3r/ContourZ.cpp
@@ -37,7 +37,8 @@ static bool contour_extrusion_path(LayerRegion *region, const sla::IndexedMesh &
 	}
 	
 	Layer *layer = region->layer();
-	coordf_t mesh_z = layer->print_z + mesh.ground_level();
+	// coordf_t mesh_z = layer->print_z + mesh.ground_level();
+	coordf_t mesh_slice_z = layer->slice_z + mesh.ground_level();
 	coordf_t min_z = region->region().config().zaa_min_z;
 
 	const Points3 &points = path.polyline.points;
@@ -74,14 +75,10 @@ static bool contour_extrusion_path(LayerRegion *region, const sla::IndexedMesh &
             coordf_t x = p.x();
 			coordf_t y = p.y();
 
-			sla::IndexedMesh::hit_result hit_up = mesh.query_ray_hit({x, y, mesh_z}, {0.0, 0.0, 1.0});
-			sla::IndexedMesh::hit_result hit_down = mesh.query_ray_hit({x, y, mesh_z}, {0.0, 0.0, -1.0});
+			sla::IndexedMesh::hit_result hit_up = mesh.query_ray_hit({x, y, mesh_slice_z}, {0.0, 0.0, 1.0});
 
-			double up = hit_up.distance();
-			double down = hit_down.distance();
-			double d = up < down ? up : -down;
-			const Vec3d &normal = (up < down ? hit_up : hit_down).normal();
-			
+			double d = hit_up.distance() - (layer->print_z - layer->slice_z);
+
 			double max_up = min_z;
 			double min_down = -(height - min_z);
 			double half_width = path.width / 2.0;
@@ -90,7 +87,8 @@ static bool contour_extrusion_path(LayerRegion *region, const sla::IndexedMesh &
 				min_down = -(height + 0.1);
 			}
 
-            if (is_perimeter(path.role())) {
+            if (is_perimeter(path.role()) && hit_up.is_hit()) {
+				const Vec3d &normal = hit_up.normal();
                 double slope_rad     = slope_from_normal(normal);
                 double slope_degrees = slope_rad * 180.0 / M_PI;
 

--- a/src/libslic3r/ContourZ.cpp
+++ b/src/libslic3r/ContourZ.cpp
@@ -51,7 +51,7 @@ static bool contour_extrusion_path(LayerRegion *region, const sla::IndexedMesh &
 	bool was_contoured = false;
 
     if (points.size() < 2) {
-        // Safety check. The loop below does handle handle paths with less than two points correctly.
+        // Safety check. The loop below does not handle paths with less than two points correctly.
         return false;
     }
 

--- a/src/libslic3r/ContourZ.cpp
+++ b/src/libslic3r/ContourZ.cpp
@@ -50,7 +50,12 @@ static bool contour_extrusion_path(LayerRegion *region, const sla::IndexedMesh &
 	Pointf3s contoured_points;
 	bool was_contoured = false;
 
-	for (Points3::const_iterator it = points.begin(); it != points.end()-1; ++it) {
+    if (points.size() < 2) {
+        // Safety check. The loop below does handle handle paths with less than two points correctly.
+        return false;
+    }
+
+    for (Points3::const_iterator it = points.begin(); it != points.end()-1; ++it) {
 		Vec2d p1d(unscale_(it->x()), unscale_(it->y()));
 		Vec2d p2d(unscale_((it+1)->x()), unscale_((it+1)->y()));
 		Linef line(p1d, p2d);
@@ -123,7 +128,14 @@ static bool contour_extrusion_path(LayerRegion *region, const sla::IndexedMesh &
 
             Vec3d new_point = {p.x(), p.y(), d};
 
-            if (contoured_points.size() >= 2) {
+            if (contoured_points.size() >= 2 && i != 0) {
+                // Normally, if the new point is collinear with the last two points, we do not add
+                // it to the list of contoured points. Instead we update the last point to be the
+                // new point. This is to avoid creating a large number of very short segments.
+                //
+                // However, if the new point corresponds to a point in the original path (i == 0),
+                // even if it is collinear, we add it anyway. This is to avoid creating a degenerate
+                // polygon with only two points, which may cause issues in downstream code.
                 double dist = Linef3::distance_to_infinite_squared(new_point, contoured_points[contoured_points.size() - 2],
                                                                    contoured_points[contoured_points.size() - 1]);
                 if (dist < EPSILON * EPSILON) {


### PR DESCRIPTION
# Description

Problem 1: wrong ray origin and ambiguous surface selection

The raycaster fired both an upward and downward ray from `print_z` and picked whichever hit was closer. This could potentially hit the bottom surface, causing the layer height to be lowered erroneously.

Fix: Fire a single upward ray from slice_z (the slicing cross-section plane). This should find the top surface. This approach should work for ordinary meshes that don't have too much detail at less than layer height. The raw hit distance is then adjusted by (print_z - slice_z) so that `d = 0` means the mesh surface is exactly at print_z, preserving the semantics expected by the downstream clamping logic.

Problem 2: undefined behaviour on ray miss

This was identified by Claude Code.

When the upward ray missed (open air), `hit_up.normal()` returned a zero vector. Passing it to `slope_from_normal()` called Eigen::normalized() on a zero vector — undefined behaviour that produces NaN. The subsequent NaN comparison silently short-circuited rather than corrupting `d`, but this was fragile and platform-dependent.

Fix: Guard the slope adjustment block with `hit_up.is_hit()`. A missed ray carries no surface normal and requires no slope adjustment, so skipping it is both safe and semantically correct.

## Tests

Tested with ZAA testplate files.

<!--
> A guide for users on how to download the artifacts from this PR.
-->

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
