### PR TITLE
Pr/stderr to file

### DIFF
--- a/deps/Boost/Boost.cmake
+++ b/deps/Boost/Boost.cmake
@@ -10,7 +10,13 @@ if (APPLE AND CMAKE_OSX_ARCHITECTURES)
     set(_context_arch_line "-DBOOST_CONTEXT_ARCHITECTURE:STRING=${CMAKE_OSX_ARCHITECTURES}")
 endif ()
 
+set(_options "")
+if (MSVC)
+    set(_options "FORWARD_CONFIG")
+endif ()
+
 orcaslicer_add_cmake_project(Boost
+    ${_options}
     URL "https://github.com/boostorg/boost/releases/download/boost-1.84.0/boost-1.84.0.tar.gz"
     URL_HASH SHA256=4d27e9efed0f6f152dc28db6430b9d3dfb40c0345da7342eaa5a987dde57bd95
     LIST_SEPARATOR |

--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -155,16 +155,24 @@ if (NOT _is_multi AND NOT CMAKE_BUILD_TYPE)
 endif ()
 
 function(orcaslicer_add_cmake_project projectname)
-    cmake_parse_arguments(P_ARGS "" "INSTALL_DIR;BUILD_COMMAND;INSTALL_COMMAND" "CMAKE_ARGS" ${ARGN})
+    cmake_parse_arguments(P_ARGS "FORWARD_CONFIG" "INSTALL_DIR;BUILD_COMMAND;INSTALL_COMMAND" "CMAKE_ARGS" ${ARGN})
 
     set(_configs_line -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE})
     if (_is_multi OR MSVC)
-        if (ORCA_INCLUDE_DEBUG_INFO AND NOT DEP_DEBUG)
+        if (P_ARGS_FORWARD_CONFIG)
+            set(_configs_line -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE})
+        elseif (ORCA_INCLUDE_DEBUG_INFO AND NOT DEP_DEBUG)
             set(_configs_line "-DCMAKE_C_FLAGS_RELEASE:STRING=${CMAKE_C_FLAGS_RELWITHDEBINFO} -DCMAKE_CXX_FLAGS_RELEASE:STRING=${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
         else ()
             set(_configs_line "")
         endif ()
     endif ()
+
+    if (P_ARGS_FORWARD_CONFIG)
+        set(_target_config "$<CONFIG>")
+    else()
+        set(_target_config "Release")
+    endif()
 
     if (MSVC)
       set(_gen CMAKE_GENERATOR "${DEP_MSVC_GEN}" CMAKE_GENERATOR_PLATFORM "${DEP_PLATFORM}")
@@ -206,8 +214,8 @@ if (NOT IS_CROSS_COMPILE OR NOT APPLE)
             ${DEP_CMAKE_OPTS}
             ${P_ARGS_CMAKE_ARGS}
        ${P_ARGS_UNPARSED_ARGUMENTS}
-       BUILD_COMMAND ${CMAKE_COMMAND} --build . --config Release -- ${_build_j}
-       INSTALL_COMMAND ${CMAKE_COMMAND} --build . --target install --config Release
+       BUILD_COMMAND ${CMAKE_COMMAND} --build . --config ${_target_config} -- ${_build_j}
+       INSTALL_COMMAND ${CMAKE_COMMAND} --build . --target install --config ${_target_config}
     )
 
     if (FLATPAK)
@@ -247,8 +255,8 @@ else()
             ${DEP_CMAKE_OPTS}
             ${P_ARGS_CMAKE_ARGS}
        ${P_ARGS_UNPARSED_ARGUMENTS}
-       BUILD_COMMAND ${CMAKE_COMMAND} --build . --config Release -- ${_build_j}
-       INSTALL_COMMAND ${CMAKE_COMMAND} --build . --target install --config Release
+       BUILD_COMMAND ${CMAKE_COMMAND} --build . --config ${_target_config} -- ${_build_j}
+       INSTALL_COMMAND ${CMAKE_COMMAND} --build . --target install --config ${_target_config}
     )
 
 endif()

--- a/deps/Draco/Draco.cmake
+++ b/deps/Draco/Draco.cmake
@@ -1,4 +1,10 @@
+set(_options "")
+if (MSVC)
+    set(_options "FORWARD_CONFIG")
+endif ()
+
 orcaslicer_add_cmake_project(Draco
+    ${_options}
     URL https://github.com/google/draco/archive/refs/tags/1.5.7.zip
     URL_HASH SHA256=27b72ba2d5ff3d0a9814ad40d4cb88f8dc89a35491c0866d952473f8f9416b77
 )

--- a/deps/Eigen/Eigen.cmake
+++ b/deps/Eigen/Eigen.cmake
@@ -1,5 +1,11 @@
+set(_eigen_extra_flags "")
+if (MSVC)
+    set(_eigen_extra_flags "-DCMAKE_CXX_FLAGS:STRING=/bigobj")
+endif ()
+
 orcaslicer_add_cmake_project(Eigen
     URL https://gitlab.com/libeigen/eigen/-/archive/5.0.1/eigen-5.0.1.zip
     URL_HASH SHA256=0dbb1f9e3aaad66f352c03227d8c983f6f0b49e0b07e71a7300f4abcc01aee12
+    CMAKE_ARGS "${_eigen_extra_flags}"
     DEPENDS dep_Boost dep_GMP dep_MPFR
 )

--- a/deps/OpenCV/OpenCV.cmake
+++ b/deps/OpenCV/OpenCV.cmake
@@ -1,7 +1,9 @@
 if (MSVC)
     set(_use_IPP "-DWITH_IPP=ON")
+    set(_options "FORWARD_CONFIG")
 else ()
     set(_use_IPP "-DWITH_IPP=OFF")
+    set(_options "")
 endif ()
 
 if (IN_GIT_REPO)
@@ -9,6 +11,7 @@ if (IN_GIT_REPO)
 endif ()
 
 orcaslicer_add_cmake_project(OpenCV
+    ${_options}
     URL https://github.com/opencv/opencv/archive/refs/tags/4.6.0.tar.gz
     URL_HASH SHA256=1ec1cba65f9f20fe5a41fda1586e01c70ea0c9a6d7b67c9e13edf0cfe2239277
     PATCH_COMMAND git apply ${OpenCV_DIRECTORY_FLAG} --verbose --ignore-space-change --whitespace=fix ${CMAKE_CURRENT_LIST_DIR}/0001-vs.patch  ${CMAKE_CURRENT_LIST_DIR}/0002-clang19-macos.patch

--- a/src/OrcaSlicer.cpp
+++ b/src/OrcaSlicer.cpp
@@ -1357,6 +1357,10 @@ int CLI::run(int argc, char **argv)
     else {
         set_logging_level(2);
     }
+    const ConfigOptionString* opt_logfile = m_config.opt<ConfigOptionString>("logfile");
+    if (opt_logfile) {
+        set_logging_file(opt_logfile->value);
+    }
 
     global_begin_time = (long long)Slic3r::Utils::get_current_time_utc();
     BOOST_LOG_TRIVIAL(warning) << boost::format("cli mode, Current OrcaSlicer Version %1%")%SoftFever_VERSION;

--- a/src/OrcaSlicer.cpp
+++ b/src/OrcaSlicer.cpp
@@ -1361,6 +1361,10 @@ int CLI::run(int argc, char **argv)
     if (opt_logfile) {
         set_logging_file(opt_logfile->value);
     }
+    const ConfigOptionString* opt_errorfile = m_config.opt<ConfigOptionString>("errorfile");
+    if (opt_errorfile) {
+        set_error_file(opt_errorfile->value);
+    }
 
     global_begin_time = (long long)Slic3r::Utils::get_current_time_utc();
     BOOST_LOG_TRIVIAL(warning) << boost::format("cli mode, Current OrcaSlicer Version %1%")%SoftFever_VERSION;

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -10741,6 +10741,12 @@ CLIMiscConfigDef::CLIMiscConfigDef()
     def->cli_params = "file";
     def->set_default_value(new ConfigOptionString());
 
+    def = this->add("errorfile", coInt);
+    def->label = L("Error file");
+    def->tooltip = L("Redirects error messages to file.\n");
+    def->cli_params = "file";
+    def->set_default_value(new ConfigOptionString());
+
     def = this->add("enable_timelapse", coBool);
     def->label = L("Enable timelapse for print");
     def->tooltip = L("If enabled, this slicing will be considered using timelapse.");

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -9643,6 +9643,12 @@ void DynamicPrintConfig::update_values_to_printer_extruders_for_multiple_filamen
                 BOOST_LOG_TRIVIAL(warning) << __FUNCTION__ << boost::format(", Line %1%: can not find opt define for %2%")%__LINE__%key;
                 continue;
             }
+            ConfigOption *opt = this->option(key);
+            if (!opt) {
+                BOOST_LOG_TRIVIAL(warning) << __FUNCTION__ << boost::format(", Line %1%: can not find opt %2%")%__LINE__%key;
+                continue;
+            }
+
             switch (optdef->type) {
                 case coStrings:
                 {
@@ -10728,6 +10734,12 @@ CLIMiscConfigDef::CLIMiscConfigDef()
     def->min = 0;
     def->cli_params = "level";
     def->set_default_value(new ConfigOptionInt(1));
+
+    def = this->add("logfile", coInt);
+    def->label = L("Log file");
+    def->tooltip = L("Redirects debug logging to file.\n");
+    def->cli_params = "file";
+    def->set_default_value(new ConfigOptionString());
 
     def = this->add("enable_timelapse", coBool);
     def->label = L("Enable timelapse for print");

--- a/src/libslic3r/Utils.hpp
+++ b/src/libslic3r/Utils.hpp
@@ -79,6 +79,7 @@ namespace boost { namespace filesystem { class directory_entry; }}
 namespace Slic3r {
 
 extern void set_logging_level(unsigned int level);
+extern void set_logging_file(const std::string &file);
 extern unsigned int level_string_to_boost(std::string level);
 extern std::string  get_string_logging_level(unsigned level);
 extern unsigned get_logging_level();

--- a/src/libslic3r/Utils.hpp
+++ b/src/libslic3r/Utils.hpp
@@ -80,6 +80,7 @@ namespace Slic3r {
 
 extern void set_logging_level(unsigned int level);
 extern void set_logging_file(const std::string &file);
+extern void set_error_file(const std::string& file);
 extern unsigned int level_string_to_boost(std::string level);
 extern std::string  get_string_logging_level(unsigned level);
 extern unsigned get_logging_level();

--- a/src/libslic3r/utils.cpp
+++ b/src/libslic3r/utils.cpp
@@ -129,6 +129,11 @@ void set_logging_level(unsigned int level)
     );
 }
 
+void set_logging_file(const std::string &file)
+{
+	boost::log::add_file_log(file);
+}
+
 unsigned int level_string_to_boost(std::string level)
 {
     std::map<std::string, int> Control_Param;

--- a/src/libslic3r/utils.cpp
+++ b/src/libslic3r/utils.cpp
@@ -392,6 +392,24 @@ void flush_logs()
 	return;
 }
 
+void set_error_file(const std::string &file)
+{
+	static boost::nowide::ofstream *error_file = nullptr;
+	static std::streambuf *old_buf = nullptr;
+
+	if (error_file) {
+		error_file->close();
+		error_file = nullptr;
+		boost::nowide::cerr.rdbuf(old_buf);
+		old_buf = nullptr;
+	}
+
+	if (!file.empty()) {
+		error_file = new boost::nowide::ofstream(file);
+		old_buf = boost::nowide::cerr.rdbuf(error_file->rdbuf());
+	}
+}
+
 #ifdef _WIN32
 // The following helpers are borrowed from the LLVM project https://github.com/llvm
 namespace WindowsSupport

--- a/src/slic3r/GUI/BackgroundSlicingProcess.cpp
+++ b/src/slic3r/GUI/BackgroundSlicingProcess.cpp
@@ -696,7 +696,7 @@ Print::ApplyStatus BackgroundSlicingProcess::apply(const Model &model, const Dyn
 	Print::ApplyStatus invalidated = m_print->apply(model, new_config);
 
 	// Orca: prevent resetting under gcode viewer mode
-    if (invalidated != PrintBase::APPLY_STATUS_UNCHANGED) {
+    if ((invalidated != PrintBase::APPLY_STATUS_UNCHANGED) && GUI::wxGetApp().mainframe) {
         const auto plater = GUI::wxGetApp().mainframe->m_plater;
         if (plater && plater->only_gcode_mode()) {
             invalidated = PrintBase::APPLY_STATUS_UNCHANGED;

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -2909,7 +2909,19 @@ static std::vector<std::string> intersect(std::vector<std::string> const& l, std
 static std::vector<std::string> concat(std::vector<std::string> const& l, std::vector<std::string> const& r)
 {
     std::vector<std::string> t;
-    std::set_union(l.begin(), l.end(), r.begin(), r.end(), std::back_inserter(t));
+    bool l_sorted = std::is_sorted(l.begin(), l.end());
+    bool r_sorted = std::is_sorted(r.begin(), r.end());
+
+    if (l_sorted && r_sorted) {
+        std::set_union(l.begin(), l.end(), r.begin(), r.end(), std::back_inserter(t));
+        return t;
+    }
+
+    std::vector<std::string> l_sorted = l;
+    std::vector<std::string> r_sorted = r;
+    std::sort(l_sorted.begin(), l_sorted.end());
+    std::sort(r_sorted.begin(), r_sorted.end());
+    std::set_union(l_sorted.begin(), l_sorted.end(), r_sorted.begin(), r_sorted.end(), std::back_inserter(t));
     return t;
 }
 


### PR DESCRIPTION
# Description

On Windows, when running the OrcaSlicer CLI, output to stderr is lost because the executable uses the Windows subsystem.  Similar to the recently added option to capture the output of the boost-based log in a file, this option can be used to redirect stderr to a file:

    --errorfile <path>

If the option is not used, nothing changes in OrcaSlicer or OrcaSlicer CLI.

## Tests

Running OrcaSlicer CLI with the argument shown above.

