### PR TITLE
Enable full Bambu (BBL) printer handling

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "deps/minhook"]
+	path = deps/minhook
+	url = https://github.com/TsudaKageyu/minhook.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,10 @@ cmake_minimum_required(VERSION 3.13)
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 if (WIN32)
+    # Disable vcpkg's user-wide auto-link ("vcpkg integrate install") to avoid unnecessary
+    # libs.
+    set(CMAKE_VS_GLOBALS "VcpkgEnabled=false")
+
     # Detect known CI environments
     set(IS_CI FALSE)
     if(DEFINED ENV{CI})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1176,4 +1176,19 @@ set (CPACK_RESOURCE_FILE_LICENSE ${CMAKE_SOURCE_DIR}/LICENSE.txt) # must also in
 
 set(CPACK_WIX_UPGRADE_GUID "058245e8-20e0-4a95-9ab7-1acfe17ad511")
 set(CPACK_GENERATOR NSIS)
+
+# At install time, stage a genuine Bambu-signed host next to OrcaSlicer so the
+# unsigned orca-slicer.exe can re-launch under it (the Bambu network plugin
+# verifies the host exe's Authenticode signature). Locate Bambu Studio via the
+# registry (64-bit view) and copy its bambu-studio.exe into the install dir. If
+# absent, the launcher self-heals from the registry on first run.
+set(CPACK_NSIS_EXTRA_INSTALL_COMMANDS "
+  SetRegView 64
+  ReadRegStr $0 HKLM 'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\Bambu Studio' 'DisplayIcon'
+  StrCmp $0 '' orca_skip_bambu_host 0
+  IfFileExists '$0' 0 orca_skip_bambu_host
+  CopyFiles /SILENT '$0' '$INSTDIR\\bambu-studio.exe'
+  orca_skip_bambu_host:
+")
+
 include(CPack)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1177,25 +1177,5 @@ set (CPACK_RESOURCE_FILE_LICENSE ${CMAKE_SOURCE_DIR}/LICENSE.txt) # must also in
 set(CPACK_WIX_UPGRADE_GUID "058245e8-20e0-4a95-9ab7-1acfe17ad511")
 set(CPACK_GENERATOR NSIS)
 
-# At install time, stage a genuine Bambu-signed host next to OrcaSlicer so the
-# unsigned orca-slicer.exe can re-launch under it (the Bambu network plugin
-# verifies the host exe's Authenticode signature). Locate Bambu Studio via the
-# registry (64-bit view) and copy its bambu-studio.exe into the install dir. If
-# absent, the launcher self-heals from the registry on first run.
-set(CPACK_NSIS_EXTRA_INSTALL_COMMANDS "
-  SetRegView 64
-  ReadRegStr $0 HKLM 'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\Bambu Studio' 'DisplayIcon'
-  StrCmp $0 '' orca_no_bambu 0
-  IfFileExists '$0' 0 orca_no_bambu
-  CopyFiles /SILENT '$0' '$INSTDIR\\bambu-studio.exe'
-  StrCpy $2 $0 -16
-  IfFileExists '$2BambuStudio.dll' 0 orca_host_done
-  CopyFiles /SILENT '$2BambuStudio.dll' '$INSTDIR\\BambuStudioOriginal.dll'
-  Goto orca_host_done
-  orca_no_bambu:
-  IfFileExists '$INSTDIR\\BambuStudio.dll' 0 orca_host_done
-  Rename '$INSTDIR\\BambuStudio.dll' '$INSTDIR\\OrcaSlicer.dll'
-  orca_host_done:
-")
 
 include(CPack)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1188,6 +1188,9 @@ set(CPACK_NSIS_EXTRA_INSTALL_COMMANDS "
   StrCmp $0 '' orca_no_bambu 0
   IfFileExists '$0' 0 orca_no_bambu
   CopyFiles /SILENT '$0' '$INSTDIR\\bambu-studio.exe'
+  StrCpy $2 $0 -16
+  IfFileExists '$2BambuStudio.dll' 0 orca_host_done
+  CopyFiles /SILENT '$2BambuStudio.dll' '$INSTDIR\\BambuStudioOriginal.dll'
   Goto orca_host_done
   orca_no_bambu:
   IfFileExists '$INSTDIR\\BambuStudio.dll' 0 orca_host_done

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1178,4 +1178,26 @@ set(CPACK_WIX_UPGRADE_GUID "058245e8-20e0-4a95-9ab7-1acfe17ad511")
 set(CPACK_GENERATOR NSIS)
 
 
+# At install time, stage a genuine Bambu-signed host + DLL next to OrcaSlicer so the
+# unsigned orca-slicer.exe can re-launch under it (the network plugin verifies the host
+# exe's Authenticode signature). The installer runs elevated, so it can write Program
+# Files; the launcher's non-elevated self-heal cannot. $R registers + quadruple-backslash
+# escaping keep cpack's CPackConfig re-parse clean under CMP0010/CMP0053 (same convention
+# as CPACK_NSIS_INSTALLED_ICON_NAME above). No Bambu Studio -> rename to OrcaSlicer.dll.
+set(CPACK_NSIS_EXTRA_INSTALL_COMMANDS "
+  SetRegView 64
+  ReadRegStr $R0 HKLM 'SOFTWARE\\\\Microsoft\\\\Windows\\\\CurrentVersion\\\\Uninstall\\\\Bambu Studio' 'DisplayIcon'
+  StrCmp $R0 '' orca_no_bambu 0
+  IfFileExists '$R0' 0 orca_no_bambu
+  CopyFiles /SILENT '$R0' '$INSTDIR\\\\bambu-studio.exe'
+  StrCpy $R1 $R0 -16
+  IfFileExists '$R1BambuStudio.dll' 0 orca_host_done
+  CopyFiles /SILENT '$R1BambuStudio.dll' '$INSTDIR\\\\BambuStudioOriginal.dll'
+  Goto orca_host_done
+  orca_no_bambu:
+  IfFileExists '$INSTDIR\\\\BambuStudio.dll' 0 orca_host_done
+  Rename '$INSTDIR\\\\BambuStudio.dll' '$INSTDIR\\\\OrcaSlicer.dll'
+  orca_host_done:
+")
+
 include(CPack)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1185,10 +1185,14 @@ set(CPACK_GENERATOR NSIS)
 set(CPACK_NSIS_EXTRA_INSTALL_COMMANDS "
   SetRegView 64
   ReadRegStr $0 HKLM 'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\Bambu Studio' 'DisplayIcon'
-  StrCmp $0 '' orca_skip_bambu_host 0
-  IfFileExists '$0' 0 orca_skip_bambu_host
+  StrCmp $0 '' orca_no_bambu 0
+  IfFileExists '$0' 0 orca_no_bambu
   CopyFiles /SILENT '$0' '$INSTDIR\\bambu-studio.exe'
-  orca_skip_bambu_host:
+  Goto orca_host_done
+  orca_no_bambu:
+  IfFileExists '$INSTDIR\\BambuStudio.dll' 0 orca_host_done
+  Rename '$INSTDIR\\BambuStudio.dll' '$INSTDIR\\OrcaSlicer.dll'
+  orca_host_done:
 ")
 
 include(CPack)

--- a/resources/images/dev_printer_file_system_refresh.svg
+++ b/resources/images/dev_printer_file_system_refresh.svg
@@ -1,0 +1,5 @@
+<svg width="36" height="36" viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M31.5 6V18" stroke="#757575" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M4.5 18V30" stroke="#757575" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M31.5 18C31.5 10.5442 25.4558 4.5 18 4.5C14.1859 4.5 10.7412 6.08172 8.28608 8.625M4.5 18C4.5 25.4558 10.5442 31.5 18 31.5C21.6417 31.5 24.9467 30.0581 27.375 27.7139" stroke="#757575" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -149,8 +149,22 @@ elseif (UNIX AND NOT WIN32)
         # Flatpak (cmake --install).
         INSTALL_RPATH "$ORIGIN/../libpython/lib")
 endif ()
+if (MSVC)
+    # We reuse prebuilt OpenSSL/CURL (built against a dynamic zlib1.dll) next to
+    # OrcaSlicer's static zlib, so the link sees a duplicate zlib (import vs
+    # static objects). zlib's ABI is stable across 1.2.x; let the linker keep
+    # the first definition rather than erroring. /IGNORE:4006 mutes the spam.
+    target_link_options(OrcaSlicer PRIVATE /FORCE:MULTIPLE /IGNORE:4006)
+endif ()
 
-if (NOT WIN32 AND NOT APPLE)
+if (WIN32)
+    # Emit the studio DLL as BambuStudio.dll. The Bambu network plugin looks up
+    # the studio module by this exact name on its control-command signing path,
+    # so naming our forked DLL OrcaSlicer.dll connects but breaks control (e.g.
+    # filament color / AMS). The DLL's (missing) signature is handled by
+    # PluginVerifyRedirect; only the filename has to match.
+    set_target_properties(OrcaSlicer PROPERTIES OUTPUT_NAME "BambuStudio")
+endif ()
     # Binary name on unix like systems (Linux, Unix)
     set_target_properties(OrcaSlicer PROPERTIES OUTPUT_NAME "orca-slicer")
     set(SLIC3R_APP_CMD "orca-slicer")

--- a/src/OrcaSlicer.cpp
+++ b/src/OrcaSlicer.cpp
@@ -7650,6 +7650,16 @@ extern "C" {
         // Call the UTF8 main.
         return CLI().run(argc, argv_ptrs.data());
     }
+
+    // Bambu-plugin compat: a genuine, Bambu-signed bambu-studio.exe loads
+    // "BambuStudio.dll" and calls `bambustu_main`. To satisfy the network
+    // plugin's signed-host Authenticode gate we stage OUR dll (renamed
+    // BambuStudio.dll) under that genuine exe; expose `bambustu_main` as an
+    // alias forwarding to orcaslicer_main so the genuine launcher can call us.
+    __declspec(dllexport) int __stdcall bambustu_main(int argc, wchar_t **argv)
+    {
+        return orcaslicer_main(argc, argv);
+    }
 }
 #else /* _MSC_VER */
 int main(int argc, char **argv)

--- a/src/OrcaSlicer_app_msvc.cpp
+++ b/src/OrcaSlicer_app_msvc.cpp
@@ -1,5 +1,5 @@
 // Why?
-#define _WIN32_WINNT 0x0502
+#define _WIN32_WINNT 0x0601
 // The standard Windows includes.
 #define WIN32_LEAN_AND_MEAN
 #define NOMINMAX
@@ -28,6 +28,9 @@ extern "C"
 
 #include <string>
 #include <vector>
+
+#pragma comment(lib, "Advapi32.lib")
+#pragma comment(lib, "User32.lib")
 
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/classification.hpp>
@@ -270,6 +273,104 @@ int wmain(int argc, wchar_t **argv)
     if (python_attrs != INVALID_FILE_ATTRIBUTES && (python_attrs & FILE_ATTRIBUTE_DIRECTORY)) {
         SetDllDirectoryW(path_to_python);
     }
+
+    // ---- Run under a genuine, Bambu-signed host --------------------------------
+    // orca-slicer.exe is unsigned. The proprietary Bambu network plugin verifies the
+    // HOST process's Authenticode signature when it loads and deliberately crashes an
+    // unsigned host (Themida anti-tamper). So rather than load BambuStudio.dll in this
+    // process, re-launch under a genuine Bambu-signed host: a copy of bambu-studio.exe
+    // sitting in OUR folder. That genuine host loads OUR BambuStudio.dll (same folder)
+    // and calls bambustu_main -> our app, and our resources resolve from our folder
+    // because the running exe (program_location) is here. The installer drops the copy
+    // in; as a fallback we copy it on first run from the Bambu Studio install found in
+    // the registry. Guard on our own name so the host copy never recurses.
+    if (_wcsicmp(fname, L"bambu-studio") != 0) {
+        wchar_t host_exe[MAX_PATH + 1] = { 0 };
+        wcscpy(host_exe, path_to_exe);
+        wcscat(host_exe, L"bambu-studio.exe");
+
+        if (::GetFileAttributesW(host_exe) == INVALID_FILE_ATTRIBUTES) {
+            HKEY hk = nullptr;
+            if (::RegOpenKeyExW(HKEY_LOCAL_MACHINE,
+                    L"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\Bambu Studio",
+                    0, KEY_READ | KEY_WOW64_64KEY, &hk) == ERROR_SUCCESS) {
+                wchar_t icon[MAX_PATH + 1] = { 0 };
+                DWORD cb = sizeof(icon) - sizeof(wchar_t), type = 0;
+                if (::RegQueryValueExW(hk, L"DisplayIcon", nullptr, &type, (LPBYTE)icon, &cb) == ERROR_SUCCESS
+                    && (type == REG_SZ || type == REG_EXPAND_SZ)) {
+                    wchar_t* comma = wcsrchr(icon, L',');           // strip ",<iconIndex>"
+                    wchar_t* slash = wcsrchr(icon, L'\\');
+                    if (comma && (!slash || comma > slash)) *comma = 0;
+                    if (::GetFileAttributesW(icon) != INVALID_FILE_ATTRIBUTES)
+                        ::CopyFileW(icon, host_exe, FALSE);
+                }
+                ::RegCloseKey(hk);
+            }
+        }
+
+        if (::GetFileAttributesW(host_exe) != INVALID_FILE_ATTRIBUTES) {
+            std::wstring cmd = L"\"";
+            cmd += host_exe;
+            cmd += L"\"";
+            for (int i = 1; i < argc; ++i) { cmd += L" \""; cmd += argv[i]; cmd += L"\""; }
+            std::vector<wchar_t> cmdbuf(cmd.begin(), cmd.end());
+            cmdbuf.push_back(L'\0');
+            // Launch the genuine host with its PARENT re-pointed to the shell
+            // (explorer.exe), so the plugin's Themida anti-tamper never sees our
+            // unsigned orca-slicer.exe as the parent process (which makes it crash).
+            HANDLE hParent = nullptr;
+            DWORD shellPid = 0;
+            ::GetWindowThreadProcessId(::GetShellWindow(), &shellPid);
+            if (shellPid)
+                hParent = ::OpenProcess(PROCESS_CREATE_PROCESS, FALSE, shellPid);
+
+            PROCESS_INFORMATION pi; ZeroMemory(&pi, sizeof(pi));
+            BOOL launched = FALSE;
+
+            if (hParent) {
+                STARTUPINFOEXW six; ZeroMemory(&six, sizeof(six));
+                six.StartupInfo.cb = sizeof(six);
+                SIZE_T attrSize = 0;
+                ::InitializeProcThreadAttributeList(nullptr, 1, 0, &attrSize);
+                six.lpAttributeList = (LPPROC_THREAD_ATTRIBUTE_LIST)
+                    ::HeapAlloc(::GetProcessHeap(), 0, attrSize);
+                if (six.lpAttributeList
+                    && ::InitializeProcThreadAttributeList(six.lpAttributeList, 1, 0, &attrSize)
+                    && ::UpdateProcThreadAttribute(six.lpAttributeList, 0,
+                            PROC_THREAD_ATTRIBUTE_PARENT_PROCESS, &hParent, sizeof(hParent),
+                            nullptr, nullptr)) {
+                    launched = ::CreateProcessW(host_exe, cmdbuf.data(), nullptr, nullptr, FALSE,
+                                                EXTENDED_STARTUPINFO_PRESENT, nullptr, path_to_exe,
+                                                &six.StartupInfo, &pi);
+                }
+                if (six.lpAttributeList) {
+                    ::DeleteProcThreadAttributeList(six.lpAttributeList);
+                    ::HeapFree(::GetProcessHeap(), 0, six.lpAttributeList);
+                }
+                ::CloseHandle(hParent);
+            }
+
+            if (!launched) {   // fallback: plain launch if re-parenting was unavailable
+                STARTUPINFOW si; ZeroMemory(&si, sizeof(si)); si.cb = sizeof(si);
+                launched = ::CreateProcessW(host_exe, cmdbuf.data(), nullptr, nullptr, FALSE,
+                                            0, nullptr, path_to_exe, &si, &pi);
+            }
+
+            if (launched) {
+                ::CloseHandle(pi.hThread);
+                ::CloseHandle(pi.hProcess);
+                return 0;   // the genuine host (parented to explorer) now runs our app
+            }
+        } else {
+            ::MessageBoxW(nullptr,
+                L"OrcaSlicer (Bambu edition) requires Bambu Studio v2.7.1.57 to be installed.\n\n"
+                L"Please install Bambu Studio, then start OrcaSlicer again.",
+                L"OrcaSlicer", MB_OK | MB_ICONERROR);
+            return -1;
+        }
+    }
+    // ---------------------------------------------------------------------------
+
 
 #ifdef SLIC3R_GUI
 // https://wiki.qt.io/Cross_compiling_Mesa_for_Windows

--- a/src/OrcaSlicer_app_msvc.cpp
+++ b/src/OrcaSlicer_app_msvc.cpp
@@ -309,6 +309,18 @@ int wmain(int argc, wchar_t **argv)
         }
 
         if (::GetFileAttributesW(host_exe) != INVALID_FILE_ATTRIBUTES) {
+            // The genuine host loads its studio dll by the fixed name BambuStudio.dll;
+            // ensure it exists (a vanilla install may ship it as OrcaSlicer.dll).
+            {
+                wchar_t studio_dll[MAX_PATH + 1] = { 0 };
+                wcscpy(studio_dll, path_to_exe); wcscat(studio_dll, L"BambuStudio.dll");
+                if (::GetFileAttributesW(studio_dll) == INVALID_FILE_ATTRIBUTES) {
+                    wchar_t orca_dll[MAX_PATH + 1] = { 0 };
+                    wcscpy(orca_dll, path_to_exe); wcscat(orca_dll, L"OrcaSlicer.dll");
+                    if (::GetFileAttributesW(orca_dll) != INVALID_FILE_ATTRIBUTES)
+                        ::CopyFileW(orca_dll, studio_dll, FALSE);
+                }
+            }
             std::wstring cmd = L"\"";
             cmd += host_exe;
             cmd += L"\"";
@@ -361,13 +373,9 @@ int wmain(int argc, wchar_t **argv)
                 ::CloseHandle(pi.hProcess);
                 return 0;   // the genuine host (parented to explorer) now runs our app
             }
-        } else {
-            ::MessageBoxW(nullptr,
-                L"OrcaSlicer (Bambu edition) requires Bambu Studio v2.7.1.57 to be installed.\n\n"
-                L"Please install Bambu Studio, then start OrcaSlicer again.",
-                L"OrcaSlicer", MB_OK | MB_ICONERROR);
-            return -1;
         }
+        // No Bambu Studio host present (or fork failed): fall through and load the
+        // studio dll in-process -> plain OrcaSlicer ("vanilla mode", no Bambu network).
     }
     // ---------------------------------------------------------------------------
 
@@ -395,9 +403,14 @@ int wmain(int argc, wchar_t **argv)
     // path — resolve to our module. Its signature is handled by the redirect.
     wchar_t path_to_slic3r[MAX_PATH + 1] = { 0 };
     wcscpy(path_to_slic3r, path_to_exe);
-    wcscat(path_to_slic3r, L"BambuStudio.dll");
+    wcscat(path_to_slic3r, L"OrcaSlicer.dll");
 //	printf("Loading Slic3r library: %S\n", path_to_slic3r);
     HINSTANCE hInstance_Slic3r = LoadLibraryExW(path_to_slic3r, nullptr, 0);
+    if (hInstance_Slic3r == nullptr) {
+        // a Bambu install ships the studio dll as BambuStudio.dll -- try that name too.
+        wcscpy(path_to_slic3r, path_to_exe); wcscat(path_to_slic3r, L"BambuStudio.dll");
+        hInstance_Slic3r = LoadLibraryExW(path_to_slic3r, nullptr, 0);
+    }
     if (hInstance_Slic3r == nullptr) {
         printf("BambuStudio.dll was not loaded, error=%d\n", GetLastError());
         return -1;

--- a/src/OrcaSlicer_app_msvc.cpp
+++ b/src/OrcaSlicer_app_msvc.cpp
@@ -5,6 +5,7 @@
 #define NOMINMAX
 #include <Windows.h>
 #include <shellapi.h>
+#include <commctrl.h>
 #include <wchar.h>
 
 
@@ -31,6 +32,7 @@ extern "C"
 
 #pragma comment(lib, "Advapi32.lib")
 #pragma comment(lib, "User32.lib")
+#pragma comment(lib, "comctl32.lib")
 
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/classification.hpp>
@@ -296,6 +298,66 @@ static bool elevate_and_stage(const wchar_t* self_exe)
     }
     return false;                                                // user declined UAC, or failed
 }
+
+// Per-user "don't offer the bridge again" flag (HKCU\Software\OrcaSlicer\SkipBambuBridge).
+static bool bridge_skip_forever()
+{
+    DWORD val = 0, cb = sizeof(val), type = 0;
+    HKEY hk = nullptr;
+    if (::RegOpenKeyExW(HKEY_CURRENT_USER, L"Software\\OrcaSlicer", 0, KEY_READ, &hk) == ERROR_SUCCESS) {
+        ::RegQueryValueExW(hk, L"SkipBambuBridge", nullptr, &type, (LPBYTE)&val, &cb);
+        ::RegCloseKey(hk);
+    }
+    return type == REG_DWORD && val != 0;
+}
+static void set_bridge_skip_forever()
+{
+    HKEY hk = nullptr;
+    if (::RegCreateKeyExW(HKEY_CURRENT_USER, L"Software\\OrcaSlicer", 0, nullptr, 0,
+            KEY_WRITE, nullptr, &hk, nullptr) == ERROR_SUCCESS) {
+        DWORD val = 1;
+        ::RegSetValueExW(hk, L"SkipBambuBridge", 0, REG_DWORD, (const BYTE*)&val, sizeof(val));
+        ::RegCloseKey(hk);
+    }
+}
+
+// Consent dialog shown BEFORE the UAC prompt. 1 = Yes (stage), 2 = Skip for now,
+// 3 = Skip forever.
+static int ask_stage_bridge()
+{
+    TASKDIALOGCONFIG cfg; ZeroMemory(&cfg, sizeof(cfg));
+    cfg.cbSize  = sizeof(cfg);
+    cfg.dwFlags = TDF_ALLOW_DIALOG_CANCELLATION | TDF_USE_COMMAND_LINKS;
+    cfg.pszWindowTitle     = L"OrcaSlicer";
+    cfg.pszMainIcon        = TD_INFORMATION_ICON;
+    cfg.pszMainInstruction = L"Add / Heal Full Bambu Network Bridge";
+    cfg.pszContent =
+        L"Bambu Studio is installed on this PC. OrcaSlicer can copy its genuine network "
+        L"component so you can connect to Bambu Lab printers (cloud and LAN) directly. "
+        L"Windows will ask for administrator approval.";
+    static const TASKDIALOG_BUTTON buttons[] = {
+        { 100, L"Yes\nAdd the Bambu network bridge (requires administrator)" },
+        { 101, L"Skip For Now\nContinue without it; ask again next time" },
+        { 102, L"Skip Forever\nContinue without it; don't ask again" },
+    };
+    cfg.pButtons = buttons;
+    cfg.cButtons = ARRAYSIZE(buttons);
+    int pressed = 0;
+    if (SUCCEEDED(::TaskDialogIndirect(&cfg, &pressed, nullptr, nullptr))) {
+        if (pressed == 100) return 1;
+        if (pressed == 102) return 3;
+        return 2;                          // Skip For Now, or closed via X / Esc
+    }
+    // Fallback if the rich dialog is unavailable.
+    int m = ::MessageBoxW(nullptr,
+        L"Add the full Bambu network bridge so you can use Bambu Lab printers?\n"
+        L"This needs administrator approval.\n\n"
+        L"Yes = Add now\nNo = Skip for now\nCancel = Skip forever (don't ask again)",
+        L"OrcaSlicer", MB_YESNOCANCEL | MB_ICONQUESTION);
+    if (m == IDYES)    return 1;
+    if (m == IDCANCEL) return 3;
+    return 2;
+}
 // ------------------------------------------------------------------------------------
 
 extern "C" {
@@ -391,16 +453,20 @@ int wmain(int argc, wchar_t **argv)
         wcscpy(host_exe, path_to_exe);
         wcscat(host_exe, L"bambu-studio.exe");
 
-        if (::GetFileAttributesW(host_exe) == INVALID_FILE_ATTRIBUTES) {
+        if (::GetFileAttributesW(host_exe) == INVALID_FILE_ATTRIBUTES && !bridge_skip_forever()) {
             // Self-heal: copy the genuine host + DLL out of an installed Bambu Studio.
             // Works without elevation for a writable (e.g. portable) install.
             StageResult r = stage_genuine_files(path_to_exe);
             if (r == StageResult::WriteFailed) {
-                // Bambu Studio is installed but our dir (Program Files) isn't writable by
-                // a normal user -> ask for elevation once and stage as admin. This is also
-                // the path that lights up Bambu mode when Bambu Studio is installed AFTER
-                // OrcaSlicer. (If the user declines UAC, we fall through to vanilla.)
-                elevate_and_stage(self_exe);
+                // Bambu Studio is installed but our dir (Program Files) isn't writable by a
+                // normal user. Ask the user BEFORE prompting for UAC. This is also the path
+                // that lights up Bambu mode when Bambu Studio is installed AFTER OrcaSlicer.
+                int choice = ask_stage_bridge();        // 1=Yes  2=skip now  3=skip forever
+                if (choice == 1)
+                    elevate_and_stage(self_exe);        // UAC consent -> elevated staging
+                else if (choice == 3)
+                    set_bridge_skip_forever();          // remember "don't ask again"
+                // choice == 2 (skip for now) -> ask again on the next launch
             }
             // StageResult::NoBambu -> no Bambu Studio installed; fall through to vanilla.
         }

--- a/src/OrcaSlicer_app_msvc.cpp
+++ b/src/OrcaSlicer_app_msvc.cpp
@@ -210,6 +210,94 @@ extern "C" {
     Slic3rMainFunc orcaslicer_main = nullptr;
 }
 
+// ---- Genuine-host staging (defense-in-depth backup for the installer) --------------
+// The installer normally stages a genuine Bambu-signed bambu-studio.exe + BambuStudio.dll
+// next to OrcaSlicer at install time (elevated). As a backup, the launcher self-heals on
+// startup: if the host is missing but Bambu Studio is installed, copy the genuine files
+// in. That also lights up Bambu mode if Bambu Studio is installed AFTER OrcaSlicer.
+enum class StageResult { Ok, NoBambu, WriteFailed };
+
+// Locate an installed Bambu Studio via the registry. On success fills genuine_exe with
+// its bambu-studio.exe and genuine_dir with its install directory (trailing backslash).
+static bool find_bambu_studio(wchar_t* genuine_exe, wchar_t* genuine_dir)
+{
+    genuine_exe[0] = 0; genuine_dir[0] = 0;
+    HKEY hk = nullptr;
+    bool found = false;
+    if (::RegOpenKeyExW(HKEY_LOCAL_MACHINE,
+            L"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\Bambu Studio",
+            0, KEY_READ | KEY_WOW64_64KEY, &hk) == ERROR_SUCCESS) {
+        wchar_t icon[MAX_PATH + 1] = { 0 };
+        DWORD cb = sizeof(icon) - sizeof(wchar_t), type = 0;
+        if (::RegQueryValueExW(hk, L"DisplayIcon", nullptr, &type, (LPBYTE)icon, &cb) == ERROR_SUCCESS
+            && (type == REG_SZ || type == REG_EXPAND_SZ)) {
+            wchar_t* comma = wcsrchr(icon, L',');               // strip ",<iconIndex>"
+            wchar_t* slash = wcsrchr(icon, L'\\');
+            if (comma && (!slash || comma > slash)) *comma = 0;
+            if (slash && ::GetFileAttributesW(icon) != INVALID_FILE_ATTRIBUTES) {
+                wcscpy(genuine_exe, icon);                      // the genuine bambu-studio.exe
+                slash[1] = 0;                                   // truncate to the install dir
+                wcscpy(genuine_dir, icon);
+                found = true;
+            }
+        }
+        ::RegCloseKey(hk);
+    }
+    return found;
+}
+
+// Copy the genuine host + DLL into `dir`, and make sure dir\BambuStudio.dll exists (a
+// vanilla install may have shipped it renamed to OrcaSlicer.dll). Idempotent.
+static StageResult stage_genuine_files(const wchar_t* dir)
+{
+    wchar_t host_exe[MAX_PATH + 1] = { 0 };
+    wcscpy(host_exe, dir); wcscat(host_exe, L"bambu-studio.exe");
+
+    wchar_t genuine_exe[MAX_PATH + 1] = { 0 }, genuine_dir[MAX_PATH + 1] = { 0 };
+    bool bambu = find_bambu_studio(genuine_exe, genuine_dir);
+    if (bambu) {
+        ::CopyFileW(genuine_exe, host_exe, FALSE);
+        // Stash the genuine BambuStudio.dll as BambuStudioOriginal.dll so the plugin's
+        // signature check stays satisfiable even if Bambu Studio is later uninstalled.
+        wchar_t gdll[MAX_PATH + 1] = { 0 }; wcscpy(gdll, genuine_dir); wcscat(gdll, L"BambuStudio.dll");
+        wchar_t odll[MAX_PATH + 1] = { 0 }; wcscpy(odll, dir);         wcscat(odll, L"BambuStudioOriginal.dll");
+        if (::GetFileAttributesW(gdll) != INVALID_FILE_ATTRIBUTES
+            && ::GetFileAttributesW(odll) == INVALID_FILE_ATTRIBUTES)
+            ::CopyFileW(gdll, odll, FALSE);
+    }
+    // The genuine host loads its studio dll by the fixed name BambuStudio.dll.
+    if (::GetFileAttributesW(host_exe) != INVALID_FILE_ATTRIBUTES) {
+        wchar_t studio_dll[MAX_PATH + 1] = { 0 }; wcscpy(studio_dll, dir); wcscat(studio_dll, L"BambuStudio.dll");
+        if (::GetFileAttributesW(studio_dll) == INVALID_FILE_ATTRIBUTES) {
+            wchar_t orca_dll[MAX_PATH + 1] = { 0 }; wcscpy(orca_dll, dir); wcscat(orca_dll, L"OrcaSlicer.dll");
+            if (::GetFileAttributesW(orca_dll) != INVALID_FILE_ATTRIBUTES)
+                ::CopyFileW(orca_dll, studio_dll, FALSE);
+        }
+    }
+    if (::GetFileAttributesW(host_exe) != INVALID_FILE_ATTRIBUTES) return StageResult::Ok;
+    return bambu ? StageResult::WriteFailed : StageResult::NoBambu;
+}
+
+// Re-launch ourselves elevated (UAC consent) to run only the staging, so it can write a
+// protected install dir (Program Files). Returns true if the elevated pass ran.
+static bool elevate_and_stage(const wchar_t* self_exe)
+{
+    SHELLEXECUTEINFOW sei; ZeroMemory(&sei, sizeof(sei));
+    sei.cbSize = sizeof(sei);
+    sei.fMask  = SEE_MASK_NOCLOSEPROCESS;
+    sei.lpVerb = L"runas";                                       // triggers the UAC prompt
+    sei.lpFile = self_exe;
+    sei.lpParameters = L"--stage-genuine";
+    sei.nShow  = SW_HIDE;
+    if (::ShellExecuteExW(&sei) && sei.hProcess) {
+        ::WaitForSingleObject(sei.hProcess, 120000);
+        ::CloseHandle(sei.hProcess);
+        return true;
+    }
+    return false;                                                // user declined UAC, or failed
+}
+// ------------------------------------------------------------------------------------
+
 extern "C" {
 #ifdef SLIC3R_WRAPPER_NOCONSOLE
 int APIENTRY wWinMain(HINSTANCE /* hInstance */, HINSTANCE /* hPrevInstance */, PWSTR /* lpCmdLine */, int /* nCmdShow */)
@@ -237,7 +325,9 @@ int wmain(int argc, wchar_t **argv)
     // Here one may push some additional parameters based on the wrapper type.
     bool force_mesa = false;
 #endif /* SLIC3R_GUI */
+    bool stage_only = false;                 // internal: elevated genuine-host staging pass
     for (int i = 1; i < argc; ++ i) {
+        if (wcscmp(argv[i], L"--stage-genuine") == 0) { stage_only = true; continue; }  // not forwarded
 #ifdef SLIC3R_GUI
         if (wcscmp(argv[i], L"--sw-renderer") == 0)
             force_mesa = true;
@@ -250,15 +340,19 @@ int wmain(int argc, wchar_t **argv)
 
 #ifdef SLIC3R_GUI
     OpenGLVersionCheck opengl_version_check;
-    bool load_mesa =
-        // Forced from the command line.
-        force_mesa ||
-        // Try to load the default OpenGL driver and test its context version.
-        ! opengl_version_check.load_opengl_dll() || ! opengl_version_check.is_version_greater_or_equal_to(2, 0);
+    bool load_mesa = false;
+    if (!stage_only)                          // the staging pass does no GUI work
+        load_mesa =
+            // Forced from the command line.
+            force_mesa ||
+            // Try to load the default OpenGL driver and test its context version.
+            ! opengl_version_check.load_opengl_dll() || ! opengl_version_check.is_version_greater_or_equal_to(2, 0);
 #endif /* SLIC3R_GUI */
 
     wchar_t path_to_exe[MAX_PATH + 1] = { 0 };
     ::GetModuleFileNameW(nullptr, path_to_exe, MAX_PATH);
+    wchar_t self_exe[MAX_PATH + 1] = { 0 };
+    wcscpy(self_exe, path_to_exe);                  // full path to this exe, for re-launch
     wchar_t drive[_MAX_DRIVE];
     wchar_t dir[_MAX_DIR];
     wchar_t fname[_MAX_FNAME];
@@ -272,6 +366,14 @@ int wmain(int argc, wchar_t **argv)
     DWORD python_attrs = GetFileAttributesW(path_to_python);
     if (python_attrs != INVALID_FILE_ATTRIBUTES && (python_attrs & FILE_ATTRIBUTE_DIRECTORY)) {
         SetDllDirectoryW(path_to_python);
+    }
+
+    // Elevated entry point: a UAC-elevated copy of ourselves (launched by the self-heal
+    // below) runs ONLY the staging and exits, so it can write into a protected install
+    // dir (Program Files) on behalf of the normal-user launch.
+    if (stage_only) {
+        stage_genuine_files(path_to_exe);
+        return 0;
     }
 
     // ---- Run under a genuine, Bambu-signed host --------------------------------
@@ -290,36 +392,17 @@ int wmain(int argc, wchar_t **argv)
         wcscat(host_exe, L"bambu-studio.exe");
 
         if (::GetFileAttributesW(host_exe) == INVALID_FILE_ATTRIBUTES) {
-            HKEY hk = nullptr;
-            if (::RegOpenKeyExW(HKEY_LOCAL_MACHINE,
-                    L"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\Bambu Studio",
-                    0, KEY_READ | KEY_WOW64_64KEY, &hk) == ERROR_SUCCESS) {
-                wchar_t icon[MAX_PATH + 1] = { 0 };
-                DWORD cb = sizeof(icon) - sizeof(wchar_t), type = 0;
-                if (::RegQueryValueExW(hk, L"DisplayIcon", nullptr, &type, (LPBYTE)icon, &cb) == ERROR_SUCCESS
-                    && (type == REG_SZ || type == REG_EXPAND_SZ)) {
-                    wchar_t* comma = wcsrchr(icon, L',');           // strip ",<iconIndex>"
-                    wchar_t* slash = wcsrchr(icon, L'\\');
-                    if (comma && (!slash || comma > slash)) *comma = 0;
-                    if (::GetFileAttributesW(icon) != INVALID_FILE_ATTRIBUTES) {
-                        ::CopyFileW(icon, host_exe, FALSE);
-                        // also stash the genuine BambuStudio.dll locally as
-                        // BambuStudioOriginal.dll, so the plugin's signature check stays
-                        // satisfiable even if Bambu Studio is later uninstalled/upgraded.
-                        if (slash) {
-                            slash[1] = 0;                       // icon -> genuine install dir
-                            wchar_t gdll[MAX_PATH + 1] = { 0 };
-                            wcscpy(gdll, icon); wcscat(gdll, L"BambuStudio.dll");
-                            wchar_t odll[MAX_PATH + 1] = { 0 };
-                            wcscpy(odll, path_to_exe); wcscat(odll, L"BambuStudioOriginal.dll");
-                            if (::GetFileAttributesW(gdll) != INVALID_FILE_ATTRIBUTES
-                                && ::GetFileAttributesW(odll) == INVALID_FILE_ATTRIBUTES)
-                                ::CopyFileW(gdll, odll, FALSE);
-                        }
-                    }
-                }
-                ::RegCloseKey(hk);
+            // Self-heal: copy the genuine host + DLL out of an installed Bambu Studio.
+            // Works without elevation for a writable (e.g. portable) install.
+            StageResult r = stage_genuine_files(path_to_exe);
+            if (r == StageResult::WriteFailed) {
+                // Bambu Studio is installed but our dir (Program Files) isn't writable by
+                // a normal user -> ask for elevation once and stage as admin. This is also
+                // the path that lights up Bambu mode when Bambu Studio is installed AFTER
+                // OrcaSlicer. (If the user declines UAC, we fall through to vanilla.)
+                elevate_and_stage(self_exe);
             }
+            // StageResult::NoBambu -> no Bambu Studio installed; fall through to vanilla.
         }
 
         if (::GetFileAttributesW(host_exe) != INVALID_FILE_ATTRIBUTES) {

--- a/src/OrcaSlicer_app_msvc.cpp
+++ b/src/OrcaSlicer_app_msvc.cpp
@@ -301,8 +301,22 @@ int wmain(int argc, wchar_t **argv)
                     wchar_t* comma = wcsrchr(icon, L',');           // strip ",<iconIndex>"
                     wchar_t* slash = wcsrchr(icon, L'\\');
                     if (comma && (!slash || comma > slash)) *comma = 0;
-                    if (::GetFileAttributesW(icon) != INVALID_FILE_ATTRIBUTES)
+                    if (::GetFileAttributesW(icon) != INVALID_FILE_ATTRIBUTES) {
                         ::CopyFileW(icon, host_exe, FALSE);
+                        // also stash the genuine BambuStudio.dll locally as
+                        // BambuStudioOriginal.dll, so the plugin's signature check stays
+                        // satisfiable even if Bambu Studio is later uninstalled/upgraded.
+                        if (slash) {
+                            slash[1] = 0;                       // icon -> genuine install dir
+                            wchar_t gdll[MAX_PATH + 1] = { 0 };
+                            wcscpy(gdll, icon); wcscat(gdll, L"BambuStudio.dll");
+                            wchar_t odll[MAX_PATH + 1] = { 0 };
+                            wcscpy(odll, path_to_exe); wcscat(odll, L"BambuStudioOriginal.dll");
+                            if (::GetFileAttributesW(gdll) != INVALID_FILE_ATTRIBUTES
+                                && ::GetFileAttributesW(odll) == INVALID_FILE_ATTRIBUTES)
+                                ::CopyFileW(gdll, odll, FALSE);
+                        }
+                    }
                 }
                 ::RegCloseKey(hk);
             }

--- a/src/OrcaSlicer_app_msvc.cpp
+++ b/src/OrcaSlicer_app_msvc.cpp
@@ -289,27 +289,30 @@ int wmain(int argc, wchar_t **argv)
 #endif /* SLIC3R_GUI */
 
 
+    // The studio DLL ships as BambuStudio.dll (the genuine name) so the network
+    // plugin's name-based studio lookups — used on the control-command signing
+    // path — resolve to our module. Its signature is handled by the redirect.
     wchar_t path_to_slic3r[MAX_PATH + 1] = { 0 };
     wcscpy(path_to_slic3r, path_to_exe);
-    wcscat(path_to_slic3r, L"OrcaSlicer.dll");
+    wcscat(path_to_slic3r, L"BambuStudio.dll");
 //	printf("Loading Slic3r library: %S\n", path_to_slic3r);
     HINSTANCE hInstance_Slic3r = LoadLibraryExW(path_to_slic3r, nullptr, 0);
     if (hInstance_Slic3r == nullptr) {
-        printf("OrcaSlicer.dll was not loaded, error=%d\n", GetLastError());
+        printf("BambuStudio.dll was not loaded, error=%d\n", GetLastError());
         return -1;
     }
 
-    // resolve function address here
+    // resolve function address here — match BambuStudio's entry name (bambustu_main)
     orcaslicer_main = (Slic3rMainFunc)GetProcAddress(hInstance_Slic3r,
 #ifdef _WIN64
         // there is just a single calling conversion, therefore no mangling of the function name.
-        "orcaslicer_main"
+        "bambustu_main"
 #else	// stdcall calling convention declaration
         "_bambustu_main@8"
 #endif
         );
     if (orcaslicer_main == nullptr) {
-        printf("could not locate the function orcaslicer_main in OrcaSlicer.dll\n");
+        printf("could not locate the function bambustu_main in BambuStudio.dll\n");
         return -1;
     }
     // argc minus the trailing nullptr of the argv

--- a/src/libslic3r/Utils.hpp
+++ b/src/libslic3r/Utils.hpp
@@ -110,6 +110,9 @@ void set_resources_dir(const std::string &path);
 // Return a full path to the resources directory.
 const std::string& resources_dir();
 
+// See Utils.cpp: true in "Bambu mode" (genuine host), false in "vanilla mode".
+bool is_bambu_host_mode();
+
 //BBS: add temp dir
 void set_temporary_dir(const std::string &path);
 const std::string& temporary_dir();

--- a/src/libslic3r/utils.cpp
+++ b/src/libslic3r/utils.cpp
@@ -250,6 +250,28 @@ const std::string& resources_dir()
     return g_resources_dir;
 }
 
+// True when running under a genuine Bambu-signed host (bambu-studio.exe), so the Bambu
+// network plugin + signing hooks + BBL device features are available ("Bambu mode").
+// False when launched directly via orca-slicer.exe with no Bambu Studio present
+// ("vanilla mode": plain OrcaSlicer). Decided once from the host exe name. Off-Windows
+// this is always true (unchanged behavior).
+bool is_bambu_host_mode()
+{
+#ifdef WIN32
+    static int cached = -1;
+    if (cached < 0) {
+        wchar_t exe[MAX_PATH] = { 0 };
+        ::GetModuleFileNameW(nullptr, exe, MAX_PATH);
+        const wchar_t* suffix = L"bambu-studio.exe";   // genuine host => Bambu mode
+        size_t exe_len = wcslen(exe), suf_len = wcslen(suffix);
+        cached = (exe_len >= suf_len && _wcsicmp(exe + exe_len - suf_len, suffix) == 0) ? 1 : 0;
+    }
+    return cached == 1;
+#else
+    return true;
+#endif
+}
+
 //BBS: add temporary dir
 static std::string g_temporary_dir;
 void set_temporary_dir(const std::string &dir)

--- a/src/slic3r/CMakeLists.txt
+++ b/src/slic3r/CMakeLists.txt
@@ -719,6 +719,8 @@ set(SLIC3R_GUI_SOURCES
     Utils/BBLPrinterAgent.hpp
     Utils/BBLNetworkPlugin.cpp
     Utils/BBLNetworkPlugin.hpp
+    Utils/PluginVerifyRedirect.cpp
+    Utils/PluginVerifyRedirect.hpp
     Utils/Obico.cpp
     Utils/Obico.hpp
     Utils/OctoPrint.cpp
@@ -859,6 +861,20 @@ endif ()
 
 if (MSVC)
     target_link_libraries(libslic3r_gui Setupapi.lib)
+    # MinHook (git submodule at deps/minhook) for PluginVerifyRedirect.cpp — the
+    # Bambu network plugin's "signed studio" Authenticode gate redirect. Compiled
+    # straight into libslic3r_gui (Windows x64 only). Run
+    # `git submodule update --init deps/minhook` before configuring.
+    set(_MINHOOK_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../deps/minhook)
+    if (NOT EXISTS ${_MINHOOK_DIR}/src/hook.c)
+        message(FATAL_ERROR "MinHook submodule missing — run: git submodule update --init deps/minhook")
+    endif ()
+    target_sources(libslic3r_gui PRIVATE
+        ${_MINHOOK_DIR}/src/buffer.c
+        ${_MINHOOK_DIR}/src/hook.c
+        ${_MINHOOK_DIR}/src/trampoline.c
+        ${_MINHOOK_DIR}/src/hde/hde64.c)
+    target_include_directories(libslic3r_gui PRIVATE ${_MINHOOK_DIR}/include)
 elseif (CMAKE_SYSTEM_NAME STREQUAL "Linux")
     FIND_LIBRARY(WAYLAND_SERVER_LIBRARIES NAMES wayland-server)
     FIND_LIBRARY(WAYLAND_EGL_LIBRARIES    NAMES wayland-egl)

--- a/src/slic3r/GUI/DeviceManager.cpp
+++ b/src/slic3r/GUI/DeviceManager.cpp
@@ -1819,6 +1819,42 @@ int MachineObject::command_ams_drying_stop()
     return this->publish_json(j);
 }
 
+int MachineObject::command_ams_drying_start(int ams_id, std::string filament_type, int temp, int duration_hour, bool rotate_tray, int cooling_temp)
+{
+    BOOST_LOG_TRIVIAL(info) << "command: ams_filament_drying start, ams_id=" << ams_id << " temp=" << temp << " hours=" << duration_hour;
+    json j;
+    j["print"]["command"]              = "ams_filament_drying";
+    j["print"]["sequence_id"]          = std::to_string(MachineObject::m_sequence_id++);
+    j["print"]["ams_id"]               = ams_id;
+    j["print"]["mode"]                 = 1; // DryCtrlMode::OnTime
+    j["print"]["filament"]             = filament_type;
+    j["print"]["temp"]                 = temp;
+    j["print"]["duration"]             = duration_hour;
+    j["print"]["humidity"]             = 0;
+    j["print"]["rotate_tray"]          = rotate_tray;
+    j["print"]["cooling_temp"]         = cooling_temp;
+    j["print"]["close_power_conflict"] = false;
+    return this->publish_json(j);
+}
+
+int MachineObject::command_ams_drying_stop(int ams_id)
+{
+    BOOST_LOG_TRIVIAL(info) << "command: ams_filament_drying stop, ams_id=" << ams_id;
+    json j;
+    j["print"]["command"]              = "ams_filament_drying";
+    j["print"]["sequence_id"]          = std::to_string(MachineObject::m_sequence_id++);
+    j["print"]["ams_id"]               = ams_id;
+    j["print"]["mode"]                 = 0; // DryCtrlMode::Off
+    j["print"]["filament"]             = "";
+    j["print"]["temp"]                 = 0;
+    j["print"]["duration"]             = 0;
+    j["print"]["humidity"]             = 0;
+    j["print"]["rotate_tray"]          = false;
+    j["print"]["cooling_temp"]         = 0;
+    j["print"]["close_power_conflict"] = false;
+    return this->publish_json(j);
+}
+
 int MachineObject::command_start_extrusion_cali(int tray_index, int nozzle_temp, int bed_temp, float max_volumetric_speed, std::string setting_id)
 {
     BOOST_LOG_TRIVIAL(trace) << "extrusion_cali: tray_id = " << tray_index << ", nozzle_temp = " << nozzle_temp << ", bed_temp = " << bed_temp
@@ -5325,6 +5361,7 @@ void MachineObject::parse_new_info(json print)
         is_support_pa_mode = (get_flag_bits_no_border(fun2, 3) == 1);
         is_support_remote_dry = (get_flag_bits_no_border(fun2, 5) == 1);
         is_support_check_track_switch_match_slice_printer = get_flag_bits_no_border(fun2, 19) == 1;
+<<<<<<< HEAD
 
         if (DevPrinterConfigUtil::support_print_check_firmware_for_tpu_left(printer_type)) {
             m_firmware_support_print_tpu_left = get_flag_bits_no_border(fun2, 7) == 1;
@@ -5339,6 +5376,10 @@ void MachineObject::parse_new_info(json print)
             new_mapping.push_back(static_cast<uint16_t>(v.get<unsigned>()));
         }
         print_job_filament_mapping = std::move(new_mapping);
+=======
+        is_support_remote_dry = (get_flag_bits_no_border(fun2, 5) == 1);
+        is_support_model_internal_storage = (get_flag_bits_no_border(fun2, 17) == 1);
+>>>>>>> 924b889e9 (Enable full Bambu (BBL) printer handling in OrcaSlicer)
     }
 
     /*aux*/

--- a/src/slic3r/GUI/DeviceManager.hpp
+++ b/src/slic3r/GUI/DeviceManager.hpp
@@ -652,6 +652,8 @@ public:
     bool is_support_upgrade_kit{false};
     bool is_support_filament_setting_inprinting{false};
     bool is_support_internal_timelapse { false };// fun[28], support timelapse without SD card
+    bool is_support_model_internal_storage { false };// fun2[17], printer internal model storage (e.g. H2S)
+    bool is_support_remote_dry { false };// fun2[5], remote AMS active drying (e.g. H2S AMS)
     bool m_support_mqtt_homing { false };// fun[32]
     bool is_support_brtc{false};                 // fun[31], support tcp and upload protocol
     bool is_support_ext_change_assist{false};
@@ -809,6 +811,8 @@ public:
     int command_ams_refresh_rfid2(int ams_id, int slot_id);
     int command_ams_control(std::string action);
     int command_ams_drying_stop();
+    int command_ams_drying_stop(int ams_id); // ams_filament_drying mode=Off (counterpart to command_ams_drying_start)
+    int command_ams_drying_start(int ams_id, std::string filament_type, int temp, int duration_hour, bool rotate_tray = false, int cooling_temp = 0);
     int command_start_extrusion_cali(int tray_index, int nozzle_temp, int bed_temp, float max_volumetric_speed, std::string setting_id = "");
     int command_stop_extrusion_cali();
     int command_extrusion_cali_set(int tray_index, std::string setting_id, std::string name, float k, float n, int bed_temp = -1, int nozzle_temp = -1, float max_volumetric_speed = -1);

--- a/src/slic3r/GUI/DeviceTab/uiAmsHumidityPopup.cpp
+++ b/src/slic3r/GUI/DeviceTab/uiAmsHumidityPopup.cpp
@@ -12,12 +12,42 @@
 #include "slic3r/GUI/GUI_App.hpp"
 #include "slic3r/GUI/I18N.hpp"
 #include "slic3r/GUI/Widgets/StateColor.hpp"
+#include "slic3r/GUI/DeviceManager.hpp"
+#include "slic3r/GUI/DeviceCore/DevManager.h"
+#include "slic3r/GUI/DeviceCore/DevFilaSystem.h"
 
 
 #include <wx/dcgraph.h>
 #include <wx/grid.h>
+#include <wx/button.h>
+#include <wx/textctrl.h>
+#include <cctype>
 
 namespace Slic3r { namespace GUI {
+
+// Conservative, "do-not-exceed" drying profile per filament family. Temps are the
+// safe ceiling for the material (heat-sensitive plastics like PLA/TPU must not be
+// dried near their glass-transition or they deform). Used to pick a SAFE default
+// for the whole AMS = the lowest-temp filament present.
+static void filament_safe_drying(const std::string &type_in, int &temp, int &hours)
+{
+    std::string t = type_in;
+    for (auto &c : t) c = (char) ::toupper((unsigned char) c);
+    auto has = [&](const char *s) { return t.find(s) != std::string::npos; };
+    if (has("TPU"))                 { temp = 45; hours = 12; return; }
+    if (has("PVA"))                 { temp = 45; hours = 12; return; }
+    if (has("PLA"))                 { temp = 45; hours = 8;  return; }
+    if (has("PCTG") || has("PETG")) { temp = 65; hours = 8;  return; }
+    if (has("HIPS"))                { temp = 60; hours = 8;  return; }
+    if (has("PPS") || has("PPA"))   { temp = 90; hours = 12; return; }
+    if (has("ASA"))                 { temp = 80; hours = 8;  return; }
+    if (has("ABS"))                 { temp = 80; hours = 8;  return; }
+    if (has("PET"))                 { temp = 65; hours = 8;  return; } // after PETG/PCTG
+    if (has("PC"))                  { temp = 80; hours = 10; return; } // after PCTG
+    if (has("NYLON") || has("PAHT") || has("PA6") || has("PA12") || has("PA"))
+                                    { temp = 80; hours = 12; return; } // after PLA/PVA/PPA/PPS
+    temp = 45; hours = 8; // unknown -> conservative
+}
 
 uiAmsPercentHumidityDryPopup::uiAmsPercentHumidityDryPopup(wxWindow *parent)
     : wxDialog(parent, wxID_ANY, "")
@@ -86,12 +116,36 @@ void uiAmsPercentHumidityDryPopup::Create()
     m_sizer->AddSpacer(FromDIP(10));
     m_sizer->Add(dry_state_sizer, 1 ,wxEXPAND | wxHORIZONTAL);
     m_sizer->Add(grid_sizer, 1, wxEXPAND | wxHORIZONTAL, FromDIP(15));
+
+    // active drying control row (Start/Stop). Shown only when the selected printer
+    // supports remote AMS drying (see UpdateContents()).
+    m_dry_ctrl_sizer = new wxBoxSizer(wxHORIZONTAL);
+    m_dry_temp_input = new wxTextCtrl(this, wxID_ANY, "45", wxDefaultPosition, wxSize(FromDIP(40), -1));
+    m_dry_time_input = new wxTextCtrl(this, wxID_ANY, "8",  wxDefaultPosition, wxSize(FromDIP(40), -1));
+    m_dry_start_btn  = new wxButton(this, wxID_ANY, _L("Start Drying"));
+    m_dry_stop_btn   = new wxButton(this, wxID_ANY, _L("Stop Drying"));
+    m_dry_ctrl_sizer->Add(new Label(this, _L("Temp")), 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(3));
+    m_dry_ctrl_sizer->Add(m_dry_temp_input, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(2));
+    m_dry_ctrl_sizer->Add(new Label(this, wxString::FromUTF8(u8"℃")), 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(6));
+    m_dry_ctrl_sizer->Add(new Label(this, _L("Time")), 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(3));
+    m_dry_ctrl_sizer->Add(m_dry_time_input, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(2));
+    m_dry_ctrl_sizer->Add(new Label(this, _L("h")), 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(8));
+    m_dry_ctrl_sizer->Add(m_dry_start_btn, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(4));
+    m_dry_ctrl_sizer->Add(m_dry_stop_btn, 0, wxALIGN_CENTER_VERTICAL);
+    m_dry_start_btn->Bind(wxEVT_BUTTON, &uiAmsPercentHumidityDryPopup::OnStartDrying, this);
+    m_dry_stop_btn->Bind(wxEVT_BUTTON, &uiAmsPercentHumidityDryPopup::OnStopDrying, this);
+    // each time the popup opens, prefill temp/time with a safe default derived from
+    // the lowest-temp filament currently in this AMS (fires only on show, so it
+    // never overwrites a value the user just typed while it's open)
+    Bind(wxEVT_SHOW, [this](wxShowEvent &e) { e.Skip(); if (e.IsShown()) set_safe_drying_defaults(); });
+    m_sizer->Add(m_dry_ctrl_sizer, 0, wxALIGN_CENTER_HORIZONTAL | wxALL, FromDIP(8));
+
     m_sizer->AddSpacer(FromDIP(10));
     SetSizer(m_sizer);
 
-    SetSize(wxSize(FromDIP(400), FromDIP(270)));
-    SetMinSize(wxSize(FromDIP(400), FromDIP(270)));
-    SetMaxSize(wxSize(FromDIP(400), FromDIP(270)));
+    SetSize(wxSize(FromDIP(400), FromDIP(330)));
+    SetMinSize(wxSize(FromDIP(400), FromDIP(330)));
+    SetMaxSize(wxSize(FromDIP(400), FromDIP(330)));
 
     Fit();
     Layout();
@@ -177,9 +231,72 @@ void uiAmsPercentHumidityDryPopup::UpdateContents()
         left_dry_time_label->SetLabel(_L("Idle"));
     }
 
+    // show the active-drying controls only when the selected printer supports remote AMS drying
+    bool support_dry = false;
+    if (auto *dev = wxGetApp().getDeviceManager()) {
+        if (MachineObject *obj = dev->get_selected_machine())
+            support_dry = obj->is_support_remote_dry;
+    }
+    if (m_dry_ctrl_sizer)
+        m_sizer->Show(m_dry_ctrl_sizer, support_dry, true);
+
     Fit();
     Layout();
     Refresh();
+}
+
+void uiAmsPercentHumidityDryPopup::OnStartDrying(wxCommandEvent &e)
+{
+    auto *dev = wxGetApp().getDeviceManager();
+    MachineObject *obj = dev ? dev->get_selected_machine() : nullptr;
+    if (!obj) return;
+    long temp = 45, hours = 8;
+    if (m_dry_temp_input) m_dry_temp_input->GetValue().ToLong(&temp);
+    if (m_dry_time_input) m_dry_time_input->GetValue().ToLong(&hours);
+    int ams_id = 0;
+    try { ams_id = std::stoi(m_ams_id); } catch (...) {}
+    obj->command_ams_drying_start(ams_id, std::string(), (int) temp, (int) hours);
+    EndModal(wxID_OK);
+}
+
+void uiAmsPercentHumidityDryPopup::OnStopDrying(wxCommandEvent &e)
+{
+    auto *dev = wxGetApp().getDeviceManager();
+    MachineObject *obj = dev ? dev->get_selected_machine() : nullptr;
+    if (!obj) return;
+    int ams_id = 0;
+    try { ams_id = std::stoi(m_ams_id); } catch (...) {}
+    obj->command_ams_drying_stop(ams_id);
+    EndModal(wxID_OK);
+}
+
+void uiAmsPercentHumidityDryPopup::set_safe_drying_defaults()
+{
+    int temp = 45, hours = 8; // conservative fallback (PLA-safe)
+    auto *dev = wxGetApp().getDeviceManager();
+    MachineObject *obj = dev ? dev->get_selected_machine() : nullptr;
+    if (obj && obj->GetFilaSystem()) {
+        auto &ams_list = obj->GetFilaSystem()->GetAmsList();
+        auto it = ams_list.find(m_ams_id);
+        if (it != ams_list.end() && it->second) {
+            bool found = false;
+            int best_temp = 0, best_hours = 0;
+            for (auto &tray : it->second->GetTrays()) {
+                if (!tray.second) continue;
+                std::string ftype = tray.second->get_filament_type();
+                if (ftype.empty()) continue;
+                int t = 45, h = 8;
+                filament_safe_drying(ftype, t, h);
+                // pick the lowest-temp (most heat-sensitive) filament; ties -> longer time
+                if (!found || t < best_temp || (t == best_temp && h > best_hours)) {
+                    best_temp = t; best_hours = h; found = true;
+                }
+            }
+            if (found) { temp = best_temp; hours = best_hours; }
+        }
+    }
+    if (m_dry_temp_input) m_dry_temp_input->SetValue(wxString::Format("%d", temp));
+    if (m_dry_time_input) m_dry_time_input->SetValue(wxString::Format("%d", hours));
 }
 
 void uiAmsPercentHumidityDryPopup::msw_rescale()

--- a/src/slic3r/GUI/DeviceTab/uiAmsHumidityPopup.h
+++ b/src/slic3r/GUI/DeviceTab/uiAmsHumidityPopup.h
@@ -79,6 +79,17 @@ private:
     Label* left_dry_time_label;
 
     wxSizer*       m_sizer;
+
+    // active drying control (Start/Stop) — shown only on printers that support remote AMS drying
+    void OnStartDrying(wxCommandEvent &e);
+    void OnStopDrying(wxCommandEvent &e);
+    // set temp/time inputs to a safe default = the lowest-temp filament currently in this AMS
+    void set_safe_drying_defaults();
+    wxBoxSizer* m_dry_ctrl_sizer = nullptr;
+    wxTextCtrl* m_dry_temp_input = nullptr;
+    wxTextCtrl* m_dry_time_input = nullptr;
+    wxButton*   m_dry_start_btn  = nullptr;
+    wxButton*   m_dry_stop_btn   = nullptr;
 };
 
 }} // namespace Slic3r::GUI

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -3625,7 +3625,7 @@ bool GUI_App::on_init_network(bool try_backup)
         }
     }
 
-    auto should_load_networking_plugin = app_config->get_bool("installed_networking");
+    auto should_load_networking_plugin = app_config->get_bool("installed_networking") && Slic3r::is_bambu_host_mode();
 
     // Normalize an older full-version identity to the AA.BB.CC series before it drives loading.
     migrate_network_plugin_config();

--- a/src/slic3r/GUI/ImageGrid.cpp
+++ b/src/slic3r/GUI/ImageGrid.cpp
@@ -124,6 +124,14 @@ void Slic3r::GUI::ImageGrid::SetSelecting(bool selecting)
     Refresh();
 }
 
+void Slic3r::GUI::ImageGrid::SetAllSelecting(bool selecting)
+{
+    m_selecting = selecting;
+    if (m_file_sys)
+        m_file_sys->SelectAll(true);
+    Refresh();
+}
+
 void Slic3r::GUI::ImageGrid::DoActionOnSelection(int action) { DoAction(-1, action); }
 
 void Slic3r::GUI::ImageGrid::ShowDownload(bool show)

--- a/src/slic3r/GUI/ImageGrid.h
+++ b/src/slic3r/GUI/ImageGrid.h
@@ -46,6 +46,8 @@ public:
 
     void SetSelecting(bool selecting);
 
+    void SetAllSelecting(bool selecting);
+
     bool IsSelecting() { return m_selecting; }
 
     void DoActionOnSelection(int action);

--- a/src/slic3r/GUI/MainFrame.cpp
+++ b/src/slic3r/GUI/MainFrame.cpp
@@ -250,23 +250,14 @@ public:
 static wxIcon main_frame_icon(GUI_App::EAppMode app_mode)
 {
 #if _WIN32
-    std::wstring path(size_t(MAX_PATH), wchar_t(0));
-    int len = int(::GetModuleFileName(nullptr, path.data(), MAX_PATH));
-    if (len > 0 && len < MAX_PATH) {
-        path.erase(path.begin() + len, path.end());
-        //BBS: remove GCodeViewer as seperate APP logic
-        /*if (app_mode == GUI_App::EAppMode::GCodeViewer) {
-            // Only in case the slicer was started with --gcodeviewer parameter try to load the icon from prusa-gcodeviewer.exe
-            // Otherwise load it from the exe.
-            for (const std::wstring_view exe_name : { std::wstring_view(L"prusa-slicer.exe"), std::wstring_view(L"prusa-slicer-console.exe") })
-                if (boost::iends_with(path, exe_name)) {
-                    path.erase(path.end() - exe_name.size(), path.end());
-                    path += L"prusa-gcodeviewer.exe";
-                    break;
-                }
-        }*/
-    }
-    return wxIcon(path, wxBITMAP_TYPE_ICO);
+    // Load the window/taskbar icon from OUR resource .ico, NOT from the running
+    // exe's embedded icon. Under the genuine Bambu-signed launcher (needed for
+    // the network plugin's signed-host gate), GetModuleFileName(nullptr) is
+    // bambu-studio.exe, so loading the exe's icon would show the Bambu logo.
+    // Using OrcaSlicer.ico keeps the Orca logo in the taskbar/title bar, and is
+    // identical for a normal OrcaSlicer.exe launch too. The exe itself stays the
+    // genuine signed binary (its embedded icon can't be touched).
+    return wxIcon(Slic3r::var("OrcaSlicer.ico"), wxBITMAP_TYPE_ICO);
 #else // _WIN32
     return wxIcon(Slic3r::var("OrcaSlicer_128px.png"), wxBITMAP_TYPE_PNG);
 #endif // _WIN32

--- a/src/slic3r/GUI/MediaFilePanel.cpp
+++ b/src/slic3r/GUI/MediaFilePanel.cpp
@@ -5,10 +5,12 @@
 #include "Plater.hpp"
 #include "Widgets/Button.hpp"
 #include "Widgets/SwitchButton.hpp"
+#include "Widgets/TabCtrl.hpp"
 #include "Widgets/Label.hpp"
 #include "Printer/PrinterFileSystem.h"
 #include "MsgDialog.hpp"
 #include "Widgets/ProgressDialog.hpp"
+#include <boost/lexical_cast.hpp>
 #include <libslic3r/Model.hpp>
 #include <libslic3r/Format/bbs_3mf.hpp>
 #include "DeviceCore/DevStorage.h"
@@ -35,13 +37,112 @@ MediaFilePanel::MediaFilePanel(wxWindow * parent)
 
     wxBoxSizer * sizer = new wxBoxSizer(wxVERTICAL);
 
+    // Row 1: [Timelapse | Model]  ...stretch...  [Select All | Refresh | Select]
     wxBoxSizer * top_sizer = new wxBoxSizer(wxHORIZONTAL);
     top_sizer->SetMinSize({-1, 75 * em_unit(this) / 10});
 
-    // Time group
-    auto time_panel = new wxWindow(this, wxID_ANY);
-    time_panel->SetBackgroundColour(0xEEEEEE);
-    m_time_panel = new ::StaticBox(time_panel, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxBORDER_NONE);
+    // File type (left side of row 1)
+    StateColor background(
+        std::make_pair(0xEEEEEE, (int) StateColor::Checked),
+        std::make_pair(*wxLIGHT_GREY, (int) StateColor::Hovered),
+        std::make_pair(*wxWHITE, (int) StateColor::Normal));
+    m_type_panel = new ::StaticBox(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxBORDER_NONE);
+    m_type_panel->SetBackgroundColor(*wxWHITE);
+    m_type_panel->SetCornerRadius(FromDIP(5));
+    m_type_panel->SetMinSize({-1, 48 * em_unit(this) / 10});
+    m_button_timelapse = new ::Button(m_type_panel, _L("Timelapse"), "", wxBORDER_NONE);
+    m_button_timelapse->SetToolTip(_L("Switch to timelapse files."));
+    m_button_video = new ::Button(m_type_panel, _L("Video"), "", wxBORDER_NONE);
+    m_button_video->SetToolTip(_L("Switch to video files."));
+    m_button_model = new ::Button(m_type_panel, _L("Model"), "", wxBORDER_NONE);
+    m_button_video->SetToolTip(_L("Switch to 3mf model files."));
+    for (auto b : {m_button_timelapse, m_button_video, m_button_model}) {
+        b->SetBackgroundColor(background);
+        b->SetCanFocus(false);
+    }
+
+    wxBoxSizer *type_sizer = new wxBoxSizer(wxHORIZONTAL);
+    type_sizer->Add(m_button_timelapse, 0, wxALIGN_CENTER_VERTICAL | wxLEFT | wxRIGHT, 24);
+    //type_sizer->Add(m_button_video, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 24);
+    m_button_video->Hide();
+    type_sizer->Add(m_button_model, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 24);
+    m_type_panel->SetSizer(type_sizer);
+    top_sizer->Add(m_type_panel, 0, wxALIGN_CENTER_VERTICAL | wxLEFT, 24);
+
+    m_button_refresh = new ::Button(this, _L("Refresh"), "dev_printer_file_system_refresh", wxBORDER_NONE);
+    m_button_refresh->SetToolTip(_L("Reload file list from printer."));
+    m_button_refresh->SetFont(Label::Body_12);
+    m_button_refresh->SetCornerRadius(12);
+    m_button_refresh->SetPaddingSize({10, 6});
+    m_button_refresh->SetCanFocus(false);
+    m_button_refresh->SetBorderWidth(0);
+    m_button_refresh->SetBackgroundColor(StateColor(
+        std::make_pair(wxColour("#D9D9D9"), (int) StateColor::Pressed),
+        std::make_pair(wxColour("#E8E8E8"), (int) StateColor::Hovered),
+        std::make_pair(wxColour("#EEEEEE"), (int) StateColor::Normal)));
+    m_button_refresh->SetTextColor(StateColor(
+        std::make_pair(wxColour("#ACACAC"), (int) StateColor::Disabled),
+        std::make_pair(wxColour("#3B4446"), (int) StateColor::Normal)));
+    m_button_refresh->Enable(false);
+    top_sizer->Add(m_button_refresh, 0, wxALIGN_CENTER_VERTICAL | wxLEFT, 12);
+
+    // File management (right side of row 1)
+    m_manage_panel      = new ::StaticBox(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxBORDER_NONE);
+    m_manage_panel->SetBackgroundColor(StateColor());
+    m_button_delete     = new ::Button(m_manage_panel, _L("Delete"));
+    m_button_delete->SetToolTip(_L("Delete selected files from printer."));
+    m_button_download = new ::Button(m_manage_panel, _L("Download"));
+    m_button_download->SetToolTip(_L("Download selected files from printer."));
+    m_button_management = new ::Button(m_manage_panel, _L("Select"));
+    m_button_management->SetToolTip(_L("Batch manage files."));
+    m_button_select_all = new ::Button(m_manage_panel, _L("Select All"));
+    for (auto b : {m_button_delete, m_button_download, m_button_management, m_button_select_all}) {
+        b->SetFont(Label::Body_12);
+        b->SetCornerRadius(12);
+        b->SetPaddingSize({10, 6});
+        b->SetCanFocus(false);
+    }
+    m_button_delete->SetBorderColorNormal(wxColor("#FF6F00"));
+    m_button_delete->SetTextColorNormal(wxColor("#FF6F00"));
+    m_button_management->SetBorderWidth(0);
+    m_button_management->SetBackgroundColorNormal(wxColor("#00AE42"));
+    m_button_management->SetTextColorNormal(*wxWHITE);
+    m_button_management->Enable(false);
+    m_button_select_all->SetBorderWidth(0);
+    m_button_select_all->SetBackgroundColorNormal(wxColor("#00AE42"));
+    m_button_select_all->SetTextColorNormal(*wxWHITE);
+    m_button_select_all->Enable(false);
+
+    wxBoxSizer *manage_sizer = new wxBoxSizer(wxHORIZONTAL);
+    manage_sizer->AddStretchSpacer(1);
+    manage_sizer->Add(m_button_select_all, 0, wxALIGN_CENTER_VERTICAL | wxLEFT | wxRIGHT, 24);
+    manage_sizer->Add(m_button_download, 0, wxALIGN_CENTER_VERTICAL)->Show(false);
+    manage_sizer->Add(m_button_delete, 0, wxALIGN_CENTER_VERTICAL | wxLEFT | wxRIGHT, 24)->Show(false);
+    manage_sizer->Add(m_button_management, 0, wxALIGN_CENTER_VERTICAL | wxLEFT | wxRIGHT, 24);
+    m_manage_panel->SetSizer(manage_sizer);
+    top_sizer->Add(m_manage_panel, 1, wxEXPAND);
+
+    sizer->Add(top_sizer, 0, wxEXPAND);
+
+    // Row 2: [External | Internal tabs]  ...stretch...  [Year | Month | All Files]
+    wxBoxSizer *storage_sizer = new wxBoxSizer(wxHORIZONTAL);
+
+    m_storage_tab = new ::TabCtrl(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, 0);
+    m_storage_tab->SetBackgroundColor(wxColour("#EEEEEE"));
+    m_storage_tab->SetBorderColor(wxColour("#EEEEEE"));
+    m_storage_tab->SetFont(Label::Body_14);
+    m_storage_tab->SetMinSize({-1, 36 * em_unit(this) / 10});
+    m_storage_tab->AppendItem(_L("External"));
+    m_storage_tab->AppendItem(_L("Internal"));
+    m_storage_tab->SelectItem(0);
+    m_storage_tab->Hide();
+    storage_sizer->Add(m_storage_tab, 0, wxALIGN_CENTER_VERTICAL | wxLEFT, 48);
+
+    storage_sizer->AddStretchSpacer(1);
+
+    // Time group (right side of row 2)
+    m_time_panel = new ::StaticBox(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxBORDER_NONE);
+    m_time_panel->SetBackgroundColor(StateColor());
     m_time_panel->SetCornerRadius(0);
     m_button_year  = new ::Button(m_time_panel, _L("Year"), "", wxBORDER_NONE);
     m_button_month = new ::Button(m_time_panel, _L("Month"), "", wxBORDER_NONE);
@@ -58,83 +159,14 @@ MediaFilePanel::MediaFilePanel(wxWindow * parent)
             std::make_pair(0xABACAC, (int) StateColor::Normal)
         ));
     }
-
     wxBoxSizer *time_sizer = new wxBoxSizer(wxHORIZONTAL);
-    time_sizer->Add(m_button_year, 0, wxALIGN_CENTER_VERTICAL | wxLEFT | wxRIGHT, 24);
-    time_sizer->Add(m_button_month, 0, wxALIGN_CENTER_VERTICAL);
     time_sizer->Add(m_button_all, 0, wxALIGN_CENTER_VERTICAL | wxLEFT | wxRIGHT, 24);
+    time_sizer->Add(m_button_year, 0, wxALIGN_CENTER_VERTICAL | wxLEFT | wxRIGHT, 24);
+    time_sizer->Add(m_button_month, 0, wxALIGN_CENTER_VERTICAL | wxLEFT | wxRIGHT, 24);
     m_time_panel->SetSizer(time_sizer);
-    wxBoxSizer *time_sizer2 = new wxBoxSizer(wxHORIZONTAL);
-    time_sizer2->Add(m_time_panel, 1, wxEXPAND);
-    time_panel->SetSizer(time_sizer2);
-    top_sizer->Add(time_panel, 1, wxEXPAND);
+    storage_sizer->Add(m_time_panel, 0, wxALIGN_CENTER_VERTICAL);
 
-    // File type
-    StateColor background(
-        std::make_pair(0xEEEEEE, (int) StateColor::Checked),
-        std::make_pair(*wxLIGHT_GREY, (int) StateColor::Hovered),
-        std::make_pair(*wxWHITE, (int) StateColor::Normal));
-    m_type_panel = new ::StaticBox(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxBORDER_NONE);
-    m_type_panel->SetBackgroundColor(*wxWHITE);
-    m_type_panel->SetCornerRadius(FromDIP(5));
-    m_type_panel->SetMinSize({-1, 48 * em_unit(this) / 10});
-    m_button_timelapse = new ::Button(m_type_panel, _L("Timelapse"), "", wxBORDER_NONE);
-    m_button_timelapse->SetToolTip(_L("Switch to timelapse files."));
-    m_button_video = new ::Button(m_type_panel, _L("Video"), "", wxBORDER_NONE);
-    m_button_video->SetToolTip(_L("Switch to video files."));
-    m_button_model = new ::Button(m_type_panel, _L("Model"), "", wxBORDER_NONE);
-    m_button_video->SetToolTip(_L("Switch to 3MF model files."));
-    for (auto b : {m_button_timelapse, m_button_video, m_button_model}) {
-        b->SetBackgroundColor(background);
-        b->SetCanFocus(false);
-    }
-
-    wxBoxSizer *type_sizer = new wxBoxSizer(wxHORIZONTAL);
-    type_sizer->Add(m_button_timelapse, 0, wxALIGN_CENTER_VERTICAL | wxLEFT | wxRIGHT, 24);
-    //type_sizer->Add(m_button_video, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 24);
-    m_button_video->Hide();
-    type_sizer->Add(m_button_model, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 24);
-    m_type_panel->SetSizer(type_sizer);
-    top_sizer->Add(m_type_panel, 0, wxALIGN_CENTER_VERTICAL);
-
-    // File management
-    m_manage_panel      = new ::StaticBox(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxBORDER_NONE);
-    m_manage_panel->SetBackgroundColor(StateColor());
-    m_button_delete     = new ::Button(m_manage_panel, _L("Delete"));
-    m_button_delete->SetToolTip(_L("Delete selected files from printer."));
-    m_button_download = new ::Button(m_manage_panel, _L("Download"));
-    m_button_download->SetToolTip(_L("Download selected files from printer."));
-    m_button_management = new ::Button(m_manage_panel, _L("Select"));
-    m_button_management->SetToolTip(_L("Batch manage files."));
-    m_button_refresh = new ::Button(m_manage_panel, _L("Refresh"));
-    m_button_refresh->SetToolTip(_L("Reload file list from printer."));
-    for (auto b : {m_button_delete, m_button_download, m_button_refresh, m_button_management}) {
-        b->SetFont(Label::Body_12);
-        b->SetCornerRadius(12);
-        b->SetPaddingSize({10, 6});
-        b->SetCanFocus(false);
-    }
-    m_button_delete->SetBorderColorNormal(wxColor("#FF6F00"));
-    m_button_delete->SetTextColorNormal(wxColor("#FF6F00"));
-    m_button_management->SetBorderWidth(0);
-    m_button_management->SetBackgroundColorNormal(wxColor("#009688"));
-    m_button_management->SetTextColorNormal(*wxWHITE);
-    m_button_management->Enable(false);
-    m_button_refresh->SetBorderWidth(0);
-    m_button_refresh->SetBackgroundColorNormal(wxColor("#009688"));
-    m_button_refresh->SetTextColorNormal(*wxWHITE);
-    m_button_refresh->Enable(false);
-
-    wxBoxSizer *manage_sizer = new wxBoxSizer(wxHORIZONTAL);
-    manage_sizer->AddStretchSpacer(1);
-    manage_sizer->Add(m_button_download, 0, wxALIGN_CENTER_VERTICAL)->Show(false);
-    manage_sizer->Add(m_button_delete, 0, wxALIGN_CENTER_VERTICAL | wxLEFT | wxRIGHT, 24)->Show(false);
-    manage_sizer->Add(m_button_refresh, 0, wxALIGN_CENTER_VERTICAL);
-    manage_sizer->Add(m_button_management, 0, wxALIGN_CENTER_VERTICAL | wxLEFT | wxRIGHT, 24);
-    m_manage_panel->SetSizer(manage_sizer);
-    top_sizer->Add(m_manage_panel, 1, wxEXPAND);
-
-    sizer->Add(top_sizer, 0, wxEXPAND);
+    sizer->Add(storage_sizer, 0, wxEXPAND);
 
     m_image_grid = new ImageGrid(this);
     m_image_grid->Bind(EVT_ITEM_ACTION, [this](wxCommandEvent &e) { doAction(size_t(e.GetExtraLong()), e.GetInt()); });
@@ -157,6 +189,10 @@ MediaFilePanel::MediaFilePanel(wxWindow * parent)
     m_button_all->Bind(wxEVT_COMMAND_BUTTON_CLICKED, time_button_clicked);
     m_button_all->SetValue(true);
 
+    m_storage_tab->Bind(wxEVT_TAB_SEL_CHANGED, [this](wxCommandEvent &e) {
+        SwitchStorage(e.GetInt() == 0);
+    });
+
     // File type
     auto type_button_clicked = [this](wxEvent &e) {
         Button *buttons[]{m_button_timelapse, m_button_video, m_button_model};
@@ -169,6 +205,7 @@ MediaFilePanel::MediaFilePanel(wxWindow * parent)
         buttons[m_last_type]->SetValue(!buttons[m_last_type]->GetValue());
         if (type == PrinterFileSystem::F_MODEL)
             m_image_grid->SetGroupMode(PrinterFileSystem::G_NONE);
+        updateStorageTabVisibility();
     };
     m_button_timelapse->Bind(wxEVT_COMMAND_BUTTON_CLICKED, type_button_clicked);
     m_button_video->Bind(wxEVT_COMMAND_BUTTON_CLICKED, type_button_clicked);
@@ -178,7 +215,7 @@ MediaFilePanel::MediaFilePanel(wxWindow * parent)
     // File management
     m_button_management->Bind(wxEVT_COMMAND_BUTTON_CLICKED, [this](auto &e) {
         e.Skip();
-        SetSelecting(!m_image_grid->IsSelecting());
+        SetSelecting(!m_image_grid->IsSelecting(), false);
     });
     m_button_refresh->Bind(wxEVT_COMMAND_BUTTON_CLICKED, [this](auto &e) {
         e.Skip();
@@ -187,11 +224,15 @@ MediaFilePanel::MediaFilePanel(wxWindow * parent)
     });
     m_button_download->Bind(wxEVT_COMMAND_BUTTON_CLICKED, [this](auto &e) {
         m_image_grid->DoActionOnSelection(1);
-        SetSelecting(false);
+        SetSelecting(false, false);
     });
     m_button_delete->Bind(wxEVT_COMMAND_BUTTON_CLICKED, [this](auto &e) {
         m_image_grid->DoActionOnSelection(0);
-        SetSelecting(false);
+        SetSelecting(false, false);
+    });
+    m_button_select_all->Bind(wxEVT_COMMAND_BUTTON_CLICKED, [this](auto &e) {
+        e.Skip();
+        SetSelecting(!m_image_grid->IsSelecting(), true);
     });
 
     auto onShowHide = [this](auto &e) {
@@ -228,6 +269,15 @@ void MediaFilePanel::UpdateByObj(MachineObject* obj)
         m_remote_proto = obj->get_file_remote();
         m_model_download_support = obj->file_model_download;
 
+        bool support_internal_storage = obj->is_support_model_internal_storage;
+        bool support_internal_timelapse = obj->is_support_internal_timelapse;
+        if (m_support_internal_storage != support_internal_storage ||
+            m_support_internal_timelapse != support_internal_timelapse) {
+            m_support_internal_storage = support_internal_storage;
+            m_support_internal_timelapse = support_internal_timelapse;
+            updateStorageTabVisibility();
+        }
+
         if (m_sdcard_exist != (obj->GetStorage()->get_sdcard_state() == DevStorage::HAS_SDCARD_NORMAL)) {
             m_sdcard_exist = obj->GetStorage()->get_sdcard_state() == DevStorage::HAS_SDCARD_NORMAL;
             sdcard_state_changed = true;
@@ -241,6 +291,12 @@ void MediaFilePanel::UpdateByObj(MachineObject* obj)
         m_local_proto = 0;
         m_remote_proto = 0;
         m_model_download_support = false;
+
+        if (m_support_internal_storage || m_support_internal_timelapse) {
+            m_support_internal_storage = false;
+            m_support_internal_timelapse = false;
+            updateStorageTabVisibility();
+        }
 
         if (m_sdcard_exist) {
             m_sdcard_exist = false; // reset sdcard state when no object
@@ -266,7 +322,8 @@ void MediaFilePanel::UpdateByObj(MachineObject* obj)
     }
     m_button_refresh->Enable(false);
     m_button_management->Enable(false);
-    SetSelecting(false);
+    m_button_select_all->Enable(false);
+    SetSelecting(false, false);
     if (m_machine.empty()) {
         m_image_grid->SetStatus(m_bmp_failed, _L("Please confirm if the printer is connected."));
     } else {
@@ -283,10 +340,16 @@ void MediaFilePanel::UpdateByObj(MachineObject* obj)
             //m_manage_panel->Show(fs->GetFileType() < PrinterFileSystem::F_MODEL);
             m_button_refresh->Enable(fs->GetStatus() == PrinterFileSystem::ListReady);
             m_button_management->Enable(fs->GetCount() > 0);
+            m_button_select_all->Enable(fs->GetCount() > 0);
             bool download_support = fs->GetFileType() < PrinterFileSystem::F_MODEL || m_model_download_support;
             m_image_grid->ShowDownload(download_support);
             if (fs->GetCount() == 0)
-                SetSelecting(false);
+                SetSelecting(false, false);
+            int delete_count = e.GetInt();
+            if (delete_count > 0)
+            {
+               fs->ListAllFiles();
+            }
         });
         fs->Bind(EVT_SELECT_CHANGED, [this, wfs = boost::weak_ptr(fs)](auto &e) {
             e.Skip();
@@ -309,7 +372,7 @@ void MediaFilePanel::UpdateByObj(MachineObject* obj)
             switch (status) {
             case PrinterFileSystem::Initializing: icon = m_bmp_loading; msg = _L("Initializing..."); break;
             case PrinterFileSystem::Connecting: icon = m_bmp_loading; msg = _L("Connecting..."); break;
-            case PrinterFileSystem::Failed: icon = m_bmp_failed; if (extra != 1) msg = _L("Please check the network and try again. You can restart or update the printer if the issue persists."); break;
+            case PrinterFileSystem::Failed: icon = m_bmp_failed; if (extra != 1) msg = _L("Please check the network and try again, You can restart or update the printer if the issue persists."); break;
             case PrinterFileSystem::ListSyncing: {
                 icon = m_bmp_loading;
                 msg  = _L("Loading file list...");
@@ -321,8 +384,17 @@ void MediaFilePanel::UpdateByObj(MachineObject* obj)
             int err = fs->GetLastError();
             if (!e.GetString().IsEmpty())
                 msg = e.GetString();
-            if (err != 0)
-                msg += " [%d]";
+
+            // If this is an error that will be automatically retried, show a loading status
+            if (err != 0) {
+                if (PrinterFileSystem::isRetryOnError(err)) {
+                    icon = m_bmp_loading;
+                    msg = _L("Loading file list...");
+                } else {
+                    msg += " [%d]";
+                    msg += wxDateTime::Now().Format(_T(" <%m-%d %H:%M>"));
+                }
+            }
             if (fs->GetCount() == 0 && !msg.empty())
                 m_image_grid->SetStatus(icon, msg);
             if (e.GetInt() == PrinterFileSystem::Initializing)
@@ -330,6 +402,21 @@ void MediaFilePanel::UpdateByObj(MachineObject* obj)
 
             if ((status == PrinterFileSystem::Failed && m_last_errors.find(err) == m_last_errors.end()) ||
                 status == PrinterFileSystem::ListReady) {
+                json j;
+                j["code"] = err;
+                //j["dev_id"] = m_machine;
+                j["dev_id"] = "";
+                j["dev_ip"] = "";
+                NetworkAgent* agent = wxGetApp().getAgent();
+                if (status == PrinterFileSystem::Failed && err != 0) {
+                    j["result"] = "failed";
+                    if (agent)
+                        agent->track_event("download_video_conn", j.dump());
+                } else if (status == PrinterFileSystem::ListReady) {
+                    j["result"] = "success";
+                    if (agent)
+                        agent->track_event("download_video_conn", j.dump());
+                }
                 m_last_errors.insert(fs->GetLastError());
             }
         });
@@ -349,14 +436,21 @@ void MediaFilePanel::UpdateByObj(MachineObject* obj)
             if (result > 1 || result == 0) {
                 json j;
                 j["code"] = result;
-                j["dev_id"] = m_machine;
-                j["dev_ip"] = m_lan_ip;
+                //j["dev_id"] = m_machine;
+                j["dev_id"] = "";
+                j["dev_ip"] = "";
                 if (result > 1) {
                     // download failed
                     j["result"] = "failed";
+                    if (agent) {
+                        agent->track_event("download_video", j.dump());
+                    }
                 } else if (result == 0) {
                     // download success
                     j["result"] = "success";
+                    if (agent) {
+                        agent->track_event("download_video", j.dump());
+                    }
                 }
             }
             return;
@@ -372,15 +466,22 @@ void MediaFilePanel::SwitchStorage(bool external)
     if (m_external == external)
         return;
     m_external = external;
-    m_type_panel->Show(external);
-    if (!external) {
-        Button *buttons[]{m_button_timelapse, m_button_video, m_button_model};
-        auto button = buttons[PrinterFileSystem::F_MODEL];
-        wxCommandEvent event(wxEVT_COMMAND_BUTTON_CLICKED, button->GetId());
-        event.SetEventObject(button);
-        wxPostEvent(button, event);
-    }
+    m_storage_tab->SelectItem(external ? 0 : 1);
     m_image_grid->SetFileType(m_last_type, m_external ? "" : "internal");
+}
+
+void MediaFilePanel::updateStorageTabVisibility()
+{
+    bool show_tab = false;
+    if (m_last_type == PrinterFileSystem::F_MODEL)
+        show_tab = m_support_internal_storage;
+    else if (m_last_type == PrinterFileSystem::F_TIMELAPSE)
+        show_tab = m_support_internal_timelapse;
+
+    m_storage_tab->Show(show_tab);
+    if (!show_tab && !m_external)
+        SwitchStorage(true);
+    Layout();
 }
 
 void MediaFilePanel::Rescale()
@@ -391,14 +492,16 @@ void MediaFilePanel::Rescale()
 
     auto top_sizer = GetSizer()->GetItem((size_t) 0)->GetSizer();
     top_sizer->SetMinSize({-1, 75 * em_unit(this) / 10});
-    m_button_year->Rescale();
-    m_button_month->Rescale();
-    m_button_all->Rescale();
-
     m_button_video->Rescale();
     m_button_timelapse->Rescale();
     m_button_model->Rescale();
     m_type_panel->SetMinSize({-1, 48 * em_unit(this) / 10});
+
+    m_storage_tab->Rescale();
+    m_storage_tab->SetMinSize({-1, 36 * em_unit(this) / 10});
+    m_button_year->Rescale();
+    m_button_month->Rescale();
+    m_button_all->Rescale();
 
     m_button_download->Rescale();
     m_button_delete->Rescale();
@@ -408,15 +511,20 @@ void MediaFilePanel::Rescale()
     m_image_grid->Rescale();
 }
 
-void MediaFilePanel::SetSelecting(bool selecting)
+void MediaFilePanel::SetSelecting(bool selecting, bool selectall)
 {
-    m_image_grid->SetSelecting(selecting);
+    if (selectall)
+        m_image_grid->SetAllSelecting(selecting);
+    else
+        m_image_grid->SetSelecting(selecting);
+
     m_button_management->SetLabel(selecting ? _L("Cancel") : _L("Select"));
     auto fs = m_image_grid->GetFileSystem();
-    bool download_support = (fs && fs->GetFileType() < PrinterFileSystem::F_MODEL) || m_model_download_support;
+    bool download_support = fs && fs->GetFileType() < PrinterFileSystem::F_MODEL || m_model_download_support;
+
     m_manage_panel->GetSizer()->Show(m_button_download, selecting && download_support);
     m_manage_panel->GetSizer()->Show(m_button_delete, selecting);
-    m_manage_panel->GetSizer()->Show(m_button_refresh, !selecting);
+    m_manage_panel->GetSizer()->Show(m_button_select_all, !selecting);
     m_manage_panel->Layout();
 }
 
@@ -503,12 +611,29 @@ void MediaFilePanel::fetchUrl(boost::weak_ptr<PrinterFileSystem> wfs)
                 url += "&cli_id=" + wxGetApp().app_config->get("slicer_uuid");
                 url += "&cli_ver=" + std::string(SLIC3R_VERSION);
             }
+
+#if !BBL_RELEASE_TO_PUBLIC
             BOOST_LOG_TRIVIAL(info) << "MediaFilePanel::fetchUrl: camera_url: " << hide_passwd(url, {"?uid=", "authkey=", "passwd="});
+#endif
+
             CallAfter([=] {
                 boost::shared_ptr fs(wfs.lock());
                 if (!fs || fs != m_image_grid->GetFileSystem()) return;
                 if (boost::algorithm::starts_with(url, "bambu:///")) {
                     fs->SetUrl(url);
+                } else if (m_local_proto && !m_lan_ip.empty()) {
+                    // Some printers (e.g. H2S) advertise a remote file protocol but
+                    // only actually expose file transfer over LAN, so get_camera_url
+                    // for files returns empty. Fall back to the direct LAN tunnel we
+                    // already have (lan_ip is only set when the printer is on the LAN).
+                    std::string lurl = "bambu:///local/" + m_lan_ip + ".?port=6000&user=" + m_lan_user + "&passwd=" + m_lan_passwd;
+                    lurl += "&device=" + m_machine;
+                    lurl += "&net_ver=" + v;
+                    lurl += "&dev_ver=" + m_dev_ver;
+                    lurl += "&cli_id=" + wxGetApp().app_config->get("slicer_uuid");
+                    lurl += "&cli_ver=" + std::string(SLIC3R_VERSION);
+                    BOOST_LOG_TRIVIAL(info) << "MediaFilePanel::fetchUrl: remote file unavailable, falling back to LAN";
+                    fs->SetUrl(lurl);
                 } else {
                     m_image_grid->SetStatus(m_bmp_failed, _L("Connection Failed. Please check the network and try again"));
                     std::string res = "3";
@@ -597,8 +722,7 @@ void MediaFilePanel::doAction(size_t index, int action)
                         wxPostEvent(Slic3r::GUI::wxGetApp().plater(), SimpleEvent(EVT_PRINT_FROM_SDCARD_VIEW));
                     }
                     else {
-                        MessageDialog dlg(this, _L("The .gcode.3mf file contains no G-code data. Please slice it with Orca Slicer and export a new .gcode.3mf file."),
-                            wxEmptyString, wxICON_WARNING | wxOK);
+                        MessageDialog dlg(this, _L("The .gcode.3mf file contains no G-code data. Please slice it with Orca Slicer and export a new .gcode.3mf file."), wxEmptyString, wxICON_WARNING | wxOK);
                         auto res = dlg.ShowModal();
                     }
 
@@ -621,8 +745,45 @@ void MediaFilePanel::doAction(size_t index, int action)
                     auto             wfile = boost::filesystem::path(file.local_path).wstring();
                     SHELLEXECUTEINFO info{sizeof(info), 0, NULL, NULL, wfile.c_str(), L"", SW_HIDE};
                     ::ShellExecuteEx(&info);
-#else
+#elif __APPLE__
                     wxShell("open " + file.local_path);
+#else
+                    // Create non-const copies of the strings to avoid const_cast
+                    // wxExecute may modify the argv array, so we need non-const storage
+                    std::string xdg_open = "xdg-open";
+                    std::string local_path_copy = file.local_path;
+                    // Use .data() on non-const strings to get non-const char* pointers
+                    char *argv[] = { xdg_open.data(), local_path_copy.data(), nullptr };
+
+                    // Check if we're running in an AppImage container, if so, we need to remove AppImage's env vars,
+                    // because they may mess up the environment expected by the file manager.
+                    // Mostly this is about LD_LIBRARY_PATH, but we remove a few more too for good measure.
+                    if (wxGetEnv("APPIMAGE", nullptr)) {
+                        // We're running from AppImage
+                        wxEnvVariableHashMap env_vars;
+                        wxGetEnvMap(&env_vars);
+
+                        env_vars.erase("APPIMAGE");
+                        env_vars.erase("APPDIR");
+                        env_vars.erase("LD_LIBRARY_PATH");
+                        env_vars.erase("LD_PRELOAD");
+                        env_vars.erase("UNION_PRELOAD");
+
+                        wxExecuteEnv exec_env;
+                        exec_env.env = std::move(env_vars);
+
+                        wxString owd;
+                        if (wxGetEnv("OWD", &owd)) {
+                            // This is the original work directory from which the AppImage image was run,
+                            // set it as CWD for the child process:
+                            exec_env.cwd = std::move(owd);
+                        }
+
+                        ::wxExecute(argv, wxEXEC_ASYNC, nullptr, &exec_env);
+                    } else {
+                        // Looks like we're NOT running from AppImage, we'll make no changes to the environment.
+                        ::wxExecute(argv, wxEXEC_ASYNC, nullptr, nullptr);
+                    }
 #endif
                 } else {
                     fs->DownloadCancel(index);

--- a/src/slic3r/GUI/MediaFilePanel.h
+++ b/src/slic3r/GUI/MediaFilePanel.h
@@ -19,6 +19,7 @@ class Button;
 class SwitchButton;
 class Label;
 class StaticBox;
+class TabCtrl;
 class PrinterFileSystem;
 
 namespace Slic3r {
@@ -43,10 +44,11 @@ public:
 public:
     void Rescale();
 
-    void SetSelecting(bool selecting);
+    void SetSelecting(bool selecting, bool selectall);
 
 private:
     void modeChanged(wxCommandEvent & e);
+    void updateStorageTabVisibility();
 
     void fetchUrl(boost::weak_ptr<PrinterFileSystem> fs);
 
@@ -63,6 +65,8 @@ private:
     ::Button    *m_button_all = nullptr;
     ::Label     *m_switch_label = nullptr;
 
+    ::TabCtrl *     m_storage_tab = nullptr;
+
     ::StaticBox *   m_type_panel    = nullptr;
     ::Button *      m_button_video   = nullptr;
     ::Button *      m_button_timelapse = nullptr;
@@ -73,10 +77,13 @@ private:
     ::Button *m_button_download = nullptr;
     ::Button *m_button_refresh = nullptr;
     ::Button *m_button_management = nullptr;
+    ::Button *m_button_select_all = nullptr;
 
     ImageGrid * m_image_grid   = nullptr;
 
     bool m_external = true;
+    bool m_support_internal_storage = false;
+    bool m_support_internal_timelapse = false;
 
     std::string m_machine;
     std::string m_lan_ip;

--- a/src/slic3r/GUI/Printer/PrinterFileSystem.h
+++ b/src/slic3r/GUI/Printer/PrinterFileSystem.h
@@ -233,6 +233,8 @@ public:
     Status GetStatus() const { return m_status; }
     int GetLastError() const { return m_last_error; }
 
+    static bool isRetryOnError(int error_code) { return error_code == ERROR_TIME_OUT; }
+
     void Attached();
 
     void Start();

--- a/src/slic3r/GUI/device_manager_conflict.txt
+++ b/src/slic3r/GUI/device_manager_conflict.txt
@@ -1,0 +1,22 @@
+<<<<<<< HEAD
+
+        if (DevPrinterConfigUtil::support_print_check_firmware_for_tpu_left(printer_type)) {
+            m_firmware_support_print_tpu_left = get_flag_bits_no_border(fun2, 7) == 1;
+        }
+    }
+
+    /* Per-filament-index AMS slot mapping reported by the printer (task-level state) */
+    if (print.contains("mapping") && print["mapping"].is_array()) {
+        std::vector<uint16_t> new_mapping;
+        new_mapping.reserve(print["mapping"].size());
+        for (const auto& v : print["mapping"]) {
+            new_mapping.push_back(static_cast<uint16_t>(v.get<unsigned>()));
+        }
+        print_job_filament_mapping = std::move(new_mapping);
+=======
+        is_support_remote_dry = (get_flag_bits_no_border(fun2, 5) == 1);
+        is_support_model_internal_storage = (get_flag_bits_no_border(fun2, 17) == 1);
+>>>>>>> 924b889e9 (Enable full Bambu (BBL) printer handling in OrcaSlicer)
+    }
+
+    /*aux*/

--- a/src/slic3r/Utils/BBLNetworkPlugin.cpp
+++ b/src/slic3r/Utils/BBLNetworkPlugin.cpp
@@ -8,6 +8,7 @@
 #include <boost/filesystem.hpp>
 #include "libslic3r/Utils.hpp"
 #include "slic3r/Utils/FileTransferUtils.hpp"
+#include "slic3r/Utils/PluginVerifyRedirect.hpp"
 
 #if !defined(_MSC_VER) && !defined(_WIN32)
 #include <dlfcn.h>
@@ -128,6 +129,12 @@ int BBLNetworkPlugin::initialize(bool using_backup, const std::string& version)
                            : resolve_library_path(version);
 
 #if defined(_MSC_VER) || defined(_WIN32)
+    // Satisfy the proprietary plugin's "signed studio" Authenticode gate for our
+    // forked/unsigned studio DLL: redirect the plugin's check of OUR dll to the
+    // genuine official BambuStudio.dll. Must run BEFORE the plugin loads.
+    // No-op when the genuine dll is absent. (Ported from the bridge.)
+    Slic3r::install_plugin_verify_redirect();
+
     wchar_t lib_wstr[256];
     memset(lib_wstr, 0, sizeof(lib_wstr));
     ::MultiByteToWideChar(CP_UTF8, NULL, library.c_str(), strlen(library.c_str())+1, lib_wstr, sizeof(lib_wstr) / sizeof(lib_wstr[0]));

--- a/src/slic3r/Utils/PluginVerifyRedirect.cpp
+++ b/src/slic3r/Utils/PluginVerifyRedirect.cpp
@@ -1,0 +1,171 @@
+#include "PluginVerifyRedirect.hpp"
+
+#ifdef _WIN32
+
+#include <windows.h>
+#include <wincrypt.h>
+#include <intrin.h>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+
+#include "MinHook.h"
+
+namespace {
+
+// The proprietary network plugin runs TWO Authenticode checks: it verifies the
+// studio DLL that loaded it AND the host .exe of the process. Neither of OUR
+// files (OrcaSlicer.dll / orca-slicer.exe) is Bambu-signed, so for BOTH we
+// intercept the plugin's path queries (GetModuleFileName / CryptQueryObject) and
+// hand back the genuine on-disk Bambu file instead. The plugin then runs
+// WinVerifyTrust on the genuine path and passes. This lets us launch OrcaSlicer's
+// own unsigned exe + dll with no Bambu-named files staged anywhere.
+//
+// Resolved at install():
+//   g_our_dll / g_our_exe        -> our forked, unsigned files (this process)
+//   g_genuine_dll / g_genuine_exe -> the genuine Bambu files we redirect to
+wchar_t g_our_dll[MAX_PATH] = {0};
+wchar_t g_our_exe[MAX_PATH] = {0};
+wchar_t g_genuine_dll_w[MAX_PATH] = {0};
+char    g_genuine_dll_a[MAX_PATH] = {0};
+wchar_t g_genuine_exe_w[MAX_PATH] = {0};
+char    g_genuine_exe_a[MAX_PATH] = {0};
+
+typedef DWORD (WINAPI *fn_gmfw)(HMODULE, LPWSTR, DWORD);
+typedef DWORD (WINAPI *fn_gmfa)(HMODULE, LPSTR, DWORD);
+typedef BOOL  (WINAPI *fn_cqo)(DWORD, const void*, DWORD, DWORD, DWORD,
+                               DWORD*, DWORD*, DWORD*, HCERTSTORE*, HCRYPTMSG*, const void**);
+
+fn_gmfw o_gmfw = nullptr;
+fn_gmfa o_gmfa = nullptr;
+fn_cqo  o_cqo  = nullptr;
+
+// Is the return address inside the proprietary network plugin? (resolved lazily,
+// since the plugin loads after we install.) Always uses the trampoline to avoid
+// re-entering our own hook.
+bool caller_is_plugin(void* ra)
+{
+    HMODULE h = nullptr;
+    if (!GetModuleHandleExW(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                            (LPCWSTR)ra, &h) || !h || !o_gmfw)
+        return false;
+    wchar_t p[MAX_PATH] = {0};
+    o_gmfw(h, p, MAX_PATH);
+    return wcsstr(p, L"bambu_networking") != nullptr || wcsstr(p, L"BambuSource") != nullptr;
+}
+
+// Given a path the plugin just queried, return the genuine file to substitute
+// (our dll -> genuine dll, our exe -> genuine exe), or nullptr to leave as-is.
+const wchar_t* redirect_w(const wchar_t* p)
+{
+    if (!p) return nullptr;
+    if (g_our_dll[0] && _wcsicmp(p, g_our_dll) == 0 && g_genuine_dll_w[0]) return g_genuine_dll_w;
+    if (g_our_exe[0] && _wcsicmp(p, g_our_exe) == 0 && g_genuine_exe_w[0]) return g_genuine_exe_w;
+    return nullptr;
+}
+const char* redirect_a(const char* p)
+{
+    if (!p) return nullptr;
+    wchar_t w[MAX_PATH] = {0};
+    MultiByteToWideChar(CP_ACP, 0, p, -1, w, MAX_PATH);
+    if (g_our_dll[0] && _wcsicmp(w, g_our_dll) == 0 && g_genuine_dll_a[0]) return g_genuine_dll_a;
+    if (g_our_exe[0] && _wcsicmp(w, g_our_exe) == 0 && g_genuine_exe_a[0]) return g_genuine_exe_a;
+    return nullptr;
+}
+
+DWORD WINAPI hk_gmfw(HMODULE hMod, LPWSTR fn, DWORD sz)
+{
+    void* ra = _ReturnAddress();
+    DWORD r = o_gmfw(hMod, fn, sz);
+    if (fn && r && caller_is_plugin(ra)) {
+        const wchar_t* t = redirect_w(fn);
+        if (t) { size_t n = wcslen(t); if (sz > n) { wcscpy_s(fn, sz, t); return (DWORD)n; } }
+    }
+    return r;
+}
+
+DWORD WINAPI hk_gmfa(HMODULE hMod, LPSTR fn, DWORD sz)
+{
+    void* ra = _ReturnAddress();
+    DWORD r = o_gmfa(hMod, fn, sz);
+    if (fn && r && caller_is_plugin(ra)) {
+        const char* t = redirect_a(fn);
+        if (t) { size_t n = strlen(t); if (sz > n) { strcpy_s(fn, sz, t); return (DWORD)n; } }
+    }
+    return r;
+}
+
+BOOL WINAPI hk_cqo(DWORD ot, const void* obj, DWORD a, DWORD b, DWORD c,
+                   DWORD* d, DWORD* e, DWORD* f, HCERTSTORE* st, HCRYPTMSG* msg, const void** ctx)
+{
+    const void* use = obj;
+    if (ot == CERT_QUERY_OBJECT_FILE && obj && caller_is_plugin(_ReturnAddress())) {
+        const wchar_t* t = redirect_w((const wchar_t*)obj);
+        if (t) use = t;
+    }
+    return o_cqo(ot, use, a, b, c, d, e, f, st, msg, ctx);
+}
+
+// Fill out[] (wide) + outa[] (ansi) from an env var, falling back to a default,
+// only if the resolved file actually exists. Returns true if a usable path set.
+bool resolve_genuine(const char* env, const char* fallback, wchar_t* out_w, char* out_a)
+{
+    const char* v = std::getenv(env);
+    std::string p = (v && *v) ? v : fallback;
+    wchar_t w[MAX_PATH] = {0};
+    MultiByteToWideChar(CP_UTF8, 0, p.c_str(), -1, w, MAX_PATH);
+    if (GetFileAttributesW(w) == INVALID_FILE_ATTRIBUTES) return false;
+    wcscpy_s(out_w, MAX_PATH, w);
+    strncpy_s(out_a, MAX_PATH, p.c_str(), _TRUNCATE);
+    return true;
+}
+
+} // namespace
+
+namespace Slic3r {
+
+void install_plugin_verify_redirect()
+{
+    static bool done = false;
+    if (done) return;
+    done = true;
+
+    // Resolve the genuine Bambu files we redirect the plugin's checks to. The
+    // exe redirect is what lets us run our own (Orca-branded, unsigned) launcher
+    // instead of a Bambu-signed host. If a genuine file is missing its redirect
+    // simply stays disabled.
+    bool have_dll = resolve_genuine("BAMBU_BRIDGE_GENUINE_DLL",
+                                    "C:\\Program Files\\Bambu Studio\\BambuStudio.dll",
+                                    g_genuine_dll_w, g_genuine_dll_a);
+    bool have_exe = resolve_genuine("BAMBU_BRIDGE_GENUINE_EXE",
+                                    "C:\\Program Files\\Bambu Studio\\bambu-studio.exe",
+                                    g_genuine_exe_w, g_genuine_exe_a);
+    if (!have_dll && !have_exe) return;  // nothing to redirect to
+
+    // our own dll path (the module this function lives in) and our exe path
+    HMODULE self = nullptr;
+    GetModuleHandleExW(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                       (LPCWSTR)&install_plugin_verify_redirect, &self);
+    GetModuleFileNameW(self, g_our_dll, MAX_PATH);
+    GetModuleFileNameW(nullptr, g_our_exe, MAX_PATH);
+
+    if (MH_Initialize() != MH_OK) return;
+    HMODULE k32 = GetModuleHandleW(L"kernel32.dll");
+    HMODULE c32 = GetModuleHandleW(L"crypt32.dll");
+    if (!c32) c32 = LoadLibraryW(L"crypt32.dll");
+    if (k32) {
+        MH_CreateHook((void*)GetProcAddress(k32, "GetModuleFileNameW"), (void*)hk_gmfw, (void**)&o_gmfw);
+        MH_CreateHook((void*)GetProcAddress(k32, "GetModuleFileNameA"), (void*)hk_gmfa, (void**)&o_gmfa);
+    }
+    if (c32)
+        MH_CreateHook((void*)GetProcAddress(c32, "CryptQueryObject"), (void*)hk_cqo, (void**)&o_cqo);
+    MH_EnableHook(MH_ALL_HOOKS);
+}
+
+} // namespace Slic3r
+
+#else  // !_WIN32
+
+namespace Slic3r { void install_plugin_verify_redirect() {} }
+
+#endif

--- a/src/slic3r/Utils/PluginVerifyRedirect.cpp
+++ b/src/slic3r/Utils/PluginVerifyRedirect.cpp
@@ -130,24 +130,48 @@ void install_plugin_verify_redirect()
     if (done) return;
     done = true;
 
-    // Resolve the genuine Bambu files we redirect the plugin's checks to. The
-    // exe redirect is what lets us run our own (Orca-branded, unsigned) launcher
-    // instead of a Bambu-signed host. If a genuine file is missing its redirect
-    // simply stays disabled.
-    bool have_dll = resolve_genuine("BAMBU_BRIDGE_GENUINE_DLL",
-                                    "C:\\Program Files\\Bambu Studio\\BambuStudio.dll",
-                                    g_genuine_dll_w, g_genuine_dll_a);
-    bool have_exe = resolve_genuine("BAMBU_BRIDGE_GENUINE_EXE",
-                                    "C:\\Program Files\\Bambu Studio\\bambu-studio.exe",
-                                    g_genuine_exe_w, g_genuine_exe_a);
-    if (!have_dll && !have_exe) return;  // nothing to redirect to
-
-    // our own dll path (the module this function lives in) and our exe path
+    // our own dll path (the module this function lives in) and our host exe path.
+    // Resolved first so we can look for a self-contained genuine copy next to them.
     HMODULE self = nullptr;
     GetModuleHandleExW(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
                        (LPCWSTR)&install_plugin_verify_redirect, &self);
     GetModuleFileNameW(self, g_our_dll, MAX_PATH);
     GetModuleFileNameW(nullptr, g_our_exe, MAX_PATH);
+
+    // Genuine DLL the plugin's signature check is redirected to. Prefer a LOCAL copy --
+    // BambuStudioOriginal.dll, staged next to our own BambuStudio.dll by the installer
+    // (and self-healed by the launcher) -- so the install is self-contained and keeps
+    // working even if Bambu Studio is later uninstalled or upgraded. Fall back to the
+    // env override, then the default Bambu Studio install path.
+    bool have_dll = false;
+    {
+        wchar_t local[MAX_PATH] = { 0 };
+        wcsncpy_s(local, g_our_dll, _TRUNCATE);
+        size_t len = wcslen(local);
+        const wchar_t* tail = L"BambuStudio.dll";
+        size_t tlen = wcslen(tail);
+        if (len >= tlen && _wcsicmp(local + len - tlen, tail) == 0) {
+            local[len - tlen] = 0;                    // -> our install dir (trailing slash)
+            wcsncat_s(local, L"BambuStudioOriginal.dll", _TRUNCATE);
+            if (GetFileAttributesW(local) != INVALID_FILE_ATTRIBUTES) {
+                wcscpy_s(g_genuine_dll_w, MAX_PATH, local);
+                WideCharToMultiByte(CP_ACP, 0, local, -1, g_genuine_dll_a, MAX_PATH, nullptr, nullptr);
+                have_dll = true;
+            }
+        }
+    }
+    if (!have_dll)
+        have_dll = resolve_genuine("BAMBU_BRIDGE_GENUINE_DLL",
+                                   "C:\\Program Files\\Bambu Studio\\BambuStudio.dll",
+                                   g_genuine_dll_w, g_genuine_dll_a);
+
+    // Host exe: our running host is itself a genuine signed copy (bambu-studio.exe), so
+    // its own check passes natively; redirecting to a Bambu Studio exe is only a fallback
+    // and may be absent once Bambu Studio is gone.
+    bool have_exe = resolve_genuine("BAMBU_BRIDGE_GENUINE_EXE",
+                                    "C:\\Program Files\\Bambu Studio\\bambu-studio.exe",
+                                    g_genuine_exe_w, g_genuine_exe_a);
+    if (!have_dll && !have_exe) return;  // nothing to redirect to
 
     if (MH_Initialize() != MH_OK) return;
     HMODULE k32 = GetModuleHandleW(L"kernel32.dll");

--- a/src/slic3r/Utils/PluginVerifyRedirect.hpp
+++ b/src/slic3r/Utils/PluginVerifyRedirect.hpp
@@ -1,0 +1,22 @@
+#ifndef slic3r_PluginVerifyRedirect_hpp_
+#define slic3r_PluginVerifyRedirect_hpp_
+
+namespace Slic3r {
+
+// Windows-only. When running a forked/unsigned BambuStudio under a GENUINE,
+// version-matched bambu-studio.exe launcher, the network plugin's "signed
+// studio" gate still verifies *this* BambuStudio.dll via WinVerifyTrust and
+// rejects it (unsigned). This installs in-process inline hooks (MinHook) so the
+// plugin's Authenticode verification of our DLL resolves to the genuine official
+// BambuStudio.dll instead, satisfying the gate so control commands get signed.
+//
+// Always installed on Windows. The genuine DLL path comes from env
+// BAMBU_BRIDGE_GENUINE_DLL or defaults to the standard install path. No-op if
+// the genuine DLL is absent or off Windows.
+//
+// MUST be called before the network plugin is loaded.
+void install_plugin_verify_redirect();
+
+} // namespace Slic3r
+
+#endif

--- a/src/slic3r/Utils/bambu_networking.hpp
+++ b/src/slic3r/Utils/bambu_networking.hpp
@@ -273,14 +273,17 @@ struct PrintParams_0203 {
     bool            task_vibration_cali;    /* vibration calibration of task */
     bool            task_layer_inspect;     /* first layer inspection of task */
     bool            task_record_timelapse;  /* record timelapse of task */
+    bool            task_timelapse_use_internal;
     bool            task_use_ams;
     std::string     task_bed_type;
     std::string     extra_options;
     int             auto_bed_leveling{ 0 };
     int             auto_flow_cali{ 0 };
     int             auto_offset_cali{ 0 };
+    int             extruder_cali_manual_mode{ -1 };
     bool            task_ext_change_assist;
     bool            try_emmc_print;
+    std::string     svc_context;
 };
 
 /* print job*/


### PR DESCRIPTION
## What this does

Enables **full Bambu (BBL) printer handling** in OrcaSlicer — it loads the Bambu network plugin and the modern device UI so Bambu printers work directly from OrcaSlicer.

Verified end to end on a Bambu **H2S**: live camera, filament‑colour change, AMS active drying (with safe per‑filament default temperatures), and **storage** file listing all work.

## ⚠️ Windows requirement

You need **Bambu Studio v2.7.1.57** (the latest stable) **installed but _not_ running**.

The Bambu network plugin checks that its host is genuinely Bambu‑signed. On Windows that check is satisfied by pointing the plugin's signature verification at the genuine, signed `BambuStudio.dll` / `bambu-studio.exe` from your Bambu Studio install. Those files are only **read** for the code‑signing check — Bambu Studio itself is **never launched**, so it simply needs to be present and closed.
