### PR TITLE
Don't change the Pressure Advance value if the change is insignificant.

### DIFF
--- a/src/libslic3r/GCode/AdaptivePAProcessor.cpp
+++ b/src/libslic3r/GCode/AdaptivePAProcessor.cpp
@@ -256,6 +256,11 @@ std::string AdaptivePAProcessor::process_layer(std::string &&gcode) {
                         if(m_config.gcode_comments) output << "; APA: Interpolation failed, using fallback pressure advance value\n";
                     }
                 }
+                // Round predicted PA to nearest 0.01 to reduce meaningless adjustments.
+                // Prusa printers have to wait for planner sync to change PA, causing a delay.
+                if (predicted_pa > 0.04) {
+                    predicted_pa = std::round(predicted_pa * 100.0) / 100.0;
+                }
                 if(m_config.gcode_comments) {
                     // Output debug GCode comments
                     output << pa_change_line << '\n'; // Output PA change command tag

--- a/src/libslic3r/GCode/AdaptivePAProcessor.cpp
+++ b/src/libslic3r/GCode/AdaptivePAProcessor.cpp
@@ -279,7 +279,7 @@ std::string AdaptivePAProcessor::process_layer(std::string &&gcode) {
                     significant_change = std::fabs(predicted_pa) > 1e-12;
                 } else {
                     double relative_change = std::fabs((predicted_pa - m_last_predicted_pa) / m_last_predicted_pa);
-                    significant_change = (relative_change >= 0.10); // 10% threshold
+                    significant_change = (relative_change >= 0.03); // 3% threshold
                 }
                 
                 if (significant_change) {

--- a/src/libslic3r/GCode/AdaptivePAProcessor.cpp
+++ b/src/libslic3r/GCode/AdaptivePAProcessor.cpp
@@ -255,12 +255,7 @@ std::string AdaptivePAProcessor::process_layer(std::string &&gcode) {
                         predicted_pa = m_config.enable_pressure_advance.get_at(m_last_extruder_id) ? m_config.pressure_advance.get_at(m_last_extruder_id) : 0;
                         if(m_config.gcode_comments) output << "; APA: Interpolation failed, using fallback pressure advance value\n";
                     }
-                }
-                // Round predicted PA to nearest 0.01 to reduce meaningless adjustments.
-                // Prusa printers have to wait for planner sync to change PA, causing a delay.
-                if (predicted_pa > 0.04) {
-                    predicted_pa = std::round(predicted_pa * 100.0) / 100.0;
-                }
+                }                
                 if(m_config.gcode_comments) {
                     // Output debug GCode comments
                     output << pa_change_line << '\n'; // Output PA change command tag
@@ -273,9 +268,23 @@ std::string AdaptivePAProcessor::process_layer(std::string &&gcode) {
                     output << "; APA Flow rate: " << std::to_string(mm3mm_value * m_max_next_feedrate) << "\n";
                     output << "; APA Prev PA: " << std::to_string(m_last_predicted_pa) << " New PA: " << std::to_string(predicted_pa) << "\n"; 
                 }
-                if (extruder_changed || std::fabs(predicted_pa - m_last_predicted_pa) > EPSILON) {
-                    output << m_gcodegen.writer().set_pressure_advance(predicted_pa); // Use m_writer to set pressure advance
-                    m_last_predicted_pa = predicted_pa; // Update the last predicted PA value
+                // Only change the PA value if the change is significant.
+                // Good for prusa printers, which currently have to wait for plotter synchronisation before changing PA 
+                // See https://github.com/prusa3d/Prusa-Firmware-Buddy/issues/5322
+                bool significant_change = false;
+                if (extruder_changed) {
+                    significant_change = true;
+                } else if (std::fabs(m_last_predicted_pa) < 1e-12) {
+                    // Previous value was effectively zero: any non-zero predicted PA is significant
+                    significant_change = std::fabs(predicted_pa) > 1e-12;
+                } else {
+                    double relative_change = std::fabs((predicted_pa - m_last_predicted_pa) / m_last_predicted_pa);
+                    significant_change = (relative_change >= 0.10); // 10% threshold
+                }
+                
+                if (significant_change) {
+                    output << m_gcodegen.writer().set_pressure_advance(predicted_pa);
+                    m_last_predicted_pa = predicted_pa;// Update the last predicted PA value
                 }
             }
         }else {


### PR DESCRIPTION
Added rounding for predicted pressure advance to reduce the number of adjustments. 

It's a soft proposal, I'm open to reasons why this wouldn't make a negative difference to some users or suggestions of a better way to do this. 

# Description

Now that Adaptive Pressure Advance is quite well established and seems to be functioning without problems, the need for extremely small adjustments to pressure advance values seems unnecessary. 

This PR rounds the PA value to the nearest 0.010 when values are over 0.040. Therefore it prevents changes which only represent 2-3% of the PA value, only emitting M900 Kx.xx0 when a change is _needed_.

Fixes a problem with prusa printers where the printer waits for print moves to finish before changing PA, causing a slowdown. https://github.com/OrcaSlicer/OrcaSlicer/issues/13789


# Screenshots/Recordings/Graphs
Sections like this don't _need_ 4 PA changes in a 0.3mm section.
<img width="1473" height="824" alt="image" src="https://github.com/user-attachments/assets/de6eec1d-bf6f-4dc0-8b49-546184aa80df" />

A possible alternative way to solve this problem is some way to increase the line width consistency. Here we can see that the line has been increased to 150% width to close the gap in the walls. This seems very sensible to me because it means no time is wasted placing extra infill, but if the thickness _continued_ at 150% through the filleted corner, there wouldn't be a change in flow rate and therefore no need to change pressure advance. **I'd really like to hear thoughts on this.** 


## Tests



[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
