### PR TITLE
Fix: macOS Print/Export dropdown dismissed before the cursor reaches the menu (#12936)

### DIFF
--- a/src/slic3r/GUI/Widgets/SideMenuPopup.cpp
+++ b/src/slic3r/GUI/Widgets/SideMenuPopup.cpp
@@ -56,15 +56,22 @@ void SidePopup::Popup(wxWindow* focus)
     }
     if (focus) {
         wxPoint pos = focus->ClientToScreen(wxPoint(0, -6));
+        int anchor_h = focus->GetSize().y + 12;
 
 #ifdef __APPLE__
          pos.x = pos.x - FromDIP(20);
+         // Orca #12936: since the wxWidgets 3.3 upgrade the transient popup is dismissed the
+         // instant the cursor enters the gap between the button and the menu, making
+         // "Print -> Export" unselectable. Anchor the menu flush against the button (slight
+         // overlap) so there is no dead-zone for the cursor to cross.
+         pos.y = focus->ClientToScreen(wxPoint(0, 0)).y;
+         anchor_h = focus->GetSize().y - 2;
 #endif // __APPLE__
 
         if (pos.x + max_width > screenwidth)
-            Position({pos.x - (pos.x + max_width - screenwidth),pos.y}, {0, focus->GetSize().y + 12});
+            Position({pos.x - (pos.x + max_width - screenwidth), pos.y}, {0, anchor_h});
         else
-            Position(pos, {0, focus->GetSize().y + 12});
+            Position(pos, {0, anchor_h});
     }
     Slic3r::GUI::wxGetApp().set_side_menu_popup_status(true);
     PopupWindow::Popup();


### PR DESCRIPTION
# Description

Fixes #12936.

On macOS, since the wxWidgets 3.3 upgrade, the Print/Export split-button dropdown is dismissed the instant the cursor enters the gap between the button and the menu, so **"Export"** cannot be selected — the transient popup closes before the pointer reaches it.

The menu was anchored ~6 px below the button with an additional 12 px offset, leaving a dead-zone between the button and the menu. Under wx 3.3's transient-popup behavior, moving the cursor into that gap is treated as leaving the popup, which closes it.

This anchors the menu flush against the button (slight overlap) on macOS, removing the dead-zone:

- set `pos.y` to the button's screen top (instead of 6 px above it);
- use anchor height `button_height - 2` (slight overlap) instead of `button_height + 12`.

The change is guarded by `__APPLE__`; other platforms are unchanged.

## Tests

Built and ran on macOS (Apple Silicon, wxWidgets 3.3.2). Verified the Print → Export dropdown now stays open when moving from the button toward the menu and that "Export" is selectable; the primary slice/print action is unaffected.

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
