### PR TITLE
Fix nozzle diameter mismatch error in manual calibration

### DIFF
--- a/src/slic3r/GUI/CalibrationWizard.cpp
+++ b/src/slic3r/GUI/CalibrationWizard.cpp
@@ -761,6 +761,7 @@ void PressureAdvanceWizard::on_cali_start()
             calib_info.extruder_id       = preset_page->get_extruder_id(calib_info.ams_id);
             calib_info.extruder_type     = preset_page->get_extruder_type(calib_info.extruder_id);
             calib_info.nozzle_volume_type = preset_page->get_nozzle_volume_type(calib_info.extruder_id);
+            calib_info.nozzle_diameter    = preset_page->get_nozzle_diameter(calib_info.extruder_id);
             calib_info.select_ams         = std::to_string(selected_tray_id);
             Preset *preset               = selected_filaments.begin()->second;
             Preset * temp_filament_preset = new Preset(preset->type, preset->name + "_temp");
@@ -1293,6 +1294,7 @@ void FlowRateWizard::on_cali_start(CaliPresetStage stage, float cali_value, Flow
             calib_info.extruder_id = preset_page->get_extruder_id(calib_info.ams_id);
             calib_info.extruder_type      = preset_page->get_extruder_type(calib_info.extruder_id);
             calib_info.nozzle_volume_type = preset_page->get_nozzle_volume_type(calib_info.extruder_id);
+            calib_info.nozzle_diameter    = preset_page->get_nozzle_diameter(calib_info.extruder_id);
             Preset* preset = selected_filaments.begin()->second;
             temp_filament_preset = new Preset(preset->type, preset->name + "_temp");
             temp_filament_preset->config = preset->config;
@@ -1708,6 +1710,7 @@ void MaxVolumetricSpeedWizard::on_cali_start()
         calib_info.extruder_id        = preset_page->get_extruder_id(calib_info.ams_id);
         calib_info.extruder_type      = preset_page->get_extruder_type(calib_info.extruder_id);
         calib_info.nozzle_volume_type = preset_page->get_nozzle_volume_type(calib_info.extruder_id);
+        calib_info.nozzle_diameter    = preset_page->get_nozzle_diameter(calib_info.extruder_id);
         calib_info.filament_prest = selected_filaments.begin()->second;
         std::map<int, DynamicPrintConfig> filament_list = preset_page->get_filament_ams_list();
         calib_info.filament_color = filament_list[selected_filaments.begin()->first].opt_string("filament_colour", 0u);

--- a/src/slic3r/Utils/CalibUtils.hpp
+++ b/src/slic3r/Utils/CalibUtils.hpp
@@ -20,7 +20,7 @@ public:
     int                                extruder_id = 0;
     int                                ams_id = 0;
     int                                slot_id = 0;
-    float                              nozzle_diameter;
+    float                              nozzle_diameter = 0.0f;
     ExtruderType                       extruder_type{ExtruderType::etDirectDrive};
     NozzleVolumeType                   nozzle_volume_type;
     Calib_Params                       params;


### PR DESCRIPTION
# Description

Fixes #13798.

Starting Flow Rate or Flow Dynamics calibration on P1-series printers fails
with "The nozzle diameter does not match the actual printer nozzle diameter"
even when the diameter matches and the UI shows nozzle info as synced.

# Screenshots/Recordings/Graphs

<!--
> Please attach relevant screenshots to showcase the UI changes.
> Please attach images that can help explain the changes.
-->

## Tests

<!--
> Please describe the tests that you have conducted to verify the changes made in this PR.
-->

<!--
> A guide for users on how to download the artifacts from this PR.
-->

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
