### PR TITLE
fix: reflect synced preset values in UI without switching tabs

### DIFF
--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -5849,17 +5849,20 @@ void GUI_App::reload_settings()
         load_pending_vendors();
         preset_bundle->load_user_presets(*app_config, user_presets, ForwardCompatibilitySubstitutionRule::Enable);
         preset_bundle->save_user_presets(*app_config, get_delete_cache_presets());
-        if (is_main_thread_active()) {
+        // Orca: settings changed, refresh ui to reflect the new preset values
+        auto refresh_synced_ui = [this] {
             mainframe->update_side_preset_ui();
+            for (auto tab : tabs_list) {
+                tab->reload_config();
+                tab->update_changed_ui();
+            }
             if (plater_)
                 plater_->sidebar().update_all_preset_comboboxes();
-        } else {
-            CallAfter([this] {
-                mainframe->update_side_preset_ui();
-                if (plater_)
-                    plater_->sidebar().update_all_preset_comboboxes();
-            });
-        }
+        };
+        if (is_main_thread_active())
+            refresh_synced_ui();
+        else
+            CallAfter(refresh_synced_ui);
     }
 }
 

--- a/src/slic3r/GUI/MainFrame.cpp
+++ b/src/slic3r/GUI/MainFrame.cpp
@@ -2788,9 +2788,6 @@ void MainFrame::init_menubar_as_editor()
                     info_dlg.ShowModal();
                     return;
                 }
-                if (m_plater)
-                    m_plater->get_notification_manager()->push_notification(
-                        into_u8(_L("Syncing presets from cloud\u2026")));
                 wxGetApp().restart_sync_user_preset();
             }, "", nullptr,
             [this]() {


### PR DESCRIPTION
# Description

After pulling the latest presets from the cloud, changed values such as Layer height kept showing the old value until the user switched tabs. Refresh the active settings tab on sync so updates appear immediately.
# Screenshots/Recordings/Graphs

<!--
> Please attach relevant screenshots to showcase the UI changes.
> Please attach images that can help explain the changes.
-->

## Tests

<!--
> Please describe the tests that you have conducted to verify the changes made in this PR.
-->

<!--
> A guide for users on how to download the artifacts from this PR.
-->

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
