### PR TITLE
add option to redirect stderr to a file

### DIFF
--- a/src/OrcaSlicer.cpp
+++ b/src/OrcaSlicer.cpp
@@ -1426,6 +1426,10 @@ int CLI::run(int argc, char **argv)
     if (opt_logfile) {
         set_logging_file(opt_logfile->value);
     }
+    const ConfigOptionString* opt_errorfile = m_config.opt<ConfigOptionString>("errorfile");
+    if (opt_errorfile) {
+        set_error_file(opt_errorfile->value);
+    }
 
     global_begin_time = (long long)Slic3r::Utils::get_current_time_utc();
     BOOST_LOG_TRIVIAL(warning) << boost::format("cli mode, Current OrcaSlicer Version %1%")%SoftFever_VERSION;

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -10870,6 +10870,12 @@ CLIMiscConfigDef::CLIMiscConfigDef()
     def->cli_params = "file";
     def->set_default_value(new ConfigOptionString());
 
+    def = this->add("errorfile", coInt);
+    def->label = L("Error file");
+    def->tooltip = L("Redirects error messages to file.\n");
+    def->cli_params = "file";
+    def->set_default_value(new ConfigOptionString());
+
     def = this->add("enable_timelapse", coBool);
     def->label = L("Enable timelapse for print");
     def->tooltip = L("If enabled, this slicing will be considered using timelapse.");

--- a/src/libslic3r/Utils.hpp
+++ b/src/libslic3r/Utils.hpp
@@ -80,6 +80,7 @@ namespace Slic3r {
 
 extern void set_logging_level(unsigned int level);
 extern void set_logging_file(const std::string &file);
+extern void set_error_file(const std::string& file);
 extern unsigned int level_string_to_boost(std::string level);
 extern std::string  get_string_logging_level(unsigned level);
 extern unsigned get_logging_level();

--- a/src/libslic3r/utils.cpp
+++ b/src/libslic3r/utils.cpp
@@ -400,6 +400,24 @@ boost::filesystem::path get_log_file_name()
     return {};
 }
 
+void set_error_file(const std::string &file)
+{
+	static boost::nowide::ofstream *error_file = nullptr;
+	static std::streambuf *old_buf = nullptr;
+
+	if (error_file) {
+		error_file->close();
+		error_file = nullptr;
+		boost::nowide::cerr.rdbuf(old_buf);
+		old_buf = nullptr;
+	}
+
+	if (!file.empty()) {
+		error_file = new boost::nowide::ofstream(file);
+		old_buf = boost::nowide::cerr.rdbuf(error_file->rdbuf());
+	}
+}
+
 #ifdef _WIN32
 // The following helpers are borrowed from the LLVM project https://github.com/llvm
 namespace WindowsSupport


### PR DESCRIPTION
# Description

On Windows, OrcaSlicer is built with the Windows subsystem, which doesn't support stderr.  When running OrcaSlicer CLI, fatal error messages that get written to stderr are lost.  This PR adds an option to redirect stderr to a file:

    --errorfile <path>
    
This is similar to a recently submitted and merged PR that gives the option to write Boost's log a file.

## Tests

Running OrcaSlicer CLI with the above option.  Fatal errors can be triggered with invalid command line arguments.

