### PR TITLE
Move Lulzbot 2.85mm filaments to OrcaFilamentLibrary

### DIFF
--- a/resources/profiles/Lulzbot/filament/Lulzbot 2.85mm ABS.json
+++ b/resources/profiles/Lulzbot/filament/Lulzbot 2.85mm ABS.json
@@ -1,17 +1,10 @@
 {
 	"type": "filament",
 	"name": "Lulzbot 2.85mm ABS",
-	"inherits": "Generic ABS @System",
+	"inherits": "Lulzbot 2.85mm ABS @base",
 	"from": "system",
 	"setting_id": "GFSA04",
-	"filament_id": "GFB99",
 	"instantiation": "true",
-	"filament_diameter": [
-		"2.85"
-	],
-	"filament_max_volumetric_speed": [
-		"6"
-	],
 	"compatible_printers": [
 		"Lulzbot Taz 6 0.5 nozzle",
 		"Lulzbot Taz 4 or 5 0.5 nozzle",

--- a/resources/profiles/Lulzbot/filament/Lulzbot 2.85mm PETG.json
+++ b/resources/profiles/Lulzbot/filament/Lulzbot 2.85mm PETG.json
@@ -1,17 +1,10 @@
 {
 	"type": "filament",
 	"name": "Lulzbot 2.85mm PETG",
-	"inherits": "Generic PETG @System",
+	"inherits": "Lulzbot 2.85mm PETG @base",
 	"from": "system",
 	"setting_id": "GFSG99",
-	"filament_id": "GFG99",
 	"instantiation": "true",
-	"filament_diameter": [
-		"2.85"
-	],
-	"filament_max_volumetric_speed": [
-		"6"
-	],
 	"compatible_printers": [
 		"Lulzbot Taz 6 0.5 nozzle",
 		"Lulzbot Taz 4 or 5 0.5 nozzle",

--- a/resources/profiles/Lulzbot/filament/Lulzbot 2.85mm PLA.json
+++ b/resources/profiles/Lulzbot/filament/Lulzbot 2.85mm PLA.json
@@ -1,17 +1,10 @@
 {
 	"type": "filament",
 	"name": "Lulzbot 2.85mm PLA",
-	"inherits": "Generic PLA @System",
+	"inherits": "Lulzbot 2.85mm PLA @base",
 	"from": "system",
 	"setting_id": "GFSL99",
-	"filament_id": "GFL99",
 	"instantiation": "true",
-	"filament_diameter": [
-		"2.85"
-	],
-	"filament_max_volumetric_speed": [
-		"8"
-	],
 	"compatible_printers": [
 		"Lulzbot Taz 6 0.5 nozzle",
 		"Lulzbot Taz 4 or 5 0.5 nozzle",

--- a/resources/profiles/OrcaFilamentLibrary.json
+++ b/resources/profiles/OrcaFilamentLibrary.json
@@ -133,6 +133,10 @@
 			"sub_path": "filament/Generic ABS @System.json"
 		},
 		{
+			"name": "Lulzbot 2.85mm ABS @base",
+			"sub_path": "filament/Lulzbot/Lulzbot 2.85mm ABS @base.json"
+		},
+		{
 			"name": "NIT ABS @base",
 			"sub_path": "filament/NIT/NIT ABS @base.json"
 		},
@@ -389,6 +393,10 @@
 			"sub_path": "filament/Generic PETG-CF @System.json"
 		},
 		{
+			"name": "Lulzbot 2.85mm PETG @base",
+			"sub_path": "filament/Lulzbot/Lulzbot 2.85mm PETG @base.json"
+		},
+		{
 			"name": "NIT PETG @base",
 			"sub_path": "filament/NIT/NIT PETG @base.json"
 		},
@@ -579,6 +587,10 @@
 		{
 			"name": "Generic PLA-CF @System",
 			"sub_path": "filament/Generic PLA-CF @System.json"
+		},
+		{
+			"name": "Lulzbot 2.85mm PLA @base",
+			"sub_path": "filament/Lulzbot/Lulzbot 2.85mm PLA @base.json"
 		},
 		{
 			"name": "NIT PLA @base",
@@ -897,6 +909,10 @@
 			"sub_path": "filament/FDplast/FDplast ABS @System.json"
 		},
 		{
+			"name": "Lulzbot 2.85mm ABS @System",
+			"sub_path": "filament/Lulzbot/Lulzbot 2.85mm ABS @System.json"
+		},
+		{
 			"name": "NIT ABS @System",
 			"sub_path": "filament/NIT/NIT ABS @System.json"
 		},
@@ -1073,6 +1089,10 @@
 			"sub_path": "filament/Polymaker/Fiberon PETG-rCF @System.json"
 		},
 		{
+			"name": "Lulzbot 2.85mm PETG @System",
+			"sub_path": "filament/Lulzbot/Lulzbot 2.85mm PETG @System.json"
+		},
+		{
 			"name": "NIT PETG @System",
 			"sub_path": "filament/NIT/NIT PETG @System.json"
 		},
@@ -1243,6 +1263,10 @@
 		{
 			"name": "FILL3D PA @System",
 			"sub_path": "filament/FILL3D/FILL3D PA @System.json"
+		},
+		{
+			"name": "Lulzbot 2.85mm PLA @System",
+			"sub_path": "filament/Lulzbot/Lulzbot 2.85mm PLA @System.json"
 		},
 		{
 			"name": "NIT PLA @System",

--- a/resources/profiles/OrcaFilamentLibrary/filament/Lulzbot/Lulzbot 2.85mm ABS @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Lulzbot/Lulzbot 2.85mm ABS @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "Lulzbot 2.85mm ABS @System",
+	"inherits": "Lulzbot 2.85mm ABS @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Lulzbot/Lulzbot 2.85mm ABS @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Lulzbot/Lulzbot 2.85mm ABS @base.json
@@ -1,0 +1,17 @@
+{
+	"type": "filament",
+	"name": "Lulzbot 2.85mm ABS @base",
+	"inherits": "fdm_filament_abs",
+	"from": "system",
+	"filament_id": "GFB99",
+	"instantiation": "false",
+	"filament_vendor": [
+		"Lulzbot"
+	],
+	"filament_diameter": [
+		"2.85"
+	],
+	"filament_max_volumetric_speed": [
+		"6"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Lulzbot/Lulzbot 2.85mm PETG @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Lulzbot/Lulzbot 2.85mm PETG @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "Lulzbot 2.85mm PETG @System",
+	"inherits": "Lulzbot 2.85mm PETG @base",
+	"from": "system",
+	"setting_id": "GFSG99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Lulzbot/Lulzbot 2.85mm PETG @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Lulzbot/Lulzbot 2.85mm PETG @base.json
@@ -1,0 +1,17 @@
+{
+	"type": "filament",
+	"name": "Lulzbot 2.85mm PETG @base",
+	"inherits": "fdm_filament_pet",
+	"from": "system",
+	"filament_id": "GFG99",
+	"instantiation": "false",
+	"filament_vendor": [
+		"Lulzbot"
+	],
+	"filament_diameter": [
+		"2.85"
+	],
+	"filament_max_volumetric_speed": [
+		"6"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Lulzbot/Lulzbot 2.85mm PLA @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Lulzbot/Lulzbot 2.85mm PLA @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "Lulzbot 2.85mm PLA @System",
+	"inherits": "Lulzbot 2.85mm PLA @base",
+	"from": "system",
+	"setting_id": "GFSL99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Lulzbot/Lulzbot 2.85mm PLA @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Lulzbot/Lulzbot 2.85mm PLA @base.json
@@ -1,0 +1,17 @@
+{
+	"type": "filament",
+	"name": "Lulzbot 2.85mm PLA @base",
+	"inherits": "fdm_filament_pla",
+	"from": "system",
+	"filament_id": "GFL99",
+	"instantiation": "false",
+	"filament_vendor": [
+		"Lulzbot"
+	],
+	"filament_diameter": [
+		"2.85"
+	],
+	"filament_max_volumetric_speed": [
+		"8"
+	]
+}


### PR DESCRIPTION
## Summary
- Move the Lulzbot 2.85mm ABS, PETG, and PLA filament definitions into `OrcaFilamentLibrary` as `@base` + `@System` presets.
- Keep the existing Lulzbot vendor presets as compatibility shims so their printer compatibility lists stay intact.
- Register the new global Lulzbot profiles in `OrcaFilamentLibrary.json`.

Contributes to #12162.

## Validation
- `py scripts/orca_extra_profile_check.py --vendor Lulzbot --check-filaments --check-obsolete-keys` -> 0 errors, 0 warnings
- Parsed the changed JSON files successfully.
- Checked the changed profiles for missing inheritance parents -> none.
- Compared resolved old vs new Lulzbot ABS/PETG/PLA settings, excluding metadata/vendor attribution -> 0 diffs.
- `git diff --check`