### PR TITLE
Fix tree support interfaces and edge filling

### DIFF
--- a/src/libslic3r/Support/TreeSupport.cpp
+++ b/src/libslic3r/Support/TreeSupport.cpp
@@ -1687,13 +1687,6 @@ void TreeSupport::generate_toolpaths()
     );
 }
 
-void deleteDirectoryContents(const std::filesystem::path& dir)
-{
-    for (const auto& entry : std::filesystem::directory_iterator(dir))
-        std::filesystem::remove_all(entry.path());
-}
-
-
 void TreeSupport::move_bounds_to_contact_nodes(std::vector<TreeSupport3D::SupportElements> &move_bounds,
                                   PrintObject                             &print_object,
                                   const TreeSupport3D::TreeSupportSettings    &config)
@@ -2146,13 +2139,9 @@ void TreeSupport::draw_circles()
                         if (!area.empty()) has_circle_node = true;
                         if (node.need_extra_wall) need_extra_wall = true;
 
-                        // Merge the overhang into the roof area so tree tips can still produce
-                        // a continuous support interface. Suppressing this for build-plate-only
-                        // support drops the roof polygons entirely in valid tree branches.
-                        // ORCA: Only keep top interface polygons that fully fit in the mm height cap.
-                        if (top_interface_layers > 0 && node.support_roof_layers_below > 0 &&
-                            (node.dist_mm_to_top - this->top_z_distance) < top_interface_height + EPSILON &&
-                            !node.is_sharp_tail) {
+                        // merge overhang to get a smoother interface surface
+                        // Do not merge when buildplate_only is on, because some underneath nodes may have been deleted.
+                        if (top_interface_layers > 0 && node.support_roof_layers_below > 0 && !on_buildplate_only && !node.is_sharp_tail) {
                             ExPolygons overhang_expanded;
                             if (node.overhang.contour.size() > 100 || node.overhang.holes.size()>1)
                                 overhang_expanded.emplace_back(node.overhang);
@@ -2197,16 +2186,6 @@ void TreeSupport::draw_circles()
                 // roof_1st_layer and roof_areas may intersect, so need to subtract roof_areas from roof_1st_layer
                 roof_1st_layer = diff_ex(roof_1st_layer, ClipperUtils::clip_clipper_polygons_with_subject_bbox(roof_areas,get_extents(roof_1st_layer)));
                 roof_1st_layer = intersection_ex(roof_1st_layer, m_machine_border);
-
-                // Build-plate-only pruning can collapse the roof stack down to a single
-                // printable layer. In that case we still need to emit an interface layer
-                // instead of downgrading the last roof-adjacent layer to base support.
-                if (on_buildplate_only && top_interface_layers > 0 && roof_areas.empty() && !roof_1st_layer.empty()) {
-                    append(roof_areas, roof_1st_layer);
-                    roof_1st_layer.clear();
-                    max_layers_above_roof = std::max(max_layers_above_roof, max_layers_above_roof1);
-                    max_layers_above_roof1 = 0;
-                }
 
                 ExPolygons roofs; append(roofs, roof_1st_layer); append(roofs, roof_areas);append(roofs, roof_gap_areas);
                 base_areas = diff_ex(base_areas, ClipperUtils::clip_clipper_polygons_with_subject_bbox(roofs, get_extents(base_areas)));
@@ -3567,7 +3546,14 @@ void TreeSupport::generate_contact_points()
                     }
 
                     // add supports along contours
-                    libnest2d::placers::EdgeCache<ExPolygon> edge_cache(overhang);
+                    ExPolygon closed_overhang = overhang; // make a copy to add closing point for edge cache
+                    if (closed_overhang.contour.points.size() > 1)
+                        closed_overhang.contour.points.emplace_back(closed_overhang.contour.points.front());
+                    for (Polygon &hole : closed_overhang.holes)
+                        if (hole.points.size() > 1)
+                            hole.points.emplace_back(hole.points.front());
+
+                    libnest2d::placers::EdgeCache<ExPolygon> edge_cache(closed_overhang);
                     for (size_t i = 0; i < edge_cache.holeCount() + 1; i++) {
                         double step     = point_spread / (i == 0 ? edge_cache.circumference() : edge_cache.circumference(i - 1));
                         double distance = 0;

--- a/src/libslic3r/Support/TreeSupport3D.cpp
+++ b/src/libslic3r/Support/TreeSupport3D.cpp
@@ -1603,6 +1603,7 @@ static Point move_inside_if_outside(const Polygons &polygons, Point from, int di
     if (settings.increase_radius)
         current_elem.effective_radius_height += 1;
     coord_t radius = support_element_collision_radius(config, current_elem);
+
     const auto _tiny_area_threshold = tiny_area_threshold();
     if (settings.move) {
         increased = relevant_offset;
@@ -3468,6 +3469,7 @@ static void generate_support_areas(Print &print, TreeSupport* tree_support, cons
 
             // value is the area where support may be placed. As this is calculated in CreateLayerPathing it is saved and reused in draw_areas
             std::vector<SupportElements> move_bounds(num_support_layers);
+
             // ### Place tips of the support tree
             for (size_t mesh_idx : processing.second)
                 generate_initial_areas(*print.get_object(mesh_idx), volumes, config, overhangs, 
@@ -3778,6 +3780,7 @@ void organic_draw_branches(
 //            ++ ielement;
         }
     }
+
     const SlicingParameters &slicing_params = print_object.slicing_parameters();
     MeshSlicingParams mesh_slicing_params;
     mesh_slicing_params.mode = MeshSlicingParams::SlicingMode::Positive;
@@ -3959,19 +3962,7 @@ void organic_draw_branches(
                     }
                     // ORCA: bottom contacts provide the footprint; interface layers are built later.
 
-#if 0
-                    //FIXME branch.has_tip seems to not be reliable.
-                    if (branch.has_tip && interface_placer.support_parameters.has_top_contacts)
-                        // Add top slices to top contacts / interfaces / base interfaces.
-                        for (int i = int(branch.path.size()) - 1; i >= 0; -- i) {
-                            const SupportElement &el = *branch.path[i];
-                            if (el.state.missing_roof_layers == 0)
-                                break;
-                            //FIXME Move or not?
-                            interface_placer.add_roof(std::move(slices[int(slices.size()) - i - 1]), el.state.layer_idx,
-                                interface_placer.support_parameters.num_top_interface_layers + 1 - el.state.missing_roof_layers);
-                        }
-#endif
+                    recover_pending_branch_roofs(interface_placer, branch.path, layer_begin, slices);
 
                     while (! slices.empty() && slices.back().empty()) {
                         slices.pop_back();


### PR DESCRIPTION
This PR is about tree supports and their interfaces.
It tackles 3 points:

#### 1. Non organic tree supports may print support top interfaces in thin air and/or above unsupported area

|Before|After|
|---|---|
|<img width="2017" height="1426" alt="image" src="https://github.com/user-attachments/assets/8619bce5-9b14-4c9b-b915-d417d20b9e42" />|<img width="2002" height="1442" alt="image" src="https://github.com/user-attachments/assets/3dd6bfbb-9da9-4f5d-9a44-a92bbef7c994" />|
|<img width="1667" height="1206" alt="image" src="https://github.com/user-attachments/assets/a2b36f03-248f-4001-b903-8af2dd60316d" />|<img width="1659" height="1193" alt="image" src="https://github.com/user-attachments/assets/ab20be20-beb4-4877-99c1-90694bee328b" />|
|This bug was introduced by PR #13192|Reverted the specific changes from PR #13192|

<br>

#### 2. Organic tree support can miss generating top interface

|Before|After|
|---|---|
|<img width="1917" height="1397" alt="image" src="https://github.com/user-attachments/assets/8785dc69-3ece-44b5-98e7-397878406fb3" />|<img width="1849" height="1360" alt="image" src="https://github.com/user-attachments/assets/e3cb34c5-3ad7-4019-aa34-8718a97d4dc7" />|
|PR #11812 removed a change from PR #13192|Restored the removed part|

<br>

#### 3. Non organic tree supports didn't fill up all the edges of the unsupported area, leaving those edges barely supported

|Before|After|
|---|---|
|<img width="939" height="1136" alt="image" src="https://github.com/user-attachments/assets/bd0a3423-d33e-46c3-8f55-baf7ddb542c7" />|<img width="950" height="1135" alt="image" src="https://github.com/user-attachments/assets/0ec4348e-ad3e-4f92-be02-a544d96409f2" />|
|<img width="936" height="1124" alt="image" src="https://github.com/user-attachments/assets/07c926fa-a71e-4af0-b327-2f5cb8d83f98" />|<img width="915" height="1101" alt="image" src="https://github.com/user-attachments/assets/d3cacc6c-041a-4151-b4e1-9a4367c5b518" />|