### PR TITLE
Launch troubleshoot center with clicking to dev button

### DIFF
--- a/src/slic3r/GUI/ParamsPanel.cpp
+++ b/src/slic3r/GUI/ParamsPanel.cpp
@@ -279,12 +279,9 @@ ParamsPanel::ParamsPanel( wxWindow* parent, wxWindowID id, const wxPoint& pos, c
         });
         m_mode_icon->SetToolTip(_L("Cycle settings visibility"));
         m_mode_view = new ModeSwitchButton(m_top_panel);
-        if (wxGetApp().get_mode() == comDevelop) {
-            m_mode_view->SetSelection(mode_to_selection(comExpert));
-            m_mode_view->Enable(false);
-        } else {
-            m_mode_view->SetSelection(mode_to_selection(wxGetApp().get_saved_mode()));
-        }
+        bool isDevMode = wxGetApp().get_mode() == comDevelop;
+        m_mode_view->SetSelection(mode_to_selection(isDevMode ? comExpert : wxGetApp().get_saved_mode()));
+        m_mode_view->SetDevMode(isDevMode);
 
         // BBS: new layout
         //m_search_btn = new ScalableButton(m_top_panel, wxID_ANY, "search", wxEmptyString, wxDefaultSize, wxDefaultPosition, wxBU_EXACTFIT | wxNO_BORDER, true);
@@ -653,13 +650,13 @@ void ParamsPanel::update_mode()
 
         if (app_mode == comDevelop) {
             mode_view->SetSelection(mode_to_selection(comExpert));
-            mode_view->Enable(false);
+            mode_view->SetDevMode(true);
             return;
         }
 
         mode_view->SetSelection(mode_to_selection(Slic3r::GUI::wxGetApp().get_saved_mode()));
-        if (!mode_view->IsEnabled())
-            mode_view->Enable();
+        if (mode_view->GetDevMode())
+            mode_view->SetDevMode(false);
     };
 
     sync_mode_view(m_mode_view);

--- a/src/slic3r/GUI/Widgets/SwitchButton.cpp
+++ b/src/slic3r/GUI/Widgets/SwitchButton.cpp
@@ -280,7 +280,7 @@ void ModeSwitchButton::SetSelection(int selection)
 
 void ModeSwitchButton::SelectAndNotify(int selection)
 {
-    if (!IsEnabled())
+    if (m_dev_mode || !IsEnabled())
         return;
 
     SetSelection(selection);
@@ -310,6 +310,14 @@ bool ModeSwitchButton::Enable(bool enable /* = true */)
     return changed;
 }
 
+void ModeSwitchButton::SetDevMode(bool enable /* = true */)
+{
+    if (enable != m_dev_mode){
+        m_dev_mode = enable;
+        Refresh();
+    }
+}
+
 void ModeSwitchButton::doRender(wxDC& dc)
 {
     const wxRect bounds = GetClientRect();
@@ -328,7 +336,7 @@ void ModeSwitchButton::doRender(wxDC& dc)
     dc.SetBrush(wxBrush(background_color.colorForStates(states)));
     dc.DrawRoundedRectangle(bounds, v_center);
 
-    if (m_enabled) {
+    if (!m_dev_mode) {
         double dot_dist = (bounds.width - bounds.height) * 0.50;
 
         // Track
@@ -368,6 +376,11 @@ void ModeSwitchButton::doRender(wxDC& dc)
 
 void ModeSwitchButton::mouseDown(wxMouseEvent& event)
 {
+    if (m_dev_mode){
+        Slic3r::GUI::wxGetApp().troubleshoot();
+        return;
+    }
+
     if (!IsEnabled()) {
         event.Skip();
         return;

--- a/src/slic3r/GUI/Widgets/SwitchButton.cpp
+++ b/src/slic3r/GUI/Widgets/SwitchButton.cpp
@@ -262,6 +262,7 @@ ModeSwitchButton::ModeSwitchButton(wxWindow* parent, wxWindowID id)
     m_tooltips[0] = _L("Simple settings");
     m_tooltips[1] = _L("Advanced settings");
     m_tooltips[2] = _L("Expert settings");
+    m_tooltips[3] = _L("Developer mode") + "\n" + _L("Launch troubleshoot center") + "...";
 
     Bind(wxEVT_LEFT_DOWN, &ModeSwitchButton::mouseDown, this);
     Bind(wxEVT_LEFT_UP, &ModeSwitchButton::mouseReleased, this);
@@ -314,6 +315,7 @@ void ModeSwitchButton::SetDevMode(bool enable /* = true */)
 {
     if (enable != m_dev_mode){
         m_dev_mode = enable;
+        update_tooltip();
         Refresh();
     }
 }
@@ -438,7 +440,10 @@ wxRect ModeSwitchButton::thumb_rect_for(int selection) const
 
 void ModeSwitchButton::update_tooltip()
 {
-    SetToolTip(m_tooltips[m_selection]);
+    if (m_dev_mode)
+        SetToolTip(m_tooltips[3]);
+    else
+        SetToolTip(m_tooltips[m_selection]);
 }
 
 MultiSwitchButton::MultiSwitchButton(wxWindow *parent, wxWindowID id, const wxPoint &pos, const wxSize &size, long style)

--- a/src/slic3r/GUI/Widgets/SwitchButton.hpp
+++ b/src/slic3r/GUI/Widgets/SwitchButton.hpp
@@ -63,6 +63,8 @@ public:
     void msw_rescale() { Rescale(); }
 
     bool Enable(bool enable = true) override;
+    void SetDevMode(bool enable = true);
+    bool GetDevMode() const {return m_dev_mode;};
 
 protected:
     void doRender(wxDC& dc) override;
@@ -79,6 +81,7 @@ private:
     int      m_selection { 0 };
     bool     m_pressed   { false };
     bool     m_enabled   { true };
+    bool     m_dev_mode  { false };
     wxString m_tooltips[3];
     StateColor dot_active;
     StateColor dot_dimmed;

--- a/src/slic3r/GUI/Widgets/SwitchButton.hpp
+++ b/src/slic3r/GUI/Widgets/SwitchButton.hpp
@@ -82,7 +82,7 @@ private:
     bool     m_pressed   { false };
     bool     m_enabled   { true };
     bool     m_dev_mode  { false };
-    wxString m_tooltips[3];
+    wxString   m_tooltips[4];
     StateColor dot_active;
     StateColor dot_dimmed;
     StateColor text_color;


### PR DESCRIPTION
Allows launching troubleshoot center with clicking dev button that allows;
• easy access to configuration folder
• packing project logs
• cleaning logs
• changing log level
etc.

Note. only added this function to dev button placed on sidebar. printer / filament settings dialogs not opens it