### PR TITLE
Fix a regression that second extruder settings not properly handled for H2D/X2D

### DIFF
--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -7352,7 +7352,7 @@ void Tab::switch_excluder(int extruder_id)
         {}, {"", "filament_extruder_variant"},                   // Preset::TYPE_FILAMENT filament don't use id anymore
         {}, {"printer_extruder_id", "printer_extruder_variant"}, // Preset::TYPE_PRINTER
     };
-    if (!m_variant_combo && (extruder_id >= nozzle_volumes->size() || extruder_id >= extruders->size()))
+    if (!m_variant_combo && (extruder_id >= (int)nozzle_volumes->size() || extruder_id >= (int)extruders->size()))
         extruder_id = 0;
     if (m_extruder_switch && m_type != Preset::TYPE_PRINTER) {
         int current_extruder = m_extruder_switch->GetValue() ? 1 : 0;


### PR DESCRIPTION
# Description

Fix #13559

The problem here is how it deals with comparasion between signed & unsigned unmbers. It will convert both into unsigned then do the comparasion, which means when `extruder_id` is `-1` (which is a valid value, means all extruders), it will be treated as `0xFFFFFFFF` which is obviously greater than `nozzle_volumes->size()` then be reset to `0`. So when the parameter dialog is built (which will call this function with `extruder_id=-1`), only the first extruder will be set to the correct variant index.

# Screenshots/Recordings/Graphs

With this PR, now the second extruder shows the correct retraction value:

<img width="1478" height="1189" alt="35fd370fd1de2107133f3056e52b0ec7" src="https://github.com/user-attachments/assets/e0620927-7c48-4031-80e2-d1c934a968fe" />
<img width="1478" height="1189" alt="448a68f2276d5db8f701da9889603af5" src="https://github.com/user-attachments/assets/8d9ff1a1-e3cc-4761-9086-9e13370d840d" />


## Tests

<!--
> Please describe the tests that you have conducted to verify the changes made in this PR.
-->

<!--
> A guide for users on how to download the artifacts from this PR.
-->

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
