### PR TITLE
Fix Arch Linux dependency installation (gstreamermm, webkit2gtk, -Syy)

### DIFF
--- a/scripts/linux.d/arch
+++ b/scripts/linux.d/arch
@@ -14,7 +14,6 @@ export REQUIRED_DEV_PACKAGES=(
     glew
     gst-plugins-good
     gstreamer
-    gstreamermm
     gtk3
     libmspack
     libsecret
@@ -24,7 +23,7 @@ export REQUIRED_DEV_PACKAGES=(
     openssl
     texinfo
     wayland-protocols
-    webkit2gtk
+    webkit2gtk-4.1
     wget
 )
 
@@ -37,7 +36,7 @@ then
     done
 
     if [[ "${#NEEDED_PKGS[*]}" -gt 0 ]]; then
-        sudo pacman -Syy --noconfirm "${NEEDED_PKGS[@]}"
+        sudo pacman -Syu --noconfirm "${NEEDED_PKGS[@]}"
     fi
     echo -e "done\n"
     exit 0


### PR DESCRIPTION
## Problem

`./build_linux.sh -u` fails on current Arch Linux / Arch-based distros (e.g. CachyOS) because `scripts/linux.d/arch` lists packages that are no longer available in the official repositories:

```
error: target not found: gstreamermm
error: target not found: webkit2gtk
```

## Changes

- **Drop `gstreamermm`** — it was removed from the official Arch repos (AUR only) and is not referenced anywhere in the OrcaSlicer build; the build uses plain `gstreamer` (still listed).
- **`webkit2gtk` → `webkit2gtk-4.1`** — upstream Arch renamed the package; `webkit2gtk-4.1` is the current provider used by wxWidgets' WebView.
- **`pacman -Syy` → `pacman -Syu`** — avoids the partial-upgrade pattern that Arch officially discourages on a rolling-release distro.

## Verification

With these changes, `./build_linux.sh -u` resolves all dependencies on CachyOS (ID_LIKE=arch), and a full `./build_linux.sh -ds` completes successfully (orca-slicer binary built, exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)