### PR TITLE
Migrate Eryone filaments to OrcaFilamentLibrary

### DIFF
--- a/resources/profiles/Eryone/filament/Eryone ABS @0.2 nozzle.json
+++ b/resources/profiles/Eryone/filament/Eryone ABS @0.2 nozzle.json
@@ -1,16 +1,10 @@
 {
 	"type": "filament",
 	"name": "Eryone ABS @0.2 nozzle",
+	"inherits": "Eryone ABS @0.2 nozzle @base",
 	"from": "system",
 	"instantiation": "true",
-	"inherits": "Eryone ABS",
 	"compatible_printers": [
 		"Thinker X400 0.2 nozzle"
-	],
-	"filament_max_volumetric_speed": [
-		"2"
-	],
-	"filament_settings_id": [
-		"Eryone ABS @0.2 nozzle"
 	]
 }

--- a/resources/profiles/Eryone/filament/Eryone ABS-CF @0.2 nozzle.json
+++ b/resources/profiles/Eryone/filament/Eryone ABS-CF @0.2 nozzle.json
@@ -1,16 +1,10 @@
 {
 	"type": "filament",
 	"name": "Eryone ABS-CF @0.2 nozzle",
+	"inherits": "Eryone ABS-CF @0.2 nozzle @base",
 	"from": "system",
 	"instantiation": "true",
-	"inherits": "Eryone ABS-CF",
 	"compatible_printers": [
 		"Thinker X400 0.2 nozzle"
-	],
-	"filament_max_volumetric_speed": [
-		"2"
-	],
-	"filament_settings_id": [
-		"Eryone ABS-CF @0.2 nozzle"
 	]
 }

--- a/resources/profiles/Eryone/filament/Eryone ABS-CF.json
+++ b/resources/profiles/Eryone/filament/Eryone ABS-CF.json
@@ -1,78 +1,12 @@
 {
 	"type": "filament",
 	"name": "Eryone ABS-CF",
-	"inherits": "Eryone Standard PLA",
+	"inherits": "Eryone ABS-CF @base",
 	"from": "system",
 	"setting_id": "EFSA11",
 	"filament_id": "EFL81",
 	"instantiation": "true",
 	"compatible_printers": [
 		"Thinker X400 0.4 nozzle"
-	],
-	"filament_end_gcode": [
-		"; filament end gcode \nSET_FAN_SPEED FAN=filter_fan SPEED=0"
-	],
-	"filament_flow_ratio": [
-		"0.92"
-	],
-	"filament_max_volumetric_speed": [
-		"10"
-	],
-	"filament_retraction_length": [
-		"1"
-	],
-	"close_fan_the_first_x_layers": [
-		"3"
-	],
-	"fan_cooling_layer_time": [
-		"30"
-	],
-	"fan_max_speed": [
-		"60"
-	],
-	"fan_min_speed": [
-		"30"
-	],
-	"filament_settings_id": [
-		"Eryone ABS-CF"
-	],
-	"filament_start_gcode": [
-		"; filament start gcode\nSET_FAN_SPEED FAN=filter_fan SPEED=0"
-	],
-	"filament_type": [
-		"ABS-CF"
-	],
-	"filament_vendor": [
-		"Eryone"
-	],
-	"hot_plate_temp": [
-		"100"
-	],
-	"hot_plate_temp_initial_layer": [
-		"100"
-	],
-	"nozzle_temperature": [
-		"250"
-	],
-	"nozzle_temperature_initial_layer": [
-		"260"
-	],
-	"nozzle_temperature_range_high": [
-		"290"
-	],
-	"nozzle_temperature_range_low": [
-		"240"
-	],
-	"slow_down_layer_time": [
-		"10"
-	],
-	"overhang_fan_threshold": [
-		"25%"
-	],
-	"support_material_interface_fan_speed": [
-		"60"
-	],
-	"temperature_vitrification": [
-		"100"
 	]
 }

--- a/resources/profiles/Eryone/filament/Eryone ABS.json
+++ b/resources/profiles/Eryone/filament/Eryone ABS.json
@@ -1,111 +1,12 @@
 {
 	"type": "filament",
 	"name": "Eryone ABS",
-	"inherits": "Eryone Standard PLA",
+	"inherits": "Eryone ABS @base",
 	"from": "system",
 	"setting_id": "EFSA01",
 	"filament_id": "EFL91",
 	"instantiation": "true",
 	"compatible_printers": [
 		"Thinker X400 0.4 nozzle"
-	],
-	"close_fan_the_first_x_layers": [
-		"3"
-	],
-	"additional_cooling_fan_speed": [
-		"0"
-	],
-	"complete_print_exhaust_fan_speed": [
-		"70"
-	],
-	"cool_plate_temp": [
-		"0"
-	],
-	"cool_plate_temp_initial_layer": [
-		"0"
-	],
-	"during_print_exhaust_fan_speed": [
-		"70"
-	],
-	"eng_plate_temp": [
-		"100"
-	],
-	"eng_plate_temp_initial_layer": [
-		"105"
-	],
-	"fan_cooling_layer_time": [
-		"30"
-	],
-	"fan_max_speed": [
-		"70"
-	],
-	"fan_min_speed": [
-		"10"
-	],
-	"filament_settings_id": [
-		"Eryone ABS"
-	],
-	"filament_density": [
-		"1.04"
-	],
-	"filament_end_gcode": [
-		"; filament end gcode\nSET_FAN_SPEED FAN=filter_fan SPEED=0"
-	],
-	"filament_start_gcode": [
-		"; filament start gcode\nSET_FAN_SPEED FAN=filter_fan SPEED=0\n"
-	],
-	"filament_type": [
-		"ABS"
-	],
-	"filament_flow_ratio": [
-		"0.92"
-	],
-	"filament_max_volumetric_speed": [
-		"15"
-	],
-	"filament_vendor": [
-		"Eryone"
-	],
-	"hot_plate_temp": [
-		"95"
-	],
-	"hot_plate_temp_initial_layer": [
-		"95"
-	],
-	"nozzle_temperature": [
-		"255"
-	],
-	"nozzle_temperature_initial_layer": [
-		"260"
-	],
-	"nozzle_temperature_range_high": [
-		"290"
-	],
-	"overhang_fan_speed": [
-		"80"
-	],
-	"overhang_fan_threshold": [
-		"25%"
-	],
-	"nozzle_temperature_range_low": [
-		"240"
-	],
-	"required_nozzle_HRC": [
-		"3"
-	],
-	"slow_down_layer_time": [
-		"4"
-	],
-	"support_material_interface_fan_speed": [
-		"60"
-	],
-	"temperature_vitrification": [
-		"100"
-	],
-	"textured_plate_temp": [
-		"100"
-	],
-	"textured_plate_temp_initial_layer": [
-		"105"
 	]
 }

--- a/resources/profiles/Eryone/filament/Eryone ASA @0.2 nozzle.json
+++ b/resources/profiles/Eryone/filament/Eryone ASA @0.2 nozzle.json
@@ -1,16 +1,10 @@
 {
 	"type": "filament",
 	"name": "Eryone ASA @0.2 nozzle",
+	"inherits": "Eryone ASA @0.2 nozzle @base",
 	"from": "system",
 	"instantiation": "true",
-	"inherits": "Eryone ASA",
 	"compatible_printers": [
 		"Thinker X400 0.2 nozzle"
-	],
-	"filament_max_volumetric_speed": [
-		"2"
-	],
-	"filament_settings_id": [
-		"Eryone ASA @0.2 nozzle"
 	]
 }

--- a/resources/profiles/Eryone/filament/Eryone ASA-CF @0.2 nozzle.json
+++ b/resources/profiles/Eryone/filament/Eryone ASA-CF @0.2 nozzle.json
@@ -1,16 +1,10 @@
 {
 	"type": "filament",
 	"name": "Eryone ASA-CF @0.2 nozzle",
+	"inherits": "Eryone ASA-CF @0.2 nozzle @base",
 	"from": "system",
 	"instantiation": "true",
-	"inherits": "Eryone ASA-CF",
 	"compatible_printers": [
 		"Thinker X400 0.2 nozzle"
-	],
-	"filament_max_volumetric_speed": [
-		"2"
-	],
-	"filament_settings_id": [
-		"Eryone ASA-CF @0.2 nozzle"
 	]
 }

--- a/resources/profiles/Eryone/filament/Eryone ASA-CF.json
+++ b/resources/profiles/Eryone/filament/Eryone ASA-CF.json
@@ -1,78 +1,12 @@
 {
 	"type": "filament",
 	"name": "Eryone ASA-CF",
-	"inherits": "Eryone Standard PLA",
+	"inherits": "Eryone ASA-CF @base",
 	"from": "system",
 	"setting_id": "EFSA82",
 	"filament_id": "EFL82",
 	"instantiation": "true",
 	"compatible_printers": [
 		"Thinker X400 0.4 nozzle"
-	],
-	"close_fan_the_first_x_layers": [
-		"3"
-	],
-	"fan_cooling_layer_time": [
-		"30"
-	],
-	"fan_max_speed": [
-		"50"
-	],
-	"fan_min_speed": [
-		"20"
-	],
-	"filament_settings_id": [
-		"Eryone ASA-CF"
-	],
-	"filament_type": [
-		"ASA-CF"
-	],
-	"filament_vendor": [
-		"Eryone"
-	],
-	"filament_end_gcode": [
-		"; filament end gcode \nSET_FAN_SPEED FAN=filter_fan SPEED=0"
-	],
-	"filament_flow_ratio": [
-		"0.92"
-	],
-	"filament_max_volumetric_speed": [
-		"8"
-	],
-	"filament_retraction_length": [
-		"1"
-	],
-	"filament_start_gcode": [
-		"; filament start gcode\nSET_FAN_SPEED FAN=filter_fan SPEED=0"
-	],
-	"hot_plate_temp": [
-		"110"
-	],
-	"hot_plate_temp_initial_layer": [
-		"110"
-	],
-	"nozzle_temperature": [
-		"260"
-	],
-	"nozzle_temperature_initial_layer": [
-		"275"
-	],
-	"nozzle_temperature_range_high": [
-		"290"
-	],
-	"overhang_fan_threshold": [
-		"25%"
-	],
-	"support_material_interface_fan_speed": [
-		"60"
-	],
-	"temperature_vitrification": [
-		"180"
-	],
-	"nozzle_temperature_range_low": [
-		"240"
-	],
-	"slow_down_layer_time": [
-		"12"
 	]
 }

--- a/resources/profiles/Eryone/filament/Eryone ASA.json
+++ b/resources/profiles/Eryone/filament/Eryone ASA.json
@@ -1,81 +1,12 @@
 {
 	"type": "filament",
 	"name": "Eryone ASA",
-	"inherits": "Eryone Standard PLA",
+	"inherits": "Eryone ASA @base",
 	"from": "system",
 	"setting_id": "EFSA02",
 	"filament_id": "EFL92",
 	"instantiation": "true",
 	"compatible_printers": [
 		"Thinker X400 0.4 nozzle"
-	],
-	"close_fan_the_first_x_layers": [
-		"3"
-	],
-	"fan_cooling_layer_time": [
-		"30"
-	],
-	"fan_max_speed": [
-		"50"
-	],
-	"fan_min_speed": [
-		"20"
-	],
-	"filament_end_gcode": [
-		"; filament end gcode \nSET_FAN_SPEED FAN=filter_fan SPEED=0"
-	],
-	"filament_flow_ratio": [
-		"0.92"
-	],
-	"filament_max_volumetric_speed": [
-		"14"
-	],
-	"filament_retraction_length": [
-		"1"
-	],
-	"filament_settings_id": [
-		"Eryone ASA"
-	],
-	"filament_type": [
-		"ASA"
-	],
-	"filament_start_gcode": [
-		"; filament start gcode\nSET_FAN_SPEED FAN=filter_fan SPEED=0"
-	],
-	"filament_vendor": [
-		"Eryone"
-	],
-	"hot_plate_temp": [
-		"110"
-	],
-	"hot_plate_temp_initial_layer": [
-		"110"
-	],
-	"nozzle_temperature": [
-		"265"
-	],
-	"nozzle_temperature_initial_layer": [
-		"270"
-	],
-	"nozzle_temperature_range_high": [
-		"290"
-	],
-	"nozzle_temperature_range_low": [
-		"240"
-	],
-	"slow_down_layer_time": [
-		"12"
-	],
-	"overhang_fan_threshold": [
-		"25%"
-	],
-	"slow_down_min_speed": [
-		"20"
-	],
-	"support_material_interface_fan_speed": [
-		"60"
-	],
-	"temperature_vitrification": [
-		"180"
 	]
 }

--- a/resources/profiles/Eryone/filament/Eryone PA @0.2 nozzle.json
+++ b/resources/profiles/Eryone/filament/Eryone PA @0.2 nozzle.json
@@ -1,16 +1,10 @@
 {
 	"type": "filament",
 	"name": "Eryone PA @0.2 nozzle",
+	"inherits": "Eryone PA @0.2 nozzle @base",
 	"from": "system",
 	"instantiation": "true",
-	"inherits": "Eryone PA",
 	"compatible_printers": [
 		"Thinker X400 0.2 nozzle"
-	],
-	"filament_max_volumetric_speed": [
-		"2"
-	],
-	"filament_settings_id": [
-		"Eryone PA @0.2 nozzle"
 	]
 }

--- a/resources/profiles/Eryone/filament/Eryone PA-CF @0.2 nozzle.json
+++ b/resources/profiles/Eryone/filament/Eryone PA-CF @0.2 nozzle.json
@@ -1,16 +1,10 @@
 {
 	"type": "filament",
 	"name": "Eryone PA-CF @0.2 nozzle",
+	"inherits": "Eryone PA-CF @0.2 nozzle @base",
 	"from": "system",
 	"instantiation": "true",
-	"inherits": "Eryone PA-CF",
 	"compatible_printers": [
 		"Thinker X400 0.2 nozzle"
-	],
-	"filament_max_volumetric_speed": [
-		"2"
-	],
-	"filament_settings_id": [
-		"Eryone PA-CF @0.2 nozzle"
 	]
 }

--- a/resources/profiles/Eryone/filament/Eryone PA-CF.json
+++ b/resources/profiles/Eryone/filament/Eryone PA-CF.json
@@ -1,78 +1,12 @@
 {
 	"type": "filament",
 	"name": "Eryone PA-CF",
-	"inherits": "Eryone Standard PLA",
+	"inherits": "Eryone PA-CF @base",
 	"from": "system",
 	"setting_id": "EFSA72",
 	"filament_id": "EFL72",
 	"instantiation": "true",
 	"compatible_printers": [
 		"Thinker X400 0.4 nozzle"
-	],
-	"close_fan_the_first_x_layers": [
-		"3"
-	],
-	"fan_cooling_layer_time": [
-		"20"
-	],
-	"fan_max_speed": [
-		"40"
-	],
-	"fan_min_speed": [
-		"20"
-	],
-	"filament_end_gcode": [
-		"; filament end gcode \nSET_FAN_SPEED FAN=filter_fan SPEED=0"
-	],
-	"filament_flow_ratio": [
-		"0.94"
-	],
-	"filament_max_volumetric_speed": [
-		"8"
-	],
-	"filament_retraction_length": [
-		"1"
-	],
-	"filament_settings_id": [
-		"Eryone PA-CF"
-	],
-	"filament_start_gcode": [
-		"; filament start gcode\nSET_FAN_SPEED FAN=filter_fan SPEED=0"
-	],
-	"filament_type": [
-		"PA-CF"
-	],
-	"filament_vendor": [
-		"Eryone"
-	],
-	"hot_plate_temp": [
-		"115"
-	],
-	"hot_plate_temp_initial_layer": [
-		"115"
-	],
-	"nozzle_temperature": [
-		"265"
-	],
-	"nozzle_temperature_initial_layer": [
-		"275"
-	],
-	"overhang_fan_threshold": [
-		"25%"
-	],
-	"nozzle_temperature_range_high": [
-		"280"
-	],
-	"nozzle_temperature_range_low": [
-		"240"
-	],
-	"support_material_interface_fan_speed": [
-		"60"
-	],
-	"temperature_vitrification": [
-		"200"
-	],
-	"slow_down_layer_time": [
-		"10"
 	]
 }

--- a/resources/profiles/Eryone/filament/Eryone PA-GF @0.2 nozzle.json
+++ b/resources/profiles/Eryone/filament/Eryone PA-GF @0.2 nozzle.json
@@ -1,16 +1,10 @@
 {
 	"type": "filament",
 	"name": "Eryone PA-GF @0.2 nozzle",
+	"inherits": "Eryone PA-GF @0.2 nozzle @base",
 	"from": "system",
 	"instantiation": "true",
-	"inherits": "Eryone PA-GF",
 	"compatible_printers": [
 		"Thinker X400 0.2 nozzle"
-	],
-	"filament_max_volumetric_speed": [
-		"2"
-	],
-	"filament_settings_id": [
-		"Eryone PA-GF @0.2 nozzle"
 	]
 }

--- a/resources/profiles/Eryone/filament/Eryone PA-GF.json
+++ b/resources/profiles/Eryone/filament/Eryone PA-GF.json
@@ -1,75 +1,12 @@
 {
 	"type": "filament",
 	"name": "Eryone PA-GF",
-	"inherits": "Eryone Standard PLA",
+	"inherits": "Eryone PA-GF @base",
 	"from": "system",
 	"setting_id": "EFSA73",
 	"filament_id": "EFL73",
 	"instantiation": "true",
 	"compatible_printers": [
 		"Thinker X400 0.4 nozzle"
-	],
-	"close_fan_the_first_x_layers": [
-		"3"
-	],
-	"fan_cooling_layer_time": [
-		"20"
-	],
-	"fan_max_speed": [
-		"40"
-	],
-	"fan_min_speed": [
-		"20"
-	],
-	"filament_end_gcode": [
-		"; filament end gcode \nSET_FAN_SPEED FAN=filter_fan SPEED=0"
-	],
-	"filament_flow_ratio": [
-		"0.94"
-	],
-	"filament_retraction_length": [
-		"1"
-	],
-	"filament_settings_id": [
-		"Eryone PA-GF"
-	],
-	"filament_start_gcode": [
-		"; filament start gcode\nSET_FAN_SPEED FAN=filter_fan SPEED=0"
-	],
-	"filament_type": [
-		"PA-GF"
-	],
-	"filament_vendor": [
-		"Eryone"
-	],
-	"hot_plate_temp": [
-		"110"
-	],
-	"hot_plate_temp_initial_layer": [
-		"110"
-	],
-	"nozzle_temperature": [
-		"270"
-	],
-	"nozzle_temperature_initial_layer": [
-		"280"
-	],
-	"nozzle_temperature_range_high": [
-		"280"
-	],
-	"nozzle_temperature_range_low": [
-		"240"
-	],
-	"overhang_fan_threshold": [
-		"25%"
-	],
-	"support_material_interface_fan_speed": [
-		"60"
-	],
-	"temperature_vitrification": [
-		"200"
-	],
-	"slow_down_layer_time": [
-		"10"
 	]
 }

--- a/resources/profiles/Eryone/filament/Eryone PA.json
+++ b/resources/profiles/Eryone/filament/Eryone PA.json
@@ -1,84 +1,12 @@
 {
 	"type": "filament",
 	"name": "Eryone PA",
-	"inherits": "Eryone Standard PLA",
+	"inherits": "Eryone PA @base",
 	"from": "system",
 	"setting_id": "EFSA71",
 	"filament_id": "EFL71",
 	"instantiation": "true",
 	"compatible_printers": [
 		"Thinker X400 0.4 nozzle"
-	],
-	"close_fan_the_first_x_layers": [
-		"3"
-	],
-	"fan_cooling_layer_time": [
-		"30"
-	],
-	"fan_max_speed": [
-		"20"
-	],
-	"fan_min_speed": [
-		"10"
-	],
-	"filament_end_gcode": [
-		"; filament end gcode \nSET_FAN_SPEED FAN=filter_fan SPEED=0"
-	],
-	"filament_flow_ratio": [
-		"0.92"
-	],
-	"filament_max_volumetric_speed": [
-		"8"
-	],
-	"filament_notes": [
-		"brim width >= 20;"
-	],
-	"filament_retraction_length": [
-		"1"
-	],
-	"filament_settings_id": [
-		"Eryone PA"
-	],
-	"filament_start_gcode": [
-		"; filament start gcode\nSET_FAN_SPEED FAN=filter_fan SPEED=0"
-	],
-	"filament_type": [
-		"PA"
-	],
-	"filament_vendor": [
-		"Eryone"
-	],
-	"hot_plate_temp": [
-		"115"
-	],
-	"hot_plate_temp_initial_layer": [
-		"115"
-	],
-	"nozzle_temperature": [
-		"265"
-	],
-	"nozzle_temperature_initial_layer": [
-		"270"
-	],
-	"overhang_fan_threshold": [
-		"25%"
-	],
-	"slow_down_layer_time": [
-		"10"
-	],
-	"slow_down_min_speed": [
-		"15"
-	],
-	"support_material_interface_fan_speed": [
-		"60"
-	],
-	"temperature_vitrification": [
-		"200"
-	],
-	"nozzle_temperature_range_high": [
-		"280"
-	],
-	"nozzle_temperature_range_low": [
-		"240"
 	]
 }

--- a/resources/profiles/Eryone/filament/Eryone PETG @0.2 nozzle.json
+++ b/resources/profiles/Eryone/filament/Eryone PETG @0.2 nozzle.json
@@ -1,16 +1,10 @@
 {
 	"type": "filament",
 	"name": "Eryone PETG @0.2 nozzle",
+	"inherits": "Eryone PETG @0.2 nozzle @base",
 	"from": "system",
 	"instantiation": "true",
-	"inherits": "Eryone PETG",
 	"compatible_printers": [
 		"Thinker X400 0.2 nozzle"
-	],
-	"filament_max_volumetric_speed": [
-		"2"
-	],
-	"filament_settings_id": [
-		"Eryone PETG @0.2 nozzle"
 	]
 }

--- a/resources/profiles/Eryone/filament/Eryone PETG-CF @0.2 nozzle.json
+++ b/resources/profiles/Eryone/filament/Eryone PETG-CF @0.2 nozzle.json
@@ -1,16 +1,10 @@
 {
 	"type": "filament",
 	"name": "Eryone PETG-CF @0.2 nozzle",
+	"inherits": "Eryone PETG-CF @0.2 nozzle @base",
 	"from": "system",
 	"instantiation": "true",
-	"inherits": "Eryone PETG-CF",
 	"compatible_printers": [
 		"Thinker X400 0.2 nozzle"
-	],
-	"filament_max_volumetric_speed": [
-		"2"
-	],
-	"filament_settings_id": [
-		"Eryone PETG-CF @0.2 nozzle"
 	]
 }

--- a/resources/profiles/Eryone/filament/Eryone PETG-CF.json
+++ b/resources/profiles/Eryone/filament/Eryone PETG-CF.json
@@ -1,81 +1,12 @@
 {
 	"type": "filament",
 	"name": "Eryone PETG-CF",
-	"inherits": "Eryone Standard PLA",
+	"inherits": "Eryone PETG-CF @base",
 	"from": "system",
 	"setting_id": "EFSA43",
 	"filament_id": "EFL43",
 	"instantiation": "true",
 	"compatible_printers": [
 		"Thinker X400 0.4 nozzle"
-	],
-	"close_fan_the_first_x_layers": [
-		"3"
-	],
-	"fan_cooling_layer_time": [
-		"30"
-	],
-	"fan_max_speed": [
-		"90"
-	],
-	"fan_min_speed": [
-		"50"
-	],
-	"filament_vendor": [
-		"Eryone"
-	],
-	"filament_end_gcode": [
-		"; filament end gcode \nSET_FAN_SPEED FAN=filter_fan SPEED=0\n"
-	],
-	"filament_flow_ratio": [
-		"0.94"
-	],
-	"filament_retraction_length": [
-		"1"
-	],
-	"filament_start_gcode": [
-		"; filament start gcode\nSET_FAN_SPEED FAN=filter_fan SPEED=1"
-	],
-	"filament_max_volumetric_speed": [
-		"14"
-	],
-	"filament_settings_id": [
-		"Eryone PETG"
-	],
-	"filament_type": [
-		"PETG-CF"
-	],
-	"hot_plate_temp": [
-		"80"
-	],
-	"hot_plate_temp_initial_layer": [
-		"80"
-	],
-	"overhang_fan_threshold": [
-		"25%"
-	],
-	"nozzle_temperature": [
-		"245"
-	],
-	"nozzle_temperature_initial_layer": [
-		"250"
-	],
-	"nozzle_temperature_range_high": [
-		"270"
-	],
-	"nozzle_temperature_range_low": [
-		"225"
-	],
-	"slow_down_min_speed": [
-		"20"
-	],
-	"support_material_interface_fan_speed": [
-		"80"
-	],
-	"temperature_vitrification": [
-		"80"
-	],
-	"slow_down_layer_time": [
-		"7"
 	]
 }

--- a/resources/profiles/Eryone/filament/Eryone PETG.json
+++ b/resources/profiles/Eryone/filament/Eryone PETG.json
@@ -1,60 +1,12 @@
 {
 	"type": "filament",
 	"name": "Eryone PETG",
-	"inherits": "Eryone Standard PLA",
+	"inherits": "Eryone PETG @base",
 	"from": "system",
 	"setting_id": "EFSA03",
 	"filament_id": "EFL93",
 	"instantiation": "true",
 	"compatible_printers": [
 		"Thinker X400 0.4 nozzle"
-	],
-	"fan_min_speed": [
-		"90"
-	],
-	"close_fan_the_first_x_layers": [
-		"2"
-	],
-	"filament_vendor": [
-		"Eryone"
-	],
-	"filament_end_gcode": [
-		"; filament end gcode \nSET_FAN_SPEED FAN=filter_fan SPEED=0\n"
-	],
-	"filament_start_gcode": [
-		"; filament start gcode\nSET_FAN_SPEED FAN=filter_fan SPEED=1"
-	],
-	"filament_max_volumetric_speed": [
-		"14"
-	],
-	"filament_settings_id": [
-		"Eryone PETG"
-	],
-	"filament_type": [
-		"PETG"
-	],
-	"hot_plate_temp": [
-		"75"
-	],
-	"hot_plate_temp_initial_layer": [
-		"75"
-	],
-	"overhang_fan_threshold": [
-		"25%"
-	],
-	"nozzle_temperature": [
-		"245"
-	],
-	"nozzle_temperature_initial_layer": [
-		"245"
-	],
-	"nozzle_temperature_range_high": [
-		"270"
-	],
-	"nozzle_temperature_range_low": [
-		"225"
-	],
-	"slow_down_layer_time": [
-		"7"
 	]
 }

--- a/resources/profiles/Eryone/filament/Eryone PLA @0.2 nozzle.json
+++ b/resources/profiles/Eryone/filament/Eryone PLA @0.2 nozzle.json
@@ -1,16 +1,10 @@
 {
 	"type": "filament",
 	"name": "Eryone PLA @0.2 nozzle",
+	"inherits": "Eryone PLA @0.2 nozzle @base",
 	"from": "system",
 	"instantiation": "true",
-	"inherits": "Eryone PLA",
 	"compatible_printers": [
 		"Thinker X400 0.2 nozzle"
-	],
-	"filament_max_volumetric_speed": [
-		"2"
-	],
-	"filament_settings_id": [
-		"Eryone PLA @0.2 nozzle"
 	]
 }

--- a/resources/profiles/Eryone/filament/Eryone PLA-CF @0.2 nozzle.json
+++ b/resources/profiles/Eryone/filament/Eryone PLA-CF @0.2 nozzle.json
@@ -1,16 +1,10 @@
 {
 	"type": "filament",
 	"name": "Eryone PLA-CF @0.2 nozzle",
+	"inherits": "Eryone PLA-CF @0.2 nozzle @base",
 	"from": "system",
 	"instantiation": "true",
-	"inherits": "Eryone PLA-CF",
 	"compatible_printers": [
 		"Thinker X400 0.2 nozzle"
-	],
-	"filament_max_volumetric_speed": [
-		"2"
-	],
-	"filament_settings_id": [
-		"Eryone PLA-CF @0.2 nozzle"
 	]
 }

--- a/resources/profiles/Eryone/filament/Eryone PLA-CF.json
+++ b/resources/profiles/Eryone/filament/Eryone PLA-CF.json
@@ -1,57 +1,12 @@
 {
 	"type": "filament",
 	"name": "Eryone PLA-CF",
-	"inherits": "Eryone Standard PLA",
+	"inherits": "Eryone PLA-CF @base",
 	"from": "system",
 	"setting_id": "EFSA40",
 	"filament_id": "EFL40",
 	"instantiation": "true",
 	"compatible_printers": [
 		"Thinker X400 0.4 nozzle"
-	],
-	"fan_min_speed": [
-		"100"
-	],
-	"filament_flow_ratio": [
-		"0.95"
-	],
-	"filament_max_volumetric_speed": [
-		"15"
-	],
-	"filament_retraction_length": [
-		"1"
-	],
-	"filament_settings_id": [
-		"Eryone PLA-CF"
-	],
-	"filament_type": [
-		"PLA-CF"
-	],
-	"hot_plate_temp": [
-		"55"
-	],
-	"hot_plate_temp_initial_layer": [
-		"55"
-	],
-	"filament_start_gcode": [
-		"; filament start gcode\nSET_FAN_SPEED FAN=filter_fan SPEED=1"
-	],
-	"filament_end_gcode": [
-		"; filament end gcode \nSET_FAN_SPEED FAN=filter_fan SPEED=0"
-	],
-	"nozzle_temperature": [
-		"225"
-	],
-	"nozzle_temperature_initial_layer": [
-		"230"
-	],
-	"nozzle_temperature_range_high": [
-		"250"
-	],
-	"slow_down_layer_time": [
-		"7"
-	],
-	"support_material_interface_fan_speed": [
-		"100"
 	]
 }

--- a/resources/profiles/Eryone/filament/Eryone PLA.json
+++ b/resources/profiles/Eryone/filament/Eryone PLA.json
@@ -1,39 +1,12 @@
 {
 	"type": "filament",
 	"name": "Eryone PLA",
-	"inherits": "Eryone Standard PLA",
+	"inherits": "Eryone PLA @base",
 	"from": "system",
 	"setting_id": "EFSA00",
 	"filament_id": "EFL90",
 	"instantiation": "true",
 	"compatible_printers": [
 		"Thinker X400 0.4 nozzle"
-	],
-	"fan_min_speed": [
-		"90"
-	],
-	"filament_max_volumetric_speed": [
-		"20"
-	],
-	"filament_settings_id": [
-		"Eryone PLA"
-	],
-	"hot_plate_temp": [
-		"60"
-	],
-	"hot_plate_temp_initial_layer": [
-		"60"
-	],
-	"filament_start_gcode": [
-		"; filament start gcode\nSET_FAN_SPEED FAN=filter_fan SPEED=1"
-	],
-	"filament_end_gcode": [
-		"; filament end gcode \nSET_FAN_SPEED FAN=filter_fan SPEED=0"
-	],
-	"slow_down_layer_time": [
-		"4"
-	],
-	"slow_down_min_speed": [
-		"15"
 	]
 }

--- a/resources/profiles/Eryone/filament/Eryone PP @0.2 nozzle.json
+++ b/resources/profiles/Eryone/filament/Eryone PP @0.2 nozzle.json
@@ -1,16 +1,10 @@
 {
 	"type": "filament",
 	"name": "Eryone PP @0.2 nozzle",
+	"inherits": "Eryone PP @0.2 nozzle @base",
 	"from": "system",
 	"instantiation": "true",
-	"inherits": "Eryone PP",
 	"compatible_printers": [
 		"Thinker X400 0.2 nozzle"
-	],
-	"filament_max_volumetric_speed": [
-		"2"
-	],
-	"filament_settings_id": [
-		"Eryone PP @0.2 nozzle"
 	]
 }

--- a/resources/profiles/Eryone/filament/Eryone PP-CF @0.2 nozzle.json
+++ b/resources/profiles/Eryone/filament/Eryone PP-CF @0.2 nozzle.json
@@ -1,16 +1,10 @@
 {
 	"type": "filament",
 	"name": "Eryone PP-CF @0.2 nozzle",
+	"inherits": "Eryone PP-CF @0.2 nozzle @base",
 	"from": "system",
 	"instantiation": "true",
-	"inherits": "Eryone PP-CF",
 	"compatible_printers": [
 		"Thinker X400 0.2 nozzle"
-	],
-	"filament_max_volumetric_speed": [
-		"2"
-	],
-	"filament_settings_id": [
-		"Eryone PP-CF @0.2 nozzle"
 	]
 }

--- a/resources/profiles/Eryone/filament/Eryone PP-CF.json
+++ b/resources/profiles/Eryone/filament/Eryone PP-CF.json
@@ -1,75 +1,12 @@
 {
 	"type": "filament",
 	"name": "Eryone PP-CF",
-	"inherits": "Eryone Standard PLA",
+	"inherits": "Eryone PP-CF @base",
 	"from": "system",
 	"setting_id": "EFSA33",
 	"filament_id": "EFL33",
 	"instantiation": "true",
 	"compatible_printers": [
 		"Thinker X400 0.4 nozzle"
-	],
-	"fan_max_speed": [
-		"35"
-	],
-	"fan_min_speed": [
-		"20"
-	],
-	"filament_end_gcode": [
-		"; filament end gcode \nSET_FAN_SPEED FAN=filter_fan SPEED=0"
-	],
-	"filament_flow_ratio": [
-		"0.92"
-	],
-	"fan_cooling_layer_time": [
-		"30"
-	],
-	"close_fan_the_first_x_layers": [
-		"3"
-	],
-	"filament_max_volumetric_speed": [
-		"8"
-	],
-	"filament_notes": [
-		"Printing platform glue spraying"
-	],
-	"filament_retraction_length": [
-		"1"
-	],
-	"filament_vendor": [
-		"Eryone"
-	],
-	"filament_settings_id": [
-		"Eryone PP-CF"
-	],
-	"filament_type": [
-		"PP-CF"
-	],
-	"filament_start_gcode": [
-		"; filament start gcode\nSET_FAN_SPEED FAN=filter_fan SPEED=0"
-	],
-	"hot_plate_temp": [
-		"100"
-	],
-	"hot_plate_temp_initial_layer": [
-		"100"
-	],
-	"nozzle_temperature": [
-		"240"
-	],
-	"nozzle_temperature_initial_layer": [
-		"240"
-	],
-	"overhang_fan_threshold": [
-		"25%"
-	],
-	"slow_down_layer_time": [
-		"10"
-	],
-	"support_material_interface_fan_speed": [
-		"60"
-	],
-	"temperature_vitrification": [
-		"160"
 	]
 }

--- a/resources/profiles/Eryone/filament/Eryone PP.json
+++ b/resources/profiles/Eryone/filament/Eryone PP.json
@@ -1,78 +1,12 @@
 {
 	"type": "filament",
 	"name": "Eryone PP",
-	"inherits": "Eryone Standard PLA",
+	"inherits": "Eryone PP @base",
 	"from": "system",
 	"setting_id": "EFSA43",
 	"filament_id": "EFL43",
 	"instantiation": "true",
 	"compatible_printers": [
 		"Thinker X400 0.4 nozzle"
-	],
-	"close_fan_the_first_x_layers": [
-		"3"
-	],
-	"fan_cooling_layer_time": [
-		"30"
-	],
-	"fan_max_speed": [
-		"35"
-	],
-	"fan_min_speed": [
-		"20"
-	],
-	"filament_end_gcode": [
-		"; filament end gcode \nSET_FAN_SPEED FAN=filter_fan SPEED=0"
-	],
-	"filament_flow_ratio": [
-		"0.95"
-	],
-	"filament_max_volumetric_speed": [
-		"10"
-	],
-	"filament_notes": [
-		"Printing platform glue spraying"
-	],
-	"filament_vendor": [
-		"Eryone"
-	],
-	"filament_settings_id": [
-		"Eryone PP"
-	],
-	"filament_type": [
-		"PP"
-	],
-	"filament_start_gcode": [
-		"; filament start gcode\nSET_FAN_SPEED FAN=filter_fan SPEED=0"
-	],
-	"hot_plate_temp": [
-		"100"
-	],
-	"hot_plate_temp_initial_layer": [
-		"100"
-	],
-	"nozzle_temperature": [
-		"230"
-	],
-	"nozzle_temperature_initial_layer": [
-		"235"
-	],
-	"overhang_fan_threshold": [
-		"25%"
-	],
-	"nozzle_temperature_range_high": [
-		"270"
-	],
-	"nozzle_temperature_range_low": [
-		"225"
-	],
-	"slow_down_layer_time": [
-		"10"
-	],
-	"support_material_interface_fan_speed": [
-		"60"
-	],
-	"temperature_vitrification": [
-		"160"
 	]
 }

--- a/resources/profiles/Eryone/filament/Eryone Silk PLA @0.2 nozzle.json
+++ b/resources/profiles/Eryone/filament/Eryone Silk PLA @0.2 nozzle.json
@@ -1,16 +1,10 @@
 {
 	"type": "filament",
 	"name": "Eryone Silk PLA @0.2 nozzle",
+	"inherits": "Eryone Silk PLA @0.2 nozzle @base",
 	"from": "system",
 	"instantiation": "true",
-	"inherits": "Eryone Silk PLA",
 	"compatible_printers": [
 		"Thinker X400 0.2 nozzle"
-	],
-	"filament_max_volumetric_speed": [
-		"2"
-	],
-	"filament_settings_id": [
-		"Eryone Silk PLA @0.2 nozzle"
 	]
 }

--- a/resources/profiles/Eryone/filament/Eryone Silk PLA.json
+++ b/resources/profiles/Eryone/filament/Eryone Silk PLA.json
@@ -1,39 +1,12 @@
 {
 	"type": "filament",
 	"name": "Eryone Silk PLA",
-	"inherits": "Eryone Standard PLA",
+	"inherits": "Eryone Silk PLA @base",
 	"from": "system",
 	"setting_id": "EFSA041",
 	"filament_id": "EFL941",
 	"instantiation": "true",
 	"compatible_printers": [
 		"Thinker X400 0.4 nozzle"
-	],
-	"filament_start_gcode": [
-		"; filament start gcode\nSET_FAN_SPEED FAN=filter_fan SPEED=1"
-	],
-	"filament_end_gcode": [
-		"; filament end gcode \nSET_FAN_SPEED FAN=filter_fan SPEED=0\n"
-	],
-	"filament_max_volumetric_speed": [
-		"12"
-	],
-	"filament_type": [
-		"PLA Silk"
-	],
-	"filament_settings_id": [
-		"Eryone Silk PLA"
-	],
-	"hot_plate_temp": [
-		"60"
-	],
-	"nozzle_temperature": [
-		"230"
-	],
-	"nozzle_temperature_initial_layer": [
-		"230"
-	],
-	"slow_down_layer_time": [
-		"7"
 	]
 }

--- a/resources/profiles/Eryone/filament/Eryone Standard PLA.json
+++ b/resources/profiles/Eryone/filament/Eryone Standard PLA.json
@@ -90,9 +90,6 @@
 	"filament_is_support": [
 		"0"
 	],
-	"filament_load_time": [
-		"0"
-	],
 	"filament_loading_speed": [
 		"28"
 	],
@@ -164,9 +161,6 @@
 	],
 	"filament_type": [
 		"PLA"
-	],
-	"filament_unload_time": [
-		"0"
 	],
 	"filament_unloading_speed": [
 		"90"

--- a/resources/profiles/Eryone/filament/Eryone TPU @0.2 nozzle.json
+++ b/resources/profiles/Eryone/filament/Eryone TPU @0.2 nozzle.json
@@ -1,16 +1,10 @@
 {
 	"type": "filament",
 	"name": "Eryone TPU @0.2 nozzle",
+	"inherits": "Eryone TPU @0.2 nozzle @base",
 	"from": "system",
 	"instantiation": "true",
-	"inherits": "Eryone TPU",
 	"compatible_printers": [
 		"Thinker X400 0.2 nozzle"
-	],
-	"filament_max_volumetric_speed": [
-		"2"
-	],
-	"filament_settings_id": [
-		"Eryone TPU @0.2 nozzle"
 	]
 }

--- a/resources/profiles/Eryone/filament/Eryone TPU.json
+++ b/resources/profiles/Eryone/filament/Eryone TPU.json
@@ -1,48 +1,12 @@
 {
 	"type": "filament",
 	"name": "Eryone TPU",
-	"inherits": "Eryone Standard PLA",
+	"inherits": "Eryone TPU @base",
 	"from": "system",
 	"setting_id": "EFSA05",
 	"filament_id": "EFL95",
 	"instantiation": "true",
 	"compatible_printers": [
 		"Thinker X400 0.4 nozzle"
-	],
-	"filament_end_gcode": [
-		"; filament end gcode \nSET_FAN_SPEED FAN=filter_fan SPEED=0"
-	],
-	"filament_start_gcode": [
-		"; filament start gcode\nSET_FAN_SPEED FAN=filter_fan SPEED=1"
-	],
-	"fan_min_speed": [
-		"90"
-	],
-	"filament_max_volumetric_speed": [
-		"5"
-	],
-	"filament_retraction_length": [
-		"1.6"
-	],
-	"filament_settings_id": [
-		"Eryone TPU"
-	],
-	"filament_type": [
-		"TPU"
-	],
-	"nozzle_temperature": [
-		"230"
-	],
-	"nozzle_temperature_initial_layer": [
-		"230"
-	],
-	"hot_plate_temp": [
-		"50"
-	],
-	"hot_plate_temp_initial_layer": [
-		"50"
-	],
-	"slow_down_layer_time": [
-		"8"
 	]
 }

--- a/resources/profiles/OrcaFilamentLibrary.json
+++ b/resources/profiles/OrcaFilamentLibrary.json
@@ -1507,6 +1507,246 @@
 		{
 			"name": "GreenGate3D PETG @System",
 			"sub_path": "filament/GreenGate3D/GreenGate3D PETG @System.json"
+		},
+		{
+			"name": "Eryone ABS @base",
+			"sub_path": "filament/Eryone/Eryone ABS @base.json"
+		},
+		{
+			"name": "Eryone ABS @System",
+			"sub_path": "filament/Eryone/Eryone ABS @System.json"
+		},
+		{
+			"name": "Eryone ABS @0.2 nozzle @base",
+			"sub_path": "filament/Eryone/Eryone ABS @0.2 nozzle @base.json"
+		},
+		{
+			"name": "Eryone ABS @0.2 nozzle @System",
+			"sub_path": "filament/Eryone/Eryone ABS @0.2 nozzle @System.json"
+		},
+		{
+			"name": "Eryone ABS-CF @base",
+			"sub_path": "filament/Eryone/Eryone ABS-CF @base.json"
+		},
+		{
+			"name": "Eryone ABS-CF @System",
+			"sub_path": "filament/Eryone/Eryone ABS-CF @System.json"
+		},
+		{
+			"name": "Eryone ABS-CF @0.2 nozzle @base",
+			"sub_path": "filament/Eryone/Eryone ABS-CF @0.2 nozzle @base.json"
+		},
+		{
+			"name": "Eryone ABS-CF @0.2 nozzle @System",
+			"sub_path": "filament/Eryone/Eryone ABS-CF @0.2 nozzle @System.json"
+		},
+		{
+			"name": "Eryone ASA @base",
+			"sub_path": "filament/Eryone/Eryone ASA @base.json"
+		},
+		{
+			"name": "Eryone ASA @System",
+			"sub_path": "filament/Eryone/Eryone ASA @System.json"
+		},
+		{
+			"name": "Eryone ASA @0.2 nozzle @base",
+			"sub_path": "filament/Eryone/Eryone ASA @0.2 nozzle @base.json"
+		},
+		{
+			"name": "Eryone ASA @0.2 nozzle @System",
+			"sub_path": "filament/Eryone/Eryone ASA @0.2 nozzle @System.json"
+		},
+		{
+			"name": "Eryone ASA-CF @base",
+			"sub_path": "filament/Eryone/Eryone ASA-CF @base.json"
+		},
+		{
+			"name": "Eryone ASA-CF @System",
+			"sub_path": "filament/Eryone/Eryone ASA-CF @System.json"
+		},
+		{
+			"name": "Eryone ASA-CF @0.2 nozzle @base",
+			"sub_path": "filament/Eryone/Eryone ASA-CF @0.2 nozzle @base.json"
+		},
+		{
+			"name": "Eryone ASA-CF @0.2 nozzle @System",
+			"sub_path": "filament/Eryone/Eryone ASA-CF @0.2 nozzle @System.json"
+		},
+		{
+			"name": "Eryone PA @base",
+			"sub_path": "filament/Eryone/Eryone PA @base.json"
+		},
+		{
+			"name": "Eryone PA @System",
+			"sub_path": "filament/Eryone/Eryone PA @System.json"
+		},
+		{
+			"name": "Eryone PA @0.2 nozzle @base",
+			"sub_path": "filament/Eryone/Eryone PA @0.2 nozzle @base.json"
+		},
+		{
+			"name": "Eryone PA @0.2 nozzle @System",
+			"sub_path": "filament/Eryone/Eryone PA @0.2 nozzle @System.json"
+		},
+		{
+			"name": "Eryone PA-CF @base",
+			"sub_path": "filament/Eryone/Eryone PA-CF @base.json"
+		},
+		{
+			"name": "Eryone PA-CF @System",
+			"sub_path": "filament/Eryone/Eryone PA-CF @System.json"
+		},
+		{
+			"name": "Eryone PA-CF @0.2 nozzle @base",
+			"sub_path": "filament/Eryone/Eryone PA-CF @0.2 nozzle @base.json"
+		},
+		{
+			"name": "Eryone PA-CF @0.2 nozzle @System",
+			"sub_path": "filament/Eryone/Eryone PA-CF @0.2 nozzle @System.json"
+		},
+		{
+			"name": "Eryone PA-GF @base",
+			"sub_path": "filament/Eryone/Eryone PA-GF @base.json"
+		},
+		{
+			"name": "Eryone PA-GF @System",
+			"sub_path": "filament/Eryone/Eryone PA-GF @System.json"
+		},
+		{
+			"name": "Eryone PA-GF @0.2 nozzle @base",
+			"sub_path": "filament/Eryone/Eryone PA-GF @0.2 nozzle @base.json"
+		},
+		{
+			"name": "Eryone PA-GF @0.2 nozzle @System",
+			"sub_path": "filament/Eryone/Eryone PA-GF @0.2 nozzle @System.json"
+		},
+		{
+			"name": "Eryone PETG @base",
+			"sub_path": "filament/Eryone/Eryone PETG @base.json"
+		},
+		{
+			"name": "Eryone PETG @System",
+			"sub_path": "filament/Eryone/Eryone PETG @System.json"
+		},
+		{
+			"name": "Eryone PETG @0.2 nozzle @base",
+			"sub_path": "filament/Eryone/Eryone PETG @0.2 nozzle @base.json"
+		},
+		{
+			"name": "Eryone PETG @0.2 nozzle @System",
+			"sub_path": "filament/Eryone/Eryone PETG @0.2 nozzle @System.json"
+		},
+		{
+			"name": "Eryone PETG-CF @base",
+			"sub_path": "filament/Eryone/Eryone PETG-CF @base.json"
+		},
+		{
+			"name": "Eryone PETG-CF @System",
+			"sub_path": "filament/Eryone/Eryone PETG-CF @System.json"
+		},
+		{
+			"name": "Eryone PETG-CF @0.2 nozzle @base",
+			"sub_path": "filament/Eryone/Eryone PETG-CF @0.2 nozzle @base.json"
+		},
+		{
+			"name": "Eryone PETG-CF @0.2 nozzle @System",
+			"sub_path": "filament/Eryone/Eryone PETG-CF @0.2 nozzle @System.json"
+		},
+		{
+			"name": "Eryone PLA @base",
+			"sub_path": "filament/Eryone/Eryone PLA @base.json"
+		},
+		{
+			"name": "Eryone PLA @System",
+			"sub_path": "filament/Eryone/Eryone PLA @System.json"
+		},
+		{
+			"name": "Eryone PLA @0.2 nozzle @base",
+			"sub_path": "filament/Eryone/Eryone PLA @0.2 nozzle @base.json"
+		},
+		{
+			"name": "Eryone PLA @0.2 nozzle @System",
+			"sub_path": "filament/Eryone/Eryone PLA @0.2 nozzle @System.json"
+		},
+		{
+			"name": "Eryone PLA-CF @base",
+			"sub_path": "filament/Eryone/Eryone PLA-CF @base.json"
+		},
+		{
+			"name": "Eryone PLA-CF @System",
+			"sub_path": "filament/Eryone/Eryone PLA-CF @System.json"
+		},
+		{
+			"name": "Eryone PLA-CF @0.2 nozzle @base",
+			"sub_path": "filament/Eryone/Eryone PLA-CF @0.2 nozzle @base.json"
+		},
+		{
+			"name": "Eryone PLA-CF @0.2 nozzle @System",
+			"sub_path": "filament/Eryone/Eryone PLA-CF @0.2 nozzle @System.json"
+		},
+		{
+			"name": "Eryone PP @base",
+			"sub_path": "filament/Eryone/Eryone PP @base.json"
+		},
+		{
+			"name": "Eryone PP @System",
+			"sub_path": "filament/Eryone/Eryone PP @System.json"
+		},
+		{
+			"name": "Eryone PP @0.2 nozzle @base",
+			"sub_path": "filament/Eryone/Eryone PP @0.2 nozzle @base.json"
+		},
+		{
+			"name": "Eryone PP @0.2 nozzle @System",
+			"sub_path": "filament/Eryone/Eryone PP @0.2 nozzle @System.json"
+		},
+		{
+			"name": "Eryone PP-CF @base",
+			"sub_path": "filament/Eryone/Eryone PP-CF @base.json"
+		},
+		{
+			"name": "Eryone PP-CF @System",
+			"sub_path": "filament/Eryone/Eryone PP-CF @System.json"
+		},
+		{
+			"name": "Eryone PP-CF @0.2 nozzle @base",
+			"sub_path": "filament/Eryone/Eryone PP-CF @0.2 nozzle @base.json"
+		},
+		{
+			"name": "Eryone PP-CF @0.2 nozzle @System",
+			"sub_path": "filament/Eryone/Eryone PP-CF @0.2 nozzle @System.json"
+		},
+		{
+			"name": "Eryone Silk PLA @base",
+			"sub_path": "filament/Eryone/Eryone Silk PLA @base.json"
+		},
+		{
+			"name": "Eryone Silk PLA @System",
+			"sub_path": "filament/Eryone/Eryone Silk PLA @System.json"
+		},
+		{
+			"name": "Eryone Silk PLA @0.2 nozzle @base",
+			"sub_path": "filament/Eryone/Eryone Silk PLA @0.2 nozzle @base.json"
+		},
+		{
+			"name": "Eryone Silk PLA @0.2 nozzle @System",
+			"sub_path": "filament/Eryone/Eryone Silk PLA @0.2 nozzle @System.json"
+		},
+		{
+			"name": "Eryone TPU @base",
+			"sub_path": "filament/Eryone/Eryone TPU @base.json"
+		},
+		{
+			"name": "Eryone TPU @System",
+			"sub_path": "filament/Eryone/Eryone TPU @System.json"
+		},
+		{
+			"name": "Eryone TPU @0.2 nozzle @base",
+			"sub_path": "filament/Eryone/Eryone TPU @0.2 nozzle @base.json"
+		},
+		{
+			"name": "Eryone TPU @0.2 nozzle @System",
+			"sub_path": "filament/Eryone/Eryone TPU @0.2 nozzle @System.json"
 		}
 	],
 	"process_list": [],

--- a/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone ABS @0.2 nozzle @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone ABS @0.2 nozzle @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Eryone ABS @0.2 nozzle @System",
+	"inherits": "Eryone ABS @0.2 nozzle @base",
+	"from": "system",
+	"setting_id": "",
+	"filament_id": "",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone ABS @0.2 nozzle @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone ABS @0.2 nozzle @base.json
@@ -1,0 +1,240 @@
+{
+	"type": "filament",
+	"name": "Eryone ABS @0.2 nozzle @base",
+	"inherits": "Eryone ABS",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"activate_chamber_temp_control": [
+		"0"
+	],
+	"additional_cooling_fan_speed": [
+		"0"
+	],
+	"chamber_temperature": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"compatible_prints": [],
+	"compatible_prints_condition": "",
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"0"
+	],
+	"cool_plate_temp_initial_layer": [
+		"0"
+	],
+	"default_filament_colour": [
+		""
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"enable_overhang_bridge_fan": [
+		"1"
+	],
+	"enable_pressure_advance": [
+		"0"
+	],
+	"eng_plate_temp": [
+		"100"
+	],
+	"eng_plate_temp_initial_layer": [
+		"105"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"fan_max_speed": [
+		"70"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"filament_cooling_final_speed": [
+		"3.4"
+	],
+	"filament_cooling_initial_speed": [
+		"2.2"
+	],
+	"filament_cooling_moves": [
+		"4"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.04"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode\nSET_FAN_SPEED FAN=filter_fan SPEED=0"
+	],
+	"filament_flow_ratio": [
+		"0.92"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_loading_speed": [
+		"28"
+	],
+	"filament_loading_speed_start": [
+		"3"
+	],
+	"filament_max_volumetric_speed": [
+		"2"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_multitool_ramming": [
+		"0"
+	],
+	"filament_multitool_ramming_flow": [
+		"10"
+	],
+	"filament_multitool_ramming_volume": [
+		"10"
+	],
+	"filament_notes": [
+		""
+	],
+	"filament_ramming_parameters": [
+		"120 100 6.6 6.8 7.2 7.6 7.9 8.2 8.7 9.4 9.9 10.0| 0.05 6.6 0.45 6.8 0.95 7.8 1.45 8.3 1.95 9.7 2.45 10 2.95 7.6 3.45 7.6 3.95 7.6 4.45 7.6 4.95 7.6"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_lift_above": [
+		"nil"
+	],
+	"filament_retract_lift_below": [
+		"nil"
+	],
+	"filament_retract_lift_enforce": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		"Eryone ABS @0.2 nozzle"
+	],
+	"filament_shrink": [
+		"100%"
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\nSET_FAN_SPEED FAN=filter_fan SPEED=0\n"
+	],
+	"filament_toolchange_delay": [
+		"0"
+	],
+	"filament_type": [
+		"ABS"
+	],
+	"filament_unloading_speed": [
+		"90"
+	],
+	"filament_unloading_speed_start": [
+		"100"
+	],
+	"filament_vendor": [
+		"Eryone"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"95"
+	],
+	"hot_plate_temp_initial_layer": [
+		"95"
+	],
+	"nozzle_temperature": [
+		"255"
+	],
+	"nozzle_temperature_initial_layer": [
+		"260"
+	],
+	"nozzle_temperature_range_high": [
+		"290"
+	],
+	"nozzle_temperature_range_low": [
+		"240"
+	],
+	"overhang_fan_speed": [
+		"80"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"pressure_advance": [
+		"0.02"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"3"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"4"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"support_material_interface_fan_speed": [
+		"60"
+	],
+	"temperature_vitrification": [
+		"100"
+	],
+	"textured_plate_temp": [
+		"100"
+	],
+	"textured_plate_temp_initial_layer": [
+		"105"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone ABS @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone ABS @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Eryone ABS @System",
+	"inherits": "Eryone ABS @base",
+	"from": "system",
+	"setting_id": "EFSA01",
+	"filament_id": "EFL91",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone ABS @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone ABS @base.json
@@ -1,0 +1,240 @@
+{
+	"type": "filament",
+	"name": "Eryone ABS @base",
+	"inherits": "Eryone Standard PLA",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"activate_chamber_temp_control": [
+		"0"
+	],
+	"additional_cooling_fan_speed": [
+		"0"
+	],
+	"chamber_temperature": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"compatible_prints": [],
+	"compatible_prints_condition": "",
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"0"
+	],
+	"cool_plate_temp_initial_layer": [
+		"0"
+	],
+	"default_filament_colour": [
+		""
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"enable_overhang_bridge_fan": [
+		"1"
+	],
+	"enable_pressure_advance": [
+		"0"
+	],
+	"eng_plate_temp": [
+		"100"
+	],
+	"eng_plate_temp_initial_layer": [
+		"105"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"fan_max_speed": [
+		"70"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"filament_cooling_final_speed": [
+		"3.4"
+	],
+	"filament_cooling_initial_speed": [
+		"2.2"
+	],
+	"filament_cooling_moves": [
+		"4"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.04"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode\nSET_FAN_SPEED FAN=filter_fan SPEED=0"
+	],
+	"filament_flow_ratio": [
+		"0.92"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_loading_speed": [
+		"28"
+	],
+	"filament_loading_speed_start": [
+		"3"
+	],
+	"filament_max_volumetric_speed": [
+		"15"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_multitool_ramming": [
+		"0"
+	],
+	"filament_multitool_ramming_flow": [
+		"10"
+	],
+	"filament_multitool_ramming_volume": [
+		"10"
+	],
+	"filament_notes": [
+		""
+	],
+	"filament_ramming_parameters": [
+		"120 100 6.6 6.8 7.2 7.6 7.9 8.2 8.7 9.4 9.9 10.0| 0.05 6.6 0.45 6.8 0.95 7.8 1.45 8.3 1.95 9.7 2.45 10 2.95 7.6 3.45 7.6 3.95 7.6 4.45 7.6 4.95 7.6"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_lift_above": [
+		"nil"
+	],
+	"filament_retract_lift_below": [
+		"nil"
+	],
+	"filament_retract_lift_enforce": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		"Eryone ABS"
+	],
+	"filament_shrink": [
+		"100%"
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\nSET_FAN_SPEED FAN=filter_fan SPEED=0\n"
+	],
+	"filament_toolchange_delay": [
+		"0"
+	],
+	"filament_type": [
+		"ABS"
+	],
+	"filament_unloading_speed": [
+		"90"
+	],
+	"filament_unloading_speed_start": [
+		"100"
+	],
+	"filament_vendor": [
+		"Eryone"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"95"
+	],
+	"hot_plate_temp_initial_layer": [
+		"95"
+	],
+	"nozzle_temperature": [
+		"255"
+	],
+	"nozzle_temperature_initial_layer": [
+		"260"
+	],
+	"nozzle_temperature_range_high": [
+		"290"
+	],
+	"nozzle_temperature_range_low": [
+		"240"
+	],
+	"overhang_fan_speed": [
+		"80"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"pressure_advance": [
+		"0.02"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"3"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"4"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"support_material_interface_fan_speed": [
+		"60"
+	],
+	"temperature_vitrification": [
+		"100"
+	],
+	"textured_plate_temp": [
+		"100"
+	],
+	"textured_plate_temp_initial_layer": [
+		"105"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone ABS-CF @0.2 nozzle @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone ABS-CF @0.2 nozzle @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Eryone ABS-CF @0.2 nozzle @System",
+	"inherits": "Eryone ABS-CF @0.2 nozzle @base",
+	"from": "system",
+	"setting_id": "",
+	"filament_id": "",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone ABS-CF @0.2 nozzle @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone ABS-CF @0.2 nozzle @base.json
@@ -1,0 +1,240 @@
+{
+	"type": "filament",
+	"name": "Eryone ABS-CF @0.2 nozzle @base",
+	"inherits": "Eryone ABS-CF",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"activate_chamber_temp_control": [
+		"0"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"chamber_temperature": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"compatible_prints": [],
+	"compatible_prints_condition": "",
+	"complete_print_exhaust_fan_speed": [
+		"80"
+	],
+	"cool_plate_temp": [
+		"60"
+	],
+	"cool_plate_temp_initial_layer": [
+		"60"
+	],
+	"default_filament_colour": [
+		""
+	],
+	"during_print_exhaust_fan_speed": [
+		"60"
+	],
+	"enable_overhang_bridge_fan": [
+		"1"
+	],
+	"enable_pressure_advance": [
+		"0"
+	],
+	"eng_plate_temp": [
+		"60"
+	],
+	"eng_plate_temp_initial_layer": [
+		"60"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"fan_max_speed": [
+		"60"
+	],
+	"fan_min_speed": [
+		"30"
+	],
+	"filament_cooling_final_speed": [
+		"3.4"
+	],
+	"filament_cooling_initial_speed": [
+		"2.2"
+	],
+	"filament_cooling_moves": [
+		"4"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \nSET_FAN_SPEED FAN=filter_fan SPEED=0"
+	],
+	"filament_flow_ratio": [
+		"0.92"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_loading_speed": [
+		"28"
+	],
+	"filament_loading_speed_start": [
+		"3"
+	],
+	"filament_max_volumetric_speed": [
+		"2"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_multitool_ramming": [
+		"0"
+	],
+	"filament_multitool_ramming_flow": [
+		"10"
+	],
+	"filament_multitool_ramming_volume": [
+		"10"
+	],
+	"filament_notes": [
+		""
+	],
+	"filament_ramming_parameters": [
+		"120 100 6.6 6.8 7.2 7.6 7.9 8.2 8.7 9.4 9.9 10.0| 0.05 6.6 0.45 6.8 0.95 7.8 1.45 8.3 1.95 9.7 2.45 10 2.95 7.6 3.45 7.6 3.95 7.6 4.45 7.6 4.95 7.6"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_lift_above": [
+		"nil"
+	],
+	"filament_retract_lift_below": [
+		"nil"
+	],
+	"filament_retract_lift_enforce": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"1"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		"Eryone ABS-CF @0.2 nozzle"
+	],
+	"filament_shrink": [
+		"100%"
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\nSET_FAN_SPEED FAN=filter_fan SPEED=0"
+	],
+	"filament_toolchange_delay": [
+		"0"
+	],
+	"filament_type": [
+		"ABS-CF"
+	],
+	"filament_unloading_speed": [
+		"90"
+	],
+	"filament_unloading_speed_start": [
+		"100"
+	],
+	"filament_vendor": [
+		"Eryone"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"100"
+	],
+	"hot_plate_temp_initial_layer": [
+		"100"
+	],
+	"nozzle_temperature": [
+		"250"
+	],
+	"nozzle_temperature_initial_layer": [
+		"260"
+	],
+	"nozzle_temperature_range_high": [
+		"290"
+	],
+	"nozzle_temperature_range_low": [
+		"240"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"pressure_advance": [
+		"0.02"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"0"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"10"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"support_material_interface_fan_speed": [
+		"60"
+	],
+	"temperature_vitrification": [
+		"100"
+	],
+	"textured_plate_temp": [
+		"60"
+	],
+	"textured_plate_temp_initial_layer": [
+		"60"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone ABS-CF @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone ABS-CF @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Eryone ABS-CF @System",
+	"inherits": "Eryone ABS-CF @base",
+	"from": "system",
+	"setting_id": "EFSA11",
+	"filament_id": "EFL81",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone ABS-CF @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone ABS-CF @base.json
@@ -1,0 +1,240 @@
+{
+	"type": "filament",
+	"name": "Eryone ABS-CF @base",
+	"inherits": "Eryone Standard PLA",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"activate_chamber_temp_control": [
+		"0"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"chamber_temperature": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"compatible_prints": [],
+	"compatible_prints_condition": "",
+	"complete_print_exhaust_fan_speed": [
+		"80"
+	],
+	"cool_plate_temp": [
+		"60"
+	],
+	"cool_plate_temp_initial_layer": [
+		"60"
+	],
+	"default_filament_colour": [
+		""
+	],
+	"during_print_exhaust_fan_speed": [
+		"60"
+	],
+	"enable_overhang_bridge_fan": [
+		"1"
+	],
+	"enable_pressure_advance": [
+		"0"
+	],
+	"eng_plate_temp": [
+		"60"
+	],
+	"eng_plate_temp_initial_layer": [
+		"60"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"fan_max_speed": [
+		"60"
+	],
+	"fan_min_speed": [
+		"30"
+	],
+	"filament_cooling_final_speed": [
+		"3.4"
+	],
+	"filament_cooling_initial_speed": [
+		"2.2"
+	],
+	"filament_cooling_moves": [
+		"4"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \nSET_FAN_SPEED FAN=filter_fan SPEED=0"
+	],
+	"filament_flow_ratio": [
+		"0.92"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_loading_speed": [
+		"28"
+	],
+	"filament_loading_speed_start": [
+		"3"
+	],
+	"filament_max_volumetric_speed": [
+		"10"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_multitool_ramming": [
+		"0"
+	],
+	"filament_multitool_ramming_flow": [
+		"10"
+	],
+	"filament_multitool_ramming_volume": [
+		"10"
+	],
+	"filament_notes": [
+		""
+	],
+	"filament_ramming_parameters": [
+		"120 100 6.6 6.8 7.2 7.6 7.9 8.2 8.7 9.4 9.9 10.0| 0.05 6.6 0.45 6.8 0.95 7.8 1.45 8.3 1.95 9.7 2.45 10 2.95 7.6 3.45 7.6 3.95 7.6 4.45 7.6 4.95 7.6"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_lift_above": [
+		"nil"
+	],
+	"filament_retract_lift_below": [
+		"nil"
+	],
+	"filament_retract_lift_enforce": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"1"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		"Eryone ABS-CF"
+	],
+	"filament_shrink": [
+		"100%"
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\nSET_FAN_SPEED FAN=filter_fan SPEED=0"
+	],
+	"filament_toolchange_delay": [
+		"0"
+	],
+	"filament_type": [
+		"ABS-CF"
+	],
+	"filament_unloading_speed": [
+		"90"
+	],
+	"filament_unloading_speed_start": [
+		"100"
+	],
+	"filament_vendor": [
+		"Eryone"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"100"
+	],
+	"hot_plate_temp_initial_layer": [
+		"100"
+	],
+	"nozzle_temperature": [
+		"250"
+	],
+	"nozzle_temperature_initial_layer": [
+		"260"
+	],
+	"nozzle_temperature_range_high": [
+		"290"
+	],
+	"nozzle_temperature_range_low": [
+		"240"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"pressure_advance": [
+		"0.02"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"0"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"10"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"support_material_interface_fan_speed": [
+		"60"
+	],
+	"temperature_vitrification": [
+		"100"
+	],
+	"textured_plate_temp": [
+		"60"
+	],
+	"textured_plate_temp_initial_layer": [
+		"60"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone ASA @0.2 nozzle @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone ASA @0.2 nozzle @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Eryone ASA @0.2 nozzle @System",
+	"inherits": "Eryone ASA @0.2 nozzle @base",
+	"from": "system",
+	"setting_id": "",
+	"filament_id": "",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone ASA @0.2 nozzle @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone ASA @0.2 nozzle @base.json
@@ -1,0 +1,240 @@
+{
+	"type": "filament",
+	"name": "Eryone ASA @0.2 nozzle @base",
+	"inherits": "Eryone ASA",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"activate_chamber_temp_control": [
+		"0"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"chamber_temperature": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"compatible_prints": [],
+	"compatible_prints_condition": "",
+	"complete_print_exhaust_fan_speed": [
+		"80"
+	],
+	"cool_plate_temp": [
+		"60"
+	],
+	"cool_plate_temp_initial_layer": [
+		"60"
+	],
+	"default_filament_colour": [
+		""
+	],
+	"during_print_exhaust_fan_speed": [
+		"60"
+	],
+	"enable_overhang_bridge_fan": [
+		"1"
+	],
+	"enable_pressure_advance": [
+		"0"
+	],
+	"eng_plate_temp": [
+		"60"
+	],
+	"eng_plate_temp_initial_layer": [
+		"60"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"fan_max_speed": [
+		"50"
+	],
+	"fan_min_speed": [
+		"20"
+	],
+	"filament_cooling_final_speed": [
+		"3.4"
+	],
+	"filament_cooling_initial_speed": [
+		"2.2"
+	],
+	"filament_cooling_moves": [
+		"4"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \nSET_FAN_SPEED FAN=filter_fan SPEED=0"
+	],
+	"filament_flow_ratio": [
+		"0.92"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_loading_speed": [
+		"28"
+	],
+	"filament_loading_speed_start": [
+		"3"
+	],
+	"filament_max_volumetric_speed": [
+		"2"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_multitool_ramming": [
+		"0"
+	],
+	"filament_multitool_ramming_flow": [
+		"10"
+	],
+	"filament_multitool_ramming_volume": [
+		"10"
+	],
+	"filament_notes": [
+		""
+	],
+	"filament_ramming_parameters": [
+		"120 100 6.6 6.8 7.2 7.6 7.9 8.2 8.7 9.4 9.9 10.0| 0.05 6.6 0.45 6.8 0.95 7.8 1.45 8.3 1.95 9.7 2.45 10 2.95 7.6 3.45 7.6 3.95 7.6 4.45 7.6 4.95 7.6"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_lift_above": [
+		"nil"
+	],
+	"filament_retract_lift_below": [
+		"nil"
+	],
+	"filament_retract_lift_enforce": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"1"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		"Eryone ASA @0.2 nozzle"
+	],
+	"filament_shrink": [
+		"100%"
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\nSET_FAN_SPEED FAN=filter_fan SPEED=0"
+	],
+	"filament_toolchange_delay": [
+		"0"
+	],
+	"filament_type": [
+		"ASA"
+	],
+	"filament_unloading_speed": [
+		"90"
+	],
+	"filament_unloading_speed_start": [
+		"100"
+	],
+	"filament_vendor": [
+		"Eryone"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"110"
+	],
+	"hot_plate_temp_initial_layer": [
+		"110"
+	],
+	"nozzle_temperature": [
+		"265"
+	],
+	"nozzle_temperature_initial_layer": [
+		"270"
+	],
+	"nozzle_temperature_range_high": [
+		"290"
+	],
+	"nozzle_temperature_range_low": [
+		"240"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"pressure_advance": [
+		"0.02"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"0"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"12"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"support_material_interface_fan_speed": [
+		"60"
+	],
+	"temperature_vitrification": [
+		"180"
+	],
+	"textured_plate_temp": [
+		"60"
+	],
+	"textured_plate_temp_initial_layer": [
+		"60"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone ASA @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone ASA @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Eryone ASA @System",
+	"inherits": "Eryone ASA @base",
+	"from": "system",
+	"setting_id": "EFSA02",
+	"filament_id": "EFL92",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone ASA @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone ASA @base.json
@@ -1,0 +1,240 @@
+{
+	"type": "filament",
+	"name": "Eryone ASA @base",
+	"inherits": "Eryone Standard PLA",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"activate_chamber_temp_control": [
+		"0"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"chamber_temperature": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"compatible_prints": [],
+	"compatible_prints_condition": "",
+	"complete_print_exhaust_fan_speed": [
+		"80"
+	],
+	"cool_plate_temp": [
+		"60"
+	],
+	"cool_plate_temp_initial_layer": [
+		"60"
+	],
+	"default_filament_colour": [
+		""
+	],
+	"during_print_exhaust_fan_speed": [
+		"60"
+	],
+	"enable_overhang_bridge_fan": [
+		"1"
+	],
+	"enable_pressure_advance": [
+		"0"
+	],
+	"eng_plate_temp": [
+		"60"
+	],
+	"eng_plate_temp_initial_layer": [
+		"60"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"fan_max_speed": [
+		"50"
+	],
+	"fan_min_speed": [
+		"20"
+	],
+	"filament_cooling_final_speed": [
+		"3.4"
+	],
+	"filament_cooling_initial_speed": [
+		"2.2"
+	],
+	"filament_cooling_moves": [
+		"4"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \nSET_FAN_SPEED FAN=filter_fan SPEED=0"
+	],
+	"filament_flow_ratio": [
+		"0.92"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_loading_speed": [
+		"28"
+	],
+	"filament_loading_speed_start": [
+		"3"
+	],
+	"filament_max_volumetric_speed": [
+		"14"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_multitool_ramming": [
+		"0"
+	],
+	"filament_multitool_ramming_flow": [
+		"10"
+	],
+	"filament_multitool_ramming_volume": [
+		"10"
+	],
+	"filament_notes": [
+		""
+	],
+	"filament_ramming_parameters": [
+		"120 100 6.6 6.8 7.2 7.6 7.9 8.2 8.7 9.4 9.9 10.0| 0.05 6.6 0.45 6.8 0.95 7.8 1.45 8.3 1.95 9.7 2.45 10 2.95 7.6 3.45 7.6 3.95 7.6 4.45 7.6 4.95 7.6"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_lift_above": [
+		"nil"
+	],
+	"filament_retract_lift_below": [
+		"nil"
+	],
+	"filament_retract_lift_enforce": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"1"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		"Eryone ASA"
+	],
+	"filament_shrink": [
+		"100%"
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\nSET_FAN_SPEED FAN=filter_fan SPEED=0"
+	],
+	"filament_toolchange_delay": [
+		"0"
+	],
+	"filament_type": [
+		"ASA"
+	],
+	"filament_unloading_speed": [
+		"90"
+	],
+	"filament_unloading_speed_start": [
+		"100"
+	],
+	"filament_vendor": [
+		"Eryone"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"110"
+	],
+	"hot_plate_temp_initial_layer": [
+		"110"
+	],
+	"nozzle_temperature": [
+		"265"
+	],
+	"nozzle_temperature_initial_layer": [
+		"270"
+	],
+	"nozzle_temperature_range_high": [
+		"290"
+	],
+	"nozzle_temperature_range_low": [
+		"240"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"pressure_advance": [
+		"0.02"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"0"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"12"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"support_material_interface_fan_speed": [
+		"60"
+	],
+	"temperature_vitrification": [
+		"180"
+	],
+	"textured_plate_temp": [
+		"60"
+	],
+	"textured_plate_temp_initial_layer": [
+		"60"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone ASA-CF @0.2 nozzle @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone ASA-CF @0.2 nozzle @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Eryone ASA-CF @0.2 nozzle @System",
+	"inherits": "Eryone ASA-CF @0.2 nozzle @base",
+	"from": "system",
+	"setting_id": "",
+	"filament_id": "",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone ASA-CF @0.2 nozzle @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone ASA-CF @0.2 nozzle @base.json
@@ -1,0 +1,240 @@
+{
+	"type": "filament",
+	"name": "Eryone ASA-CF @0.2 nozzle @base",
+	"inherits": "Eryone ASA-CF",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"activate_chamber_temp_control": [
+		"0"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"chamber_temperature": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"compatible_prints": [],
+	"compatible_prints_condition": "",
+	"complete_print_exhaust_fan_speed": [
+		"80"
+	],
+	"cool_plate_temp": [
+		"60"
+	],
+	"cool_plate_temp_initial_layer": [
+		"60"
+	],
+	"default_filament_colour": [
+		""
+	],
+	"during_print_exhaust_fan_speed": [
+		"60"
+	],
+	"enable_overhang_bridge_fan": [
+		"1"
+	],
+	"enable_pressure_advance": [
+		"0"
+	],
+	"eng_plate_temp": [
+		"60"
+	],
+	"eng_plate_temp_initial_layer": [
+		"60"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"fan_max_speed": [
+		"50"
+	],
+	"fan_min_speed": [
+		"20"
+	],
+	"filament_cooling_final_speed": [
+		"3.4"
+	],
+	"filament_cooling_initial_speed": [
+		"2.2"
+	],
+	"filament_cooling_moves": [
+		"4"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \nSET_FAN_SPEED FAN=filter_fan SPEED=0"
+	],
+	"filament_flow_ratio": [
+		"0.92"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_loading_speed": [
+		"28"
+	],
+	"filament_loading_speed_start": [
+		"3"
+	],
+	"filament_max_volumetric_speed": [
+		"2"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_multitool_ramming": [
+		"0"
+	],
+	"filament_multitool_ramming_flow": [
+		"10"
+	],
+	"filament_multitool_ramming_volume": [
+		"10"
+	],
+	"filament_notes": [
+		""
+	],
+	"filament_ramming_parameters": [
+		"120 100 6.6 6.8 7.2 7.6 7.9 8.2 8.7 9.4 9.9 10.0| 0.05 6.6 0.45 6.8 0.95 7.8 1.45 8.3 1.95 9.7 2.45 10 2.95 7.6 3.45 7.6 3.95 7.6 4.45 7.6 4.95 7.6"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_lift_above": [
+		"nil"
+	],
+	"filament_retract_lift_below": [
+		"nil"
+	],
+	"filament_retract_lift_enforce": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"1"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		"Eryone ASA-CF @0.2 nozzle"
+	],
+	"filament_shrink": [
+		"100%"
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\nSET_FAN_SPEED FAN=filter_fan SPEED=0"
+	],
+	"filament_toolchange_delay": [
+		"0"
+	],
+	"filament_type": [
+		"ASA-CF"
+	],
+	"filament_unloading_speed": [
+		"90"
+	],
+	"filament_unloading_speed_start": [
+		"100"
+	],
+	"filament_vendor": [
+		"Eryone"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"110"
+	],
+	"hot_plate_temp_initial_layer": [
+		"110"
+	],
+	"nozzle_temperature": [
+		"260"
+	],
+	"nozzle_temperature_initial_layer": [
+		"275"
+	],
+	"nozzle_temperature_range_high": [
+		"290"
+	],
+	"nozzle_temperature_range_low": [
+		"240"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"pressure_advance": [
+		"0.02"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"0"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"12"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"support_material_interface_fan_speed": [
+		"60"
+	],
+	"temperature_vitrification": [
+		"180"
+	],
+	"textured_plate_temp": [
+		"60"
+	],
+	"textured_plate_temp_initial_layer": [
+		"60"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone ASA-CF @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone ASA-CF @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Eryone ASA-CF @System",
+	"inherits": "Eryone ASA-CF @base",
+	"from": "system",
+	"setting_id": "EFSA82",
+	"filament_id": "EFL82",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone ASA-CF @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone ASA-CF @base.json
@@ -1,0 +1,240 @@
+{
+	"type": "filament",
+	"name": "Eryone ASA-CF @base",
+	"inherits": "Eryone Standard PLA",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"activate_chamber_temp_control": [
+		"0"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"chamber_temperature": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"compatible_prints": [],
+	"compatible_prints_condition": "",
+	"complete_print_exhaust_fan_speed": [
+		"80"
+	],
+	"cool_plate_temp": [
+		"60"
+	],
+	"cool_plate_temp_initial_layer": [
+		"60"
+	],
+	"default_filament_colour": [
+		""
+	],
+	"during_print_exhaust_fan_speed": [
+		"60"
+	],
+	"enable_overhang_bridge_fan": [
+		"1"
+	],
+	"enable_pressure_advance": [
+		"0"
+	],
+	"eng_plate_temp": [
+		"60"
+	],
+	"eng_plate_temp_initial_layer": [
+		"60"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"fan_max_speed": [
+		"50"
+	],
+	"fan_min_speed": [
+		"20"
+	],
+	"filament_cooling_final_speed": [
+		"3.4"
+	],
+	"filament_cooling_initial_speed": [
+		"2.2"
+	],
+	"filament_cooling_moves": [
+		"4"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \nSET_FAN_SPEED FAN=filter_fan SPEED=0"
+	],
+	"filament_flow_ratio": [
+		"0.92"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_loading_speed": [
+		"28"
+	],
+	"filament_loading_speed_start": [
+		"3"
+	],
+	"filament_max_volumetric_speed": [
+		"8"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_multitool_ramming": [
+		"0"
+	],
+	"filament_multitool_ramming_flow": [
+		"10"
+	],
+	"filament_multitool_ramming_volume": [
+		"10"
+	],
+	"filament_notes": [
+		""
+	],
+	"filament_ramming_parameters": [
+		"120 100 6.6 6.8 7.2 7.6 7.9 8.2 8.7 9.4 9.9 10.0| 0.05 6.6 0.45 6.8 0.95 7.8 1.45 8.3 1.95 9.7 2.45 10 2.95 7.6 3.45 7.6 3.95 7.6 4.45 7.6 4.95 7.6"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_lift_above": [
+		"nil"
+	],
+	"filament_retract_lift_below": [
+		"nil"
+	],
+	"filament_retract_lift_enforce": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"1"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		"Eryone ASA-CF"
+	],
+	"filament_shrink": [
+		"100%"
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\nSET_FAN_SPEED FAN=filter_fan SPEED=0"
+	],
+	"filament_toolchange_delay": [
+		"0"
+	],
+	"filament_type": [
+		"ASA-CF"
+	],
+	"filament_unloading_speed": [
+		"90"
+	],
+	"filament_unloading_speed_start": [
+		"100"
+	],
+	"filament_vendor": [
+		"Eryone"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"110"
+	],
+	"hot_plate_temp_initial_layer": [
+		"110"
+	],
+	"nozzle_temperature": [
+		"260"
+	],
+	"nozzle_temperature_initial_layer": [
+		"275"
+	],
+	"nozzle_temperature_range_high": [
+		"290"
+	],
+	"nozzle_temperature_range_low": [
+		"240"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"pressure_advance": [
+		"0.02"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"0"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"12"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"support_material_interface_fan_speed": [
+		"60"
+	],
+	"temperature_vitrification": [
+		"180"
+	],
+	"textured_plate_temp": [
+		"60"
+	],
+	"textured_plate_temp_initial_layer": [
+		"60"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone PA @0.2 nozzle @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone PA @0.2 nozzle @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Eryone PA @0.2 nozzle @System",
+	"inherits": "Eryone PA @0.2 nozzle @base",
+	"from": "system",
+	"setting_id": "",
+	"filament_id": "",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone PA @0.2 nozzle @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone PA @0.2 nozzle @base.json
@@ -1,0 +1,240 @@
+{
+	"type": "filament",
+	"name": "Eryone PA @0.2 nozzle @base",
+	"inherits": "Eryone PA",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"activate_chamber_temp_control": [
+		"0"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"chamber_temperature": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"compatible_prints": [],
+	"compatible_prints_condition": "",
+	"complete_print_exhaust_fan_speed": [
+		"80"
+	],
+	"cool_plate_temp": [
+		"60"
+	],
+	"cool_plate_temp_initial_layer": [
+		"60"
+	],
+	"default_filament_colour": [
+		""
+	],
+	"during_print_exhaust_fan_speed": [
+		"60"
+	],
+	"enable_overhang_bridge_fan": [
+		"1"
+	],
+	"enable_pressure_advance": [
+		"0"
+	],
+	"eng_plate_temp": [
+		"60"
+	],
+	"eng_plate_temp_initial_layer": [
+		"60"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"fan_max_speed": [
+		"20"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"filament_cooling_final_speed": [
+		"3.4"
+	],
+	"filament_cooling_initial_speed": [
+		"2.2"
+	],
+	"filament_cooling_moves": [
+		"4"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \nSET_FAN_SPEED FAN=filter_fan SPEED=0"
+	],
+	"filament_flow_ratio": [
+		"0.92"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_loading_speed": [
+		"28"
+	],
+	"filament_loading_speed_start": [
+		"3"
+	],
+	"filament_max_volumetric_speed": [
+		"2"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_multitool_ramming": [
+		"0"
+	],
+	"filament_multitool_ramming_flow": [
+		"10"
+	],
+	"filament_multitool_ramming_volume": [
+		"10"
+	],
+	"filament_notes": [
+		"brim width >= 20;"
+	],
+	"filament_ramming_parameters": [
+		"120 100 6.6 6.8 7.2 7.6 7.9 8.2 8.7 9.4 9.9 10.0| 0.05 6.6 0.45 6.8 0.95 7.8 1.45 8.3 1.95 9.7 2.45 10 2.95 7.6 3.45 7.6 3.95 7.6 4.45 7.6 4.95 7.6"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_lift_above": [
+		"nil"
+	],
+	"filament_retract_lift_below": [
+		"nil"
+	],
+	"filament_retract_lift_enforce": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"1"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		"Eryone PA @0.2 nozzle"
+	],
+	"filament_shrink": [
+		"100%"
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\nSET_FAN_SPEED FAN=filter_fan SPEED=0"
+	],
+	"filament_toolchange_delay": [
+		"0"
+	],
+	"filament_type": [
+		"PA"
+	],
+	"filament_unloading_speed": [
+		"90"
+	],
+	"filament_unloading_speed_start": [
+		"100"
+	],
+	"filament_vendor": [
+		"Eryone"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"115"
+	],
+	"hot_plate_temp_initial_layer": [
+		"115"
+	],
+	"nozzle_temperature": [
+		"265"
+	],
+	"nozzle_temperature_initial_layer": [
+		"270"
+	],
+	"nozzle_temperature_range_high": [
+		"280"
+	],
+	"nozzle_temperature_range_low": [
+		"240"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"pressure_advance": [
+		"0.02"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"0"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"10"
+	],
+	"slow_down_min_speed": [
+		"15"
+	],
+	"support_material_interface_fan_speed": [
+		"60"
+	],
+	"temperature_vitrification": [
+		"200"
+	],
+	"textured_plate_temp": [
+		"60"
+	],
+	"textured_plate_temp_initial_layer": [
+		"60"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone PA @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone PA @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Eryone PA @System",
+	"inherits": "Eryone PA @base",
+	"from": "system",
+	"setting_id": "EFSA71",
+	"filament_id": "EFL71",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone PA @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone PA @base.json
@@ -1,0 +1,240 @@
+{
+	"type": "filament",
+	"name": "Eryone PA @base",
+	"inherits": "Eryone Standard PLA",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"activate_chamber_temp_control": [
+		"0"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"chamber_temperature": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"compatible_prints": [],
+	"compatible_prints_condition": "",
+	"complete_print_exhaust_fan_speed": [
+		"80"
+	],
+	"cool_plate_temp": [
+		"60"
+	],
+	"cool_plate_temp_initial_layer": [
+		"60"
+	],
+	"default_filament_colour": [
+		""
+	],
+	"during_print_exhaust_fan_speed": [
+		"60"
+	],
+	"enable_overhang_bridge_fan": [
+		"1"
+	],
+	"enable_pressure_advance": [
+		"0"
+	],
+	"eng_plate_temp": [
+		"60"
+	],
+	"eng_plate_temp_initial_layer": [
+		"60"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"fan_max_speed": [
+		"20"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"filament_cooling_final_speed": [
+		"3.4"
+	],
+	"filament_cooling_initial_speed": [
+		"2.2"
+	],
+	"filament_cooling_moves": [
+		"4"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \nSET_FAN_SPEED FAN=filter_fan SPEED=0"
+	],
+	"filament_flow_ratio": [
+		"0.92"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_loading_speed": [
+		"28"
+	],
+	"filament_loading_speed_start": [
+		"3"
+	],
+	"filament_max_volumetric_speed": [
+		"8"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_multitool_ramming": [
+		"0"
+	],
+	"filament_multitool_ramming_flow": [
+		"10"
+	],
+	"filament_multitool_ramming_volume": [
+		"10"
+	],
+	"filament_notes": [
+		"brim width >= 20;"
+	],
+	"filament_ramming_parameters": [
+		"120 100 6.6 6.8 7.2 7.6 7.9 8.2 8.7 9.4 9.9 10.0| 0.05 6.6 0.45 6.8 0.95 7.8 1.45 8.3 1.95 9.7 2.45 10 2.95 7.6 3.45 7.6 3.95 7.6 4.45 7.6 4.95 7.6"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_lift_above": [
+		"nil"
+	],
+	"filament_retract_lift_below": [
+		"nil"
+	],
+	"filament_retract_lift_enforce": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"1"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		"Eryone PA"
+	],
+	"filament_shrink": [
+		"100%"
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\nSET_FAN_SPEED FAN=filter_fan SPEED=0"
+	],
+	"filament_toolchange_delay": [
+		"0"
+	],
+	"filament_type": [
+		"PA"
+	],
+	"filament_unloading_speed": [
+		"90"
+	],
+	"filament_unloading_speed_start": [
+		"100"
+	],
+	"filament_vendor": [
+		"Eryone"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"115"
+	],
+	"hot_plate_temp_initial_layer": [
+		"115"
+	],
+	"nozzle_temperature": [
+		"265"
+	],
+	"nozzle_temperature_initial_layer": [
+		"270"
+	],
+	"nozzle_temperature_range_high": [
+		"280"
+	],
+	"nozzle_temperature_range_low": [
+		"240"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"pressure_advance": [
+		"0.02"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"0"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"10"
+	],
+	"slow_down_min_speed": [
+		"15"
+	],
+	"support_material_interface_fan_speed": [
+		"60"
+	],
+	"temperature_vitrification": [
+		"200"
+	],
+	"textured_plate_temp": [
+		"60"
+	],
+	"textured_plate_temp_initial_layer": [
+		"60"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone PA-CF @0.2 nozzle @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone PA-CF @0.2 nozzle @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Eryone PA-CF @0.2 nozzle @System",
+	"inherits": "Eryone PA-CF @0.2 nozzle @base",
+	"from": "system",
+	"setting_id": "",
+	"filament_id": "",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone PA-CF @0.2 nozzle @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone PA-CF @0.2 nozzle @base.json
@@ -1,0 +1,240 @@
+{
+	"type": "filament",
+	"name": "Eryone PA-CF @0.2 nozzle @base",
+	"inherits": "Eryone PA-CF",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"activate_chamber_temp_control": [
+		"0"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"chamber_temperature": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"compatible_prints": [],
+	"compatible_prints_condition": "",
+	"complete_print_exhaust_fan_speed": [
+		"80"
+	],
+	"cool_plate_temp": [
+		"60"
+	],
+	"cool_plate_temp_initial_layer": [
+		"60"
+	],
+	"default_filament_colour": [
+		""
+	],
+	"during_print_exhaust_fan_speed": [
+		"60"
+	],
+	"enable_overhang_bridge_fan": [
+		"1"
+	],
+	"enable_pressure_advance": [
+		"0"
+	],
+	"eng_plate_temp": [
+		"60"
+	],
+	"eng_plate_temp_initial_layer": [
+		"60"
+	],
+	"fan_cooling_layer_time": [
+		"20"
+	],
+	"fan_max_speed": [
+		"40"
+	],
+	"fan_min_speed": [
+		"20"
+	],
+	"filament_cooling_final_speed": [
+		"3.4"
+	],
+	"filament_cooling_initial_speed": [
+		"2.2"
+	],
+	"filament_cooling_moves": [
+		"4"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \nSET_FAN_SPEED FAN=filter_fan SPEED=0"
+	],
+	"filament_flow_ratio": [
+		"0.94"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_loading_speed": [
+		"28"
+	],
+	"filament_loading_speed_start": [
+		"3"
+	],
+	"filament_max_volumetric_speed": [
+		"2"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_multitool_ramming": [
+		"0"
+	],
+	"filament_multitool_ramming_flow": [
+		"10"
+	],
+	"filament_multitool_ramming_volume": [
+		"10"
+	],
+	"filament_notes": [
+		""
+	],
+	"filament_ramming_parameters": [
+		"120 100 6.6 6.8 7.2 7.6 7.9 8.2 8.7 9.4 9.9 10.0| 0.05 6.6 0.45 6.8 0.95 7.8 1.45 8.3 1.95 9.7 2.45 10 2.95 7.6 3.45 7.6 3.95 7.6 4.45 7.6 4.95 7.6"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_lift_above": [
+		"nil"
+	],
+	"filament_retract_lift_below": [
+		"nil"
+	],
+	"filament_retract_lift_enforce": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"1"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		"Eryone PA-CF @0.2 nozzle"
+	],
+	"filament_shrink": [
+		"100%"
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\nSET_FAN_SPEED FAN=filter_fan SPEED=0"
+	],
+	"filament_toolchange_delay": [
+		"0"
+	],
+	"filament_type": [
+		"PA-CF"
+	],
+	"filament_unloading_speed": [
+		"90"
+	],
+	"filament_unloading_speed_start": [
+		"100"
+	],
+	"filament_vendor": [
+		"Eryone"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"115"
+	],
+	"hot_plate_temp_initial_layer": [
+		"115"
+	],
+	"nozzle_temperature": [
+		"265"
+	],
+	"nozzle_temperature_initial_layer": [
+		"275"
+	],
+	"nozzle_temperature_range_high": [
+		"280"
+	],
+	"nozzle_temperature_range_low": [
+		"240"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"pressure_advance": [
+		"0.02"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"0"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"10"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"support_material_interface_fan_speed": [
+		"60"
+	],
+	"temperature_vitrification": [
+		"200"
+	],
+	"textured_plate_temp": [
+		"60"
+	],
+	"textured_plate_temp_initial_layer": [
+		"60"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone PA-CF @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone PA-CF @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Eryone PA-CF @System",
+	"inherits": "Eryone PA-CF @base",
+	"from": "system",
+	"setting_id": "EFSA72",
+	"filament_id": "EFL72",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone PA-CF @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone PA-CF @base.json
@@ -1,0 +1,240 @@
+{
+	"type": "filament",
+	"name": "Eryone PA-CF @base",
+	"inherits": "Eryone Standard PLA",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"activate_chamber_temp_control": [
+		"0"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"chamber_temperature": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"compatible_prints": [],
+	"compatible_prints_condition": "",
+	"complete_print_exhaust_fan_speed": [
+		"80"
+	],
+	"cool_plate_temp": [
+		"60"
+	],
+	"cool_plate_temp_initial_layer": [
+		"60"
+	],
+	"default_filament_colour": [
+		""
+	],
+	"during_print_exhaust_fan_speed": [
+		"60"
+	],
+	"enable_overhang_bridge_fan": [
+		"1"
+	],
+	"enable_pressure_advance": [
+		"0"
+	],
+	"eng_plate_temp": [
+		"60"
+	],
+	"eng_plate_temp_initial_layer": [
+		"60"
+	],
+	"fan_cooling_layer_time": [
+		"20"
+	],
+	"fan_max_speed": [
+		"40"
+	],
+	"fan_min_speed": [
+		"20"
+	],
+	"filament_cooling_final_speed": [
+		"3.4"
+	],
+	"filament_cooling_initial_speed": [
+		"2.2"
+	],
+	"filament_cooling_moves": [
+		"4"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \nSET_FAN_SPEED FAN=filter_fan SPEED=0"
+	],
+	"filament_flow_ratio": [
+		"0.94"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_loading_speed": [
+		"28"
+	],
+	"filament_loading_speed_start": [
+		"3"
+	],
+	"filament_max_volumetric_speed": [
+		"8"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_multitool_ramming": [
+		"0"
+	],
+	"filament_multitool_ramming_flow": [
+		"10"
+	],
+	"filament_multitool_ramming_volume": [
+		"10"
+	],
+	"filament_notes": [
+		""
+	],
+	"filament_ramming_parameters": [
+		"120 100 6.6 6.8 7.2 7.6 7.9 8.2 8.7 9.4 9.9 10.0| 0.05 6.6 0.45 6.8 0.95 7.8 1.45 8.3 1.95 9.7 2.45 10 2.95 7.6 3.45 7.6 3.95 7.6 4.45 7.6 4.95 7.6"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_lift_above": [
+		"nil"
+	],
+	"filament_retract_lift_below": [
+		"nil"
+	],
+	"filament_retract_lift_enforce": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"1"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		"Eryone PA-CF"
+	],
+	"filament_shrink": [
+		"100%"
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\nSET_FAN_SPEED FAN=filter_fan SPEED=0"
+	],
+	"filament_toolchange_delay": [
+		"0"
+	],
+	"filament_type": [
+		"PA-CF"
+	],
+	"filament_unloading_speed": [
+		"90"
+	],
+	"filament_unloading_speed_start": [
+		"100"
+	],
+	"filament_vendor": [
+		"Eryone"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"115"
+	],
+	"hot_plate_temp_initial_layer": [
+		"115"
+	],
+	"nozzle_temperature": [
+		"265"
+	],
+	"nozzle_temperature_initial_layer": [
+		"275"
+	],
+	"nozzle_temperature_range_high": [
+		"280"
+	],
+	"nozzle_temperature_range_low": [
+		"240"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"pressure_advance": [
+		"0.02"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"0"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"10"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"support_material_interface_fan_speed": [
+		"60"
+	],
+	"temperature_vitrification": [
+		"200"
+	],
+	"textured_plate_temp": [
+		"60"
+	],
+	"textured_plate_temp_initial_layer": [
+		"60"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone PA-GF @0.2 nozzle @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone PA-GF @0.2 nozzle @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Eryone PA-GF @0.2 nozzle @System",
+	"inherits": "Eryone PA-GF @0.2 nozzle @base",
+	"from": "system",
+	"setting_id": "",
+	"filament_id": "",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone PA-GF @0.2 nozzle @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone PA-GF @0.2 nozzle @base.json
@@ -1,0 +1,240 @@
+{
+	"type": "filament",
+	"name": "Eryone PA-GF @0.2 nozzle @base",
+	"inherits": "Eryone PA-GF",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"activate_chamber_temp_control": [
+		"0"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"chamber_temperature": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"compatible_prints": [],
+	"compatible_prints_condition": "",
+	"complete_print_exhaust_fan_speed": [
+		"80"
+	],
+	"cool_plate_temp": [
+		"60"
+	],
+	"cool_plate_temp_initial_layer": [
+		"60"
+	],
+	"default_filament_colour": [
+		""
+	],
+	"during_print_exhaust_fan_speed": [
+		"60"
+	],
+	"enable_overhang_bridge_fan": [
+		"1"
+	],
+	"enable_pressure_advance": [
+		"0"
+	],
+	"eng_plate_temp": [
+		"60"
+	],
+	"eng_plate_temp_initial_layer": [
+		"60"
+	],
+	"fan_cooling_layer_time": [
+		"20"
+	],
+	"fan_max_speed": [
+		"40"
+	],
+	"fan_min_speed": [
+		"20"
+	],
+	"filament_cooling_final_speed": [
+		"3.4"
+	],
+	"filament_cooling_initial_speed": [
+		"2.2"
+	],
+	"filament_cooling_moves": [
+		"4"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \nSET_FAN_SPEED FAN=filter_fan SPEED=0"
+	],
+	"filament_flow_ratio": [
+		"0.94"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_loading_speed": [
+		"28"
+	],
+	"filament_loading_speed_start": [
+		"3"
+	],
+	"filament_max_volumetric_speed": [
+		"2"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_multitool_ramming": [
+		"0"
+	],
+	"filament_multitool_ramming_flow": [
+		"10"
+	],
+	"filament_multitool_ramming_volume": [
+		"10"
+	],
+	"filament_notes": [
+		""
+	],
+	"filament_ramming_parameters": [
+		"120 100 6.6 6.8 7.2 7.6 7.9 8.2 8.7 9.4 9.9 10.0| 0.05 6.6 0.45 6.8 0.95 7.8 1.45 8.3 1.95 9.7 2.45 10 2.95 7.6 3.45 7.6 3.95 7.6 4.45 7.6 4.95 7.6"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_lift_above": [
+		"nil"
+	],
+	"filament_retract_lift_below": [
+		"nil"
+	],
+	"filament_retract_lift_enforce": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"1"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		"Eryone PA-GF @0.2 nozzle"
+	],
+	"filament_shrink": [
+		"100%"
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\nSET_FAN_SPEED FAN=filter_fan SPEED=0"
+	],
+	"filament_toolchange_delay": [
+		"0"
+	],
+	"filament_type": [
+		"PA-GF"
+	],
+	"filament_unloading_speed": [
+		"90"
+	],
+	"filament_unloading_speed_start": [
+		"100"
+	],
+	"filament_vendor": [
+		"Eryone"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"110"
+	],
+	"hot_plate_temp_initial_layer": [
+		"110"
+	],
+	"nozzle_temperature": [
+		"270"
+	],
+	"nozzle_temperature_initial_layer": [
+		"280"
+	],
+	"nozzle_temperature_range_high": [
+		"280"
+	],
+	"nozzle_temperature_range_low": [
+		"240"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"pressure_advance": [
+		"0.02"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"0"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"10"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"support_material_interface_fan_speed": [
+		"60"
+	],
+	"temperature_vitrification": [
+		"200"
+	],
+	"textured_plate_temp": [
+		"60"
+	],
+	"textured_plate_temp_initial_layer": [
+		"60"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone PA-GF @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone PA-GF @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Eryone PA-GF @System",
+	"inherits": "Eryone PA-GF @base",
+	"from": "system",
+	"setting_id": "EFSA73",
+	"filament_id": "EFL73",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone PA-GF @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone PA-GF @base.json
@@ -1,0 +1,240 @@
+{
+	"type": "filament",
+	"name": "Eryone PA-GF @base",
+	"inherits": "Eryone Standard PLA",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"activate_chamber_temp_control": [
+		"0"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"chamber_temperature": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"compatible_prints": [],
+	"compatible_prints_condition": "",
+	"complete_print_exhaust_fan_speed": [
+		"80"
+	],
+	"cool_plate_temp": [
+		"60"
+	],
+	"cool_plate_temp_initial_layer": [
+		"60"
+	],
+	"default_filament_colour": [
+		""
+	],
+	"during_print_exhaust_fan_speed": [
+		"60"
+	],
+	"enable_overhang_bridge_fan": [
+		"1"
+	],
+	"enable_pressure_advance": [
+		"0"
+	],
+	"eng_plate_temp": [
+		"60"
+	],
+	"eng_plate_temp_initial_layer": [
+		"60"
+	],
+	"fan_cooling_layer_time": [
+		"20"
+	],
+	"fan_max_speed": [
+		"40"
+	],
+	"fan_min_speed": [
+		"20"
+	],
+	"filament_cooling_final_speed": [
+		"3.4"
+	],
+	"filament_cooling_initial_speed": [
+		"2.2"
+	],
+	"filament_cooling_moves": [
+		"4"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \nSET_FAN_SPEED FAN=filter_fan SPEED=0"
+	],
+	"filament_flow_ratio": [
+		"0.94"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_loading_speed": [
+		"28"
+	],
+	"filament_loading_speed_start": [
+		"3"
+	],
+	"filament_max_volumetric_speed": [
+		"12"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_multitool_ramming": [
+		"0"
+	],
+	"filament_multitool_ramming_flow": [
+		"10"
+	],
+	"filament_multitool_ramming_volume": [
+		"10"
+	],
+	"filament_notes": [
+		""
+	],
+	"filament_ramming_parameters": [
+		"120 100 6.6 6.8 7.2 7.6 7.9 8.2 8.7 9.4 9.9 10.0| 0.05 6.6 0.45 6.8 0.95 7.8 1.45 8.3 1.95 9.7 2.45 10 2.95 7.6 3.45 7.6 3.95 7.6 4.45 7.6 4.95 7.6"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_lift_above": [
+		"nil"
+	],
+	"filament_retract_lift_below": [
+		"nil"
+	],
+	"filament_retract_lift_enforce": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"1"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		"Eryone PA-GF"
+	],
+	"filament_shrink": [
+		"100%"
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\nSET_FAN_SPEED FAN=filter_fan SPEED=0"
+	],
+	"filament_toolchange_delay": [
+		"0"
+	],
+	"filament_type": [
+		"PA-GF"
+	],
+	"filament_unloading_speed": [
+		"90"
+	],
+	"filament_unloading_speed_start": [
+		"100"
+	],
+	"filament_vendor": [
+		"Eryone"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"110"
+	],
+	"hot_plate_temp_initial_layer": [
+		"110"
+	],
+	"nozzle_temperature": [
+		"270"
+	],
+	"nozzle_temperature_initial_layer": [
+		"280"
+	],
+	"nozzle_temperature_range_high": [
+		"280"
+	],
+	"nozzle_temperature_range_low": [
+		"240"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"pressure_advance": [
+		"0.02"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"0"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"10"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"support_material_interface_fan_speed": [
+		"60"
+	],
+	"temperature_vitrification": [
+		"200"
+	],
+	"textured_plate_temp": [
+		"60"
+	],
+	"textured_plate_temp_initial_layer": [
+		"60"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone PETG @0.2 nozzle @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone PETG @0.2 nozzle @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Eryone PETG @0.2 nozzle @System",
+	"inherits": "Eryone PETG @0.2 nozzle @base",
+	"from": "system",
+	"setting_id": "",
+	"filament_id": "",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone PETG @0.2 nozzle @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone PETG @0.2 nozzle @base.json
@@ -1,0 +1,240 @@
+{
+	"type": "filament",
+	"name": "Eryone PETG @0.2 nozzle @base",
+	"inherits": "Eryone PETG",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"activate_chamber_temp_control": [
+		"0"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"chamber_temperature": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"2"
+	],
+	"compatible_prints": [],
+	"compatible_prints_condition": "",
+	"complete_print_exhaust_fan_speed": [
+		"80"
+	],
+	"cool_plate_temp": [
+		"60"
+	],
+	"cool_plate_temp_initial_layer": [
+		"60"
+	],
+	"default_filament_colour": [
+		""
+	],
+	"during_print_exhaust_fan_speed": [
+		"60"
+	],
+	"enable_overhang_bridge_fan": [
+		"1"
+	],
+	"enable_pressure_advance": [
+		"0"
+	],
+	"eng_plate_temp": [
+		"60"
+	],
+	"eng_plate_temp_initial_layer": [
+		"60"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"90"
+	],
+	"filament_cooling_final_speed": [
+		"3.4"
+	],
+	"filament_cooling_initial_speed": [
+		"2.2"
+	],
+	"filament_cooling_moves": [
+		"4"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \nSET_FAN_SPEED FAN=filter_fan SPEED=0\n"
+	],
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_loading_speed": [
+		"28"
+	],
+	"filament_loading_speed_start": [
+		"3"
+	],
+	"filament_max_volumetric_speed": [
+		"2"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_multitool_ramming": [
+		"0"
+	],
+	"filament_multitool_ramming_flow": [
+		"10"
+	],
+	"filament_multitool_ramming_volume": [
+		"10"
+	],
+	"filament_notes": [
+		""
+	],
+	"filament_ramming_parameters": [
+		"120 100 6.6 6.8 7.2 7.6 7.9 8.2 8.7 9.4 9.9 10.0| 0.05 6.6 0.45 6.8 0.95 7.8 1.45 8.3 1.95 9.7 2.45 10 2.95 7.6 3.45 7.6 3.95 7.6 4.45 7.6 4.95 7.6"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_lift_above": [
+		"nil"
+	],
+	"filament_retract_lift_below": [
+		"nil"
+	],
+	"filament_retract_lift_enforce": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		"Eryone PETG @0.2 nozzle"
+	],
+	"filament_shrink": [
+		"100%"
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\nSET_FAN_SPEED FAN=filter_fan SPEED=1"
+	],
+	"filament_toolchange_delay": [
+		"0"
+	],
+	"filament_type": [
+		"PETG"
+	],
+	"filament_unloading_speed": [
+		"90"
+	],
+	"filament_unloading_speed_start": [
+		"100"
+	],
+	"filament_vendor": [
+		"Eryone"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"75"
+	],
+	"hot_plate_temp_initial_layer": [
+		"75"
+	],
+	"nozzle_temperature": [
+		"245"
+	],
+	"nozzle_temperature_initial_layer": [
+		"245"
+	],
+	"nozzle_temperature_range_high": [
+		"270"
+	],
+	"nozzle_temperature_range_low": [
+		"225"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"pressure_advance": [
+		"0.02"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"0"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"7"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"support_material_interface_fan_speed": [
+		"-1"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"textured_plate_temp": [
+		"60"
+	],
+	"textured_plate_temp_initial_layer": [
+		"60"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone PETG @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone PETG @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Eryone PETG @System",
+	"inherits": "Eryone PETG @base",
+	"from": "system",
+	"setting_id": "EFSA03",
+	"filament_id": "EFL93",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone PETG @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone PETG @base.json
@@ -1,0 +1,240 @@
+{
+	"type": "filament",
+	"name": "Eryone PETG @base",
+	"inherits": "Eryone Standard PLA",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"activate_chamber_temp_control": [
+		"0"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"chamber_temperature": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"2"
+	],
+	"compatible_prints": [],
+	"compatible_prints_condition": "",
+	"complete_print_exhaust_fan_speed": [
+		"80"
+	],
+	"cool_plate_temp": [
+		"60"
+	],
+	"cool_plate_temp_initial_layer": [
+		"60"
+	],
+	"default_filament_colour": [
+		""
+	],
+	"during_print_exhaust_fan_speed": [
+		"60"
+	],
+	"enable_overhang_bridge_fan": [
+		"1"
+	],
+	"enable_pressure_advance": [
+		"0"
+	],
+	"eng_plate_temp": [
+		"60"
+	],
+	"eng_plate_temp_initial_layer": [
+		"60"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"90"
+	],
+	"filament_cooling_final_speed": [
+		"3.4"
+	],
+	"filament_cooling_initial_speed": [
+		"2.2"
+	],
+	"filament_cooling_moves": [
+		"4"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \nSET_FAN_SPEED FAN=filter_fan SPEED=0\n"
+	],
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_loading_speed": [
+		"28"
+	],
+	"filament_loading_speed_start": [
+		"3"
+	],
+	"filament_max_volumetric_speed": [
+		"14"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_multitool_ramming": [
+		"0"
+	],
+	"filament_multitool_ramming_flow": [
+		"10"
+	],
+	"filament_multitool_ramming_volume": [
+		"10"
+	],
+	"filament_notes": [
+		""
+	],
+	"filament_ramming_parameters": [
+		"120 100 6.6 6.8 7.2 7.6 7.9 8.2 8.7 9.4 9.9 10.0| 0.05 6.6 0.45 6.8 0.95 7.8 1.45 8.3 1.95 9.7 2.45 10 2.95 7.6 3.45 7.6 3.95 7.6 4.45 7.6 4.95 7.6"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_lift_above": [
+		"nil"
+	],
+	"filament_retract_lift_below": [
+		"nil"
+	],
+	"filament_retract_lift_enforce": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		"Eryone PETG"
+	],
+	"filament_shrink": [
+		"100%"
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\nSET_FAN_SPEED FAN=filter_fan SPEED=1"
+	],
+	"filament_toolchange_delay": [
+		"0"
+	],
+	"filament_type": [
+		"PETG"
+	],
+	"filament_unloading_speed": [
+		"90"
+	],
+	"filament_unloading_speed_start": [
+		"100"
+	],
+	"filament_vendor": [
+		"Eryone"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"75"
+	],
+	"hot_plate_temp_initial_layer": [
+		"75"
+	],
+	"nozzle_temperature": [
+		"245"
+	],
+	"nozzle_temperature_initial_layer": [
+		"245"
+	],
+	"nozzle_temperature_range_high": [
+		"270"
+	],
+	"nozzle_temperature_range_low": [
+		"225"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"pressure_advance": [
+		"0.02"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"0"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"7"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"support_material_interface_fan_speed": [
+		"-1"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"textured_plate_temp": [
+		"60"
+	],
+	"textured_plate_temp_initial_layer": [
+		"60"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone PETG-CF @0.2 nozzle @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone PETG-CF @0.2 nozzle @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Eryone PETG-CF @0.2 nozzle @System",
+	"inherits": "Eryone PETG-CF @0.2 nozzle @base",
+	"from": "system",
+	"setting_id": "",
+	"filament_id": "",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone PETG-CF @0.2 nozzle @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone PETG-CF @0.2 nozzle @base.json
@@ -1,0 +1,240 @@
+{
+	"type": "filament",
+	"name": "Eryone PETG-CF @0.2 nozzle @base",
+	"inherits": "Eryone PETG-CF",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"activate_chamber_temp_control": [
+		"0"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"chamber_temperature": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"compatible_prints": [],
+	"compatible_prints_condition": "",
+	"complete_print_exhaust_fan_speed": [
+		"80"
+	],
+	"cool_plate_temp": [
+		"60"
+	],
+	"cool_plate_temp_initial_layer": [
+		"60"
+	],
+	"default_filament_colour": [
+		""
+	],
+	"during_print_exhaust_fan_speed": [
+		"60"
+	],
+	"enable_overhang_bridge_fan": [
+		"1"
+	],
+	"enable_pressure_advance": [
+		"0"
+	],
+	"eng_plate_temp": [
+		"60"
+	],
+	"eng_plate_temp_initial_layer": [
+		"60"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"fan_max_speed": [
+		"90"
+	],
+	"fan_min_speed": [
+		"50"
+	],
+	"filament_cooling_final_speed": [
+		"3.4"
+	],
+	"filament_cooling_initial_speed": [
+		"2.2"
+	],
+	"filament_cooling_moves": [
+		"4"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \nSET_FAN_SPEED FAN=filter_fan SPEED=0\n"
+	],
+	"filament_flow_ratio": [
+		"0.94"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_loading_speed": [
+		"28"
+	],
+	"filament_loading_speed_start": [
+		"3"
+	],
+	"filament_max_volumetric_speed": [
+		"2"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_multitool_ramming": [
+		"0"
+	],
+	"filament_multitool_ramming_flow": [
+		"10"
+	],
+	"filament_multitool_ramming_volume": [
+		"10"
+	],
+	"filament_notes": [
+		""
+	],
+	"filament_ramming_parameters": [
+		"120 100 6.6 6.8 7.2 7.6 7.9 8.2 8.7 9.4 9.9 10.0| 0.05 6.6 0.45 6.8 0.95 7.8 1.45 8.3 1.95 9.7 2.45 10 2.95 7.6 3.45 7.6 3.95 7.6 4.45 7.6 4.95 7.6"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_lift_above": [
+		"nil"
+	],
+	"filament_retract_lift_below": [
+		"nil"
+	],
+	"filament_retract_lift_enforce": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"1"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		"Eryone PETG-CF @0.2 nozzle"
+	],
+	"filament_shrink": [
+		"100%"
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\nSET_FAN_SPEED FAN=filter_fan SPEED=1"
+	],
+	"filament_toolchange_delay": [
+		"0"
+	],
+	"filament_type": [
+		"PETG-CF"
+	],
+	"filament_unloading_speed": [
+		"90"
+	],
+	"filament_unloading_speed_start": [
+		"100"
+	],
+	"filament_vendor": [
+		"Eryone"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"80"
+	],
+	"hot_plate_temp_initial_layer": [
+		"80"
+	],
+	"nozzle_temperature": [
+		"245"
+	],
+	"nozzle_temperature_initial_layer": [
+		"250"
+	],
+	"nozzle_temperature_range_high": [
+		"270"
+	],
+	"nozzle_temperature_range_low": [
+		"225"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"pressure_advance": [
+		"0.02"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"0"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"7"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"support_material_interface_fan_speed": [
+		"80"
+	],
+	"temperature_vitrification": [
+		"80"
+	],
+	"textured_plate_temp": [
+		"60"
+	],
+	"textured_plate_temp_initial_layer": [
+		"60"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone PETG-CF @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone PETG-CF @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Eryone PETG-CF @System",
+	"inherits": "Eryone PETG-CF @base",
+	"from": "system",
+	"setting_id": "EFSA43",
+	"filament_id": "EFL43",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone PETG-CF @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone PETG-CF @base.json
@@ -1,0 +1,240 @@
+{
+	"type": "filament",
+	"name": "Eryone PETG-CF @base",
+	"inherits": "Eryone Standard PLA",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"activate_chamber_temp_control": [
+		"0"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"chamber_temperature": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"compatible_prints": [],
+	"compatible_prints_condition": "",
+	"complete_print_exhaust_fan_speed": [
+		"80"
+	],
+	"cool_plate_temp": [
+		"60"
+	],
+	"cool_plate_temp_initial_layer": [
+		"60"
+	],
+	"default_filament_colour": [
+		""
+	],
+	"during_print_exhaust_fan_speed": [
+		"60"
+	],
+	"enable_overhang_bridge_fan": [
+		"1"
+	],
+	"enable_pressure_advance": [
+		"0"
+	],
+	"eng_plate_temp": [
+		"60"
+	],
+	"eng_plate_temp_initial_layer": [
+		"60"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"fan_max_speed": [
+		"90"
+	],
+	"fan_min_speed": [
+		"50"
+	],
+	"filament_cooling_final_speed": [
+		"3.4"
+	],
+	"filament_cooling_initial_speed": [
+		"2.2"
+	],
+	"filament_cooling_moves": [
+		"4"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \nSET_FAN_SPEED FAN=filter_fan SPEED=0\n"
+	],
+	"filament_flow_ratio": [
+		"0.94"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_loading_speed": [
+		"28"
+	],
+	"filament_loading_speed_start": [
+		"3"
+	],
+	"filament_max_volumetric_speed": [
+		"14"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_multitool_ramming": [
+		"0"
+	],
+	"filament_multitool_ramming_flow": [
+		"10"
+	],
+	"filament_multitool_ramming_volume": [
+		"10"
+	],
+	"filament_notes": [
+		""
+	],
+	"filament_ramming_parameters": [
+		"120 100 6.6 6.8 7.2 7.6 7.9 8.2 8.7 9.4 9.9 10.0| 0.05 6.6 0.45 6.8 0.95 7.8 1.45 8.3 1.95 9.7 2.45 10 2.95 7.6 3.45 7.6 3.95 7.6 4.45 7.6 4.95 7.6"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_lift_above": [
+		"nil"
+	],
+	"filament_retract_lift_below": [
+		"nil"
+	],
+	"filament_retract_lift_enforce": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"1"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		"Eryone PETG"
+	],
+	"filament_shrink": [
+		"100%"
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\nSET_FAN_SPEED FAN=filter_fan SPEED=1"
+	],
+	"filament_toolchange_delay": [
+		"0"
+	],
+	"filament_type": [
+		"PETG-CF"
+	],
+	"filament_unloading_speed": [
+		"90"
+	],
+	"filament_unloading_speed_start": [
+		"100"
+	],
+	"filament_vendor": [
+		"Eryone"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"80"
+	],
+	"hot_plate_temp_initial_layer": [
+		"80"
+	],
+	"nozzle_temperature": [
+		"245"
+	],
+	"nozzle_temperature_initial_layer": [
+		"250"
+	],
+	"nozzle_temperature_range_high": [
+		"270"
+	],
+	"nozzle_temperature_range_low": [
+		"225"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"pressure_advance": [
+		"0.02"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"0"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"7"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"support_material_interface_fan_speed": [
+		"80"
+	],
+	"temperature_vitrification": [
+		"80"
+	],
+	"textured_plate_temp": [
+		"60"
+	],
+	"textured_plate_temp_initial_layer": [
+		"60"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone PLA @0.2 nozzle @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone PLA @0.2 nozzle @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Eryone PLA @0.2 nozzle @System",
+	"inherits": "Eryone PLA @0.2 nozzle @base",
+	"from": "system",
+	"setting_id": "",
+	"filament_id": "",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone PLA @0.2 nozzle @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone PLA @0.2 nozzle @base.json
@@ -1,0 +1,240 @@
+{
+	"type": "filament",
+	"name": "Eryone PLA @0.2 nozzle @base",
+	"inherits": "Eryone PLA",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"activate_chamber_temp_control": [
+		"0"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"chamber_temperature": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"compatible_prints": [],
+	"compatible_prints_condition": "",
+	"complete_print_exhaust_fan_speed": [
+		"80"
+	],
+	"cool_plate_temp": [
+		"60"
+	],
+	"cool_plate_temp_initial_layer": [
+		"60"
+	],
+	"default_filament_colour": [
+		""
+	],
+	"during_print_exhaust_fan_speed": [
+		"60"
+	],
+	"enable_overhang_bridge_fan": [
+		"1"
+	],
+	"enable_pressure_advance": [
+		"0"
+	],
+	"eng_plate_temp": [
+		"60"
+	],
+	"eng_plate_temp_initial_layer": [
+		"60"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"90"
+	],
+	"filament_cooling_final_speed": [
+		"3.4"
+	],
+	"filament_cooling_initial_speed": [
+		"2.2"
+	],
+	"filament_cooling_moves": [
+		"4"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \nSET_FAN_SPEED FAN=filter_fan SPEED=0"
+	],
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_loading_speed": [
+		"28"
+	],
+	"filament_loading_speed_start": [
+		"3"
+	],
+	"filament_max_volumetric_speed": [
+		"2"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_multitool_ramming": [
+		"0"
+	],
+	"filament_multitool_ramming_flow": [
+		"10"
+	],
+	"filament_multitool_ramming_volume": [
+		"10"
+	],
+	"filament_notes": [
+		""
+	],
+	"filament_ramming_parameters": [
+		"120 100 6.6 6.8 7.2 7.6 7.9 8.2 8.7 9.4 9.9 10.0| 0.05 6.6 0.45 6.8 0.95 7.8 1.45 8.3 1.95 9.7 2.45 10 2.95 7.6 3.45 7.6 3.95 7.6 4.45 7.6 4.95 7.6"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_lift_above": [
+		"nil"
+	],
+	"filament_retract_lift_below": [
+		"nil"
+	],
+	"filament_retract_lift_enforce": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		"Eryone PLA @0.2 nozzle"
+	],
+	"filament_shrink": [
+		"100%"
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\nSET_FAN_SPEED FAN=filter_fan SPEED=1"
+	],
+	"filament_toolchange_delay": [
+		"0"
+	],
+	"filament_type": [
+		"PLA"
+	],
+	"filament_unloading_speed": [
+		"90"
+	],
+	"filament_unloading_speed_start": [
+		"100"
+	],
+	"filament_vendor": [
+		"Eryone"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"60"
+	],
+	"hot_plate_temp_initial_layer": [
+		"60"
+	],
+	"nozzle_temperature": [
+		"220"
+	],
+	"nozzle_temperature_initial_layer": [
+		"220"
+	],
+	"nozzle_temperature_range_high": [
+		"260"
+	],
+	"nozzle_temperature_range_low": [
+		"180"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"pressure_advance": [
+		"0.02"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"0"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"4"
+	],
+	"slow_down_min_speed": [
+		"15"
+	],
+	"support_material_interface_fan_speed": [
+		"-1"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"textured_plate_temp": [
+		"60"
+	],
+	"textured_plate_temp_initial_layer": [
+		"60"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone PLA @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone PLA @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Eryone PLA @System",
+	"inherits": "Eryone PLA @base",
+	"from": "system",
+	"setting_id": "EFSA00",
+	"filament_id": "EFL90",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone PLA @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone PLA @base.json
@@ -1,0 +1,240 @@
+{
+	"type": "filament",
+	"name": "Eryone PLA @base",
+	"inherits": "Eryone Standard PLA",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"activate_chamber_temp_control": [
+		"0"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"chamber_temperature": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"compatible_prints": [],
+	"compatible_prints_condition": "",
+	"complete_print_exhaust_fan_speed": [
+		"80"
+	],
+	"cool_plate_temp": [
+		"60"
+	],
+	"cool_plate_temp_initial_layer": [
+		"60"
+	],
+	"default_filament_colour": [
+		""
+	],
+	"during_print_exhaust_fan_speed": [
+		"60"
+	],
+	"enable_overhang_bridge_fan": [
+		"1"
+	],
+	"enable_pressure_advance": [
+		"0"
+	],
+	"eng_plate_temp": [
+		"60"
+	],
+	"eng_plate_temp_initial_layer": [
+		"60"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"90"
+	],
+	"filament_cooling_final_speed": [
+		"3.4"
+	],
+	"filament_cooling_initial_speed": [
+		"2.2"
+	],
+	"filament_cooling_moves": [
+		"4"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \nSET_FAN_SPEED FAN=filter_fan SPEED=0"
+	],
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_loading_speed": [
+		"28"
+	],
+	"filament_loading_speed_start": [
+		"3"
+	],
+	"filament_max_volumetric_speed": [
+		"20"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_multitool_ramming": [
+		"0"
+	],
+	"filament_multitool_ramming_flow": [
+		"10"
+	],
+	"filament_multitool_ramming_volume": [
+		"10"
+	],
+	"filament_notes": [
+		""
+	],
+	"filament_ramming_parameters": [
+		"120 100 6.6 6.8 7.2 7.6 7.9 8.2 8.7 9.4 9.9 10.0| 0.05 6.6 0.45 6.8 0.95 7.8 1.45 8.3 1.95 9.7 2.45 10 2.95 7.6 3.45 7.6 3.95 7.6 4.45 7.6 4.95 7.6"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_lift_above": [
+		"nil"
+	],
+	"filament_retract_lift_below": [
+		"nil"
+	],
+	"filament_retract_lift_enforce": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		"Eryone PLA"
+	],
+	"filament_shrink": [
+		"100%"
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\nSET_FAN_SPEED FAN=filter_fan SPEED=1"
+	],
+	"filament_toolchange_delay": [
+		"0"
+	],
+	"filament_type": [
+		"PLA"
+	],
+	"filament_unloading_speed": [
+		"90"
+	],
+	"filament_unloading_speed_start": [
+		"100"
+	],
+	"filament_vendor": [
+		"Eryone"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"60"
+	],
+	"hot_plate_temp_initial_layer": [
+		"60"
+	],
+	"nozzle_temperature": [
+		"220"
+	],
+	"nozzle_temperature_initial_layer": [
+		"220"
+	],
+	"nozzle_temperature_range_high": [
+		"260"
+	],
+	"nozzle_temperature_range_low": [
+		"180"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"pressure_advance": [
+		"0.02"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"0"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"4"
+	],
+	"slow_down_min_speed": [
+		"15"
+	],
+	"support_material_interface_fan_speed": [
+		"-1"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"textured_plate_temp": [
+		"60"
+	],
+	"textured_plate_temp_initial_layer": [
+		"60"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone PLA-CF @0.2 nozzle @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone PLA-CF @0.2 nozzle @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Eryone PLA-CF @0.2 nozzle @System",
+	"inherits": "Eryone PLA-CF @0.2 nozzle @base",
+	"from": "system",
+	"setting_id": "",
+	"filament_id": "",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone PLA-CF @0.2 nozzle @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone PLA-CF @0.2 nozzle @base.json
@@ -1,0 +1,240 @@
+{
+	"type": "filament",
+	"name": "Eryone PLA-CF @0.2 nozzle @base",
+	"inherits": "Eryone PLA-CF",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"activate_chamber_temp_control": [
+		"0"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"chamber_temperature": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"compatible_prints": [],
+	"compatible_prints_condition": "",
+	"complete_print_exhaust_fan_speed": [
+		"80"
+	],
+	"cool_plate_temp": [
+		"60"
+	],
+	"cool_plate_temp_initial_layer": [
+		"60"
+	],
+	"default_filament_colour": [
+		""
+	],
+	"during_print_exhaust_fan_speed": [
+		"60"
+	],
+	"enable_overhang_bridge_fan": [
+		"1"
+	],
+	"enable_pressure_advance": [
+		"0"
+	],
+	"eng_plate_temp": [
+		"60"
+	],
+	"eng_plate_temp_initial_layer": [
+		"60"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"filament_cooling_final_speed": [
+		"3.4"
+	],
+	"filament_cooling_initial_speed": [
+		"2.2"
+	],
+	"filament_cooling_moves": [
+		"4"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \nSET_FAN_SPEED FAN=filter_fan SPEED=0"
+	],
+	"filament_flow_ratio": [
+		"0.95"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_loading_speed": [
+		"28"
+	],
+	"filament_loading_speed_start": [
+		"3"
+	],
+	"filament_max_volumetric_speed": [
+		"2"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_multitool_ramming": [
+		"0"
+	],
+	"filament_multitool_ramming_flow": [
+		"10"
+	],
+	"filament_multitool_ramming_volume": [
+		"10"
+	],
+	"filament_notes": [
+		""
+	],
+	"filament_ramming_parameters": [
+		"120 100 6.6 6.8 7.2 7.6 7.9 8.2 8.7 9.4 9.9 10.0| 0.05 6.6 0.45 6.8 0.95 7.8 1.45 8.3 1.95 9.7 2.45 10 2.95 7.6 3.45 7.6 3.95 7.6 4.45 7.6 4.95 7.6"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_lift_above": [
+		"nil"
+	],
+	"filament_retract_lift_below": [
+		"nil"
+	],
+	"filament_retract_lift_enforce": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"1"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		"Eryone PLA-CF @0.2 nozzle"
+	],
+	"filament_shrink": [
+		"100%"
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\nSET_FAN_SPEED FAN=filter_fan SPEED=1"
+	],
+	"filament_toolchange_delay": [
+		"0"
+	],
+	"filament_type": [
+		"PLA-CF"
+	],
+	"filament_unloading_speed": [
+		"90"
+	],
+	"filament_unloading_speed_start": [
+		"100"
+	],
+	"filament_vendor": [
+		"Eryone"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"55"
+	],
+	"hot_plate_temp_initial_layer": [
+		"55"
+	],
+	"nozzle_temperature": [
+		"225"
+	],
+	"nozzle_temperature_initial_layer": [
+		"230"
+	],
+	"nozzle_temperature_range_high": [
+		"250"
+	],
+	"nozzle_temperature_range_low": [
+		"180"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"pressure_advance": [
+		"0.02"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"0"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"7"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"support_material_interface_fan_speed": [
+		"100"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"textured_plate_temp": [
+		"60"
+	],
+	"textured_plate_temp_initial_layer": [
+		"60"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone PLA-CF @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone PLA-CF @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Eryone PLA-CF @System",
+	"inherits": "Eryone PLA-CF @base",
+	"from": "system",
+	"setting_id": "EFSA40",
+	"filament_id": "EFL40",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone PLA-CF @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone PLA-CF @base.json
@@ -1,0 +1,240 @@
+{
+	"type": "filament",
+	"name": "Eryone PLA-CF @base",
+	"inherits": "Eryone Standard PLA",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"activate_chamber_temp_control": [
+		"0"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"chamber_temperature": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"compatible_prints": [],
+	"compatible_prints_condition": "",
+	"complete_print_exhaust_fan_speed": [
+		"80"
+	],
+	"cool_plate_temp": [
+		"60"
+	],
+	"cool_plate_temp_initial_layer": [
+		"60"
+	],
+	"default_filament_colour": [
+		""
+	],
+	"during_print_exhaust_fan_speed": [
+		"60"
+	],
+	"enable_overhang_bridge_fan": [
+		"1"
+	],
+	"enable_pressure_advance": [
+		"0"
+	],
+	"eng_plate_temp": [
+		"60"
+	],
+	"eng_plate_temp_initial_layer": [
+		"60"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"filament_cooling_final_speed": [
+		"3.4"
+	],
+	"filament_cooling_initial_speed": [
+		"2.2"
+	],
+	"filament_cooling_moves": [
+		"4"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \nSET_FAN_SPEED FAN=filter_fan SPEED=0"
+	],
+	"filament_flow_ratio": [
+		"0.95"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_loading_speed": [
+		"28"
+	],
+	"filament_loading_speed_start": [
+		"3"
+	],
+	"filament_max_volumetric_speed": [
+		"15"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_multitool_ramming": [
+		"0"
+	],
+	"filament_multitool_ramming_flow": [
+		"10"
+	],
+	"filament_multitool_ramming_volume": [
+		"10"
+	],
+	"filament_notes": [
+		""
+	],
+	"filament_ramming_parameters": [
+		"120 100 6.6 6.8 7.2 7.6 7.9 8.2 8.7 9.4 9.9 10.0| 0.05 6.6 0.45 6.8 0.95 7.8 1.45 8.3 1.95 9.7 2.45 10 2.95 7.6 3.45 7.6 3.95 7.6 4.45 7.6 4.95 7.6"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_lift_above": [
+		"nil"
+	],
+	"filament_retract_lift_below": [
+		"nil"
+	],
+	"filament_retract_lift_enforce": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"1"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		"Eryone PLA-CF"
+	],
+	"filament_shrink": [
+		"100%"
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\nSET_FAN_SPEED FAN=filter_fan SPEED=1"
+	],
+	"filament_toolchange_delay": [
+		"0"
+	],
+	"filament_type": [
+		"PLA-CF"
+	],
+	"filament_unloading_speed": [
+		"90"
+	],
+	"filament_unloading_speed_start": [
+		"100"
+	],
+	"filament_vendor": [
+		"Eryone"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"55"
+	],
+	"hot_plate_temp_initial_layer": [
+		"55"
+	],
+	"nozzle_temperature": [
+		"225"
+	],
+	"nozzle_temperature_initial_layer": [
+		"230"
+	],
+	"nozzle_temperature_range_high": [
+		"250"
+	],
+	"nozzle_temperature_range_low": [
+		"180"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"pressure_advance": [
+		"0.02"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"0"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"7"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"support_material_interface_fan_speed": [
+		"100"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"textured_plate_temp": [
+		"60"
+	],
+	"textured_plate_temp_initial_layer": [
+		"60"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone PP @0.2 nozzle @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone PP @0.2 nozzle @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Eryone PP @0.2 nozzle @System",
+	"inherits": "Eryone PP @0.2 nozzle @base",
+	"from": "system",
+	"setting_id": "",
+	"filament_id": "",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone PP @0.2 nozzle @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone PP @0.2 nozzle @base.json
@@ -1,0 +1,240 @@
+{
+	"type": "filament",
+	"name": "Eryone PP @0.2 nozzle @base",
+	"inherits": "Eryone PP",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"activate_chamber_temp_control": [
+		"0"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"chamber_temperature": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"compatible_prints": [],
+	"compatible_prints_condition": "",
+	"complete_print_exhaust_fan_speed": [
+		"80"
+	],
+	"cool_plate_temp": [
+		"60"
+	],
+	"cool_plate_temp_initial_layer": [
+		"60"
+	],
+	"default_filament_colour": [
+		""
+	],
+	"during_print_exhaust_fan_speed": [
+		"60"
+	],
+	"enable_overhang_bridge_fan": [
+		"1"
+	],
+	"enable_pressure_advance": [
+		"0"
+	],
+	"eng_plate_temp": [
+		"60"
+	],
+	"eng_plate_temp_initial_layer": [
+		"60"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"fan_max_speed": [
+		"35"
+	],
+	"fan_min_speed": [
+		"20"
+	],
+	"filament_cooling_final_speed": [
+		"3.4"
+	],
+	"filament_cooling_initial_speed": [
+		"2.2"
+	],
+	"filament_cooling_moves": [
+		"4"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \nSET_FAN_SPEED FAN=filter_fan SPEED=0"
+	],
+	"filament_flow_ratio": [
+		"0.95"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_loading_speed": [
+		"28"
+	],
+	"filament_loading_speed_start": [
+		"3"
+	],
+	"filament_max_volumetric_speed": [
+		"2"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_multitool_ramming": [
+		"0"
+	],
+	"filament_multitool_ramming_flow": [
+		"10"
+	],
+	"filament_multitool_ramming_volume": [
+		"10"
+	],
+	"filament_notes": [
+		"Printing platform glue spraying"
+	],
+	"filament_ramming_parameters": [
+		"120 100 6.6 6.8 7.2 7.6 7.9 8.2 8.7 9.4 9.9 10.0| 0.05 6.6 0.45 6.8 0.95 7.8 1.45 8.3 1.95 9.7 2.45 10 2.95 7.6 3.45 7.6 3.95 7.6 4.45 7.6 4.95 7.6"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_lift_above": [
+		"nil"
+	],
+	"filament_retract_lift_below": [
+		"nil"
+	],
+	"filament_retract_lift_enforce": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		"Eryone PP @0.2 nozzle"
+	],
+	"filament_shrink": [
+		"100%"
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\nSET_FAN_SPEED FAN=filter_fan SPEED=0"
+	],
+	"filament_toolchange_delay": [
+		"0"
+	],
+	"filament_type": [
+		"PP"
+	],
+	"filament_unloading_speed": [
+		"90"
+	],
+	"filament_unloading_speed_start": [
+		"100"
+	],
+	"filament_vendor": [
+		"Eryone"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"100"
+	],
+	"hot_plate_temp_initial_layer": [
+		"100"
+	],
+	"nozzle_temperature": [
+		"230"
+	],
+	"nozzle_temperature_initial_layer": [
+		"235"
+	],
+	"nozzle_temperature_range_high": [
+		"270"
+	],
+	"nozzle_temperature_range_low": [
+		"225"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"pressure_advance": [
+		"0.02"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"0"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"10"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"support_material_interface_fan_speed": [
+		"60"
+	],
+	"temperature_vitrification": [
+		"160"
+	],
+	"textured_plate_temp": [
+		"60"
+	],
+	"textured_plate_temp_initial_layer": [
+		"60"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone PP @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone PP @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Eryone PP @System",
+	"inherits": "Eryone PP @base",
+	"from": "system",
+	"setting_id": "EFSA43",
+	"filament_id": "EFL43",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone PP @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone PP @base.json
@@ -1,0 +1,240 @@
+{
+	"type": "filament",
+	"name": "Eryone PP @base",
+	"inherits": "Eryone Standard PLA",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"activate_chamber_temp_control": [
+		"0"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"chamber_temperature": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"compatible_prints": [],
+	"compatible_prints_condition": "",
+	"complete_print_exhaust_fan_speed": [
+		"80"
+	],
+	"cool_plate_temp": [
+		"60"
+	],
+	"cool_plate_temp_initial_layer": [
+		"60"
+	],
+	"default_filament_colour": [
+		""
+	],
+	"during_print_exhaust_fan_speed": [
+		"60"
+	],
+	"enable_overhang_bridge_fan": [
+		"1"
+	],
+	"enable_pressure_advance": [
+		"0"
+	],
+	"eng_plate_temp": [
+		"60"
+	],
+	"eng_plate_temp_initial_layer": [
+		"60"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"fan_max_speed": [
+		"35"
+	],
+	"fan_min_speed": [
+		"20"
+	],
+	"filament_cooling_final_speed": [
+		"3.4"
+	],
+	"filament_cooling_initial_speed": [
+		"2.2"
+	],
+	"filament_cooling_moves": [
+		"4"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \nSET_FAN_SPEED FAN=filter_fan SPEED=0"
+	],
+	"filament_flow_ratio": [
+		"0.95"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_loading_speed": [
+		"28"
+	],
+	"filament_loading_speed_start": [
+		"3"
+	],
+	"filament_max_volumetric_speed": [
+		"10"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_multitool_ramming": [
+		"0"
+	],
+	"filament_multitool_ramming_flow": [
+		"10"
+	],
+	"filament_multitool_ramming_volume": [
+		"10"
+	],
+	"filament_notes": [
+		"Printing platform glue spraying"
+	],
+	"filament_ramming_parameters": [
+		"120 100 6.6 6.8 7.2 7.6 7.9 8.2 8.7 9.4 9.9 10.0| 0.05 6.6 0.45 6.8 0.95 7.8 1.45 8.3 1.95 9.7 2.45 10 2.95 7.6 3.45 7.6 3.95 7.6 4.45 7.6 4.95 7.6"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_lift_above": [
+		"nil"
+	],
+	"filament_retract_lift_below": [
+		"nil"
+	],
+	"filament_retract_lift_enforce": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		"Eryone PP"
+	],
+	"filament_shrink": [
+		"100%"
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\nSET_FAN_SPEED FAN=filter_fan SPEED=0"
+	],
+	"filament_toolchange_delay": [
+		"0"
+	],
+	"filament_type": [
+		"PP"
+	],
+	"filament_unloading_speed": [
+		"90"
+	],
+	"filament_unloading_speed_start": [
+		"100"
+	],
+	"filament_vendor": [
+		"Eryone"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"100"
+	],
+	"hot_plate_temp_initial_layer": [
+		"100"
+	],
+	"nozzle_temperature": [
+		"230"
+	],
+	"nozzle_temperature_initial_layer": [
+		"235"
+	],
+	"nozzle_temperature_range_high": [
+		"270"
+	],
+	"nozzle_temperature_range_low": [
+		"225"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"pressure_advance": [
+		"0.02"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"0"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"10"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"support_material_interface_fan_speed": [
+		"60"
+	],
+	"temperature_vitrification": [
+		"160"
+	],
+	"textured_plate_temp": [
+		"60"
+	],
+	"textured_plate_temp_initial_layer": [
+		"60"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone PP-CF @0.2 nozzle @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone PP-CF @0.2 nozzle @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Eryone PP-CF @0.2 nozzle @System",
+	"inherits": "Eryone PP-CF @0.2 nozzle @base",
+	"from": "system",
+	"setting_id": "",
+	"filament_id": "",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone PP-CF @0.2 nozzle @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone PP-CF @0.2 nozzle @base.json
@@ -1,0 +1,240 @@
+{
+	"type": "filament",
+	"name": "Eryone PP-CF @0.2 nozzle @base",
+	"inherits": "Eryone PP-CF",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"activate_chamber_temp_control": [
+		"0"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"chamber_temperature": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"compatible_prints": [],
+	"compatible_prints_condition": "",
+	"complete_print_exhaust_fan_speed": [
+		"80"
+	],
+	"cool_plate_temp": [
+		"60"
+	],
+	"cool_plate_temp_initial_layer": [
+		"60"
+	],
+	"default_filament_colour": [
+		""
+	],
+	"during_print_exhaust_fan_speed": [
+		"60"
+	],
+	"enable_overhang_bridge_fan": [
+		"1"
+	],
+	"enable_pressure_advance": [
+		"0"
+	],
+	"eng_plate_temp": [
+		"60"
+	],
+	"eng_plate_temp_initial_layer": [
+		"60"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"fan_max_speed": [
+		"35"
+	],
+	"fan_min_speed": [
+		"20"
+	],
+	"filament_cooling_final_speed": [
+		"3.4"
+	],
+	"filament_cooling_initial_speed": [
+		"2.2"
+	],
+	"filament_cooling_moves": [
+		"4"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \nSET_FAN_SPEED FAN=filter_fan SPEED=0"
+	],
+	"filament_flow_ratio": [
+		"0.92"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_loading_speed": [
+		"28"
+	],
+	"filament_loading_speed_start": [
+		"3"
+	],
+	"filament_max_volumetric_speed": [
+		"2"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_multitool_ramming": [
+		"0"
+	],
+	"filament_multitool_ramming_flow": [
+		"10"
+	],
+	"filament_multitool_ramming_volume": [
+		"10"
+	],
+	"filament_notes": [
+		"Printing platform glue spraying"
+	],
+	"filament_ramming_parameters": [
+		"120 100 6.6 6.8 7.2 7.6 7.9 8.2 8.7 9.4 9.9 10.0| 0.05 6.6 0.45 6.8 0.95 7.8 1.45 8.3 1.95 9.7 2.45 10 2.95 7.6 3.45 7.6 3.95 7.6 4.45 7.6 4.95 7.6"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_lift_above": [
+		"nil"
+	],
+	"filament_retract_lift_below": [
+		"nil"
+	],
+	"filament_retract_lift_enforce": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"1"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		"Eryone PP-CF @0.2 nozzle"
+	],
+	"filament_shrink": [
+		"100%"
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\nSET_FAN_SPEED FAN=filter_fan SPEED=0"
+	],
+	"filament_toolchange_delay": [
+		"0"
+	],
+	"filament_type": [
+		"PP-CF"
+	],
+	"filament_unloading_speed": [
+		"90"
+	],
+	"filament_unloading_speed_start": [
+		"100"
+	],
+	"filament_vendor": [
+		"Eryone"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"100"
+	],
+	"hot_plate_temp_initial_layer": [
+		"100"
+	],
+	"nozzle_temperature": [
+		"240"
+	],
+	"nozzle_temperature_initial_layer": [
+		"240"
+	],
+	"nozzle_temperature_range_high": [
+		"260"
+	],
+	"nozzle_temperature_range_low": [
+		"180"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"pressure_advance": [
+		"0.02"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"0"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"10"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"support_material_interface_fan_speed": [
+		"60"
+	],
+	"temperature_vitrification": [
+		"160"
+	],
+	"textured_plate_temp": [
+		"60"
+	],
+	"textured_plate_temp_initial_layer": [
+		"60"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone PP-CF @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone PP-CF @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Eryone PP-CF @System",
+	"inherits": "Eryone PP-CF @base",
+	"from": "system",
+	"setting_id": "EFSA33",
+	"filament_id": "EFL33",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone PP-CF @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone PP-CF @base.json
@@ -1,0 +1,240 @@
+{
+	"type": "filament",
+	"name": "Eryone PP-CF @base",
+	"inherits": "Eryone Standard PLA",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"activate_chamber_temp_control": [
+		"0"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"chamber_temperature": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"compatible_prints": [],
+	"compatible_prints_condition": "",
+	"complete_print_exhaust_fan_speed": [
+		"80"
+	],
+	"cool_plate_temp": [
+		"60"
+	],
+	"cool_plate_temp_initial_layer": [
+		"60"
+	],
+	"default_filament_colour": [
+		""
+	],
+	"during_print_exhaust_fan_speed": [
+		"60"
+	],
+	"enable_overhang_bridge_fan": [
+		"1"
+	],
+	"enable_pressure_advance": [
+		"0"
+	],
+	"eng_plate_temp": [
+		"60"
+	],
+	"eng_plate_temp_initial_layer": [
+		"60"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"fan_max_speed": [
+		"35"
+	],
+	"fan_min_speed": [
+		"20"
+	],
+	"filament_cooling_final_speed": [
+		"3.4"
+	],
+	"filament_cooling_initial_speed": [
+		"2.2"
+	],
+	"filament_cooling_moves": [
+		"4"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \nSET_FAN_SPEED FAN=filter_fan SPEED=0"
+	],
+	"filament_flow_ratio": [
+		"0.92"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_loading_speed": [
+		"28"
+	],
+	"filament_loading_speed_start": [
+		"3"
+	],
+	"filament_max_volumetric_speed": [
+		"8"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_multitool_ramming": [
+		"0"
+	],
+	"filament_multitool_ramming_flow": [
+		"10"
+	],
+	"filament_multitool_ramming_volume": [
+		"10"
+	],
+	"filament_notes": [
+		"Printing platform glue spraying"
+	],
+	"filament_ramming_parameters": [
+		"120 100 6.6 6.8 7.2 7.6 7.9 8.2 8.7 9.4 9.9 10.0| 0.05 6.6 0.45 6.8 0.95 7.8 1.45 8.3 1.95 9.7 2.45 10 2.95 7.6 3.45 7.6 3.95 7.6 4.45 7.6 4.95 7.6"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_lift_above": [
+		"nil"
+	],
+	"filament_retract_lift_below": [
+		"nil"
+	],
+	"filament_retract_lift_enforce": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"1"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		"Eryone PP-CF"
+	],
+	"filament_shrink": [
+		"100%"
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\nSET_FAN_SPEED FAN=filter_fan SPEED=0"
+	],
+	"filament_toolchange_delay": [
+		"0"
+	],
+	"filament_type": [
+		"PP-CF"
+	],
+	"filament_unloading_speed": [
+		"90"
+	],
+	"filament_unloading_speed_start": [
+		"100"
+	],
+	"filament_vendor": [
+		"Eryone"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"100"
+	],
+	"hot_plate_temp_initial_layer": [
+		"100"
+	],
+	"nozzle_temperature": [
+		"240"
+	],
+	"nozzle_temperature_initial_layer": [
+		"240"
+	],
+	"nozzle_temperature_range_high": [
+		"260"
+	],
+	"nozzle_temperature_range_low": [
+		"180"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"pressure_advance": [
+		"0.02"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"0"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"10"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"support_material_interface_fan_speed": [
+		"60"
+	],
+	"temperature_vitrification": [
+		"160"
+	],
+	"textured_plate_temp": [
+		"60"
+	],
+	"textured_plate_temp_initial_layer": [
+		"60"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone Silk PLA @0.2 nozzle @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone Silk PLA @0.2 nozzle @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Eryone Silk PLA @0.2 nozzle @System",
+	"inherits": "Eryone Silk PLA @0.2 nozzle @base",
+	"from": "system",
+	"setting_id": "",
+	"filament_id": "",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone Silk PLA @0.2 nozzle @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone Silk PLA @0.2 nozzle @base.json
@@ -1,0 +1,240 @@
+{
+	"type": "filament",
+	"name": "Eryone Silk PLA @0.2 nozzle @base",
+	"inherits": "Eryone Silk PLA",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"activate_chamber_temp_control": [
+		"0"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"chamber_temperature": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"compatible_prints": [],
+	"compatible_prints_condition": "",
+	"complete_print_exhaust_fan_speed": [
+		"80"
+	],
+	"cool_plate_temp": [
+		"60"
+	],
+	"cool_plate_temp_initial_layer": [
+		"60"
+	],
+	"default_filament_colour": [
+		""
+	],
+	"during_print_exhaust_fan_speed": [
+		"60"
+	],
+	"enable_overhang_bridge_fan": [
+		"1"
+	],
+	"enable_pressure_advance": [
+		"0"
+	],
+	"eng_plate_temp": [
+		"60"
+	],
+	"eng_plate_temp_initial_layer": [
+		"60"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"filament_cooling_final_speed": [
+		"3.4"
+	],
+	"filament_cooling_initial_speed": [
+		"2.2"
+	],
+	"filament_cooling_moves": [
+		"4"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \nSET_FAN_SPEED FAN=filter_fan SPEED=0\n"
+	],
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_loading_speed": [
+		"28"
+	],
+	"filament_loading_speed_start": [
+		"3"
+	],
+	"filament_max_volumetric_speed": [
+		"2"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_multitool_ramming": [
+		"0"
+	],
+	"filament_multitool_ramming_flow": [
+		"10"
+	],
+	"filament_multitool_ramming_volume": [
+		"10"
+	],
+	"filament_notes": [
+		""
+	],
+	"filament_ramming_parameters": [
+		"120 100 6.6 6.8 7.2 7.6 7.9 8.2 8.7 9.4 9.9 10.0| 0.05 6.6 0.45 6.8 0.95 7.8 1.45 8.3 1.95 9.7 2.45 10 2.95 7.6 3.45 7.6 3.95 7.6 4.45 7.6 4.95 7.6"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_lift_above": [
+		"nil"
+	],
+	"filament_retract_lift_below": [
+		"nil"
+	],
+	"filament_retract_lift_enforce": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		"Eryone Silk PLA @0.2 nozzle"
+	],
+	"filament_shrink": [
+		"100%"
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\nSET_FAN_SPEED FAN=filter_fan SPEED=1"
+	],
+	"filament_toolchange_delay": [
+		"0"
+	],
+	"filament_type": [
+		"PLA Silk"
+	],
+	"filament_unloading_speed": [
+		"90"
+	],
+	"filament_unloading_speed_start": [
+		"100"
+	],
+	"filament_vendor": [
+		"Eryone"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"60"
+	],
+	"hot_plate_temp_initial_layer": [
+		"65"
+	],
+	"nozzle_temperature": [
+		"230"
+	],
+	"nozzle_temperature_initial_layer": [
+		"230"
+	],
+	"nozzle_temperature_range_high": [
+		"260"
+	],
+	"nozzle_temperature_range_low": [
+		"180"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"pressure_advance": [
+		"0.02"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"0"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"7"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"support_material_interface_fan_speed": [
+		"-1"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"textured_plate_temp": [
+		"60"
+	],
+	"textured_plate_temp_initial_layer": [
+		"60"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone Silk PLA @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone Silk PLA @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Eryone Silk PLA @System",
+	"inherits": "Eryone Silk PLA @base",
+	"from": "system",
+	"setting_id": "EFSA041",
+	"filament_id": "EFL941",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone Silk PLA @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone Silk PLA @base.json
@@ -1,0 +1,240 @@
+{
+	"type": "filament",
+	"name": "Eryone Silk PLA @base",
+	"inherits": "Eryone Standard PLA",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"activate_chamber_temp_control": [
+		"0"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"chamber_temperature": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"compatible_prints": [],
+	"compatible_prints_condition": "",
+	"complete_print_exhaust_fan_speed": [
+		"80"
+	],
+	"cool_plate_temp": [
+		"60"
+	],
+	"cool_plate_temp_initial_layer": [
+		"60"
+	],
+	"default_filament_colour": [
+		""
+	],
+	"during_print_exhaust_fan_speed": [
+		"60"
+	],
+	"enable_overhang_bridge_fan": [
+		"1"
+	],
+	"enable_pressure_advance": [
+		"0"
+	],
+	"eng_plate_temp": [
+		"60"
+	],
+	"eng_plate_temp_initial_layer": [
+		"60"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"filament_cooling_final_speed": [
+		"3.4"
+	],
+	"filament_cooling_initial_speed": [
+		"2.2"
+	],
+	"filament_cooling_moves": [
+		"4"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \nSET_FAN_SPEED FAN=filter_fan SPEED=0\n"
+	],
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_loading_speed": [
+		"28"
+	],
+	"filament_loading_speed_start": [
+		"3"
+	],
+	"filament_max_volumetric_speed": [
+		"12"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_multitool_ramming": [
+		"0"
+	],
+	"filament_multitool_ramming_flow": [
+		"10"
+	],
+	"filament_multitool_ramming_volume": [
+		"10"
+	],
+	"filament_notes": [
+		""
+	],
+	"filament_ramming_parameters": [
+		"120 100 6.6 6.8 7.2 7.6 7.9 8.2 8.7 9.4 9.9 10.0| 0.05 6.6 0.45 6.8 0.95 7.8 1.45 8.3 1.95 9.7 2.45 10 2.95 7.6 3.45 7.6 3.95 7.6 4.45 7.6 4.95 7.6"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_lift_above": [
+		"nil"
+	],
+	"filament_retract_lift_below": [
+		"nil"
+	],
+	"filament_retract_lift_enforce": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		"Eryone Silk PLA"
+	],
+	"filament_shrink": [
+		"100%"
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\nSET_FAN_SPEED FAN=filter_fan SPEED=1"
+	],
+	"filament_toolchange_delay": [
+		"0"
+	],
+	"filament_type": [
+		"PLA Silk"
+	],
+	"filament_unloading_speed": [
+		"90"
+	],
+	"filament_unloading_speed_start": [
+		"100"
+	],
+	"filament_vendor": [
+		"Eryone"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"60"
+	],
+	"hot_plate_temp_initial_layer": [
+		"65"
+	],
+	"nozzle_temperature": [
+		"230"
+	],
+	"nozzle_temperature_initial_layer": [
+		"230"
+	],
+	"nozzle_temperature_range_high": [
+		"260"
+	],
+	"nozzle_temperature_range_low": [
+		"180"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"pressure_advance": [
+		"0.02"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"0"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"7"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"support_material_interface_fan_speed": [
+		"-1"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"textured_plate_temp": [
+		"60"
+	],
+	"textured_plate_temp_initial_layer": [
+		"60"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone TPU @0.2 nozzle @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone TPU @0.2 nozzle @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Eryone TPU @0.2 nozzle @System",
+	"inherits": "Eryone TPU @0.2 nozzle @base",
+	"from": "system",
+	"setting_id": "",
+	"filament_id": "",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone TPU @0.2 nozzle @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone TPU @0.2 nozzle @base.json
@@ -1,0 +1,240 @@
+{
+	"type": "filament",
+	"name": "Eryone TPU @0.2 nozzle @base",
+	"inherits": "Eryone TPU",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"activate_chamber_temp_control": [
+		"0"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"chamber_temperature": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"compatible_prints": [],
+	"compatible_prints_condition": "",
+	"complete_print_exhaust_fan_speed": [
+		"80"
+	],
+	"cool_plate_temp": [
+		"60"
+	],
+	"cool_plate_temp_initial_layer": [
+		"60"
+	],
+	"default_filament_colour": [
+		""
+	],
+	"during_print_exhaust_fan_speed": [
+		"60"
+	],
+	"enable_overhang_bridge_fan": [
+		"1"
+	],
+	"enable_pressure_advance": [
+		"0"
+	],
+	"eng_plate_temp": [
+		"60"
+	],
+	"eng_plate_temp_initial_layer": [
+		"60"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"90"
+	],
+	"filament_cooling_final_speed": [
+		"3.4"
+	],
+	"filament_cooling_initial_speed": [
+		"2.2"
+	],
+	"filament_cooling_moves": [
+		"4"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \nSET_FAN_SPEED FAN=filter_fan SPEED=0"
+	],
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_loading_speed": [
+		"28"
+	],
+	"filament_loading_speed_start": [
+		"3"
+	],
+	"filament_max_volumetric_speed": [
+		"2"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_multitool_ramming": [
+		"0"
+	],
+	"filament_multitool_ramming_flow": [
+		"10"
+	],
+	"filament_multitool_ramming_volume": [
+		"10"
+	],
+	"filament_notes": [
+		""
+	],
+	"filament_ramming_parameters": [
+		"120 100 6.6 6.8 7.2 7.6 7.9 8.2 8.7 9.4 9.9 10.0| 0.05 6.6 0.45 6.8 0.95 7.8 1.45 8.3 1.95 9.7 2.45 10 2.95 7.6 3.45 7.6 3.95 7.6 4.45 7.6 4.95 7.6"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_lift_above": [
+		"nil"
+	],
+	"filament_retract_lift_below": [
+		"nil"
+	],
+	"filament_retract_lift_enforce": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"1.6"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		"Eryone TPU @0.2 nozzle"
+	],
+	"filament_shrink": [
+		"100%"
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\nSET_FAN_SPEED FAN=filter_fan SPEED=1"
+	],
+	"filament_toolchange_delay": [
+		"0"
+	],
+	"filament_type": [
+		"TPU"
+	],
+	"filament_unloading_speed": [
+		"90"
+	],
+	"filament_unloading_speed_start": [
+		"100"
+	],
+	"filament_vendor": [
+		"Eryone"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"50"
+	],
+	"hot_plate_temp_initial_layer": [
+		"50"
+	],
+	"nozzle_temperature": [
+		"230"
+	],
+	"nozzle_temperature_initial_layer": [
+		"230"
+	],
+	"nozzle_temperature_range_high": [
+		"260"
+	],
+	"nozzle_temperature_range_low": [
+		"180"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"pressure_advance": [
+		"0.02"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"0"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"8"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"support_material_interface_fan_speed": [
+		"-1"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"textured_plate_temp": [
+		"60"
+	],
+	"textured_plate_temp_initial_layer": [
+		"60"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone TPU @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone TPU @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Eryone TPU @System",
+	"inherits": "Eryone TPU @base",
+	"from": "system",
+	"setting_id": "EFSA05",
+	"filament_id": "EFL95",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone TPU @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Eryone/Eryone TPU @base.json
@@ -1,0 +1,240 @@
+{
+	"type": "filament",
+	"name": "Eryone TPU @base",
+	"inherits": "Eryone Standard PLA",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"activate_chamber_temp_control": [
+		"0"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"chamber_temperature": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"compatible_prints": [],
+	"compatible_prints_condition": "",
+	"complete_print_exhaust_fan_speed": [
+		"80"
+	],
+	"cool_plate_temp": [
+		"60"
+	],
+	"cool_plate_temp_initial_layer": [
+		"60"
+	],
+	"default_filament_colour": [
+		""
+	],
+	"during_print_exhaust_fan_speed": [
+		"60"
+	],
+	"enable_overhang_bridge_fan": [
+		"1"
+	],
+	"enable_pressure_advance": [
+		"0"
+	],
+	"eng_plate_temp": [
+		"60"
+	],
+	"eng_plate_temp_initial_layer": [
+		"60"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"90"
+	],
+	"filament_cooling_final_speed": [
+		"3.4"
+	],
+	"filament_cooling_initial_speed": [
+		"2.2"
+	],
+	"filament_cooling_moves": [
+		"4"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \nSET_FAN_SPEED FAN=filter_fan SPEED=0"
+	],
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_loading_speed": [
+		"28"
+	],
+	"filament_loading_speed_start": [
+		"3"
+	],
+	"filament_max_volumetric_speed": [
+		"5"
+	],
+	"filament_minimal_purge_on_wipe_tower": [
+		"15"
+	],
+	"filament_multitool_ramming": [
+		"0"
+	],
+	"filament_multitool_ramming_flow": [
+		"10"
+	],
+	"filament_multitool_ramming_volume": [
+		"10"
+	],
+	"filament_notes": [
+		""
+	],
+	"filament_ramming_parameters": [
+		"120 100 6.6 6.8 7.2 7.6 7.9 8.2 8.7 9.4 9.9 10.0| 0.05 6.6 0.45 6.8 0.95 7.8 1.45 8.3 1.95 9.7 2.45 10 2.95 7.6 3.45 7.6 3.95 7.6 4.45 7.6 4.95 7.6"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_lift_above": [
+		"nil"
+	],
+	"filament_retract_lift_below": [
+		"nil"
+	],
+	"filament_retract_lift_enforce": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"1.6"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		"Eryone TPU"
+	],
+	"filament_shrink": [
+		"100%"
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\nSET_FAN_SPEED FAN=filter_fan SPEED=1"
+	],
+	"filament_toolchange_delay": [
+		"0"
+	],
+	"filament_type": [
+		"TPU"
+	],
+	"filament_unloading_speed": [
+		"90"
+	],
+	"filament_unloading_speed_start": [
+		"100"
+	],
+	"filament_vendor": [
+		"Eryone"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"50"
+	],
+	"hot_plate_temp_initial_layer": [
+		"50"
+	],
+	"nozzle_temperature": [
+		"230"
+	],
+	"nozzle_temperature_initial_layer": [
+		"230"
+	],
+	"nozzle_temperature_range_high": [
+		"260"
+	],
+	"nozzle_temperature_range_low": [
+		"180"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"pressure_advance": [
+		"0.02"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"0"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"8"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"support_material_interface_fan_speed": [
+		"-1"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"textured_plate_temp": [
+		"60"
+	],
+	"textured_plate_temp_initial_layer": [
+		"60"
+	]
+}


### PR DESCRIPTION
## Summary

Migrates the Eryone filament presets to inherit from `OrcaFilamentLibrary` vendor bases while keeping Eryone printer-scoped profiles focused on their compatibility constraints.

## Changes

- Added Eryone `@base` and `@System` filament presets under `OrcaFilamentLibrary`.
- Updated Eryone vendor filament presets to inherit from the new library bases.
- Registered the new Eryone library entries in `OrcaFilamentLibrary.json`.
- Removed obsolete load/unload timing keys from migrated Eryone filament data so validation is clean.

## Testing

- `python3 scripts/orca_extra_profile_check.py --vendor Eryone --check-filaments --check-materials --check-obsolete-keys`
- `git diff --check`

Contributes to #12162.