### PR TITLE
Add tooltips to Transfer buttons

### DIFF
--- a/src/slic3r/GUI/UnsavedChangesDialog.cpp
+++ b/src/slic3r/GUI/UnsavedChangesDialog.cpp
@@ -1015,21 +1015,21 @@ void UnsavedChangesDialog::build(Preset::Type type, PresetCollection *dependent_
 
         if (m_discard_btn) {
             m_discard_btn->SetToolTip(format_wxstr(
-                _L("Switch to \"%1%\", discarding any changes made in \"%2%\"."),
+                _L("Switch to\n\"%1%\"\ndiscarding any changes made in\n\"%2%\"."),
                 new_profile,
                 previous_profile));
         }
 
         if (m_transfer_btn) {
             m_transfer_btn->SetToolTip(format_wxstr(
-                _L("All \"New Value\" settings modified in \"%1%\" will be transferred to \"%2%\"."),
+                _L("All \"New Value\" settings modified in\n\"%1%\"\nwill be transferred to\n\"%2%\"."),
                 previous_profile,
                 new_profile));
         }
 
         if (m_save_btn) {
             m_save_btn->SetToolTip(format_wxstr(
-                _L("All \"New Value\" settings are saved in \"%1%\", and \"%2%\" will open without any changes."),
+                _L("All \"New Value\" settings are saved in\n\"%1%\"\nand \"%2%\" will open without any changes."),
                 previous_profile,
                 new_profile));
         }

--- a/src/slic3r/GUI/UnsavedChangesDialog.cpp
+++ b/src/slic3r/GUI/UnsavedChangesDialog.cpp
@@ -1009,6 +1009,32 @@ void UnsavedChangesDialog::build(Preset::Type type, PresetCollection *dependent_
     // "Save" button
     if (ActionButtons::SAVE & m_buttons) add_btn(&m_save_btn, m_save_btn_id, "save", Action::Save, _L("Save"), false);
 
+    if (dependent_presets != nullptr) {
+        const wxString previous_profile = from_u8(dependent_presets->get_edited_preset().name);
+        const wxString new_profile      = new_selected_preset.empty() ? _L("the new profile") : from_u8(new_selected_preset);
+
+        if (m_discard_btn) {
+            m_discard_btn->SetToolTip(format_wxstr(
+                _L("Switch to \"%1%\", discarding any changes made in \"%2%\"."),
+                new_profile,
+                previous_profile));
+        }
+
+        if (m_transfer_btn) {
+            m_transfer_btn->SetToolTip(format_wxstr(
+                _L("All \"New Value\" settings modified in \"%1%\" will be transferred to \"%2%\"."),
+                previous_profile,
+                new_profile));
+        }
+
+        if (m_save_btn) {
+            m_save_btn->SetToolTip(format_wxstr(
+                _L("All \"New Value\" settings are saved in \"%1%\", and \"%2%\" will open without any changes."),
+                previous_profile,
+                new_profile));
+        }
+    }
+
     /* ScalableButton *cancel_btn = new ScalableButton(this, wxID_CANCEL, "cross", _L("Cancel"), wxDefaultSize, wxDefaultPosition, wxBORDER_DEFAULT, true, 24);
       buttons->Add(cancel_btn, 1, wxLEFT | wxRIGHT, 5);
       cancel_btn->SetFont(btn_font);*/


### PR DESCRIPTION
Closes #11487
Set contextual tooltips for the Discard, Transfer and Save buttons explaining exactly what each button will do:

<img width="891" height="620" alt="260508_163657_orca-slicer" src="https://github.com/user-attachments/assets/40f811a7-ddea-496c-8761-58ca975352a7" />
<img width="636" height="607" alt="260508_163515_orca-slicer" src="https://github.com/user-attachments/assets/d173c4fb-523f-4bb5-8be1-65e6130b29a4" />
<img width="788" height="607" alt="260508_163647_orca-slicer" src="https://github.com/user-attachments/assets/2dcf2f56-2add-4b30-95ba-eaf42c59065c" />
