### PR TITLE
Re-enable [OrcaCloudServiceAgent] headless tests now that the crash is fixed

### DIFF
--- a/tests/slic3rutils/slic3rutils_tests_main.cpp
+++ b/tests/slic3rutils/slic3rutils_tests_main.cpp
@@ -53,8 +53,7 @@ TEST_CASE("Check SSL certificates paths", "[Http][NotWorking]") {
     REQUIRE(status == 200);
 }
 
-// [NotWorking]: OrcaCloudServiceAgent ctor segfaults headless (wxStandardPaths::Get() -> null wxTheApp).
-TEST_CASE("Orca cloud flat session resolves display name consistently", "[OrcaCloudServiceAgent][NotWorking]")
+TEST_CASE("Orca cloud flat session resolves display name consistently", "[OrcaCloudServiceAgent]")
 {
     CHECK(resolved_display_name(flat_session_json({
         {"username", "orca_username"},
@@ -82,8 +81,7 @@ TEST_CASE("Orca cloud flat session resolves display name consistently", "[OrcaCl
     })) == "orca_username");
 }
 
-// [NotWorking]: see flat-session test above.
-TEST_CASE("Orca cloud nested session resolves display name consistently", "[OrcaCloudServiceAgent][NotWorking]")
+TEST_CASE("Orca cloud nested session resolves display name consistently", "[OrcaCloudServiceAgent]")
 {
     CHECK(resolved_display_name(nested_session_json({
         {"username", "orca_username"},


### PR DESCRIPTION
# Description

The two `[OrcaCloudServiceAgent]` display-name tests in `tests/slic3rutils/slic3rutils_tests_main.cpp` were tagged `[NotWorking]` in #14175 because the agent constructor dereferenced a null `wxTheApp` when run headless, segfaulting before any assertion. The CI unit-test job excludes `[NotWorking]` (`-LE NotWorking`), so they never ran.

That null dereference has since been fixed in 14d2dfdd4c (guard `wxTheApp` in `OrcaCloudServiceAgent::compute_fallback_path()`, skip persistence when no fallback path is available). This PR drops the now-unnecessary `[NotWorking]` tag and the stale explanatory comments so the tests run in CI again.

The `[Http][NotWorking]` network tests are intentionally left tagged.

Closes #14193.

## Tests

Built `slic3rutils_tests` and ran the suite headless on Linux with clang-18 (the CI compiler), with no display:

```
$ ./build/tests/slic3rutils/Release/slic3rutils_tests '[OrcaCloudServiceAgent]'
All tests passed (20 assertions in 2 test cases)
```

No crash; both cases pass.
