### PR TITLE
Fix collision with the bed using tree supports

### DIFF
--- a/src/libslic3r/Support/TreeSupport.cpp
+++ b/src/libslic3r/Support/TreeSupport.cpp
@@ -3048,6 +3048,7 @@ std::vector<LayerHeightData> TreeSupport::plan_layer_heights()
         obj_layer_zs.reserve(m_object->layer_count());
         for (const Layer *l : m_object->layers()) obj_layer_zs.emplace_back((float) l->print_z);
         z_heights[m_object->get_layer(0)->print_z] = m_object->get_layer(0)->height;
+        const coordf_t min_print_z = m_object->get_layer(0)->print_z;
         // Collect top contact layers
         for (int layer_nr = 1; layer_nr < contact_nodes.size(); layer_nr++) {
             if (!contact_nodes[layer_nr].empty()) {
@@ -3055,7 +3056,7 @@ std::vector<LayerHeightData> TreeSupport::plan_layer_heights()
                 coordf_t height = contact_nodes[layer_nr].front()->height;
                 // insertion will fail if there is already a key of print_z, so no need to check
                 bounds.insert({print_z, height});
-                bounds.insert({print_z - height, 0}); // the bottom_z of the layer
+                bounds.insert({std::max(min_print_z, print_z - height), 0}); // the bottom_z of the layer
             }
         }
 


### PR DESCRIPTION
# Description

Safeguard to ensure that the height of the first layer is not less than the height of the brim, preventing the nozzle from colliding with the bed—a rare edge case when using tree supports.

# Screenshots/Recordings/Graphs
# Before (Z -0.1)
<img width="2560" height="1392" alt="image" src="https://github.com/user-attachments/assets/962b1b85-7fa6-4790-9478-bf5debb4ccc9" />

 # After (Z 0.1)
<img width="2560" height="1392" alt="image" src="https://github.com/user-attachments/assets/666eb912-943d-48f5-a385-00e588bdde61" />


## Tests

[bmw.i7.2017.front.intake.fin.zip](https://github.com/user-attachments/files/27497785/bmw.i7.2017.front.intake.fin.zip)

Fix #13500

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
