### PR TITLE
feat: double-click object list row to frame object in 3D view

### DIFF
--- a/src/slic3r/GUI/GUI_ObjectList.cpp
+++ b/src/slic3r/GUI/GUI_ObjectList.cpp
@@ -488,12 +488,17 @@ void ObjectList::create_objects_ctrl()
         // matching the "Fit camera to scene or selected object" canvas button.
         // The preceding single click has already synced the canvas selection via
         // wxEVT_DATAVIEW_SELECTION_CHANGED, so we just trigger the zoom here.
+        // No-op in slice-preview mode: the camera is shared with the editor
+        // canvas, so zooming there would move the preview view too — and the
+        // preview canvas's own toolbar button intentionally resets to the bed.
         const wxDataViewItem item = event.GetItem();
         if (!item.IsOk())
             return;
+        if (wxGetApp().plater()->is_preview_shown())
+            return;
         const ItemType type = m_objects_model->GetItemType(item);
         if (type & (itObject | itVolume | itInstance)) {
-            if (GLCanvas3D* canvas = wxGetApp().plater()->get_current_canvas3D(true /* exclude preview */))
+            if (GLCanvas3D* canvas = wxGetApp().plater()->get_current_canvas3D())
                 canvas->zoom_to_selection();
         }
     });

--- a/src/slic3r/GUI/GUI_ObjectList.cpp
+++ b/src/slic3r/GUI/GUI_ObjectList.cpp
@@ -481,6 +481,20 @@ void ObjectList::create_objects_ctrl()
             // Trigger the editor opening manually
             this->EditItem(event.GetItem(), GetColumn(colFilament));
 #endif
+            return;
+        }
+
+        // Double-clicking an object/part/instance row frames it in the 3D view,
+        // matching the "Fit camera to scene or selected object" canvas button.
+        // The preceding single click has already synced the canvas selection via
+        // wxEVT_DATAVIEW_SELECTION_CHANGED, so we just trigger the zoom here.
+        const wxDataViewItem item = event.GetItem();
+        if (!item.IsOk())
+            return;
+        const ItemType type = m_objects_model->GetItemType(item);
+        if (type & (itObject | itVolume | itInstance)) {
+            if (GLCanvas3D* canvas = wxGetApp().plater()->get_current_canvas3D(true /* exclude preview */))
+                canvas->zoom_to_selection();
         }
     });
 


### PR DESCRIPTION
# Description

Resolves #13800.

Adds Blender-style "Frame Selected" behavior to the object list: **double-clicking an object, part, or instance row in the left panel now frames that item in the 3D view**, while preserving the current view angle. This is the same camera move the existing **Fit camera to scene or selected object** canvas-toolbar button performs (`GLCanvas3D::zoom_to_selection()`) — just exposed via a more natural trigger from the list users are already interacting with.

### Implementation

Extends the existing `wxEVT_DATAVIEW_ITEM_ACTIVATED` handler in `ObjectList::create_objects_ctrl()` (the same place that today opens the filament-color editor on activation of the filament column). For object / part / instance rows the handler now calls `GLCanvas3D::zoom_to_selection()`. The preceding single click has already synced the canvas selection via `wxEVT_DATAVIEW_SELECTION_CHANGED`, so we don't need to drive selection ourselves — the new branch is purely the camera move.

### Scope (deliberately small, no behavior changes elsewhere)

- Object / Part / Instance rows → `zoom_to_selection()`.
- Filament-color column → **unchanged** (still opens the color editor on the existing platform-specific code paths).
- Plate rows → **unchanged** (no-op; they already deselect-all on single click — can be revisited later as `zoom_to_plate(...)`).
- Slice-preview mode → **inert** (guarded by `Plater::is_preview_shown()`; see follow-up note below).

No new helpers, no new files, no plumbing changes.

### Relationship to existing work

Complementary to (not duplicate of) the keyboard-shortcut work in #13331 / #13419 — those add a `Z` hotkey for the same camera move. This adds a mouse trigger from a different interaction surface (the object list). Both can coexist; both ultimately reuse the same `zoom_to_selection()` call site.

### Follow-up commit (2026-05-22)

The first revision relied on `Plater::get_current_canvas3D(true /* exclude_preview */)` returning `nullptr` in slice-preview mode. Empirical testing showed that flag actually falls through to the editor canvas as a default ([Plater.cpp:10953-10954](src/slic3r/GUI/Plater.cpp#L10953-L10954)), so the handler was still calling `zoom_to_selection()` on the editor canvas — and the shared camera made the move visible in the preview view (centered on empty world positions for unsliced/excluded objects). Fixed in the follow-up commit by replacing the misnamed flag with an explicit `is_preview_shown()` guard before any canvas lookup.

### AI disclosure

This change was developed with the assistance of Claude (Anthropic), at the contributor's direction and after manual verification. The diff was kept intentionally small and is summarized above; reviewers should not need to chase any auto-generated boilerplate.

# Screenshots/Recordings/Graphs

A short screen recording would be the clearest demo here — happy to attach one on request. UX summary: on a populated plate, rotate the view to any angle, then double-click rows in the object list — the camera pans/zooms to each in turn, view angle unchanged.

Behavior before confirming double clicking on list items does not focus

https://github.com/user-attachments/assets/02b4e58e-2f49-4ffa-aa10-125e6bd2d91c

Behavior after confirming double clicking on list items now does focus


https://github.com/user-attachments/assets/a4a4c96d-356b-4797-8cff-7fd96ba61753


I'm not sure if you want just to spot check or if you want me to show all the scenarios of testing clicking on STLs/parts/assemblies etc.
There is also a check to make sure disable navigation in Sliced Preview that I didn't show off either.
I'm just not sure how thorough you want the recordings to be.
Let me know if you want more.

## Tests

There is no automated GUI test infrastructure in this repo (`tests/` is entirely headless: `libslic3r` / `fff_print` / `sla_print` / `libnest2d` / `slic3rutils`; none link wxWidgets or `slic3r/GUI`). Standing up a wxWidgets + OpenGL test harness for a single event-handler binding would be disproportionate to the change. Manual verification instead, on Windows 11 / RelWithDebInfo:

- [x] Double-click an object row → camera frames the object, view angle preserved.
- [x] Double-click the filament-color cell → existing color picker still opens (regression check).
- [x] Double-click a plate row → no-op (intended; plate rows already deselect-all on single click).
- [x] Re-double-click an already-selected row → frames as expected.
- [x] Multi-select then plain double-click → wxDataView reduces selection to the clicked row before activation, so it frames just that row (good outcome).
- [x] Multi-select with shift held → activation runs on the group, frames the combined bbox (also good outcome — matches the existing "Fit camera" canvas button in the same state).
- [x] Switch to slice-preview view → double-click in object list is inert (after the follow-up commit).
- [ ] Double-click a part (sub-volume) row → frames that part.
- [ ] Double-click a per-object instance row → frames that instance.

The two unchecked items above are expected to follow from the same code path but haven't been individually clicked through yet — easy to verify with the artifact below.

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
