### PR TITLE
fix: use bambu's network plugin

### DIFF
--- a/src/slic3r/GUI/MediaPlayCtrl.cpp
+++ b/src/slic3r/GUI/MediaPlayCtrl.cpp
@@ -184,7 +184,7 @@ void MediaPlayCtrl::SetMachineObject(MachineObject* obj)
                 && m_last_user_play + wxTimeSpan::Seconds(3) < wxDateTime::Now()) {
             // resend ttcode to printer
             if (auto agent = wxGetApp().getAgent())
-                agent->get_camera_url(machine, [](auto) {}, BBL_CLOUD_PROVIDER);
+                agent->get_camera_url(machine, [](auto) {}, wxGetApp().get_printer_cloud_provider());
             m_last_user_play = wxDateTime::Now();
         }
         return;
@@ -252,7 +252,7 @@ void refresh_agora_url(char const* device, char const* dev_ver, char const* chan
     device2 += channel;
     wxGetApp().getAgent()->get_camera_url(device2, [context, callback](std::string url) {
         callback(context, url.c_str());
-    }, BBL_CLOUD_PROVIDER);
+    }, wxGetApp().get_printer_cloud_provider());
 }
 
 void MediaPlayCtrl::Play()
@@ -378,7 +378,7 @@ void MediaPlayCtrl::Play()
                     BOOST_LOG_TRIVIAL(info) << "MediaPlayCtrl drop late ttcode for state: " << m_last_state;
                 }
             });
-        }, BBL_CLOUD_PROVIDER);
+        }, wxGetApp().get_printer_cloud_provider());
     }
 }
 
@@ -580,7 +580,7 @@ void MediaPlayCtrl::ToggleStream()
             file.close();
             m_streaming = true;
         });
-    }, BBL_CLOUD_PROVIDER);
+    }, wxGetApp().get_printer_cloud_provider());
 }
 
 void MediaPlayCtrl::msw_rescale() { 

--- a/src/slic3r/GUI/MediaPlayCtrl.cpp
+++ b/src/slic3r/GUI/MediaPlayCtrl.cpp
@@ -184,7 +184,7 @@ void MediaPlayCtrl::SetMachineObject(MachineObject* obj)
                 && m_last_user_play + wxTimeSpan::Seconds(3) < wxDateTime::Now()) {
             // resend ttcode to printer
             if (auto agent = wxGetApp().getAgent())
-                agent->get_camera_url(machine, [](auto) {});
+                agent->get_camera_url(machine, [](auto) {}, BBL_CLOUD_PROVIDER);
             m_last_user_play = wxDateTime::Now();
         }
         return;
@@ -252,7 +252,7 @@ void refresh_agora_url(char const* device, char const* dev_ver, char const* chan
     device2 += channel;
     wxGetApp().getAgent()->get_camera_url(device2, [context, callback](std::string url) {
         callback(context, url.c_str());
-    });
+    }, BBL_CLOUD_PROVIDER);
 }
 
 void MediaPlayCtrl::Play()
@@ -378,7 +378,7 @@ void MediaPlayCtrl::Play()
                     BOOST_LOG_TRIVIAL(info) << "MediaPlayCtrl drop late ttcode for state: " << m_last_state;
                 }
             });
-        });
+        }, BBL_CLOUD_PROVIDER);
     }
 }
 
@@ -580,7 +580,7 @@ void MediaPlayCtrl::ToggleStream()
             file.close();
             m_streaming = true;
         });
-    });
+    }, BBL_CLOUD_PROVIDER);
 }
 
 void MediaPlayCtrl::msw_rescale() { 


### PR DESCRIPTION
# Description

When migrating to use OrcaCloudServiceAgent, we are calling a stub instead. We should be using the bambu network plugin's API instead.

```cpp
int OrcaCloudServiceAgent::get_camera_url(std::string dev_id, std::function<void(std::string)> callback)
{
    BOOST_LOG_TRIVIAL(debug) << "OrcaCloudServiceAgent: get_camera_url (stub)";
    if (callback) callback("");
    return BAMBU_NETWORK_SUCCESS;
}
```

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
