### PR TITLE
Migrate RatRig filaments to OrcaFilamentLibrary

### DIFF
--- a/resources/profiles/OrcaFilamentLibrary.json
+++ b/resources/profiles/OrcaFilamentLibrary.json
@@ -1507,6 +1507,166 @@
 		{
 			"name": "GreenGate3D PETG @System",
 			"sub_path": "filament/GreenGate3D/GreenGate3D PETG @System.json"
+		},
+		{
+			"name": "RatRig BigNozzle ABS @base",
+			"sub_path": "filament/RatRig/RatRig BigNozzle ABS @base.json"
+		},
+		{
+			"name": "RatRig BigNozzle ABS @System",
+			"sub_path": "filament/RatRig/RatRig BigNozzle ABS @System.json"
+		},
+		{
+			"name": "RatRig BigNozzle ASA @base",
+			"sub_path": "filament/RatRig/RatRig BigNozzle ASA @base.json"
+		},
+		{
+			"name": "RatRig BigNozzle ASA @System",
+			"sub_path": "filament/RatRig/RatRig BigNozzle ASA @System.json"
+		},
+		{
+			"name": "RatRig BigNozzle PCTG @base",
+			"sub_path": "filament/RatRig/RatRig BigNozzle PCTG @base.json"
+		},
+		{
+			"name": "RatRig BigNozzle PCTG @System",
+			"sub_path": "filament/RatRig/RatRig BigNozzle PCTG @System.json"
+		},
+		{
+			"name": "RatRig BigNozzle PETG @base",
+			"sub_path": "filament/RatRig/RatRig BigNozzle PETG @base.json"
+		},
+		{
+			"name": "RatRig BigNozzle PETG @System",
+			"sub_path": "filament/RatRig/RatRig BigNozzle PETG @System.json"
+		},
+		{
+			"name": "RatRig BigNozzle PLA @base",
+			"sub_path": "filament/RatRig/RatRig BigNozzle PLA @base.json"
+		},
+		{
+			"name": "RatRig BigNozzle PLA @System",
+			"sub_path": "filament/RatRig/RatRig BigNozzle PLA @System.json"
+		},
+		{
+			"name": "RatRig BigNozzle TPU @base",
+			"sub_path": "filament/RatRig/RatRig BigNozzle TPU @base.json"
+		},
+		{
+			"name": "RatRig BigNozzle TPU @System",
+			"sub_path": "filament/RatRig/RatRig BigNozzle TPU @System.json"
+		},
+		{
+			"name": "RatRig Generic ABS @base",
+			"sub_path": "filament/RatRig/RatRig Generic ABS @base.json"
+		},
+		{
+			"name": "RatRig Generic ABS @System",
+			"sub_path": "filament/RatRig/RatRig Generic ABS @System.json"
+		},
+		{
+			"name": "RatRig Generic ASA @base",
+			"sub_path": "filament/RatRig/RatRig Generic ASA @base.json"
+		},
+		{
+			"name": "RatRig Generic ASA @System",
+			"sub_path": "filament/RatRig/RatRig Generic ASA @System.json"
+		},
+		{
+			"name": "RatRig Generic PA-CF @base",
+			"sub_path": "filament/RatRig/RatRig Generic PA-CF @base.json"
+		},
+		{
+			"name": "RatRig Generic PA-CF @System",
+			"sub_path": "filament/RatRig/RatRig Generic PA-CF @System.json"
+		},
+		{
+			"name": "RatRig Generic PA @base",
+			"sub_path": "filament/RatRig/RatRig Generic PA @base.json"
+		},
+		{
+			"name": "RatRig Generic PA @System",
+			"sub_path": "filament/RatRig/RatRig Generic PA @System.json"
+		},
+		{
+			"name": "RatRig Generic PC @base",
+			"sub_path": "filament/RatRig/RatRig Generic PC @base.json"
+		},
+		{
+			"name": "RatRig Generic PC @System",
+			"sub_path": "filament/RatRig/RatRig Generic PC @System.json"
+		},
+		{
+			"name": "RatRig Generic PCTG @base",
+			"sub_path": "filament/RatRig/RatRig Generic PCTG @base.json"
+		},
+		{
+			"name": "RatRig Generic PCTG @System",
+			"sub_path": "filament/RatRig/RatRig Generic PCTG @System.json"
+		},
+		{
+			"name": "RatRig Generic PETG @base",
+			"sub_path": "filament/RatRig/RatRig Generic PETG @base.json"
+		},
+		{
+			"name": "RatRig Generic PETG @System",
+			"sub_path": "filament/RatRig/RatRig Generic PETG @System.json"
+		},
+		{
+			"name": "RatRig Generic PLA-CF @base",
+			"sub_path": "filament/RatRig/RatRig Generic PLA-CF @base.json"
+		},
+		{
+			"name": "RatRig Generic PLA-CF @System",
+			"sub_path": "filament/RatRig/RatRig Generic PLA-CF @System.json"
+		},
+		{
+			"name": "RatRig Generic PLA @base",
+			"sub_path": "filament/RatRig/RatRig Generic PLA @base.json"
+		},
+		{
+			"name": "RatRig Generic PLA @System",
+			"sub_path": "filament/RatRig/RatRig Generic PLA @System.json"
+		},
+		{
+			"name": "RatRig Generic PVA @base",
+			"sub_path": "filament/RatRig/RatRig Generic PVA @base.json"
+		},
+		{
+			"name": "RatRig Generic PVA @System",
+			"sub_path": "filament/RatRig/RatRig Generic PVA @System.json"
+		},
+		{
+			"name": "RatRig Generic TPU @base",
+			"sub_path": "filament/RatRig/RatRig Generic TPU @base.json"
+		},
+		{
+			"name": "RatRig Generic TPU @System",
+			"sub_path": "filament/RatRig/RatRig Generic TPU @System.json"
+		},
+		{
+			"name": "RatRig PunkFil ABS @base",
+			"sub_path": "filament/RatRig/RatRig PunkFil ABS @base.json"
+		},
+		{
+			"name": "RatRig PunkFil ABS @System",
+			"sub_path": "filament/RatRig/RatRig PunkFil ABS @System.json"
+		},
+		{
+			"name": "RatRig PunkFil PETG CF @base",
+			"sub_path": "filament/RatRig/RatRig PunkFil PETG CF @base.json"
+		},
+		{
+			"name": "RatRig PunkFil PETG CF @System",
+			"sub_path": "filament/RatRig/RatRig PunkFil PETG CF @System.json"
+		},
+		{
+			"name": "RatRig PunkFil PETG @base",
+			"sub_path": "filament/RatRig/RatRig PunkFil PETG @base.json"
+		},
+		{
+			"name": "RatRig PunkFil PETG @System",
+			"sub_path": "filament/RatRig/RatRig PunkFil PETG @System.json"
 		}
 	],
 	"process_list": [],

--- a/resources/profiles/OrcaFilamentLibrary/filament/RatRig/RatRig BigNozzle ABS @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/RatRig/RatRig BigNozzle ABS @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "RatRig BigNozzle ABS @System",
+	"inherits": "RatRig BigNozzle ABS @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFB99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/RatRig/RatRig BigNozzle ABS @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/RatRig/RatRig BigNozzle ABS @base.json
@@ -1,0 +1,154 @@
+{
+	"type": "filament",
+	"name": "RatRig BigNozzle ABS @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"105"
+	],
+	"eng_plate_temp": [
+		"105"
+	],
+	"hot_plate_temp": [
+		"105"
+	],
+	"textured_plate_temp": [
+		"105"
+	],
+	"cool_plate_temp_initial_layer": [
+		"105"
+	],
+	"eng_plate_temp_initial_layer": [
+		"105"
+	],
+	"hot_plate_temp_initial_layer": [
+		"108"
+	],
+	"textured_plate_temp_initial_layer": [
+		"105"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"overhang_fan_speed": [
+		"30"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"2"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.94"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"10"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.04"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"18"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"0"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"ABS"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"270"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"30"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"3"
+	],
+	"filament_start_gcode": [
+		"; Filament gcode\n"
+	],
+	"nozzle_temperature": [
+		"265"
+	],
+	"temperature_vitrification": [
+		"110"
+	],
+	"nozzle_temperature_range_low": [
+		"240"
+	],
+	"nozzle_temperature_range_high": [
+		"290"
+	],
+	"enable_pressure_advance": [
+		"1"
+	],
+	"pressure_advance": [
+		"0.03"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/RatRig/RatRig BigNozzle ASA @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/RatRig/RatRig BigNozzle ASA @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "RatRig BigNozzle ASA @System",
+	"inherits": "RatRig BigNozzle ASA @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFB98",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/RatRig/RatRig BigNozzle ASA @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/RatRig/RatRig BigNozzle ASA @base.json
@@ -1,0 +1,154 @@
+{
+	"type": "filament",
+	"name": "RatRig BigNozzle ASA @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"105"
+	],
+	"eng_plate_temp": [
+		"105"
+	],
+	"hot_plate_temp": [
+		"105"
+	],
+	"textured_plate_temp": [
+		"105"
+	],
+	"cool_plate_temp_initial_layer": [
+		"105"
+	],
+	"eng_plate_temp_initial_layer": [
+		"105"
+	],
+	"hot_plate_temp_initial_layer": [
+		"108"
+	],
+	"textured_plate_temp_initial_layer": [
+		"105"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"overhang_fan_speed": [
+		"28"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"2"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.92"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"10"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.04"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"19"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"0"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"ASA"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"270"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"30"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"3"
+	],
+	"filament_start_gcode": [
+		"; Filament gcode\n"
+	],
+	"nozzle_temperature": [
+		"265"
+	],
+	"temperature_vitrification": [
+		"110"
+	],
+	"nozzle_temperature_range_low": [
+		"240"
+	],
+	"nozzle_temperature_range_high": [
+		"290"
+	],
+	"enable_pressure_advance": [
+		"1"
+	],
+	"pressure_advance": [
+		"0.033"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/RatRig/RatRig BigNozzle PCTG @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/RatRig/RatRig BigNozzle PCTG @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "RatRig BigNozzle PCTG @System",
+	"inherits": "RatRig BigNozzle PCTG @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFC99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/RatRig/RatRig BigNozzle PCTG @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/RatRig/RatRig BigNozzle PCTG @base.json
@@ -1,0 +1,154 @@
+{
+	"type": "filament",
+	"name": "RatRig BigNozzle PCTG @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"60"
+	],
+	"eng_plate_temp": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"80"
+	],
+	"textured_plate_temp": [
+		"80"
+	],
+	"cool_plate_temp_initial_layer": [
+		"60"
+	],
+	"eng_plate_temp_initial_layer": [
+		"0"
+	],
+	"hot_plate_temp_initial_layer": [
+		"80"
+	],
+	"textured_plate_temp_initial_layer": [
+		"80"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"overhang_fan_speed": [
+		"90"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.92"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"filament_cost": [
+		"30"
+	],
+	"filament_density": [
+		"1.29"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"12"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"0"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PETG"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"280"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"50"
+	],
+	"fan_min_speed": [
+		"15"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"8"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n"
+	],
+	"nozzle_temperature": [
+		"275"
+	],
+	"temperature_vitrification": [
+		"90"
+	],
+	"nozzle_temperature_range_low": [
+		"240"
+	],
+	"nozzle_temperature_range_high": [
+		"300"
+	],
+	"enable_pressure_advance": [
+		"1"
+	],
+	"pressure_advance": [
+		"0.045"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/RatRig/RatRig BigNozzle PETG @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/RatRig/RatRig BigNozzle PETG @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "RatRig BigNozzle PETG @System",
+	"inherits": "RatRig BigNozzle PETG @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFG99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/RatRig/RatRig BigNozzle PETG @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/RatRig/RatRig BigNozzle PETG @base.json
@@ -1,0 +1,154 @@
+{
+	"type": "filament",
+	"name": "RatRig BigNozzle PETG @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"60"
+	],
+	"eng_plate_temp": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"80"
+	],
+	"textured_plate_temp": [
+		"80"
+	],
+	"cool_plate_temp_initial_layer": [
+		"60"
+	],
+	"eng_plate_temp_initial_layer": [
+		"0"
+	],
+	"hot_plate_temp_initial_layer": [
+		"80"
+	],
+	"textured_plate_temp_initial_layer": [
+		"80"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.92"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"10"
+	],
+	"filament_cost": [
+		"30"
+	],
+	"filament_density": [
+		"1.27"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"12"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"0"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PETG"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"260"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"90"
+	],
+	"fan_min_speed": [
+		"40"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"8"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n"
+	],
+	"nozzle_temperature": [
+		"255"
+	],
+	"temperature_vitrification": [
+		"80"
+	],
+	"nozzle_temperature_range_low": [
+		"230"
+	],
+	"nozzle_temperature_range_high": [
+		"280"
+	],
+	"enable_pressure_advance": [
+		"1"
+	],
+	"pressure_advance": [
+		"0.045"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/RatRig/RatRig BigNozzle PLA @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/RatRig/RatRig BigNozzle PLA @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "RatRig BigNozzle PLA @System",
+	"inherits": "RatRig BigNozzle PLA @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFL99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/RatRig/RatRig BigNozzle PLA @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/RatRig/RatRig BigNozzle PLA @base.json
@@ -1,0 +1,157 @@
+{
+	"type": "filament",
+	"name": "RatRig BigNozzle PLA @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"60"
+	],
+	"eng_plate_temp": [
+		"60"
+	],
+	"hot_plate_temp": [
+		"60"
+	],
+	"textured_plate_temp": [
+		"60"
+	],
+	"cool_plate_temp_initial_layer": [
+		"60"
+	],
+	"eng_plate_temp_initial_layer": [
+		"60"
+	],
+	"hot_plate_temp_initial_layer": [
+		"60"
+	],
+	"textured_plate_temp_initial_layer": [
+		"60"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.94"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"20"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"0"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PLA"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"230"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"8"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n"
+	],
+	"nozzle_temperature": [
+		"235"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"nozzle_temperature_range_low": [
+		"210"
+	],
+	"nozzle_temperature_range_high": [
+		"260"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"enable_pressure_advance": [
+		"1"
+	],
+	"pressure_advance": [
+		"0.05"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/RatRig/RatRig BigNozzle TPU @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/RatRig/RatRig BigNozzle TPU @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "RatRig BigNozzle TPU @System",
+	"inherits": "RatRig BigNozzle TPU @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFL99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/RatRig/RatRig BigNozzle TPU @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/RatRig/RatRig BigNozzle TPU @base.json
@@ -1,0 +1,157 @@
+{
+	"type": "filament",
+	"name": "RatRig BigNozzle TPU @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"30"
+	],
+	"eng_plate_temp": [
+		"30"
+	],
+	"hot_plate_temp": [
+		"35"
+	],
+	"textured_plate_temp": [
+		"35"
+	],
+	"cool_plate_temp_initial_layer": [
+		"30"
+	],
+	"eng_plate_temp_initial_layer": [
+		"30"
+	],
+	"hot_plate_temp_initial_layer": [
+		"35"
+	],
+	"textured_plate_temp_initial_layer": [
+		"35"
+	],
+	"overhang_fan_threshold": [
+		"95%"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"1"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"5"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"0.4"
+	],
+	"filament_z_hop": [
+		"0"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"TPU"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"240"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"8"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n"
+	],
+	"nozzle_temperature": [
+		"245"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"nozzle_temperature_range_low": [
+		"220"
+	],
+	"nozzle_temperature_range_high": [
+		"270"
+	],
+	"enable_pressure_advance": [
+		"1"
+	],
+	"pressure_advance": [
+		"0.1"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/RatRig/RatRig Generic ABS @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/RatRig/RatRig Generic ABS @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "RatRig Generic ABS @System",
+	"inherits": "RatRig Generic ABS @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFB99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/RatRig/RatRig Generic ABS @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/RatRig/RatRig Generic ABS @base.json
@@ -1,0 +1,154 @@
+{
+	"type": "filament",
+	"name": "RatRig Generic ABS @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"105"
+	],
+	"eng_plate_temp": [
+		"105"
+	],
+	"hot_plate_temp": [
+		"105"
+	],
+	"textured_plate_temp": [
+		"105"
+	],
+	"cool_plate_temp_initial_layer": [
+		"105"
+	],
+	"eng_plate_temp_initial_layer": [
+		"105"
+	],
+	"hot_plate_temp_initial_layer": [
+		"108"
+	],
+	"textured_plate_temp_initial_layer": [
+		"105"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"overhang_fan_speed": [
+		"30"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"2"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.980"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"10"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.04"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"18"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"0"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"ABS"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"248"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"30"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"3"
+	],
+	"filament_start_gcode": [
+		"; Filament gcode\n"
+	],
+	"nozzle_temperature": [
+		"243"
+	],
+	"temperature_vitrification": [
+		"110"
+	],
+	"nozzle_temperature_range_low": [
+		"240"
+	],
+	"nozzle_temperature_range_high": [
+		"270"
+	],
+	"enable_pressure_advance": [
+		"1"
+	],
+	"pressure_advance": [
+		"0.03"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/RatRig/RatRig Generic ASA @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/RatRig/RatRig Generic ASA @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "RatRig Generic ASA @System",
+	"inherits": "RatRig Generic ASA @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFB98",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/RatRig/RatRig Generic ASA @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/RatRig/RatRig Generic ASA @base.json
@@ -1,0 +1,154 @@
+{
+	"type": "filament",
+	"name": "RatRig Generic ASA @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"105"
+	],
+	"eng_plate_temp": [
+		"105"
+	],
+	"hot_plate_temp": [
+		"105"
+	],
+	"textured_plate_temp": [
+		"105"
+	],
+	"cool_plate_temp_initial_layer": [
+		"105"
+	],
+	"eng_plate_temp_initial_layer": [
+		"105"
+	],
+	"hot_plate_temp_initial_layer": [
+		"105"
+	],
+	"textured_plate_temp_initial_layer": [
+		"105"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"overhang_fan_speed": [
+		"25"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"2"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.93"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"10"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.1"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"19"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"0"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"ASA"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"260"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"30"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"3"
+	],
+	"filament_start_gcode": [
+		"; Filament gcode\n"
+	],
+	"nozzle_temperature": [
+		"260"
+	],
+	"temperature_vitrification": [
+		"110"
+	],
+	"nozzle_temperature_range_low": [
+		"240"
+	],
+	"nozzle_temperature_range_high": [
+		"270"
+	],
+	"enable_pressure_advance": [
+		"1"
+	],
+	"pressure_advance": [
+		"0.033"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/RatRig/RatRig Generic PA @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/RatRig/RatRig Generic PA @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "RatRig Generic PA @System",
+	"inherits": "RatRig Generic PA @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFN99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/RatRig/RatRig Generic PA @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/RatRig/RatRig Generic PA @base.json
@@ -1,0 +1,154 @@
+{
+	"type": "filament",
+	"name": "RatRig Generic PA @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"0"
+	],
+	"eng_plate_temp": [
+		"100"
+	],
+	"hot_plate_temp": [
+		"80"
+	],
+	"textured_plate_temp": [
+		"100"
+	],
+	"cool_plate_temp_initial_layer": [
+		"0"
+	],
+	"eng_plate_temp_initial_layer": [
+		"100"
+	],
+	"hot_plate_temp_initial_layer": [
+		"80"
+	],
+	"textured_plate_temp_initial_layer": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"95%"
+	],
+	"overhang_fan_speed": [
+		"50"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"1"
+	],
+	"reduce_fan_stop_start_freq": [
+		"0"
+	],
+	"fan_cooling_layer_time": [
+		"4"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"8"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"0"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PA"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"270"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"60"
+	],
+	"fan_min_speed": [
+		"0"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"2"
+	],
+	"filament_start_gcode": [
+		"; Filament gcode\n"
+	],
+	"nozzle_temperature": [
+		"270"
+	],
+	"temperature_vitrification": [
+		"108"
+	],
+	"nozzle_temperature_range_low": [
+		"270"
+	],
+	"nozzle_temperature_range_high": [
+		"280"
+	],
+	"enable_pressure_advance": [
+		"1"
+	],
+	"pressure_advance": [
+		"0.045"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/RatRig/RatRig Generic PA-CF @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/RatRig/RatRig Generic PA-CF @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "RatRig Generic PA-CF @System",
+	"inherits": "RatRig Generic PA-CF @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFN98",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/RatRig/RatRig Generic PA-CF @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/RatRig/RatRig Generic PA-CF @base.json
@@ -1,0 +1,154 @@
+{
+	"type": "filament",
+	"name": "RatRig Generic PA-CF @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"0"
+	],
+	"eng_plate_temp": [
+		"100"
+	],
+	"hot_plate_temp": [
+		"80"
+	],
+	"textured_plate_temp": [
+		"100"
+	],
+	"cool_plate_temp_initial_layer": [
+		"0"
+	],
+	"eng_plate_temp_initial_layer": [
+		"100"
+	],
+	"hot_plate_temp_initial_layer": [
+		"80"
+	],
+	"textured_plate_temp_initial_layer": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"95%"
+	],
+	"overhang_fan_speed": [
+		"50"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"1"
+	],
+	"reduce_fan_stop_start_freq": [
+		"0"
+	],
+	"fan_cooling_layer_time": [
+		"4"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"8"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"0"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PA-CF"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"270"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"60"
+	],
+	"fan_min_speed": [
+		"0"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"2"
+	],
+	"filament_start_gcode": [
+		"; Filament gcode\n"
+	],
+	"nozzle_temperature": [
+		"270"
+	],
+	"temperature_vitrification": [
+		"108"
+	],
+	"nozzle_temperature_range_low": [
+		"270"
+	],
+	"nozzle_temperature_range_high": [
+		"280"
+	],
+	"enable_pressure_advance": [
+		"1"
+	],
+	"pressure_advance": [
+		"0.045"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/RatRig/RatRig Generic PC @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/RatRig/RatRig Generic PC @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "RatRig Generic PC @System",
+	"inherits": "RatRig Generic PC @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFC99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/RatRig/RatRig Generic PC @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/RatRig/RatRig Generic PC @base.json
@@ -1,0 +1,154 @@
+{
+	"type": "filament",
+	"name": "RatRig Generic PC @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"0"
+	],
+	"eng_plate_temp": [
+		"110"
+	],
+	"hot_plate_temp": [
+		"100"
+	],
+	"textured_plate_temp": [
+		"110"
+	],
+	"cool_plate_temp_initial_layer": [
+		"0"
+	],
+	"eng_plate_temp_initial_layer": [
+		"110"
+	],
+	"hot_plate_temp_initial_layer": [
+		"100"
+	],
+	"textured_plate_temp_initial_layer": [
+		"110"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"overhang_fan_speed": [
+		"60"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.93"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.04"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"12"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"0"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PC"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"280"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"60"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"2"
+	],
+	"filament_start_gcode": [
+		"; Filament gcode\n"
+	],
+	"nozzle_temperature": [
+		"280"
+	],
+	"temperature_vitrification": [
+		"140"
+	],
+	"nozzle_temperature_range_low": [
+		"260"
+	],
+	"nozzle_temperature_range_high": [
+		"290"
+	],
+	"enable_pressure_advance": [
+		"1"
+	],
+	"pressure_advance": [
+		"0.045"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/RatRig/RatRig Generic PCTG @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/RatRig/RatRig Generic PCTG @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "RatRig Generic PCTG @System",
+	"inherits": "RatRig Generic PCTG @base",
+	"from": "system",
+	"setting_id": "GFCA04",
+	"filament_id": "GFC99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/RatRig/RatRig Generic PCTG @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/RatRig/RatRig Generic PCTG @base.json
@@ -1,0 +1,154 @@
+{
+	"type": "filament",
+	"name": "RatRig Generic PCTG @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"60"
+	],
+	"eng_plate_temp": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"80"
+	],
+	"textured_plate_temp": [
+		"80"
+	],
+	"cool_plate_temp_initial_layer": [
+		"60"
+	],
+	"eng_plate_temp_initial_layer": [
+		"0"
+	],
+	"hot_plate_temp_initial_layer": [
+		"80"
+	],
+	"textured_plate_temp_initial_layer": [
+		"80"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"overhang_fan_speed": [
+		"90"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.93"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"filament_cost": [
+		"30"
+	],
+	"filament_density": [
+		"1.29"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"12"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"0"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PETG"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"260"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"40"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"8"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n"
+	],
+	"nozzle_temperature": [
+		"255"
+	],
+	"temperature_vitrification": [
+		"90"
+	],
+	"nozzle_temperature_range_low": [
+		"220"
+	],
+	"nozzle_temperature_range_high": [
+		"270"
+	],
+	"enable_pressure_advance": [
+		"1"
+	],
+	"pressure_advance": [
+		"0.045"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/RatRig/RatRig Generic PETG @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/RatRig/RatRig Generic PETG @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "RatRig Generic PETG @System",
+	"inherits": "RatRig Generic PETG @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFG99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/RatRig/RatRig Generic PETG @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/RatRig/RatRig Generic PETG @base.json
@@ -1,0 +1,154 @@
+{
+	"type": "filament",
+	"name": "RatRig Generic PETG @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"60"
+	],
+	"eng_plate_temp": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"80"
+	],
+	"textured_plate_temp": [
+		"80"
+	],
+	"cool_plate_temp_initial_layer": [
+		"60"
+	],
+	"eng_plate_temp_initial_layer": [
+		"0"
+	],
+	"hot_plate_temp_initial_layer": [
+		"80"
+	],
+	"textured_plate_temp_initial_layer": [
+		"80"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.94"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"10"
+	],
+	"filament_cost": [
+		"30"
+	],
+	"filament_density": [
+		"1.27"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"11"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"0"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PETG"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"240"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"40"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"8"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n"
+	],
+	"nozzle_temperature": [
+		"235"
+	],
+	"temperature_vitrification": [
+		"80"
+	],
+	"nozzle_temperature_range_low": [
+		"220"
+	],
+	"nozzle_temperature_range_high": [
+		"250"
+	],
+	"enable_pressure_advance": [
+		"1"
+	],
+	"pressure_advance": [
+		"0.045"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/RatRig/RatRig Generic PLA @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/RatRig/RatRig Generic PLA @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "RatRig Generic PLA @System",
+	"inherits": "RatRig Generic PLA @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFL99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/RatRig/RatRig Generic PLA @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/RatRig/RatRig Generic PLA @base.json
@@ -1,0 +1,157 @@
+{
+	"type": "filament",
+	"name": "RatRig Generic PLA @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"60"
+	],
+	"eng_plate_temp": [
+		"60"
+	],
+	"hot_plate_temp": [
+		"60"
+	],
+	"textured_plate_temp": [
+		"60"
+	],
+	"cool_plate_temp_initial_layer": [
+		"60"
+	],
+	"eng_plate_temp_initial_layer": [
+		"60"
+	],
+	"hot_plate_temp_initial_layer": [
+		"60"
+	],
+	"textured_plate_temp_initial_layer": [
+		"60"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.92"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"20"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"0"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PLA"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"205"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"8"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n"
+	],
+	"nozzle_temperature": [
+		"200"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"230"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"enable_pressure_advance": [
+		"1"
+	],
+	"pressure_advance": [
+		"0.05"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/RatRig/RatRig Generic PLA-CF @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/RatRig/RatRig Generic PLA-CF @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "RatRig Generic PLA-CF @System",
+	"inherits": "RatRig Generic PLA-CF @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFL98",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/RatRig/RatRig Generic PLA-CF @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/RatRig/RatRig Generic PLA-CF @base.json
@@ -1,0 +1,157 @@
+{
+	"type": "filament",
+	"name": "RatRig Generic PLA-CF @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"60"
+	],
+	"eng_plate_temp": [
+		"60"
+	],
+	"hot_plate_temp": [
+		"60"
+	],
+	"textured_plate_temp": [
+		"60"
+	],
+	"cool_plate_temp_initial_layer": [
+		"60"
+	],
+	"eng_plate_temp_initial_layer": [
+		"60"
+	],
+	"hot_plate_temp_initial_layer": [
+		"60"
+	],
+	"textured_plate_temp_initial_layer": [
+		"60"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.92"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"12"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"0"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PLA-CF"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"210"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"7"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n"
+	],
+	"nozzle_temperature": [
+		"205"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"230"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"enable_pressure_advance": [
+		"1"
+	],
+	"pressure_advance": [
+		"0.05"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/RatRig/RatRig Generic PVA @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/RatRig/RatRig Generic PVA @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "RatRig Generic PVA @System",
+	"inherits": "RatRig Generic PVA @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFS99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/RatRig/RatRig Generic PVA @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/RatRig/RatRig Generic PVA @base.json
@@ -1,0 +1,160 @@
+{
+	"type": "filament",
+	"name": "RatRig Generic PVA @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"35"
+	],
+	"eng_plate_temp": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"45"
+	],
+	"textured_plate_temp": [
+		"45"
+	],
+	"cool_plate_temp_initial_layer": [
+		"35"
+	],
+	"eng_plate_temp_initial_layer": [
+		"0"
+	],
+	"hot_plate_temp_initial_layer": [
+		"45"
+	],
+	"textured_plate_temp_initial_layer": [
+		"45"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.95"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"12"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"0"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"1"
+	],
+	"filament_type": [
+		"PVA"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"220"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"7"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n"
+	],
+	"nozzle_temperature": [
+		"220"
+	],
+	"temperature_vitrification": [
+		"50"
+	],
+	"filament_is_support": [
+		"1"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"250"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"enable_pressure_advance": [
+		"1"
+	],
+	"pressure_advance": [
+		"0.03"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/RatRig/RatRig Generic TPU @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/RatRig/RatRig Generic TPU @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "RatRig Generic TPU @System",
+	"inherits": "RatRig Generic TPU @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFU99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/RatRig/RatRig Generic TPU @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/RatRig/RatRig Generic TPU @base.json
@@ -1,0 +1,157 @@
+{
+	"type": "filament",
+	"name": "RatRig Generic TPU @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"30"
+	],
+	"eng_plate_temp": [
+		"30"
+	],
+	"hot_plate_temp": [
+		"35"
+	],
+	"textured_plate_temp": [
+		"35"
+	],
+	"cool_plate_temp_initial_layer": [
+		"30"
+	],
+	"eng_plate_temp_initial_layer": [
+		"30"
+	],
+	"hot_plate_temp_initial_layer": [
+		"35"
+	],
+	"textured_plate_temp_initial_layer": [
+		"35"
+	],
+	"overhang_fan_threshold": [
+		"95%"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"1"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"5"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"0.4"
+	],
+	"filament_z_hop": [
+		"0"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"TPU"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"220"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"8"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n"
+	],
+	"nozzle_temperature": [
+		"220"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"nozzle_temperature_range_low": [
+		"200"
+	],
+	"nozzle_temperature_range_high": [
+		"250"
+	],
+	"enable_pressure_advance": [
+		"1"
+	],
+	"pressure_advance": [
+		"0.1"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/RatRig/RatRig PunkFil ABS @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/RatRig/RatRig PunkFil ABS @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "RatRig PunkFil ABS @System",
+	"inherits": "RatRig PunkFil ABS @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFB99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/RatRig/RatRig PunkFil ABS @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/RatRig/RatRig PunkFil ABS @base.json
@@ -1,0 +1,154 @@
+{
+	"type": "filament",
+	"name": "RatRig PunkFil ABS @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"105"
+	],
+	"eng_plate_temp": [
+		"105"
+	],
+	"hot_plate_temp": [
+		"110"
+	],
+	"textured_plate_temp": [
+		"105"
+	],
+	"cool_plate_temp_initial_layer": [
+		"105"
+	],
+	"eng_plate_temp_initial_layer": [
+		"105"
+	],
+	"hot_plate_temp_initial_layer": [
+		"110"
+	],
+	"textured_plate_temp_initial_layer": [
+		"105"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"overhang_fan_speed": [
+		"60"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"2"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.92"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"7"
+	],
+	"filament_cost": [
+		"25.5"
+	],
+	"filament_density": [
+		"1.04"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"40"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"ABS"
+	],
+	"filament_vendor": [
+		"RatRig"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"260"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"60"
+	],
+	"fan_min_speed": [
+		"30"
+	],
+	"slow_down_min_speed": [
+		"50"
+	],
+	"slow_down_layer_time": [
+		"2"
+	],
+	"filament_start_gcode": [
+		"; Filament gcode\n"
+	],
+	"nozzle_temperature": [
+		"260"
+	],
+	"temperature_vitrification": [
+		"110"
+	],
+	"nozzle_temperature_range_low": [
+		"240"
+	],
+	"nozzle_temperature_range_high": [
+		"270"
+	],
+	"enable_pressure_advance": [
+		"1"
+	],
+	"pressure_advance": [
+		"0.022"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/RatRig/RatRig PunkFil PETG @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/RatRig/RatRig PunkFil PETG @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "RatRig PunkFil PETG @System",
+	"inherits": "RatRig PunkFil PETG @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFB99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/RatRig/RatRig PunkFil PETG @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/RatRig/RatRig PunkFil PETG @base.json
@@ -1,0 +1,154 @@
+{
+	"type": "filament",
+	"name": "RatRig PunkFil PETG @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"60"
+	],
+	"eng_plate_temp": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"80"
+	],
+	"textured_plate_temp": [
+		"80"
+	],
+	"cool_plate_temp_initial_layer": [
+		"60"
+	],
+	"eng_plate_temp_initial_layer": [
+		"0"
+	],
+	"hot_plate_temp_initial_layer": [
+		"80"
+	],
+	"textured_plate_temp_initial_layer": [
+		"80"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"overhang_fan_speed": [
+		"50"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"2"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.93"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"8"
+	],
+	"filament_cost": [
+		"24.5"
+	],
+	"filament_density": [
+		"1.27"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"40"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PETG"
+	],
+	"filament_vendor": [
+		"RatRig"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"235"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"60"
+	],
+	"fan_min_speed": [
+		"30"
+	],
+	"slow_down_min_speed": [
+		"50"
+	],
+	"slow_down_layer_time": [
+		"2"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n"
+	],
+	"nozzle_temperature": [
+		"235"
+	],
+	"temperature_vitrification": [
+		"80"
+	],
+	"nozzle_temperature_range_low": [
+		"220"
+	],
+	"nozzle_temperature_range_high": [
+		"260"
+	],
+	"enable_pressure_advance": [
+		"1"
+	],
+	"pressure_advance": [
+		"0.025"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/RatRig/RatRig PunkFil PETG CF @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/RatRig/RatRig PunkFil PETG CF @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "RatRig PunkFil PETG CF @System",
+	"inherits": "RatRig PunkFil PETG CF @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFB99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/RatRig/RatRig PunkFil PETG CF @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/RatRig/RatRig PunkFil PETG CF @base.json
@@ -1,0 +1,154 @@
+{
+	"type": "filament",
+	"name": "RatRig PunkFil PETG CF @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"60"
+	],
+	"eng_plate_temp": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"80"
+	],
+	"textured_plate_temp": [
+		"80"
+	],
+	"cool_plate_temp_initial_layer": [
+		"60"
+	],
+	"eng_plate_temp_initial_layer": [
+		"0"
+	],
+	"hot_plate_temp_initial_layer": [
+		"80"
+	],
+	"textured_plate_temp_initial_layer": [
+		"80"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"overhang_fan_speed": [
+		"40"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"2"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.93"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"10"
+	],
+	"filament_cost": [
+		"48"
+	],
+	"filament_density": [
+		"1.27"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"20"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PETG-CF10"
+	],
+	"filament_vendor": [
+		"RatRig"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"230"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"30"
+	],
+	"fan_min_speed": [
+		"0"
+	],
+	"slow_down_min_speed": [
+		"30"
+	],
+	"slow_down_layer_time": [
+		"8"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n"
+	],
+	"nozzle_temperature": [
+		"230"
+	],
+	"temperature_vitrification": [
+		"80"
+	],
+	"nozzle_temperature_range_low": [
+		"220"
+	],
+	"nozzle_temperature_range_high": [
+		"260"
+	],
+	"enable_pressure_advance": [
+		"1"
+	],
+	"pressure_advance": [
+		"0.038"
+	]
+}

--- a/resources/profiles/Ratrig/filament/RatRig BigNozzle ABS.json
+++ b/resources/profiles/Ratrig/filament/RatRig BigNozzle ABS.json
@@ -1,56 +1,11 @@
 {
 	"type": "filament",
 	"name": "RatRig BigNozzle ABS",
-	"inherits": "fdm_filament_abs",
+	"inherits": "RatRig BigNozzle ABS @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFB99",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"0.94"
-	],
-	"filament_max_volumetric_speed": [
-		"18"
-	],
-	"filament_z_hop": [
-		"0"
-	],
-	"enable_pressure_advance": [
-		"1"
-	],
-	"pressure_advance": [
-		"0.03"
-	],
-	"hot_plate_temp_initial_layer": [
-		"108"
-	],
-	"nozzle_temperature_initial_layer": [
-		"270"
-	],
-	"nozzle_temperature": [
-		"265"
-	],
-	"nozzle_temperature_range_low": [
-		"240"
-	],
-	"nozzle_temperature_range_high": [
-		"290"
-	],
-	"close_fan_the_first_x_layers": [
-		"2"
-	],
-	"fan_cooling_layer_time": [
-		"10"
-	],
-	"fan_max_speed": [
-		"30"
-	],
-	"fan_min_speed": [
-		"10"
-	],
-	"overhang_fan_speed": [
-		"30"
-	],
 	"compatible_printers": [
 		"RatRig V-Core 3 200 0.4 nozzle",
 		"RatRig V-Core 3 300 0.4 nozzle",

--- a/resources/profiles/Ratrig/filament/RatRig BigNozzle ASA.json
+++ b/resources/profiles/Ratrig/filament/RatRig BigNozzle ASA.json
@@ -1,56 +1,11 @@
 {
 	"type": "filament",
 	"name": "RatRig BigNozzle ASA",
-	"inherits": "fdm_filament_asa",
+	"inherits": "RatRig BigNozzle ASA @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFB98",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"0.92"
-	],
-	"filament_max_volumetric_speed": [
-		"19"
-	],
-	"filament_z_hop": [
-		"0"
-	],
-	"enable_pressure_advance": [
-		"1"
-	],
-	"pressure_advance": [
-		"0.033"
-	],
-	"hot_plate_temp_initial_layer": [
-		"108"
-	],
-	"nozzle_temperature_initial_layer": [
-		"270"
-	],
-	"nozzle_temperature": [
-		"265"
-	],
-	"nozzle_temperature_range_low": [
-		"240"
-	],
-	"nozzle_temperature_range_high": [
-		"290"
-	],
-	"close_fan_the_first_x_layers": [
-		"2"
-	],
-	"fan_cooling_layer_time": [
-		"10"
-	],
-	"fan_max_speed": [
-		"30"
-	],
-	"fan_min_speed": [
-		"10"
-	],
-	"overhang_fan_speed": [
-		"28"
-	],
 	"compatible_printers": [
 		"RatRig V-Core 3 200 0.4 nozzle",
 		"RatRig V-Core 3 300 0.4 nozzle",

--- a/resources/profiles/Ratrig/filament/RatRig BigNozzle PCTG.json
+++ b/resources/profiles/Ratrig/filament/RatRig BigNozzle PCTG.json
@@ -1,71 +1,11 @@
 {
 	"type": "filament",
 	"name": "RatRig BigNozzle PCTG",
-	"inherits": "fdm_filament_pet",
+	"inherits": "RatRig BigNozzle PCTG @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFC99",
 	"instantiation": "true",
-	"reduce_fan_stop_start_freq": [
-		"1"
-	],
-	"slow_down_for_layer_cooling": [
-		"1"
-	],
-	"fan_cooling_layer_time": [
-		"30"
-	],
-	"overhang_fan_speed": [
-		"90"
-	],
-	"overhang_fan_threshold": [
-		"25%"
-	],
-	"fan_max_speed": [
-		"50"
-	],
-	"fan_min_speed": [
-		"15"
-	],
-	"slow_down_min_speed": [
-		"10"
-	],
-	"slow_down_layer_time": [
-		"8"
-	],
-	"filament_flow_ratio": [
-		"0.92"
-	],
-	"filament_density": [
-		"1.29"
-	],
-	"filament_max_volumetric_speed": [
-		"12"
-	],
-	"filament_z_hop": [
-		"0"
-	],
-	"enable_pressure_advance": [
-		"1"
-	],
-	"pressure_advance": [
-		"0.045"
-	],
-	"nozzle_temperature_initial_layer": [
-		"280"
-	],
-	"nozzle_temperature": [
-		"275"
-	],
-	"nozzle_temperature_range_high": [
-		"300"
-	],
-	"nozzle_temperature_range_low": [
-		"240"
-	],
-	"temperature_vitrification": [
-		"90"
-	],
 	"compatible_printers": [
 		"RatRig V-Core 3 200 0.4 nozzle",
 		"RatRig V-Core 3 300 0.4 nozzle",

--- a/resources/profiles/Ratrig/filament/RatRig BigNozzle PETG.json
+++ b/resources/profiles/Ratrig/filament/RatRig BigNozzle PETG.json
@@ -1,65 +1,11 @@
 {
 	"type": "filament",
 	"name": "RatRig BigNozzle PETG",
-	"inherits": "fdm_filament_pet",
+	"inherits": "RatRig BigNozzle PETG @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFG99",
 	"instantiation": "true",
-	"reduce_fan_stop_start_freq": [
-		"1"
-	],
-	"slow_down_for_layer_cooling": [
-		"1"
-	],
-	"fan_cooling_layer_time": [
-		"10"
-	],
-	"overhang_fan_speed": [
-		"100"
-	],
-	"overhang_fan_threshold": [
-		"25%"
-	],
-	"fan_max_speed": [
-		"90"
-	],
-	"fan_min_speed": [
-		"40"
-	],
-	"slow_down_min_speed": [
-		"10"
-	],
-	"slow_down_layer_time": [
-		"8"
-	],
-	"filament_flow_ratio": [
-		"0.92"
-	],
-	"filament_max_volumetric_speed": [
-		"12"
-	],
-	"filament_z_hop": [
-		"0"
-	],
-	"enable_pressure_advance": [
-		"1"
-	],
-	"pressure_advance": [
-		"0.045"
-	],
-	"nozzle_temperature_initial_layer": [
-		"260"
-	],
-	"nozzle_temperature": [
-		"255"
-	],
-	"nozzle_temperature_range_high": [
-		"280"
-	],
-	"nozzle_temperature_range_low": [
-		"230"
-	],
 	"compatible_printers": [
 		"RatRig V-Core 3 200 0.4 nozzle",
 		"RatRig V-Core 3 300 0.4 nozzle",

--- a/resources/profiles/Ratrig/filament/RatRig BigNozzle PLA.json
+++ b/resources/profiles/Ratrig/filament/RatRig BigNozzle PLA.json
@@ -1,41 +1,11 @@
 {
 	"type": "filament",
 	"name": "RatRig BigNozzle PLA",
-	"inherits": "fdm_filament_pla",
+	"inherits": "RatRig BigNozzle PLA @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFL99",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"0.94"
-	],
-	"filament_max_volumetric_speed": [
-		"20"
-	],
-	"filament_z_hop": [
-		"0"
-	],
-	"enable_pressure_advance": [
-		"1"
-	],
-	"pressure_advance": [
-		"0.05"
-	],
-	"slow_down_layer_time": [
-		"8"
-	],
-	"nozzle_temperature_initial_layer": [
-		"230"
-	],
-	"nozzle_temperature": [
-		"235"
-	],
-	"nozzle_temperature_range_high": [
-		"260"
-	],
-	"nozzle_temperature_range_low": [
-		"210"
-	],
 	"compatible_printers": [
 		"RatRig V-Core 3 200 0.4 nozzle",
 		"RatRig V-Core 3 300 0.4 nozzle",

--- a/resources/profiles/Ratrig/filament/RatRig BigNozzle TPU.json
+++ b/resources/profiles/Ratrig/filament/RatRig BigNozzle TPU.json
@@ -1,35 +1,11 @@
 {
 	"type": "filament",
 	"name": "RatRig BigNozzle TPU",
-	"inherits": "fdm_filament_tpu",
+	"inherits": "RatRig BigNozzle TPU @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFL99",
 	"instantiation": "true",
-	"filament_max_volumetric_speed": [
-		"5"
-	],
-	"filament_z_hop": [
-		"0"
-	],
-	"enable_pressure_advance": [
-		"1"
-	],
-	"pressure_advance": [
-		"0.1"
-	],
-	"nozzle_temperature_initial_layer": [
-		"240"
-	],
-	"nozzle_temperature": [
-		"245"
-	],
-	"nozzle_temperature_range_high": [
-		"270"
-	],
-	"nozzle_temperature_range_low": [
-		"220"
-	],
 	"compatible_printers": [
 		"RatRig V-Core 3 200 0.4 nozzle",
 		"RatRig V-Core 3 300 0.4 nozzle",

--- a/resources/profiles/Ratrig/filament/RatRig Generic ABS.json
+++ b/resources/profiles/Ratrig/filament/RatRig Generic ABS.json
@@ -1,50 +1,11 @@
 {
 	"type": "filament",
 	"name": "RatRig Generic ABS",
-	"inherits": "fdm_filament_abs",
+	"inherits": "RatRig Generic ABS @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFB99",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"0.980"
-	],
-	"filament_max_volumetric_speed": [
-		"18"
-	],
-	"filament_z_hop": [
-		"0"
-	],
-	"enable_pressure_advance": [
-		"1"
-	],
-	"pressure_advance": [
-		"0.03"
-	],
-	"hot_plate_temp_initial_layer": [
-		"108"
-	],
-	"nozzle_temperature_initial_layer": [
-		"248"
-	],
-	"nozzle_temperature": [
-		"243"
-	],
-	"close_fan_the_first_x_layers": [
-		"2"
-	],
-	"fan_cooling_layer_time": [
-		"10"
-	],
-	"fan_max_speed": [
-		"30"
-	],
-	"fan_min_speed": [
-		"10"
-	],
-	"overhang_fan_speed": [
-		"30"
-	],
 	"compatible_printers": [
 		"RatRig V-Core 3 200 0.4 nozzle",
 		"RatRig V-Core 3 300 0.4 nozzle",

--- a/resources/profiles/Ratrig/filament/RatRig Generic ASA.json
+++ b/resources/profiles/Ratrig/filament/RatRig Generic ASA.json
@@ -1,44 +1,11 @@
 {
 	"type": "filament",
 	"name": "RatRig Generic ASA",
-	"inherits": "fdm_filament_asa",
+	"inherits": "RatRig Generic ASA @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFB98",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"0.93"
-	],
-	"filament_max_volumetric_speed": [
-		"19"
-	],
-	"filament_density": [
-		"1.1"
-	],
-	"filament_z_hop": [
-		"0"
-	],
-	"enable_pressure_advance": [
-		"1"
-	],
-	"pressure_advance": [
-		"0.033"
-	],
-	"close_fan_the_first_x_layers": [
-		"2"
-	],
-	"fan_cooling_layer_time": [
-		"10"
-	],
-	"fan_max_speed": [
-		"30"
-	],
-	"fan_min_speed": [
-		"10"
-	],
-	"overhang_fan_speed": [
-		"25"
-	],
 	"compatible_printers": [
 		"RatRig V-Core 3 200 0.4 nozzle",
 		"RatRig V-Core 3 300 0.4 nozzle",

--- a/resources/profiles/Ratrig/filament/RatRig Generic PA-CF.json
+++ b/resources/profiles/Ratrig/filament/RatRig Generic PA-CF.json
@@ -1,44 +1,11 @@
 {
 	"type": "filament",
 	"name": "RatRig Generic PA-CF",
-	"inherits": "fdm_filament_pa",
+	"inherits": "RatRig Generic PA-CF @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFN98",
 	"instantiation": "true",
-	"filament_type": [
-		"PA-CF"
-	],
-	"filament_z_hop": [
-		"0"
-	],
-	"enable_pressure_advance": [
-		"1"
-	],
-	"pressure_advance": [
-		"0.045"
-	],
-	"nozzle_temperature_initial_layer": [
-		"270"
-	],
-	"nozzle_temperature": [
-		"270"
-	],
-	"hot_plate_temp": [
-		"80"
-	],
-	"hot_plate_temp_initial_layer": [
-		"80"
-	],
-	"filament_density": [
-		"1.24"
-	],
-	"nozzle_temperature_range_high": [
-		"280"
-	],
-	"overhang_fan_speed": [
-		"50"
-	],
 	"compatible_printers": [
 		"RatRig V-Core 3 200 0.4 nozzle",
 		"RatRig V-Core 3 300 0.4 nozzle",

--- a/resources/profiles/Ratrig/filament/RatRig Generic PA.json
+++ b/resources/profiles/Ratrig/filament/RatRig Generic PA.json
@@ -1,41 +1,11 @@
 {
 	"type": "filament",
 	"name": "RatRig Generic PA",
-	"inherits": "fdm_filament_pa",
+	"inherits": "RatRig Generic PA @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFN99",
 	"instantiation": "true",
-	"nozzle_temperature_initial_layer": [
-		"270"
-	],
-	"nozzle_temperature": [
-		"270"
-	],
-	"hot_plate_temp": [
-		"80"
-	],
-	"hot_plate_temp_initial_layer": [
-		"80"
-	],
-	"filament_z_hop": [
-		"0"
-	],
-	"enable_pressure_advance": [
-		"1"
-	],
-	"pressure_advance": [
-		"0.045"
-	],
-	"filament_density": [
-		"1.24"
-	],
-	"nozzle_temperature_range_high": [
-		"280"
-	],
-	"overhang_fan_speed": [
-		"50"
-	],
 	"compatible_printers": [
 		"RatRig V-Core 3 200 0.4 nozzle",
 		"RatRig V-Core 3 300 0.4 nozzle",

--- a/resources/profiles/Ratrig/filament/RatRig Generic PC.json
+++ b/resources/profiles/Ratrig/filament/RatRig Generic PC.json
@@ -1,38 +1,11 @@
 {
 	"type": "filament",
 	"name": "RatRig Generic PC",
-	"inherits": "fdm_filament_pc",
+	"inherits": "RatRig Generic PC @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFC99",
 	"instantiation": "true",
-	"filament_max_volumetric_speed": [
-		"12"
-	],
-	"filament_flow_ratio": [
-		"0.93"
-	],
-	"filament_z_hop": [
-		"0"
-	],
-	"enable_pressure_advance": [
-		"1"
-	],
-	"pressure_advance": [
-		"0.045"
-	],
-	"nozzle_temperature_initial_layer": [
-		"280"
-	],
-	"nozzle_temperature_range_high": [
-		"290"
-	],
-	"hot_plate_temp": [
-		"100"
-	],
-	"hot_plate_temp_initial_layer": [
-		"100"
-	],
 	"compatible_printers": [
 		"RatRig V-Core 3 200 0.4 nozzle",
 		"RatRig V-Core 3 300 0.4 nozzle",

--- a/resources/profiles/Ratrig/filament/RatRig Generic PCTG.json
+++ b/resources/profiles/Ratrig/filament/RatRig Generic PCTG.json
@@ -1,68 +1,11 @@
 {
 	"type": "filament",
 	"name": "RatRig Generic PCTG",
-	"inherits": "fdm_filament_pet",
+	"inherits": "RatRig Generic PCTG @base",
 	"from": "system",
 	"setting_id": "GFCA04",
 	"filament_id": "GFC99",
 	"instantiation": "true",
-	"reduce_fan_stop_start_freq": [
-		"1"
-	],
-	"slow_down_for_layer_cooling": [
-		"1"
-	],
-	"fan_cooling_layer_time": [
-		"30"
-	],
-	"overhang_fan_speed": [
-		"90"
-	],
-	"overhang_fan_threshold": [
-		"25%"
-	],
-	"fan_max_speed": [
-		"40"
-	],
-	"fan_min_speed": [
-		"10"
-	],
-	"slow_down_min_speed": [
-		"10"
-	],
-	"slow_down_layer_time": [
-		"8"
-	],
-	"filament_flow_ratio": [
-		"0.93"
-	],
-	"filament_density": [
-		"1.29"
-	],
-	"filament_max_volumetric_speed": [
-		"12"
-	],
-	"filament_z_hop": [
-		"0"
-	],
-	"enable_pressure_advance": [
-		"1"
-	],
-	"pressure_advance": [
-		"0.045"
-	],
-	"nozzle_temperature_initial_layer": [
-		"260"
-	],
-	"nozzle_temperature": [
-		"255"
-	],
-	"nozzle_temperature_range_high": [
-		"270"
-	],
-	"temperature_vitrification": [
-		"90"
-	],
 	"compatible_printers": [
 		"RatRig V-Core 3 200 0.4 nozzle",
 		"RatRig V-Core 3 300 0.4 nozzle",

--- a/resources/profiles/Ratrig/filament/RatRig Generic PETG.json
+++ b/resources/profiles/Ratrig/filament/RatRig Generic PETG.json
@@ -1,62 +1,11 @@
 {
 	"type": "filament",
 	"name": "RatRig Generic PETG",
-	"inherits": "fdm_filament_pet",
+	"inherits": "RatRig Generic PETG @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFG99",
 	"instantiation": "true",
-	"reduce_fan_stop_start_freq": [
-		"1"
-	],
-	"slow_down_for_layer_cooling": [
-		"1"
-	],
-	"fan_cooling_layer_time": [
-		"10"
-	],
-	"overhang_fan_speed": [
-		"100"
-	],
-	"overhang_fan_threshold": [
-		"25%"
-	],
-	"fan_max_speed": [
-		"100"
-	],
-	"fan_min_speed": [
-		"40"
-	],
-	"slow_down_min_speed": [
-		"10"
-	],
-	"slow_down_layer_time": [
-		"8"
-	],
-	"filament_flow_ratio": [
-		"0.94"
-	],
-	"filament_max_volumetric_speed": [
-		"11"
-	],
-	"filament_z_hop": [
-		"0"
-	],
-	"enable_pressure_advance": [
-		"1"
-	],
-	"pressure_advance": [
-		"0.045"
-	],
-	"nozzle_temperature_initial_layer": [
-		"240"
-	],
-	"nozzle_temperature": [
-		"235"
-	],
-	"nozzle_temperature_range_high": [
-		"250"
-	],
 	"compatible_printers": [
 		"RatRig V-Core 3 200 0.4 nozzle",
 		"RatRig V-Core 3 300 0.4 nozzle",

--- a/resources/profiles/Ratrig/filament/RatRig Generic PLA-CF.json
+++ b/resources/profiles/Ratrig/filament/RatRig Generic PLA-CF.json
@@ -1,38 +1,11 @@
 {
 	"type": "filament",
 	"name": "RatRig Generic PLA-CF",
-	"inherits": "fdm_filament_pla",
+	"inherits": "RatRig Generic PLA-CF @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFL98",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"0.92"
-	],
-	"filament_type": [
-		"PLA-CF"
-	],
-	"filament_max_volumetric_speed": [
-		"12"
-	],
-	"filament_z_hop": [
-		"0"
-	],
-	"enable_pressure_advance": [
-		"1"
-	],
-	"pressure_advance": [
-		"0.05"
-	],
-	"slow_down_layer_time": [
-		"7"
-	],
-	"nozzle_temperature_initial_layer": [
-		"210"
-	],
-	"nozzle_temperature": [
-		"205"
-	],
 	"compatible_printers": [
 		"RatRig V-Core 3 200 0.4 nozzle",
 		"RatRig V-Core 3 300 0.4 nozzle",

--- a/resources/profiles/Ratrig/filament/RatRig Generic PLA.json
+++ b/resources/profiles/Ratrig/filament/RatRig Generic PLA.json
@@ -1,35 +1,11 @@
 {
 	"type": "filament",
 	"name": "RatRig Generic PLA",
-	"inherits": "fdm_filament_pla",
+	"inherits": "RatRig Generic PLA @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFL99",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"0.92"
-	],
-	"filament_max_volumetric_speed": [
-		"20"
-	],
-	"filament_z_hop": [
-		"0"
-	],
-	"enable_pressure_advance": [
-		"1"
-	],
-	"pressure_advance": [
-		"0.05"
-	],
-	"slow_down_layer_time": [
-		"8"
-	],
-	"nozzle_temperature_initial_layer": [
-		"205"
-	],
-	"nozzle_temperature": [
-		"200"
-	],
 	"compatible_printers": [
 		"RatRig V-Core 3 200 0.4 nozzle",
 		"RatRig V-Core 3 300 0.4 nozzle",

--- a/resources/profiles/Ratrig/filament/RatRig Generic PVA.json
+++ b/resources/profiles/Ratrig/filament/RatRig Generic PVA.json
@@ -1,32 +1,11 @@
 {
 	"type": "filament",
 	"name": "RatRig Generic PVA",
-	"inherits": "fdm_filament_pva",
+	"inherits": "RatRig Generic PVA @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFS99",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"0.95"
-	],
-	"filament_max_volumetric_speed": [
-		"12"
-	],
-	"filament_z_hop": [
-		"0"
-	],
-	"enable_pressure_advance": [
-		"1"
-	],
-	"pressure_advance": [
-		"0.03"
-	],
-	"slow_down_layer_time": [
-		"7"
-	],
-	"slow_down_min_speed": [
-		"10"
-	],
 	"compatible_printers": [
 		"RatRig V-Core 3 200 0.4 nozzle",
 		"RatRig V-Core 3 300 0.4 nozzle",

--- a/resources/profiles/Ratrig/filament/RatRig Generic TPU.json
+++ b/resources/profiles/Ratrig/filament/RatRig Generic TPU.json
@@ -1,29 +1,11 @@
 {
 	"type": "filament",
 	"name": "RatRig Generic TPU",
-	"inherits": "fdm_filament_tpu",
+	"inherits": "RatRig Generic TPU @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFU99",
 	"instantiation": "true",
-	"filament_max_volumetric_speed": [
-		"5"
-	],
-	"filament_z_hop": [
-		"0"
-	],
-	"enable_pressure_advance": [
-		"1"
-	],
-	"pressure_advance": [
-		"0.1"
-	],
-	"nozzle_temperature": [
-		"220"
-	],
-	"nozzle_temperature_initial_layer": [
-		"220"
-	],
 	"compatible_printers": [
 		"RatRig V-Core 3 200 0.4 nozzle",
 		"RatRig V-Core 3 300 0.4 nozzle",

--- a/resources/profiles/Ratrig/filament/RatRig PunkFil ABS.json
+++ b/resources/profiles/Ratrig/filament/RatRig PunkFil ABS.json
@@ -1,71 +1,11 @@
 {
 	"type": "filament",
 	"name": "RatRig PunkFil ABS",
-	"inherits": "fdm_filament_abs",
+	"inherits": "RatRig PunkFil ABS @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFB99",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"0.92"
-	],
-	"filament_max_volumetric_speed": [
-		"40"
-	],
-	"filament_z_hop": [
-		"nil"
-	],
-	"enable_pressure_advance": [
-		"1"
-	],
-	"pressure_advance": [
-		"0.022"
-	],
-	"hot_plate_temp_initial_layer": [
-		"110"
-	],
-	"hot_plate_temp": [
-		"110"
-	],
-	"nozzle_temperature_initial_layer": [
-		"260"
-	],
-	"nozzle_temperature": [
-		"260"
-	],
-	"close_fan_the_first_x_layers": [
-		"2"
-	],
-	"fan_cooling_layer_time": [
-		"7"
-	],
-	"fan_max_speed": [
-		"60"
-	],
-	"fan_min_speed": [
-		"30"
-	],
-	"overhang_fan_speed": [
-		"60"
-	],
-	"overhang_fan_threshold": [
-		"25%"
-	],
-	"slow_down_min_speed": [
-		"50"
-	],
-	"slow_down_layer_time": [
-		"2"
-	],
-	"slow_down_for_layer_cooling": [
-		"1"
-	],
-	"filament_cost": [
-		"25.5"
-	],
-	"filament_vendor": [
-		"RatRig"
-	],
 	"compatible_printers": [
 		"RatRig V-Core 3 200 0.4 nozzle",
 		"RatRig V-Core 3 300 0.4 nozzle",

--- a/resources/profiles/Ratrig/filament/RatRig PunkFil PETG CF.json
+++ b/resources/profiles/Ratrig/filament/RatRig PunkFil PETG CF.json
@@ -1,74 +1,11 @@
 {
 	"type": "filament",
 	"name": "RatRig PunkFil PETG CF",
-	"inherits": "fdm_filament_pet",
+	"inherits": "RatRig PunkFil PETG CF @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFB99",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"0.93"
-	],
-	"filament_max_volumetric_speed": [
-		"20"
-	],
-	"filament_z_hop": [
-		"nil"
-	],
-	"enable_pressure_advance": [
-		"1"
-	],
-	"pressure_advance": [
-		"0.038"
-	],
-	"hot_plate_temp_initial_layer": [
-		"80"
-	],
-	"hot_plate_temp": [
-		"80"
-	],
-	"nozzle_temperature_initial_layer": [
-		"230"
-	],
-	"nozzle_temperature": [
-		"230"
-	],
-	"close_fan_the_first_x_layers": [
-		"2"
-	],
-	"fan_cooling_layer_time": [
-		"10"
-	],
-	"fan_max_speed": [
-		"30"
-	],
-	"fan_min_speed": [
-		"0"
-	],
-	"overhang_fan_speed": [
-		"40"
-	],
-	"overhang_fan_threshold": [
-		"50%"
-	],
-	"slow_down_min_speed": [
-		"30"
-	],
-	"slow_down_layer_time": [
-		"8"
-	],
-	"slow_down_for_layer_cooling": [
-		"1"
-	],
-	"filament_cost": [
-		"48"
-	],
-	"filament_type": [
-		"PETG-CF10"
-	],
-	"filament_vendor": [
-		"RatRig"
-	],
 	"compatible_printers": [
 		"RatRig V-Core 3 200 0.4 nozzle",
 		"RatRig V-Core 3 300 0.4 nozzle",

--- a/resources/profiles/Ratrig/filament/RatRig PunkFil PETG.json
+++ b/resources/profiles/Ratrig/filament/RatRig PunkFil PETG.json
@@ -1,71 +1,11 @@
 {
 	"type": "filament",
 	"name": "RatRig PunkFil PETG",
-	"inherits": "fdm_filament_pet",
+	"inherits": "RatRig PunkFil PETG @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFB99",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"0.93"
-	],
-	"filament_max_volumetric_speed": [
-		"40"
-	],
-	"filament_z_hop": [
-		"nil"
-	],
-	"enable_pressure_advance": [
-		"1"
-	],
-	"pressure_advance": [
-		"0.025"
-	],
-	"hot_plate_temp_initial_layer": [
-		"80"
-	],
-	"hot_plate_temp": [
-		"80"
-	],
-	"nozzle_temperature_initial_layer": [
-		"235"
-	],
-	"nozzle_temperature": [
-		"235"
-	],
-	"close_fan_the_first_x_layers": [
-		"2"
-	],
-	"fan_cooling_layer_time": [
-		"8"
-	],
-	"fan_max_speed": [
-		"60"
-	],
-	"fan_min_speed": [
-		"30"
-	],
-	"overhang_fan_speed": [
-		"50"
-	],
-	"overhang_fan_threshold": [
-		"50%"
-	],
-	"slow_down_min_speed": [
-		"50"
-	],
-	"slow_down_layer_time": [
-		"2"
-	],
-	"slow_down_for_layer_cooling": [
-		"1"
-	],
-	"filament_cost": [
-		"24.5"
-	],
-	"filament_vendor": [
-		"RatRig"
-	],
 	"compatible_printers": [
 		"RatRig V-Core 3 200 0.4 nozzle",
 		"RatRig V-Core 3 300 0.4 nozzle",


### PR DESCRIPTION
## Summary

Migrates RatRig filament presets into the shared OrcaFilamentLibrary for #12162.

## Changes

- Added RatRig BigNozzle, Generic, and PunkFil `@base` / `@System` presets under `OrcaFilamentLibrary`.
- Updated the RatRig printer-scoped filament presets to inherit from the new library bases while preserving their existing printer compatibility constraints.
- Registered the new RatRig OrcaFilamentLibrary entries in `resources/profiles/OrcaFilamentLibrary.json`.

## Testing

- `python3 scripts/orca_extra_profile_check.py --vendor Ratrig --check-filaments --check-materials --check-obsolete-keys` — 0 errors, 0 warnings
- `git diff --check`

Part of OrcaSlicer/OrcaSlicer#12162.
