### PR TITLE
CLI: absolutize argv file paths before GUI launch

### DIFF
--- a/src/OrcaSlicer.cpp
+++ b/src/OrcaSlicer.cpp
@@ -1317,13 +1317,26 @@ int CLI::run(int argc, char **argv)
         params.load_configs = load_configs;
         params.extra_config = std::move(m_extra_config);
 
+        //ORCA: argv file paths must be absolutized before they reach the GUI. wxWidgets can change
+        //      the process cwd during init (locale / AppConfig / wxStandardPaths), so a relative
+        //      argv path resolves against the wrong directory by the time Plater::load_files runs —
+        //      silent failure / "no geometry data". Use weakly_canonical so existing relative paths
+        //      are fully canonicalized; non-existent paths fall back to absolute() against the
+        //      current cwd.
         std::vector<std::string>    gcode_files;
         std::vector<std::string>    non_gcode_files;
         for (const auto& filename : m_input_files) {
-            if (is_gcode_file(filename))
-                gcode_files.emplace_back(filename);
+            std::string abs_filename = filename;
+            try {
+                abs_filename = boost::filesystem::weakly_canonical(boost::filesystem::path(filename)).string();
+            } catch (const std::exception &ex) {
+                BOOST_LOG_TRIVIAL(warning) << __FUNCTION__ << ": failed to canonicalize input path \""
+                                           << filename << "\": " << ex.what() << "; using path as-is";
+            }
+            if (is_gcode_file(abs_filename))
+                gcode_files.emplace_back(std::move(abs_filename));
             else {
-                non_gcode_files.emplace_back(filename);
+                non_gcode_files.emplace_back(std::move(abs_filename));
             }
         }
         if (non_gcode_files.empty() && !gcode_files.empty()) {
@@ -1332,7 +1345,9 @@ int CLI::run(int argc, char **argv)
             BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << ", gcode only, gcode_files size = "<<params.input_files.size();
         }
         else {
-            params.input_files  = std::move(m_input_files);
+            //ORCA: use the absolutized non_gcode_files vector here, not the raw m_input_files
+            //      (which still holds the relative paths read from argv).
+            params.input_files  = std::move(non_gcode_files);
             BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << ", normal mode, input_files size = "<<params.input_files.size();
         }
         //BBS: remove GCodeViewer as separate APP logic


### PR DESCRIPTION
# Description

Launching `orcaslicer model.3mf` (relative path) from a working directory
other than the binary's runtime cwd silently fails — either with no
visible error or with a "The file does not contain any geometry data."
dialog. The same launch with an absolute path works:

```bash
cd ~/Documents/parts
orcaslicer model.3mf                 # silent fail
orcaslicer /home/$USER/Documents/parts/model.3mf   # works
```

Cause: wxWidgets changes the process cwd during init (locale /
`AppConfig` / `wxStandardPaths` plumbing). By the time
`Plater::load_files` runs in `GUI_App::on_init_inner`, the relative argv
path resolves against the wrong directory and the load fails.

## Fix

Canonicalize each `m_input_files` entry with
`boost::filesystem::weakly_canonical` before partitioning into
`gcode_files` / `non_gcode_files`. `weakly_canonical` absolutizes against
`current_path()` for existing files, falls back to plain `absolute()`
semantics for non-existent paths (no throw), and normalizes `.` / `..`
for either. Failed calls log a warning and use the original path so
malformed inputs still get the same downstream error today.

A second hunk in the same loop fixes the `else` branch that fills
`params.input_files`: it previously moved `m_input_files` verbatim,
undoing the canonicalization. Now both branches feed from the
absolutized vectors.

## Tests

```bash
cd ~/some/directory
orcaslicer some_model.3mf   # before: silent fail — after: opens cleanly
```

Both relative and absolute paths now work regardless of launch cwd.
G-code-only inputs (`.gcode`) also go through the same canonicalization.