### PR TITLE
QIDI box filament sync with custom vendor metadata 

### DIFF
--- a/src/slic3r/Utils/MoonrakerPrinterAgent.cpp
+++ b/src/slic3r/Utils/MoonrakerPrinterAgent.cpp
@@ -97,9 +97,35 @@ std::string normalize_filament_name_for_match(const std::string& input)
     if (const auto suffix_pos = normalized.find(" @"); suffix_pos != std::string::npos) {
         normalized = normalized.substr(0, suffix_pos);
     }
-    std::transform(normalized.begin(), normalized.end(), normalized.begin(),
-                   [](unsigned char c) { return static_cast<char>(std::toupper(c)); });
-    return normalized;
+    // Remove non-name symbols (e.g. trademark signs) while preserving separators
+    // commonly used in filament names.
+    std::string cleaned;
+    cleaned.reserve(normalized.size());
+    for (unsigned char c : normalized) {
+        if (std::isalnum(c) || c == '-' || c == '+' || c == '/' || std::isspace(c)) {
+            cleaned.push_back(static_cast<char>(std::toupper(c)));
+        } else {
+            cleaned.push_back(' ');
+        }
+    }
+
+    // Collapse repeated whitespace.
+    std::string collapsed;
+    collapsed.reserve(cleaned.size());
+    bool prev_space = true;
+    for (unsigned char c : cleaned) {
+        if (std::isspace(c)) {
+            if (!prev_space) {
+                collapsed.push_back(' ');
+            }
+            prev_space = true;
+        } else {
+            collapsed.push_back(static_cast<char>(c));
+            prev_space = false;
+        }
+    }
+    boost::trim(collapsed);
+    return collapsed;
 }
 
 bool filament_name_match_relaxed(const std::string& wanted, const std::string& candidate)
@@ -138,7 +164,9 @@ std::vector<std::string> vendor_match_candidates(std::string vendor)
     return candidates;
 }
 
-std::string filament_id_by_name(const Slic3r::PresetCollection& filaments, const std::string& filament_name)
+std::string filament_id_by_name(const Slic3r::PresetCollection& filaments,
+                                const std::string&             filament_name,
+                                const std::vector<std::string>& vendor_filters = {})
 {
     if (filament_name.empty()) {
         BOOST_LOG_TRIVIAL(debug) << "MoonrakerPrinterAgent: filament matcher received empty filament name";
@@ -146,8 +174,17 @@ std::string filament_id_by_name(const Slic3r::PresetCollection& filaments, const
     }
 
     const std::string wanted = normalize_filament_name_for_match(filament_name);
+    std::vector<std::string> normalized_vendor_filters;
+    normalized_vendor_filters.reserve(vendor_filters.size());
+    for (const auto& vendor_filter : vendor_filters) {
+        const std::string normalized_vendor = normalize_filament_name_for_match(vendor_filter);
+        if (!normalized_vendor.empty()) {
+            normalized_vendor_filters.push_back(normalized_vendor);
+        }
+    }
+
     BOOST_LOG_TRIVIAL(debug) << "MoonrakerPrinterAgent: filament matcher lookup requested='" << filament_name
-                             << "' normalized='" << wanted << "'";
+                             << "' normalized='" << wanted << "' vendor_filters=" << normalized_vendor_filters.size();
     for (size_t i = 0; i < filaments.size(); ++i) {
         const auto& preset = filaments.preset(i);
         if (!preset.is_visible || !preset.is_compatible || preset.filament_id.empty()) {
@@ -155,6 +192,21 @@ std::string filament_id_by_name(const Slic3r::PresetCollection& filaments, const
                                      << "' visible=" << preset.is_visible << " compatible=" << preset.is_compatible
                                      << " filament_id_empty=" << preset.filament_id.empty();
             continue;
+        }
+        if (!normalized_vendor_filters.empty()) {
+            const std::string preset_vendor = normalize_filament_name_for_match(preset.config.opt_string("filament_vendor", 0u));
+            bool vendor_match = false;
+            for (const auto& vendor_filter : normalized_vendor_filters) {
+                if (preset_vendor == vendor_filter) {
+                    vendor_match = true;
+                    break;
+                }
+            }
+            if (!vendor_match) {
+                BOOST_LOG_TRIVIAL(debug) << "MoonrakerPrinterAgent: filament matcher skip preset='" << preset.name
+                                         << "' reason=vendor_filter_miss preset_vendor='" << preset_vendor << "'";
+                continue;
+            }
         }
         const std::string candidate = normalize_filament_name_for_match(preset.name);
         BOOST_LOG_TRIVIAL(debug) << "MoonrakerPrinterAgent: filament matcher compare preset='" << preset.name
@@ -907,7 +959,7 @@ bool MoonrakerPrinterAgent::fetch_moonraker_filament_data(std::vector<AmsTrayDat
                 }
                 for (const auto& vendor_candidate : vendor_candidates) {
                     const std::string requested = vendor_candidate + " " + suffix;
-                    std::string match_id = filament_id_by_name(bundle->filaments, requested);
+                    std::string match_id = filament_id_by_name(bundle->filaments, requested, vendor_candidates);
                     if (!match_id.empty()) {
                         return match_id;
                     }
@@ -921,7 +973,7 @@ bool MoonrakerPrinterAgent::fetch_moonraker_filament_data(std::vector<AmsTrayDat
                 tray.tray_info_idx = match_with_vendor_prefix(tray.tray_type);
             }
             if (tray.tray_info_idx.empty() && !lane_name.empty()) {
-                tray.tray_info_idx = filament_id_by_name(bundle->filaments, lane_name);
+                tray.tray_info_idx = filament_id_by_name(bundle->filaments, lane_name, vendor_candidates);
             }
             if (tray.tray_info_idx.empty()) {
                 tray.tray_info_idx = bundle->filaments.filament_id_by_type(tray.tray_type);

--- a/src/slic3r/Utils/MoonrakerPrinterAgent.cpp
+++ b/src/slic3r/Utils/MoonrakerPrinterAgent.cpp
@@ -4,6 +4,7 @@
 #include "libslic3r/PresetBundle.hpp"
 #include "slic3r/GUI/GUI_App.hpp"
 #include "slic3r/GUI/DeviceCore/DevFilaSystem.h"
+#include "slic3r/GUI/DeviceCore/DevExtruderSystem.h"
 #include "slic3r/GUI/DeviceCore/DevManager.h"
 #include "../GUI/DeviceCore/DevStorage.h"
 #include "../GUI/DeviceCore/DevFirmware.h"
@@ -86,6 +87,88 @@ std::string map_moonraker_state(std::string state)
         return "FAILED";
     }
     return "IDLE";
+}
+
+std::string normalize_filament_name_for_match(const std::string& input)
+{
+    std::string normalized = input;
+    boost::trim(normalized);
+    // Ignore profile suffixes like " @0.4 nozzle" for name matching.
+    if (const auto suffix_pos = normalized.find(" @"); suffix_pos != std::string::npos) {
+        normalized = normalized.substr(0, suffix_pos);
+    }
+    std::transform(normalized.begin(), normalized.end(), normalized.begin(),
+                   [](unsigned char c) { return static_cast<char>(std::toupper(c)); });
+    return normalized;
+}
+
+bool filament_name_match_relaxed(const std::string& wanted, const std::string& candidate)
+{
+    if (wanted == candidate) {
+        return true;
+    }
+
+    // Allow lane names with trailing color descriptors, e.g.:
+    // "ELEGOO RAPID PETG GREY" -> "ELEGOO RAPID PETG".
+    if (!candidate.empty() && boost::starts_with(wanted, candidate + " ")) {
+        return true;
+    }
+    return false;
+}
+
+std::vector<std::string> vendor_match_candidates(std::string vendor)
+{
+    std::vector<std::string> candidates;
+    boost::trim(vendor);
+    if (vendor.empty()) {
+        return candidates;
+    }
+
+    candidates.push_back(vendor);
+
+    // Also try first token (e.g. "Bambu Lab" -> "Bambu") without hardcoded aliases.
+    const auto first_space = vendor.find_first_of(" \t");
+    if (first_space != std::string::npos) {
+        std::string first = vendor.substr(0, first_space);
+        boost::trim(first);
+        if (!first.empty() && !boost::iequals(first, vendor)) {
+            candidates.push_back(first);
+        }
+    }
+    return candidates;
+}
+
+std::string filament_id_by_name(const Slic3r::PresetCollection& filaments, const std::string& filament_name)
+{
+    if (filament_name.empty()) {
+        BOOST_LOG_TRIVIAL(debug) << "MoonrakerPrinterAgent: filament matcher received empty filament name";
+        return "";
+    }
+
+    const std::string wanted = normalize_filament_name_for_match(filament_name);
+    BOOST_LOG_TRIVIAL(debug) << "MoonrakerPrinterAgent: filament matcher lookup requested='" << filament_name
+                             << "' normalized='" << wanted << "'";
+    for (size_t i = 0; i < filaments.size(); ++i) {
+        const auto& preset = filaments.preset(i);
+        if (!preset.is_visible || !preset.is_compatible || preset.filament_id.empty()) {
+            BOOST_LOG_TRIVIAL(debug) << "MoonrakerPrinterAgent: filament matcher skip preset='" << preset.name
+                                     << "' visible=" << preset.is_visible << " compatible=" << preset.is_compatible
+                                     << " filament_id_empty=" << preset.filament_id.empty();
+            continue;
+        }
+        const std::string candidate = normalize_filament_name_for_match(preset.name);
+        BOOST_LOG_TRIVIAL(debug) << "MoonrakerPrinterAgent: filament matcher compare preset='" << preset.name
+                                 << "' normalized='" << candidate << "' filament_id='" << preset.filament_id << "'";
+        if (filament_name_match_relaxed(wanted, candidate)) {
+            BOOST_LOG_TRIVIAL(info) << "MoonrakerPrinterAgent: filament matcher matched requested='" << filament_name
+                                    << "' normalized='" << wanted << "' to preset='" << preset.name
+                                    << "' filament_id='" << preset.filament_id << "'";
+            return preset.filament_id;
+        }
+    }
+    BOOST_LOG_TRIVIAL(info) << "MoonrakerPrinterAgent: filament matcher found no match for requested='" << filament_name
+                            << "' normalized='" << wanted << "'";
+    return "";
 }
 
 } // namespace
@@ -448,7 +531,7 @@ int MoonrakerPrinterAgent::set_queue_on_main_fn(QueueOnMainFn fn)
     return BAMBU_NETWORK_SUCCESS;
 }
 
-void MoonrakerPrinterAgent::build_ams_payload(int ams_count, int max_lane_index, const std::vector<AmsTrayData>& trays)
+void MoonrakerPrinterAgent::build_ams_payload(int ams_count, int max_lane_index, const std::vector<AmsTrayData>& trays, int active_lane_index)
 {
 
     // Look up MachineObject via DeviceManager
@@ -499,6 +582,7 @@ void MoonrakerPrinterAgent::build_ams_payload(int ams_count, int max_lane_index,
 
                 tray_json["tray_info_idx"] = tray->tray_info_idx;
                 tray_json["tray_type"] = tray->tray_type;
+                tray_json["tray_sub_brands"] = tray->tray_sub_brands.empty() ? tray->tray_type : tray->tray_sub_brands;
                 tray_json["tray_color"] = normalize_color_value(tray->tray_color);
 
                 // Add temperature data if provided
@@ -530,6 +614,11 @@ void MoonrakerPrinterAgent::build_ams_payload(int ams_count, int max_lane_index,
     ams_json["ams"] = ams_array;
     ams_json["ams_exist_bits"] = ams_exist_ss.str();
     ams_json["tray_exist_bits"] = tray_exist_ss.str();
+    if (active_lane_index >= 0) {
+        const std::string active_lane = std::to_string(active_lane_index);
+        ams_json["tray_now"] = active_lane;
+        ams_json["tray_tar"] = active_lane;
+    }
 
     // Wrap in the expected structure for ParseV1_0
     nlohmann::json print_json = nlohmann::json::object();
@@ -537,6 +626,7 @@ void MoonrakerPrinterAgent::build_ams_payload(int ams_count, int max_lane_index,
 
     // Call the parser to populate DevFilaSystem
     DevFilaSystemParser::ParseV1_0(print_json, obj, obj->GetFilaSystem(), false);
+    ExtderSystemParser::ParseV1_0(print_json, obj->GetExtderSystem());
     BOOST_LOG_TRIVIAL(info) << "MoonrakerPrinterAgent::build_ams_payload: Parsed " << trays.size() << " trays";
 
     // Set printer_type so update_sync_status() can match it against the preset's printer type.
@@ -570,6 +660,7 @@ bool MoonrakerPrinterAgent::fetch_filament_info(std::string dev_id)
 {
     std::vector<AmsTrayData> trays;
     int max_lane_index = 0;
+    int active_lane_index = -1;
 
     // Try Moonraker filament data (more generic, supports any filament changer
     // software that reports lane data to Moonraker like AFC and recent Happy
@@ -578,16 +669,16 @@ bool MoonrakerPrinterAgent::fetch_filament_info(std::string dev_id)
         BOOST_LOG_TRIVIAL(info) << "MoonrakerPrinterAgent::fetch_filament_info: Detected Moonraker filament system with "
                                 << (max_lane_index + 1) << " lanes";
         int ams_count = (max_lane_index + 4) / 4;
-        build_ams_payload(ams_count, max_lane_index, trays);
+        build_ams_payload(ams_count, max_lane_index, trays, active_lane_index);
         return true;
     }
 
     // Attempt Happy Hare first (more widely adopted, supports more filament changers)
-    if (fetch_hh_filament_info(trays, max_lane_index)) {
+    if (fetch_hh_filament_info(trays, max_lane_index, active_lane_index)) {
         BOOST_LOG_TRIVIAL(info) << "MoonrakerPrinterAgent::fetch_filament_info: Detected Happy Hare MMU with "
                                 << (max_lane_index + 1) << " gates";
         int ams_count = (max_lane_index + 4) / 4;
-        build_ams_payload(ams_count, max_lane_index, trays);
+        build_ams_payload(ams_count, max_lane_index, trays, active_lane_index);
         return true;
     }
 
@@ -801,13 +892,51 @@ bool MoonrakerPrinterAgent::fetch_moonraker_filament_data(std::vector<AmsTrayDat
         tray.slot_index = lane_index;
         tray.tray_color = safe_json_string(lane_obj, "color");
         tray.tray_type = safe_json_string(lane_obj, "material");
+        const std::string lane_name = safe_json_string(lane_obj, "name");
+        const std::string lane_vendor = safe_json_string(lane_obj, "vendor_name");
+        tray.tray_sub_brands = lane_name;
         tray.bed_temp = safe_json_int(lane_obj, "bed_temp");
         tray.nozzle_temp = safe_json_int(lane_obj, "nozzle_temp");
         tray.has_filament = !tray.tray_type.empty();
         auto* bundle = GUI::wxGetApp().preset_bundle;
-        tray.tray_info_idx = bundle
-            ? bundle->filaments.filament_id_by_type(tray.tray_type)
-            : map_filament_type_to_generic_id(tray.tray_type);
+        if (bundle) {
+            const auto vendor_candidates = vendor_match_candidates(lane_vendor);
+            auto match_with_vendor_prefix = [&](const std::string& suffix) -> std::string {
+                if (suffix.empty()) {
+                    return "";
+                }
+                for (const auto& vendor_candidate : vendor_candidates) {
+                    const std::string requested = vendor_candidate + " " + suffix;
+                    std::string match_id = filament_id_by_name(bundle->filaments, requested);
+                    if (!match_id.empty()) {
+                        return match_id;
+                    }
+                }
+                return "";
+            };
+
+            // Prefer the most specific lane identity first, then broader vendor/material mapping.
+            tray.tray_info_idx = match_with_vendor_prefix(lane_name);
+            if (tray.tray_info_idx.empty()) {
+                tray.tray_info_idx = match_with_vendor_prefix(tray.tray_type);
+            }
+            if (tray.tray_info_idx.empty() && !lane_name.empty()) {
+                tray.tray_info_idx = filament_id_by_name(bundle->filaments, lane_name);
+            }
+            if (tray.tray_info_idx.empty()) {
+                tray.tray_info_idx = bundle->filaments.filament_id_by_type(tray.tray_type);
+            }
+            BOOST_LOG_TRIVIAL(info) << "MoonrakerPrinterAgent::fetch_moonraker_filament_data: lane='" << lane_key
+                                    << "' index=" << lane_index << " material='" << tray.tray_type
+                                    << "' vendor='" << lane_vendor << "' vendor_candidates=" << vendor_candidates.size()
+                                    << "' name='" << lane_name
+                                    << "' mapped_by='preset_bundle' tray_info_idx='" << tray.tray_info_idx << "'";
+        } else {
+            tray.tray_info_idx = map_filament_type_to_generic_id(tray.tray_type);
+            BOOST_LOG_TRIVIAL(info) << "MoonrakerPrinterAgent::fetch_moonraker_filament_data: lane='" << lane_key
+                                    << "' index=" << lane_index << " material='" << tray.tray_type
+                                    << "' mapped_by='generic_fallback' tray_info_idx='" << tray.tray_info_idx << "'";
+        }
 
         max_lane_index = std::max(max_lane_index, lane_index);
         trays.push_back(tray);
@@ -822,7 +951,7 @@ bool MoonrakerPrinterAgent::fetch_moonraker_filament_data(std::vector<AmsTrayDat
 }
 
 // Fetch filament info from Happy Hare MMU
-bool MoonrakerPrinterAgent::fetch_hh_filament_info(std::vector<AmsTrayData>& trays, int& max_lane_index)
+bool MoonrakerPrinterAgent::fetch_hh_filament_info(std::vector<AmsTrayData>& trays, int& max_lane_index, int& active_lane_index)
 {
     // Query Happy Hare MMU status
     std::string url = join_url(device_info.base_url, "/printer/objects/query?mmu");
@@ -894,8 +1023,18 @@ bool MoonrakerPrinterAgent::fetch_hh_filament_info(std::vector<AmsTrayData>& tra
     // Get arrays
     const auto& gate_status = mmu.contains("gate_status") ? mmu["gate_status"] : nlohmann::json::array();
     const auto& gate_material = mmu.contains("gate_material") ? mmu["gate_material"] : nlohmann::json::array();
+    const auto& gate_filament_name = mmu.contains("gate_filament_name") ? mmu["gate_filament_name"] : nlohmann::json::array();
     const auto& gate_color = mmu.contains("gate_color") ? mmu["gate_color"] : nlohmann::json::array();
     const auto& gate_temperature = mmu.contains("gate_temperature") ? mmu["gate_temperature"] : nlohmann::json::array();
+    const int active_gate = safe_json_int(mmu, "gate");
+    active_lane_index = active_gate;
+    std::string active_filament_name;
+    if (mmu.contains("active_filament") && mmu["active_filament"].is_object()) {
+        active_filament_name = safe_json_string(mmu["active_filament"], "filament_name");
+        if (active_filament_name.empty()) {
+            active_filament_name = safe_json_string(mmu["active_filament"], "material");
+        }
+    }
 
     if (!gate_status.is_array() || !gate_material.is_array() ||
         !gate_color.is_array() || !gate_temperature.is_array()) {
@@ -916,8 +1055,13 @@ bool MoonrakerPrinterAgent::fetch_hh_filament_info(std::vector<AmsTrayData>& tra
 
         // Extract gate data
         std::string material = safe_array_string(gate_material, gate_idx);
+        std::string filament_name = safe_array_string(gate_filament_name, gate_idx);
         std::string color = safe_array_string(gate_color, gate_idx);
         int nozzle_temp = safe_array_int(gate_temperature, gate_idx);
+        // For the active gate, prefer active_filament from MMU state.
+        if (gate_idx == active_gate && !active_filament_name.empty()) {
+            filament_name = active_filament_name;
+        }
 
         // Skip if no material type (empty gate)
         if (material.empty()) {
@@ -927,15 +1071,21 @@ bool MoonrakerPrinterAgent::fetch_hh_filament_info(std::vector<AmsTrayData>& tra
         AmsTrayData tray;
         tray.slot_index = gate_idx;
         tray.tray_type = material;
+        tray.tray_sub_brands = filament_name;
         tray.tray_color = color;
         tray.nozzle_temp = nozzle_temp;
         tray.bed_temp = 0;  // HH doesn't provide bed temp in gate arrays
         tray.has_filament = true;
 
         auto* bundle = GUI::wxGetApp().preset_bundle;
-        tray.tray_info_idx = bundle
-            ? bundle->filaments.filament_id_by_type(tray.tray_type)
-            : map_filament_type_to_generic_id(tray.tray_type);
+        if (bundle) {
+            tray.tray_info_idx = filament_id_by_name(bundle->filaments, filament_name);
+            if (tray.tray_info_idx.empty()) {
+                tray.tray_info_idx = bundle->filaments.filament_id_by_type(tray.tray_type);
+            }
+        } else {
+            tray.tray_info_idx = map_filament_type_to_generic_id(tray.tray_type);
+        }
 
         max_lane_index = std::max(max_lane_index, gate_idx);
         trays.push_back(tray);

--- a/src/slic3r/Utils/MoonrakerPrinterAgent.hpp
+++ b/src/slic3r/Utils/MoonrakerPrinterAgent.hpp
@@ -92,6 +92,7 @@ protected:
         int         slot_index = 0;      // 0-based slot index
         bool        has_filament = false;
         std::string tray_type;           // Material type (e.g., "PLA", "ASA")
+        std::string tray_sub_brands;     // Human-readable filament name
         std::string tray_color;          // Raw color (#RRGGBB, 0xRRGGBB, or RRGGBBAA)
         std::string tray_info_idx;       // Setting ID (optional)
         int         bed_temp = 0;        // Optional
@@ -99,7 +100,7 @@ protected:
     };
 
     // Build ams JSON and call parser
-    void build_ams_payload(int ams_count, int max_lane_index, const std::vector<AmsTrayData>& trays);
+    void build_ams_payload(int ams_count, int max_lane_index, const std::vector<AmsTrayData>& trays, int active_lane_index = -1);
 
     // Methods that derived classes may need to override or access
     virtual bool init_device_info(std::string dev_id, std::string dev_ip, std::string username, std::string password, bool use_ssl);
@@ -161,7 +162,7 @@ private:
                                    uint64_t generation);
 
     // System-specific filament fetch methods
-    bool fetch_hh_filament_info(std::vector<AmsTrayData>& trays, int& max_lane_index);
+    bool fetch_hh_filament_info(std::vector<AmsTrayData>& trays, int& max_lane_index, int& active_lane_index);
     bool fetch_moonraker_filament_data(std::vector<AmsTrayData>& trays, int& max_lane_index);
 
     // JSON helper methods

--- a/src/slic3r/Utils/QidiPrinterAgent.cpp
+++ b/src/slic3r/Utils/QidiPrinterAgent.cpp
@@ -6,12 +6,16 @@
 #include "nlohmann/json.hpp"
 #include <boost/algorithm/string.hpp>
 #include <boost/log/trivial.hpp>
+#include <algorithm>
 #include <cctype>
 #include <sstream>
 
 namespace Slic3r {
 
 namespace {
+
+constexpr int QIDI_MAX_BOX_COUNT = 4;
+constexpr int QIDI_SLOTS_PER_BOX = 4;
 
 // Check whether any visible, compatible base preset in the collection has the given filament_id.
 bool has_visible_base_preset(const PresetCollection& filaments, const std::string& filament_id)
@@ -25,70 +29,169 @@ bool has_visible_base_preset(const PresetCollection& filaments, const std::strin
     return false;
 }
 
-} // anonymous namespace
-
-const std::string QidiPrinterAgent_VERSION = "0.0.1";
-
-QidiPrinterAgent::QidiPrinterAgent(std::string log_dir) : MoonrakerPrinterAgent(std::move(log_dir))
+std::string normalize_filament_name_for_match(const std::string& input)
 {
-}
+    std::string normalized = input;
+    boost::trim(normalized);
+    if (const auto suffix_pos = normalized.find(" @"); suffix_pos != std::string::npos) {
+        normalized = normalized.substr(0, suffix_pos);
+    }
 
-AgentInfo QidiPrinterAgent::get_agent_info_static()
-{
-    return AgentInfo{"qidi", "Qidi", QidiPrinterAgent_VERSION, "Qidi printer agent"};
-}
-
-bool QidiPrinterAgent::fetch_filament_info(std::string dev_id)
-{
-    std::string error;
-
-    // 1. Fetch device info and infer series_id
-    std::string series_id;
-    {
-        MoonrakerDeviceInfo info;
-        if (fetch_device_info(device_info.base_url, device_info.api_key, info, error)) {
-            series_id = infer_series_id(info.model_id, info.dev_name);
+    std::string cleaned;
+    cleaned.reserve(normalized.size());
+    for (unsigned char c : normalized) {
+        if (std::isalnum(c) || c == '-' || c == '+' || c == '/' || std::isspace(c)) {
+            cleaned.push_back(static_cast<char>(std::toupper(c)));
+        } else {
+            cleaned.push_back(' ');
         }
     }
-    if (series_id.empty()) {
-        // Fall back to the configured Orca model if Moonraker doesn't expose a usable identifier.
-        series_id = infer_series_id(device_info.model_id, device_info.model_name);
-    }
 
-    // 2. Fetch filament dictionary
-    QidiFilamentDict dict;
-    if (!fetch_filament_dict(device_info.base_url, device_info.api_key, dict, error)) {
-        BOOST_LOG_TRIVIAL(warning) << "QidiPrinterAgent::fetch_filament_info: Failed to fetch filament dict: " << error;
+    std::string collapsed;
+    collapsed.reserve(cleaned.size());
+    bool prev_space = true;
+    for (unsigned char c : cleaned) {
+        if (std::isspace(c)) {
+            if (!prev_space) {
+                collapsed.push_back(' ');
+            }
+            prev_space = true;
+        } else {
+            collapsed.push_back(static_cast<char>(c));
+            prev_space = false;
+        }
     }
-
-    // 3. Fetch slot info and build AmsTrayData directly
-    std::vector<AmsTrayData> trays;
-    int                      box_count = 0;
-    if (!fetch_slot_info(device_info.base_url, device_info.api_key, dict, series_id, trays, box_count, error)) {
-        BOOST_LOG_TRIVIAL(warning) << "QidiPrinterAgent::fetch_filament_info: Failed to fetch slot info: " << error;
-        return false;
-    }
-
-    // 4. Build the AMS payload
-    build_ams_payload(box_count, box_count * 4 - 1, trays);
-    return true;
+    boost::trim(collapsed);
+    return collapsed;
 }
 
-bool QidiPrinterAgent::fetch_slot_info(const std::string&        base_url,
-                                       const std::string&        api_key,
-                                       const QidiFilamentDict&   dict,
-                                       const std::string&        series_id,
-                                       std::vector<AmsTrayData>& trays,
-                                       int&                      box_count,
-                                       std::string&              error)
+bool filament_name_match_relaxed(const std::string& wanted, const std::string& candidate)
 {
-    std::string url = join_url(base_url, "/printer/objects/query?save_variables=variables");
-    for (int i = 0; i < 16; ++i) {
-        url += "&box_stepper%20slot" + std::to_string(i) + "=runout_button";
+    return wanted == candidate || (!candidate.empty() && boost::starts_with(wanted, candidate + " "));
+}
+
+std::vector<std::string> vendor_match_candidates(std::string vendor)
+{
+    std::vector<std::string> candidates;
+    boost::trim(vendor);
+    if (vendor.empty()) {
+        return candidates;
     }
 
-    std::string response_body;
-    bool        success = false;
+    candidates.push_back(vendor);
+    const auto first_space = vendor.find_first_of(" \t");
+    if (first_space != std::string::npos) {
+        std::string first = vendor.substr(0, first_space);
+        boost::trim(first);
+        if (!first.empty() && !boost::iequals(first, vendor)) {
+            candidates.push_back(first);
+        }
+    }
+    return candidates;
+}
+
+std::string filament_id_by_name(const PresetCollection& filaments,
+                                const std::string&     filament_name,
+                                const std::vector<std::string>& vendor_filters = {})
+{
+    if (filament_name.empty()) {
+        return "";
+    }
+
+    const std::string wanted = normalize_filament_name_for_match(filament_name);
+    std::vector<std::string> normalized_vendor_filters;
+    for (const auto& vendor_filter : vendor_filters) {
+        const std::string normalized_vendor = normalize_filament_name_for_match(vendor_filter);
+        if (!normalized_vendor.empty()) {
+            normalized_vendor_filters.push_back(normalized_vendor);
+        }
+    }
+
+    for (size_t i = 0; i < filaments.size(); ++i) {
+        const auto& preset = filaments.preset(i);
+        if (!preset.is_visible || !preset.is_compatible || preset.filament_id.empty()) {
+            continue;
+        }
+        if (!normalized_vendor_filters.empty()) {
+            const std::string preset_vendor = normalize_filament_name_for_match(preset.config.opt_string("filament_vendor", 0u));
+            if (std::find(normalized_vendor_filters.begin(), normalized_vendor_filters.end(), preset_vendor)
+                == normalized_vendor_filters.end()) {
+                continue;
+            }
+        }
+        if (filament_name_match_relaxed(wanted, normalize_filament_name_for_match(preset.name))) {
+            BOOST_LOG_TRIVIAL(info) << "QidiPrinterAgent: filament matcher matched requested='" << filament_name
+                                    << "' to preset='" << preset.name << "' filament_id='" << preset.filament_id << "'";
+            return preset.filament_id;
+        }
+    }
+    return "";
+}
+
+std::string qidi_setting_id(const std::string& series_id, int filament_type_idx, int vendor_type, const std::string& tray_type)
+{
+    const int vendor = (vendor_type == 1) ? 1 : 0;
+    if (!series_id.empty() && std::all_of(series_id.begin(), series_id.end(), [](unsigned char c) { return std::isdigit(c); })
+        && filament_type_idx > 0) {
+        return "QD_" + series_id + "_" + std::to_string(vendor) + "_" + std::to_string(filament_type_idx);
+    }
+
+    const std::string upper = normalize_filament_name_for_match(tray_type);
+    if (upper == "PLA") return "QD_1_0_1";
+    if (upper == "ABS") return "QD_1_0_11";
+    if (upper == "PETG") return "QD_1_0_41";
+    if (upper == "TPU") return "QD_1_0_50";
+    return "";
+}
+
+std::string match_qidi_filament_id(const std::string& full_name,
+                                   const std::string& material,
+                                   const std::string& vendor,
+                                   const std::string& setting_id,
+                                   const std::string& tray_type)
+{
+    auto* bundle = GUI::wxGetApp().preset_bundle;
+    if (!bundle) {
+        return setting_id;
+    }
+
+    const auto vendor_candidates = vendor_match_candidates(vendor);
+    auto match_with_vendor_prefix = [&](const std::string& suffix) -> std::string {
+        if (suffix.empty()) {
+            return "";
+        }
+        for (const auto& vendor_candidate : vendor_candidates) {
+            const std::string requested = vendor_candidate + " " + suffix;
+            std::string match_id = filament_id_by_name(bundle->filaments, requested, vendor_candidates);
+            if (!match_id.empty()) {
+                return match_id;
+            }
+        }
+        return "";
+    };
+
+    std::string match_id = match_with_vendor_prefix(full_name);
+    if (match_id.empty()) {
+        match_id = match_with_vendor_prefix(material);
+    }
+    if (match_id.empty()) {
+        match_id = filament_id_by_name(bundle->filaments, full_name, vendor_candidates);
+    }
+    if (match_id.empty()) {
+        match_id = filament_id_by_name(bundle->filaments, material, vendor_candidates);
+    }
+    if (match_id.empty() && !setting_id.empty() && has_visible_base_preset(bundle->filaments, setting_id)) {
+        match_id = setting_id;
+    }
+    if (match_id.empty()) {
+        match_id = bundle->filaments.filament_id_by_type(tray_type);
+    }
+    return match_id;
+}
+
+bool http_get_text(const std::string& url, const std::string& api_key, std::string& response_body, std::string& error)
+{
+    bool success = false;
     std::string http_error;
 
     auto http = Http::get(url);
@@ -115,6 +218,214 @@ bool QidiPrinterAgent::fetch_slot_info(const std::string&        base_url,
 
     if (!success) {
         error = http_error.empty() ? "Connection failed" : http_error;
+    }
+    return success;
+}
+
+const nlohmann::json* object_member(const nlohmann::json& obj, const std::string& key)
+{
+    if (!obj.is_object() || !obj.contains(key) || !obj[key].is_object()) {
+        return nullptr;
+    }
+    return &obj[key];
+}
+
+std::string json_string(const nlohmann::json* obj, const char* key)
+{
+    if (!obj || !obj->is_object() || !obj->contains(key) || !(*obj)[key].is_string()) {
+        return "";
+    }
+    return (*obj)[key].get<std::string>();
+}
+
+int json_int_member(const nlohmann::json* obj, const std::string& key, int default_value, bool* found = nullptr)
+{
+    if (found) {
+        *found = false;
+    }
+    if (!obj || !obj->is_object() || !obj->contains(key) || !(*obj)[key].is_number_integer()) {
+        return default_value;
+    }
+
+    try {
+        const int value = (*obj)[key].get<int>();
+        if (found) {
+            *found = true;
+        }
+        return value;
+    } catch (...) {}
+    return default_value;
+}
+
+} // anonymous namespace
+
+const std::string QidiPrinterAgent_VERSION = "0.0.1";
+
+QidiPrinterAgent::QidiPrinterAgent(std::string log_dir) : MoonrakerPrinterAgent(std::move(log_dir))
+{
+}
+
+AgentInfo QidiPrinterAgent::get_agent_info_static()
+{
+    return AgentInfo{"qidi", "Qidi", QidiPrinterAgent_VERSION, "Qidi printer agent"};
+}
+
+bool QidiPrinterAgent::fetch_filament_info(std::string dev_id)
+{
+    std::string error;
+
+    std::string series_id;
+    {
+        MoonrakerDeviceInfo info;
+        if (fetch_device_info(device_info.base_url, device_info.api_key, info, error)) {
+            series_id = infer_series_id(info.model_id, info.dev_name);
+        }
+    }
+    if (series_id.empty()) {
+        series_id = infer_series_id(device_info.model_id, device_info.model_name);
+    }
+
+    std::vector<AmsTrayData> trays;
+    int                      box_count = 0;
+    if (fetch_multi_color_controller_slot_info(series_id, trays, box_count, error)) {
+        build_ams_payload(box_count, box_count * QIDI_SLOTS_PER_BOX - 1, trays);
+        return true;
+    }
+    BOOST_LOG_TRIVIAL(info) << "QidiPrinterAgent::fetch_filament_info: multi_color_controller path unavailable: " << error;
+
+    QidiFilamentDict dict;
+    if (!fetch_filament_dict(dict, error)) {
+        BOOST_LOG_TRIVIAL(warning) << "QidiPrinterAgent::fetch_filament_info: Failed to fetch filament dict: " << error;
+    }
+
+    if (!fetch_slot_info(dict, series_id, trays, box_count, error)) {
+        BOOST_LOG_TRIVIAL(warning) << "QidiPrinterAgent::fetch_filament_info: Failed to fetch slot info: " << error;
+        return false;
+    }
+
+    build_ams_payload(box_count, box_count * QIDI_SLOTS_PER_BOX - 1, trays);
+    return true;
+}
+
+bool QidiPrinterAgent::fetch_multi_color_controller_slot_info(const std::string&        series_id,
+                                                             std::vector<AmsTrayData>& trays,
+                                                             int&                      box_count,
+                                                             std::string&              error)
+{
+    std::string url = join_url(device_info.base_url, "/printer/objects/query?multi_color_controller");
+
+    std::string response_body;
+    if (!http_get_text(url, device_info.api_key, response_body, error)) {
+        return false;
+    }
+
+    auto json = nlohmann::json::parse(response_body, nullptr, false, true);
+    if (json.is_discarded()) {
+        error = "Invalid JSON response";
+        return false;
+    }
+
+    const auto* result = object_member(json, "result");
+    const auto* status = result ? object_member(*result, "status") : nullptr;
+    const auto* mcc    = status ? object_member(*status, "multi_color_controller") : nullptr;
+    if (!mcc) {
+        error = "Unexpected JSON structure: missing multi_color_controller status";
+        return false;
+    }
+
+    const auto* hardware = object_member(*mcc, "hardware");
+    const auto* config   = object_member(*mcc, "config");
+    bool has_box_count = false;
+    box_count = json_int_member(hardware, "box_count", 0, &has_box_count);
+    if (!has_box_count) {
+        box_count = json_int_member(config, "box_count", 0, &has_box_count);
+    }
+    if (!has_box_count) {
+        error = "multi_color_controller did not report box_count";
+        return false;
+    }
+    if (box_count <= 0) {
+        box_count = 0;
+        trays.clear();
+        return true;
+    }
+    box_count = std::min(box_count, QIDI_MAX_BOX_COUNT);
+
+    const int max_slots = box_count * QIDI_SLOTS_PER_BOX;
+
+    const auto* slots     = object_member(*mcc, "slots");
+    const auto* states    = slots ? object_member(*slots, "states") : nullptr;
+    const auto* materials = slots ? object_member(*slots, "materials") : nullptr;
+    if (!states || states->empty()) {
+        error = "multi_color_controller missing slot states";
+        return false;
+    }
+
+    trays.clear();
+    trays.reserve(max_slots);
+
+    for (int i = 0; i < max_slots; ++i) {
+        const std::string slot_key = "slot" + std::to_string(i);
+
+        bool has_state = false;
+        const int state = json_int_member(states, slot_key, 0, &has_state);
+        bool has_filament = has_state && state > 0;
+
+        AmsTrayData tray;
+        tray.slot_index = i;
+        tray.has_filament = has_filament;
+
+        if (tray.has_filament) {
+            const auto* slot_material = materials && materials->contains(slot_key) && (*materials)[slot_key].is_object()
+                                            ? &(*materials)[slot_key] : nullptr;
+            const auto* filament      = slot_material ? object_member(*slot_material, "filament") : nullptr;
+
+            const std::string full_name = json_string(filament, "filament");
+            const std::string material_type = json_string(filament, "type");
+            const std::string material  = material_type.empty() ? full_name : material_type;
+            const std::string vendor    = json_string(slot_material, "vendor");
+
+            tray.tray_color = json_string(slot_material, "color");
+            tray.tray_type = normalize_filament_type(material.empty() ? full_name : material);
+            tray.tray_sub_brands = full_name;
+
+            const int filament_type_idx = json_int_member(config, "filament_slot" + std::to_string(i), 0);
+            const int vendor_type       = json_int_member(config, "vendor_slot" + std::to_string(i), 0);
+            std::string setting_id;
+            if (tray.tray_type.empty()) {
+                error = "multi_color_controller loaded slot material metadata is incomplete";
+                BOOST_LOG_TRIVIAL(warning) << "QidiPrinterAgent::fetch_multi_color_controller_slot_info: loaded " << slot_key
+                                           << " has no material metadata; using legacy path";
+                return false;
+            }
+            setting_id = qidi_setting_id(series_id, filament_type_idx, vendor_type, tray.tray_type);
+            tray.tray_info_idx = match_qidi_filament_id(full_name, material, vendor, setting_id, tray.tray_type);
+
+            BOOST_LOG_TRIVIAL(info) << "QidiPrinterAgent::fetch_multi_color_controller_slot_info: slot=" << i
+                                    << " state=" << state << " material='" << material << "' name='" << full_name
+                                    << "' vendor='" << vendor << "' setting_id='" << setting_id
+                                    << "' tray_info_idx='" << tray.tray_info_idx << "'";
+        }
+
+        trays.push_back(tray);
+    }
+
+    return true;
+}
+
+bool QidiPrinterAgent::fetch_slot_info(const QidiFilamentDict&   dict,
+                                       const std::string&        series_id,
+                                       std::vector<AmsTrayData>& trays,
+                                       int&                      box_count,
+                                       std::string&              error)
+{
+    std::string url = join_url(device_info.base_url, "/printer/objects/query?save_variables=variables");
+    for (int i = 0; i < QIDI_MAX_BOX_COUNT * QIDI_SLOTS_PER_BOX; ++i) {
+        url += "&box_stepper%20slot" + std::to_string(i) + "=runout_button";
+    }
+
+    std::string response_body;
+    if (!http_get_text(url, device_info.api_key, response_body, error)) {
         return false;
     }
 
@@ -137,67 +448,52 @@ bool QidiPrinterAgent::fetch_slot_info(const std::string&        base_url,
     if (box_count < 0) {
         box_count = 0;
     }
+    box_count = std::min(box_count, QIDI_MAX_BOX_COUNT);
 
-    const int max_slots = box_count * 4;
+    const int max_slots = box_count * QIDI_SLOTS_PER_BOX;
     trays.clear();
     trays.reserve(max_slots);
-
-    // Lambda to build setting_id from slot data
-    auto build_setting_id = [&](int filament_type_idx, int vendor_type, const std::string& tray_type) {
-        const int vendor = (vendor_type == 1) ? 1 : 0;
-        if (is_numeric(series_id) && filament_type_idx > 0) {
-            return "QD_" + series_id + "_" + std::to_string(vendor) + "_" + std::to_string(filament_type_idx);
-        }
-        return map_filament_type_to_setting_id(tray_type);
-    };
 
     for (int i = 0; i < max_slots; ++i) {
         AmsTrayData tray;
         tray.slot_index = i;
 
-        // Read slot variables
-        const int color_index     = variables.value("color_slot" + std::to_string(i), 1);
-        const int filament_type   = variables.value("filament_slot" + std::to_string(i), 1);
-        const int vendor_type     = variables.value("vendor_slot" + std::to_string(i), 0);
+        const int color_index   = variables.value("color_slot" + std::to_string(i), 1);
+        const int filament_type = variables.value("filament_slot" + std::to_string(i), 1);
+        const int vendor_type   = variables.value("vendor_slot" + std::to_string(i), 0);
 
-        // Check filament presence via runout sensor
         std::string box_stepper_key = "box_stepper slot" + std::to_string(i);
         tray.has_filament = false;
         if (status.contains(box_stepper_key)) {
             auto& box_stepper = status[box_stepper_key];
             if (box_stepper.contains("runout_button") && !box_stepper["runout_button"].is_null()) {
-                int runout_button = box_stepper["runout_button"].template get<int>();
-                tray.has_filament = (runout_button == 0);
+                tray.has_filament = (box_stepper["runout_button"].get<int>() == 0);
             }
         }
 
         if (tray.has_filament) {
-            // Look up filament type name from dictionary
             std::string filament_name = "PLA";
             auto filament_it = dict.filaments.find(filament_type);
             if (filament_it != dict.filaments.end()) {
                 filament_name = filament_it->second;
             }
             tray.tray_type = normalize_filament_type(filament_name);
+            tray.tray_sub_brands = filament_name;
 
-            // Try Qidi-specific setting ID first; fall back to visible preset by type
-            std::string setting_id = build_setting_id(filament_type, vendor_type, tray.tray_type);
-            auto* bundle = GUI::wxGetApp().preset_bundle;
-            if (!bundle) {
-                tray.tray_info_idx = setting_id;
-            } else if (!setting_id.empty() && has_visible_base_preset(bundle->filaments, setting_id)) {
-                tray.tray_info_idx = setting_id;
-            } else {
-                tray.tray_info_idx = bundle->filaments.filament_id_by_type(tray.tray_type);
-            }
+            const std::string setting_id = qidi_setting_id(series_id, filament_type, vendor_type, tray.tray_type);
+            tray.tray_info_idx = match_qidi_filament_id("", "", "", setting_id, tray.tray_type);
 
-            // Look up color from dictionary
             auto color_it = dict.colors.find(color_index);
             if (color_it != dict.colors.end()) {
                 tray.tray_color = color_it->second;
             } else {
                 tray.tray_color = "FFFFFFFF";
             }
+
+            BOOST_LOG_TRIVIAL(info) << "QidiPrinterAgent::fetch_slot_info: slot=" << i
+                                    << " material='" << filament_name
+                                    << "' setting_id='" << setting_id
+                                    << "' tray_info_idx='" << tray.tray_info_idx << "'";
         }
 
         trays.push_back(tray);
@@ -206,41 +502,12 @@ bool QidiPrinterAgent::fetch_slot_info(const std::string&        base_url,
     return true;
 }
 
-bool QidiPrinterAgent::fetch_filament_dict(const std::string& base_url,
-                                           const std::string& api_key,
-                                           QidiFilamentDict& dict,
-                                           std::string& error) const
+bool QidiPrinterAgent::fetch_filament_dict(QidiFilamentDict& dict, std::string& error) const
 {
-    std::string url = join_url(base_url, "/server/files/config/officiall_filas_list.cfg");
+    std::string url = join_url(device_info.base_url, "/server/files/config/officiall_filas_list.cfg");
 
     std::string response_body;
-    bool        success = false;
-    std::string http_error;
-
-    auto http = Http::get(url);
-    if (!api_key.empty()) {
-        http.header("X-Api-Key", api_key);
-    }
-    http.timeout_connect(5)
-        .timeout_max(10)
-        .on_complete([&](std::string body, unsigned status) {
-            if (status == 200) {
-                response_body = body;
-                success       = true;
-            } else {
-                http_error = "HTTP error: " + std::to_string(status);
-            }
-        })
-        .on_error([&](std::string body, std::string err, unsigned status) {
-            http_error = err;
-            if (status > 0) {
-                http_error += " (HTTP " + std::to_string(status) + ")";
-            }
-        })
-        .perform_sync();
-
-    if (!success) {
-        error = http_error.empty() ? "Connection failed" : http_error;
+    if (!http_get_text(url, device_info.api_key, response_body, error)) {
         return false;
     }
 
@@ -320,25 +587,6 @@ void QidiPrinterAgent::parse_filament_sections(const std::string& content, std::
             }
         }
     }
-}
-
-std::string QidiPrinterAgent::map_filament_type_to_setting_id(const std::string& filament_type)
-{
-    const std::string upper = trim_and_upper(filament_type);
-
-    if (upper == "PLA") {
-        return "QD_1_0_1";
-    }
-    if (upper == "ABS") {
-        return "QD_1_0_11";
-    }
-    if (upper == "PETG") {
-        return "QD_1_0_41";
-    }
-    if (upper == "TPU") {
-        return "QD_1_0_50";
-    }
-    return "";
 }
 
 std::string QidiPrinterAgent::normalize_model_key(std::string value)

--- a/src/slic3r/Utils/QidiPrinterAgent.hpp
+++ b/src/slic3r/Utils/QidiPrinterAgent.hpp
@@ -29,14 +29,16 @@ private:
     };
 
     // Qidi-specific methods
-    bool fetch_slot_info(const std::string&        base_url,
-                         const std::string&        api_key,
-                         const QidiFilamentDict&   dict,
+    bool fetch_multi_color_controller_slot_info(const std::string&        series_id,
+                                                std::vector<AmsTrayData>& trays,
+                                                int&                      box_count,
+                                                std::string&              error);
+    bool fetch_slot_info(const QidiFilamentDict&   dict,
                          const std::string&        series_id,
                          std::vector<AmsTrayData>& trays,
                          int&                      box_count,
                          std::string&              error);
-    bool fetch_filament_dict(const std::string& base_url, const std::string& api_key, QidiFilamentDict& dict, std::string& error) const;
+    bool fetch_filament_dict(QidiFilamentDict& dict, std::string& error) const;
     std::string normalize_filament_type(const std::string& filament_type);
     std::string infer_series_id(const std::string& model_id, const std::string& dev_name);
     std::string normalize_model_key(std::string value);
@@ -44,7 +46,6 @@ private:
     // Static helpers
     static void parse_ini_section(const std::string& content, const std::string& section_name, std::map<int, std::string>& result);
     static void parse_filament_sections(const std::string& content, std::map<int, std::string>& result);
-    static std::string map_filament_type_to_setting_id(const std::string& filament_type);
 };
 
 } // namespace Slic3r


### PR DESCRIPTION
# Description

Users can add vendors to their printer's filament list, but previously that would only get mapped to "Generic".  This updates the matching to attempt to find the actual vendor passed back from the printer.  If this match fails, it falls back to the way it worked before.

This reimplements the logic from https://github.com/OrcaSlicer/OrcaSlicer/pull/13719, intentionally duplicating it so that the separation between QIDI and other Moonraker printers is well defined.

# Screenshots/Recordings/Graphs

_in testing_

## Tests

_in testing_

<!--
> A guide for users on how to download the artifacts from this PR.
-->

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
