### PR TITLE
Fix (UI consistency/efficiency): Preview invalidated by settings change falls back to Prepare tab

### DIFF
--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -16743,6 +16743,13 @@ void Plater::on_config_change(const DynamicPrintConfig &config)
         this->p->schedule_background_process();
         update_title_dirty_status();
         p->schedule_auto_reslice_if_needed();
+        
+        // If auto-slice is disabled and user is on Preview tab,
+        // switch to Prepare to avoid confusing intermediate state
+        AppConfig* cfg = wxGetApp().app_config;
+        if (cfg && !cfg->get_bool("auto_slice_after_change") && is_preview_shown()) {
+            wxGetApp().mainframe->select_tab(MainFrame::tp3DEditor);
+        }
     }
 }
 


### PR DESCRIPTION
When editing print settings after slicing while on the Preview tab, the view shows raw geometry instead of sliced layers but stays on the Preview tab. This creates a confusing intermediate state where users see their model without layer data even though they're in "Preview" mode. To refresh the preview, users must toggle to some other tab and then back to Preview, or they can click on a plate thumbnail (but that resets the view, which may not be preferable).

This happens because config changes invalidate the slice results, but the code doesn't switch tabs. The Preview canvas falls through to "pre-gcode preview" mode showing only raw geometry with no layer sliders. My fix detects when the user is editing settings on the Preview tab with auto-slice disabled and automatically switches back to the Prepare tab. Config edits clearly punt the view back to Prepare (instead of the "invalid" intermediate state, which was only ever intended to be a transition while slicing or waiting for auto-slice).

I'm adding a check in `Plater::on_config_change()` that runs after scheduling auto-reslice. If auto-slice is disabled AND the user is viewing the Preview tab, it switches to the Prepare tab. This respects the auto-slice workflow (users with auto-slice enabled stay on Preview) while fixing the UX for users who manually manage slices.

The fix reduces clicks from 3 to 1 (or `Tab` presses from 2 to 1) while also making it much clearer to the user that they are no longer in Preview mode after their config change, as the view will now fully switch back to Prepare instead of landing in the intermediate state. The typical user would click 2-3 times after a config edit (once on Preview, which does nothing, then Prepare and back to Preview). Now they clearly see they are in Prepare after their edit and can click once on Preview (or press `Tab` once) to re-slice the plate with their change.

Changes:
- Added automatic tab switch to Prepare when config changes on Preview tab with auto-slice disabled
- Check placed after `schedule_auto_reslice_if_needed()` in `Plater::on_config_change()`
- Only triggers when `auto_slice_after_change` setting is false while on Preview tab
- Follows existing precedent for state-based tab switching
- Respects auto-slice workflow: no tab switch when auto-slice is enabled

Files modified:
- src/slic3r/GUI/Plater.cpp
