### PR TITLE
Adjust creality generic ASA first layer temp from 60c to 100c

### DIFF
--- a/resources/profiles/Creality/filament/fdm_filament_asa.json
+++ b/resources/profiles/Creality/filament/fdm_filament_asa.json
@@ -17,8 +17,8 @@
 		"100"
 	],
 	"textured_plate_temp_initial_layer": [
-    	"100"
-    ],
+		"100"
+	 ],
 	"cool_plate_temp_initial_layer": [
 		"105"
 	],

--- a/resources/profiles/Creality/filament/fdm_filament_asa.json
+++ b/resources/profiles/Creality/filament/fdm_filament_asa.json
@@ -18,7 +18,7 @@
 	],
 	"textured_plate_temp_initial_layer": [
 		"100"
-	 ],
+	],
 	"cool_plate_temp_initial_layer": [
 		"105"
 	],

--- a/resources/profiles/Creality/filament/fdm_filament_asa.json
+++ b/resources/profiles/Creality/filament/fdm_filament_asa.json
@@ -16,6 +16,9 @@
 	"textured_plate_temp": [
 		"100"
 	],
+	"textured_plate_temp_initial_layer": [
+    	"100"
+    ],
 	"cool_plate_temp_initial_layer": [
 		"105"
 	],


### PR DESCRIPTION
# Description
Fixes #13551, Related to #8321

Creality's fdm_filament_asa.json was missing textured_plate_temp_initial_layer causing it to fall back to 60°C from fdm_filament_common. The Creality website says the K1 heatbed maximum temp is at or below 100°C, set initial layer temp to 100°C to match textured_plate_temp.

## Tests
Copied profile into my slicer to verify it pulled correct temps (appdata may need cleared for these changes to be cached properly)

