### PR TITLE
fix: prevent CPU-spin in Sidebar leave handler on inactive Wayland workspace

### DIFF
--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -1853,6 +1853,14 @@ Sidebar::Sidebar(Plater *parent)
                 e.Skip();
             });
             w->Bind(wxEVT_LEAVE_WINDOW, [this, panel_color](wxMouseEvent &e) {
+                // Orca: if the edit button is already hidden the handler has no
+                // state to change, so skip the expensive wxFindWindowAtPoint tree
+                // walk. Without this guard, when the parent window is on an
+                // inactive Hyprland/Wayland workspace, GTK keeps delivering
+                // synthetic leave events and the Hide()+Layout() below re-enters
+                // the same handler in a feedback loop that pegs a CPU core.
+                // (IsShownOnScreen() can't be used here — see Plater.cpp:9304.)
+                if (!p->btn_edit_printer->IsShown()) { e.Skip(); return; }
                 // Use event-relative coords instead of wxGetMousePosition() which
                 // returns (0,0) on Wayland for global screen coordinates.
                 wxWindow* evtObj = dynamic_cast<wxWindow*>(e.GetEventObject());


### PR DESCRIPTION
# Description

Fix UI freeze on inactive Hyprland/Wayland workspace caused by `wxFindWindowAtPoint` feedback loop in the Sidebar printer-preset hover handler introduced by #11196.

## Root cause

GDB attached to a frozen OrcaSlicer process (single thread spinning at 100% CPU in userspace, all others sleeping) shows the main thread stuck in this stack:

```
#0  libgobject-2.0.so.0
#1  gtk_widget_get_child_visible() in libgtk-3.so.0
#2  wxWindow::IsShown() const
#3..#12  wxFindWindowAtPoint(wxWindow*, wxPoint const&)        ← tree-walk
#13      wxGenericFindWindowAtPoint(wxPoint const&)
#14      Slic3r::GUI::Sidebar::Sidebar(Plater*)::$_14           ← wxEVT_LEAVE_WINDOW lambda
#15..#19 wxEvtHandler::ProcessEvent / SafelyProcessEvent
#20      wxGTKImpl::WindowLeaveCallback                         ← GTK leave event
#21..#27 GTK signal emit machinery
#28      gtk_main_do_event
...
#34      gtk_main
#35      wxGUIEventLoop::DoRun
```

The flow is:

1. OrcaSlicer is on an inactive Hyprland workspace.
2. GTK keeps delivering synthetic `leave-notify-event`s to the printer-preset row.
3. The leave handler bound at `Plater.cpp:1855` calls `wxFindWindowAtPoint(screenPos)`, an O(N) walk of the entire wxWidgets window tree calling `IsShown()` (i.e. `gtk_widget_get_child_visible`) on each.
4. The mouse position from the synthetic event consistently fails `panel_printer_preset->IsDescendant(next_w)`, so the handler calls `btn_edit_printer->Hide()` + `panel_printer_preset->Layout()` every time.
5. `Hide()`+`Layout()` re-trigger leave events on the changed widgets — feedback loop.

Because `IsShownOnScreen()` is unreliable on Wayland (per the existing comment at `Plater.cpp:9304`), a visibility guard there does nothing on Hyprland inactive workspaces.

## Fix

State-based early return: if `btn_edit_printer` is already hidden, the handler has no transition to perform — skip the expensive tree walk and the `Hide()`+`Layout()` that would otherwise re-trigger more leave events.

```cpp
if (!p->btn_edit_printer->IsShown()) { e.Skip(); return; }
```

After the first leave event hides the button, every subsequent leave event is O(1), breaking the feedback loop.

Refs:
- #12387 — open issue, same setup (Arch + Hyprland + RTX 3060 + Bambu A1)
- #11196 — PR that introduced the hover-edit-button feature

## Tests

Reproduction:
1. Open OrcaSlicer on Hyprland or any compositor that keeps Wayland surfaces mapped on inactive workspaces (also reproduces on KDE Plasma Wayland and Cinnamon per #12387 / #13067 comments).
2. Hover the printer-preset row to show the edit button.
3. Switch to another workspace.
4. Without the fix: main thread pegs one CPU core indefinitely; only force-kill recovers.
5. With the fix: CPU drops to idle after the first leave event.
