### PR TITLE
fix: tombstone resolution for 409 status code with error code -3

### DIFF
--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -4940,6 +4940,7 @@ void GUI_App::on_http_error(wxCommandEvent &evt)
         // Parse the conflict body to extract the error code and server profile id
         int conflict_code = 0;
         std::string conflict_setting_id;
+        std::string conflict_preset_name;
         try {
             json conflict_body = json::parse(body_str);
             if (conflict_body.contains("code"))
@@ -4947,9 +4948,15 @@ void GUI_App::on_http_error(wxCommandEvent &evt)
             if (conflict_body.contains("server_profile") && conflict_body["server_profile"].contains("id")
                 && conflict_body["server_profile"]["id"].is_string())
                 conflict_setting_id = conflict_body["server_profile"]["id"].get<std::string>();
+            // The local preset name is injected into the conflict body by the agent (sync_push),
+            // since the server response itself omits it for tombstone (-3) conflicts.
+            if (conflict_body.contains("name") && conflict_body["name"].is_string())
+                conflict_preset_name = conflict_body["name"].get<std::string>();
         } catch (...) {
             BOOST_LOG_TRIVIAL(warning) << "Failed to parse 409 conflict body.";
         }
+        // Capture the user id up front so the force-push closure does not have to touch m_agent.
+        std::string conflict_user_id = m_agent ? m_agent->get_user_id() : std::string();
         auto* plater = wxGetApp().plater();
         if (plater != nullptr && wxGetApp().imgui()->display_initialized()) {
             std::string text;
@@ -4984,7 +4991,7 @@ void GUI_App::on_http_error(wxCommandEvent &evt)
                     restart_sync_user_preset();
                     return true;
                 },
-                [this, conflict_setting_id](wxEvtHandler*) {
+                [this, conflict_setting_id, conflict_preset_name, conflict_user_id](wxEvtHandler*) {
                     if (mainframe == nullptr)
                         return false;
                     MessageDialog
@@ -4994,7 +5001,13 @@ void GUI_App::on_http_error(wxCommandEvent &evt)
                     if (dlg.ShowModal() != wxID_YES)
                         return false;
 
-                    force_push_conflicting_preset(conflict_setting_id);
+                    std::string setting_id = conflict_setting_id;
+                    if (setting_id.empty()) {
+                        setting_id = OrcaCloudServiceAgent::generate_uuid_for_setting_id(conflict_preset_name, conflict_user_id);
+                        BOOST_LOG_TRIVIAL(info) << "conflict setting id empty, generated one: " << setting_id;
+                    }
+
+                    force_push_conflicting_preset(setting_id);
                     return true;
                 });
         }

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -5007,7 +5007,7 @@ void GUI_App::on_http_error(wxCommandEvent &evt)
                         BOOST_LOG_TRIVIAL(info) << "conflict setting id empty, generated one: " << setting_id;
                     }
 
-                    force_push_conflicting_preset(setting_id);
+                    force_push_conflicting_preset(setting_id, conflict_preset_name);
                     return true;
                 });
         }
@@ -7070,7 +7070,7 @@ void GUI_App::restart_sync_user_preset()
     }).detach();
 }
 
-void GUI_App::force_push_conflicting_preset(const std::string& setting_id)
+void GUI_App::force_push_conflicting_preset(const std::string& setting_id, const std::string& preset_name)
 {
     if (setting_id.empty() || !preset_bundle)
         return;
@@ -7085,11 +7085,17 @@ void GUI_App::force_push_conflicting_preset(const std::string& setting_id)
     // "update" so the next push-sync re-includes it and consumes the queued force flag.
     // (We must NOT pull from the cloud here as the Pull path does — that would overwrite
     // the local changes the user is trying to force-push.)
+    // For a -3 tombstone on a newly created preset the on-disk setting_id is EMPTY (it only
+    // gets assigned after a successful first push), so match by name and stamp the generated
+    // setting_id onto the preset — otherwise sync_with_lock's `id == preset.setting_id` check
+    // never fires and the force-push silently no-ops.
     PresetCollection* collections[] = {&preset_bundle->prints, &preset_bundle->filaments, &preset_bundle->printers};
     for (PresetCollection* coll : collections) {
         for (const Preset& preset : coll->get_presets()) {
-            if (preset.setting_id == setting_id && preset.sync_info == "hold") {
-                coll->set_sync_info_and_save(preset.name, preset.setting_id, "update", 0);
+            const bool id_match   = !preset.setting_id.empty() && preset.setting_id == setting_id;
+            const bool name_match = preset.setting_id.empty() && !preset_name.empty() && preset.name == preset_name;
+            if ((id_match || name_match) && preset.sync_info == "hold") {
+                coll->set_sync_info_and_save(preset.name, setting_id, "update", 0);
                 break;
             }
         }

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -4953,16 +4953,25 @@ void GUI_App::on_http_error(wxCommandEvent &evt)
         auto* plater = wxGetApp().plater();
         if (plater != nullptr && wxGetApp().imgui()->display_initialized()) {
             std::string text;
-            if (conflict_code == -1) {
+
+            switch (conflict_code) {
+            case -1:
                 text = _u8L("Cloud sync conflict: this preset has a newer version in OrcaCloud.\n"
                             "Pull downloads the cloud copy. Force push overwrites it with your local preset.");
-            } else {
+                break;
+            case -2:
                 text = _u8L("Cloud sync conflict: a preset with this name already exists in OrcaCloud.\n"
                             "Pull downloads the cloud copy. Force push overwrites it with your local preset.");
-            }
+                break;
+            case -3:
+                text = _u8L("Cloud sync conflict: a preset with the same name was previously deleted from the cloud.\n"
+                            "Do you want to push this new copy to the cloud?");
+                break;
+            };
+
             plater->get_notification_manager()->push_orca_sync_conflict_notification(
                 text,
-                [this](wxEvtHandler*) {
+                conflict_code == -3 ? nullptr : std::function<bool(wxEvtHandler*)>{[this](wxEvtHandler*) {
                     // Runs on the GUI thread (on_http_error is a queued wx event); restart_sync_user_preset()
                     // already joins the old sync thread off the UI thread, so no extra thread is needed here.
                     if (is_closing() || !m_agent || !preset_bundle)
@@ -4970,7 +4979,7 @@ void GUI_App::on_http_error(wxCommandEvent &evt)
                     BOOST_LOG_TRIVIAL(info) << "Pulling Orca Cloud settings to resolve sync conflict.";
                     restart_sync_user_preset();
                     return true;
-                },
+                }},
                 [this, conflict_setting_id](wxEvtHandler*) {
                     if (mainframe == nullptr)
                         return false;

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -5007,7 +5007,7 @@ void GUI_App::on_http_error(wxCommandEvent &evt)
                         BOOST_LOG_TRIVIAL(info) << "conflict setting id empty, generated one: " << setting_id;
                     }
 
-                    force_push_conflicting_preset(setting_id, conflict_preset_name);
+                    force_push_conflicting_preset(setting_id);
                     return true;
                 });
         }
@@ -7070,7 +7070,7 @@ void GUI_App::restart_sync_user_preset()
     }).detach();
 }
 
-void GUI_App::force_push_conflicting_preset(const std::string& setting_id, const std::string& preset_name)
+void GUI_App::force_push_conflicting_preset(const std::string& setting_id)
 {
     if (setting_id.empty() || !preset_bundle)
         return;
@@ -7081,20 +7081,25 @@ void GUI_App::force_push_conflicting_preset(const std::string& setting_id, const
         m_pending_conflict_setting_ids.push_back(setting_id);
     }
 
+    const std::string user_id = m_agent ? m_agent->get_user_id() : std::string();
+
     // The 409 left this preset on "hold", which get_user_presets() skips. Restore it to
     // "update" so the next push-sync re-includes it and consumes the queued force flag.
     // (We must NOT pull from the cloud here as the Pull path does — that would overwrite
     // the local changes the user is trying to force-push.)
     // For a -3 tombstone on a newly created preset the on-disk setting_id is EMPTY (it only
-    // gets assigned after a successful first push), so match by name and stamp the generated
-    // setting_id onto the preset — otherwise sync_with_lock's `id == preset.setting_id` check
-    // never fires and the force-push silently no-ops.
+    // gets assigned after a successful first push), so derive it on the fly from the preset
+    // name and stamp it onto the preset — otherwise sync_with_lock's `id == preset.setting_id`
+    // check never fires and the force-push silently no-ops.
     PresetCollection* collections[] = {&preset_bundle->prints, &preset_bundle->filaments, &preset_bundle->printers};
     for (PresetCollection* coll : collections) {
         for (const Preset& preset : coll->get_presets()) {
-            const bool id_match   = !preset.setting_id.empty() && preset.setting_id == setting_id;
-            const bool name_match = preset.setting_id.empty() && !preset_name.empty() && preset.name == preset_name;
-            if ((id_match || name_match) && preset.sync_info == "hold") {
+            if (preset.sync_info != "hold")
+                continue;
+            const std::string preset_id = preset.setting_id.empty()
+                ? OrcaCloudServiceAgent::generate_uuid_for_setting_id(preset.name, user_id)
+                : preset.setting_id;
+            if (preset_id == setting_id) {
                 coll->set_sync_info_and_save(preset.name, setting_id, "update", 0);
                 break;
             }

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -4965,13 +4965,17 @@ void GUI_App::on_http_error(wxCommandEvent &evt)
                 break;
             case -3:
                 text = _u8L("Cloud sync conflict: a preset with the same name was previously deleted from the cloud.\n"
-                            "Do you want to push this new copy to the cloud?");
+                            "Delete will delete your local preset. Force push overwrites it with your local preset.");
+                break;
+            default:
+                text = _u8L("Cloud sync conflict: there was an unexpected or unidentified preset conflict.\n"
+                            "Pull downloads the cloud copy. Force push overwrites it with your local preset.");
                 break;
             };
 
             plater->get_notification_manager()->push_orca_sync_conflict_notification(
-                text,
-                conflict_code == -3 ? nullptr : std::function<bool(wxEvtHandler*)>{[this](wxEvtHandler*) {
+                text, conflict_code,
+                [this](wxEvtHandler*) {
                     // Runs on the GUI thread (on_http_error is a queued wx event); restart_sync_user_preset()
                     // already joins the old sync thread off the UI thread, so no extra thread is needed here.
                     if (is_closing() || !m_agent || !preset_bundle)
@@ -4979,7 +4983,7 @@ void GUI_App::on_http_error(wxCommandEvent &evt)
                     BOOST_LOG_TRIVIAL(info) << "Pulling Orca Cloud settings to resolve sync conflict.";
                     restart_sync_user_preset();
                     return true;
-                }},
+                },
                 [this, conflict_setting_id](wxEvtHandler*) {
                     if (mainframe == nullptr)
                         return false;

--- a/src/slic3r/GUI/GUI_App.hpp
+++ b/src/slic3r/GUI/GUI_App.hpp
@@ -539,7 +539,7 @@ public:
     void            restart_sync_user_preset();
     // Resolve a cloud sync 409 by force-pushing the conflicting preset: clears the "hold"
     // state the conflict left behind and queues it to be re-uploaded with force=true.
-    void            force_push_conflicting_preset(const std::string& setting_id, const std::string& preset_name);
+    void            force_push_conflicting_preset(const std::string& setting_id);
     void            on_stealth_mode_enter();
 
     // Bundle subscription sync

--- a/src/slic3r/GUI/GUI_App.hpp
+++ b/src/slic3r/GUI/GUI_App.hpp
@@ -539,7 +539,7 @@ public:
     void            restart_sync_user_preset();
     // Resolve a cloud sync 409 by force-pushing the conflicting preset: clears the "hold"
     // state the conflict left behind and queues it to be re-uploaded with force=true.
-    void            force_push_conflicting_preset(const std::string& setting_id);
+    void            force_push_conflicting_preset(const std::string& setting_id, const std::string& preset_name);
     void            on_stealth_mode_enter();
 
     // Bundle subscription sync

--- a/src/slic3r/GUI/NotificationManager.cpp
+++ b/src/slic3r/GUI/NotificationManager.cpp
@@ -2416,12 +2416,18 @@ void NotificationManager::OrcaSyncConflictNotification::render_text(ImGuiWrapper
 	}
 
 	const float action_y = starting_y + m_endlines.size() * shift_y;
-	const std::string pull_text = _u8L("Pull");
-	render_hyperlink_action(imgui, x_offset, action_y, pull_text, "##orca_sync_pull",
-		[this] { if (m_pull_callback && m_pull_callback(m_evt_handler)) close(); });
+	std::string pull_text = "";
+	float padding = 0.f;
+
+	if (m_pull_callback) {
+		pull_text = _u8L("Pull");
+		padding = ImGui::CalcTextSize((pull_text + "   ").c_str()).x;
+		render_hyperlink_action(imgui, x_offset, action_y, pull_text, "##orca_sync_pull",
+			[this] { if (m_pull_callback && m_pull_callback(m_evt_handler)) close(); });
+	}
 	if (m_force_push_callback) {
 		const std::string force_push_text = _u8L("Force push");
-		const float force_x = x_offset + ImGui::CalcTextSize((pull_text + "   ").c_str()).x;
+		const float force_x = x_offset + padding;
 		render_hyperlink_action(imgui, force_x, action_y, force_push_text, "##orca_sync_force_push",
 			[this] { if (m_force_push_callback && m_force_push_callback(m_evt_handler)) close(); });
 	}

--- a/src/slic3r/GUI/NotificationManager.cpp
+++ b/src/slic3r/GUI/NotificationManager.cpp
@@ -2416,18 +2416,12 @@ void NotificationManager::OrcaSyncConflictNotification::render_text(ImGuiWrapper
 	}
 
 	const float action_y = starting_y + m_endlines.size() * shift_y;
-	std::string pull_text = "";
-	float padding = 0.f;
-
-	if (m_pull_callback) {
-		pull_text = _u8L("Pull");
-		padding = ImGui::CalcTextSize((pull_text + "   ").c_str()).x;
-		render_hyperlink_action(imgui, x_offset, action_y, pull_text, "##orca_sync_pull",
-			[this] { if (m_pull_callback && m_pull_callback(m_evt_handler)) close(); });
-	}
+	const std::string pull_text = conflict_code == -3 ? _u8L("Delete") : _u8L("Pull");
+	render_hyperlink_action(imgui, x_offset, action_y, pull_text, "##orca_sync_pull",
+		[this] { if (m_pull_callback && m_pull_callback(m_evt_handler)) close(); });
 	if (m_force_push_callback) {
 		const std::string force_push_text = _u8L("Force push");
-		const float force_x = x_offset + padding;
+		const float force_x = x_offset + ImGui::CalcTextSize((pull_text + "   ").c_str()).x;
 		render_hyperlink_action(imgui, force_x, action_y, force_push_text, "##orca_sync_force_push",
 			[this] { if (m_force_push_callback && m_force_push_callback(m_evt_handler)) close(); });
 	}
@@ -2443,13 +2437,14 @@ void NotificationManager::push_shared_profiles_notification(const std::string& e
 }
 
 void NotificationManager::push_orca_sync_conflict_notification(const std::string& text,
+	int conflict_code,
 	std::function<bool(wxEvtHandler*)> pull_callback,
 	std::function<bool(wxEvtHandler*)> force_push_callback)
 {
 	close_notification_of_type(NotificationType::OrcaSyncConflict);
 	NotificationData data{ NotificationType::OrcaSyncConflict, NotificationLevel::WarningNotificationLevel, 0, text };
 	push_notification_data(std::make_unique<NotificationManager::OrcaSyncConflictNotification>(
-		data, m_id_provider, m_evt_handler, std::move(pull_callback), std::move(force_push_callback)), 0);
+		data, m_id_provider, m_evt_handler, std::move(pull_callback), std::move(force_push_callback), conflict_code), 0);
 }
 
 void NotificationManager::push_download_URL_progress_notification(size_t id, const std::string& text, std::function<bool(DownloaderUserAction, int)> user_action_callback)

--- a/src/slic3r/GUI/NotificationManager.hpp
+++ b/src/slic3r/GUI/NotificationManager.hpp
@@ -279,6 +279,7 @@ public:
 	// Shared profiles available for selected printer
 	void push_shared_profiles_notification(const std::string& explore_url);
 	void push_orca_sync_conflict_notification(const std::string& text,
+		int conflict_code,
 		std::function<bool(wxEvtHandler*)> pull_callback,
 		std::function<bool(wxEvtHandler*)> force_push_callback);
 
@@ -905,10 +906,12 @@ private:
 	public:
 		OrcaSyncConflictNotification(const NotificationData& n, NotificationIDProvider& id_provider, wxEvtHandler* evt_handler,
 			std::function<bool(wxEvtHandler*)> pull_callback,
-			std::function<bool(wxEvtHandler*)> force_push_callback)
+			std::function<bool(wxEvtHandler*)> force_push_callback,
+			int conflict_code)
 			: PopNotification(n, id_provider, evt_handler)
 			, m_pull_callback(std::move(pull_callback))
 			, m_force_push_callback(std::move(force_push_callback))
+			, conflict_code(conflict_code)
 		{
 			m_multiline = true;
 		}
@@ -920,6 +923,7 @@ private:
 
 		std::function<bool(wxEvtHandler*)> m_pull_callback;
 		std::function<bool(wxEvtHandler*)> m_force_push_callback;
+		int conflict_code;
 	};
 	class SlicingProgressNotification;
 

--- a/src/slic3r/Utils/OrcaCloudServiceAgent.cpp
+++ b/src/slic3r/Utils/OrcaCloudServiceAgent.cpp
@@ -101,24 +101,6 @@ std::string resolve_display_name(
     return username;
 }
 
-std::string generate_uuid_for_setting_id(const std::string& name, const std::string& user_id = "")
-{
-    if (name.empty()) {
-        return "";
-    }
-
-    // Mix user_id into the hashed input so two different users generating a setting_id
-    // for an identically-named preset get distinct UUIDs. Without this, the cloud's ID
-    // space collides across accounts and the second user's create gets HTTP 409 with
-    // server_profile=null on every sync (the foreign owner's record is not exposed).
-    static const boost::uuids::uuid orca_namespace =
-        boost::uuids::string_generator()("f47ac10b-58cc-4372-a567-0e02b2c3d479");
-
-    boost::uuids::name_generator_sha1 gen(orca_namespace);
-    boost::uuids::uuid id = user_id.empty() ? gen(name) : gen(user_id + "/" + name);
-    return boost::uuids::to_string(id);
-}
-
 std::string base64url_encode(const std::vector<unsigned char>& data)
 {
     std::string out;
@@ -410,6 +392,24 @@ OrcaCloudServiceAgent::~OrcaCloudServiceAgent()
     if (refresh_thread.joinable()) {
         refresh_thread.join();
     }
+}
+
+std::string OrcaCloudServiceAgent::generate_uuid_for_setting_id(const std::string& name, const std::string& user_id)
+{
+    if (name.empty()) {
+        return "";
+    }
+
+    // Mix user_id into the hashed input so two different users generating a setting_id
+    // for an identically-named preset get distinct UUIDs. Without this, the cloud's ID
+    // space collides across accounts and the second user's create gets HTTP 409 with
+    // server_profile=null on every sync (the foreign owner's record is not exposed).
+    static const boost::uuids::uuid orca_namespace =
+        boost::uuids::string_generator()("f47ac10b-58cc-4372-a567-0e02b2c3d479");
+
+    boost::uuids::name_generator_sha1 gen(orca_namespace);
+    boost::uuids::uuid id = user_id.empty() ? gen(name) : gen(user_id + "/" + name);
+    return boost::uuids::to_string(id);
 }
 
 void OrcaCloudServiceAgent::configure_urls(AppConfig* app_config)
@@ -1250,8 +1250,10 @@ SyncPushResult OrcaCloudServiceAgent::sync_push(const std::string& profile_id,
 
     if (http_code == 409) {
         // Conflict - parse server version
+        nlohmann::json err_body;
         try {
             auto json = nlohmann::json::parse(response);
+            err_body = json;
             if (json.is_null()) {
                 result.server_deleted = true;
             } else {
@@ -1261,6 +1263,13 @@ SyncPushResult OrcaCloudServiceAgent::sync_push(const std::string& profile_id,
                 result.server_version.updated_time = profile_data.value(ORCA_JSON_KEY_UPDATE_TIME, 0);
             }
         } catch (...) {}
+        // Surface the conflict via the http-error callback with the local preset name injected.
+        // The raw server body omits the name for tombstone (-3) conflicts (server_profile is null),
+        // but the GUI needs it to regenerate the deterministic setting_id for a force push.
+        if (!err_body.is_object())
+            err_body = nlohmann::json::object();
+        err_body["name"] = name;
+        invoke_http_error_callback(409, err_body.dump());
         result.error_message = response;
         return result;
     }
@@ -1937,7 +1946,10 @@ int OrcaCloudServiceAgent::http_post(const std::string& path, const std::string&
     if (response_body) *response_body = res.body;
     if (http_code) *http_code = res.status;
 
-    if (!suppress && (!res.success || res.status >= 400)) {
+    // 409 is a push-only domain conflict; sync_push re-fires the error callback with the
+    // local preset name injected (the raw server body omits it for tombstone conflicts),
+    // so skip the generic nameless auto-fire here to avoid a duplicate, nameless event.
+    if (!suppress && (!res.success || res.status >= 400) && res.status != 409) {
         invoke_http_error_callback(res.status, res.body);
     }
 

--- a/src/slic3r/Utils/OrcaCloudServiceAgent.hpp
+++ b/src/slic3r/Utils/OrcaCloudServiceAgent.hpp
@@ -300,6 +300,8 @@ public:
     bool set_user_session(const nlohmann::json& session_json, bool notify_login = true);
     void clear_session();
 
+    static std::string generate_uuid_for_setting_id(const std::string& name, const std::string& user_id = "");
+
 private:
     // Sync protocol helpers
     int sync_pull(


### PR DESCRIPTION
# Description

There is an edge case where the user deletes their preset via OrcaCloud and when they want to create a new preset with the same name on OrcaSlicer, pulling in the new changes will delete the local "new" preset that has the same name. OrcaCloud's API now handles this with an error code -3 and we will give the option to force push only, because pulling will result in a local delete. 

<img width="725" height="377" alt="image" src="https://github.com/user-attachments/assets/5042c867-b243-417e-8c81-88e8b029cccd" />

Additionally, we handle 409 HTTP codes that we don't recognize as generic resolutions.

Additional fix: 
Because the preset has been deleted from the cloud, when we try to do a force push, the setting_id, which was originally fetched from the cloud, is empty, so we need to generate the deterministic setting id before doing a force push.

# Testing
1. Create a preset on OrcaSlicer, this can be any preset, but the simplest one would be a process preset. Click sync preset.
2. Go to OrcaCloud and delete that preset.
3. Repeat step 1 with the same preset and you will see the notification for 409. Previously, you would have the option to pull or force push only, but pulling will delete your local preset. In this PR you should see the image above.

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
