### PR TITLE
Migrate Elegoo filaments to OrcaFilamentLibrary

### DIFF
--- a/resources/profiles/Elegoo/filament/EC/Elegoo ASA @EC.json
+++ b/resources/profiles/Elegoo/filament/EC/Elegoo ASA @EC.json
@@ -1,19 +1,10 @@
 {
 	"type": "filament",
 	"name": "Elegoo ASA @EC",
-	"inherits": "Elegoo ASA @base",
+	"inherits": "Elegoo ASA @EC @base",
 	"from": "system",
 	"setting_id": "EASAEC",
 	"instantiation": "true",
-	"pressure_advance": [
-		"0.024"
-	],
-	"nozzle_temperature": [
-		"270"
-	],
-	"nozzle_temperature_initial_layer": [
-		"270"
-	],
 	"compatible_printers": [
 		"Elegoo Centauri 0.4 nozzle",
 		"Elegoo Centauri 0.6 nozzle",

--- a/resources/profiles/Elegoo/filament/EC/Elegoo PETG PRO @EC.json
+++ b/resources/profiles/Elegoo/filament/EC/Elegoo PETG PRO @EC.json
@@ -1,13 +1,10 @@
 {
 	"type": "filament",
 	"name": "Elegoo PETG PRO @EC",
-	"inherits": "Elegoo PETG PRO @base",
+	"inherits": "Elegoo PETG PRO @EC @base",
 	"from": "system",
 	"setting_id": "EPETGPROEC",
 	"instantiation": "true",
-	"pressure_advance": [
-		"0.024"
-	],
 	"compatible_printers": [
 		"Elegoo Centauri 0.4 nozzle",
 		"Elegoo Centauri 0.6 nozzle",

--- a/resources/profiles/Elegoo/filament/EC/Elegoo PLA @EC.json
+++ b/resources/profiles/Elegoo/filament/EC/Elegoo PLA @EC.json
@@ -1,28 +1,10 @@
 {
 	"type": "filament",
 	"name": "Elegoo PLA @EC",
-	"inherits": "Elegoo PLA @base",
+	"inherits": "Elegoo PLA @EC @base",
 	"from": "system",
 	"setting_id": "EPLAEC",
 	"instantiation": "true",
-	"filament_max_volumetric_speed": [
-		"21"
-	],
-	"nozzle_temperature_initial_layer": [
-		"210"
-	],
-	"nozzle_temperature": [
-		"210"
-	],
-	"pressure_advance": [
-		"0.024"
-	],
-	"slow_down_layer_time": [
-		"4"
-	],
-	"filament_start_gcode": [
-		"; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
-	],
 	"compatible_printers": [
 		"Elegoo Centauri 0.4 nozzle",
 		"Elegoo Centauri 0.6 nozzle",

--- a/resources/profiles/Elegoo/filament/EC/Elegoo PLA Matte @EC.json
+++ b/resources/profiles/Elegoo/filament/EC/Elegoo PLA Matte @EC.json
@@ -1,43 +1,10 @@
 {
 	"type": "filament",
 	"name": "Elegoo PLA Matte @EC",
-	"inherits": "Elegoo PLA Matte @base",
+	"inherits": "Elegoo PLA Matte @EC @base",
 	"from": "system",
 	"setting_id": "EPLAMEC",
 	"instantiation": "true",
-	"fan_cooling_layer_time": [
-		"80"
-	],
-	"fan_max_speed": [
-		"80"
-	],
-	"fan_min_speed": [
-		"60"
-	],
-	"filament_max_volumetric_speed": [
-		"16"
-	],
-	"hot_plate_temp": [
-		"60"
-	],
-	"hot_plate_temp_initial_layer": [
-		"60"
-	],
-	"slow_down_layer_time": [
-		"6"
-	],
-	"textured_plate_temp": [
-		"65"
-	],
-	"textured_plate_temp_initial_layer": [
-		"65"
-	],
-	"pressure_advance": [
-		"0.024"
-	],
-	"filament_start_gcode": [
-		"; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
-	],
 	"compatible_printers": [
 		"Elegoo Centauri 0.4 nozzle",
 		"Elegoo Centauri 0.6 nozzle",

--- a/resources/profiles/Elegoo/filament/EC/Elegoo PLA PRO @EC.json
+++ b/resources/profiles/Elegoo/filament/EC/Elegoo PLA PRO @EC.json
@@ -1,22 +1,10 @@
 {
 	"type": "filament",
 	"name": "Elegoo PLA PRO @EC",
-	"inherits": "Elegoo PLA @base",
+	"inherits": "Elegoo PLA PRO @EC @base",
 	"from": "system",
 	"setting_id": "EPLAPROEC",
 	"instantiation": "true",
-	"filament_max_volumetric_speed": [
-		"20"
-	],
-	"pressure_advance": [
-		"0.024"
-	],
-	"slow_down_layer_time": [
-		"6"
-	],
-	"filament_start_gcode": [
-		"; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
-	],
 	"compatible_printers": [
 		"Elegoo Centauri 0.4 nozzle",
 		"Elegoo Centauri 0.6 nozzle",

--- a/resources/profiles/Elegoo/filament/EC/Elegoo PLA Silk @EC.json
+++ b/resources/profiles/Elegoo/filament/EC/Elegoo PLA Silk @EC.json
@@ -1,40 +1,10 @@
 {
 	"type": "filament",
 	"name": "Elegoo PLA Silk @EC",
-	"inherits": "Elegoo PLA Silk @base",
+	"inherits": "Elegoo PLA Silk @EC @base",
 	"from": "system",
 	"setting_id": "EPLASEC",
 	"instantiation": "true",
-	"fan_cooling_layer_time": [
-		"80"
-	],
-	"fan_max_speed": [
-		"80"
-	],
-	"fan_min_speed": [
-		"60"
-	],
-	"hot_plate_temp": [
-		"60"
-	],
-	"hot_plate_temp_initial_layer": [
-		"60"
-	],
-	"slow_down_layer_time": [
-		"8"
-	],
-	"textured_plate_temp": [
-		"65"
-	],
-	"textured_plate_temp_initial_layer": [
-		"65"
-	],
-	"pressure_advance": [
-		"0.024"
-	],
-	"filament_start_gcode": [
-		"; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
-	],
 	"compatible_printers": [
 		"Elegoo Centauri 0.4 nozzle",
 		"Elegoo Centauri 0.6 nozzle",

--- a/resources/profiles/Elegoo/filament/EC/Elegoo PLA+ @EC.json
+++ b/resources/profiles/Elegoo/filament/EC/Elegoo PLA+ @EC.json
@@ -1,22 +1,10 @@
 {
 	"type": "filament",
 	"name": "Elegoo PLA+ @EC",
-	"inherits": "Elegoo PLA @base",
+	"inherits": "Elegoo PLA+ @EC @base",
 	"from": "system",
 	"setting_id": "EPLAPLUSEC",
 	"instantiation": "true",
-	"filament_max_volumetric_speed": [
-		"20"
-	],
-	"pressure_advance": [
-		"0.024"
-	],
-	"slow_down_layer_time": [
-		"6"
-	],
-	"filament_start_gcode": [
-		"; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
-	],
 	"compatible_printers": [
 		"Elegoo Centauri 0.4 nozzle",
 		"Elegoo Centauri 0.6 nozzle",

--- a/resources/profiles/Elegoo/filament/EC/Elegoo Rapid PETG @EC.json
+++ b/resources/profiles/Elegoo/filament/EC/Elegoo Rapid PETG @EC.json
@@ -2,13 +2,10 @@
 	"type": "filament",
 	"name": "Elegoo Rapid PETG @EC",
 	"renamed_from": "Elegoo RAPID PETG @EC",
-	"inherits": "Elegoo Rapid PETG @base",
+	"inherits": "Elegoo Rapid PETG @EC @base",
 	"from": "system",
 	"setting_id": "ERPETGEC",
 	"instantiation": "true",
-	"pressure_advance": [
-		"0.024"
-	],
 	"compatible_printers": [
 		"Elegoo Centauri 0.4 nozzle",
 		"Elegoo Centauri 0.6 nozzle",

--- a/resources/profiles/Elegoo/filament/EC/Elegoo Rapid PLA+ @EC.json
+++ b/resources/profiles/Elegoo/filament/EC/Elegoo Rapid PLA+ @EC.json
@@ -2,43 +2,10 @@
 	"type": "filament",
 	"name": "Elegoo Rapid PLA+ @EC",
 	"renamed_from": "Elegoo RAPID PLA+ @EC",
-	"inherits": "Elegoo Rapid PLA+ @base",
+	"inherits": "Elegoo Rapid PLA+ @EC @base",
 	"from": "system",
 	"setting_id": "ERPLAPLUSEC",
 	"instantiation": "true",
-	"fan_cooling_layer_time": [
-		"80"
-	],
-	"fan_max_speed": [
-		"100"
-	],
-	"fan_min_speed": [
-		"60"
-	],
-	"filament_max_volumetric_speed": [
-		"21"
-	],
-	"hot_plate_temp": [
-		"60"
-	],
-	"hot_plate_temp_initial_layer": [
-		"60"
-	],
-	"slow_down_layer_time": [
-		"4"
-	],
-	"textured_plate_temp": [
-		"60"
-	],
-	"textured_plate_temp_initial_layer": [
-		"60"
-	],
-	"pressure_advance": [
-		"0.024"
-	],
-	"filament_start_gcode": [
-		"; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
-	],
 	"compatible_printers": [
 		"Elegoo Centauri 0.4 nozzle",
 		"Elegoo Centauri 0.6 nozzle",

--- a/resources/profiles/Elegoo/filament/EC/Elegoo TPU 95A @EC.json
+++ b/resources/profiles/Elegoo/filament/EC/Elegoo TPU 95A @EC.json
@@ -1,16 +1,10 @@
 {
 	"type": "filament",
 	"name": "Elegoo TPU 95A @EC",
-	"inherits": "Elegoo TPU 95A @base",
+	"inherits": "Elegoo TPU 95A @EC @base",
 	"from": "system",
 	"setting_id": "ETPU95AEC",
 	"instantiation": "true",
-	"filament_max_volumetric_speed": [
-		"3.2"
-	],
-	"pressure_advance": [
-		"0.024"
-	],
 	"compatible_printers": [
 		"Elegoo Centauri 0.4 nozzle",
 		"Elegoo Centauri 0.6 nozzle",

--- a/resources/profiles/Elegoo/filament/ECC/Elegoo ASA @ECC.json
+++ b/resources/profiles/Elegoo/filament/ECC/Elegoo ASA @ECC.json
@@ -1,19 +1,10 @@
 {
 	"type": "filament",
 	"name": "Elegoo ASA @ECC",
-	"inherits": "Elegoo ASA @base",
+	"inherits": "Elegoo ASA @ECC @base",
 	"from": "system",
 	"setting_id": "EASAECC",
 	"instantiation": "true",
-	"pressure_advance": [
-		"0.024"
-	],
-	"nozzle_temperature": [
-		"270"
-	],
-	"nozzle_temperature_initial_layer": [
-		"270"
-	],
 	"compatible_printers": [
 		"Elegoo Centauri Carbon 0.4 nozzle",
 		"Elegoo Centauri Carbon 0.6 nozzle",

--- a/resources/profiles/Elegoo/filament/ECC/Elegoo PETG PRO @ECC.json
+++ b/resources/profiles/Elegoo/filament/ECC/Elegoo PETG PRO @ECC.json
@@ -1,13 +1,10 @@
 {
 	"type": "filament",
 	"name": "Elegoo PETG PRO @ECC",
-	"inherits": "Elegoo PETG PRO @base",
+	"inherits": "Elegoo PETG PRO @ECC @base",
 	"from": "system",
 	"setting_id": "EPETGPROECC",
 	"instantiation": "true",
-	"pressure_advance": [
-		"0.024"
-	],
 	"compatible_printers": [
 		"Elegoo Centauri Carbon 0.4 nozzle",
 		"Elegoo Centauri Carbon 0.6 nozzle",

--- a/resources/profiles/Elegoo/filament/ECC/Elegoo PLA @ECC.json
+++ b/resources/profiles/Elegoo/filament/ECC/Elegoo PLA @ECC.json
@@ -1,28 +1,10 @@
 {
 	"type": "filament",
 	"name": "Elegoo PLA @ECC",
-	"inherits": "Elegoo PLA @base",
+	"inherits": "Elegoo PLA @ECC @base",
 	"from": "system",
 	"setting_id": "EPLAECC",
 	"instantiation": "true",
-	"filament_max_volumetric_speed": [
-		"21"
-	],
-	"nozzle_temperature_initial_layer": [
-		"210"
-	],
-	"nozzle_temperature": [
-		"210"
-	],
-	"pressure_advance": [
-		"0.024"
-	],
-	"slow_down_layer_time": [
-		"4"
-	],
-	"filament_start_gcode": [
-		"; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
-	],
 	"compatible_printers": [
 		"Elegoo Centauri Carbon 0.4 nozzle",
 		"Elegoo Centauri Carbon 0.6 nozzle",

--- a/resources/profiles/Elegoo/filament/ECC/Elegoo PLA Matte @ECC.json
+++ b/resources/profiles/Elegoo/filament/ECC/Elegoo PLA Matte @ECC.json
@@ -1,43 +1,10 @@
 {
 	"type": "filament",
 	"name": "Elegoo PLA Matte @ECC",
-	"inherits": "Elegoo PLA Matte @base",
+	"inherits": "Elegoo PLA Matte @ECC @base",
 	"from": "system",
 	"setting_id": "EPLAMECC",
 	"instantiation": "true",
-	"fan_cooling_layer_time": [
-		"80"
-	],
-	"fan_max_speed": [
-		"80"
-	],
-	"fan_min_speed": [
-		"60"
-	],
-	"filament_max_volumetric_speed": [
-		"16"
-	],
-	"hot_plate_temp": [
-		"60"
-	],
-	"hot_plate_temp_initial_layer": [
-		"60"
-	],
-	"slow_down_layer_time": [
-		"6"
-	],
-	"textured_plate_temp": [
-		"65"
-	],
-	"textured_plate_temp_initial_layer": [
-		"65"
-	],
-	"pressure_advance": [
-		"0.024"
-	],
-	"filament_start_gcode": [
-		"; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
-	],
 	"compatible_printers": [
 		"Elegoo Centauri Carbon 0.4 nozzle",
 		"Elegoo Centauri Carbon 0.6 nozzle",

--- a/resources/profiles/Elegoo/filament/ECC/Elegoo PLA PRO @ECC.json
+++ b/resources/profiles/Elegoo/filament/ECC/Elegoo PLA PRO @ECC.json
@@ -1,22 +1,10 @@
 {
 	"type": "filament",
 	"name": "Elegoo PLA PRO @ECC",
-	"inherits": "Elegoo PLA @base",
+	"inherits": "Elegoo PLA PRO @ECC @base",
 	"from": "system",
 	"setting_id": "EPLAPROECC",
 	"instantiation": "true",
-	"filament_max_volumetric_speed": [
-		"20"
-	],
-	"pressure_advance": [
-		"0.024"
-	],
-	"slow_down_layer_time": [
-		"6"
-	],
-	"filament_start_gcode": [
-		"; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
-	],
 	"compatible_printers": [
 		"Elegoo Centauri Carbon 0.4 nozzle",
 		"Elegoo Centauri Carbon 0.6 nozzle",

--- a/resources/profiles/Elegoo/filament/ECC/Elegoo PLA Silk @ECC.json
+++ b/resources/profiles/Elegoo/filament/ECC/Elegoo PLA Silk @ECC.json
@@ -1,40 +1,10 @@
 {
 	"type": "filament",
 	"name": "Elegoo PLA Silk @ECC",
-	"inherits": "Elegoo PLA Silk @base",
+	"inherits": "Elegoo PLA Silk @ECC @base",
 	"from": "system",
 	"setting_id": "EPLASECC",
 	"instantiation": "true",
-	"fan_cooling_layer_time": [
-		"80"
-	],
-	"fan_max_speed": [
-		"80"
-	],
-	"fan_min_speed": [
-		"60"
-	],
-	"hot_plate_temp": [
-		"60"
-	],
-	"hot_plate_temp_initial_layer": [
-		"60"
-	],
-	"slow_down_layer_time": [
-		"8"
-	],
-	"textured_plate_temp": [
-		"65"
-	],
-	"textured_plate_temp_initial_layer": [
-		"65"
-	],
-	"pressure_advance": [
-		"0.024"
-	],
-	"filament_start_gcode": [
-		"; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
-	],
 	"compatible_printers": [
 		"Elegoo Centauri Carbon 0.4 nozzle",
 		"Elegoo Centauri Carbon 0.6 nozzle",

--- a/resources/profiles/Elegoo/filament/ECC/Elegoo PLA+ @ECC.json
+++ b/resources/profiles/Elegoo/filament/ECC/Elegoo PLA+ @ECC.json
@@ -1,22 +1,10 @@
 {
 	"type": "filament",
 	"name": "Elegoo PLA+ @ECC",
-	"inherits": "Elegoo PLA @base",
+	"inherits": "Elegoo PLA+ @ECC @base",
 	"from": "system",
 	"setting_id": "EPLAPLUSECC",
 	"instantiation": "true",
-	"filament_max_volumetric_speed": [
-		"20"
-	],
-	"pressure_advance": [
-		"0.024"
-	],
-	"slow_down_layer_time": [
-		"6"
-	],
-	"filament_start_gcode": [
-		"; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
-	],
 	"compatible_printers": [
 		"Elegoo Centauri Carbon 0.4 nozzle",
 		"Elegoo Centauri Carbon 0.6 nozzle",

--- a/resources/profiles/Elegoo/filament/ECC/Elegoo PLA-CF @ECC.json
+++ b/resources/profiles/Elegoo/filament/ECC/Elegoo PLA-CF @ECC.json
@@ -1,43 +1,10 @@
 {
 	"type": "filament",
 	"name": "Elegoo PLA-CF @ECC",
-	"inherits": "Elegoo PLA-CF @base",
+	"inherits": "Elegoo PLA-CF @ECC @base",
 	"from": "system",
 	"setting_id": "EPLACFECC",
 	"instantiation": "true",
-	"fan_cooling_layer_time": [
-		"80"
-	],
-	"fan_max_speed": [
-		"80"
-	],
-	"fan_min_speed": [
-		"60"
-	],
-	"filament_max_volumetric_speed": [
-		"21"
-	],
-	"hot_plate_temp": [
-		"60"
-	],
-	"hot_plate_temp_initial_layer": [
-		"60"
-	],
-	"slow_down_layer_time": [
-		"6"
-	],
-	"textured_plate_temp": [
-		"65"
-	],
-	"textured_plate_temp_initial_layer": [
-		"65"
-	],
-	"pressure_advance": [
-		"0.024"
-	],
-	"filament_start_gcode": [
-		"; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
-	],
 	"compatible_printers": [
 		"Elegoo Centauri Carbon 0.4 nozzle",
 		"Elegoo Centauri Carbon 0.6 nozzle",

--- a/resources/profiles/Elegoo/filament/ECC/Elegoo Rapid PETG @ECC.json
+++ b/resources/profiles/Elegoo/filament/ECC/Elegoo Rapid PETG @ECC.json
@@ -2,13 +2,10 @@
 	"type": "filament",
 	"name": "Elegoo Rapid PETG @ECC",
 	"renamed_from": "Elegoo RAPID PETG @ECC",
-	"inherits": "Elegoo Rapid PETG @base",
+	"inherits": "Elegoo Rapid PETG @ECC @base",
 	"from": "system",
 	"setting_id": "ERPETGECC",
 	"instantiation": "true",
-	"pressure_advance": [
-		"0.024"
-	],
 	"compatible_printers": [
 		"Elegoo Centauri Carbon 0.4 nozzle",
 		"Elegoo Centauri Carbon 0.6 nozzle",

--- a/resources/profiles/Elegoo/filament/ECC/Elegoo Rapid PLA+ @ECC.json
+++ b/resources/profiles/Elegoo/filament/ECC/Elegoo Rapid PLA+ @ECC.json
@@ -2,43 +2,10 @@
 	"type": "filament",
 	"name": "Elegoo Rapid PLA+ @ECC",
 	"renamed_from": "Elegoo RAPID PLA+ @ECC",
-	"inherits": "Elegoo Rapid PLA+ @base",
+	"inherits": "Elegoo Rapid PLA+ @ECC @base",
 	"from": "system",
 	"setting_id": "ERPLAPLUSECC",
 	"instantiation": "true",
-	"fan_cooling_layer_time": [
-		"80"
-	],
-	"fan_max_speed": [
-		"100"
-	],
-	"fan_min_speed": [
-		"60"
-	],
-	"filament_max_volumetric_speed": [
-		"21"
-	],
-	"hot_plate_temp": [
-		"60"
-	],
-	"hot_plate_temp_initial_layer": [
-		"60"
-	],
-	"slow_down_layer_time": [
-		"4"
-	],
-	"textured_plate_temp": [
-		"60"
-	],
-	"textured_plate_temp_initial_layer": [
-		"60"
-	],
-	"pressure_advance": [
-		"0.024"
-	],
-	"filament_start_gcode": [
-		"; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
-	],
 	"compatible_printers": [
 		"Elegoo Centauri Carbon 0.4 nozzle",
 		"Elegoo Centauri Carbon 0.6 nozzle",

--- a/resources/profiles/Elegoo/filament/ECC/Elegoo TPU 95A @ECC.json
+++ b/resources/profiles/Elegoo/filament/ECC/Elegoo TPU 95A @ECC.json
@@ -1,16 +1,10 @@
 {
 	"type": "filament",
 	"name": "Elegoo TPU 95A @ECC",
-	"inherits": "Elegoo TPU 95A @base",
+	"inherits": "Elegoo TPU 95A @ECC @base",
 	"from": "system",
 	"setting_id": "ETPU95AECC",
 	"instantiation": "true",
-	"filament_max_volumetric_speed": [
-		"3.2"
-	],
-	"pressure_advance": [
-		"0.024"
-	],
 	"compatible_printers": [
 		"Elegoo Centauri Carbon 0.4 nozzle",
 		"Elegoo Centauri Carbon 0.6 nozzle",

--- a/resources/profiles/Elegoo/filament/ECC2/Elegoo ABS @ECC2.json
+++ b/resources/profiles/Elegoo/filament/ECC2/Elegoo ABS @ECC2.json
@@ -1,25 +1,10 @@
 {
 	"type": "filament",
 	"name": "Elegoo ABS @ECC2",
-	"inherits": "Elegoo ABS @base",
+	"inherits": "Elegoo ABS @ECC2 @base",
 	"from": "system",
 	"setting_id": "EABSECC2",
 	"instantiation": "true",
-	"fan_max_speed": [
-		"40"
-	],
-	"filament_max_volumetric_speed": [
-		"18"
-	],
-	"pressure_advance": [
-		"0.024"
-	],
-	"nozzle_temperature": [
-		"270"
-	],
-	"nozzle_temperature_initial_layer": [
-		"270"
-	],
 	"compatible_printers": [
 		"Elegoo Centauri Carbon 2 0.4 nozzle",
 		"Elegoo Centauri Carbon 2 0.6 nozzle",

--- a/resources/profiles/Elegoo/filament/ECC2/Elegoo ASA @ECC2.json
+++ b/resources/profiles/Elegoo/filament/ECC2/Elegoo ASA @ECC2.json
@@ -1,19 +1,10 @@
 {
 	"type": "filament",
 	"name": "Elegoo ASA @ECC2",
-	"inherits": "Elegoo ASA @base",
+	"inherits": "Elegoo ASA @ECC2 @base",
 	"from": "system",
 	"setting_id": "EASAECC2",
 	"instantiation": "true",
-	"pressure_advance": [
-		"0.024"
-	],
-	"nozzle_temperature": [
-		"270"
-	],
-	"nozzle_temperature_initial_layer": [
-		"270"
-	],
 	"compatible_printers": [
 		"Elegoo Centauri Carbon 2 0.4 nozzle",
 		"Elegoo Centauri Carbon 2 0.6 nozzle",

--- a/resources/profiles/Elegoo/filament/ECC2/Elegoo PAHT-CF @ECC2.json
+++ b/resources/profiles/Elegoo/filament/ECC2/Elegoo PAHT-CF @ECC2.json
@@ -1,67 +1,10 @@
 {
 	"type": "filament",
 	"name": "Elegoo PAHT-CF @ECC2",
-	"inherits": "Elegoo PAHT @base",
+	"inherits": "Elegoo PAHT-CF @ECC2 @base",
 	"from": "system",
 	"setting_id": "EPAHTCFECC2",
 	"instantiation": "true",
-	"close_fan_the_first_x_layers": [
-		"3"
-	],
-	"fan_cooling_layer_time": [
-		"5"
-	],
-	"fan_max_speed": [
-		"30"
-	],
-	"fan_min_speed": [
-		"10"
-	],
-	"filament_flow_ratio": [
-		"0.96"
-	],
-	"filament_max_volumetric_speed": [
-		"8"
-	],
-	"nozzle_temperature": [
-		"290"
-	],
-	"nozzle_temperature_initial_layer": [
-		"290"
-	],
-	"nozzle_temperature_range_high": [
-		"290"
-	],
-	"nozzle_temperature_range_low": [
-		"260"
-	],
-	"overhang_fan_speed": [
-		"40"
-	],
-	"overhang_fan_threshold": [
-		"0%"
-	],
-	"reduce_fan_stop_start_freq": [
-		"0"
-	],
-	"slow_down_layer_time": [
-		"2"
-	],
-	"slow_down_min_speed": [
-		"10"
-	],
-	"textured_plate_temp": [
-		"100"
-	],
-	"textured_plate_temp_initial_layer": [
-		"100"
-	],
-	"pressure_advance": [
-		"0.024"
-	],
-	"filament_start_gcode": [
-		"; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
-	],
 	"compatible_printers": [
 		"Elegoo Centauri Carbon 2 0.4 nozzle",
 		"Elegoo Centauri Carbon 2 0.6 nozzle",

--- a/resources/profiles/Elegoo/filament/ECC2/Elegoo PC @ECC2.json
+++ b/resources/profiles/Elegoo/filament/ECC2/Elegoo PC @ECC2.json
@@ -1,52 +1,10 @@
 {
 	"type": "filament",
 	"name": "Elegoo PC @ECC2",
-	"inherits": "Elegoo PC @base",
+	"inherits": "Elegoo PC @ECC2 @base",
 	"from": "system",
 	"setting_id": "EPCECC2",
 	"instantiation": "true",
-	"pressure_advance": [
-		"0.024"
-	],
-	"nozzle_temperature": [
-		"270"
-	],
-	"nozzle_temperature_initial_layer": [
-		"270"
-	],
-	"nozzle_temperature_range_high": [
-		"270"
-	],
-	"nozzle_temperature_range_low": [
-		"250"
-	],
-	"overhang_fan_threshold": [
-		"25%"
-	],
-	"slow_down_layer_time": [
-		"6"
-	],
-	"textured_plate_temp": [
-		"100"
-	],
-	"textured_plate_temp_initial_layer": [
-		"100"
-	],
-	"fan_cooling_layer_time": [
-		"30"
-	],
-	"fan_max_speed": [
-		"35"
-	],
-	"fan_min_speed": [
-		"10"
-	],
-	"filament_max_volumetric_speed": [
-		"16"
-	],
-	"filament_start_gcode": [
-		"; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
-	],
 	"compatible_printers": [
 		"Elegoo Centauri Carbon 2 0.4 nozzle",
 		"Elegoo Centauri Carbon 2 0.6 nozzle",

--- a/resources/profiles/Elegoo/filament/ECC2/Elegoo PC-FR @ECC2.json
+++ b/resources/profiles/Elegoo/filament/ECC2/Elegoo PC-FR @ECC2.json
@@ -1,37 +1,10 @@
 {
 	"type": "filament",
 	"name": "Elegoo PC-FR @ECC2",
-	"inherits": "Elegoo PC @base",
+	"inherits": "Elegoo PC-FR @ECC2 @base",
 	"from": "system",
 	"setting_id": "EPCFRECC2",
 	"instantiation": "true",
-	"pressure_advance": [
-		"0.024"
-	],
-	"nozzle_temperature": [
-		"280"
-	],
-	"nozzle_temperature_initial_layer": [
-		"280"
-	],
-	"nozzle_temperature_range_high": [
-		"290"
-	],
-	"nozzle_temperature_range_low": [
-		"260"
-	],
-	"slow_down_layer_time": [
-		"10"
-	],
-	"fan_max_speed": [
-		"40"
-	],
-	"filament_density": [
-		"1.1"
-	],
-	"filament_max_volumetric_speed": [
-		"18"
-	],
 	"compatible_printers": [
 		"Elegoo Centauri Carbon 2 0.4 nozzle",
 		"Elegoo Centauri Carbon 2 0.6 nozzle",

--- a/resources/profiles/Elegoo/filament/ECC2/Elegoo PETG @ECC2.json
+++ b/resources/profiles/Elegoo/filament/ECC2/Elegoo PETG @ECC2.json
@@ -1,25 +1,10 @@
 {
 	"type": "filament",
 	"name": "Elegoo PETG @ECC2",
-	"inherits": "Elegoo PETG @base",
+	"inherits": "Elegoo PETG @ECC2 @base",
 	"from": "system",
 	"setting_id": "EPETGECC2",
 	"instantiation": "true",
-	"pressure_advance": [
-		"0.024"
-	],
-	"overhang_fan_threshold": [
-		"50%"
-	],
-	"nozzle_temperature": [
-		"250"
-	],
-	"nozzle_temperature_initial_layer": [
-		"250"
-	],
-	"filament_max_volumetric_speed": [
-		"11"
-	],
 	"compatible_printers": [
 		"Elegoo Centauri Carbon 2 0.4 nozzle",
 		"Elegoo Centauri Carbon 2 0.6 nozzle",

--- a/resources/profiles/Elegoo/filament/ECC2/Elegoo PETG PRO @ECC2.json
+++ b/resources/profiles/Elegoo/filament/ECC2/Elegoo PETG PRO @ECC2.json
@@ -1,16 +1,10 @@
 {
 	"type": "filament",
 	"name": "Elegoo PETG PRO @ECC2",
-	"inherits": "Elegoo PETG @base",
+	"inherits": "Elegoo PETG PRO @ECC2 @base",
 	"from": "system",
 	"setting_id": "EPETGPROECC2",
 	"instantiation": "true",
-	"pressure_advance": [
-		"0.024"
-	],
-	"overhang_fan_threshold": [
-		"50%"
-	],
 	"compatible_printers": [
 		"Elegoo Centauri Carbon 2 0.4 nozzle",
 		"Elegoo Centauri Carbon 2 0.6 nozzle",

--- a/resources/profiles/Elegoo/filament/ECC2/Elegoo PETG Translucent @ECC2.json
+++ b/resources/profiles/Elegoo/filament/ECC2/Elegoo PETG Translucent @ECC2.json
@@ -1,25 +1,10 @@
 {
 	"type": "filament",
 	"name": "Elegoo PETG Translucent @ECC2",
-	"inherits": "Elegoo PETG @base",
+	"inherits": "Elegoo PETG Translucent @ECC2 @base",
 	"from": "system",
 	"setting_id": "EPETGTRANSECC2",
 	"instantiation": "true",
-	"pressure_advance": [
-		"0.024"
-	],
-	"fan_max_speed": [
-		"35"
-	],
-	"filament_max_volumetric_speed": [
-		"10"
-	],
-	"nozzle_temperature": [
-		"255"
-	],
-	"nozzle_temperature_initial_layer": [
-		"255"
-	],
 	"compatible_printers": [
 		"Elegoo Centauri Carbon 2 0.4 nozzle",
 		"Elegoo Centauri Carbon 2 0.6 nozzle",

--- a/resources/profiles/Elegoo/filament/ECC2/Elegoo PETG-CF @ECC2.json
+++ b/resources/profiles/Elegoo/filament/ECC2/Elegoo PETG-CF @ECC2.json
@@ -1,40 +1,10 @@
 {
 	"type": "filament",
 	"name": "Elegoo PETG-CF @ECC2",
-	"inherits": "Elegoo PETG @base",
+	"inherits": "Elegoo PETG-CF @ECC2 @base",
 	"from": "system",
 	"setting_id": "EPETGCFECC2",
 	"instantiation": "true",
-	"pressure_advance": [
-		"0.024"
-	],
-	"filament_density": [
-		"1.26"
-	],
-	"nozzle_temperature": [
-		"250"
-	],
-	"nozzle_temperature_initial_layer": [
-		"250"
-	],
-	"fan_max_speed": [
-		"40"
-	],
-	"fan_min_speed": [
-		"5"
-	],
-	"filament_max_volumetric_speed": [
-		"15"
-	],
-	"nozzle_temperature_range_low": [
-		"240"
-	],
-	"overhang_fan_speed": [
-		"100"
-	],
-	"slow_down_layer_time": [
-		"6"
-	],
 	"compatible_printers": [
 		"Elegoo Centauri Carbon 2 0.4 nozzle",
 		"Elegoo Centauri Carbon 2 0.6 nozzle",

--- a/resources/profiles/Elegoo/filament/ECC2/Elegoo PETG-GF @ECC2.json
+++ b/resources/profiles/Elegoo/filament/ECC2/Elegoo PETG-GF @ECC2.json
@@ -1,40 +1,10 @@
 {
 	"type": "filament",
 	"name": "Elegoo PETG-GF @ECC2",
-	"inherits": "Elegoo PETG @base",
+	"inherits": "Elegoo PETG-GF @ECC2 @base",
 	"from": "system",
 	"setting_id": "EPETGFECC2",
 	"instantiation": "true",
-	"pressure_advance": [
-		"0.024"
-	],
-	"filament_density": [
-		"1.26"
-	],
-	"nozzle_temperature": [
-		"250"
-	],
-	"nozzle_temperature_initial_layer": [
-		"250"
-	],
-	"fan_max_speed": [
-		"40"
-	],
-	"fan_min_speed": [
-		"5"
-	],
-	"filament_max_volumetric_speed": [
-		"12"
-	],
-	"nozzle_temperature_range_low": [
-		"240"
-	],
-	"overhang_fan_speed": [
-		"100"
-	],
-	"slow_down_layer_time": [
-		"6"
-	],
 	"compatible_printers": [
 		"Elegoo Centauri Carbon 2 0.4 nozzle",
 		"Elegoo Centauri Carbon 2 0.6 nozzle",

--- a/resources/profiles/Elegoo/filament/ECC2/Elegoo PLA @ECC2.json
+++ b/resources/profiles/Elegoo/filament/ECC2/Elegoo PLA @ECC2.json
@@ -1,28 +1,10 @@
 {
 	"type": "filament",
 	"name": "Elegoo PLA @ECC2",
-	"inherits": "Elegoo PLA @base",
+	"inherits": "Elegoo PLA @ECC2 @base",
 	"from": "system",
 	"setting_id": "EPLAECC2",
 	"instantiation": "true",
-	"filament_max_volumetric_speed": [
-		"21"
-	],
-	"nozzle_temperature_initial_layer": [
-		"210"
-	],
-	"nozzle_temperature": [
-		"210"
-	],
-	"pressure_advance": [
-		"0.024"
-	],
-	"slow_down_layer_time": [
-		"4"
-	],
-	"filament_start_gcode": [
-		"; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
-	],
 	"compatible_printers": [
 		"Elegoo Centauri Carbon 2 0.4 nozzle",
 		"Elegoo Centauri Carbon 2 0.6 nozzle",

--- a/resources/profiles/Elegoo/filament/ECC2/Elegoo PLA Basic @ECC2.json
+++ b/resources/profiles/Elegoo/filament/ECC2/Elegoo PLA Basic @ECC2.json
@@ -1,31 +1,10 @@
 {
 	"type": "filament",
 	"name": "Elegoo PLA Basic @ECC2",
-	"inherits": "Elegoo PLA @base",
+	"inherits": "Elegoo PLA Basic @ECC2 @base",
 	"from": "system",
 	"setting_id": "EPLABASICECC2",
 	"instantiation": "true",
-	"nozzle_temperature": [
-		"220"
-	],
-	"nozzle_temperature_initial_layer": [
-		"220"
-	],
-	"nozzle_temperature_range_high": [
-		"230"
-	],
-	"filament_max_volumetric_speed": [
-		"21"
-	],
-	"pressure_advance": [
-		"0.024"
-	],
-	"slow_down_layer_time": [
-		"4"
-	],
-	"filament_start_gcode": [
-		"; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
-	],
 	"compatible_printers": [
 		"Elegoo Centauri Carbon 2 0.4 nozzle",
 		"Elegoo Centauri Carbon 2 0.6 nozzle",

--- a/resources/profiles/Elegoo/filament/ECC2/Elegoo PLA Galaxy @ECC2.json
+++ b/resources/profiles/Elegoo/filament/ECC2/Elegoo PLA Galaxy @ECC2.json
@@ -1,34 +1,10 @@
 {
 	"type": "filament",
 	"name": "Elegoo PLA Galaxy @ECC2",
-	"inherits": "Elegoo PLA @base",
+	"inherits": "Elegoo PLA Galaxy @ECC2 @base",
 	"from": "system",
 	"setting_id": "EPLAGALAXYECC2",
 	"instantiation": "true",
-	"fan_min_speed": [
-		"80"
-	],
-	"filament_max_volumetric_speed": [
-		"18"
-	],
-	"nozzle_temperature": [
-		"220"
-	],
-	"nozzle_temperature_initial_layer": [
-		"220"
-	],
-	"nozzle_temperature_range_high": [
-		"220"
-	],
-	"pressure_advance": [
-		"0.024"
-	],
-	"slow_down_layer_time": [
-		"4"
-	],
-	"filament_start_gcode": [
-		"; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
-	],
 	"compatible_printers": [
 		"Elegoo Centauri Carbon 2 0.4 nozzle",
 		"Elegoo Centauri Carbon 2 0.6 nozzle",

--- a/resources/profiles/Elegoo/filament/ECC2/Elegoo PLA Marble @ECC2.json
+++ b/resources/profiles/Elegoo/filament/ECC2/Elegoo PLA Marble @ECC2.json
@@ -1,34 +1,10 @@
 {
 	"type": "filament",
 	"name": "Elegoo PLA Marble @ECC2",
-	"inherits": "Elegoo PLA @base",
+	"inherits": "Elegoo PLA Marble @ECC2 @base",
 	"from": "system",
 	"setting_id": "EPLAMARBLEECC2",
 	"instantiation": "true",
-	"fan_min_speed": [
-		"80"
-	],
-	"filament_max_volumetric_speed": [
-		"18"
-	],
-	"nozzle_temperature": [
-		"220"
-	],
-	"nozzle_temperature_initial_layer": [
-		"220"
-	],
-	"nozzle_temperature_range_high": [
-		"220"
-	],
-	"pressure_advance": [
-		"0.024"
-	],
-	"slow_down_layer_time": [
-		"4"
-	],
-	"filament_start_gcode": [
-		"; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
-	],
 	"compatible_printers": [
 		"Elegoo Centauri Carbon 2 0.4 nozzle",
 		"Elegoo Centauri Carbon 2 0.6 nozzle",

--- a/resources/profiles/Elegoo/filament/ECC2/Elegoo PLA Matte @ECC2.json
+++ b/resources/profiles/Elegoo/filament/ECC2/Elegoo PLA Matte @ECC2.json
@@ -1,49 +1,10 @@
 {
 	"type": "filament",
 	"name": "Elegoo PLA Matte @ECC2",
-	"inherits": "Elegoo PLA @base",
+	"inherits": "Elegoo PLA Matte @ECC2 @base",
 	"from": "system",
 	"setting_id": "EPLAMECC2",
 	"instantiation": "true",
-	"fan_cooling_layer_time": [
-		"80"
-	],
-	"fan_max_speed": [
-		"80"
-	],
-	"fan_min_speed": [
-		"60"
-	],
-	"filament_max_volumetric_speed": [
-		"16"
-	],
-	"hot_plate_temp": [
-		"60"
-	],
-	"hot_plate_temp_initial_layer": [
-		"60"
-	],
-	"slow_down_layer_time": [
-		"6"
-	],
-	"textured_plate_temp": [
-		"65"
-	],
-	"textured_plate_temp_initial_layer": [
-		"65"
-	],
-	"pressure_advance": [
-		"0.024"
-	],
-	"filament_cost": [
-		"0"
-	],
-	"filament_density": [
-		"1.25"
-	],
-	"filament_start_gcode": [
-		"; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
-	],
 	"compatible_printers": [
 		"Elegoo Centauri Carbon 2 0.4 nozzle",
 		"Elegoo Centauri Carbon 2 0.6 nozzle",

--- a/resources/profiles/Elegoo/filament/ECC2/Elegoo PLA PRO @ECC2.json
+++ b/resources/profiles/Elegoo/filament/ECC2/Elegoo PLA PRO @ECC2.json
@@ -1,22 +1,10 @@
 {
 	"type": "filament",
 	"name": "Elegoo PLA PRO @ECC2",
-	"inherits": "Elegoo PLA @base",
+	"inherits": "Elegoo PLA PRO @ECC2 @base",
 	"from": "system",
 	"setting_id": "EPLAPROECC2",
 	"instantiation": "true",
-	"filament_max_volumetric_speed": [
-		"20"
-	],
-	"pressure_advance": [
-		"0.024"
-	],
-	"slow_down_layer_time": [
-		"6"
-	],
-	"filament_start_gcode": [
-		"; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
-	],
 	"compatible_printers": [
 		"Elegoo Centauri Carbon 2 0.4 nozzle",
 		"Elegoo Centauri Carbon 2 0.6 nozzle",

--- a/resources/profiles/Elegoo/filament/ECC2/Elegoo PLA Silk @ECC2.json
+++ b/resources/profiles/Elegoo/filament/ECC2/Elegoo PLA Silk @ECC2.json
@@ -1,49 +1,10 @@
 {
 	"type": "filament",
 	"name": "Elegoo PLA Silk @ECC2",
-	"inherits": "Elegoo PLA @base",
+	"inherits": "Elegoo PLA Silk @ECC2 @base",
 	"from": "system",
 	"setting_id": "EPLASECC2",
 	"instantiation": "true",
-	"fan_cooling_layer_time": [
-		"80"
-	],
-	"fan_max_speed": [
-		"80"
-	],
-	"fan_min_speed": [
-		"60"
-	],
-	"hot_plate_temp": [
-		"60"
-	],
-	"hot_plate_temp_initial_layer": [
-		"60"
-	],
-	"slow_down_layer_time": [
-		"8"
-	],
-	"textured_plate_temp": [
-		"65"
-	],
-	"textured_plate_temp_initial_layer": [
-		"65"
-	],
-	"pressure_advance": [
-		"0.024"
-	],
-	"filament_density": [
-		"1.32"
-	],
-	"nozzle_temperature": [
-		"230"
-	],
-	"nozzle_temperature_initial_layer": [
-		"230"
-	],
-	"filament_start_gcode": [
-		"; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
-	],
 	"compatible_printers": [
 		"Elegoo Centauri Carbon 2 0.4 nozzle",
 		"Elegoo Centauri Carbon 2 0.6 nozzle",

--- a/resources/profiles/Elegoo/filament/ECC2/Elegoo PLA Sparkle @ECC2.json
+++ b/resources/profiles/Elegoo/filament/ECC2/Elegoo PLA Sparkle @ECC2.json
@@ -1,34 +1,10 @@
 {
 	"type": "filament",
 	"name": "Elegoo PLA Sparkle @ECC2",
-	"inherits": "Elegoo PLA @base",
+	"inherits": "Elegoo PLA Sparkle @ECC2 @base",
 	"from": "system",
 	"setting_id": "EPLASPARKLEECC2",
 	"instantiation": "true",
-	"fan_min_speed": [
-		"80"
-	],
-	"filament_max_volumetric_speed": [
-		"18"
-	],
-	"nozzle_temperature": [
-		"220"
-	],
-	"nozzle_temperature_initial_layer": [
-		"220"
-	],
-	"nozzle_temperature_range_high": [
-		"220"
-	],
-	"pressure_advance": [
-		"0.024"
-	],
-	"slow_down_layer_time": [
-		"4"
-	],
-	"filament_start_gcode": [
-		"; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
-	],
 	"compatible_printers": [
 		"Elegoo Centauri Carbon 2 0.4 nozzle",
 		"Elegoo Centauri Carbon 2 0.6 nozzle",

--- a/resources/profiles/Elegoo/filament/ECC2/Elegoo PLA Wood @ECC2.json
+++ b/resources/profiles/Elegoo/filament/ECC2/Elegoo PLA Wood @ECC2.json
@@ -1,34 +1,10 @@
 {
 	"type": "filament",
 	"name": "Elegoo PLA Wood @ECC2",
-	"inherits": "Elegoo PLA @base",
+	"inherits": "Elegoo PLA Wood @ECC2 @base",
 	"from": "system",
 	"setting_id": "EPLAWOODECC2",
 	"instantiation": "true",
-	"fan_min_speed": [
-		"80"
-	],
-	"filament_max_volumetric_speed": [
-		"15"
-	],
-	"nozzle_temperature": [
-		"220"
-	],
-	"nozzle_temperature_initial_layer": [
-		"220"
-	],
-	"nozzle_temperature_range_low": [
-		"200"
-	],
-	"pressure_advance": [
-		"0.024"
-	],
-	"slow_down_layer_time": [
-		"4"
-	],
-	"filament_start_gcode": [
-		"; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
-	],
 	"compatible_printers": [
 		"Elegoo Centauri Carbon 2 0.4 nozzle",
 		"Elegoo Centauri Carbon 2 0.6 nozzle",

--- a/resources/profiles/Elegoo/filament/ECC2/Elegoo PLA+ @ECC2.json
+++ b/resources/profiles/Elegoo/filament/ECC2/Elegoo PLA+ @ECC2.json
@@ -1,22 +1,10 @@
 {
 	"type": "filament",
 	"name": "Elegoo PLA+ @ECC2",
-	"inherits": "Elegoo PLA @base",
+	"inherits": "Elegoo PLA+ @ECC2 @base",
 	"from": "system",
 	"setting_id": "EPLAPLUSECC2",
 	"instantiation": "true",
-	"filament_max_volumetric_speed": [
-		"20"
-	],
-	"pressure_advance": [
-		"0.024"
-	],
-	"slow_down_layer_time": [
-		"6"
-	],
-	"filament_start_gcode": [
-		"; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
-	],
 	"compatible_printers": [
 		"Elegoo Centauri Carbon 2 0.4 nozzle",
 		"Elegoo Centauri Carbon 2 0.6 nozzle",

--- a/resources/profiles/Elegoo/filament/ECC2/Elegoo PLA-CF @ECC2.json
+++ b/resources/profiles/Elegoo/filament/ECC2/Elegoo PLA-CF @ECC2.json
@@ -1,58 +1,10 @@
 {
 	"type": "filament",
 	"name": "Elegoo PLA-CF @ECC2",
-	"inherits": "Elegoo PLA @base",
+	"inherits": "Elegoo PLA-CF @ECC2 @base",
 	"from": "system",
 	"setting_id": "EPLACFECC2",
 	"instantiation": "true",
-	"fan_cooling_layer_time": [
-		"80"
-	],
-	"fan_max_speed": [
-		"80"
-	],
-	"fan_min_speed": [
-		"60"
-	],
-	"filament_max_volumetric_speed": [
-		"21"
-	],
-	"hot_plate_temp": [
-		"60"
-	],
-	"hot_plate_temp_initial_layer": [
-		"60"
-	],
-	"slow_down_layer_time": [
-		"6"
-	],
-	"textured_plate_temp": [
-		"65"
-	],
-	"textured_plate_temp_initial_layer": [
-		"65"
-	],
-	"pressure_advance": [
-		"0.024"
-	],
-	"additional_cooling_fan_speed": [
-		"0"
-	],
-	"cool_plate_temp": [
-		"45"
-	],
-	"cool_plate_temp_initial_layer": [
-		"45"
-	],
-	"filament_density": [
-		"1.21"
-	],
-	"required_nozzle_HRC": [
-		"40"
-	],
-	"filament_start_gcode": [
-		"; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
-	],
 	"compatible_printers": [
 		"Elegoo Centauri Carbon 2 0.4 nozzle",
 		"Elegoo Centauri Carbon 2 0.6 nozzle",

--- a/resources/profiles/Elegoo/filament/ECC2/Elegoo Rapid PETG @ECC2.json
+++ b/resources/profiles/Elegoo/filament/ECC2/Elegoo Rapid PETG @ECC2.json
@@ -2,31 +2,10 @@
 	"type": "filament",
 	"name": "Elegoo Rapid PETG @ECC2",
 	"renamed_from": "Elegoo RAPID PETG @ECC2",
-	"inherits": "Elegoo PETG @base",
+	"inherits": "Elegoo Rapid PETG @ECC2 @base",
 	"from": "system",
 	"setting_id": "ERPETGECC2",
 	"instantiation": "true",
-	"pressure_advance": [
-		"0.024"
-	],
-	"fan_max_speed": [
-		"80"
-	],
-	"fan_min_speed": [
-		"30"
-	],
-	"filament_density": [
-		"1.26"
-	],
-	"filament_max_volumetric_speed": [
-		"18"
-	],
-	"nozzle_temperature": [
-		"250"
-	],
-	"nozzle_temperature_initial_layer": [
-		"250"
-	],
 	"compatible_printers": [
 		"Elegoo Centauri Carbon 2 0.4 nozzle",
 		"Elegoo Centauri Carbon 2 0.6 nozzle",

--- a/resources/profiles/Elegoo/filament/ECC2/Elegoo Rapid PLA+ @ECC2.json
+++ b/resources/profiles/Elegoo/filament/ECC2/Elegoo Rapid PLA+ @ECC2.json
@@ -2,46 +2,10 @@
 	"type": "filament",
 	"name": "Elegoo Rapid PLA+ @ECC2",
 	"renamed_from": "Elegoo RAPID PLA+ @ECC2",
-	"inherits": "Elegoo PLA @base",
+	"inherits": "Elegoo Rapid PLA+ @ECC2 @base",
 	"from": "system",
 	"setting_id": "ERPLAPLUSECC2",
 	"instantiation": "true",
-	"fan_cooling_layer_time": [
-		"80"
-	],
-	"fan_max_speed": [
-		"100"
-	],
-	"fan_min_speed": [
-		"60"
-	],
-	"hot_plate_temp": [
-		"60"
-	],
-	"hot_plate_temp_initial_layer": [
-		"60"
-	],
-	"slow_down_layer_time": [
-		"4"
-	],
-	"textured_plate_temp": [
-		"60"
-	],
-	"textured_plate_temp_initial_layer": [
-		"60"
-	],
-	"pressure_advance": [
-		"0.024"
-	],
-	"filament_max_volumetric_speed": [
-		"21"
-	],
-	"filament_density": [
-		"1.25"
-	],
-	"filament_start_gcode": [
-		"; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
-	],
 	"compatible_printers": [
 		"Elegoo Centauri Carbon 2 0.4 nozzle",
 		"Elegoo Centauri Carbon 2 0.6 nozzle",

--- a/resources/profiles/Elegoo/filament/ECC2/Elegoo Rapid TPU 95A @ECC2.json
+++ b/resources/profiles/Elegoo/filament/ECC2/Elegoo Rapid TPU 95A @ECC2.json
@@ -2,25 +2,10 @@
 	"type": "filament",
 	"name": "Elegoo Rapid TPU 95A @ECC2",
 	"renamed_from": "Elegoo RAPID TPU 95A @ECC2",
-	"inherits": "Elegoo TPU @base",
+	"inherits": "Elegoo Rapid TPU 95A @ECC2 @base",
 	"from": "system",
 	"setting_id": "ERTPU95AECC2",
 	"instantiation": "true",
-	"pressure_advance": [
-		"0.024"
-	],
-	"nozzle_temperature": [
-		"230"
-	],
-	"nozzle_temperature_initial_layer": [
-		"230"
-	],
-	"nozzle_temperature_range_high": [
-		"230"
-	],
-	"filament_max_volumetric_speed": [
-		"12"
-	],
 	"compatible_printers": [
 		"Elegoo Centauri Carbon 2 0.4 nozzle",
 		"Elegoo Centauri Carbon 2 0.6 nozzle",

--- a/resources/profiles/Elegoo/filament/ECC2/Elegoo TPU 95A @ECC2.json
+++ b/resources/profiles/Elegoo/filament/ECC2/Elegoo TPU 95A @ECC2.json
@@ -1,16 +1,10 @@
 {
 	"type": "filament",
 	"name": "Elegoo TPU 95A @ECC2",
-	"inherits": "Elegoo TPU @base",
+	"inherits": "Elegoo TPU 95A @ECC2 @base",
 	"from": "system",
 	"setting_id": "ETPU95AECC2",
 	"instantiation": "true",
-	"filament_max_volumetric_speed": [
-		"3.2"
-	],
-	"pressure_advance": [
-		"0.024"
-	],
 	"compatible_printers": [
 		"Elegoo Centauri Carbon 2 0.4 nozzle",
 		"Elegoo Centauri Carbon 2 0.6 nozzle",

--- a/resources/profiles/Elegoo/filament/ELEGOO/Elegoo ABS @0.2 nozzle.json
+++ b/resources/profiles/Elegoo/filament/ELEGOO/Elegoo ABS @0.2 nozzle.json
@@ -1,25 +1,10 @@
 {
 	"type": "filament",
 	"name": "Elegoo ABS @0.2 nozzle",
-	"inherits": "Elegoo ABS @base",
+	"inherits": "Elegoo ABS @0.2 nozzle @base",
 	"from": "system",
 	"setting_id": "EABS00020",
 	"instantiation": "true",
-	"fan_max_speed": [
-		"40"
-	],
-	"filament_max_volumetric_speed": [
-		"18"
-	],
-	"pressure_advance": [
-		"0.024"
-	],
-	"nozzle_temperature": [
-		"270"
-	],
-	"nozzle_temperature_initial_layer": [
-		"270"
-	],
 	"compatible_printers": [
 		"Elegoo Centauri 0.2 nozzle",
 		"Elegoo Centauri Carbon 0.2 nozzle",

--- a/resources/profiles/Elegoo/filament/ELEGOO/Elegoo ASA @0.2 nozzle.json
+++ b/resources/profiles/Elegoo/filament/ELEGOO/Elegoo ASA @0.2 nozzle.json
@@ -1,13 +1,10 @@
 {
 	"type": "filament",
 	"name": "Elegoo ASA @0.2 nozzle",
-	"inherits": "Elegoo ASA @base",
+	"inherits": "Elegoo ASA @0.2 nozzle @base",
 	"from": "system",
 	"setting_id": "EASA00020",
 	"instantiation": "true",
-	"filament_max_volumetric_speed": [
-		"3.2"
-	],
 	"compatible_printers": [
 		"Elegoo Centauri 0.2 nozzle",
 		"Elegoo Centauri Carbon 0.2 nozzle",

--- a/resources/profiles/Elegoo/filament/ELEGOO/Elegoo PC @0.2 nozzle.json
+++ b/resources/profiles/Elegoo/filament/ELEGOO/Elegoo PC @0.2 nozzle.json
@@ -1,52 +1,10 @@
 {
 	"type": "filament",
 	"name": "Elegoo PC @0.2 nozzle",
-	"inherits": "Elegoo PC @base",
+	"inherits": "Elegoo PC @0.2 nozzle @base",
 	"from": "system",
 	"setting_id": "EPC00020",
 	"instantiation": "true",
-	"pressure_advance": [
-		"0.024"
-	],
-	"nozzle_temperature": [
-		"270"
-	],
-	"nozzle_temperature_initial_layer": [
-		"270"
-	],
-	"nozzle_temperature_range_high": [
-		"270"
-	],
-	"nozzle_temperature_range_low": [
-		"250"
-	],
-	"overhang_fan_threshold": [
-		"25%"
-	],
-	"slow_down_layer_time": [
-		"6"
-	],
-	"textured_plate_temp": [
-		"100"
-	],
-	"textured_plate_temp_initial_layer": [
-		"100"
-	],
-	"fan_cooling_layer_time": [
-		"30"
-	],
-	"fan_max_speed": [
-		"35"
-	],
-	"fan_min_speed": [
-		"10"
-	],
-	"filament_max_volumetric_speed": [
-		"16"
-	],
-	"filament_start_gcode": [
-		"; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
-	],
 	"compatible_printers": [
 		"Elegoo Centauri 0.2 nozzle",
 		"Elegoo Centauri Carbon 0.2 nozzle",

--- a/resources/profiles/Elegoo/filament/ELEGOO/Elegoo PC-FR @0.2 nozzle.json
+++ b/resources/profiles/Elegoo/filament/ELEGOO/Elegoo PC-FR @0.2 nozzle.json
@@ -1,37 +1,10 @@
 {
 	"type": "filament",
 	"name": "Elegoo PC-FR @0.2 nozzle",
-	"inherits": "Elegoo PC @base",
+	"inherits": "Elegoo PC-FR @0.2 nozzle @base",
 	"from": "system",
 	"setting_id": "EPCFR00020",
 	"instantiation": "true",
-	"pressure_advance": [
-		"0.024"
-	],
-	"nozzle_temperature": [
-		"280"
-	],
-	"nozzle_temperature_initial_layer": [
-		"280"
-	],
-	"nozzle_temperature_range_high": [
-		"290"
-	],
-	"nozzle_temperature_range_low": [
-		"260"
-	],
-	"slow_down_layer_time": [
-		"10"
-	],
-	"fan_max_speed": [
-		"40"
-	],
-	"filament_density": [
-		"1.1"
-	],
-	"filament_max_volumetric_speed": [
-		"18"
-	],
 	"compatible_printers": [
 		"Elegoo Centauri 0.2 nozzle",
 		"Elegoo Centauri Carbon 0.2 nozzle",

--- a/resources/profiles/Elegoo/filament/ELEGOO/Elegoo PETG @0.2 nozzle.json
+++ b/resources/profiles/Elegoo/filament/ELEGOO/Elegoo PETG @0.2 nozzle.json
@@ -1,25 +1,10 @@
 {
 	"type": "filament",
 	"name": "Elegoo PETG @0.2 nozzle",
-	"inherits": "Elegoo PETG @base",
+	"inherits": "Elegoo PETG @0.2 nozzle @base",
 	"from": "system",
 	"setting_id": "EPETG00020",
 	"instantiation": "true",
-	"pressure_advance": [
-		"0.024"
-	],
-	"overhang_fan_threshold": [
-		"50%"
-	],
-	"nozzle_temperature": [
-		"250"
-	],
-	"nozzle_temperature_initial_layer": [
-		"250"
-	],
-	"filament_max_volumetric_speed": [
-		"11"
-	],
 	"compatible_printers": [
 		"Elegoo Centauri 0.2 nozzle",
 		"Elegoo Centauri Carbon 0.2 nozzle",

--- a/resources/profiles/Elegoo/filament/ELEGOO/Elegoo PETG PRO @0.2 nozzle.json
+++ b/resources/profiles/Elegoo/filament/ELEGOO/Elegoo PETG PRO @0.2 nozzle.json
@@ -1,13 +1,10 @@
 {
 	"type": "filament",
 	"name": "Elegoo PETG PRO @0.2 nozzle",
-	"inherits": "Elegoo PETG PRO @base",
+	"inherits": "Elegoo PETG PRO @0.2 nozzle @base",
 	"from": "system",
 	"setting_id": "EGPETG00020",
 	"instantiation": "true",
-	"filament_max_volumetric_speed": [
-		"1"
-	],
 	"compatible_printers": [
 		"Elegoo Centauri 0.2 nozzle",
 		"Elegoo Centauri Carbon 0.2 nozzle",

--- a/resources/profiles/Elegoo/filament/ELEGOO/Elegoo PETG Translucent @0.2 nozzle.json
+++ b/resources/profiles/Elegoo/filament/ELEGOO/Elegoo PETG Translucent @0.2 nozzle.json
@@ -1,25 +1,10 @@
 {
 	"type": "filament",
 	"name": "Elegoo PETG Translucent @0.2 nozzle",
-	"inherits": "Elegoo PETG @base",
+	"inherits": "Elegoo PETG Translucent @0.2 nozzle @base",
 	"from": "system",
 	"setting_id": "EPETGTRAN00020",
 	"instantiation": "true",
-	"pressure_advance": [
-		"0.024"
-	],
-	"fan_max_speed": [
-		"35"
-	],
-	"filament_max_volumetric_speed": [
-		"10"
-	],
-	"nozzle_temperature": [
-		"255"
-	],
-	"nozzle_temperature_initial_layer": [
-		"255"
-	],
 	"compatible_printers": [
 		"Elegoo Centauri 0.2 nozzle",
 		"Elegoo Centauri Carbon 0.2 nozzle",

--- a/resources/profiles/Elegoo/filament/ELEGOO/Elegoo PLA @0.2 nozzle.json
+++ b/resources/profiles/Elegoo/filament/ELEGOO/Elegoo PLA @0.2 nozzle.json
@@ -1,13 +1,10 @@
 {
 	"type": "filament",
 	"name": "Elegoo PLA @0.2 nozzle",
-	"inherits": "Elegoo PLA @base",
+	"inherits": "Elegoo PLA @0.2 nozzle @base",
 	"from": "system",
 	"setting_id": "EPLA00020",
 	"instantiation": "true",
-	"filament_max_volumetric_speed": [
-		"3.2"
-	],
 	"compatible_printers": [
 		"Elegoo Centauri 0.2 nozzle",
 		"Elegoo Centauri Carbon 0.2 nozzle",

--- a/resources/profiles/Elegoo/filament/ELEGOO/Elegoo PLA Basic @0.2 nozzle.json
+++ b/resources/profiles/Elegoo/filament/ELEGOO/Elegoo PLA Basic @0.2 nozzle.json
@@ -1,31 +1,10 @@
 {
 	"type": "filament",
 	"name": "Elegoo PLA Basic @0.2 nozzle",
-	"inherits": "Elegoo PLA @base",
+	"inherits": "Elegoo PLA Basic @0.2 nozzle @base",
 	"from": "system",
 	"setting_id": "EPLABASIC00020",
 	"instantiation": "true",
-	"nozzle_temperature": [
-		"220"
-	],
-	"nozzle_temperature_initial_layer": [
-		"220"
-	],
-	"nozzle_temperature_range_high": [
-		"230"
-	],
-	"filament_max_volumetric_speed": [
-		"21"
-	],
-	"pressure_advance": [
-		"0.024"
-	],
-	"slow_down_layer_time": [
-		"4"
-	],
-	"filament_start_gcode": [
-		"; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
-	],
 	"compatible_printers": [
 		"Elegoo Centauri 0.2 nozzle",
 		"Elegoo Centauri Carbon 0.2 nozzle",

--- a/resources/profiles/Elegoo/filament/ELEGOO/Elegoo PLA Matte @0.2 nozzle.json
+++ b/resources/profiles/Elegoo/filament/ELEGOO/Elegoo PLA Matte @0.2 nozzle.json
@@ -1,37 +1,10 @@
 {
 	"type": "filament",
 	"name": "Elegoo PLA Matte @0.2 nozzle",
-	"inherits": "Elegoo PLA Matte @base",
+	"inherits": "Elegoo PLA Matte @0.2 nozzle @base",
 	"from": "system",
 	"setting_id": "EPLAM00020",
 	"instantiation": "true",
-	"fan_cooling_layer_time": [
-		"80"
-	],
-	"fan_max_speed": [
-		"80"
-	],
-	"fan_min_speed": [
-		"60"
-	],
-	"filament_max_volumetric_speed": [
-		"2"
-	],
-	"hot_plate_temp": [
-		"60"
-	],
-	"hot_plate_temp_initial_layer": [
-		"60"
-	],
-	"slow_down_layer_time": [
-		"6"
-	],
-	"textured_plate_temp": [
-		"65"
-	],
-	"textured_plate_temp_initial_layer": [
-		"65"
-	],
 	"compatible_printers": [
 		"Elegoo Centauri 0.2 nozzle",
 		"Elegoo Centauri Carbon 0.2 nozzle",

--- a/resources/profiles/Elegoo/filament/ELEGOO/Elegoo PLA Matte.json
+++ b/resources/profiles/Elegoo/filament/ELEGOO/Elegoo PLA Matte.json
@@ -5,33 +5,6 @@
 	"from": "system",
 	"setting_id": "EPLAM00",
 	"instantiation": "true",
-	"fan_cooling_layer_time": [
-		"80"
-	],
-	"fan_max_speed": [
-		"80"
-	],
-	"fan_min_speed": [
-		"60"
-	],
-	"filament_max_volumetric_speed": [
-		"16"
-	],
-	"hot_plate_temp": [
-		"60"
-	],
-	"hot_plate_temp_initial_layer": [
-		"60"
-	],
-	"slow_down_layer_time": [
-		"6"
-	],
-	"textured_plate_temp": [
-		"60"
-	],
-	"textured_plate_temp_initial_layer": [
-		"60"
-	],
 	"compatible_printers": [
 		"Elegoo Neptune 0.4 nozzle",
 		"Elegoo Neptune X 0.4 nozzle",

--- a/resources/profiles/Elegoo/filament/ELEGOO/Elegoo PLA PRO @0.2 nozzle.json
+++ b/resources/profiles/Elegoo/filament/ELEGOO/Elegoo PLA PRO @0.2 nozzle.json
@@ -1,13 +1,10 @@
 {
 	"type": "filament",
 	"name": "Elegoo PLA PRO @0.2 nozzle",
-	"inherits": "Elegoo PLA @base",
+	"inherits": "Elegoo PLA PRO @0.2 nozzle @base",
 	"from": "system",
 	"setting_id": "EPLAPRO00020",
 	"instantiation": "true",
-	"filament_max_volumetric_speed": [
-		"3.2"
-	],
 	"compatible_printers": [
 		"Elegoo Centauri 0.2 nozzle",
 		"Elegoo Centauri Carbon 0.2 nozzle",

--- a/resources/profiles/Elegoo/filament/ELEGOO/Elegoo PLA PRO.json
+++ b/resources/profiles/Elegoo/filament/ELEGOO/Elegoo PLA PRO.json
@@ -1,13 +1,10 @@
 {
 	"type": "filament",
 	"name": "Elegoo PLA PRO",
-	"inherits": "Elegoo PLA @base",
+	"inherits": "Elegoo PLA PRO @base",
 	"from": "system",
 	"setting_id": "EPLAPRO00",
 	"instantiation": "true",
-	"filament_max_volumetric_speed": [
-		"16"
-	],
 	"compatible_printers": [
 		"Elegoo Neptune 0.4 nozzle",
 		"Elegoo Neptune X 0.4 nozzle",

--- a/resources/profiles/Elegoo/filament/ELEGOO/Elegoo PLA Silk @0.2 nozzle.json
+++ b/resources/profiles/Elegoo/filament/ELEGOO/Elegoo PLA Silk @0.2 nozzle.json
@@ -1,37 +1,10 @@
 {
 	"type": "filament",
 	"name": "Elegoo PLA Silk @0.2 nozzle",
-	"inherits": "Elegoo PLA Silk @base",
+	"inherits": "Elegoo PLA Silk @0.2 nozzle @base",
 	"from": "system",
 	"setting_id": "EPLAS00020",
 	"instantiation": "true",
-	"fan_cooling_layer_time": [
-		"80"
-	],
-	"fan_max_speed": [
-		"80"
-	],
-	"fan_min_speed": [
-		"60"
-	],
-	"filament_max_volumetric_speed": [
-		"2"
-	],
-	"hot_plate_temp": [
-		"60"
-	],
-	"hot_plate_temp_initial_layer": [
-		"60"
-	],
-	"slow_down_layer_time": [
-		"8"
-	],
-	"textured_plate_temp": [
-		"60"
-	],
-	"textured_plate_temp_initial_layer": [
-		"60"
-	],
 	"compatible_printers": [
 		"Elegoo Centauri 0.2 nozzle",
 		"Elegoo Centauri Carbon 0.2 nozzle",

--- a/resources/profiles/Elegoo/filament/ELEGOO/Elegoo PLA Silk.json
+++ b/resources/profiles/Elegoo/filament/ELEGOO/Elegoo PLA Silk.json
@@ -5,30 +5,6 @@
 	"from": "system",
 	"setting_id": "EPLAS00",
 	"instantiation": "true",
-	"fan_cooling_layer_time": [
-		"80"
-	],
-	"fan_max_speed": [
-		"80"
-	],
-	"fan_min_speed": [
-		"60"
-	],
-	"hot_plate_temp": [
-		"60"
-	],
-	"hot_plate_temp_initial_layer": [
-		"60"
-	],
-	"slow_down_layer_time": [
-		"8"
-	],
-	"textured_plate_temp": [
-		"60"
-	],
-	"textured_plate_temp_initial_layer": [
-		"60"
-	],
 	"compatible_printers": [
 		"Elegoo Neptune 0.4 nozzle",
 		"Elegoo Neptune X 0.4 nozzle",

--- a/resources/profiles/Elegoo/filament/ELEGOO/Elegoo PLA+ @0.2 nozzle.json
+++ b/resources/profiles/Elegoo/filament/ELEGOO/Elegoo PLA+ @0.2 nozzle.json
@@ -1,13 +1,10 @@
 {
 	"type": "filament",
 	"name": "Elegoo PLA+ @0.2 nozzle",
-	"inherits": "Elegoo PLA @base",
+	"inherits": "Elegoo PLA+ @0.2 nozzle @base",
 	"from": "system",
 	"setting_id": "EPLAPLUS00020",
 	"instantiation": "true",
-	"filament_max_volumetric_speed": [
-		"3.2"
-	],
 	"compatible_printers": [
 		"Elegoo Centauri 0.2 nozzle",
 		"Elegoo Centauri Carbon 0.2 nozzle",

--- a/resources/profiles/Elegoo/filament/ELEGOO/Elegoo PLA+.json
+++ b/resources/profiles/Elegoo/filament/ELEGOO/Elegoo PLA+.json
@@ -1,13 +1,10 @@
 {
 	"type": "filament",
 	"name": "Elegoo PLA+",
-	"inherits": "Elegoo PLA @base",
+	"inherits": "Elegoo PLA+ @base",
 	"from": "system",
 	"setting_id": "EPLAPLUS00",
 	"instantiation": "true",
-	"filament_max_volumetric_speed": [
-		"16"
-	],
 	"compatible_printers": [
 		"Elegoo Neptune 0.4 nozzle",
 		"Elegoo Neptune X 0.4 nozzle",

--- a/resources/profiles/Elegoo/filament/ELEGOO/Elegoo PLA-CF.json
+++ b/resources/profiles/Elegoo/filament/ELEGOO/Elegoo PLA-CF.json
@@ -5,33 +5,6 @@
 	"from": "system",
 	"setting_id": "EPLACF00",
 	"instantiation": "true",
-	"fan_cooling_layer_time": [
-		"80"
-	],
-	"fan_max_speed": [
-		"100"
-	],
-	"fan_min_speed": [
-		"60"
-	],
-	"filament_max_volumetric_speed": [
-		"12"
-	],
-	"hot_plate_temp": [
-		"60"
-	],
-	"hot_plate_temp_initial_layer": [
-		"60"
-	],
-	"slow_down_layer_time": [
-		"6"
-	],
-	"textured_plate_temp": [
-		"65"
-	],
-	"textured_plate_temp_initial_layer": [
-		"65"
-	],
 	"compatible_printers": [
 		"Elegoo Neptune 0.4 nozzle",
 		"Elegoo Neptune X 0.4 nozzle",

--- a/resources/profiles/Elegoo/filament/ELEGOO/Elegoo Rapid PETG @0.2 nozzle.json
+++ b/resources/profiles/Elegoo/filament/ELEGOO/Elegoo Rapid PETG @0.2 nozzle.json
@@ -2,13 +2,10 @@
 	"type": "filament",
 	"name": "Elegoo Rapid PETG @0.2 nozzle",
 	"renamed_from": "Elegoo RAPID PETG @0.2 nozzle",
-	"inherits": "Elegoo Rapid PETG @base",
+	"inherits": "Elegoo Rapid PETG @0.2 nozzle @base",
 	"from": "system",
 	"setting_id": "ERPETG00020",
 	"instantiation": "true",
-	"filament_max_volumetric_speed": [
-		"1"
-	],
 	"compatible_printers": [
 		"Elegoo Centauri 0.2 nozzle",
 		"Elegoo Centauri Carbon 0.2 nozzle",

--- a/resources/profiles/Elegoo/filament/ELEGOO/Elegoo Rapid PETG+.json
+++ b/resources/profiles/Elegoo/filament/ELEGOO/Elegoo Rapid PETG+.json
@@ -2,7 +2,7 @@
 	"type": "filament",
 	"name": "Elegoo Rapid PETG+",
 	"renamed_from": "Elegoo RAPID PETG+",
-	"inherits": "Elegoo Rapid PETG @base",
+	"inherits": "Elegoo Rapid PETG+ @base",
 	"from": "system",
 	"setting_id": "ERPETGPLUS00",
 	"instantiation": "true",

--- a/resources/profiles/Elegoo/filament/ELEGOO/Elegoo Rapid PLA+ @0.2 nozzle.json
+++ b/resources/profiles/Elegoo/filament/ELEGOO/Elegoo Rapid PLA+ @0.2 nozzle.json
@@ -2,13 +2,10 @@
 	"type": "filament",
 	"name": "Elegoo Rapid PLA+ @0.2 nozzle",
 	"renamed_from": "Elegoo RAPID PLA+ @0.2 nozzle",
-	"inherits": "Elegoo Rapid PLA+ @base",
+	"inherits": "Elegoo Rapid PLA+ @0.2 nozzle @base",
 	"from": "system",
 	"setting_id": "ERPLAPLUS00020",
 	"instantiation": "true",
-	"filament_max_volumetric_speed": [
-		"3.2"
-	],
 	"compatible_printers": [
 		"Elegoo Centauri 0.2 nozzle",
 		"Elegoo Centauri Carbon 0.2 nozzle",

--- a/resources/profiles/Elegoo/filament/EOSGIGA/Elegoo ASA @Elegoo Giga.json
+++ b/resources/profiles/Elegoo/filament/EOSGIGA/Elegoo ASA @Elegoo Giga.json
@@ -1,20 +1,11 @@
 {
 	"type": "filament",
 	"name": "Elegoo ASA @Elegoo Giga",
-	"inherits": "Generic ASA @Elegoo",
+	"inherits": "Elegoo ASA @Elegoo Giga @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFB98",
 	"instantiation": "true",
-	"filament_max_volumetric_speed": [
-		"30"
-	],
-	"nozzle_temperature": [
-		"270"
-	],
-	"nozzle_temperature_initial_layer": [
-		"270"
-	],
 	"compatible_printers": [
 		"Elegoo OrangeStorm Giga 0.4 nozzle",
 		"Elegoo OrangeStorm Giga 0.6 nozzle",

--- a/resources/profiles/Elegoo/filament/EOSGIGA/Elegoo PETG PRO @Elegoo Giga.json
+++ b/resources/profiles/Elegoo/filament/EOSGIGA/Elegoo PETG PRO @Elegoo Giga.json
@@ -1,14 +1,11 @@
 {
 	"type": "filament",
 	"name": "Elegoo PETG PRO @Elegoo Giga",
-	"inherits": "Generic PETG PRO @Elegoo",
+	"inherits": "Elegoo PETG PRO @Elegoo Giga @base",
 	"from": "system",
 	"setting_id": "GFSG99",
 	"filament_id": "GFG99",
 	"instantiation": "true",
-	"filament_max_volumetric_speed": [
-		"21"
-	],
 	"compatible_printers": [
 		"Elegoo OrangeStorm Giga 0.4 nozzle",
 		"Elegoo OrangeStorm Giga 0.6 nozzle",

--- a/resources/profiles/Elegoo/filament/EOSGIGA/Elegoo PLA @Elegoo Giga.json
+++ b/resources/profiles/Elegoo/filament/EOSGIGA/Elegoo PLA @Elegoo Giga.json
@@ -1,14 +1,11 @@
 {
 	"type": "filament",
 	"name": "Elegoo PLA @Elegoo Giga",
-	"inherits": "Generic PLA @Elegoo",
+	"inherits": "Elegoo PLA @Elegoo Giga @base",
 	"from": "system",
 	"setting_id": "GFSL99",
 	"filament_id": "GFL99",
 	"instantiation": "true",
-	"filament_max_volumetric_speed": [
-		"30"
-	],
 	"compatible_printers": [
 		"Elegoo OrangeStorm Giga 0.4 nozzle",
 		"Elegoo OrangeStorm Giga 0.6 nozzle",

--- a/resources/profiles/Elegoo/filament/EOSGIGA/Elegoo PLA Matte @Elegoo Giga.json
+++ b/resources/profiles/Elegoo/filament/EOSGIGA/Elegoo PLA Matte @Elegoo Giga.json
@@ -1,38 +1,11 @@
 {
 	"type": "filament",
 	"name": "Elegoo PLA Matte @Elegoo Giga",
-	"inherits": "Generic PLA Matte @Elegoo",
+	"inherits": "Elegoo PLA Matte @Elegoo Giga @base",
 	"from": "system",
 	"setting_id": "GFSL99",
 	"filament_id": "GFL99",
 	"instantiation": "true",
-	"fan_cooling_layer_time": [
-		"80"
-	],
-	"fan_max_speed": [
-		"80"
-	],
-	"fan_min_speed": [
-		"60"
-	],
-	"filament_max_volumetric_speed": [
-		"30"
-	],
-	"hot_plate_temp": [
-		"60"
-	],
-	"hot_plate_temp_initial_layer": [
-		"60"
-	],
-	"slow_down_layer_time": [
-		"6"
-	],
-	"textured_plate_temp": [
-		"65"
-	],
-	"textured_plate_temp_initial_layer": [
-		"65"
-	],
 	"compatible_printers": [
 		"Elegoo OrangeStorm Giga 0.4 nozzle",
 		"Elegoo OrangeStorm Giga 0.6 nozzle",

--- a/resources/profiles/Elegoo/filament/Generic/Generic ABS @Elegoo.json
+++ b/resources/profiles/Elegoo/filament/Generic/Generic ABS @Elegoo.json
@@ -1,20 +1,11 @@
 {
 	"type": "filament",
 	"name": "Generic ABS @Elegoo",
-	"inherits": "fdm_filament_abs",
+	"inherits": "Generic ABS @Elegoo @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFB99",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"0.926"
-	],
-	"filament_max_volumetric_speed": [
-		"12"
-	],
-	"nozzle_temperature_initial_layer": [
-		"245"
-	],
 	"compatible_printers": [
 		"Elegoo Neptune 0.4 nozzle",
 		"Elegoo Neptune X 0.4 nozzle",

--- a/resources/profiles/Elegoo/filament/Generic/Generic ASA @Elegoo.json
+++ b/resources/profiles/Elegoo/filament/Generic/Generic ASA @Elegoo.json
@@ -1,20 +1,11 @@
 {
 	"type": "filament",
 	"name": "Generic ASA @Elegoo",
-	"inherits": "fdm_filament_asa",
+	"inherits": "Generic ASA @Elegoo @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFB98",
 	"instantiation": "true",
-	"filament_vendor": [
-		"Elegoo"
-	],
-	"filament_density": [
-		"1.1"
-	],
-	"filament_max_volumetric_speed": [
-		"12"
-	],
 	"compatible_printers": [
 		"Elegoo Neptune 0.4 nozzle",
 		"Elegoo Neptune X 0.4 nozzle",

--- a/resources/profiles/Elegoo/filament/Generic/Generic PETG @Elegoo.json
+++ b/resources/profiles/Elegoo/filament/Generic/Generic PETG @Elegoo.json
@@ -1,50 +1,11 @@
 {
 	"type": "filament",
 	"name": "Generic PETG @Elegoo",
-	"inherits": "fdm_filament_pet",
+	"inherits": "Generic PETG @Elegoo @base",
 	"from": "system",
 	"setting_id": "GFSG99",
 	"filament_id": "GFG99",
 	"instantiation": "true",
-	"reduce_fan_stop_start_freq": [
-		"1"
-	],
-	"slow_down_for_layer_cooling": [
-		"1"
-	],
-	"fan_cooling_layer_time": [
-		"30"
-	],
-	"overhang_fan_speed": [
-		"90"
-	],
-	"overhang_fan_threshold": [
-		"25%"
-	],
-	"nozzle_temperature_initial_layer": [
-		"240"
-	],
-	"fan_max_speed": [
-		"50"
-	],
-	"fan_min_speed": [
-		"20"
-	],
-	"slow_down_min_speed": [
-		"10"
-	],
-	"slow_down_layer_time": [
-		"8"
-	],
-	"filament_flow_ratio": [
-		"0.95"
-	],
-	"filament_max_volumetric_speed": [
-		"10"
-	],
-	"filament_start_gcode": [
-		"; filament start gcode\n"
-	],
 	"compatible_printers": [
 		"Elegoo Neptune 0.4 nozzle",
 		"Elegoo Neptune X 0.4 nozzle",

--- a/resources/profiles/Elegoo/filament/Generic/Generic PETG PRO @Elegoo.json
+++ b/resources/profiles/Elegoo/filament/Generic/Generic PETG PRO @Elegoo.json
@@ -1,83 +1,11 @@
 {
 	"type": "filament",
 	"name": "Generic PETG PRO @Elegoo",
-	"inherits": "fdm_filament_pet",
+	"inherits": "Generic PETG PRO @Elegoo @base",
 	"from": "system",
 	"setting_id": "GFSG99",
 	"filament_id": "GFG99",
 	"instantiation": "true",
-	"cool_plate_temp": [
-		"0"
-	],
-	"cool_plate_temp_initial_layer": [
-		"0"
-	],
-	"eng_plate_temp": [
-		"70"
-	],
-	"eng_plate_temp_initial_layer": [
-		"70"
-	],
-	"fan_cooling_layer_time": [
-		"30"
-	],
-	"fan_max_speed": [
-		"40"
-	],
-	"fan_min_speed": [
-		"10"
-	],
-	"filament_cost": [
-		"0"
-	],
-	"filament_density": [
-		"1.25"
-	],
-	"filament_max_volumetric_speed": [
-		"8"
-	],
-	"filament_vendor": [
-		"Elegoo"
-	],
-	"hot_plate_temp": [
-		"70"
-	],
-	"hot_plate_temp_initial_layer": [
-		"70"
-	],
-	"nozzle_temperature_range_high": [
-		"270"
-	],
-	"nozzle_temperature_range_low": [
-		"230"
-	],
-	"nozzle_temperature": [
-		"240"
-	],
-	"nozzle_temperature_initial_layer": [
-		"240"
-	],
-	"overhang_fan_speed": [
-		"90"
-	],
-	"overhang_fan_threshold": [
-		"10%"
-	],
-	"slow_down_layer_time": [
-		"12"
-	],
-	"textured_plate_temp": [
-		"70"
-	],
-	"textured_plate_temp_initial_layer": [
-		"70"
-	],
-	"filament_start_gcode": [
-		"; Filament start gcode\n"
-	],
-	"filament_end_gcode": [
-		"; filament end gcode \n"
-	],
 	"compatible_printers": [
 		"Elegoo Neptune 0.4 nozzle",
 		"Elegoo Neptune X 0.4 nozzle",

--- a/resources/profiles/Elegoo/filament/Generic/Generic PLA @Elegoo.json
+++ b/resources/profiles/Elegoo/filament/Generic/Generic PLA @Elegoo.json
@@ -1,23 +1,11 @@
 {
 	"type": "filament",
 	"name": "Generic PLA @Elegoo",
-	"inherits": "fdm_filament_pla",
+	"inherits": "Generic PLA @Elegoo @base",
 	"from": "system",
 	"setting_id": "GFSL99",
 	"filament_id": "GFL99",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"0.98"
-	],
-	"filament_max_volumetric_speed": [
-		"15"
-	],
-	"nozzle_temperature_initial_layer": [
-		"210"
-	],
-	"slow_down_layer_time": [
-		"8"
-	],
 	"compatible_printers": [
 		"Elegoo Neptune 0.4 nozzle",
 		"Elegoo Neptune X 0.4 nozzle",

--- a/resources/profiles/Elegoo/filament/Generic/Generic PLA Matte @Elegoo.json
+++ b/resources/profiles/Elegoo/filament/Generic/Generic PLA Matte @Elegoo.json
@@ -1,23 +1,11 @@
 {
 	"type": "filament",
 	"name": "Generic PLA Matte @Elegoo",
-	"inherits": "fdm_filament_pla",
+	"inherits": "Generic PLA Matte @Elegoo @base",
 	"from": "system",
 	"setting_id": "GFSL99",
 	"filament_id": "GFL99",
 	"instantiation": "true",
-	"filament_cost": [
-		"0"
-	],
-	"filament_density": [
-		"1.25"
-	],
-	"filament_vendor": [
-		"Elegoo"
-	],
-	"filament_start_gcode": [
-		"; filament start gcode\n"
-	],
 	"compatible_printers": [
 		"Elegoo Neptune 0.4 nozzle",
 		"Elegoo Neptune X 0.4 nozzle",

--- a/resources/profiles/OrcaFilamentLibrary.json
+++ b/resources/profiles/OrcaFilamentLibrary.json
@@ -5,8 +5,40 @@
 	"description": "Orca Filament Library",
 	"filament_list": [
 		{
+			"name": "Elegoo ASA @Elegoo Giga @base",
+			"sub_path": "filament/Elegoo/Elegoo ASA @Elegoo Giga @base.json"
+		},
+		{
+			"name": "Elegoo PETG PRO @Elegoo Giga @base",
+			"sub_path": "filament/Elegoo/Elegoo PETG PRO @Elegoo Giga @base.json"
+		},
+		{
+			"name": "Elegoo PLA @Elegoo Giga @base",
+			"sub_path": "filament/Elegoo/Elegoo PLA @Elegoo Giga @base.json"
+		},
+		{
+			"name": "Elegoo PLA Matte @Elegoo Giga @base",
+			"sub_path": "filament/Elegoo/Elegoo PLA Matte @Elegoo Giga @base.json"
+		},
+		{
 			"name": "fdm_filament_common",
 			"sub_path": "filament/base/fdm_filament_common.json"
+		},
+		{
+			"name": "Elegoo ASA @Elegoo Giga @System",
+			"sub_path": "filament/Elegoo/Elegoo ASA @Elegoo Giga @System.json"
+		},
+		{
+			"name": "Elegoo PETG PRO @Elegoo Giga @System",
+			"sub_path": "filament/Elegoo/Elegoo PETG PRO @Elegoo Giga @System.json"
+		},
+		{
+			"name": "Elegoo PLA @Elegoo Giga @System",
+			"sub_path": "filament/Elegoo/Elegoo PLA @Elegoo Giga @System.json"
+		},
+		{
+			"name": "Elegoo PLA Matte @Elegoo Giga @System",
+			"sub_path": "filament/Elegoo/Elegoo PLA Matte @Elegoo Giga @System.json"
 		},
 		{
 			"name": "FusRock ABS-GF @base",
@@ -129,6 +161,10 @@
 			"sub_path": "filament/FDplast/FDplast ABS @base.json"
 		},
 		{
+			"name": "Generic ABS @Elegoo @base",
+			"sub_path": "filament/Elegoo/Generic ABS @Elegoo @base.json"
+		},
+		{
 			"name": "Generic ABS @System",
 			"sub_path": "filament/Generic ABS @System.json"
 		},
@@ -171,6 +207,10 @@
 		{
 			"name": "Eolas Prints ASA @System",
 			"sub_path": "filament/Eolas Prints/Eolas Prints ASA @System.json"
+		},
+		{
+			"name": "Generic ASA @Elegoo @base",
+			"sub_path": "filament/Elegoo/Generic ASA @Elegoo @base.json"
 		},
 		{
 			"name": "Generic ASA @System",
@@ -239,6 +279,10 @@
 		{
 			"name": "COEX NYLEX UNFILLED @base",
 			"sub_path": "filament/COEX/COEX NYLEX UNFILLED @base.json"
+		},
+		{
+			"name": "FILL3D PA @base",
+			"sub_path": "filament/FILL3D/FILL3D PA @base.json"
 		},
 		{
 			"name": "Fiberon PA12-CF @base",
@@ -365,6 +409,14 @@
 			"sub_path": "filament/FDplast/FDplast PETG @base.json"
 		},
 		{
+			"name": "FILL3D PETG @base",
+			"sub_path": "filament/FILL3D/FILL3D PETG @base.json"
+		},
+		{
+			"name": "FILL3D PETG CF @base",
+			"sub_path": "filament/FILL3D/FILL3D PETG CF @base.json"
+		},
+		{
 			"name": "Fiberon PET-CF @base",
 			"sub_path": "filament/Polymaker/Fiberon PET-CF @base.json"
 		},
@@ -377,6 +429,10 @@
 			"sub_path": "filament/Polymaker/Fiberon PETG-rCF @base.json"
 		},
 		{
+			"name": "Generic PETG @Elegoo @base",
+			"sub_path": "filament/Elegoo/Generic PETG @Elegoo @base.json"
+		},
+		{
 			"name": "Generic PETG @System",
 			"sub_path": "filament/Generic PETG @System.json"
 		},
@@ -385,8 +441,16 @@
 			"sub_path": "filament/Generic PETG HF @System.json"
 		},
 		{
+			"name": "Generic PETG PRO @Elegoo @base",
+			"sub_path": "filament/Elegoo/Generic PETG PRO @Elegoo @base.json"
+		},
+		{
 			"name": "Generic PETG-CF @System",
 			"sub_path": "filament/Generic PETG-CF @System.json"
+		},
+		{
+			"name": "GreenGate3D PETG @base",
+			"sub_path": "filament/GreenGate3D/GreenGate3D PETG @base.json"
 		},
 		{
 			"name": "NIT PETG @base",
@@ -561,8 +625,16 @@
 			"sub_path": "filament/FDplast/FDplast PLA @base.json"
 		},
 		{
+			"name": "FILL3D PLA Basic @base",
+			"sub_path": "filament/FILL3D/FILL3D PLA Basic @base.json"
+		},
+		{
 			"name": "FILL3D PLA Turbo @base",
 			"sub_path": "filament/FILL3D/FILL3D PLA Turbo @base.json"
+		},
+		{
+			"name": "Generic PLA @Elegoo @base",
+			"sub_path": "filament/Elegoo/Generic PLA @Elegoo @base.json"
 		},
 		{
 			"name": "Generic PLA @System",
@@ -571,6 +643,10 @@
 		{
 			"name": "Generic PLA High Speed @System",
 			"sub_path": "filament/Generic PLA High Speed @System.json"
+		},
+		{
+			"name": "Generic PLA Matte @Elegoo @base",
+			"sub_path": "filament/Elegoo/Generic PLA Matte @Elegoo @base.json"
 		},
 		{
 			"name": "Generic PLA Matte @System",
@@ -769,6 +845,14 @@
 			"sub_path": "filament/base/fdm_filament_pla_silk.json"
 		},
 		{
+			"name": "FILL3D PP @base",
+			"sub_path": "filament/FILL3D/FILL3D PP @base.json"
+		},
+		{
+			"name": "FILL3D PPCF @base",
+			"sub_path": "filament/FILL3D/FILL3D PPCF @base.json"
+		},
+		{
 			"name": "Generic PP @System",
 			"sub_path": "filament/Generic PP @System.json"
 		},
@@ -893,8 +977,20 @@
 			"sub_path": "filament/COEX/COEX ABS PRIME @System.json"
 		},
 		{
+			"name": "Elegoo ABS @0.2 nozzle @base",
+			"sub_path": "filament/Elegoo/Elegoo ABS @0.2 nozzle @base.json"
+		},
+		{
+			"name": "Elegoo ABS @ECC2 @base",
+			"sub_path": "filament/Elegoo/Elegoo ABS @ECC2 @base.json"
+		},
+		{
 			"name": "FDplast ABS @System",
 			"sub_path": "filament/FDplast/FDplast ABS @System.json"
+		},
+		{
+			"name": "Generic ABS @Elegoo @System",
+			"sub_path": "filament/Elegoo/Generic ABS @Elegoo @System.json"
 		},
 		{
 			"name": "NIT ABS @System",
@@ -929,8 +1025,28 @@
 			"sub_path": "filament/Elas/Elas ASA @System.json"
 		},
 		{
+			"name": "Elegoo ASA @0.2 nozzle @base",
+			"sub_path": "filament/Elegoo/Elegoo ASA @0.2 nozzle @base.json"
+		},
+		{
+			"name": "Elegoo ASA @EC @base",
+			"sub_path": "filament/Elegoo/Elegoo ASA @EC @base.json"
+		},
+		{
+			"name": "Elegoo ASA @ECC @base",
+			"sub_path": "filament/Elegoo/Elegoo ASA @ECC @base.json"
+		},
+		{
+			"name": "Elegoo ASA @ECC2 @base",
+			"sub_path": "filament/Elegoo/Elegoo ASA @ECC2 @base.json"
+		},
+		{
 			"name": "Elegoo ASA @System",
 			"sub_path": "filament/Elegoo/Elegoo ASA @System.json"
+		},
+		{
+			"name": "Generic ASA @Elegoo @System",
+			"sub_path": "filament/Elegoo/Generic ASA @Elegoo @System.json"
 		},
 		{
 			"name": "Overture ASA @System",
@@ -977,6 +1093,10 @@
 			"sub_path": "filament/COEX/COEX NYLEX PA6-CF @System.json"
 		},
 		{
+			"name": "FILL3D PA @System",
+			"sub_path": "filament/FILL3D/FILL3D PA @System.json"
+		},
+		{
 			"name": "Fiberon PA12-CF @System",
 			"sub_path": "filament/Polymaker/Fiberon PA12-CF @System.json"
 		},
@@ -993,12 +1113,32 @@
 			"sub_path": "filament/Polymaker/Fiberon PA612-CF @System.json"
 		},
 		{
+			"name": "Elegoo PAHT-CF @ECC2 @base",
+			"sub_path": "filament/Elegoo/Elegoo PAHT-CF @ECC2 @base.json"
+		},
+		{
 			"name": "Bambu PC @System",
 			"sub_path": "filament/Bambu/Bambu PC @System.json"
 		},
 		{
 			"name": "Bambu PC FR @System",
 			"sub_path": "filament/Bambu/Bambu PC FR @System.json"
+		},
+		{
+			"name": "Elegoo PC @0.2 nozzle @base",
+			"sub_path": "filament/Elegoo/Elegoo PC @0.2 nozzle @base.json"
+		},
+		{
+			"name": "Elegoo PC @ECC2 @base",
+			"sub_path": "filament/Elegoo/Elegoo PC @ECC2 @base.json"
+		},
+		{
+			"name": "Elegoo PC-FR @0.2 nozzle @base",
+			"sub_path": "filament/Elegoo/Elegoo PC-FR @0.2 nozzle @base.json"
+		},
+		{
+			"name": "Elegoo PC-FR @ECC2 @base",
+			"sub_path": "filament/Elegoo/Elegoo PC-FR @ECC2 @base.json"
 		},
 		{
 			"name": "COEX PCTG PRIME @System",
@@ -1045,6 +1185,50 @@
 			"sub_path": "filament/Elas/Elas PETG Basic @System.json"
 		},
 		{
+			"name": "Elegoo PETG @0.2 nozzle @base",
+			"sub_path": "filament/Elegoo/Elegoo PETG @0.2 nozzle @base.json"
+		},
+		{
+			"name": "Elegoo PETG @ECC2 @base",
+			"sub_path": "filament/Elegoo/Elegoo PETG @ECC2 @base.json"
+		},
+		{
+			"name": "Elegoo PETG PRO @ECC2 @base",
+			"sub_path": "filament/Elegoo/Elegoo PETG PRO @ECC2 @base.json"
+		},
+		{
+			"name": "Elegoo PETG Translucent @0.2 nozzle @base",
+			"sub_path": "filament/Elegoo/Elegoo PETG Translucent @0.2 nozzle @base.json"
+		},
+		{
+			"name": "Elegoo PETG Translucent @ECC2 @base",
+			"sub_path": "filament/Elegoo/Elegoo PETG Translucent @ECC2 @base.json"
+		},
+		{
+			"name": "Elegoo PETG-CF @ECC2 @base",
+			"sub_path": "filament/Elegoo/Elegoo PETG-CF @ECC2 @base.json"
+		},
+		{
+			"name": "Elegoo PETG-GF @ECC2 @base",
+			"sub_path": "filament/Elegoo/Elegoo PETG-GF @ECC2 @base.json"
+		},
+		{
+			"name": "Elegoo Rapid PETG @ECC2 @base",
+			"sub_path": "filament/Elegoo/Elegoo Rapid PETG @ECC2 @base.json"
+		},
+		{
+			"name": "Elegoo PETG PRO @0.2 nozzle @base",
+			"sub_path": "filament/Elegoo/Elegoo PETG PRO @0.2 nozzle @base.json"
+		},
+		{
+			"name": "Elegoo PETG PRO @EC @base",
+			"sub_path": "filament/Elegoo/Elegoo PETG PRO @EC @base.json"
+		},
+		{
+			"name": "Elegoo PETG PRO @ECC @base",
+			"sub_path": "filament/Elegoo/Elegoo PETG PRO @ECC @base.json"
+		},
+		{
 			"name": "Elegoo PETG PRO @System",
 			"sub_path": "filament/Elegoo/Elegoo PETG PRO @System.json"
 		},
@@ -1053,12 +1237,36 @@
 			"sub_path": "filament/Elegoo/Elegoo PETG-CF @System.json"
 		},
 		{
+			"name": "Elegoo Rapid PETG @0.2 nozzle @base",
+			"sub_path": "filament/Elegoo/Elegoo Rapid PETG @0.2 nozzle @base.json"
+		},
+		{
+			"name": "Elegoo Rapid PETG @EC @base",
+			"sub_path": "filament/Elegoo/Elegoo Rapid PETG @EC @base.json"
+		},
+		{
+			"name": "Elegoo Rapid PETG @ECC @base",
+			"sub_path": "filament/Elegoo/Elegoo Rapid PETG @ECC @base.json"
+		},
+		{
 			"name": "Elegoo Rapid PETG @System",
 			"sub_path": "filament/Elegoo/Elegoo Rapid PETG @System.json"
 		},
 		{
+			"name": "Elegoo Rapid PETG+ @base",
+			"sub_path": "filament/Elegoo/Elegoo Rapid PETG+ @base.json"
+		},
+		{
 			"name": "FDplast PETG @System",
 			"sub_path": "filament/FDplast/FDplast PETG @System.json"
+		},
+		{
+			"name": "FILL3D PETG @System",
+			"sub_path": "filament/FILL3D/FILL3D PETG @System.json"
+		},
+		{
+			"name": "FILL3D PETG CF @System",
+			"sub_path": "filament/FILL3D/FILL3D PETG CF @System.json"
 		},
 		{
 			"name": "Fiberon PET-CF @System",
@@ -1071,6 +1279,18 @@
 		{
 			"name": "Fiberon PETG-rCF @System",
 			"sub_path": "filament/Polymaker/Fiberon PETG-rCF @System.json"
+		},
+		{
+			"name": "Generic PETG @Elegoo @System",
+			"sub_path": "filament/Elegoo/Generic PETG @Elegoo @System.json"
+		},
+		{
+			"name": "Generic PETG PRO @Elegoo @System",
+			"sub_path": "filament/Elegoo/Generic PETG PRO @Elegoo @System.json"
+		},
+		{
+			"name": "GreenGate3D PETG @System",
+			"sub_path": "filament/GreenGate3D/GreenGate3D PETG @System.json"
 		},
 		{
 			"name": "NIT PETG @System",
@@ -1181,8 +1401,156 @@
 			"sub_path": "filament/Elas/Elas PLA Pro @System.json"
 		},
 		{
+			"name": "Elegoo PLA @0.2 nozzle @base",
+			"sub_path": "filament/Elegoo/Elegoo PLA @0.2 nozzle @base.json"
+		},
+		{
+			"name": "Elegoo PLA @EC @base",
+			"sub_path": "filament/Elegoo/Elegoo PLA @EC @base.json"
+		},
+		{
+			"name": "Elegoo PLA @ECC @base",
+			"sub_path": "filament/Elegoo/Elegoo PLA @ECC @base.json"
+		},
+		{
+			"name": "Elegoo PLA @ECC2 @base",
+			"sub_path": "filament/Elegoo/Elegoo PLA @ECC2 @base.json"
+		},
+		{
 			"name": "Elegoo PLA @System",
 			"sub_path": "filament/Elegoo/Elegoo PLA @System.json"
+		},
+		{
+			"name": "Elegoo PLA Basic @0.2 nozzle @base",
+			"sub_path": "filament/Elegoo/Elegoo PLA Basic @0.2 nozzle @base.json"
+		},
+		{
+			"name": "Elegoo PLA Basic @ECC2 @base",
+			"sub_path": "filament/Elegoo/Elegoo PLA Basic @ECC2 @base.json"
+		},
+		{
+			"name": "Elegoo PLA Galaxy @ECC2 @base",
+			"sub_path": "filament/Elegoo/Elegoo PLA Galaxy @ECC2 @base.json"
+		},
+		{
+			"name": "Elegoo PLA Marble @ECC2 @base",
+			"sub_path": "filament/Elegoo/Elegoo PLA Marble @ECC2 @base.json"
+		},
+		{
+			"name": "Elegoo PLA Matte @ECC2 @base",
+			"sub_path": "filament/Elegoo/Elegoo PLA Matte @ECC2 @base.json"
+		},
+		{
+			"name": "Elegoo PLA PRO @0.2 nozzle @base",
+			"sub_path": "filament/Elegoo/Elegoo PLA PRO @0.2 nozzle @base.json"
+		},
+		{
+			"name": "Elegoo PLA PRO @EC @base",
+			"sub_path": "filament/Elegoo/Elegoo PLA PRO @EC @base.json"
+		},
+		{
+			"name": "Elegoo PLA PRO @ECC @base",
+			"sub_path": "filament/Elegoo/Elegoo PLA PRO @ECC @base.json"
+		},
+		{
+			"name": "Elegoo PLA PRO @ECC2 @base",
+			"sub_path": "filament/Elegoo/Elegoo PLA PRO @ECC2 @base.json"
+		},
+		{
+			"name": "Elegoo PLA PRO @base",
+			"sub_path": "filament/Elegoo/Elegoo PLA PRO @base.json"
+		},
+		{
+			"name": "Elegoo PLA Silk @ECC2 @base",
+			"sub_path": "filament/Elegoo/Elegoo PLA Silk @ECC2 @base.json"
+		},
+		{
+			"name": "Elegoo PLA Sparkle @ECC2 @base",
+			"sub_path": "filament/Elegoo/Elegoo PLA Sparkle @ECC2 @base.json"
+		},
+		{
+			"name": "Elegoo PLA Wood @ECC2 @base",
+			"sub_path": "filament/Elegoo/Elegoo PLA Wood @ECC2 @base.json"
+		},
+		{
+			"name": "Elegoo PLA+ @0.2 nozzle @base",
+			"sub_path": "filament/Elegoo/Elegoo PLA+ @0.2 nozzle @base.json"
+		},
+		{
+			"name": "Elegoo PLA+ @EC @base",
+			"sub_path": "filament/Elegoo/Elegoo PLA+ @EC @base.json"
+		},
+		{
+			"name": "Elegoo PLA+ @ECC @base",
+			"sub_path": "filament/Elegoo/Elegoo PLA+ @ECC @base.json"
+		},
+		{
+			"name": "Elegoo PLA+ @ECC2 @base",
+			"sub_path": "filament/Elegoo/Elegoo PLA+ @ECC2 @base.json"
+		},
+		{
+			"name": "Elegoo PLA+ @base",
+			"sub_path": "filament/Elegoo/Elegoo PLA+ @base.json"
+		},
+		{
+			"name": "Elegoo PLA-CF @ECC2 @base",
+			"sub_path": "filament/Elegoo/Elegoo PLA-CF @ECC2 @base.json"
+		},
+		{
+			"name": "Elegoo Rapid PLA+ @ECC2 @base",
+			"sub_path": "filament/Elegoo/Elegoo Rapid PLA+ @ECC2 @base.json"
+		},
+		{
+			"name": "Elegoo PLA Matte @0.2 nozzle @base",
+			"sub_path": "filament/Elegoo/Elegoo PLA Matte @0.2 nozzle @base.json"
+		},
+		{
+			"name": "Elegoo PLA Matte @EC @base",
+			"sub_path": "filament/Elegoo/Elegoo PLA Matte @EC @base.json"
+		},
+		{
+			"name": "Elegoo PLA Matte @ECC @base",
+			"sub_path": "filament/Elegoo/Elegoo PLA Matte @ECC @base.json"
+		},
+		{
+			"name": "Elegoo PLA Matte @System",
+			"sub_path": "filament/Elegoo/Elegoo PLA Matte @System.json"
+		},
+		{
+			"name": "Elegoo PLA Silk @0.2 nozzle @base",
+			"sub_path": "filament/Elegoo/Elegoo PLA Silk @0.2 nozzle @base.json"
+		},
+		{
+			"name": "Elegoo PLA Silk @EC @base",
+			"sub_path": "filament/Elegoo/Elegoo PLA Silk @EC @base.json"
+		},
+		{
+			"name": "Elegoo PLA Silk @ECC @base",
+			"sub_path": "filament/Elegoo/Elegoo PLA Silk @ECC @base.json"
+		},
+		{
+			"name": "Elegoo PLA Silk @System",
+			"sub_path": "filament/Elegoo/Elegoo PLA Silk @System.json"
+		},
+		{
+			"name": "Elegoo PLA-CF @ECC @base",
+			"sub_path": "filament/Elegoo/Elegoo PLA-CF @ECC @base.json"
+		},
+		{
+			"name": "Elegoo PLA-CF @System",
+			"sub_path": "filament/Elegoo/Elegoo PLA-CF @System.json"
+		},
+		{
+			"name": "Elegoo Rapid PLA+ @0.2 nozzle @base",
+			"sub_path": "filament/Elegoo/Elegoo Rapid PLA+ @0.2 nozzle @base.json"
+		},
+		{
+			"name": "Elegoo Rapid PLA+ @EC @base",
+			"sub_path": "filament/Elegoo/Elegoo Rapid PLA+ @EC @base.json"
+		},
+		{
+			"name": "Elegoo Rapid PLA+ @ECC @base",
+			"sub_path": "filament/Elegoo/Elegoo Rapid PLA+ @ECC @base.json"
 		},
 		{
 			"name": "Elegoo Rapid PLA+ @System",
@@ -1193,56 +1561,20 @@
 			"sub_path": "filament/FDplast/FDplast PLA @System.json"
 		},
 		{
-			"name": "FILL3D PLA Turbo @System",
-			"sub_path": "filament/FILL3D/FILL3D PLA Turbo @System.json"
-		},
-		{
-			"name": "FILL3D PLA Basic @base",
-			"sub_path": "filament/FILL3D/FILL3D PLA Basic @base.json"
-		},
-		{
 			"name": "FILL3D PLA Basic @System",
 			"sub_path": "filament/FILL3D/FILL3D PLA Basic @System.json"
 		},
 		{
-			"name": "FILL3D PETG @base",
-			"sub_path": "filament/FILL3D/FILL3D PETG @base.json"
+			"name": "FILL3D PLA Turbo @System",
+			"sub_path": "filament/FILL3D/FILL3D PLA Turbo @System.json"
 		},
 		{
-			"name": "FILL3D PETG @System",
-			"sub_path": "filament/FILL3D/FILL3D PETG @System.json"
+			"name": "Generic PLA @Elegoo @System",
+			"sub_path": "filament/Elegoo/Generic PLA @Elegoo @System.json"
 		},
 		{
-			"name": "FILL3D PETG CF @base",
-			"sub_path": "filament/FILL3D/FILL3D PETG CF @base.json"
-		},
-		{
-			"name": "FILL3D PETG CF @System",
-			"sub_path": "filament/FILL3D/FILL3D PETG CF @System.json"
-		},
-		{
-			"name": "FILL3D PP @base",
-			"sub_path": "filament/FILL3D/FILL3D PP @base.json"
-		},
-		{
-			"name": "FILL3D PP @System",
-			"sub_path": "filament/FILL3D/FILL3D PP @System.json"
-		},
-		{
-			"name": "FILL3D PPCF @base",
-			"sub_path": "filament/FILL3D/FILL3D PPCF @base.json"
-		},
-		{
-			"name": "FILL3D PPCF @System",
-			"sub_path": "filament/FILL3D/FILL3D PPCF @System.json"
-		},
-		{
-			"name": "FILL3D PA @base",
-			"sub_path": "filament/FILL3D/FILL3D PA @base.json"
-		},
-		{
-			"name": "FILL3D PA @System",
-			"sub_path": "filament/FILL3D/FILL3D PA @System.json"
+			"name": "Generic PLA Matte @Elegoo @System",
+			"sub_path": "filament/Elegoo/Generic PLA Matte @Elegoo @System.json"
 		},
 		{
 			"name": "NIT PLA @System",
@@ -1441,6 +1773,14 @@
 			"sub_path": "filament/Generic PLA Silk @System.json"
 		},
 		{
+			"name": "FILL3D PP @System",
+			"sub_path": "filament/FILL3D/FILL3D PP @System.json"
+		},
+		{
+			"name": "FILL3D PPCF @System",
+			"sub_path": "filament/FILL3D/FILL3D PPCF @System.json"
+		},
+		{
 			"name": "Bambu PPA-CF @System",
 			"sub_path": "filament/Bambu/Bambu PPA-CF @System.json"
 		},
@@ -1477,8 +1817,24 @@
 			"sub_path": "filament/COEX/COEX TPU 60A @System.json"
 		},
 		{
+			"name": "Elegoo TPU 95A @EC @base",
+			"sub_path": "filament/Elegoo/Elegoo TPU 95A @EC @base.json"
+		},
+		{
+			"name": "Elegoo TPU 95A @ECC @base",
+			"sub_path": "filament/Elegoo/Elegoo TPU 95A @ECC @base.json"
+		},
+		{
 			"name": "Elegoo TPU 95A @System",
 			"sub_path": "filament/Elegoo/Elegoo TPU 95A @System.json"
+		},
+		{
+			"name": "Elegoo Rapid TPU 95A @ECC2 @base",
+			"sub_path": "filament/Elegoo/Elegoo Rapid TPU 95A @ECC2 @base.json"
+		},
+		{
+			"name": "Elegoo TPU 95A @ECC2 @base",
+			"sub_path": "filament/Elegoo/Elegoo TPU 95A @ECC2 @base.json"
 		},
 		{
 			"name": "FDplast TPU @System",
@@ -1489,6 +1845,50 @@
 			"sub_path": "filament/Overture/Overture TPU @System.json"
 		},
 		{
+			"name": "Elegoo ABS @0.2 nozzle @System",
+			"sub_path": "filament/Elegoo/Elegoo ABS @0.2 nozzle @System.json"
+		},
+		{
+			"name": "Elegoo ABS @ECC2 @System",
+			"sub_path": "filament/Elegoo/Elegoo ABS @ECC2 @System.json"
+		},
+		{
+			"name": "Elegoo ASA @0.2 nozzle @System",
+			"sub_path": "filament/Elegoo/Elegoo ASA @0.2 nozzle @System.json"
+		},
+		{
+			"name": "Elegoo ASA @EC @System",
+			"sub_path": "filament/Elegoo/Elegoo ASA @EC @System.json"
+		},
+		{
+			"name": "Elegoo ASA @ECC @System",
+			"sub_path": "filament/Elegoo/Elegoo ASA @ECC @System.json"
+		},
+		{
+			"name": "Elegoo ASA @ECC2 @System",
+			"sub_path": "filament/Elegoo/Elegoo ASA @ECC2 @System.json"
+		},
+		{
+			"name": "Elegoo PAHT-CF @ECC2 @System",
+			"sub_path": "filament/Elegoo/Elegoo PAHT-CF @ECC2 @System.json"
+		},
+		{
+			"name": "Elegoo PC @0.2 nozzle @System",
+			"sub_path": "filament/Elegoo/Elegoo PC @0.2 nozzle @System.json"
+		},
+		{
+			"name": "Elegoo PC @ECC2 @System",
+			"sub_path": "filament/Elegoo/Elegoo PC @ECC2 @System.json"
+		},
+		{
+			"name": "Elegoo PC-FR @0.2 nozzle @System",
+			"sub_path": "filament/Elegoo/Elegoo PC-FR @0.2 nozzle @System.json"
+		},
+		{
+			"name": "Elegoo PC-FR @ECC2 @System",
+			"sub_path": "filament/Elegoo/Elegoo PC-FR @ECC2 @System.json"
+		},
+		{
 			"name": "AliZ PETG-CF @System",
 			"sub_path": "filament/AliZ/AliZ PETG-CF @System.json"
 		},
@@ -1497,16 +1897,220 @@
 			"sub_path": "filament/AliZ/AliZ PETG-Metal @System.json"
 		},
 		{
+			"name": "Elegoo PETG @0.2 nozzle @System",
+			"sub_path": "filament/Elegoo/Elegoo PETG @0.2 nozzle @System.json"
+		},
+		{
+			"name": "Elegoo PETG @ECC2 @System",
+			"sub_path": "filament/Elegoo/Elegoo PETG @ECC2 @System.json"
+		},
+		{
+			"name": "Elegoo PETG PRO @ECC2 @System",
+			"sub_path": "filament/Elegoo/Elegoo PETG PRO @ECC2 @System.json"
+		},
+		{
+			"name": "Elegoo PETG Translucent @0.2 nozzle @System",
+			"sub_path": "filament/Elegoo/Elegoo PETG Translucent @0.2 nozzle @System.json"
+		},
+		{
+			"name": "Elegoo PETG Translucent @ECC2 @System",
+			"sub_path": "filament/Elegoo/Elegoo PETG Translucent @ECC2 @System.json"
+		},
+		{
+			"name": "Elegoo PETG-CF @ECC2 @System",
+			"sub_path": "filament/Elegoo/Elegoo PETG-CF @ECC2 @System.json"
+		},
+		{
+			"name": "Elegoo PETG-GF @ECC2 @System",
+			"sub_path": "filament/Elegoo/Elegoo PETG-GF @ECC2 @System.json"
+		},
+		{
+			"name": "Elegoo Rapid PETG @ECC2 @System",
+			"sub_path": "filament/Elegoo/Elegoo Rapid PETG @ECC2 @System.json"
+		},
+		{
+			"name": "Elegoo PETG PRO @0.2 nozzle @System",
+			"sub_path": "filament/Elegoo/Elegoo PETG PRO @0.2 nozzle @System.json"
+		},
+		{
+			"name": "Elegoo PETG PRO @EC @System",
+			"sub_path": "filament/Elegoo/Elegoo PETG PRO @EC @System.json"
+		},
+		{
+			"name": "Elegoo PETG PRO @ECC @System",
+			"sub_path": "filament/Elegoo/Elegoo PETG PRO @ECC @System.json"
+		},
+		{
+			"name": "Elegoo Rapid PETG @0.2 nozzle @System",
+			"sub_path": "filament/Elegoo/Elegoo Rapid PETG @0.2 nozzle @System.json"
+		},
+		{
+			"name": "Elegoo Rapid PETG @EC @System",
+			"sub_path": "filament/Elegoo/Elegoo Rapid PETG @EC @System.json"
+		},
+		{
+			"name": "Elegoo Rapid PETG @ECC @System",
+			"sub_path": "filament/Elegoo/Elegoo Rapid PETG @ECC @System.json"
+		},
+		{
+			"name": "Elegoo Rapid PETG+ @System",
+			"sub_path": "filament/Elegoo/Elegoo Rapid PETG+ @System.json"
+		},
+		{
+			"name": "Elegoo PLA @0.2 nozzle @System",
+			"sub_path": "filament/Elegoo/Elegoo PLA @0.2 nozzle @System.json"
+		},
+		{
+			"name": "Elegoo PLA @EC @System",
+			"sub_path": "filament/Elegoo/Elegoo PLA @EC @System.json"
+		},
+		{
+			"name": "Elegoo PLA @ECC @System",
+			"sub_path": "filament/Elegoo/Elegoo PLA @ECC @System.json"
+		},
+		{
+			"name": "Elegoo PLA @ECC2 @System",
+			"sub_path": "filament/Elegoo/Elegoo PLA @ECC2 @System.json"
+		},
+		{
+			"name": "Elegoo PLA Basic @0.2 nozzle @System",
+			"sub_path": "filament/Elegoo/Elegoo PLA Basic @0.2 nozzle @System.json"
+		},
+		{
+			"name": "Elegoo PLA Basic @ECC2 @System",
+			"sub_path": "filament/Elegoo/Elegoo PLA Basic @ECC2 @System.json"
+		},
+		{
+			"name": "Elegoo PLA Galaxy @ECC2 @System",
+			"sub_path": "filament/Elegoo/Elegoo PLA Galaxy @ECC2 @System.json"
+		},
+		{
+			"name": "Elegoo PLA Marble @ECC2 @System",
+			"sub_path": "filament/Elegoo/Elegoo PLA Marble @ECC2 @System.json"
+		},
+		{
+			"name": "Elegoo PLA Matte @ECC2 @System",
+			"sub_path": "filament/Elegoo/Elegoo PLA Matte @ECC2 @System.json"
+		},
+		{
+			"name": "Elegoo PLA PRO @0.2 nozzle @System",
+			"sub_path": "filament/Elegoo/Elegoo PLA PRO @0.2 nozzle @System.json"
+		},
+		{
+			"name": "Elegoo PLA PRO @EC @System",
+			"sub_path": "filament/Elegoo/Elegoo PLA PRO @EC @System.json"
+		},
+		{
+			"name": "Elegoo PLA PRO @ECC @System",
+			"sub_path": "filament/Elegoo/Elegoo PLA PRO @ECC @System.json"
+		},
+		{
+			"name": "Elegoo PLA PRO @ECC2 @System",
+			"sub_path": "filament/Elegoo/Elegoo PLA PRO @ECC2 @System.json"
+		},
+		{
+			"name": "Elegoo PLA PRO @System",
+			"sub_path": "filament/Elegoo/Elegoo PLA PRO @System.json"
+		},
+		{
+			"name": "Elegoo PLA Silk @ECC2 @System",
+			"sub_path": "filament/Elegoo/Elegoo PLA Silk @ECC2 @System.json"
+		},
+		{
+			"name": "Elegoo PLA Sparkle @ECC2 @System",
+			"sub_path": "filament/Elegoo/Elegoo PLA Sparkle @ECC2 @System.json"
+		},
+		{
+			"name": "Elegoo PLA Wood @ECC2 @System",
+			"sub_path": "filament/Elegoo/Elegoo PLA Wood @ECC2 @System.json"
+		},
+		{
+			"name": "Elegoo PLA+ @0.2 nozzle @System",
+			"sub_path": "filament/Elegoo/Elegoo PLA+ @0.2 nozzle @System.json"
+		},
+		{
+			"name": "Elegoo PLA+ @EC @System",
+			"sub_path": "filament/Elegoo/Elegoo PLA+ @EC @System.json"
+		},
+		{
+			"name": "Elegoo PLA+ @ECC @System",
+			"sub_path": "filament/Elegoo/Elegoo PLA+ @ECC @System.json"
+		},
+		{
+			"name": "Elegoo PLA+ @ECC2 @System",
+			"sub_path": "filament/Elegoo/Elegoo PLA+ @ECC2 @System.json"
+		},
+		{
+			"name": "Elegoo PLA+ @System",
+			"sub_path": "filament/Elegoo/Elegoo PLA+ @System.json"
+		},
+		{
+			"name": "Elegoo PLA-CF @ECC2 @System",
+			"sub_path": "filament/Elegoo/Elegoo PLA-CF @ECC2 @System.json"
+		},
+		{
+			"name": "Elegoo Rapid PLA+ @ECC2 @System",
+			"sub_path": "filament/Elegoo/Elegoo Rapid PLA+ @ECC2 @System.json"
+		},
+		{
+			"name": "Elegoo PLA Matte @0.2 nozzle @System",
+			"sub_path": "filament/Elegoo/Elegoo PLA Matte @0.2 nozzle @System.json"
+		},
+		{
+			"name": "Elegoo PLA Matte @EC @System",
+			"sub_path": "filament/Elegoo/Elegoo PLA Matte @EC @System.json"
+		},
+		{
+			"name": "Elegoo PLA Matte @ECC @System",
+			"sub_path": "filament/Elegoo/Elegoo PLA Matte @ECC @System.json"
+		},
+		{
+			"name": "Elegoo PLA Silk @0.2 nozzle @System",
+			"sub_path": "filament/Elegoo/Elegoo PLA Silk @0.2 nozzle @System.json"
+		},
+		{
+			"name": "Elegoo PLA Silk @EC @System",
+			"sub_path": "filament/Elegoo/Elegoo PLA Silk @EC @System.json"
+		},
+		{
+			"name": "Elegoo PLA Silk @ECC @System",
+			"sub_path": "filament/Elegoo/Elegoo PLA Silk @ECC @System.json"
+		},
+		{
+			"name": "Elegoo PLA-CF @ECC @System",
+			"sub_path": "filament/Elegoo/Elegoo PLA-CF @ECC @System.json"
+		},
+		{
+			"name": "Elegoo Rapid PLA+ @0.2 nozzle @System",
+			"sub_path": "filament/Elegoo/Elegoo Rapid PLA+ @0.2 nozzle @System.json"
+		},
+		{
+			"name": "Elegoo Rapid PLA+ @EC @System",
+			"sub_path": "filament/Elegoo/Elegoo Rapid PLA+ @EC @System.json"
+		},
+		{
+			"name": "Elegoo Rapid PLA+ @ECC @System",
+			"sub_path": "filament/Elegoo/Elegoo Rapid PLA+ @ECC @System.json"
+		},
+		{
 			"name": "COEX PLA+Silk @System",
 			"sub_path": "filament/COEX/COEX PLA+Silk @System.json"
 		},
 		{
-			"name": "GreenGate3D PETG @base",
-			"sub_path": "filament/GreenGate3D/GreenGate3D PETG @base.json"
+			"name": "Elegoo TPU 95A @EC @System",
+			"sub_path": "filament/Elegoo/Elegoo TPU 95A @EC @System.json"
 		},
 		{
-			"name": "GreenGate3D PETG @System",
-			"sub_path": "filament/GreenGate3D/GreenGate3D PETG @System.json"
+			"name": "Elegoo TPU 95A @ECC @System",
+			"sub_path": "filament/Elegoo/Elegoo TPU 95A @ECC @System.json"
+		},
+		{
+			"name": "Elegoo Rapid TPU 95A @ECC2 @System",
+			"sub_path": "filament/Elegoo/Elegoo Rapid TPU 95A @ECC2 @System.json"
+		},
+		{
+			"name": "Elegoo TPU 95A @ECC2 @System",
+			"sub_path": "filament/Elegoo/Elegoo TPU 95A @ECC2 @System.json"
 		}
 	],
 	"process_list": [],

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo ABS @0.2 nozzle @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo ABS @0.2 nozzle @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "Elegoo ABS @0.2 nozzle @System",
+	"inherits": "Elegoo ABS @0.2 nozzle @base",
+	"from": "system",
+	"setting_id": "EABS00020",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo ABS @0.2 nozzle @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo ABS @0.2 nozzle @base.json
@@ -1,0 +1,22 @@
+{
+	"type": "filament",
+	"name": "Elegoo ABS @0.2 nozzle @base",
+	"inherits": "Elegoo ABS @base",
+	"from": "system",
+	"instantiation": "false",
+	"fan_max_speed": [
+		"40"
+	],
+	"filament_max_volumetric_speed": [
+		"18"
+	],
+	"pressure_advance": [
+		"0.024"
+	],
+	"nozzle_temperature": [
+		"270"
+	],
+	"nozzle_temperature_initial_layer": [
+		"270"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo ABS @ECC2 @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo ABS @ECC2 @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "Elegoo ABS @ECC2 @System",
+	"inherits": "Elegoo ABS @ECC2 @base",
+	"from": "system",
+	"setting_id": "EABSECC2",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo ABS @ECC2 @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo ABS @ECC2 @base.json
@@ -1,0 +1,22 @@
+{
+	"type": "filament",
+	"name": "Elegoo ABS @ECC2 @base",
+	"inherits": "Elegoo ABS @base",
+	"from": "system",
+	"instantiation": "false",
+	"fan_max_speed": [
+		"40"
+	],
+	"filament_max_volumetric_speed": [
+		"18"
+	],
+	"pressure_advance": [
+		"0.024"
+	],
+	"nozzle_temperature": [
+		"270"
+	],
+	"nozzle_temperature_initial_layer": [
+		"270"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo ASA @0.2 nozzle @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo ASA @0.2 nozzle @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "Elegoo ASA @0.2 nozzle @System",
+	"inherits": "Elegoo ASA @0.2 nozzle @base",
+	"from": "system",
+	"setting_id": "EASA00020",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo ASA @0.2 nozzle @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo ASA @0.2 nozzle @base.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Elegoo ASA @0.2 nozzle @base",
+	"inherits": "Elegoo ASA @base",
+	"from": "system",
+	"instantiation": "false",
+	"filament_max_volumetric_speed": [
+		"3.2"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo ASA @EC @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo ASA @EC @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "Elegoo ASA @EC @System",
+	"inherits": "Elegoo ASA @EC @base",
+	"from": "system",
+	"setting_id": "EASAEC",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo ASA @EC @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo ASA @EC @base.json
@@ -1,0 +1,16 @@
+{
+	"type": "filament",
+	"name": "Elegoo ASA @EC @base",
+	"inherits": "Elegoo ASA @base",
+	"from": "system",
+	"instantiation": "false",
+	"pressure_advance": [
+		"0.024"
+	],
+	"nozzle_temperature": [
+		"270"
+	],
+	"nozzle_temperature_initial_layer": [
+		"270"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo ASA @ECC @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo ASA @ECC @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "Elegoo ASA @ECC @System",
+	"inherits": "Elegoo ASA @ECC @base",
+	"from": "system",
+	"setting_id": "EASAECC",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo ASA @ECC @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo ASA @ECC @base.json
@@ -1,0 +1,16 @@
+{
+	"type": "filament",
+	"name": "Elegoo ASA @ECC @base",
+	"inherits": "Elegoo ASA @base",
+	"from": "system",
+	"instantiation": "false",
+	"pressure_advance": [
+		"0.024"
+	],
+	"nozzle_temperature": [
+		"270"
+	],
+	"nozzle_temperature_initial_layer": [
+		"270"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo ASA @ECC2 @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo ASA @ECC2 @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "Elegoo ASA @ECC2 @System",
+	"inherits": "Elegoo ASA @ECC2 @base",
+	"from": "system",
+	"setting_id": "EASAECC2",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo ASA @ECC2 @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo ASA @ECC2 @base.json
@@ -1,0 +1,16 @@
+{
+	"type": "filament",
+	"name": "Elegoo ASA @ECC2 @base",
+	"inherits": "Elegoo ASA @base",
+	"from": "system",
+	"instantiation": "false",
+	"pressure_advance": [
+		"0.024"
+	],
+	"nozzle_temperature": [
+		"270"
+	],
+	"nozzle_temperature_initial_layer": [
+		"270"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo ASA @Elegoo Giga @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo ASA @Elegoo Giga @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Elegoo ASA @Elegoo Giga @System",
+	"inherits": "Elegoo ASA @Elegoo Giga @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFB98",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo ASA @Elegoo Giga @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo ASA @Elegoo Giga @base.json
@@ -1,0 +1,16 @@
+{
+	"type": "filament",
+	"name": "Elegoo ASA @Elegoo Giga @base",
+	"inherits": "Generic ASA @Elegoo",
+	"from": "system",
+	"instantiation": "false",
+	"filament_max_volumetric_speed": [
+		"30"
+	],
+	"nozzle_temperature": [
+		"270"
+	],
+	"nozzle_temperature_initial_layer": [
+		"270"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PAHT-CF @ECC2 @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PAHT-CF @ECC2 @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "Elegoo PAHT-CF @ECC2 @System",
+	"inherits": "Elegoo PAHT-CF @ECC2 @base",
+	"from": "system",
+	"setting_id": "EPAHTCFECC2",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PAHT-CF @ECC2 @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PAHT-CF @ECC2 @base.json
@@ -1,0 +1,64 @@
+{
+	"type": "filament",
+	"name": "Elegoo PAHT-CF @ECC2 @base",
+	"inherits": "Elegoo PAHT @base",
+	"from": "system",
+	"instantiation": "false",
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"fan_cooling_layer_time": [
+		"5"
+	],
+	"fan_max_speed": [
+		"30"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"filament_flow_ratio": [
+		"0.96"
+	],
+	"filament_max_volumetric_speed": [
+		"8"
+	],
+	"nozzle_temperature": [
+		"290"
+	],
+	"nozzle_temperature_initial_layer": [
+		"290"
+	],
+	"nozzle_temperature_range_high": [
+		"290"
+	],
+	"nozzle_temperature_range_low": [
+		"260"
+	],
+	"overhang_fan_speed": [
+		"40"
+	],
+	"overhang_fan_threshold": [
+		"0%"
+	],
+	"reduce_fan_stop_start_freq": [
+		"0"
+	],
+	"slow_down_layer_time": [
+		"2"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"textured_plate_temp": [
+		"100"
+	],
+	"textured_plate_temp_initial_layer": [
+		"100"
+	],
+	"pressure_advance": [
+		"0.024"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PC @0.2 nozzle @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PC @0.2 nozzle @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "Elegoo PC @0.2 nozzle @System",
+	"inherits": "Elegoo PC @0.2 nozzle @base",
+	"from": "system",
+	"setting_id": "EPC00020",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PC @0.2 nozzle @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PC @0.2 nozzle @base.json
@@ -1,0 +1,49 @@
+{
+	"type": "filament",
+	"name": "Elegoo PC @0.2 nozzle @base",
+	"inherits": "Elegoo PC @base",
+	"from": "system",
+	"instantiation": "false",
+	"pressure_advance": [
+		"0.024"
+	],
+	"nozzle_temperature": [
+		"270"
+	],
+	"nozzle_temperature_initial_layer": [
+		"270"
+	],
+	"nozzle_temperature_range_high": [
+		"270"
+	],
+	"nozzle_temperature_range_low": [
+		"250"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"slow_down_layer_time": [
+		"6"
+	],
+	"textured_plate_temp": [
+		"100"
+	],
+	"textured_plate_temp_initial_layer": [
+		"100"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"fan_max_speed": [
+		"35"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"filament_max_volumetric_speed": [
+		"16"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PC @ECC2 @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PC @ECC2 @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "Elegoo PC @ECC2 @System",
+	"inherits": "Elegoo PC @ECC2 @base",
+	"from": "system",
+	"setting_id": "EPCECC2",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PC @ECC2 @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PC @ECC2 @base.json
@@ -1,0 +1,49 @@
+{
+	"type": "filament",
+	"name": "Elegoo PC @ECC2 @base",
+	"inherits": "Elegoo PC @base",
+	"from": "system",
+	"instantiation": "false",
+	"pressure_advance": [
+		"0.024"
+	],
+	"nozzle_temperature": [
+		"270"
+	],
+	"nozzle_temperature_initial_layer": [
+		"270"
+	],
+	"nozzle_temperature_range_high": [
+		"270"
+	],
+	"nozzle_temperature_range_low": [
+		"250"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"slow_down_layer_time": [
+		"6"
+	],
+	"textured_plate_temp": [
+		"100"
+	],
+	"textured_plate_temp_initial_layer": [
+		"100"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"fan_max_speed": [
+		"35"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"filament_max_volumetric_speed": [
+		"16"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PC-FR @0.2 nozzle @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PC-FR @0.2 nozzle @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "Elegoo PC-FR @0.2 nozzle @System",
+	"inherits": "Elegoo PC-FR @0.2 nozzle @base",
+	"from": "system",
+	"setting_id": "EPCFR00020",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PC-FR @0.2 nozzle @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PC-FR @0.2 nozzle @base.json
@@ -1,0 +1,34 @@
+{
+	"type": "filament",
+	"name": "Elegoo PC-FR @0.2 nozzle @base",
+	"inherits": "Elegoo PC @base",
+	"from": "system",
+	"instantiation": "false",
+	"pressure_advance": [
+		"0.024"
+	],
+	"nozzle_temperature": [
+		"280"
+	],
+	"nozzle_temperature_initial_layer": [
+		"280"
+	],
+	"nozzle_temperature_range_high": [
+		"290"
+	],
+	"nozzle_temperature_range_low": [
+		"260"
+	],
+	"slow_down_layer_time": [
+		"10"
+	],
+	"fan_max_speed": [
+		"40"
+	],
+	"filament_density": [
+		"1.1"
+	],
+	"filament_max_volumetric_speed": [
+		"18"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PC-FR @ECC2 @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PC-FR @ECC2 @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "Elegoo PC-FR @ECC2 @System",
+	"inherits": "Elegoo PC-FR @ECC2 @base",
+	"from": "system",
+	"setting_id": "EPCFRECC2",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PC-FR @ECC2 @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PC-FR @ECC2 @base.json
@@ -1,0 +1,34 @@
+{
+	"type": "filament",
+	"name": "Elegoo PC-FR @ECC2 @base",
+	"inherits": "Elegoo PC @base",
+	"from": "system",
+	"instantiation": "false",
+	"pressure_advance": [
+		"0.024"
+	],
+	"nozzle_temperature": [
+		"280"
+	],
+	"nozzle_temperature_initial_layer": [
+		"280"
+	],
+	"nozzle_temperature_range_high": [
+		"290"
+	],
+	"nozzle_temperature_range_low": [
+		"260"
+	],
+	"slow_down_layer_time": [
+		"10"
+	],
+	"fan_max_speed": [
+		"40"
+	],
+	"filament_density": [
+		"1.1"
+	],
+	"filament_max_volumetric_speed": [
+		"18"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PETG @0.2 nozzle @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PETG @0.2 nozzle @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "Elegoo PETG @0.2 nozzle @System",
+	"inherits": "Elegoo PETG @0.2 nozzle @base",
+	"from": "system",
+	"setting_id": "EPETG00020",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PETG @0.2 nozzle @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PETG @0.2 nozzle @base.json
@@ -1,0 +1,22 @@
+{
+	"type": "filament",
+	"name": "Elegoo PETG @0.2 nozzle @base",
+	"inherits": "Elegoo PETG @base",
+	"from": "system",
+	"instantiation": "false",
+	"pressure_advance": [
+		"0.024"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"nozzle_temperature": [
+		"250"
+	],
+	"nozzle_temperature_initial_layer": [
+		"250"
+	],
+	"filament_max_volumetric_speed": [
+		"11"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PETG @ECC2 @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PETG @ECC2 @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "Elegoo PETG @ECC2 @System",
+	"inherits": "Elegoo PETG @ECC2 @base",
+	"from": "system",
+	"setting_id": "EPETGECC2",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PETG @ECC2 @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PETG @ECC2 @base.json
@@ -1,0 +1,22 @@
+{
+	"type": "filament",
+	"name": "Elegoo PETG @ECC2 @base",
+	"inherits": "Elegoo PETG @base",
+	"from": "system",
+	"instantiation": "false",
+	"pressure_advance": [
+		"0.024"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"nozzle_temperature": [
+		"250"
+	],
+	"nozzle_temperature_initial_layer": [
+		"250"
+	],
+	"filament_max_volumetric_speed": [
+		"11"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PETG PRO @0.2 nozzle @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PETG PRO @0.2 nozzle @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "Elegoo PETG PRO @0.2 nozzle @System",
+	"inherits": "Elegoo PETG PRO @0.2 nozzle @base",
+	"from": "system",
+	"setting_id": "EGPETG00020",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PETG PRO @0.2 nozzle @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PETG PRO @0.2 nozzle @base.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Elegoo PETG PRO @0.2 nozzle @base",
+	"inherits": "Elegoo PETG PRO @base",
+	"from": "system",
+	"instantiation": "false",
+	"filament_max_volumetric_speed": [
+		"1"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PETG PRO @EC @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PETG PRO @EC @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "Elegoo PETG PRO @EC @System",
+	"inherits": "Elegoo PETG PRO @EC @base",
+	"from": "system",
+	"setting_id": "EPETGPROEC",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PETG PRO @EC @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PETG PRO @EC @base.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Elegoo PETG PRO @EC @base",
+	"inherits": "Elegoo PETG PRO @base",
+	"from": "system",
+	"instantiation": "false",
+	"pressure_advance": [
+		"0.024"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PETG PRO @ECC @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PETG PRO @ECC @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "Elegoo PETG PRO @ECC @System",
+	"inherits": "Elegoo PETG PRO @ECC @base",
+	"from": "system",
+	"setting_id": "EPETGPROECC",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PETG PRO @ECC @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PETG PRO @ECC @base.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Elegoo PETG PRO @ECC @base",
+	"inherits": "Elegoo PETG PRO @base",
+	"from": "system",
+	"instantiation": "false",
+	"pressure_advance": [
+		"0.024"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PETG PRO @ECC2 @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PETG PRO @ECC2 @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "Elegoo PETG PRO @ECC2 @System",
+	"inherits": "Elegoo PETG PRO @ECC2 @base",
+	"from": "system",
+	"setting_id": "EPETGPROECC2",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PETG PRO @ECC2 @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PETG PRO @ECC2 @base.json
@@ -1,0 +1,13 @@
+{
+	"type": "filament",
+	"name": "Elegoo PETG PRO @ECC2 @base",
+	"inherits": "Elegoo PETG @base",
+	"from": "system",
+	"instantiation": "false",
+	"pressure_advance": [
+		"0.024"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PETG PRO @Elegoo Giga @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PETG PRO @Elegoo Giga @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Elegoo PETG PRO @Elegoo Giga @System",
+	"inherits": "Elegoo PETG PRO @Elegoo Giga @base",
+	"from": "system",
+	"setting_id": "GFSG99",
+	"filament_id": "GFG99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PETG PRO @Elegoo Giga @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PETG PRO @Elegoo Giga @base.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Elegoo PETG PRO @Elegoo Giga @base",
+	"inherits": "Generic PETG PRO @Elegoo",
+	"from": "system",
+	"instantiation": "false",
+	"filament_max_volumetric_speed": [
+		"21"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PETG Translucent @0.2 nozzle @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PETG Translucent @0.2 nozzle @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "Elegoo PETG Translucent @0.2 nozzle @System",
+	"inherits": "Elegoo PETG Translucent @0.2 nozzle @base",
+	"from": "system",
+	"setting_id": "EPETGTRAN00020",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PETG Translucent @0.2 nozzle @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PETG Translucent @0.2 nozzle @base.json
@@ -1,0 +1,22 @@
+{
+	"type": "filament",
+	"name": "Elegoo PETG Translucent @0.2 nozzle @base",
+	"inherits": "Elegoo PETG @base",
+	"from": "system",
+	"instantiation": "false",
+	"pressure_advance": [
+		"0.024"
+	],
+	"fan_max_speed": [
+		"35"
+	],
+	"filament_max_volumetric_speed": [
+		"10"
+	],
+	"nozzle_temperature": [
+		"255"
+	],
+	"nozzle_temperature_initial_layer": [
+		"255"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PETG Translucent @ECC2 @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PETG Translucent @ECC2 @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "Elegoo PETG Translucent @ECC2 @System",
+	"inherits": "Elegoo PETG Translucent @ECC2 @base",
+	"from": "system",
+	"setting_id": "EPETGTRANSECC2",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PETG Translucent @ECC2 @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PETG Translucent @ECC2 @base.json
@@ -1,0 +1,22 @@
+{
+	"type": "filament",
+	"name": "Elegoo PETG Translucent @ECC2 @base",
+	"inherits": "Elegoo PETG @base",
+	"from": "system",
+	"instantiation": "false",
+	"pressure_advance": [
+		"0.024"
+	],
+	"fan_max_speed": [
+		"35"
+	],
+	"filament_max_volumetric_speed": [
+		"10"
+	],
+	"nozzle_temperature": [
+		"255"
+	],
+	"nozzle_temperature_initial_layer": [
+		"255"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PETG-CF @ECC2 @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PETG-CF @ECC2 @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "Elegoo PETG-CF @ECC2 @System",
+	"inherits": "Elegoo PETG-CF @ECC2 @base",
+	"from": "system",
+	"setting_id": "EPETGCFECC2",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PETG-CF @ECC2 @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PETG-CF @ECC2 @base.json
@@ -1,0 +1,37 @@
+{
+	"type": "filament",
+	"name": "Elegoo PETG-CF @ECC2 @base",
+	"inherits": "Elegoo PETG @base",
+	"from": "system",
+	"instantiation": "false",
+	"pressure_advance": [
+		"0.024"
+	],
+	"filament_density": [
+		"1.26"
+	],
+	"nozzle_temperature": [
+		"250"
+	],
+	"nozzle_temperature_initial_layer": [
+		"250"
+	],
+	"fan_max_speed": [
+		"40"
+	],
+	"fan_min_speed": [
+		"5"
+	],
+	"filament_max_volumetric_speed": [
+		"15"
+	],
+	"nozzle_temperature_range_low": [
+		"240"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"slow_down_layer_time": [
+		"6"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PETG-GF @ECC2 @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PETG-GF @ECC2 @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "Elegoo PETG-GF @ECC2 @System",
+	"inherits": "Elegoo PETG-GF @ECC2 @base",
+	"from": "system",
+	"setting_id": "EPETGFECC2",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PETG-GF @ECC2 @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PETG-GF @ECC2 @base.json
@@ -1,0 +1,37 @@
+{
+	"type": "filament",
+	"name": "Elegoo PETG-GF @ECC2 @base",
+	"inherits": "Elegoo PETG @base",
+	"from": "system",
+	"instantiation": "false",
+	"pressure_advance": [
+		"0.024"
+	],
+	"filament_density": [
+		"1.26"
+	],
+	"nozzle_temperature": [
+		"250"
+	],
+	"nozzle_temperature_initial_layer": [
+		"250"
+	],
+	"fan_max_speed": [
+		"40"
+	],
+	"fan_min_speed": [
+		"5"
+	],
+	"filament_max_volumetric_speed": [
+		"12"
+	],
+	"nozzle_temperature_range_low": [
+		"240"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"slow_down_layer_time": [
+		"6"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA @0.2 nozzle @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA @0.2 nozzle @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "Elegoo PLA @0.2 nozzle @System",
+	"inherits": "Elegoo PLA @0.2 nozzle @base",
+	"from": "system",
+	"setting_id": "EPLA00020",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA @0.2 nozzle @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA @0.2 nozzle @base.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Elegoo PLA @0.2 nozzle @base",
+	"inherits": "Elegoo PLA @base",
+	"from": "system",
+	"instantiation": "false",
+	"filament_max_volumetric_speed": [
+		"3.2"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA @EC @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA @EC @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "Elegoo PLA @EC @System",
+	"inherits": "Elegoo PLA @EC @base",
+	"from": "system",
+	"setting_id": "EPLAEC",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA @EC @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA @EC @base.json
@@ -1,0 +1,25 @@
+{
+	"type": "filament",
+	"name": "Elegoo PLA @EC @base",
+	"inherits": "Elegoo PLA @base",
+	"from": "system",
+	"instantiation": "false",
+	"filament_max_volumetric_speed": [
+		"21"
+	],
+	"nozzle_temperature_initial_layer": [
+		"210"
+	],
+	"nozzle_temperature": [
+		"210"
+	],
+	"pressure_advance": [
+		"0.024"
+	],
+	"slow_down_layer_time": [
+		"4"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA @ECC @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA @ECC @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "Elegoo PLA @ECC @System",
+	"inherits": "Elegoo PLA @ECC @base",
+	"from": "system",
+	"setting_id": "EPLAECC",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA @ECC @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA @ECC @base.json
@@ -1,0 +1,25 @@
+{
+	"type": "filament",
+	"name": "Elegoo PLA @ECC @base",
+	"inherits": "Elegoo PLA @base",
+	"from": "system",
+	"instantiation": "false",
+	"filament_max_volumetric_speed": [
+		"21"
+	],
+	"nozzle_temperature_initial_layer": [
+		"210"
+	],
+	"nozzle_temperature": [
+		"210"
+	],
+	"pressure_advance": [
+		"0.024"
+	],
+	"slow_down_layer_time": [
+		"4"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA @ECC2 @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA @ECC2 @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "Elegoo PLA @ECC2 @System",
+	"inherits": "Elegoo PLA @ECC2 @base",
+	"from": "system",
+	"setting_id": "EPLAECC2",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA @ECC2 @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA @ECC2 @base.json
@@ -1,0 +1,25 @@
+{
+	"type": "filament",
+	"name": "Elegoo PLA @ECC2 @base",
+	"inherits": "Elegoo PLA @base",
+	"from": "system",
+	"instantiation": "false",
+	"filament_max_volumetric_speed": [
+		"21"
+	],
+	"nozzle_temperature_initial_layer": [
+		"210"
+	],
+	"nozzle_temperature": [
+		"210"
+	],
+	"pressure_advance": [
+		"0.024"
+	],
+	"slow_down_layer_time": [
+		"4"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA @Elegoo Giga @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA @Elegoo Giga @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Elegoo PLA @Elegoo Giga @System",
+	"inherits": "Elegoo PLA @Elegoo Giga @base",
+	"from": "system",
+	"setting_id": "GFSL99",
+	"filament_id": "GFL99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA @Elegoo Giga @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA @Elegoo Giga @base.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Elegoo PLA @Elegoo Giga @base",
+	"inherits": "Generic PLA @Elegoo",
+	"from": "system",
+	"instantiation": "false",
+	"filament_max_volumetric_speed": [
+		"30"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA Basic @0.2 nozzle @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA Basic @0.2 nozzle @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "Elegoo PLA Basic @0.2 nozzle @System",
+	"inherits": "Elegoo PLA Basic @0.2 nozzle @base",
+	"from": "system",
+	"setting_id": "EPLABASIC00020",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA Basic @0.2 nozzle @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA Basic @0.2 nozzle @base.json
@@ -1,0 +1,28 @@
+{
+	"type": "filament",
+	"name": "Elegoo PLA Basic @0.2 nozzle @base",
+	"inherits": "Elegoo PLA @base",
+	"from": "system",
+	"instantiation": "false",
+	"nozzle_temperature": [
+		"220"
+	],
+	"nozzle_temperature_initial_layer": [
+		"220"
+	],
+	"nozzle_temperature_range_high": [
+		"230"
+	],
+	"filament_max_volumetric_speed": [
+		"21"
+	],
+	"pressure_advance": [
+		"0.024"
+	],
+	"slow_down_layer_time": [
+		"4"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA Basic @ECC2 @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA Basic @ECC2 @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "Elegoo PLA Basic @ECC2 @System",
+	"inherits": "Elegoo PLA Basic @ECC2 @base",
+	"from": "system",
+	"setting_id": "EPLABASICECC2",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA Basic @ECC2 @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA Basic @ECC2 @base.json
@@ -1,0 +1,28 @@
+{
+	"type": "filament",
+	"name": "Elegoo PLA Basic @ECC2 @base",
+	"inherits": "Elegoo PLA @base",
+	"from": "system",
+	"instantiation": "false",
+	"nozzle_temperature": [
+		"220"
+	],
+	"nozzle_temperature_initial_layer": [
+		"220"
+	],
+	"nozzle_temperature_range_high": [
+		"230"
+	],
+	"filament_max_volumetric_speed": [
+		"21"
+	],
+	"pressure_advance": [
+		"0.024"
+	],
+	"slow_down_layer_time": [
+		"4"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA Galaxy @ECC2 @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA Galaxy @ECC2 @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "Elegoo PLA Galaxy @ECC2 @System",
+	"inherits": "Elegoo PLA Galaxy @ECC2 @base",
+	"from": "system",
+	"setting_id": "EPLAGALAXYECC2",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA Galaxy @ECC2 @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA Galaxy @ECC2 @base.json
@@ -1,0 +1,31 @@
+{
+	"type": "filament",
+	"name": "Elegoo PLA Galaxy @ECC2 @base",
+	"inherits": "Elegoo PLA @base",
+	"from": "system",
+	"instantiation": "false",
+	"fan_min_speed": [
+		"80"
+	],
+	"filament_max_volumetric_speed": [
+		"18"
+	],
+	"nozzle_temperature": [
+		"220"
+	],
+	"nozzle_temperature_initial_layer": [
+		"220"
+	],
+	"nozzle_temperature_range_high": [
+		"220"
+	],
+	"pressure_advance": [
+		"0.024"
+	],
+	"slow_down_layer_time": [
+		"4"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA Marble @ECC2 @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA Marble @ECC2 @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "Elegoo PLA Marble @ECC2 @System",
+	"inherits": "Elegoo PLA Marble @ECC2 @base",
+	"from": "system",
+	"setting_id": "EPLAMARBLEECC2",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA Marble @ECC2 @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA Marble @ECC2 @base.json
@@ -1,0 +1,31 @@
+{
+	"type": "filament",
+	"name": "Elegoo PLA Marble @ECC2 @base",
+	"inherits": "Elegoo PLA @base",
+	"from": "system",
+	"instantiation": "false",
+	"fan_min_speed": [
+		"80"
+	],
+	"filament_max_volumetric_speed": [
+		"18"
+	],
+	"nozzle_temperature": [
+		"220"
+	],
+	"nozzle_temperature_initial_layer": [
+		"220"
+	],
+	"nozzle_temperature_range_high": [
+		"220"
+	],
+	"pressure_advance": [
+		"0.024"
+	],
+	"slow_down_layer_time": [
+		"4"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA Matte @0.2 nozzle @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA Matte @0.2 nozzle @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "Elegoo PLA Matte @0.2 nozzle @System",
+	"inherits": "Elegoo PLA Matte @0.2 nozzle @base",
+	"from": "system",
+	"setting_id": "EPLAM00020",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA Matte @0.2 nozzle @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA Matte @0.2 nozzle @base.json
@@ -1,0 +1,34 @@
+{
+	"type": "filament",
+	"name": "Elegoo PLA Matte @0.2 nozzle @base",
+	"inherits": "Elegoo PLA Matte @base",
+	"from": "system",
+	"instantiation": "false",
+	"fan_cooling_layer_time": [
+		"80"
+	],
+	"fan_max_speed": [
+		"80"
+	],
+	"fan_min_speed": [
+		"60"
+	],
+	"filament_max_volumetric_speed": [
+		"2"
+	],
+	"hot_plate_temp": [
+		"60"
+	],
+	"hot_plate_temp_initial_layer": [
+		"60"
+	],
+	"slow_down_layer_time": [
+		"6"
+	],
+	"textured_plate_temp": [
+		"65"
+	],
+	"textured_plate_temp_initial_layer": [
+		"65"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA Matte @EC @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA Matte @EC @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "Elegoo PLA Matte @EC @System",
+	"inherits": "Elegoo PLA Matte @EC @base",
+	"from": "system",
+	"setting_id": "EPLAMEC",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA Matte @EC @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA Matte @EC @base.json
@@ -1,0 +1,40 @@
+{
+	"type": "filament",
+	"name": "Elegoo PLA Matte @EC @base",
+	"inherits": "Elegoo PLA Matte @base",
+	"from": "system",
+	"instantiation": "false",
+	"fan_cooling_layer_time": [
+		"80"
+	],
+	"fan_max_speed": [
+		"80"
+	],
+	"fan_min_speed": [
+		"60"
+	],
+	"filament_max_volumetric_speed": [
+		"16"
+	],
+	"hot_plate_temp": [
+		"60"
+	],
+	"hot_plate_temp_initial_layer": [
+		"60"
+	],
+	"slow_down_layer_time": [
+		"6"
+	],
+	"textured_plate_temp": [
+		"65"
+	],
+	"textured_plate_temp_initial_layer": [
+		"65"
+	],
+	"pressure_advance": [
+		"0.024"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA Matte @ECC @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA Matte @ECC @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "Elegoo PLA Matte @ECC @System",
+	"inherits": "Elegoo PLA Matte @ECC @base",
+	"from": "system",
+	"setting_id": "EPLAMECC",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA Matte @ECC @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA Matte @ECC @base.json
@@ -1,0 +1,40 @@
+{
+	"type": "filament",
+	"name": "Elegoo PLA Matte @ECC @base",
+	"inherits": "Elegoo PLA Matte @base",
+	"from": "system",
+	"instantiation": "false",
+	"fan_cooling_layer_time": [
+		"80"
+	],
+	"fan_max_speed": [
+		"80"
+	],
+	"fan_min_speed": [
+		"60"
+	],
+	"filament_max_volumetric_speed": [
+		"16"
+	],
+	"hot_plate_temp": [
+		"60"
+	],
+	"hot_plate_temp_initial_layer": [
+		"60"
+	],
+	"slow_down_layer_time": [
+		"6"
+	],
+	"textured_plate_temp": [
+		"65"
+	],
+	"textured_plate_temp_initial_layer": [
+		"65"
+	],
+	"pressure_advance": [
+		"0.024"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA Matte @ECC2 @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA Matte @ECC2 @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "Elegoo PLA Matte @ECC2 @System",
+	"inherits": "Elegoo PLA Matte @ECC2 @base",
+	"from": "system",
+	"setting_id": "EPLAMECC2",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA Matte @ECC2 @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA Matte @ECC2 @base.json
@@ -1,0 +1,46 @@
+{
+	"type": "filament",
+	"name": "Elegoo PLA Matte @ECC2 @base",
+	"inherits": "Elegoo PLA @base",
+	"from": "system",
+	"instantiation": "false",
+	"fan_cooling_layer_time": [
+		"80"
+	],
+	"fan_max_speed": [
+		"80"
+	],
+	"fan_min_speed": [
+		"60"
+	],
+	"filament_max_volumetric_speed": [
+		"16"
+	],
+	"hot_plate_temp": [
+		"60"
+	],
+	"hot_plate_temp_initial_layer": [
+		"60"
+	],
+	"slow_down_layer_time": [
+		"6"
+	],
+	"textured_plate_temp": [
+		"65"
+	],
+	"textured_plate_temp_initial_layer": [
+		"65"
+	],
+	"pressure_advance": [
+		"0.024"
+	],
+	"filament_cost": [
+		"0"
+	],
+	"filament_density": [
+		"1.25"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA Matte @Elegoo Giga @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA Matte @Elegoo Giga @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Elegoo PLA Matte @Elegoo Giga @System",
+	"inherits": "Elegoo PLA Matte @Elegoo Giga @base",
+	"from": "system",
+	"setting_id": "GFSL99",
+	"filament_id": "GFL99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA Matte @Elegoo Giga @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA Matte @Elegoo Giga @base.json
@@ -1,0 +1,34 @@
+{
+	"type": "filament",
+	"name": "Elegoo PLA Matte @Elegoo Giga @base",
+	"inherits": "Generic PLA Matte @Elegoo",
+	"from": "system",
+	"instantiation": "false",
+	"fan_cooling_layer_time": [
+		"80"
+	],
+	"fan_max_speed": [
+		"80"
+	],
+	"fan_min_speed": [
+		"60"
+	],
+	"filament_max_volumetric_speed": [
+		"30"
+	],
+	"hot_plate_temp": [
+		"60"
+	],
+	"hot_plate_temp_initial_layer": [
+		"60"
+	],
+	"slow_down_layer_time": [
+		"6"
+	],
+	"textured_plate_temp": [
+		"65"
+	],
+	"textured_plate_temp_initial_layer": [
+		"65"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA Matte @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA Matte @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "Elegoo PLA Matte @System",
+	"inherits": "Elegoo PLA Matte @base",
+	"from": "system",
+	"setting_id": "EPLAM00",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA PRO @0.2 nozzle @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA PRO @0.2 nozzle @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "Elegoo PLA PRO @0.2 nozzle @System",
+	"inherits": "Elegoo PLA PRO @0.2 nozzle @base",
+	"from": "system",
+	"setting_id": "EPLAPRO00020",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA PRO @0.2 nozzle @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA PRO @0.2 nozzle @base.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Elegoo PLA PRO @0.2 nozzle @base",
+	"inherits": "Elegoo PLA @base",
+	"from": "system",
+	"instantiation": "false",
+	"filament_max_volumetric_speed": [
+		"3.2"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA PRO @EC @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA PRO @EC @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "Elegoo PLA PRO @EC @System",
+	"inherits": "Elegoo PLA PRO @EC @base",
+	"from": "system",
+	"setting_id": "EPLAPROEC",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA PRO @EC @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA PRO @EC @base.json
@@ -1,0 +1,19 @@
+{
+	"type": "filament",
+	"name": "Elegoo PLA PRO @EC @base",
+	"inherits": "Elegoo PLA @base",
+	"from": "system",
+	"instantiation": "false",
+	"filament_max_volumetric_speed": [
+		"20"
+	],
+	"pressure_advance": [
+		"0.024"
+	],
+	"slow_down_layer_time": [
+		"6"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA PRO @ECC @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA PRO @ECC @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "Elegoo PLA PRO @ECC @System",
+	"inherits": "Elegoo PLA PRO @ECC @base",
+	"from": "system",
+	"setting_id": "EPLAPROECC",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA PRO @ECC @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA PRO @ECC @base.json
@@ -1,0 +1,19 @@
+{
+	"type": "filament",
+	"name": "Elegoo PLA PRO @ECC @base",
+	"inherits": "Elegoo PLA @base",
+	"from": "system",
+	"instantiation": "false",
+	"filament_max_volumetric_speed": [
+		"20"
+	],
+	"pressure_advance": [
+		"0.024"
+	],
+	"slow_down_layer_time": [
+		"6"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA PRO @ECC2 @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA PRO @ECC2 @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "Elegoo PLA PRO @ECC2 @System",
+	"inherits": "Elegoo PLA PRO @ECC2 @base",
+	"from": "system",
+	"setting_id": "EPLAPROECC2",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA PRO @ECC2 @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA PRO @ECC2 @base.json
@@ -1,0 +1,19 @@
+{
+	"type": "filament",
+	"name": "Elegoo PLA PRO @ECC2 @base",
+	"inherits": "Elegoo PLA @base",
+	"from": "system",
+	"instantiation": "false",
+	"filament_max_volumetric_speed": [
+		"20"
+	],
+	"pressure_advance": [
+		"0.024"
+	],
+	"slow_down_layer_time": [
+		"6"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA PRO @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA PRO @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "Elegoo PLA PRO @System",
+	"inherits": "Elegoo PLA PRO @base",
+	"from": "system",
+	"setting_id": "EPLAPRO00",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA PRO @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA PRO @base.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Elegoo PLA PRO @base",
+	"inherits": "Elegoo PLA @base",
+	"from": "system",
+	"instantiation": "false",
+	"filament_max_volumetric_speed": [
+		"16"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA Silk @0.2 nozzle @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA Silk @0.2 nozzle @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "Elegoo PLA Silk @0.2 nozzle @System",
+	"inherits": "Elegoo PLA Silk @0.2 nozzle @base",
+	"from": "system",
+	"setting_id": "EPLAS00020",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA Silk @0.2 nozzle @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA Silk @0.2 nozzle @base.json
@@ -1,0 +1,34 @@
+{
+	"type": "filament",
+	"name": "Elegoo PLA Silk @0.2 nozzle @base",
+	"inherits": "Elegoo PLA Silk @base",
+	"from": "system",
+	"instantiation": "false",
+	"fan_cooling_layer_time": [
+		"80"
+	],
+	"fan_max_speed": [
+		"80"
+	],
+	"fan_min_speed": [
+		"60"
+	],
+	"filament_max_volumetric_speed": [
+		"2"
+	],
+	"hot_plate_temp": [
+		"60"
+	],
+	"hot_plate_temp_initial_layer": [
+		"60"
+	],
+	"slow_down_layer_time": [
+		"8"
+	],
+	"textured_plate_temp": [
+		"60"
+	],
+	"textured_plate_temp_initial_layer": [
+		"60"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA Silk @EC @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA Silk @EC @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "Elegoo PLA Silk @EC @System",
+	"inherits": "Elegoo PLA Silk @EC @base",
+	"from": "system",
+	"setting_id": "EPLASEC",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA Silk @EC @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA Silk @EC @base.json
@@ -1,0 +1,37 @@
+{
+	"type": "filament",
+	"name": "Elegoo PLA Silk @EC @base",
+	"inherits": "Elegoo PLA Silk @base",
+	"from": "system",
+	"instantiation": "false",
+	"fan_cooling_layer_time": [
+		"80"
+	],
+	"fan_max_speed": [
+		"80"
+	],
+	"fan_min_speed": [
+		"60"
+	],
+	"hot_plate_temp": [
+		"60"
+	],
+	"hot_plate_temp_initial_layer": [
+		"60"
+	],
+	"slow_down_layer_time": [
+		"8"
+	],
+	"textured_plate_temp": [
+		"65"
+	],
+	"textured_plate_temp_initial_layer": [
+		"65"
+	],
+	"pressure_advance": [
+		"0.024"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA Silk @ECC @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA Silk @ECC @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "Elegoo PLA Silk @ECC @System",
+	"inherits": "Elegoo PLA Silk @ECC @base",
+	"from": "system",
+	"setting_id": "EPLASECC",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA Silk @ECC @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA Silk @ECC @base.json
@@ -1,0 +1,37 @@
+{
+	"type": "filament",
+	"name": "Elegoo PLA Silk @ECC @base",
+	"inherits": "Elegoo PLA Silk @base",
+	"from": "system",
+	"instantiation": "false",
+	"fan_cooling_layer_time": [
+		"80"
+	],
+	"fan_max_speed": [
+		"80"
+	],
+	"fan_min_speed": [
+		"60"
+	],
+	"hot_plate_temp": [
+		"60"
+	],
+	"hot_plate_temp_initial_layer": [
+		"60"
+	],
+	"slow_down_layer_time": [
+		"8"
+	],
+	"textured_plate_temp": [
+		"65"
+	],
+	"textured_plate_temp_initial_layer": [
+		"65"
+	],
+	"pressure_advance": [
+		"0.024"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA Silk @ECC2 @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA Silk @ECC2 @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "Elegoo PLA Silk @ECC2 @System",
+	"inherits": "Elegoo PLA Silk @ECC2 @base",
+	"from": "system",
+	"setting_id": "EPLASECC2",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA Silk @ECC2 @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA Silk @ECC2 @base.json
@@ -1,0 +1,46 @@
+{
+	"type": "filament",
+	"name": "Elegoo PLA Silk @ECC2 @base",
+	"inherits": "Elegoo PLA @base",
+	"from": "system",
+	"instantiation": "false",
+	"fan_cooling_layer_time": [
+		"80"
+	],
+	"fan_max_speed": [
+		"80"
+	],
+	"fan_min_speed": [
+		"60"
+	],
+	"hot_plate_temp": [
+		"60"
+	],
+	"hot_plate_temp_initial_layer": [
+		"60"
+	],
+	"slow_down_layer_time": [
+		"8"
+	],
+	"textured_plate_temp": [
+		"65"
+	],
+	"textured_plate_temp_initial_layer": [
+		"65"
+	],
+	"pressure_advance": [
+		"0.024"
+	],
+	"filament_density": [
+		"1.32"
+	],
+	"nozzle_temperature": [
+		"230"
+	],
+	"nozzle_temperature_initial_layer": [
+		"230"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA Silk @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA Silk @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "Elegoo PLA Silk @System",
+	"inherits": "Elegoo PLA Silk @base",
+	"from": "system",
+	"setting_id": "EPLAS00",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA Sparkle @ECC2 @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA Sparkle @ECC2 @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "Elegoo PLA Sparkle @ECC2 @System",
+	"inherits": "Elegoo PLA Sparkle @ECC2 @base",
+	"from": "system",
+	"setting_id": "EPLASPARKLEECC2",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA Sparkle @ECC2 @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA Sparkle @ECC2 @base.json
@@ -1,0 +1,31 @@
+{
+	"type": "filament",
+	"name": "Elegoo PLA Sparkle @ECC2 @base",
+	"inherits": "Elegoo PLA @base",
+	"from": "system",
+	"instantiation": "false",
+	"fan_min_speed": [
+		"80"
+	],
+	"filament_max_volumetric_speed": [
+		"18"
+	],
+	"nozzle_temperature": [
+		"220"
+	],
+	"nozzle_temperature_initial_layer": [
+		"220"
+	],
+	"nozzle_temperature_range_high": [
+		"220"
+	],
+	"pressure_advance": [
+		"0.024"
+	],
+	"slow_down_layer_time": [
+		"4"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA Wood @ECC2 @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA Wood @ECC2 @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "Elegoo PLA Wood @ECC2 @System",
+	"inherits": "Elegoo PLA Wood @ECC2 @base",
+	"from": "system",
+	"setting_id": "EPLAWOODECC2",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA Wood @ECC2 @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA Wood @ECC2 @base.json
@@ -1,0 +1,31 @@
+{
+	"type": "filament",
+	"name": "Elegoo PLA Wood @ECC2 @base",
+	"inherits": "Elegoo PLA @base",
+	"from": "system",
+	"instantiation": "false",
+	"fan_min_speed": [
+		"80"
+	],
+	"filament_max_volumetric_speed": [
+		"15"
+	],
+	"nozzle_temperature": [
+		"220"
+	],
+	"nozzle_temperature_initial_layer": [
+		"220"
+	],
+	"nozzle_temperature_range_low": [
+		"200"
+	],
+	"pressure_advance": [
+		"0.024"
+	],
+	"slow_down_layer_time": [
+		"4"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA+ @0.2 nozzle @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA+ @0.2 nozzle @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "Elegoo PLA+ @0.2 nozzle @System",
+	"inherits": "Elegoo PLA+ @0.2 nozzle @base",
+	"from": "system",
+	"setting_id": "EPLAPLUS00020",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA+ @0.2 nozzle @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA+ @0.2 nozzle @base.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Elegoo PLA+ @0.2 nozzle @base",
+	"inherits": "Elegoo PLA @base",
+	"from": "system",
+	"instantiation": "false",
+	"filament_max_volumetric_speed": [
+		"3.2"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA+ @EC @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA+ @EC @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "Elegoo PLA+ @EC @System",
+	"inherits": "Elegoo PLA+ @EC @base",
+	"from": "system",
+	"setting_id": "EPLAPLUSEC",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA+ @EC @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA+ @EC @base.json
@@ -1,0 +1,19 @@
+{
+	"type": "filament",
+	"name": "Elegoo PLA+ @EC @base",
+	"inherits": "Elegoo PLA @base",
+	"from": "system",
+	"instantiation": "false",
+	"filament_max_volumetric_speed": [
+		"20"
+	],
+	"pressure_advance": [
+		"0.024"
+	],
+	"slow_down_layer_time": [
+		"6"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA+ @ECC @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA+ @ECC @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "Elegoo PLA+ @ECC @System",
+	"inherits": "Elegoo PLA+ @ECC @base",
+	"from": "system",
+	"setting_id": "EPLAPLUSECC",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA+ @ECC @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA+ @ECC @base.json
@@ -1,0 +1,19 @@
+{
+	"type": "filament",
+	"name": "Elegoo PLA+ @ECC @base",
+	"inherits": "Elegoo PLA @base",
+	"from": "system",
+	"instantiation": "false",
+	"filament_max_volumetric_speed": [
+		"20"
+	],
+	"pressure_advance": [
+		"0.024"
+	],
+	"slow_down_layer_time": [
+		"6"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA+ @ECC2 @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA+ @ECC2 @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "Elegoo PLA+ @ECC2 @System",
+	"inherits": "Elegoo PLA+ @ECC2 @base",
+	"from": "system",
+	"setting_id": "EPLAPLUSECC2",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA+ @ECC2 @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA+ @ECC2 @base.json
@@ -1,0 +1,19 @@
+{
+	"type": "filament",
+	"name": "Elegoo PLA+ @ECC2 @base",
+	"inherits": "Elegoo PLA @base",
+	"from": "system",
+	"instantiation": "false",
+	"filament_max_volumetric_speed": [
+		"20"
+	],
+	"pressure_advance": [
+		"0.024"
+	],
+	"slow_down_layer_time": [
+		"6"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA+ @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA+ @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "Elegoo PLA+ @System",
+	"inherits": "Elegoo PLA+ @base",
+	"from": "system",
+	"setting_id": "EPLAPLUS00",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA+ @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA+ @base.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Elegoo PLA+ @base",
+	"inherits": "Elegoo PLA @base",
+	"from": "system",
+	"instantiation": "false",
+	"filament_max_volumetric_speed": [
+		"16"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA-CF @ECC @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA-CF @ECC @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "Elegoo PLA-CF @ECC @System",
+	"inherits": "Elegoo PLA-CF @ECC @base",
+	"from": "system",
+	"setting_id": "EPLACFECC",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA-CF @ECC @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA-CF @ECC @base.json
@@ -1,0 +1,40 @@
+{
+	"type": "filament",
+	"name": "Elegoo PLA-CF @ECC @base",
+	"inherits": "Elegoo PLA-CF @base",
+	"from": "system",
+	"instantiation": "false",
+	"fan_cooling_layer_time": [
+		"80"
+	],
+	"fan_max_speed": [
+		"80"
+	],
+	"fan_min_speed": [
+		"60"
+	],
+	"filament_max_volumetric_speed": [
+		"21"
+	],
+	"hot_plate_temp": [
+		"60"
+	],
+	"hot_plate_temp_initial_layer": [
+		"60"
+	],
+	"slow_down_layer_time": [
+		"6"
+	],
+	"textured_plate_temp": [
+		"65"
+	],
+	"textured_plate_temp_initial_layer": [
+		"65"
+	],
+	"pressure_advance": [
+		"0.024"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA-CF @ECC2 @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA-CF @ECC2 @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "Elegoo PLA-CF @ECC2 @System",
+	"inherits": "Elegoo PLA-CF @ECC2 @base",
+	"from": "system",
+	"setting_id": "EPLACFECC2",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA-CF @ECC2 @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA-CF @ECC2 @base.json
@@ -1,0 +1,55 @@
+{
+	"type": "filament",
+	"name": "Elegoo PLA-CF @ECC2 @base",
+	"inherits": "Elegoo PLA @base",
+	"from": "system",
+	"instantiation": "false",
+	"fan_cooling_layer_time": [
+		"80"
+	],
+	"fan_max_speed": [
+		"80"
+	],
+	"fan_min_speed": [
+		"60"
+	],
+	"filament_max_volumetric_speed": [
+		"21"
+	],
+	"hot_plate_temp": [
+		"60"
+	],
+	"hot_plate_temp_initial_layer": [
+		"60"
+	],
+	"slow_down_layer_time": [
+		"6"
+	],
+	"textured_plate_temp": [
+		"65"
+	],
+	"textured_plate_temp_initial_layer": [
+		"65"
+	],
+	"pressure_advance": [
+		"0.024"
+	],
+	"additional_cooling_fan_speed": [
+		"0"
+	],
+	"cool_plate_temp": [
+		"45"
+	],
+	"cool_plate_temp_initial_layer": [
+		"45"
+	],
+	"filament_density": [
+		"1.21"
+	],
+	"required_nozzle_HRC": [
+		"40"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA-CF @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo PLA-CF @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "Elegoo PLA-CF @System",
+	"inherits": "Elegoo PLA-CF @base",
+	"from": "system",
+	"setting_id": "EPLACF00",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo Rapid PETG @0.2 nozzle @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo Rapid PETG @0.2 nozzle @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "Elegoo Rapid PETG @0.2 nozzle @System",
+	"inherits": "Elegoo Rapid PETG @0.2 nozzle @base",
+	"from": "system",
+	"setting_id": "ERPETG00020",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo Rapid PETG @0.2 nozzle @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo Rapid PETG @0.2 nozzle @base.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Elegoo Rapid PETG @0.2 nozzle @base",
+	"inherits": "Elegoo Rapid PETG @base",
+	"from": "system",
+	"instantiation": "false",
+	"filament_max_volumetric_speed": [
+		"1"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo Rapid PETG @EC @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo Rapid PETG @EC @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "Elegoo Rapid PETG @EC @System",
+	"inherits": "Elegoo Rapid PETG @EC @base",
+	"from": "system",
+	"setting_id": "ERPETGEC",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo Rapid PETG @EC @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo Rapid PETG @EC @base.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Elegoo Rapid PETG @EC @base",
+	"inherits": "Elegoo Rapid PETG @base",
+	"from": "system",
+	"instantiation": "false",
+	"pressure_advance": [
+		"0.024"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo Rapid PETG @ECC @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo Rapid PETG @ECC @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "Elegoo Rapid PETG @ECC @System",
+	"inherits": "Elegoo Rapid PETG @ECC @base",
+	"from": "system",
+	"setting_id": "ERPETGECC",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo Rapid PETG @ECC @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo Rapid PETG @ECC @base.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Elegoo Rapid PETG @ECC @base",
+	"inherits": "Elegoo Rapid PETG @base",
+	"from": "system",
+	"instantiation": "false",
+	"pressure_advance": [
+		"0.024"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo Rapid PETG @ECC2 @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo Rapid PETG @ECC2 @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "Elegoo Rapid PETG @ECC2 @System",
+	"inherits": "Elegoo Rapid PETG @ECC2 @base",
+	"from": "system",
+	"setting_id": "ERPETGECC2",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo Rapid PETG @ECC2 @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo Rapid PETG @ECC2 @base.json
@@ -1,0 +1,28 @@
+{
+	"type": "filament",
+	"name": "Elegoo Rapid PETG @ECC2 @base",
+	"inherits": "Elegoo PETG @base",
+	"from": "system",
+	"instantiation": "false",
+	"pressure_advance": [
+		"0.024"
+	],
+	"fan_max_speed": [
+		"80"
+	],
+	"fan_min_speed": [
+		"30"
+	],
+	"filament_density": [
+		"1.26"
+	],
+	"filament_max_volumetric_speed": [
+		"18"
+	],
+	"nozzle_temperature": [
+		"250"
+	],
+	"nozzle_temperature_initial_layer": [
+		"250"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo Rapid PETG+ @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo Rapid PETG+ @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "Elegoo Rapid PETG+ @System",
+	"inherits": "Elegoo Rapid PETG+ @base",
+	"from": "system",
+	"setting_id": "ERPETGPLUS00",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo Rapid PETG+ @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo Rapid PETG+ @base.json
@@ -1,0 +1,7 @@
+{
+	"type": "filament",
+	"name": "Elegoo Rapid PETG+ @base",
+	"inherits": "Elegoo Rapid PETG @base",
+	"from": "system",
+	"instantiation": "false"
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo Rapid PLA+ @0.2 nozzle @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo Rapid PLA+ @0.2 nozzle @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "Elegoo Rapid PLA+ @0.2 nozzle @System",
+	"inherits": "Elegoo Rapid PLA+ @0.2 nozzle @base",
+	"from": "system",
+	"setting_id": "ERPLAPLUS00020",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo Rapid PLA+ @0.2 nozzle @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo Rapid PLA+ @0.2 nozzle @base.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Elegoo Rapid PLA+ @0.2 nozzle @base",
+	"inherits": "Elegoo Rapid PLA+ @base",
+	"from": "system",
+	"instantiation": "false",
+	"filament_max_volumetric_speed": [
+		"3.2"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo Rapid PLA+ @EC @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo Rapid PLA+ @EC @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "Elegoo Rapid PLA+ @EC @System",
+	"inherits": "Elegoo Rapid PLA+ @EC @base",
+	"from": "system",
+	"setting_id": "ERPLAPLUSEC",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo Rapid PLA+ @EC @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo Rapid PLA+ @EC @base.json
@@ -1,0 +1,40 @@
+{
+	"type": "filament",
+	"name": "Elegoo Rapid PLA+ @EC @base",
+	"inherits": "Elegoo Rapid PLA+ @base",
+	"from": "system",
+	"instantiation": "false",
+	"fan_cooling_layer_time": [
+		"80"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"60"
+	],
+	"filament_max_volumetric_speed": [
+		"21"
+	],
+	"hot_plate_temp": [
+		"60"
+	],
+	"hot_plate_temp_initial_layer": [
+		"60"
+	],
+	"slow_down_layer_time": [
+		"4"
+	],
+	"textured_plate_temp": [
+		"60"
+	],
+	"textured_plate_temp_initial_layer": [
+		"60"
+	],
+	"pressure_advance": [
+		"0.024"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo Rapid PLA+ @ECC @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo Rapid PLA+ @ECC @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "Elegoo Rapid PLA+ @ECC @System",
+	"inherits": "Elegoo Rapid PLA+ @ECC @base",
+	"from": "system",
+	"setting_id": "ERPLAPLUSECC",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo Rapid PLA+ @ECC @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo Rapid PLA+ @ECC @base.json
@@ -1,0 +1,40 @@
+{
+	"type": "filament",
+	"name": "Elegoo Rapid PLA+ @ECC @base",
+	"inherits": "Elegoo Rapid PLA+ @base",
+	"from": "system",
+	"instantiation": "false",
+	"fan_cooling_layer_time": [
+		"80"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"60"
+	],
+	"filament_max_volumetric_speed": [
+		"21"
+	],
+	"hot_plate_temp": [
+		"60"
+	],
+	"hot_plate_temp_initial_layer": [
+		"60"
+	],
+	"slow_down_layer_time": [
+		"4"
+	],
+	"textured_plate_temp": [
+		"60"
+	],
+	"textured_plate_temp_initial_layer": [
+		"60"
+	],
+	"pressure_advance": [
+		"0.024"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo Rapid PLA+ @ECC2 @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo Rapid PLA+ @ECC2 @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "Elegoo Rapid PLA+ @ECC2 @System",
+	"inherits": "Elegoo Rapid PLA+ @ECC2 @base",
+	"from": "system",
+	"setting_id": "ERPLAPLUSECC2",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo Rapid PLA+ @ECC2 @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo Rapid PLA+ @ECC2 @base.json
@@ -1,0 +1,43 @@
+{
+	"type": "filament",
+	"name": "Elegoo Rapid PLA+ @ECC2 @base",
+	"inherits": "Elegoo PLA @base",
+	"from": "system",
+	"instantiation": "false",
+	"fan_cooling_layer_time": [
+		"80"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"60"
+	],
+	"hot_plate_temp": [
+		"60"
+	],
+	"hot_plate_temp_initial_layer": [
+		"60"
+	],
+	"slow_down_layer_time": [
+		"4"
+	],
+	"textured_plate_temp": [
+		"60"
+	],
+	"textured_plate_temp_initial_layer": [
+		"60"
+	],
+	"pressure_advance": [
+		"0.024"
+	],
+	"filament_max_volumetric_speed": [
+		"21"
+	],
+	"filament_density": [
+		"1.25"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo Rapid TPU 95A @ECC2 @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo Rapid TPU 95A @ECC2 @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "Elegoo Rapid TPU 95A @ECC2 @System",
+	"inherits": "Elegoo Rapid TPU 95A @ECC2 @base",
+	"from": "system",
+	"setting_id": "ERTPU95AECC2",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo Rapid TPU 95A @ECC2 @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo Rapid TPU 95A @ECC2 @base.json
@@ -1,0 +1,22 @@
+{
+	"type": "filament",
+	"name": "Elegoo Rapid TPU 95A @ECC2 @base",
+	"inherits": "Elegoo TPU @base",
+	"from": "system",
+	"instantiation": "false",
+	"pressure_advance": [
+		"0.024"
+	],
+	"nozzle_temperature": [
+		"230"
+	],
+	"nozzle_temperature_initial_layer": [
+		"230"
+	],
+	"nozzle_temperature_range_high": [
+		"230"
+	],
+	"filament_max_volumetric_speed": [
+		"12"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo TPU 95A @EC @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo TPU 95A @EC @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "Elegoo TPU 95A @EC @System",
+	"inherits": "Elegoo TPU 95A @EC @base",
+	"from": "system",
+	"setting_id": "ETPU95AEC",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo TPU 95A @EC @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo TPU 95A @EC @base.json
@@ -1,0 +1,13 @@
+{
+	"type": "filament",
+	"name": "Elegoo TPU 95A @EC @base",
+	"inherits": "Elegoo TPU 95A @base",
+	"from": "system",
+	"instantiation": "false",
+	"filament_max_volumetric_speed": [
+		"3.2"
+	],
+	"pressure_advance": [
+		"0.024"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo TPU 95A @ECC @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo TPU 95A @ECC @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "Elegoo TPU 95A @ECC @System",
+	"inherits": "Elegoo TPU 95A @ECC @base",
+	"from": "system",
+	"setting_id": "ETPU95AECC",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo TPU 95A @ECC @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo TPU 95A @ECC @base.json
@@ -1,0 +1,13 @@
+{
+	"type": "filament",
+	"name": "Elegoo TPU 95A @ECC @base",
+	"inherits": "Elegoo TPU 95A @base",
+	"from": "system",
+	"instantiation": "false",
+	"filament_max_volumetric_speed": [
+		"3.2"
+	],
+	"pressure_advance": [
+		"0.024"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo TPU 95A @ECC2 @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo TPU 95A @ECC2 @System.json
@@ -1,0 +1,9 @@
+{
+	"type": "filament",
+	"name": "Elegoo TPU 95A @ECC2 @System",
+	"inherits": "Elegoo TPU 95A @ECC2 @base",
+	"from": "system",
+	"setting_id": "ETPU95AECC2",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo TPU 95A @ECC2 @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo TPU 95A @ECC2 @base.json
@@ -1,0 +1,13 @@
+{
+	"type": "filament",
+	"name": "Elegoo TPU 95A @ECC2 @base",
+	"inherits": "Elegoo TPU @base",
+	"from": "system",
+	"instantiation": "false",
+	"filament_max_volumetric_speed": [
+		"3.2"
+	],
+	"pressure_advance": [
+		"0.024"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Generic ABS @Elegoo @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Generic ABS @Elegoo @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Generic ABS @Elegoo @System",
+	"inherits": "Generic ABS @Elegoo @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFB99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Generic ABS @Elegoo @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Generic ABS @Elegoo @base.json
@@ -1,0 +1,16 @@
+{
+	"type": "filament",
+	"name": "Generic ABS @Elegoo @base",
+	"inherits": "fdm_filament_abs",
+	"from": "system",
+	"instantiation": "false",
+	"filament_flow_ratio": [
+		"0.926"
+	],
+	"filament_max_volumetric_speed": [
+		"12"
+	],
+	"nozzle_temperature_initial_layer": [
+		"245"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Generic ASA @Elegoo @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Generic ASA @Elegoo @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Generic ASA @Elegoo @System",
+	"inherits": "Generic ASA @Elegoo @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFB98",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Generic ASA @Elegoo @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Generic ASA @Elegoo @base.json
@@ -1,0 +1,16 @@
+{
+	"type": "filament",
+	"name": "Generic ASA @Elegoo @base",
+	"inherits": "fdm_filament_asa",
+	"from": "system",
+	"instantiation": "false",
+	"filament_vendor": [
+		"Elegoo"
+	],
+	"filament_density": [
+		"1.1"
+	],
+	"filament_max_volumetric_speed": [
+		"12"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Generic PETG @Elegoo @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Generic PETG @Elegoo @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Generic PETG @Elegoo @System",
+	"inherits": "Generic PETG @Elegoo @base",
+	"from": "system",
+	"setting_id": "GFSG99",
+	"filament_id": "GFG99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Generic PETG @Elegoo @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Generic PETG @Elegoo @base.json
@@ -1,0 +1,46 @@
+{
+	"type": "filament",
+	"name": "Generic PETG @Elegoo @base",
+	"inherits": "fdm_filament_pet",
+	"from": "system",
+	"instantiation": "false",
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"overhang_fan_speed": [
+		"90"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"nozzle_temperature_initial_layer": [
+		"240"
+	],
+	"fan_max_speed": [
+		"50"
+	],
+	"fan_min_speed": [
+		"20"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"8"
+	],
+	"filament_flow_ratio": [
+		"0.95"
+	],
+	"filament_max_volumetric_speed": [
+		"10"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Generic PETG PRO @Elegoo @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Generic PETG PRO @Elegoo @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Generic PETG PRO @Elegoo @System",
+	"inherits": "Generic PETG PRO @Elegoo @base",
+	"from": "system",
+	"setting_id": "GFSG99",
+	"filament_id": "GFG99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Generic PETG PRO @Elegoo @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Generic PETG PRO @Elegoo @base.json
@@ -1,0 +1,79 @@
+{
+	"type": "filament",
+	"name": "Generic PETG PRO @Elegoo @base",
+	"inherits": "fdm_filament_pet",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"0"
+	],
+	"cool_plate_temp_initial_layer": [
+		"0"
+	],
+	"eng_plate_temp": [
+		"70"
+	],
+	"eng_plate_temp_initial_layer": [
+		"70"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"fan_max_speed": [
+		"40"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"filament_cost": [
+		"0"
+	],
+	"filament_density": [
+		"1.25"
+	],
+	"filament_max_volumetric_speed": [
+		"8"
+	],
+	"filament_vendor": [
+		"Elegoo"
+	],
+	"hot_plate_temp": [
+		"70"
+	],
+	"hot_plate_temp_initial_layer": [
+		"70"
+	],
+	"nozzle_temperature_range_high": [
+		"270"
+	],
+	"nozzle_temperature_range_low": [
+		"230"
+	],
+	"nozzle_temperature": [
+		"240"
+	],
+	"nozzle_temperature_initial_layer": [
+		"240"
+	],
+	"overhang_fan_speed": [
+		"90"
+	],
+	"overhang_fan_threshold": [
+		"10%"
+	],
+	"slow_down_layer_time": [
+		"12"
+	],
+	"textured_plate_temp": [
+		"70"
+	],
+	"textured_plate_temp_initial_layer": [
+		"70"
+	],
+	"filament_start_gcode": [
+		"; Filament start gcode\n"
+	],
+	"filament_end_gcode": [
+		"; filament end gcode \n"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Generic PLA @Elegoo @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Generic PLA @Elegoo @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Generic PLA @Elegoo @System",
+	"inherits": "Generic PLA @Elegoo @base",
+	"from": "system",
+	"setting_id": "GFSL99",
+	"filament_id": "GFL99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Generic PLA @Elegoo @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Generic PLA @Elegoo @base.json
@@ -1,0 +1,19 @@
+{
+	"type": "filament",
+	"name": "Generic PLA @Elegoo @base",
+	"inherits": "fdm_filament_pla",
+	"from": "system",
+	"instantiation": "false",
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"filament_max_volumetric_speed": [
+		"15"
+	],
+	"nozzle_temperature_initial_layer": [
+		"210"
+	],
+	"slow_down_layer_time": [
+		"8"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Generic PLA Matte @Elegoo @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Generic PLA Matte @Elegoo @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Generic PLA Matte @Elegoo @System",
+	"inherits": "Generic PLA Matte @Elegoo @base",
+	"from": "system",
+	"setting_id": "GFSL99",
+	"filament_id": "GFL99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Generic PLA Matte @Elegoo @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Generic PLA Matte @Elegoo @base.json
@@ -1,0 +1,19 @@
+{
+	"type": "filament",
+	"name": "Generic PLA Matte @Elegoo @base",
+	"inherits": "fdm_filament_pla",
+	"from": "system",
+	"instantiation": "false",
+	"filament_cost": [
+		"0"
+	],
+	"filament_density": [
+		"1.25"
+	],
+	"filament_vendor": [
+		"Elegoo"
+	],
+	"filament_start_gcode": [
+		"; filament start gcode\n"
+	]
+}


### PR DESCRIPTION
## Summary

Migrates the remaining Elegoo vendor-scoped filament profiles into `OrcaFilamentLibrary` for OrcaSlicer/OrcaSlicer#12162. The vendor profiles are kept as compatibility-scoped wrappers so Elegoo printer compatibility remains unchanged.

## Changes

- Adds `@base` and `@System` OrcaFilamentLibrary entries for Elegoo's printer/nozzle-specific and generic wrapper filaments that were still only present under the vendor folder.
- Updates the corresponding Elegoo vendor filament profiles to inherit from the new library bases while preserving `compatible_printers` / compatibility metadata.
- Regenerates `resources/profiles/OrcaFilamentLibrary.json` so the new Elegoo library profiles are registered.

## Testing

- `python3 scripts/orca_extra_profile_check.py --vendor Elegoo --check-filaments --check-materials --check-obsolete-keys` — 0 errors, 0 warnings
- `git diff --check`

Fixes OrcaSlicer/OrcaSlicer#12162
