### PR TITLE
Fix macOS crash in DataViewBitmapText assignment

### DIFF
--- a/src/slic3r/GUI/ExtraRenderers.hpp
+++ b/src/slic3r/GUI/ExtraRenderers.hpp
@@ -28,6 +28,15 @@ public:
         m_bmp(other.m_bmp)
     { }
 
+    DataViewBitmapText& operator=(const DataViewBitmapText &other)
+    {
+        if (this != &other) {
+            m_text = other.m_text;
+            m_bmp = other.m_bmp;
+        }
+        return *this;
+    }
+
     void SetText(const wxString &text)      { m_text = text; }
     wxString GetText() const                { return m_text; }
     void SetBitmap(const wxBitmap &bmp)     { m_bmp = bmp; }


### PR DESCRIPTION
# Description

Fixes a macOS crash when committing edits in the object list filament/color column.  `DataViewBitmapText` defines a custom copy constructor that avoids copying the `wxObject` base, but did not define a copy assignment operator. The compiler-generated assignment operator copied the `wxObject` base and could crash in `wxObject::Ref()` when a `DataViewBitmapText` was assigned through `wxVariant`.

This adds an explicit assignment operator that copies only `m_text` and `m_bmp`, matching the existing copy-constructor behavior.

Fixes #13682 

## Note

This PR only addresses the crash caused by `DataViewBitmapText` assignment.

There appears to be a separate macOS object-list editing issue where the filament selector path can occasionally expose wxWidgets' custom renderer placeholder text, e.g. `wxCustomRendererObject: 0x...`, instead of immediately showing the filament selector. That issue does not crash and retrying the selection works, but it likely needs a separate change to the macOS `wxDataViewCtrl`/custom renderer edit flow.

## Tests

After this change, I no longer experience the crash in #13682.  Tested by repeatedly selecting filaments on objects.  I could reliably produce the crash after a few filament selections.  I can no longer repro with this fix.

<!--
> A guide for users on how to download the artifacts from this PR.
-->

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
