### PR TITLE
Migrate Anker filaments to OrcaFilamentLibrary

### DIFF
--- a/resources/profiles/Anker/filament/Anker Generic ABS @base.json
+++ b/resources/profiles/Anker/filament/Anker Generic ABS @base.json
@@ -1,7 +1,7 @@
 {
 	"type": "filament",
 	"name": "Anker Generic ABS @base",
-	"inherits": "fdm_filament_abs",
+	"inherits": "Anker ABS @base",
 	"from": "system",
 	"filament_id": "GFB99",
 	"instantiation": "false"

--- a/resources/profiles/Anker/filament/Anker Generic ASA @base.json
+++ b/resources/profiles/Anker/filament/Anker Generic ASA @base.json
@@ -1,7 +1,7 @@
 {
 	"type": "filament",
 	"name": "Anker Generic ASA @base",
-	"inherits": "fdm_filament_asa",
+	"inherits": "Anker ASA @base",
 	"from": "system",
 	"filament_id": "GFB98",
 	"instantiation": "false"

--- a/resources/profiles/Anker/filament/Anker Generic PA @base.json
+++ b/resources/profiles/Anker/filament/Anker Generic PA @base.json
@@ -1,7 +1,7 @@
 {
 	"type": "filament",
 	"name": "Anker Generic PA @base",
-	"inherits": "fdm_filament_pa",
+	"inherits": "Anker PA @base",
 	"from": "system",
 	"filament_id": "GFN99",
 	"instantiation": "false"

--- a/resources/profiles/Anker/filament/Anker Generic PA-CF @base.json
+++ b/resources/profiles/Anker/filament/Anker Generic PA-CF @base.json
@@ -1,20 +1,8 @@
 {
 	"type": "filament",
 	"name": "Anker Generic PA-CF @base",
-	"inherits": "fdm_filament_pa",
+	"inherits": "Anker PA-CF @base",
 	"from": "system",
 	"filament_id": "GFN98",
-	"instantiation": "false",
-	"filament_type": [
-		"PA-CF"
-	],
-	"required_nozzle_HRC": [
-		"40"
-	],
-	"filament_cost": [
-		"55"
-	],
-	"filament_max_volumetric_speed": [
-		"6"
-	]
+	"instantiation": "false"
 }

--- a/resources/profiles/Anker/filament/Anker Generic PC @base.json
+++ b/resources/profiles/Anker/filament/Anker Generic PC @base.json
@@ -1,7 +1,7 @@
 {
 	"type": "filament",
 	"name": "Anker Generic PC @base",
-	"inherits": "fdm_filament_pc",
+	"inherits": "Anker PC @base",
 	"from": "system",
 	"filament_id": "GFC99",
 	"instantiation": "false"

--- a/resources/profiles/Anker/filament/Anker Generic PETG @base.json
+++ b/resources/profiles/Anker/filament/Anker Generic PETG @base.json
@@ -1,16 +1,8 @@
 {
 	"type": "filament",
 	"name": "Anker Generic PETG @base",
-	"inherits": "fdm_filament_pet",
+	"inherits": "Anker PETG @base",
 	"from": "system",
 	"filament_id": "GFG99",
-	"instantiation": "false",
-	"filament_type": [
-		"PETG"
-	],
-	"filament_retraction_speed": "20",
-	"filament_deretraction_speed": "60",
-	"filament_retract_when_changing_layer": "1",
-	"filament_wipe": "1",
-	"filament_retract_before_wipe": "100"
+	"instantiation": "false"
 }

--- a/resources/profiles/Anker/filament/Anker Generic PETG-CF @base.json
+++ b/resources/profiles/Anker/filament/Anker Generic PETG-CF @base.json
@@ -1,25 +1,8 @@
 {
 	"type": "filament",
 	"name": "Anker Generic PETG-CF @base",
-	"inherits": "fdm_filament_pet",
+	"inherits": "Anker PETG-CF @base",
 	"from": "system",
 	"filament_id": "GFG98",
-	"instantiation": "false",
-	"filament_type": [
-		"PETG-CF"
-	],
-	"required_nozzle_HRC": [
-		"40"
-	],
-	"filament_cost": [
-		"35"
-	],
-	"filament_max_volumetric_speed": [
-		"6"
-	],
-	"filament_retraction_speed": "20",
-	"filament_deretraction_speed": "60",
-	"filament_retract_when_changing_layer": "1",
-	"filament_wipe": "1",
-	"filament_retract_before_wipe": "100"
+	"instantiation": "false"
 }

--- a/resources/profiles/Anker/filament/Anker Generic PLA @base.json
+++ b/resources/profiles/Anker/filament/Anker Generic PLA @base.json
@@ -1,7 +1,7 @@
 {
 	"type": "filament",
 	"name": "Anker Generic PLA @base",
-	"inherits": "fdm_filament_pla",
+	"inherits": "Anker PLA @base",
 	"from": "system",
 	"filament_id": "GFL99",
 	"instantiation": "false"

--- a/resources/profiles/Anker/filament/Anker Generic PLA Silk @base.json
+++ b/resources/profiles/Anker/filament/Anker Generic PLA Silk @base.json
@@ -1,38 +1,8 @@
 {
 	"type": "filament",
 	"name": "Anker Generic PLA Silk @base",
-	"inherits": "fdm_filament_pla",
+	"inherits": "Anker PLA Silk @base",
 	"from": "system",
 	"filament_id": "GFL96",
-	"instantiation": "false",
-	"filament_cost": [
-		"20"
-	],
-	"temperature_vitrification": [
-		"60"
-	],
-	"nozzle_temperature_initial_layer": [
-		"225"
-	],
-	"nozzle_temperature": [
-		"225"
-	],
-	"hot_plate_temp_initial_layer": [
-		"60"
-	],
-	"hot_plate_temp": [
-		"60"
-	],
-	"filament_max_volumetric_speed": [
-		"6"
-	],
-	"fan_cooling_layer_time": [
-		"80"
-	],
-	"fan_max_speed": [
-		"80"
-	],
-	"fan_min_speed": [
-		"60"
-	]
+	"instantiation": "false"
 }

--- a/resources/profiles/Anker/filament/Anker Generic PLA+ @base.json
+++ b/resources/profiles/Anker/filament/Anker Generic PLA+ @base.json
@@ -1,23 +1,8 @@
 {
 	"type": "filament",
 	"name": "Anker Generic PLA+ @base",
-	"inherits": "fdm_filament_pla",
+	"inherits": "Anker PLA+ @base",
 	"from": "system",
 	"filament_id": "GFL95",
-	"instantiation": "false",
-	"filament_cost": [
-		"25"
-	],
-	"temperature_vitrification": [
-		"70"
-	],
-	"nozzle_temperature_initial_layer": [
-		"220"
-	],
-	"nozzle_temperature": [
-		"220"
-	],
-	"filament_max_volumetric_speed": [
-		"16"
-	]
+	"instantiation": "false"
 }

--- a/resources/profiles/Anker/filament/Anker Generic PLA-CF @base.json
+++ b/resources/profiles/Anker/filament/Anker Generic PLA-CF @base.json
@@ -1,38 +1,8 @@
 {
 	"type": "filament",
 	"name": "Anker Generic PLA-CF @base",
-	"inherits": "fdm_filament_pla",
+	"inherits": "Anker PLA-CF @base",
 	"from": "system",
 	"filament_id": "GFL98",
-	"instantiation": "false",
-	"filament_type": [
-		"PLA-CF"
-	],
-	"required_nozzle_HRC": [
-		"40"
-	],
-	"filament_cost": [
-		"25"
-	],
-	"temperature_vitrification": [
-		"70"
-	],
-	"nozzle_temperature_initial_layer": [
-		"225"
-	],
-	"nozzle_temperature": [
-		"220"
-	],
-	"hot_plate_temp_initial_layer": [
-		"65"
-	],
-	"hot_plate_temp": [
-		"65"
-	],
-	"filament_max_volumetric_speed": [
-		"12"
-	],
-	"slow_down_layer_time": [
-		"7"
-	]
+	"instantiation": "false"
 }

--- a/resources/profiles/Anker/filament/Anker Generic PVA @base.json
+++ b/resources/profiles/Anker/filament/Anker Generic PVA @base.json
@@ -1,7 +1,7 @@
 {
 	"type": "filament",
 	"name": "Anker Generic PVA @base",
-	"inherits": "fdm_filament_pva",
+	"inherits": "Anker PVA @base",
 	"from": "system",
 	"filament_id": "GFS99",
 	"instantiation": "false"

--- a/resources/profiles/Anker/filament/Anker Generic TPU @base.json
+++ b/resources/profiles/Anker/filament/Anker Generic TPU @base.json
@@ -1,13 +1,8 @@
 {
 	"type": "filament",
 	"name": "Anker Generic TPU @base",
-	"inherits": "fdm_filament_tpu",
+	"inherits": "Anker TPU @base",
 	"from": "system",
 	"filament_id": "GFU99",
-	"instantiation": "false",
-	"filament_retraction_speed": "90",
-	"filament_deretraction_speed": "50",
-	"filament_retract_when_changing_layer": "1",
-	"filament_wipe": "1",
-	"filament_retract_before_wipe": "70"
+	"instantiation": "false"
 }

--- a/resources/profiles/OrcaFilamentLibrary.json
+++ b/resources/profiles/OrcaFilamentLibrary.json
@@ -1507,6 +1507,110 @@
 		{
 			"name": "GreenGate3D PETG @System",
 			"sub_path": "filament/GreenGate3D/GreenGate3D PETG @System.json"
+		},
+		{
+			"name": "Anker ABS @base",
+			"sub_path": "filament/Anker/Anker ABS @base.json"
+		},
+		{
+			"name": "Anker ABS @System",
+			"sub_path": "filament/Anker/Anker ABS @System.json"
+		},
+		{
+			"name": "Anker ASA @base",
+			"sub_path": "filament/Anker/Anker ASA @base.json"
+		},
+		{
+			"name": "Anker ASA @System",
+			"sub_path": "filament/Anker/Anker ASA @System.json"
+		},
+		{
+			"name": "Anker PA @base",
+			"sub_path": "filament/Anker/Anker PA @base.json"
+		},
+		{
+			"name": "Anker PA @System",
+			"sub_path": "filament/Anker/Anker PA @System.json"
+		},
+		{
+			"name": "Anker PA-CF @base",
+			"sub_path": "filament/Anker/Anker PA-CF @base.json"
+		},
+		{
+			"name": "Anker PA-CF @System",
+			"sub_path": "filament/Anker/Anker PA-CF @System.json"
+		},
+		{
+			"name": "Anker PC @base",
+			"sub_path": "filament/Anker/Anker PC @base.json"
+		},
+		{
+			"name": "Anker PC @System",
+			"sub_path": "filament/Anker/Anker PC @System.json"
+		},
+		{
+			"name": "Anker PETG @base",
+			"sub_path": "filament/Anker/Anker PETG @base.json"
+		},
+		{
+			"name": "Anker PETG @System",
+			"sub_path": "filament/Anker/Anker PETG @System.json"
+		},
+		{
+			"name": "Anker PETG-CF @base",
+			"sub_path": "filament/Anker/Anker PETG-CF @base.json"
+		},
+		{
+			"name": "Anker PETG-CF @System",
+			"sub_path": "filament/Anker/Anker PETG-CF @System.json"
+		},
+		{
+			"name": "Anker PLA @base",
+			"sub_path": "filament/Anker/Anker PLA @base.json"
+		},
+		{
+			"name": "Anker PLA @System",
+			"sub_path": "filament/Anker/Anker PLA @System.json"
+		},
+		{
+			"name": "Anker PLA Silk @base",
+			"sub_path": "filament/Anker/Anker PLA Silk @base.json"
+		},
+		{
+			"name": "Anker PLA Silk @System",
+			"sub_path": "filament/Anker/Anker PLA Silk @System.json"
+		},
+		{
+			"name": "Anker PLA+ @base",
+			"sub_path": "filament/Anker/Anker PLA+ @base.json"
+		},
+		{
+			"name": "Anker PLA+ @System",
+			"sub_path": "filament/Anker/Anker PLA+ @System.json"
+		},
+		{
+			"name": "Anker PLA-CF @base",
+			"sub_path": "filament/Anker/Anker PLA-CF @base.json"
+		},
+		{
+			"name": "Anker PLA-CF @System",
+			"sub_path": "filament/Anker/Anker PLA-CF @System.json"
+		},
+		{
+			"name": "Anker PVA @base",
+			"sub_path": "filament/Anker/Anker PVA @base.json"
+		},
+		{
+			"name": "Anker PVA @System",
+			"sub_path": "filament/Anker/Anker PVA @System.json"
+		},
+		{
+			"name": "Anker TPU @base",
+			"sub_path": "filament/Anker/Anker TPU @base.json"
+		},
+		{
+			"name": "Anker TPU @System",
+			"sub_path": "filament/Anker/Anker TPU @System.json"
 		}
 	],
 	"process_list": [],

--- a/resources/profiles/OrcaFilamentLibrary/filament/Anker/Anker ABS @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Anker/Anker ABS @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "Anker ABS @System",
+	"inherits": "Anker ABS @base",
+	"from": "system",
+	"setting_id": "ANKS01_00",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Anker/Anker ABS @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Anker/Anker ABS @base.json
@@ -5,6 +5,111 @@
 	"from": "system",
 	"filament_id": "ANKB99",
 	"instantiation": "false",
+	"filament_soluble": [
+		"0"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"required_nozzle_HRC": [
+		"0"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"0.926"
+	],
+	"filament_start_gcode": [
+		"; Filament gcode\n"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"10"
+	],
+	"filament_cooling_moves": [
+		"0"
+	],
+	"filament_cooling_initial_speed": [
+		"0"
+	],
+	"filament_cooling_final_speed": [
+		"0"
+	],
+	"filament_type": [
+		"ABS"
+	],
+	"filament_density": [
+		"1.04"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"temperature_vitrification": [
+		"110"
+	],
+	"nozzle_temperature_range_low": [
+		"240"
+	],
+	"nozzle_temperature_range_high": [
+		"280"
+	],
+	"nozzle_temperature_initial_layer": [
+		"240"
+	],
+	"nozzle_temperature": [
+		"240"
+	],
+	"hot_plate_temp_initial_layer": [
+		"100"
+	],
+	"hot_plate_temp": [
+		"100"
+	],
+	"filament_max_volumetric_speed": [
+		"12"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"full_fan_speed_layer": [
+		"3"
+	],
+	"fan_min_speed": [
+		"20"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"fan_max_speed": [
+		"30"
+	],
+	"slow_down_layer_time": [
+		"3"
+	],
+	"reduce_fan_stop_start_freq": [
+		"0"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"enable_overhang_bridge_fan": [
+		"1"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"overhang_fan_speed": [
+		"80"
+	],
+	"support_material_interface_fan_speed": [
+		"-1"
+	],
 	"filament_vendor": [
 		"Anker"
 	]

--- a/resources/profiles/OrcaFilamentLibrary/filament/Anker/Anker ABS @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Anker/Anker ABS @base.json
@@ -1,0 +1,11 @@
+{
+	"type": "filament",
+	"name": "Anker ABS @base",
+	"inherits": "fdm_filament_abs",
+	"from": "system",
+	"filament_id": "ANKB99",
+	"instantiation": "false",
+	"filament_vendor": [
+		"Anker"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Anker/Anker ASA @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Anker/Anker ASA @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "Anker ASA @System",
+	"inherits": "Anker ASA @base",
+	"from": "system",
+	"setting_id": "ANKS02_00",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Anker/Anker ASA @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Anker/Anker ASA @base.json
@@ -5,6 +5,111 @@
 	"from": "system",
 	"filament_id": "ANKA99",
 	"instantiation": "false",
+	"filament_soluble": [
+		"0"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"required_nozzle_HRC": [
+		"0"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"0.93"
+	],
+	"filament_start_gcode": [
+		"; Filament gcode\n"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"10"
+	],
+	"filament_cooling_moves": [
+		"0"
+	],
+	"filament_cooling_initial_speed": [
+		"0"
+	],
+	"filament_cooling_final_speed": [
+		"0"
+	],
+	"filament_type": [
+		"ASA"
+	],
+	"filament_density": [
+		"1.05"
+	],
+	"filament_cost": [
+		"30"
+	],
+	"temperature_vitrification": [
+		"110"
+	],
+	"nozzle_temperature_range_low": [
+		"240"
+	],
+	"nozzle_temperature_range_high": [
+		"280"
+	],
+	"nozzle_temperature_initial_layer": [
+		"240"
+	],
+	"nozzle_temperature": [
+		"240"
+	],
+	"hot_plate_temp_initial_layer": [
+		"100"
+	],
+	"hot_plate_temp": [
+		"100"
+	],
+	"filament_max_volumetric_speed": [
+		"12"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"full_fan_speed_layer": [
+		"3"
+	],
+	"fan_min_speed": [
+		"15"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"fan_max_speed": [
+		"20"
+	],
+	"slow_down_layer_time": [
+		"3"
+	],
+	"reduce_fan_stop_start_freq": [
+		"0"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"enable_overhang_bridge_fan": [
+		"1"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"overhang_fan_speed": [
+		"80"
+	],
+	"support_material_interface_fan_speed": [
+		"-1"
+	],
 	"filament_vendor": [
 		"Anker"
 	]

--- a/resources/profiles/OrcaFilamentLibrary/filament/Anker/Anker ASA @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Anker/Anker ASA @base.json
@@ -1,0 +1,11 @@
+{
+	"type": "filament",
+	"name": "Anker ASA @base",
+	"inherits": "fdm_filament_asa",
+	"from": "system",
+	"filament_id": "ANKA99",
+	"instantiation": "false",
+	"filament_vendor": [
+		"Anker"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Anker/Anker PA @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Anker/Anker PA @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "Anker PA @System",
+	"inherits": "Anker PA @base",
+	"from": "system",
+	"setting_id": "ANKS03_00",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Anker/Anker PA @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Anker/Anker PA @base.json
@@ -1,0 +1,11 @@
+{
+	"type": "filament",
+	"name": "Anker PA @base",
+	"inherits": "fdm_filament_pa",
+	"from": "system",
+	"filament_id": "ANKN99",
+	"instantiation": "false",
+	"filament_vendor": [
+		"Anker"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Anker/Anker PA @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Anker/Anker PA @base.json
@@ -5,6 +5,111 @@
 	"from": "system",
 	"filament_id": "ANKN99",
 	"instantiation": "false",
+	"filament_soluble": [
+		"0"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"required_nozzle_HRC": [
+		"0"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"0.97"
+	],
+	"filament_start_gcode": [
+		"; Filament gcode\n"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"10"
+	],
+	"filament_cooling_moves": [
+		"0"
+	],
+	"filament_cooling_initial_speed": [
+		"0"
+	],
+	"filament_cooling_final_speed": [
+		"0"
+	],
+	"filament_type": [
+		"PA"
+	],
+	"filament_density": [
+		"1.05"
+	],
+	"filament_cost": [
+		"40"
+	],
+	"temperature_vitrification": [
+		"108"
+	],
+	"nozzle_temperature_range_low": [
+		"260"
+	],
+	"nozzle_temperature_range_high": [
+		"300"
+	],
+	"nozzle_temperature_initial_layer": [
+		"290"
+	],
+	"nozzle_temperature": [
+		"290"
+	],
+	"hot_plate_temp_initial_layer": [
+		"95"
+	],
+	"hot_plate_temp": [
+		"95"
+	],
+	"filament_max_volumetric_speed": [
+		"8"
+	],
+	"close_fan_the_first_x_layers": [
+		"4"
+	],
+	"full_fan_speed_layer": [
+		"4"
+	],
+	"fan_min_speed": [
+		"0"
+	],
+	"fan_cooling_layer_time": [
+		"4"
+	],
+	"fan_max_speed": [
+		"60"
+	],
+	"slow_down_layer_time": [
+		"2"
+	],
+	"reduce_fan_stop_start_freq": [
+		"0"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"enable_overhang_bridge_fan": [
+		"1"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"overhang_fan_speed": [
+		"30"
+	],
+	"support_material_interface_fan_speed": [
+		"-1"
+	],
 	"filament_vendor": [
 		"Anker"
 	]

--- a/resources/profiles/OrcaFilamentLibrary/filament/Anker/Anker PA-CF @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Anker/Anker PA-CF @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "Anker PA-CF @System",
+	"inherits": "Anker PA-CF @base",
+	"from": "system",
+	"setting_id": "ANKS04_00",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Anker/Anker PA-CF @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Anker/Anker PA-CF @base.json
@@ -1,0 +1,23 @@
+{
+	"type": "filament",
+	"name": "Anker PA-CF @base",
+	"inherits": "fdm_filament_pa",
+	"from": "system",
+	"filament_id": "ANKN98",
+	"instantiation": "false",
+	"filament_type": [
+		"PA-CF"
+	],
+	"required_nozzle_HRC": [
+		"40"
+	],
+	"filament_cost": [
+		"55"
+	],
+	"filament_max_volumetric_speed": [
+		"6"
+	],
+	"filament_vendor": [
+		"Anker"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Anker/Anker PA-CF @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Anker/Anker PA-CF @base.json
@@ -5,17 +5,110 @@
 	"from": "system",
 	"filament_id": "ANKN98",
 	"instantiation": "false",
-	"filament_type": [
-		"PA-CF"
+	"filament_soluble": [
+		"0"
+	],
+	"filament_is_support": [
+		"0"
 	],
 	"required_nozzle_HRC": [
 		"40"
 	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"0.97"
+	],
+	"filament_start_gcode": [
+		"; Filament gcode\n"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"10"
+	],
+	"filament_cooling_moves": [
+		"0"
+	],
+	"filament_cooling_initial_speed": [
+		"0"
+	],
+	"filament_cooling_final_speed": [
+		"0"
+	],
+	"filament_type": [
+		"PA-CF"
+	],
+	"filament_density": [
+		"1.05"
+	],
 	"filament_cost": [
 		"55"
 	],
+	"temperature_vitrification": [
+		"108"
+	],
+	"nozzle_temperature_range_low": [
+		"260"
+	],
+	"nozzle_temperature_range_high": [
+		"300"
+	],
+	"nozzle_temperature_initial_layer": [
+		"290"
+	],
+	"nozzle_temperature": [
+		"290"
+	],
+	"hot_plate_temp_initial_layer": [
+		"95"
+	],
+	"hot_plate_temp": [
+		"95"
+	],
 	"filament_max_volumetric_speed": [
 		"6"
+	],
+	"close_fan_the_first_x_layers": [
+		"4"
+	],
+	"full_fan_speed_layer": [
+		"4"
+	],
+	"fan_min_speed": [
+		"0"
+	],
+	"fan_cooling_layer_time": [
+		"4"
+	],
+	"fan_max_speed": [
+		"60"
+	],
+	"slow_down_layer_time": [
+		"2"
+	],
+	"reduce_fan_stop_start_freq": [
+		"0"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"enable_overhang_bridge_fan": [
+		"1"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"overhang_fan_speed": [
+		"30"
+	],
+	"support_material_interface_fan_speed": [
+		"-1"
 	],
 	"filament_vendor": [
 		"Anker"

--- a/resources/profiles/OrcaFilamentLibrary/filament/Anker/Anker PC @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Anker/Anker PC @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "Anker PC @System",
+	"inherits": "Anker PC @base",
+	"from": "system",
+	"setting_id": "ANKS05_00",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Anker/Anker PC @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Anker/Anker PC @base.json
@@ -5,6 +5,111 @@
 	"from": "system",
 	"filament_id": "ANKC99",
 	"instantiation": "false",
+	"filament_soluble": [
+		"0"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"required_nozzle_HRC": [
+		"0"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"0.94"
+	],
+	"filament_start_gcode": [
+		"; Filament gcode\n"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"10"
+	],
+	"filament_cooling_moves": [
+		"0"
+	],
+	"filament_cooling_initial_speed": [
+		"0"
+	],
+	"filament_cooling_final_speed": [
+		"0"
+	],
+	"filament_type": [
+		"PC"
+	],
+	"filament_density": [
+		"1.21"
+	],
+	"filament_cost": [
+		"45"
+	],
+	"temperature_vitrification": [
+		"140"
+	],
+	"nozzle_temperature_range_low": [
+		"260"
+	],
+	"nozzle_temperature_range_high": [
+		"280"
+	],
+	"nozzle_temperature_initial_layer": [
+		"270"
+	],
+	"nozzle_temperature": [
+		"270"
+	],
+	"hot_plate_temp_initial_layer": [
+		"100"
+	],
+	"hot_plate_temp": [
+		"100"
+	],
+	"filament_max_volumetric_speed": [
+		"14"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"full_fan_speed_layer": [
+		"3"
+	],
+	"fan_min_speed": [
+		"15"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"fan_max_speed": [
+		"20"
+	],
+	"slow_down_layer_time": [
+		"4"
+	],
+	"reduce_fan_stop_start_freq": [
+		"0"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"enable_overhang_bridge_fan": [
+		"1"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"overhang_fan_speed": [
+		"60"
+	],
+	"support_material_interface_fan_speed": [
+		"-1"
+	],
 	"filament_vendor": [
 		"Anker"
 	]

--- a/resources/profiles/OrcaFilamentLibrary/filament/Anker/Anker PC @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Anker/Anker PC @base.json
@@ -1,0 +1,11 @@
+{
+	"type": "filament",
+	"name": "Anker PC @base",
+	"inherits": "fdm_filament_pc",
+	"from": "system",
+	"filament_id": "ANKC99",
+	"instantiation": "false",
+	"filament_vendor": [
+		"Anker"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Anker/Anker PETG @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Anker/Anker PETG @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "Anker PETG @System",
+	"inherits": "Anker PETG @base",
+	"from": "system",
+	"setting_id": "ANKS06_00",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Anker/Anker PETG @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Anker/Anker PETG @base.json
@@ -1,0 +1,19 @@
+{
+	"type": "filament",
+	"name": "Anker PETG @base",
+	"inherits": "fdm_filament_pet",
+	"from": "system",
+	"filament_id": "ANKG99",
+	"instantiation": "false",
+	"filament_type": [
+		"PETG"
+	],
+	"filament_retraction_speed": "20",
+	"filament_deretraction_speed": "60",
+	"filament_retract_when_changing_layer": "1",
+	"filament_wipe": "1",
+	"filament_retract_before_wipe": "100",
+	"filament_vendor": [
+		"Anker"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Anker/Anker PETG @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Anker/Anker PETG @base.json
@@ -5,8 +5,110 @@
 	"from": "system",
 	"filament_id": "ANKG99",
 	"instantiation": "false",
+	"filament_soluble": [
+		"0"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"required_nozzle_HRC": [
+		"0"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"0.95"
+	],
+	"filament_start_gcode": [
+		"; Filament gcode\n"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"10"
+	],
+	"filament_cooling_moves": [
+		"0"
+	],
+	"filament_cooling_initial_speed": [
+		"0"
+	],
+	"filament_cooling_final_speed": [
+		"0"
+	],
 	"filament_type": [
 		"PETG"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_cost": [
+		"18"
+	],
+	"temperature_vitrification": [
+		"85"
+	],
+	"nozzle_temperature_range_low": [
+		"220"
+	],
+	"nozzle_temperature_range_high": [
+		"260"
+	],
+	"nozzle_temperature_initial_layer": [
+		"240"
+	],
+	"nozzle_temperature": [
+		"240"
+	],
+	"hot_plate_temp_initial_layer": [
+		"80"
+	],
+	"hot_plate_temp": [
+		"80"
+	],
+	"filament_max_volumetric_speed": [
+		"8"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"full_fan_speed_layer": [
+		"3"
+	],
+	"fan_min_speed": [
+		"30"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"fan_max_speed": [
+		"50"
+	],
+	"slow_down_layer_time": [
+		"8"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"enable_overhang_bridge_fan": [
+		"1"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"overhang_fan_speed": [
+		"50"
+	],
+	"support_material_interface_fan_speed": [
+		"-1"
 	],
 	"filament_retraction_speed": "20",
 	"filament_deretraction_speed": "60",

--- a/resources/profiles/OrcaFilamentLibrary/filament/Anker/Anker PETG-CF @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Anker/Anker PETG-CF @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "Anker PETG-CF @System",
+	"inherits": "Anker PETG-CF @base",
+	"from": "system",
+	"setting_id": "ANKS07_00",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Anker/Anker PETG-CF @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Anker/Anker PETG-CF @base.json
@@ -5,17 +5,110 @@
 	"from": "system",
 	"filament_id": "ANKG98",
 	"instantiation": "false",
-	"filament_type": [
-		"PETG-CF"
+	"filament_soluble": [
+		"0"
+	],
+	"filament_is_support": [
+		"0"
 	],
 	"required_nozzle_HRC": [
 		"40"
 	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"0.95"
+	],
+	"filament_start_gcode": [
+		"; Filament gcode\n"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"10"
+	],
+	"filament_cooling_moves": [
+		"0"
+	],
+	"filament_cooling_initial_speed": [
+		"0"
+	],
+	"filament_cooling_final_speed": [
+		"0"
+	],
+	"filament_type": [
+		"PETG-CF"
+	],
+	"filament_density": [
+		"1.24"
+	],
 	"filament_cost": [
 		"35"
 	],
+	"temperature_vitrification": [
+		"85"
+	],
+	"nozzle_temperature_range_low": [
+		"220"
+	],
+	"nozzle_temperature_range_high": [
+		"260"
+	],
+	"nozzle_temperature_initial_layer": [
+		"240"
+	],
+	"nozzle_temperature": [
+		"240"
+	],
+	"hot_plate_temp_initial_layer": [
+		"80"
+	],
+	"hot_plate_temp": [
+		"80"
+	],
 	"filament_max_volumetric_speed": [
 		"6"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"full_fan_speed_layer": [
+		"3"
+	],
+	"fan_min_speed": [
+		"30"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"fan_max_speed": [
+		"50"
+	],
+	"slow_down_layer_time": [
+		"8"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"enable_overhang_bridge_fan": [
+		"1"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"overhang_fan_speed": [
+		"50"
+	],
+	"support_material_interface_fan_speed": [
+		"-1"
 	],
 	"filament_retraction_speed": "20",
 	"filament_deretraction_speed": "60",

--- a/resources/profiles/OrcaFilamentLibrary/filament/Anker/Anker PETG-CF @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Anker/Anker PETG-CF @base.json
@@ -1,0 +1,28 @@
+{
+	"type": "filament",
+	"name": "Anker PETG-CF @base",
+	"inherits": "fdm_filament_pet",
+	"from": "system",
+	"filament_id": "ANKG98",
+	"instantiation": "false",
+	"filament_type": [
+		"PETG-CF"
+	],
+	"required_nozzle_HRC": [
+		"40"
+	],
+	"filament_cost": [
+		"35"
+	],
+	"filament_max_volumetric_speed": [
+		"6"
+	],
+	"filament_retraction_speed": "20",
+	"filament_deretraction_speed": "60",
+	"filament_retract_when_changing_layer": "1",
+	"filament_wipe": "1",
+	"filament_retract_before_wipe": "100",
+	"filament_vendor": [
+		"Anker"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Anker/Anker PLA @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Anker/Anker PLA @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "Anker PLA @System",
+	"inherits": "Anker PLA @base",
+	"from": "system",
+	"setting_id": "ANKS08_00",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Anker/Anker PLA @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Anker/Anker PLA @base.json
@@ -5,6 +5,111 @@
 	"from": "system",
 	"filament_id": "ANKL99",
 	"instantiation": "false",
+	"filament_soluble": [
+		"0"
+	],
+	"filament_is_support": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"0"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"filament_start_gcode": [
+		"; Filament gcode\n"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"10"
+	],
+	"filament_cooling_moves": [
+		"0"
+	],
+	"filament_cooling_initial_speed": [
+		"0"
+	],
+	"filament_cooling_final_speed": [
+		"0"
+	],
+	"filament_type": [
+		"PLA"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_cost": [
+		"15"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"230"
+	],
+	"nozzle_temperature_initial_layer": [
+		"215"
+	],
+	"nozzle_temperature": [
+		"210"
+	],
+	"hot_plate_temp_initial_layer": [
+		"60"
+	],
+	"hot_plate_temp": [
+		"60"
+	],
+	"filament_max_volumetric_speed": [
+		"12"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"slow_down_layer_time": [
+		"4"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"enable_overhang_bridge_fan": [
+		"1"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"support_material_interface_fan_speed": [
+		"-1"
+	],
 	"filament_vendor": [
 		"Anker"
 	]

--- a/resources/profiles/OrcaFilamentLibrary/filament/Anker/Anker PLA @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Anker/Anker PLA @base.json
@@ -1,0 +1,11 @@
+{
+	"type": "filament",
+	"name": "Anker PLA @base",
+	"inherits": "fdm_filament_pla",
+	"from": "system",
+	"filament_id": "ANKL99",
+	"instantiation": "false",
+	"filament_vendor": [
+		"Anker"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Anker/Anker PLA Silk @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Anker/Anker PLA Silk @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "Anker PLA Silk @System",
+	"inherits": "Anker PLA Silk @base",
+	"from": "system",
+	"setting_id": "ANKS09_00",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Anker/Anker PLA Silk @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Anker/Anker PLA Silk @base.json
@@ -1,0 +1,41 @@
+{
+	"type": "filament",
+	"name": "Anker PLA Silk @base",
+	"inherits": "fdm_filament_pla",
+	"from": "system",
+	"filament_id": "ANKL96",
+	"instantiation": "false",
+	"filament_cost": [
+		"20"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"nozzle_temperature_initial_layer": [
+		"225"
+	],
+	"nozzle_temperature": [
+		"225"
+	],
+	"hot_plate_temp_initial_layer": [
+		"60"
+	],
+	"hot_plate_temp": [
+		"60"
+	],
+	"filament_max_volumetric_speed": [
+		"6"
+	],
+	"fan_cooling_layer_time": [
+		"80"
+	],
+	"fan_max_speed": [
+		"80"
+	],
+	"fan_min_speed": [
+		"60"
+	],
+	"filament_vendor": [
+		"Anker"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Anker/Anker PLA Silk @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Anker/Anker PLA Silk @base.json
@@ -5,11 +5,56 @@
 	"from": "system",
 	"filament_id": "ANKL96",
 	"instantiation": "false",
+	"filament_soluble": [
+		"0"
+	],
+	"filament_is_support": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"0"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"filament_start_gcode": [
+		"; Filament gcode\n"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"10"
+	],
+	"filament_cooling_moves": [
+		"0"
+	],
+	"filament_cooling_initial_speed": [
+		"0"
+	],
+	"filament_cooling_final_speed": [
+		"0"
+	],
+	"filament_type": [
+		"PLA"
+	],
+	"filament_density": [
+		"1.24"
+	],
 	"filament_cost": [
 		"20"
 	],
 	"temperature_vitrification": [
 		"60"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"230"
 	],
 	"nozzle_temperature_initial_layer": [
 		"225"
@@ -26,14 +71,44 @@
 	"filament_max_volumetric_speed": [
 		"6"
 	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_min_speed": [
+		"60"
+	],
 	"fan_cooling_layer_time": [
 		"80"
 	],
 	"fan_max_speed": [
 		"80"
 	],
-	"fan_min_speed": [
-		"60"
+	"slow_down_layer_time": [
+		"4"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"enable_overhang_bridge_fan": [
+		"1"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"support_material_interface_fan_speed": [
+		"-1"
 	],
 	"filament_vendor": [
 		"Anker"

--- a/resources/profiles/OrcaFilamentLibrary/filament/Anker/Anker PLA+ @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Anker/Anker PLA+ @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "Anker PLA+ @System",
+	"inherits": "Anker PLA+ @base",
+	"from": "system",
+	"setting_id": "ANKS10_00",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Anker/Anker PLA+ @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Anker/Anker PLA+ @base.json
@@ -1,0 +1,26 @@
+{
+	"type": "filament",
+	"name": "Anker PLA+ @base",
+	"inherits": "fdm_filament_pla",
+	"from": "system",
+	"filament_id": "ANKL95",
+	"instantiation": "false",
+	"filament_cost": [
+		"25"
+	],
+	"temperature_vitrification": [
+		"70"
+	],
+	"nozzle_temperature_initial_layer": [
+		"220"
+	],
+	"nozzle_temperature": [
+		"220"
+	],
+	"filament_max_volumetric_speed": [
+		"16"
+	],
+	"filament_vendor": [
+		"Anker"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Anker/Anker PLA+ @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Anker/Anker PLA+ @base.json
@@ -5,11 +5,56 @@
 	"from": "system",
 	"filament_id": "ANKL95",
 	"instantiation": "false",
+	"filament_soluble": [
+		"0"
+	],
+	"filament_is_support": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"0"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"filament_start_gcode": [
+		"; Filament gcode\n"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"10"
+	],
+	"filament_cooling_moves": [
+		"0"
+	],
+	"filament_cooling_initial_speed": [
+		"0"
+	],
+	"filament_cooling_final_speed": [
+		"0"
+	],
+	"filament_type": [
+		"PLA"
+	],
+	"filament_density": [
+		"1.24"
+	],
 	"filament_cost": [
 		"25"
 	],
 	"temperature_vitrification": [
 		"70"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"230"
 	],
 	"nozzle_temperature_initial_layer": [
 		"220"
@@ -17,8 +62,53 @@
 	"nozzle_temperature": [
 		"220"
 	],
+	"hot_plate_temp_initial_layer": [
+		"60"
+	],
+	"hot_plate_temp": [
+		"60"
+	],
 	"filament_max_volumetric_speed": [
 		"16"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"slow_down_layer_time": [
+		"4"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"enable_overhang_bridge_fan": [
+		"1"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"support_material_interface_fan_speed": [
+		"-1"
 	],
 	"filament_vendor": [
 		"Anker"

--- a/resources/profiles/OrcaFilamentLibrary/filament/Anker/Anker PLA-CF @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Anker/Anker PLA-CF @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "Anker PLA-CF @System",
+	"inherits": "Anker PLA-CF @base",
+	"from": "system",
+	"setting_id": "ANKS11_00",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Anker/Anker PLA-CF @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Anker/Anker PLA-CF @base.json
@@ -5,17 +5,56 @@
 	"from": "system",
 	"filament_id": "ANKL98",
 	"instantiation": "false",
-	"filament_type": [
-		"PLA-CF"
+	"filament_soluble": [
+		"0"
+	],
+	"filament_is_support": [
+		"1"
 	],
 	"required_nozzle_HRC": [
 		"40"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"filament_start_gcode": [
+		"; Filament gcode\n"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"10"
+	],
+	"filament_cooling_moves": [
+		"0"
+	],
+	"filament_cooling_initial_speed": [
+		"0"
+	],
+	"filament_cooling_final_speed": [
+		"0"
+	],
+	"filament_type": [
+		"PLA-CF"
+	],
+	"filament_density": [
+		"1.24"
 	],
 	"filament_cost": [
 		"25"
 	],
 	"temperature_vitrification": [
 		"70"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"230"
 	],
 	"nozzle_temperature_initial_layer": [
 		"225"
@@ -32,8 +71,44 @@
 	"filament_max_volumetric_speed": [
 		"12"
 	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"fan_max_speed": [
+		"100"
+	],
 	"slow_down_layer_time": [
 		"7"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"enable_overhang_bridge_fan": [
+		"1"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"support_material_interface_fan_speed": [
+		"-1"
 	],
 	"filament_vendor": [
 		"Anker"

--- a/resources/profiles/OrcaFilamentLibrary/filament/Anker/Anker PLA-CF @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Anker/Anker PLA-CF @base.json
@@ -1,0 +1,41 @@
+{
+	"type": "filament",
+	"name": "Anker PLA-CF @base",
+	"inherits": "fdm_filament_pla",
+	"from": "system",
+	"filament_id": "ANKL98",
+	"instantiation": "false",
+	"filament_type": [
+		"PLA-CF"
+	],
+	"required_nozzle_HRC": [
+		"40"
+	],
+	"filament_cost": [
+		"25"
+	],
+	"temperature_vitrification": [
+		"70"
+	],
+	"nozzle_temperature_initial_layer": [
+		"225"
+	],
+	"nozzle_temperature": [
+		"220"
+	],
+	"hot_plate_temp_initial_layer": [
+		"65"
+	],
+	"hot_plate_temp": [
+		"65"
+	],
+	"filament_max_volumetric_speed": [
+		"12"
+	],
+	"slow_down_layer_time": [
+		"7"
+	],
+	"filament_vendor": [
+		"Anker"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Anker/Anker PVA @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Anker/Anker PVA @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "Anker PVA @System",
+	"inherits": "Anker PVA @base",
+	"from": "system",
+	"setting_id": "ANKS12_00",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Anker/Anker PVA @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Anker/Anker PVA @base.json
@@ -5,6 +5,111 @@
 	"from": "system",
 	"filament_id": "ANKS99",
 	"instantiation": "false",
+	"filament_soluble": [
+		"1"
+	],
+	"filament_is_support": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"0"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"0.95"
+	],
+	"filament_start_gcode": [
+		"; Filament gcode\n"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"10"
+	],
+	"filament_cooling_moves": [
+		"0"
+	],
+	"filament_cooling_initial_speed": [
+		"0"
+	],
+	"filament_cooling_final_speed": [
+		"0"
+	],
+	"filament_type": [
+		"PVA"
+	],
+	"filament_density": [
+		"1.25"
+	],
+	"filament_cost": [
+		"60"
+	],
+	"temperature_vitrification": [
+		"85"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"240"
+	],
+	"nozzle_temperature_initial_layer": [
+		"220"
+	],
+	"nozzle_temperature": [
+		"220"
+	],
+	"hot_plate_temp_initial_layer": [
+		"65"
+	],
+	"hot_plate_temp": [
+		"65"
+	],
+	"filament_max_volumetric_speed": [
+		"16"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"full_fan_speed_layer": [
+		"3"
+	],
+	"fan_min_speed": [
+		"60"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"fan_max_speed": [
+		"80"
+	],
+	"slow_down_layer_time": [
+		"7"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"enable_overhang_bridge_fan": [
+		"1"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"support_material_interface_fan_speed": [
+		"-1"
+	],
 	"filament_vendor": [
 		"Anker"
 	]

--- a/resources/profiles/OrcaFilamentLibrary/filament/Anker/Anker PVA @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Anker/Anker PVA @base.json
@@ -1,0 +1,11 @@
+{
+	"type": "filament",
+	"name": "Anker PVA @base",
+	"inherits": "fdm_filament_pva",
+	"from": "system",
+	"filament_id": "ANKS99",
+	"instantiation": "false",
+	"filament_vendor": [
+		"Anker"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Anker/Anker TPU @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Anker/Anker TPU @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "Anker TPU @System",
+	"inherits": "Anker TPU @base",
+	"from": "system",
+	"setting_id": "ANKS13_00",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Anker/Anker TPU @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Anker/Anker TPU @base.json
@@ -1,0 +1,16 @@
+{
+	"type": "filament",
+	"name": "Anker TPU @base",
+	"inherits": "fdm_filament_tpu",
+	"from": "system",
+	"filament_id": "ANKU99",
+	"instantiation": "false",
+	"filament_retraction_speed": "90",
+	"filament_deretraction_speed": "50",
+	"filament_retract_when_changing_layer": "1",
+	"filament_wipe": "1",
+	"filament_retract_before_wipe": "70",
+	"filament_vendor": [
+		"Anker"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Anker/Anker TPU @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Anker/Anker TPU @base.json
@@ -5,6 +5,111 @@
 	"from": "system",
 	"filament_id": "ANKU99",
 	"instantiation": "false",
+	"filament_soluble": [
+		"0"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"required_nozzle_HRC": [
+		"0"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"1.03"
+	],
+	"filament_start_gcode": [
+		"; Filament gcode\n"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"10"
+	],
+	"filament_cooling_moves": [
+		"0"
+	],
+	"filament_cooling_initial_speed": [
+		"0"
+	],
+	"filament_cooling_final_speed": [
+		"0"
+	],
+	"filament_type": [
+		"TPU"
+	],
+	"filament_density": [
+		"1.21"
+	],
+	"filament_cost": [
+		"25"
+	],
+	"temperature_vitrification": [
+		"30"
+	],
+	"nozzle_temperature_range_low": [
+		"200"
+	],
+	"nozzle_temperature_range_high": [
+		"250"
+	],
+	"nozzle_temperature_initial_layer": [
+		"240"
+	],
+	"nozzle_temperature": [
+		"240"
+	],
+	"hot_plate_temp_initial_layer": [
+		"25"
+	],
+	"hot_plate_temp": [
+		"25"
+	],
+	"filament_max_volumetric_speed": [
+		"1.8"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"full_fan_speed_layer": [
+		"3"
+	],
+	"fan_min_speed": [
+		"30"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"fan_max_speed": [
+		"80"
+	],
+	"slow_down_layer_time": [
+		"4"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"enable_overhang_bridge_fan": [
+		"1"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"overhang_fan_speed": [
+		"50"
+	],
+	"support_material_interface_fan_speed": [
+		"-1"
+	],
 	"filament_retraction_speed": "90",
 	"filament_deretraction_speed": "50",
 	"filament_retract_when_changing_layer": "1",


### PR DESCRIPTION
## Summary
- Move Anker generic filament base profiles into `OrcaFilamentLibrary` as global `Anker ... @base` and `Anker ... @System` profiles.
- Preserve the old resolved Anker material defaults in the new library bases, including temperature, flow, cooling, support, retraction, and filament gcode settings from the previous Anker inheritance chain.
- Keep the existing Anker vendor base profile names and filament IDs as compatibility shims that inherit from the new global Anker bases.
- Register the new Anker library profiles in `OrcaFilamentLibrary.json`.

Contributes to #12162.

## Validation
- `python3 scripts/orca_extra_profile_check.py --vendor Anker --check-filaments --check-materials --check-obsolete-keys`
- `git diff --check`
- Parsed all changed JSON files successfully.
- Checked 26 Anker library files, 26 manifest entries, and no duplicate new Anker profile names in `OrcaFilamentLibrary`.
- Regression check: resolved the old `origin/main` Anker inheritance chain and verified the old effective values are preserved for all 13 legacy `Anker Generic ... @base` profiles.
- Regression check: verified the old effective values are preserved for all non-base `Anker Generic ...` profiles that inherit from those bases.
