### PR TITLE
Fix Unit Tests CI job that silently ran zero tests

### DIFF
--- a/scripts/run_unit_tests.sh
+++ b/scripts/run_unit_tests.sh
@@ -9,4 +9,6 @@ ROOT_DIR="$(dirname "$0")/.."
 
 cd "${ROOT_DIR}" || exit 1
 
-ctest --test-dir build/tests -L "Http|PlaceholderParser" --output-junit "$(pwd)/ctest_results.xml" --output-on-failure -j
+# Run the whole suite, excluding tests tagged [NotWorking].
+# --no-tests=error fails the job if the filter matches nothing (instead of passing green).
+ctest --test-dir build/tests -LE "NotWorking" --no-tests=error --output-junit "$(pwd)/ctest_results.xml" --output-on-failure -j

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -47,6 +47,11 @@ function(orcaslicer_copy_test_dlls)
     endforeach()
 endfunction()
 
+# Register Catch2 tags as CTest labels so `ctest -L`/`-LE` can filter by tag.
+function(orcaslicer_discover_tests TARGET)
+    catch_discover_tests(${TARGET} ADD_TAGS_AS_LABELS)
+endfunction()
+
 add_subdirectory(libnest2d)
 add_subdirectory(libslic3r)
 add_subdirectory(slic3rutils)

--- a/tests/fff_print/CMakeLists.txt
+++ b/tests/fff_print/CMakeLists.txt
@@ -21,4 +21,4 @@ set_property(TARGET ${_TEST_NAME}_tests PROPERTY FOLDER "tests")
 
 orcaslicer_copy_test_dlls()
 
-catch_discover_tests(${_TEST_NAME}_tests)
+orcaslicer_discover_tests(${_TEST_NAME}_tests)

--- a/tests/libnest2d/CMakeLists.txt
+++ b/tests/libnest2d/CMakeLists.txt
@@ -10,4 +10,4 @@ set_property(TARGET ${_TEST_NAME}_tests PROPERTY FOLDER "tests")
 
 orcaslicer_copy_test_dlls()
 
-catch_discover_tests(${_TEST_NAME}_tests)
+orcaslicer_discover_tests(${_TEST_NAME}_tests)

--- a/tests/libslic3r/CMakeLists.txt
+++ b/tests/libslic3r/CMakeLists.txt
@@ -38,4 +38,4 @@ set_property(TARGET ${_TEST_NAME}_tests PROPERTY FOLDER "tests")
 
 orcaslicer_copy_test_dlls()
 
-catch_discover_tests(${_TEST_NAME}_tests)
+orcaslicer_discover_tests(${_TEST_NAME}_tests)

--- a/tests/sla_print/CMakeLists.txt
+++ b/tests/sla_print/CMakeLists.txt
@@ -9,4 +9,4 @@ set_property(TARGET ${_TEST_NAME}_tests PROPERTY FOLDER "tests")
 
 orcaslicer_copy_test_dlls()
 
-catch_discover_tests(${_TEST_NAME}_tests)
+orcaslicer_discover_tests(${_TEST_NAME}_tests)

--- a/tests/slic3rutils/CMakeLists.txt
+++ b/tests/slic3rutils/CMakeLists.txt
@@ -12,4 +12,4 @@ set_property(TARGET ${_TEST_NAME}_tests PROPERTY FOLDER "tests")
 
 orcaslicer_copy_test_dlls()
 
-catch_discover_tests(${_TEST_NAME}_tests)
+orcaslicer_discover_tests(${_TEST_NAME}_tests)

--- a/tests/slic3rutils/slic3rutils_tests_main.cpp
+++ b/tests/slic3rutils/slic3rutils_tests_main.cpp
@@ -53,7 +53,8 @@ TEST_CASE("Check SSL certificates paths", "[Http][NotWorking]") {
     REQUIRE(status == 200);
 }
 
-TEST_CASE("Orca cloud flat session resolves display name consistently", "[OrcaCloudServiceAgent]")
+// [NotWorking]: OrcaCloudServiceAgent ctor segfaults headless (wxStandardPaths::Get() -> null wxTheApp).
+TEST_CASE("Orca cloud flat session resolves display name consistently", "[OrcaCloudServiceAgent][NotWorking]")
 {
     CHECK(resolved_display_name(flat_session_json({
         {"username", "orca_username"},
@@ -81,7 +82,8 @@ TEST_CASE("Orca cloud flat session resolves display name consistently", "[OrcaCl
     })) == "orca_username");
 }
 
-TEST_CASE("Orca cloud nested session resolves display name consistently", "[OrcaCloudServiceAgent]")
+// [NotWorking]: see flat-session test above.
+TEST_CASE("Orca cloud nested session resolves display name consistently", "[OrcaCloudServiceAgent][NotWorking]")
 {
     CHECK(resolved_display_name(nested_session_json({
         {"username", "orca_username"},


### PR DESCRIPTION
# Description

The Unit Tests CI job has been passing **without running a single test since #11485 (2025-12-23)**. `scripts/run_unit_tests.sh` filters with `ctest -L "Http|PlaceholderParser"`, but `catch_discover_tests()` was called without `ADD_TAGS_AS_LABELS`, so Catch2 tags were never registered as CTest labels. The filter matched nothing, ctest printed `No tests were found!!!` and exited 0, and the job stayed green-but-empty.

**Fix**

* Register tags as CTest labels via a shared `orcaslicer_discover_tests()` wrapper (`ADD_TAGS_AS_LABELS`), used by all five test suites.
* Run the full suite excluding `[NotWorking]`: `ctest --test-dir build/tests -LE "NotWorking"`.
* Add `--no-tests=error` so the job fails if the filter ever matches zero tests again, instead of silently passing.

**`[NotWorking]` audit** (the tag finally has an effect, so I checked each one)

* 3 `[Http]` tests: require live network, only pass when the remote host is reachable.
* 2 libnest2d tests: genuinely broken, already `[.]` hidden so never discovered.
* 2 OrcaCloud tests (tagged `[NotWorking]` in this PR): segfault in the headless binary because the `OrcaCloudServiceAgent` constructor reaches `wxStandardPaths::Get()` and dereferences the null `wxTheApp`. Added in #13645 after the job went dark, so they had never actually run in CI.

# Screenshots/Recordings/Graphs

N/A (no UI changes).

## Tests

* Before: `ctest -L "Http|PlaceholderParser" -N` reported 0 tests.
* After: Linux CI runs 151 tests, all passing (previously `No tests were found!!!`).

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
