### PR TITLE
Fix organic tree support bottom interface layer number fallback

### DIFF
--- a/src/libslic3r/Support/SupportCommon.cpp
+++ b/src/libslic3r/Support/SupportCommon.cpp
@@ -1733,8 +1733,8 @@ void generate_support_toolpaths(
                         interface_as_base ? ExtrusionRole::erSupportMaterial : ExtrusionRole::erSupportMaterialInterface, interface_flow);
                 }
             };
-            const bool top_interfaces = config.support_interface_top_layers.value != 0;
-            const bool bottom_interfaces = top_interfaces && config.support_interface_bottom_layers != 0;
+            const bool top_interfaces = support_params.num_top_interface_layers > 0;
+            const bool bottom_interfaces = top_interfaces && support_params.num_bottom_interface_layers > 0;
             extrude_interface(top_contact_layer,    raft_layer ? InterfaceLayerType::RaftContact : top_interfaces ? InterfaceLayerType::TopContact : InterfaceLayerType::InterfaceAsBase);
             if (!organic_tree)
                 extrude_interface(bottom_contact_layer, bottom_interfaces ? InterfaceLayerType::BottomContact : InterfaceLayerType::InterfaceAsBase);

--- a/src/libslic3r/Support/SupportParameters.hpp
+++ b/src/libslic3r/Support/SupportParameters.hpp
@@ -6,6 +6,14 @@
 #include "../Flow.hpp"
 
 namespace Slic3r {
+
+inline int number_of_support_interface_bottom_layers(const PrintObjectConfig& object_config)
+{
+    return object_config.support_interface_bottom_layers.value < 0 ?
+        object_config.support_interface_top_layers.value :
+        object_config.support_interface_bottom_layers.value;
+}
+
 struct SupportParameters {
     SupportParameters() = delete;
     SupportParameters(const PrintObject& object)
@@ -26,8 +34,7 @@ struct SupportParameters {
 
 	    {
 	        this->num_top_interface_layers    = std::max(0, object_config.support_interface_top_layers.value);
-	        this->num_bottom_interface_layers = object_config.support_interface_bottom_layers < 0 ? 
-	            num_top_interface_layers : object_config.support_interface_bottom_layers;
+	        this->num_bottom_interface_layers = number_of_support_interface_bottom_layers(object_config);
 	        this->has_top_contacts              = num_top_interface_layers    > 0;
 	        this->has_bottom_contacts           = num_bottom_interface_layers > 0;
             // BBS: if support interface and support base do not use the same filament, add a base layer to improve their adhesion

--- a/src/libslic3r/Support/TreeSupport.cpp
+++ b/src/libslic3r/Support/TreeSupport.cpp
@@ -2013,8 +2013,8 @@ void TreeSupport::draw_circles()
 
     // generate areas
     const coordf_t layer_height = config.layer_height.value;
-    const size_t   top_interface_layers = config.support_interface_top_layers.value;
-    const size_t   bottom_interface_layers = config.support_interface_bottom_layers.value < 0 ? top_interface_layers : config.support_interface_bottom_layers.value;
+    const size_t top_interface_layers = m_support_params.num_top_interface_layers;
+    const size_t bottom_interface_layers = number_of_support_interface_bottom_layers(config);
     const double nozzle_diameter = m_object->print()->config().nozzle_diameter.get_at(0);
     const coordf_t line_width = config.get_abs_value("support_line_width", nozzle_diameter);
     const coordf_t line_width_scaled           = scale_(line_width);
@@ -2653,8 +2653,7 @@ void TreeSupport::drop_nodes()
     const size_t tip_layers = base_radius / layer_height; //The number of layers to be shrinking the circle to create a tip. This produces a 45 degree angle.
     const coordf_t radius_sample_resolution = m_ts_data->m_radius_sample_resolution;
     const bool support_on_buildplate_only = config.support_on_build_plate_only.value;
-    const size_t top_interface_layers = config.support_interface_top_layers.value;
-    const size_t bottom_interface_layers = config.support_interface_bottom_layers.value < 0 ? top_interface_layers : config.support_interface_bottom_layers.value;
+    const size_t bottom_interface_layers = number_of_support_interface_bottom_layers(config);
     SupportNode::diameter_angle_scale_factor = diameter_angle_scale_factor;
     float        DO_NOT_MOVER_UNDER_MM       = is_slim ? 0 : 5;                     // do not move contact points under 5mm
 

--- a/src/libslic3r/Support/TreeSupportCommon.hpp
+++ b/src/libslic3r/Support/TreeSupportCommon.hpp
@@ -61,12 +61,10 @@ struct TreeSupportMeshGroupSettings {
         this->support_angle             = 0.5 * M_PI - std::clamp<double>((config.support_threshold_angle + 1) * M_PI / 180., 0., 0.5 * M_PI);
         this->support_line_width        = support_material_flow(&print_object, config.layer_height).scaled_width();
         this->support_roof_line_width   = support_material_interface_flow(&print_object, config.layer_height).scaled_width();
-        //FIXME add it to SlicingParameters and reuse in both tree and normal supports?
-        this->support_bottom_enable     = config.support_interface_top_layers.value > 0 && config.support_interface_bottom_layers.value != 0;
+        const int bottom_interface_layers = number_of_support_interface_bottom_layers(config);
+        this->support_bottom_enable     = config.support_interface_top_layers.value > 0 && bottom_interface_layers > 0;
         this->support_bottom_height     = this->support_bottom_enable ?
-            (config.support_interface_bottom_layers.value > 0 ?
-                config.support_interface_bottom_layers.value :
-                config.support_interface_top_layers.value) * this->layer_height :
+            bottom_interface_layers * this->layer_height :
             0;
         this->support_material_buildplate_only = config.support_on_build_plate_only;
         this->support_xy_distance       = scaled<coord_t>(config.support_object_xy_distance.value);
@@ -77,8 +75,8 @@ struct TreeSupportMeshGroupSettings {
         this->support_bottom_distance   = scaled<coord_t>(slicing_params.gap_object_support);
         this->support_roof_enable       = config.support_interface_top_layers.value > 0;
         this->support_roof_layers       = config.support_interface_top_layers.value;
-        this->support_floor_enable      = config.support_interface_bottom_layers.value > 0;
-        this->support_floor_layers      = config.support_interface_bottom_layers.value;
+        this->support_floor_enable      = bottom_interface_layers > 0;
+        this->support_floor_layers      = bottom_interface_layers;
         this->support_roof_pattern      = config.support_interface_pattern;
         this->support_pattern           = config.support_base_pattern;
         this->support_line_spacing      = scaled<coord_t>(config.support_base_pattern_spacing.value);


### PR DESCRIPTION
This fixes an issue that for organic tree support the support bottom layer interface would not honor the "Same as top" setting.
The fix uses a generic helper which is used now all across the support types.

**Before:**
<img width="1449" height="578" alt="image" src="https://github.com/user-attachments/assets/1523ebf6-a29f-42f3-8e47-cdb772179fe0" />

**After:**
<img width="1440" height="579" alt="image" src="https://github.com/user-attachments/assets/5441e9e6-10de-41a8-8210-69f01674cd54" />
