### PR TITLE
Fix missing normal-support BottomContact interface with variable layer height + MM paint

### DIFF
--- a/src/libslic3r/Support/SupportMaterial.cpp
+++ b/src/libslic3r/Support/SupportMaterial.cpp
@@ -3148,7 +3148,25 @@ void PrintObjectSupportMaterial::trim_support_layers_by_object(
                 // BOOST_LOG_TRIVIAL(trace) << "Support generator - trim_support_layers_by_object - trimmming non-empty layer " << idx_layer << " of " << nonempty_layers.size();
                 assert(! support_layer.polygons.empty() && support_layer.print_z >= m_slicing_params.raft_contact_top_z + EPSILON);
                 // Find the overlapping object layers including the extra above / below gap.
-                coordf_t z_threshold = support_layer.bottom_print_z() - gap_extra_below + EPSILON;
+                // ORCA: For bottom-contact support layers, the support physically occupies
+                // [bottom_print_z, print_z] and sits on an object top surface that's gap_object_support
+                // below it. Object layers outside that vertical span cannot collide with the support,
+                // and including them in the lslice-based trim can erase the very area the support is
+                // meant to underpin. This is particularly harmful when:
+                //   * an object layer lies entirely above the support (its lslice may contain a
+                //     newly-emerging horizontal/cantilever cross-section), or
+                //   * an object layer lies entirely below the support with is_overlap == false; its
+                //     lslice gets inflated by no_overlap_xy_gap and that halo bleeds outward into
+                //     the cantilever bottom area near the riser/cantilever junction.
+                // Variable-layer-height combined with multi-material painting exposes this because
+                // painting forces extra object layer subdivisions that pull such layers into the trim.
+                const bool is_bottom_contact = (support_layer.layer_type == SupporLayerType::BottomContact);
+                const coordf_t upper_z_limit = is_bottom_contact
+                    ? support_layer.bottom_print_z()
+                    : support_layer.print_z + gap_extra_above;
+                coordf_t z_threshold = is_bottom_contact
+                    ? support_layer.bottom_print_z()
+                    : (support_layer.bottom_print_z() - gap_extra_below + EPSILON);
                 idx_object_layer_overlapping = Layer::idx_higher_or_equal(
                     object.layers().begin(), object.layers().end(), idx_object_layer_overlapping,
                     [z_threshold](const Layer *layer){ return layer->print_z >= z_threshold; });
@@ -3157,7 +3175,7 @@ void PrintObjectSupportMaterial::trim_support_layers_by_object(
                 size_t i = idx_object_layer_overlapping;
                 for (; i < object.layers().size(); ++ i) {
                     const Layer &object_layer = *object.layers()[i];
-                    if (object_layer.bottom_z() > support_layer.print_z + gap_extra_above - EPSILON)
+                    if (object_layer.bottom_z() > upper_z_limit - EPSILON)
                         break;
 
                     bool is_overlap = is_layers_overlap(support_layer, object_layer);
@@ -3177,13 +3195,13 @@ void PrintObjectSupportMaterial::trim_support_layers_by_object(
                         bool some_region_overlaps = false;
                         for (LayerRegion *region : object_layer.regions()) {
                             coordf_t bridging_height = region->region().bridging_height_avg(*m_print_config);
-                            if (object_layer.print_z - bridging_height > support_layer.print_z + gap_extra_above - EPSILON)
+                            if (object_layer.print_z - bridging_height > upper_z_limit - EPSILON)
                                 break;
                             some_region_overlaps = true;
 
                             bool is_overlap = is_layers_overlap(support_layer, object_layer, bridging_height);
                             coordf_t trimming_offset = is_overlap ? gap_xy_scaled : scale_(no_overlap_xy_gap);
-                            polygons_append(polygons_trimming, 
+                            polygons_append(polygons_trimming,
                                 offset(region->fill_surfaces.filter_by_type(stBottomBridge), trimming_offset, SUPPORT_SURFACES_OFFSET_PARAMETERS));
                             if (region->region().config().detect_overhang_wall.value)
                                 // Add bridging perimeters.

--- a/src/libslic3r/Support/SupportMaterial.cpp
+++ b/src/libslic3r/Support/SupportMaterial.cpp
@@ -3165,7 +3165,7 @@ void PrintObjectSupportMaterial::trim_support_layers_by_object(
                     ? support_layer.bottom_print_z()
                     : support_layer.print_z + gap_extra_above;
                 coordf_t z_threshold = is_bottom_contact
-                    ? support_layer.bottom_print_z()
+                    ? support_layer.bottom_print_z() - EPSILON
                     : (support_layer.bottom_print_z() - gap_extra_below + EPSILON);
                 idx_object_layer_overlapping = Layer::idx_higher_or_equal(
                     object.layers().begin(), object.layers().end(), idx_object_layer_overlapping,


### PR DESCRIPTION
> _This fix was developed with the assistance of GitHub Copilot._

Fixes #13911.

## Summary

Normal (non-tree) auto-generated supports could fail to emit a `BottomContact` interface layer (a solid cap of support sitting on an object surface, beneath additional support material that continues above) when **both** variable layer height **and** multi-material painting were enabled. Either feature alone produced correct supports. Tree/organic supports are unaffected.

Without the interface cap, support material printed in the layers above started in free space, producing visibly disconnected/floating support sticks above the contact area.

## Root cause

In `PrintObjectSupportMaterial::trim_support_layers_by_object` (`src/libslic3r/Support/SupportMaterial.cpp`), the trim window around a support layer included object layers lying **entirely below** the support (`is_overlap == false`). Their slices are inflated by `no_overlap_xy_gap` (0.2 mm), and when MM painting forces an extra object-layer subdivision at a color boundary that lands inside that window, the 0.2 mm halo bleeds outward and erases the cantilever-bottom area near the riser/cantilever junction.

Concretely on the repro project: bottom_contact area at Z ≈ 15.91 mm shrinks from 17.53 mm² (no-paint baseline) to 3.28 mm² — too narrow for the configured line width, so no extrusions are emitted.

Variable layer height alone doesn't trigger it because the adaptive Z chosen by the slicer doesn't land at the painful Z. Painting adds the extra subdivisions that do.

## Fix

For `BottomContact` layers only, restrict the trim window to the single object layer whose top is exactly at the support's `bottom_print_z` (the one layer the support actually sits on). Other layer types (top_contact, intermediate, base) use the original window and are not affected.

## Verification

CLI re-slice of the reproduction `.3mf`:

| Z (mm) | Pre-trim area (mm²) | Post-trim broken (mm²) | Post-trim fixed (mm²) | No-paint baseline (mm²) |
|---|---|---|---|---|
| 15.9067 | 27.35 | **3.28** | **17.53** | 17.53 |

Gcode `; FEATURE: Support interface` extrusion length per Z:

| Z (mm) | Before fix | After fix |
|---|---|---|
| 15.9067 | 0 mm | ~30.6 mm |
| 16.18   | 0 mm | ~28.6 mm |
| 16.4267 | 0 mm | ~28.6 mm |

Additionally, surrounding `Support` extrusion length grew by ~30–35 mm per layer in the layers just above the fix area, because new support lines now correctly anchor into the interface cap instead of starting in mid-air.

The fix was verified visually in the GUI preview by the reporter as well as via CLI gcode diffs.

## Out of scope

A separate (visually larger) bug remains where a TopContact interface is also missing immediately beneath the cantilever bridge at the very top of the part (Z ≈ 27.5 mm in the repro). That is a different code path (overhang/top-contact detection, not trim) and will be tracked separately.

## Screenshots

**Before (problem):**

<img width="2510" height="1397" alt="disconnected-supports0-angle2" src="https://github.com/user-attachments/assets/006ab49a-dd80-45dc-b387-c068be0bffe5" />


**After (fix):**

<img width="2512" height="1732" alt="added-missing-interface" src="https://github.com/user-attachments/assets/c16920ac-10a5-4bac-97fb-6be99d4b1e40" />

<img width="2525" height="1686" alt="added-missing-support-top" src="https://github.com/user-attachments/assets/12e39301-cf4a-49b7-b4cb-4835db986a2b" />

## Test plan

1. Build OrcaSlicer.
2. Open the `.3mf` attached to #13911.
3. Slice with **Normal (auto)** support, variable layer height on, MM painting on.
4. In Preview at Z ≈ 16 mm, verify a `Support interface` cap is present and the support lines above connect into it.
5. Toggle variable layer height off and/or painting off; verify behavior is unchanged from current `main` (no regressions).

## Risk

- Change is scoped to `BottomContact` layers via a single new code branch.
- Other support layer types take the unchanged code path.
- The new branch makes the trim window *narrower*, which can only *retain more* support polygon area, not invent new area — so it cannot produce new collisions with the object that didn't exist before this code was reached.

---

_PR opened with the help of GitHub Copilot CLI. All analysis and verification was reviewed and confirmed before submission._

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>