### PR TITLE
One wall top/bottom surface applied incorrectly in assembly objects

### DIFF
--- a/src/libslic3r/Layer.cpp
+++ b/src/libslic3r/Layer.cpp
@@ -159,6 +159,12 @@ bool Layer::is_perimeter_compatible(const PrintRegion& a, const PrintRegion& b)
 		&& config.detect_thin_wall                  == other_config.detect_thin_wall
 		&& config.infill_wall_overlap              == other_config.infill_wall_overlap
         && config.top_bottom_infill_wall_overlap              == other_config.top_bottom_infill_wall_overlap
+        // Orca: these flags directly change the effective wall count produced by the perimeter
+        // generator. If two regions disagree on any of them, merging their slices into one shared make_perimeters
+        // call would silently use the first region's flag for both.
+        && config.only_one_wall_first_layer == other_config.only_one_wall_first_layer
+        && config.only_one_wall_top         == other_config.only_one_wall_top
+        && config.min_width_top_surface     == other_config.min_width_top_surface
         && config.seam_slope_type         == other_config.seam_slope_type
         && config.seam_slope_conditional == other_config.seam_slope_conditional
         && config.scarf_angle_threshold  == other_config.scarf_angle_threshold


### PR DESCRIPTION
# Description

 When a per-volume override for `only_one_wall_first_layer` or `only_one_wall_top` is applied to one part of an assembly, the setting is silently ignored — both parts get the same wall count on the first/top layer. Changing the wall count on one of the parts is the only way to make the override take effect.

**Root cause:**
`Layer::is_perimeter_compatible` decides whether two PrintRegions on the same layer can share a single perimeter-generation pass. It checks wall_loops etc, but omits only_one_wall_first_layer, only_one_wall_top, and min_width_top_surface. 

When two regions differ only in those keys, the compatibility check returns true, Layer::make_perimeters **merges their slices**, and the call uses the first region's config — silently discarding the second region's flag.

# Screenshots/Recordings/Graphs

<img width="3166" height="1820" alt="image" src="https://github.com/user-attachments/assets/fa286460-2c7b-4814-a3e9-8a009528f278" />


[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
