### PR TITLE
fix: persist user-selected preview view mode after first load

### DIFF
--- a/src/slic3r/GUI/GCodeViewer.cpp
+++ b/src/slic3r/GUI/GCodeViewer.cpp
@@ -1344,18 +1344,26 @@ void GCodeViewer::load_as_gcode(const GCodeProcessorResult& gcode_result, const 
 
     // load_toolpaths(gcode_result, build_volume, exclude_bounding_box);
     
-    // ORCA: Only show filament/color print preview if more than one tool/extruder is actually used in the toolpaths.
-    // Only reset back to Toolpaths (FeatureType) if we are currently in ColorPrint and this load is single-tool.
-    if (m_viewer.get_used_extruders_count() > 1) {
-        auto it = std::find(view_type_items.begin(), view_type_items.end(), libvgcode::EViewType::ColorPrint);
-        if (it != view_type_items.end())
-            m_view_type_sel = std::distance(view_type_items.begin(), it);
-        set_view_type(libvgcode::EViewType::ColorPrint);
-    } else if (get_view_type() == libvgcode::EViewType::ColorPrint) {
-        auto it = std::find(view_type_items.begin(), view_type_items.end(), libvgcode::EViewType::FeatureType);
-        if (it != view_type_items.end())
-            m_view_type_sel = std::distance(view_type_items.begin(), it);
-        set_view_type(libvgcode::EViewType::FeatureType);
+    // ORCA: Apply smart default view type when extruder count changes.
+    // Multi-color: ColorPrint (Filament), Single-color: FeatureType (Line Type).
+    // User selections persist within same extruder count, defaults reapply on count change.
+    int current_count = m_viewer.get_used_extruders_count();
+    if (current_count > 1) {
+        if (m_last_extruder_count_default_applied != 2) {
+            auto it = std::find(view_type_items.begin(), view_type_items.end(), libvgcode::EViewType::ColorPrint);
+            if (it != view_type_items.end())
+                m_view_type_sel = std::distance(view_type_items.begin(), it);
+            set_view_type(libvgcode::EViewType::ColorPrint);
+            m_last_extruder_count_default_applied = 2;
+        }
+    } else {
+        if (m_last_extruder_count_default_applied != 1) {
+            auto it = std::find(view_type_items.begin(), view_type_items.end(), libvgcode::EViewType::FeatureType);
+            if (it != view_type_items.end())
+                m_view_type_sel = std::distance(view_type_items.begin(), it);
+            set_view_type(libvgcode::EViewType::FeatureType);
+            m_last_extruder_count_default_applied = 1;
+        }
     }
 
     // BBS: data for rendering color arrangement recommendation
@@ -1453,18 +1461,6 @@ void GCodeViewer::load_as_gcode(const GCodeProcessorResult& gcode_result, const 
         if (time == 0.0f ||
             short_time(get_time_dhms(time)) == short_time(get_time_dhms(m_print_statistics.modes[static_cast<size_t>(PrintEstimatedStatistics::ETimeMode::Normal)].time)))
             m_viewer.set_time_mode(libvgcode::convert(PrintEstimatedStatistics::ETimeMode::Normal));
-    }
-
-    // set to color print by default if use multi extruders
-    if (m_viewer.get_used_extruders_count() > 1) {
-        for (int i = 0; i < view_type_items.size(); i++) {
-            if (view_type_items[i] == libvgcode::EViewType::ColorPrint) {
-                m_view_type_sel = i;
-                break;
-            }
-        }
-
-        set_view_type(libvgcode::EViewType::ColorPrint);
     }
 
     bool only_gcode_3mf = false;

--- a/src/slic3r/GUI/GCodeViewer.hpp
+++ b/src/slic3r/GUI/GCodeViewer.hpp
@@ -226,6 +226,7 @@ private:
     std::vector<libvgcode::EViewType> view_type_items;
     std::vector<std::string> view_type_items_str;
     int       m_view_type_sel = 0;
+    int       m_last_extruder_count_default_applied{0};  // 0=unset, 1=single, 2+=multi
     std::vector<EMoveType> options_items;
 
     bool m_legend_visible{ true };


### PR DESCRIPTION
This PR uses a cleaner approach that tracks extruder count instead of a simple flag. Smart defaults apply when switching between single/multi-color plates, while user selections persist within the same extruder count.

---

Multi-extruder prints forcibly reset the preview view to "Filament" on every refresh, ignoring user selection after manually changing the view. Single-extruder prints default to "Line Type" and let subsequent user changes stick. This fix makes multi-extruder behave consistently with single-extruder.

Re-slicing or switching between single-color plates retains the user's selection. This now extends to multi-color plates: user choices persist on re-slice and when switching between multi-color plates. When switching between single and multi-color plates, the appropriate default view is applied.

## History

1. **Before v2.3.2**: Preview defaulted to Line Type for all prints.

2. **Nov 2025 — Issue #11363 reported**: Users wanted single-filament prints to show Line Type by default (restoring pre-2.3.2 behavior), while multi-filament prints should show Filament view.

3. **Dec 2025 — PR #11397 merged** (@RF47, @igiannakas): Implemented smart defaults:
   - Single filament → Line Type (FeatureType) ✅
   - Multiple filaments → Filament (ColorPrint) ✅
   
   **Regression introduced**: The implementation unconditionally forced ColorPrint on every `load_as_gcode()` call for multi-filament prints. User manual view changes were immediately overwritten on refresh/slice. Single-filament branch correctly persisted user choices due to its conditional guard (`else if (get_view_type() == ColorPrint)`).

4. **This PR (#13625)**: Fixes the regression by tracking extruder count state, allowing smart defaults to apply only when count changes while respecting user selections within the same extruder count. Restores symmetry between single and multi-color behavior.

## Problem

In `GCodeViewer::load_as_gcode()`, the multi-extruder branch unconditionally sets `ColorPrint` every load. The single-extruder branch only resets if currently in `ColorPrint`, letting other choices persist. Multi-extruder has no such guard, so manual view changes get overwritten.

There's also a duplicate override block further down (lines 1466-1476), left as commented-out scaffolding and uncommented during a TODO cleanup (`f8a7589354`). I'm removing it since the first block already handles this case.

## Solution

Track the last extruder count that received a smart default (1=single, 2+=multi). Apply the appropriate default only when the count changes. User selections persist within the same extruder count.

## Changes

- Add `m_last_extruder_count_default_applied` int member (0=unset, 1=single, 2+=multi)
- Multi-color branch: apply ColorPrint default when count differs from last applied
- Single-color branch: apply FeatureType default when count differs from last applied
- Both branches set the tracking variable after applying default
- Remove redundant duplicate block at lines 1466-1476

## Behavior

| Scenario | Before | After |
|----------|--------|-------|
| First multi-color slice | Filament ✅ | Filament ✅ |
| First single-color slice | Line Type ✅ | Line Type ✅ |
| User changes view | Overwritten ❌ | Persists ✅ |
| Re-slice same plate | Overwritten ❌ | Persists ✅ |
| Switch single→single | N/A | Persists ✅ |
| Switch multi→multi | N/A | Persists ✅ |
| Switch single→multi | Filament ✅ | Filament ✅ |
| Switch multi→single | Stays at previous ❌ | Line Type ✅ |

## Files

- `src/slic3r/GUI/GCodeViewer.hpp`
- `src/slic3r/GUI/GCodeViewer.cpp`