### PR TITLE
Bug fix of Creality K2 Plus profiles start gcode

### DIFF
--- a/resources/profiles/Creality/filament/CR-ABS @K2 Plus-all.json
+++ b/resources/profiles/Creality/filament/CR-ABS @K2 Plus-all.json
@@ -114,7 +114,7 @@
         "100"
     ],
     "filament_start_gcode": [
-        ";filament start gcode\n{if !multicolor_method}\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}\n\n{if(initial_extruder != current_extruder || layer_z > first_layer_height)}\n{if (layer_z +0.4  < printable_height) }\nG2 Z{layer_z  + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X205 Y345 F20000\nG1 Z{layer_z } F1200\n{else}\nG1 X205 Y345 F20000\n{endif}\n{endif}\n{endif}"
+        "; filament start gcode\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
     ],
     "filament_end_gcode": [
         "; filament end gcode \n"

--- a/resources/profiles/Creality/filament/CR-Nylon @K2 Plus-all.json
+++ b/resources/profiles/Creality/filament/CR-Nylon @K2 Plus-all.json
@@ -153,7 +153,7 @@
         "50"
     ],
     "filament_start_gcode": [
-        ";filament start gcode\n{if !multicolor_method}\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}\n\n{if(initial_extruder != current_extruder || layer_z > first_layer_height)}\n{if (layer_z +0.4  < printable_height) }\nG2 Z{layer_z  + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X205 Y345 F20000\nG1 Z{layer_z } F1200\n{else}\nG1 X205 Y345 F20000\n{endif}\n{endif}\n{endif}"
+        "; filament start gcode\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
     ],
     "filament_end_gcode": [
         ";filament end gcode \n"

--- a/resources/profiles/Creality/filament/CR-PETG @K2 Plus-all.json
+++ b/resources/profiles/Creality/filament/CR-PETG @K2 Plus-all.json
@@ -102,7 +102,7 @@
         "70"
     ],
     "filament_start_gcode": [
-        ";filament start gcode\n{if !multicolor_method}\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}\n\n{if(initial_extruder != current_extruder || layer_z > first_layer_height)}\n{if (layer_z +0.4  < printable_height) }\nG2 Z{layer_z  + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X205 Y345 F20000\nG1 Z{layer_z } F1200\n{else}\nG1 X205 Y345 F20000\n{endif}\n{endif}\n{endif}"
+        "; filament start gcode\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
     ],
     "activate_chamber_temp_control": "1",
     "chamber_temperature": "35",

--- a/resources/profiles/Creality/filament/CR-PLA @K2 Plus-all.json
+++ b/resources/profiles/Creality/filament/CR-PLA @K2 Plus-all.json
@@ -111,7 +111,7 @@
         "50"
     ],
     "filament_start_gcode": [
-        ";filament start gcode\n{if !multicolor_method}\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}\n\n{if(initial_extruder != current_extruder || layer_z > first_layer_height)}\n{if (layer_z +0.4  < printable_height) }\nG2 Z{layer_z  + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X205 Y345 F20000\nG1 Z{layer_z } F1200\n{else}\nG1 X205 Y345 F20000\n{endif}\n{endif}\n{endif}"
+        "; filament start gcode\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
     ],
     "filament_end_gcode": [
         "; filament end gcode \n"

--- a/resources/profiles/Creality/filament/CR-PLA Carbon @K2 Plus-all.json
+++ b/resources/profiles/Creality/filament/CR-PLA Carbon @K2 Plus-all.json
@@ -120,7 +120,7 @@
         "50"
     ],
     "filament_start_gcode": [
-        ";filament start gcode\n{if !multicolor_method}\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}\n\n{if(initial_extruder != current_extruder || layer_z > first_layer_height)}\n{if (layer_z +0.4  < printable_height) }\nG2 Z{layer_z  + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X205 Y345 F20000\nG1 Z{layer_z } F1200\n{else}\nG1 X205 Y345 F20000\n{endif}\n{endif}\n{endif}"
+        "; filament start gcode\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
     ],
     "filament_end_gcode": [
         ";filament end gcode \n"

--- a/resources/profiles/Creality/filament/CR-PLA Fluo @K2 Plus-all.json
+++ b/resources/profiles/Creality/filament/CR-PLA Fluo @K2 Plus-all.json
@@ -111,7 +111,7 @@
         "50"
     ],
     "filament_start_gcode": [
-        ";filament start gcode\n{if !multicolor_method}\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}\n\n{if(initial_extruder != current_extruder || layer_z > first_layer_height)}\n{if (layer_z +0.4  < printable_height) }\nG2 Z{layer_z  + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X205 Y345 F20000\nG1 Z{layer_z } F1200\n{else}\nG1 X205 Y345 F20000\n{endif}\n{endif}\n{endif}"
+        "; filament start gcode\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
     ],
     "filament_end_gcode": [
         "; filament end gcode \n"

--- a/resources/profiles/Creality/filament/CR-PLA Matte @K2 Plus-all.json
+++ b/resources/profiles/Creality/filament/CR-PLA Matte @K2 Plus-all.json
@@ -114,7 +114,7 @@
         "50"
     ],
     "filament_start_gcode": [
-        ";filament start gcode\n{if !multicolor_method}\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}\n\n{if(initial_extruder != current_extruder || layer_z > first_layer_height)}\n{if (layer_z +0.4  < printable_height) }\nG2 Z{layer_z  + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X205 Y345 F20000\nG1 Z{layer_z } F1200\n{else}\nG1 X205 Y345 F20000\n{endif}\n{endif}\n{endif}"
+        "; filament start gcode\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
     ],
     "filament_end_gcode": [
         "; filament end gcode \n"

--- a/resources/profiles/Creality/filament/CR-Silk @K2 Plus-all.json
+++ b/resources/profiles/Creality/filament/CR-Silk @K2 Plus-all.json
@@ -120,7 +120,7 @@
         "50"
     ],
     "filament_start_gcode": [
-        ";filament start gcode\n{if !multicolor_method}\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}\n\n{if(initial_extruder != current_extruder || layer_z > first_layer_height)}\n{if (layer_z +0.4  < printable_height) }\nG2 Z{layer_z  + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X205 Y345 F20000\nG1 Z{layer_z } F1200\n{else}\nG1 X205 Y345 F20000\n{endif}\n{endif}\n{endif}"
+        "; filament start gcode\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
     ],
     "filament_end_gcode": [
         "; filament end gcode \n"

--- a/resources/profiles/Creality/filament/CR-TPU @K2 Plus-all.json
+++ b/resources/profiles/Creality/filament/CR-TPU @K2 Plus-all.json
@@ -126,7 +126,7 @@
         "40"
     ],
     "filament_start_gcode": [
-        ";filament start gcode\n{if !multicolor_method}\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}\n\n{if(initial_extruder != current_extruder || layer_z > first_layer_height)}\n{if (layer_z +0.4  < printable_height) }\nG2 Z{layer_z  + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X205 Y345 F20000\nG1 Z{layer_z } F1200\n{else}\nG1 X205 Y345 F20000\n{endif}\n{endif}\n{endif}"
+        "; filament start gcode\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
     ],
     "filament_end_gcode": [
         ";filament end gcode \n"

--- a/resources/profiles/Creality/filament/CR-Wood @K2 Plus-all.json
+++ b/resources/profiles/Creality/filament/CR-Wood @K2 Plus-all.json
@@ -117,7 +117,7 @@
         "50"
     ],
     "filament_start_gcode": [
-        ";filament start gcode\n{if !multicolor_method}\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}\n\n{if(initial_extruder != current_extruder || layer_z > first_layer_height)}\n{if (layer_z +0.4  < printable_height) }\nG2 Z{layer_z  + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X205 Y345 F20000\nG1 Z{layer_z } F1200\n{else}\nG1 X205 Y345 F20000\n{endif}\n{endif}\n{endif}"
+        "; filament start gcode\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
     ],
     "filament_end_gcode": [
         ";filament end gcode \n"

--- a/resources/profiles/Creality/filament/EN-PLA+ @K2 Plus-all.json
+++ b/resources/profiles/Creality/filament/EN-PLA+ @K2 Plus-all.json
@@ -111,7 +111,7 @@
         "50"
     ],
     "filament_start_gcode": [
-        ";filament start gcode\n{if !multicolor_method}\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}\n\n{if(initial_extruder != current_extruder || layer_z > first_layer_height)}\n{if (layer_z +0.4  < printable_height) }\nG2 Z{layer_z  + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X205 Y345 F20000\nG1 Z{layer_z } F1200\n{else}\nG1 X205 Y345 F20000\n{endif}\n{endif}\n{endif}"
+        "; filament start gcode\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
     ],
     "filament_end_gcode": [
         ";filament end gcode \n"

--- a/resources/profiles/Creality/filament/ENDER FAST PLA @K2 Plus-all.json
+++ b/resources/profiles/Creality/filament/ENDER FAST PLA @K2 Plus-all.json
@@ -120,7 +120,7 @@
         "50"
     ],
     "filament_start_gcode": [
-        ";filament start gcode\n{if !multicolor_method}\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}\n\n{if(initial_extruder != current_extruder || layer_z > first_layer_height)}\n{if (layer_z +0.4  < printable_height) }\nG2 Z{layer_z  + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X205 Y345 F20000\nG1 Z{layer_z } F1200\n{else}\nG1 X205 Y345 F20000\n{endif}\n{endif}\n{endif}"
+        "; filament start gcode\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
     ],
     "filament_end_gcode": [
         "; filament end gcode \n"

--- a/resources/profiles/Creality/filament/Ender-PLA @K2 Plus-all.json
+++ b/resources/profiles/Creality/filament/Ender-PLA @K2 Plus-all.json
@@ -108,7 +108,7 @@
         "50"
     ],
     "filament_start_gcode": [
-        ";filament start gcode\n{if !multicolor_method}\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}\n\n{if(initial_extruder != current_extruder || layer_z > first_layer_height)}\n{if (layer_z +0.4  < printable_height) }\nG2 Z{layer_z  + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X205 Y345 F20000\nG1 Z{layer_z } F1200\n{else}\nG1 X205 Y345 F20000\n{endif}\n{endif}\n{endif}"
+        "; filament start gcode\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
     ],
     "filament_end_gcode": [
         ";filament end gcode \n"

--- a/resources/profiles/Creality/filament/Generic ABS @K2 Plus-all.json
+++ b/resources/profiles/Creality/filament/Generic ABS @K2 Plus-all.json
@@ -111,7 +111,7 @@
         "100"
     ],
     "filament_start_gcode": [
-        ";filament start gcode\n{if !multicolor_method}\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}\n\n{if(initial_extruder != current_extruder || layer_z > first_layer_height)}\n{if (layer_z +0.4  < printable_height) }\nG2 Z{layer_z  + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X205 Y345 F20000\nG1 Z{layer_z } F1200\n{else}\nG1 X205 Y345 F20000\n{endif}\n{endif}\n{endif}"
+        "; filament start gcode\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
     ],
     "filament_end_gcode": [
         ";filament end gcode \n"

--- a/resources/profiles/Creality/filament/Generic ASA @K2 Plus-all.json
+++ b/resources/profiles/Creality/filament/Generic ASA @K2 Plus-all.json
@@ -114,7 +114,7 @@
         "90"
     ],
     "filament_start_gcode": [
-        ";filament start gcode\n{if !multicolor_method}\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}\n\n{if(initial_extruder != current_extruder || layer_z > first_layer_height)}\n{if (layer_z +0.4  < printable_height) }\nG2 Z{layer_z  + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X205 Y345 F20000\nG1 Z{layer_z } F1200\n{else}\nG1 X205 Y345 F20000\n{endif}\n{endif}\n{endif}"
+        "; filament start gcode\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
     ],
     "filament_end_gcode": [
         ";filament end gcode \n"

--- a/resources/profiles/Creality/filament/Generic ASA-CF @K2 Plus-all.json
+++ b/resources/profiles/Creality/filament/Generic ASA-CF @K2 Plus-all.json
@@ -102,7 +102,7 @@
         "90"
     ],
     "filament_start_gcode": [
-        ";filament start gcode\n{if !multicolor_method}\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}\n\n{if(initial_extruder != current_extruder || layer_z > first_layer_height)}\n{if (layer_z +0.4  < printable_height) }\nG2 Z{layer_z  + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X205 Y345 F20000\nG1 Z{layer_z } F1200\n{else}\nG1 X205 Y345 F20000\n{endif}\n{endif}\n{endif}"
+        "; filament start gcode\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
     ],
     "filament_end_gcode": [
         ";filament end gcode \n"

--- a/resources/profiles/Creality/filament/Generic BVOH @K2 Plus-all.json
+++ b/resources/profiles/Creality/filament/Generic BVOH @K2 Plus-all.json
@@ -99,7 +99,7 @@
         "50"
     ],
     "filament_start_gcode": [
-        ";filament start gcode\n{if !multicolor_method}\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}\n\n{if(initial_extruder != current_extruder || layer_z > first_layer_height)}\n{if (layer_z +0.4  < printable_height) }\nG2 Z{layer_z  + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X205 Y345 F20000\nG1 Z{layer_z } F1200\n{else}\nG1 X205 Y345 F20000\n{endif}\n{endif}\n{endif}"
+        "; filament start gcode\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
     ],
     "filament_end_gcode": [
         ";filament end gcode \n"

--- a/resources/profiles/Creality/filament/Generic HIPS @K2 Plus-all.json
+++ b/resources/profiles/Creality/filament/Generic HIPS @K2 Plus-all.json
@@ -99,7 +99,7 @@
         "100"
     ],
     "filament_start_gcode": [
-        ";filament start gcode\n{if !multicolor_method}\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}\n\n{if(initial_extruder != current_extruder || layer_z > first_layer_height)}\n{if (layer_z +0.4  < printable_height) }\nG2 Z{layer_z  + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X205 Y345 F20000\nG1 Z{layer_z } F1200\n{else}\nG1 X205 Y345 F20000\n{endif}\n{endif}\n{endif}"
+        "; filament start gcode\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
     ],
     "filament_end_gcode": [
         ";filament end gcode \n"

--- a/resources/profiles/Creality/filament/Generic PA @K2 Plus-all.json
+++ b/resources/profiles/Creality/filament/Generic PA @K2 Plus-all.json
@@ -138,7 +138,7 @@
         "50"
     ],
     "filament_start_gcode": [
-        ";filament start gcode\n{if !multicolor_method}\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}\n\n{if(initial_extruder != current_extruder || layer_z > first_layer_height)}\n{if (layer_z +0.4  < printable_height) }\nG2 Z{layer_z  + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X205 Y345 F20000\nG1 Z{layer_z } F1200\n{else}\nG1 X205 Y345 F20000\n{endif}\n{endif}\n{endif}"
+        "; filament start gcode\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
     ],
     "filament_end_gcode": [
         ";filament end gcode \n"

--- a/resources/profiles/Creality/filament/Generic PA-CF @K2 Plus-all.json
+++ b/resources/profiles/Creality/filament/Generic PA-CF @K2 Plus-all.json
@@ -135,7 +135,7 @@
         "60"
     ],
     "filament_start_gcode": [
-        ";filament start gcode\n{if !multicolor_method}\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}\n\n{if(initial_extruder != current_extruder || layer_z > first_layer_height)}\n{if (layer_z +0.4  < printable_height) }\nG2 Z{layer_z  + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X205 Y345 F20000\nG1 Z{layer_z } F1200\n{else}\nG1 X205 Y345 F20000\n{endif}\n{endif}\n{endif}"
+        "; filament start gcode\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
     ],
     "filament_end_gcode": [
         ";filament end gcode \n"

--- a/resources/profiles/Creality/filament/Generic PA12-CF @K2 Plus-all.json
+++ b/resources/profiles/Creality/filament/Generic PA12-CF @K2 Plus-all.json
@@ -138,7 +138,7 @@
         "60"
     ],
     "filament_start_gcode": [
-        ";filament start gcode\n{if !multicolor_method}\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}\n\n{if(initial_extruder != current_extruder || layer_z > first_layer_height)}\n{if (layer_z +0.4  < printable_height) }\nG2 Z{layer_z  + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X205 Y345 F20000\nG1 Z{layer_z } F1200\n{else}\nG1 X205 Y345 F20000\n{endif}\n{endif}\n{endif}"
+        "; filament start gcode\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
     ],
     "filament_end_gcode": [
         ";filament end gcode \n"

--- a/resources/profiles/Creality/filament/Generic PA6-CF @K2 Plus-all.json
+++ b/resources/profiles/Creality/filament/Generic PA6-CF @K2 Plus-all.json
@@ -147,7 +147,7 @@
         "60"
     ],
     "filament_start_gcode": [
-        ";filament start gcode\n{if !multicolor_method}\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}\n\n{if(initial_extruder != current_extruder || layer_z > first_layer_height)}\n{if (layer_z +0.4  < printable_height) }\nG2 Z{layer_z  + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X205 Y345 F20000\nG1 Z{layer_z } F1200\n{else}\nG1 X205 Y345 F20000\n{endif}\n{endif}\n{endif}"
+        "; filament start gcode\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
     ],
     "filament_end_gcode": [
         ";filament end gcode \n"

--- a/resources/profiles/Creality/filament/Generic PA6-GF @K2 Plus-all.json
+++ b/resources/profiles/Creality/filament/Generic PA6-GF @K2 Plus-all.json
@@ -105,7 +105,7 @@
         "100"
     ],
     "filament_start_gcode": [
-        ";filament start gcode\n{if !multicolor_method}\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}\n\n{if(initial_extruder != current_extruder || layer_z > first_layer_height)}\n{if (layer_z +0.4  < printable_height) }\nG2 Z{layer_z  + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X205 Y345 F20000\nG1 Z{layer_z } F1200\n{else}\nG1 X205 Y345 F20000\n{endif}\n{endif}\n{endif}"
+        "; filament start gcode\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
     ],
     "filament_end_gcode": [
         ";filament end gcode "

--- a/resources/profiles/Creality/filament/Generic PA612-CF @K2 Plus-all.json
+++ b/resources/profiles/Creality/filament/Generic PA612-CF @K2 Plus-all.json
@@ -138,7 +138,7 @@
         "60"
     ],
     "filament_start_gcode": [
-        ";filament start gcode\n{if !multicolor_method}\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}\n\n{if(initial_extruder != current_extruder || layer_z > first_layer_height)}\n{if (layer_z +0.4  < printable_height) }\nG2 Z{layer_z  + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X205 Y345 F20000\nG1 Z{layer_z } F1200\n{else}\nG1 X205 Y345 F20000\n{endif}\n{endif}\n{endif}"
+        "; filament start gcode\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
     ],
     "filament_end_gcode": [
         ";filament end gcode \n"

--- a/resources/profiles/Creality/filament/Generic PAHT-CF @K2 Plus-all.json
+++ b/resources/profiles/Creality/filament/Generic PAHT-CF @K2 Plus-all.json
@@ -150,7 +150,7 @@
         "90"
     ],
     "filament_start_gcode": [
-        ";filament start gcode\n{if !multicolor_method}\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}\n\n{if(initial_extruder != current_extruder || layer_z > first_layer_height)}\n{if (layer_z +0.4  < printable_height) }\nG2 Z{layer_z  + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X205 Y345 F20000\nG1 Z{layer_z } F1200\n{else}\nG1 X205 Y345 F20000\n{endif}\n{endif}\n{endif}"
+        "; filament start gcode\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
     ],
     "filament_end_gcode": [
         ";filament end gcode \n"

--- a/resources/profiles/Creality/filament/Generic PC @K2 Plus-all.json
+++ b/resources/profiles/Creality/filament/Generic PC @K2 Plus-all.json
@@ -120,7 +120,7 @@
         "110"
     ],
     "filament_start_gcode": [
-        ";filament start gcode\n{if !multicolor_method}\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}\n\n{if(initial_extruder != current_extruder || layer_z > first_layer_height)}\n{if (layer_z +0.4  < printable_height) }\nG2 Z{layer_z  + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X205 Y345 F20000\nG1 Z{layer_z } F1200\n{else}\nG1 X205 Y345 F20000\n{endif}\n{endif}\n{endif}"
+        "; filament start gcode\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
     ],
     "filament_end_gcode": [
         ";filament end gcode \n"

--- a/resources/profiles/Creality/filament/Generic PCTG @K2 Plus-all.json
+++ b/resources/profiles/Creality/filament/Generic PCTG @K2 Plus-all.json
@@ -102,7 +102,7 @@
         "70"
     ],
     "filament_start_gcode": [
-        ";filament start gcode\n{if !multicolor_method}\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}\n\n{if(initial_extruder != current_extruder || layer_z > first_layer_height)}\n{if (layer_z +0.4  < printable_height) }\nG2 Z{layer_z  + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X205 Y345 F20000\nG1 Z{layer_z } F1200\n{else}\nG1 X205 Y345 F20000\n{endif}\n{endif}\n{endif}"
+        "; filament start gcode\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
     ],
     "filament_end_gcode": [
         ";filament end gcode "

--- a/resources/profiles/Creality/filament/Generic PET @K2 Plus-all.json
+++ b/resources/profiles/Creality/filament/Generic PET @K2 Plus-all.json
@@ -147,7 +147,7 @@
         "90"
     ],
     "filament_start_gcode": [
-        ";filament start gcode\n{if !multicolor_method}\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}\n\n{if(initial_extruder != current_extruder || layer_z > first_layer_height)}\n{if (layer_z +0.4  < printable_height) }\nG2 Z{layer_z  + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X205 Y345 F20000\nG1 Z{layer_z } F1200\n{else}\nG1 X205 Y345 F20000\n{endif}\n{endif}\n{endif}"
+        "; filament start gcode\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
     ],
     "filament_end_gcode": [
         ";filament end gcode \n"

--- a/resources/profiles/Creality/filament/Generic PET-CF @K2 Plus-all.json
+++ b/resources/profiles/Creality/filament/Generic PET-CF @K2 Plus-all.json
@@ -150,7 +150,7 @@
         "90"
     ],
     "filament_start_gcode": [
-        ";filament start gcode\n{if !multicolor_method}\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}\n\n{if(initial_extruder != current_extruder || layer_z > first_layer_height)}\n{if (layer_z +0.4  < printable_height) }\nG2 Z{layer_z  + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X205 Y345 F20000\nG1 Z{layer_z } F1200\n{else}\nG1 X205 Y345 F20000\n{endif}\n{endif}\n{endif}"
+        "; filament start gcode\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
     ],
     "filament_end_gcode": [
         ";filament end gcode \n"

--- a/resources/profiles/Creality/filament/Generic PETG @K2 Plus-all.json
+++ b/resources/profiles/Creality/filament/Generic PETG @K2 Plus-all.json
@@ -96,7 +96,7 @@
         "70"
     ],
     "filament_start_gcode": [
-        ";filament start gcode\n{if !multicolor_method}\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}\n\n{if(initial_extruder != current_extruder || layer_z > first_layer_height)}\n{if (layer_z +0.4  < printable_height) }\nG2 Z{layer_z  + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X205 Y345 F20000\nG1 Z{layer_z } F1200\n{else}\nG1 X205 Y345 F20000\n{endif}\n{endif}\n{endif}"
+        "; filament start gcode\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
     ],
     "filament_end_gcode": [
         ";filament end gcode \n"

--- a/resources/profiles/Creality/filament/Generic PETG-CF @K2 Plus-all.json
+++ b/resources/profiles/Creality/filament/Generic PETG-CF @K2 Plus-all.json
@@ -105,7 +105,7 @@
         "80"
     ],
     "filament_start_gcode": [
-        ";filament start gcode\n{if !multicolor_method}\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}\n\n{if(initial_extruder != current_extruder || layer_z > first_layer_height)}\n{if (layer_z +0.4  < printable_height) }\nG2 Z{layer_z  + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X205 Y345 F20000\nG1 Z{layer_z } F1200\n{else}\nG1 X205 Y345 F20000\n{endif}\n{endif}\n{endif}"
+        "; filament start gcode\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
     ],
     "filament_end_gcode": [
         ";filament end gcode \n"

--- a/resources/profiles/Creality/filament/Generic PETG-GF @K2 Plus-all.json
+++ b/resources/profiles/Creality/filament/Generic PETG-GF @K2 Plus-all.json
@@ -105,7 +105,7 @@
         "70"
     ],
     "filament_start_gcode": [
-        ";filament start gcode\n{if !multicolor_method}\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}\n\n{if(initial_extruder != current_extruder || layer_z > first_layer_height)}\n{if (layer_z +0.4  < printable_height) }\nG2 Z{layer_z  + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X205 Y345 F20000\nG1 Z{layer_z } F1200\n{else}\nG1 X205 Y345 F20000\n{endif}\n{endif}\n{endif}"
+        "; filament start gcode\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
     ],
     "filament_end_gcode": [
         ";filament end gcode \n"

--- a/resources/profiles/Creality/filament/Generic PLA @K2 Plus-all.json
+++ b/resources/profiles/Creality/filament/Generic PLA @K2 Plus-all.json
@@ -120,7 +120,7 @@
         "50"
     ],
     "filament_start_gcode": [
-        ";filament start gcode\n{if !multicolor_method}\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}\n\n{if(initial_extruder != current_extruder || layer_z > first_layer_height)}\n{if (layer_z +0.4  < printable_height) }\nG2 Z{layer_z  + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X205 Y345 F20000\nG1 Z{layer_z } F1200\n{else}\nG1 X205 Y345 F20000\n{endif}\n{endif}\n{endif}"
+        "; filament start gcode\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
     ],
     "filament_end_gcode": [
         ";filament end gcode \n"

--- a/resources/profiles/Creality/filament/Generic PLA-CF @K2 Plus-all.json
+++ b/resources/profiles/Creality/filament/Generic PLA-CF @K2 Plus-all.json
@@ -123,7 +123,7 @@
         "50"
     ],
     "filament_start_gcode": [
-        ";filament start gcode\n{if !multicolor_method}\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}\n\n{if(initial_extruder != current_extruder || layer_z > first_layer_height)}\n{if (layer_z +0.4  < printable_height) }\nG2 Z{layer_z  + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X205 Y345 F20000\nG1 Z{layer_z } F1200\n{else}\nG1 X205 Y345 F20000\n{endif}\n{endif}\n{endif}"
+        "; filament start gcode\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
     ],
     "filament_end_gcode": [
         ";filament end gcode \n"

--- a/resources/profiles/Creality/filament/Generic PLA-Silk @K2 Plus-all.json
+++ b/resources/profiles/Creality/filament/Generic PLA-Silk @K2 Plus-all.json
@@ -117,7 +117,7 @@
         "50"
     ],
     "filament_start_gcode": [
-        ";filament start gcode\n{if !multicolor_method}\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}\n\n{if(initial_extruder != current_extruder || layer_z > first_layer_height)}\n{if (layer_z +0.4  < printable_height) }\nG2 Z{layer_z  + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X205 Y345 F20000\nG1 Z{layer_z } F1200\n{else}\nG1 X205 Y345 F20000\n{endif}\n{endif}\n{endif}"
+        "; filament start gcode\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
     ],
     "filament_end_gcode": [
         ";filament end gcode "

--- a/resources/profiles/Creality/filament/Generic PP @K2 Plus-all.json
+++ b/resources/profiles/Creality/filament/Generic PP @K2 Plus-all.json
@@ -99,7 +99,7 @@
         "40"
     ],
     "filament_start_gcode": [
-        ";filament start gcode\n{if !multicolor_method}\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}\n\n{if(initial_extruder != current_extruder || layer_z > first_layer_height)}\n{if (layer_z +0.4  < printable_height) }\nG2 Z{layer_z  + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X205 Y345 F20000\nG1 Z{layer_z } F1200\n{else}\nG1 X205 Y345 F20000\n{endif}\n{endif}\n{endif}"
+        "; filament start gcode\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
     ],
     "filament_end_gcode": [
         ";filament end gcode \n"

--- a/resources/profiles/Creality/filament/Generic PP-CF @K2 Plus-all.json
+++ b/resources/profiles/Creality/filament/Generic PP-CF @K2 Plus-all.json
@@ -102,7 +102,7 @@
         "80"
     ],
     "filament_start_gcode": [
-        ";filament start gcode\n{if !multicolor_method}\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}\n\n{if(initial_extruder != current_extruder || layer_z > first_layer_height)}\n{if (layer_z +0.4  < printable_height) }\nG2 Z{layer_z  + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X205 Y345 F20000\nG1 Z{layer_z } F1200\n{else}\nG1 X205 Y345 F20000\n{endif}\n{endif}\n{endif}"
+        "; filament start gcode\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
     ],
     "filament_end_gcode": [
         ";filament end gcode "

--- a/resources/profiles/Creality/filament/Generic PPS @K2 Plus-all.json
+++ b/resources/profiles/Creality/filament/Generic PPS @K2 Plus-all.json
@@ -105,7 +105,7 @@
         "90"
     ],
     "filament_start_gcode": [
-        ";filament start gcode\n{if !multicolor_method}\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}\n\n{if(initial_extruder != current_extruder || layer_z > first_layer_height)}\n{if (layer_z +0.4  < printable_height) }\nG2 Z{layer_z  + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X205 Y345 F20000\nG1 Z{layer_z } F1200\n{else}\nG1 X205 Y345 F20000\n{endif}\n{endif}\n{endif}"
+        "; filament start gcode\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
     ],
     "filament_end_gcode": [
         ";filament end gcode \n"

--- a/resources/profiles/Creality/filament/Generic PPS-CF @K2 Plus-all.json
+++ b/resources/profiles/Creality/filament/Generic PPS-CF @K2 Plus-all.json
@@ -99,7 +99,7 @@
         "105"
     ],
     "filament_start_gcode": [
-        ";filament start gcode\n{if !multicolor_method}\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}\n\n{if(initial_extruder != current_extruder || layer_z > first_layer_height)}\n{if (layer_z +0.4  < printable_height) }\nG2 Z{layer_z  + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X205 Y345 F20000\nG1 Z{layer_z } F1200\n{else}\nG1 X205 Y345 F20000\n{endif}\n{endif}\n{endif}"
+        "; filament start gcode\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
     ],
     "filament_end_gcode": [
         ";filament end gcode \n"

--- a/resources/profiles/Creality/filament/Generic PVA @K2 Plus-all.json
+++ b/resources/profiles/Creality/filament/Generic PVA @K2 Plus-all.json
@@ -102,7 +102,7 @@
         "50"
     ],
     "filament_start_gcode": [
-        ";filament start gcode\n{if !multicolor_method}\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}\n\n{if(initial_extruder != current_extruder || layer_z > first_layer_height)}\n{if (layer_z +0.4  < printable_height) }\nG2 Z{layer_z  + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X205 Y345 F20000\nG1 Z{layer_z } F1200\n{else}\nG1 X205 Y345 F20000\n{endif}\n{endif}\n{endif}"
+        "; filament start gcode\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
     ],
     "filament_end_gcode": [
         ";filament end gcode \n"

--- a/resources/profiles/Creality/filament/Generic Support for PA @K2 Plus-all.json
+++ b/resources/profiles/Creality/filament/Generic Support for PA @K2 Plus-all.json
@@ -135,7 +135,7 @@
         "80"
     ],
     "filament_start_gcode": [
-        ";filament start gcode\n{if !multicolor_method}\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}\n\n{if(initial_extruder != current_extruder || layer_z > first_layer_height)}\n{if (layer_z +0.4  < printable_height) }\nG2 Z{layer_z  + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X205 Y345 F20000\nG1 Z{layer_z } F1200\n{else}\nG1 X205 Y345 F20000\n{endif}\n{endif}\n{endif}"
+        "; filament start gcode\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
     ],
     "filament_end_gcode": [
         ";filament end gcode \n"

--- a/resources/profiles/Creality/filament/Generic Support for PLA @K2 Plus-all.json
+++ b/resources/profiles/Creality/filament/Generic Support for PLA @K2 Plus-all.json
@@ -117,7 +117,7 @@
         "50"
     ],
     "filament_start_gcode": [
-        ";filament start gcode\n{if !multicolor_method}\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}\n\n{if(initial_extruder != current_extruder || layer_z > first_layer_height)}\n{if (layer_z +0.4  < printable_height) }\nG2 Z{layer_z  + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X205 Y345 F20000\nG1 Z{layer_z } F1200\n{else}\nG1 X205 Y345 F20000\n{endif}\n{endif}\n{endif}"
+        "; filament start gcode\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
     ],
     "filament_end_gcode": [
         ";filament end gcode \n"

--- a/resources/profiles/Creality/filament/Generic TPU 64D @K2 Plus-all.json
+++ b/resources/profiles/Creality/filament/Generic TPU 64D @K2 Plus-all.json
@@ -129,7 +129,7 @@
         "40"
     ],
     "filament_start_gcode": [
-        ";filament start gcode\n{if !multicolor_method}\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}\n\n{if(initial_extruder != current_extruder || layer_z > first_layer_height)}\n{if (layer_z +0.4  < printable_height) }\nG2 Z{layer_z  + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X205 Y345 F20000\nG1 Z{layer_z } F1200\n{else}\nG1 X205 Y345 F20000\n{endif}\n{endif}\n{endif}"
+        "; filament start gcode\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
     ],
     "filament_end_gcode": [
         ";filament end gcode \n"

--- a/resources/profiles/Creality/filament/Generic TPU @K2 Plus-all.json
+++ b/resources/profiles/Creality/filament/Generic TPU @K2 Plus-all.json
@@ -117,7 +117,7 @@
         "40"
     ],
     "filament_start_gcode": [
-        ";filament start gcode\n{if !multicolor_method}\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}\n\n{if(initial_extruder != current_extruder || layer_z > first_layer_height)}\n{if (layer_z +0.4  < printable_height) }\nG2 Z{layer_z  + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X205 Y345 F20000\nG1 Z{layer_z } F1200\n{else}\nG1 X205 Y345 F20000\n{endif}\n{endif}\n{endif}"
+        "; filament start gcode\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
     ],
     "filament_end_gcode": [
         ";filament end gcode \n"

--- a/resources/profiles/Creality/filament/HP Ultra PLA @K2 Plus-all.json
+++ b/resources/profiles/Creality/filament/HP Ultra PLA @K2 Plus-all.json
@@ -114,7 +114,7 @@
         "50"
     ],
     "filament_start_gcode": [
-        ";filament start gcode\n{if !multicolor_method}\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}\n\n{if(initial_extruder != current_extruder || layer_z > first_layer_height)}\n{if (layer_z +0.4  < printable_height) }\nG2 Z{layer_z  + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X205 Y345 F20000\nG1 Z{layer_z } F1200\n{else}\nG1 X205 Y345 F20000\n{endif}\n{endif}\n{endif}"
+        "; filament start gcode\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
     ],
     "filament_end_gcode": [
         ";filament end gcode \n"

--- a/resources/profiles/Creality/filament/HP-ASA @K2 Plus-all.json
+++ b/resources/profiles/Creality/filament/HP-ASA @K2 Plus-all.json
@@ -132,7 +132,7 @@
         "90"
     ],
     "filament_start_gcode": [
-        ";filament start gcode\n{if !multicolor_method}\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}\n\n{if(initial_extruder != current_extruder || layer_z > first_layer_height)}\n{if (layer_z +0.4  < printable_height) }\nG2 Z{layer_z  + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X205 Y345 F20000\nG1 Z{layer_z } F1200\n{else}\nG1 X205 Y345 F20000\n{endif}\n{endif}\n{endif}"
+        "; filament start gcode\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
     ],
     "filament_end_gcode": [
         "; filament end gcode \n"

--- a/resources/profiles/Creality/filament/HP-TPU @K2 Plus-all.json
+++ b/resources/profiles/Creality/filament/HP-TPU @K2 Plus-all.json
@@ -126,7 +126,7 @@
         "40"
     ],
     "filament_start_gcode": [
-        ";filament start gcode\n{if !multicolor_method}\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}\n\n{if(initial_extruder != current_extruder || layer_z > first_layer_height)}\n{if (layer_z +0.4  < printable_height) }\nG2 Z{layer_z  + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X205 Y345 F20000\nG1 Z{layer_z } F1200\n{else}\nG1 X205 Y345 F20000\n{endif}\n{endif}\n{endif}"
+        "; filament start gcode\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
     ],
     "filament_end_gcode": [
         ";filament end gcode \n"

--- a/resources/profiles/Creality/filament/Hyper ABS @K2 Plus-all.json
+++ b/resources/profiles/Creality/filament/Hyper ABS @K2 Plus-all.json
@@ -120,7 +120,7 @@
         "80"
     ],
     "filament_start_gcode": [
-        ";filament start gcode\n{if !multicolor_method}\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}\n\n{if(initial_extruder != current_extruder || layer_z > first_layer_height)}\n{if (layer_z +0.4  < printable_height) }\nG2 Z{layer_z  + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X205 Y345 F20000\nG1 Z{layer_z } F1200\n{else}\nG1 X205 Y345 F20000\n{endif}\n{endif}\n{endif}"
+        "; filament start gcode\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
     ],
     "filament_end_gcode": [
         "; filament end gcode \n"

--- a/resources/profiles/Creality/filament/Hyper L-W PLA @K2 Plus-all.json
+++ b/resources/profiles/Creality/filament/Hyper L-W PLA @K2 Plus-all.json
@@ -120,7 +120,7 @@
         "50"
     ],
     "filament_start_gcode": [
-        ";filament start gcode\n{if !multicolor_method}\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}\n\n{if(initial_extruder != current_extruder || layer_z > first_layer_height)}\n{if (layer_z +0.4  < printable_height) }\nG2 Z{layer_z  + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X205 Y345 F20000\nG1 Z{layer_z } F1200\n{else}\nG1 X205 Y345 F20000\n{endif}\n{endif}\n{endif}"
+        "; filament start gcode\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
     ],
     "filament_end_gcode": [
         ";filament end gcode "

--- a/resources/profiles/Creality/filament/Hyper Marble @K2 Plus-all.json
+++ b/resources/profiles/Creality/filament/Hyper Marble @K2 Plus-all.json
@@ -117,7 +117,7 @@
         "50"
     ],
     "filament_start_gcode": [
-        ";filament start gcode\n{if !multicolor_method}\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}\n\n{if(initial_extruder != current_extruder || layer_z > first_layer_height)}\n{if (layer_z +0.4  < printable_height) }\nG2 Z{layer_z  + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X205 Y345 F20000\nG1 Z{layer_z } F1200\n{else}\nG1 X205 Y345 F20000\n{endif}\n{endif}\n{endif}"
+        "; filament start gcode\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
     ],
     "filament_end_gcode": [
         ";filament end gcode \n"

--- a/resources/profiles/Creality/filament/Hyper PA6-CF @K2 Plus-all.json
+++ b/resources/profiles/Creality/filament/Hyper PA6-CF @K2 Plus-all.json
@@ -153,7 +153,7 @@
         "60"
     ],
     "filament_start_gcode": [
-        ";filament start gcode\n{if !multicolor_method}\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}\n\n{if(initial_extruder != current_extruder || layer_z > first_layer_height)}\n{if (layer_z +0.4  < printable_height) }\nG2 Z{layer_z  + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X205 Y345 F20000\nG1 Z{layer_z } F1200\n{else}\nG1 X205 Y345 F20000\n{endif}\n{endif}\n{endif}"
+        "; filament start gcode\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
     ],
     "filament_end_gcode": [
         ";filament end gcode \n"

--- a/resources/profiles/Creality/filament/Hyper PA612-CF @K2 Plus-all.json
+++ b/resources/profiles/Creality/filament/Hyper PA612-CF @K2 Plus-all.json
@@ -147,7 +147,7 @@
         "60"
     ],
     "filament_start_gcode": [
-        ";filament start gcode\n{if !multicolor_method}\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}\n\n{if(initial_extruder != current_extruder || layer_z > first_layer_height)}\n{if (layer_z +0.4  < printable_height) }\nG2 Z{layer_z  + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X205 Y345 F20000\nG1 Z{layer_z } F1200\n{else}\nG1 X205 Y345 F20000\n{endif}\n{endif}\n{endif}"
+        "; filament start gcode\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
     ],
     "filament_end_gcode": [
         ";filament end gcode \n"

--- a/resources/profiles/Creality/filament/Hyper PAHT-CF @K2 Plus-all.json
+++ b/resources/profiles/Creality/filament/Hyper PAHT-CF @K2 Plus-all.json
@@ -147,7 +147,7 @@
         "90"
     ],
     "filament_start_gcode": [
-        ";filament start gcode\n{if !multicolor_method}\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}\n\n{if(initial_extruder != current_extruder || layer_z > first_layer_height)}\n{if (layer_z +0.4  < printable_height) }\nG2 Z{layer_z  + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X205 Y345 F20000\nG1 Z{layer_z } F1200\n{else}\nG1 X205 Y345 F20000\n{endif}\n{endif}\n{endif}"
+        "; filament start gcode\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
     ],
     "filament_end_gcode": [
         ";filament end gcode \n"

--- a/resources/profiles/Creality/filament/Hyper PC @K2 Plus-all.json
+++ b/resources/profiles/Creality/filament/Hyper PC @K2 Plus-all.json
@@ -123,7 +123,7 @@
         "110"
     ],
     "filament_start_gcode": [
-        ";filament start gcode\n{if !multicolor_method}\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}\n\n{if(initial_extruder != current_extruder || layer_z > first_layer_height)}\n{if (layer_z +0.4  < printable_height) }\nG2 Z{layer_z  + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X205 Y345 F20000\nG1 Z{layer_z } F1200\n{else}\nG1 X205 Y345 F20000\n{endif}\n{endif}\n{endif}"
+        "; filament start gcode\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
     ],
     "filament_end_gcode": [
         "; filament end gcode \n"

--- a/resources/profiles/Creality/filament/Hyper PETG @K2 Plus-all.json
+++ b/resources/profiles/Creality/filament/Hyper PETG @K2 Plus-all.json
@@ -105,7 +105,7 @@
         "70"
     ],
     "filament_start_gcode": [
-        ";filament start gcode\n{if !multicolor_method}\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}\n\n{if(initial_extruder != current_extruder || layer_z > first_layer_height)}\n{if (layer_z +0.4  < printable_height) }\nG2 Z{layer_z  + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X205 Y345 F20000\nG1 Z{layer_z } F1200\n{else}\nG1 X205 Y345 F20000\n{endif}\n{endif}\n{endif}"
+        "; filament start gcode\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
     ],
     "activate_chamber_temp_control": "1",
     "chamber_temperature": "35",

--- a/resources/profiles/Creality/filament/Hyper PETG-CF @K2 Plus-all.json
+++ b/resources/profiles/Creality/filament/Hyper PETG-CF @K2 Plus-all.json
@@ -96,7 +96,7 @@
         "70"
     ],
     "filament_start_gcode": [
-        ";filament start gcode\n{if !multicolor_method}\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}\n\n{if(initial_extruder != current_extruder || layer_z > first_layer_height)}\n{if (layer_z +0.4  < printable_height) }\nG2 Z{layer_z  + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X205 Y345 F20000\nG1 Z{layer_z } F1200\n{else}\nG1 X205 Y345 F20000\n{endif}\n{endif}\n{endif}"
+        "; filament start gcode\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
     ],
     "filament_end_gcode": [
         ";filament end gcode \n"

--- a/resources/profiles/Creality/filament/Hyper PETG-GF @K2 Plus-all.json
+++ b/resources/profiles/Creality/filament/Hyper PETG-GF @K2 Plus-all.json
@@ -96,7 +96,7 @@
         "70"
     ],
     "filament_start_gcode": [
-        ";filament start gcode\n{if !multicolor_method}\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}\n\n{if(initial_extruder != current_extruder || layer_z > first_layer_height)}\n{if (layer_z +0.4  < printable_height) }\nG2 Z{layer_z  + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X205 Y345 F20000\nG1 Z{layer_z } F1200\n{else}\nG1 X205 Y345 F20000\n{endif}\n{endif}\n{endif}"
+        "; filament start gcode\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
     ],
     "filament_end_gcode": [
         ";filament end gcode \n"

--- a/resources/profiles/Creality/filament/Hyper PLA @K2 Plus-all.json
+++ b/resources/profiles/Creality/filament/Hyper PLA @K2 Plus-all.json
@@ -111,7 +111,7 @@
         "50"
     ],
     "filament_start_gcode": [
-        ";filament start gcode\n{if !multicolor_method}\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}\n\n{if(initial_extruder != current_extruder || layer_z > first_layer_height)}\n{if (layer_z +0.4  < printable_height) }\nG2 Z{layer_z  + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X205 Y345 F20000\nG1 Z{layer_z } F1200\n{else}\nG1 X205 Y345 F20000\n{endif}\n{endif}\n{endif}"
+        "; filament start gcode\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
     ],
     "filament_end_gcode": [
         "; filament end gcode \n"

--- a/resources/profiles/Creality/filament/Hyper PLA-CF @K2 Plus-all.json
+++ b/resources/profiles/Creality/filament/Hyper PLA-CF @K2 Plus-all.json
@@ -120,7 +120,7 @@
         "50"
     ],
     "filament_start_gcode": [
-        ";filament start gcode\n{if !multicolor_method}\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}\n\n{if(initial_extruder != current_extruder || layer_z > first_layer_height)}\n{if (layer_z +0.4  < printable_height) }\nG2 Z{layer_z  + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X205 Y345 F20000\nG1 Z{layer_z } F1200\n{else}\nG1 X205 Y345 F20000\n{endif}\n{endif}\n{endif}"
+        "; filament start gcode\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
     ],
     "filament_end_gcode": [
         ";filament end gcode \n"

--- a/resources/profiles/Creality/filament/Hyper PPA-CF @K2 Plus-all.json
+++ b/resources/profiles/Creality/filament/Hyper PPA-CF @K2 Plus-all.json
@@ -138,7 +138,7 @@
         "110"
     ],
     "filament_start_gcode": [
-        ";filament start gcode\n{if !multicolor_method}\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}\n\n{if(initial_extruder != current_extruder || layer_z > first_layer_height)}\n{if (layer_z +0.4  < printable_height) }\nG2 Z{layer_z  + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X205 Y345 F20000\nG1 Z{layer_z } F1200\n{else}\nG1 X205 Y345 F20000\n{endif}\n{endif}\n{endif}"
+        "; filament start gcode\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
     ],
     "filament_end_gcode": [
         ";filament end gcode \n"

--- a/resources/profiles/Creality/filament/Hyper Stardust @K2 Plus-all.json
+++ b/resources/profiles/Creality/filament/Hyper Stardust @K2 Plus-all.json
@@ -114,7 +114,7 @@
         "50"
     ],
     "filament_start_gcode": [
-        ";filament start gcode\n{if !multicolor_method}\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}\n\n{if(initial_extruder != current_extruder || layer_z > first_layer_height)}\n{if (layer_z +0.4  < printable_height) }\nG2 Z{layer_z  + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X205 Y345 F20000\nG1 Z{layer_z } F1200\n{else}\nG1 X205 Y345 F20000\n{endif}\n{endif}\n{endif}"
+        "; filament start gcode\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
     ],
     "filament_end_gcode": [
         ";filament end gcode \n"

--- a/resources/profiles/Creality/filament/Panchroma PLA Matte @K2 Plus-all.json
+++ b/resources/profiles/Creality/filament/Panchroma PLA Matte @K2 Plus-all.json
@@ -123,7 +123,7 @@
         "50"
     ],
     "filament_start_gcode": [
-        ";filament start gcode\n{if !multicolor_method}\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}\n\n{if(initial_extruder != current_extruder || layer_z > first_layer_height)}\n{if (layer_z +0.4  < printable_height) }\nG2 Z{layer_z  + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X205 Y345 F20000\nG1 Z{layer_z } F1200\n{else}\nG1 X205 Y345 F20000\n{endif}\n{endif}\n{endif}"
+        "; filament start gcode\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
     ],
     "filament_end_gcode": [
         ";filament end gcode \n"

--- a/resources/profiles/Creality/filament/Panchroma PLA Satin @K2 Plus-all.json
+++ b/resources/profiles/Creality/filament/Panchroma PLA Satin @K2 Plus-all.json
@@ -120,7 +120,7 @@
         "50"
     ],
     "filament_start_gcode": [
-        ";filament start gcode\n{if !multicolor_method}\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}\n\n{if(initial_extruder != current_extruder || layer_z > first_layer_height)}\n{if (layer_z +0.4  < printable_height) }\nG2 Z{layer_z  + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X205 Y345 F20000\nG1 Z{layer_z } F1200\n{else}\nG1 X205 Y345 F20000\n{endif}\n{endif}\n{endif}"
+        "; filament start gcode\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
     ],
     "filament_end_gcode": [
         ";filament end gcode \n"

--- a/resources/profiles/Creality/filament/PolySonic PLA @K2 Plus-all.json
+++ b/resources/profiles/Creality/filament/PolySonic PLA @K2 Plus-all.json
@@ -126,7 +126,7 @@
         "50"
     ],
     "filament_start_gcode": [
-        ";filament start gcode\n{if !multicolor_method}\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}\n\n{if(initial_extruder != current_extruder || layer_z > first_layer_height)}\n{if (layer_z +0.4  < printable_height) }\nG2 Z{layer_z  + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X205 Y345 F20000\nG1 Z{layer_z } F1200\n{else}\nG1 X205 Y345 F20000\n{endif}\n{endif}\n{endif}"
+        "; filament start gcode\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
     ],
     "filament_end_gcode": [
         ";filament end gcode \n"

--- a/resources/profiles/Creality/filament/PolySonic PLA Pro @K2 Plus-all.json
+++ b/resources/profiles/Creality/filament/PolySonic PLA Pro @K2 Plus-all.json
@@ -120,7 +120,7 @@
         "50"
     ],
     "filament_start_gcode": [
-        ";filament start gcode\n{if !multicolor_method}\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}\n\n{if(initial_extruder != current_extruder || layer_z > first_layer_height)}\n{if (layer_z +0.4  < printable_height) }\nG2 Z{layer_z  + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X205 Y345 F20000\nG1 Z{layer_z } F1200\n{else}\nG1 X205 Y345 F20000\n{endif}\n{endif}\n{endif}"
+        "; filament start gcode\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
     ],
     "filament_end_gcode": [
         ";filament end gcode \n"

--- a/resources/profiles/Creality/filament/Soleyin Ultra PLA @K2 Plus-all.json
+++ b/resources/profiles/Creality/filament/Soleyin Ultra PLA @K2 Plus-all.json
@@ -120,7 +120,7 @@
         "50"
     ],
     "filament_start_gcode": [
-        ";filament start gcode\n{if !multicolor_method}\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}\n\n{if(initial_extruder != current_extruder || layer_z > first_layer_height)}\n{if (layer_z +0.4  < printable_height) }\nG2 Z{layer_z  + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X205 Y345 F20000\nG1 Z{layer_z } F1200\n{else}\nG1 X205 Y345 F20000\n{endif}\n{endif}\n{endif}"
+        "; filament start gcode\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
     ],
     "filament_end_gcode": [
         ";filament end gcode \n"

--- a/resources/profiles/Creality/filament/eSUN ABS+ @K2 Plus-all.json
+++ b/resources/profiles/Creality/filament/eSUN ABS+ @K2 Plus-all.json
@@ -114,7 +114,7 @@
         "100"
     ],
     "filament_start_gcode": [
-        ";filament start gcode\n{if !multicolor_method}\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}\n\n{if(initial_extruder != current_extruder || layer_z > first_layer_height)}\n{if (layer_z +0.4  < printable_height) }\nG2 Z{layer_z  + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X205 Y345 F20000\nG1 Z{layer_z } F1200\n{else}\nG1 X205 Y345 F20000\n{endif}\n{endif}\n{endif}"
+        "; filament start gcode\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
     ],
     "filament_end_gcode": [
         ";filament end gcode \n"

--- a/resources/profiles/Creality/filament/eSUN ASA+ @K2 Plus-all.json
+++ b/resources/profiles/Creality/filament/eSUN ASA+ @K2 Plus-all.json
@@ -114,7 +114,7 @@
         "20"
     ],
     "filament_start_gcode": [
-        ";filament start gcode\n{if !multicolor_method}\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}\n\n{if(initial_extruder != current_extruder || layer_z > first_layer_height)}\n{if (layer_z +0.4  < printable_height) }\nG2 Z{layer_z  + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X205 Y345 F20000\nG1 Z{layer_z } F1200\n{else}\nG1 X205 Y345 F20000\n{endif}\n{endif}\n{endif}"
+        "; filament start gcode\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
     ],
     "filament_end_gcode": [
         ";filament end gcode \n"

--- a/resources/profiles/Creality/filament/eSUN PET-Basic @K2 Plus-all.json
+++ b/resources/profiles/Creality/filament/eSUN PET-Basic @K2 Plus-all.json
@@ -144,7 +144,7 @@
         "70"
     ],
     "filament_start_gcode": [
-        ";filament start gcode\n{if !multicolor_method}\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}\n\n{if(initial_extruder != current_extruder || layer_z > first_layer_height)}\n{if (layer_z +0.4  < printable_height) }\nG2 Z{layer_z  + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X205 Y345 F20000\nG1 Z{layer_z } F1200\n{else}\nG1 X205 Y345 F20000\n{endif}\n{endif}\n{endif}"
+        "; filament start gcode\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
     ],
     "filament_end_gcode": [
         ";filament end gcode \n"

--- a/resources/profiles/Creality/filament/eSUN PETG @K2 Plus-all.json
+++ b/resources/profiles/Creality/filament/eSUN PETG @K2 Plus-all.json
@@ -72,7 +72,7 @@
         "70"
     ],
     "filament_start_gcode": [
-        ";filament start gcode\n{if !multicolor_method}\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}\n\n{if(initial_extruder != current_extruder || layer_z > first_layer_height)}\n{if (layer_z +0.4  < printable_height) }\nG2 Z{layer_z  + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X205 Y345 F20000\nG1 Z{layer_z } F1200\n{else}\nG1 X205 Y345 F20000\n{endif}\n{endif}\n{endif}"
+        "; filament start gcode\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
     ],
     "customized_plate_temp": "70",
     "customized_plate_temp_initial_layer": "70",

--- a/resources/profiles/Creality/filament/eSUN PETG+HS @K2 Plus-all.json
+++ b/resources/profiles/Creality/filament/eSUN PETG+HS @K2 Plus-all.json
@@ -69,7 +69,7 @@
         "70"
     ],
     "filament_start_gcode": [
-        ";filament start gcode\n{if !multicolor_method}\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}\n\n{if(initial_extruder != current_extruder || layer_z > first_layer_height)}\n{if (layer_z +0.4  < printable_height) }\nG2 Z{layer_z  + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X205 Y345 F20000\nG1 Z{layer_z } F1200\n{else}\nG1 X205 Y345 F20000\n{endif}\n{endif}\n{endif}"
+        "; filament start gcode\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
     ],
     "customized_plate_temp": "70",
     "customized_plate_temp_initial_layer": "70",

--- a/resources/profiles/Creality/filament/eSUN PETG-Basic @K2 Plus-all.json
+++ b/resources/profiles/Creality/filament/eSUN PETG-Basic @K2 Plus-all.json
@@ -72,7 +72,7 @@
         "70"
     ],
     "filament_start_gcode": [
-        ";filament start gcode\n{if !multicolor_method}\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}\n\n{if(initial_extruder != current_extruder || layer_z > first_layer_height)}\n{if (layer_z +0.4  < printable_height) }\nG2 Z{layer_z  + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X205 Y345 F20000\nG1 Z{layer_z } F1200\n{else}\nG1 X205 Y345 F20000\n{endif}\n{endif}\n{endif}"
+        "; filament start gcode\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
     ],
     "customized_plate_temp": "70",
     "customized_plate_temp_initial_layer": "70",

--- a/resources/profiles/Creality/filament/eSUN PLA+ @K2 Plus-all.json
+++ b/resources/profiles/Creality/filament/eSUN PLA+ @K2 Plus-all.json
@@ -117,7 +117,7 @@
         "55"
     ],
     "filament_start_gcode": [
-        ";filament start gcode\n{if !multicolor_method}\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}\n\n{if(initial_extruder != current_extruder || layer_z > first_layer_height)}\n{if (layer_z +0.4  < printable_height) }\nG2 Z{layer_z  + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X205 Y345 F20000\nG1 Z{layer_z } F1200\n{else}\nG1 X205 Y345 F20000\n{endif}\n{endif}\n{endif}"
+        "; filament start gcode\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
     ],
     "filament_end_gcode": [
         ";filament end gcode \n"

--- a/resources/profiles/Creality/filament/eSUN PLA-CF @K2 Plus-all.json
+++ b/resources/profiles/Creality/filament/eSUN PLA-CF @K2 Plus-all.json
@@ -63,7 +63,7 @@
         "50"
     ],
     "filament_start_gcode": [
-        ";filament start gcode\n{if !multicolor_method}\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}\n\n{if(initial_extruder != current_extruder || layer_z > first_layer_height)}\n{if (layer_z +0.4  < printable_height) }\nG2 Z{layer_z  + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X205 Y345 F20000\nG1 Z{layer_z } F1200\n{else}\nG1 X205 Y345 F20000\n{endif}\n{endif}\n{endif}"
+        "; filament start gcode\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
     ],
     "customized_plate_temp": "50",
     "customized_plate_temp_initial_layer": "50",

--- a/resources/profiles/Creality/filament/eSUN PLA-HS @K2 Plus-all.json
+++ b/resources/profiles/Creality/filament/eSUN PLA-HS @K2 Plus-all.json
@@ -54,7 +54,7 @@
         "50"
     ],
     "filament_start_gcode": [
-        ";filament start gcode\n{if !multicolor_method}\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}\n\n{if(initial_extruder != current_extruder || layer_z > first_layer_height)}\n{if (layer_z +0.4  < printable_height) }\nG2 Z{layer_z  + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X205 Y345 F20000\nG1 Z{layer_z } F1200\n{else}\nG1 X205 Y345 F20000\n{endif}\n{endif}\n{endif}"
+        "; filament start gcode\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
     ],
     "customized_plate_temp": "50",
     "customized_plate_temp_initial_layer": "50",

--- a/resources/profiles/Creality/filament/eSUN PLA-LW @K2 Plus-all.json
+++ b/resources/profiles/Creality/filament/eSUN PLA-LW @K2 Plus-all.json
@@ -123,7 +123,7 @@
         "50"
     ],
     "filament_start_gcode": [
-        ";filament start gcode\n{if !multicolor_method}\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}\n\n{if(initial_extruder != current_extruder || layer_z > first_layer_height)}\n{if (layer_z +0.4  < printable_height) }\nG2 Z{layer_z  + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X205 Y345 F20000\nG1 Z{layer_z } F1200\n{else}\nG1 X205 Y345 F20000\n{endif}\n{endif}\n{endif}"
+        "; filament start gcode\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
     ],
     "filament_end_gcode": [
         ";filament end gcode "

--- a/resources/profiles/Creality/filament/eSUN PLA-Lite @K2 Plus-all.json
+++ b/resources/profiles/Creality/filament/eSUN PLA-Lite @K2 Plus-all.json
@@ -123,7 +123,7 @@
         "50"
     ],
     "filament_start_gcode": [
-        ";filament start gcode\n{if !multicolor_method}\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}\n\n{if(initial_extruder != current_extruder || layer_z > first_layer_height)}\n{if (layer_z +0.4  < printable_height) }\nG2 Z{layer_z  + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X205 Y345 F20000\nG1 Z{layer_z } F1200\n{else}\nG1 X205 Y345 F20000\n{endif}\n{endif}\n{endif}"
+        "; filament start gcode\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
     ],
     "filament_end_gcode": [
         ";filament end gcode \n"

--- a/resources/profiles/Creality/filament/eSUN PLA-Matte @K2 Plus-all.json
+++ b/resources/profiles/Creality/filament/eSUN PLA-Matte @K2 Plus-all.json
@@ -120,7 +120,7 @@
         "50"
     ],
     "filament_start_gcode": [
-        ";filament start gcode\n{if !multicolor_method}\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}\n\n{if(initial_extruder != current_extruder || layer_z > first_layer_height)}\n{if (layer_z +0.4  < printable_height) }\nG2 Z{layer_z  + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X205 Y345 F20000\nG1 Z{layer_z } F1200\n{else}\nG1 X205 Y345 F20000\n{endif}\n{endif}\n{endif}"
+        "; filament start gcode\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
     ],
     "filament_end_gcode": [
         ";filament end gcode \n"

--- a/resources/profiles/Creality/filament/eSUN PLA-Silk @K2 Plus-all.json
+++ b/resources/profiles/Creality/filament/eSUN PLA-Silk @K2 Plus-all.json
@@ -120,7 +120,7 @@
         "50"
     ],
     "filament_start_gcode": [
-        ";filament start gcode\n{if !multicolor_method}\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}\n\n{if(initial_extruder != current_extruder || layer_z > first_layer_height)}\n{if (layer_z +0.4  < printable_height) }\nG2 Z{layer_z  + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X205 Y345 F20000\nG1 Z{layer_z } F1200\n{else}\nG1 X205 Y345 F20000\n{endif}\n{endif}\n{endif}"
+        "; filament start gcode\n{if (layer_z > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
     ],
     "filament_end_gcode": [
         ";filament end gcode "


### PR DESCRIPTION
# Bug fix of Creality K2 Plus profiles start gcode

Changing the start gcode of Creality K2 plus profiles as the gcode "if multicolor" isn´t supported by orca and causes an error under certain settings when slicing

Those changes were missed in some profiles in the PR https://github.com/OrcaSlicer/OrcaSlicer/pull/13947 - so this acts as a quick fix, no other changes were made

Follow-up to PR https://github.com/OrcaSlicer/OrcaSlicer/pull/13947 were those changes were missed in some profiles



## Tests

It was tested on a K2 Plus: slicing and multicolor printing work again without errors

