### PR TITLE
Migrate Peopoly filaments to OrcaFilamentLibrary

### DIFF
--- a/resources/profiles/OrcaFilamentLibrary.json
+++ b/resources/profiles/OrcaFilamentLibrary.json
@@ -1507,6 +1507,62 @@
 		{
 			"name": "GreenGate3D PETG @System",
 			"sub_path": "filament/GreenGate3D/GreenGate3D PETG @System.json"
+		},
+		{
+			"name": "Peopoly Generic ABS @base",
+			"sub_path": "filament/Peopoly/Peopoly Generic ABS @base.json"
+		},
+		{
+			"name": "Peopoly Generic ABS @System",
+			"sub_path": "filament/Peopoly/Peopoly Generic ABS @System.json"
+		},
+		{
+			"name": "Peopoly Generic PETG @base",
+			"sub_path": "filament/Peopoly/Peopoly Generic PETG @base.json"
+		},
+		{
+			"name": "Peopoly Generic PETG @System",
+			"sub_path": "filament/Peopoly/Peopoly Generic PETG @System.json"
+		},
+		{
+			"name": "Peopoly Generic PLA @base",
+			"sub_path": "filament/Peopoly/Peopoly Generic PLA @base.json"
+		},
+		{
+			"name": "Peopoly Generic PLA @System",
+			"sub_path": "filament/Peopoly/Peopoly Generic PLA @System.json"
+		},
+		{
+			"name": "Peopoly Lancer ABS-GF @base",
+			"sub_path": "filament/Peopoly/Peopoly Lancer ABS-GF @base.json"
+		},
+		{
+			"name": "Peopoly Lancer ABS-GF @System",
+			"sub_path": "filament/Peopoly/Peopoly Lancer ABS-GF @System.json"
+		},
+		{
+			"name": "Peopoly Lancer PET-CF @base",
+			"sub_path": "filament/Peopoly/Peopoly Lancer PET-CF @base.json"
+		},
+		{
+			"name": "Peopoly Lancer PET-CF @System",
+			"sub_path": "filament/Peopoly/Peopoly Lancer PET-CF @System.json"
+		},
+		{
+			"name": "Peopoly Lancer PETG-C @base",
+			"sub_path": "filament/Peopoly/Peopoly Lancer PETG-C @base.json"
+		},
+		{
+			"name": "Peopoly Lancer PETG-C @System",
+			"sub_path": "filament/Peopoly/Peopoly Lancer PETG-C @System.json"
+		},
+		{
+			"name": "Peopoly Lancer PLA-C @base",
+			"sub_path": "filament/Peopoly/Peopoly Lancer PLA-C @base.json"
+		},
+		{
+			"name": "Peopoly Lancer PLA-C @System",
+			"sub_path": "filament/Peopoly/Peopoly Lancer PLA-C @System.json"
 		}
 	],
 	"process_list": [],

--- a/resources/profiles/OrcaFilamentLibrary/filament/Peopoly/Peopoly Generic ABS @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Peopoly/Peopoly Generic ABS @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "Peopoly Generic ABS @System",
+	"inherits": "Peopoly Generic ABS @base",
+	"from": "system",
+	"filament_id": "GFSL99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Peopoly/Peopoly Generic ABS @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Peopoly/Peopoly Generic ABS @base.json
@@ -1,0 +1,160 @@
+{
+	"type": "filament",
+	"name": "Peopoly Generic ABS @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"0"
+	],
+	"eng_plate_temp": [
+		"90"
+	],
+	"hot_plate_temp": [
+		"90"
+	],
+	"cool_plate_temp_initial_layer": [
+		"0"
+	],
+	"eng_plate_temp_initial_layer": [
+		"90"
+	],
+	"hot_plate_temp_initial_layer": [
+		"90"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"overhang_fan_speed": [
+		"80"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.93"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.04"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"22"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"ABS"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"275"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"80"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"slow_down_layer_time": [
+		"3"
+	],
+	"filament_start_gcode": [
+		"; Filament gcode\n"
+	],
+	"nozzle_temperature": [
+		"270"
+	],
+	"temperature_vitrification": [
+		"100"
+	],
+	"activate_air_filtration": [
+		"1"
+	],
+	"nozzle_temperature_range_high": [
+		"280"
+	],
+	"nozzle_temperature_range_low": [
+		"240"
+	],
+	"textured_plate_temp": [
+		"90"
+	],
+	"textured_plate_temp_initial_layer": [
+		"90"
+	],
+	"enable_pressure_advance": [
+		"1"
+	],
+	"pressure_advance": [
+		"0.02"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Peopoly/Peopoly Generic PETG @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Peopoly/Peopoly Generic PETG @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Peopoly Generic PETG @System",
+	"inherits": "Peopoly Generic PETG @base",
+	"from": "system",
+	"setting_id": "GSPETG-1",
+	"filament_id": "GFPETG-1",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Peopoly/Peopoly Generic PETG @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Peopoly/Peopoly Generic PETG @base.json
@@ -1,0 +1,151 @@
+{
+	"type": "filament",
+	"name": "Peopoly Generic PETG @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"60"
+	],
+	"eng_plate_temp": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"70"
+	],
+	"cool_plate_temp_initial_layer": [
+		"60"
+	],
+	"eng_plate_temp_initial_layer": [
+		"0"
+	],
+	"hot_plate_temp_initial_layer": [
+		"70"
+	],
+	"overhang_fan_threshold": [
+		"95%"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.92"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"20"
+	],
+	"filament_cost": [
+		"30"
+	],
+	"filament_density": [
+		"1.27"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"20"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PETG"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"245"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"40"
+	],
+	"fan_min_speed": [
+		"20"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"8"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if (bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S180\n{elsif (bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S255\n{endif};Prevent PLA from jamming\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+	],
+	"nozzle_temperature": [
+		"235"
+	],
+	"temperature_vitrification": [
+		"70"
+	],
+	"nozzle_temperature_range_high": [
+		"280"
+	],
+	"nozzle_temperature_range_low": [
+		"220"
+	],
+	"textured_plate_temp": [
+		"80"
+	],
+	"textured_plate_temp_initial_layer": [
+		"80"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Peopoly/Peopoly Generic PLA @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Peopoly/Peopoly Generic PLA @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Peopoly Generic PLA @System",
+	"inherits": "Peopoly Generic PLA @base",
+	"from": "system",
+	"setting_id": "GFSL99",
+	"filament_id": "GFL99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Peopoly/Peopoly Generic PLA @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Peopoly/Peopoly Generic PLA @base.json
@@ -1,0 +1,154 @@
+{
+	"type": "filament",
+	"name": "Peopoly Generic PLA @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"35"
+	],
+	"eng_plate_temp": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"60"
+	],
+	"cool_plate_temp_initial_layer": [
+		"35"
+	],
+	"eng_plate_temp_initial_layer": [
+		"0"
+	],
+	"hot_plate_temp_initial_layer": [
+		"60"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.92"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"18"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PLA"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"225"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"60"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"8"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n"
+	],
+	"nozzle_temperature": [
+		"220"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"230"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"enable_pressure_advance": [
+		"1"
+	],
+	"pressure_advance": [
+		"0.02"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Peopoly/Peopoly Lancer ABS-GF @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Peopoly/Peopoly Lancer ABS-GF @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Peopoly Lancer ABS-GF @System",
+	"inherits": "Peopoly Lancer ABS-GF @base",
+	"from": "system",
+	"setting_id": "GFSL99",
+	"filament_id": "GFL99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Peopoly/Peopoly Lancer ABS-GF @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Peopoly/Peopoly Lancer ABS-GF @base.json
@@ -1,0 +1,160 @@
+{
+	"type": "filament",
+	"name": "Peopoly Lancer ABS-GF @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"0"
+	],
+	"eng_plate_temp": [
+		"90"
+	],
+	"hot_plate_temp": [
+		"100"
+	],
+	"cool_plate_temp_initial_layer": [
+		"0"
+	],
+	"eng_plate_temp_initial_layer": [
+		"90"
+	],
+	"hot_plate_temp_initial_layer": [
+		"90"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"overhang_fan_speed": [
+		"30"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.91"
+	],
+	"reduce_fan_stop_start_freq": [
+		"0"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.04"
+	],
+	"filament_deretraction_speed": [
+		"60"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"35"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"0.8"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"60"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"ABS"
+	],
+	"filament_vendor": [
+		"Peopoly"
+	],
+	"filament_wipe": [
+		"1"
+	],
+	"filament_wipe_distance": [
+		"1"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"260"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"40"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"slow_down_layer_time": [
+		"6"
+	],
+	"filament_start_gcode": [
+		"; Filament gcode\n"
+	],
+	"nozzle_temperature": [
+		"270"
+	],
+	"temperature_vitrification": [
+		"100"
+	],
+	"activate_air_filtration": [
+		"1"
+	],
+	"nozzle_temperature_range_high": [
+		"280"
+	],
+	"nozzle_temperature_range_low": [
+		"240"
+	],
+	"textured_plate_temp": [
+		"90"
+	],
+	"textured_plate_temp_initial_layer": [
+		"90"
+	],
+	"enable_pressure_advance": [
+		"1"
+	],
+	"pressure_advance": [
+		"0.016"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Peopoly/Peopoly Lancer PET-CF @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Peopoly/Peopoly Lancer PET-CF @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Peopoly Lancer PET-CF @System",
+	"inherits": "Peopoly Lancer PET-CF @base",
+	"from": "system",
+	"setting_id": "GFSL99",
+	"filament_id": "GFL99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Peopoly/Peopoly Lancer PET-CF @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Peopoly/Peopoly Lancer PET-CF @base.json
@@ -1,0 +1,160 @@
+{
+	"type": "filament",
+	"name": "Peopoly Lancer PET-CF @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"0"
+	],
+	"eng_plate_temp": [
+		"90"
+	],
+	"hot_plate_temp": [
+		"80"
+	],
+	"cool_plate_temp_initial_layer": [
+		"0"
+	],
+	"eng_plate_temp_initial_layer": [
+		"90"
+	],
+	"hot_plate_temp_initial_layer": [
+		"70"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"overhang_fan_speed": [
+		"30"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.90"
+	],
+	"reduce_fan_stop_start_freq": [
+		"0"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.3"
+	],
+	"filament_deretraction_speed": [
+		"60"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"35"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"0.8"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"60"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PET-CF"
+	],
+	"filament_vendor": [
+		"Peopoly"
+	],
+	"filament_wipe": [
+		"1"
+	],
+	"filament_wipe_distance": [
+		"1"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"280"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"40"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"slow_down_layer_time": [
+		"8"
+	],
+	"filament_start_gcode": [
+		"; Filament gcode\n"
+	],
+	"nozzle_temperature": [
+		"300"
+	],
+	"temperature_vitrification": [
+		"100"
+	],
+	"activate_air_filtration": [
+		"1"
+	],
+	"nozzle_temperature_range_high": [
+		"280"
+	],
+	"nozzle_temperature_range_low": [
+		"240"
+	],
+	"textured_plate_temp": [
+		"90"
+	],
+	"textured_plate_temp_initial_layer": [
+		"90"
+	],
+	"enable_pressure_advance": [
+		"1"
+	],
+	"pressure_advance": [
+		"0.005"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Peopoly/Peopoly Lancer PETG-C @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Peopoly/Peopoly Lancer PETG-C @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Peopoly Lancer PETG-C @System",
+	"inherits": "Peopoly Lancer PETG-C @base",
+	"from": "system",
+	"setting_id": "GFSL99",
+	"filament_id": "GFL99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Peopoly/Peopoly Lancer PETG-C @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Peopoly/Peopoly Lancer PETG-C @base.json
@@ -1,0 +1,157 @@
+{
+	"type": "filament",
+	"name": "Peopoly Lancer PETG-C @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"60"
+	],
+	"eng_plate_temp": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"70"
+	],
+	"cool_plate_temp_initial_layer": [
+		"60"
+	],
+	"eng_plate_temp_initial_layer": [
+		"0"
+	],
+	"hot_plate_temp_initial_layer": [
+		"70"
+	],
+	"overhang_fan_threshold": [
+		"95%"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.90"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"20"
+	],
+	"filament_cost": [
+		"30"
+	],
+	"filament_density": [
+		"1.27"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"32"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PETG"
+	],
+	"filament_vendor": [
+		"Peopoly"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"235"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"40"
+	],
+	"fan_min_speed": [
+		"5"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"8"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if (bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S180\n{elsif (bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S255\n{endif};Prevent PLA from jamming\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+	],
+	"nozzle_temperature": [
+		"225"
+	],
+	"temperature_vitrification": [
+		"70"
+	],
+	"nozzle_temperature_range_high": [
+		"280"
+	],
+	"nozzle_temperature_range_low": [
+		"220"
+	],
+	"textured_plate_temp": [
+		"80"
+	],
+	"textured_plate_temp_initial_layer": [
+		"80"
+	],
+	"enable_pressure_advance": [
+		"1"
+	],
+	"pressure_advance": [
+		"0.04"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Peopoly/Peopoly Lancer PLA-C @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Peopoly/Peopoly Lancer PLA-C @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Peopoly Lancer PLA-C @System",
+	"inherits": "Peopoly Lancer PLA-C @base",
+	"from": "system",
+	"setting_id": "GFSL99",
+	"filament_id": "GFL99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Peopoly/Peopoly Lancer PLA-C @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Peopoly/Peopoly Lancer PLA-C @base.json
@@ -1,0 +1,154 @@
+{
+	"type": "filament",
+	"name": "Peopoly Lancer PLA-C @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"35"
+	],
+	"eng_plate_temp": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"70"
+	],
+	"cool_plate_temp_initial_layer": [
+		"35"
+	],
+	"eng_plate_temp_initial_layer": [
+		"0"
+	],
+	"hot_plate_temp_initial_layer": [
+		"70"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.92"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"35"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PLA"
+	],
+	"filament_vendor": [
+		"Peopoly"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"215"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"50"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"6"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n"
+	],
+	"nozzle_temperature": [
+		"210"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"230"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"enable_pressure_advance": [
+		"1"
+	],
+	"pressure_advance": [
+		"0.03"
+	]
+}

--- a/resources/profiles/Peopoly/filament/Peopoly Generic ABS.json
+++ b/resources/profiles/Peopoly/filament/Peopoly Generic ABS.json
@@ -1,7 +1,7 @@
 {
 	"type": "filament",
 	"name": "Peopoly Generic ABS",
-	"inherits": "fdm_filament_abs",
+	"inherits": "Peopoly Generic ABS @base",
 	"from": "system",
 	"filament_id": "GFSL99",
 	"instantiation": "true",

--- a/resources/profiles/Peopoly/filament/Peopoly Generic PETG.json
+++ b/resources/profiles/Peopoly/filament/Peopoly Generic PETG.json
@@ -1,7 +1,7 @@
 {
 	"type": "filament",
 	"name": "Peopoly Generic PETG",
-	"inherits": "fdm_filament_petg",
+	"inherits": "Peopoly Generic PETG @base",
 	"from": "system",
 	"setting_id": "GSPETG-1",
 	"filament_id": "GFPETG-1",

--- a/resources/profiles/Peopoly/filament/Peopoly Generic PLA.json
+++ b/resources/profiles/Peopoly/filament/Peopoly Generic PLA.json
@@ -1,7 +1,7 @@
 {
 	"type": "filament",
 	"name": "Peopoly Generic PLA",
-	"inherits": "fdm_filament_pla",
+	"inherits": "Peopoly Generic PLA @base",
 	"from": "system",
 	"setting_id": "GFSL99",
 	"filament_id": "GFL99",

--- a/resources/profiles/Peopoly/filament/Peopoly Lancer ABS-GF.json
+++ b/resources/profiles/Peopoly/filament/Peopoly Lancer ABS-GF.json
@@ -1,7 +1,7 @@
 {
 	"type": "filament",
 	"name": "Peopoly Lancer ABS-GF",
-	"inherits": "fdm_filament_abs",
+	"inherits": "Peopoly Lancer ABS-GF @base",
 	"from": "system",
 	"setting_id": "GFSL99",
 	"filament_id": "GFL99",

--- a/resources/profiles/Peopoly/filament/Peopoly Lancer PET-CF.json
+++ b/resources/profiles/Peopoly/filament/Peopoly Lancer PET-CF.json
@@ -1,7 +1,7 @@
 {
 	"type": "filament",
 	"name": "Peopoly Lancer PET-CF",
-	"inherits": "fdm_filament_abs",
+	"inherits": "Peopoly Lancer PET-CF @base",
 	"from": "system",
 	"setting_id": "GFSL99",
 	"filament_id": "GFL99",

--- a/resources/profiles/Peopoly/filament/Peopoly Lancer PETG-C.json
+++ b/resources/profiles/Peopoly/filament/Peopoly Lancer PETG-C.json
@@ -1,7 +1,7 @@
 {
 	"type": "filament",
 	"name": "Peopoly Lancer PETG-C",
-	"inherits": "fdm_filament_petg",
+	"inherits": "Peopoly Lancer PETG-C @base",
 	"from": "system",
 	"setting_id": "GFSL99",
 	"filament_id": "GFL99",

--- a/resources/profiles/Peopoly/filament/Peopoly Lancer PLA-C.json
+++ b/resources/profiles/Peopoly/filament/Peopoly Lancer PLA-C.json
@@ -1,7 +1,7 @@
 {
 	"type": "filament",
 	"name": "Peopoly Lancer PLA-C",
-	"inherits": "fdm_filament_pla",
+	"inherits": "Peopoly Lancer PLA-C @base",
 	"from": "system",
 	"setting_id": "GFSL99",
 	"filament_id": "GFL99",


### PR DESCRIPTION
## Summary

Migrate the Peopoly filament presets to OrcaFilamentLibrary while keeping the existing Peopoly printer-scoped presets compatible with their current machines.

## Changes

- Added Peopoly Generic and Lancer filament base/System presets under `OrcaFilamentLibrary`.
- Updated Peopoly vendor-scoped filament profiles to inherit from the new library bases.
- Registered the new Peopoly OrcaFilamentLibrary entries.

## Testing

- `python3 scripts/orca_extra_profile_check.py --vendor Peopoly --check-filaments --check-materials --check-obsolete-keys`
- `git diff --check`

Fixes OrcaSlicer/OrcaSlicer#12162