### PR TITLE
fix: printer and print upload dialog colors

### DIFF
--- a/src/slic3r/GUI/DeviceTab/uiDeviceUpdateVersion.cpp
+++ b/src/slic3r/GUI/DeviceTab/uiDeviceUpdateVersion.cpp
@@ -27,6 +27,7 @@ uiDeviceUpdateVersion::uiDeviceUpdateVersion(wxWindow* parent,
                                              long style /*= wxTAB_TRAVERSAL*/)
      : wxPanel(parent, id, pos, size, style)
 {
+    SetBackgroundColour(*wxWHITE);
     CreateWidgets();
 }
 

--- a/src/slic3r/GUI/SelectMachine.cpp
+++ b/src/slic3r/GUI/SelectMachine.cpp
@@ -517,7 +517,7 @@ SelectMachineDialog::SelectMachineDialog(Plater *plater)
     sizer_split_options->Add(m_split_options_line, 1, wxALIGN_CENTER, 0);
 
     m_options_other = new wxPanel(m_scroll_area);
-
+    m_options_other->SetBackgroundColour(m_colour_def_color);
 
     auto option_timelapse = new PrintOption(m_options_other, _L("Timelapse"), wxEmptyString, ops_no_auto, "timelapse");
 
@@ -566,6 +566,7 @@ SelectMachineDialog::SelectMachineDialog(Plater *plater)
     option_nozzle_offset_cali_cali->Hide();
 
     m_simplebook   = new wxSimplebook(this, wxID_ANY, wxDefaultPosition, SELECT_MACHINE_DIALOG_SIMBOOK_SIZE2, 0);
+    m_simplebook->SetBackgroundColour(m_colour_def_color);
     m_simplebook->SetMinSize(SELECT_MACHINE_DIALOG_SIMBOOK_SIZE2);
     m_simplebook->SetMaxSize(SELECT_MACHINE_DIALOG_SIMBOOK_SIZE2);
 

--- a/src/slic3r/GUI/SelectMachinePop.cpp
+++ b/src/slic3r/GUI/SelectMachinePop.cpp
@@ -325,7 +325,7 @@ SelectMachinePopup::SelectMachinePopup(wxWindow *parent)
 
 
     m_scrolledWindow = new wxScrolledWindow(this, wxID_ANY, wxDefaultPosition, SELECT_MACHINE_LIST_SIZE, wxHSCROLL | wxVSCROLL);
-    m_scrolledWindow->SetBackgroundColour(*wxWHITE);
+    m_scrolledWindow->SetBackgroundColour(StateColor::darkModeColorFor(*wxWHITE));
     m_scrolledWindow->SetMinSize(SELECT_MACHINE_LIST_SIZE);
     m_scrolledWindow->SetScrollRate(0, 5);
     auto m_sizxer_scrolledWindow = new wxBoxSizer(wxVERTICAL);
@@ -465,7 +465,7 @@ bool SelectMachinePopup::Show(bool show) {
 wxWindow *SelectMachinePopup::create_title_panel(wxString text)
 {
     auto m_panel_title_own = new wxWindow(m_scrolledWindow, wxID_ANY, wxDefaultPosition, SELECT_MACHINE_ITEM_SIZE, wxTAB_TRAVERSAL);
-    m_panel_title_own->SetBackgroundColour(*wxWHITE);
+    m_panel_title_own->SetBackgroundColour(StateColor::darkModeColorFor(*wxWHITE));
 
     wxBoxSizer *m_sizer_title_own = new wxBoxSizer(wxHORIZONTAL);
 
@@ -993,6 +993,7 @@ void EditDevNameDialog::on_edit_name(wxCommandEvent &e)
 PinCodePanel::PinCodePanel(wxWindow* parent, int type, wxWindowID winid /*= wxID_ANY*/, const wxPoint& pos /*= wxDefaultPosition*/, const wxSize& size /*= wxDefaultSize*/)
  {
      wxPanel::Create(parent, winid, pos);
+     SetBackgroundColour(StateColor::darkModeColorFor(*wxWHITE));
      Bind(wxEVT_PAINT, &PinCodePanel::OnPaint, this);
      SetSize(SELECT_MACHINE_ITEM_SIZE);
      SetMaxSize(SELECT_MACHINE_ITEM_SIZE);

--- a/src/slic3r/GUI/StatusPanel.cpp
+++ b/src/slic3r/GUI/StatusPanel.cpp
@@ -536,6 +536,7 @@ void PrintingTaskPanel::create_panel(wxWindow* parent)
     wxBoxSizer *bSizer_task_name = new wxBoxSizer(wxVERTICAL);
     wxBoxSizer *bSizer_task_name_hor = new wxBoxSizer(wxHORIZONTAL);
     wxPanel*    task_name_panel      = new wxPanel(parent);
+    task_name_panel->SetBackgroundColour(*wxWHITE);
 
     m_staticText_subtask_value = new wxStaticText(task_name_panel, wxID_ANY, _L("N/A"), wxDefaultPosition, wxDefaultSize, wxALIGN_LEFT | wxST_ELLIPSIZE_END);
     m_staticText_subtask_value->SetMaxSize(wxSize(FromDIP(600), -1));

--- a/src/slic3r/GUI/StatusPanel.cpp
+++ b/src/slic3r/GUI/StatusPanel.cpp
@@ -704,6 +704,7 @@ void PrintingTaskPanel::create_panel(wxWindow* parent)
     bSizer_text->Add(m_staticText_progress_left, 0, wxALIGN_CENTER_VERTICAL | wxALL, 0);
 
     m_printing_stage_panel = new wxPanel(penel_finish_time);
+    m_printing_stage_panel->SetBackgroundColour(*wxWHITE);
     wxBoxSizer *printingstage_vertical_sizer = new wxBoxSizer(wxVERTICAL);
     wxBoxSizer *printingstage_horizontal_sizer = new wxBoxSizer(wxHORIZONTAL);
 

--- a/src/slic3r/GUI/UpgradePanel.cpp
+++ b/src/slic3r/GUI/UpgradePanel.cpp
@@ -1352,12 +1352,11 @@ void MachineInfoPanel::on_show_release_note(wxMouseEvent &event)
 UpgradePanel::UpgradePanel(wxWindow *parent, wxWindowID id, const wxPoint &pos, const wxSize &size, long style)
     :wxPanel(parent, id, pos, size, style)
 {
-    this->SetBackgroundColour(wxColour(255, 255, 255));
+    this->SetBackgroundColour(wxColour(238, 238, 238));
 
     auto m_main_sizer = new wxBoxSizer(wxVERTICAL);
 
     m_scrolledWindow = new wxScrolledWindow(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxVSCROLL);
-    m_scrolledWindow->SetBackgroundColour(wxColour(255, 255, 255));
     m_scrolledWindow->SetScrollRate(5, 25);
 
     m_machine_list_sizer = new wxBoxSizer(wxVERTICAL);
@@ -1612,6 +1611,7 @@ bool UpgradePanel::Show(bool show)
      const wxString& name /*= wxEmptyString*/)
      : wxPanel(parent, id, pos, size, style)
  {
+
      upgrade_green_icon = ScalableBitmap(this, "monitor_upgrade_online", 5);
 
      auto top_sizer = new wxBoxSizer(wxVERTICAL);

--- a/src/slic3r/GUI/UpgradePanel.cpp
+++ b/src/slic3r/GUI/UpgradePanel.cpp
@@ -1352,11 +1352,12 @@ void MachineInfoPanel::on_show_release_note(wxMouseEvent &event)
 UpgradePanel::UpgradePanel(wxWindow *parent, wxWindowID id, const wxPoint &pos, const wxSize &size, long style)
     :wxPanel(parent, id, pos, size, style)
 {
-    this->SetBackgroundColour(wxColour(238, 238, 238));
+    this->SetBackgroundColour(wxColour(255, 255, 255));
 
     auto m_main_sizer = new wxBoxSizer(wxVERTICAL);
 
     m_scrolledWindow = new wxScrolledWindow(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxVSCROLL);
+    m_scrolledWindow->SetBackgroundColour(wxColour(255, 255, 255));
     m_scrolledWindow->SetScrollRate(5, 25);
 
     m_machine_list_sizer = new wxBoxSizer(wxVERTICAL);
@@ -1527,6 +1528,7 @@ bool UpgradePanel::Show(bool show)
                    const wxString &name /*= wxEmptyString*/)
     : wxPanel(parent,id,pos,size,style)
 {
+     SetBackgroundColour(*wxWHITE);
      upgrade_green_icon = ScalableBitmap(this, "monitor_upgrade_online", 5);
 
      auto ams_sizer = new wxFlexGridSizer(0, 2, 0, 0);
@@ -1610,7 +1612,6 @@ bool UpgradePanel::Show(bool show)
      const wxString& name /*= wxEmptyString*/)
      : wxPanel(parent, id, pos, size, style)
  {
-
      upgrade_green_icon = ScalableBitmap(this, "monitor_upgrade_online", 5);
 
      auto top_sizer = new wxBoxSizer(wxVERTICAL);


### PR DESCRIPTION
# Description

This fixes some inconsistent colors in dark mode on the print upload GUI and print tab.

# Screenshots/Recordings/Graphs

<table>
<tr>
 <td>Before</td>
 <td>After</td>
<tr>
 <td>
<img width="658" height="237" alt="image" src="https://github.com/user-attachments/assets/8c2a6ae6-ed1e-43be-b223-d7a3b04254f2" />
</td>
 <td>
<img width="660" height="238" alt="image" src="https://github.com/user-attachments/assets/8082a973-9ad5-4d95-a13d-97142cc9e0b0" />
</td>
</table>

<table>
<tr>
 <td>Before</td>
 <td>After</td>
<tr>
 <td>
<img width="691" height="292" alt="image" src="https://github.com/user-attachments/assets/0f29c97d-cb05-406b-a04f-a9bc72f1cb72" />
</td>
 <td>
<img width="694" height="300" alt="image" src="https://github.com/user-attachments/assets/ed96181b-986c-48b9-ada0-9386ea634c80" />
</td>
</table>

<table>
<tr>
 <td>Before</td>
 <td>After</td>
<tr>
 <td>
<img width="1512" height="832" alt="Screenshot 2026-05-18 at 10 33 06 PM" src="https://github.com/user-attachments/assets/f3a84799-1325-41f8-a6e8-e6559435f6e4" />

</td>
 <td>
<img width="1511" height="825" alt="Screenshot 2026-05-18 at 10 33 59 PM" src="https://github.com/user-attachments/assets/dd3318eb-5a06-466f-93da-7ffaa7fcf5a8" />


</td>
</table>

<table>
<tr>
 <td>Before</td>
 <td>After</td>
<tr>
 <td>
<img width="221" height="423" alt="image" src="https://github.com/user-attachments/assets/60f43db9-e70c-4ed8-8ea9-69b270a74de6" />
</td>
 <td>
<img width="218" height="418" alt="image" src="https://github.com/user-attachments/assets/316eb4d0-2150-4f96-9725-908dc0141086" />


</td>
</table>

## Tests

<!--
> Please describe the tests that you have conducted to verify the changes made in this PR.
-->

Visually verified between latest nightly and build on local machine

<!--
> A guide for users on how to download the artifacts from this PR.
-->

NOTE: Claude was (obviously) used for the construction of these commits. The changes are quite minimal so hopefully should be easy enough to review along with the screenshots. 