### PR TITLE
fix(CrealityPrint): avoid false 'End of file' error when K1 closes the WS after start

### DIFF
--- a/src/slic3r/Utils/CrealityPrint.cpp
+++ b/src/slic3r/Utils/CrealityPrint.cpp
@@ -414,11 +414,19 @@ bool CrealityPrint::start_print(wxString &msg, const std::string &filename, cons
             };
             ws.write(net::buffer(to_string(cmd)));
 
+            // K1-family firmware closes the WebSocket right after accepting the
+            // start command, so a blocking read here surfaces a benign
+            // "End of file [asio.misc:2]" even though the print already started
+            // (the command is delivered by write()). Read best-effort, ignore errors.
             beast::flat_buffer buffer;
-            ws.read(buffer);
+            beast::error_code  read_ec;
+            ws.read(buffer, read_ec);
         }
 
-        ws.close(websocket::close_code::normal);
+        // Same reason: the printer may have already closed the connection. A close
+        // error here is not a failure — the start command was sent above.
+        beast::error_code close_ec;
+        ws.close(websocket::close_code::normal, close_ec);
         return true;
     } catch(std::exception const& e) {
         BOOST_LOG_TRIVIAL(error) << "CrealityPrint: Error starting print: " << e.what();


### PR DESCRIPTION
## Problem
Sending a print to a Creality **K1-family** printer via the `crealityprint` host type pops up
`Error sending to print host: End of file [asio.misc:2]` — even though the print actually starts.

## Cause
`CrealityPrint::start_print()` sends the `printprt:` start command over the port-9999 control
WebSocket and then does a **blocking `ws.read(buffer)`** to wait for a reply. K1-family firmware
closes the WebSocket as soon as it accepts the command, so that read throws `End of file` and the
operation is reported as a failure — but the command was already delivered by `write()`, so the
print starts. The trailing `ws.close()` can throw for the same reason.

## Fix
Make the post-write `read` and the `close` best-effort via the Boost.Beast `error_code` overloads,
so a benign EOF after a successful `write()` no longer surfaces as an error. Covers the single-color
and multi-color paths; no change to the actual start command.

## Tests
Reproduced and fixed on a real Creality **K1C** (firmware 1.0.0): before, every send showed the
popup (print started anyway); after, no popup and the print starts normally.

_Touches `CrealityPrint::start_print()` introduced in #13752._