### PR TITLE
[RFC] Feature: Add custom G-code output for active print region (`SET_PRINT_FEATURE`) to support smart filament runout

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -6719,6 +6719,18 @@ std::string GCode::_extrude(const ExtrusionPath &path, std::string description, 
         m_last_processor_extrusion_role = path.role();
         sprintf(buf, ";%s%s\n", GCodeProcessor::reserved_tag(GCodeProcessor::ETags::Role).c_str(), ExtrusionEntity::role_to_string(m_last_processor_extrusion_role).c_str());
         gcode += buf;
+
+        // Custom SET_PRINT_FEATURE command to signal the current region to Klipper
+        // Contributed by Hwang Younsang <famtory@gmail.com>
+        int p_val = 3;
+        if (m_last_processor_extrusion_role == erExternalPerimeter || m_last_processor_extrusion_role == erOverhangPerimeter) {
+            p_val = 1;
+        } else if (is_infill(m_last_processor_extrusion_role)) {
+            p_val = 2;
+        }
+        char m603_buf[64];
+        sprintf(m603_buf, "SET_PRINT_FEATURE FEATURE=%d\n", p_val);
+        gcode += m603_buf;
     }
 
     if (last_was_wipe_tower || m_last_width != path.width) {

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -6725,9 +6725,11 @@ std::string GCode::_extrude(const ExtrusionPath &path, std::string description, 
 
         // Custom SET_PRINT_FEATURE command to signal the current region to Klipper
         // Contributed by Hwang Younsang <famtory@gmail.com>
-        int p_val = 3;
+        int p_val = 0;
         if (m_last_processor_extrusion_role == erExternalPerimeter || m_last_processor_extrusion_role == erOverhangPerimeter) {
             p_val = 1;
+        } else if (is_bridge(m_last_processor_extrusion_role)) {
+            p_val = 3;
         } else if (is_infill(m_last_processor_extrusion_role)) {
             p_val = 2;
         }

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -1,3 +1,6 @@
+/**
+ * Region-Aware Filament Runout Pause Feature Concept & Implementation Copyright (C) 2026 Famtory <famtory@gmail.com>
+ */
 #include "BoundingBox.hpp"
 #include "Config.hpp"
 #include "GCodeWriter.hpp"


### PR DESCRIPTION
Hello! I would like to propose a feature that enables smart, region-aware filament runout handling in Klipper.

**The Problem:**
When a filament runout is detected, standard firmware pauses immediately. If this happens on the outer wall (external perimeter), it leaves a visible blob/scar on the outer surface of the print, degrading the print quality.

**The Proposal / Solution:**
We can emit a custom tag `SET_PRINT_FEATURE FEATURE=<1/2/3>` to signal the current printing region when the extrusion role changes:
- `FEATURE=1`: Outer Walls (`erExternalPerimeter`, `erOverhangPerimeter`)
- `FEATURE=2`: Infills (`is_infill`)
- `FEATURE=3`: Others (Inner walls, support, brim, etc.)

Non-Klipper firmware will simply ignore this command. In Klipper, we can intercept this to delay the runout pause until the print head transitions to an infill region (or reaches a safety limit), protecting the outer wall's cosmetic quality.

I have implemented a working proof-of-concept by modifying `GCode.cpp` to output these tags. I'd love to hear your feedback on whether this should be guarded behind a config setting (e.g., linked to `enable_extrusion_role_markers`) or if you have any suggestions on the implementation before I finalize it.

Signed-off-by: Hwang Younsang <famtory@gmail.com>