### PR TITLE
fix(profiles): Snapmaker U1 — add bed dimensions to fdm_U1 for all nozzle variants

### DIFF
--- a/resources/profiles/Snapmaker.json
+++ b/resources/profiles/Snapmaker.json
@@ -1,6 +1,6 @@
 {
 	"name": "Snapmaker",
-	"version": "02.04.00.04",
+	"version": "02.04.00.06",
 	"force_update": "0",
 	"description": "Snapmaker configurations",
 	"machine_model_list": [

--- a/resources/profiles/Snapmaker/machine/fdm_U1.json
+++ b/resources/profiles/Snapmaker/machine/fdm_U1.json
@@ -186,5 +186,12 @@
 	"nozzle_type": "undefine",
 	"auxiliary_fan": "0",
 	"default_bed_type": "Textured PEI Plate",
-	"printer_agent": "snapmaker"
+	"printer_agent": "snapmaker",
+	"printable_area": [
+		"0.5x1",
+		"270.5x1",
+		"270.5x271",
+		"0.5x271"
+	],
+	"printable_height": "270.05"
 }


### PR DESCRIPTION
## Summary

The 0.2mm, 0.6mm, and 0.8mm nozzle profiles for Snapmaker U1 displayed a smaller-than-actual bed because `printable_area` was missing from the shared parent `fdm_U1.json`. Only the 0.4mm profile had it set explicitly.

## Fix

Add `printable_area` (270×270mm) and `printable_height` (270.05mm) to `fdm_U1.json` so all nozzle variants inherit the correct bed dimensions. Bump vendor version to `.06` to trigger profile re-sync on existing installs.

## Files changed

- `resources/profiles/Snapmaker/machine/fdm_U1.json` — added `printable_area` + `printable_height`
- `resources/profiles/Snapmaker.json` — vendor version `02.04.00.04` → `02.04.00.06`

## Testing

- All nozzle variants (0.2/0.4/0.6/0.8) now show the correct 270×270mm bed in the 3D view
- Existing 0.4 profile unaffected (its explicit override is identical to the parent value)

## Related PR
* https://github.com/OrcaSlicer/OrcaSlicer/pull/14305

## Screenshots

### 0.6 mm Profile
<img width="1273" height="824" alt="image" src="https://github.com/user-attachments/assets/0917bd1e-894b-4f3b-bc12-52978695b312" />

### 0.2 mm 
<img width="1288" height="881" alt="image" src="https://github.com/user-attachments/assets/0c10df35-2d44-4786-b12b-d7638649581c" />

### Original 0.4 mm
<img width="1241" height="639" alt="image" src="https://github.com/user-attachments/assets/b79175f4-853e-4495-93e8-150bd99e64e4" />
