### PR TITLE
fixed an issue that FilamentGroupPopup dialog didn't dismiss on macOS

### DIFF
--- a/src/slic3r/GUI/FilamentGroupPopup.cpp
+++ b/src/slic3r/GUI/FilamentGroupPopup.cpp
@@ -353,7 +353,13 @@ void FilamentGroupPopup::OnLeaveWindow(wxMouseEvent &)
     StartTimer();
 }
 
-void FilamentGroupPopup::OnEnterWindow(wxMouseEvent &) { ResetTimer(); }
+void FilamentGroupPopup::OnEnterWindow(wxMouseEvent &)
+{
+    // Ignore spurious ENTER synthesized by PopupWindow::OnMouseEvent2 on macOS.
+    wxPoint pos = this->ScreenToClient(wxGetMousePosition());
+    if (!this->GetClientRect().Contains(pos)) return;
+    ResetTimer();
+}
 
 void FilamentGroupPopup::UpdateButtonStatus(int hover_idx)
 {


### PR DESCRIPTION
# Description
Fixed an issue on macOS where clicking the FilamentGroupPopup dialog prevented it from dismissing, causing OrcaSlicer to become unresponsive to other UI interactions.

# Screenshots/Recordings/Graphs

<!--
> Please attach relevant screenshots to showcase the UI changes.
> Please attach images that can help explain the changes.
-->

## Tests

<!--
> Please describe the tests that you have conducted to verify the changes made in this PR.
-->

<!--
> A guide for users on how to download the artifacts from this PR.
-->

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
