### PR TITLE
fix: macOS deep links after wxWidgets 3.3.2 upgrade

### DIFF
--- a/src/slic3r/CMakeLists.txt
+++ b/src/slic3r/CMakeLists.txt
@@ -687,6 +687,8 @@ if (APPLE)
             GUI/Mouse3DHandlerMac.mm
             GUI/InstanceCheckMac.mm
             GUI/InstanceCheckMac.h
+            GUI/DeepLinkHandlerMac.mm
+            GUI/DeepLinkHandlerMac.h
             GUI/GUI_UtilsMac.mm
             GUI/wxMediaCtrl2.mm
             GUI/wxMediaCtrl2.h

--- a/src/slic3r/GUI/DeepLinkHandlerMac.h
+++ b/src/slic3r/GUI/DeepLinkHandlerMac.h
@@ -1,0 +1,16 @@
+#ifndef slic3r_GUI_DeepLinkHandlerMac_h_
+#define slic3r_GUI_DeepLinkHandlerMac_h_
+
+namespace Slic3r {
+namespace GUI {
+
+// Re-registers a Cocoa Apple Event handler for kInternetEventClass/kAEGetURL.
+// Works around a regression observed after upgrading to wxWidgets 3.3.2 on
+// macOS Tahoe (#13119) where wxWidgets' built-in handler is registered but
+// never fires for orcaslicer:// deep links.
+void register_mac_deep_link_handler();
+
+} // namespace GUI
+} // namespace Slic3r
+
+#endif

--- a/src/slic3r/GUI/DeepLinkHandlerMac.mm
+++ b/src/slic3r/GUI/DeepLinkHandlerMac.mm
@@ -1,0 +1,41 @@
+#import <AppKit/AppKit.h>
+#import <Foundation/Foundation.h>
+
+#include <boost/log/trivial.hpp>
+
+#include "DeepLinkHandlerMac.h"
+#include "GUI_App.hpp"
+
+@interface OrcaDeepLinkHandler : NSObject
+- (void)handleGetURLEvent:(NSAppleEventDescriptor *)event withReplyEvent:(NSAppleEventDescriptor *)reply;
+@end
+
+@implementation OrcaDeepLinkHandler
+- (void)handleGetURLEvent:(NSAppleEventDescriptor *)event withReplyEvent:(NSAppleEventDescriptor *)reply
+{
+    NSString *url = [[event paramDescriptorForKeyword:keyDirectObject] stringValue];
+    if (url == nil || url.length == 0)
+        return;
+    BOOST_LOG_TRIVIAL(info) << "Deep link received: " << [url UTF8String];
+    Slic3r::GUI::wxGetApp().MacOpenURL(wxString::FromUTF8([url UTF8String]));
+}
+@end
+
+namespace Slic3r {
+namespace GUI {
+
+void register_mac_deep_link_handler()
+{
+    static OrcaDeepLinkHandler *handler = nil;
+    if (handler == nil)
+        handler = [[OrcaDeepLinkHandler alloc] init];
+
+    [[NSAppleEventManager sharedAppleEventManager]
+        setEventHandler:handler
+            andSelector:@selector(handleGetURLEvent:withReplyEvent:)
+          forEventClass:kInternetEventClass
+             andEventID:kAEGetURL];
+}
+
+} // namespace GUI
+} // namespace Slic3r

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -100,6 +100,9 @@
 #include "Mouse3DController.hpp"
 #include "RemovableDriveManager.hpp"
 #include "InstanceCheck.hpp"
+#ifdef __APPLE__
+#include "DeepLinkHandlerMac.h"
+#endif
 #include "NotificationManager.hpp"
 #include "UnsavedChangesDialog.hpp"
 #include "SavePresetDialog.hpp"
@@ -2547,6 +2550,12 @@ std::string get_system_info()
 bool GUI_App::on_init_inner()
 {
     wxLog::SetActiveTarget(new wxBoostLog());
+
+#ifdef __APPLE__
+    // Override wxWidgets' kAEGetURL handler so orcaslicer:// deep links keep
+    // working after the wxWidgets 3.3.2 upgrade on macOS (#13119).
+    register_mac_deep_link_handler();
+#endif
 #if BBL_RELEASE_TO_PUBLIC
     wxLog::SetLogLevel(wxLOG_Message);
 #endif


### PR DESCRIPTION


# Description

Installs an OrcaSlicer-owned `kAEGetURL` Apple Event handler from `on_init_inner()`. The wxWidgets 3.3.2 handler registered in `applicationWillFinishLaunching:` stopped delivering URL events to `GUI_App::MacOpenURL` on macOS (#13119), so links from Printables opened a blank project instead of importing the model.

Registering our own handler late in startup is last-writer-wins on NSAppleEventManager and routes back to the existing MacOpenURL -> start_download path, restoring the pre-upgrade behavior without touching wxWidgets.

NOTE: I am not a C++/macOS dev and leaned heavily on Claude for debugging and implementation. I have confirmed this fix works and restores deep link functionality.

There is an argument here that this should be resolved in wxwidgets but in the meantime, we should get this fixed as having broken integration with a bunch of third party sites (Printables, Thingiverse, etc) isn't a good UX. The changes here are very easy to revert (delete 2 files, revert CMakeLists, and remove the call to install the handler) once wxwidgets fixes it upstream.

Closes #13119

# Screenshots/Recordings/Graphs

N/A

## Tests

<!--
> Please describe the tests that you have conducted to verify the changes made in this PR.
-->

Tried opening a .stl file from Printables via the Open in Orcaslicer button on latest nightly which just opens a blank project (as described in #13119). Opening a on a build from this branch from the button successfully imports the file as it did before the wxwidgets upgrade (#12941). 

I narrowed the cause down to that specific PR as before the merge commit, functionality was fine, but after that commit was merged, the deeplink no longer works.


