### PR TITLE
Don't allow adding more colors for non-semm printers on obj import color remapping dialog

### DIFF
--- a/src/slic3r/GUI/ObjColorDialog.cpp
+++ b/src/slic3r/GUI/ObjColorDialog.cpp
@@ -79,7 +79,7 @@ bool ObjColorDialog::Show(bool show) {
     }
 };
 
-ObjColorDialog::ObjColorDialog(wxWindow *parent, Slic3r::ObjDialogInOut &in_out, const std::vector<std::string> &extruder_colours)
+ObjColorDialog::ObjColorDialog(wxWindow *parent, Slic3r::ObjDialogInOut &in_out, const std::vector<std::string> &extruder_colours, const bool semm)
     : DPIDialog(parent ? parent : static_cast<wxWindow *>(wxGetApp().mainframe),
                 wxID_ANY,
                 _(L("OBJ file import color")),
@@ -109,7 +109,7 @@ ObjColorDialog::ObjColorDialog(wxWindow *parent, Slic3r::ObjDialogInOut &in_out,
     }
     bool ok        = in_out.lost_material_name.empty() && !some_face_no_color;
     if (ok) {
-        m_panel_ObjColor = new ObjColorPanel(this, in_out, extruder_colours);
+        m_panel_ObjColor = new ObjColorPanel(this, in_out, extruder_colours, semm);
         m_panel_ObjColor->set_layout_callback([this]() { update_layout(); });
         m_main_sizer->Add(m_panel_ObjColor, 1, wxEXPAND | wxALL, 0);
     }
@@ -178,12 +178,13 @@ ObjColorDialog::ObjColorDialog(wxWindow *parent, Slic3r::ObjDialogInOut &in_out,
 }
 
 // This panel contains all control widgets for both simple and advanced mode (these reside in separate sizers)
-ObjColorPanel::ObjColorPanel(wxWindow *parent, Slic3r::ObjDialogInOut &in_out, const std::vector<std::string> &extruder_colours)
+ObjColorPanel::ObjColorPanel(wxWindow *parent, Slic3r::ObjDialogInOut &in_out, const std::vector<std::string> &extruder_colours, const bool semm)
     : wxPanel(parent, wxID_ANY, wxDefaultPosition, wxDefaultSize /*,wxBORDER_RAISED*/)
     , m_obj_in_out(in_out)
     , m_input_colors(in_out.input_colors)
     , m_filament_ids(in_out.filament_ids)
     , m_first_extruder_id(in_out.first_extruder_id)
+    , m_semm(semm)
 {
     if (in_out.input_colors.size() == 0) { return; }
     for (const std::string& color : extruder_colours) {
@@ -504,6 +505,7 @@ wxBoxSizer *ObjColorPanel::create_add_btn_sizer(wxWindow *parent)
         deal_add_btn();
         deal_thumbnail();
     });
+    m_quick_add_btn->Enable(m_semm); // only SEMM printer can add more colors
     return btn_sizer;
 }
 
@@ -859,6 +861,7 @@ bool ObjColorPanel::do_show(bool show) {
 
 bool ObjColorPanel::deal_add_btn()
 {
+    if (!m_semm) { return false; }// only SEMM printer can add more colors
     if (m_colours.size() > g_max_color) { return false; }
     deal_reset_btn();
     std::vector<wxBitmap *> new_icons;

--- a/src/slic3r/GUI/ObjColorDialog.hpp
+++ b/src/slic3r/GUI/ObjColorDialog.hpp
@@ -20,7 +20,7 @@ class ObjColorPanel : public wxPanel
 {
 public:
     // BBS
-    ObjColorPanel(wxWindow *parent, Slic3r::ObjDialogInOut &in_out, const std::vector<std::string> &extruder_colours);
+    ObjColorPanel(wxWindow *parent, Slic3r::ObjDialogInOut &in_out, const std::vector<std::string> &extruder_colours, bool semm);
     ~ObjColorPanel();
     void msw_rescale();
     bool is_ok();
@@ -90,6 +90,7 @@ private:
     int m_color_num_recommend{0};
     int m_color_cluster_num_by_algo{0};
     int m_input_colors_size{0};
+    bool m_semm; // only SEMM printer can add more colors
     std::vector<wxColour> m_colours;//from project and show right
     std::vector<int>      m_cluster_map_filaments;//show middle
     int                   m_max_filament_index = 0;
@@ -112,7 +113,7 @@ private:
 class ObjColorDialog : public Slic3r::GUI::DPIDialog
 {
 public:
-    ObjColorDialog(wxWindow *parent, Slic3r::ObjDialogInOut &in_out, const std::vector<std::string> &extruder_colours);
+    ObjColorDialog(wxWindow *parent, Slic3r::ObjDialogInOut &in_out, const std::vector<std::string> &extruder_colours, bool semm);
     wxBoxSizer *create_btn_sizer(long flags, bool exist_error);
     void on_dpi_changed(const wxRect &suggested_rect) override;
     void update_layout();

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -6554,7 +6554,7 @@ std::vector<size_t> Plater::priv::load_files(const std::vector<fs::path>& input_
 
                     if (!boost::iends_with(path.string(), ".obj")) { return; }
                     const std::vector<std::string> extruder_colours = wxGetApp().plater()->get_extruder_colors_from_plater_config();
-                    ObjColorDialog                 color_dlg(nullptr, in_out, extruder_colours);
+                    ObjColorDialog                 color_dlg(nullptr, in_out, extruder_colours, Sidebar::should_show_SEMM_buttons());
                     if (color_dlg.ShowModal() != wxID_OK) {
                         in_out.filament_ids.clear();
                     }
@@ -8816,7 +8816,7 @@ void Plater::priv::reload_from_disk()
         auto        obj_color_fun = [this, &path](ObjDialogInOut &in_out) {
             if (!boost::iends_with(path, ".obj")) { return; }
             const std::vector<std::string> extruder_colours = wxGetApp().plater()->get_extruder_colors_from_plater_config();
-            ObjColorDialog                 color_dlg(nullptr, in_out, extruder_colours);
+            ObjColorDialog                 color_dlg(nullptr, in_out, extruder_colours, Sidebar::should_show_SEMM_buttons());
             if (color_dlg.ShowModal() != wxID_OK) {
                 in_out.filament_ids.clear();
             }


### PR DESCRIPTION
# Description

There is a bug that if you use a non-bbl multi-tool printer (such as snapmaker u1), and you attempt to import a multi-color obj file, the color mapping dialog will show colors that exceed the extruder count, and if you click ok, there will be more colors appear in sidebar that will not work properly:
<img width="439" height="195" alt="image" src="https://github.com/user-attachments/assets/cd5fcf66-c1e0-4825-83de-5b05a8f7b508" />
<img width="405" height="316" alt="image" src="https://github.com/user-attachments/assets/1726d8e1-2d51-442d-9633-52f58fac8703" />

This PR fix this problem:
<img width="747" height="543" alt="image" src="https://github.com/user-attachments/assets/5eb79bb7-0558-4af2-900f-69df18eb47a7" />



# Screenshots/Recordings/Graphs

## Tests

<!--
> Please describe the tests that you have conducted to verify the changes made in this PR.
-->

<!--
> A guide for users on how to download the artifacts from this PR.
-->

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
