### PR TITLE
Fix Flow Ratio dialog shrinking after main window minimize

### DIFF
--- a/src/slic3r/GUI/calib_dlg.cpp
+++ b/src/slic3r/GUI/calib_dlg.cpp
@@ -1505,6 +1505,7 @@ FlowRateCalibrationDialog::FlowRateCalibrationDialog(wxWindow* parent, wxWindowI
 
     Layout();
     Fit();
+    v_sizer->SetSizeHints(this);
 }
 
 FlowRateCalibrationDialog::~FlowRateCalibrationDialog() {
@@ -1527,7 +1528,6 @@ void FlowRateCalibrationDialog::on_start(wxCommandEvent& event) {
 
 void FlowRateCalibrationDialog::on_dpi_changed(const wxRect& suggested_rect) {
     this->Refresh();
-    Fit();
 }
 
 }} // namespace Slic3r::GUI


### PR DESCRIPTION
## Summary

`FlowRateCalibrationDialog` was missing the `SetSizeHints` call that every other calibration dialog in `calib_dlg.cpp` already uses (Cornering, Pa, Pa Pattern, Max Volumetric Speed, Temperature, Retraction, VFA, Input Shaping). Without it, the dialog has no enforced minimum size on wxGTK: iconizing the main window while the dialog is open triggers a layout/refresh that re-runs `Fit()` with transient zero-sized children, collapsing the dialog to ~222×249 px with the OK button clipped and unreachable. The window manager then honors that small geometry hint, so the user cannot resize it back manually (`xdotool` / `wmctrl` resize calls are silently ignored).

Two changes:

- Add `v_sizer->SetSizeHints(this);` after `Fit()` in the constructor, matching the pattern used by all 8 other calibration dialogs in the same file. This locks in the correct minimum the first time `Fit()` runs, before any iconize event can trigger the shrink path.
- Remove the redundant `Fit()` from `on_dpi_changed`. With `SetSizeHints` in place the WM enforces the minimum, but the unconditional `Fit()` on every DPI/refresh signal was the trigger for the collapse; `Refresh()` alone is sufficient.

Reproduction (before patch, Linux/wxGTK, tested on Debian 13 + GNOME):

1. Calibration menu → Flow Rate.
2. While the dialog is visible, minimize the main OrcaSlicer window from the taskbar.
3. Restore the main window. The dialog is now ~222×249 px with the OK button cut off, and cannot be resized.

After the patch the dialog retains its full size across minimize/restore.

## Test plan

- [x] Builds cleanly on Linux (`build_linux.sh -si`, RelWithDebInfo).
- [x] Manual test: minimize/restore main window with Flow Rate dialog open — dialog stays at full size, OK reachable.
- [ ] No Windows/macOS regressions (please verify on review — the change matches an existing pattern used by 8 sibling dialogs, so behavior should be identical to those on all platforms).

## Screenshots

Before: dialog shrinks to a tiny chrome-only box after minimize/restore, OK button clipped.
After: dialog stays at full size, OK button reachable.

(I can attach screenshots on request.)