### PR TITLE
Fix junction deviation and jerk settings behavior

### DIFF
--- a/resources/images/param_junction_deviation.svg
+++ b/resources/images/param_junction_deviation.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 18 18">
+  <line x1="0.5" y1="4.5" x2="7.5" y2="4.5" style="fill:none;stroke:#949494;stroke-linecap:square;stroke-linejoin:round"/>
+  <line x1="15.5" y1="4.5" x2="16.5" y2="4.5" style="fill:none;stroke:#949494;stroke-linecap:square;stroke-linejoin:round"/>
+  <rect x="7.5" y="0.5" width="8" height="13" rx="1" style="fill:none;stroke:#949494;stroke-linecap:round;stroke-linejoin:round"/>
+  <circle cx="11.5" cy="7.5" r="2" style="fill:none;stroke:#949494;stroke-linecap:round;stroke-linejoin:round"/>
+  <polyline points="9.5 13.5 11.5 16.5 13.5 13.5" style="fill:none;stroke:#949494;stroke-linecap:round;stroke-linejoin:round"/>
+
+  <path d="M1.5 6.2 L1.5 11.6 C1.5 14.0 3.0 15.5 5.4 15.5 L8.2 15.5"
+        style="fill:none;stroke:#009688;stroke-linecap:round;stroke-linejoin:round"/>
+</svg>

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -1836,15 +1836,12 @@ StringObjectException Print::validate(StringObjectException *warning, Polygons* 
                    }
                 }
             }
-
-            // Check junction deviation
-            // Orca: Only marlin FW supports max junction deviation. Dont display warning if firmware is not supporting it.
-            const bool support_max_junction_deviation = ( m_config.gcode_flavor == gcfMarlinFirmware);
-            if (warning_key.empty() && m_default_object_config.default_junction_deviation.value > max_junction_deviation && support_max_junction_deviation) {
+            // check junction deviation
+            else if (m_default_object_config.default_junction_deviation.value > max_junction_deviation) {
                 warning->string  = L( "Junction deviation setting exceeds the printer's maximum value (machine_max_junction_deviation).\n"
                                       "Orca will automatically cap the junction deviation to ensure it doesn't surpass the printer's capabilities.\n"
                                       "You can adjust the machine_max_junction_deviation value in your printer's configuration to get higher limits.");
-                warning->opt_key = warning_key;
+                warning->opt_key = "default_junction_deviation";
             }
             
             // check acceleration

--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -681,15 +681,14 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig *config, co
             machine_supports_junction_deviation = !machine_jd->values.empty() && machine_jd->values.front() > 0.0;
         }
     }
-    toggle_line("default_junction_deviation", gcflavor == gcfMarlinFirmware);
+
     if (machine_supports_junction_deviation) {
-        toggle_field("default_junction_deviation", true);
-        toggle_field("default_jerk", false);
-        for (auto el : { "outer_wall_jerk", "inner_wall_jerk", "initial_layer_jerk", "initial_layer_travel_jerk", "top_surface_jerk", "travel_jerk", "infill_jerk"})
+        toggle_line("default_junction_deviation", true);
+        for (auto el : { "default_jerk", "outer_wall_jerk", "inner_wall_jerk", "initial_layer_jerk", "initial_layer_travel_jerk", "top_surface_jerk", "travel_jerk", "infill_jerk"})
             toggle_line(el, false);
     } else {
-        toggle_field("default_junction_deviation", false);
-        toggle_field("default_jerk", true);
+        toggle_line("default_junction_deviation", false);
+        toggle_line("default_jerk", true);
         bool have_default_jerk = config->has("default_jerk") && config->opt_float("default_jerk") > 0;
         for (auto el : { "outer_wall_jerk", "inner_wall_jerk", "initial_layer_jerk", "initial_layer_travel_jerk", "top_surface_jerk", "travel_jerk", "infill_jerk"}) {
             toggle_line(el, true);

--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -571,7 +571,11 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig *config, co
 {
     PresetBundle *preset_bundle  = wxGetApp().preset_bundle;
 
-    auto gcflavor = preset_bundle->printers.get_edited_preset().config.option<ConfigOptionEnum<GCodeFlavor>>("gcode_flavor")->value;
+    const GCodeFlavor gcflavor = preset_bundle->printers.get_edited_preset().config.option<ConfigOptionEnum<GCodeFlavor>>("gcode_flavor")->value;
+
+    // Orca: use booleans to avoid repeated comparisons with enum values
+    const bool gcf_is_marlin_firmware = gcflavor == GCodeFlavor::gcfMarlinFirmware;
+    const bool gcf_is_klipper = gcflavor == GCodeFlavor::gcfKlipper;
 
     bool have_volumetric_extrusion_rate_slope = config->option<ConfigOptionFloat>("max_volumetric_extrusion_rate_slope")->value > 0;
     float have_volumetric_extrusion_rate_slope_segment_length = config->option<ConfigOptionFloat>("max_volumetric_extrusion_rate_slope_segment_length")->value;
@@ -675,22 +679,28 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig *config, co
         "top_surface_acceleration", "travel_acceleration", "bridge_acceleration", "sparse_infill_acceleration", "internal_solid_infill_acceleration"})
         toggle_field(el, have_default_acceleration);
 
-    bool machine_supports_junction_deviation = false;
-    if (gcflavor == gcfMarlinFirmware) {
-        if (const auto *machine_jd = preset_bundle->printers.get_edited_preset().config.option<ConfigOptionFloats>("machine_max_junction_deviation")) {
-            machine_supports_junction_deviation = !machine_jd->values.empty() && machine_jd->values.front() > 0.0;
-        }
-    }
+    const bool junction_deviation_enabled =
+        gcf_is_marlin_firmware &&
+        [&]() {
+            const auto *machine_jd = preset_bundle->printers.get_edited_preset().config.option<ConfigOptionFloats>("machine_max_junction_deviation");
+            return machine_jd && !machine_jd->values.empty() && machine_jd->values.front() > 0.0;
+        }();
 
-    if (machine_supports_junction_deviation) {
-        toggle_line("default_junction_deviation", true);
-        for (auto el : { "default_jerk", "outer_wall_jerk", "inner_wall_jerk", "initial_layer_jerk", "initial_layer_travel_jerk", "top_surface_jerk", "travel_jerk", "infill_jerk"})
+    toggle_line("default_junction_deviation", gcf_is_marlin_firmware);
+    toggle_field("default_junction_deviation", junction_deviation_enabled);
+    toggle_field("default_jerk", !junction_deviation_enabled);
+
+    const std::initializer_list<const char*> jerk_options = {
+        "outer_wall_jerk", "inner_wall_jerk", "initial_layer_jerk",
+        "initial_layer_travel_jerk", "top_surface_jerk", "travel_jerk", "infill_jerk"
+    };
+
+    if (junction_deviation_enabled) {
+        for (auto el : jerk_options)
             toggle_line(el, false);
     } else {
-        toggle_line("default_junction_deviation", false);
-        toggle_line("default_jerk", true);
-        bool have_default_jerk = config->has("default_jerk") && config->opt_float("default_jerk") > 0;
-        for (auto el : { "outer_wall_jerk", "inner_wall_jerk", "initial_layer_jerk", "initial_layer_travel_jerk", "top_surface_jerk", "travel_jerk", "infill_jerk"}) {
+        const bool have_default_jerk = config->has("default_jerk") && config->opt_float("default_jerk") > 0;
+        for (auto el : jerk_options) {
             toggle_line(el, true);
             toggle_field(el, have_default_jerk);
         }
@@ -903,8 +913,8 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig *config, co
     toggle_field("wipe_speed",!is_role_based_wipe_speed);
 
     for (auto el : {"accel_to_decel_enable", "accel_to_decel_factor"})
-        toggle_line(el, gcflavor == gcfKlipper);
-    if(gcflavor == gcfKlipper)
+        toggle_line(el, gcf_is_klipper);
+    if(gcf_is_klipper)
         toggle_field("accel_to_decel_factor", config->opt_bool("accel_to_decel_enable"));
 
     bool have_make_overhang_printable = config->opt_bool("make_overhang_printable");

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -2559,8 +2559,10 @@ void TabPrint::build()
         optgroup->append_single_option_line("accel_to_decel_enable", "speed_settings_acceleration");
         optgroup->append_single_option_line("accel_to_decel_factor", "speed_settings_acceleration");
 
-        optgroup = page->new_optgroup(L("Jerk(XY)"), L"param_jerk", 15);
+        optgroup = page->new_optgroup(L("Junction Deviation"), L"param_junction_deviation", 15);
         optgroup->append_single_option_line("default_junction_deviation", "speed_settings_jerk_xy#junction-deviation");
+
+        optgroup = page->new_optgroup(L("Jerk(XY)"), L"param_jerk", 15);
         optgroup->append_single_option_line("default_jerk", "speed_settings_jerk_xy#default");
         optgroup->append_single_option_line("outer_wall_jerk", "speed_settings_jerk_xy#outer-wall");
         optgroup->append_single_option_line("inner_wall_jerk", "speed_settings_jerk_xy#inner-wall");
@@ -5580,10 +5582,10 @@ void TabPrinter::toggle_options()
         update_input_shaper_menu(gcf);
 
         // Orca: use booleans to avoid repeated comparisons with enum values
-        bool gcf_is_marlin_legacy = gcf == GCodeFlavor::gcfMarlinLegacy;
-        bool gcf_is_marlin_firmware = gcf == GCodeFlavor::gcfMarlinFirmware;
-        bool gcf_is_klipper = gcf == GCodeFlavor::gcfKlipper;
-        bool gcf_is_reprap_firmware = gcf == GCodeFlavor::gcfRepRapFirmware;
+        const bool gcf_is_marlin_legacy = gcf == GCodeFlavor::gcfMarlinLegacy;
+        const bool gcf_is_marlin_firmware = gcf == GCodeFlavor::gcfMarlinFirmware;
+        const bool gcf_is_klipper = gcf == GCodeFlavor::gcfKlipper;
+        const bool gcf_is_reprap_firmware = gcf == GCodeFlavor::gcfRepRapFirmware;
 
         bool silent_mode = m_config->opt_bool("silent_mode");
         int  max_field   = silent_mode ? 2 : 1;

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -5445,8 +5445,8 @@ void TabPrinter::toggle_options()
         for (auto el : {"use_firmware_retraction", "use_relative_e_distances", "support_multi_bed_types", "pellet_modded_printer", "bed_mesh_max", "bed_mesh_min", "bed_mesh_probe_distance", "adaptive_bed_mesh_margin", "thumbnails"})
           toggle_line(el, !is_BBL_printer);
 
-        auto gcf = m_config->option<ConfigOptionEnum<GCodeFlavor>>("gcode_flavor")->value;
-        toggle_line("enable_power_loss_recovery", is_BBL_printer || gcf == gcfMarlinFirmware);
+        bool gcf_is_marlin_firmware = m_config->option<ConfigOptionEnum<GCodeFlavor>>("gcode_flavor")->value == GCodeFlavor::gcfMarlinFirmware;
+        toggle_line("enable_power_loss_recovery", is_BBL_printer || gcf_is_marlin_firmware);
 
         const bool support_parallel_printheads = printer_cfg.opt_bool("support_parallel_printheads");
         toggle_line("parallel_printheads_count", support_parallel_printheads);
@@ -5578,18 +5578,25 @@ void TabPrinter::toggle_options()
     if (m_active_page->title() == L("Motion ability")) {
         auto gcf = m_config->option<ConfigOptionEnum<GCodeFlavor>>("gcode_flavor")->value;
         update_input_shaper_menu(gcf);
+
+        // Orca: use booleans to avoid repeated comparisons with enum values
+        bool gcf_is_marlin_legacy = gcf == GCodeFlavor::gcfMarlinLegacy;
+        bool gcf_is_marlin_firmware = gcf == GCodeFlavor::gcfMarlinFirmware;
+        bool gcf_is_klipper = gcf == GCodeFlavor::gcfKlipper;
+        bool gcf_is_reprap_firmware = gcf == GCodeFlavor::gcfRepRapFirmware;
+
         bool silent_mode = m_config->opt_bool("silent_mode");
         int  max_field   = silent_mode ? 2 : 1;
         for (int i = 0; i < max_field; ++i)
-            toggle_option("machine_max_acceleration_travel", gcf != gcfMarlinLegacy && gcf != gcfKlipper, i);
-        toggle_line("machine_max_acceleration_travel", gcf != gcfMarlinLegacy && gcf != gcfKlipper);
+            toggle_option("machine_max_acceleration_travel", !gcf_is_marlin_legacy && !gcf_is_klipper, i);
+        toggle_line("machine_max_acceleration_travel", !gcf_is_marlin_legacy && !gcf_is_klipper);
         for (int i = 0; i < max_field; ++i)
-            toggle_option("machine_max_junction_deviation", gcf == gcfMarlinFirmware, i);
-        toggle_line("machine_max_junction_deviation", gcf == gcfMarlinFirmware);
+            toggle_option("machine_max_junction_deviation", gcf_is_marlin_firmware, i);
+        toggle_line("machine_max_junction_deviation", gcf_is_marlin_firmware);
 
         // Check if junction deviation value is non-zero and firmware is Marlin
-        bool enable_jerk = gcf != gcfMarlinFirmware;
-        if (gcf == gcfMarlinFirmware) {
+        bool enable_jerk = !gcf_is_marlin_firmware;
+        if (gcf_is_marlin_firmware) {
             const auto *junction_deviation = m_config->option<ConfigOptionFloats>("machine_max_junction_deviation");
             if (junction_deviation != nullptr) {
                 const auto &values = junction_deviation->values;
@@ -5605,14 +5612,14 @@ void TabPrinter::toggle_options()
             toggle_option("machine_max_jerk_e", enable_jerk, i);
         }
 
-        bool emittable_limits = m_config->opt_enum<GCodeFlavor>("gcode_flavor") == GCodeFlavor::gcfMarlinLegacy || m_config->opt_enum<GCodeFlavor>("gcode_flavor") == GCodeFlavor::gcfMarlinFirmware || m_config->opt_enum<GCodeFlavor>("gcode_flavor") == GCodeFlavor::gcfRepRapFirmware;
+        bool emittable_limits = gcf_is_marlin_legacy || gcf_is_marlin_firmware || gcf_is_reprap_firmware;
         toggle_option("emit_machine_limits_to_gcode", emittable_limits);
 
         bool resonance_avoidance = m_config->opt_bool("resonance_avoidance");
         toggle_option("min_resonance_avoidance_speed", resonance_avoidance);
         toggle_option("max_resonance_avoidance_speed", resonance_avoidance);
 
-        bool input_shaping_compatible = m_config->opt_enum<GCodeFlavor>("gcode_flavor") == GCodeFlavor::gcfMarlinFirmware || m_config->opt_enum<GCodeFlavor>("gcode_flavor") == GCodeFlavor::gcfRepRapFirmware;
+        bool input_shaping_compatible = gcf_is_marlin_firmware || gcf_is_reprap_firmware;
 
         for (auto is : {"input_shaping_emit", "input_shaping_type", "input_shaping_freq_x", "input_shaping_freq_y",
                             "input_shaping_damp_x", "input_shaping_damp_y"})
@@ -5622,12 +5629,11 @@ void TabPrinter::toggle_options()
             bool emit_machine_limits_to_gcode = m_config->opt_bool("emit_machine_limits_to_gcode");
             toggle_option("input_shaping_emit", emit_machine_limits_to_gcode);
             bool input_shaping_emit = emit_machine_limits_to_gcode && m_config->opt_bool("input_shaping_emit");
-            bool reprap = m_config->opt_enum<GCodeFlavor>("gcode_flavor") == GCodeFlavor::gcfRepRapFirmware;
             toggle_option("input_shaping_type", input_shaping_emit);
             toggle_option("input_shaping_freq_x", input_shaping_emit);
-            toggle_option("input_shaping_freq_y", input_shaping_emit && !reprap);
+            toggle_option("input_shaping_freq_y", input_shaping_emit && !gcf_is_reprap_firmware);
             toggle_option("input_shaping_damp_x", input_shaping_emit);
-            toggle_option("input_shaping_damp_y", input_shaping_emit && !reprap);
+            toggle_option("input_shaping_damp_y", input_shaping_emit && !gcf_is_reprap_firmware);
         }
 
     }


### PR DESCRIPTION
## Description
This change improves how OrcaSlicer handles Marlin junction deviation and jerk settings.

When a Marlin printer profile has a non-zero `machine_max_junction_deviation`, process profiles now expose `default_junction_deviation` and hide the jerk controls. When junction deviation is disabled by setting `machine_max_junction_deviation = 0`, Orca now hides `default_junction_deviation`, restores the jerk settings, and no longer reports a junction deviation mismatch warning for the disabled JD path.

## Reasoning

Junction deviation and jerk are mutually exclusive motion-control approaches in this UI flow. Previously, Orca could still warn about a junction deviation mismatch even when junction deviation was effectively disabled on the printer with `machine_max_junction_deviation = 0`.

This made the warning misleading, because there was no active junction deviation limit for the process setting to match. The UI also left irrelevant controls visible or disabled instead of clearly showing the active control set.

## What Changed

* `default_junction_deviation` is shown only when the selected printer uses Marlin firmware and `machine_max_junction_deviation > 0`.
* Process jerk settings are hidden while junction deviation is active.
* Process jerk settings are restored when junction deviation is disabled or unsupported.
* Junction deviation validation is now scoped to the active JD path, avoiding mismatch warnings when `machine_max_junction_deviation = 0`.
* If the process JD value exceeds the printer JD limit while JD is active, the warning now points directly to `default_junction_deviation`.
* Simplified firmware-specific visibility checks by reusing local firmware-flavor booleans instead of repeating enum comparisons.
<br>
Fixes #14000
<br>

## Screenshots

|Before|After|
|---|---|
|<img width="560" height="514" alt="image" src="https://github.com/user-attachments/assets/67bce175-85f1-4c96-b897-e99b5e1a293f" />|<img width="557" height="464" alt="image" src="https://github.com/user-attachments/assets/c2362a94-ead1-467d-9c4d-7691c08c1b98" />|
|<img width="558" height="214" alt="image" src="https://github.com/user-attachments/assets/aad63060-a7d8-420a-ad40-9abfb3386152" />|<img width="546" height="158" alt="image" src="https://github.com/user-attachments/assets/44a1f7c1-f3c8-4a6a-99fd-8e9517744246" />|
|<img width="643" height="239" alt="image" src="https://github.com/user-attachments/assets/7ba96d53-9429-48e9-9487-7c5fd14511b9" />|<img width="646" height="242" alt="image" src="https://github.com/user-attachments/assets/3abfc779-ddb9-48e9-ab28-d5c3df686ca5" />|