### PR TITLE
Add Linux ARM64 (aarch64) AppImage build

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -55,11 +55,23 @@ jobs:
   build_linux:
     strategy:
       fail-fast: false
+      # Build both arches on every event (PRs included), through the same
+      # build_check_cache -> build_deps -> build_orca chain (the AppImage).
+      # aarch64 always uses the GitHub-hosted arm runner (there is no arm
+      # self-hosted server). amd64's empty arch is load-bearing: it keeps the
+      # historical 'linux-clang' deps cache key and the unsuffixed asset names.
+      matrix:
+        include:
+          - arch: ""
+            os: ${{ vars.SELF_HOSTED && 'orca-lnx-server' || 'ubuntu-24.04' }}
+          - arch: "aarch64"
+            os: ubuntu-24.04-arm
     # Don't run scheduled builds on forks:
     if: ${{ !cancelled() && (github.event_name != 'schedule' || github.repository == 'OrcaSlicer/OrcaSlicer') }}
     uses: ./.github/workflows/build_check_cache.yml
     with:
-      os: ${{ vars.SELF_HOSTED && 'orca-lnx-server' || 'ubuntu-24.04' }}
+      os: ${{ matrix.os }}
+      arch: ${{ matrix.arch }}
       build-deps-only: ${{ inputs.build-deps-only || false }}
     secrets: inherit
   build_windows:
@@ -99,7 +111,9 @@ jobs:
     secrets: inherit
   unit_tests:
     name: Unit Tests
-    runs-on: ${{ vars.SELF_HOSTED && 'orca-lnx-server' || 'ubuntu-24.04' }}
+    # Tests are built on the aarch64 leg by default (faster GitHub arm runner),
+    # so run them there; self-hosted builds them on the amd64 server instead.
+    runs-on: ${{ vars.SELF_HOSTED && 'orca-lnx-server' || 'ubuntu-24.04-arm' }}
     needs: build_linux
     if: ${{ !cancelled() && success() }}
     steps:
@@ -237,4 +251,3 @@ jobs:
         asset_name: OrcaSlicer-Linux-flatpak_nightly_${{ matrix.variant.arch }}.flatpak
         asset_content_type: application/octet-stream
         max_releases: 1 # optional, if there are more releases than this matching the asset_name, the oldest ones are going to be deleted
-

--- a/.github/workflows/build_check_cache.yml
+++ b/.github/workflows/build_check_cache.yml
@@ -33,8 +33,10 @@ jobs:
       - name: set outputs
         id: set_outputs
         env:
-          # Keep macOS cache keys and paths architecture-specific.
-          cache-os: ${{ runner.os == 'macOS' && format('macos-{0}', inputs.arch) || (runner.os == 'Windows' && 'windows' || 'linux-clang') }}
+          # Keep macOS/Linux cache keys architecture-specific. amd64 Linux passes
+          # no arch (key stays 'linux-clang', preserving the existing cache);
+          # aarch64 gets its own 'linux-clang-aarch64' key.
+          cache-os: ${{ runner.os == 'macOS' && format('macos-{0}', inputs.arch) || (runner.os == 'Windows' && 'windows' || format('linux-clang{0}', inputs.arch && format('-{0}', inputs.arch) || '')) }}
           dep-folder-name: ${{ runner.os == 'macOS' && format('/{0}', inputs.arch) || '/OrcaSlicer_dep' }}
           output-cmd: ${{ runner.os == 'Windows' && '$env:GITHUB_OUTPUT' || '"$GITHUB_OUTPUT"'}}
         run: |

--- a/.github/workflows/build_orca.yml
+++ b/.github/workflows/build_orca.yml
@@ -65,6 +65,11 @@ jobs:
           echo "ver_pure=$ver_pure" >> $GITHUB_ENV
           echo "date=$(date +'%Y%m%d')" >> $GITHUB_ENV
           echo "git_commit_hash=$git_commit_hash" >> $GITHUB_ENV
+          # Per-arch Linux AppImage naming: amd64 keeps the historical unsuffixed
+          # name (arch_suffix empty). Unused on macOS/Windows.
+          if [ '${{ inputs.arch }}' = 'aarch64' ]; then
+            echo "arch_suffix=_aarch64" >> $GITHUB_ENV
+          fi
         shell: bash
 
       - name: Get the version and date on Windows
@@ -401,16 +406,23 @@ jobs:
         if: runner.os == 'Linux'
         shell: bash
         run: |
-          ./build_linux.sh -istrlL
+          # Build + tar the unit tests (-t) only on the leg that runs them: the
+          # aarch64 leg by default (faster GitHub arm runner), or amd64 when using
+          # self-hosted runners (no arm self-hosted server). unit_tests downloads
+          # this tarball. The profile validator is built with -s, so amd64 keeps it.
+          tests=${{ (!vars.SELF_HOSTED && inputs.arch == 'aarch64') || (vars.SELF_HOSTED && inputs.arch != 'aarch64') }}
+          if $tests; then flags=-istrlL; else flags=-isrlL; fi
+          ./build_linux.sh "$flags"
           ./scripts/check_appimage_libs.sh ./build/package ./build/package/bin/orca-slicer
-          mv -n ./build/OrcaSlicer_Linux_V${{ env.ver_pure }}.AppImage ./build/OrcaSlicer_Linux_AppImage${{ env.ubuntu-ver-str }}_${{ env.ver }}.AppImage
-          chmod +x ./build/OrcaSlicer_Linux_AppImage${{ env.ubuntu-ver-str }}_${{ env.ver }}.AppImage
-          tar -cvpf build_tests.tar build/tests
+          appimage=./build/OrcaSlicer_Linux_AppImage${{ env.ubuntu-ver-str }}${{ env.arch_suffix }}_${{ env.ver }}.AppImage
+          mv -n ./build/OrcaSlicer_Linux_V${{ env.ver_pure }}.AppImage "$appimage"
+          chmod +x "$appimage"
+          if $tests; then tar -cvpf build_tests.tar build/tests; fi
 
         # Use tar because upload-artifacts won't always preserve directory structure
         # and doesn't preserve file permissions
       - name: Upload Test Artifact
-        if: runner.os == 'Linux'
+        if: runner.os == 'Linux' && ((!vars.SELF_HOSTED && inputs.arch == 'aarch64') || (vars.SELF_HOSTED && inputs.arch != 'aarch64'))
         uses: actions/upload-artifact@v7
         with:
           name: ${{ github.sha }}-tests
@@ -420,7 +432,7 @@ jobs:
           if-no-files-found: error
 
       - name: Run external slicer regression tests
-        if: runner.os == 'Linux'
+        if: runner.os == 'Linux' && inputs.arch != 'aarch64'
         timeout-minutes: 20
         shell: bash
         run: |
@@ -430,7 +442,7 @@ jobs:
           python3 "$test_repo_dir/run_test.py" "${{ github.workspace }}/build/package/bin/orca-slicer"
 
       - name: Build orca_custom_preset_tests
-        if: github.ref == 'refs/heads/main' && runner.os == 'Linux' && !vars.SELF_HOSTED
+        if: github.ref == 'refs/heads/main' && runner.os == 'Linux' && !vars.SELF_HOSTED && inputs.arch != 'aarch64'
         working-directory: ${{ github.workspace }}/build/src/Release
         shell: bash
         run: |
@@ -442,11 +454,11 @@ jobs:
         if: ${{ ! env.ACT && runner.os == 'Linux' }}
         uses: actions/upload-artifact@v7
         with:
-          name: OrcaSlicer_Linux_ubuntu_${{ env.ubuntu-ver }}_${{ env.ver }}
-          path: './build/OrcaSlicer_Linux_AppImage${{ env.ubuntu-ver-str }}_${{ env.ver }}.AppImage'
+          name: OrcaSlicer_Linux_ubuntu_${{ env.ubuntu-ver }}${{ env.arch_suffix }}_${{ env.ver }}
+          path: "./build/OrcaSlicer_Linux_AppImage${{ env.ubuntu-ver-str }}${{ env.arch_suffix }}_${{ env.ver }}.AppImage"
 
       - name: Upload OrcaSlicer_profile_validator Ubuntu
-        if: ${{ ! env.ACT && runner.os == 'Linux' && !vars.SELF_HOSTED }}
+        if: ${{ ! env.ACT && runner.os == 'Linux' && !vars.SELF_HOSTED && inputs.arch != 'aarch64' }}
         uses: actions/upload-artifact@v7
         with:
           name: OrcaSlicer_profile_validator_Linux_ubuntu_${{ env.ubuntu-ver }}_${{ env.ver }}
@@ -458,12 +470,12 @@ jobs:
         with:
           upload_url: https://uploads.github.com/repos/OrcaSlicer/OrcaSlicer/releases/137995723/assets{?name,label}
           release_id: 137995723
-          asset_path: ./build/OrcaSlicer_Linux_AppImage${{ env.ubuntu-ver-str }}_${{ env.ver }}.AppImage
-          asset_name: OrcaSlicer_Linux_AppImage${{ env.ubuntu-ver-str }}_nightly.AppImage
+          asset_path: ./build/OrcaSlicer_Linux_AppImage${{ env.ubuntu-ver-str }}${{ env.arch_suffix }}_${{ env.ver }}.AppImage
+          asset_name: OrcaSlicer_Linux_AppImage${{ env.ubuntu-ver-str }}${{ env.arch_suffix }}_nightly.AppImage
           asset_content_type: application/octet-stream
           max_releases: 1 # optional, if there are more releases than this matching the asset_name, the oldest ones are going to be deleted
       - name: Deploy Ubuntu release
-        if: ${{ github.repository == 'OrcaSlicer/OrcaSlicer' && ! env.ACT && github.ref == 'refs/heads/main' && runner.os == 'Linux' && !vars.SELF_HOSTED }}
+        if: ${{ github.repository == 'OrcaSlicer/OrcaSlicer' && ! env.ACT && github.ref == 'refs/heads/main' && runner.os == 'Linux' && !vars.SELF_HOSTED && inputs.arch != 'aarch64' }}
         uses: rickstaa/action-create-tag@v1
         with:
           tag: "nightly-builds"
@@ -472,7 +484,7 @@ jobs:
           message: "nightly-builds"
 
       - name: Deploy Ubuntu OrcaSlicer_profile_validator release
-        if: ${{ github.repository == 'OrcaSlicer/OrcaSlicer' && ! env.ACT && github.ref == 'refs/heads/main' && runner.os == 'Linux' && !vars.SELF_HOSTED }}
+        if: ${{ github.repository == 'OrcaSlicer/OrcaSlicer' && ! env.ACT && github.ref == 'refs/heads/main' && runner.os == 'Linux' && !vars.SELF_HOSTED && inputs.arch != 'aarch64' }}
         uses: WebFreak001/deploy-nightly@v3.2.0
         with:
           upload_url: https://uploads.github.com/repos/OrcaSlicer/OrcaSlicer/releases/137995723/assets{?name,label}
@@ -483,7 +495,7 @@ jobs:
           max_releases: 1
 
       - name: Deploy orca_custom_preset_tests
-        if: ${{ github.repository == 'OrcaSlicer/OrcaSlicer' && ! env.ACT && github.ref == 'refs/heads/main' && runner.os == 'Linux' && !vars.SELF_HOSTED }}
+        if: ${{ github.repository == 'OrcaSlicer/OrcaSlicer' && ! env.ACT && github.ref == 'refs/heads/main' && runner.os == 'Linux' && !vars.SELF_HOSTED && inputs.arch != 'aarch64' }}
         uses: WebFreak001/deploy-nightly@v3.2.0
         with:
           upload_url: https://uploads.github.com/repos/OrcaSlicer/OrcaSlicer/releases/137995723/assets{?name,label}

--- a/README.md
+++ b/README.md
@@ -161,6 +161,8 @@ It can also be installed through graphical software managers (KDE Discover, GNOM
 
 ### AppImage
 
+AppImages are published for both **x86_64** and **aarch64** (ARM64). Pick the file matching your CPU — the ARM64 build has `aarch64` in its name (e.g. `OrcaSlicer_Linux_AppImage_Ubuntu2404_aarch64_*.AppImage`).
+
  1. Download App image from the [releases page](https://github.com/OrcaSlicer/OrcaSlicer/releases).
  2. Double click the downloaded file to run it.
 


### PR DESCRIPTION
# Description

Adds a **Linux ARM64 (aarch64)** build of the AppImage, alongside the existing x86_64 build.
The Linux CI job now builds both architectures, and the aarch64 AppImage is published to the
nightly and release pages just like the x86_64 one.

The **unit-test suite now runs on the aarch64 runner** (faster); the tests are built on that leg.

The README's AppImage section notes that both architectures are available.

# Screenshots/Recordings/Graphs

N/A — CI/build only.

## Tests

This PR's CI builds the x86_64 and aarch64 AppImages and runs the unit-test suite on the aarch64 runner.

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
