### PR TITLE
Allow drop of sunken objects

### DIFF
--- a/src/slic3r/GUI/GUI_Factories.cpp
+++ b/src/slic3r/GUI/GUI_Factories.cpp
@@ -2130,7 +2130,7 @@ void MenuFactory::append_menu_item_drop(wxMenu* menu)
             if (plater()->canvas3D()->get_canvas_type() != GLCanvas3D::ECanvasType::CanvasView3D)
                 return false;
             else {
-                return (plater()->get_view3D_canvas3D()->get_selection().get_bounding_box().min.z() > SINKING_Z_THRESHOLD);
+                return (std::abs(plater()->get_view3D_canvas3D()->get_selection().get_bounding_box().min.z()) > -SINKING_Z_THRESHOLD);
             } //disable if model is on the bed / not in View3D
         }, m_parent);
 }

--- a/src/slic3r/GUI/Selection.cpp
+++ b/src/slic3r/GUI/Selection.cpp
@@ -525,7 +525,7 @@ void Selection::center()
 
 void Selection::drop()
 {
-    if (this->get_bounding_box().min.z() < SINKING_Z_THRESHOLD) {
+    if (std::abs(this->get_bounding_box().min.z()) < -SINKING_Z_THRESHOLD) {
         return; // shouldnt happen, but better check anyways, already checked in append_menu_item_drop()
     }
 


### PR DESCRIPTION
This PR disabled graying out **Drop** menu item if object is sunken, thus allowing actually rising object to bed level.

<img width="578" height="322" alt="image" src="https://github.com/user-attachments/assets/b649bf3d-cf86-4db3-bd5b-a51c2607b445" />

