### PR TITLE
Fix non-organic tree support base clearance above object surfaces

### DIFF
--- a/src/libslic3r/Support/TreeSupport.cpp
+++ b/src/libslic3r/Support/TreeSupport.cpp
@@ -2349,6 +2349,15 @@ void TreeSupport::draw_circles()
                     ts_layer->base_areas = std::move(expanded_base_areas);
                 }
 
+                // Orca: Final tree base polygons may be too close above model surfaces.
+                // Enforce bottom Z clearance for non-contact support layers as well.
+                if (!ts_layer->base_areas.empty()) {
+                    const Polygons trimming = get_trim_support_regions(
+                        *m_object, ts_layer, 0., m_slicing_params.gap_object_support, 0);
+                    if (!trimming.empty())
+                        ts_layer->base_areas = diff_ex(ts_layer->base_areas, trimming);
+                }
+
                 auto &area_groups = ts_layer->area_groups;
 
                 for (auto& expoly : ts_layer->base_areas) {


### PR DESCRIPTION
Non-organic tree supports can end up partially printed on object top surfaces. This PR enforces the configured "Bottom Z distance" as vertical clearance.
<br>
|Screenshots|
|---|
|Before|
|<img width="1706" height="710" alt="image" src="https://github.com/user-attachments/assets/7dd39b9d-6563-44c6-b597-477d13d66960" />|
|After|
|<img width="1716" height="708" alt="image" src="https://github.com/user-attachments/assets/dffbc059-102f-48bd-b97d-e344b2c6931f" />|

I deliberately avoided introducing any new parameter.
Fixes #13997