### PR TITLE
Change wall Generator to arachne for Creality Printers

### DIFF
--- a/resources/profiles/Creality/process/0.06mm SuperDetail @Creality K2 Plus 0.2 nozzle.json
+++ b/resources/profiles/Creality/process/0.06mm SuperDetail @Creality K2 Plus 0.2 nozzle.json
@@ -226,7 +226,7 @@
 	"tree_support_wall_count": "0",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "4",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.08mm HueForge @Creality Hi 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.08mm HueForge @Creality Hi 0.4 nozzle.json
@@ -249,7 +249,7 @@
 	"wall_direction": "auto",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "1",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.08mm HueForge @Creality K2 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.08mm HueForge @Creality K2 0.4 nozzle.json
@@ -248,7 +248,7 @@
 	"wall_direction": "auto",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "1",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.08mm HueForge @Creality K2 Plus 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.08mm HueForge @Creality K2 Plus 0.4 nozzle.json
@@ -249,7 +249,7 @@
 	"wall_direction": "auto",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "1",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.08mm HueForge @Creality K2 Pro 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.08mm HueForge @Creality K2 Pro 0.4 nozzle.json
@@ -248,7 +248,7 @@
 	"wall_direction": "auto",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "1",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.08mm HueForge @Creality SPARKX i7 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.08mm HueForge @Creality SPARKX i7 0.4 nozzle.json
@@ -251,7 +251,7 @@
 	"wall_direction": "auto",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "2",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.08mm SuperDetail @Creality Hi 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.08mm SuperDetail @Creality Hi 0.4 nozzle.json
@@ -227,7 +227,7 @@
 	"tree_support_wall_count": "0",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "2",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.08mm SuperDetail @Creality K1 (0.4 nozzle).json
+++ b/resources/profiles/Creality/process/0.08mm SuperDetail @Creality K1 (0.4 nozzle).json
@@ -249,7 +249,7 @@
 	"wall_direction": "auto",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "2",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.08mm SuperDetail @Creality K1 Max_CFS-C 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.08mm SuperDetail @Creality K1 Max_CFS-C 0.4 nozzle.json
@@ -248,7 +248,7 @@
 	"wall_direction": "auto",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "2",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.08mm SuperDetail @Creality K1C 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.08mm SuperDetail @Creality K1C 0.4 nozzle.json
@@ -249,7 +249,7 @@
 	"wall_direction": "auto",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "2",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.08mm SuperDetail @Creality K1C_CFS-C 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.08mm SuperDetail @Creality K1C_CFS-C 0.4 nozzle.json
@@ -248,7 +248,7 @@
 	"wall_direction": "auto",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "2",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.08mm SuperDetail @Creality K1Max (0.4 nozzle).json
+++ b/resources/profiles/Creality/process/0.08mm SuperDetail @Creality K1Max (0.4 nozzle).json
@@ -249,7 +249,7 @@
 	"wall_direction": "auto",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "2",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.08mm SuperDetail @Creality K1_CFS-C 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.08mm SuperDetail @Creality K1_CFS-C 0.4 nozzle.json
@@ -248,7 +248,7 @@
 	"wall_direction": "auto",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "2",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.08mm SuperDetail @Creality K2 0.2 nozzle.json
+++ b/resources/profiles/Creality/process/0.08mm SuperDetail @Creality K2 0.2 nozzle.json
@@ -25,7 +25,7 @@
 	"outer_wall_speed": "100",
 	"outer_wall_acceleration": "5000",
 	"inner_wall_acceleration": "5000",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_infill_order": "inner wall/outer wall/infill",
 	"line_width": "0.22",
 	"infill_direction": "45",

--- a/resources/profiles/Creality/process/0.08mm SuperDetail @Creality K2 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.08mm SuperDetail @Creality K2 0.4 nozzle.json
@@ -225,7 +225,7 @@
 	"tree_support_wall_count": "0",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "2",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.08mm SuperDetail @Creality K2 Plus 0.2 nozzle.json
+++ b/resources/profiles/Creality/process/0.08mm SuperDetail @Creality K2 Plus 0.2 nozzle.json
@@ -224,7 +224,7 @@
 	"tree_support_wall_count": "0",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "4",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.08mm SuperDetail @Creality K2 Plus 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.08mm SuperDetail @Creality K2 Plus 0.4 nozzle.json
@@ -226,7 +226,7 @@
 	"tree_support_wall_count": "0",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "2",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.08mm SuperDetail @Creality K2 Pro 0.2 nozzle.json
+++ b/resources/profiles/Creality/process/0.08mm SuperDetail @Creality K2 Pro 0.2 nozzle.json
@@ -25,7 +25,7 @@
 	"outer_wall_speed": "100",
 	"outer_wall_acceleration": "5000",
 	"inner_wall_acceleration": "5000",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_infill_order": "inner wall/outer wall/infill",
 	"line_width": "0.22",
 	"infill_direction": "45",

--- a/resources/profiles/Creality/process/0.08mm SuperDetail @Creality K2 Pro 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.08mm SuperDetail @Creality K2 Pro 0.4 nozzle.json
@@ -225,7 +225,7 @@
 	"tree_support_wall_count": "0",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "2",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.08mm SuperDetail @Creality SPARKX i7 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.08mm SuperDetail @Creality SPARKX i7 0.4 nozzle.json
@@ -228,7 +228,7 @@
 	"tree_support_wall_count": "0",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "2",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.10mm HighDetail @Creality K2 0.2 nozzle.json
+++ b/resources/profiles/Creality/process/0.10mm HighDetail @Creality K2 0.2 nozzle.json
@@ -25,7 +25,7 @@
 	"outer_wall_speed": "100",
 	"outer_wall_acceleration": "5000",
 	"inner_wall_acceleration": "5000",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_infill_order": "inner wall/outer wall/infill",
 	"line_width": "0.22",
 	"infill_direction": "45",

--- a/resources/profiles/Creality/process/0.10mm HighDetail @Creality K2 Plus 0.2 nozzle.json
+++ b/resources/profiles/Creality/process/0.10mm HighDetail @Creality K2 Plus 0.2 nozzle.json
@@ -224,7 +224,7 @@
 	"tree_support_wall_count": "0",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "4",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.10mm HighDetail @Creality K2 Pro 0.2 nozzle.json
+++ b/resources/profiles/Creality/process/0.10mm HighDetail @Creality K2 Pro 0.2 nozzle.json
@@ -25,7 +25,7 @@
 	"outer_wall_speed": "100",
 	"outer_wall_acceleration": "5000",
 	"inner_wall_acceleration": "5000",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_infill_order": "inner wall/outer wall/infill",
 	"line_width": "0.22",
 	"infill_direction": "45",

--- a/resources/profiles/Creality/process/0.10mm HighDetail @Creality SPARKX i7 0.2 nozzle.json
+++ b/resources/profiles/Creality/process/0.10mm HighDetail @Creality SPARKX i7 0.2 nozzle.json
@@ -252,7 +252,7 @@
 	"wall_direction": "auto",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "4",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.12mm Detail @Creality K2 0.2 nozzle.json
+++ b/resources/profiles/Creality/process/0.12mm Detail @Creality K2 0.2 nozzle.json
@@ -25,7 +25,7 @@
 	"outer_wall_speed": "100",
 	"outer_wall_acceleration": "5000",
 	"inner_wall_acceleration": "5000",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_infill_order": "inner wall/outer wall/infill",
 	"line_width": "0.22",
 	"infill_direction": "45",

--- a/resources/profiles/Creality/process/0.12mm Detail @Creality K2 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.12mm Detail @Creality K2 0.4 nozzle.json
@@ -248,7 +248,7 @@
 	"wall_direction": "auto",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "2",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.12mm Detail @Creality K2 Plus 0.2 nozzle.json
+++ b/resources/profiles/Creality/process/0.12mm Detail @Creality K2 Plus 0.2 nozzle.json
@@ -224,7 +224,7 @@
 	"tree_support_wall_count": "0",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "4",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.12mm Detail @Creality K2 Plus 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.12mm Detail @Creality K2 Plus 0.4 nozzle.json
@@ -226,7 +226,7 @@
 	"tree_support_wall_count": "0",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "2",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.12mm Detail @Creality K2 Pro 0.2 nozzle.json
+++ b/resources/profiles/Creality/process/0.12mm Detail @Creality K2 Pro 0.2 nozzle.json
@@ -25,7 +25,7 @@
 	"outer_wall_speed": "100",
 	"outer_wall_acceleration": "5000",
 	"inner_wall_acceleration": "5000",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_infill_order": "inner wall/outer wall/infill",
 	"line_width": "0.22",
 	"infill_direction": "45",

--- a/resources/profiles/Creality/process/0.12mm Detail @Creality K2 Pro 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.12mm Detail @Creality K2 Pro 0.4 nozzle.json
@@ -248,7 +248,7 @@
 	"wall_direction": "auto",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "2",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.12mm Fine @Creality Hi 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.12mm Fine @Creality Hi 0.4 nozzle.json
@@ -247,7 +247,7 @@
 	"wall_direction": "auto",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "2",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.12mm Fine @Creality SPARKX i7 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.12mm Fine @Creality SPARKX i7 0.4 nozzle.json
@@ -249,7 +249,7 @@
 	"wall_direction": "auto",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "2",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.14mm Optimal @Creality K2 0.2 nozzle.json
+++ b/resources/profiles/Creality/process/0.14mm Optimal @Creality K2 0.2 nozzle.json
@@ -25,7 +25,7 @@
 	"outer_wall_speed": "100",
 	"outer_wall_acceleration": "5000",
 	"inner_wall_acceleration": "5000",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_infill_order": "inner wall/outer wall/infill",
 	"line_width": "0.22",
 	"infill_direction": "45",

--- a/resources/profiles/Creality/process/0.14mm Optimal @Creality K2 Plus 0.2 nozzle.json
+++ b/resources/profiles/Creality/process/0.14mm Optimal @Creality K2 Plus 0.2 nozzle.json
@@ -226,7 +226,7 @@
 	"tree_support_wall_count": "0",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "4",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.14mm Optimal @Creality K2 Pro 0.2 nozzle.json
+++ b/resources/profiles/Creality/process/0.14mm Optimal @Creality K2 Pro 0.2 nozzle.json
@@ -25,7 +25,7 @@
 	"outer_wall_speed": "100",
 	"outer_wall_acceleration": "5000",
 	"inner_wall_acceleration": "5000",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_infill_order": "inner wall/outer wall/infill",
 	"line_width": "0.22",
 	"infill_direction": "45",

--- a/resources/profiles/Creality/process/0.16mm Fine @Creality Ender-3 V4 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.16mm Fine @Creality Ender-3 V4 0.4 nozzle.json
@@ -246,7 +246,7 @@
 	"wall_direction": "auto",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "2",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.16mm Optimal @Creality Hi 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.16mm Optimal @Creality Hi 0.4 nozzle.json
@@ -247,7 +247,7 @@
 	"wall_direction": "auto",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "2",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.16mm Optimal @Creality K1 (0.4 nozzle).json
+++ b/resources/profiles/Creality/process/0.16mm Optimal @Creality K1 (0.4 nozzle).json
@@ -249,7 +249,7 @@
 	"wall_direction": "auto",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "2",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.16mm Optimal @Creality K1 Max_CFS-C 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.16mm Optimal @Creality K1 Max_CFS-C 0.4 nozzle.json
@@ -248,7 +248,7 @@
 	"wall_direction": "auto",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "2",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.16mm Optimal @Creality K1 SE 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.16mm Optimal @Creality K1 SE 0.4 nozzle.json
@@ -247,7 +247,7 @@
 	"wall_direction": "auto",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "2",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.16mm Optimal @Creality K1 SE_CFS-C 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.16mm Optimal @Creality K1 SE_CFS-C 0.4 nozzle.json
@@ -246,7 +246,7 @@
 	"wall_direction": "auto",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "2",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.16mm Optimal @Creality K1C 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.16mm Optimal @Creality K1C 0.4 nozzle.json
@@ -249,7 +249,7 @@
 	"wall_direction": "auto",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "2",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.16mm Optimal @Creality K1C_CFS-C 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.16mm Optimal @Creality K1C_CFS-C 0.4 nozzle.json
@@ -248,7 +248,7 @@
 	"wall_direction": "auto",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "2",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.16mm Optimal @Creality K1Max (0.4 nozzle).json
+++ b/resources/profiles/Creality/process/0.16mm Optimal @Creality K1Max (0.4 nozzle).json
@@ -249,7 +249,7 @@
 	"wall_direction": "auto",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "2",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.16mm Optimal @Creality K1_CFS-C 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.16mm Optimal @Creality K1_CFS-C 0.4 nozzle.json
@@ -248,7 +248,7 @@
 	"wall_direction": "auto",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "2",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.16mm Optimal @Creality K2 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.16mm Optimal @Creality K2 0.4 nozzle.json
@@ -248,7 +248,7 @@
 	"wall_direction": "auto",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "2",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.16mm Optimal @Creality K2 Plus 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.16mm Optimal @Creality K2 Plus 0.4 nozzle.json
@@ -226,7 +226,7 @@
 	"tree_support_wall_count": "0",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "2",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.16mm Optimal @Creality K2 Pro 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.16mm Optimal @Creality K2 Pro 0.4 nozzle.json
@@ -248,7 +248,7 @@
 	"wall_direction": "auto",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "2",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.16mm Optimal @Creality SPARKX i7 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.16mm Optimal @Creality SPARKX i7 0.4 nozzle.json
@@ -249,7 +249,7 @@
 	"wall_direction": "auto",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "2",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.16mm Standard @Creality K2 SE 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.16mm Standard @Creality K2 SE 0.4 nozzle.json
@@ -246,7 +246,7 @@
 	"wall_direction": "auto",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "2",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.18mm Detail @Creality K2 0.6 nozzle.json
+++ b/resources/profiles/Creality/process/0.18mm Detail @Creality K2 0.6 nozzle.json
@@ -25,7 +25,7 @@
 	"outer_wall_speed": "100",
 	"outer_wall_acceleration": "5000",
 	"inner_wall_acceleration": "5000",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_infill_order": "inner wall/outer wall/infill",
 	"line_width": "0.62",
 	"infill_direction": "45",

--- a/resources/profiles/Creality/process/0.18mm Detail @Creality K2 Plus 0.6 nozzle.json
+++ b/resources/profiles/Creality/process/0.18mm Detail @Creality K2 Plus 0.6 nozzle.json
@@ -226,7 +226,7 @@
 	"tree_support_wall_count": "0",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "2",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.18mm Detail @Creality K2 Pro 0.6 nozzle.json
+++ b/resources/profiles/Creality/process/0.18mm Detail @Creality K2 Pro 0.6 nozzle.json
@@ -25,7 +25,7 @@
 	"outer_wall_speed": "100",
 	"outer_wall_acceleration": "5000",
 	"inner_wall_acceleration": "5000",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_infill_order": "inner wall/outer wall/infill",
 	"line_width": "0.62",
 	"infill_direction": "45",

--- a/resources/profiles/Creality/process/0.1mm Standard @Creality Hi 0.2 nozzle.json
+++ b/resources/profiles/Creality/process/0.1mm Standard @Creality Hi 0.2 nozzle.json
@@ -248,7 +248,7 @@
 	"wall_direction": "auto",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "4",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.20mm High Quality @Creality K2 Plus 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.20mm High Quality @Creality K2 Plus 0.4 nozzle.json
@@ -249,7 +249,7 @@
 	"wall_direction": "auto",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "2",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.20mm Standard @Creality Ender-3 V4 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.20mm Standard @Creality Ender-3 V4 0.4 nozzle.json
@@ -246,7 +246,7 @@
 	"wall_direction": "auto",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "2",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.20mm Standard @Creality Hi 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.20mm Standard @Creality Hi 0.4 nozzle.json
@@ -253,7 +253,7 @@
 	"wall_direction": "auto",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",
 	"wall_transition_filter_deviation": "25%",

--- a/resources/profiles/Creality/process/0.20mm Standard @Creality K1 (0.4 nozzle).json
+++ b/resources/profiles/Creality/process/0.20mm Standard @Creality K1 (0.4 nozzle).json
@@ -251,7 +251,7 @@
 	"wall_direction": "auto",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",
 	"wall_transition_filter_deviation": "25%",

--- a/resources/profiles/Creality/process/0.20mm Standard @Creality K1 Max_CFS-C 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.20mm Standard @Creality K1 Max_CFS-C 0.4 nozzle.json
@@ -246,7 +246,7 @@
 	"wall_direction": "auto",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "2",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.20mm Standard @Creality K1 SE 0.4.json
+++ b/resources/profiles/Creality/process/0.20mm Standard @Creality K1 SE 0.4.json
@@ -251,7 +251,7 @@
 	"wall_direction": "auto",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",
 	"wall_transition_filter_deviation": "25%",

--- a/resources/profiles/Creality/process/0.20mm Standard @Creality K1 SE_CFS-C 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.20mm Standard @Creality K1 SE_CFS-C 0.4 nozzle.json
@@ -246,7 +246,7 @@
 	"wall_direction": "auto",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "2",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.20mm Standard @Creality K1C 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.20mm Standard @Creality K1C 0.4 nozzle.json
@@ -251,7 +251,7 @@
 	"wall_direction": "auto",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",
 	"wall_transition_filter_deviation": "25%",

--- a/resources/profiles/Creality/process/0.20mm Standard @Creality K1C_CFS-C 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.20mm Standard @Creality K1C_CFS-C 0.4 nozzle.json
@@ -246,7 +246,7 @@
 	"wall_direction": "auto",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "2",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.20mm Standard @Creality K1Max (0.4 nozzle).json
+++ b/resources/profiles/Creality/process/0.20mm Standard @Creality K1Max (0.4 nozzle).json
@@ -251,7 +251,7 @@
 	"wall_direction": "auto",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",
 	"wall_transition_filter_deviation": "25%",

--- a/resources/profiles/Creality/process/0.20mm Standard @Creality K1_CFS-C 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.20mm Standard @Creality K1_CFS-C 0.4 nozzle.json
@@ -246,7 +246,7 @@
 	"wall_direction": "auto",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "2",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.20mm Standard @Creality K2 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.20mm Standard @Creality K2 0.4 nozzle.json
@@ -254,7 +254,7 @@
 	"wall_filament": "1",
 	"outer_wall_filament_id": "0",
 	"inner_wall_filament_id": "0",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "2",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.20mm Standard @Creality K2 Plus 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.20mm Standard @Creality K2 Plus 0.4 nozzle.json
@@ -230,7 +230,7 @@
 	"tree_support_top_rate": "30%",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",
 	"wall_transition_filter_deviation": "25%",

--- a/resources/profiles/Creality/process/0.20mm Standard @Creality K2 Pro 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.20mm Standard @Creality K2 Pro 0.4 nozzle.json
@@ -25,7 +25,7 @@
 	"outer_wall_speed": "200",
 	"outer_wall_acceleration": "5000",
 	"inner_wall_acceleration": "5000",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"line_width": "0.42",
 	"infill_direction": "45",
 	"sparse_infill_density": "15",

--- a/resources/profiles/Creality/process/0.20mm Standard @Creality K2 SE 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.20mm Standard @Creality K2 SE 0.4 nozzle.json
@@ -246,7 +246,7 @@
 	"wall_direction": "auto",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "2",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.20mm Standard @Creality SPARKX i7 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.20mm Standard @Creality SPARKX i7 0.4 nozzle.json
@@ -252,7 +252,7 @@
 	"wall_direction": "auto",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "2",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.20mm Strength @Creality K2 Plus 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.20mm Strength @Creality K2 Plus 0.4 nozzle.json
@@ -226,7 +226,7 @@
 	"tree_support_wall_count": "0",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "6",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.24mm Detail @Creality K2 0.8 nozzle.json
+++ b/resources/profiles/Creality/process/0.24mm Detail @Creality K2 0.8 nozzle.json
@@ -25,7 +25,7 @@
 	"outer_wall_speed": "100",
 	"outer_wall_acceleration": "5000",
 	"inner_wall_acceleration": "5000",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_infill_order": "inner wall/outer wall/infill",
 	"line_width": "0.82",
 	"infill_direction": "45",

--- a/resources/profiles/Creality/process/0.24mm Detail @Creality K2 Plus 0.8 nozzle.json
+++ b/resources/profiles/Creality/process/0.24mm Detail @Creality K2 Plus 0.8 nozzle.json
@@ -224,7 +224,7 @@
 	"tree_support_wall_count": "0",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "2",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.24mm Detail @Creality K2 Pro 0.8 nozzle.json
+++ b/resources/profiles/Creality/process/0.24mm Detail @Creality K2 Pro 0.8 nozzle.json
@@ -25,7 +25,7 @@
 	"outer_wall_speed": "100",
 	"outer_wall_acceleration": "5000",
 	"inner_wall_acceleration": "5000",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_infill_order": "inner wall/outer wall/infill",
 	"line_width": "0.82",
 	"infill_direction": "45",

--- a/resources/profiles/Creality/process/0.24mm Draft @Creality Ender-3 V4 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.24mm Draft @Creality Ender-3 V4 0.4 nozzle.json
@@ -246,7 +246,7 @@
 	"wall_direction": "auto",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "2",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.24mm Draft @Creality Hi 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.24mm Draft @Creality Hi 0.4 nozzle.json
@@ -247,7 +247,7 @@
 	"wall_direction": "auto",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "2",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.24mm Draft @Creality K1 (0.4 nozzle).json
+++ b/resources/profiles/Creality/process/0.24mm Draft @Creality K1 (0.4 nozzle).json
@@ -249,7 +249,7 @@
 	"wall_direction": "auto",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "2",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.24mm Draft @Creality K1 Max_CFS-C 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.24mm Draft @Creality K1 Max_CFS-C 0.4 nozzle.json
@@ -248,7 +248,7 @@
 	"wall_direction": "auto",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "2",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.24mm Draft @Creality K1 SE 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.24mm Draft @Creality K1 SE 0.4 nozzle.json
@@ -247,7 +247,7 @@
 	"wall_direction": "auto",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "2",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.24mm Draft @Creality K1 SE_CFS-C 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.24mm Draft @Creality K1 SE_CFS-C 0.4 nozzle.json
@@ -246,7 +246,7 @@
 	"wall_direction": "auto",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "2",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.24mm Draft @Creality K1C 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.24mm Draft @Creality K1C 0.4 nozzle.json
@@ -249,7 +249,7 @@
 	"wall_direction": "auto",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "2",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.24mm Draft @Creality K1C_CFS-C 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.24mm Draft @Creality K1C_CFS-C 0.4 nozzle.json
@@ -248,7 +248,7 @@
 	"wall_direction": "auto",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "2",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.24mm Draft @Creality K1Max (0.4 nozzle).json
+++ b/resources/profiles/Creality/process/0.24mm Draft @Creality K1Max (0.4 nozzle).json
@@ -249,7 +249,7 @@
 	"wall_direction": "auto",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "2",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.24mm Draft @Creality K1_CFS-C 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.24mm Draft @Creality K1_CFS-C 0.4 nozzle.json
@@ -248,7 +248,7 @@
 	"wall_direction": "auto",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "2",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.24mm Draft @Creality K2 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.24mm Draft @Creality K2 0.4 nozzle.json
@@ -249,7 +249,7 @@
 	"wall_direction": "auto",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "2",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.24mm Draft @Creality K2 Plus 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.24mm Draft @Creality K2 Plus 0.4 nozzle.json
@@ -226,7 +226,7 @@
 	"tree_support_wall_count": "0",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "2",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.24mm Draft @Creality K2 Pro 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.24mm Draft @Creality K2 Pro 0.4 nozzle.json
@@ -249,7 +249,7 @@
 	"wall_direction": "auto",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "2",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.24mm Draft @Creality SPARKX i7 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.24mm Draft @Creality SPARKX i7 0.4 nozzle.json
@@ -249,7 +249,7 @@
 	"wall_direction": "auto",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "2",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.24mm Optimal @Creality K2 0.6 nozzle.json
+++ b/resources/profiles/Creality/process/0.24mm Optimal @Creality K2 0.6 nozzle.json
@@ -25,7 +25,7 @@
 	"outer_wall_speed": "100",
 	"outer_wall_acceleration": "5000",
 	"inner_wall_acceleration": "5000",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_infill_order": "inner wall/outer wall/infill",
 	"line_width": "0.62",
 	"infill_direction": "45",

--- a/resources/profiles/Creality/process/0.24mm Optimal @Creality K2 Plus 0.6 nozzle.json
+++ b/resources/profiles/Creality/process/0.24mm Optimal @Creality K2 Plus 0.6 nozzle.json
@@ -224,7 +224,7 @@
 	"tree_support_wall_count": "0",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "2",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.24mm Optimal @Creality K2 Pro 0.6 nozzle.json
+++ b/resources/profiles/Creality/process/0.24mm Optimal @Creality K2 Pro 0.6 nozzle.json
@@ -25,7 +25,7 @@
 	"outer_wall_speed": "100",
 	"outer_wall_acceleration": "5000",
 	"inner_wall_acceleration": "5000",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_infill_order": "inner wall/outer wall/infill",
 	"line_width": "0.62",
 	"infill_direction": "45",

--- a/resources/profiles/Creality/process/0.24mm Standard @Creality K2 SE 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.24mm Standard @Creality K2 SE 0.4 nozzle.json
@@ -246,7 +246,7 @@
 	"wall_direction": "auto",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "2",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.28mm SuperDraft @Creality Ender-3 V4 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.28mm SuperDraft @Creality Ender-3 V4 0.4 nozzle.json
@@ -246,7 +246,7 @@
 	"wall_direction": "auto",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "2",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.28mm SuperDraft @Creality Hi 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.28mm SuperDraft @Creality Hi 0.4 nozzle.json
@@ -247,7 +247,7 @@
 	"wall_direction": "auto",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "2",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.28mm SuperDraft @Creality K2 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.28mm SuperDraft @Creality K2 0.4 nozzle.json
@@ -249,7 +249,7 @@
 	"wall_direction": "auto",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "2",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.28mm SuperDraft @Creality K2 Plus 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.28mm SuperDraft @Creality K2 Plus 0.4 nozzle.json
@@ -226,7 +226,7 @@
 	"tree_support_wall_count": "0",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "2",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.28mm SuperDraft @Creality K2 Pro 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.28mm SuperDraft @Creality K2 Pro 0.4 nozzle.json
@@ -249,7 +249,7 @@
 	"wall_direction": "auto",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "2",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.28mm SuperDraft @Creality SPARKX i7 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.28mm SuperDraft @Creality SPARKX i7 0.4 nozzle.json
@@ -249,7 +249,7 @@
 	"wall_direction": "auto",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "2",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.2mm Standard @Creality Ender-5 Max 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.2mm Standard @Creality Ender-5 Max 0.4 nozzle.json
@@ -244,7 +244,7 @@
 	"wall_direction": "auto",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "2",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.2mm Ultrafast @Creality Ender-5 Max 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.2mm Ultrafast @Creality Ender-5 Max 0.4 nozzle.json
@@ -246,7 +246,7 @@
 	"wall_direction": "auto",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "2",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.30mm Standard @Creality Ender-5 Max 0.6 nozzle.json
+++ b/resources/profiles/Creality/process/0.30mm Standard @Creality Ender-5 Max 0.6 nozzle.json
@@ -244,7 +244,7 @@
 	"wall_direction": "auto",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "2",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.30mm Standard @Creality Hi 0.6 nozzle.json
+++ b/resources/profiles/Creality/process/0.30mm Standard @Creality Hi 0.6 nozzle.json
@@ -250,7 +250,7 @@
 	"wall_direction": "auto",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",
 	"wall_transition_filter_deviation": "25%",

--- a/resources/profiles/Creality/process/0.30mm Standard @Creality K1 (0.6 nozzle).json
+++ b/resources/profiles/Creality/process/0.30mm Standard @Creality K1 (0.6 nozzle).json
@@ -249,7 +249,7 @@
 	"wall_direction": "auto",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",
 	"wall_transition_filter_deviation": "25%",

--- a/resources/profiles/Creality/process/0.30mm Standard @Creality K1 SE 0.6 nozzle.json
+++ b/resources/profiles/Creality/process/0.30mm Standard @Creality K1 SE 0.6 nozzle.json
@@ -245,7 +245,7 @@
 	"wall_direction": "auto",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "2",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.30mm Standard @Creality K1C 0.6 nozzle.json
+++ b/resources/profiles/Creality/process/0.30mm Standard @Creality K1C 0.6 nozzle.json
@@ -249,7 +249,7 @@
 	"wall_direction": "auto",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",
 	"wall_transition_filter_deviation": "25%",

--- a/resources/profiles/Creality/process/0.30mm Standard @Creality K1Max (0.6 nozzle).json
+++ b/resources/profiles/Creality/process/0.30mm Standard @Creality K1Max (0.6 nozzle).json
@@ -249,7 +249,7 @@
 	"wall_direction": "auto",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",
 	"wall_transition_filter_deviation": "25%",

--- a/resources/profiles/Creality/process/0.30mm Standard @Creality K2 0.6 nozzle.json
+++ b/resources/profiles/Creality/process/0.30mm Standard @Creality K2 0.6 nozzle.json
@@ -229,7 +229,7 @@
 	"wall_filament": "1",
 	"outer_wall_filament_id": "0",
 	"inner_wall_filament_id": "0",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "2",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.30mm Standard @Creality K2 Plus 0.6 nozzle.json
+++ b/resources/profiles/Creality/process/0.30mm Standard @Creality K2 Plus 0.6 nozzle.json
@@ -228,7 +228,7 @@
 	"tree_support_top_rate": "30%",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",
 	"wall_transition_filter_deviation": "25%",

--- a/resources/profiles/Creality/process/0.30mm Standard @Creality K2 Pro 0.6 nozzle.json
+++ b/resources/profiles/Creality/process/0.30mm Standard @Creality K2 Pro 0.6 nozzle.json
@@ -25,7 +25,7 @@
 	"outer_wall_speed": "100",
 	"outer_wall_acceleration": "5000",
 	"inner_wall_acceleration": "5000",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"line_width": "0.62",
 	"infill_direction": "45",
 	"sparse_infill_density": "15",

--- a/resources/profiles/Creality/process/0.30mm Strength @Creality K2 Plus 0.6 nozzle.json
+++ b/resources/profiles/Creality/process/0.30mm Strength @Creality K2 Plus 0.6 nozzle.json
@@ -224,7 +224,7 @@
 	"tree_support_wall_count": "0",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "6",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.32mm Optimal @Creality K2 0.8 nozzle.json
+++ b/resources/profiles/Creality/process/0.32mm Optimal @Creality K2 0.8 nozzle.json
@@ -25,7 +25,7 @@
 	"outer_wall_speed": "100",
 	"outer_wall_acceleration": "5000",
 	"inner_wall_acceleration": "5000",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_infill_order": "inner wall/outer wall/infill",
 	"line_width": "0.82",
 	"infill_direction": "45",

--- a/resources/profiles/Creality/process/0.32mm Optimal @Creality K2 Plus 0.8 nozzle.json
+++ b/resources/profiles/Creality/process/0.32mm Optimal @Creality K2 Plus 0.8 nozzle.json
@@ -226,7 +226,7 @@
 	"tree_support_wall_count": "0",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "2",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.32mm Optimal @Creality K2 Pro 0.8 nozzle.json
+++ b/resources/profiles/Creality/process/0.32mm Optimal @Creality K2 Pro 0.8 nozzle.json
@@ -25,7 +25,7 @@
 	"outer_wall_speed": "100",
 	"outer_wall_acceleration": "5000",
 	"inner_wall_acceleration": "5000",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_infill_order": "inner wall/outer wall/infill",
 	"line_width": "0.82",
 	"infill_direction": "45",

--- a/resources/profiles/Creality/process/0.36mm Draft @Creality K2 0.6 nozzle.json
+++ b/resources/profiles/Creality/process/0.36mm Draft @Creality K2 0.6 nozzle.json
@@ -25,7 +25,7 @@
 	"outer_wall_speed": "100",
 	"outer_wall_acceleration": "5000",
 	"inner_wall_acceleration": "5000",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_infill_order": "inner wall/outer wall/infill",
 	"line_width": "0.62",
 	"infill_direction": "45",

--- a/resources/profiles/Creality/process/0.36mm Draft @Creality K2 Plus 0.6 nozzle.json
+++ b/resources/profiles/Creality/process/0.36mm Draft @Creality K2 Plus 0.6 nozzle.json
@@ -224,7 +224,7 @@
 	"tree_support_wall_count": "0",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "2",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.36mm Draft @Creality K2 Pro 0.6 nozzle.json
+++ b/resources/profiles/Creality/process/0.36mm Draft @Creality K2 Pro 0.6 nozzle.json
@@ -25,7 +25,7 @@
 	"outer_wall_speed": "100",
 	"outer_wall_acceleration": "5000",
 	"inner_wall_acceleration": "5000",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_infill_order": "inner wall/outer wall/infill",
 	"line_width": "0.62",
 	"infill_direction": "45",

--- a/resources/profiles/Creality/process/0.40mm Standard @Creality Ender-5 Max 0.8 nozzle.json
+++ b/resources/profiles/Creality/process/0.40mm Standard @Creality Ender-5 Max 0.8 nozzle.json
@@ -244,7 +244,7 @@
 	"wall_direction": "auto",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "2",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.40mm Standard @Creality Hi 0.8 nozzle.json
+++ b/resources/profiles/Creality/process/0.40mm Standard @Creality Hi 0.8 nozzle.json
@@ -246,7 +246,7 @@
 	"wall_direction": "auto",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "2",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.40mm Standard @Creality K1 (0.8 nozzle).json
+++ b/resources/profiles/Creality/process/0.40mm Standard @Creality K1 (0.8 nozzle).json
@@ -248,7 +248,7 @@
 	"wall_direction": "auto",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",
 	"wall_transition_filter_deviation": "25%",

--- a/resources/profiles/Creality/process/0.40mm Standard @Creality K1C 0.8 nozzle.json
+++ b/resources/profiles/Creality/process/0.40mm Standard @Creality K1C 0.8 nozzle.json
@@ -248,7 +248,7 @@
 	"wall_direction": "auto",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",
 	"wall_transition_filter_deviation": "25%",

--- a/resources/profiles/Creality/process/0.40mm Standard @Creality K1Max (0.8 nozzle).json
+++ b/resources/profiles/Creality/process/0.40mm Standard @Creality K1Max (0.8 nozzle).json
@@ -248,7 +248,7 @@
 	"wall_direction": "auto",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",
 	"wall_transition_filter_deviation": "25%",

--- a/resources/profiles/Creality/process/0.40mm Standard @Creality K2 0.8 nozzle.json
+++ b/resources/profiles/Creality/process/0.40mm Standard @Creality K2 0.8 nozzle.json
@@ -229,7 +229,7 @@
 	"wall_filament": "1",
 	"outer_wall_filament_id": "0",
 	"inner_wall_filament_id": "0",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "2",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.40mm Standard @Creality K2 Plus 0.8 nozzle.json
+++ b/resources/profiles/Creality/process/0.40mm Standard @Creality K2 Plus 0.8 nozzle.json
@@ -228,7 +228,7 @@
 	"tree_support_top_rate": "30%",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",
 	"wall_transition_filter_deviation": "25%",

--- a/resources/profiles/Creality/process/0.40mm Standard @Creality K2 Pro 0.8 nozzle.json
+++ b/resources/profiles/Creality/process/0.40mm Standard @Creality K2 Pro 0.8 nozzle.json
@@ -25,7 +25,7 @@
 	"outer_wall_speed": "100",
 	"outer_wall_acceleration": "3000",
 	"inner_wall_acceleration": "3000",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"line_width": "0.82",
 	"infill_direction": "45",
 	"sparse_infill_density": "15",

--- a/resources/profiles/Creality/process/0.40mm Strength @Creality K2 Plus 0.8 nozzle.json
+++ b/resources/profiles/Creality/process/0.40mm Strength @Creality K2 Plus 0.8 nozzle.json
@@ -224,7 +224,7 @@
 	"tree_support_wall_count": "0",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "6",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.42mm SuperDraft @Creality K2 0.6 nozzle.json
+++ b/resources/profiles/Creality/process/0.42mm SuperDraft @Creality K2 0.6 nozzle.json
@@ -25,7 +25,7 @@
 	"outer_wall_speed": "100",
 	"outer_wall_acceleration": "5000",
 	"inner_wall_acceleration": "5000",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_infill_order": "inner wall/outer wall/infill",
 	"line_width": "0.62",
 	"infill_direction": "45",

--- a/resources/profiles/Creality/process/0.42mm SuperDraft @Creality K2 Plus 0.6 nozzle.json
+++ b/resources/profiles/Creality/process/0.42mm SuperDraft @Creality K2 Plus 0.6 nozzle.json
@@ -226,7 +226,7 @@
 	"tree_support_wall_count": "0",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "2",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.42mm SuperDraft @Creality K2 Pro 0.6 nozzle.json
+++ b/resources/profiles/Creality/process/0.42mm SuperDraft @Creality K2 Pro 0.6 nozzle.json
@@ -25,7 +25,7 @@
 	"outer_wall_speed": "100",
 	"outer_wall_acceleration": "5000",
 	"inner_wall_acceleration": "5000",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_infill_order": "inner wall/outer wall/infill",
 	"line_width": "0.62",
 	"infill_direction": "45",

--- a/resources/profiles/Creality/process/0.48mm Draft @Creality K2 0.8 nozzle.json
+++ b/resources/profiles/Creality/process/0.48mm Draft @Creality K2 0.8 nozzle.json
@@ -25,7 +25,7 @@
 	"outer_wall_speed": "100",
 	"outer_wall_acceleration": "5000",
 	"inner_wall_acceleration": "5000",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_infill_order": "inner wall/outer wall/infill",
 	"line_width": "0.82",
 	"infill_direction": "45",

--- a/resources/profiles/Creality/process/0.48mm Draft @Creality K2 Plus 0.8 nozzle.json
+++ b/resources/profiles/Creality/process/0.48mm Draft @Creality K2 Plus 0.8 nozzle.json
@@ -226,7 +226,7 @@
 	"tree_support_wall_count": "0",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "2",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.48mm Draft @Creality K2 Pro 0.8 nozzle.json
+++ b/resources/profiles/Creality/process/0.48mm Draft @Creality K2 Pro 0.8 nozzle.json
@@ -25,7 +25,7 @@
 	"outer_wall_speed": "100",
 	"outer_wall_acceleration": "5000",
 	"inner_wall_acceleration": "5000",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_infill_order": "inner wall/outer wall/infill",
 	"line_width": "0.82",
 	"infill_direction": "45",

--- a/resources/profiles/Creality/process/0.56mm SuperDraft @Creality K2 0.8 nozzle.json
+++ b/resources/profiles/Creality/process/0.56mm SuperDraft @Creality K2 0.8 nozzle.json
@@ -25,7 +25,7 @@
 	"outer_wall_speed": "100",
 	"outer_wall_acceleration": "5000",
 	"inner_wall_acceleration": "5000",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_infill_order": "inner wall/outer wall/infill",
 	"line_width": "0.82",
 	"infill_direction": "45",

--- a/resources/profiles/Creality/process/0.56mm SuperDraft @Creality K2 Plus 0.8 nozzle.json
+++ b/resources/profiles/Creality/process/0.56mm SuperDraft @Creality K2 Plus 0.8 nozzle.json
@@ -226,7 +226,7 @@
 	"tree_support_wall_count": "0",
 	"wall_distribution_count": "1",
 	"wall_filament": "1",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_loops": "2",
 	"wall_sequence": "inner wall/outer wall",
 	"wall_transition_angle": "10",

--- a/resources/profiles/Creality/process/0.56mm SuperDraft @Creality K2 Pro 0.8 nozzle.json
+++ b/resources/profiles/Creality/process/0.56mm SuperDraft @Creality K2 Pro 0.8 nozzle.json
@@ -25,7 +25,7 @@
 	"outer_wall_speed": "100",
 	"outer_wall_acceleration": "5000",
 	"inner_wall_acceleration": "5000",
-	"wall_generator": "classic",
+	"wall_generator": "arachne",
 	"wall_infill_order": "inner wall/outer wall/infill",
 	"line_width": "0.82",
 	"infill_direction": "45",


### PR DESCRIPTION
# Change wall Generator to arachne for Creality Printers

> Follow- up to PR https://github.com/OrcaSlicer/OrcaSlicer/pull/13947

Some profiles were missed in the original PR. So this PR addresses this and changes the wall generator to Arachne for all Creality Printers to improve print quality and details.

## Tests

validated the profiles, checking everything works


