### PR TITLE
Make sure mouse position is updated before hit test

### DIFF
--- a/src/slic3r/GUI/BBLTopbar.cpp
+++ b/src/slic3r/GUI/BBLTopbar.cpp
@@ -807,6 +807,8 @@ wxAuiToolBarItem* BBLTopbar::FindToolByCurrentPosition()
 }
 
 #ifdef __WXMSW__
+#include <windowsx.h>
+
 WXLRESULT CenteredTitle::MSWWindowProc(WXUINT nMsg, WXWPARAM wParam, WXLPARAM lParam)
 {
     switch (nMsg) {
@@ -823,6 +825,8 @@ WXLRESULT BBLTopbar::MSWWindowProc(WXUINT nMsg, WXWPARAM wParam, WXLPARAM lParam
 {
     switch (nMsg) {
     case WM_NCHITTEST: {
+        m_last_mouse_position = ScreenToClient({GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam)});
+
         wxAuiToolBarItem* item = this->FindToolByCurrentPosition();
         if (item != NULL && item->GetWindow() != m_title_ctrl) {
             break;


### PR DESCRIPTION
# Description

This fix issue on Windows, that in some cases the title bar buttons became unclickable:

<img width="924" height="516" alt="win-title-freeze" src="https://github.com/user-attachments/assets/a9a8b054-12a1-4dec-bbc7-01dd9aaaef9f" />


# Screenshots/Recordings/Graphs

<!--
> Please attach relevant screenshots to showcase the UI changes.
> Please attach images that can help explain the changes.
-->

## Tests

<!--
> Please describe the tests that you have conducted to verify the changes made in this PR.
-->

<!--
> A guide for users on how to download the artifacts from this PR.
-->

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
