### PR TITLE
Increase the timeout threshold for loading profiles.

### DIFF
--- a/resources/web/guide/0/load.js
+++ b/resources/web/guide/0/load.js
@@ -7,8 +7,9 @@ function OnInit()
 
 	TargetPage=GetQueryString("target");
 	
-	// Fallback timeout in case the C++ -> JS signal fails (e.g., WebKit issues)
-	setTimeout("JumpToTarget()",20*1000);
+	// Orca: fallback timeout in case the C++ -> JS signal fails (e.g., WebKit issues).
+	// Jump to the target page after 3 minutes so slow computers don't get stuck on a partially loaded page.
+	setTimeout("JumpToTarget()",180*1000);
 }
 
 function HandleStudio( pVal )


### PR DESCRIPTION
# Description

The loading speed has been greatly improved with PR #13334.  

However, 20 seconds may still not be enough on some computers, so I've increased the timeout to 3 minutes from the previous 20 seconds.

Fixed  #12728  #12789  #13565 

# Screenshots/Recordings/Graphs

<!--
> Please attach relevant screenshots to showcase the UI changes.
> Please attach images that can help explain the changes.
-->

## Tests

<!--
> Please describe the tests that you have conducted to verify the changes made in this PR.
-->

<!--
> A guide for users on how to download the artifacts from this PR.
-->

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
