### PR TITLE
Migrate Blocks filaments to OrcaFilamentLibrary

### DIFF
--- a/resources/profiles/Blocks/filament/Blocks Generic ABS.json
+++ b/resources/profiles/Blocks/filament/Blocks Generic ABS.json
@@ -1,86 +1,11 @@
 {
 	"type": "filament",
 	"name": "Blocks Generic ABS",
-	"inherits": "fdm_filament_abs",
+	"inherits": "Blocks Generic ABS @base",
 	"from": "system",
 	"setting_id": "BSSI004",
 	"filament_id": "BSFI004",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"0.95"
-	],
-	"filament_density": [
-		"1.04"
-	],
-	"filament_shrink": [
-		"99.5%"
-	],
-	"filament_max_volumetric_speed": [
-		"18"
-	],
-	"nozzle_temperature_initial_layer": [
-		"255"
-	],
-	"nozzle_temperature": [
-		"255"
-	],
-	"nozzle_temperature_range_low": [
-		"230"
-	],
-	"nozzle_temperature_range_high": [
-		"280"
-	],
-	"hot_plate_temp_initial_layer": [
-		"90"
-	],
-	"hot_plate_temp": [
-		"90"
-	],
-	"fan_min_speed": [
-		"10"
-	],
-	"fan_max_speed": [
-		"100"
-	],
-	"fan_cooling_layer_time": [
-		"30"
-	],
-	"slow_down_layer_time": [
-		"10"
-	],
-	"close_fan_the_first_x_layers": [
-		"4"
-	],
-	"slow_down_for_layer_cooling": [
-		"1"
-	],
-	"reduce_fan_stop_start_freq": [
-		"1"
-	],
-	"slow_down_min_speed": [
-		"30"
-	],
-	"enable_overhang_bridge_fan": [
-		"1"
-	],
-	"overhang_fan_threshold": [
-		"25%"
-	],
-	"overhang_fan_speed": [
-		"100%"
-	],
-	"additional_cooling_fan_speed": [
-		"0"
-	],
-	"activate_air_filtration": [
-		"1"
-	],
-	"complete_print_exhaust_fan_speed": [
-		"100"
-	],
-	"during_print_exhaust_fan_speed": [
-		"100"
-	],
 	"compatible_printers": [
 		"BLOCKS RD50 V2 0.4 nozzle",
 		"BLOCKS RD50 V2 0.6 nozzle",

--- a/resources/profiles/Blocks/filament/Blocks Generic ASA-CF.json
+++ b/resources/profiles/Blocks/filament/Blocks Generic ASA-CF.json
@@ -1,86 +1,11 @@
 {
 	"type": "filament",
 	"name": "Blocks Generic ASA-CF",
-	"inherits": "fdm_filament_asa",
+	"inherits": "Blocks Generic ASA-CF @base",
 	"from": "system",
 	"setting_id": "BSSI010",
 	"filament_id": "BSFI010",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"0.95"
-	],
-	"filament_density": [
-		"1.04"
-	],
-	"filament_shrink": [
-		"99.5%"
-	],
-	"filament_max_volumetric_speed": [
-		"10"
-	],
-	"nozzle_temperature_initial_layer": [
-		"260"
-	],
-	"nozzle_temperature": [
-		"260"
-	],
-	"nozzle_temperature_range_low": [
-		"230"
-	],
-	"nozzle_temperature_range_high": [
-		"280"
-	],
-	"hot_plate_temp_initial_layer": [
-		"95"
-	],
-	"hot_plate_temp": [
-		"95"
-	],
-	"fan_min_speed": [
-		"10"
-	],
-	"fan_max_speed": [
-		"45"
-	],
-	"fan_cooling_layer_time": [
-		"35"
-	],
-	"slow_down_layer_time": [
-		"3"
-	],
-	"close_fan_the_first_x_layers": [
-		"4"
-	],
-	"slow_down_for_layer_cooling": [
-		"1"
-	],
-	"reduce_fan_stop_start_freq": [
-		"1"
-	],
-	"slow_down_min_speed": [
-		"10"
-	],
-	"enable_overhang_bridge_fan": [
-		"1"
-	],
-	"overhang_fan_threshold": [
-		"25%"
-	],
-	"overhang_fan_speed": [
-		"50%"
-	],
-	"additional_cooling_fan_speed": [
-		"0"
-	],
-	"activate_air_filtration": [
-		"1"
-	],
-	"complete_print_exhaust_fan_speed": [
-		"80"
-	],
-	"during_print_exhaust_fan_speed": [
-		"100"
-	],
 	"compatible_printers": [
 		"BLOCKS RD50 V2 0.4 nozzle",
 		"BLOCKS RD50 V2 0.6 nozzle",

--- a/resources/profiles/Blocks/filament/Blocks Generic ASA.json
+++ b/resources/profiles/Blocks/filament/Blocks Generic ASA.json
@@ -1,86 +1,11 @@
 {
 	"type": "filament",
 	"name": "Blocks Generic ASA",
-	"inherits": "fdm_filament_asa",
+	"inherits": "Blocks Generic ASA @base",
 	"from": "system",
 	"setting_id": "BSSI005",
 	"filament_id": "BSFI005",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"0.95"
-	],
-	"filament_density": [
-		"1.04"
-	],
-	"filament_shrink": [
-		"99.5%"
-	],
-	"filament_max_volumetric_speed": [
-		"18"
-	],
-	"nozzle_temperature_initial_layer": [
-		"260"
-	],
-	"nozzle_temperature": [
-		"260"
-	],
-	"nozzle_temperature_range_low": [
-		"230"
-	],
-	"nozzle_temperature_range_high": [
-		"280"
-	],
-	"hot_plate_temp_initial_layer": [
-		"90"
-	],
-	"hot_plate_temp": [
-		"90"
-	],
-	"fan_min_speed": [
-		"10"
-	],
-	"fan_max_speed": [
-		"100"
-	],
-	"fan_cooling_layer_time": [
-		"30"
-	],
-	"slow_down_layer_time": [
-		"10"
-	],
-	"close_fan_the_first_x_layers": [
-		"4"
-	],
-	"slow_down_for_layer_cooling": [
-		"1"
-	],
-	"reduce_fan_stop_start_freq": [
-		"1"
-	],
-	"slow_down_min_speed": [
-		"30"
-	],
-	"enable_overhang_bridge_fan": [
-		"1"
-	],
-	"overhang_fan_threshold": [
-		"25%"
-	],
-	"overhang_fan_speed": [
-		"100%"
-	],
-	"additional_cooling_fan_speed": [
-		"0"
-	],
-	"activate_air_filtration": [
-		"1"
-	],
-	"complete_print_exhaust_fan_speed": [
-		"100"
-	],
-	"during_print_exhaust_fan_speed": [
-		"100"
-	],
 	"compatible_printers": [
 		"BLOCKS RD50 V2 0.4 nozzle",
 		"BLOCKS RD50 V2 0.6 nozzle",

--- a/resources/profiles/Blocks/filament/Blocks Generic PA-CF.json
+++ b/resources/profiles/Blocks/filament/Blocks Generic PA-CF.json
@@ -1,92 +1,11 @@
 {
 	"type": "filament",
 	"name": "Blocks Generic PA-CF",
-	"inherits": "fdm_filament_pa",
+	"inherits": "Blocks Generic PA-CF @base",
 	"from": "system",
 	"setting_id": "BSSI007",
 	"filament_id": "BSFI007",
 	"instantiation": "true",
-	"filament_type": [
-		"PA-CF"
-	],
-	"filament_flow_ratio": [
-		"0.95"
-	],
-	"filament_max_volumetric_speed": [
-		"10"
-	],
-	"nozzle_temperature_range_low": [
-		"240"
-	],
-	"nozzle_temperature_range_high": [
-		"290"
-	],
-	"nozzle_temperature_initial_layer": [
-		"255"
-	],
-	"filament_density": [
-		"1.25"
-	],
-	"nozzle_temperature": [
-		"250"
-	],
-	"hot_plate_temp_initial_layer": [
-		"90"
-	],
-	"hot_plate_temp": [
-		"90"
-	],
-	"filament_retraction_length": [
-		"1.2"
-	],
-	"filament_z_hop": [
-		"0.0"
-	],
-	"fan_min_speed": [
-		"0"
-	],
-	"fan_max_speed": [
-		"60"
-	],
-	"fan_cooling_layer_time": [
-		"4"
-	],
-	"close_fan_the_first_x_layers": [
-		"3"
-	],
-	"slow_down_layer_time": [
-		"2"
-	],
-	"slow_down_for_layer_cooling": [
-		"1"
-	],
-	"reduce_fan_stop_start_freq": [
-		"0"
-	],
-	"slow_down_min_speed": [
-		"10"
-	],
-	"enable_overhang_bridge_fan": [
-		"1"
-	],
-	"overhang_fan_threshold": [
-		"95%"
-	],
-	"overhang_fan_speed": [
-		"80%"
-	],
-	"additional_cooling_fan_speed": [
-		"0"
-	],
-	"activate_air_filtration": [
-		"1"
-	],
-	"complete_print_exhaust_fan_speed": [
-		"100"
-	],
-	"during_print_exhaust_fan_speed": [
-		"80"
-	],
 	"compatible_printers": [
 		"BLOCKS RD50 V2 0.4 nozzle",
 		"BLOCKS RD50 V2 0.6 nozzle",

--- a/resources/profiles/Blocks/filament/Blocks Generic PA.json
+++ b/resources/profiles/Blocks/filament/Blocks Generic PA.json
@@ -1,17 +1,11 @@
 {
 	"type": "filament",
 	"name": "Blocks Generic PA",
-	"inherits": "fdm_filament_pa",
+	"inherits": "Blocks Generic PA @base",
 	"from": "system",
 	"setting_id": "BSSI006",
 	"filament_id": "BSFI006",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"0.98"
-	],
-	"filament_max_volumetric_speed": [
-		"10"
-	],
 	"compatible_printers": [
 		"BLOCKS RD50 V2 0.4 nozzle",
 		"BLOCKS RD50 V2 0.6 nozzle",

--- a/resources/profiles/Blocks/filament/Blocks Generic PC.json
+++ b/resources/profiles/Blocks/filament/Blocks Generic PC.json
@@ -1,17 +1,11 @@
 {
 	"type": "filament",
 	"name": "Blocks Generic PC",
-	"inherits": "fdm_filament_pc",
+	"inherits": "Blocks Generic PC @base",
 	"from": "system",
 	"setting_id": "BSSI008",
 	"filament_id": "BSFI008",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"0.94"
-	],
-	"filament_max_volumetric_speed": [
-		"10"
-	],
 	"compatible_printers": [
 		"BLOCKS RD50 V2 0.4 nozzle",
 		"BLOCKS RD50 V2 0.6 nozzle",

--- a/resources/profiles/Blocks/filament/Blocks Generic PETG.json
+++ b/resources/profiles/Blocks/filament/Blocks Generic PETG.json
@@ -1,86 +1,11 @@
 {
 	"type": "filament",
 	"name": "Blocks Generic PETG",
-	"inherits": "fdm_filament_petg",
+	"inherits": "Blocks Generic PETG @base",
 	"from": "system",
 	"setting_id": "BSSI002",
 	"filament_id": "BSFI002",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"0.94"
-	],
-	"filament_density": [
-		"1.24"
-	],
-	"filament_shrink": [
-		"99.9%"
-	],
-	"filament_max_volumetric_speed": [
-		"12"
-	],
-	"nozzle_temperature_initial_layer": [
-		"250"
-	],
-	"nozzle_temperature": [
-		"245"
-	],
-	"nozzle_temperature_range_low": [
-		"210"
-	],
-	"nozzle_temperature_range_high": [
-		"270"
-	],
-	"hot_plate_temp_initial_layer": [
-		"70"
-	],
-	"hot_plate_temp": [
-		"70"
-	],
-	"close_fan_the_first_x_layers": [
-		"1"
-	],
-	"slow_down_for_layer_cooling": [
-		"1"
-	],
-	"reduce_fan_stop_start_freq": [
-		"1"
-	],
-	"slow_down_min_speed": [
-		"30"
-	],
-	"enable_overhang_bridge_fan": [
-		"1"
-	],
-	"overhang_fan_threshold": [
-		"25%"
-	],
-	"overhang_fan_speed": [
-		"100%"
-	],
-	"additional_cooling_fan_speed": [
-		"40"
-	],
-	"complete_print_exhaust_fan_speed": [
-		"80"
-	],
-	"activate_air_filtration": [
-		"1"
-	],
-	"during_print_exhaust_fan_speed": [
-		"100"
-	],
-	"fan_min_speed": [
-		"40"
-	],
-	"fan_cooling_layer_time": [
-		"30"
-	],
-	"fan_max_speed": [
-		"80"
-	],
-	"slow_down_layer_time": [
-		"5"
-	],
 	"compatible_printers": [
 		"BLOCKS Pro S100 0.4 nozzle",
 		"BLOCKS Pro S100 0.6 nozzle",

--- a/resources/profiles/Blocks/filament/Blocks Generic PLA-CF.json
+++ b/resources/profiles/Blocks/filament/Blocks Generic PLA-CF.json
@@ -1,23 +1,11 @@
 {
 	"type": "filament",
 	"name": "Blocks Generic PLA-CF",
-	"inherits": "fdm_filament_pla",
+	"inherits": "Blocks Generic PLA-CF @base",
 	"from": "system",
 	"setting_id": "BSSI010",
 	"filament_id": "BSFI010",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"0.95"
-	],
-	"filament_max_volumetric_speed": [
-		"20"
-	],
-	"filament_type": [
-		"PLA-CF"
-	],
-	"slow_down_layer_time": [
-		"7"
-	],
 	"compatible_printers": [
 		"BLOCKS RD50 V2 0.4 nozzle",
 		"BLOCKS RD50 V2 0.6 nozzle",

--- a/resources/profiles/Blocks/filament/Blocks Generic PLA.json
+++ b/resources/profiles/Blocks/filament/Blocks Generic PLA.json
@@ -1,44 +1,11 @@
 {
 	"type": "filament",
 	"name": "Blocks Generic PLA",
-	"inherits": "fdm_filament_pla",
+	"inherits": "Blocks Generic PLA @base",
 	"from": "system",
 	"setting_id": "BSSI001",
 	"filament_id": "BSFI001",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"0.95"
-	],
-	"filament_max_volumetric_speed": [
-		"18"
-	],
-	"nozzle_temperature_initial_layer": [
-		"210"
-	],
-	"nozzle_temperature": [
-		"210"
-	],
-	"nozzle_temperature_range_low": [
-		"190"
-	],
-	"nozzle_temperature_range_high": [
-		"230"
-	],
-	"slow_down_min_speed": [
-		"30"
-	],
-	"additional_cooling_fan_speed": [
-		"100"
-	],
-	"complete_print_exhaust_fan_speed": [
-		"80"
-	],
-	"activate_air_filtration": [
-		"1"
-	],
-	"during_print_exhaust_fan_speed": [
-		"100"
-	],
 	"compatible_printers": [
 		"BLOCKS Pro S100 0.4 nozzle",
 		"BLOCKS Pro S100 0.6 nozzle",

--- a/resources/profiles/Blocks/filament/Blocks Generic PVA.json
+++ b/resources/profiles/Blocks/filament/Blocks Generic PVA.json
@@ -1,17 +1,11 @@
 {
 	"type": "filament",
 	"name": "Blocks Generic PVA",
-	"inherits": "fdm_filament_pva",
+	"inherits": "Blocks Generic PVA @base",
 	"from": "system",
 	"setting_id": "BSSI009",
 	"filament_id": "BSFI009",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"0.98"
-	],
-	"filament_max_volumetric_speed": [
-		"20"
-	],
 	"compatible_printers": [
 		"BLOCKS RD50 V2 0.4 nozzle",
 		"BLOCKS RD50 V2 0.6 nozzle",

--- a/resources/profiles/Blocks/filament/Blocks Generic TPU.json
+++ b/resources/profiles/Blocks/filament/Blocks Generic TPU.json
@@ -1,59 +1,11 @@
 {
 	"type": "filament",
 	"name": "Blocks Generic TPU",
-	"inherits": "fdm_filament_tpu",
+	"inherits": "Blocks Generic TPU @base",
 	"from": "system",
 	"setting_id": "BSSI003",
 	"filament_id": "BSFI003",
 	"instantiation": "true",
-	"filament_max_volumetric_speed": [
-		"4"
-	],
-	"filament_flow_ratio": [
-		"0.95"
-	],
-	"filament_density": [
-		"1.25"
-	],
-	"filament_shrink": [
-		"99.5%"
-	],
-	"nozzle_temperature_initial_layer": [
-		"250"
-	],
-	"nozzle_temperature": [
-		"250"
-	],
-	"nozzle_temperature_range_low": [
-		"240"
-	],
-	"nozzle_temperature_range_high": [
-		"280"
-	],
-	"hot_plate_temp_initial_layer": [
-		"90"
-	],
-	"hot_plate_temp": [
-		"90"
-	],
-	"fan_min_speed": [
-		"10"
-	],
-	"fan_max_speed": [
-		"100"
-	],
-	"additional_cooling_fan_speed": [
-		"60"
-	],
-	"activate_air_filtration": [
-		"1"
-	],
-	"complete_print_exhaust_fan_speed": [
-		"100"
-	],
-	"during_print_exhaust_fan_speed": [
-		"80"
-	],
 	"compatible_printers": [
 		"BLOCKS Pro S100 0.4 nozzle",
 		"BLOCKS Pro S100 0.6 nozzle",

--- a/resources/profiles/OrcaFilamentLibrary.json
+++ b/resources/profiles/OrcaFilamentLibrary.json
@@ -1507,6 +1507,94 @@
 		{
 			"name": "GreenGate3D PETG @System",
 			"sub_path": "filament/GreenGate3D/GreenGate3D PETG @System.json"
+		},
+		{
+			"name": "Blocks Generic ABS @base",
+			"sub_path": "filament/Blocks/Blocks Generic ABS @base.json"
+		},
+		{
+			"name": "Blocks Generic ABS @System",
+			"sub_path": "filament/Blocks/Blocks Generic ABS @System.json"
+		},
+		{
+			"name": "Blocks Generic ASA-CF @base",
+			"sub_path": "filament/Blocks/Blocks Generic ASA-CF @base.json"
+		},
+		{
+			"name": "Blocks Generic ASA-CF @System",
+			"sub_path": "filament/Blocks/Blocks Generic ASA-CF @System.json"
+		},
+		{
+			"name": "Blocks Generic ASA @base",
+			"sub_path": "filament/Blocks/Blocks Generic ASA @base.json"
+		},
+		{
+			"name": "Blocks Generic ASA @System",
+			"sub_path": "filament/Blocks/Blocks Generic ASA @System.json"
+		},
+		{
+			"name": "Blocks Generic PA-CF @base",
+			"sub_path": "filament/Blocks/Blocks Generic PA-CF @base.json"
+		},
+		{
+			"name": "Blocks Generic PA-CF @System",
+			"sub_path": "filament/Blocks/Blocks Generic PA-CF @System.json"
+		},
+		{
+			"name": "Blocks Generic PA @base",
+			"sub_path": "filament/Blocks/Blocks Generic PA @base.json"
+		},
+		{
+			"name": "Blocks Generic PA @System",
+			"sub_path": "filament/Blocks/Blocks Generic PA @System.json"
+		},
+		{
+			"name": "Blocks Generic PC @base",
+			"sub_path": "filament/Blocks/Blocks Generic PC @base.json"
+		},
+		{
+			"name": "Blocks Generic PC @System",
+			"sub_path": "filament/Blocks/Blocks Generic PC @System.json"
+		},
+		{
+			"name": "Blocks Generic PETG @base",
+			"sub_path": "filament/Blocks/Blocks Generic PETG @base.json"
+		},
+		{
+			"name": "Blocks Generic PETG @System",
+			"sub_path": "filament/Blocks/Blocks Generic PETG @System.json"
+		},
+		{
+			"name": "Blocks Generic PLA-CF @base",
+			"sub_path": "filament/Blocks/Blocks Generic PLA-CF @base.json"
+		},
+		{
+			"name": "Blocks Generic PLA-CF @System",
+			"sub_path": "filament/Blocks/Blocks Generic PLA-CF @System.json"
+		},
+		{
+			"name": "Blocks Generic PLA @base",
+			"sub_path": "filament/Blocks/Blocks Generic PLA @base.json"
+		},
+		{
+			"name": "Blocks Generic PLA @System",
+			"sub_path": "filament/Blocks/Blocks Generic PLA @System.json"
+		},
+		{
+			"name": "Blocks Generic PVA @base",
+			"sub_path": "filament/Blocks/Blocks Generic PVA @base.json"
+		},
+		{
+			"name": "Blocks Generic PVA @System",
+			"sub_path": "filament/Blocks/Blocks Generic PVA @System.json"
+		},
+		{
+			"name": "Blocks Generic TPU @base",
+			"sub_path": "filament/Blocks/Blocks Generic TPU @base.json"
+		},
+		{
+			"name": "Blocks Generic TPU @System",
+			"sub_path": "filament/Blocks/Blocks Generic TPU @System.json"
 		}
 	],
 	"process_list": [],

--- a/resources/profiles/OrcaFilamentLibrary/filament/Blocks/Blocks Generic ABS @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Blocks/Blocks Generic ABS @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Blocks Generic ABS @System",
+	"inherits": "Blocks Generic ABS @base",
+	"from": "system",
+	"setting_id": "BSSI004",
+	"filament_id": "BSFI004",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Blocks/Blocks Generic ABS @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Blocks/Blocks Generic ABS @base.json
@@ -1,0 +1,169 @@
+{
+	"type": "filament",
+	"name": "Blocks Generic ABS @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"105"
+	],
+	"eng_plate_temp": [
+		"105"
+	],
+	"hot_plate_temp": [
+		"90"
+	],
+	"textured_plate_temp": [
+		"105"
+	],
+	"cool_plate_temp_initial_layer": [
+		"105"
+	],
+	"eng_plate_temp_initial_layer": [
+		"105"
+	],
+	"hot_plate_temp_initial_layer": [
+		"90"
+	],
+	"textured_plate_temp_initial_layer": [
+		"105"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"overhang_fan_speed": [
+		"100%"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"4"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.95"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"filament_cost": [
+		"30"
+	],
+	"filament_density": [
+		"1.04"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"18"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"ABS"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"255"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"slow_down_min_speed": [
+		"30"
+	],
+	"slow_down_layer_time": [
+		"10"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n"
+	],
+	"nozzle_temperature": [
+		"255"
+	],
+	"temperature_vitrification": [
+		"110"
+	],
+	"nozzle_temperature_range_low": [
+		"230"
+	],
+	"nozzle_temperature_range_high": [
+		"280"
+	],
+	"additional_cooling_fan_speed": [
+		"0"
+	],
+	"filament_shrink": [
+		"99.5%"
+	],
+	"enable_overhang_bridge_fan": [
+		"1"
+	],
+	"activate_air_filtration": [
+		"1"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"100"
+	],
+	"during_print_exhaust_fan_speed": [
+		"100"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Blocks/Blocks Generic ASA @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Blocks/Blocks Generic ASA @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Blocks Generic ASA @System",
+	"inherits": "Blocks Generic ASA @base",
+	"from": "system",
+	"setting_id": "BSSI005",
+	"filament_id": "BSFI005",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Blocks/Blocks Generic ASA @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Blocks/Blocks Generic ASA @base.json
@@ -1,0 +1,169 @@
+{
+	"type": "filament",
+	"name": "Blocks Generic ASA @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"105"
+	],
+	"eng_plate_temp": [
+		"105"
+	],
+	"hot_plate_temp": [
+		"90"
+	],
+	"textured_plate_temp": [
+		"105"
+	],
+	"cool_plate_temp_initial_layer": [
+		"105"
+	],
+	"eng_plate_temp_initial_layer": [
+		"105"
+	],
+	"hot_plate_temp_initial_layer": [
+		"90"
+	],
+	"textured_plate_temp_initial_layer": [
+		"105"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"overhang_fan_speed": [
+		"100%"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"4"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.95"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"filament_cost": [
+		"30"
+	],
+	"filament_density": [
+		"1.04"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"18"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"ASA"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"260"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"slow_down_min_speed": [
+		"30"
+	],
+	"slow_down_layer_time": [
+		"10"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n"
+	],
+	"nozzle_temperature": [
+		"260"
+	],
+	"temperature_vitrification": [
+		"110"
+	],
+	"nozzle_temperature_range_low": [
+		"230"
+	],
+	"nozzle_temperature_range_high": [
+		"280"
+	],
+	"additional_cooling_fan_speed": [
+		"0"
+	],
+	"filament_shrink": [
+		"99.5%"
+	],
+	"enable_overhang_bridge_fan": [
+		"1"
+	],
+	"activate_air_filtration": [
+		"1"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"100"
+	],
+	"during_print_exhaust_fan_speed": [
+		"100"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Blocks/Blocks Generic ASA-CF @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Blocks/Blocks Generic ASA-CF @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Blocks Generic ASA-CF @System",
+	"inherits": "Blocks Generic ASA-CF @base",
+	"from": "system",
+	"setting_id": "BSSI010",
+	"filament_id": "BSFI010",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Blocks/Blocks Generic ASA-CF @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Blocks/Blocks Generic ASA-CF @base.json
@@ -1,0 +1,169 @@
+{
+	"type": "filament",
+	"name": "Blocks Generic ASA-CF @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"105"
+	],
+	"eng_plate_temp": [
+		"105"
+	],
+	"hot_plate_temp": [
+		"95"
+	],
+	"textured_plate_temp": [
+		"105"
+	],
+	"cool_plate_temp_initial_layer": [
+		"105"
+	],
+	"eng_plate_temp_initial_layer": [
+		"105"
+	],
+	"hot_plate_temp_initial_layer": [
+		"95"
+	],
+	"textured_plate_temp_initial_layer": [
+		"105"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"overhang_fan_speed": [
+		"50%"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"4"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.95"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"35"
+	],
+	"filament_cost": [
+		"30"
+	],
+	"filament_density": [
+		"1.04"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"10"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"ASA"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"260"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"45"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"3"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n"
+	],
+	"nozzle_temperature": [
+		"260"
+	],
+	"temperature_vitrification": [
+		"110"
+	],
+	"nozzle_temperature_range_low": [
+		"230"
+	],
+	"nozzle_temperature_range_high": [
+		"280"
+	],
+	"additional_cooling_fan_speed": [
+		"0"
+	],
+	"filament_shrink": [
+		"99.5%"
+	],
+	"enable_overhang_bridge_fan": [
+		"1"
+	],
+	"activate_air_filtration": [
+		"1"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"80"
+	],
+	"during_print_exhaust_fan_speed": [
+		"100"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Blocks/Blocks Generic PA @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Blocks/Blocks Generic PA @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Blocks Generic PA @System",
+	"inherits": "Blocks Generic PA @base",
+	"from": "system",
+	"setting_id": "BSSI006",
+	"filament_id": "BSFI006",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Blocks/Blocks Generic PA @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Blocks/Blocks Generic PA @base.json
@@ -1,0 +1,151 @@
+{
+	"type": "filament",
+	"name": "Blocks Generic PA @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"0"
+	],
+	"eng_plate_temp": [
+		"100"
+	],
+	"hot_plate_temp": [
+		"100"
+	],
+	"textured_plate_temp": [
+		"100"
+	],
+	"cool_plate_temp_initial_layer": [
+		"0"
+	],
+	"eng_plate_temp_initial_layer": [
+		"100"
+	],
+	"hot_plate_temp_initial_layer": [
+		"100"
+	],
+	"textured_plate_temp_initial_layer": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"95%"
+	],
+	"overhang_fan_speed": [
+		"60"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"reduce_fan_stop_start_freq": [
+		"0"
+	],
+	"fan_cooling_layer_time": [
+		"10"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.04"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"10"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"1.0"
+	],
+	"filament_z_hop": [
+		"0.0"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PA"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"270"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"60"
+	],
+	"fan_min_speed": [
+		"0"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"2"
+	],
+	"filament_start_gcode": [
+		"; Filament gcode\n"
+	],
+	"nozzle_temperature": [
+		"270"
+	],
+	"temperature_vitrification": [
+		"108"
+	],
+	"nozzle_temperature_range_low": [
+		"260"
+	],
+	"nozzle_temperature_range_high": [
+		"300"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Blocks/Blocks Generic PA-CF @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Blocks/Blocks Generic PA-CF @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Blocks Generic PA-CF @System",
+	"inherits": "Blocks Generic PA-CF @base",
+	"from": "system",
+	"setting_id": "BSSI007",
+	"filament_id": "BSFI007",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Blocks/Blocks Generic PA-CF @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Blocks/Blocks Generic PA-CF @base.json
@@ -1,0 +1,166 @@
+{
+	"type": "filament",
+	"name": "Blocks Generic PA-CF @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"0"
+	],
+	"eng_plate_temp": [
+		"100"
+	],
+	"hot_plate_temp": [
+		"90"
+	],
+	"textured_plate_temp": [
+		"100"
+	],
+	"cool_plate_temp_initial_layer": [
+		"0"
+	],
+	"eng_plate_temp_initial_layer": [
+		"100"
+	],
+	"hot_plate_temp_initial_layer": [
+		"90"
+	],
+	"textured_plate_temp_initial_layer": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"95%"
+	],
+	"overhang_fan_speed": [
+		"80%"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.95"
+	],
+	"reduce_fan_stop_start_freq": [
+		"0"
+	],
+	"fan_cooling_layer_time": [
+		"4"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.25"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"10"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"1.2"
+	],
+	"filament_z_hop": [
+		"0.0"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PA-CF"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"255"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"60"
+	],
+	"fan_min_speed": [
+		"0"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"2"
+	],
+	"filament_start_gcode": [
+		"; Filament gcode\n"
+	],
+	"nozzle_temperature": [
+		"250"
+	],
+	"temperature_vitrification": [
+		"108"
+	],
+	"nozzle_temperature_range_low": [
+		"240"
+	],
+	"nozzle_temperature_range_high": [
+		"290"
+	],
+	"enable_overhang_bridge_fan": [
+		"1"
+	],
+	"additional_cooling_fan_speed": [
+		"0"
+	],
+	"activate_air_filtration": [
+		"1"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"100"
+	],
+	"during_print_exhaust_fan_speed": [
+		"80"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Blocks/Blocks Generic PC @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Blocks/Blocks Generic PC @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Blocks Generic PC @System",
+	"inherits": "Blocks Generic PC @base",
+	"from": "system",
+	"setting_id": "BSSI008",
+	"filament_id": "BSFI008",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Blocks/Blocks Generic PC @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Blocks/Blocks Generic PC @base.json
@@ -1,0 +1,151 @@
+{
+	"type": "filament",
+	"name": "Blocks Generic PC @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"0"
+	],
+	"eng_plate_temp": [
+		"100"
+	],
+	"hot_plate_temp": [
+		"100"
+	],
+	"textured_plate_temp": [
+		"100"
+	],
+	"cool_plate_temp_initial_layer": [
+		"0"
+	],
+	"eng_plate_temp_initial_layer": [
+		"100"
+	],
+	"hot_plate_temp_initial_layer": [
+		"100"
+	],
+	"textured_plate_temp_initial_layer": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"overhang_fan_speed": [
+		"60"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.94"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.04"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"10"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PC"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"270"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"50"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"2"
+	],
+	"filament_start_gcode": [
+		"; Filament gcode\n"
+	],
+	"nozzle_temperature": [
+		"270"
+	],
+	"temperature_vitrification": [
+		"140"
+	],
+	"nozzle_temperature_range_low": [
+		"250"
+	],
+	"nozzle_temperature_range_high": [
+		"280"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Blocks/Blocks Generic PETG @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Blocks/Blocks Generic PETG @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Blocks Generic PETG @System",
+	"inherits": "Blocks Generic PETG @base",
+	"from": "system",
+	"setting_id": "BSSI002",
+	"filament_id": "BSFI002",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Blocks/Blocks Generic PETG @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Blocks/Blocks Generic PETG @base.json
@@ -1,0 +1,169 @@
+{
+	"type": "filament",
+	"name": "Blocks Generic PETG @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"70"
+	],
+	"hot_plate_temp": [
+		"70"
+	],
+	"textured_plate_temp": [
+		"70"
+	],
+	"cool_plate_temp_initial_layer": [
+		"70"
+	],
+	"eng_plate_temp_initial_layer": [
+		"70"
+	],
+	"hot_plate_temp_initial_layer": [
+		"70"
+	],
+	"textured_plate_temp_initial_layer": [
+		"70"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"overhang_fan_speed": [
+		"100%"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.94"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"filament_cost": [
+		"30"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"12"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"1.0"
+	],
+	"filament_z_hop": [
+		"0.0"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PETG"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"250"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"80"
+	],
+	"fan_min_speed": [
+		"40"
+	],
+	"slow_down_min_speed": [
+		"30"
+	],
+	"slow_down_layer_time": [
+		"5"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n"
+	],
+	"nozzle_temperature": [
+		"245"
+	],
+	"temperature_vitrification": [
+		"70"
+	],
+	"nozzle_temperature_range_low": [
+		"210"
+	],
+	"nozzle_temperature_range_high": [
+		"270"
+	],
+	"additional_cooling_fan_speed": [
+		"40"
+	],
+	"filament_shrink": [
+		"99.9%"
+	],
+	"enable_overhang_bridge_fan": [
+		"1"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"80"
+	],
+	"activate_air_filtration": [
+		"1"
+	],
+	"during_print_exhaust_fan_speed": [
+		"100"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Blocks/Blocks Generic PLA @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Blocks/Blocks Generic PLA @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Blocks Generic PLA @System",
+	"inherits": "Blocks Generic PLA @base",
+	"from": "system",
+	"setting_id": "BSSI001",
+	"filament_id": "BSFI001",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Blocks/Blocks Generic PLA @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Blocks/Blocks Generic PLA @base.json
@@ -1,0 +1,163 @@
+{
+	"type": "filament",
+	"name": "Blocks Generic PLA @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"50"
+	],
+	"eng_plate_temp": [
+		"50"
+	],
+	"hot_plate_temp": [
+		"50"
+	],
+	"textured_plate_temp": [
+		"50"
+	],
+	"cool_plate_temp_initial_layer": [
+		"50"
+	],
+	"eng_plate_temp_initial_layer": [
+		"50"
+	],
+	"hot_plate_temp_initial_layer": [
+		"50"
+	],
+	"textured_plate_temp_initial_layer": [
+		"50"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.95"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"filament_cost": [
+		"30"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"18"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PLA"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"210"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"slow_down_min_speed": [
+		"30"
+	],
+	"slow_down_layer_time": [
+		"5"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n"
+	],
+	"nozzle_temperature": [
+		"210"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"230"
+	],
+	"additional_cooling_fan_speed": [
+		"100"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"80"
+	],
+	"activate_air_filtration": [
+		"1"
+	],
+	"during_print_exhaust_fan_speed": [
+		"100"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Blocks/Blocks Generic PLA-CF @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Blocks/Blocks Generic PLA-CF @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Blocks Generic PLA-CF @System",
+	"inherits": "Blocks Generic PLA-CF @base",
+	"from": "system",
+	"setting_id": "BSSI010",
+	"filament_id": "BSFI010",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Blocks/Blocks Generic PLA-CF @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Blocks/Blocks Generic PLA-CF @base.json
@@ -1,0 +1,154 @@
+{
+	"type": "filament",
+	"name": "Blocks Generic PLA-CF @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"50"
+	],
+	"eng_plate_temp": [
+		"50"
+	],
+	"hot_plate_temp": [
+		"50"
+	],
+	"textured_plate_temp": [
+		"50"
+	],
+	"cool_plate_temp_initial_layer": [
+		"50"
+	],
+	"eng_plate_temp_initial_layer": [
+		"50"
+	],
+	"hot_plate_temp_initial_layer": [
+		"50"
+	],
+	"textured_plate_temp_initial_layer": [
+		"50"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.95"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"filament_cost": [
+		"30"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"20"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PLA-CF"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"220"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"slow_down_min_speed": [
+		"5"
+	],
+	"slow_down_layer_time": [
+		"7"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n"
+	],
+	"nozzle_temperature": [
+		"220"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"230"
+	],
+	"additional_cooling_fan_speed": [
+		"0"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Blocks/Blocks Generic PVA @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Blocks/Blocks Generic PVA @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Blocks Generic PVA @System",
+	"inherits": "Blocks Generic PVA @base",
+	"from": "system",
+	"setting_id": "BSSI009",
+	"filament_id": "BSFI009",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Blocks/Blocks Generic PVA @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Blocks/Blocks Generic PVA @base.json
@@ -1,0 +1,157 @@
+{
+	"type": "filament",
+	"name": "Blocks Generic PVA @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"35"
+	],
+	"eng_plate_temp": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"45"
+	],
+	"textured_plate_temp": [
+		"45"
+	],
+	"cool_plate_temp_initial_layer": [
+		"35"
+	],
+	"eng_plate_temp_initial_layer": [
+		"0"
+	],
+	"hot_plate_temp_initial_layer": [
+		"45"
+	],
+	"textured_plate_temp_initial_layer": [
+		"45"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"20"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"1"
+	],
+	"filament_type": [
+		"PVA"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"220"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"4"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n"
+	],
+	"nozzle_temperature": [
+		"220"
+	],
+	"temperature_vitrification": [
+		"50"
+	],
+	"filament_is_support": [
+		"1"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"250"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Blocks/Blocks Generic TPU @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Blocks/Blocks Generic TPU @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Blocks Generic TPU @System",
+	"inherits": "Blocks Generic TPU @base",
+	"from": "system",
+	"setting_id": "BSSI003",
+	"filament_id": "BSFI003",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Blocks/Blocks Generic TPU @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Blocks/Blocks Generic TPU @base.json
@@ -1,0 +1,166 @@
+{
+	"type": "filament",
+	"name": "Blocks Generic TPU @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"40"
+	],
+	"eng_plate_temp": [
+		"40"
+	],
+	"hot_plate_temp": [
+		"90"
+	],
+	"textured_plate_temp": [
+		"40"
+	],
+	"cool_plate_temp_initial_layer": [
+		"40"
+	],
+	"eng_plate_temp_initial_layer": [
+		"40"
+	],
+	"hot_plate_temp_initial_layer": [
+		"90"
+	],
+	"textured_plate_temp_initial_layer": [
+		"50"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.95"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"filament_cost": [
+		"35"
+	],
+	"filament_density": [
+		"1.25"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"4"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"TPU"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"250"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"slow_down_min_speed": [
+		"5"
+	],
+	"slow_down_layer_time": [
+		"5"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n"
+	],
+	"nozzle_temperature": [
+		"250"
+	],
+	"temperature_vitrification": [
+		"50"
+	],
+	"nozzle_temperature_range_low": [
+		"240"
+	],
+	"nozzle_temperature_range_high": [
+		"280"
+	],
+	"additional_cooling_fan_speed": [
+		"60"
+	],
+	"filament_shrink": [
+		"99.5%"
+	],
+	"activate_air_filtration": [
+		"1"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"100"
+	],
+	"during_print_exhaust_fan_speed": [
+		"80"
+	]
+}


### PR DESCRIPTION
## Summary

Migrates the Blocks filament presets into OrcaFilamentLibrary while preserving the existing Blocks printer compatibility constraints on the vendor-scoped profiles.

## Changes

- Added Blocks ABS, ASA, ASA-CF, PA, PA-CF, PC, PETG, PLA, PLA-CF, PVA, and TPU `@base`/`@System` presets under `OrcaFilamentLibrary`.
- Updated the Blocks vendor-scoped filament presets to inherit from the new library bases.
- Registered the new Blocks OrcaFilamentLibrary entries in `resources/profiles/OrcaFilamentLibrary.json`.

## Testing

- `python3 scripts/orca_extra_profile_check.py --vendor Blocks --check-filaments --check-materials --check-obsolete-keys`
- `git diff --check`

Refs OrcaSlicer/OrcaSlicer#12162
