### PR TITLE
std::set_union expects its inputs to be sorted.

### DIFF
--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -2909,7 +2909,19 @@ static std::vector<std::string> intersect(std::vector<std::string> const& l, std
 static std::vector<std::string> concat(std::vector<std::string> const& l, std::vector<std::string> const& r)
 {
     std::vector<std::string> t;
-    std::set_union(l.begin(), l.end(), r.begin(), r.end(), std::back_inserter(t));
+    bool l_is_sorted = std::is_sorted(l.begin(), l.end());
+    bool r_is_sorted = std::is_sorted(r.begin(), r.end());
+
+    if (l_is_sorted && r_is_sorted) {
+        std::set_union(l.begin(), l.end(), r.begin(), r.end(), std::back_inserter(t));
+        return t;
+    }
+
+    std::vector<std::string> l_sorted = l;
+    std::vector<std::string> r_sorted = r;
+    std::sort(l_sorted.begin(), l_sorted.end());
+    std::sort(r_sorted.begin(), r_sorted.end());
+    std::set_union(l_sorted.begin(), l_sorted.end(), r_sorted.begin(), r_sorted.end(), std::back_inserter(t));
     return t;
 }
 


### PR DESCRIPTION
# Description

The utility function concat combines the contents of two std::vector<std::string>.  The apparently intended behavior is to create a union.  The implementation uses std::set_union which assumes that the two input vectors are sorted, which is not always the case when concat is called.

The new implementation first checks if the input is ordered, which takes O(n) time, so should be reasonable.  If it is, it calls std::set_union as before.  If the input is not sorted, it creates local copies of the vectors and sorts them before using those as input to std::set_union.

## Tests

Running OrcaSlicer.  The function in question is called at different times.

I ran into problems when I ran a Debug build in Visual Studio 2022, which internally checks if the vectors are sorted.

