### PR TITLE
Enable "Exclude objects" by default

### DIFF
--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -3952,7 +3952,7 @@ void PrintConfigDef::init_fff_params()
     def->label = L("Exclude objects");
     def->tooltip = L("Enable this option to add EXCLUDE OBJECT command in G-code.");
     def->mode = comAdvanced;
-    def->set_default_value(new ConfigOptionBool(false));
+    def->set_default_value(new ConfigOptionBool(true));
 
     def = this->add("gcode_comments", coBool);
     def->label = L("Verbose G-code");


### PR DESCRIPTION
Flips the default of `exclude_object` from false to true, emitting per-object cancellation markers (`EXCLUDE_OBJECT`/`M486` on Klipper/Marlin, `M624`/`M625` on Bambu) by default.

### Why
- **Saves prints** — with multiple parts on one plate, a single failed object can be cancelled without aborting the whole job, instead of losing everything.
- **Already on for many users** — BBL printers force-enable object exclusion in the G-code generator regardless of this setting (outside calibration mode), and profiles already opt in (e.g. Snapmaker U1 via #12869). Off-by-default largely hides a capability the machine already has.

### Relationship to existing per-profile enablement
#12869 enabled this on the Snapmaker U1 process profile to support dynamic MBL. This PR proposes promoting that to the global default rather than repeating the opt-in per profile. Profiles that explicitly set `exclude_object` continue to override the default, so their behavior is unchanged.

### Known caveat
Object-exclusion output currently emits Marlin-style `M486` even when the G-code flavor is Klipper (#13101). That bug affects the feature regardless of this default, but flipping the default on increases its exposure — so resolving #13101 alongside or before this is worth considering.

Bare default flip — no profile-migration logic.