### PR TITLE
fix: misc issues in step import dialog

### DIFF
--- a/src/libslic3r/Format/STEP.hpp
+++ b/src/libslic3r/Format/STEP.hpp
@@ -107,7 +107,7 @@ public:
                      double linear_defletion = 0.003,
                      double angle_defletion = 0.5);
 
-    std::atomic<bool> m_stop_mesh;
+    std::atomic<bool> m_stop_mesh{false};
     void update_process(int load_stage, int current, int total, bool& cancel);
 private:
     std::string m_path;

--- a/src/slic3r/GUI/StepMeshDialog.cpp
+++ b/src/slic3r/GUI/StepMeshDialog.cpp
@@ -258,10 +258,9 @@ StepMeshDialog::StepMeshDialog(wxWindow* parent, Slic3r::Step& file, double line
     wxStaticText *mesh_face_number_title = new wxStaticText(this, wxID_ANY, _L("Number of triangular facets") + ": ");
     mesh_face_number_title->SetFont(::Label::Body_14);
     mesh_face_number_title->SetForegroundColour(StateColor::darkModeColorFor(FONT_COLOR));
-    mesh_face_number_text = new wxStaticText(this, wxID_ANY, "0");
+    mesh_face_number_text = new wxStaticText(this, wxID_ANY, _L("Calculating, please wait..."));
     mesh_face_number_text->SetFont(::Label::Body_14);
     mesh_face_number_text->SetForegroundColour(StateColor::darkModeColorFor(FONT_COLOR));
-    mesh_face_number_text->SetMinSize(wxSize(FromDIP(150), -1));
     mesh_face_number_sizer->Add(mesh_face_number_title, 0, wxALIGN_LEFT);
     mesh_face_number_sizer->Add(mesh_face_number_text, 0, wxALIGN_LEFT);
     bSizer->Add(mesh_face_number_sizer, 0, wxEXPAND | wxALL, LEFT_RIGHT_PADING);


### PR DESCRIPTION
## Description
Small bug fixes for the STEP import dialog

### Initial mesh count sometimes does not complete
The `m_stop_mesh` flag for cancelling the mesh face calculation uses uninitialized memory, causing the initial face count to sometimes cancel before completion. Fix is to initialize it to `false`.

### Initial "Calculating, please wait..." text is cut off
<img width="300" alt="Screenshot_2" src="https://github.com/user-attachments/assets/2c93bad8-08b5-4e7f-8e42-4e3f853cee13" />
<img width="300" alt="Screenshot_1" src="https://github.com/user-attachments/assets/94ac503d-d221-4bd6-85f6-a9bbdfca95e0" />

The issue appears on the initial wait text only, it goes away after manually updating the STEP parameters. Fix is to remove the hardcoded minimum width and let wxWidgets dynamically calculate the needed width.

## Tests
Tested fixes on Linux. I can test on Windows with a CI build.

* Initial mesh count completes successfully
* Initial "Calculating, please wait..." text is completely shown  
  [Sample moderately sized step file](https://www.steptools.com/docs/stpfiles/ap203/tork.stp)

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
