### PR TITLE
fix: stuck hover state after opening printer preset dialog

### DIFF
--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -1747,19 +1747,23 @@ Sidebar::Sidebar(Plater *parent)
             e.Skip();
         });
 
+        // hover state data for printer panel
+        auto printer_preset_hovered = std::make_shared<std::unordered_set<wxWindow*>>();
+
         p->btn_edit_printer = new ScalableButton(p->panel_printer_preset, wxID_ANY, "edit");
         p->btn_edit_printer->SetToolTip(_L("Click to edit preset"));
         p->btn_edit_printer->Hide(); // hide for first launch
-        p->btn_edit_printer->Bind(wxEVT_BUTTON, [this, panel_color](wxCommandEvent){
+        p->btn_edit_printer->Bind(wxEVT_BUTTON, [this, panel_color, printer_preset_hovered](wxCommandEvent){
             p->editing_filament = -1;
             if (p->combo_printer->switch_to_tab())
                 p->editing_filament = 0;
             // ORCA: FIX crash on wxGTK, directly modifying UI (self->Hide() / parent->Layout()) inside a button event can crash because callbacks are not re-entrant, leaving widgets in an inconsistent state
-            wxGetApp().CallAfter([this, panel_color]() {
+            wxGetApp().CallAfter([this, panel_color, printer_preset_hovered]() {
                 // ORCA clicking edit button not triggers wxEVT_KILL_FOCUS wxEVT_LEAVE_WINDOW make changes manually to prevent stucked colors when opening printer settings
                 if (!p || !p->panel_printer_preset || !p->btn_edit_printer)
                     return;
 				p->panel_printer_preset->SetBorderColor(panel_color.bd_normal);
+                printer_preset_hovered->clear();
                 p->btn_edit_printer->Hide();
                 p->panel_printer_preset->Layout();
             });
@@ -1797,7 +1801,6 @@ Sidebar::Sidebar(Plater *parent)
             });
         */
         // ORCA use Show/Hide to gain text area instead using blank icon. also manages hover effect for border
-        auto printer_preset_hovered = std::make_shared<std::unordered_set<wxWindow*>>();
         for (wxWindow *w : std::initializer_list<wxWindow *>{p->panel_printer_preset, p->btn_edit_printer, p->image_printer, p->combo_printer}) {
             w->Bind(wxEVT_ENTER_WINDOW, [this, w, panel_color, printer_preset_hovered](wxMouseEvent &e) {
                 printer_preset_hovered->insert(w);


### PR DESCRIPTION
# Description
This is a follow-up to #14067 to address a UI regression on macOS reported by @Noisyfox.

<img width="924" height="516" alt="603850706-9e6fd1b6-5426-453a-9045-f83eced2589e" src="https://github.com/user-attachments/assets/94c9c2c1-d27f-47ed-ac35-9efc2cf0c531" />

Border highlight and edit button visibility appearing stuck after opening printer preset edit dialog

On macOS, `wxEVT_LEAVE_WINDOW` events for the printer preset widgets may be missed after opening the preset edit dialog. There is existing code to account for this by returning the widgets to their unhovered appearance when the button is clicked. This code needs to be extended to also clear the new hover tracking data structure introduced by #14067.

## Tests
Smoke tested on linux. I don't have access to macOS, so I'll appreciate help with testing.
* Click printer preset edit button
* Confirm that the border highlight and edit button disappear (returns to unhovered state)
* Close the dialog and confirm that hovering and unhovering of the printer preset panel works

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
