### PR TITLE
Ignore SIGPIPE at startup to prevent crashes on dropped printer connections

### DIFF
--- a/src/OrcaSlicer.cpp
+++ b/src/OrcaSlicer.cpp
@@ -23,6 +23,7 @@
 #include <cstring>
 #include <iostream>
 #include <math.h>
+#include <csignal>
 
 #if defined(__linux__) || defined(__LINUX__)
 #include <condition_variable>
@@ -7459,6 +7460,13 @@ extern "C" {
 #else /* _MSC_VER */
 int main(int argc, char **argv)
 {
+#ifndef _WIN32
+    // Ignore SIGPIPE so a write to a closed socket (e.g. a dropped printer
+    // network connection) returns EPIPE to the caller instead of terminating
+    // the whole process. Without this, losing the printer link kills
+    // OrcaSlicer with SIGPIPE (exit 141) and produces no crash report.
+    std::signal(SIGPIPE, SIG_IGN);
+#endif
     return CLI().run(argc, argv);
 }
 #endif /* _MSC_VER */


### PR DESCRIPTION

## Summary

OrcaSlicer terminates with **SIGPIPE (exit 141)** when it writes to a printer network socket that has been closed (a dropped LAN/cloud connection to a Bambu printer). The process installs no SIGPIPE disposition, so the signal's default action kills the whole GUI — silently, with no crash report.

This PR sets `SIGPIPE` to `SIG_IGN` once at `main()` entry (POSIX only). Writes to closed sockets then return `EPIPE` to the caller, which the existing networking error paths already handle (they log `send_message_to_printer … ret=-4`). No behavior change on Windows (no SIGPIPE there).

Fixes #13787.

## Root cause

`src/OrcaSlicer.cpp` has no signal handling. The Bambu networking layer writes to TCP/MQTT sockets without `SO_NOSIGPIPE`/`MSG_NOSIGNAL`, so a write after the connection drops raises SIGPIPE → default action terminates the process. No `.ips` crash report is produced because SIGPIPE's default termination bypasses the crash reporter.

## Verification

Pre-setting `SIG_IGN` before `exec` (disposition survives `exec`) eliminates the crashes while the printer stays connected through repeated drops — confirming both the cause and that nothing in the app/networking plugin resets the disposition:

```bash
python3 -c 'import signal, os, sys; signal.signal(signal.SIGPIPE, signal.SIG_IGN); os.execv(sys.argv[1], sys.argv[1:])' \
  /Applications/OrcaSlicer.app/Contents/MacOS/OrcaSlicer
```

Before: app exits with `EXIT: 141` within minutes of a connection hiccup.
After (with this patch / the wrapper): app remains stable; the same `ret=-4` socket errors are logged and handled instead of being fatal.

## The patch

```diff
diff --git a/src/OrcaSlicer.cpp b/src/OrcaSlicer.cpp
index 880eaff..7107e1b 100644
--- a/src/OrcaSlicer.cpp
+++ b/src/OrcaSlicer.cpp
@@ -23,6 +23,7 @@
 #include <cstring>
 #include <iostream>
 #include <math.h>
+#include <csignal>
 
 #if defined(__linux__) || defined(__LINUX__)
 #include <condition_variable>
@@ -7459,6 +7460,13 @@ extern "C" {
 #else /* _MSC_VER */
 int main(int argc, char **argv)
 {
+#ifndef _WIN32
+    // Ignore SIGPIPE so a write to a closed socket (e.g. a dropped printer
+    // network connection) returns EPIPE to the caller instead of terminating
+    // the whole process. Without this, losing the printer link kills
+    // OrcaSlicer with SIGPIPE (exit 141) and produces no crash report.
+    std::signal(SIGPIPE, SIG_IGN);
+#endif
     return CLI().run(argc, argv);
 }
 #endif /* _MSC_VER */
```

> Verified: this is the `git diff` output against current `main`, confirmed to apply cleanly with `git apply --check`.

## How to apply (for building/testing the fix)

```bash
git clone https://github.com/OrcaSlicer/OrcaSlicer
cd OrcaSlicer
git checkout -b fix/sigpipe-printer-crash
git apply /path/to/this.patch     # or paste the two edits manually
# build per the project's build instructions, then run with a printer connected
```

If `git apply` reports offsets (line numbers drift between versions), apply the two edits by hand — they're trivial:
1. add `#include <csignal>` to the include block near the top of `src/OrcaSlicer.cpp`
2. add the `#ifndef _WIN32 … std::signal(SIGPIPE, SIG_IGN); … #endif` block as the first statement inside `int main(...)`.

## Notes / scope

- **POSIX-only** (`#ifndef _WIN32`): Windows has no SIGPIPE. The non-MSVC `main()` is the correct, earliest place — it runs before any GUI/CLI init and before the networking plugin loads, and signal dispositions are process-wide (covers all threads and the closed-source Bambu networking module).
- **Minimal and conventional**: `signal(SIGPIPE, SIG_IGN)` at startup is the standard idiom for networked applications; many wxWidgets/socket apps do exactly this.
- **Not a masking change**: it does not hide errors — the networking code already detects and logs the failed writes (`ret=-4`); this just lets it handle them as `EPIPE` rather than the OS killing the process.
- A complementary, lower-level hardening would be `SO_NOSIGPIPE` (macOS) / `MSG_NOSIGNAL` (Linux) on the printer sockets, but those live in the networking layer (partly closed-source for Bambu); the process-wide `SIG_IGN` is the complete and portable fix at the app level.
