### PR TITLE
Fix issue that printer name disappear if profile is modified

### DIFF
--- a/src/slic3r/GUI/PresetComboBoxes.cpp
+++ b/src/slic3r/GUI/PresetComboBoxes.cpp
@@ -1241,6 +1241,9 @@ void PlaterPresetComboBox::update()
                     // Remove the old preset name if exists, and add the new one with the same name but with modified suffix if needed.
                     if (system_presets.erase(alternate_name))
                         system_presets.emplace(name, bmp);
+
+                    preset_aliases.erase(alternate_name);  // ORCA: do this to aliases too
+                    preset_aliases[name] = name.utf8_string();
                 }
             } else {
                 system_presets.emplace(name, bmp);


### PR DESCRIPTION
# Description

Fix issue that printer name disappear if profile is modified (other than the first one among its variants) is modified for printers that have multiple variants with different nozzle size

# Screenshots/Recordings/Graphs

<img width="857" height="924" alt="1" src="https://github.com/user-attachments/assets/66be91de-92f3-4368-a080-c550997d9de6" />


## Tests

Fixed:
<img width="694" height="596" alt="image" src="https://github.com/user-attachments/assets/62d5d38f-c57b-4446-b35c-ab2133d90d46" />

<!--
> A guide for users on how to download the artifacts from this PR.
-->

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
