### PR TITLE
Z safe guard

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -3519,6 +3519,27 @@ void GCode::_do_export(Print& print, GCodeOutputStream &file, ThumbnailsGenerato
     update_placeholder_parser_with_variant_params();
 
     std::string machine_start_gcode = this->placeholder_parser_process("machine_start_gcode", print.config().machine_start_gcode.value, initial_extruder_id);
+
+    auto emit_z_clearance = [this, &file, initial_extruder_id]() {
+        const double height = m_config.initial_z_clearance_height.value;
+        if (height <= 0.)
+            return;
+
+        const double z_travel_speed = m_config.travel_speed_z.get_at(initial_extruder_id);
+        const double speed = z_travel_speed > 0.
+            ? z_travel_speed
+            : m_config.travel_speed.get_at(initial_extruder_id);
+
+        file.write_format(
+            "; Raise Z for clearance\n"
+            "G91\n"
+            "G1 Z%.3f F%.0f\n"
+            "G90\n",
+            height,
+            speed * 60.
+        );
+    };
+
     if (print.config().gcode_flavor != gcfKlipper) {
         // Set bed temperature if the start G-code does not contain any bed temp control G-codes.
         this->_print_first_layer_bed_temperature(file, print, machine_start_gcode, initial_extruder_id, true);
@@ -3536,6 +3557,10 @@ void GCode::_do_export(Print& print, GCodeOutputStream &file, ThumbnailsGenerato
             file.write(m_writer.set_chamber_temperature(max_chamber_temp, true)); // set chamber_temperature
     }
 
+    if (m_config.initial_z_clearance_placement.value == ZClearancePlacement::BeforeStartGCode ||
+        m_config.initial_z_clearance_placement.value == ZClearancePlacement::Both)
+        emit_z_clearance();
+
     // Write the custom start G-code
     file.writeln(machine_start_gcode);
     // Mark the end of the machine start g-code so the GCodeProcessor usage-block builder knows where user
@@ -3549,6 +3574,10 @@ void GCode::_do_export(Print& print, GCodeOutputStream &file, ThumbnailsGenerato
     //BBS: gcode writer doesn't know where the real position of extruder is after inserting custom gcode
     m_writer.set_current_position_clear(false);
     m_start_gcode_filament = GCodeProcessor::get_gcode_last_filament(machine_start_gcode);
+
+    if (m_config.initial_z_clearance_placement.value == ZClearancePlacement::AfterStartGCode ||
+        m_config.initial_z_clearance_placement.value == ZClearancePlacement::Both)
+        emit_z_clearance();
 
     if (is_bbl_printers) {
         m_writer.init_extruder(initial_non_support_extruder_id);

--- a/src/libslic3r/GCodeWriter.cpp
+++ b/src/libslic3r/GCodeWriter.cpp
@@ -869,11 +869,11 @@ std::string GCodeWriter::travel_to_xyz(const Vec3d &point, const std::string &co
         Vec3d target = { dest_point(0) - m_x_offset, dest_point(1) - m_y_offset, dest_point(2) };
         Vec3d delta = target - source;
         Vec2d delta_no_z = { delta(0), delta(1) };
-        //BBS: don'need slope travel because we don't know where is the source position the first time
+        //Orca: Only attempt slope/spiral/normal lift if current position is known
         //BBS: Also don't need to do slope move or spiral lift if x-y distance is absolute zero
-        if (delta(2) > 0 && delta_no_z.norm() != 0.0f)    {
+        if (delta(2) > 0 && delta_no_z.norm() != 0.0f && this->is_current_position_clear()) {
             //BBS: SpiralLift
-            if (m_to_lift_type == LiftType::SpiralLift && this->is_current_position_clear()) {
+            if (m_to_lift_type == LiftType::SpiralLift) {
                 //BBS: todo: check the arc move all in bed area, if not, then use lazy lift
                 double radius = delta(2) / (2 * PI * atan(this->filament()->travel_slope()));
                 Vec2d ij_offset = radius * delta_no_z.normalized();

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -1410,7 +1410,7 @@ static std::vector<std::string> s_Preset_printer_options {
     "nozzle_height", "master_extruder_id",
     "default_print_profile", "inherits",
     "silent_mode",
-    "scan_first_layer", "enable_power_loss_recovery", "wrapping_detection_layers", "wrapping_exclude_area", "machine_load_filament_time", "machine_unload_filament_time", "machine_tool_change_time", "time_cost", "machine_pause_gcode", "template_custom_gcode",
+    "scan_first_layer", "enable_power_loss_recovery", "initial_z_clearance_placement", "initial_z_clearance_height", "wrapping_detection_layers", "wrapping_exclude_area", "machine_load_filament_time", "machine_unload_filament_time", "machine_tool_change_time", "time_cost", "machine_pause_gcode", "template_custom_gcode",
     "nozzle_type", "nozzle_hrc","auxiliary_fan", "fan_direction", "nozzle_volume","upward_compatible_machine", "z_hop_types", "travel_slope", "retract_lift_enforce","support_chamber_temp_control","support_air_filtration","support_cooling_filter","cooling_filter_enabled","printer_structure","farthest_point_timelapse",
     "best_object_pos", "head_wrap_detect_zone",
     "host_type", "print_host", "printhost_apikey", "flashforge_serial_number", "bbl_use_printhost", "printer_agent",

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -206,6 +206,13 @@ static t_config_enum_values s_keys_map_CenterOfSurfacePattern{
     {"each_assembly", int(CenterOfSurfacePattern::Each_Assembly)}};
 CONFIG_OPTION_ENUM_DEFINE_STATIC_MAPS(CenterOfSurfacePattern)
 
+static t_config_enum_values s_keys_map_ZClearancePlacement {
+    { "before_start_gcode",      int(ZClearancePlacement::BeforeStartGCode) },
+    { "after_start_gcode",       int(ZClearancePlacement::AfterStartGCode) },
+    { "before_and_after_start_gcode", int(ZClearancePlacement::Both) }
+};
+CONFIG_OPTION_ENUM_DEFINE_STATIC_MAPS(ZClearancePlacement)
+
 static t_config_enum_values s_keys_map_FuzzySkinType {
     { "none",           int(FuzzySkinType::None) },
     { "external",       int(FuzzySkinType::External) },
@@ -4040,6 +4047,28 @@ void PrintConfigDef::init_fff_params()
     def->enum_labels.push_back(L("Enable"));
     def->enum_labels.push_back(L("Disable"));
     def->set_default_value(new ConfigOptionEnum<PowerLossRecoveryMode>(PowerLossRecoveryMode::PrinterConfiguration));
+    
+    def = this->add("initial_z_clearance_height", coFloat);
+    def->label = L("Height");
+    def->tooltip = L("Lift Z before initial travel moves to avoid nozzle collisions. Set to 0 to disable.");
+    def->sidetext = L("mm");
+    def->min = 0;
+    def->max = 10;
+    def->mode = comAdvanced;
+    def->set_default_value(new ConfigOptionFloat(0));
+
+    def = this->add("initial_z_clearance_placement", coEnum);
+    def->label = L("Placement");
+    def->tooltip = L("Choose where to insert the safety lift: before machine start G-code, after it, or both places.");
+    def->mode = comAdvanced;
+    def->enum_keys_map = &ConfigOptionEnum<ZClearancePlacement>::get_enum_values();
+    def->enum_values.push_back("before_start_gcode");
+    def->enum_values.push_back("after_start_gcode");
+    def->enum_values.push_back("before_and_after_start_gcode");
+    def->enum_labels.push_back(L("Before start G-code"));
+    def->enum_labels.push_back(L("After start G-code"));
+    def->enum_labels.push_back(L("Before and after start G-code"));
+    def->set_default_value(new ConfigOptionEnum<ZClearancePlacement>(ZClearancePlacement::AfterStartGCode));
 
     //BBS
     // def = this->add("spaghetti_detector", coBool);

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -177,6 +177,13 @@ enum class PowerLossRecoveryMode {
     Disable,
 };
 
+// Orca
+enum class ZClearancePlacement {
+    BeforeStartGCode,
+    AfterStartGCode,
+    Both,
+};
+
 // BBS
 enum class WallSequence {
     InnerOuter,
@@ -650,6 +657,7 @@ CONFIG_OPTION_ENUM_DECLARE_STATIC_MAPS(SlicingMode)
 CONFIG_OPTION_ENUM_DECLARE_STATIC_MAPS(SupportMaterialPattern)
 CONFIG_OPTION_ENUM_DECLARE_STATIC_MAPS(SupportMaterialStyle)
 CONFIG_OPTION_ENUM_DECLARE_STATIC_MAPS(SupportMaterialInterfacePattern)
+CONFIG_OPTION_ENUM_DECLARE_STATIC_MAPS(ZClearancePlacement)
 // BBS
 CONFIG_OPTION_ENUM_DECLARE_STATIC_MAPS(SupportType)
 CONFIG_OPTION_ENUM_DECLARE_STATIC_MAPS(SeamPosition)
@@ -1537,6 +1545,8 @@ PRINT_CONFIG_CLASS_DEFINE(
     // BBS
     ((ConfigOptionBool,                scan_first_layer))
     ((ConfigOptionEnum<PowerLossRecoveryMode>, enable_power_loss_recovery))
+    ((ConfigOptionEnum<ZClearancePlacement>, initial_z_clearance_placement))
+    ((ConfigOptionFloat,               initial_z_clearance_height))
     ((ConfigOptionBool,                enable_wrapping_detection))
     ((ConfigOptionInt,                 wrapping_detection_layers))
     ((ConfigOptionPoints,              wrapping_exclude_area))

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -5079,6 +5079,10 @@ void TabPrinter::build_fff()
         optgroup->append_single_option_line("extruder_clearance_height_to_rod", "printer_basic_information_extruder_clearance#height-to-rod");
         optgroup->append_single_option_line("extruder_clearance_height_to_lid", "printer_basic_information_extruder_clearance#height-to-lid");
 
+        optgroup = page->new_optgroup(L("Initial Z Clearance"), "param_extruder_clearance");
+        optgroup->append_single_option_line("initial_z_clearance_height");
+        optgroup->append_single_option_line("initial_z_clearance_placement");
+
         optgroup = page->new_optgroup(L("Adaptive bed mesh"), "param_adaptive_mesh");
         optgroup->append_single_option_line("bed_mesh_min", "printer_basic_information_adaptive_bed_mesh#bed-mesh");
         optgroup->append_single_option_line("bed_mesh_max", "printer_basic_information_adaptive_bed_mesh#bed-mesh");
@@ -6048,6 +6052,8 @@ void TabPrinter::toggle_options()
         // The cooling filter and air filtration are alternative accessories: show only the one the printer supports.
         toggle_line("support_air_filtration", !m_config->opt_bool("support_cooling_filter"));
         toggle_line("cooling_filter_enabled", m_config->opt_bool("support_cooling_filter"));
+
+        toggle_option("initial_z_clearance_placement", m_config->opt_float("initial_z_clearance_height") > 0.);
     }
 
 


### PR DESCRIPTION
This PR does two things:

#### 1. Adds a configurable initial Z clearance

A new printer setting allows inserting an upward relative Z move during startup. The clearance can be configured from 0 to 10 mm and can be inserted:

* before machine start G-code,
* after machine start G-code,
* or in both places.

This provides an explicit and configurable way to create vertical clearance between the nozzle and the print surface before startup travel movements. The insertion point is configurable because Orca cannot know what movements may occur inside user-defined machine start G-code or macros such as `START_PRINT`.

The setting is available under **Printer Settings → Basic information → Initial Z Clearance**, as shown below.

<img width="1297" height="677" alt="image" src="https://github.com/user-attachments/assets/5ca46217-960e-410b-9e00-8e3a503e4cbf" />

#### 2. Prevents Z-hop when the tool position is unknown

This part includes the fix from PR #10991.

Previously, Orca could emit a Z-hop even when the current tool position was unknown. The startup case discussed in PR #10991 was only one manifestation of this issue and occurred under the following combination of settings:

* Z-hop height is non-zero
* Z-hop type is set to Normal
* Only lift Z above is set to 0

The resulting Z movement was not an intentional safety feature, but rather a side effect of the normal Z-hop logic used before travel moves. Because it used absolute coordinates, it could just as easily produce a downward move, which is the opposite of what would be expected from a safety clearance mechanism.

The issue is not limited to startup movements. Any operation that allows firmware or user-defined macros to reposition the toolhead without Orca knowing the resulting position, such as tool changes, can leave the slicer without reliable position information. In such situations, generating a Z-hop is unsafe because Orca cannot determine whether the resulting move will raise the nozzle, leave it unchanged, or move it downward.

Some users nevertheless found the incidental startup Z movement beneficial because it occasionally provided additional clearance before the first travel move.

With the addition of a dedicated Initial Z Clearance feature, that behavior is no longer needed. Startup clearance is now provided by an explicit, configurable mechanism rather than by an accidental side effect of the Z-hop implementation. This makes it possible to adopt the fix from PR #10991 without losing the occasional benefit that some users observed.

Fixes https://github.com/OrcaSlicer/OrcaSlicer/issues/10964
