### PR TITLE
Fix sidebar filament count for multi-extruder printers

### DIFF
--- a/src/libslic3r/PresetBundle.cpp
+++ b/src/libslic3r/PresetBundle.cpp
@@ -2614,6 +2614,9 @@ void PresetBundle::update_selections(AppConfig &config)
             break;
         this->filament_presets.emplace_back(remove_ini_suffix(f_name));
     }
+
+    update_filament_count();
+
     std::vector<std::string> filament_colors;
     auto f_colors = config.get_printer_setting(initial_printer_profile_name, "filament_colors");
     if (!f_colors.empty()) {
@@ -2754,6 +2757,8 @@ void PresetBundle::load_selections(AppConfig &config, const PresetPreferences& p
             break;
         this->filament_presets.emplace_back(remove_ini_suffix(f_name));
     }
+
+    update_filament_count();
 
     // Load data from AppConfig to ProjectConfig when Studio is initialized.
     std::vector<std::string> filament_colors;
@@ -3777,6 +3782,18 @@ int PresetBundle::get_printer_extruder_count() const
     int count = printer_preset.config.option<ConfigOptionFloats>("nozzle_diameter")->values.size();
 
     return count;
+}
+
+void PresetBundle::update_filament_count()
+{
+    if (printers.get_edited_preset().printer_technology() != ptFFF)
+        return;
+    const size_t num_extruders = static_cast<size_t>(get_printer_extruder_count());
+    if (filament_presets.size() >= num_extruders)
+        return;
+    filament_presets.resize(num_extruders, filament_presets.empty()
+        ? filaments.first_visible().name
+        : filament_presets.back());
 }
 
 bool PresetBundle::support_different_extruders()

--- a/src/libslic3r/PresetBundle.hpp
+++ b/src/libslic3r/PresetBundle.hpp
@@ -372,6 +372,12 @@ public:
     int get_printer_extruder_count() const;
     bool support_different_extruders();
 
+    // Orca: Ensure filament_presets has at least one slot per nozzle on FFF printers.
+    // Called from (load|update)_selections before the parallel project_config arrays
+    // (filament_colour/colour_type/map) are sized off filament_presets.size(), so a
+    // short saved filament list doesn't truncate the loaded colors.
+    void update_filament_count();
+
     // Load user configuration and store it into the user profiles.
     // This method is called by the configuration wizard.
     void                        load_config_from_wizard(const std::string &name, DynamicPrintConfig config, Semver file_version)


### PR DESCRIPTION
Multi-extruder printers can end up showing fewer filament slots in the sidebar than the printer actually has nozzles. This happens in two situations users have hit:

1. **Switching between dual-extruder printers** — picking a never-used dual-extruder profile drops the sidebar to a single filament, even though the printer has two nozzles. The only known workaround was toggling the *Single Extruder Multi Material* checkbox off and on to force a resync. (Originally reported in #13053.)

2. **Multi-extruder printers with a partial saved filament list** — e.g. a 4-extruder Snapmaker U1 whose saved config has only 3 filament entries (never fully configured, manually edited config, or carried over from an older session). At startup the sidebar shows 3 combos instead of 4, and any extra filament colors that were saved get silently dropped.

In both cases the printer settings panel correctly shows the nozzle count, but the sidebar disagrees with it.

The sidebar now always shows at least one filament slot per nozzle on multi-extruder printers, at both startup and when switching printer presets. Filament colors loaded from the saved config are preserved rather than truncated.


Supersedes #13053.

<img width="458" height="325" alt="image" src="https://github.com/user-attachments/assets/4aaada18-694b-4d7c-8103-34176878a99e" />
