### PR TITLE
Migrate Tiertime filaments to OrcaFilamentLibrary

### DIFF
--- a/resources/profiles/OrcaFilamentLibrary.json
+++ b/resources/profiles/OrcaFilamentLibrary.json
@@ -1507,6 +1507,614 @@
 		{
 			"name": "GreenGate3D PETG @System",
 			"sub_path": "filament/GreenGate3D/GreenGate3D PETG @System.json"
+		},
+		{
+			"name": "Tiertime ABS @base",
+			"sub_path": "filament/Tiertime/Tiertime ABS @base.json"
+		},
+		{
+			"name": "Tiertime ABS @System",
+			"sub_path": "filament/Tiertime/Tiertime ABS @System.json"
+		},
+		{
+			"name": "Tiertime ABS@300HS @base",
+			"sub_path": "filament/Tiertime/Tiertime ABS@300HS @base.json"
+		},
+		{
+			"name": "Tiertime ABS@300HS @System",
+			"sub_path": "filament/Tiertime/Tiertime ABS@300HS @System.json"
+		},
+		{
+			"name": "Tiertime ASA @base",
+			"sub_path": "filament/Tiertime/Tiertime ASA @base.json"
+		},
+		{
+			"name": "Tiertime ASA @System",
+			"sub_path": "filament/Tiertime/Tiertime ASA @System.json"
+		},
+		{
+			"name": "Tiertime ASA@300HS @base",
+			"sub_path": "filament/Tiertime/Tiertime ASA@300HS @base.json"
+		},
+		{
+			"name": "Tiertime ASA@300HS @System",
+			"sub_path": "filament/Tiertime/Tiertime ASA@300HS @System.json"
+		},
+		{
+			"name": "Tiertime Generic ABS @base",
+			"sub_path": "filament/Tiertime/Tiertime Generic ABS @base.json"
+		},
+		{
+			"name": "Tiertime Generic ABS @System",
+			"sub_path": "filament/Tiertime/Tiertime Generic ABS @System.json"
+		},
+		{
+			"name": "Tiertime Generic ABS@300HS @base",
+			"sub_path": "filament/Tiertime/Tiertime Generic ABS@300HS @base.json"
+		},
+		{
+			"name": "Tiertime Generic ABS@300HS @System",
+			"sub_path": "filament/Tiertime/Tiertime Generic ABS@300HS @System.json"
+		},
+		{
+			"name": "Tiertime Generic ASA @base",
+			"sub_path": "filament/Tiertime/Tiertime Generic ASA @base.json"
+		},
+		{
+			"name": "Tiertime Generic ASA @System",
+			"sub_path": "filament/Tiertime/Tiertime Generic ASA @System.json"
+		},
+		{
+			"name": "Tiertime Generic ASA@300HS @base",
+			"sub_path": "filament/Tiertime/Tiertime Generic ASA@300HS @base.json"
+		},
+		{
+			"name": "Tiertime Generic ASA@300HS @System",
+			"sub_path": "filament/Tiertime/Tiertime Generic ASA@300HS @System.json"
+		},
+		{
+			"name": "Tiertime Generic BVOH @base",
+			"sub_path": "filament/Tiertime/Tiertime Generic BVOH @base.json"
+		},
+		{
+			"name": "Tiertime Generic BVOH @System",
+			"sub_path": "filament/Tiertime/Tiertime Generic BVOH @System.json"
+		},
+		{
+			"name": "Tiertime Generic BVOH@300HS @base",
+			"sub_path": "filament/Tiertime/Tiertime Generic BVOH@300HS @base.json"
+		},
+		{
+			"name": "Tiertime Generic BVOH@300HS @System",
+			"sub_path": "filament/Tiertime/Tiertime Generic BVOH@300HS @System.json"
+		},
+		{
+			"name": "Tiertime Generic EVA @base",
+			"sub_path": "filament/Tiertime/Tiertime Generic EVA @base.json"
+		},
+		{
+			"name": "Tiertime Generic EVA @System",
+			"sub_path": "filament/Tiertime/Tiertime Generic EVA @System.json"
+		},
+		{
+			"name": "Tiertime Generic EVA@300HS @base",
+			"sub_path": "filament/Tiertime/Tiertime Generic EVA@300HS @base.json"
+		},
+		{
+			"name": "Tiertime Generic EVA@300HS @System",
+			"sub_path": "filament/Tiertime/Tiertime Generic EVA@300HS @System.json"
+		},
+		{
+			"name": "Tiertime Generic HIPS @base",
+			"sub_path": "filament/Tiertime/Tiertime Generic HIPS @base.json"
+		},
+		{
+			"name": "Tiertime Generic HIPS @System",
+			"sub_path": "filament/Tiertime/Tiertime Generic HIPS @System.json"
+		},
+		{
+			"name": "Tiertime Generic HIPS@300HS @base",
+			"sub_path": "filament/Tiertime/Tiertime Generic HIPS@300HS @base.json"
+		},
+		{
+			"name": "Tiertime Generic HIPS@300HS @System",
+			"sub_path": "filament/Tiertime/Tiertime Generic HIPS@300HS @System.json"
+		},
+		{
+			"name": "Tiertime Generic PA @base",
+			"sub_path": "filament/Tiertime/Tiertime Generic PA @base.json"
+		},
+		{
+			"name": "Tiertime Generic PA @System",
+			"sub_path": "filament/Tiertime/Tiertime Generic PA @System.json"
+		},
+		{
+			"name": "Tiertime Generic PA-CF @base",
+			"sub_path": "filament/Tiertime/Tiertime Generic PA-CF @base.json"
+		},
+		{
+			"name": "Tiertime Generic PA-CF @System",
+			"sub_path": "filament/Tiertime/Tiertime Generic PA-CF @System.json"
+		},
+		{
+			"name": "Tiertime Generic PA-CF@300HS @base",
+			"sub_path": "filament/Tiertime/Tiertime Generic PA-CF@300HS @base.json"
+		},
+		{
+			"name": "Tiertime Generic PA-CF@300HS @System",
+			"sub_path": "filament/Tiertime/Tiertime Generic PA-CF@300HS @System.json"
+		},
+		{
+			"name": "Tiertime Generic PA@300HS @base",
+			"sub_path": "filament/Tiertime/Tiertime Generic PA@300HS @base.json"
+		},
+		{
+			"name": "Tiertime Generic PA@300HS @System",
+			"sub_path": "filament/Tiertime/Tiertime Generic PA@300HS @System.json"
+		},
+		{
+			"name": "Tiertime Generic PC @base",
+			"sub_path": "filament/Tiertime/Tiertime Generic PC @base.json"
+		},
+		{
+			"name": "Tiertime Generic PC @System",
+			"sub_path": "filament/Tiertime/Tiertime Generic PC @System.json"
+		},
+		{
+			"name": "Tiertime Generic PC@300HS @base",
+			"sub_path": "filament/Tiertime/Tiertime Generic PC@300HS @base.json"
+		},
+		{
+			"name": "Tiertime Generic PC@300HS @System",
+			"sub_path": "filament/Tiertime/Tiertime Generic PC@300HS @System.json"
+		},
+		{
+			"name": "Tiertime Generic PCTG @base",
+			"sub_path": "filament/Tiertime/Tiertime Generic PCTG @base.json"
+		},
+		{
+			"name": "Tiertime Generic PCTG @System",
+			"sub_path": "filament/Tiertime/Tiertime Generic PCTG @System.json"
+		},
+		{
+			"name": "Tiertime Generic PCTG@300HS @base",
+			"sub_path": "filament/Tiertime/Tiertime Generic PCTG@300HS @base.json"
+		},
+		{
+			"name": "Tiertime Generic PCTG@300HS @System",
+			"sub_path": "filament/Tiertime/Tiertime Generic PCTG@300HS @System.json"
+		},
+		{
+			"name": "Tiertime Generic PE @base",
+			"sub_path": "filament/Tiertime/Tiertime Generic PE @base.json"
+		},
+		{
+			"name": "Tiertime Generic PE @System",
+			"sub_path": "filament/Tiertime/Tiertime Generic PE @System.json"
+		},
+		{
+			"name": "Tiertime Generic PE-CF @base",
+			"sub_path": "filament/Tiertime/Tiertime Generic PE-CF @base.json"
+		},
+		{
+			"name": "Tiertime Generic PE-CF @System",
+			"sub_path": "filament/Tiertime/Tiertime Generic PE-CF @System.json"
+		},
+		{
+			"name": "Tiertime Generic PE-CF@300HS @base",
+			"sub_path": "filament/Tiertime/Tiertime Generic PE-CF@300HS @base.json"
+		},
+		{
+			"name": "Tiertime Generic PE-CF@300HS @System",
+			"sub_path": "filament/Tiertime/Tiertime Generic PE-CF@300HS @System.json"
+		},
+		{
+			"name": "Tiertime Generic PE@300HS @base",
+			"sub_path": "filament/Tiertime/Tiertime Generic PE@300HS @base.json"
+		},
+		{
+			"name": "Tiertime Generic PE@300HS @System",
+			"sub_path": "filament/Tiertime/Tiertime Generic PE@300HS @System.json"
+		},
+		{
+			"name": "Tiertime Generic PETG @base",
+			"sub_path": "filament/Tiertime/Tiertime Generic PETG @base.json"
+		},
+		{
+			"name": "Tiertime Generic PETG @System",
+			"sub_path": "filament/Tiertime/Tiertime Generic PETG @System.json"
+		},
+		{
+			"name": "Tiertime Generic PETG-CF @base",
+			"sub_path": "filament/Tiertime/Tiertime Generic PETG-CF @base.json"
+		},
+		{
+			"name": "Tiertime Generic PETG-CF @System",
+			"sub_path": "filament/Tiertime/Tiertime Generic PETG-CF @System.json"
+		},
+		{
+			"name": "Tiertime Generic PETG-CF@300HS @base",
+			"sub_path": "filament/Tiertime/Tiertime Generic PETG-CF@300HS @base.json"
+		},
+		{
+			"name": "Tiertime Generic PETG-CF@300HS @System",
+			"sub_path": "filament/Tiertime/Tiertime Generic PETG-CF@300HS @System.json"
+		},
+		{
+			"name": "Tiertime Generic PETG@300HS @base",
+			"sub_path": "filament/Tiertime/Tiertime Generic PETG@300HS @base.json"
+		},
+		{
+			"name": "Tiertime Generic PETG@300HS @System",
+			"sub_path": "filament/Tiertime/Tiertime Generic PETG@300HS @System.json"
+		},
+		{
+			"name": "Tiertime Generic PHA @base",
+			"sub_path": "filament/Tiertime/Tiertime Generic PHA @base.json"
+		},
+		{
+			"name": "Tiertime Generic PHA @System",
+			"sub_path": "filament/Tiertime/Tiertime Generic PHA @System.json"
+		},
+		{
+			"name": "Tiertime Generic PHA@300HS @base",
+			"sub_path": "filament/Tiertime/Tiertime Generic PHA@300HS @base.json"
+		},
+		{
+			"name": "Tiertime Generic PHA@300HS @System",
+			"sub_path": "filament/Tiertime/Tiertime Generic PHA@300HS @System.json"
+		},
+		{
+			"name": "Tiertime Generic PLA @base",
+			"sub_path": "filament/Tiertime/Tiertime Generic PLA @base.json"
+		},
+		{
+			"name": "Tiertime Generic PLA @System",
+			"sub_path": "filament/Tiertime/Tiertime Generic PLA @System.json"
+		},
+		{
+			"name": "Tiertime Generic PLA High Speed @base",
+			"sub_path": "filament/Tiertime/Tiertime Generic PLA High Speed @base.json"
+		},
+		{
+			"name": "Tiertime Generic PLA High Speed @System",
+			"sub_path": "filament/Tiertime/Tiertime Generic PLA High Speed @System.json"
+		},
+		{
+			"name": "Tiertime Generic PLA High Speed@300HS @base",
+			"sub_path": "filament/Tiertime/Tiertime Generic PLA High Speed@300HS @base.json"
+		},
+		{
+			"name": "Tiertime Generic PLA High Speed@300HS @System",
+			"sub_path": "filament/Tiertime/Tiertime Generic PLA High Speed@300HS @System.json"
+		},
+		{
+			"name": "Tiertime Generic PLA Silk @base",
+			"sub_path": "filament/Tiertime/Tiertime Generic PLA Silk @base.json"
+		},
+		{
+			"name": "Tiertime Generic PLA Silk @System",
+			"sub_path": "filament/Tiertime/Tiertime Generic PLA Silk @System.json"
+		},
+		{
+			"name": "Tiertime Generic PLA Silk@300HS @base",
+			"sub_path": "filament/Tiertime/Tiertime Generic PLA Silk@300HS @base.json"
+		},
+		{
+			"name": "Tiertime Generic PLA Silk@300HS @System",
+			"sub_path": "filament/Tiertime/Tiertime Generic PLA Silk@300HS @System.json"
+		},
+		{
+			"name": "Tiertime Generic PLA-CF @base",
+			"sub_path": "filament/Tiertime/Tiertime Generic PLA-CF @base.json"
+		},
+		{
+			"name": "Tiertime Generic PLA-CF @System",
+			"sub_path": "filament/Tiertime/Tiertime Generic PLA-CF @System.json"
+		},
+		{
+			"name": "Tiertime Generic PLA-CF@300HS @base",
+			"sub_path": "filament/Tiertime/Tiertime Generic PLA-CF@300HS @base.json"
+		},
+		{
+			"name": "Tiertime Generic PLA-CF@300HS @System",
+			"sub_path": "filament/Tiertime/Tiertime Generic PLA-CF@300HS @System.json"
+		},
+		{
+			"name": "Tiertime Generic PLA@300HS @base",
+			"sub_path": "filament/Tiertime/Tiertime Generic PLA@300HS @base.json"
+		},
+		{
+			"name": "Tiertime Generic PLA@300HS @System",
+			"sub_path": "filament/Tiertime/Tiertime Generic PLA@300HS @System.json"
+		},
+		{
+			"name": "Tiertime Generic PP @base",
+			"sub_path": "filament/Tiertime/Tiertime Generic PP @base.json"
+		},
+		{
+			"name": "Tiertime Generic PP @System",
+			"sub_path": "filament/Tiertime/Tiertime Generic PP @System.json"
+		},
+		{
+			"name": "Tiertime Generic PP-CF @base",
+			"sub_path": "filament/Tiertime/Tiertime Generic PP-CF @base.json"
+		},
+		{
+			"name": "Tiertime Generic PP-CF @System",
+			"sub_path": "filament/Tiertime/Tiertime Generic PP-CF @System.json"
+		},
+		{
+			"name": "Tiertime Generic PP-CF@300HS @base",
+			"sub_path": "filament/Tiertime/Tiertime Generic PP-CF@300HS @base.json"
+		},
+		{
+			"name": "Tiertime Generic PP-CF@300HS @System",
+			"sub_path": "filament/Tiertime/Tiertime Generic PP-CF@300HS @System.json"
+		},
+		{
+			"name": "Tiertime Generic PP-GF @base",
+			"sub_path": "filament/Tiertime/Tiertime Generic PP-GF @base.json"
+		},
+		{
+			"name": "Tiertime Generic PP-GF @System",
+			"sub_path": "filament/Tiertime/Tiertime Generic PP-GF @System.json"
+		},
+		{
+			"name": "Tiertime Generic PP-GF@300HS @base",
+			"sub_path": "filament/Tiertime/Tiertime Generic PP-GF@300HS @base.json"
+		},
+		{
+			"name": "Tiertime Generic PP-GF@300HS @System",
+			"sub_path": "filament/Tiertime/Tiertime Generic PP-GF@300HS @System.json"
+		},
+		{
+			"name": "Tiertime Generic PP@300HS @base",
+			"sub_path": "filament/Tiertime/Tiertime Generic PP@300HS @base.json"
+		},
+		{
+			"name": "Tiertime Generic PP@300HS @System",
+			"sub_path": "filament/Tiertime/Tiertime Generic PP@300HS @System.json"
+		},
+		{
+			"name": "Tiertime Generic PPA-CF @base",
+			"sub_path": "filament/Tiertime/Tiertime Generic PPA-CF @base.json"
+		},
+		{
+			"name": "Tiertime Generic PPA-CF @System",
+			"sub_path": "filament/Tiertime/Tiertime Generic PPA-CF @System.json"
+		},
+		{
+			"name": "Tiertime Generic PPA-CF@300HS @base",
+			"sub_path": "filament/Tiertime/Tiertime Generic PPA-CF@300HS @base.json"
+		},
+		{
+			"name": "Tiertime Generic PPA-CF@300HS @System",
+			"sub_path": "filament/Tiertime/Tiertime Generic PPA-CF@300HS @System.json"
+		},
+		{
+			"name": "Tiertime Generic PPA-GF @base",
+			"sub_path": "filament/Tiertime/Tiertime Generic PPA-GF @base.json"
+		},
+		{
+			"name": "Tiertime Generic PPA-GF @System",
+			"sub_path": "filament/Tiertime/Tiertime Generic PPA-GF @System.json"
+		},
+		{
+			"name": "Tiertime Generic PPA-GF@300HS @base",
+			"sub_path": "filament/Tiertime/Tiertime Generic PPA-GF@300HS @base.json"
+		},
+		{
+			"name": "Tiertime Generic PPA-GF@300HS @System",
+			"sub_path": "filament/Tiertime/Tiertime Generic PPA-GF@300HS @System.json"
+		},
+		{
+			"name": "Tiertime Generic PPS @base",
+			"sub_path": "filament/Tiertime/Tiertime Generic PPS @base.json"
+		},
+		{
+			"name": "Tiertime Generic PPS @System",
+			"sub_path": "filament/Tiertime/Tiertime Generic PPS @System.json"
+		},
+		{
+			"name": "Tiertime Generic PPS-CF @base",
+			"sub_path": "filament/Tiertime/Tiertime Generic PPS-CF @base.json"
+		},
+		{
+			"name": "Tiertime Generic PPS-CF @System",
+			"sub_path": "filament/Tiertime/Tiertime Generic PPS-CF @System.json"
+		},
+		{
+			"name": "Tiertime Generic PPS-CF@300HS @base",
+			"sub_path": "filament/Tiertime/Tiertime Generic PPS-CF@300HS @base.json"
+		},
+		{
+			"name": "Tiertime Generic PPS-CF@300HS @System",
+			"sub_path": "filament/Tiertime/Tiertime Generic PPS-CF@300HS @System.json"
+		},
+		{
+			"name": "Tiertime Generic PPS@300HS @base",
+			"sub_path": "filament/Tiertime/Tiertime Generic PPS@300HS @base.json"
+		},
+		{
+			"name": "Tiertime Generic PPS@300HS @System",
+			"sub_path": "filament/Tiertime/Tiertime Generic PPS@300HS @System.json"
+		},
+		{
+			"name": "Tiertime Generic PVA @base",
+			"sub_path": "filament/Tiertime/Tiertime Generic PVA @base.json"
+		},
+		{
+			"name": "Tiertime Generic PVA @System",
+			"sub_path": "filament/Tiertime/Tiertime Generic PVA @System.json"
+		},
+		{
+			"name": "Tiertime Generic PVA@300HS @base",
+			"sub_path": "filament/Tiertime/Tiertime Generic PVA@300HS @base.json"
+		},
+		{
+			"name": "Tiertime Generic PVA@300HS @System",
+			"sub_path": "filament/Tiertime/Tiertime Generic PVA@300HS @System.json"
+		},
+		{
+			"name": "Tiertime Generic SBS @base",
+			"sub_path": "filament/Tiertime/Tiertime Generic SBS @base.json"
+		},
+		{
+			"name": "Tiertime Generic SBS @System",
+			"sub_path": "filament/Tiertime/Tiertime Generic SBS @System.json"
+		},
+		{
+			"name": "Tiertime Generic SBS@300HS @base",
+			"sub_path": "filament/Tiertime/Tiertime Generic SBS@300HS @base.json"
+		},
+		{
+			"name": "Tiertime Generic SBS@300HS @System",
+			"sub_path": "filament/Tiertime/Tiertime Generic SBS@300HS @System.json"
+		},
+		{
+			"name": "Tiertime Generic TPU @base",
+			"sub_path": "filament/Tiertime/Tiertime Generic TPU @base.json"
+		},
+		{
+			"name": "Tiertime Generic TPU @System",
+			"sub_path": "filament/Tiertime/Tiertime Generic TPU @System.json"
+		},
+		{
+			"name": "Tiertime Generic TPU@300HS @base",
+			"sub_path": "filament/Tiertime/Tiertime Generic TPU@300HS @base.json"
+		},
+		{
+			"name": "Tiertime Generic TPU@300HS @System",
+			"sub_path": "filament/Tiertime/Tiertime Generic TPU@300HS @System.json"
+		},
+		{
+			"name": "Tiertime PA6-CF @base",
+			"sub_path": "filament/Tiertime/Tiertime PA6-CF @base.json"
+		},
+		{
+			"name": "Tiertime PA6-CF @System",
+			"sub_path": "filament/Tiertime/Tiertime PA6-CF @System.json"
+		},
+		{
+			"name": "Tiertime PA6-CF@300HS @base",
+			"sub_path": "filament/Tiertime/Tiertime PA6-CF@300HS @base.json"
+		},
+		{
+			"name": "Tiertime PA6-CF@300HS @System",
+			"sub_path": "filament/Tiertime/Tiertime PA6-CF@300HS @System.json"
+		},
+		{
+			"name": "Tiertime PC @base",
+			"sub_path": "filament/Tiertime/Tiertime PC @base.json"
+		},
+		{
+			"name": "Tiertime PC @System",
+			"sub_path": "filament/Tiertime/Tiertime PC @System.json"
+		},
+		{
+			"name": "Tiertime PC@300HS @base",
+			"sub_path": "filament/Tiertime/Tiertime PC@300HS @base.json"
+		},
+		{
+			"name": "Tiertime PC@300HS @System",
+			"sub_path": "filament/Tiertime/Tiertime PC@300HS @System.json"
+		},
+		{
+			"name": "Tiertime PET-CF @base",
+			"sub_path": "filament/Tiertime/Tiertime PET-CF @base.json"
+		},
+		{
+			"name": "Tiertime PET-CF @System",
+			"sub_path": "filament/Tiertime/Tiertime PET-CF @System.json"
+		},
+		{
+			"name": "Tiertime PET-CF@300HS @base",
+			"sub_path": "filament/Tiertime/Tiertime PET-CF@300HS @base.json"
+		},
+		{
+			"name": "Tiertime PET-CF@300HS @System",
+			"sub_path": "filament/Tiertime/Tiertime PET-CF@300HS @System.json"
+		},
+		{
+			"name": "Tiertime PETG @base",
+			"sub_path": "filament/Tiertime/Tiertime PETG @base.json"
+		},
+		{
+			"name": "Tiertime PETG @System",
+			"sub_path": "filament/Tiertime/Tiertime PETG @System.json"
+		},
+		{
+			"name": "Tiertime PETG@300HS @base",
+			"sub_path": "filament/Tiertime/Tiertime PETG@300HS @base.json"
+		},
+		{
+			"name": "Tiertime PETG@300HS @System",
+			"sub_path": "filament/Tiertime/Tiertime PETG@300HS @System.json"
+		},
+		{
+			"name": "Tiertime PLA @base",
+			"sub_path": "filament/Tiertime/Tiertime PLA @base.json"
+		},
+		{
+			"name": "Tiertime PLA @System",
+			"sub_path": "filament/Tiertime/Tiertime PLA @System.json"
+		},
+		{
+			"name": "Tiertime PLA-CF @base",
+			"sub_path": "filament/Tiertime/Tiertime PLA-CF @base.json"
+		},
+		{
+			"name": "Tiertime PLA-CF @System",
+			"sub_path": "filament/Tiertime/Tiertime PLA-CF @System.json"
+		},
+		{
+			"name": "Tiertime PLA-CF@300HS @base",
+			"sub_path": "filament/Tiertime/Tiertime PLA-CF@300HS @base.json"
+		},
+		{
+			"name": "Tiertime PLA-CF@300HS @System",
+			"sub_path": "filament/Tiertime/Tiertime PLA-CF@300HS @System.json"
+		},
+		{
+			"name": "Tiertime PLA@300HS @base",
+			"sub_path": "filament/Tiertime/Tiertime PLA@300HS @base.json"
+		},
+		{
+			"name": "Tiertime PLA@300HS @System",
+			"sub_path": "filament/Tiertime/Tiertime PLA@300HS @System.json"
+		},
+		{
+			"name": "Tiertime PVA @base",
+			"sub_path": "filament/Tiertime/Tiertime PVA @base.json"
+		},
+		{
+			"name": "Tiertime PVA @System",
+			"sub_path": "filament/Tiertime/Tiertime PVA @System.json"
+		},
+		{
+			"name": "Tiertime PVA@300HS @base",
+			"sub_path": "filament/Tiertime/Tiertime PVA@300HS @base.json"
+		},
+		{
+			"name": "Tiertime PVA@300HS @System",
+			"sub_path": "filament/Tiertime/Tiertime PVA@300HS @System.json"
+		},
+		{
+			"name": "Tiertime TPU 95A @base",
+			"sub_path": "filament/Tiertime/Tiertime TPU 95A @base.json"
+		},
+		{
+			"name": "Tiertime TPU 95A @System",
+			"sub_path": "filament/Tiertime/Tiertime TPU 95A @System.json"
+		},
+		{
+			"name": "Tiertime TPU 95A@300HS @base",
+			"sub_path": "filament/Tiertime/Tiertime TPU 95A@300HS @base.json"
+		},
+		{
+			"name": "Tiertime TPU 95A@300HS @System",
+			"sub_path": "filament/Tiertime/Tiertime TPU 95A@300HS @System.json"
 		}
 	],
 	"process_list": [],

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime ABS @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime ABS @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Tiertime ABS @System",
+	"inherits": "Tiertime ABS @base",
+	"from": "system",
+	"setting_id": "GFSB00",
+	"filament_id": "GFB00",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime ABS @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime ABS @base.json
@@ -1,0 +1,169 @@
+{
+	"type": "filament",
+	"name": "Tiertime ABS @base",
+	"inherits": "fdm_filament_abs",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"chamber_temperatures": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"0"
+	],
+	"cool_plate_temp_initial_layer": [
+		"0"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"90"
+	],
+	"eng_plate_temp_initial_layer": [
+		"90"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"fan_max_speed": [
+		"60"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"filament_cost": [
+		"24.99"
+	],
+	"filament_density": [
+		"1.04"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"0.95"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"16"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"ABS"
+	],
+	"filament_vendor": [
+		"Tiertime"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"90"
+	],
+	"hot_plate_temp_initial_layer": [
+		"90"
+	],
+	"nozzle_temperature": [
+		"270"
+	],
+	"nozzle_temperature_initial_layer": [
+		"270"
+	],
+	"overhang_fan_speed": [
+		"80"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"3"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"12"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"temperature_vitrification": [
+		"100"
+	],
+	"textured_plate_temp": [
+		"90"
+	],
+	"textured_plate_temp_initial_layer": [
+		"90"
+	],
+	"filament_start_gcode": [
+		"; Filament gcode\n;{if activate_air_filtration[current_extruder] && support_air_filtration}\n;M106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n;{endif}"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n;M106 P3 S0\n"
+	],
+	"nozzle_temperature_range_high": [
+		"280"
+	],
+	"nozzle_temperature_range_low": [
+		"240"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime ABS@300HS @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime ABS@300HS @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Tiertime ABS@300HS @System",
+	"inherits": "Tiertime ABS@300HS @base",
+	"from": "system",
+	"setting_id": "GFSB00",
+	"filament_id": "GFB00_01",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime ABS@300HS @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime ABS@300HS @base.json
@@ -1,0 +1,169 @@
+{
+	"type": "filament",
+	"name": "Tiertime ABS@300HS @base",
+	"inherits": "fdm_filament_abs",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"chamber_temperatures": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"0"
+	],
+	"cool_plate_temp_initial_layer": [
+		"0"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"90"
+	],
+	"eng_plate_temp_initial_layer": [
+		"90"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"fan_max_speed": [
+		"60"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"filament_cost": [
+		"24.99"
+	],
+	"filament_density": [
+		"1.04"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"0.95"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"16"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"ABS"
+	],
+	"filament_vendor": [
+		"Tiertime"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"90"
+	],
+	"hot_plate_temp_initial_layer": [
+		"90"
+	],
+	"nozzle_temperature": [
+		"270"
+	],
+	"nozzle_temperature_initial_layer": [
+		"270"
+	],
+	"overhang_fan_speed": [
+		"80"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"3"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"12"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"temperature_vitrification": [
+		"100"
+	],
+	"textured_plate_temp": [
+		"90"
+	],
+	"textured_plate_temp_initial_layer": [
+		"90"
+	],
+	"filament_start_gcode": [
+		"; Filament gcode\n;{if activate_air_filtration[current_extruder] && support_air_filtration}\n;M106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n;{endif}"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n;M106 P3 S0\n"
+	],
+	"nozzle_temperature_range_high": [
+		"280"
+	],
+	"nozzle_temperature_range_low": [
+		"240"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime ASA @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime ASA @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Tiertime ASA @System",
+	"inherits": "Tiertime ASA @base",
+	"from": "system",
+	"setting_id": "",
+	"filament_id": "GFB01",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime ASA @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime ASA @base.json
@@ -1,0 +1,169 @@
+{
+	"type": "filament",
+	"name": "Tiertime ASA @base",
+	"inherits": "fdm_filament_asa",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"chamber_temperatures": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"0"
+	],
+	"cool_plate_temp_initial_layer": [
+		"0"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"90"
+	],
+	"eng_plate_temp_initial_layer": [
+		"90"
+	],
+	"fan_cooling_layer_time": [
+		"35"
+	],
+	"fan_max_speed": [
+		"35"
+	],
+	"fan_min_speed": [
+		"25"
+	],
+	"filament_cost": [
+		"31.99"
+	],
+	"filament_density": [
+		"1.05"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"0.95"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"18"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"ASA"
+	],
+	"filament_vendor": [
+		"Tiertime"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"90"
+	],
+	"hot_plate_temp_initial_layer": [
+		"90"
+	],
+	"nozzle_temperature": [
+		"270"
+	],
+	"nozzle_temperature_initial_layer": [
+		"270"
+	],
+	"overhang_fan_speed": [
+		"80"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"3"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"12"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"temperature_vitrification": [
+		"100"
+	],
+	"textured_plate_temp": [
+		"90"
+	],
+	"textured_plate_temp_initial_layer": [
+		"90"
+	],
+	"filament_start_gcode": [
+		"; Filament gcode\n;{if activate_air_filtration[current_extruder] && support_air_filtration}\n;M106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n;{endif}"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n;M106 P3 S0\n"
+	],
+	"nozzle_temperature_range_high": [
+		"280"
+	],
+	"nozzle_temperature_range_low": [
+		"240"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime ASA@300HS @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime ASA@300HS @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Tiertime ASA@300HS @System",
+	"inherits": "Tiertime ASA@300HS @base",
+	"from": "system",
+	"setting_id": "",
+	"filament_id": "GFB01_01",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime ASA@300HS @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime ASA@300HS @base.json
@@ -1,0 +1,169 @@
+{
+	"type": "filament",
+	"name": "Tiertime ASA@300HS @base",
+	"inherits": "fdm_filament_asa",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"chamber_temperatures": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"0"
+	],
+	"cool_plate_temp_initial_layer": [
+		"0"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"90"
+	],
+	"eng_plate_temp_initial_layer": [
+		"90"
+	],
+	"fan_cooling_layer_time": [
+		"35"
+	],
+	"fan_max_speed": [
+		"35"
+	],
+	"fan_min_speed": [
+		"25"
+	],
+	"filament_cost": [
+		"31.99"
+	],
+	"filament_density": [
+		"1.05"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"0.95"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"18"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"ASA"
+	],
+	"filament_vendor": [
+		"Tiertime"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"90"
+	],
+	"hot_plate_temp_initial_layer": [
+		"90"
+	],
+	"nozzle_temperature": [
+		"270"
+	],
+	"nozzle_temperature_initial_layer": [
+		"270"
+	],
+	"overhang_fan_speed": [
+		"80"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"3"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"12"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"temperature_vitrification": [
+		"100"
+	],
+	"textured_plate_temp": [
+		"90"
+	],
+	"textured_plate_temp_initial_layer": [
+		"90"
+	],
+	"filament_start_gcode": [
+		"; Filament gcode\n;{if activate_air_filtration[current_extruder] && support_air_filtration}\n;M106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n;{endif}"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n;M106 P3 S0\n"
+	],
+	"nozzle_temperature_range_high": [
+		"280"
+	],
+	"nozzle_temperature_range_low": [
+		"240"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic ABS @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic ABS @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic ABS @System",
+	"inherits": "Tiertime Generic ABS @base",
+	"from": "system",
+	"setting_id": "",
+	"filament_id": "GFB99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic ABS @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic ABS @base.json
@@ -1,0 +1,169 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic ABS @base",
+	"inherits": "fdm_filament_abs",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"chamber_temperatures": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"0"
+	],
+	"cool_plate_temp_initial_layer": [
+		"0"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"90"
+	],
+	"eng_plate_temp_initial_layer": [
+		"90"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"fan_max_speed": [
+		"20"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.04"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"0.95"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"15"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"ABS"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"100"
+	],
+	"hot_plate_temp_initial_layer": [
+		"100"
+	],
+	"nozzle_temperature": [
+		"270"
+	],
+	"nozzle_temperature_initial_layer": [
+		"270"
+	],
+	"overhang_fan_speed": [
+		"80"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"0"
+	],
+	"required_nozzle_HRC": [
+		"3"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"3"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"temperature_vitrification": [
+		"100"
+	],
+	"textured_plate_temp": [
+		"100"
+	],
+	"textured_plate_temp_initial_layer": [
+		"100"
+	],
+	"filament_start_gcode": [
+		"; Filament gcode\n;{if activate_air_filtration[current_extruder] && support_air_filtration}\n;M106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n;{endif}"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n;M106 P3 S0\n"
+	],
+	"nozzle_temperature_range_high": [
+		"280"
+	],
+	"nozzle_temperature_range_low": [
+		"240"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic ABS@300HS @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic ABS@300HS @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic ABS@300HS @System",
+	"inherits": "Tiertime Generic ABS@300HS @base",
+	"from": "system",
+	"setting_id": "",
+	"filament_id": "GFB99_01",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic ABS@300HS @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic ABS@300HS @base.json
@@ -1,0 +1,169 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic ABS@300HS @base",
+	"inherits": "fdm_filament_abs",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"chamber_temperatures": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"0"
+	],
+	"cool_plate_temp_initial_layer": [
+		"0"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"90"
+	],
+	"eng_plate_temp_initial_layer": [
+		"90"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"fan_max_speed": [
+		"20"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.04"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"0.95"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"15"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"ABS"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"100"
+	],
+	"hot_plate_temp_initial_layer": [
+		"100"
+	],
+	"nozzle_temperature": [
+		"270"
+	],
+	"nozzle_temperature_initial_layer": [
+		"270"
+	],
+	"overhang_fan_speed": [
+		"80"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"0"
+	],
+	"required_nozzle_HRC": [
+		"3"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"3"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"temperature_vitrification": [
+		"100"
+	],
+	"textured_plate_temp": [
+		"100"
+	],
+	"textured_plate_temp_initial_layer": [
+		"100"
+	],
+	"filament_start_gcode": [
+		"; Filament gcode\n;{if activate_air_filtration[current_extruder] && support_air_filtration}\n;M106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n;{endif}"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n;M106 P3 S0\n"
+	],
+	"nozzle_temperature_range_high": [
+		"280"
+	],
+	"nozzle_temperature_range_low": [
+		"240"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic ASA @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic ASA @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic ASA @System",
+	"inherits": "Tiertime Generic ASA @base",
+	"from": "system",
+	"setting_id": "",
+	"filament_id": "GFB98",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic ASA @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic ASA @base.json
@@ -1,0 +1,169 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic ASA @base",
+	"inherits": "fdm_filament_asa",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"chamber_temperatures": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"0"
+	],
+	"cool_plate_temp_initial_layer": [
+		"0"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"90"
+	],
+	"eng_plate_temp_initial_layer": [
+		"90"
+	],
+	"fan_cooling_layer_time": [
+		"35"
+	],
+	"fan_max_speed": [
+		"80"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.04"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"0.95"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"12"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"ASA"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"100"
+	],
+	"hot_plate_temp_initial_layer": [
+		"100"
+	],
+	"nozzle_temperature": [
+		"260"
+	],
+	"nozzle_temperature_initial_layer": [
+		"260"
+	],
+	"overhang_fan_speed": [
+		"80"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"3"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"3"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"temperature_vitrification": [
+		"100"
+	],
+	"textured_plate_temp": [
+		"100"
+	],
+	"textured_plate_temp_initial_layer": [
+		"100"
+	],
+	"filament_start_gcode": [
+		"; Filament gcode\n;{if activate_air_filtration[current_extruder] && support_air_filtration}\n;M106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n;{endif}"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n;M106 P3 S0\n"
+	],
+	"nozzle_temperature_range_high": [
+		"280"
+	],
+	"nozzle_temperature_range_low": [
+		"240"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic ASA@300HS @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic ASA@300HS @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic ASA@300HS @System",
+	"inherits": "Tiertime Generic ASA@300HS @base",
+	"from": "system",
+	"setting_id": "",
+	"filament_id": "GFB98_01",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic ASA@300HS @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic ASA@300HS @base.json
@@ -1,0 +1,169 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic ASA@300HS @base",
+	"inherits": "fdm_filament_asa",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"chamber_temperatures": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"0"
+	],
+	"cool_plate_temp_initial_layer": [
+		"0"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"90"
+	],
+	"eng_plate_temp_initial_layer": [
+		"90"
+	],
+	"fan_cooling_layer_time": [
+		"35"
+	],
+	"fan_max_speed": [
+		"80"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.04"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"0.95"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"12"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"ASA"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"100"
+	],
+	"hot_plate_temp_initial_layer": [
+		"100"
+	],
+	"nozzle_temperature": [
+		"260"
+	],
+	"nozzle_temperature_initial_layer": [
+		"260"
+	],
+	"overhang_fan_speed": [
+		"80"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"3"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"3"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"temperature_vitrification": [
+		"100"
+	],
+	"textured_plate_temp": [
+		"100"
+	],
+	"textured_plate_temp_initial_layer": [
+		"100"
+	],
+	"filament_start_gcode": [
+		"; Filament gcode\n;{if activate_air_filtration[current_extruder] && support_air_filtration}\n;M106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n;{endif}"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n;M106 P3 S0\n"
+	],
+	"nozzle_temperature_range_high": [
+		"280"
+	],
+	"nozzle_temperature_range_low": [
+		"240"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic BVOH @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic BVOH @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic BVOH @System",
+	"inherits": "Tiertime Generic BVOH @base",
+	"from": "system",
+	"setting_id": "",
+	"filament_id": "GFS97",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic BVOH @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic BVOH @base.json
@@ -1,0 +1,172 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic BVOH @base",
+	"inherits": "fdm_filament_bvoh",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"chamber_temperatures": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"40"
+	],
+	"cool_plate_temp_initial_layer": [
+		"40"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"0"
+	],
+	"eng_plate_temp_initial_layer": [
+		"0"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"filament_cost": [
+		"69.99"
+	],
+	"filament_density": [
+		"1.13"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"1"
+	],
+	"filament_is_support": [
+		"1"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"8"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"BVOH"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"55"
+	],
+	"hot_plate_temp_initial_layer": [
+		"55"
+	],
+	"nozzle_temperature": [
+		"220"
+	],
+	"nozzle_temperature_initial_layer": [
+		"220"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"3"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"8"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"temperature_vitrification": [
+		"45"
+	],
+	"textured_plate_temp": [
+		"55"
+	],
+	"textured_plate_temp_initial_layer": [
+		"55"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n;M106 P3 S0\n"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"nozzle_temperature_range_high": [
+		"240"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic BVOH@300HS @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic BVOH@300HS @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic BVOH@300HS @System",
+	"inherits": "Tiertime Generic BVOH@300HS @base",
+	"from": "system",
+	"setting_id": "",
+	"filament_id": "GFS97_01",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic BVOH@300HS @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic BVOH@300HS @base.json
@@ -1,0 +1,172 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic BVOH@300HS @base",
+	"inherits": "fdm_filament_bvoh",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"chamber_temperatures": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"40"
+	],
+	"cool_plate_temp_initial_layer": [
+		"40"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"0"
+	],
+	"eng_plate_temp_initial_layer": [
+		"0"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"filament_cost": [
+		"69.99"
+	],
+	"filament_density": [
+		"1.13"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"1"
+	],
+	"filament_is_support": [
+		"1"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"8"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"BVOH"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"55"
+	],
+	"hot_plate_temp_initial_layer": [
+		"55"
+	],
+	"nozzle_temperature": [
+		"220"
+	],
+	"nozzle_temperature_initial_layer": [
+		"220"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"3"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"8"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"temperature_vitrification": [
+		"45"
+	],
+	"textured_plate_temp": [
+		"55"
+	],
+	"textured_plate_temp_initial_layer": [
+		"55"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n;M106 P3 S0\n"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"nozzle_temperature_range_high": [
+		"240"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic EVA @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic EVA @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic EVA @System",
+	"inherits": "Tiertime Generic EVA @base",
+	"from": "system",
+	"setting_id": "",
+	"filament_id": "GFR99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic EVA @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic EVA @base.json
@@ -1,0 +1,172 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic EVA @base",
+	"inherits": "fdm_filament_eva",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"chamber_temperatures": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"35"
+	],
+	"cool_plate_temp_initial_layer": [
+		"35"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"0"
+	],
+	"eng_plate_temp_initial_layer": [
+		"0"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"filament_cost": [
+		"21.99"
+	],
+	"filament_density": [
+		"0.94"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"1"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"12"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"EVA"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"55"
+	],
+	"hot_plate_temp_initial_layer": [
+		"55"
+	],
+	"nozzle_temperature": [
+		"210"
+	],
+	"nozzle_temperature_initial_layer": [
+		"210"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"3"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"4"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"temperature_vitrification": [
+		"70"
+	],
+	"textured_plate_temp": [
+		"55"
+	],
+	"textured_plate_temp_initial_layer": [
+		"55"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n;M106 P3 S0\n"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"nozzle_temperature_range_high": [
+		"220"
+	],
+	"nozzle_temperature_range_low": [
+		"175"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic EVA@300HS @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic EVA@300HS @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic EVA@300HS @System",
+	"inherits": "Tiertime Generic EVA@300HS @base",
+	"from": "system",
+	"setting_id": "",
+	"filament_id": "GFR99_01",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic EVA@300HS @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic EVA@300HS @base.json
@@ -1,0 +1,172 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic EVA@300HS @base",
+	"inherits": "fdm_filament_eva",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"chamber_temperatures": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"35"
+	],
+	"cool_plate_temp_initial_layer": [
+		"35"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"0"
+	],
+	"eng_plate_temp_initial_layer": [
+		"0"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"filament_cost": [
+		"21.99"
+	],
+	"filament_density": [
+		"0.94"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"1"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"12"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"EVA"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"55"
+	],
+	"hot_plate_temp_initial_layer": [
+		"55"
+	],
+	"nozzle_temperature": [
+		"210"
+	],
+	"nozzle_temperature_initial_layer": [
+		"210"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"3"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"4"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"temperature_vitrification": [
+		"70"
+	],
+	"textured_plate_temp": [
+		"55"
+	],
+	"textured_plate_temp_initial_layer": [
+		"55"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n;M106 P3 S0\n"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"nozzle_temperature_range_high": [
+		"220"
+	],
+	"nozzle_temperature_range_low": [
+		"175"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic HIPS @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic HIPS @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic HIPS @System",
+	"inherits": "Tiertime Generic HIPS @base",
+	"from": "system",
+	"setting_id": "",
+	"filament_id": "GFS98",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic HIPS @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic HIPS @base.json
@@ -1,0 +1,172 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic HIPS @base",
+	"inherits": "fdm_filament_hips",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"chamber_temperatures": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"0"
+	],
+	"cool_plate_temp_initial_layer": [
+		"0"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"90"
+	],
+	"eng_plate_temp_initial_layer": [
+		"90"
+	],
+	"fan_cooling_layer_time": [
+		"10"
+	],
+	"fan_max_speed": [
+		"60"
+	],
+	"fan_min_speed": [
+		"0"
+	],
+	"filament_cost": [
+		"22.99"
+	],
+	"filament_density": [
+		"1.06"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"1"
+	],
+	"filament_is_support": [
+		"1"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"8"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"HIPS"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"90"
+	],
+	"hot_plate_temp_initial_layer": [
+		"90"
+	],
+	"nozzle_temperature": [
+		"240"
+	],
+	"nozzle_temperature_initial_layer": [
+		"240"
+	],
+	"overhang_fan_speed": [
+		"80"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"0"
+	],
+	"required_nozzle_HRC": [
+		"3"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"6"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"temperature_vitrification": [
+		"100"
+	],
+	"textured_plate_temp": [
+		"90"
+	],
+	"textured_plate_temp_initial_layer": [
+		"90"
+	],
+	"filament_start_gcode": [
+		"; Filament gcode\n;{if activate_air_filtration[current_extruder] && support_air_filtration}\n;M106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n;{endif}"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n;M106 P3 S0\n"
+	],
+	"nozzle_temperature_range_low": [
+		"220"
+	],
+	"nozzle_temperature_range_high": [
+		"270"
+	],
+	"additional_cooling_fan_speed": [
+		"0"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic HIPS@300HS @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic HIPS@300HS @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic HIPS@300HS @System",
+	"inherits": "Tiertime Generic HIPS@300HS @base",
+	"from": "system",
+	"setting_id": "",
+	"filament_id": "GFS98_01",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic HIPS@300HS @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic HIPS@300HS @base.json
@@ -1,0 +1,172 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic HIPS@300HS @base",
+	"inherits": "fdm_filament_hips",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"chamber_temperatures": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"0"
+	],
+	"cool_plate_temp_initial_layer": [
+		"0"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"90"
+	],
+	"eng_plate_temp_initial_layer": [
+		"90"
+	],
+	"fan_cooling_layer_time": [
+		"10"
+	],
+	"fan_max_speed": [
+		"60"
+	],
+	"fan_min_speed": [
+		"0"
+	],
+	"filament_cost": [
+		"22.99"
+	],
+	"filament_density": [
+		"1.06"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"1"
+	],
+	"filament_is_support": [
+		"1"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"8"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"HIPS"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"90"
+	],
+	"hot_plate_temp_initial_layer": [
+		"90"
+	],
+	"nozzle_temperature": [
+		"240"
+	],
+	"nozzle_temperature_initial_layer": [
+		"240"
+	],
+	"overhang_fan_speed": [
+		"80"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"0"
+	],
+	"required_nozzle_HRC": [
+		"3"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"6"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"temperature_vitrification": [
+		"100"
+	],
+	"textured_plate_temp": [
+		"90"
+	],
+	"textured_plate_temp_initial_layer": [
+		"90"
+	],
+	"filament_start_gcode": [
+		"; Filament gcode\n;{if activate_air_filtration[current_extruder] && support_air_filtration}\n;M106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n;{endif}"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n;M106 P3 S0\n"
+	],
+	"nozzle_temperature_range_low": [
+		"220"
+	],
+	"nozzle_temperature_range_high": [
+		"270"
+	],
+	"additional_cooling_fan_speed": [
+		"0"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PA @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PA @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic PA @System",
+	"inherits": "Tiertime Generic PA @base",
+	"from": "system",
+	"setting_id": "GFSN98",
+	"filament_id": "GFN99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PA @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PA @base.json
@@ -1,0 +1,169 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic PA @base",
+	"inherits": "fdm_filament_pa",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"1"
+	],
+	"chamber_temperatures": [
+		"60"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"0"
+	],
+	"cool_plate_temp_initial_layer": [
+		"0"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"100"
+	],
+	"eng_plate_temp_initial_layer": [
+		"100"
+	],
+	"fan_cooling_layer_time": [
+		"65"
+	],
+	"fan_max_speed": [
+		"85"
+	],
+	"fan_min_speed": [
+		"40"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.04"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"1"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"12"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PA"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"100"
+	],
+	"hot_plate_temp_initial_layer": [
+		"100"
+	],
+	"nozzle_temperature": [
+		"260"
+	],
+	"nozzle_temperature_initial_layer": [
+		"260"
+	],
+	"overhang_fan_speed": [
+		"95"
+	],
+	"overhang_fan_threshold": [
+		"10%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"0"
+	],
+	"required_nozzle_HRC": [
+		"3"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"8"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"temperature_vitrification": [
+		"108"
+	],
+	"textured_plate_temp": [
+		"100"
+	],
+	"textured_plate_temp_initial_layer": [
+		"100"
+	],
+	"filament_start_gcode": [
+		"; Filament gcode\n;{if activate_air_filtration[current_extruder] && support_air_filtration}\n;M106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n;{endif}"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n;M106 P3 S0\n"
+	],
+	"nozzle_temperature_range_high": [
+		"280"
+	],
+	"nozzle_temperature_range_low": [
+		"240"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PA-CF @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PA-CF @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic PA-CF @System",
+	"inherits": "Tiertime Generic PA-CF @base",
+	"from": "system",
+	"setting_id": "GFSN99",
+	"filament_id": "GFN98",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PA-CF @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PA-CF @base.json
@@ -1,0 +1,169 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic PA-CF @base",
+	"inherits": "fdm_filament_pa",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"1"
+	],
+	"chamber_temperatures": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"0"
+	],
+	"cool_plate_temp_initial_layer": [
+		"0"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"100"
+	],
+	"eng_plate_temp_initial_layer": [
+		"100"
+	],
+	"fan_cooling_layer_time": [
+		"5"
+	],
+	"fan_max_speed": [
+		"30"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.04"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"1"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"8"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PA-CF"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"2"
+	],
+	"hot_plate_temp": [
+		"100"
+	],
+	"hot_plate_temp_initial_layer": [
+		"100"
+	],
+	"nozzle_temperature": [
+		"290"
+	],
+	"nozzle_temperature_initial_layer": [
+		"290"
+	],
+	"overhang_fan_speed": [
+		"40"
+	],
+	"overhang_fan_threshold": [
+		"0%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"0"
+	],
+	"required_nozzle_HRC": [
+		"40"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"2"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"temperature_vitrification": [
+		"170"
+	],
+	"textured_plate_temp": [
+		"100"
+	],
+	"textured_plate_temp_initial_layer": [
+		"100"
+	],
+	"filament_start_gcode": [
+		"; Filament gcode\n;{if activate_air_filtration[current_extruder] && support_air_filtration}\n;M106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n;{endif}"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n;M106 P3 S0\n"
+	],
+	"nozzle_temperature_range_high": [
+		"300"
+	],
+	"nozzle_temperature_range_low": [
+		"260"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PA-CF@300HS @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PA-CF@300HS @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic PA-CF@300HS @System",
+	"inherits": "Tiertime Generic PA-CF@300HS @base",
+	"from": "system",
+	"setting_id": "GFSN99",
+	"filament_id": "GFN98_02",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PA-CF@300HS @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PA-CF@300HS @base.json
@@ -1,0 +1,169 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic PA-CF@300HS @base",
+	"inherits": "fdm_filament_pa",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"1"
+	],
+	"chamber_temperatures": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"0"
+	],
+	"cool_plate_temp_initial_layer": [
+		"0"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"100"
+	],
+	"eng_plate_temp_initial_layer": [
+		"100"
+	],
+	"fan_cooling_layer_time": [
+		"5"
+	],
+	"fan_max_speed": [
+		"30"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.04"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"1"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"8"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PA-CF"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"2"
+	],
+	"hot_plate_temp": [
+		"100"
+	],
+	"hot_plate_temp_initial_layer": [
+		"100"
+	],
+	"nozzle_temperature": [
+		"290"
+	],
+	"nozzle_temperature_initial_layer": [
+		"290"
+	],
+	"overhang_fan_speed": [
+		"40"
+	],
+	"overhang_fan_threshold": [
+		"0%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"0"
+	],
+	"required_nozzle_HRC": [
+		"40"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"2"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"temperature_vitrification": [
+		"170"
+	],
+	"textured_plate_temp": [
+		"100"
+	],
+	"textured_plate_temp_initial_layer": [
+		"100"
+	],
+	"filament_start_gcode": [
+		"; Filament gcode\n;{if activate_air_filtration[current_extruder] && support_air_filtration}\n;M106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n;{endif}"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n;M106 P3 S0\n"
+	],
+	"nozzle_temperature_range_high": [
+		"300"
+	],
+	"nozzle_temperature_range_low": [
+		"260"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PA@300HS @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PA@300HS @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic PA@300HS @System",
+	"inherits": "Tiertime Generic PA@300HS @base",
+	"from": "system",
+	"setting_id": "GFSN98",
+	"filament_id": "GFN99_01",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PA@300HS @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PA@300HS @base.json
@@ -1,0 +1,169 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic PA@300HS @base",
+	"inherits": "fdm_filament_pa",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"1"
+	],
+	"chamber_temperatures": [
+		"60"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"0"
+	],
+	"cool_plate_temp_initial_layer": [
+		"0"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"100"
+	],
+	"eng_plate_temp_initial_layer": [
+		"100"
+	],
+	"fan_cooling_layer_time": [
+		"65"
+	],
+	"fan_max_speed": [
+		"85"
+	],
+	"fan_min_speed": [
+		"40"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.04"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"1"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"12"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PA"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"100"
+	],
+	"hot_plate_temp_initial_layer": [
+		"100"
+	],
+	"nozzle_temperature": [
+		"260"
+	],
+	"nozzle_temperature_initial_layer": [
+		"260"
+	],
+	"overhang_fan_speed": [
+		"95"
+	],
+	"overhang_fan_threshold": [
+		"10%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"0"
+	],
+	"required_nozzle_HRC": [
+		"3"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"8"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"temperature_vitrification": [
+		"108"
+	],
+	"textured_plate_temp": [
+		"100"
+	],
+	"textured_plate_temp_initial_layer": [
+		"100"
+	],
+	"filament_start_gcode": [
+		"; Filament gcode\n;{if activate_air_filtration[current_extruder] && support_air_filtration}\n;M106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n;{endif}"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n;M106 P3 S0\n"
+	],
+	"nozzle_temperature_range_high": [
+		"280"
+	],
+	"nozzle_temperature_range_low": [
+		"240"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PC @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PC @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic PC @System",
+	"inherits": "Tiertime Generic PC @base",
+	"from": "system",
+	"setting_id": "",
+	"filament_id": "GFC99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PC @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PC @base.json
@@ -1,0 +1,169 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic PC @base",
+	"inherits": "fdm_filament_pc",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"chamber_temperatures": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"0"
+	],
+	"cool_plate_temp_initial_layer": [
+		"0"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"110"
+	],
+	"eng_plate_temp_initial_layer": [
+		"110"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"fan_max_speed": [
+		"60"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.04"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"0.94"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"16"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PC"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"110"
+	],
+	"hot_plate_temp_initial_layer": [
+		"110"
+	],
+	"nozzle_temperature": [
+		"280"
+	],
+	"nozzle_temperature_initial_layer": [
+		"270"
+	],
+	"overhang_fan_speed": [
+		"60"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"3"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"2"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"temperature_vitrification": [
+		"120"
+	],
+	"textured_plate_temp": [
+		"110"
+	],
+	"textured_plate_temp_initial_layer": [
+		"110"
+	],
+	"filament_start_gcode": [
+		"; Filament gcode\n;{if activate_air_filtration[current_extruder] && support_air_filtration}\n;M106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n;{endif}"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n;M106 P3 S0\n"
+	],
+	"nozzle_temperature_range_high": [
+		"290"
+	],
+	"nozzle_temperature_range_low": [
+		"260"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PC@300HS @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PC@300HS @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic PC@300HS @System",
+	"inherits": "Tiertime Generic PC@300HS @base",
+	"from": "system",
+	"setting_id": "",
+	"filament_id": "GFC99_01",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PC@300HS @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PC@300HS @base.json
@@ -1,0 +1,169 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic PC@300HS @base",
+	"inherits": "fdm_filament_pc",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"chamber_temperatures": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"0"
+	],
+	"cool_plate_temp_initial_layer": [
+		"0"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"110"
+	],
+	"eng_plate_temp_initial_layer": [
+		"110"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"fan_max_speed": [
+		"60"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.04"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"0.94"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"16"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PC"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"110"
+	],
+	"hot_plate_temp_initial_layer": [
+		"110"
+	],
+	"nozzle_temperature": [
+		"280"
+	],
+	"nozzle_temperature_initial_layer": [
+		"270"
+	],
+	"overhang_fan_speed": [
+		"60"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"3"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"2"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"temperature_vitrification": [
+		"120"
+	],
+	"textured_plate_temp": [
+		"110"
+	],
+	"textured_plate_temp_initial_layer": [
+		"110"
+	],
+	"filament_start_gcode": [
+		"; Filament gcode\n;{if activate_air_filtration[current_extruder] && support_air_filtration}\n;M106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n;{endif}"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n;M106 P3 S0\n"
+	],
+	"nozzle_temperature_range_high": [
+		"290"
+	],
+	"nozzle_temperature_range_low": [
+		"260"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PCTG @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PCTG @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic PCTG @System",
+	"inherits": "Tiertime Generic PCTG @base",
+	"from": "system",
+	"setting_id": "",
+	"filament_id": "GFG97",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PCTG @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PCTG @base.json
@@ -1,0 +1,169 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic PCTG @base",
+	"inherits": "fdm_filament_pctg",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"chamber_temperatures": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"0"
+	],
+	"cool_plate_temp_initial_layer": [
+		"0"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"70"
+	],
+	"eng_plate_temp_initial_layer": [
+		"70"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"fan_max_speed": [
+		"40"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"filament_cost": [
+		"28.99"
+	],
+	"filament_density": [
+		"1.29"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"0.95"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"6"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PCTG"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"70"
+	],
+	"hot_plate_temp_initial_layer": [
+		"70"
+	],
+	"nozzle_temperature": [
+		"255"
+	],
+	"nozzle_temperature_initial_layer": [
+		"255"
+	],
+	"overhang_fan_speed": [
+		"90"
+	],
+	"overhang_fan_threshold": [
+		"10%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"3"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"12"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"temperature_vitrification": [
+		"90"
+	],
+	"textured_plate_temp": [
+		"70"
+	],
+	"textured_plate_temp_initial_layer": [
+		"70"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if (bed_temperature[current_extruder] >80)||(bed_temperature_initial_layer[current_extruder] >80)}M106 P3 S255\n{elsif (bed_temperature[current_extruder] >60)||(bed_temperature_initial_layer[current_extruder] >60)}M106 P3 S180\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n;M106 P3 S0\n"
+	],
+	"nozzle_temperature_range_high": [
+		"270"
+	],
+	"nozzle_temperature_range_low": [
+		"240"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PCTG@300HS @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PCTG@300HS @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic PCTG@300HS @System",
+	"inherits": "Tiertime Generic PCTG@300HS @base",
+	"from": "system",
+	"setting_id": "",
+	"filament_id": "GFG97-01",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PCTG@300HS @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PCTG@300HS @base.json
@@ -1,0 +1,169 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic PCTG@300HS @base",
+	"inherits": "fdm_filament_pctg",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"chamber_temperatures": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"0"
+	],
+	"cool_plate_temp_initial_layer": [
+		"0"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"70"
+	],
+	"eng_plate_temp_initial_layer": [
+		"70"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"fan_max_speed": [
+		"40"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"filament_cost": [
+		"28.99"
+	],
+	"filament_density": [
+		"1.29"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"0.95"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"6"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PCTG"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"70"
+	],
+	"hot_plate_temp_initial_layer": [
+		"70"
+	],
+	"nozzle_temperature": [
+		"255"
+	],
+	"nozzle_temperature_initial_layer": [
+		"255"
+	],
+	"overhang_fan_speed": [
+		"90"
+	],
+	"overhang_fan_threshold": [
+		"10%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"3"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"12"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"temperature_vitrification": [
+		"90"
+	],
+	"textured_plate_temp": [
+		"70"
+	],
+	"textured_plate_temp_initial_layer": [
+		"70"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if (bed_temperature[current_extruder] >80)||(bed_temperature_initial_layer[current_extruder] >80)}M106 P3 S255\n{elsif (bed_temperature[current_extruder] >60)||(bed_temperature_initial_layer[current_extruder] >60)}M106 P3 S180\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n;M106 P3 S0\n"
+	],
+	"nozzle_temperature_range_high": [
+		"270"
+	],
+	"nozzle_temperature_range_low": [
+		"240"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PE @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PE @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic PE @System",
+	"inherits": "Tiertime Generic PE @base",
+	"from": "system",
+	"setting_id": "",
+	"filament_id": "GFP99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PE @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PE @base.json
@@ -1,0 +1,172 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic PE @base",
+	"inherits": "fdm_filament_pe",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"chamber_temperatures": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"35"
+	],
+	"cool_plate_temp_initial_layer": [
+		"35"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"0"
+	],
+	"eng_plate_temp_initial_layer": [
+		"0"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"filament_cost": [
+		"40.99"
+	],
+	"filament_density": [
+		"0.95"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"1"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"8"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PE"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"55"
+	],
+	"hot_plate_temp_initial_layer": [
+		"55"
+	],
+	"nozzle_temperature": [
+		"210"
+	],
+	"nozzle_temperature_initial_layer": [
+		"210"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"3"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"4"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"temperature_vitrification": [
+		"70"
+	],
+	"textured_plate_temp": [
+		"55"
+	],
+	"textured_plate_temp_initial_layer": [
+		"55"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n;M106 P3 S0\n"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"nozzle_temperature_range_high": [
+		"220"
+	],
+	"nozzle_temperature_range_low": [
+		"175"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PE-CF @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PE-CF @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic PE-CF @System",
+	"inherits": "Tiertime Generic PE-CF @base",
+	"from": "system",
+	"setting_id": "",
+	"filament_id": "GFP98",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PE-CF @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PE-CF @base.json
@@ -1,0 +1,172 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic PE-CF @base",
+	"inherits": "fdm_filament_pe",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"chamber_temperatures": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"35"
+	],
+	"cool_plate_temp_initial_layer": [
+		"35"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"0"
+	],
+	"eng_plate_temp_initial_layer": [
+		"0"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"filament_cost": [
+		"65.99"
+	],
+	"filament_density": [
+		"0.95"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"1"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"6"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PE-CF"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"55"
+	],
+	"hot_plate_temp_initial_layer": [
+		"55"
+	],
+	"nozzle_temperature": [
+		"210"
+	],
+	"nozzle_temperature_initial_layer": [
+		"210"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"3"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"4"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"temperature_vitrification": [
+		"70"
+	],
+	"textured_plate_temp": [
+		"55"
+	],
+	"textured_plate_temp_initial_layer": [
+		"55"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n;M106 P3 S0\n"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"nozzle_temperature_range_high": [
+		"220"
+	],
+	"nozzle_temperature_range_low": [
+		"175"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PE-CF@300HS @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PE-CF@300HS @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic PE-CF@300HS @System",
+	"inherits": "Tiertime Generic PE-CF@300HS @base",
+	"from": "system",
+	"setting_id": "",
+	"filament_id": "GFP98_01",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PE-CF@300HS @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PE-CF@300HS @base.json
@@ -1,0 +1,172 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic PE-CF@300HS @base",
+	"inherits": "fdm_filament_pe",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"chamber_temperatures": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"35"
+	],
+	"cool_plate_temp_initial_layer": [
+		"35"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"0"
+	],
+	"eng_plate_temp_initial_layer": [
+		"0"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"filament_cost": [
+		"65.99"
+	],
+	"filament_density": [
+		"0.95"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"1"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"6"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PE-CF"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"55"
+	],
+	"hot_plate_temp_initial_layer": [
+		"55"
+	],
+	"nozzle_temperature": [
+		"210"
+	],
+	"nozzle_temperature_initial_layer": [
+		"210"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"3"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"4"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"temperature_vitrification": [
+		"70"
+	],
+	"textured_plate_temp": [
+		"55"
+	],
+	"textured_plate_temp_initial_layer": [
+		"55"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n;M106 P3 S0\n"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"nozzle_temperature_range_high": [
+		"220"
+	],
+	"nozzle_temperature_range_low": [
+		"175"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PE@300HS @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PE@300HS @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic PE@300HS @System",
+	"inherits": "Tiertime Generic PE@300HS @base",
+	"from": "system",
+	"setting_id": "",
+	"filament_id": "GFP99_01",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PE@300HS @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PE@300HS @base.json
@@ -1,0 +1,172 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic PE@300HS @base",
+	"inherits": "fdm_filament_pe",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"chamber_temperatures": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"35"
+	],
+	"cool_plate_temp_initial_layer": [
+		"35"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"0"
+	],
+	"eng_plate_temp_initial_layer": [
+		"0"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"filament_cost": [
+		"40.99"
+	],
+	"filament_density": [
+		"0.95"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"1"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"8"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PE"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"55"
+	],
+	"hot_plate_temp_initial_layer": [
+		"55"
+	],
+	"nozzle_temperature": [
+		"210"
+	],
+	"nozzle_temperature_initial_layer": [
+		"210"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"3"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"4"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"temperature_vitrification": [
+		"70"
+	],
+	"textured_plate_temp": [
+		"55"
+	],
+	"textured_plate_temp_initial_layer": [
+		"55"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n;M106 P3 S0\n"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"nozzle_temperature_range_high": [
+		"220"
+	],
+	"nozzle_temperature_range_low": [
+		"175"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PETG @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PETG @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic PETG @System",
+	"inherits": "Tiertime Generic PETG @base",
+	"from": "system",
+	"setting_id": "",
+	"filament_id": "GFG99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PETG @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PETG @base.json
@@ -1,0 +1,169 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic PETG @base",
+	"inherits": "fdm_filament_pet",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"chamber_temperatures": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"0"
+	],
+	"cool_plate_temp_initial_layer": [
+		"0"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"70"
+	],
+	"eng_plate_temp_initial_layer": [
+		"70"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"fan_max_speed": [
+		"90"
+	],
+	"fan_min_speed": [
+		"40"
+	],
+	"filament_cost": [
+		"30"
+	],
+	"filament_density": [
+		"1.27"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"0.95"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"12"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PETG"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"70"
+	],
+	"hot_plate_temp_initial_layer": [
+		"70"
+	],
+	"nozzle_temperature": [
+		"255"
+	],
+	"nozzle_temperature_initial_layer": [
+		"255"
+	],
+	"overhang_fan_speed": [
+		"90"
+	],
+	"overhang_fan_threshold": [
+		"10%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"3"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"12"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"temperature_vitrification": [
+		"70"
+	],
+	"textured_plate_temp": [
+		"70"
+	],
+	"textured_plate_temp_initial_layer": [
+		"70"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if (bed_temperature[current_extruder] >80)||(bed_temperature_initial_layer[current_extruder] >80)}M106 P3 S255\n{elsif (bed_temperature[current_extruder] >60)||(bed_temperature_initial_layer[current_extruder] >60)}M106 P3 S180\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n;M106 P3 S0\n"
+	],
+	"nozzle_temperature_range_high": [
+		"270"
+	],
+	"nozzle_temperature_range_low": [
+		"220"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PETG-CF @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PETG-CF @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic PETG-CF @System",
+	"inherits": "Tiertime Generic PETG-CF @base",
+	"from": "system",
+	"setting_id": "",
+	"filament_id": "GFG98",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PETG-CF @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PETG-CF @base.json
@@ -1,0 +1,169 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic PETG-CF @base",
+	"inherits": "fdm_filament_pet",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"chamber_temperatures": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"0"
+	],
+	"cool_plate_temp_initial_layer": [
+		"0"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"70"
+	],
+	"eng_plate_temp_initial_layer": [
+		"70"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"fan_max_speed": [
+		"40"
+	],
+	"fan_min_speed": [
+		"5"
+	],
+	"filament_cost": [
+		"34.99"
+	],
+	"filament_density": [
+		"1.25"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"0.95"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"11.5"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PETG-CF"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"70"
+	],
+	"hot_plate_temp_initial_layer": [
+		"70"
+	],
+	"nozzle_temperature": [
+		"255"
+	],
+	"nozzle_temperature_initial_layer": [
+		"255"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"10%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"40"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"6"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"temperature_vitrification": [
+		"70"
+	],
+	"textured_plate_temp": [
+		"70"
+	],
+	"textured_plate_temp_initial_layer": [
+		"70"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if (bed_temperature[current_extruder] >80)||(bed_temperature_initial_layer[current_extruder] >80)}M106 P3 S255\n{elsif (bed_temperature[current_extruder] >60)||(bed_temperature_initial_layer[current_extruder] >60)}M106 P3 S180\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n;M106 P3 S0\n"
+	],
+	"nozzle_temperature_range_high": [
+		"270"
+	],
+	"nozzle_temperature_range_low": [
+		"240"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PETG-CF@300HS @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PETG-CF@300HS @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic PETG-CF@300HS @System",
+	"inherits": "Tiertime Generic PETG-CF@300HS @base",
+	"from": "system",
+	"setting_id": "",
+	"filament_id": "GFG98_01",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PETG-CF@300HS @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PETG-CF@300HS @base.json
@@ -1,0 +1,169 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic PETG-CF@300HS @base",
+	"inherits": "fdm_filament_pet",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"chamber_temperatures": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"0"
+	],
+	"cool_plate_temp_initial_layer": [
+		"0"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"70"
+	],
+	"eng_plate_temp_initial_layer": [
+		"70"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"fan_max_speed": [
+		"40"
+	],
+	"fan_min_speed": [
+		"5"
+	],
+	"filament_cost": [
+		"34.99"
+	],
+	"filament_density": [
+		"1.25"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"0.95"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"11.5"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PETG-CF"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"70"
+	],
+	"hot_plate_temp_initial_layer": [
+		"70"
+	],
+	"nozzle_temperature": [
+		"255"
+	],
+	"nozzle_temperature_initial_layer": [
+		"255"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"10%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"40"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"6"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"temperature_vitrification": [
+		"70"
+	],
+	"textured_plate_temp": [
+		"70"
+	],
+	"textured_plate_temp_initial_layer": [
+		"70"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if (bed_temperature[current_extruder] >80)||(bed_temperature_initial_layer[current_extruder] >80)}M106 P3 S255\n{elsif (bed_temperature[current_extruder] >60)||(bed_temperature_initial_layer[current_extruder] >60)}M106 P3 S180\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n;M106 P3 S0\n"
+	],
+	"nozzle_temperature_range_high": [
+		"270"
+	],
+	"nozzle_temperature_range_low": [
+		"240"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PETG@300HS @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PETG@300HS @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic PETG@300HS @System",
+	"inherits": "Tiertime Generic PETG@300HS @base",
+	"from": "system",
+	"setting_id": "",
+	"filament_id": "GFG99_01",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PETG@300HS @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PETG@300HS @base.json
@@ -1,0 +1,169 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic PETG@300HS @base",
+	"inherits": "fdm_filament_pet",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"chamber_temperatures": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"0"
+	],
+	"cool_plate_temp_initial_layer": [
+		"0"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"70"
+	],
+	"eng_plate_temp_initial_layer": [
+		"70"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"fan_max_speed": [
+		"90"
+	],
+	"fan_min_speed": [
+		"40"
+	],
+	"filament_cost": [
+		"30"
+	],
+	"filament_density": [
+		"1.27"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"0.95"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"12"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PETG"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"70"
+	],
+	"hot_plate_temp_initial_layer": [
+		"70"
+	],
+	"nozzle_temperature": [
+		"255"
+	],
+	"nozzle_temperature_initial_layer": [
+		"255"
+	],
+	"overhang_fan_speed": [
+		"90"
+	],
+	"overhang_fan_threshold": [
+		"10%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"3"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"12"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"temperature_vitrification": [
+		"70"
+	],
+	"textured_plate_temp": [
+		"70"
+	],
+	"textured_plate_temp_initial_layer": [
+		"70"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if (bed_temperature[current_extruder] >80)||(bed_temperature_initial_layer[current_extruder] >80)}M106 P3 S255\n{elsif (bed_temperature[current_extruder] >60)||(bed_temperature_initial_layer[current_extruder] >60)}M106 P3 S180\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n;M106 P3 S0\n"
+	],
+	"nozzle_temperature_range_high": [
+		"270"
+	],
+	"nozzle_temperature_range_low": [
+		"220"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PHA @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PHA @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic PHA @System",
+	"inherits": "Tiertime Generic PHA @base",
+	"from": "system",
+	"setting_id": "",
+	"filament_id": "GFR98",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PHA @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PHA @base.json
@@ -1,0 +1,172 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic PHA @base",
+	"inherits": "fdm_filament_pha",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"chamber_temperatures": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"35"
+	],
+	"cool_plate_temp_initial_layer": [
+		"35"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"0"
+	],
+	"eng_plate_temp_initial_layer": [
+		"0"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"filament_cost": [
+		"27.99"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"1"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"6"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PHA"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"55"
+	],
+	"hot_plate_temp_initial_layer": [
+		"55"
+	],
+	"nozzle_temperature": [
+		"220"
+	],
+	"nozzle_temperature_initial_layer": [
+		"220"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"3"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"4"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"temperature_vitrification": [
+		"120"
+	],
+	"textured_plate_temp": [
+		"55"
+	],
+	"textured_plate_temp_initial_layer": [
+		"55"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if  (bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S255\n{elsif(bed_temperature[current_extruder] >35)||(bed_temperature_initial_layer[current_extruder] >35)}M106 P3 S180\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n;M106 P3 S0\n"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"nozzle_temperature_range_high": [
+		"240"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PHA@300HS @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PHA@300HS @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic PHA@300HS @System",
+	"inherits": "Tiertime Generic PHA@300HS @base",
+	"from": "system",
+	"setting_id": "",
+	"filament_id": "GFR98_01",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PHA@300HS @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PHA@300HS @base.json
@@ -1,0 +1,172 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic PHA@300HS @base",
+	"inherits": "fdm_filament_pha",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"chamber_temperatures": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"35"
+	],
+	"cool_plate_temp_initial_layer": [
+		"35"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"0"
+	],
+	"eng_plate_temp_initial_layer": [
+		"0"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"filament_cost": [
+		"27.99"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"1"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"6"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PHA"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"55"
+	],
+	"hot_plate_temp_initial_layer": [
+		"55"
+	],
+	"nozzle_temperature": [
+		"220"
+	],
+	"nozzle_temperature_initial_layer": [
+		"220"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"3"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"4"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"temperature_vitrification": [
+		"120"
+	],
+	"textured_plate_temp": [
+		"55"
+	],
+	"textured_plate_temp_initial_layer": [
+		"55"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if  (bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S255\n{elsif(bed_temperature[current_extruder] >35)||(bed_temperature_initial_layer[current_extruder] >35)}M106 P3 S180\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n;M106 P3 S0\n"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"nozzle_temperature_range_high": [
+		"240"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PLA @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PLA @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic PLA @System",
+	"inherits": "Tiertime Generic PLA @base",
+	"from": "system",
+	"setting_id": "",
+	"filament_id": "GFL99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PLA @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PLA @base.json
@@ -1,0 +1,172 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic PLA @base",
+	"inherits": "fdm_filament_pla",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"chamber_temperatures": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"35"
+	],
+	"cool_plate_temp_initial_layer": [
+		"35"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"0"
+	],
+	"eng_plate_temp_initial_layer": [
+		"0"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"12"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PLA"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"60"
+	],
+	"hot_plate_temp_initial_layer": [
+		"60"
+	],
+	"nozzle_temperature": [
+		"220"
+	],
+	"nozzle_temperature_initial_layer": [
+		"220"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"3"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"8"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"temperature_vitrification": [
+		"45"
+	],
+	"textured_plate_temp": [
+		"60"
+	],
+	"textured_plate_temp_initial_layer": [
+		"60"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if  (bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S255\n{elsif(bed_temperature[current_extruder] >35)||(bed_temperature_initial_layer[current_extruder] >35)}M106 P3 S180\n{endif};Prevent PLA from jamming\n\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n;M106 P3 S0\n"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"240"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PLA High Speed @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PLA High Speed @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic PLA High Speed @System",
+	"inherits": "Tiertime Generic PLA High Speed @base",
+	"from": "system",
+	"setting_id": "",
+	"filament_id": "GFL95",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PLA High Speed @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PLA High Speed @base.json
@@ -1,0 +1,172 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic PLA High Speed @base",
+	"inherits": "fdm_filament_pla",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"chamber_temperatures": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"35"
+	],
+	"cool_plate_temp_initial_layer": [
+		"35"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"0"
+	],
+	"eng_plate_temp_initial_layer": [
+		"0"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"18"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PLA"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"60"
+	],
+	"hot_plate_temp_initial_layer": [
+		"60"
+	],
+	"nozzle_temperature": [
+		"220"
+	],
+	"nozzle_temperature_initial_layer": [
+		"220"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"3"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"4"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"temperature_vitrification": [
+		"45"
+	],
+	"textured_plate_temp": [
+		"60"
+	],
+	"textured_plate_temp_initial_layer": [
+		"60"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n;{if  (bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S255\n;{elsif(bed_temperature[current_extruder] >35)||(bed_temperature_initial_layer[current_extruder] >35)}M106 P3 S180\n;{endif}\n\n;{if activate_air_filtration[current_extruder] && support_air_filtration}\n;M106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n;{endif}"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n;M106 P3 S0\n"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"240"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PLA High Speed@300HS @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PLA High Speed@300HS @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic PLA High Speed@300HS @System",
+	"inherits": "Tiertime Generic PLA High Speed@300HS @base",
+	"from": "system",
+	"setting_id": "",
+	"filament_id": "GFL95_01",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PLA High Speed@300HS @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PLA High Speed@300HS @base.json
@@ -1,0 +1,172 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic PLA High Speed@300HS @base",
+	"inherits": "fdm_filament_pla",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"chamber_temperatures": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"35"
+	],
+	"cool_plate_temp_initial_layer": [
+		"35"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"0"
+	],
+	"eng_plate_temp_initial_layer": [
+		"0"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"18"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PLA"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"60"
+	],
+	"hot_plate_temp_initial_layer": [
+		"60"
+	],
+	"nozzle_temperature": [
+		"220"
+	],
+	"nozzle_temperature_initial_layer": [
+		"220"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"3"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"4"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"temperature_vitrification": [
+		"45"
+	],
+	"textured_plate_temp": [
+		"60"
+	],
+	"textured_plate_temp_initial_layer": [
+		"60"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n;{if  (bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S255\n;{elsif(bed_temperature[current_extruder] >35)||(bed_temperature_initial_layer[current_extruder] >35)}M106 P3 S180\n;{endif}\n\n;{if activate_air_filtration[current_extruder] && support_air_filtration}\n;M106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n;{endif}"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n;M106 P3 S0\n"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"240"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PLA Silk @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PLA Silk @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic PLA Silk @System",
+	"inherits": "Tiertime Generic PLA Silk @base",
+	"from": "system",
+	"setting_id": "",
+	"filament_id": "GFL96",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PLA Silk @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PLA Silk @base.json
@@ -1,0 +1,172 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic PLA Silk @base",
+	"inherits": "fdm_filament_pla",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"chamber_temperatures": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"35"
+	],
+	"cool_plate_temp_initial_layer": [
+		"35"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"0"
+	],
+	"eng_plate_temp_initial_layer": [
+		"0"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"7.5"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"0.5"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PLA"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"60"
+	],
+	"hot_plate_temp_initial_layer": [
+		"60"
+	],
+	"nozzle_temperature": [
+		"220"
+	],
+	"nozzle_temperature_initial_layer": [
+		"220"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"3"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"8"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"temperature_vitrification": [
+		"45"
+	],
+	"textured_plate_temp": [
+		"60"
+	],
+	"textured_plate_temp_initial_layer": [
+		"60"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if  (bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S255\n{elsif(bed_temperature[current_extruder] >35)||(bed_temperature_initial_layer[current_extruder] >35)}M106 P3 S180\n{endif};Prevent PLA from jamming\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n;M106 P3 S0\n"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"240"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PLA Silk@300HS @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PLA Silk@300HS @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic PLA Silk@300HS @System",
+	"inherits": "Tiertime Generic PLA Silk@300HS @base",
+	"from": "system",
+	"setting_id": "",
+	"filament_id": "GFL96_01",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PLA Silk@300HS @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PLA Silk@300HS @base.json
@@ -1,0 +1,172 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic PLA Silk@300HS @base",
+	"inherits": "fdm_filament_pla",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"chamber_temperatures": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"35"
+	],
+	"cool_plate_temp_initial_layer": [
+		"35"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"0"
+	],
+	"eng_plate_temp_initial_layer": [
+		"0"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"7.5"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"0.5"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PLA"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"60"
+	],
+	"hot_plate_temp_initial_layer": [
+		"60"
+	],
+	"nozzle_temperature": [
+		"220"
+	],
+	"nozzle_temperature_initial_layer": [
+		"220"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"3"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"8"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"temperature_vitrification": [
+		"45"
+	],
+	"textured_plate_temp": [
+		"60"
+	],
+	"textured_plate_temp_initial_layer": [
+		"60"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if  (bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S255\n{elsif(bed_temperature[current_extruder] >35)||(bed_temperature_initial_layer[current_extruder] >35)}M106 P3 S180\n{endif};Prevent PLA from jamming\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n;M106 P3 S0\n"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"240"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PLA-CF @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PLA-CF @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic PLA-CF @System",
+	"inherits": "Tiertime Generic PLA-CF @base",
+	"from": "system",
+	"setting_id": "",
+	"filament_id": "GFL98",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PLA-CF @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PLA-CF @base.json
@@ -1,0 +1,172 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic PLA-CF @base",
+	"inherits": "fdm_filament_pla",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"chamber_temperatures": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"45"
+	],
+	"cool_plate_temp_initial_layer": [
+		"45"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"0"
+	],
+	"eng_plate_temp_initial_layer": [
+		"0"
+	],
+	"fan_cooling_layer_time": [
+		"80"
+	],
+	"fan_max_speed": [
+		"80"
+	],
+	"fan_min_speed": [
+		"60"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"0.95"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"12"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PLA-CF"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"65"
+	],
+	"hot_plate_temp_initial_layer": [
+		"65"
+	],
+	"nozzle_temperature": [
+		"220"
+	],
+	"nozzle_temperature_initial_layer": [
+		"220"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"40"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"7"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"temperature_vitrification": [
+		"45"
+	],
+	"textured_plate_temp": [
+		"65"
+	],
+	"textured_plate_temp_initial_layer": [
+		"65"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n;M106 P3 S0\n"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"240"
+	],
+	"additional_cooling_fan_speed": [
+		"0"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PLA-CF@300HS @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PLA-CF@300HS @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic PLA-CF@300HS @System",
+	"inherits": "Tiertime Generic PLA-CF@300HS @base",
+	"from": "system",
+	"setting_id": "",
+	"filament_id": "GFL98_01",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PLA-CF@300HS @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PLA-CF@300HS @base.json
@@ -1,0 +1,172 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic PLA-CF@300HS @base",
+	"inherits": "fdm_filament_pla",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"chamber_temperatures": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"45"
+	],
+	"cool_plate_temp_initial_layer": [
+		"45"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"0"
+	],
+	"eng_plate_temp_initial_layer": [
+		"0"
+	],
+	"fan_cooling_layer_time": [
+		"80"
+	],
+	"fan_max_speed": [
+		"80"
+	],
+	"fan_min_speed": [
+		"60"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"0.95"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"12"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PLA-CF"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"65"
+	],
+	"hot_plate_temp_initial_layer": [
+		"65"
+	],
+	"nozzle_temperature": [
+		"220"
+	],
+	"nozzle_temperature_initial_layer": [
+		"220"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"40"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"7"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"temperature_vitrification": [
+		"45"
+	],
+	"textured_plate_temp": [
+		"65"
+	],
+	"textured_plate_temp_initial_layer": [
+		"65"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n;M106 P3 S0\n"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"240"
+	],
+	"additional_cooling_fan_speed": [
+		"0"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PLA@300HS @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PLA@300HS @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic PLA@300HS @System",
+	"inherits": "Tiertime Generic PLA@300HS @base",
+	"from": "system",
+	"setting_id": "",
+	"filament_id": "GFL99_01",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PLA@300HS @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PLA@300HS @base.json
@@ -1,0 +1,172 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic PLA@300HS @base",
+	"inherits": "fdm_filament_pla",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"chamber_temperatures": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"35"
+	],
+	"cool_plate_temp_initial_layer": [
+		"35"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"0"
+	],
+	"eng_plate_temp_initial_layer": [
+		"0"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"12"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PLA"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"60"
+	],
+	"hot_plate_temp_initial_layer": [
+		"60"
+	],
+	"nozzle_temperature": [
+		"220"
+	],
+	"nozzle_temperature_initial_layer": [
+		"220"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"3"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"8"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"temperature_vitrification": [
+		"45"
+	],
+	"textured_plate_temp": [
+		"60"
+	],
+	"textured_plate_temp_initial_layer": [
+		"60"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if  (bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S255\n{elsif(bed_temperature[current_extruder] >35)||(bed_temperature_initial_layer[current_extruder] >35)}M106 P3 S180\n{endif};Prevent PLA from jamming\n\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n;M106 P3 S0\n"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"240"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PP @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PP @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic PP @System",
+	"inherits": "Tiertime Generic PP @base",
+	"from": "system",
+	"setting_id": "",
+	"filament_id": "GFP97",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PP @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PP @base.json
@@ -1,0 +1,172 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic PP @base",
+	"inherits": "fdm_filament_pp",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"chamber_temperatures": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"35"
+	],
+	"cool_plate_temp_initial_layer": [
+		"35"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"0"
+	],
+	"eng_plate_temp_initial_layer": [
+		"0"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"filament_cost": [
+		"34.99"
+	],
+	"filament_density": [
+		"0.93"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"1"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"12"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PP"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"55"
+	],
+	"hot_plate_temp_initial_layer": [
+		"55"
+	],
+	"nozzle_temperature": [
+		"235"
+	],
+	"nozzle_temperature_initial_layer": [
+		"235"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"3"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"4"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"temperature_vitrification": [
+		"110"
+	],
+	"textured_plate_temp": [
+		"55"
+	],
+	"textured_plate_temp_initial_layer": [
+		"55"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if  (bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S255\n{elsif(bed_temperature[current_extruder] >35)||(bed_temperature_initial_layer[current_extruder] >35)}M106 P3 S180\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n;M106 P3 S0\n"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"nozzle_temperature_range_high": [
+		"250"
+	],
+	"nozzle_temperature_range_low": [
+		"220"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PP-CF @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PP-CF @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic PP-CF @System",
+	"inherits": "Tiertime Generic PP-CF @base",
+	"from": "system",
+	"setting_id": "",
+	"filament_id": "GFP96",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PP-CF @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PP-CF @base.json
@@ -1,0 +1,172 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic PP-CF @base",
+	"inherits": "fdm_filament_pp",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"chamber_temperatures": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"35"
+	],
+	"cool_plate_temp_initial_layer": [
+		"35"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"0"
+	],
+	"eng_plate_temp_initial_layer": [
+		"0"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"filament_cost": [
+		"77.99"
+	],
+	"filament_density": [
+		"1.01"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"1"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"6"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PP-CF"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"55"
+	],
+	"hot_plate_temp_initial_layer": [
+		"55"
+	],
+	"nozzle_temperature": [
+		"235"
+	],
+	"nozzle_temperature_initial_layer": [
+		"235"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"3"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"4"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"temperature_vitrification": [
+		"110"
+	],
+	"textured_plate_temp": [
+		"55"
+	],
+	"textured_plate_temp_initial_layer": [
+		"55"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if  (bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S255\n{elsif(bed_temperature[current_extruder] >35)||(bed_temperature_initial_layer[current_extruder] >35)}M106 P3 S180\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n;M106 P3 S0\n"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"nozzle_temperature_range_high": [
+		"250"
+	],
+	"nozzle_temperature_range_low": [
+		"220"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PP-CF@300HS @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PP-CF@300HS @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic PP-CF@300HS @System",
+	"inherits": "Tiertime Generic PP-CF@300HS @base",
+	"from": "system",
+	"setting_id": "",
+	"filament_id": "GFP96_01",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PP-CF@300HS @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PP-CF@300HS @base.json
@@ -1,0 +1,172 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic PP-CF@300HS @base",
+	"inherits": "fdm_filament_pp",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"chamber_temperatures": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"35"
+	],
+	"cool_plate_temp_initial_layer": [
+		"35"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"0"
+	],
+	"eng_plate_temp_initial_layer": [
+		"0"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"filament_cost": [
+		"77.99"
+	],
+	"filament_density": [
+		"1.01"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"1"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"6"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PP-CF"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"55"
+	],
+	"hot_plate_temp_initial_layer": [
+		"55"
+	],
+	"nozzle_temperature": [
+		"235"
+	],
+	"nozzle_temperature_initial_layer": [
+		"235"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"3"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"4"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"temperature_vitrification": [
+		"110"
+	],
+	"textured_plate_temp": [
+		"55"
+	],
+	"textured_plate_temp_initial_layer": [
+		"55"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if  (bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S255\n{elsif(bed_temperature[current_extruder] >35)||(bed_temperature_initial_layer[current_extruder] >35)}M106 P3 S180\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n;M106 P3 S0\n"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"nozzle_temperature_range_high": [
+		"250"
+	],
+	"nozzle_temperature_range_low": [
+		"220"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PP-GF @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PP-GF @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic PP-GF @System",
+	"inherits": "Tiertime Generic PP-GF @base",
+	"from": "system",
+	"setting_id": "",
+	"filament_id": "GFP95",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PP-GF @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PP-GF @base.json
@@ -1,0 +1,172 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic PP-GF @base",
+	"inherits": "fdm_filament_pp",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"chamber_temperatures": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"35"
+	],
+	"cool_plate_temp_initial_layer": [
+		"35"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"0"
+	],
+	"eng_plate_temp_initial_layer": [
+		"0"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"filament_cost": [
+		"59.99"
+	],
+	"filament_density": [
+		"1.05"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"1"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"6"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PP-GF"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"55"
+	],
+	"hot_plate_temp_initial_layer": [
+		"55"
+	],
+	"nozzle_temperature": [
+		"235"
+	],
+	"nozzle_temperature_initial_layer": [
+		"235"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"3"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"4"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"temperature_vitrification": [
+		"110"
+	],
+	"textured_plate_temp": [
+		"55"
+	],
+	"textured_plate_temp_initial_layer": [
+		"55"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if  (bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S255\n{elsif(bed_temperature[current_extruder] >35)||(bed_temperature_initial_layer[current_extruder] >35)}M106 P3 S180\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n;M106 P3 S0\n"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"nozzle_temperature_range_high": [
+		"250"
+	],
+	"nozzle_temperature_range_low": [
+		"220"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PP-GF@300HS @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PP-GF@300HS @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic PP-GF@300HS @System",
+	"inherits": "Tiertime Generic PP-GF@300HS @base",
+	"from": "system",
+	"setting_id": "",
+	"filament_id": "GFP95_01",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PP-GF@300HS @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PP-GF@300HS @base.json
@@ -1,0 +1,172 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic PP-GF@300HS @base",
+	"inherits": "fdm_filament_pp",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"chamber_temperatures": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"35"
+	],
+	"cool_plate_temp_initial_layer": [
+		"35"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"0"
+	],
+	"eng_plate_temp_initial_layer": [
+		"0"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"filament_cost": [
+		"59.99"
+	],
+	"filament_density": [
+		"1.05"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"1"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"6"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PP-GF"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"55"
+	],
+	"hot_plate_temp_initial_layer": [
+		"55"
+	],
+	"nozzle_temperature": [
+		"235"
+	],
+	"nozzle_temperature_initial_layer": [
+		"235"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"3"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"4"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"temperature_vitrification": [
+		"110"
+	],
+	"textured_plate_temp": [
+		"55"
+	],
+	"textured_plate_temp_initial_layer": [
+		"55"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if  (bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S255\n{elsif(bed_temperature[current_extruder] >35)||(bed_temperature_initial_layer[current_extruder] >35)}M106 P3 S180\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n;M106 P3 S0\n"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"nozzle_temperature_range_high": [
+		"250"
+	],
+	"nozzle_temperature_range_low": [
+		"220"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PP@300HS @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PP@300HS @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic PP@300HS @System",
+	"inherits": "Tiertime Generic PP@300HS @base",
+	"from": "system",
+	"setting_id": "",
+	"filament_id": "GFP97_01",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PP@300HS @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PP@300HS @base.json
@@ -1,0 +1,172 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic PP@300HS @base",
+	"inherits": "fdm_filament_pp",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"chamber_temperatures": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"35"
+	],
+	"cool_plate_temp_initial_layer": [
+		"35"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"0"
+	],
+	"eng_plate_temp_initial_layer": [
+		"0"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"filament_cost": [
+		"34.99"
+	],
+	"filament_density": [
+		"0.93"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"1"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"12"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PP"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"55"
+	],
+	"hot_plate_temp_initial_layer": [
+		"55"
+	],
+	"nozzle_temperature": [
+		"235"
+	],
+	"nozzle_temperature_initial_layer": [
+		"235"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"3"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"4"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"temperature_vitrification": [
+		"110"
+	],
+	"textured_plate_temp": [
+		"55"
+	],
+	"textured_plate_temp_initial_layer": [
+		"55"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if  (bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S255\n{elsif(bed_temperature[current_extruder] >35)||(bed_temperature_initial_layer[current_extruder] >35)}M106 P3 S180\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n;M106 P3 S0\n"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"nozzle_temperature_range_high": [
+		"250"
+	],
+	"nozzle_temperature_range_low": [
+		"220"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PPA-CF @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PPA-CF @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic PPA-CF @System",
+	"inherits": "Tiertime Generic PPA-CF @base",
+	"from": "system",
+	"setting_id": "",
+	"filament_id": "GFN97",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PPA-CF @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PPA-CF @base.json
@@ -1,0 +1,169 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic PPA-CF @base",
+	"inherits": "fdm_filament_ppa",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"1"
+	],
+	"chamber_temperatures": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"0"
+	],
+	"cool_plate_temp_initial_layer": [
+		"0"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"100"
+	],
+	"eng_plate_temp_initial_layer": [
+		"100"
+	],
+	"fan_cooling_layer_time": [
+		"5"
+	],
+	"fan_max_speed": [
+		"35"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.17"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"0.96"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"6.5"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PPA-CF"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"100"
+	],
+	"hot_plate_temp_initial_layer": [
+		"100"
+	],
+	"nozzle_temperature": [
+		"290"
+	],
+	"nozzle_temperature_initial_layer": [
+		"290"
+	],
+	"overhang_fan_speed": [
+		"40"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"0"
+	],
+	"required_nozzle_HRC": [
+		"40"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"2"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"temperature_vitrification": [
+		"210"
+	],
+	"textured_plate_temp": [
+		"100"
+	],
+	"textured_plate_temp_initial_layer": [
+		"100"
+	],
+	"filament_start_gcode": [
+		"; Filament gcode\n;{if activate_air_filtration[current_extruder] && support_air_filtration}\n;M106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n;{endif}"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n;M106 P3 S0\n"
+	],
+	"nozzle_temperature_range_high": [
+		"320"
+	],
+	"nozzle_temperature_range_low": [
+		"280"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PPA-CF@300HS @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PPA-CF@300HS @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic PPA-CF@300HS @System",
+	"inherits": "Tiertime Generic PPA-CF@300HS @base",
+	"from": "system",
+	"setting_id": "",
+	"filament_id": "GFN97_01",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PPA-CF@300HS @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PPA-CF@300HS @base.json
@@ -1,0 +1,169 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic PPA-CF@300HS @base",
+	"inherits": "fdm_filament_ppa",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"1"
+	],
+	"chamber_temperatures": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"0"
+	],
+	"cool_plate_temp_initial_layer": [
+		"0"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"100"
+	],
+	"eng_plate_temp_initial_layer": [
+		"100"
+	],
+	"fan_cooling_layer_time": [
+		"5"
+	],
+	"fan_max_speed": [
+		"35"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.17"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"0.96"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"6.5"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PPA-CF"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"100"
+	],
+	"hot_plate_temp_initial_layer": [
+		"100"
+	],
+	"nozzle_temperature": [
+		"290"
+	],
+	"nozzle_temperature_initial_layer": [
+		"290"
+	],
+	"overhang_fan_speed": [
+		"40"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"0"
+	],
+	"required_nozzle_HRC": [
+		"40"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"2"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"temperature_vitrification": [
+		"210"
+	],
+	"textured_plate_temp": [
+		"100"
+	],
+	"textured_plate_temp_initial_layer": [
+		"100"
+	],
+	"filament_start_gcode": [
+		"; Filament gcode\n;{if activate_air_filtration[current_extruder] && support_air_filtration}\n;M106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n;{endif}"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n;M106 P3 S0\n"
+	],
+	"nozzle_temperature_range_high": [
+		"320"
+	],
+	"nozzle_temperature_range_low": [
+		"280"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PPA-GF @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PPA-GF @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic PPA-GF @System",
+	"inherits": "Tiertime Generic PPA-GF @base",
+	"from": "system",
+	"setting_id": "",
+	"filament_id": "GFN96",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PPA-GF @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PPA-GF @base.json
@@ -1,0 +1,169 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic PPA-GF @base",
+	"inherits": "fdm_filament_ppa",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"1"
+	],
+	"chamber_temperatures": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"0"
+	],
+	"cool_plate_temp_initial_layer": [
+		"0"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"100"
+	],
+	"eng_plate_temp_initial_layer": [
+		"100"
+	],
+	"fan_cooling_layer_time": [
+		"5"
+	],
+	"fan_max_speed": [
+		"30"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.17"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"0.96"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"6"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PPA-GF"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"100"
+	],
+	"hot_plate_temp_initial_layer": [
+		"100"
+	],
+	"nozzle_temperature": [
+		"290"
+	],
+	"nozzle_temperature_initial_layer": [
+		"290"
+	],
+	"overhang_fan_speed": [
+		"40"
+	],
+	"overhang_fan_threshold": [
+		"0%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"0"
+	],
+	"required_nozzle_HRC": [
+		"40"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"2"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"temperature_vitrification": [
+		"210"
+	],
+	"textured_plate_temp": [
+		"100"
+	],
+	"textured_plate_temp_initial_layer": [
+		"100"
+	],
+	"filament_start_gcode": [
+		"; Filament gcode\n;{if activate_air_filtration[current_extruder] && support_air_filtration}\n;M106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n;{endif}"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n;M106 P3 S0\n"
+	],
+	"nozzle_temperature_range_high": [
+		"320"
+	],
+	"nozzle_temperature_range_low": [
+		"280"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PPA-GF@300HS @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PPA-GF@300HS @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic PPA-GF@300HS @System",
+	"inherits": "Tiertime Generic PPA-GF@300HS @base",
+	"from": "system",
+	"setting_id": "",
+	"filament_id": "GFN96_01",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PPA-GF@300HS @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PPA-GF@300HS @base.json
@@ -1,0 +1,169 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic PPA-GF@300HS @base",
+	"inherits": "fdm_filament_ppa",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"1"
+	],
+	"chamber_temperatures": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"0"
+	],
+	"cool_plate_temp_initial_layer": [
+		"0"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"100"
+	],
+	"eng_plate_temp_initial_layer": [
+		"100"
+	],
+	"fan_cooling_layer_time": [
+		"5"
+	],
+	"fan_max_speed": [
+		"30"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.17"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"0.96"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"6"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PPA-GF"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"100"
+	],
+	"hot_plate_temp_initial_layer": [
+		"100"
+	],
+	"nozzle_temperature": [
+		"290"
+	],
+	"nozzle_temperature_initial_layer": [
+		"290"
+	],
+	"overhang_fan_speed": [
+		"40"
+	],
+	"overhang_fan_threshold": [
+		"0%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"0"
+	],
+	"required_nozzle_HRC": [
+		"40"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"2"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"temperature_vitrification": [
+		"210"
+	],
+	"textured_plate_temp": [
+		"100"
+	],
+	"textured_plate_temp_initial_layer": [
+		"100"
+	],
+	"filament_start_gcode": [
+		"; Filament gcode\n;{if activate_air_filtration[current_extruder] && support_air_filtration}\n;M106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n;{endif}"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n;M106 P3 S0\n"
+	],
+	"nozzle_temperature_range_high": [
+		"320"
+	],
+	"nozzle_temperature_range_low": [
+		"280"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PPS @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PPS @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic PPS @System",
+	"inherits": "Tiertime Generic PPS @base",
+	"from": "system",
+	"setting_id": "",
+	"filament_id": "GFT97",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PPS @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PPS @base.json
@@ -1,0 +1,169 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic PPS @base",
+	"inherits": "fdm_filament_pps",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"chamber_temperatures": [
+		"60"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"0"
+	],
+	"cool_plate_temp_initial_layer": [
+		"0"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"110"
+	],
+	"eng_plate_temp_initial_layer": [
+		"110"
+	],
+	"fan_cooling_layer_time": [
+		"5"
+	],
+	"fan_max_speed": [
+		"50"
+	],
+	"fan_min_speed": [
+		"0"
+	],
+	"filament_cost": [
+		"0"
+	],
+	"filament_density": [
+		"1.36"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"0.96"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"4"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PPS"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"110"
+	],
+	"hot_plate_temp_initial_layer": [
+		"110"
+	],
+	"nozzle_temperature": [
+		"320"
+	],
+	"nozzle_temperature_initial_layer": [
+		"320"
+	],
+	"overhang_fan_speed": [
+		"30"
+	],
+	"overhang_fan_threshold": [
+		"0%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"0"
+	],
+	"required_nozzle_HRC": [
+		"3"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"2"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"temperature_vitrification": [
+		"125"
+	],
+	"textured_plate_temp": [
+		"110"
+	],
+	"textured_plate_temp_initial_layer": [
+		"110"
+	],
+	"filament_start_gcode": [
+		"; Filament gcode\n;{if activate_air_filtration[current_extruder] && support_air_filtration}\n;M106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n;{endif}"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n;M106 P3 S0\n"
+	],
+	"nozzle_temperature_range_high": [
+		"340"
+	],
+	"nozzle_temperature_range_low": [
+		"300"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PPS-CF @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PPS-CF @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic PPS-CF @System",
+	"inherits": "Tiertime Generic PPS-CF @base",
+	"from": "system",
+	"setting_id": "",
+	"filament_id": "GFT98",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PPS-CF @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PPS-CF @base.json
@@ -1,0 +1,169 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic PPS-CF @base",
+	"inherits": "fdm_filament_pps",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"chamber_temperatures": [
+		"60"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"0"
+	],
+	"cool_plate_temp_initial_layer": [
+		"0"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"110"
+	],
+	"eng_plate_temp_initial_layer": [
+		"110"
+	],
+	"fan_cooling_layer_time": [
+		"5"
+	],
+	"fan_max_speed": [
+		"30"
+	],
+	"fan_min_speed": [
+		"0"
+	],
+	"filament_cost": [
+		"0"
+	],
+	"filament_density": [
+		"1.3"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"0.96"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"3"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PPS-CF"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"110"
+	],
+	"hot_plate_temp_initial_layer": [
+		"110"
+	],
+	"nozzle_temperature": [
+		"320"
+	],
+	"nozzle_temperature_initial_layer": [
+		"320"
+	],
+	"overhang_fan_speed": [
+		"30"
+	],
+	"overhang_fan_threshold": [
+		"0%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"0"
+	],
+	"required_nozzle_HRC": [
+		"40"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"2"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"temperature_vitrification": [
+		"220"
+	],
+	"textured_plate_temp": [
+		"110"
+	],
+	"textured_plate_temp_initial_layer": [
+		"110"
+	],
+	"filament_start_gcode": [
+		"; Filament gcode\n;{if activate_air_filtration[current_extruder] && support_air_filtration}\n;M106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n;{endif}"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n;M106 P3 S0\n"
+	],
+	"nozzle_temperature_range_high": [
+		"350"
+	],
+	"nozzle_temperature_range_low": [
+		"300"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PPS-CF@300HS @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PPS-CF@300HS @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic PPS-CF@300HS @System",
+	"inherits": "Tiertime Generic PPS-CF@300HS @base",
+	"from": "system",
+	"setting_id": "",
+	"filament_id": "GFT98_01",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PPS-CF@300HS @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PPS-CF@300HS @base.json
@@ -1,0 +1,169 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic PPS-CF@300HS @base",
+	"inherits": "fdm_filament_pps",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"chamber_temperatures": [
+		"60"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"0"
+	],
+	"cool_plate_temp_initial_layer": [
+		"0"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"110"
+	],
+	"eng_plate_temp_initial_layer": [
+		"110"
+	],
+	"fan_cooling_layer_time": [
+		"5"
+	],
+	"fan_max_speed": [
+		"30"
+	],
+	"fan_min_speed": [
+		"0"
+	],
+	"filament_cost": [
+		"0"
+	],
+	"filament_density": [
+		"1.3"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"0.96"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"3"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PPS-CF"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"110"
+	],
+	"hot_plate_temp_initial_layer": [
+		"110"
+	],
+	"nozzle_temperature": [
+		"320"
+	],
+	"nozzle_temperature_initial_layer": [
+		"320"
+	],
+	"overhang_fan_speed": [
+		"30"
+	],
+	"overhang_fan_threshold": [
+		"0%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"0"
+	],
+	"required_nozzle_HRC": [
+		"40"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"2"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"temperature_vitrification": [
+		"220"
+	],
+	"textured_plate_temp": [
+		"110"
+	],
+	"textured_plate_temp_initial_layer": [
+		"110"
+	],
+	"filament_start_gcode": [
+		"; Filament gcode\n;{if activate_air_filtration[current_extruder] && support_air_filtration}\n;M106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n;{endif}"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n;M106 P3 S0\n"
+	],
+	"nozzle_temperature_range_high": [
+		"350"
+	],
+	"nozzle_temperature_range_low": [
+		"300"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PPS@300HS @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PPS@300HS @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic PPS@300HS @System",
+	"inherits": "Tiertime Generic PPS@300HS @base",
+	"from": "system",
+	"setting_id": "",
+	"filament_id": "GFT97_01",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PPS@300HS @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PPS@300HS @base.json
@@ -1,0 +1,169 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic PPS@300HS @base",
+	"inherits": "fdm_filament_pps",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"chamber_temperatures": [
+		"60"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"0"
+	],
+	"cool_plate_temp_initial_layer": [
+		"0"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"110"
+	],
+	"eng_plate_temp_initial_layer": [
+		"110"
+	],
+	"fan_cooling_layer_time": [
+		"5"
+	],
+	"fan_max_speed": [
+		"50"
+	],
+	"fan_min_speed": [
+		"0"
+	],
+	"filament_cost": [
+		"0"
+	],
+	"filament_density": [
+		"1.36"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"0.96"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"4"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PPS"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"110"
+	],
+	"hot_plate_temp_initial_layer": [
+		"110"
+	],
+	"nozzle_temperature": [
+		"320"
+	],
+	"nozzle_temperature_initial_layer": [
+		"320"
+	],
+	"overhang_fan_speed": [
+		"30"
+	],
+	"overhang_fan_threshold": [
+		"0%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"0"
+	],
+	"required_nozzle_HRC": [
+		"3"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"2"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"temperature_vitrification": [
+		"125"
+	],
+	"textured_plate_temp": [
+		"110"
+	],
+	"textured_plate_temp_initial_layer": [
+		"110"
+	],
+	"filament_start_gcode": [
+		"; Filament gcode\n;{if activate_air_filtration[current_extruder] && support_air_filtration}\n;M106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n;{endif}"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n;M106 P3 S0\n"
+	],
+	"nozzle_temperature_range_high": [
+		"340"
+	],
+	"nozzle_temperature_range_low": [
+		"300"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PVA @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PVA @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic PVA @System",
+	"inherits": "Tiertime Generic PVA @base",
+	"from": "system",
+	"setting_id": "",
+	"filament_id": "GFS99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PVA @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PVA @base.json
@@ -1,0 +1,172 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic PVA @base",
+	"inherits": "fdm_filament_pva",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"chamber_temperatures": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"45"
+	],
+	"cool_plate_temp_initial_layer": [
+		"45"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"0"
+	],
+	"eng_plate_temp_initial_layer": [
+		"0"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"0.95"
+	],
+	"filament_is_support": [
+		"1"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"16"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"1"
+	],
+	"filament_type": [
+		"PVA"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"55"
+	],
+	"hot_plate_temp_initial_layer": [
+		"55"
+	],
+	"nozzle_temperature": [
+		"220"
+	],
+	"nozzle_temperature_initial_layer": [
+		"220"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"3"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"7"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"temperature_vitrification": [
+		"45"
+	],
+	"textured_plate_temp": [
+		"55"
+	],
+	"textured_plate_temp_initial_layer": [
+		"55"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if  (bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S255\n{elsif(bed_temperature[current_extruder] >35)||(bed_temperature_initial_layer[current_extruder] >35)}M106 P3 S180\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n;M106 P3 S0\n"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"nozzle_temperature_range_high": [
+		"240"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PVA@300HS @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PVA@300HS @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic PVA@300HS @System",
+	"inherits": "Tiertime Generic PVA@300HS @base",
+	"from": "system",
+	"setting_id": "",
+	"filament_id": "GFS99_01",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PVA@300HS @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic PVA@300HS @base.json
@@ -1,0 +1,172 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic PVA@300HS @base",
+	"inherits": "fdm_filament_pva",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"chamber_temperatures": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"45"
+	],
+	"cool_plate_temp_initial_layer": [
+		"45"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"0"
+	],
+	"eng_plate_temp_initial_layer": [
+		"0"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"0.95"
+	],
+	"filament_is_support": [
+		"1"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"16"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"1"
+	],
+	"filament_type": [
+		"PVA"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"55"
+	],
+	"hot_plate_temp_initial_layer": [
+		"55"
+	],
+	"nozzle_temperature": [
+		"220"
+	],
+	"nozzle_temperature_initial_layer": [
+		"220"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"3"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"7"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"temperature_vitrification": [
+		"45"
+	],
+	"textured_plate_temp": [
+		"55"
+	],
+	"textured_plate_temp_initial_layer": [
+		"55"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if  (bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S255\n{elsif(bed_temperature[current_extruder] >35)||(bed_temperature_initial_layer[current_extruder] >35)}M106 P3 S180\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n;M106 P3 S0\n"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"nozzle_temperature_range_high": [
+		"240"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic SBS @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic SBS @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic SBS @System",
+	"inherits": "Tiertime Generic SBS @base",
+	"from": "system",
+	"setting_id": "",
+	"filament_id": "GFL99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic SBS @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic SBS @base.json
@@ -1,0 +1,172 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic SBS @base",
+	"inherits": "fdm_filament_sbs",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"chamber_temperatures": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"70"
+	],
+	"cool_plate_temp_initial_layer": [
+		"70"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"70"
+	],
+	"eng_plate_temp_initial_layer": [
+		"70"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"0"
+	],
+	"filament_cost": [
+		"15"
+	],
+	"filament_density": [
+		"1.02"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"23"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"SBS"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"70"
+	],
+	"hot_plate_temp_initial_layer": [
+		"70"
+	],
+	"nozzle_temperature": [
+		"235"
+	],
+	"nozzle_temperature_initial_layer": [
+		"235"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"0"
+	],
+	"required_nozzle_HRC": [
+		"3"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"4"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"temperature_vitrification": [
+		"70"
+	],
+	"textured_plate_temp": [
+		"70"
+	],
+	"textured_plate_temp_initial_layer": [
+		"70"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if  (bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S255\n{elsif(bed_temperature[current_extruder] >35)||(bed_temperature_initial_layer[current_extruder] >35)}M106 P3 S180\n{endif};Prevent PLA from jamming\n\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n;M106 P3 S0\n"
+	],
+	"nozzle_temperature_range_low": [
+		"215"
+	],
+	"nozzle_temperature_range_high": [
+		"250"
+	],
+	"additional_cooling_fan_speed": [
+		"40"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic SBS@300HS @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic SBS@300HS @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic SBS@300HS @System",
+	"inherits": "Tiertime Generic SBS@300HS @base",
+	"from": "system",
+	"setting_id": "",
+	"filament_id": "GFL99_01",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic SBS@300HS @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic SBS@300HS @base.json
@@ -1,0 +1,172 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic SBS@300HS @base",
+	"inherits": "fdm_filament_sbs",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"chamber_temperatures": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"70"
+	],
+	"cool_plate_temp_initial_layer": [
+		"70"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"70"
+	],
+	"eng_plate_temp_initial_layer": [
+		"70"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"0"
+	],
+	"filament_cost": [
+		"15"
+	],
+	"filament_density": [
+		"1.02"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"23"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"SBS"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"70"
+	],
+	"hot_plate_temp_initial_layer": [
+		"70"
+	],
+	"nozzle_temperature": [
+		"235"
+	],
+	"nozzle_temperature_initial_layer": [
+		"235"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"0"
+	],
+	"required_nozzle_HRC": [
+		"3"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"4"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"temperature_vitrification": [
+		"70"
+	],
+	"textured_plate_temp": [
+		"70"
+	],
+	"textured_plate_temp_initial_layer": [
+		"70"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if  (bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S255\n{elsif(bed_temperature[current_extruder] >35)||(bed_temperature_initial_layer[current_extruder] >35)}M106 P3 S180\n{endif};Prevent PLA from jamming\n\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n;M106 P3 S0\n"
+	],
+	"nozzle_temperature_range_low": [
+		"215"
+	],
+	"nozzle_temperature_range_high": [
+		"250"
+	],
+	"additional_cooling_fan_speed": [
+		"40"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic TPU @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic TPU @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic TPU @System",
+	"inherits": "Tiertime Generic TPU @base",
+	"from": "system",
+	"setting_id": "GFSR99",
+	"filament_id": "GFU99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic TPU @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic TPU @base.json
@@ -1,0 +1,172 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic TPU @base",
+	"inherits": "fdm_filament_tpu",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"chamber_temperatures": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"30"
+	],
+	"cool_plate_temp_initial_layer": [
+		"30"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"30"
+	],
+	"eng_plate_temp_initial_layer": [
+		"30"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"1"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"3.2"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"2.0"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"TPU"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"35"
+	],
+	"hot_plate_temp_initial_layer": [
+		"35"
+	],
+	"nozzle_temperature": [
+		"240"
+	],
+	"nozzle_temperature_initial_layer": [
+		"240"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"95%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"3"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"8"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"temperature_vitrification": [
+		"30"
+	],
+	"textured_plate_temp": [
+		"35"
+	],
+	"textured_plate_temp_initial_layer": [
+		"35"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if (bed_temperature[current_extruder] >35)||(bed_temperature_initial_layer[current_extruder] >35)}M106 P3 S255\n{elsif (bed_temperature[current_extruder] >30)||(bed_temperature_initial_layer[current_extruder] >30)}M106 P3 S180\n{endif} \n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n;M106 P3 S0\n"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"nozzle_temperature_range_high": [
+		"250"
+	],
+	"nozzle_temperature_range_low": [
+		"200"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic TPU@300HS @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic TPU@300HS @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic TPU@300HS @System",
+	"inherits": "Tiertime Generic TPU@300HS @base",
+	"from": "system",
+	"setting_id": "GFSR99",
+	"filament_id": "GFU99_01",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic TPU@300HS @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime Generic TPU@300HS @base.json
@@ -1,0 +1,172 @@
+{
+	"type": "filament",
+	"name": "Tiertime Generic TPU@300HS @base",
+	"inherits": "fdm_filament_tpu",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"chamber_temperatures": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"30"
+	],
+	"cool_plate_temp_initial_layer": [
+		"30"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"30"
+	],
+	"eng_plate_temp_initial_layer": [
+		"30"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"filament_cost": [
+		"20"
+	],
+	"filament_density": [
+		"1.24"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"1"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"3.2"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"2.0"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"TPU"
+	],
+	"filament_vendor": [
+		"Generic"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"35"
+	],
+	"hot_plate_temp_initial_layer": [
+		"35"
+	],
+	"nozzle_temperature": [
+		"240"
+	],
+	"nozzle_temperature_initial_layer": [
+		"240"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"95%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"3"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"8"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"temperature_vitrification": [
+		"30"
+	],
+	"textured_plate_temp": [
+		"35"
+	],
+	"textured_plate_temp_initial_layer": [
+		"35"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if (bed_temperature[current_extruder] >35)||(bed_temperature_initial_layer[current_extruder] >35)}M106 P3 S255\n{elsif (bed_temperature[current_extruder] >30)||(bed_temperature_initial_layer[current_extruder] >30)}M106 P3 S180\n{endif} \n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n;M106 P3 S0\n"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"nozzle_temperature_range_high": [
+		"250"
+	],
+	"nozzle_temperature_range_low": [
+		"200"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime PA6-CF @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime PA6-CF @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Tiertime PA6-CF @System",
+	"inherits": "Tiertime PA6-CF @base",
+	"from": "system",
+	"setting_id": "",
+	"filament_id": "GFN05",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime PA6-CF @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime PA6-CF @base.json
@@ -1,0 +1,169 @@
+{
+	"type": "filament",
+	"name": "Tiertime PA6-CF @base",
+	"inherits": "fdm_filament_pa",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"1"
+	],
+	"chamber_temperatures": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"0"
+	],
+	"cool_plate_temp_initial_layer": [
+		"0"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"100"
+	],
+	"eng_plate_temp_initial_layer": [
+		"100"
+	],
+	"fan_cooling_layer_time": [
+		"5"
+	],
+	"fan_max_speed": [
+		"30"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"filament_cost": [
+		"79.99"
+	],
+	"filament_density": [
+		"1.10"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"0.96"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"8"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PA6-CF"
+	],
+	"filament_vendor": [
+		"Tiertime"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"100"
+	],
+	"hot_plate_temp_initial_layer": [
+		"100"
+	],
+	"nozzle_temperature": [
+		"275"
+	],
+	"nozzle_temperature_initial_layer": [
+		"275"
+	],
+	"overhang_fan_speed": [
+		"40"
+	],
+	"overhang_fan_threshold": [
+		"0%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"0"
+	],
+	"required_nozzle_HRC": [
+		"40"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"2"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"temperature_vitrification": [
+		"170"
+	],
+	"textured_plate_temp": [
+		"100"
+	],
+	"textured_plate_temp_initial_layer": [
+		"100"
+	],
+	"filament_start_gcode": [
+		"; Filament gcode\n;{if activate_air_filtration[current_extruder] && support_air_filtration}\n;M106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n;{endif}"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n;M106 P3 S0\n"
+	],
+	"nozzle_temperature_range_high": [
+		"300"
+	],
+	"nozzle_temperature_range_low": [
+		"260"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime PA6-CF@300HS @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime PA6-CF@300HS @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Tiertime PA6-CF@300HS @System",
+	"inherits": "Tiertime PA6-CF@300HS @base",
+	"from": "system",
+	"setting_id": "",
+	"filament_id": "GFN05_01",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime PA6-CF@300HS @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime PA6-CF@300HS @base.json
@@ -1,0 +1,169 @@
+{
+	"type": "filament",
+	"name": "Tiertime PA6-CF@300HS @base",
+	"inherits": "fdm_filament_pa",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"1"
+	],
+	"chamber_temperatures": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"0"
+	],
+	"cool_plate_temp_initial_layer": [
+		"0"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"100"
+	],
+	"eng_plate_temp_initial_layer": [
+		"100"
+	],
+	"fan_cooling_layer_time": [
+		"5"
+	],
+	"fan_max_speed": [
+		"30"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"filament_cost": [
+		"79.99"
+	],
+	"filament_density": [
+		"1.10"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"0.96"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"8"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PA6-CF"
+	],
+	"filament_vendor": [
+		"Tiertime"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"100"
+	],
+	"hot_plate_temp_initial_layer": [
+		"100"
+	],
+	"nozzle_temperature": [
+		"275"
+	],
+	"nozzle_temperature_initial_layer": [
+		"275"
+	],
+	"overhang_fan_speed": [
+		"40"
+	],
+	"overhang_fan_threshold": [
+		"0%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"0"
+	],
+	"required_nozzle_HRC": [
+		"40"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"2"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"temperature_vitrification": [
+		"170"
+	],
+	"textured_plate_temp": [
+		"100"
+	],
+	"textured_plate_temp_initial_layer": [
+		"100"
+	],
+	"filament_start_gcode": [
+		"; Filament gcode\n;{if activate_air_filtration[current_extruder] && support_air_filtration}\n;M106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n;{endif}"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n;M106 P3 S0\n"
+	],
+	"nozzle_temperature_range_high": [
+		"300"
+	],
+	"nozzle_temperature_range_low": [
+		"260"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime PC @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime PC @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Tiertime PC @System",
+	"inherits": "Tiertime PC @base",
+	"from": "system",
+	"setting_id": "",
+	"filament_id": "GFC00",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime PC @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime PC @base.json
@@ -1,0 +1,169 @@
+{
+	"type": "filament",
+	"name": "Tiertime PC @base",
+	"inherits": "fdm_filament_pc",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"chamber_temperatures": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"0"
+	],
+	"cool_plate_temp_initial_layer": [
+		"0"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"110"
+	],
+	"eng_plate_temp_initial_layer": [
+		"110"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"fan_max_speed": [
+		"40"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"filament_cost": [
+		"39.99"
+	],
+	"filament_density": [
+		"1.04"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"0.94"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"18"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PC"
+	],
+	"filament_vendor": [
+		"Tiertime"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"110"
+	],
+	"hot_plate_temp_initial_layer": [
+		"110"
+	],
+	"nozzle_temperature": [
+		"280"
+	],
+	"nozzle_temperature_initial_layer": [
+		"270"
+	],
+	"overhang_fan_speed": [
+		"60"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"3"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"12"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"temperature_vitrification": [
+		"120"
+	],
+	"textured_plate_temp": [
+		"110"
+	],
+	"textured_plate_temp_initial_layer": [
+		"110"
+	],
+	"filament_start_gcode": [
+		"; Filament gcode\n;{if activate_air_filtration[current_extruder] && support_air_filtration}\n;M106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n;{endif}"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n;M106 P3 S0\n"
+	],
+	"nozzle_temperature_range_high": [
+		"290"
+	],
+	"nozzle_temperature_range_low": [
+		"260"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime PC@300HS @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime PC@300HS @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Tiertime PC@300HS @System",
+	"inherits": "Tiertime PC@300HS @base",
+	"from": "system",
+	"setting_id": "",
+	"filament_id": "GFC00_01",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime PC@300HS @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime PC@300HS @base.json
@@ -1,0 +1,169 @@
+{
+	"type": "filament",
+	"name": "Tiertime PC@300HS @base",
+	"inherits": "fdm_filament_pc",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"chamber_temperatures": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"0"
+	],
+	"cool_plate_temp_initial_layer": [
+		"0"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"110"
+	],
+	"eng_plate_temp_initial_layer": [
+		"110"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"fan_max_speed": [
+		"40"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"filament_cost": [
+		"39.99"
+	],
+	"filament_density": [
+		"1.04"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"0.94"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"18"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PC"
+	],
+	"filament_vendor": [
+		"Tiertime"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"110"
+	],
+	"hot_plate_temp_initial_layer": [
+		"110"
+	],
+	"nozzle_temperature": [
+		"280"
+	],
+	"nozzle_temperature_initial_layer": [
+		"270"
+	],
+	"overhang_fan_speed": [
+		"60"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"3"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"12"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"temperature_vitrification": [
+		"120"
+	],
+	"textured_plate_temp": [
+		"110"
+	],
+	"textured_plate_temp_initial_layer": [
+		"110"
+	],
+	"filament_start_gcode": [
+		"; Filament gcode\n;{if activate_air_filtration[current_extruder] && support_air_filtration}\n;M106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n;{endif}"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n;M106 P3 S0\n"
+	],
+	"nozzle_temperature_range_high": [
+		"290"
+	],
+	"nozzle_temperature_range_low": [
+		"260"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime PET-CF @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime PET-CF @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Tiertime PET-CF @System",
+	"inherits": "Tiertime PET-CF @base",
+	"from": "system",
+	"setting_id": "",
+	"filament_id": "GFT01",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime PET-CF @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime PET-CF @base.json
@@ -1,0 +1,169 @@
+{
+	"type": "filament",
+	"name": "Tiertime PET-CF @base",
+	"inherits": "fdm_filament_pet",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"chamber_temperatures": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"0"
+	],
+	"cool_plate_temp_initial_layer": [
+		"0"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"80"
+	],
+	"eng_plate_temp_initial_layer": [
+		"80"
+	],
+	"fan_cooling_layer_time": [
+		"5"
+	],
+	"fan_max_speed": [
+		"30"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"filament_cost": [
+		"84.99"
+	],
+	"filament_density": [
+		"1.29"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"1"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"8"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PET-CF"
+	],
+	"filament_vendor": [
+		"Tiertime"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"100"
+	],
+	"hot_plate_temp_initial_layer": [
+		"100"
+	],
+	"nozzle_temperature": [
+		"270"
+	],
+	"nozzle_temperature_initial_layer": [
+		"270"
+	],
+	"overhang_fan_speed": [
+		"40"
+	],
+	"overhang_fan_threshold": [
+		"0%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"0"
+	],
+	"required_nozzle_HRC": [
+		"40"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"2"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"temperature_vitrification": [
+		"185"
+	],
+	"textured_plate_temp": [
+		"100"
+	],
+	"textured_plate_temp_initial_layer": [
+		"100"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if (bed_temperature[current_extruder] >80)||(bed_temperature_initial_layer[current_extruder] >80)}M106 P3 S255\n{elsif (bed_temperature[current_extruder] >60)||(bed_temperature_initial_layer[current_extruder] >60)}M106 P3 S180\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n;M106 P3 S0\n"
+	],
+	"nozzle_temperature_range_high": [
+		"290"
+	],
+	"nozzle_temperature_range_low": [
+		"260"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime PET-CF@300HS @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime PET-CF@300HS @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Tiertime PET-CF@300HS @System",
+	"inherits": "Tiertime PET-CF@300HS @base",
+	"from": "system",
+	"setting_id": "",
+	"filament_id": "GFT01_01",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime PET-CF@300HS @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime PET-CF@300HS @base.json
@@ -1,0 +1,169 @@
+{
+	"type": "filament",
+	"name": "Tiertime PET-CF@300HS @base",
+	"inherits": "fdm_filament_pet",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"chamber_temperatures": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"0"
+	],
+	"cool_plate_temp_initial_layer": [
+		"0"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"80"
+	],
+	"eng_plate_temp_initial_layer": [
+		"80"
+	],
+	"fan_cooling_layer_time": [
+		"5"
+	],
+	"fan_max_speed": [
+		"30"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"filament_cost": [
+		"84.99"
+	],
+	"filament_density": [
+		"1.29"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"1"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"8"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PET-CF"
+	],
+	"filament_vendor": [
+		"Tiertime"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"100"
+	],
+	"hot_plate_temp_initial_layer": [
+		"100"
+	],
+	"nozzle_temperature": [
+		"270"
+	],
+	"nozzle_temperature_initial_layer": [
+		"270"
+	],
+	"overhang_fan_speed": [
+		"40"
+	],
+	"overhang_fan_threshold": [
+		"0%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"0"
+	],
+	"required_nozzle_HRC": [
+		"40"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"2"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"temperature_vitrification": [
+		"185"
+	],
+	"textured_plate_temp": [
+		"100"
+	],
+	"textured_plate_temp_initial_layer": [
+		"100"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if (bed_temperature[current_extruder] >80)||(bed_temperature_initial_layer[current_extruder] >80)}M106 P3 S255\n{elsif (bed_temperature[current_extruder] >60)||(bed_temperature_initial_layer[current_extruder] >60)}M106 P3 S180\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n;M106 P3 S0\n"
+	],
+	"nozzle_temperature_range_high": [
+		"290"
+	],
+	"nozzle_temperature_range_low": [
+		"260"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime PETG @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime PETG @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Tiertime PETG @System",
+	"inherits": "Tiertime PETG @base",
+	"from": "system",
+	"setting_id": "",
+	"filament_id": "GFG00",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime PETG @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime PETG @base.json
@@ -1,0 +1,169 @@
+{
+	"type": "filament",
+	"name": "Tiertime PETG @base",
+	"inherits": "fdm_filament_pet",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"chamber_temperatures": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"0"
+	],
+	"cool_plate_temp_initial_layer": [
+		"0"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"70"
+	],
+	"eng_plate_temp_initial_layer": [
+		"70"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"fan_max_speed": [
+		"40"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"filament_cost": [
+		"24.99"
+	],
+	"filament_density": [
+		"1.25"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"0.95"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_long_retractions_when_cut": [
+		"1"
+	],
+	"filament_max_volumetric_speed": [
+		"13"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"18"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PETG"
+	],
+	"filament_vendor": [
+		"Tiertime"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"70"
+	],
+	"hot_plate_temp_initial_layer": [
+		"70"
+	],
+	"nozzle_temperature": [
+		"255"
+	],
+	"nozzle_temperature_initial_layer": [
+		"255"
+	],
+	"overhang_fan_speed": [
+		"90"
+	],
+	"overhang_fan_threshold": [
+		"10%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"3"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"12"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"temperature_vitrification": [
+		"70"
+	],
+	"textured_plate_temp": [
+		"70"
+	],
+	"textured_plate_temp_initial_layer": [
+		"70"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if (bed_temperature[current_extruder] >80)||(bed_temperature_initial_layer[current_extruder] >80)}M106 P3 S255\n{elsif (bed_temperature[current_extruder] >60)||(bed_temperature_initial_layer[current_extruder] >60)}M106 P3 S180\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n;M106 P3 S0\n"
+	],
+	"nozzle_temperature_range_high": [
+		"270"
+	],
+	"nozzle_temperature_range_low": [
+		"230"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime PETG@300HS @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime PETG@300HS @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Tiertime PETG@300HS @System",
+	"inherits": "Tiertime PETG@300HS @base",
+	"from": "system",
+	"setting_id": "",
+	"filament_id": "GFG00_01",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime PETG@300HS @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime PETG@300HS @base.json
@@ -1,0 +1,169 @@
+{
+	"type": "filament",
+	"name": "Tiertime PETG@300HS @base",
+	"inherits": "fdm_filament_pet",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"chamber_temperatures": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"0"
+	],
+	"cool_plate_temp_initial_layer": [
+		"0"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"70"
+	],
+	"eng_plate_temp_initial_layer": [
+		"70"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"fan_max_speed": [
+		"40"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"filament_cost": [
+		"24.99"
+	],
+	"filament_density": [
+		"1.25"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"0.95"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_long_retractions_when_cut": [
+		"1"
+	],
+	"filament_max_volumetric_speed": [
+		"13"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"18"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PETG"
+	],
+	"filament_vendor": [
+		"Tiertime"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"70"
+	],
+	"hot_plate_temp_initial_layer": [
+		"70"
+	],
+	"nozzle_temperature": [
+		"255"
+	],
+	"nozzle_temperature_initial_layer": [
+		"255"
+	],
+	"overhang_fan_speed": [
+		"90"
+	],
+	"overhang_fan_threshold": [
+		"10%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"3"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"12"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"temperature_vitrification": [
+		"70"
+	],
+	"textured_plate_temp": [
+		"70"
+	],
+	"textured_plate_temp_initial_layer": [
+		"70"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if (bed_temperature[current_extruder] >80)||(bed_temperature_initial_layer[current_extruder] >80)}M106 P3 S255\n{elsif (bed_temperature[current_extruder] >60)||(bed_temperature_initial_layer[current_extruder] >60)}M106 P3 S180\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n;M106 P3 S0\n"
+	],
+	"nozzle_temperature_range_high": [
+		"270"
+	],
+	"nozzle_temperature_range_low": [
+		"230"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime PLA @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime PLA @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Tiertime PLA @System",
+	"inherits": "Tiertime PLA @base",
+	"from": "system",
+	"setting_id": "GFSA00",
+	"filament_id": "GFA00",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime PLA @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime PLA @base.json
@@ -1,0 +1,172 @@
+{
+	"type": "filament",
+	"name": "Tiertime PLA @base",
+	"inherits": "fdm_filament_pla",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"chamber_temperatures": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"35"
+	],
+	"cool_plate_temp_initial_layer": [
+		"35"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"0"
+	],
+	"eng_plate_temp_initial_layer": [
+		"0"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"filament_cost": [
+		"24.99"
+	],
+	"filament_density": [
+		"1.26"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_long_retractions_when_cut": [
+		"1"
+	],
+	"filament_max_volumetric_speed": [
+		"21"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"18"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PLA"
+	],
+	"filament_vendor": [
+		"Tiertime"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"60"
+	],
+	"hot_plate_temp_initial_layer": [
+		"60"
+	],
+	"nozzle_temperature": [
+		"220"
+	],
+	"nozzle_temperature_initial_layer": [
+		"220"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"3"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"4"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"temperature_vitrification": [
+		"45"
+	],
+	"textured_plate_temp": [
+		"60"
+	],
+	"textured_plate_temp_initial_layer": [
+		"60"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n;{if  (bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S255\n;{elsif(bed_temperature[current_extruder] >35)||(bed_temperature_initial_layer[current_extruder] >35)}M106 P3 S180\n;{endif}\n\n;{if activate_air_filtration[current_extruder] && support_air_filtration}\n;M106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n;{endif}"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n;M106 P3 S0\n"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"240"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime PLA-CF @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime PLA-CF @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Tiertime PLA-CF @System",
+	"inherits": "Tiertime PLA-CF @base",
+	"from": "system",
+	"setting_id": "",
+	"filament_id": "GFA50",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime PLA-CF @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime PLA-CF @base.json
@@ -1,0 +1,172 @@
+{
+	"type": "filament",
+	"name": "Tiertime PLA-CF @base",
+	"inherits": "fdm_filament_pla",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"chamber_temperatures": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"45"
+	],
+	"cool_plate_temp_initial_layer": [
+		"45"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"0"
+	],
+	"eng_plate_temp_initial_layer": [
+		"0"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"filament_cost": [
+		"34.99"
+	],
+	"filament_density": [
+		"1.22"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"15"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PLA-CF"
+	],
+	"filament_vendor": [
+		"Tiertime"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"60"
+	],
+	"hot_plate_temp_initial_layer": [
+		"60"
+	],
+	"nozzle_temperature": [
+		"230"
+	],
+	"nozzle_temperature_initial_layer": [
+		"230"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"40"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"8"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"temperature_vitrification": [
+		"45"
+	],
+	"textured_plate_temp": [
+		"60"
+	],
+	"textured_plate_temp_initial_layer": [
+		"60"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\nM142 P1 R35 S40\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n;M106 P3 S0\n"
+	],
+	"nozzle_temperature_range_low": [
+		"210"
+	],
+	"nozzle_temperature_range_high": [
+		"250"
+	],
+	"additional_cooling_fan_speed": [
+		"0"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime PLA-CF@300HS @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime PLA-CF@300HS @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Tiertime PLA-CF@300HS @System",
+	"inherits": "Tiertime PLA-CF@300HS @base",
+	"from": "system",
+	"setting_id": "",
+	"filament_id": "GFA50_01",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime PLA-CF@300HS @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime PLA-CF@300HS @base.json
@@ -1,0 +1,172 @@
+{
+	"type": "filament",
+	"name": "Tiertime PLA-CF@300HS @base",
+	"inherits": "fdm_filament_pla",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"chamber_temperatures": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"45"
+	],
+	"cool_plate_temp_initial_layer": [
+		"45"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"0"
+	],
+	"eng_plate_temp_initial_layer": [
+		"0"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"filament_cost": [
+		"34.99"
+	],
+	"filament_density": [
+		"1.22"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"15"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PLA-CF"
+	],
+	"filament_vendor": [
+		"Tiertime"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"60"
+	],
+	"hot_plate_temp_initial_layer": [
+		"60"
+	],
+	"nozzle_temperature": [
+		"230"
+	],
+	"nozzle_temperature_initial_layer": [
+		"230"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"40"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"8"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"temperature_vitrification": [
+		"45"
+	],
+	"textured_plate_temp": [
+		"60"
+	],
+	"textured_plate_temp_initial_layer": [
+		"60"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\nM142 P1 R35 S40\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n;M106 P3 S0\n"
+	],
+	"nozzle_temperature_range_low": [
+		"210"
+	],
+	"nozzle_temperature_range_high": [
+		"250"
+	],
+	"additional_cooling_fan_speed": [
+		"0"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime PLA@300HS @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime PLA@300HS @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Tiertime PLA@300HS @System",
+	"inherits": "Tiertime PLA@300HS @base",
+	"from": "system",
+	"setting_id": "GFSA00",
+	"filament_id": "GFA00_01",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime PLA@300HS @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime PLA@300HS @base.json
@@ -1,0 +1,172 @@
+{
+	"type": "filament",
+	"name": "Tiertime PLA@300HS @base",
+	"inherits": "fdm_filament_pla",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"chamber_temperatures": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"35"
+	],
+	"cool_plate_temp_initial_layer": [
+		"35"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"0"
+	],
+	"eng_plate_temp_initial_layer": [
+		"0"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"filament_cost": [
+		"24.99"
+	],
+	"filament_density": [
+		"1.26"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_long_retractions_when_cut": [
+		"1"
+	],
+	"filament_max_volumetric_speed": [
+		"21"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"18"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"PLA"
+	],
+	"filament_vendor": [
+		"Tiertime"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"60"
+	],
+	"hot_plate_temp_initial_layer": [
+		"60"
+	],
+	"nozzle_temperature": [
+		"220"
+	],
+	"nozzle_temperature_initial_layer": [
+		"220"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"3"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"4"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"temperature_vitrification": [
+		"45"
+	],
+	"textured_plate_temp": [
+		"60"
+	],
+	"textured_plate_temp_initial_layer": [
+		"60"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n;{if  (bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S255\n;{elsif(bed_temperature[current_extruder] >35)||(bed_temperature_initial_layer[current_extruder] >35)}M106 P3 S180\n;{endif}\n\n;{if activate_air_filtration[current_extruder] && support_air_filtration}\n;M106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n;{endif}"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n;M106 P3 S0\n"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"240"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime PVA @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime PVA @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Tiertime PVA @System",
+	"inherits": "Tiertime PVA @base",
+	"from": "system",
+	"setting_id": "",
+	"filament_id": "GFS04",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime PVA @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime PVA @base.json
@@ -1,0 +1,172 @@
+{
+	"type": "filament",
+	"name": "Tiertime PVA @base",
+	"inherits": "fdm_filament_pva",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"chamber_temperatures": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"45"
+	],
+	"cool_plate_temp_initial_layer": [
+		"45"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"0"
+	],
+	"eng_plate_temp_initial_layer": [
+		"0"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"filament_cost": [
+		"79.98"
+	],
+	"filament_density": [
+		"1.27"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"1"
+	],
+	"filament_is_support": [
+		"1"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"6"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"1"
+	],
+	"filament_type": [
+		"PVA"
+	],
+	"filament_vendor": [
+		"Tiertime"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"55"
+	],
+	"hot_plate_temp_initial_layer": [
+		"55"
+	],
+	"nozzle_temperature": [
+		"240"
+	],
+	"nozzle_temperature_initial_layer": [
+		"240"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"3"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"7"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"temperature_vitrification": [
+		"45"
+	],
+	"textured_plate_temp": [
+		"55"
+	],
+	"textured_plate_temp_initial_layer": [
+		"55"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if  (bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S255\n{elsif(bed_temperature[current_extruder] >35)||(bed_temperature_initial_layer[current_extruder] >35)}M106 P3 S180\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n;M106 P3 S0\n"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"nozzle_temperature_range_high": [
+		"250"
+	],
+	"nozzle_temperature_range_low": [
+		"210"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime PVA@300HS @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime PVA@300HS @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Tiertime PVA@300HS @System",
+	"inherits": "Tiertime PVA@300HS @base",
+	"from": "system",
+	"setting_id": "",
+	"filament_id": "GFS04_01",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime PVA@300HS @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime PVA@300HS @base.json
@@ -1,0 +1,172 @@
+{
+	"type": "filament",
+	"name": "Tiertime PVA@300HS @base",
+	"inherits": "fdm_filament_pva",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"chamber_temperatures": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"45"
+	],
+	"cool_plate_temp_initial_layer": [
+		"45"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"0"
+	],
+	"eng_plate_temp_initial_layer": [
+		"0"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"filament_cost": [
+		"79.98"
+	],
+	"filament_density": [
+		"1.27"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"1"
+	],
+	"filament_is_support": [
+		"1"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"6"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"nil"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"1"
+	],
+	"filament_type": [
+		"PVA"
+	],
+	"filament_vendor": [
+		"Tiertime"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"55"
+	],
+	"hot_plate_temp_initial_layer": [
+		"55"
+	],
+	"nozzle_temperature": [
+		"240"
+	],
+	"nozzle_temperature_initial_layer": [
+		"240"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"3"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"7"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"temperature_vitrification": [
+		"45"
+	],
+	"textured_plate_temp": [
+		"55"
+	],
+	"textured_plate_temp_initial_layer": [
+		"55"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if  (bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S255\n{elsif(bed_temperature[current_extruder] >35)||(bed_temperature_initial_layer[current_extruder] >35)}M106 P3 S180\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n;M106 P3 S0\n"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"nozzle_temperature_range_high": [
+		"250"
+	],
+	"nozzle_temperature_range_low": [
+		"210"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime TPU 95A @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime TPU 95A @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Tiertime TPU 95A @System",
+	"inherits": "Tiertime TPU 95A @base",
+	"from": "system",
+	"setting_id": "",
+	"filament_id": "GFU01",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime TPU 95A @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime TPU 95A @base.json
@@ -1,0 +1,172 @@
+{
+	"type": "filament",
+	"name": "Tiertime TPU 95A @base",
+	"inherits": "fdm_filament_tpu",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"chamber_temperatures": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"30"
+	],
+	"cool_plate_temp_initial_layer": [
+		"30"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"30"
+	],
+	"eng_plate_temp_initial_layer": [
+		"30"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"filament_cost": [
+		"41.99"
+	],
+	"filament_density": [
+		"1.22"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"1"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"8"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"2.0"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"TPU"
+	],
+	"filament_vendor": [
+		"Tiertime"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"35"
+	],
+	"hot_plate_temp_initial_layer": [
+		"35"
+	],
+	"nozzle_temperature": [
+		"230"
+	],
+	"nozzle_temperature_initial_layer": [
+		"230"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"95%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"3"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"8"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"temperature_vitrification": [
+		"30"
+	],
+	"textured_plate_temp": [
+		"35"
+	],
+	"textured_plate_temp_initial_layer": [
+		"35"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if  (bed_temperature[current_extruder] >35)||(bed_temperature_initial_layer[current_extruder] >35)}M106 P3 S255\n{elsif(bed_temperature[current_extruder] >30)||(bed_temperature_initial_layer[current_extruder] >30)}M106 P3 S180\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n;M106 P3 S0\n"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"nozzle_temperature_range_high": [
+		"250"
+	],
+	"nozzle_temperature_range_low": [
+		"200"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime TPU 95A@300HS @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime TPU 95A@300HS @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Tiertime TPU 95A@300HS @System",
+	"inherits": "Tiertime TPU 95A@300HS @base",
+	"from": "system",
+	"setting_id": "",
+	"filament_id": "GFU01_01",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime TPU 95A@300HS @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Tiertime/Tiertime TPU 95A@300HS @base.json
@@ -1,0 +1,172 @@
+{
+	"type": "filament",
+	"name": "Tiertime TPU 95A@300HS @base",
+	"inherits": "fdm_filament_tpu",
+	"from": "system",
+	"instantiation": "false",
+	"activate_air_filtration": [
+		"0"
+	],
+	"chamber_temperatures": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"70"
+	],
+	"cool_plate_temp": [
+		"30"
+	],
+	"cool_plate_temp_initial_layer": [
+		"30"
+	],
+	"during_print_exhaust_fan_speed": [
+		"70"
+	],
+	"eng_plate_temp": [
+		"30"
+	],
+	"eng_plate_temp_initial_layer": [
+		"30"
+	],
+	"fan_cooling_layer_time": [
+		"100"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"filament_cost": [
+		"41.99"
+	],
+	"filament_density": [
+		"1.22"
+	],
+	"filament_deretraction_speed": [
+		"nil"
+	],
+	"filament_diameter": [
+		"1.75"
+	],
+	"filament_flow_ratio": [
+		"1"
+	],
+	"filament_is_support": [
+		"0"
+	],
+	"filament_long_retractions_when_cut": [
+		"nil"
+	],
+	"filament_max_volumetric_speed": [
+		"8"
+	],
+	"filament_retract_before_wipe": [
+		"nil"
+	],
+	"filament_retract_restart_extra": [
+		"nil"
+	],
+	"filament_retract_when_changing_layer": [
+		"nil"
+	],
+	"filament_retraction_distances_when_cut": [
+		"nil"
+	],
+	"filament_retraction_length": [
+		"2.0"
+	],
+	"filament_retraction_minimum_travel": [
+		"nil"
+	],
+	"filament_retraction_speed": [
+		"nil"
+	],
+	"filament_settings_id": [
+		""
+	],
+	"filament_soluble": [
+		"0"
+	],
+	"filament_type": [
+		"TPU"
+	],
+	"filament_vendor": [
+		"Tiertime"
+	],
+	"filament_wipe": [
+		"nil"
+	],
+	"filament_wipe_distance": [
+		"nil"
+	],
+	"filament_z_hop": [
+		"nil"
+	],
+	"filament_z_hop_types": [
+		"nil"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"hot_plate_temp": [
+		"35"
+	],
+	"hot_plate_temp_initial_layer": [
+		"35"
+	],
+	"nozzle_temperature": [
+		"230"
+	],
+	"nozzle_temperature_initial_layer": [
+		"230"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"95%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"required_nozzle_HRC": [
+		"3"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"slow_down_layer_time": [
+		"8"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"temperature_vitrification": [
+		"30"
+	],
+	"textured_plate_temp": [
+		"35"
+	],
+	"textured_plate_temp_initial_layer": [
+		"35"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if  (bed_temperature[current_extruder] >35)||(bed_temperature_initial_layer[current_extruder] >35)}M106 P3 S255\n{elsif(bed_temperature[current_extruder] >30)||(bed_temperature_initial_layer[current_extruder] >30)}M106 P3 S180\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n;M106 P3 S0\n"
+	],
+	"additional_cooling_fan_speed": [
+		"70"
+	],
+	"nozzle_temperature_range_high": [
+		"250"
+	],
+	"nozzle_temperature_range_low": [
+		"200"
+	]
+}

--- a/resources/profiles/Tiertime/filament/Tiertime ABS.json
+++ b/resources/profiles/Tiertime/filament/Tiertime ABS.json
@@ -1,29 +1,11 @@
 {
 	"type": "filament",
-	"filament_id": "GFB00",
-	"setting_id": "GFSB00",
 	"name": "Tiertime ABS",
+	"inherits": "Tiertime ABS @base",
 	"from": "system",
+	"setting_id": "GFSB00",
+	"filament_id": "GFB00",
 	"instantiation": "true",
-	"inherits": "fdm_filament_abs",
-	"filament_flow_ratio": [
-		"0.95"
-	],
-	"filament_cost": [
-		"24.99"
-	],
-	"filament_vendor": [
-		"Tiertime"
-	],
-	"fan_max_speed": [
-		"60"
-	],
-	"filament_max_volumetric_speed": [
-		"16"
-	],
-	"slow_down_layer_time": [
-		"12"
-	],
 	"compatible_printers": [
 		"Tiertime UP400 Pro 0.4 nozzle",
 		"Tiertime UP400 Pro 0.6 nozzle",

--- a/resources/profiles/Tiertime/filament/Tiertime ABS@300HS.json
+++ b/resources/profiles/Tiertime/filament/Tiertime ABS@300HS.json
@@ -1,29 +1,11 @@
 {
 	"type": "filament",
-	"filament_id": "GFB00_01",
-	"setting_id": "GFSB00",
 	"name": "Tiertime ABS@300HS",
+	"inherits": "Tiertime ABS@300HS @base",
 	"from": "system",
+	"setting_id": "GFSB00",
+	"filament_id": "GFB00_01",
 	"instantiation": "true",
-	"inherits": "fdm_filament_abs",
-	"filament_flow_ratio": [
-		"0.95"
-	],
-	"filament_cost": [
-		"24.99"
-	],
-	"filament_vendor": [
-		"Tiertime"
-	],
-	"fan_max_speed": [
-		"60"
-	],
-	"filament_max_volumetric_speed": [
-		"16"
-	],
-	"slow_down_layer_time": [
-		"12"
-	],
 	"compatible_printers": [
 		"Tiertime UP300 HS 0.4 nozzle",
 		"Tiertime UP600 HS 0.4 nozzle",

--- a/resources/profiles/Tiertime/filament/Tiertime ASA.json
+++ b/resources/profiles/Tiertime/filament/Tiertime ASA.json
@@ -1,40 +1,10 @@
 {
 	"type": "filament",
 	"name": "Tiertime ASA",
-	"inherits": "fdm_filament_asa",
+	"inherits": "Tiertime ASA @base",
 	"from": "system",
 	"filament_id": "GFB01",
 	"instantiation": "true",
-	"fan_max_speed": [
-		"35"
-	],
-	"filament_cost": [
-		"31.99"
-	],
-	"filament_density": [
-		"1.05"
-	],
-	"filament_flow_ratio": [
-		"0.95"
-	],
-	"filament_max_volumetric_speed": [
-		"18"
-	],
-	"filament_vendor": [
-		"Tiertime"
-	],
-	"nozzle_temperature": [
-		"270"
-	],
-	"nozzle_temperature_initial_layer": [
-		"270"
-	],
-	"slow_down_layer_time": [
-		"12"
-	],
-	"fan_min_speed": [
-		"25"
-	],
 	"compatible_printers": [
 		"Tiertime UP400 Pro 0.4 nozzle",
 		"Tiertime UP400 Pro 0.6 nozzle",

--- a/resources/profiles/Tiertime/filament/Tiertime ASA@300HS.json
+++ b/resources/profiles/Tiertime/filament/Tiertime ASA@300HS.json
@@ -1,40 +1,10 @@
 {
 	"type": "filament",
 	"name": "Tiertime ASA@300HS",
-	"inherits": "fdm_filament_asa",
+	"inherits": "Tiertime ASA@300HS @base",
 	"from": "system",
 	"filament_id": "GFB01_01",
 	"instantiation": "true",
-	"fan_max_speed": [
-		"35"
-	],
-	"filament_cost": [
-		"31.99"
-	],
-	"filament_density": [
-		"1.05"
-	],
-	"filament_flow_ratio": [
-		"0.95"
-	],
-	"filament_max_volumetric_speed": [
-		"18"
-	],
-	"filament_vendor": [
-		"Tiertime"
-	],
-	"nozzle_temperature": [
-		"270"
-	],
-	"nozzle_temperature_initial_layer": [
-		"270"
-	],
-	"slow_down_layer_time": [
-		"12"
-	],
-	"fan_min_speed": [
-		"25"
-	],
 	"compatible_printers": [
 		"Tiertime UP300 HS 0.4 nozzle",
 		"Tiertime UP600 HS 0.4 nozzle",

--- a/resources/profiles/Tiertime/filament/Tiertime Generic ABS.json
+++ b/resources/profiles/Tiertime/filament/Tiertime Generic ABS.json
@@ -1,34 +1,10 @@
 {
 	"type": "filament",
 	"name": "Tiertime Generic ABS",
-	"inherits": "fdm_filament_abs",
+	"inherits": "Tiertime Generic ABS @base",
 	"from": "system",
 	"filament_id": "GFB99",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"0.95"
-	],
-	"fan_max_speed": [
-		"20"
-	],
-	"filament_max_volumetric_speed": [
-		"15"
-	],
-	"hot_plate_temp": [
-		"100"
-	],
-	"hot_plate_temp_initial_layer": [
-		"100"
-	],
-	"reduce_fan_stop_start_freq": [
-		"0"
-	],
-	"textured_plate_temp": [
-		"100"
-	],
-	"textured_plate_temp_initial_layer": [
-		"100"
-	],
 	"compatible_printers": [
 		"Tiertime UP400 Pro 0.4 nozzle",
 		"Tiertime UP400 Pro 0.6 nozzle",

--- a/resources/profiles/Tiertime/filament/Tiertime Generic ABS@300HS.json
+++ b/resources/profiles/Tiertime/filament/Tiertime Generic ABS@300HS.json
@@ -1,34 +1,10 @@
 {
 	"type": "filament",
 	"name": "Tiertime Generic ABS@300HS",
-	"inherits": "fdm_filament_abs",
+	"inherits": "Tiertime Generic ABS@300HS @base",
 	"from": "system",
 	"filament_id": "GFB99_01",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"0.95"
-	],
-	"fan_max_speed": [
-		"20"
-	],
-	"filament_max_volumetric_speed": [
-		"15"
-	],
-	"hot_plate_temp": [
-		"100"
-	],
-	"hot_plate_temp_initial_layer": [
-		"100"
-	],
-	"reduce_fan_stop_start_freq": [
-		"0"
-	],
-	"textured_plate_temp": [
-		"100"
-	],
-	"textured_plate_temp_initial_layer": [
-		"100"
-	],
 	"compatible_printers": [
 		"Tiertime UP300 HS 0.4 nozzle",
 		"Tiertime UP600 HS 0.4 nozzle",

--- a/resources/profiles/Tiertime/filament/Tiertime Generic ASA.json
+++ b/resources/profiles/Tiertime/filament/Tiertime Generic ASA.json
@@ -1,28 +1,10 @@
 {
 	"type": "filament",
 	"name": "Tiertime Generic ASA",
-	"inherits": "fdm_filament_asa",
+	"inherits": "Tiertime Generic ASA @base",
 	"from": "system",
 	"filament_id": "GFB98",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"0.95"
-	],
-	"filament_max_volumetric_speed": [
-		"12"
-	],
-	"hot_plate_temp": [
-		"100"
-	],
-	"hot_plate_temp_initial_layer": [
-		"100"
-	],
-	"textured_plate_temp": [
-		"100"
-	],
-	"textured_plate_temp_initial_layer": [
-		"100"
-	],
 	"compatible_printers": [
 		"Tiertime UP400 Pro 0.4 nozzle",
 		"Tiertime UP400 Pro 0.6 nozzle",

--- a/resources/profiles/Tiertime/filament/Tiertime Generic ASA@300HS.json
+++ b/resources/profiles/Tiertime/filament/Tiertime Generic ASA@300HS.json
@@ -1,28 +1,10 @@
 {
 	"type": "filament",
 	"name": "Tiertime Generic ASA@300HS",
-	"inherits": "fdm_filament_asa",
+	"inherits": "Tiertime Generic ASA@300HS @base",
 	"from": "system",
 	"filament_id": "GFB98_01",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"0.95"
-	],
-	"filament_max_volumetric_speed": [
-		"12"
-	],
-	"hot_plate_temp": [
-		"100"
-	],
-	"hot_plate_temp_initial_layer": [
-		"100"
-	],
-	"textured_plate_temp": [
-		"100"
-	],
-	"textured_plate_temp_initial_layer": [
-		"100"
-	],
 	"compatible_printers": [
 		"Tiertime UP300 HS 0.4 nozzle",
 		"Tiertime UP600 HS 0.4 nozzle",

--- a/resources/profiles/Tiertime/filament/Tiertime Generic BVOH.json
+++ b/resources/profiles/Tiertime/filament/Tiertime Generic BVOH.json
@@ -1,7 +1,7 @@
 {
 	"type": "filament",
 	"name": "Tiertime Generic BVOH",
-	"inherits": "fdm_filament_bvoh",
+	"inherits": "Tiertime Generic BVOH @base",
 	"from": "system",
 	"filament_id": "GFS97",
 	"instantiation": "true",

--- a/resources/profiles/Tiertime/filament/Tiertime Generic BVOH@300HS.json
+++ b/resources/profiles/Tiertime/filament/Tiertime Generic BVOH@300HS.json
@@ -1,7 +1,7 @@
 {
 	"type": "filament",
 	"name": "Tiertime Generic BVOH@300HS",
-	"inherits": "fdm_filament_bvoh",
+	"inherits": "Tiertime Generic BVOH@300HS @base",
 	"from": "system",
 	"filament_id": "GFS97_01",
 	"instantiation": "true",

--- a/resources/profiles/Tiertime/filament/Tiertime Generic EVA.json
+++ b/resources/profiles/Tiertime/filament/Tiertime Generic EVA.json
@@ -1,88 +1,10 @@
 {
 	"type": "filament",
 	"name": "Tiertime Generic EVA",
-	"inherits": "fdm_filament_eva",
+	"inherits": "Tiertime Generic EVA @base",
 	"from": "system",
 	"filament_id": "GFR99",
 	"instantiation": "true",
-	"additional_cooling_fan_speed": [
-		"70"
-	],
-	"close_fan_the_first_x_layers": [
-		"1"
-	],
-	"cool_plate_temp": [
-		"35"
-	],
-	"cool_plate_temp_initial_layer": [
-		"35"
-	],
-	"eng_plate_temp": [
-		"0"
-	],
-	"eng_plate_temp_initial_layer": [
-		"0"
-	],
-	"fan_cooling_layer_time": [
-		"100"
-	],
-	"fan_min_speed": [
-		"100"
-	],
-	"filament_cost": [
-		"21.99"
-	],
-	"filament_density": [
-		"0.94"
-	],
-	"filament_max_volumetric_speed": [
-		"12"
-	],
-	"filament_type": [
-		"EVA"
-	],
-	"hot_plate_temp": [
-		"55"
-	],
-	"hot_plate_temp_initial_layer": [
-		"55"
-	],
-	"nozzle_temperature": [
-		"210"
-	],
-	"nozzle_temperature_initial_layer": [
-		"210"
-	],
-	"nozzle_temperature_range_high": [
-		"220"
-	],
-	"nozzle_temperature_range_low": [
-		"175"
-	],
-	"overhang_fan_threshold": [
-		"50%"
-	],
-	"reduce_fan_stop_start_freq": [
-		"1"
-	],
-	"slow_down_layer_time": [
-		"4"
-	],
-	"slow_down_min_speed": [
-		"20"
-	],
-	"temperature_vitrification": [
-		"70"
-	],
-	"textured_plate_temp": [
-		"55"
-	],
-	"textured_plate_temp_initial_layer": [
-		"55"
-	],
-	"filament_start_gcode": [
-		"; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
-	],
 	"compatible_printers": [
 		"Tiertime UP400 Pro 0.4 nozzle",
 		"Tiertime UP400 Pro 0.6 nozzle",

--- a/resources/profiles/Tiertime/filament/Tiertime Generic EVA@300HS.json
+++ b/resources/profiles/Tiertime/filament/Tiertime Generic EVA@300HS.json
@@ -1,88 +1,10 @@
 {
 	"type": "filament",
 	"name": "Tiertime Generic EVA@300HS",
-	"inherits": "fdm_filament_eva",
+	"inherits": "Tiertime Generic EVA@300HS @base",
 	"from": "system",
 	"filament_id": "GFR99_01",
 	"instantiation": "true",
-	"additional_cooling_fan_speed": [
-		"70"
-	],
-	"close_fan_the_first_x_layers": [
-		"1"
-	],
-	"cool_plate_temp": [
-		"35"
-	],
-	"cool_plate_temp_initial_layer": [
-		"35"
-	],
-	"eng_plate_temp": [
-		"0"
-	],
-	"eng_plate_temp_initial_layer": [
-		"0"
-	],
-	"fan_cooling_layer_time": [
-		"100"
-	],
-	"fan_min_speed": [
-		"100"
-	],
-	"filament_cost": [
-		"21.99"
-	],
-	"filament_density": [
-		"0.94"
-	],
-	"filament_max_volumetric_speed": [
-		"12"
-	],
-	"filament_type": [
-		"EVA"
-	],
-	"hot_plate_temp": [
-		"55"
-	],
-	"hot_plate_temp_initial_layer": [
-		"55"
-	],
-	"nozzle_temperature": [
-		"210"
-	],
-	"nozzle_temperature_initial_layer": [
-		"210"
-	],
-	"nozzle_temperature_range_high": [
-		"220"
-	],
-	"nozzle_temperature_range_low": [
-		"175"
-	],
-	"overhang_fan_threshold": [
-		"50%"
-	],
-	"reduce_fan_stop_start_freq": [
-		"1"
-	],
-	"slow_down_layer_time": [
-		"4"
-	],
-	"slow_down_min_speed": [
-		"20"
-	],
-	"temperature_vitrification": [
-		"70"
-	],
-	"textured_plate_temp": [
-		"55"
-	],
-	"textured_plate_temp_initial_layer": [
-		"55"
-	],
-	"filament_start_gcode": [
-		"; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
-	],
 	"compatible_printers": [
 		"Tiertime UP300 HS 0.4 nozzle",
 		"Tiertime UP600 HS 0.4 nozzle",

--- a/resources/profiles/Tiertime/filament/Tiertime Generic HIPS.json
+++ b/resources/profiles/Tiertime/filament/Tiertime Generic HIPS.json
@@ -1,13 +1,10 @@
 {
 	"type": "filament",
 	"name": "Tiertime Generic HIPS",
-	"inherits": "fdm_filament_hips",
+	"inherits": "Tiertime Generic HIPS @base",
 	"from": "system",
 	"filament_id": "GFS98",
 	"instantiation": "true",
-	"filament_is_support": [
-		"1"
-	],
 	"compatible_printers": [
 		"Tiertime UP400 Pro 0.4 nozzle",
 		"Tiertime UP400 Pro 0.6 nozzle",

--- a/resources/profiles/Tiertime/filament/Tiertime Generic HIPS@300HS.json
+++ b/resources/profiles/Tiertime/filament/Tiertime Generic HIPS@300HS.json
@@ -1,13 +1,10 @@
 {
 	"type": "filament",
 	"name": "Tiertime Generic HIPS@300HS",
-	"inherits": "fdm_filament_hips",
+	"inherits": "Tiertime Generic HIPS@300HS @base",
 	"from": "system",
 	"filament_id": "GFS98_01",
 	"instantiation": "true",
-	"filament_is_support": [
-		"1"
-	],
 	"compatible_printers": [
 		"Tiertime UP300 HS 0.4 nozzle",
 		"Tiertime UP600 HS 0.4 nozzle",

--- a/resources/profiles/Tiertime/filament/Tiertime Generic PA-CF.json
+++ b/resources/profiles/Tiertime/filament/Tiertime Generic PA-CF.json
@@ -1,35 +1,11 @@
 {
 	"type": "filament",
 	"name": "Tiertime Generic PA-CF",
-	"inherits": "fdm_filament_pa",
+	"inherits": "Tiertime Generic PA-CF @base",
 	"from": "system",
-	"filament_id": "GFN98",
 	"setting_id": "GFSN99",
+	"filament_id": "GFN98",
 	"instantiation": "true",
-	"fan_cooling_layer_time": [
-		"5"
-	],
-	"fan_max_speed": [
-		"30"
-	],
-	"fan_min_speed": [
-		"10"
-	],
-	"filament_type": [
-		"PA-CF"
-	],
-	"full_fan_speed_layer": [
-		"2"
-	],
-	"overhang_fan_speed": [
-		"40"
-	],
-	"overhang_fan_threshold": [
-		"0%"
-	],
-	"temperature_vitrification": [
-		"170"
-	],
 	"compatible_printers": [
 		"Tiertime UP400 Pro 0.4 nozzle",
 		"Tiertime UP400 Pro 0.6 nozzle",

--- a/resources/profiles/Tiertime/filament/Tiertime Generic PA-CF@300HS.json
+++ b/resources/profiles/Tiertime/filament/Tiertime Generic PA-CF@300HS.json
@@ -1,35 +1,11 @@
 {
 	"type": "filament",
 	"name": "Tiertime Generic PA-CF@300HS",
-	"inherits": "fdm_filament_pa",
+	"inherits": "Tiertime Generic PA-CF@300HS @base",
 	"from": "system",
-	"filament_id": "GFN98_02",
 	"setting_id": "GFSN99",
+	"filament_id": "GFN98_02",
 	"instantiation": "true",
-	"fan_cooling_layer_time": [
-		"5"
-	],
-	"fan_max_speed": [
-		"30"
-	],
-	"fan_min_speed": [
-		"10"
-	],
-	"filament_type": [
-		"PA-CF"
-	],
-	"full_fan_speed_layer": [
-		"2"
-	],
-	"overhang_fan_speed": [
-		"40"
-	],
-	"overhang_fan_threshold": [
-		"0%"
-	],
-	"temperature_vitrification": [
-		"170"
-	],
 	"compatible_printers": [
 		"Tiertime UP300 HS 0.4 nozzle",
 		"Tiertime UP600 HS 0.4 nozzle",

--- a/resources/profiles/Tiertime/filament/Tiertime Generic PA.json
+++ b/resources/profiles/Tiertime/filament/Tiertime Generic PA.json
@@ -1,53 +1,11 @@
 {
 	"type": "filament",
 	"name": "Tiertime Generic PA",
-	"inherits": "fdm_filament_pa",
+	"inherits": "Tiertime Generic PA @base",
 	"from": "system",
-	"filament_id": "GFN99",
 	"setting_id": "GFSN98",
+	"filament_id": "GFN99",
 	"instantiation": "true",
-	"chamber_temperatures": [
-		"60"
-	],
-	"fan_cooling_layer_time": [
-		"65"
-	],
-	"fan_max_speed": [
-		"85"
-	],
-	"fan_min_speed": [
-		"40"
-	],
-	"filament_max_volumetric_speed": [
-		"12"
-	],
-	"nozzle_temperature": [
-		"260"
-	],
-	"nozzle_temperature_initial_layer": [
-		"260"
-	],
-	"nozzle_temperature_range_high": [
-		"280"
-	],
-	"nozzle_temperature_range_low": [
-		"240"
-	],
-	"overhang_fan_speed": [
-		"95"
-	],
-	"overhang_fan_threshold": [
-		"10%"
-	],
-	"required_nozzle_HRC": [
-		"3"
-	],
-	"slow_down_layer_time": [
-		"8"
-	],
-	"slow_down_min_speed": [
-		"10"
-	],
 	"compatible_printers": [
 		"Tiertime UP400 Pro 0.4 nozzle",
 		"Tiertime UP400 Pro 0.6 nozzle",

--- a/resources/profiles/Tiertime/filament/Tiertime Generic PA@300HS.json
+++ b/resources/profiles/Tiertime/filament/Tiertime Generic PA@300HS.json
@@ -1,53 +1,11 @@
 {
 	"type": "filament",
 	"name": "Tiertime Generic PA@300HS",
-	"inherits": "fdm_filament_pa",
+	"inherits": "Tiertime Generic PA@300HS @base",
 	"from": "system",
-	"filament_id": "GFN99_01",
 	"setting_id": "GFSN98",
+	"filament_id": "GFN99_01",
 	"instantiation": "true",
-	"chamber_temperatures": [
-		"60"
-	],
-	"fan_cooling_layer_time": [
-		"65"
-	],
-	"fan_max_speed": [
-		"85"
-	],
-	"fan_min_speed": [
-		"40"
-	],
-	"filament_max_volumetric_speed": [
-		"12"
-	],
-	"nozzle_temperature": [
-		"260"
-	],
-	"nozzle_temperature_initial_layer": [
-		"260"
-	],
-	"nozzle_temperature_range_high": [
-		"280"
-	],
-	"nozzle_temperature_range_low": [
-		"240"
-	],
-	"overhang_fan_speed": [
-		"95"
-	],
-	"overhang_fan_threshold": [
-		"10%"
-	],
-	"required_nozzle_HRC": [
-		"3"
-	],
-	"slow_down_layer_time": [
-		"8"
-	],
-	"slow_down_min_speed": [
-		"10"
-	],
 	"compatible_printers": [
 		"Tiertime UP300 HS 0.4 nozzle",
 		"Tiertime UP600 HS 0.4 nozzle",

--- a/resources/profiles/Tiertime/filament/Tiertime Generic PC.json
+++ b/resources/profiles/Tiertime/filament/Tiertime Generic PC.json
@@ -1,16 +1,10 @@
 {
 	"type": "filament",
 	"name": "Tiertime Generic PC",
-	"inherits": "fdm_filament_pc",
+	"inherits": "Tiertime Generic PC @base",
 	"from": "system",
 	"filament_id": "GFC99",
 	"instantiation": "true",
-	"filament_max_volumetric_speed": [
-		"16"
-	],
-	"filament_flow_ratio": [
-		"0.94"
-	],
 	"compatible_printers": [
 		"Tiertime UP400 Pro 0.4 nozzle",
 		"Tiertime UP400 Pro 0.6 nozzle",

--- a/resources/profiles/Tiertime/filament/Tiertime Generic PC@300HS.json
+++ b/resources/profiles/Tiertime/filament/Tiertime Generic PC@300HS.json
@@ -1,16 +1,10 @@
 {
 	"type": "filament",
 	"name": "Tiertime Generic PC@300HS",
-	"inherits": "fdm_filament_pc",
+	"inherits": "Tiertime Generic PC@300HS @base",
 	"from": "system",
 	"filament_id": "GFC99_01",
 	"instantiation": "true",
-	"filament_max_volumetric_speed": [
-		"16"
-	],
-	"filament_flow_ratio": [
-		"0.94"
-	],
 	"compatible_printers": [
 		"Tiertime UP300 HS 0.4 nozzle",
 		"Tiertime UP600 HS 0.4 nozzle",

--- a/resources/profiles/Tiertime/filament/Tiertime Generic PCTG.json
+++ b/resources/profiles/Tiertime/filament/Tiertime Generic PCTG.json
@@ -1,76 +1,10 @@
 {
 	"type": "filament",
 	"name": "Tiertime Generic PCTG",
-	"inherits": "fdm_filament_pctg",
+	"inherits": "Tiertime Generic PCTG @base",
 	"from": "system",
 	"filament_id": "GFG97",
 	"instantiation": "true",
-	"cool_plate_temp": [
-		"0"
-	],
-	"cool_plate_temp_initial_layer": [
-		"0"
-	],
-	"eng_plate_temp": [
-		"70"
-	],
-	"eng_plate_temp_initial_layer": [
-		"70"
-	],
-	"fan_cooling_layer_time": [
-		"30"
-	],
-	"fan_max_speed": [
-		"40"
-	],
-	"fan_min_speed": [
-		"10"
-	],
-	"filament_cost": [
-		"28.99"
-	],
-	"filament_density": [
-		"1.29"
-	],
-	"filament_flow_ratio": [
-		"0.95"
-	],
-	"filament_max_volumetric_speed": [
-		"6"
-	],
-	"hot_plate_temp": [
-		"70"
-	],
-	"hot_plate_temp_initial_layer": [
-		"70"
-	],
-	"nozzle_temperature_range_high": [
-		"270"
-	],
-	"nozzle_temperature_range_low": [
-		"240"
-	],
-	"overhang_fan_speed": [
-		"90"
-	],
-	"overhang_fan_threshold": [
-		"10%"
-	],
-	"slow_down_layer_time": [
-		"12"
-	],
-	"temperature_vitrification": [
-		"90"
-	],
-	"textured_plate_temp": [
-		"70"
-	],
-	"textured_plate_temp_initial_layer": [
-		"70"
-	],
-	"filament_start_gcode": [
-		"; filament start gcode\n{if (bed_temperature[current_extruder] >80)||(bed_temperature_initial_layer[current_extruder] >80)}M106 P3 S255\n{elsif (bed_temperature[current_extruder] >60)||(bed_temperature_initial_layer[current_extruder] >60)}M106 P3 S180\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
-	],
 	"compatible_printers": [
 		"Tiertime UP400 Pro 0.4 nozzle",
 		"Tiertime UP400 Pro 0.6 nozzle",

--- a/resources/profiles/Tiertime/filament/Tiertime Generic PCTG@300HS.json
+++ b/resources/profiles/Tiertime/filament/Tiertime Generic PCTG@300HS.json
@@ -1,76 +1,10 @@
 {
 	"type": "filament",
 	"name": "Tiertime Generic PCTG@300HS",
-	"inherits": "fdm_filament_pctg",
+	"inherits": "Tiertime Generic PCTG@300HS @base",
 	"from": "system",
 	"filament_id": "GFG97-01",
 	"instantiation": "true",
-	"cool_plate_temp": [
-		"0"
-	],
-	"cool_plate_temp_initial_layer": [
-		"0"
-	],
-	"eng_plate_temp": [
-		"70"
-	],
-	"eng_plate_temp_initial_layer": [
-		"70"
-	],
-	"fan_cooling_layer_time": [
-		"30"
-	],
-	"fan_max_speed": [
-		"40"
-	],
-	"fan_min_speed": [
-		"10"
-	],
-	"filament_cost": [
-		"28.99"
-	],
-	"filament_density": [
-		"1.29"
-	],
-	"filament_flow_ratio": [
-		"0.95"
-	],
-	"filament_max_volumetric_speed": [
-		"6"
-	],
-	"hot_plate_temp": [
-		"70"
-	],
-	"hot_plate_temp_initial_layer": [
-		"70"
-	],
-	"nozzle_temperature_range_high": [
-		"270"
-	],
-	"nozzle_temperature_range_low": [
-		"240"
-	],
-	"overhang_fan_speed": [
-		"90"
-	],
-	"overhang_fan_threshold": [
-		"10%"
-	],
-	"slow_down_layer_time": [
-		"12"
-	],
-	"temperature_vitrification": [
-		"90"
-	],
-	"textured_plate_temp": [
-		"70"
-	],
-	"textured_plate_temp_initial_layer": [
-		"70"
-	],
-	"filament_start_gcode": [
-		"; filament start gcode\n{if (bed_temperature[current_extruder] >80)||(bed_temperature_initial_layer[current_extruder] >80)}M106 P3 S255\n{elsif (bed_temperature[current_extruder] >60)||(bed_temperature_initial_layer[current_extruder] >60)}M106 P3 S180\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
-	],
 	"compatible_printers": [
 		"Tiertime UP300 HS 0.4 nozzle",
 		"Tiertime UP600 HS 0.4 nozzle",

--- a/resources/profiles/Tiertime/filament/Tiertime Generic PE-CF.json
+++ b/resources/profiles/Tiertime/filament/Tiertime Generic PE-CF.json
@@ -1,40 +1,10 @@
 {
 	"type": "filament",
 	"name": "Tiertime Generic PE-CF",
-	"inherits": "fdm_filament_pe",
+	"inherits": "Tiertime Generic PE-CF @base",
 	"from": "system",
 	"filament_id": "GFP98",
 	"instantiation": "true",
-	"filament_cost": [
-		"65.99"
-	],
-	"filament_density": [
-		"0.95"
-	],
-	"filament_max_volumetric_speed": [
-		"6"
-	],
-	"filament_type": [
-		"PE-CF"
-	],
-	"nozzle_temperature": [
-		"210"
-	],
-	"nozzle_temperature_initial_layer": [
-		"210"
-	],
-	"nozzle_temperature_range_high": [
-		"220"
-	],
-	"nozzle_temperature_range_low": [
-		"175"
-	],
-	"temperature_vitrification": [
-		"70"
-	],
-	"filament_start_gcode": [
-		"; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
-	],
 	"compatible_printers": [
 		"Tiertime UP400 Pro 0.4 nozzle",
 		"Tiertime UP400 Pro 0.6 nozzle",

--- a/resources/profiles/Tiertime/filament/Tiertime Generic PE-CF@300HS.json
+++ b/resources/profiles/Tiertime/filament/Tiertime Generic PE-CF@300HS.json
@@ -1,40 +1,10 @@
 {
 	"type": "filament",
 	"name": "Tiertime Generic PE-CF@300HS",
-	"inherits": "fdm_filament_pe",
+	"inherits": "Tiertime Generic PE-CF@300HS @base",
 	"from": "system",
 	"filament_id": "GFP98_01",
 	"instantiation": "true",
-	"filament_cost": [
-		"65.99"
-	],
-	"filament_density": [
-		"0.95"
-	],
-	"filament_max_volumetric_speed": [
-		"6"
-	],
-	"filament_type": [
-		"PE-CF"
-	],
-	"nozzle_temperature": [
-		"210"
-	],
-	"nozzle_temperature_initial_layer": [
-		"210"
-	],
-	"nozzle_temperature_range_high": [
-		"220"
-	],
-	"nozzle_temperature_range_low": [
-		"175"
-	],
-	"temperature_vitrification": [
-		"70"
-	],
-	"filament_start_gcode": [
-		"; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
-	],
 	"compatible_printers": [
 		"Tiertime UP300 HS 0.4 nozzle",
 		"Tiertime UP600 HS 0.4 nozzle",

--- a/resources/profiles/Tiertime/filament/Tiertime Generic PE.json
+++ b/resources/profiles/Tiertime/filament/Tiertime Generic PE.json
@@ -1,37 +1,10 @@
 {
 	"type": "filament",
 	"name": "Tiertime Generic PE",
-	"inherits": "fdm_filament_pe",
+	"inherits": "Tiertime Generic PE @base",
 	"from": "system",
 	"filament_id": "GFP99",
 	"instantiation": "true",
-	"filament_cost": [
-		"40.99"
-	],
-	"filament_density": [
-		"0.95"
-	],
-	"filament_max_volumetric_speed": [
-		"8"
-	],
-	"nozzle_temperature": [
-		"210"
-	],
-	"nozzle_temperature_initial_layer": [
-		"210"
-	],
-	"nozzle_temperature_range_high": [
-		"220"
-	],
-	"nozzle_temperature_range_low": [
-		"175"
-	],
-	"temperature_vitrification": [
-		"70"
-	],
-	"filament_start_gcode": [
-		"; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
-	],
 	"compatible_printers": [
 		"Tiertime UP400 Pro 0.4 nozzle",
 		"Tiertime UP400 Pro 0.6 nozzle",

--- a/resources/profiles/Tiertime/filament/Tiertime Generic PE@300HS.json
+++ b/resources/profiles/Tiertime/filament/Tiertime Generic PE@300HS.json
@@ -1,37 +1,10 @@
 {
 	"type": "filament",
 	"name": "Tiertime Generic PE@300HS",
-	"inherits": "fdm_filament_pe",
+	"inherits": "Tiertime Generic PE@300HS @base",
 	"from": "system",
 	"filament_id": "GFP99_01",
 	"instantiation": "true",
-	"filament_cost": [
-		"40.99"
-	],
-	"filament_density": [
-		"0.95"
-	],
-	"filament_max_volumetric_speed": [
-		"8"
-	],
-	"nozzle_temperature": [
-		"210"
-	],
-	"nozzle_temperature_initial_layer": [
-		"210"
-	],
-	"nozzle_temperature_range_high": [
-		"220"
-	],
-	"nozzle_temperature_range_low": [
-		"175"
-	],
-	"temperature_vitrification": [
-		"70"
-	],
-	"filament_start_gcode": [
-		"; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
-	],
 	"compatible_printers": [
 		"Tiertime UP300 HS 0.4 nozzle",
 		"Tiertime UP600 HS 0.4 nozzle",

--- a/resources/profiles/Tiertime/filament/Tiertime Generic PETG-CF.json
+++ b/resources/profiles/Tiertime/filament/Tiertime Generic PETG-CF.json
@@ -1,82 +1,10 @@
 {
 	"type": "filament",
 	"name": "Tiertime Generic PETG-CF",
-	"inherits": "fdm_filament_pet",
+	"inherits": "Tiertime Generic PETG-CF @base",
 	"from": "system",
 	"filament_id": "GFG98",
 	"instantiation": "true",
-	"cool_plate_temp": [
-		"0"
-	],
-	"cool_plate_temp_initial_layer": [
-		"0"
-	],
-	"eng_plate_temp": [
-		"70"
-	],
-	"eng_plate_temp_initial_layer": [
-		"70"
-	],
-	"filament_cost": [
-		"34.99"
-	],
-	"filament_density": [
-		"1.25"
-	],
-	"filament_flow_ratio": [
-		"0.95"
-	],
-	"filament_type": [
-		"PETG-CF"
-	],
-	"hot_plate_temp": [
-		"70"
-	],
-	"hot_plate_temp_initial_layer": [
-		"70"
-	],
-	"nozzle_temperature_range_high": [
-		"270"
-	],
-	"nozzle_temperature_range_low": [
-		"240"
-	],
-	"overhang_fan_threshold": [
-		"10%"
-	],
-	"required_nozzle_HRC": [
-		"40"
-	],
-	"slow_down_layer_time": [
-		"6"
-	],
-	"temperature_vitrification": [
-		"70"
-	],
-	"textured_plate_temp": [
-		"70"
-	],
-	"textured_plate_temp_initial_layer": [
-		"70"
-	],
-	"fan_cooling_layer_time": [
-		"30"
-	],
-	"fan_max_speed": [
-		"40"
-	],
-	"fan_min_speed": [
-		"5"
-	],
-	"filament_max_volumetric_speed": [
-		"11.5"
-	],
-	"overhang_fan_speed": [
-		"100"
-	],
-	"filament_start_gcode": [
-		"; filament start gcode\n{if (bed_temperature[current_extruder] >80)||(bed_temperature_initial_layer[current_extruder] >80)}M106 P3 S255\n{elsif (bed_temperature[current_extruder] >60)||(bed_temperature_initial_layer[current_extruder] >60)}M106 P3 S180\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
-	],
 	"compatible_printers": [
 		"Tiertime UP400 Pro 0.4 nozzle",
 		"Tiertime UP400 Pro 0.6 nozzle",

--- a/resources/profiles/Tiertime/filament/Tiertime Generic PETG-CF@300HS.json
+++ b/resources/profiles/Tiertime/filament/Tiertime Generic PETG-CF@300HS.json
@@ -1,82 +1,10 @@
 {
 	"type": "filament",
 	"name": "Tiertime Generic PETG-CF@300HS",
-	"inherits": "fdm_filament_pet",
+	"inherits": "Tiertime Generic PETG-CF@300HS @base",
 	"from": "system",
 	"filament_id": "GFG98_01",
 	"instantiation": "true",
-	"cool_plate_temp": [
-		"0"
-	],
-	"cool_plate_temp_initial_layer": [
-		"0"
-	],
-	"eng_plate_temp": [
-		"70"
-	],
-	"eng_plate_temp_initial_layer": [
-		"70"
-	],
-	"filament_cost": [
-		"34.99"
-	],
-	"filament_density": [
-		"1.25"
-	],
-	"filament_flow_ratio": [
-		"0.95"
-	],
-	"filament_type": [
-		"PETG-CF"
-	],
-	"hot_plate_temp": [
-		"70"
-	],
-	"hot_plate_temp_initial_layer": [
-		"70"
-	],
-	"nozzle_temperature_range_high": [
-		"270"
-	],
-	"nozzle_temperature_range_low": [
-		"240"
-	],
-	"overhang_fan_threshold": [
-		"10%"
-	],
-	"required_nozzle_HRC": [
-		"40"
-	],
-	"slow_down_layer_time": [
-		"6"
-	],
-	"temperature_vitrification": [
-		"70"
-	],
-	"textured_plate_temp": [
-		"70"
-	],
-	"textured_plate_temp_initial_layer": [
-		"70"
-	],
-	"fan_cooling_layer_time": [
-		"30"
-	],
-	"fan_max_speed": [
-		"40"
-	],
-	"fan_min_speed": [
-		"5"
-	],
-	"filament_max_volumetric_speed": [
-		"11.5"
-	],
-	"overhang_fan_speed": [
-		"100"
-	],
-	"filament_start_gcode": [
-		"; filament start gcode\n{if (bed_temperature[current_extruder] >80)||(bed_temperature_initial_layer[current_extruder] >80)}M106 P3 S255\n{elsif (bed_temperature[current_extruder] >60)||(bed_temperature_initial_layer[current_extruder] >60)}M106 P3 S180\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
-	],
 	"compatible_printers": [
 		"Tiertime UP300 HS 0.4 nozzle",
 		"Tiertime UP600 HS 0.4 nozzle",

--- a/resources/profiles/Tiertime/filament/Tiertime Generic PETG.json
+++ b/resources/profiles/Tiertime/filament/Tiertime Generic PETG.json
@@ -1,67 +1,10 @@
 {
 	"type": "filament",
 	"name": "Tiertime Generic PETG",
-	"inherits": "fdm_filament_pet",
+	"inherits": "Tiertime Generic PETG @base",
 	"from": "system",
 	"filament_id": "GFG99",
 	"instantiation": "true",
-	"cool_plate_temp": [
-		"0"
-	],
-	"cool_plate_temp_initial_layer": [
-		"0"
-	],
-	"eng_plate_temp": [
-		"70"
-	],
-	"eng_plate_temp_initial_layer": [
-		"70"
-	],
-	"fan_cooling_layer_time": [
-		"30"
-	],
-	"fan_max_speed": [
-		"90"
-	],
-	"fan_min_speed": [
-		"40"
-	],
-	"filament_flow_ratio": [
-		"0.95"
-	],
-	"filament_max_volumetric_speed": [
-		"12"
-	],
-	"hot_plate_temp": [
-		"70"
-	],
-	"hot_plate_temp_initial_layer": [
-		"70"
-	],
-	"nozzle_temperature_range_high": [
-		"270"
-	],
-	"overhang_fan_speed": [
-		"90"
-	],
-	"overhang_fan_threshold": [
-		"10%"
-	],
-	"slow_down_layer_time": [
-		"12"
-	],
-	"slow_down_min_speed": [
-		"20"
-	],
-	"textured_plate_temp": [
-		"70"
-	],
-	"textured_plate_temp_initial_layer": [
-		"70"
-	],
-	"filament_start_gcode": [
-		"; filament start gcode\n{if (bed_temperature[current_extruder] >80)||(bed_temperature_initial_layer[current_extruder] >80)}M106 P3 S255\n{elsif (bed_temperature[current_extruder] >60)||(bed_temperature_initial_layer[current_extruder] >60)}M106 P3 S180\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
-	],
 	"compatible_printers": [
 		"Tiertime UP400 Pro 0.4 nozzle",
 		"Tiertime UP400 Pro 0.6 nozzle",

--- a/resources/profiles/Tiertime/filament/Tiertime Generic PETG@300HS.json
+++ b/resources/profiles/Tiertime/filament/Tiertime Generic PETG@300HS.json
@@ -1,67 +1,10 @@
 {
 	"type": "filament",
 	"name": "Tiertime Generic PETG@300HS",
-	"inherits": "fdm_filament_pet",
+	"inherits": "Tiertime Generic PETG@300HS @base",
 	"from": "system",
 	"filament_id": "GFG99_01",
 	"instantiation": "true",
-	"cool_plate_temp": [
-		"0"
-	],
-	"cool_plate_temp_initial_layer": [
-		"0"
-	],
-	"eng_plate_temp": [
-		"70"
-	],
-	"eng_plate_temp_initial_layer": [
-		"70"
-	],
-	"fan_cooling_layer_time": [
-		"30"
-	],
-	"fan_max_speed": [
-		"90"
-	],
-	"fan_min_speed": [
-		"40"
-	],
-	"filament_flow_ratio": [
-		"0.95"
-	],
-	"filament_max_volumetric_speed": [
-		"12"
-	],
-	"hot_plate_temp": [
-		"70"
-	],
-	"hot_plate_temp_initial_layer": [
-		"70"
-	],
-	"nozzle_temperature_range_high": [
-		"270"
-	],
-	"overhang_fan_speed": [
-		"90"
-	],
-	"overhang_fan_threshold": [
-		"10%"
-	],
-	"slow_down_layer_time": [
-		"12"
-	],
-	"slow_down_min_speed": [
-		"20"
-	],
-	"textured_plate_temp": [
-		"70"
-	],
-	"textured_plate_temp_initial_layer": [
-		"70"
-	],
-	"filament_start_gcode": [
-		"; filament start gcode\n{if (bed_temperature[current_extruder] >80)||(bed_temperature_initial_layer[current_extruder] >80)}M106 P3 S255\n{elsif (bed_temperature[current_extruder] >60)||(bed_temperature_initial_layer[current_extruder] >60)}M106 P3 S180\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
-	],
 	"compatible_printers": [
 		"Tiertime UP300 HS 0.4 nozzle",
 		"Tiertime UP600 HS 0.4 nozzle",

--- a/resources/profiles/Tiertime/filament/Tiertime Generic PHA.json
+++ b/resources/profiles/Tiertime/filament/Tiertime Generic PHA.json
@@ -1,7 +1,7 @@
 {
 	"type": "filament",
 	"name": "Tiertime Generic PHA",
-	"inherits": "fdm_filament_pha",
+	"inherits": "Tiertime Generic PHA @base",
 	"from": "system",
 	"filament_id": "GFR98",
 	"instantiation": "true",

--- a/resources/profiles/Tiertime/filament/Tiertime Generic PHA@300HS.json
+++ b/resources/profiles/Tiertime/filament/Tiertime Generic PHA@300HS.json
@@ -1,7 +1,7 @@
 {
 	"type": "filament",
 	"name": "Tiertime Generic PHA@300HS",
-	"inherits": "fdm_filament_pha",
+	"inherits": "Tiertime Generic PHA@300HS @base",
 	"from": "system",
 	"filament_id": "GFR98_01",
 	"instantiation": "true",

--- a/resources/profiles/Tiertime/filament/Tiertime Generic PLA High Speed.json
+++ b/resources/profiles/Tiertime/filament/Tiertime Generic PLA High Speed.json
@@ -1,19 +1,10 @@
 {
 	"type": "filament",
 	"name": "Tiertime Generic PLA High Speed",
-	"inherits": "fdm_filament_pla",
+	"inherits": "Tiertime Generic PLA High Speed @base",
 	"from": "system",
 	"filament_id": "GFL95",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"0.98"
-	],
-	"filament_max_volumetric_speed": [
-		"18"
-	],
-	"slow_down_layer_time": [
-		"4"
-	],
 	"compatible_printers": [
 		"Tiertime UP400 Pro 0.4 nozzle",
 		"Tiertime UP400 Pro 0.6 nozzle",

--- a/resources/profiles/Tiertime/filament/Tiertime Generic PLA High Speed@300HS.json
+++ b/resources/profiles/Tiertime/filament/Tiertime Generic PLA High Speed@300HS.json
@@ -1,19 +1,10 @@
 {
 	"type": "filament",
 	"name": "Tiertime Generic PLA High Speed@300HS",
-	"inherits": "fdm_filament_pla",
+	"inherits": "Tiertime Generic PLA High Speed@300HS @base",
 	"from": "system",
 	"filament_id": "GFL95_01",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"0.98"
-	],
-	"filament_max_volumetric_speed": [
-		"18"
-	],
-	"slow_down_layer_time": [
-		"4"
-	],
 	"compatible_printers": [
 		"Tiertime UP300 HS 0.4 nozzle",
 		"Tiertime UP600 HS 0.4 nozzle",

--- a/resources/profiles/Tiertime/filament/Tiertime Generic PLA Silk.json
+++ b/resources/profiles/Tiertime/filament/Tiertime Generic PLA Silk.json
@@ -1,29 +1,14 @@
 {
 	"type": "filament",
 	"name": "Tiertime Generic PLA Silk",
-	"inherits": "fdm_filament_pla",
+	"inherits": "Tiertime Generic PLA Silk @base",
 	"from": "system",
 	"filament_id": "GFL96",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"0.98"
-	],
-	"slow_down_layer_time": [
-		"8"
-	],
-	"filament_max_volumetric_speed": [
-		"7.5"
-	],
-	"filament_retraction_length": [
-		"0.5"
-	],
 	"compatible_printers": [
 		"Tiertime UP400 Pro 0.4 nozzle",
 		"Tiertime UP400 Pro 0.6 nozzle",
 		"Tiertime UP400 Pro 0.8 nozzle",
 		"Tiertime UP310 Pro 0.4 nozzle"
-	],
-	"filament_start_gcode": [
-		"; filament start gcode\n{if  (bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S255\n{elsif(bed_temperature[current_extruder] >35)||(bed_temperature_initial_layer[current_extruder] >35)}M106 P3 S180\n{endif};Prevent PLA from jamming\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
 	]
 }

--- a/resources/profiles/Tiertime/filament/Tiertime Generic PLA Silk@300HS.json
+++ b/resources/profiles/Tiertime/filament/Tiertime Generic PLA Silk@300HS.json
@@ -1,29 +1,14 @@
 {
 	"type": "filament",
 	"name": "Tiertime Generic PLA Silk@300HS",
-	"inherits": "fdm_filament_pla",
+	"inherits": "Tiertime Generic PLA Silk@300HS @base",
 	"from": "system",
 	"filament_id": "GFL96_01",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"0.98"
-	],
-	"slow_down_layer_time": [
-		"8"
-	],
-	"filament_max_volumetric_speed": [
-		"7.5"
-	],
-	"filament_retraction_length": [
-		"0.5"
-	],
 	"compatible_printers": [
 		"Tiertime UP300 HS 0.4 nozzle",
 		"Tiertime UP600 HS 0.4 nozzle",
 		"Tiertime UP600 HS 0.6 nozzle",
 		"Tiertime UP600 HS 0.8 nozzle"
-	],
-	"filament_start_gcode": [
-		"; filament start gcode\n{if  (bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S255\n{elsif(bed_temperature[current_extruder] >35)||(bed_temperature_initial_layer[current_extruder] >35)}M106 P3 S180\n{endif};Prevent PLA from jamming\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
 	]
 }

--- a/resources/profiles/Tiertime/filament/Tiertime Generic PLA-CF.json
+++ b/resources/profiles/Tiertime/filament/Tiertime Generic PLA-CF.json
@@ -1,55 +1,10 @@
 {
 	"type": "filament",
 	"name": "Tiertime Generic PLA-CF",
-	"inherits": "fdm_filament_pla",
+	"inherits": "Tiertime Generic PLA-CF @base",
 	"from": "system",
 	"filament_id": "GFL98",
 	"instantiation": "true",
-	"additional_cooling_fan_speed": [
-		"0"
-	],
-	"cool_plate_temp": [
-		"45"
-	],
-	"cool_plate_temp_initial_layer": [
-		"45"
-	],
-	"filament_flow_ratio": [
-		"0.95"
-	],
-	"filament_type": [
-		"PLA-CF"
-	],
-	"required_nozzle_HRC": [
-		"40"
-	],
-	"slow_down_layer_time": [
-		"7"
-	],
-	"fan_cooling_layer_time": [
-		"80"
-	],
-	"fan_max_speed": [
-		"80"
-	],
-	"fan_min_speed": [
-		"60"
-	],
-	"hot_plate_temp": [
-		"65"
-	],
-	"hot_plate_temp_initial_layer": [
-		"65"
-	],
-	"textured_plate_temp": [
-		"65"
-	],
-	"textured_plate_temp_initial_layer": [
-		"65"
-	],
-	"filament_start_gcode": [
-		"; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
-	],
 	"compatible_printers": [
 		"Tiertime UP400 Pro 0.4 nozzle",
 		"Tiertime UP400 Pro 0.6 nozzle",

--- a/resources/profiles/Tiertime/filament/Tiertime Generic PLA-CF@300HS.json
+++ b/resources/profiles/Tiertime/filament/Tiertime Generic PLA-CF@300HS.json
@@ -1,55 +1,10 @@
 {
 	"type": "filament",
 	"name": "Tiertime Generic PLA-CF@300HS",
-	"inherits": "fdm_filament_pla",
+	"inherits": "Tiertime Generic PLA-CF@300HS @base",
 	"from": "system",
 	"filament_id": "GFL98_01",
 	"instantiation": "true",
-	"additional_cooling_fan_speed": [
-		"0"
-	],
-	"cool_plate_temp": [
-		"45"
-	],
-	"cool_plate_temp_initial_layer": [
-		"45"
-	],
-	"filament_flow_ratio": [
-		"0.95"
-	],
-	"filament_type": [
-		"PLA-CF"
-	],
-	"required_nozzle_HRC": [
-		"40"
-	],
-	"slow_down_layer_time": [
-		"7"
-	],
-	"fan_cooling_layer_time": [
-		"80"
-	],
-	"fan_max_speed": [
-		"80"
-	],
-	"fan_min_speed": [
-		"60"
-	],
-	"hot_plate_temp": [
-		"65"
-	],
-	"hot_plate_temp_initial_layer": [
-		"65"
-	],
-	"textured_plate_temp": [
-		"65"
-	],
-	"textured_plate_temp_initial_layer": [
-		"65"
-	],
-	"filament_start_gcode": [
-		"; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
-	],
 	"compatible_printers": [
 		"Tiertime UP300 HS 0.4 nozzle",
 		"Tiertime UP600 HS 0.4 nozzle",

--- a/resources/profiles/Tiertime/filament/Tiertime Generic PLA.json
+++ b/resources/profiles/Tiertime/filament/Tiertime Generic PLA.json
@@ -1,19 +1,10 @@
 {
 	"type": "filament",
 	"name": "Tiertime Generic PLA",
-	"inherits": "fdm_filament_pla",
+	"inherits": "Tiertime Generic PLA @base",
 	"from": "system",
 	"filament_id": "GFL99",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"0.98"
-	],
-	"slow_down_layer_time": [
-		"8"
-	],
-	"filament_start_gcode": [
-		"; filament start gcode\n{if  (bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S255\n{elsif(bed_temperature[current_extruder] >35)||(bed_temperature_initial_layer[current_extruder] >35)}M106 P3 S180\n{endif};Prevent PLA from jamming\n\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
-	],
 	"compatible_printers": [
 		"Tiertime UP400 Pro 0.4 nozzle",
 		"Tiertime UP400 Pro 0.6 nozzle",

--- a/resources/profiles/Tiertime/filament/Tiertime Generic PLA@300HS.json
+++ b/resources/profiles/Tiertime/filament/Tiertime Generic PLA@300HS.json
@@ -1,19 +1,10 @@
 {
 	"type": "filament",
 	"name": "Tiertime Generic PLA@300HS",
-	"inherits": "fdm_filament_pla",
+	"inherits": "Tiertime Generic PLA@300HS @base",
 	"from": "system",
 	"filament_id": "GFL99_01",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"0.98"
-	],
-	"slow_down_layer_time": [
-		"8"
-	],
-	"filament_start_gcode": [
-		"; filament start gcode\n{if  (bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S255\n{elsif(bed_temperature[current_extruder] >35)||(bed_temperature_initial_layer[current_extruder] >35)}M106 P3 S180\n{endif};Prevent PLA from jamming\n\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
-	],
 	"compatible_printers": [
 		"Tiertime UP300 HS 0.4 nozzle",
 		"Tiertime UP600 HS 0.4 nozzle",

--- a/resources/profiles/Tiertime/filament/Tiertime Generic PP-CF.json
+++ b/resources/profiles/Tiertime/filament/Tiertime Generic PP-CF.json
@@ -1,22 +1,10 @@
 {
 	"type": "filament",
 	"name": "Tiertime Generic PP-CF",
-	"inherits": "fdm_filament_pp",
+	"inherits": "Tiertime Generic PP-CF @base",
 	"from": "system",
 	"filament_id": "GFP96",
 	"instantiation": "true",
-	"filament_cost": [
-		"77.99"
-	],
-	"filament_density": [
-		"1.01"
-	],
-	"filament_max_volumetric_speed": [
-		"6"
-	],
-	"filament_type": [
-		"PP-CF"
-	],
 	"compatible_printers": [
 		"Tiertime UP400 Pro 0.4 nozzle",
 		"Tiertime UP400 Pro 0.6 nozzle",

--- a/resources/profiles/Tiertime/filament/Tiertime Generic PP-CF@300HS.json
+++ b/resources/profiles/Tiertime/filament/Tiertime Generic PP-CF@300HS.json
@@ -1,22 +1,10 @@
 {
 	"type": "filament",
 	"name": "Tiertime Generic PP-CF@300HS",
-	"inherits": "fdm_filament_pp",
+	"inherits": "Tiertime Generic PP-CF@300HS @base",
 	"from": "system",
 	"filament_id": "GFP96_01",
 	"instantiation": "true",
-	"filament_cost": [
-		"77.99"
-	],
-	"filament_density": [
-		"1.01"
-	],
-	"filament_max_volumetric_speed": [
-		"6"
-	],
-	"filament_type": [
-		"PP-CF"
-	],
 	"compatible_printers": [
 		"Tiertime UP300 HS 0.4 nozzle",
 		"Tiertime UP600 HS 0.4 nozzle",

--- a/resources/profiles/Tiertime/filament/Tiertime Generic PP-GF.json
+++ b/resources/profiles/Tiertime/filament/Tiertime Generic PP-GF.json
@@ -1,22 +1,10 @@
 {
 	"type": "filament",
 	"name": "Tiertime Generic PP-GF",
-	"inherits": "fdm_filament_pp",
+	"inherits": "Tiertime Generic PP-GF @base",
 	"from": "system",
 	"filament_id": "GFP95",
 	"instantiation": "true",
-	"filament_cost": [
-		"59.99"
-	],
-	"filament_density": [
-		"1.05"
-	],
-	"filament_max_volumetric_speed": [
-		"6"
-	],
-	"filament_type": [
-		"PP-GF"
-	],
 	"compatible_printers": [
 		"Tiertime UP400 Pro 0.4 nozzle",
 		"Tiertime UP400 Pro 0.6 nozzle",

--- a/resources/profiles/Tiertime/filament/Tiertime Generic PP-GF@300HS.json
+++ b/resources/profiles/Tiertime/filament/Tiertime Generic PP-GF@300HS.json
@@ -1,22 +1,10 @@
 {
 	"type": "filament",
 	"name": "Tiertime Generic PP-GF@300HS",
-	"inherits": "fdm_filament_pp",
+	"inherits": "Tiertime Generic PP-GF@300HS @base",
 	"from": "system",
 	"filament_id": "GFP95_01",
 	"instantiation": "true",
-	"filament_cost": [
-		"59.99"
-	],
-	"filament_density": [
-		"1.05"
-	],
-	"filament_max_volumetric_speed": [
-		"6"
-	],
-	"filament_type": [
-		"PP-GF"
-	],
 	"compatible_printers": [
 		"Tiertime UP300 HS 0.4 nozzle",
 		"Tiertime UP600 HS 0.4 nozzle",

--- a/resources/profiles/Tiertime/filament/Tiertime Generic PP.json
+++ b/resources/profiles/Tiertime/filament/Tiertime Generic PP.json
@@ -1,7 +1,7 @@
 {
 	"type": "filament",
 	"name": "Tiertime Generic PP",
-	"inherits": "fdm_filament_pp",
+	"inherits": "Tiertime Generic PP @base",
 	"from": "system",
 	"filament_id": "GFP97",
 	"instantiation": "true",

--- a/resources/profiles/Tiertime/filament/Tiertime Generic PP@300HS.json
+++ b/resources/profiles/Tiertime/filament/Tiertime Generic PP@300HS.json
@@ -1,7 +1,7 @@
 {
 	"type": "filament",
 	"name": "Tiertime Generic PP@300HS",
-	"inherits": "fdm_filament_pp",
+	"inherits": "Tiertime Generic PP@300HS @base",
 	"from": "system",
 	"filament_id": "GFP97_01",
 	"instantiation": "true",

--- a/resources/profiles/Tiertime/filament/Tiertime Generic PPA-CF.json
+++ b/resources/profiles/Tiertime/filament/Tiertime Generic PPA-CF.json
@@ -1,22 +1,10 @@
 {
 	"type": "filament",
 	"name": "Tiertime Generic PPA-CF",
-	"inherits": "fdm_filament_ppa",
+	"inherits": "Tiertime Generic PPA-CF @base",
 	"from": "system",
 	"filament_id": "GFN97",
 	"instantiation": "true",
-	"filament_type": [
-		"PPA-CF"
-	],
-	"fan_max_speed": [
-		"35"
-	],
-	"filament_max_volumetric_speed": [
-		"6.5"
-	],
-	"overhang_fan_threshold": [
-		"25%"
-	],
 	"compatible_printers": [
 		"Tiertime UP400 Pro 0.4 nozzle",
 		"Tiertime UP400 Pro 0.6 nozzle",

--- a/resources/profiles/Tiertime/filament/Tiertime Generic PPA-CF@300HS.json
+++ b/resources/profiles/Tiertime/filament/Tiertime Generic PPA-CF@300HS.json
@@ -1,22 +1,10 @@
 {
 	"type": "filament",
 	"name": "Tiertime Generic PPA-CF@300HS",
-	"inherits": "fdm_filament_ppa",
+	"inherits": "Tiertime Generic PPA-CF@300HS @base",
 	"from": "system",
 	"filament_id": "GFN97_01",
 	"instantiation": "true",
-	"filament_type": [
-		"PPA-CF"
-	],
-	"fan_max_speed": [
-		"35"
-	],
-	"filament_max_volumetric_speed": [
-		"6.5"
-	],
-	"overhang_fan_threshold": [
-		"25%"
-	],
 	"compatible_printers": [
 		"Tiertime UP300 HS 0.4 nozzle",
 		"Tiertime UP600 HS 0.4 nozzle",

--- a/resources/profiles/Tiertime/filament/Tiertime Generic PPA-GF.json
+++ b/resources/profiles/Tiertime/filament/Tiertime Generic PPA-GF.json
@@ -1,16 +1,10 @@
 {
 	"type": "filament",
 	"name": "Tiertime Generic PPA-GF",
-	"inherits": "fdm_filament_ppa",
+	"inherits": "Tiertime Generic PPA-GF @base",
 	"from": "system",
 	"filament_id": "GFN96",
 	"instantiation": "true",
-	"filament_max_volumetric_speed": [
-		"6"
-	],
-	"filament_type": [
-		"PPA-GF"
-	],
 	"compatible_printers": [
 		"Tiertime UP400 Pro 0.4 nozzle",
 		"Tiertime UP400 Pro 0.6 nozzle",

--- a/resources/profiles/Tiertime/filament/Tiertime Generic PPA-GF@300HS.json
+++ b/resources/profiles/Tiertime/filament/Tiertime Generic PPA-GF@300HS.json
@@ -1,16 +1,10 @@
 {
 	"type": "filament",
 	"name": "Tiertime Generic PPA-GF@300HS",
-	"inherits": "fdm_filament_ppa",
+	"inherits": "Tiertime Generic PPA-GF@300HS @base",
 	"from": "system",
 	"filament_id": "GFN96_01",
 	"instantiation": "true",
-	"filament_max_volumetric_speed": [
-		"6"
-	],
-	"filament_type": [
-		"PPA-GF"
-	],
 	"compatible_printers": [
 		"Tiertime UP300 HS 0.4 nozzle",
 		"Tiertime UP600 HS 0.4 nozzle",

--- a/resources/profiles/Tiertime/filament/Tiertime Generic PPS-CF.json
+++ b/resources/profiles/Tiertime/filament/Tiertime Generic PPS-CF.json
@@ -1,31 +1,10 @@
 {
 	"type": "filament",
 	"name": "Tiertime Generic PPS-CF",
-	"inherits": "fdm_filament_pps",
+	"inherits": "Tiertime Generic PPS-CF @base",
 	"from": "system",
 	"filament_id": "GFT98",
 	"instantiation": "true",
-	"fan_max_speed": [
-		"30"
-	],
-	"filament_density": [
-		"1.3"
-	],
-	"filament_max_volumetric_speed": [
-		"3"
-	],
-	"filament_type": [
-		"PPS-CF"
-	],
-	"nozzle_temperature_range_high": [
-		"350"
-	],
-	"required_nozzle_HRC": [
-		"40"
-	],
-	"temperature_vitrification": [
-		"220"
-	],
 	"compatible_printers": [
 		"Tiertime UP400 Pro 0.4 nozzle",
 		"Tiertime UP400 Pro 0.6 nozzle",

--- a/resources/profiles/Tiertime/filament/Tiertime Generic PPS-CF@300HS.json
+++ b/resources/profiles/Tiertime/filament/Tiertime Generic PPS-CF@300HS.json
@@ -1,31 +1,10 @@
 {
 	"type": "filament",
 	"name": "Tiertime Generic PPS-CF@300HS",
-	"inherits": "fdm_filament_pps",
+	"inherits": "Tiertime Generic PPS-CF@300HS @base",
 	"from": "system",
 	"filament_id": "GFT98_01",
 	"instantiation": "true",
-	"fan_max_speed": [
-		"30"
-	],
-	"filament_density": [
-		"1.3"
-	],
-	"filament_max_volumetric_speed": [
-		"3"
-	],
-	"filament_type": [
-		"PPS-CF"
-	],
-	"nozzle_temperature_range_high": [
-		"350"
-	],
-	"required_nozzle_HRC": [
-		"40"
-	],
-	"temperature_vitrification": [
-		"220"
-	],
 	"compatible_printers": [
 		"Tiertime UP300 HS 0.4 nozzle",
 		"Tiertime UP600 HS 0.4 nozzle",

--- a/resources/profiles/Tiertime/filament/Tiertime Generic PPS.json
+++ b/resources/profiles/Tiertime/filament/Tiertime Generic PPS.json
@@ -1,7 +1,7 @@
 {
 	"type": "filament",
 	"name": "Tiertime Generic PPS",
-	"inherits": "fdm_filament_pps",
+	"inherits": "Tiertime Generic PPS @base",
 	"from": "system",
 	"filament_id": "GFT97",
 	"instantiation": "true",

--- a/resources/profiles/Tiertime/filament/Tiertime Generic PPS@300HS.json
+++ b/resources/profiles/Tiertime/filament/Tiertime Generic PPS@300HS.json
@@ -1,7 +1,7 @@
 {
 	"type": "filament",
 	"name": "Tiertime Generic PPS@300HS",
-	"inherits": "fdm_filament_pps",
+	"inherits": "Tiertime Generic PPS@300HS @base",
 	"from": "system",
 	"filament_id": "GFT97_01",
 	"instantiation": "true",

--- a/resources/profiles/Tiertime/filament/Tiertime Generic PVA.json
+++ b/resources/profiles/Tiertime/filament/Tiertime Generic PVA.json
@@ -1,22 +1,10 @@
 {
 	"type": "filament",
 	"name": "Tiertime Generic PVA",
-	"inherits": "fdm_filament_pva",
+	"inherits": "Tiertime Generic PVA @base",
 	"from": "system",
 	"filament_id": "GFS99",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"0.95"
-	],
-	"filament_max_volumetric_speed": [
-		"16"
-	],
-	"slow_down_layer_time": [
-		"7"
-	],
-	"slow_down_min_speed": [
-		"20"
-	],
 	"compatible_printers": [
 		"Tiertime UP400 Pro 0.4 nozzle",
 		"Tiertime UP400 Pro 0.6 nozzle",

--- a/resources/profiles/Tiertime/filament/Tiertime Generic PVA@300HS.json
+++ b/resources/profiles/Tiertime/filament/Tiertime Generic PVA@300HS.json
@@ -1,22 +1,10 @@
 {
 	"type": "filament",
 	"name": "Tiertime Generic PVA@300HS",
-	"inherits": "fdm_filament_pva",
+	"inherits": "Tiertime Generic PVA@300HS @base",
 	"from": "system",
 	"filament_id": "GFS99_01",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"0.95"
-	],
-	"filament_max_volumetric_speed": [
-		"16"
-	],
-	"slow_down_layer_time": [
-		"7"
-	],
-	"slow_down_min_speed": [
-		"20"
-	],
 	"compatible_printers": [
 		"Tiertime UP300 HS 0.4 nozzle",
 		"Tiertime UP600 HS 0.4 nozzle",

--- a/resources/profiles/Tiertime/filament/Tiertime Generic SBS.json
+++ b/resources/profiles/Tiertime/filament/Tiertime Generic SBS.json
@@ -1,19 +1,10 @@
 {
 	"type": "filament",
 	"name": "Tiertime Generic SBS",
-	"inherits": "fdm_filament_sbs",
+	"inherits": "Tiertime Generic SBS @base",
 	"from": "system",
 	"filament_id": "GFL99",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"0.98"
-	],
-	"slow_down_layer_time": [
-		"4"
-	],
-	"filament_start_gcode": [
-		"; filament start gcode\n{if  (bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S255\n{elsif(bed_temperature[current_extruder] >35)||(bed_temperature_initial_layer[current_extruder] >35)}M106 P3 S180\n{endif};Prevent PLA from jamming\n\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
-	],
 	"compatible_printers": [
 		"Tiertime UP400 Pro 0.4 nozzle",
 		"Tiertime UP400 Pro 0.6 nozzle",

--- a/resources/profiles/Tiertime/filament/Tiertime Generic SBS@300HS.json
+++ b/resources/profiles/Tiertime/filament/Tiertime Generic SBS@300HS.json
@@ -1,19 +1,10 @@
 {
 	"type": "filament",
 	"name": "Tiertime Generic SBS@300HS",
-	"inherits": "fdm_filament_sbs",
+	"inherits": "Tiertime Generic SBS@300HS @base",
 	"from": "system",
 	"filament_id": "GFL99_01",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"0.98"
-	],
-	"slow_down_layer_time": [
-		"4"
-	],
-	"filament_start_gcode": [
-		"; filament start gcode\n{if  (bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S255\n{elsif(bed_temperature[current_extruder] >35)||(bed_temperature_initial_layer[current_extruder] >35)}M106 P3 S180\n{endif};Prevent PLA from jamming\n\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
-	],
 	"compatible_printers": [
 		"Tiertime UP300 HS 0.4 nozzle",
 		"Tiertime UP600 HS 0.4 nozzle",

--- a/resources/profiles/Tiertime/filament/Tiertime Generic TPU.json
+++ b/resources/profiles/Tiertime/filament/Tiertime Generic TPU.json
@@ -1,21 +1,15 @@
 {
 	"type": "filament",
 	"name": "Tiertime Generic TPU",
-	"inherits": "fdm_filament_tpu",
+	"inherits": "Tiertime Generic TPU @base",
 	"from": "system",
-	"filament_id": "GFU99",
 	"setting_id": "GFSR99",
+	"filament_id": "GFU99",
 	"instantiation": "true",
-	"filament_max_volumetric_speed": [
-		"3.2"
-	],
 	"compatible_printers": [
 		"Tiertime UP400 Pro 0.4 nozzle",
 		"Tiertime UP400 Pro 0.6 nozzle",
 		"Tiertime UP400 Pro 0.8 nozzle",
 		"Tiertime UP310 Pro 0.4 nozzle"
-	],
-	"filament_start_gcode": [
-		"; filament start gcode\n{if (bed_temperature[current_extruder] >35)||(bed_temperature_initial_layer[current_extruder] >35)}M106 P3 S255\n{elsif (bed_temperature[current_extruder] >30)||(bed_temperature_initial_layer[current_extruder] >30)}M106 P3 S180\n{endif} \n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
 	]
 }

--- a/resources/profiles/Tiertime/filament/Tiertime Generic TPU@300HS.json
+++ b/resources/profiles/Tiertime/filament/Tiertime Generic TPU@300HS.json
@@ -1,21 +1,15 @@
 {
 	"type": "filament",
 	"name": "Tiertime Generic TPU@300HS",
-	"inherits": "fdm_filament_tpu",
+	"inherits": "Tiertime Generic TPU@300HS @base",
 	"from": "system",
-	"filament_id": "GFU99_01",
 	"setting_id": "GFSR99",
+	"filament_id": "GFU99_01",
 	"instantiation": "true",
-	"filament_max_volumetric_speed": [
-		"3.2"
-	],
 	"compatible_printers": [
 		"Tiertime UP300 HS 0.4 nozzle",
 		"Tiertime UP600 HS 0.4 nozzle",
 		"Tiertime UP600 HS 0.6 nozzle",
 		"Tiertime UP600 HS 0.8 nozzle"
-	],
-	"filament_start_gcode": [
-		"; filament start gcode\n{if (bed_temperature[current_extruder] >35)||(bed_temperature_initial_layer[current_extruder] >35)}M106 P3 S255\n{elsif (bed_temperature[current_extruder] >30)||(bed_temperature_initial_layer[current_extruder] >30)}M106 P3 S180\n{endif} \n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
 	]
 }

--- a/resources/profiles/Tiertime/filament/Tiertime PA6-CF.json
+++ b/resources/profiles/Tiertime/filament/Tiertime PA6-CF.json
@@ -1,49 +1,10 @@
 {
 	"type": "filament",
 	"name": "Tiertime PA6-CF",
-	"inherits": "fdm_filament_pa",
+	"inherits": "Tiertime PA6-CF @base",
 	"from": "system",
 	"filament_id": "GFN05",
 	"instantiation": "true",
-	"fan_cooling_layer_time": [
-		"5"
-	],
-	"fan_max_speed": [
-		"30"
-	],
-	"fan_min_speed": [
-		"10"
-	],
-	"filament_cost": [
-		"79.99"
-	],
-	"filament_density": [
-		"1.10"
-	],
-	"filament_flow_ratio": [
-		"0.96"
-	],
-	"filament_type": [
-		"PA6-CF"
-	],
-	"filament_vendor": [
-		"Tiertime"
-	],
-	"nozzle_temperature": [
-		"275"
-	],
-	"nozzle_temperature_initial_layer": [
-		"275"
-	],
-	"overhang_fan_speed": [
-		"40"
-	],
-	"overhang_fan_threshold": [
-		"0%"
-	],
-	"temperature_vitrification": [
-		"170"
-	],
 	"compatible_printers": [
 		"Tiertime UP400 Pro 0.4 nozzle",
 		"Tiertime UP400 Pro 0.6 nozzle",

--- a/resources/profiles/Tiertime/filament/Tiertime PA6-CF@300HS.json
+++ b/resources/profiles/Tiertime/filament/Tiertime PA6-CF@300HS.json
@@ -1,49 +1,10 @@
 {
 	"type": "filament",
 	"name": "Tiertime PA6-CF@300HS",
-	"inherits": "fdm_filament_pa",
+	"inherits": "Tiertime PA6-CF@300HS @base",
 	"from": "system",
 	"filament_id": "GFN05_01",
 	"instantiation": "true",
-	"fan_cooling_layer_time": [
-		"5"
-	],
-	"fan_max_speed": [
-		"30"
-	],
-	"fan_min_speed": [
-		"10"
-	],
-	"filament_cost": [
-		"79.99"
-	],
-	"filament_density": [
-		"1.10"
-	],
-	"filament_flow_ratio": [
-		"0.96"
-	],
-	"filament_type": [
-		"PA6-CF"
-	],
-	"filament_vendor": [
-		"Tiertime"
-	],
-	"nozzle_temperature": [
-		"275"
-	],
-	"nozzle_temperature_initial_layer": [
-		"275"
-	],
-	"overhang_fan_speed": [
-		"40"
-	],
-	"overhang_fan_threshold": [
-		"0%"
-	],
-	"temperature_vitrification": [
-		"170"
-	],
 	"compatible_printers": [
 		"Tiertime UP300 HS 0.4 nozzle",
 		"Tiertime UP600 HS 0.4 nozzle",

--- a/resources/profiles/Tiertime/filament/Tiertime PC.json
+++ b/resources/profiles/Tiertime/filament/Tiertime PC.json
@@ -1,25 +1,10 @@
 {
 	"type": "filament",
 	"name": "Tiertime PC",
-	"inherits": "fdm_filament_pc",
+	"inherits": "Tiertime PC @base",
 	"from": "system",
 	"filament_id": "GFC00",
 	"instantiation": "true",
-	"filament_vendor": [
-		"Tiertime"
-	],
-	"filament_cost": [
-		"39.99"
-	],
-	"filament_flow_ratio": [
-		"0.94"
-	],
-	"fan_max_speed": [
-		"40"
-	],
-	"slow_down_layer_time": [
-		"12"
-	],
 	"compatible_printers": [
 		"Tiertime UP400 Pro 0.4 nozzle",
 		"Tiertime UP400 Pro 0.6 nozzle",

--- a/resources/profiles/Tiertime/filament/Tiertime PC@300HS.json
+++ b/resources/profiles/Tiertime/filament/Tiertime PC@300HS.json
@@ -1,25 +1,10 @@
 {
 	"type": "filament",
 	"name": "Tiertime PC@300HS",
-	"inherits": "fdm_filament_pc",
+	"inherits": "Tiertime PC@300HS @base",
 	"from": "system",
 	"filament_id": "GFC00_01",
 	"instantiation": "true",
-	"filament_vendor": [
-		"Tiertime"
-	],
-	"filament_cost": [
-		"39.99"
-	],
-	"filament_flow_ratio": [
-		"0.94"
-	],
-	"fan_max_speed": [
-		"40"
-	],
-	"slow_down_layer_time": [
-		"12"
-	],
 	"compatible_printers": [
 		"Tiertime UP300 HS 0.4 nozzle",
 		"Tiertime UP600 HS 0.4 nozzle",

--- a/resources/profiles/Tiertime/filament/Tiertime PET-CF.json
+++ b/resources/profiles/Tiertime/filament/Tiertime PET-CF.json
@@ -1,94 +1,10 @@
 {
 	"type": "filament",
 	"name": "Tiertime PET-CF",
-	"inherits": "fdm_filament_pet",
+	"inherits": "Tiertime PET-CF @base",
 	"from": "system",
 	"filament_id": "GFT01",
 	"instantiation": "true",
-	"cool_plate_temp": [
-		"0"
-	],
-	"cool_plate_temp_initial_layer": [
-		"0"
-	],
-	"eng_plate_temp": [
-		"80"
-	],
-	"eng_plate_temp_initial_layer": [
-		"80"
-	],
-	"fan_cooling_layer_time": [
-		"5"
-	],
-	"fan_max_speed": [
-		"30"
-	],
-	"fan_min_speed": [
-		"10"
-	],
-	"filament_cost": [
-		"84.99"
-	],
-	"filament_density": [
-		"1.29"
-	],
-	"filament_max_volumetric_speed": [
-		"8"
-	],
-	"filament_type": [
-		"PET-CF"
-	],
-	"filament_vendor": [
-		"Tiertime"
-	],
-	"hot_plate_temp": [
-		"100"
-	],
-	"hot_plate_temp_initial_layer": [
-		"100"
-	],
-	"nozzle_temperature": [
-		"270"
-	],
-	"nozzle_temperature_initial_layer": [
-		"270"
-	],
-	"nozzle_temperature_range_high": [
-		"290"
-	],
-	"nozzle_temperature_range_low": [
-		"260"
-	],
-	"overhang_fan_speed": [
-		"40"
-	],
-	"overhang_fan_threshold": [
-		"0%"
-	],
-	"required_nozzle_HRC": [
-		"40"
-	],
-	"slow_down_layer_time": [
-		"2"
-	],
-	"temperature_vitrification": [
-		"185"
-	],
-	"textured_plate_temp": [
-		"100"
-	],
-	"textured_plate_temp_initial_layer": [
-		"100"
-	],
-	"filament_start_gcode": [
-		"; filament start gcode\n{if (bed_temperature[current_extruder] >80)||(bed_temperature_initial_layer[current_extruder] >80)}M106 P3 S255\n{elsif (bed_temperature[current_extruder] >60)||(bed_temperature_initial_layer[current_extruder] >60)}M106 P3 S180\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
-	],
-	"reduce_fan_stop_start_freq": [
-		"0"
-	],
-	"slow_down_min_speed": [
-		"20"
-	],
 	"compatible_printers": [
 		"Tiertime UP400 Pro 0.4 nozzle",
 		"Tiertime UP400 Pro 0.6 nozzle",

--- a/resources/profiles/Tiertime/filament/Tiertime PET-CF@300HS.json
+++ b/resources/profiles/Tiertime/filament/Tiertime PET-CF@300HS.json
@@ -1,94 +1,10 @@
 {
 	"type": "filament",
 	"name": "Tiertime PET-CF@300HS",
-	"inherits": "fdm_filament_pet",
+	"inherits": "Tiertime PET-CF@300HS @base",
 	"from": "system",
 	"filament_id": "GFT01_01",
 	"instantiation": "true",
-	"cool_plate_temp": [
-		"0"
-	],
-	"cool_plate_temp_initial_layer": [
-		"0"
-	],
-	"eng_plate_temp": [
-		"80"
-	],
-	"eng_plate_temp_initial_layer": [
-		"80"
-	],
-	"fan_cooling_layer_time": [
-		"5"
-	],
-	"fan_max_speed": [
-		"30"
-	],
-	"fan_min_speed": [
-		"10"
-	],
-	"filament_cost": [
-		"84.99"
-	],
-	"filament_density": [
-		"1.29"
-	],
-	"filament_max_volumetric_speed": [
-		"8"
-	],
-	"filament_type": [
-		"PET-CF"
-	],
-	"filament_vendor": [
-		"Tiertime"
-	],
-	"hot_plate_temp": [
-		"100"
-	],
-	"hot_plate_temp_initial_layer": [
-		"100"
-	],
-	"nozzle_temperature": [
-		"270"
-	],
-	"nozzle_temperature_initial_layer": [
-		"270"
-	],
-	"nozzle_temperature_range_high": [
-		"290"
-	],
-	"nozzle_temperature_range_low": [
-		"260"
-	],
-	"overhang_fan_speed": [
-		"40"
-	],
-	"overhang_fan_threshold": [
-		"0%"
-	],
-	"required_nozzle_HRC": [
-		"40"
-	],
-	"slow_down_layer_time": [
-		"2"
-	],
-	"temperature_vitrification": [
-		"185"
-	],
-	"textured_plate_temp": [
-		"100"
-	],
-	"textured_plate_temp_initial_layer": [
-		"100"
-	],
-	"filament_start_gcode": [
-		"; filament start gcode\n{if (bed_temperature[current_extruder] >80)||(bed_temperature_initial_layer[current_extruder] >80)}M106 P3 S255\n{elsif (bed_temperature[current_extruder] >60)||(bed_temperature_initial_layer[current_extruder] >60)}M106 P3 S180\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
-	],
-	"reduce_fan_stop_start_freq": [
-		"0"
-	],
-	"slow_down_min_speed": [
-		"20"
-	],
 	"compatible_printers": [
 		"Tiertime UP300 HS 0.4 nozzle",
 		"Tiertime UP600 HS 0.4 nozzle",

--- a/resources/profiles/Tiertime/filament/Tiertime PETG.json
+++ b/resources/profiles/Tiertime/filament/Tiertime PETG.json
@@ -1,86 +1,14 @@
 {
 	"type": "filament",
 	"name": "Tiertime PETG",
-	"inherits": "fdm_filament_pet",
+	"inherits": "Tiertime PETG @base",
 	"from": "system",
 	"filament_id": "GFG00",
 	"instantiation": "true",
-	"cool_plate_temp": [
-		"0"
-	],
-	"cool_plate_temp_initial_layer": [
-		"0"
-	],
-	"eng_plate_temp": [
-		"70"
-	],
-	"eng_plate_temp_initial_layer": [
-		"70"
-	],
-	"fan_cooling_layer_time": [
-		"30"
-	],
-	"fan_max_speed": [
-		"40"
-	],
-	"fan_min_speed": [
-		"10"
-	],
-	"filament_cost": [
-		"24.99"
-	],
-	"filament_density": [
-		"1.25"
-	],
-	"filament_flow_ratio": [
-		"0.95"
-	],
-	"filament_vendor": [
-		"Tiertime"
-	],
-	"hot_plate_temp": [
-		"70"
-	],
-	"hot_plate_temp_initial_layer": [
-		"70"
-	],
-	"nozzle_temperature_range_high": [
-		"270"
-	],
-	"nozzle_temperature_range_low": [
-		"230"
-	],
-	"overhang_fan_speed": [
-		"90"
-	],
-	"overhang_fan_threshold": [
-		"10%"
-	],
-	"slow_down_layer_time": [
-		"12"
-	],
-	"textured_plate_temp": [
-		"70"
-	],
-	"textured_plate_temp_initial_layer": [
-		"70"
-	],
-	"filament_max_volumetric_speed": [
-		"13"
-	],
-	"filament_long_retractions_when_cut": [
-		"1"
-	],
-	"filament_retraction_distances_when_cut": [
-		"18"
-	],
 	"compatible_printers": [
 		"Tiertime UP400 Pro 0.4 nozzle",
 		"Tiertime UP400 Pro 0.6 nozzle",
 		"Tiertime UP400 Pro 0.8 nozzle",
 		"Tiertime UP310 Pro 0.4 nozzle"
-	],
-	"filament_start_gcode": [
-		"; filament start gcode\n{if (bed_temperature[current_extruder] >80)||(bed_temperature_initial_layer[current_extruder] >80)}M106 P3 S255\n{elsif (bed_temperature[current_extruder] >60)||(bed_temperature_initial_layer[current_extruder] >60)}M106 P3 S180\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
 	]
 }

--- a/resources/profiles/Tiertime/filament/Tiertime PETG@300HS.json
+++ b/resources/profiles/Tiertime/filament/Tiertime PETG@300HS.json
@@ -1,86 +1,14 @@
 {
 	"type": "filament",
 	"name": "Tiertime PETG@300HS",
-	"inherits": "fdm_filament_pet",
+	"inherits": "Tiertime PETG@300HS @base",
 	"from": "system",
 	"filament_id": "GFG00_01",
 	"instantiation": "true",
-	"cool_plate_temp": [
-		"0"
-	],
-	"cool_plate_temp_initial_layer": [
-		"0"
-	],
-	"eng_plate_temp": [
-		"70"
-	],
-	"eng_plate_temp_initial_layer": [
-		"70"
-	],
-	"fan_cooling_layer_time": [
-		"30"
-	],
-	"fan_max_speed": [
-		"40"
-	],
-	"fan_min_speed": [
-		"10"
-	],
-	"filament_cost": [
-		"24.99"
-	],
-	"filament_density": [
-		"1.25"
-	],
-	"filament_flow_ratio": [
-		"0.95"
-	],
-	"filament_vendor": [
-		"Tiertime"
-	],
-	"hot_plate_temp": [
-		"70"
-	],
-	"hot_plate_temp_initial_layer": [
-		"70"
-	],
-	"nozzle_temperature_range_high": [
-		"270"
-	],
-	"nozzle_temperature_range_low": [
-		"230"
-	],
-	"overhang_fan_speed": [
-		"90"
-	],
-	"overhang_fan_threshold": [
-		"10%"
-	],
-	"slow_down_layer_time": [
-		"12"
-	],
-	"textured_plate_temp": [
-		"70"
-	],
-	"textured_plate_temp_initial_layer": [
-		"70"
-	],
-	"filament_max_volumetric_speed": [
-		"13"
-	],
-	"filament_long_retractions_when_cut": [
-		"1"
-	],
-	"filament_retraction_distances_when_cut": [
-		"18"
-	],
 	"compatible_printers": [
 		"Tiertime UP300 HS 0.4 nozzle",
 		"Tiertime UP600 HS 0.4 nozzle",
 		"Tiertime UP600 HS 0.6 nozzle",
 		"Tiertime UP600 HS 0.8 nozzle"
-	],
-	"filament_start_gcode": [
-		"; filament start gcode\n{if (bed_temperature[current_extruder] >80)||(bed_temperature_initial_layer[current_extruder] >80)}M106 P3 S255\n{elsif (bed_temperature[current_extruder] >60)||(bed_temperature_initial_layer[current_extruder] >60)}M106 P3 S180\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
 	]
 }

--- a/resources/profiles/Tiertime/filament/Tiertime PLA-CF.json
+++ b/resources/profiles/Tiertime/filament/Tiertime PLA-CF.json
@@ -1,62 +1,14 @@
 {
 	"type": "filament",
 	"name": "Tiertime PLA-CF",
-	"inherits": "fdm_filament_pla",
+	"inherits": "Tiertime PLA-CF @base",
 	"from": "system",
 	"filament_id": "GFA50",
 	"instantiation": "true",
-	"additional_cooling_fan_speed": [
-		"0"
-	],
-	"cool_plate_temp": [
-		"45"
-	],
-	"cool_plate_temp_initial_layer": [
-		"45"
-	],
-	"filament_cost": [
-		"34.99"
-	],
-	"filament_density": [
-		"1.22"
-	],
-	"filament_flow_ratio": [
-		"0.98"
-	],
-	"filament_type": [
-		"PLA-CF"
-	],
-	"filament_vendor": [
-		"Tiertime"
-	],
-	"nozzle_temperature_range_high": [
-		"250"
-	],
-	"nozzle_temperature_range_low": [
-		"210"
-	],
-	"required_nozzle_HRC": [
-		"40"
-	],
-	"slow_down_layer_time": [
-		"8"
-	],
-	"filament_max_volumetric_speed": [
-		"15"
-	],
-	"nozzle_temperature": [
-		"230"
-	],
-	"nozzle_temperature_initial_layer": [
-		"230"
-	],
 	"compatible_printers": [
 		"Tiertime UP400 Pro 0.4 nozzle",
 		"Tiertime UP400 Pro 0.6 nozzle",
 		"Tiertime UP400 Pro 0.8 nozzle",
 		"Tiertime UP310 Pro 0.4 nozzle"
-	],
-	"filament_start_gcode": [
-		"; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\nM142 P1 R35 S40\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
 	]
 }

--- a/resources/profiles/Tiertime/filament/Tiertime PLA-CF@300HS.json
+++ b/resources/profiles/Tiertime/filament/Tiertime PLA-CF@300HS.json
@@ -1,62 +1,14 @@
 {
 	"type": "filament",
 	"name": "Tiertime PLA-CF@300HS",
-	"inherits": "fdm_filament_pla",
+	"inherits": "Tiertime PLA-CF@300HS @base",
 	"from": "system",
 	"filament_id": "GFA50_01",
 	"instantiation": "true",
-	"additional_cooling_fan_speed": [
-		"0"
-	],
-	"cool_plate_temp": [
-		"45"
-	],
-	"cool_plate_temp_initial_layer": [
-		"45"
-	],
-	"filament_cost": [
-		"34.99"
-	],
-	"filament_density": [
-		"1.22"
-	],
-	"filament_flow_ratio": [
-		"0.98"
-	],
-	"filament_type": [
-		"PLA-CF"
-	],
-	"filament_vendor": [
-		"Tiertime"
-	],
-	"nozzle_temperature_range_high": [
-		"250"
-	],
-	"nozzle_temperature_range_low": [
-		"210"
-	],
-	"required_nozzle_HRC": [
-		"40"
-	],
-	"slow_down_layer_time": [
-		"8"
-	],
-	"filament_max_volumetric_speed": [
-		"15"
-	],
-	"nozzle_temperature": [
-		"230"
-	],
-	"nozzle_temperature_initial_layer": [
-		"230"
-	],
 	"compatible_printers": [
 		"Tiertime UP300 HS 0.4 nozzle",
 		"Tiertime UP600 HS 0.4 nozzle",
 		"Tiertime UP600 HS 0.6 nozzle",
 		"Tiertime UP600 HS 0.8 nozzle"
-	],
-	"filament_start_gcode": [
-		"; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\nM142 P1 R35 S40\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
 	]
 }

--- a/resources/profiles/Tiertime/filament/Tiertime PLA.json
+++ b/resources/profiles/Tiertime/filament/Tiertime PLA.json
@@ -1,32 +1,11 @@
 {
 	"type": "filament",
-	"filament_id": "GFA00",
-	"setting_id": "GFSA00",
 	"name": "Tiertime PLA",
+	"inherits": "Tiertime PLA @base",
 	"from": "system",
+	"setting_id": "GFSA00",
+	"filament_id": "GFA00",
 	"instantiation": "true",
-	"inherits": "fdm_filament_pla",
-	"filament_cost": [
-		"24.99"
-	],
-	"filament_density": [
-		"1.26"
-	],
-	"filament_flow_ratio": [
-		"0.98"
-	],
-	"filament_max_volumetric_speed": [
-		"21"
-	],
-	"filament_vendor": [
-		"Tiertime"
-	],
-	"filament_long_retractions_when_cut": [
-		"1"
-	],
-	"filament_retraction_distances_when_cut": [
-		"18"
-	],
 	"compatible_printers": [
 		"Tiertime UP400 Pro 0.4 nozzle",
 		"Tiertime UP400 Pro 0.6 nozzle",

--- a/resources/profiles/Tiertime/filament/Tiertime PLA@300HS.json
+++ b/resources/profiles/Tiertime/filament/Tiertime PLA@300HS.json
@@ -1,32 +1,11 @@
 {
 	"type": "filament",
-	"filament_id": "GFA00_01",
-	"setting_id": "GFSA00",
 	"name": "Tiertime PLA@300HS",
+	"inherits": "Tiertime PLA@300HS @base",
 	"from": "system",
+	"setting_id": "GFSA00",
+	"filament_id": "GFA00_01",
 	"instantiation": "true",
-	"inherits": "fdm_filament_pla",
-	"filament_cost": [
-		"24.99"
-	],
-	"filament_density": [
-		"1.26"
-	],
-	"filament_flow_ratio": [
-		"0.98"
-	],
-	"filament_max_volumetric_speed": [
-		"21"
-	],
-	"filament_vendor": [
-		"Tiertime"
-	],
-	"filament_long_retractions_when_cut": [
-		"1"
-	],
-	"filament_retraction_distances_when_cut": [
-		"18"
-	],
 	"compatible_printers": [
 		"Tiertime UP300 HS 0.4 nozzle",
 		"Tiertime UP600 HS 0.4 nozzle",

--- a/resources/profiles/Tiertime/filament/Tiertime PVA.json
+++ b/resources/profiles/Tiertime/filament/Tiertime PVA.json
@@ -1,40 +1,10 @@
 {
 	"type": "filament",
 	"name": "Tiertime PVA",
-	"inherits": "fdm_filament_pva",
+	"inherits": "Tiertime PVA @base",
 	"from": "system",
 	"filament_id": "GFS04",
 	"instantiation": "true",
-	"filament_cost": [
-		"79.98"
-	],
-	"filament_density": [
-		"1.27"
-	],
-	"filament_max_volumetric_speed": [
-		"6"
-	],
-	"filament_vendor": [
-		"Tiertime"
-	],
-	"nozzle_temperature_range_high": [
-		"250"
-	],
-	"nozzle_temperature_range_low": [
-		"210"
-	],
-	"slow_down_layer_time": [
-		"7"
-	],
-	"slow_down_min_speed": [
-		"20"
-	],
-	"nozzle_temperature": [
-		"240"
-	],
-	"nozzle_temperature_initial_layer": [
-		"240"
-	],
 	"compatible_printers": [
 		"Tiertime UP400 Pro 0.4 nozzle",
 		"Tiertime UP400 Pro 0.6 nozzle",

--- a/resources/profiles/Tiertime/filament/Tiertime PVA@300HS.json
+++ b/resources/profiles/Tiertime/filament/Tiertime PVA@300HS.json
@@ -1,40 +1,10 @@
 {
 	"type": "filament",
 	"name": "Tiertime PVA@300HS",
-	"inherits": "fdm_filament_pva",
+	"inherits": "Tiertime PVA@300HS @base",
 	"from": "system",
 	"filament_id": "GFS04_01",
 	"instantiation": "true",
-	"filament_cost": [
-		"79.98"
-	],
-	"filament_density": [
-		"1.27"
-	],
-	"filament_max_volumetric_speed": [
-		"6"
-	],
-	"filament_vendor": [
-		"Tiertime"
-	],
-	"nozzle_temperature_range_high": [
-		"250"
-	],
-	"nozzle_temperature_range_low": [
-		"210"
-	],
-	"slow_down_layer_time": [
-		"7"
-	],
-	"slow_down_min_speed": [
-		"20"
-	],
-	"nozzle_temperature": [
-		"240"
-	],
-	"nozzle_temperature_initial_layer": [
-		"240"
-	],
 	"compatible_printers": [
 		"Tiertime UP300 HS 0.4 nozzle",
 		"Tiertime UP600 HS 0.4 nozzle",

--- a/resources/profiles/Tiertime/filament/Tiertime TPU 95A.json
+++ b/resources/profiles/Tiertime/filament/Tiertime TPU 95A.json
@@ -1,25 +1,10 @@
 {
 	"type": "filament",
 	"name": "Tiertime TPU 95A",
-	"inherits": "fdm_filament_tpu",
+	"inherits": "Tiertime TPU 95A @base",
 	"from": "system",
 	"filament_id": "GFU01",
 	"instantiation": "true",
-	"filament_vendor": [
-		"Tiertime"
-	],
-	"filament_density": [
-		"1.22"
-	],
-	"nozzle_temperature_initial_layer": [
-		"230"
-	],
-	"filament_cost": [
-		"41.99"
-	],
-	"nozzle_temperature": [
-		"230"
-	],
 	"compatible_printers": [
 		"Tiertime UP400 Pro 0.4 nozzle",
 		"Tiertime UP400 Pro 0.6 nozzle",

--- a/resources/profiles/Tiertime/filament/Tiertime TPU 95A@300HS.json
+++ b/resources/profiles/Tiertime/filament/Tiertime TPU 95A@300HS.json
@@ -1,25 +1,10 @@
 {
 	"type": "filament",
 	"name": "Tiertime TPU 95A@300HS",
-	"inherits": "fdm_filament_tpu",
+	"inherits": "Tiertime TPU 95A@300HS @base",
 	"from": "system",
 	"filament_id": "GFU01_01",
 	"instantiation": "true",
-	"filament_vendor": [
-		"Tiertime"
-	],
-	"filament_density": [
-		"1.22"
-	],
-	"nozzle_temperature_initial_layer": [
-		"230"
-	],
-	"filament_cost": [
-		"41.99"
-	],
-	"nozzle_temperature": [
-		"230"
-	],
 	"compatible_printers": [
 		"Tiertime UP300 HS 0.4 nozzle",
 		"Tiertime UP600 HS 0.4 nozzle",

--- a/resources/profiles/Tiertime/machine/fdm_tiertime_common.json
+++ b/resources/profiles/Tiertime/machine/fdm_tiertime_common.json
@@ -123,9 +123,6 @@
 	"wipe": [
 		"1"
 	],
-	"default_filament_profile": [
-		""
-	],
 	"default_print_profile": "0.20mm Standard @Tiertime UP400 Pro",
 	"bed_exclude_area": [
 		"0x0"


### PR DESCRIPTION
## Summary
- migrate Tiertime filament presets into OrcaFilamentLibrary `@base` / `@System` entries
- update Tiertime vendor-scoped filament presets to inherit from the new library bases while keeping compatibility constraints
- remove the invalid empty `default_filament_profile` reference from the Tiertime common machine profile so vendor validation passes

References #12162

## Verification
- `python3 scripts/orca_extra_profile_check.py --vendor Tiertime --check-filaments --check-materials --check-obsolete-keys`
- `git diff --check`
