### PR TITLE
Migrate Co Print filaments to OrcaFilamentLibrary

### DIFF
--- a/resources/profiles/Co Print/filament/CoPrint Generic ABS.json
+++ b/resources/profiles/Co Print/filament/CoPrint Generic ABS.json
@@ -1,71 +1,11 @@
 {
 	"type": "filament",
 	"name": "CoPrint Generic ABS",
-	"inherits": "CoPrint Generic PLA",
+	"inherits": "CoPrint Generic ABS @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFL99",
 	"instantiation": "true",
-	"close_fan_the_first_x_layers": [
-		"3"
-	],
-	"fan_cooling_layer_time": [
-		"30"
-	],
-	"fan_max_speed": [
-		"60"
-	],
-	"fan_min_speed": [
-		"10"
-	],
-	"filament_density": [
-		"1.04"
-	],
-	"filament_flow_ratio": [
-		"0.94"
-	],
-	"filament_max_volumetric_speed": [
-		"16"
-	],
-	"filament_type": [
-		"ABS"
-	],
-	"full_fan_speed_layer": [
-		"5"
-	],
-	"hot_plate_temp": [
-		"100"
-	],
-	"hot_plate_temp_initial_layer": [
-		"100"
-	],
-	"nozzle_temperature": [
-		"280"
-	],
-	"nozzle_temperature_initial_layer": [
-		"260"
-	],
-	"nozzle_temperature_range_high": [
-		"280"
-	],
-	"nozzle_temperature_range_low": [
-		"240"
-	],
-	"overhang_fan_threshold": [
-		"25%"
-	],
-	"pressure_advance": [
-		"0.02"
-	],
-	"slow_down_layer_time": [
-		"12"
-	],
-	"slow_down_min_speed": [
-		"20"
-	],
-	"temperature_vitrification": [
-		"100"
-	],
 	"compatible_printers": [
 		"Co Print ChromaSet 0.4 nozzle",
 		"Co Print ChromaSet 0.4 nozzle - Ender-3 V3",

--- a/resources/profiles/Co Print/filament/CoPrint Generic PETG.json
+++ b/resources/profiles/Co Print/filament/CoPrint Generic PETG.json
@@ -1,41 +1,11 @@
 {
 	"type": "filament",
 	"name": "CoPrint Generic PETG",
-	"inherits": "CoPrint Generic PLA",
+	"inherits": "CoPrint Generic PETG @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFL99",
 	"instantiation": "true",
-	"fan_max_speed": [
-		"90"
-	],
-	"fan_min_speed": [
-		"60"
-	],
-	"filament_deretraction_speed": [
-		"50"
-	],
-	"filament_retraction_length": [
-		"1.2"
-	],
-	"filament_retraction_speed": [
-		"50"
-	],
-	"filament_type": [
-		"PETG"
-	],
-	"hot_plate_temp": [
-		"70"
-	],
-	"hot_plate_temp_initial_layer": [
-		"70"
-	],
-	"nozzle_temperature": [
-		"240"
-	],
-	"nozzle_temperature_initial_layer": [
-		"240"
-	],
 	"compatible_printers": [
 		"Co Print ChromaSet 0.4 nozzle",
 		"Co Print ChromaSet 0.4 nozzle - Ender-3 V3",

--- a/resources/profiles/Co Print/filament/CoPrint Generic PLA.json
+++ b/resources/profiles/Co Print/filament/CoPrint Generic PLA.json
@@ -1,17 +1,11 @@
 {
 	"type": "filament",
 	"name": "CoPrint Generic PLA",
-	"inherits": "fdm_filament_pla",
+	"inherits": "CoPrint Generic PLA @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFL99",
 	"instantiation": "true",
-	"filament_load_time": [
-		"9.75"
-	],
-	"filament_unload_time": [
-		"9.75"
-	],
 	"compatible_printers": [
 		"Co Print ChromaSet 0.4 nozzle",
 		"Co Print ChromaSet 0.4 nozzle - Ender-3 V3",

--- a/resources/profiles/Co Print/filament/CoPrint Generic TPU.json
+++ b/resources/profiles/Co Print/filament/CoPrint Generic TPU.json
@@ -1,47 +1,11 @@
 {
 	"type": "filament",
 	"name": "CoPrint Generic TPU",
-	"inherits": "CoPrint Generic PLA",
+	"inherits": "CoPrint Generic TPU @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFL99",
 	"instantiation": "true",
-	"fan_max_speed": [
-		"80"
-	],
-	"fan_min_speed": [
-		"80"
-	],
-	"filament_deretraction_speed": [
-		"20"
-	],
-	"filament_flow_ratio": [
-		"0.97"
-	],
-	"filament_retract_when_changing_layer": [
-		"0"
-	],
-	"filament_retraction_length": [
-		"1.8"
-	],
-	"filament_retraction_speed": [
-		"20"
-	],
-	"filament_type": [
-		"TPU"
-	],
-	"hot_plate_temp": [
-		"50"
-	],
-	"hot_plate_temp_initial_layer": [
-		"50"
-	],
-	"nozzle_temperature": [
-		"230"
-	],
-	"nozzle_temperature_initial_layer": [
-		"230"
-	],
 	"compatible_printers": [
 		"Co Print ChromaSet 0.4 nozzle",
 		"Co Print ChromaSet 0.4 nozzle - Ender-3 V3",

--- a/resources/profiles/Co Print/filament/fdm_filament_pla.json
+++ b/resources/profiles/Co Print/filament/fdm_filament_pla.json
@@ -173,12 +173,6 @@
 	"filament_unloading_speed": [
 		"90"
 	],
-	"filament_load_time": [
-		"9.75"
-	],
-	"filament_unload_time": [
-		"9.75"
-	],
 	"filament_toolchange_delay": [
 		"0"
 	],

--- a/resources/profiles/OrcaFilamentLibrary.json
+++ b/resources/profiles/OrcaFilamentLibrary.json
@@ -1507,6 +1507,38 @@
 		{
 			"name": "GreenGate3D PETG @System",
 			"sub_path": "filament/GreenGate3D/GreenGate3D PETG @System.json"
+		},
+		{
+			"name": "CoPrint Generic ABS @base",
+			"sub_path": "filament/Co Print/CoPrint Generic ABS @base.json"
+		},
+		{
+			"name": "CoPrint Generic ABS @System",
+			"sub_path": "filament/Co Print/CoPrint Generic ABS @System.json"
+		},
+		{
+			"name": "CoPrint Generic PETG @base",
+			"sub_path": "filament/Co Print/CoPrint Generic PETG @base.json"
+		},
+		{
+			"name": "CoPrint Generic PETG @System",
+			"sub_path": "filament/Co Print/CoPrint Generic PETG @System.json"
+		},
+		{
+			"name": "CoPrint Generic PLA @base",
+			"sub_path": "filament/Co Print/CoPrint Generic PLA @base.json"
+		},
+		{
+			"name": "CoPrint Generic PLA @System",
+			"sub_path": "filament/Co Print/CoPrint Generic PLA @System.json"
+		},
+		{
+			"name": "CoPrint Generic TPU @base",
+			"sub_path": "filament/Co Print/CoPrint Generic TPU @base.json"
+		},
+		{
+			"name": "CoPrint Generic TPU @System",
+			"sub_path": "filament/Co Print/CoPrint Generic TPU @System.json"
 		}
 	],
 	"process_list": [],

--- a/resources/profiles/OrcaFilamentLibrary/filament/Co Print/CoPrint Generic ABS @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Co Print/CoPrint Generic ABS @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "CoPrint Generic ABS @System",
+	"inherits": "CoPrint Generic ABS @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFL99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Co Print/CoPrint Generic ABS @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Co Print/CoPrint Generic ABS @base.json
@@ -1,6 +1,8 @@
 {
 	"type": "filament",
 	"name": "CoPrint Generic ABS @base",
+	"instantiation": "false",
+	"filament_id": "GFB99",
 	"inherits": "fdm_filament_pla",
 	"from": "system",
 	"cool_plate_temp": [

--- a/resources/profiles/OrcaFilamentLibrary/filament/Co Print/CoPrint Generic ABS @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Co Print/CoPrint Generic ABS @base.json
@@ -1,0 +1,201 @@
+{
+	"type": "filament",
+	"name": "CoPrint Generic ABS @base",
+	"inherits": "fdm_filament_pla",
+	"from": "system",
+	"cool_plate_temp": [
+		"35"
+	],
+	"eng_plate_temp": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"100"
+	],
+	"textured_plate_temp": [
+		"55"
+	],
+	"cool_plate_temp_initial_layer": [
+		"35"
+	],
+	"eng_plate_temp_initial_layer": [
+		"0"
+	],
+	"hot_plate_temp_initial_layer": [
+		"100"
+	],
+	"textured_plate_temp_initial_layer": [
+		"55"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"filament_flow_ratio": [
+		"0.94"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.04"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"16"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"ABS"
+	],
+	"filament_vendor": [
+		"Co Print"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"260"
+	],
+	"full_fan_speed_layer": [
+		"5"
+	],
+	"fan_max_speed": [
+		"60"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"slow_down_layer_time": [
+		"12"
+	],
+	"nozzle_temperature": [
+		"280"
+	],
+	"temperature_vitrification": [
+		"100"
+	],
+	"activate_air_filtration": [
+		"0"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"chamber_temperatures": [
+		"0"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"100"
+	],
+	"during_print_exhaust_fan_speed": [
+		"100"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"nozzle_temperature_range_low": [
+		"240"
+	],
+	"nozzle_temperature_range_high": [
+		"280"
+	],
+	"required_nozzle_HRC": [
+		"3"
+	],
+	"filament_shrink": [
+		"100"
+	],
+	"filament_loading_speed_start": [
+		"3"
+	],
+	"filament_loading_speed": [
+		"28"
+	],
+	"filament_unloading_speed_start": [
+		"100"
+	],
+	"filament_unloading_speed": [
+		"90"
+	],
+	"filament_load_time": [
+		"9.75"
+	],
+	"filament_unload_time": [
+		"9.75"
+	],
+	"filament_toolchange_delay": [
+		"0"
+	],
+	"filament_cooling_moves": [
+		"0"
+	],
+	"filament_cooling_initial_speed": [
+		"2.2"
+	],
+	"filament_cooling_final_speed": [
+		"3.4"
+	],
+	"enable_pressure_advance": [
+		"1"
+	],
+	"pressure_advance": [
+		"0.02"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Co Print/CoPrint Generic PETG @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Co Print/CoPrint Generic PETG @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "CoPrint Generic PETG @System",
+	"inherits": "CoPrint Generic PETG @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFL99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Co Print/CoPrint Generic PETG @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Co Print/CoPrint Generic PETG @base.json
@@ -1,0 +1,201 @@
+{
+	"type": "filament",
+	"name": "CoPrint Generic PETG @base",
+	"inherits": "fdm_filament_pla",
+	"from": "system",
+	"cool_plate_temp": [
+		"35"
+	],
+	"eng_plate_temp": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"70"
+	],
+	"textured_plate_temp": [
+		"55"
+	],
+	"cool_plate_temp_initial_layer": [
+		"35"
+	],
+	"eng_plate_temp_initial_layer": [
+		"0"
+	],
+	"hot_plate_temp_initial_layer": [
+		"70"
+	],
+	"textured_plate_temp_initial_layer": [
+		"55"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"filament_flow_ratio": [
+		"0.95"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"50"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"50"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"14"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"1.2"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"50"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PETG"
+	],
+	"filament_vendor": [
+		"Co Print"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"240"
+	],
+	"full_fan_speed_layer": [
+		"3"
+	],
+	"fan_max_speed": [
+		"90"
+	],
+	"fan_min_speed": [
+		"60"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"5"
+	],
+	"nozzle_temperature": [
+		"240"
+	],
+	"temperature_vitrification": [
+		"45"
+	],
+	"activate_air_filtration": [
+		"0"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"chamber_temperatures": [
+		"0"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"100"
+	],
+	"during_print_exhaust_fan_speed": [
+		"100"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"250"
+	],
+	"required_nozzle_HRC": [
+		"3"
+	],
+	"filament_shrink": [
+		"100"
+	],
+	"filament_loading_speed_start": [
+		"3"
+	],
+	"filament_loading_speed": [
+		"28"
+	],
+	"filament_unloading_speed_start": [
+		"100"
+	],
+	"filament_unloading_speed": [
+		"90"
+	],
+	"filament_load_time": [
+		"9.75"
+	],
+	"filament_unload_time": [
+		"9.75"
+	],
+	"filament_toolchange_delay": [
+		"0"
+	],
+	"filament_cooling_moves": [
+		"0"
+	],
+	"filament_cooling_initial_speed": [
+		"2.2"
+	],
+	"filament_cooling_final_speed": [
+		"3.4"
+	],
+	"enable_pressure_advance": [
+		"1"
+	],
+	"pressure_advance": [
+		"0.05"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Co Print/CoPrint Generic PETG @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Co Print/CoPrint Generic PETG @base.json
@@ -1,6 +1,8 @@
 {
 	"type": "filament",
 	"name": "CoPrint Generic PETG @base",
+	"instantiation": "false",
+	"filament_id": "GFG99",
 	"inherits": "fdm_filament_pla",
 	"from": "system",
 	"cool_plate_temp": [

--- a/resources/profiles/OrcaFilamentLibrary/filament/Co Print/CoPrint Generic PLA @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Co Print/CoPrint Generic PLA @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "CoPrint Generic PLA @System",
+	"inherits": "CoPrint Generic PLA @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFL99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Co Print/CoPrint Generic PLA @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Co Print/CoPrint Generic PLA @base.json
@@ -1,0 +1,201 @@
+{
+	"type": "filament",
+	"name": "CoPrint Generic PLA @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"cool_plate_temp": [
+		"35"
+	],
+	"eng_plate_temp": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"60"
+	],
+	"textured_plate_temp": [
+		"55"
+	],
+	"cool_plate_temp_initial_layer": [
+		"35"
+	],
+	"eng_plate_temp_initial_layer": [
+		"0"
+	],
+	"hot_plate_temp_initial_layer": [
+		"60"
+	],
+	"textured_plate_temp_initial_layer": [
+		"55"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"filament_flow_ratio": [
+		"0.95"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"50"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"14"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PLA"
+	],
+	"filament_vendor": [
+		"Co Print"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"210"
+	],
+	"full_fan_speed_layer": [
+		"3"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"5"
+	],
+	"nozzle_temperature": [
+		"210"
+	],
+	"temperature_vitrification": [
+		"45"
+	],
+	"activate_air_filtration": [
+		"0"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"chamber_temperatures": [
+		"0"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"100"
+	],
+	"during_print_exhaust_fan_speed": [
+		"100"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"250"
+	],
+	"required_nozzle_HRC": [
+		"3"
+	],
+	"filament_shrink": [
+		"100"
+	],
+	"filament_loading_speed_start": [
+		"3"
+	],
+	"filament_loading_speed": [
+		"28"
+	],
+	"filament_unloading_speed_start": [
+		"100"
+	],
+	"filament_unloading_speed": [
+		"90"
+	],
+	"filament_load_time": [
+		"9.75"
+	],
+	"filament_unload_time": [
+		"9.75"
+	],
+	"filament_toolchange_delay": [
+		"0"
+	],
+	"filament_cooling_moves": [
+		"0"
+	],
+	"filament_cooling_initial_speed": [
+		"2.2"
+	],
+	"filament_cooling_final_speed": [
+		"3.4"
+	],
+	"enable_pressure_advance": [
+		"1"
+	],
+	"pressure_advance": [
+		"0.05"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Co Print/CoPrint Generic PLA @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Co Print/CoPrint Generic PLA @base.json
@@ -1,6 +1,8 @@
 {
 	"type": "filament",
 	"name": "CoPrint Generic PLA @base",
+	"instantiation": "false",
+	"filament_id": "GFL99",
 	"inherits": "fdm_filament_common",
 	"from": "system",
 	"cool_plate_temp": [

--- a/resources/profiles/OrcaFilamentLibrary/filament/Co Print/CoPrint Generic TPU @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Co Print/CoPrint Generic TPU @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "CoPrint Generic TPU @System",
+	"inherits": "CoPrint Generic TPU @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFL99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Co Print/CoPrint Generic TPU @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Co Print/CoPrint Generic TPU @base.json
@@ -1,0 +1,42 @@
+{
+	"type": "filament",
+	"name": "CoPrint Generic TPU @base",
+	"inherits": "CoPrint Generic PLA @base",
+	"from": "system",
+	"fan_max_speed": [
+		"80"
+	],
+	"fan_min_speed": [
+		"80"
+	],
+	"filament_deretraction_speed": [
+		"20"
+	],
+	"filament_flow_ratio": [
+		"0.97"
+	],
+	"filament_retract_when_changing_layer": [
+		"0"
+	],
+	"filament_retraction_length": [
+		"1.8"
+	],
+	"filament_retraction_speed": [
+		"20"
+	],
+	"filament_type": [
+		"TPU"
+	],
+	"hot_plate_temp": [
+		"50"
+	],
+	"hot_plate_temp_initial_layer": [
+		"50"
+	],
+	"nozzle_temperature": [
+		"230"
+	],
+	"nozzle_temperature_initial_layer": [
+		"230"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Co Print/CoPrint Generic TPU @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Co Print/CoPrint Generic TPU @base.json
@@ -1,6 +1,8 @@
 {
 	"type": "filament",
 	"name": "CoPrint Generic TPU @base",
+	"instantiation": "false",
+	"filament_id": "GFU99",
 	"inherits": "CoPrint Generic PLA @base",
 	"from": "system",
 	"fan_max_speed": [


### PR DESCRIPTION
## Summary

Migrates the Co Print filament presets into `OrcaFilamentLibrary` as a focused slice of issue #12162.

## Changes

- Added `Co Print` `@base` and `@System` filament entries under `resources/profiles/OrcaFilamentLibrary`.
- Updated the existing vendor-scoped filament presets to inherit from the new library bases.
- Registered the new library presets in `resources/profiles/OrcaFilamentLibrary.json`.

## Testing

- `python3 scripts/orca_extra_profile_check.py --vendor "Co Print" --check-filaments --check-materials --check-obsolete-keys`
  - Result: 0 errors; existing obsolete-key warnings remain in vendor base files.
- `git diff --check`

Part of #12162.