### PR TITLE
Fix input_filename_base using object name instead of project name

### DIFF
--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -14839,7 +14839,8 @@ void Plater::export_gcode(bool prefer_removable)
         unsigned int state = this->p->update_restart_background_process(false, false);
         if (state & priv::UPDATE_BACKGROUND_PROCESS_INVALID)
             return;
-        default_output_file = this->p->background_process.output_filepath_for_project("");
+        default_output_file = this->p->background_process.output_filepath_for_project(
+            into_path(this->p->get_project_filename(".3mf")));
     } catch (const Slic3r::PlaceholderParserError &ex) {
         // Show the error with monospaced font.
         show_error(this, ex.what(), true);
@@ -14942,7 +14943,8 @@ void Plater::export_gcode_3mf(bool export_all)
         unsigned int state = this->p->update_restart_background_process(false, false);
         if (state & priv::UPDATE_BACKGROUND_PROCESS_INVALID)
             return;
-        default_output_file = this->p->background_process.output_filepath_for_project("");
+        default_output_file = this->p->background_process.output_filepath_for_project(
+            into_path(this->p->get_project_filename(".3mf")));
     }
     catch (const Slic3r::PlaceholderParserError& ex) {
         // Show the error with monospaced font.
@@ -16089,7 +16091,8 @@ void Plater::send_gcode_legacy(int plate_idx, Export3mfProgressFn proFn, bool us
         unsigned int state = this->p->update_restart_background_process(false, false);
         if (state & priv::UPDATE_BACKGROUND_PROCESS_INVALID)
             return;
-        default_output_file = this->p->background_process.output_filepath_for_project("");
+        default_output_file = this->p->background_process.output_filepath_for_project(
+            into_path(this->p->get_project_filename(".3mf")));
     } catch (const Slic3r::PlaceholderParserError& ex) {
         // Show the error with monospaced font.
         show_error(this, ex.what(), true);


### PR DESCRIPTION
Fix `input_filename_base` and `input_filename` using object name instead of project name when exporting G-code

# Description

Fixes #1945.

This is a bug fix. When exporting G-code, the suggested output filename was always derived from the first imported object's name (e.g. `cube.gcode`) rather than the saved project name (e.g. `MyPrint.gcode`), even when the project had been saved to disk with a custom name.

**Root cause:** Three export functions in `Plater.cpp` were passing an empty string to `output_filepath_for_project()`, which caused `input_filename_base` to always fall through to the object-name code path in `PrintBase::update_object_placeholders()`. The logic to use the project filename as `input_filename_base` already existed and worked correctly — it was just never being reached.

**Fix:** Pass the current saved project path to `output_filepath_for_project()` at all three call sites:

- `Plater::export_gcode` — File → Export G-code
- `Plater::export_gcode_3mf` — File → Export plate sliced file
- `Plater::send_gcode_legacy` — legacy send-to-printer path

When no project has been saved to disk (unsaved or untitled project), `get_project_filename()` returns an empty path and the existing fallback to object name is preserved unchanged.

# Screenshots/Recordings/Graphs
Suggested name is now file name:
<img width="627" height="381" alt="Suggested name is now file name" src="https://github.com/user-attachments/assets/5ae90651-8654-46e4-920e-e1695f3645fc" />

Export G-code file works too:
<img width="611" height="248" alt="Export G-code file works too" src="https://github.com/user-attachments/assets/6d417548-1b56-470c-ba88-3c8c944994c3" />

Unsaved project continues to fallback to object name as before:
<img width="567" height="339" alt="Unsaved File Uses Object Name as before" src="https://github.com/user-attachments/assets/575eccc6-0c5b-4e5c-a2bb-437cd77e48ae" />

## Tests

- With an unsaved/untitled project: suggested export filename still derives from the object name (no regression)
- With a saved project (e.g. `MyPrint.3mf`): suggested export filename now correctly uses the project name (`MyPrint_PLA_...gcode`) across all three export paths
- Verified `{input_filename_base}` placeholder in G-code output reflects the project name when a project is saved

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)