### PR TITLE
Migrate FLSun filaments to OrcaFilamentLibrary

### DIFF
--- a/resources/profiles/FLSun/filament/FLSun Generic ABS.json
+++ b/resources/profiles/FLSun/filament/FLSun Generic ABS.json
@@ -1,17 +1,11 @@
 {
 	"type": "filament",
 	"name": "FLSun Generic ABS",
-	"inherits": "fdm_filament_abs",
+	"inherits": "FLSun Generic ABS @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFB99",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"0.926"
-	],
-	"filament_max_volumetric_speed": [
-		"12"
-	],
 	"compatible_printers": [
 		"FLSun Q5 0.4 nozzle",
 		"FLSun QQ-S Pro 0.4 nozzle",

--- a/resources/profiles/FLSun/filament/FLSun Generic ASA.json
+++ b/resources/profiles/FLSun/filament/FLSun Generic ASA.json
@@ -1,17 +1,11 @@
 {
 	"type": "filament",
 	"name": "FLSun Generic ASA",
-	"inherits": "fdm_filament_asa",
+	"inherits": "FLSun Generic ASA @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFB98",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"0.93"
-	],
-	"filament_max_volumetric_speed": [
-		"12"
-	],
 	"compatible_printers": [
 		"FLSun Q5 0.4 nozzle",
 		"FLSun QQ-S Pro 0.4 nozzle",

--- a/resources/profiles/FLSun/filament/FLSun Generic PA-CF.json
+++ b/resources/profiles/FLSun/filament/FLSun Generic PA-CF.json
@@ -1,23 +1,11 @@
 {
 	"type": "filament",
 	"name": "FLSun Generic PA-CF",
-	"inherits": "fdm_filament_pa",
+	"inherits": "FLSun Generic PA-CF @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFN98",
 	"instantiation": "true",
-	"filament_type": [
-		"PA-CF"
-	],
-	"nozzle_temperature_initial_layer": [
-		"280"
-	],
-	"nozzle_temperature": [
-		"280"
-	],
-	"filament_max_volumetric_speed": [
-		"8"
-	],
 	"compatible_printers": [
 		"FLSun Q5 0.4 nozzle",
 		"FLSun QQ-S Pro 0.4 nozzle",

--- a/resources/profiles/FLSun/filament/FLSun Generic PA.json
+++ b/resources/profiles/FLSun/filament/FLSun Generic PA.json
@@ -1,20 +1,11 @@
 {
 	"type": "filament",
 	"name": "FLSun Generic PA",
-	"inherits": "fdm_filament_pa",
+	"inherits": "FLSun Generic PA @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFN99",
 	"instantiation": "true",
-	"nozzle_temperature_initial_layer": [
-		"280"
-	],
-	"nozzle_temperature": [
-		"280"
-	],
-	"filament_max_volumetric_speed": [
-		"12"
-	],
 	"compatible_printers": [
 		"FLSun Q5 0.4 nozzle",
 		"FLSun QQ-S Pro 0.4 nozzle",

--- a/resources/profiles/FLSun/filament/FLSun Generic PC.json
+++ b/resources/profiles/FLSun/filament/FLSun Generic PC.json
@@ -1,17 +1,11 @@
 {
 	"type": "filament",
 	"name": "FLSun Generic PC",
-	"inherits": "fdm_filament_pc",
+	"inherits": "FLSun Generic PC @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFC99",
 	"instantiation": "true",
-	"filament_max_volumetric_speed": [
-		"12"
-	],
-	"filament_flow_ratio": [
-		"0.94"
-	],
 	"compatible_printers": [
 		"FLSun Q5 0.4 nozzle",
 		"FLSun QQ-S Pro 0.4 nozzle",

--- a/resources/profiles/FLSun/filament/FLSun Generic PETG.json
+++ b/resources/profiles/FLSun/filament/FLSun Generic PETG.json
@@ -1,47 +1,11 @@
 {
 	"type": "filament",
 	"name": "FLSun Generic PETG",
-	"inherits": "fdm_filament_pet",
+	"inherits": "FLSun Generic PETG @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFG99",
 	"instantiation": "true",
-	"reduce_fan_stop_start_freq": [
-		"1"
-	],
-	"slow_down_for_layer_cooling": [
-		"1"
-	],
-	"fan_cooling_layer_time": [
-		"30"
-	],
-	"overhang_fan_speed": [
-		"90"
-	],
-	"overhang_fan_threshold": [
-		"25%"
-	],
-	"fan_max_speed": [
-		"90"
-	],
-	"fan_min_speed": [
-		"40"
-	],
-	"slow_down_min_speed": [
-		"10"
-	],
-	"slow_down_layer_time": [
-		"8"
-	],
-	"filament_flow_ratio": [
-		"0.95"
-	],
-	"filament_max_volumetric_speed": [
-		"10"
-	],
-	"filament_start_gcode": [
-		"; filament start gcode\n"
-	],
 	"compatible_printers": [
 		"FLSun Q5 0.4 nozzle",
 		"FLSun QQ-S Pro 0.4 nozzle",

--- a/resources/profiles/FLSun/filament/FLSun Generic PLA-CF.json
+++ b/resources/profiles/FLSun/filament/FLSun Generic PLA-CF.json
@@ -1,23 +1,11 @@
 {
 	"type": "filament",
 	"name": "FLSun Generic PLA-CF",
-	"inherits": "fdm_filament_pla",
+	"inherits": "FLSun Generic PLA-CF @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFL98",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"0.95"
-	],
-	"filament_type": [
-		"PLA-CF"
-	],
-	"filament_max_volumetric_speed": [
-		"12"
-	],
-	"slow_down_layer_time": [
-		"7"
-	],
 	"compatible_printers": [
 		"FLSun Q5 0.4 nozzle",
 		"FLSun QQ-S Pro 0.4 nozzle",

--- a/resources/profiles/FLSun/filament/FLSun Generic PLA.json
+++ b/resources/profiles/FLSun/filament/FLSun Generic PLA.json
@@ -1,20 +1,11 @@
 {
 	"type": "filament",
 	"name": "FLSun Generic PLA",
-	"inherits": "fdm_filament_pla",
+	"inherits": "FLSun Generic PLA @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFL99",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"0.98"
-	],
-	"filament_max_volumetric_speed": [
-		"12"
-	],
-	"slow_down_layer_time": [
-		"8"
-	],
 	"compatible_printers": [
 		"FLSun Q5 0.4 nozzle",
 		"FLSun QQ-S Pro 0.4 nozzle",

--- a/resources/profiles/FLSun/filament/FLSun Generic PVA.json
+++ b/resources/profiles/FLSun/filament/FLSun Generic PVA.json
@@ -1,23 +1,11 @@
 {
 	"type": "filament",
 	"name": "FLSun Generic PVA",
-	"inherits": "fdm_filament_pva",
+	"inherits": "FLSun Generic PVA @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFS99",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"0.95"
-	],
-	"filament_max_volumetric_speed": [
-		"12"
-	],
-	"slow_down_layer_time": [
-		"7"
-	],
-	"slow_down_min_speed": [
-		"10"
-	],
 	"compatible_printers": [
 		"FLSun Q5 0.4 nozzle",
 		"FLSun QQ-S Pro 0.4 nozzle",

--- a/resources/profiles/FLSun/filament/FLSun Generic TPU.json
+++ b/resources/profiles/FLSun/filament/FLSun Generic TPU.json
@@ -1,14 +1,11 @@
 {
 	"type": "filament",
 	"name": "FLSun Generic TPU",
-	"inherits": "fdm_filament_tpu",
+	"inherits": "FLSun Generic TPU @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFU99",
 	"instantiation": "true",
-	"filament_max_volumetric_speed": [
-		"3.2"
-	],
 	"compatible_printers": [
 		"FLSun Q5 0.4 nozzle",
 		"FLSun QQ-S Pro 0.4 nozzle",

--- a/resources/profiles/FLSun/filament/FLSun S1 ABS.json
+++ b/resources/profiles/FLSun/filament/FLSun S1 ABS.json
@@ -1,75 +1,11 @@
 {
 	"type": "filament",
 	"name": "FLSun S1 ABS",
-	"inherits": "FLSun Generic ABS",
+	"inherits": "FLSun S1 ABS @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFB99",
 	"instantiation": "true",
-	"fan_max_speed": [
-		"50"
-	],
-	"fan_min_speed": [
-		"10"
-	],
-	"filament_density": [
-		"1.05"
-	],
-	"filament_flow_ratio": "0.95",
-	"activate_air_filtration": [
-		"1"
-	],
-	"complete_print_exhaust_fan_speed": [
-		"0"
-	],
-	"during_print_exhaust_fan_speed": [
-		"0"
-	],
-	"fan_cooling_layer_time": [
-		"30"
-	],
-	"filament_cost": [
-		"0"
-	],
-	"full_fan_speed_layer": [
-		"3"
-	],
-	"hot_plate_temp": [
-		"90"
-	],
-	"hot_plate_temp_initial_layer": [
-		"90"
-	],
-	"nozzle_temperature": [
-		"280"
-	],
-	"nozzle_temperature_initial_layer": [
-		"280"
-	],
-	"nozzle_temperature_range_low": [
-		"240"
-	],
-	"nozzle_temperature_range_high": [
-		"300"
-	],
-	"overhang_fan_speed": [
-		"50"
-	],
-	"slow_down_layer_time": [
-		"12"
-	],
-	"slow_down_min_speed": [
-		"30"
-	],
-	"temperature_vitrification": [
-		"100"
-	],
-	"filament_max_volumetric_speed": [
-		"20"
-	],
-	"dont_slow_down_outer_wall": [
-		"1"
-	],
 	"compatible_printers": [
 		"FLSun S1 0.4 nozzle"
 	]

--- a/resources/profiles/FLSun/filament/FLSun S1 ASA.json
+++ b/resources/profiles/FLSun/filament/FLSun S1 ASA.json
@@ -1,75 +1,11 @@
 {
 	"type": "filament",
 	"name": "FLSun S1 ASA",
-	"inherits": "FLSun Generic ASA",
+	"inherits": "FLSun S1 ASA @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFB98",
 	"instantiation": "true",
-	"fan_max_speed": [
-		"50"
-	],
-	"fan_min_speed": [
-		"35"
-	],
-	"filament_density": [
-		"1.05"
-	],
-	"filament_flow_ratio": "0.95",
-	"activate_air_filtration": [
-		"1"
-	],
-	"complete_print_exhaust_fan_speed": [
-		"0"
-	],
-	"during_print_exhaust_fan_speed": [
-		"0"
-	],
-	"fan_cooling_layer_time": [
-		"35"
-	],
-	"filament_cost": [
-		"0"
-	],
-	"full_fan_speed_layer": [
-		"3"
-	],
-	"hot_plate_temp": [
-		"90"
-	],
-	"hot_plate_temp_initial_layer": [
-		"90"
-	],
-	"nozzle_temperature": [
-		"280"
-	],
-	"nozzle_temperature_initial_layer": [
-		"280"
-	],
-	"nozzle_temperature_range_low": [
-		"240"
-	],
-	"nozzle_temperature_range_high": [
-		"300"
-	],
-	"overhang_fan_speed": [
-		"35"
-	],
-	"slow_down_layer_time": [
-		"2"
-	],
-	"slow_down_min_speed": [
-		"80"
-	],
-	"temperature_vitrification": [
-		"100"
-	],
-	"filament_max_volumetric_speed": [
-		"25"
-	],
-	"dont_slow_down_outer_wall": [
-		"1"
-	],
 	"compatible_printers": [
 		"FLSun S1 0.4 nozzle"
 	]

--- a/resources/profiles/FLSun/filament/FLSun S1 PETG.json
+++ b/resources/profiles/FLSun/filament/FLSun S1 PETG.json
@@ -1,71 +1,11 @@
 {
 	"type": "filament",
 	"name": "FLSun S1 PETG",
-	"inherits": "FLSun Generic PETG",
+	"inherits": "FLSun S1 PETG @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFG99",
 	"instantiation": "true",
-	"fan_max_speed": [
-		"60"
-	],
-	"fan_min_speed": [
-		"50"
-	],
-	"activate_air_filtration": [
-		"1"
-	],
-	"complete_print_exhaust_fan_speed": [
-		"0"
-	],
-	"during_print_exhaust_fan_speed": [
-		"100"
-	],
-	"fan_cooling_layer_time": [
-		"100"
-	],
-	"filament_cost": [
-		"0"
-	],
-	"full_fan_speed_layer": [
-		"2"
-	],
-	"hot_plate_temp": [
-		"80"
-	],
-	"hot_plate_temp_initial_layer": [
-		"80"
-	],
-	"nozzle_temperature": [
-		"260"
-	],
-	"nozzle_temperature_initial_layer": [
-		"260"
-	],
-	"nozzle_temperature_range_low": [
-		"230"
-	],
-	"nozzle_temperature_range_high": [
-		"270"
-	],
-	"overhang_fan_speed": [
-		"35"
-	],
-	"slow_down_layer_time": [
-		"2"
-	],
-	"slow_down_min_speed": [
-		"30"
-	],
-	"temperature_vitrification": [
-		"70"
-	],
-	"filament_max_volumetric_speed": [
-		"15"
-	],
-	"dont_slow_down_outer_wall": [
-		"1"
-	],
 	"compatible_printers": [
 		"FLSun S1 0.4 nozzle"
 	]

--- a/resources/profiles/FLSun/filament/FLSun S1 PLA Generic.json
+++ b/resources/profiles/FLSun/filament/FLSun S1 PLA Generic.json
@@ -1,65 +1,11 @@
 {
 	"type": "filament",
 	"name": "FLSun S1 PLA Generic",
-	"inherits": "FLSun Generic PLA",
+	"inherits": "FLSun S1 PLA Generic @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFL99",
 	"instantiation": "true",
-	"activate_air_filtration": [
-		"1"
-	],
-	"complete_print_exhaust_fan_speed": [
-		"0"
-	],
-	"during_print_exhaust_fan_speed": [
-		"100"
-	],
-	"fan_cooling_layer_time": [
-		"100"
-	],
-	"filament_cost": [
-		"0"
-	],
-	"filament_density": [
-		"1.32"
-	],
-	"full_fan_speed_layer": [
-		"3"
-	],
-	"hot_plate_temp": [
-		"60"
-	],
-	"hot_plate_temp_initial_layer": [
-		"60"
-	],
-	"nozzle_temperature": [
-		"230"
-	],
-	"nozzle_temperature_initial_layer": [
-		"230"
-	],
-	"nozzle_temperature_range_low": [
-		"190"
-	],
-	"nozzle_temperature_range_high": [
-		"240"
-	],
-	"overhang_fan_speed": [
-		"35"
-	],
-	"slow_down_layer_time": [
-		"1"
-	],
-	"slow_down_min_speed": [
-		"80"
-	],
-	"filament_max_volumetric_speed": [
-		"60"
-	],
-	"dont_slow_down_outer_wall": [
-		"1"
-	],
 	"compatible_printers": [
 		"FLSun S1 0.4 nozzle"
 	]

--- a/resources/profiles/FLSun/filament/FLSun S1 PLA High Speed.json
+++ b/resources/profiles/FLSun/filament/FLSun S1 PLA High Speed.json
@@ -1,62 +1,11 @@
 {
 	"type": "filament",
 	"name": "FLSun S1 PLA High Speed",
-	"inherits": "FLSun Generic PLA",
+	"inherits": "FLSun S1 PLA High Speed @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFL99",
 	"instantiation": "true",
-	"activate_air_filtration": [
-		"1"
-	],
-	"complete_print_exhaust_fan_speed": [
-		"0"
-	],
-	"during_print_exhaust_fan_speed": [
-		"100"
-	],
-	"fan_cooling_layer_time": [
-		"100"
-	],
-	"filament_cost": [
-		"0"
-	],
-	"full_fan_speed_layer": [
-		"3"
-	],
-	"hot_plate_temp": [
-		"60"
-	],
-	"hot_plate_temp_initial_layer": [
-		"60"
-	],
-	"nozzle_temperature": [
-		"230"
-	],
-	"nozzle_temperature_initial_layer": [
-		"230"
-	],
-	"nozzle_temperature_range_low": [
-		"190"
-	],
-	"nozzle_temperature_range_high": [
-		"240"
-	],
-	"overhang_fan_speed": [
-		"35"
-	],
-	"slow_down_layer_time": [
-		"1"
-	],
-	"slow_down_min_speed": [
-		"80"
-	],
-	"filament_max_volumetric_speed": [
-		"110"
-	],
-	"dont_slow_down_outer_wall": [
-		"1"
-	],
 	"compatible_printers": [
 		"FLSun S1 0.4 nozzle"
 	]

--- a/resources/profiles/FLSun/filament/FLSun S1 PLA Silk.json
+++ b/resources/profiles/FLSun/filament/FLSun S1 PLA Silk.json
@@ -1,65 +1,11 @@
 {
 	"type": "filament",
 	"name": "FLSun S1 PLA Silk",
-	"inherits": "FLSun Generic PLA",
+	"inherits": "FLSun S1 PLA Silk @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFL99",
 	"instantiation": "true",
-	"activate_air_filtration": [
-		"1"
-	],
-	"complete_print_exhaust_fan_speed": [
-		"0"
-	],
-	"during_print_exhaust_fan_speed": [
-		"100"
-	],
-	"fan_cooling_layer_time": [
-		"100"
-	],
-	"filament_cost": [
-		"0"
-	],
-	"filament_density": [
-		"1.32"
-	],
-	"full_fan_speed_layer": [
-		"3"
-	],
-	"hot_plate_temp": [
-		"60"
-	],
-	"hot_plate_temp_initial_layer": [
-		"60"
-	],
-	"nozzle_temperature": [
-		"230"
-	],
-	"nozzle_temperature_initial_layer": [
-		"230"
-	],
-	"nozzle_temperature_range_low": [
-		"190"
-	],
-	"nozzle_temperature_range_high": [
-		"240"
-	],
-	"overhang_fan_speed": [
-		"35"
-	],
-	"slow_down_layer_time": [
-		"1"
-	],
-	"slow_down_min_speed": [
-		"80"
-	],
-	"filament_max_volumetric_speed": [
-		"25"
-	],
-	"dont_slow_down_outer_wall": [
-		"1"
-	],
 	"compatible_printers": [
 		"FLSun S1 0.4 nozzle"
 	]

--- a/resources/profiles/FLSun/filament/FLSun S1 TPU.json
+++ b/resources/profiles/FLSun/filament/FLSun S1 TPU.json
@@ -1,78 +1,11 @@
 {
 	"type": "filament",
 	"name": "FLSun S1 TPU",
-	"inherits": "FLSun Generic TPU",
+	"inherits": "FLSun S1 TPU @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFU99",
 	"instantiation": "true",
-	"fan_max_speed": [
-		"100"
-	],
-	"fan_min_speed": [
-		"100"
-	],
-	"filament_density": [
-		"1.22"
-	],
-	"filament_flow_ratio": "1",
-	"activate_air_filtration": [
-		"1"
-	],
-	"complete_print_exhaust_fan_speed": [
-		"0"
-	],
-	"close_fan_the_first_x_layers": [
-		"1"
-	],
-	"during_print_exhaust_fan_speed": [
-		"100"
-	],
-	"fan_cooling_layer_time": [
-		"100"
-	],
-	"filament_cost": [
-		"0"
-	],
-	"full_fan_speed_layer": [
-		"3"
-	],
-	"hot_plate_temp": [
-		"35"
-	],
-	"hot_plate_temp_initial_layer": [
-		"35"
-	],
-	"nozzle_temperature": [
-		"240"
-	],
-	"nozzle_temperature_initial_layer": [
-		"240"
-	],
-	"nozzle_temperature_range_low": [
-		"200"
-	],
-	"nozzle_temperature_range_high": [
-		"250"
-	],
-	"overhang_fan_speed": [
-		"100"
-	],
-	"slow_down_layer_time": [
-		"8"
-	],
-	"slow_down_min_speed": [
-		"20"
-	],
-	"temperature_vitrification": [
-		"30"
-	],
-	"filament_max_volumetric_speed": [
-		"3.5"
-	],
-	"dont_slow_down_outer_wall": [
-		"1"
-	],
 	"compatible_printers": [
 		"FLSun S1 0.4 nozzle"
 	]

--- a/resources/profiles/FLSun/filament/FLSun T1 ABS.json
+++ b/resources/profiles/FLSun/filament/FLSun T1 ABS.json
@@ -1,75 +1,11 @@
 {
 	"type": "filament",
 	"name": "FLSun T1 ABS",
-	"inherits": "FLSun Generic ABS",
+	"inherits": "FLSun T1 ABS @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFB99",
 	"instantiation": "true",
-	"fan_max_speed": [
-		"50"
-	],
-	"fan_min_speed": [
-		"10"
-	],
-	"filament_density": [
-		"1.05"
-	],
-	"filament_flow_ratio": "0.95",
-	"activate_air_filtration": [
-		"1"
-	],
-	"complete_print_exhaust_fan_speed": [
-		"0"
-	],
-	"during_print_exhaust_fan_speed": [
-		"0"
-	],
-	"fan_cooling_layer_time": [
-		"30"
-	],
-	"filament_cost": [
-		"0"
-	],
-	"full_fan_speed_layer": [
-		"3"
-	],
-	"hot_plate_temp": [
-		"90"
-	],
-	"hot_plate_temp_initial_layer": [
-		"90"
-	],
-	"nozzle_temperature": [
-		"280"
-	],
-	"nozzle_temperature_initial_layer": [
-		"280"
-	],
-	"nozzle_temperature_range_low": [
-		"240"
-	],
-	"nozzle_temperature_range_high": [
-		"300"
-	],
-	"overhang_fan_speed": [
-		"50"
-	],
-	"slow_down_layer_time": [
-		"12"
-	],
-	"slow_down_min_speed": [
-		"30"
-	],
-	"temperature_vitrification": [
-		"100"
-	],
-	"filament_max_volumetric_speed": [
-		"20"
-	],
-	"dont_slow_down_outer_wall": [
-		"1"
-	],
 	"compatible_printers": [
 		"FLSun T1 0.4 nozzle"
 	]

--- a/resources/profiles/FLSun/filament/FLSun T1 ASA.json
+++ b/resources/profiles/FLSun/filament/FLSun T1 ASA.json
@@ -1,75 +1,11 @@
 {
 	"type": "filament",
 	"name": "FLSun T1 ASA",
-	"inherits": "FLSun Generic ASA",
+	"inherits": "FLSun T1 ASA @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFB98",
 	"instantiation": "true",
-	"fan_max_speed": [
-		"50"
-	],
-	"fan_min_speed": [
-		"35"
-	],
-	"filament_density": [
-		"1.05"
-	],
-	"filament_flow_ratio": "0.95",
-	"activate_air_filtration": [
-		"1"
-	],
-	"complete_print_exhaust_fan_speed": [
-		"0"
-	],
-	"during_print_exhaust_fan_speed": [
-		"0"
-	],
-	"fan_cooling_layer_time": [
-		"35"
-	],
-	"filament_cost": [
-		"0"
-	],
-	"full_fan_speed_layer": [
-		"3"
-	],
-	"hot_plate_temp": [
-		"90"
-	],
-	"hot_plate_temp_initial_layer": [
-		"90"
-	],
-	"nozzle_temperature": [
-		"280"
-	],
-	"nozzle_temperature_initial_layer": [
-		"280"
-	],
-	"nozzle_temperature_range_low": [
-		"240"
-	],
-	"nozzle_temperature_range_high": [
-		"300"
-	],
-	"overhang_fan_speed": [
-		"35"
-	],
-	"slow_down_layer_time": [
-		"2"
-	],
-	"slow_down_min_speed": [
-		"80"
-	],
-	"temperature_vitrification": [
-		"100"
-	],
-	"filament_max_volumetric_speed": [
-		"25"
-	],
-	"dont_slow_down_outer_wall": [
-		"1"
-	],
 	"compatible_printers": [
 		"FLSun T1 0.4 nozzle"
 	]

--- a/resources/profiles/FLSun/filament/FLSun T1 PETG.json
+++ b/resources/profiles/FLSun/filament/FLSun T1 PETG.json
@@ -1,71 +1,11 @@
 {
 	"type": "filament",
 	"name": "FLSun T1 PETG",
-	"inherits": "FLSun Generic PETG",
+	"inherits": "FLSun T1 PETG @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFG99",
 	"instantiation": "true",
-	"fan_max_speed": [
-		"60"
-	],
-	"fan_min_speed": [
-		"50"
-	],
-	"activate_air_filtration": [
-		"1"
-	],
-	"complete_print_exhaust_fan_speed": [
-		"0"
-	],
-	"during_print_exhaust_fan_speed": [
-		"100"
-	],
-	"fan_cooling_layer_time": [
-		"100"
-	],
-	"filament_cost": [
-		"0"
-	],
-	"full_fan_speed_layer": [
-		"2"
-	],
-	"hot_plate_temp": [
-		"80"
-	],
-	"hot_plate_temp_initial_layer": [
-		"80"
-	],
-	"nozzle_temperature": [
-		"260"
-	],
-	"nozzle_temperature_initial_layer": [
-		"260"
-	],
-	"nozzle_temperature_range_low": [
-		"230"
-	],
-	"nozzle_temperature_range_high": [
-		"270"
-	],
-	"overhang_fan_speed": [
-		"35"
-	],
-	"slow_down_layer_time": [
-		"2"
-	],
-	"slow_down_min_speed": [
-		"30"
-	],
-	"temperature_vitrification": [
-		"70"
-	],
-	"filament_max_volumetric_speed": [
-		"15"
-	],
-	"dont_slow_down_outer_wall": [
-		"1"
-	],
 	"compatible_printers": [
 		"FLSun T1 0.4 nozzle"
 	]

--- a/resources/profiles/FLSun/filament/FLSun T1 PLA Generic.json
+++ b/resources/profiles/FLSun/filament/FLSun T1 PLA Generic.json
@@ -1,65 +1,11 @@
 {
 	"type": "filament",
 	"name": "FLSun T1 PLA Generic",
-	"inherits": "FLSun Generic PLA",
+	"inherits": "FLSun T1 PLA Generic @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFL99",
 	"instantiation": "true",
-	"activate_air_filtration": [
-		"1"
-	],
-	"complete_print_exhaust_fan_speed": [
-		"0"
-	],
-	"during_print_exhaust_fan_speed": [
-		"100"
-	],
-	"fan_cooling_layer_time": [
-		"100"
-	],
-	"filament_cost": [
-		"0"
-	],
-	"filament_density": [
-		"1.32"
-	],
-	"full_fan_speed_layer": [
-		"3"
-	],
-	"hot_plate_temp": [
-		"60"
-	],
-	"hot_plate_temp_initial_layer": [
-		"60"
-	],
-	"nozzle_temperature": [
-		"230"
-	],
-	"nozzle_temperature_initial_layer": [
-		"230"
-	],
-	"nozzle_temperature_range_low": [
-		"190"
-	],
-	"nozzle_temperature_range_high": [
-		"240"
-	],
-	"overhang_fan_speed": [
-		"35"
-	],
-	"slow_down_layer_time": [
-		"1"
-	],
-	"slow_down_min_speed": [
-		"80"
-	],
-	"filament_max_volumetric_speed": [
-		"60"
-	],
-	"dont_slow_down_outer_wall": [
-		"1"
-	],
 	"compatible_printers": [
 		"FLSun T1 0.4 nozzle"
 	]

--- a/resources/profiles/FLSun/filament/FLSun T1 PLA High Speed.json
+++ b/resources/profiles/FLSun/filament/FLSun T1 PLA High Speed.json
@@ -1,62 +1,11 @@
 {
 	"type": "filament",
 	"name": "FLSun T1 PLA High Speed",
-	"inherits": "FLSun Generic PLA",
+	"inherits": "FLSun T1 PLA High Speed @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFL99",
 	"instantiation": "true",
-	"activate_air_filtration": [
-		"1"
-	],
-	"complete_print_exhaust_fan_speed": [
-		"0"
-	],
-	"during_print_exhaust_fan_speed": [
-		"100"
-	],
-	"fan_cooling_layer_time": [
-		"100"
-	],
-	"filament_cost": [
-		"0"
-	],
-	"full_fan_speed_layer": [
-		"3"
-	],
-	"hot_plate_temp": [
-		"60"
-	],
-	"hot_plate_temp_initial_layer": [
-		"60"
-	],
-	"nozzle_temperature": [
-		"230"
-	],
-	"nozzle_temperature_initial_layer": [
-		"230"
-	],
-	"nozzle_temperature_range_low": [
-		"190"
-	],
-	"nozzle_temperature_range_high": [
-		"240"
-	],
-	"overhang_fan_speed": [
-		"35"
-	],
-	"slow_down_layer_time": [
-		"1"
-	],
-	"slow_down_min_speed": [
-		"80"
-	],
-	"filament_max_volumetric_speed": [
-		"60"
-	],
-	"dont_slow_down_outer_wall": [
-		"1"
-	],
 	"compatible_printers": [
 		"FLSun T1 0.4 nozzle"
 	]

--- a/resources/profiles/FLSun/filament/FLSun T1 PLA Silk.json
+++ b/resources/profiles/FLSun/filament/FLSun T1 PLA Silk.json
@@ -1,65 +1,11 @@
 {
 	"type": "filament",
 	"name": "FLSun T1 PLA Silk",
-	"inherits": "FLSun Generic PLA",
+	"inherits": "FLSun T1 PLA Silk @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFL99",
 	"instantiation": "true",
-	"activate_air_filtration": [
-		"1"
-	],
-	"complete_print_exhaust_fan_speed": [
-		"0"
-	],
-	"during_print_exhaust_fan_speed": [
-		"100"
-	],
-	"fan_cooling_layer_time": [
-		"100"
-	],
-	"filament_cost": [
-		"0"
-	],
-	"filament_density": [
-		"1.32"
-	],
-	"full_fan_speed_layer": [
-		"3"
-	],
-	"hot_plate_temp": [
-		"60"
-	],
-	"hot_plate_temp_initial_layer": [
-		"60"
-	],
-	"nozzle_temperature": [
-		"230"
-	],
-	"nozzle_temperature_initial_layer": [
-		"230"
-	],
-	"nozzle_temperature_range_low": [
-		"190"
-	],
-	"nozzle_temperature_range_high": [
-		"240"
-	],
-	"overhang_fan_speed": [
-		"35"
-	],
-	"slow_down_layer_time": [
-		"1"
-	],
-	"slow_down_min_speed": [
-		"80"
-	],
-	"filament_max_volumetric_speed": [
-		"25"
-	],
-	"dont_slow_down_outer_wall": [
-		"1"
-	],
 	"compatible_printers": [
 		"FLSun T1 0.4 nozzle"
 	]

--- a/resources/profiles/FLSun/filament/FLSun T1 TPU.json
+++ b/resources/profiles/FLSun/filament/FLSun T1 TPU.json
@@ -1,78 +1,11 @@
 {
 	"type": "filament",
 	"name": "FLSun T1 TPU",
-	"inherits": "FLSun Generic TPU",
+	"inherits": "FLSun T1 TPU @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFU99",
 	"instantiation": "true",
-	"fan_max_speed": [
-		"100"
-	],
-	"fan_min_speed": [
-		"100"
-	],
-	"filament_density": [
-		"1.22"
-	],
-	"filament_flow_ratio": "1",
-	"activate_air_filtration": [
-		"1"
-	],
-	"complete_print_exhaust_fan_speed": [
-		"0"
-	],
-	"close_fan_the_first_x_layers": [
-		"1"
-	],
-	"during_print_exhaust_fan_speed": [
-		"100"
-	],
-	"fan_cooling_layer_time": [
-		"100"
-	],
-	"filament_cost": [
-		"0"
-	],
-	"full_fan_speed_layer": [
-		"3"
-	],
-	"hot_plate_temp": [
-		"35"
-	],
-	"hot_plate_temp_initial_layer": [
-		"35"
-	],
-	"nozzle_temperature": [
-		"240"
-	],
-	"nozzle_temperature_initial_layer": [
-		"240"
-	],
-	"nozzle_temperature_range_low": [
-		"200"
-	],
-	"nozzle_temperature_range_high": [
-		"250"
-	],
-	"overhang_fan_speed": [
-		"100"
-	],
-	"slow_down_layer_time": [
-		"8"
-	],
-	"slow_down_min_speed": [
-		"20"
-	],
-	"temperature_vitrification": [
-		"30"
-	],
-	"filament_max_volumetric_speed": [
-		"3.5"
-	],
-	"dont_slow_down_outer_wall": [
-		"1"
-	],
 	"compatible_printers": [
 		"FLSun T1 0.4 nozzle"
 	]

--- a/resources/profiles/OrcaFilamentLibrary.json
+++ b/resources/profiles/OrcaFilamentLibrary.json
@@ -1507,6 +1507,198 @@
 		{
 			"name": "GreenGate3D PETG @System",
 			"sub_path": "filament/GreenGate3D/GreenGate3D PETG @System.json"
+		},
+		{
+			"name": "FLSun Generic ABS @base",
+			"sub_path": "filament/FLSun/FLSun Generic ABS @base.json"
+		},
+		{
+			"name": "FLSun Generic ABS @System",
+			"sub_path": "filament/FLSun/FLSun Generic ABS @System.json"
+		},
+		{
+			"name": "FLSun Generic ASA @base",
+			"sub_path": "filament/FLSun/FLSun Generic ASA @base.json"
+		},
+		{
+			"name": "FLSun Generic ASA @System",
+			"sub_path": "filament/FLSun/FLSun Generic ASA @System.json"
+		},
+		{
+			"name": "FLSun Generic PA @base",
+			"sub_path": "filament/FLSun/FLSun Generic PA @base.json"
+		},
+		{
+			"name": "FLSun Generic PA @System",
+			"sub_path": "filament/FLSun/FLSun Generic PA @System.json"
+		},
+		{
+			"name": "FLSun Generic PA-CF @base",
+			"sub_path": "filament/FLSun/FLSun Generic PA-CF @base.json"
+		},
+		{
+			"name": "FLSun Generic PA-CF @System",
+			"sub_path": "filament/FLSun/FLSun Generic PA-CF @System.json"
+		},
+		{
+			"name": "FLSun Generic PC @base",
+			"sub_path": "filament/FLSun/FLSun Generic PC @base.json"
+		},
+		{
+			"name": "FLSun Generic PC @System",
+			"sub_path": "filament/FLSun/FLSun Generic PC @System.json"
+		},
+		{
+			"name": "FLSun Generic PETG @base",
+			"sub_path": "filament/FLSun/FLSun Generic PETG @base.json"
+		},
+		{
+			"name": "FLSun Generic PETG @System",
+			"sub_path": "filament/FLSun/FLSun Generic PETG @System.json"
+		},
+		{
+			"name": "FLSun Generic PLA @base",
+			"sub_path": "filament/FLSun/FLSun Generic PLA @base.json"
+		},
+		{
+			"name": "FLSun Generic PLA @System",
+			"sub_path": "filament/FLSun/FLSun Generic PLA @System.json"
+		},
+		{
+			"name": "FLSun Generic PLA-CF @base",
+			"sub_path": "filament/FLSun/FLSun Generic PLA-CF @base.json"
+		},
+		{
+			"name": "FLSun Generic PLA-CF @System",
+			"sub_path": "filament/FLSun/FLSun Generic PLA-CF @System.json"
+		},
+		{
+			"name": "FLSun Generic PVA @base",
+			"sub_path": "filament/FLSun/FLSun Generic PVA @base.json"
+		},
+		{
+			"name": "FLSun Generic PVA @System",
+			"sub_path": "filament/FLSun/FLSun Generic PVA @System.json"
+		},
+		{
+			"name": "FLSun Generic TPU @base",
+			"sub_path": "filament/FLSun/FLSun Generic TPU @base.json"
+		},
+		{
+			"name": "FLSun Generic TPU @System",
+			"sub_path": "filament/FLSun/FLSun Generic TPU @System.json"
+		},
+		{
+			"name": "FLSun S1 ABS @base",
+			"sub_path": "filament/FLSun/FLSun S1 ABS @base.json"
+		},
+		{
+			"name": "FLSun S1 ABS @System",
+			"sub_path": "filament/FLSun/FLSun S1 ABS @System.json"
+		},
+		{
+			"name": "FLSun S1 ASA @base",
+			"sub_path": "filament/FLSun/FLSun S1 ASA @base.json"
+		},
+		{
+			"name": "FLSun S1 ASA @System",
+			"sub_path": "filament/FLSun/FLSun S1 ASA @System.json"
+		},
+		{
+			"name": "FLSun S1 PETG @base",
+			"sub_path": "filament/FLSun/FLSun S1 PETG @base.json"
+		},
+		{
+			"name": "FLSun S1 PETG @System",
+			"sub_path": "filament/FLSun/FLSun S1 PETG @System.json"
+		},
+		{
+			"name": "FLSun S1 PLA Generic @base",
+			"sub_path": "filament/FLSun/FLSun S1 PLA Generic @base.json"
+		},
+		{
+			"name": "FLSun S1 PLA Generic @System",
+			"sub_path": "filament/FLSun/FLSun S1 PLA Generic @System.json"
+		},
+		{
+			"name": "FLSun S1 PLA High Speed @base",
+			"sub_path": "filament/FLSun/FLSun S1 PLA High Speed @base.json"
+		},
+		{
+			"name": "FLSun S1 PLA High Speed @System",
+			"sub_path": "filament/FLSun/FLSun S1 PLA High Speed @System.json"
+		},
+		{
+			"name": "FLSun S1 PLA Silk @base",
+			"sub_path": "filament/FLSun/FLSun S1 PLA Silk @base.json"
+		},
+		{
+			"name": "FLSun S1 PLA Silk @System",
+			"sub_path": "filament/FLSun/FLSun S1 PLA Silk @System.json"
+		},
+		{
+			"name": "FLSun S1 TPU @base",
+			"sub_path": "filament/FLSun/FLSun S1 TPU @base.json"
+		},
+		{
+			"name": "FLSun S1 TPU @System",
+			"sub_path": "filament/FLSun/FLSun S1 TPU @System.json"
+		},
+		{
+			"name": "FLSun T1 ABS @base",
+			"sub_path": "filament/FLSun/FLSun T1 ABS @base.json"
+		},
+		{
+			"name": "FLSun T1 ABS @System",
+			"sub_path": "filament/FLSun/FLSun T1 ABS @System.json"
+		},
+		{
+			"name": "FLSun T1 ASA @base",
+			"sub_path": "filament/FLSun/FLSun T1 ASA @base.json"
+		},
+		{
+			"name": "FLSun T1 ASA @System",
+			"sub_path": "filament/FLSun/FLSun T1 ASA @System.json"
+		},
+		{
+			"name": "FLSun T1 PETG @base",
+			"sub_path": "filament/FLSun/FLSun T1 PETG @base.json"
+		},
+		{
+			"name": "FLSun T1 PETG @System",
+			"sub_path": "filament/FLSun/FLSun T1 PETG @System.json"
+		},
+		{
+			"name": "FLSun T1 PLA Generic @base",
+			"sub_path": "filament/FLSun/FLSun T1 PLA Generic @base.json"
+		},
+		{
+			"name": "FLSun T1 PLA Generic @System",
+			"sub_path": "filament/FLSun/FLSun T1 PLA Generic @System.json"
+		},
+		{
+			"name": "FLSun T1 PLA High Speed @base",
+			"sub_path": "filament/FLSun/FLSun T1 PLA High Speed @base.json"
+		},
+		{
+			"name": "FLSun T1 PLA High Speed @System",
+			"sub_path": "filament/FLSun/FLSun T1 PLA High Speed @System.json"
+		},
+		{
+			"name": "FLSun T1 PLA Silk @base",
+			"sub_path": "filament/FLSun/FLSun T1 PLA Silk @base.json"
+		},
+		{
+			"name": "FLSun T1 PLA Silk @System",
+			"sub_path": "filament/FLSun/FLSun T1 PLA Silk @System.json"
+		},
+		{
+			"name": "FLSun T1 TPU @base",
+			"sub_path": "filament/FLSun/FLSun T1 TPU @base.json"
+		},
+		{
+			"name": "FLSun T1 TPU @System",
+			"sub_path": "filament/FLSun/FLSun T1 TPU @System.json"
 		}
 	],
 	"process_list": [],

--- a/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun Generic ABS @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun Generic ABS @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "FLSun Generic ABS @System",
+	"inherits": "FLSun Generic ABS @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFB99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun Generic ABS @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun Generic ABS @base.json
@@ -1,0 +1,145 @@
+{
+	"type": "filament",
+	"name": "FLSun Generic ABS @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"105"
+	],
+	"eng_plate_temp": [
+		"105"
+	],
+	"hot_plate_temp": [
+		"105"
+	],
+	"cool_plate_temp_initial_layer": [
+		"105"
+	],
+	"eng_plate_temp_initial_layer": [
+		"105"
+	],
+	"hot_plate_temp_initial_layer": [
+		"105"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"overhang_fan_speed": [
+		"80"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.926"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.04"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"12"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"ABS"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"260"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"80"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"3"
+	],
+	"filament_start_gcode": [
+		"; Filament gcode\n"
+	],
+	"nozzle_temperature": [
+		"260"
+	],
+	"temperature_vitrification": [
+		"110"
+	],
+	"nozzle_temperature_range_low": [
+		"240"
+	],
+	"nozzle_temperature_range_high": [
+		"270"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun Generic ASA @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun Generic ASA @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "FLSun Generic ASA @System",
+	"inherits": "FLSun Generic ASA @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFB98",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun Generic ASA @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun Generic ASA @base.json
@@ -1,0 +1,145 @@
+{
+	"type": "filament",
+	"name": "FLSun Generic ASA @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"105"
+	],
+	"eng_plate_temp": [
+		"105"
+	],
+	"hot_plate_temp": [
+		"105"
+	],
+	"cool_plate_temp_initial_layer": [
+		"105"
+	],
+	"eng_plate_temp_initial_layer": [
+		"105"
+	],
+	"hot_plate_temp_initial_layer": [
+		"105"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"overhang_fan_speed": [
+		"80"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.93"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"35"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.04"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"12"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"ASA"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"260"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"80"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"3"
+	],
+	"filament_start_gcode": [
+		"; Filament gcode\n"
+	],
+	"nozzle_temperature": [
+		"260"
+	],
+	"temperature_vitrification": [
+		"110"
+	],
+	"nozzle_temperature_range_low": [
+		"240"
+	],
+	"nozzle_temperature_range_high": [
+		"270"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun Generic PA @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun Generic PA @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "FLSun Generic PA @System",
+	"inherits": "FLSun Generic PA @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFN99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun Generic PA @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun Generic PA @base.json
@@ -1,0 +1,145 @@
+{
+	"type": "filament",
+	"name": "FLSun Generic PA @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"0"
+	],
+	"eng_plate_temp": [
+		"100"
+	],
+	"hot_plate_temp": [
+		"100"
+	],
+	"cool_plate_temp_initial_layer": [
+		"0"
+	],
+	"eng_plate_temp_initial_layer": [
+		"100"
+	],
+	"hot_plate_temp_initial_layer": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"95%"
+	],
+	"overhang_fan_speed": [
+		"30"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"1"
+	],
+	"reduce_fan_stop_start_freq": [
+		"0"
+	],
+	"fan_cooling_layer_time": [
+		"4"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.04"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"12"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PA"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"280"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"60"
+	],
+	"fan_min_speed": [
+		"0"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"2"
+	],
+	"filament_start_gcode": [
+		"; Filament gcode\n"
+	],
+	"nozzle_temperature": [
+		"280"
+	],
+	"temperature_vitrification": [
+		"108"
+	],
+	"nozzle_temperature_range_low": [
+		"270"
+	],
+	"nozzle_temperature_range_high": [
+		"300"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun Generic PA-CF @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun Generic PA-CF @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "FLSun Generic PA-CF @System",
+	"inherits": "FLSun Generic PA-CF @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFN98",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun Generic PA-CF @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun Generic PA-CF @base.json
@@ -1,0 +1,145 @@
+{
+	"type": "filament",
+	"name": "FLSun Generic PA-CF @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"0"
+	],
+	"eng_plate_temp": [
+		"100"
+	],
+	"hot_plate_temp": [
+		"100"
+	],
+	"cool_plate_temp_initial_layer": [
+		"0"
+	],
+	"eng_plate_temp_initial_layer": [
+		"100"
+	],
+	"hot_plate_temp_initial_layer": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"95%"
+	],
+	"overhang_fan_speed": [
+		"30"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"1"
+	],
+	"reduce_fan_stop_start_freq": [
+		"0"
+	],
+	"fan_cooling_layer_time": [
+		"4"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.04"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"8"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PA-CF"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"280"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"60"
+	],
+	"fan_min_speed": [
+		"0"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"2"
+	],
+	"filament_start_gcode": [
+		"; Filament gcode\n"
+	],
+	"nozzle_temperature": [
+		"280"
+	],
+	"temperature_vitrification": [
+		"108"
+	],
+	"nozzle_temperature_range_low": [
+		"270"
+	],
+	"nozzle_temperature_range_high": [
+		"300"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun Generic PC @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun Generic PC @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "FLSun Generic PC @System",
+	"inherits": "FLSun Generic PC @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFC99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun Generic PC @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun Generic PC @base.json
@@ -1,0 +1,145 @@
+{
+	"type": "filament",
+	"name": "FLSun Generic PC @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"0"
+	],
+	"eng_plate_temp": [
+		"110"
+	],
+	"hot_plate_temp": [
+		"110"
+	],
+	"cool_plate_temp_initial_layer": [
+		"0"
+	],
+	"eng_plate_temp_initial_layer": [
+		"110"
+	],
+	"hot_plate_temp_initial_layer": [
+		"110"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"overhang_fan_speed": [
+		"60"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.94"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.04"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"12"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PC"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"270"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"60"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"2"
+	],
+	"filament_start_gcode": [
+		"; Filament gcode\n"
+	],
+	"nozzle_temperature": [
+		"280"
+	],
+	"temperature_vitrification": [
+		"140"
+	],
+	"nozzle_temperature_range_low": [
+		"260"
+	],
+	"nozzle_temperature_range_high": [
+		"280"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun Generic PETG @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun Generic PETG @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "FLSun Generic PETG @System",
+	"inherits": "FLSun Generic PETG @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFG99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun Generic PETG @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun Generic PETG @base.json
@@ -1,0 +1,145 @@
+{
+	"type": "filament",
+	"name": "FLSun Generic PETG @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"60"
+	],
+	"eng_plate_temp": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"80"
+	],
+	"cool_plate_temp_initial_layer": [
+		"60"
+	],
+	"eng_plate_temp_initial_layer": [
+		"0"
+	],
+	"hot_plate_temp_initial_layer": [
+		"80"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"overhang_fan_speed": [
+		"90"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.95"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"filament_cost": [
+		"30"
+	],
+	"filament_density": [
+		"1.27"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"10"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PETG"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"255"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"90"
+	],
+	"fan_min_speed": [
+		"40"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"8"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n"
+	],
+	"nozzle_temperature": [
+		"255"
+	],
+	"temperature_vitrification": [
+		"80"
+	],
+	"nozzle_temperature_range_low": [
+		"220"
+	],
+	"nozzle_temperature_range_high": [
+		"260"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun Generic PLA @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun Generic PLA @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "FLSun Generic PLA @System",
+	"inherits": "FLSun Generic PLA @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFL99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun Generic PLA @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun Generic PLA @base.json
@@ -1,0 +1,148 @@
+{
+	"type": "filament",
+	"name": "FLSun Generic PLA @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"35"
+	],
+	"eng_plate_temp": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"45"
+	],
+	"cool_plate_temp_initial_layer": [
+		"35"
+	],
+	"eng_plate_temp_initial_layer": [
+		"0"
+	],
+	"hot_plate_temp_initial_layer": [
+		"45"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"12"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PLA"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"220"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"8"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n"
+	],
+	"nozzle_temperature": [
+		"220"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"230"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun Generic PLA-CF @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun Generic PLA-CF @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "FLSun Generic PLA-CF @System",
+	"inherits": "FLSun Generic PLA-CF @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFL98",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun Generic PLA-CF @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun Generic PLA-CF @base.json
@@ -1,0 +1,148 @@
+{
+	"type": "filament",
+	"name": "FLSun Generic PLA-CF @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"35"
+	],
+	"eng_plate_temp": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"45"
+	],
+	"cool_plate_temp_initial_layer": [
+		"35"
+	],
+	"eng_plate_temp_initial_layer": [
+		"0"
+	],
+	"hot_plate_temp_initial_layer": [
+		"45"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.95"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"12"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PLA-CF"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"220"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"7"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n"
+	],
+	"nozzle_temperature": [
+		"220"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"230"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun Generic PVA @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun Generic PVA @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "FLSun Generic PVA @System",
+	"inherits": "FLSun Generic PVA @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFS99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun Generic PVA @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun Generic PVA @base.json
@@ -1,0 +1,151 @@
+{
+	"type": "filament",
+	"name": "FLSun Generic PVA @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"35"
+	],
+	"eng_plate_temp": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"45"
+	],
+	"cool_plate_temp_initial_layer": [
+		"35"
+	],
+	"eng_plate_temp_initial_layer": [
+		"0"
+	],
+	"hot_plate_temp_initial_layer": [
+		"45"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.95"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"12"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"1"
+	],
+	"filament_type": [
+		"PVA"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"220"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"7"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n"
+	],
+	"nozzle_temperature": [
+		"220"
+	],
+	"temperature_vitrification": [
+		"50"
+	],
+	"filament_is_support": [
+		"1"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"250"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun Generic TPU @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun Generic TPU @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "FLSun Generic TPU @System",
+	"inherits": "FLSun Generic TPU @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFU99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun Generic TPU @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun Generic TPU @base.json
@@ -1,0 +1,148 @@
+{
+	"type": "filament",
+	"name": "FLSun Generic TPU @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"30"
+	],
+	"eng_plate_temp": [
+		"30"
+	],
+	"hot_plate_temp": [
+		"35"
+	],
+	"cool_plate_temp_initial_layer": [
+		"30"
+	],
+	"eng_plate_temp_initial_layer": [
+		"30"
+	],
+	"hot_plate_temp_initial_layer": [
+		"35"
+	],
+	"overhang_fan_threshold": [
+		"95%"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"1"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"3.2"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"0.4"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"TPU"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"240"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"8"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n"
+	],
+	"nozzle_temperature": [
+		"240"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"nozzle_temperature_range_low": [
+		"200"
+	],
+	"nozzle_temperature_range_high": [
+		"250"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun S1 ABS @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun S1 ABS @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "FLSun S1 ABS @System",
+	"inherits": "FLSun S1 ABS @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFB99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun S1 ABS @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun S1 ABS @base.json
@@ -1,0 +1,155 @@
+{
+	"type": "filament",
+	"name": "FLSun S1 ABS @base",
+	"inherits": "FLSun Generic ABS",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"105"
+	],
+	"eng_plate_temp": [
+		"105"
+	],
+	"hot_plate_temp": [
+		"90"
+	],
+	"cool_plate_temp_initial_layer": [
+		"105"
+	],
+	"eng_plate_temp_initial_layer": [
+		"105"
+	],
+	"hot_plate_temp_initial_layer": [
+		"90"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"overhang_fan_speed": [
+		"50"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": "0.95",
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"filament_cost": [
+		"0"
+	],
+	"filament_density": [
+		"1.05"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"20"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"ABS"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"280"
+	],
+	"full_fan_speed_layer": [
+		"3"
+	],
+	"fan_max_speed": [
+		"50"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"slow_down_min_speed": [
+		"30"
+	],
+	"slow_down_layer_time": [
+		"12"
+	],
+	"filament_start_gcode": [
+		"; Filament gcode\n"
+	],
+	"nozzle_temperature": [
+		"280"
+	],
+	"temperature_vitrification": [
+		"100"
+	],
+	"nozzle_temperature_range_low": [
+		"240"
+	],
+	"nozzle_temperature_range_high": [
+		"300"
+	],
+	"activate_air_filtration": [
+		"1"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"0"
+	],
+	"during_print_exhaust_fan_speed": [
+		"0"
+	],
+	"dont_slow_down_outer_wall": [
+		"1"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun S1 ASA @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun S1 ASA @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "FLSun S1 ASA @System",
+	"inherits": "FLSun S1 ASA @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFB98",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun S1 ASA @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun S1 ASA @base.json
@@ -1,0 +1,155 @@
+{
+	"type": "filament",
+	"name": "FLSun S1 ASA @base",
+	"inherits": "FLSun Generic ASA",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"105"
+	],
+	"eng_plate_temp": [
+		"105"
+	],
+	"hot_plate_temp": [
+		"90"
+	],
+	"cool_plate_temp_initial_layer": [
+		"105"
+	],
+	"eng_plate_temp_initial_layer": [
+		"105"
+	],
+	"hot_plate_temp_initial_layer": [
+		"90"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"overhang_fan_speed": [
+		"35"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": "0.95",
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"35"
+	],
+	"filament_cost": [
+		"0"
+	],
+	"filament_density": [
+		"1.05"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"25"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"ASA"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"280"
+	],
+	"full_fan_speed_layer": [
+		"3"
+	],
+	"fan_max_speed": [
+		"50"
+	],
+	"fan_min_speed": [
+		"35"
+	],
+	"slow_down_min_speed": [
+		"80"
+	],
+	"slow_down_layer_time": [
+		"2"
+	],
+	"filament_start_gcode": [
+		"; Filament gcode\n"
+	],
+	"nozzle_temperature": [
+		"280"
+	],
+	"temperature_vitrification": [
+		"100"
+	],
+	"nozzle_temperature_range_low": [
+		"240"
+	],
+	"nozzle_temperature_range_high": [
+		"300"
+	],
+	"activate_air_filtration": [
+		"1"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"0"
+	],
+	"during_print_exhaust_fan_speed": [
+		"0"
+	],
+	"dont_slow_down_outer_wall": [
+		"1"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun S1 PETG @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun S1 PETG @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "FLSun S1 PETG @System",
+	"inherits": "FLSun S1 PETG @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFG99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun S1 PETG @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun S1 PETG @base.json
@@ -1,0 +1,157 @@
+{
+	"type": "filament",
+	"name": "FLSun S1 PETG @base",
+	"inherits": "FLSun Generic PETG",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"60"
+	],
+	"eng_plate_temp": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"80"
+	],
+	"cool_plate_temp_initial_layer": [
+		"60"
+	],
+	"eng_plate_temp_initial_layer": [
+		"0"
+	],
+	"hot_plate_temp_initial_layer": [
+		"80"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"overhang_fan_speed": [
+		"35"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.95"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"filament_cost": [
+		"0"
+	],
+	"filament_density": [
+		"1.27"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"15"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PETG"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"260"
+	],
+	"full_fan_speed_layer": [
+		"2"
+	],
+	"fan_max_speed": [
+		"60"
+	],
+	"fan_min_speed": [
+		"50"
+	],
+	"slow_down_min_speed": [
+		"30"
+	],
+	"slow_down_layer_time": [
+		"2"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n"
+	],
+	"nozzle_temperature": [
+		"260"
+	],
+	"temperature_vitrification": [
+		"70"
+	],
+	"nozzle_temperature_range_low": [
+		"230"
+	],
+	"nozzle_temperature_range_high": [
+		"270"
+	],
+	"activate_air_filtration": [
+		"1"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"0"
+	],
+	"during_print_exhaust_fan_speed": [
+		"100"
+	],
+	"dont_slow_down_outer_wall": [
+		"1"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun S1 PLA Generic @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun S1 PLA Generic @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "FLSun S1 PLA Generic @System",
+	"inherits": "FLSun S1 PLA Generic @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFL99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun S1 PLA Generic @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun S1 PLA Generic @base.json
@@ -1,0 +1,160 @@
+{
+	"type": "filament",
+	"name": "FLSun S1 PLA Generic @base",
+	"inherits": "FLSun Generic PLA",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"35"
+	],
+	"eng_plate_temp": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"60"
+	],
+	"cool_plate_temp_initial_layer": [
+		"35"
+	],
+	"eng_plate_temp_initial_layer": [
+		"0"
+	],
+	"hot_plate_temp_initial_layer": [
+		"60"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"overhang_fan_speed": [
+		"35"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"filament_cost": [
+		"0"
+	],
+	"filament_density": [
+		"1.32"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"60"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PLA"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"230"
+	],
+	"full_fan_speed_layer": [
+		"3"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"slow_down_min_speed": [
+		"80"
+	],
+	"slow_down_layer_time": [
+		"1"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n"
+	],
+	"nozzle_temperature": [
+		"230"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"240"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"activate_air_filtration": [
+		"1"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"0"
+	],
+	"during_print_exhaust_fan_speed": [
+		"100"
+	],
+	"dont_slow_down_outer_wall": [
+		"1"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun S1 PLA High Speed @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun S1 PLA High Speed @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "FLSun S1 PLA High Speed @System",
+	"inherits": "FLSun S1 PLA High Speed @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFL99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun S1 PLA High Speed @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun S1 PLA High Speed @base.json
@@ -1,0 +1,160 @@
+{
+	"type": "filament",
+	"name": "FLSun S1 PLA High Speed @base",
+	"inherits": "FLSun Generic PLA",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"35"
+	],
+	"eng_plate_temp": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"60"
+	],
+	"cool_plate_temp_initial_layer": [
+		"35"
+	],
+	"eng_plate_temp_initial_layer": [
+		"0"
+	],
+	"hot_plate_temp_initial_layer": [
+		"60"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"overhang_fan_speed": [
+		"35"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"filament_cost": [
+		"0"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"110"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PLA"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"230"
+	],
+	"full_fan_speed_layer": [
+		"3"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"slow_down_min_speed": [
+		"80"
+	],
+	"slow_down_layer_time": [
+		"1"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n"
+	],
+	"nozzle_temperature": [
+		"230"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"240"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"activate_air_filtration": [
+		"1"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"0"
+	],
+	"during_print_exhaust_fan_speed": [
+		"100"
+	],
+	"dont_slow_down_outer_wall": [
+		"1"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun S1 PLA Silk @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun S1 PLA Silk @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "FLSun S1 PLA Silk @System",
+	"inherits": "FLSun S1 PLA Silk @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFL99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun S1 PLA Silk @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun S1 PLA Silk @base.json
@@ -1,0 +1,160 @@
+{
+	"type": "filament",
+	"name": "FLSun S1 PLA Silk @base",
+	"inherits": "FLSun Generic PLA",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"35"
+	],
+	"eng_plate_temp": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"60"
+	],
+	"cool_plate_temp_initial_layer": [
+		"35"
+	],
+	"eng_plate_temp_initial_layer": [
+		"0"
+	],
+	"hot_plate_temp_initial_layer": [
+		"60"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"overhang_fan_speed": [
+		"35"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"filament_cost": [
+		"0"
+	],
+	"filament_density": [
+		"1.32"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"25"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PLA"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"230"
+	],
+	"full_fan_speed_layer": [
+		"3"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"slow_down_min_speed": [
+		"80"
+	],
+	"slow_down_layer_time": [
+		"1"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n"
+	],
+	"nozzle_temperature": [
+		"230"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"240"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"activate_air_filtration": [
+		"1"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"0"
+	],
+	"during_print_exhaust_fan_speed": [
+		"100"
+	],
+	"dont_slow_down_outer_wall": [
+		"1"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun S1 TPU @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun S1 TPU @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "FLSun S1 TPU @System",
+	"inherits": "FLSun S1 TPU @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFU99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun S1 TPU @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun S1 TPU @base.json
@@ -1,0 +1,158 @@
+{
+	"type": "filament",
+	"name": "FLSun S1 TPU @base",
+	"inherits": "FLSun Generic TPU",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"30"
+	],
+	"eng_plate_temp": [
+		"30"
+	],
+	"hot_plate_temp": [
+		"35"
+	],
+	"cool_plate_temp_initial_layer": [
+		"30"
+	],
+	"eng_plate_temp_initial_layer": [
+		"30"
+	],
+	"hot_plate_temp_initial_layer": [
+		"35"
+	],
+	"overhang_fan_threshold": [
+		"95%"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": "1",
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"filament_cost": [
+		"0"
+	],
+	"filament_density": [
+		"1.22"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"3.5"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"0.4"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"TPU"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"240"
+	],
+	"full_fan_speed_layer": [
+		"3"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"slow_down_layer_time": [
+		"8"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n"
+	],
+	"nozzle_temperature": [
+		"240"
+	],
+	"temperature_vitrification": [
+		"30"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"nozzle_temperature_range_low": [
+		"200"
+	],
+	"nozzle_temperature_range_high": [
+		"250"
+	],
+	"activate_air_filtration": [
+		"1"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"0"
+	],
+	"during_print_exhaust_fan_speed": [
+		"100"
+	],
+	"dont_slow_down_outer_wall": [
+		"1"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun T1 ABS @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun T1 ABS @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "FLSun T1 ABS @System",
+	"inherits": "FLSun T1 ABS @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFB99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun T1 ABS @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun T1 ABS @base.json
@@ -1,0 +1,155 @@
+{
+	"type": "filament",
+	"name": "FLSun T1 ABS @base",
+	"inherits": "FLSun Generic ABS",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"105"
+	],
+	"eng_plate_temp": [
+		"105"
+	],
+	"hot_plate_temp": [
+		"90"
+	],
+	"cool_plate_temp_initial_layer": [
+		"105"
+	],
+	"eng_plate_temp_initial_layer": [
+		"105"
+	],
+	"hot_plate_temp_initial_layer": [
+		"90"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"overhang_fan_speed": [
+		"50"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": "0.95",
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"filament_cost": [
+		"0"
+	],
+	"filament_density": [
+		"1.05"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"20"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"ABS"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"280"
+	],
+	"full_fan_speed_layer": [
+		"3"
+	],
+	"fan_max_speed": [
+		"50"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"slow_down_min_speed": [
+		"30"
+	],
+	"slow_down_layer_time": [
+		"12"
+	],
+	"filament_start_gcode": [
+		"; Filament gcode\n"
+	],
+	"nozzle_temperature": [
+		"280"
+	],
+	"temperature_vitrification": [
+		"100"
+	],
+	"nozzle_temperature_range_low": [
+		"240"
+	],
+	"nozzle_temperature_range_high": [
+		"300"
+	],
+	"activate_air_filtration": [
+		"1"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"0"
+	],
+	"during_print_exhaust_fan_speed": [
+		"0"
+	],
+	"dont_slow_down_outer_wall": [
+		"1"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun T1 ASA @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun T1 ASA @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "FLSun T1 ASA @System",
+	"inherits": "FLSun T1 ASA @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFB98",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun T1 ASA @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun T1 ASA @base.json
@@ -1,0 +1,155 @@
+{
+	"type": "filament",
+	"name": "FLSun T1 ASA @base",
+	"inherits": "FLSun Generic ASA",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"105"
+	],
+	"eng_plate_temp": [
+		"105"
+	],
+	"hot_plate_temp": [
+		"90"
+	],
+	"cool_plate_temp_initial_layer": [
+		"105"
+	],
+	"eng_plate_temp_initial_layer": [
+		"105"
+	],
+	"hot_plate_temp_initial_layer": [
+		"90"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"overhang_fan_speed": [
+		"35"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": "0.95",
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"35"
+	],
+	"filament_cost": [
+		"0"
+	],
+	"filament_density": [
+		"1.05"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"25"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"ASA"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"280"
+	],
+	"full_fan_speed_layer": [
+		"3"
+	],
+	"fan_max_speed": [
+		"50"
+	],
+	"fan_min_speed": [
+		"35"
+	],
+	"slow_down_min_speed": [
+		"80"
+	],
+	"slow_down_layer_time": [
+		"2"
+	],
+	"filament_start_gcode": [
+		"; Filament gcode\n"
+	],
+	"nozzle_temperature": [
+		"280"
+	],
+	"temperature_vitrification": [
+		"100"
+	],
+	"nozzle_temperature_range_low": [
+		"240"
+	],
+	"nozzle_temperature_range_high": [
+		"300"
+	],
+	"activate_air_filtration": [
+		"1"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"0"
+	],
+	"during_print_exhaust_fan_speed": [
+		"0"
+	],
+	"dont_slow_down_outer_wall": [
+		"1"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun T1 PETG @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun T1 PETG @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "FLSun T1 PETG @System",
+	"inherits": "FLSun T1 PETG @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFG99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun T1 PETG @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun T1 PETG @base.json
@@ -1,0 +1,157 @@
+{
+	"type": "filament",
+	"name": "FLSun T1 PETG @base",
+	"inherits": "FLSun Generic PETG",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"60"
+	],
+	"eng_plate_temp": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"80"
+	],
+	"cool_plate_temp_initial_layer": [
+		"60"
+	],
+	"eng_plate_temp_initial_layer": [
+		"0"
+	],
+	"hot_plate_temp_initial_layer": [
+		"80"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"overhang_fan_speed": [
+		"35"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.95"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"filament_cost": [
+		"0"
+	],
+	"filament_density": [
+		"1.27"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"15"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PETG"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"260"
+	],
+	"full_fan_speed_layer": [
+		"2"
+	],
+	"fan_max_speed": [
+		"60"
+	],
+	"fan_min_speed": [
+		"50"
+	],
+	"slow_down_min_speed": [
+		"30"
+	],
+	"slow_down_layer_time": [
+		"2"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n"
+	],
+	"nozzle_temperature": [
+		"260"
+	],
+	"temperature_vitrification": [
+		"70"
+	],
+	"nozzle_temperature_range_low": [
+		"230"
+	],
+	"nozzle_temperature_range_high": [
+		"270"
+	],
+	"activate_air_filtration": [
+		"1"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"0"
+	],
+	"during_print_exhaust_fan_speed": [
+		"100"
+	],
+	"dont_slow_down_outer_wall": [
+		"1"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun T1 PLA Generic @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun T1 PLA Generic @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "FLSun T1 PLA Generic @System",
+	"inherits": "FLSun T1 PLA Generic @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFL99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun T1 PLA Generic @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun T1 PLA Generic @base.json
@@ -1,0 +1,160 @@
+{
+	"type": "filament",
+	"name": "FLSun T1 PLA Generic @base",
+	"inherits": "FLSun Generic PLA",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"35"
+	],
+	"eng_plate_temp": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"60"
+	],
+	"cool_plate_temp_initial_layer": [
+		"35"
+	],
+	"eng_plate_temp_initial_layer": [
+		"0"
+	],
+	"hot_plate_temp_initial_layer": [
+		"60"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"overhang_fan_speed": [
+		"35"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"filament_cost": [
+		"0"
+	],
+	"filament_density": [
+		"1.32"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"60"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PLA"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"230"
+	],
+	"full_fan_speed_layer": [
+		"3"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"slow_down_min_speed": [
+		"80"
+	],
+	"slow_down_layer_time": [
+		"1"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n"
+	],
+	"nozzle_temperature": [
+		"230"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"240"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"activate_air_filtration": [
+		"1"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"0"
+	],
+	"during_print_exhaust_fan_speed": [
+		"100"
+	],
+	"dont_slow_down_outer_wall": [
+		"1"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun T1 PLA High Speed @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun T1 PLA High Speed @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "FLSun T1 PLA High Speed @System",
+	"inherits": "FLSun T1 PLA High Speed @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFL99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun T1 PLA High Speed @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun T1 PLA High Speed @base.json
@@ -1,0 +1,160 @@
+{
+	"type": "filament",
+	"name": "FLSun T1 PLA High Speed @base",
+	"inherits": "FLSun Generic PLA",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"35"
+	],
+	"eng_plate_temp": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"60"
+	],
+	"cool_plate_temp_initial_layer": [
+		"35"
+	],
+	"eng_plate_temp_initial_layer": [
+		"0"
+	],
+	"hot_plate_temp_initial_layer": [
+		"60"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"overhang_fan_speed": [
+		"35"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"filament_cost": [
+		"0"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"60"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PLA"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"230"
+	],
+	"full_fan_speed_layer": [
+		"3"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"slow_down_min_speed": [
+		"80"
+	],
+	"slow_down_layer_time": [
+		"1"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n"
+	],
+	"nozzle_temperature": [
+		"230"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"240"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"activate_air_filtration": [
+		"1"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"0"
+	],
+	"during_print_exhaust_fan_speed": [
+		"100"
+	],
+	"dont_slow_down_outer_wall": [
+		"1"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun T1 PLA Silk @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun T1 PLA Silk @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "FLSun T1 PLA Silk @System",
+	"inherits": "FLSun T1 PLA Silk @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFL99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun T1 PLA Silk @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun T1 PLA Silk @base.json
@@ -1,0 +1,160 @@
+{
+	"type": "filament",
+	"name": "FLSun T1 PLA Silk @base",
+	"inherits": "FLSun Generic PLA",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"35"
+	],
+	"eng_plate_temp": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"60"
+	],
+	"cool_plate_temp_initial_layer": [
+		"35"
+	],
+	"eng_plate_temp_initial_layer": [
+		"0"
+	],
+	"hot_plate_temp_initial_layer": [
+		"60"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"overhang_fan_speed": [
+		"35"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"filament_cost": [
+		"0"
+	],
+	"filament_density": [
+		"1.32"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"25"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PLA"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"230"
+	],
+	"full_fan_speed_layer": [
+		"3"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"slow_down_min_speed": [
+		"80"
+	],
+	"slow_down_layer_time": [
+		"1"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n"
+	],
+	"nozzle_temperature": [
+		"230"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"240"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"activate_air_filtration": [
+		"1"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"0"
+	],
+	"during_print_exhaust_fan_speed": [
+		"100"
+	],
+	"dont_slow_down_outer_wall": [
+		"1"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun T1 TPU @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun T1 TPU @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "FLSun T1 TPU @System",
+	"inherits": "FLSun T1 TPU @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFU99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun T1 TPU @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FLSun/FLSun T1 TPU @base.json
@@ -1,0 +1,158 @@
+{
+	"type": "filament",
+	"name": "FLSun T1 TPU @base",
+	"inherits": "FLSun Generic TPU",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"30"
+	],
+	"eng_plate_temp": [
+		"30"
+	],
+	"hot_plate_temp": [
+		"35"
+	],
+	"cool_plate_temp_initial_layer": [
+		"30"
+	],
+	"eng_plate_temp_initial_layer": [
+		"30"
+	],
+	"hot_plate_temp_initial_layer": [
+		"35"
+	],
+	"overhang_fan_threshold": [
+		"95%"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": "1",
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"filament_cost": [
+		"0"
+	],
+	"filament_density": [
+		"1.22"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"3.5"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"0.4"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"TPU"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"240"
+	],
+	"full_fan_speed_layer": [
+		"3"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"slow_down_layer_time": [
+		"8"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n"
+	],
+	"nozzle_temperature": [
+		"240"
+	],
+	"temperature_vitrification": [
+		"30"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"nozzle_temperature_range_low": [
+		"200"
+	],
+	"nozzle_temperature_range_high": [
+		"250"
+	],
+	"activate_air_filtration": [
+		"1"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"0"
+	],
+	"during_print_exhaust_fan_speed": [
+		"100"
+	],
+	"dont_slow_down_outer_wall": [
+		"1"
+	]
+}


### PR DESCRIPTION
## Summary

Migrates FLSun filament presets so their reusable base settings live under OrcaFilamentLibrary while the vendor-scoped presets keep printer compatibility constraints.

## Changes

- Added FLSun Generic/S1/T1 filament `@base` and `@System` presets under `resources/profiles/OrcaFilamentLibrary/filament/FLSun`.
- Updated FLSun vendor filament presets to inherit from the new library bases.
- Registered the FLSun OrcaFilamentLibrary entries in `resources/profiles/OrcaFilamentLibrary.json`.

## Testing

- `python3 scripts/orca_extra_profile_check.py --vendor FLSun --check-filaments --check-materials --check-obsolete-keys` — 0 errors, 0 warnings.
- `git diff --check`

Part of OrcaSlicer/OrcaSlicer#12162