### PR TITLE
Fix inconsistent displayed name

### DIFF
--- a/src/slic3r/Utils/OrcaCloudServiceAgent.cpp
+++ b/src/slic3r/Utils/OrcaCloudServiceAgent.cpp
@@ -74,6 +74,14 @@ constexpr const char* SECRET_STORE_SERVICE = "OrcaSlicer/Auth";
 constexpr const char* SECRET_STORE_USER    = "orca_refresh_token";
 constexpr std::chrono::seconds TOKEN_REFRESH_SKEW{900}; // 15 minutes
 
+// Return a JSON field only when it is present as a string. Missing or non-string values normalize to empty.
+std::string get_json_string_field(const json& j, const std::string& key)
+{
+    if (j.contains(key) && j[key].is_string()) {
+        return j[key].get<std::string>();
+    }
+    return "";
+}
 std::string generate_uuid_for_setting_id(const std::string& name, const std::string& user_id = "")
 {
     if (name.empty()) {

--- a/src/slic3r/Utils/OrcaCloudServiceAgent.cpp
+++ b/src/slic3r/Utils/OrcaCloudServiceAgent.cpp
@@ -1707,25 +1707,28 @@ bool OrcaCloudServiceAgent::set_user_session(const json& session_json, bool noti
 
         if (user.contains("user_metadata") && user["user_metadata"].is_object()) {
             const auto& meta = user["user_metadata"];
-            nickname = safe_str(meta, "display_name"); // Orca Cloud's primary display name field
-            // Fallback to different name from different providers if display_name is not set
-            if (nickname.empty())
-                nickname = safe_str(meta, "full_name");
-            if (nickname.empty())
-                nickname = safe_str(meta, "name");
-            if (nickname.empty())
-                nickname = username;
             username = get_json_string_field(meta, "username"); // Orca Cloud's unique username
 
+            // Orca Cloud's primary display name field is display_name.
+            // Fallback to different names from different providers if display_name is not set.
+            nickname = resolve_display_name(
+                get_json_string_field(meta, "display_name"),
+                get_json_string_field(meta, "nickname"),
+                get_json_string_field(meta, "full_name"),
+                get_json_string_field(meta, "name"),
+                username);
             avatar = get_json_string_field(meta, "avatar_url");
         }
     } else {
         // Flat format (WebView direct token flow)
-        nickname = safe_str(session_json, "display_name");
-        if(nickname.empty())
-            nickname = safe_str(session_json, "nickname");
         user_id = get_json_string_field(session_json, "user_id");
         username = get_json_string_field(session_json, "username");
+        nickname = resolve_display_name(
+            get_json_string_field(session_json, "display_name"),
+            get_json_string_field(session_json, "nickname"),
+            get_json_string_field(session_json, "full_name"),
+            get_json_string_field(session_json, "name"),
+            username);
         avatar = get_json_string_field(session_json, "avatar");
     }
 

--- a/src/slic3r/Utils/OrcaCloudServiceAgent.cpp
+++ b/src/slic3r/Utils/OrcaCloudServiceAgent.cpp
@@ -1693,27 +1693,20 @@ bool OrcaCloudServiceAgent::set_user_session(const std::string& token,
 
 bool OrcaCloudServiceAgent::set_user_session(const json& session_json, bool notify_login)
 {
-    auto safe_str = [](const json& j, const std::string& key) -> std::string {
-        if (j.contains(key) && j[key].is_string()) return j[key].get<std::string>();
-        return "";
-    };
-
-    std::string access_token = safe_str(session_json, "access_token");
+    std::string access_token = get_json_string_field(session_json, "access_token");
     if (access_token.empty()) {
-        access_token = safe_str(session_json, "token");
+        access_token = get_json_string_field(session_json, "token");
     }
-    std::string refresh_token = safe_str(session_json, "refresh_token");
+    std::string refresh_token = get_json_string_field(session_json, "refresh_token");
 
     std::string user_id, username, nickname, avatar;
     if (session_json.contains("user") && session_json["user"].is_object()) {
         // Nested format (Orca cloud / GoTrue response)
         const auto& user = session_json["user"];
-        user_id = safe_str(user, "id");
+        user_id = get_json_string_field(user, "id");
+
         if (user.contains("user_metadata") && user["user_metadata"].is_object()) {
-
             const auto& meta = user["user_metadata"];
-            username = safe_str(meta, "username"); // Orca Cloud's unique username 
-
             nickname = safe_str(meta, "display_name"); // Orca Cloud's primary display name field
             // Fallback to different name from different providers if display_name is not set
             if (nickname.empty())
@@ -1722,18 +1715,18 @@ bool OrcaCloudServiceAgent::set_user_session(const json& session_json, bool noti
                 nickname = safe_str(meta, "name");
             if (nickname.empty())
                 nickname = username;
+            username = get_json_string_field(meta, "username"); // Orca Cloud's unique username
 
-            avatar = safe_str(meta, "avatar_url");
+            avatar = get_json_string_field(meta, "avatar_url");
         }
     } else {
         // Flat format (WebView direct token flow)
-        user_id = safe_str(session_json, "user_id");
-        username = safe_str(session_json, "username");
         nickname = safe_str(session_json, "display_name");
         if(nickname.empty())
             nickname = safe_str(session_json, "nickname");
-            
-        avatar = safe_str(session_json, "avatar");
+        user_id = get_json_string_field(session_json, "user_id");
+        username = get_json_string_field(session_json, "username");
+        avatar = get_json_string_field(session_json, "avatar");
     }
 
     if (access_token.empty() || user_id.empty()) {

--- a/src/slic3r/Utils/OrcaCloudServiceAgent.cpp
+++ b/src/slic3r/Utils/OrcaCloudServiceAgent.cpp
@@ -82,6 +82,24 @@ std::string get_json_string_field(const json& j, const std::string& key)
     }
     return "";
 }
+
+// Resolve the human-facing UI label from provider metadata.
+std::string resolve_display_name(
+    const std::string& display_name,
+    const std::string& nickname,
+    const std::string& full_name,
+    const std::string& name,
+    const std::string& username)
+{
+    // Providers and payload shapes do not all use the same display-name field.
+    // Fallback sequence: display_name -> nickname -> full_name -> name
+    if (!display_name.empty()) return display_name;
+    if (!nickname.empty()) return nickname;
+    if (!full_name.empty()) return full_name;
+    if (!name.empty()) return name;
+    return username;
+}
+
 std::string generate_uuid_for_setting_id(const std::string& name, const std::string& user_id = "")
 {
     if (name.empty()) {

--- a/src/slic3r/Utils/OrcaCloudServiceAgent.hpp
+++ b/src/slic3r/Utils/OrcaCloudServiceAgent.hpp
@@ -88,8 +88,8 @@ public:
         std::string access_token;
         std::string refresh_token;
         std::string user_id;
-        // Orca auth semantics: user_name is unique orca cloud username(orca_xxxxx), user_nickname is
-        // the display name shown in the UI when available.
+        // Orca auth semantics: user_name is the unique Orca Cloud username (orca_xxxxx),
+        // user_nickname is the display name shown in the UI when available.
         std::string user_name;
         std::string user_nickname;
         std::string user_avatar;
@@ -276,13 +276,14 @@ public:
     bool refresh_now(const std::string& refresh_token, const std::string& reason, bool async = false);
     bool refresh_session_with_token(const std::string& refresh_token);
 
-    // Session state helpers
+    // Session state helpers. nickname is the human-facing UI label after provider fallback resolution.
     bool set_user_session(const std::string& token,
                           const std::string& user_id,
                           const std::string& username,
                           const std::string& nickname,
                           const std::string& avatar,
                           const std::string& refresh_token = "");
+    // Accepts either nested Orca cloud / GoTrue session JSON or flat WebView token JSON.
     bool set_user_session(const nlohmann::json& session_json, bool notify_login = true);
     void clear_session();
 

--- a/tests/slic3rutils/slic3rutils_tests_main.cpp
+++ b/tests/slic3rutils/slic3rutils_tests_main.cpp
@@ -1,6 +1,47 @@
 #include <catch2/catch_all.hpp>
 
 #include "slic3r/Utils/Http.hpp"
+#include "slic3r/Utils/OrcaCloudServiceAgent.hpp"
+
+#include <wx/init.h>
+
+namespace {
+
+struct WxFixture {
+    WxFixture() { REQUIRE(initializer.IsOk()); }
+
+    wxInitializer initializer;
+};
+
+nlohmann::json flat_session_json(const nlohmann::json& fields)
+{
+    nlohmann::json session = {
+        {"access_token", "test-token"},
+        {"user_id", "test-user-id"}
+    };
+    session.update(fields);
+    return session;
+}
+
+nlohmann::json nested_session_json(const nlohmann::json& metadata)
+{
+    return {
+        {"access_token", "test-token"},
+        {"user", {
+            {"id", "test-user-id"},
+            {"user_metadata", metadata}
+        }}
+    };
+}
+
+std::string resolved_display_name(const nlohmann::json& session)
+{
+    Slic3r::OrcaCloudServiceAgent agent("");
+    REQUIRE(agent.set_user_session(session, false));
+    return agent.get_user_nickname();
+}
+
+} // namespace
 
 TEST_CASE("Check SSL certificates paths", "[Http][NotWorking]") {
     
@@ -18,6 +59,62 @@ TEST_CASE("Check SSL certificates paths", "[Http][NotWorking]") {
     g.perform_sync();
     
     REQUIRE(status == 200);
+}
+
+TEST_CASE_METHOD(WxFixture, "Orca cloud flat session resolves display name consistently", "[OrcaCloudServiceAgent]")
+{
+    CHECK(resolved_display_name(flat_session_json({
+        {"username", "orca_username"},
+        {"display_name", "Display Name"},
+        {"nickname", "Nickname"}
+    })) == "Display Name");
+
+    CHECK(resolved_display_name(flat_session_json({
+        {"username", "orca_username"},
+        {"nickname", "Nickname"}
+    })) == "Nickname");
+
+    CHECK(resolved_display_name(flat_session_json({
+        {"username", "orca_username"},
+        {"full_name", "Full Name"}
+    })) == "Full Name");
+
+    CHECK(resolved_display_name(flat_session_json({
+        {"username", "orca_username"},
+        {"name", "Provider Name"}
+    })) == "Provider Name");
+
+    CHECK(resolved_display_name(flat_session_json({
+        {"username", "orca_username"}
+    })) == "orca_username");
+}
+
+TEST_CASE_METHOD(WxFixture, "Orca cloud nested session resolves display name consistently", "[OrcaCloudServiceAgent]")
+{
+    CHECK(resolved_display_name(nested_session_json({
+        {"username", "orca_username"},
+        {"display_name", "Display Name"},
+        {"nickname", "Nickname"}
+    })) == "Display Name");
+
+    CHECK(resolved_display_name(nested_session_json({
+        {"username", "orca_username"},
+        {"nickname", "Nickname"}
+    })) == "Nickname");
+
+    CHECK(resolved_display_name(nested_session_json({
+        {"username", "orca_username"},
+        {"full_name", "Full Name"}
+    })) == "Full Name");
+
+    CHECK(resolved_display_name(nested_session_json({
+        {"username", "orca_username"},
+        {"name", "Provider Name"}
+    })) == "Provider Name");
+
+    CHECK(resolved_display_name(nested_session_json({
+        {"username", "orca_username"}
+    })) == "orca_username");
 }
 
 TEST_CASE("Http digest authentication", "[Http][NotWorking]") {


### PR DESCRIPTION
# Description
Closes #13644. Refer to issue for more info. 

This issue happens because the first-login flow and the later refresh flow parse different session payload shapes. First login usually uses the flat WebView token payload, while refresh usually uses the nested Orca Cloud / GoTrue payload. Before this PR, those two paths used different fallback chains for the same user-facing name, so the UI could show different values for the same account.

The visible bug was triggered when `display_name` was empty on first login and the backend-provided `nickname` value was actually the unique `username`. That made the UI show the username instead of the intended display name. The backend mapping has been fixed, but this PR also makes the client-side fallback logic consistent so both flows behave the same way.

This PR cleans up the display name / username handling in `OrcaCloudServiceAgent::set_user_session(...)`.

This PR makes both paths use the same fallback order: display_name -> nickname -> full_name -> name -> username

`username` is kept as the final fallback only.

# Screenshots/Recordings/Graphs

N/A. No UI changes.

## Tests

Added focused tests for `OrcaCloudServiceAgent::set_user_session(...)` covering both flat and nested session payloads.

The tests verify that both payload formats resolve the display name using the same fallback order: display_name -> nickname -> full_name -> name -> username