### PR TITLE
Migrate LONGER filaments to OrcaFilamentLibrary

### DIFF
--- a/resources/profiles/LONGER/filament/Generic PETG @LONGER LK10 Plus.json
+++ b/resources/profiles/LONGER/filament/Generic PETG @LONGER LK10 Plus.json
@@ -1,50 +1,11 @@
 {
 	"type": "filament",
 	"name": "Generic PETG @LONGER LK10 Plus",
-	"inherits": "fdm_filament_pet",
+	"inherits": "Generic PETG @LONGER LK10 Plus @base",
 	"from": "system",
 	"setting_id": "GFLLKPG",
 	"filament_id": "GFLLK10PPETG",
 	"instantiation": "true",
-	"reduce_fan_stop_start_freq": [
-		"1"
-	],
-	"slow_down_for_layer_cooling": [
-		"1"
-	],
-	"fan_cooling_layer_time": [
-		"30"
-	],
-	"overhang_fan_speed": [
-		"90"
-	],
-	"overhang_fan_threshold": [
-		"25%"
-	],
-	"nozzle_temperature_initial_layer": [
-		"240"
-	],
-	"fan_max_speed": [
-		"50"
-	],
-	"fan_min_speed": [
-		"20"
-	],
-	"slow_down_min_speed": [
-		"10"
-	],
-	"slow_down_layer_time": [
-		"8"
-	],
-	"filament_flow_ratio": [
-		"0.95"
-	],
-	"filament_max_volumetric_speed": [
-		"10"
-	],
-	"filament_start_gcode": [
-		"; filament start gcode\n"
-	],
 	"compatible_printers": [
 		"LONGER LK10 Plus (0.2 nozzle)",
 		"LONGER LK10 Plus (0.4 nozzle)",

--- a/resources/profiles/LONGER/filament/Generic PETG @LONGER LK10.json
+++ b/resources/profiles/LONGER/filament/Generic PETG @LONGER LK10.json
@@ -1,50 +1,11 @@
 {
 	"type": "filament",
 	"name": "Generic PETG @LONGER LK10",
-	"inherits": "fdm_filament_pet",
+	"inherits": "Generic PETG @LONGER LK10 @base",
 	"from": "system",
 	"setting_id": "GFLLK10G",
 	"filament_id": "GFLLK10PETG",
 	"instantiation": "true",
-	"reduce_fan_stop_start_freq": [
-		"1"
-	],
-	"slow_down_for_layer_cooling": [
-		"1"
-	],
-	"fan_cooling_layer_time": [
-		"30"
-	],
-	"overhang_fan_speed": [
-		"90"
-	],
-	"overhang_fan_threshold": [
-		"25%"
-	],
-	"nozzle_temperature_initial_layer": [
-		"240"
-	],
-	"fan_max_speed": [
-		"50"
-	],
-	"fan_min_speed": [
-		"20"
-	],
-	"slow_down_min_speed": [
-		"10"
-	],
-	"slow_down_layer_time": [
-		"8"
-	],
-	"filament_flow_ratio": [
-		"0.95"
-	],
-	"filament_max_volumetric_speed": [
-		"10"
-	],
-	"filament_start_gcode": [
-		"; filament start gcode\n"
-	],
 	"compatible_printers": [
 		"LONGER LK10 (0.2 nozzle)",
 		"LONGER LK10 (0.4 nozzle)",

--- a/resources/profiles/LONGER/filament/Generic PLA @LONGER LK10 Plus.json
+++ b/resources/profiles/LONGER/filament/Generic PLA @LONGER LK10 Plus.json
@@ -1,23 +1,11 @@
 {
 	"type": "filament",
 	"name": "Generic PLA @LONGER LK10 Plus",
-	"inherits": "fdm_filament_pla",
+	"inherits": "Generic PLA @LONGER LK10 Plus @base",
 	"from": "system",
 	"setting_id": "GFLLKPPL",
 	"filament_id": "GFLLK10PPLA",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"0.98"
-	],
-	"filament_max_volumetric_speed": [
-		"15"
-	],
-	"nozzle_temperature_initial_layer": [
-		"210"
-	],
-	"slow_down_layer_time": [
-		"8"
-	],
 	"compatible_printers": [
 		"LONGER LK10 Plus (0.2 nozzle)",
 		"LONGER LK10 Plus (0.4 nozzle)",

--- a/resources/profiles/LONGER/filament/Generic PLA @LONGER LK10.json
+++ b/resources/profiles/LONGER/filament/Generic PLA @LONGER LK10.json
@@ -1,23 +1,11 @@
 {
 	"type": "filament",
 	"name": "Generic PLA @LONGER LK10",
-	"inherits": "fdm_filament_pla",
+	"inherits": "Generic PLA @LONGER LK10 @base",
 	"from": "system",
 	"setting_id": "GFLLK10P",
 	"filament_id": "GFLLK10PLA",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"0.98"
-	],
-	"filament_max_volumetric_speed": [
-		"15"
-	],
-	"nozzle_temperature_initial_layer": [
-		"210"
-	],
-	"slow_down_layer_time": [
-		"8"
-	],
 	"compatible_printers": [
 		"LONGER LK10 (0.2 nozzle)",
 		"LONGER LK10 (0.4 nozzle)",

--- a/resources/profiles/OrcaFilamentLibrary.json
+++ b/resources/profiles/OrcaFilamentLibrary.json
@@ -1507,6 +1507,38 @@
 		{
 			"name": "GreenGate3D PETG @System",
 			"sub_path": "filament/GreenGate3D/GreenGate3D PETG @System.json"
+		},
+		{
+			"name": "Generic PETG @LONGER LK10 @base",
+			"sub_path": "filament/LONGER/Generic PETG @LONGER LK10 @base.json"
+		},
+		{
+			"name": "Generic PETG @LONGER LK10 @System",
+			"sub_path": "filament/LONGER/Generic PETG @LONGER LK10 @System.json"
+		},
+		{
+			"name": "Generic PETG @LONGER LK10 Plus @base",
+			"sub_path": "filament/LONGER/Generic PETG @LONGER LK10 Plus @base.json"
+		},
+		{
+			"name": "Generic PETG @LONGER LK10 Plus @System",
+			"sub_path": "filament/LONGER/Generic PETG @LONGER LK10 Plus @System.json"
+		},
+		{
+			"name": "Generic PLA @LONGER LK10 @base",
+			"sub_path": "filament/LONGER/Generic PLA @LONGER LK10 @base.json"
+		},
+		{
+			"name": "Generic PLA @LONGER LK10 @System",
+			"sub_path": "filament/LONGER/Generic PLA @LONGER LK10 @System.json"
+		},
+		{
+			"name": "Generic PLA @LONGER LK10 Plus @base",
+			"sub_path": "filament/LONGER/Generic PLA @LONGER LK10 Plus @base.json"
+		},
+		{
+			"name": "Generic PLA @LONGER LK10 Plus @System",
+			"sub_path": "filament/LONGER/Generic PLA @LONGER LK10 Plus @System.json"
 		}
 	],
 	"process_list": [],

--- a/resources/profiles/OrcaFilamentLibrary/filament/LONGER/Generic PETG @LONGER LK10 @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/LONGER/Generic PETG @LONGER LK10 @System.json
@@ -4,7 +4,7 @@
 	"inherits": "Generic PETG @LONGER LK10 @base",
 	"from": "system",
 	"setting_id": "GFLLK10G",
-	"filament_id": "GFLLK10PETG",
+	"filament_id": "GFLLK10G",
 	"instantiation": "true",
 	"compatible_printers": []
 }

--- a/resources/profiles/OrcaFilamentLibrary/filament/LONGER/Generic PETG @LONGER LK10 @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/LONGER/Generic PETG @LONGER LK10 @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Generic PETG @LONGER LK10 @System",
+	"inherits": "Generic PETG @LONGER LK10 @base",
+	"from": "system",
+	"setting_id": "GFLLK10G",
+	"filament_id": "GFLLK10PETG",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/LONGER/Generic PETG @LONGER LK10 @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/LONGER/Generic PETG @LONGER LK10 @base.json
@@ -3,6 +3,8 @@
 	"name": "Generic PETG @LONGER LK10 @base",
 	"inherits": "fdm_filament_pet",
 	"from": "system",
+	"filament_id": "GFLLK10G",
+	"instantiation": "false",
 	"cool_plate_temp": [
 		"60"
 	],

--- a/resources/profiles/OrcaFilamentLibrary/filament/LONGER/Generic PETG @LONGER LK10 @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/LONGER/Generic PETG @LONGER LK10 @base.json
@@ -1,0 +1,150 @@
+{
+	"type": "filament",
+	"name": "Generic PETG @LONGER LK10 @base",
+	"inherits": "fdm_filament_pet",
+	"from": "system",
+	"cool_plate_temp": [
+		"60"
+	],
+	"eng_plate_temp": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"80"
+	],
+	"textured_plate_temp": [
+		"80"
+	],
+	"cool_plate_temp_initial_layer": [
+		"60"
+	],
+	"eng_plate_temp_initial_layer": [
+		"0"
+	],
+	"hot_plate_temp_initial_layer": [
+		"80"
+	],
+	"textured_plate_temp_initial_layer": [
+		"80"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"overhang_fan_speed": [
+		"90"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.95"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"filament_cost": [
+		"0"
+	],
+	"filament_density": [
+		"1.27"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"10"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PETG"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"240"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"50"
+	],
+	"fan_min_speed": [
+		"20"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"8"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n"
+	],
+	"nozzle_temperature": [
+		"250"
+	],
+	"temperature_vitrification": [
+		"70"
+	],
+	"nozzle_temperature_range_high": [
+		"260"
+	],
+	"nozzle_temperature_range_low": [
+		"220"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/LONGER/Generic PETG @LONGER LK10 Plus @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/LONGER/Generic PETG @LONGER LK10 Plus @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Generic PETG @LONGER LK10 Plus @System",
+	"inherits": "Generic PETG @LONGER LK10 Plus @base",
+	"from": "system",
+	"setting_id": "GFLLKPG",
+	"filament_id": "GFLLK10PPETG",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/LONGER/Generic PETG @LONGER LK10 Plus @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/LONGER/Generic PETG @LONGER LK10 Plus @System.json
@@ -4,7 +4,7 @@
 	"inherits": "Generic PETG @LONGER LK10 Plus @base",
 	"from": "system",
 	"setting_id": "GFLLKPG",
-	"filament_id": "GFLLK10PPETG",
+	"filament_id": "GFLLKPG",
 	"instantiation": "true",
 	"compatible_printers": []
 }

--- a/resources/profiles/OrcaFilamentLibrary/filament/LONGER/Generic PETG @LONGER LK10 Plus @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/LONGER/Generic PETG @LONGER LK10 Plus @base.json
@@ -1,0 +1,150 @@
+{
+	"type": "filament",
+	"name": "Generic PETG @LONGER LK10 Plus @base",
+	"inherits": "fdm_filament_pet",
+	"from": "system",
+	"cool_plate_temp": [
+		"60"
+	],
+	"eng_plate_temp": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"80"
+	],
+	"textured_plate_temp": [
+		"80"
+	],
+	"cool_plate_temp_initial_layer": [
+		"60"
+	],
+	"eng_plate_temp_initial_layer": [
+		"0"
+	],
+	"hot_plate_temp_initial_layer": [
+		"80"
+	],
+	"textured_plate_temp_initial_layer": [
+		"80"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"overhang_fan_speed": [
+		"90"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.95"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"filament_cost": [
+		"0"
+	],
+	"filament_density": [
+		"1.27"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"10"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PETG"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"240"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"50"
+	],
+	"fan_min_speed": [
+		"20"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"8"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n"
+	],
+	"nozzle_temperature": [
+		"250"
+	],
+	"temperature_vitrification": [
+		"70"
+	],
+	"nozzle_temperature_range_high": [
+		"260"
+	],
+	"nozzle_temperature_range_low": [
+		"220"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/LONGER/Generic PETG @LONGER LK10 Plus @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/LONGER/Generic PETG @LONGER LK10 Plus @base.json
@@ -3,6 +3,8 @@
 	"name": "Generic PETG @LONGER LK10 Plus @base",
 	"inherits": "fdm_filament_pet",
 	"from": "system",
+	"filament_id": "GFLLKPG",
+	"instantiation": "false",
 	"cool_plate_temp": [
 		"60"
 	],

--- a/resources/profiles/OrcaFilamentLibrary/filament/LONGER/Generic PLA @LONGER LK10 @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/LONGER/Generic PLA @LONGER LK10 @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Generic PLA @LONGER LK10 @System",
+	"inherits": "Generic PLA @LONGER LK10 @base",
+	"from": "system",
+	"setting_id": "GFLLK10P",
+	"filament_id": "GFLLK10PLA",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/LONGER/Generic PLA @LONGER LK10 @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/LONGER/Generic PLA @LONGER LK10 @System.json
@@ -4,7 +4,7 @@
 	"inherits": "Generic PLA @LONGER LK10 @base",
 	"from": "system",
 	"setting_id": "GFLLK10P",
-	"filament_id": "GFLLK10PLA",
+	"filament_id": "GFLLK10P",
 	"instantiation": "true",
 	"compatible_printers": []
 }

--- a/resources/profiles/OrcaFilamentLibrary/filament/LONGER/Generic PLA @LONGER LK10 @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/LONGER/Generic PLA @LONGER LK10 @base.json
@@ -1,0 +1,153 @@
+{
+	"type": "filament",
+	"name": "Generic PLA @LONGER LK10 @base",
+	"inherits": "fdm_filament_pla",
+	"from": "system",
+	"cool_plate_temp": [
+		"60"
+	],
+	"eng_plate_temp": [
+		"60"
+	],
+	"hot_plate_temp": [
+		"60"
+	],
+	"textured_plate_temp": [
+		"60"
+	],
+	"cool_plate_temp_initial_layer": [
+		"60"
+	],
+	"eng_plate_temp_initial_layer": [
+		"60"
+	],
+	"hot_plate_temp_initial_layer": [
+		"60"
+	],
+	"textured_plate_temp_initial_layer": [
+		"60"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"15"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PLA"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"210"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"8"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n"
+	],
+	"nozzle_temperature": [
+		"205"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"nozzle_temperature_range_low": [
+		"205"
+	],
+	"nozzle_temperature_range_high": [
+		"210"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/LONGER/Generic PLA @LONGER LK10 @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/LONGER/Generic PLA @LONGER LK10 @base.json
@@ -3,6 +3,8 @@
 	"name": "Generic PLA @LONGER LK10 @base",
 	"inherits": "fdm_filament_pla",
 	"from": "system",
+	"filament_id": "GFLLK10P",
+	"instantiation": "false",
 	"cool_plate_temp": [
 		"60"
 	],

--- a/resources/profiles/OrcaFilamentLibrary/filament/LONGER/Generic PLA @LONGER LK10 Plus @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/LONGER/Generic PLA @LONGER LK10 Plus @System.json
@@ -4,7 +4,7 @@
 	"inherits": "Generic PLA @LONGER LK10 Plus @base",
 	"from": "system",
 	"setting_id": "GFLLKPPL",
-	"filament_id": "GFLLK10PPLA",
+	"filament_id": "GFLLKPPL",
 	"instantiation": "true",
 	"compatible_printers": []
 }

--- a/resources/profiles/OrcaFilamentLibrary/filament/LONGER/Generic PLA @LONGER LK10 Plus @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/LONGER/Generic PLA @LONGER LK10 Plus @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Generic PLA @LONGER LK10 Plus @System",
+	"inherits": "Generic PLA @LONGER LK10 Plus @base",
+	"from": "system",
+	"setting_id": "GFLLKPPL",
+	"filament_id": "GFLLK10PPLA",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/LONGER/Generic PLA @LONGER LK10 Plus @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/LONGER/Generic PLA @LONGER LK10 Plus @base.json
@@ -1,0 +1,153 @@
+{
+	"type": "filament",
+	"name": "Generic PLA @LONGER LK10 Plus @base",
+	"inherits": "fdm_filament_pla",
+	"from": "system",
+	"cool_plate_temp": [
+		"60"
+	],
+	"eng_plate_temp": [
+		"60"
+	],
+	"hot_plate_temp": [
+		"60"
+	],
+	"textured_plate_temp": [
+		"60"
+	],
+	"cool_plate_temp_initial_layer": [
+		"60"
+	],
+	"eng_plate_temp_initial_layer": [
+		"60"
+	],
+	"hot_plate_temp_initial_layer": [
+		"60"
+	],
+	"textured_plate_temp_initial_layer": [
+		"60"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"15"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PLA"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"210"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"8"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n"
+	],
+	"nozzle_temperature": [
+		"205"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"nozzle_temperature_range_low": [
+		"205"
+	],
+	"nozzle_temperature_range_high": [
+		"210"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/LONGER/Generic PLA @LONGER LK10 Plus @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/LONGER/Generic PLA @LONGER LK10 Plus @base.json
@@ -3,6 +3,8 @@
 	"name": "Generic PLA @LONGER LK10 Plus @base",
 	"inherits": "fdm_filament_pla",
 	"from": "system",
+	"filament_id": "GFLLKPPL",
+	"instantiation": "false",
 	"cool_plate_temp": [
 		"60"
 	],


### PR DESCRIPTION
## Summary

Migrates LONGER LK10/LK10 Plus PLA and PETG filament profiles into `OrcaFilamentLibrary` while keeping the vendor-scoped profiles compatible with their original LONGER printers.

## Changes

- Added LONGER PLA/PETG `@base` and `@System` profiles under `resources/profiles/OrcaFilamentLibrary/filament/LONGER`.
- Flattened the existing LONGER vendor base settings into the new library bases so current filament behavior is preserved.
- Updated the printer-scoped LONGER filament profiles to inherit from the new library bases.
- Registered the new LONGER library profiles in `OrcaFilamentLibrary.json`.

## Testing

- `python3 scripts/orca_extra_profile_check.py --vendor LONGER --check-filaments --check-materials --check-obsolete-keys`
- `git diff --check`

Fixes OrcaSlicer/OrcaSlicer#12162