### PR TITLE
Allow appimage execution for non-owner

### DIFF
--- a/src/dev-utils/platform/unix/build_linux_image.sh.in
+++ b/src/dev-utils/platform/unix/build_linux_image.sh.in
@@ -350,7 +350,7 @@ fi
 
 exec "\$@"
 EOF
-    chmod ug+x "$LIBEXEC_DIR/@SLIC3R_APP_CMD@-env"
+    chmod a+x "$LIBEXEC_DIR/@SLIC3R_APP_CMD@-env"
 
 cat << EOF >@SLIC3R_APP_CMD@
 #!/bin/bash


### PR DESCRIPTION
# Description

The appimage of 2.4.0 sets execute permissions only for the user and group, but not for 'other'. This prevents execution when run as another user. I encountered this when running OrcaSilcer in a firejail namespace:
```
/run/firejail/appimage/AppRun: line 28: /run/firejail/appimage/libexec/orca-slicer-env: Permission denied
```
and it has also been [noted by the AUR package maintainers](https://aur.archlinux.org/packages/orca-slicer-bin#comment-1076025) (who extract the appimage)

## Tests

<strike>None yet, I am not able to build locally. This is just a guess.

I will follow up if I can test with artifacts from this PR.</strike>

Tested working by unpacking appimage modifying and repacking.
