### PR TITLE
Enhance G92 E0 case sensitivity check

### DIFF
--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -1254,10 +1254,6 @@ StringObjectException Print::check_multi_filament_valid(const Print& print)
     return ret;
 }
 
-// Orca: this g92e0 regex is used copied from PrusaSlicer
-// Matches "G92 E0" with various forms of writing the zero and with an optional comment.
-boost::regex regex_g92e0 { "^[ \\t]*[gG]92[ \\t]*[eE](0(\\.0*)?|\\.0+)[ \\t]*(;.*)?$" };
-
 // Precondition: Print::validate() requires the Print::apply() to be called its invocation.
 //BBS: refine seq-print validation logic.....FIXME:StringObjectException *warning can only contain one warning, but there might be many warnings, need a vector<StringObjectException>
 StringObjectException Print::validate(StringObjectException *warning, Polygons* collison_polygons, std::vector<std::pair<Polygon, float>>* height_polygons) const
@@ -1676,17 +1672,23 @@ StringObjectException Print::validate(StringObjectException *warning, Polygons* 
 
     // Orca: G92 E0 is not supported when using absolute extruder addressing
     // This check is modified from PrusaSlicer, the original author is Vojtech Bubnik
-	// Orca: case‑sensitive match for exactly "G92 E0" (uppercase G and E only) 
-	// because gcode is case sensitive and G92 e0 satisfies the regex but causes a slicing error
-	// https://github.com/OrcaSlicer/OrcaSlicer/issues/13927
-	
-    if(!is_BBL_printer()) {
-		static const boost::regex regex_g92e0_correct { 
-    		"^[ \\t]*G92[ \\t]*E(0(\\.0*)?|\\.0+)[ \\t]*(;.*)?$"
-    	};
+    // Orca: case‑sensitive match for exactly "G92 E0" (uppercase G and E only) 
+    // because gcode is case sensitive and G92 e0 satisfies the regex but causes a slicing error
+    // https://github.com/OrcaSlicer/OrcaSlicer/issues/13927
+
+    if (!is_BBL_printer()) {
+        // Matches any case of "G92 E0" (original pattern)
+        static const boost::regex regex_g92e0 {
+            "^[ \\t]*[gG]92[ \\t]*[eE](0(\\.0*)?|\\.0+)[ \\t]*(;.*)?$"
+        };
+        // Matches only the exact uppercase "G92 E0"
+        static const boost::regex regex_g92e0_correct {
+            "^[ \\t]*G92[ \\t]*E(0(\\.0*)?|\\.0+)[ \\t]*(;.*)?$"
+        };
+
         bool before_layer_gcode_resets_extruder = boost::regex_search(m_config.before_layer_change_gcode.value, regex_g92e0);
-        bool layer_gcode_resets_extruder = boost::regex_search(m_config.layer_change_gcode.value, regex_g92e0);
-		
+		bool layer_gcode_resets_extruder	= boost::regex_search(m_config.layer_change_gcode.value, regex_g92e0);
+
         // Detect presence with wrong case and show a dedicated error
         if (before_layer_gcode_resets_extruder && !boost::regex_search(m_config.before_layer_change_gcode.value, regex_g92e0_correct))
             return {L("\"G92 E0\" was found in before_layer_gcode, but the G or E are not uppercase. "
@@ -1696,7 +1698,7 @@ StringObjectException Print::validate(StringObjectException *warning, Polygons* 
             return {L("\"G92 E0\" was found in layer_gcode, but the G or E are not uppercase. "
                       "Please change them to the exact uppercase \"G92 E0\"."),
                     nullptr, "layer_change_gcode"};
-		
+
         if (m_config.use_relative_e_distances) {
             // See GH issues https://github.com/prusa3d/PrusaSlicer/issues/6336 https://github.com/prusa3d/PrusaSlicer/issues/5073
             if ((m_config.gcode_flavor == gcfMarlinLegacy || m_config.gcode_flavor == gcfMarlinFirmware) &&

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -1675,13 +1675,30 @@ StringObjectException Print::validate(StringObjectException *warning, Polygons* 
     }
 
     // Orca: G92 E0 is not supported when using absolute extruder addressing
-    // This check is copied from PrusaSlicer, the original author is Vojtech Bubnik
+    // This check is modified from PrusaSlicer, the original author is Vojtech Bubnik
+	// Orca: case‑sensitive match for exactly "G92 E0" (uppercase G and E only) 
+	// because gcode is case sensitive and G92 e0 satisfies the regex but causes a slicing error
+	// https://github.com/OrcaSlicer/OrcaSlicer/issues/13927
+	
     if(!is_BBL_printer()) {
-        bool before_layer_gcode_resets_extruder =
-            boost::regex_search(m_config.before_layer_change_gcode.value, regex_g92e0);
+		static const boost::regex regex_g92e0_correct { 
+    		"^[ \\t]*G92[ \\t]*E(0(\\.0*)?|\\.0+)[ \\t]*(;.*)?$"
+    	};
+        bool before_layer_gcode_resets_extruder = boost::regex_search(m_config.before_layer_change_gcode.value, regex_g92e0);
         bool layer_gcode_resets_extruder = boost::regex_search(m_config.layer_change_gcode.value, regex_g92e0);
+		
+        // Detect presence with wrong case and show a dedicated error
+        if (before_layer_gcode_resets_extruder && !boost::regex_search(m_config.before_layer_change_gcode.value, regex_g92e0_correct))
+            return {L("\"G92 E0\" was found in before_layer_gcode, but the G or E are not uppercase. "
+                      "Please change them to the exact uppercase \"G92 E0\"."),
+                    nullptr, "before_layer_change_gcode"};
+        if (layer_gcode_resets_extruder && !boost::regex_search(m_config.layer_change_gcode.value, regex_g92e0_correct))
+            return {L("\"G92 E0\" was found in layer_gcode, but the G or E are not uppercase. "
+                      "Please change them to the exact uppercase \"G92 E0\"."),
+                    nullptr, "layer_change_gcode"};
+		
         if (m_config.use_relative_e_distances) {
-            // See GH issues #6336 #5073
+            // See GH issues https://github.com/prusa3d/PrusaSlicer/issues/6336 https://github.com/prusa3d/PrusaSlicer/issues/5073
             if ((m_config.gcode_flavor == gcfMarlinLegacy || m_config.gcode_flavor == gcfMarlinFirmware) &&
                 !before_layer_gcode_resets_extruder && !layer_gcode_resets_extruder)
                 return {L("Relative extruder addressing requires resetting the extruder position at each layer to "

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -1676,44 +1676,55 @@ StringObjectException Print::validate(StringObjectException *warning, Polygons* 
     // because gcode is case sensitive and G92 e0 satisfies the regex but causes a slicing error
     // https://github.com/OrcaSlicer/OrcaSlicer/issues/13927
 
-    if (!is_BBL_printer()) {
-        // Matches any case of "G92 E0" (original pattern)
-        static const boost::regex regex_g92e0 {
-            "^[ \\t]*[gG]92[ \\t]*[eE](0(\\.0*)?|\\.0+)[ \\t]*(;.*)?$"
-        };
-        // Matches only the exact uppercase "G92 E0"
-        static const boost::regex regex_g92e0_correct {
-            "^[ \\t]*G92[ \\t]*E(0(\\.0*)?|\\.0+)[ \\t]*(;.*)?$"
-        };
+	    // Matches any case of "G92 E0" (original pattern)
+    static const boost::regex regex_g92e0 {
+        "^[ \\t]*[gG]92[ \\t]*[eE](0(\\.0*)?|\\.0+)[ \\t]*(;.*)?$"
+    };
+    // Matches only the exact uppercase "G92 E0"
+    static const boost::regex regex_g92e0_correct {
+        "^[ \\t]*G92[ \\t]*E(0(\\.0*)?|\\.0+)[ \\t]*(;.*)?$"
+    };
 
-        bool before_layer_gcode_resets_extruder = boost::regex_search(m_config.before_layer_change_gcode.value, regex_g92e0);
-		bool layer_gcode_resets_extruder	= boost::regex_search(m_config.layer_change_gcode.value, regex_g92e0);
+    const bool before_has_g92_any = boost::regex_search(
+        m_config.before_layer_change_gcode.value, regex_g92e0);
+    const bool layer_has_g92_any  = boost::regex_search(
+        m_config.layer_change_gcode.value, regex_g92e0);
 
-        // Detect presence with wrong case and show a dedicated error
-        if (before_layer_gcode_resets_extruder && !boost::regex_search(m_config.before_layer_change_gcode.value, regex_g92e0_correct))
-            return {L("\"G92 E0\" was found in before_layer_gcode, but the G or E are not uppercase. "
+    if (m_config.use_relative_e_distances) {
+        // Relative mode: "G92 E0" is required to reset extruder position.
+        const bool before_has_g92_exact = boost::regex_search(
+            m_config.before_layer_change_gcode.value, regex_g92e0_correct);
+        const bool layer_has_g92_exact  = boost::regex_search(
+            m_config.layer_change_gcode.value, regex_g92e0_correct);
+
+        // Wrong case found?
+        if (before_has_g92_any && !before_has_g92_exact)
+            return {L("\"G92 E0\" was found in before_layer_change_gcode, but the G or E are not uppercase. "
                       "Please change them to the exact uppercase \"G92 E0\"."),
                     nullptr, "before_layer_change_gcode"};
-        if (layer_gcode_resets_extruder && !boost::regex_search(m_config.layer_change_gcode.value, regex_g92e0_correct))
-            return {L("\"G92 E0\" was found in layer_gcode, but the G or E are not uppercase. "
+        if (layer_has_g92_any && !layer_has_g92_exact)
+            return {L("\"G92 E0\" was found in layer_change_gcode, but the G or E are not uppercase. "
                       "Please change them to the exact uppercase \"G92 E0\"."),
                     nullptr, "layer_change_gcode"};
 
-        if (m_config.use_relative_e_distances) {
-            // See GH issues https://github.com/prusa3d/PrusaSlicer/issues/6336 https://github.com/prusa3d/PrusaSlicer/issues/5073
-            if ((m_config.gcode_flavor == gcfMarlinLegacy || m_config.gcode_flavor == gcfMarlinFirmware) &&
-                !before_layer_gcode_resets_extruder && !layer_gcode_resets_extruder)
-                return {L("Relative extruder addressing requires resetting the extruder position at each layer to "
-                          "prevent loss of floating point accuracy. Add \"G92 E0\" to layer_gcode."),
-                        nullptr, "before_layer_change_gcode"};
-        } else if (before_layer_gcode_resets_extruder)
-            return {L("\"G92 E0\" was found in before_layer_gcode, which is incompatible with absolute extruder "
+        // Only Marlin flavours need the reset; BBL printers do not.
+        if ((m_config.gcode_flavor == gcfMarlinLegacy || m_config.gcode_flavor == gcfMarlinFirmware) &&
+            !is_BBL_printer() &&
+            !before_has_g92_exact && !layer_has_g92_exact)
+            return {L("Relative extruder addressing requires resetting the extruder position at each layer to "
+                      "prevent loss of floating point accuracy. Add \"G92 E0\" to layer_gcode."),
+                    nullptr, "before_layer_change_gcode"};
+    } else {
+        // Absolute mode: any occurrence of "G92 E0" is incompatible.
+        if (before_has_g92_any)
+            return {L("\"G92 E0\" was found in before_layer_change_gcode, which is incompatible with absolute extruder "
                       "addressing."),
                     nullptr, "before_layer_change_gcode"};
-        else if (layer_gcode_resets_extruder)
-            return {L("\"G92 E0\" was found in layer_gcode, which is incompatible with absolute extruder addressing."),
+        if (layer_has_g92_any)
+            return {L("\"G92 E0\" was found in layer_change_gcode, which is incompatible with absolute extruder "
+                      "addressing."),
                     nullptr, "layer_change_gcode"};
-    }
+	}
 
     const ConfigOptionDef* bed_type_def = print_config_def.get("curr_bed_type");
     assert(bed_type_def != nullptr);


### PR DESCRIPTION
Modified regex check for G92 E0 to ensure case sensitivity and added error messages for incorrect casing.

# Description

* Fixes https://github.com/OrcaSlicer/OrcaSlicer/issues/13927
* Very lightweight change, shouldn't break anything

# Screenshots/Recordings/Graphs

Result in orcaslicer when `G92 e0` is used 

<img width="1353" height="1023" alt="image" src="https://github.com/user-attachments/assets/5cd1f5e1-2859-4d1c-bcf7-cb4083f9ae1e" />


## Tests

Not tested

<!--
> A guide for users on how to download the artifacts from this PR.
-->

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
