### PR TITLE
Add gradient filament color preview (single-spool gradient / rainbow filaments)

### DIFF
--- a/resources/shaders/110/gouraud.fs
+++ b/resources/shaders/110/gouraud.fs
@@ -64,6 +64,15 @@ uniform float shadow_map_texel;
 // LIGHT_TOP_DIR in eye space (matches the diffuse light used for shading in gouraud.vs).
 const vec3 SHADOW_LIGHT_DIR = vec3(-0.4574957, 0.4574957, 0.7624929);
 
+// Filament gradient (Prepare-view approximation): map one gradient cycle up the object's Z.
+const int GRAD_MAX = 8;
+uniform bool  use_filament_gradient;
+uniform int   gradient_count;
+uniform float gradient_pos[GRAD_MAX];
+uniform vec4  gradient_col[GRAD_MAX];
+uniform float gradient_z_min;
+uniform float gradient_z_max;
+
 varying vec3 clipping_planes_dots;
 varying float color_clip_plane_dot;
 
@@ -77,6 +86,26 @@ varying vec3 eye_normal;
 vec3 getBackfaceColor(vec3 fill) {
     float brightness = 0.2126 * fill.r + 0.7152 * fill.g + 0.0722 * fill.b;
     return (brightness > 0.75) ? vec3(0.11, 0.165, 0.208) : vec3(0.988, 0.988, 0.988);
+}
+
+vec3 sample_filament_gradient(float t) {
+    t = clamp(t, 0.0, 1.0);
+    vec3  prev_col = gradient_col[0].rgb;
+    float prev_pos = gradient_pos[0];
+    vec3  last_col = gradient_col[0].rgb;
+    for (int i = 0; i < GRAD_MAX; ++i) {
+        if (i >= gradient_count) break;
+        float p = gradient_pos[i];
+        vec3  c = gradient_col[i].rgb;
+        if (t <= p) {
+            float f = (p > prev_pos) ? (t - prev_pos) / (p - prev_pos) : 0.0;
+            return mix(prev_col, c, f);
+        }
+        prev_pos = p;
+        prev_col = c;
+        last_col = c;
+    }
+    return last_col;
 }
 
 // Silhouette edge detection & rendering algorithem by leoneruggiero
@@ -180,6 +209,11 @@ void main()
     }
     else
 	    color = uniform_color;
+
+    if (use_filament_gradient) {
+        float gt = (gradient_z_max > gradient_z_min) ? (world_pos.z - gradient_z_min) / (gradient_z_max - gradient_z_min) : 0.0;
+        color.rgb = sample_filament_gradient(gt);
+    }
 
     if (slope.actived) {
          if(world_pos.z<0.1&&world_pos.z>-0.1)

--- a/resources/shaders/140/gouraud.fs
+++ b/resources/shaders/140/gouraud.fs
@@ -73,6 +73,15 @@ uniform float shadow_map_texel;
 // LIGHT_TOP_DIR in eye space (matches the diffuse light used for shading in gouraud.vs).
 const vec3 SHADOW_LIGHT_DIR = vec3(-0.4574957, 0.4574957, 0.7624929);
 
+// Filament gradient (Prepare-view approximation): map one gradient cycle up the object's Z.
+const int GRAD_MAX = 8;
+uniform bool  use_filament_gradient;
+uniform int   gradient_count;
+uniform float gradient_pos[GRAD_MAX];
+uniform vec4  gradient_col[GRAD_MAX];
+uniform float gradient_z_min;
+uniform float gradient_z_max;
+
 in vec3 clipping_planes_dots;
 in float color_clip_plane_dot;
 
@@ -86,6 +95,26 @@ in vec3 eye_normal;
 vec3 getBackfaceColor(vec3 fill) {
     float brightness = 0.2126 * fill.r + 0.7152 * fill.g + 0.0722 * fill.b;
     return (brightness > 0.75) ? vec3(0.11, 0.165, 0.208) : vec3(0.988, 0.988, 0.988);
+}
+
+vec3 sample_filament_gradient(float t) {
+    t = clamp(t, 0.0, 1.0);
+    vec3  prev_col = gradient_col[0].rgb;
+    float prev_pos = gradient_pos[0];
+    vec3  last_col = gradient_col[0].rgb;
+    for (int i = 0; i < GRAD_MAX; ++i) {
+        if (i >= gradient_count) break;
+        float p = gradient_pos[i];
+        vec3  c = gradient_col[i].rgb;
+        if (t <= p) {
+            float f = (p > prev_pos) ? (t - prev_pos) / (p - prev_pos) : 0.0;
+            return mix(prev_col, c, f);
+        }
+        prev_pos = p;
+        prev_col = c;
+        last_col = c;
+    }
+    return last_col;
 }
 
 // Silhouette edge detection & rendering algorithem by leoneruggiero
@@ -233,6 +262,11 @@ void main()
     }
     else
 	    color = uniform_color;
+
+    if (use_filament_gradient) {
+        float gt = (gradient_z_max > gradient_z_min) ? (world_pos.z - gradient_z_min) / (gradient_z_max - gradient_z_min) : 0.0;
+        color.rgb = sample_filament_gradient(gt);
+    }
 
     if (slope.actived) {
          if(world_pos.z<0.1&&world_pos.z>-0.1)

--- a/src/libslic3r/CMakeLists.txt
+++ b/src/libslic3r/CMakeLists.txt
@@ -492,6 +492,8 @@ set(lisbslic3r_sources
     VariableWidth.hpp
     Zipper.cpp
     Zipper.hpp
+    FilamentGradient.hpp
+    FilamentGradient.cpp
     FilamentGroup.hpp
     FilamentGroup.cpp
     FilamentGroupUtils.hpp

--- a/src/libslic3r/FilamentGradient.cpp
+++ b/src/libslic3r/FilamentGradient.cpp
@@ -1,0 +1,77 @@
+#include "FilamentGradient.hpp"
+#include "Color.hpp"
+
+#include <sstream>
+#include <stdexcept>
+
+namespace Slic3r {
+
+std::string FilamentGradient::serialize_stops() const
+{
+    std::ostringstream ss;
+    for (size_t i = 0; i < stops.size(); ++i) {
+        if (i > 0) ss << ';';
+        ss << stops[i].position << ',' << encode_color(stops[i].color);
+    }
+    return ss.str();
+}
+
+bool FilamentGradient::parse_stops(const std::string& s, std::vector<GradientColorStop>& out)
+{
+    out.clear();
+    if (s.empty()) return true;
+
+    std::istringstream ss(s);
+    std::string token;
+    while (std::getline(ss, token, ';')) {
+        const auto comma = token.find(',');
+        if (comma == std::string::npos) return false;
+
+        GradientColorStop stop;
+        try {
+            stop.position = std::stof(token.substr(0, comma));
+        } catch (...) { return false; }
+
+        if (!decode_color(token.substr(comma + 1), stop.color))
+            return false;
+
+        out.push_back(stop);
+    }
+
+    std::sort(out.begin(), out.end());
+    return out.size() >= 2;
+}
+
+bool FilamentGradient::stops_from_color_list(const std::string& s, std::vector<GradientColorStop>& out)
+{
+    out.clear();
+    if (s.empty()) return false;
+
+    // Split on whitespace or commas (native filament_multi_colour is space-separated).
+    std::vector<ColorRGBA> colors;
+    std::string token;
+    std::istringstream ss(s);
+    while (ss >> token) {
+        // a token may itself contain commas
+        size_t start = 0;
+        while (start < token.size()) {
+            const size_t comma = token.find(',', start);
+            const std::string piece = token.substr(start, comma == std::string::npos ? std::string::npos : comma - start);
+            ColorRGBA c;
+            if (!piece.empty() && decode_color(piece, c))
+                colors.push_back(c);
+            if (comma == std::string::npos) break;
+            start = comma + 1;
+        }
+    }
+
+    if (colors.size() < 2) return false;
+
+    const float denom = static_cast<float>(colors.size() - 1);
+    out.reserve(colors.size());
+    for (size_t i = 0; i < colors.size(); ++i)
+        out.push_back({ static_cast<float>(i) / denom, colors[i] });
+    return true;
+}
+
+} // namespace Slic3r

--- a/src/libslic3r/FilamentGradient.hpp
+++ b/src/libslic3r/FilamentGradient.hpp
@@ -1,0 +1,71 @@
+#pragma once
+
+#include <vector>
+#include <string>
+#include <algorithm>
+#include <cmath>
+#include "Color.hpp"
+
+namespace Slic3r {
+
+// A single color stop in a gradient, position is in [0, 1] along one cycle.
+struct GradientColorStop {
+    float     position { 0.0f };  // 0.0 = cycle start, 1.0 = cycle end
+    ColorRGBA color;
+
+    bool operator<(const GradientColorStop& other) const { return position < other.position; }
+};
+
+// Describes a repeating filament color gradient.
+// The gradient repeats every cycle_length_mm of extruded filament.
+// start_offset_mm shifts where in the cycle the spool begins.
+struct FilamentGradient {
+    std::vector<GradientColorStop> stops;
+    float cycle_length_mm  { 500.0f };
+    float start_offset_mm  { 0.0f };
+
+    bool empty() const { return stops.size() < 2; }
+
+    // Returns the interpolated color at a given cumulative extrusion distance.
+    ColorRGBA sample(float extruded_mm) const
+    {
+        if (empty())
+            return ColorRGBA(1.0f, 1.0f, 1.0f, 1.0f);
+
+        const float len = cycle_length_mm > 0.0f ? cycle_length_mm : 1.0f;
+        float pos = std::fmod(extruded_mm + start_offset_mm, len) / len;
+        if (pos < 0.0f) pos += 1.0f;
+
+        // Find the two stops that bracket pos.
+        // stops is kept sorted by position.
+        auto it = std::lower_bound(stops.begin(), stops.end(),
+                                   GradientColorStop{ pos, {} });
+
+        if (it == stops.end())
+            return stops.back().color;
+        if (it == stops.begin())
+            return stops.front().color;
+
+        const GradientColorStop& hi = *it;
+        const GradientColorStop& lo = *std::prev(it);
+
+        const float range = hi.position - lo.position;
+        const float t     = (range > 0.0f) ? (pos - lo.position) / range : 0.0f;
+
+        return lo.color * (1.0f - t) + hi.color * t;
+    }
+
+    // Serialize stops to a compact string: "pos1,#RRGGBBAA;pos2,#RRGGBBAA;..."
+    std::string serialize_stops() const;
+
+    // Parse stops from the format produced by serialize_stops().
+    // Returns false if the string is malformed.
+    static bool parse_stops(const std::string& s, std::vector<GradientColorStop>& out);
+
+    // Build evenly-spaced stops from a list of colors (space- or comma-separated hex,
+    // e.g. "#RRGGBB #RRGGBB ..."), as used by OrcaSlicer's native filament_multi_colour.
+    // Returns false if fewer than 2 valid colors are found.
+    static bool stops_from_color_list(const std::string& s, std::vector<GradientColorStop>& out);
+};
+
+} // namespace Slic3r

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -7077,7 +7077,15 @@ void GCode::append_full_config(const Print &print, std::string &str)
         "printhost_cafile"sv,
         "printhost_user"sv,
         "printhost_password"sv,
-        "printhost_port"sv
+        "printhost_port"sv,
+        // Gradient-filament preview keys: UI/preview-only metadata with no effect on the
+        // printed result. Kept out of the G-code config block to avoid bloating it and to
+        // avoid adding unusual characters (e.g. the ';' separators in filament_gradient_stops)
+        // that fragile firmware parsers can choke on. This mirrors the rationale of upstream
+        // PR #13507 (skip filament_colour_type) addressing issue #12952 (Anycubic Kobra 3 parse hang).
+        "filament_gradient_stops"sv,
+        "filament_gradient_cycle_length"sv,
+        "filament_gradient_start_offset"sv
     });
     auto is_banned = [](const std::string &key) {
         return banned_keys.find(key) != banned_keys.end();

--- a/src/libslic3r/PresetBundle.cpp
+++ b/src/libslic3r/PresetBundle.cpp
@@ -58,6 +58,9 @@ static std::vector<std::string> s_project_options {
     "filament_colour",
     "filament_colour_type",
     "filament_multi_colour",
+    "filament_gradient_stops",
+    "filament_gradient_cycle_length",
+    "filament_gradient_start_offset",
     "wipe_tower_x",
     "wipe_tower_y",
     "curr_bed_type",
@@ -3042,6 +3045,35 @@ void PresetBundle::update_selections(AppConfig &config)
     filament_color_types.resize(filament_presets.size(), "1");
     project_config.option<ConfigOptionStrings>("filament_colour_type")->values = filament_color_types;
 
+    // Gradient filament data (per extruder), restored from printer settings (persisted across
+    // sessions in export_selections). Stops are joined with '|' since each stop string itself
+    // contains commas. Defaults mean "no gradient".
+    {
+        std::vector<std::string> grad_stops;
+        if (config.has_printer_setting(initial_printer_profile_name, "filament_gradient_stops"))
+            boost::algorithm::split(grad_stops, config.get_printer_setting(initial_printer_profile_name, "filament_gradient_stops"), boost::algorithm::is_any_of("|"));
+        grad_stops.resize(filament_presets.size(), "");
+        project_config.option<ConfigOptionStrings>("filament_gradient_stops")->values = grad_stops;
+
+        std::vector<double> grad_cycle(filament_presets.size(), 500.0);
+        if (config.has_printer_setting(initial_printer_profile_name, "filament_gradient_cycle_length")) {
+            std::vector<std::string> toks;
+            boost::algorithm::split(toks, config.get_printer_setting(initial_printer_profile_name, "filament_gradient_cycle_length"), boost::algorithm::is_any_of("|"));
+            for (size_t i = 0; i < grad_cycle.size() && i < toks.size(); ++i)
+                if (!toks[i].empty()) try { grad_cycle[i] = boost::lexical_cast<double>(toks[i]); } catch (...) {}
+        }
+        project_config.option<ConfigOptionFloats>("filament_gradient_cycle_length")->values = grad_cycle;
+
+        std::vector<double> grad_offset(filament_presets.size(), 0.0);
+        if (config.has_printer_setting(initial_printer_profile_name, "filament_gradient_start_offset")) {
+            std::vector<std::string> toks;
+            boost::algorithm::split(toks, config.get_printer_setting(initial_printer_profile_name, "filament_gradient_start_offset"), boost::algorithm::is_any_of("|"));
+            for (size_t i = 0; i < grad_offset.size() && i < toks.size(); ++i)
+                if (!toks[i].empty()) try { grad_offset[i] = boost::lexical_cast<double>(toks[i]); } catch (...) {}
+        }
+        project_config.option<ConfigOptionFloats>("filament_gradient_start_offset")->values = grad_offset;
+    }
+
     std::vector<int> filament_maps(filament_colors.size(), 1);
     project_config.option<ConfigOptionInts>("filament_map")->values = filament_maps;
 
@@ -3205,6 +3237,35 @@ void PresetBundle::load_selections(AppConfig &config, const PresetPreferences& p
     filament_color_types.resize(filament_presets.size(), "1");
     project_config.option<ConfigOptionStrings>("filament_colour_type")->values = filament_color_types;
 
+    // Gradient filament data (per extruder), restored from printer settings (persisted across
+    // sessions in export_selections). Stops are joined with '|' since each stop string itself
+    // contains commas. Defaults mean "no gradient".
+    {
+        std::vector<std::string> grad_stops;
+        if (config.has_printer_setting(initial_printer_profile_name, "filament_gradient_stops"))
+            boost::algorithm::split(grad_stops, config.get_printer_setting(initial_printer_profile_name, "filament_gradient_stops"), boost::algorithm::is_any_of("|"));
+        grad_stops.resize(filament_presets.size(), "");
+        project_config.option<ConfigOptionStrings>("filament_gradient_stops")->values = grad_stops;
+
+        std::vector<double> grad_cycle(filament_presets.size(), 500.0);
+        if (config.has_printer_setting(initial_printer_profile_name, "filament_gradient_cycle_length")) {
+            std::vector<std::string> toks;
+            boost::algorithm::split(toks, config.get_printer_setting(initial_printer_profile_name, "filament_gradient_cycle_length"), boost::algorithm::is_any_of("|"));
+            for (size_t i = 0; i < grad_cycle.size() && i < toks.size(); ++i)
+                if (!toks[i].empty()) try { grad_cycle[i] = boost::lexical_cast<double>(toks[i]); } catch (...) {}
+        }
+        project_config.option<ConfigOptionFloats>("filament_gradient_cycle_length")->values = grad_cycle;
+
+        std::vector<double> grad_offset(filament_presets.size(), 0.0);
+        if (config.has_printer_setting(initial_printer_profile_name, "filament_gradient_start_offset")) {
+            std::vector<std::string> toks;
+            boost::algorithm::split(toks, config.get_printer_setting(initial_printer_profile_name, "filament_gradient_start_offset"), boost::algorithm::is_any_of("|"));
+            for (size_t i = 0; i < grad_offset.size() && i < toks.size(); ++i)
+                if (!toks[i].empty()) try { grad_offset[i] = boost::lexical_cast<double>(toks[i]); } catch (...) {}
+        }
+        project_config.option<ConfigOptionFloats>("filament_gradient_start_offset")->values = grad_offset;
+    }
+
     std::vector<int> filament_maps(filament_colors.size(), 1);
     project_config.option<ConfigOptionInts>("filament_map")->values = filament_maps;
 
@@ -3351,6 +3412,18 @@ void PresetBundle::export_selections(AppConfig &config)
     // Load filament color type data into app config
     std::string           filament_color_types = boost::algorithm::join(project_config.option<ConfigOptionStrings>("filament_colour_type")->values, ",");
     config.set_printer_setting(printer_name, "filament_color_types", filament_color_types);
+
+    // Gradient filament data — stops joined with '|' (each stop string itself contains commas).
+    std::string filament_gradient_stops = boost::algorithm::join(project_config.option<ConfigOptionStrings>("filament_gradient_stops")->values, "|");
+    config.set_printer_setting(printer_name, "filament_gradient_stops", filament_gradient_stops);
+    std::string filament_gradient_cycle = boost::algorithm::join(project_config.option<ConfigOptionFloats>("filament_gradient_cycle_length")->values |
+                                                                 boost::adaptors::transformed(static_cast<std::string (*)(double)>(std::to_string)),
+                                                             "|");
+    config.set_printer_setting(printer_name, "filament_gradient_cycle_length", filament_gradient_cycle);
+    std::string filament_gradient_offset = boost::algorithm::join(project_config.option<ConfigOptionFloats>("filament_gradient_start_offset")->values |
+                                                                  boost::adaptors::transformed(static_cast<std::string (*)(double)>(std::to_string)),
+                                                              "|");
+    config.set_printer_setting(printer_name, "filament_gradient_start_offset", filament_gradient_offset);
 
     // Load ams counts data into app config
     std::string           extruder_ams_count_str = boost::algorithm::join(save_extruder_ams_count_to_string(this->extruder_ams_counts), ",");

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -2812,6 +2812,34 @@ void PrintConfigDef::init_fff_params()
     def = this->add("filament_colour_type", coStrings);
     def->set_default_value(new ConfigOptionStrings{"1"}); // Init as default color
 
+    // Gradient filament color stops — serialized as "pos,#RRGGBBAA;pos,#RRGGBBAA;..."
+    // Only used when filament_colour_type == "0".
+    def = this->add("filament_gradient_stops", coStrings);
+    def->label   = L("Gradient color stops");
+    def->tooltip = L("Color stops for the gradient filament preview. Each stop is a position (0-1) and a color.");
+    def->mode    = comAdvanced;
+    def->set_default_value(new ConfigOptionStrings{""});
+
+    // Total length in mm of one full gradient color cycle.
+    def        = this->add("filament_gradient_cycle_length", coFloats);
+    def->label   = L("Gradient cycle length");
+    def->tooltip = L("Length of one full color cycle in mm of extruded filament. "
+                     "Check the filament manufacturer's website or measure your spool.");
+    def->sidetext = L("mm");
+    def->min     = 1.0;
+    def->mode    = comAdvanced;
+    def->set_default_value(new ConfigOptionFloats{500.0});
+
+    // Starting offset into the gradient cycle for this spool.
+    def        = this->add("filament_gradient_start_offset", coFloats);
+    def->label   = L("Gradient start offset");
+    def->tooltip = L("Offset into the gradient cycle at the start of this spool, in mm. "
+                     "Use this to match the preview to where your spool actually begins.");
+    def->sidetext = L("mm");
+    def->min     = 0.0;
+    def->mode    = comAdvanced;
+    def->set_default_value(new ConfigOptionFloats{0.0});
+
     //bbs
     def          = this->add("required_nozzle_HRC", coInts);
     def->label   = L("Required nozzle HRC");

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -1536,6 +1536,9 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionBools,               filament_soluble))
     ((ConfigOptionStrings,             filament_ids))
     ((ConfigOptionStrings,             filament_colour))
+    ((ConfigOptionStrings,             filament_gradient_stops))
+    ((ConfigOptionFloats,              filament_gradient_cycle_length))
+    ((ConfigOptionFloats,              filament_gradient_start_offset))
     ((ConfigOptionStrings,             filament_vendor))
     ((ConfigOptionBools,               filament_is_support))
     // Mixed-color filament: a virtual slot realized from 2-3 physical filaments.

--- a/src/libvgcode/include/GCodeInputData.hpp
+++ b/src/libvgcode/include/GCodeInputData.hpp
@@ -29,6 +29,12 @@ struct GCodeInputData
     // Palette for color print colors
     //
     Palette color_print_colors;
+    //
+    // Per-vertex gradient colors, parallel to vertices[].
+    // Empty when no gradient filaments are configured.
+    // When non-empty, used by EViewType::GradientFilament rendering.
+    //
+    std::vector<Color> gradient_colors;
 };
 
 } // namespace libvgcode

--- a/src/libvgcode/include/Types.hpp
+++ b/src/libvgcode/include/Types.hpp
@@ -99,6 +99,7 @@ enum class EViewType : uint8_t
     // ORCA: Add Jerk visualization support
     Jerk,
     Tool,
+    GradientFilament,
     COUNT
 };
 

--- a/src/libvgcode/src/Viewer.cpp
+++ b/src/libvgcode/src/Viewer.cpp
@@ -309,7 +309,7 @@ float Viewer::get_estimated_time_at(size_t id) const
 
 Color Viewer::get_vertex_color(const PathVertex& vertex) const
 {
-    return m_impl->get_vertex_color(vertex);
+    return m_impl->get_vertex_color(vertex, 0);
 }
 
 size_t Viewer::get_extrusion_roles_count() const

--- a/src/libvgcode/src/ViewerImpl.cpp
+++ b/src/libvgcode/src/ViewerImpl.cpp
@@ -995,6 +995,7 @@ void ViewerImpl::load(GCodeInputData&& gcode_data)
     m_vertices = std::move(gcode_data.vertices);
     m_tool_colors = std::move(gcode_data.tools_colors);
     m_color_print_colors = std::move(gcode_data.color_print_colors);
+    m_gradient_colors = std::move(gcode_data.gradient_colors);
     m_vertices_colors.resize(m_vertices.size());
 
     m_settings.spiral_vase_mode = gcode_data.spiral_vase_mode;
@@ -1315,7 +1316,7 @@ void ViewerImpl::update_colors()
     // care of in update_colors_texture. That is to avoid the need to recalculate
     // the "normal" color on every slider move.
     for (size_t i = 0; i < m_vertices.size(); ++i)
-        m_vertices_colors[i] = encode_color(get_vertex_color(m_vertices[i]));
+        m_vertices_colors[i] = encode_color(get_vertex_color(m_vertices[i], i));
     
     update_colors_texture();
     m_settings.update_colors = false;
@@ -1520,7 +1521,7 @@ float ViewerImpl::get_estimated_time_at(size_t id) const
         [this](float a, const PathVertex& v) { return a + v.times[static_cast<size_t>(m_settings.time_mode)]; });
 }
 
-Color ViewerImpl::get_vertex_color(const PathVertex& v) const
+Color ViewerImpl::get_vertex_color(const PathVertex& v, size_t vertex_index) const
 {
     if (v.type == EMoveType::Noop)
         return DUMMY_COLOR;
@@ -1592,13 +1593,19 @@ Color ViewerImpl::get_vertex_color(const PathVertex& v) const
             m_layer_time_range[1].get_color_at(m_layers.get_layer_time(m_settings.time_mode, static_cast<size_t>(v.layer_id)));
     }
     case EViewType::Tool:
+    case EViewType::GradientFilament:
     {
+        if (!m_gradient_colors.empty() && vertex_index < m_gradient_colors.size())
+            return m_gradient_colors[vertex_index];
         assert(static_cast<size_t>(v.extruder_id) < m_tool_colors.size());
         return m_tool_colors[v.extruder_id];
     }
     case EViewType::Summary: // ORCA
     case EViewType::ColorPrint:
     {
+        // "Filament" view: show per-vertex gradient colors when a gradient filament is in use.
+        if (!m_gradient_colors.empty() && vertex_index < m_gradient_colors.size())
+            return m_gradient_colors[vertex_index];
         return m_layers.layer_contains_colorprint_options(static_cast<size_t>(v.layer_id)) ? DUMMY_COLOR :
             m_color_print_colors[static_cast<size_t>(v.color_id) % m_color_print_colors.size()];
     }

--- a/src/libvgcode/src/ViewerImpl.hpp
+++ b/src/libvgcode/src/ViewerImpl.hpp
@@ -144,7 +144,7 @@ public:
     }
     float get_estimated_time() const { return m_total_time[static_cast<size_t>(m_settings.time_mode)]; }
     float get_estimated_time_at(size_t id) const;
-    Color get_vertex_color(const PathVertex& vertex) const;
+    Color get_vertex_color(const PathVertex& vertex, size_t vertex_index) const;
 
     size_t get_extrusion_roles_count() const { return m_extrusion_roles.get_roles_count(); }
     std::vector<EGCodeExtrusionRole> get_extrusion_roles() const { return m_extrusion_roles.get_roles(); }
@@ -311,6 +311,7 @@ private:
     };
     Palette m_tool_colors;
     Palette m_color_print_colors;
+    std::vector<Color> m_gradient_colors;
     //
     // OpenGL shaders ids
     //

--- a/src/slic3r/CMakeLists.txt
+++ b/src/slic3r/CMakeLists.txt
@@ -459,6 +459,8 @@ set(SLIC3R_GUI_SOURCES
     GUI/PurgeModeDialog.hpp
     GUI/RammingChart.cpp
     GUI/RammingChart.hpp
+    GUI/GradientColorPickerDialog.cpp
+    GUI/GradientColorPickerDialog.hpp
     GUI/RecenterDialog.cpp
     GUI/RecenterDialog.hpp
     GUI/ReleaseNote.cpp

--- a/src/slic3r/GUI/3DScene.cpp
+++ b/src/slic3r/GUI/3DScene.cpp
@@ -19,6 +19,7 @@
 #include "libslic3r/Utils.hpp"
 #include "libslic3r/AppConfig.hpp"
 #include "libslic3r/PresetBundle.hpp"
+#include "libslic3r/FilamentGradient.hpp"
 #include "libslic3r/ClipperUtils.hpp"
 #include "libslic3r/GCode/WipeTower.hpp"
 #include "libslic3r/GCode/WipeTowerEstimate.hpp"
@@ -1153,6 +1154,35 @@ void GLVolumeCollection::render(GLVolumeCollection::ERenderType       type,
     // default sampler unit 0, which can conflict with other sampler types.
     shader->set_uniform("depth_tex", OUTLINE_DEPTH_TEX_UNIT);
 
+    // Per-extruder filament gradients (Prepare-view approximation), read from project_config.
+    // A filament is a gradient when filament_colour_type == "0"; stops come from our positioned
+    // filament_gradient_stops or (fallback) evenly spaced from the native filament_multi_colour.
+    std::vector<Slic3r::FilamentGradient> filament_gradients;
+    {
+        const DynamicPrintConfig& pcfg = GUI::wxGetApp().preset_bundle->project_config;
+        const auto* type_opt  = pcfg.option<ConfigOptionStrings>("filament_colour_type");
+        const auto* stops_opt = pcfg.option<ConfigOptionStrings>("filament_gradient_stops");
+        const auto* multi_opt = pcfg.option<ConfigOptionStrings>("filament_multi_colour");
+        // Fast path: skip all allocation/parsing when no filament is a gradient (the common case).
+        const bool any_gradient = type_opt != nullptr &&
+            std::any_of(type_opt->values.begin(), type_opt->values.end(),
+                        [](const std::string& t) { return t == "0"; });
+        if (any_gradient) {
+            filament_gradients.resize(type_opt->values.size());
+            for (size_t i = 0; i < type_opt->values.size(); ++i) {
+                if (type_opt->values[i] != "0") continue;
+                Slic3r::FilamentGradient grad;
+                const std::string stops_str = (stops_opt && i < stops_opt->values.size()) ? stops_opt->values[i] : std::string();
+                if (!Slic3r::FilamentGradient::parse_stops(stops_str, grad.stops)) {
+                    if (multi_opt && i < multi_opt->values.size())
+                        Slic3r::FilamentGradient::stops_from_color_list(multi_opt->values[i], grad.stops);
+                }
+                if (grad.stops.size() >= 2)
+                    filament_gradients[i] = std::move(grad);
+            }
+        }
+    }
+
     for (GLVolumeWithIdAndZ& volume : to_render) {
 #if ENABLE_MODIFIERS_ALWAYS_TRANSPARENT
         if (type == ERenderType::Transparent) {
@@ -1190,6 +1220,31 @@ void GLVolumeCollection::render(GLVolumeCollection::ERenderType       type,
         shader->set_uniform("color_clip_plane", m_color_clip_plane);
         shader->set_uniform("uniform_color_clip_plane_1", m_color_clip_plane_colors[0]);
         shader->set_uniform("uniform_color_clip_plane_2", m_color_clip_plane_colors[1]);
+
+        // Filament gradient (Prepare-view approximation): stretch one gradient cycle up the object's Z.
+        {
+            const int eid = volume.first->extruder_id - 1;
+            const Slic3r::FilamentGradient* grad =
+                (!volume.first->is_modifier && !volume.first->is_wipe_tower &&
+                 eid >= 0 && eid < (int)filament_gradients.size() && !filament_gradients[eid].empty())
+                ? &filament_gradients[eid] : nullptr;
+            if (grad != nullptr) {
+                const BoundingBoxf3& bb = volume.first->transformed_bounding_box();
+                const int count = std::min((int)grad->stops.size(), 8);
+                shader->set_uniform("use_filament_gradient", true);
+                shader->set_uniform("gradient_count", count);
+                shader->set_uniform("gradient_z_min", (float)bb.min.z());
+                shader->set_uniform("gradient_z_max", (float)bb.max.z());
+                for (int s = 0; s < count; ++s) {
+                    const GradientColorStop& st = grad->stops[s];
+                    shader->set_uniform(("gradient_pos[" + std::to_string(s) + "]").c_str(), (float)st.position);
+                    shader->set_uniform(("gradient_col[" + std::to_string(s) + "]").c_str(),
+                        std::array<float, 4>{ st.color.r(), st.color.g(), st.color.b(), st.color.a() });
+                }
+            } else {
+                shader->set_uniform("use_filament_gradient", false);
+            }
+        }
         //BOOST_LOG_TRIVIAL(info) << boost::format("set uniform_color to {%1%, %2%, %3%, %4%}, with_outline=%5%, selected %6%")
         //    %volume.first->render_color[0]%volume.first->render_color[1]%volume.first->render_color[2]%volume.first->render_color[3]
         //    %with_outline%volume.first->selected;
@@ -1262,6 +1317,9 @@ void GLVolumeCollection::render(GLVolumeCollection::ERenderType       type,
         glsafe(::glBindBuffer(GL_ARRAY_BUFFER, 0));
         glsafe(::glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0));
     }
+
+    // Don't let gradient mode leak to other users of the gouraud shader.
+    shader->set_uniform("use_filament_gradient", false);
 
     if (m_show_sinking_contours) {
         shader->stop_using();

--- a/src/slic3r/GUI/GCodeViewer.cpp
+++ b/src/slic3r/GUI/GCodeViewer.cpp
@@ -9,6 +9,7 @@
 #include "libslic3r/Utils.hpp"
 #include "libslic3r/LocalesUtils.hpp"
 #include "libslic3r/PresetBundle.hpp"
+#include "libslic3r/FilamentGradient.hpp"
 //BBS: add convex hull logic for toolpath check
 #include "libslic3r/Geometry/ConvexHull.hpp"
 
@@ -100,6 +101,8 @@ static std::string get_view_type_string(libvgcode::EViewType view_type)
 // ORCA: Add Pressure Advance visualization support
     else if (view_type == libvgcode::EViewType::PressureAdvance)
         return _u8L("Pressure Advance");
+    else if (view_type == libvgcode::EViewType::GradientFilament)
+        return _u8L("Gradient Filament");
     return "";
 }
 
@@ -1218,8 +1221,49 @@ void GCodeViewer::load_as_gcode(const GCodeProcessorResult& gcode_result, const 
         return;
     }
 
+    // Build per-filament gradient definitions from the active project config (flattened,
+    // per-extruder) — the same source as the swatch colors. A filament is a gradient when
+    // filament_colour_type == "0". Stops come from our positioned filament_gradient_stops,
+    // or (for native library gradients) are evenly spaced across filament_multi_colour.
+    std::vector<Slic3r::FilamentGradient> filament_gradients;
+    {
+        auto* bundle = wxGetApp().preset_bundle;
+        if (bundle != nullptr) {
+            const DynamicPrintConfig& cfg = bundle->project_config;
+            const size_t n = str_tool_colors.size();
+            filament_gradients.resize(n);
+
+            const auto* type_opt  = cfg.option<ConfigOptionStrings>("filament_colour_type");
+            const auto* stops_opt = cfg.option<ConfigOptionStrings>("filament_gradient_stops");
+            const auto* multi_opt = cfg.option<ConfigOptionStrings>("filament_multi_colour");
+            const auto* cycle_opt = cfg.option<ConfigOptionFloats>("filament_gradient_cycle_length");
+            const auto* off_opt   = cfg.option<ConfigOptionFloats>("filament_gradient_start_offset");
+
+            for (size_t fi = 0; fi < n; ++fi) {
+                if (type_opt == nullptr || fi >= type_opt->values.size() || type_opt->values[fi] != "0")
+                    continue;
+
+                Slic3r::FilamentGradient grad;
+                const std::string stops_str = (stops_opt && fi < stops_opt->values.size()) ? stops_opt->values[fi] : "";
+                if (!Slic3r::FilamentGradient::parse_stops(stops_str, grad.stops)) {
+                    // No positioned stops — fall back to evenly spaced from the native color list.
+                    if (multi_opt && fi < multi_opt->values.size())
+                        Slic3r::FilamentGradient::stops_from_color_list(multi_opt->values[fi], grad.stops);
+                }
+                if (grad.stops.size() < 2)
+                    continue;
+
+                const float cycle_len = (cycle_opt && fi < cycle_opt->values.size()) ? (float)cycle_opt->values[fi] : 500.0f;
+                const float start_off = (off_opt && fi < off_opt->values.size()) ? (float)off_opt->values[fi] : 0.0f;
+                grad.cycle_length_mm = cycle_len > 0.0f ? cycle_len : 500.0f;
+                grad.start_offset_mm = start_off;
+                filament_gradients[fi] = std::move(grad);
+            }
+        }
+    }
+
     // convert data from PrusaSlicer format to libvgcode format
-    libvgcode::GCodeInputData data = libvgcode::convert(gcode_result, str_tool_colors, str_color_print_colors, m_viewer);
+    libvgcode::GCodeInputData data = libvgcode::convert(gcode_result, str_tool_colors, str_color_print_colors, m_viewer, filament_gradients);
 
 //#define ENABLE_DATA_EXPORT 1
 //#if ENABLE_DATA_EXPORT
@@ -1315,7 +1359,14 @@ void GCodeViewer::load_as_gcode(const GCodeProcessorResult& gcode_result, const 
 
     // send data to the viewer
     m_viewer.reset_default_extrusion_roles_colors();
+
+    // remember whether gradient data was computed before the move
+    const bool has_gradient_data = !data.gradient_colors.empty();
+
     m_viewer.load(std::move(data));
+
+    // Gradient auto-view is integrated into the "smart default view type" block below
+    // (ORCA #13625) so the two don't fight: a gradient print defaults to the Filament view.
 
 // #if !VGCODE_ENABLE_COG_AND_TOOL_MARKERS
 //     const size_t vertices_count = m_viewer.get_vertices_count();
@@ -1404,10 +1455,14 @@ void GCodeViewer::load_as_gcode(const GCodeProcessorResult& gcode_result, const 
         }
     } else {
         if (m_last_extruder_count_default_applied != 1) {
-            auto it = std::find(view_type_items.begin(), view_type_items.end(), libvgcode::EViewType::FeatureType);
+            // Single extruder: default to Line Type, except a gradient filament defaults to the
+            // Filament (ColorPrint) view so its computed gradient colors are visible.
+            const libvgcode::EViewType def = has_gradient_data ? libvgcode::EViewType::ColorPrint
+                                                               : libvgcode::EViewType::FeatureType;
+            auto it = std::find(view_type_items.begin(), view_type_items.end(), def);
             if (it != view_type_items.end())
                 m_view_type_sel = std::distance(view_type_items.begin(), it);
-            set_view_type(libvgcode::EViewType::FeatureType);
+            set_view_type(def);
             m_last_extruder_count_default_applied = 1;
         }
     }
@@ -3527,6 +3582,9 @@ void GCodeViewer::render_legend(float &legend_height, int canvas_width, int canv
     push_combo_style();
 
     ImGui::SameLine();
+    // Guard against an out-of-range selection (e.g. a view type that is not in the label list).
+    if (m_view_type_sel < 0 || m_view_type_sel >= static_cast<int>(view_type_items_str.size()))
+        m_view_type_sel = 0;
     const char* view_type_value = view_type_items_str[m_view_type_sel].c_str();
     ImGuiComboFlags flags = ImGuiComboFlags_HeightLargest; // ORCA allow to fit all items to prevent scrolling on reaching last elements
     if (ImGui::BBLBeginCombo("", view_type_value, flags)) {

--- a/src/slic3r/GUI/GradientColorPickerDialog.cpp
+++ b/src/slic3r/GUI/GradientColorPickerDialog.cpp
@@ -1,0 +1,461 @@
+#include "GradientColorPickerDialog.hpp"
+#include "GUI_App.hpp"
+#include "I18N.hpp"
+#include "libslic3r/Color.hpp"
+
+#include <wx/dcbuffer.h>
+#include <wx/colordlg.h>
+#include <wx/sizer.h>
+#include <wx/stattext.h>
+#include <wx/button.h>
+#include <wx/textctrl.h>
+#include <algorithm>
+#include <cmath>
+
+namespace Slic3r { namespace GUI {
+
+// ---------------------------------------------------------------------------
+// GradientBarWidget
+// ---------------------------------------------------------------------------
+
+BEGIN_EVENT_TABLE(GradientBarWidget, wxWindow)
+    EVT_PAINT        (GradientBarWidget::on_paint)
+    EVT_LEFT_DOWN    (GradientBarWidget::on_left_down)
+    EVT_LEFT_UP      (GradientBarWidget::on_left_up)
+    EVT_MOTION       (GradientBarWidget::on_motion)
+    EVT_LEFT_DCLICK  (GradientBarWidget::on_double_click)
+    EVT_RIGHT_DOWN   (GradientBarWidget::on_right_down)
+END_EVENT_TABLE()
+
+GradientBarWidget::GradientBarWidget(wxWindow* parent, const FilamentGradient& gradient)
+    : wxWindow(parent, wxID_ANY, wxDefaultPosition, wxSize(-1, TOTAL_H))
+    , m_stops(gradient.stops)
+{
+    SetBackgroundStyle(wxBG_STYLE_PAINT);
+    SetMinSize(wxSize(200, TOTAL_H));
+
+    // ensure we always have at least two stops
+    if (m_stops.size() < 2) {
+        m_stops.clear();
+        m_stops.push_back({ 0.0f, ColorRGBA(1.f, 0.f, 0.f, 1.f) });
+        m_stops.push_back({ 1.0f, ColorRGBA(0.f, 0.f, 1.f, 1.f) });
+    }
+    std::sort(m_stops.begin(), m_stops.end());
+    m_selected = 0; // start with a selection so the hex field has a value
+}
+
+bool GradientBarWidget::get_selected_color(ColorRGBA& out) const
+{
+    if (m_selected < 0 || m_selected >= static_cast<int>(m_stops.size()))
+        return false;
+    out = m_stops[m_selected].color;
+    return true;
+}
+
+void GradientBarWidget::set_selected_color(const ColorRGBA& c)
+{
+    if (m_selected < 0 || m_selected >= static_cast<int>(m_stops.size()))
+        return;
+    m_stops[m_selected].color = c;
+    m_bmp_dirty = true;
+    Refresh();
+    if (on_selection_changed) on_selection_changed();
+}
+
+void GradientBarWidget::add_stop()
+{
+    // Insert at the midpoint of the largest gap between consecutive stops.
+    std::sort(m_stops.begin(), m_stops.end());
+    float best_pos = 0.5f, best_gap = -1.f;
+    for (size_t i = 1; i < m_stops.size(); ++i) {
+        const float gap = m_stops[i].position - m_stops[i - 1].position;
+        if (gap > best_gap) { best_gap = gap; best_pos = 0.5f * (m_stops[i].position + m_stops[i - 1].position); }
+    }
+    FilamentGradient tmp; tmp.stops = m_stops;
+    m_stops.push_back({ best_pos, tmp.sample(best_pos * 500.f) });
+    std::sort(m_stops.begin(), m_stops.end());
+    m_selected = static_cast<int>(std::find_if(m_stops.begin(), m_stops.end(),
+        [best_pos](const GradientColorStop& s){ return std::abs(s.position - best_pos) < 0.0005f; }) - m_stops.begin());
+    m_bmp_dirty = true;
+    Refresh();
+    if (on_selection_changed) on_selection_changed();
+}
+
+void GradientBarWidget::remove_selected_stop()
+{
+    if (m_selected < 0 || m_selected >= static_cast<int>(m_stops.size()) || m_stops.size() <= 2)
+        return;
+    m_stops.erase(m_stops.begin() + m_selected);
+    m_selected = std::min(m_selected, static_cast<int>(m_stops.size()) - 1);
+    m_bmp_dirty = true;
+    Refresh();
+    if (on_selection_changed) on_selection_changed();
+}
+
+FilamentGradient GradientBarWidget::get_gradient() const
+{
+    FilamentGradient g;
+    g.stops = m_stops;
+    return g;
+}
+
+int GradientBarWidget::pos_to_x(float pos) const
+{
+    const int w = GetClientSize().x - 2 * MARGIN_X;
+    return MARGIN_X + static_cast<int>(std::round(pos * w));
+}
+
+float GradientBarWidget::x_to_pos(int x) const
+{
+    const int w = GetClientSize().x - 2 * MARGIN_X;
+    if (w <= 0) return 0.f;
+    return std::clamp(static_cast<float>(x - MARGIN_X) / w, 0.f, 1.f);
+}
+
+int GradientBarWidget::hit_test(wxPoint pt) const
+{
+    for (int i = 0; i < static_cast<int>(m_stops.size()); ++i) {
+        const int cx = pos_to_x(m_stops[i].position);
+        if (std::abs(pt.x - cx) <= HANDLE_W && pt.y >= BAR_H)
+            return i;
+    }
+    return -1;
+}
+
+void GradientBarWidget::rebuild_gradient_bitmap()
+{
+    const wxSize sz = GetClientSize();
+    if (sz.x <= 0 || sz.y <= 0) return;
+
+    const int bar_w = sz.x - 2 * MARGIN_X;
+    m_gradient_bmp = wxBitmap(bar_w, BAR_H);
+    wxMemoryDC mdc(m_gradient_bmp);
+
+    for (int px = 0; px < bar_w; ++px) {
+        const float pos = static_cast<float>(px) / std::max(bar_w - 1, 1);
+        // find bracketing stops
+        auto it = std::lower_bound(m_stops.begin(), m_stops.end(), GradientColorStop{ pos, {} });
+        ColorRGBA col;
+        if (it == m_stops.end()) {
+            col = m_stops.back().color;
+        } else if (it == m_stops.begin()) {
+            col = m_stops.front().color;
+        } else {
+            const auto& hi = *it;
+            const auto& lo = *std::prev(it);
+            const float range = hi.position - lo.position;
+            const float t = (range > 0.f) ? (pos - lo.position) / range : 0.f;
+            col = lo.color * (1.f - t) + hi.color * t;
+        }
+        mdc.SetPen(wxColour(col.r_uchar(), col.g_uchar(), col.b_uchar()));
+        mdc.DrawLine(px, 0, px, BAR_H);
+    }
+    m_bmp_dirty = false;
+}
+
+void GradientBarWidget::on_paint(wxPaintEvent&)
+{
+    wxAutoBufferedPaintDC dc(this);
+    const wxSize sz = GetClientSize();
+    dc.SetBackground(wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOW));
+    dc.Clear();
+
+    if (m_bmp_dirty)
+        rebuild_gradient_bitmap();
+
+    // draw gradient bar
+    if (m_gradient_bmp.IsOk())
+        dc.DrawBitmap(m_gradient_bmp, MARGIN_X, 0);
+
+    // draw bar border
+    dc.SetPen(wxSystemSettings::GetColour(wxSYS_COLOUR_GRAYTEXT));
+    dc.SetBrush(*wxTRANSPARENT_BRUSH);
+    dc.DrawRectangle(MARGIN_X, 0, sz.x - 2 * MARGIN_X, BAR_H);
+
+    // draw handles (downward triangles)
+    for (int i = 0; i < static_cast<int>(m_stops.size()); ++i) {
+        const int cx = pos_to_x(m_stops[i].position);
+        const ColorRGBA& c = m_stops[i].color;
+        wxColour fill(c.r_uchar(), c.g_uchar(), c.b_uchar());
+        wxColour border = (i == m_selected)
+            ? wxColour(0, 120, 215)
+            : wxSystemSettings::GetColour(wxSYS_COLOUR_GRAYTEXT);
+
+        wxPoint tri[3] = {
+            { cx - HANDLE_W, BAR_H + 2 },
+            { cx + HANDLE_W, BAR_H + 2 },
+            { cx,            BAR_H + HANDLE_H + 1 }
+        };
+        dc.SetBrush(wxBrush(fill));
+        dc.SetPen(wxPen(border, i == m_selected ? 2 : 1));
+        dc.DrawPolygon(3, tri);
+    }
+}
+
+void GradientBarWidget::on_left_down(wxMouseEvent& e)
+{
+    const int hit = hit_test(e.GetPosition());
+    if (hit >= 0) {
+        m_dragging = hit;
+        m_selected = hit;
+    } else if (e.GetPosition().y < BAR_H) {
+        // click in the bar with no stop hit: add a new stop
+        const float pos = x_to_pos(e.GetPosition().x);
+        // sample current gradient color at that position
+        FilamentGradient tmp;
+        tmp.stops = m_stops;
+        const ColorRGBA col = tmp.sample(pos * 500.f); // arbitrary cycle; sample at pos*cycle
+        // actually sample at position directly
+        GradientColorStop ns{ pos, col };
+        m_stops.push_back(ns);
+        std::sort(m_stops.begin(), m_stops.end());
+        m_selected = static_cast<int>(std::find_if(m_stops.begin(), m_stops.end(),
+            [pos](const GradientColorStop& s){ return std::abs(s.position - pos) < 0.001f; }) - m_stops.begin());
+        m_bmp_dirty = true;
+    } else {
+        m_selected = -1;
+    }
+    CaptureMouse();
+    Refresh();
+    if (on_selection_changed) on_selection_changed();
+}
+
+void GradientBarWidget::on_left_up(wxMouseEvent&)
+{
+    m_dragging = -1;
+    if (HasCapture()) ReleaseMouse();
+    Refresh();
+}
+
+void GradientBarWidget::on_motion(wxMouseEvent& e)
+{
+    if (m_dragging < 0 || !e.LeftIsDown()) return;
+
+    float new_pos = x_to_pos(e.GetPosition().x);
+    // endpoints must stay at 0 and 1
+    if (m_dragging == 0)
+        new_pos = 0.f;
+    else if (m_dragging == static_cast<int>(m_stops.size()) - 1)
+        new_pos = 1.f;
+    else
+        new_pos = std::clamp(new_pos, 0.001f, 0.999f);
+
+    m_stops[m_dragging].position = new_pos;
+    std::sort(m_stops.begin(), m_stops.end());
+    // re-find dragged stop after sort
+    m_dragging = static_cast<int>(std::min_element(m_stops.begin(), m_stops.end(),
+        [new_pos](const GradientColorStop& a, const GradientColorStop& b){
+            return std::abs(a.position - new_pos) < std::abs(b.position - new_pos);
+        }) - m_stops.begin());
+    m_selected = m_dragging;
+    m_bmp_dirty = true;
+    Refresh();
+    if (on_selection_changed) on_selection_changed();
+}
+
+void GradientBarWidget::on_double_click(wxMouseEvent& e)
+{
+    const int hit = hit_test(e.GetPosition());
+    if (hit >= 0)
+        pick_color_for(hit);
+}
+
+void GradientBarWidget::on_right_down(wxMouseEvent& e)
+{
+    const int hit = hit_test(e.GetPosition());
+    if (hit >= 0 && m_stops.size() > 2) {
+        m_stops.erase(m_stops.begin() + hit);
+        m_selected = -1;
+        m_bmp_dirty = true;
+        Refresh();
+        if (on_selection_changed) on_selection_changed();
+    }
+}
+
+void GradientBarWidget::pick_color_for(int index)
+{
+    if (index < 0 || index >= static_cast<int>(m_stops.size())) return;
+    // Static so custom colors persist across dialog openings within the session.
+    static wxColourData s_colour_data;
+    const ColorRGBA& c = m_stops[index].color;
+    s_colour_data.SetColour(wxColour(c.r_uchar(), c.g_uchar(), c.b_uchar()));
+    s_colour_data.SetChooseFull(true);
+    wxColourDialog dlg(this, &s_colour_data);
+    if (dlg.ShowModal() == wxID_OK) {
+        s_colour_data = dlg.GetColourData(); // save custom colors for next time
+        const wxColour chosen = s_colour_data.GetColour();
+        m_stops[index].color = ColorRGBA(
+            chosen.Red()   / 255.f,
+            chosen.Green() / 255.f,
+            chosen.Blue()  / 255.f,
+            1.f);
+        m_bmp_dirty = true;
+        Refresh();
+        if (on_selection_changed) on_selection_changed();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// GradientColorPickerDialog
+// ---------------------------------------------------------------------------
+
+GradientColorPickerDialog::GradientColorPickerDialog(wxWindow* parent, const FilamentGradient& gradient,
+                                                     double filament_diameter_mm, double filament_density_g_cm3)
+    : DPIDialog(parent, wxID_ANY, _L("Gradient Filament Color Editor"),
+                wxDefaultPosition, wxDefaultSize,
+                wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER)
+    , m_diameter(filament_diameter_mm)
+    , m_density(filament_density_g_cm3)
+{
+    auto* main = new wxBoxSizer(wxVERTICAL);
+
+    // Instructions
+    auto* hint = new wxStaticText(this, wxID_ANY,
+        _L("Click a handle to select a stop, then set its color by hex below (or double-click a handle "
+           "for the color picker). Add or remove stops with the buttons, or click the bar / right-click a handle."));
+    hint->Wrap(440);
+    main->Add(hint, 0, wxALL, 8);
+
+    // Gradient bar
+    m_bar = new GradientBarWidget(this, gradient);
+    main->Add(m_bar, 0, wxEXPAND | wxLEFT | wxRIGHT, 8);
+
+    // Selected-stop hex entry + add/remove buttons (keyboard-accessible alternatives to the
+    // mouse-only bar interactions; hex is how filament makers publish colors).
+    auto* row = new wxBoxSizer(wxHORIZONTAL);
+    row->Add(new wxStaticText(this, wxID_ANY, _L("Color (hex):")), 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 4);
+    m_hex = new wxTextCtrl(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize(100, -1), wxTE_PROCESS_ENTER);
+    m_hex->SetMaxLength(9); // "#RRGGBBAA"
+    m_hex->SetToolTip(_L("Enter a color as #RRGGBB (e.g. the value from the filament maker)."));
+    m_hex->Bind(wxEVT_TEXT_ENTER, [this](wxCommandEvent&) { commit_hex_field(); });
+    m_hex->Bind(wxEVT_KILL_FOCUS, [this](wxFocusEvent& e) { commit_hex_field(); e.Skip(); });
+    row->Add(m_hex, 0, wxALIGN_CENTER_VERTICAL);
+
+    auto* add_btn = new wxButton(this, wxID_ANY, _L("Add stop"));
+    add_btn->Bind(wxEVT_BUTTON, [this](wxCommandEvent&) { m_bar->add_stop(); });
+    row->Add(add_btn, 0, wxLEFT | wxALIGN_CENTER_VERTICAL, 8);
+
+    auto* remove_btn = new wxButton(this, wxID_ANY, _L("Remove stop"));
+    remove_btn->Bind(wxEVT_BUTTON, [this](wxCommandEvent&) { m_bar->remove_selected_stop(); });
+    row->Add(remove_btn, 0, wxLEFT | wxALIGN_CENTER_VERTICAL, 4);
+
+    main->Add(row, 0, wxEXPAND | wxALL, 8);
+
+    // Keep the hex field synced to the bar's currently-selected stop.
+    m_bar->on_selection_changed = [this]() { refresh_hex_field(); };
+
+    // Cycle length and start offset
+    auto* grid = new wxFlexGridSizer(2, 2, 6, 8);
+    grid->AddGrowableCol(1);
+
+    grid->Add(new wxStaticText(this, wxID_ANY, _L("Cycle length:")),
+              0, wxALIGN_CENTER_VERTICAL);
+    auto* cycle_sizer = new wxBoxSizer(wxHORIZONTAL);
+    m_cycle = new wxSpinCtrlDouble(this, wxID_ANY, wxEmptyString,
+                                   wxDefaultPosition, wxDefaultSize,
+                                   wxSP_ARROW_KEYS, 0.1, 1000000.0,
+                                   gradient.cycle_length_mm, 1.0);
+    m_cycle->SetDigits(1);
+    cycle_sizer->Add(m_cycle, 1, wxEXPAND);
+    // Unit selector: the canonical stored value is mm; "g" lets the user enter the cycle by
+    // weight (what most filament makers publish), converted via diameter + density.
+    m_cycle_unit = new wxChoice(this, wxID_ANY);
+    m_cycle_unit->Append("mm");
+    m_cycle_unit->Append("g");
+    m_cycle_unit->SetSelection(0);
+    if (m_diameter <= 0.0 || m_density <= 0.0)
+        m_cycle_unit->Disable(); // can't convert without valid filament properties
+    m_cycle_unit->Bind(wxEVT_CHOICE, [this](wxCommandEvent&) {
+        // The field currently holds a value in the PREVIOUS unit; convert to the new one.
+        const double v = m_cycle->GetValue();
+        if (m_cycle_unit->GetSelection() == 1)
+            m_cycle->SetValue(mm_to_grams(v));   // mm -> g
+        else
+            m_cycle->SetValue(grams_to_mm(v));   // g -> mm
+    });
+    cycle_sizer->Add(m_cycle_unit, 0, wxLEFT | wxALIGN_CENTER_VERTICAL, 6);
+    grid->Add(cycle_sizer, 1, wxEXPAND);
+
+    grid->Add(new wxStaticText(this, wxID_ANY, _L("Start offset (mm):")),
+              0, wxALIGN_CENTER_VERTICAL);
+    m_offset = new wxSpinCtrlDouble(this, wxID_ANY, wxEmptyString,
+                                    wxDefaultPosition, wxDefaultSize,
+                                    wxSP_ARROW_KEYS, 0.0, 100000.0,
+                                    gradient.start_offset_mm, 1.0);
+    grid->Add(m_offset, 1, wxEXPAND);
+
+    main->Add(grid, 0, wxEXPAND | wxALL, 8);
+
+    // OK / Cancel
+    main->Add(CreateStdDialogButtonSizer(wxOK | wxCANCEL), 0,
+              wxEXPAND | wxALL, 8);
+
+    SetSizer(main);
+    Fit();
+    SetMinSize(wxSize(480, -1));
+    Layout();
+    refresh_hex_field(); // populate hex from the initially-selected stop
+    CentreOnParent();
+}
+
+void GradientColorPickerDialog::refresh_hex_field()
+{
+    if (m_hex == nullptr || m_bar == nullptr) return;
+    ColorRGBA c;
+    if (m_bar->get_selected_color(c)) {
+        m_hex->ChangeValue(encode_color(c)); // ChangeValue: no EVT_TEXT, avoids re-entrancy
+        m_hex->Enable(true);
+    } else {
+        m_hex->ChangeValue(wxEmptyString);
+        m_hex->Enable(false);
+    }
+}
+
+void GradientColorPickerDialog::commit_hex_field()
+{
+    if (m_hex == nullptr || m_bar == nullptr || !m_hex->IsEnabled()) return;
+    std::string hs = m_hex->GetValue().Trim(true).Trim(false).ToStdString();
+    if (hs.empty()) { refresh_hex_field(); return; }
+    if (hs[0] != '#') hs = "#" + hs; // accept "RRGGBB" or "#RRGGBB"
+    ColorRGBA c;
+    if (decode_color(hs, c)) {
+        c.a(1.0f); // gradient stops are opaque
+        m_bar->set_selected_color(c);
+    } else {
+        refresh_hex_field(); // invalid input: revert to the current color
+    }
+}
+
+FilamentGradient GradientColorPickerDialog::get_gradient() const
+{
+    FilamentGradient g = m_bar->get_gradient();
+    const double cycle_val = m_cycle->GetValue();
+    g.cycle_length_mm = static_cast<float>(
+        (m_cycle_unit->GetSelection() == 1) ? grams_to_mm(cycle_val) : cycle_val);
+    g.start_offset_mm  = static_cast<float>(m_offset->GetValue());
+    return g;
+}
+
+double GradientColorPickerDialog::grams_to_mm(double grams) const
+{
+    if (m_density <= 0.0 || m_diameter <= 0.0)
+        return grams;
+    const double PI       = 3.14159265358979323846;
+    const double r_mm     = m_diameter / 2.0;
+    const double area_cm2 = (PI * r_mm * r_mm) / 100.0; // mm^2 -> cm^2
+    const double vol_cm3  = grams / m_density;
+    return (vol_cm3 / area_cm2) * 10.0;                 // cm -> mm
+}
+
+double GradientColorPickerDialog::mm_to_grams(double mm) const
+{
+    if (m_density <= 0.0 || m_diameter <= 0.0)
+        return mm;
+    const double PI       = 3.14159265358979323846;
+    const double r_mm     = m_diameter / 2.0;
+    const double area_cm2 = (PI * r_mm * r_mm) / 100.0; // mm^2 -> cm^2
+    const double vol_cm3  = (mm / 10.0) * area_cm2;
+    return vol_cm3 * m_density;
+}
+
+}} // namespace Slic3r::GUI

--- a/src/slic3r/GUI/GradientColorPickerDialog.hpp
+++ b/src/slic3r/GUI/GradientColorPickerDialog.hpp
@@ -1,0 +1,106 @@
+#pragma once
+
+#include "GUI_Utils.hpp"
+#include "libslic3r/FilamentGradient.hpp"
+
+#include <wx/wx.h>
+#include <wx/spinctrl.h>
+#include <functional>
+
+namespace Slic3r { namespace GUI {
+
+// ---------------------------------------------------------------------------
+// GradientBarWidget — custom wxWindow that renders the gradient bar and
+// lets the user add, move and remove color stops.
+// ---------------------------------------------------------------------------
+class GradientBarWidget : public wxWindow
+{
+public:
+    GradientBarWidget(wxWindow* parent, const FilamentGradient& gradient);
+
+    FilamentGradient get_gradient() const;
+
+    // Selected-stop access for the hosting dialog (hex entry, add/remove buttons).
+    bool get_selected_color(ColorRGBA& out) const;
+    void set_selected_color(const ColorRGBA& c);
+    void add_stop();              // add a stop in the largest gap and select it
+    void remove_selected_stop();  // remove the selected stop (keeps >= 2 stops)
+
+    // Invoked whenever the selected stop or its colour changes (so the dialog can refresh).
+    std::function<void()> on_selection_changed;
+
+    // Draw everything.
+    void on_paint(wxPaintEvent&);
+
+    // Mouse interaction.
+    void on_left_down(wxMouseEvent& e);
+    void on_left_up(wxMouseEvent& e);
+    void on_motion(wxMouseEvent& e);
+    void on_double_click(wxMouseEvent& e);
+    void on_right_down(wxMouseEvent& e);
+
+    DECLARE_EVENT_TABLE()
+
+private:
+    static constexpr int BAR_H       = 28;  // height of the gradient bar strip
+    static constexpr int HANDLE_H    = 10;  // height of the triangular handle below the bar
+    static constexpr int TOTAL_H     = BAR_H + HANDLE_H + 4;
+    static constexpr int MARGIN_X    = 12;  // left/right margin so handles can reach the edges
+    static constexpr int HANDLE_W    = 9;   // half-width of the handle triangle base
+
+    // Convert stop position [0,1] to pixel x inside the bar.
+    int pos_to_x(float pos) const;
+    // Convert pixel x to stop position [0,1].
+    float x_to_pos(int x) const;
+
+    // Return index of handle under point, or -1.
+    int hit_test(wxPoint pt) const;
+
+    // Redraw the cached gradient bitmap.
+    void rebuild_gradient_bitmap();
+
+    // Open the system colour picker for stop[index].
+    void pick_color_for(int index);
+
+    std::vector<GradientColorStop> m_stops;
+    int   m_dragging { -1 };   // index of stop being dragged, -1 = none
+    int   m_selected { -1 };   // index of currently selected stop
+    wxBitmap m_gradient_bmp;   // cached rendered gradient bar
+    bool     m_bmp_dirty { true };
+};
+
+
+// ---------------------------------------------------------------------------
+// GradientColorPickerDialog — wraps GradientBarWidget with cycle length,
+// start offset, and OK/Cancel controls.
+// ---------------------------------------------------------------------------
+class GradientColorPickerDialog : public DPIDialog
+{
+public:
+    GradientColorPickerDialog(wxWindow* parent, const FilamentGradient& gradient,
+                              double filament_diameter_mm = 1.75, double filament_density_g_cm3 = 1.24);
+
+    FilamentGradient get_gradient() const;
+
+protected:
+    void on_dpi_changed(const wxRect&) override {}
+
+private:
+    // Convert between a filament weight (g) and extruded length (mm) for this filament,
+    // using its diameter and density. No-ops if either is non-positive.
+    double grams_to_mm(double grams) const;
+    double mm_to_grams(double mm) const;
+
+    void refresh_hex_field();   // sync the hex text box to the selected stop's colour
+    void commit_hex_field();    // parse the hex box and apply it to the selected stop
+
+    GradientBarWidget* m_bar       { nullptr };
+    wxTextCtrl*        m_hex       { nullptr };  // "#RRGGBB" for the selected stop
+    wxSpinCtrlDouble*  m_cycle     { nullptr };
+    wxChoice*          m_cycle_unit{ nullptr };  // "mm" (0) or "g" (1)
+    wxSpinCtrlDouble*  m_offset    { nullptr };
+    double             m_diameter  { 1.75 };     // mm
+    double             m_density   { 1.24 };     // g/cm^3
+};
+
+}} // namespace Slic3r::GUI

--- a/src/slic3r/GUI/LibVGCode/LibVGCodeWrapper.cpp
+++ b/src/slic3r/GUI/LibVGCode/LibVGCodeWrapper.cpp
@@ -189,7 +189,8 @@ Slic3r::PrintEstimatedStatistics::ETimeMode convert(const ETimeMode& mode)
 }
 
 GCodeInputData convert(const Slic3r::GCodeProcessorResult& result, const std::vector<std::string>& str_tool_colors,
-    const std::vector<std::string>& str_color_print_colors, const Viewer& viewer)
+    const std::vector<std::string>& str_color_print_colors, const Viewer& viewer,
+    const std::vector<Slic3r::FilamentGradient>& gradients)
 {
     GCodeInputData ret;
 
@@ -206,6 +207,26 @@ GCodeInputData convert(const Slic3r::GCodeProcessorResult& result, const std::ve
         ret.color_print_colors.emplace_back(convert(color));
     }
 
+    // determine if any filament has a gradient — if so we will populate gradient_colors
+    const bool has_gradients = !gradients.empty() &&
+        std::any_of(gradients.begin(), gradients.end(),
+                    [](const Slic3r::FilamentGradient& g) { return !g.empty(); });
+
+    // Cumulative consumed FILAMENT FEEDSTOCK length (mm) per extruder, for gradient sampling.
+    // The gradient cycle length is given in mm of filament off the spool, so we accumulate
+    // feedstock length (extruded volume / filament cross-section), NOT nozzle path length
+    // (which is ~30x longer because the extruded line is far thinner than the filament).
+    std::vector<float> cumulative_extrusion_mm(str_tool_colors.size(), 0.0f);
+
+    // Filament feedstock cross-section area (mm^2) per extruder (fallback to 1.75 mm dia).
+    static constexpr float PI = 3.14159265358979323846f;
+    std::vector<float> filament_area(str_tool_colors.size(), 0.0f);
+    for (size_t e = 0; e < filament_area.size(); ++e) {
+        const float d = (e < result.filament_diameters.size() && result.filament_diameters[e] > 0.0f)
+                        ? result.filament_diameters[e] : 1.75f;
+        filament_area[e] = PI * (d * 0.5f) * (d * 0.5f);
+    }
+
     const std::vector<Slic3r::GCodeProcessorResult::MoveVertex>& moves = result.moves;
     ret.vertices.reserve(2 * moves.size());
     for (size_t i = 1; i < moves.size(); ++i) {
@@ -213,6 +234,29 @@ GCodeInputData convert(const Slic3r::GCodeProcessorResult& result, const std::ve
         const Slic3r::GCodeProcessorResult::MoveVertex& prev = moves[i - 1];
         const EMoveType curr_type = convert(curr.type);
         const EOptionType option_type = move_type_to_option(curr_type);
+        // Accumulate consumed filament feedstock length (extrusion moves only): segment volume
+        // (path length * mm^3-per-mm) divided by filament cross-section area.
+        const float seg_len = (curr.position - prev.position).norm();
+        const uint8_t eid   = curr.extruder_id;
+        if (curr_type == EMoveType::Extrude && eid < cumulative_extrusion_mm.size()) {
+            const float area = (eid < filament_area.size()) ? filament_area[eid] : 0.0f;
+            if (area > 0.0f)
+                cumulative_extrusion_mm[eid] += seg_len * curr.mm3_per_mm / area;
+        }
+
+        // helper: compute gradient color for the current extruder position
+        auto gradient_color_for = [&](uint8_t extruder_id) -> libvgcode::Color {
+            if (has_gradients && extruder_id < gradients.size() && !gradients[extruder_id].empty()) {
+                const Slic3r::ColorRGBA rgba = gradients[extruder_id].sample(
+                    extruder_id < cumulative_extrusion_mm.size() ? cumulative_extrusion_mm[extruder_id] : 0.0f);
+                return { rgba.r_uchar(), rgba.g_uchar(), rgba.b_uchar() };
+            }
+            // no gradient: fall back to flat tool color
+            if (extruder_id < ret.tools_colors.size())
+                return ret.tools_colors[extruder_id];
+            return libvgcode::DUMMY_COLOR;
+        };
+
         if (option_type == EOptionType::COUNT || option_type == EOptionType::Travels || option_type == EOptionType::Wipes) {
             if (ret.vertices.empty() || prev.type != curr.type || prev.extrusion_role != curr.extrusion_role
                 // ORCA: Split the path when a preview value changes.
@@ -238,6 +282,8 @@ GCodeInputData convert(const Slic3r::GCodeProcessorResult& result, const std::ve
                     /* ORCA: Add Jerk visualization support */ curr.jerk };
 #endif // VGCODE_ENABLE_COG_AND_TOOL_MARKERS
                 ret.vertices.emplace_back(vertex);
+                if (has_gradients)
+                    ret.gradient_colors.emplace_back(gradient_color_for(curr.extruder_id));
             }
         }
 
@@ -260,8 +306,12 @@ GCodeInputData convert(const Slic3r::GCodeProcessorResult& result, const std::ve
             /* ORCA: Add Jerk visualization support */ curr.jerk };
 #endif // VGCODE_ENABLE_COG_AND_TOOL_MARKERS
         ret.vertices.emplace_back(vertex);
+        if (has_gradients)
+            ret.gradient_colors.emplace_back(gradient_color_for(curr.extruder_id));
     }
     ret.vertices.shrink_to_fit();
+    if (has_gradients)
+        ret.gradient_colors.shrink_to_fit();
 
     ret.spiral_vase_mode = result.spiral_vase_mode;
 

--- a/src/slic3r/GUI/LibVGCode/LibVGCodeWrapper.hpp
+++ b/src/slic3r/GUI/LibVGCode/LibVGCodeWrapper.hpp
@@ -16,6 +16,7 @@
 
 #include "../../src/libvgcode/include/Types.hpp"
 #include "libslic3r/Color.hpp"
+#include "libslic3r/FilamentGradient.hpp"
 #include "libslic3r/GCode/GCodeProcessor.hpp"
 #include "slic3r/GUI/GUI_Preview.hpp"
 #include "libslic3r/ExtrusionEntity.hpp"
@@ -71,7 +72,8 @@ extern Slic3r::PrintEstimatedStatistics::ETimeMode convert(const ETimeMode& mode
 
 // mapping from Slic3r::GCodeProcessorResult to libvgcode::GCodeInputData
 extern GCodeInputData convert(const Slic3r::GCodeProcessorResult& result, const std::vector<std::string>& str_tool_colors,
-    const std::vector<std::string>& str_color_print_colors, const Viewer& viewer);
+    const std::vector<std::string>& str_color_print_colors, const Viewer& viewer,
+    const std::vector<Slic3r::FilamentGradient>& gradients = {});
 
 // mapping from Slic3r::Print to libvgcode::GCodeInputData
 extern GCodeInputData convert(const Slic3r::Print& print, const std::vector<std::string>& str_tool_colors,

--- a/src/slic3r/GUI/PresetComboBoxes.cpp
+++ b/src/slic3r/GUI/PresetComboBoxes.cpp
@@ -16,6 +16,7 @@
 #include <wx/colordlg.h>
 #include <wx/wupdlock.h>
 #include <wx/menu.h>
+#include <wx/time.h>   // wxGetUTCTimeMillis
 #include <wx/odcombo.h>
 #include <wx/listbook.h>
 
@@ -25,6 +26,7 @@
 #endif
 
 #include "libslic3r/libslic3r.h"
+#include "libslic3r/Utils.hpp"
 #include "libslic3r/PrintConfig.hpp"
 #include "libslic3r/PresetBundle.hpp"
 #include "libslic3r/Color.hpp"
@@ -44,6 +46,8 @@
 #include "MsgDialog.hpp"
 #include "ParamsDialog.hpp"
 #include "FilamentPickerDialog.hpp"
+#include "GradientColorPickerDialog.hpp"
+#include "libslic3r/Color.hpp"
 #include "wxExtensions.hpp"
 
 #include "DeviceCore/DevManager.h"
@@ -920,6 +924,18 @@ PlaterPresetComboBox::PlaterPresetComboBox(wxWindow *parent, Preset::Type preset
             evt->SetInt(m_filament_idx);
             wxQueueEvent(wxGetApp().plater(), evt);
         });
+        // Right-click the swatch to set/edit a gradient on ANY filament (not just Bambu library ones).
+        // Bind both CONTEXT_MENU and RIGHT_UP for cross-platform reach: CONTEXT_MENU covers the
+        // standard path (and macOS Ctrl-click); RIGHT_UP is a fallback for platforms/widgets where
+        // a button does not generate CONTEXT_MENU. open_gradient_editor() is re-entrancy guarded so
+        // platforms that deliver both events (e.g. Windows) do not open the dialog twice.
+        clr_picker->Bind(wxEVT_CONTEXT_MENU, [this](wxContextMenuEvent&) {
+            open_gradient_editor();
+        });
+        clr_picker->Bind(wxEVT_RIGHT_UP, [this](wxMouseEvent& e) {
+            open_gradient_editor();
+            e.Skip();
+        });
     }
     else {
         edit_btn = new ScalableButton(parent, wxID_ANY, "cog");
@@ -1625,6 +1641,123 @@ void PlaterPresetComboBox::sync_colour_config(const std::vector<std::string> &cl
     wxGetApp().preset_bundle->export_selections(*wxGetApp().app_config);
     update();  // refresh the preset combobox with new config
 
+    wxGetApp().plater()->on_config_change(cfg_new);
+}
+
+void PlaterPresetComboBox::open_gradient_editor()
+{
+    if (m_filament_idx < 0) return;
+    // Re-entrancy guard for overlapping calls, plus a short debounce: a single right-click can
+    // deliver both RIGHT_UP and CONTEXT_MENU, and the second fires right after the modal closes
+    // (so the boolean alone would let it reopen). Ignore a second open within 300 ms of a close.
+    if (m_gradient_editor_open) return;
+    if (wxGetUTCTimeMillis().GetValue() - m_gradient_editor_last_close_ms < 300) return;
+    m_gradient_editor_open = true;
+    Slic3r::ScopeGuard editor_guard([this]() {
+        m_gradient_editor_open = false;
+        m_gradient_editor_last_close_ms = wxGetUTCTimeMillis().GetValue();
+    });
+
+    DynamicPrintConfig* cfg = &wxGetApp().preset_bundle->project_config;
+
+    auto get_str = [&](const char* key) -> std::string {
+        auto* o = cfg->option<ConfigOptionStrings>(key);
+        return (o && m_filament_idx < (int)o->values.size()) ? o->values[m_filament_idx] : std::string();
+    };
+    auto get_flt = [&](const char* key, double def) -> double {
+        auto* o = cfg->option<ConfigOptionFloats>(key);
+        return (o && m_filament_idx < (int)o->values.size()) ? o->values[m_filament_idx] : def;
+    };
+
+    // Seed the editor from the current project_config for this extruder.
+    FilamentGradient grad;
+    if (!FilamentGradient::parse_stops(get_str("filament_gradient_stops"), grad.stops))
+        FilamentGradient::stops_from_color_list(get_str("filament_multi_colour"), grad.stops);
+    grad.cycle_length_mm = (float)get_flt("filament_gradient_cycle_length", 500.0);
+    grad.start_offset_mm = (float)get_flt("filament_gradient_start_offset", 0.0);
+
+    // Look up this filament's diameter & density so the editor can offer weight (g) input.
+    double diameter_mm = 1.75, density = 1.24;
+    {
+        auto* bundle = wxGetApp().preset_bundle;
+        if (bundle != nullptr && m_filament_idx < (int)bundle->filament_presets.size()) {
+            const Preset* fp = bundle->filaments.find_preset(bundle->filament_presets[m_filament_idx]);
+            if (fp != nullptr) {
+                if (auto* d = fp->config.option<ConfigOptionFloats>("filament_diameter");
+                    d && !d->values.empty() && d->values[0] > 0.0)
+                    diameter_mm = d->values[0];
+                if (auto* r = fp->config.option<ConfigOptionFloats>("filament_density");
+                    r && !r->values.empty() && r->values[0] > 0.0)
+                    density = r->values[0];
+            }
+        }
+    }
+
+    GradientColorPickerDialog dlg(this, grad, diameter_mm, density);
+    if (dlg.ShowModal() != wxID_OK)
+        return;
+
+    const FilamentGradient result = dlg.get_gradient();
+    std::vector<std::string> colours;
+    colours.reserve(result.stops.size());
+    for (const auto& s : result.stops)
+        colours.push_back(encode_color(s.color));
+
+    sync_gradient_config(result.serialize_stops(), colours,
+                         result.cycle_length_mm, result.start_offset_mm);
+
+    wxCommandEvent* evt = new wxCommandEvent(EVT_FILAMENT_COLOR_CHANGED);
+    evt->SetInt(m_filament_idx);
+    wxQueueEvent(wxGetApp().plater(), evt);
+}
+
+void PlaterPresetComboBox::sync_gradient_config(const std::string& stops_serialized,
+                                                const std::vector<std::string>& colours,
+                                                double cycle_length_mm, double start_offset_mm)
+{
+    if (colours.empty() || m_filament_idx < 0) return;
+    DynamicPrintConfig* cfg = &wxGetApp().preset_bundle->project_config;
+
+    // option(key, true) creates the option from its definition if absent, so clone() is never
+    // called on a null pointer (hardening against a project_config missing these keys).
+    auto multi_colour_opt = static_cast<ConfigOptionStrings*>(cfg->option("filament_multi_colour", true)->clone());
+    auto colour_type_opt  = static_cast<ConfigOptionStrings*>(cfg->option("filament_colour_type", true)->clone());
+    auto colour_opt       = static_cast<ConfigOptionStrings*>(cfg->option("filament_colour", true)->clone());
+    auto stops_opt        = static_cast<ConfigOptionStrings*>(cfg->option("filament_gradient_stops", true)->clone());
+    auto cycle_opt        = static_cast<ConfigOptionFloats*>(cfg->option("filament_gradient_cycle_length", true)->clone());
+    auto offset_opt       = static_cast<ConfigOptionFloats*>(cfg->option("filament_gradient_start_offset", true)->clone());
+
+    const size_t need = (size_t)m_filament_idx + 1;
+    if (multi_colour_opt->values.size() < need) multi_colour_opt->values.resize(need);
+    if (colour_type_opt->values.size()  < need) colour_type_opt->values.resize(need, "1");
+    if (colour_opt->values.size()       < need) colour_opt->values.resize(need);
+    if (stops_opt->values.size()        < need) stops_opt->values.resize(need);
+    if (cycle_opt->values.size()        < need) cycle_opt->values.resize(need, 500.0);
+    if (offset_opt->values.size()       < need) offset_opt->values.resize(need, 0.0);
+
+    std::string clr_str;
+    for (const auto& c : colours) clr_str += c + " ";
+    if (!clr_str.empty()) clr_str.pop_back();
+
+    multi_colour_opt->values[m_filament_idx] = clr_str;
+    colour_opt->values[m_filament_idx]       = colours.front();
+    colour_type_opt->values[m_filament_idx]  = "0"; // 0 == gradient
+    stops_opt->values[m_filament_idx]        = stops_serialized;
+    cycle_opt->values[m_filament_idx]        = cycle_length_mm;
+    offset_opt->values[m_filament_idx]       = start_offset_mm;
+
+    DynamicPrintConfig cfg_new = *cfg;
+    cfg_new.set_key_value("filament_multi_colour", multi_colour_opt);
+    cfg_new.set_key_value("filament_colour", colour_opt);
+    cfg_new.set_key_value("filament_colour_type", colour_type_opt);
+    cfg_new.set_key_value("filament_gradient_stops", stops_opt);
+    cfg_new.set_key_value("filament_gradient_cycle_length", cycle_opt);
+    cfg_new.set_key_value("filament_gradient_start_offset", offset_opt);
+    cfg->apply(cfg_new);
+
+    wxGetApp().plater()->update_project_dirty_from_presets();
+    wxGetApp().preset_bundle->export_selections(*wxGetApp().app_config);
+    update();
     wxGetApp().plater()->on_config_change(cfg_new);
 }
 

--- a/src/slic3r/GUI/PresetComboBoxes.hpp
+++ b/src/slic3r/GUI/PresetComboBoxes.hpp
@@ -209,11 +209,26 @@ public:
     FilamentColor get_cur_color_info();
     void show_default_color_picker();
     void sync_colour_config(const std::vector<std::string> &clrs, bool is_gradient);
+    // Open our gradient editor for the current filament (any filament, not just Bambu),
+    // seeded from project_config, and persist the result via sync_gradient_config.
+    void open_gradient_editor();
+    // Persist a full gradient (positioned stops + cycle length + start offset) into
+    // project_config alongside the native filament_colour_type / filament_multi_colour.
+    void sync_gradient_config(const std::string& stops_serialized,
+                              const std::vector<std::string>& colours,
+                              double cycle_length_mm, double start_offset_mm);
     void sys_color_changed() override;
 
 private:
     // BBS
     wxColor m_color;
+    // Guards against the gradient editor reopening when one right-click delivers
+    // both CONTEXT_MENU and RIGHT_UP events (platform-dependent).
+    bool m_gradient_editor_open { false };
+    // Time (ms) the editor last closed. A single right-click can deliver BOTH RIGHT_UP and
+    // CONTEXT_MENU; the second is queued behind the modal and fires right after it closes, so
+    // the boolean guard alone (which only blocks overlapping calls) can't stop the reopen.
+    long long m_gradient_editor_last_close_ms { 0 };
 };
 
 

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -4296,6 +4296,7 @@ void TabFilament::build()
         //optgroup->append_single_option_line("filament_colour");
         optgroup->append_single_option_line("required_nozzle_HRC", "material_basic_information#required-nozzle-hrc");
         optgroup->append_single_option_line("default_filament_colour", "material_basic_information#default-color");
+
         optgroup->append_single_option_line("filament_diameter", "material_basic_information#diameter");
         optgroup->append_single_option_line("filament_adhesiveness_category", "material_basic_information#adhesiveness-category");
 

--- a/tests/libslic3r/CMakeLists.txt
+++ b/tests/libslic3r/CMakeLists.txt
@@ -2,6 +2,7 @@ get_filename_component(_TEST_NAME ${CMAKE_CURRENT_LIST_DIR} NAME)
 
 add_executable(${_TEST_NAME}_tests
     ${_TEST_NAME}_tests.cpp
+    test_filament_gradient.cpp
     test_3mf.cpp
     test_aabbindirect.cpp
     test_appconfig.cpp

--- a/tests/libslic3r/test_filament_gradient.cpp
+++ b/tests/libslic3r/test_filament_gradient.cpp
@@ -1,0 +1,141 @@
+#include <catch2/catch_all.hpp>
+#include "libslic3r/FilamentGradient.hpp"
+
+using namespace Slic3r;
+using Catch::Approx;   // Catch2 v3 moved Approx into the Catch namespace
+
+static FilamentGradient make_grad(std::vector<GradientColorStop> stops,
+                                  float cycle = 100.f, float offset = 0.f)
+{
+    FilamentGradient g;
+    g.stops = std::move(stops);
+    g.cycle_length_mm = cycle;
+    g.start_offset_mm = offset;
+    return g;
+}
+
+static const ColorRGBA RED{ 1.f, 0.f, 0.f, 1.f };
+static const ColorRGBA GRN{ 0.f, 1.f, 0.f, 1.f };
+static const ColorRGBA BLU{ 0.f, 0.f, 1.f, 1.f };
+
+TEST_CASE("FilamentGradient sample - two stops", "[FilamentGradient]")
+{
+    auto g = make_grad({ {0.f, RED}, {1.f, BLU} }, /*cycle*/100.f);
+
+    SECTION("endpoints and blends") {              // SMP-01..03
+        REQUIRE(g.sample(0.f).r()  == Approx(1.f));
+        REQUIRE(g.sample(0.f).b()  == Approx(0.f));
+        const ColorRGBA mid = g.sample(50.f);
+        REQUIRE(mid.r() == Approx(0.5f));
+        REQUIRE(mid.b() == Approx(0.5f));
+        const ColorRGBA q = g.sample(25.f);
+        REQUIRE(q.r() == Approx(0.75f));
+        REQUIRE(q.b() == Approx(0.25f));
+    }
+    SECTION("cycling wraps") {                      // SMP-04..06
+        REQUIRE(g.sample(100.f).r() == Approx(1.f));   // fmod -> start
+        REQUIRE(g.sample(150.f).r() == Approx(0.5f));  // == sample(50)
+        REQUIRE(g.sample(250.f).b() == Approx(0.5f));
+    }
+    SECTION("start offset shifts") {                // SMP-07..08
+        auto go = make_grad({ {0.f, RED}, {1.f, BLU} }, 100.f, /*offset*/50.f);
+        REQUIRE(go.sample(0.f).b()  == Approx(0.5f));
+        REQUIRE(go.sample(75.f).r() == Approx(0.75f)); // fmod(125,100)=25
+    }
+    SECTION("negative position guard") {            // SMP-09
+        REQUIRE(g.sample(-25.f).b() == Approx(0.75f));
+    }
+    SECTION("zero cycle length does not divide by zero") { // SMP-10
+        auto gz = make_grad({ {0.f, RED}, {1.f, BLU} }, /*cycle*/0.f);
+        const ColorRGBA c = gz.sample(50.f);
+        REQUIRE(std::isfinite(c.r()));
+    }
+}
+
+TEST_CASE("FilamentGradient sample - three stops", "[FilamentGradient]")
+{
+    auto g = make_grad({ {0.f, RED}, {0.5f, GRN}, {1.f, BLU} }, 100.f);
+    SECTION("first segment") {                      // SMP-11
+        const ColorRGBA c = g.sample(25.f);
+        REQUIRE(c.r() == Approx(0.5f));
+        REQUIRE(c.g() == Approx(0.5f));
+    }
+    SECTION("exactly on middle stop") {             // SMP-12
+        const ColorRGBA c = g.sample(50.f);
+        REQUIRE(c.g() == Approx(1.f));
+        REQUIRE(c.r() == Approx(0.f));
+    }
+    SECTION("second segment") {                     // SMP-13
+        const ColorRGBA c = g.sample(75.f);
+        REQUIRE(c.g() == Approx(0.5f));
+        REQUIRE(c.b() == Approx(0.5f));
+    }
+}
+
+TEST_CASE("FilamentGradient sample - degenerate", "[FilamentGradient]")
+{
+    REQUIRE(make_grad({}).sample(10.f).r() == Approx(1.f));          // SMP-14 white
+    REQUIRE(make_grad({ {0.f, RED} }).sample(10.f).g() == Approx(1.f)); // SMP-15 white
+    REQUIRE(make_grad({}).empty());                                  // EMP-01
+    REQUIRE(make_grad({ {0.f, RED} }).empty());                      // EMP-02
+    REQUIRE_FALSE(make_grad({ {0.f, RED}, {1.f, BLU} }).empty());    // EMP-03
+}
+
+TEST_CASE("FilamentGradient parse and serialize", "[FilamentGradient]")
+{
+    SECTION("round trip preserves RGB") {           // SER-01
+        auto g = make_grad({ {0.f, RED}, {1.f, BLU} });
+        std::vector<GradientColorStop> out;
+        REQUIRE(FilamentGradient::parse_stops(g.serialize_stops(), out));
+        REQUIRE(out.size() == 2);
+        REQUIRE(out[0].position == Approx(0.f));
+        REQUIRE(out[0].color.r() == Approx(1.f));
+        REQUIRE(out[1].position == Approx(1.f));
+        REQUIRE(out[1].color.b() == Approx(1.f));
+    }
+    SECTION("parse sorts by position") {            // PAR-02
+        std::vector<GradientColorStop> out;
+        REQUIRE(FilamentGradient::parse_stops("1,#0000FF;0,#FF0000", out));
+        REQUIRE(out.size() == 2);
+        REQUIRE(out.front().position == Approx(0.f));
+        REQUIRE(out.front().color.r() == Approx(1.f));
+    }
+    SECTION("validation") {                         // PAR-03..07
+        std::vector<GradientColorStop> out;
+        REQUIRE(FilamentGradient::parse_stops("", out));            // empty -> true, 0 stops
+        REQUIRE(out.empty());
+        REQUIRE_FALSE(FilamentGradient::parse_stops("0,#FF0000", out));     // single stop
+        REQUIRE_FALSE(FilamentGradient::parse_stops("abc", out));           // no comma
+        REQUIRE_FALSE(FilamentGradient::parse_stops("0,notacolor", out));   // bad color
+        REQUIRE_FALSE(FilamentGradient::parse_stops("x,#FF0000;1,#0000FF", out)); // bad pos
+    }
+    SECTION("accepts 8-digit RRGGBBAA") {           // PAR-08
+        std::vector<GradientColorStop> out;
+        REQUIRE(FilamentGradient::parse_stops("0,#FF0000FF;1,#0000FFFF", out));
+        REQUIRE(out.size() == 2);
+    }
+}
+
+TEST_CASE("FilamentGradient stops_from_color_list", "[FilamentGradient]")
+{
+    std::vector<GradientColorStop> out;
+    SECTION("even spacing from 3 colors") {         // CLR-01
+        REQUIRE(FilamentGradient::stops_from_color_list("#FF0000 #00FF00 #0000FF", out));
+        REQUIRE(out.size() == 3);
+        REQUIRE(out[0].position == Approx(0.f));
+        REQUIRE(out[1].position == Approx(0.5f));
+        REQUIRE(out[2].position == Approx(1.f));
+    }
+    SECTION("comma separator") {                    // CLR-02
+        REQUIRE(FilamentGradient::stops_from_color_list("#FF0000,#0000FF", out));
+        REQUIRE(out.size() == 2);
+    }
+    SECTION("rejects single / empty") {             // CLR-03..04
+        REQUIRE_FALSE(FilamentGradient::stops_from_color_list("#FF0000", out));
+        REQUIRE_FALSE(FilamentGradient::stops_from_color_list("", out));
+    }
+    SECTION("skips invalid tokens") {               // CLR-05
+        REQUIRE(FilamentGradient::stops_from_color_list("#FF0000 garbage #0000FF", out));
+        REQUIRE(out.size() == 2);
+    }
+}


### PR DESCRIPTION
## Summary

Adds a preview for **physical gradient filaments** — spools whose color transitions
continuously along the filament (sold as gradient / ombre / rainbow / silk-transition).
Previously OrcaSlicer rendered any such filament as a single flat color in both the
Prepare and Preview views, so the user had no way to see how the color would fall across
the print. This change samples the filament's color along the print and shows it:

- **Preview (sliced):** per-extrusion-length gradient colors in the **Filament** view.
- **Prepare (pre-slice):** a fast Z-height approximation so you can preview before slicing.

It is configured per filament slot (color stops + cycle length + start offset) and the
gradient is edited directly from the sidebar color swatch.

## Motivation

Addresses **#11177** (the single-spool gradient/rainbow filament case — "Allow colors that
are not just a single color"). The requester explicitly noted *"I'm not sure how the sliced
preview would work"* — that's the gap this fills.

This is **complementary to Full Spectrum (#13437)**, not overlapping: Full Spectrum is
AMS-side color *mixing* (dithering layers of different physical filaments). This is the
inverse — faithfully representing *one* filament that is already a gradient. The two share
the existing `filament_colour_type` / `filament_multi_colour` config and compose cleanly.

## What it does

- **Edit from the swatch:** right-click any filament color swatch (not just Bambu library
  filaments) to open a gradient editor — draggable color stops, **hex color entry**
  (filament makers publish hex), add/remove stops, and a cycle length enterable in **mm or
  grams** (auto-converted via the filament's diameter + density).
- **Accurate sliced preview:** in the Filament view, each move is colored by the **cumulative
  filament length consumed** (extruded volume ÷ filament cross-section), so the toolpath
  closely matches what the physical spool produces at that point.
- **Prepare-view indication:** one gradient cycle stretched up the object's Z bounding box —
  a cheap, pre-slice "this filament is a gradient" preview.
- **Persistence:** survives app restart (AppConfig) and project save/load (`.3mf`).

## How it works

The feature plugs into OrcaSlicer's existing per-extruder color system (`project_config`:
`filament_colour_type == "0"` denotes a gradient; colors/stops alongside `filament_multi_colour`).

| Path | Where | Mechanism |
|---|---|---|
| **Data model** | `libslic3r/FilamentGradient` | `GradientColorStop` + `FilamentGradient::sample()`; serialize/parse; build stops from a color list |
| **Config** | `PrintConfig`, `PresetBundle` | 3 keys (`filament_gradient_stops/_cycle_length/_start_offset`) in `s_project_options`; AppConfig + 3MF round-trip |
| **Editor** | `GradientColorPickerDialog`, `PresetComboBoxes` | swatch right-click → editor → `sync_gradient_config` writes `project_config` |
| **Sliced preview** | `GCodeViewer`, `LibVGCodeWrapper`, `libvgcode` | per-vertex `gradient_colors[]` (parallel to vertices), returned by `get_vertex_color()` for the Filament view |
| **Prepare view** | `3DScene`, `gouraud.fs` (110 + 140) | per-volume gradient uniforms; fragment shader samples by world-space Z |

## Key design decisions

- **Stored at the project/slot level** (`project_config`), not the filament preset — each
  physical spool starts at a different point in its cycle, so it's a per-slot property
  (mirrors `filament_colour` / `filament_multi_colour`).
- **Cycle by filament length, not nozzle path** — the cycle is specified in mm/g of filament
  off the spool, so the preview accumulates *consumed feedstock length* (volume ÷
  cross-section), which is ~30× shorter than nozzle travel.
- **Preview keys excluded from the G-code config block** — `filament_gradient_*` are
  preview-only metadata with no effect on the print, so they're added to `banned_keys` in
  `GCode.cpp`. This avoids bloat and the `;`-containing stops string that can trip fragile
  firmware parsers — same rationale as **#13507** (skip `filament_colour_type`) which
  addresses **#12952** (Anycubic Kobra 3 parse hang). *(They are still written to the `.3mf`,
  which is a separate path.)*
- **Composes with #13625** — the gradient view auto-selection is folded into the new
  extruder-count "smart default view" logic, so a single-extruder gradient print defaults to
  the Filament view without overriding the user's manual view choice on re-slice.

## Testing

- **Unit tests:** `tests/libslic3r/test_filament_gradient.cpp` (Catch2) — 53 assertions / 5
  cases covering `sample()` (interpolation, cycling, offset, negative/zero guards), three-stop
  interpolation, degenerate→white, parse/serialize round-trip + validation, and
  `stops_from_color_list`. Run: `libslic3r_tests "[FilamentGradient]"` (`-DBUILD_TESTS=ON`).
- **Manual:** editor (hex/add-remove/right-click), Prepare-view rendering, sliced-preview
  cycle accuracy, persistence (AppConfig + `.3mf`), and confirmation that no
  `filament_gradient_*` keys appear in exported G-code.
- Rebased onto **v2.4.0**; full build + unit tests pass on Windows. *(Linux/macOS via CI.)*

## Screenshots

_Screenshots to follow._

## Notes / out of scope

- Prepare-view is an approximation (one cycle over Z); the sliced Preview is the accurate one.
- Prepare-view GLSL uses up to 8 stops (`GRAD_MAX`); the data model and sliced preview are
  unbounded.
- No cross-filament mixing (that's Full Spectrum's domain).
- Other slicers / older OrcaSlicer opening the `.3mf` degrade gracefully (unknown keys are
  dropped; `filament_colour` still carries the base color).
