### PR TITLE
Migrate Sovol filaments to OrcaFilamentLibrary

### DIFF
--- a/resources/profiles/OrcaFilamentLibrary.json
+++ b/resources/profiles/OrcaFilamentLibrary.json
@@ -1507,6 +1507,254 @@
 		{
 			"name": "GreenGate3D PETG @System",
 			"sub_path": "filament/GreenGate3D/GreenGate3D PETG @System.json"
+		},
+		{
+			"name": "Generic ABS @Sovol SV08 MAX @base",
+			"sub_path": "filament/Sovol/Generic ABS @Sovol SV08 MAX @base.json"
+		},
+		{
+			"name": "Generic ABS @Sovol SV08 MAX @System",
+			"sub_path": "filament/Sovol/Generic ABS @Sovol SV08 MAX @System.json"
+		},
+		{
+			"name": "Generic PC @Sovol SV08 MAX @base",
+			"sub_path": "filament/Sovol/Generic PC @Sovol SV08 MAX @base.json"
+		},
+		{
+			"name": "Generic PC @Sovol SV08 MAX @System",
+			"sub_path": "filament/Sovol/Generic PC @Sovol SV08 MAX @System.json"
+		},
+		{
+			"name": "Generic PETG @Sovol SV08 MAX @base",
+			"sub_path": "filament/Sovol/Generic PETG @Sovol SV08 MAX @base.json"
+		},
+		{
+			"name": "Generic PETG @Sovol SV08 MAX @System",
+			"sub_path": "filament/Sovol/Generic PETG @Sovol SV08 MAX @System.json"
+		},
+		{
+			"name": "Generic PLA @Sovol SV08 MAX @base",
+			"sub_path": "filament/Sovol/Generic PLA @Sovol SV08 MAX @base.json"
+		},
+		{
+			"name": "Generic PLA @Sovol SV08 MAX @System",
+			"sub_path": "filament/Sovol/Generic PLA @Sovol SV08 MAX @System.json"
+		},
+		{
+			"name": "Generic PLA Silk @Sovol SV08 MAX @base",
+			"sub_path": "filament/Sovol/Generic PLA Silk @Sovol SV08 MAX @base.json"
+		},
+		{
+			"name": "Generic PLA Silk @Sovol SV08 MAX @System",
+			"sub_path": "filament/Sovol/Generic PLA Silk @Sovol SV08 MAX @System.json"
+		},
+		{
+			"name": "Generic TPU @Sovol SV08 MAX @base",
+			"sub_path": "filament/Sovol/Generic TPU @Sovol SV08 MAX @base.json"
+		},
+		{
+			"name": "Generic TPU @Sovol SV08 MAX @System",
+			"sub_path": "filament/Sovol/Generic TPU @Sovol SV08 MAX @System.json"
+		},
+		{
+			"name": "Polymaker PETG @Sovol SV08 MAX @base",
+			"sub_path": "filament/Sovol/Polymaker PETG @Sovol SV08 MAX @base.json"
+		},
+		{
+			"name": "Polymaker PETG @Sovol SV08 MAX @System",
+			"sub_path": "filament/Sovol/Polymaker PETG @Sovol SV08 MAX @System.json"
+		},
+		{
+			"name": "SUNLU PETG @Sovol SV08 MAX @base",
+			"sub_path": "filament/Sovol/SUNLU PETG @Sovol SV08 MAX @base.json"
+		},
+		{
+			"name": "SUNLU PETG @Sovol SV08 MAX @System",
+			"sub_path": "filament/Sovol/SUNLU PETG @Sovol SV08 MAX @System.json"
+		},
+		{
+			"name": "Sovol SV06 ACE ABS @base",
+			"sub_path": "filament/Sovol/Sovol SV06 ACE ABS @base.json"
+		},
+		{
+			"name": "Sovol SV06 ACE ABS @System",
+			"sub_path": "filament/Sovol/Sovol SV06 ACE ABS @System.json"
+		},
+		{
+			"name": "Sovol SV06 ACE PETG @base",
+			"sub_path": "filament/Sovol/Sovol SV06 ACE PETG @base.json"
+		},
+		{
+			"name": "Sovol SV06 ACE PETG @System",
+			"sub_path": "filament/Sovol/Sovol SV06 ACE PETG @System.json"
+		},
+		{
+			"name": "Sovol SV06 ACE PLA @base",
+			"sub_path": "filament/Sovol/Sovol SV06 ACE PLA @base.json"
+		},
+		{
+			"name": "Sovol SV06 ACE PLA @System",
+			"sub_path": "filament/Sovol/Sovol SV06 ACE PLA @System.json"
+		},
+		{
+			"name": "Sovol SV06 ACE TPU @base",
+			"sub_path": "filament/Sovol/Sovol SV06 ACE TPU @base.json"
+		},
+		{
+			"name": "Sovol SV06 ACE TPU @System",
+			"sub_path": "filament/Sovol/Sovol SV06 ACE TPU @System.json"
+		},
+		{
+			"name": "Sovol SV06 Plus ACE ABS @base",
+			"sub_path": "filament/Sovol/Sovol SV06 Plus ACE ABS @base.json"
+		},
+		{
+			"name": "Sovol SV06 Plus ACE ABS @System",
+			"sub_path": "filament/Sovol/Sovol SV06 Plus ACE ABS @System.json"
+		},
+		{
+			"name": "Sovol SV06 Plus ACE PETG @base",
+			"sub_path": "filament/Sovol/Sovol SV06 Plus ACE PETG @base.json"
+		},
+		{
+			"name": "Sovol SV06 Plus ACE PETG @System",
+			"sub_path": "filament/Sovol/Sovol SV06 Plus ACE PETG @System.json"
+		},
+		{
+			"name": "Sovol SV06 Plus ACE PLA @base",
+			"sub_path": "filament/Sovol/Sovol SV06 Plus ACE PLA @base.json"
+		},
+		{
+			"name": "Sovol SV06 Plus ACE PLA @System",
+			"sub_path": "filament/Sovol/Sovol SV06 Plus ACE PLA @System.json"
+		},
+		{
+			"name": "Sovol SV06 Plus ACE TPU @base",
+			"sub_path": "filament/Sovol/Sovol SV06 Plus ACE TPU @base.json"
+		},
+		{
+			"name": "Sovol SV06 Plus ACE TPU @System",
+			"sub_path": "filament/Sovol/Sovol SV06 Plus ACE TPU @System.json"
+		},
+		{
+			"name": "Sovol SV07 PLA @base",
+			"sub_path": "filament/Sovol/Sovol SV07 PLA @base.json"
+		},
+		{
+			"name": "Sovol SV07 PLA @System",
+			"sub_path": "filament/Sovol/Sovol SV07 PLA @System.json"
+		},
+		{
+			"name": "Sovol SV08 ABS @base",
+			"sub_path": "filament/Sovol/Sovol SV08 ABS @base.json"
+		},
+		{
+			"name": "Sovol SV08 ABS @System",
+			"sub_path": "filament/Sovol/Sovol SV08 ABS @System.json"
+		},
+		{
+			"name": "Sovol SV08 PETG @base",
+			"sub_path": "filament/Sovol/Sovol SV08 PETG @base.json"
+		},
+		{
+			"name": "Sovol SV08 PETG @System",
+			"sub_path": "filament/Sovol/Sovol SV08 PETG @System.json"
+		},
+		{
+			"name": "Sovol SV08 PLA @base",
+			"sub_path": "filament/Sovol/Sovol SV08 PLA @base.json"
+		},
+		{
+			"name": "Sovol SV08 PLA @System",
+			"sub_path": "filament/Sovol/Sovol SV08 PLA @System.json"
+		},
+		{
+			"name": "Sovol SV08 PLA @SV08 0.2 nozzle @base",
+			"sub_path": "filament/Sovol/Sovol SV08 PLA @SV08 0.2 nozzle @base.json"
+		},
+		{
+			"name": "Sovol SV08 PLA @SV08 0.2 nozzle @System",
+			"sub_path": "filament/Sovol/Sovol SV08 PLA @SV08 0.2 nozzle @System.json"
+		},
+		{
+			"name": "Sovol SV08 TPU @base",
+			"sub_path": "filament/Sovol/Sovol SV08 TPU @base.json"
+		},
+		{
+			"name": "Sovol SV08 TPU @System",
+			"sub_path": "filament/Sovol/Sovol SV08 TPU @System.json"
+		},
+		{
+			"name": "Sovol Zero ABS @base",
+			"sub_path": "filament/Sovol/Sovol Zero ABS @base.json"
+		},
+		{
+			"name": "Sovol Zero ABS @System",
+			"sub_path": "filament/Sovol/Sovol Zero ABS @System.json"
+		},
+		{
+			"name": "Sovol Zero PC @base",
+			"sub_path": "filament/Sovol/Sovol Zero PC @base.json"
+		},
+		{
+			"name": "Sovol Zero PC @System",
+			"sub_path": "filament/Sovol/Sovol Zero PC @System.json"
+		},
+		{
+			"name": "Sovol Zero PETG @base",
+			"sub_path": "filament/Sovol/Sovol Zero PETG @base.json"
+		},
+		{
+			"name": "Sovol Zero PETG @System",
+			"sub_path": "filament/Sovol/Sovol Zero PETG @System.json"
+		},
+		{
+			"name": "Sovol Zero PETG HS Nozzle @base",
+			"sub_path": "filament/Sovol/Sovol Zero PETG HS Nozzle @base.json"
+		},
+		{
+			"name": "Sovol Zero PETG HS Nozzle @System",
+			"sub_path": "filament/Sovol/Sovol Zero PETG HS Nozzle @System.json"
+		},
+		{
+			"name": "Sovol Zero PLA Basic @base",
+			"sub_path": "filament/Sovol/Sovol Zero PLA Basic @base.json"
+		},
+		{
+			"name": "Sovol Zero PLA Basic @System",
+			"sub_path": "filament/Sovol/Sovol Zero PLA Basic @System.json"
+		},
+		{
+			"name": "Sovol Zero PLA Basic HS Nozzle @base",
+			"sub_path": "filament/Sovol/Sovol Zero PLA Basic HS Nozzle @base.json"
+		},
+		{
+			"name": "Sovol Zero PLA Basic HS Nozzle @System",
+			"sub_path": "filament/Sovol/Sovol Zero PLA Basic HS Nozzle @System.json"
+		},
+		{
+			"name": "Sovol Zero PLA Silk @base",
+			"sub_path": "filament/Sovol/Sovol Zero PLA Silk @base.json"
+		},
+		{
+			"name": "Sovol Zero PLA Silk @System",
+			"sub_path": "filament/Sovol/Sovol Zero PLA Silk @System.json"
+		},
+		{
+			"name": "Sovol Zero PLA Silk HS Nozzle @base",
+			"sub_path": "filament/Sovol/Sovol Zero PLA Silk HS Nozzle @base.json"
+		},
+		{
+			"name": "Sovol Zero PLA Silk HS Nozzle @System",
+			"sub_path": "filament/Sovol/Sovol Zero PLA Silk HS Nozzle @System.json"
+		},
+		{
+			"name": "Sovol Zero TPU @base",
+			"sub_path": "filament/Sovol/Sovol Zero TPU @base.json"
+		},
+		{
+			"name": "Sovol Zero TPU @System",
+			"sub_path": "filament/Sovol/Sovol Zero TPU @System.json"
 		}
 	],
 	"process_list": [],

--- a/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Generic ABS @Sovol SV08 MAX @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Generic ABS @Sovol SV08 MAX @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Generic ABS @Sovol SV08 MAX @System",
+	"inherits": "Generic ABS @Sovol SV08 MAX @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFL99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Generic ABS @Sovol SV08 MAX @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Generic ABS @Sovol SV08 MAX @base.json
@@ -1,0 +1,73 @@
+{
+	"type": "filament",
+	"name": "Generic ABS @Sovol SV08 MAX @base",
+	"inherits": "Generic ABS @System",
+	"from": "system",
+	"instantiation": "false",
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"filament_max_volumetric_speed": [
+		"20"
+	],
+	"nozzle_temperature_initial_layer": [
+		"280"
+	],
+	"nozzle_temperature": [
+		"270"
+	],
+	"nozzle_temperature_range_low": [
+		"230"
+	],
+	"nozzle_temperature_range_high": [
+		"300"
+	],
+	"hot_plate_temp": [
+		"95"
+	],
+	"hot_plate_temp_initial_layer": [
+		"95"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"fan_max_speed": [
+		"60"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"full_fan_speed_layer": [
+		"3"
+	],
+	"slow_down_layer_time": [
+		"12"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"activate_air_filtration": [
+		"0"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"50"
+	],
+	"during_print_exhaust_fan_speed": [
+		"50"
+	],
+	"additional_cooling_fan_speed": [
+		"0"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Generic PC @Sovol SV08 MAX @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Generic PC @Sovol SV08 MAX @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Generic PC @Sovol SV08 MAX @System",
+	"inherits": "Generic PC @Sovol SV08 MAX @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFL99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Generic PC @Sovol SV08 MAX @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Generic PC @Sovol SV08 MAX @base.json
@@ -1,0 +1,66 @@
+{
+	"type": "filament",
+	"name": "Generic PC @Sovol SV08 MAX @base",
+	"inherits": "Generic PC @System",
+	"from": "system",
+	"instantiation": "false",
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"filament_max_volumetric_speed": [
+		"18"
+	],
+	"close_fan_the_first_x_layers": "3",
+	"nozzle_temperature_initial_layer": [
+		"280"
+	],
+	"nozzle_temperature": [
+		"260"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"350"
+	],
+	"hot_plate_temp": [
+		"100"
+	],
+	"hot_plate_temp_initial_layer": [
+		"100"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"fan_max_speed": [
+		"40"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"full_fan_speed_layer": [
+		"3"
+	],
+	"slow_down_layer_time": [
+		"12"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"dont_slow_down_outer_wall": "0",
+	"overhang_fan_speed": [
+		"60"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"additional_cooling_fan_speed": "0",
+	"activate_air_filtration": [
+		"0"
+	],
+	"during_print_exhaust_fan_speed": "50",
+	"complete_print_exhaust_fan_speed": "50"
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Generic PETG @Sovol SV08 MAX @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Generic PETG @Sovol SV08 MAX @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Generic PETG @Sovol SV08 MAX @System",
+	"inherits": "Generic PETG @Sovol SV08 MAX @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFL99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Generic PETG @Sovol SV08 MAX @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Generic PETG @Sovol SV08 MAX @base.json
@@ -1,0 +1,74 @@
+{
+	"type": "filament",
+	"name": "Generic PETG @Sovol SV08 MAX @base",
+	"inherits": "Generic PETG @System",
+	"from": "system",
+	"instantiation": "false",
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"filament_max_volumetric_speed": [
+		"15"
+	],
+	"enable_pressure_advance": "1",
+	"pressure_advance": "0.048",
+	"nozzle_temperature_initial_layer": [
+		"265"
+	],
+	"nozzle_temperature": [
+		"255"
+	],
+	"nozzle_temperature_range_low": [
+		"230"
+	],
+	"nozzle_temperature_range_high": [
+		"280"
+	],
+	"hot_plate_temp": [
+		"80"
+	],
+	"hot_plate_temp_initial_layer": [
+		"80"
+	],
+	"fan_min_speed": [
+		"30"
+	],
+	"fan_max_speed": [
+		"50"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"full_fan_speed_layer": [
+		"3"
+	],
+	"slow_down_layer_time": [
+		"8"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"10%"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"filament_retraction_length": [
+		"0.5"
+	],
+	"filament_z_hop": [
+		"0.4"
+	],
+	"activate_air_filtration": [
+		"0"
+	],
+	"during_print_exhaust_fan_speed": "50",
+	"complete_print_exhaust_fan_speed": "50"
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Generic PLA @Sovol SV08 MAX @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Generic PLA @Sovol SV08 MAX @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Generic PLA @Sovol SV08 MAX @System",
+	"inherits": "Generic PLA @Sovol SV08 MAX @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFL99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Generic PLA @Sovol SV08 MAX @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Generic PLA @Sovol SV08 MAX @base.json
@@ -1,0 +1,67 @@
+{
+	"type": "filament",
+	"name": "Generic PLA @Sovol SV08 MAX @base",
+	"inherits": "Generic PLA @System",
+	"from": "system",
+	"instantiation": "false",
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"filament_max_volumetric_speed": [
+		"21"
+	],
+	"nozzle_temperature_initial_layer": [
+		"250"
+	],
+	"nozzle_temperature": [
+		"230"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"250"
+	],
+	"hot_plate_temp": [
+		"65"
+	],
+	"hot_plate_temp_initial_layer": [
+		"65"
+	],
+	"fan_min_speed": [
+		"80"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_cooling_layer_time": [
+		"50"
+	],
+	"slow_down_layer_time": [
+		"6"
+	],
+	"full_fan_speed_layer": [
+		"3"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"dont_slow_down_outer_wall": "0",
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"enable_pressure_advance": "1",
+	"pressure_advance": "0.036",
+	"additional_cooling_fan_speed": "75%",
+	"activate_air_filtration": [
+		"0"
+	],
+	"during_print_exhaust_fan_speed": "50%",
+	"complete_print_exhaust_fan_speed": "50%"
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Generic PLA Silk @Sovol SV08 MAX @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Generic PLA Silk @Sovol SV08 MAX @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Generic PLA Silk @Sovol SV08 MAX @System",
+	"inherits": "Generic PLA Silk @Sovol SV08 MAX @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFL99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Generic PLA Silk @Sovol SV08 MAX @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Generic PLA Silk @Sovol SV08 MAX @base.json
@@ -1,0 +1,68 @@
+{
+	"type": "filament",
+	"name": "Generic PLA Silk @Sovol SV08 MAX @base",
+	"inherits": "Generic PLA @System",
+	"from": "system",
+	"instantiation": "false",
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"filament_max_volumetric_speed": [
+		"15"
+	],
+	"nozzle_temperature_initial_layer": [
+		"250"
+	],
+	"nozzle_temperature": [
+		"230"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"250"
+	],
+	"hot_plate_temp": [
+		"65"
+	],
+	"hot_plate_temp_initial_layer": [
+		"65"
+	],
+	"fan_min_speed": [
+		"80"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_cooling_layer_time": [
+		"50"
+	],
+	"slow_down_layer_time": [
+		"6"
+	],
+	"full_fan_speed_layer": [
+		"3"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"dont_slow_down_outer_wall": "0",
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"enable_pressure_advance": "1",
+	"pressure_advance": "0.038",
+	"filament_z_hop": "0.4",
+	"additional_cooling_fan_speed": "75%",
+	"activate_air_filtration": [
+		"0"
+	],
+	"during_print_exhaust_fan_speed": "50%",
+	"complete_print_exhaust_fan_speed": "50%"
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Generic TPU @Sovol SV08 MAX @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Generic TPU @Sovol SV08 MAX @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Generic TPU @Sovol SV08 MAX @System",
+	"inherits": "Generic TPU @Sovol SV08 MAX @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFL99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Generic TPU @Sovol SV08 MAX @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Generic TPU @Sovol SV08 MAX @base.json
@@ -1,0 +1,70 @@
+{
+	"type": "filament",
+	"name": "Generic TPU @Sovol SV08 MAX @base",
+	"inherits": "Generic TPU @System",
+	"from": "system",
+	"instantiation": "false",
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"filament_max_volumetric_speed": [
+		"3"
+	],
+	"nozzle_temperature": [
+		"240"
+	],
+	"nozzle_temperature_initial_layer": [
+		"250"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"250"
+	],
+	"hot_plate_temp": [
+		"85"
+	],
+	"hot_plate_temp_initial_layer": [
+		"85"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"fan_cooling_layer_time": [
+		"50"
+	],
+	"full_fan_speed_layer": [
+		"3"
+	],
+	"slow_down_layer_time": [
+		"8"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"filament_retraction_length": [
+		"0.4"
+	],
+	"filament_z_hop": [
+		"0.4"
+	],
+	"additional_cooling_fan_speed": "50",
+	"activate_air_filtration": [
+		"0"
+	],
+	"during_print_exhaust_fan_speed": "100",
+	"complete_print_exhaust_fan_speed": "50"
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Polymaker PETG @Sovol SV08 MAX @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Polymaker PETG @Sovol SV08 MAX @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Polymaker PETG @Sovol SV08 MAX @System",
+	"inherits": "Polymaker PETG @Sovol SV08 MAX @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFL99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Polymaker PETG @Sovol SV08 MAX @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Polymaker PETG @Sovol SV08 MAX @base.json
@@ -1,0 +1,75 @@
+{
+	"type": "filament",
+	"name": "Polymaker PETG @Sovol SV08 MAX @base",
+	"inherits": "Generic PETG @System",
+	"from": "system",
+	"instantiation": "false",
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"filament_max_volumetric_speed": [
+		"12"
+	],
+	"enable_pressure_advance": "1",
+	"pressure_advance": "0.08",
+	"nozzle_temperature_initial_layer": [
+		"275"
+	],
+	"nozzle_temperature": [
+		"270"
+	],
+	"nozzle_temperature_range_low": [
+		"230"
+	],
+	"nozzle_temperature_range_high": [
+		"280"
+	],
+	"hot_plate_temp": [
+		"80"
+	],
+	"hot_plate_temp_initial_layer": [
+		"80"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"fan_max_speed": [
+		"40"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"full_fan_speed_layer": [
+		"3"
+	],
+	"slow_down_layer_time": [
+		"12"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"10%"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"filament_retraction_length": [
+		"0.5"
+	],
+	"filament_z_hop": [
+		"0.4"
+	],
+	"dont_slow_down_outer_wall": "1",
+	"activate_air_filtration": [
+		"0"
+	],
+	"during_print_exhaust_fan_speed": "50",
+	"complete_print_exhaust_fan_speed": "50"
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Sovol/SUNLU PETG @Sovol SV08 MAX @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Sovol/SUNLU PETG @Sovol SV08 MAX @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "SUNLU PETG @Sovol SV08 MAX @System",
+	"inherits": "SUNLU PETG @Sovol SV08 MAX @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFL99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Sovol/SUNLU PETG @Sovol SV08 MAX @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Sovol/SUNLU PETG @Sovol SV08 MAX @base.json
@@ -1,0 +1,75 @@
+{
+	"type": "filament",
+	"name": "SUNLU PETG @Sovol SV08 MAX @base",
+	"inherits": "Generic PETG @System",
+	"from": "system",
+	"instantiation": "false",
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"filament_max_volumetric_speed": [
+		"13"
+	],
+	"enable_pressure_advance": "1",
+	"pressure_advance": "0.052",
+	"nozzle_temperature_initial_layer": [
+		"265"
+	],
+	"nozzle_temperature": [
+		"255"
+	],
+	"nozzle_temperature_range_low": [
+		"230"
+	],
+	"nozzle_temperature_range_high": [
+		"280"
+	],
+	"hot_plate_temp": [
+		"80"
+	],
+	"hot_plate_temp_initial_layer": [
+		"80"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"fan_max_speed": [
+		"40"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"full_fan_speed_layer": [
+		"3"
+	],
+	"slow_down_layer_time": [
+		"12"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"10%"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"filament_retraction_length": [
+		"0.5"
+	],
+	"filament_z_hop": [
+		"0.4"
+	],
+	"dont_slow_down_outer_wall": "1",
+	"activate_air_filtration": [
+		"0"
+	],
+	"during_print_exhaust_fan_speed": "50",
+	"complete_print_exhaust_fan_speed": "50"
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol SV06 ACE ABS @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol SV06 ACE ABS @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Sovol SV06 ACE ABS @System",
+	"inherits": "Sovol SV06 ACE ABS @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFL99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol SV06 ACE ABS @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol SV06 ACE ABS @base.json
@@ -1,0 +1,46 @@
+{
+	"type": "filament",
+	"name": "Sovol SV06 ACE ABS @base",
+	"inherits": "Generic ABS @System",
+	"from": "system",
+	"instantiation": "false",
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"filament_max_volumetric_speed": [
+		"15"
+	],
+	"full_fan_speed_layer": [
+		"3"
+	],
+	"fan_min_speed": [
+		"30"
+	],
+	"fan_cooling_layer_time": [
+		"80"
+	],
+	"fan_max_speed": [
+		"30"
+	],
+	"slow_down_layer_time": [
+		"5"
+	],
+	"nozzle_temperature_initial_layer": [
+		"280"
+	],
+	"nozzle_temperature": [
+		"270"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"300"
+	],
+	"hot_plate_temp_initial_layer": [
+		"95"
+	],
+	"hot_plate_temp": [
+		"95"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol SV06 ACE PETG @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol SV06 ACE PETG @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Sovol SV06 ACE PETG @System",
+	"inherits": "Sovol SV06 ACE PETG @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFL99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol SV06 ACE PETG @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol SV06 ACE PETG @base.json
@@ -1,0 +1,46 @@
+{
+	"type": "filament",
+	"name": "Sovol SV06 ACE PETG @base",
+	"inherits": "Generic PETG @System",
+	"from": "system",
+	"instantiation": "false",
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"filament_max_volumetric_speed": [
+		"15"
+	],
+	"full_fan_speed_layer": [
+		"3"
+	],
+	"fan_min_speed": [
+		"30"
+	],
+	"fan_cooling_layer_time": [
+		"80"
+	],
+	"fan_max_speed": [
+		"30"
+	],
+	"slow_down_layer_time": [
+		"5"
+	],
+	"nozzle_temperature_initial_layer": [
+		"260"
+	],
+	"nozzle_temperature": [
+		"245"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"300"
+	],
+	"hot_plate_temp_initial_layer": [
+		"85"
+	],
+	"hot_plate_temp": [
+		"85"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol SV06 ACE PLA @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol SV06 ACE PLA @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Sovol SV06 ACE PLA @System",
+	"inherits": "Sovol SV06 ACE PLA @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFL99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol SV06 ACE PLA @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol SV06 ACE PLA @base.json
@@ -1,0 +1,49 @@
+{
+	"type": "filament",
+	"name": "Sovol SV06 ACE PLA @base",
+	"inherits": "Generic PLA @System",
+	"from": "system",
+	"instantiation": "false",
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"filament_max_volumetric_speed": [
+		"21"
+	],
+	"full_fan_speed_layer": [
+		"3"
+	],
+	"fan_min_speed": [
+		"50"
+	],
+	"fan_cooling_layer_time": [
+		"80"
+	],
+	"fan_max_speed": [
+		"80"
+	],
+	"slow_down_layer_time": [
+		"6"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"nozzle_temperature_initial_layer": [
+		"235"
+	],
+	"nozzle_temperature": [
+		"210"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"300"
+	],
+	"hot_plate_temp_initial_layer": [
+		"60"
+	],
+	"hot_plate_temp": [
+		"60"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol SV06 ACE TPU @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol SV06 ACE TPU @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Sovol SV06 ACE TPU @System",
+	"inherits": "Sovol SV06 ACE TPU @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFL99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol SV06 ACE TPU @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol SV06 ACE TPU @base.json
@@ -1,0 +1,49 @@
+{
+	"type": "filament",
+	"name": "Sovol SV06 ACE TPU @base",
+	"inherits": "Generic TPU @System",
+	"from": "system",
+	"instantiation": "false",
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"filament_max_volumetric_speed": [
+		"3.6"
+	],
+	"full_fan_speed_layer": [
+		"3"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"fan_cooling_layer_time": [
+		"80"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"slow_down_layer_time": [
+		"5"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"nozzle_temperature_initial_layer": [
+		"250"
+	],
+	"nozzle_temperature": [
+		"245"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"300"
+	],
+	"hot_plate_temp_initial_layer": [
+		"60"
+	],
+	"hot_plate_temp": [
+		"60"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol SV06 Plus ACE ABS @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol SV06 Plus ACE ABS @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Sovol SV06 Plus ACE ABS @System",
+	"inherits": "Sovol SV06 Plus ACE ABS @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFL99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol SV06 Plus ACE ABS @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol SV06 Plus ACE ABS @base.json
@@ -1,0 +1,46 @@
+{
+	"type": "filament",
+	"name": "Sovol SV06 Plus ACE ABS @base",
+	"inherits": "Generic ABS @System",
+	"from": "system",
+	"instantiation": "false",
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"filament_max_volumetric_speed": [
+		"15"
+	],
+	"full_fan_speed_layer": [
+		"3"
+	],
+	"fan_min_speed": [
+		"30"
+	],
+	"fan_cooling_layer_time": [
+		"80"
+	],
+	"fan_max_speed": [
+		"30"
+	],
+	"slow_down_layer_time": [
+		"5"
+	],
+	"nozzle_temperature_initial_layer": [
+		"280"
+	],
+	"nozzle_temperature": [
+		"270"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"300"
+	],
+	"hot_plate_temp_initial_layer": [
+		"95"
+	],
+	"hot_plate_temp": [
+		"95"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol SV06 Plus ACE PETG @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol SV06 Plus ACE PETG @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Sovol SV06 Plus ACE PETG @System",
+	"inherits": "Sovol SV06 Plus ACE PETG @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFL99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol SV06 Plus ACE PETG @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol SV06 Plus ACE PETG @base.json
@@ -1,0 +1,46 @@
+{
+	"type": "filament",
+	"name": "Sovol SV06 Plus ACE PETG @base",
+	"inherits": "Generic PETG @System",
+	"from": "system",
+	"instantiation": "false",
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"filament_max_volumetric_speed": [
+		"15"
+	],
+	"full_fan_speed_layer": [
+		"3"
+	],
+	"fan_min_speed": [
+		"30"
+	],
+	"fan_cooling_layer_time": [
+		"80"
+	],
+	"fan_max_speed": [
+		"30"
+	],
+	"slow_down_layer_time": [
+		"5"
+	],
+	"nozzle_temperature_initial_layer": [
+		"260"
+	],
+	"nozzle_temperature": [
+		"245"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"300"
+	],
+	"hot_plate_temp_initial_layer": [
+		"85"
+	],
+	"hot_plate_temp": [
+		"85"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol SV06 Plus ACE PLA @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol SV06 Plus ACE PLA @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Sovol SV06 Plus ACE PLA @System",
+	"inherits": "Sovol SV06 Plus ACE PLA @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFL99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol SV06 Plus ACE PLA @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol SV06 Plus ACE PLA @base.json
@@ -1,0 +1,49 @@
+{
+	"type": "filament",
+	"name": "Sovol SV06 Plus ACE PLA @base",
+	"inherits": "Generic PLA @System",
+	"from": "system",
+	"instantiation": "false",
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"filament_max_volumetric_speed": [
+		"21"
+	],
+	"full_fan_speed_layer": [
+		"3"
+	],
+	"fan_min_speed": [
+		"50"
+	],
+	"fan_cooling_layer_time": [
+		"80"
+	],
+	"fan_max_speed": [
+		"80"
+	],
+	"slow_down_layer_time": [
+		"6"
+	],
+	"slow_down_min_speed": [
+		"20"
+	],
+	"nozzle_temperature_initial_layer": [
+		"235"
+	],
+	"nozzle_temperature": [
+		"210"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"300"
+	],
+	"hot_plate_temp_initial_layer": [
+		"60"
+	],
+	"hot_plate_temp": [
+		"60"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol SV06 Plus ACE TPU @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol SV06 Plus ACE TPU @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Sovol SV06 Plus ACE TPU @System",
+	"inherits": "Sovol SV06 Plus ACE TPU @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFL99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol SV06 Plus ACE TPU @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol SV06 Plus ACE TPU @base.json
@@ -1,0 +1,49 @@
+{
+	"type": "filament",
+	"name": "Sovol SV06 Plus ACE TPU @base",
+	"inherits": "Generic TPU @System",
+	"from": "system",
+	"instantiation": "false",
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"filament_max_volumetric_speed": [
+		"3.6"
+	],
+	"full_fan_speed_layer": [
+		"3"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"fan_cooling_layer_time": [
+		"80"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"slow_down_layer_time": [
+		"5"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"nozzle_temperature_initial_layer": [
+		"250"
+	],
+	"nozzle_temperature": [
+		"245"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"300"
+	],
+	"hot_plate_temp_initial_layer": [
+		"60"
+	],
+	"hot_plate_temp": [
+		"60"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol SV07 PLA @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol SV07 PLA @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Sovol SV07 PLA @System",
+	"inherits": "Sovol SV07 PLA @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFL99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol SV07 PLA @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol SV07 PLA @base.json
@@ -1,0 +1,49 @@
+{
+	"type": "filament",
+	"name": "Sovol SV07 PLA @base",
+	"inherits": "Generic PLA @System",
+	"from": "system",
+	"instantiation": "false",
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"filament_max_volumetric_speed": [
+		"24"
+	],
+	"filament_retraction_length": [
+		"0.5"
+	],
+	"full_fan_speed_layer": [
+		"3"
+	],
+	"fan_min_speed": [
+		"60"
+	],
+	"fan_cooling_layer_time": [
+		"50"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"slow_down_layer_time": [
+		"6"
+	],
+	"nozzle_temperature_initial_layer": [
+		"235"
+	],
+	"nozzle_temperature": [
+		"200"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"260"
+	],
+	"hot_plate_temp_initial_layer": [
+		"65"
+	],
+	"hot_plate_temp": [
+		"65"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol SV08 ABS @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol SV08 ABS @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Sovol SV08 ABS @System",
+	"inherits": "Sovol SV08 ABS @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFL99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol SV08 ABS @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol SV08 ABS @base.json
@@ -1,0 +1,70 @@
+{
+	"type": "filament",
+	"name": "Sovol SV08 ABS @base",
+	"inherits": "Generic ABS @System",
+	"from": "system",
+	"instantiation": "false",
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"filament_max_volumetric_speed": [
+		"21"
+	],
+	"nozzle_temperature_initial_layer": [
+		"280"
+	],
+	"nozzle_temperature": [
+		"270"
+	],
+	"nozzle_temperature_range_low": [
+		"230"
+	],
+	"nozzle_temperature_range_high": [
+		"280"
+	],
+	"hot_plate_temp": [
+		"95"
+	],
+	"hot_plate_temp_initial_layer": [
+		"95"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"fan_max_speed": [
+		"30"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"slow_down_layer_time": [
+		"4"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"overhang_fan_speed": [
+		"30"
+	],
+	"overhang_fan_threshold": [
+		"25%"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"activate_air_filtration": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"60"
+	],
+	"during_print_exhaust_fan_speed": [
+		"100"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol SV08 PETG @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol SV08 PETG @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Sovol SV08 PETG @System",
+	"inherits": "Sovol SV08 PETG @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFL99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol SV08 PETG @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol SV08 PETG @base.json
@@ -1,0 +1,67 @@
+{
+	"type": "filament",
+	"name": "Sovol SV08 PETG @base",
+	"inherits": "Generic PETG @System",
+	"from": "system",
+	"instantiation": "false",
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"filament_max_volumetric_speed": [
+		"17"
+	],
+	"nozzle_temperature_initial_layer": [
+		"255"
+	],
+	"nozzle_temperature": [
+		"235"
+	],
+	"nozzle_temperature_range_low": [
+		"230"
+	],
+	"nozzle_temperature_range_high": [
+		"280"
+	],
+	"hot_plate_temp": [
+		"75"
+	],
+	"hot_plate_temp_initial_layer": [
+		"75"
+	],
+	"fan_min_speed": [
+		"30"
+	],
+	"fan_max_speed": [
+		"70"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"full_fan_speed_layer": [
+		"0"
+	],
+	"slow_down_layer_time": [
+		"5"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"overhang_fan_speed": [
+		"70"
+	],
+	"overhang_fan_threshold": [
+		"10%"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"filament_retraction_length": [
+		"0.5"
+	],
+	"filament_z_hop": [
+		"0.4"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol SV08 PLA @SV08 0.2 nozzle @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol SV08 PLA @SV08 0.2 nozzle @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Sovol SV08 PLA @SV08 0.2 nozzle @System",
+	"inherits": "Sovol SV08 PLA @SV08 0.2 nozzle @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFL99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol SV08 PLA @SV08 0.2 nozzle @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol SV08 PLA @SV08 0.2 nozzle @base.json
@@ -1,0 +1,61 @@
+{
+	"type": "filament",
+	"name": "Sovol SV08 PLA @SV08 0.2 nozzle @base",
+	"inherits": "Generic PLA @System",
+	"from": "system",
+	"instantiation": "false",
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"filament_max_volumetric_speed": [
+		"10"
+	],
+	"nozzle_temperature_initial_layer": [
+		"235"
+	],
+	"nozzle_temperature": [
+		"220"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"250"
+	],
+	"hot_plate_temp": [
+		"65"
+	],
+	"hot_plate_temp_initial_layer": [
+		"65"
+	],
+	"fan_min_speed": [
+		"100"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_cooling_layer_time": [
+		"50"
+	],
+	"close_fan_the_first_x_layers": [
+		"3"
+	],
+	"full_fan_speed_layer": [
+		"3"
+	],
+	"slow_down_layer_time": [
+		"5"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"temperature_vitrification": [
+		"60"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol SV08 PLA @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol SV08 PLA @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Sovol SV08 PLA @System",
+	"inherits": "Sovol SV08 PLA @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFL99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol SV08 PLA @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol SV08 PLA @base.json
@@ -1,0 +1,58 @@
+{
+	"type": "filament",
+	"name": "Sovol SV08 PLA @base",
+	"inherits": "Generic PLA @System",
+	"from": "system",
+	"instantiation": "false",
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"filament_max_volumetric_speed": [
+		"21"
+	],
+	"nozzle_temperature_initial_layer": [
+		"235"
+	],
+	"nozzle_temperature": [
+		"220"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"250"
+	],
+	"hot_plate_temp": [
+		"65"
+	],
+	"hot_plate_temp_initial_layer": [
+		"65"
+	],
+	"fan_min_speed": [
+		"50"
+	],
+	"fan_max_speed": [
+		"70"
+	],
+	"fan_cooling_layer_time": [
+		"50"
+	],
+	"full_fan_speed_layer": [
+		"3"
+	],
+	"slow_down_layer_time": [
+		"5"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"temperature_vitrification": [
+		"60"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol SV08 TPU @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol SV08 TPU @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Sovol SV08 TPU @System",
+	"inherits": "Sovol SV08 TPU @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFL99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol SV08 TPU @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol SV08 TPU @base.json
@@ -1,0 +1,61 @@
+{
+	"type": "filament",
+	"name": "Sovol SV08 TPU @base",
+	"inherits": "Generic TPU @System",
+	"from": "system",
+	"instantiation": "false",
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"filament_max_volumetric_speed": [
+		"3.6"
+	],
+	"nozzle_temperature": [
+		"235"
+	],
+	"nozzle_temperature_initial_layer": [
+		"240"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"250"
+	],
+	"hot_plate_temp": [
+		"65"
+	],
+	"hot_plate_temp_initial_layer": [
+		"65"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"80"
+	],
+	"fan_cooling_layer_time": [
+		"50"
+	],
+	"full_fan_speed_layer": [
+		"3"
+	],
+	"slow_down_layer_time": [
+		"5"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"filament_z_hop": [
+		"0.4"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol Zero ABS @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol Zero ABS @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Sovol Zero ABS @System",
+	"inherits": "Sovol Zero ABS @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFL99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol Zero ABS @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol Zero ABS @base.json
@@ -1,0 +1,73 @@
+{
+	"type": "filament",
+	"name": "Sovol Zero ABS @base",
+	"inherits": "Generic ABS @System",
+	"from": "system",
+	"instantiation": "false",
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"filament_max_volumetric_speed": [
+		"21"
+	],
+	"nozzle_temperature_initial_layer": [
+		"280"
+	],
+	"nozzle_temperature": [
+		"270"
+	],
+	"nozzle_temperature_range_low": [
+		"230"
+	],
+	"nozzle_temperature_range_high": [
+		"300"
+	],
+	"hot_plate_temp": [
+		"100"
+	],
+	"hot_plate_temp_initial_layer": [
+		"100"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"fan_max_speed": [
+		"30"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"full_fan_speed_layer": [
+		"3"
+	],
+	"slow_down_layer_time": [
+		"5"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"overhang_fan_speed": [
+		"30"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"activate_air_filtration": [
+		"1"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"complete_print_exhaust_fan_speed": [
+		"50"
+	],
+	"during_print_exhaust_fan_speed": [
+		"50"
+	],
+	"additional_cooling_fan_speed": [
+		"0"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol Zero PC @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol Zero PC @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Sovol Zero PC @System",
+	"inherits": "Sovol Zero PC @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFL99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol Zero PC @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol Zero PC @base.json
@@ -1,0 +1,63 @@
+{
+	"type": "filament",
+	"name": "Sovol Zero PC @base",
+	"inherits": "Generic PC @System",
+	"from": "system",
+	"instantiation": "false",
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"filament_max_volumetric_speed": [
+		"21"
+	],
+	"nozzle_temperature_initial_layer": [
+		"290"
+	],
+	"nozzle_temperature": [
+		"270"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"350"
+	],
+	"hot_plate_temp": [
+		"110"
+	],
+	"hot_plate_temp_initial_layer": [
+		"110"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"fan_max_speed": [
+		"20"
+	],
+	"fan_cooling_layer_time": [
+		"40"
+	],
+	"full_fan_speed_layer": [
+		"3"
+	],
+	"slow_down_layer_time": [
+		"5"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"dont_slow_down_outer_wall": "0",
+	"overhang_fan_speed": [
+		"20"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"additional_cooling_fan_speed": "0",
+	"activate_air_filtration": "1",
+	"during_print_exhaust_fan_speed": "50",
+	"complete_print_exhaust_fan_speed": "50"
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol Zero PETG @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol Zero PETG @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Sovol Zero PETG @System",
+	"inherits": "Sovol Zero PETG @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFL99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol Zero PETG @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol Zero PETG @base.json
@@ -1,0 +1,72 @@
+{
+	"type": "filament",
+	"name": "Sovol Zero PETG @base",
+	"inherits": "Generic PETG @System",
+	"from": "system",
+	"instantiation": "false",
+	"filament_flow_ratio": [
+		"1.0348"
+	],
+	"enable_pressure_advance": "1",
+	"pressure_advance": "0.046",
+	"filament_max_volumetric_speed": [
+		"15"
+	],
+	"nozzle_temperature_initial_layer": [
+		"265"
+	],
+	"nozzle_temperature": [
+		"245"
+	],
+	"nozzle_temperature_range_low": [
+		"230"
+	],
+	"nozzle_temperature_range_high": [
+		"280"
+	],
+	"hot_plate_temp": [
+		"85"
+	],
+	"hot_plate_temp_initial_layer": [
+		"85"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"fan_max_speed": [
+		"40"
+	],
+	"fan_cooling_layer_time": [
+		"50"
+	],
+	"full_fan_speed_layer": [
+		"3"
+	],
+	"slow_down_layer_time": [
+		"10"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"overhang_fan_speed": [
+		"70"
+	],
+	"overhang_fan_threshold": [
+		"10%"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"filament_retraction_length": [
+		"0.5"
+	],
+	"filament_z_hop": [
+		"0.4"
+	],
+	"activate_air_filtration": "1",
+	"during_print_exhaust_fan_speed": "50",
+	"complete_print_exhaust_fan_speed": "50"
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol Zero PETG HS Nozzle @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol Zero PETG HS Nozzle @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Sovol Zero PETG HS Nozzle @System",
+	"inherits": "Sovol Zero PETG HS Nozzle @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFL99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol Zero PETG HS Nozzle @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol Zero PETG HS Nozzle @base.json
@@ -1,0 +1,72 @@
+{
+	"type": "filament",
+	"name": "Sovol Zero PETG HS Nozzle @base",
+	"inherits": "Generic PETG @System",
+	"from": "system",
+	"instantiation": "false",
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"enable_pressure_advance": "1",
+	"pressure_advance": "0.048",
+	"filament_max_volumetric_speed": [
+		"15"
+	],
+	"nozzle_temperature_initial_layer": [
+		"265"
+	],
+	"nozzle_temperature": [
+		"250"
+	],
+	"nozzle_temperature_range_low": [
+		"230"
+	],
+	"nozzle_temperature_range_high": [
+		"280"
+	],
+	"hot_plate_temp": [
+		"85"
+	],
+	"hot_plate_temp_initial_layer": [
+		"85"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"fan_max_speed": [
+		"40"
+	],
+	"fan_cooling_layer_time": [
+		"50"
+	],
+	"full_fan_speed_layer": [
+		"3"
+	],
+	"slow_down_layer_time": [
+		"10"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"overhang_fan_speed": [
+		"70"
+	],
+	"overhang_fan_threshold": [
+		"10%"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"close_fan_the_first_x_layers": [
+		"1"
+	],
+	"filament_retraction_length": [
+		"0.5"
+	],
+	"filament_z_hop": [
+		"0.4"
+	],
+	"activate_air_filtration": "1",
+	"during_print_exhaust_fan_speed": "50",
+	"complete_print_exhaust_fan_speed": "50"
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol Zero PLA Basic @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol Zero PLA Basic @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Sovol Zero PLA Basic @System",
+	"inherits": "Sovol Zero PLA Basic @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFL99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol Zero PLA Basic @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol Zero PLA Basic @base.json
@@ -1,0 +1,65 @@
+{
+	"type": "filament",
+	"name": "Sovol Zero PLA Basic @base",
+	"inherits": "Generic PLA @System",
+	"from": "system",
+	"instantiation": "false",
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"filament_max_volumetric_speed": [
+		"21"
+	],
+	"enable_pressure_advance": "1",
+	"pressure_advance": "0.032",
+	"nozzle_temperature_initial_layer": [
+		"230"
+	],
+	"nozzle_temperature": [
+		"210"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"250"
+	],
+	"hot_plate_temp": [
+		"65"
+	],
+	"hot_plate_temp_initial_layer": [
+		"65"
+	],
+	"fan_min_speed": [
+		"70"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_cooling_layer_time": [
+		"80"
+	],
+	"full_fan_speed_layer": [
+		"3"
+	],
+	"slow_down_layer_time": [
+		"5"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"dont_slow_down_outer_wall": "0",
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"additional_cooling_fan_speed": "75%",
+	"activate_air_filtration": "1",
+	"during_print_exhaust_fan_speed": "80%",
+	"complete_print_exhaust_fan_speed": "80%"
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol Zero PLA Basic HS Nozzle @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol Zero PLA Basic HS Nozzle @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Sovol Zero PLA Basic HS Nozzle @System",
+	"inherits": "Sovol Zero PLA Basic HS Nozzle @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFL99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol Zero PLA Basic HS Nozzle @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol Zero PLA Basic HS Nozzle @base.json
@@ -1,0 +1,65 @@
+{
+	"type": "filament",
+	"name": "Sovol Zero PLA Basic HS Nozzle @base",
+	"inherits": "Generic PLA @System",
+	"from": "system",
+	"instantiation": "false",
+	"filament_flow_ratio": [
+		"1.0348"
+	],
+	"filament_max_volumetric_speed": [
+		"21"
+	],
+	"enable_pressure_advance": "1",
+	"pressure_advance": "0.03",
+	"nozzle_temperature_initial_layer": [
+		"245"
+	],
+	"nozzle_temperature": [
+		"230"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"250"
+	],
+	"hot_plate_temp": [
+		"65"
+	],
+	"hot_plate_temp_initial_layer": [
+		"65"
+	],
+	"fan_min_speed": [
+		"70"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_cooling_layer_time": [
+		"80"
+	],
+	"full_fan_speed_layer": [
+		"3"
+	],
+	"slow_down_layer_time": [
+		"5"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"dont_slow_down_outer_wall": "0",
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"additional_cooling_fan_speed": "75%",
+	"activate_air_filtration": "1",
+	"during_print_exhaust_fan_speed": "80%",
+	"complete_print_exhaust_fan_speed": "80%"
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol Zero PLA Silk @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol Zero PLA Silk @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Sovol Zero PLA Silk @System",
+	"inherits": "Sovol Zero PLA Silk @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFL99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol Zero PLA Silk @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol Zero PLA Silk @base.json
@@ -1,0 +1,65 @@
+{
+	"type": "filament",
+	"name": "Sovol Zero PLA Silk @base",
+	"inherits": "Generic PLA @System",
+	"from": "system",
+	"instantiation": "false",
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"filament_max_volumetric_speed": [
+		"15"
+	],
+	"enable_pressure_advance": "1",
+	"pressure_advance": "0.029",
+	"nozzle_temperature_initial_layer": [
+		"245"
+	],
+	"nozzle_temperature": [
+		"220"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"250"
+	],
+	"hot_plate_temp": [
+		"65"
+	],
+	"hot_plate_temp_initial_layer": [
+		"65"
+	],
+	"fan_min_speed": [
+		"70"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_cooling_layer_time": [
+		"80"
+	],
+	"full_fan_speed_layer": [
+		"3"
+	],
+	"slow_down_layer_time": [
+		"7"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"dont_slow_down_outer_wall": "0",
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"additional_cooling_fan_speed": "75%",
+	"activate_air_filtration": "1",
+	"during_print_exhaust_fan_speed": "80%",
+	"complete_print_exhaust_fan_speed": "80%"
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol Zero PLA Silk HS Nozzle @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol Zero PLA Silk HS Nozzle @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Sovol Zero PLA Silk HS Nozzle @System",
+	"inherits": "Sovol Zero PLA Silk HS Nozzle @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFL99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol Zero PLA Silk HS Nozzle @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol Zero PLA Silk HS Nozzle @base.json
@@ -1,0 +1,65 @@
+{
+	"type": "filament",
+	"name": "Sovol Zero PLA Silk HS Nozzle @base",
+	"inherits": "Generic PLA @System",
+	"from": "system",
+	"instantiation": "false",
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"filament_max_volumetric_speed": [
+		"15"
+	],
+	"enable_pressure_advance": "1",
+	"pressure_advance": "0.027",
+	"nozzle_temperature_initial_layer": [
+		"245"
+	],
+	"nozzle_temperature": [
+		"230"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"250"
+	],
+	"hot_plate_temp": [
+		"65"
+	],
+	"hot_plate_temp_initial_layer": [
+		"65"
+	],
+	"fan_min_speed": [
+		"70"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_cooling_layer_time": [
+		"80"
+	],
+	"full_fan_speed_layer": [
+		"3"
+	],
+	"slow_down_layer_time": [
+		"5"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"dont_slow_down_outer_wall": "0",
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"additional_cooling_fan_speed": "75%",
+	"activate_air_filtration": "1",
+	"during_print_exhaust_fan_speed": "80%",
+	"complete_print_exhaust_fan_speed": "80%"
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol Zero TPU @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol Zero TPU @System.json
@@ -1,0 +1,10 @@
+{
+	"type": "filament",
+	"name": "Sovol Zero TPU @System",
+	"inherits": "Sovol Zero TPU @base",
+	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFL99",
+	"instantiation": "true",
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol Zero TPU @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Sovol/Sovol Zero TPU @base.json
@@ -1,0 +1,65 @@
+{
+	"type": "filament",
+	"name": "Sovol Zero TPU @base",
+	"inherits": "Generic TPU @System",
+	"from": "system",
+	"instantiation": "false",
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"filament_max_volumetric_speed": [
+		"3.2"
+	],
+	"nozzle_temperature": [
+		"235"
+	],
+	"nozzle_temperature_initial_layer": [
+		"250"
+	],
+	"nozzle_temperature_range_low": [
+		"190"
+	],
+	"nozzle_temperature_range_high": [
+		"250"
+	],
+	"hot_plate_temp": [
+		"85"
+	],
+	"hot_plate_temp_initial_layer": [
+		"85"
+	],
+	"fan_max_speed": [
+		"100"
+	],
+	"fan_min_speed": [
+		"80"
+	],
+	"fan_cooling_layer_time": [
+		"50"
+	],
+	"full_fan_speed_layer": [
+		"3"
+	],
+	"slow_down_layer_time": [
+		"5"
+	],
+	"slow_down_min_speed": [
+		"10"
+	],
+	"overhang_fan_speed": [
+		"100"
+	],
+	"overhang_fan_threshold": [
+		"50%"
+	],
+	"temperature_vitrification": [
+		"60"
+	],
+	"filament_z_hop": [
+		"0.4"
+	],
+	"additional_cooling_fan_speed": "50",
+	"activate_air_filtration": "1",
+	"during_print_exhaust_fan_speed": "100",
+	"complete_print_exhaust_fan_speed": "50"
+}

--- a/resources/profiles/Sovol/filament/Generic ABS @Sovol SV08 MAX.json
+++ b/resources/profiles/Sovol/filament/Generic ABS @Sovol SV08 MAX.json
@@ -1,77 +1,11 @@
 {
 	"type": "filament",
-	"filament_id": "GFL99",
-	"setting_id": "GFSA04",
 	"name": "Generic ABS @Sovol SV08 MAX",
+	"inherits": "Generic ABS @Sovol SV08 MAX @base",
 	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFL99",
 	"instantiation": "true",
-	"inherits": "Generic ABS @System",
-	"filament_flow_ratio": [
-		"0.98"
-	],
-	"filament_max_volumetric_speed": [
-		"20"
-	],
-	"nozzle_temperature_initial_layer": [
-		"280"
-	],
-	"nozzle_temperature": [
-		"270"
-	],
-	"nozzle_temperature_range_low": [
-		"230"
-	],
-	"nozzle_temperature_range_high": [
-		"300"
-	],
-	"hot_plate_temp": [
-		"95"
-	],
-	"hot_plate_temp_initial_layer": [
-		"95"
-	],
-	"fan_min_speed": [
-		"10"
-	],
-	"fan_max_speed": [
-		"60"
-	],
-	"fan_cooling_layer_time": [
-		"30"
-	],
-	"full_fan_speed_layer": [
-		"3"
-	],
-	"slow_down_layer_time": [
-		"12"
-	],
-	"slow_down_min_speed": [
-		"10"
-	],
-	"overhang_fan_speed": [
-		"100"
-	],
-	"overhang_fan_threshold": [
-		"25%"
-	],
-	"temperature_vitrification": [
-		"60"
-	],
-	"activate_air_filtration": [
-		"0"
-	],
-	"close_fan_the_first_x_layers": [
-		"1"
-	],
-	"complete_print_exhaust_fan_speed": [
-		"50"
-	],
-	"during_print_exhaust_fan_speed": [
-		"50"
-	],
-	"additional_cooling_fan_speed": [
-		"0"
-	],
 	"compatible_printers": [
 		"Sovol SV08 MAX 0.4 nozzle",
 		"Sovol SV08 MAX 0.6 nozzle",

--- a/resources/profiles/Sovol/filament/Generic PC @Sovol SV08 MAX.json
+++ b/resources/profiles/Sovol/filament/Generic PC @Sovol SV08 MAX.json
@@ -1,73 +1,14 @@
 {
 	"type": "filament",
-	"filament_id": "GFL99",
-	"setting_id": "GFSA04",
 	"name": "Generic PC @Sovol SV08 MAX",
+	"inherits": "Generic PC @Sovol SV08 MAX @base",
 	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFL99",
 	"instantiation": "true",
-	"inherits": "Generic PC @System",
-	"filament_flow_ratio": [
-		"0.98"
-	],
-	"filament_max_volumetric_speed": [
-		"18"
-	],
 	"compatible_printers": [
 		"Sovol SV08 MAX 0.4 nozzle",
 		"Sovol SV08 MAX 0.6 nozzle",
 		"Sovol SV08 MAX 0.8 nozzle"
-	],
-	"close_fan_the_first_x_layers": "3",
-	"nozzle_temperature_initial_layer": [
-		"280"
-	],
-	"nozzle_temperature": [
-		"260"
-	],
-	"nozzle_temperature_range_low": [
-		"190"
-	],
-	"nozzle_temperature_range_high": [
-		"350"
-	],
-	"hot_plate_temp": [
-		"100"
-	],
-	"hot_plate_temp_initial_layer": [
-		"100"
-	],
-	"fan_min_speed": [
-		"10"
-	],
-	"fan_max_speed": [
-		"40"
-	],
-	"fan_cooling_layer_time": [
-		"30"
-	],
-	"full_fan_speed_layer": [
-		"3"
-	],
-	"slow_down_layer_time": [
-		"12"
-	],
-	"slow_down_min_speed": [
-		"10"
-	],
-	"dont_slow_down_outer_wall": "0",
-	"overhang_fan_speed": [
-		"60"
-	],
-	"overhang_fan_threshold": [
-		"25%"
-	],
-	"temperature_vitrification": [
-		"60"
-	],
-	"additional_cooling_fan_speed": "0",
-	"activate_air_filtration": [
-		"0"
-	],
-	"during_print_exhaust_fan_speed": "50",
-	"complete_print_exhaust_fan_speed": "50"
+	]
 }

--- a/resources/profiles/Sovol/filament/Generic PETG @Sovol SV08 MAX.json
+++ b/resources/profiles/Sovol/filament/Generic PETG @Sovol SV08 MAX.json
@@ -1,78 +1,11 @@
 {
 	"type": "filament",
-	"filament_id": "GFL99",
-	"setting_id": "GFSA04",
 	"name": "Generic PETG @Sovol SV08 MAX",
+	"inherits": "Generic PETG @Sovol SV08 MAX @base",
 	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFL99",
 	"instantiation": "true",
-	"inherits": "Generic PETG @System",
-	"filament_flow_ratio": [
-		"0.98"
-	],
-	"filament_max_volumetric_speed": [
-		"15"
-	],
-	"enable_pressure_advance": "1",
-	"pressure_advance": "0.048",
-	"nozzle_temperature_initial_layer": [
-		"265"
-	],
-	"nozzle_temperature": [
-		"255"
-	],
-	"nozzle_temperature_range_low": [
-		"230"
-	],
-	"nozzle_temperature_range_high": [
-		"280"
-	],
-	"hot_plate_temp": [
-		"80"
-	],
-	"hot_plate_temp_initial_layer": [
-		"80"
-	],
-	"fan_min_speed": [
-		"30"
-	],
-	"fan_max_speed": [
-		"50"
-	],
-	"fan_cooling_layer_time": [
-		"30"
-	],
-	"full_fan_speed_layer": [
-		"3"
-	],
-	"slow_down_layer_time": [
-		"8"
-	],
-	"slow_down_min_speed": [
-		"10"
-	],
-	"overhang_fan_speed": [
-		"100"
-	],
-	"overhang_fan_threshold": [
-		"10%"
-	],
-	"temperature_vitrification": [
-		"60"
-	],
-	"close_fan_the_first_x_layers": [
-		"1"
-	],
-	"filament_retraction_length": [
-		"0.5"
-	],
-	"filament_z_hop": [
-		"0.4"
-	],
-	"activate_air_filtration": [
-		"0"
-	],
-	"during_print_exhaust_fan_speed": "50",
-	"complete_print_exhaust_fan_speed": "50",
 	"compatible_printers": [
 		"Sovol SV08 MAX 0.4 nozzle",
 		"Sovol SV08 MAX 0.6 nozzle",

--- a/resources/profiles/Sovol/filament/Generic PLA @Sovol SV08 MAX.json
+++ b/resources/profiles/Sovol/filament/Generic PLA @Sovol SV08 MAX.json
@@ -1,74 +1,14 @@
 {
 	"type": "filament",
-	"filament_id": "GFL99",
-	"setting_id": "GFSA04",
 	"name": "Generic PLA @Sovol SV08 MAX",
+	"inherits": "Generic PLA @Sovol SV08 MAX @base",
 	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFL99",
 	"instantiation": "true",
-	"inherits": "Generic PLA @System",
-	"filament_flow_ratio": [
-		"0.98"
-	],
-	"filament_max_volumetric_speed": [
-		"21"
-	],
 	"compatible_printers": [
 		"Sovol SV08 MAX 0.4 nozzle",
 		"Sovol SV08 MAX 0.6 nozzle",
 		"Sovol SV08 MAX 0.8 nozzle"
-	],
-	"nozzle_temperature_initial_layer": [
-		"250"
-	],
-	"nozzle_temperature": [
-		"230"
-	],
-	"nozzle_temperature_range_low": [
-		"190"
-	],
-	"nozzle_temperature_range_high": [
-		"250"
-	],
-	"hot_plate_temp": [
-		"65"
-	],
-	"hot_plate_temp_initial_layer": [
-		"65"
-	],
-	"fan_min_speed": [
-		"80"
-	],
-	"fan_max_speed": [
-		"100"
-	],
-	"fan_cooling_layer_time": [
-		"50"
-	],
-	"slow_down_layer_time": [
-		"6"
-	],
-	"full_fan_speed_layer": [
-		"3"
-	],
-	"slow_down_min_speed": [
-		"10"
-	],
-	"dont_slow_down_outer_wall": "0",
-	"overhang_fan_speed": [
-		"100"
-	],
-	"overhang_fan_threshold": [
-		"50%"
-	],
-	"temperature_vitrification": [
-		"60"
-	],
-	"enable_pressure_advance": "1",
-	"pressure_advance": "0.036",
-	"additional_cooling_fan_speed": "75%",
-	"activate_air_filtration": [
-		"0"
-	],
-	"during_print_exhaust_fan_speed": "50%",
-	"complete_print_exhaust_fan_speed": "50%"
+	]
 }

--- a/resources/profiles/Sovol/filament/Generic PLA Silk @Sovol SV08 MAX.json
+++ b/resources/profiles/Sovol/filament/Generic PLA Silk @Sovol SV08 MAX.json
@@ -1,75 +1,14 @@
 {
 	"type": "filament",
-	"filament_id": "GFL99",
-	"setting_id": "GFSA04",
 	"name": "Generic PLA Silk @Sovol SV08 MAX",
+	"inherits": "Generic PLA Silk @Sovol SV08 MAX @base",
 	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFL99",
 	"instantiation": "true",
-	"inherits": "Generic PLA @System",
-	"filament_flow_ratio": [
-		"0.98"
-	],
-	"filament_max_volumetric_speed": [
-		"15"
-	],
 	"compatible_printers": [
 		"Sovol SV08 MAX 0.4 nozzle",
 		"Sovol SV08 MAX 0.6 nozzle",
 		"Sovol SV08 MAX 0.8 nozzle"
-	],
-	"nozzle_temperature_initial_layer": [
-		"250"
-	],
-	"nozzle_temperature": [
-		"230"
-	],
-	"nozzle_temperature_range_low": [
-		"190"
-	],
-	"nozzle_temperature_range_high": [
-		"250"
-	],
-	"hot_plate_temp": [
-		"65"
-	],
-	"hot_plate_temp_initial_layer": [
-		"65"
-	],
-	"fan_min_speed": [
-		"80"
-	],
-	"fan_max_speed": [
-		"100"
-	],
-	"fan_cooling_layer_time": [
-		"50"
-	],
-	"slow_down_layer_time": [
-		"6"
-	],
-	"full_fan_speed_layer": [
-		"3"
-	],
-	"slow_down_min_speed": [
-		"10"
-	],
-	"dont_slow_down_outer_wall": "0",
-	"overhang_fan_speed": [
-		"100"
-	],
-	"overhang_fan_threshold": [
-		"50%"
-	],
-	"temperature_vitrification": [
-		"60"
-	],
-	"enable_pressure_advance": "1",
-	"pressure_advance": "0.038",
-	"filament_z_hop": "0.4",
-	"additional_cooling_fan_speed": "75%",
-	"activate_air_filtration": [
-		"0"
-	],
-	"during_print_exhaust_fan_speed": "50%",
-	"complete_print_exhaust_fan_speed": "50%"
+	]
 }

--- a/resources/profiles/Sovol/filament/Generic TPU @Sovol SV08 MAX.json
+++ b/resources/profiles/Sovol/filament/Generic TPU @Sovol SV08 MAX.json
@@ -1,74 +1,11 @@
 {
 	"type": "filament",
-	"filament_id": "GFL99",
-	"setting_id": "GFSA04",
 	"name": "Generic TPU @Sovol SV08 MAX",
+	"inherits": "Generic TPU @Sovol SV08 MAX @base",
 	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFL99",
 	"instantiation": "true",
-	"inherits": "Generic TPU @System",
-	"filament_flow_ratio": [
-		"0.98"
-	],
-	"filament_max_volumetric_speed": [
-		"3"
-	],
-	"nozzle_temperature": [
-		"240"
-	],
-	"nozzle_temperature_initial_layer": [
-		"250"
-	],
-	"nozzle_temperature_range_low": [
-		"190"
-	],
-	"nozzle_temperature_range_high": [
-		"250"
-	],
-	"hot_plate_temp": [
-		"85"
-	],
-	"hot_plate_temp_initial_layer": [
-		"85"
-	],
-	"fan_max_speed": [
-		"100"
-	],
-	"fan_min_speed": [
-		"100"
-	],
-	"fan_cooling_layer_time": [
-		"50"
-	],
-	"full_fan_speed_layer": [
-		"3"
-	],
-	"slow_down_layer_time": [
-		"8"
-	],
-	"slow_down_min_speed": [
-		"10"
-	],
-	"overhang_fan_speed": [
-		"100"
-	],
-	"overhang_fan_threshold": [
-		"25%"
-	],
-	"temperature_vitrification": [
-		"60"
-	],
-	"filament_retraction_length": [
-		"0.4"
-	],
-	"filament_z_hop": [
-		"0.4"
-	],
-	"additional_cooling_fan_speed": "50",
-	"activate_air_filtration": [
-		"0"
-	],
-	"during_print_exhaust_fan_speed": "100",
-	"complete_print_exhaust_fan_speed": "50",
 	"compatible_printers": [
 		"Sovol SV08 MAX 0.4 nozzle",
 		"Sovol SV08 MAX 0.6 nozzle",

--- a/resources/profiles/Sovol/filament/Polymaker PETG @Sovol SV08 MAX.json
+++ b/resources/profiles/Sovol/filament/Polymaker PETG @Sovol SV08 MAX.json
@@ -1,79 +1,11 @@
 {
 	"type": "filament",
-	"filament_id": "GFL99",
-	"setting_id": "GFSA04",
 	"name": "Polymaker PETG @Sovol SV08 MAX",
+	"inherits": "Polymaker PETG @Sovol SV08 MAX @base",
 	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFL99",
 	"instantiation": "true",
-	"inherits": "Generic PETG @System",
-	"filament_flow_ratio": [
-		"0.98"
-	],
-	"filament_max_volumetric_speed": [
-		"12"
-	],
-	"enable_pressure_advance": "1",
-	"pressure_advance": "0.08",
-	"nozzle_temperature_initial_layer": [
-		"275"
-	],
-	"nozzle_temperature": [
-		"270"
-	],
-	"nozzle_temperature_range_low": [
-		"230"
-	],
-	"nozzle_temperature_range_high": [
-		"280"
-	],
-	"hot_plate_temp": [
-		"80"
-	],
-	"hot_plate_temp_initial_layer": [
-		"80"
-	],
-	"fan_min_speed": [
-		"10"
-	],
-	"fan_max_speed": [
-		"40"
-	],
-	"fan_cooling_layer_time": [
-		"30"
-	],
-	"full_fan_speed_layer": [
-		"3"
-	],
-	"slow_down_layer_time": [
-		"12"
-	],
-	"slow_down_min_speed": [
-		"10"
-	],
-	"overhang_fan_speed": [
-		"100"
-	],
-	"overhang_fan_threshold": [
-		"10%"
-	],
-	"temperature_vitrification": [
-		"60"
-	],
-	"close_fan_the_first_x_layers": [
-		"1"
-	],
-	"filament_retraction_length": [
-		"0.5"
-	],
-	"filament_z_hop": [
-		"0.4"
-	],
-	"dont_slow_down_outer_wall": "1",
-	"activate_air_filtration": [
-		"0"
-	],
-	"during_print_exhaust_fan_speed": "50",
-	"complete_print_exhaust_fan_speed": "50",
 	"compatible_printers": [
 		"Sovol SV08 MAX 0.4 nozzle",
 		"Sovol SV08 MAX 0.6 nozzle",

--- a/resources/profiles/Sovol/filament/SUNLU PETG @Sovol SV08 MAX.json
+++ b/resources/profiles/Sovol/filament/SUNLU PETG @Sovol SV08 MAX.json
@@ -1,79 +1,11 @@
 {
 	"type": "filament",
-	"filament_id": "GFL99",
-	"setting_id": "GFSA04",
 	"name": "SUNLU PETG @Sovol SV08 MAX",
+	"inherits": "SUNLU PETG @Sovol SV08 MAX @base",
 	"from": "system",
+	"setting_id": "GFSA04",
+	"filament_id": "GFL99",
 	"instantiation": "true",
-	"inherits": "Generic PETG @System",
-	"filament_flow_ratio": [
-		"0.98"
-	],
-	"filament_max_volumetric_speed": [
-		"13"
-	],
-	"enable_pressure_advance": "1",
-	"pressure_advance": "0.052",
-	"nozzle_temperature_initial_layer": [
-		"265"
-	],
-	"nozzle_temperature": [
-		"255"
-	],
-	"nozzle_temperature_range_low": [
-		"230"
-	],
-	"nozzle_temperature_range_high": [
-		"280"
-	],
-	"hot_plate_temp": [
-		"80"
-	],
-	"hot_plate_temp_initial_layer": [
-		"80"
-	],
-	"fan_min_speed": [
-		"10"
-	],
-	"fan_max_speed": [
-		"40"
-	],
-	"fan_cooling_layer_time": [
-		"30"
-	],
-	"full_fan_speed_layer": [
-		"3"
-	],
-	"slow_down_layer_time": [
-		"12"
-	],
-	"slow_down_min_speed": [
-		"10"
-	],
-	"overhang_fan_speed": [
-		"100"
-	],
-	"overhang_fan_threshold": [
-		"10%"
-	],
-	"temperature_vitrification": [
-		"60"
-	],
-	"close_fan_the_first_x_layers": [
-		"1"
-	],
-	"filament_retraction_length": [
-		"0.5"
-	],
-	"filament_z_hop": [
-		"0.4"
-	],
-	"dont_slow_down_outer_wall": "1",
-	"activate_air_filtration": [
-		"0"
-	],
-	"during_print_exhaust_fan_speed": "50",
-	"complete_print_exhaust_fan_speed": "50",
 	"compatible_printers": [
 		"Sovol SV08 MAX 0.4 nozzle",
 		"Sovol SV08 MAX 0.6 nozzle",

--- a/resources/profiles/Sovol/filament/Sovol SV06 ACE ABS.json
+++ b/resources/profiles/Sovol/filament/Sovol SV06 ACE ABS.json
@@ -1,54 +1,15 @@
 {
 	"type": "filament",
 	"name": "Sovol SV06 ACE ABS",
-	"inherits": "Generic ABS @System",
+	"inherits": "Sovol SV06 ACE ABS @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFL99",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"0.98"
-	],
-	"filament_max_volumetric_speed": [
-		"15"
-	],
-	"full_fan_speed_layer": [
-		"3"
-	],
 	"compatible_printers": [
 		"Sovol SV06 ACE 0.2 nozzle",
 		"Sovol SV06 ACE 0.4 nozzle",
 		"Sovol SV06 ACE 0.6 nozzle",
 		"Sovol SV06 ACE 0.8 nozzle"
-	],
-	"fan_min_speed": [
-		"30"
-	],
-	"fan_cooling_layer_time": [
-		"80"
-	],
-	"fan_max_speed": [
-		"30"
-	],
-	"slow_down_layer_time": [
-		"5"
-	],
-	"nozzle_temperature_initial_layer": [
-		"280"
-	],
-	"nozzle_temperature": [
-		"270"
-	],
-	"nozzle_temperature_range_low": [
-		"190"
-	],
-	"nozzle_temperature_range_high": [
-		"300"
-	],
-	"hot_plate_temp_initial_layer": [
-		"95"
-	],
-	"hot_plate_temp": [
-		"95"
 	]
 }

--- a/resources/profiles/Sovol/filament/Sovol SV06 ACE PETG.json
+++ b/resources/profiles/Sovol/filament/Sovol SV06 ACE PETG.json
@@ -1,54 +1,15 @@
 {
 	"type": "filament",
 	"name": "Sovol SV06 ACE PETG",
-	"inherits": "Generic PETG @System",
+	"inherits": "Sovol SV06 ACE PETG @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFL99",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"0.98"
-	],
-	"filament_max_volumetric_speed": [
-		"15"
-	],
-	"full_fan_speed_layer": [
-		"3"
-	],
 	"compatible_printers": [
 		"Sovol SV06 ACE 0.2 nozzle",
 		"Sovol SV06 ACE 0.4 nozzle",
 		"Sovol SV06 ACE 0.6 nozzle",
 		"Sovol SV06 ACE 0.8 nozzle"
-	],
-	"fan_min_speed": [
-		"30"
-	],
-	"fan_cooling_layer_time": [
-		"80"
-	],
-	"fan_max_speed": [
-		"30"
-	],
-	"slow_down_layer_time": [
-		"5"
-	],
-	"nozzle_temperature_initial_layer": [
-		"260"
-	],
-	"nozzle_temperature": [
-		"245"
-	],
-	"nozzle_temperature_range_low": [
-		"190"
-	],
-	"nozzle_temperature_range_high": [
-		"300"
-	],
-	"hot_plate_temp_initial_layer": [
-		"85"
-	],
-	"hot_plate_temp": [
-		"85"
 	]
 }

--- a/resources/profiles/Sovol/filament/Sovol SV06 ACE PLA.json
+++ b/resources/profiles/Sovol/filament/Sovol SV06 ACE PLA.json
@@ -1,57 +1,15 @@
 {
 	"type": "filament",
 	"name": "Sovol SV06 ACE PLA",
-	"inherits": "Generic PLA @System",
+	"inherits": "Sovol SV06 ACE PLA @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFL99",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"0.98"
-	],
-	"filament_max_volumetric_speed": [
-		"21"
-	],
-	"full_fan_speed_layer": [
-		"3"
-	],
 	"compatible_printers": [
 		"Sovol SV06 ACE 0.2 nozzle",
 		"Sovol SV06 ACE 0.4 nozzle",
 		"Sovol SV06 ACE 0.6 nozzle",
 		"Sovol SV06 ACE 0.8 nozzle"
-	],
-	"fan_min_speed": [
-		"50"
-	],
-	"fan_cooling_layer_time": [
-		"80"
-	],
-	"fan_max_speed": [
-		"80"
-	],
-	"slow_down_layer_time": [
-		"6"
-	],
-	"slow_down_min_speed": [
-		"20"
-	],
-	"nozzle_temperature_initial_layer": [
-		"235"
-	],
-	"nozzle_temperature": [
-		"210"
-	],
-	"nozzle_temperature_range_low": [
-		"190"
-	],
-	"nozzle_temperature_range_high": [
-		"300"
-	],
-	"hot_plate_temp_initial_layer": [
-		"60"
-	],
-	"hot_plate_temp": [
-		"60"
 	]
 }

--- a/resources/profiles/Sovol/filament/Sovol SV06 ACE TPU.json
+++ b/resources/profiles/Sovol/filament/Sovol SV06 ACE TPU.json
@@ -1,57 +1,15 @@
 {
 	"type": "filament",
 	"name": "Sovol SV06 ACE TPU",
-	"inherits": "Generic TPU @System",
+	"inherits": "Sovol SV06 ACE TPU @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFL99",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"0.98"
-	],
-	"filament_max_volumetric_speed": [
-		"3.6"
-	],
-	"full_fan_speed_layer": [
-		"3"
-	],
 	"compatible_printers": [
 		"Sovol SV06 ACE 0.2 nozzle",
 		"Sovol SV06 ACE 0.4 nozzle",
 		"Sovol SV06 ACE 0.6 nozzle",
 		"Sovol SV06 ACE 0.8 nozzle"
-	],
-	"fan_min_speed": [
-		"100"
-	],
-	"fan_cooling_layer_time": [
-		"80"
-	],
-	"fan_max_speed": [
-		"100"
-	],
-	"slow_down_layer_time": [
-		"5"
-	],
-	"slow_down_min_speed": [
-		"10"
-	],
-	"nozzle_temperature_initial_layer": [
-		"250"
-	],
-	"nozzle_temperature": [
-		"245"
-	],
-	"nozzle_temperature_range_low": [
-		"190"
-	],
-	"nozzle_temperature_range_high": [
-		"300"
-	],
-	"hot_plate_temp_initial_layer": [
-		"60"
-	],
-	"hot_plate_temp": [
-		"60"
 	]
 }

--- a/resources/profiles/Sovol/filament/Sovol SV06 Plus ACE ABS.json
+++ b/resources/profiles/Sovol/filament/Sovol SV06 Plus ACE ABS.json
@@ -1,51 +1,12 @@
 {
 	"type": "filament",
 	"name": "Sovol SV06 Plus ACE ABS",
-	"inherits": "Generic ABS @System",
+	"inherits": "Sovol SV06 Plus ACE ABS @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFL99",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"0.98"
-	],
-	"filament_max_volumetric_speed": [
-		"15"
-	],
-	"full_fan_speed_layer": [
-		"3"
-	],
 	"compatible_printers": [
 		"Sovol SV06 Plus ACE 0.4 nozzle"
-	],
-	"fan_min_speed": [
-		"30"
-	],
-	"fan_cooling_layer_time": [
-		"80"
-	],
-	"fan_max_speed": [
-		"30"
-	],
-	"slow_down_layer_time": [
-		"5"
-	],
-	"nozzle_temperature_initial_layer": [
-		"280"
-	],
-	"nozzle_temperature": [
-		"270"
-	],
-	"nozzle_temperature_range_low": [
-		"190"
-	],
-	"nozzle_temperature_range_high": [
-		"300"
-	],
-	"hot_plate_temp_initial_layer": [
-		"95"
-	],
-	"hot_plate_temp": [
-		"95"
 	]
 }

--- a/resources/profiles/Sovol/filament/Sovol SV06 Plus ACE PETG.json
+++ b/resources/profiles/Sovol/filament/Sovol SV06 Plus ACE PETG.json
@@ -1,51 +1,12 @@
 {
 	"type": "filament",
 	"name": "Sovol SV06 Plus ACE PETG",
-	"inherits": "Generic PETG @System",
+	"inherits": "Sovol SV06 Plus ACE PETG @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFL99",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"0.98"
-	],
-	"filament_max_volumetric_speed": [
-		"15"
-	],
-	"full_fan_speed_layer": [
-		"3"
-	],
 	"compatible_printers": [
 		"Sovol SV06 Plus ACE 0.4 nozzle"
-	],
-	"fan_min_speed": [
-		"30"
-	],
-	"fan_cooling_layer_time": [
-		"80"
-	],
-	"fan_max_speed": [
-		"30"
-	],
-	"slow_down_layer_time": [
-		"5"
-	],
-	"nozzle_temperature_initial_layer": [
-		"260"
-	],
-	"nozzle_temperature": [
-		"245"
-	],
-	"nozzle_temperature_range_low": [
-		"190"
-	],
-	"nozzle_temperature_range_high": [
-		"300"
-	],
-	"hot_plate_temp_initial_layer": [
-		"85"
-	],
-	"hot_plate_temp": [
-		"85"
 	]
 }

--- a/resources/profiles/Sovol/filament/Sovol SV06 Plus ACE PLA.json
+++ b/resources/profiles/Sovol/filament/Sovol SV06 Plus ACE PLA.json
@@ -1,54 +1,12 @@
 {
 	"type": "filament",
 	"name": "Sovol SV06 Plus ACE PLA",
-	"inherits": "Generic PLA @System",
+	"inherits": "Sovol SV06 Plus ACE PLA @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFL99",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"0.98"
-	],
-	"filament_max_volumetric_speed": [
-		"21"
-	],
-	"full_fan_speed_layer": [
-		"3"
-	],
 	"compatible_printers": [
 		"Sovol SV06 Plus ACE 0.4 nozzle"
-	],
-	"fan_min_speed": [
-		"50"
-	],
-	"fan_cooling_layer_time": [
-		"80"
-	],
-	"fan_max_speed": [
-		"80"
-	],
-	"slow_down_layer_time": [
-		"6"
-	],
-	"slow_down_min_speed": [
-		"20"
-	],
-	"nozzle_temperature_initial_layer": [
-		"235"
-	],
-	"nozzle_temperature": [
-		"210"
-	],
-	"nozzle_temperature_range_low": [
-		"190"
-	],
-	"nozzle_temperature_range_high": [
-		"300"
-	],
-	"hot_plate_temp_initial_layer": [
-		"60"
-	],
-	"hot_plate_temp": [
-		"60"
 	]
 }

--- a/resources/profiles/Sovol/filament/Sovol SV06 Plus ACE TPU.json
+++ b/resources/profiles/Sovol/filament/Sovol SV06 Plus ACE TPU.json
@@ -1,54 +1,12 @@
 {
 	"type": "filament",
 	"name": "Sovol SV06 Plus ACE TPU",
-	"inherits": "Generic TPU @System",
+	"inherits": "Sovol SV06 Plus ACE TPU @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFL99",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"0.98"
-	],
-	"filament_max_volumetric_speed": [
-		"3.6"
-	],
-	"full_fan_speed_layer": [
-		"3"
-	],
 	"compatible_printers": [
 		"Sovol SV06 Plus ACE 0.4 nozzle"
-	],
-	"fan_min_speed": [
-		"100"
-	],
-	"fan_cooling_layer_time": [
-		"80"
-	],
-	"fan_max_speed": [
-		"100"
-	],
-	"slow_down_layer_time": [
-		"5"
-	],
-	"slow_down_min_speed": [
-		"10"
-	],
-	"nozzle_temperature_initial_layer": [
-		"250"
-	],
-	"nozzle_temperature": [
-		"245"
-	],
-	"nozzle_temperature_range_low": [
-		"190"
-	],
-	"nozzle_temperature_range_high": [
-		"300"
-	],
-	"hot_plate_temp_initial_layer": [
-		"60"
-	],
-	"hot_plate_temp": [
-		"60"
 	]
 }

--- a/resources/profiles/Sovol/filament/Sovol SV07 PLA.json
+++ b/resources/profiles/Sovol/filament/Sovol SV07 PLA.json
@@ -1,54 +1,12 @@
 {
 	"type": "filament",
 	"name": "Sovol SV07 PLA",
-	"inherits": "Generic PLA @System",
+	"inherits": "Sovol SV07 PLA @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFL99",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"0.98"
-	],
-	"filament_max_volumetric_speed": [
-		"24"
-	],
-	"filament_retraction_length": [
-		"0.5"
-	],
-	"full_fan_speed_layer": [
-		"3"
-	],
 	"compatible_printers": [
 		"Sovol SV07 0.4 nozzle"
-	],
-	"fan_min_speed": [
-		"60"
-	],
-	"fan_cooling_layer_time": [
-		"50"
-	],
-	"fan_max_speed": [
-		"100"
-	],
-	"slow_down_layer_time": [
-		"6"
-	],
-	"nozzle_temperature_initial_layer": [
-		"235"
-	],
-	"nozzle_temperature": [
-		"200"
-	],
-	"nozzle_temperature_range_low": [
-		"190"
-	],
-	"nozzle_temperature_range_high": [
-		"260"
-	],
-	"hot_plate_temp_initial_layer": [
-		"65"
-	],
-	"hot_plate_temp": [
-		"65"
 	]
 }

--- a/resources/profiles/Sovol/filament/Sovol SV08 ABS.json
+++ b/resources/profiles/Sovol/filament/Sovol SV08 ABS.json
@@ -1,74 +1,11 @@
 {
 	"type": "filament",
 	"name": "Sovol SV08 ABS",
-	"inherits": "Generic ABS @System",
+	"inherits": "Sovol SV08 ABS @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFL99",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"0.98"
-	],
-	"filament_max_volumetric_speed": [
-		"21"
-	],
-	"nozzle_temperature_initial_layer": [
-		"280"
-	],
-	"nozzle_temperature": [
-		"270"
-	],
-	"nozzle_temperature_range_low": [
-		"230"
-	],
-	"nozzle_temperature_range_high": [
-		"280"
-	],
-	"hot_plate_temp": [
-		"95"
-	],
-	"hot_plate_temp_initial_layer": [
-		"95"
-	],
-	"fan_min_speed": [
-		"10"
-	],
-	"fan_max_speed": [
-		"30"
-	],
-	"fan_cooling_layer_time": [
-		"30"
-	],
-	"full_fan_speed_layer": [
-		"0"
-	],
-	"slow_down_layer_time": [
-		"4"
-	],
-	"slow_down_min_speed": [
-		"10"
-	],
-	"overhang_fan_speed": [
-		"30"
-	],
-	"overhang_fan_threshold": [
-		"25%"
-	],
-	"temperature_vitrification": [
-		"60"
-	],
-	"activate_air_filtration": [
-		"1"
-	],
-	"close_fan_the_first_x_layers": [
-		"3"
-	],
-	"complete_print_exhaust_fan_speed": [
-		"60"
-	],
-	"during_print_exhaust_fan_speed": [
-		"100"
-	],
 	"compatible_printers": [
 		"Sovol SV08 0.2 nozzle",
 		"Sovol SV08 0.4 nozzle",

--- a/resources/profiles/Sovol/filament/Sovol SV08 PETG.json
+++ b/resources/profiles/Sovol/filament/Sovol SV08 PETG.json
@@ -1,71 +1,11 @@
 {
 	"type": "filament",
 	"name": "Sovol SV08 PETG",
-	"inherits": "Generic PETG @System",
+	"inherits": "Sovol SV08 PETG @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFL99",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"0.98"
-	],
-	"filament_max_volumetric_speed": [
-		"17"
-	],
-	"nozzle_temperature_initial_layer": [
-		"255"
-	],
-	"nozzle_temperature": [
-		"235"
-	],
-	"nozzle_temperature_range_low": [
-		"230"
-	],
-	"nozzle_temperature_range_high": [
-		"280"
-	],
-	"hot_plate_temp": [
-		"75"
-	],
-	"hot_plate_temp_initial_layer": [
-		"75"
-	],
-	"fan_min_speed": [
-		"30"
-	],
-	"fan_max_speed": [
-		"70"
-	],
-	"fan_cooling_layer_time": [
-		"30"
-	],
-	"full_fan_speed_layer": [
-		"0"
-	],
-	"slow_down_layer_time": [
-		"5"
-	],
-	"slow_down_min_speed": [
-		"10"
-	],
-	"overhang_fan_speed": [
-		"70"
-	],
-	"overhang_fan_threshold": [
-		"10%"
-	],
-	"temperature_vitrification": [
-		"60"
-	],
-	"close_fan_the_first_x_layers": [
-		"3"
-	],
-	"filament_retraction_length": [
-		"0.5"
-	],
-	"filament_z_hop": [
-		"0.4"
-	],
 	"compatible_printers": [
 		"Sovol SV08 0.2 nozzle",
 		"Sovol SV08 0.4 nozzle",

--- a/resources/profiles/Sovol/filament/Sovol SV08 PLA @SV08 0.2 nozzle.json
+++ b/resources/profiles/Sovol/filament/Sovol SV08 PLA @SV08 0.2 nozzle.json
@@ -1,66 +1,12 @@
 {
 	"type": "filament",
 	"name": "Sovol SV08 PLA @SV08 0.2 nozzle",
-	"inherits": "Generic PLA @System",
+	"inherits": "Sovol SV08 PLA @SV08 0.2 nozzle @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFL99",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"0.98"
-	],
-	"filament_max_volumetric_speed": [
-		"10"
-	],
 	"compatible_printers": [
 		"Sovol SV08 0.2 nozzle"
-	],
-	"nozzle_temperature_initial_layer": [
-		"235"
-	],
-	"nozzle_temperature": [
-		"220"
-	],
-	"nozzle_temperature_range_low": [
-		"190"
-	],
-	"nozzle_temperature_range_high": [
-		"250"
-	],
-	"hot_plate_temp": [
-		"65"
-	],
-	"hot_plate_temp_initial_layer": [
-		"65"
-	],
-	"fan_min_speed": [
-		"100"
-	],
-	"fan_max_speed": [
-		"100"
-	],
-	"fan_cooling_layer_time": [
-		"50"
-	],
-	"close_fan_the_first_x_layers": [
-		"3"
-	],
-	"full_fan_speed_layer": [
-		"3"
-	],
-	"slow_down_layer_time": [
-		"5"
-	],
-	"slow_down_min_speed": [
-		"10"
-	],
-	"overhang_fan_speed": [
-		"100"
-	],
-	"overhang_fan_threshold": [
-		"50%"
-	],
-	"temperature_vitrification": [
-		"60"
 	]
 }

--- a/resources/profiles/Sovol/filament/Sovol SV08 PLA.json
+++ b/resources/profiles/Sovol/filament/Sovol SV08 PLA.json
@@ -1,65 +1,14 @@
 {
 	"type": "filament",
 	"name": "Sovol SV08 PLA",
-	"inherits": "Generic PLA @System",
+	"inherits": "Sovol SV08 PLA @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFL99",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"0.98"
-	],
-	"filament_max_volumetric_speed": [
-		"21"
-	],
 	"compatible_printers": [
 		"Sovol SV08 0.4 nozzle",
 		"Sovol SV08 0.6 nozzle",
 		"Sovol SV08 0.8 nozzle"
-	],
-	"nozzle_temperature_initial_layer": [
-		"235"
-	],
-	"nozzle_temperature": [
-		"220"
-	],
-	"nozzle_temperature_range_low": [
-		"190"
-	],
-	"nozzle_temperature_range_high": [
-		"250"
-	],
-	"hot_plate_temp": [
-		"65"
-	],
-	"hot_plate_temp_initial_layer": [
-		"65"
-	],
-	"fan_min_speed": [
-		"50"
-	],
-	"fan_max_speed": [
-		"70"
-	],
-	"fan_cooling_layer_time": [
-		"50"
-	],
-	"full_fan_speed_layer": [
-		"3"
-	],
-	"slow_down_layer_time": [
-		"5"
-	],
-	"slow_down_min_speed": [
-		"10"
-	],
-	"overhang_fan_speed": [
-		"100"
-	],
-	"overhang_fan_threshold": [
-		"50%"
-	],
-	"temperature_vitrification": [
-		"60"
 	]
 }

--- a/resources/profiles/Sovol/filament/Sovol SV08 TPU.json
+++ b/resources/profiles/Sovol/filament/Sovol SV08 TPU.json
@@ -1,65 +1,11 @@
 {
 	"type": "filament",
 	"name": "Sovol SV08 TPU",
-	"inherits": "Generic TPU @System",
+	"inherits": "Sovol SV08 TPU @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFL99",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"0.98"
-	],
-	"filament_max_volumetric_speed": [
-		"3.6"
-	],
-	"nozzle_temperature": [
-		"235"
-	],
-	"nozzle_temperature_initial_layer": [
-		"240"
-	],
-	"nozzle_temperature_range_low": [
-		"190"
-	],
-	"nozzle_temperature_range_high": [
-		"250"
-	],
-	"hot_plate_temp": [
-		"65"
-	],
-	"hot_plate_temp_initial_layer": [
-		"65"
-	],
-	"fan_max_speed": [
-		"100"
-	],
-	"fan_min_speed": [
-		"80"
-	],
-	"fan_cooling_layer_time": [
-		"50"
-	],
-	"full_fan_speed_layer": [
-		"3"
-	],
-	"slow_down_layer_time": [
-		"5"
-	],
-	"slow_down_min_speed": [
-		"10"
-	],
-	"overhang_fan_speed": [
-		"100"
-	],
-	"overhang_fan_threshold": [
-		"50%"
-	],
-	"temperature_vitrification": [
-		"60"
-	],
-	"filament_z_hop": [
-		"0.4"
-	],
 	"compatible_printers": [
 		"Sovol SV08 0.2 nozzle",
 		"Sovol SV08 0.4 nozzle",

--- a/resources/profiles/Sovol/filament/Sovol Zero ABS.json
+++ b/resources/profiles/Sovol/filament/Sovol Zero ABS.json
@@ -1,77 +1,11 @@
 {
 	"type": "filament",
 	"name": "Sovol Zero ABS",
-	"inherits": "Generic ABS @System",
+	"inherits": "Sovol Zero ABS @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFL99",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"0.98"
-	],
-	"filament_max_volumetric_speed": [
-		"21"
-	],
-	"nozzle_temperature_initial_layer": [
-		"280"
-	],
-	"nozzle_temperature": [
-		"270"
-	],
-	"nozzle_temperature_range_low": [
-		"230"
-	],
-	"nozzle_temperature_range_high": [
-		"300"
-	],
-	"hot_plate_temp": [
-		"100"
-	],
-	"hot_plate_temp_initial_layer": [
-		"100"
-	],
-	"fan_min_speed": [
-		"10"
-	],
-	"fan_max_speed": [
-		"30"
-	],
-	"fan_cooling_layer_time": [
-		"30"
-	],
-	"full_fan_speed_layer": [
-		"3"
-	],
-	"slow_down_layer_time": [
-		"5"
-	],
-	"slow_down_min_speed": [
-		"10"
-	],
-	"overhang_fan_speed": [
-		"30"
-	],
-	"overhang_fan_threshold": [
-		"50%"
-	],
-	"temperature_vitrification": [
-		"60"
-	],
-	"activate_air_filtration": [
-		"1"
-	],
-	"close_fan_the_first_x_layers": [
-		"1"
-	],
-	"complete_print_exhaust_fan_speed": [
-		"50"
-	],
-	"during_print_exhaust_fan_speed": [
-		"50"
-	],
-	"additional_cooling_fan_speed": [
-		"0"
-	],
 	"compatible_printers": [
 		"Sovol Zero 0.4 nozzle"
 	]

--- a/resources/profiles/Sovol/filament/Sovol Zero PC.json
+++ b/resources/profiles/Sovol/filament/Sovol Zero PC.json
@@ -1,68 +1,12 @@
 {
 	"type": "filament",
 	"name": "Sovol Zero PC",
-	"inherits": "Generic PC @System",
+	"inherits": "Sovol Zero PC @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFL99",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"0.98"
-	],
-	"filament_max_volumetric_speed": [
-		"21"
-	],
 	"compatible_printers": [
 		"Sovol Zero 0.4 nozzle"
-	],
-	"nozzle_temperature_initial_layer": [
-		"290"
-	],
-	"nozzle_temperature": [
-		"270"
-	],
-	"nozzle_temperature_range_low": [
-		"190"
-	],
-	"nozzle_temperature_range_high": [
-		"350"
-	],
-	"hot_plate_temp": [
-		"110"
-	],
-	"hot_plate_temp_initial_layer": [
-		"110"
-	],
-	"fan_min_speed": [
-		"10"
-	],
-	"fan_max_speed": [
-		"20"
-	],
-	"fan_cooling_layer_time": [
-		"40"
-	],
-	"full_fan_speed_layer": [
-		"3"
-	],
-	"slow_down_layer_time": [
-		"5"
-	],
-	"slow_down_min_speed": [
-		"10"
-	],
-	"dont_slow_down_outer_wall": "0",
-	"overhang_fan_speed": [
-		"20"
-	],
-	"overhang_fan_threshold": [
-		"50%"
-	],
-	"temperature_vitrification": [
-		"60"
-	],
-	"additional_cooling_fan_speed": "0",
-	"activate_air_filtration": "1",
-	"during_print_exhaust_fan_speed": "50",
-	"complete_print_exhaust_fan_speed": "50"
+	]
 }

--- a/resources/profiles/Sovol/filament/Sovol Zero PETG HS Nozzle.json
+++ b/resources/profiles/Sovol/filament/Sovol Zero PETG HS Nozzle.json
@@ -1,76 +1,11 @@
 {
 	"type": "filament",
 	"name": "Sovol Zero PETG HS Nozzle",
-	"inherits": "Generic PETG @System",
+	"inherits": "Sovol Zero PETG HS Nozzle @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFL99",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"0.98"
-	],
-	"enable_pressure_advance": "1",
-	"pressure_advance": "0.048",
-	"filament_max_volumetric_speed": [
-		"15"
-	],
-	"nozzle_temperature_initial_layer": [
-		"265"
-	],
-	"nozzle_temperature": [
-		"250"
-	],
-	"nozzle_temperature_range_low": [
-		"230"
-	],
-	"nozzle_temperature_range_high": [
-		"280"
-	],
-	"hot_plate_temp": [
-		"85"
-	],
-	"hot_plate_temp_initial_layer": [
-		"85"
-	],
-	"fan_min_speed": [
-		"10"
-	],
-	"fan_max_speed": [
-		"40"
-	],
-	"fan_cooling_layer_time": [
-		"50"
-	],
-	"full_fan_speed_layer": [
-		"3"
-	],
-	"slow_down_layer_time": [
-		"10"
-	],
-	"slow_down_min_speed": [
-		"10"
-	],
-	"overhang_fan_speed": [
-		"70"
-	],
-	"overhang_fan_threshold": [
-		"10%"
-	],
-	"temperature_vitrification": [
-		"60"
-	],
-	"close_fan_the_first_x_layers": [
-		"1"
-	],
-	"filament_retraction_length": [
-		"0.5"
-	],
-	"filament_z_hop": [
-		"0.4"
-	],
-	"activate_air_filtration": "1",
-	"during_print_exhaust_fan_speed": "50",
-	"complete_print_exhaust_fan_speed": "50",
 	"compatible_printers": [
 		"Sovol Zero 0.4 nozzle"
 	]

--- a/resources/profiles/Sovol/filament/Sovol Zero PETG.json
+++ b/resources/profiles/Sovol/filament/Sovol Zero PETG.json
@@ -1,76 +1,11 @@
 {
 	"type": "filament",
 	"name": "Sovol Zero PETG",
-	"inherits": "Generic PETG @System",
+	"inherits": "Sovol Zero PETG @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFL99",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"1.0348"
-	],
-	"enable_pressure_advance": "1",
-	"pressure_advance": "0.046",
-	"filament_max_volumetric_speed": [
-		"15"
-	],
-	"nozzle_temperature_initial_layer": [
-		"265"
-	],
-	"nozzle_temperature": [
-		"245"
-	],
-	"nozzle_temperature_range_low": [
-		"230"
-	],
-	"nozzle_temperature_range_high": [
-		"280"
-	],
-	"hot_plate_temp": [
-		"85"
-	],
-	"hot_plate_temp_initial_layer": [
-		"85"
-	],
-	"fan_min_speed": [
-		"10"
-	],
-	"fan_max_speed": [
-		"40"
-	],
-	"fan_cooling_layer_time": [
-		"50"
-	],
-	"full_fan_speed_layer": [
-		"3"
-	],
-	"slow_down_layer_time": [
-		"10"
-	],
-	"slow_down_min_speed": [
-		"10"
-	],
-	"overhang_fan_speed": [
-		"70"
-	],
-	"overhang_fan_threshold": [
-		"10%"
-	],
-	"temperature_vitrification": [
-		"60"
-	],
-	"close_fan_the_first_x_layers": [
-		"1"
-	],
-	"filament_retraction_length": [
-		"0.5"
-	],
-	"filament_z_hop": [
-		"0.4"
-	],
-	"activate_air_filtration": "1",
-	"during_print_exhaust_fan_speed": "50",
-	"complete_print_exhaust_fan_speed": "50",
 	"compatible_printers": [
 		"Sovol Zero 0.4 nozzle"
 	]

--- a/resources/profiles/Sovol/filament/Sovol Zero PLA Basic HS Nozzle.json
+++ b/resources/profiles/Sovol/filament/Sovol Zero PLA Basic HS Nozzle.json
@@ -1,70 +1,12 @@
 {
 	"type": "filament",
 	"name": "Sovol Zero PLA Basic HS Nozzle",
-	"inherits": "Generic PLA @System",
+	"inherits": "Sovol Zero PLA Basic HS Nozzle @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFL99",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"1.0348"
-	],
-	"filament_max_volumetric_speed": [
-		"21"
-	],
-	"enable_pressure_advance": "1",
-	"pressure_advance": "0.03",
 	"compatible_printers": [
 		"Sovol Zero 0.4 nozzle"
-	],
-	"nozzle_temperature_initial_layer": [
-		"245"
-	],
-	"nozzle_temperature": [
-		"230"
-	],
-	"nozzle_temperature_range_low": [
-		"190"
-	],
-	"nozzle_temperature_range_high": [
-		"250"
-	],
-	"hot_plate_temp": [
-		"65"
-	],
-	"hot_plate_temp_initial_layer": [
-		"65"
-	],
-	"fan_min_speed": [
-		"70"
-	],
-	"fan_max_speed": [
-		"100"
-	],
-	"fan_cooling_layer_time": [
-		"80"
-	],
-	"full_fan_speed_layer": [
-		"3"
-	],
-	"slow_down_layer_time": [
-		"5"
-	],
-	"slow_down_min_speed": [
-		"10"
-	],
-	"dont_slow_down_outer_wall": "0",
-	"overhang_fan_speed": [
-		"100"
-	],
-	"overhang_fan_threshold": [
-		"50%"
-	],
-	"temperature_vitrification": [
-		"60"
-	],
-	"additional_cooling_fan_speed": "75%",
-	"activate_air_filtration": "1",
-	"during_print_exhaust_fan_speed": "80%",
-	"complete_print_exhaust_fan_speed": "80%"
+	]
 }

--- a/resources/profiles/Sovol/filament/Sovol Zero PLA Basic.json
+++ b/resources/profiles/Sovol/filament/Sovol Zero PLA Basic.json
@@ -1,70 +1,12 @@
 {
 	"type": "filament",
 	"name": "Sovol Zero PLA Basic",
-	"inherits": "Generic PLA @System",
+	"inherits": "Sovol Zero PLA Basic @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFL99",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"0.98"
-	],
-	"filament_max_volumetric_speed": [
-		"21"
-	],
-	"enable_pressure_advance": "1",
-	"pressure_advance": "0.032",
 	"compatible_printers": [
 		"Sovol Zero 0.4 nozzle"
-	],
-	"nozzle_temperature_initial_layer": [
-		"230"
-	],
-	"nozzle_temperature": [
-		"210"
-	],
-	"nozzle_temperature_range_low": [
-		"190"
-	],
-	"nozzle_temperature_range_high": [
-		"250"
-	],
-	"hot_plate_temp": [
-		"65"
-	],
-	"hot_plate_temp_initial_layer": [
-		"65"
-	],
-	"fan_min_speed": [
-		"70"
-	],
-	"fan_max_speed": [
-		"100"
-	],
-	"fan_cooling_layer_time": [
-		"80"
-	],
-	"full_fan_speed_layer": [
-		"3"
-	],
-	"slow_down_layer_time": [
-		"5"
-	],
-	"slow_down_min_speed": [
-		"10"
-	],
-	"dont_slow_down_outer_wall": "0",
-	"overhang_fan_speed": [
-		"100"
-	],
-	"overhang_fan_threshold": [
-		"50%"
-	],
-	"temperature_vitrification": [
-		"60"
-	],
-	"additional_cooling_fan_speed": "75%",
-	"activate_air_filtration": "1",
-	"during_print_exhaust_fan_speed": "80%",
-	"complete_print_exhaust_fan_speed": "80%"
+	]
 }

--- a/resources/profiles/Sovol/filament/Sovol Zero PLA Silk HS Nozzle.json
+++ b/resources/profiles/Sovol/filament/Sovol Zero PLA Silk HS Nozzle.json
@@ -1,70 +1,12 @@
 {
 	"type": "filament",
 	"name": "Sovol Zero PLA Silk HS Nozzle",
-	"inherits": "Generic PLA @System",
+	"inherits": "Sovol Zero PLA Silk HS Nozzle @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFL99",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"0.98"
-	],
-	"filament_max_volumetric_speed": [
-		"15"
-	],
-	"enable_pressure_advance": "1",
-	"pressure_advance": "0.027",
 	"compatible_printers": [
 		"Sovol Zero 0.4 nozzle"
-	],
-	"nozzle_temperature_initial_layer": [
-		"245"
-	],
-	"nozzle_temperature": [
-		"230"
-	],
-	"nozzle_temperature_range_low": [
-		"190"
-	],
-	"nozzle_temperature_range_high": [
-		"250"
-	],
-	"hot_plate_temp": [
-		"65"
-	],
-	"hot_plate_temp_initial_layer": [
-		"65"
-	],
-	"fan_min_speed": [
-		"70"
-	],
-	"fan_max_speed": [
-		"100"
-	],
-	"fan_cooling_layer_time": [
-		"80"
-	],
-	"full_fan_speed_layer": [
-		"3"
-	],
-	"slow_down_layer_time": [
-		"5"
-	],
-	"slow_down_min_speed": [
-		"10"
-	],
-	"dont_slow_down_outer_wall": "0",
-	"overhang_fan_speed": [
-		"100"
-	],
-	"overhang_fan_threshold": [
-		"50%"
-	],
-	"temperature_vitrification": [
-		"60"
-	],
-	"additional_cooling_fan_speed": "75%",
-	"activate_air_filtration": "1",
-	"during_print_exhaust_fan_speed": "80%",
-	"complete_print_exhaust_fan_speed": "80%"
+	]
 }

--- a/resources/profiles/Sovol/filament/Sovol Zero PLA Silk.json
+++ b/resources/profiles/Sovol/filament/Sovol Zero PLA Silk.json
@@ -1,70 +1,12 @@
 {
 	"type": "filament",
 	"name": "Sovol Zero PLA Silk",
-	"inherits": "Generic PLA @System",
+	"inherits": "Sovol Zero PLA Silk @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFL99",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"0.98"
-	],
-	"filament_max_volumetric_speed": [
-		"15"
-	],
-	"enable_pressure_advance": "1",
-	"pressure_advance": "0.029",
 	"compatible_printers": [
 		"Sovol Zero 0.4 nozzle"
-	],
-	"nozzle_temperature_initial_layer": [
-		"245"
-	],
-	"nozzle_temperature": [
-		"220"
-	],
-	"nozzle_temperature_range_low": [
-		"190"
-	],
-	"nozzle_temperature_range_high": [
-		"250"
-	],
-	"hot_plate_temp": [
-		"65"
-	],
-	"hot_plate_temp_initial_layer": [
-		"65"
-	],
-	"fan_min_speed": [
-		"70"
-	],
-	"fan_max_speed": [
-		"100"
-	],
-	"fan_cooling_layer_time": [
-		"80"
-	],
-	"full_fan_speed_layer": [
-		"3"
-	],
-	"slow_down_layer_time": [
-		"7"
-	],
-	"slow_down_min_speed": [
-		"10"
-	],
-	"dont_slow_down_outer_wall": "0",
-	"overhang_fan_speed": [
-		"100"
-	],
-	"overhang_fan_threshold": [
-		"50%"
-	],
-	"temperature_vitrification": [
-		"60"
-	],
-	"additional_cooling_fan_speed": "75%",
-	"activate_air_filtration": "1",
-	"during_print_exhaust_fan_speed": "80%",
-	"complete_print_exhaust_fan_speed": "80%"
+	]
 }

--- a/resources/profiles/Sovol/filament/Sovol Zero TPU.json
+++ b/resources/profiles/Sovol/filament/Sovol Zero TPU.json
@@ -1,69 +1,11 @@
 {
 	"type": "filament",
 	"name": "Sovol Zero TPU",
-	"inherits": "Generic TPU @System",
+	"inherits": "Sovol Zero TPU @base",
 	"from": "system",
 	"setting_id": "GFSA04",
 	"filament_id": "GFL99",
 	"instantiation": "true",
-	"filament_flow_ratio": [
-		"0.98"
-	],
-	"filament_max_volumetric_speed": [
-		"3.2"
-	],
-	"nozzle_temperature": [
-		"235"
-	],
-	"nozzle_temperature_initial_layer": [
-		"250"
-	],
-	"nozzle_temperature_range_low": [
-		"190"
-	],
-	"nozzle_temperature_range_high": [
-		"250"
-	],
-	"hot_plate_temp": [
-		"85"
-	],
-	"hot_plate_temp_initial_layer": [
-		"85"
-	],
-	"fan_max_speed": [
-		"100"
-	],
-	"fan_min_speed": [
-		"80"
-	],
-	"fan_cooling_layer_time": [
-		"50"
-	],
-	"full_fan_speed_layer": [
-		"3"
-	],
-	"slow_down_layer_time": [
-		"5"
-	],
-	"slow_down_min_speed": [
-		"10"
-	],
-	"overhang_fan_speed": [
-		"100"
-	],
-	"overhang_fan_threshold": [
-		"50%"
-	],
-	"temperature_vitrification": [
-		"60"
-	],
-	"filament_z_hop": [
-		"0.4"
-	],
-	"additional_cooling_fan_speed": "50",
-	"activate_air_filtration": "1",
-	"during_print_exhaust_fan_speed": "100",
-	"complete_print_exhaust_fan_speed": "50",
 	"compatible_printers": [
 		"Sovol Zero 0.4 nozzle"
 	]

--- a/resources/profiles/Sovol/machine/Sovol SV08 MAX.json
+++ b/resources/profiles/Sovol/machine/Sovol SV08 MAX.json
@@ -8,5 +8,5 @@
 	"bed_model": "sovol_sv08_max_buildplate_model.stl",
 	"bed_texture": "sovol_sv08_max_buildplate_texture.svg",
 	"hotend_model": "",
-	"default_materials": "Generic PLA;Generic PLA Silk;Generic ABS;Generic PETG;Polymaker PETG;SUNLU PETG;Generic TPU;Generic PC"
+	"default_materials": "Generic PLA @Sovol SV08 MAX;Generic PLA Silk @Sovol SV08 MAX;Generic ABS @Sovol SV08 MAX;Generic PETG @Sovol SV08 MAX;Polymaker PETG @Sovol SV08 MAX;SUNLU PETG @Sovol SV08 MAX;Generic TPU @Sovol SV08 MAX;Generic PC @Sovol SV08 MAX"
 }


### PR DESCRIPTION
## Summary
- migrate Sovol filament presets into `OrcaFilamentLibrary` with `@base` and `@System` entries
- update Sovol vendor-scoped presets to inherit from the new library bases while preserving compatibility metadata
- repair stale Sovol SV08 MAX `default_materials` references so profile validation stays clean

Fixes part of #12162.

## Verification
- `python3 scripts/orca_extra_profile_check.py --vendor Sovol --check-filaments --check-materials --check-obsolete-keys` — 0 errors, 0 warnings
- `git diff --check`