### PR TITLE
APA for overhangs - Prusa incompatibility warning

### DIFF
--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -2394,7 +2394,8 @@ void PrintConfigDef::init_fff_params()
     def = this->add("adaptive_pressure_advance_overhangs", coBools);
     def->label = L("Enable adaptive pressure advance for overhangs (beta)");
     def->tooltip = L("Enable adaptive PA for overhangs as well as when flow changes within the same feature. This is an experimental option, "
-                     "as if the PA profile is not set accurately, it will cause uniformity issues on the external surfaces before and after overhangs.\n");
+                     "as if the PA profile is not set accurately, it will cause uniformity issues on the external surfaces before and after overhangs.\n"
+					 "Not compatible with Prusa printers as they pause to process PA changes, which causes delays and defects.");
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionBools{ false });
 

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -2395,7 +2395,7 @@ void PrintConfigDef::init_fff_params()
     def->label = L("Enable adaptive pressure advance for overhangs (beta)");
     def->tooltip = L("Enable adaptive PA for overhangs as well as when flow changes within the same feature. This is an experimental option, "
                      "as if the PA profile is not set accurately, it will cause uniformity issues on the external surfaces before and after overhangs.\n"
-					 "Not compatible with Prusa printers as they pause to process PA changes, which causes delays and defects.");
+                     "Not compatible with Prusa printers as they pause to process PA changes, which causes delays and defects.");
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionBools{ false });
 


### PR DESCRIPTION
Added a sentence explicitly stating that APA for overhangs is not compatible with prusa printers

# Description

This will reduce problems from https://github.com/OrcaSlicer/OrcaSlicer/issues/14264#issuecomment-4740572709 but I think that a little more will be needed just to make everything intuitive from a UX perspective.

No breaking changes - tooltip change only

# Screenshots/Recordings/Graphs

<!--
> Please attach relevant screenshots to showcase the UI changes.
> Please attach images that can help explain the changes.
-->

## Tests

<!--
> Please describe the tests that you have conducted to verify the changes made in this PR.
-->

<!--
> A guide for users on how to download the artifacts from this PR.
-->

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
