### PR TITLE
Migrate re3D filaments to OrcaFilamentLibrary

### DIFF
--- a/resources/profiles/OrcaFilamentLibrary.json
+++ b/resources/profiles/OrcaFilamentLibrary.json
@@ -241,6 +241,10 @@
 			"sub_path": "filament/COEX/COEX NYLEX UNFILLED @base.json"
 		},
 		{
+			"name": "FILL3D PA @base",
+			"sub_path": "filament/FILL3D/FILL3D PA @base.json"
+		},
+		{
 			"name": "Fiberon PA12-CF @base",
 			"sub_path": "filament/Polymaker/Fiberon PA12-CF @base.json"
 		},
@@ -283,6 +287,10 @@
 		{
 			"name": "Generic PC @System",
 			"sub_path": "filament/Generic PC @System.json"
+		},
+		{
+			"name": "re3D PC @base",
+			"sub_path": "filament/re3D/re3D PC @base.json"
 		},
 		{
 			"name": "COEX PCTG PRIME @base",
@@ -365,6 +373,14 @@
 			"sub_path": "filament/FDplast/FDplast PETG @base.json"
 		},
 		{
+			"name": "FILL3D PETG @base",
+			"sub_path": "filament/FILL3D/FILL3D PETG @base.json"
+		},
+		{
+			"name": "FILL3D PETG CF @base",
+			"sub_path": "filament/FILL3D/FILL3D PETG CF @base.json"
+		},
+		{
 			"name": "Fiberon PET-CF @base",
 			"sub_path": "filament/Polymaker/Fiberon PET-CF @base.json"
 		},
@@ -389,6 +405,10 @@
 			"sub_path": "filament/Generic PETG-CF @System.json"
 		},
 		{
+			"name": "GreenGate3D PETG @base",
+			"sub_path": "filament/GreenGate3D/GreenGate3D PETG @base.json"
+		},
+		{
 			"name": "NIT PETG @base",
 			"sub_path": "filament/NIT/NIT PETG @base.json"
 		},
@@ -403,6 +423,18 @@
 		{
 			"name": "eSUN PETG @base",
 			"sub_path": "filament/eSUN/eSUN PETG @base.json"
+		},
+		{
+			"name": "re3D Greengate rPETG @base",
+			"sub_path": "filament/re3D/re3D Greengate rPETG @base.json"
+		},
+		{
+			"name": "re3D PETG @base",
+			"sub_path": "filament/re3D/re3D PETG @base.json"
+		},
+		{
+			"name": "re3D rPP @base",
+			"sub_path": "filament/re3D/re3D rPP @base.json"
 		},
 		{
 			"name": "Generic PHA @System",
@@ -559,6 +591,10 @@
 		{
 			"name": "FDplast PLA @base",
 			"sub_path": "filament/FDplast/FDplast PLA @base.json"
+		},
+		{
+			"name": "FILL3D PLA Basic @base",
+			"sub_path": "filament/FILL3D/FILL3D PLA Basic @base.json"
 		},
 		{
 			"name": "FILL3D PLA Turbo @base",
@@ -769,6 +805,18 @@
 			"sub_path": "filament/base/fdm_filament_pla_silk.json"
 		},
 		{
+			"name": "re3D PLA @base",
+			"sub_path": "filament/re3D/re3D PLA @base.json"
+		},
+		{
+			"name": "FILL3D PP @base",
+			"sub_path": "filament/FILL3D/FILL3D PP @base.json"
+		},
+		{
+			"name": "FILL3D PPCF @base",
+			"sub_path": "filament/FILL3D/FILL3D PPCF @base.json"
+		},
+		{
 			"name": "Generic PP @System",
 			"sub_path": "filament/Generic PP @System.json"
 		},
@@ -977,6 +1025,10 @@
 			"sub_path": "filament/COEX/COEX NYLEX PA6-CF @System.json"
 		},
 		{
+			"name": "FILL3D PA @System",
+			"sub_path": "filament/FILL3D/FILL3D PA @System.json"
+		},
+		{
 			"name": "Fiberon PA12-CF @System",
 			"sub_path": "filament/Polymaker/Fiberon PA12-CF @System.json"
 		},
@@ -999,6 +1051,10 @@
 		{
 			"name": "Bambu PC FR @System",
 			"sub_path": "filament/Bambu/Bambu PC FR @System.json"
+		},
+		{
+			"name": "re3D PC @System",
+			"sub_path": "filament/re3D/re3D PC @System.json"
 		},
 		{
 			"name": "COEX PCTG PRIME @System",
@@ -1061,6 +1117,14 @@
 			"sub_path": "filament/FDplast/FDplast PETG @System.json"
 		},
 		{
+			"name": "FILL3D PETG @System",
+			"sub_path": "filament/FILL3D/FILL3D PETG @System.json"
+		},
+		{
+			"name": "FILL3D PETG CF @System",
+			"sub_path": "filament/FILL3D/FILL3D PETG CF @System.json"
+		},
+		{
 			"name": "Fiberon PET-CF @System",
 			"sub_path": "filament/Polymaker/Fiberon PET-CF @System.json"
 		},
@@ -1071,6 +1135,10 @@
 		{
 			"name": "Fiberon PETG-rCF @System",
 			"sub_path": "filament/Polymaker/Fiberon PETG-rCF @System.json"
+		},
+		{
+			"name": "GreenGate3D PETG @System",
+			"sub_path": "filament/GreenGate3D/GreenGate3D PETG @System.json"
 		},
 		{
 			"name": "NIT PETG @System",
@@ -1087,6 +1155,18 @@
 		{
 			"name": "eSUN PETG @System",
 			"sub_path": "filament/eSUN/eSUN PETG @System.json"
+		},
+		{
+			"name": "re3D Greengate rPETG @System",
+			"sub_path": "filament/re3D/re3D Greengate rPETG @System.json"
+		},
+		{
+			"name": "re3D PETG @System",
+			"sub_path": "filament/re3D/re3D PETG @System.json"
+		},
+		{
+			"name": "re3D rPP @System",
+			"sub_path": "filament/re3D/re3D rPP @System.json"
 		},
 		{
 			"name": "AliZ PLA @System",
@@ -1193,56 +1273,12 @@
 			"sub_path": "filament/FDplast/FDplast PLA @System.json"
 		},
 		{
-			"name": "FILL3D PLA Turbo @System",
-			"sub_path": "filament/FILL3D/FILL3D PLA Turbo @System.json"
-		},
-		{
-			"name": "FILL3D PLA Basic @base",
-			"sub_path": "filament/FILL3D/FILL3D PLA Basic @base.json"
-		},
-		{
 			"name": "FILL3D PLA Basic @System",
 			"sub_path": "filament/FILL3D/FILL3D PLA Basic @System.json"
 		},
 		{
-			"name": "FILL3D PETG @base",
-			"sub_path": "filament/FILL3D/FILL3D PETG @base.json"
-		},
-		{
-			"name": "FILL3D PETG @System",
-			"sub_path": "filament/FILL3D/FILL3D PETG @System.json"
-		},
-		{
-			"name": "FILL3D PETG CF @base",
-			"sub_path": "filament/FILL3D/FILL3D PETG CF @base.json"
-		},
-		{
-			"name": "FILL3D PETG CF @System",
-			"sub_path": "filament/FILL3D/FILL3D PETG CF @System.json"
-		},
-		{
-			"name": "FILL3D PP @base",
-			"sub_path": "filament/FILL3D/FILL3D PP @base.json"
-		},
-		{
-			"name": "FILL3D PP @System",
-			"sub_path": "filament/FILL3D/FILL3D PP @System.json"
-		},
-		{
-			"name": "FILL3D PPCF @base",
-			"sub_path": "filament/FILL3D/FILL3D PPCF @base.json"
-		},
-		{
-			"name": "FILL3D PPCF @System",
-			"sub_path": "filament/FILL3D/FILL3D PPCF @System.json"
-		},
-		{
-			"name": "FILL3D PA @base",
-			"sub_path": "filament/FILL3D/FILL3D PA @base.json"
-		},
-		{
-			"name": "FILL3D PA @System",
-			"sub_path": "filament/FILL3D/FILL3D PA @System.json"
+			"name": "FILL3D PLA Turbo @System",
+			"sub_path": "filament/FILL3D/FILL3D PLA Turbo @System.json"
 		},
 		{
 			"name": "NIT PLA @System",
@@ -1441,6 +1477,18 @@
 			"sub_path": "filament/Generic PLA Silk @System.json"
 		},
 		{
+			"name": "re3D PLA @System",
+			"sub_path": "filament/re3D/re3D PLA @System.json"
+		},
+		{
+			"name": "FILL3D PP @System",
+			"sub_path": "filament/FILL3D/FILL3D PP @System.json"
+		},
+		{
+			"name": "FILL3D PPCF @System",
+			"sub_path": "filament/FILL3D/FILL3D PPCF @System.json"
+		},
+		{
 			"name": "Bambu PPA-CF @System",
 			"sub_path": "filament/Bambu/Bambu PPA-CF @System.json"
 		},
@@ -1499,14 +1547,6 @@
 		{
 			"name": "COEX PLA+Silk @System",
 			"sub_path": "filament/COEX/COEX PLA+Silk @System.json"
-		},
-		{
-			"name": "GreenGate3D PETG @base",
-			"sub_path": "filament/GreenGate3D/GreenGate3D PETG @base.json"
-		},
-		{
-			"name": "GreenGate3D PETG @System",
-			"sub_path": "filament/GreenGate3D/GreenGate3D PETG @System.json"
 		}
 	],
 	"process_list": [],

--- a/resources/profiles/OrcaFilamentLibrary/filament/re3D/re3D Greengate rPETG @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/re3D/re3D Greengate rPETG @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "re3D Greengate rPETG @System",
+	"inherits": "re3D Greengate rPETG @base",
+	"from": "system",
+	"setting_id": "GFSG99",
+	"filament_id": "GFG99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/re3D/re3D Greengate rPETG @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/re3D/re3D Greengate rPETG @base.json
@@ -1,0 +1,40 @@
+{
+	"type": "filament",
+	"name": "re3D Greengate rPETG @base",
+	"inherits": "fdm_filament_pet",
+	"from": "system",
+	"instantiation": "false",
+	"nozzle_temperature_initial_layer": [
+		"255"
+	],
+	"nozzle_temperature": [
+		"255"
+	],
+	"nozzle_temperature_range_low": [
+		"220"
+	],
+	"nozzle_temperature_range_high": [
+		"260"
+	],
+	"hot_plate_temp_initial_layer": [
+		"80"
+	],
+	"hot_plate_temp": [
+		"80"
+	],
+	"filament_flow_ratio": [
+		"1.02"
+	],
+	"enable_pressure_advance": [
+		"0"
+	],
+	"slow_down_layer_time": [
+		"20"
+	],
+	"slow_down_min_speed": [
+		"25"
+	],
+	"filament_start_gcode": [
+		"M190 S75\nM104 S220 T0\nM104 S210 T1\nM104 S200 T2\nM109 S220 T0\nM109 S210 T1\nM109 S200 T2"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/re3D/re3D PC @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/re3D/re3D PC @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "re3D PC @System",
+	"inherits": "re3D PC @base",
+	"from": "system",
+	"setting_id": "GFSG99",
+	"filament_id": "GFG99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/re3D/re3D PC @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/re3D/re3D PC @base.json
@@ -1,0 +1,7 @@
+{
+	"type": "filament",
+	"name": "re3D PC @base",
+	"inherits": "fdm_filament_pc",
+	"from": "system",
+	"instantiation": "false"
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/re3D/re3D PETG @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/re3D/re3D PETG @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "re3D PETG @System",
+	"inherits": "re3D PETG @base",
+	"from": "system",
+	"setting_id": "GFSG99",
+	"filament_id": "GFG99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/re3D/re3D PETG @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/re3D/re3D PETG @base.json
@@ -1,0 +1,16 @@
+{
+	"type": "filament",
+	"name": "re3D PETG @base",
+	"inherits": "fdm_filament_pet",
+	"from": "system",
+	"instantiation": "false",
+	"filament_start_gcode": [
+		"; Filament gcode"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode"
+	],
+	"filament_retraction_length": [
+		"1"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/re3D/re3D PLA @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/re3D/re3D PLA @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "re3D PLA @System",
+	"inherits": "re3D PLA @base",
+	"from": "system",
+	"setting_id": "GFSL99",
+	"filament_id": "GFL99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/re3D/re3D PLA @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/re3D/re3D PLA @base.json
@@ -1,0 +1,7 @@
+{
+	"type": "filament",
+	"name": "re3D PLA @base",
+	"inherits": "fdm_filament_pla",
+	"from": "system",
+	"instantiation": "false"
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/re3D/re3D rPP @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/re3D/re3D rPP @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "re3D rPP @System",
+	"inherits": "re3D rPP @base",
+	"from": "system",
+	"setting_id": "GFSG99",
+	"filament_id": "GFG99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/re3D/re3D rPP @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/re3D/re3D rPP @base.json
@@ -1,0 +1,43 @@
+{
+	"type": "filament",
+	"name": "re3D rPP @base",
+	"inherits": "fdm_filament_pet",
+	"from": "system",
+	"instantiation": "false",
+	"filament_type": [
+		"PP"
+	],
+	"nozzle_temperature_initial_layer": [
+		"185"
+	],
+	"nozzle_temperature": [
+		"185"
+	],
+	"nozzle_temperature_range_low": [
+		"180"
+	],
+	"nozzle_temperature_range_high": [
+		"200"
+	],
+	"hot_plate_temp_initial_layer": [
+		"110"
+	],
+	"hot_plate_temp": [
+		"110"
+	],
+	"filament_flow_ratio": [
+		"1.18"
+	],
+	"enable_pressure_advance": [
+		"0"
+	],
+	"slow_down_layer_time": [
+		"60"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"filament_start_gcode": [
+		"M190 S110\nM104 S185 T0\nM104 S185 T1\nM104 S185 T2\nM109 S185 T0\nM109 S185 T1\nM109 S185 T2"
+	]
+}

--- a/resources/profiles/re3D/filament/re3D Greengate rPETG.json
+++ b/resources/profiles/re3D/filament/re3D Greengate rPETG.json
@@ -1,44 +1,11 @@
 {
 	"type": "filament",
-	"filament_id": "GFG99",
-	"setting_id": "GFSG99",
 	"name": "re3D Greengate rPETG",
+	"inherits": "re3D Greengate rPETG @base",
 	"from": "system",
+	"setting_id": "GFSG99",
+	"filament_id": "GFG99",
 	"instantiation": "true",
-	"inherits": "fdm_filament_pet",
-	"nozzle_temperature_initial_layer": [
-		"255"
-	],
-	"nozzle_temperature": [
-		"255"
-	],
-	"nozzle_temperature_range_low": [
-		"220"
-	],
-	"nozzle_temperature_range_high": [
-		"260"
-	],
-	"hot_plate_temp_initial_layer": [
-		"80"
-	],
-	"hot_plate_temp": [
-		"80"
-	],
-	"filament_flow_ratio": [
-		"1.02"
-	],
-	"enable_pressure_advance": [
-		"0"
-	],
-	"slow_down_layer_time": [
-		"20"
-	],
-	"slow_down_min_speed": [
-		"25"
-	],
-	"filament_start_gcode": [
-		"M190 S75\nM104 S220 T0\nM104 S210 T1\nM104 S200 T2\nM109 S220 T0\nM109 S210 T1\nM109 S200 T2"
-	],
 	"compatible_printers": [
 		"re3D Gigabot X2 1.75 nozzle",
 		"re3D Gigabot X2 XLT 1.75 nozzle",

--- a/resources/profiles/re3D/filament/re3D PC.json
+++ b/resources/profiles/re3D/filament/re3D PC.json
@@ -1,11 +1,11 @@
 {
 	"type": "filament",
-	"filament_id": "GFG99",
-	"setting_id": "GFSG99",
 	"name": "re3D PC",
+	"inherits": "re3D PC @base",
 	"from": "system",
+	"setting_id": "GFSG99",
+	"filament_id": "GFG99",
 	"instantiation": "true",
-	"inherits": "fdm_filament_pc",
 	"compatible_printers": [
 		"re3D Gigabot 4 0.4 nozzle",
 		"re3D Gigabot 4 XLT 0.4 nozzle",

--- a/resources/profiles/re3D/filament/re3D PETG.json
+++ b/resources/profiles/re3D/filament/re3D PETG.json
@@ -1,20 +1,11 @@
 {
 	"type": "filament",
-	"filament_id": "GFG99",
-	"setting_id": "GFSG99",
 	"name": "re3D PETG",
+	"inherits": "re3D PETG @base",
 	"from": "system",
+	"setting_id": "GFSG99",
+	"filament_id": "GFG99",
 	"instantiation": "true",
-	"inherits": "fdm_filament_pet",
-	"filament_start_gcode": [
-		"; Filament gcode"
-	],
-	"filament_end_gcode": [
-		"; filament end gcode"
-	],
-	"filament_retraction_length": [
-		"1"
-	],
 	"compatible_printers": [
 		"re3D Gigabot 4 0.4 nozzle",
 		"re3D Gigabot 4 XLT 0.4 nozzle",

--- a/resources/profiles/re3D/filament/re3D PLA.json
+++ b/resources/profiles/re3D/filament/re3D PLA.json
@@ -1,11 +1,11 @@
 {
 	"type": "filament",
-	"filament_id": "GFL99",
-	"setting_id": "GFSL99",
 	"name": "re3D PLA",
+	"inherits": "re3D PLA @base",
 	"from": "system",
+	"setting_id": "GFSL99",
+	"filament_id": "GFL99",
 	"instantiation": "true",
-	"inherits": "fdm_filament_pla",
 	"compatible_printers": [
 		"re3D Gigabot 4 0.4 nozzle",
 		"re3D Gigabot 4 XLT 0.4 nozzle",

--- a/resources/profiles/re3D/filament/re3D rPP.json
+++ b/resources/profiles/re3D/filament/re3D rPP.json
@@ -1,47 +1,11 @@
 {
 	"type": "filament",
-	"filament_id": "GFG99",
-	"setting_id": "GFSG99",
 	"name": "re3D rPP",
+	"inherits": "re3D rPP @base",
 	"from": "system",
+	"setting_id": "GFSG99",
+	"filament_id": "GFG99",
 	"instantiation": "true",
-	"inherits": "fdm_filament_pet",
-	"filament_type": [
-		"PP"
-	],
-	"nozzle_temperature_initial_layer": [
-		"185"
-	],
-	"nozzle_temperature": [
-		"185"
-	],
-	"nozzle_temperature_range_low": [
-		"180"
-	],
-	"nozzle_temperature_range_high": [
-		"200"
-	],
-	"hot_plate_temp_initial_layer": [
-		"110"
-	],
-	"hot_plate_temp": [
-		"110"
-	],
-	"filament_flow_ratio": [
-		"1.18"
-	],
-	"enable_pressure_advance": [
-		"0"
-	],
-	"slow_down_layer_time": [
-		"60"
-	],
-	"slow_down_min_speed": [
-		"10"
-	],
-	"filament_start_gcode": [
-		"M190 S110\nM104 S185 T0\nM104 S185 T1\nM104 S185 T2\nM109 S185 T0\nM109 S185 T1\nM109 S185 T2"
-	],
 	"compatible_printers": [
 		"re3D Gigabot X2 1.75 nozzle",
 		"re3D Gigabot X2 XLT 1.75 nozzle",

--- a/resources/profiles/re3D/machine/fdm_re3D_common.json
+++ b/resources/profiles/re3D/machine/fdm_re3D_common.json
@@ -1,9 +1,9 @@
 {
 	"type": "machine",
 	"name": "fdm_re3D_common",
+	"inherits": "fdm_machine_common",
 	"from": "system",
 	"instantiation": "false",
-	"inherits": "fdm_machine_common",
 	"gcode_flavor": "klipper",
 	"machine_max_acceleration_e": [
 		"5000",
@@ -126,9 +126,6 @@
 	"machine_pause_gcode": "PAUSE",
 	"wipe": [
 		"0"
-	],
-	"default_filament_profile": [
-		""
 	],
 	"default_print_profile": "",
 	"bed_exclude_area": [


### PR DESCRIPTION
## Summary
- migrate re3D filament presets into OrcaFilamentLibrary @base/@System entries
- keep re3D printer-scoped presets as lightweight compatibility wrappers inheriting from the new library bases
- remove the invalid empty default_filament_profile entry from the re3D common machine profile so profile validation is clean

Part of #12162.

## Verification
- python3 scripts/orca_extra_profile_check.py --vendor re3D --check-filaments --check-materials --check-obsolete-keys
- git diff --check