### PR TITLE
Fix wxGTK submenu popup parenting and sizing on Wayland

### DIFF
--- a/src/slic3r/GUI/Widgets/DropDown.cpp
+++ b/src/slic3r/GUI/Widgets/DropDown.cpp
@@ -564,11 +564,6 @@ void DropDown::messureSize()
         subDropDown->use_content_width = true;
         subDropDown->Create(GetParent());
 #ifdef __WXGTK__
-        // Orca:  Keep the wx parent as the combobox so wxPopupTransientWindow installs
-        // its capture handlers on the main dropdown, but make the native GTK
-        // popup transient for the currently open popup to satisfy Wayland's
-        // xdg-shell rule that a popup's parent must be the topmost mapped popup.
-        gtk_window_set_transient_for(GTK_WINDOW(subDropDown->GetHandle()), GTK_WINDOW(GetHandle()));
         // Orca: On Wayland, while the sub holds an xdg_popup grab, motion events for
         // the cursor over main may not be delivered (Mutter drops motion
         // outside the grabbing surface). Poll on idle and synthesize a
@@ -636,8 +631,11 @@ void DropDown::autoPosition()
         // may exceed
         auto drect = wxDisplay(GetParent()).GetGeometry();
         if (GetPosition().y + size.y + 10 > drect.GetBottom()) {
+            int available_height = drect.GetBottom() - GetPosition().y - 10;
+            if (available_height < rowSize.y * 2)
+                return;
             if (use_content_width && count <= 15) size.x += 6;
-            size.y = drect.GetBottom() - GetPosition().y - 10;
+            size.y = available_height;
             wxWindow::SetSize(size);
             if (selection >= 0) {
                 if (offset.y + rowSize.y * (selection + 1) > size.y)
@@ -727,6 +725,13 @@ void DropDown::mouseMove(wxMouseEvent &event)
             drop.group  = items[-index - 2].group_key;
             drop.need_sync = true;
             drop.messureSize();
+#ifdef __WXGTK__
+            // wxGTK wraps popup contents in a native GtkWindow. Make the submenu
+            // transient for the currently mapped parent popup window before
+            // positioning/showing it, so wlroots/Hyprland sees the topmost parent.
+            if (m_widget && drop.m_widget)
+                gtk_window_set_transient_for(GTK_WINDOW(drop.m_widget), GTK_WINDOW(m_widget));
+#endif
             drop.autoPosition();
             drop.paintNow();
             if (!drop.IsShown())


### PR DESCRIPTION
## Problem

PR #13563 fixed Linux/Wayland dropdown submenus for most tested desktop environments, but on Hyprland/wlroots the same change could still leave submenu popups unusable.

On Hyprland, the Prepare-view dropdown popup could open at roughly the expected size, but the entries rendered empty/transparent. The popup shell was visible, yet the list contents were not.

While narrowing the follow-up fix for grouped submenus, hovering a grouped item could also produce one of these behaviors:

- the submenu did not open reliably
- the submenu opened with a collapsed/tiny height and required scrolling to reveal entries
- GTK/GDK warnings appeared around popup parenting or invalid popup geometry

Observed warnings included:

```text
Gdk-WARNING **: Tried to map a popup with a non-top most parent
Gtk-CRITICAL **: gtk_widget_set_size_request: assertion 'height >= -1' failed
Gtk-WARNING **: drawing failure for widget 'wxPizza': invalid matrix (not invertible)
```

## Root Cause

The submenu popup's native GTK transient parent was assigned when the submenu window was created/measured. On Wayland, especially wlroots/Hyprland, the compositor expects a nested popup to be parented to the currently mapped topmost popup surface.

That means the native transient parent needs to be set when the submenu is actually about to be positioned/shown, not earlier while the popup hierarchy is still being prepared.

There was also an edge case in popup sizing: when the dropdown was positioned near the bottom of the display, the available height calculation could produce a tiny or invalid popup height. That led to collapsed submenus and GTK geometry warnings.

## Fix

- Remove the eager GTK transient-parent assignment from submenu creation/measurement.
- Set the submenu's native GTK transient parent immediately before submenu positioning/showing.
- Keep the wx parent unchanged so the existing wx popup/capture behavior remains intact.
- Guard the available-height path so the dropdown is not resized to a collapsed or invalid height when there is not enough space below the parent item.

## User-visible result

- Nested dropdown submenus open correctly on Hyprland/Wayland.
- Submenus remain usable when moving between the parent dropdown and child submenu.
- Dropdowns near the bottom of the screen are positioned above the parent item instead of collapsing to a tiny scroll area.
- Existing working behavior on GNOME, Plasma, XFCE, and X11 is preserved.

# Screenshots/Recordings/Graphs

Before:
<img width="674" height="519" alt="screenshot-2026-05-17_15-36-26" src="https://github.com/user-attachments/assets/bb9dab7c-933a-4cef-bd96-c93b580785a3" />


After:
<img width="567" height="497" alt="screenshot-2026-05-17_17-35-50" src="https://github.com/user-attachments/assets/6ba68690-330a-48aa-b51a-233f3ec14026" />

## Tests

Built locally on Arch Linux from current upstream `main`.

Manual test matrix:

- Hyprland / Wayland: OK
- GNOME / Wayland: OK
- Plasma / Wayland: OK
- Plasma / X11: OK
- XFCE / X11: OK

Tested behavior:

- Prepare-view dropdowns render entries correctly.
- Grouped dropdown items open their child submenu.
- Cursor movement between parent dropdown and child submenu works.
- Dropdowns near the bottom of the screen open upward instead of collapsing.
- Top-bar dropdowns and Device-tab dropdowns still work.

Not tested: Windows / macOS.

[[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)]

## Related

- Follow-up to #13563.
- Likely addresses #13525, which reports the same filament System Presets submenu failure on Linux 2.4.0-dev and includes `Tried to map a popup with a non-top most parent`.
- The final patch is intentionally small and scoped to `DropDown.cpp`.