### PR TITLE
Migrate Vzbot filaments to OrcaFilamentLibrary

### DIFF
--- a/resources/profiles/OrcaFilamentLibrary.json
+++ b/resources/profiles/OrcaFilamentLibrary.json
@@ -1507,6 +1507,86 @@
 		{
 			"name": "GreenGate3D PETG @System",
 			"sub_path": "filament/GreenGate3D/GreenGate3D PETG @System.json"
+		},
+		{
+			"name": "Vzbot Generic ABS @base",
+			"sub_path": "filament/Vzbot/Vzbot Generic ABS @base.json"
+		},
+		{
+			"name": "Vzbot Generic ABS @System",
+			"sub_path": "filament/Vzbot/Vzbot Generic ABS @System.json"
+		},
+		{
+			"name": "Vzbot Generic ASA @base",
+			"sub_path": "filament/Vzbot/Vzbot Generic ASA @base.json"
+		},
+		{
+			"name": "Vzbot Generic ASA @System",
+			"sub_path": "filament/Vzbot/Vzbot Generic ASA @System.json"
+		},
+		{
+			"name": "Vzbot Generic PA-CF @base",
+			"sub_path": "filament/Vzbot/Vzbot Generic PA-CF @base.json"
+		},
+		{
+			"name": "Vzbot Generic PA-CF @System",
+			"sub_path": "filament/Vzbot/Vzbot Generic PA-CF @System.json"
+		},
+		{
+			"name": "Vzbot Generic PA @base",
+			"sub_path": "filament/Vzbot/Vzbot Generic PA @base.json"
+		},
+		{
+			"name": "Vzbot Generic PA @System",
+			"sub_path": "filament/Vzbot/Vzbot Generic PA @System.json"
+		},
+		{
+			"name": "Vzbot Generic PC @base",
+			"sub_path": "filament/Vzbot/Vzbot Generic PC @base.json"
+		},
+		{
+			"name": "Vzbot Generic PC @System",
+			"sub_path": "filament/Vzbot/Vzbot Generic PC @System.json"
+		},
+		{
+			"name": "Vzbot Generic PETG @base",
+			"sub_path": "filament/Vzbot/Vzbot Generic PETG @base.json"
+		},
+		{
+			"name": "Vzbot Generic PETG @System",
+			"sub_path": "filament/Vzbot/Vzbot Generic PETG @System.json"
+		},
+		{
+			"name": "Vzbot Generic PLA-CF @base",
+			"sub_path": "filament/Vzbot/Vzbot Generic PLA-CF @base.json"
+		},
+		{
+			"name": "Vzbot Generic PLA-CF @System",
+			"sub_path": "filament/Vzbot/Vzbot Generic PLA-CF @System.json"
+		},
+		{
+			"name": "Vzbot Generic PLA @base",
+			"sub_path": "filament/Vzbot/Vzbot Generic PLA @base.json"
+		},
+		{
+			"name": "Vzbot Generic PLA @System",
+			"sub_path": "filament/Vzbot/Vzbot Generic PLA @System.json"
+		},
+		{
+			"name": "Vzbot Generic PVA @base",
+			"sub_path": "filament/Vzbot/Vzbot Generic PVA @base.json"
+		},
+		{
+			"name": "Vzbot Generic PVA @System",
+			"sub_path": "filament/Vzbot/Vzbot Generic PVA @System.json"
+		},
+		{
+			"name": "Vzbot Generic TPU @base",
+			"sub_path": "filament/Vzbot/Vzbot Generic TPU @base.json"
+		},
+		{
+			"name": "Vzbot Generic TPU @System",
+			"sub_path": "filament/Vzbot/Vzbot Generic TPU @System.json"
 		}
 	],
 	"process_list": [],

--- a/resources/profiles/OrcaFilamentLibrary/filament/Vzbot/Vzbot Generic ABS @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Vzbot/Vzbot Generic ABS @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Vzbot Generic ABS @System",
+	"inherits": "Vzbot Generic ABS @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFB99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Vzbot/Vzbot Generic ABS @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Vzbot/Vzbot Generic ABS @base.json
@@ -1,0 +1,151 @@
+{
+	"type": "filament",
+	"name": "Vzbot Generic ABS @base",
+	"inherits": "fdm_filament_abs",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"105"
+	],
+	"eng_plate_temp": [
+		"105"
+	],
+	"hot_plate_temp": [
+		"105"
+	],
+	"textured_plate_temp": [
+		"105"
+	],
+	"cool_plate_temp_initial_layer": [
+		"105"
+	],
+	"eng_plate_temp_initial_layer": [
+		"105"
+	],
+	"hot_plate_temp_initial_layer": [
+		"105"
+	],
+	"textured_plate_temp_initial_layer": [
+		"105"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"overhang_fan_speed": [
+		"40%"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.926"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"5"
+	],
+	"filament_cost": [
+		"30"
+	],
+	"filament_density": [
+		"1.04"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"50"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"ABS"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"250"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"60"
+	],
+	"fan_min_speed": [
+		"18"
+	],
+	"slow_down_min_speed": [
+		"30"
+	],
+	"slow_down_layer_time": [
+		"3"
+	],
+	"filament_start_gcode": [
+		"; Filament gcode\n"
+	],
+	"nozzle_temperature": [
+		"250"
+	],
+	"temperature_vitrification": [
+		"110"
+	],
+	"nozzle_temperature_range_low": [
+		"240"
+	],
+	"nozzle_temperature_range_high": [
+		"280"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Vzbot/Vzbot Generic ASA @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Vzbot/Vzbot Generic ASA @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Vzbot Generic ASA @System",
+	"inherits": "Vzbot Generic ASA @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFB98",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Vzbot/Vzbot Generic ASA @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Vzbot/Vzbot Generic ASA @base.json
@@ -1,0 +1,151 @@
+{
+	"type": "filament",
+	"name": "Vzbot Generic ASA @base",
+	"inherits": "fdm_filament_asa",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"105"
+	],
+	"eng_plate_temp": [
+		"105"
+	],
+	"hot_plate_temp": [
+		"105"
+	],
+	"textured_plate_temp": [
+		"105"
+	],
+	"cool_plate_temp_initial_layer": [
+		"105"
+	],
+	"eng_plate_temp_initial_layer": [
+		"105"
+	],
+	"hot_plate_temp_initial_layer": [
+		"105"
+	],
+	"textured_plate_temp_initial_layer": [
+		"105"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"overhang_fan_speed": [
+		"80"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.93"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"35"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.04"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"50"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"ASA"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"260"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"80"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"3"
+	],
+	"filament_start_gcode": [
+		"; Filament gcode\n"
+	],
+	"nozzle_temperature": [
+		"260"
+	],
+	"temperature_vitrification": [
+		"110"
+	],
+	"nozzle_temperature_range_low": [
+		"240"
+	],
+	"nozzle_temperature_range_high": [
+		"270"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Vzbot/Vzbot Generic PA @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Vzbot/Vzbot Generic PA @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Vzbot Generic PA @System",
+	"inherits": "Vzbot Generic PA @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFN99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Vzbot/Vzbot Generic PA @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Vzbot/Vzbot Generic PA @base.json
@@ -1,0 +1,151 @@
+{
+	"type": "filament",
+	"name": "Vzbot Generic PA @base",
+	"inherits": "fdm_filament_pa",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"0"
+	],
+	"eng_plate_temp": [
+		"100"
+	],
+	"hot_plate_temp": [
+		"100"
+	],
+	"textured_plate_temp": [
+		"100"
+	],
+	"cool_plate_temp_initial_layer": [
+		"0"
+	],
+	"eng_plate_temp_initial_layer": [
+		"100"
+	],
+	"hot_plate_temp_initial_layer": [
+		"100"
+	],
+	"textured_plate_temp_initial_layer": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"95%"
+	],
+	"overhang_fan_speed": [
+		"30"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"1"
+	],
+	"reduce_fan_stop_start_freq": [
+		"0"
+	],
+	"fan_cooling_layer_time": [
+		"4"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.04"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"50"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PA"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"280"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"60"
+	],
+	"fan_min_speed": [
+		"0"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"2"
+	],
+	"filament_start_gcode": [
+		"; Filament gcode\n"
+	],
+	"nozzle_temperature": [
+		"280"
+	],
+	"temperature_vitrification": [
+		"108"
+	],
+	"nozzle_temperature_range_low": [
+		"270"
+	],
+	"nozzle_temperature_range_high": [
+		"300"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Vzbot/Vzbot Generic PA-CF @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Vzbot/Vzbot Generic PA-CF @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Vzbot Generic PA-CF @System",
+	"inherits": "Vzbot Generic PA-CF @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFN98",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Vzbot/Vzbot Generic PA-CF @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Vzbot/Vzbot Generic PA-CF @base.json
@@ -1,0 +1,151 @@
+{
+	"type": "filament",
+	"name": "Vzbot Generic PA-CF @base",
+	"inherits": "fdm_filament_pa",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"0"
+	],
+	"eng_plate_temp": [
+		"100"
+	],
+	"hot_plate_temp": [
+		"100"
+	],
+	"textured_plate_temp": [
+		"100"
+	],
+	"cool_plate_temp_initial_layer": [
+		"0"
+	],
+	"eng_plate_temp_initial_layer": [
+		"100"
+	],
+	"hot_plate_temp_initial_layer": [
+		"100"
+	],
+	"textured_plate_temp_initial_layer": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"95%"
+	],
+	"overhang_fan_speed": [
+		"30"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"1"
+	],
+	"reduce_fan_stop_start_freq": [
+		"0"
+	],
+	"fan_cooling_layer_time": [
+		"4"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.04"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"50"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PA-CF"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"280"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"60"
+	],
+	"fan_min_speed": [
+		"0"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"2"
+	],
+	"filament_start_gcode": [
+		"; Filament gcode\n"
+	],
+	"nozzle_temperature": [
+		"280"
+	],
+	"temperature_vitrification": [
+		"108"
+	],
+	"nozzle_temperature_range_low": [
+		"270"
+	],
+	"nozzle_temperature_range_high": [
+		"300"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Vzbot/Vzbot Generic PC @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Vzbot/Vzbot Generic PC @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Vzbot Generic PC @System",
+	"inherits": "Vzbot Generic PC @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFC99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Vzbot/Vzbot Generic PC @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Vzbot/Vzbot Generic PC @base.json
@@ -1,0 +1,151 @@
+{
+	"type": "filament",
+	"name": "Vzbot Generic PC @base",
+	"inherits": "fdm_filament_pc",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"0"
+	],
+	"eng_plate_temp": [
+		"110"
+	],
+	"hot_plate_temp": [
+		"110"
+	],
+	"textured_plate_temp": [
+		"110"
+	],
+	"cool_plate_temp_initial_layer": [
+		"0"
+	],
+	"eng_plate_temp_initial_layer": [
+		"110"
+	],
+	"hot_plate_temp_initial_layer": [
+		"110"
+	],
+	"textured_plate_temp_initial_layer": [
+		"110"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"overhang_fan_speed": [
+		"60"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.94"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.04"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"50"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PC"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"270"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"60"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"2"
+	],
+	"filament_start_gcode": [
+		"; Filament gcode\n"
+	],
+	"nozzle_temperature": [
+		"280"
+	],
+	"temperature_vitrification": [
+		"140"
+	],
+	"nozzle_temperature_range_low": [
+		"260"
+	],
+	"nozzle_temperature_range_high": [
+		"280"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Vzbot/Vzbot Generic PETG @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Vzbot/Vzbot Generic PETG @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Vzbot Generic PETG @System",
+	"inherits": "Vzbot Generic PETG @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFG99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Vzbot/Vzbot Generic PETG @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Vzbot/Vzbot Generic PETG @base.json
@@ -1,0 +1,151 @@
+{
+	"type": "filament",
+	"name": "Vzbot Generic PETG @base",
+	"inherits": "fdm_filament_pet",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"60"
+	],
+	"eng_plate_temp": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"80"
+	],
+	"textured_plate_temp": [
+		"80"
+	],
+	"cool_plate_temp_initial_layer": [
+		"60"
+	],
+	"eng_plate_temp_initial_layer": [
+		"70"
+	],
+	"hot_plate_temp_initial_layer": [
+		"70"
+	],
+	"textured_plate_temp_initial_layer": [
+		"70"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"overhang_fan_speed": [
+		"70"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.95"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"filament_cost": [
+		"30"
+	],
+	"filament_density": [
+		"1.27"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"50"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PETG"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"255"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"80"
+	],
+	"fan_min_speed": [
+		"20"
+	],
+	"slow_down_min_speed": [
+		"30"
+	],
+	"slow_down_layer_time": [
+		"5"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n"
+	],
+	"nozzle_temperature": [
+		"255"
+	],
+	"temperature_vitrification": [
+		"80"
+	],
+	"nozzle_temperature_range_low": [
+		"220"
+	],
+	"nozzle_temperature_range_high": [
+		"280"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Vzbot/Vzbot Generic PLA @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Vzbot/Vzbot Generic PLA @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Vzbot Generic PLA @System",
+	"inherits": "Vzbot Generic PLA @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFL99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Vzbot/Vzbot Generic PLA @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Vzbot/Vzbot Generic PLA @base.json
@@ -1,0 +1,154 @@
+{
+	"type": "filament",
+	"name": "Vzbot Generic PLA @base",
+	"inherits": "fdm_filament_pla",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"60"
+	],
+	"eng_plate_temp": [
+		"60"
+	],
+	"hot_plate_temp": [
+		"60"
+	],
+	"textured_plate_temp": [
+		"60"
+	],
+	"cool_plate_temp_initial_layer": [
+		"60"
+	],
+	"eng_plate_temp_initial_layer": [
+		"60"
+	],
+	"hot_plate_temp_initial_layer": [
+		"60"
+	],
+	"textured_plate_temp_initial_layer": [
+		"60"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"overhang_fan_speed": [
+		"75"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"50"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PLA"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"220"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"45"
+	],
+	"slow_down_min_speed": [
+		"5"
+	],
+	"slow_down_layer_time": [
+		"5"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n"
+	],
+	"nozzle_temperature": [
+		"220"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"230"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Vzbot/Vzbot Generic PLA-CF @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Vzbot/Vzbot Generic PLA-CF @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Vzbot Generic PLA-CF @System",
+	"inherits": "Vzbot Generic PLA-CF @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFL98",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Vzbot/Vzbot Generic PLA-CF @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Vzbot/Vzbot Generic PLA-CF @base.json
@@ -1,0 +1,154 @@
+{
+	"type": "filament",
+	"name": "Vzbot Generic PLA-CF @base",
+	"inherits": "fdm_filament_pla",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"60"
+	],
+	"eng_plate_temp": [
+		"60"
+	],
+	"hot_plate_temp": [
+		"60"
+	],
+	"textured_plate_temp": [
+		"60"
+	],
+	"cool_plate_temp_initial_layer": [
+		"60"
+	],
+	"eng_plate_temp_initial_layer": [
+		"60"
+	],
+	"hot_plate_temp_initial_layer": [
+		"60"
+	],
+	"textured_plate_temp_initial_layer": [
+		"60"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"overhang_fan_speed": [
+		"75"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.95"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"50"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PLA-CF"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"220"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"45"
+	],
+	"slow_down_min_speed": [
+		"5"
+	],
+	"slow_down_layer_time": [
+		"7"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n"
+	],
+	"nozzle_temperature": [
+		"220"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"230"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Vzbot/Vzbot Generic PVA @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Vzbot/Vzbot Generic PVA @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Vzbot Generic PVA @System",
+	"inherits": "Vzbot Generic PVA @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFS99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Vzbot/Vzbot Generic PVA @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Vzbot/Vzbot Generic PVA @base.json
@@ -1,0 +1,157 @@
+{
+	"type": "filament",
+	"name": "Vzbot Generic PVA @base",
+	"inherits": "fdm_filament_pva",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"35"
+	],
+	"eng_plate_temp": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"45"
+	],
+	"textured_plate_temp": [
+		"45"
+	],
+	"cool_plate_temp_initial_layer": [
+		"35"
+	],
+	"eng_plate_temp_initial_layer": [
+		"0"
+	],
+	"hot_plate_temp_initial_layer": [
+		"45"
+	],
+	"textured_plate_temp_initial_layer": [
+		"45"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.95"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"50"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"1"
+	],
+	"filament_type": [
+		"PVA"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"220"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"slow_down_min_speed": [
+		"30"
+	],
+	"slow_down_layer_time": [
+		"7"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n"
+	],
+	"nozzle_temperature": [
+		"220"
+	],
+	"temperature_vitrification": [
+		"50"
+	],
+	"filament_is_support": [
+		"1"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"250"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Vzbot/Vzbot Generic TPU @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Vzbot/Vzbot Generic TPU @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Vzbot Generic TPU @System",
+	"inherits": "Vzbot Generic TPU @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFU99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Vzbot/Vzbot Generic TPU @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Vzbot/Vzbot Generic TPU @base.json
@@ -1,0 +1,154 @@
+{
+	"type": "filament",
+	"name": "Vzbot Generic TPU @base",
+	"inherits": "fdm_filament_tpu",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"30"
+	],
+	"eng_plate_temp": [
+		"30"
+	],
+	"hot_plate_temp": [
+		"35"
+	],
+	"textured_plate_temp": [
+		"35"
+	],
+	"cool_plate_temp_initial_layer": [
+		"30"
+	],
+	"eng_plate_temp_initial_layer": [
+		"30"
+	],
+	"hot_plate_temp_initial_layer": [
+		"35"
+	],
+	"textured_plate_temp_initial_layer": [
+		"35"
+	],
+	"overhang_fan_threshold": [
+		"95%"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"1"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"50"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"0.4"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"TPU"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"240"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"8"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n"
+	],
+	"nozzle_temperature": [
+		"240"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"nozzle_temperature_range_low": [
+		"200"
+	],
+	"nozzle_temperature_range_high": [
+		"250"
+	]
+}

--- a/resources/profiles/Vzbot/filament/Vzbot Generic ABS.json
+++ b/resources/profiles/Vzbot/filament/Vzbot Generic ABS.json
@@ -1,17 +1,11 @@
 {
 	"type": "filament",
 	"name": "Vzbot Generic ABS",
-	"inherits": "fdm_filament_abs",
+	"inherits": "Vzbot Generic ABS @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFB99",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"0.926"
-	],
-	"filament_max_volumetric_speed": [
-		"50"
-	],
 	"compatible_printers": [
 		"Vzbot 235 AWD 0.4 nozzle",
 		"Vzbot 330 AWD 0.4 nozzle",

--- a/resources/profiles/Vzbot/filament/Vzbot Generic ASA.json
+++ b/resources/profiles/Vzbot/filament/Vzbot Generic ASA.json
@@ -1,17 +1,11 @@
 {
 	"type": "filament",
 	"name": "Vzbot Generic ASA",
-	"inherits": "fdm_filament_asa",
+	"inherits": "Vzbot Generic ASA @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFB98",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"0.93"
-	],
-	"filament_max_volumetric_speed": [
-		"50"
-	],
 	"compatible_printers": [
 		"Vzbot 235 AWD 0.4 nozzle",
 		"Vzbot 330 AWD 0.4 nozzle",

--- a/resources/profiles/Vzbot/filament/Vzbot Generic PA-CF.json
+++ b/resources/profiles/Vzbot/filament/Vzbot Generic PA-CF.json
@@ -1,23 +1,11 @@
 {
 	"type": "filament",
 	"name": "Vzbot Generic PA-CF",
-	"inherits": "fdm_filament_pa",
+	"inherits": "Vzbot Generic PA-CF @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFN98",
 	"instantiation": "true",
-	"filament_type": [
-		"PA-CF"
-	],
-	"nozzle_temperature_initial_layer": [
-		"280"
-	],
-	"nozzle_temperature": [
-		"280"
-	],
-	"filament_max_volumetric_speed": [
-		"50"
-	],
 	"compatible_printers": [
 		"Vzbot 235 AWD 0.4 nozzle",
 		"Vzbot 330 AWD 0.4 nozzle",

--- a/resources/profiles/Vzbot/filament/Vzbot Generic PA.json
+++ b/resources/profiles/Vzbot/filament/Vzbot Generic PA.json
@@ -1,20 +1,11 @@
 {
 	"type": "filament",
 	"name": "Vzbot Generic PA",
-	"inherits": "fdm_filament_pa",
+	"inherits": "Vzbot Generic PA @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFN99",
 	"instantiation": "true",
-	"nozzle_temperature_initial_layer": [
-		"280"
-	],
-	"nozzle_temperature": [
-		"280"
-	],
-	"filament_max_volumetric_speed": [
-		"50"
-	],
 	"compatible_printers": [
 		"Vzbot 235 AWD 0.4 nozzle",
 		"Vzbot 330 AWD 0.4 nozzle",

--- a/resources/profiles/Vzbot/filament/Vzbot Generic PC.json
+++ b/resources/profiles/Vzbot/filament/Vzbot Generic PC.json
@@ -1,17 +1,11 @@
 {
 	"type": "filament",
 	"name": "Vzbot Generic PC",
-	"inherits": "fdm_filament_pc",
+	"inherits": "Vzbot Generic PC @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFC99",
 	"instantiation": "true",
-	"filament_max_volumetric_speed": [
-		"50"
-	],
-	"filament_flow_ratio": [
-		"0.94"
-	],
 	"compatible_printers": [
 		"Vzbot 235 AWD 0.4 nozzle",
 		"Vzbot 330 AWD 0.4 nozzle",

--- a/resources/profiles/Vzbot/filament/Vzbot Generic PETG.json
+++ b/resources/profiles/Vzbot/filament/Vzbot Generic PETG.json
@@ -1,47 +1,11 @@
 {
 	"type": "filament",
 	"name": "Vzbot Generic PETG",
-	"inherits": "fdm_filament_pet",
+	"inherits": "Vzbot Generic PETG @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFG99",
 	"instantiation": "true",
-	"reduce_fan_stop_start_freq": [
-		"1"
-	],
-	"slow_down_for_layer_cooling": [
-		"1"
-	],
-	"fan_cooling_layer_time": [
-		"30"
-	],
-	"overhang_fan_speed": [
-		"70"
-	],
-	"overhang_fan_threshold": [
-		"25%"
-	],
-	"fan_max_speed": [
-		"80"
-	],
-	"fan_min_speed": [
-		"20"
-	],
-	"slow_down_min_speed": [
-		"30"
-	],
-	"slow_down_layer_time": [
-		"5"
-	],
-	"filament_flow_ratio": [
-		"0.95"
-	],
-	"filament_max_volumetric_speed": [
-		"50"
-	],
-	"filament_start_gcode": [
-		"; filament start gcode\n"
-	],
 	"compatible_printers": [
 		"Vzbot 235 AWD 0.4 nozzle",
 		"Vzbot 330 AWD 0.4 nozzle",

--- a/resources/profiles/Vzbot/filament/Vzbot Generic PLA-CF.json
+++ b/resources/profiles/Vzbot/filament/Vzbot Generic PLA-CF.json
@@ -1,23 +1,11 @@
 {
 	"type": "filament",
 	"name": "Vzbot Generic PLA-CF",
-	"inherits": "fdm_filament_pla",
+	"inherits": "Vzbot Generic PLA-CF @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFL98",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"0.95"
-	],
-	"filament_type": [
-		"PLA-CF"
-	],
-	"filament_max_volumetric_speed": [
-		"50"
-	],
-	"slow_down_layer_time": [
-		"7"
-	],
 	"compatible_printers": [
 		"Vzbot 235 AWD 0.4 nozzle",
 		"Vzbot 330 AWD 0.4 nozzle",

--- a/resources/profiles/Vzbot/filament/Vzbot Generic PLA.json
+++ b/resources/profiles/Vzbot/filament/Vzbot Generic PLA.json
@@ -1,20 +1,11 @@
 {
 	"type": "filament",
 	"name": "Vzbot Generic PLA",
-	"inherits": "fdm_filament_pla",
+	"inherits": "Vzbot Generic PLA @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFL99",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"0.98"
-	],
-	"filament_max_volumetric_speed": [
-		"50"
-	],
-	"slow_down_layer_time": [
-		"5"
-	],
 	"compatible_printers": [
 		"Vzbot 235 AWD 0.4 nozzle",
 		"Vzbot 330 AWD 0.4 nozzle",

--- a/resources/profiles/Vzbot/filament/Vzbot Generic PVA.json
+++ b/resources/profiles/Vzbot/filament/Vzbot Generic PVA.json
@@ -1,23 +1,11 @@
 {
 	"type": "filament",
 	"name": "Vzbot Generic PVA",
-	"inherits": "fdm_filament_pva",
+	"inherits": "Vzbot Generic PVA @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFS99",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"0.95"
-	],
-	"filament_max_volumetric_speed": [
-		"50"
-	],
-	"slow_down_layer_time": [
-		"7"
-	],
-	"slow_down_min_speed": [
-		"30"
-	],
 	"compatible_printers": [
 		"Vzbot 235 AWD 0.4 nozzle",
 		"Vzbot 330 AWD 0.4 nozzle",

--- a/resources/profiles/Vzbot/filament/Vzbot Generic TPU.json
+++ b/resources/profiles/Vzbot/filament/Vzbot Generic TPU.json
@@ -1,14 +1,11 @@
 {
 	"type": "filament",
 	"name": "Vzbot Generic TPU",
-	"inherits": "fdm_filament_tpu",
+	"inherits": "Vzbot Generic TPU @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFU99",
 	"instantiation": "true",
-	"filament_max_volumetric_speed": [
-		"50"
-	],
 	"compatible_printers": [
 		"Vzbot 235 AWD 0.4 nozzle",
 		"Vzbot 330 AWD 0.4 nozzle",


### PR DESCRIPTION
## Summary

Migrates Vzbot filament presets into the shared OrcaFilamentLibrary while keeping the Vzbot vendor-scoped presets compatible with the existing printers.

## Changes

- Added Vzbot filament @base/@System presets under OrcaFilamentLibrary.
- Updated Vzbot vendor-scoped filament presets to inherit from the new library bases.
- Registered the Vzbot OrcaFilamentLibrary entries in resources/profiles/OrcaFilamentLibrary.json.

## Testing

- python3 scripts/orca_extra_profile_check.py --vendor Vzbot --check-filaments --check-materials --check-obsolete-keys
- git diff --check

/claim #12162