### PR TITLE
fix: register enable_filament_dynamic_map and has_filament_switcher config options

### DIFF
--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -2427,6 +2427,18 @@ void PrintConfigDef::init_fff_params()
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionEnum<FilamentMapMode>(fmmAutoForFlush));
 
+    def = this->add("enable_filament_dynamic_map", coBool);
+    def->label = L("Enable filament dynamic map");
+    def->tooltip = L("Enable dynamic filament mapping during print.");
+    def->mode = comDevelop;
+    def->set_default_value(new ConfigOptionBool(false));
+
+    def = this->add("has_filament_switcher", coBool);
+    def->label = L("Has filament switcher");
+    def->tooltip = L("Printer has a filament switcher hardware (e.g., AMS).");
+    def->mode = comDevelop;
+    def->set_default_value(new ConfigOptionBool(false));
+
     def = this->add("filament_flush_temp", coInts);
     def->label = L("Flush temperature");
     def->tooltip = L("Temperature when flushing filament. 0 indicates the upper bound of the recommended nozzle temperature range.");


### PR DESCRIPTION
## Summary

Fix "unknown option exception: enable_filament_dynamic_map" crash on .3mf load.

## Root Cause

PR #13388 (X2D Support, commit 9956ad5b48) added import/export for two config options in `bbs_3mf.cpp` but never registered them in `PrintConfig.cpp`:

- `enable_filament_dynamic_map` — bbs_3mf.cpp:4550-4557 (import), :8201 (export)
- `has_filament_switcher` — bbs_3mf.cpp:4558-4565 (import), :8203-8204 (export)

When loading any .3mf containing these keys, `PartPlate.cpp:6153` calls `config->apply()` which iterates all stored keys and looks them up in the PrintConfig definition. Missing key → `UnknownOptionException` → "failed loading file".

## Fix

Register both as `ConfigOptionBool` with default `false`, placed alongside other filament map options at PrintConfig.cpp:2429. Mode set to `comDevelop` since neither option is currently exposed in the UI.

## Reproduce

Open any .3mf exported by a nightly build from May 9+. Fails with `unknown option exception: enable_filament_dynamic_map`.