### PR TITLE
Add optional outer brim with auto-spacing to Flow Rate Calibration

### DIFF
--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -12929,7 +12929,8 @@ void Plater::_calib_pa_select_added_objects() {
 // Adjust settings for flowrate calibration
 // For linear mode, pass 1 means normal version while pass 2 mean "for perfectionists" version
 // ORCA: Add pattern parameter
-void adjust_settings_for_flowrate_calib(ModelObjectPtrs& objects, bool linear, int pass, InfillPattern pattern)
+void adjust_settings_for_flowrate_calib(ModelObjectPtrs& objects, bool linear, int pass, InfillPattern pattern,
+                                        bool brim_enabled, double brim_width, double brim_extra_gap)
 {
     auto print_config = &wxGetApp().preset_bundle->prints.get_edited_preset().config;
     auto printerConfig = &wxGetApp().preset_bundle->printers.get_edited_preset().config;
@@ -13028,6 +13029,54 @@ void adjust_settings_for_flowrate_calib(ModelObjectPtrs& objects, bool linear, i
         else
             _obj->config.set_key_value("print_flow_ratio", new ConfigOptionFloat(1.0f + modifier/100.f));
 
+        // ORCA: optional outer brim per block (helps with warp-prone filaments)
+        if (brim_enabled) {
+            _obj->config.set_key_value("brim_type", new ConfigOptionEnum<BrimType>(btOuterOnly));
+            _obj->config.set_key_value("brim_width", new ConfigOptionFloat(brim_width));
+            _obj->config.set_key_value("brim_object_gap", new ConfigOptionFloat(0.0));
+        }
+    }
+
+    // ORCA: when per-block brim is enabled, scale object positions outward from
+    // the layout centroid so adjacent brims don't merge. Uniform scaling preserves
+    // the prebuilt grid layout while widening every gap by the same delta.
+    if (brim_enabled && objects.size() >= 2) {
+        std::vector<Vec2d>          centers;
+        std::vector<BoundingBoxf3>  bbs;
+        centers.reserve(objects.size());
+        bbs.reserve(objects.size());
+        for (auto _obj : objects) {
+            const BoundingBoxf3 bb = _obj->instance_bounding_box(0);
+            bbs.push_back(bb);
+            centers.emplace_back(0.5 * (bb.min.x() + bb.max.x()), 0.5 * (bb.min.y() + bb.max.y()));
+        }
+        Vec2d centroid(0.0, 0.0);
+        for (const auto& c : centers) centroid += c;
+        centroid /= double(centers.size());
+
+        double min_center_dist = std::numeric_limits<double>::infinity();
+        double min_edge_gap    = std::numeric_limits<double>::infinity();
+        for (size_t i = 0; i < objects.size(); ++i) {
+            for (size_t j = i + 1; j < objects.size(); ++j) {
+                const double cd = (centers[i] - centers[j]).norm();
+                if (cd < min_center_dist) min_center_dist = cd;
+                const double dx = std::max(0.0, std::max(bbs[i].min.x() - bbs[j].max.x(), bbs[j].min.x() - bbs[i].max.x()));
+                const double dy = std::max(0.0, std::max(bbs[i].min.y() - bbs[j].max.y(), bbs[j].min.y() - bbs[i].max.y()));
+                const double eg = std::max(dx, dy); // axis-aligned grid: the larger axial gap is the actual gap
+                if (eg < min_edge_gap) min_edge_gap = eg;
+            }
+        }
+
+        const double required_gap = 2.0 * brim_width + brim_extra_gap;
+        if (min_center_dist > 0.0 && min_edge_gap < required_gap) {
+            const double extra_needed = required_gap - min_edge_gap;
+            const double scale = 1.0 + extra_needed / min_center_dist;
+            for (size_t i = 0; i < objects.size(); ++i) {
+                const Vec2d new_center = centroid + scale * (centers[i] - centroid);
+                const Vec2d delta      = new_center - centers[i];
+                objects[i]->translate_instances(Vec3d(delta.x(), delta.y(), 0.0));
+            }
+        }
     }
 
     print_config->set_key_value("layer_height", new ConfigOptionFloat(layer_height));
@@ -13044,8 +13093,9 @@ void adjust_settings_for_flowrate_calib(ModelObjectPtrs& objects, bool linear, i
     wxGetApp().get_tab(Preset::TYPE_PRINTER)->reload_config();
 }
 
-// ORCA: Add pattern parameter
-void Plater::calib_flowrate(bool is_linear, int pass, InfillPattern pattern) {
+// ORCA: Add pattern parameter and optional brim with auto-spacing
+void Plater::calib_flowrate(bool is_linear, int pass, InfillPattern pattern,
+                            bool brim_enabled, double brim_width, double brim_extra_gap) {
     if (pass != 1 && pass != 2)
         return;
     wxString calib_name;
@@ -13077,8 +13127,9 @@ void Plater::calib_flowrate(bool is_linear, int pass, InfillPattern pattern) {
                       (boost::filesystem::path(Slic3r::resources_dir()) / "calib" / "filament_flow" / "flowrate-test-pass2.3mf").string());
     }
 
-    // ORCA: pass the pattern
-    adjust_settings_for_flowrate_calib(model().objects, is_linear, pass, pattern);
+    // ORCA: pass the pattern and brim options
+    adjust_settings_for_flowrate_calib(model().objects, is_linear, pass, pattern,
+                                       brim_enabled, brim_width, brim_extra_gap);
     wxGetApp().get_tab(Preset::TYPE_PRINTER)->reload_config();
     auto printer_config = &wxGetApp().preset_bundle->printers.get_edited_preset().config;
     printer_config->set_key_value("resonance_avoidance", new ConfigOptionBool{false});

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -16098,7 +16098,8 @@ void Plater::_calib_pa_select_added_objects() {
 // Adjust settings for flowrate calibration
 // For linear mode, pass 1 means normal version while pass 2 mean "for perfectionists" version
 // ORCA: Add pattern parameter
-void adjust_settings_for_flowrate_calib(ModelObjectPtrs& objects, bool linear, int pass, InfillPattern pattern)
+void adjust_settings_for_flowrate_calib(ModelObjectPtrs& objects, bool linear, int pass, InfillPattern pattern,
+                                        bool brim_enabled, double brim_width, double brim_extra_gap)
 {
     auto print_config = &wxGetApp().preset_bundle->prints.get_edited_preset().config;
     auto printer_config  = &wxGetApp().preset_bundle->printers.get_edited_preset().config;
@@ -16200,6 +16201,54 @@ void adjust_settings_for_flowrate_calib(ModelObjectPtrs& objects, bool linear, i
         else
             _obj->config.set_key_value("print_flow_ratio", new ConfigOptionFloat(1.0f + modifier/100.f));
 
+        // ORCA: optional outer brim per block (helps with warp-prone filaments)
+        if (brim_enabled) {
+            _obj->config.set_key_value("brim_type", new ConfigOptionEnum<BrimType>(btOuterOnly));
+            _obj->config.set_key_value("brim_width", new ConfigOptionFloat(brim_width));
+            _obj->config.set_key_value("brim_object_gap", new ConfigOptionFloat(0.0));
+        }
+    }
+
+    // ORCA: when per-block brim is enabled, scale object positions outward from
+    // the layout centroid so adjacent brims don't merge. Uniform scaling preserves
+    // the prebuilt grid layout while widening every gap by the same delta.
+    if (brim_enabled && objects.size() >= 2) {
+        std::vector<Vec2d>          centers;
+        std::vector<BoundingBoxf3>  bbs;
+        centers.reserve(objects.size());
+        bbs.reserve(objects.size());
+        for (auto _obj : objects) {
+            const BoundingBoxf3 bb = _obj->instance_bounding_box(0);
+            bbs.push_back(bb);
+            centers.emplace_back(0.5 * (bb.min.x() + bb.max.x()), 0.5 * (bb.min.y() + bb.max.y()));
+        }
+        Vec2d centroid(0.0, 0.0);
+        for (const auto& c : centers) centroid += c;
+        centroid /= double(centers.size());
+
+        double min_center_dist = std::numeric_limits<double>::infinity();
+        double min_edge_gap    = std::numeric_limits<double>::infinity();
+        for (size_t i = 0; i < objects.size(); ++i) {
+            for (size_t j = i + 1; j < objects.size(); ++j) {
+                const double cd = (centers[i] - centers[j]).norm();
+                if (cd < min_center_dist) min_center_dist = cd;
+                const double dx = std::max(0.0, std::max(bbs[i].min.x() - bbs[j].max.x(), bbs[j].min.x() - bbs[i].max.x()));
+                const double dy = std::max(0.0, std::max(bbs[i].min.y() - bbs[j].max.y(), bbs[j].min.y() - bbs[i].max.y()));
+                const double eg = std::max(dx, dy); // axis-aligned grid: the larger axial gap is the actual gap
+                if (eg < min_edge_gap) min_edge_gap = eg;
+            }
+        }
+
+        const double required_gap = 2.0 * brim_width + brim_extra_gap;
+        if (min_center_dist > 0.0 && min_edge_gap < required_gap) {
+            const double extra_needed = required_gap - min_edge_gap;
+            const double scale = 1.0 + extra_needed / min_center_dist;
+            for (size_t i = 0; i < objects.size(); ++i) {
+                const Vec2d new_center = centroid + scale * (centers[i] - centroid);
+                const Vec2d delta      = new_center - centers[i];
+                objects[i]->translate_instances(Vec3d(delta.x(), delta.y(), 0.0));
+            }
+        }
     }
 
     print_config->set_key_value("layer_height", new ConfigOptionFloat(layer_height));
@@ -16216,8 +16265,9 @@ void adjust_settings_for_flowrate_calib(ModelObjectPtrs& objects, bool linear, i
     wxGetApp().get_tab(Preset::TYPE_PRINTER)->reload_config();
 }
 
-// ORCA: Add pattern parameter
-void Plater::calib_flowrate(bool is_linear, int pass, InfillPattern pattern) {
+// ORCA: Add pattern parameter and optional brim with auto-spacing
+void Plater::calib_flowrate(bool is_linear, int pass, InfillPattern pattern,
+                            bool brim_enabled, double brim_width, double brim_extra_gap) {
     if (pass != 1 && pass != 2)
         return;
     wxString calib_name;
@@ -16249,8 +16299,9 @@ void Plater::calib_flowrate(bool is_linear, int pass, InfillPattern pattern) {
                       (boost::filesystem::path(Slic3r::resources_dir()) / "calib" / "filament_flow" / "flowrate-test-pass2.3mf").string());
     }
 
-    // ORCA: pass the pattern
-    adjust_settings_for_flowrate_calib(model().objects, is_linear, pass, pattern);
+    // ORCA: pass the pattern and brim options
+    adjust_settings_for_flowrate_calib(model().objects, is_linear, pass, pattern,
+                                       brim_enabled, brim_width, brim_extra_gap);
     wxGetApp().get_tab(Preset::TYPE_PRINTER)->reload_config();
     auto printer_config = &wxGetApp().preset_bundle->printers.get_edited_preset().config;
     printer_config->set_key_value("resonance_avoidance", new ConfigOptionBool{false});

--- a/src/slic3r/GUI/Plater.hpp
+++ b/src/slic3r/GUI/Plater.hpp
@@ -332,7 +332,9 @@ public:
     // SoftFever
     void calib_pa(const Calib_Params& params);
     //ORCA: Add pattern parameter to calib_flowrate
-    void calib_flowrate(bool is_linear, int pass, InfillPattern pattern = ipArchimedeanChords);
+    //ORCA: Optional outer brim with auto-spacing (for warp-prone filaments like ASA)
+    void calib_flowrate(bool is_linear, int pass, InfillPattern pattern = ipArchimedeanChords,
+                        bool brim_enabled = false, double brim_width = 3.0, double brim_extra_gap = 2.0);
     void calib_temp(const Calib_Params& params);
     void calib_max_vol_speed(const Calib_Params& params);
     void calib_retraction(const Calib_Params& params);

--- a/src/slic3r/GUI/Plater.hpp
+++ b/src/slic3r/GUI/Plater.hpp
@@ -365,7 +365,9 @@ public:
     // SoftFever
     void calib_pa(const Calib_Params& params);
     //ORCA: Add pattern parameter to calib_flowrate
-    void calib_flowrate(bool is_linear, int pass, InfillPattern pattern = ipArchimedeanChords);
+    //ORCA: Optional outer brim with auto-spacing (for warp-prone filaments like ASA)
+    void calib_flowrate(bool is_linear, int pass, InfillPattern pattern = ipArchimedeanChords,
+                        bool brim_enabled = false, double brim_width = 3.0, double brim_extra_gap = 2.0);
     void calib_temp(const Calib_Params& params);
     void calib_max_vol_speed(const Calib_Params& params);
     void calib_retraction(const Calib_Params& params);

--- a/src/slic3r/GUI/calib_dlg.cpp
+++ b/src/slic3r/GUI/calib_dlg.cpp
@@ -6,8 +6,11 @@
 #include "MainFrame.hpp"
 #include "Widgets/DialogButtons.hpp"
 #include "Widgets/HyperLink.hpp"
+#include <algorithm>
+#include <cstdlib>
 #include <string>
 #include <vector>
+#include "libslic3r/AppConfig.hpp"
 #include "libslic3r/PrintConfig.hpp"
 #include "libslic3r/Utils.hpp"
 
@@ -1501,6 +1504,58 @@ FlowRateCalibrationDialog::FlowRateCalibrationDialog(wxWindow* parent, wxWindowI
     pattern_box->Add(m_rbPattern, 0, wxALL | wxEXPAND, FromDIP(4));
     v_sizer->Add(pattern_box, 0, wxTOP | wxRIGHT | wxLEFT | wxEXPAND, FromDIP(10));
 
+    // ORCA: optional outer brim with auto-spacing (helps with warp-prone filaments)
+    {
+        AppConfig* cfg = wxGetApp().app_config;
+        const bool   default_brim_enabled = cfg && cfg->get("calibration_flowrate", "brim_enabled") == "true";
+        const wxString default_brim_width = wxString::FromDouble(
+            cfg && !cfg->get("calibration_flowrate", "brim_width").empty()
+                ? std::atof(cfg->get("calibration_flowrate", "brim_width").c_str())
+                : 3.0);
+        const wxString default_brim_gap = wxString::FromDouble(
+            cfg && !cfg->get("calibration_flowrate", "brim_extra_gap").empty()
+                ? std::atof(cfg->get("calibration_flowrate", "brim_extra_gap").c_str())
+                : 2.0);
+
+        auto brim_sizer = new wxBoxSizer(wxVERTICAL);
+
+        auto cb_row = new wxBoxSizer(wxHORIZONTAL);
+        m_cbBrim = new CheckBox(this);
+        m_cbBrim->SetValue(default_brim_enabled);
+        auto cb_label = new wxStaticText(this, wxID_ANY, _L("Enable brim"));
+        cb_row->Add(m_cbBrim, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(6));
+        cb_row->Add(cb_label, 0, wxALIGN_CENTER_VERTICAL);
+        brim_sizer->Add(cb_row, 0, wxLEFT | wxBOTTOM, FromDIP(4));
+
+        const wxSize ti_size = wxSize(FromDIP(80), -1);
+        const wxSize lbl_size = wxSize(FromDIP(140), -1);
+
+        auto width_row = new wxBoxSizer(wxHORIZONTAL);
+        auto width_lbl = new wxStaticText(this, wxID_ANY, _L("Brim width (mm)"), wxDefaultPosition, lbl_size);
+        m_tiBrimWidth = new TextInput(this, default_brim_width, "", "", wxDefaultPosition, ti_size, wxTE_PROCESS_ENTER);
+        m_tiBrimWidth->GetTextCtrl()->SetValidator(wxTextValidator(wxFILTER_NUMERIC));
+        m_tiBrimWidth->SetToolTip(_L("Outer brim width applied to each calibration block."));
+        width_row->Add(FromDIP(20), 0); // indent under the checkbox
+        width_row->Add(width_lbl, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(4));
+        width_row->Add(m_tiBrimWidth, 0, wxALIGN_CENTER_VERTICAL);
+        brim_sizer->Add(width_row, 0, wxLEFT | wxBOTTOM, FromDIP(4));
+
+        auto gap_row = new wxBoxSizer(wxHORIZONTAL);
+        auto gap_lbl = new wxStaticText(this, wxID_ANY, _L("Extra gap (mm)"), wxDefaultPosition, lbl_size);
+        m_tiBrimGap = new TextInput(this, default_brim_gap, "", "", wxDefaultPosition, ti_size, wxTE_PROCESS_ENTER);
+        m_tiBrimGap->GetTextCtrl()->SetValidator(wxTextValidator(wxFILTER_NUMERIC));
+        m_tiBrimGap->SetToolTip(_L("Safety margin between brims of adjacent blocks. Total spacing added is 2 * brim width + extra gap."));
+        gap_row->Add(FromDIP(20), 0);
+        gap_row->Add(gap_lbl, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(4));
+        gap_row->Add(m_tiBrimGap, 0, wxALIGN_CENTER_VERTICAL);
+        brim_sizer->Add(gap_row, 0, wxLEFT | wxBOTTOM, FromDIP(4));
+
+        v_sizer->Add(brim_sizer, 0, wxTOP | wxRIGHT | wxLEFT | wxEXPAND, FromDIP(10));
+
+        m_cbBrim->Bind(wxEVT_TOGGLEBUTTON, [this](wxCommandEvent& e) { on_brim_toggled(); e.Skip(); });
+        on_brim_toggled(); // sync enabled state with initial checkbox value
+    }
+
     v_sizer->AddSpacer(FromDIP(5));
 
     auto dlg_btns = new DialogButtons(this, {"OK"});
@@ -1528,15 +1583,36 @@ FlowRateCalibrationDialog::~FlowRateCalibrationDialog() {
 void FlowRateCalibrationDialog::on_start(wxCommandEvent& event) {
     int type = m_rbType->GetSelection();
     int patternIdx = m_rbPattern->GetSelection();
-    
+
     InfillPattern pattern = ipArchimedeanChords;
     if (patternIdx == 1) pattern = ipMonotonic;
-    
+
     bool is_linear = (type >= 2);
     int pass = (type % 2) + 1;
 
-    m_plater->calib_flowrate(is_linear, pass, pattern);
+    // ORCA: read brim toggle / values, clamp to sane bounds, persist for next session
+    const bool brim_enabled = m_cbBrim->GetValue();
+    double brim_width = 3.0;
+    double brim_gap   = 2.0;
+    m_tiBrimWidth->GetTextCtrl()->GetValue().ToDouble(&brim_width);
+    m_tiBrimGap->GetTextCtrl()->GetValue().ToDouble(&brim_gap);
+    brim_width = std::clamp(brim_width, 0.0, 20.0);
+    brim_gap   = std::clamp(brim_gap,   0.0, 20.0);
+
+    if (auto* cfg = wxGetApp().app_config) {
+        cfg->set("calibration_flowrate", "brim_enabled",   brim_enabled ? "true" : "false");
+        cfg->set("calibration_flowrate", "brim_width",     std::to_string(brim_width));
+        cfg->set("calibration_flowrate", "brim_extra_gap", std::to_string(brim_gap));
+    }
+
+    m_plater->calib_flowrate(is_linear, pass, pattern, brim_enabled, brim_width, brim_gap);
     EndModal(wxID_OK);
+}
+
+void FlowRateCalibrationDialog::on_brim_toggled() {
+    const bool enabled = m_cbBrim->GetValue();
+    m_tiBrimWidth->Enable(enabled);
+    m_tiBrimGap->Enable(enabled);
 }
 
 void FlowRateCalibrationDialog::on_dpi_changed(const wxRect& suggested_rect) {

--- a/src/slic3r/GUI/calib_dlg.cpp
+++ b/src/slic3r/GUI/calib_dlg.cpp
@@ -6,9 +6,12 @@
 #include "MainFrame.hpp"
 #include "Widgets/DialogButtons.hpp"
 #include "Widgets/HyperLink.hpp"
+#include <algorithm>
+#include <cstdlib>
 #include <string>
 #include <vector>
 #include <cmath>
+#include "libslic3r/AppConfig.hpp"
 #include "libslic3r/PrintConfig.hpp"
 #include "libslic3r/Flow.hpp"
 #include "libslic3r/Utils.hpp"
@@ -1686,6 +1689,58 @@ FlowRateCalibrationDialog::FlowRateCalibrationDialog(wxWindow* parent, wxWindowI
 
     v_sizer->Add(settings_sizer, 0, wxTOP | wxRIGHT | wxLEFT | wxEXPAND, FromDIP(10));
 
+    // ORCA: optional outer brim with auto-spacing (helps with warp-prone filaments)
+    {
+        AppConfig* cfg = wxGetApp().app_config;
+        const bool   default_brim_enabled = cfg && cfg->get("calibration_flowrate", "brim_enabled") == "true";
+        const wxString default_brim_width = wxString::FromDouble(
+            cfg && !cfg->get("calibration_flowrate", "brim_width").empty()
+                ? std::atof(cfg->get("calibration_flowrate", "brim_width").c_str())
+                : 3.0);
+        const wxString default_brim_gap = wxString::FromDouble(
+            cfg && !cfg->get("calibration_flowrate", "brim_extra_gap").empty()
+                ? std::atof(cfg->get("calibration_flowrate", "brim_extra_gap").c_str())
+                : 2.0);
+
+        auto brim_sizer = new wxBoxSizer(wxVERTICAL);
+
+        auto cb_row = new wxBoxSizer(wxHORIZONTAL);
+        m_cbBrim = new CheckBox(this);
+        m_cbBrim->SetValue(default_brim_enabled);
+        auto cb_label = new wxStaticText(this, wxID_ANY, _L("Enable brim"));
+        cb_row->Add(m_cbBrim, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(6));
+        cb_row->Add(cb_label, 0, wxALIGN_CENTER_VERTICAL);
+        brim_sizer->Add(cb_row, 0, wxLEFT | wxBOTTOM, FromDIP(4));
+
+        const wxSize ti_size = wxSize(FromDIP(80), -1);
+        const wxSize lbl_size = wxSize(FromDIP(140), -1);
+
+        auto width_row = new wxBoxSizer(wxHORIZONTAL);
+        auto width_lbl = new wxStaticText(this, wxID_ANY, _L("Brim width (mm)"), wxDefaultPosition, lbl_size);
+        m_tiBrimWidth = new TextInput(this, default_brim_width, "", "", wxDefaultPosition, ti_size, wxTE_PROCESS_ENTER);
+        m_tiBrimWidth->GetTextCtrl()->SetValidator(wxTextValidator(wxFILTER_NUMERIC));
+        m_tiBrimWidth->SetToolTip(_L("Outer brim width applied to each calibration block."));
+        width_row->Add(FromDIP(20), 0); // indent under the checkbox
+        width_row->Add(width_lbl, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(4));
+        width_row->Add(m_tiBrimWidth, 0, wxALIGN_CENTER_VERTICAL);
+        brim_sizer->Add(width_row, 0, wxLEFT | wxBOTTOM, FromDIP(4));
+
+        auto gap_row = new wxBoxSizer(wxHORIZONTAL);
+        auto gap_lbl = new wxStaticText(this, wxID_ANY, _L("Extra gap (mm)"), wxDefaultPosition, lbl_size);
+        m_tiBrimGap = new TextInput(this, default_brim_gap, "", "", wxDefaultPosition, ti_size, wxTE_PROCESS_ENTER);
+        m_tiBrimGap->GetTextCtrl()->SetValidator(wxTextValidator(wxFILTER_NUMERIC));
+        m_tiBrimGap->SetToolTip(_L("Safety margin between brims of adjacent blocks. Total spacing added is 2 * brim width + extra gap."));
+        gap_row->Add(FromDIP(20), 0);
+        gap_row->Add(gap_lbl, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(4));
+        gap_row->Add(m_tiBrimGap, 0, wxALIGN_CENTER_VERTICAL);
+        brim_sizer->Add(gap_row, 0, wxLEFT | wxBOTTOM, FromDIP(4));
+
+        v_sizer->Add(brim_sizer, 0, wxTOP | wxRIGHT | wxLEFT | wxEXPAND, FromDIP(10));
+
+        m_cbBrim->Bind(wxEVT_TOGGLEBUTTON, [this](wxCommandEvent& e) { on_brim_toggled(); e.Skip(); });
+        on_brim_toggled(); // sync enabled state with initial checkbox value
+    }
+
     v_sizer->AddSpacer(FromDIP(5));
 
     auto dlg_btns = new DialogButtons(this, {"OK"});
@@ -1713,15 +1768,36 @@ FlowRateCalibrationDialog::~FlowRateCalibrationDialog() {
 void FlowRateCalibrationDialog::on_start(wxCommandEvent& event) {
     int type = m_rbType->GetSelection();
     int patternIdx = m_rbPattern->GetSelection();
-    
+
     InfillPattern pattern = ipArchimedeanChords;
     if (patternIdx == 1) pattern = ipMonotonic;
-    
+
     bool is_linear = (type >= 2);
     int pass = (type % 2) + 1;
 
-    m_plater->calib_flowrate(is_linear, pass, pattern);
+    // ORCA: read brim toggle / values, clamp to sane bounds, persist for next session
+    const bool brim_enabled = m_cbBrim->GetValue();
+    double brim_width = 3.0;
+    double brim_gap   = 2.0;
+    m_tiBrimWidth->GetTextCtrl()->GetValue().ToDouble(&brim_width);
+    m_tiBrimGap->GetTextCtrl()->GetValue().ToDouble(&brim_gap);
+    brim_width = std::clamp(brim_width, 0.0, 20.0);
+    brim_gap   = std::clamp(brim_gap,   0.0, 20.0);
+
+    if (auto* cfg = wxGetApp().app_config) {
+        cfg->set("calibration_flowrate", "brim_enabled",   brim_enabled ? "true" : "false");
+        cfg->set("calibration_flowrate", "brim_width",     std::to_string(brim_width));
+        cfg->set("calibration_flowrate", "brim_extra_gap", std::to_string(brim_gap));
+    }
+
+    m_plater->calib_flowrate(is_linear, pass, pattern, brim_enabled, brim_width, brim_gap);
     EndModal(wxID_OK);
+}
+
+void FlowRateCalibrationDialog::on_brim_toggled() {
+    const bool enabled = m_cbBrim->GetValue();
+    m_tiBrimWidth->Enable(enabled);
+    m_tiBrimGap->Enable(enabled);
 }
 
 void FlowRateCalibrationDialog::on_dpi_changed(const wxRect& suggested_rect) {

--- a/src/slic3r/GUI/calib_dlg.hpp
+++ b/src/slic3r/GUI/calib_dlg.hpp
@@ -190,10 +190,15 @@ public:
 
 protected:
     virtual void on_start(wxCommandEvent& event);
+    void on_brim_toggled();
 
     RadioGroup* m_rbType;
     // ORCA: use standard OrcaSlicer ComboBox instead of BitmapComboBox
     ComboBox* m_rbPattern;
+    // ORCA: optional outer brim with auto-spacing for warp-prone filaments
+    CheckBox*  m_cbBrim;
+    TextInput* m_tiBrimWidth;
+    TextInput* m_tiBrimGap;
     Plater* m_plater;
 };
 }} // namespace Slic3r::GUI

--- a/src/slic3r/GUI/calib_dlg.hpp
+++ b/src/slic3r/GUI/calib_dlg.hpp
@@ -193,10 +193,15 @@ public:
 
 protected:
     virtual void on_start(wxCommandEvent& event);
+    void on_brim_toggled();
 
     RadioGroup* m_rbType;
     // ORCA: use standard OrcaSlicer ComboBox instead of BitmapComboBox
     ComboBox* m_rbPattern;
+    // ORCA: optional outer brim with auto-spacing for warp-prone filaments
+    CheckBox*  m_cbBrim;
+    TextInput* m_tiBrimWidth;
+    TextInput* m_tiBrimGap;
     Plater* m_plater;
 };
 }} // namespace Slic3r::GUI


### PR DESCRIPTION
## Summary

The Flow Rate Calibration plate (Pass 1 / Pass 2 / YOLO Recommended / YOLO Perfectionist) places its calibration blocks tight enough that applying any non-trivial brim merges adjacent blocks into one mat. For warp-prone filaments (ASA, ABS, PC, etc.) on small footprints, brim is the key first-layer adhesion mitigation — so users currently have to pick between *"use brim, lose the calibration plate layout"* and *"use the plate, get warped/lifted blocks"*. This adds an **opt-in** toggle that gives both: per-block outer brim plus uniform layout expansion so brims don't merge.

## UI

In `FlowRateCalibrationDialog`, new **"Enable brim"** checkbox plus two spinboxes:
- **Brim width (mm)** — default `3.0`
- **Extra gap (mm)** — default `2.0` (safety margin on top of `2 × brim_width`)

The spinboxes are disabled when the toggle is off. **Default state is OFF**, so existing users see no behavior change.

## Persistence

Toggle and values are stored under a new `[calibration_flowrate]` section in `OrcaSlicer.conf` so they survive across sessions:

```
[calibration_flowrate]
brim_enabled = true
brim_width = 3.000000
brim_extra_gap = 2.000000
```

## Plate generation

When the toggle is on, `adjust_settings_for_flowrate_calib()`:

1. Sets per-object `brim_type=btOuterOnly`, `brim_width=N`, `brim_object_gap=0` — same pattern `Plater::calib_temp` already uses for the temperature tower (proven path).
2. Computes a **uniform scale-from-centroid factor** so every gap between adjacent blocks grows by exactly `2 × brim_width + extra_gap`:
   - `s = 1 + (required_gap − current_min_gap) / min_center_distance`
   - For each object: `new_center = centroid + s × (current_center − centroid)`, applied via `translate_instances()`.
3. Uniform scaling preserves the prebuilt grid layout (3×3 for Pass 1/2, 4×4 for YOLO Perfectionist, etc.) while avoiding collision. If the existing gap is already ≥ required, no translation is applied.

## Test plan

Tested on Linux (Debian 13, wxGTK) for all four modes:

- [x] Toggle **OFF**: original tightly-spaced no-brim layout, unchanged. (Regression check.)
- [x] Toggle **ON** (defaults, YOLO Perfectionist 4×4 with Archimedean Chords): each of the 16 blocks gets its own outer brim ring with a clear unmerged gap in slice preview.
- [x] Toggle **ON** + clicking OK + reopening dialog: values persist via AppConfig.
- [x] Spinboxes grey out when checkbox is off.
- [ ] Windows / macOS sanity check (the change uses already-portable widgets — `CheckBox`, `TextInput` — already used elsewhere in this file, so behavior should be identical, but visual confirmation on review is appreciated).

## Screenshot

YOLO Perfectionist with brim toggled on, slice preview — every block has its own outer brim ring, no merging:

(I can attach a screenshot on request.)

## Notes for reviewers

- This patch is independent of #13545 (Flow Ratio dialog size-hint fix). They touch the same file but non-overlapping regions and can be merged in either order.
- For very small print beds (e.g., 180 mm Mini) with a wide brim, the auto-expanded layout could push outer blocks off the printable area. I considered clamping but decided against it for simplicity — the slicer's own bed-bounds warnings will surface this, and dialing back `Brim width` is the obvious fix. Happy to add a clamp if reviewers prefer.