### PR TITLE
Fix Linux data-view dropdown popup parenting

### DIFF
--- a/src/slic3r/GUI/ExtraRenderers.cpp
+++ b/src/slic3r/GUI/ExtraRenderers.cpp
@@ -324,9 +324,18 @@ wxWindow* BitmapChoiceRenderer::CreateEditorCtrl(wxWindow* parent, wxRect labelR
     else
         c_editor->SetSelection(atoi(data.GetText().c_str()) - 1);
 
-    // Open the dropdown immediately when the editor is focused.
     c_editor->Bind(wxEVT_SET_FOCUS, [c_editor](wxFocusEvent& evt) {
+#ifdef __WXGTK__
+        // On wxGTK the data-view editor may receive focus before its native
+        // window is mapped. Opening the popup one event later avoids creating
+        // the GTK popup without a valid toplevel parent.
+        c_editor->CallAfter([c_editor]() {
+            if (c_editor->IsShownOnScreen())
+                c_editor->ForceDropdownOpen();
+        });
+#else
         c_editor->ForceDropdownOpen();
+#endif
         evt.Skip(); 
     });
 
@@ -391,5 +400,4 @@ wxSize TextRenderer::GetSize() const
 {
     return GetTextExtent(m_value);
 }
-
 

--- a/src/slic3r/GUI/Widgets/DropDown.cpp
+++ b/src/slic3r/GUI/Widgets/DropDown.cpp
@@ -167,6 +167,30 @@ bool DropDown::HasDismissLongTime()
         (now - dismissTime).total_milliseconds() >= 20;
 }
 
+void DropDown::Popup(wxWindow *focus)
+{
+#ifdef __WXGTK__
+    if (!mainDropDown && m_widget) {
+        // Data-view cell editors can receive focus before wxGTK infers a
+        // native popup parent, so provide the current toplevel explicitly.
+        GtkWindow *transient_parent = nullptr;
+        for (wxWindow *win = GetParent(); win; win = win->GetParent()) {
+            GtkWidget *widget = static_cast<GtkWidget *>(win->GetHandle());
+            if (!widget)
+                continue;
+            GtkWidget *top = gtk_widget_get_toplevel(widget);
+            if (GTK_IS_WINDOW(top)) {
+                transient_parent = GTK_WINDOW(top);
+                break;
+            }
+        }
+        if (transient_parent)
+            gtk_window_set_transient_for(GTK_WINDOW(m_widget), transient_parent);
+    }
+#endif
+    PopupWindow::Popup(focus);
+}
+
 void DropDown::paintEvent(wxPaintEvent& evt)
 {
     // depending on your system you may need to look at double-buffered dcs

--- a/src/slic3r/GUI/Widgets/DropDown.hpp
+++ b/src/slic3r/GUI/Widgets/DropDown.hpp
@@ -105,6 +105,8 @@ public:
 
     bool HasDismissLongTime();
 
+    void Popup(wxWindow *focus = nullptr) override;
+
 protected:
     void Dismiss() override;
 


### PR DESCRIPTION
# Description

This fixed an regression about object filament selector popup menu on Linux.
The UX improvement introduced in PR #12603 is reverted on Linux

# Screenshots/Recordings/Graphs
<img width="1046" height="927" alt="linux-issue" src="https://github.com/user-attachments/assets/85b0ffd1-47bc-48cc-ab8b-5a356466cb16" />



## Tests

<!--
> Please describe the tests that you have conducted to verify the changes made in this PR.
-->

<!--
> A guide for users on how to download the artifacts from this PR.
-->

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
