### PR TITLE
Migrate Volumic filaments to OrcaFilamentLibrary

### DIFF
--- a/resources/profiles/OrcaFilamentLibrary.json
+++ b/resources/profiles/OrcaFilamentLibrary.json
@@ -1507,6 +1507,222 @@
 		{
 			"name": "GreenGate3D PETG @System",
 			"sub_path": "filament/GreenGate3D/GreenGate3D PETG @System.json"
+		},
+		{
+			"name": "Désactivé @base",
+			"sub_path": "filament/Volumic/Désactivé @base.json"
+		},
+		{
+			"name": "Désactivé @System",
+			"sub_path": "filament/Volumic/Désactivé @System.json"
+		},
+		{
+			"name": "PA6 CF20 (Performance) @base",
+			"sub_path": "filament/Volumic/PA6 CF20 (Performance) @base.json"
+		},
+		{
+			"name": "PA6 CF20 (Performance) @System",
+			"sub_path": "filament/Volumic/PA6 CF20 (Performance) @System.json"
+		},
+		{
+			"name": "PETG ESD (Performance) @base",
+			"sub_path": "filament/Volumic/PETG ESD (Performance) @base.json"
+		},
+		{
+			"name": "PETG ESD (Performance) @System",
+			"sub_path": "filament/Volumic/PETG ESD (Performance) @System.json"
+		},
+		{
+			"name": "PPS Carbone (Performance) @base",
+			"sub_path": "filament/Volumic/PPS Carbone (Performance) @base.json"
+		},
+		{
+			"name": "PPS Carbone (Performance) @System",
+			"sub_path": "filament/Volumic/PPS Carbone (Performance) @System.json"
+		},
+		{
+			"name": "Volumic ABS Ultra @base",
+			"sub_path": "filament/Volumic/Volumic ABS Ultra @base.json"
+		},
+		{
+			"name": "Volumic ABS Ultra @System",
+			"sub_path": "filament/Volumic/Volumic ABS Ultra @System.json"
+		},
+		{
+			"name": "Volumic ABS Ultra (Performance) @base",
+			"sub_path": "filament/Volumic/Volumic ABS Ultra (Performance) @base.json"
+		},
+		{
+			"name": "Volumic ABS Ultra (Performance) @System",
+			"sub_path": "filament/Volumic/Volumic ABS Ultra (Performance) @System.json"
+		},
+		{
+			"name": "Volumic ASA Ultra @base",
+			"sub_path": "filament/Volumic/Volumic ASA Ultra @base.json"
+		},
+		{
+			"name": "Volumic ASA Ultra @System",
+			"sub_path": "filament/Volumic/Volumic ASA Ultra @System.json"
+		},
+		{
+			"name": "Volumic ASA Ultra (Performance) @base",
+			"sub_path": "filament/Volumic/Volumic ASA Ultra (Performance) @base.json"
+		},
+		{
+			"name": "Volumic ASA Ultra (Performance) @System",
+			"sub_path": "filament/Volumic/Volumic ASA Ultra (Performance) @System.json"
+		},
+		{
+			"name": "Volumic FLEX93 Ultra @base",
+			"sub_path": "filament/Volumic/Volumic FLEX93 Ultra @base.json"
+		},
+		{
+			"name": "Volumic FLEX93 Ultra @System",
+			"sub_path": "filament/Volumic/Volumic FLEX93 Ultra @System.json"
+		},
+		{
+			"name": "Volumic FLEX93 Ultra (Performance) @base",
+			"sub_path": "filament/Volumic/Volumic FLEX93 Ultra (Performance) @base.json"
+		},
+		{
+			"name": "Volumic FLEX93 Ultra (Performance) @System",
+			"sub_path": "filament/Volumic/Volumic FLEX93 Ultra (Performance) @System.json"
+		},
+		{
+			"name": "Volumic NYLON Ultra @base",
+			"sub_path": "filament/Volumic/Volumic NYLON Ultra @base.json"
+		},
+		{
+			"name": "Volumic NYLON Ultra @System",
+			"sub_path": "filament/Volumic/Volumic NYLON Ultra @System.json"
+		},
+		{
+			"name": "Volumic NYLON Ultra (Performance) @base",
+			"sub_path": "filament/Volumic/Volumic NYLON Ultra (Performance) @base.json"
+		},
+		{
+			"name": "Volumic NYLON Ultra (Performance) @System",
+			"sub_path": "filament/Volumic/Volumic NYLON Ultra (Performance) @System.json"
+		},
+		{
+			"name": "Volumic PC @base",
+			"sub_path": "filament/Volumic/Volumic PC @base.json"
+		},
+		{
+			"name": "Volumic PC @System",
+			"sub_path": "filament/Volumic/Volumic PC @System.json"
+		},
+		{
+			"name": "Volumic PC (Performance) @base",
+			"sub_path": "filament/Volumic/Volumic PC (Performance) @base.json"
+		},
+		{
+			"name": "Volumic PC (Performance) @System",
+			"sub_path": "filament/Volumic/Volumic PC (Performance) @System.json"
+		},
+		{
+			"name": "Volumic PCTG Ultra (Performance) @base",
+			"sub_path": "filament/Volumic/Volumic PCTG Ultra (Performance) @base.json"
+		},
+		{
+			"name": "Volumic PCTG Ultra (Performance) @System",
+			"sub_path": "filament/Volumic/Volumic PCTG Ultra (Performance) @System.json"
+		},
+		{
+			"name": "Volumic PETG Ultra @base",
+			"sub_path": "filament/Volumic/Volumic PETG Ultra @base.json"
+		},
+		{
+			"name": "Volumic PETG Ultra @System",
+			"sub_path": "filament/Volumic/Volumic PETG Ultra @System.json"
+		},
+		{
+			"name": "Volumic PETG Ultra (Performance) @base",
+			"sub_path": "filament/Volumic/Volumic PETG Ultra (Performance) @base.json"
+		},
+		{
+			"name": "Volumic PETG Ultra (Performance) @System",
+			"sub_path": "filament/Volumic/Volumic PETG Ultra (Performance) @System.json"
+		},
+		{
+			"name": "Volumic PETG Ultra carbone @base",
+			"sub_path": "filament/Volumic/Volumic PETG Ultra carbone @base.json"
+		},
+		{
+			"name": "Volumic PETG Ultra carbone @System",
+			"sub_path": "filament/Volumic/Volumic PETG Ultra carbone @System.json"
+		},
+		{
+			"name": "Volumic PETG Ultra carbone (Performance) @base",
+			"sub_path": "filament/Volumic/Volumic PETG Ultra carbone (Performance) @base.json"
+		},
+		{
+			"name": "Volumic PETG Ultra carbone (Performance) @System",
+			"sub_path": "filament/Volumic/Volumic PETG Ultra carbone (Performance) @System.json"
+		},
+		{
+			"name": "Volumic PLA Ultra @base",
+			"sub_path": "filament/Volumic/Volumic PLA Ultra @base.json"
+		},
+		{
+			"name": "Volumic PLA Ultra @System",
+			"sub_path": "filament/Volumic/Volumic PLA Ultra @System.json"
+		},
+		{
+			"name": "Volumic PLA Ultra (Performance) @base",
+			"sub_path": "filament/Volumic/Volumic PLA Ultra (Performance) @base.json"
+		},
+		{
+			"name": "Volumic PLA Ultra (Performance) @System",
+			"sub_path": "filament/Volumic/Volumic PLA Ultra (Performance) @System.json"
+		},
+		{
+			"name": "Volumic PP Ultra @base",
+			"sub_path": "filament/Volumic/Volumic PP Ultra @base.json"
+		},
+		{
+			"name": "Volumic PP Ultra @System",
+			"sub_path": "filament/Volumic/Volumic PP Ultra @System.json"
+		},
+		{
+			"name": "Volumic PP Ultra (Performance) @base",
+			"sub_path": "filament/Volumic/Volumic PP Ultra (Performance) @base.json"
+		},
+		{
+			"name": "Volumic PP Ultra (Performance) @System",
+			"sub_path": "filament/Volumic/Volumic PP Ultra (Performance) @System.json"
+		},
+		{
+			"name": "Volumic PVA @base",
+			"sub_path": "filament/Volumic/Volumic PVA @base.json"
+		},
+		{
+			"name": "Volumic PVA @System",
+			"sub_path": "filament/Volumic/Volumic PVA @System.json"
+		},
+		{
+			"name": "Volumic PVA-BVOH (Performance) @base",
+			"sub_path": "filament/Volumic/Volumic PVA-BVOH (Performance) @base.json"
+		},
+		{
+			"name": "Volumic PVA-BVOH (Performance) @System",
+			"sub_path": "filament/Volumic/Volumic PVA-BVOH (Performance) @System.json"
+		},
+		{
+			"name": "Volumic UNIVERSAL Ultra @base",
+			"sub_path": "filament/Volumic/Volumic UNIVERSAL Ultra @base.json"
+		},
+		{
+			"name": "Volumic UNIVERSAL Ultra @System",
+			"sub_path": "filament/Volumic/Volumic UNIVERSAL Ultra @System.json"
+		},
+		{
+			"name": "Volumic UNIVERSAL Ultra (Performance) @base",
+			"sub_path": "filament/Volumic/Volumic UNIVERSAL Ultra (Performance) @base.json"
+		},
+		{
+			"name": "Volumic UNIVERSAL Ultra (Performance) @System",
+			"sub_path": "filament/Volumic/Volumic UNIVERSAL Ultra (Performance) @System.json"
 		}
 	],
 	"process_list": [],

--- a/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Désactivé @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Désactivé @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Désactivé @System",
+	"inherits": "Désactivé @base",
+	"from": "system",
+	"setting_id": "DFSL99",
+	"filament_id": "DFL99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Désactivé @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Désactivé @base.json
@@ -1,0 +1,94 @@
+{
+	"type": "filament",
+	"name": "Désactivé @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"50"
+	],
+	"eng_plate_temp": [
+		"50"
+	],
+	"hot_plate_temp": [
+		"0"
+	],
+	"textured_plate_temp": [
+		"50"
+	],
+	"cool_plate_temp_initial_layer": [
+		"50"
+	],
+	"eng_plate_temp_initial_layer": [
+		"50"
+	],
+	"hot_plate_temp_initial_layer": [
+		"50"
+	],
+	"textured_plate_temp_initial_layer": [
+		"50"
+	],
+	"filament_max_volumetric_speed": [
+		"1"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"filament_cost": [
+		"37.50"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_type": [
+		"PLA"
+	],
+	"filament_vendor": [
+		"Volumic"
+	],
+	"bed_type": [
+		"Hot Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"0"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"0"
+	],
+	"fan_min_speed": [
+		"0"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"4"
+	],
+	"nozzle_temperature": [
+		"0"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"filament_flow_ratio": [
+		"0.1"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Volumic/PA6 CF20 (Performance) @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Volumic/PA6 CF20 (Performance) @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "PA6 CF20 (Performance) @System",
+	"inherits": "PA6 CF20 (Performance) @base",
+	"from": "system",
+	"setting_id": "GFSN98",
+	"filament_id": "GFN99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Volumic/PA6 CF20 (Performance) @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Volumic/PA6 CF20 (Performance) @base.json
@@ -1,0 +1,100 @@
+{
+	"type": "filament",
+	"name": "PA6 CF20 (Performance) @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"65"
+	],
+	"eng_plate_temp": [
+		"65"
+	],
+	"hot_plate_temp": [
+		"45"
+	],
+	"textured_plate_temp": [
+		"65"
+	],
+	"cool_plate_temp_initial_layer": [
+		"65"
+	],
+	"eng_plate_temp_initial_layer": [
+		"65"
+	],
+	"hot_plate_temp_initial_layer": [
+		"45"
+	],
+	"textured_plate_temp_initial_layer": [
+		"65"
+	],
+	"filament_max_volumetric_speed": [
+		"36"
+	],
+	"overhang_fan_speed": [
+		"50"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"fan_cooling_layer_time": [
+		"4"
+	],
+	"filament_cost": [
+		"37.50"
+	],
+	"filament_density": [
+		"1.14"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_type": [
+		"PA6-CF"
+	],
+	"filament_vendor": [
+		"Volumic"
+	],
+	"bed_type": [
+		"Hot Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"270"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"30"
+	],
+	"fan_min_speed": [
+		"0"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"2"
+	],
+	"nozzle_temperature": [
+		"270"
+	],
+	"reduce_fan_stop_start_freq": [
+		"0"
+	],
+	"filament_flow_ratio": [
+		"0.96"
+	],
+	"nozzle_temperature_range_high": [
+		"290"
+	],
+	"nozzle_temperature_range_low": [
+		"240"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Volumic/PETG ESD (Performance) @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Volumic/PETG ESD (Performance) @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "PETG ESD (Performance) @System",
+	"inherits": "PETG ESD (Performance) @base",
+	"from": "system",
+	"setting_id": "GFSG99",
+	"filament_id": "GFG99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Volumic/PETG ESD (Performance) @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Volumic/PETG ESD (Performance) @base.json
@@ -1,0 +1,100 @@
+{
+	"type": "filament",
+	"name": "PETG ESD (Performance) @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"60"
+	],
+	"eng_plate_temp": [
+		"60"
+	],
+	"hot_plate_temp": [
+		"75"
+	],
+	"textured_plate_temp": [
+		"60"
+	],
+	"cool_plate_temp_initial_layer": [
+		"60"
+	],
+	"eng_plate_temp_initial_layer": [
+		"60"
+	],
+	"hot_plate_temp_initial_layer": [
+		"75"
+	],
+	"textured_plate_temp_initial_layer": [
+		"60"
+	],
+	"filament_max_volumetric_speed": [
+		"36"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"20"
+	],
+	"filament_cost": [
+		"37.50"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_type": [
+		"PETG-ESD"
+	],
+	"filament_vendor": [
+		"Volumic"
+	],
+	"bed_type": [
+		"Hot Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"270"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"40"
+	],
+	"fan_min_speed": [
+		"0"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"8"
+	],
+	"nozzle_temperature": [
+		"270"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"filament_flow_ratio": [
+		"1.00"
+	],
+	"nozzle_temperature_range_high": [
+		"290"
+	],
+	"nozzle_temperature_range_low": [
+		"250"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Volumic/PPS Carbone (Performance) @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Volumic/PPS Carbone (Performance) @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "PPS Carbone (Performance) @System",
+	"inherits": "PPS Carbone (Performance) @base",
+	"from": "system",
+	"setting_id": "GFSN98",
+	"filament_id": "GFN99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Volumic/PPS Carbone (Performance) @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Volumic/PPS Carbone (Performance) @base.json
@@ -1,0 +1,103 @@
+{
+	"type": "filament",
+	"name": "PPS Carbone (Performance) @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"65"
+	],
+	"eng_plate_temp": [
+		"65"
+	],
+	"hot_plate_temp": [
+		"90"
+	],
+	"textured_plate_temp": [
+		"65"
+	],
+	"cool_plate_temp_initial_layer": [
+		"65"
+	],
+	"eng_plate_temp_initial_layer": [
+		"65"
+	],
+	"hot_plate_temp_initial_layer": [
+		"90"
+	],
+	"textured_plate_temp_initial_layer": [
+		"65"
+	],
+	"filament_max_volumetric_speed": [
+		"25"
+	],
+	"overhang_fan_speed": [
+		"50"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"fan_cooling_layer_time": [
+		"4"
+	],
+	"filament_cost": [
+		"37.50"
+	],
+	"filament_density": [
+		"1.29"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_type": [
+		"PPS-CF"
+	],
+	"filament_vendor": [
+		"Volumic"
+	],
+	"bed_type": [
+		"Hot Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"320"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"0"
+	],
+	"fan_min_speed": [
+		"0"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"2"
+	],
+	"nozzle_temperature": [
+		"320"
+	],
+	"reduce_fan_stop_start_freq": [
+		"0"
+	],
+	"filament_flow_ratio": [
+		"1.00"
+	],
+	"nozzle_temperature_range_high": [
+		"350"
+	],
+	"nozzle_temperature_range_low": [
+		"310"
+	],
+	"temperature_vitrification": [
+		"98"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic ABS Ultra (Performance) @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic ABS Ultra (Performance) @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Volumic ABS Ultra (Performance) @System",
+	"inherits": "Volumic ABS Ultra (Performance) @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFB99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic ABS Ultra (Performance) @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic ABS Ultra (Performance) @base.json
@@ -1,0 +1,94 @@
+{
+	"type": "filament",
+	"name": "Volumic ABS Ultra (Performance) @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"90"
+	],
+	"eng_plate_temp": [
+		"90"
+	],
+	"hot_plate_temp": [
+		"75"
+	],
+	"textured_plate_temp": [
+		"90"
+	],
+	"cool_plate_temp_initial_layer": [
+		"90"
+	],
+	"eng_plate_temp_initial_layer": [
+		"90"
+	],
+	"hot_plate_temp_initial_layer": [
+		"90"
+	],
+	"textured_plate_temp_initial_layer": [
+		"90"
+	],
+	"filament_max_volumetric_speed": [
+		"36"
+	],
+	"overhang_fan_speed": [
+		"70"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"filament_cost": [
+		"37.50"
+	],
+	"filament_density": [
+		"1.04"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_type": [
+		"ABS"
+	],
+	"filament_vendor": [
+		"Volumic"
+	],
+	"bed_type": [
+		"Hot Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"240"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"40"
+	],
+	"fan_min_speed": [
+		"30"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"3"
+	],
+	"nozzle_temperature": [
+		"240"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"filament_flow_ratio": [
+		"1.00"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic ABS Ultra @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic ABS Ultra @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Volumic ABS Ultra @System",
+	"inherits": "Volumic ABS Ultra @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFB99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic ABS Ultra @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic ABS Ultra @base.json
@@ -1,0 +1,94 @@
+{
+	"type": "filament",
+	"name": "Volumic ABS Ultra @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"90"
+	],
+	"eng_plate_temp": [
+		"90"
+	],
+	"hot_plate_temp": [
+		"75"
+	],
+	"textured_plate_temp": [
+		"90"
+	],
+	"cool_plate_temp_initial_layer": [
+		"90"
+	],
+	"eng_plate_temp_initial_layer": [
+		"90"
+	],
+	"hot_plate_temp_initial_layer": [
+		"90"
+	],
+	"textured_plate_temp_initial_layer": [
+		"90"
+	],
+	"filament_max_volumetric_speed": [
+		"22"
+	],
+	"overhang_fan_speed": [
+		"70"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"filament_cost": [
+		"37.50"
+	],
+	"filament_density": [
+		"1.04"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_type": [
+		"ABS"
+	],
+	"filament_vendor": [
+		"Volumic"
+	],
+	"bed_type": [
+		"Hot Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"235"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"30"
+	],
+	"fan_min_speed": [
+		"30"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"3"
+	],
+	"nozzle_temperature": [
+		"235"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"filament_flow_ratio": [
+		"1.00"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic ASA Ultra (Performance) @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic ASA Ultra (Performance) @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Volumic ASA Ultra (Performance) @System",
+	"inherits": "Volumic ASA Ultra (Performance) @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFB99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic ASA Ultra (Performance) @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic ASA Ultra (Performance) @base.json
@@ -1,0 +1,94 @@
+{
+	"type": "filament",
+	"name": "Volumic ASA Ultra (Performance) @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"0"
+	],
+	"eng_plate_temp": [
+		"90"
+	],
+	"hot_plate_temp": [
+		"85"
+	],
+	"textured_plate_temp": [
+		"90"
+	],
+	"cool_plate_temp_initial_layer": [
+		"0"
+	],
+	"eng_plate_temp_initial_layer": [
+		"90"
+	],
+	"hot_plate_temp_initial_layer": [
+		"90"
+	],
+	"textured_plate_temp_initial_layer": [
+		"90"
+	],
+	"filament_max_volumetric_speed": [
+		"36"
+	],
+	"overhang_fan_speed": [
+		"70"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"fan_cooling_layer_time": [
+		"35"
+	],
+	"filament_cost": [
+		"37.50"
+	],
+	"filament_density": [
+		"1.04"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_type": [
+		"ASA"
+	],
+	"filament_vendor": [
+		"Volumic"
+	],
+	"bed_type": [
+		"Hot Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"245"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"30"
+	],
+	"fan_min_speed": [
+		"30"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"3"
+	],
+	"nozzle_temperature": [
+		"245"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"filament_flow_ratio": [
+		"0.96"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic ASA Ultra @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic ASA Ultra @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Volumic ASA Ultra @System",
+	"inherits": "Volumic ASA Ultra @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFB99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic ASA Ultra @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic ASA Ultra @base.json
@@ -1,0 +1,94 @@
+{
+	"type": "filament",
+	"name": "Volumic ASA Ultra @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"0"
+	],
+	"eng_plate_temp": [
+		"90"
+	],
+	"hot_plate_temp": [
+		"85"
+	],
+	"textured_plate_temp": [
+		"90"
+	],
+	"cool_plate_temp_initial_layer": [
+		"0"
+	],
+	"eng_plate_temp_initial_layer": [
+		"90"
+	],
+	"hot_plate_temp_initial_layer": [
+		"90"
+	],
+	"textured_plate_temp_initial_layer": [
+		"90"
+	],
+	"filament_max_volumetric_speed": [
+		"22"
+	],
+	"overhang_fan_speed": [
+		"70"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"fan_cooling_layer_time": [
+		"35"
+	],
+	"filament_cost": [
+		"37.50"
+	],
+	"filament_density": [
+		"1.04"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_type": [
+		"ASA"
+	],
+	"filament_vendor": [
+		"Volumic"
+	],
+	"bed_type": [
+		"Hot Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"235"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"30"
+	],
+	"fan_min_speed": [
+		"30"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"3"
+	],
+	"nozzle_temperature": [
+		"235"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"filament_flow_ratio": [
+		"0.96"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic FLEX93 Ultra (Performance) @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic FLEX93 Ultra (Performance) @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Volumic FLEX93 Ultra (Performance) @System",
+	"inherits": "Volumic FLEX93 Ultra (Performance) @base",
+	"from": "system",
+	"setting_id": "GFSR99",
+	"filament_id": "GFU99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic FLEX93 Ultra (Performance) @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic FLEX93 Ultra (Performance) @base.json
@@ -1,0 +1,97 @@
+{
+	"type": "filament",
+	"name": "Volumic FLEX93 Ultra (Performance) @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"45"
+	],
+	"eng_plate_temp": [
+		"45"
+	],
+	"hot_plate_temp": [
+		"45"
+	],
+	"textured_plate_temp": [
+		"45"
+	],
+	"cool_plate_temp_initial_layer": [
+		"30"
+	],
+	"eng_plate_temp_initial_layer": [
+		"30"
+	],
+	"hot_plate_temp_initial_layer": [
+		"30"
+	],
+	"textured_plate_temp_initial_layer": [
+		"30"
+	],
+	"filament_max_volumetric_speed": [
+		"16"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"filament_cost": [
+		"37.50"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_type": [
+		"TPU"
+	],
+	"filament_vendor": [
+		"Volumic"
+	],
+	"bed_type": [
+		"Hot Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"235"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"8"
+	],
+	"nozzle_temperature": [
+		"235"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"filament_flow_ratio": [
+		"1.00"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic FLEX93 Ultra @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic FLEX93 Ultra @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Volumic FLEX93 Ultra @System",
+	"inherits": "Volumic FLEX93 Ultra @base",
+	"from": "system",
+	"setting_id": "GFSR99",
+	"filament_id": "GFU99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic FLEX93 Ultra @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic FLEX93 Ultra @base.json
@@ -1,0 +1,97 @@
+{
+	"type": "filament",
+	"name": "Volumic FLEX93 Ultra @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"45"
+	],
+	"eng_plate_temp": [
+		"45"
+	],
+	"hot_plate_temp": [
+		"45"
+	],
+	"textured_plate_temp": [
+		"45"
+	],
+	"cool_plate_temp_initial_layer": [
+		"30"
+	],
+	"eng_plate_temp_initial_layer": [
+		"30"
+	],
+	"hot_plate_temp_initial_layer": [
+		"30"
+	],
+	"textured_plate_temp_initial_layer": [
+		"30"
+	],
+	"filament_max_volumetric_speed": [
+		"5"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"filament_cost": [
+		"37.50"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_type": [
+		"TPU"
+	],
+	"filament_vendor": [
+		"Volumic"
+	],
+	"bed_type": [
+		"Hot Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"210"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"80"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"8"
+	],
+	"nozzle_temperature": [
+		"235"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"filament_flow_ratio": [
+		"1.20"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic NYLON Ultra (Performance) @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic NYLON Ultra (Performance) @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Volumic NYLON Ultra (Performance) @System",
+	"inherits": "Volumic NYLON Ultra (Performance) @base",
+	"from": "system",
+	"setting_id": "GFSN98",
+	"filament_id": "GFN99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic NYLON Ultra (Performance) @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic NYLON Ultra (Performance) @base.json
@@ -1,0 +1,94 @@
+{
+	"type": "filament",
+	"name": "Volumic NYLON Ultra (Performance) @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"65"
+	],
+	"eng_plate_temp": [
+		"65"
+	],
+	"hot_plate_temp": [
+		"65"
+	],
+	"textured_plate_temp": [
+		"65"
+	],
+	"cool_plate_temp_initial_layer": [
+		"65"
+	],
+	"eng_plate_temp_initial_layer": [
+		"65"
+	],
+	"hot_plate_temp_initial_layer": [
+		"65"
+	],
+	"textured_plate_temp_initial_layer": [
+		"65"
+	],
+	"filament_max_volumetric_speed": [
+		"30"
+	],
+	"overhang_fan_speed": [
+		"50"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"fan_cooling_layer_time": [
+		"4"
+	],
+	"filament_cost": [
+		"37.50"
+	],
+	"filament_density": [
+		"1.04"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_type": [
+		"PA"
+	],
+	"filament_vendor": [
+		"Volumic"
+	],
+	"bed_type": [
+		"Hot Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"245"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"0"
+	],
+	"fan_min_speed": [
+		"0"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"2"
+	],
+	"nozzle_temperature": [
+		"245"
+	],
+	"reduce_fan_stop_start_freq": [
+		"0"
+	],
+	"filament_flow_ratio": [
+		"1.00"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic NYLON Ultra @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic NYLON Ultra @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Volumic NYLON Ultra @System",
+	"inherits": "Volumic NYLON Ultra @base",
+	"from": "system",
+	"setting_id": "GFSN98",
+	"filament_id": "GFN99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic NYLON Ultra @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic NYLON Ultra @base.json
@@ -1,0 +1,94 @@
+{
+	"type": "filament",
+	"name": "Volumic NYLON Ultra @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"65"
+	],
+	"eng_plate_temp": [
+		"65"
+	],
+	"hot_plate_temp": [
+		"65"
+	],
+	"textured_plate_temp": [
+		"65"
+	],
+	"cool_plate_temp_initial_layer": [
+		"65"
+	],
+	"eng_plate_temp_initial_layer": [
+		"65"
+	],
+	"hot_plate_temp_initial_layer": [
+		"65"
+	],
+	"textured_plate_temp_initial_layer": [
+		"65"
+	],
+	"filament_max_volumetric_speed": [
+		"22"
+	],
+	"overhang_fan_speed": [
+		"50"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"fan_cooling_layer_time": [
+		"4"
+	],
+	"filament_cost": [
+		"37.50"
+	],
+	"filament_density": [
+		"1.04"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_type": [
+		"PA"
+	],
+	"filament_vendor": [
+		"Volumic"
+	],
+	"bed_type": [
+		"Hot Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"238"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"0"
+	],
+	"fan_min_speed": [
+		"0"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"2"
+	],
+	"nozzle_temperature": [
+		"238"
+	],
+	"reduce_fan_stop_start_freq": [
+		"0"
+	],
+	"filament_flow_ratio": [
+		"1.00"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic PC (Performance) @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic PC (Performance) @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Volumic PC (Performance) @System",
+	"inherits": "Volumic PC (Performance) @base",
+	"from": "system",
+	"setting_id": "GFSC99",
+	"filament_id": "GFC99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic PC (Performance) @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic PC (Performance) @base.json
@@ -1,0 +1,94 @@
+{
+	"type": "filament",
+	"name": "Volumic PC (Performance) @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"0"
+	],
+	"eng_plate_temp": [
+		"110"
+	],
+	"hot_plate_temp": [
+		"120"
+	],
+	"textured_plate_temp": [
+		"110"
+	],
+	"cool_plate_temp_initial_layer": [
+		"0"
+	],
+	"eng_plate_temp_initial_layer": [
+		"110"
+	],
+	"hot_plate_temp_initial_layer": [
+		"110"
+	],
+	"textured_plate_temp_initial_layer": [
+		"110"
+	],
+	"filament_max_volumetric_speed": [
+		"36"
+	],
+	"overhang_fan_speed": [
+		"50"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"filament_cost": [
+		"37.50"
+	],
+	"filament_density": [
+		"1.04"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_type": [
+		"PC"
+	],
+	"filament_vendor": [
+		"Volumic"
+	],
+	"bed_type": [
+		"Hot Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"280"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"0"
+	],
+	"fan_min_speed": [
+		"0"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"2"
+	],
+	"nozzle_temperature": [
+		"280"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"filament_flow_ratio": [
+		"1.00"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic PC @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic PC @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Volumic PC @System",
+	"inherits": "Volumic PC @base",
+	"from": "system",
+	"setting_id": "GFSC99",
+	"filament_id": "GFC99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic PC @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic PC @base.json
@@ -1,0 +1,94 @@
+{
+	"type": "filament",
+	"name": "Volumic PC @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"0"
+	],
+	"eng_plate_temp": [
+		"110"
+	],
+	"hot_plate_temp": [
+		"115"
+	],
+	"textured_plate_temp": [
+		"110"
+	],
+	"cool_plate_temp_initial_layer": [
+		"0"
+	],
+	"eng_plate_temp_initial_layer": [
+		"110"
+	],
+	"hot_plate_temp_initial_layer": [
+		"110"
+	],
+	"textured_plate_temp_initial_layer": [
+		"110"
+	],
+	"filament_max_volumetric_speed": [
+		"22"
+	],
+	"overhang_fan_speed": [
+		"50"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"filament_cost": [
+		"37.50"
+	],
+	"filament_density": [
+		"1.04"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_type": [
+		"PC"
+	],
+	"filament_vendor": [
+		"Volumic"
+	],
+	"bed_type": [
+		"Hot Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"270"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"0"
+	],
+	"fan_min_speed": [
+		"0"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"2"
+	],
+	"nozzle_temperature": [
+		"270"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"filament_flow_ratio": [
+		"1.00"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic PCTG Ultra (Performance) @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic PCTG Ultra (Performance) @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Volumic PCTG Ultra (Performance) @System",
+	"inherits": "Volumic PCTG Ultra (Performance) @base",
+	"from": "system",
+	"setting_id": "GFSG99",
+	"filament_id": "GFG99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic PCTG Ultra (Performance) @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic PCTG Ultra (Performance) @base.json
@@ -1,0 +1,94 @@
+{
+	"type": "filament",
+	"name": "Volumic PCTG Ultra (Performance) @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"60"
+	],
+	"eng_plate_temp": [
+		"60"
+	],
+	"hot_plate_temp": [
+		"60"
+	],
+	"textured_plate_temp": [
+		"60"
+	],
+	"cool_plate_temp_initial_layer": [
+		"60"
+	],
+	"eng_plate_temp_initial_layer": [
+		"60"
+	],
+	"hot_plate_temp_initial_layer": [
+		"60"
+	],
+	"textured_plate_temp_initial_layer": [
+		"60"
+	],
+	"filament_max_volumetric_speed": [
+		"36"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"20"
+	],
+	"filament_cost": [
+		"37.50"
+	],
+	"filament_density": [
+		"1.27"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_type": [
+		"PETG"
+	],
+	"filament_vendor": [
+		"Volumic"
+	],
+	"bed_type": [
+		"Hot Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"270"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"90"
+	],
+	"fan_min_speed": [
+		"60"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"8"
+	],
+	"nozzle_temperature": [
+		"270"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"filament_flow_ratio": [
+		"1.00"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic PETG Ultra (Performance) @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic PETG Ultra (Performance) @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Volumic PETG Ultra (Performance) @System",
+	"inherits": "Volumic PETG Ultra (Performance) @base",
+	"from": "system",
+	"setting_id": "GFSG99",
+	"filament_id": "GFG99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic PETG Ultra (Performance) @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic PETG Ultra (Performance) @base.json
@@ -1,0 +1,94 @@
+{
+	"type": "filament",
+	"name": "Volumic PETG Ultra (Performance) @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"60"
+	],
+	"eng_plate_temp": [
+		"60"
+	],
+	"hot_plate_temp": [
+		"60"
+	],
+	"textured_plate_temp": [
+		"60"
+	],
+	"cool_plate_temp_initial_layer": [
+		"60"
+	],
+	"eng_plate_temp_initial_layer": [
+		"60"
+	],
+	"hot_plate_temp_initial_layer": [
+		"60"
+	],
+	"textured_plate_temp_initial_layer": [
+		"60"
+	],
+	"filament_max_volumetric_speed": [
+		"36"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"20"
+	],
+	"filament_cost": [
+		"37.50"
+	],
+	"filament_density": [
+		"1.27"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_type": [
+		"PETG"
+	],
+	"filament_vendor": [
+		"Volumic"
+	],
+	"bed_type": [
+		"Hot Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"240"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"90"
+	],
+	"fan_min_speed": [
+		"70"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"8"
+	],
+	"nozzle_temperature": [
+		"240"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"filament_flow_ratio": [
+		"1.00"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic PETG Ultra @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic PETG Ultra @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Volumic PETG Ultra @System",
+	"inherits": "Volumic PETG Ultra @base",
+	"from": "system",
+	"setting_id": "GFSG99",
+	"filament_id": "GFG99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic PETG Ultra @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic PETG Ultra @base.json
@@ -1,0 +1,94 @@
+{
+	"type": "filament",
+	"name": "Volumic PETG Ultra @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"60"
+	],
+	"eng_plate_temp": [
+		"60"
+	],
+	"hot_plate_temp": [
+		"60"
+	],
+	"textured_plate_temp": [
+		"60"
+	],
+	"cool_plate_temp_initial_layer": [
+		"60"
+	],
+	"eng_plate_temp_initial_layer": [
+		"60"
+	],
+	"hot_plate_temp_initial_layer": [
+		"60"
+	],
+	"textured_plate_temp_initial_layer": [
+		"60"
+	],
+	"filament_max_volumetric_speed": [
+		"22"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"20"
+	],
+	"filament_cost": [
+		"37.50"
+	],
+	"filament_density": [
+		"1.27"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_type": [
+		"PETG"
+	],
+	"filament_vendor": [
+		"Volumic"
+	],
+	"bed_type": [
+		"Hot Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"235"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"80"
+	],
+	"fan_min_speed": [
+		"50"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"8"
+	],
+	"nozzle_temperature": [
+		"235"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"filament_flow_ratio": [
+		"1.00"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic PETG Ultra carbone (Performance) @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic PETG Ultra carbone (Performance) @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Volumic PETG Ultra carbone (Performance) @System",
+	"inherits": "Volumic PETG Ultra carbone (Performance) @base",
+	"from": "system",
+	"setting_id": "GFSG50",
+	"filament_id": "GFG98",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic PETG Ultra carbone (Performance) @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic PETG Ultra carbone (Performance) @base.json
@@ -1,0 +1,94 @@
+{
+	"type": "filament",
+	"name": "Volumic PETG Ultra carbone (Performance) @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"60"
+	],
+	"eng_plate_temp": [
+		"60"
+	],
+	"hot_plate_temp": [
+		"65"
+	],
+	"textured_plate_temp": [
+		"60"
+	],
+	"cool_plate_temp_initial_layer": [
+		"60"
+	],
+	"eng_plate_temp_initial_layer": [
+		"60"
+	],
+	"hot_plate_temp_initial_layer": [
+		"60"
+	],
+	"textured_plate_temp_initial_layer": [
+		"60"
+	],
+	"filament_max_volumetric_speed": [
+		"30"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"20"
+	],
+	"filament_cost": [
+		"37.50"
+	],
+	"filament_density": [
+		"1.27"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_type": [
+		"PETG"
+	],
+	"filament_vendor": [
+		"Volumic"
+	],
+	"bed_type": [
+		"Hot Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"245"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"60"
+	],
+	"fan_min_speed": [
+		"60"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"8"
+	],
+	"nozzle_temperature": [
+		"245"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"filament_flow_ratio": [
+		"1.00"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic PETG Ultra carbone @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic PETG Ultra carbone @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Volumic PETG Ultra carbone @System",
+	"inherits": "Volumic PETG Ultra carbone @base",
+	"from": "system",
+	"setting_id": "GFSG50",
+	"filament_id": "GFG98",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic PETG Ultra carbone @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic PETG Ultra carbone @base.json
@@ -1,0 +1,94 @@
+{
+	"type": "filament",
+	"name": "Volumic PETG Ultra carbone @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"60"
+	],
+	"eng_plate_temp": [
+		"60"
+	],
+	"hot_plate_temp": [
+		"65"
+	],
+	"textured_plate_temp": [
+		"60"
+	],
+	"cool_plate_temp_initial_layer": [
+		"60"
+	],
+	"eng_plate_temp_initial_layer": [
+		"60"
+	],
+	"hot_plate_temp_initial_layer": [
+		"60"
+	],
+	"textured_plate_temp_initial_layer": [
+		"60"
+	],
+	"filament_max_volumetric_speed": [
+		"20"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"20"
+	],
+	"filament_cost": [
+		"37.50"
+	],
+	"filament_density": [
+		"1.27"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_type": [
+		"PETG"
+	],
+	"filament_vendor": [
+		"Volumic"
+	],
+	"bed_type": [
+		"Hot Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"235"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"60"
+	],
+	"fan_min_speed": [
+		"60"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"8"
+	],
+	"nozzle_temperature": [
+		"230"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"filament_flow_ratio": [
+		"1.00"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic PLA Ultra (Performance) @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic PLA Ultra (Performance) @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Volumic PLA Ultra (Performance) @System",
+	"inherits": "Volumic PLA Ultra (Performance) @base",
+	"from": "system",
+	"setting_id": "GFSL99",
+	"filament_id": "GFL99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic PLA Ultra (Performance) @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic PLA Ultra (Performance) @base.json
@@ -1,0 +1,94 @@
+{
+	"type": "filament",
+	"name": "Volumic PLA Ultra (Performance) @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"50"
+	],
+	"eng_plate_temp": [
+		"50"
+	],
+	"hot_plate_temp": [
+		"50"
+	],
+	"textured_plate_temp": [
+		"50"
+	],
+	"cool_plate_temp_initial_layer": [
+		"50"
+	],
+	"eng_plate_temp_initial_layer": [
+		"50"
+	],
+	"hot_plate_temp_initial_layer": [
+		"50"
+	],
+	"textured_plate_temp_initial_layer": [
+		"50"
+	],
+	"filament_max_volumetric_speed": [
+		"36"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"filament_cost": [
+		"37.50"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_type": [
+		"PLA"
+	],
+	"filament_vendor": [
+		"Volumic"
+	],
+	"bed_type": [
+		"Hot Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"210"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"4"
+	],
+	"nozzle_temperature": [
+		"210"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"filament_flow_ratio": [
+		"1.00"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic PLA Ultra @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic PLA Ultra @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Volumic PLA Ultra @System",
+	"inherits": "Volumic PLA Ultra @base",
+	"from": "system",
+	"setting_id": "GFSL99",
+	"filament_id": "GFL99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic PLA Ultra @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic PLA Ultra @base.json
@@ -1,0 +1,94 @@
+{
+	"type": "filament",
+	"name": "Volumic PLA Ultra @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"50"
+	],
+	"eng_plate_temp": [
+		"50"
+	],
+	"hot_plate_temp": [
+		"50"
+	],
+	"textured_plate_temp": [
+		"50"
+	],
+	"cool_plate_temp_initial_layer": [
+		"50"
+	],
+	"eng_plate_temp_initial_layer": [
+		"50"
+	],
+	"hot_plate_temp_initial_layer": [
+		"50"
+	],
+	"textured_plate_temp_initial_layer": [
+		"50"
+	],
+	"filament_max_volumetric_speed": [
+		"22"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"filament_cost": [
+		"37.50"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_type": [
+		"PLA"
+	],
+	"filament_vendor": [
+		"Volumic"
+	],
+	"bed_type": [
+		"Hot Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"210"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"4"
+	],
+	"nozzle_temperature": [
+		"210"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"filament_flow_ratio": [
+		"1.00"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic PP Ultra (Performance) @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic PP Ultra (Performance) @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Volumic PP Ultra (Performance) @System",
+	"inherits": "Volumic PP Ultra (Performance) @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFB99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic PP Ultra (Performance) @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic PP Ultra (Performance) @base.json
@@ -1,0 +1,112 @@
+{
+	"type": "filament",
+	"name": "Volumic PP Ultra (Performance) @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"90"
+	],
+	"eng_plate_temp": [
+		"90"
+	],
+	"hot_plate_temp": [
+		"70"
+	],
+	"textured_plate_temp": [
+		"90"
+	],
+	"cool_plate_temp_initial_layer": [
+		"90"
+	],
+	"eng_plate_temp_initial_layer": [
+		"90"
+	],
+	"hot_plate_temp_initial_layer": [
+		"90"
+	],
+	"textured_plate_temp_initial_layer": [
+		"90"
+	],
+	"filament_max_volumetric_speed": [
+		"22"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"4"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"filament_cost": [
+		"37.50"
+	],
+	"filament_density": [
+		"0.92"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_type": [
+		"PP"
+	],
+	"filament_vendor": [
+		"Volumic"
+	],
+	"bed_type": [
+		"Hot Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"205"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"3"
+	],
+	"nozzle_temperature": [
+		"205"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"filament_flow_ratio": [
+		"1.0"
+	],
+	"filament_retraction_length": [
+		"3"
+	],
+	"filament_z_hop": [
+		"0.4"
+	],
+	"nozzle_temperature_range_high": [
+		"225"
+	],
+	"nozzle_temperature_range_low": [
+		"200"
+	],
+	"internal_bridge_fan_speed": [
+		"100"
+	],
+	"support_material_interface_fan_speed": [
+		"100"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic PP Ultra @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic PP Ultra @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Volumic PP Ultra @System",
+	"inherits": "Volumic PP Ultra @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFB99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic PP Ultra @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic PP Ultra @base.json
@@ -1,0 +1,94 @@
+{
+	"type": "filament",
+	"name": "Volumic PP Ultra @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"90"
+	],
+	"eng_plate_temp": [
+		"90"
+	],
+	"hot_plate_temp": [
+		"90"
+	],
+	"textured_plate_temp": [
+		"90"
+	],
+	"cool_plate_temp_initial_layer": [
+		"90"
+	],
+	"eng_plate_temp_initial_layer": [
+		"90"
+	],
+	"hot_plate_temp_initial_layer": [
+		"90"
+	],
+	"textured_plate_temp_initial_layer": [
+		"90"
+	],
+	"filament_max_volumetric_speed": [
+		"22"
+	],
+	"overhang_fan_speed": [
+		"80"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"4"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"filament_cost": [
+		"37.50"
+	],
+	"filament_density": [
+		"0.92"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_type": [
+		"PP"
+	],
+	"filament_vendor": [
+		"Volumic"
+	],
+	"bed_type": [
+		"Hot Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"225"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"80"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"3"
+	],
+	"nozzle_temperature": [
+		"225"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"filament_flow_ratio": [
+		"1.24"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic PVA @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic PVA @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Volumic PVA @System",
+	"inherits": "Volumic PVA @base",
+	"from": "system",
+	"setting_id": "GFSS99",
+	"filament_id": "GFS99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic PVA @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic PVA @base.json
@@ -1,0 +1,100 @@
+{
+	"type": "filament",
+	"name": "Volumic PVA @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"60"
+	],
+	"eng_plate_temp": [
+		"60"
+	],
+	"hot_plate_temp": [
+		"60"
+	],
+	"textured_plate_temp": [
+		"60"
+	],
+	"cool_plate_temp_initial_layer": [
+		"60"
+	],
+	"eng_plate_temp_initial_layer": [
+		"60"
+	],
+	"hot_plate_temp_initial_layer": [
+		"60"
+	],
+	"textured_plate_temp_initial_layer": [
+		"60"
+	],
+	"filament_max_volumetric_speed": [
+		"20"
+	],
+	"overhang_fan_speed": [
+		"80"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"filament_cost": [
+		"37.50"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_type": [
+		"PVA"
+	],
+	"filament_vendor": [
+		"Volumic"
+	],
+	"bed_type": [
+		"Hot Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"220"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"70"
+	],
+	"fan_min_speed": [
+		"40"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"4"
+	],
+	"nozzle_temperature": [
+		"210"
+	],
+	"filament_soluble": [
+		"1"
+	],
+	"filament_is_support": [
+		"1"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"filament_flow_ratio": [
+		"1.00"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic PVA-BVOH (Performance) @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic PVA-BVOH (Performance) @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Volumic PVA-BVOH (Performance) @System",
+	"inherits": "Volumic PVA-BVOH (Performance) @base",
+	"from": "system",
+	"setting_id": "GFSS99",
+	"filament_id": "GFS99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic PVA-BVOH (Performance) @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic PVA-BVOH (Performance) @base.json
@@ -1,0 +1,100 @@
+{
+	"type": "filament",
+	"name": "Volumic PVA-BVOH (Performance) @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"60"
+	],
+	"eng_plate_temp": [
+		"60"
+	],
+	"hot_plate_temp": [
+		"60"
+	],
+	"textured_plate_temp": [
+		"60"
+	],
+	"cool_plate_temp_initial_layer": [
+		"60"
+	],
+	"eng_plate_temp_initial_layer": [
+		"60"
+	],
+	"hot_plate_temp_initial_layer": [
+		"60"
+	],
+	"textured_plate_temp_initial_layer": [
+		"60"
+	],
+	"filament_max_volumetric_speed": [
+		"20"
+	],
+	"overhang_fan_speed": [
+		"80"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"filament_cost": [
+		"37.50"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_type": [
+		"PVA"
+	],
+	"filament_vendor": [
+		"Volumic"
+	],
+	"bed_type": [
+		"Hot Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"220"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"80"
+	],
+	"fan_min_speed": [
+		"40"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"4"
+	],
+	"nozzle_temperature": [
+		"220"
+	],
+	"filament_soluble": [
+		"1"
+	],
+	"filament_is_support": [
+		"1"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"filament_flow_ratio": [
+		"1.00"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic UNIVERSAL Ultra (Performance) @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic UNIVERSAL Ultra (Performance) @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Volumic UNIVERSAL Ultra (Performance) @System",
+	"inherits": "Volumic UNIVERSAL Ultra (Performance) @base",
+	"from": "system",
+	"setting_id": "GFSL99",
+	"filament_id": "GFL99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic UNIVERSAL Ultra (Performance) @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic UNIVERSAL Ultra (Performance) @base.json
@@ -1,0 +1,94 @@
+{
+	"type": "filament",
+	"name": "Volumic UNIVERSAL Ultra (Performance) @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"50"
+	],
+	"eng_plate_temp": [
+		"50"
+	],
+	"hot_plate_temp": [
+		"50"
+	],
+	"textured_plate_temp": [
+		"50"
+	],
+	"cool_plate_temp_initial_layer": [
+		"50"
+	],
+	"eng_plate_temp_initial_layer": [
+		"50"
+	],
+	"hot_plate_temp_initial_layer": [
+		"50"
+	],
+	"textured_plate_temp_initial_layer": [
+		"50"
+	],
+	"filament_max_volumetric_speed": [
+		"36"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"filament_cost": [
+		"37.50"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_type": [
+		"UNIV"
+	],
+	"filament_vendor": [
+		"Volumic"
+	],
+	"bed_type": [
+		"Hot Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"220"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"4"
+	],
+	"nozzle_temperature": [
+		"220"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"filament_flow_ratio": [
+		"1.00"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic UNIVERSAL Ultra @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic UNIVERSAL Ultra @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Volumic UNIVERSAL Ultra @System",
+	"inherits": "Volumic UNIVERSAL Ultra @base",
+	"from": "system",
+	"setting_id": "GFSL99",
+	"filament_id": "GFL99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic UNIVERSAL Ultra @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Volumic/Volumic UNIVERSAL Ultra @base.json
@@ -1,0 +1,94 @@
+{
+	"type": "filament",
+	"name": "Volumic UNIVERSAL Ultra @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"50"
+	],
+	"eng_plate_temp": [
+		"50"
+	],
+	"hot_plate_temp": [
+		"50"
+	],
+	"textured_plate_temp": [
+		"50"
+	],
+	"cool_plate_temp_initial_layer": [
+		"50"
+	],
+	"eng_plate_temp_initial_layer": [
+		"50"
+	],
+	"hot_plate_temp_initial_layer": [
+		"50"
+	],
+	"textured_plate_temp_initial_layer": [
+		"50"
+	],
+	"filament_max_volumetric_speed": [
+		"22"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"filament_cost": [
+		"37.50"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_type": [
+		"UNIV"
+	],
+	"filament_vendor": [
+		"Volumic"
+	],
+	"bed_type": [
+		"Hot Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"210"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"4"
+	],
+	"nozzle_temperature": [
+		"225"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"filament_flow_ratio": [
+		"1.00"
+	]
+}

--- a/resources/profiles/Volumic/filament/PA6 CF20 (Performance).json
+++ b/resources/profiles/Volumic/filament/PA6 CF20 (Performance).json
@@ -1,47 +1,11 @@
 {
 	"type": "filament",
-	"filament_id": "GFN99",
-	"setting_id": "GFSN98",
 	"name": "PA6 CF20 (Performance)",
+	"inherits": "PA6 CF20 (Performance) @base",
 	"from": "system",
+	"setting_id": "GFSN98",
+	"filament_id": "GFN99",
 	"instantiation": "true",
-	"inherits": "fdm_filament_pa",
-	"filament_flow_ratio": [
-		"0.96"
-	],
-	"nozzle_temperature": [
-		"270"
-	],
-	"nozzle_temperature_initial_layer": [
-		"270"
-	],
-	"nozzle_temperature_range_high": [
-		"290"
-	],
-	"nozzle_temperature_range_low": [
-		"240"
-	],
-	"hot_plate_temp": [
-		"45"
-	],
-	"hot_plate_temp_initial_layer": [
-		"45"
-	],
-	"fan_max_speed": [
-		"30"
-	],
-	"fan_min_speed": [
-		"0"
-	],
-	"filament_max_volumetric_speed": [
-		"36"
-	],
-	"filament_density": [
-		"1.14"
-	],
-	"filament_type": [
-		"PA6-CF"
-	],
 	"compatible_printers": [
 		"EXO42 Performance (0.4 nozzle)",
 		"EXO65 Performance (0.4 nozzle)",

--- a/resources/profiles/Volumic/filament/PETG ESD (Performance).json
+++ b/resources/profiles/Volumic/filament/PETG ESD (Performance).json
@@ -1,47 +1,11 @@
 {
 	"type": "filament",
-	"filament_id": "GFG99",
-	"setting_id": "GFSG99",
 	"name": "PETG ESD (Performance)",
+	"inherits": "PETG ESD (Performance) @base",
 	"from": "system",
+	"setting_id": "GFSG99",
+	"filament_id": "GFG99",
 	"instantiation": "true",
-	"inherits": "fdm_filament_pet",
-	"filament_type": [
-		"PETG-ESD"
-	],
-	"filament_flow_ratio": [
-		"1.00"
-	],
-	"nozzle_temperature_initial_layer": [
-		"270"
-	],
-	"nozzle_temperature": [
-		"270"
-	],
-	"hot_plate_temp_initial_layer": [
-		"75"
-	],
-	"hot_plate_temp": [
-		"75"
-	],
-	"fan_max_speed": [
-		"40"
-	],
-	"fan_min_speed": [
-		"0"
-	],
-	"filament_max_volumetric_speed": [
-		"36"
-	],
-	"nozzle_temperature_range_high": [
-		"290"
-	],
-	"nozzle_temperature_range_low": [
-		"250"
-	],
-	"filament_density": [
-		"1.24"
-	],
 	"compatible_printers": [
 		"EXO42 Performance (0.4 nozzle)",
 		"EXO65 Performance (0.4 nozzle)",

--- a/resources/profiles/Volumic/filament/PPS Carbone (Performance).json
+++ b/resources/profiles/Volumic/filament/PPS Carbone (Performance).json
@@ -1,50 +1,11 @@
 {
 	"type": "filament",
-	"filament_id": "GFN99",
-	"setting_id": "GFSN98",
 	"name": "PPS Carbone (Performance)",
+	"inherits": "PPS Carbone (Performance) @base",
 	"from": "system",
+	"setting_id": "GFSN98",
+	"filament_id": "GFN99",
 	"instantiation": "true",
-	"inherits": "fdm_filament_pa",
-	"filament_flow_ratio": [
-		"1.00"
-	],
-	"filament_type": [
-		"PPS-CF"
-	],
-	"filament_density": [
-		"1.29"
-	],
-	"nozzle_temperature_initial_layer": [
-		"320"
-	],
-	"nozzle_temperature": [
-		"320"
-	],
-	"hot_plate_temp": [
-		"90"
-	],
-	"hot_plate_temp_initial_layer": [
-		"90"
-	],
-	"fan_max_speed": [
-		"0"
-	],
-	"fan_min_speed": [
-		"0"
-	],
-	"filament_max_volumetric_speed": [
-		"25"
-	],
-	"nozzle_temperature_range_high": [
-		"350"
-	],
-	"nozzle_temperature_range_low": [
-		"310"
-	],
-	"temperature_vitrification": [
-		"98"
-	],
 	"compatible_printers": [
 		"EXO42 Performance (0.4 nozzle)",
 		"EXO65 Performance (0.4 nozzle)",

--- a/resources/profiles/Volumic/filament/Volumic ABS Ultra Performance.json
+++ b/resources/profiles/Volumic/filament/Volumic ABS Ultra Performance.json
@@ -1,32 +1,11 @@
 {
 	"type": "filament",
-	"filament_id": "GFB99",
-	"setting_id": "GFSA04",
 	"name": "Volumic ABS Ultra (Performance)",
+	"inherits": "Volumic ABS Ultra (Performance) @base",
 	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFB99",
 	"instantiation": "true",
-	"inherits": "fdm_filament_abs",
-	"filament_flow_ratio": [
-		"1.00"
-	],
-	"nozzle_temperature_initial_layer": [
-		"240"
-	],
-	"nozzle_temperature": [
-		"240"
-	],
-	"hot_plate_temp": [
-		"75"
-	],
-	"fan_max_speed": [
-		"40"
-	],
-	"fan_min_speed": [
-		"30"
-	],
-	"filament_max_volumetric_speed": [
-		"36"
-	],
 	"compatible_printers": [
 		"EXO42 Performance (0.4 nozzle)",
 		"EXO65 Performance (0.4 nozzle)",

--- a/resources/profiles/Volumic/filament/Volumic ABS Ultra.json
+++ b/resources/profiles/Volumic/filament/Volumic ABS Ultra.json
@@ -1,29 +1,11 @@
 {
 	"type": "filament",
-	"filament_id": "GFB99",
-	"setting_id": "GFSA04",
 	"name": "Volumic ABS Ultra",
+	"inherits": "Volumic ABS Ultra @base",
 	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFB99",
 	"instantiation": "true",
-	"inherits": "fdm_filament_abs",
-	"filament_flow_ratio": [
-		"1.00"
-	],
-	"nozzle_temperature": [
-		"235"
-	],
-	"hot_plate_temp": [
-		"75"
-	],
-	"fan_max_speed": [
-		"30"
-	],
-	"fan_min_speed": [
-		"30"
-	],
-	"filament_max_volumetric_speed": [
-		"22"
-	],
 	"compatible_printers": [
 		"EXO42 (0.4 nozzle)",
 		"EXO65 (0.6 nozzle)",

--- a/resources/profiles/Volumic/filament/Volumic ASA Ultra Performance.json
+++ b/resources/profiles/Volumic/filament/Volumic ASA Ultra Performance.json
@@ -1,32 +1,11 @@
 {
 	"type": "filament",
-	"filament_id": "GFB99",
-	"setting_id": "GFSA04",
 	"name": "Volumic ASA Ultra (Performance)",
+	"inherits": "Volumic ASA Ultra (Performance) @base",
 	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFB99",
 	"instantiation": "true",
-	"inherits": "fdm_filament_asa",
-	"filament_flow_ratio": [
-		"0.96"
-	],
-	"nozzle_temperature_initial_layer": [
-		"245"
-	],
-	"nozzle_temperature": [
-		"245"
-	],
-	"hot_plate_temp": [
-		"85"
-	],
-	"fan_max_speed": [
-		"30"
-	],
-	"fan_min_speed": [
-		"30"
-	],
-	"filament_max_volumetric_speed": [
-		"36"
-	],
 	"compatible_printers": [
 		"EXO42 Performance (0.4 nozzle)",
 		"EXO65 Performance (0.4 nozzle)",

--- a/resources/profiles/Volumic/filament/Volumic ASA Ultra.json
+++ b/resources/profiles/Volumic/filament/Volumic ASA Ultra.json
@@ -1,29 +1,11 @@
 {
 	"type": "filament",
-	"filament_id": "GFB99",
-	"setting_id": "GFSA04",
 	"name": "Volumic ASA Ultra",
+	"inherits": "Volumic ASA Ultra @base",
 	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFB99",
 	"instantiation": "true",
-	"inherits": "fdm_filament_asa",
-	"filament_flow_ratio": [
-		"0.96"
-	],
-	"nozzle_temperature": [
-		"235"
-	],
-	"hot_plate_temp": [
-		"85"
-	],
-	"fan_max_speed": [
-		"30"
-	],
-	"fan_min_speed": [
-		"30"
-	],
-	"filament_max_volumetric_speed": [
-		"22"
-	],
 	"compatible_printers": [
 		"EXO42 (0.4 nozzle)",
 		"EXO65 (0.6 nozzle)",

--- a/resources/profiles/Volumic/filament/Volumic FLEX93 Ultra Performance.json
+++ b/resources/profiles/Volumic/filament/Volumic FLEX93 Ultra Performance.json
@@ -1,32 +1,11 @@
 {
 	"type": "filament",
-	"filament_id": "GFU99",
-	"setting_id": "GFSR99",
 	"name": "Volumic FLEX93 Ultra (Performance)",
+	"inherits": "Volumic FLEX93 Ultra (Performance) @base",
 	"from": "system",
+	"setting_id": "GFSR99",
+	"filament_id": "GFU99",
 	"instantiation": "true",
-	"inherits": "fdm_filament_tpu",
-	"filament_flow_ratio": [
-		"1.00"
-	],
-	"nozzle_temperature_initial_layer": [
-		"235"
-	],
-	"nozzle_temperature": [
-		"235"
-	],
-	"hot_plate_temp": [
-		"45"
-	],
-	"fan_max_speed": [
-		"100"
-	],
-	"fan_min_speed": [
-		"100"
-	],
-	"filament_max_volumetric_speed": [
-		"16"
-	],
 	"compatible_printers": [
 		"EXO42 Performance (0.4 nozzle)",
 		"EXO65 Performance (0.4 nozzle)",

--- a/resources/profiles/Volumic/filament/Volumic FLEX93 Ultra.json
+++ b/resources/profiles/Volumic/filament/Volumic FLEX93 Ultra.json
@@ -1,29 +1,11 @@
 {
 	"type": "filament",
-	"filament_id": "GFU99",
-	"setting_id": "GFSR99",
 	"name": "Volumic FLEX93 Ultra",
+	"inherits": "Volumic FLEX93 Ultra @base",
 	"from": "system",
+	"setting_id": "GFSR99",
+	"filament_id": "GFU99",
 	"instantiation": "true",
-	"inherits": "fdm_filament_tpu",
-	"filament_flow_ratio": [
-		"1.20"
-	],
-	"nozzle_temperature": [
-		"235"
-	],
-	"hot_plate_temp": [
-		"45"
-	],
-	"fan_max_speed": [
-		"100"
-	],
-	"fan_min_speed": [
-		"80"
-	],
-	"filament_max_volumetric_speed": [
-		"5"
-	],
 	"compatible_printers": [
 		"EXO42 (0.4 nozzle)",
 		"EXO65 (0.6 nozzle)",

--- a/resources/profiles/Volumic/filament/Volumic NYLON Ultra Performance.json
+++ b/resources/profiles/Volumic/filament/Volumic NYLON Ultra Performance.json
@@ -1,32 +1,11 @@
 {
 	"type": "filament",
-	"filament_id": "GFN99",
-	"setting_id": "GFSN98",
 	"name": "Volumic NYLON Ultra (Performance)",
+	"inherits": "Volumic NYLON Ultra (Performance) @base",
 	"from": "system",
+	"setting_id": "GFSN98",
+	"filament_id": "GFN99",
 	"instantiation": "true",
-	"inherits": "fdm_filament_pa",
-	"filament_flow_ratio": [
-		"1.00"
-	],
-	"nozzle_temperature_initial_layer": [
-		"245"
-	],
-	"nozzle_temperature": [
-		"245"
-	],
-	"hot_plate_temp": [
-		"65"
-	],
-	"fan_max_speed": [
-		"0"
-	],
-	"fan_min_speed": [
-		"0"
-	],
-	"filament_max_volumetric_speed": [
-		"30"
-	],
 	"compatible_printers": [
 		"EXO42 Performance (0.4 nozzle)",
 		"EXO65 Performance (0.4 nozzle)",

--- a/resources/profiles/Volumic/filament/Volumic NYLON Ultra.json
+++ b/resources/profiles/Volumic/filament/Volumic NYLON Ultra.json
@@ -1,29 +1,11 @@
 {
 	"type": "filament",
-	"filament_id": "GFN99",
-	"setting_id": "GFSN98",
 	"name": "Volumic NYLON Ultra",
+	"inherits": "Volumic NYLON Ultra @base",
 	"from": "system",
+	"setting_id": "GFSN98",
+	"filament_id": "GFN99",
 	"instantiation": "true",
-	"inherits": "fdm_filament_pa",
-	"filament_flow_ratio": [
-		"1.00"
-	],
-	"nozzle_temperature": [
-		"238"
-	],
-	"hot_plate_temp": [
-		"65"
-	],
-	"fan_max_speed": [
-		"0"
-	],
-	"fan_min_speed": [
-		"0"
-	],
-	"filament_max_volumetric_speed": [
-		"22"
-	],
 	"compatible_printers": [
 		"EXO42 (0.4 nozzle)",
 		"EXO65 (0.6 nozzle)",

--- a/resources/profiles/Volumic/filament/Volumic PC Performance.json
+++ b/resources/profiles/Volumic/filament/Volumic PC Performance.json
@@ -1,32 +1,11 @@
 {
 	"type": "filament",
-	"filament_id": "GFC99",
-	"setting_id": "GFSC99",
 	"name": "Volumic PC (Performance)",
+	"inherits": "Volumic PC (Performance) @base",
 	"from": "system",
+	"setting_id": "GFSC99",
+	"filament_id": "GFC99",
 	"instantiation": "true",
-	"inherits": "fdm_filament_pc",
-	"filament_flow_ratio": [
-		"1.00"
-	],
-	"nozzle_temperature_initial_layer": [
-		"280"
-	],
-	"nozzle_temperature": [
-		"280"
-	],
-	"hot_plate_temp": [
-		"120"
-	],
-	"fan_max_speed": [
-		"0"
-	],
-	"fan_min_speed": [
-		"0"
-	],
-	"filament_max_volumetric_speed": [
-		"36"
-	],
 	"compatible_printers": [
 		"EXO42 Performance (0.4 nozzle)",
 		"EXO65 Performance (0.4 nozzle)",

--- a/resources/profiles/Volumic/filament/Volumic PC.json
+++ b/resources/profiles/Volumic/filament/Volumic PC.json
@@ -1,29 +1,11 @@
 {
 	"type": "filament",
-	"filament_id": "GFC99",
-	"setting_id": "GFSC99",
 	"name": "Volumic PC",
+	"inherits": "Volumic PC @base",
 	"from": "system",
+	"setting_id": "GFSC99",
+	"filament_id": "GFC99",
 	"instantiation": "true",
-	"inherits": "fdm_filament_pc",
-	"filament_flow_ratio": [
-		"1.00"
-	],
-	"nozzle_temperature": [
-		"270"
-	],
-	"hot_plate_temp": [
-		"115"
-	],
-	"fan_max_speed": [
-		"0"
-	],
-	"fan_min_speed": [
-		"0"
-	],
-	"filament_max_volumetric_speed": [
-		"22"
-	],
 	"compatible_printers": [
 		"EXO42 (0.4 nozzle)",
 		"EXO65 (0.6 nozzle)",

--- a/resources/profiles/Volumic/filament/Volumic PCTG Ultra (Performance).json
+++ b/resources/profiles/Volumic/filament/Volumic PCTG Ultra (Performance).json
@@ -1,32 +1,11 @@
 {
 	"type": "filament",
-	"filament_id": "GFG99",
-	"setting_id": "GFSG99",
 	"name": "Volumic PCTG Ultra (Performance)",
+	"inherits": "Volumic PCTG Ultra (Performance) @base",
 	"from": "system",
+	"setting_id": "GFSG99",
+	"filament_id": "GFG99",
 	"instantiation": "true",
-	"inherits": "fdm_filament_pet",
-	"filament_flow_ratio": [
-		"1.00"
-	],
-	"nozzle_temperature_initial_layer": [
-		"270"
-	],
-	"nozzle_temperature": [
-		"270"
-	],
-	"hot_plate_temp": [
-		"60"
-	],
-	"fan_max_speed": [
-		"90"
-	],
-	"fan_min_speed": [
-		"60"
-	],
-	"filament_max_volumetric_speed": [
-		"36"
-	],
 	"compatible_printers": [
 		"EXO42 Performance (0.4 nozzle)",
 		"EXO65 Performance (0.4 nozzle)",

--- a/resources/profiles/Volumic/filament/Volumic PETG Ultra Performance.json
+++ b/resources/profiles/Volumic/filament/Volumic PETG Ultra Performance.json
@@ -1,32 +1,11 @@
 {
 	"type": "filament",
-	"filament_id": "GFG99",
-	"setting_id": "GFSG99",
 	"name": "Volumic PETG Ultra (Performance)",
+	"inherits": "Volumic PETG Ultra (Performance) @base",
 	"from": "system",
+	"setting_id": "GFSG99",
+	"filament_id": "GFG99",
 	"instantiation": "true",
-	"inherits": "fdm_filament_pet",
-	"filament_flow_ratio": [
-		"1.00"
-	],
-	"nozzle_temperature_initial_layer": [
-		"240"
-	],
-	"nozzle_temperature": [
-		"240"
-	],
-	"hot_plate_temp": [
-		"60"
-	],
-	"fan_max_speed": [
-		"90"
-	],
-	"fan_min_speed": [
-		"70"
-	],
-	"filament_max_volumetric_speed": [
-		"36"
-	],
 	"compatible_printers": [
 		"EXO42 Performance (0.4 nozzle)",
 		"EXO65 Performance (0.4 nozzle)",

--- a/resources/profiles/Volumic/filament/Volumic PETG Ultra carbone Performance.json
+++ b/resources/profiles/Volumic/filament/Volumic PETG Ultra carbone Performance.json
@@ -1,32 +1,11 @@
 {
 	"type": "filament",
-	"filament_id": "GFG98",
-	"setting_id": "GFSG50",
 	"name": "Volumic PETG Ultra carbone (Performance)",
+	"inherits": "Volumic PETG Ultra carbone (Performance) @base",
 	"from": "system",
+	"setting_id": "GFSG50",
+	"filament_id": "GFG98",
 	"instantiation": "true",
-	"inherits": "fdm_filament_pet",
-	"filament_flow_ratio": [
-		"1.00"
-	],
-	"nozzle_temperature_initial_layer": [
-		"245"
-	],
-	"nozzle_temperature": [
-		"245"
-	],
-	"hot_plate_temp": [
-		"65"
-	],
-	"fan_max_speed": [
-		"60"
-	],
-	"fan_min_speed": [
-		"60"
-	],
-	"filament_max_volumetric_speed": [
-		"30"
-	],
 	"compatible_printers": [
 		"EXO42 Performance (0.4 nozzle)",
 		"EXO65 Performance (0.4 nozzle)",

--- a/resources/profiles/Volumic/filament/Volumic PETG Ultra carbone.json
+++ b/resources/profiles/Volumic/filament/Volumic PETG Ultra carbone.json
@@ -1,29 +1,11 @@
 {
 	"type": "filament",
-	"filament_id": "GFG98",
-	"setting_id": "GFSG50",
 	"name": "Volumic PETG Ultra carbone",
+	"inherits": "Volumic PETG Ultra carbone @base",
 	"from": "system",
+	"setting_id": "GFSG50",
+	"filament_id": "GFG98",
 	"instantiation": "true",
-	"inherits": "fdm_filament_pet",
-	"filament_flow_ratio": [
-		"1.00"
-	],
-	"nozzle_temperature": [
-		"230"
-	],
-	"hot_plate_temp": [
-		"65"
-	],
-	"fan_max_speed": [
-		"60"
-	],
-	"fan_min_speed": [
-		"60"
-	],
-	"filament_max_volumetric_speed": [
-		"20"
-	],
 	"compatible_printers": [
 		"EXO42 (0.4 nozzle)",
 		"EXO65 (0.6 nozzle)",

--- a/resources/profiles/Volumic/filament/Volumic PETG Ultra.json
+++ b/resources/profiles/Volumic/filament/Volumic PETG Ultra.json
@@ -1,29 +1,11 @@
 {
 	"type": "filament",
-	"filament_id": "GFG99",
-	"setting_id": "GFSG99",
 	"name": "Volumic PETG Ultra",
+	"inherits": "Volumic PETG Ultra @base",
 	"from": "system",
+	"setting_id": "GFSG99",
+	"filament_id": "GFG99",
 	"instantiation": "true",
-	"inherits": "fdm_filament_pet",
-	"filament_flow_ratio": [
-		"1.00"
-	],
-	"nozzle_temperature": [
-		"235"
-	],
-	"hot_plate_temp": [
-		"60"
-	],
-	"fan_max_speed": [
-		"80"
-	],
-	"fan_min_speed": [
-		"50"
-	],
-	"filament_max_volumetric_speed": [
-		"22"
-	],
 	"compatible_printers": [
 		"EXO42 (0.4 nozzle)",
 		"EXO65 (0.6 nozzle)",

--- a/resources/profiles/Volumic/filament/Volumic PLA Ultra Performance.json
+++ b/resources/profiles/Volumic/filament/Volumic PLA Ultra Performance.json
@@ -1,32 +1,11 @@
 {
 	"type": "filament",
-	"filament_id": "GFL99",
-	"setting_id": "GFSL99",
 	"name": "Volumic PLA Ultra (Performance)",
+	"inherits": "Volumic PLA Ultra (Performance) @base",
 	"from": "system",
+	"setting_id": "GFSL99",
+	"filament_id": "GFL99",
 	"instantiation": "true",
-	"inherits": "fdm_filament_pla",
-	"filament_flow_ratio": [
-		"1.00"
-	],
-	"nozzle_temperature_initial_layer": [
-		"210"
-	],
-	"nozzle_temperature": [
-		"210"
-	],
-	"hot_plate_temp": [
-		"50"
-	],
-	"fan_max_speed": [
-		"100"
-	],
-	"fan_min_speed": [
-		"100"
-	],
-	"filament_max_volumetric_speed": [
-		"36"
-	],
 	"compatible_printers": [
 		"EXO42 Performance (0.4 nozzle)",
 		"EXO65 Performance (0.4 nozzle)",

--- a/resources/profiles/Volumic/filament/Volumic PLA Ultra.json
+++ b/resources/profiles/Volumic/filament/Volumic PLA Ultra.json
@@ -1,29 +1,11 @@
 {
 	"type": "filament",
-	"filament_id": "GFL99",
-	"setting_id": "GFSL99",
 	"name": "Volumic PLA Ultra",
+	"inherits": "Volumic PLA Ultra @base",
 	"from": "system",
+	"setting_id": "GFSL99",
+	"filament_id": "GFL99",
 	"instantiation": "true",
-	"inherits": "fdm_filament_pla",
-	"filament_flow_ratio": [
-		"1.00"
-	],
-	"nozzle_temperature": [
-		"210"
-	],
-	"hot_plate_temp": [
-		"50"
-	],
-	"fan_max_speed": [
-		"100"
-	],
-	"fan_min_speed": [
-		"100"
-	],
-	"filament_max_volumetric_speed": [
-		"22"
-	],
 	"compatible_printers": [
 		"EXO42 (0.4 nozzle)",
 		"EXO65 (0.6 nozzle)",

--- a/resources/profiles/Volumic/filament/Volumic PP Ultra Performance.json
+++ b/resources/profiles/Volumic/filament/Volumic PP Ultra Performance.json
@@ -1,56 +1,11 @@
 {
 	"type": "filament",
-	"filament_id": "GFB99",
-	"setting_id": "GFSA04",
 	"name": "Volumic PP Ultra (Performance)",
+	"inherits": "Volumic PP Ultra (Performance) @base",
 	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFB99",
 	"instantiation": "true",
-	"inherits": "fdm_filament_pp",
-	"filament_flow_ratio": [
-		"1.0"
-	],
-	"filament_retraction_length": [
-		"3"
-	],
-	"filament_z_hop": [
-		"0.4"
-	],
-	"nozzle_temperature_initial_layer": [
-		"205"
-	],
-	"nozzle_temperature": [
-		"205"
-	],
-	"nozzle_temperature_range_high": [
-		"225"
-	],
-	"nozzle_temperature_range_low": [
-		"200"
-	],
-	"hot_plate_temp_initial_layer": [
-		"90"
-	],
-	"hot_plate_temp": [
-		"70"
-	],
-	"internal_bridge_fan_speed": [
-		"100"
-	],
-	"overhang_fan_speed": [
-		"100"
-	],
-	"support_material_interface_fan_speed": [
-		"100"
-	],
-	"fan_max_speed": [
-		"100"
-	],
-	"fan_min_speed": [
-		"100"
-	],
-	"filament_max_volumetric_speed": [
-		"22"
-	],
 	"compatible_printers": [
 		"EXO42 Performance (0.4 nozzle)",
 		"EXO65 Performance (0.4 nozzle)",

--- a/resources/profiles/Volumic/filament/Volumic PP Ultra.json
+++ b/resources/profiles/Volumic/filament/Volumic PP Ultra.json
@@ -1,29 +1,11 @@
 {
 	"type": "filament",
-	"filament_id": "GFB99",
-	"setting_id": "GFSA04",
 	"name": "Volumic PP Ultra",
+	"inherits": "Volumic PP Ultra @base",
 	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFB99",
 	"instantiation": "true",
-	"inherits": "fdm_filament_pp",
-	"filament_flow_ratio": [
-		"1.24"
-	],
-	"nozzle_temperature": [
-		"225"
-	],
-	"hot_plate_temp": [
-		"90"
-	],
-	"fan_max_speed": [
-		"100"
-	],
-	"fan_min_speed": [
-		"80"
-	],
-	"filament_max_volumetric_speed": [
-		"22"
-	],
 	"compatible_printers": [
 		"EXO42 (0.4 nozzle)",
 		"EXO65 (0.6 nozzle)",

--- a/resources/profiles/Volumic/filament/Volumic PVA Performance.json
+++ b/resources/profiles/Volumic/filament/Volumic PVA Performance.json
@@ -1,32 +1,11 @@
 {
 	"type": "filament",
-	"filament_id": "GFS99",
-	"setting_id": "GFSS99",
 	"name": "Volumic PVA-BVOH (Performance)",
+	"inherits": "Volumic PVA-BVOH (Performance) @base",
 	"from": "system",
+	"setting_id": "GFSS99",
+	"filament_id": "GFS99",
 	"instantiation": "true",
-	"inherits": "fdm_filament_pva",
-	"filament_flow_ratio": [
-		"1.00"
-	],
-	"nozzle_temperature_initial_layer": [
-		"220"
-	],
-	"nozzle_temperature": [
-		"220"
-	],
-	"hot_plate_temp": [
-		"60"
-	],
-	"fan_max_speed": [
-		"80"
-	],
-	"fan_min_speed": [
-		"40"
-	],
-	"filament_max_volumetric_speed": [
-		"20"
-	],
 	"compatible_printers": [
 		"EXO42 Performance (0.4 nozzle)",
 		"EXO65 Performance (0.4 nozzle)",

--- a/resources/profiles/Volumic/filament/Volumic PVA.json
+++ b/resources/profiles/Volumic/filament/Volumic PVA.json
@@ -1,29 +1,11 @@
 {
 	"type": "filament",
-	"filament_id": "GFS99",
-	"setting_id": "GFSS99",
 	"name": "Volumic PVA",
+	"inherits": "Volumic PVA @base",
 	"from": "system",
+	"setting_id": "GFSS99",
+	"filament_id": "GFS99",
 	"instantiation": "true",
-	"inherits": "fdm_filament_pva",
-	"filament_flow_ratio": [
-		"1.00"
-	],
-	"nozzle_temperature": [
-		"210"
-	],
-	"hot_plate_temp": [
-		"60"
-	],
-	"fan_max_speed": [
-		"70"
-	],
-	"fan_min_speed": [
-		"40"
-	],
-	"filament_max_volumetric_speed": [
-		"20"
-	],
 	"compatible_printers": [
 		"EXO42 (0.4 nozzle)",
 		"EXO65 (0.6 nozzle)",

--- a/resources/profiles/Volumic/filament/Volumic UNIVERSAL Ultra Performance.json
+++ b/resources/profiles/Volumic/filament/Volumic UNIVERSAL Ultra Performance.json
@@ -1,35 +1,11 @@
 {
 	"type": "filament",
-	"filament_id": "GFL99",
-	"setting_id": "GFSL99",
 	"name": "Volumic UNIVERSAL Ultra (Performance)",
+	"inherits": "Volumic UNIVERSAL Ultra (Performance) @base",
 	"from": "system",
+	"setting_id": "GFSL99",
+	"filament_id": "GFL99",
 	"instantiation": "true",
-	"inherits": "fdm_filament_pla",
-	"filament_type": [
-		"UNIV"
-	],
-	"filament_flow_ratio": [
-		"1.00"
-	],
-	"nozzle_temperature_initial_layer": [
-		"220"
-	],
-	"nozzle_temperature": [
-		"220"
-	],
-	"hot_plate_temp": [
-		"50"
-	],
-	"fan_max_speed": [
-		"100"
-	],
-	"fan_min_speed": [
-		"100"
-	],
-	"filament_max_volumetric_speed": [
-		"36"
-	],
 	"compatible_printers": [
 		"EXO42 Performance (0.4 nozzle)",
 		"EXO65 Performance (0.4 nozzle)",

--- a/resources/profiles/Volumic/filament/Volumic UNIVERSAL Ultra.json
+++ b/resources/profiles/Volumic/filament/Volumic UNIVERSAL Ultra.json
@@ -1,32 +1,11 @@
 {
 	"type": "filament",
-	"filament_id": "GFL99",
-	"setting_id": "GFSL99",
 	"name": "Volumic UNIVERSAL Ultra",
+	"inherits": "Volumic UNIVERSAL Ultra @base",
 	"from": "system",
+	"setting_id": "GFSL99",
+	"filament_id": "GFL99",
 	"instantiation": "true",
-	"inherits": "fdm_filament_pla",
-	"filament_type": [
-		"UNIV"
-	],
-	"filament_flow_ratio": [
-		"1.00"
-	],
-	"nozzle_temperature": [
-		"225"
-	],
-	"hot_plate_temp": [
-		"50"
-	],
-	"fan_max_speed": [
-		"100"
-	],
-	"fan_min_speed": [
-		"100"
-	],
-	"filament_max_volumetric_speed": [
-		"22"
-	],
 	"compatible_printers": [
 		"EXO42 (0.4 nozzle)",
 		"EXO65 (0.6 nozzle)",

--- a/resources/profiles/Volumic/filament/desactive.json
+++ b/resources/profiles/Volumic/filament/desactive.json
@@ -1,32 +1,11 @@
 {
 	"type": "filament",
-	"filament_id": "DFL99",
-	"setting_id": "DFSL99",
 	"name": "Désactivé",
+	"inherits": "Désactivé @base",
 	"from": "system",
+	"setting_id": "DFSL99",
+	"filament_id": "DFL99",
 	"instantiation": "true",
-	"inherits": "fdm_filament_pla",
-	"filament_flow_ratio": [
-		"0.1"
-	],
-	"nozzle_temperature_initial_layer": [
-		"0"
-	],
-	"nozzle_temperature": [
-		"0"
-	],
-	"hot_plate_temp": [
-		"0"
-	],
-	"fan_max_speed": [
-		"0"
-	],
-	"fan_min_speed": [
-		"0"
-	],
-	"filament_max_volumetric_speed": [
-		"1"
-	],
 	"compatible_printers": [
 		"EXO42 IDRE (0.4 nozzle)",
 		"EXO65 IDRE (0.4 nozzle)",


### PR DESCRIPTION
## Summary

Migrates Volumic filament presets so reusable base settings live under OrcaFilamentLibrary while vendor-scoped presets retain their compatibility constraints.

## Changes

- Added Volumic filament `@base` and `@System` presets under `resources/profiles/OrcaFilamentLibrary/filament/Volumic`.
- Updated Volumic vendor filament presets to inherit from the new library bases.
- Registered the Volumic OrcaFilamentLibrary entries in `resources/profiles/OrcaFilamentLibrary.json`.

## Testing

- `python3 scripts/orca_extra_profile_check.py --vendor Volumic --check-filaments --check-materials --check-obsolete-keys` — 0 errors, 0 warnings.
- `git diff --check`

Part of OrcaSlicer/OrcaSlicer#12162