### PR TITLE
Fix missing normal-support TopContact interface with variable layer height + MM paint

### DIFF
--- a/src/libslic3r/Support/SupportMaterial.cpp
+++ b/src/libslic3r/Support/SupportMaterial.cpp
@@ -3148,7 +3148,25 @@ void PrintObjectSupportMaterial::trim_support_layers_by_object(
                 // BOOST_LOG_TRIVIAL(trace) << "Support generator - trim_support_layers_by_object - trimmming non-empty layer " << idx_layer << " of " << nonempty_layers.size();
                 assert(! support_layer.polygons.empty() && support_layer.print_z >= m_slicing_params.raft_contact_top_z + EPSILON);
                 // Find the overlapping object layers including the extra above / below gap.
-                coordf_t z_threshold = support_layer.bottom_print_z() - gap_extra_below + EPSILON;
+                // ORCA: For bottom-contact support layers, the support physically occupies
+                // [bottom_print_z, print_z] and sits on an object top surface that's gap_object_support
+                // below it. Object layers outside that vertical span cannot collide with the support,
+                // and including them in the lslice-based trim can erase the very area the support is
+                // meant to underpin. This is particularly harmful when:
+                //   * an object layer lies entirely above the support (its lslice may contain a
+                //     newly-emerging horizontal/cantilever cross-section), or
+                //   * an object layer lies entirely below the support with is_overlap == false; its
+                //     lslice gets inflated by no_overlap_xy_gap and that halo bleeds outward into
+                //     the cantilever bottom area near the riser/cantilever junction.
+                // Variable-layer-height combined with multi-material painting exposes this because
+                // painting forces extra object layer subdivisions that pull such layers into the trim.
+                const bool is_bottom_contact = (support_layer.layer_type == SupporLayerType::BottomContact);
+                const coordf_t upper_z_limit = is_bottom_contact
+                    ? support_layer.bottom_print_z()
+                    : support_layer.print_z + gap_extra_above;
+                coordf_t z_threshold = is_bottom_contact
+                    ? support_layer.bottom_print_z()
+                    : (support_layer.bottom_print_z() - gap_extra_below + EPSILON);
                 idx_object_layer_overlapping = Layer::idx_higher_or_equal(
                     object.layers().begin(), object.layers().end(), idx_object_layer_overlapping,
                     [z_threshold](const Layer *layer){ return layer->print_z >= z_threshold; });
@@ -3157,7 +3175,7 @@ void PrintObjectSupportMaterial::trim_support_layers_by_object(
                 size_t i = idx_object_layer_overlapping;
                 for (; i < object.layers().size(); ++ i) {
                     const Layer &object_layer = *object.layers()[i];
-                    if (object_layer.bottom_z() > support_layer.print_z + gap_extra_above - EPSILON)
+                    if (object_layer.bottom_z() > upper_z_limit - EPSILON)
                         break;
 
                     bool is_overlap = is_layers_overlap(support_layer, object_layer);
@@ -3177,13 +3195,13 @@ void PrintObjectSupportMaterial::trim_support_layers_by_object(
                         bool some_region_overlaps = false;
                         for (LayerRegion *region : object_layer.regions()) {
                             coordf_t bridging_height = region->region().bridging_height_avg(*m_print_config);
-                            if (object_layer.print_z - bridging_height > support_layer.print_z + gap_extra_above - EPSILON)
+                            if (object_layer.print_z - bridging_height > upper_z_limit - EPSILON)
                                 break;
                             some_region_overlaps = true;
 
                             bool is_overlap = is_layers_overlap(support_layer, object_layer, bridging_height);
                             coordf_t trimming_offset = is_overlap ? gap_xy_scaled : scale_(no_overlap_xy_gap);
-                            polygons_append(polygons_trimming, 
+                            polygons_append(polygons_trimming,
                                 offset(region->fill_surfaces.filter_by_type(stBottomBridge), trimming_offset, SUPPORT_SURFACES_OFFSET_PARAMETERS));
                             if (region->region().config().detect_overhang_wall.value)
                                 // Add bridging perimeters.

--- a/src/libslic3r/Support/SupportMaterial.cpp
+++ b/src/libslic3r/Support/SupportMaterial.cpp
@@ -3165,7 +3165,7 @@ void PrintObjectSupportMaterial::trim_support_layers_by_object(
                     ? support_layer.bottom_print_z()
                     : support_layer.print_z + gap_extra_above;
                 coordf_t z_threshold = is_bottom_contact
-                    ? support_layer.bottom_print_z()
+                    ? support_layer.bottom_print_z() - EPSILON
                     : (support_layer.bottom_print_z() - gap_extra_below + EPSILON);
                 idx_object_layer_overlapping = Layer::idx_higher_or_equal(
                     object.layers().begin(), object.layers().end(), idx_object_layer_overlapping,

--- a/src/libslic3r/Support/SupportMaterial.cpp
+++ b/src/libslic3r/Support/SupportMaterial.cpp
@@ -3179,7 +3179,28 @@ void PrintObjectSupportMaterial::trim_support_layers_by_object(
                         break;
 
                     bool is_overlap = is_layers_overlap(support_layer, object_layer);
-                    for (const ExPolygon& expoly : object_layer.lslices) {
+
+                    // ORCA: When a top-contact support is trimmed by an object layer that lies
+                    // entirely above it, only the part of that cross-section that continues down
+                    // as a real wall (i.e. is present in the object layer immediately below) can
+                    // physically collide with the support. The freshly-emerging part is the
+                    // overhang this contact is meant to support, so trimming the contact by it
+                    // would erase the dense interface directly beneath the overhang. Restrict the
+                    // trim source to the vertically-continuous region in that case.
+                    // With uniform layers the supported overhang sits more than gap_support_object
+                    // above the contact and never enters the [print_z, print_z + gap_extra_above]
+                    // window, so this is a no-op for vertical walls; variable layer height combined
+                    // with multi-material painting can subdivide the object thinner than
+                    // gap_support_object and pull the supported bridge/overhang into the window,
+                    // which previously wiped the interface (e.g. a flat bridge over a recess losing
+                    // its interface on the recessed areas).
+                    const ExPolygons *trim_source = &object_layer.lslices;
+                    ExPolygons trim_continuous;
+                    if (!is_bottom_contact && i > 0 && object_layer.bottom_z() >= support_layer.print_z - EPSILON) {
+                        trim_continuous = intersection_ex(object_layer.lslices, object.layers()[i - 1]->lslices);
+                        trim_source = &trim_continuous;
+                    }
+                    for (const ExPolygon& expoly : *trim_source) {
                         // BBS
                         bool is_sharptail = !intersection_ex({ expoly }, object_layer.sharp_tails).empty();
                         coordf_t trimming_offset = is_sharptail ? scale_(sharp_tail_xy_gap) :


### PR DESCRIPTION
> _This fix was developed with the assistance of GitHub Copilot._

Fixes #13938.

> **🥞 Stacked on #13912.** This branch builds on top of `fix/normal-support-interface-vlh-mmpaint` (PR #13912). Because that branch is not yet merged into `main`, this PR currently shows **both** commits and the combined diff of `SupportMaterial.cpp`. Please merge #13912 first; once it lands, this PR will automatically reduce to the single TopContact commit below. The two fixes touch the same function (`trim_support_layers_by_object`) but different layer types (BottomContact vs. TopContact) and are independent.

## Summary

Normal (non-tree) auto-generated supports could fail to emit the **TopContact** interface cap across the full underside of a flat overhang/bridge when **both** variable layer height **and** multi-material painting were enabled. Either feature alone produced the correct full-coverage interface. Tree/organic supports are unaffected.

In the reproduction project the flat cantilever bridge spans two recessed "square" pockets. With both features on, the interface is generated only as a thin perimeter frame; over the two pockets the interface cap is **missing**, leaving the bridge underside without a dense interface to print onto in those areas.

This is the second of two bugs found on the same project. #13911 / PR #13912 fix the **BottomContact** interface lower on the part; PR #13912 explicitly listed this TopContact bug as out-of-scope and to be tracked separately — this PR is that follow-up.

**Reproduction project file** (same one attached to #13911 / #13938): [Adapter-Plate-variable-layer-height-color-swap-support-broken.zip](https://github.com/user-attachments/files/28357647/Adapter-Plate-variable-layer-height-color-swap-support-broken.zip)

## Root cause

In `PrintObjectSupportMaterial::trim_support_layers_by_object` (`src/libslic3r/Support/SupportMaterial.cpp`), a `TopContact` support layer is trimmed against the union of object-layer slices that fall within a Z window above the contact: `[print_z, print_z + gap_extra_above]` (where `gap_extra_above == gap_support_object`).

Normally the supported overhang (the flat bridge) sits a full object-layer-height above the contact — more than `gap_support_object` — so it lies *outside* this window and is excluded by the loop's break. Variable layer height combined with MM painting subdivides the object into layers **thinner than `gap_support_object`**, so the bridge's full-footprint slice falls *inside* the window. The bridge cross-section then trims the contact directly beneath itself, erasing the interface over the recessed pockets — exactly the part of the bridge that is a genuine overhang, with no wall continuing below it.

## Fix

When a `TopContact` is trimmed by an object layer lying entirely above it (`bottom_z() >= print_z`), restrict the trim source to the **vertically-continuous** region: the intersection of that object layer's slice with the object layer immediately below it (i.e. real walls that physically continue down toward the support). The freshly-emerging overhang cross-section is no longer part of the trim source, so it can no longer erase the interface directly beneath it.

Other layer types (BottomContact, intermediate, base) and the uniform-layer case are unchanged.

## Verification

CLI re-slice of the reproduction `.3mf`, measuring `; FEATURE: Support interface` extrusion length (z-hop-aware parsing via `; CHANGE_LAYER` / `; Z_HEIGHT:` markers):

| Case | Interface length | Square pockets covered? |
|---|---|---|
| Broken (VLH + paint), before fix | 4345 mm | ❌ thin frame only |
| Broken (VLH + paint), after fix | 12366 mm (**+185%**) | ✅ both pockets filled |
| Reference (VLH off), for comparison | 12388 mm | ✅ both pockets filled |

After the fix, the broken slice's interface coverage **matches the reference** (either-feature-disabled) result at Z ≈ 26.83 and 26.61 mm — both recessed pockets are fully capped. Surrounding dense `Support` extrusion drops ~2.4% as it is correctly converted into interface; object geometry is unchanged.

## Risk

- Change is scoped to `TopContact` layers via a single new code branch; all other layer types take the unchanged path.
- The new trim source is the **intersection** of the layer slice with the layer below — i.e. a **subset** of the original trim source. The fix can therefore only *retain more* interface area, never invent new support area or new object collisions.
- For uniform-layer prints the supported overhang never enters the trim window, so the branch is a no-op.

## Screenshots

<!-- Before (problem): interface missing over the two recessed pockets under the bridge -->
**Before (problem):**

<img width="3232" height="2070" alt="interface-broken" src="https://github.com/user-attachments/assets/f6c7587b-7d84-4772-8b02-8c8fb1954e45" />

<!-- After (fix): full interface cap across the bridge underside -->
**After (fix):**

<img width="3208" height="2076" alt="interface-fixed" src="https://github.com/user-attachments/assets/547c8668-7f3c-4d2f-a9f1-00797bc97533" />

## Test plan

1. Build OrcaSlicer (merge or rebase onto #13912 first while it is unmerged).
2. Open the project file attached to #13911 / #13938: [Adapter-Plate-variable-layer-height-color-swap-support-broken.zip](https://github.com/user-attachments/files/28357647/Adapter-Plate-variable-layer-height-color-swap-support-broken.zip).
3. Slice with **Normal (auto)** support, variable layer height on, MM painting on.
4. In Preview at Z ≈ 26.8 mm, verify a `Support interface` cap covers the **entire** bridge underside, including the two recessed pockets.
5. Toggle variable layer height off and/or painting off; verify behavior is unchanged from current `main` (no regressions).

---

_PR opened with the help of GitHub Copilot CLI. All analysis and verification was reviewed and confirmed before submission._

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
