### PR TITLE
Migrate MagicMaker filament to OrcaFilamentLibrary

### DIFF
--- a/resources/profiles/MagicMaker/filament/MM Generic PEEK.json
+++ b/resources/profiles/MagicMaker/filament/MM Generic PEEK.json
@@ -1,47 +1,11 @@
 {
 	"type": "filament",
 	"name": "MM Generic PEEK",
-	"inherits": "fdm_filament_peek",
+	"inherits": "MM Generic PEEK @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFG99",
 	"instantiation": "true",
-	"fan_max_speed": [
-		"40"
-	],
-	"filament_cost": [
-		"1000"
-	],
-	"filament_diameter": [
-		"1.75"
-	],
-	"filament_max_volumetric_speed": [
-		"10"
-	],
-	"full_fan_speed_layer": [
-		"5"
-	],
-	"hot_plate_temp": [
-		"60"
-	],
-	"hot_plate_temp_initial_layer": [
-		"60"
-	],
-	"nozzle_temperature": [
-		"420"
-	],
-	"nozzle_temperature_initial_layer": [
-		"420"
-	],
-	"nozzle_temperature_range_high": [
-		"460"
-	],
-	"nozzle_temperature_range_low": [
-		"380"
-	],
-	"temperature_vitrification": [
-		"340"
-	],
 	"compatible_printers": [
 		"MM hj SK 0.4 nozzle",
 		"MM BoneKing 0.4 nozzle"

--- a/resources/profiles/MagicMaker/machine/MM BoneKing 0.4 nozzle.json
+++ b/resources/profiles/MagicMaker/machine/MM BoneKing 0.4 nozzle.json
@@ -73,7 +73,7 @@
 		"30"
 	],
 	"default_filament_profile": [
-		"MM Generic PLA"
+		"Generic PLA @System"
 	],
 	"machine_max_acceleration_e": [
 		"10000"

--- a/resources/profiles/OrcaFilamentLibrary.json
+++ b/resources/profiles/OrcaFilamentLibrary.json
@@ -1507,6 +1507,14 @@
 		{
 			"name": "GreenGate3D PETG @System",
 			"sub_path": "filament/GreenGate3D/GreenGate3D PETG @System.json"
+		},
+		{
+			"name": "MM Generic PEEK @base",
+			"sub_path": "filament/MagicMaker/MM Generic PEEK @base.json"
+		},
+		{
+			"name": "MM Generic PEEK @System",
+			"sub_path": "filament/MagicMaker/MM Generic PEEK @System.json"
 		}
 	],
 	"process_list": [],

--- a/resources/profiles/OrcaFilamentLibrary/filament/MagicMaker/MM Generic PEEK @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/MagicMaker/MM Generic PEEK @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "MM Generic PEEK @System",
+	"inherits": "MM Generic PEEK @base",
+	"from": "system",
+	"instantiation": "true",
+	"compatible_printers": [],
+	"filament_id": "GFG99",
+	"setting_id": "GFSA04"
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/MagicMaker/MM Generic PEEK @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/MagicMaker/MM Generic PEEK @base.json
@@ -1,0 +1,95 @@
+{
+	"type": "filament",
+	"name": "MM Generic PEEK @base",
+	"inherits": "fdm_filament_common",
+	"from": "system",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"105"
+	],
+	"eng_plate_temp": [
+		"105"
+	],
+	"hot_plate_temp": [
+		"60"
+	],
+	"textured_plate_temp": [
+		"105"
+	],
+	"cool_plate_temp_initial_layer": [
+		"105"
+	],
+	"eng_plate_temp_initial_layer": [
+		"105"
+	],
+	"hot_plate_temp_initial_layer": [
+		"60"
+	],
+	"textured_plate_temp_initial_layer": [
+		"105"
+	],
+	"slow_down_for_layer_cooling": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"fan_cooling_layer_time": [
+		"35"
+	],
+	"filament_max_volumetric_speed": [
+		"10"
+	],
+	"filament_type": [
+		"PEEK"
+	],
+	"filament_density": [
+		"1.04"
+	],
+	"filament_cost": [
+		"1000"
+	],
+	"nozzle_temperature_initial_layer": [
+		"420"
+	],
+	"reduce_fan_stop_start_freq": [
+		"1"
+	],
+	"fan_max_speed": [
+		"40"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"overhang_fan_speed": [
+		"80"
+	],
+	"nozzle_temperature": [
+		"420"
+	],
+	"temperature_vitrification": [
+		"340"
+	],
+	"nozzle_temperature_range_low": [
+		"380"
+	],
+	"nozzle_temperature_range_high": [
+		"460"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"slow_down_layer_time": [
+		"3"
+	],
+	"filament_id": "GFG99",
+	"filament_diameter": [
+		"1.75"
+	],
+	"full_fan_speed_layer": [
+		"5"
+	]
+}


### PR DESCRIPTION
## Summary
- add MagicMaker PEEK base/system profiles under OrcaFilamentLibrary
- update the vendor-scoped MagicMaker PEEK profile to inherit from the library base
- fix the BoneKing default filament reference to an existing Generic PLA @System profile so vendor validation is clean

Refs: OrcaSlicer/OrcaSlicer#12162

## Verification
- python3 scripts/orca_extra_profile_check.py --vendor MagicMaker --check-filaments --check-materials --check-obsolete-keys
- git diff --check