### PR TITLE
when the stealth mode is enabled, log out cloud service and hide sideboard

### DIFF
--- a/resources/web/homepage/css/home.css
+++ b/resources/web/homepage/css/home.css
@@ -71,6 +71,7 @@ body
 
 #LeftBoard
 {
+	display: none;  /* shown by cloud_providers_info from backend */
 	border-right-width: 1px;
 	border-right-style: solid;
 	width:262px;

--- a/resources/web/homepage/js/home.js
+++ b/resources/web/homepage/js/home.js
@@ -103,10 +103,19 @@ function HandleStudio( pVal )
 
     GotoMenu(strName);
   } else if (strCmd == "cloud_providers_info") {
-    if (pVal["data"]["providers"] && pVal["data"]["providers"].indexOf("bbl") >= 0) {
+    var providers = (pVal["data"] && pVal["data"]["providers"]) || [];
+
+    if (providers.indexOf("bbl") >= 0) {
       $("#BambuCloudSection").show();
     } else {
+      SetBambuUserOffline();
       $("#BambuCloudSection").hide();
+    }
+
+    if (providers.indexOf("orca") >= 0) {
+      $("#LeftBoard").show();
+    } else {
+      $("#LeftBoard").hide();
     }
   } else if (strCmd == "network_plugin_installtip") {
     let nShow = pVal["show"] * 1;

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -4469,6 +4469,21 @@ std::string GUI_App::handle_web_request(std::string cmd)
         boost::optional<std::string> command = root.get_optional<std::string>("command");
         if (command.has_value()) {
             std::string command_str = command.value();
+            static const std::unordered_set<std::string> stealth_blocked_commands = {
+                "get_login_info",
+                "get_orca_login_info",
+                "get_bambu_login_info",
+                "homepage_login_or_register",
+                "homepage_orca_login_or_register",
+                "homepage_bambu_login_or_register",
+            };
+            if (app_config->get_stealth_mode() && stealth_blocked_commands.count(command_str)) {
+                CallAfter([this] {
+                    if (mainframe && mainframe->m_webview)
+                        mainframe->m_webview->SendCloudProvidersInfo();
+                });
+                return "";
+            }
             if (command_str.compare("request_project_download") == 0) {
                 if (root.get_child_optional("data") != boost::none) {
                     pt::ptree data_node = root.get_child("data");
@@ -6728,6 +6743,16 @@ void GUI_App::stop_sync_user_preset()
             m_sync_update_thread.join();
         else
             m_sync_update_thread.detach();
+    }
+}
+
+void GUI_App::on_stealth_mode_enter()
+{
+    stop_sync_user_preset();
+    request_user_logout(ORCA_CLOUD_PROVIDER);
+    request_user_logout(BBL_CLOUD_PROVIDER);
+    if (mainframe && mainframe->m_webview) {
+        mainframe->m_webview->SendCloudProvidersInfo();
     }
 }
 

--- a/src/slic3r/GUI/GUI_App.hpp
+++ b/src/slic3r/GUI/GUI_App.hpp
@@ -530,6 +530,7 @@ public:
     void            sync_preset(Preset* preset);
     void            start_sync_user_preset(bool with_progress_dlg = false);
     void            stop_sync_user_preset();
+    void            on_stealth_mode_enter();
 
     // Bundle subscription sync
     void            check_bundle_updates();

--- a/src/slic3r/GUI/Preferences.cpp
+++ b/src/slic3r/GUI/Preferences.cpp
@@ -1536,7 +1536,7 @@ void PreferencesDialog::create_items()
     auto item_region           = create_item_region_combobox(_L("Login region"), "");
     g_sizer->Add(item_region);
  
-    auto item_stealth_mode     = create_item_checkbox(_L("Stealth mode"), _L("This stops the transmission of data to Bambu's cloud services. Users who don't use BBL machines or use LAN mode only can safely turn on this function."), "stealth_mode");
+    auto item_stealth_mode     = create_item_checkbox(_L("Stealth mode"), _L("This disables all cloud services e.g. Orca Cloud and Bambu Cloud. This stops the transmission of data to Bambu's cloud services too. Users who don't use BBL machines or use LAN mode only can safely turn on this function."), "stealth_mode");
     g_sizer->Add(item_stealth_mode);
 
     auto item_network_test     = create_item_button(_L("Network test"), _L("Test") + " " + dots, "", _L("Open Network Test"), []() {

--- a/src/slic3r/GUI/Preferences.cpp
+++ b/src/slic3r/GUI/Preferences.cpp
@@ -924,6 +924,8 @@ wxBoxSizer *PreferencesDialog::create_item_checkbox(wxString title, wxString too
     checkbox->SetValue(app_config->get_bool(param));
     checkbox->SetToolTip(tip);
 
+    if (param == "sync_user_preset") { m_sync_user_preset_checkbox = checkbox; }
+
     m_sizer_checkbox->Add(checkbox_title, 0, wxALIGN_CENTER | wxTOP | wxBOTTOM, FromDIP(3));
     m_sizer_checkbox->Add(checkbox      , 0, wxALIGN_CENTER | wxRIGHT | wxLEFT, FromDIP(5));
 
@@ -954,6 +956,12 @@ wxBoxSizer *PreferencesDialog::create_item_checkbox(wxString title, wxString too
                 wxGetApp().stop_sync_user_preset();
             }
             BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << " sync_user_preset: " << (sync ? "true" : "false");
+        }
+        else if (param == "stealth_mode") {
+            bool enabled = app_config->get_stealth_mode();
+            if (enabled) wxGetApp().on_stealth_mode_enter();
+            if (m_sync_user_preset_checkbox) m_sync_user_preset_checkbox->Enable(!enabled);
+            if (m_bambu_cloud_checkbox)      m_bambu_cloud_checkbox->Enable(!enabled);
         }
 
         #ifdef __WXMSW__
@@ -1552,6 +1560,7 @@ void PreferencesDialog::create_items()
         text->Wrap(DESIGN_TITLE_SIZE.x);
 
         auto cb = new ::CheckBox(m_parent);
+        m_bambu_cloud_checkbox = cb;
         cb->SetValue(app_config->has_cloud_provider(BBL_CLOUD_PROVIDER));
         cb->SetToolTip(text->GetToolTipText());
 
@@ -1584,6 +1593,11 @@ void PreferencesDialog::create_items()
 
     auto item_user_sync        = create_item_checkbox(_L("Auto sync user presets (Printer/Filament/Process)"), "", "sync_user_preset");
     g_sizer->Add(item_user_sync);
+
+    if (app_config->get_stealth_mode()) {
+        if (m_bambu_cloud_checkbox)      m_bambu_cloud_checkbox->Enable(false);
+        if (m_sync_user_preset_checkbox) m_sync_user_preset_checkbox->Enable(false);
+    }
 
     auto item_system_sync      = create_item_checkbox(_L("Update built-in Presets automatically."), "", "sync_system_preset");
     g_sizer->Add(item_system_sync);

--- a/src/slic3r/GUI/Preferences.hpp
+++ b/src/slic3r/GUI/Preferences.hpp
@@ -71,6 +71,8 @@ public:
     ::CheckBox * m_developer_mode_ckeckbox   = {nullptr};
     ::CheckBox * m_internal_developer_mode_ckeckbox = {nullptr};
     ::CheckBox * m_dark_mode_ckeckbox        = {nullptr};
+    ::CheckBox * m_sync_user_preset_checkbox = {nullptr};
+    ::CheckBox * m_bambu_cloud_checkbox      = {nullptr};
     ::TextInput *m_backup_interval_textinput = {nullptr};
     ::ComboBox * m_network_version_combo     = {nullptr};
     wxBoxSizer * m_network_version_sizer     = {nullptr};

--- a/src/slic3r/GUI/WebViewDialog.cpp
+++ b/src/slic3r/GUI/WebViewDialog.cpp
@@ -418,8 +418,9 @@ void WebViewPanel::OnFreshLoginStatus(wxTimerEvent &event)
 {
     auto mainframe = Slic3r::GUI::wxGetApp().mainframe;
     if (mainframe && mainframe->m_webview == this) {
-        Slic3r::GUI::wxGetApp().get_login_info(ORCA_CLOUD_PROVIDER);
         auto* app_config = Slic3r::GUI::wxGetApp().app_config;
+        if (app_config && app_config->get_stealth_mode()) return;
+        Slic3r::GUI::wxGetApp().get_login_info(ORCA_CLOUD_PROVIDER);
         if (app_config && app_config->has_cloud_provider(BBL_CLOUD_PROVIDER)) {
             Slic3r::GUI::wxGetApp().get_login_info(BBL_CLOUD_PROVIDER);
         }
@@ -520,14 +521,18 @@ void WebViewPanel::SendCloudProvidersInfo()
     if (!app_config)
         return;
 
-    auto providers = app_config->get_cloud_providers();
     json j;
     j["command"] = "cloud_providers_info";
     json data;
     json provider_array = json::array();
-    for (const auto& p : providers) {
-        provider_array.push_back(p);
+
+    if (!app_config->get_stealth_mode()) {
+        auto providers = app_config->get_cloud_providers();
+        for (const auto& p : providers) {
+            provider_array.push_back(p);
+        }
     }
+
     data["providers"] = provider_array;
     j["data"] = data;
 


### PR DESCRIPTION

# Description

When stealth mode is enabled, disable related options in preference dlg and hide sideboard of the homepage
<img width="642" height="403" alt="Screenshot 2026-05-09 at 00 37 56" src="https://github.com/user-attachments/assets/83c15ffb-ce9b-472f-8229-4d8cacec1cf0" />
<img width="1001" height="768" alt="Screenshot 2026-05-09 at 00 38 43" src="https://github.com/user-attachments/assets/3873146a-9bca-43d5-81a8-90c99fe4a297" />

# Screenshots/Recordings/Graphs

<!--
> Please attach relevant screenshots to showcase the UI changes.
> Please attach images that can help explain the changes.
-->

## Tests

<!--
> Please describe the tests that you have conducted to verify the changes made in this PR.
-->

<!--
> A guide for users on how to download the artifacts from this PR.
-->

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
