### PR TITLE
Fix MMU color painting shortcuts

### DIFF
--- a/src/libslic3r/MixedFilament.hpp
+++ b/src/libslic3r/MixedFilament.hpp
@@ -12,9 +12,9 @@ namespace Slic3r {
 
 // Represents a virtual "mixed" filament created from physical filaments
 // (layer cadence and/or same-layer interleaved stripe distribution). Display
-// colour blending uses FilamentMixer  so pair previews better
-//  match expected print mixing 
-// (for example Blue+Yellow -> Green, Red+Yellow -> Orange, Red+Blue -> Purple). 
+// colour blending uses FilamentMixer so pair previews better
+// match expected print mixing
+// (for example Blue+Yellow -> Green, Red+Yellow -> Orange, Red+Blue -> Purple).
 // Legacy RYB code is retained in source for reference only.
 struct MixedFilament
 {

--- a/src/slic3r/GUI/Gizmos/GLGizmoMmuSegmentation.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoMmuSegmentation.cpp
@@ -32,7 +32,10 @@ static inline void show_notification_extruders_limit_exceeded()
 
 void GLGizmoMmuSegmentation::on_opening()
 {
-    if (wxGetApp().filaments_cnt() > int(GLGizmoMmuSegmentation::EXTRUDERS_LIMIT))
+    const int total_filaments = wxGetApp().preset_bundle != nullptr ?
+        int(wxGetApp().preset_bundle->total_filament_count()) :
+        wxGetApp().filaments_cnt();
+    if (total_filaments > int(GLGizmoMmuSegmentation::EXTRUDERS_LIMIT))
         show_notification_extruders_limit_exceeded();
 }
 
@@ -201,10 +204,12 @@ void GLGizmoMmuSegmentation::data_changed(bool is_serializing)
 bool GLGizmoMmuSegmentation::on_number_key_down(int number)
 {
     int extruder_idx = number - 1;
-    if (extruder_idx < m_extruders_colors.size() && extruder_idx >= 0)
+    if (extruder_idx < int(std::min(m_extruders_colors.size(), GLGizmoMmuSegmentation::EXTRUDERS_LIMIT)) && extruder_idx >= 0) {
         m_selected_extruder_idx = extruder_idx;
+        return true;
+    }
 
-    return true;
+    return false;
 }
 
 bool GLGizmoMmuSegmentation::on_key_down_select_tool_type(int keyCode) {

--- a/src/slic3r/GUI/Gizmos/GLGizmosManager.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmosManager.cpp
@@ -32,6 +32,7 @@
 #include "libslic3r/Model.hpp"
 #include "libslic3r/PresetBundle.hpp"
 
+#include <algorithm>
 #include <wx/glcanvas.h>
 
 namespace Slic3r {
@@ -55,6 +56,52 @@ GLGizmosManager::GLGizmosManager(GLCanvas3D& parent)
     , m_object_manipulation(parent)
 {
     m_timer_set_color.Bind(wxEVT_TIMER, &GLGizmosManager::on_set_color_timer, this);
+}
+
+MmuSegmentationColorShortcutResult resolve_mmu_segmentation_color_shortcut(int digit, int shortcut_max, int pending_tens)
+{
+    MmuSegmentationColorShortcutResult out;
+    if (digit < 0 || digit > 9)
+        return out;
+
+    out.processed = true;
+    shortcut_max = std::max(0, shortcut_max);
+
+    auto can_start_two_digit = [shortcut_max](int d) {
+        return d > 0 && d * 10 <= shortcut_max;
+    };
+    auto can_select_single_digit = [shortcut_max](int d) {
+        return d > 0 && d <= shortcut_max;
+    };
+
+    if (pending_tens > 0) {
+        out.stop_timer = true;
+        const int two_digit_shortcut = pending_tens * 10 + digit;
+        if (two_digit_shortcut <= shortcut_max) {
+            out.select_now = two_digit_shortcut;
+            return out;
+        }
+
+        if (can_start_two_digit(digit)) {
+            out.select_now = can_select_single_digit(pending_tens) ? pending_tens : 0;
+            out.pending_tens = digit;
+            out.start_timer = true;
+            return out;
+        }
+
+        out.select_now = can_select_single_digit(digit) ? digit :
+                         can_select_single_digit(pending_tens) ? pending_tens : 0;
+        return out;
+    }
+
+    if (can_start_two_digit(digit)) {
+        out.pending_tens = digit;
+        out.start_timer = true;
+    } else if (can_select_single_digit(digit)) {
+        out.select_now = digit;
+    }
+
+    return out;
 }
 
 std::vector<size_t> GLGizmosManager::get_selectable_idxs() const
@@ -942,7 +989,7 @@ bool GLGizmosManager::on_key(wxKeyEvent& evt)
             }
         }
         // BBS
-        if (m_current == MmSegmentation && keyCode > '0' && keyCode <= '9') {
+        if (m_current == MmSegmentation && keyCode >= '0' && keyCode <= '9') {
             // capture number key
             processed = true;
         }
@@ -999,42 +1046,27 @@ bool GLGizmosManager::on_key(wxKeyEvent& evt)
                 }
                 if (keyCode >= '0' && keyCode <= '9') {
                     const int digit = keyCode - '0';
-                    const int shortcut_max = int(GLGizmoMmuSegmentation::EXTRUDERS_LIMIT);
-                    auto select_shortcut = [mmu_seg](int number) {
-                        return number > 0 && mmu_seg->on_number_key_down(number);
-                    };
+                    const int total_filaments = wxGetApp().preset_bundle != nullptr ?
+                        int(wxGetApp().preset_bundle->total_filament_count()) :
+                        wxGetApp().filaments_cnt();
+                    const int shortcut_max = std::min(total_filaments, int(GLGizmoMmuSegmentation::EXTRUDERS_LIMIT));
+                    const MmuSegmentationColorShortcutResult shortcut =
+                        resolve_mmu_segmentation_color_shortcut(
+                            digit,
+                            shortcut_max,
+                            m_timer_set_color.IsRunning() ? m_pending_color_shortcut_tens : 0);
 
-                    if (m_timer_set_color.IsRunning() && m_pending_color_shortcut_tens > 0) {
-                        const int two_digit_shortcut = m_pending_color_shortcut_tens * 10 + digit;
-                        if (two_digit_shortcut <= shortcut_max) {
-                            processed = select_shortcut(two_digit_shortcut);
-                            m_pending_color_shortcut_tens = 0;
-                            m_timer_set_color.Stop();
-                        } else {
-                            // Fall back to the pending single-digit shortcut and then process current digit as fresh input.
-                            processed = select_shortcut(m_pending_color_shortcut_tens);
-                            m_pending_color_shortcut_tens = 0;
-                            m_timer_set_color.Stop();
+                    if (shortcut.stop_timer)
+                        m_timer_set_color.Stop();
 
-                            const bool can_start_two_digit = digit > 0 && digit * 10 <= shortcut_max;
-                            if (can_start_two_digit) {
-                                m_pending_color_shortcut_tens = digit;
-                                m_timer_set_color.StartOnce(500);
-                                processed = true;
-                            } else {
-                                processed = select_shortcut(digit) || processed;
-                            }
-                        }
-                    } else {
-                        const bool can_start_two_digit = digit > 0 && digit * 10 <= shortcut_max;
-                        if (can_start_two_digit) {
-                            m_pending_color_shortcut_tens = digit;
-                            m_timer_set_color.StartOnce(500);
-                            processed = true;
-                        } else {
-                            processed = select_shortcut(digit);
-                        }
-                    }
+                    if (shortcut.select_now > 0)
+                        processed = mmu_seg->on_number_key_down(shortcut.select_now) || processed;
+
+                    m_pending_color_shortcut_tens = shortcut.pending_tens;
+                    if (shortcut.start_timer)
+                        m_timer_set_color.StartOnce(500);
+
+                    processed = shortcut.processed || processed;
                 }
                 else if (keyCode == 'F' || keyCode == 'T' || keyCode == 'S' || keyCode == 'C' || keyCode == 'H' || keyCode == 'G') {
                     processed = mmu_seg->on_key_down_select_tool_type(keyCode);

--- a/src/slic3r/GUI/Gizmos/GLGizmosManager.hpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmosManager.hpp
@@ -30,6 +30,18 @@ enum class SLAGizmoEventType : unsigned char;
 class CommonGizmosDataPool;
 //BBS: GUI refactor: add object manipulation
 class GizmoObjectManipulation;
+
+struct MmuSegmentationColorShortcutResult
+{
+    int  select_now = 0;
+    int  pending_tens = 0;
+    bool start_timer = false;
+    bool stop_timer = false;
+    bool processed = false;
+};
+
+MmuSegmentationColorShortcutResult resolve_mmu_segmentation_color_shortcut(int digit, int shortcut_max, int pending_tens);
+
 class Rect
 {
     float m_left{ 0.0f };

--- a/tests/slic3rutils/CMakeLists.txt
+++ b/tests/slic3rutils/CMakeLists.txt
@@ -1,6 +1,7 @@
 get_filename_component(_TEST_NAME ${CMAKE_CURRENT_LIST_DIR} NAME)
 add_executable(${_TEST_NAME}_tests
     ${_TEST_NAME}_tests_main.cpp
+    test_mmu_segmentation_shortcuts.cpp
     )
 
 if (MSVC)

--- a/tests/slic3rutils/test_mmu_segmentation_shortcuts.cpp
+++ b/tests/slic3rutils/test_mmu_segmentation_shortcuts.cpp
@@ -1,0 +1,65 @@
+#include <catch2/catch_all.hpp>
+
+#include "slic3r/GUI/Gizmos/GLGizmosManager.hpp"
+
+using Slic3r::GUI::MmuSegmentationColorShortcutResult;
+using Slic3r::GUI::resolve_mmu_segmentation_color_shortcut;
+
+TEST_CASE("MMU segmentation color shortcuts use the available filament count", "[GLGizmosManager][MmSegmentation]")
+{
+    SECTION("single digit colors select immediately when no two digit color is possible") {
+        const MmuSegmentationColorShortcutResult shortcut = resolve_mmu_segmentation_color_shortcut(1, 4, 0);
+        CHECK(shortcut.select_now == 1);
+        CHECK(shortcut.pending_tens == 0);
+        CHECK_FALSE(shortcut.start_timer);
+        CHECK_FALSE(shortcut.stop_timer);
+        CHECK(shortcut.processed);
+    }
+
+    SECTION("valid two digit colors defer the first digit and select on the second") {
+        const MmuSegmentationColorShortcutResult first = resolve_mmu_segmentation_color_shortcut(1, 12, 0);
+        CHECK(first.select_now == 0);
+        CHECK(first.pending_tens == 1);
+        CHECK(first.start_timer);
+
+        const MmuSegmentationColorShortcutResult second = resolve_mmu_segmentation_color_shortcut(2, 12, first.pending_tens);
+        CHECK(second.select_now == 12);
+        CHECK(second.pending_tens == 0);
+        CHECK_FALSE(second.start_timer);
+        CHECK(second.stop_timer);
+    }
+
+    SECTION("invalid two digit colors fall back to the fresh single digit") {
+        const MmuSegmentationColorShortcutResult shortcut = resolve_mmu_segmentation_color_shortcut(7, 16, 1);
+        CHECK(shortcut.select_now == 7);
+        CHECK(shortcut.pending_tens == 0);
+        CHECK_FALSE(shortcut.start_timer);
+        CHECK(shortcut.stop_timer);
+    }
+
+    SECTION("21 and 32 are reachable when mixed virtual filaments make them available") {
+        const MmuSegmentationColorShortcutResult twenty_first = resolve_mmu_segmentation_color_shortcut(1, 21, 2);
+        CHECK(twenty_first.select_now == 21);
+        CHECK(twenty_first.pending_tens == 0);
+        CHECK(twenty_first.stop_timer);
+
+        const MmuSegmentationColorShortcutResult thirty_first = resolve_mmu_segmentation_color_shortcut(3, 32, 0);
+        CHECK(thirty_first.select_now == 0);
+        CHECK(thirty_first.pending_tens == 3);
+        CHECK(thirty_first.start_timer);
+
+        const MmuSegmentationColorShortcutResult thirty_second =
+            resolve_mmu_segmentation_color_shortcut(2, 32, thirty_first.pending_tens);
+        CHECK(thirty_second.select_now == 32);
+        CHECK(thirty_second.pending_tens == 0);
+        CHECK(thirty_second.stop_timer);
+    }
+
+    SECTION("zero is consumed but never selects a filament") {
+        const MmuSegmentationColorShortcutResult shortcut = resolve_mmu_segmentation_color_shortcut(0, 9, 0);
+        CHECK(shortcut.select_now == 0);
+        CHECK(shortcut.pending_tens == 0);
+        CHECK_FALSE(shortcut.start_timer);
+        CHECK(shortcut.processed);
+    }
+}


### PR DESCRIPTION
Targets the `FullSpectrum_integration` branch used by OrcaSlicer/OrcaSlicer#13437.

## Summary
- Use the total filament count, including mixed virtual filaments, for MMU color painting shortcut limits.
- Allow two-digit color shortcuts through the painting limit, including shortcuts that require `0` as the second digit.
- Reject out-of-range shortcut selections instead of reporting them as handled.
- Add focused Catch2 coverage for the shortcut state machine.

## Validation
- `git diff --cached --check` passed before commit.
- `git diff --check` is clean after commit.
- Existing upstream PR #13437 checks are green.

Local build/test execution was not run in this checkout because the built Orca dependency bundle is not present.