### PR TITLE
Fix crash when you have custom profile set to multi-extruder but the base printer is semm

### DIFF
--- a/src/libslic3r/PresetBundle.cpp
+++ b/src/libslic3r/PresetBundle.cpp
@@ -2871,6 +2871,14 @@ void PresetBundle::load_selections(AppConfig &config, const PresetPreferences& p
 
     if (use_default_nozzle_volume_type) {
         project_config.option<ConfigOptionEnumsGeneric>("nozzle_volume_type")->values = current_printer.config.option<ConfigOptionEnumsGeneric>("default_nozzle_volume_type")->values;
+    } else {
+        // Orca: make sure `nozzle_volume_type` not shorter than `default_nozzle_volume_type`, otherwise we got array out of bound access
+        // later in `Tab::switch_excluder`
+        auto& opt = project_config.option<ConfigOptionEnumsGeneric>("nozzle_volume_type")->values;
+        const auto& opt_default = current_printer.config.option<ConfigOptionEnumsGeneric>("default_nozzle_volume_type")->values;
+        while (opt.size() < opt_default.size()) {
+            opt.emplace_back(opt_default[opt.size()]);
+        }
     }
 
     // Parse the initial physical printer name.


### PR DESCRIPTION
# Description

When you have custom printer profile based on a SEMM printer, and you change the profile to be multi-extruder, there is a chance that you got crash during app startup, due to the length of the `nozzle_volume_type` option is shorter than extruder count.

The value of `nozzle_volume_type` can come from two different sources:
1. From `OrcaSlicer.conf` -> `nozzle_volume_types`, which is key-ed by the base printer model:
   <img width="978" height="412" alt="image" src="https://github.com/user-attachments/assets/fc7727cf-aa40-4a42-b97a-443efec091d4" />

2. From printer profile -> `default_nozzle_volume_type`, when 1 is missing
  https://github.com/OrcaSlicer/OrcaSlicer/blob/2d09b7aefb95c8b371307b0f8d26ea6149dbbc0b/src/libslic3r/PresetBundle.cpp#L2872-L2874

The problem is, if you ever used the base printer, then the `nozzle_volume_types` field in `OrcaSlicer.conf` will contains a single value, because the base printer is SEMM. However when you switched to the custom profile which is multi-extruder, it will try to access the `nozzle_volume_type` for each extruder, which causes the array access out of range then crash.

This PR fix this by making sure `nozzle_volume_type` is no shorter than `default_nozzle_volume_type`. `default_nozzle_volume_type` always have the correct length:
<img width="976" height="494" alt="image" src="https://github.com/user-attachments/assets/9766d7ef-c2c5-437e-9f7a-4e86fdc6148a" />


# Screenshots/Recordings/Graphs

<!--
> Please attach relevant screenshots to showcase the UI changes.
> Please attach images that can help explain the changes.
-->

## Tests

<!--
> Please describe the tests that you have conducted to verify the changes made in this PR.
-->

<!--
> A guide for users on how to download the artifacts from this PR.
-->

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
