### PR TITLE
fix: use regular slice_z computation in first layer when ZAA  enabled

### DIFF
--- a/src/libslic3r/PrintObjectSlice.cpp
+++ b/src/libslic3r/PrintObjectSlice.cpp
@@ -21,6 +21,32 @@ namespace Slic3r {
 bool PrintObject::clip_multipart_objects = true;
 bool PrintObject::infill_only_where_needed = false;
 
+static coordf_t compute_slice_z(PrintObject* print_object, size_t i_layer, coordf_t lo, coordf_t hi)
+{
+    bool zaa_active   = false;
+    coordf_t z_offset = 0.0;
+
+    size_t num_regions = print_object->num_printing_regions();
+    for (size_t rid = 0; rid < num_regions; ++rid) {
+        const auto& rcfg = print_object->printing_region(rid).config();
+        if (rcfg.zaa_enabled) {
+            if (!zaa_active || rcfg.zaa_min_z < z_offset)
+                z_offset = rcfg.zaa_min_z;
+            zaa_active = true;
+        }
+    }
+
+    if (!zaa_active || i_layer == 0) {
+        return 0.5 * (lo + hi);
+    }
+
+    coordf_t slice_z = lo + z_offset;
+    if ((slice_z < lo && !is_approx(slice_z, lo)) || (slice_z > hi && !is_approx(slice_z, hi))) {
+        throw RuntimeError("Bad min Z value");
+    }
+    return slice_z;
+}
+
 LayerPtrs new_layers(
     PrintObject                 *print_object,
     // Object layers (pairs of bottom/top Z coordinate), without the raft.
@@ -34,24 +60,8 @@ LayerPtrs new_layers(
     for (size_t i_layer = 0; i_layer < object_layers.size(); i_layer += 2) {
         coordf_t lo = object_layers[i_layer];
         coordf_t hi = object_layers[i_layer + 1];
-        coordf_t slice_z = 0.5 * (lo + hi);
-        bool zaa_active = false;
-        coordf_t z_offset = 0.0;
-        size_t num_regions = print_object->num_printing_regions();
-        for (size_t rid = 0; rid < num_regions; ++rid) {
-            const auto &rcfg = print_object->printing_region(rid).config();
-            if (rcfg.zaa_enabled) {
-                if (!zaa_active || rcfg.zaa_min_z < z_offset)
-                    z_offset = rcfg.zaa_min_z;
-                zaa_active = true;
-            }
-        }
-        if (zaa_active) {
-            slice_z = lo + z_offset;
-            if ((slice_z < lo && !is_approx(slice_z, lo)) || (slice_z > hi && !is_approx(slice_z, hi))) {
-                throw RuntimeError("Bad min Z value");
-            }
-        }
+        coordf_t slice_z = compute_slice_z(print_object, i_layer, lo, hi);
+
         Layer *layer = new Layer(id ++, print_object, hi - lo, hi + zmin, slice_z);
         out.emplace_back(layer);
         if (prev != nullptr) {


### PR DESCRIPTION
# Description

This PR ensures the regular slicing plane calculation is always used for first layer, even when ZAA is enabled.

Normally, when the ZAA feature is enabled, the slicing plane is changed to match the "minimum Z height" ZAA setting (0.05 mm by default). This can cause surprising artifacts on the first layer when the object is not perfectly flat, as was reported in https://github.com/OrcaSlicer/OrcaSlicer/pull/13450.

Since ZAA doesn't process the first layer anyway, we can restore the normal slicing plane behavior for the first layer without any ill effects while avoiding the bug see in https://github.com/OrcaSlicer/OrcaSlicer/pull/13450.

<!--
> Please provide a summary of the changes made in this PR. Include details such as:
  > * What issue does this PR address or fix?
  > * What new features or enhancements does this PR introduce?
  > * Are there any breaking changes or dependencies that need to be considered?
-->

## Tests

Tested with the framebaroque test file and regular ZAA testplate files.

- [framebaroque.zip](https://github.com/user-attachments/files/27307267/framebaroque.zip)
- [zaa_testplate_x1c.3mf](https://github.com/adob/BambuStudio-ZAA/blob/zaa/resources/nonplanar/zaa_testplate_x1c.3mf)


<!--
> Please describe the tests that you have conducted to verify the changes made in this PR.
-->

<!--
> A guide for users on how to download the artifacts from this PR.
-->

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
