### PR TITLE
Fix incorrect custom printer profile grouping

### DIFF
--- a/src/slic3r/GUI/PresetComboBoxes.cpp
+++ b/src/slic3r/GUI/PresetComboBoxes.cpp
@@ -1402,7 +1402,12 @@ void PlaterPresetComboBox::update()
                                    : group_filament_presets  == "2" ? "by_type"            // Create sub menus with filament type
                                    : group_filament_presets  == "3" ? "by_vendor"          // Create sub menus with filament vendor
                                    : "";                                                   // Use without sub menu
-    add_presets(nonsys_presets, selected_user_preset, L("User presets"), group_filament_presets_by);
+    // ORCA: the by_type/by_vendor grouping is derived from filament-only attributes
+    // (filament_type/filament_vendor), which are empty for printer and material presets.
+    // Applying it to non-filament combos buckets every user preset under "Unspecified",
+    // so only group user presets by those attributes for the filament combobox.
+    add_presets(nonsys_presets, selected_user_preset, L("User presets"),
+                m_type == Preset::TYPE_FILAMENT ? group_filament_presets_by : wxString(""));
     // ORCA: add bundle presets with sub-dropdown grouping for filament and printer
     auto bundle_group_name = (m_type == Preset::TYPE_FILAMENT || m_type == Preset::TYPE_PRINTER) ? "by_bundle" : "";
     add_presets(bundle_presets, selected_bundle_preset, L("Bundle presets"), bundle_group_name);


### PR DESCRIPTION
# Description

Fix custom printer profiles grouping being influenced by filament grouping selection due to no filtering in the preset combo box.

# Screenshots/Recordings/Graphs

**Before:
All custom profiles are set to unspecified group.**
<img width="1078" height="1056" alt="image" src="https://github.com/user-attachments/assets/c8b12236-38d4-4354-814a-1583a4f3b0e3" />


**After (mirrors 2.3.2 behaviour):**
<img width="1078" height="1056" alt="image" src="https://github.com/user-attachments/assets/21a6dbd7-81eb-425a-8507-e579f83d37fd" />

<img width="1078" height="1262" alt="image" src="https://github.com/user-attachments/assets/a95b8fad-7904-4f3b-94c3-9396488d3f83" />



<!--
> A guide for users on how to download the artifacts from this PR.
-->

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
