### PR TITLE
Fix wrong variant index is used on motion ability setting tab

### DIFF
--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -7458,7 +7458,7 @@ void Tab::switch_excluder(int extruder_id)
                 if (extruder_id2 > 0)
                     index = get_index_for_extruder(extruder_id2);
                 is_extruder = true;
-            } else if (page->title().StartsWith("Speed limitation")) {
+            } else if (page->title().StartsWith("Motion ability")) {
                 index = get_index_for_extruder(extruder_id == -1 ? 0 : extruder_id, 2);
             }
         }


### PR DESCRIPTION
# Description

There is a bug that options on motion ability page are always stored with index = (nozzle_count - 1) * variant_per_nozzle; for example for U1 it's always (4 - 1) * 1 = 3, and for H2D it's always (2 - 1) * 2 = 2.

This PR fix this issue so the value is always stores in the first slot because we haven't enable variant selection yet.

Fix #13308

# Screenshots/Recordings/Graphs

<!--
> Please attach relevant screenshots to showcase the UI changes.
> Please attach images that can help explain the changes.
-->

## Tests

Change any value on motion ability page for U1 and save the profile.
Open the json file and verify the value is stored at index 0.

Slice a project and verify the `SET_VELOCITY_LIMIT` is emitted with the configured value properly.

<!--
> A guide for users on how to download the artifacts from this PR.
-->

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
