### PR TITLE
Preserve Z scale and apply correct offset when Ctrl‑dragging XY corner

### DIFF
--- a/src/slic3r/GUI/Gizmos/GLGizmoScale.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoScale.cpp
@@ -448,7 +448,29 @@ void GLGizmoScale3D::do_scale_uniform(const UpdateData& data)
     if (ratio > 0.0)
     {
         m_scale = m_starting.scale * ratio;
-        m_offset = Vec3d::Zero();
+        if (m_starting.ctrl_down && abs(ratio-1.0f)>0.001) {
+            m_scale.z() = m_starting.scale.z();
+            double local_offset_x = 0.5 * (m_scale.x() - m_starting.scale.x()) * m_starting.box.size().x();
+            double local_offset_y = 0.5 * (m_scale.y() - m_starting.scale.y()) * m_starting.box.size().y();
+            
+            Vec3d local_offset_vec = Vec3d::Zero();
+            switch (m_hover_id)
+            {
+                case 6: { local_offset_vec = Vec3d(-local_offset_x, -local_offset_y, 0.0); break; }
+                case 7: { local_offset_vec = Vec3d( local_offset_x, -local_offset_y, 0.0); break; }
+                case 8: { local_offset_vec = Vec3d( local_offset_x,  local_offset_y, 0.0); break; }
+                case 9: { local_offset_vec = Vec3d(-local_offset_x,  local_offset_y, 0.0); break; }
+                default: break;
+            }
+            
+            if (m_object_manipulation->is_world_coordinates()) {
+                m_offset = local_offset_vec;
+            } else {
+                m_offset = m_grabbers_tran.get_matrix_no_offset() * local_offset_vec;
+            }
+        } else {
+            m_offset = Vec3d::Zero();
+        }
     }
 }
 


### PR DESCRIPTION
# Description

When using the scaling with Ctrl+drag on the corner grabbers, the scaling was applied to all three axes (X, Y, and Z). This function was different than when Ctrl+drag scaling for single axes scaling. Updating Ctrl+drag on the corners to align with single axes to not scale Z and apply offset so that just the corners are moved. This change follows offset handling similar to do_scale_along_axis() for single axes scaling.

Before:

https://github.com/user-attachments/assets/9bca6e5a-d097-4a47-97f2-76a70c083e0f

After:

https://github.com/user-attachments/assets/94caacf3-67d6-4f1c-a122-3ec04b5301f8


## Test
  - Ctrl+drag corners scales XY while preserving Z
  - Normal drag still scales uniformly
