### PR TITLE
Add configurable custom prepare time for print estimation

### DIFF
--- a/src/libslic3r/GCode/GCodeProcessor.cpp
+++ b/src/libslic3r/GCode/GCodeProcessor.cpp
@@ -2030,6 +2030,8 @@ void GCodeProcessor::apply_config(const PrintConfig& config)
 
     m_disable_m73 = config.disable_m73;
 
+    m_custom_prepare_time = static_cast<float>(config.machine_custom_prepare_time.value);
+
     const ConfigOptionFloat* initial_layer_print_height = config.option<ConfigOptionFloat>("initial_layer_print_height");
     if (initial_layer_print_height != nullptr)
         m_first_layer_height = std::abs(initial_layer_print_height->value);
@@ -2263,6 +2265,10 @@ void GCodeProcessor::apply_config(const DynamicPrintConfig& config)
     if (machine_tool_change_time != nullptr)
         m_time_processor.machine_tool_change_time = static_cast<float>(machine_tool_change_time->value);
 
+    const ConfigOptionFloat* machine_custom_prepare_time = config.option<ConfigOptionFloat>("machine_custom_prepare_time");
+    if (machine_custom_prepare_time != nullptr)
+        m_custom_prepare_time = static_cast<float>(machine_custom_prepare_time->value);
+
     if (m_flavor == gcfMarlinLegacy || m_flavor == gcfMarlinFirmware || m_flavor == gcfKlipper) {
         const ConfigOptionFloats* machine_max_acceleration_x = config.option<ConfigOptionFloats>("machine_max_acceleration_x");
         if (machine_max_acceleration_x != nullptr)
@@ -2453,6 +2459,7 @@ void GCodeProcessor::reset()
     m_g1_line_id = 0;
     m_layer_id = 0;
     m_cp_color.reset();
+    m_custom_prepare_time = 0.0f;
 
     m_producer = EProducer::Unknown;
 
@@ -2630,7 +2637,11 @@ float GCodeProcessor::get_time(PrintEstimatedStatistics::ETimeMode mode) const
 
 float GCodeProcessor::get_prepare_time(PrintEstimatedStatistics::ETimeMode mode) const
 {
-    return (mode < PrintEstimatedStatistics::ETimeMode::Count) ? m_time_processor.machines[static_cast<size_t>(mode)].prepare_time : 0.0f;
+    if (mode >= PrintEstimatedStatistics::ETimeMode::Count)
+        return 0.0f;
+    if (m_custom_prepare_time > 0.0f)
+        return m_custom_prepare_time;
+    return m_time_processor.machines[static_cast<size_t>(mode)].prepare_time;
 }
 
 std::string GCodeProcessor::get_time_dhm(PrintEstimatedStatistics::ETimeMode mode) const

--- a/src/libslic3r/GCode/GCodeProcessor.hpp
+++ b/src/libslic3r/GCode/GCodeProcessor.hpp
@@ -817,6 +817,7 @@ class Print;
         float m_preheat_time;
         int m_preheat_steps;
         bool m_disable_m73;
+        float m_custom_prepare_time;
 
         enum class EProducer
         {

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -1333,7 +1333,7 @@ static std::vector<std::string> s_Preset_printer_options {
     "nozzle_height", "master_extruder_id",
     "default_print_profile", "inherits",
     "silent_mode",
-    "scan_first_layer", "enable_power_loss_recovery", "wrapping_detection_layers", "wrapping_exclude_area", "machine_load_filament_time", "machine_unload_filament_time", "machine_tool_change_time", "time_cost", "machine_pause_gcode", "template_custom_gcode",
+    "scan_first_layer", "enable_power_loss_recovery", "wrapping_detection_layers", "wrapping_exclude_area", "machine_load_filament_time", "machine_unload_filament_time", "machine_tool_change_time", "time_cost", "machine_custom_prepare_time", "machine_pause_gcode", "template_custom_gcode",
     "nozzle_type", "nozzle_hrc","auxiliary_fan", "nozzle_volume","upward_compatible_machine", "z_hop_types", "travel_slope", "retract_lift_enforce","support_chamber_temp_control","support_air_filtration","printer_structure",
     "best_object_pos", "head_wrap_detect_zone",
     "host_type", "print_host", "printhost_apikey", "bbl_use_printhost", "printer_agent",

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -3733,6 +3733,17 @@ void PrintConfigDef::init_fff_params()
     def->mode    = comAdvanced;
     def->set_default_value(new ConfigOptionFloat(0));
 
+    def = this->add("machine_custom_prepare_time", coFloat);
+    def->label = L("Custom prepare time");
+    def->tooltip = L("Override the prepare time (heating, homing, etc.) used in print time estimation. "
+                     "Set this when your start G-code is minimal (e.g. Klipper PRINT_START macro) and the "
+                     "actual preparation happens in the printer firmware or macros. Set to 0 to use the time "
+                     "computed from the start G-code.");
+    def->sidetext = L("s");
+    def->min = 0;
+    def->mode = comAdvanced;
+    def->set_default_value(new ConfigOptionFloat(0));
+
     // Orca: may remove this option later
     def =this->add("support_chamber_temp_control",coBool);
     def->label=L("Support control chamber temperature");

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -1349,7 +1349,8 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionBool,                bbl_bed_temperature_gcode))
     ((ConfigOptionEnum<GCodeFlavor>,   gcode_flavor))
 
-    ((ConfigOptionFloat,               time_cost)) 
+    ((ConfigOptionFloat,               time_cost))
+    ((ConfigOptionFloat,               machine_custom_prepare_time))
     ((ConfigOptionString,              layer_change_gcode))
     ((ConfigOptionString,              time_lapse_gcode))
     ((ConfigOptionString,              wrapping_detection_gcode))

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -4492,6 +4492,7 @@ void TabPrinter::build_fff()
         optgroup->append_single_option_line("use_firmware_retraction", "printer_basic_information_advanced#use-firmware-retraction");
         // optgroup->append_single_option_line("spaghetti_detector");
         optgroup->append_single_option_line("time_cost", "printer_basic_information_advanced#time-cost");
+        optgroup->append_single_option_line("machine_custom_prepare_time", "printer_basic_information_advanced#custom-prepare-time");
 
         optgroup  = page->new_optgroup(L("Cooling Fan"), "param_cooling_fan");
         Line line = Line{ L("Fan speed-up time"), optgroup->get_option("fan_speedup_time").opt.tooltip };


### PR DESCRIPTION
Adds a "Custom prepare time" setting (machine_custom_prepare_time, in seconds) to printer profiles. When set to a non-zero value it overrides the prepare time that is normally computed from the start G-code, giving users an accurate total time estimate even when their preparation routine lives entirely in firmware macros (e.g. a Klipper PRINT_START call).

# Description

Closes #5796.

OrcaSlicer estimates prepare time (heating, homing, etc.) by timing the moves in the start G-code. Klipper users who delegate preparation to firmware macros get an estimate of ~1 second, making total print time estimates inaccurate.

**Changes:**
- New **Custom prepare time** field (seconds) in Printer Settings → Basic Information → Advanced, alongside the existing Time Cost field
- New `machine_custom_prepare_time` config option (default `0` = use computed value) saved and loaded with printer profiles
- When non-zero, the value replaces the G-code-computed prepare time in the prepare/total time display; print (model-only) time is unaffected
- No behavior change when left at the default of 0

# Screenshots/Recordings/Graphs
<img width="708" height="512" alt="Screenshot 2026-05-18 213610" src="https://github.com/user-attachments/assets/ed775157-414a-41f1-8394-91bf927022cc" />

## Tests

- With field at 0 (default): prepare time and total time are unchanged from existing behavior
- With field set to 180s: prepare time in the G-code viewer shows 3:00 and total time increases by the same amount; model print time is unaffected
- Setting back to 0 restores the G-code-computed prepare time
- Value persists after saving, closing, and reopening the printer profile
- Tested with a Klipper printer profile using a minimal `PRINT_START` start G-code

<!--
> A guide for users on how to download the artifacts from this PR.
-->

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
