### PR TITLE
Refine CHB parciall bridge

### DIFF
--- a/src/libslic3r/PerimeterGenerator.cpp
+++ b/src/libslic3r/PerimeterGenerator.cpp
@@ -1875,7 +1875,15 @@ void PerimeterGenerator::process_no_bridge(Surfaces& all_surfaces, coord_t perim
                                 bridgeable_filtered = union_ex(offset_ex(last, perimeter_spacing), bridgeable_filtered);
                                 bridgeable_filtered = offset_ex(bridgeable_filtered, -perimeter_spacing);
                                 bridgeable_filtered = diff_ex(bridgeable_filtered, last, ApplySafetyOffset::Yes);
-                                bridgeable_filtered = opening_ex(bridgeable_filtered, perimeter_spacing); // filter noise from the diff_ex
+                                ExPolygons bridgeable_smoothed;
+                                for (const ExPolygon& span : bridgeable_filtered) {
+                                    ExPolygons span_opened = opening_ex(ExPolygons{ span }, perimeter_spacing);
+                                    if (area(span_opened) >= 0.5 * std::abs(span.area()))
+                                        append(bridgeable_smoothed, std::move(span_opened)); // big span: keep smoothed shape
+                                    else
+                                        bridgeable_smoothed.push_back(span);                 // small/middle span: keep full length
+                                }
+                                bridgeable_filtered = std::move(bridgeable_smoothed);
                                 bridgeable_filtered = offset_ex(bridgeable_filtered, perimeter_spacing);  // restore the size to the original bridgeable area
                                 // Safety measure: Keep the bridge mask from intruding deeper into the
                                 // supported anchor region (`last`) than the explicit anchor overlap.


### PR DESCRIPTION
Fixes https://github.com/OrcaSlicer/OrcaSlicer/issues/13828#issuecomment-4682204549

Running a full perimeter_spacing opening on the whole diff_ex mask causes problems.
It adds noise to the downstream bridge-angle detection (especially messing up symmetric or circular counterbores) and its erode step can chew up or completely wipe out smaller spans.

To fix that, ditches the single opening_ex call and instead smoothing each bridge span on its own. 

The rule: we try opening a span, and if the opened version still has at least half of its original area, we keep it—nice and smoothed, ready for accurate angle detection. But if the opening eats away more than half (or straight-up deletes it), we just keep the original raw span instead.

This way, big spans get their noise filtered out without losing much, while smaller or mid-size spans don't get shortened into oblivion—which is fine, because their bridge direction is kind of ambiguous anyway. And don't worry, we're keeping all the existing offset and restore behavior exactly as it was.

<img width="645" height="915" alt="imagen" src="https://github.com/user-attachments/assets/04cae99d-d9b1-436a-a28f-30891b9fa883" />

As always thanks @RF47 he found the issue origin.

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
