### PR TITLE
Fix CrealityPrint uploads with non-ASCII filenames

### DIFF
--- a/src/slic3r/Utils/CrealityPrint.cpp
+++ b/src/slic3r/Utils/CrealityPrint.cpp
@@ -137,20 +137,22 @@ bool CrealityPrint::upload(PrintHostUpload upload_data, ProgressFn prorgess_fn, 
     }
 
     bool res = true;
-    auto url = make_url("upload/" + safe_filename(upload_filename.string()));
+    const auto safe_upload_filename = safe_filename(upload_filename.string());
+    // Only encode the URL path segment; keep the multipart filename and start-print path as the stored filename.
+    auto url = make_url("upload/" + Http::url_encode(safe_upload_filename));
 
     auto  http = Http::post(url); // std::move(url));
     set_auth(http);
     if (!supports_multi_color_print())
         http.form_add("path", upload_parent_path.string());
-    http.form_add_file("file", upload_data.source_path.string(), upload_filename.string())
+    http.form_add_file("file", upload_data.source_path.string(), safe_upload_filename)
 
         .on_complete([&](std::string body, unsigned status) {
             BOOST_LOG_TRIVIAL(debug) << boost::format("%1%: File uploaded: HTTP %2%: %3%") % name % status % body;
 
             if (upload_data.post_action == PrintHostPostUploadAction::StartPrint) {
                 wxString errormsg;
-                if (!start_print(errormsg, safe_filename(upload_filename.string()), upload_data.extended_info)) {
+                if (!start_print(errormsg, safe_upload_filename, upload_data.extended_info)) {
                     error_fn(std::move(errormsg));
                     res = false;
                 }


### PR DESCRIPTION
# Description

Fixes #11163.

CrealityPrint uploads can fail when the generated G-code filename contains non-ASCII or URL-sensitive characters.

These printers expose file uploads as `/upload/<filename>`. OrcaSlicer previously inserted the sanitized filename directly into the URL path, only replacing spaces with underscores. Filenames containing Chinese characters or reserved URL characters can make the printer-side HTTP server close the connection during upload, surfacing as curl error 55.

This change percent-encodes the filename only for the upload URL path while keeping the actual multipart filename and post-upload print command unchanged.

# Tests

- Verified `git diff --check`.
- Verified against a Creality Ender-3 V3 KE:
  - Uploading with an unencoded Chinese filename in `/upload/<filename>` reproduces the failure.
  - Uploading the same filename with a percent-encoded URL returns `200 OK`.
  - Manually renaming the G-code to ASCII in OrcaSlicer works around the issue.