### PR TITLE
Fix (UI consistency/efficiency): Preview invalidated by settings change falls back to Prepare tab

### DIFF
--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -16743,6 +16743,12 @@ void Plater::on_config_change(const DynamicPrintConfig &config)
         this->p->schedule_background_process();
         update_title_dirty_status();
         p->schedule_auto_reslice_if_needed();
+        
+        // If config change will cause view to revert to raw geometry,
+        // switch to Prepare tab to avoid confusing intermediate state
+        if (update_scheduled && is_preview_shown()) {
+            wxGetApp().mainframe->select_tab(MainFrame::tp3DEditor);
+        }
     }
 }
 


### PR DESCRIPTION
When editing print settings after slicing while on the Preview tab, the view shows raw geometry instead of sliced layers but stays on the Preview tab. This creates a confusing intermediate state where users see their model without layer data even though they're in "Preview" mode. To refresh the preview, users must toggle to some other tab and then back to Preview, or they can click on a plate thumbnail (but that resets the view, which may not be preferable).

This happens because config changes invalidate the slice results, but the code doesn't switch tabs or trigger auto-reslice. The Preview canvas falls through to "pre-gcode preview" mode showing only raw geometry with no layer sliders. My fix detects when slice results become invalid during active editing and automatically switches back to the Prepare tab. Config edits clearly punt the view back to Prepare (instead of the "invalid" intermediate state, which I believe was only ever intended to be a transition while slicing).

I'm adding a check in `Plater::on_config_change()` that runs after scheduling auto-reslice. If the current plate's slice results are now invalid AND the user is viewing the Preview tab, it switches to the Prepare tab. This matches existing patterns in the codebase where tabs are switched based on slice validity (file loading, validation errors, etc.).

The fix reduces clicks from 3 to 1 (or `Tab` presses from 2 to 1) while also making it much clearer to the user that they are no longer in Preview mode after their config change, as the view will now fully switch back to Prepare instead of landing in the intermediate state. The typical user would click 2-3 times after a config edit (once on Preview, which does nothing, then Prepare and back to Preview). Now they clearly see they are in Prepare after their edit and can click once on Preview (or press `Tab` once) to re-slice the plate with their change.

Changes:
- Added automatic tab switch to Prepare when slice invalidated by config edit
- Check placed after `schedule_auto_reslice_if_needed()` in `Plater::on_config_change()`
- Only triggers when `is_slice_result_valid()` returns false while on Preview tab
- Follows existing precedent for state-based tab switching

Files modified:
- src/slic3r/GUI/Plater.cpp
