### PR TITLE
Fix crash when deleting filaments after a profile switch

### DIFF
--- a/src/slic3r/GUI/PartPlate.cpp
+++ b/src/slic3r/GUI/PartPlate.cpp
@@ -3762,7 +3762,11 @@ void PartPlate::on_filament_deleted(int filament_count, int filament_id)
 {
     if (m_config.has("filament_map")) {
         std::vector<int>& filament_maps = m_config.option<ConfigOptionInts>("filament_map")->values;
-        filament_maps.erase(filament_maps.begin() + filament_id);
+        // Guard against an out-of-range index: the per-plate filament_map can be out of sync
+        // with the global filament count, and erasing at/past end() triggers an out-of-bounds
+        // memmove (crash on macOS, see PartPlate::on_filament_deleted in crash reports).
+        if (filament_id >= 0 && filament_id < (int) filament_maps.size())
+            filament_maps.erase(filament_maps.begin() + filament_id);
     }
     update_first_layer_print_sequence_when_delete_filament(filament_id);
 }


### PR DESCRIPTION
# Description

Fixes a crash when deleting a filament, caused by an unguarded out-of-bounds std::vector::erase in PartPlate::on_filament_deleted where filament_id could index at or past the end of the per-plate filament_map. 

The caller validates filament_id against the global filament count rather than this plate's filament_map size, which can be shorter or out of sync (e.g. after loading a project or switching printer profiles), so a "valid" index could still walk off the end of the vector. 

The fix adds a bounds check (filament_id >= 0 && filament_id < filament_maps.size()) before erasing, leaving a stale or short map untouched instead of corrupting memory.


## Tests

Switch profiles with largely different filament numbers. Remove filaments. Doesn't crash any more

<!--
> A guide for users on how to download the artifacts from this PR.
-->

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
