### PR TITLE
Fix freeze after hiding sync popup

### DIFF
--- a/src/slic3r/GUI/BaseTransparentDPIFrame.cpp
+++ b/src/slic3r/GUI/BaseTransparentDPIFrame.cpp
@@ -156,9 +156,11 @@ void BaseTransparentDPIFrame::on_hide()
         m_refresh_timer->Stop();
     }
     Hide();
-    if (wxGetApp().mainframe != nullptr) {
-        wxGetApp().mainframe->Show();
-        wxGetApp().mainframe->Raise();
+    auto *mainframe = wxGetApp().mainframe;
+    if (mainframe != nullptr) {
+        if (!mainframe->IsShown())
+            mainframe->Show();
+        mainframe->Raise();
     }
 }
 


### PR DESCRIPTION
Fixes a Linux/GTK UI freeze after filament sync.

`BaseTransparentDPIFrame::on_hide()` always called `mainframe->Show()` after hiding the transparent sync popup. If the main frame is already visible, this can re-enter GTK/wx size/layout handling after AMS filament sync and leave the UI unresponsive.

This changes the code to call `Show()` only when the main frame is not already shown, while keeping `Raise()` behavior unchanged.

Tested locally on Linux with a Bambu H2D connected: sync filament -> overwrite -> OK no longer freezes.

Related issues:
- Fixes #11288
- Fixes #11701
- Fixes #12553
