### PR TITLE
Fix H2D LAN print job routing

### DIFF
--- a/src/slic3r/GUI/DeviceManager.cpp
+++ b/src/slic3r/GUI/DeviceManager.cpp
@@ -493,6 +493,13 @@ bool MachineObject::is_series_p() const { return is_series_p(DevPrinterConfigUti
 bool MachineObject::is_series_x() const { return is_series_x(DevPrinterConfigUtil::get_printer_series_str(printer_type)); }
 bool MachineObject::is_series_o() const { return is_series_o(DevPrinterConfigUtil::get_printer_series_str(printer_type)); }
 
+bool MachineObject::can_use_emmc_print() const
+{
+    AppConfig* config = GUI::wxGetApp().app_config;
+    std::string disable_emmc_print = config ? config->get("disable_emmc_print") : "true";
+    return is_support_print_with_emmc && (disable_emmc_print == "0" || disable_emmc_print == "false");
+}
+
 std::string MachineObject::get_printer_series_str() const{ return DevPrinterConfigUtil::get_printer_series_str(printer_type);};
 
 void MachineObject::reload_printer_settings()

--- a/src/slic3r/GUI/DeviceManager.hpp
+++ b/src/slic3r/GUI/DeviceManager.hpp
@@ -218,6 +218,7 @@ public:
     bool is_series_p() const;
     bool is_series_x() const;
     bool is_series_o() const;
+    bool can_use_emmc_print() const;
 
     void reload_printer_settings();
     std::string get_printer_thumbnail_img_str() const;

--- a/src/slic3r/GUI/SelectMachine.cpp
+++ b/src/slic3r/GUI/SelectMachine.cpp
@@ -2526,7 +2526,10 @@ void SelectMachineDialog::on_send_print()
                || m_print_job->sdcard_state == DevStorage::SdcardState::HAS_SDCARD_ABNORMAL)
             : m_print_job->sdcard_state == DevStorage::SdcardState::HAS_SDCARD_NORMAL;
 
-    m_print_job->could_emmc_print = obj_->is_support_print_with_emmc;
+    m_print_job->could_emmc_print = obj_->can_use_emmc_print();
+    if (obj_->is_support_print_with_emmc && !m_print_job->could_emmc_print) {
+        BOOST_LOG_TRIVIAL(info) << "print_job: emmc print disabled by config";
+    }
 
 
     bool timelapse_option = m_checkbox_list["timelapse"]->IsShown()?true:false;
@@ -3327,7 +3330,7 @@ void SelectMachineDialog::update_show_status(MachineObject* obj_)
     /*check sdcard when if lan mode printer*/
     if (obj_->is_lan_mode_printer()) {
         if (obj_->GetStorage()->get_sdcard_state() == DevStorage::SdcardState::NO_SDCARD
-            && !obj_->is_support_print_with_emmc) {
+            && !obj_->can_use_emmc_print()) {
             show_status(PrintDialogStatus::PrintStatusLanModeNoSdcard);
             return;
         } else if (obj_->GetStorage()->get_sdcard_state() == DevStorage::SdcardState::HAS_SDCARD_READONLY) {

--- a/src/slic3r/Utils/CalibUtils.cpp
+++ b/src/slic3r/Utils/CalibUtils.cpp
@@ -1839,7 +1839,7 @@ void CalibUtils::send_to_print(const CalibInfo &calib_info, wxString &error_mess
             ? (print_job->sdcard_state == DevStorage::SdcardState::HAS_SDCARD_NORMAL
                || print_job->sdcard_state == DevStorage::SdcardState::HAS_SDCARD_ABNORMAL)
             : print_job->sdcard_state == DevStorage::SdcardState::HAS_SDCARD_NORMAL;
-    print_job->could_emmc_print = obj_->is_support_print_with_emmc;
+    print_job->could_emmc_print = obj_->can_use_emmc_print();
     print_job->set_print_config(MachineBedTypeString[bed_type], true, false, false, false, true, false, 0, 0, 0);
     print_job->set_print_job_finished_event(wxGetApp().plater()->get_send_calibration_finished_event(), print_job->m_project_name);
 
@@ -1962,7 +1962,7 @@ void CalibUtils::send_to_print(const std::vector<CalibInfo> &calib_infos, wxStri
             ? (print_job->sdcard_state == DevStorage::SdcardState::HAS_SDCARD_NORMAL
                || print_job->sdcard_state == DevStorage::SdcardState::HAS_SDCARD_ABNORMAL)
             : print_job->sdcard_state == DevStorage::SdcardState::HAS_SDCARD_NORMAL;
-    print_job->could_emmc_print = obj_->is_support_print_with_emmc;
+    print_job->could_emmc_print = obj_->can_use_emmc_print();
     print_job->set_print_config(MachineBedTypeString[bed_type], true, true, false, false, true, false, 0, 1, 0);
     print_job->set_print_job_finished_event(wxGetApp().plater()->get_send_calibration_finished_event(), print_job->m_project_name);
 


### PR DESCRIPTION
# Description

O-series printers such as H2D can advertise eMMC print support through `fun2`, but in LAN-only mode direct print jobs should not use the eMMC print path.

This adds `MachineObject::can_use_emmc_print()` and uses it when creating normal and calibration print jobs. For O-series printers in LAN mode, Orca now falls back to the regular storage upload path instead of setting `PrintJob::could_emmc_print`.

Related to #11499 and #12563.

# Screenshots/Recordings/Graphs

N/A

## Tests

- Ran `git diff --check`
- Verified an equivalent 2.3.2 AppImage patch on an H2D in LAN-only mode: print jobs no longer require manual start from the printer.
- Local build of current `main` was not completed because the local dependency prefix has Eigen 3.4.0 while current `main` requires Eigen 5.0.1.
