### PR TITLE
CrealityPrint: remove hardcoded :4408 from Device WebView URL

### DIFF
--- a/src/slic3r/Utils/CrealityPrint.cpp
+++ b/src/slic3r/Utils/CrealityPrint.cpp
@@ -298,40 +298,6 @@ std::string CrealityPrint::query_boxes_info() const
     }
 }
 
-std::string CrealityPrint::get_print_host_webui(DynamicPrintConfig* config)
-{
-    // K-series printers (K2 / K2 Plus / K2 Pro) ship with Mainsail on port 4408.
-    // Port 80 hosts only the Creality control / upload API, which returns 404
-    // for unknown paths and therefore renders as a blank/404 page in Orca's
-    // Device WebView. Default to the Mainsail URL when the user hasn't
-    // explicitly set print_host_webui. Use printhost_port if configured,
-    // otherwise fall back to 4408.
-    if (config == nullptr)
-        return {};
-
-    std::string explicit_url = config->opt_string("print_host_webui");
-    if (!explicit_url.empty())
-        return explicit_url;
-
-    std::string host = config->opt_string("print_host");
-    if (host.empty())
-        return {};
-
-    if (boost::algorithm::istarts_with(host, "http://"))
-        host = host.substr(7);
-    else if (boost::algorithm::istarts_with(host, "https://"))
-        host = host.substr(8);
-    if (auto slash = host.find('/'); slash != std::string::npos)
-        host = host.substr(0, slash);
-    if (auto colon = host.find(':'); colon != std::string::npos)
-        host = host.substr(0, colon);
-
-    std::string port = config->opt_string("printhost_port");
-    if (port.empty())
-        port = "4408";
-    return "http://" + host + ":" + port + "/";
-}
-
 bool CrealityPrint::start_print(wxString &msg, const std::string &filename, const std::map<std::string, std::string>& extended_info) const
 {
     try {

--- a/src/slic3r/Utils/CrealityPrint.cpp
+++ b/src/slic3r/Utils/CrealityPrint.cpp
@@ -304,7 +304,8 @@ std::string CrealityPrint::get_print_host_webui(DynamicPrintConfig* config)
     // Port 80 hosts only the Creality control / upload API, which returns 404
     // for unknown paths and therefore renders as a blank/404 page in Orca's
     // Device WebView. Default to the Mainsail URL when the user hasn't
-    // explicitly set print_host_webui.
+    // explicitly set print_host_webui. Use printhost_port if configured,
+    // otherwise fall back to 4408.
     if (config == nullptr)
         return {};
 
@@ -325,7 +326,10 @@ std::string CrealityPrint::get_print_host_webui(DynamicPrintConfig* config)
     if (auto colon = host.find(':'); colon != std::string::npos)
         host = host.substr(0, colon);
 
-    return "http://" + host + ":4408/";
+    std::string port = config->opt_string("printhost_port");
+    if (port.empty())
+        port = "4408";
+    return "http://" + host + ":" + port + "/";
 }
 
 bool CrealityPrint::start_print(wxString &msg, const std::string &filename, const std::map<std::string, std::string>& extended_info) const

--- a/src/slic3r/Utils/CrealityPrint.hpp
+++ b/src/slic3r/Utils/CrealityPrint.hpp
@@ -34,10 +34,6 @@ public:
     std::string query_boxes_info() const;
     std::string model_name() const;
 
-    // Mainsail on K-series printers listens on port 4408. Use that as the
-    // default Device-tab WebView URL when the user has not set print_host_webui.
-    static std::string get_print_host_webui(DynamicPrintConfig *config);
-
 protected:
     virtual void set_auth(Http& http) const;
 private:

--- a/src/slic3r/Utils/PrintHost.cpp
+++ b/src/slic3r/Utils/PrintHost.cpp
@@ -92,10 +92,6 @@ std::string PrintHost::get_print_host_webui(DynamicPrintConfig* config)
         webui_url = ElegooLink::get_print_host_webui(config);
         break;
     }
-    case htCrealityPrint: {
-        webui_url = CrealityPrint::get_print_host_webui(config);
-        break;
-    }
     default: break;
     }
 


### PR DESCRIPTION
Remove the `CrealityPrint::get_print_host_webui()` override that unconditionally forced the Device tab WebView URL to use port `:4408`.

## Why

The CrealityPrint-specific override treated `:4408` as the default WebUI/Mainsail port whenever `print_host_webui` was empty. That breaks users whose printers expose the UI through a different route, especially printers with a built-in reverse proxy where browsing to the plain printer host is expected to route to the correct web interface.

It also removes control from users: the Device tab should not invent a port. Users who need a specific WebUI URL or port can already configure it explicitly with `print_host_webui`.

## What changed

- Remove `CrealityPrint::get_print_host_webui()` declaration and implementation
- Remove the `htCrealityPrint` special case from `PrintHost::get_print_host_webui()`
- Let CrealityPrint use the existing generic fallback behavior

The fallback chain is now:

1. `print_host_webui` — user-configured WebUI URL, including any required port, for example `http://192.168.1.100:4408/`
2. `print_host` — plain printer host/IP/domain, with no port appended by OrcaSlicer
3. empty — no Device tab URL configured

## Result

The Device tab no longer hardcodes any port for CrealityPrint printers. Users who rely on the printer's reverse proxy can leave `print_host_webui` empty and set `print_host` to the printer host/IP. Users who need a specific UI port can set the full URL in `print_host_webui`.

## Related issues

- #7747 — Creality K2 Plus Device tab shows 404
- #10740 — Creality Hi / Ender 5 Max Device tab shows 404
- #14114 — Partially related: includes Device tab / printer WebUI routing symptoms, but CFS sync and upload errors are outside the scope of this PR
