### PR TITLE
Migrate Creality filaments to OrcaFilamentLibrary

### DIFF
--- a/resources/profiles/Creality/filament/Creality Generic ABS @Ender-3V3-all.json
+++ b/resources/profiles/Creality/filament/Creality Generic ABS @Ender-3V3-all.json
@@ -1,16 +1,10 @@
 {
 	"type": "filament",
 	"name": "Creality Generic ABS @Ender-3V3-all",
-	"inherits": "Creality Generic ABS",
+	"inherits": "Creality Generic ABS @Ender-3V3-all @base",
 	"from": "system",
 	"setting_id": "GFSA04_CREALITY_00",
 	"instantiation": "true",
-	"filament_max_volumetric_speed": [
-		"9"
-	],
-	"slow_down_layer_time": [
-		"5"
-	],
 	"compatible_printers": [
 		"Creality Ender-3 V3 SE 0.2 nozzle",
 		"Creality Ender-3 V3 SE 0.4 nozzle",

--- a/resources/profiles/Creality/filament/Creality Generic ABS @Ender-5Max-all.json
+++ b/resources/profiles/Creality/filament/Creality Generic ABS @Ender-5Max-all.json
@@ -1,107 +1,12 @@
 {
 	"type": "filament",
 	"name": "Creality Generic ABS @Ender-5Max-all",
-	"inherits": "fdm_filament_common",
+	"inherits": "Creality Generic ABS @Ender-5Max-all @base",
 	"from": "system",
 	"setting_id": "GFSA04_CREALITY_00",
 	"filament_id": "07001",
 	"instantiation": "true",
-	"activate_air_filtration": "0",
-	"activate_chamber_temp_control": "0",
-	"additional_cooling_fan_speed": "0",
-	"chamber_temperature": "35",
-	"close_fan_the_first_x_layers": "3",
 	"compatible_printers": [
 		"Creality Ender-5 Max 0.4 nozzle"
-	],
-	"complete_print_exhaust_fan_speed": "80",
-	"cool_plate_temp": "90",
-	"cool_plate_temp_initial_layer": "90",
-	"cool_special_cds_fan_speed": "0",
-	"default_filament_colour": "\"\"",
-	"during_print_exhaust_fan_speed": "60",
-	"enable_overhang_bridge_fan": "1",
-	"enable_pressure_advance": "1",
-	"eng_plate_temp": "105",
-	"eng_plate_temp_initial_layer": "105",
-	"fan_cooling_layer_time": "30",
-	"fan_max_speed": "20",
-	"fan_min_speed": "20",
-	"filament_cooling_final_speed": "3.4",
-	"filament_cooling_initial_speed": "2.2",
-	"filament_cooling_moves": "4",
-	"filament_cost": [
-		"15"
-	],
-	"filament_density": [
-		"1.08"
-	],
-	"filament_deretraction_speed": "nil",
-	"filament_diameter": "1.75",
-	"filament_end_gcode": [
-		"; filament end gcode \n"
-	],
-	"filament_flow_ratio": "0.85",
-	"filament_is_support": "0",
-	"filament_load_time": "0",
-	"filament_loading_speed": "28",
-	"filament_loading_speed_start": "3",
-	"filament_max_volumetric_speed": [
-		"35"
-	],
-	"filament_minimal_purge_on_wipe_tower": "15",
-	"filament_multitool_ramming": "0",
-	"filament_multitool_ramming_flow": "10",
-	"filament_multitool_ramming_volume": "10",
-	"filament_notes": "\"\"",
-	"filament_ramming_parameters": "\"120 100 6.6 6.8 7.2 7.6 7.9 8.2 8.7 9.4 9.9 10.0| 0.05 6.6 0.45 6.8 0.95 7.8 1.45 8.3 1.95 9.7 2.45 10 2.95 7.6 3.45 7.6 3.95 7.6 4.45 7.6 4.95 7.6\"",
-	"filament_retract_before_wipe": "nil",
-	"filament_retract_lift_above": "0",
-	"filament_retract_lift_below": "0",
-	"filament_retract_lift_enforce": "All Surfaces",
-	"filament_retract_restart_extra": "0",
-	"filament_retract_when_changing_layer": "nil",
-	"filament_retraction_length": "nil",
-	"filament_retraction_minimum_travel": "nil",
-	"filament_retraction_speed": "nil",
-	"filament_shrink": "100%",
-	"filament_soluble": "0",
-	"filament_start_gcode": [
-		"; Filament gcode\n"
-	],
-	"filament_toolchange_delay": "0",
-	"filament_type": [
-		"ABS"
-	],
-	"filament_unload_time": "0",
-	"filament_unloading_speed": "90",
-	"filament_unloading_speed_start": "100",
-	"filament_vendor": [
-		"Creality"
-	],
-	"filament_wipe": "nil",
-	"filament_wipe_distance": "nil",
-	"filament_z_hop": "nil",
-	"filament_z_hop_types": "nil",
-	"full_fan_speed_layer": "0",
-	"hot_plate_temp": "90",
-	"hot_plate_temp_initial_layer": "90",
-	"nozzle_temperature": "260",
-	"nozzle_temperature_initial_layer": "260",
-	"nozzle_temperature_range_high": "260",
-	"nozzle_temperature_range_low": "230",
-	"overhang_fan_speed": "20",
-	"overhang_fan_threshold": "25%",
-	"pressure_advance": "0.03",
-	"reduce_fan_stop_start_freq": "1",
-	"required_nozzle_HRC": "0",
-	"slow_down_for_layer_cooling": "1",
-	"slow_down_layer_time": "5",
-	"slow_down_min_speed": "10",
-	"support_material_interface_fan_speed": "-1",
-	"temperature_vitrification": [
-		"110"
-	],
-	"textured_plate_temp": "90",
-	"textured_plate_temp_initial_layer": "90"
+	]
 }

--- a/resources/profiles/Creality/filament/Creality Generic ABS @Hi-all.json
+++ b/resources/profiles/Creality/filament/Creality Generic ABS @Hi-all.json
@@ -1,19 +1,10 @@
 {
 	"type": "filament",
 	"name": "Creality Generic ABS @Hi-all",
-	"inherits": "Creality Generic ABS",
+	"inherits": "Creality Generic ABS @Hi-all @base",
 	"from": "system",
 	"setting_id": "GFSA04_CREALITY_00",
 	"instantiation": "true",
-	"filament_max_volumetric_speed": [
-		"9"
-	],
-	"slow_down_layer_time": [
-		"5"
-	],
-	"filament_start_gcode": [
-		"; filament start gcode\n{if (position[2] > first_layer_height) }\nM104 S[nozzle_temperature]\n{else}\nM104 S[first_layer_temperature]\n{endif}\n"
-	],
 	"compatible_printers": [
 		"Creality Hi 0.4 nozzle",
 		"Creality Hi 0.6 nozzle"

--- a/resources/profiles/Creality/filament/Creality Generic ABS @K1-all.json
+++ b/resources/profiles/Creality/filament/Creality Generic ABS @K1-all.json
@@ -1,19 +1,10 @@
 {
 	"type": "filament",
 	"name": "Creality Generic ABS @K1-all",
-	"inherits": "Creality Generic ABS",
+	"inherits": "Creality Generic ABS @K1-all @base",
 	"from": "system",
 	"setting_id": "GFSA04_CREALITY_00",
 	"instantiation": "true",
-	"filament_max_volumetric_speed": [
-		"14"
-	],
-	"slow_down_layer_time": [
-		"5"
-	],
-	"slow_down_min_speed": [
-		"20"
-	],
 	"compatible_printers": [
 		"Creality K1C 0.4 nozzle",
 		"Creality K1C 0.6 nozzle",

--- a/resources/profiles/Creality/filament/Creality Generic ABS @K2-all.json
+++ b/resources/profiles/Creality/filament/Creality Generic ABS @K2-all.json
@@ -1,25 +1,10 @@
 {
 	"type": "filament",
 	"name": "Creality Generic ABS @K2-all",
-	"inherits": "Creality Generic ABS",
+	"inherits": "Creality Generic ABS @K2-all @base",
 	"from": "system",
 	"setting_id": "GFSA04_CREALITY_00",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"0.95"
-	],
-	"filament_max_volumetric_speed": [
-		"18"
-	],
-	"slow_down_layer_time": [
-		"12"
-	],
-	"slow_down_min_speed": [
-		"20"
-	],
-	"filament_start_gcode": [
-		";filament start gcode\n{if (position[2] > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
-	],
 	"compatible_printers": [
 		"Creality K2 0.2 nozzle",
 		"Creality K2 0.4 nozzle",

--- a/resources/profiles/Creality/filament/Creality Generic ABS.json
+++ b/resources/profiles/Creality/filament/Creality Generic ABS.json
@@ -1,17 +1,11 @@
 {
 	"type": "filament",
 	"name": "Creality Generic ABS",
-	"inherits": "fdm_filament_abs",
+	"inherits": "Creality Generic ABS @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFB99",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"0.926"
-	],
-	"filament_max_volumetric_speed": [
-		"12"
-	],
 	"compatible_printers": [
 		"Creality CR-10 V2 0.4 nozzle",
 		"Creality CR-10 V3 0.4 nozzle",

--- a/resources/profiles/Creality/filament/Creality Generic ASA @Ender-3V3-all.json
+++ b/resources/profiles/Creality/filament/Creality Generic ASA @Ender-3V3-all.json
@@ -1,16 +1,10 @@
 {
 	"type": "filament",
 	"name": "Creality Generic ASA @Ender-3V3-all",
-	"inherits": "Creality Generic ASA",
+	"inherits": "Creality Generic ASA @Ender-3V3-all @base",
 	"from": "system",
 	"setting_id": "GFSA04_00",
 	"instantiation": "true",
-	"filament_max_volumetric_speed": [
-		"9"
-	],
-	"slow_down_layer_time": [
-		"5"
-	],
 	"compatible_printers": [
 		"Creality Ender-3 V3 SE 0.2 nozzle",
 		"Creality Ender-3 V3 SE 0.4 nozzle",

--- a/resources/profiles/Creality/filament/Creality Generic ASA @Ender-5Max-all.json
+++ b/resources/profiles/Creality/filament/Creality Generic ASA @Ender-5Max-all.json
@@ -1,107 +1,12 @@
 {
 	"type": "filament",
 	"name": "Creality Generic ASA @Ender-5Max-all",
-	"inherits": "fdm_filament_common",
+	"inherits": "Creality Generic ASA @Ender-5Max-all @base",
 	"from": "system",
 	"setting_id": "GFSA04_CREALITY_00",
 	"filament_id": "19001",
 	"instantiation": "true",
-	"activate_air_filtration": "0",
-	"activate_chamber_temp_control": "0",
-	"additional_cooling_fan_speed": "0",
-	"chamber_temperature": "55",
-	"close_fan_the_first_x_layers": "1",
 	"compatible_printers": [
 		"Creality Ender-5 Max 0.4 nozzle"
-	],
-	"complete_print_exhaust_fan_speed": "80",
-	"cool_plate_temp": "90",
-	"cool_plate_temp_initial_layer": "90",
-	"cool_special_cds_fan_speed": "0",
-	"default_filament_colour": "\"\"",
-	"during_print_exhaust_fan_speed": "60",
-	"enable_overhang_bridge_fan": "1",
-	"enable_pressure_advance": "1",
-	"eng_plate_temp": "50",
-	"eng_plate_temp_initial_layer": "50",
-	"fan_cooling_layer_time": "30",
-	"fan_max_speed": "20",
-	"fan_min_speed": "20",
-	"filament_cooling_final_speed": "3.4",
-	"filament_cooling_initial_speed": "2.2",
-	"filament_cooling_moves": "4",
-	"filament_cost": [
-		"29"
-	],
-	"filament_density": [
-		"1.15"
-	],
-	"filament_deretraction_speed": "nil",
-	"filament_diameter": "1.75",
-	"filament_end_gcode": [
-		"; filament end gcode \n"
-	],
-	"filament_flow_ratio": "0.85",
-	"filament_is_support": "0",
-	"filament_load_time": "0",
-	"filament_loading_speed": "28",
-	"filament_loading_speed_start": "3",
-	"filament_max_volumetric_speed": [
-		"35"
-	],
-	"filament_minimal_purge_on_wipe_tower": "15",
-	"filament_multitool_ramming": "0",
-	"filament_multitool_ramming_flow": "10",
-	"filament_multitool_ramming_volume": "10",
-	"filament_notes": "\"\"",
-	"filament_ramming_parameters": "\"120 100 6.6 6.8 7.2 7.6 7.9 8.2 8.7 9.4 9.9 10.0| 0.05 6.6 0.45 6.8 0.95 7.8 1.45 8.3 1.95 9.7 2.45 10 2.95 7.6 3.45 7.6 3.95 7.6 4.45 7.6 4.95 7.6\"",
-	"filament_retract_before_wipe": "nil",
-	"filament_retract_lift_above": "0",
-	"filament_retract_lift_below": "0",
-	"filament_retract_lift_enforce": "All Surfaces",
-	"filament_retract_restart_extra": "nil",
-	"filament_retract_when_changing_layer": "nil",
-	"filament_retraction_length": "nil",
-	"filament_retraction_minimum_travel": "nil",
-	"filament_retraction_speed": "nil",
-	"filament_shrink": "100%",
-	"filament_soluble": "0",
-	"filament_start_gcode": [
-		"; filament start gcode\n"
-	],
-	"filament_toolchange_delay": "0",
-	"filament_type": [
-		"ASA"
-	],
-	"filament_unload_time": "0",
-	"filament_unloading_speed": "90",
-	"filament_unloading_speed_start": "100",
-	"filament_vendor": [
-		"Creality"
-	],
-	"filament_wipe": "nil",
-	"filament_wipe_distance": "nil",
-	"filament_z_hop": "nil",
-	"filament_z_hop_types": "nil",
-	"full_fan_speed_layer": "0",
-	"hot_plate_temp": "90",
-	"hot_plate_temp_initial_layer": "90",
-	"nozzle_temperature": "260",
-	"nozzle_temperature_initial_layer": "260",
-	"nozzle_temperature_range_high": "280",
-	"nozzle_temperature_range_low": "240",
-	"overhang_fan_speed": "20",
-	"overhang_fan_threshold": "50%",
-	"pressure_advance": "0.032",
-	"reduce_fan_stop_start_freq": "1",
-	"required_nozzle_HRC": "0",
-	"slow_down_for_layer_cooling": "1",
-	"slow_down_layer_time": "5",
-	"slow_down_min_speed": "10",
-	"support_material_interface_fan_speed": "-1",
-	"temperature_vitrification": [
-		"110"
-	],
-	"textured_plate_temp": "90",
-	"textured_plate_temp_initial_layer": "90"
+	]
 }

--- a/resources/profiles/Creality/filament/Creality Generic ASA @Hi-all.json
+++ b/resources/profiles/Creality/filament/Creality Generic ASA @Hi-all.json
@@ -1,19 +1,10 @@
 {
 	"type": "filament",
 	"name": "Creality Generic ASA @Hi-all",
-	"inherits": "Creality Generic ASA",
+	"inherits": "Creality Generic ASA @Hi-all @base",
 	"from": "system",
 	"setting_id": "GFSA04_00",
 	"instantiation": "true",
-	"filament_max_volumetric_speed": [
-		"9"
-	],
-	"slow_down_layer_time": [
-		"5"
-	],
-	"filament_start_gcode": [
-		"; filament start gcode\n{if (position[2] > first_layer_height) }\nM104 S[nozzle_temperature]\n{else}\nM104 S[first_layer_temperature]\n{endif}\n"
-	],
 	"compatible_printers": [
 		"Creality Hi 0.4 nozzle",
 		"Creality Hi 0.6 nozzle"

--- a/resources/profiles/Creality/filament/Creality Generic ASA @K1-all.json
+++ b/resources/profiles/Creality/filament/Creality Generic ASA @K1-all.json
@@ -1,19 +1,10 @@
 {
 	"type": "filament",
 	"name": "Creality Generic ASA @K1-all",
-	"inherits": "Creality Generic ASA",
+	"inherits": "Creality Generic ASA @K1-all @base",
 	"from": "system",
 	"setting_id": "GFSA04_00",
 	"instantiation": "true",
-	"filament_max_volumetric_speed": [
-		"12"
-	],
-	"slow_down_layer_time": [
-		"3"
-	],
-	"slow_down_min_speed": [
-		"20"
-	],
 	"compatible_printers": [
 		"Creality K1C 0.4 nozzle",
 		"Creality K1C 0.6 nozzle",

--- a/resources/profiles/Creality/filament/Creality Generic ASA @K2-all.json
+++ b/resources/profiles/Creality/filament/Creality Generic ASA @K2-all.json
@@ -1,25 +1,10 @@
 {
 	"type": "filament",
 	"name": "Creality Generic ASA @K2-all",
-	"inherits": "Creality Generic ASA",
+	"inherits": "Creality Generic ASA @K2-all @base",
 	"from": "system",
 	"setting_id": "GFSA04_00",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"0.95"
-	],
-	"filament_max_volumetric_speed": [
-		"14"
-	],
-	"slow_down_layer_time": [
-		"10"
-	],
-	"slow_down_min_speed": [
-		"20"
-	],
-	"filament_start_gcode": [
-		";filament start gcode\n{if (position[2] > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
-	],
 	"compatible_printers": [
 		"Creality K2 0.2 nozzle",
 		"Creality K2 0.4 nozzle",

--- a/resources/profiles/Creality/filament/Creality Generic ASA-CF @Hi-all.json
+++ b/resources/profiles/Creality/filament/Creality Generic ASA-CF @Hi-all.json
@@ -1,16 +1,10 @@
 {
 	"type": "filament",
 	"name": "Creality Generic ASA-CF @Hi-all",
-	"inherits": "Creality Generic ASA @Hi-all",
+	"inherits": "Creality Generic ASA-CF @Hi-all @base",
 	"from": "system",
 	"setting_id": "GFSA04_00",
 	"instantiation": "true",
-	"filament_max_volumetric_speed": [
-		"9"
-	],
-	"slow_down_layer_time": [
-		"5"
-	],
 	"compatible_printers": [
 		"Creality Hi 0.4 nozzle",
 		"Creality Hi 0.6 nozzle"

--- a/resources/profiles/Creality/filament/Creality Generic ASA.json
+++ b/resources/profiles/Creality/filament/Creality Generic ASA.json
@@ -1,17 +1,11 @@
 {
 	"type": "filament",
 	"name": "Creality Generic ASA",
-	"inherits": "fdm_filament_asa",
+	"inherits": "Creality Generic ASA @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFB98",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"0.926"
-	],
-	"filament_max_volumetric_speed": [
-		"12"
-	],
 	"compatible_printers": [
 		"Creality CR-10 V2 0.4 nozzle",
 		"Creality CR-10 V3 0.4 nozzle",

--- a/resources/profiles/Creality/filament/Creality Generic PA @Ender-5Max-all.json
+++ b/resources/profiles/Creality/filament/Creality Generic PA @Ender-5Max-all.json
@@ -1,107 +1,12 @@
 {
 	"type": "filament",
 	"name": "Creality Generic PA @Ender-5Max-all",
-	"inherits": "fdm_filament_common",
+	"inherits": "Creality Generic PA @Ender-5Max-all @base",
 	"from": "system",
 	"setting_id": "GFSA04_CREALITY_00",
 	"filament_id": "11001",
 	"instantiation": "true",
-	"activate_air_filtration": "0",
-	"activate_chamber_temp_control": "0",
-	"additional_cooling_fan_speed": "0",
-	"chamber_temperature": "35",
-	"close_fan_the_first_x_layers": "1",
 	"compatible_printers": [
 		"Creality Ender-5 Max 0.4 nozzle"
-	],
-	"complete_print_exhaust_fan_speed": "100",
-	"cool_plate_temp": "45",
-	"cool_plate_temp_initial_layer": "45",
-	"cool_special_cds_fan_speed": "0",
-	"default_filament_colour": "\"\"",
-	"during_print_exhaust_fan_speed": "0",
-	"enable_overhang_bridge_fan": "1",
-	"enable_pressure_advance": "1",
-	"eng_plate_temp": "100",
-	"eng_plate_temp_initial_layer": "100",
-	"fan_cooling_layer_time": "100",
-	"fan_max_speed": "100",
-	"fan_min_speed": "100",
-	"filament_cooling_final_speed": "3.4",
-	"filament_cooling_initial_speed": "2.2",
-	"filament_cooling_moves": "4",
-	"filament_cost": [
-		"50"
-	],
-	"filament_density": [
-		"1.24"
-	],
-	"filament_deretraction_speed": "nil",
-	"filament_diameter": "1.75",
-	"filament_end_gcode": [
-		"; filament end gcode \n"
-	],
-	"filament_flow_ratio": "0.9",
-	"filament_is_support": "0",
-	"filament_load_time": "0",
-	"filament_loading_speed": "28",
-	"filament_loading_speed_start": "3",
-	"filament_max_volumetric_speed": [
-		"2"
-	],
-	"filament_minimal_purge_on_wipe_tower": "15",
-	"filament_multitool_ramming": "0",
-	"filament_multitool_ramming_flow": "10",
-	"filament_multitool_ramming_volume": "10",
-	"filament_notes": "\"\"",
-	"filament_ramming_parameters": "\"120 100 6.6 6.8 7.2 7.6 7.9 8.2 8.7 9.4 9.9 10.0| 0.05 6.6 0.45 6.8 0.95 7.8 1.45 8.3 1.95 9.7 2.45 10 2.95 7.6 3.45 7.6 3.95 7.6 4.45 7.6 4.95 7.6\"",
-	"filament_retract_before_wipe": "nil",
-	"filament_retract_lift_above": "0",
-	"filament_retract_lift_below": "0",
-	"filament_retract_lift_enforce": "All Surfaces",
-	"filament_retract_restart_extra": "0",
-	"filament_retract_when_changing_layer": "nil",
-	"filament_retraction_length": "1.5",
-	"filament_retraction_minimum_travel": "nil",
-	"filament_retraction_speed": "nil",
-	"filament_shrink": "100%",
-	"filament_soluble": "0",
-	"filament_start_gcode": [
-		"; Filament gcode\n"
-	],
-	"filament_toolchange_delay": "0",
-	"filament_type": [
-		"PA"
-	],
-	"filament_unload_time": "0",
-	"filament_unloading_speed": "90",
-	"filament_unloading_speed_start": "100",
-	"filament_vendor": [
-		"Creality"
-	],
-	"filament_wipe": "nil",
-	"filament_wipe_distance": "nil",
-	"filament_z_hop": "0.2",
-	"filament_z_hop_types": "nil",
-	"full_fan_speed_layer": "0",
-	"hot_plate_temp": "45",
-	"hot_plate_temp_initial_layer": "45",
-	"nozzle_temperature": "250",
-	"nozzle_temperature_initial_layer": "250",
-	"nozzle_temperature_range_high": "280",
-	"nozzle_temperature_range_low": "250",
-	"overhang_fan_speed": "50",
-	"overhang_fan_threshold": "50%",
-	"pressure_advance": "0.042",
-	"reduce_fan_stop_start_freq": "1",
-	"required_nozzle_HRC": "40",
-	"slow_down_for_layer_cooling": "1",
-	"slow_down_layer_time": "8",
-	"slow_down_min_speed": "5",
-	"support_material_interface_fan_speed": "-1",
-	"temperature_vitrification": [
-		"108"
-	],
-	"textured_plate_temp": "45",
-	"textured_plate_temp_initial_layer": "45"
+	]
 }

--- a/resources/profiles/Creality/filament/Creality Generic PA-CF @Ender-3V3-all.json
+++ b/resources/profiles/Creality/filament/Creality Generic PA-CF @Ender-3V3-all.json
@@ -1,7 +1,7 @@
 {
 	"type": "filament",
 	"name": "Creality Generic PA-CF @Ender-3V3-all",
-	"inherits": "Creality Generic PA-CF",
+	"inherits": "Creality Generic PA-CF @Ender-3V3-all @base",
 	"from": "system",
 	"setting_id": "GFSN99_01",
 	"instantiation": "true",

--- a/resources/profiles/Creality/filament/Creality Generic PA-CF @K1-all.json
+++ b/resources/profiles/Creality/filament/Creality Generic PA-CF @K1-all.json
@@ -1,7 +1,7 @@
 {
 	"type": "filament",
 	"name": "Creality Generic PA-CF @K1-all",
-	"inherits": "Creality Generic PA-CF",
+	"inherits": "Creality Generic PA-CF @K1-all @base",
 	"from": "system",
 	"setting_id": "GFSN99_01",
 	"instantiation": "true",

--- a/resources/profiles/Creality/filament/Creality Generic PA-CF @K2-all.json
+++ b/resources/profiles/Creality/filament/Creality Generic PA-CF @K2-all.json
@@ -1,22 +1,10 @@
 {
 	"type": "filament",
 	"name": "Creality Generic PA-CF @K2-all",
-	"inherits": "Creality Generic PA-CF",
+	"inherits": "Creality Generic PA-CF @K2-all @base",
 	"from": "system",
 	"setting_id": "GFSN99_01",
 	"instantiation": "true",
-	"nozzle_temperature_initial_layer": [
-		"280"
-	],
-	"nozzle_temperature": [
-		"280"
-	],
-	"fan_min_speed": [
-		"30"
-	],
-	"filament_start_gcode": [
-		";filament start gcode\n{if (position[2] > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
-	],
 	"compatible_printers": [
 		"Creality K2 0.2 nozzle",
 		"Creality K2 0.4 nozzle",

--- a/resources/profiles/Creality/filament/Creality Generic PA-CF.json
+++ b/resources/profiles/Creality/filament/Creality Generic PA-CF.json
@@ -1,47 +1,11 @@
 {
 	"type": "filament",
 	"name": "Creality Generic PA-CF",
-	"inherits": "fdm_filament_pa",
+	"inherits": "Creality Generic PA-CF @base",
 	"from": "system",
 	"setting_id": "GFSN99",
 	"filament_id": "GFN98",
 	"instantiation": "true",
-	"filament_type": [
-		"PA-CF"
-	],
-	"nozzle_temperature_initial_layer": [
-		"290"
-	],
-	"nozzle_temperature": [
-		"290"
-	],
-	"filament_max_volumetric_speed": [
-		"8"
-	],
-	"fan_max_speed": [
-		"30"
-	],
-	"fan_min_speed": [
-		"10"
-	],
-	"overhang_fan_threshold": [
-		"0%"
-	],
-	"overhang_fan_speed": [
-		"40"
-	],
-	"fan_cooling_layer_time": [
-		"5"
-	],
-	"full_fan_speed_layer": [
-		"2"
-	],
-	"enable_pressure_advance": [
-		"1"
-	],
-	"pressure_advance": [
-		"0.01"
-	],
 	"compatible_printers": [
 		"Creality CR-10 V2 0.4 nozzle",
 		"Creality CR-10 V3 0.4 nozzle",

--- a/resources/profiles/Creality/filament/Creality Generic PC @K1-all.json
+++ b/resources/profiles/Creality/filament/Creality Generic PC @K1-all.json
@@ -1,13 +1,10 @@
 {
 	"type": "filament",
 	"name": "Creality Generic PC @K1-all",
-	"inherits": "Creality Generic PC",
+	"inherits": "Creality Generic PC @K1-all @base",
 	"from": "system",
 	"setting_id": "GFSC99_06",
 	"instantiation": "true",
-	"chamber_temperatures": [
-		"60"
-	],
 	"compatible_printers": [
 		"Creality K1 (0.4 nozzle)",
 		"Creality K1 (0.6 nozzle)",

--- a/resources/profiles/Creality/filament/Creality Generic PETG @Ender-3V3-all.json
+++ b/resources/profiles/Creality/filament/Creality Generic PETG @Ender-3V3-all.json
@@ -1,46 +1,10 @@
 {
 	"type": "filament",
 	"name": "Creality Generic PETG @Ender-3V3-all",
-	"inherits": "Creality Generic PETG",
+	"inherits": "Creality Generic PETG @Ender-3V3-all @base",
 	"from": "system",
 	"setting_id": "GFSG99_00",
 	"instantiation": "true",
-	"filament_max_volumetric_speed": [
-		"9"
-	],
-	"slow_down_layer_time": [
-		"5"
-	],
-	"cool_plate_temp": [
-		"70"
-	],
-	"eng_plate_temp": [
-		"70"
-	],
-	"hot_plate_temp": [
-		"70"
-	],
-	"textured_plate_temp": [
-		"70"
-	],
-	"cool_plate_temp_initial_layer": [
-		"70"
-	],
-	"eng_plate_temp_initial_layer": [
-		"70"
-	],
-	"hot_plate_temp_initial_layer": [
-		"70"
-	],
-	"textured_plate_temp_initial_layer": [
-		"70"
-	],
-	"nozzle_temperature_initial_layer": [
-		"250"
-	],
-	"nozzle_temperature": [
-		"250"
-	],
 	"compatible_printers": [
 		"Creality Ender-3 V3 SE 0.2 nozzle",
 		"Creality Ender-3 V3 SE 0.4 nozzle",

--- a/resources/profiles/Creality/filament/Creality Generic PETG @Ender-5Max-all.json
+++ b/resources/profiles/Creality/filament/Creality Generic PETG @Ender-5Max-all.json
@@ -1,107 +1,12 @@
 {
 	"type": "filament",
 	"name": "Creality Generic PETG @Ender-5Max-all",
-	"inherits": "fdm_filament_common",
+	"inherits": "Creality Generic PETG @Ender-5Max-all @base",
 	"from": "system",
 	"setting_id": "GFSA04_CREALITY_00",
 	"filament_id": "06001",
 	"instantiation": "true",
-	"activate_air_filtration": "0",
-	"activate_chamber_temp_control": "0",
-	"additional_cooling_fan_speed": "0",
-	"chamber_temperature": "35",
-	"close_fan_the_first_x_layers": "1",
 	"compatible_printers": [
 		"Creality Ender-5 Max 0.4 nozzle"
-	],
-	"complete_print_exhaust_fan_speed": "80",
-	"cool_plate_temp": "70",
-	"cool_plate_temp_initial_layer": "70",
-	"cool_special_cds_fan_speed": "0",
-	"default_filament_colour": "\"\"",
-	"during_print_exhaust_fan_speed": "60",
-	"enable_overhang_bridge_fan": "1",
-	"enable_pressure_advance": "1",
-	"eng_plate_temp": "0",
-	"eng_plate_temp_initial_layer": "0",
-	"fan_cooling_layer_time": "30",
-	"fan_max_speed": "100",
-	"fan_min_speed": "100",
-	"filament_cooling_final_speed": "3.4",
-	"filament_cooling_initial_speed": "2.2",
-	"filament_cooling_moves": "4",
-	"filament_cost": [
-		"14"
-	],
-	"filament_density": [
-		"1.23"
-	],
-	"filament_deretraction_speed": "nil",
-	"filament_diameter": "1.75",
-	"filament_end_gcode": [
-		"; filament end gcode \n"
-	],
-	"filament_flow_ratio": "0.85",
-	"filament_is_support": "0",
-	"filament_load_time": "0",
-	"filament_loading_speed": "28",
-	"filament_loading_speed_start": "3",
-	"filament_max_volumetric_speed": [
-		"30"
-	],
-	"filament_minimal_purge_on_wipe_tower": "15",
-	"filament_multitool_ramming": "0",
-	"filament_multitool_ramming_flow": "10",
-	"filament_multitool_ramming_volume": "10",
-	"filament_notes": "\"\"",
-	"filament_ramming_parameters": "\"120 100 6.6 6.8 7.2 7.6 7.9 8.2 8.7 9.4 9.9 10.0| 0.05 6.6 0.45 6.8 0.95 7.8 1.45 8.3 1.95 9.7 2.45 10 2.95 7.6 3.45 7.6 3.95 7.6 4.45 7.6 4.95 7.6\"",
-	"filament_retract_before_wipe": "nil",
-	"filament_retract_lift_above": "0",
-	"filament_retract_lift_below": "0",
-	"filament_retract_lift_enforce": "All Surfaces",
-	"filament_retract_restart_extra": "0",
-	"filament_retract_when_changing_layer": "nil",
-	"filament_retraction_length": "nil",
-	"filament_retraction_minimum_travel": "nil",
-	"filament_retraction_speed": "nil",
-	"filament_shrink": "100%",
-	"filament_soluble": "0",
-	"filament_start_gcode": [
-		"; filament start gcode\n"
-	],
-	"filament_toolchange_delay": "0",
-	"filament_type": [
-		"PETG"
-	],
-	"filament_unload_time": "0",
-	"filament_unloading_speed": "90",
-	"filament_unloading_speed_start": "100",
-	"filament_vendor": [
-		"Creality"
-	],
-	"filament_wipe": "nil",
-	"filament_wipe_distance": "nil",
-	"filament_z_hop": "nil",
-	"filament_z_hop_types": "nil",
-	"full_fan_speed_layer": "0",
-	"hot_plate_temp": "70",
-	"hot_plate_temp_initial_layer": "70",
-	"nozzle_temperature": "250",
-	"nozzle_temperature_initial_layer": "250",
-	"nozzle_temperature_range_high": "270",
-	"nozzle_temperature_range_low": "220",
-	"overhang_fan_speed": "100",
-	"overhang_fan_threshold": "25%",
-	"pressure_advance": "0.038",
-	"reduce_fan_stop_start_freq": "1",
-	"required_nozzle_HRC": "0",
-	"slow_down_for_layer_cooling": "1",
-	"slow_down_layer_time": "8",
-	"slow_down_min_speed": "10",
-	"support_material_interface_fan_speed": "-1",
-	"temperature_vitrification": [
-		"80"
-	],
-	"textured_plate_temp": "70",
-	"textured_plate_temp_initial_layer": "70"
+	]
 }

--- a/resources/profiles/Creality/filament/Creality Generic PETG @Hi-all.json
+++ b/resources/profiles/Creality/filament/Creality Generic PETG @Hi-all.json
@@ -1,49 +1,10 @@
 {
 	"type": "filament",
 	"name": "Creality Generic PETG @Hi-all",
-	"inherits": "Creality Generic PETG",
+	"inherits": "Creality Generic PETG @Hi-all @base",
 	"from": "system",
 	"setting_id": "GFSG99_00",
 	"instantiation": "true",
-	"filament_max_volumetric_speed": [
-		"9"
-	],
-	"slow_down_layer_time": [
-		"5"
-	],
-	"cool_plate_temp": [
-		"70"
-	],
-	"eng_plate_temp": [
-		"70"
-	],
-	"hot_plate_temp": [
-		"70"
-	],
-	"textured_plate_temp": [
-		"70"
-	],
-	"cool_plate_temp_initial_layer": [
-		"70"
-	],
-	"eng_plate_temp_initial_layer": [
-		"70"
-	],
-	"hot_plate_temp_initial_layer": [
-		"70"
-	],
-	"textured_plate_temp_initial_layer": [
-		"70"
-	],
-	"nozzle_temperature_initial_layer": [
-		"250"
-	],
-	"nozzle_temperature": [
-		"250"
-	],
-	"filament_start_gcode": [
-		"; filament start gcode\n{if (position[2] > first_layer_height) }\nM104 S[nozzle_temperature]\n{else}\nM104 S[first_layer_temperature]\n{endif}\n"
-	],
 	"compatible_printers": [
 		"Creality Hi 0.4 nozzle",
 		"Creality Hi 0.6 nozzle"

--- a/resources/profiles/Creality/filament/Creality Generic PETG @K1-all.json
+++ b/resources/profiles/Creality/filament/Creality Generic PETG @K1-all.json
@@ -1,52 +1,10 @@
 {
 	"type": "filament",
 	"name": "Creality Generic PETG @K1-all",
-	"inherits": "Creality Generic PETG",
+	"inherits": "Creality Generic PETG @K1-all @base",
 	"from": "system",
 	"setting_id": "GFSG99_00",
 	"instantiation": "true",
-	"filament_max_volumetric_speed": [
-		"9"
-	],
-	"slow_down_layer_time": [
-		"12"
-	],
-	"slow_down_min_speed": [
-		"20"
-	],
-	"cool_plate_temp": [
-		"70"
-	],
-	"eng_plate_temp": [
-		"70"
-	],
-	"hot_plate_temp": [
-		"70"
-	],
-	"textured_plate_temp": [
-		"70"
-	],
-	"cool_plate_temp_initial_layer": [
-		"70"
-	],
-	"eng_plate_temp_initial_layer": [
-		"70"
-	],
-	"hot_plate_temp_initial_layer": [
-		"70"
-	],
-	"textured_plate_temp_initial_layer": [
-		"70"
-	],
-	"nozzle_temperature_initial_layer": [
-		"250"
-	],
-	"nozzle_temperature": [
-		"250"
-	],
-	"reduce_fan_stop_start_freq": [
-		"0"
-	],
 	"compatible_printers": [
 		"Creality K1C 0.4 nozzle",
 		"Creality K1C 0.6 nozzle",

--- a/resources/profiles/Creality/filament/Creality Generic PETG @K2-all.json
+++ b/resources/profiles/Creality/filament/Creality Generic PETG @K2-all.json
@@ -1,58 +1,10 @@
 {
 	"type": "filament",
 	"name": "Creality Generic PETG @K2-all",
-	"inherits": "Creality Generic PETG",
+	"inherits": "Creality Generic PETG @K2-all @base",
 	"from": "system",
 	"setting_id": "GFSG99_00",
 	"instantiation": "true",
-	"filament_max_volumetric_speed": [
-		"18"
-	],
-	"slow_down_layer_time": [
-		"8"
-	],
-	"slow_down_min_speed": [
-		"20"
-	],
-	"cool_plate_temp": [
-		"70"
-	],
-	"eng_plate_temp": [
-		"50"
-	],
-	"hot_plate_temp": [
-		"70"
-	],
-	"textured_plate_temp": [
-		"70"
-	],
-	"cool_plate_temp_initial_layer": [
-		"70"
-	],
-	"eng_plate_temp_initial_layer": [
-		"0"
-	],
-	"hot_plate_temp_initial_layer": [
-		"70"
-	],
-	"textured_plate_temp_initial_layer": [
-		"70"
-	],
-	"nozzle_temperature_initial_layer": [
-		"250"
-	],
-	"nozzle_temperature": [
-		"250"
-	],
-	"fan_max_speed": [
-		"80"
-	],
-	"reduce_fan_stop_start_freq": [
-		"1"
-	],
-	"filament_start_gcode": [
-		";filament start gcode\n{if (position[2] > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
-	],
 	"compatible_printers": [
 		"Creality K2 0.2 nozzle",
 		"Creality K2 0.4 nozzle",

--- a/resources/profiles/Creality/filament/Creality Generic PETG-CF @Hi-all.json
+++ b/resources/profiles/Creality/filament/Creality Generic PETG-CF @Hi-all.json
@@ -1,16 +1,10 @@
 {
 	"type": "filament",
 	"name": "Creality Generic PETG-CF @Hi-all",
-	"inherits": "Creality Generic PETG @Hi-all",
+	"inherits": "Creality Generic PETG-CF @Hi-all @base",
 	"from": "system",
 	"setting_id": "GFSG99_00",
 	"instantiation": "true",
-	"filament_max_volumetric_speed": [
-		"9"
-	],
-	"filament_flow_ratio": [
-		"0.95"
-	],
 	"compatible_printers": [
 		"Creality Hi 0.4 nozzle",
 		"Creality Hi 0.6 nozzle"

--- a/resources/profiles/Creality/filament/Creality Generic PETG.json
+++ b/resources/profiles/Creality/filament/Creality Generic PETG.json
@@ -1,47 +1,11 @@
 {
 	"type": "filament",
 	"name": "Creality Generic PETG",
-	"inherits": "fdm_filament_pet",
+	"inherits": "Creality Generic PETG @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFG99",
 	"instantiation": "true",
-	"reduce_fan_stop_start_freq": [
-		"1"
-	],
-	"slow_down_for_layer_cooling": [
-		"1"
-	],
-	"fan_cooling_layer_time": [
-		"30"
-	],
-	"overhang_fan_speed": [
-		"90"
-	],
-	"overhang_fan_threshold": [
-		"25%"
-	],
-	"fan_max_speed": [
-		"90"
-	],
-	"fan_min_speed": [
-		"40"
-	],
-	"slow_down_min_speed": [
-		"10"
-	],
-	"slow_down_layer_time": [
-		"8"
-	],
-	"filament_flow_ratio": [
-		"0.95"
-	],
-	"filament_max_volumetric_speed": [
-		"10"
-	],
-	"filament_start_gcode": [
-		"; filament start gcode\n"
-	],
 	"compatible_printers": [
 		"Creality CR-10 V2 0.4 nozzle",
 		"Creality CR-10 V3 0.4 nozzle",

--- a/resources/profiles/Creality/filament/Creality Generic PLA @Ender-3V3-all.json
+++ b/resources/profiles/Creality/filament/Creality Generic PLA @Ender-3V3-all.json
@@ -1,40 +1,10 @@
 {
 	"type": "filament",
 	"name": "Creality Generic PLA @Ender-3V3-all",
-	"inherits": "Creality Generic PLA",
+	"inherits": "Creality Generic PLA @Ender-3V3-all @base",
 	"from": "system",
 	"setting_id": "GFSL99_00",
 	"instantiation": "true",
-	"filament_max_volumetric_speed": [
-		"18"
-	],
-	"slow_down_min_speed": [
-		"20"
-	],
-	"cool_plate_temp": [
-		"55"
-	],
-	"eng_plate_temp": [
-		"55"
-	],
-	"hot_plate_temp": [
-		"55"
-	],
-	"textured_plate_temp": [
-		"55"
-	],
-	"cool_plate_temp_initial_layer": [
-		"55"
-	],
-	"eng_plate_temp_initial_layer": [
-		"55"
-	],
-	"hot_plate_temp_initial_layer": [
-		"55"
-	],
-	"textured_plate_temp_initial_layer": [
-		"55"
-	],
 	"compatible_printers": [
 		"Creality Ender-3 V3 SE 0.2 nozzle",
 		"Creality Ender-3 V3 SE 0.4 nozzle",

--- a/resources/profiles/Creality/filament/Creality Generic PLA @Ender-5Max-all.json
+++ b/resources/profiles/Creality/filament/Creality Generic PLA @Ender-5Max-all.json
@@ -1,107 +1,12 @@
 {
 	"type": "filament",
 	"name": "Creality Generic PLA @Ender-5Max-all",
-	"inherits": "fdm_filament_common",
+	"inherits": "Creality Generic PLA @Ender-5Max-all @base",
 	"from": "system",
 	"setting_id": "GFSA04_CREALITY_00",
 	"filament_id": "04001",
 	"instantiation": "true",
-	"activate_air_filtration": "0",
-	"activate_chamber_temp_control": "0",
-	"additional_cooling_fan_speed": "0",
-	"chamber_temperature": "35",
-	"close_fan_the_first_x_layers": "1",
 	"compatible_printers": [
 		"Creality Ender-5 Max 0.4 nozzle"
-	],
-	"complete_print_exhaust_fan_speed": "80",
-	"cool_plate_temp": "45",
-	"cool_plate_temp_initial_layer": "45",
-	"cool_special_cds_fan_speed": "0",
-	"default_filament_colour": "\"\"",
-	"during_print_exhaust_fan_speed": "60",
-	"enable_overhang_bridge_fan": "1",
-	"enable_pressure_advance": "1",
-	"eng_plate_temp": "50",
-	"eng_plate_temp_initial_layer": "50",
-	"fan_cooling_layer_time": "100",
-	"fan_max_speed": "100",
-	"fan_min_speed": "100",
-	"filament_cooling_final_speed": "3.4",
-	"filament_cooling_initial_speed": "2.2",
-	"filament_cooling_moves": "4",
-	"filament_cost": [
-		"20"
-	],
-	"filament_density": [
-		"1.24"
-	],
-	"filament_deretraction_speed": "nil",
-	"filament_diameter": "1.75",
-	"filament_end_gcode": [
-		"; filament end gcode \n"
-	],
-	"filament_flow_ratio": "0.9",
-	"filament_is_support": "0",
-	"filament_load_time": "0",
-	"filament_loading_speed": "28",
-	"filament_loading_speed_start": "3",
-	"filament_max_volumetric_speed": [
-		"40"
-	],
-	"filament_minimal_purge_on_wipe_tower": "15",
-	"filament_multitool_ramming": "0",
-	"filament_multitool_ramming_flow": "10",
-	"filament_multitool_ramming_volume": "10",
-	"filament_notes": "\"\"",
-	"filament_ramming_parameters": "\"120 100 6.6 6.8 7.2 7.6 7.9 8.2 8.7 9.4 9.9 10.0| 0.05 6.6 0.45 6.8 0.95 7.8 1.45 8.3 1.95 9.7 2.45 10 2.95 7.6 3.45 7.6 3.95 7.6 4.45 7.6 4.95 7.6\"",
-	"filament_retract_before_wipe": "nil",
-	"filament_retract_lift_above": "0",
-	"filament_retract_lift_below": "0",
-	"filament_retract_lift_enforce": "All Surfaces",
-	"filament_retract_restart_extra": "0",
-	"filament_retract_when_changing_layer": "nil",
-	"filament_retraction_length": "nil",
-	"filament_retraction_minimum_travel": "nil",
-	"filament_retraction_speed": "nil",
-	"filament_shrink": "100%",
-	"filament_soluble": "0",
-	"filament_start_gcode": [
-		"; Filament gcode\n"
-	],
-	"filament_toolchange_delay": "0",
-	"filament_type": [
-		"PLA"
-	],
-	"filament_unload_time": "0",
-	"filament_unloading_speed": "90",
-	"filament_unloading_speed_start": "100",
-	"filament_vendor": [
-		"Generic"
-	],
-	"filament_wipe": "nil",
-	"filament_wipe_distance": "nil",
-	"filament_z_hop": "nil",
-	"filament_z_hop_types": "nil",
-	"full_fan_speed_layer": "0",
-	"hot_plate_temp": "45",
-	"hot_plate_temp_initial_layer": "45",
-	"nozzle_temperature": "220",
-	"nozzle_temperature_initial_layer": "220",
-	"nozzle_temperature_range_high": "240",
-	"nozzle_temperature_range_low": "190",
-	"overhang_fan_speed": "100",
-	"overhang_fan_threshold": "25%",
-	"pressure_advance": "0.03",
-	"reduce_fan_stop_start_freq": "1",
-	"required_nozzle_HRC": "0",
-	"slow_down_for_layer_cooling": "1",
-	"slow_down_layer_time": "5",
-	"slow_down_min_speed": "10",
-	"support_material_interface_fan_speed": "-1",
-	"temperature_vitrification": [
-		"60"
-	],
-	"textured_plate_temp": "45",
-	"textured_plate_temp_initial_layer": "45"
+	]
 }

--- a/resources/profiles/Creality/filament/Creality Generic PLA @Hi-all.json
+++ b/resources/profiles/Creality/filament/Creality Generic PLA @Hi-all.json
@@ -1,94 +1,10 @@
 {
 	"type": "filament",
 	"name": "Creality Generic PLA @Hi-all",
-	"inherits": "Creality Generic PLA",
+	"inherits": "Creality Generic PLA @Hi-all @base",
 	"from": "system",
 	"setting_id": "GFSL99_00",
 	"instantiation": "true",
-	"filament_max_volumetric_speed": [
-		"18"
-	],
-	"slow_down_min_speed": [
-		"20"
-	],
-	"cool_plate_temp": [
-		"55"
-	],
-	"eng_plate_temp": [
-		"55"
-	],
-	"hot_plate_temp": [
-		"55"
-	],
-	"textured_plate_temp": [
-		"55"
-	],
-	"cool_plate_temp_initial_layer": [
-		"55"
-	],
-	"eng_plate_temp_initial_layer": [
-		"55"
-	],
-	"hot_plate_temp_initial_layer": [
-		"55"
-	],
-	"textured_plate_temp_initial_layer": [
-		"55"
-	],
-	"filament_cooling_final_speed": [
-		"3.4"
-	],
-	"filament_cooling_initial_speed": [
-		"2.2"
-	],
-	"filament_cooling_moves": [
-		"4"
-	],
-	"filament_load_time": [
-		"0"
-	],
-	"filament_loading_speed": [
-		"28"
-	],
-	"filament_loading_speed_start": [
-		"3"
-	],
-	"filament_toolchange_delay": [
-		"0"
-	],
-	"filament_unload_time": [
-		"0"
-	],
-	"filament_unloading_speed": [
-		"90"
-	],
-	"filament_unloading_speed_start": [
-		"100"
-	],
-	"filament_long_retractions_when_cut": [
-		"nil"
-	],
-	"filament_minimal_purge_on_wipe_tower": [
-		"15"
-	],
-	"filament_multitool_ramming": [
-		"0"
-	],
-	"filament_multitool_ramming_flow": [
-		"0"
-	],
-	"filament_multitool_ramming_volume": [
-		"0"
-	],
-	"filament_notes": [
-		""
-	],
-	"filament_ramming_parameters": [
-		"120 100 6.6 6.8 7.2 7.6 7.9 8.2 8.7 9.4 9.9 10.0| 0.05 6.6 0.45 6.8 0.95 7.8 1.45 8.3 1.95 9.7 2.45 10 2.95 7.6 3.45 7.6 3.95 7.6 4.45 7.6 4.95 7.6"
-	],
-	"filament_start_gcode": [
-		"; filament start gcode\n{if (position[2] > first_layer_height) }\nM104 S[nozzle_temperature]\n{else}\nM104 S[first_layer_temperature]\n{endif}\n"
-	],
 	"compatible_printers": [
 		"Creality Hi 0.4 nozzle",
 		"Creality Hi 0.6 nozzle"

--- a/resources/profiles/Creality/filament/Creality Generic PLA @K1-all.json
+++ b/resources/profiles/Creality/filament/Creality Generic PLA @K1-all.json
@@ -1,43 +1,10 @@
 {
 	"type": "filament",
 	"name": "Creality Generic PLA @K1-all",
-	"inherits": "Creality Generic PLA",
+	"inherits": "Creality Generic PLA @K1-all @base",
 	"from": "system",
 	"setting_id": "GFSL99_00",
 	"instantiation": "true",
-	"filament_max_volumetric_speed": [
-		"18"
-	],
-	"slow_down_min_speed": [
-		"20"
-	],
-	"cool_plate_temp": [
-		"55"
-	],
-	"eng_plate_temp": [
-		"55"
-	],
-	"hot_plate_temp": [
-		"55"
-	],
-	"textured_plate_temp": [
-		"55"
-	],
-	"cool_plate_temp_initial_layer": [
-		"55"
-	],
-	"eng_plate_temp_initial_layer": [
-		"55"
-	],
-	"hot_plate_temp_initial_layer": [
-		"55"
-	],
-	"textured_plate_temp_initial_layer": [
-		"55"
-	],
-	"reduce_fan_stop_start_freq": [
-		"0"
-	],
 	"compatible_printers": [
 		"Creality K1C 0.4 nozzle",
 		"Creality K1C 0.6 nozzle",

--- a/resources/profiles/Creality/filament/Creality Generic PLA @K2-all.json
+++ b/resources/profiles/Creality/filament/Creality Generic PLA @K2-all.json
@@ -1,52 +1,10 @@
 {
 	"type": "filament",
 	"name": "Creality Generic PLA @K2-all",
-	"inherits": "Creality Generic PLA",
+	"inherits": "Creality Generic PLA @K2-all @base",
 	"from": "system",
 	"setting_id": "GFSL99_00",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"0.95"
-	],
-	"filament_max_volumetric_speed": [
-		"18"
-	],
-	"slow_down_min_speed": [
-		"20"
-	],
-	"slow_down_layer_time": [
-		"4"
-	],
-	"cool_plate_temp": [
-		"50"
-	],
-	"eng_plate_temp": [
-		"50"
-	],
-	"hot_plate_temp": [
-		"50"
-	],
-	"textured_plate_temp": [
-		"50"
-	],
-	"cool_plate_temp_initial_layer": [
-		"50"
-	],
-	"eng_plate_temp_initial_layer": [
-		"50"
-	],
-	"hot_plate_temp_initial_layer": [
-		"50"
-	],
-	"textured_plate_temp_initial_layer": [
-		"50"
-	],
-	"reduce_fan_stop_start_freq": [
-		"1"
-	],
-	"filament_start_gcode": [
-		";filament start gcode\n{if (position[2] > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
-	],
 	"compatible_printers": [
 		"Creality K2 0.2 nozzle",
 		"Creality K2 0.4 nozzle",

--- a/resources/profiles/Creality/filament/Creality Generic PLA High Speed @Ender-3V3-all.json
+++ b/resources/profiles/Creality/filament/Creality Generic PLA High Speed @Ender-3V3-all.json
@@ -1,13 +1,10 @@
 {
 	"type": "filament",
 	"name": "Creality Generic PLA High Speed @Ender-3V3-all",
-	"inherits": "Creality Generic PLA @Ender-3V3-all",
+	"inherits": "Creality Generic PLA High Speed @Ender-3V3-all @base",
 	"from": "system",
 	"setting_id": "GFSL95_00",
 	"instantiation": "true",
-	"filament_max_volumetric_speed": [
-		"23"
-	],
 	"compatible_printers": [
 		"Creality Ender-3 V3 SE 0.2 nozzle",
 		"Creality Ender-3 V3 SE 0.4 nozzle",

--- a/resources/profiles/Creality/filament/Creality Generic PLA High Speed @Hi-all.json
+++ b/resources/profiles/Creality/filament/Creality Generic PLA High Speed @Hi-all.json
@@ -1,16 +1,10 @@
 {
 	"type": "filament",
 	"name": "Creality Generic PLA High Speed @Hi-all",
-	"inherits": "Creality Generic PLA @Hi-all",
+	"inherits": "Creality Generic PLA High Speed @Hi-all @base",
 	"from": "system",
 	"setting_id": "GFSL95_00",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"0.95"
-	],
-	"filament_max_volumetric_speed": [
-		"23"
-	],
 	"compatible_printers": [
 		"Creality Hi 0.4 nozzle",
 		"Creality Hi 0.6 nozzle"

--- a/resources/profiles/Creality/filament/Creality Generic PLA High Speed @K1-all.json
+++ b/resources/profiles/Creality/filament/Creality Generic PLA High Speed @K1-all.json
@@ -1,13 +1,10 @@
 {
 	"type": "filament",
 	"name": "Creality Generic PLA High Speed @K1-all",
-	"inherits": "Creality Generic PLA @K1-all",
+	"inherits": "Creality Generic PLA High Speed @K1-all @base",
 	"from": "system",
 	"setting_id": "GFSL95_00",
 	"instantiation": "true",
-	"filament_max_volumetric_speed": [
-		"23"
-	],
 	"compatible_printers": [
 		"Creality K1 (0.4 nozzle)",
 		"Creality K1 (0.6 nozzle)",

--- a/resources/profiles/Creality/filament/Creality Generic PLA High Speed @K2-all.json
+++ b/resources/profiles/Creality/filament/Creality Generic PLA High Speed @K2-all.json
@@ -1,13 +1,10 @@
 {
 	"type": "filament",
 	"name": "Creality Generic PLA High Speed @K2-all",
-	"inherits": "Creality Generic PLA @K2-all",
+	"inherits": "Creality Generic PLA High Speed @K2-all @base",
 	"from": "system",
 	"setting_id": "GFSL95_00",
 	"instantiation": "true",
-	"filament_max_volumetric_speed": [
-		"23"
-	],
 	"compatible_printers": [
 		"Creality K2 0.2 nozzle",
 		"Creality K2 0.4 nozzle",

--- a/resources/profiles/Creality/filament/Creality Generic PLA Matte @Ender-3V3-all.json
+++ b/resources/profiles/Creality/filament/Creality Generic PLA Matte @Ender-3V3-all.json
@@ -1,13 +1,10 @@
 {
 	"type": "filament",
 	"name": "Creality Generic PLA Matte @Ender-3V3-all",
-	"inherits": "Creality Generic PLA @Ender-3V3-all",
+	"inherits": "Creality Generic PLA Matte @Ender-3V3-all @base",
 	"from": "system",
 	"setting_id": "GFSL05_00",
 	"instantiation": "true",
-	"filament_max_volumetric_speed": [
-		"18"
-	],
 	"compatible_printers": [
 		"Creality Ender-3 V3 SE 0.2 nozzle",
 		"Creality Ender-3 V3 SE 0.4 nozzle",

--- a/resources/profiles/Creality/filament/Creality Generic PLA Matte @Hi-all.json
+++ b/resources/profiles/Creality/filament/Creality Generic PLA Matte @Hi-all.json
@@ -1,13 +1,10 @@
 {
 	"type": "filament",
 	"name": "Creality Generic PLA Matte @Hi-all",
-	"inherits": "Creality Generic PLA @Hi-all",
+	"inherits": "Creality Generic PLA Matte @Hi-all @base",
 	"from": "system",
 	"setting_id": "GFSL05_00",
 	"instantiation": "true",
-	"filament_max_volumetric_speed": [
-		"18"
-	],
 	"compatible_printers": [
 		"Creality Hi 0.4 nozzle",
 		"Creality Hi 0.6 nozzle"

--- a/resources/profiles/Creality/filament/Creality Generic PLA Matte @K1-all.json
+++ b/resources/profiles/Creality/filament/Creality Generic PLA Matte @K1-all.json
@@ -1,13 +1,10 @@
 {
 	"type": "filament",
 	"name": "Creality Generic PLA Matte @K1-all",
-	"inherits": "Creality Generic PLA @K1-all",
+	"inherits": "Creality Generic PLA Matte @K1-all @base",
 	"from": "system",
 	"setting_id": "GFSL05_00",
 	"instantiation": "true",
-	"filament_max_volumetric_speed": [
-		"18"
-	],
 	"compatible_printers": [
 		"Creality K1 (0.4 nozzle)",
 		"Creality K1 (0.6 nozzle)",

--- a/resources/profiles/Creality/filament/Creality Generic PLA Matte @K2-all.json
+++ b/resources/profiles/Creality/filament/Creality Generic PLA Matte @K2-all.json
@@ -1,13 +1,10 @@
 {
 	"type": "filament",
 	"name": "Creality Generic PLA Matte @K2-all",
-	"inherits": "Creality Generic PLA @K2-all",
+	"inherits": "Creality Generic PLA Matte @K2-all @base",
 	"from": "system",
 	"setting_id": "GFSL05_00",
 	"instantiation": "true",
-	"filament_max_volumetric_speed": [
-		"18"
-	],
 	"compatible_printers": [
 		"Creality K2 0.2 nozzle",
 		"Creality K2 0.4 nozzle",

--- a/resources/profiles/Creality/filament/Creality Generic PLA Silk @Ender-3V3-all.json
+++ b/resources/profiles/Creality/filament/Creality Generic PLA Silk @Ender-3V3-all.json
@@ -1,13 +1,10 @@
 {
 	"type": "filament",
 	"name": "Creality Generic PLA Silk @Ender-3V3-all",
-	"inherits": "Creality Generic PLA @Ender-3V3-all",
+	"inherits": "Creality Generic PLA Silk @Ender-3V3-all @base",
 	"from": "system",
 	"setting_id": "GFSL96_00",
 	"instantiation": "true",
-	"filament_max_volumetric_speed": [
-		"7.5"
-	],
 	"compatible_printers": [
 		"Creality Ender-3 V3 SE 0.2 nozzle",
 		"Creality Ender-3 V3 SE 0.4 nozzle",

--- a/resources/profiles/Creality/filament/Creality Generic PLA Silk @Hi-all.json
+++ b/resources/profiles/Creality/filament/Creality Generic PLA Silk @Hi-all.json
@@ -1,16 +1,10 @@
 {
 	"type": "filament",
 	"name": "Creality Generic PLA Silk @Hi-all",
-	"inherits": "Creality Generic PLA @Hi-all",
+	"inherits": "Creality Generic PLA Silk @Hi-all @base",
 	"from": "system",
 	"setting_id": "GFSL96_00",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"0.97"
-	],
-	"filament_max_volumetric_speed": [
-		"7.5"
-	],
 	"compatible_printers": [
 		"Creality Hi 0.4 nozzle",
 		"Creality Hi 0.6 nozzle"

--- a/resources/profiles/Creality/filament/Creality Generic PLA Silk @K1-all.json
+++ b/resources/profiles/Creality/filament/Creality Generic PLA Silk @K1-all.json
@@ -1,13 +1,10 @@
 {
 	"type": "filament",
 	"name": "Creality Generic PLA Silk @K1-all",
-	"inherits": "Creality Generic PLA @K1-all",
+	"inherits": "Creality Generic PLA Silk @K1-all @base",
 	"from": "system",
 	"setting_id": "GFSL96_00",
 	"instantiation": "true",
-	"filament_max_volumetric_speed": [
-		"7.5"
-	],
 	"compatible_printers": [
 		"Creality K1 (0.4 nozzle)",
 		"Creality K1 (0.6 nozzle)",

--- a/resources/profiles/Creality/filament/Creality Generic PLA Silk @K2-all.json
+++ b/resources/profiles/Creality/filament/Creality Generic PLA Silk @K2-all.json
@@ -1,13 +1,10 @@
 {
 	"type": "filament",
 	"name": "Creality Generic PLA Silk @K2-all",
-	"inherits": "Creality Generic PLA @K2-all",
+	"inherits": "Creality Generic PLA Silk @K2-all @base",
 	"from": "system",
 	"setting_id": "GFSL96_00",
 	"instantiation": "true",
-	"filament_max_volumetric_speed": [
-		"10"
-	],
 	"compatible_printers": [
 		"Creality K2 0.2 nozzle",
 		"Creality K2 0.4 nozzle",

--- a/resources/profiles/Creality/filament/Creality Generic PLA Wood @Hi-all.json
+++ b/resources/profiles/Creality/filament/Creality Generic PLA Wood @Hi-all.json
@@ -1,16 +1,10 @@
 {
 	"type": "filament",
 	"name": "Creality Generic PLA Wood @Hi-all",
-	"inherits": "Creality Generic PLA @Hi-all",
+	"inherits": "Creality Generic PLA Wood @Hi-all @base",
 	"from": "system",
 	"setting_id": "GFSL96_00",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"0.88"
-	],
-	"filament_max_volumetric_speed": [
-		"8"
-	],
 	"compatible_printers": [
 		"Creality Hi 0.4 nozzle",
 		"Creality Hi 0.6 nozzle"

--- a/resources/profiles/Creality/filament/Creality Generic PLA-CF @Hi-all.json
+++ b/resources/profiles/Creality/filament/Creality Generic PLA-CF @Hi-all.json
@@ -1,13 +1,10 @@
 {
 	"type": "filament",
 	"name": "Creality Generic PLA-CF @Hi-all",
-	"inherits": "Creality Generic PLA-CF",
+	"inherits": "Creality Generic PLA-CF @Hi-all @base",
 	"from": "system",
 	"setting_id": "GFSL96_00",
 	"instantiation": "true",
-	"filament_max_volumetric_speed": [
-		"18"
-	],
 	"compatible_printers": [
 		"Creality Hi 0.4 nozzle",
 		"Creality Hi 0.6 nozzle"

--- a/resources/profiles/Creality/filament/Creality Generic PLA-CF @K1-all.json
+++ b/resources/profiles/Creality/filament/Creality Generic PLA-CF @K1-all.json
@@ -1,13 +1,10 @@
 {
 	"type": "filament",
 	"name": "Creality Generic PLA-CF @K1-all",
-	"inherits": "Creality Generic PLA-CF",
+	"inherits": "Creality Generic PLA-CF @K1-all @base",
 	"from": "system",
 	"setting_id": "GFSL96_00",
 	"instantiation": "true",
-	"additional_cooling_fan_speed": [
-		"0"
-	],
 	"compatible_printers": [
 		"Creality K1 (0.4 nozzle)",
 		"Creality K1 (0.6 nozzle)",

--- a/resources/profiles/Creality/filament/Creality Generic PLA-CF @K2-all.json
+++ b/resources/profiles/Creality/filament/Creality Generic PLA-CF @K2-all.json
@@ -1,19 +1,10 @@
 {
 	"type": "filament",
 	"name": "Creality Generic PLA-CF @K2-all",
-	"inherits": "Creality Generic PLA-CF",
+	"inherits": "Creality Generic PLA-CF @K2-all @base",
 	"from": "system",
 	"setting_id": "GFSL96_00",
 	"instantiation": "true",
-	"filament_max_volumetric_speed": [
-		"18"
-	],
-	"slow_down_layer_time": [
-		"8"
-	],
-	"additional_cooling_fan_speed": [
-		"0"
-	],
 	"compatible_printers": [
 		"Creality K2 0.2 nozzle",
 		"Creality K2 0.4 nozzle",

--- a/resources/profiles/Creality/filament/Creality Generic PLA-CF.json
+++ b/resources/profiles/Creality/filament/Creality Generic PLA-CF.json
@@ -1,25 +1,10 @@
 {
 	"type": "filament",
 	"name": "Creality Generic PLA-CF",
-	"inherits": "fdm_filament_pla",
+	"inherits": "Creality Generic PLA-CF @base",
 	"from": "system",
 	"filament_id": "GFL98",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"0.95"
-	],
-	"filament_type": [
-		"PLA-CF"
-	],
-	"filament_max_volumetric_speed": [
-		"12"
-	],
-	"slow_down_layer_time": [
-		"7"
-	],
-	"filament_cost": [
-		"30"
-	],
 	"compatible_printers": [
 		"Creality CR-10 V2 0.4 nozzle",
 		"Creality CR-10 V3 0.4 nozzle",

--- a/resources/profiles/Creality/filament/Creality Generic PLA.json
+++ b/resources/profiles/Creality/filament/Creality Generic PLA.json
@@ -1,20 +1,11 @@
 {
 	"type": "filament",
 	"name": "Creality Generic PLA",
-	"inherits": "fdm_filament_pla",
+	"inherits": "Creality Generic PLA @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFL99",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"0.98"
-	],
-	"filament_max_volumetric_speed": [
-		"12"
-	],
-	"slow_down_layer_time": [
-		"8"
-	],
 	"compatible_printers": [
 		"Creality CR-10 V2 0.4 nozzle",
 		"Creality CR-10 V3 0.4 nozzle",

--- a/resources/profiles/Creality/filament/Creality Generic TPU @Ender-3V3-all.json
+++ b/resources/profiles/Creality/filament/Creality Generic TPU @Ender-3V3-all.json
@@ -1,34 +1,10 @@
 {
 	"type": "filament",
 	"name": "Creality Generic TPU @Ender-3V3-all",
-	"inherits": "Creality Generic TPU",
+	"inherits": "Creality Generic TPU @Ender-3V3-all @base",
 	"from": "system",
 	"setting_id": "GFU99_CREALITY_00",
 	"instantiation": "true",
-	"hot_plate_temp": [
-		"30"
-	],
-	"hot_plate_temp_initial_layer": [
-		"30"
-	],
-	"textured_plate_temp": [
-		"30"
-	],
-	"textured_plate_temp_initial_layer": [
-		"30"
-	],
-	"nozzle_temperature_initial_layer": [
-		"230"
-	],
-	"nozzle_temperature": [
-		"230"
-	],
-	"filament_max_volumetric_speed": [
-		"3.5"
-	],
-	"slow_down_layer_time": [
-		"5"
-	],
 	"compatible_printers": [
 		"Creality Ender-3 V3 SE 0.2 nozzle",
 		"Creality Ender-3 V3 SE 0.4 nozzle",

--- a/resources/profiles/Creality/filament/Creality Generic TPU @Ender-5Max-all.json
+++ b/resources/profiles/Creality/filament/Creality Generic TPU @Ender-5Max-all.json
@@ -1,107 +1,12 @@
 {
 	"type": "filament",
 	"name": "Creality Generic TPU @Ender-5Max-all",
-	"inherits": "fdm_filament_common",
+	"inherits": "Creality Generic TPU @Ender-5Max-all @base",
 	"from": "system",
 	"setting_id": "GFSA04_CREALITY_00",
 	"filament_id": "10001",
 	"instantiation": "true",
-	"activate_air_filtration": "0",
-	"activate_chamber_temp_control": "0",
-	"additional_cooling_fan_speed": "0",
-	"chamber_temperature": "35",
-	"close_fan_the_first_x_layers": "1",
 	"compatible_printers": [
 		"Creality Ender-5 Max 0.4 nozzle"
-	],
-	"complete_print_exhaust_fan_speed": "80",
-	"cool_plate_temp": "45",
-	"cool_plate_temp_initial_layer": "45",
-	"cool_special_cds_fan_speed": "0",
-	"default_filament_colour": "\"\"",
-	"during_print_exhaust_fan_speed": "60",
-	"enable_overhang_bridge_fan": "1",
-	"enable_pressure_advance": "0",
-	"eng_plate_temp": "35",
-	"eng_plate_temp_initial_layer": "35",
-	"fan_cooling_layer_time": "100",
-	"fan_max_speed": "100",
-	"fan_min_speed": "100",
-	"filament_cooling_final_speed": "3.4",
-	"filament_cooling_initial_speed": "2.2",
-	"filament_cooling_moves": "4",
-	"filament_cost": [
-		"20"
-	],
-	"filament_density": [
-		"1.26"
-	],
-	"filament_deretraction_speed": "30",
-	"filament_diameter": "1.75",
-	"filament_end_gcode": [
-		"; filament end gcode \n"
-	],
-	"filament_flow_ratio": "1",
-	"filament_is_support": "0",
-	"filament_load_time": "0",
-	"filament_loading_speed": "28",
-	"filament_loading_speed_start": "3",
-	"filament_max_volumetric_speed": [
-		"2"
-	],
-	"filament_minimal_purge_on_wipe_tower": "15",
-	"filament_multitool_ramming": "0",
-	"filament_multitool_ramming_flow": "10",
-	"filament_multitool_ramming_volume": "10",
-	"filament_notes": "\"\"",
-	"filament_ramming_parameters": "\"120 100 6.6 6.8 7.2 7.6 7.9 8.2 8.7 9.4 9.9 10.0| 0.05 6.6 0.45 6.8 0.95 7.8 1.45 8.3 1.95 9.7 2.45 10 2.95 7.6 3.45 7.6 3.95 7.6 4.45 7.6 4.95 7.6\"",
-	"filament_retract_before_wipe": "nil",
-	"filament_retract_lift_above": "0",
-	"filament_retract_lift_below": "0",
-	"filament_retract_lift_enforce": "All Surfaces",
-	"filament_retract_restart_extra": "nil",
-	"filament_retract_when_changing_layer": "nil",
-	"filament_retraction_length": "3",
-	"filament_retraction_minimum_travel": "nil",
-	"filament_retraction_speed": "30",
-	"filament_shrink": "100%",
-	"filament_soluble": "0",
-	"filament_start_gcode": [
-		"; filament start gcode\n"
-	],
-	"filament_toolchange_delay": "0",
-	"filament_type": [
-		"TPU"
-	],
-	"filament_unload_time": "0",
-	"filament_unloading_speed": "90",
-	"filament_unloading_speed_start": "100",
-	"filament_vendor": [
-		"Creality"
-	],
-	"filament_wipe": "nil",
-	"filament_wipe_distance": "nil",
-	"filament_z_hop": "nil",
-	"filament_z_hop_types": "nil",
-	"full_fan_speed_layer": "0",
-	"hot_plate_temp": "45",
-	"hot_plate_temp_initial_layer": "45",
-	"nozzle_temperature": "195",
-	"nozzle_temperature_initial_layer": "195",
-	"nozzle_temperature_range_high": "220",
-	"nozzle_temperature_range_low": "200",
-	"overhang_fan_speed": "100",
-	"overhang_fan_threshold": "50%",
-	"pressure_advance": "0.02",
-	"reduce_fan_stop_start_freq": "1",
-	"required_nozzle_HRC": "0",
-	"slow_down_for_layer_cooling": "1",
-	"slow_down_layer_time": "8",
-	"slow_down_min_speed": "5",
-	"support_material_interface_fan_speed": "-1",
-	"temperature_vitrification": [
-		"60"
-	],
-	"textured_plate_temp": "45",
-	"textured_plate_temp_initial_layer": "45"
+	]
 }

--- a/resources/profiles/Creality/filament/Creality Generic TPU @Hi-all.json
+++ b/resources/profiles/Creality/filament/Creality Generic TPU @Hi-all.json
@@ -1,37 +1,10 @@
 {
 	"type": "filament",
 	"name": "Creality Generic TPU @Hi-all",
-	"inherits": "Creality Generic TPU",
+	"inherits": "Creality Generic TPU @Hi-all @base",
 	"from": "system",
 	"setting_id": "GFU99_CREALITY_00",
 	"instantiation": "true",
-	"hot_plate_temp": [
-		"30"
-	],
-	"hot_plate_temp_initial_layer": [
-		"30"
-	],
-	"textured_plate_temp": [
-		"30"
-	],
-	"textured_plate_temp_initial_layer": [
-		"30"
-	],
-	"nozzle_temperature_initial_layer": [
-		"230"
-	],
-	"nozzle_temperature": [
-		"230"
-	],
-	"filament_max_volumetric_speed": [
-		"3.5"
-	],
-	"slow_down_layer_time": [
-		"5"
-	],
-	"filament_start_gcode": [
-		"; filament start gcode\n{if (position[2] > first_layer_height) }\nM104 S[nozzle_temperature]\n{else}\nM104 S[first_layer_temperature]\n{endif}\n"
-	],
 	"compatible_printers": [
 		"Creality Hi 0.4 nozzle",
 		"Creality Hi 0.6 nozzle"

--- a/resources/profiles/Creality/filament/Creality Generic TPU @K1-all.json
+++ b/resources/profiles/Creality/filament/Creality Generic TPU @K1-all.json
@@ -1,37 +1,10 @@
 {
 	"type": "filament",
 	"name": "Creality Generic TPU @K1-all",
-	"inherits": "Creality Generic TPU",
+	"inherits": "Creality Generic TPU @K1-all @base",
 	"from": "system",
 	"setting_id": "GFU99_CREALITY_00",
 	"instantiation": "true",
-	"hot_plate_temp": [
-		"30"
-	],
-	"hot_plate_temp_initial_layer": [
-		"30"
-	],
-	"textured_plate_temp": [
-		"30"
-	],
-	"textured_plate_temp_initial_layer": [
-		"30"
-	],
-	"nozzle_temperature_initial_layer": [
-		"230"
-	],
-	"nozzle_temperature": [
-		"230"
-	],
-	"filament_max_volumetric_speed": [
-		"3.5"
-	],
-	"slow_down_layer_time": [
-		"5"
-	],
-	"reduce_fan_stop_start_freq": [
-		"0"
-	],
 	"compatible_printers": [
 		"Creality K1C 0.4 nozzle",
 		"Creality K1C 0.6 nozzle",

--- a/resources/profiles/Creality/filament/Creality Generic TPU @K2-all.json
+++ b/resources/profiles/Creality/filament/Creality Generic TPU @K2-all.json
@@ -1,40 +1,10 @@
 {
 	"type": "filament",
 	"name": "Creality Generic TPU @K2-all",
-	"inherits": "Creality Generic TPU",
+	"inherits": "Creality Generic TPU @K2-all @base",
 	"from": "system",
 	"setting_id": "GFU99_CREALITY_00",
 	"instantiation": "true",
-	"hot_plate_temp": [
-		"40"
-	],
-	"hot_plate_temp_initial_layer": [
-		"40"
-	],
-	"textured_plate_temp": [
-		"40"
-	],
-	"textured_plate_temp_initial_layer": [
-		"40"
-	],
-	"nozzle_temperature_initial_layer": [
-		"220"
-	],
-	"nozzle_temperature": [
-		"220"
-	],
-	"filament_max_volumetric_speed": [
-		"3"
-	],
-	"slow_down_layer_time": [
-		"8"
-	],
-	"reduce_fan_stop_start_freq": [
-		"1"
-	],
-	"filament_start_gcode": [
-		";filament start gcode\n{if (position[2] > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
-	],
 	"compatible_printers": [
 		"Creality K2 0.2 nozzle",
 		"Creality K2 0.4 nozzle",

--- a/resources/profiles/Creality/filament/Creality Generic TPU.json
+++ b/resources/profiles/Creality/filament/Creality Generic TPU.json
@@ -1,14 +1,11 @@
 {
 	"type": "filament",
 	"name": "Creality Generic TPU",
-	"inherits": "fdm_filament_tpu",
+	"inherits": "Creality Generic TPU @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFU99",
 	"instantiation": "true",
-	"filament_max_volumetric_speed": [
-		"3.2"
-	],
 	"compatible_printers": [
 		"Creality CR-10 V3 0.4 nozzle",
 		"Creality CR-10 V3 0.6 nozzle",

--- a/resources/profiles/Creality/filament/Creality HF Generic PLA.json
+++ b/resources/profiles/Creality/filament/Creality HF Generic PLA.json
@@ -1,23 +1,11 @@
 {
 	"type": "filament",
 	"name": "Creality HF Generic PLA",
-	"inherits": "fdm_filament_pla",
+	"inherits": "Creality HF Generic PLA @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFL99",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"0.98"
-	],
-	"filament_max_volumetric_speed": [
-		"18"
-	],
-	"slow_down_layer_time": [
-		"8"
-	],
-	"slow_down_min_speed": [
-		"20"
-	],
 	"compatible_printers": [
 		"Creality K1 (0.4 nozzle)",
 		"Creality K1 (0.6 nozzle)",

--- a/resources/profiles/Creality/filament/Creality HF Generic Speed PLA.json
+++ b/resources/profiles/Creality/filament/Creality HF Generic Speed PLA.json
@@ -1,23 +1,11 @@
 {
 	"type": "filament",
 	"name": "Creality HF Generic Speed PLA",
-	"inherits": "fdm_filament_pla",
+	"inherits": "Creality HF Generic Speed PLA @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFL99",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"0.98"
-	],
-	"filament_max_volumetric_speed": [
-		"23"
-	],
-	"slow_down_layer_time": [
-		"5"
-	],
-	"slow_down_min_speed": [
-		"20"
-	],
 	"compatible_printers": [
 		"Creality K1 (0.4 nozzle)",
 		"Creality K1 (0.6 nozzle)",

--- a/resources/profiles/Creality/filament/Creality Hyper ABS @Ender-5Max-all.json
+++ b/resources/profiles/Creality/filament/Creality Hyper ABS @Ender-5Max-all.json
@@ -1,107 +1,12 @@
 {
 	"type": "filament",
 	"name": "Creality Hyper ABS @Ender-5Max-all",
-	"inherits": "fdm_filament_common",
+	"inherits": "Creality Hyper ABS @Ender-5Max-all @base",
 	"from": "system",
 	"setting_id": "GFSA04_CREALITY_00",
 	"filament_id": "03001",
 	"instantiation": "true",
-	"activate_air_filtration": "0",
-	"activate_chamber_temp_control": "0",
-	"additional_cooling_fan_speed": "0",
-	"chamber_temperature": "35",
-	"close_fan_the_first_x_layers": "3",
 	"compatible_printers": [
 		"Creality Ender-5 Max 0.4 nozzle"
-	],
-	"complete_print_exhaust_fan_speed": "80",
-	"cool_plate_temp": "90",
-	"cool_plate_temp_initial_layer": "90",
-	"cool_special_cds_fan_speed": "0",
-	"default_filament_colour": "\"\"",
-	"during_print_exhaust_fan_speed": "60",
-	"enable_overhang_bridge_fan": "1",
-	"enable_pressure_advance": "1",
-	"eng_plate_temp": "105",
-	"eng_plate_temp_initial_layer": "105",
-	"fan_cooling_layer_time": "30",
-	"fan_max_speed": "20",
-	"fan_min_speed": "20",
-	"filament_cooling_final_speed": "3.4",
-	"filament_cooling_initial_speed": "2.2",
-	"filament_cooling_moves": "4",
-	"filament_cost": [
-		"15"
-	],
-	"filament_density": [
-		"1.08"
-	],
-	"filament_deretraction_speed": "nil",
-	"filament_diameter": "1.75",
-	"filament_end_gcode": [
-		"; filament end gcode \n"
-	],
-	"filament_flow_ratio": "0.92",
-	"filament_is_support": "0",
-	"filament_load_time": "0",
-	"filament_loading_speed": "28",
-	"filament_loading_speed_start": "3",
-	"filament_max_volumetric_speed": [
-		"60"
-	],
-	"filament_minimal_purge_on_wipe_tower": "15",
-	"filament_multitool_ramming": "0",
-	"filament_multitool_ramming_flow": "10",
-	"filament_multitool_ramming_volume": "10",
-	"filament_notes": "\"\"",
-	"filament_ramming_parameters": "\"120 100 6.6 6.8 7.2 7.6 7.9 8.2 8.7 9.4 9.9 10.0| 0.05 6.6 0.45 6.8 0.95 7.8 1.45 8.3 1.95 9.7 2.45 10 2.95 7.6 3.45 7.6 3.95 7.6 4.45 7.6 4.95 7.6\"",
-	"filament_retract_before_wipe": "nil",
-	"filament_retract_lift_above": "0",
-	"filament_retract_lift_below": "0",
-	"filament_retract_lift_enforce": "All Surfaces",
-	"filament_retract_restart_extra": "0",
-	"filament_retract_when_changing_layer": "nil",
-	"filament_retraction_length": "nil",
-	"filament_retraction_minimum_travel": "nil",
-	"filament_retraction_speed": "nil",
-	"filament_shrink": "100%",
-	"filament_soluble": "0",
-	"filament_start_gcode": [
-		"; Filament gcode\n"
-	],
-	"filament_toolchange_delay": "0",
-	"filament_type": [
-		"ABS"
-	],
-	"filament_unload_time": "0",
-	"filament_unloading_speed": "90",
-	"filament_unloading_speed_start": "100",
-	"filament_vendor": [
-		"Creality"
-	],
-	"filament_wipe": "nil",
-	"filament_wipe_distance": "nil",
-	"filament_z_hop": "nil",
-	"filament_z_hop_types": "nil",
-	"full_fan_speed_layer": "0",
-	"hot_plate_temp": "90",
-	"hot_plate_temp_initial_layer": "90",
-	"nozzle_temperature": "260",
-	"nozzle_temperature_initial_layer": "260",
-	"nozzle_temperature_range_high": "260",
-	"nozzle_temperature_range_low": "230",
-	"overhang_fan_speed": "20",
-	"overhang_fan_threshold": "25%",
-	"pressure_advance": "0.025",
-	"reduce_fan_stop_start_freq": "1",
-	"required_nozzle_HRC": "0",
-	"slow_down_for_layer_cooling": "1",
-	"slow_down_layer_time": "5",
-	"slow_down_min_speed": "10",
-	"support_material_interface_fan_speed": "-1",
-	"temperature_vitrification": [
-		"110"
-	],
-	"textured_plate_temp": "90",
-	"textured_plate_temp_initial_layer": "90"
+	]
 }

--- a/resources/profiles/Creality/filament/Creality Hyper PLA @Ender-5Max-all.json
+++ b/resources/profiles/Creality/filament/Creality Hyper PLA @Ender-5Max-all.json
@@ -1,108 +1,12 @@
 {
 	"type": "filament",
 	"name": "Creality Hyper PLA @Ender-5Max-all",
-	"inherits": "fdm_filament_common",
+	"inherits": "Creality Hyper PLA @Ender-5Max-all @base",
 	"from": "system",
 	"setting_id": "GFSA04_CREALITY_00",
 	"filament_id": "01001",
 	"instantiation": "true",
-	"activate_air_filtration": "0",
-	"activate_chamber_temp_control": "0",
-	"additional_cooling_fan_speed": "0",
-	"chamber_temperature": "0",
-	"close_fan_the_first_x_layers": "1",
 	"compatible_printers": [
 		"Creality Ender-5 Max 0.4 nozzle"
-	],
-	"complete_print_exhaust_fan_speed": "80",
-	"cool_plate_temp": "45",
-	"cool_plate_temp_initial_layer": "45",
-	"cool_special_cds_fan_speed": "0",
-	"default_filament_colour": "\"\"",
-	"during_print_exhaust_fan_speed": "60",
-	"enable_overhang_bridge_fan": "1",
-	"enable_pressure_advance": "1",
-	"eng_plate_temp": "50",
-	"eng_plate_temp_initial_layer": "50",
-	"fan_cooling_layer_time": "100",
-	"fan_max_speed": "100",
-	"fan_min_speed": "100",
-	"filament_cooling_final_speed": "3.4",
-	"filament_cooling_initial_speed": "2.2",
-	"filament_cooling_moves": "4",
-	"filament_cost": [
-		"30"
-	],
-	"filament_density": [
-		"1.24"
-	],
-	"filament_deretraction_speed": "nil",
-	"filament_diameter": "1.75",
-	"filament_end_gcode": [
-		"; filament end gcode \n"
-	],
-	"filament_flow_ratio": "0.97",
-	"filament_is_support": "0",
-	"filament_load_time": "0",
-	"filament_loading_speed": "28",
-	"filament_loading_speed_start": "3",
-	"filament_max_volumetric_speed": [
-		"50"
-	],
-	"filament_minimal_purge_on_wipe_tower": "15",
-	"filament_multitool_ramming": "0",
-	"filament_multitool_ramming_flow": "10",
-	"filament_multitool_ramming_volume": "10",
-	"filament_notes": "\"\"",
-	"filament_ramming_parameters": "\"120 100 6.6 6.8 7.2 7.6 7.9 8.2 8.7 9.4 9.9 10.0| 0.05 6.6 0.45 6.8 0.95 7.8 1.45 8.3 1.95 9.7 2.45 10 2.95 7.6 3.45 7.6 3.95 7.6 4.45 7.6 4.95 7.6\"",
-	"filament_retract_before_wipe": "nil",
-	"filament_retract_lift_above": "0",
-	"filament_retract_lift_below": "0",
-	"filament_retract_lift_enforce": "All Surfaces",
-	"filament_retract_restart_extra": "nil",
-	"filament_retract_when_changing_layer": "nil",
-	"filament_retraction_length": "nil",
-	"filament_retraction_minimum_travel": "nil",
-	"filament_retraction_speed": "nil",
-	"filament_shrink": "100%",
-	"filament_shrinkage_compensation_z": "100%",
-	"filament_soluble": "0",
-	"filament_start_gcode": [
-		"; filament start gcode\n"
-	],
-	"filament_toolchange_delay": "0",
-	"filament_type": [
-		"PLA"
-	],
-	"filament_unload_time": "0",
-	"filament_unloading_speed": "90",
-	"filament_unloading_speed_start": "100",
-	"filament_vendor": [
-		"Creality"
-	],
-	"filament_wipe": "nil",
-	"filament_wipe_distance": "nil",
-	"filament_z_hop": "nil",
-	"filament_z_hop_types": "nil",
-	"full_fan_speed_layer": "0",
-	"hot_plate_temp": "45",
-	"hot_plate_temp_initial_layer": "45",
-	"nozzle_temperature": "220",
-	"nozzle_temperature_initial_layer": "220",
-	"nozzle_temperature_range_high": "240",
-	"nozzle_temperature_range_low": "190",
-	"overhang_fan_speed": "100",
-	"overhang_fan_threshold": "50%",
-	"pressure_advance": "0.04",
-	"reduce_fan_stop_start_freq": "1",
-	"required_nozzle_HRC": "0",
-	"slow_down_for_layer_cooling": "1",
-	"slow_down_layer_time": "5",
-	"slow_down_min_speed": "20",
-	"support_material_interface_fan_speed": "-1",
-	"temperature_vitrification": [
-		"60"
-	],
-	"textured_plate_temp": "45",
-	"textured_plate_temp_initial_layer": "45"
+	]
 }

--- a/resources/profiles/Creality/filament/Creality Hyper PLA-CF @Ender-5Max-all.json
+++ b/resources/profiles/Creality/filament/Creality Hyper PLA-CF @Ender-5Max-all.json
@@ -1,107 +1,12 @@
 {
 	"type": "filament",
 	"name": "Creality Hyper PLA-CF @Ender-5Max-all",
-	"inherits": "fdm_filament_common",
+	"inherits": "Creality Hyper PLA-CF @Ender-5Max-all @base",
 	"from": "system",
 	"setting_id": "GFSA04_CREALITY_00",
 	"filament_id": "02001",
 	"instantiation": "true",
-	"activate_air_filtration": "0",
-	"activate_chamber_temp_control": "0",
-	"additional_cooling_fan_speed": "0",
-	"chamber_temperature": "35",
-	"close_fan_the_first_x_layers": "1",
 	"compatible_printers": [
 		"Creality Ender-5 Max 0.4 nozzle"
-	],
-	"complete_print_exhaust_fan_speed": "80",
-	"cool_plate_temp": "45",
-	"cool_plate_temp_initial_layer": "45",
-	"cool_special_cds_fan_speed": "0",
-	"default_filament_colour": "\"\"",
-	"during_print_exhaust_fan_speed": "60",
-	"enable_overhang_bridge_fan": "1",
-	"enable_pressure_advance": "1",
-	"eng_plate_temp": "50",
-	"eng_plate_temp_initial_layer": "50",
-	"fan_cooling_layer_time": "100",
-	"fan_max_speed": "100",
-	"fan_min_speed": "100",
-	"filament_cooling_final_speed": "3.4",
-	"filament_cooling_initial_speed": "2.2",
-	"filament_cooling_moves": "4",
-	"filament_cost": [
-		"32"
-	],
-	"filament_density": [
-		"1.27"
-	],
-	"filament_deretraction_speed": "nil",
-	"filament_diameter": "1.75",
-	"filament_end_gcode": [
-		"; filament end gcode \n"
-	],
-	"filament_flow_ratio": "0.9",
-	"filament_is_support": "0",
-	"filament_load_time": "0",
-	"filament_loading_speed": "28",
-	"filament_loading_speed_start": "3",
-	"filament_max_volumetric_speed": [
-		"40"
-	],
-	"filament_minimal_purge_on_wipe_tower": "15",
-	"filament_multitool_ramming": "0",
-	"filament_multitool_ramming_flow": "10",
-	"filament_multitool_ramming_volume": "10",
-	"filament_notes": "\"\"",
-	"filament_ramming_parameters": "\"120 100 6.6 6.8 7.2 7.6 7.9 8.2 8.7 9.4 9.9 10.0| 0.05 6.6 0.45 6.8 0.95 7.8 1.45 8.3 1.95 9.7 2.45 10 2.95 7.6 3.45 7.6 3.95 7.6 4.45 7.6 4.95 7.6\"",
-	"filament_retract_before_wipe": "nil",
-	"filament_retract_lift_above": "0",
-	"filament_retract_lift_below": "0",
-	"filament_retract_lift_enforce": "All Surfaces",
-	"filament_retract_restart_extra": "nil",
-	"filament_retract_when_changing_layer": "nil",
-	"filament_retraction_length": "nil",
-	"filament_retraction_minimum_travel": "nil",
-	"filament_retraction_speed": "nil",
-	"filament_shrink": "100%",
-	"filament_soluble": "0",
-	"filament_start_gcode": [
-		"; filament start gcode\n"
-	],
-	"filament_toolchange_delay": "0",
-	"filament_type": [
-		"PLA-CF"
-	],
-	"filament_unload_time": "0",
-	"filament_unloading_speed": "90",
-	"filament_unloading_speed_start": "100",
-	"filament_vendor": [
-		"Creality"
-	],
-	"filament_wipe": "nil",
-	"filament_wipe_distance": "nil",
-	"filament_z_hop": "nil",
-	"filament_z_hop_types": "nil",
-	"full_fan_speed_layer": "0",
-	"hot_plate_temp": "45",
-	"hot_plate_temp_initial_layer": "45",
-	"nozzle_temperature": "220",
-	"nozzle_temperature_initial_layer": "220",
-	"nozzle_temperature_range_high": "240",
-	"nozzle_temperature_range_low": "190",
-	"overhang_fan_speed": "100",
-	"overhang_fan_threshold": "50%",
-	"pressure_advance": "0.035",
-	"reduce_fan_stop_start_freq": "1",
-	"required_nozzle_HRC": "0",
-	"slow_down_for_layer_cooling": "1",
-	"slow_down_layer_time": "5",
-	"slow_down_min_speed": "10",
-	"support_material_interface_fan_speed": "-1",
-	"temperature_vitrification": [
-		"60"
-	],
-	"textured_plate_temp": "45",
-	"textured_plate_temp_initial_layer": "45"
+	]
 }

--- a/resources/profiles/Creality/filament/Creality Silk PLA @Ender-5Max-all.json
+++ b/resources/profiles/Creality/filament/Creality Silk PLA @Ender-5Max-all.json
@@ -1,107 +1,12 @@
 {
 	"type": "filament",
 	"name": "Creality Silk PLA @Ender-5Max-all",
-	"inherits": "fdm_filament_common",
+	"inherits": "Creality Silk PLA @Ender-5Max-all @base",
 	"from": "system",
 	"setting_id": "GFSA04_CREALITY_00",
 	"filament_id": "05001",
 	"instantiation": "true",
-	"activate_air_filtration": "0",
-	"activate_chamber_temp_control": "0",
-	"additional_cooling_fan_speed": "0",
-	"chamber_temperature": "35",
-	"close_fan_the_first_x_layers": "1",
 	"compatible_printers": [
 		"Creality Ender-5 Max 0.4 nozzle"
-	],
-	"complete_print_exhaust_fan_speed": "80",
-	"cool_plate_temp": "45",
-	"cool_plate_temp_initial_layer": "45",
-	"cool_special_cds_fan_speed": "0",
-	"default_filament_colour": "\"\"",
-	"during_print_exhaust_fan_speed": "60",
-	"enable_overhang_bridge_fan": "1",
-	"enable_pressure_advance": "1",
-	"eng_plate_temp": "50",
-	"eng_plate_temp_initial_layer": "50",
-	"fan_cooling_layer_time": "100",
-	"fan_max_speed": "100",
-	"fan_min_speed": "100",
-	"filament_cooling_final_speed": "3.4",
-	"filament_cooling_initial_speed": "2.2",
-	"filament_cooling_moves": "4",
-	"filament_cost": [
-		"22"
-	],
-	"filament_density": [
-		"1.25"
-	],
-	"filament_deretraction_speed": "nil",
-	"filament_diameter": "1.75",
-	"filament_end_gcode": [
-		"; filament end gcode \n"
-	],
-	"filament_flow_ratio": "0.85",
-	"filament_is_support": "0",
-	"filament_load_time": "0",
-	"filament_loading_speed": "28",
-	"filament_loading_speed_start": "3",
-	"filament_max_volumetric_speed": [
-		"20"
-	],
-	"filament_minimal_purge_on_wipe_tower": "15",
-	"filament_multitool_ramming": "0",
-	"filament_multitool_ramming_flow": "10",
-	"filament_multitool_ramming_volume": "10",
-	"filament_notes": "\"\"",
-	"filament_ramming_parameters": "\"120 100 6.6 6.8 7.2 7.6 7.9 8.2 8.7 9.4 9.9 10.0| 0.05 6.6 0.45 6.8 0.95 7.8 1.45 8.3 1.95 9.7 2.45 10 2.95 7.6 3.45 7.6 3.95 7.6 4.45 7.6 4.95 7.6\"",
-	"filament_retract_before_wipe": "nil",
-	"filament_retract_lift_above": "0",
-	"filament_retract_lift_below": "0",
-	"filament_retract_lift_enforce": "All Surfaces",
-	"filament_retract_restart_extra": "nil",
-	"filament_retract_when_changing_layer": "nil",
-	"filament_retraction_length": "nil",
-	"filament_retraction_minimum_travel": "nil",
-	"filament_retraction_speed": "nil",
-	"filament_shrink": "100%",
-	"filament_soluble": "0",
-	"filament_start_gcode": [
-		"; filament start gcode\n"
-	],
-	"filament_toolchange_delay": "0",
-	"filament_type": [
-		"PLA"
-	],
-	"filament_unload_time": "0",
-	"filament_unloading_speed": "90",
-	"filament_unloading_speed_start": "100",
-	"filament_vendor": [
-		"Creality"
-	],
-	"filament_wipe": "nil",
-	"filament_wipe_distance": "nil",
-	"filament_z_hop": "nil",
-	"filament_z_hop_types": "nil",
-	"full_fan_speed_layer": "0",
-	"hot_plate_temp": "45",
-	"hot_plate_temp_initial_layer": "45",
-	"nozzle_temperature": "230",
-	"nozzle_temperature_initial_layer": "230",
-	"nozzle_temperature_range_high": "240",
-	"nozzle_temperature_range_low": "190",
-	"overhang_fan_speed": "100",
-	"overhang_fan_threshold": "50%",
-	"pressure_advance": "0.02",
-	"reduce_fan_stop_start_freq": "1",
-	"required_nozzle_HRC": "0",
-	"slow_down_for_layer_cooling": "1",
-	"slow_down_layer_time": "5",
-	"slow_down_min_speed": "10",
-	"support_material_interface_fan_speed": "-1",
-	"temperature_vitrification": [
-		"60"
-	],
-	"textured_plate_temp": "45",
-	"textured_plate_temp_initial_layer": "45"
+	]
 }

--- a/resources/profiles/OrcaFilamentLibrary.json
+++ b/resources/profiles/OrcaFilamentLibrary.json
@@ -1507,6 +1507,494 @@
 		{
 			"name": "GreenGate3D PETG @System",
 			"sub_path": "filament/GreenGate3D/GreenGate3D PETG @System.json"
+		},
+		{
+			"name": "Creality Generic ABS @base",
+			"sub_path": "filament/Creality/Creality Generic ABS @base.json"
+		},
+		{
+			"name": "Creality Generic ABS @System",
+			"sub_path": "filament/Creality/Creality Generic ABS @System.json"
+		},
+		{
+			"name": "Creality Generic ABS @Ender-3V3-all @base",
+			"sub_path": "filament/Creality/Creality Generic ABS @Ender-3V3-all @base.json"
+		},
+		{
+			"name": "Creality Generic ABS @Ender-3V3-all @System",
+			"sub_path": "filament/Creality/Creality Generic ABS @Ender-3V3-all @System.json"
+		},
+		{
+			"name": "Creality Generic ABS @Ender-5Max-all @base",
+			"sub_path": "filament/Creality/Creality Generic ABS @Ender-5Max-all @base.json"
+		},
+		{
+			"name": "Creality Generic ABS @Ender-5Max-all @System",
+			"sub_path": "filament/Creality/Creality Generic ABS @Ender-5Max-all @System.json"
+		},
+		{
+			"name": "Creality Generic ABS @Hi-all @base",
+			"sub_path": "filament/Creality/Creality Generic ABS @Hi-all @base.json"
+		},
+		{
+			"name": "Creality Generic ABS @Hi-all @System",
+			"sub_path": "filament/Creality/Creality Generic ABS @Hi-all @System.json"
+		},
+		{
+			"name": "Creality Generic ABS @K1-all @base",
+			"sub_path": "filament/Creality/Creality Generic ABS @K1-all @base.json"
+		},
+		{
+			"name": "Creality Generic ABS @K1-all @System",
+			"sub_path": "filament/Creality/Creality Generic ABS @K1-all @System.json"
+		},
+		{
+			"name": "Creality Generic ABS @K2-all @base",
+			"sub_path": "filament/Creality/Creality Generic ABS @K2-all @base.json"
+		},
+		{
+			"name": "Creality Generic ABS @K2-all @System",
+			"sub_path": "filament/Creality/Creality Generic ABS @K2-all @System.json"
+		},
+		{
+			"name": "Creality Generic ASA @base",
+			"sub_path": "filament/Creality/Creality Generic ASA @base.json"
+		},
+		{
+			"name": "Creality Generic ASA @System",
+			"sub_path": "filament/Creality/Creality Generic ASA @System.json"
+		},
+		{
+			"name": "Creality Generic ASA @Ender-3V3-all @base",
+			"sub_path": "filament/Creality/Creality Generic ASA @Ender-3V3-all @base.json"
+		},
+		{
+			"name": "Creality Generic ASA @Ender-3V3-all @System",
+			"sub_path": "filament/Creality/Creality Generic ASA @Ender-3V3-all @System.json"
+		},
+		{
+			"name": "Creality Generic ASA @Ender-5Max-all @base",
+			"sub_path": "filament/Creality/Creality Generic ASA @Ender-5Max-all @base.json"
+		},
+		{
+			"name": "Creality Generic ASA @Ender-5Max-all @System",
+			"sub_path": "filament/Creality/Creality Generic ASA @Ender-5Max-all @System.json"
+		},
+		{
+			"name": "Creality Generic ASA @Hi-all @base",
+			"sub_path": "filament/Creality/Creality Generic ASA @Hi-all @base.json"
+		},
+		{
+			"name": "Creality Generic ASA @Hi-all @System",
+			"sub_path": "filament/Creality/Creality Generic ASA @Hi-all @System.json"
+		},
+		{
+			"name": "Creality Generic ASA @K1-all @base",
+			"sub_path": "filament/Creality/Creality Generic ASA @K1-all @base.json"
+		},
+		{
+			"name": "Creality Generic ASA @K1-all @System",
+			"sub_path": "filament/Creality/Creality Generic ASA @K1-all @System.json"
+		},
+		{
+			"name": "Creality Generic ASA @K2-all @base",
+			"sub_path": "filament/Creality/Creality Generic ASA @K2-all @base.json"
+		},
+		{
+			"name": "Creality Generic ASA @K2-all @System",
+			"sub_path": "filament/Creality/Creality Generic ASA @K2-all @System.json"
+		},
+		{
+			"name": "Creality Generic ASA-CF @Hi-all @base",
+			"sub_path": "filament/Creality/Creality Generic ASA-CF @Hi-all @base.json"
+		},
+		{
+			"name": "Creality Generic ASA-CF @Hi-all @System",
+			"sub_path": "filament/Creality/Creality Generic ASA-CF @Hi-all @System.json"
+		},
+		{
+			"name": "Creality Generic PA @Ender-5Max-all @base",
+			"sub_path": "filament/Creality/Creality Generic PA @Ender-5Max-all @base.json"
+		},
+		{
+			"name": "Creality Generic PA @Ender-5Max-all @System",
+			"sub_path": "filament/Creality/Creality Generic PA @Ender-5Max-all @System.json"
+		},
+		{
+			"name": "Creality Generic PA-CF @base",
+			"sub_path": "filament/Creality/Creality Generic PA-CF @base.json"
+		},
+		{
+			"name": "Creality Generic PA-CF @System",
+			"sub_path": "filament/Creality/Creality Generic PA-CF @System.json"
+		},
+		{
+			"name": "Creality Generic PA-CF @Ender-3V3-all @base",
+			"sub_path": "filament/Creality/Creality Generic PA-CF @Ender-3V3-all @base.json"
+		},
+		{
+			"name": "Creality Generic PA-CF @Ender-3V3-all @System",
+			"sub_path": "filament/Creality/Creality Generic PA-CF @Ender-3V3-all @System.json"
+		},
+		{
+			"name": "Creality Generic PA-CF @K1-all @base",
+			"sub_path": "filament/Creality/Creality Generic PA-CF @K1-all @base.json"
+		},
+		{
+			"name": "Creality Generic PA-CF @K1-all @System",
+			"sub_path": "filament/Creality/Creality Generic PA-CF @K1-all @System.json"
+		},
+		{
+			"name": "Creality Generic PA-CF @K2-all @base",
+			"sub_path": "filament/Creality/Creality Generic PA-CF @K2-all @base.json"
+		},
+		{
+			"name": "Creality Generic PA-CF @K2-all @System",
+			"sub_path": "filament/Creality/Creality Generic PA-CF @K2-all @System.json"
+		},
+		{
+			"name": "Creality Generic PC @K1-all @base",
+			"sub_path": "filament/Creality/Creality Generic PC @K1-all @base.json"
+		},
+		{
+			"name": "Creality Generic PC @K1-all @System",
+			"sub_path": "filament/Creality/Creality Generic PC @K1-all @System.json"
+		},
+		{
+			"name": "Creality Generic PETG @base",
+			"sub_path": "filament/Creality/Creality Generic PETG @base.json"
+		},
+		{
+			"name": "Creality Generic PETG @System",
+			"sub_path": "filament/Creality/Creality Generic PETG @System.json"
+		},
+		{
+			"name": "Creality Generic PETG @Ender-3V3-all @base",
+			"sub_path": "filament/Creality/Creality Generic PETG @Ender-3V3-all @base.json"
+		},
+		{
+			"name": "Creality Generic PETG @Ender-3V3-all @System",
+			"sub_path": "filament/Creality/Creality Generic PETG @Ender-3V3-all @System.json"
+		},
+		{
+			"name": "Creality Generic PETG @Ender-5Max-all @base",
+			"sub_path": "filament/Creality/Creality Generic PETG @Ender-5Max-all @base.json"
+		},
+		{
+			"name": "Creality Generic PETG @Ender-5Max-all @System",
+			"sub_path": "filament/Creality/Creality Generic PETG @Ender-5Max-all @System.json"
+		},
+		{
+			"name": "Creality Generic PETG @Hi-all @base",
+			"sub_path": "filament/Creality/Creality Generic PETG @Hi-all @base.json"
+		},
+		{
+			"name": "Creality Generic PETG @Hi-all @System",
+			"sub_path": "filament/Creality/Creality Generic PETG @Hi-all @System.json"
+		},
+		{
+			"name": "Creality Generic PETG @K1-all @base",
+			"sub_path": "filament/Creality/Creality Generic PETG @K1-all @base.json"
+		},
+		{
+			"name": "Creality Generic PETG @K1-all @System",
+			"sub_path": "filament/Creality/Creality Generic PETG @K1-all @System.json"
+		},
+		{
+			"name": "Creality Generic PETG @K2-all @base",
+			"sub_path": "filament/Creality/Creality Generic PETG @K2-all @base.json"
+		},
+		{
+			"name": "Creality Generic PETG @K2-all @System",
+			"sub_path": "filament/Creality/Creality Generic PETG @K2-all @System.json"
+		},
+		{
+			"name": "Creality Generic PETG-CF @Hi-all @base",
+			"sub_path": "filament/Creality/Creality Generic PETG-CF @Hi-all @base.json"
+		},
+		{
+			"name": "Creality Generic PETG-CF @Hi-all @System",
+			"sub_path": "filament/Creality/Creality Generic PETG-CF @Hi-all @System.json"
+		},
+		{
+			"name": "Creality Generic PLA @base",
+			"sub_path": "filament/Creality/Creality Generic PLA @base.json"
+		},
+		{
+			"name": "Creality Generic PLA @System",
+			"sub_path": "filament/Creality/Creality Generic PLA @System.json"
+		},
+		{
+			"name": "Creality Generic PLA @Ender-3V3-all @base",
+			"sub_path": "filament/Creality/Creality Generic PLA @Ender-3V3-all @base.json"
+		},
+		{
+			"name": "Creality Generic PLA @Ender-3V3-all @System",
+			"sub_path": "filament/Creality/Creality Generic PLA @Ender-3V3-all @System.json"
+		},
+		{
+			"name": "Creality Generic PLA @Ender-5Max-all @base",
+			"sub_path": "filament/Creality/Creality Generic PLA @Ender-5Max-all @base.json"
+		},
+		{
+			"name": "Creality Generic PLA @Ender-5Max-all @System",
+			"sub_path": "filament/Creality/Creality Generic PLA @Ender-5Max-all @System.json"
+		},
+		{
+			"name": "Creality Generic PLA @Hi-all @base",
+			"sub_path": "filament/Creality/Creality Generic PLA @Hi-all @base.json"
+		},
+		{
+			"name": "Creality Generic PLA @Hi-all @System",
+			"sub_path": "filament/Creality/Creality Generic PLA @Hi-all @System.json"
+		},
+		{
+			"name": "Creality Generic PLA @K1-all @base",
+			"sub_path": "filament/Creality/Creality Generic PLA @K1-all @base.json"
+		},
+		{
+			"name": "Creality Generic PLA @K1-all @System",
+			"sub_path": "filament/Creality/Creality Generic PLA @K1-all @System.json"
+		},
+		{
+			"name": "Creality Generic PLA @K2-all @base",
+			"sub_path": "filament/Creality/Creality Generic PLA @K2-all @base.json"
+		},
+		{
+			"name": "Creality Generic PLA @K2-all @System",
+			"sub_path": "filament/Creality/Creality Generic PLA @K2-all @System.json"
+		},
+		{
+			"name": "Creality Generic PLA High Speed @Ender-3V3-all @base",
+			"sub_path": "filament/Creality/Creality Generic PLA High Speed @Ender-3V3-all @base.json"
+		},
+		{
+			"name": "Creality Generic PLA High Speed @Ender-3V3-all @System",
+			"sub_path": "filament/Creality/Creality Generic PLA High Speed @Ender-3V3-all @System.json"
+		},
+		{
+			"name": "Creality Generic PLA High Speed @Hi-all @base",
+			"sub_path": "filament/Creality/Creality Generic PLA High Speed @Hi-all @base.json"
+		},
+		{
+			"name": "Creality Generic PLA High Speed @Hi-all @System",
+			"sub_path": "filament/Creality/Creality Generic PLA High Speed @Hi-all @System.json"
+		},
+		{
+			"name": "Creality Generic PLA High Speed @K1-all @base",
+			"sub_path": "filament/Creality/Creality Generic PLA High Speed @K1-all @base.json"
+		},
+		{
+			"name": "Creality Generic PLA High Speed @K1-all @System",
+			"sub_path": "filament/Creality/Creality Generic PLA High Speed @K1-all @System.json"
+		},
+		{
+			"name": "Creality Generic PLA High Speed @K2-all @base",
+			"sub_path": "filament/Creality/Creality Generic PLA High Speed @K2-all @base.json"
+		},
+		{
+			"name": "Creality Generic PLA High Speed @K2-all @System",
+			"sub_path": "filament/Creality/Creality Generic PLA High Speed @K2-all @System.json"
+		},
+		{
+			"name": "Creality Generic PLA Matte @Ender-3V3-all @base",
+			"sub_path": "filament/Creality/Creality Generic PLA Matte @Ender-3V3-all @base.json"
+		},
+		{
+			"name": "Creality Generic PLA Matte @Ender-3V3-all @System",
+			"sub_path": "filament/Creality/Creality Generic PLA Matte @Ender-3V3-all @System.json"
+		},
+		{
+			"name": "Creality Generic PLA Matte @Hi-all @base",
+			"sub_path": "filament/Creality/Creality Generic PLA Matte @Hi-all @base.json"
+		},
+		{
+			"name": "Creality Generic PLA Matte @Hi-all @System",
+			"sub_path": "filament/Creality/Creality Generic PLA Matte @Hi-all @System.json"
+		},
+		{
+			"name": "Creality Generic PLA Matte @K1-all @base",
+			"sub_path": "filament/Creality/Creality Generic PLA Matte @K1-all @base.json"
+		},
+		{
+			"name": "Creality Generic PLA Matte @K1-all @System",
+			"sub_path": "filament/Creality/Creality Generic PLA Matte @K1-all @System.json"
+		},
+		{
+			"name": "Creality Generic PLA Matte @K2-all @base",
+			"sub_path": "filament/Creality/Creality Generic PLA Matte @K2-all @base.json"
+		},
+		{
+			"name": "Creality Generic PLA Matte @K2-all @System",
+			"sub_path": "filament/Creality/Creality Generic PLA Matte @K2-all @System.json"
+		},
+		{
+			"name": "Creality Generic PLA Silk @Ender-3V3-all @base",
+			"sub_path": "filament/Creality/Creality Generic PLA Silk @Ender-3V3-all @base.json"
+		},
+		{
+			"name": "Creality Generic PLA Silk @Ender-3V3-all @System",
+			"sub_path": "filament/Creality/Creality Generic PLA Silk @Ender-3V3-all @System.json"
+		},
+		{
+			"name": "Creality Generic PLA Silk @Hi-all @base",
+			"sub_path": "filament/Creality/Creality Generic PLA Silk @Hi-all @base.json"
+		},
+		{
+			"name": "Creality Generic PLA Silk @Hi-all @System",
+			"sub_path": "filament/Creality/Creality Generic PLA Silk @Hi-all @System.json"
+		},
+		{
+			"name": "Creality Generic PLA Silk @K1-all @base",
+			"sub_path": "filament/Creality/Creality Generic PLA Silk @K1-all @base.json"
+		},
+		{
+			"name": "Creality Generic PLA Silk @K1-all @System",
+			"sub_path": "filament/Creality/Creality Generic PLA Silk @K1-all @System.json"
+		},
+		{
+			"name": "Creality Generic PLA Silk @K2-all @base",
+			"sub_path": "filament/Creality/Creality Generic PLA Silk @K2-all @base.json"
+		},
+		{
+			"name": "Creality Generic PLA Silk @K2-all @System",
+			"sub_path": "filament/Creality/Creality Generic PLA Silk @K2-all @System.json"
+		},
+		{
+			"name": "Creality Generic PLA Wood @Hi-all @base",
+			"sub_path": "filament/Creality/Creality Generic PLA Wood @Hi-all @base.json"
+		},
+		{
+			"name": "Creality Generic PLA Wood @Hi-all @System",
+			"sub_path": "filament/Creality/Creality Generic PLA Wood @Hi-all @System.json"
+		},
+		{
+			"name": "Creality Generic PLA-CF @base",
+			"sub_path": "filament/Creality/Creality Generic PLA-CF @base.json"
+		},
+		{
+			"name": "Creality Generic PLA-CF @System",
+			"sub_path": "filament/Creality/Creality Generic PLA-CF @System.json"
+		},
+		{
+			"name": "Creality Generic PLA-CF @Hi-all @base",
+			"sub_path": "filament/Creality/Creality Generic PLA-CF @Hi-all @base.json"
+		},
+		{
+			"name": "Creality Generic PLA-CF @Hi-all @System",
+			"sub_path": "filament/Creality/Creality Generic PLA-CF @Hi-all @System.json"
+		},
+		{
+			"name": "Creality Generic PLA-CF @K1-all @base",
+			"sub_path": "filament/Creality/Creality Generic PLA-CF @K1-all @base.json"
+		},
+		{
+			"name": "Creality Generic PLA-CF @K1-all @System",
+			"sub_path": "filament/Creality/Creality Generic PLA-CF @K1-all @System.json"
+		},
+		{
+			"name": "Creality Generic PLA-CF @K2-all @base",
+			"sub_path": "filament/Creality/Creality Generic PLA-CF @K2-all @base.json"
+		},
+		{
+			"name": "Creality Generic PLA-CF @K2-all @System",
+			"sub_path": "filament/Creality/Creality Generic PLA-CF @K2-all @System.json"
+		},
+		{
+			"name": "Creality Generic TPU @base",
+			"sub_path": "filament/Creality/Creality Generic TPU @base.json"
+		},
+		{
+			"name": "Creality Generic TPU @System",
+			"sub_path": "filament/Creality/Creality Generic TPU @System.json"
+		},
+		{
+			"name": "Creality Generic TPU @Ender-3V3-all @base",
+			"sub_path": "filament/Creality/Creality Generic TPU @Ender-3V3-all @base.json"
+		},
+		{
+			"name": "Creality Generic TPU @Ender-3V3-all @System",
+			"sub_path": "filament/Creality/Creality Generic TPU @Ender-3V3-all @System.json"
+		},
+		{
+			"name": "Creality Generic TPU @Ender-5Max-all @base",
+			"sub_path": "filament/Creality/Creality Generic TPU @Ender-5Max-all @base.json"
+		},
+		{
+			"name": "Creality Generic TPU @Ender-5Max-all @System",
+			"sub_path": "filament/Creality/Creality Generic TPU @Ender-5Max-all @System.json"
+		},
+		{
+			"name": "Creality Generic TPU @Hi-all @base",
+			"sub_path": "filament/Creality/Creality Generic TPU @Hi-all @base.json"
+		},
+		{
+			"name": "Creality Generic TPU @Hi-all @System",
+			"sub_path": "filament/Creality/Creality Generic TPU @Hi-all @System.json"
+		},
+		{
+			"name": "Creality Generic TPU @K1-all @base",
+			"sub_path": "filament/Creality/Creality Generic TPU @K1-all @base.json"
+		},
+		{
+			"name": "Creality Generic TPU @K1-all @System",
+			"sub_path": "filament/Creality/Creality Generic TPU @K1-all @System.json"
+		},
+		{
+			"name": "Creality Generic TPU @K2-all @base",
+			"sub_path": "filament/Creality/Creality Generic TPU @K2-all @base.json"
+		},
+		{
+			"name": "Creality Generic TPU @K2-all @System",
+			"sub_path": "filament/Creality/Creality Generic TPU @K2-all @System.json"
+		},
+		{
+			"name": "Creality HF Generic PLA @base",
+			"sub_path": "filament/Creality/Creality HF Generic PLA @base.json"
+		},
+		{
+			"name": "Creality HF Generic PLA @System",
+			"sub_path": "filament/Creality/Creality HF Generic PLA @System.json"
+		},
+		{
+			"name": "Creality HF Generic Speed PLA @base",
+			"sub_path": "filament/Creality/Creality HF Generic Speed PLA @base.json"
+		},
+		{
+			"name": "Creality HF Generic Speed PLA @System",
+			"sub_path": "filament/Creality/Creality HF Generic Speed PLA @System.json"
+		},
+		{
+			"name": "Creality Hyper ABS @Ender-5Max-all @base",
+			"sub_path": "filament/Creality/Creality Hyper ABS @Ender-5Max-all @base.json"
+		},
+		{
+			"name": "Creality Hyper ABS @Ender-5Max-all @System",
+			"sub_path": "filament/Creality/Creality Hyper ABS @Ender-5Max-all @System.json"
+		},
+		{
+			"name": "Creality Hyper PLA @Ender-5Max-all @base",
+			"sub_path": "filament/Creality/Creality Hyper PLA @Ender-5Max-all @base.json"
+		},
+		{
+			"name": "Creality Hyper PLA @Ender-5Max-all @System",
+			"sub_path": "filament/Creality/Creality Hyper PLA @Ender-5Max-all @System.json"
+		},
+		{
+			"name": "Creality Hyper PLA-CF @Ender-5Max-all @base",
+			"sub_path": "filament/Creality/Creality Hyper PLA-CF @Ender-5Max-all @base.json"
+		},
+		{
+			"name": "Creality Hyper PLA-CF @Ender-5Max-all @System",
+			"sub_path": "filament/Creality/Creality Hyper PLA-CF @Ender-5Max-all @System.json"
+		},
+		{
+			"name": "Creality Silk PLA @Ender-5Max-all @base",
+			"sub_path": "filament/Creality/Creality Silk PLA @Ender-5Max-all @base.json"
+		},
+		{
+			"name": "Creality Silk PLA @Ender-5Max-all @System",
+			"sub_path": "filament/Creality/Creality Silk PLA @Ender-5Max-all @System.json"
 		}
 	],
 	"process_list": [],

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic ABS @Ender-3V3-all @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic ABS @Ender-3V3-all @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Creality Generic ABS @Ender-3V3-all @System",
+	"inherits": "Creality Generic ABS @Ender-3V3-all @base",
+	"from": "system",
+	"setting_id": "GFSA04_CREALITY_00",
+	"filament_id": "",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic ABS @Ender-3V3-all @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic ABS @Ender-3V3-all @base.json
@@ -1,0 +1,148 @@
+{
+	"type": "filament",
+	"name": "Creality Generic ABS @Ender-3V3-all @base",
+	"inherits": "Creality Generic ABS",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"105"
+	],
+	"eng_plate_temp": [
+		"105"
+	],
+	"hot_plate_temp": [
+		"105"
+	],
+	"textured_plate_temp": [
+		"105"
+	],
+	"cool_plate_temp_initial_layer": [
+		"105"
+	],
+	"eng_plate_temp_initial_layer": [
+		"105"
+	],
+	"hot_plate_temp_initial_layer": [
+		"105"
+	],
+	"textured_plate_temp_initial_layer": [
+		"105"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"overhang_fan_speed": [
+		"80"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.926"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.04"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"9"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"ABS"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"260"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"80"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"5"
+	],
+	"filament_start_gcode": [
+		"; Filament gcode\n"
+	],
+	"nozzle_temperature": [
+		"260"
+	],
+	"temperature_vitrification": [
+		"110"
+	],
+	"nozzle_temperature_range_low": [
+		"240"
+	],
+	"nozzle_temperature_range_high": [
+		"270"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic ABS @Ender-5Max-all @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic ABS @Ender-5Max-all @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Creality Generic ABS @Ender-5Max-all @System",
+	"inherits": "Creality Generic ABS @Ender-5Max-all @base",
+	"from": "system",
+	"setting_id": "GFSA04_CREALITY_00",
+	"filament_id": "07001",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic ABS @Ender-5Max-all @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic ABS @Ender-5Max-all @base.json
@@ -1,0 +1,103 @@
+{
+	"type": "filament",
+	"name": "Creality Generic ABS @Ender-5Max-all @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": "90",
+	"eng_plate_temp": "105",
+	"hot_plate_temp": "90",
+	"textured_plate_temp": "90",
+	"cool_plate_temp_initial_layer": "90",
+	"eng_plate_temp_initial_layer": "105",
+	"hot_plate_temp_initial_layer": "90",
+	"textured_plate_temp_initial_layer": "90",
+	"overhang_fan_threshold": "25%",
+	"overhang_fan_speed": "20",
+	"slow_down_for_layer_cooling": "1",
+	"close_fan_the_first_x_layers": "3",
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": "0.85",
+	"reduce_fan_stop_start_freq": "1",
+	"fan_cooling_layer_time": "30",
+	"filament_cost": [
+		"15"
+	],
+	"filament_density": [
+		"1.08"
+	],
+	"filament_deretraction_speed": "nil",
+	"filament_diameter": "1.75",
+	"filament_max_volumetric_speed": [
+		"35"
+	],
+	"filament_retraction_minimum_travel": "nil",
+	"filament_retract_before_wipe": "nil",
+	"filament_retract_when_changing_layer": "nil",
+	"filament_retraction_length": "nil",
+	"filament_z_hop": "nil",
+	"filament_z_hop_types": "nil",
+	"filament_retract_restart_extra": "0",
+	"filament_retraction_speed": "nil",
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": "0",
+	"filament_type": [
+		"ABS"
+	],
+	"filament_vendor": [
+		"Creality"
+	],
+	"filament_wipe": "nil",
+	"filament_wipe_distance": "nil",
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": "260",
+	"full_fan_speed_layer": "0",
+	"fan_max_speed": "20",
+	"fan_min_speed": "20",
+	"slow_down_min_speed": "10",
+	"slow_down_layer_time": "5",
+	"filament_start_gcode": [
+		"; Filament gcode\n"
+	],
+	"nozzle_temperature": "260",
+	"temperature_vitrification": [
+		"110"
+	],
+	"activate_air_filtration": "0",
+	"activate_chamber_temp_control": "0",
+	"additional_cooling_fan_speed": "0",
+	"chamber_temperature": "35",
+	"complete_print_exhaust_fan_speed": "80",
+	"cool_special_cds_fan_speed": "0",
+	"default_filament_colour": "\"\"",
+	"during_print_exhaust_fan_speed": "60",
+	"enable_overhang_bridge_fan": "1",
+	"enable_pressure_advance": "1",
+	"filament_cooling_initial_speed": "2.2",
+	"filament_cooling_moves": "4",
+	"filament_is_support": "0",
+	"filament_loading_speed": "28",
+	"filament_loading_speed_start": "3",
+	"filament_multitool_ramming": "0",
+	"filament_multitool_ramming_flow": "10",
+	"filament_multitool_ramming_volume": "10",
+	"filament_notes": "\"\"",
+	"filament_ramming_parameters": "\"120 100 6.6 6.8 7.2 7.6 7.9 8.2 8.7 9.4 9.9 10.0| 0.05 6.6 0.45 6.8 0.95 7.8 1.45 8.3 1.95 9.7 2.45 10 2.95 7.6 3.45 7.6 3.95 7.6 4.45 7.6 4.95 7.6\"",
+	"filament_retract_lift_above": "0",
+	"filament_retract_lift_below": "0",
+	"filament_retract_lift_enforce": "All Surfaces",
+	"filament_shrink": "100%",
+	"filament_unloading_speed": "90",
+	"filament_unloading_speed_start": "100",
+	"nozzle_temperature_range_high": "260",
+	"nozzle_temperature_range_low": "230",
+	"pressure_advance": "0.03",
+	"required_nozzle_HRC": "0",
+	"support_material_interface_fan_speed": "-1"
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic ABS @Hi-all @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic ABS @Hi-all @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Creality Generic ABS @Hi-all @System",
+	"inherits": "Creality Generic ABS @Hi-all @base",
+	"from": "system",
+	"setting_id": "GFSA04_CREALITY_00",
+	"filament_id": "",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic ABS @Hi-all @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic ABS @Hi-all @base.json
@@ -1,0 +1,148 @@
+{
+	"type": "filament",
+	"name": "Creality Generic ABS @Hi-all @base",
+	"inherits": "Creality Generic ABS",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"105"
+	],
+	"eng_plate_temp": [
+		"105"
+	],
+	"hot_plate_temp": [
+		"105"
+	],
+	"textured_plate_temp": [
+		"105"
+	],
+	"cool_plate_temp_initial_layer": [
+		"105"
+	],
+	"eng_plate_temp_initial_layer": [
+		"105"
+	],
+	"hot_plate_temp_initial_layer": [
+		"105"
+	],
+	"textured_plate_temp_initial_layer": [
+		"105"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"overhang_fan_speed": [
+		"80"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.926"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.04"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"9"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"ABS"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"260"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"80"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"5"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if (position[2] > first_layer_height) }\nM104 S[nozzle_temperature]\n{else}\nM104 S[first_layer_temperature]\n{endif}\n"
+	],
+	"nozzle_temperature": [
+		"260"
+	],
+	"temperature_vitrification": [
+		"110"
+	],
+	"nozzle_temperature_range_low": [
+		"240"
+	],
+	"nozzle_temperature_range_high": [
+		"270"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic ABS @K1-all @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic ABS @K1-all @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Creality Generic ABS @K1-all @System",
+	"inherits": "Creality Generic ABS @K1-all @base",
+	"from": "system",
+	"setting_id": "GFSA04_CREALITY_00",
+	"filament_id": "",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic ABS @K1-all @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic ABS @K1-all @base.json
@@ -1,0 +1,148 @@
+{
+	"type": "filament",
+	"name": "Creality Generic ABS @K1-all @base",
+	"inherits": "Creality Generic ABS",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"105"
+	],
+	"eng_plate_temp": [
+		"105"
+	],
+	"hot_plate_temp": [
+		"105"
+	],
+	"textured_plate_temp": [
+		"105"
+	],
+	"cool_plate_temp_initial_layer": [
+		"105"
+	],
+	"eng_plate_temp_initial_layer": [
+		"105"
+	],
+	"hot_plate_temp_initial_layer": [
+		"105"
+	],
+	"textured_plate_temp_initial_layer": [
+		"105"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"overhang_fan_speed": [
+		"80"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.926"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.04"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"14"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"ABS"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"260"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"80"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"slow_down_layer_time": [
+		"5"
+	],
+	"filament_start_gcode": [
+		"; Filament gcode\n"
+	],
+	"nozzle_temperature": [
+		"260"
+	],
+	"temperature_vitrification": [
+		"110"
+	],
+	"nozzle_temperature_range_low": [
+		"240"
+	],
+	"nozzle_temperature_range_high": [
+		"270"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic ABS @K2-all @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic ABS @K2-all @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Creality Generic ABS @K2-all @System",
+	"inherits": "Creality Generic ABS @K2-all @base",
+	"from": "system",
+	"setting_id": "GFSA04_CREALITY_00",
+	"filament_id": "",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic ABS @K2-all @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic ABS @K2-all @base.json
@@ -1,0 +1,148 @@
+{
+	"type": "filament",
+	"name": "Creality Generic ABS @K2-all @base",
+	"inherits": "Creality Generic ABS",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"105"
+	],
+	"eng_plate_temp": [
+		"105"
+	],
+	"hot_plate_temp": [
+		"105"
+	],
+	"textured_plate_temp": [
+		"105"
+	],
+	"cool_plate_temp_initial_layer": [
+		"105"
+	],
+	"eng_plate_temp_initial_layer": [
+		"105"
+	],
+	"hot_plate_temp_initial_layer": [
+		"105"
+	],
+	"textured_plate_temp_initial_layer": [
+		"105"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"overhang_fan_speed": [
+		"80"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.95"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.04"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"18"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"ABS"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"260"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"80"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"slow_down_layer_time": [
+		"12"
+	],
+	"filament_start_gcode": [
+		";filament start gcode\n{if (position[2] > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
+	],
+	"nozzle_temperature": [
+		"260"
+	],
+	"temperature_vitrification": [
+		"110"
+	],
+	"nozzle_temperature_range_low": [
+		"240"
+	],
+	"nozzle_temperature_range_high": [
+		"270"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic ABS @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic ABS @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Creality Generic ABS @System",
+	"inherits": "Creality Generic ABS @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFB99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic ABS @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic ABS @base.json
@@ -1,0 +1,148 @@
+{
+	"type": "filament",
+	"name": "Creality Generic ABS @base",
+	"inherits": "fdm_filament_abs",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"105"
+	],
+	"eng_plate_temp": [
+		"105"
+	],
+	"hot_plate_temp": [
+		"105"
+	],
+	"textured_plate_temp": [
+		"105"
+	],
+	"cool_plate_temp_initial_layer": [
+		"105"
+	],
+	"eng_plate_temp_initial_layer": [
+		"105"
+	],
+	"hot_plate_temp_initial_layer": [
+		"105"
+	],
+	"textured_plate_temp_initial_layer": [
+		"105"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"overhang_fan_speed": [
+		"80"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.926"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.04"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"12"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"ABS"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"260"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"80"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"3"
+	],
+	"filament_start_gcode": [
+		"; Filament gcode\n"
+	],
+	"nozzle_temperature": [
+		"260"
+	],
+	"temperature_vitrification": [
+		"110"
+	],
+	"nozzle_temperature_range_low": [
+		"240"
+	],
+	"nozzle_temperature_range_high": [
+		"270"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic ASA @Ender-3V3-all @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic ASA @Ender-3V3-all @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Creality Generic ASA @Ender-3V3-all @System",
+	"inherits": "Creality Generic ASA @Ender-3V3-all @base",
+	"from": "system",
+	"setting_id": "GFSA04_00",
+	"filament_id": "",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic ASA @Ender-3V3-all @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic ASA @Ender-3V3-all @base.json
@@ -1,0 +1,148 @@
+{
+	"type": "filament",
+	"name": "Creality Generic ASA @Ender-3V3-all @base",
+	"inherits": "Creality Generic ASA",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"105"
+	],
+	"eng_plate_temp": [
+		"105"
+	],
+	"hot_plate_temp": [
+		"105"
+	],
+	"textured_plate_temp": [
+		"100"
+	],
+	"cool_plate_temp_initial_layer": [
+		"105"
+	],
+	"eng_plate_temp_initial_layer": [
+		"105"
+	],
+	"hot_plate_temp_initial_layer": [
+		"105"
+	],
+	"textured_plate_temp_initial_layer": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"overhang_fan_speed": [
+		"80"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.926"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"35"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.04"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"9"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"ASA"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"260"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"80"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"5"
+	],
+	"filament_start_gcode": [
+		"; Filament gcode\n"
+	],
+	"nozzle_temperature": [
+		"260"
+	],
+	"temperature_vitrification": [
+		"110"
+	],
+	"nozzle_temperature_range_low": [
+		"240"
+	],
+	"nozzle_temperature_range_high": [
+		"270"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic ASA @Ender-5Max-all @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic ASA @Ender-5Max-all @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Creality Generic ASA @Ender-5Max-all @System",
+	"inherits": "Creality Generic ASA @Ender-5Max-all @base",
+	"from": "system",
+	"setting_id": "GFSA04_CREALITY_00",
+	"filament_id": "19001",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic ASA @Ender-5Max-all @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic ASA @Ender-5Max-all @base.json
@@ -1,0 +1,103 @@
+{
+	"type": "filament",
+	"name": "Creality Generic ASA @Ender-5Max-all @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": "90",
+	"eng_plate_temp": "50",
+	"hot_plate_temp": "90",
+	"textured_plate_temp": "90",
+	"cool_plate_temp_initial_layer": "90",
+	"eng_plate_temp_initial_layer": "50",
+	"hot_plate_temp_initial_layer": "90",
+	"textured_plate_temp_initial_layer": "90",
+	"overhang_fan_threshold": "50%",
+	"overhang_fan_speed": "20",
+	"slow_down_for_layer_cooling": "1",
+	"close_fan_the_first_x_layers": "1",
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": "0.85",
+	"reduce_fan_stop_start_freq": "1",
+	"fan_cooling_layer_time": "30",
+	"filament_cost": [
+		"29"
+	],
+	"filament_density": [
+		"1.15"
+	],
+	"filament_deretraction_speed": "nil",
+	"filament_diameter": "1.75",
+	"filament_max_volumetric_speed": [
+		"35"
+	],
+	"filament_retraction_minimum_travel": "nil",
+	"filament_retract_before_wipe": "nil",
+	"filament_retract_when_changing_layer": "nil",
+	"filament_retraction_length": "nil",
+	"filament_z_hop": "nil",
+	"filament_z_hop_types": "nil",
+	"filament_retract_restart_extra": "nil",
+	"filament_retraction_speed": "nil",
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": "0",
+	"filament_type": [
+		"ASA"
+	],
+	"filament_vendor": [
+		"Creality"
+	],
+	"filament_wipe": "nil",
+	"filament_wipe_distance": "nil",
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": "260",
+	"full_fan_speed_layer": "0",
+	"fan_max_speed": "20",
+	"fan_min_speed": "20",
+	"slow_down_min_speed": "10",
+	"slow_down_layer_time": "5",
+	"filament_start_gcode": [
+		"; filament start gcode\n"
+	],
+	"nozzle_temperature": "260",
+	"temperature_vitrification": [
+		"110"
+	],
+	"activate_air_filtration": "0",
+	"activate_chamber_temp_control": "0",
+	"additional_cooling_fan_speed": "0",
+	"chamber_temperature": "55",
+	"complete_print_exhaust_fan_speed": "80",
+	"cool_special_cds_fan_speed": "0",
+	"default_filament_colour": "\"\"",
+	"during_print_exhaust_fan_speed": "60",
+	"enable_overhang_bridge_fan": "1",
+	"enable_pressure_advance": "1",
+	"filament_cooling_initial_speed": "2.2",
+	"filament_cooling_moves": "4",
+	"filament_is_support": "0",
+	"filament_loading_speed": "28",
+	"filament_loading_speed_start": "3",
+	"filament_multitool_ramming": "0",
+	"filament_multitool_ramming_flow": "10",
+	"filament_multitool_ramming_volume": "10",
+	"filament_notes": "\"\"",
+	"filament_ramming_parameters": "\"120 100 6.6 6.8 7.2 7.6 7.9 8.2 8.7 9.4 9.9 10.0| 0.05 6.6 0.45 6.8 0.95 7.8 1.45 8.3 1.95 9.7 2.45 10 2.95 7.6 3.45 7.6 3.95 7.6 4.45 7.6 4.95 7.6\"",
+	"filament_retract_lift_above": "0",
+	"filament_retract_lift_below": "0",
+	"filament_retract_lift_enforce": "All Surfaces",
+	"filament_shrink": "100%",
+	"filament_unloading_speed": "90",
+	"filament_unloading_speed_start": "100",
+	"nozzle_temperature_range_high": "280",
+	"nozzle_temperature_range_low": "240",
+	"pressure_advance": "0.032",
+	"required_nozzle_HRC": "0",
+	"support_material_interface_fan_speed": "-1"
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic ASA @Hi-all @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic ASA @Hi-all @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Creality Generic ASA @Hi-all @System",
+	"inherits": "Creality Generic ASA @Hi-all @base",
+	"from": "system",
+	"setting_id": "GFSA04_00",
+	"filament_id": "",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic ASA @Hi-all @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic ASA @Hi-all @base.json
@@ -1,0 +1,148 @@
+{
+	"type": "filament",
+	"name": "Creality Generic ASA @Hi-all @base",
+	"inherits": "Creality Generic ASA",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"105"
+	],
+	"eng_plate_temp": [
+		"105"
+	],
+	"hot_plate_temp": [
+		"105"
+	],
+	"textured_plate_temp": [
+		"100"
+	],
+	"cool_plate_temp_initial_layer": [
+		"105"
+	],
+	"eng_plate_temp_initial_layer": [
+		"105"
+	],
+	"hot_plate_temp_initial_layer": [
+		"105"
+	],
+	"textured_plate_temp_initial_layer": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"overhang_fan_speed": [
+		"80"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.926"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"35"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.04"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"9"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"ASA"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"260"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"80"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"5"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if (position[2] > first_layer_height) }\nM104 S[nozzle_temperature]\n{else}\nM104 S[first_layer_temperature]\n{endif}\n"
+	],
+	"nozzle_temperature": [
+		"260"
+	],
+	"temperature_vitrification": [
+		"110"
+	],
+	"nozzle_temperature_range_low": [
+		"240"
+	],
+	"nozzle_temperature_range_high": [
+		"270"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic ASA @K1-all @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic ASA @K1-all @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Creality Generic ASA @K1-all @System",
+	"inherits": "Creality Generic ASA @K1-all @base",
+	"from": "system",
+	"setting_id": "GFSA04_00",
+	"filament_id": "",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic ASA @K1-all @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic ASA @K1-all @base.json
@@ -1,0 +1,148 @@
+{
+	"type": "filament",
+	"name": "Creality Generic ASA @K1-all @base",
+	"inherits": "Creality Generic ASA",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"105"
+	],
+	"eng_plate_temp": [
+		"105"
+	],
+	"hot_plate_temp": [
+		"105"
+	],
+	"textured_plate_temp": [
+		"100"
+	],
+	"cool_plate_temp_initial_layer": [
+		"105"
+	],
+	"eng_plate_temp_initial_layer": [
+		"105"
+	],
+	"hot_plate_temp_initial_layer": [
+		"105"
+	],
+	"textured_plate_temp_initial_layer": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"overhang_fan_speed": [
+		"80"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.926"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"35"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.04"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"12"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"ASA"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"260"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"80"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"slow_down_layer_time": [
+		"3"
+	],
+	"filament_start_gcode": [
+		"; Filament gcode\n"
+	],
+	"nozzle_temperature": [
+		"260"
+	],
+	"temperature_vitrification": [
+		"110"
+	],
+	"nozzle_temperature_range_low": [
+		"240"
+	],
+	"nozzle_temperature_range_high": [
+		"270"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic ASA @K2-all @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic ASA @K2-all @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Creality Generic ASA @K2-all @System",
+	"inherits": "Creality Generic ASA @K2-all @base",
+	"from": "system",
+	"setting_id": "GFSA04_00",
+	"filament_id": "",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic ASA @K2-all @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic ASA @K2-all @base.json
@@ -1,0 +1,148 @@
+{
+	"type": "filament",
+	"name": "Creality Generic ASA @K2-all @base",
+	"inherits": "Creality Generic ASA",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"105"
+	],
+	"eng_plate_temp": [
+		"105"
+	],
+	"hot_plate_temp": [
+		"105"
+	],
+	"textured_plate_temp": [
+		"100"
+	],
+	"cool_plate_temp_initial_layer": [
+		"105"
+	],
+	"eng_plate_temp_initial_layer": [
+		"105"
+	],
+	"hot_plate_temp_initial_layer": [
+		"105"
+	],
+	"textured_plate_temp_initial_layer": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"overhang_fan_speed": [
+		"80"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.95"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"35"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.04"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"14"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"ASA"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"260"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"80"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"slow_down_layer_time": [
+		"10"
+	],
+	"filament_start_gcode": [
+		";filament start gcode\n{if (position[2] > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
+	],
+	"nozzle_temperature": [
+		"260"
+	],
+	"temperature_vitrification": [
+		"110"
+	],
+	"nozzle_temperature_range_low": [
+		"240"
+	],
+	"nozzle_temperature_range_high": [
+		"270"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic ASA @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic ASA @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Creality Generic ASA @System",
+	"inherits": "Creality Generic ASA @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFB98",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic ASA @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic ASA @base.json
@@ -1,0 +1,148 @@
+{
+	"type": "filament",
+	"name": "Creality Generic ASA @base",
+	"inherits": "fdm_filament_asa",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"105"
+	],
+	"eng_plate_temp": [
+		"105"
+	],
+	"hot_plate_temp": [
+		"105"
+	],
+	"textured_plate_temp": [
+		"100"
+	],
+	"cool_plate_temp_initial_layer": [
+		"105"
+	],
+	"eng_plate_temp_initial_layer": [
+		"105"
+	],
+	"hot_plate_temp_initial_layer": [
+		"105"
+	],
+	"textured_plate_temp_initial_layer": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"overhang_fan_speed": [
+		"80"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.926"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"35"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.04"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"12"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"ASA"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"260"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"80"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"3"
+	],
+	"filament_start_gcode": [
+		"; Filament gcode\n"
+	],
+	"nozzle_temperature": [
+		"260"
+	],
+	"temperature_vitrification": [
+		"110"
+	],
+	"nozzle_temperature_range_low": [
+		"240"
+	],
+	"nozzle_temperature_range_high": [
+		"270"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic ASA-CF @Hi-all @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic ASA-CF @Hi-all @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Creality Generic ASA-CF @Hi-all @System",
+	"inherits": "Creality Generic ASA-CF @Hi-all @base",
+	"from": "system",
+	"setting_id": "GFSA04_00",
+	"filament_id": "",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic ASA-CF @Hi-all @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic ASA-CF @Hi-all @base.json
@@ -1,0 +1,148 @@
+{
+	"type": "filament",
+	"name": "Creality Generic ASA-CF @Hi-all @base",
+	"inherits": "Creality Generic ASA @Hi-all",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"105"
+	],
+	"eng_plate_temp": [
+		"105"
+	],
+	"hot_plate_temp": [
+		"105"
+	],
+	"textured_plate_temp": [
+		"100"
+	],
+	"cool_plate_temp_initial_layer": [
+		"105"
+	],
+	"eng_plate_temp_initial_layer": [
+		"105"
+	],
+	"hot_plate_temp_initial_layer": [
+		"105"
+	],
+	"textured_plate_temp_initial_layer": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"overhang_fan_speed": [
+		"80"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.926"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"35"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.04"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"9"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"ASA"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"260"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"80"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"5"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if (position[2] > first_layer_height) }\nM104 S[nozzle_temperature]\n{else}\nM104 S[first_layer_temperature]\n{endif}\n"
+	],
+	"nozzle_temperature": [
+		"260"
+	],
+	"temperature_vitrification": [
+		"110"
+	],
+	"nozzle_temperature_range_low": [
+		"240"
+	],
+	"nozzle_temperature_range_high": [
+		"270"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PA @Ender-5Max-all @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PA @Ender-5Max-all @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Creality Generic PA @Ender-5Max-all @System",
+	"inherits": "Creality Generic PA @Ender-5Max-all @base",
+	"from": "system",
+	"setting_id": "GFSA04_CREALITY_00",
+	"filament_id": "11001",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PA @Ender-5Max-all @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PA @Ender-5Max-all @base.json
@@ -1,0 +1,103 @@
+{
+	"type": "filament",
+	"name": "Creality Generic PA @Ender-5Max-all @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": "45",
+	"eng_plate_temp": "100",
+	"hot_plate_temp": "45",
+	"textured_plate_temp": "45",
+	"cool_plate_temp_initial_layer": "45",
+	"eng_plate_temp_initial_layer": "100",
+	"hot_plate_temp_initial_layer": "45",
+	"textured_plate_temp_initial_layer": "45",
+	"overhang_fan_threshold": "50%",
+	"overhang_fan_speed": "50",
+	"slow_down_for_layer_cooling": "1",
+	"close_fan_the_first_x_layers": "1",
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": "0.9",
+	"reduce_fan_stop_start_freq": "1",
+	"fan_cooling_layer_time": "100",
+	"filament_cost": [
+		"50"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": "nil",
+	"filament_diameter": "1.75",
+	"filament_max_volumetric_speed": [
+		"2"
+	],
+	"filament_retraction_minimum_travel": "nil",
+	"filament_retract_before_wipe": "nil",
+	"filament_retract_when_changing_layer": "nil",
+	"filament_retraction_length": "1.5",
+	"filament_z_hop": "0.2",
+	"filament_z_hop_types": "nil",
+	"filament_retract_restart_extra": "0",
+	"filament_retraction_speed": "nil",
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": "0",
+	"filament_type": [
+		"PA"
+	],
+	"filament_vendor": [
+		"Creality"
+	],
+	"filament_wipe": "nil",
+	"filament_wipe_distance": "nil",
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": "250",
+	"full_fan_speed_layer": "0",
+	"fan_max_speed": "100",
+	"fan_min_speed": "100",
+	"slow_down_min_speed": "5",
+	"slow_down_layer_time": "8",
+	"filament_start_gcode": [
+		"; Filament gcode\n"
+	],
+	"nozzle_temperature": "250",
+	"temperature_vitrification": [
+		"108"
+	],
+	"activate_air_filtration": "0",
+	"activate_chamber_temp_control": "0",
+	"additional_cooling_fan_speed": "0",
+	"chamber_temperature": "35",
+	"complete_print_exhaust_fan_speed": "100",
+	"cool_special_cds_fan_speed": "0",
+	"default_filament_colour": "\"\"",
+	"during_print_exhaust_fan_speed": "0",
+	"enable_overhang_bridge_fan": "1",
+	"enable_pressure_advance": "1",
+	"filament_cooling_initial_speed": "2.2",
+	"filament_cooling_moves": "4",
+	"filament_is_support": "0",
+	"filament_loading_speed": "28",
+	"filament_loading_speed_start": "3",
+	"filament_multitool_ramming": "0",
+	"filament_multitool_ramming_flow": "10",
+	"filament_multitool_ramming_volume": "10",
+	"filament_notes": "\"\"",
+	"filament_ramming_parameters": "\"120 100 6.6 6.8 7.2 7.6 7.9 8.2 8.7 9.4 9.9 10.0| 0.05 6.6 0.45 6.8 0.95 7.8 1.45 8.3 1.95 9.7 2.45 10 2.95 7.6 3.45 7.6 3.95 7.6 4.45 7.6 4.95 7.6\"",
+	"filament_retract_lift_above": "0",
+	"filament_retract_lift_below": "0",
+	"filament_retract_lift_enforce": "All Surfaces",
+	"filament_shrink": "100%",
+	"filament_unloading_speed": "90",
+	"filament_unloading_speed_start": "100",
+	"nozzle_temperature_range_high": "280",
+	"nozzle_temperature_range_low": "250",
+	"pressure_advance": "0.042",
+	"required_nozzle_HRC": "40",
+	"support_material_interface_fan_speed": "-1"
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PA-CF @Ender-3V3-all @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PA-CF @Ender-3V3-all @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Creality Generic PA-CF @Ender-3V3-all @System",
+	"inherits": "Creality Generic PA-CF @Ender-3V3-all @base",
+	"from": "system",
+	"setting_id": "GFSN99_01",
+	"filament_id": "",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PA-CF @Ender-3V3-all @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PA-CF @Ender-3V3-all @base.json
@@ -1,0 +1,160 @@
+{
+	"type": "filament",
+	"name": "Creality Generic PA-CF @Ender-3V3-all @base",
+	"inherits": "Creality Generic PA-CF",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"0"
+	],
+	"eng_plate_temp": [
+		"100"
+	],
+	"hot_plate_temp": [
+		"100"
+	],
+	"textured_plate_temp": [
+		"100"
+	],
+	"cool_plate_temp_initial_layer": [
+		"0"
+	],
+	"eng_plate_temp_initial_layer": [
+		"100"
+	],
+	"hot_plate_temp_initial_layer": [
+		"100"
+	],
+	"textured_plate_temp_initial_layer": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"0%"
+	],
+	"overhang_fan_speed": [
+		"40"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"1"
+	],
+	"reduce_fan_stop_start_freq": [
+		"0"
+	],
+	"fan_cooling_layer_time": [
+		"5"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.04"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"8"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PA-CF"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"290"
+	],
+	"full_fan_speed_layer": [
+		"2"
+	],
+	"fan_max_speed": [
+		"30"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"slow_down_layer_time": [
+		"2"
+	],
+	"filament_start_gcode": [
+		"; Filament gcode\n"
+	],
+	"nozzle_temperature": [
+		"290"
+	],
+	"temperature_vitrification": [
+		"108"
+	],
+	"activate_air_filtration": [
+		"1"
+	],
+	"nozzle_temperature_range_high": [
+		"300"
+	],
+	"nozzle_temperature_range_low": [
+		"260"
+	],
+	"required_nozzle_HRC": [
+		"40"
+	],
+	"enable_pressure_advance": [
+		"1"
+	],
+	"pressure_advance": [
+		"0.01"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PA-CF @K1-all @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PA-CF @K1-all @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Creality Generic PA-CF @K1-all @System",
+	"inherits": "Creality Generic PA-CF @K1-all @base",
+	"from": "system",
+	"setting_id": "GFSN99_01",
+	"filament_id": "",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PA-CF @K1-all @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PA-CF @K1-all @base.json
@@ -1,0 +1,160 @@
+{
+	"type": "filament",
+	"name": "Creality Generic PA-CF @K1-all @base",
+	"inherits": "Creality Generic PA-CF",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"0"
+	],
+	"eng_plate_temp": [
+		"100"
+	],
+	"hot_plate_temp": [
+		"100"
+	],
+	"textured_plate_temp": [
+		"100"
+	],
+	"cool_plate_temp_initial_layer": [
+		"0"
+	],
+	"eng_plate_temp_initial_layer": [
+		"100"
+	],
+	"hot_plate_temp_initial_layer": [
+		"100"
+	],
+	"textured_plate_temp_initial_layer": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"0%"
+	],
+	"overhang_fan_speed": [
+		"40"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"1"
+	],
+	"reduce_fan_stop_start_freq": [
+		"0"
+	],
+	"fan_cooling_layer_time": [
+		"5"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.04"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"8"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PA-CF"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"290"
+	],
+	"full_fan_speed_layer": [
+		"2"
+	],
+	"fan_max_speed": [
+		"30"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"slow_down_layer_time": [
+		"2"
+	],
+	"filament_start_gcode": [
+		"; Filament gcode\n"
+	],
+	"nozzle_temperature": [
+		"290"
+	],
+	"temperature_vitrification": [
+		"108"
+	],
+	"activate_air_filtration": [
+		"1"
+	],
+	"nozzle_temperature_range_high": [
+		"300"
+	],
+	"nozzle_temperature_range_low": [
+		"260"
+	],
+	"required_nozzle_HRC": [
+		"40"
+	],
+	"enable_pressure_advance": [
+		"1"
+	],
+	"pressure_advance": [
+		"0.01"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PA-CF @K2-all @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PA-CF @K2-all @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Creality Generic PA-CF @K2-all @System",
+	"inherits": "Creality Generic PA-CF @K2-all @base",
+	"from": "system",
+	"setting_id": "GFSN99_01",
+	"filament_id": "",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PA-CF @K2-all @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PA-CF @K2-all @base.json
@@ -1,0 +1,160 @@
+{
+	"type": "filament",
+	"name": "Creality Generic PA-CF @K2-all @base",
+	"inherits": "Creality Generic PA-CF",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"0"
+	],
+	"eng_plate_temp": [
+		"100"
+	],
+	"hot_plate_temp": [
+		"100"
+	],
+	"textured_plate_temp": [
+		"100"
+	],
+	"cool_plate_temp_initial_layer": [
+		"0"
+	],
+	"eng_plate_temp_initial_layer": [
+		"100"
+	],
+	"hot_plate_temp_initial_layer": [
+		"100"
+	],
+	"textured_plate_temp_initial_layer": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"0%"
+	],
+	"overhang_fan_speed": [
+		"40"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"1"
+	],
+	"reduce_fan_stop_start_freq": [
+		"0"
+	],
+	"fan_cooling_layer_time": [
+		"5"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.04"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"8"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PA-CF"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"280"
+	],
+	"full_fan_speed_layer": [
+		"2"
+	],
+	"fan_max_speed": [
+		"30"
+	],
+	"fan_min_speed": [
+		"30"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"slow_down_layer_time": [
+		"2"
+	],
+	"filament_start_gcode": [
+		";filament start gcode\n{if (position[2] > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
+	],
+	"nozzle_temperature": [
+		"280"
+	],
+	"temperature_vitrification": [
+		"108"
+	],
+	"activate_air_filtration": [
+		"1"
+	],
+	"nozzle_temperature_range_high": [
+		"300"
+	],
+	"nozzle_temperature_range_low": [
+		"260"
+	],
+	"required_nozzle_HRC": [
+		"40"
+	],
+	"enable_pressure_advance": [
+		"1"
+	],
+	"pressure_advance": [
+		"0.01"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PA-CF @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PA-CF @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Creality Generic PA-CF @System",
+	"inherits": "Creality Generic PA-CF @base",
+	"from": "system",
+	"setting_id": "GFSN99",
+	"filament_id": "GFN98",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PA-CF @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PA-CF @base.json
@@ -1,0 +1,160 @@
+{
+	"type": "filament",
+	"name": "Creality Generic PA-CF @base",
+	"inherits": "fdm_filament_pa",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"0"
+	],
+	"eng_plate_temp": [
+		"100"
+	],
+	"hot_plate_temp": [
+		"100"
+	],
+	"textured_plate_temp": [
+		"100"
+	],
+	"cool_plate_temp_initial_layer": [
+		"0"
+	],
+	"eng_plate_temp_initial_layer": [
+		"100"
+	],
+	"hot_plate_temp_initial_layer": [
+		"100"
+	],
+	"textured_plate_temp_initial_layer": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"0%"
+	],
+	"overhang_fan_speed": [
+		"40"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"1"
+	],
+	"reduce_fan_stop_start_freq": [
+		"0"
+	],
+	"fan_cooling_layer_time": [
+		"5"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.04"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"8"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PA-CF"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"290"
+	],
+	"full_fan_speed_layer": [
+		"2"
+	],
+	"fan_max_speed": [
+		"30"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"slow_down_layer_time": [
+		"2"
+	],
+	"filament_start_gcode": [
+		"; Filament gcode\n"
+	],
+	"nozzle_temperature": [
+		"290"
+	],
+	"temperature_vitrification": [
+		"108"
+	],
+	"activate_air_filtration": [
+		"1"
+	],
+	"nozzle_temperature_range_high": [
+		"300"
+	],
+	"nozzle_temperature_range_low": [
+		"260"
+	],
+	"required_nozzle_HRC": [
+		"40"
+	],
+	"enable_pressure_advance": [
+		"1"
+	],
+	"pressure_advance": [
+		"0.01"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PC @K1-all @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PC @K1-all @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Creality Generic PC @K1-all @System",
+	"inherits": "Creality Generic PC @K1-all @base",
+	"from": "system",
+	"setting_id": "GFSC99_06",
+	"filament_id": "",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PC @K1-all @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PC @K1-all @base.json
@@ -1,0 +1,151 @@
+{
+	"type": "filament",
+	"name": "Creality Generic PC @K1-all @base",
+	"inherits": "Creality Generic PC",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"0"
+	],
+	"eng_plate_temp": [
+		"110"
+	],
+	"hot_plate_temp": [
+		"110"
+	],
+	"textured_plate_temp": [
+		"110"
+	],
+	"cool_plate_temp_initial_layer": [
+		"0"
+	],
+	"eng_plate_temp_initial_layer": [
+		"110"
+	],
+	"hot_plate_temp_initial_layer": [
+		"110"
+	],
+	"textured_plate_temp_initial_layer": [
+		"110"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"overhang_fan_speed": [
+		"60"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.94"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.04"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"16"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PC"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"270"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"60"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"slow_down_layer_time": [
+		"2"
+	],
+	"filament_start_gcode": [
+		"; Filament gcode\n"
+	],
+	"nozzle_temperature": [
+		"280"
+	],
+	"temperature_vitrification": [
+		"120"
+	],
+	"nozzle_temperature_range_low": [
+		"260"
+	],
+	"nozzle_temperature_range_high": [
+		"290"
+	],
+	"chamber_temperatures": [
+		"60"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PETG @Ender-3V3-all @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PETG @Ender-3V3-all @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Creality Generic PETG @Ender-3V3-all @System",
+	"inherits": "Creality Generic PETG @Ender-3V3-all @base",
+	"from": "system",
+	"setting_id": "GFSG99_00",
+	"filament_id": "",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PETG @Ender-3V3-all @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PETG @Ender-3V3-all @base.json
@@ -1,0 +1,148 @@
+{
+	"type": "filament",
+	"name": "Creality Generic PETG @Ender-3V3-all @base",
+	"inherits": "Creality Generic PETG",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"70"
+	],
+	"hot_plate_temp": [
+		"70"
+	],
+	"textured_plate_temp": [
+		"70"
+	],
+	"cool_plate_temp_initial_layer": [
+		"70"
+	],
+	"eng_plate_temp_initial_layer": [
+		"70"
+	],
+	"hot_plate_temp_initial_layer": [
+		"70"
+	],
+	"textured_plate_temp_initial_layer": [
+		"70"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"overhang_fan_speed": [
+		"90"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.95"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"filament_cost": [
+		"30"
+	],
+	"filament_density": [
+		"1.27"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"9"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PETG"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"250"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"90"
+	],
+	"fan_min_speed": [
+		"40"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"5"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n"
+	],
+	"nozzle_temperature": [
+		"250"
+	],
+	"temperature_vitrification": [
+		"80"
+	],
+	"nozzle_temperature_range_low": [
+		"220"
+	],
+	"nozzle_temperature_range_high": [
+		"270"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PETG @Ender-5Max-all @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PETG @Ender-5Max-all @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Creality Generic PETG @Ender-5Max-all @System",
+	"inherits": "Creality Generic PETG @Ender-5Max-all @base",
+	"from": "system",
+	"setting_id": "GFSA04_CREALITY_00",
+	"filament_id": "06001",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PETG @Ender-5Max-all @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PETG @Ender-5Max-all @base.json
@@ -1,0 +1,103 @@
+{
+	"type": "filament",
+	"name": "Creality Generic PETG @Ender-5Max-all @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": "70",
+	"eng_plate_temp": "0",
+	"hot_plate_temp": "70",
+	"textured_plate_temp": "70",
+	"cool_plate_temp_initial_layer": "70",
+	"eng_plate_temp_initial_layer": "0",
+	"hot_plate_temp_initial_layer": "70",
+	"textured_plate_temp_initial_layer": "70",
+	"overhang_fan_threshold": "25%",
+	"overhang_fan_speed": "100",
+	"slow_down_for_layer_cooling": "1",
+	"close_fan_the_first_x_layers": "1",
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": "0.85",
+	"reduce_fan_stop_start_freq": "1",
+	"fan_cooling_layer_time": "30",
+	"filament_cost": [
+		"14"
+	],
+	"filament_density": [
+		"1.23"
+	],
+	"filament_deretraction_speed": "nil",
+	"filament_diameter": "1.75",
+	"filament_max_volumetric_speed": [
+		"30"
+	],
+	"filament_retraction_minimum_travel": "nil",
+	"filament_retract_before_wipe": "nil",
+	"filament_retract_when_changing_layer": "nil",
+	"filament_retraction_length": "nil",
+	"filament_z_hop": "nil",
+	"filament_z_hop_types": "nil",
+	"filament_retract_restart_extra": "0",
+	"filament_retraction_speed": "nil",
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": "0",
+	"filament_type": [
+		"PETG"
+	],
+	"filament_vendor": [
+		"Creality"
+	],
+	"filament_wipe": "nil",
+	"filament_wipe_distance": "nil",
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": "250",
+	"full_fan_speed_layer": "0",
+	"fan_max_speed": "100",
+	"fan_min_speed": "100",
+	"slow_down_min_speed": "10",
+	"slow_down_layer_time": "8",
+	"filament_start_gcode": [
+		"; filament start gcode\n"
+	],
+	"nozzle_temperature": "250",
+	"temperature_vitrification": [
+		"80"
+	],
+	"activate_air_filtration": "0",
+	"activate_chamber_temp_control": "0",
+	"additional_cooling_fan_speed": "0",
+	"chamber_temperature": "35",
+	"complete_print_exhaust_fan_speed": "80",
+	"cool_special_cds_fan_speed": "0",
+	"default_filament_colour": "\"\"",
+	"during_print_exhaust_fan_speed": "60",
+	"enable_overhang_bridge_fan": "1",
+	"enable_pressure_advance": "1",
+	"filament_cooling_initial_speed": "2.2",
+	"filament_cooling_moves": "4",
+	"filament_is_support": "0",
+	"filament_loading_speed": "28",
+	"filament_loading_speed_start": "3",
+	"filament_multitool_ramming": "0",
+	"filament_multitool_ramming_flow": "10",
+	"filament_multitool_ramming_volume": "10",
+	"filament_notes": "\"\"",
+	"filament_ramming_parameters": "\"120 100 6.6 6.8 7.2 7.6 7.9 8.2 8.7 9.4 9.9 10.0| 0.05 6.6 0.45 6.8 0.95 7.8 1.45 8.3 1.95 9.7 2.45 10 2.95 7.6 3.45 7.6 3.95 7.6 4.45 7.6 4.95 7.6\"",
+	"filament_retract_lift_above": "0",
+	"filament_retract_lift_below": "0",
+	"filament_retract_lift_enforce": "All Surfaces",
+	"filament_shrink": "100%",
+	"filament_unloading_speed": "90",
+	"filament_unloading_speed_start": "100",
+	"nozzle_temperature_range_high": "270",
+	"nozzle_temperature_range_low": "220",
+	"pressure_advance": "0.038",
+	"required_nozzle_HRC": "0",
+	"support_material_interface_fan_speed": "-1"
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PETG @Hi-all @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PETG @Hi-all @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Creality Generic PETG @Hi-all @System",
+	"inherits": "Creality Generic PETG @Hi-all @base",
+	"from": "system",
+	"setting_id": "GFSG99_00",
+	"filament_id": "",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PETG @Hi-all @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PETG @Hi-all @base.json
@@ -1,0 +1,148 @@
+{
+	"type": "filament",
+	"name": "Creality Generic PETG @Hi-all @base",
+	"inherits": "Creality Generic PETG",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"70"
+	],
+	"hot_plate_temp": [
+		"70"
+	],
+	"textured_plate_temp": [
+		"70"
+	],
+	"cool_plate_temp_initial_layer": [
+		"70"
+	],
+	"eng_plate_temp_initial_layer": [
+		"70"
+	],
+	"hot_plate_temp_initial_layer": [
+		"70"
+	],
+	"textured_plate_temp_initial_layer": [
+		"70"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"overhang_fan_speed": [
+		"90"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.95"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"filament_cost": [
+		"30"
+	],
+	"filament_density": [
+		"1.27"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"9"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PETG"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"250"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"90"
+	],
+	"fan_min_speed": [
+		"40"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"5"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if (position[2] > first_layer_height) }\nM104 S[nozzle_temperature]\n{else}\nM104 S[first_layer_temperature]\n{endif}\n"
+	],
+	"nozzle_temperature": [
+		"250"
+	],
+	"temperature_vitrification": [
+		"80"
+	],
+	"nozzle_temperature_range_low": [
+		"220"
+	],
+	"nozzle_temperature_range_high": [
+		"270"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PETG @K1-all @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PETG @K1-all @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Creality Generic PETG @K1-all @System",
+	"inherits": "Creality Generic PETG @K1-all @base",
+	"from": "system",
+	"setting_id": "GFSG99_00",
+	"filament_id": "",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PETG @K1-all @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PETG @K1-all @base.json
@@ -1,0 +1,148 @@
+{
+	"type": "filament",
+	"name": "Creality Generic PETG @K1-all @base",
+	"inherits": "Creality Generic PETG",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"70"
+	],
+	"hot_plate_temp": [
+		"70"
+	],
+	"textured_plate_temp": [
+		"70"
+	],
+	"cool_plate_temp_initial_layer": [
+		"70"
+	],
+	"eng_plate_temp_initial_layer": [
+		"70"
+	],
+	"hot_plate_temp_initial_layer": [
+		"70"
+	],
+	"textured_plate_temp_initial_layer": [
+		"70"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"overhang_fan_speed": [
+		"90"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.95"
+	],
+	"reduce_fan_stop_start_freq": [
+		"0"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"filament_cost": [
+		"30"
+	],
+	"filament_density": [
+		"1.27"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"9"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PETG"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"250"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"90"
+	],
+	"fan_min_speed": [
+		"40"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"slow_down_layer_time": [
+		"12"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n"
+	],
+	"nozzle_temperature": [
+		"250"
+	],
+	"temperature_vitrification": [
+		"80"
+	],
+	"nozzle_temperature_range_low": [
+		"220"
+	],
+	"nozzle_temperature_range_high": [
+		"270"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PETG @K2-all @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PETG @K2-all @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Creality Generic PETG @K2-all @System",
+	"inherits": "Creality Generic PETG @K2-all @base",
+	"from": "system",
+	"setting_id": "GFSG99_00",
+	"filament_id": "",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PETG @K2-all @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PETG @K2-all @base.json
@@ -1,0 +1,148 @@
+{
+	"type": "filament",
+	"name": "Creality Generic PETG @K2-all @base",
+	"inherits": "Creality Generic PETG",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"50"
+	],
+	"hot_plate_temp": [
+		"70"
+	],
+	"textured_plate_temp": [
+		"70"
+	],
+	"cool_plate_temp_initial_layer": [
+		"70"
+	],
+	"eng_plate_temp_initial_layer": [
+		"0"
+	],
+	"hot_plate_temp_initial_layer": [
+		"70"
+	],
+	"textured_plate_temp_initial_layer": [
+		"70"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"overhang_fan_speed": [
+		"90"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.95"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"filament_cost": [
+		"30"
+	],
+	"filament_density": [
+		"1.27"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"18"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PETG"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"250"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"80"
+	],
+	"fan_min_speed": [
+		"40"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"slow_down_layer_time": [
+		"8"
+	],
+	"filament_start_gcode": [
+		";filament start gcode\n{if (position[2] > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
+	],
+	"nozzle_temperature": [
+		"250"
+	],
+	"temperature_vitrification": [
+		"80"
+	],
+	"nozzle_temperature_range_low": [
+		"220"
+	],
+	"nozzle_temperature_range_high": [
+		"270"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PETG @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PETG @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Creality Generic PETG @System",
+	"inherits": "Creality Generic PETG @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFG99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PETG @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PETG @base.json
@@ -1,0 +1,148 @@
+{
+	"type": "filament",
+	"name": "Creality Generic PETG @base",
+	"inherits": "fdm_filament_pet",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"60"
+	],
+	"eng_plate_temp": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"80"
+	],
+	"textured_plate_temp": [
+		"80"
+	],
+	"cool_plate_temp_initial_layer": [
+		"60"
+	],
+	"eng_plate_temp_initial_layer": [
+		"0"
+	],
+	"hot_plate_temp_initial_layer": [
+		"80"
+	],
+	"textured_plate_temp_initial_layer": [
+		"80"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"overhang_fan_speed": [
+		"90"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.95"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"filament_cost": [
+		"30"
+	],
+	"filament_density": [
+		"1.27"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"10"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PETG"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"255"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"90"
+	],
+	"fan_min_speed": [
+		"40"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"8"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n"
+	],
+	"nozzle_temperature": [
+		"255"
+	],
+	"temperature_vitrification": [
+		"80"
+	],
+	"nozzle_temperature_range_low": [
+		"220"
+	],
+	"nozzle_temperature_range_high": [
+		"270"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PETG-CF @Hi-all @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PETG-CF @Hi-all @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Creality Generic PETG-CF @Hi-all @System",
+	"inherits": "Creality Generic PETG-CF @Hi-all @base",
+	"from": "system",
+	"setting_id": "GFSG99_00",
+	"filament_id": "",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PETG-CF @Hi-all @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PETG-CF @Hi-all @base.json
@@ -1,0 +1,148 @@
+{
+	"type": "filament",
+	"name": "Creality Generic PETG-CF @Hi-all @base",
+	"inherits": "Creality Generic PETG @Hi-all",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"70"
+	],
+	"hot_plate_temp": [
+		"70"
+	],
+	"textured_plate_temp": [
+		"70"
+	],
+	"cool_plate_temp_initial_layer": [
+		"70"
+	],
+	"eng_plate_temp_initial_layer": [
+		"70"
+	],
+	"hot_plate_temp_initial_layer": [
+		"70"
+	],
+	"textured_plate_temp_initial_layer": [
+		"70"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"overhang_fan_speed": [
+		"90"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.95"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"filament_cost": [
+		"30"
+	],
+	"filament_density": [
+		"1.27"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"9"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PETG"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"250"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"90"
+	],
+	"fan_min_speed": [
+		"40"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"5"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if (position[2] > first_layer_height) }\nM104 S[nozzle_temperature]\n{else}\nM104 S[first_layer_temperature]\n{endif}\n"
+	],
+	"nozzle_temperature": [
+		"250"
+	],
+	"temperature_vitrification": [
+		"80"
+	],
+	"nozzle_temperature_range_low": [
+		"220"
+	],
+	"nozzle_temperature_range_high": [
+		"270"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA @Ender-3V3-all @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA @Ender-3V3-all @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Creality Generic PLA @Ender-3V3-all @System",
+	"inherits": "Creality Generic PLA @Ender-3V3-all @base",
+	"from": "system",
+	"setting_id": "GFSL99_00",
+	"filament_id": "",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA @Ender-3V3-all @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA @Ender-3V3-all @base.json
@@ -1,0 +1,151 @@
+{
+	"type": "filament",
+	"name": "Creality Generic PLA @Ender-3V3-all @base",
+	"inherits": "Creality Generic PLA",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"55"
+	],
+	"eng_plate_temp": [
+		"55"
+	],
+	"hot_plate_temp": [
+		"55"
+	],
+	"textured_plate_temp": [
+		"55"
+	],
+	"cool_plate_temp_initial_layer": [
+		"55"
+	],
+	"eng_plate_temp_initial_layer": [
+		"55"
+	],
+	"hot_plate_temp_initial_layer": [
+		"55"
+	],
+	"textured_plate_temp_initial_layer": [
+		"55"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"18"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PLA"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"220"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"slow_down_layer_time": [
+		"8"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n"
+	],
+	"nozzle_temperature": [
+		"220"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"230"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA @Ender-5Max-all @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA @Ender-5Max-all @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Creality Generic PLA @Ender-5Max-all @System",
+	"inherits": "Creality Generic PLA @Ender-5Max-all @base",
+	"from": "system",
+	"setting_id": "GFSA04_CREALITY_00",
+	"filament_id": "04001",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA @Ender-5Max-all @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA @Ender-5Max-all @base.json
@@ -1,0 +1,103 @@
+{
+	"type": "filament",
+	"name": "Creality Generic PLA @Ender-5Max-all @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": "45",
+	"eng_plate_temp": "50",
+	"hot_plate_temp": "45",
+	"textured_plate_temp": "45",
+	"cool_plate_temp_initial_layer": "45",
+	"eng_plate_temp_initial_layer": "50",
+	"hot_plate_temp_initial_layer": "45",
+	"textured_plate_temp_initial_layer": "45",
+	"overhang_fan_threshold": "25%",
+	"overhang_fan_speed": "100",
+	"slow_down_for_layer_cooling": "1",
+	"close_fan_the_first_x_layers": "1",
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": "0.9",
+	"reduce_fan_stop_start_freq": "1",
+	"fan_cooling_layer_time": "100",
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": "nil",
+	"filament_diameter": "1.75",
+	"filament_max_volumetric_speed": [
+		"40"
+	],
+	"filament_retraction_minimum_travel": "nil",
+	"filament_retract_before_wipe": "nil",
+	"filament_retract_when_changing_layer": "nil",
+	"filament_retraction_length": "nil",
+	"filament_z_hop": "nil",
+	"filament_z_hop_types": "nil",
+	"filament_retract_restart_extra": "0",
+	"filament_retraction_speed": "nil",
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": "0",
+	"filament_type": [
+		"PLA"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": "nil",
+	"filament_wipe_distance": "nil",
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": "220",
+	"full_fan_speed_layer": "0",
+	"fan_max_speed": "100",
+	"fan_min_speed": "100",
+	"slow_down_min_speed": "10",
+	"slow_down_layer_time": "5",
+	"filament_start_gcode": [
+		"; Filament gcode\n"
+	],
+	"nozzle_temperature": "220",
+	"temperature_vitrification": [
+		"60"
+	],
+	"activate_air_filtration": "0",
+	"activate_chamber_temp_control": "0",
+	"additional_cooling_fan_speed": "0",
+	"chamber_temperature": "35",
+	"complete_print_exhaust_fan_speed": "80",
+	"cool_special_cds_fan_speed": "0",
+	"default_filament_colour": "\"\"",
+	"during_print_exhaust_fan_speed": "60",
+	"enable_overhang_bridge_fan": "1",
+	"enable_pressure_advance": "1",
+	"filament_cooling_initial_speed": "2.2",
+	"filament_cooling_moves": "4",
+	"filament_is_support": "0",
+	"filament_loading_speed": "28",
+	"filament_loading_speed_start": "3",
+	"filament_multitool_ramming": "0",
+	"filament_multitool_ramming_flow": "10",
+	"filament_multitool_ramming_volume": "10",
+	"filament_notes": "\"\"",
+	"filament_ramming_parameters": "\"120 100 6.6 6.8 7.2 7.6 7.9 8.2 8.7 9.4 9.9 10.0| 0.05 6.6 0.45 6.8 0.95 7.8 1.45 8.3 1.95 9.7 2.45 10 2.95 7.6 3.45 7.6 3.95 7.6 4.45 7.6 4.95 7.6\"",
+	"filament_retract_lift_above": "0",
+	"filament_retract_lift_below": "0",
+	"filament_retract_lift_enforce": "All Surfaces",
+	"filament_shrink": "100%",
+	"filament_unloading_speed": "90",
+	"filament_unloading_speed_start": "100",
+	"nozzle_temperature_range_high": "240",
+	"nozzle_temperature_range_low": "190",
+	"pressure_advance": "0.03",
+	"required_nozzle_HRC": "0",
+	"support_material_interface_fan_speed": "-1"
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA @Hi-all @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA @Hi-all @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Creality Generic PLA @Hi-all @System",
+	"inherits": "Creality Generic PLA @Hi-all @base",
+	"from": "system",
+	"setting_id": "GFSL99_00",
+	"filament_id": "",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA @Hi-all @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA @Hi-all @base.json
@@ -1,0 +1,187 @@
+{
+	"type": "filament",
+	"name": "Creality Generic PLA @Hi-all @base",
+	"inherits": "Creality Generic PLA",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"55"
+	],
+	"eng_plate_temp": [
+		"55"
+	],
+	"hot_plate_temp": [
+		"55"
+	],
+	"textured_plate_temp": [
+		"55"
+	],
+	"cool_plate_temp_initial_layer": [
+		"55"
+	],
+	"eng_plate_temp_initial_layer": [
+		"55"
+	],
+	"hot_plate_temp_initial_layer": [
+		"55"
+	],
+	"textured_plate_temp_initial_layer": [
+		"55"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"18"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PLA"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"220"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"slow_down_layer_time": [
+		"8"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if (position[2] > first_layer_height) }\nM104 S[nozzle_temperature]\n{else}\nM104 S[first_layer_temperature]\n{endif}\n"
+	],
+	"nozzle_temperature": [
+		"220"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"230"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"filament_cooling_initial_speed": [
+		"2.2"
+	],
+	"filament_cooling_moves": [
+		"4"
+	],
+	"filament_loading_speed": [
+		"28"
+	],
+	"filament_loading_speed_start": [
+		"3"
+	],
+	"filament_unloading_speed": [
+		"90"
+	],
+	"filament_unloading_speed_start": [
+		"100"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_multitool_ramming": [
+		"0"
+	],
+	"filament_multitool_ramming_flow": [
+		"0"
+	],
+	"filament_multitool_ramming_volume": [
+		"0"
+	],
+	"filament_notes": [
+		""
+	],
+	"filament_ramming_parameters": [
+		"120 100 6.6 6.8 7.2 7.6 7.9 8.2 8.7 9.4 9.9 10.0| 0.05 6.6 0.45 6.8 0.95 7.8 1.45 8.3 1.95 9.7 2.45 10 2.95 7.6 3.45 7.6 3.95 7.6 4.45 7.6 4.95 7.6"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA @K1-all @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA @K1-all @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Creality Generic PLA @K1-all @System",
+	"inherits": "Creality Generic PLA @K1-all @base",
+	"from": "system",
+	"setting_id": "GFSL99_00",
+	"filament_id": "",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA @K1-all @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA @K1-all @base.json
@@ -1,0 +1,151 @@
+{
+	"type": "filament",
+	"name": "Creality Generic PLA @K1-all @base",
+	"inherits": "Creality Generic PLA",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"55"
+	],
+	"eng_plate_temp": [
+		"55"
+	],
+	"hot_plate_temp": [
+		"55"
+	],
+	"textured_plate_temp": [
+		"55"
+	],
+	"cool_plate_temp_initial_layer": [
+		"55"
+	],
+	"eng_plate_temp_initial_layer": [
+		"55"
+	],
+	"hot_plate_temp_initial_layer": [
+		"55"
+	],
+	"textured_plate_temp_initial_layer": [
+		"55"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"reduce_fan_stop_start_freq": [
+		"0"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"18"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PLA"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"220"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"slow_down_layer_time": [
+		"8"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n"
+	],
+	"nozzle_temperature": [
+		"220"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"230"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA @K2-all @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA @K2-all @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Creality Generic PLA @K2-all @System",
+	"inherits": "Creality Generic PLA @K2-all @base",
+	"from": "system",
+	"setting_id": "GFSL99_00",
+	"filament_id": "",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA @K2-all @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA @K2-all @base.json
@@ -1,0 +1,151 @@
+{
+	"type": "filament",
+	"name": "Creality Generic PLA @K2-all @base",
+	"inherits": "Creality Generic PLA",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"50"
+	],
+	"eng_plate_temp": [
+		"50"
+	],
+	"hot_plate_temp": [
+		"50"
+	],
+	"textured_plate_temp": [
+		"50"
+	],
+	"cool_plate_temp_initial_layer": [
+		"50"
+	],
+	"eng_plate_temp_initial_layer": [
+		"50"
+	],
+	"hot_plate_temp_initial_layer": [
+		"50"
+	],
+	"textured_plate_temp_initial_layer": [
+		"50"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.95"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"18"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PLA"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"220"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"slow_down_layer_time": [
+		"4"
+	],
+	"filament_start_gcode": [
+		";filament start gcode\n{if (position[2] > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
+	],
+	"nozzle_temperature": [
+		"220"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"230"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Creality Generic PLA @System",
+	"inherits": "Creality Generic PLA @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFL99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA @base.json
@@ -1,0 +1,151 @@
+{
+	"type": "filament",
+	"name": "Creality Generic PLA @base",
+	"inherits": "fdm_filament_pla",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"60"
+	],
+	"eng_plate_temp": [
+		"60"
+	],
+	"hot_plate_temp": [
+		"60"
+	],
+	"textured_plate_temp": [
+		"60"
+	],
+	"cool_plate_temp_initial_layer": [
+		"60"
+	],
+	"eng_plate_temp_initial_layer": [
+		"60"
+	],
+	"hot_plate_temp_initial_layer": [
+		"60"
+	],
+	"textured_plate_temp_initial_layer": [
+		"60"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"12"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PLA"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"220"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"8"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n"
+	],
+	"nozzle_temperature": [
+		"220"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"230"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA High Speed @Ender-3V3-all @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA High Speed @Ender-3V3-all @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Creality Generic PLA High Speed @Ender-3V3-all @System",
+	"inherits": "Creality Generic PLA High Speed @Ender-3V3-all @base",
+	"from": "system",
+	"setting_id": "GFSL95_00",
+	"filament_id": "",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA High Speed @Ender-3V3-all @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA High Speed @Ender-3V3-all @base.json
@@ -1,0 +1,151 @@
+{
+	"type": "filament",
+	"name": "Creality Generic PLA High Speed @Ender-3V3-all @base",
+	"inherits": "Creality Generic PLA @Ender-3V3-all",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"55"
+	],
+	"eng_plate_temp": [
+		"55"
+	],
+	"hot_plate_temp": [
+		"55"
+	],
+	"textured_plate_temp": [
+		"55"
+	],
+	"cool_plate_temp_initial_layer": [
+		"55"
+	],
+	"eng_plate_temp_initial_layer": [
+		"55"
+	],
+	"hot_plate_temp_initial_layer": [
+		"55"
+	],
+	"textured_plate_temp_initial_layer": [
+		"55"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"23"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PLA"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"220"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"slow_down_layer_time": [
+		"8"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n"
+	],
+	"nozzle_temperature": [
+		"220"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"230"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA High Speed @Hi-all @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA High Speed @Hi-all @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Creality Generic PLA High Speed @Hi-all @System",
+	"inherits": "Creality Generic PLA High Speed @Hi-all @base",
+	"from": "system",
+	"setting_id": "GFSL95_00",
+	"filament_id": "",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA High Speed @Hi-all @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA High Speed @Hi-all @base.json
@@ -1,0 +1,187 @@
+{
+	"type": "filament",
+	"name": "Creality Generic PLA High Speed @Hi-all @base",
+	"inherits": "Creality Generic PLA @Hi-all",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"55"
+	],
+	"eng_plate_temp": [
+		"55"
+	],
+	"hot_plate_temp": [
+		"55"
+	],
+	"textured_plate_temp": [
+		"55"
+	],
+	"cool_plate_temp_initial_layer": [
+		"55"
+	],
+	"eng_plate_temp_initial_layer": [
+		"55"
+	],
+	"hot_plate_temp_initial_layer": [
+		"55"
+	],
+	"textured_plate_temp_initial_layer": [
+		"55"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.95"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"23"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PLA"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"220"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"slow_down_layer_time": [
+		"8"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if (position[2] > first_layer_height) }\nM104 S[nozzle_temperature]\n{else}\nM104 S[first_layer_temperature]\n{endif}\n"
+	],
+	"nozzle_temperature": [
+		"220"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"230"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"filament_cooling_initial_speed": [
+		"2.2"
+	],
+	"filament_cooling_moves": [
+		"4"
+	],
+	"filament_loading_speed": [
+		"28"
+	],
+	"filament_loading_speed_start": [
+		"3"
+	],
+	"filament_unloading_speed": [
+		"90"
+	],
+	"filament_unloading_speed_start": [
+		"100"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_multitool_ramming": [
+		"0"
+	],
+	"filament_multitool_ramming_flow": [
+		"0"
+	],
+	"filament_multitool_ramming_volume": [
+		"0"
+	],
+	"filament_notes": [
+		""
+	],
+	"filament_ramming_parameters": [
+		"120 100 6.6 6.8 7.2 7.6 7.9 8.2 8.7 9.4 9.9 10.0| 0.05 6.6 0.45 6.8 0.95 7.8 1.45 8.3 1.95 9.7 2.45 10 2.95 7.6 3.45 7.6 3.95 7.6 4.45 7.6 4.95 7.6"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA High Speed @K1-all @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA High Speed @K1-all @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Creality Generic PLA High Speed @K1-all @System",
+	"inherits": "Creality Generic PLA High Speed @K1-all @base",
+	"from": "system",
+	"setting_id": "GFSL95_00",
+	"filament_id": "",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA High Speed @K1-all @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA High Speed @K1-all @base.json
@@ -1,0 +1,151 @@
+{
+	"type": "filament",
+	"name": "Creality Generic PLA High Speed @K1-all @base",
+	"inherits": "Creality Generic PLA @K1-all",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"55"
+	],
+	"eng_plate_temp": [
+		"55"
+	],
+	"hot_plate_temp": [
+		"55"
+	],
+	"textured_plate_temp": [
+		"55"
+	],
+	"cool_plate_temp_initial_layer": [
+		"55"
+	],
+	"eng_plate_temp_initial_layer": [
+		"55"
+	],
+	"hot_plate_temp_initial_layer": [
+		"55"
+	],
+	"textured_plate_temp_initial_layer": [
+		"55"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"reduce_fan_stop_start_freq": [
+		"0"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"23"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PLA"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"220"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"slow_down_layer_time": [
+		"8"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n"
+	],
+	"nozzle_temperature": [
+		"220"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"230"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA High Speed @K2-all @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA High Speed @K2-all @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Creality Generic PLA High Speed @K2-all @System",
+	"inherits": "Creality Generic PLA High Speed @K2-all @base",
+	"from": "system",
+	"setting_id": "GFSL95_00",
+	"filament_id": "",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA High Speed @K2-all @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA High Speed @K2-all @base.json
@@ -1,0 +1,151 @@
+{
+	"type": "filament",
+	"name": "Creality Generic PLA High Speed @K2-all @base",
+	"inherits": "Creality Generic PLA @K2-all",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"50"
+	],
+	"eng_plate_temp": [
+		"50"
+	],
+	"hot_plate_temp": [
+		"50"
+	],
+	"textured_plate_temp": [
+		"50"
+	],
+	"cool_plate_temp_initial_layer": [
+		"50"
+	],
+	"eng_plate_temp_initial_layer": [
+		"50"
+	],
+	"hot_plate_temp_initial_layer": [
+		"50"
+	],
+	"textured_plate_temp_initial_layer": [
+		"50"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.95"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"23"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PLA"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"220"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"slow_down_layer_time": [
+		"4"
+	],
+	"filament_start_gcode": [
+		";filament start gcode\n{if (position[2] > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
+	],
+	"nozzle_temperature": [
+		"220"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"230"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA Matte @Ender-3V3-all @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA Matte @Ender-3V3-all @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Creality Generic PLA Matte @Ender-3V3-all @System",
+	"inherits": "Creality Generic PLA Matte @Ender-3V3-all @base",
+	"from": "system",
+	"setting_id": "GFSL05_00",
+	"filament_id": "",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA Matte @Ender-3V3-all @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA Matte @Ender-3V3-all @base.json
@@ -1,0 +1,151 @@
+{
+	"type": "filament",
+	"name": "Creality Generic PLA Matte @Ender-3V3-all @base",
+	"inherits": "Creality Generic PLA @Ender-3V3-all",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"55"
+	],
+	"eng_plate_temp": [
+		"55"
+	],
+	"hot_plate_temp": [
+		"55"
+	],
+	"textured_plate_temp": [
+		"55"
+	],
+	"cool_plate_temp_initial_layer": [
+		"55"
+	],
+	"eng_plate_temp_initial_layer": [
+		"55"
+	],
+	"hot_plate_temp_initial_layer": [
+		"55"
+	],
+	"textured_plate_temp_initial_layer": [
+		"55"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"18"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PLA"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"220"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"slow_down_layer_time": [
+		"8"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n"
+	],
+	"nozzle_temperature": [
+		"220"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"230"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA Matte @Hi-all @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA Matte @Hi-all @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Creality Generic PLA Matte @Hi-all @System",
+	"inherits": "Creality Generic PLA Matte @Hi-all @base",
+	"from": "system",
+	"setting_id": "GFSL05_00",
+	"filament_id": "",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA Matte @Hi-all @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA Matte @Hi-all @base.json
@@ -1,0 +1,187 @@
+{
+	"type": "filament",
+	"name": "Creality Generic PLA Matte @Hi-all @base",
+	"inherits": "Creality Generic PLA @Hi-all",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"55"
+	],
+	"eng_plate_temp": [
+		"55"
+	],
+	"hot_plate_temp": [
+		"55"
+	],
+	"textured_plate_temp": [
+		"55"
+	],
+	"cool_plate_temp_initial_layer": [
+		"55"
+	],
+	"eng_plate_temp_initial_layer": [
+		"55"
+	],
+	"hot_plate_temp_initial_layer": [
+		"55"
+	],
+	"textured_plate_temp_initial_layer": [
+		"55"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"18"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PLA"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"220"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"slow_down_layer_time": [
+		"8"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if (position[2] > first_layer_height) }\nM104 S[nozzle_temperature]\n{else}\nM104 S[first_layer_temperature]\n{endif}\n"
+	],
+	"nozzle_temperature": [
+		"220"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"230"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"filament_cooling_initial_speed": [
+		"2.2"
+	],
+	"filament_cooling_moves": [
+		"4"
+	],
+	"filament_loading_speed": [
+		"28"
+	],
+	"filament_loading_speed_start": [
+		"3"
+	],
+	"filament_unloading_speed": [
+		"90"
+	],
+	"filament_unloading_speed_start": [
+		"100"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_multitool_ramming": [
+		"0"
+	],
+	"filament_multitool_ramming_flow": [
+		"0"
+	],
+	"filament_multitool_ramming_volume": [
+		"0"
+	],
+	"filament_notes": [
+		""
+	],
+	"filament_ramming_parameters": [
+		"120 100 6.6 6.8 7.2 7.6 7.9 8.2 8.7 9.4 9.9 10.0| 0.05 6.6 0.45 6.8 0.95 7.8 1.45 8.3 1.95 9.7 2.45 10 2.95 7.6 3.45 7.6 3.95 7.6 4.45 7.6 4.95 7.6"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA Matte @K1-all @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA Matte @K1-all @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Creality Generic PLA Matte @K1-all @System",
+	"inherits": "Creality Generic PLA Matte @K1-all @base",
+	"from": "system",
+	"setting_id": "GFSL05_00",
+	"filament_id": "",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA Matte @K1-all @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA Matte @K1-all @base.json
@@ -1,0 +1,151 @@
+{
+	"type": "filament",
+	"name": "Creality Generic PLA Matte @K1-all @base",
+	"inherits": "Creality Generic PLA @K1-all",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"55"
+	],
+	"eng_plate_temp": [
+		"55"
+	],
+	"hot_plate_temp": [
+		"55"
+	],
+	"textured_plate_temp": [
+		"55"
+	],
+	"cool_plate_temp_initial_layer": [
+		"55"
+	],
+	"eng_plate_temp_initial_layer": [
+		"55"
+	],
+	"hot_plate_temp_initial_layer": [
+		"55"
+	],
+	"textured_plate_temp_initial_layer": [
+		"55"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"reduce_fan_stop_start_freq": [
+		"0"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"18"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PLA"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"220"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"slow_down_layer_time": [
+		"8"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n"
+	],
+	"nozzle_temperature": [
+		"220"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"230"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA Matte @K2-all @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA Matte @K2-all @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Creality Generic PLA Matte @K2-all @System",
+	"inherits": "Creality Generic PLA Matte @K2-all @base",
+	"from": "system",
+	"setting_id": "GFSL05_00",
+	"filament_id": "",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA Matte @K2-all @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA Matte @K2-all @base.json
@@ -1,0 +1,151 @@
+{
+	"type": "filament",
+	"name": "Creality Generic PLA Matte @K2-all @base",
+	"inherits": "Creality Generic PLA @K2-all",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"50"
+	],
+	"eng_plate_temp": [
+		"50"
+	],
+	"hot_plate_temp": [
+		"50"
+	],
+	"textured_plate_temp": [
+		"50"
+	],
+	"cool_plate_temp_initial_layer": [
+		"50"
+	],
+	"eng_plate_temp_initial_layer": [
+		"50"
+	],
+	"hot_plate_temp_initial_layer": [
+		"50"
+	],
+	"textured_plate_temp_initial_layer": [
+		"50"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.95"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"18"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PLA"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"220"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"slow_down_layer_time": [
+		"4"
+	],
+	"filament_start_gcode": [
+		";filament start gcode\n{if (position[2] > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
+	],
+	"nozzle_temperature": [
+		"220"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"230"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA Silk @Ender-3V3-all @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA Silk @Ender-3V3-all @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Creality Generic PLA Silk @Ender-3V3-all @System",
+	"inherits": "Creality Generic PLA Silk @Ender-3V3-all @base",
+	"from": "system",
+	"setting_id": "GFSL96_00",
+	"filament_id": "",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA Silk @Ender-3V3-all @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA Silk @Ender-3V3-all @base.json
@@ -1,0 +1,151 @@
+{
+	"type": "filament",
+	"name": "Creality Generic PLA Silk @Ender-3V3-all @base",
+	"inherits": "Creality Generic PLA @Ender-3V3-all",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"55"
+	],
+	"eng_plate_temp": [
+		"55"
+	],
+	"hot_plate_temp": [
+		"55"
+	],
+	"textured_plate_temp": [
+		"55"
+	],
+	"cool_plate_temp_initial_layer": [
+		"55"
+	],
+	"eng_plate_temp_initial_layer": [
+		"55"
+	],
+	"hot_plate_temp_initial_layer": [
+		"55"
+	],
+	"textured_plate_temp_initial_layer": [
+		"55"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"7.5"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PLA"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"220"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"slow_down_layer_time": [
+		"8"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n"
+	],
+	"nozzle_temperature": [
+		"220"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"230"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA Silk @Hi-all @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA Silk @Hi-all @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Creality Generic PLA Silk @Hi-all @System",
+	"inherits": "Creality Generic PLA Silk @Hi-all @base",
+	"from": "system",
+	"setting_id": "GFSL96_00",
+	"filament_id": "",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA Silk @Hi-all @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA Silk @Hi-all @base.json
@@ -1,0 +1,187 @@
+{
+	"type": "filament",
+	"name": "Creality Generic PLA Silk @Hi-all @base",
+	"inherits": "Creality Generic PLA @Hi-all",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"55"
+	],
+	"eng_plate_temp": [
+		"55"
+	],
+	"hot_plate_temp": [
+		"55"
+	],
+	"textured_plate_temp": [
+		"55"
+	],
+	"cool_plate_temp_initial_layer": [
+		"55"
+	],
+	"eng_plate_temp_initial_layer": [
+		"55"
+	],
+	"hot_plate_temp_initial_layer": [
+		"55"
+	],
+	"textured_plate_temp_initial_layer": [
+		"55"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.97"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"7.5"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PLA"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"220"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"slow_down_layer_time": [
+		"8"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if (position[2] > first_layer_height) }\nM104 S[nozzle_temperature]\n{else}\nM104 S[first_layer_temperature]\n{endif}\n"
+	],
+	"nozzle_temperature": [
+		"220"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"230"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"filament_cooling_initial_speed": [
+		"2.2"
+	],
+	"filament_cooling_moves": [
+		"4"
+	],
+	"filament_loading_speed": [
+		"28"
+	],
+	"filament_loading_speed_start": [
+		"3"
+	],
+	"filament_unloading_speed": [
+		"90"
+	],
+	"filament_unloading_speed_start": [
+		"100"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_multitool_ramming": [
+		"0"
+	],
+	"filament_multitool_ramming_flow": [
+		"0"
+	],
+	"filament_multitool_ramming_volume": [
+		"0"
+	],
+	"filament_notes": [
+		""
+	],
+	"filament_ramming_parameters": [
+		"120 100 6.6 6.8 7.2 7.6 7.9 8.2 8.7 9.4 9.9 10.0| 0.05 6.6 0.45 6.8 0.95 7.8 1.45 8.3 1.95 9.7 2.45 10 2.95 7.6 3.45 7.6 3.95 7.6 4.45 7.6 4.95 7.6"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA Silk @K1-all @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA Silk @K1-all @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Creality Generic PLA Silk @K1-all @System",
+	"inherits": "Creality Generic PLA Silk @K1-all @base",
+	"from": "system",
+	"setting_id": "GFSL96_00",
+	"filament_id": "",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA Silk @K1-all @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA Silk @K1-all @base.json
@@ -1,0 +1,151 @@
+{
+	"type": "filament",
+	"name": "Creality Generic PLA Silk @K1-all @base",
+	"inherits": "Creality Generic PLA @K1-all",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"55"
+	],
+	"eng_plate_temp": [
+		"55"
+	],
+	"hot_plate_temp": [
+		"55"
+	],
+	"textured_plate_temp": [
+		"55"
+	],
+	"cool_plate_temp_initial_layer": [
+		"55"
+	],
+	"eng_plate_temp_initial_layer": [
+		"55"
+	],
+	"hot_plate_temp_initial_layer": [
+		"55"
+	],
+	"textured_plate_temp_initial_layer": [
+		"55"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"reduce_fan_stop_start_freq": [
+		"0"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"7.5"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PLA"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"220"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"slow_down_layer_time": [
+		"8"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n"
+	],
+	"nozzle_temperature": [
+		"220"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"230"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA Silk @K2-all @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA Silk @K2-all @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Creality Generic PLA Silk @K2-all @System",
+	"inherits": "Creality Generic PLA Silk @K2-all @base",
+	"from": "system",
+	"setting_id": "GFSL96_00",
+	"filament_id": "",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA Silk @K2-all @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA Silk @K2-all @base.json
@@ -1,0 +1,151 @@
+{
+	"type": "filament",
+	"name": "Creality Generic PLA Silk @K2-all @base",
+	"inherits": "Creality Generic PLA @K2-all",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"50"
+	],
+	"eng_plate_temp": [
+		"50"
+	],
+	"hot_plate_temp": [
+		"50"
+	],
+	"textured_plate_temp": [
+		"50"
+	],
+	"cool_plate_temp_initial_layer": [
+		"50"
+	],
+	"eng_plate_temp_initial_layer": [
+		"50"
+	],
+	"hot_plate_temp_initial_layer": [
+		"50"
+	],
+	"textured_plate_temp_initial_layer": [
+		"50"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.95"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"10"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PLA"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"220"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"slow_down_layer_time": [
+		"4"
+	],
+	"filament_start_gcode": [
+		";filament start gcode\n{if (position[2] > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
+	],
+	"nozzle_temperature": [
+		"220"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"230"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA Wood @Hi-all @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA Wood @Hi-all @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Creality Generic PLA Wood @Hi-all @System",
+	"inherits": "Creality Generic PLA Wood @Hi-all @base",
+	"from": "system",
+	"setting_id": "GFSL96_00",
+	"filament_id": "",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA Wood @Hi-all @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA Wood @Hi-all @base.json
@@ -1,0 +1,187 @@
+{
+	"type": "filament",
+	"name": "Creality Generic PLA Wood @Hi-all @base",
+	"inherits": "Creality Generic PLA @Hi-all",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"55"
+	],
+	"eng_plate_temp": [
+		"55"
+	],
+	"hot_plate_temp": [
+		"55"
+	],
+	"textured_plate_temp": [
+		"55"
+	],
+	"cool_plate_temp_initial_layer": [
+		"55"
+	],
+	"eng_plate_temp_initial_layer": [
+		"55"
+	],
+	"hot_plate_temp_initial_layer": [
+		"55"
+	],
+	"textured_plate_temp_initial_layer": [
+		"55"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.88"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"8"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PLA"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"220"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"slow_down_layer_time": [
+		"8"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if (position[2] > first_layer_height) }\nM104 S[nozzle_temperature]\n{else}\nM104 S[first_layer_temperature]\n{endif}\n"
+	],
+	"nozzle_temperature": [
+		"220"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"230"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"filament_cooling_initial_speed": [
+		"2.2"
+	],
+	"filament_cooling_moves": [
+		"4"
+	],
+	"filament_loading_speed": [
+		"28"
+	],
+	"filament_loading_speed_start": [
+		"3"
+	],
+	"filament_unloading_speed": [
+		"90"
+	],
+	"filament_unloading_speed_start": [
+		"100"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_multitool_ramming": [
+		"0"
+	],
+	"filament_multitool_ramming_flow": [
+		"0"
+	],
+	"filament_multitool_ramming_volume": [
+		"0"
+	],
+	"filament_notes": [
+		""
+	],
+	"filament_ramming_parameters": [
+		"120 100 6.6 6.8 7.2 7.6 7.9 8.2 8.7 9.4 9.9 10.0| 0.05 6.6 0.45 6.8 0.95 7.8 1.45 8.3 1.95 9.7 2.45 10 2.95 7.6 3.45 7.6 3.95 7.6 4.45 7.6 4.95 7.6"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA-CF @Hi-all @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA-CF @Hi-all @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Creality Generic PLA-CF @Hi-all @System",
+	"inherits": "Creality Generic PLA-CF @Hi-all @base",
+	"from": "system",
+	"setting_id": "GFSL96_00",
+	"filament_id": "",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA-CF @Hi-all @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA-CF @Hi-all @base.json
@@ -1,0 +1,151 @@
+{
+	"type": "filament",
+	"name": "Creality Generic PLA-CF @Hi-all @base",
+	"inherits": "Creality Generic PLA-CF",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"60"
+	],
+	"eng_plate_temp": [
+		"60"
+	],
+	"hot_plate_temp": [
+		"60"
+	],
+	"textured_plate_temp": [
+		"60"
+	],
+	"cool_plate_temp_initial_layer": [
+		"60"
+	],
+	"eng_plate_temp_initial_layer": [
+		"60"
+	],
+	"hot_plate_temp_initial_layer": [
+		"60"
+	],
+	"textured_plate_temp_initial_layer": [
+		"60"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.95"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"filament_cost": [
+		"30"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"18"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PLA-CF"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"220"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"7"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n"
+	],
+	"nozzle_temperature": [
+		"220"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"230"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA-CF @K1-all @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA-CF @K1-all @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Creality Generic PLA-CF @K1-all @System",
+	"inherits": "Creality Generic PLA-CF @K1-all @base",
+	"from": "system",
+	"setting_id": "GFSL96_00",
+	"filament_id": "",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA-CF @K1-all @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA-CF @K1-all @base.json
@@ -1,0 +1,151 @@
+{
+	"type": "filament",
+	"name": "Creality Generic PLA-CF @K1-all @base",
+	"inherits": "Creality Generic PLA-CF",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"60"
+	],
+	"eng_plate_temp": [
+		"60"
+	],
+	"hot_plate_temp": [
+		"60"
+	],
+	"textured_plate_temp": [
+		"60"
+	],
+	"cool_plate_temp_initial_layer": [
+		"60"
+	],
+	"eng_plate_temp_initial_layer": [
+		"60"
+	],
+	"hot_plate_temp_initial_layer": [
+		"60"
+	],
+	"textured_plate_temp_initial_layer": [
+		"60"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.95"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"filament_cost": [
+		"30"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"12"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PLA-CF"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"220"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"7"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n"
+	],
+	"nozzle_temperature": [
+		"220"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"230"
+	],
+	"additional_cooling_fan_speed": [
+		"0"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA-CF @K2-all @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA-CF @K2-all @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Creality Generic PLA-CF @K2-all @System",
+	"inherits": "Creality Generic PLA-CF @K2-all @base",
+	"from": "system",
+	"setting_id": "GFSL96_00",
+	"filament_id": "",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA-CF @K2-all @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA-CF @K2-all @base.json
@@ -1,0 +1,151 @@
+{
+	"type": "filament",
+	"name": "Creality Generic PLA-CF @K2-all @base",
+	"inherits": "Creality Generic PLA-CF",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"60"
+	],
+	"eng_plate_temp": [
+		"60"
+	],
+	"hot_plate_temp": [
+		"60"
+	],
+	"textured_plate_temp": [
+		"60"
+	],
+	"cool_plate_temp_initial_layer": [
+		"60"
+	],
+	"eng_plate_temp_initial_layer": [
+		"60"
+	],
+	"hot_plate_temp_initial_layer": [
+		"60"
+	],
+	"textured_plate_temp_initial_layer": [
+		"60"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.95"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"filament_cost": [
+		"30"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"18"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PLA-CF"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"220"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"8"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n"
+	],
+	"nozzle_temperature": [
+		"220"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"230"
+	],
+	"additional_cooling_fan_speed": [
+		"0"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA-CF @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA-CF @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Creality Generic PLA-CF @System",
+	"inherits": "Creality Generic PLA-CF @base",
+	"from": "system",
+	"setting_id": "",
+	"filament_id": "GFL98",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA-CF @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic PLA-CF @base.json
@@ -1,0 +1,151 @@
+{
+	"type": "filament",
+	"name": "Creality Generic PLA-CF @base",
+	"inherits": "fdm_filament_pla",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"60"
+	],
+	"eng_plate_temp": [
+		"60"
+	],
+	"hot_plate_temp": [
+		"60"
+	],
+	"textured_plate_temp": [
+		"60"
+	],
+	"cool_plate_temp_initial_layer": [
+		"60"
+	],
+	"eng_plate_temp_initial_layer": [
+		"60"
+	],
+	"hot_plate_temp_initial_layer": [
+		"60"
+	],
+	"textured_plate_temp_initial_layer": [
+		"60"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.95"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"filament_cost": [
+		"30"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"12"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PLA-CF"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"220"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"7"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n"
+	],
+	"nozzle_temperature": [
+		"220"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"230"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic TPU @Ender-3V3-all @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic TPU @Ender-3V3-all @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Creality Generic TPU @Ender-3V3-all @System",
+	"inherits": "Creality Generic TPU @Ender-3V3-all @base",
+	"from": "system",
+	"setting_id": "GFU99_CREALITY_00",
+	"filament_id": "",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic TPU @Ender-3V3-all @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic TPU @Ender-3V3-all @base.json
@@ -1,0 +1,151 @@
+{
+	"type": "filament",
+	"name": "Creality Generic TPU @Ender-3V3-all @base",
+	"inherits": "Creality Generic TPU",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"30"
+	],
+	"eng_plate_temp": [
+		"30"
+	],
+	"hot_plate_temp": [
+		"30"
+	],
+	"textured_plate_temp": [
+		"30"
+	],
+	"cool_plate_temp_initial_layer": [
+		"30"
+	],
+	"eng_plate_temp_initial_layer": [
+		"30"
+	],
+	"hot_plate_temp_initial_layer": [
+		"30"
+	],
+	"textured_plate_temp_initial_layer": [
+		"30"
+	],
+	"overhang_fan_threshold": [
+		"95%"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"1"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"3.5"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"0.4"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"TPU"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"230"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"5"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n"
+	],
+	"nozzle_temperature": [
+		"230"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"nozzle_temperature_range_low": [
+		"200"
+	],
+	"nozzle_temperature_range_high": [
+		"250"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic TPU @Ender-5Max-all @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic TPU @Ender-5Max-all @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Creality Generic TPU @Ender-5Max-all @System",
+	"inherits": "Creality Generic TPU @Ender-5Max-all @base",
+	"from": "system",
+	"setting_id": "GFSA04_CREALITY_00",
+	"filament_id": "10001",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic TPU @Ender-5Max-all @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic TPU @Ender-5Max-all @base.json
@@ -1,0 +1,103 @@
+{
+	"type": "filament",
+	"name": "Creality Generic TPU @Ender-5Max-all @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": "45",
+	"eng_plate_temp": "35",
+	"hot_plate_temp": "45",
+	"textured_plate_temp": "45",
+	"cool_plate_temp_initial_layer": "45",
+	"eng_plate_temp_initial_layer": "35",
+	"hot_plate_temp_initial_layer": "45",
+	"textured_plate_temp_initial_layer": "45",
+	"overhang_fan_threshold": "50%",
+	"overhang_fan_speed": "100",
+	"slow_down_for_layer_cooling": "1",
+	"close_fan_the_first_x_layers": "1",
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": "1",
+	"reduce_fan_stop_start_freq": "1",
+	"fan_cooling_layer_time": "100",
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.26"
+	],
+	"filament_deretraction_speed": "30",
+	"filament_diameter": "1.75",
+	"filament_max_volumetric_speed": [
+		"2"
+	],
+	"filament_retraction_minimum_travel": "nil",
+	"filament_retract_before_wipe": "nil",
+	"filament_retract_when_changing_layer": "nil",
+	"filament_retraction_length": "3",
+	"filament_z_hop": "nil",
+	"filament_z_hop_types": "nil",
+	"filament_retract_restart_extra": "nil",
+	"filament_retraction_speed": "30",
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": "0",
+	"filament_type": [
+		"TPU"
+	],
+	"filament_vendor": [
+		"Creality"
+	],
+	"filament_wipe": "nil",
+	"filament_wipe_distance": "nil",
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": "195",
+	"full_fan_speed_layer": "0",
+	"fan_max_speed": "100",
+	"fan_min_speed": "100",
+	"slow_down_min_speed": "5",
+	"slow_down_layer_time": "8",
+	"filament_start_gcode": [
+		"; filament start gcode\n"
+	],
+	"nozzle_temperature": "195",
+	"temperature_vitrification": [
+		"60"
+	],
+	"activate_air_filtration": "0",
+	"activate_chamber_temp_control": "0",
+	"additional_cooling_fan_speed": "0",
+	"chamber_temperature": "35",
+	"complete_print_exhaust_fan_speed": "80",
+	"cool_special_cds_fan_speed": "0",
+	"default_filament_colour": "\"\"",
+	"during_print_exhaust_fan_speed": "60",
+	"enable_overhang_bridge_fan": "1",
+	"enable_pressure_advance": "0",
+	"filament_cooling_initial_speed": "2.2",
+	"filament_cooling_moves": "4",
+	"filament_is_support": "0",
+	"filament_loading_speed": "28",
+	"filament_loading_speed_start": "3",
+	"filament_multitool_ramming": "0",
+	"filament_multitool_ramming_flow": "10",
+	"filament_multitool_ramming_volume": "10",
+	"filament_notes": "\"\"",
+	"filament_ramming_parameters": "\"120 100 6.6 6.8 7.2 7.6 7.9 8.2 8.7 9.4 9.9 10.0| 0.05 6.6 0.45 6.8 0.95 7.8 1.45 8.3 1.95 9.7 2.45 10 2.95 7.6 3.45 7.6 3.95 7.6 4.45 7.6 4.95 7.6\"",
+	"filament_retract_lift_above": "0",
+	"filament_retract_lift_below": "0",
+	"filament_retract_lift_enforce": "All Surfaces",
+	"filament_shrink": "100%",
+	"filament_unloading_speed": "90",
+	"filament_unloading_speed_start": "100",
+	"nozzle_temperature_range_high": "220",
+	"nozzle_temperature_range_low": "200",
+	"pressure_advance": "0.02",
+	"required_nozzle_HRC": "0",
+	"support_material_interface_fan_speed": "-1"
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic TPU @Hi-all @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic TPU @Hi-all @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Creality Generic TPU @Hi-all @System",
+	"inherits": "Creality Generic TPU @Hi-all @base",
+	"from": "system",
+	"setting_id": "GFU99_CREALITY_00",
+	"filament_id": "",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic TPU @Hi-all @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic TPU @Hi-all @base.json
@@ -1,0 +1,151 @@
+{
+	"type": "filament",
+	"name": "Creality Generic TPU @Hi-all @base",
+	"inherits": "Creality Generic TPU",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"30"
+	],
+	"eng_plate_temp": [
+		"30"
+	],
+	"hot_plate_temp": [
+		"30"
+	],
+	"textured_plate_temp": [
+		"30"
+	],
+	"cool_plate_temp_initial_layer": [
+		"30"
+	],
+	"eng_plate_temp_initial_layer": [
+		"30"
+	],
+	"hot_plate_temp_initial_layer": [
+		"30"
+	],
+	"textured_plate_temp_initial_layer": [
+		"30"
+	],
+	"overhang_fan_threshold": [
+		"95%"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"1"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"3.5"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"0.4"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"TPU"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"230"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"5"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if (position[2] > first_layer_height) }\nM104 S[nozzle_temperature]\n{else}\nM104 S[first_layer_temperature]\n{endif}\n"
+	],
+	"nozzle_temperature": [
+		"230"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"nozzle_temperature_range_low": [
+		"200"
+	],
+	"nozzle_temperature_range_high": [
+		"250"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic TPU @K1-all @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic TPU @K1-all @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Creality Generic TPU @K1-all @System",
+	"inherits": "Creality Generic TPU @K1-all @base",
+	"from": "system",
+	"setting_id": "GFU99_CREALITY_00",
+	"filament_id": "",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic TPU @K1-all @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic TPU @K1-all @base.json
@@ -1,0 +1,151 @@
+{
+	"type": "filament",
+	"name": "Creality Generic TPU @K1-all @base",
+	"inherits": "Creality Generic TPU",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"30"
+	],
+	"eng_plate_temp": [
+		"30"
+	],
+	"hot_plate_temp": [
+		"30"
+	],
+	"textured_plate_temp": [
+		"30"
+	],
+	"cool_plate_temp_initial_layer": [
+		"30"
+	],
+	"eng_plate_temp_initial_layer": [
+		"30"
+	],
+	"hot_plate_temp_initial_layer": [
+		"30"
+	],
+	"textured_plate_temp_initial_layer": [
+		"30"
+	],
+	"overhang_fan_threshold": [
+		"95%"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"1"
+	],
+	"reduce_fan_stop_start_freq": [
+		"0"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"3.5"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"0.4"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"TPU"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"230"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"5"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n"
+	],
+	"nozzle_temperature": [
+		"230"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"nozzle_temperature_range_low": [
+		"200"
+	],
+	"nozzle_temperature_range_high": [
+		"250"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic TPU @K2-all @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic TPU @K2-all @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Creality Generic TPU @K2-all @System",
+	"inherits": "Creality Generic TPU @K2-all @base",
+	"from": "system",
+	"setting_id": "GFU99_CREALITY_00",
+	"filament_id": "",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic TPU @K2-all @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic TPU @K2-all @base.json
@@ -1,0 +1,151 @@
+{
+	"type": "filament",
+	"name": "Creality Generic TPU @K2-all @base",
+	"inherits": "Creality Generic TPU",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"30"
+	],
+	"eng_plate_temp": [
+		"30"
+	],
+	"hot_plate_temp": [
+		"40"
+	],
+	"textured_plate_temp": [
+		"40"
+	],
+	"cool_plate_temp_initial_layer": [
+		"30"
+	],
+	"eng_plate_temp_initial_layer": [
+		"30"
+	],
+	"hot_plate_temp_initial_layer": [
+		"40"
+	],
+	"textured_plate_temp_initial_layer": [
+		"40"
+	],
+	"overhang_fan_threshold": [
+		"95%"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"1"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"3"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"0.4"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"TPU"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"220"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"8"
+	],
+	"filament_start_gcode": [
+		";filament start gcode\n{if (position[2] > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
+	],
+	"nozzle_temperature": [
+		"220"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"nozzle_temperature_range_low": [
+		"200"
+	],
+	"nozzle_temperature_range_high": [
+		"250"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic TPU @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic TPU @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Creality Generic TPU @System",
+	"inherits": "Creality Generic TPU @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFU99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic TPU @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Generic TPU @base.json
@@ -1,0 +1,151 @@
+{
+	"type": "filament",
+	"name": "Creality Generic TPU @base",
+	"inherits": "fdm_filament_tpu",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"30"
+	],
+	"eng_plate_temp": [
+		"30"
+	],
+	"hot_plate_temp": [
+		"35"
+	],
+	"textured_plate_temp": [
+		"60"
+	],
+	"cool_plate_temp_initial_layer": [
+		"30"
+	],
+	"eng_plate_temp_initial_layer": [
+		"30"
+	],
+	"hot_plate_temp_initial_layer": [
+		"35"
+	],
+	"textured_plate_temp_initial_layer": [
+		"60"
+	],
+	"overhang_fan_threshold": [
+		"95%"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"1"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"3.2"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"0.4"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"TPU"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"240"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"8"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n"
+	],
+	"nozzle_temperature": [
+		"240"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"nozzle_temperature_range_low": [
+		"200"
+	],
+	"nozzle_temperature_range_high": [
+		"250"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality HF Generic PLA @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality HF Generic PLA @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Creality HF Generic PLA @System",
+	"inherits": "Creality HF Generic PLA @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFL99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality HF Generic PLA @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality HF Generic PLA @base.json
@@ -1,0 +1,151 @@
+{
+	"type": "filament",
+	"name": "Creality HF Generic PLA @base",
+	"inherits": "fdm_filament_pla",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"60"
+	],
+	"eng_plate_temp": [
+		"60"
+	],
+	"hot_plate_temp": [
+		"60"
+	],
+	"textured_plate_temp": [
+		"60"
+	],
+	"cool_plate_temp_initial_layer": [
+		"60"
+	],
+	"eng_plate_temp_initial_layer": [
+		"60"
+	],
+	"hot_plate_temp_initial_layer": [
+		"60"
+	],
+	"textured_plate_temp_initial_layer": [
+		"60"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"18"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PLA"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"220"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"slow_down_layer_time": [
+		"8"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n"
+	],
+	"nozzle_temperature": [
+		"220"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"230"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality HF Generic Speed PLA @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality HF Generic Speed PLA @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Creality HF Generic Speed PLA @System",
+	"inherits": "Creality HF Generic Speed PLA @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFL99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality HF Generic Speed PLA @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality HF Generic Speed PLA @base.json
@@ -1,0 +1,151 @@
+{
+	"type": "filament",
+	"name": "Creality HF Generic Speed PLA @base",
+	"inherits": "fdm_filament_pla",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"60"
+	],
+	"eng_plate_temp": [
+		"60"
+	],
+	"hot_plate_temp": [
+		"60"
+	],
+	"textured_plate_temp": [
+		"60"
+	],
+	"cool_plate_temp_initial_layer": [
+		"60"
+	],
+	"eng_plate_temp_initial_layer": [
+		"60"
+	],
+	"hot_plate_temp_initial_layer": [
+		"60"
+	],
+	"textured_plate_temp_initial_layer": [
+		"60"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_max_volumetric_speed": [
+		"23"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PLA"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": [
+		"220"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"slow_down_layer_time": [
+		"5"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n"
+	],
+	"nozzle_temperature": [
+		"220"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"230"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Hyper ABS @Ender-5Max-all @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Hyper ABS @Ender-5Max-all @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Creality Hyper ABS @Ender-5Max-all @System",
+	"inherits": "Creality Hyper ABS @Ender-5Max-all @base",
+	"from": "system",
+	"setting_id": "GFSA04_CREALITY_00",
+	"filament_id": "03001",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Hyper ABS @Ender-5Max-all @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Hyper ABS @Ender-5Max-all @base.json
@@ -1,0 +1,103 @@
+{
+	"type": "filament",
+	"name": "Creality Hyper ABS @Ender-5Max-all @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": "90",
+	"eng_plate_temp": "105",
+	"hot_plate_temp": "90",
+	"textured_plate_temp": "90",
+	"cool_plate_temp_initial_layer": "90",
+	"eng_plate_temp_initial_layer": "105",
+	"hot_plate_temp_initial_layer": "90",
+	"textured_plate_temp_initial_layer": "90",
+	"overhang_fan_threshold": "25%",
+	"overhang_fan_speed": "20",
+	"slow_down_for_layer_cooling": "1",
+	"close_fan_the_first_x_layers": "3",
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": "0.92",
+	"reduce_fan_stop_start_freq": "1",
+	"fan_cooling_layer_time": "30",
+	"filament_cost": [
+		"15"
+	],
+	"filament_density": [
+		"1.08"
+	],
+	"filament_deretraction_speed": "nil",
+	"filament_diameter": "1.75",
+	"filament_max_volumetric_speed": [
+		"60"
+	],
+	"filament_retraction_minimum_travel": "nil",
+	"filament_retract_before_wipe": "nil",
+	"filament_retract_when_changing_layer": "nil",
+	"filament_retraction_length": "nil",
+	"filament_z_hop": "nil",
+	"filament_z_hop_types": "nil",
+	"filament_retract_restart_extra": "0",
+	"filament_retraction_speed": "nil",
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": "0",
+	"filament_type": [
+		"ABS"
+	],
+	"filament_vendor": [
+		"Creality"
+	],
+	"filament_wipe": "nil",
+	"filament_wipe_distance": "nil",
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": "260",
+	"full_fan_speed_layer": "0",
+	"fan_max_speed": "20",
+	"fan_min_speed": "20",
+	"slow_down_min_speed": "10",
+	"slow_down_layer_time": "5",
+	"filament_start_gcode": [
+		"; Filament gcode\n"
+	],
+	"nozzle_temperature": "260",
+	"temperature_vitrification": [
+		"110"
+	],
+	"activate_air_filtration": "0",
+	"activate_chamber_temp_control": "0",
+	"additional_cooling_fan_speed": "0",
+	"chamber_temperature": "35",
+	"complete_print_exhaust_fan_speed": "80",
+	"cool_special_cds_fan_speed": "0",
+	"default_filament_colour": "\"\"",
+	"during_print_exhaust_fan_speed": "60",
+	"enable_overhang_bridge_fan": "1",
+	"enable_pressure_advance": "1",
+	"filament_cooling_initial_speed": "2.2",
+	"filament_cooling_moves": "4",
+	"filament_is_support": "0",
+	"filament_loading_speed": "28",
+	"filament_loading_speed_start": "3",
+	"filament_multitool_ramming": "0",
+	"filament_multitool_ramming_flow": "10",
+	"filament_multitool_ramming_volume": "10",
+	"filament_notes": "\"\"",
+	"filament_ramming_parameters": "\"120 100 6.6 6.8 7.2 7.6 7.9 8.2 8.7 9.4 9.9 10.0| 0.05 6.6 0.45 6.8 0.95 7.8 1.45 8.3 1.95 9.7 2.45 10 2.95 7.6 3.45 7.6 3.95 7.6 4.45 7.6 4.95 7.6\"",
+	"filament_retract_lift_above": "0",
+	"filament_retract_lift_below": "0",
+	"filament_retract_lift_enforce": "All Surfaces",
+	"filament_shrink": "100%",
+	"filament_unloading_speed": "90",
+	"filament_unloading_speed_start": "100",
+	"nozzle_temperature_range_high": "260",
+	"nozzle_temperature_range_low": "230",
+	"pressure_advance": "0.025",
+	"required_nozzle_HRC": "0",
+	"support_material_interface_fan_speed": "-1"
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Hyper PLA @Ender-5Max-all @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Hyper PLA @Ender-5Max-all @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Creality Hyper PLA @Ender-5Max-all @System",
+	"inherits": "Creality Hyper PLA @Ender-5Max-all @base",
+	"from": "system",
+	"setting_id": "GFSA04_CREALITY_00",
+	"filament_id": "01001",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Hyper PLA @Ender-5Max-all @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Hyper PLA @Ender-5Max-all @base.json
@@ -1,0 +1,104 @@
+{
+	"type": "filament",
+	"name": "Creality Hyper PLA @Ender-5Max-all @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": "45",
+	"eng_plate_temp": "50",
+	"hot_plate_temp": "45",
+	"textured_plate_temp": "45",
+	"cool_plate_temp_initial_layer": "45",
+	"eng_plate_temp_initial_layer": "50",
+	"hot_plate_temp_initial_layer": "45",
+	"textured_plate_temp_initial_layer": "45",
+	"overhang_fan_threshold": "50%",
+	"overhang_fan_speed": "100",
+	"slow_down_for_layer_cooling": "1",
+	"close_fan_the_first_x_layers": "1",
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": "0.97",
+	"reduce_fan_stop_start_freq": "1",
+	"fan_cooling_layer_time": "100",
+	"filament_cost": [
+		"30"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": "nil",
+	"filament_diameter": "1.75",
+	"filament_max_volumetric_speed": [
+		"50"
+	],
+	"filament_retraction_minimum_travel": "nil",
+	"filament_retract_before_wipe": "nil",
+	"filament_retract_when_changing_layer": "nil",
+	"filament_retraction_length": "nil",
+	"filament_z_hop": "nil",
+	"filament_z_hop_types": "nil",
+	"filament_retract_restart_extra": "nil",
+	"filament_retraction_speed": "nil",
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": "0",
+	"filament_type": [
+		"PLA"
+	],
+	"filament_vendor": [
+		"Creality"
+	],
+	"filament_wipe": "nil",
+	"filament_wipe_distance": "nil",
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": "220",
+	"full_fan_speed_layer": "0",
+	"fan_max_speed": "100",
+	"fan_min_speed": "100",
+	"slow_down_min_speed": "20",
+	"slow_down_layer_time": "5",
+	"filament_start_gcode": [
+		"; filament start gcode\n"
+	],
+	"nozzle_temperature": "220",
+	"temperature_vitrification": [
+		"60"
+	],
+	"activate_air_filtration": "0",
+	"activate_chamber_temp_control": "0",
+	"additional_cooling_fan_speed": "0",
+	"chamber_temperature": "0",
+	"complete_print_exhaust_fan_speed": "80",
+	"cool_special_cds_fan_speed": "0",
+	"default_filament_colour": "\"\"",
+	"during_print_exhaust_fan_speed": "60",
+	"enable_overhang_bridge_fan": "1",
+	"enable_pressure_advance": "1",
+	"filament_cooling_initial_speed": "2.2",
+	"filament_cooling_moves": "4",
+	"filament_is_support": "0",
+	"filament_loading_speed": "28",
+	"filament_loading_speed_start": "3",
+	"filament_multitool_ramming": "0",
+	"filament_multitool_ramming_flow": "10",
+	"filament_multitool_ramming_volume": "10",
+	"filament_notes": "\"\"",
+	"filament_ramming_parameters": "\"120 100 6.6 6.8 7.2 7.6 7.9 8.2 8.7 9.4 9.9 10.0| 0.05 6.6 0.45 6.8 0.95 7.8 1.45 8.3 1.95 9.7 2.45 10 2.95 7.6 3.45 7.6 3.95 7.6 4.45 7.6 4.95 7.6\"",
+	"filament_retract_lift_above": "0",
+	"filament_retract_lift_below": "0",
+	"filament_retract_lift_enforce": "All Surfaces",
+	"filament_shrink": "100%",
+	"filament_shrinkage_compensation_z": "100%",
+	"filament_unloading_speed": "90",
+	"filament_unloading_speed_start": "100",
+	"nozzle_temperature_range_high": "240",
+	"nozzle_temperature_range_low": "190",
+	"pressure_advance": "0.04",
+	"required_nozzle_HRC": "0",
+	"support_material_interface_fan_speed": "-1"
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Hyper PLA-CF @Ender-5Max-all @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Hyper PLA-CF @Ender-5Max-all @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Creality Hyper PLA-CF @Ender-5Max-all @System",
+	"inherits": "Creality Hyper PLA-CF @Ender-5Max-all @base",
+	"from": "system",
+	"setting_id": "GFSA04_CREALITY_00",
+	"filament_id": "02001",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Hyper PLA-CF @Ender-5Max-all @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Hyper PLA-CF @Ender-5Max-all @base.json
@@ -1,0 +1,103 @@
+{
+	"type": "filament",
+	"name": "Creality Hyper PLA-CF @Ender-5Max-all @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": "45",
+	"eng_plate_temp": "50",
+	"hot_plate_temp": "45",
+	"textured_plate_temp": "45",
+	"cool_plate_temp_initial_layer": "45",
+	"eng_plate_temp_initial_layer": "50",
+	"hot_plate_temp_initial_layer": "45",
+	"textured_plate_temp_initial_layer": "45",
+	"overhang_fan_threshold": "50%",
+	"overhang_fan_speed": "100",
+	"slow_down_for_layer_cooling": "1",
+	"close_fan_the_first_x_layers": "1",
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": "0.9",
+	"reduce_fan_stop_start_freq": "1",
+	"fan_cooling_layer_time": "100",
+	"filament_cost": [
+		"32"
+	],
+	"filament_density": [
+		"1.27"
+	],
+	"filament_deretraction_speed": "nil",
+	"filament_diameter": "1.75",
+	"filament_max_volumetric_speed": [
+		"40"
+	],
+	"filament_retraction_minimum_travel": "nil",
+	"filament_retract_before_wipe": "nil",
+	"filament_retract_when_changing_layer": "nil",
+	"filament_retraction_length": "nil",
+	"filament_z_hop": "nil",
+	"filament_z_hop_types": "nil",
+	"filament_retract_restart_extra": "nil",
+	"filament_retraction_speed": "nil",
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": "0",
+	"filament_type": [
+		"PLA-CF"
+	],
+	"filament_vendor": [
+		"Creality"
+	],
+	"filament_wipe": "nil",
+	"filament_wipe_distance": "nil",
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": "220",
+	"full_fan_speed_layer": "0",
+	"fan_max_speed": "100",
+	"fan_min_speed": "100",
+	"slow_down_min_speed": "10",
+	"slow_down_layer_time": "5",
+	"filament_start_gcode": [
+		"; filament start gcode\n"
+	],
+	"nozzle_temperature": "220",
+	"temperature_vitrification": [
+		"60"
+	],
+	"activate_air_filtration": "0",
+	"activate_chamber_temp_control": "0",
+	"additional_cooling_fan_speed": "0",
+	"chamber_temperature": "35",
+	"complete_print_exhaust_fan_speed": "80",
+	"cool_special_cds_fan_speed": "0",
+	"default_filament_colour": "\"\"",
+	"during_print_exhaust_fan_speed": "60",
+	"enable_overhang_bridge_fan": "1",
+	"enable_pressure_advance": "1",
+	"filament_cooling_initial_speed": "2.2",
+	"filament_cooling_moves": "4",
+	"filament_is_support": "0",
+	"filament_loading_speed": "28",
+	"filament_loading_speed_start": "3",
+	"filament_multitool_ramming": "0",
+	"filament_multitool_ramming_flow": "10",
+	"filament_multitool_ramming_volume": "10",
+	"filament_notes": "\"\"",
+	"filament_ramming_parameters": "\"120 100 6.6 6.8 7.2 7.6 7.9 8.2 8.7 9.4 9.9 10.0| 0.05 6.6 0.45 6.8 0.95 7.8 1.45 8.3 1.95 9.7 2.45 10 2.95 7.6 3.45 7.6 3.95 7.6 4.45 7.6 4.95 7.6\"",
+	"filament_retract_lift_above": "0",
+	"filament_retract_lift_below": "0",
+	"filament_retract_lift_enforce": "All Surfaces",
+	"filament_shrink": "100%",
+	"filament_unloading_speed": "90",
+	"filament_unloading_speed_start": "100",
+	"nozzle_temperature_range_high": "240",
+	"nozzle_temperature_range_low": "190",
+	"pressure_advance": "0.035",
+	"required_nozzle_HRC": "0",
+	"support_material_interface_fan_speed": "-1"
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Silk PLA @Ender-5Max-all @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Silk PLA @Ender-5Max-all @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Creality Silk PLA @Ender-5Max-all @System",
+	"inherits": "Creality Silk PLA @Ender-5Max-all @base",
+	"from": "system",
+	"setting_id": "GFSA04_CREALITY_00",
+	"filament_id": "05001",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Silk PLA @Ender-5Max-all @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Creality/Creality Silk PLA @Ender-5Max-all @base.json
@@ -1,0 +1,103 @@
+{
+	"type": "filament",
+	"name": "Creality Silk PLA @Ender-5Max-all @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": "45",
+	"eng_plate_temp": "50",
+	"hot_plate_temp": "45",
+	"textured_plate_temp": "45",
+	"cool_plate_temp_initial_layer": "45",
+	"eng_plate_temp_initial_layer": "50",
+	"hot_plate_temp_initial_layer": "45",
+	"textured_plate_temp_initial_layer": "45",
+	"overhang_fan_threshold": "50%",
+	"overhang_fan_speed": "100",
+	"slow_down_for_layer_cooling": "1",
+	"close_fan_the_first_x_layers": "1",
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	],
+	"filament_flow_ratio": "0.85",
+	"reduce_fan_stop_start_freq": "1",
+	"fan_cooling_layer_time": "100",
+	"filament_cost": [
+		"22"
+	],
+	"filament_density": [
+		"1.25"
+	],
+	"filament_deretraction_speed": "nil",
+	"filament_diameter": "1.75",
+	"filament_max_volumetric_speed": [
+		"20"
+	],
+	"filament_retraction_minimum_travel": "nil",
+	"filament_retract_before_wipe": "nil",
+	"filament_retract_when_changing_layer": "nil",
+	"filament_retraction_length": "nil",
+	"filament_z_hop": "nil",
+	"filament_z_hop_types": "nil",
+	"filament_retract_restart_extra": "nil",
+	"filament_retraction_speed": "nil",
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": "0",
+	"filament_type": [
+		"PLA"
+	],
+	"filament_vendor": [
+		"Creality"
+	],
+	"filament_wipe": "nil",
+	"filament_wipe_distance": "nil",
+	"bed_type": [
+		"Cool Plate"
+	],
+	"nozzle_temperature_initial_layer": "230",
+	"full_fan_speed_layer": "0",
+	"fan_max_speed": "100",
+	"fan_min_speed": "100",
+	"slow_down_min_speed": "10",
+	"slow_down_layer_time": "5",
+	"filament_start_gcode": [
+		"; filament start gcode\n"
+	],
+	"nozzle_temperature": "230",
+	"temperature_vitrification": [
+		"60"
+	],
+	"activate_air_filtration": "0",
+	"activate_chamber_temp_control": "0",
+	"additional_cooling_fan_speed": "0",
+	"chamber_temperature": "35",
+	"complete_print_exhaust_fan_speed": "80",
+	"cool_special_cds_fan_speed": "0",
+	"default_filament_colour": "\"\"",
+	"during_print_exhaust_fan_speed": "60",
+	"enable_overhang_bridge_fan": "1",
+	"enable_pressure_advance": "1",
+	"filament_cooling_initial_speed": "2.2",
+	"filament_cooling_moves": "4",
+	"filament_is_support": "0",
+	"filament_loading_speed": "28",
+	"filament_loading_speed_start": "3",
+	"filament_multitool_ramming": "0",
+	"filament_multitool_ramming_flow": "10",
+	"filament_multitool_ramming_volume": "10",
+	"filament_notes": "\"\"",
+	"filament_ramming_parameters": "\"120 100 6.6 6.8 7.2 7.6 7.9 8.2 8.7 9.4 9.9 10.0| 0.05 6.6 0.45 6.8 0.95 7.8 1.45 8.3 1.95 9.7 2.45 10 2.95 7.6 3.45 7.6 3.95 7.6 4.45 7.6 4.95 7.6\"",
+	"filament_retract_lift_above": "0",
+	"filament_retract_lift_below": "0",
+	"filament_retract_lift_enforce": "All Surfaces",
+	"filament_shrink": "100%",
+	"filament_unloading_speed": "90",
+	"filament_unloading_speed_start": "100",
+	"nozzle_temperature_range_high": "240",
+	"nozzle_temperature_range_low": "190",
+	"pressure_advance": "0.02",
+	"required_nozzle_HRC": "0",
+	"support_material_interface_fan_speed": "-1"
+}


### PR DESCRIPTION
## Summary

Migrates Creality filament presets to the shared OrcaFilamentLibrary for #12162.

## Changes

- Added Creality `@base` and `@System` filament presets under `resources/profiles/OrcaFilamentLibrary/filament/Creality`.
- Updated Creality vendor/printer-scoped filament presets to inherit from the new library bases while preserving compatibility constraints and overrides.
- Registered the new Creality OrcaFilamentLibrary entries in `resources/profiles/OrcaFilamentLibrary.json`.
- Dropped obsolete filament load/unload timing keys from migrated base data so vendor validation is clean.

## Testing

- `python3 scripts/orca_extra_profile_check.py --vendor Creality --check-filaments --check-materials --check-obsolete-keys` — 0 errors, 0 warnings
- `git diff --check`

/claim #12162