### PR TITLE
Fix printer variant for voron 0.4 profiles

### DIFF
--- a/resources/profiles/Voron.json
+++ b/resources/profiles/Voron.json
@@ -1,6 +1,6 @@
 {
 	"name": "Voron",
-	"version": "02.04.00.00",
+	"version": "02.04.00.01",
 	"force_update": "0",
 	"description": "Voron configurations",
 	"machine_model_list": [

--- a/resources/profiles/Voron/machine/Voron 0.1 0.4 nozzle.json
+++ b/resources/profiles/Voron/machine/Voron 0.1 0.4 nozzle.json
@@ -24,5 +24,6 @@
 	],
 	"printable_height": "120",
 	"nozzle_type": "undefine",
-	"auxiliary_fan": "0"
+	"auxiliary_fan": "0",
+	"printer_variant": "0.4"
 }

--- a/resources/profiles/Voron/machine/Voron 2.4 250 0.4 nozzle.json
+++ b/resources/profiles/Voron/machine/Voron 2.4 250 0.4 nozzle.json
@@ -22,5 +22,6 @@
 		"250x250",
 		"0x250"
 	],
-	"printable_height": "225"
+	"printable_height": "225",
+	"printer_variant": "0.4"
 }

--- a/resources/profiles/Voron/machine/Voron 2.4 300 0.4 nozzle.json
+++ b/resources/profiles/Voron/machine/Voron 2.4 300 0.4 nozzle.json
@@ -22,5 +22,6 @@
 		"300x300",
 		"0x300"
 	],
-	"printable_height": "275"
+	"printable_height": "275",
+	"printer_variant": "0.4"
 }

--- a/resources/profiles/Voron/machine/Voron 2.4 350 0.4 nozzle.json
+++ b/resources/profiles/Voron/machine/Voron 2.4 350 0.4 nozzle.json
@@ -22,5 +22,6 @@
 		"350x350",
 		"0x350"
 	],
-	"printable_height": "325"
+	"printable_height": "325",
+	"printer_variant": "0.4"
 }

--- a/resources/profiles/Voron/machine/Voron Switchwire 250 0.4 nozzle.json
+++ b/resources/profiles/Voron/machine/Voron Switchwire 250 0.4 nozzle.json
@@ -22,5 +22,6 @@
 		"250x210",
 		"0x210"
 	],
-	"printable_height": "240"
+	"printable_height": "240",
+	"printer_variant": "0.4"
 }

--- a/resources/profiles/Voron/machine/Voron Trident 250 0.4 nozzle.json
+++ b/resources/profiles/Voron/machine/Voron Trident 250 0.4 nozzle.json
@@ -22,5 +22,6 @@
 		"250x250",
 		"0x250"
 	],
-	"printable_height": "250"
+	"printable_height": "250",
+	"printer_variant": "0.4"
 }

--- a/resources/profiles/Voron/machine/Voron Trident 300 0.4 nozzle.json
+++ b/resources/profiles/Voron/machine/Voron Trident 300 0.4 nozzle.json
@@ -22,5 +22,6 @@
 		"300x300",
 		"0x300"
 	],
-	"printable_height": "250"
+	"printable_height": "250",
+	"printer_variant": "0.4"
 }

--- a/resources/profiles/Voron/machine/Voron Trident 350 0.4 nozzle.json
+++ b/resources/profiles/Voron/machine/Voron Trident 350 0.4 nozzle.json
@@ -22,5 +22,6 @@
 		"350x350",
 		"0x350"
 	],
-	"printable_height": "250"
+	"printable_height": "250",
+	"printer_variant": "0.4"
 }


### PR DESCRIPTION
# Description

Introduces nozzle variant for 0.4 mm nozzle voron profiles



<!--
> A guide for users on how to download the artifacts from this PR.
-->

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
