### PR TITLE
feat: add UI feedback on http error and some logs

### DIFF
--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -4835,12 +4835,12 @@ void GUI_App::on_http_error(wxCommandEvent &evt)
                 BOOST_LOG_TRIVIAL(warning) << "logout: http error 401.";
                 this->request_user_logout(provider);
 
-                if (!m_show_http_errpr_msgdlg) {
+                if (!m_show_http_error_msgdlg) {
                     MessageDialog msg_dlg(nullptr, _L("Login information expired. Please login again."), "", wxAPPLY | wxOK);
-                    m_show_http_errpr_msgdlg = true;
+                    m_show_http_error_msgdlg = true;
                     auto modal_result = msg_dlg.ShowModal();
                     if (modal_result == wxOK || modal_result == wxCLOSE) {
-                        m_show_http_errpr_msgdlg = false;
+                        m_show_http_error_msgdlg = false;
                         return;
                     }
                 }
@@ -4851,9 +4851,9 @@ void GUI_App::on_http_error(wxCommandEvent &evt)
 
     // Show general error notification for Orca Cloud API failures (not Bambu)
     if (provider == ORCA_CLOUD_PROVIDER && status >= 400 && code != HttpErrorVersionLimited) {
-        if (m_show_http_errpr_msgdlg)
+        if (m_show_http_error_msgdlg)
             return;
-        m_show_http_errpr_msgdlg = true;
+        m_show_http_error_msgdlg = true;
 
         wxString msg;
         if (!error.empty()) {
@@ -4862,7 +4862,7 @@ void GUI_App::on_http_error(wxCommandEvent &evt)
             msg = wxString::Format(_L("API error (HTTP %u)"), status);
         }
         wxMessageBox(msg, _L("Orca Cloud API Error"), wxOK | wxICON_ERROR, wxGetApp().mainframe);
-        m_show_http_errpr_msgdlg = false;
+        m_show_http_error_msgdlg = false;
     }
 }
 

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -4848,6 +4848,22 @@ void GUI_App::on_http_error(wxCommandEvent &evt)
         }
         return;
     }
+
+    // Show general error notification for Orca Cloud API failures (not Bambu)
+    if (provider == ORCA_CLOUD_PROVIDER && status >= 400 && code != HttpErrorVersionLimited) {
+        if (m_show_http_errpr_msgdlg)
+            return;
+        m_show_http_errpr_msgdlg = true;
+
+        wxString msg;
+        if (!error.empty()) {
+            msg = wxString::Format(_L("API error (HTTP %u): %s"), status, wxString::FromUTF8(error));
+        } else {
+            msg = wxString::Format(_L("API error (HTTP %u)"), status);
+        }
+        wxMessageBox(msg, _L("Orca Cloud API Error"), wxOK | wxICON_ERROR, wxGetApp().mainframe);
+        m_show_http_errpr_msgdlg = false;
+    }
 }
 
 void GUI_App::enable_user_preset_folder(bool enable)

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -4849,11 +4849,12 @@ void GUI_App::on_http_error(wxCommandEvent &evt)
         return;
     }
 
+    static bool m_show_api_error = false;
     // Show general error notification for Orca Cloud API failures (not Bambu)
     if (provider == ORCA_CLOUD_PROVIDER && status >= 400 && code != HttpErrorVersionLimited) {
-        if (m_show_http_error_msgdlg)
+        if (m_show_api_error)
             return;
-        m_show_http_error_msgdlg = true;
+        m_show_api_error = true;
 
         wxString msg;
         if (!error.empty()) {
@@ -4862,7 +4863,6 @@ void GUI_App::on_http_error(wxCommandEvent &evt)
             msg = wxString::Format(_L("API error (HTTP %u)"), status);
         }
         wxMessageBox(msg, _L("Orca Cloud API Error"), wxOK | wxICON_ERROR, wxGetApp().mainframe);
-        m_show_http_error_msgdlg = false;
     }
 }
 

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -4876,7 +4876,6 @@ void GUI_App::on_http_error(wxCommandEvent &evt)
                     ->push_notification(NotificationType::PlaterError, NotificationManager::NotificationLevel::WarningNotificationLevel,
                                         msg.ToUTF8().data());
             }
-            return;
         }
 
         if (!m_is_error_shown) {

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -11,6 +11,7 @@
 #include "Downloader.hpp"
 #include <boost/chrono/duration.hpp>
 #include <boost/log/detail/native_typeof.hpp>
+#include <libslic3r/Config.hpp>
 #include <wx/event.h>
 
 // Localization headers: include libslic3r version first so everything in this file
@@ -4849,20 +4850,39 @@ void GUI_App::on_http_error(wxCommandEvent &evt)
         return;
     }
 
-    static bool m_show_api_error = false;
+    // No need to show dialog for 410: 410 means resource has been deleted from the server.
+    if (status == 410) {
+        BOOST_LOG_TRIVIAL(info) << "Http error 410.";
+        return;
+    }
+
+    static bool m_is_error_shown = false;
     // Show general error notification for Orca Cloud API failures (not Bambu)
     if (provider == ORCA_CLOUD_PROVIDER && status >= 400 && code != HttpErrorVersionLimited) {
-        if (m_show_api_error)
-            return;
-        m_show_api_error = true;
-
         wxString msg;
         if (!error.empty()) {
             msg = wxString::Format(_L("API error (HTTP %u): %s"), status, wxString::FromUTF8(error));
         } else {
             msg = wxString::Format(_L("API error (HTTP %u)"), status);
         }
-        wxMessageBox(msg, _L("Orca Cloud API Error"), wxOK | wxICON_ERROR, wxGetApp().mainframe);
+
+        if (app_config->get_bool("developer_mode")) {
+            // Use notification manager if ImGui is ready; fall back to wxMessageBox on Linux
+            // where ImGui may not be initialized until the user switches to the Prepare tab.
+            if (wxGetApp().plater() != nullptr && wxGetApp().imgui()->display_initialized()) {
+                wxGetApp()
+                    .plater()
+                    ->get_notification_manager()
+                    ->push_notification(NotificationType::PlaterError, NotificationManager::NotificationLevel::WarningNotificationLevel,
+                                        msg.ToUTF8().data());
+            }
+            return;
+        }
+
+        if (!m_is_error_shown) {
+            m_is_error_shown = true;
+            wxMessageBox(msg, _L("Orca Cloud API Error"), wxOK | wxICON_ERROR, wxGetApp().mainframe);
+        }
     }
 }
 

--- a/src/slic3r/GUI/GUI_App.hpp
+++ b/src/slic3r/GUI/GUI_App.hpp
@@ -324,7 +324,7 @@ private:
     bool             m_is_dark_mode{ false };
     bool             m_adding_script_handler { false };
     bool             m_side_popup_status{false};
-    bool             m_show_http_errpr_msgdlg{false};
+    bool             m_show_http_error_msgdlg{false};
     bool             m_show_error_msgdlg{false};
     wxString         m_info_dialog_content;
     HttpServer       m_http_server;

--- a/src/slic3r/GUI/ImGuiWrapper.hpp
+++ b/src/slic3r/GUI/ImGuiWrapper.hpp
@@ -373,12 +373,13 @@ public:
     //BBS
     static int TOOLBAR_WINDOW_FLAGS;
 
+    bool display_initialized() const;
+
 private:
     void init_font(bool compress);
     void init_input();
     void init_style();
     void render_draw_data(ImDrawData *draw_data);
-    bool display_initialized() const;
     void destroy_font();
     std::vector<unsigned char> load_svg(const std::string& bitmap_name, unsigned target_width, unsigned target_height, unsigned *outwidth, unsigned *outheight);
 

--- a/src/slic3r/Utils/OrcaCloudServiceAgent.cpp
+++ b/src/slic3r/Utils/OrcaCloudServiceAgent.cpp
@@ -1304,7 +1304,6 @@ void OrcaCloudServiceAgent::load_sync_state()
             }
         }
     } catch (...) {
-        BOOST_LOG_TRIVIAL(warning) << "load_sync_state: failed to read sync state file, resetting timestamp to 0";
         sync_state.last_sync_timestamp = 0;
     }
 }
@@ -1323,9 +1322,7 @@ void OrcaCloudServiceAgent::save_sync_state()
             ofs.close();
             boost::filesystem::rename(tmp_path, sync_state_path);
         }
-    } catch (...) {
-        BOOST_LOG_TRIVIAL(warning) << "save_sync_state: failed to write sync state file";
-    }
+    } catch (...) {}
 }
 
 void OrcaCloudServiceAgent::clear_sync_state()
@@ -2233,9 +2230,7 @@ void OrcaCloudServiceAgent::json_to_map(const std::string& json, std::map<std::s
                 map[it.key()] = it.value().dump();
             }
         }
-    } catch (...) {
-        BOOST_LOG_TRIVIAL(warning) << "json_to_map: failed to parse JSON";
-    }
+    } catch (...) {}
 }
 
 // ============================================================================

--- a/src/slic3r/Utils/OrcaCloudServiceAgent.cpp
+++ b/src/slic3r/Utils/OrcaCloudServiceAgent.cpp
@@ -1304,6 +1304,7 @@ void OrcaCloudServiceAgent::load_sync_state()
             }
         }
     } catch (...) {
+        BOOST_LOG_TRIVIAL(warning) << "load_sync_state: failed to read sync state file, resetting timestamp to 0";
         sync_state.last_sync_timestamp = 0;
     }
 }
@@ -1322,7 +1323,9 @@ void OrcaCloudServiceAgent::save_sync_state()
             ofs.close();
             boost::filesystem::rename(tmp_path, sync_state_path);
         }
-    } catch (...) {}
+    } catch (...) {
+        BOOST_LOG_TRIVIAL(warning) << "save_sync_state: failed to write sync state file";
+    }
 }
 
 void OrcaCloudServiceAgent::clear_sync_state()
@@ -2230,7 +2233,9 @@ void OrcaCloudServiceAgent::json_to_map(const std::string& json, std::map<std::s
                 map[it.key()] = it.value().dump();
             }
         }
-    } catch (...) {}
+    } catch (...) {
+        BOOST_LOG_TRIVIAL(warning) << "json_to_map: failed to parse JSON";
+    }
 }
 
 // ============================================================================


### PR DESCRIPTION
# Description

Previously, the central on_http_error handler in GUI_App silently
dropped all Orca Cloud HTTP errors except 401 and version-limited.
This meant users had no indication when sync, bundle, or other cloud
API calls failed.

- Show a native message box for Orca Cloud API errors (4xx/5xx),
  skipped for Bambu/BBL errors. Uses a guard flag to prevent
  multiple dialogs from stacking.
- Add warning-level logging to three previously-silent catch blocks
  in OrcaCloudServiceAgent: load_sync_state, save_sync_state, and
  json_to_map.

<img width="3367" height="1397" alt="image" src="https://github.com/user-attachments/assets/381d5498-3236-4a8f-978d-b3f53facfdc7" />

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
