### PR TITLE
Scaling fixes

### DIFF
--- a/src/slic3r/GUI/Auxiliary.cpp
+++ b/src/slic3r/GUI/Auxiliary.cpp
@@ -64,12 +64,15 @@ AuFile::AuFile(wxWindow *parent, fs::path file_path, wxString file_name, Auxilia
     m_file_path = file_path;
     m_file_name = file_name;
 
-    wxSize panel_size = m_type == MODEL_PICTURE ? AUFILE_PICTURES_PANEL_SIZE : AUFILE_PANEL_SIZE;
+    wxSize panel_size = parent->FromDIP(m_type == MODEL_PICTURE ? AUFILE_PICTURES_PANEL_SIZE : AUFILE_PANEL_SIZE);
+    SetMinSize(panel_size);
+    SetMaxSize(panel_size);
+    SetInitialSize(panel_size);
+    SetSize(panel_size); // ORCA call sizing before create to avoid wxEVT_SIZE event with wrong size
+
     wxPanel::Create(parent, id, pos, panel_size, style);
     SetBackgroundColour(StateColor::darkModeColorFor(AUFILE_GREY300));
     wxBoxSizer *sizer_body = new wxBoxSizer(wxVERTICAL);
-
-   SetSize(panel_size);
 
     if (m_type == MODEL_PICTURE) {
         if (m_file_path.empty()) { return; }
@@ -85,7 +88,7 @@ AuFile::AuFile(wxWindow *parent, fs::path file_path, wxString file_name, Auxilia
             size.y = AUFILE_PICTURES_SIZE.y;
             size.x = AUFILE_PICTURES_SIZE.y * proportion;
         }
-
+        size -= FromDIP(wxSize(6,6));// ORCA draw inside borders
         image->Rescale(size.x, size.y);
         m_file_bitmap.bmp() = wxBitmap(*image);
     } else {
@@ -121,8 +124,8 @@ AuFile::AuFile(wxWindow *parent, fs::path file_path, wxString file_name, Auxilia
 
     wxBoxSizer *m_text_sizer = new wxBoxSizer(wxHORIZONTAL);
     m_text_name              = new wxStaticText(m_text_panel, wxID_ANY, m_file_name, wxDefaultPosition, wxSize(panel_size.x, -1), wxST_ELLIPSIZE_END);
-    m_text_name->Wrap(panel_size.x - FromDIP(10));
     m_text_name->SetFont(::Label::Body_14);
+    m_text_name->Wrap(panel_size.x - FromDIP(10));
     m_text_name->SetForegroundColour(StateColor::darkModeColorFor(*wxBLACK));
 
     m_input_name = new ::TextInput(m_text_panel, wxEmptyString, wxEmptyString, wxEmptyString, wxDefaultPosition, wxSize(panel_size.x - FromDIP(28), FromDIP(32)), wxTE_PROCESS_ENTER);
@@ -181,26 +184,12 @@ void AuFile::exit_rename_mode()
 
 void AuFile::OnPaint(wxPaintEvent &event)
 {
-    wxPaintDC dc(this);
-#ifdef __WXMSW__
-    wxSize     size = GetSize();
-    wxMemoryDC memdc;
-    wxBitmap   bmp(size.x, size.y);
-    memdc.SelectObject(bmp);
-    memdc.Blit({ 0, 0 }, size, &dc, { 0, 0 });
+    wxAutoBufferedPaintDC dc(this);   // handles buffering correctly per-platform
+    dc.Clear();
 
-    {
-        wxGCDC dc2(memdc);
-        PaintBackground(dc2);
-        PaintForeground(dc2);
-    }
-
-    memdc.SelectObject(wxNullBitmap);
-    dc.DrawBitmap(bmp, 0, 0);
-#else
-    PaintBackground(dc);
-    PaintForeground(dc);
-#endif
+    wxGCDC gdc(dc);
+    PaintBackground(gdc);
+    PaintForeground(gdc);
 }
 
 void AuFile::PaintBackground(wxDC &dc)
@@ -232,7 +221,7 @@ void AuFile::PaintBackground(wxDC &dc)
         auto sizet = dc.GetTextExtent(m_add_file);
         auto pos = wxPoint(0, 0);
         pos.x = (size.x - sizet.x) / 2;
-        pos.y = (size.y - 40); // to modify
+        pos.y = (size.y - FromDIP(40));
         dc.SetTextForeground(AUFILE_GREY500);
         dc.DrawText(m_add_file, pos);
     }
@@ -270,7 +259,7 @@ void AuFile::PaintForeground(wxDC &dc)
             auto sizet = dc.GetTextExtent(m_add_file);
             auto pos = wxPoint(0, 0);
             pos.x = (size.x - sizet.x) / 2;
-            pos.y = (size.y - 40); // to modify
+            pos.y = (size.y - FromDIP(40));
             dc.SetTextForeground(AUFILE_BRAND);
             dc.DrawText(m_add_file, pos);
             return;
@@ -566,9 +555,21 @@ AuFile::~AuFile() {}
 
 void AuFile::msw_rescale() 
 { 
+    wxSize panel_size = m_type == MODEL_PICTURE ? AUFILE_PICTURES_PANEL_SIZE : AUFILE_PANEL_SIZE;
+    SetMinSize(panel_size);
+    SetMaxSize(panel_size);
+    SetInitialSize(panel_size);
+    SetSize(panel_size);
+
     m_file_cover     = ScalableBitmap(this, "auxiliary_cover", 40);
-    m_file_edit_mask = ScalableBitmap(this, "auxiliary_edit_mask", FromDIP(30));
+    m_file_edit_mask = ScalableBitmap(this, "auxiliary_edit_mask", 30);
     m_file_delete    = ScalableBitmap(this, "auxiliary_delete", 20);
+
+    m_text_name->SetMinSize(wxSize(panel_size.x, -1));
+    m_text_name->SetMaxSize(wxSize(panel_size.x, -1));
+    m_text_name->Wrap(panel_size.x - FromDIP(10));
+    m_input_name->SetMinSize(wxSize(panel_size.x - FromDIP(28), FromDIP(32)));
+    m_input_name->SetSize(   wxSize(panel_size.x - FromDIP(28), FromDIP(32)));
 
     if (m_type == MODEL_PICTURE) {
         if (m_file_path.empty()) { return;}
@@ -577,13 +578,13 @@ void AuFile::msw_rescale()
         auto  size       = wxSize(0, 0);
         float proportion = float(image->GetSize().x) / float(image->GetSize().y);
         if (proportion >= 1) {
-            size.x = FromDIP(300);
-            size.y = FromDIP(300) / proportion;
+            size.x = AUFILE_PICTURES_SIZE.x;
+            size.y = AUFILE_PICTURES_SIZE.x / proportion;
         } else {
-            size.y = FromDIP(300);
-            size.x = FromDIP(300) * proportion;
+            size.y = AUFILE_PICTURES_SIZE.x;
+            size.x = AUFILE_PICTURES_SIZE.x * proportion;
         }
-
+        size -= FromDIP(wxSize(6,6));// ORCA draw inside borders
         image->Rescale(size.x, size.y);
         m_file_bitmap.bmp() = wxBitmap(*image);
     } else {
@@ -595,6 +596,8 @@ void AuFile::msw_rescale()
         if (m_type == BILL_OF_MATERIALS) { m_file_bitmap = m_bitmap_excel; }
         if (m_type == ASSEMBLY_GUIDE) { m_file_bitmap = m_bitmap_pdf; }
     }
+
+    Layout();
     Refresh();
 }
 
@@ -695,11 +698,15 @@ void AuFolderPanel::update(std::vector<fs::path> paths)
 
 void AuFolderPanel::msw_rescale() 
 {
+    m_big_button_add->msw_rescale();
     //m_button_add->SetMinSize(wxSize(-1, FromDIP(24)));
     for (auto i = 0; i < m_aufiles_list.GetCount(); i++) {
         AuFiles *aufile = m_aufiles_list[i];
         aufile->file->msw_rescale();
     }
+    m_gsizer_content->Layout();
+    m_scrolledWindow->Layout();
+    Layout();
 }
 
 void AuFolderPanel::on_add(wxMouseEvent& event)
@@ -846,7 +853,7 @@ void AuxiliaryPanel::init_tabpanel()
                             std::pair<wxColour, int>(wxColour(0, 137, 123), StateColor::Pressed),
                             std::pair<wxColour, int>(wxColour(38, 166, 154), StateColor::Hovered),
                             std::pair<wxColour, int>(wxColour(0, 150, 136), StateColor::Normal));
-    auto back_btn = new Button(this, _L("Return"), "assemble_return", wxBORDER_NONE | wxBU_LEFT | wxBU_EXACTFIT);
+    back_btn = new Button(this, _L("Return"), "assemble_return", wxBORDER_NONE | wxBU_LEFT | wxBU_EXACTFIT);
     back_btn->SetSize(wxSize(FromDIP(220), FromDIP(18)));
     back_btn->SetBackgroundColor(btn_bg_green);
     back_btn->SetTextColor(StateColor (std::pair<wxColour, int>(wxColour("#FDFFFD"), StateColor::Normal))); // ORCA fixes color change on text. icon stays white color but text changes to black without this
@@ -888,6 +895,8 @@ wxWindow *AuxiliaryPanel::create_side_tools()
 }
 
 void AuxiliaryPanel::msw_rescale() { 
+    back_btn->Rescale();
+    m_tabpanel->Rescale();
     m_pictures_panel->msw_rescale();
     m_bill_of_materials_panel->msw_rescale();
     m_assembly_panel->msw_rescale();

--- a/src/slic3r/GUI/Auxiliary.cpp
+++ b/src/slic3r/GUI/Auxiliary.cpp
@@ -187,9 +187,14 @@ void AuFile::OnPaint(wxPaintEvent &event)
     wxAutoBufferedPaintDC dc(this);   // handles buffering correctly per-platform
     dc.Clear();
 
+#ifdef __WXMSW__
     wxGCDC gdc(dc);
     PaintBackground(gdc);
     PaintForeground(gdc);
+#else
+    PaintBackground(dc);
+    PaintForeground(dc);
+#endif
 }
 
 void AuFile::PaintBackground(wxDC &dc)

--- a/src/slic3r/GUI/Auxiliary.cpp
+++ b/src/slic3r/GUI/Auxiliary.cpp
@@ -64,15 +64,12 @@ AuFile::AuFile(wxWindow *parent, fs::path file_path, wxString file_name, Auxilia
     m_file_path = file_path;
     m_file_name = file_name;
 
-    wxSize panel_size = parent->FromDIP(m_type == MODEL_PICTURE ? AUFILE_PICTURES_PANEL_SIZE : AUFILE_PANEL_SIZE);
-    SetMinSize(panel_size);
-    SetMaxSize(panel_size);
-    SetInitialSize(panel_size);
-    SetSize(panel_size); // ORCA call sizing before create to avoid wxEVT_SIZE event with wrong size
-
+    wxSize panel_size = m_type == MODEL_PICTURE ? AUFILE_PICTURES_PANEL_SIZE : AUFILE_PANEL_SIZE;
     wxPanel::Create(parent, id, pos, panel_size, style);
     SetBackgroundColour(StateColor::darkModeColorFor(AUFILE_GREY300));
     wxBoxSizer *sizer_body = new wxBoxSizer(wxVERTICAL);
+
+    SetSize(panel_size);
 
     if (m_type == MODEL_PICTURE) {
         if (m_file_path.empty()) { return; }
@@ -118,9 +115,9 @@ AuFile::AuFile(wxWindow *parent, fs::path file_path, wxString file_name, Auxilia
     m_file_delete    = ScalableBitmap(this, "auxiliary_delete", 20);
     
 
-    auto m_text_panel = new wxPanel(this, wxID_ANY, wxDefaultPosition, wxSize(panel_size.x, AUFILE_TEXT_HEIGHT), wxTAB_TRAVERSAL);
+    m_text_panel = new wxPanel(this, wxID_ANY, wxDefaultPosition, wxSize(panel_size.x, AUFILE_TEXT_HEIGHT), wxTAB_TRAVERSAL);
     m_text_panel->SetBackgroundColour(StateColor::darkModeColorFor(AUFILE_GREY300));
-    
+    m_text_panel->SetMaxSize(wxSize(panel_size.x, AUFILE_TEXT_HEIGHT));
 
     wxBoxSizer *m_text_sizer = new wxBoxSizer(wxHORIZONTAL);
     m_text_name              = new wxStaticText(m_text_panel, wxID_ANY, m_file_name, wxDefaultPosition, wxSize(panel_size.x, -1), wxST_ELLIPSIZE_END);
@@ -148,8 +145,9 @@ AuFile::AuFile(wxWindow *parent, fs::path file_path, wxString file_name, Auxilia
 
     m_text_panel->SetSizer(m_text_sizer);
     m_text_panel->Layout();
-    sizer_body->Add(0, 0, 0, wxTOP, panel_size.y - AUFILE_TEXT_HEIGHT);
-    sizer_body->Add(m_text_panel, 0, wxALIGN_CENTER, 0);
+    //sizer_body->Add(0, 0, 0, wxTOP, panel_size.y - AUFILE_TEXT_HEIGHT);
+    sizer_body->AddStretchSpacer(); // ensures m_text_sizer rendered on bottom while using scaled screens
+    sizer_body->Add(m_text_panel, 1, wxALIGN_CENTER, 0);
 
     SetSizer(sizer_body);
     Layout();
@@ -563,12 +561,14 @@ void AuFile::msw_rescale()
     wxSize panel_size = m_type == MODEL_PICTURE ? AUFILE_PICTURES_PANEL_SIZE : AUFILE_PANEL_SIZE;
     SetMinSize(panel_size);
     SetMaxSize(panel_size);
-    SetInitialSize(panel_size);
     SetSize(panel_size);
 
     m_file_cover     = ScalableBitmap(this, "auxiliary_cover", 40);
     m_file_edit_mask = ScalableBitmap(this, "auxiliary_edit_mask", 30);
     m_file_delete    = ScalableBitmap(this, "auxiliary_delete", 20);
+
+    m_text_panel->SetSize(wxSize(panel_size.x, AUFILE_TEXT_HEIGHT));
+    m_text_panel->SetMaxSize(wxSize(panel_size.x, AUFILE_TEXT_HEIGHT));
 
     m_text_name->SetMinSize(wxSize(panel_size.x, -1));
     m_text_name->SetMaxSize(wxSize(panel_size.x, -1));
@@ -641,7 +641,7 @@ AuFolderPanel::AuFolderPanel(wxWindow *parent, AuxiliaryFolderType type, wxWindo
     // m_button_del->Bind(wxEVT_LEFT_UP, &AuxiliaryPanel::on_delete, this);
 
     sizer_top->Add(0, 0, 0, wxLEFT, FromDIP(10));
-    m_gsizer_content = new wxWrapSizer(wxHORIZONTAL, wxWRAPSIZER_DEFAULT_FLAGS);
+    m_gsizer_content = new wxWrapSizer(wxHORIZONTAL, 0); // wxWRAPSIZER_DEFAULT_FLAGS causes last item expands horizontaly
     //if (m_type == MODEL_PICTURE) {
     //    //sizer_top->Add(m_button_add, 0, wxALL, 0);
     //    //m_big_button_add->Hide();
@@ -690,6 +690,9 @@ void AuFolderPanel::update(std::vector<fs::path> paths)
         auto name = encode_path(temp_name.c_str());
 
         auto        aufile = new AuFile(m_scrolledWindow, paths[i], name, m_type, wxID_ANY);
+
+        aufile->msw_rescale(); // Force initial scale evaluation for high-DPI contexts
+
         m_gsizer_content->Add(aufile, 0, wxALL, FromDIP(8));
         auto af  = new AuFiles;
         af->path = paths[i].string();

--- a/src/slic3r/GUI/Auxiliary.hpp
+++ b/src/slic3r/GUI/Auxiliary.hpp
@@ -197,6 +197,8 @@ public:
 class AuxiliaryPanel : public wxPanel
 {
 private:
+    Button * back_btn = {nullptr};
+
     Tabbook *m_tabpanel = {nullptr};
     wxSizer *m_main_sizer = {nullptr};
 

--- a/src/slic3r/GUI/Auxiliary.hpp
+++ b/src/slic3r/GUI/Auxiliary.hpp
@@ -85,6 +85,7 @@ public:
     AuxiliaryFolderType m_type;
     bool                m_hover{false};
     bool                m_cover{false};
+    wxPanel*            m_text_panel {nullptr};
     wxStaticText*       m_text_name {nullptr};
     ::TextInput*        m_input_name {nullptr};
     fs::path m_file_path;

--- a/src/slic3r/GUI/BBLTopbar.cpp
+++ b/src/slic3r/GUI/BBLTopbar.cpp
@@ -605,6 +605,13 @@ void BBLTopbar::Rescale() {
     item->SetBitmap(create_scaled_bitmap("topbar_close", this, TOPBAR_ICON_SIZE));
 
     Realize();
+
+#ifdef __WXMSW__
+    // Update menus
+    msw_rescale_menu(GetTopMenu());
+    msw_rescale_menu(GetCalibMenu());
+    msw_rescale_menu(m_file_menu);
+#endif
 }
 
 void BBLTopbar::OnIconize(wxAuiToolBarEvent& event)

--- a/src/slic3r/GUI/BBLTopbar.cpp
+++ b/src/slic3r/GUI/BBLTopbar.cpp
@@ -244,7 +244,7 @@ void BBLTopbar::Init(wxFrame* parent)
         wxBitmap close_bitmap = create_scaled_bitmap("topbar_close", nullptr, TOPBAR_ICON_SIZE);
         wxAuiToolBarItem* close_btn = this->AddTool(wxID_CLOSE_FRAME, "", close_bitmap);
 
-        this->AddSpacer(FromDIP(4));
+        this->AddDIPSpacer(4);
 
         maximize_bitmap = create_scaled_bitmap("topbar_max", nullptr, TOPBAR_ICON_SIZE);
         window_bitmap = create_scaled_bitmap("topbar_win", nullptr, TOPBAR_ICON_SIZE);
@@ -255,7 +255,7 @@ void BBLTopbar::Init(wxFrame* parent)
             maximize_btn = this->AddTool(wxID_MAXIMIZE_FRAME, "", maximize_bitmap);
         }
 
-        this->AddSpacer(FromDIP(4));
+        this->AddDIPSpacer(4);
 
         wxBitmap iconize_bitmap = create_scaled_bitmap("topbar_min", nullptr, TOPBAR_ICON_SIZE);
         wxAuiToolBarItem* iconize_btn = this->AddTool(wxID_ICONIZE_FRAME, "", iconize_bitmap);
@@ -265,7 +265,7 @@ void BBLTopbar::Init(wxFrame* parent)
 #endif
 
     if(!window_btns_on_left)
-        this->AddSpacer(5);
+        this->AddDIPSpacer(5);
 
     /*wxBitmap logo_bitmap = create_scaled_bitmap("topbar_logo", nullptr, TOPBAR_ICON_SIZE);
     wxAuiToolBarItem* logo_item = this->AddTool(ID_LOGO, "", logo_bitmap);
@@ -277,46 +277,46 @@ void BBLTopbar::Init(wxFrame* parent)
 
     this->SetForegroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_HIGHLIGHTTEXT));
 
-    this->AddSpacer(FromDIP(5));
+    this->AddDIPSpacer(5);
 
     wxBitmap dropdown_bitmap = create_scaled_bitmap("topbar_dropdown", nullptr, TOPBAR_ICON_SIZE);
     m_dropdown_menu_item = this->AddTool(ID_TOP_DROPDOWN_MENU, "",
         dropdown_bitmap, wxEmptyString);
 
-    this->AddSpacer(FromDIP(5));
+    this->AddDIPSpacer(5);
     this->AddSeparator();
-    this->AddSpacer(FromDIP(5));
+    this->AddDIPSpacer(5);
 
     //wxBitmap open_bitmap = create_scaled_bitmap("topbar_open", nullptr, TOPBAR_ICON_SIZE);
     //wxAuiToolBarItem* tool_item = this->AddTool(wxID_OPEN, "", open_bitmap);
 
-    this->AddSpacer(FromDIP(10));
+    this->AddDIPSpacer(10);
 
     wxBitmap save_bitmap = create_scaled_bitmap("topbar_save", nullptr, TOPBAR_ICON_SIZE);
     wxAuiToolBarItem* save_btn = this->AddTool(wxID_SAVE, "", save_bitmap);
 
-    this->AddSpacer(FromDIP(10));
+    this->AddDIPSpacer(10);
 
     wxBitmap undo_bitmap = create_scaled_bitmap("topbar_undo", nullptr, TOPBAR_ICON_SIZE);
     m_undo_item = this->AddTool(wxID_UNDO, "", undo_bitmap);
     wxBitmap undo_inactive_bitmap = create_scaled_bitmap("topbar_undo_inactive", nullptr, TOPBAR_ICON_SIZE);
     m_undo_item->SetDisabledBitmap(undo_inactive_bitmap);
 
-    this->AddSpacer(FromDIP(10));
+    this->AddDIPSpacer(10);
 
     wxBitmap redo_bitmap = create_scaled_bitmap("topbar_redo", nullptr, TOPBAR_ICON_SIZE);
     m_redo_item = this->AddTool(wxID_REDO, "", redo_bitmap);
     wxBitmap redo_inactive_bitmap = create_scaled_bitmap("topbar_redo_inactive", nullptr, TOPBAR_ICON_SIZE);
     m_redo_item->SetDisabledBitmap(redo_inactive_bitmap);
 
-    this->AddSpacer(FromDIP(10));
+    this->AddDIPSpacer(10);
 
     wxBitmap calib_bitmap          = create_scaled_bitmap("calib_sf", nullptr, TOPBAR_ICON_SIZE);
     wxBitmap calib_bitmap_inactive = create_scaled_bitmap("calib_sf_inactive", nullptr, TOPBAR_ICON_SIZE);
     m_calib_item                   = this->AddTool(ID_CALIB, _L("Calibration"), calib_bitmap);
     m_calib_item->SetDisabledBitmap(calib_bitmap_inactive);
 
-    this->AddSpacer(FromDIP(25));
+    this->AddDIPSpacer(25);
     //this->AddStretchSpacer(1);
 
     m_title_ctrl = new CenteredTitle(this);
@@ -324,7 +324,7 @@ void BBLTopbar::Init(wxFrame* parent)
     wxAuiToolBarItem* title_item = this->AddControl(m_title_ctrl, "");
     title_item->SetProportion(1); 
 
-    this->AddSpacer(FromDIP(25));
+    this->AddDIPSpacer(25);
     //this->AddStretchSpacer(1);
 
     //m_publish_bitmap = create_scaled_bitmap("topbar_publish", nullptr, TOPBAR_ICON_SIZE);
@@ -332,7 +332,7 @@ void BBLTopbar::Init(wxFrame* parent)
     //m_publish_disable_bitmap = create_scaled_bitmap("topbar_publish_disable", nullptr, TOPBAR_ICON_SIZE);
     //m_publish_item->SetDisabledBitmap(m_publish_disable_bitmap);
     //this->EnableTool(m_publish_item->GetId(), false);
-    //this->AddSpacer(FromDIP(4));
+    //this->AddDIPSpacer(4);
 
     /*wxBitmap model_store_bitmap = create_scaled_bitmap("topbar_store", nullptr, TOPBAR_ICON_SIZE);
     m_model_store_item = this->AddTool(ID_MODEL_STORE, "", model_store_bitmap);
@@ -340,13 +340,13 @@ void BBLTopbar::Init(wxFrame* parent)
     */
 
     //this->AddSeparator();
-    //this->AddSpacer(FromDIP(4));
+    //this->AddDIPSpacer(4);
 
     if(!window_btns_on_left){
     wxBitmap iconize_bitmap = create_scaled_bitmap("topbar_min", nullptr, TOPBAR_ICON_SIZE);
     wxAuiToolBarItem* iconize_btn = this->AddTool(wxID_ICONIZE_FRAME, "", iconize_bitmap);
 
-    this->AddSpacer(FromDIP(4));
+    this->AddDIPSpacer(4);
 
     maximize_bitmap = create_scaled_bitmap("topbar_max", nullptr, TOPBAR_ICON_SIZE);
     window_bitmap = create_scaled_bitmap("topbar_win", nullptr, TOPBAR_ICON_SIZE);
@@ -357,7 +357,7 @@ void BBLTopbar::Init(wxFrame* parent)
         maximize_btn = this->AddTool(wxID_MAXIMIZE_FRAME, "", maximize_bitmap);
     }
 
-    this->AddSpacer(FromDIP(4));
+    this->AddDIPSpacer(4);
 
     wxBitmap close_bitmap = create_scaled_bitmap("topbar_close", nullptr, TOPBAR_ICON_SIZE);
     wxAuiToolBarItem* close_btn = this->AddTool(wxID_CLOSE_FRAME, "", close_bitmap);
@@ -533,8 +533,21 @@ void BBLTopbar::UpdateToolbarWidth(int width)
     this->SetSize(width, m_toolbar_h);
 }
 
+void BBLTopbar::AddDIPSpacer(int dip)
+{
+    m_spacers.emplace_back(AddSpacer(FromDIP(dip)), dip);
+}
+
 void BBLTopbar::Rescale() {
-    int em = em_unit(this);
+    m_toolbar_h = FromDIP(30);
+    int client_w = GetParent()->GetClientSize().GetWidth();
+    SetMinSize({GetMinSize().GetWidth(), m_toolbar_h});
+    this->SetSize(client_w, m_toolbar_h);
+    // Update spacer size
+    for (auto spacer : m_spacers) {
+        spacer.first->SetSpacerPixels(FromDIP(spacer.second));
+    }
+
     wxAuiToolBarItem* item;
 
     /*item = this->FindTool(ID_LOGO);

--- a/src/slic3r/GUI/BBLTopbar.hpp
+++ b/src/slic3r/GUI/BBLTopbar.hpp
@@ -112,4 +112,7 @@ private:
     bool m_skip_popup_file_menu;
     bool m_skip_popup_dropdown_menu;
     bool m_skip_popup_calib_menu;
+
+    void AddDIPSpacer(int dip);
+    std::vector<std::pair<wxAuiToolBarItem*, int>> m_spacers;
 };

--- a/src/slic3r/GUI/CalibrationPanel.cpp
+++ b/src/slic3r/GUI/CalibrationPanel.cpp
@@ -685,6 +685,8 @@ void CalibrationPanel::set_default()
 
 void CalibrationPanel::msw_rescale()
 {
+    m_side_tools->msw_rescale();
+    m_tabpanel->Rescale();
     for (int i = 0; i < (int)CALI_MODE_COUNT; i++) {
         m_cali_panels[i]->msw_rescale();
     }

--- a/src/slic3r/GUI/CalibrationPanel.cpp
+++ b/src/slic3r/GUI/CalibrationPanel.cpp
@@ -685,8 +685,8 @@ void CalibrationPanel::set_default()
 
 void CalibrationPanel::msw_rescale()
 {
-    m_side_tools->msw_rescale();
-    m_tabpanel->Rescale();
+    m_side_tools->msw_rescale(); //ORCA
+    m_tabpanel->Rescale(); //ORCA
     for (int i = 0; i < (int)CALI_MODE_COUNT; i++) {
         m_cali_panels[i]->msw_rescale();
     }

--- a/src/slic3r/GUI/CapsuleButton.cpp
+++ b/src/slic3r/GUI/CapsuleButton.cpp
@@ -25,8 +25,8 @@ CapsuleButton::CapsuleButton(wxWindow *parent, wxWindowID id, const wxString &la
 
     auto sizer = new wxBoxSizer(wxHORIZONTAL);
 
-    tag_on_bmp = create_scaled_bitmap("capsule_tag_on", nullptr, FromDIP(16));
-    tag_off_bmp = create_scaled_bitmap("capsule_tag_off", nullptr, FromDIP(16));
+    tag_on_bmp  = create_scaled_bitmap("capsule_tag_on" , nullptr, 16); // ORCA dont scale px count already scaled inside create_scaled_bitmap
+    tag_off_bmp = create_scaled_bitmap("capsule_tag_off", nullptr, 16); // ORCA
 
     m_btn = new wxBitmapButton(this, wxID_ANY, selected?tag_on_bmp:tag_off_bmp, wxDefaultPosition, wxDefaultSize, wxNO_BORDER);
     m_btn->SetBackgroundColour(*wxWHITE);

--- a/src/slic3r/GUI/CreatePresetsDialog.cpp
+++ b/src/slic3r/GUI/CreatePresetsDialog.cpp
@@ -309,7 +309,7 @@ static wxBoxSizer* create_checkbox(wxWindow* parent, Preset* preset, wxString& p
     wxStaticText *preset_name_str = new wxStaticText(parent, wxID_ANY, preset_name);
     wxToolTip *   toolTip         = new wxToolTip(preset_name);
     preset_name_str->SetToolTip(toolTip);
-    sizer->Add(preset_name_str, 0, wxLEFT, 5);
+    sizer->Add(preset_name_str, 0, wxLEFT, parent->FromDIP(5));
     return sizer;
 }
 
@@ -320,7 +320,7 @@ static wxBoxSizer *create_checkbox(wxWindow *parent, std::string &compatible_pri
     sizer->Add(checkbox, 0, 0, 0);
     ptinter_compatible_filament_preset[checkbox] = std::make_pair(compatible_printer, preset);
     wxStaticText *preset_name_str = new wxStaticText(parent, wxID_ANY, wxString::FromUTF8(compatible_printer));
-    sizer->Add(preset_name_str, 0, wxLEFT, 5);
+    sizer->Add(preset_name_str, 0, wxLEFT, parent->FromDIP(5));
     return sizer;
 }
 
@@ -331,7 +331,7 @@ static wxBoxSizer *create_checkbox(wxWindow *parent, wxString &preset_name, std:
     sizer->Add(checkbox, 0, 0, 0);
     preset_checkbox.push_back(std::make_pair(checkbox, into_u8(preset_name)));
     wxStaticText *preset_name_str = new wxStaticText(parent, wxID_ANY, preset_name);
-    sizer->Add(preset_name_str, 0, wxLEFT, 5);
+    sizer->Add(preset_name_str, 0, wxLEFT, parent->FromDIP(5));
     return sizer;
 }
 
@@ -422,11 +422,11 @@ static wxBoxSizer *create_select_filament_preset_checkbox(wxWindow *            
     wxBoxSizer *horizontal_sizer = new wxBoxSizer(wxHORIZONTAL);
     wxBoxSizer *checkbox_sizer   = new wxBoxSizer(wxVERTICAL);
     ::CheckBox *checkbox         = new ::CheckBox(parent);
-    checkbox_sizer->Add(checkbox, 0, wxEXPAND | wxRIGHT, 5);
+    checkbox_sizer->Add(checkbox, 0, wxEXPAND | wxRIGHT, parent->FromDIP(5));
 
     wxBoxSizer *combobox_sizer = new wxBoxSizer(wxVERTICAL);
     wxStaticText *machine_name_str = new wxStaticText(parent, wxID_ANY, wxString::FromUTF8(compatible_printer));
-    ComboBox *    combobox        = new ComboBox(parent, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize(200, 24), 0, nullptr, wxCB_READONLY);
+    ComboBox *    combobox        = new ComboBox(parent, wxID_ANY, wxEmptyString, wxDefaultPosition, parent->FromDIP(wxSize(200, 24)), 0, nullptr, wxCB_READONLY);
     combobox->SetBackgroundColor(PRINTER_LIST_COLOUR);
     combobox->SetBorderColor(*wxWHITE);
     combobox->SetLabel(_L("Select filament preset"));
@@ -442,7 +442,7 @@ static wxBoxSizer *create_select_filament_preset_checkbox(wxWindow *            
         e.Skip();
     });
     combobox_sizer->Add(machine_name_str, 0, wxEXPAND, 0);
-    combobox_sizer->Add(combobox, 0, wxEXPAND | wxTOP, 5);
+    combobox_sizer->Add(combobox, 0, wxEXPAND | wxTOP, parent->FromDIP(5));
 
     wxArrayString choices;
     for (Preset *preset : presets) {
@@ -687,12 +687,12 @@ CreateFilamentPresetDialog::CreateFilamentPresetDialog(wxWindow *parent)
 
     wxStaticText *presets_information = new wxStaticText(this, wxID_ANY, _L("Add Filament Preset under this filament"));
     presets_information->SetFont(Label::Head_16);
-    m_main_sizer->Add(presets_information, 0, wxLEFT | wxRIGHT, FromDIP(15));
+    m_main_sizer->Add(presets_information, 0, wxLEFT | wxRIGHT, FromDIP(10));
 
     m_main_sizer->Add(create_item(FilamentOptionType::FILAMENT_PRESET), 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, FromDIP(5));
 
     m_filament_preset_text = new wxStaticText(this, wxID_ANY, _L("We could create the filament presets for your following printer:"), wxDefaultPosition, wxDefaultSize);
-    m_main_sizer->Add(m_filament_preset_text, 0, wxEXPAND | wxLEFT | wxRIGHT, FromDIP(15));
+    m_main_sizer->Add(m_filament_preset_text, 0, wxEXPAND | wxLEFT | wxRIGHT, FromDIP(10));
 
     m_scrolled_preset_panel = new wxScrolledWindow(this, wxID_ANY);
     m_scrolled_preset_panel->SetMaxSize(wxSize(-1, FromDIP(350)));
@@ -733,7 +733,34 @@ CreateFilamentPresetDialog::~CreateFilamentPresetDialog()
 }
 
 void CreateFilamentPresetDialog::on_dpi_changed(const wxRect &suggested_rect) {
+
+    std::function<void(wxWindow*, int)> WalkControls;
+    WalkControls = [&](wxWindow* parent, int depth) -> void {
+        if (!parent) return;
+
+        for (auto* child : parent->GetChildren()) {
+            if (!child)
+                continue;
+            else if (auto* btn = dynamic_cast<Button*>(child))
+                btn->Rescale();
+            else if (auto* chk = dynamic_cast<CheckBox*>(child))
+                chk->msw_rescale();
+            else if (auto* txt = dynamic_cast<TextInput*>(child))
+                txt->Rescale();
+            else if (auto* cmb = dynamic_cast<ComboBox*>(child))
+                cmb->Rescale();
+            else if (auto* spn = dynamic_cast<SpinInput*>(child))
+                spn->Rescale();
+            else if (auto* rbx = dynamic_cast<RadioBox*>(child))
+                rbx->Rescale();
+            WalkControls(child, depth + 1);
+        }
+    };
+    WalkControls(this, 0);
+
     Layout();
+    Fit();
+    Refresh();
 }
 
 bool CreateFilamentPresetDialog::is_check_box_selected()
@@ -767,9 +794,8 @@ wxBoxSizer *CreateFilamentPresetDialog::create_vendor_item()
     wxBoxSizer *horizontal_sizer = new wxBoxSizer(wxHORIZONTAL);
 
     wxBoxSizer *  optionSizer = new wxBoxSizer(wxVERTICAL);
-    wxStaticText *static_vendor_text = new wxStaticText(this, wxID_ANY, _L("Vendor"), wxDefaultPosition, wxDefaultSize);
+    wxStaticText *static_vendor_text = new wxStaticText(this, wxID_ANY, _L("Vendor"), wxDefaultPosition, OPTION_SIZE); // create with scaled size so wxWidgets handles scaled size
     optionSizer->Add(static_vendor_text, 0, wxEXPAND | wxALL, 0);
-    optionSizer->SetMinSize(OPTION_SIZE);
     horizontal_sizer->Add(optionSizer, 0, wxEXPAND | wxALL, FromDIP(5));
 
     // Convert all std::any to std::string
@@ -859,9 +885,8 @@ wxBoxSizer *CreateFilamentPresetDialog::create_type_item()
     wxBoxSizer *horizontal_sizer = new wxBoxSizer(wxHORIZONTAL);
 
     wxBoxSizer *  optionSizer        = new wxBoxSizer(wxVERTICAL);
-    wxStaticText *static_type_text = new wxStaticText(this, wxID_ANY, _L("Type"), wxDefaultPosition, wxDefaultSize);
+    wxStaticText *static_type_text = new wxStaticText(this, wxID_ANY, _L("Type"), wxDefaultPosition, OPTION_SIZE); // create with scaled size so wxWidgets handles scaled size
     optionSizer->Add(static_type_text, 0, wxEXPAND | wxALL, 0);
-    optionSizer->SetMinSize(OPTION_SIZE);
     horizontal_sizer->Add(optionSizer, 0, wxEXPAND | wxALL, FromDIP(5));
 
     wxArrayString filament_type;
@@ -905,9 +930,8 @@ wxBoxSizer *CreateFilamentPresetDialog::create_serial_item()
     wxBoxSizer *horizontal_sizer = new wxBoxSizer(wxHORIZONTAL);
 
     wxBoxSizer *  optionSizer        = new wxBoxSizer(wxVERTICAL);
-    wxStaticText *static_serial_text = new wxStaticText(this, wxID_ANY, _L("Serial"), wxDefaultPosition, wxDefaultSize);
+    wxStaticText *static_serial_text = new wxStaticText(this, wxID_ANY, _L("Serial"), wxDefaultPosition, OPTION_SIZE); // create with scaled size so wxWidgets handles scaled size
     optionSizer->Add(static_serial_text, 0, wxEXPAND | wxALL, 0);
-    optionSizer->SetMinSize(OPTION_SIZE);
     horizontal_sizer->Add(optionSizer, 0, wxEXPAND | wxALL, FromDIP(5));
 
     wxBoxSizer *comboBoxSizer = new wxBoxSizer(wxVERTICAL);
@@ -937,10 +961,9 @@ wxBoxSizer *CreateFilamentPresetDialog::create_filament_preset_item()
     wxBoxSizer *horizontal_sizer = new wxBoxSizer(wxHORIZONTAL);
 
     wxBoxSizer *  optionSizer        = new wxBoxSizer(wxVERTICAL);
-    wxStaticText *static_filament_preset_text = new wxStaticText(this, wxID_ANY, _L("Filament Preset"), wxDefaultPosition, wxDefaultSize);
+    wxStaticText *static_filament_preset_text = new wxStaticText(this, wxID_ANY, _L("Filament Preset"), wxDefaultPosition, OPTION_SIZE); // create with scaled size so wxWidgets handles scaled size
     optionSizer->Add(static_filament_preset_text, 0, wxEXPAND | wxALL, 0);
-    optionSizer->SetMinSize(OPTION_SIZE);
-    horizontal_sizer->Add(optionSizer, 0, wxEXPAND | wxALL, FromDIP(10));
+    horizontal_sizer->Add(optionSizer, 0, wxEXPAND | wxALL, FromDIP(5));
 
     wxBoxSizer *  comboBoxSizer  = new wxBoxSizer(wxVERTICAL);
     comboBoxSizer->Add(create_radio_item(m_create_type.base_filament, this, wxEmptyString, m_create_type_btns), 0, wxEXPAND | wxALL, 0);
@@ -1015,9 +1038,7 @@ wxBoxSizer *CreateFilamentPresetDialog::create_filament_preset_item()
 
     comboBoxSizer->Add(create_radio_item(m_create_type.base_filament_preset, this, wxEmptyString, m_create_type_btns), 0, wxEXPAND | wxTOP, FromDIP(10));
 
-    horizontal_sizer->Add(comboBoxSizer, 0, wxEXPAND | wxALL, FromDIP(10));
-
-    horizontal_sizer->Add(0, 0, 0, wxLEFT, FromDIP(30));
+    horizontal_sizer->Add(comboBoxSizer, 0, wxEXPAND | wxALL, FromDIP(5));
 
     return horizontal_sizer;
 
@@ -1629,7 +1650,35 @@ CreatePrinterPresetDialog::~CreatePrinterPresetDialog()
 }
 
 void CreatePrinterPresetDialog::on_dpi_changed(const wxRect &suggested_rect) {
-    Layout();
+    std::function<void(wxWindow*, int)> WalkControls;
+    WalkControls = [&](wxWindow* parent, int depth) -> void {
+        if (!parent) return;
+
+        for (auto* child : parent->GetChildren()) {
+            if (!child)
+                continue;
+            else if (auto* btn = dynamic_cast<Button*>(child))
+                btn->Rescale();
+            else if (auto* chk = dynamic_cast<CheckBox*>(child))
+                chk->msw_rescale();
+            else if (auto* txt = dynamic_cast<TextInput*>(child))
+                txt->Rescale();
+            else if (auto* cmb = dynamic_cast<ComboBox*>(child))
+                cmb->Rescale();
+            else if (auto* spn = dynamic_cast<SpinInput*>(child))
+                spn->Rescale();
+            else if (auto* rbx = dynamic_cast<RadioBox*>(child))
+                rbx->Rescale();
+            WalkControls(child, depth + 1);
+        }
+    };
+    WalkControls(this, 0);
+
+    // rebuild step icons and call Layout
+    if(m_page1->IsShown())
+        show_page1();
+    if(m_page2->IsShown())
+        show_page2();
 }
 
 wxBoxSizer *CreatePrinterPresetDialog::create_step_switch_item()
@@ -1702,9 +1751,8 @@ wxBoxSizer *CreatePrinterPresetDialog::create_type_item(wxWindow *parent)
     wxBoxSizer *horizontal_sizer = new wxBoxSizer(wxHORIZONTAL);
 
     wxBoxSizer *  optionSizer        = new wxBoxSizer(wxVERTICAL);
-    wxStaticText *static_serial_text = new wxStaticText(parent, wxID_ANY, _L("Create Type"), wxDefaultPosition, wxDefaultSize);
+    wxStaticText *static_serial_text = new wxStaticText(parent, wxID_ANY, _L("Create Type"), wxDefaultPosition, OPTION_SIZE); // create with scaled size so wxWidgets handles scaled size
     optionSizer->Add(static_serial_text, 0, wxEXPAND | wxALL, 0);
-    optionSizer->SetMinSize(OPTION_SIZE);
     horizontal_sizer->Add(optionSizer, 0, wxEXPAND | wxALL, FromDIP(10));
 
     wxBoxSizer *radioBoxSizer = new wxBoxSizer(wxVERTICAL);
@@ -1721,9 +1769,8 @@ wxBoxSizer *CreatePrinterPresetDialog::create_printer_item(wxWindow *parent)
     wxBoxSizer *horizontal_sizer = new wxBoxSizer(wxHORIZONTAL);
 
     wxBoxSizer *  optionSizer        = new wxBoxSizer(wxVERTICAL);
-    wxStaticText *static_vendor_text = new wxStaticText(parent, wxID_ANY, _L("Printer"), wxDefaultPosition, wxDefaultSize);
+    wxStaticText *static_vendor_text = new wxStaticText(parent, wxID_ANY, _L("Printer"), wxDefaultPosition, OPTION_SIZE); // create with scaled size so wxWidgets handles scaled size
     optionSizer->Add(static_vendor_text, 0, wxEXPAND | wxALL, 0);
-    optionSizer->SetMinSize(OPTION_SIZE);
     horizontal_sizer->Add(optionSizer, 0, wxEXPAND | wxALL, FromDIP(10));
 
     wxBoxSizer *vertical_sizer = new wxBoxSizer(wxVERTICAL);
@@ -1863,9 +1910,8 @@ wxBoxSizer *CreatePrinterPresetDialog::create_nozzle_diameter_item(wxWindow *par
     wxBoxSizer *horizontal_sizer = new wxBoxSizer(wxHORIZONTAL);
 
     wxBoxSizer *  optionSizer      = new wxBoxSizer(wxVERTICAL);
-    wxStaticText *static_type_text = new wxStaticText(parent, wxID_ANY, _L("Nozzle Diameter"), wxDefaultPosition, wxDefaultSize);
+    wxStaticText *static_type_text = new wxStaticText(parent, wxID_ANY, _L("Nozzle Diameter"), wxDefaultPosition, OPTION_SIZE); // create with scaled size so wxWidgets handles scaled size
     optionSizer->Add(static_type_text, 0, wxEXPAND | wxALL, 0);
-    optionSizer->SetMinSize(OPTION_SIZE);
     horizontal_sizer->Add(optionSizer, 0, wxEXPAND | wxALL, FromDIP(10));
 
     wxBoxSizer *vertical_sizer = new wxBoxSizer(wxVERTICAL);
@@ -1942,9 +1988,8 @@ wxBoxSizer *CreatePrinterPresetDialog::create_bed_shape_item(wxWindow *parent)
     wxBoxSizer *horizontal_sizer = new wxBoxSizer(wxHORIZONTAL);
 
     wxBoxSizer *  optionSizer      = new wxBoxSizer(wxVERTICAL);
-    wxStaticText *static_type_text = new wxStaticText(parent, wxID_ANY, _L("Bed Shape"), wxDefaultPosition, wxDefaultSize);
+    wxStaticText *static_type_text = new wxStaticText(parent, wxID_ANY, _L("Bed Shape"), wxDefaultPosition, OPTION_SIZE); // create with scaled size so wxWidgets handles scaled size
     optionSizer->Add(static_type_text, 0, wxEXPAND | wxALL, 0);
-    optionSizer->SetMinSize(OPTION_SIZE);
     horizontal_sizer->Add(optionSizer, 0, wxEXPAND | wxALL, FromDIP(10));
 
     wxBoxSizer *  bed_shape_sizer       = new wxBoxSizer(wxVERTICAL);
@@ -1960,9 +2005,8 @@ wxBoxSizer *CreatePrinterPresetDialog::create_bed_size_item(wxWindow *parent)
     wxBoxSizer *horizontal_sizer = new wxBoxSizer(wxHORIZONTAL);
 
     wxBoxSizer *  optionSizer      = new wxBoxSizer(wxVERTICAL);
-    wxStaticText *static_type_text = new wxStaticText(parent, wxID_ANY, _L("Printable Space"), wxDefaultPosition, wxDefaultSize);
+    wxStaticText *static_type_text = new wxStaticText(parent, wxID_ANY, _L("Printable Space"), wxDefaultPosition, OPTION_SIZE); // create with scaled size so wxWidgets handles scaled size
     optionSizer->Add(static_type_text, 0, wxEXPAND | wxALL, 0);
-    optionSizer->SetMinSize(OPTION_SIZE);
     horizontal_sizer->Add(optionSizer, 0, wxEXPAND | wxALL, FromDIP(10));
 
     wxBoxSizer *  length_sizer          = new wxBoxSizer(wxVERTICAL);
@@ -1993,9 +2037,8 @@ wxBoxSizer *CreatePrinterPresetDialog::create_origin_item(wxWindow *parent)
     wxBoxSizer *horizontal_sizer = new wxBoxSizer(wxHORIZONTAL);
 
     wxBoxSizer *  optionSizer      = new wxBoxSizer(wxVERTICAL);
-    wxStaticText *static_type_text = new wxStaticText(parent, wxID_ANY, _L("Origin"), wxDefaultPosition, wxDefaultSize);
+    wxStaticText *static_type_text = new wxStaticText(parent, wxID_ANY, _L("Origin"), wxDefaultPosition, OPTION_SIZE); // create with scaled size so wxWidgets handles scaled size
     optionSizer->Add(static_type_text, 0, wxEXPAND | wxALL, 0);
-    optionSizer->SetMinSize(OPTION_SIZE);
     horizontal_sizer->Add(optionSizer, 0, wxEXPAND | wxALL, FromDIP(10));
 
     wxBoxSizer *  length_sizer       = new wxBoxSizer(wxVERTICAL);
@@ -2025,9 +2068,8 @@ wxBoxSizer *CreatePrinterPresetDialog::create_hot_bed_stl_item(wxWindow *parent)
     wxBoxSizer *horizontal_sizer = new wxBoxSizer(wxHORIZONTAL);
 
     wxBoxSizer *  optionSizer      = new wxBoxSizer(wxVERTICAL);
-    wxStaticText *static_type_text = new wxStaticText(parent, wxID_ANY, _L("Hot Bed STL"), wxDefaultPosition, wxDefaultSize);
+    wxStaticText *static_type_text = new wxStaticText(parent, wxID_ANY, _L("Hot Bed STL"), wxDefaultPosition, OPTION_SIZE); // create with scaled size so wxWidgets handles scaled size
     optionSizer->Add(static_type_text, 0, wxEXPAND | wxALL, 0);
-    optionSizer->SetMinSize(OPTION_SIZE);
     horizontal_sizer->Add(optionSizer, 0, wxEXPAND | wxALL, FromDIP(10));
 
     wxBoxSizer *hot_bed_stl_sizer = new wxBoxSizer(wxVERTICAL);
@@ -2051,9 +2093,8 @@ wxBoxSizer *CreatePrinterPresetDialog::create_hot_bed_svg_item(wxWindow *parent)
     wxBoxSizer *horizontal_sizer = new wxBoxSizer(wxHORIZONTAL);
 
     wxBoxSizer *  optionSizer      = new wxBoxSizer(wxVERTICAL);
-    wxStaticText *static_type_text = new wxStaticText(parent, wxID_ANY, _L("Hot Bed SVG"), wxDefaultPosition, wxDefaultSize);
+    wxStaticText *static_type_text = new wxStaticText(parent, wxID_ANY, _L("Hot Bed SVG"), wxDefaultPosition, OPTION_SIZE); // create with scaled size so wxWidgets handles scaled size
     optionSizer->Add(static_type_text, 0, wxEXPAND | wxALL, 0);
-    optionSizer->SetMinSize(OPTION_SIZE);
     horizontal_sizer->Add(optionSizer, 0, wxEXPAND | wxALL, FromDIP(10));
 
     wxBoxSizer *hot_bed_stl_sizer = new wxBoxSizer(wxVERTICAL);
@@ -2077,9 +2118,8 @@ wxBoxSizer *CreatePrinterPresetDialog::create_max_print_height_item(wxWindow *pa
     wxBoxSizer *  horizontal_sizer  = new wxBoxSizer(wxHORIZONTAL);
 
     wxBoxSizer *  optionSizer      = new wxBoxSizer(wxVERTICAL);
-    wxStaticText *static_type_text = new wxStaticText(parent, wxID_ANY, _L("Max Print Height"), wxDefaultPosition, wxDefaultSize);
+    wxStaticText *static_type_text = new wxStaticText(parent, wxID_ANY, _L("Max Print Height"), wxDefaultPosition, OPTION_SIZE); // create with scaled size so wxWidgets handles scaled size
     optionSizer->Add(static_type_text, 0, wxEXPAND | wxALL, 0);
-    optionSizer->SetMinSize(OPTION_SIZE);
     horizontal_sizer->Add(optionSizer, 0, wxEXPAND | wxALL, FromDIP(10));
 
     wxBoxSizer *hight_input_sizer = new wxBoxSizer(wxVERTICAL);
@@ -2595,9 +2635,8 @@ wxBoxSizer *CreatePrinterPresetDialog::create_printer_preset_item(wxWindow *pare
     wxBoxSizer *horizontal_sizer = new wxBoxSizer(wxHORIZONTAL);
 
     wxBoxSizer *  optionSizer        = new wxBoxSizer(wxVERTICAL);
-    wxStaticText *static_vendor_text = new wxStaticText(parent, wxID_ANY, _L("Printer Preset"), wxDefaultPosition, wxDefaultSize);
+    wxStaticText *static_vendor_text = new wxStaticText(parent, wxID_ANY, _L("Printer Preset"), wxDefaultPosition, OPTION_SIZE); // create with scaled size so wxWidgets handles scaled size
     optionSizer->Add(static_vendor_text, 0, wxEXPAND | wxALL, 0);
-    optionSizer->SetMinSize(OPTION_SIZE);
     horizontal_sizer->Add(optionSizer, 0, wxEXPAND | wxALL, FromDIP(10));
 
     wxBoxSizer *  vertical_sizer = new wxBoxSizer(wxVERTICAL);
@@ -2642,9 +2681,8 @@ wxBoxSizer *CreatePrinterPresetDialog::create_presets_item(wxWindow *parent)
     wxBoxSizer *horizontal_sizer = new wxBoxSizer(wxHORIZONTAL);
 
     wxBoxSizer *  optionSizer        = new wxBoxSizer(wxVERTICAL);
-    wxStaticText *static_serial_text = new wxStaticText(parent, wxID_ANY, _L("Presets"), wxDefaultPosition, wxDefaultSize);
+    wxStaticText *static_serial_text = new wxStaticText(parent, wxID_ANY, _L("Presets"), wxDefaultPosition, OPTION_SIZE); // create with scaled size so wxWidgets handles scaled size
     optionSizer->Add(static_serial_text, 0, wxEXPAND | wxALL, 0);
-    optionSizer->SetMinSize(OPTION_SIZE);
     horizontal_sizer->Add(optionSizer, 0, wxEXPAND | wxALL, FromDIP(10));
 
     wxBoxSizer *radioBoxSizer = new wxBoxSizer(wxVERTICAL);
@@ -2959,8 +2997,8 @@ wxWindow *CreatePrinterPresetDialog::create_page2_dialog_buttons(wxWindow *paren
 
 void CreatePrinterPresetDialog::show_page1()
 {
-    m_step_1->SetBitmap(create_scaled_bitmap("step_1", nullptr, FromDIP(20)));
-    m_step_2->SetBitmap(create_scaled_bitmap("step_2_ready", nullptr, FromDIP(20)));
+    m_step_1->SetBitmap(create_scaled_bitmap("step_1", nullptr, 20)); // ORCA value already scales inside create_scaled_bitmap
+    m_step_2->SetBitmap(create_scaled_bitmap("step_2_ready", nullptr, 20));
     m_page1->Show();
     m_page2->Hide();
     Refresh();
@@ -2970,8 +3008,8 @@ void CreatePrinterPresetDialog::show_page1()
 
 void CreatePrinterPresetDialog::show_page2()
 {
-    m_step_1->SetBitmap(create_scaled_bitmap("step_is_ok", nullptr, FromDIP(20)));
-    m_step_2->SetBitmap(create_scaled_bitmap("step_2", nullptr, FromDIP(20)));
+    m_step_1->SetBitmap(create_scaled_bitmap("step_is_ok", nullptr, 20)); // ORCA value already scales inside create_scaled_bitmap
+    m_step_2->SetBitmap(create_scaled_bitmap("step_2", nullptr, 20));
     m_page2->Show();
     m_page1->Hide();
     Refresh();
@@ -3607,7 +3645,33 @@ ExportConfigsDialog::~ExportConfigsDialog()
 }
 
 void ExportConfigsDialog::on_dpi_changed(const wxRect &suggested_rect) {
+    std::function<void(wxWindow*, int)> WalkControls;
+    WalkControls = [&](wxWindow* parent, int depth) -> void {
+        if (!parent) return;
+
+        for (auto* child : parent->GetChildren()) {
+            if (!child)
+                continue;
+            else if (auto* btn = dynamic_cast<Button*>(child))
+                btn->Rescale();
+            else if (auto* chk = dynamic_cast<CheckBox*>(child))
+                chk->msw_rescale();
+            else if (auto* txt = dynamic_cast<TextInput*>(child))
+                txt->Rescale();
+            else if (auto* cmb = dynamic_cast<ComboBox*>(child))
+                cmb->Rescale();
+            else if (auto* spn = dynamic_cast<SpinInput*>(child))
+                spn->Rescale();
+            else if (auto* rbx = dynamic_cast<RadioBox*>(child))
+                rbx->Rescale();
+            WalkControls(child, depth + 1);
+        }
+    };
+    WalkControls(this, 0);
+
     Layout();
+    Fit();
+    Refresh();
 }
 
 void ExportConfigsDialog::show_export_result(const ExportCase &export_case)
@@ -3738,9 +3802,8 @@ wxBoxSizer *ExportConfigsDialog::create_export_config_item(wxWindow *parent)
     wxBoxSizer *horizontal_sizer = new wxBoxSizer(wxHORIZONTAL);
 
     wxBoxSizer *  optionSizer        = new wxBoxSizer(wxVERTICAL);
-    wxStaticText *static_serial_text = new wxStaticText(parent, wxID_ANY, _L("Presets"), wxDefaultPosition, wxDefaultSize);
+    wxStaticText *static_serial_text = new wxStaticText(parent, wxID_ANY, _L("Presets"), wxDefaultPosition, OPTION_SIZE); // create with scaled size so wxWidgets handles scaled size
     optionSizer->Add(static_serial_text, 0, wxEXPAND | wxALL, 0);
-    optionSizer->SetMinSize(OPTION_SIZE);
     horizontal_sizer->Add(optionSizer, 0, wxEXPAND | wxALL, FromDIP(10));
 
     wxBoxSizer *radioBoxSizer = new wxBoxSizer(wxVERTICAL);
@@ -4487,7 +4550,34 @@ EditFilamentPresetDialog::EditFilamentPresetDialog(wxWindow *parent, Filamentinf
 EditFilamentPresetDialog::~EditFilamentPresetDialog() {}
 
 void EditFilamentPresetDialog::on_dpi_changed(const wxRect &suggested_rect) {
+
+    std::function<void(wxWindow*, int)> WalkControls;
+    WalkControls = [&](wxWindow* parent, int depth) -> void {
+        if (!parent) return;
+
+        for (auto* child : parent->GetChildren()) {
+            if (!child)
+                continue;
+            else if (auto* btn = dynamic_cast<Button*>(child))
+                btn->Rescale();
+            else if (auto* chk = dynamic_cast<CheckBox*>(child))
+                chk->msw_rescale();
+            else if (auto* txt = dynamic_cast<TextInput*>(child))
+                txt->Rescale();
+            else if (auto* cmb = dynamic_cast<ComboBox*>(child))
+                cmb->Rescale();
+            else if (auto* spn = dynamic_cast<SpinInput*>(child))
+                spn->Rescale();
+            else if (auto* rbx = dynamic_cast<RadioBox*>(child))
+                rbx->Rescale();
+            WalkControls(child, depth + 1);
+        }
+    };
+    WalkControls(this, 0);
+
     Layout();
+    Fit();
+    Refresh();
 }
 
 bool EditFilamentPresetDialog::get_same_filament_id_presets(std::string filament_id)
@@ -4672,9 +4762,8 @@ wxBoxSizer *EditFilamentPresetDialog::create_filament_basic_info()
 
     //vendor
     wxBoxSizer *  vendor_key_sizer        = new wxBoxSizer(wxVERTICAL);
-    wxStaticText *static_vendor_text = new wxStaticText(this, wxID_ANY, _L("Vendor"), wxDefaultPosition, wxDefaultSize);
+    wxStaticText *static_vendor_text = new wxStaticText(this, wxID_ANY, _L("Vendor"), wxDefaultPosition, OPTION_SIZE); // create with scaled size so wxWidgets handles scaled size
     vendor_key_sizer->Add(static_vendor_text, 0, wxEXPAND | wxALL, 0);
-    vendor_key_sizer->SetMinSize(OPTION_SIZE);
     vendor_sizer->Add(vendor_key_sizer, 0, wxEXPAND | wxLEFT | wxBOTTOM, FromDIP(10));
 
     wxBoxSizer *vendor_value_sizer = new wxBoxSizer(wxVERTICAL);
@@ -4684,9 +4773,8 @@ wxBoxSizer *EditFilamentPresetDialog::create_filament_basic_info()
 
     //type
     wxBoxSizer *  type_key_sizer   = new wxBoxSizer(wxVERTICAL);
-    wxStaticText *static_type_text = new wxStaticText(this, wxID_ANY, _L("Type"), wxDefaultPosition, wxDefaultSize);
+    wxStaticText *static_type_text = new wxStaticText(this, wxID_ANY, _L("Type"), wxDefaultPosition, OPTION_SIZE); // create with scaled size so wxWidgets handles scaled size
     type_key_sizer->Add(static_type_text, 0, wxEXPAND | wxALL, 0);
-    type_key_sizer->SetMinSize(OPTION_SIZE);
     type_sizer->Add(type_key_sizer, 0, wxEXPAND | wxLEFT | wxBOTTOM, FromDIP(10));
 
     wxBoxSizer *  type_value_sizer = new wxBoxSizer(wxVERTICAL);
@@ -4696,9 +4784,8 @@ wxBoxSizer *EditFilamentPresetDialog::create_filament_basic_info()
 
     //serial
     wxBoxSizer *  serial_key_sizer   = new wxBoxSizer(wxVERTICAL);
-    wxStaticText *static_serial_text = new wxStaticText(this, wxID_ANY, _L("Serial"), wxDefaultPosition, wxDefaultSize);
+    wxStaticText *static_serial_text = new wxStaticText(this, wxID_ANY, _L("Serial"), wxDefaultPosition, OPTION_SIZE); // create with scaled size so wxWidgets handles scaled size
     serial_key_sizer->Add(static_serial_text, 0, wxEXPAND | wxALL, 0);
-    serial_key_sizer->SetMinSize(OPTION_SIZE);
     serial_sizer->Add(serial_key_sizer, 0, wxEXPAND | wxLEFT | wxBOTTOM, FromDIP(10));
 
     wxBoxSizer *  serial_value_sizer = new wxBoxSizer(wxVERTICAL);
@@ -4848,7 +4935,34 @@ CreatePresetForPrinterDialog::CreatePresetForPrinterDialog(wxWindow *parent, std
 CreatePresetForPrinterDialog::~CreatePresetForPrinterDialog() {}
 
 void CreatePresetForPrinterDialog::on_dpi_changed(const wxRect &suggested_rect) {
+
+    std::function<void(wxWindow*, int)> WalkControls;
+    WalkControls = [&](wxWindow* parent, int depth) -> void {
+        if (!parent) return;
+
+        for (auto* child : parent->GetChildren()) {
+            if (!child)
+                continue;
+            else if (auto* btn = dynamic_cast<Button*>(child))
+                btn->Rescale();
+            else if (auto* chk = dynamic_cast<CheckBox*>(child))
+                chk->msw_rescale();
+            else if (auto* txt = dynamic_cast<TextInput*>(child))
+                txt->Rescale();
+            else if (auto* cmb = dynamic_cast<ComboBox*>(child))
+                cmb->Rescale();
+            else if (auto* spn = dynamic_cast<SpinInput*>(child))
+                spn->Rescale();
+            else if (auto* rbx = dynamic_cast<RadioBox*>(child))
+                rbx->Rescale();
+            WalkControls(child, depth + 1);
+        }
+    };
+    WalkControls(this, 0);
+
     Layout();
+    Fit();
+    Refresh();
 }
 
 void CreatePresetForPrinterDialog::get_visible_printer_and_compatible_filament_presets()

--- a/src/slic3r/GUI/DeviceTab/wgtDeviceNozzleRackUpdate.cpp
+++ b/src/slic3r/GUI/DeviceTab/wgtDeviceNozzleRackUpdate.cpp
@@ -688,6 +688,8 @@ void wgtDeviceNozzleRackHotendUpdate::UpdateInfo(const DevNozzle& nozzle)
 
 void wgtDeviceNozzleRackHotendUpdate::Rescale()
 {
+    StaticBox::Rescale();
+
     // update images
     if (m_nozzle_image) { m_nozzle_image->msw_rescale(); }
     if (m_nozzle_empty_image) { m_nozzle_empty_image->msw_rescale(); }

--- a/src/slic3r/GUI/DeviceTab/wgtDeviceNozzleRackUpdate.h
+++ b/src/slic3r/GUI/DeviceTab/wgtDeviceNozzleRackUpdate.h
@@ -97,7 +97,7 @@ public:
     void UpdateRackNozzleInfo(const std::shared_ptr<DevNozzleRack> rack);
 
     // gui
-    void Rescale();
+    void Rescale() override;
 
 private:
     void CreateGui();

--- a/src/slic3r/GUI/DragCanvas.cpp
+++ b/src/slic3r/GUI/DragCanvas.cpp
@@ -14,6 +14,7 @@ DragCanvas::DragCanvas(wxWindow* parent, const std::vector<std::string>& colors,
     : wxPanel(parent, wxID_ANY, wxDefaultPosition, wxDefaultSize)
     , m_drag_mode(DragMode::NONE)
     , m_max_shape_pos(wxPoint(0, 0))
+    , m_colors(colors)
 {
     SetBackgroundColour(*wxWHITE);
 
@@ -122,7 +123,10 @@ void DragCanvas::on_paint(wxPaintEvent& event)
             arrow_pos.x = m_max_shape_pos.x;
             arrow_pos.y -= LINE_HEIGHT;
         }
-        arrow_pos += wxSize((SHAPE_GAP - SHAPE_SIZE - m_arrow_bmp.GetWidth() / dc.GetContentScaleFactor()) / 2, (SHAPE_SIZE - m_arrow_bmp.GetHeight() / dc.GetContentScaleFactor()) / 2);
+        arrow_pos += wxSize(
+            (SHAPE_GAP - SHAPE_SIZE - m_arrow_bmp.GetWidth()) / 2,
+            (SHAPE_SIZE - m_arrow_bmp.GetHeight()) / 2
+        );
         dc.DrawBitmap(m_arrow_bmp, arrow_pos);
     }
 }
@@ -214,6 +218,16 @@ void DragCanvas::on_mouse(wxMouseEvent& event)
         Refresh();
         Update();
     }
+}
+
+void DragCanvas::Rescale()
+{
+    m_arrow_bmp = create_scaled_bitmap("plate_settings_arrow", this, 16);
+
+    auto order = get_shape_list_order();
+    set_shape_list(m_colors, order);
+
+    Refresh();
 }
 
 DragShape* DragCanvas::find_shape(const wxPoint& pt) const

--- a/src/slic3r/GUI/DragCanvas.hpp
+++ b/src/slic3r/GUI/DragCanvas.hpp
@@ -43,6 +43,8 @@ public:
     std::vector<int> get_shape_list_order();
     std::vector<DragShape*> get_ordered_shape_list();
 
+    void Rescale();
+
 protected:
     void on_paint(wxPaintEvent& event);
     void on_erase(wxEraseEvent& event);
@@ -60,6 +62,7 @@ private:
     wxPoint                    m_max_shape_pos;
     wxColour                   m_background_color; // ORCA
     wxColour                   m_border_color; // ORCA
+    std::vector<std::string>   m_colors;
 };
 
 

--- a/src/slic3r/GUI/Field.cpp
+++ b/src/slic3r/GUI/Field.cpp
@@ -2878,6 +2878,9 @@ void PointCtrl::msw_rescale()
         x_input->SetMinSize(field_size);
         y_input->SetMinSize(field_size);
     }
+
+    x_input->Rescale(); // for icons
+    y_input->Rescale();
 }
 
 void PointCtrl::sys_color_changed()

--- a/src/slic3r/GUI/Field.cpp
+++ b/src/slic3r/GUI/Field.cpp
@@ -1163,6 +1163,9 @@ void CheckBox::BUILD() {
 	if (!wxOSX) temp->SetBackgroundStyle(wxBG_STYLE_PAINT);
 	//temp->SetBackgroundColour(*wxWHITE);
 	temp->SetValue(check_value);
+    // Ensure reused widget has the correct scaling
+    // TODO: only call this if scaling changed? Then we need to store the old em_unit/scale somewhere in the widget
+    temp->Rescale();
 
 	temp->Bind(wxEVT_TOGGLEBUTTON, ([this](wxCommandEvent & e) {
         m_is_na_val = false;

--- a/src/slic3r/GUI/FilamentMapDialog.cpp
+++ b/src/slic3r/GUI/FilamentMapDialog.cpp
@@ -209,7 +209,7 @@ FilamentMapDialog::FilamentMapDialog(wxWindow                       *parent,
                                      bool                            machine_synced,
                                      bool                            show_default,
                                      bool                            with_checkbox)
-    : wxDialog(parent, wxID_ANY, _L("Filament grouping"), wxDefaultPosition, wxDefaultSize,wxDEFAULT_DIALOG_STYLE)
+    : DPIDialog(parent, wxID_ANY, _L("Filament grouping"), wxDefaultPosition, wxDefaultSize,wxDEFAULT_DIALOG_STYLE)
     , m_filament_color(filament_color)
     , m_filament_type(filament_type)
     , m_filament_map(filament_map)
@@ -450,6 +450,11 @@ void FilamentMapDialog::set_modal_btn_labels(const wxString &ok_label, const wxS
 {
     m_ok_btn->SetLabel(ok_label);
     m_cancel_btn->SetLabel(cancel_label);
+}
+
+void FilamentMapDialog::on_dpi_changed(const wxRect& suggested_rect) {
+    Refresh();
+    Fit();
 }
 
 }} // namespace Slic3r::GUI

--- a/src/slic3r/GUI/FilamentMapDialog.hpp
+++ b/src/slic3r/GUI/FilamentMapDialog.hpp
@@ -5,6 +5,7 @@
 #include <vector>
 #include "CapsuleButton.hpp"
 #include "Widgets/CheckBox.hpp"
+#include "GUI_Utils.hpp"
 
 class Button;
 
@@ -31,7 +32,7 @@ class SmartFilamentPanel;
 bool try_pop_up_before_slice(bool is_slice_all, Plater* plater_ref, PartPlate* partplate_ref, bool force_pop_up = false);
 
 
-class FilamentMapDialog : public wxDialog
+class FilamentMapDialog : public DPIDialog
 {
     enum PageType {
         ptAuto,
@@ -66,6 +67,8 @@ public:
 
     int ShowModal();
     void set_modal_btn_labels(const wxString& left_label, const wxString& right_label);
+    void on_dpi_changed(const wxRect& suggested_rect) override;
+
 private:
     void on_ok(wxCommandEvent &event);
     void on_cancel(wxCommandEvent &event);

--- a/src/slic3r/GUI/MultiMachineManagerPage.cpp
+++ b/src/slic3r/GUI/MultiMachineManagerPage.cpp
@@ -386,7 +386,7 @@ MultiMachineManagerPage::MultiMachineManagerPage(wxWindow* parent)
     m_tip_text->Wrap(-1);
 
     m_button_add = new Button(m_main_panel, _L("Add"));
-    m_button_add->SetStyle(ButtonStyle::Confirm, ButtonType::Window);
+    m_button_add->SetStyle(ButtonStyle::Confirm, ButtonType::Parameter);
 
     m_button_add->Bind(wxEVT_BUTTON, [this](wxCommandEvent& evt) {
         MultiMachinePickPage dlg;
@@ -712,9 +712,9 @@ void MultiMachineManagerPage::msw_rescale()
     m_action->Rescale();
     m_action->SetMinSize(wxSize(FromDIP(DEVICE_LEFT_PRO_NAME), FromDIP(DEVICE_ITEM_MAX_HEIGHT)));
     m_action->SetMaxSize(wxSize(FromDIP(DEVICE_LEFT_PRO_NAME), FromDIP(DEVICE_ITEM_MAX_HEIGHT)));
-    m_button_add->Rescale();
-    m_button_add->SetMinSize(wxSize(FromDIP(90), FromDIP(36)));
-    m_button_add->SetMaxSize(wxSize(FromDIP(90), FromDIP(36)));
+    m_button_add->Rescale(); // ORCA reapplies size and style
+    //m_button_add->SetMinSize(wxSize(FromDIP(90), FromDIP(36)));
+    //m_button_add->SetMaxSize(wxSize(FromDIP(90), FromDIP(36)));
 
     btn_last_page->Rescale();
     btn_last_page->SetMinSize(wxSize(FromDIP(20), FromDIP(20)));
@@ -726,9 +726,9 @@ void MultiMachineManagerPage::msw_rescale()
     m_page_num_enter->SetMinSize(wxSize(FromDIP(25), FromDIP(25)));
     m_page_num_enter->SetMaxSize(wxSize(FromDIP(25), FromDIP(25)));
 
-    m_button_edit->Rescale();
-    m_button_edit->SetMinSize(wxSize(FromDIP(90), FromDIP(36)));
-    m_button_edit->SetMaxSize(wxSize(FromDIP(90), FromDIP(36)));
+    m_button_edit->Rescale(); // ORCA reapplies size and style
+    //m_button_edit->SetMinSize(wxSize(FromDIP(90), FromDIP(36)));
+    //m_button_edit->SetMaxSize(wxSize(FromDIP(90), FromDIP(36)));
 
 
     for (const auto& item : m_device_items) {

--- a/src/slic3r/GUI/MultiMachinePage.cpp
+++ b/src/slic3r/GUI/MultiMachinePage.cpp
@@ -75,8 +75,8 @@ bool MultiMachinePage::Show(bool show)
 
 void MultiMachinePage::init_tabpanel()
 {
-    auto m_side_tools = new wxPanel(this, wxID_ANY, wxDefaultPosition, wxSize(FromDIP(220), FromDIP(18)));
-    wxBoxSizer* sizer_side_tools = new wxBoxSizer(wxHORIZONTAL);
+    auto m_side_tools = new wxPanel(this, wxID_ANY); // ORCA match layout with other windows with sidetools
+    wxBoxSizer* sizer_side_tools = new wxBoxSizer(wxVERTICAL); //ORCA
     sizer_side_tools->Add(m_side_tools, 1, wxEXPAND, 0);
     m_tabpanel = new Tabbook(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, sizer_side_tools, wxNB_LEFT | wxTAB_TRAVERSAL | wxNB_NOPAGETHEME);
     m_tabpanel->SetBackgroundColour(wxColour("#FEFFFF"));

--- a/src/slic3r/GUI/Notebook.cpp
+++ b/src/slic3r/GUI/Notebook.cpp
@@ -102,10 +102,9 @@ void ButtonsListCtrl::UpdateMode()
 void ButtonsListCtrl::Rescale()
 {
     //m_mode_sizer->msw_rescale();
-    int em = em_unit(this);
     for (Button* btn : m_pageButtons) {
         //BBS
-        btn->SetMinSize({(btn->GetLabel().empty() ? 40 : 132) * em / 10, 36 * em / 10});
+        btn->SetMinSize(FromDIP(wxSize{btn->GetLabel().empty() ? 40 : 136, 36}));
         btn->Rescale();
     }
 
@@ -156,9 +155,8 @@ bool ButtonsListCtrl::InsertPage(size_t n, const wxString &text, bool bSelect /*
     Button * btn = new Button(this, text.empty() ? text : " " + text, bmp_name, wxNO_BORDER);
     btn->SetCornerRadius(0);
 
-    int em = em_unit(this);
     //BBS set size for button
-    btn->SetMinSize({(text.empty() ? 40 : 136) * em / 10, 36 * em / 10});
+    btn->SetMinSize(FromDIP(wxSize{text.empty() ? 40 : 136, 36}));
 
     StateColor bg_color = StateColor(
         std::pair{wxColour(107, 107, 107), (int) StateColor::Hovered},
@@ -228,9 +226,8 @@ void ButtonsListCtrl::SetPageText(size_t n, const wxString& strText)
 // ORCA
 void ButtonsListCtrl::SetCompact(size_t n, bool compact)
 {
-    int em = em_unit(this);
     Button* btn = m_pageButtons[n];
-    btn->SetMinSize({(compact ? 40 : 136) * em / 10, 36 * em / 10});
+    btn->SetMinSize(FromDIP(wxSize{compact ? 40 : 136, 36}));
     btn->SetLabel(compact ? "" : (" " +  m_pageLabels[n]));
 }
 

--- a/src/slic3r/GUI/Notebook.cpp
+++ b/src/slic3r/GUI/Notebook.cpp
@@ -102,9 +102,10 @@ void ButtonsListCtrl::UpdateMode()
 void ButtonsListCtrl::Rescale()
 {
     //m_mode_sizer->msw_rescale();
+    int em = em_unit(this);
     for (Button* btn : m_pageButtons) {
         //BBS
-        btn->SetMinSize(FromDIP(wxSize{btn->GetLabel().empty() ? 40 : 136, 36}));
+        btn->SetMinSize({(btn->GetLabel().empty() ? 40 : 132) * em / 10, 36 * em / 10});
         btn->Rescale();
     }
 
@@ -155,8 +156,9 @@ bool ButtonsListCtrl::InsertPage(size_t n, const wxString &text, bool bSelect /*
     Button * btn = new Button(this, text.empty() ? text : " " + text, bmp_name, wxNO_BORDER);
     btn->SetCornerRadius(0);
 
+    int em = em_unit(this);
     //BBS set size for button
-    btn->SetMinSize(FromDIP(wxSize{text.empty() ? 40 : 136, 36}));
+    btn->SetMinSize({(text.empty() ? 40 : 136) * em / 10, 36 * em / 10});
 
     StateColor bg_color = StateColor(
         std::pair{wxColour(107, 107, 107), (int) StateColor::Hovered},
@@ -226,8 +228,9 @@ void ButtonsListCtrl::SetPageText(size_t n, const wxString& strText)
 // ORCA
 void ButtonsListCtrl::SetCompact(size_t n, bool compact)
 {
+    int em = em_unit(this);
     Button* btn = m_pageButtons[n];
-    btn->SetMinSize(FromDIP(wxSize{compact ? 40 : 136, 36}));
+    btn->SetMinSize({(compact ? 40 : 136) * em / 10, 36 * em / 10});
     btn->SetLabel(compact ? "" : (" " +  m_pageLabels[n]));
 }
 

--- a/src/slic3r/GUI/OG_CustomCtrl.cpp
+++ b/src/slic3r/GUI/OG_CustomCtrl.cpp
@@ -603,6 +603,8 @@ void OG_CustomCtrl::msw_rescale()
     //m_bmp_mode_sz = create_scaled_bitmap("mode_simple", this, wxOSX ? 10 : 12).GetSize();
     m_bmp_blinking_sz = create_scaled_bitmap("blank_16", this).GetSize();
 
+    m_multi_extruder.msw_rescale();
+
     m_max_win_width = 0;
 
     wxCoord    h_pos = (ctrlWidth + get_title_width() - titleWidth) * m_em_unit;
@@ -807,8 +809,10 @@ void OG_CustomCtrl::CtrlLine::render(wxDC& dc, wxCoord h_pos, wxCoord v_pos)
                 is_multi_extruder |= opt.opt_id.find_last_of('#') != std::string::npos;
         wxCoord icon_pos = h_pos;
         if (is_multi_extruder) {
-            static ScalableBitmap multi_extruder(ctrl, "multi_extruder");
-            h_pos = draw_act_bmps(dc, wxPoint(h_pos, v_pos), multi_extruder.bmp(), multi_extruder.bmp(), false, 0, true).x;
+            if (!ctrl->m_multi_extruder.bmp().IsOk()) {
+                ctrl->m_multi_extruder = ScalableBitmap(ctrl, "multi_extruder");
+            }
+            h_pos = draw_act_bmps(dc, wxPoint(h_pos, v_pos), ctrl->m_multi_extruder.bmp(), ctrl->m_multi_extruder.bmp(), false, 0, true).x;
         }
         is_url_string = !suppress_hyperlinks && !og_line.label_path.empty();
         // BBS

--- a/src/slic3r/GUI/OG_CustomCtrl.cpp
+++ b/src/slic3r/GUI/OG_CustomCtrl.cpp
@@ -696,7 +696,7 @@ void OG_CustomCtrl::CtrlLine::msw_rescale()
 {
     // if we have a single option with no label, no sidetext
     if (draw_just_act_buttons)
-        height = get_bitmap_size(create_scaled_bitmap("empty")).GetHeight();
+        height = get_bitmap_size(create_scaled_bitmap("empty")).GetHeight() + ctrl->m_v_gap;
 
     if (ctrl->opt_group->label_width != 0 && !og_line.label.IsEmpty()) {
         wxSize label_sz = ctrl->GetTextExtent(og_line.label);

--- a/src/slic3r/GUI/OG_CustomCtrl.hpp
+++ b/src/slic3r/GUI/OG_CustomCtrl.hpp
@@ -36,6 +36,8 @@ class OG_CustomCtrl :public wxPanel
 
     int     m_max_win_width{0};
 
+    ScalableBitmap m_multi_extruder;
+
     struct CtrlLine {
         wxCoord           width{ wxDefaultCoord };
         wxCoord           height{ wxDefaultCoord };

--- a/src/slic3r/GUI/ObjColorDialog.cpp
+++ b/src/slic3r/GUI/ObjColorDialog.cpp
@@ -819,7 +819,7 @@ void ObjColorPanel::generate_thumbnail()
                         image.SetAlpha((int) c, (int) r, px[3]);
                     }
                 }
-                image = image.Rescale(FromDIP(IMAGE_SIZE_WIDTH), FromDIP(IMAGE_SIZE_WIDTH));
+                image = image.Rescale(IMAGE_SIZE_WIDTH, IMAGE_SIZE_WIDTH); // ORCA control bitmap is DPI aware now
                 m_image_button->SetBitmap(image);
             }
 

--- a/src/slic3r/GUI/OptionsGroup.cpp
+++ b/src/slic3r/GUI/OptionsGroup.cpp
@@ -944,6 +944,12 @@ void ConfigOptionsGroup::msw_rescale()
                     cbtn->Rescale();
                     return;
                 }
+                // check if window is MultiSwitchButton // m_extruder_switch / m_variant_combo   
+                MultiSwitchButton* msbtn = dynamic_cast<MultiSwitchButton*>(win); 
+                if (msbtn) { 
+                    msbtn->Rescale();
+                    return;
+                }
                 // check if window is wxButton
                 wxButton* btn = dynamic_cast<wxButton*>(win);
                 if (btn) {

--- a/src/slic3r/GUI/OptionsGroup.cpp
+++ b/src/slic3r/GUI/OptionsGroup.cpp
@@ -938,6 +938,12 @@ void ConfigOptionsGroup::msw_rescale()
                     sc_btn->SetSize(sc_btn->GetBestSize());
                     return;
                 }
+                // check if window is Button // printer / filament settings > setup buttons etc
+                Button* cbtn = dynamic_cast<Button*>(win);
+                if (cbtn) { 
+                    cbtn->Rescale();
+                    return;
+                }
                 // check if window is wxButton
                 wxButton* btn = dynamic_cast<wxButton*>(win);
                 if (btn) {

--- a/src/slic3r/GUI/OptionsGroup.cpp
+++ b/src/slic3r/GUI/OptionsGroup.cpp
@@ -944,12 +944,6 @@ void ConfigOptionsGroup::msw_rescale()
                     cbtn->Rescale();
                     return;
                 }
-                // check if window is MultiSwitchButton // m_extruder_switch / m_variant_combo   
-                MultiSwitchButton* msbtn = dynamic_cast<MultiSwitchButton*>(win); 
-                if (msbtn) { 
-                    msbtn->Rescale();
-                    return;
-                }
                 // check if window is wxButton
                 wxButton* btn = dynamic_cast<wxButton*>(win);
                 if (btn) {

--- a/src/slic3r/GUI/ParamsPanel.cpp
+++ b/src/slic3r/GUI/ParamsPanel.cpp
@@ -263,7 +263,7 @@ ParamsPanel::ParamsPanel( wxWindow* parent, wxWindowID id, const wxPoint& pos, c
         //int width, height;
         // BBS: new layout
         m_mode_region = new SwitchButton(m_top_panel);
-        m_mode_region->SetMaxSize({em_unit(this) * 12, -1});
+        m_mode_region->SetMaxSize({FromDIP(120), -1});
         m_mode_region->SetLabels(_L("Global"), _L("Objects"));
         //m_mode_region->GetSize(&width, &height);
         m_tips_arrow = new ScalableButton(m_top_panel, wxID_ANY, "tips_arrow");
@@ -408,7 +408,7 @@ void ParamsPanel::create_layout()
 
     m_left_sizer = new wxBoxSizer( wxVERTICAL );
     // BBS: new layout
-    m_left_sizer->SetMinSize( wxSize(40 * em_unit(this), -1 ) );
+    m_left_sizer->SetMinSize( wxSize(FromDIP(400), -1 ) );
 
     if (m_top_panel) {
         m_mode_sizer = new wxBoxSizer( wxHORIZONTAL );
@@ -483,7 +483,7 @@ void ParamsPanel::create_layout()
 
     //m_top_sizer->Add( m_right_sizer, 1, wxEXPAND, 5 );
     // BBS: new layout
-    m_left_sizer->AddSpacer(6 * em_unit(this) / 10);
+    m_left_sizer->AddSpacer(FromDIP(6));
 #if __WXOSX__
     m_left_sizer->Add(m_tmp_panel, 1, wxEXPAND | wxALL, 0);
     m_tmp_panel->GetSizer()->Add( m_page_view, 1, wxEXPAND );
@@ -678,9 +678,9 @@ void ParamsPanel::msw_rescale()
     if (m_search_btn) m_search_btn->msw_rescale();
     if (m_compare_btn) m_compare_btn->msw_rescale();
     if (m_tips_arrow) m_tips_arrow->msw_rescale();
-    m_left_sizer->SetMinSize(wxSize(40 * em_unit(this), -1));
+    m_left_sizer->SetMinSize(wxSize(FromDIP(400), -1));
     if (m_mode_sizer)
-        m_mode_sizer->SetMinSize(-1, 3 * em_unit(this));
+        m_mode_sizer->SetMinSize(-1, FromDIP(30));
     if (m_mode_region)
         ((SwitchButton* )m_mode_region)->Rescale();
     if (m_mode_icon) m_mode_icon->msw_rescale();

--- a/src/slic3r/GUI/ParamsPanel.cpp
+++ b/src/slic3r/GUI/ParamsPanel.cpp
@@ -408,7 +408,7 @@ void ParamsPanel::create_layout()
 
     m_left_sizer = new wxBoxSizer( wxVERTICAL );
     // BBS: new layout
-    m_left_sizer->SetMinSize( wxSize(FromDIP(400), -1 ) );
+    m_left_sizer->SetMinSize( wxSize(FromDIP(SidebarProps::MinWidth()), -1 ) );
 
     if (m_top_panel) {
         m_mode_sizer = new wxBoxSizer( wxHORIZONTAL );
@@ -678,9 +678,9 @@ void ParamsPanel::msw_rescale()
     if (m_search_btn) m_search_btn->msw_rescale();
     if (m_compare_btn) m_compare_btn->msw_rescale();
     if (m_tips_arrow) m_tips_arrow->msw_rescale();
-    m_left_sizer->SetMinSize(wxSize(FromDIP(400), -1));
+    m_left_sizer->SetMinSize(wxSize(FromDIP(SidebarProps::MinWidth()), -1));
     if (m_mode_sizer)
-        m_mode_sizer->SetMinSize(-1, FromDIP(30));
+        m_mode_sizer->SetMinSize(-1, FromDIP(SidebarProps::TitlebarHeight()));
     if (m_mode_region)
         ((SwitchButton* )m_mode_region)->Rescale();
     if (m_mode_icon) m_mode_icon->msw_rescale();

--- a/src/slic3r/GUI/ParamsPanel.cpp
+++ b/src/slic3r/GUI/ParamsPanel.cpp
@@ -263,7 +263,7 @@ ParamsPanel::ParamsPanel( wxWindow* parent, wxWindowID id, const wxPoint& pos, c
         //int width, height;
         // BBS: new layout
         m_mode_region = new SwitchButton(m_top_panel);
-        m_mode_region->SetMaxSize({FromDIP(120), -1});
+        m_mode_region->SetMaxSize({em_unit(this) * 12, -1});
         m_mode_region->SetLabels(_L("Global"), _L("Objects"));
         //m_mode_region->GetSize(&width, &height);
         m_tips_arrow = new ScalableButton(m_top_panel, wxID_ANY, "tips_arrow");
@@ -408,7 +408,7 @@ void ParamsPanel::create_layout()
 
     m_left_sizer = new wxBoxSizer( wxVERTICAL );
     // BBS: new layout
-    m_left_sizer->SetMinSize( wxSize(FromDIP(SidebarProps::MinWidth()), -1 ) );
+    m_left_sizer->SetMinSize( wxSize(SidebarProps::MinWidth() * em_unit(this)/10, -1 ) );
 
     if (m_top_panel) {
         m_mode_sizer = new wxBoxSizer( wxHORIZONTAL );
@@ -483,7 +483,7 @@ void ParamsPanel::create_layout()
 
     //m_top_sizer->Add( m_right_sizer, 1, wxEXPAND, 5 );
     // BBS: new layout
-    m_left_sizer->AddSpacer(FromDIP(6));
+    m_left_sizer->AddSpacer(6 * em_unit(this) / 10);
 #if __WXOSX__
     m_left_sizer->Add(m_tmp_panel, 1, wxEXPAND | wxALL, 0);
     m_tmp_panel->GetSizer()->Add( m_page_view, 1, wxEXPAND );
@@ -678,9 +678,9 @@ void ParamsPanel::msw_rescale()
     if (m_search_btn) m_search_btn->msw_rescale();
     if (m_compare_btn) m_compare_btn->msw_rescale();
     if (m_tips_arrow) m_tips_arrow->msw_rescale();
-    m_left_sizer->SetMinSize(wxSize(FromDIP(SidebarProps::MinWidth()), -1));
+    m_left_sizer->SetMinSize(wxSize(SidebarProps::MinWidth() * em_unit(this) / 10, -1));
     if (m_mode_sizer)
-        m_mode_sizer->SetMinSize(-1, FromDIP(SidebarProps::TitlebarHeight()));
+        m_mode_sizer->SetMinSize(-1, SidebarProps::TitlebarHeight() * em_unit(this) / 10);
     if (m_mode_region)
         ((SwitchButton* )m_mode_region)->Rescale();
     if (m_mode_icon) m_mode_icon->msw_rescale();

--- a/src/slic3r/GUI/PlateSettingsDialog.cpp
+++ b/src/slic3r/GUI/PlateSettingsDialog.cpp
@@ -615,6 +615,30 @@ wxString PlateSettingsDialog::to_print_sequence_name(PrintSequence print_seq) {
 
 void PlateSettingsDialog::on_dpi_changed(const wxRect& suggested_rect)
 {
+    std::function<void(wxWindow*, int)> WalkControls;
+    WalkControls = [&](wxWindow* parent, int depth) -> void {
+        if (!parent) return;
+
+        for (auto* child : parent->GetChildren()) {
+            if (!child)
+                continue;
+            else if (auto* txt = dynamic_cast<TextInput*>(child))
+                txt->Rescale();
+            else if (auto* cmb = dynamic_cast<ComboBox*>(child))
+                cmb->Rescale();
+            else if (auto* dc = dynamic_cast<DragCanvas*>(child))
+                dc->Rescale();
+            else if (auto* sb = dynamic_cast<ScalableButton*>(child))
+                sb->msw_rescale();
+                
+            WalkControls(child, depth + 1);
+        }
+    };
+    WalkControls(this, 0);
+
+    Layout();
+    Refresh();
+    Fit();
 }
 
 wxString PlateSettingsDialog::get_plate_name() const {

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -3736,7 +3736,9 @@ void Sidebar::update_filaments_counter(bool force_layout)
 void Sidebar::msw_rescale()
 {
     SetMinSize(wxSize(39 * wxGetApp().em_unit(), -1));
+    p->m_panel_printer_title->Rescale();
     p->m_panel_printer_title->GetSizer()->SetMinSize(-1, 3 * wxGetApp().em_unit());
+    p->m_panel_filament_title->Rescale();
     p->m_panel_filament_title->GetSizer()
         ->SetMinSize(-1, 3 * wxGetApp().em_unit());
     p->m_printer_icon->msw_rescale();
@@ -3745,6 +3747,7 @@ void Sidebar::msw_rescale()
     p->m_printer_icon->msw_rescale();
     p->m_printer_setting->msw_rescale();
 
+    p->panel_printer_preset->Rescale();
     p->panel_printer_preset->SetMinSize(FromDIP(PRINTER_PANEL_SIZE));
     p->panel_printer_preset->SetCornerRadius(FromDIP(PRINTER_PANEL_RADIUS));
     p->image_printer->SetSize(FromDIP(PRINTER_THUMBNAIL_SIZE));
@@ -3753,10 +3756,12 @@ void Sidebar::msw_rescale()
     p->combo_printer->SetMaxSize(wxSize(-1, FromDIP(30))); // limiting height makes badge visible
     p->btn_edit_printer->msw_rescale();
 
+    p->panel_nozzle_dia->Rescale();
     p->panel_nozzle_dia->SetMinSize(FromDIP(PRINTER_PANEL_SIZE));
     p->panel_nozzle_dia->SetCornerRadius(FromDIP(PRINTER_PANEL_RADIUS));
     p->combo_nozzle_dia->Rescale();
 
+    p->panel_printer_bed->Rescale();
     p->panel_printer_bed->SetMinSize(FromDIP(PRINTER_PANEL_SIZE));
     p->panel_printer_bed->SetCornerRadius(FromDIP(PRINTER_PANEL_RADIUS));
     p->combo_printer_bed->Rescale();
@@ -3817,6 +3822,7 @@ void Sidebar::msw_rescale()
     p->m_search_bar->SetSize(wxSize(-1, 3 * wxGetApp().em_unit()));
     p->m_search_item->Rescale();
     p->m_search_item->GetTextCtrl()->SetSize(wxSize(-1, FromDIP(16)));
+    p->m_search_bar->Rescale();
     p->m_search_bar->Layout();
 
     // BBS

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -2356,7 +2356,8 @@ void Sidebar::update_sync_ams_btn_enable(wxUpdateUIEvent &e)
  }
 
 Sidebar::Sidebar(Plater *parent)
-    : wxPanel(parent, wxID_ANY, wxDefaultPosition, wxSize(39 * wxGetApp().em_unit(), -1)), p(new priv(parent))
+    : m_em_unit(em_unit(parent))
+    , wxPanel(parent, wxID_ANY, wxDefaultPosition, wxSize(SidebarProps::MinWidth() * em_unit(parent) / 10, -1)), p(new priv(parent))
 {
     Choice::register_dynamic_list("support_filament", &dynamic_filament_list);
     Choice::register_dynamic_list("support_interface_filament", &dynamic_filament_list);
@@ -2387,7 +2388,6 @@ Sidebar::Sidebar(Plater *parent)
 #endif
 #endif
 
-    int em = wxGetApp().em_unit();
     //BBS refine layout and styles
     // Sizer in the scrolled area
     auto* scrolled_sizer = m_scrolled_sizer = new wxBoxSizer(wxVERTICAL);
@@ -2450,7 +2450,7 @@ Sidebar::Sidebar(Plater *parent)
         h_sizer_title->Add(p->m_printer_bbl_sync, 0, wxALIGN_CENTER | wxRIGHT, FromDIP(SidebarProps::WideSpacing())); // used larger margin to prevent accidental clicks
         h_sizer_title->Add(p->m_printer_setting, 0, wxALIGN_CENTER);
         h_sizer_title->AddSpacer(FromDIP(SidebarProps::TitlebarMargin()));
-        h_sizer_title->SetMinSize(-1, SidebarProps::TitlebarHeight() * em / 10);
+        h_sizer_title->SetMinSize(-1, SidebarProps::TitlebarHeight() * m_em_unit / 10);
 
         p->m_panel_printer_title->SetSizer(h_sizer_title);
         p->m_panel_printer_title->Layout();
@@ -3152,13 +3152,12 @@ void Sidebar::init_filament_combo(PlaterPresetComboBox **combo, const int filame
 
     // BBS:  filament double columns
 
-    // int em = wxGetApp().em_unit();
     if ((filament_idx % 2) == 0) // Dont add right column item. this one create equal spacing on left, right & middle
         combo_and_btn_sizer->AddSpacer(FromDIP((filament_idx % 2) == 0 ? 12 : 3)); // Content Margin
 
     (*combo)->clr_picker->SetLabel(wxString::Format("%d", filament_idx + 1));
     combo_and_btn_sizer->Add((*combo)->clr_picker, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(SidebarProps::ElementSpacing()) - FromDIP(2)); // ElementSpacing - 2 (from combo box))
-    combo_and_btn_sizer->Add(*combo, 1, wxALL | wxEXPAND, FromDIP(2))->SetMinSize({-1, SidebarProps::ComboHeightBig() * wxGetApp().em_unit() / 10}); // ORCA ensure height matches with PlaterPresetComboBox
+    combo_and_btn_sizer->Add(*combo, 1, wxALL | wxEXPAND, FromDIP(2))->SetMinSize({-1, SidebarProps::ComboHeightBig() * m_em_unit / 10}); // ORCA ensure height matches with PlaterPresetComboBox
 
     /* BBS hide del_btn
     ScalableButton* del_btn = new ScalableButton(p->m_panel_filament_content, wxID_ANY, "delete_filament");
@@ -3735,11 +3734,14 @@ void Sidebar::update_filaments_counter(bool force_layout)
 
 void Sidebar::msw_rescale()
 {
-    SetMinSize(wxSize(39 * wxGetApp().em_unit(), -1));
+    m_em_unit = em_unit(this);
+    
+    SetMinSize(wxSize(SidebarProps::MinWidth() * m_em_unit / 10, -1));
+
     p->m_panel_printer_title->Rescale();
-    p->m_panel_printer_title->GetSizer()->SetMinSize(-1, SidebarProps::TitlebarHeight() * wxGetApp().em_unit() / 10);
+    p->m_panel_printer_title->GetSizer()->SetMinSize(-1, SidebarProps::TitlebarHeight() * m_em_unit / 10);
     p->m_panel_filament_title->Rescale();
-    p->m_panel_filament_title->GetSizer()->SetMinSize(-1, SidebarProps::TitlebarHeight() * wxGetApp().em_unit() / 10);
+    p->m_panel_filament_title->GetSizer()->SetMinSize(-1, SidebarProps::TitlebarHeight() * m_em_unit / 10);
     p->m_printer_icon->msw_rescale();
     p->m_printer_connect->msw_rescale();
     p->m_printer_bbl_sync->msw_rescale();
@@ -3752,7 +3754,7 @@ void Sidebar::msw_rescale()
     p->image_printer->SetSize(FromDIP(PRINTER_THUMBNAIL_SIZE));
     update_printer_thumbnail();
     p->combo_printer->Rescale();
-    p->combo_printer->SetMaxSize(wxSize(-1, FromDIP(SidebarProps::ComboHeight()))); // limiting height makes badge visible
+    p->combo_printer->SetMaxSize(wxSize(-1, SidebarProps::ComboHeight() * m_em_unit / 10)); // limiting height makes badge visible
     p->btn_edit_printer->msw_rescale();
 
     p->panel_nozzle_dia->Rescale();
@@ -3818,7 +3820,7 @@ void Sidebar::msw_rescale()
     // BBS
     //p->object_manipulation->msw_rescale();
     p->object_settings->msw_rescale();
-    p->m_search_bar->SetSize(wxSize(-1, SidebarProps::ComboHeightBig() * wxGetApp().em_unit() / 10));
+    p->m_search_bar->SetSize(wxSize(-1, SidebarProps::ComboHeightBig() * m_em_unit / 10));
     p->m_search_item->Rescale();
     p->m_search_item->GetTextCtrl()->SetSize(wxSize(-1, FromDIP(16)));
     p->m_search_bar->Rescale();
@@ -4794,7 +4796,7 @@ template<typename T> void setup_dialog_position(T& info)
 
         auto screen_width = wxDisplay(&sidebar).GetClientArea().GetSize().x;
         auto right_space  = screen_width - sidebar.get_sidebar_pos_right_x();
-        if (right_space < sidebar.FromDIP(SidebarProps::MinWidth())) {
+        if (right_space < SidebarProps::MinWidth() * sidebar.m_em_unit / 10) {
             on_right = false;
         }
     }
@@ -5962,7 +5964,7 @@ Plater::priv::priv(Plater *q, MainFrame *main_frame)
                                    .CloseButton(false)
                                    .TopDockable(false)
                                    .BottomDockable(false)
-                                   .BestSize(wxSize(39 * wxGetApp().em_unit(), 90 * wxGetApp().em_unit())));
+                                   .BestSize(wxSize(SidebarProps::MinWidth() * sidebar->m_em_unit / 10, 90 * sidebar->m_em_unit)));
 
     auto* panel_sizer = new wxBoxSizer(wxHORIZONTAL);
     panel_sizer->Add(view3D, 1, wxEXPAND | wxALL, 0);

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -2449,7 +2449,7 @@ Sidebar::Sidebar(Plater *parent)
         h_sizer_title->Add(p->m_printer_bbl_sync, 0, wxALIGN_CENTER | wxRIGHT, FromDIP(SidebarProps::WideSpacing())); // used larger margin to prevent accidental clicks
         h_sizer_title->Add(p->m_printer_setting, 0, wxALIGN_CENTER);
         h_sizer_title->AddSpacer(FromDIP(SidebarProps::TitlebarMargin()));
-        h_sizer_title->SetMinSize(-1, FromDIP(30));
+        h_sizer_title->SetMinSize(-1, FromDIP(SidebarProps::TitlebarHeight()));
 
         p->m_panel_printer_title->SetSizer(h_sizer_title);
         p->m_panel_printer_title->Layout();
@@ -2538,7 +2538,7 @@ Sidebar::Sidebar(Plater *parent)
 
         p->combo_printer = new PlaterPresetComboBox(p->panel_printer_preset, Preset::TYPE_PRINTER);
         p->combo_printer->SetBorderWidth(0);
-        p->combo_printer->SetMaxSize(wxSize(-1, FromDIP(30))); // limiting height makes badge visible
+        p->combo_printer->SetMaxSize(wxSize(-1, SidebarProps::ComboHeight())); // limiting height makes badge visible
         // ORCA paint whole combobox on focus
         auto printer_focus_bg = [this, panel_color](bool focused){
             auto bg_color = StateColor::darkModeColorFor(focused ? panel_color.bg_focus : panel_color.bg_normal);
@@ -2606,8 +2606,8 @@ Sidebar::Sidebar(Plater *parent)
         p->combo_nozzle_dia = new ComboBox(p->panel_nozzle_dia, wxID_ANY, wxString(""), wxDefaultPosition, wxDefaultSize, 0, nullptr, wxCB_READONLY);
         p->combo_nozzle_dia->SetBorderWidth(0);
         p->combo_nozzle_dia->GetDropDown().SetUseContentWidth(true);
-        p->combo_nozzle_dia->SetMinSize(FromDIP(wxSize(PRINTER_PANEL_SIZE.GetWidth() - 4, 26))); // requires a static value in here
-        p->combo_nozzle_dia->SetMaxSize(FromDIP(wxSize(PRINTER_PANEL_SIZE.GetWidth() - 4, 26))); // using -1 with wxEXPAND has issues
+        p->combo_nozzle_dia->SetMinSize(FromDIP(wxSize(PRINTER_PANEL_SIZE.GetWidth() - 4, SidebarProps::ComboHeight()))); // requires a static value in here
+        p->combo_nozzle_dia->SetMaxSize(FromDIP(wxSize(PRINTER_PANEL_SIZE.GetWidth() - 4, SidebarProps::ComboHeight()))); // using -1 with wxEXPAND has issues
         p->combo_nozzle_dia->Bind(wxEVT_COMBOBOX, [this](auto &e) {
             auto evt_combo = (*p->single_extruder).combo_diameter;
             evt_combo->SetSelection(e.GetSelection());
@@ -2862,7 +2862,7 @@ Sidebar::Sidebar(Plater *parent)
     p->m_staticText_filament_settings = new Label(p->m_panel_filament_title, _L("Project Filaments"), LB_PROPAGATE_MOUSE_EVENT);
     bSizer39->Add(p->m_filament_icon, 0, wxALIGN_CENTER | wxLEFT, FromDIP(SidebarProps::TitlebarMargin()));
     bSizer39->Add(p->m_staticText_filament_settings, 0, wxALIGN_CENTER | wxLEFT | wxRIGHT, FromDIP(SidebarProps::ElementSpacing()));
-    bSizer39->SetMinSize(-1, FromDIP(30));
+    bSizer39->SetMinSize(-1, FromDIP(SidebarProps::TitlebarHeight()));
 
     p->m_staticText_filament_count = new Label(p->m_panel_filament_title, "(0)", LB_PROPAGATE_MOUSE_EVENT);
     bSizer39->Add(p->m_staticText_filament_count, 0, wxALIGN_CENTER );
@@ -3013,7 +3013,7 @@ Sidebar::Sidebar(Plater *parent)
     p->sizer_params = new wxBoxSizer(wxVERTICAL);
 
     // ORCA: Update search box to modern style
-    p->m_search_bar = new StaticBox(p->scrolled, wxID_ANY, wxDefaultPosition, wxSize(-1, FromDIP(30))); // ensure its size matches with combo box
+    p->m_search_bar = new StaticBox(p->scrolled, wxID_ANY, wxDefaultPosition, wxSize(-1, FromDIP(SidebarProps::ComboHeightBig()))); // ensure its size matches with combo box
     p->m_search_bar->SetCornerRadius(0);
     p->m_search_bar->SetBorderColor(wxColour("#CECECE"));
 
@@ -3157,7 +3157,7 @@ void Sidebar::init_filament_combo(PlaterPresetComboBox **combo, const int filame
 
     (*combo)->clr_picker->SetLabel(wxString::Format("%d", filament_idx + 1));
     combo_and_btn_sizer->Add((*combo)->clr_picker, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(SidebarProps::ElementSpacing()) - FromDIP(2)); // ElementSpacing - 2 (from combo box))
-    combo_and_btn_sizer->Add(*combo, 1, wxALL | wxEXPAND, FromDIP(2))->SetMinSize(FromDIP(wxSize{-1, 30})); // ORCA ensure height matches with PlaterPresetComboBox
+    combo_and_btn_sizer->Add(*combo, 1, wxALL | wxEXPAND, FromDIP(2))->SetMinSize(wxSize{-1, FromDIP(SidebarProps::ComboHeightBig())}); // ORCA ensure height matches with PlaterPresetComboBox
 
     /* BBS hide del_btn
     ScalableButton* del_btn = new ScalableButton(p->m_panel_filament_content, wxID_ANY, "delete_filament");
@@ -3736,9 +3736,9 @@ void Sidebar::msw_rescale()
 {
     SetMinSize(wxSize(FromDIP(390), -1));
     p->m_panel_printer_title->Rescale();
-    p->m_panel_printer_title->GetSizer()->SetMinSize(-1, FromDIP(30));
+    p->m_panel_printer_title->GetSizer()->SetMinSize(-1, FromDIP(SidebarProps::TitlebarHeight()));
     p->m_panel_filament_title->Rescale();
-    p->m_panel_filament_title->GetSizer()->SetMinSize(-1, FromDIP(30));
+    p->m_panel_filament_title->GetSizer()->SetMinSize(-1, FromDIP(SidebarProps::TitlebarHeight()));
     p->m_printer_icon->msw_rescale();
     p->m_printer_connect->msw_rescale();
     p->m_printer_bbl_sync->msw_rescale();
@@ -3751,7 +3751,7 @@ void Sidebar::msw_rescale()
     p->image_printer->SetSize(FromDIP(PRINTER_THUMBNAIL_SIZE));
     update_printer_thumbnail();
     p->combo_printer->Rescale();
-    p->combo_printer->SetMaxSize(wxSize(-1, FromDIP(30))); // limiting height makes badge visible
+    p->combo_printer->SetMaxSize(wxSize(-1, FromDIP(SidebarProps::ComboHeightBig()))); // limiting height makes badge visible
     p->btn_edit_printer->msw_rescale();
 
     p->panel_nozzle_dia->Rescale();
@@ -3817,7 +3817,7 @@ void Sidebar::msw_rescale()
     // BBS
     //p->object_manipulation->msw_rescale();
     p->object_settings->msw_rescale();
-    p->m_search_bar->SetSize(wxSize(-1, FromDIP(30)));
+    p->m_search_bar->SetSize(wxSize(-1, FromDIP(SidebarProps::ComboHeightBig())));
     p->m_search_item->Rescale();
     p->m_search_item->GetTextCtrl()->SetSize(wxSize(-1, FromDIP(16)));
     p->m_search_bar->Rescale();
@@ -4793,7 +4793,7 @@ template<typename T> void setup_dialog_position(T& info)
 
         auto screen_width = wxDisplay(&sidebar).GetClientArea().GetSize().x;
         auto right_space  = screen_width - sidebar.get_sidebar_pos_right_x();
-        if (right_space < sidebar.FromDIP(400)) {
+        if (right_space < sidebar.FromDIP(SidebarProps::MinWidth())) {
             on_right = false;
         }
     }

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -2356,7 +2356,7 @@ void Sidebar::update_sync_ams_btn_enable(wxUpdateUIEvent &e)
  }
 
 Sidebar::Sidebar(Plater *parent)
-    : wxPanel(parent, wxID_ANY, wxDefaultPosition, wxSize(FromDIP(390), -1)), p(new priv(parent))
+    : wxPanel(parent, wxID_ANY, wxDefaultPosition, wxSize(parent->FromDIP(390), -1)), p(new priv(parent))
 {
     Choice::register_dynamic_list("support_filament", &dynamic_filament_list);
     Choice::register_dynamic_list("support_interface_filament", &dynamic_filament_list);

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -3752,7 +3752,7 @@ void Sidebar::msw_rescale()
     p->image_printer->SetSize(FromDIP(PRINTER_THUMBNAIL_SIZE));
     update_printer_thumbnail();
     p->combo_printer->Rescale();
-    p->combo_printer->SetMaxSize(wxSize(-1, FromDIP(SidebarProps::ComboHeightBig()))); // limiting height makes badge visible
+    p->combo_printer->SetMaxSize(wxSize(-1, FromDIP(SidebarProps::ComboHeight()))); // limiting height makes badge visible
     p->btn_edit_printer->msw_rescale();
 
     p->panel_nozzle_dia->Rescale();

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -626,8 +626,11 @@ struct ExtruderGroup : StaticGroup
 
     void sync_ams(MachineObject const *obj, std::vector<DevAms *> const &ams4, std::vector<DevAms *> const &ams1);
 
-    void Rescale()
+    void Rescale() override
     {
+        StaticGroup::Rescale();
+
+        SetCornerRadius(FromDIP(PRINTER_PANEL_RADIUS)); // ORCA match radius with other boxes
         if (hover_label)
             hover_label->Rescale();
         if (btn_edit)

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -3011,7 +3011,7 @@ Sidebar::Sidebar(Plater *parent)
     p->sizer_params = new wxBoxSizer(wxVERTICAL);
 
     // ORCA: Update search box to modern style
-    p->m_search_bar = new StaticBox(p->scrolled);
+    p->m_search_bar = new StaticBox(p->scrolled, wxID_ANY, wxDefaultPosition, wxSize(-1, 3 * wxGetApp().em_unit())); // ensure its size matches with combo box
     p->m_search_bar->SetCornerRadius(0);
     p->m_search_bar->SetBorderColor(wxColour("#CECECE"));
 
@@ -3811,6 +3811,7 @@ void Sidebar::msw_rescale()
     // BBS
     //p->object_manipulation->msw_rescale();
     p->object_settings->msw_rescale();
+    p->m_search_bar->SetSize(wxSize(-1, 3 * wxGetApp().em_unit()));
     p->m_search_item->Rescale();
     p->m_search_item->GetTextCtrl()->SetSize(wxSize(-1, FromDIP(16)));
     p->m_search_bar->Layout();

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -2356,7 +2356,7 @@ void Sidebar::update_sync_ams_btn_enable(wxUpdateUIEvent &e)
  }
 
 Sidebar::Sidebar(Plater *parent)
-    : wxPanel(parent, wxID_ANY, wxDefaultPosition, wxSize(39 * wxGetApp().em_unit(), -1)), p(new priv(parent))
+    : wxPanel(parent, wxID_ANY, wxDefaultPosition, wxSize(FromDIP(390), -1)), p(new priv(parent))
 {
     Choice::register_dynamic_list("support_filament", &dynamic_filament_list);
     Choice::register_dynamic_list("support_interface_filament", &dynamic_filament_list);
@@ -2387,7 +2387,6 @@ Sidebar::Sidebar(Plater *parent)
 #endif
 #endif
 
-    int em = wxGetApp().em_unit();
     //BBS refine layout and styles
     // Sizer in the scrolled area
     auto* scrolled_sizer = m_scrolled_sizer = new wxBoxSizer(wxVERTICAL);
@@ -2450,7 +2449,7 @@ Sidebar::Sidebar(Plater *parent)
         h_sizer_title->Add(p->m_printer_bbl_sync, 0, wxALIGN_CENTER | wxRIGHT, FromDIP(SidebarProps::WideSpacing())); // used larger margin to prevent accidental clicks
         h_sizer_title->Add(p->m_printer_setting, 0, wxALIGN_CENTER);
         h_sizer_title->AddSpacer(FromDIP(SidebarProps::TitlebarMargin()));
-        h_sizer_title->SetMinSize(-1, 3 * em);
+        h_sizer_title->SetMinSize(-1, FromDIP(30));
 
         p->m_panel_printer_title->SetSizer(h_sizer_title);
         p->m_panel_printer_title->Layout();
@@ -3014,7 +3013,7 @@ Sidebar::Sidebar(Plater *parent)
     p->sizer_params = new wxBoxSizer(wxVERTICAL);
 
     // ORCA: Update search box to modern style
-    p->m_search_bar = new StaticBox(p->scrolled, wxID_ANY, wxDefaultPosition, wxSize(-1, 3 * wxGetApp().em_unit())); // ensure its size matches with combo box
+    p->m_search_bar = new StaticBox(p->scrolled, wxID_ANY, wxDefaultPosition, wxSize(-1, FromDIP(30))); // ensure its size matches with combo box
     p->m_search_bar->SetCornerRadius(0);
     p->m_search_bar->SetBorderColor(wxColour("#CECECE"));
 
@@ -3158,7 +3157,7 @@ void Sidebar::init_filament_combo(PlaterPresetComboBox **combo, const int filame
 
     (*combo)->clr_picker->SetLabel(wxString::Format("%d", filament_idx + 1));
     combo_and_btn_sizer->Add((*combo)->clr_picker, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(SidebarProps::ElementSpacing()) - FromDIP(2)); // ElementSpacing - 2 (from combo box))
-    combo_and_btn_sizer->Add(*combo, 1, wxALL | wxEXPAND, FromDIP(2))->SetMinSize({-1, 30 * wxGetApp().em_unit() / 10}); // ORCA ensure height matches with PlaterPresetComboBox
+    combo_and_btn_sizer->Add(*combo, 1, wxALL | wxEXPAND, FromDIP(2))->SetMinSize(FromDIP(wxSize{-1, 30})); // ORCA ensure height matches with PlaterPresetComboBox
 
     /* BBS hide del_btn
     ScalableButton* del_btn = new ScalableButton(p->m_panel_filament_content, wxID_ANY, "delete_filament");
@@ -3735,12 +3734,11 @@ void Sidebar::update_filaments_counter(bool force_layout)
 
 void Sidebar::msw_rescale()
 {
-    SetMinSize(wxSize(39 * wxGetApp().em_unit(), -1));
+    SetMinSize(wxSize(FromDIP(390), -1));
     p->m_panel_printer_title->Rescale();
-    p->m_panel_printer_title->GetSizer()->SetMinSize(-1, 3 * wxGetApp().em_unit());
+    p->m_panel_printer_title->GetSizer()->SetMinSize(-1, FromDIP(30));
     p->m_panel_filament_title->Rescale();
-    p->m_panel_filament_title->GetSizer()
-        ->SetMinSize(-1, 3 * wxGetApp().em_unit());
+    p->m_panel_filament_title->GetSizer()->SetMinSize(-1, FromDIP(30));
     p->m_printer_icon->msw_rescale();
     p->m_printer_connect->msw_rescale();
     p->m_printer_bbl_sync->msw_rescale();
@@ -3819,7 +3817,7 @@ void Sidebar::msw_rescale()
     // BBS
     //p->object_manipulation->msw_rescale();
     p->object_settings->msw_rescale();
-    p->m_search_bar->SetSize(wxSize(-1, 3 * wxGetApp().em_unit()));
+    p->m_search_bar->SetSize(wxSize(-1, FromDIP(30)));
     p->m_search_item->Rescale();
     p->m_search_item->GetTextCtrl()->SetSize(wxSize(-1, FromDIP(16)));
     p->m_search_bar->Rescale();
@@ -5963,7 +5961,7 @@ Plater::priv::priv(Plater *q, MainFrame *main_frame)
                                    .CloseButton(false)
                                    .TopDockable(false)
                                    .BottomDockable(false)
-                                   .BestSize(wxSize(39 * wxGetApp().em_unit(), 90 * wxGetApp().em_unit())));
+                                   .BestSize(wxSize(q->FromDIP(390), q->FromDIP(900))));
 
     auto* panel_sizer = new wxBoxSizer(wxHORIZONTAL);
     panel_sizer->Add(view3D, 1, wxEXPAND | wxALL, 0);

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -3015,8 +3015,8 @@ Sidebar::Sidebar(Plater *parent)
     p->m_search_bar->SetCornerRadius(0);
     p->m_search_bar->SetBorderColor(wxColour("#CECECE"));
 
-    p->m_search_item = new TextInput(p->m_search_bar, wxEmptyString, wxEmptyString, "", wxDefaultPosition, wxDefaultSize, 0 | wxBORDER_NONE);
-    p->m_search_item->SetIcon(*BitmapCache().load_svg("search", FromDIP(16), FromDIP(16))); // ORCA: Add search icon to search box
+    // ORCA use search bar with icon
+    p->m_search_item = new TextInput(p->m_search_bar, wxEmptyString, wxEmptyString, "search", wxDefaultPosition, wxDefaultSize, 0 | wxBORDER_NONE);
 
     wxTextCtrl* text_ctrl = p->m_search_item->GetTextCtrl();
     text_ctrl->SetHint(_L("Search plate, object and part."));
@@ -3042,7 +3042,6 @@ Sidebar::Sidebar(Plater *parent)
     });
 
     auto search_sizer = new wxBoxSizer(wxHORIZONTAL);
-    search_sizer->Add(new wxWindow(p->m_search_bar, wxID_ANY, wxDefaultPosition, wxSize(0, 0)), 0, wxEXPAND|wxLEFT|wxRIGHT, FromDIP(1));
     search_sizer->Add(p->m_search_item, 1, wxEXPAND | wxALL, FromDIP(2));
     p->m_search_bar->SetSizer(search_sizer);
     p->m_search_bar->Layout();

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -2356,7 +2356,7 @@ void Sidebar::update_sync_ams_btn_enable(wxUpdateUIEvent &e)
  }
 
 Sidebar::Sidebar(Plater *parent)
-    : wxPanel(parent, wxID_ANY, wxDefaultPosition, wxSize(parent->FromDIP(390), -1)), p(new priv(parent))
+    : wxPanel(parent, wxID_ANY, wxDefaultPosition, wxSize(39 * wxGetApp().em_unit(), -1)), p(new priv(parent))
 {
     Choice::register_dynamic_list("support_filament", &dynamic_filament_list);
     Choice::register_dynamic_list("support_interface_filament", &dynamic_filament_list);
@@ -2387,6 +2387,7 @@ Sidebar::Sidebar(Plater *parent)
 #endif
 #endif
 
+    int em = wxGetApp().em_unit();
     //BBS refine layout and styles
     // Sizer in the scrolled area
     auto* scrolled_sizer = m_scrolled_sizer = new wxBoxSizer(wxVERTICAL);
@@ -2449,7 +2450,7 @@ Sidebar::Sidebar(Plater *parent)
         h_sizer_title->Add(p->m_printer_bbl_sync, 0, wxALIGN_CENTER | wxRIGHT, FromDIP(SidebarProps::WideSpacing())); // used larger margin to prevent accidental clicks
         h_sizer_title->Add(p->m_printer_setting, 0, wxALIGN_CENTER);
         h_sizer_title->AddSpacer(FromDIP(SidebarProps::TitlebarMargin()));
-        h_sizer_title->SetMinSize(-1, FromDIP(SidebarProps::TitlebarHeight()));
+        h_sizer_title->SetMinSize(-1, SidebarProps::TitlebarHeight() * em / 10);
 
         p->m_panel_printer_title->SetSizer(h_sizer_title);
         p->m_panel_printer_title->Layout();
@@ -3013,7 +3014,7 @@ Sidebar::Sidebar(Plater *parent)
     p->sizer_params = new wxBoxSizer(wxVERTICAL);
 
     // ORCA: Update search box to modern style
-    p->m_search_bar = new StaticBox(p->scrolled, wxID_ANY, wxDefaultPosition, wxSize(-1, FromDIP(SidebarProps::ComboHeightBig()))); // ensure its size matches with combo box
+    p->m_search_bar = new StaticBox(p->scrolled, wxID_ANY, wxDefaultPosition, wxSize(-1, SidebarProps::ComboHeightBig() * wxGetApp().em_unit() / 10)); // ensure its size matches with combo box
     p->m_search_bar->SetCornerRadius(0);
     p->m_search_bar->SetBorderColor(wxColour("#CECECE"));
 
@@ -3157,7 +3158,7 @@ void Sidebar::init_filament_combo(PlaterPresetComboBox **combo, const int filame
 
     (*combo)->clr_picker->SetLabel(wxString::Format("%d", filament_idx + 1));
     combo_and_btn_sizer->Add((*combo)->clr_picker, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(SidebarProps::ElementSpacing()) - FromDIP(2)); // ElementSpacing - 2 (from combo box))
-    combo_and_btn_sizer->Add(*combo, 1, wxALL | wxEXPAND, FromDIP(2))->SetMinSize(wxSize{-1, FromDIP(SidebarProps::ComboHeightBig())}); // ORCA ensure height matches with PlaterPresetComboBox
+    combo_and_btn_sizer->Add(*combo, 1, wxALL | wxEXPAND, FromDIP(2))->SetMinSize({-1, SidebarProps::ComboHeightBig() * wxGetApp().em_unit() / 10}); // ORCA ensure height matches with PlaterPresetComboBox
 
     /* BBS hide del_btn
     ScalableButton* del_btn = new ScalableButton(p->m_panel_filament_content, wxID_ANY, "delete_filament");
@@ -3734,11 +3735,11 @@ void Sidebar::update_filaments_counter(bool force_layout)
 
 void Sidebar::msw_rescale()
 {
-    SetMinSize(wxSize(FromDIP(390), -1));
+    SetMinSize(wxSize(39 * wxGetApp().em_unit(), -1));
     p->m_panel_printer_title->Rescale();
-    p->m_panel_printer_title->GetSizer()->SetMinSize(-1, FromDIP(SidebarProps::TitlebarHeight()));
+    p->m_panel_printer_title->GetSizer()->SetMinSize(-1, SidebarProps::TitlebarHeight() * wxGetApp().em_unit() / 10);
     p->m_panel_filament_title->Rescale();
-    p->m_panel_filament_title->GetSizer()->SetMinSize(-1, FromDIP(SidebarProps::TitlebarHeight()));
+    p->m_panel_filament_title->GetSizer()->SetMinSize(-1, SidebarProps::TitlebarHeight() * wxGetApp().em_unit() / 10);
     p->m_printer_icon->msw_rescale();
     p->m_printer_connect->msw_rescale();
     p->m_printer_bbl_sync->msw_rescale();
@@ -3817,7 +3818,7 @@ void Sidebar::msw_rescale()
     // BBS
     //p->object_manipulation->msw_rescale();
     p->object_settings->msw_rescale();
-    p->m_search_bar->SetSize(wxSize(-1, FromDIP(SidebarProps::ComboHeightBig())));
+    p->m_search_bar->SetSize(wxSize(-1, SidebarProps::ComboHeightBig() * wxGetApp().em_unit() / 10));
     p->m_search_item->Rescale();
     p->m_search_item->GetTextCtrl()->SetSize(wxSize(-1, FromDIP(16)));
     p->m_search_bar->Rescale();
@@ -5961,7 +5962,7 @@ Plater::priv::priv(Plater *q, MainFrame *main_frame)
                                    .CloseButton(false)
                                    .TopDockable(false)
                                    .BottomDockable(false)
-                                   .BestSize(wxSize(q->FromDIP(390), q->FromDIP(900))));
+                                   .BestSize(wxSize(39 * wxGetApp().em_unit(), 90 * wxGetApp().em_unit())));
 
     auto* panel_sizer = new wxBoxSizer(wxHORIZONTAL);
     panel_sizer->Add(view3D, 1, wxEXPAND | wxALL, 0);

--- a/src/slic3r/GUI/Plater.hpp
+++ b/src/slic3r/GUI/Plater.hpp
@@ -120,11 +120,15 @@ class SidebarProps
 {
 public:
     static int TitlebarMargin(){ return 8 ;} // Use as side margins on titlebar. Has less margin on sides to create separation with its content
+    static int TitlebarHeight(){ return 30;} // Titlebar Height
     static int ContentMargin() { return 12;} // Use as side margins contents of title
     static int ContentMarginV(){ return 9 ;} // Use as vertical margins contents of title
     static int IconSpacing()   { return 10;} // Use on main elements in same group of controls
     static int WideSpacing()   { return 18;} // Use between main elements / control groups for separation or preventing accidental clicks important
     static int ElementSpacing(){ return 5 ;} // Use if elements has relation between them like edit button for combo box etc.
+    static int ComboHeight()   { return 26;} // ComboBox height for parameter comboboxes
+    static int ComboHeightBig(){ return 30;} // ComboBox height for Filament, Process comboboxes
+    static int MinWidth()      { return 400;} // min width for sidebar. Should match with end of parameter boxes
 };
 
 class Sidebar : public wxPanel

--- a/src/slic3r/GUI/Plater.hpp
+++ b/src/slic3r/GUI/Plater.hpp
@@ -128,7 +128,7 @@ public:
     static int ElementSpacing(){ return 5 ;} // Use if elements has relation between them like edit button for combo box etc.
     static int ComboHeight()   { return 26;} // ComboBox height for parameter comboboxes
     static int ComboHeightBig(){ return 30;} // ComboBox height for Filament, Process comboboxes
-    static int MinWidth()      { return 400;} // min width for sidebar. Should match with end of parameter boxes
+    static int MinWidth()      { return 390;} // min width for sidebar. Should match with end of parameter boxes
 };
 
 class Sidebar : public wxPanel
@@ -159,6 +159,8 @@ public:
     Sidebar &operator=(Sidebar &&) = delete;
     Sidebar &operator=(const Sidebar &) = delete;
     ~Sidebar();
+
+    int  m_em_unit = 10;
 
     void on_enter_image_printer_bed(wxMouseEvent &evt);
     void on_leave_image_printer_bed(wxMouseEvent &evt);

--- a/src/slic3r/GUI/PresetComboBoxes.cpp
+++ b/src/slic3r/GUI/PresetComboBoxes.cpp
@@ -837,7 +837,7 @@ bool PresetComboBox::selection_is_changed_according_to_physical_printers()
 // ---------------------------------
 
 PlaterPresetComboBox::PlaterPresetComboBox(wxWindow *parent, Preset::Type preset_type) :
-    PresetComboBox(parent, preset_type, wxSize(25 * wxGetApp().em_unit(), 30 * wxGetApp().em_unit() / 10))
+    PresetComboBox(parent, preset_type, wxSize(-1, parent->FromDIP(SidebarProps::ComboHeightBig())))
 {
     GetDropDown().SetUseContentWidth(true,true);
 
@@ -1641,7 +1641,7 @@ void PlaterPresetComboBox::sync_colour_config(const std::vector<std::string> &cl
 
 TabPresetComboBox::TabPresetComboBox(wxWindow* parent, Preset::Type preset_type) :
     // BBS: new layout
-    PresetComboBox(parent, preset_type, wxSize(20 * wxGetApp().em_unit(), 30 * wxGetApp().em_unit() / 10))
+    PresetComboBox(parent, preset_type, wxSize(-1, parent->FromDIP(SidebarProps::ComboHeightBig())))
 {
     GetDropDown().SetUseContentWidth(true,true);
 }

--- a/src/slic3r/GUI/PresetComboBoxes.cpp
+++ b/src/slic3r/GUI/PresetComboBoxes.cpp
@@ -876,8 +876,8 @@ PlaterPresetComboBox::PlaterPresetComboBox(wxWindow *parent, Preset::Type preset
 
     // BBS
     if (m_type == Preset::TYPE_FILAMENT) {
-        int em = wxGetApp().em_unit();
-        clr_picker = new wxBitmapButton(parent, wxID_ANY, {}, wxDefaultPosition, wxSize(FromDIP(20), FromDIP(20)), wxBU_EXACTFIT | wxBU_AUTODRAW | wxBORDER_NONE);
+        int em = em_unit(parent);
+        clr_picker = new wxBitmapButton(parent, wxID_ANY, {}, wxDefaultPosition, wxSize(2 * em, 2 * em), wxBU_EXACTFIT | wxBU_AUTODRAW | wxBORDER_NONE);
         clr_picker->SetBackgroundColour(StateColor::darkModeColorFor(*wxWHITE));
         clr_picker->SetToolTip(_L("Click to select filament color"));
 #ifdef __WXGTK__
@@ -1543,10 +1543,12 @@ void PlaterPresetComboBox::update()
 void PlaterPresetComboBox::msw_rescale()
 {
     PresetComboBox::msw_rescale();
-    SetMinSize({-1, 30 * m_em_unit / 10});
+    wxSize sz = wxSize(-1, SidebarProps::ComboHeightBig() * m_em_unit / 10);
+    SetMinSize(sz);
+    SetSize(sz);
 
     if (clr_picker)
-        clr_picker->SetSize(20 * m_em_unit / 10, 20 * m_em_unit / 10);
+        clr_picker->SetSize(2 * m_em_unit, 2 * m_em_unit);
     // BBS
     if (edit_btn != nullptr)
         edit_btn->msw_rescale();
@@ -1913,8 +1915,7 @@ void TabPresetComboBox::update()
 void TabPresetComboBox::msw_rescale()
 {
     PresetComboBox::msw_rescale();
-    // BBS: new layout
-    wxSize sz = wxSize(20 * m_em_unit, 30 * m_em_unit / 10);
+    wxSize sz = wxSize(-1, SidebarProps::ComboHeightBig() * m_em_unit / 10);
     SetMinSize(sz);
     SetSize(sz);
 }

--- a/src/slic3r/GUI/PresetComboBoxes.cpp
+++ b/src/slic3r/GUI/PresetComboBoxes.cpp
@@ -729,7 +729,7 @@ wxBitmap *PresetComboBox::get_bmp(Preset const &preset)
                 dc.SelectObject(*bmp);
         #else
                 wxMemoryDC dc;
-                dc.SelectObject(*bitmap);
+                dc.SelectObject(*bmp);
         #endif
                 dc.SetBackground(wxBrush(clr));
                 dc.Clear();

--- a/src/slic3r/GUI/PresetComboBoxes.cpp
+++ b/src/slic3r/GUI/PresetComboBoxes.cpp
@@ -837,7 +837,7 @@ bool PresetComboBox::selection_is_changed_according_to_physical_printers()
 // ---------------------------------
 
 PlaterPresetComboBox::PlaterPresetComboBox(wxWindow *parent, Preset::Type preset_type) :
-    PresetComboBox(parent, preset_type, wxSize(-1, SidebarProps::ComboHeightBig() * m_em_unit / 10))
+    PresetComboBox(parent, preset_type, wxSize(-1, SidebarProps::ComboHeightBig() * em_unit(parent) / 10))
 {
     GetDropDown().SetUseContentWidth(true,true);
 

--- a/src/slic3r/GUI/PresetComboBoxes.cpp
+++ b/src/slic3r/GUI/PresetComboBoxes.cpp
@@ -839,7 +839,10 @@ bool PresetComboBox::selection_is_changed_according_to_physical_printers()
 PlaterPresetComboBox::PlaterPresetComboBox(wxWindow *parent, Preset::Type preset_type) :
     PresetComboBox(parent, preset_type, wxSize(-1, SidebarProps::ComboHeightBig() * em_unit(parent) / 10))
 {
-    GetDropDown().SetUseContentWidth(true,true);
+    // ComboBox might not be created yet. dropdowns uses incorrect size if limit_max_content_width is true and GetParent()->GetSize() returns {0,0}
+    CallAfter([this]() {
+        GetDropDown().SetUseContentWidth(true, true);
+    });
 
     if (m_type == Preset::TYPE_FILAMENT)
     {

--- a/src/slic3r/GUI/PresetComboBoxes.cpp
+++ b/src/slic3r/GUI/PresetComboBoxes.cpp
@@ -1644,9 +1644,12 @@ void PlaterPresetComboBox::sync_colour_config(const std::vector<std::string> &cl
 
 TabPresetComboBox::TabPresetComboBox(wxWindow* parent, Preset::Type preset_type) :
     // BBS: new layout
-    PresetComboBox(parent, preset_type, wxSize(-1, SidebarProps::ComboHeightBig() * m_em_unit / 10))
+    PresetComboBox(parent, preset_type, wxSize(-1, SidebarProps::ComboHeightBig() * em_unit(parent) / 10))
 {
-    GetDropDown().SetUseContentWidth(true,true);
+    // ComboBox might not be created yet. dropdowns uses incorrect size if limit_max_content_width is true and GetParent()->GetSize() returns {0,0}
+    CallAfter([this]() {
+        GetDropDown().SetUseContentWidth(true, true);
+    });
 }
 
 void TabPresetComboBox::OnSelect(wxCommandEvent &evt)

--- a/src/slic3r/GUI/PresetComboBoxes.cpp
+++ b/src/slic3r/GUI/PresetComboBoxes.cpp
@@ -837,7 +837,7 @@ bool PresetComboBox::selection_is_changed_according_to_physical_printers()
 // ---------------------------------
 
 PlaterPresetComboBox::PlaterPresetComboBox(wxWindow *parent, Preset::Type preset_type) :
-    PresetComboBox(parent, preset_type, wxSize(-1, parent->FromDIP(SidebarProps::ComboHeightBig())))
+    PresetComboBox(parent, preset_type, wxSize(-1, SidebarProps::ComboHeightBig() * m_em_unit / 10))
 {
     GetDropDown().SetUseContentWidth(true,true);
 
@@ -1641,7 +1641,7 @@ void PlaterPresetComboBox::sync_colour_config(const std::vector<std::string> &cl
 
 TabPresetComboBox::TabPresetComboBox(wxWindow* parent, Preset::Type preset_type) :
     // BBS: new layout
-    PresetComboBox(parent, preset_type, wxSize(-1, parent->FromDIP(SidebarProps::ComboHeightBig())))
+    PresetComboBox(parent, preset_type, wxSize(-1, SidebarProps::ComboHeightBig() * m_em_unit / 10))
 {
     GetDropDown().SetUseContentWidth(true,true);
 }

--- a/src/slic3r/GUI/PresetComboBoxes.cpp
+++ b/src/slic3r/GUI/PresetComboBoxes.cpp
@@ -1540,10 +1540,10 @@ void PlaterPresetComboBox::update()
 void PlaterPresetComboBox::msw_rescale()
 {
     PresetComboBox::msw_rescale();
-    SetMinSize({-1, FromDIP(30)});
+    SetMinSize({-1, 30 * m_em_unit / 10});
 
     if (clr_picker)
-        clr_picker->SetSize(FromDIP(20), FromDIP(20));
+        clr_picker->SetSize(20 * m_em_unit / 10, 20 * m_em_unit / 10);
     // BBS
     if (edit_btn != nullptr)
         edit_btn->msw_rescale();
@@ -1908,7 +1908,7 @@ void TabPresetComboBox::msw_rescale()
 {
     PresetComboBox::msw_rescale();
     // BBS: new layout
-    wxSize sz = wxSize(20 * m_em_unit, FromDIP(30));
+    wxSize sz = wxSize(20 * m_em_unit, 30 * m_em_unit / 10);
     SetMinSize(sz);
     SetSize(sz);
 }

--- a/src/slic3r/GUI/PresetComboBoxes.cpp
+++ b/src/slic3r/GUI/PresetComboBoxes.cpp
@@ -714,19 +714,31 @@ wxBitmap *PresetComboBox::get_bmp(Preset const &preset)
         wxString color = preset2.config.opt_string("default_filament_colour", 0);
         wxColour clr(color);
         if (clr.IsOk()) {
-            std::string bitmap_key = "default_filament_colour_" + color.ToStdString();
+            const double em      = Slic3r::GUI::wxGetApp().em_unit();
+            const int    icon_sz = lround(1.5 * em);
+            std::string bitmap_key = "default_filament_colour_" + color.ToStdString() + "-h" + std::to_string(icon_sz) + "-w" + std::to_string(icon_sz);
             wxBitmap *bmp        = bitmap_cache().find(bitmap_key);
             if (bmp == nullptr) {
-                wxImage img(16, 16);
-                if (clr.Red() > 224 && clr.Blue() > 224 && clr.Green() > 224) {
-                    img.SetRGB(wxRect({0, 0}, img.GetSize()), 128, 128, 128);
-                    img.SetRGB(wxRect({1, 1}, img.GetSize() - wxSize{2, 2}), clr.Red(), clr.Green(), clr.Blue());
-                } else {
-                    img.SetRGB(wxRect({0, 0}, img.GetSize()), clr.Red(), clr.Green(), clr.Blue());
-                }
-                bmp = new wxBitmap(img);
-                bmp = bitmap_cache().insert(bitmap_key, *bmp);
+                bmp = bitmap_cache().insert(bitmap_key, wxBitmap(icon_sz, icon_sz));
+        #ifdef __WXOSX__
+                bmp->UseAlpha();
+                wxMemoryDC dc(*bmp);
+        #elif defined(__WXMSW__)
+                wxClientDC cdc(this);
+                wxMemoryDC dc(&cdc);
+                dc.SelectObject(*bmp);
+        #else
+                wxMemoryDC dc;
+                dc.SelectObject(*bitmap);
+        #endif
+                dc.SetBackground(wxBrush(clr));
+                dc.Clear();
+                dc.SetBrush(wxBrush(clr));
+                dc.SelectObject(wxNullBitmap);
             }
+            #ifdef __WXMSW__  // ORCA MSW needs to set scale factor for bitmaps loaded from cache because they arent auto scaled by wxBitmapBundle like bitmaps
+                bmp->SetScaleFactor(GetDPIScaleFactor());
+            #endif
             return bmp;
         }
     }

--- a/src/slic3r/GUI/PresetComboBoxes.cpp
+++ b/src/slic3r/GUI/PresetComboBoxes.cpp
@@ -1540,10 +1540,10 @@ void PlaterPresetComboBox::update()
 void PlaterPresetComboBox::msw_rescale()
 {
     PresetComboBox::msw_rescale();
-    SetMinSize({-1, 30 * m_em_unit / 10});
+    SetMinSize({-1, FromDIP(30)});
 
     if (clr_picker)
-        clr_picker->SetSize(20 * m_em_unit / 10, 20 * m_em_unit / 10);
+        clr_picker->SetSize(FromDIP(20), FromDIP(20));
     // BBS
     if (edit_btn != nullptr)
         edit_btn->msw_rescale();
@@ -1908,7 +1908,7 @@ void TabPresetComboBox::msw_rescale()
 {
     PresetComboBox::msw_rescale();
     // BBS: new layout
-    wxSize sz = wxSize(20 * m_em_unit, 30 * m_em_unit / 10);
+    wxSize sz = wxSize(20 * m_em_unit, FromDIP(30));
     SetMinSize(sz);
     SetSize(sz);
 }

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -238,7 +238,7 @@ void Tab::create_preset_tab()
     if (m_type < Preset::TYPE_COUNT) {
         // preset chooser
         m_presets_choice = new TabPresetComboBox(panel, m_type);
-        m_presets_choice->SetMinSize(wxSize(-1, SidebarProps::ComboHeightBig() * wxGetApp().em_unit() / 10));
+        m_presets_choice->SetMinSize(wxSize(-1, SidebarProps::ComboHeightBig() * m_em_unit / 10));
         // m_presets_choice->SetFont(Label::Body_10); // BBS
         m_presets_choice->set_selection_changed_function([this](int selection) {
             if (!m_presets_choice->selection_is_changed_according_to_physical_printers())
@@ -445,7 +445,7 @@ void Tab::create_preset_tab()
 
     m_top_sizer->AddSpacer(FromDIP(SidebarProps::ContentMargin()));
 
-    m_top_sizer->SetMinSize(-1, FromDIP(SidebarProps::TitlebarHeight()));
+    m_top_sizer->SetMinSize(-1, SidebarProps::TitlebarHeight() * m_em_unit / 10);
     m_top_panel->SetSizer(m_top_sizer);
     if (m_presets_choice)
         m_main_sizer->Add(m_top_panel, 0, wxEXPAND | wxUP | wxDOWN, FromDIP(SidebarProps::ContentMarginV()));
@@ -1591,7 +1591,7 @@ void Tab::msw_rescale()
     //if (m_mode_sizer)
     //    m_mode_sizer->msw_rescale();
     if (m_presets_choice){
-        m_presets_choice->SetMinSize(wxSize(-1, SidebarProps::ComboHeightBig() * wxGetApp().em_unit() / 10));
+        m_presets_choice->SetMinSize(wxSize(-1, SidebarProps::ComboHeightBig() * m_em_unit / 10));
         m_presets_choice->msw_rescale();
     }
 

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -238,6 +238,7 @@ void Tab::create_preset_tab()
     if (m_type < Preset::TYPE_COUNT) {
         // preset chooser
         m_presets_choice = new TabPresetComboBox(panel, m_type);
+        m_presets_choice->SetMinSize(wxSize(-1, SidebarProps::ComboHeightBig() * wxGetApp().em_unit() / 10));
         // m_presets_choice->SetFont(Label::Body_10); // BBS
         m_presets_choice->set_selection_changed_function([this](int selection) {
             if (!m_presets_choice->selection_is_changed_according_to_physical_printers())
@@ -316,7 +317,7 @@ void Tab::create_preset_tab()
     m_btn_search->SetToolTip(_L("Search in preset"));
 
     //search input
-    m_search_item = new StaticBox(m_top_panel, wxID_ANY, wxDefaultPosition, wxSize(-1, FromDIP(SidebarProps::ComboHeightBig()))); // ensure its size matches with combo box
+    m_search_item = new StaticBox(m_top_panel, wxID_ANY, wxDefaultPosition, wxSize(-1, SidebarProps::ComboHeightBig() * m_em_unit / 10)); // ensure its size matches with combo box
     StateColor box_colour(std::pair<wxColour, int>(*wxWHITE, StateColor::Normal));
     StateColor box_border_colour(std::pair<wxColour, int>(wxColour("#009688"), StateColor::Normal)); // ORCA match border color with other input/combo boxes
 
@@ -1584,13 +1585,15 @@ void Tab::msw_rescale()
 {
     m_em_unit = em_unit(m_parent);
 
-    m_top_sizer->SetMinSize(-1, FromDIP(SidebarProps::TitlebarHeight(), m_parent));
+    m_top_sizer->SetMinSize(-1, SidebarProps::TitlebarHeight() * m_em_unit / 10);
 
     //BBS: GUI refactor
     //if (m_mode_sizer)
     //    m_mode_sizer->msw_rescale();
-    if (m_presets_choice)
+    if (m_presets_choice){
+        m_presets_choice->SetMinSize(wxSize(-1, SidebarProps::ComboHeightBig() * wxGetApp().em_unit() / 10));
         m_presets_choice->msw_rescale();
+    }
 
     m_tabctrl->SetMinSize(wxSize(20 * m_em_unit, -1));
 
@@ -1614,7 +1617,7 @@ void Tab::msw_rescale()
         m_extruder_sync->msw_rescale();
 
     if (m_search_item){
-        m_search_item->SetSize(wxSize(-1, FromDIP(SidebarProps::ComboHeightBig(), m_parent))); // ensure height matches with preset combo
+        m_search_item->SetSize(wxSize(-1, SidebarProps::ComboHeightBig() * m_em_unit / 10)); // ensure height matches with preset combo
     }
     if (m_search_input){
         m_search_input->Rescale();

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -327,17 +327,13 @@ void Tab::create_preset_tab()
 
     //StateColor::darkModeColorFor(wxColour(238, 238, 238)), wxDefaultPosition, wxSize(m_top_panel->GetSize().GetWidth(), 3 * wxGetApp().em_unit()), 8);
     auto search_sizer = new wxBoxSizer(wxHORIZONTAL);
-    m_search_input = new TextInput(m_search_item, wxEmptyString, wxEmptyString, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 | wxBORDER_NONE);
+    m_search_input = new TextInput(m_search_item, wxEmptyString, wxEmptyString, "search", wxDefaultPosition, wxDefaultSize, 0 | wxBORDER_NONE);
     m_search_input->SetBackgroundColour(wxColour(238, 238, 238));
     m_search_input->SetForegroundColour(wxColour(43, 52, 54));
     m_search_input->SetFont(wxGetApp().bold_font());
-    m_search_input->SetIcon(*BitmapCache().load_svg("search", FromDIP(16), FromDIP(16)));
     m_search_input->GetTextCtrl()->SetHint(_L("Search in preset") + dots);
-    search_sizer->Add(new wxWindow(m_search_item, wxID_ANY, wxDefaultPosition, wxSize(0, 0)), 0, wxEXPAND|wxLEFT|wxRIGHT, FromDIP(2));
+    m_search_input->GetTextCtrl()->SetSize(wxSize(-1, FromDIP(16))); // Centers text vertically
     search_sizer->Add(m_search_input, 1, wxEXPAND | wxALL, FromDIP(2));
-    //bbl for linux
-    //search_sizer->Add(new wxWindow(m_search_input, wxID_ANY, wxDefaultPosition, wxSize(0, 0)), 0, wxEXPAND | wxLEFT, 16);
-
 
      m_search_item->Bind(wxEVT_LEFT_DOWN, [this](wxMouseEvent &e) {
         m_search_input->SetFocus();
@@ -1613,6 +1609,11 @@ void Tab::msw_rescale()
 
     if (m_detach_preset_btn)
         m_detach_preset_btn->msw_rescale();
+
+    if (m_search_input){
+        m_search_input->Rescale();
+        m_search_input->GetTextCtrl()->SetSize(wxSize(-1, FromDIP(16)));
+    }
 
     // rescale icons for tree_ctrl
     for (ScalableBitmap& bmp : m_scaled_icons_list)

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -316,7 +316,7 @@ void Tab::create_preset_tab()
     m_btn_search->SetToolTip(_L("Search in preset"));
 
     //search input
-    m_search_item = new StaticBox(m_top_panel, wxID_ANY, wxDefaultPosition, wxSize(-1, 3 * wxGetApp().em_unit())); // ensure its size matches with combo box
+    m_search_item = new StaticBox(m_top_panel, wxID_ANY, wxDefaultPosition, wxSize(-1, FromDIP(SidebarProps::ComboHeightBig()))); // ensure its size matches with combo box
     StateColor box_colour(std::pair<wxColour, int>(*wxWHITE, StateColor::Normal));
     StateColor box_border_colour(std::pair<wxColour, int>(wxColour("#009688"), StateColor::Normal)); // ORCA match border color with other input/combo boxes
 
@@ -444,7 +444,7 @@ void Tab::create_preset_tab()
 
     m_top_sizer->AddSpacer(FromDIP(SidebarProps::ContentMargin()));
 
-    m_top_sizer->SetMinSize(-1, 3 * m_em_unit);
+    m_top_sizer->SetMinSize(-1, FromDIP(SidebarProps::TitlebarHeight()));
     m_top_panel->SetSizer(m_top_sizer);
     if (m_presets_choice)
         m_main_sizer->Add(m_top_panel, 0, wxEXPAND | wxUP | wxDOWN, FromDIP(SidebarProps::ContentMarginV()));
@@ -1584,7 +1584,7 @@ void Tab::msw_rescale()
 {
     m_em_unit = em_unit(m_parent);
 
-    m_top_sizer->SetMinSize(-1, 3 * m_em_unit);
+    m_top_sizer->SetMinSize(-1, FromDIP(SidebarProps::TitlebarHeight(), m_parent));
 
     //BBS: GUI refactor
     //if (m_mode_sizer)
@@ -1614,7 +1614,7 @@ void Tab::msw_rescale()
         m_extruder_sync->msw_rescale();
 
     if (m_search_item){
-        m_search_item->SetSize(wxSize(-1, 3 * m_em_unit)); // ensure height matches with preset combo
+        m_search_item->SetSize(wxSize(-1, FromDIP(SidebarProps::ComboHeightBig(), m_parent))); // ensure height matches with preset combo
     }
     if (m_search_input){
         m_search_input->Rescale();

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -316,7 +316,7 @@ void Tab::create_preset_tab()
     m_btn_search->SetToolTip(_L("Search in preset"));
 
     //search input
-    m_search_item = new StaticBox(m_top_panel);
+    m_search_item = new StaticBox(m_top_panel, wxID_ANY, wxDefaultPosition, wxSize(-1, 3 * wxGetApp().em_unit())); // ensure its size matches with combo box
     StateColor box_colour(std::pair<wxColour, int>(*wxWHITE, StateColor::Normal));
     StateColor box_border_colour(std::pair<wxColour, int>(wxColour("#009688"), StateColor::Normal)); // ORCA match border color with other input/combo boxes
 
@@ -1610,6 +1610,9 @@ void Tab::msw_rescale()
     if (m_detach_preset_btn)
         m_detach_preset_btn->msw_rescale();
 
+    if (m_search_item){
+        m_search_item->SetSize(wxSize(-1, 3 * m_em_unit)); // ensure height matches with preset combo
+    }
     if (m_search_input){
         m_search_input->Rescale();
         m_search_input->GetTextCtrl()->SetSize(wxSize(-1, FromDIP(16)));

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -1610,6 +1610,9 @@ void Tab::msw_rescale()
     if (m_detach_preset_btn)
         m_detach_preset_btn->msw_rescale();
 
+    if (m_extruder_sync)
+        m_extruder_sync->msw_rescale();
+
     if (m_search_item){
         m_search_item->SetSize(wxSize(-1, 3 * m_em_unit)); // ensure height matches with preset combo
     }

--- a/src/slic3r/GUI/TabButton.cpp
+++ b/src/slic3r/GUI/TabButton.cpp
@@ -117,6 +117,7 @@ bool TabButton::Enable(bool enable)
 
 void TabButton::Rescale()
 {
+    StaticBox::Rescale();
     messureSize();
 }
 

--- a/src/slic3r/GUI/TabButton.hpp
+++ b/src/slic3r/GUI/TabButton.hpp
@@ -42,7 +42,7 @@ public:
 
     bool Enable(bool enable = true);
 
-    void Rescale();
+    void Rescale() override;
 
     void ShowNewTag(bool tag = false) {show_new_tag = tag; Refresh();};
     bool GetShowNewTag() const { return show_new_tag; };

--- a/src/slic3r/GUI/Widgets/Button.cpp
+++ b/src/slic3r/GUI/Widgets/Button.cpp
@@ -257,6 +257,8 @@ void Button::SetStyle(const ButtonStyle style, const ButtonType type)
 
 void Button::Rescale()
 {
+    StaticBox::Rescale();
+
     if (this->active_icon.bmp().IsOk())
         this->active_icon.msw_rescale();
 

--- a/src/slic3r/GUI/Widgets/Button.hpp
+++ b/src/slic3r/GUI/Widgets/Button.hpp
@@ -95,7 +95,7 @@ public:
 
     void SetVertical(bool vertical = true);
 
-    void Rescale();
+    void Rescale() override;
 
 protected:
 #ifdef __WIN32__

--- a/src/slic3r/GUI/Widgets/DropDown.cpp
+++ b/src/slic3r/GUI/Widgets/DropDown.cpp
@@ -157,8 +157,7 @@ void DropDown::SetAlignIcon(bool align) { align_icon = align; }
 
 void DropDown::Rescale()
 {
-    if (check_bitmap.bmp().IsOk())
-        check_bitmap.msw_rescale();
+    check_bitmap.msw_rescale();
     arrow_bitmap.msw_rescale();
     need_sync = true;
     messureSize();

--- a/src/slic3r/GUI/Widgets/DropDown.cpp
+++ b/src/slic3r/GUI/Widgets/DropDown.cpp
@@ -60,8 +60,8 @@ void DropDown::Create(wxWindow *parent, long style)
     state_handler.attach({&border_color, &text_color, &selector_border_color, &selector_background_color});
     state_handler.update_binds();
     if ((style & DD_NO_CHECK_ICON) == 0)
-        check_bitmap = ScalableBitmap(this, "checked", 16);
-    arrow_bitmap = ScalableBitmap(this, "hms_arrow", 16);
+        check_bitmap = ScalableBitmap(parent, "checked", 16); // use parent window for proper scaling info in here since popup is a temporary window
+    arrow_bitmap = ScalableBitmap(parent, "hms_arrow", 16);
     text_off = style & DD_NO_TEXT;
 
     // BBS set default font
@@ -157,7 +157,12 @@ void DropDown::SetAlignIcon(bool align) { align_icon = align; }
 
 void DropDown::Rescale()
 {
+    if (check_bitmap.bmp().IsOk())
+        check_bitmap.msw_rescale();
+    arrow_bitmap.msw_rescale();
     need_sync = true;
+    messureSize();
+    paintNow();
 }
 
 bool DropDown::HasDismissLongTime()

--- a/src/slic3r/GUI/Widgets/DropDown.cpp
+++ b/src/slic3r/GUI/Widgets/DropDown.cpp
@@ -157,7 +157,8 @@ void DropDown::SetAlignIcon(bool align) { align_icon = align; }
 
 void DropDown::Rescale()
 {
-    check_bitmap.msw_rescale();
+    if(!check_bitmap.name().empty())
+        check_bitmap.msw_rescale();
     arrow_bitmap.msw_rescale();
     need_sync = true;
     messureSize();

--- a/src/slic3r/GUI/Widgets/DropDown.cpp
+++ b/src/slic3r/GUI/Widgets/DropDown.cpp
@@ -520,19 +520,21 @@ void DropDown::messureSize()
     std::set<wxString> groups;
     for (size_t i = 0; i < items.size(); ++i) {
         auto &item = items[i];
-        // Skip by group
+        // measure every item's label width, but only count rows once
+        bool counted = true;
         if (group.IsEmpty()) {
             if (!item.group_key.IsEmpty()) {
                 if (groups.find(item.group_key) == groups.end())
                     groups.insert(item.group_key);
-                else
-                    continue;
+                else // duplicate group row — don't count it as an extra visible row, but still measure it below
+                    counted = false;
             }
         } else {
             if (item.group_key != group)
                 continue;
         }
-        ++count;
+        if (counted) ++count;
+
         wxSize size1;
         if (!text_off) {
             auto text = group.IsEmpty()

--- a/src/slic3r/GUI/Widgets/DropDown.cpp
+++ b/src/slic3r/GUI/Widgets/DropDown.cpp
@@ -520,21 +520,19 @@ void DropDown::messureSize()
     std::set<wxString> groups;
     for (size_t i = 0; i < items.size(); ++i) {
         auto &item = items[i];
-        // measure every item's label width, but only count rows once
-        bool counted = true;
+        // Skip by group
         if (group.IsEmpty()) {
             if (!item.group_key.IsEmpty()) {
                 if (groups.find(item.group_key) == groups.end())
                     groups.insert(item.group_key);
-                else // duplicate group row — don't count it as an extra visible row, but still measure it below
-                    counted = false;
+                else
+                    continue;
             }
         } else {
             if (item.group_key != group)
                 continue;
         }
-        if (counted) ++count;
-
+        ++count;
         wxSize size1;
         if (!text_off) {
             auto text = group.IsEmpty()

--- a/src/slic3r/GUI/Widgets/ImageSwitchButton.cpp
+++ b/src/slic3r/GUI/Widgets/ImageSwitchButton.cpp
@@ -144,6 +144,7 @@ void ImageSwitchButton::render(wxDC& dc)
 
 void ImageSwitchButton::Rescale()
 {
+    StaticBox::Rescale();
 	messureSize();
 }
 
@@ -345,6 +346,7 @@ void FanSwitchButton::render(wxDC& dc)
 
 void FanSwitchButton::Rescale()
 {
+    StaticBox::Rescale();
     messureSize();
 }
 

--- a/src/slic3r/GUI/Widgets/ImageSwitchButton.hpp
+++ b/src/slic3r/GUI/Widgets/ImageSwitchButton.hpp
@@ -21,7 +21,7 @@ public:
 	void SetPadding(int padding);
 
 	bool GetValue() { return m_on_off; }
-	void Rescale();
+	void Rescale() override;
 
 private:
     void messureSize();
@@ -61,7 +61,7 @@ public:
     void SetPadding(int padding);
 
     bool GetValue() { return m_on_off; }
-    void Rescale();
+    void Rescale() override;
     void setFanValue(int val);
 
     void UseTextFan();

--- a/src/slic3r/GUI/Widgets/LabeledStaticBox.cpp
+++ b/src/slic3r/GUI/Widgets/LabeledStaticBox.cpp
@@ -9,7 +9,7 @@ LabeledStaticBox::LabeledStaticBox()
 {
     m_radius       = 3;
     m_border_width = 1;
-    m_font         = Label::Head_14;
+    SetFont(Label::Head_14);
     text_color = StateColor(
         std::make_pair(0x363636, (int) StateColor::Normal),
         std::make_pair(0x6B6B6B, (int) StateColor::Disabled)
@@ -52,18 +52,13 @@ bool LabeledStaticBox::Create(
 #endif
 
     m_label = label;
-    m_scale = FromDIP(100) / 100.f;
     m_pos   = this->GetPosition();
 
-    int tW,tH,descent,externalLeading;
-    // empty label sets m_label_height as 0 that causes extra spacing at top
-    GetTextExtent(m_label.IsEmpty() ? "Orca" : m_label, &tW, &tH, &descent, &externalLeading, &m_font);
-    m_label_height = tH - externalLeading;
-    m_label_width  = tW;
+    update_label_size();
 
-    Bind(wxEVT_PAINT,([this](wxPaintEvent e) {
-        wxPaintDC dc(this);
-        PickDC(dc);
+    Bind(wxEVT_PAINT,([this](wxPaintEvent& e) {
+        wxAutoBufferedPaintDC dc(this);
+        DrawBorderAndLabel(dc);
     }));
 
     state_handler.attach({&text_color, &background_color, &border_color});
@@ -77,6 +72,15 @@ bool LabeledStaticBox::Create(
     SetCanFocus(false);
     DisableFocusFromKeyboard();
     return true;
+}
+
+void LabeledStaticBox::update_label_size()
+{
+    int tW,tH,descent,externalLeading;
+    // empty label sets m_label_height as 0 that causes extra spacing at top
+    GetTextExtent(m_label.IsEmpty() ? "Orca" : m_label, &tW, &tH, &descent, &externalLeading);
+    m_label_height = tH - externalLeading;
+    m_label_width  = tW;
 }
 
 void LabeledStaticBox::SetCornerRadius(int radius)
@@ -98,19 +102,6 @@ void LabeledStaticBox::SetBorderColor(StateColor const &color)
     Refresh();
 }
 
-void LabeledStaticBox::SetFont(wxFont set_font)
-{
-    m_font = set_font;
-
-    int tW,tH,descent,externalLeading;
-    // empty label sets m_label_height as 0 that causes extra spacing at top
-    GetTextExtent(m_label.IsEmpty() ? "Orca" : m_label, &tW, &tH, &descent, &externalLeading, &m_font);
-    m_label_height = tH - externalLeading;
-    m_label_width  = tW;
-
-    Refresh();
-}
-
 bool LabeledStaticBox::Enable(bool enable)
 {
     bool result = this->wxStaticBox::Enable(enable);
@@ -124,72 +115,34 @@ bool LabeledStaticBox::Enable(bool enable)
     return result;
 }
 
-void LabeledStaticBox::PickDC(wxDC& dc)
-{
-#ifdef __WXMSW__
-    wxSize size = GetSize();
-    if (size.x <= 0 || size.y <= 0)
-        return;
-    wxMemoryDC memdc(&dc);
-    if (!memdc.IsOk()) {
-        DrawBorderAndLabel(dc);
-        return;
-    }
-    wxBitmap bmp(size.x, size.y);
-    memdc.SelectObject(bmp);
-    memdc.SetBackground(wxBrush(GetBackgroundColour()));
-    memdc.Clear();
-    {
-        wxGCDC dc2(memdc);
-        DrawBorderAndLabel(dc2);
-    }
-
-    memdc.SelectObject(wxNullBitmap);
-    dc.DrawBitmap(bmp, 0, 0);
-#else
-    DrawBorderAndLabel(dc);
-#endif
-}
-
 void LabeledStaticBox::DrawBorderAndLabel(wxDC& dc)
 {
     // fill full background
     dc.SetBackground(wxBrush(background_color.colorForStates(0)));
     dc.Clear();
 
+    update_label_size();
+
     wxSize wSz = GetSize();
-
-    int tW = 0;
-    int tH = 0;
-
-    if (!m_label.IsEmpty()) {
-        #ifdef __WXMSW__ 
-            dc.SetFont(m_font.Scaled(m_parent->GetDPIScaleFactor()));
-        #else
-            dc.SetFont(m_font);
-        #endif
-        wxSize textSize = dc.GetTextExtent(m_label);
-        tW = textSize.GetWidth();
-        tH = textSize.GetHeight();
-    }
 
     dc.SetBrush(*wxTRANSPARENT_BRUSH);
     dc.SetPen(wxPen(border_color.colorForStates(state_handler.states()), m_border_width, wxPENSTYLE_SOLID));
     dc.DrawRoundedRectangle( // Border
         std::max(0, m_pos.x),
-        std::max(0, m_pos.y) + tH * .5,
+        std::max(0, m_pos.y) + m_label_height * .5,
         wSz.GetWidth(),
-        wSz.GetHeight() - tH * .5,
+        wSz.GetHeight() - m_label_height * .5,
         m_radius
     );
 
     if (!m_label.IsEmpty()) {
+        dc.SetFont(GetFont());
         dc.SetPen(*wxTRANSPARENT_PEN);
         dc.SetBrush(wxBrush(background_color.colorForStates(0)));
-        dc.DrawRectangle(wxRect(7 * m_scale,0 , tW + 7 * m_scale, tH)); // text background
+        dc.DrawRectangle(wxRect(FromDIP(7) ,0 , m_label_width + FromDIP(7), m_label_height)); // text background
         // NEEDFIX if text lenght > client size 
         dc.SetTextForeground(text_color.colorForStates(state_handler.states()));
-        dc.DrawText(m_label, wxPoint(10 * m_scale, 0));
+        dc.DrawText(m_label, FromDIP(wxPoint(10, 0)));
     }
 }
 

--- a/src/slic3r/GUI/Widgets/LabeledStaticBox.cpp
+++ b/src/slic3r/GUI/Widgets/LabeledStaticBox.cpp
@@ -180,7 +180,7 @@ void LabeledStaticBox::DrawBorderAndLabel(wxDC& dc)
         std::max(0, m_pos.y) + tH * .5,
         wSz.GetWidth(),
         wSz.GetHeight() - tH * .5,
-        m_radius * m_scale
+        m_radius
     );
 
     if (!m_label.IsEmpty()) {

--- a/src/slic3r/GUI/Widgets/LabeledStaticBox.cpp
+++ b/src/slic3r/GUI/Widgets/LabeledStaticBox.cpp
@@ -158,7 +158,6 @@ void LabeledStaticBox::DrawBorderAndLabel(wxDC& dc)
     dc.Clear();
 
     wxSize wSz = GetSize();
-    m_scale = FromDIP(100) / 100.f;
 
     int tW = 0;
     int tH = 0;

--- a/src/slic3r/GUI/Widgets/LabeledStaticBox.cpp
+++ b/src/slic3r/GUI/Widgets/LabeledStaticBox.cpp
@@ -52,7 +52,11 @@ bool LabeledStaticBox::Create(
 #endif
 
     m_label = label;
-    m_scale = FromDIP(100) / 100.f;
+    #if defined(__WXMSW__)
+        m_scale = parent->GetDPIScaleFactor();
+    #else
+        m_scale = FromDIP(100) / 100.f;
+    #endif
     m_pos   = this->GetPosition();
 
     int tW,tH,descent,externalLeading;
@@ -158,6 +162,11 @@ void LabeledStaticBox::DrawBorderAndLabel(wxDC& dc)
     dc.Clear();
 
     wxSize wSz = GetSize();
+    #if defined(__WXMSW__)
+        m_scale = m_parent->GetDPIScaleFactor();
+    #else
+        m_scale = FromDIP(100) / 100.f;
+    #endif
 
     dc.SetBrush(*wxTRANSPARENT_BRUSH);
     dc.SetPen(wxPen(border_color.colorForStates(state_handler.states()), m_border_width, wxPENSTYLE_SOLID));
@@ -170,7 +179,11 @@ void LabeledStaticBox::DrawBorderAndLabel(wxDC& dc)
     );
 
     if (!m_label.IsEmpty()) {
-        dc.SetFont(m_font);
+        #ifdef __WXMSW__ 
+            dc.SetFont(m_font.Scaled(m_scale));
+        #else
+            dc.SetFont(m_font);
+        #endif
         dc.SetPen(*wxTRANSPARENT_PEN);
         dc.SetBrush(wxBrush(background_color.colorForStates(0)));
         dc.DrawRectangle(wxRect(7 * m_scale,0 , m_label_width + 7 * m_scale, m_label_height)); // text background

--- a/src/slic3r/GUI/Widgets/LabeledStaticBox.cpp
+++ b/src/slic3r/GUI/Widgets/LabeledStaticBox.cpp
@@ -168,15 +168,8 @@ void LabeledStaticBox::DrawBorderAndLabel(wxDC& dc)
         m_scale = FromDIP(100) / 100.f;
     #endif
 
-    dc.SetBrush(*wxTRANSPARENT_BRUSH);
-    dc.SetPen(wxPen(border_color.colorForStates(state_handler.states()), m_border_width, wxPENSTYLE_SOLID));
-    dc.DrawRoundedRectangle( // Border
-        std::max(0, m_pos.x),
-        std::max(0, m_pos.y) + m_label_height * .5,
-        wSz.GetWidth(),
-        wSz.GetHeight() - m_label_height * .5,
-        m_radius * m_scale
-    );
+    int tW = 0;
+    int tH = 0;
 
     if (!m_label.IsEmpty()) {
         #ifdef __WXMSW__ 
@@ -184,9 +177,25 @@ void LabeledStaticBox::DrawBorderAndLabel(wxDC& dc)
         #else
             dc.SetFont(m_font);
         #endif
+        wxSize textSize = dc.GetTextExtent(m_label);
+        tW = textSize.GetWidth();
+        tH = textSize.GetHeight();
+    }
+
+    dc.SetBrush(*wxTRANSPARENT_BRUSH);
+    dc.SetPen(wxPen(border_color.colorForStates(state_handler.states()), m_border_width, wxPENSTYLE_SOLID));
+    dc.DrawRoundedRectangle( // Border
+        std::max(0, m_pos.x),
+        std::max(0, m_pos.y) + tH * .5,
+        wSz.GetWidth(),
+        wSz.GetHeight() - tH * .5,
+        m_radius * m_scale
+    );
+
+    if (!m_label.IsEmpty()) {
         dc.SetPen(*wxTRANSPARENT_PEN);
         dc.SetBrush(wxBrush(background_color.colorForStates(0)));
-        dc.DrawRectangle(wxRect(7 * m_scale,0 , m_label_width + 7 * m_scale, m_label_height)); // text background
+        dc.DrawRectangle(wxRect(7 * m_scale,0 , tW + 7 * m_scale, tH)); // text background
         // NEEDFIX if text lenght > client size 
         dc.SetTextForeground(text_color.colorForStates(state_handler.states()));
         dc.DrawText(m_label, wxPoint(10 * m_scale, 0));

--- a/src/slic3r/GUI/Widgets/LabeledStaticBox.cpp
+++ b/src/slic3r/GUI/Widgets/LabeledStaticBox.cpp
@@ -162,18 +162,14 @@ void LabeledStaticBox::DrawBorderAndLabel(wxDC& dc)
     dc.Clear();
 
     wxSize wSz = GetSize();
-    #if defined(__WXMSW__)
-        m_scale = m_parent->GetDPIScaleFactor();
-    #else
-        m_scale = FromDIP(100) / 100.f;
-    #endif
+    m_scale = FromDIP(100) / 100.f;
 
     int tW = 0;
     int tH = 0;
 
     if (!m_label.IsEmpty()) {
         #ifdef __WXMSW__ 
-            dc.SetFont(m_font.Scaled(m_scale));
+            dc.SetFont(m_font.Scaled(m_parent->GetDPIScaleFactor()));
         #else
             dc.SetFont(m_font);
         #endif

--- a/src/slic3r/GUI/Widgets/LabeledStaticBox.cpp
+++ b/src/slic3r/GUI/Widgets/LabeledStaticBox.cpp
@@ -52,11 +52,7 @@ bool LabeledStaticBox::Create(
 #endif
 
     m_label = label;
-    #if defined(__WXMSW__)
-        m_scale = parent->GetDPIScaleFactor();
-    #else
-        m_scale = FromDIP(100) / 100.f;
-    #endif
+    m_scale = FromDIP(100) / 100.f;
     m_pos   = this->GetPosition();
 
     int tW,tH,descent,externalLeading;

--- a/src/slic3r/GUI/Widgets/LabeledStaticBox.cpp
+++ b/src/slic3r/GUI/Widgets/LabeledStaticBox.cpp
@@ -74,13 +74,18 @@ bool LabeledStaticBox::Create(
     return true;
 }
 
-void LabeledStaticBox::update_label_size()
+void LabeledStaticBox::calc_label_size(int& w, int& h) const
 {
     int tW,tH,descent,externalLeading;
     // empty label sets m_label_height as 0 that causes extra spacing at top
     GetTextExtent(m_label.IsEmpty() ? "Orca" : m_label, &tW, &tH, &descent, &externalLeading);
-    m_label_height = tH - externalLeading;
-    m_label_width  = tW;
+    h = tH - externalLeading;
+    w = tW;
+}
+
+void LabeledStaticBox::update_label_size()
+{
+    calc_label_size(m_label_width, m_label_height);
 }
 
 void LabeledStaticBox::SetCornerRadius(int radius)
@@ -148,6 +153,11 @@ void LabeledStaticBox::DrawBorderAndLabel(wxDC& dc)
 
 void LabeledStaticBox::GetBordersForSizer(int* borderTop, int* borderOther) const {
     wxStaticBox::GetBordersForSizer(borderTop, borderOther);
+#ifdef __WXMSW__
+    int lw, lh;
+    calc_label_size(lw, lh);
+    *borderTop = lh;
+#endif
 #ifdef __WXOSX__
     *borderOther = 5; // Make sure macOS uses the same border padding as other platforms
 #endif

--- a/src/slic3r/GUI/Widgets/LabeledStaticBox.cpp
+++ b/src/slic3r/GUI/Widgets/LabeledStaticBox.cpp
@@ -58,7 +58,12 @@ bool LabeledStaticBox::Create(
 
     Bind(wxEVT_PAINT,([this](wxPaintEvent& e) {
         wxAutoBufferedPaintDC dc(this);
+#ifdef __WXMSW__
+        wxGCDC gdc(dc);
+        DrawBorderAndLabel(gdc);
+#else
         DrawBorderAndLabel(dc);
+#endif
     }));
 
     state_handler.attach({&text_color, &background_color, &border_color});

--- a/src/slic3r/GUI/Widgets/LabeledStaticBox.hpp
+++ b/src/slic3r/GUI/Widgets/LabeledStaticBox.hpp
@@ -42,8 +42,6 @@ public:
 
     void SetBorderColor(StateColor const &color);
 
-    void SetFont(wxFont set_font);
-
     bool Enable(bool enable) override;
 
     // Only meant to be used by inspector, not public API
@@ -53,7 +51,7 @@ public:
     float      GetScale() const        { return m_scale; }
 
 private:
-    void PickDC(wxDC& dc);
+    void update_label_size();
 
 protected:
     StateHandler state_handler;
@@ -62,11 +60,9 @@ protected:
     StateColor   background_color;
     int          m_border_width;
     int          m_radius;
-    wxFont       m_font;
     wxString     m_label;
     int          m_label_height;
     int          m_label_width;
-    float        m_scale;
     wxPoint      m_pos;
 
     virtual void DrawBorderAndLabel(wxDC& dc);

--- a/src/slic3r/GUI/Widgets/LabeledStaticBox.hpp
+++ b/src/slic3r/GUI/Widgets/LabeledStaticBox.hpp
@@ -48,7 +48,6 @@ public:
     int        GetCornerRadius() const { return m_radius; }
     int        GetBorderWidth() const  { return m_border_width; }
     StateColor GetBorderColor() const  { return border_color; }
-    float      GetScale() const        { return m_scale; }
 
 private:
     void calc_label_size(int& w, int& h) const;

--- a/src/slic3r/GUI/Widgets/LabeledStaticBox.hpp
+++ b/src/slic3r/GUI/Widgets/LabeledStaticBox.hpp
@@ -51,6 +51,7 @@ public:
     float      GetScale() const        { return m_scale; }
 
 private:
+    void calc_label_size(int& w, int& h) const;
     void update_label_size();
 
 protected:

--- a/src/slic3r/GUI/Widgets/RadioGroup.cpp
+++ b/src/slic3r/GUI/Widgets/RadioGroup.cpp
@@ -106,6 +106,11 @@ void RadioGroup::Create(
     }
     SetSelection(m_selectedIndex);
     SetSizer(f_sizer);
+
+    parent->Bind(wxEVT_DPI_CHANGED, [this](wxDPIChangedEvent e) {
+        for (size_t i = 0; i < m_item_count; ++i)
+            m_labelButtons[i]->Rescale();
+    });
 }
 
 void RadioGroup::SetSelection(int index, bool focus)

--- a/src/slic3r/GUI/Widgets/RadioGroup.cpp
+++ b/src/slic3r/GUI/Widgets/RadioGroup.cpp
@@ -107,10 +107,6 @@ void RadioGroup::Create(
     SetSelection(m_selectedIndex);
     SetSizer(f_sizer);
 
-    parent->Bind(wxEVT_DPI_CHANGED, [this](wxDPIChangedEvent e) {
-        for (size_t i = 0; i < m_item_count; ++i)
-            m_labelButtons[i]->Rescale();
-    });
 }
 
 void RadioGroup::SetSelection(int index, bool focus)
@@ -172,6 +168,25 @@ bool RadioGroup::Enable(bool enable)
     }
 
     return result;
+};
+
+void RadioGroup::Rescale()
+{
+    m_on.msw_rescale();
+    m_off.msw_rescale();
+    m_on_hover.msw_rescale();
+    m_off_hover.msw_rescale();
+    m_disabled.msw_rescale();
+    for (size_t i = 0; i < m_item_count; ++i)
+        SetRadioIcon(i, i == m_selectedIndex);
+    for (size_t i = 0; i < m_item_count; ++i){
+        auto tx =  m_labelButtons[i];
+        tx->SetPaddingSize(FromDIP(wxSize(5,2)));
+        tx->SetBorderWidth(FromDIP(1));
+        tx->Rescale();
+    }
+    Layout();
+    Refresh();
 };
 
 // is focused

--- a/src/slic3r/GUI/Widgets/RadioGroup.hpp
+++ b/src/slic3r/GUI/Widgets/RadioGroup.hpp
@@ -46,6 +46,8 @@ public:
 
     bool Disable();
 
+    void Rescale();
+
     void SetRadioTooltip(int i, wxString tooltip);
 
 private:

--- a/src/slic3r/GUI/Widgets/StaticBox.cpp
+++ b/src/slic3r/GUI/Widgets/StaticBox.cpp
@@ -129,6 +129,11 @@ void StaticBox::ShowBadge(bool show)
     }
 }
 
+void StaticBox::Rescale()
+{
+    badge.msw_rescale();
+}
+
 void StaticBox::eraseEvent(wxEraseEvent& evt)
 {
     // for transparent background, but not work

--- a/src/slic3r/GUI/Widgets/StaticBox.hpp
+++ b/src/slic3r/GUI/Widgets/StaticBox.hpp
@@ -43,7 +43,7 @@ public:
 
     void ShowBadge(bool show);
 
-    void Rescale();
+    virtual void Rescale();
 
 protected:
     void eraseEvent(wxEraseEvent& evt);

--- a/src/slic3r/GUI/Widgets/StaticBox.hpp
+++ b/src/slic3r/GUI/Widgets/StaticBox.hpp
@@ -43,6 +43,8 @@ public:
 
     void ShowBadge(bool show);
 
+    void Rescale();
+
 protected:
     void eraseEvent(wxEraseEvent& evt);
 

--- a/src/slic3r/GUI/Widgets/StaticGroup.cpp
+++ b/src/slic3r/GUI/Widgets/StaticGroup.cpp
@@ -18,6 +18,11 @@ void StaticGroup::ShowBadge(bool show)
     }
 }
 
+void StaticGroup::Rescale()
+{
+    badge.msw_rescale();
+}
+
 void StaticGroup::DrawBorderAndLabel(wxDC& dc)
 {
     LabeledStaticBox::DrawBorderAndLabel(dc);

--- a/src/slic3r/GUI/Widgets/StaticGroup.hpp
+++ b/src/slic3r/GUI/Widgets/StaticGroup.hpp
@@ -11,6 +11,9 @@ public:
     StaticGroup(wxWindow *parent, wxWindowID id, const wxString &label);
     void ShowBadge(bool show);
 
+protected:
+    virtual void Rescale();
+
 private:
     void DrawBorderAndLabel(wxDC& dc) override;
     ScalableBitmap badge;

--- a/src/slic3r/GUI/Widgets/StepCtrl.cpp
+++ b/src/slic3r/GUI/Widgets/StepCtrl.cpp
@@ -133,6 +133,7 @@ StepCtrl::StepCtrl(wxWindow *parent, wxWindowID id, const wxPoint &pos, const wx
 
 void StepCtrl::Rescale()
 {
+    StepCtrlBase::Rescale();
     bmp_thumb.msw_rescale();
     radius    = radius * bmp_thumb.GetBmpHeight() / 36;
     bar_width = bar_width * bmp_thumb.GetBmpHeight() / 36;
@@ -272,6 +273,7 @@ StepIndicator::StepIndicator(wxWindow *parent, wxWindowID id, const wxPoint &pos
 
 void StepIndicator::Rescale()
 {
+    StepCtrlBase::Rescale();
     bmp_ok.msw_rescale();
     radius    = bmp_ok.GetBmpHeight() / 2;
     bar_width = bmp_ok.GetBmpHeight() / 20;
@@ -381,6 +383,7 @@ FilamentStepIndicator::FilamentStepIndicator(wxWindow* parent, wxWindowID id, co
 
 void FilamentStepIndicator::Rescale()
 {
+    StepCtrlBase::Rescale();
     bmp_ok.msw_rescale();
     radius = bmp_ok.GetBmpHeight() / 2;
     bar_width = bmp_ok.GetBmpHeight() / 20;

--- a/src/slic3r/GUI/Widgets/StepCtrl.hpp
+++ b/src/slic3r/GUI/Widgets/StepCtrl.hpp
@@ -72,7 +72,7 @@ public:
              const wxSize &  size      = wxDefaultSize,
              long            style     = 0);
 
-    virtual void Rescale();
+    virtual void Rescale() override;
 
 private:
     void mouseDown(wxMouseEvent &event);
@@ -96,7 +96,7 @@ public:
              const wxSize &  size      = wxDefaultSize,
              long            style     = 0);
 
-    virtual void Rescale();
+    virtual void Rescale() override;
 
     void SelectNext();
 private:
@@ -118,7 +118,7 @@ public:
         const wxSize& size = wxDefaultSize,
         long            style = 0);
 
-    virtual void Rescale();
+    virtual void Rescale() override;
 
     void SelectNext();
     void SetSlotInformation(wxString slot);

--- a/src/slic3r/GUI/Widgets/SwitchButton.cpp
+++ b/src/slic3r/GUI/Widgets/SwitchButton.cpp
@@ -640,7 +640,7 @@ MultiSwitchButton::MultiSwitchButton(wxWindow *parent, wxWindowID id, const wxPo
     , m_button_radius(10.0)
     , m_button_padding(10, 6)
 {
-    SetCornerRadius(m_button_radius);
+    SetCornerRadius(parent->FromDIP(m_button_radius));
     SetBorderWidth(0);
 
     sizer = new wxBoxSizer(wxHORIZONTAL);
@@ -665,15 +665,15 @@ int MultiSwitchButton::AppendOption(const wxString &option, void *clientData)
     btn->SetFont(GetFont());
     btn->SetBackgroundColor(m_bg_color);
     btn->SetTextColor(m_text_color);
-    btn->SetCornerRadius(m_button_radius);
-    btn->SetPaddingSize(m_button_padding);
+    btn->SetCornerRadius(m_parent->FromDIP(m_button_radius));
+    btn->SetPaddingSize(m_parent->FromDIP(m_button_padding));
     btn->SetClientData(clientData);
 
     btns.push_back(btn);
     sizer->Add(btn, 1, wxEXPAND | wxALIGN_CENTER_VERTICAL);
 
     wxSize text_size = btn->GetTextExtent(option);
-    btn->SetMinSize(wxSize(text_size.x + m_button_padding.x * 2 + 6, -1));
+    btn->SetMinSize(wxSize(text_size.x + (m_parent->FromDIP(m_button_padding)).x * 2 + 6, -1));
 
     return int(btns.size()) - 1;
 }
@@ -774,10 +774,10 @@ void MultiSwitchButton::SetTextColor(const StateColor &color)
 
 void MultiSwitchButton::SetButtonCornerRadius(double radius)
 {
-    m_button_radius = radius;
-    SetCornerRadius(radius);
+    m_button_radius = m_parent->FromDIP(radius);
+    SetCornerRadius(m_button_radius);
     for (auto *btn : btns)
-        btn->SetCornerRadius(radius);
+        btn->SetCornerRadius(m_button_radius);
     Layout();
     Refresh();
 }
@@ -793,8 +793,11 @@ void MultiSwitchButton::SetButtonPadding(const wxSize &padding)
 
 void MultiSwitchButton::Rescale()
 {
-    for (auto *btn : btns)
+    for (auto *btn : btns){
         btn->Rescale();
+        btn->SetCornerRadius(m_parent->FromDIP(m_button_radius));
+        btn->SetPaddingSize(m_parent->FromDIP(m_button_padding));
+    }
 }
 
 void MultiSwitchButton::button_clicked(wxCommandEvent &event)

--- a/src/slic3r/GUI/Widgets/SwitchButton.cpp
+++ b/src/slic3r/GUI/Widgets/SwitchButton.cpp
@@ -646,7 +646,7 @@ MultiSwitchButton::MultiSwitchButton(wxWindow *parent, wxWindowID id, const wxPo
     auto *hsizer = new wxBoxSizer(wxVERTICAL);
     hsizer->Add(sizer, 1, wxEXPAND);
     SetSizer(hsizer);
-    SetMinSize(wxSize(-1, 20));
+    SetMinSize(parent->FromDIP(wxSize(-1, 20)));
 
     Bind(wxEVT_COMMAND_BUTTON_CLICKED, &MultiSwitchButton::button_clicked, this);
     SetFont(Label::Body_12);
@@ -797,6 +797,7 @@ void MultiSwitchButton::Rescale()
         btn->SetCornerRadius(m_parent->FromDIP(m_button_radius));
         btn->SetPaddingSize(m_parent->FromDIP(m_button_padding));
     }
+    SetMinSize(GetParent()->FromDIP(wxSize(-1, 20)));
 }
 
 void MultiSwitchButton::button_clicked(wxCommandEvent &event)

--- a/src/slic3r/GUI/Widgets/SwitchButton.cpp
+++ b/src/slic3r/GUI/Widgets/SwitchButton.cpp
@@ -290,6 +290,7 @@ void ModeSwitchButton::SelectAndNotify(int selection)
 
 void ModeSwitchButton::Rescale()
 {
+    StaticBox::Rescale();
     const wxSize button_size = FromDIP(wxSize(48, 18));
     SetMinSize(button_size);
     SetMaxSize(button_size);
@@ -792,6 +793,7 @@ void MultiSwitchButton::SetButtonPadding(const wxSize &padding)
 
 void MultiSwitchButton::Rescale()
 {
+    StaticBox::Rescale();
     for (auto *btn : btns){
         btn->Rescale();
         btn->SetCornerRadius(m_parent->FromDIP(m_button_radius));

--- a/src/slic3r/GUI/Widgets/SwitchButton.cpp
+++ b/src/slic3r/GUI/Widgets/SwitchButton.cpp
@@ -139,18 +139,17 @@ void SwitchButton::Rescale()
 			}
 		}
 		for (int i = 0; i < 2; ++i) {
-			wxMemoryDC memdc(&dc);
-#ifdef __WXMSW__
-			wxBitmap bmp(trackSize.x, trackSize.y);
-			memdc.SelectObject(bmp);
-			memdc.SetBackground(wxBrush(GetBackgroundColour()));
-			memdc.Clear();
-#else
+            wxMemoryDC memdc(&dc);
             wxImage image(trackSize);
+#ifndef __WXMSW__ // DrawText doesn't work properly on Windows with Alpha channel
             image.InitAlpha();
             memset(image.GetAlpha(), 0, trackSize.GetWidth() * trackSize.GetHeight());
+#endif
             wxBitmap bmp(std::move(image));
             memdc.SelectObject(bmp);
+#ifdef __WXMSW__
+            memdc.SetBackground(wxBrush(GetBackgroundColour()));
+            memdc.Clear();
 #endif
             memdc.SetFont(dc.GetFont());
 #ifdef __WXMSW__

--- a/src/slic3r/GUI/Widgets/SwitchButton.cpp
+++ b/src/slic3r/GUI/Widgets/SwitchButton.cpp
@@ -380,12 +380,9 @@ void ModeSwitchButton::doRender(wxDC& dc)
         wxFontMetrics fm = dc.GetFontMetrics();
         int lineHeight   = fm.ascent + fm.descent + fm.internalLeading;
 
-#if   defined(__WXGTK__)
-	    double y_offset = 0;
-#elif defined(__WXMSW__)
-	    double y_offset = scale;
-#elif defined(__WXOSX_)
         double y_offset = scale;
+#if   defined(__WXGTK__)
+        y_offset = 0;
 #endif
         wxCoord y = std::floor(v_center - lineHeight * 0.50 - y_offset);
 

--- a/src/slic3r/GUI/Widgets/SwitchButton.cpp
+++ b/src/slic3r/GUI/Widgets/SwitchButton.cpp
@@ -258,6 +258,7 @@ ModeSwitchButton::ModeSwitchButton(wxWindow* parent, wxWindowID id)
     StaticBox::Create(parent, id, wxDefaultPosition, wxDefaultSize, 0);
     SetBackgroundColour(StaticBox::GetParentBackgroundColor(parent));
     SetCursor(wxCursor(wxCURSOR_HAND));
+    SetFont(Label::Body_12);
 
     m_tooltips[0] = _L("Simple settings");
     m_tooltips[1] = _L("Advanced settings");
@@ -356,6 +357,15 @@ void ModeSwitchButton::doRender(wxDC& dc)
         }
     }
     else { // Developer mode
+        double scale = 1.00;
+#ifdef __WXOSX__
+        scale = Slic3r::GUI::mac_max_scaling_factor();
+        dc.SetFont(dc.GetFont().Scaled(scale));
+#elif defined(__WXMSW__)
+        scale = m_parent->GetDPIScaleFactor();
+        dc.SetFont(dc.GetFont().Scaled(scale));
+#endif
+
         wxString str = "DEV";
         int kerning = 3; // pixels between chars
         dc.SetTextForeground(text_color.colorForStates(states));
@@ -365,8 +375,11 @@ void ModeSwitchButton::doRender(wxDC& dc)
             totalWidth += dc.GetTextExtent(wxString(c)).x + kerning;
         totalWidth -= kerning;
 
-        wxCoord x = bounds.x + (bounds.width - totalWidth) / 2;
-        wxCoord y = bounds.y + (bounds.height - dc.GetTextExtent(str).y) / 2 - 1;
+        wxCoord x = bounds.x + (bounds.width  - totalWidth) * 0.50;
+
+        wxFontMetrics fm = dc.GetFontMetrics();
+        int lineHeight   = fm.ascent + fm.descent + fm.internalLeading;
+        wxCoord y = std::floor(v_center - lineHeight * 0.50 - scale);
 
         for (char c : str) {
             wxString ch(c);

--- a/src/slic3r/GUI/Widgets/SwitchButton.cpp
+++ b/src/slic3r/GUI/Widgets/SwitchButton.cpp
@@ -379,7 +379,15 @@ void ModeSwitchButton::doRender(wxDC& dc)
 
         wxFontMetrics fm = dc.GetFontMetrics();
         int lineHeight   = fm.ascent + fm.descent + fm.internalLeading;
-        wxCoord y = std::floor(v_center - lineHeight * 0.50 - scale);
+
+#if   defined(__WXGTK__)
+	    double y_offset = 0;
+#elif defined(__WXMSW__)
+	    double y_offset = scale;
+#elif defined(__WXOSX_)
+        double y_offset = scale;
+#endif
+        wxCoord y = std::floor(v_center - lineHeight * 0.50 - y_offset);
 
         for (char c : str) {
             wxString ch(c);

--- a/src/slic3r/GUI/Widgets/SwitchButton.hpp
+++ b/src/slic3r/GUI/Widgets/SwitchButton.hpp
@@ -58,7 +58,7 @@ public:
     void SetSelection(int selection);
     void SelectAndNotify(int selection);
 
-    void Rescale();
+    void Rescale() override;
     void msw_rescale() { Rescale(); }
 
     bool Enable(bool enable = true) override;
@@ -164,7 +164,7 @@ public:
     void SetButtonCornerRadius(double radius);
     void SetButtonPadding(const wxSize &padding);
 
-    void Rescale();
+    void Rescale() override;
 
 protected:
     void button_clicked(wxCommandEvent &event);

--- a/src/slic3r/GUI/Widgets/TabCtrl.cpp
+++ b/src/slic3r/GUI/Widgets/TabCtrl.cpp
@@ -82,6 +82,7 @@ void TabCtrl::Unselect()
 
 void TabCtrl::Rescale()
 {
+    StaticBox::Rescale();
     for (auto & b : btns)
         b->Rescale();
 }

--- a/src/slic3r/GUI/Widgets/TabCtrl.hpp
+++ b/src/slic3r/GUI/Widgets/TabCtrl.hpp
@@ -42,7 +42,7 @@ public:
 
     void Unselect();
 
-    virtual void Rescale();
+    virtual void Rescale() override;
 
     wxString GetItemText(unsigned int item) const;
     void     SetItemText(unsigned int item, wxString const &value);

--- a/src/slic3r/GUI/Widgets/TextInput.cpp
+++ b/src/slic3r/GUI/Widgets/TextInput.cpp
@@ -153,6 +153,9 @@ void TextInput::SetTextColor(StateColor const& color)
 
 void TextInput::Rescale()
 {
+    // Clear the min size so the `messureSize()` can shrink
+    wxWindow::SetMinSize(wxDefaultSize);
+
     StaticBox::Rescale();
 
     if (!this->icon.name().empty())
@@ -341,6 +344,9 @@ void TextInput::messureSize()
     }
 
     size.y = textSize.y + 8;
+
+    // If owner already give it a larger size, don't shrink
+    size.y = std::max(size.y, GetMinHeight());
 
     wxSize minSize = size;
     minSize.x = GetMinWidth();

--- a/src/slic3r/GUI/Widgets/TextInput.cpp
+++ b/src/slic3r/GUI/Widgets/TextInput.cpp
@@ -206,7 +206,7 @@ void TextInput::DoSetSize(int x, int y, int width, int height, int sizeFlags)
     if (align_right)
         textPos.x += labelSize.x;
     if (text_ctrl) {
-        wxSize textSize = text_ctrl->GetSize();
+        wxSize textSize = text_ctrl->GetBestSize();
         textSize.x = size.x - textPos.x - labelSize.x - 10;
         if(textSize.x < -1) textSize.x = -1;
         text_ctrl->SetSize(textSize);
@@ -331,7 +331,7 @@ void TextInput::messureSize()
     else
         dc.SetFont(Label::Body_12);
     labelSize = dc.GetTextExtent(wxWindow::GetLabel());
-    wxSize textSize = text_ctrl->GetSize();
+    wxSize textSize = text_ctrl->GetBestSize();
 
     if (!static_tips.empty()) {
         static_tips_size = dc.GetTextExtent(static_tips);
@@ -340,10 +340,7 @@ void TextInput::messureSize()
         textSize.y += 8;
     }
 
-    int h = textSize.y + 8;
-    if (size.y < h) {
-        size.y = h;
-    }
+    size.y = textSize.y + 8;
 
     wxSize minSize = size;
     minSize.x = GetMinWidth();

--- a/src/slic3r/GUI/Widgets/TextInput.cpp
+++ b/src/slic3r/GUI/Widgets/TextInput.cpp
@@ -153,6 +153,8 @@ void TextInput::SetTextColor(StateColor const& color)
 
 void TextInput::Rescale()
 {
+    StaticBox::Rescale();
+
     if (!this->icon.name().empty())
         this->icon.msw_rescale();
     if (!this->icon_1.name().empty())

--- a/src/slic3r/GUI/Widgets/TextInput.cpp
+++ b/src/slic3r/GUI/Widgets/TextInput.cpp
@@ -153,9 +153,6 @@ void TextInput::SetTextColor(StateColor const& color)
 
 void TextInput::Rescale()
 {
-    // Clear the min size so the `messureSize()` can shrink
-    wxWindow::SetMinSize(wxDefaultSize);
-
     StaticBox::Rescale();
 
     if (!this->icon.name().empty())
@@ -181,14 +178,15 @@ bool TextInput::Enable(bool enable)
 
 void TextInput::SetMinSize(const wxSize& size)
 {
-    wxSize size2 = size;
-    if (size2.y < 0) {
+    m_min_size = size;
+    wxWindow::SetMinSize(size);
+
 #ifdef __WXMAC__
         if (GetPeer()) // peer is not ready in Create on mac
+        return;
 #endif
-        size2.y = GetSize().y;
-    }
-    wxWindow::SetMinSize(size2);
+
+    messureSize();
 }
 
 void TextInput::DoSetSize(int x, int y, int width, int height, int sizeFlags)
@@ -334,7 +332,7 @@ void TextInput::messureSize()
     else
         dc.SetFont(Label::Body_12);
     labelSize = dc.GetTextExtent(wxWindow::GetLabel());
-    wxSize textSize = text_ctrl->GetBestSize();
+    wxSize textSize = text_ctrl ? text_ctrl->GetBestSize() : wxSize(0, 0); // GetBestSize might also include border width + padding from OS
 
     if (!static_tips.empty()) {
         static_tips_size = dc.GetTextExtent(static_tips);
@@ -343,13 +341,12 @@ void TextInput::messureSize()
         textSize.y += 8;
     }
 
-    size.y = textSize.y + 8;
+    int calculatedH = textSize.y + 8;
+    size.y = std::max(std::max(calculatedH, m_min_size.y), size.y); // pick max value for regular size so min value works 
 
-    // If owner already give it a larger size, don't shrink
-    size.y = std::max(size.y, GetMinHeight());
+    int minY = (m_min_size.y > 0) ? std::max(calculatedH, m_min_size.y) : calculatedH; // pick calculated height instead min value to prevent clipping
+    int minX = GetMinWidth(); // dont limit with text content so it will shrinks properly
 
-    wxSize minSize = size;
-    minSize.x = GetMinWidth();
-    SetMinSize(minSize);
-    SetSize(size);
+    wxWindow::SetMinSize(wxSize(minX, minY));
+    wxWindow::SetSize(size);
 }

--- a/src/slic3r/GUI/Widgets/TextInput.hpp
+++ b/src/slic3r/GUI/Widgets/TextInput.hpp
@@ -14,6 +14,8 @@ class TextInput : public wxNavigationEnabled<StaticBox>
     StateColor     text_color;
     wxTextCtrl * text_ctrl;
 
+    wxSize m_min_size;
+
     wxString  static_tips;
     wxSize    static_tips_size;
     wxBitmap  static_tips_icon;

--- a/src/slic3r/GUI/Widgets/TextInput.hpp
+++ b/src/slic3r/GUI/Widgets/TextInput.hpp
@@ -59,7 +59,7 @@ public:
 
     void SetTextColor(StateColor const &color);
 
-    virtual void Rescale();
+    virtual void Rescale() override;
 
     virtual bool Enable(bool enable = true) override;
 

--- a/src/slic3r/GUI/calib_dlg.cpp
+++ b/src/slic3r/GUI/calib_dlg.cpp
@@ -338,6 +338,16 @@ void PA_Calibration_Dlg::on_method_changed(wxCommandEvent& event) {
 }
 
 void PA_Calibration_Dlg::on_dpi_changed(const wxRect& suggested_rect) {
+    m_rbExtruderType->Rescale();
+    m_rbMethod->Rescale();
+    m_tiStartPA->Rescale();
+    m_tiEndPA->Rescale();
+    m_tiPAStep->Rescale();
+    m_cbPrintNum->Rescale();
+    m_tiBMAccels->Rescale();
+    m_tiBMSpeeds->Rescale();
+
+    Layout();
     this->Refresh();
     Fit();
 }
@@ -547,9 +557,14 @@ void Temp_Calibration_Dlg::on_filament_type_changed(wxCommandEvent& event) {
 }
 
 void Temp_Calibration_Dlg::on_dpi_changed(const wxRect& suggested_rect) {
+    m_rbFilamentType->Rescale();
+    m_tiStart->Rescale();
+    m_tiEnd->Rescale();
+    m_tiStep->Rescale();
+
+    Layout();
     this->Refresh();
     Fit();
-
 }
 
 
@@ -652,9 +667,13 @@ void MaxVolumetricSpeed_Test_Dlg::on_start(wxCommandEvent& event) {
 }
 
 void MaxVolumetricSpeed_Test_Dlg::on_dpi_changed(const wxRect& suggested_rect) {
+    m_tiStart->Rescale();
+    m_tiEnd->Rescale();
+    m_tiStep->Rescale();
+
+    Layout();
     this->Refresh();
     Fit();
-
 }
 
 
@@ -908,6 +927,11 @@ void VFA_Test_Dlg::on_start(wxCommandEvent& event)
 
 void VFA_Test_Dlg::on_dpi_changed(const wxRect& suggested_rect)
 {
+    m_tiStart->Rescale();
+    m_tiEnd->Rescale();
+    m_tiStep->Rescale();
+
+    Layout();
     this->Refresh();
     Fit();
 }
@@ -1015,9 +1039,13 @@ void Retraction_Test_Dlg::on_start(wxCommandEvent& event) {
 }
 
 void Retraction_Test_Dlg::on_dpi_changed(const wxRect& suggested_rect) {
+    m_tiStart->Rescale();
+    m_tiEnd->Rescale();
+    m_tiStep->Rescale();
+
+    Layout();
     this->Refresh();
     Fit();
-
 }
 
 // Input_Shaping_Freq_Test_Dlg
@@ -1234,6 +1262,15 @@ void Input_Shaping_Freq_Test_Dlg::on_start(wxCommandEvent& event) {
 }
 
 void Input_Shaping_Freq_Test_Dlg::on_dpi_changed(const wxRect& suggested_rect) {
+    m_rbModel->Rescale();
+    m_rbType->Rescale();
+    m_tiFreqStartX->Rescale();
+    m_tiFreqStartY->Rescale();
+    m_tiFreqEndX->Rescale();
+    m_tiFreqEndY->Rescale();
+    m_tiDampingFactor->Rescale();
+
+    Layout();
     this->Refresh();
     Fit();
 }
@@ -1428,6 +1465,14 @@ void Input_Shaping_Damp_Test_Dlg::on_start(wxCommandEvent& event) {
 }
 
 void Input_Shaping_Damp_Test_Dlg::on_dpi_changed(const wxRect& suggested_rect) {
+    m_rbModel->Rescale();
+    m_rbType->Rescale();
+    m_tiFreqX->Rescale();
+    m_tiFreqY->Rescale();
+    m_tiDampingFactorStart->Rescale();
+    m_tiDampingFactorEnd->Rescale();
+
+    Layout();
     this->Refresh();
     Fit();
 }
@@ -1615,6 +1660,11 @@ void Cornering_Test_Dlg::on_start(wxCommandEvent& event) {
 }
 
 void Cornering_Test_Dlg::on_dpi_changed(const wxRect& suggested_rect) {
+    m_rbModel->Rescale();
+    m_tiJDStart->Rescale();
+    m_tiJDEnd->Rescale();
+
+    Layout();
     this->Refresh();
     Fit();
 }
@@ -1725,6 +1775,10 @@ void FlowRateCalibrationDialog::on_start(wxCommandEvent& event) {
 }
 
 void FlowRateCalibrationDialog::on_dpi_changed(const wxRect& suggested_rect) {
+    m_rbPattern->Rescale();
+    m_rbType->Rescale();
+
+    Layout();
     this->Refresh();
 }
 

--- a/src/slic3r/GUI/calib_dlg.cpp
+++ b/src/slic3r/GUI/calib_dlg.cpp
@@ -348,7 +348,7 @@ void PA_Calibration_Dlg::on_dpi_changed(const wxRect& suggested_rect) {
     m_tiBMSpeeds->Rescale();
 
     Layout();
-    this->Refresh();
+    Refresh();
     Fit();
 }
 
@@ -563,7 +563,7 @@ void Temp_Calibration_Dlg::on_dpi_changed(const wxRect& suggested_rect) {
     m_tiStep->Rescale();
 
     Layout();
-    this->Refresh();
+    Refresh();
     Fit();
 }
 
@@ -672,7 +672,7 @@ void MaxVolumetricSpeed_Test_Dlg::on_dpi_changed(const wxRect& suggested_rect) {
     m_tiStep->Rescale();
 
     Layout();
-    this->Refresh();
+    Refresh();
     Fit();
 }
 
@@ -932,7 +932,7 @@ void VFA_Test_Dlg::on_dpi_changed(const wxRect& suggested_rect)
     m_tiStep->Rescale();
 
     Layout();
-    this->Refresh();
+    Refresh();
     Fit();
 }
 
@@ -1044,7 +1044,7 @@ void Retraction_Test_Dlg::on_dpi_changed(const wxRect& suggested_rect) {
     m_tiStep->Rescale();
 
     Layout();
-    this->Refresh();
+    Refresh();
     Fit();
 }
 
@@ -1271,7 +1271,7 @@ void Input_Shaping_Freq_Test_Dlg::on_dpi_changed(const wxRect& suggested_rect) {
     m_tiDampingFactor->Rescale();
 
     Layout();
-    this->Refresh();
+    Refresh();
     Fit();
 }
 
@@ -1473,7 +1473,7 @@ void Input_Shaping_Damp_Test_Dlg::on_dpi_changed(const wxRect& suggested_rect) {
     m_tiDampingFactorEnd->Rescale();
 
     Layout();
-    this->Refresh();
+    Refresh();
     Fit();
 }
 
@@ -1665,7 +1665,7 @@ void Cornering_Test_Dlg::on_dpi_changed(const wxRect& suggested_rect) {
     m_tiJDEnd->Rescale();
 
     Layout();
-    this->Refresh();
+    Refresh();
     Fit();
 }
 
@@ -1779,7 +1779,8 @@ void FlowRateCalibrationDialog::on_dpi_changed(const wxRect& suggested_rect) {
     m_rbType->Rescale();
 
     Layout();
-    this->Refresh();
+    Refresh();
+    Fit();
 }
 
 }} // namespace Slic3r::GUI

--- a/src/slic3r/GUI/wxExtensions.cpp
+++ b/src/slic3r/GUI/wxExtensions.cpp
@@ -981,6 +981,10 @@ int ScalableBitmap::GetBmpHeight() const
 
 void ScalableBitmap::msw_rescale()
 {
+    // This makes caller's life easier
+    if (!m_bmp.IsOk()) {
+        return;
+    }
     // BBS: support resize by fill border
     m_bmp = create_scaled_bitmap(m_icon_name, m_parent, m_px_cnt, m_grayscale, std::string(), false, m_resize);
 }

--- a/src/slic3r/Utils/wxInspectorPlugins/CustomWidgetsPlugin.cpp
+++ b/src/slic3r/Utils/wxInspectorPlugins/CustomWidgetsPlugin.cpp
@@ -266,9 +266,4 @@ void CustomWidgetsPlugin::addLabeledStaticBoxProps(LabeledStaticBox* lsb,
             lsb->SetBorderColor(StateColor(c));
             return true;
         }});
-
-    props.push_back({"Scale", "LabeledStaticBox", PropertyType::ReadOnly,
-        wxString::Format("%.2f", lsb->GetScale()), true, {},
-        [lsb]() { return wxString::Format("%.2f", lsb->GetScale()); },
-        nullptr});
 }

--- a/src/slic3r/Utils/wxInspectorPlugins/CustomWidgetsPlugin.cpp
+++ b/src/slic3r/Utils/wxInspectorPlugins/CustomWidgetsPlugin.cpp
@@ -11,6 +11,21 @@
 #include <wx/window.h>
 #include <wx/tglbtn.h>
 
+namespace {
+
+template<typename T>
+void addRescaleMethod(T* w, wxVector<wxInspector::MethodInfo>& methods)
+{
+    methods.push_back({"Rescale", "Rescale()",
+        "Re-apply DPI-scaled sizes and fonts to this widget",
+        [w](const wxVector<wxString>&) -> wxString {
+            w->Rescale();
+            return "Rescaled";
+        }});
+}
+
+} // anonymous namespace
+
 wxString CustomWidgetsPlugin::GetName() const
 {
     return "OrcaCustomWidgets";
@@ -44,6 +59,36 @@ wxVector<wxInspector::PropertyDef> CustomWidgetsPlugin::GetProperties(
         addLabeledStaticBoxProps(lsb, props);
 
     return props;
+}
+
+wxVector<wxInspector::MethodInfo> CustomWidgetsPlugin::GetMethods(
+    wxInspector::InspectableObject& obj)
+{
+    wxVector<wxInspector::MethodInfo> methods;
+    wxWindow* win = obj.AsWindow();
+    if (!win) return methods;
+
+    if (auto* btn = dynamic_cast<Button*>(win))
+        addRescaleMethod(btn, methods);
+    if (auto* cb = dynamic_cast<CheckBox*>(win))
+        addRescaleMethod(cb, methods);
+    if (auto* ti = dynamic_cast<TextInput*>(win))
+        addRescaleMethod(ti, methods);
+    if (auto* sb = dynamic_cast<SwitchButton*>(win))
+        addRescaleMethod(sb, methods);
+    if (auto* pb = dynamic_cast<ProgressBar*>(win))
+        addRescaleMethod(pb, methods);
+    if (auto* msb = dynamic_cast<ModeSwitchButton*>(win)) {
+        addRescaleMethod(msb, methods);
+        methods.push_back({"msw_rescale", "msw_rescale()",
+            wxString::FromUTF8("MSW alias of Rescale() — re-apply DPI-scaled sizes and fonts"),
+            [msb](const wxVector<wxString>&) -> wxString {
+                msb->msw_rescale();
+                return "msw_rescaled";
+            }});
+    }
+
+    return methods;
 }
 
 void CustomWidgetsPlugin::addButtonProps(Button* btn,

--- a/src/slic3r/Utils/wxInspectorPlugins/CustomWidgetsPlugin.hpp
+++ b/src/slic3r/Utils/wxInspectorPlugins/CustomWidgetsPlugin.hpp
@@ -12,6 +12,9 @@ public:
     wxVector<wxInspector::PropertyDef> GetProperties(
         wxInspector::InspectableObject& obj) override;
 
+    wxVector<wxInspector::MethodInfo> GetMethods(
+        wxInspector::InspectableObject& obj) override;
+
 private:
     void addButtonProps(class Button* btn,
         wxVector<wxInspector::PropertyDef>& props);


### PR DESCRIPTION
### TODO
• Objectlist > icons not scaled on_dpi_change
• Process combo box
• AMS popup > spin inputs
• ...

### Other issues that requires major changes
• Texinput Rescale() unconsistent after wxWidgets upgrade that effects most of controls
• Sidebar Searchboxes > Search popup much wider (em value issue)

### 1 - Updated on_dpi_changed on all calibration dialogs &
### 2 - Labeled static box text is small &
### 3 - Radio button text clipping > Added Rescale() capability
**Before - After**
<img width="960" height="771" alt="explorer_budAoHTX5M" src="https://github.com/user-attachments/assets/4eb51e61-7c0b-4e33-9d2c-70f76c5d5515" />
**Before - After**
<img width="1373" height="165" alt="orca-slicer_bzBQXFeltj" src="https://github.com/user-attachments/assets/14b9e470-b70b-402c-a904-2808e9b7a421" />

### 4 - BBL > Calibration tab > Sidetools not scales properly
**Before - After**
<img width="814" height="280" alt="orca-slicer_K9XXP7t9mW" src="https://github.com/user-attachments/assets/8a791f6c-aa6e-487e-9894-2250bb0433a7" />

### 5 - BBL > Filament Grouping > Capsule buttons over scales
**Before - After**
<img width="1012" height="406" alt="explorer_XGWLY9DZes" src="https://github.com/user-attachments/assets/e707997a-2aab-4ae1-af34-aa605d72cfde" />

### 6 - BBL > Multi device tab > Buttons not properly scaled
**Before - After**
<img width="1920" height="1080" alt="chwO4sxR0x" src="https://github.com/user-attachments/assets/bb1788da-753b-4292-8f6b-905f151dbb8d" />

### 7 - BBL > Multi device tab > Side tools has unnecessary spacing on top and right
**Before - After**
<img width="819" height="362" alt="orca-slicer_DCR6nwu8xO" src="https://github.com/user-attachments/assets/ec8562d2-c3fe-4e20-998d-4c3a1c2734f0" />

### 8 - OBJ import dialog > Oversized thumbnail
|Before|After|
|---|---|
|<img width="747" height="1080" alt="ShareX_pEkh9mqkUp" src="https://github.com/user-attachments/assets/eaa7b11b-f409-4f61-9318-d06dbd9ff8da" />  |  <img width="748" height="1080" alt="explorer_dnmwrK9Ah4" src="https://github.com/user-attachments/assets/2eb6337f-7698-46ae-a398-b3d4e865baca" />|

### 9 - Printer / Filament settings > Buttons after dpi change
**Before - After**
<img width="880" height="129" alt="Screenshot-20260516142048" src="https://github.com/user-attachments/assets/849a0f84-fdea-438d-9377-a077ab96a091" />

### 10 - Sidebar > Search boxes > icon not scales
**Before - After**
<img width="677" height="293" alt="Screenshot-20260516144957" src="https://github.com/user-attachments/assets/4c3f2b81-7ae7-4509-bef7-5e0e9bb8d2a1" />

**Before - After**
<img width="844" height="132" alt="orca-slicer_IkmUBC2jUe" src="https://github.com/user-attachments/assets/e7d978bf-0f32-40ff-9a70-c7f71f081804" />

### 11 - Checkbox and Arrow icons not scaled on dropdowns
**Before - After**
<img width="894" height="627" alt="Screenshot-20260516163816" src="https://github.com/user-attachments/assets/d90bfdd8-e8ae-45f1-8f68-e779d7576798" />

### 12 - Dev button text small
**Before - After**
<img width="698" height="131" alt="orca-slicer_6KWO8gtzEA" src="https://github.com/user-attachments/assets/c124b523-0386-4b62-a189-08abb050f8bd" />
<img width="703" height="144" alt="orca-slicer_3AhrSwgcVF" src="https://github.com/user-attachments/assets/7e352af9-8c8a-4885-a8d9-154dff48a817" />

### 13 - Default filament color
**Before**
<img width="849" height="368" alt="Screenshot-20260714014232" src="https://github.com/user-attachments/assets/2ff5481d-d932-4be6-a623-c2a3aebafe36" />

**After**
<img width="864" height="356" alt="Screenshot-20260714014255" src="https://github.com/user-attachments/assets/2f683ace-2a57-4afb-b422-68be579513c2" />

### 14 - Project page
**Before - After**
<img width="781" height="321" alt="Screenshot-20260802124711" src="https://github.com/user-attachments/assets/9c6fb91b-7d2b-45bc-831e-6821246fef07" />

**Before**
<img width="562" height="381" alt="Screenshot-20260802124757" src="https://github.com/user-attachments/assets/6af0bd91-4201-4ab1-b093-37d6d9dfc064" />

**After**
<img width="673" height="430" alt="Screenshot-20260802124827" src="https://github.com/user-attachments/assets/8a5174b4-beec-48c7-a865-44ecac87f139" />

**Before**
<img width="584" height="398" alt="Screenshot-20260802124917" src="https://github.com/user-attachments/assets/8f578503-976d-4476-8a26-9510e1cc9640" />

**After**
<img width="657" height="421" alt="Screenshot-20260802124858" src="https://github.com/user-attachments/assets/63fd6e11-22d6-4ae7-918e-d8b1eb98d7e4" />

### 15 - Create / edit profile dialogs
Create printer / nozzle
**Before - After**
• Label sizes not scaled
• Controls not scaled
<img width="1851" height="1064" alt="orca-slicer_3QMMO1g7Qj" src="https://github.com/user-attachments/assets/ea15b5f6-39d8-4a48-865a-c3f58984d6ad" />

Create filament
**Before - After**
<img width="1729" height="837" alt="explorer_lHm1EbALUS" src="https://github.com/user-attachments/assets/d152cb90-e84e-4605-8cec-4034538b1b9d" />

### 16 - Filament Grouping dialog after dpi change
**Before - Picks wrong size**
<img width="1058" height="336" alt="Screenshot-20260802145040" src="https://github.com/user-attachments/assets/a61db1b8-701d-4f0f-a7bc-a4dbe163b6ff" />

**After**
<img width="585" height="339" alt="Screenshot-20260802150643" src="https://github.com/user-attachments/assets/8a900c2a-1767-499b-957c-dfb66bd6247a" />

### 17 - Plate settings dialog - on_dpi_change
**Before**
<img width="1142" height="815" alt="orca-slicer_iTvTmZVocv" src="https://github.com/user-attachments/assets/9f0f7be9-15ae-4905-8287-57cebc9159fa" />

**After**
<img width="1146" height="832" alt="orca-slicer_lw6XoMWFoh" src="https://github.com/user-attachments/assets/636c2900-b86d-40bc-a046-9cc50707279f" />
