### PR TITLE
fix: application crashes on wayland when swtiching to device tab for Bambu printers

### DIFF
--- a/src/OrcaSlicer.cpp
+++ b/src/OrcaSlicer.cpp
@@ -1213,12 +1213,25 @@ int CLI::run(int argc, char **argv)
 
     // XInitThreads is needed before GStreamer may use Xlib. On native
     // Wayland without DISPLAY, GStreamer uses waylandsink (no Xlib).
+    // Install a custom X11 error handler to prevent the default handler
+    // from calling exit()/abort() on non-fatal X11 errors. This is
+    // necessary on XWayland where GDK/X11 operations can produce
+    // BadWindow errors during widget realization of GStreamer sinks.
     #if __has_include(<X11/Xlib.h>)
     {
         const char* display_env = ::getenv("DISPLAY");
         if (display_env && *display_env) {
             XInitThreads();
         }
+        XSetErrorHandler([](Display* dpy, XErrorEvent* evt) -> int {
+            char buffer[256];
+            XGetErrorText(dpy, evt->error_code, buffer, sizeof(buffer));
+            BOOST_LOG_TRIVIAL(error) << boost::format(
+                "X11 error: %1% (code=%2%, request=%3%, resource=0x%|4$08x|)")
+                % buffer % static_cast<int>(evt->error_code)
+                % static_cast<int>(evt->request_code) % evt->resourceid;
+            return 0;
+        });
     }
     #endif
 #endif


### PR DESCRIPTION
This PR fixes a crash that occurs on Wayland systems when opening the Device tab after connecting to a Bambu printer, such as the P1S.

## Steps to reproduce
Run the application on a Wayland-based desktop environment.
Connect to a Bambu P1S printer.
Switch to the Device tab.
The application crashes.

## Expected behavior
The Device tab should open normally without crashing on Wayland.

## Actual behavior
The application crashes when switching to the Device tab on Wayland devices.

There is still a remaining issue where the camera feed shows a blank screen that might be related to the issue above.