### PR TITLE
[FIX] Fix Elegoo process profiles

### DIFF
--- a/resources/profiles/Elegoo.json
+++ b/resources/profiles/Elegoo.json
@@ -1,6 +1,6 @@
 {
 	"name": "Elegoo",
-	"version": "02.04.00.01",
+	"version": "02.04.00.02",
 	"force_update": "0",
 	"description": "Elegoo configurations",
 	"machine_model_list": [
@@ -287,6 +287,10 @@
 			"sub_path": "process/EN2SERIES/0.40mm Standard @Elegoo Neptune 0.8 nozzle.json"
 		},
 		{
+			"name": "0.50mm Standard @Elegoo Giga 1.0 nozzle",
+			"sub_path": "process/EOSGIGA/0.50mm Standard @Elegoo Giga 1.0 nozzle.json"
+		},
+		{
 			"name": "0.50mm Standard @Elegoo N3Max 1.0 nozzle",
 			"sub_path": "process/EN3SERIES/0.50mm Standard @Elegoo N3Max 1.0 nozzle.json"
 		},
@@ -313,6 +317,42 @@
 		{
 			"name": "0.50mm Standard @Elegoo N4Pro 1.0 nozzle",
 			"sub_path": "process/EN4SERIES/0.50mm Standard @Elegoo N4Pro 1.0 nozzle.json"
+		},
+		{
+			"name": "0.08mm Optimal @Elegoo C 0.2 nozzle",
+			"sub_path": "process/EC/0.08mm Optimal @Elegoo C 0.2 nozzle.json"
+		},
+		{
+			"name": "0.12mm Draft @Elegoo C 0.2 nozzle",
+			"sub_path": "process/EC/0.12mm Draft @Elegoo C 0.2 nozzle.json"
+		},
+		{
+			"name": "0.14mm Extra Draft @Elegoo C 0.2 nozzle",
+			"sub_path": "process/EC/0.14mm Extra Draft @Elegoo C 0.2 nozzle.json"
+		},
+		{
+			"name": "0.08mm Optimal @Elegoo CC 0.2 nozzle",
+			"sub_path": "process/ECC/0.08mm Optimal @Elegoo CC 0.2 nozzle.json"
+		},
+		{
+			"name": "0.12mm Draft @Elegoo CC 0.2 nozzle",
+			"sub_path": "process/ECC/0.12mm Draft @Elegoo CC 0.2 nozzle.json"
+		},
+		{
+			"name": "0.14mm Extra Draft @Elegoo CC 0.2 nozzle",
+			"sub_path": "process/ECC/0.14mm Extra Draft @Elegoo CC 0.2 nozzle.json"
+		},
+		{
+			"name": "0.08mm Optimal @Elegoo CC2 0.2 nozzle",
+			"sub_path": "process/ECC2/0.08mm Optimal @Elegoo CC2 0.2 nozzle.json"
+		},
+		{
+			"name": "0.12mm Draft @Elegoo CC2 0.2 nozzle",
+			"sub_path": "process/ECC2/0.12mm Draft @Elegoo CC2 0.2 nozzle.json"
+		},
+		{
+			"name": "0.14mm Extra Draft @Elegoo CC2 0.2 nozzle",
+			"sub_path": "process/ECC2/0.14mm Extra Draft @Elegoo CC2 0.2 nozzle.json"
 		},
 		{
 			"name": "0.08mm Optimal @Elegoo N3Max 0.2 nozzle",
@@ -369,6 +409,322 @@
 		{
 			"name": "0.12mm Draft @Elegoo N4Pro 0.2 nozzle",
 			"sub_path": "process/EN4SERIES/0.12mm Draft @Elegoo N4Pro 0.2 nozzle.json"
+		},
+		{
+			"name": "0.12mm Fine @Elegoo C 0.4 nozzle",
+			"sub_path": "process/EC/0.12mm Fine @Elegoo C 0.4 nozzle.json"
+		},
+		{
+			"name": "0.16mm Optimal @Elegoo C 0.4 nozzle",
+			"sub_path": "process/EC/0.16mm Optimal @Elegoo C 0.4 nozzle.json"
+		},
+		{
+			"name": "0.20mm Strength @Elegoo C 0.4 nozzle",
+			"sub_path": "process/EC/0.20mm Strength @Elegoo C 0.4 nozzle.json"
+		},
+		{
+			"name": "0.24mm Draft @Elegoo C 0.4 nozzle",
+			"sub_path": "process/EC/0.24mm Draft @Elegoo C 0.4 nozzle.json"
+		},
+		{
+			"name": "0.28mm Extra Draft @Elegoo C 0.4 nozzle",
+			"sub_path": "process/EC/0.28mm Extra Draft @Elegoo C 0.4 nozzle.json"
+		},
+		{
+			"name": "0.12mm Fine @Elegoo CC 0.4 nozzle",
+			"sub_path": "process/ECC/0.12mm Fine @Elegoo CC 0.4 nozzle.json"
+		},
+		{
+			"name": "0.16mm Optimal @Elegoo CC 0.4 nozzle",
+			"sub_path": "process/ECC/0.16mm Optimal @Elegoo CC 0.4 nozzle.json"
+		},
+		{
+			"name": "0.20mm Strength @Elegoo CC 0.4 nozzle",
+			"sub_path": "process/ECC/0.20mm Strength @Elegoo CC 0.4 nozzle.json"
+		},
+		{
+			"name": "0.24mm Draft @Elegoo CC 0.4 nozzle",
+			"sub_path": "process/ECC/0.24mm Draft @Elegoo CC 0.4 nozzle.json"
+		},
+		{
+			"name": "0.28mm Extra Draft @Elegoo CC 0.4 nozzle",
+			"sub_path": "process/ECC/0.28mm Extra Draft @Elegoo CC 0.4 nozzle.json"
+		},
+		{
+			"name": "0.12mm Fine @Elegoo CC2 0.4 nozzle",
+			"sub_path": "process/ECC2/0.12mm Fine @Elegoo CC2 0.4 nozzle.json"
+		},
+		{
+			"name": "0.16mm Optimal @Elegoo CC2 0.4 nozzle",
+			"sub_path": "process/ECC2/0.16mm Optimal @Elegoo CC2 0.4 nozzle.json"
+		},
+		{
+			"name": "0.20mm Strength @Elegoo CC2 0.4 nozzle",
+			"sub_path": "process/ECC2/0.20mm Strength @Elegoo CC2 0.4 nozzle.json"
+		},
+		{
+			"name": "0.24mm Draft @Elegoo CC2 0.4 nozzle",
+			"sub_path": "process/ECC2/0.24mm Draft @Elegoo CC2 0.4 nozzle.json"
+		},
+		{
+			"name": "0.28mm Extra Draft @Elegoo CC2 0.4 nozzle",
+			"sub_path": "process/ECC2/0.28mm Extra Draft @Elegoo CC2 0.4 nozzle.json"
+		},
+		{
+			"name": "0.16mm Optimal @Elegoo Giga 0.4 nozzle",
+			"sub_path": "process/EOSGIGA/0.16mm Optimal @Elegoo Giga 0.4 nozzle.json"
+		},
+		{
+			"name": "0.20mm Strength @Elegoo Giga 0.4 nozzle",
+			"sub_path": "process/EOSGIGA/0.20mm Strength @Elegoo Giga 0.4 nozzle.json"
+		},
+		{
+			"name": "0.24mm Draft @Elegoo Giga 0.4 nozzle",
+			"sub_path": "process/EOSGIGA/0.24mm Draft @Elegoo Giga 0.4 nozzle.json"
+		},
+		{
+			"name": "0.28mm Extra Draft @Elegoo Giga 0.4 nozzle",
+			"sub_path": "process/EOSGIGA/0.28mm Extra Draft @Elegoo Giga 0.4 nozzle.json"
+		},
+		{
+			"name": "0.12mm Fine @Elegoo N3Max 0.4 nozzle",
+			"sub_path": "process/EN3SERIES/0.12mm Fine @Elegoo N3Max 0.4 nozzle.json"
+		},
+		{
+			"name": "0.16mm Optimal @Elegoo N3Max 0.4 nozzle",
+			"sub_path": "process/EN3SERIES/0.16mm Optimal @Elegoo N3Max 0.4 nozzle.json"
+		},
+		{
+			"name": "0.20mm Strength @Elegoo N3Max 0.4 nozzle",
+			"sub_path": "process/EN3SERIES/0.20mm Strength @Elegoo N3Max 0.4 nozzle.json"
+		},
+		{
+			"name": "0.24mm Draft @Elegoo N3Max 0.4 nozzle",
+			"sub_path": "process/EN3SERIES/0.24mm Draft @Elegoo N3Max 0.4 nozzle.json"
+		},
+		{
+			"name": "0.28mm Extra Draft @Elegoo N3Max 0.4 nozzle",
+			"sub_path": "process/EN3SERIES/0.28mm Extra Draft @Elegoo N3Max 0.4 nozzle.json"
+		},
+		{
+			"name": "0.12mm Fine @Elegoo N3Plus 0.4 nozzle",
+			"sub_path": "process/EN3SERIES/0.12mm Fine @Elegoo N3Plus 0.4 nozzle.json"
+		},
+		{
+			"name": "0.16mm Optimal @Elegoo N3Plus 0.4 nozzle",
+			"sub_path": "process/EN3SERIES/0.16mm Optimal @Elegoo N3Plus 0.4 nozzle.json"
+		},
+		{
+			"name": "0.20mm Strength @Elegoo N3Plus 0.4 nozzle",
+			"sub_path": "process/EN3SERIES/0.20mm Strength @Elegoo N3Plus 0.4 nozzle.json"
+		},
+		{
+			"name": "0.24mm Draft @Elegoo N3Plus 0.4 nozzle",
+			"sub_path": "process/EN3SERIES/0.24mm Draft @Elegoo N3Plus 0.4 nozzle.json"
+		},
+		{
+			"name": "0.28mm Extra Draft @Elegoo N3Plus 0.4 nozzle",
+			"sub_path": "process/EN3SERIES/0.28mm Extra Draft @Elegoo N3Plus 0.4 nozzle.json"
+		},
+		{
+			"name": "0.12mm Fine @Elegoo N3Pro 0.4 nozzle",
+			"sub_path": "process/EN3SERIES/0.12mm Fine @Elegoo N3Pro 0.4 nozzle.json"
+		},
+		{
+			"name": "0.16mm Optimal @Elegoo N3Pro 0.4 nozzle",
+			"sub_path": "process/EN3SERIES/0.16mm Optimal @Elegoo N3Pro 0.4 nozzle.json"
+		},
+		{
+			"name": "0.20mm Strength @Elegoo N3Pro 0.4 nozzle",
+			"sub_path": "process/EN3SERIES/0.20mm Strength @Elegoo N3Pro 0.4 nozzle.json"
+		},
+		{
+			"name": "0.24mm Draft @Elegoo N3Pro 0.4 nozzle",
+			"sub_path": "process/EN3SERIES/0.24mm Draft @Elegoo N3Pro 0.4 nozzle.json"
+		},
+		{
+			"name": "0.28mm Extra Draft @Elegoo N3Pro 0.4 nozzle",
+			"sub_path": "process/EN3SERIES/0.28mm Extra Draft @Elegoo N3Pro 0.4 nozzle.json"
+		},
+		{
+			"name": "0.12mm Fine @Elegoo N4 0.4 nozzle",
+			"sub_path": "process/EN4SERIES/0.12mm Fine @Elegoo N4 0.4 nozzle.json"
+		},
+		{
+			"name": "0.16mm Optimal @Elegoo N4 0.4 nozzle",
+			"sub_path": "process/EN4SERIES/0.16mm Optimal @Elegoo N4 0.4 nozzle.json"
+		},
+		{
+			"name": "0.20mm Strength @Elegoo N4 0.4 nozzle",
+			"sub_path": "process/EN4SERIES/0.20mm Strength @Elegoo N4 0.4 nozzle.json"
+		},
+		{
+			"name": "0.24mm Draft @Elegoo N4 0.4 nozzle",
+			"sub_path": "process/EN4SERIES/0.24mm Draft @Elegoo N4 0.4 nozzle.json"
+		},
+		{
+			"name": "0.28mm Extra Draft @Elegoo N4 0.4 nozzle",
+			"sub_path": "process/EN4SERIES/0.28mm Extra Draft @Elegoo N4 0.4 nozzle.json"
+		},
+		{
+			"name": "0.12mm Fine @Elegoo N4Max 0.4 nozzle",
+			"sub_path": "process/EN4SERIES/0.12mm Fine @Elegoo N4Max 0.4 nozzle.json"
+		},
+		{
+			"name": "0.16mm Optimal @Elegoo N4Max 0.4 nozzle",
+			"sub_path": "process/EN4SERIES/0.16mm Optimal @Elegoo N4Max 0.4 nozzle.json"
+		},
+		{
+			"name": "0.20mm Strength @Elegoo N4Max 0.4 nozzle",
+			"sub_path": "process/EN4SERIES/0.20mm Strength @Elegoo N4Max 0.4 nozzle.json"
+		},
+		{
+			"name": "0.24mm Draft @Elegoo N4Max 0.4 nozzle",
+			"sub_path": "process/EN4SERIES/0.24mm Draft @Elegoo N4Max 0.4 nozzle.json"
+		},
+		{
+			"name": "0.28mm Extra Draft @Elegoo N4Max 0.4 nozzle",
+			"sub_path": "process/EN4SERIES/0.28mm Extra Draft @Elegoo N4Max 0.4 nozzle.json"
+		},
+		{
+			"name": "0.12mm Fine @Elegoo N4Plus 0.4 nozzle",
+			"sub_path": "process/EN4SERIES/0.12mm Fine @Elegoo N4Plus 0.4 nozzle.json"
+		},
+		{
+			"name": "0.16mm Optimal @Elegoo N4Plus 0.4 nozzle",
+			"sub_path": "process/EN4SERIES/0.16mm Optimal @Elegoo N4Plus 0.4 nozzle.json"
+		},
+		{
+			"name": "0.20mm Strength @Elegoo N4Plus 0.4 nozzle",
+			"sub_path": "process/EN4SERIES/0.20mm Strength @Elegoo N4Plus 0.4 nozzle.json"
+		},
+		{
+			"name": "0.24mm Draft @Elegoo N4Plus 0.4 nozzle",
+			"sub_path": "process/EN4SERIES/0.24mm Draft @Elegoo N4Plus 0.4 nozzle.json"
+		},
+		{
+			"name": "0.28mm Extra Draft @Elegoo N4Plus 0.4 nozzle",
+			"sub_path": "process/EN4SERIES/0.28mm Extra Draft @Elegoo N4Plus 0.4 nozzle.json"
+		},
+		{
+			"name": "0.12mm Fine @Elegoo N4Pro 0.4 nozzle",
+			"sub_path": "process/EN4SERIES/0.12mm Fine @Elegoo N4Pro 0.4 nozzle.json"
+		},
+		{
+			"name": "0.16mm Optimal @Elegoo N4Pro 0.4 nozzle",
+			"sub_path": "process/EN4SERIES/0.16mm Optimal @Elegoo N4Pro 0.4 nozzle.json"
+		},
+		{
+			"name": "0.20mm Strength @Elegoo N4Pro 0.4 nozzle",
+			"sub_path": "process/EN4SERIES/0.20mm Strength @Elegoo N4Pro 0.4 nozzle.json"
+		},
+		{
+			"name": "0.24mm Draft @Elegoo N4Pro 0.4 nozzle",
+			"sub_path": "process/EN4SERIES/0.24mm Draft @Elegoo N4Pro 0.4 nozzle.json"
+		},
+		{
+			"name": "0.28mm Extra Draft @Elegoo N4Pro 0.4 nozzle",
+			"sub_path": "process/EN4SERIES/0.28mm Extra Draft @Elegoo N4Pro 0.4 nozzle.json"
+		},
+		{
+			"name": "0.12mm Fine @Elegoo Neptune 0.4 nozzle",
+			"sub_path": "process/EN2SERIES/0.12mm Fine @Elegoo Neptune 0.4 nozzle.json"
+		},
+		{
+			"name": "0.16mm Optimal @Elegoo Neptune 0.4 nozzle",
+			"sub_path": "process/EN2SERIES/0.16mm Optimal @Elegoo Neptune 0.4 nozzle.json"
+		},
+		{
+			"name": "0.20mm Strength @Elegoo Neptune 0.4 nozzle",
+			"sub_path": "process/EN2SERIES/0.20mm Strength @Elegoo Neptune 0.4 nozzle.json"
+		},
+		{
+			"name": "0.24mm Draft @Elegoo Neptune 0.4 nozzle",
+			"sub_path": "process/EN2SERIES/0.24mm Draft @Elegoo Neptune 0.4 nozzle.json"
+		},
+		{
+			"name": "0.28mm Extra Draft @Elegoo Neptune 0.4 nozzle",
+			"sub_path": "process/EN2SERIES/0.28mm Extra Draft @Elegoo Neptune 0.4 nozzle.json"
+		},
+		{
+			"name": "0.18mm Fine @Elegoo C 0.6 nozzle",
+			"sub_path": "process/EC/0.18mm Fine @Elegoo C 0.6 nozzle.json"
+		},
+		{
+			"name": "0.24mm Optimal @Elegoo C 0.6 nozzle",
+			"sub_path": "process/EC/0.24mm Optimal @Elegoo C 0.6 nozzle.json"
+		},
+		{
+			"name": "0.30mm Strength @Elegoo C 0.6 nozzle",
+			"sub_path": "process/EC/0.30mm Strength @Elegoo C 0.6 nozzle.json"
+		},
+		{
+			"name": "0.36mm Draft @Elegoo C 0.6 nozzle",
+			"sub_path": "process/EC/0.36mm Draft @Elegoo C 0.6 nozzle.json"
+		},
+		{
+			"name": "0.42mm Extra Draft @Elegoo C 0.6 nozzle",
+			"sub_path": "process/EC/0.42mm Extra Draft @Elegoo C 0.6 nozzle.json"
+		},
+		{
+			"name": "0.18mm Fine @Elegoo CC 0.6 nozzle",
+			"sub_path": "process/ECC/0.18mm Fine @Elegoo CC 0.6 nozzle.json"
+		},
+		{
+			"name": "0.24mm Optimal @Elegoo CC 0.6 nozzle",
+			"sub_path": "process/ECC/0.24mm Optimal @Elegoo CC 0.6 nozzle.json"
+		},
+		{
+			"name": "0.30mm Strength @Elegoo CC 0.6 nozzle",
+			"sub_path": "process/ECC/0.30mm Strength @Elegoo CC 0.6 nozzle.json"
+		},
+		{
+			"name": "0.36mm Draft @Elegoo CC 0.6 nozzle",
+			"sub_path": "process/ECC/0.36mm Draft @Elegoo CC 0.6 nozzle.json"
+		},
+		{
+			"name": "0.42mm Extra Draft @Elegoo CC 0.6 nozzle",
+			"sub_path": "process/ECC/0.42mm Extra Draft @Elegoo CC 0.6 nozzle.json"
+		},
+		{
+			"name": "0.18mm Fine @Elegoo CC2 0.6 nozzle",
+			"sub_path": "process/ECC2/0.18mm Fine @Elegoo CC2 0.6 nozzle.json"
+		},
+		{
+			"name": "0.24mm Optimal @Elegoo CC2 0.6 nozzle",
+			"sub_path": "process/ECC2/0.24mm Optimal @Elegoo CC2 0.6 nozzle.json"
+		},
+		{
+			"name": "0.30mm Strength @Elegoo CC2 0.6 nozzle",
+			"sub_path": "process/ECC2/0.30mm Strength @Elegoo CC2 0.6 nozzle.json"
+		},
+		{
+			"name": "0.36mm Draft @Elegoo CC2 0.6 nozzle",
+			"sub_path": "process/ECC2/0.36mm Draft @Elegoo CC2 0.6 nozzle.json"
+		},
+		{
+			"name": "0.42mm Extra Draft @Elegoo CC2 0.6 nozzle",
+			"sub_path": "process/ECC2/0.42mm Extra Draft @Elegoo CC2 0.6 nozzle.json"
+		},
+		{
+			"name": "0.18mm Fine @Elegoo Giga 0.6 nozzle",
+			"sub_path": "process/EOSGIGA/0.18mm Fine @Elegoo Giga 0.6 nozzle.json"
+		},
+		{
+			"name": "0.24mm Optimal @Elegoo Giga 0.6 nozzle",
+			"sub_path": "process/EOSGIGA/0.24mm Optimal @Elegoo Giga 0.6 nozzle.json"
+		},
+		{
+			"name": "0.30mm Strength @Elegoo Giga 0.6 nozzle",
+			"sub_path": "process/EOSGIGA/0.30mm Strength @Elegoo Giga 0.6 nozzle.json"
+		},
+		{
+			"name": "0.36mm Draft @Elegoo Giga 0.6 nozzle",
+			"sub_path": "process/EOSGIGA/0.36mm Draft @Elegoo Giga 0.6 nozzle.json"
+		},
+		{
+			"name": "0.42mm Extra Draft @Elegoo Giga 0.6 nozzle",
+			"sub_path": "process/EOSGIGA/0.42mm Extra Draft @Elegoo Giga 0.6 nozzle.json"
 		},
 		{
 			"name": "0.24mm Optimal @Elegoo N3Max 0.6 nozzle",
@@ -455,6 +811,82 @@
 			"sub_path": "process/EN4SERIES/0.42mm Extra Draft @Elegoo N4Pro 0.6 nozzle.json"
 		},
 		{
+			"name": "0.24mm Optimal @Elegoo Neptune 0.6 nozzle",
+			"sub_path": "process/EN2SERIES/0.24mm Optimal @Elegoo Neptune 0.6 nozzle.json"
+		},
+		{
+			"name": "0.36mm Draft @Elegoo Neptune 0.6 nozzle",
+			"sub_path": "process/EN2SERIES/0.36mm Draft @Elegoo Neptune 0.6 nozzle.json"
+		},
+		{
+			"name": "0.42mm Extra Draft @Elegoo Neptune 0.6 nozzle",
+			"sub_path": "process/EN2SERIES/0.42mm Extra Draft @Elegoo Neptune 0.6 nozzle.json"
+		},
+		{
+			"name": "0.16mm Extra Fine @Elegoo C 0.8 nozzle",
+			"sub_path": "process/EC/0.16mm Extra Fine @Elegoo C 0.8 nozzle.json"
+		},
+		{
+			"name": "0.24mm Fine @Elegoo C 0.8 nozzle",
+			"sub_path": "process/EC/0.24mm Fine @Elegoo C 0.8 nozzle.json"
+		},
+		{
+			"name": "0.32mm Optimal @Elegoo C 0.8 nozzle",
+			"sub_path": "process/EC/0.32mm Optimal @Elegoo C 0.8 nozzle.json"
+		},
+		{
+			"name": "0.48mm Draft @Elegoo C 0.8 nozzle",
+			"sub_path": "process/EC/0.48mm Draft @Elegoo C 0.8 nozzle.json"
+		},
+		{
+			"name": "0.16mm Extra Fine @Elegoo CC 0.8 nozzle",
+			"sub_path": "process/ECC/0.16mm Extra Fine @Elegoo CC 0.8 nozzle.json"
+		},
+		{
+			"name": "0.24mm Fine @Elegoo CC 0.8 nozzle",
+			"sub_path": "process/ECC/0.24mm Fine @Elegoo CC 0.8 nozzle.json"
+		},
+		{
+			"name": "0.32mm Optimal @Elegoo CC 0.8 nozzle",
+			"sub_path": "process/ECC/0.32mm Optimal @Elegoo CC 0.8 nozzle.json"
+		},
+		{
+			"name": "0.48mm Draft @Elegoo CC 0.8 nozzle",
+			"sub_path": "process/ECC/0.48mm Draft @Elegoo CC 0.8 nozzle.json"
+		},
+		{
+			"name": "0.16mm Extra Fine @Elegoo CC2 0.8 nozzle",
+			"sub_path": "process/ECC2/0.16mm Extra Fine @Elegoo CC2 0.8 nozzle.json"
+		},
+		{
+			"name": "0.24mm Fine @Elegoo CC2 0.8 nozzle",
+			"sub_path": "process/ECC2/0.24mm Fine @Elegoo CC2 0.8 nozzle.json"
+		},
+		{
+			"name": "0.32mm Optimal @Elegoo CC2 0.8 nozzle",
+			"sub_path": "process/ECC2/0.32mm Optimal @Elegoo CC2 0.8 nozzle.json"
+		},
+		{
+			"name": "0.48mm Draft @Elegoo CC2 0.8 nozzle",
+			"sub_path": "process/ECC2/0.48mm Draft @Elegoo CC2 0.8 nozzle.json"
+		},
+		{
+			"name": "0.24mm Fine @Elegoo Giga 0.8 nozzle",
+			"sub_path": "process/EOSGIGA/0.24mm Fine @Elegoo Giga 0.8 nozzle.json"
+		},
+		{
+			"name": "0.32mm Optimal @Elegoo Giga 0.8 nozzle",
+			"sub_path": "process/EOSGIGA/0.32mm Optimal @Elegoo Giga 0.8 nozzle.json"
+		},
+		{
+			"name": "0.48mm Draft @Elegoo Giga 0.8 nozzle",
+			"sub_path": "process/EOSGIGA/0.48mm Draft @Elegoo Giga 0.8 nozzle.json"
+		},
+		{
+			"name": "0.56mm Extra Draft @Elegoo Giga 0.8 nozzle",
+			"sub_path": "process/EOSGIGA/0.56mm Extra Draft @Elegoo Giga 0.8 nozzle.json"
+		},
+		{
 			"name": "0.24mm Fine @Elegoo N3Max 0.8 nozzle",
 			"sub_path": "process/EN3SERIES/0.24mm Fine @Elegoo N3Max 0.8 nozzle.json"
 		},
@@ -537,6 +969,26 @@
 		{
 			"name": "0.48mm Draft @Elegoo N4Pro 0.8 nozzle",
 			"sub_path": "process/EN4SERIES/0.48mm Draft @Elegoo N4Pro 0.8 nozzle.json"
+		},
+		{
+			"name": "0.24mm Fine @Elegoo Neptune 0.8 nozzle",
+			"sub_path": "process/EN2SERIES/0.24mm Fine @Elegoo Neptune 0.8 nozzle.json"
+		},
+		{
+			"name": "0.32mm Optimal @Elegoo Neptune 0.8 nozzle",
+			"sub_path": "process/EN2SERIES/0.32mm Optimal @Elegoo Neptune 0.8 nozzle.json"
+		},
+		{
+			"name": "0.30mm Fine @Elegoo Giga 1.0 nozzle",
+			"sub_path": "process/EOSGIGA/0.30mm Fine @Elegoo Giga 1.0 nozzle.json"
+		},
+		{
+			"name": "0.40mm Optimal @Elegoo Giga 1.0 nozzle",
+			"sub_path": "process/EOSGIGA/0.40mm Optimal @Elegoo Giga 1.0 nozzle.json"
+		},
+		{
+			"name": "0.60mm Draft @Elegoo Giga 1.0 nozzle",
+			"sub_path": "process/EOSGIGA/0.60mm Draft @Elegoo Giga 1.0 nozzle.json"
 		},
 		{
 			"name": "0.30mm Fine @Elegoo N3Max 1.0 nozzle",

--- a/resources/profiles/Elegoo.json
+++ b/resources/profiles/Elegoo.json
@@ -1,6 +1,6 @@
 {
 	"name": "Elegoo",
-	"version": "02.04.00.00",
+	"version": "02.04.00.01",
 	"force_update": "0",
 	"description": "Elegoo configurations",
 	"machine_model_list": [


### PR DESCRIPTION
# Description

Fixes missing Elegoo process profiles by listing all bundled Elegoo process presets in `resources/profiles/Elegoo.json`.

After the recent Elegoo profile sync in #13790, many process preset JSON files existed under `resources/profiles/Elegoo/process/` but were not included in the vendor manifest `process_list`. Existing and fresh installs could therefore load incomplete Elegoo profile sets. One visible symptom was OrangeStorm Giga showing only a single process profile for a selected nozzle, but the same manifest gap affected Centauri, Centauri Carbon, Centauri Carbon 2, Neptune, and OrangeStorm Giga profile families.

This updates the Elegoo manifest to include all 250 bundled Elegoo process profiles and bumps the Elegoo vendor profile version to force installed profile bundles to refresh from bundled resources.

   Fixes #14019

## Screenshots

After implementing the version bump, pre-existing Elegoo printers remained in my printer list after rebuilding Orca.
<img width="478" height="419" alt="image" src="https://github.com/user-attachments/assets/a97b0420-f7a4-4bc6-848d-cbafe6e419e6" />

After implementing, all printer processes are listed as expected.
<img width="750" height="407" alt="image" src="https://github.com/user-attachments/assets/f0336acc-ec3e-454f-9ec0-34eab5216fc4" />


<!--
> A guide for users on how to download the artifacts from this PR.
-->

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
