### PR TITLE
fix: bambu slice hover popup disappears too fast macos

### DIFF
--- a/src/slic3r/GUI/FilamentGroupPopup.cpp
+++ b/src/slic3r/GUI/FilamentGroupPopup.cpp
@@ -338,7 +338,15 @@ void FilamentGroupPopup::OnRadioBtn(int idx)
     }
 }
 
-void FilamentGroupPopup::OnTimer(wxTimerEvent &event) { Dismiss(); }
+void FilamentGroupPopup::OnTimer(wxTimerEvent&)
+{
+    if (IsMouseInPopup()) {
+        StartTimer();
+        return;
+    }
+
+    Dismiss();
+}
 
 void FilamentGroupPopup::Dismiss() {
     m_active = false;
@@ -348,17 +356,20 @@ void FilamentGroupPopup::Dismiss() {
 
 void FilamentGroupPopup::OnLeaveWindow(wxMouseEvent &)
 {
-    wxPoint pos = this->ScreenToClient(wxGetMousePosition());
-    if (this->GetClientRect().Contains(pos)) return;
+    if (this->GetScreenRect().Contains(wxGetMousePosition())) return;
     StartTimer();
 }
 
 void FilamentGroupPopup::OnEnterWindow(wxMouseEvent &)
 {
     // Ignore spurious ENTER synthesized by PopupWindow::OnMouseEvent2 on macOS.
-    wxPoint pos = this->ScreenToClient(wxGetMousePosition());
-    if (!this->GetClientRect().Contains(pos)) return;
+    if (!this->GetScreenRect().Contains(wxGetMousePosition())) return;
     ResetTimer();
+}
+
+bool FilamentGroupPopup::IsMouseInPopup() const
+{
+    return this->GetScreenRect().Contains(wxGetMousePosition());
 }
 
 void FilamentGroupPopup::UpdateButtonStatus(int hover_idx)

--- a/src/slic3r/GUI/FilamentGroupPopup.hpp
+++ b/src/slic3r/GUI/FilamentGroupPopup.hpp
@@ -36,6 +36,7 @@ private:
     void OnEnterWindow(wxMouseEvent &);
     void OnTimer(wxTimerEvent &event);
     void Dismiss();
+    bool IsMouseInPopup() const;
 
     void CreateBmps();
 


### PR DESCRIPTION
# Description

Steps to Repro:

    Launch OrcaSlicer nightly

    add the X2D printer from Bambu 

    Add another filament

    Hover over the Slice arrow down button

    A custom menu will pop up but this menu doesn’t stay long enough for users to be able to select any options

Expected: The menu should remain as long as the mouse is over the menu.

Video:  

https://github.com/user-attachments/assets/bc3259fc-d4ca-4cdb-b986-4aa690e0ef13

Validated on MacOS 26.4.1 (25E253) Apple M5 Pro 

Note: This seems to be a macos only issue.

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
