### PR TITLE
Migrate WonderMaker filaments to OrcaFilamentLibrary

### DIFF
--- a/resources/profiles/OrcaFilamentLibrary.json
+++ b/resources/profiles/OrcaFilamentLibrary.json
@@ -1507,6 +1507,126 @@
 		{
 			"name": "GreenGate3D PETG @System",
 			"sub_path": "filament/GreenGate3D/GreenGate3D PETG @System.json"
+		},
+		{
+			"name": "WonderMaker ABS @WonderMaker ZR Ultra S @base",
+			"sub_path": "filament/WonderMaker/WonderMaker ABS @WonderMaker ZR Ultra S @base.json"
+		},
+		{
+			"name": "WonderMaker ABS @WonderMaker ZR Ultra S @System",
+			"sub_path": "filament/WonderMaker/WonderMaker ABS @WonderMaker ZR Ultra S @System.json"
+		},
+		{
+			"name": "WonderMaker ABS @base",
+			"sub_path": "filament/WonderMaker/WonderMaker ABS @base.json"
+		},
+		{
+			"name": "WonderMaker ABS @System",
+			"sub_path": "filament/WonderMaker/WonderMaker ABS @System.json"
+		},
+		{
+			"name": "WonderMaker ASA @WonderMaker ZR Ultra S @base",
+			"sub_path": "filament/WonderMaker/WonderMaker ASA @WonderMaker ZR Ultra S @base.json"
+		},
+		{
+			"name": "WonderMaker ASA @WonderMaker ZR Ultra S @System",
+			"sub_path": "filament/WonderMaker/WonderMaker ASA @WonderMaker ZR Ultra S @System.json"
+		},
+		{
+			"name": "WonderMaker ASA @base",
+			"sub_path": "filament/WonderMaker/WonderMaker ASA @base.json"
+		},
+		{
+			"name": "WonderMaker ASA @System",
+			"sub_path": "filament/WonderMaker/WonderMaker ASA @System.json"
+		},
+		{
+			"name": "WonderMaker PET-CF @WonderMaker ZR Ultra S @base",
+			"sub_path": "filament/WonderMaker/WonderMaker PET-CF @WonderMaker ZR Ultra S @base.json"
+		},
+		{
+			"name": "WonderMaker PET-CF @WonderMaker ZR Ultra S @System",
+			"sub_path": "filament/WonderMaker/WonderMaker PET-CF @WonderMaker ZR Ultra S @System.json"
+		},
+		{
+			"name": "WonderMaker PET-CF @base",
+			"sub_path": "filament/WonderMaker/WonderMaker PET-CF @base.json"
+		},
+		{
+			"name": "WonderMaker PET-CF @System",
+			"sub_path": "filament/WonderMaker/WonderMaker PET-CF @System.json"
+		},
+		{
+			"name": "WonderMaker PETG Basic @base",
+			"sub_path": "filament/WonderMaker/WonderMaker PETG Basic @base.json"
+		},
+		{
+			"name": "WonderMaker PETG Basic @System",
+			"sub_path": "filament/WonderMaker/WonderMaker PETG Basic @System.json"
+		},
+		{
+			"name": "WonderMaker PLA Basic @base",
+			"sub_path": "filament/WonderMaker/WonderMaker PLA Basic @base.json"
+		},
+		{
+			"name": "WonderMaker PLA Basic @System",
+			"sub_path": "filament/WonderMaker/WonderMaker PLA Basic @System.json"
+		},
+		{
+			"name": "WonderMaker PLA Marble @base",
+			"sub_path": "filament/WonderMaker/WonderMaker PLA Marble @base.json"
+		},
+		{
+			"name": "WonderMaker PLA Marble @System",
+			"sub_path": "filament/WonderMaker/WonderMaker PLA Marble @System.json"
+		},
+		{
+			"name": "WonderMaker PLA Matte @base",
+			"sub_path": "filament/WonderMaker/WonderMaker PLA Matte @base.json"
+		},
+		{
+			"name": "WonderMaker PLA Matte @System",
+			"sub_path": "filament/WonderMaker/WonderMaker PLA Matte @System.json"
+		},
+		{
+			"name": "WonderMaker PLA Metal @base",
+			"sub_path": "filament/WonderMaker/WonderMaker PLA Metal @base.json"
+		},
+		{
+			"name": "WonderMaker PLA Metal @System",
+			"sub_path": "filament/WonderMaker/WonderMaker PLA Metal @System.json"
+		},
+		{
+			"name": "WonderMaker PLA Silk @base",
+			"sub_path": "filament/WonderMaker/WonderMaker PLA Silk @base.json"
+		},
+		{
+			"name": "WonderMaker PLA Silk @System",
+			"sub_path": "filament/WonderMaker/WonderMaker PLA Silk @System.json"
+		},
+		{
+			"name": "WonderMaker PLA Wood @base",
+			"sub_path": "filament/WonderMaker/WonderMaker PLA Wood @base.json"
+		},
+		{
+			"name": "WonderMaker PLA Wood @System",
+			"sub_path": "filament/WonderMaker/WonderMaker PLA Wood @System.json"
+		},
+		{
+			"name": "WonderMaker PVA @base",
+			"sub_path": "filament/WonderMaker/WonderMaker PVA @base.json"
+		},
+		{
+			"name": "WonderMaker PVA @System",
+			"sub_path": "filament/WonderMaker/WonderMaker PVA @System.json"
+		},
+		{
+			"name": "WonderMaker TPU 95A @base",
+			"sub_path": "filament/WonderMaker/WonderMaker TPU 95A @base.json"
+		},
+		{
+			"name": "WonderMaker TPU 95A @System",
+			"sub_path": "filament/WonderMaker/WonderMaker TPU 95A @System.json"
 		}
 	],
 	"process_list": [],

--- a/resources/profiles/OrcaFilamentLibrary/filament/WonderMaker/WonderMaker ABS @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/WonderMaker/WonderMaker ABS @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "WonderMaker ABS @System",
+	"inherits": "WonderMaker ABS @base",
+	"from": "system",
+	"filament_id": "GFB00",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/WonderMaker/WonderMaker ABS @WonderMaker ZR Ultra S @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/WonderMaker/WonderMaker ABS @WonderMaker ZR Ultra S @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "WonderMaker ABS @WonderMaker ZR Ultra S @System",
+	"inherits": "WonderMaker ABS @WonderMaker ZR Ultra S @base",
+	"from": "system",
+	"setting_id": "GFSB01_07",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/WonderMaker/WonderMaker ABS @WonderMaker ZR Ultra S @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/WonderMaker/WonderMaker ABS @WonderMaker ZR Ultra S @base.json
@@ -1,0 +1,194 @@
+{
+	"type": "filament",
+	"name": "WonderMaker ABS @WonderMaker ZR Ultra S @base",
+	"inherits": "WonderMaker ABS",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"1"
+	],
+	"chamber_temperatures": [
+		"60"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"0"
+	],
+	"cool_plate_temp_initial_layer": [
+		"0"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"90"
+	],
+	"eng_plate_temp_initial_layer": [
+		"90"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"fan_max_speed": [
+		"80"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"filament_cost": [
+		"24.99"
+	],
+	"filament_density": [
+		"1.04"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"0.95"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"28.6"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"ABS"
+	],
+	"filament_vendor": [
+		"WonderMaker"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"filament_scarf_seam_type": [
+		"none"
+	],
+	"filament_scarf_height": [
+		"10%"
+	],
+	"filament_scarf_gap": [
+		"0%"
+	],
+	"filament_scarf_length": [
+		"10"
+	],
+	"filament_shrink": [
+		"100%"
+	],
+	"hot_plate_temp": [
+		"90"
+	],
+	"hot_plate_temp_initial_layer": [
+		"90"
+	],
+	"nozzle_temperature": [
+		"270"
+	],
+	"nozzle_temperature_initial_layer": [
+		"260"
+	],
+	"overhang_fan_speed": [
+		"80"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"3"
+	],
+	"supertack_plate_temp": [
+		"0"
+	],
+	"supertack_plate_temp_initial_layer": [
+		"0"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"3"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"temperature_vitrification": [
+		"100"
+	],
+	"textured_plate_temp": [
+		"90"
+	],
+	"textured_plate_temp_initial_layer": [
+		"90"
+	],
+	"nozzle_temperature_range_high": [
+		"280"
+	],
+	"nozzle_temperature_range_low": [
+		"240"
+	],
+	"description": "When printing this filament, there's a risk of warping and low layer adhesion strength. To get better results, please refer to this wiki: Printing Tips for High Temp / Engineering materials.",
+	"filament_multitool_ramming": [
+		"1"
+	],
+	"activate_chamber_temp_control": [
+		"1"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/WonderMaker/WonderMaker ABS @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/WonderMaker/WonderMaker ABS @base.json
@@ -1,0 +1,191 @@
+{
+	"type": "filament",
+	"name": "WonderMaker ABS @base",
+	"inherits": "fdm_filament_abs",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"1"
+	],
+	"chamber_temperatures": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"0"
+	],
+	"cool_plate_temp_initial_layer": [
+		"0"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"90"
+	],
+	"eng_plate_temp_initial_layer": [
+		"90"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"fan_max_speed": [
+		"80"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"filament_cost": [
+		"24.99"
+	],
+	"filament_density": [
+		"1.04"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"0.95"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"28.6"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"ABS"
+	],
+	"filament_vendor": [
+		"WonderMaker"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"filament_scarf_seam_type": [
+		"none"
+	],
+	"filament_scarf_height": [
+		"10%"
+	],
+	"filament_scarf_gap": [
+		"0%"
+	],
+	"filament_scarf_length": [
+		"10"
+	],
+	"filament_shrink": [
+		"100%"
+	],
+	"hot_plate_temp": [
+		"90"
+	],
+	"hot_plate_temp_initial_layer": [
+		"90"
+	],
+	"nozzle_temperature": [
+		"270"
+	],
+	"nozzle_temperature_initial_layer": [
+		"260"
+	],
+	"overhang_fan_speed": [
+		"80"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"3"
+	],
+	"supertack_plate_temp": [
+		"0"
+	],
+	"supertack_plate_temp_initial_layer": [
+		"0"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"3"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"temperature_vitrification": [
+		"100"
+	],
+	"textured_plate_temp": [
+		"90"
+	],
+	"textured_plate_temp_initial_layer": [
+		"90"
+	],
+	"nozzle_temperature_range_high": [
+		"280"
+	],
+	"nozzle_temperature_range_low": [
+		"240"
+	],
+	"description": "When printing this filament, there's a risk of warping and low layer adhesion strength. To get better results, please refer to this wiki: Printing Tips for High Temp / Engineering materials.",
+	"filament_multitool_ramming": [
+		"1"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/WonderMaker/WonderMaker ASA @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/WonderMaker/WonderMaker ASA @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "WonderMaker ASA @System",
+	"inherits": "WonderMaker ASA @base",
+	"from": "system",
+	"filament_id": "GFB01",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/WonderMaker/WonderMaker ASA @WonderMaker ZR Ultra S @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/WonderMaker/WonderMaker ASA @WonderMaker ZR Ultra S @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "WonderMaker ASA @WonderMaker ZR Ultra S @System",
+	"inherits": "WonderMaker ASA @WonderMaker ZR Ultra S @base",
+	"from": "system",
+	"setting_id": "GFSB01_07",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/WonderMaker/WonderMaker ASA @WonderMaker ZR Ultra S @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/WonderMaker/WonderMaker ASA @WonderMaker ZR Ultra S @base.json
@@ -1,0 +1,194 @@
+{
+	"type": "filament",
+	"name": "WonderMaker ASA @WonderMaker ZR Ultra S @base",
+	"inherits": "WonderMaker ASA",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"1"
+	],
+	"chamber_temperatures": [
+		"60"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"0"
+	],
+	"cool_plate_temp_initial_layer": [
+		"0"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"100"
+	],
+	"eng_plate_temp_initial_layer": [
+		"100"
+	],
+	"fan_cooling_layer_time": [
+		"35"
+	],
+	"fan_max_speed": [
+		"35"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"filament_cost": [
+		"31.99"
+	],
+	"filament_density": [
+		"1.05"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"0.95"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"18"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"ASA"
+	],
+	"filament_vendor": [
+		"WonderMaker"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"filament_scarf_seam_type": [
+		"none"
+	],
+	"filament_scarf_height": [
+		"10%"
+	],
+	"filament_scarf_gap": [
+		"0%"
+	],
+	"filament_scarf_length": [
+		"10"
+	],
+	"filament_shrink": [
+		"100%"
+	],
+	"hot_plate_temp": [
+		"100"
+	],
+	"hot_plate_temp_initial_layer": [
+		"100"
+	],
+	"nozzle_temperature": [
+		"270"
+	],
+	"nozzle_temperature_initial_layer": [
+		"270"
+	],
+	"overhang_fan_speed": [
+		"80"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"3"
+	],
+	"supertack_plate_temp": [
+		"0"
+	],
+	"supertack_plate_temp_initial_layer": [
+		"0"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"12"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"temperature_vitrification": [
+		"100"
+	],
+	"textured_plate_temp": [
+		"100"
+	],
+	"textured_plate_temp_initial_layer": [
+		"100"
+	],
+	"nozzle_temperature_range_high": [
+		"280"
+	],
+	"nozzle_temperature_range_low": [
+		"240"
+	],
+	"description": "When printing this filament, there's a risk of warping and low layer adhesion strength. To get better results, please refer to this wiki: Printing Tips for High Temp / Engineering materials.",
+	"filament_multitool_ramming": [
+		"1"
+	],
+	"activate_chamber_temp_control": [
+		"1"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/WonderMaker/WonderMaker ASA @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/WonderMaker/WonderMaker ASA @base.json
@@ -1,0 +1,191 @@
+{
+	"type": "filament",
+	"name": "WonderMaker ASA @base",
+	"inherits": "fdm_filament_asa",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"1"
+	],
+	"chamber_temperatures": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"0"
+	],
+	"cool_plate_temp_initial_layer": [
+		"0"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"100"
+	],
+	"eng_plate_temp_initial_layer": [
+		"100"
+	],
+	"fan_cooling_layer_time": [
+		"35"
+	],
+	"fan_max_speed": [
+		"35"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"filament_cost": [
+		"31.99"
+	],
+	"filament_density": [
+		"1.05"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"0.95"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"18"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"ASA"
+	],
+	"filament_vendor": [
+		"WonderMaker"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"filament_scarf_seam_type": [
+		"none"
+	],
+	"filament_scarf_height": [
+		"10%"
+	],
+	"filament_scarf_gap": [
+		"0%"
+	],
+	"filament_scarf_length": [
+		"10"
+	],
+	"filament_shrink": [
+		"100%"
+	],
+	"hot_plate_temp": [
+		"100"
+	],
+	"hot_plate_temp_initial_layer": [
+		"100"
+	],
+	"nozzle_temperature": [
+		"270"
+	],
+	"nozzle_temperature_initial_layer": [
+		"270"
+	],
+	"overhang_fan_speed": [
+		"80"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"3"
+	],
+	"supertack_plate_temp": [
+		"0"
+	],
+	"supertack_plate_temp_initial_layer": [
+		"0"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"12"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"temperature_vitrification": [
+		"100"
+	],
+	"textured_plate_temp": [
+		"100"
+	],
+	"textured_plate_temp_initial_layer": [
+		"100"
+	],
+	"nozzle_temperature_range_high": [
+		"280"
+	],
+	"nozzle_temperature_range_low": [
+		"240"
+	],
+	"description": "When printing this filament, there's a risk of warping and low layer adhesion strength. To get better results, please refer to this wiki: Printing Tips for High Temp / Engineering materials.",
+	"filament_multitool_ramming": [
+		"1"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/WonderMaker/WonderMaker PET-CF @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/WonderMaker/WonderMaker PET-CF @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "WonderMaker PET-CF @System",
+	"inherits": "WonderMaker PET-CF @base",
+	"from": "system",
+	"filament_id": "GFT01",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/WonderMaker/WonderMaker PET-CF @WonderMaker ZR Ultra S @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/WonderMaker/WonderMaker PET-CF @WonderMaker ZR Ultra S @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "WonderMaker PET-CF @WonderMaker ZR Ultra S @System",
+	"inherits": "WonderMaker PET-CF @WonderMaker ZR Ultra S @base",
+	"from": "system",
+	"setting_id": "GFST01_00",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/WonderMaker/WonderMaker PET-CF @WonderMaker ZR Ultra S @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/WonderMaker/WonderMaker PET-CF @WonderMaker ZR Ultra S @base.json
@@ -1,0 +1,194 @@
+{
+	"type": "filament",
+	"name": "WonderMaker PET-CF @WonderMaker ZR Ultra S @base",
+	"inherits": "WonderMaker PET-CF",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"chamber_temperatures": [
+		"60"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"0"
+	],
+	"cool_plate_temp_initial_layer": [
+		"0"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"80"
+	],
+	"eng_plate_temp_initial_layer": [
+		"80"
+	],
+	"fan_cooling_layer_time": [
+		"5"
+	],
+	"fan_max_speed": [
+		"30"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"filament_cost": [
+		"84.99"
+	],
+	"filament_density": [
+		"1.29"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"1"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"8"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PET-CF"
+	],
+	"filament_vendor": [
+		"WonderMaker"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"filament_scarf_seam_type": [
+		"none"
+	],
+	"filament_scarf_height": [
+		"10%"
+	],
+	"filament_scarf_gap": [
+		"0%"
+	],
+	"filament_scarf_length": [
+		"10"
+	],
+	"filament_shrink": [
+		"100%"
+	],
+	"hot_plate_temp": [
+		"100"
+	],
+	"hot_plate_temp_initial_layer": [
+		"100"
+	],
+	"nozzle_temperature": [
+		"270"
+	],
+	"nozzle_temperature_initial_layer": [
+		"270"
+	],
+	"overhang_fan_speed": [
+		"40"
+	],
+	"overhang_fan_threshold": [
+		"0%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"40"
+	],
+	"supertack_plate_temp": [
+		"80"
+	],
+	"supertack_plate_temp_initial_layer": [
+		"80"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"2"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"temperature_vitrification": [
+		"185"
+	],
+	"textured_plate_temp": [
+		"100"
+	],
+	"textured_plate_temp_initial_layer": [
+		"100"
+	],
+	"nozzle_temperature_range_high": [
+		"290"
+	],
+	"nozzle_temperature_range_low": [
+		"260"
+	],
+	"description": "When printing this filament, there's a risk of nozzle clogging, oozing, warping and low layer adhesion strength. To get better results, please refer to this wiki: Printing Tips for High Temp / Engineering materials.",
+	"filament_multitool_ramming": [
+		"1"
+	],
+	"activate_chamber_temp_control": [
+		"1"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/WonderMaker/WonderMaker PET-CF @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/WonderMaker/WonderMaker PET-CF @base.json
@@ -1,0 +1,191 @@
+{
+	"type": "filament",
+	"name": "WonderMaker PET-CF @base",
+	"inherits": "fdm_filament_pet",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"chamber_temperatures": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"0"
+	],
+	"cool_plate_temp_initial_layer": [
+		"0"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"80"
+	],
+	"eng_plate_temp_initial_layer": [
+		"80"
+	],
+	"fan_cooling_layer_time": [
+		"5"
+	],
+	"fan_max_speed": [
+		"30"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"filament_cost": [
+		"84.99"
+	],
+	"filament_density": [
+		"1.29"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"1"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"8"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PET-CF"
+	],
+	"filament_vendor": [
+		"WonderMaker"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"filament_scarf_seam_type": [
+		"none"
+	],
+	"filament_scarf_height": [
+		"10%"
+	],
+	"filament_scarf_gap": [
+		"0%"
+	],
+	"filament_scarf_length": [
+		"10"
+	],
+	"filament_shrink": [
+		"100%"
+	],
+	"hot_plate_temp": [
+		"100"
+	],
+	"hot_plate_temp_initial_layer": [
+		"100"
+	],
+	"nozzle_temperature": [
+		"270"
+	],
+	"nozzle_temperature_initial_layer": [
+		"270"
+	],
+	"overhang_fan_speed": [
+		"40"
+	],
+	"overhang_fan_threshold": [
+		"0%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"40"
+	],
+	"supertack_plate_temp": [
+		"80"
+	],
+	"supertack_plate_temp_initial_layer": [
+		"80"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"2"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"temperature_vitrification": [
+		"185"
+	],
+	"textured_plate_temp": [
+		"100"
+	],
+	"textured_plate_temp_initial_layer": [
+		"100"
+	],
+	"nozzle_temperature_range_high": [
+		"290"
+	],
+	"nozzle_temperature_range_low": [
+		"260"
+	],
+	"description": "When printing this filament, there's a risk of nozzle clogging, oozing, warping and low layer adhesion strength. To get better results, please refer to this wiki: Printing Tips for High Temp / Engineering materials.",
+	"filament_multitool_ramming": [
+		"1"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/WonderMaker/WonderMaker PETG Basic @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/WonderMaker/WonderMaker PETG Basic @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "WonderMaker PETG Basic @System",
+	"inherits": "WonderMaker PETG Basic @base",
+	"from": "system",
+	"filament_id": "GFG00",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/WonderMaker/WonderMaker PETG Basic @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/WonderMaker/WonderMaker PETG Basic @base.json
@@ -1,0 +1,191 @@
+{
+	"type": "filament",
+	"name": "WonderMaker PETG Basic @base",
+	"inherits": "fdm_filament_pet",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"chamber_temperatures": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"0"
+	],
+	"cool_plate_temp_initial_layer": [
+		"0"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"70"
+	],
+	"eng_plate_temp_initial_layer": [
+		"70"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"fan_max_speed": [
+		"40"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"filament_cost": [
+		"24.99"
+	],
+	"filament_density": [
+		"1.25"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"0.95"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"8"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PETG"
+	],
+	"filament_vendor": [
+		"WonderMaker"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"filament_scarf_seam_type": [
+		"none"
+	],
+	"filament_scarf_height": [
+		"10%"
+	],
+	"filament_scarf_gap": [
+		"0%"
+	],
+	"filament_scarf_length": [
+		"10"
+	],
+	"filament_shrink": [
+		"100%"
+	],
+	"hot_plate_temp": [
+		"70"
+	],
+	"hot_plate_temp_initial_layer": [
+		"70"
+	],
+	"nozzle_temperature": [
+		"255"
+	],
+	"nozzle_temperature_initial_layer": [
+		"255"
+	],
+	"overhang_fan_speed": [
+		"90"
+	],
+	"overhang_fan_threshold": [
+		"10%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"3"
+	],
+	"supertack_plate_temp": [
+		"70"
+	],
+	"supertack_plate_temp_initial_layer": [
+		"70"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"12"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"temperature_vitrification": [
+		"70"
+	],
+	"textured_plate_temp": [
+		"70"
+	],
+	"textured_plate_temp_initial_layer": [
+		"70"
+	],
+	"nozzle_temperature_range_high": [
+		"270"
+	],
+	"nozzle_temperature_range_low": [
+		"230"
+	],
+	"description": "To get better transparent or translucent results with the corresponding filament, please refer to this wiki: Printing tips for transparent PETG.",
+	"filament_multitool_ramming": [
+		"1"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/WonderMaker/WonderMaker PLA Basic @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/WonderMaker/WonderMaker PLA Basic @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "WonderMaker PLA Basic @System",
+	"inherits": "WonderMaker PLA Basic @base",
+	"from": "system",
+	"filament_id": "GFA00",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/WonderMaker/WonderMaker PLA Basic @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/WonderMaker/WonderMaker PLA Basic @base.json
@@ -1,0 +1,193 @@
+{
+	"type": "filament",
+	"name": "WonderMaker PLA Basic @base",
+	"inherits": "fdm_filament_pla",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"chamber_temperatures": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"35"
+	],
+	"cool_plate_temp_initial_layer": [
+		"35"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"0"
+	],
+	"eng_plate_temp_initial_layer": [
+		"0"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"filament_cost": [
+		"24.99"
+	],
+	"filament_density": [
+		"1.26"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"21"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PLA"
+	],
+	"filament_vendor": [
+		"WonderMaker"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"filament_scarf_seam_type": [
+		"none"
+	],
+	"filament_scarf_height": [
+		"10%"
+	],
+	"filament_scarf_gap": [
+		"0%"
+	],
+	"filament_scarf_length": [
+		"10"
+	],
+	"filament_shrink": [
+		"100%"
+	],
+	"hot_plate_temp": [
+		"55"
+	],
+	"hot_plate_temp_initial_layer": [
+		"55"
+	],
+	"nozzle_temperature": [
+		"220"
+	],
+	"nozzle_temperature_initial_layer": [
+		"220"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"3"
+	],
+	"supertack_plate_temp": [
+		"45"
+	],
+	"supertack_plate_temp_initial_layer": [
+		"45"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"4"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"temperature_vitrification": [
+		"45"
+	],
+	"textured_plate_temp": [
+		"55"
+	],
+	"textured_plate_temp_initial_layer": [
+		"55"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"240"
+	],
+	"filament_multitool_ramming": [
+		"1"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/WonderMaker/WonderMaker PLA Marble @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/WonderMaker/WonderMaker PLA Marble @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "WonderMaker PLA Marble @System",
+	"inherits": "WonderMaker PLA Marble @base",
+	"from": "system",
+	"filament_id": "GFA07",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/WonderMaker/WonderMaker PLA Marble @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/WonderMaker/WonderMaker PLA Marble @base.json
@@ -1,0 +1,193 @@
+{
+	"type": "filament",
+	"name": "WonderMaker PLA Marble @base",
+	"inherits": "fdm_filament_pla",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"chamber_temperatures": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"35"
+	],
+	"cool_plate_temp_initial_layer": [
+		"35"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"0"
+	],
+	"eng_plate_temp_initial_layer": [
+		"0"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"filament_cost": [
+		"29.99"
+	],
+	"filament_density": [
+		"1.22"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"12"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PLA"
+	],
+	"filament_vendor": [
+		"WonderMaker"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"filament_scarf_seam_type": [
+		"none"
+	],
+	"filament_scarf_height": [
+		"10%"
+	],
+	"filament_scarf_gap": [
+		"15%"
+	],
+	"filament_scarf_length": [
+		"10"
+	],
+	"filament_shrink": [
+		"100%"
+	],
+	"hot_plate_temp": [
+		"55"
+	],
+	"hot_plate_temp_initial_layer": [
+		"55"
+	],
+	"nozzle_temperature": [
+		"220"
+	],
+	"nozzle_temperature_initial_layer": [
+		"220"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"3"
+	],
+	"supertack_plate_temp": [
+		"45"
+	],
+	"supertack_plate_temp_initial_layer": [
+		"45"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"4"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"temperature_vitrification": [
+		"45"
+	],
+	"textured_plate_temp": [
+		"55"
+	],
+	"textured_plate_temp_initial_layer": [
+		"55"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"240"
+	],
+	"filament_multitool_ramming": [
+		"1"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/WonderMaker/WonderMaker PLA Matte @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/WonderMaker/WonderMaker PLA Matte @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "WonderMaker PLA Matte @System",
+	"inherits": "WonderMaker PLA Matte @base",
+	"from": "system",
+	"filament_id": "GFA01",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/WonderMaker/WonderMaker PLA Matte @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/WonderMaker/WonderMaker PLA Matte @base.json
@@ -1,0 +1,193 @@
+{
+	"type": "filament",
+	"name": "WonderMaker PLA Matte @base",
+	"inherits": "fdm_filament_pla",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"chamber_temperatures": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"35"
+	],
+	"cool_plate_temp_initial_layer": [
+		"35"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"0"
+	],
+	"eng_plate_temp_initial_layer": [
+		"0"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"filament_cost": [
+		"24.99"
+	],
+	"filament_density": [
+		"1.32"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"12"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PLA"
+	],
+	"filament_vendor": [
+		"WonderMaker"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"filament_scarf_seam_type": [
+		"none"
+	],
+	"filament_scarf_height": [
+		"5%"
+	],
+	"filament_scarf_gap": [
+		"0%"
+	],
+	"filament_scarf_length": [
+		"10"
+	],
+	"filament_shrink": [
+		"100%"
+	],
+	"hot_plate_temp": [
+		"55"
+	],
+	"hot_plate_temp_initial_layer": [
+		"55"
+	],
+	"nozzle_temperature": [
+		"220"
+	],
+	"nozzle_temperature_initial_layer": [
+		"220"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"3"
+	],
+	"supertack_plate_temp": [
+		"45"
+	],
+	"supertack_plate_temp_initial_layer": [
+		"45"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"4"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"temperature_vitrification": [
+		"45"
+	],
+	"textured_plate_temp": [
+		"55"
+	],
+	"textured_plate_temp_initial_layer": [
+		"55"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"240"
+	],
+	"filament_multitool_ramming": [
+		"1"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/WonderMaker/WonderMaker PLA Metal @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/WonderMaker/WonderMaker PLA Metal @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "WonderMaker PLA Metal @System",
+	"inherits": "WonderMaker PLA Metal @base",
+	"from": "system",
+	"filament_id": "GFA02",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/WonderMaker/WonderMaker PLA Metal @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/WonderMaker/WonderMaker PLA Metal @base.json
@@ -1,0 +1,194 @@
+{
+	"type": "filament",
+	"name": "WonderMaker PLA Metal @base",
+	"inherits": "fdm_filament_pla",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"chamber_temperatures": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"35"
+	],
+	"cool_plate_temp_initial_layer": [
+		"35"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"0"
+	],
+	"eng_plate_temp_initial_layer": [
+		"0"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"filament_cost": [
+		"29.99"
+	],
+	"filament_density": [
+		"1.25"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"12"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PLA"
+	],
+	"filament_vendor": [
+		"WonderMaker"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"filament_scarf_seam_type": [
+		"none"
+	],
+	"filament_scarf_height": [
+		"10%"
+	],
+	"filament_scarf_gap": [
+		"15%"
+	],
+	"filament_scarf_length": [
+		"10"
+	],
+	"filament_shrink": [
+		"100%"
+	],
+	"hot_plate_temp": [
+		"55"
+	],
+	"hot_plate_temp_initial_layer": [
+		"55"
+	],
+	"nozzle_temperature": [
+		"220"
+	],
+	"nozzle_temperature_initial_layer": [
+		"220"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"3"
+	],
+	"supertack_plate_temp": [
+		"45"
+	],
+	"supertack_plate_temp_initial_layer": [
+		"45"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"4"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"temperature_vitrification": [
+		"45"
+	],
+	"textured_plate_temp": [
+		"55"
+	],
+	"textured_plate_temp_initial_layer": [
+		"55"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"240"
+	],
+	"description": "To make the prints get higher gloss, please dry the filament before use, and set the outer wall speed to be 40 to 60 mm/s when slicing.",
+	"filament_multitool_ramming": [
+		"1"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/WonderMaker/WonderMaker PLA Silk @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/WonderMaker/WonderMaker PLA Silk @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "WonderMaker PLA Silk @System",
+	"inherits": "WonderMaker PLA Silk @base",
+	"from": "system",
+	"filament_id": "GFA05",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/WonderMaker/WonderMaker PLA Silk @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/WonderMaker/WonderMaker PLA Silk @base.json
@@ -1,0 +1,194 @@
+{
+	"type": "filament",
+	"name": "WonderMaker PLA Silk @base",
+	"inherits": "fdm_filament_pla",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"chamber_temperatures": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"35"
+	],
+	"cool_plate_temp_initial_layer": [
+		"35"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"0"
+	],
+	"eng_plate_temp_initial_layer": [
+		"0"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"filament_cost": [
+		"29.99"
+	],
+	"filament_density": [
+		"1.32"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"12"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PLA"
+	],
+	"filament_vendor": [
+		"WonderMaker"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"filament_scarf_seam_type": [
+		"none"
+	],
+	"filament_scarf_height": [
+		"5%"
+	],
+	"filament_scarf_gap": [
+		"0%"
+	],
+	"filament_scarf_length": [
+		"10"
+	],
+	"filament_shrink": [
+		"100%"
+	],
+	"hot_plate_temp": [
+		"55"
+	],
+	"hot_plate_temp_initial_layer": [
+		"55"
+	],
+	"nozzle_temperature": [
+		"230"
+	],
+	"nozzle_temperature_initial_layer": [
+		"230"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"3"
+	],
+	"supertack_plate_temp": [
+		"0"
+	],
+	"supertack_plate_temp_initial_layer": [
+		"0"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"4"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"temperature_vitrification": [
+		"45"
+	],
+	"textured_plate_temp": [
+		"55"
+	],
+	"textured_plate_temp_initial_layer": [
+		"55"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"240"
+	],
+	"description": "To make the prints get higher gloss, please dry the filament before use, and set the outer wall speed to be 40 to 60 mm/s when slicing.",
+	"filament_multitool_ramming": [
+		"1"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/WonderMaker/WonderMaker PLA Wood @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/WonderMaker/WonderMaker PLA Wood @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "WonderMaker PLA Wood @System",
+	"inherits": "WonderMaker PLA Wood @base",
+	"from": "system",
+	"filament_id": "GFA16",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/WonderMaker/WonderMaker PLA Wood @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/WonderMaker/WonderMaker PLA Wood @base.json
@@ -1,0 +1,193 @@
+{
+	"type": "filament",
+	"name": "WonderMaker PLA Wood @base",
+	"inherits": "fdm_filament_pla",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"chamber_temperatures": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"35"
+	],
+	"cool_plate_temp_initial_layer": [
+		"35"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"0"
+	],
+	"eng_plate_temp_initial_layer": [
+		"0"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"filament_cost": [
+		"24.99"
+	],
+	"filament_density": [
+		"1.21"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_long_retractions_when_cut": [
+		"1"
+	],
+	"filament_max_volumetric_speed": [
+		"18"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"18"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PLA"
+	],
+	"filament_vendor": [
+		"WonderMaker"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"filament_scarf_seam_type": [
+		"none"
+	],
+	"filament_scarf_height": [
+		"10%"
+	],
+	"filament_scarf_gap": [
+		"15%"
+	],
+	"filament_scarf_length": [
+		"10"
+	],
+	"filament_shrink": [
+		"100%"
+	],
+	"hot_plate_temp": [
+		"55"
+	],
+	"hot_plate_temp_initial_layer": [
+		"55"
+	],
+	"nozzle_temperature": [
+		"220"
+	],
+	"nozzle_temperature_initial_layer": [
+		"220"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"3"
+	],
+	"supertack_plate_temp": [
+		"45"
+	],
+	"supertack_plate_temp_initial_layer": [
+		"45"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"4"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"temperature_vitrification": [
+		"45"
+	],
+	"textured_plate_temp": [
+		"55"
+	],
+	"textured_plate_temp_initial_layer": [
+		"55"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"240"
+	],
+	"filament_multitool_ramming": [
+		"1"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/WonderMaker/WonderMaker PVA @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/WonderMaker/WonderMaker PVA @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "WonderMaker PVA @System",
+	"inherits": "WonderMaker PVA @base",
+	"from": "system",
+	"filament_id": "GFS04",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/WonderMaker/WonderMaker PVA @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/WonderMaker/WonderMaker PVA @base.json
@@ -1,0 +1,194 @@
+{
+	"type": "filament",
+	"name": "WonderMaker PVA @base",
+	"inherits": "fdm_filament_pva",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"chamber_temperatures": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"45"
+	],
+	"cool_plate_temp_initial_layer": [
+		"45"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"0"
+	],
+	"eng_plate_temp_initial_layer": [
+		"0"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"filament_cost": [
+		"79.98"
+	],
+	"filament_density": [
+		"1.27"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"1"
+	],
+	"filament_is_support": [
+		"1"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"6"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"1"
+	],
+	"filament_type": [
+		"PVA"
+	],
+	"filament_vendor": [
+		"WonderMaker"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"filament_scarf_seam_type": [
+		"none"
+	],
+	"filament_scarf_height": [
+		"10%"
+	],
+	"filament_scarf_gap": [
+		"0%"
+	],
+	"filament_scarf_length": [
+		"10"
+	],
+	"filament_shrink": [
+		"100%"
+	],
+	"hot_plate_temp": [
+		"55"
+	],
+	"hot_plate_temp_initial_layer": [
+		"55"
+	],
+	"nozzle_temperature": [
+		"220"
+	],
+	"nozzle_temperature_initial_layer": [
+		"220"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"3"
+	],
+	"supertack_plate_temp": [
+		"35"
+	],
+	"supertack_plate_temp_initial_layer": [
+		"35"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"7"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"temperature_vitrification": [
+		"45"
+	],
+	"textured_plate_temp": [
+		"55"
+	],
+	"textured_plate_temp_initial_layer": [
+		"55"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"nozzle_temperature_range_high": [
+		"250"
+	],
+	"nozzle_temperature_range_low": [
+		"210"
+	],
+	"description": "This is a water-soluble support filament, and usually it is only for the support structure and not for the model body. Printing this filament is of many requirements, and to get better printing quality, please refer to this wiki: PVA Printing Guide.",
+	"filament_multitool_ramming": [
+		"1"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/WonderMaker/WonderMaker TPU 95A @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/WonderMaker/WonderMaker TPU 95A @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "WonderMaker TPU 95A @System",
+	"inherits": "WonderMaker TPU 95A @base",
+	"from": "system",
+	"filament_id": "GFU01",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/WonderMaker/WonderMaker TPU 95A @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/WonderMaker/WonderMaker TPU 95A @base.json
@@ -1,0 +1,194 @@
+{
+	"type": "filament",
+	"name": "WonderMaker TPU 95A @base",
+	"inherits": "fdm_filament_tpu",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"chamber_temperatures": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"30"
+	],
+	"cool_plate_temp_initial_layer": [
+		"30"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"30"
+	],
+	"eng_plate_temp_initial_layer": [
+		"30"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"filament_cost": [
+		"41.99"
+	],
+	"filament_density": [
+		"1.22"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"1"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"15"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"0.4"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"TPU"
+	],
+	"filament_vendor": [
+		"WonderMaker"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"filament_scarf_seam_type": [
+		"none"
+	],
+	"filament_scarf_height": [
+		"10%"
+	],
+	"filament_scarf_gap": [
+		"0%"
+	],
+	"filament_scarf_length": [
+		"10"
+	],
+	"filament_shrink": [
+		"100%"
+	],
+	"hot_plate_temp": [
+		"35"
+	],
+	"hot_plate_temp_initial_layer": [
+		"35"
+	],
+	"nozzle_temperature": [
+		"230"
+	],
+	"nozzle_temperature_initial_layer": [
+		"230"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"95%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"3"
+	],
+	"supertack_plate_temp": [
+		"0"
+	],
+	"supertack_plate_temp_initial_layer": [
+		"0"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"8"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"temperature_vitrification": [
+		"30"
+	],
+	"textured_plate_temp": [
+		"35"
+	],
+	"textured_plate_temp_initial_layer": [
+		"35"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"nozzle_temperature_range_high": [
+		"250"
+	],
+	"nozzle_temperature_range_low": [
+		"200"
+	],
+	"description": "This filament is too soft and not compatible with the AMS. Printing it is of many requirements, and to get better printing quality, please refer to this wiki: TPU printing guide.",
+	"filament_multitool_ramming": [
+		"1"
+	]
+}

--- a/resources/profiles/WonderMaker/filament/WonderMaker ABS @WonderMaker ZR Ultra S.json
+++ b/resources/profiles/WonderMaker/filament/WonderMaker ABS @WonderMaker ZR Ultra S.json
@@ -1,19 +1,10 @@
 {
 	"type": "filament",
 	"name": "WonderMaker ABS @WonderMaker ZR Ultra S",
-	"inherits": "WonderMaker ABS",
+	"inherits": "WonderMaker ABS @WonderMaker ZR Ultra S @base",
 	"from": "system",
 	"setting_id": "GFSB01_07",
 	"instantiation": "true",
-	"chamber_temperatures": [
-		"60"
-	],
-	"activate_chamber_temp_control": [
-		"1"
-	],
-	"filament_multitool_ramming": [
-		"1"
-	],
 	"compatible_printers": [
 		"WonderMaker ZR Ultra S 0.2 nozzle",
 		"WonderMaker ZR Ultra S 0.4 nozzle",

--- a/resources/profiles/WonderMaker/filament/WonderMaker ABS.json
+++ b/resources/profiles/WonderMaker/filament/WonderMaker ABS.json
@@ -1,23 +1,10 @@
 {
 	"type": "filament",
 	"name": "WonderMaker ABS",
-	"inherits": "fdm_filament_abs",
+	"inherits": "WonderMaker ABS @base",
 	"from": "system",
 	"filament_id": "GFB00",
 	"instantiation": "true",
-	"description": "When printing this filament, there's a risk of warping and low layer adhesion strength. To get better results, please refer to this wiki: Printing Tips for High Temp / Engineering materials.",
-	"filament_cost": [
-		"24.99"
-	],
-	"filament_flow_ratio": [
-		"0.95"
-	],
-	"filament_vendor": [
-		"WonderMaker"
-	],
-	"filament_multitool_ramming": [
-		"1"
-	],
 	"compatible_printers": [
 		"WonderMaker ZR 0.2 nozzle",
 		"WonderMaker ZR 0.4 nozzle",

--- a/resources/profiles/WonderMaker/filament/WonderMaker ASA @WonderMaker ZR Ultra S.json
+++ b/resources/profiles/WonderMaker/filament/WonderMaker ASA @WonderMaker ZR Ultra S.json
@@ -1,19 +1,10 @@
 {
 	"type": "filament",
 	"name": "WonderMaker ASA @WonderMaker ZR Ultra S",
-	"inherits": "WonderMaker ASA",
+	"inherits": "WonderMaker ASA @WonderMaker ZR Ultra S @base",
 	"from": "system",
 	"setting_id": "GFSB01_07",
 	"instantiation": "true",
-	"chamber_temperatures": [
-		"60"
-	],
-	"activate_chamber_temp_control": [
-		"1"
-	],
-	"filament_multitool_ramming": [
-		"1"
-	],
 	"compatible_printers": [
 		"WonderMaker ZR Ultra S 0.2 nozzle",
 		"WonderMaker ZR Ultra S 0.4 nozzle",

--- a/resources/profiles/WonderMaker/filament/WonderMaker ASA.json
+++ b/resources/profiles/WonderMaker/filament/WonderMaker ASA.json
@@ -1,59 +1,10 @@
 {
 	"type": "filament",
 	"name": "WonderMaker ASA",
-	"inherits": "fdm_filament_asa",
+	"inherits": "WonderMaker ASA @base",
 	"from": "system",
 	"filament_id": "GFB01",
 	"instantiation": "true",
-	"description": "When printing this filament, there's a risk of warping and low layer adhesion strength. To get better results, please refer to this wiki: Printing Tips for High Temp / Engineering materials.",
-	"eng_plate_temp": [
-		"100"
-	],
-	"eng_plate_temp_initial_layer": [
-		"100"
-	],
-	"fan_max_speed": [
-		"35"
-	],
-	"filament_cost": [
-		"31.99"
-	],
-	"filament_density": [
-		"1.05"
-	],
-	"filament_flow_ratio": [
-		"0.95"
-	],
-	"filament_max_volumetric_speed": [
-		"18"
-	],
-	"filament_vendor": [
-		"WonderMaker"
-	],
-	"hot_plate_temp": [
-		"100"
-	],
-	"hot_plate_temp_initial_layer": [
-		"100"
-	],
-	"nozzle_temperature": [
-		"270"
-	],
-	"nozzle_temperature_initial_layer": [
-		"270"
-	],
-	"slow_down_layer_time": [
-		"12"
-	],
-	"textured_plate_temp": [
-		"100"
-	],
-	"textured_plate_temp_initial_layer": [
-		"100"
-	],
-	"filament_multitool_ramming": [
-		"1"
-	],
 	"compatible_printers": [
 		"WonderMaker ZR 0.2 nozzle",
 		"WonderMaker ZR 0.4 nozzle",

--- a/resources/profiles/WonderMaker/filament/WonderMaker PET-CF @WonderMaker ZR Ultra S.json
+++ b/resources/profiles/WonderMaker/filament/WonderMaker PET-CF @WonderMaker ZR Ultra S.json
@@ -1,19 +1,10 @@
 {
 	"type": "filament",
 	"name": "WonderMaker PET-CF @WonderMaker ZR Ultra S",
-	"inherits": "WonderMaker PET-CF",
+	"inherits": "WonderMaker PET-CF @WonderMaker ZR Ultra S @base",
 	"from": "system",
 	"setting_id": "GFST01_00",
 	"instantiation": "true",
-	"chamber_temperatures": [
-		"60"
-	],
-	"activate_chamber_temp_control": [
-		"1"
-	],
-	"filament_multitool_ramming": [
-		"1"
-	],
 	"compatible_printers": [
 		"WonderMaker ZR Ultra S 0.4 nozzle",
 		"WonderMaker ZR Ultra S 0.6 nozzle",

--- a/resources/profiles/WonderMaker/filament/WonderMaker PET-CF.json
+++ b/resources/profiles/WonderMaker/filament/WonderMaker PET-CF.json
@@ -1,95 +1,10 @@
 {
 	"type": "filament",
 	"name": "WonderMaker PET-CF",
-	"inherits": "fdm_filament_pet",
+	"inherits": "WonderMaker PET-CF @base",
 	"from": "system",
 	"filament_id": "GFT01",
 	"instantiation": "true",
-	"description": "When printing this filament, there's a risk of nozzle clogging, oozing, warping and low layer adhesion strength. To get better results, please refer to this wiki: Printing Tips for High Temp / Engineering materials.",
-	"cool_plate_temp": [
-		"0"
-	],
-	"cool_plate_temp_initial_layer": [
-		"0"
-	],
-	"eng_plate_temp": [
-		"80"
-	],
-	"eng_plate_temp_initial_layer": [
-		"80"
-	],
-	"fan_cooling_layer_time": [
-		"5"
-	],
-	"fan_max_speed": [
-		"30"
-	],
-	"fan_min_speed": [
-		"10"
-	],
-	"filament_cost": [
-		"84.99"
-	],
-	"filament_density": [
-		"1.29"
-	],
-	"filament_max_volumetric_speed": [
-		"8"
-	],
-	"filament_type": [
-		"PET-CF"
-	],
-	"filament_vendor": [
-		"WonderMaker"
-	],
-	"hot_plate_temp": [
-		"100"
-	],
-	"hot_plate_temp_initial_layer": [
-		"100"
-	],
-	"nozzle_temperature": [
-		"270"
-	],
-	"nozzle_temperature_initial_layer": [
-		"270"
-	],
-	"nozzle_temperature_range_high": [
-		"290"
-	],
-	"nozzle_temperature_range_low": [
-		"260"
-	],
-	"overhang_fan_speed": [
-		"40"
-	],
-	"overhang_fan_threshold": [
-		"0%"
-	],
-	"required_nozzle_HRC": [
-		"40"
-	],
-	"supertack_plate_temp": [
-		"80"
-	],
-	"supertack_plate_temp_initial_layer": [
-		"80"
-	],
-	"slow_down_layer_time": [
-		"2"
-	],
-	"temperature_vitrification": [
-		"185"
-	],
-	"textured_plate_temp": [
-		"100"
-	],
-	"textured_plate_temp_initial_layer": [
-		"100"
-	],
-	"filament_multitool_ramming": [
-		"1"
-	],
 	"compatible_printers": [
 		"WonderMaker ZR 0.4 nozzle",
 		"WonderMaker ZR 0.6 nozzle",

--- a/resources/profiles/WonderMaker/filament/WonderMaker PETG Basic.json
+++ b/resources/profiles/WonderMaker/filament/WonderMaker PETG Basic.json
@@ -1,77 +1,10 @@
 {
 	"type": "filament",
 	"name": "WonderMaker PETG Basic",
-	"inherits": "fdm_filament_pet",
+	"inherits": "WonderMaker PETG Basic @base",
 	"from": "system",
 	"filament_id": "GFG00",
 	"instantiation": "true",
-	"description": "To get better transparent or translucent results with the corresponding filament, please refer to this wiki: Printing tips for transparent PETG.",
-	"cool_plate_temp": [
-		"0"
-	],
-	"cool_plate_temp_initial_layer": [
-		"0"
-	],
-	"eng_plate_temp": [
-		"70"
-	],
-	"eng_plate_temp_initial_layer": [
-		"70"
-	],
-	"fan_cooling_layer_time": [
-		"30"
-	],
-	"fan_max_speed": [
-		"40"
-	],
-	"fan_min_speed": [
-		"10"
-	],
-	"filament_cost": [
-		"24.99"
-	],
-	"filament_density": [
-		"1.25"
-	],
-	"filament_flow_ratio": [
-		"0.95"
-	],
-	"filament_max_volumetric_speed": [
-		"8"
-	],
-	"filament_vendor": [
-		"WonderMaker"
-	],
-	"hot_plate_temp": [
-		"70"
-	],
-	"hot_plate_temp_initial_layer": [
-		"70"
-	],
-	"nozzle_temperature_range_high": [
-		"270"
-	],
-	"nozzle_temperature_range_low": [
-		"230"
-	],
-	"overhang_fan_speed": [
-		"90"
-	],
-	"overhang_fan_threshold": [
-		"10%"
-	],
-	"slow_down_layer_time": [
-		"12"
-	],
-	"textured_plate_temp": [
-		"70"
-	],
-	"textured_plate_temp_initial_layer": [
-		"70"
-	],
-	"filament_multitool_ramming": [
-		"1"
-	],
 	"compatible_printers": [
 		"WonderMaker ZR 0.2 nozzle",
 		"WonderMaker ZR 0.4 nozzle",

--- a/resources/profiles/WonderMaker/filament/WonderMaker PLA Basic.json
+++ b/resources/profiles/WonderMaker/filament/WonderMaker PLA Basic.json
@@ -1,40 +1,10 @@
 {
 	"type": "filament",
 	"name": "WonderMaker PLA Basic",
-	"inherits": "fdm_filament_pla",
+	"inherits": "WonderMaker PLA Basic @base",
 	"from": "system",
 	"filament_id": "GFA00",
 	"instantiation": "true",
-	"filament_cost": [
-		"24.99"
-	],
-	"filament_density": [
-		"1.26"
-	],
-	"filament_flow_ratio": [
-		"0.98"
-	],
-	"filament_max_volumetric_speed": [
-		"21"
-	],
-	"filament_vendor": [
-		"WonderMaker"
-	],
-	"filament_scarf_seam_type": [
-		"none"
-	],
-	"filament_scarf_height": [
-		"10%"
-	],
-	"filament_scarf_gap": [
-		"0%"
-	],
-	"filament_scarf_length": [
-		"10"
-	],
-	"filament_multitool_ramming": [
-		"1"
-	],
 	"compatible_printers": [
 		"WonderMaker ZR 0.2 nozzle",
 		"WonderMaker ZR 0.4 nozzle",

--- a/resources/profiles/WonderMaker/filament/WonderMaker PLA Marble.json
+++ b/resources/profiles/WonderMaker/filament/WonderMaker PLA Marble.json
@@ -1,25 +1,10 @@
 {
 	"type": "filament",
 	"name": "WonderMaker PLA Marble",
-	"inherits": "fdm_filament_pla",
+	"inherits": "WonderMaker PLA Marble @base",
 	"from": "system",
 	"filament_id": "GFA07",
 	"instantiation": "true",
-	"filament_cost": [
-		"29.99"
-	],
-	"filament_density": [
-		"1.22"
-	],
-	"filament_flow_ratio": [
-		"0.98"
-	],
-	"filament_vendor": [
-		"WonderMaker"
-	],
-	"filament_multitool_ramming": [
-		"1"
-	],
 	"compatible_printers": [
 		"WonderMaker ZR 0.2 nozzle",
 		"WonderMaker ZR 0.4 nozzle",

--- a/resources/profiles/WonderMaker/filament/WonderMaker PLA Matte.json
+++ b/resources/profiles/WonderMaker/filament/WonderMaker PLA Matte.json
@@ -1,37 +1,10 @@
 {
 	"type": "filament",
 	"name": "WonderMaker PLA Matte",
-	"inherits": "fdm_filament_pla",
+	"inherits": "WonderMaker PLA Matte @base",
 	"from": "system",
 	"filament_id": "GFA01",
 	"instantiation": "true",
-	"filament_cost": [
-		"24.99"
-	],
-	"filament_density": [
-		"1.32"
-	],
-	"filament_flow_ratio": [
-		"0.98"
-	],
-	"filament_vendor": [
-		"WonderMaker"
-	],
-	"filament_scarf_seam_type": [
-		"none"
-	],
-	"filament_scarf_height": [
-		"5%"
-	],
-	"filament_scarf_gap": [
-		"0%"
-	],
-	"filament_scarf_length": [
-		"10"
-	],
-	"filament_multitool_ramming": [
-		"1"
-	],
 	"compatible_printers": [
 		"WonderMaker ZR 0.2 nozzle",
 		"WonderMaker ZR 0.4 nozzle",

--- a/resources/profiles/WonderMaker/filament/WonderMaker PLA Metal.json
+++ b/resources/profiles/WonderMaker/filament/WonderMaker PLA Metal.json
@@ -1,29 +1,10 @@
 {
 	"type": "filament",
 	"name": "WonderMaker PLA Metal",
-	"inherits": "fdm_filament_pla",
+	"inherits": "WonderMaker PLA Metal @base",
 	"from": "system",
 	"filament_id": "GFA02",
 	"instantiation": "true",
-	"description": "To make the prints get higher gloss, please dry the filament before use, and set the outer wall speed to be 40 to 60 mm/s when slicing.",
-	"filament_cost": [
-		"29.99"
-	],
-	"filament_density": [
-		"1.25"
-	],
-	"filament_flow_ratio": [
-		"0.98"
-	],
-	"filament_vendor": [
-		"WonderMaker"
-	],
-	"filament_scarf_seam_type": [
-		"none"
-	],
-	"filament_multitool_ramming": [
-		"1"
-	],
 	"compatible_printers": [
 		"WonderMaker ZR 0.2 nozzle",
 		"WonderMaker ZR 0.4 nozzle",

--- a/resources/profiles/WonderMaker/filament/WonderMaker PLA Silk.json
+++ b/resources/profiles/WonderMaker/filament/WonderMaker PLA Silk.json
@@ -1,44 +1,10 @@
 {
 	"type": "filament",
 	"name": "WonderMaker PLA Silk",
-	"inherits": "fdm_filament_pla",
+	"inherits": "WonderMaker PLA Silk @base",
 	"from": "system",
 	"filament_id": "GFA05",
 	"instantiation": "true",
-	"description": "To make the prints get higher gloss, please dry the filament before use, and set the outer wall speed to be 40 to 60 mm/s when slicing.",
-	"filament_cost": [
-		"29.99"
-	],
-	"filament_density": [
-		"1.32"
-	],
-	"filament_flow_ratio": [
-		"0.98"
-	],
-	"filament_vendor": [
-		"WonderMaker"
-	],
-	"filament_scarf_height": [
-		"5%"
-	],
-	"filament_scarf_gap": [
-		"0%"
-	],
-	"nozzle_temperature": [
-		"230"
-	],
-	"nozzle_temperature_initial_layer": [
-		"230"
-	],
-	"supertack_plate_temp": [
-		"0"
-	],
-	"supertack_plate_temp_initial_layer": [
-		"0"
-	],
-	"filament_multitool_ramming": [
-		"1"
-	],
 	"compatible_printers": [
 		"WonderMaker ZR 0.2 nozzle",
 		"WonderMaker ZR 0.4 nozzle",

--- a/resources/profiles/WonderMaker/filament/WonderMaker PLA Wood.json
+++ b/resources/profiles/WonderMaker/filament/WonderMaker PLA Wood.json
@@ -1,37 +1,10 @@
 {
 	"type": "filament",
 	"name": "WonderMaker PLA Wood",
-	"inherits": "fdm_filament_pla",
+	"inherits": "WonderMaker PLA Wood @base",
 	"from": "system",
 	"filament_id": "GFA16",
 	"instantiation": "true",
-	"filament_cost": [
-		"24.99"
-	],
-	"filament_density": [
-		"1.21"
-	],
-	"filament_flow_ratio": [
-		"0.98"
-	],
-	"filament_long_retractions_when_cut": [
-		"1"
-	],
-	"filament_max_volumetric_speed": [
-		"18"
-	],
-	"filament_retraction_distances_when_cut": [
-		"18"
-	],
-	"filament_scarf_seam_type": [
-		"none"
-	],
-	"filament_vendor": [
-		"WonderMaker"
-	],
-	"filament_multitool_ramming": [
-		"1"
-	],
 	"compatible_printers": [
 		"WonderMaker ZR 0.4 nozzle",
 		"WonderMaker ZR 0.6 nozzle",

--- a/resources/profiles/WonderMaker/filament/WonderMaker PVA.json
+++ b/resources/profiles/WonderMaker/filament/WonderMaker PVA.json
@@ -1,38 +1,10 @@
 {
 	"type": "filament",
 	"name": "WonderMaker PVA",
-	"inherits": "fdm_filament_pva",
+	"inherits": "WonderMaker PVA @base",
 	"from": "system",
 	"filament_id": "GFS04",
 	"instantiation": "true",
-	"description": "This is a water-soluble support filament, and usually it is only for the support structure and not for the model body. Printing this filament is of many requirements, and to get better printing quality, please refer to this wiki: PVA Printing Guide.",
-	"filament_cost": [
-		"79.98"
-	],
-	"filament_density": [
-		"1.27"
-	],
-	"filament_max_volumetric_speed": [
-		"6"
-	],
-	"filament_vendor": [
-		"WonderMaker"
-	],
-	"nozzle_temperature_range_high": [
-		"250"
-	],
-	"nozzle_temperature_range_low": [
-		"210"
-	],
-	"slow_down_layer_time": [
-		"7"
-	],
-	"slow_down_min_speed": [
-		"20"
-	],
-	"filament_multitool_ramming": [
-		"1"
-	],
 	"compatible_printers": [
 		"WonderMaker ZR 0.2 nozzle",
 		"WonderMaker ZR 0.4 nozzle",

--- a/resources/profiles/WonderMaker/filament/WonderMaker TPU 95A.json
+++ b/resources/profiles/WonderMaker/filament/WonderMaker TPU 95A.json
@@ -1,29 +1,10 @@
 {
 	"type": "filament",
 	"name": "WonderMaker TPU 95A",
-	"inherits": "fdm_filament_tpu",
+	"inherits": "WonderMaker TPU 95A @base",
 	"from": "system",
 	"filament_id": "GFU01",
 	"instantiation": "true",
-	"description": "This filament is too soft and not compatible with the AMS. Printing it is of many requirements, and to get better printing quality, please refer to this wiki: TPU printing guide.",
-	"filament_cost": [
-		"41.99"
-	],
-	"filament_density": [
-		"1.22"
-	],
-	"filament_vendor": [
-		"WonderMaker"
-	],
-	"nozzle_temperature": [
-		"230"
-	],
-	"nozzle_temperature_initial_layer": [
-		"230"
-	],
-	"filament_multitool_ramming": [
-		"1"
-	],
 	"compatible_printers": [
 		"WonderMaker ZR 0.2 nozzle",
 		"WonderMaker ZR 0.4 nozzle",


### PR DESCRIPTION
## Summary

Migrates WonderMaker filament presets into the shared OrcaFilamentLibrary while keeping the vendor-scoped presets available for WonderMaker printers.

## Changes

- Added WonderMaker filament @base/@System presets under OrcaFilamentLibrary.
- Updated WonderMaker vendor-scoped filament presets to inherit from the new library bases.
- Registered the WonderMaker OrcaFilamentLibrary entries in resources/profiles/OrcaFilamentLibrary.json.

## Testing

- python3 scripts/orca_extra_profile_check.py --vendor WonderMaker --check-filaments --check-materials --check-obsolete-keys
- git diff --check

/claim #12162