### PR TITLE
Set Qidi X-Max 4 printer agent

### DIFF
--- a/resources/profiles/Qidi.json
+++ b/resources/profiles/Qidi.json
@@ -1,6 +1,6 @@
 {
 	"name": "Qidi",
-	"version": "02.04.00.03",
+	"version": "02.04.00.04",
 	"force_update": "0",
 	"description": "Qidi configurations",
 	"machine_model_list": [

--- a/resources/profiles/Qidi/machine/Qidi X-Max 4 0.4 nozzle.json
+++ b/resources/profiles/Qidi/machine/Qidi X-Max 4 0.4 nozzle.json
@@ -79,5 +79,6 @@
 		"150x150"
 	],
 	"fan_direction": "left",
+	"printer_agent": "qidi",
 	"use_3mf": "1"
 }


### PR DESCRIPTION
# Description

The Qidi Max 4 should be using `qidi` as the printer agent.  Currently users have to set this manually.  This is already set properly for the Q2 and Plus 4.


<!--
> A guide for users on how to download the artifacts from this PR.
-->

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
