### PR TITLE
Fix UI freeze and 409 storm during Orca Cloud sync recovery

### DIFF
--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -27,6 +27,7 @@
 #include <iterator>
 #include <exception>
 #include <cstdlib>
+#include <future>
 #include <regex>
 #include <thread>
 #include <string_view>
@@ -4875,6 +4876,13 @@ void GUI_App::on_http_error(wxCommandEvent &evt)
         return;
     }
 
+    // 409 Conflict is expected during normal cloud sync (preset already exists on cloud).
+    // Treat it as a no-op - the caller handles conflict resolution via sync_push.
+    if (status == 409) {
+        BOOST_LOG_TRIVIAL(info) << "Http 409 Conflict — preset already exists on cloud, no dialog needed.";
+        return;
+    }
+
     static bool m_is_error_shown = false;
     // Show general error notification for Orca Cloud API failures (not Bambu)
     if (provider == ORCA_CLOUD_PROVIDER && status >= 400 && code != HttpErrorVersionLimited) {
@@ -5840,7 +5848,7 @@ void  GUI_App::push_notification(const MachineObject* obj, wxString msg, wxStrin
     }
 }
 
-void GUI_App::reload_settings()
+void GUI_App::reload_settings(std::optional<std::weak_ptr<int>> cancel_token)
 {
     if (preset_bundle && m_agent) {
         // Load user's personal presets
@@ -5917,10 +5925,42 @@ void GUI_App::reload_settings()
             if (plater_)
                 plater_->sidebar().update_all_preset_comboboxes();
         };
-        if (is_main_thread_active())
+        if (is_main_thread_active()) {
             refresh_synced_ui();
-        else
-            CallAfter(refresh_synced_ui);
+        } else {
+            // Block the background sync thread until the main thread has applied the
+            // cloud-sourced setting_ids back into local presets.  Without this wait,
+            // the periodic push loop starts immediately with stale sync_info="create"
+            // / empty setting_ids and re-uploads every preset, getting a 409 from the
+            // cloud for each one (it already has them from the pull that just finished).
+            auto p = std::make_shared<std::promise<void>>();
+            std::future<void> fut = p->get_future();
+            CallAfter([refresh_synced_ui = std::move(refresh_synced_ui), p]() mutable {
+                try {
+                    refresh_synced_ui();
+                } catch (const std::exception& e) {
+                    BOOST_LOG_TRIVIAL(error) << "reload_settings: refresh_synced_ui threw: " << e.what();
+                } catch (...) {
+                    BOOST_LOG_TRIVIAL(error) << "reload_settings: refresh_synced_ui threw unknown exception";
+                }
+                p->set_value(); // always unblock the sync thread
+            });
+            // Poll every 100 ms so we can bail out on cancellation (app close)
+            // without blocking stop_sync_user_preset()'s join() for up to 10 s.
+            auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(10);
+            while (fut.wait_for(std::chrono::milliseconds(100)) == std::future_status::timeout) {
+                if (cancel_token.has_value() && cancel_token->expired()) {
+                    BOOST_LOG_TRIVIAL(warning) << "reload_settings: cancelled while waiting for UI "
+                                                  "preset update — sync loop may see stale setting_ids";
+                    break;
+                }
+                if (std::chrono::steady_clock::now() >= deadline) {
+                    BOOST_LOG_TRIVIAL(warning) << "reload_settings: timed out waiting for UI "
+                                                  "preset update — sync loop may see stale setting_ids";
+                    break;
+                }
+            }
+        }
     }
 }
 
@@ -6699,7 +6739,7 @@ void GUI_App::start_sync_user_preset(bool with_progress_dlg)
             finishFn(ret == 0);
 
             if (ret == 0 && m_agent && !t.expired())
-                reload_settings();
+                reload_settings(t);
 
             // For orca specific syncing
             auto orca_agent = std::dynamic_pointer_cast<OrcaCloudServiceAgent>(m_agent->get_cloud_agent());

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -4883,31 +4883,19 @@ void GUI_App::on_http_error(wxCommandEvent &evt)
         return;
     }
 
-    static bool m_is_error_shown = false;
-    // Show general error notification for Orca Cloud API failures (not Bambu)
     if (provider == ORCA_CLOUD_PROVIDER && status >= 400 && code != HttpErrorVersionLimited) {
-        wxString msg;
-        if (!error.empty()) {
-            msg = wxString::Format(_L("Failed to connect to OrcaCloud.\nPlease check your network connectivity\n(HTTP %u): %s"), status, wxString::FromUTF8(error));
-        } else {
-            msg = wxString::Format(_L("Failed to connect to OrcaCloud.\nPlease check your network connectivity\n(HTTP %u)"), status);
-        }
-        
-        if (app_config->get_bool("developer_mode")) {
-            // Use notification manager if ImGui is ready; fall back to wxMessageBox on Linux
-            // where ImGui may not be initialized until the user switches to the Prepare tab.
-            if (wxGetApp().plater() != nullptr && wxGetApp().imgui()->display_initialized()) {
-                wxGetApp()
-                    .plater()
-                    ->get_notification_manager()
-                    ->push_notification(NotificationType::PlaterError, NotificationManager::NotificationLevel::WarningNotificationLevel,
-                                        msg.ToUTF8().data());
+        if (wxGetApp().plater() != nullptr && wxGetApp().imgui()->display_initialized()) {
+            wxString msg;
+            if (!error.empty()) {
+                msg = wxString::Format(_L("Failed to connect to OrcaCloud.\nPlease check your network connectivity\n(HTTP %u): %s"), status, wxString::FromUTF8(error));
+            } else {
+                msg = wxString::Format(_L("Failed to connect to OrcaCloud.\nPlease check your network connectivity\n(HTTP %u)"), status);
             }
-        }
-
-        if (!m_is_error_shown) {
-            m_is_error_shown = true;
-            wxMessageBox(msg, _L("Cloud Error"), wxOK | wxICON_ERROR, wxGetApp().mainframe);
+            wxGetApp()
+                .plater()
+                ->get_notification_manager()
+                ->push_notification(NotificationType::PlaterError, NotificationManager::NotificationLevel::WarningNotificationLevel,
+                                    msg.ToUTF8().data());
         }
     }
 }

--- a/src/slic3r/GUI/GUI_App.hpp
+++ b/src/slic3r/GUI/GUI_App.hpp
@@ -2,6 +2,7 @@
 #define slic3r_GUI_App_hpp_
 
 #include <memory>
+#include <optional>
 #include <string>
 #include "ImGuiWrapper.hpp"
 #include "ConfigWizard.hpp"
@@ -519,7 +520,7 @@ public:
     std::string     format_IP(const std::string& ip);
     void            show_dialog(wxString msg);
     void            push_notification(const MachineObject* obj, wxString msg, wxString title = wxEmptyString, UserNotificationStyle style = UserNotificationStyle::UNS_NORMAL);
-    void            reload_settings();
+    void            reload_settings(std::optional<std::weak_ptr<int>> cancel_token = std::nullopt);
     void            remove_user_presets();
 
     bool            maybe_migrate_user_presets_on_login();

--- a/src/slic3r/Utils/OrcaCloudServiceAgent.cpp
+++ b/src/slic3r/Utils/OrcaCloudServiceAgent.cpp
@@ -500,10 +500,14 @@ int OrcaCloudServiceAgent::start()
 {
     regenerate_pkce();
 
-    // Attempt silent sign-in from stored refresh token
+    // Attempt silent sign-in from stored refresh token.
+    // Use async=true so the HTTP round-trip does not block the main UI thread.
+    // start_sync_user_preset() guards with is_user_login(), so if the refresh has
+    // not completed by the time it is called the sync simply defers to the next
+    // login-complete callback — safe and preferred over a 30-second UI stall.
     std::string stored_refresh;
     if (load_refresh_token(stored_refresh) && !stored_refresh.empty()) {
-        refresh_now(stored_refresh, "refresh token", false);
+        refresh_now(stored_refresh, "startup_refresh", true);
     }
 
     return BAMBU_NETWORK_SUCCESS;
@@ -1888,7 +1892,7 @@ int OrcaCloudServiceAgent::http_post(const std::string& path, const std::string&
                 .on_error([&](std::string resp_body, std::string error, unsigned resp_status) {
                     result.success = false;
                     result.status  = resp_status == 0 ? 404 : resp_status;
-                    result.body    = body;
+                    result.body    = resp_body;
                     BOOST_LOG_TRIVIAL(error) << "OrcaCloudServiceAgent: HTTP error - " << error;
                 })
                 .timeout_max(30)
@@ -1958,7 +1962,7 @@ int OrcaCloudServiceAgent::http_put(const std::string& path, const std::string& 
                 .on_error([&](std::string resp_body, std::string error, unsigned resp_status) {
                     result.success = false;
                     result.status  = resp_status == 0 ? 404 : resp_status;
-                    result.body    = body;
+                    result.body    = resp_body;
                     BOOST_LOG_TRIVIAL(error) << "OrcaCloudServiceAgent: HTTP error - " << error;
                 })
                 .timeout_max(30)

--- a/src/slic3r/Utils/OrcaCloudServiceAgent.cpp
+++ b/src/slic3r/Utils/OrcaCloudServiceAgent.cpp
@@ -500,14 +500,10 @@ int OrcaCloudServiceAgent::start()
 {
     regenerate_pkce();
 
-    // Attempt silent sign-in from stored refresh token.
-    // Use async=true so the HTTP round-trip does not block the main UI thread.
-    // start_sync_user_preset() guards with is_user_login(), so if the refresh has
-    // not completed by the time it is called the sync simply defers to the next
-    // login-complete callback — safe and preferred over a 30-second UI stall.
+    // Attempt silent sign-in from stored refresh token
     std::string stored_refresh;
     if (load_refresh_token(stored_refresh) && !stored_refresh.empty()) {
-        refresh_now(stored_refresh, "startup_refresh", true);
+        refresh_now(stored_refresh, "refresh token", false);
     }
 
     return BAMBU_NETWORK_SUCCESS;


### PR DESCRIPTION
# Description
## Problem
When the Orca Cloud sync cursor expires (server returns 410 Gone), a full resync is triggered. During the resulting request_setting_id storm, every local user preset is pushed to the cloud, each returning HTTP 409 Conflict (the cloud already has them from the pull that just completed). This caused two cases:

- UI freeze - the main thread became unresponsive for the duration of the storm. Menus would highlight but never open; the window close button did nothing; the app had to be force-killed.
- Blocking error dialog - a wxMessageBox("Cloud Error") modal was shown for the first failed request, blocking the UI thread until dismissed, after which all subsequent errors were silently swallowed.

## Root cause
After a successful sync_pull, reload_settings posts refresh_synced_ui to the main thread via CallAfter and returns immediately. The background sync thread then re-enters the push loop before the main thread has had a chance to apply the cloud-sourced setting_id values back into local presets. Every preset therefore still has an empty setting_id, the push loop treats them all as new (sync_info="create"), and each push returns 409 because the cloud already has them.

## Changes

### OrcaCloudServiceAgent.cpp

- http_post / http_put error handler: was incorrectly setting result.body = body (request body) on error; fixed to result.body = resp_body (actual response body). This was causing misleading error logging.

### GUI_App.cpp / GUI_App.hpp

- reload_settings now accepts an optional cancel token. When called from the background sync thread it uses a promise/future to wait for the main thread to finish applying refresh_synced_ui before returning. The sync thread polls every 100 ms so it can bail out on app close (cancel token expiry) or a 10 s deadline, preventing a hard hang on shutdown.
- on_http_error: HTTP 409 from Orca Cloud is now a silent no-op. A 409 on sync_push means the preset already exists on the cloud - conflict resolution is handled by the caller via sync_push's OCC logic; showing a dialog is incorrect.
- on_http_error: replaced the one-shot wxMessageBox modal for other 4xx/5xx Orca Cloud errors with a non-blocking bottom-right notification. 