### PR TITLE
Enable printing to Bambu cloud printers via a genuine Bambu Studio host (Windows)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "deps/minhook"]
+	path = deps/minhook
+	url = https://github.com/TsudaKageyu/minhook.git

--- a/src/slic3r/CMakeLists.txt
+++ b/src/slic3r/CMakeLists.txt
@@ -719,6 +719,8 @@ set(SLIC3R_GUI_SOURCES
     Utils/BBLPrinterAgent.hpp
     Utils/BBLNetworkPlugin.cpp
     Utils/BBLNetworkPlugin.hpp
+    Utils/PluginVerifyRedirect.cpp
+    Utils/PluginVerifyRedirect.hpp
     Utils/Obico.cpp
     Utils/Obico.hpp
     Utils/OctoPrint.cpp
@@ -859,6 +861,29 @@ endif ()
 
 if (MSVC)
     target_link_libraries(libslic3r_gui Setupapi.lib)
+    # MinHook (git submodule at deps/minhook) for PluginVerifyRedirect.cpp — the
+    # Bambu network plugin's "signed studio" Authenticode gate redirect. Compiled
+    # straight into libslic3r_gui (Windows x64 only).
+    set(_MINHOOK_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../deps/minhook)
+    # CI (actions/checkout) clones with submodules disabled, so fetch it on demand
+    # if the sources are absent; fall back to a clear error if that fails.
+    if (NOT EXISTS ${_MINHOOK_DIR}/src/hook.c)
+        find_package(Git QUIET)
+        if (GIT_FOUND)
+            execute_process(
+                COMMAND ${GIT_EXECUTABLE} submodule update --init deps/minhook
+                WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+        endif ()
+        if (NOT EXISTS ${_MINHOOK_DIR}/src/hook.c)
+            message(FATAL_ERROR "MinHook submodule missing — run: git submodule update --init deps/minhook")
+        endif ()
+    endif ()
+    target_sources(libslic3r_gui PRIVATE
+        ${_MINHOOK_DIR}/src/buffer.c
+        ${_MINHOOK_DIR}/src/hook.c
+        ${_MINHOOK_DIR}/src/trampoline.c
+        ${_MINHOOK_DIR}/src/hde/hde64.c)
+    target_include_directories(libslic3r_gui PRIVATE ${_MINHOOK_DIR}/include)
 elseif (CMAKE_SYSTEM_NAME STREQUAL "Linux")
     FIND_LIBRARY(WAYLAND_SERVER_LIBRARIES NAMES wayland-server)
     FIND_LIBRARY(WAYLAND_EGL_LIBRARIES    NAMES wayland-egl)

--- a/src/slic3r/Utils/BBLNetworkPlugin.cpp
+++ b/src/slic3r/Utils/BBLNetworkPlugin.cpp
@@ -8,6 +8,7 @@
 #include <boost/filesystem.hpp>
 #include "libslic3r/Utils.hpp"
 #include "slic3r/Utils/FileTransferUtils.hpp"
+#include "slic3r/Utils/PluginVerifyRedirect.hpp"
 
 #if !defined(_MSC_VER) && !defined(_WIN32)
 #include <dlfcn.h>
@@ -128,6 +129,9 @@ int BBLNetworkPlugin::initialize(bool using_backup, const std::string& version)
                            : resolve_library_path(version);
 
 #if defined(_MSC_VER) || defined(_WIN32)
+    // Satisfy the proprietary plugin's "signed studio" Authenticode gate.
+    Slic3r::install_plugin_verify_redirect();
+
     wchar_t lib_wstr[256];
     memset(lib_wstr, 0, sizeof(lib_wstr));
     ::MultiByteToWideChar(CP_UTF8, NULL, library.c_str(), strlen(library.c_str())+1, lib_wstr, sizeof(lib_wstr) / sizeof(lib_wstr[0]));

--- a/src/slic3r/Utils/PluginVerifyRedirect.cpp
+++ b/src/slic3r/Utils/PluginVerifyRedirect.cpp
@@ -1,0 +1,261 @@
+#include "PluginVerifyRedirect.hpp"
+
+#ifdef _WIN32
+
+#include <windows.h>
+#include <wincrypt.h>
+#include <intrin.h>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+
+#include "MinHook.h"
+
+namespace {
+
+// The proprietary network plugin runs Authenticode checks on the host .exe and the
+// studio DLL that loaded it. Neither of OUR files (orca-slicer.exe / OrcaSlicer.dll)
+// is Bambu-signed, so we MinHook the plugin's lookups and feed it the genuine,
+// Bambu-signed files instead:
+//   * GetModuleFileName / CryptQueryObject on our exe/dll -> the genuine path, so
+//     WinVerifyTrust runs against a real Bambu-signed binary and passes.
+//   * GetModuleHandle("BambuStudio.dll")                  -> OUR module, so the plugin's
+//     name-based studio lookup resolves to us even though our DLL is OrcaSlicer.dll.
+// The genuine files are NOT shipped; we locate them in the installed Bambu Studio via
+// its uninstall registry entry (env vars override for development).
+//
+// Resolved at install():
+//   g_our_dll / g_our_exe         -> our unsigned files (this process)
+//   g_genuine_dll / g_genuine_exe -> the genuine Bambu files we redirect to
+//   g_self                        -> our studio DLL's own module handle
+wchar_t g_our_dll[MAX_PATH] = {0};
+wchar_t g_our_exe[MAX_PATH] = {0};
+wchar_t g_genuine_dll_w[MAX_PATH] = {0};
+char    g_genuine_dll_a[MAX_PATH] = {0};
+wchar_t g_genuine_exe_w[MAX_PATH] = {0};
+char    g_genuine_exe_a[MAX_PATH] = {0};
+HMODULE g_self = nullptr;
+
+// Signatures of the Win32 APIs we hook, used to call through to the originals.
+typedef DWORD   (WINAPI *fn_gmfw)(HMODULE, LPWSTR, DWORD);
+typedef DWORD   (WINAPI *fn_gmfa)(HMODULE, LPSTR, DWORD);
+typedef BOOL    (WINAPI *fn_cqo)(DWORD, const void*, DWORD, DWORD, DWORD,
+                                 DWORD*, DWORD*, DWORD*, HCERTSTORE*, HCRYPTMSG*, const void**);
+typedef HMODULE (WINAPI *fn_gmhw)(LPCWSTR);
+typedef HMODULE (WINAPI *fn_gmha)(LPCSTR);
+
+// Trampolines to the original, un-hooked APIs, filled in by MH_CreateHook.
+fn_gmfw o_gmfw = nullptr;
+fn_gmfa o_gmfa = nullptr;
+fn_cqo  o_cqo  = nullptr;
+fn_gmhw o_gmhw = nullptr;
+fn_gmha o_gmha = nullptr;
+
+// Is the return address inside the proprietary network plugin? (resolved lazily, since the
+// plugin loads after we install.) Always uses the trampoline to avoid re-entering our hook.
+bool caller_is_plugin(void* ra)
+{
+    HMODULE h = nullptr;
+    if (!GetModuleHandleExW(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                            (LPCWSTR)ra, &h) || !h || !o_gmfw)
+        return false;
+    wchar_t p[MAX_PATH] = {0};
+    o_gmfw(h, p, MAX_PATH);
+    return wcsstr(p, L"bambu_networking") != nullptr || wcsstr(p, L"BambuSource") != nullptr;
+}
+
+// Does this name refer to the genuine studio module name "BambuStudio.dll"?
+bool wants_studio_w(const wchar_t* n)
+{
+    if (!n) return false;
+    const wchar_t* b = wcsrchr(n, L'\\'); b = b ? b + 1 : n;
+    return _wcsicmp(b, L"BambuStudio.dll") == 0 || _wcsicmp(b, L"BambuStudio") == 0;
+}
+bool wants_studio_a(const char* n)
+{
+    if (!n) return false;
+    const char* b = strrchr(n, '\\'); b = b ? b + 1 : n;
+    return _stricmp(b, "BambuStudio.dll") == 0 || _stricmp(b, "BambuStudio") == 0;
+}
+
+// Given a path the plugin queried, return the genuine file to substitute (our dll -> genuine
+// dll, our exe -> genuine exe), or nullptr to leave as-is.
+const wchar_t* redirect_w(const wchar_t* p)
+{
+    if (!p) return nullptr;
+    if (g_our_dll[0] && _wcsicmp(p, g_our_dll) == 0 && g_genuine_dll_w[0]) return g_genuine_dll_w;
+    if (g_our_exe[0] && _wcsicmp(p, g_our_exe) == 0 && g_genuine_exe_w[0]) return g_genuine_exe_w;
+    return nullptr;
+}
+// ANSI counterpart of redirect_w(): widen the queried path, then return its genuine one.
+const char* redirect_a(const char* p)
+{
+    if (!p) return nullptr;
+    wchar_t w[MAX_PATH] = {0};
+    MultiByteToWideChar(CP_ACP, 0, p, -1, w, MAX_PATH);
+    if (g_our_dll[0] && _wcsicmp(w, g_our_dll) == 0 && g_genuine_dll_a[0]) return g_genuine_dll_a;
+    if (g_our_exe[0] && _wcsicmp(w, g_our_exe) == 0 && g_genuine_exe_a[0]) return g_genuine_exe_a;
+    return nullptr;
+}
+
+// Hook for GetModuleFileNameW: when the plugin queries one of our module paths, overwrite the
+// returned buffer with the genuine path so its WinVerifyTrust check sees a Bambu-signed file.
+DWORD WINAPI hk_gmfw(HMODULE hMod, LPWSTR fn, DWORD sz)
+{
+    void* ra = _ReturnAddress();
+    DWORD r = o_gmfw(hMod, fn, sz);
+    if (fn && r && caller_is_plugin(ra)) {
+        const wchar_t* t = redirect_w(fn);
+        if (t) { size_t n = wcslen(t); if (sz > n) { wcscpy_s(fn, sz, t); return (DWORD)n; } }
+    }
+    return r;
+}
+
+// Hook for GetModuleFileNameA: ANSI counterpart of hk_gmfw.
+DWORD WINAPI hk_gmfa(HMODULE hMod, LPSTR fn, DWORD sz)
+{
+    void* ra = _ReturnAddress();
+    DWORD r = o_gmfa(hMod, fn, sz);
+    if (fn && r && caller_is_plugin(ra)) {
+        const char* t = redirect_a(fn);
+        if (t) { size_t n = strlen(t); if (sz > n) { strcpy_s(fn, sz, t); return (DWORD)n; } }
+    }
+    return r;
+}
+
+// Hook for CryptQueryObject: when the plugin verifies a file object that is one of ours,
+// substitute the genuine file path before the call reaches crypt32.
+BOOL WINAPI hk_cqo(DWORD ot, const void* obj, DWORD a, DWORD b, DWORD c,
+                   DWORD* d, DWORD* e, DWORD* f, HCERTSTORE* st, HCRYPTMSG* msg, const void** ctx)
+{
+    const void* use = obj;
+    if (ot == CERT_QUERY_OBJECT_FILE && obj && caller_is_plugin(_ReturnAddress())) {
+        const wchar_t* t = redirect_w((const wchar_t*)obj);
+        if (t) use = t;
+    }
+    return o_cqo(ot, use, a, b, c, d, e, f, st, msg, ctx);
+}
+
+// Hooks for GetModuleHandleW/A: the plugin locates the studio module by the hardcoded name
+// "BambuStudio.dll". Hand back our own module instead -- the plugin then caches it and uses
+// it for the control-command signing path.
+HMODULE WINAPI hk_gmhw(LPCWSTR name)
+{
+    if (g_self && wants_studio_w(name) && caller_is_plugin(_ReturnAddress())) return g_self;
+    return o_gmhw(name);
+}
+HMODULE WINAPI hk_gmha(LPCSTR name)
+{
+    if (g_self && wants_studio_a(name) && caller_is_plugin(_ReturnAddress())) return g_self;
+    return o_gmha(name);
+}
+
+// Record `path` in out_w (wide) + out_a (ansi) if it exists on disk. Returns true on success.
+bool set_genuine(const wchar_t* path, wchar_t* out_w, char* out_a)
+{
+    if (!path || !path[0] || GetFileAttributesW(path) == INVALID_FILE_ATTRIBUTES) return false;
+    wcscpy_s(out_w, MAX_PATH, path);
+    WideCharToMultiByte(CP_ACP, 0, path, -1, out_a, MAX_PATH, nullptr, nullptr);
+    return true;
+}
+
+// Dev override: take a genuine path from an environment variable, if the file exists.
+bool genuine_from_env(const char* env, wchar_t* out_w, char* out_a)
+{
+    const char* v = std::getenv(env);
+    if (!v || !*v) return false;
+    wchar_t w[MAX_PATH] = {0};
+    MultiByteToWideChar(CP_UTF8, 0, v, -1, w, MAX_PATH);
+    return set_genuine(w, out_w, out_a);
+}
+
+// Find the installed Bambu Studio directory (with trailing backslash) from its uninstall
+// registry entry's DisplayIcon (which points at bambu-studio.exe). Returns false if Bambu
+// Studio is not installed.
+bool bambu_studio_dir(wchar_t* dir, size_t n)
+{
+    HKEY k = nullptr;
+    if (RegOpenKeyExW(HKEY_LOCAL_MACHINE,
+            L"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\Bambu Studio",
+            0, KEY_READ | KEY_WOW64_64KEY, &k) != ERROR_SUCCESS)
+        return false;
+    wchar_t icon[MAX_PATH] = {0};
+    DWORD sz = sizeof(icon), type = 0;
+    LONG rc = RegQueryValueExW(k, L"DisplayIcon", nullptr, &type, (LPBYTE)icon, &sz);
+    RegCloseKey(k);
+    if (rc != ERROR_SUCCESS || !icon[0]) return false;
+    wchar_t* slash = wcsrchr(icon, L'\\');
+    if (!slash) return false;
+    slash[1] = 0;                       // keep the trailing backslash
+    wcsncpy_s(dir, n, icon, _TRUNCATE);
+    return true;
+}
+
+// Resolve a genuine file: env override first, then <bambu studio dir>\<leaf>.
+bool resolve_genuine(const char* env, const wchar_t* bsdir, const wchar_t* leaf,
+                     wchar_t* out_w, char* out_a)
+{
+    if (genuine_from_env(env, out_w, out_a)) return true;
+    if (bsdir && bsdir[0]) {
+        wchar_t p[MAX_PATH] = {0};
+        wcscpy_s(p, MAX_PATH, bsdir);
+        wcsncat_s(p, MAX_PATH, leaf, _TRUNCATE);
+        return set_genuine(p, out_w, out_a);
+    }
+    return false;
+}
+
+} // namespace
+
+namespace Slic3r {
+
+// Entry point (idempotent): resolve our unsigned files + the genuine Bambu files (from the
+// registry / env), then install the hooks that feed the plugin the genuine paths and our
+// own module handle.
+void install_plugin_verify_redirect()
+{
+    static bool done = false;
+    if (done) return;
+    done = true;
+
+    HMODULE self = nullptr;
+    GetModuleHandleExW(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                       (LPCWSTR)&install_plugin_verify_redirect, &self);
+    g_self = self;
+    GetModuleFileNameW(self, g_our_dll, MAX_PATH);
+    GetModuleFileNameW(nullptr, g_our_exe, MAX_PATH);
+
+    // Genuine, Bambu-signed files the plugin's Authenticode checks are redirected to. We do
+    // NOT ship copies -- locate them in the installed Bambu Studio via the registry (env vars
+    // override for development). Bambu Studio must be installed for the network plugin to work.
+    wchar_t bsdir[MAX_PATH] = {0};
+    bambu_studio_dir(bsdir, MAX_PATH);
+    bool have_dll = resolve_genuine("BAMBU_BRIDGE_GENUINE_DLL", bsdir, L"BambuStudio.dll",
+                                    g_genuine_dll_w, g_genuine_dll_a);
+    bool have_exe = resolve_genuine("BAMBU_BRIDGE_GENUINE_EXE", bsdir, L"bambu-studio.exe",
+                                    g_genuine_exe_w, g_genuine_exe_a);
+    if (!have_dll && !have_exe) return;  // no genuine files found -> nothing to redirect
+
+    if (MH_Initialize() != MH_OK) return;
+    HMODULE k32 = GetModuleHandleW(L"kernel32.dll");
+    HMODULE c32 = GetModuleHandleW(L"crypt32.dll");
+    if (!c32) c32 = LoadLibraryW(L"crypt32.dll");
+    if (k32) {
+        MH_CreateHook((void*)GetProcAddress(k32, "GetModuleFileNameW"), (void*)hk_gmfw, (void**)&o_gmfw);
+        MH_CreateHook((void*)GetProcAddress(k32, "GetModuleFileNameA"), (void*)hk_gmfa, (void**)&o_gmfa);
+        MH_CreateHook((void*)GetProcAddress(k32, "GetModuleHandleW"),   (void*)hk_gmhw, (void**)&o_gmhw);
+        MH_CreateHook((void*)GetProcAddress(k32, "GetModuleHandleA"),   (void*)hk_gmha, (void**)&o_gmha);
+    }
+    if (c32)
+        MH_CreateHook((void*)GetProcAddress(c32, "CryptQueryObject"), (void*)hk_cqo, (void**)&o_cqo);
+    MH_EnableHook(MH_ALL_HOOKS);
+}
+
+} // namespace Slic3r
+
+#else  // !_WIN32
+
+// Non-Windows build: there is no Authenticode gate to satisfy, so the entry point is a no-op.
+namespace Slic3r { void install_plugin_verify_redirect() {} }
+
+#endif

--- a/src/slic3r/Utils/PluginVerifyRedirect.hpp
+++ b/src/slic3r/Utils/PluginVerifyRedirect.hpp
@@ -1,0 +1,18 @@
+#ifndef slic3r_PluginVerifyRedirect_hpp_
+#define slic3r_PluginVerifyRedirect_hpp_
+
+namespace Slic3r {
+
+// Windows-only. When running a forked/unsigned BambuStudio under a GENUINE,
+// version-matched bambu-studio.exe launcher, the network plugin's "signed
+// studio" gate still verifies *this* BambuStudio.dll via WinVerifyTrust and
+// rejects it (unsigned). This installs in-process inline hooks (MinHook) so the
+// plugin's Authenticode verification of our DLL resolves to the genuine official
+// BambuStudio.dll instead, satisfying the gate so control commands get signed.
+//
+// MUST be called before the network plugin is loaded.
+void install_plugin_verify_redirect();
+
+} // namespace Slic3r
+
+#endif

--- a/src/slic3r/Utils/bambu_networking.hpp
+++ b/src/slic3r/Utils/bambu_networking.hpp
@@ -273,14 +273,17 @@ struct PrintParams_0203 {
     bool            task_vibration_cali;    /* vibration calibration of task */
     bool            task_layer_inspect;     /* first layer inspection of task */
     bool            task_record_timelapse;  /* record timelapse of task */
+    bool            task_timelapse_use_internal;
     bool            task_use_ams;
     std::string     task_bed_type;
     std::string     extra_options;
     int             auto_bed_leveling{ 0 };
     int             auto_flow_cali{ 0 };
     int             auto_offset_cali{ 0 };
+    int             extruder_cali_manual_mode{ -1 };
     bool            task_ext_change_assist;
     bool            try_emmc_print;
+    std::string     svc_context;
 };
 
 /* print job*/
@@ -432,6 +435,7 @@ static const NetworkLibraryVersion AVAILABLE_NETWORK_VERSIONS[] = {
      "An older plug-in series. Features that need newer plug-in support, such as print-failure "
      "snapshots in the device error dialog, are unavailable.", NetworkAbi::V0203},
     {BAMBU_NETWORK_AGENT_VERSION_LEGACY, BAMBU_NETWORK_AGENT_VERSION_LEGACY " (legacy)", nullptr, false, nullptr, NetworkAbi::Legacy},
+>>>>>>> 3e634b2dd (Enable printing to Bambu cloud printers (Windows))
 };
 
 static const size_t AVAILABLE_NETWORK_VERSIONS_COUNT = sizeof(AVAILABLE_NETWORK_VERSIONS) / sizeof(AVAILABLE_NETWORK_VERSIONS[0]);

--- a/src/slic3r/Utils/bambu_networking.hpp
+++ b/src/slic3r/Utils/bambu_networking.hpp
@@ -435,7 +435,6 @@ static const NetworkLibraryVersion AVAILABLE_NETWORK_VERSIONS[] = {
      "An older plug-in series. Features that need newer plug-in support, such as print-failure "
      "snapshots in the device error dialog, are unavailable.", NetworkAbi::V0203},
     {BAMBU_NETWORK_AGENT_VERSION_LEGACY, BAMBU_NETWORK_AGENT_VERSION_LEGACY " (legacy)", nullptr, false, nullptr, NetworkAbi::Legacy},
->>>>>>> 3e634b2dd (Enable printing to Bambu cloud printers (Windows))
 };
 
 static const size_t AVAILABLE_NETWORK_VERSIONS_COUNT = sizeof(AVAILABLE_NETWORK_VERSIONS) / sizeof(AVAILABLE_NETWORK_VERSIONS[0]);


### PR DESCRIPTION
A minimal change that lets OrcaSlicer print to Bambu **cloud** printers on Windows, by running under a genuine, Bambu-signed Bambu Studio host so the official Bambu network plugin loads.

### Scope of this first version
- ✅ Connect to and print on Bambu cloud printers
- ❌ No filament temperature control
- ⚠️ Limited storage / file-management functionality
- ❌ No self-healing: **Bambu Studio `02.07.01.57` must be installed _before_ installing OrcaSlicer** — the installer copies its signed host (`bambu-studio.exe`) and DLL at install time.

### How it works
- Emit the studio DLL as `BambuStudio.dll` plus a `bambustu_main` alias, so the genuine host loads our app.
- Re-launch under the staged genuine `bambu-studio.exe` (re-parented to `explorer.exe`) so the plugin's signed-host Authenticode check passes.
- `PluginVerifyRedirect` (MinHook) redirects the plugin's signature queries to the genuine on-disk Bambu files.
- Selects the `02.07.01.51` network plugin; studio identity `02.07.01.57`.

MinHook is vendored as a submodule at `deps/minhook` (`git submodule update --init deps/minhook`).
