### PR TITLE
Fix 2 Linux assertation errors on gtk_window_resize()

### DIFF
--- a/src/slic3r/GUI/Widgets/DropDown.cpp
+++ b/src/slic3r/GUI/Widgets/DropDown.cpp
@@ -554,7 +554,8 @@ void DropDown::messureSize()
     wxWindow::SetSize(szContent);
 #ifdef __WXGTK__
     // Gtk has a wrapper window for popup widget
-    gtk_window_resize (GTK_WINDOW (m_widget), szContent.x, szContent.y);
+    if (szContent.x > 0 && szContent.y > 0)
+        gtk_window_resize (GTK_WINDOW (m_widget), szContent.x, szContent.y);
 #endif
     if (!groups.empty() && subDropDown == nullptr) {
         subDropDown = new DropDown(items);


### PR DESCRIPTION
Fixes 2 of these errors but other 2 is a bit mystery. couldnt find which calls causing these since any of SetSize() / SetClientSize() / wxWindow::Resize() can cause that

<img width="894" height="283" alt="Screenshot-20260518124159" src="https://github.com/user-attachments/assets/d8cd2831-7ded-4b14-b7d1-68645f6b2bde" />
