### PR TITLE
use /bigobj when building Eigen with MSVC

### DIFF
--- a/deps/Eigen/Eigen.cmake
+++ b/deps/Eigen/Eigen.cmake
@@ -1,5 +1,11 @@
+set(_eigen_extra_flags "")
+if (MSVC)
+    set(_eigen_extra_flags "-DCMAKE_CXX_FLAGS:STRING=/bigobj")
+endif ()
+
 orcaslicer_add_cmake_project(Eigen
     URL https://gitlab.com/libeigen/eigen/-/archive/5.0.1/eigen-5.0.1.zip
     URL_HASH SHA256=0dbb1f9e3aaad66f352c03227d8c983f6f0b49e0b07e71a7300f4abcc01aee12
+    CMAKE_ARGS "${_eigen_extra_flags}"
     DEPENDS dep_Boost dep_GMP dep_MPFR
 )


### PR DESCRIPTION
# Description

When trying to build Eigen with the Debug configuration (also see PR #13921) with MSVC, I get error C1128.  Putting /bigobj on the command line fixes this.

## Tests

Building the dependencies with:

    build_release_vs2022.bat deps debug

