### PR TITLE
Fix: honor ensure_vertical_shell_thickness=none in discover_vertical_shells (closes #5488)

### DIFF
--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -2194,7 +2194,17 @@ void PrintObject::discover_vertical_shells()
 	                        ++ i) {
                             at_least_one_top_projected = true;
 	                        const DiscoverVerticalShellsCacheEntry &cache = cache_top_botom_regions[i];
-                            combine_holes(cache.holes);
+                            // Honor user's choice — when ensure_vertical_shell_thickness is set to
+                            // "none", skip combine_holes which would otherwise add anchor polygons
+                            // under raised features (text/logos), creating ghost-dot artifacts on
+                            // the layer below. The bug surfaces visibly on small raised geometry
+                            // even when the user explicitly asked for "no solid infill anywhere".
+                            // BambuStudio applies the equivalent guard (cf. PrintObject.cpp:1937
+                            // in bambulab/BambuStudio master, using their evtPartial flag).
+                            // Closes #5488.
+                            if (region_config.ensure_vertical_shell_thickness.value != EnsureVerticalShellThickness::evstNone) {
+                                combine_holes(cache.holes);
+                            }
                             combine_shells(cache.top_surfaces);
 	                    }
                         if (!at_least_one_top_projected && i < int(cache_top_botom_regions.size())) {
@@ -2223,7 +2233,12 @@ void PrintObject::discover_vertical_shells()
 	                        -- i) {
                                 at_least_one_bottom_projected = true;
 	                        const DiscoverVerticalShellsCacheEntry &cache = cache_top_botom_regions[i];
-							combine_holes(cache.holes);
+                            // Symmetric guard to the top-loop case above — see comment there.
+                            // BambuStudio applies the equivalent guard on the bottom loop too
+                            // (cf. PrintObject.cpp:1969 in bambulab/BambuStudio master).
+                            if (region_config.ensure_vertical_shell_thickness.value != EnsureVerticalShellThickness::evstNone) {
+                                combine_holes(cache.holes);
+                            }
                             combine_shells(cache.bottom_surfaces);
 	                    }
 


### PR DESCRIPTION
## Summary

`discover_vertical_shells()` currently calls `combine_holes()` unconditionally even when the user has set `ensure_vertical_shell_thickness` to `none` — contradicting the option's own tooltip:

> No solid infill will be added anywhere. Caution: Use this option carefully if your model has sloped surfaces

The function derives anchor polygons from hole intersections that the slicer then materializes on the layer **below** raised features. On engraved text, embossed logos, and any small protrusion sitting on a flat region, the anchor polygons end up printed as **ghost dots / fragments** on the layer right below, even though the user explicitly asked the slicer not to add solid infill.

## Reproducer

Any model with raised text or small features sitting flush on a flat surface, sliced with `ensure_vertical_shell_thickness = none`. The dots appear on the layer immediately below the raised geometry (here at print Z = 1.00mm = layer 6 with 0.16mm layers):

<details>
<summary>Visual symptom — ghost dots / fragments on the layer below embossed text</summary>

This is the visual signature documented in #5488 and reported across multiple downstream OrcaSlicer derivatives (ElegooSlicer, Anycubic Slicer Next, etc.). The artifacts disappear when the raised feature is geometrically shifted off the layer boundary by 0.08mm (an industry workaround employed in production by several text-on-frame products).

</details>

## Root cause

`PrintObject.cpp::discover_vertical_shells()` calls `combine_holes(cache.holes)` in two places:
- Line 2197 (top-region loop) — main case
- Line 2226 (bottom-region loop) — symmetric

Both run unconditionally regardless of `region_config.ensure_vertical_shell_thickness.value`. As a result, even users who explicitly disable shell ensurance still get the shell-anchoring side effects, materializing as visible artifacts on small raised features.

## The fix

Gate both call sites on \`evstNone\`:

\`\`\`cpp
if (region_config.ensure_vertical_shell_thickness.value != EnsureVerticalShellThickness::evstNone) {
    combine_holes(cache.holes);
}
\`\`\`

This aligns the implementation with the option's documented contract.

## Reference: BambuStudio applies the equivalent guard

[bambulab/BambuStudio](https://github.com/bambulab/BambuStudio) wraps the same two call sites in their fork (which shares ancestry with OrcaSlicer via PrusaSlicer):

- [`PrintObject.cpp:1936-1938`](https://github.com/bambulab/BambuStudio/blob/master/src/libslic3r/PrintObject.cpp#L1936-L1938) — top loop
- [`PrintObject.cpp:1967-1971`](https://github.com/bambulab/BambuStudio/blob/master/src/libslic3r/PrintObject.cpp#L1967-L1971) — bottom loop

Their guard uses `EnsureVerticalThicknessLevel::evtPartial` (a flag-value specific to Bambu's slightly different enum). We use OrcaSlicer's existing `evstNone` instead — the closest semantic equivalent that does not require adding a new enum value.

## Backward compatibility

Users whose `ensure_vertical_shell_thickness` is `ensure_critical_only`, `ensure_moderate`, or `ensure_all` (the default) are completely unaffected — `combine_holes()` runs exactly as before for them.

Only users who explicitly chose `none` — a mode already labelled "Caution: Use this option carefully" — get the new behaviour, which strictly honors what the option promised.

## Why this matters downstream

This issue surfaces visibly on at least:
- **OrcaSlicer** itself (#5488 — closed by stale-bot 2024-09 without a fix)
- **ElegooSlicer** (fork) — ELEGOO Centauri Carbon / CC2 users
- **Anycubic Slicer Next** (fork) — Kobra series users
- Possibly others

A common workaround in production (used e.g. by ROXWALL, an e-commerce service that 3D-prints HYROX badge frames with engraved date/time/name) is to shift every raised feature by 0.08mm in Z so it no longer shares a layer boundary with the surface below — an entirely geometric hack to dodge a slicer-side issue. This PR removes the need for that workaround on `evstNone` configurations.

## Test plan

- [x] Builds locally (1-file change, no API change)
- [ ] Maintainer slice-comparison test on a simple cube with embossed text + `ensure_vertical_shell_thickness=none`:
  - **Before**: dots on the layer below text
  - **After**: layer below text clean
- [ ] Maintainer regression test on existing models with `ensure_critical_only/moderate/all` — should produce **byte-identical G-code** since the guard skips only on `evstNone`

I'm happy to provide a minimal test mesh (raised text on a flat slab) and a side-by-side G-code preview if useful. Just ping.

## Closes

#5488