### PR TITLE
Migrate DeltaMaker filaments to OrcaFilamentLibrary

### DIFF
--- a/resources/profiles/DeltaMaker/filament/DeltaMaker Brand PLA.json
+++ b/resources/profiles/DeltaMaker/filament/DeltaMaker Brand PLA.json
@@ -1,35 +1,10 @@
 {
 	"type": "filament",
 	"name": "DeltaMaker Brand PLA",
-	"inherits": "fdm_filament_pla",
+	"inherits": "DeltaMaker Brand PLA @base",
 	"from": "system",
 	"setting_id": "GFSL99",
-	"filament_id": "GFL99",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"0.987"
-	],
-	"filament_max_volumetric_speed": [
-		"12"
-	],
-	"slow_down_layer_time": [
-		"8"
-	],
-	"filament_vendor": [
-		"DeltaMaker"
-	],
-	"nozzle_temperature_range_low": [
-		"210"
-	],
-	"nozzle_temperature_range_high": [
-		"235"
-	],
-	"nozzle_temperature": [
-		"230"
-	],
-	"nozzle_temperature_initial_layer": [
-		"235"
-	],
 	"compatible_printers": [
 		"DeltaMaker 2 0.35 nozzle",
 		"DeltaMaker 2T 0.5 nozzle",

--- a/resources/profiles/DeltaMaker/filament/DeltaMaker Generic PETG.json
+++ b/resources/profiles/DeltaMaker/filament/DeltaMaker Generic PETG.json
@@ -1,44 +1,10 @@
 {
 	"type": "filament",
 	"name": "DeltaMaker Generic PETG",
-	"inherits": "fdm_filament_pet",
+	"inherits": "DeltaMaker Generic PETG @base",
 	"from": "system",
 	"setting_id": "GFSG99",
-	"filament_id": "GFG99",
 	"instantiation": "true",
-	"reduce_fan_stop_start_freq": [
-		"1"
-	],
-	"slow_down_for_layer_cooling": [
-		"1"
-	],
-	"fan_cooling_layer_time": [
-		"30"
-	],
-	"overhang_fan_speed": [
-		"90"
-	],
-	"fan_max_speed": [
-		"40"
-	],
-	"fan_min_speed": [
-		"20"
-	],
-	"slow_down_min_speed": [
-		"10"
-	],
-	"slow_down_layer_time": [
-		"8"
-	],
-	"filament_flow_ratio": [
-		"0.95"
-	],
-	"filament_max_volumetric_speed": [
-		"2"
-	],
-	"filament_start_gcode": [
-		"; filament start gcode\n"
-	],
 	"compatible_printers": [
 		"DeltaMaker 2 0.35 nozzle",
 		"DeltaMaker 2T 0.5 nozzle",

--- a/resources/profiles/DeltaMaker/filament/DeltaMaker Generic PLA.json
+++ b/resources/profiles/DeltaMaker/filament/DeltaMaker Generic PLA.json
@@ -1,20 +1,10 @@
 {
 	"type": "filament",
 	"name": "DeltaMaker Generic PLA",
-	"inherits": "fdm_filament_pla",
+	"inherits": "DeltaMaker Generic PLA @base",
 	"from": "system",
 	"setting_id": "GFSA04",
-	"filament_id": "GFL99",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"0.987"
-	],
-	"filament_max_volumetric_speed": [
-		"10"
-	],
-	"slow_down_layer_time": [
-		"8"
-	],
 	"compatible_printers": [
 		"DeltaMaker 2 0.35 nozzle",
 		"DeltaMaker 2T 0.5 nozzle",

--- a/resources/profiles/DeltaMaker/filament/DeltaMaker Generic TPU.json
+++ b/resources/profiles/DeltaMaker/filament/DeltaMaker Generic TPU.json
@@ -1,17 +1,10 @@
 {
 	"type": "filament",
 	"name": "DeltaMaker Generic TPU",
-	"inherits": "fdm_filament_tpu",
+	"inherits": "DeltaMaker Generic TPU @base",
 	"from": "system",
 	"setting_id": "GFSA04",
-	"filament_id": "GFB99",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"0.94"
-	],
-	"filament_max_volumetric_speed": [
-		"4.5"
-	],
 	"compatible_printers": [
 		"DeltaMaker 2 0.35 nozzle",
 		"DeltaMaker 2T 0.5 nozzle",

--- a/resources/profiles/OrcaFilamentLibrary.json
+++ b/resources/profiles/OrcaFilamentLibrary.json
@@ -1507,6 +1507,38 @@
 		{
 			"name": "GreenGate3D PETG @System",
 			"sub_path": "filament/GreenGate3D/GreenGate3D PETG @System.json"
+		},
+		{
+			"name": "DeltaMaker Brand PLA @base",
+			"sub_path": "filament/DeltaMaker/DeltaMaker Brand PLA @base.json"
+		},
+		{
+			"name": "DeltaMaker Brand PLA @System",
+			"sub_path": "filament/DeltaMaker/DeltaMaker Brand PLA @System.json"
+		},
+		{
+			"name": "DeltaMaker Generic PLA @base",
+			"sub_path": "filament/DeltaMaker/DeltaMaker Generic PLA @base.json"
+		},
+		{
+			"name": "DeltaMaker Generic PLA @System",
+			"sub_path": "filament/DeltaMaker/DeltaMaker Generic PLA @System.json"
+		},
+		{
+			"name": "DeltaMaker Generic PETG @base",
+			"sub_path": "filament/DeltaMaker/DeltaMaker Generic PETG @base.json"
+		},
+		{
+			"name": "DeltaMaker Generic PETG @System",
+			"sub_path": "filament/DeltaMaker/DeltaMaker Generic PETG @System.json"
+		},
+		{
+			"name": "DeltaMaker Generic TPU @base",
+			"sub_path": "filament/DeltaMaker/DeltaMaker Generic TPU @base.json"
+		},
+		{
+			"name": "DeltaMaker Generic TPU @System",
+			"sub_path": "filament/DeltaMaker/DeltaMaker Generic TPU @System.json"
 		}
 	],
 	"process_list": [],

--- a/resources/profiles/OrcaFilamentLibrary/filament/DeltaMaker/DeltaMaker Brand PLA @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/DeltaMaker/DeltaMaker Brand PLA @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "DeltaMaker Brand PLA @System",
+	"inherits": "DeltaMaker Brand PLA @base",
+	"from": "system",
+	"setting_id": "GFSL99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/DeltaMaker/DeltaMaker Brand PLA @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/DeltaMaker/DeltaMaker Brand PLA @base.json
@@ -1,0 +1,150 @@
+{
+	"type": "filament",
+	"name": "DeltaMaker Brand PLA @base",
+	"inherits": "fdm_filament_pla",
+	"from": "system",
+	"cool_plate_temp": [
+		"0"
+	],
+	"eng_plate_temp": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"0"
+	],
+	"textured_plate_temp": [
+		"0"
+	],
+	"cool_plate_temp_initial_layer": [
+		"0"
+	],
+	"eng_plate_temp_initial_layer": [
+		"0"
+	],
+	"hot_plate_temp_initial_layer": [
+		"0"
+	],
+	"textured_plate_temp_initial_layer": [
+		"0"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.987"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": "100",
+	"filament_cost": [
+		"29"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"150"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"12"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retraction_minimum_travel": [
+		"3.0"
+	],
+	"filament_retract_before_wipe": [
+		"1"
+	],
+	"filament_retract_when_changing_layer": [
+		"0"
+	],
+	"filament_retraction_length": [
+		"8.0"
+	],
+	"filament_z_hop": [
+		"0.8"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"0.0"
+	],
+	"filament_retraction_speed": [
+		"150"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PLA"
+	],
+	"filament_vendor": [
+		"DeltaMaker"
+	],
+	"filament_wipe": [
+		"1"
+	],
+	"filament_wipe_distance": [
+		"8.0"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"8"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"nozzle_temperature_initial_layer": [
+		"235"
+	],
+	"nozzle_temperature": [
+		"230"
+	],
+	"nozzle_temperature_range_low": [
+		"210"
+	],
+	"nozzle_temperature_range_high": [
+		"235"
+	],
+	"filament_id": "GFL99",
+	"instantiation": "false"
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/DeltaMaker/DeltaMaker Generic PETG @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/DeltaMaker/DeltaMaker Generic PETG @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "DeltaMaker Generic PETG @System",
+	"inherits": "DeltaMaker Generic PETG @base",
+	"from": "system",
+	"setting_id": "GFSG99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/DeltaMaker/DeltaMaker Generic PETG @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/DeltaMaker/DeltaMaker Generic PETG @base.json
@@ -1,0 +1,152 @@
+{
+	"type": "filament",
+	"name": "DeltaMaker Generic PETG @base",
+	"inherits": "fdm_filament_pet",
+	"from": "system",
+	"cool_plate_temp": [
+		"0"
+	],
+	"eng_plate_temp": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"0"
+	],
+	"textured_plate_temp": [
+		"0"
+	],
+	"cool_plate_temp_initial_layer": [
+		"0"
+	],
+	"eng_plate_temp_initial_layer": [
+		"0"
+	],
+	"hot_plate_temp_initial_layer": [
+		"0"
+	],
+	"textured_plate_temp_initial_layer": [
+		"0"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"overhang_fan_speed": [
+		"90"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.95"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"filament_cost": [
+		"30"
+	],
+	"filament_density": [
+		"1.27"
+	],
+	"filament_deretraction_speed": [
+		"150"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"2"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retraction_minimum_travel": [
+		"3.0"
+	],
+	"filament_retract_before_wipe": [
+		"1"
+	],
+	"filament_retract_when_changing_layer": [
+		"0"
+	],
+	"filament_retraction_length": [
+		"8.0"
+	],
+	"filament_z_hop": [
+		"0.8"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"0.0"
+	],
+	"filament_retraction_speed": [
+		"150"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PETG"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"1"
+	],
+	"filament_wipe_distance": [
+		"8.0"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"40"
+	],
+	"fan_min_speed": [
+		"20"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"8"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n"
+	],
+	"temperature_vitrification": [
+		"80"
+	],
+	"nozzle_temperature_initial_layer": [
+		"240"
+	],
+	"nozzle_temperature": [
+		"250"
+	],
+	"nozzle_temperature_range_low": [
+		"235"
+	],
+	"nozzle_temperature_range_high": [
+		"255"
+	],
+	"filament_id": "GFG99",
+	"instantiation": "false"
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/DeltaMaker/DeltaMaker Generic PLA @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/DeltaMaker/DeltaMaker Generic PLA @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "DeltaMaker Generic PLA @System",
+	"inherits": "DeltaMaker Generic PLA @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/DeltaMaker/DeltaMaker Generic PLA @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/DeltaMaker/DeltaMaker Generic PLA @base.json
@@ -1,0 +1,150 @@
+{
+	"type": "filament",
+	"name": "DeltaMaker Generic PLA @base",
+	"inherits": "fdm_filament_pla",
+	"from": "system",
+	"cool_plate_temp": [
+		"0"
+	],
+	"eng_plate_temp": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"0"
+	],
+	"textured_plate_temp": [
+		"0"
+	],
+	"cool_plate_temp_initial_layer": [
+		"0"
+	],
+	"eng_plate_temp_initial_layer": [
+		"0"
+	],
+	"hot_plate_temp_initial_layer": [
+		"0"
+	],
+	"textured_plate_temp_initial_layer": [
+		"0"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.987"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": "100",
+	"filament_cost": [
+		"29"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"150"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"10"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retraction_minimum_travel": [
+		"3.0"
+	],
+	"filament_retract_before_wipe": [
+		"1"
+	],
+	"filament_retract_when_changing_layer": [
+		"0"
+	],
+	"filament_retraction_length": [
+		"8.0"
+	],
+	"filament_z_hop": [
+		"0.8"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"0.0"
+	],
+	"filament_retraction_speed": [
+		"150"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PLA"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"1"
+	],
+	"filament_wipe_distance": [
+		"8.0"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"8"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"nozzle_temperature_initial_layer": [
+		"205"
+	],
+	"nozzle_temperature": [
+		"210"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"210"
+	],
+	"filament_id": "GFL99",
+	"instantiation": "false"
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/DeltaMaker/DeltaMaker Generic TPU @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/DeltaMaker/DeltaMaker Generic TPU @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "DeltaMaker Generic TPU @System",
+	"inherits": "DeltaMaker Generic TPU @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/DeltaMaker/DeltaMaker Generic TPU @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/DeltaMaker/DeltaMaker Generic TPU @base.json
@@ -1,0 +1,152 @@
+{
+	"type": "filament",
+	"name": "DeltaMaker Generic TPU @base",
+	"inherits": "fdm_filament_tpu",
+	"from": "system",
+	"cool_plate_temp": [
+		"0"
+	],
+	"eng_plate_temp": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"0"
+	],
+	"textured_plate_temp": [
+		"0"
+	],
+	"cool_plate_temp_initial_layer": [
+		"0"
+	],
+	"eng_plate_temp_initial_layer": [
+		"0"
+	],
+	"hot_plate_temp_initial_layer": [
+		"0"
+	],
+	"textured_plate_temp_initial_layer": [
+		"0"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"overhang_fan_speed": [
+		"80"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.94"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.10"
+	],
+	"filament_deretraction_speed": [
+		"150"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"4.5"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retraction_minimum_travel": [
+		"3.0"
+	],
+	"filament_retract_before_wipe": [
+		"1"
+	],
+	"filament_retract_when_changing_layer": [
+		"0"
+	],
+	"filament_retraction_length": [
+		"8.0"
+	],
+	"filament_z_hop": [
+		"0.8"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"0.0"
+	],
+	"filament_retraction_speed": [
+		"150"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"TPU"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"1"
+	],
+	"filament_wipe_distance": [
+		"8.0"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"5"
+	],
+	"fan_min_speed": [
+		"5"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"15"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n"
+	],
+	"temperature_vitrification": [
+		"110"
+	],
+	"nozzle_temperature_initial_layer": [
+		"240"
+	],
+	"nozzle_temperature": [
+		"235"
+	],
+	"nozzle_temperature_range_low": [
+		"235"
+	],
+	"nozzle_temperature_range_high": [
+		"240"
+	],
+	"filament_id": "GFB99",
+	"instantiation": "false"
+}


### PR DESCRIPTION
## Summary

Migrates the DeltaMaker filament presets toward OrcaFilamentLibrary following the per-vendor pattern discussed in #12162.

## Changes

- Adds DeltaMaker Brand PLA, Generic PLA, Generic PETG, and Generic TPU portable `@System`/`@base` profiles under `OrcaFilamentLibrary`.
- Keeps DeltaMaker printer-scoped profiles in the DeltaMaker vendor folder, inheriting from the new library bases so existing printer compatibility remains constrained.
- Registers the new DeltaMaker OrcaFilamentLibrary profiles in `OrcaFilamentLibrary.json`.

## Verification

- `python3 scripts/orca_extra_profile_check.py --vendor DeltaMaker --check-filaments --check-materials --check-obsolete-keys`
- `git diff --check`

Related to OrcaSlicer/OrcaSlicer#12162.