### PR TITLE
Fix faint toolbar icons on Wayland

### DIFF
--- a/src/slic3r/GUI/GLTexture.cpp
+++ b/src/slic3r/GUI/GLTexture.cpp
@@ -663,7 +663,9 @@ void GLTexture::render_texture(unsigned int tex_id, float left, float right, flo
 void GLTexture::render_sub_texture(unsigned int tex_id, float left, float right, float bottom, float top, const GLTexture::Quad_UVs& uvs)
 {
     glsafe(::glEnable(GL_BLEND));
-    glsafe(::glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA));
+    // Orca: fix washed-out toolbar icons on Wayland: keep destination alpha at 1.0 so the compositor
+    // does not treat anti-aliased icon edges as window transparency.
+    glsafe(::glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE, GL_ONE_MINUS_SRC_ALPHA));
 
     glsafe(::glEnable(GL_TEXTURE_2D));
     glsafe(::glTexEnvi(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_REPLACE));


### PR DESCRIPTION

# Description

On Linux + Wayland, the top toolbar icons (move, rotate, scale, arrange, etc.) render so faint they appear nearly invisible against the toolbar background. The same icons look correct on X11, Windows, and macOS. The issue happens at any display scale, with or without fractional scaling enabled.

# Screenshots/Recordings/Graphs
before: 
<img width="1345" height="85" alt="normal_size" src="https://github.com/user-attachments/assets/756dd2c2-9fbe-496f-80e9-ddbd8780bd59" />

after:
<img width="1342" height="66" alt="Screenshot From 2026-05-19 01-38-02" src="https://github.com/user-attachments/assets/8e9c8162-8589-4009-93a6-723232b8048e" />

## Tests

<!--
> Please describe the tests that you have conducted to verify the changes made in this PR.
-->

<!--
> A guide for users on how to download the artifacts from this PR.
-->

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
