### PR TITLE
fix: temporary wxstring going out of scope causing crash on linux

### DIFF
--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -2981,7 +2981,11 @@ bool GUI_App::on_init_inner()
     }
 #endif
 
-    if (scrn) { scrn->SetText(_L("Creating main window") + dots); wxYield(); }
+    if (scrn) {
+        const auto scrn_txt = _L("Creating main window") + dots;
+        scrn->SetText(scrn_txt);
+        wxYield();
+    }
     BOOST_LOG_TRIVIAL(info) << "create the main window";
     mainframe = new MainFrame();
     // hide settings tabs after first Layout


### PR DESCRIPTION
# Description

Resolves issue: #13831 

Temporary string was going out of scope before being used in SetText.

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
