### PR TITLE
Option for Support Interface Filament only where necessary

### DIFF
--- a/src/libslic3r/ExtrusionEntity.hpp
+++ b/src/libslic3r/ExtrusionEntity.hpp
@@ -111,7 +111,8 @@ public:
     virtual bool can_reverse() const { return true; }
     virtual bool can_sort() const { return true; }//BBS: only used in ExtrusionEntityCollection
     virtual void set_reverse() {}
-    virtual void attempt_set_extrusion_role(ExtrusionRole extrusion_role) = 0;
+    // Set the extrusion role of everything inside this ExtrusionEntity
+    virtual void set_extrusion_role_all(ExtrusionRole extrusion_role) = 0;
     virtual ExtrusionEntity* clone() const = 0;
     // Create a new object, initialize it with this object using the move semantics.
     virtual ExtrusionEntity* clone_move() = 0;
@@ -298,7 +299,7 @@ public:
     bool is_force_no_extrusion() const { return m_no_extrusion; }
     void set_force_no_extrusion(bool no_extrusion) { m_no_extrusion = no_extrusion; }
     void set_extrusion_role(ExtrusionRole extrusion_role) { m_role = extrusion_role; }
-    void attempt_set_extrusion_role(ExtrusionRole extrusion_role) override { set_extrusion_role(extrusion_role); }
+    void set_extrusion_role_all(ExtrusionRole extrusion_role) override { set_extrusion_role(extrusion_role); }
     void set_reverse() override { m_can_reverse = false; }
     bool can_reverse() const override { return m_can_reverse; }
 
@@ -415,8 +416,8 @@ public:
     bool empty() const { return this->paths.empty(); }
     double length() const override;
     ExtrusionRole role() const override { return this->paths.empty() ? erNone : this->paths.front().role(); }
-    void attempt_set_extrusion_role(ExtrusionRole new_role) override {
-        for (ExtrusionPath path : this->paths) path.attempt_set_extrusion_role(new_role);
+    void set_extrusion_role_all(ExtrusionRole new_role) override {
+        for (ExtrusionPath path : this->paths) path.set_extrusion_role_all(new_role);
     }
     // Produce a list of 2D polygons covered by the extruded paths, offsetted by the extrusion width.
     // Increase the offset by scaled_epsilon to achieve an overlap, so a union will produce no gaps.
@@ -490,8 +491,8 @@ public:
     ExtrusionRole role() const override { return this->paths.empty() ? erNone : this->paths.front().role(); }
     ExtrusionLoopRole loop_role() const { return m_loop_role; }
     void set_loop_role(ExtrusionLoopRole role) {    m_loop_role = role; }
-    void attempt_set_extrusion_role(ExtrusionRole new_role) override {
-        for (ExtrusionPath path : this->paths) path.attempt_set_extrusion_role(new_role);
+    void set_extrusion_role_all(ExtrusionRole new_role) override {
+        for (ExtrusionPath path : this->paths) path.set_extrusion_role_all(new_role);
     }
     // Produce a list of 2D polygons covered by the extruded paths, offsetted by the extrusion width.
     // Increase the offset by scaled_epsilon to achieve an overlap, so a union will produce no gaps.

--- a/src/libslic3r/ExtrusionEntity.hpp
+++ b/src/libslic3r/ExtrusionEntity.hpp
@@ -102,6 +102,10 @@ inline bool is_bridge(ExtrusionRole role) {
         || role == erOverhangPerimeter;
 }
 
+inline bool is_support_interface(ExtrusionRole role) {
+    return role == erSupportMaterialInterface;
+}
+
 class ExtrusionEntity
 {
 public:
@@ -111,6 +115,7 @@ public:
     virtual bool can_reverse() const { return true; }
     virtual bool can_sort() const { return true; }//BBS: only used in ExtrusionEntityCollection
     virtual void set_reverse() {}
+    virtual void attempt_set_extrusion_role(ExtrusionRole extrusion_role) {}
     virtual ExtrusionEntity* clone() const = 0;
     // Create a new object, initialize it with this object using the move semantics.
     virtual ExtrusionEntity* clone_move() = 0;
@@ -297,6 +302,7 @@ public:
     bool is_force_no_extrusion() const { return m_no_extrusion; }
     void set_force_no_extrusion(bool no_extrusion) { m_no_extrusion = no_extrusion; }
     void set_extrusion_role(ExtrusionRole extrusion_role) { m_role = extrusion_role; }
+    void attempt_set_extrusion_role(ExtrusionRole extrusion_role) override { set_extrusion_role(extrusion_role); }
     void set_reverse() override { m_can_reverse = false; }
     bool can_reverse() const override { return m_can_reverse; }
 

--- a/src/libslic3r/ExtrusionEntity.hpp
+++ b/src/libslic3r/ExtrusionEntity.hpp
@@ -106,6 +106,11 @@ inline bool is_support_interface(ExtrusionRole role) {
     return role == erSupportMaterialInterface;
 }
 
+inline bool is_any_support(ExtrusionRole role) {
+    return role == erSupportMaterial
+        || role == erSupportMaterialInterface;
+}
+
 class ExtrusionEntity
 {
 public:

--- a/src/libslic3r/ExtrusionEntity.hpp
+++ b/src/libslic3r/ExtrusionEntity.hpp
@@ -102,15 +102,6 @@ inline bool is_bridge(ExtrusionRole role) {
         || role == erOverhangPerimeter;
 }
 
-inline bool is_support_interface(ExtrusionRole role) {
-    return role == erSupportMaterialInterface;
-}
-
-inline bool is_any_support(ExtrusionRole role) {
-    return role == erSupportMaterial
-        || role == erSupportMaterialInterface;
-}
-
 class ExtrusionEntity
 {
 public:

--- a/src/libslic3r/ExtrusionEntity.hpp
+++ b/src/libslic3r/ExtrusionEntity.hpp
@@ -120,7 +120,7 @@ public:
     virtual bool can_reverse() const { return true; }
     virtual bool can_sort() const { return true; }//BBS: only used in ExtrusionEntityCollection
     virtual void set_reverse() {}
-    virtual void attempt_set_extrusion_role(ExtrusionRole extrusion_role) {}
+    virtual void attempt_set_extrusion_role(ExtrusionRole extrusion_role) = 0;
     virtual ExtrusionEntity* clone() const = 0;
     // Create a new object, initialize it with this object using the move semantics.
     virtual ExtrusionEntity* clone_move() = 0;
@@ -424,6 +424,9 @@ public:
     bool empty() const { return this->paths.empty(); }
     double length() const override;
     ExtrusionRole role() const override { return this->paths.empty() ? erNone : this->paths.front().role(); }
+    void attempt_set_extrusion_role(ExtrusionRole new_role) override {
+        for (ExtrusionPath path : this->paths) path.attempt_set_extrusion_role(new_role);
+    }
     // Produce a list of 2D polygons covered by the extruded paths, offsetted by the extrusion width.
     // Increase the offset by scaled_epsilon to achieve an overlap, so a union will produce no gaps.
     void polygons_covered_by_width(Polygons &out, const float scaled_epsilon) const override;
@@ -496,6 +499,9 @@ public:
     ExtrusionRole role() const override { return this->paths.empty() ? erNone : this->paths.front().role(); }
     ExtrusionLoopRole loop_role() const { return m_loop_role; }
     void set_loop_role(ExtrusionLoopRole role) {    m_loop_role = role; }
+    void attempt_set_extrusion_role(ExtrusionRole new_role) override {
+        for (ExtrusionPath path : this->paths) path.attempt_set_extrusion_role(new_role);
+    }
     // Produce a list of 2D polygons covered by the extruded paths, offsetted by the extrusion width.
     // Increase the offset by scaled_epsilon to achieve an overlap, so a union will produce no gaps.
     void polygons_covered_by_width(Polygons &out, const float scaled_epsilon) const override;

--- a/src/libslic3r/ExtrusionEntityCollection.hpp
+++ b/src/libslic3r/ExtrusionEntityCollection.hpp
@@ -62,8 +62,8 @@ public:
         }
         return out;
     }
-    void attempt_set_extrusion_role(ExtrusionRole new_role) override {
-        for (ExtrusionEntity *ee : entities) ee->attempt_set_extrusion_role(new_role);
+    void set_extrusion_role_all(ExtrusionRole new_role) override {
+        for (ExtrusionEntity *ee : entities) ee->set_extrusion_role_all(new_role);
     }
     bool has_perimeters() const
     {

--- a/src/libslic3r/ExtrusionEntityCollection.hpp
+++ b/src/libslic3r/ExtrusionEntityCollection.hpp
@@ -62,6 +62,9 @@ public:
         }
         return out;
     }
+    void attempt_set_extrusion_role(ExtrusionRole new_role) override {
+        for (ExtrusionEntity *ee : entities) ee->attempt_set_extrusion_role(new_role);
+    }
     bool has_perimeters() const
     {
         return std::any_of(entities.begin(), entities.end(), [](const ExtrusionEntity* ee) { return is_perimeter(ee->role()); });

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -1063,6 +1063,7 @@ static std::vector<std::string> s_Preset_print_options{
     "support_on_build_plate_only",
     "support_critical_regions_only",
     "bridge_no_support",
+    "minimal_support_interface",
     "thick_bridges",
     "thick_internal_bridges",
     "dont_filter_internal_bridges",

--- a/src/libslic3r/Print.hpp
+++ b/src/libslic3r/Print.hpp
@@ -535,10 +535,6 @@ private:
     // Reassign the ExtrusionRole of all support built
     // up on top of an object
     void reassign_on_object_support(ExtrusionRole new_role);
-    // Returns the minimum number of support interface layers that are being
-    // generated. If this returns N, the nth (index n-1) layer of support interface
-    // geometry must not be contacting the actual model, where n < N
-    unsigned int compute_min_interface_layer_count();
 
     std::pair<FillAdaptive::OctreePtr, FillAdaptive::OctreePtr> prepare_adaptive_infill_data(
         const std::vector<std::pair<const Surface*, float>>& surfaces_w_bottom_z) const;

--- a/src/libslic3r/Print.hpp
+++ b/src/libslic3r/Print.hpp
@@ -531,6 +531,15 @@ private:
     void discover_horizontal_shells();
     void combine_infill();
     void _generate_support_material();
+
+    // Reassign the ExtrusionRole of all support interface as regular support
+    // except for top layers of the support interface geometry
+    void reassign_support_interface_except_top(ExtrusionRole new_role);
+    // Returns the minimum number of support interface layers that are being
+    // generated. If this returns N, the nth (index n-1) layer of support interface
+    // geometry must not be contacting the actual model, where n < N
+    unsigned int compute_min_interface_layer_count();
+
     std::pair<FillAdaptive::OctreePtr, FillAdaptive::OctreePtr> prepare_adaptive_infill_data(
         const std::vector<std::pair<const Surface*, float>>& surfaces_w_bottom_z) const;
     FillLightning::GeneratorPtr prepare_lightning_infill_data();

--- a/src/libslic3r/Print.hpp
+++ b/src/libslic3r/Print.hpp
@@ -532,9 +532,9 @@ private:
     void combine_infill();
     void _generate_support_material();
 
-    // Reassign the ExtrusionRole of all support interface as regular support
-    // except for top layers of the support interface geometry
-    void reassign_support_interface_except_top(ExtrusionRole new_role);
+    // Reassign the ExtrusionRole of all support built
+    // up on top of an object
+    void reassign_on_object_support(ExtrusionRole new_role);
     // Returns the minimum number of support interface layers that are being
     // generated. If this returns N, the nth (index n-1) layer of support interface
     // geometry must not be contacting the actual model, where n < N

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -1986,6 +1986,14 @@ void PrintConfigDef::init_fff_params()
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionEnum<InternalBridgeFilter>(ibfDisabled));
 
+    def = this->add("minimal_support_interface", coBool);
+    def->label = L("Use minimal support interface");
+    def->category = L("Support");
+    def->tooltip = L("Use support interface only on the direct top and bottom of objects.\n"
+                     "This reduces filament changes, and is especially helpful for multiplexer (AMS-like) multi-material systems.\n"
+                     "It may also help with support interface filament that bonds poorly to the support filament.");
+    def->mode = comAdvanced;
+    def->set_default_value(new ConfigOptionBool(false));
 
     def = this->add("max_bridge_length", coFloat);
     def->label = L("Max bridge length");

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -926,6 +926,7 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionFloat,               brim_ears_max_angle))
     ((ConfigOptionFloat,               skirt_start_angle))
     ((ConfigOptionBool,                bridge_no_support))
+    ((ConfigOptionBool,                minimal_support_interface))
     ((ConfigOptionFloat,               elefant_foot_compensation))
     ((ConfigOptionInt,                 elefant_foot_compensation_layers))
     ((ConfigOptionPercent,             elefant_foot_layers_density))

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -896,6 +896,7 @@ void PrintObject::generate_support_material()
         if (supportInterfaceMaterialForTopOnly) {
             BOOST_LOG_TRIVIAL(info) << "Reassigning support interface except on top...";
             this->reassign_support_interface_except_top(erSupportMaterial);
+            BOOST_LOG_TRIVIAL(info) << "Finished reassigning support interface.";
         }
 
         this->set_done(posSupportMaterial);
@@ -4316,8 +4317,8 @@ void PrintObject::reassign_support_interface_except_top(ExtrusionRole new_role)
     unsigned int interfaceLayerCount = this->compute_min_interface_layer_count(); // FIXME
     std::vector<unsigned int> interfaceCount;
     std::vector<BoundingBox> boxes;
-    std::vector<decltype(boxes)::size_type> boxesToDrop;
-    for (size_t layer_idx = 0; layer_idx < m_layers.size(); ++ layer_idx) {
+    std::vector<size_t> boxesToDrop;
+    for (size_t layer_idx = 0; layer_idx < m_support_layers.size(); ++ layer_idx) {
         SupportLayer* slayer = m_support_layers[layer_idx];
         boxesToDrop.clear();
         // Keep track (by reference) of which ExtrusionEntity's have been matched
@@ -4325,14 +4326,15 @@ void PrintObject::reassign_support_interface_except_top(ExtrusionRole new_role)
         // want to ever dereference it
         std::vector<const void*> matchedExtrusionEntities;
         // loop through every known support interface area
-        for (decltype(boxes)::size_type box_idx = 0; box_idx < boxes.size(); ++ box_idx) {
+        BOOST_LOG_TRIVIAL(info) << "woop woop";
+        for (size_t box_idx = 0; box_idx < boxes.size(); ++ box_idx) {
             BoundingBox knownbox = boxes[box_idx];
             bool matchingExtrusionEntity = false;
             // Loop through every support interface ExtrusionEntity
             for (ExtrusionEntity *ee : slayer->support_fills) {
                 ExtrusionRole eer = ee->role();
                 BOOST_LOG_TRIVIAL(info) << "ee";
-                BOOST_LOG_TRIVIAL(info) << boost::format("of role %1%\n") % eer;
+                BOOST_LOG_TRIVIAL(info) << boost::format("of role %1%\n") % ExtrusionEntity::role_to_string(eer);
                 if (is_support_interface(ee->role())) {
                     BoundingBox eebox = get_extents(ee->as_polyline());
                     if (!knownbox.overlap(eebox)) continue;
@@ -4358,20 +4360,26 @@ void PrintObject::reassign_support_interface_except_top(ExtrusionRole new_role)
                 boxesToDrop.push_back(box_idx);
             }
         }
+        BOOST_LOG_TRIVIAL(info) << "post";
         // Loop again through every ExtrusionEntity to see which ones we need to add
         for (const ExtrusionEntity *ee : slayer->support_fills) {
             ExtrusionRole eer = ee->role();
+            BOOST_LOG_TRIVIAL(info) << "post";
             if (ee->role() == erSupportMaterialInterface) {
                 // Go through each known box to see if this ExtrusionEntity is unknown
                 bool hasMatchingBox = false;
                 for (const void *refee : matchedExtrusionEntities) {
+                    BOOST_LOG_TRIVIAL(info) << "ptrcomp begin";
                     if (((void*)ee) == refee) { // pointer comparison
                         hasMatchingBox = true;
                         break;
                     }
+                    BOOST_LOG_TRIVIAL(info) << "ptrcomp end";
                 }
+                BOOST_LOG_TRIVIAL(info) << "ptrcomp end outer";
                 // Add a new box if necessary
                 if (!hasMatchingBox) {
+                    BOOST_LOG_TRIVIAL(info) << "adding new box";
                     BoundingBox eebox = get_extents(ee->as_polyline());
                     boxes.push_back(eebox);
                     interfaceCount.push_back(0);
@@ -4379,10 +4387,14 @@ void PrintObject::reassign_support_interface_except_top(ExtrusionRole new_role)
             }
         }
         // Drop all marked boxes
-        for (const decltype(boxes)::size_type drop_idx : boxesToDrop) {
-            boxes.erase(boxes.begin() + drop_idx);
-            interfaceCount.erase(interfaceCount.begin() + drop_idx);
+        BOOST_LOG_TRIVIAL(info) << "drop all marked boxes";
+        size_t idx_offset = 0;
+        for (const size_t drop_idx : boxesToDrop) {
+            boxes.erase(boxes.begin() + drop_idx - idx_offset);
+            interfaceCount.erase(interfaceCount.begin() + drop_idx - idx_offset);
+            idx_offset++;
         }
+        BOOST_LOG_TRIVIAL(info) << "layer loop end";
     }
 }
 

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -894,9 +894,7 @@ void PrintObject::generate_support_material()
         // if enabled, only designate the top layers of support interface geometry as support interface material
         bool supportInterfaceMaterialForTopOnly = true; // FIXME
         if (supportInterfaceMaterialForTopOnly) {
-            BOOST_LOG_TRIVIAL(info) << "Reassigning support interface except on top...";
-            this->reassign_support_interface_except_top(erSupportMaterial);
-            BOOST_LOG_TRIVIAL(info) << "Finished reassigning support interface.";
+            this->reassign_on_object_support(erSupportMaterialInterface);
         }
 
         this->set_done(posSupportMaterial);
@@ -4308,12 +4306,7 @@ void PrintObject::_generate_support_material()
     }
 }
 
-unsigned int PrintObject::compute_min_interface_layer_count() {
-    return 2; // FIXME
-}
-
-// FIXME rename to PrintObject::reassign_on_object_support_material
-void PrintObject::reassign_support_interface_except_top(ExtrusionRole new_role) {
+void PrintObject::reassign_on_object_support(ExtrusionRole new_role) {
     std::vector<BoundingBox> boxesA;
     std::vector<BoundingBox> boxesB;
     std::vector<BoundingBox> *boxesBelow = &boxesA;
@@ -4326,9 +4319,12 @@ void PrintObject::reassign_support_interface_except_top(ExtrusionRole new_role) 
         for (ExtrusionEntity *ee : slayer->support_fills) {
             BoundingBox eebox = get_extents(ee->as_polylines());
             boxesCurr->push_back(eebox);
+            if (!layer_idx) continue;
             bool unsupp = true;
             for (BoundingBox boxBelow : *boxesBelow) if (eebox.overlap(boxBelow)) unsupp = false;
-            if (unsupp) ee->attempt_set_extrusion_role(new_role);
+            if (unsupp) {
+                ee->attempt_set_extrusion_role(new_role);
+            }
         }
         // Prepare and swap the pointers
         boxesBelow->clear();
@@ -4337,92 +4333,6 @@ void PrintObject::reassign_support_interface_except_top(ExtrusionRole new_role) 
         boxesBelow = nextBoxesBelow;
     }
 }
-
-/*
-    unsigned int interfaceLayerCount = this->compute_min_interface_layer_count(); // FIXME
-    std::vector<unsigned int> interfaceCount;
-    std::vector<BoundingBox> boxes;
-    std::vector<size_t> boxesToDrop;
-    for (size_t layer_idx = 0; layer_idx < m_support_layers.size(); ++ layer_idx) {
-        SupportLayer* slayer = m_support_layers[layer_idx];
-        boxesToDrop.clear();
-        // Keep track (by reference) of which ExtrusionEntity's have been matched
-        // This is saved as a const void* since it's just an address and we don't
-        // want to ever dereference it
-        std::vector<const void*> matchedExtrusionEntities;
-        // loop through every known support interface area
-        BOOST_LOG_TRIVIAL(info) << "woop woop";
-        for (size_t box_idx = 0; box_idx < boxes.size(); ++ box_idx) {
-            BoundingBox knownbox = boxes[box_idx];
-            bool matchingExtrusionEntity = false;
-            // Loop through every support interface ExtrusionEntity
-            for (ExtrusionEntity *ee : slayer->support_fills) {
-                ExtrusionRole eer = ee->role();
-                BOOST_LOG_TRIVIAL(info) << "ee";
-                BOOST_LOG_TRIVIAL(info) << boost::format("of role %1%\n") % ExtrusionEntity::role_to_string(eer);
-                if (is_support_interface(ee->role())) {
-                    BoundingBox eebox = get_extents(ee->as_polyline());
-                    if (!knownbox.overlap(eebox)) continue;
-                    matchingExtrusionEntity = true;
-                    matchedExtrusionEntities.push_back((void*)ee);
-                    // We need to update the bounding box and interface count
-                    const BoundingBox& eeboxRef = eebox;
-                    boxes[box_idx].merge(eeboxRef);
-                    interfaceCount[box_idx]++;
-                    // Reassign the ExtrusionRole if we should
-                    BOOST_LOG_TRIVIAL(info) << boost::format("Test %1% < %2%\n")
-                        % interfaceCount[box_idx]
-                        % interfaceLayerCount;
-                    if (interfaceCount[box_idx] < interfaceLayerCount) {
-                        BOOST_LOG_TRIVIAL(info) << "test passed, calling attempt_set_extrusion_role";
-                        ee->attempt_set_extrusion_role(new_role);
-                    }
-                    break;
-                }
-            }
-            // If we don't find any match, we mark it to be dropped
-            if (!matchingExtrusionEntity) {
-                boxesToDrop.push_back(box_idx);
-            }
-        }
-        BOOST_LOG_TRIVIAL(info) << "post";
-        // Loop again through every ExtrusionEntity to see which ones we need to add
-        for (const ExtrusionEntity *ee : slayer->support_fills) {
-            ExtrusionRole eer = ee->role();
-            BOOST_LOG_TRIVIAL(info) << "post";
-            if (ee->role() == erSupportMaterialInterface) {
-                // Go through each known box to see if this ExtrusionEntity is unknown
-                bool hasMatchingBox = false;
-                for (const void *refee : matchedExtrusionEntities) {
-                    BOOST_LOG_TRIVIAL(info) << "ptrcomp begin";
-                    if (((void*)ee) == refee) { // pointer comparison
-                        hasMatchingBox = true;
-                        break;
-                    }
-                    BOOST_LOG_TRIVIAL(info) << "ptrcomp end";
-                }
-                BOOST_LOG_TRIVIAL(info) << "ptrcomp end outer";
-                // Add a new box if necessary
-                if (!hasMatchingBox) {
-                    BOOST_LOG_TRIVIAL(info) << "adding new box";
-                    BoundingBox eebox = get_extents(ee->as_polyline());
-                    boxes.push_back(eebox);
-                    interfaceCount.push_back(0);
-                }
-            }
-        }
-        // Drop all marked boxes
-        BOOST_LOG_TRIVIAL(info) << "drop all marked boxes";
-        size_t idx_offset = 0;
-        for (const size_t drop_idx : boxesToDrop) {
-            boxes.erase(boxes.begin() + drop_idx - idx_offset);
-            interfaceCount.erase(interfaceCount.begin() + drop_idx - idx_offset);
-            idx_offset++;
-        }
-        BOOST_LOG_TRIVIAL(info) << "layer loop end";
-    }
-}
-// */
 
 // BBS
 #define SUPPORT_SURFACES_OFFSET_PARAMETERS ClipperLib::jtSquare, 0.

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -4315,16 +4315,14 @@ void PrintObject::reassign_on_object_support(ExtrusionRole new_role) {
         SupportLayer* slayer = m_support_layers[layer_idx];
         // We identify on-object support as that which does not intersect (by bounding box)
         // support or support interface on the previous layer
-        // We then convert it using ExtrusionEntity::attempt_set_extrusion_role
+        // We then convert it using ExtrusionEntity::set_extrusion_role_all
         for (ExtrusionEntity *ee : slayer->support_fills) {
             BoundingBox eebox = get_extents(ee->as_polylines());
             boxesCurr->push_back(eebox);
             if (!layer_idx) continue;
             bool unsupp = true;
             for (BoundingBox boxBelow : *boxesBelow) if (eebox.overlap(boxBelow)) unsupp = false;
-            if (unsupp) {
-                ee->attempt_set_extrusion_role(new_role);
-            }
+            if (unsupp) ee->set_extrusion_role_all(new_role);
         }
         // Prepare and swap the pointers
         boxesBelow->clear();

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -891,9 +891,9 @@ void PrintObject::generate_support_material()
             m_print->throw_if_canceled();
         }
 
-        // if enabled, only designate the top layers of support interface geometry as support interface material
-        bool supportInterfaceMaterialForTopOnly = true; // FIXME
-        if (supportInterfaceMaterialForTopOnly) {
+        // When using minimal support interface the support generation doesn't realize it
+        // shouldn't change support interface on objects itself, so we have to fix this
+        if (m_config.minimal_support_interface.value) {
             this->reassign_on_object_support(erSupportMaterialInterface);
         }
 

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -4318,7 +4318,7 @@ void PrintObject::reassign_support_interface_except_top(ExtrusionRole new_role)
     std::vector<BoundingBox> boxes;
     std::vector<decltype(boxes)::size_type> boxesToDrop;
     for (size_t layer_idx = 0; layer_idx < m_layers.size(); ++ layer_idx) {
-        Layer* layer = m_layers[layer_idx];
+        SupportLayer* slayer = m_support_layers[layer_idx];
         boxesToDrop.clear();
         // Keep track (by reference) of which ExtrusionEntity's have been matched
         // This is saved as a const void* since it's just an address and we don't
@@ -4329,36 +4329,29 @@ void PrintObject::reassign_support_interface_except_top(ExtrusionRole new_role)
             BoundingBox knownbox = boxes[box_idx];
             bool matchingExtrusionEntity = false;
             // Loop through every support interface ExtrusionEntity
-            bool extrusionEntityLoopExitFlag = false;
-            auto regions = layer->regions();
-            for (size_t region_idx = 0; region_idx < regions.size(); ++ region_idx) {
-                LayerRegion* region = regions[region_idx];
-                for (ExtrusionEntity *ee : region->perimeters) {
-                    ExtrusionRole eer = ee->role();
-                    BOOST_LOG_TRIVIAL(info) << "ee";
-                    BOOST_LOG_TRIVIAL(info) << boost::format("of role %1%\n") % eer;
-                    if (is_support_interface(ee->role())) {
-                        BoundingBox eebox = get_extents(ee->as_polyline());
-                        if (!knownbox.overlap(eebox)) continue;
-                        matchingExtrusionEntity = true;
-                        matchedExtrusionEntities.push_back((void*)ee);
-                        // We need to update the bounding box and interface count
-                        const BoundingBox& eeboxRef = eebox;
-                        boxes[box_idx].merge(eeboxRef);
-                        interfaceCount[box_idx]++;
-                        // Reassign the ExtrusionRole if we should
-                        BOOST_LOG_TRIVIAL(info) << boost::format("Test %1% < %2%\n")
-                            % interfaceCount[box_idx]
-                            % interfaceLayerCount;
-                        if (interfaceCount[box_idx] < interfaceLayerCount) {
-                            BOOST_LOG_TRIVIAL(info) << "test passed, calling attempt_set_extrusion_role";
-                            ee->attempt_set_extrusion_role(new_role);
-                        }
-                        extrusionEntityLoopExitFlag = true;
-                        break;
+            for (ExtrusionEntity *ee : slayer->support_fills) {
+                ExtrusionRole eer = ee->role();
+                BOOST_LOG_TRIVIAL(info) << "ee";
+                BOOST_LOG_TRIVIAL(info) << boost::format("of role %1%\n") % eer;
+                if (is_support_interface(ee->role())) {
+                    BoundingBox eebox = get_extents(ee->as_polyline());
+                    if (!knownbox.overlap(eebox)) continue;
+                    matchingExtrusionEntity = true;
+                    matchedExtrusionEntities.push_back((void*)ee);
+                    // We need to update the bounding box and interface count
+                    const BoundingBox& eeboxRef = eebox;
+                    boxes[box_idx].merge(eeboxRef);
+                    interfaceCount[box_idx]++;
+                    // Reassign the ExtrusionRole if we should
+                    BOOST_LOG_TRIVIAL(info) << boost::format("Test %1% < %2%\n")
+                        % interfaceCount[box_idx]
+                        % interfaceLayerCount;
+                    if (interfaceCount[box_idx] < interfaceLayerCount) {
+                        BOOST_LOG_TRIVIAL(info) << "test passed, calling attempt_set_extrusion_role";
+                        ee->attempt_set_extrusion_role(new_role);
                     }
+                    break;
                 }
-                if (extrusionEntityLoopExitFlag) break;
             }
             // If we don't find any match, we mark it to be dropped
             if (!matchingExtrusionEntity) {
@@ -4366,26 +4359,22 @@ void PrintObject::reassign_support_interface_except_top(ExtrusionRole new_role)
             }
         }
         // Loop again through every ExtrusionEntity to see which ones we need to add
-        auto regions = layer->regions();
-        for (size_t region_idx = 0; region_idx < regions.size(); ++ region_idx) {
-            LayerRegion* region = regions[region_idx];
-            for (const ExtrusionEntity *ee : region->perimeters) {
-                ExtrusionRole eer = ee->role();
-                if (ee->role() == erSupportMaterialInterface) {
-                    // Go through each known box to see if this ExtrusionEntity is unknown
-                    bool hasMatchingBox = false;
-                    for (const void *refee : matchedExtrusionEntities) {
-                        if (((void*)ee) == refee) { // pointer comparison
-                            hasMatchingBox = true;
-                            break;
-                        }
+        for (const ExtrusionEntity *ee : slayer->support_fills) {
+            ExtrusionRole eer = ee->role();
+            if (ee->role() == erSupportMaterialInterface) {
+                // Go through each known box to see if this ExtrusionEntity is unknown
+                bool hasMatchingBox = false;
+                for (const void *refee : matchedExtrusionEntities) {
+                    if (((void*)ee) == refee) { // pointer comparison
+                        hasMatchingBox = true;
+                        break;
                     }
-                    // Add a new box if necessary
-                    if (!hasMatchingBox) {
-                        BoundingBox eebox = get_extents(ee->as_polyline());
-                        boxes.push_back(eebox);
-                        interfaceCount.push_back(0);
-                    }
+                }
+                // Add a new box if necessary
+                if (!hasMatchingBox) {
+                    BoundingBox eebox = get_extents(ee->as_polyline());
+                    boxes.push_back(eebox);
+                    interfaceCount.push_back(0);
                 }
             }
         }

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -890,6 +890,14 @@ void PrintObject::generate_support_material()
             this->_generate_support_material();
             m_print->throw_if_canceled();
         }
+
+        // if enabled, only designate the top layers of support interface geometry as support interface material
+        bool supportInterfaceMaterialForTopOnly = true; // FIXME
+        if (supportInterfaceMaterialForTopOnly) {
+            BOOST_LOG_TRIVIAL(info) << "Reassigning support interface except on top...";
+            this->reassign_support_interface_except_top(erSupportMaterial);
+        }
+
         this->set_done(posSupportMaterial);
     }
 }
@@ -4296,6 +4304,96 @@ void PrintObject::_generate_support_material()
     else {
         PrintObjectSupportMaterial support_material(this, m_slicing_params);
         support_material.generate(*this);
+    }
+}
+
+unsigned int PrintObject::compute_min_interface_layer_count() {
+    return 2; // FIXME
+}
+
+void PrintObject::reassign_support_interface_except_top(ExtrusionRole new_role)
+{
+    unsigned int interfaceLayerCount = this->compute_min_interface_layer_count(); // FIXME
+    std::vector<unsigned int> interfaceCount;
+    std::vector<BoundingBox> boxes;
+    std::vector<decltype(boxes)::size_type> boxesToDrop;
+    for (size_t layer_idx = 0; layer_idx < m_layers.size(); ++ layer_idx) {
+        Layer* layer = m_layers[layer_idx];
+        boxesToDrop.clear();
+        // Keep track (by reference) of which ExtrusionEntity's have been matched
+        // This is saved as a const void* since it's just an address and we don't
+        // want to ever dereference it
+        std::vector<const void*> matchedExtrusionEntities;
+        // loop through every known support interface area
+        for (decltype(boxes)::size_type box_idx = 0; box_idx < boxes.size(); ++ box_idx) {
+            BoundingBox knownbox = boxes[box_idx];
+            bool matchingExtrusionEntity = false;
+            // Loop through every support interface ExtrusionEntity
+            bool extrusionEntityLoopExitFlag = false;
+            auto regions = layer->regions();
+            for (size_t region_idx = 0; region_idx < regions.size(); ++ region_idx) {
+                LayerRegion* region = regions[region_idx];
+                for (ExtrusionEntity *ee : region->perimeters) {
+                    ExtrusionRole eer = ee->role();
+                    BOOST_LOG_TRIVIAL(info) << "ee";
+                    BOOST_LOG_TRIVIAL(info) << boost::format("of role %1%\n") % eer;
+                    if (is_support_interface(ee->role())) {
+                        BoundingBox eebox = get_extents(ee->as_polyline());
+                        if (!knownbox.overlap(eebox)) continue;
+                        matchingExtrusionEntity = true;
+                        matchedExtrusionEntities.push_back((void*)ee);
+                        // We need to update the bounding box and interface count
+                        const BoundingBox& eeboxRef = eebox;
+                        boxes[box_idx].merge(eeboxRef);
+                        interfaceCount[box_idx]++;
+                        // Reassign the ExtrusionRole if we should
+                        BOOST_LOG_TRIVIAL(info) << boost::format("Test %1% < %2%\n")
+                            % interfaceCount[box_idx]
+                            % interfaceLayerCount;
+                        if (interfaceCount[box_idx] < interfaceLayerCount) {
+                            BOOST_LOG_TRIVIAL(info) << "test passed, calling attempt_set_extrusion_role";
+                            ee->attempt_set_extrusion_role(new_role);
+                        }
+                        extrusionEntityLoopExitFlag = true;
+                        break;
+                    }
+                }
+                if (extrusionEntityLoopExitFlag) break;
+            }
+            // If we don't find any match, we mark it to be dropped
+            if (!matchingExtrusionEntity) {
+                boxesToDrop.push_back(box_idx);
+            }
+        }
+        // Loop again through every ExtrusionEntity to see which ones we need to add
+        auto regions = layer->regions();
+        for (size_t region_idx = 0; region_idx < regions.size(); ++ region_idx) {
+            LayerRegion* region = regions[region_idx];
+            for (const ExtrusionEntity *ee : region->perimeters) {
+                ExtrusionRole eer = ee->role();
+                if (ee->role() == erSupportMaterialInterface) {
+                    // Go through each known box to see if this ExtrusionEntity is unknown
+                    bool hasMatchingBox = false;
+                    for (const void *refee : matchedExtrusionEntities) {
+                        if (((void*)ee) == refee) { // pointer comparison
+                            hasMatchingBox = true;
+                            break;
+                        }
+                    }
+                    // Add a new box if necessary
+                    if (!hasMatchingBox) {
+                        BoundingBox eebox = get_extents(ee->as_polyline());
+                        boxes.push_back(eebox);
+                        interfaceCount.push_back(0);
+                    }
+                }
+            }
+        }
+        // Drop all marked boxes
+        for (const decltype(boxes)::size_type drop_idx : boxesToDrop) {
+            boxes.erase(boxes.begin() + drop_idx);
+            interfaceCount.erase(interfaceCount.begin() + drop_idx);
+        }
     }
 }
 

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -4312,8 +4312,33 @@ unsigned int PrintObject::compute_min_interface_layer_count() {
     return 2; // FIXME
 }
 
-void PrintObject::reassign_support_interface_except_top(ExtrusionRole new_role)
-{
+// FIXME rename to PrintObject::reassign_on_object_support_material
+void PrintObject::reassign_support_interface_except_top(ExtrusionRole new_role) {
+    std::vector<BoundingBox> boxesA;
+    std::vector<BoundingBox> boxesB;
+    std::vector<BoundingBox> *boxesBelow = &boxesA;
+    std::vector<BoundingBox> *boxesCurr = &boxesB;
+    for (size_t layer_idx = 0; layer_idx < m_support_layers.size(); ++ layer_idx) {
+        SupportLayer* slayer = m_support_layers[layer_idx];
+        // We identify on-object support as that which does not intersect (by bounding box)
+        // support or support interface on the previous layer
+        // We then convert it using ExtrusionEntity::attempt_set_extrusion_role
+        for (ExtrusionEntity *ee : slayer->support_fills) {
+            BoundingBox eebox = get_extents(ee->as_polylines());
+            boxesCurr->push_back(eebox);
+            bool unsupp = true;
+            for (BoundingBox boxBelow : *boxesBelow) if (eebox.overlap(boxBelow)) unsupp = false;
+            if (unsupp) ee->attempt_set_extrusion_role(new_role);
+        }
+        // Prepare and swap the pointers
+        boxesBelow->clear();
+        std::vector<BoundingBox> *nextBoxesBelow = boxesCurr;
+        boxesCurr = boxesBelow;
+        boxesBelow = nextBoxesBelow;
+    }
+}
+
+/*
     unsigned int interfaceLayerCount = this->compute_min_interface_layer_count(); // FIXME
     std::vector<unsigned int> interfaceCount;
     std::vector<BoundingBox> boxes;
@@ -4397,6 +4422,7 @@ void PrintObject::reassign_support_interface_except_top(ExtrusionRole new_role)
         BOOST_LOG_TRIVIAL(info) << "layer loop end";
     }
 }
+// */
 
 // BBS
 #define SUPPORT_SURFACES_OFFSET_PARAMETERS ClipperLib::jtSquare, 0.

--- a/src/libslic3r/Support/SupportCommon.cpp
+++ b/src/libslic3r/Support/SupportCommon.cpp
@@ -1696,6 +1696,11 @@ void generate_support_toolpaths(
             auto extrude_interface = [&](SupportGeneratorLayerExtruded &layer_ex, InterfaceLayerType interface_layer_type) {
                 if (! layer_ex.empty() && ! layer_ex.polygons_to_extrude().empty()) {
                     bool interface_as_base = interface_layer_type == InterfaceLayerType::InterfaceAsBase;
+                    bool mat_regular = interface_as_base;
+                    if (true) mat_regular |= true
+                        && (interface_layer_type != InterfaceLayerType::BottomContact)
+                        && (interface_layer_type != InterfaceLayerType::TopContact)
+                        && (interface_layer_type != InterfaceLayerType::RaftContact);
                     bool raft_contact      = interface_layer_type == InterfaceLayerType::RaftContact;
                     // ORCA: detect bottom interface layers for density selection.
                     bool bottom_interface  = interface_layer_type == InterfaceLayerType::BottomContact ||
@@ -1730,7 +1735,7 @@ void generate_support_toolpaths(
                         // Filler and its parameters
                         filler, float(density),
                         // Extrusion parameters
-                        interface_as_base ? ExtrusionRole::erSupportMaterial : ExtrusionRole::erSupportMaterialInterface, interface_flow);
+                        mat_regular ? ExtrusionRole::erSupportMaterial : ExtrusionRole::erSupportMaterialInterface, interface_flow);
                 }
             };
             const bool top_interfaces = support_params.num_top_interface_layers > 0;

--- a/src/libslic3r/Support/SupportCommon.cpp
+++ b/src/libslic3r/Support/SupportCommon.cpp
@@ -1697,7 +1697,7 @@ void generate_support_toolpaths(
                 if (! layer_ex.empty() && ! layer_ex.polygons_to_extrude().empty()) {
                     bool interface_as_base = interface_layer_type == InterfaceLayerType::InterfaceAsBase;
                     bool mat_regular = interface_as_base;
-                    if (true) mat_regular |= true
+                    if (config.minimal_support_interface.value) mat_regular |= true
                         && (interface_layer_type != InterfaceLayerType::BottomContact)
                         && (interface_layer_type != InterfaceLayerType::TopContact)
                         && (interface_layer_type != InterfaceLayerType::RaftContact);

--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -734,7 +734,7 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig *config, co
     for (auto el : { "support_style", "support_base_pattern",
         "support_base_pattern_spacing", "support_expansion", "support_angle",
         "support_interface_pattern", "support_interface_top_layers", "support_interface_bottom_layers",
-        "bridge_no_support", "max_bridge_length", "support_top_z_distance", "support_bottom_z_distance",
+        "bridge_no_support", "minimal_support_interface", "max_bridge_length", "support_top_z_distance", "support_bottom_z_distance",
         "support_type", "support_on_build_plate_only", "support_critical_regions_only", "support_interface_not_for_body",
         "support_object_xy_distance", "support_object_first_layer_gap", "independent_support_layer_height"})
         toggle_field(el, have_support_material);
@@ -1028,6 +1028,7 @@ void ConfigManipulation::toggle_print_sla_options(DynamicPrintConfig* config)
     toggle_field("support_base_height", supports_en);
     toggle_field("support_base_safety_distance", supports_en);
     toggle_field("support_critical_angle", supports_en);
+    toggle_field("support_minimal_support_interface", supports_en);
     toggle_field("support_max_bridge_length", supports_en);
     toggle_field("support_max_pillar_link_distance", supports_en);
     toggle_field("support_points_density_relative", supports_en);

--- a/src/slic3r/GUI/GUI_Factories.cpp
+++ b/src/slic3r/GUI/GUI_Factories.cpp
@@ -91,8 +91,8 @@ std::map<std::string, std::vector<SimpleSettingData>>  SettingsFactory::OBJECT_C
                     {"tree_support_brim_width", "",15}, {"tree_support_branch_angle", "",16},{"tree_support_branch_angle_organic","",17}, {"tree_support_wall_count", "",18},{"tree_support_branch_diameter_angle", "",19},//tree support
                     {"support_bottom_z_distance", "",20},{"support_top_z_distance", "",21},{"support_base_pattern", "",22},{"support_base_pattern_spacing", "",23},
                     {"support_interface_top_layers", "",24},{"support_interface_bottom_layers", "",25},{"support_interface_spacing", "",26},{"support_bottom_interface_spacing", "",27},
-                    {"support_object_xy_distance", "",28}, {"bridge_no_support", "",29},{"max_bridge_length", "",30},{"support_critical_regions_only", "",31},{"support_remove_small_overhang","",32},
-                    {"support_object_first_layer_gap","",33}
+                    {"support_object_xy_distance", "",28}, {"bridge_no_support", "",29}, {"minimal_support_interface", "", 30}, {"max_bridge_length", "",31},{"support_critical_regions_only", "",32},{"support_remove_small_overhang","",33},
+                    {"support_object_first_layer_gap","",34}
                     }},
     { L("Speed"), {{"support_speed", "",12}, {"support_interface_speed", "",13}
                   }}

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -2594,7 +2594,8 @@ void TabPrint::build()
         optgroup = page->new_optgroup(L("Filament for Supports"), L"param_support_filament");
         optgroup->append_single_option_line("support_filament", "support_settings_filament#base");
         optgroup->append_single_option_line("support_interface_filament", "support_settings_filament#interface");
-        optgroup->append_single_option_line("support_interface_not_for_body", "support_settings_filament#avoid-interface-filament-for-base");
+        optgroup->append_single_option_line("support_interface_not_for_body", "support_settings_filament#avoid-interface-filament-for-base"); 
+        optgroup->append_single_option_line("minimal_support_interface", "support_settings_filament#use-minimal-support-interface");
 
         optgroup = page->new_optgroup(L("Support ironing"), L"param_ironing");
         optgroup->append_single_option_line("support_ironing", "support_settings_ironing");


### PR DESCRIPTION
# Description

<!--
> Please provide a summary of the changes made in this PR. Include details such as:
  > * What issue does this PR address or fix?
  > * What new features or enhancements does this PR introduce?
  > * Are there any breaking changes or dependencies that need to be considered?
-->

This PR is a fix for #13109 

It introduces a new option, "Use minimal support interface", which when enabled causes the support interface filament to only be used when it directly contacts the object. Instead of having all of the support interface geometry (and often the layer of regular support geometry below) be assigned the Support role, only the very top will be assigned the Support Interface role. Likewise, when supports emerge from the object, there will only be one layer of Support Interface atop. This does setting does not alter the geometry at all, only the roles (or from the user perspective- filaments). 

The motivation is described on the issue (#13109), but in brief:
- This can drastically reduce filament changes when using a support interface filament, by up to a factor of 3 for many geometries (especially helpful for AMS-like multiplexer systems where even a small number of filament changes incur a significant time and waste penalty)
- This is also a potential solution to #13983 (though some actual testing should be performed to ensure this is the case)

This is done in two steps:
1. During support generation, relevant supports are only set to `erSupportMaterialInterface` if they is marked as directly in contact with an object
2. Near the end of the slicing process, `PrintObject::reassign_on_object_supports` ensures any supports coming off the model have at least one layer of, in this case, `erSupportMaterialInterface`. This is needed to prevent edge cases: the tree support generation cannot distinguish between bottom contacts and regular intermediate support layers. 

# Screenshots/Recordings/Graphs

<!--
> Please attach relevant screenshots to showcase the UI changes.
> Please attach images that can help explain the changes.
-->

This is a simple test, the Calicat model on it's tail:

<img width="2560" height="1568" alt="image" src="https://github.com/user-attachments/assets/536b16b3-c6fe-465b-8901-74ae4a06c495" />

## Tests

<!--
> Please describe the tests that you have conducted to verify the changes made in this PR.
-->

I ran the unit tests (100% passed) and also tested it with several orientations of the calicat model to check that it worked properly, even when supporting sloped surfaces or when supports originate from the object itself. It appears to work reliably. I have not run off any physical prints with it. 

<!--
> A guide for users on how to download the artifacts from this PR.
-->

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
