### PR TITLE
Fix duplicate Flashforge filaments in system filament list

### DIFF
--- a/resources/profiles/Flashforge.json
+++ b/resources/profiles/Flashforge.json
@@ -1,7 +1,7 @@
 {
 	"name": "Flashforge",
 	"url": "",
-	"version": "02.04.00.01",
+	"version": "02.04.00.02",
 	"force_update": "0",
 	"description": "Flashforge configurations",
 	"machine_model_list": [

--- a/resources/profiles/Flashforge/filament/Flashforge ABS Basic @FF AD5M 0.25 nozzle.json
+++ b/resources/profiles/Flashforge/filament/Flashforge ABS Basic @FF AD5M 0.25 nozzle.json
@@ -9,14 +9,7 @@
 		"Flashforge ABS Basic @FF AD5M 0.25 nozzle"
 	],
 	"compatible_printers": [
-		"Flashforge Adventurer 5M 0.4 Nozzle",
-		"Flashforge Adventurer 5M 0.6 Nozzle",
-		"Flashforge Adventurer 5M 0.8 Nozzle",
-		"Flashforge Adventurer 5M Pro 0.4 Nozzle",
-		"Flashforge Adventurer 5M Pro 0.6 Nozzle",
-		"Flashforge Adventurer 5M Pro 0.8 Nozzle",
-		"Flashforge AD5X 0.4 nozzle",
-		"Flashforge AD5X 0.6 nozzle",
-		"Flashforge AD5X 0.8 nozzle"
+		"Flashforge Adventurer 5M 0.25 Nozzle",
+		"Flashforge Adventurer 5M Pro 0.25 Nozzle"
 	]
 }

--- a/resources/profiles/Flashforge/filament/Flashforge ABS Basic.json
+++ b/resources/profiles/Flashforge/filament/Flashforge ABS Basic.json
@@ -14,9 +14,6 @@
 		"Flashforge Adventurer 5M 0.8 Nozzle",
 		"Flashforge Adventurer 5M Pro 0.4 Nozzle",
 		"Flashforge Adventurer 5M Pro 0.6 Nozzle",
-		"Flashforge Adventurer 5M Pro 0.8 Nozzle",
-		"Flashforge AD5X 0.4 nozzle",
-		"Flashforge AD5X 0.6 nozzle",
-		"Flashforge AD5X 0.8 nozzle"
+		"Flashforge Adventurer 5M Pro 0.8 Nozzle"
 	]
 }

--- a/resources/profiles/Flashforge/filament/Flashforge ASA Basic @FF AD5M 0.25 nozzle.json
+++ b/resources/profiles/Flashforge/filament/Flashforge ASA Basic @FF AD5M 0.25 nozzle.json
@@ -9,14 +9,7 @@
 		"Flashforge ASA Basic @FF AD5M 0.25 nozzle"
 	],
 	"compatible_printers": [
-		"Flashforge Adventurer 5M 0.4 Nozzle",
-		"Flashforge Adventurer 5M 0.6 Nozzle",
-		"Flashforge Adventurer 5M 0.8 Nozzle",
-		"Flashforge Adventurer 5M Pro 0.4 Nozzle",
-		"Flashforge Adventurer 5M Pro 0.6 Nozzle",
-		"Flashforge Adventurer 5M Pro 0.8 Nozzle",
-		"Flashforge AD5X 0.4 nozzle",
-		"Flashforge AD5X 0.6 nozzle",
-		"Flashforge AD5X 0.8 nozzle"
+		"Flashforge Adventurer 5M 0.25 Nozzle",
+		"Flashforge Adventurer 5M Pro 0.25 Nozzle"
 	]
 }

--- a/resources/profiles/Flashforge/filament/Flashforge ASA Basic.json
+++ b/resources/profiles/Flashforge/filament/Flashforge ASA Basic.json
@@ -14,9 +14,6 @@
 		"Flashforge Adventurer 5M 0.8 Nozzle",
 		"Flashforge Adventurer 5M Pro 0.4 Nozzle",
 		"Flashforge Adventurer 5M Pro 0.6 Nozzle",
-		"Flashforge Adventurer 5M Pro 0.8 Nozzle",
-		"Flashforge AD5X 0.4 nozzle",
-		"Flashforge AD5X 0.6 nozzle",
-		"Flashforge AD5X 0.8 nozzle"
+		"Flashforge Adventurer 5M Pro 0.8 Nozzle"
 	]
 }

--- a/resources/profiles/Flashforge/filament/Flashforge HS PETG @FF AD5M 0.25 nozzle.json
+++ b/resources/profiles/Flashforge/filament/Flashforge HS PETG @FF AD5M 0.25 nozzle.json
@@ -9,14 +9,7 @@
 		"Flashforge HS PETG @FF AD5M 0.25 nozzle"
 	],
 	"compatible_printers": [
-		"Flashforge Adventurer 5M 0.4 Nozzle",
-		"Flashforge Adventurer 5M 0.6 Nozzle",
-		"Flashforge Adventurer 5M 0.8 Nozzle",
-		"Flashforge Adventurer 5M Pro 0.4 Nozzle",
-		"Flashforge Adventurer 5M Pro 0.6 Nozzle",
-		"Flashforge Adventurer 5M Pro 0.8 Nozzle",
-		"Flashforge AD5X 0.4 nozzle",
-		"Flashforge AD5X 0.6 nozzle",
-		"Flashforge AD5X 0.8 nozzle"
+		"Flashforge Adventurer 5M 0.25 Nozzle",
+		"Flashforge Adventurer 5M Pro 0.25 Nozzle"
 	]
 }

--- a/resources/profiles/Flashforge/filament/Flashforge HS PETG.json
+++ b/resources/profiles/Flashforge/filament/Flashforge HS PETG.json
@@ -14,9 +14,6 @@
 		"Flashforge Adventurer 5M 0.8 Nozzle",
 		"Flashforge Adventurer 5M Pro 0.4 Nozzle",
 		"Flashforge Adventurer 5M Pro 0.6 Nozzle",
-		"Flashforge Adventurer 5M Pro 0.8 Nozzle",
-		"Flashforge AD5X 0.4 nozzle",
-		"Flashforge AD5X 0.6 nozzle",
-		"Flashforge AD5X 0.8 nozzle"
+		"Flashforge Adventurer 5M Pro 0.8 Nozzle"
 	]
 }

--- a/resources/profiles/Flashforge/filament/Flashforge PETG Basic @FF AD5M 0.25 nozzle.json
+++ b/resources/profiles/Flashforge/filament/Flashforge PETG Basic @FF AD5M 0.25 nozzle.json
@@ -9,14 +9,7 @@
 		"Flashforge PETG Basic @FF AD5M 0.25 nozzle"
 	],
 	"compatible_printers": [
-		"Flashforge Adventurer 5M 0.4 Nozzle",
-		"Flashforge Adventurer 5M 0.6 Nozzle",
-		"Flashforge Adventurer 5M 0.8 Nozzle",
-		"Flashforge Adventurer 5M Pro 0.4 Nozzle",
-		"Flashforge Adventurer 5M Pro 0.6 Nozzle",
-		"Flashforge Adventurer 5M Pro 0.8 Nozzle",
-		"Flashforge AD5X 0.4 nozzle",
-		"Flashforge AD5X 0.6 nozzle",
-		"Flashforge AD5X 0.8 nozzle"
+		"Flashforge Adventurer 5M 0.25 Nozzle",
+		"Flashforge Adventurer 5M Pro 0.25 Nozzle"
 	]
 }

--- a/resources/profiles/Flashforge/filament/Flashforge PETG Pro @FF AD5M 0.25 nozzle.json
+++ b/resources/profiles/Flashforge/filament/Flashforge PETG Pro @FF AD5M 0.25 nozzle.json
@@ -9,14 +9,7 @@
 		"Flashforge PETG Pro @FF AD5M 0.25 nozzle"
 	],
 	"compatible_printers": [
-		"Flashforge Adventurer 5M 0.4 Nozzle",
-		"Flashforge Adventurer 5M 0.6 Nozzle",
-		"Flashforge Adventurer 5M 0.8 Nozzle",
-		"Flashforge Adventurer 5M Pro 0.4 Nozzle",
-		"Flashforge Adventurer 5M Pro 0.6 Nozzle",
-		"Flashforge Adventurer 5M Pro 0.8 Nozzle",
-		"Flashforge AD5X 0.4 nozzle",
-		"Flashforge AD5X 0.6 nozzle",
-		"Flashforge AD5X 0.8 nozzle"
+		"Flashforge Adventurer 5M 0.25 Nozzle",
+		"Flashforge Adventurer 5M Pro 0.25 Nozzle"
 	]
 }

--- a/resources/profiles/Flashforge/filament/Flashforge PETG Pro.json
+++ b/resources/profiles/Flashforge/filament/Flashforge PETG Pro.json
@@ -32,9 +32,6 @@
 		"Flashforge Adventurer 5M 0.8 Nozzle",
 		"Flashforge Adventurer 5M Pro 0.4 Nozzle",
 		"Flashforge Adventurer 5M Pro 0.6 Nozzle",
-		"Flashforge Adventurer 5M Pro 0.8 Nozzle",
-		"Flashforge AD5X 0.4 nozzle",
-		"Flashforge AD5X 0.6 nozzle",
-		"Flashforge AD5X 0.8 nozzle"
+		"Flashforge Adventurer 5M Pro 0.8 Nozzle"
 	]
 }

--- a/resources/profiles/Flashforge/filament/Flashforge PETG Transparent @FF AD5M 0.25 nozzle.json
+++ b/resources/profiles/Flashforge/filament/Flashforge PETG Transparent @FF AD5M 0.25 nozzle.json
@@ -9,14 +9,7 @@
 		"Flashforge PETG Transparent @FF AD5M 0.25 nozzle"
 	],
 	"compatible_printers": [
-		"Flashforge Adventurer 5M 0.4 Nozzle",
-		"Flashforge Adventurer 5M 0.6 Nozzle",
-		"Flashforge Adventurer 5M 0.8 Nozzle",
-		"Flashforge Adventurer 5M Pro 0.4 Nozzle",
-		"Flashforge Adventurer 5M Pro 0.6 Nozzle",
-		"Flashforge Adventurer 5M Pro 0.8 Nozzle",
-		"Flashforge AD5X 0.4 nozzle",
-		"Flashforge AD5X 0.6 nozzle",
-		"Flashforge AD5X 0.8 nozzle"
+		"Flashforge Adventurer 5M 0.25 Nozzle",
+		"Flashforge Adventurer 5M Pro 0.25 Nozzle"
 	]
 }

--- a/resources/profiles/Flashforge/filament/Flashforge PETG Transparent.json
+++ b/resources/profiles/Flashforge/filament/Flashforge PETG Transparent.json
@@ -32,9 +32,6 @@
 		"Flashforge Adventurer 5M 0.8 Nozzle",
 		"Flashforge Adventurer 5M Pro 0.4 Nozzle",
 		"Flashforge Adventurer 5M Pro 0.6 Nozzle",
-		"Flashforge Adventurer 5M Pro 0.8 Nozzle",
-		"Flashforge AD5X 0.4 nozzle",
-		"Flashforge AD5X 0.6 nozzle",
-		"Flashforge AD5X 0.8 nozzle"
+		"Flashforge Adventurer 5M Pro 0.8 Nozzle"
 	]
 }

--- a/resources/profiles/Flashforge/filament/Flashforge PLA Basic @FF AD5M 0.25 nozzle.json
+++ b/resources/profiles/Flashforge/filament/Flashforge PLA Basic @FF AD5M 0.25 nozzle.json
@@ -9,14 +9,7 @@
 		"Flashforge PLA Basic @FF AD5M 0.25 nozzle"
 	],
 	"compatible_printers": [
-		"Flashforge Adventurer 5M 0.4 Nozzle",
-		"Flashforge Adventurer 5M 0.6 Nozzle",
-		"Flashforge Adventurer 5M 0.8 Nozzle",
-		"Flashforge Adventurer 5M Pro 0.4 Nozzle",
-		"Flashforge Adventurer 5M Pro 0.6 Nozzle",
-		"Flashforge Adventurer 5M Pro 0.8 Nozzle",
-		"Flashforge AD5X 0.4 nozzle",
-		"Flashforge AD5X 0.6 nozzle",
-		"Flashforge AD5X 0.8 nozzle"
+		"Flashforge Adventurer 5M 0.25 Nozzle",
+		"Flashforge Adventurer 5M Pro 0.25 Nozzle"
 	]
 }

--- a/resources/profiles/Flashforge/filament/Flashforge PLA Basic.json
+++ b/resources/profiles/Flashforge/filament/Flashforge PLA Basic.json
@@ -14,9 +14,6 @@
 		"Flashforge Adventurer 5M 0.8 Nozzle",
 		"Flashforge Adventurer 5M Pro 0.4 Nozzle",
 		"Flashforge Adventurer 5M Pro 0.6 Nozzle",
-		"Flashforge Adventurer 5M Pro 0.8 Nozzle",
-		"Flashforge AD5X 0.4 nozzle",
-		"Flashforge AD5X 0.6 nozzle",
-		"Flashforge AD5X 0.8 nozzle"
+		"Flashforge Adventurer 5M Pro 0.8 Nozzle"
 	]
 }

--- a/resources/profiles/Flashforge/filament/Flashforge PLA Color Change @FF AD5M 0.25 nozzle.json
+++ b/resources/profiles/Flashforge/filament/Flashforge PLA Color Change @FF AD5M 0.25 nozzle.json
@@ -9,14 +9,7 @@
 		"Flashforge PLA Color Change @FF AD5M 0.25 nozzle"
 	],
 	"compatible_printers": [
-		"Flashforge Adventurer 5M 0.4 Nozzle",
-		"Flashforge Adventurer 5M 0.6 Nozzle",
-		"Flashforge Adventurer 5M 0.8 Nozzle",
-		"Flashforge Adventurer 5M Pro 0.4 Nozzle",
-		"Flashforge Adventurer 5M Pro 0.6 Nozzle",
-		"Flashforge Adventurer 5M Pro 0.8 Nozzle",
-		"Flashforge AD5X 0.4 nozzle",
-		"Flashforge AD5X 0.6 nozzle",
-		"Flashforge AD5X 0.8 nozzle"
+		"Flashforge Adventurer 5M 0.25 Nozzle",
+		"Flashforge Adventurer 5M Pro 0.25 Nozzle"
 	]
 }

--- a/resources/profiles/Flashforge/filament/Flashforge PLA Color Change.json
+++ b/resources/profiles/Flashforge/filament/Flashforge PLA Color Change.json
@@ -14,9 +14,6 @@
 		"Flashforge Adventurer 5M 0.8 Nozzle",
 		"Flashforge Adventurer 5M Pro 0.4 Nozzle",
 		"Flashforge Adventurer 5M Pro 0.6 Nozzle",
-		"Flashforge Adventurer 5M Pro 0.8 Nozzle",
-		"Flashforge AD5X 0.4 nozzle",
-		"Flashforge AD5X 0.6 nozzle",
-		"Flashforge AD5X 0.8 nozzle"
+		"Flashforge Adventurer 5M Pro 0.8 Nozzle"
 	]
 }

--- a/resources/profiles/Flashforge/filament/Flashforge PLA Galaxy @FF AD5M 0.25 nozzle.json
+++ b/resources/profiles/Flashforge/filament/Flashforge PLA Galaxy @FF AD5M 0.25 nozzle.json
@@ -9,14 +9,7 @@
 		"Flashforge PLA Galaxy @FF AD5M 0.25 nozzle"
 	],
 	"compatible_printers": [
-		"Flashforge Adventurer 5M 0.4 Nozzle",
-		"Flashforge Adventurer 5M 0.6 Nozzle",
-		"Flashforge Adventurer 5M 0.8 Nozzle",
-		"Flashforge Adventurer 5M Pro 0.4 Nozzle",
-		"Flashforge Adventurer 5M Pro 0.6 Nozzle",
-		"Flashforge Adventurer 5M Pro 0.8 Nozzle",
-		"Flashforge AD5X 0.4 nozzle",
-		"Flashforge AD5X 0.6 nozzle",
-		"Flashforge AD5X 0.8 nozzle"
+		"Flashforge Adventurer 5M 0.25 Nozzle",
+		"Flashforge Adventurer 5M Pro 0.25 Nozzle"
 	]
 }

--- a/resources/profiles/Flashforge/filament/Flashforge PLA Galaxy.json
+++ b/resources/profiles/Flashforge/filament/Flashforge PLA Galaxy.json
@@ -14,9 +14,6 @@
 		"Flashforge Adventurer 5M 0.8 Nozzle",
 		"Flashforge Adventurer 5M Pro 0.4 Nozzle",
 		"Flashforge Adventurer 5M Pro 0.6 Nozzle",
-		"Flashforge Adventurer 5M Pro 0.8 Nozzle",
-		"Flashforge AD5X 0.4 nozzle",
-		"Flashforge AD5X 0.6 nozzle",
-		"Flashforge AD5X 0.8 nozzle"
+		"Flashforge Adventurer 5M Pro 0.8 Nozzle"
 	]
 }

--- a/resources/profiles/Flashforge/filament/Flashforge PLA Luminous @FF AD5M 0.25 nozzle.json
+++ b/resources/profiles/Flashforge/filament/Flashforge PLA Luminous @FF AD5M 0.25 nozzle.json
@@ -9,14 +9,7 @@
 		"Flashforge PLA Luminous @FF AD5M 0.25 nozzle"
 	],
 	"compatible_printers": [
-		"Flashforge Adventurer 5M 0.4 Nozzle",
-		"Flashforge Adventurer 5M 0.6 Nozzle",
-		"Flashforge Adventurer 5M 0.8 Nozzle",
-		"Flashforge Adventurer 5M Pro 0.4 Nozzle",
-		"Flashforge Adventurer 5M Pro 0.6 Nozzle",
-		"Flashforge Adventurer 5M Pro 0.8 Nozzle",
-		"Flashforge AD5X 0.4 nozzle",
-		"Flashforge AD5X 0.6 nozzle",
-		"Flashforge AD5X 0.8 nozzle"
+		"Flashforge Adventurer 5M 0.25 Nozzle",
+		"Flashforge Adventurer 5M Pro 0.25 Nozzle"
 	]
 }

--- a/resources/profiles/Flashforge/filament/Flashforge PLA Luminous.json
+++ b/resources/profiles/Flashforge/filament/Flashforge PLA Luminous.json
@@ -14,9 +14,6 @@
 		"Flashforge Adventurer 5M 0.8 Nozzle",
 		"Flashforge Adventurer 5M Pro 0.4 Nozzle",
 		"Flashforge Adventurer 5M Pro 0.6 Nozzle",
-		"Flashforge Adventurer 5M Pro 0.8 Nozzle",
-		"Flashforge AD5X 0.4 nozzle",
-		"Flashforge AD5X 0.6 nozzle",
-		"Flashforge AD5X 0.8 nozzle"
+		"Flashforge Adventurer 5M Pro 0.8 Nozzle"
 	]
 }

--- a/resources/profiles/Flashforge/filament/Flashforge PLA Matte @FF AD5M 0.25 nozzle.json
+++ b/resources/profiles/Flashforge/filament/Flashforge PLA Matte @FF AD5M 0.25 nozzle.json
@@ -9,14 +9,7 @@
 		"Flashforge PLA Matte @FF AD5M 0.25 nozzle"
 	],
 	"compatible_printers": [
-		"Flashforge Adventurer 5M 0.4 Nozzle",
-		"Flashforge Adventurer 5M 0.6 Nozzle",
-		"Flashforge Adventurer 5M 0.8 Nozzle",
-		"Flashforge Adventurer 5M Pro 0.4 Nozzle",
-		"Flashforge Adventurer 5M Pro 0.6 Nozzle",
-		"Flashforge Adventurer 5M Pro 0.8 Nozzle",
-		"Flashforge AD5X 0.4 nozzle",
-		"Flashforge AD5X 0.6 nozzle",
-		"Flashforge AD5X 0.8 nozzle"
+		"Flashforge Adventurer 5M 0.25 Nozzle",
+		"Flashforge Adventurer 5M Pro 0.25 Nozzle"
 	]
 }

--- a/resources/profiles/Flashforge/filament/Flashforge PLA Matte.json
+++ b/resources/profiles/Flashforge/filament/Flashforge PLA Matte.json
@@ -17,9 +17,6 @@
 		"Flashforge Adventurer 5M 0.8 Nozzle",
 		"Flashforge Adventurer 5M Pro 0.4 Nozzle",
 		"Flashforge Adventurer 5M Pro 0.6 Nozzle",
-		"Flashforge Adventurer 5M Pro 0.8 Nozzle",
-		"Flashforge AD5X 0.4 nozzle",
-		"Flashforge AD5X 0.6 nozzle",
-		"Flashforge AD5X 0.8 nozzle"
+		"Flashforge Adventurer 5M Pro 0.8 Nozzle"
 	]
 }

--- a/resources/profiles/Flashforge/filament/Flashforge PLA Metal @FF AD5M 0.25 nozzle.json
+++ b/resources/profiles/Flashforge/filament/Flashforge PLA Metal @FF AD5M 0.25 nozzle.json
@@ -9,14 +9,7 @@
 		"Flashforge PLA Metal @FF AD5M 0.25 nozzle"
 	],
 	"compatible_printers": [
-		"Flashforge Adventurer 5M 0.4 Nozzle",
-		"Flashforge Adventurer 5M 0.6 Nozzle",
-		"Flashforge Adventurer 5M 0.8 Nozzle",
-		"Flashforge Adventurer 5M Pro 0.4 Nozzle",
-		"Flashforge Adventurer 5M Pro 0.6 Nozzle",
-		"Flashforge Adventurer 5M Pro 0.8 Nozzle",
-		"Flashforge AD5X 0.4 nozzle",
-		"Flashforge AD5X 0.6 nozzle",
-		"Flashforge AD5X 0.8 nozzle"
+		"Flashforge Adventurer 5M 0.25 Nozzle",
+		"Flashforge Adventurer 5M Pro 0.25 Nozzle"
 	]
 }

--- a/resources/profiles/Flashforge/filament/Flashforge PLA Metal.json
+++ b/resources/profiles/Flashforge/filament/Flashforge PLA Metal.json
@@ -14,9 +14,6 @@
 		"Flashforge Adventurer 5M 0.8 Nozzle",
 		"Flashforge Adventurer 5M Pro 0.4 Nozzle",
 		"Flashforge Adventurer 5M Pro 0.6 Nozzle",
-		"Flashforge Adventurer 5M Pro 0.8 Nozzle",
-		"Flashforge AD5X 0.4 nozzle",
-		"Flashforge AD5X 0.6 nozzle",
-		"Flashforge AD5X 0.8 nozzle"
+		"Flashforge Adventurer 5M Pro 0.8 Nozzle"
 	]
 }

--- a/resources/profiles/Flashforge/filament/Flashforge PLA Pro @FF AD5M 0.25 nozzle.json
+++ b/resources/profiles/Flashforge/filament/Flashforge PLA Pro @FF AD5M 0.25 nozzle.json
@@ -9,14 +9,7 @@
 		"Flashforge PLA Pro @FF AD5M 0.25 nozzle"
 	],
 	"compatible_printers": [
-		"Flashforge Adventurer 5M 0.4 Nozzle",
-		"Flashforge Adventurer 5M 0.6 Nozzle",
-		"Flashforge Adventurer 5M 0.8 Nozzle",
-		"Flashforge Adventurer 5M Pro 0.4 Nozzle",
-		"Flashforge Adventurer 5M Pro 0.6 Nozzle",
-		"Flashforge Adventurer 5M Pro 0.8 Nozzle",
-		"Flashforge AD5X 0.4 nozzle",
-		"Flashforge AD5X 0.6 nozzle",
-		"Flashforge AD5X 0.8 nozzle"
+		"Flashforge Adventurer 5M 0.25 Nozzle",
+		"Flashforge Adventurer 5M Pro 0.25 Nozzle"
 	]
 }

--- a/resources/profiles/Flashforge/filament/Flashforge PLA Pro.json
+++ b/resources/profiles/Flashforge/filament/Flashforge PLA Pro.json
@@ -14,9 +14,6 @@
 		"Flashforge Adventurer 5M 0.8 Nozzle",
 		"Flashforge Adventurer 5M Pro 0.4 Nozzle",
 		"Flashforge Adventurer 5M Pro 0.6 Nozzle",
-		"Flashforge Adventurer 5M Pro 0.8 Nozzle",
-		"Flashforge AD5X 0.4 nozzle",
-		"Flashforge AD5X 0.6 nozzle",
-		"Flashforge AD5X 0.8 nozzle"
+		"Flashforge Adventurer 5M Pro 0.8 Nozzle"
 	]
 }

--- a/resources/profiles/Flashforge/filament/Flashforge PLA Silk @FF AD5M 0.25 nozzle.json
+++ b/resources/profiles/Flashforge/filament/Flashforge PLA Silk @FF AD5M 0.25 nozzle.json
@@ -9,14 +9,7 @@
 		"Flashforge PLA Silk @FF AD5M 0.25 nozzle"
 	],
 	"compatible_printers": [
-		"Flashforge Adventurer 5M 0.4 Nozzle",
-		"Flashforge Adventurer 5M 0.6 Nozzle",
-		"Flashforge Adventurer 5M 0.8 Nozzle",
-		"Flashforge Adventurer 5M Pro 0.4 Nozzle",
-		"Flashforge Adventurer 5M Pro 0.6 Nozzle",
-		"Flashforge Adventurer 5M Pro 0.8 Nozzle",
-		"Flashforge AD5X 0.4 nozzle",
-		"Flashforge AD5X 0.6 nozzle",
-		"Flashforge AD5X 0.8 nozzle"
+		"Flashforge Adventurer 5M 0.25 Nozzle",
+		"Flashforge Adventurer 5M Pro 0.25 Nozzle"
 	]
 }

--- a/resources/profiles/Flashforge/filament/Flashforge PLA Silk.json
+++ b/resources/profiles/Flashforge/filament/Flashforge PLA Silk.json
@@ -14,9 +14,6 @@
 		"Flashforge Adventurer 5M 0.8 Nozzle",
 		"Flashforge Adventurer 5M Pro 0.4 Nozzle",
 		"Flashforge Adventurer 5M Pro 0.6 Nozzle",
-		"Flashforge Adventurer 5M Pro 0.8 Nozzle",
-		"Flashforge AD5X 0.4 nozzle",
-		"Flashforge AD5X 0.6 nozzle",
-		"Flashforge AD5X 0.8 nozzle"
+		"Flashforge Adventurer 5M Pro 0.8 Nozzle"
 	]
 }

--- a/resources/profiles/Flashforge/filament/Flashforge PLA Sparkle @FF AD5M 0.25 nozzle.json
+++ b/resources/profiles/Flashforge/filament/Flashforge PLA Sparkle @FF AD5M 0.25 nozzle.json
@@ -9,14 +9,7 @@
 		"Flashforge PLA Sparkle @FF AD5M 0.25 nozzle"
 	],
 	"compatible_printers": [
-		"Flashforge Adventurer 5M 0.4 Nozzle",
-		"Flashforge Adventurer 5M 0.6 Nozzle",
-		"Flashforge Adventurer 5M 0.8 Nozzle",
-		"Flashforge Adventurer 5M Pro 0.4 Nozzle",
-		"Flashforge Adventurer 5M Pro 0.6 Nozzle",
-		"Flashforge Adventurer 5M Pro 0.8 Nozzle",
-		"Flashforge AD5X 0.4 nozzle",
-		"Flashforge AD5X 0.6 nozzle",
-		"Flashforge AD5X 0.8 nozzle"
+		"Flashforge Adventurer 5M 0.25 Nozzle",
+		"Flashforge Adventurer 5M Pro 0.25 Nozzle"
 	]
 }

--- a/resources/profiles/Flashforge/filament/Flashforge PLA Sparkle.json
+++ b/resources/profiles/Flashforge/filament/Flashforge PLA Sparkle.json
@@ -14,9 +14,6 @@
 		"Flashforge Adventurer 5M 0.8 Nozzle",
 		"Flashforge Adventurer 5M Pro 0.4 Nozzle",
 		"Flashforge Adventurer 5M Pro 0.6 Nozzle",
-		"Flashforge Adventurer 5M Pro 0.8 Nozzle",
-		"Flashforge AD5X 0.4 nozzle",
-		"Flashforge AD5X 0.6 nozzle",
-		"Flashforge AD5X 0.8 nozzle"
+		"Flashforge Adventurer 5M Pro 0.8 Nozzle"
 	]
 }


### PR DESCRIPTION
Closes #10998

### Problem

Several Flashforge filaments appear **twice** in the system filament list — the issue reports "Flashforge PLA Silk" and "Flashforge ASA Basic", but 15 filaments are affected. Selecting both entries collapses to one in the combobox.

### Root cause (profile data)

Two overlapping `compatible_printers` defects make multiple presets with the **same alias** compatible with the same printer:

1. The `@FF AD5M 0.25 nozzle` variants carried the base profile's full 9-printer list (AD5M / AD5M Pro / AD5X 0.4/0.6/0.8) instead of the 0.25 nozzle printers — a copy-paste error, byte-identical to the base list.
2. The base profiles also listed `AD5X 0.4/0.6/0.8`, which already have dedicated `@FF AD5X` variants.

The filament combobox keys presets by full `preset.name` but displays them by **alias** (`preset.label(false)`), so two presets with different names but the same alias render as identical duplicate rows.

### Fix (data only — no filament settings changed)

- Repoint the 15 `@FF AD5M 0.25 nozzle` variants to the real 0.25 printers (`Adventurer 5M 0.25 Nozzle`, `Adventurer 5M Pro 0.25 Nozzle`).
- Remove the redundant `AD5X 0.4/0.6/0.8` entries from the base profiles where dedicated AD5X variants exist.
- Bump Flashforge profile version `02.04.00.01` → `02.04.00.02`.

### Verification

Per-printer preset count for every affected alias is now **exactly 1** (was 2–3). No coverage lost; the previously-uncovered AD5M 0.25 nozzle printers now gain these filaments. The per-nozzle/per-printer profile architecture is preserved — these presets carry genuinely different settings (temps, pressure advance, fans, parent profiles), and alias dedup already presents a single list entry to the user.