### PR TITLE
Fix ScriptMessageHandler invalidation after RemoveAllUserScripts on Windows.

### DIFF
--- a/src/slic3r/GUI/PrinterWebView.cpp
+++ b/src/slic3r/GUI/PrinterWebView.cpp
@@ -242,6 +242,14 @@ void PrinterWebView::SendAPIKey()
 )",
                                        m_apikey);
     m_browser->RemoveAllUserScripts();
+    
+#ifdef _WIN32
+    // RemoveAllUserScripts causes WebView2 to forget about our script message handler, 
+    // so re-add it here.
+    m_browser->RemoveScriptMessageHandler("wx");
+    m_browser->AddScriptMessageHandler("wx");
+#endif
+
 #ifdef __linux__
     // Re-inject the vue-resize/WebKitGTK workaround that RemoveAllUserScripts just cleared.
     inject_vue_resize_workaround(m_browser);


### PR DESCRIPTION
Fix `ScriptMessageHandler` invalidation after `RemoveAllUserScripts` on Windows. This issue prevents the web page from communicating with native code via `window.wx.postMessage`.