### PR TITLE
Disable slowdown for curled perimeters as a default setting. Expand tooltip with tuning recommendations.

### DIFF
--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -1512,14 +1512,20 @@ void PrintConfigDef::init_fff_params()
                      "For example, additional slowdown will be applied when printing overhangs on sharp corners like the "
                      "front of the Benchy hull, reducing curling which compounds over multiple layers.\n\n"
                      "It is generally recommended to have this option switched on unless your printer cooling is powerful enough or the "
-                     "print speed slow enough that perimeter curling does not happen. If printing with a high external perimeter speed, "
-                     "this parameter may introduce slight artifacts when slowing down due to the large variance in print speeds. "
-                     "If you notice artifacts, ensure your pressure advance is tuned correctly.\n\n"
+                     "print speed is slow enough that perimeter curling does not happen. \n"
+                     "If printing with a high external perimeter speed, this parameter may introduce wall artifacts when slowing down, "
+                     "due to the potentially large variance in print speeds causing the extruder to be unable to keep up with the requested flow change.\n"
+                     "Root cause of these artefacts is most likely PA tuning being slightly off, especially when combined "
+                     "with a high PA smooth time.\n\n"
+                     "Recommendations when enabling this option:\n"
+                     "1. Reduce Pressure Advance smooth time to 0.015 - 0.02 so the extruder reacts quickly to the speed changes.\n"
+                     "2. Increase the minimum print speeds to limit the magnitude of the slowdown and reduce the variance between fast and slow segments.\n"
+                     "3. If artifacts still appear, enable Extrusion Rate Smoothing (ERS) to further smooth the flow transitions.\n\n"
                      "Note: When this option is enabled, overhang perimeters are treated like overhangs, meaning the overhang speed is "
                      "applied even if the overhanging perimeter is part of a bridge. For example, when the perimeters are 100% overhanging"
                      ", with no wall supporting them from underneath, the 100% overhang speed will be applied.");
     def->mode = comAdvanced;
-    def->set_default_value(new ConfigOptionBool{ true });
+    def->set_default_value(new ConfigOptionBool{ false });
 
     def = this->add("overhang_1_4_speed", coFloatOrPercent);
     def->label = "10%";


### PR DESCRIPTION
# Description

This option was ported from Prusa slicer in September 2023, to cater for limitations of printers with weak part cooling, where layers that overhang in sharp corners would curl upwards. However as print speeds have been getting increasingly faster, the demand on their extruders is such that very good PA tuning and low PA smooth time is needed to avoid wall consistency artefacts.

As such, this PR aims to disable this option from default as the benefit of better cooling and reduced curling is offset by the disadvantage of wall consistency issues.

Furthermore tuning recommendations are now provided in the tooltip which need to be adhered to for printers with large variances between wall speed and overhang speed.

In terms of printer profiles the following profiles have this option explicitly set to enabled. These will remain unaffected by this change:
- MagicMaker — 26 profiles (across BoneKing, hj SK, hqs SF, hqs hj, slb printers)
- Blocks — 13 profiles (all Blocks_RF50 quality presets)
- Artillery — 4 profiles (M1 Pro 0.2/0.6/0.8 nozzle, X3Pro 0.4 nozzle)
- Prusa — 3 (fdm_process_common, process_common_MK3.5, process_common_miniis)
- Creality — 3 (all three Sermoon V1 quality presets)
- Anycubic — 3 (all three Kobra original quality presets — note: the newer Kobra 2/3/X profiles already set it to "0")
- CoLiDo — 2 (colidodiy40v2_common, colidosr1_common)
- One-off common profiles: iQ, WEMAKE3D, RolohaunDesign, RH3D, Positron3D, Mellow, LH, Kingroon (KP3S V1 only), FlyingBear (marlin_common only), DeltaMaker, Custom

The following vendors actively turn it off in many/all of their profiles. These will be unaffected by this change.
- Snapmaker (all U1 profiles), 
- Anycubic (all newer Kobra 2/3/X/Max), 
- Cubicon (base templates), 
- Eryone (Thinker X400), 
- Ginger Additive, 
- Phrozen (Arco), 
- Comgrow, 
- CoLiDo (colidox16, colidodiy40), 
- Creality (K2 0.4/0.6/0.8, Ender-5 Max), 
- Elegoo ECC, 
- FlyingBear (Ghost7, S1, generic non-Marlin common)

All other profiles that don't mention the key at all will now inherit the new false default.

Fixes #9480
Fixes #11323

<!--
> A guide for users on how to download the artifacts from this PR.
-->

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
