### PR TITLE
CLI: emit type field in user preset JSONs (--load-settings unblock)

### DIFF
--- a/src/libslic3r/Config.cpp
+++ b/src/libslic3r/Config.cpp
@@ -1468,8 +1468,11 @@ void ConfigBase::save_to_json(const std::string &file, const std::string &name, 
     j[BBL_JSON_KEY_VERSION] = version;
     j[BBL_JSON_KEY_NAME] = name;
     j[BBL_JSON_KEY_FROM] = from;
-    //ORCA: emit type when caller supplies it (Preset::save passes get_iot_type_string). Required by CLI
+    //ORCA: emit type when caller supplies it (Preset::save passes get_type_string). Required by CLI
     //      --load-settings loader, which rejects JSONs missing the `type` field with "unknown config type".
+    //      Must be get_type_string ("machine"/"process"/"filament"), NOT get_iot_type_string
+    //      ("printer"/"print"/"filament") -- the CLI string-compares against the former, and system
+    //      profiles on disk carry those names. Only the filament case coincides between the two.
     if (!type.empty())
         j[BBL_JSON_KEY_TYPE] = type;
 

--- a/src/libslic3r/Config.cpp
+++ b/src/libslic3r/Config.cpp
@@ -1461,13 +1461,17 @@ ConfigSubstitutions ConfigBase::load_from_gcode_file(const std::string &file, Fo
 }
 
 //BBS: add json support
-void ConfigBase::save_to_json(const std::string &file, const std::string &name, const std::string &from, const std::string &version) const
+void ConfigBase::save_to_json(const std::string &file, const std::string &name, const std::string &from, const std::string &version, const std::string &type) const
 {
     json j;
     //record the headers
     j[BBL_JSON_KEY_VERSION] = version;
     j[BBL_JSON_KEY_NAME] = name;
     j[BBL_JSON_KEY_FROM] = from;
+    //ORCA: emit type when caller supplies it (Preset::save passes get_iot_type_string). Required by CLI
+    //      --load-settings loader, which rejects JSONs missing the `type` field with "unknown config type".
+    if (!type.empty())
+        j[BBL_JSON_KEY_TYPE] = type;
 
     //record all the key-values
     for (const std::string &opt_key : this->keys())

--- a/src/libslic3r/Config.hpp
+++ b/src/libslic3r/Config.hpp
@@ -2746,7 +2746,10 @@ public:
     void save(const std::string &file) const;
 
     //BBS: add json support
-    void save_to_json(const std::string &file, const std::string &name, const std::string &from, const std::string &version) const;
+    //ORCA: optional `type` is emitted as the BBL_JSON_KEY_TYPE field so the CLI loader can resolve preset type
+    //      without depending on the directory layout. Empty type (default) preserves prior behavior for callers
+    //      that don't have a meaningful Preset::Type (e.g. project_settings, Physical_Printer, bundle metadata).
+    void save_to_json(const std::string &file, const std::string &name, const std::string &from, const std::string &version, const std::string &type = std::string()) const;
 
 	// Set all the nullable values to nils.
     void null_nullables();

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -691,13 +691,14 @@ void Preset::save(DynamicPrintConfig* parent_config)
                     opt_dst->set(opt_src);
             }
         }
-        temp_config.save_to_json(this->file, bare_name, from_str, this->version.to_string());
+        //ORCA: emit Preset::Type so CLI --load-settings can resolve the preset type without relying on directory layout
+        temp_config.save_to_json(this->file, bare_name, from_str, this->version.to_string(), Preset::get_type_string(this->type));
     } else if (!filament_id.empty() && inherits().empty()) {
         DynamicPrintConfig temp_config = config;
         temp_config.set_key_value(BBL_JSON_KEY_FILAMENT_ID, new ConfigOptionString(filament_id));
-        temp_config.save_to_json(this->file, bare_name, from_str, this->version.to_string());
+        temp_config.save_to_json(this->file, bare_name, from_str, this->version.to_string(), Preset::get_type_string(this->type));
     } else {
-        this->config.save_to_json(this->file, bare_name, from_str, this->version.to_string());
+        this->config.save_to_json(this->file, bare_name, from_str, this->version.to_string(), Preset::get_type_string(this->type));
     }
     BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << " save config for: " << this->name << " and filament_id: " << filament_id << " and base_id: " << this->base_id;
 


### PR DESCRIPTION
# Description

`Preset::save` currently writes user JSONs without a top-level `"type"` field.
`save_to_json` doesn't accept the type, so it never lands in the file. The CLI
`--load-settings` loader inspects this field to dispatch by preset kind and
**rejects** user-saved JSONs with:

```
unknown config type
```

…because user presets only carry their kind implicitly via directory layout
(`user/default/{machine,process,filament}/…`), which the CLI doesn't read.

This means user-saved presets (system preset + your own tweaks) cannot be
used from CLI — only system JSONs work end-to-end today.

## Fix

Add an optional `type` parameter to `ConfigBase::save_to_json` and have
`Preset::save` pass `Preset::get_type_string(this->type)` at all three
call sites. User "Save as new" JSONs now carry the same `"type":
"process|filament|machine"` field system presets already have.

It has to be `get_type_string`, not `get_iot_type_string` — the two
conventions differ and only coincide for filament:

| | printer | print | filament |
|---|---|---|---|
| `get_type_string` (local) | `machine` | `process` | `filament` |
| `get_iot_type_string` (BBL cloud) | `printer` | `print` | `filament` |

`load_config_file` string-compares `config_type` against `"machine"` /
`"process"` / `"filament"` with no normalisation, and the profiles in
`resources/profiles` carry those local names. Emitting the IoT names would
leave machine and process still rejected as "unknown config type" while
filament passed by coincidence.

Default empty string preserves prior behavior for the other `save_to_json`
callers (project_settings export, Physical_Printer, bundle metadata) that
don't have a `Preset::Type` at hand.

## Compatibility

- Existing user JSONs on disk are untouched until next save in the GUI.
- Adding the `type` field is a strict superset of the prior format — older
  builds ignore unknown JSON keys.

## Tests

- "Save as new" filament/process/printer in GUI; verify the resulting JSON
  has `"type"` set.
- CLI `--load-settings <user-saved-process.json>;<user-saved-machine.json>
  --load-filaments <user-saved-filament.json>` no longer errors with
  "unknown config type". Verified against a Prusa Generic PLA-derived user
  filament and a 0.20mm SPEED-derived user process.
