### PR TITLE
Fix possible crash on startup because of low max volumetric speed on profiles

### DIFF
--- a/resources/profiles/Afinia/filament/fdm_filament_common.json
+++ b/resources/profiles/Afinia/filament/fdm_filament_common.json
@@ -61,7 +61,7 @@
 		"nil"
 	],
 	"filament_max_volumetric_speed": [
-		"0"
+		"12"
 	],
 	"filament_minimal_purge_on_wipe_tower": [
 		"15"

--- a/resources/profiles/Anycubic/filament/fdm_filament_common.json
+++ b/resources/profiles/Anycubic/filament/fdm_filament_common.json
@@ -58,7 +58,7 @@
 		"1.75"
 	],
 	"filament_max_volumetric_speed": [
-		"0"
+		"12"
 	],
 	"filament_minimal_purge_on_wipe_tower": [
 		"15"

--- a/resources/profiles/Artillery/filament/fdm_filament_common.json
+++ b/resources/profiles/Artillery/filament/fdm_filament_common.json
@@ -58,7 +58,7 @@
 		"1.75"
 	],
 	"filament_max_volumetric_speed": [
-		"0"
+		"12"
 	],
 	"filament_minimal_purge_on_wipe_tower": [
 		"15"

--- a/resources/profiles/BBL/filament/fdm_filament_common.json
+++ b/resources/profiles/BBL/filament/fdm_filament_common.json
@@ -97,7 +97,7 @@
 		"nil"
 	],
 	"filament_max_volumetric_speed": [
-		"0"
+		"12"
 	],
 	"filament_ramming_volumetric_speed": [
 		"-1"

--- a/resources/profiles/Blocks/filament/fdm_filament_common.json
+++ b/resources/profiles/Blocks/filament/fdm_filament_common.json
@@ -64,7 +64,7 @@
 		"1.75"
 	],
 	"filament_max_volumetric_speed": [
-		"0"
+		"12"
 	],
 	"filament_minimal_purge_on_wipe_tower": [
 		"15"

--- a/resources/profiles/CONSTRUCT3D/filament/fdm_filament_common.json
+++ b/resources/profiles/CONSTRUCT3D/filament/fdm_filament_common.json
@@ -64,7 +64,7 @@
 		"1.75"
 	],
 	"filament_max_volumetric_speed": [
-		"0"
+		"12"
 	],
 	"filament_minimal_purge_on_wipe_tower": [
 		"15"

--- a/resources/profiles/CoLiDo/filament/fdm_filament_common.json
+++ b/resources/profiles/CoLiDo/filament/fdm_filament_common.json
@@ -67,7 +67,7 @@
 		"1.75"
 	],
 	"filament_max_volumetric_speed": [
-		"0"
+		"12"
 	],
 	"filament_minimal_purge_on_wipe_tower": [
 		"15"

--- a/resources/profiles/Comgrow/filament/fdm_filament_common.json
+++ b/resources/profiles/Comgrow/filament/fdm_filament_common.json
@@ -64,7 +64,7 @@
 		"1.75"
 	],
 	"filament_max_volumetric_speed": [
-		"0"
+		"12"
 	],
 	"filament_minimal_purge_on_wipe_tower": [
 		"15"

--- a/resources/profiles/Creality/filament/fdm_filament_common.json
+++ b/resources/profiles/Creality/filament/fdm_filament_common.json
@@ -64,7 +64,7 @@
 		"1.75"
 	],
 	"filament_max_volumetric_speed": [
-		"0"
+		"12"
 	],
 	"filament_minimal_purge_on_wipe_tower": [
 		"15"

--- a/resources/profiles/Cubicon/filament/fdm_filament_common.json
+++ b/resources/profiles/Cubicon/filament/fdm_filament_common.json
@@ -64,7 +64,7 @@
 		"1.75"
 	],
 	"filament_max_volumetric_speed": [
-		"0"
+		"12"
 	],
 	"filament_minimal_purge_on_wipe_tower": [
 		"15"

--- a/resources/profiles/DeltaMaker/filament/fdm_filament_pet.json
+++ b/resources/profiles/DeltaMaker/filament/fdm_filament_pet.json
@@ -14,7 +14,7 @@
 		"15"
 	],
 	"filament_max_volumetric_speed": [
-		"0"
+		"8"
 	],
 	"filament_type": [
 		"PETG"

--- a/resources/profiles/DeltaMaker/filament/fdm_filament_pla.json
+++ b/resources/profiles/DeltaMaker/filament/fdm_filament_pla.json
@@ -6,7 +6,7 @@
 	"instantiation": "false",
 	"fan_cooling_layer_time": "100",
 	"filament_max_volumetric_speed": [
-		"0"
+		"12"
 	],
 	"filament_type": [
 		"PLA"

--- a/resources/profiles/DeltaMaker/filament/fdm_filament_tpu.json
+++ b/resources/profiles/DeltaMaker/filament/fdm_filament_tpu.json
@@ -14,7 +14,7 @@
 		"30"
 	],
 	"filament_max_volumetric_speed": [
-		"0"
+		"3.6"
 	],
 	"filament_type": [
 		"TPU"

--- a/resources/profiles/Dremel/filament/fdm_filament_common.json
+++ b/resources/profiles/Dremel/filament/fdm_filament_common.json
@@ -40,7 +40,7 @@
 		"1.75"
 	],
 	"filament_max_volumetric_speed": [
-		"0"
+		"12"
 	],
 	"filament_minimal_purge_on_wipe_tower": [
 		"15"

--- a/resources/profiles/Elegoo/filament/fdm_filament_common.json
+++ b/resources/profiles/Elegoo/filament/fdm_filament_common.json
@@ -64,7 +64,7 @@
 		"1.75"
 	],
 	"filament_max_volumetric_speed": [
-		"0"
+		"12"
 	],
 	"filament_minimal_purge_on_wipe_tower": [
 		"15"

--- a/resources/profiles/Eryone/filament/fdm_filament_common.json
+++ b/resources/profiles/Eryone/filament/fdm_filament_common.json
@@ -58,7 +58,7 @@
 		"1.75"
 	],
 	"filament_max_volumetric_speed": [
-		"0"
+		"12"
 	],
 	"filament_minimal_purge_on_wipe_tower": [
 		"15"

--- a/resources/profiles/FLSun/filament/fdm_filament_common.json
+++ b/resources/profiles/FLSun/filament/fdm_filament_common.json
@@ -58,7 +58,7 @@
 		"1.75"
 	],
 	"filament_max_volumetric_speed": [
-		"0"
+		"12"
 	],
 	"filament_minimal_purge_on_wipe_tower": [
 		"15"

--- a/resources/profiles/Flashforge/filament/fdm_filament_common.json
+++ b/resources/profiles/Flashforge/filament/fdm_filament_common.json
@@ -64,7 +64,7 @@
 		"1.75"
 	],
 	"filament_max_volumetric_speed": [
-		"0"
+		"12"
 	],
 	"filament_minimal_purge_on_wipe_tower": [
 		"15"

--- a/resources/profiles/Flashforge/filament/fdm_filament_pet.json
+++ b/resources/profiles/Flashforge/filament/fdm_filament_pet.json
@@ -38,7 +38,7 @@
 		"15"
 	],
 	"filament_max_volumetric_speed": [
-		"0"
+		"8"
 	],
 	"filament_type": [
 		"PETG"

--- a/resources/profiles/Flashforge/filament/fdm_filament_pla.json
+++ b/resources/profiles/Flashforge/filament/fdm_filament_pla.json
@@ -8,7 +8,7 @@
 		"100"
 	],
 	"filament_max_volumetric_speed": [
-		"0"
+		"12"
 	],
 	"filament_type": [
 		"PLA"

--- a/resources/profiles/FlyingBear/filament/Ghost7/fdm_filament_common_Ghost7.json
+++ b/resources/profiles/FlyingBear/filament/Ghost7/fdm_filament_common_Ghost7.json
@@ -64,7 +64,7 @@
 		"1.75"
 	],
 	"filament_max_volumetric_speed": [
-		"0"
+		"12"
 	],
 	"filament_minimal_purge_on_wipe_tower": [
 		"15"

--- a/resources/profiles/FlyingBear/filament/S1/fdm_filament_common_S1.json
+++ b/resources/profiles/FlyingBear/filament/S1/fdm_filament_common_S1.json
@@ -64,7 +64,7 @@
 		"1.75"
 	],
 	"filament_max_volumetric_speed": [
-		"0"
+		"12"
 	],
 	"filament_minimal_purge_on_wipe_tower": [
 		"15"

--- a/resources/profiles/FlyingBear/filament/fdm_filament_common.json
+++ b/resources/profiles/FlyingBear/filament/fdm_filament_common.json
@@ -64,7 +64,7 @@
 		"1.75"
 	],
 	"filament_max_volumetric_speed": [
-		"0"
+		"12"
 	],
 	"filament_minimal_purge_on_wipe_tower": [
 		"15"

--- a/resources/profiles/InfiMech/filament/EX+APS/fdm_filament_common_EX+APS.json
+++ b/resources/profiles/InfiMech/filament/EX+APS/fdm_filament_common_EX+APS.json
@@ -64,7 +64,7 @@
 		"1.75"
 	],
 	"filament_max_volumetric_speed": [
-		"0"
+		"12"
 	],
 	"filament_minimal_purge_on_wipe_tower": [
 		"15"

--- a/resources/profiles/InfiMech/filament/EX/fdm_filament_common_EX.json
+++ b/resources/profiles/InfiMech/filament/EX/fdm_filament_common_EX.json
@@ -64,7 +64,7 @@
 		"1.75"
 	],
 	"filament_max_volumetric_speed": [
-		"0"
+		"12"
 	],
 	"filament_minimal_purge_on_wipe_tower": [
 		"15"

--- a/resources/profiles/InfiMech/filament/HSN/fdm_filament_common_HSN.json
+++ b/resources/profiles/InfiMech/filament/HSN/fdm_filament_common_HSN.json
@@ -64,7 +64,7 @@
 		"1.75"
 	],
 	"filament_max_volumetric_speed": [
-		"0"
+		"12"
 	],
 	"filament_minimal_purge_on_wipe_tower": [
 		"15"

--- a/resources/profiles/InfiMech/filament/fdm_filament_common.json
+++ b/resources/profiles/InfiMech/filament/fdm_filament_common.json
@@ -64,7 +64,7 @@
 		"1.75"
 	],
 	"filament_max_volumetric_speed": [
-		"0"
+		"12"
 	],
 	"filament_minimal_purge_on_wipe_tower": [
 		"15"

--- a/resources/profiles/LH/filament/fdm_filament_common.json
+++ b/resources/profiles/LH/filament/fdm_filament_common.json
@@ -64,7 +64,7 @@
 		"1.75"
 	],
 	"filament_max_volumetric_speed": [
-		"0"
+		"12"
 	],
 	"filament_minimal_purge_on_wipe_tower": [
 		"15"

--- a/resources/profiles/LONGER/filament/fdm_filament_common.json
+++ b/resources/profiles/LONGER/filament/fdm_filament_common.json
@@ -64,7 +64,7 @@
 		"1.75"
 	],
 	"filament_max_volumetric_speed": [
-		"0"
+		"12"
 	],
 	"filament_minimal_purge_on_wipe_tower": [
 		"15"

--- a/resources/profiles/OrcaArena/filament/fdm_filament_common.json
+++ b/resources/profiles/OrcaArena/filament/fdm_filament_common.json
@@ -70,7 +70,7 @@
 		"1.75"
 	],
 	"filament_max_volumetric_speed": [
-		"0"
+		"12"
 	],
 	"filament_minimal_purge_on_wipe_tower": [
 		"15"

--- a/resources/profiles/OrcaFilamentLibrary/filament/base/fdm_filament_common.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/base/fdm_filament_common.json
@@ -61,7 +61,7 @@
 		"nil"
 	],
 	"filament_max_volumetric_speed": [
-		"0"
+		"12"
 	],
 	"filament_minimal_purge_on_wipe_tower": [
 		"15"

--- a/resources/profiles/Peopoly/filament/fdm_filament_common.json
+++ b/resources/profiles/Peopoly/filament/fdm_filament_common.json
@@ -58,7 +58,7 @@
 		"1.75"
 	],
 	"filament_max_volumetric_speed": [
-		"0"
+		"12"
 	],
 	"filament_minimal_purge_on_wipe_tower": [
 		"15"

--- a/resources/profiles/Phrozen/filament/fdm_filament_common.json
+++ b/resources/profiles/Phrozen/filament/fdm_filament_common.json
@@ -58,7 +58,7 @@
 		"1.75"
 	],
 	"filament_max_volumetric_speed": [
-		"0"
+		"12"
 	],
 	"filament_minimal_purge_on_wipe_tower": [
 		"15"

--- a/resources/profiles/Prusa/filament/fdm_filament_common.json
+++ b/resources/profiles/Prusa/filament/fdm_filament_common.json
@@ -58,7 +58,7 @@
 		"1.75"
 	],
 	"filament_max_volumetric_speed": [
-		"0"
+		"12"
 	],
 	"filament_minimal_purge_on_wipe_tower": [
 		"15"

--- a/resources/profiles/Qidi/filament/fdm_filament_common.json
+++ b/resources/profiles/Qidi/filament/fdm_filament_common.json
@@ -61,7 +61,7 @@
 		"1.75"
 	],
 	"filament_max_volumetric_speed": [
-		"0"
+		"12"
 	],
 	"filament_minimal_purge_on_wipe_tower": [
 		"15"

--- a/resources/profiles/Ratrig/filament/fdm_filament_common.json
+++ b/resources/profiles/Ratrig/filament/fdm_filament_common.json
@@ -64,7 +64,7 @@
 		"1.75"
 	],
 	"filament_max_volumetric_speed": [
-		"0"
+		"12"
 	],
 	"filament_minimal_purge_on_wipe_tower": [
 		"15"

--- a/resources/profiles/SecKit/filament/fdm_filament_common.json
+++ b/resources/profiles/SecKit/filament/fdm_filament_common.json
@@ -64,7 +64,7 @@
 		"1.75"
 	],
 	"filament_max_volumetric_speed": [
-		"0"
+		"12"
 	],
 	"filament_minimal_purge_on_wipe_tower": [
 		"15"

--- a/resources/profiles/Snapmaker/filament/fdm_filament_common.json
+++ b/resources/profiles/Snapmaker/filament/fdm_filament_common.json
@@ -67,7 +67,7 @@
 		"1.75"
 	],
 	"filament_max_volumetric_speed": [
-		"0"
+		"12"
 	],
 	"filament_minimal_purge_on_wipe_tower": [
 		"0"

--- a/resources/profiles/Tiertime/filament/fdm_filament_common.json
+++ b/resources/profiles/Tiertime/filament/fdm_filament_common.json
@@ -61,7 +61,7 @@
 		"nil"
 	],
 	"filament_max_volumetric_speed": [
-		"0"
+		"12"
 	],
 	"filament_minimal_purge_on_wipe_tower": [
 		"15"

--- a/resources/profiles/Vzbot/filament/fdm_filament_common.json
+++ b/resources/profiles/Vzbot/filament/fdm_filament_common.json
@@ -64,7 +64,7 @@
 		"1.75"
 	],
 	"filament_max_volumetric_speed": [
-		"0"
+		"12"
 	],
 	"filament_minimal_purge_on_wipe_tower": [
 		"15"

--- a/resources/profiles/Wanhao France/filament/fdm_filament_common.json
+++ b/resources/profiles/Wanhao France/filament/fdm_filament_common.json
@@ -64,7 +64,7 @@
 		"1.75"
 	],
 	"filament_max_volumetric_speed": [
-		"0"
+		"12"
 	],
 	"filament_minimal_purge_on_wipe_tower": [
 		"15"

--- a/resources/profiles/WonderMaker/filament/fdm_filament_common.json
+++ b/resources/profiles/WonderMaker/filament/fdm_filament_common.json
@@ -61,7 +61,7 @@
 		"nil"
 	],
 	"filament_max_volumetric_speed": [
-		"0"
+		"12"
 	],
 	"filament_minimal_purge_on_wipe_tower": [
 		"15"

--- a/resources/profiles/re3D/filament/fdm_filament_common.json
+++ b/resources/profiles/re3D/filament/fdm_filament_common.json
@@ -64,7 +64,7 @@
 		"2.85"
 	],
 	"filament_max_volumetric_speed": [
-		"0"
+		"12"
 	],
 	"filament_minimal_purge_on_wipe_tower": [
 		"15"


### PR DESCRIPTION
<img width="509" height="525" alt="Screenshot-20260518121145" src="https://github.com/user-attachments/assets/d7fe4f80-0421-4a8c-83e9-652503e016ca" />

some profiles inherits 0 value if thats not specified on main profile that leads to crash on startup

added 12 value to all common profiles to prevent any future issues
used commonly used values on material specific ones
```
DeltaMaker/filament/fdm_filament_pet.json  8
DeltaMaker/filament/fdm_filament_pla.json  12
DeltaMaker/filament/fdm_filament_tpu.json  3.2
Flashforge/filament/fdm_filament_pet.json  8
Flashforge/filament/fdm_filament_pla.json  12
```