### PR TITLE
Project create/save helper

### DIFF
--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -7787,8 +7787,14 @@ std::vector<std::pair<unsigned int, std::string>> GUI_App::get_selected_presets(
 // This is called when:
 // - Exporting config_bundle
 // - Taking snapshot
-bool GUI_App::check_and_save_current_preset_changes(const wxString& caption, const wxString& header, bool remember_choice/* = true*/, bool dont_save_insted_of_discard/* = false*/)
+bool GUI_App::check_and_save_current_preset_changes(const wxString& caption, const wxString& header, bool remember_choice/* = true*/, bool dont_save_insted_of_discard/* = false*/,
+                                                    bool* saved_changes/* = nullptr*/, bool* saved_to_project/* = nullptr*/)
 {
+    if (saved_changes)
+        *saved_changes = false;
+    if (saved_to_project)
+        *saved_to_project = false;
+
     if (has_current_preset_changes()) {
         int act_buttons = ActionButtons::SAVE;
         if (dont_save_insted_of_discard)
@@ -7802,11 +7808,19 @@ bool GUI_App::check_and_save_current_preset_changes(const wxString& caption, con
 
         if (dlg.save_preset())  // save selected changes
         {
+            bool has_project_embedded_changes = false;
             //BBS: add project embedded preset relate logic
-            for (const UnsavedChangesDialog::PresetData& nt : dlg.get_names_and_types())
+            for (const UnsavedChangesDialog::PresetData& nt : dlg.get_names_and_types()) {
                 preset_bundle->save_changes_for_preset(nt.name, nt.type, dlg.get_unselected_options(nt.type), nt.save_to_project);
+                has_project_embedded_changes |= nt.save_to_project;
+            }
             //for (const std::pair<std::string, Preset::Type>& nt : dlg.get_names_and_types())
             //    preset_bundle->save_changes_for_preset(nt.first, nt.second, dlg.get_unselected_options(nt.second));
+
+            if (saved_changes)
+                *saved_changes = true;
+            if (saved_to_project)
+                *saved_to_project = has_project_embedded_changes;
 
             load_current_presets(false);
 

--- a/src/slic3r/GUI/GUI_App.hpp
+++ b/src/slic3r/GUI/GUI_App.hpp
@@ -585,7 +585,8 @@ public:
     bool            has_current_preset_changes() const;
     void            update_saved_preset_from_current_preset();
     std::vector<std::pair<unsigned int, std::string>> get_selected_presets() const;
-    bool            check_and_save_current_preset_changes(const wxString& caption, const wxString& header, bool remember_choice = true, bool use_dont_save_insted_of_discard = false);
+    bool            check_and_save_current_preset_changes(const wxString& caption, const wxString& header, bool remember_choice = true, bool use_dont_save_insted_of_discard = false,
+                                                          bool* saved_changes = nullptr, bool* saved_to_project = nullptr);
     void            apply_keeped_preset_modifications();
     bool            check_and_keep_current_preset_changes(const wxString& caption, const wxString& header, int action_buttons, bool* postponed_apply_of_keeped_changes = nullptr);
     bool            can_load_project();

--- a/src/slic3r/GUI/GUI_ObjectList.cpp
+++ b/src/slic3r/GUI/GUI_ObjectList.cpp
@@ -2518,6 +2518,9 @@ void ObjectList::load_shape_object(const std::string &type_name)
     if (selection.get_object_idx() != -1)
         return;
 
+    if (!wxGetApp().plater()->maybe_start_new_project_after_empty_plate_delete())
+        return;
+
     const int obj_idx = m_objects->size();
     if (obj_idx < 0)
         return;

--- a/src/slic3r/GUI/MainFrame.cpp
+++ b/src/slic3r/GUI/MainFrame.cpp
@@ -585,10 +585,20 @@ DPIFrame(NULL, wxID_ANY, "", wxDefaultPosition, wxDefaultSize, BORDERLESS_FRAME_
         //    event.Veto();
         //    return;
         //}
-        auto check = [](bool yes_or_no) {
+        bool preset_changes_saved = false;
+        bool preset_changes_saved_to_project = false;
+        auto check = [&preset_changes_saved, &preset_changes_saved_to_project](bool yes_or_no) {
+            preset_changes_saved = false;
+            preset_changes_saved_to_project = false;
             if (yes_or_no)
                 return true;
-            return wxGetApp().check_and_save_current_preset_changes(_L("Application is closing"), _L("Closing Application while some presets are modified."));
+            return wxGetApp().check_and_save_current_preset_changes(
+                _L("Application is closing"),
+                _L("Closing Application while some presets are modified."),
+                true,
+                false,
+                &preset_changes_saved,
+                &preset_changes_saved_to_project);
         };
 
         // BBS: close save project
@@ -597,6 +607,24 @@ DPIFrame(NULL, wxID_ANY, "", wxDefaultPosition, wxDefaultSize, BORDERLESS_FRAME_
             event.Veto();
             BOOST_LOG_TRIVIAL(info) << __FUNCTION__<< "cancelled by close_with_confirm selection";
             return;
+        }
+        if (event.CanVeto() && preset_changes_saved && preset_changes_saved_to_project && !m_plater->get_project_filename(".3mf").IsEmpty()) {
+            int save_project_result = MessageDialog(
+                static_cast<wxWindow*>(this),
+                _L("The current project contains saved profile changes.\nDo you want to save the project before closing?"),
+                wxString(SLIC3R_APP_FULL_NAME) + " - " + _L("Save"),
+                wxYES_NO | wxCANCEL | wxYES_DEFAULT | wxCENTRE)
+                .ShowModal();
+            if (save_project_result == wxID_CANCEL) {
+                event.Veto();
+                BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << " cancelled while confirming project save after preset save";
+                return;
+            }
+            if (save_project_result == wxID_YES && m_plater->save_project() == wxID_CANCEL) {
+                event.Veto();
+                BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << " cancelled while saving project after preset save";
+                return;
+            }
         }
         if (event.CanVeto() && !wxGetApp().check_print_host_queue()) {
             event.Veto();

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -4815,6 +4815,8 @@ struct Plater::priv
 
     //BBS: project
     BBLProject                  project;
+    bool                        m_offer_new_project_after_empty_plate_on_next_add { false };
+    bool                        has_saved_or_opened_project_file() const { return !get_project_filename(".3mf").IsEmpty(); }
 
     //BBS: add print project related logic
     void update_fff_scene_only_shells(bool only_shells = true);
@@ -7374,7 +7376,9 @@ void Plater::priv::object_list_changed()
     model_fits = model_fits && object_results.filaments.empty();
 
     PartPlate* part_plate = partplate_list.get_curr_plate();
-
+    if (!model.objects.empty()) {
+        m_offer_new_project_after_empty_plate_on_next_add = false;
+    }
     // BBS
     //sidebar->enable_buttons(!model.objects.empty() && !export_in_progress && model_fits && part_plate->has_printable_instances());
     bool can_slice = !model.objects.empty() && !export_in_progress && model_fits && part_plate->has_printable_instances();
@@ -7394,6 +7398,9 @@ void Plater::priv::remove_curr_plate_all()
 {
     SingleSnapshot ss(q);
     view3D->remove_curr_plate_all();
+    if (model.objects.empty()) {
+        m_offer_new_project_after_empty_plate_on_next_add = has_saved_or_opened_project_file();
+    }
     this->sidebar->obj_list()->update_selections();
 }
 
@@ -7420,6 +7427,9 @@ void Plater::priv::remove(size_t obj_idx)
 
     m_worker.cancel_all();
     model.delete_object(obj_idx);
+    if (model.objects.empty()) {
+        m_offer_new_project_after_empty_plate_on_next_add = has_saved_or_opened_project_file();
+    }
     //BBS: notify partplate the instance removed
     partplate_list.notify_instance_removed(obj_idx, -1);
     update();
@@ -7455,6 +7465,9 @@ bool Plater::priv::delete_object_from_model(size_t obj_idx, bool refresh_immedia
         sidebar->obj_list()->invalidate_cut_info_for_object(obj_idx);
 
     model.delete_object(obj_idx);
+    if (model.objects.empty()) {
+        m_offer_new_project_after_empty_plate_on_next_add = has_saved_or_opened_project_file();
+    }
     //BBS: notify partplate the instance removed
     partplate_list.notify_instance_removed(obj_idx, -1);
 
@@ -7469,6 +7482,8 @@ bool Plater::priv::delete_object_from_model(size_t obj_idx, bool refresh_immedia
 
 void Plater::priv::delete_all_objects_from_model()
 {
+    const bool had_objects = !model.objects.empty();
+
     Plater::TakeSnapshot snapshot(q, "Delete All Objects");
 
     if (view3D->is_layers_editing_enabled())
@@ -7496,11 +7511,17 @@ void Plater::priv::delete_all_objects_from_model()
     //BBS
     model.calib_pa_pattern.reset();
     model.plates_custom_gcodes.clear();
+
+    if (had_objects) {
+        m_offer_new_project_after_empty_plate_on_next_add = has_saved_or_opened_project_file();
+    }
 }
 
 void Plater::priv::reset(bool apply_presets_change)
 {
     Plater::TakeSnapshot snapshot(q, "Reset Project", UndoRedo::SnapshotType::ProjectSeparator);
+
+    m_offer_new_project_after_empty_plate_on_next_add = false;
 
     clear_warnings();
 
@@ -12519,6 +12540,38 @@ bool Plater::up_to_date(bool saved, bool backup)
                                         !Slic3r::has_other_changes(backup));
 }
 
+static bool maybe_start_new_project_after_empty_plate_delete_impl(Plater* plater, bool& offer_prompt)
+{
+    if (!offer_prompt)
+        return true;
+
+    if (plater->get_project_filename(".3mf").IsEmpty()) {
+        offer_prompt = false;
+        return true;
+    }
+
+    int result = MessageDialog(
+                     static_cast<wxWindow*>(plater),
+                     _L("All objects were removed from the build plate.\nDo you want to create a new project before adding models?"),
+                     wxString(SLIC3R_APP_FULL_NAME) + " - " + _L("Create New Project"),
+                     wxYES_NO | wxCANCEL | wxYES_DEFAULT | wxCENTRE)
+                     .ShowModal();
+
+    if (result == wxID_CANCEL)
+        return false;
+
+    if (result == wxID_YES && plater->new_project(false, true) == wxID_CANCEL)
+        return false;
+
+    offer_prompt = false;
+    return true;
+}
+
+bool Plater::maybe_start_new_project_after_empty_plate_delete()
+{
+    return maybe_start_new_project_after_empty_plate_delete_impl(this, p->m_offer_new_project_after_empty_plate_on_next_add);
+}
+
 void Plater::add_model(bool imperial_units, std::string fname)
 {
     wxArrayString input_files;
@@ -12563,6 +12616,11 @@ void Plater::add_model(bool imperial_units, std::string fname)
     if (paths.size() > 1 && amf_files_count == 0) { loadfiles_type = LoadFilesType::MultipleOther; }
     if (paths.size() == 1 && amf_files_count == 1) { loadfiles_type = LoadFilesType::Single3MF; };
     if (paths.size() == 1 && amf_files_count == 0) { loadfiles_type = LoadFilesType::SingleOther; };
+
+    if (fname.empty() &&
+        (loadfiles_type == LoadFilesType::SingleOther || loadfiles_type == LoadFilesType::MultipleOther) &&
+        !maybe_start_new_project_after_empty_plate_delete())
+        return;
 
     bool ask_multi = false;
 
@@ -13761,6 +13819,10 @@ std::vector<size_t> Plater::load_files(const std::vector<fs::path>& input_files,
     p->m_slice_all_only_has_gcode = false;
     //BBS: wish to reset all plates stats item selected state when load a new file
     p->preview->get_canvas3d()->reset_select_plate_toolbar_selection();
+
+    if ((strategy & LoadStrategy::LoadModel) && !input_files.empty() && !maybe_start_new_project_after_empty_plate_delete())
+        return {};
+
     return p->load_files(input_files, strategy, ask_multi);
 }
 
@@ -14194,6 +14256,10 @@ bool Plater::load_files(const wxArrayString& filenames)
     if (normal_paths.size() == 1 && amf_files_count == 1) { loadfiles_type = LoadFilesType::Single3MF; };
     if (normal_paths.size() == 1 && amf_files_count == 0) { loadfiles_type = LoadFilesType::SingleOther; };
 
+    if ((loadfiles_type == LoadFilesType::SingleOther || loadfiles_type == LoadFilesType::MultipleOther) &&
+        !maybe_start_new_project_after_empty_plate_delete())
+        return false;
+
     auto first_file = std::vector<fs::path>{};
     auto tmf_file   = std::vector<fs::path>{};
     auto other_file = std::vector<fs::path>{};
@@ -14385,6 +14451,10 @@ void Plater::add_file()
     if (paths.size() > 1 && amf_files_count == 0) { loadfiles_type = LoadFilesType::MultipleOther; }
     if (paths.size() == 1 && amf_files_count == 1) { loadfiles_type = LoadFilesType::Single3MF; };
     if (paths.size() == 1 && amf_files_count == 0) { loadfiles_type = LoadFilesType::SingleOther; };
+
+    if ((loadfiles_type == LoadFilesType::SingleOther || loadfiles_type == LoadFilesType::MultipleOther) &&
+        !maybe_start_new_project_after_empty_plate_delete())
+        return;
 
     auto first_file = std::vector<fs::path>{};
     auto tmf_file   = std::vector<fs::path>{};

--- a/src/slic3r/GUI/Plater.hpp
+++ b/src/slic3r/GUI/Plater.hpp
@@ -316,6 +316,7 @@ public:
     void request_download_project(std::string project_id);
     // BBS: check snapshot
     bool up_to_date(bool saved, bool backup);
+    bool maybe_start_new_project_after_empty_plate_delete();
 
     bool open_3mf_file(const fs::path &file_path);
     int  get_3mf_file_count(std::vector<fs::path> paths);


### PR DESCRIPTION
Add flow behavior for project sessions.

- On close, if profile changes were saved to the project, the app now asks whether to save the project again.
- After deleting all objects, adding a new model now prompts to create a new project before import.
	- This will just happen if a project was open/created in the first place.
- The add-flow prompt is applied across all add entry points, including Primitive and Handy Models.
- Cancel handling remains safe: cancelling the dialog aborts the close/import action.
- This will not override/overlap with current project promp.

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
