### PR TITLE
Add FilAr filament vendor (PLA, PLA-mate, PETG)

### DIFF
--- a/resources/profiles/OrcaFilamentLibrary.json
+++ b/resources/profiles/OrcaFilamentLibrary.json
@@ -69,6 +69,258 @@
 			"sub_path": "filament/base/fdm_filament_pla.json"
 		},
 		{
+			"name": "FilAr PLA @base",
+			"sub_path": "filament/FilAr/FilAr PLA @base.json"
+		},
+		{
+			"name": "FilAr PLA Bronce",
+			"sub_path": "filament/FilAr/FilAr PLA Bronce.json"
+		},
+		{
+			"name": "FilAr PLA Gris Plata",
+			"sub_path": "filament/FilAr/FilAr PLA Gris Plata.json"
+		},
+		{
+			"name": "FilAr PLA Cobre",
+			"sub_path": "filament/FilAr/FilAr PLA Cobre.json"
+		},
+		{
+			"name": "FilAr PLA Titanio",
+			"sub_path": "filament/FilAr/FilAr PLA Titanio.json"
+		},
+		{
+			"name": "FilAr PLA Tabaco",
+			"sub_path": "filament/FilAr/FilAr PLA Tabaco.json"
+		},
+		{
+			"name": "FilAr PLA Cafe con Leche",
+			"sub_path": "filament/FilAr/FilAr PLA Cafe con Leche.json"
+		},
+		{
+			"name": "FilAr PLA Manteca",
+			"sub_path": "filament/FilAr/FilAr PLA Manteca.json"
+		},
+		{
+			"name": "FilAr PLA Marron Oxido",
+			"sub_path": "filament/FilAr/FilAr PLA Marron Oxido.json"
+		},
+		{
+			"name": "FilAr PLA Carpincho",
+			"sub_path": "filament/FilAr/FilAr PLA Carpincho.json"
+		},
+		{
+			"name": "FilAr PLA Rosa Amaranto",
+			"sub_path": "filament/FilAr/FilAr PLA Rosa Amaranto.json"
+		},
+		{
+			"name": "FilAr PLA Rosa Flamenco",
+			"sub_path": "filament/FilAr/FilAr PLA Rosa Flamenco.json"
+		},
+		{
+			"name": "FilAr PLA Piel",
+			"sub_path": "filament/FilAr/FilAr PLA Piel.json"
+		},
+		{
+			"name": "FilAr PLA Verde FilAr",
+			"sub_path": "filament/FilAr/FilAr PLA Verde FilAr.json"
+		},
+		{
+			"name": "FilAr PLA Verde Manzana",
+			"sub_path": "filament/FilAr/FilAr PLA Verde Manzana.json"
+		},
+		{
+			"name": "FilAr PLA Verde Pixel",
+			"sub_path": "filament/FilAr/FilAr PLA Verde Pixel.json"
+		},
+		{
+			"name": "FilAr PLA Verde Oliva",
+			"sub_path": "filament/FilAr/FilAr PLA Verde Oliva.json"
+		},
+		{
+			"name": "FilAr PLA Blanco Antartida",
+			"sub_path": "filament/FilAr/FilAr PLA Blanco Antartida.json"
+		},
+		{
+			"name": "FilAr PLA Blanco Calido",
+			"sub_path": "filament/FilAr/FilAr PLA Blanco Calido.json"
+		},
+		{
+			"name": "FilAr PLA Negro Azabache",
+			"sub_path": "filament/FilAr/FilAr PLA Negro Azabache.json"
+		},
+		{
+			"name": "FilAr PLA Naranja Tigre",
+			"sub_path": "filament/FilAr/FilAr PLA Naranja Tigre.json"
+		},
+		{
+			"name": "FilAr PLA Rojo de Carreras",
+			"sub_path": "filament/FilAr/FilAr PLA Rojo de Carreras.json"
+		},
+		{
+			"name": "FilAr PLA Amarillo Lirio",
+			"sub_path": "filament/FilAr/FilAr PLA Amarillo Lirio.json"
+		},
+		{
+			"name": "FilAr PLA Violeta Jacaranda",
+			"sub_path": "filament/FilAr/FilAr PLA Violeta Jacaranda.json"
+		},
+		{
+			"name": "FilAr PLA Gris Pizarra",
+			"sub_path": "filament/FilAr/FilAr PLA Gris Pizarra.json"
+		},
+		{
+			"name": "FilAr PLA Gris Ceniza",
+			"sub_path": "filament/FilAr/FilAr PLA Gris Ceniza.json"
+		},
+		{
+			"name": "FilAr PLA Azul Francia",
+			"sub_path": "filament/FilAr/FilAr PLA Azul Francia.json"
+		},
+		{
+			"name": "FilAr PLA Celeste Cielo",
+			"sub_path": "filament/FilAr/FilAr PLA Celeste Cielo.json"
+		},
+		{
+			"name": "FilAr PLA Oro",
+			"sub_path": "filament/FilAr/FilAr PLA Oro.json"
+		},
+		{
+			"name": "FilAr PLA Dorado",
+			"sub_path": "filament/FilAr/FilAr PLA Dorado.json"
+		},
+		{
+			"name": "FilAr PLA-mate @base",
+			"sub_path": "filament/FilAr/FilAr PLA-mate @base.json"
+		},
+		{
+			"name": "FilAr PLA-mate Amarillo",
+			"sub_path": "filament/FilAr/FilAr PLA-mate Amarillo.json"
+		},
+		{
+			"name": "FilAr PLA-mate Azul",
+			"sub_path": "filament/FilAr/FilAr PLA-mate Azul.json"
+		},
+		{
+			"name": "FilAr PLA-mate Beige",
+			"sub_path": "filament/FilAr/FilAr PLA-mate Beige.json"
+		},
+		{
+			"name": "FilAr PLA-mate Blanco",
+			"sub_path": "filament/FilAr/FilAr PLA-mate Blanco.json"
+		},
+		{
+			"name": "FilAr PLA-mate Bordo",
+			"sub_path": "filament/FilAr/FilAr PLA-mate Bordo.json"
+		},
+		{
+			"name": "FilAr PLA-mate Celeste Cielo",
+			"sub_path": "filament/FilAr/FilAr PLA-mate Celeste Cielo.json"
+		},
+		{
+			"name": "FilAr PLA-mate Chocolate",
+			"sub_path": "filament/FilAr/FilAr PLA-mate Chocolate.json"
+		},
+		{
+			"name": "FilAr PLA-mate Gris",
+			"sub_path": "filament/FilAr/FilAr PLA-mate Gris.json"
+		},
+		{
+			"name": "FilAr PLA-mate Marron",
+			"sub_path": "filament/FilAr/FilAr PLA-mate Marron.json"
+		},
+		{
+			"name": "FilAr PLA-mate Naranja",
+			"sub_path": "filament/FilAr/FilAr PLA-mate Naranja.json"
+		},
+		{
+			"name": "FilAr PLA-mate Negro",
+			"sub_path": "filament/FilAr/FilAr PLA-mate Negro.json"
+		},
+		{
+			"name": "FilAr PLA-mate Piel",
+			"sub_path": "filament/FilAr/FilAr PLA-mate Piel.json"
+		},
+		{
+			"name": "FilAr PLA-mate Rojo",
+			"sub_path": "filament/FilAr/FilAr PLA-mate Rojo.json"
+		},
+		{
+			"name": "FilAr PLA-mate Rosa",
+			"sub_path": "filament/FilAr/FilAr PLA-mate Rosa.json"
+		},
+		{
+			"name": "FilAr PLA-mate Uva",
+			"sub_path": "filament/FilAr/FilAr PLA-mate Uva.json"
+		},
+		{
+			"name": "FilAr PLA-mate Verde",
+			"sub_path": "filament/FilAr/FilAr PLA-mate Verde.json"
+		},
+		{
+			"name": "FilAr PLA-mate Violeta",
+			"sub_path": "filament/FilAr/FilAr PLA-mate Violeta.json"
+		},
+		{
+			"name": "FilAr PETG @base",
+			"sub_path": "filament/FilAr/FilAr PETG @base.json"
+		},
+		{
+			"name": "FilAr PETG Amarillo Lima",
+			"sub_path": "filament/FilAr/FilAr PETG Amarillo Lima.json"
+		},
+		{
+			"name": "FilAr PETG Amarillo Radiante",
+			"sub_path": "filament/FilAr/FilAr PETG Amarillo Radiante.json"
+		},
+		{
+			"name": "FilAr PETG Azul Boreal",
+			"sub_path": "filament/FilAr/FilAr PETG Azul Boreal.json"
+		},
+		{
+			"name": "FilAr PETG Azul Francia",
+			"sub_path": "filament/FilAr/FilAr PETG Azul Francia.json"
+		},
+		{
+			"name": "FilAr PETG Azul Imperial",
+			"sub_path": "filament/FilAr/FilAr PETG Azul Imperial.json"
+		},
+		{
+			"name": "FilAr PETG Blanco Antartida",
+			"sub_path": "filament/FilAr/FilAr PETG Blanco Antartida.json"
+		},
+		{
+			"name": "FilAr PETG Cian",
+			"sub_path": "filament/FilAr/FilAr PETG Cian.json"
+		},
+		{
+			"name": "FilAr PETG Coral",
+			"sub_path": "filament/FilAr/FilAr PETG Coral.json"
+		},
+		{
+			"name": "FilAr PETG Cristal",
+			"sub_path": "filament/FilAr/FilAr PETG Cristal.json"
+		},
+		{
+			"name": "FilAr PETG Gris Ceniza",
+			"sub_path": "filament/FilAr/FilAr PETG Gris Ceniza.json"
+		},
+		{
+			"name": "FilAr PETG Gris Plata",
+			"sub_path": "filament/FilAr/FilAr PETG Gris Plata.json"
+		},
+		{
+			"name": "FilAr PETG Magenta",
+			"sub_path": "filament/FilAr/FilAr PETG Magenta.json"
+		},
+		{
+			"name": "FilAr PETG Negro Azabache",
+			"sub_path": "filament/FilAr/FilAr PETG Negro Azabache.json"
+		},
+		{
+			"name": "FilAr PETG Rojo Carmesi",
+			"sub_path": "filament/FilAr/FilAr PETG Rojo Carmesi.json"
+		},
+		{
 			"name": "fdm_filament_pp",
 			"sub_path": "filament/base/fdm_filament_pp.json"
 		},

--- a/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PETG @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PETG @base.json
@@ -1,0 +1,53 @@
+{
+    "type": "filament",
+    "name": "FilAr PETG @base",
+    "inherits": "fdm_filament_pet",
+    "from": "system",
+    "filament_id": "FILARB03",
+    "instantiation": "false",
+    "filament_type": [
+        "PETG"
+    ],
+    "filament_vendor": [
+        "FilAr"
+    ],
+    "filament_diameter": [
+        "1.75"
+    ],
+    "filament_density": [
+        "1.27"
+    ],
+    "filament_flow_ratio": [
+        "0.95"
+    ],
+    "nozzle_temperature": [
+        "240"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "245"
+    ],
+    "nozzle_temperature_range_low": [
+        "230"
+    ],
+    "nozzle_temperature_range_high": [
+        "250"
+    ],
+    "hot_plate_temp": [
+        "78"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "78"
+    ],
+    "textured_plate_temp": [
+        "78"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "78"
+    ],
+    "fan_min_speed": [
+        "40"
+    ],
+    "fan_max_speed": [
+        "60"
+    ]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PETG Amarillo Lima.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PETG Amarillo Lima.json
@@ -1,0 +1,14 @@
+{
+    "type": "filament",
+    "name": "FilAr PETG Amarillo Lima",
+    "inherits": "FilAr PETG @base",
+    "from": "system",
+    "filament_id": "FILAR0047",
+    "instantiation": "true",
+    "filament_vendor": [
+        "FilAr"
+    ],
+    "default_filament_colour": [
+        "#C7E03A"
+    ]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PETG Amarillo Radiante.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PETG Amarillo Radiante.json
@@ -1,0 +1,14 @@
+{
+    "type": "filament",
+    "name": "FilAr PETG Amarillo Radiante",
+    "inherits": "FilAr PETG @base",
+    "from": "system",
+    "filament_id": "FILAR0048",
+    "instantiation": "true",
+    "filament_vendor": [
+        "FilAr"
+    ],
+    "default_filament_colour": [
+        "#FFD400"
+    ]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PETG Azul Boreal.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PETG Azul Boreal.json
@@ -1,0 +1,14 @@
+{
+    "type": "filament",
+    "name": "FilAr PETG Azul Boreal",
+    "inherits": "FilAr PETG @base",
+    "from": "system",
+    "filament_id": "FILAR0049",
+    "instantiation": "true",
+    "filament_vendor": [
+        "FilAr"
+    ],
+    "default_filament_colour": [
+        "#1B4F9C"
+    ]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PETG Azul Francia.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PETG Azul Francia.json
@@ -1,0 +1,14 @@
+{
+    "type": "filament",
+    "name": "FilAr PETG Azul Francia",
+    "inherits": "FilAr PETG @base",
+    "from": "system",
+    "filament_id": "FILAR0050",
+    "instantiation": "true",
+    "filament_vendor": [
+        "FilAr"
+    ],
+    "default_filament_colour": [
+        "#0033A0"
+    ]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PETG Azul Imperial.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PETG Azul Imperial.json
@@ -1,0 +1,14 @@
+{
+    "type": "filament",
+    "name": "FilAr PETG Azul Imperial",
+    "inherits": "FilAr PETG @base",
+    "from": "system",
+    "filament_id": "FILAR0051",
+    "instantiation": "true",
+    "filament_vendor": [
+        "FilAr"
+    ],
+    "default_filament_colour": [
+        "#14306B"
+    ]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PETG Blanco Antartida.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PETG Blanco Antartida.json
@@ -1,0 +1,14 @@
+{
+    "type": "filament",
+    "name": "FilAr PETG Blanco Antartida",
+    "inherits": "FilAr PETG @base",
+    "from": "system",
+    "filament_id": "FILAR0052",
+    "instantiation": "true",
+    "filament_vendor": [
+        "FilAr"
+    ],
+    "default_filament_colour": [
+        "#F7FAFC"
+    ]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PETG Cian.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PETG Cian.json
@@ -1,0 +1,14 @@
+{
+    "type": "filament",
+    "name": "FilAr PETG Cian",
+    "inherits": "FilAr PETG @base",
+    "from": "system",
+    "filament_id": "FILAR0053",
+    "instantiation": "true",
+    "filament_vendor": [
+        "FilAr"
+    ],
+    "default_filament_colour": [
+        "#00B7D4"
+    ]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PETG Coral.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PETG Coral.json
@@ -1,0 +1,14 @@
+{
+    "type": "filament",
+    "name": "FilAr PETG Coral",
+    "inherits": "FilAr PETG @base",
+    "from": "system",
+    "filament_id": "FILAR0054",
+    "instantiation": "true",
+    "filament_vendor": [
+        "FilAr"
+    ],
+    "default_filament_colour": [
+        "#FF6F5E"
+    ]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PETG Cristal.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PETG Cristal.json
@@ -1,0 +1,14 @@
+{
+    "type": "filament",
+    "name": "FilAr PETG Cristal",
+    "inherits": "FilAr PETG @base",
+    "from": "system",
+    "filament_id": "FILAR0055",
+    "instantiation": "true",
+    "filament_vendor": [
+        "FilAr"
+    ],
+    "default_filament_colour": [
+        "#E8F0EC"
+    ]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PETG Gris Ceniza.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PETG Gris Ceniza.json
@@ -1,0 +1,14 @@
+{
+    "type": "filament",
+    "name": "FilAr PETG Gris Ceniza",
+    "inherits": "FilAr PETG @base",
+    "from": "system",
+    "filament_id": "FILAR0056",
+    "instantiation": "true",
+    "filament_vendor": [
+        "FilAr"
+    ],
+    "default_filament_colour": [
+        "#B4B6B1"
+    ]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PETG Gris Plata.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PETG Gris Plata.json
@@ -1,0 +1,14 @@
+{
+    "type": "filament",
+    "name": "FilAr PETG Gris Plata",
+    "inherits": "FilAr PETG @base",
+    "from": "system",
+    "filament_id": "FILAR0057",
+    "instantiation": "true",
+    "filament_vendor": [
+        "FilAr"
+    ],
+    "default_filament_colour": [
+        "#8C8686"
+    ]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PETG Magenta.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PETG Magenta.json
@@ -1,0 +1,14 @@
+{
+    "type": "filament",
+    "name": "FilAr PETG Magenta",
+    "inherits": "FilAr PETG @base",
+    "from": "system",
+    "filament_id": "FILAR0058",
+    "instantiation": "true",
+    "filament_vendor": [
+        "FilAr"
+    ],
+    "default_filament_colour": [
+        "#B5174B"
+    ]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PETG Negro Azabache.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PETG Negro Azabache.json
@@ -1,0 +1,14 @@
+{
+    "type": "filament",
+    "name": "FilAr PETG Negro Azabache",
+    "inherits": "FilAr PETG @base",
+    "from": "system",
+    "filament_id": "FILAR0059",
+    "instantiation": "true",
+    "filament_vendor": [
+        "FilAr"
+    ],
+    "default_filament_colour": [
+        "#000000"
+    ]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PETG Rojo Carmesi.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PETG Rojo Carmesi.json
@@ -1,0 +1,14 @@
+{
+    "type": "filament",
+    "name": "FilAr PETG Rojo Carmesi",
+    "inherits": "FilAr PETG @base",
+    "from": "system",
+    "filament_id": "FILAR0060",
+    "instantiation": "true",
+    "filament_vendor": [
+        "FilAr"
+    ],
+    "default_filament_colour": [
+        "#8C1020"
+    ]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA @base.json
@@ -1,0 +1,47 @@
+{
+    "type": "filament",
+    "name": "FilAr PLA @base",
+    "inherits": "fdm_filament_pla",
+    "from": "system",
+    "filament_id": "FILARB01",
+    "instantiation": "false",
+    "filament_type": [
+        "PLA"
+    ],
+    "filament_vendor": [
+        "FilAr"
+    ],
+    "filament_diameter": [
+        "1.75"
+    ],
+    "filament_density": [
+        "1.24"
+    ],
+    "filament_flow_ratio": [
+        "0.98"
+    ],
+    "nozzle_temperature": [
+        "210"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "215"
+    ],
+    "nozzle_temperature_range_low": [
+        "200"
+    ],
+    "nozzle_temperature_range_high": [
+        "220"
+    ],
+    "hot_plate_temp": [
+        "60"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "60"
+    ],
+    "textured_plate_temp": [
+        "60"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "60"
+    ]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA Amarillo Lirio.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA Amarillo Lirio.json
@@ -1,0 +1,14 @@
+{
+    "type": "filament",
+    "name": "FilAr PLA Amarillo Lirio",
+    "inherits": "FilAr PLA @base",
+    "from": "system",
+    "filament_id": "FILAR0022",
+    "instantiation": "true",
+    "filament_vendor": [
+        "FilAr"
+    ],
+    "default_filament_colour": [
+        "#FFD52B"
+    ]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA Azul Francia.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA Azul Francia.json
@@ -1,0 +1,14 @@
+{
+    "type": "filament",
+    "name": "FilAr PLA Azul Francia",
+    "inherits": "FilAr PLA @base",
+    "from": "system",
+    "filament_id": "FILAR0026",
+    "instantiation": "true",
+    "filament_vendor": [
+        "FilAr"
+    ],
+    "default_filament_colour": [
+        "#0000FF"
+    ]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA Blanco Antartida.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA Blanco Antartida.json
@@ -1,0 +1,14 @@
+{
+    "type": "filament",
+    "name": "FilAr PLA Blanco Antartida",
+    "inherits": "FilAr PLA @base",
+    "from": "system",
+    "filament_id": "FILAR0017",
+    "instantiation": "true",
+    "filament_vendor": [
+        "FilAr"
+    ],
+    "default_filament_colour": [
+        "#F7FAFC"
+    ]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA Blanco Calido.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA Blanco Calido.json
@@ -1,0 +1,14 @@
+{
+    "type": "filament",
+    "name": "FilAr PLA Blanco Calido",
+    "inherits": "FilAr PLA @base",
+    "from": "system",
+    "filament_id": "FILAR0018",
+    "instantiation": "true",
+    "filament_vendor": [
+        "FilAr"
+    ],
+    "default_filament_colour": [
+        "#FFF8E7"
+    ]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA Bronce.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA Bronce.json
@@ -1,0 +1,14 @@
+{
+    "type": "filament",
+    "name": "FilAr PLA Bronce",
+    "inherits": "FilAr PLA @base",
+    "from": "system",
+    "filament_id": "FILAR0001",
+    "instantiation": "true",
+    "filament_vendor": [
+        "FilAr"
+    ],
+    "default_filament_colour": [
+        "#AD8428"
+    ]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA Cafe con Leche.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA Cafe con Leche.json
@@ -1,0 +1,14 @@
+{
+    "type": "filament",
+    "name": "FilAr PLA Cafe con Leche",
+    "inherits": "FilAr PLA @base",
+    "from": "system",
+    "filament_id": "FILAR0006",
+    "instantiation": "true",
+    "filament_vendor": [
+        "FilAr"
+    ],
+    "default_filament_colour": [
+        "#E0B269"
+    ]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA Carpincho.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA Carpincho.json
@@ -1,0 +1,14 @@
+{
+    "type": "filament",
+    "name": "FilAr PLA Carpincho",
+    "inherits": "FilAr PLA @base",
+    "from": "system",
+    "filament_id": "FILAR0009",
+    "instantiation": "true",
+    "filament_vendor": [
+        "FilAr"
+    ],
+    "default_filament_colour": [
+        "#E8DFC1"
+    ]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA Celeste Cielo.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA Celeste Cielo.json
@@ -1,0 +1,14 @@
+{
+    "type": "filament",
+    "name": "FilAr PLA Celeste Cielo",
+    "inherits": "FilAr PLA @base",
+    "from": "system",
+    "filament_id": "FILAR0027",
+    "instantiation": "true",
+    "filament_vendor": [
+        "FilAr"
+    ],
+    "default_filament_colour": [
+        "#A1EBFF"
+    ]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA Cobre.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA Cobre.json
@@ -1,0 +1,14 @@
+{
+    "type": "filament",
+    "name": "FilAr PLA Cobre",
+    "inherits": "FilAr PLA @base",
+    "from": "system",
+    "filament_id": "FILAR0003",
+    "instantiation": "true",
+    "filament_vendor": [
+        "FilAr"
+    ],
+    "default_filament_colour": [
+        "#87421E"
+    ]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA Dorado.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA Dorado.json
@@ -1,0 +1,14 @@
+{
+    "type": "filament",
+    "name": "FilAr PLA Dorado",
+    "inherits": "FilAr PLA @base",
+    "from": "system",
+    "filament_id": "FILAR0029",
+    "instantiation": "true",
+    "filament_vendor": [
+        "FilAr"
+    ],
+    "default_filament_colour": [
+        "#A67F00"
+    ]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA Gris Ceniza.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA Gris Ceniza.json
@@ -1,0 +1,14 @@
+{
+    "type": "filament",
+    "name": "FilAr PLA Gris Ceniza",
+    "inherits": "FilAr PLA @base",
+    "from": "system",
+    "filament_id": "FILAR0025",
+    "instantiation": "true",
+    "filament_vendor": [
+        "FilAr"
+    ],
+    "default_filament_colour": [
+        "#B4B6B1"
+    ]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA Gris Pizarra.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA Gris Pizarra.json
@@ -1,0 +1,14 @@
+{
+    "type": "filament",
+    "name": "FilAr PLA Gris Pizarra",
+    "inherits": "FilAr PLA @base",
+    "from": "system",
+    "filament_id": "FILAR0024",
+    "instantiation": "true",
+    "filament_vendor": [
+        "FilAr"
+    ],
+    "default_filament_colour": [
+        "#4B4B4B"
+    ]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA Gris Plata.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA Gris Plata.json
@@ -1,0 +1,14 @@
+{
+    "type": "filament",
+    "name": "FilAr PLA Gris Plata",
+    "inherits": "FilAr PLA @base",
+    "from": "system",
+    "filament_id": "FILAR0002",
+    "instantiation": "true",
+    "filament_vendor": [
+        "FilAr"
+    ],
+    "default_filament_colour": [
+        "#8C8686"
+    ]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA Manteca.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA Manteca.json
@@ -1,0 +1,14 @@
+{
+    "type": "filament",
+    "name": "FilAr PLA Manteca",
+    "inherits": "FilAr PLA @base",
+    "from": "system",
+    "filament_id": "FILAR0007",
+    "instantiation": "true",
+    "filament_vendor": [
+        "FilAr"
+    ],
+    "default_filament_colour": [
+        "#FFF5AB"
+    ]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA Marron Oxido.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA Marron Oxido.json
@@ -1,0 +1,14 @@
+{
+    "type": "filament",
+    "name": "FilAr PLA Marron Oxido",
+    "inherits": "FilAr PLA @base",
+    "from": "system",
+    "filament_id": "FILAR0008",
+    "instantiation": "true",
+    "filament_vendor": [
+        "FilAr"
+    ],
+    "default_filament_colour": [
+        "#5E190E"
+    ]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA Naranja Tigre.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA Naranja Tigre.json
@@ -1,0 +1,14 @@
+{
+    "type": "filament",
+    "name": "FilAr PLA Naranja Tigre",
+    "inherits": "FilAr PLA @base",
+    "from": "system",
+    "filament_id": "FILAR0020",
+    "instantiation": "true",
+    "filament_vendor": [
+        "FilAr"
+    ],
+    "default_filament_colour": [
+        "#FC5017"
+    ]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA Negro Azabache.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA Negro Azabache.json
@@ -1,0 +1,14 @@
+{
+    "type": "filament",
+    "name": "FilAr PLA Negro Azabache",
+    "inherits": "FilAr PLA @base",
+    "from": "system",
+    "filament_id": "FILAR0019",
+    "instantiation": "true",
+    "filament_vendor": [
+        "FilAr"
+    ],
+    "default_filament_colour": [
+        "#000000"
+    ]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA Oro.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA Oro.json
@@ -1,0 +1,14 @@
+{
+    "type": "filament",
+    "name": "FilAr PLA Oro",
+    "inherits": "FilAr PLA @base",
+    "from": "system",
+    "filament_id": "FILAR0028",
+    "instantiation": "true",
+    "filament_vendor": [
+        "FilAr"
+    ],
+    "default_filament_colour": [
+        "#FFD700"
+    ]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA Piel.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA Piel.json
@@ -1,0 +1,14 @@
+{
+    "type": "filament",
+    "name": "FilAr PLA Piel",
+    "inherits": "FilAr PLA @base",
+    "from": "system",
+    "filament_id": "FILAR0012",
+    "instantiation": "true",
+    "filament_vendor": [
+        "FilAr"
+    ],
+    "default_filament_colour": [
+        "#FADDAC"
+    ]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA Rojo de Carreras.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA Rojo de Carreras.json
@@ -1,0 +1,14 @@
+{
+    "type": "filament",
+    "name": "FilAr PLA Rojo de Carreras",
+    "inherits": "FilAr PLA @base",
+    "from": "system",
+    "filament_id": "FILAR0021",
+    "instantiation": "true",
+    "filament_vendor": [
+        "FilAr"
+    ],
+    "default_filament_colour": [
+        "#FA0F0F"
+    ]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA Rosa Amaranto.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA Rosa Amaranto.json
@@ -1,0 +1,14 @@
+{
+    "type": "filament",
+    "name": "FilAr PLA Rosa Amaranto",
+    "inherits": "FilAr PLA @base",
+    "from": "system",
+    "filament_id": "FILAR0010",
+    "instantiation": "true",
+    "filament_vendor": [
+        "FilAr"
+    ],
+    "default_filament_colour": [
+        "#FA4164"
+    ]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA Rosa Flamenco.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA Rosa Flamenco.json
@@ -1,0 +1,14 @@
+{
+    "type": "filament",
+    "name": "FilAr PLA Rosa Flamenco",
+    "inherits": "FilAr PLA @base",
+    "from": "system",
+    "filament_id": "FILAR0011",
+    "instantiation": "true",
+    "filament_vendor": [
+        "FilAr"
+    ],
+    "default_filament_colour": [
+        "#FFC7C2"
+    ]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA Tabaco.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA Tabaco.json
@@ -1,0 +1,14 @@
+{
+    "type": "filament",
+    "name": "FilAr PLA Tabaco",
+    "inherits": "FilAr PLA @base",
+    "from": "system",
+    "filament_id": "FILAR0005",
+    "instantiation": "true",
+    "filament_vendor": [
+        "FilAr"
+    ],
+    "default_filament_colour": [
+        "#7D5429"
+    ]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA Titanio.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA Titanio.json
@@ -1,0 +1,14 @@
+{
+    "type": "filament",
+    "name": "FilAr PLA Titanio",
+    "inherits": "FilAr PLA @base",
+    "from": "system",
+    "filament_id": "FILAR0004",
+    "instantiation": "true",
+    "filament_vendor": [
+        "FilAr"
+    ],
+    "default_filament_colour": [
+        "#878681"
+    ]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA Verde FilAr.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA Verde FilAr.json
@@ -1,0 +1,14 @@
+{
+    "type": "filament",
+    "name": "FilAr PLA Verde FilAr",
+    "inherits": "FilAr PLA @base",
+    "from": "system",
+    "filament_id": "FILAR0013",
+    "instantiation": "true",
+    "filament_vendor": [
+        "FilAr"
+    ],
+    "default_filament_colour": [
+        "#036D6B"
+    ]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA Verde Manzana.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA Verde Manzana.json
@@ -1,0 +1,14 @@
+{
+    "type": "filament",
+    "name": "FilAr PLA Verde Manzana",
+    "inherits": "FilAr PLA @base",
+    "from": "system",
+    "filament_id": "FILAR0014",
+    "instantiation": "true",
+    "filament_vendor": [
+        "FilAr"
+    ],
+    "default_filament_colour": [
+        "#D4FF38"
+    ]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA Verde Oliva.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA Verde Oliva.json
@@ -1,0 +1,14 @@
+{
+    "type": "filament",
+    "name": "FilAr PLA Verde Oliva",
+    "inherits": "FilAr PLA @base",
+    "from": "system",
+    "filament_id": "FILAR0016",
+    "instantiation": "true",
+    "filament_vendor": [
+        "FilAr"
+    ],
+    "default_filament_colour": [
+        "#595900"
+    ]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA Verde Pixel.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA Verde Pixel.json
@@ -1,0 +1,14 @@
+{
+    "type": "filament",
+    "name": "FilAr PLA Verde Pixel",
+    "inherits": "FilAr PLA @base",
+    "from": "system",
+    "filament_id": "FILAR0015",
+    "instantiation": "true",
+    "filament_vendor": [
+        "FilAr"
+    ],
+    "default_filament_colour": [
+        "#02E32F"
+    ]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA Violeta Jacaranda.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA Violeta Jacaranda.json
@@ -1,0 +1,14 @@
+{
+    "type": "filament",
+    "name": "FilAr PLA Violeta Jacaranda",
+    "inherits": "FilAr PLA @base",
+    "from": "system",
+    "filament_id": "FILAR0023",
+    "instantiation": "true",
+    "filament_vendor": [
+        "FilAr"
+    ],
+    "default_filament_colour": [
+        "#9342C9"
+    ]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA-mate @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA-mate @base.json
@@ -1,0 +1,47 @@
+{
+    "type": "filament",
+    "name": "FilAr PLA-mate @base",
+    "inherits": "fdm_filament_pla",
+    "from": "system",
+    "filament_id": "FILARB02",
+    "instantiation": "false",
+    "filament_type": [
+        "PLA"
+    ],
+    "filament_vendor": [
+        "FilAr"
+    ],
+    "filament_diameter": [
+        "1.75"
+    ],
+    "filament_density": [
+        "1.24"
+    ],
+    "filament_flow_ratio": [
+        "0.98"
+    ],
+    "nozzle_temperature": [
+        "200"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "205"
+    ],
+    "nozzle_temperature_range_low": [
+        "195"
+    ],
+    "nozzle_temperature_range_high": [
+        "210"
+    ],
+    "hot_plate_temp": [
+        "60"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "60"
+    ],
+    "textured_plate_temp": [
+        "60"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "60"
+    ]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA-mate Amarillo.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA-mate Amarillo.json
@@ -1,0 +1,14 @@
+{
+    "type": "filament",
+    "name": "FilAr PLA-mate Amarillo",
+    "inherits": "FilAr PLA-mate @base",
+    "from": "system",
+    "filament_id": "FILAR0030",
+    "instantiation": "true",
+    "filament_vendor": [
+        "FilAr"
+    ],
+    "default_filament_colour": [
+        "#E8C547"
+    ]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA-mate Azul.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA-mate Azul.json
@@ -1,0 +1,14 @@
+{
+    "type": "filament",
+    "name": "FilAr PLA-mate Azul",
+    "inherits": "FilAr PLA-mate @base",
+    "from": "system",
+    "filament_id": "FILAR0031",
+    "instantiation": "true",
+    "filament_vendor": [
+        "FilAr"
+    ],
+    "default_filament_colour": [
+        "#2D5DA8"
+    ]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA-mate Beige.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA-mate Beige.json
@@ -1,0 +1,14 @@
+{
+    "type": "filament",
+    "name": "FilAr PLA-mate Beige",
+    "inherits": "FilAr PLA-mate @base",
+    "from": "system",
+    "filament_id": "FILAR0032",
+    "instantiation": "true",
+    "filament_vendor": [
+        "FilAr"
+    ],
+    "default_filament_colour": [
+        "#D8C4A0"
+    ]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA-mate Blanco.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA-mate Blanco.json
@@ -1,0 +1,14 @@
+{
+    "type": "filament",
+    "name": "FilAr PLA-mate Blanco",
+    "inherits": "FilAr PLA-mate @base",
+    "from": "system",
+    "filament_id": "FILAR0033",
+    "instantiation": "true",
+    "filament_vendor": [
+        "FilAr"
+    ],
+    "default_filament_colour": [
+        "#F2F2EC"
+    ]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA-mate Bordo.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA-mate Bordo.json
@@ -1,0 +1,14 @@
+{
+    "type": "filament",
+    "name": "FilAr PLA-mate Bordo",
+    "inherits": "FilAr PLA-mate @base",
+    "from": "system",
+    "filament_id": "FILAR0034",
+    "instantiation": "true",
+    "filament_vendor": [
+        "FilAr"
+    ],
+    "default_filament_colour": [
+        "#6E1A2B"
+    ]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA-mate Celeste Cielo.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA-mate Celeste Cielo.json
@@ -1,0 +1,14 @@
+{
+    "type": "filament",
+    "name": "FilAr PLA-mate Celeste Cielo",
+    "inherits": "FilAr PLA-mate @base",
+    "from": "system",
+    "filament_id": "FILAR0035",
+    "instantiation": "true",
+    "filament_vendor": [
+        "FilAr"
+    ],
+    "default_filament_colour": [
+        "#9DC8E8"
+    ]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA-mate Chocolate.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA-mate Chocolate.json
@@ -1,0 +1,14 @@
+{
+    "type": "filament",
+    "name": "FilAr PLA-mate Chocolate",
+    "inherits": "FilAr PLA-mate @base",
+    "from": "system",
+    "filament_id": "FILAR0036",
+    "instantiation": "true",
+    "filament_vendor": [
+        "FilAr"
+    ],
+    "default_filament_colour": [
+        "#4A2E22"
+    ]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA-mate Gris.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA-mate Gris.json
@@ -1,0 +1,14 @@
+{
+    "type": "filament",
+    "name": "FilAr PLA-mate Gris",
+    "inherits": "FilAr PLA-mate @base",
+    "from": "system",
+    "filament_id": "FILAR0037",
+    "instantiation": "true",
+    "filament_vendor": [
+        "FilAr"
+    ],
+    "default_filament_colour": [
+        "#7E7E7E"
+    ]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA-mate Marron.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA-mate Marron.json
@@ -1,0 +1,14 @@
+{
+    "type": "filament",
+    "name": "FilAr PLA-mate Marron",
+    "inherits": "FilAr PLA-mate @base",
+    "from": "system",
+    "filament_id": "FILAR0038",
+    "instantiation": "true",
+    "filament_vendor": [
+        "FilAr"
+    ],
+    "default_filament_colour": [
+        "#6B4226"
+    ]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA-mate Naranja.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA-mate Naranja.json
@@ -1,0 +1,14 @@
+{
+    "type": "filament",
+    "name": "FilAr PLA-mate Naranja",
+    "inherits": "FilAr PLA-mate @base",
+    "from": "system",
+    "filament_id": "FILAR0039",
+    "instantiation": "true",
+    "filament_vendor": [
+        "FilAr"
+    ],
+    "default_filament_colour": [
+        "#E0662A"
+    ]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA-mate Negro.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA-mate Negro.json
@@ -1,0 +1,14 @@
+{
+    "type": "filament",
+    "name": "FilAr PLA-mate Negro",
+    "inherits": "FilAr PLA-mate @base",
+    "from": "system",
+    "filament_id": "FILAR0040",
+    "instantiation": "true",
+    "filament_vendor": [
+        "FilAr"
+    ],
+    "default_filament_colour": [
+        "#1A1A1A"
+    ]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA-mate Piel.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA-mate Piel.json
@@ -1,0 +1,14 @@
+{
+    "type": "filament",
+    "name": "FilAr PLA-mate Piel",
+    "inherits": "FilAr PLA-mate @base",
+    "from": "system",
+    "filament_id": "FILAR0041",
+    "instantiation": "true",
+    "filament_vendor": [
+        "FilAr"
+    ],
+    "default_filament_colour": [
+        "#E8C9A8"
+    ]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA-mate Rojo.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA-mate Rojo.json
@@ -1,0 +1,14 @@
+{
+    "type": "filament",
+    "name": "FilAr PLA-mate Rojo",
+    "inherits": "FilAr PLA-mate @base",
+    "from": "system",
+    "filament_id": "FILAR0042",
+    "instantiation": "true",
+    "filament_vendor": [
+        "FilAr"
+    ],
+    "default_filament_colour": [
+        "#B5302E"
+    ]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA-mate Rosa.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA-mate Rosa.json
@@ -1,0 +1,14 @@
+{
+    "type": "filament",
+    "name": "FilAr PLA-mate Rosa",
+    "inherits": "FilAr PLA-mate @base",
+    "from": "system",
+    "filament_id": "FILAR0043",
+    "instantiation": "true",
+    "filament_vendor": [
+        "FilAr"
+    ],
+    "default_filament_colour": [
+        "#E07A9B"
+    ]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA-mate Uva.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA-mate Uva.json
@@ -1,0 +1,14 @@
+{
+    "type": "filament",
+    "name": "FilAr PLA-mate Uva",
+    "inherits": "FilAr PLA-mate @base",
+    "from": "system",
+    "filament_id": "FILAR0044",
+    "instantiation": "true",
+    "filament_vendor": [
+        "FilAr"
+    ],
+    "default_filament_colour": [
+        "#5B2A6B"
+    ]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA-mate Verde.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA-mate Verde.json
@@ -1,0 +1,14 @@
+{
+    "type": "filament",
+    "name": "FilAr PLA-mate Verde",
+    "inherits": "FilAr PLA-mate @base",
+    "from": "system",
+    "filament_id": "FILAR0045",
+    "instantiation": "true",
+    "filament_vendor": [
+        "FilAr"
+    ],
+    "default_filament_colour": [
+        "#3A7D44"
+    ]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA-mate Violeta.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA-mate Violeta.json
@@ -1,0 +1,14 @@
+{
+    "type": "filament",
+    "name": "FilAr PLA-mate Violeta",
+    "inherits": "FilAr PLA-mate @base",
+    "from": "system",
+    "filament_id": "FILAR0046",
+    "instantiation": "true",
+    "filament_vendor": [
+        "FilAr"
+    ],
+    "default_filament_colour": [
+        "#6B3FA0"
+    ]
+}


### PR DESCRIPTION
# Add FilAr filament vendor (PLA, PLA-mate, PETG)

This PR adds **FilAr**, an Argentine filament manufacturer, to the global `OrcaFilamentLibrary` so its filaments are available for all printers.

## What's included
- New vendor folder: `resources/profiles/OrcaFilamentLibrary/filament/FilAr/`
- 3 base profiles (`@base`, non-instantiated): `FilAr PLA @base`, `FilAr PLA-mate @base`, `FilAr PETG @base`, inheriting from `fdm_filament_pla` / `fdm_filament_pet`.
- 60 color presets (29 PLA, 17 PLA-mate, 14 PETG) inheriting from their respective `@base`.
- Registration of all 63 entries in `resources/profiles/OrcaFilamentLibrary.json` → `filament_list`.

## Profile parameters (per manufacturer datasheet)
- **PLA**: nozzle 210 °C (range 200–220), bed 60 °C.
- **PLA-mate**: nozzle 200 °C (range 195–210), bed 60 °C.
- **PETG**: nozzle 240 °C (range 230–250), bed 78 °C, reduced part cooling (40–60%).

Filament diameter 1.75 mm. Densities: PLA 1.24, PETG 1.27 g/cm³.

## Notes for reviewers
- Colors are set via `default_filament_colour`. PLA hex values come from FilAr's official catalog; PLA-mate and PETG hex are approximations (the catalog ships those lines without printed hex) and only affect the swatch, not printing.
- Temperatures follow the manufacturer's published ranges as a sensible baseline. Happy to refine any value or add per-printer tuned variants on request.

Submitted by the FilAr team. Website: https://www.filar.com.ar
