### PR TITLE
Add Point3 return type getters for first and last point to ExtrusionEntity

### DIFF
--- a/src/libslic3r/ExtrusionEntity.hpp
+++ b/src/libslic3r/ExtrusionEntity.hpp
@@ -118,6 +118,9 @@ public:
     virtual void reverse() = 0;
     virtual Point first_point() const = 0;
     virtual Point last_point() const = 0;
+    virtual const Point3& first_point3() const = 0;
+    virtual const Point3& last_point3() const = 0;
+    
     // Produce a list of 2D polygons covered by the extruded paths, offsetted by the extrusion width.
     // Increase the offset by scaled_epsilon to achieve an overlap, so a union will produce no gaps.
     virtual void polygons_covered_by_width(Polygons &out, const float scaled_epsilon) const = 0;
@@ -253,9 +256,9 @@ public:
 	ExtrusionEntity* clone_move() override { return new ExtrusionPath(std::move(*this)); }
     void reverse() override { this->polyline.reverse(); }
     Point first_point() const override { return this->polyline.points.front().to_point(); }
-    Point3 first_point3() const { return this->polyline.points.front(); }
+    const Point3& first_point3() const override { return this->polyline.points.front(); }
     Point last_point() const override { return this->polyline.points.back().to_point(); }
-    Point3 last_point3() const { return this->polyline.points.back(); }
+    const Point3& last_point3() const override { return this->polyline.points.back(); }
     size_t size() const { return this->polyline.size(); }
     bool empty() const { return this->polyline.empty(); }
     bool is_closed() const { return ! this->empty() && this->polyline.points.front() == this->polyline.points.back(); }
@@ -403,7 +406,9 @@ public:
 	ExtrusionEntity* clone_move() override { return new ExtrusionMultiPath(std::move(*this)); }
     void reverse() override;
     Point first_point() const override { return this->paths.front().polyline.points.front().to_point(); }
+    const Point3& first_point3() const override { return this->paths.front().polyline.points.front(); }
     Point last_point() const override { return this->paths.back().polyline.points.back().to_point(); }
+    const Point3& last_point3() const override { return this->paths.back().polyline.points.back(); }
     size_t size() const { return this->paths.size(); }
     bool empty() const { return this->paths.empty(); }
     double length() const override;
@@ -459,7 +464,9 @@ public:
     bool is_counter_clockwise() { return this->polygon().is_counter_clockwise(); }
     void reverse() override;
     Point first_point() const override { return this->paths.front().polyline.points.front().to_point(); }
+    const Point3& first_point3() const override { return this->paths.front().polyline.points.front(); }
     Point last_point() const override { assert(this->first_point() == this->paths.back().polyline.points.back().to_point()); return this->first_point(); }
+    const Point3& last_point3() const override { assert(this->first_point3() == this->paths.back().polyline.points.back()); return this->first_point3(); }
     Polygon polygon() const;
     double length() const override;
     bool split_at_vertex(const Point &point, const double scaled_epsilon = scaled<double>(0.001));
@@ -510,7 +517,7 @@ public:
 
 #ifndef NDEBUG
 	bool validate() const {
-		assert(this->first_point() == this->paths.back().polyline.points.back());
+		assert(this->first_point3() == this->paths.back().polyline.points.back());
 		for (size_t i = 1; i < paths.size(); ++ i)
 			assert(this->paths[i - 1].polyline.points.back() == this->paths[i].polyline.points.front());
 		return true;

--- a/src/libslic3r/ExtrusionEntityCollection.hpp
+++ b/src/libslic3r/ExtrusionEntityCollection.hpp
@@ -119,7 +119,10 @@ public:
     	{ return this->no_sort ? *this : chained_path_from(this->entities, start_near, role); }
     void reverse() override;
     Point first_point() const override { return this->entities.front()->first_point(); }
+    const Point3& first_point3() const override { return this->entities.front()->first_point3(); }
     Point last_point() const override { return this->entities.back()->last_point(); }
+    const Point3& last_point3() const override { return this->entities.back()->last_point3(); }
+
     // Produce a list of 2D polygons covered by the extruded paths, offsetted by the extrusion width.
     // Increase the offset by scaled_epsilon to achieve an overlap, so a union will produce no gaps.
     void polygons_covered_by_width(Polygons &out, const float scaled_epsilon) const override;


### PR DESCRIPTION
# Description
Fix compile error in Debug mode. Adds getters for Point3 types in ExtrusionEntity
ZAA changed ExtrusionPath::polyline from Polyline to Polyline3, preserving the existing interfaces by converting first_point and last_point to return a Point copy constructed from the underlying Point3 type.

ExtrusionLoop::validate function was not updated and is broken in debug configurations as it's currently comparing Point to Point3

This change promotes ExtrusionPath::first_point3/last_point3 to the ExtrusionEntity base class as a  pure virtual function, implements them on derived classes, and fixes ExtrusionLoop::validate

## Tests

Compiled on MacOS + Linux in Debug, RelWithDebInfo
Tested RelWithDebInfo on MacOS + Ubuntu
Ran unit tests
Sliced a variety of test objects

Fix #13851
