### PR TITLE
Bugfix: VFA calibration disables input shaping (Marlin 2)

### DIFF
--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -13299,8 +13299,6 @@ void Plater::calib_VFA(const Calib_Params& params)
     auto filament_config = &wxGetApp().preset_bundle->filaments.get_edited_preset().config;
     auto printer_config  = &wxGetApp().preset_bundle->printers.get_edited_preset().config;
     printer_config->set_key_value("resonance_avoidance", new ConfigOptionBool{false});
-    printer_config->set_key_value("input_shaping_emit", new ConfigOptionBool{true});
-    printer_config->set_key_value("input_shaping_type", new ConfigOptionEnum<InputShaperType>(InputShaperType::Disable));
     filament_config->set_key_value("slow_down_layer_time", new ConfigOptionFloats { 0.0 });
     print_config->set_key_value("enable_overhang_speed", new ConfigOptionBool { false });
     print_config->set_key_value("timelapse_type", new ConfigOptionEnum<TimelapseType>(tlTraditional));


### PR DESCRIPTION
VFA calibration should only disable resonance avoidance. It should not touch input shaping settings.

### Right now Calibration -> VFA forces:

Emit input shaping = true
Input shaper type = Disable

That causes OrcaSlicer to emit an explicit input shaping override in generated G-code instead of leaving the printer's existing firmware configuration alone.

This is problematic for printers like the Prusa Core One, where disabling firmware input shaping leads to layer shifts and hiccups as the printer's firmware is not optimised to be used without input shaper. 
TL/DR take on that: It has to do with phase stepping. By default you cannot disable input shaping.

This PR removes that override from the VFA calibration. 
VFA calibration still disables resonance avoidance as intended, but leaves all input shaping settings unchanged.

### Screenshots:
Before:
<img width="782" height="624" alt="image" src="https://github.com/user-attachments/assets/49356f7e-0c33-4096-8dc0-80d97099274f" />

After:
<img width="793" height="636" alt="image" src="https://github.com/user-attachments/assets/ccb75bdf-ec30-4dbf-8c77-d314ce90c534" />
