### PR TITLE
Fix Snapmaker U1 "Print by Object" collisions

### DIFF
--- a/resources/profiles/Snapmaker/machine/Snapmaker U1 (0.4 nozzle).json
+++ b/resources/profiles/Snapmaker/machine/Snapmaker U1 (0.4 nozzle).json
@@ -8,7 +8,7 @@
 	"printer_model": "Snapmaker U1",
 	"printer_variant": "0.4",
 	"auxiliary_fan": "1",
-	"change_filament_gcode": ";===== date: 20251213=====================\n; Change Tool[previous_extruder] -> Tool[next_extruder] (layer [layer_num])\n{\nlocal max_speed_toolchange = 350.0;\nlocal wait_for_extruder_temp = true;\nposition[2] = position[2] + 2.0;\nlocal speed_toolchange = max_speed_toolchange;\nif travel_speed < max_speed_toolchange then\n      speed_toolchange = travel_speed;\nendif\n\"G91\nG1 Z1.5 F1800\nG90\n\";\n\"G1 F\" + (speed_toolchange * 60) + \"\n\";\nif wait_for_extruder_temp and not((layer_num < 0) and (next_extruder == initial_tool)) then\n      \"\n\";\n      \"; \" + layer_num + \"\n\";\n      if layer_num == 0 then\n            \"M109 S\" + first_layer_temperature[next_extruder] + \" T\" + next_extruder + \"\n\";\n      else\n            \"M109 S\" + temperature[next_extruder] + \" T\" + next_extruder + \"\n\";\n      endif\nendif\n\"M400\" + \"\n\";\n\"T\" + next_extruder + \"\n\";\nif filament_type[next_extruder] == \"PVA\" then\n\"SET_VELOCITY_LIMIT ACCEL=3000\n\";\nelse\nendif\nif previous_extruder != next_extruder and initial_extruder != next_extruder then\n\"SM_PRINT_PREEXTRUDE_FILAMENT INDEX=\" + next_extruder + \"\n\";\nendif\n\"G90\n\";\n}\n",
+	"change_filament_gcode": ";===== date: 20260525 =====================\n; Change Tool[previous_extruder] -> Tool[next_extruder] (layer [layer_num] ; max_layer_z [max_layer_z] ; max_print_height [max_print_height])\n{\nlocal move_z = max_print_height;\nlocal max_speed_toolchange = 350.0;\nlocal wait_for_extruder_temp = true;\nposition[2] = position[2] + 2.0;\nlocal speed_toolchange = max_speed_toolchange;\nif travel_speed < max_speed_toolchange then\n      speed_toolchange = travel_speed;\nendif\n\nif max_layer_z < (max_print_height - 1) then\n    move_z = z_offset + min(max_layer_z + 2, max_print_height);\nendif\n\n\"G91\nG1 Z\" + move_z + \" F1800 ; Move nozzle just above tallest printed object\nG90\n\";\n\"G1 F\" + (speed_toolchange * 60) + \"\n\";\nif wait_for_extruder_temp and not((layer_num < 0) and (next_extruder == initial_tool)) then\n      \"\n\";\n      \"; \" + layer_num + \"\n\";\n      if layer_num == 0 then\n            \"M109 S\" + first_layer_temperature[next_extruder] + \" T\" + next_extruder + \"\n\";\n      else\n            \"M109 S\" + temperature[next_extruder] + \" T\" + next_extruder + \"\n\";\n      endif\nendif\n\"M400\" + \"\n\";\n\"T\" + next_extruder + \"\n\";\nif filament_type[next_extruder] == \"PVA\" then\n\"SET_VELOCITY_LIMIT ACCEL=3000\n\";\nelse\nendif\nif previous_extruder != next_extruder and initial_extruder != next_extruder then\n\"SM_PRINT_PREEXTRUDE_FILAMENT INDEX=\" + next_extruder + \"\n\";\nendif\n\"G90\n\";\n}\n",
 	"extruder_colour": [
 		"#FCE94F",
 		"#FCE94F",
@@ -28,7 +28,7 @@
 		"0",
 		"0"
 	],
-	"machine_end_gcode": " PRINT_END\nTIMELAPSE_STOP",
+	"machine_end_gcode": ";===== date: 20260525 =====================\n; (layer [layer_num] ; max_layer_z [max_layer_z])\n{\nlocal move_z = max_print_height;\n\nif max_layer_z < (max_print_height - 1) then\n    move_z = z_offset + min(max_layer_z + 2, max_print_height);\nendif\n\n\"G91\nG1 Z\" + move_z + \" F1800 ; Move nozzle just above tallest printed object\nG90\n; Triggering PBO Z Movement of: \" + move_z + \"\nPRINT_END\nTIMELAPSE_STOP\n\";\n}\n",
 	"machine_max_acceleration_extruding": [
 		"25000",
 		"25000"


### PR DESCRIPTION
Updated Snapmaker U1 0.4 nozzle.j "change_filament_gcode" and "machine_end_gcode" to fix the issue of collisions when using "Print by Object"

# Description

This PR fixes the Snapmaker U1 collisions that can occur while printing using "Print by Object" with multiple colors or print heads.  These collisions happen because the current configuration of the U1 only tracks the current object's Z height and not the Z height of any other objects on the plate.

This will sometimes cause the print head to collide with previously printed objects on the plate when switching print heads or homing after a print finishes.

It is a known issue with Snapmaker as I have opened a ticket and the dev team confirmed it was a bug.  There is now a warning in Snapmaker Orca about it:

<img width="372" height="74" alt="Screenshot 2026-05-25 at 12 51 04 AM" src="https://github.com/user-attachments/assets/8c88374d-90c7-487b-951a-6a561b4fc7f5" />


This PR fixes that by updating the following two settings:

## change_filament_gcode

The changes to this setting add Z height tracking of all objects and not just the current object. It calculates the height of the tallest object and adds 2mm of clearance and lowers the build plate when switching print heads to avoid collisions. It then moves to the next object and raises the build plate and continues printing.

It also takes into consideration not to lower the plate lower than the maximum print height of the printer (270mm). 

The current Snapmaker configuration only moves the build plate 1.5mm from the Z offset of the current object that was being printed.  This is what causes the collisions when moving or swapping print heads.

## machine_end_gcode

The changes to this setting are the same and are called after the print finishes, before calling PRINT_END, so that the build plate is lowered the height of the tallest object + 2mm. This avoids collisions when homing during PRINT_END.

The current Snapmaker configuration only moves the build plate 1.5mm from the Z offset of the current object that was being printed at the end of the print.  This is what causes the homing collisions.

# Screenshots & Recordings

Here is the original video of the print head colliding with previously printed objects that was provided to Snapmaker, which they then confirmed the bug (the collision happens roughly half way through the video):

https://photos.app.goo.gl/GVY4MQPvNVZfsnHH7


## Tests

I have created a 3MF with two collision tests which with the current Snapmaker U1 settings and a 3MF with the settings in this PR.

[U1 - Collision Test - Orca - Fail.3mf.zip](https://github.com/user-attachments/files/28283225/U1.-.Collision.Test.-.Orca.-.Fail.3mf.zip)

The only caveat is that in _U1 - Collision Test 2_, the circled object in front of print head 1 expects that filament/print head will handle that object.  You could move it in front of whatever print head that will be handling that color (in this case black), but in this test case I chose print head 1.

## U1 - Collision Test 1

This test will cause the print head to collide with the object circled in red when homing after the print:

<img width="919" height="932" alt="U1 - Collision Test 1 - Orca" src="https://github.com/user-attachments/assets/d6f4676e-08ac-411a-9002-91feb5bd7a74" />

Here is a video of the **U1 - Collision Test 1** being run with the current Snapmaker U1 settings, which cause a collision when homing at the end of the print:

https://photos.app.goo.gl/E8vryXHwuVoi7Aha9 (collision around 3:40)

Here is a video of the **U1 - Collision Test 1** being run with the updated Snapmaker U1 settings in this PR, which avoids the collision. Notice the build plate moves to avoid collisions:

https://photos.app.goo.gl/YSVVB1MkFNak32of6

## U1 - Collision Test 2

This test will cause the print head to collide with the object circled in red when switching print heads during the print:

<img width="958" height="973" alt="U1 - Collision Test 2 - Orca" src="https://github.com/user-attachments/assets/0bbc151f-4fef-4e36-ab43-ca6521af1db1" />

Here is a video of the **U1 - Collision Test 2** being run with the current Snapmaker U1 settings, which causes a collision when swapping tool heads:

https://photos.app.goo.gl/TuPk1dou3NsKXyUu7 (collision around 5:40)

Here is a video of the **U1 - Collision Test 2** being run with the updated Snapmaker U1 settings in this PR, which avoids the collision. Notice the build plate moves to avoid collisions:

https://photos.app.goo.gl/MiMJb2mreqgNTJkg8

## How to create a Snapmaker U1 nozzle profile to test these settings

1. Edit the current Snapmaker U1 printer profile
2. Click the `Machine G-code` tab
3. Replace the `Machine end G-code` with the following:

```
;===== date: 20260525 =====================
; (layer [layer_num] ; max_layer_z [max_layer_z])
{
local move_z = max_print_height;

if max_layer_z < (max_print_height - 1) then
    move_z = z_offset + min(max_layer_z + 2, max_print_height);
endif

"G91
G1 Z" + move_z + " F1800 ; Move nozzle just above tallest printed object
G90
; Triggering PBO Z Movement of: " + move_z + "
PRINT_END
TIMELAPSE_STOP
";
}
```

4. Replace the `Change filament G-code` with:

```
;===== date: 20260525 =====================
; Change Tool[previous_extruder] -> Tool[next_extruder] (layer [layer_num] ; max_layer_z [max_layer_z] ; max_print_height [max_print_height])
{
local move_z = max_print_height;
local max_speed_toolchange = 350.0;
local wait_for_extruder_temp = true;
position[2] = position[2] + 2.0;
local speed_toolchange = max_speed_toolchange;
if travel_speed < max_speed_toolchange then
      speed_toolchange = travel_speed;
endif

if max_layer_z < (max_print_height - 1) then
    move_z = z_offset + min(max_layer_z + 2, max_print_height);
endif

"G91
G1 Z" + move_z + " F1800 ; Move nozzle just above tallest printed object
G90
";
"G1 F" + (speed_toolchange * 60) + "
";
if wait_for_extruder_temp and not((layer_num < 0) and (next_extruder == initial_tool)) then
      "
";
      "; " + layer_num + "
";
      if layer_num == 0 then
            "M109 S" + first_layer_temperature[next_extruder] + " T" + next_extruder + "
";
      else
            "M109 S" + temperature[next_extruder] + " T" + next_extruder + "
";
      endif
endif
"M400" + "
";
"T" + next_extruder + "
";
if filament_type[next_extruder] == "PVA" then
"SET_VELOCITY_LIMIT ACCEL=3000
";
else
endif
if previous_extruder != next_extruder and initial_extruder != next_extruder then
"SM_PRINT_PREEXTRUDE_FILAMENT INDEX=" + next_extruder + "
";
endif
"G90
";
}

```
5. Save the profile with a new name `Snapmaker U1 - Print By Object`, etc.
6. Run the two test prints again and no collisions should occur.