### PR TITLE
fix: 409 sync push on app start

### DIFF
--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -581,14 +581,6 @@ void Preset::load_info(const std::string& file)
     catch (...) {
         return;
     }
-
-    //TODO: workaround for current info file convert, will remove it later
-    if (this->updated_time == 0) {
-        this->updated_time = (long long)Slic3r::Utils::get_current_time_utc();
-        //this->sync_info = "update";
-        BOOST_LOG_TRIVIAL(info) << boost::format("old info file, updated time to %1%") % this->updated_time;
-        save_info();
-    }
 }
 
 void Preset::save_info(std::string file)


### PR DESCRIPTION
# Description

There was a legacy code that set the update_time timestamp of the local preset top the current time if it was empty. 
This could happen if before pushing to the cloud, you close orcaslicer or orcaslicer crashes, resulting in a stale info file.
On subsequent startups, info file exists -> calls sync push with updated time -> updated time is different from the cloud's updated time -> 409 conflict.

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
