### PR TITLE
fix: h2d camera liveview

### DIFF
--- a/src/slic3r/Utils/BBLCloudServiceAgent.cpp
+++ b/src/slic3r/Utils/BBLCloudServiceAgent.cpp
@@ -50,7 +50,10 @@ std::map<std::string, std::string> BBLCloudServiceAgent::get_extra_header()
 {
     std::map<std::string, std::string> extra_headers;
     extra_headers.emplace("X-BBL-Client-Type", "slicer");
-    extra_headers.emplace("X-BBL-Client-Name", SLIC3R_APP_NAME);
+
+    // Unable to get camera live view when the printer is connected to cloud for H2D
+    extra_headers.emplace("X-BBL-Client-Name", "BambuStudio");
+
     extra_headers.emplace("X-BBL-Client-Version", GUI::wxGetApp().get_bbl_client_version());
 #if defined(__WINDOWS__)
 #ifdef _M_X64


### PR DESCRIPTION
# Description

Camera live view when a printer connected via cloud was fixed previously in #13756 but was not working on H2D printers. This PR fixes the camera view on H2D when H2D is connected via cloud.

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
