### PR TITLE
Retry preset migration when login warmup 401 blocks cloud check

### DIFF
--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -6044,6 +6044,25 @@ bool GUI_App::maybe_migrate_user_presets_on_login()
         if (ret != 0) {
             BOOST_LOG_TRIVIAL(warning) << "Failed to query OrcaCloud presets (error " << ret
                                        << "), skipping migration to avoid overwriting cloud data.";
+            // If this looks like a transient 401 from token propagation delay (within grace period),
+            // schedule one deferred retry so first-time users don't silently lose their preset migration.
+            if (std::chrono::steady_clock::now() - m_last_401_error_time < std::chrono::seconds(30)
+                && !m_migration_retry_pending.exchange(true)) {
+                BOOST_LOG_TRIVIAL(info) << "Scheduling migration retry after token propagation window.";
+                boost::thread([this]() {
+                    std::this_thread::sleep_for(std::chrono::seconds(5));
+                    CallAfter([this]() {
+                        m_migration_retry_pending = false;
+                        if (is_closing() || !m_agent || !m_agent->is_user_login()) return;
+                        BOOST_LOG_TRIVIAL(info) << "Retrying preset migration after token propagation window.";
+                        if (maybe_migrate_user_presets_on_login()) {
+                            const std::string user_id = m_agent->get_user_id();
+                            preset_bundle->load_user_presets(user_id, ForwardCompatibilitySubstitutionRule::Enable);
+                            if (mainframe) mainframe->update_side_preset_ui();
+                        }
+                    });
+                }).detach();
+            }
             return false;
         }
         BOOST_LOG_TRIVIAL(info) << "OrcaCloud has no presets for user " << new_user_id << ", proceeding with migration check.";

--- a/src/slic3r/GUI/GUI_App.hpp
+++ b/src/slic3r/GUI/GUI_App.hpp
@@ -324,6 +324,7 @@ private:
     std::shared_ptr<int> m_user_sync_token;
     std::atomic<bool>    m_restart_sync_pending {false};
     std::atomic<bool>    m_sync_user_presets_now {false}; // request the sync loop to push user presets on its next tick
+    std::atomic<bool>    m_migration_retry_pending {false};
     bool             m_is_dark_mode{ false };
     bool             m_adding_script_handler { false };
     bool             m_side_popup_status{false};


### PR DESCRIPTION

### Problem

After OAuth PKCE login, there is a brief window (~1–3s) during which `api.orcaslicer.com` has not yet propagated the new Supabase session. If `get_user_presets` fires inside this window, it receives a 401 and `maybe_migrate_user_presets_on_login` bails out silently:

```
[warning] Failed to query OrcaCloud presets, skipping migration to avoid overwriting cloud data.
```

This affects first-time OrcaCloud users who have existing local presets — their presets are never migrated to the cloud, and they appear to have lost them after login.

PR #13781 fixed the **immediate logout** caused by this race (30-second grace period in `on_http_error`). This PR fixes the **silent migration failure** that still occurs even after that fix, since the migration and the logout handler operate on completely separate code paths.

### Fix

When `get_user_presets` returns a non-zero error code during the 30-second login grace period, schedule a single deferred retry:

- A background thread sleeps 5 seconds (past the observed ~1–3s propagation window), then posts back to the main thread via `CallAfter`
- The retry re-runs the full migration check; if it succeeds, user presets are reloaded and the UI is updated
- An atomic `m_migration_retry_pending` flag prevents duplicate retries if multiple 401s fire during warmup
- Guards against app shutdown (`is_closing()`) and mid-retry logout (`is_user_login()`)

The 5-second delay is intentional — it must be long enough for token propagation but short enough that the user hasn't started working yet.

### Scope

- Only triggers during the 30-second login grace window (same condition as the existing suppressed-logout path)
- Only triggers when migration explicitly failed due to a query error, not when cloud already had presets or when the user declined migration
- No change to normal login flow or sync behavior

### Testing

Reproduce by building RelWithDebInfo, logging out fully, then logging in via PKCE OAuth with a network throttler adding 2–3s of latency to `api.orcaslicer.com`. Without this fix the migration is skipped; with it, logs show `Retrying preset migration after token propagation window.` approximately 5 seconds after login completes.

### Related

- Fixes silent side-effect of the race described in #13781

