### PR TITLE
feat(GUI): Snapmaker U1 nozzle easy profile selection and Mixed Nozzle Sizes support for multi toolhead printers

### DIFF
--- a/src/libslic3r/CMakeLists.txt
+++ b/src/libslic3r/CMakeLists.txt
@@ -311,6 +311,8 @@ set(lisbslic3r_sources
     MutablePriorityQueue.hpp
     NormalUtils.cpp
     NormalUtils.hpp
+    NozzleAgnostic.cpp
+    NozzleAgnostic.hpp
     NSVGUtils.cpp
     NSVGUtils.hpp
     ObjColorUtils.cpp

--- a/src/libslic3r/NozzleAgnostic.cpp
+++ b/src/libslic3r/NozzleAgnostic.cpp
@@ -1,0 +1,99 @@
+#include "NozzleAgnostic.hpp"
+
+#include <algorithm>
+#include <cmath>
+
+#include "PrintConfig.hpp"
+#include "Preset.hpp"
+#include "PresetBundle.hpp"
+
+namespace Slic3r {
+namespace nozzle_agnostic {
+
+// Nozzle diameters within this tolerance (mm) are treated as equal.
+static const double NOZZLE_EPSILON = 1e-6;
+
+double to_percent(double abs_mm, double base_nozzle)
+{
+    return abs_mm / base_nozzle * 100.0;
+}
+
+ConfigOptionFloatOrPercent convert_field(const ConfigOptionFloatOrPercent &in, double base_nozzle)
+{
+    if (in.percent || base_nozzle <= 0.0)
+        return in;
+    // Round the percentage to 0.1 (one decimal place) so the converted values stay clean/readable
+    // (e.g. 112.5%, not 112.53125%). The per-toolhead absolute width is recomputed from this % at
+    // slice time, so a 0.1% rounding is a sub-micron width difference -- below printable resolution.
+    const double pct = std::round(to_percent(in.value, base_nozzle) * 10.0) / 10.0;
+    return ConfigOptionFloatOrPercent(pct, /*percent=*/true);
+}
+
+bool is_in_scope(const ConfigOptionDef &def)
+{
+    return def.type == coFloatOrPercent && def.ratio_over == "nozzle_diameter";
+}
+
+std::vector<std::string> scoped_keys(const ConfigDef &def_registry)
+{
+    std::vector<std::string> keys;
+    for (const auto &kv : def_registry.options)
+        if (is_in_scope(kv.second))
+            keys.push_back(kv.first);
+    return keys;
+}
+
+bool is_mixed_nozzle(const std::vector<double> &nozzles)
+{
+    if (nozzles.size() < 2)
+        return false;
+    const double first = nozzles.front();
+    for (const double d : nozzles)
+        if (std::abs(d - first) > NOZZLE_EPSILON)
+            return true;
+    return false;
+}
+
+bool has_absolute_scoped_fields(const DynamicPrintConfig &process_cfg)
+{
+    const ConfigDef *def_registry = process_cfg.def();
+    if (def_registry == nullptr)
+        return false;
+    for (const std::string &key : scoped_keys(*def_registry)) {
+        const auto *fop = dynamic_cast<const ConfigOptionFloatOrPercent *>(process_cfg.option(key));
+        if (fop != nullptr && !fop->percent)
+            return true;
+    }
+    return false;
+}
+
+std::optional<double> resolve_base_nozzle(const Preset &process, const PresetBundle &bundle)
+{
+    const auto *compatible_printers =
+        dynamic_cast<const ConfigOptionStrings *>(process.config.option("compatible_printers"));
+    if (compatible_printers == nullptr || compatible_printers->values.empty())
+        return std::nullopt;
+
+    std::vector<double> bases;
+    for (const std::string &printer_name : compatible_printers->values) {
+        const Preset *machine = bundle.printers.find_preset(printer_name);
+        if (machine == nullptr)
+            continue;
+        const auto *nozzle_diameter =
+            dynamic_cast<const ConfigOptionFloats *>(machine->config.option("nozzle_diameter"));
+        if (nozzle_diameter == nullptr)
+            continue;
+        for (const double d : nozzle_diameter->values) {
+            const bool seen = std::any_of(bases.begin(), bases.end(),
+                [d](double b) { return std::abs(b - d) <= NOZZLE_EPSILON; });
+            if (!seen)
+                bases.push_back(d);
+        }
+    }
+
+    // Exactly one distinct base -> divisor; zero or several -> refuse.
+    return bases.size() == 1 ? std::optional<double>(bases.front()) : std::nullopt;
+}
+
+} // namespace nozzle_agnostic
+} // namespace Slic3r

--- a/src/libslic3r/NozzleAgnostic.hpp
+++ b/src/libslic3r/NozzleAgnostic.hpp
@@ -1,0 +1,45 @@
+#ifndef slic3r_NozzleAgnostic_hpp_
+#define slic3r_NozzleAgnostic_hpp_
+
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "Config.hpp"
+
+// Pure libslic3r helpers for making a process profile nozzle-agnostic: convert absolute
+// nozzle-diameter-scaled fields to percentages so one profile prints correctly on mixed nozzles.
+// A field is in scope iff it is a coFloatOrPercent option with ratio_over == "nozzle_diameter".
+
+namespace Slic3r {
+
+// Used only by ref/ptr below, so the heavy headers stay in the .cpp.
+class Preset;
+class PresetBundle;
+class DynamicPrintConfig;
+
+namespace nozzle_agnostic {
+
+// --- conversion math + in-scope rule ---
+
+double      to_percent(double abs_mm, double base_nozzle);          // abs / base * 100, exact
+
+// Idempotent: already-percent and base <= 0 are returned unchanged. Returns a new value, never mutates.
+ConfigOptionFloatOrPercent convert_field(const ConfigOptionFloatOrPercent &in, double base_nozzle);
+
+bool                     is_in_scope(const ConfigOptionDef &def);   // coFloatOrPercent && ratio_over=="nozzle_diameter"
+std::vector<std::string> scoped_keys(const ConfigDef &def_registry);
+
+// --- detect / resolve / refuse ---
+
+bool is_mixed_nozzle(const std::vector<double> &nozzles);           // >= 2 distinct diameters
+bool has_absolute_scoped_fields(const DynamicPrintConfig &process_cfg);
+
+// Base divisor = the nozzle the selected process profile is compatible_printers-bound to.
+// nullopt when it cannot be resolved to exactly one diameter (refuse rather than guess).
+std::optional<double> resolve_base_nozzle(const Preset &process, const PresetBundle &bundle);
+
+} // namespace nozzle_agnostic
+} // namespace Slic3r
+
+#endif // slic3r_NozzleAgnostic_hpp_

--- a/src/slic3r/CMakeLists.txt
+++ b/src/slic3r/CMakeLists.txt
@@ -353,6 +353,8 @@ set(SLIC3R_GUI_SOURCES
     GUI/Notebook.hpp
     GUI/NotificationManager.cpp
     GUI/NotificationManager.hpp
+    GUI/NozzlePickerPanel.cpp
+    GUI/NozzlePickerPanel.hpp
     GUI/OAuthDialog.cpp
     GUI/OAuthDialog.hpp
     GUI/ObjColorDialog.cpp

--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -7,10 +7,12 @@
 #include "libslic3r/Model.hpp"
 #include "libslic3r/PresetBundle.hpp"
 #include "libslic3r/MaterialType.hpp"
+#include "libslic3r/NozzleAgnostic.hpp"
 #include "MsgDialog.hpp"
 #include "libslic3r/PrintConfig.hpp"
 #include "libslic3r/GCode/AdaptivePAProcessor.hpp"
 #include "Plater.hpp"
+#include "MainFrame.hpp"
 
 #include <sstream>
 #include <wx/msgdlg.h>
@@ -218,6 +220,41 @@ void ConfigManipulation::check_chamber_temperature(DynamicPrintConfig* config)
             }
         }
     }
+}
+
+void ConfigManipulation::check_nozzle_agnostic(DynamicPrintConfig* config, bool is_mixed, std::optional<double> base)
+{
+    if (is_msg_dlg_already_exist)
+        return;
+    // Inert unless the printer is mixed, a single base nozzle resolved, and there are still
+    // absolute nozzle-scaled fields to convert. Never guess a base.
+    if (!is_mixed || !base.has_value())
+        return;
+    if (!nozzle_agnostic::has_absolute_scoped_fields(*config))
+        return;
+
+    wxString msg_text = _(L("Convert line widths for different nozzle diameters? This allows the slicer "
+                            "to adjust them automatically for each toolhead."));
+    msg_text += "\n\n" + _(L("Yes - Convert line widths.\n"
+                             "No - Do not convert."));
+    // Parent to the main frame (not the narrow Tab strip) so MessageDialog's CenterOnParent() centers
+    // the dialog on the whole window -- matching the other nozzle dialogs (the uniform-switch note).
+    MessageDialog dialog(static_cast<wxWindow*>(wxGetApp().mainframe), msg_text,
+                         _L("Mixed Nozzle Sizes"), wxICON_WARNING | wxYES | wxNO);
+    DynamicPrintConfig new_conf = *config;
+    is_msg_dlg_already_exist = true;
+    auto answer = dialog.ShowModal();
+    if (answer == wxID_YES) {
+        for (const std::string& key : nozzle_agnostic::scoped_keys(*config->def())) {
+            if (!config->has(key))
+                continue;
+            const auto* opt = dynamic_cast<const ConfigOptionFloatOrPercent*>(config->option(key));
+            if (opt)
+                new_conf.set_key_value(key, nozzle_agnostic::convert_field(*opt, *base).clone());
+        }
+        apply(config, &new_conf);
+    }
+    is_msg_dlg_already_exist = false;
 }
 
 void ConfigManipulation::update_print_fff_config(DynamicPrintConfig* config, const bool is_global_config, const bool is_plate_config)

--- a/src/slic3r/GUI/ConfigManipulation.hpp
+++ b/src/slic3r/GUI/ConfigManipulation.hpp
@@ -8,6 +8,7 @@
  *	 and local config (overrides options on sidebar)
  * */
 
+#include <optional>
 #include "libslic3r/PrintConfig.hpp"
 #include "Field.hpp"
 
@@ -80,6 +81,10 @@ public:
     void    check_adaptive_pressure_advance_model(DynamicPrintConfig* config);
     void    check_filament_max_volumetric_speed(DynamicPrintConfig *config);
     void    check_chamber_temperature(DynamicPrintConfig* config);
+    // Mixed-nozzle line-width conversion: when the printer has mixed nozzles, a base nozzle resolves,
+    // and the process still has absolute nozzle-scaled fields, offer (Yes/No) to convert them to
+    // percentages of nozzle diameter in place. is_mixed/base are computed by the caller via libslic3r.
+    void    check_nozzle_agnostic(DynamicPrintConfig* config, bool is_mixed, std::optional<double> base);
     void    set_is_BBL_Printer(bool is_bbl_printer) { is_BBL_Printer = is_bbl_printer; };
     bool    get_is_BBL_Printer() { return is_BBL_Printer; };
     // SLA print

--- a/src/slic3r/GUI/NozzlePickerPanel.cpp
+++ b/src/slic3r/GUI/NozzlePickerPanel.cpp
@@ -1,0 +1,193 @@
+#include "NozzlePickerPanel.hpp"
+
+#include <iomanip>
+#include <sstream>
+
+#include <wx/sizer.h>
+#include <wx/stattext.h>
+#include <wx/statbox.h>
+
+#include "Widgets/ComboBox.hpp"
+#include "Widgets/Button.hpp"
+#include "Widgets/StaticBox.hpp"
+#include "Widgets/StaticLine.hpp"
+#include "Widgets/Label.hpp"
+#include "wxExtensions.hpp"
+#include "GUI_App.hpp"
+#include "I18N.hpp"
+
+namespace Slic3r { namespace GUI {
+
+// Two-column grid, matching the Filament section. Nozzle i goes into column (i % NOZZLE_COLUMNS) so
+// they read row-major (1 2 / 3 4); this fits the narrow printer sidebar and scales to more nozzles.
+// The panel lives inside the sidebar's scrolled window, so extra rows scroll with it -- no wrapper here.
+static const int NOZZLE_COLUMNS = 2;
+
+// Spacing literals copied from SidebarProps (Plater.hpp) so the nozzle rows + title match the Filament
+// section without pulling in the heavy Plater.hpp: TitlebarMargin()=8 (title icon inset),
+// ElementSpacing()=5 (related controls, e.g. icon<->label and label<->combo).
+static const int kTitlebarMargin = 8;
+static const int kElementSpacing = 5;
+
+// "0.4" / "0.4mm" -> 0.4 . Strict: after an optional trailing "mm" unit, the whole string must be a
+// single number. Composite/combined variants like "0.4+0.6" are rejected (return 0), not silently
+// truncated to their leading value. The "mm" suffix is accepted because the dropdowns display it.
+static double parse_diameter(const wxString& value)
+{
+    try {
+        std::string s = value.ToStdString();
+        if (s.size() >= 2 && s.compare(s.size() - 2, 2, "mm") == 0)
+            s.erase(s.size() - 2);
+        size_t consumed = 0;
+        double d = std::stod(s, &consumed);
+        return consumed == s.size() ? d : 0.0;
+    } catch (...) {
+        return 0.0;
+    }
+}
+
+// Format a diameter as a trimmed "0.6mm" string for display in a dropdown.
+static wxString format_diameter(double mm)
+{
+    std::ostringstream stream;
+    stream << std::fixed << std::setprecision(2) << mm;
+    std::string s = stream.str();
+    if (s.find('.') != std::string::npos) {
+        s.erase(s.find_last_not_of('0') + 1);
+        if (s.back() == '.') s += '0';
+    }
+    return wxString(s) + "mm";
+}
+
+// A printer_variant is offered as a per-extruder nozzle size only if it is a single diameter.
+// A model can ship a *combined* variant such as "0.4+0.6" (the old single-preset way to describe a
+// mixed-nozzle machine, which this picker replaces); one toolhead is "0.4" or "0.6", never "0.4+0.6",
+// so combined variants are filtered out here. parse_diameter rejects them by returning 0.
+static bool is_single_diameter(const std::string& variant)
+{
+    return parse_diameter(wxString(variant)) > 0.0;
+}
+
+NozzlePickerPanel::NozzlePickerPanel(wxWindow* parent)
+    : wxPanel(parent, wxID_ANY)
+{
+    // Inherit the surrounding menu's background (the printer-content panel we're parented to) rather
+    // than hardcoding a colour, so the area behind the nozzle rows is the same shade as the rest of the
+    // sidebar by construction -- in any theme. Without this the panel kept wx's default grey and read as
+    // a lighter block. The build site also runs UpdateDarkUI on this panel (as the sibling panels get).
+    if (parent)
+        SetBackgroundColour(parent->GetBackgroundColour());
+
+    auto* root = new wxBoxSizer(wxVERTICAL);
+
+    // Title bar matching the Filament section's `m_panel_filament_title` (Plater.cpp): a gradient
+    // StaticBox holding a ScalableButton icon + a Label, bracketed top and bottom by thin StaticLine
+    // separators. Icon = "single_nozzle_n" (the nozzle glyph) where filament uses "filament".
+    auto* title = new StaticBox(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL | wxBORDER_NONE);
+    title->SetBackgroundColor(wxColour(248, 248, 248));
+    title->SetBackgroundColor2(0xF1F1F1);
+
+    auto* title_sizer = new wxBoxSizer(wxHORIZONTAL);
+    auto* icon  = new ScalableButton(title, wxID_ANY, "single_nozzle_n");
+    auto* label = new Label(title, _L("Nozzles"));
+    title_sizer->Add(icon,  0, wxALIGN_CENTER | wxLEFT, FromDIP(kTitlebarMargin));
+    title_sizer->Add(label, 0, wxALIGN_CENTER | wxLEFT | wxRIGHT, FromDIP(kElementSpacing));
+    title_sizer->SetMinSize(-1, FromDIP(30));
+    title->SetSizer(title_sizer);
+
+    auto* sep_top = new StaticLine(this);
+    sep_top->SetLineColour("#A6A9AA");
+    root->Add(sep_top, 0, wxEXPAND);
+    root->Add(title, 0, wxEXPAND);
+    auto* sep_bottom = new StaticLine(this);
+    sep_bottom->SetLineColour("#A6A9AA");
+    root->Add(sep_bottom, 0, wxEXPAND);
+
+    // Rows sit flush on the panel -- no inner frame -- like the Filament section. The sizer holds
+    // NOZZLE_COLUMNS vertical column sizers side by side, built in rebuild().
+    m_grid_sizer = new wxBoxSizer(wxHORIZONTAL);
+    root->Add(m_grid_sizer, 0, wxEXPAND | wxLEFT | wxRIGHT, FromDIP(kElementSpacing));
+
+    auto* apply_btn = new Button(this, _L("Apply"));
+    apply_btn->Bind(wxEVT_BUTTON, [this](wxCommandEvent&) { on_apply_clicked(); });
+    root->Add(apply_btn, 0, wxALIGN_RIGHT | wxTOP | wxRIGHT, FromDIP(4));
+
+    SetSizer(root);
+}
+
+void NozzlePickerPanel::rebuild(const std::vector<double>& current, const std::vector<std::string>& allowed)
+{
+    // Destroy the previous columns/rows and recreate to the new N. Clearing the sizer with
+    // delete_windows=true destroys the child combos/labels, so stale pointers are not reused.
+    m_selectors.clear();
+    m_grid_sizer->Clear(true);
+
+    // Keep only single-diameter entries from the variant list (see is_single_diameter).
+    m_allowed.clear();
+    for (const std::string& d : allowed)
+        if (is_single_diameter(d))
+            m_allowed.push_back(d);
+
+    // NOZZLE_COLUMNS vertical column sizers side by side, each an equal share (proportion 1).
+    std::vector<wxBoxSizer*> columns;
+    for (int c = 0; c < NOZZLE_COLUMNS; ++c) {
+        auto* col = new wxBoxSizer(wxVERTICAL);
+        m_grid_sizer->Add(col, 1, wxEXPAND);
+        columns.push_back(col);
+    }
+
+    for (size_t i = 0; i < current.size(); ++i) {
+        // One compact inline row, same shape as a filament row (label where filament puts its colour
+        // badge, then a stretchy combo): "Nozzle N"  [ 0.4mm v ]. No stacking, no dividers -- that is
+        // what kept the panel as short as the Filament section below it.
+        auto* row = new wxBoxSizer(wxHORIZONTAL);
+
+        auto* label = new wxStaticText(this, wxID_ANY,
+            wxString::Format(_L("Nozzle %d"), static_cast<int>(i + 1)));
+        row->Add(label, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(kElementSpacing));
+
+        // Orca's read-only ComboBox hides its inner text control, so it needs a real size; the filament
+        // combo pins its height to 30 * em / 10 and lets the sizer stretch the width (proportion 1).
+        auto* combo = new ComboBox(this, wxID_ANY, wxEmptyString, wxDefaultPosition,
+                                   wxDefaultSize, 0, nullptr, wxCB_READONLY);
+        for (const std::string& d : m_allowed)
+            combo->Append(format_diameter(parse_diameter(wxString(d))));
+
+        // Initialise to the current per-nozzle diameter (independent; no sync-all).
+        combo->SetValue(format_diameter(current[i]));
+
+        m_selectors.push_back(combo);
+        row->Add(combo, 1, wxALIGN_CENTER_VERTICAL | wxALL, FromDIP(2))
+            ->SetMinSize(wxSize(-1, 30 * wxGetApp().em_unit() / 10));
+
+        // Add the row flush (no border), like the Filament section. The only inter-row gap is the
+        // combo's own FromDIP(2) top/bottom, so the rows pack as tightly as the filament list.
+        columns[i % NOZZLE_COLUMNS]->Add(row, 0, wxEXPAND);
+    }
+
+    // Report the new best height to the parent sizer. rebuild() can change the row count (e.g. a
+    // 4-nozzle U1 vs an 8-nozzle machine = 2 vs 4 rows), and Layout() alone only arranges children
+    // inside the existing panel rect -- it does not tell the parent sizer the panel now needs a
+    // different height, so without this the panel keeps its stale size and the extra rows are clipped.
+    GetSizer()->Fit(this);
+    SetMinSize(wxSize(-1, GetSizer()->GetMinSize().y));
+    Layout();
+}
+
+std::vector<double> NozzlePickerPanel::pending_diameters() const
+{
+    std::vector<double> out;
+    out.reserve(m_selectors.size());
+    for (const ComboBox* combo : m_selectors)
+        out.push_back(parse_diameter(combo->GetValue()));
+    return out;
+}
+
+void NozzlePickerPanel::on_apply_clicked()
+{
+    if (m_selectors.empty() || !m_on_apply)
+        return;
+    m_on_apply(pending_diameters());
+}
+
+}} // namespace Slic3r::GUI

--- a/src/slic3r/GUI/NozzlePickerPanel.hpp
+++ b/src/slic3r/GUI/NozzlePickerPanel.hpp
@@ -1,0 +1,57 @@
+#ifndef slic3r_NozzlePickerPanel_hpp_
+#define slic3r_NozzlePickerPanel_hpp_
+
+#include <functional>
+#include <string>
+#include <vector>
+
+#include <wx/panel.h>
+
+class wxBoxSizer;
+
+// ComboBox is declared at global scope (not in Slic3r::GUI), so forward-declare it here, before
+// the namespace -- as Plater.hpp / AMSSetting.hpp do. Declaring it inside the namespace would make
+// a distinct Slic3r::GUI::ComboBox that shadows the real one and never completes.
+class ComboBox;
+
+namespace Slic3r { namespace GUI {
+
+// Sidebar panel that shows one nozzle-diameter dropdown per nozzle (dynamic N, e.g. the
+// Snapmaker U1 toolchanger's 4 toolheads) plus an Apply button. Mirrors the Filament section's
+// layout: a gradient title bar (nozzle icon + "Nozzles" label, bracketed by StaticLine separators)
+// above a two-column grid of flush, compact inline rows -- each row is "Nozzle N" followed by its
+// diameter dropdown, filled row-major (1 2 / 3 4 ...).
+// Selections are independent and silent: changing a dropdown only updates pending state. Clicking Apply
+// invokes the on_apply callback with the per-nozzle diameters; the owner (Sidebar) performs the actual
+// config write, extruder reconcile, and the mixed-nozzle line-width conversion offer. This widget owns
+// no print config and no conversion logic.
+class NozzlePickerPanel : public wxPanel
+{
+public:
+    NozzlePickerPanel(wxWindow* parent);
+
+    // Rebuild the dropdown grid to N = current.size(). Each combo offers `allowed` diameter strings
+    // (e.g. "0.4") and is initialised from `current`. Safe to call repeatedly (printer switch /
+    // nozzle-count change); existing combos are destroyed and recreated.
+    void rebuild(const std::vector<double>& current, const std::vector<std::string>& allowed);
+
+    // The per-nozzle diameters currently shown in the dropdowns (size == nozzle count).
+    std::vector<double> pending_diameters() const;
+
+    // Called when Apply is clicked, with pending_diameters(). The owner applies the change.
+    void set_on_apply(std::function<void(const std::vector<double>&)> cb) { m_on_apply = std::move(cb); }
+
+    size_t extruder_count() const { return m_selectors.size(); }
+
+private:
+    void on_apply_clicked();
+
+    wxBoxSizer*              m_grid_sizer{nullptr}; // flush (no frame); holds NOZZLE_COLUMNS column sizers of compact "Nozzle N + combo" rows
+    std::vector<ComboBox*>   m_selectors;           // one dropdown per nozzle (independent)
+    std::vector<std::string> m_allowed;             // diameter strings offered in every combo
+    std::function<void(const std::vector<double>&)> m_on_apply;
+};
+
+}} // namespace Slic3r::GUI
+
+#endif // slic3r_NozzlePickerPanel_hpp_

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -95,6 +95,8 @@
 #include "Camera.hpp"
 #include "Mouse3DController.hpp"
 #include "Tab.hpp"
+#include "NozzlePickerPanel.hpp"
+#include "libslic3r/NozzleAgnostic.hpp"
 #include "Jobs/OrientJob.hpp"
 #include "Jobs/ArrangeJob.hpp"
 #include "Jobs/FillBedJob.hpp"
@@ -122,6 +124,7 @@
 #include "NotificationManager.hpp"
 #include "PresetComboBoxes.hpp"
 #include "MsgDialog.hpp"
+#include "ParamsPanel.hpp" // TipsDialog (note popup for uniform-Apply profile switch)
 #include "ProjectDirtyStateManager.hpp"
 #include "Gizmos/GLGizmoSimplify.hpp" // create suggestion notification
 #include "Gizmos/GLGizmoSVG.hpp" // Drop SVG file
@@ -237,6 +240,60 @@ static string get_diameter_string(float diameter)
         if (s.back() == '.') s += '0';        // Ensure "1." → "1.0"
     }
     return s;
+}
+
+// Make each toolhead's nozzle-specific machine settings consistent with the diameter the user chose
+// for it, by copying them from the official single-nozzle profile for that diameter. This is what turns
+// a mixed-nozzle Apply into a *physically consistent* config -- e.g. a 0.6 toolhead picks up the 0.6
+// profile's max/min layer height instead of being left with the previous nozzle's values. NOTHING is
+// hardcoded: the values come from the looked-up profile, and the keys are the slicer's own per-extruder
+// key set (Preset::nozzle_options). "Nozzle-specific" is decided per key by COMPARING the looked-up
+// profile's value against what is currently in cfg for this slot: if they differ, that key depends on
+// the nozzle and is copied; if they are equal it is shared (e.g. retraction inherited from fdm_U1) and is
+// left untouched, so we never stomp a user value that the nozzle does not actually change. We deliberately
+// do NOT resolve the profile's parent (fdm_U1 ships with instantiation:false and is never loaded into the
+// printers collection, so get_preset_parent would return null). `cfg`'s per-extruder vectors MUST already
+// be sized to N (call after set_num_extruders). Diameters with no shipped single-nozzle profile are
+// left untouched.
+static void copy_per_nozzle_machine_settings(DynamicPrintConfig& cfg, const std::vector<double>& diameters)
+{
+    auto* bundle = wxGetApp().preset_bundle;
+    if (bundle == nullptr)
+        return;
+    const std::string model = bundle->printers.get_selected_preset().config.opt_string("printer_model");
+
+    // Only the layer-height limits legitimately vary by nozzle diameter. Verified against the shipped
+    // Snapmaker U1 single-nozzle profiles (0.4 -> max/min 0.32/0.08, 0.6 -> 0.48/0.12); every other
+    // per-extruder key is inherited unchanged from the fdm_U1 parent. We copy ONLY these keys rather
+    // than scanning all of Preset::nozzle_options() and guessing per-key by value equality -- that
+    // guess clobbered user-tuned shared settings (e.g. retraction_length / extruder_colour, which the
+    // shipped 0.4 profile also overrides) whenever they differed from the profile. A future
+    // nozzle-dependent key must be added here deliberately.
+    static const std::vector<std::string> nozzle_dependent_keys = { "min_layer_height", "max_layer_height" };
+
+    for (size_t i = 0; i < diameters.size(); ++i) {
+        const std::string variant = get_diameter_string(diameters[i]);
+        Preset* src = bundle->get_similar_printer_preset(model, variant);
+        // Same guard as the uniform path: get_similar_printer_preset() falls back to an arbitrary
+        // same-model preset, so require an exact variant match -- otherwise this diameter has no shipped
+        // single-nozzle profile (e.g. 0.2 / 0.8 may be absent) and we leave its slot as-is.
+        if (src == nullptr || src->config.opt_string("printer_variant") != variant)
+            continue;
+        for (const std::string& key : nozzle_dependent_keys) {
+            const ConfigOption* src_opt = src->config.option(key);
+            ConfigOption*       dst_opt = cfg.option(key, false);
+            if (src_opt == nullptr || dst_opt == nullptr || !src_opt->is_vector() || !dst_opt->is_vector())
+                continue;
+            const auto* src_vec = static_cast<const ConfigOptionVectorBase*>(src_opt);
+            auto*       dst_vec = static_cast<ConfigOptionVectorBase*>(dst_opt);
+            const std::vector<std::string> src_vals = src_vec->vserialize();
+            const std::vector<std::string> dst_vals = dst_vec->vserialize();
+            if (src_vals.empty() || i >= dst_vals.size())
+                continue;
+            // Single-nozzle profiles carry uniform vectors -> copy this nozzle's value from source idx 0.
+            dst_vec->set_at(src_opt, i, 0);
+        }
+    }
 }
 
 bool Plater::has_illegal_filename_characters(const wxString& wxs_name)
@@ -488,6 +545,12 @@ struct Sidebar::priv
     Label *         label_nozzle_title= nullptr;
     ComboBox *      combo_nozzle_dia  = nullptr;
     Label *         label_nozzle_type = nullptr;
+
+    // Per-extruder nozzle picker for mixed-nozzle (multi-toolhead) printers, e.g. the Snapmaker U1
+    // toolchanger. Shown only when the printer declares > 2 nozzles (mainline's single/dual nozzle
+    // UI cannot represent that case). Lets each toolhead take an independent diameter and offers the
+    // line-width-to-percentage conversion on Apply.
+    NozzlePickerPanel * panel_nozzle_picker = nullptr;
 
     // Printer - bed
     StaticBox *     panel_printer_bed = nullptr;
@@ -1294,6 +1357,101 @@ bool Sidebar::priv::switch_diameter(bool single)
     return wxGetApp().get_tab(Preset::TYPE_PRINTER)->select_preset(preset->name);
 }
 
+void Sidebar::apply_per_extruder_nozzles(const std::vector<double>& diameters)
+{
+    if (diameters.empty())
+        return;
+
+    const bool is_mixed = Slic3r::nozzle_agnostic::is_mixed_nozzle(diameters);
+
+    // A UNIFORM selection (every nozzle the same diameter) is really a request to run the machine as a
+    // single-nozzle setup of that size, so switch the whole printer PROFILE to the official
+    // single-nozzle Snapmaker U1 preset for that diameter (e.g. "Snapmaker U1 (0.6 nozzle)"). That
+    // updates *every* nozzle-tied machine setting (the whole preset), not just the diameter number --
+    // which is all that writing the raw vector would change. Only when no matching single-nozzle
+    // profile exists do we fall through to the raw-vector write below.
+    if (!is_mixed) {
+        const std::string variant = get_diameter_string(diameters.front());
+        Preset* preset = wxGetApp().preset_bundle->get_similar_printer_preset({}, variant);
+        // get_similar_printer_preset() falls back to an ARBITRARY same-model preset when no variant
+        // matches (for a known model it never returns null), so confirm the resolved preset really is
+        // the requested diameter before switching. Without this guard, a diameter with no local
+        // profile (e.g. 0.2 / 0.8 single-nozzle presets may be absent from a given checkout) would
+        // silently switch to the wrong profile.
+        if (preset != nullptr && preset->config.opt_string("printer_variant") == variant) {
+            // No-op guard: if the printer is ALREADY on this profile, Apply changed nothing -- don't
+            // re-select and don't pop the "Printer profile updated" dialog. (Previously the dialog fired
+            // on every Apply press, even with no change.)
+            if (wxGetApp().preset_bundle->printers.get_selected_preset_name() == preset->name)
+                return;
+
+            preset->is_visible = true; // force visible so it can be selected
+            wxGetApp().get_tab(Preset::TYPE_PRINTER)->select_preset(preset->name);
+
+            // Tell the user which official profile was selected. TipsDialog is the repo's standard note
+            // dialog (info text + a "Don't show again" checkbox gated on an app_config key, single OK),
+            // matching the fork's "Set Nozzle Diameter" note. Shown until the user opts out.
+            if (wxGetApp().app_config->get("do_not_show_nozzle_profile_switch").empty()) {
+                // Parent to the main frame (not `this`/the Sidebar): TipsDialog calls CenterOnParent(),
+                // and centering on the narrow sidebar pushed the dialog to the far left. The main frame
+                // centers it on the whole window, like Orca's other note dialogs.
+                TipsDialog dlg(static_cast<wxWindow*>(wxGetApp().mainframe), _L("Printer profile updated"),
+                    wxString::Format(_L("Switched to profile: %s"), from_u8(preset->name)),
+                    "do_not_show_nozzle_profile_switch");
+                dlg.ShowModal();
+            }
+            // Selecting the preset loads its full config (diameters + extruder count + everything tied
+            // to that nozzle), so the manual vector write / count reconcile below are unnecessary and
+            // the conversion offer (a mixed-only step) does not apply.
+            return;
+        }
+        // No matching single-nozzle profile: fall through and at least write the diameters (graceful,
+        // non-destructive -- updates the numbers without switching to an unrelated profile).
+    }
+
+    // 1) Resolve the conversion base nozzle BEFORE touching the printer config -- via the selected
+    //    PROCESS profile's compatible_printers link (libslic3r owns the logic). This MUST run before the
+    //    write below: step 2 overwrites the selected printer's nozzle_diameter with the per-toolhead
+    //    mixed vector, and the process is bound to that same printer, so resolving afterwards would read
+    //    the mixed vector and refuse (no single base). Resolving here reads the still-clean diameter.
+    std::optional<double> base;
+    {
+        const Preset& process = wxGetApp().preset_bundle->prints.get_edited_preset();
+        base = Slic3r::nozzle_agnostic::resolve_base_nozzle(process, *wxGetApp().preset_bundle);
+    }
+
+    // Read the count BEFORE the write below, so step 3 can tell whether it actually changed (the
+    // picker edits diameters, not toolhead count, so it usually hasn't).
+    const int prev_extruder_count = wxGetApp().preset_bundle->get_printer_extruder_count();
+
+    // 2) Write the per-extruder nozzle diameters onto the EDITED printer config. We deliberately do
+    //    NOT route through switch_diameter()/preset-swap: that path forbids mixed nozzles (single-head
+    //    only). Writing the vector directly is what makes a genuinely mixed-nozzle setup possible.
+    auto* printer_tab = wxGetApp().get_tab(Preset::TYPE_PRINTER);
+    if (printer_tab && printer_tab->m_config) {
+        DynamicPrintConfig new_conf = *printer_tab->m_config;
+        new_conf.set_key_value("nozzle_diameter", new ConfigOptionFloats(diameters));
+        // Size every per-extruder vector to N so the per-slot writes below are in range, then make each
+        // toolhead's nozzle-specific machine settings (e.g. max/min layer height) consistent with its
+        // chosen diameter -- sourced by lookup from the official single-nozzle profile, never hardcoded.
+        // Without this, only the diameter NUMBER would change, leaving an inconsistent config.
+        new_conf.set_num_extruders((unsigned int) diameters.size());
+        copy_per_nozzle_machine_settings(new_conf, diameters);
+        printer_tab->load_config(new_conf);
+    }
+
+    // 3) Reconcile extruder-dependent config to the new count -- only on an actual count change,
+    //    mirroring TabPrinter::extruders_count_changed. (on_extruders_count_changed unconditionally
+    //    resets project nozzle_volume_type; calling it when only diameters changed would clobber it.)
+    if ((int) diameters.size() != prev_extruder_count)
+        wxGetApp().preset_bundle->on_extruders_count_changed((int) diameters.size());
+
+    // 4) Offer the mixed-nozzle line-width conversion on the edited PROCESS profile, using the base
+    //    resolved in step 1 (the print Tab applies it).
+    if (auto* print_tab = dynamic_cast<TabPrint*>(wxGetApp().get_tab(Preset::TYPE_PRINT)))
+        print_tab->offer_nozzle_agnostic_conversion(is_mixed, base);
+}
+
 bool Sidebar::priv::sync_extruder_list(bool &only_external_material)
 {
     MachineObject *obj = wxGetApp().getDeviceManager()->get_selected_machine();
@@ -2056,6 +2214,20 @@ Sidebar::Sidebar(Plater *parent)
 
         p->vsizer_printer = new wxBoxSizer(wxVERTICAL);
         p->layout_printer(true, true);
+
+        // Per-extruder nozzle picker for multi-toolhead (mixed-nozzle) printers. Hidden until a
+        // printer with > 2 extruders is selected (see the TYPE_PRINTER preset-change handler).
+        p->panel_nozzle_picker = new NozzlePickerPanel(p->m_panel_printer_content);
+        // Run the dark-mode theming pass (as the sibling sidebar panels get) so the panel's white
+        // background flips to the dark sidebar shade and matches the Filament/Printer sections.
+        wxGetApp().UpdateDarkUI(p->panel_nozzle_picker);
+        p->panel_nozzle_picker->set_on_apply([this](const std::vector<double>& diameters) {
+            this->apply_per_extruder_nozzles(diameters);
+        });
+        p->panel_nozzle_picker->Hide();
+        p->vsizer_printer->Add(p->panel_nozzle_picker, 0, wxEXPAND | wxLEFT | wxRIGHT,
+                               FromDIP(SidebarProps::ContentMargin()));
+
         p->m_panel_printer_content->SetSizer(p->vsizer_printer);
         p->m_panel_printer_content->Layout();
         scrolled_sizer->Add(p->m_panel_printer_content, 0, wxEXPAND, 0);
@@ -2712,6 +2884,31 @@ void Sidebar::update_presets(Preset::Type preset_type)
             p->label_nozzle_type->SetToolTip(nozzle_type == "-" ? "" : nozzle_type);
 
             p->image_printer_bed->SetBitmap(create_scaled_bitmap(image_path, this, PRINTER_THUMBNAIL_SIZE.GetHeight()));
+        }
+
+        // Multi-toolhead printers (> 1 nozzle, i.e. 2+, e.g. the Snapmaker U1) cannot be represented by
+        // single/dual nozzle UI above. Populate and show the per-nozzle picker for them; hide it
+        // otherwise. This also rebuilds the dropdowns whenever the nozzle count changes.
+        //
+        // Gate = "> 1 nozzle AND a genuine multi-extruder machine". The single_extruder_multi_material
+        // guard excludes single-nozzle multi-material (MMU/AMS) printers: those report many filaments but
+        // have ONE physical nozzle, so per-nozzle diameter selection is meaningless there. Read from the
+        // same edited printer_preset.config that nozzle_diameter came from. Not model-gated (no "U1"
+        // hard-code) so future toolchangers (e.g. an 8-nozzle machine) qualify automatically.
+        if (p->panel_nozzle_picker) {
+            const bool is_semm = printer_preset.config.opt_bool("single_extruder_multi_material");
+            const bool multi_toolhead = nozzle_diameter && nozzle_diameter->size() > 1 && !is_semm;
+            if (multi_toolhead) {
+                p->panel_nozzle_picker->rebuild(nozzle_diameter->values, diameters);
+                p->panel_nozzle_picker->Show();
+            } else {
+                p->panel_nozzle_picker->Hide();
+            }
+            // Re-flow the scrolled content: showing/hiding the picker or rebuilding it to a different
+            // nozzle count changes the height of the scrolled region, and the plain Layout() below only
+            // lays out Sidebar's direct children -- not m_scrolled_sizer. Without this the picker can
+            // render clipped or not appear until another event forces a relayout.
+            m_scrolled_sizer->Layout();
         }
 
         if (GUI::wxGetApp().plater())

--- a/src/slic3r/GUI/Plater.hpp
+++ b/src/slic3r/GUI/Plater.hpp
@@ -164,6 +164,9 @@ public:
     void update_all_preset_comboboxes();
     //void update_partplate(PartPlateList& list);
     void update_presets(Slic3r::Preset::Type preset_type);
+    // Apply per-extruder nozzle diameters from the multi-toolhead picker to the edited printer
+    // config, then offer the mixed-nozzle line-width conversion on the edited process profile.
+    void apply_per_extruder_nozzles(const std::vector<double>& diameters);
     //BBS
     const std::vector<BedType>& get_cur_combox_bed_types() { return m_cur_combox_bed_types; }
     void update_presets_from_to(Slic3r::Preset::Type preset_type, std::string from, std::string to);

--- a/src/slic3r/GUI/Tab.hpp
+++ b/src/slic3r/GUI/Tab.hpp
@@ -472,6 +472,12 @@ public:
 	void		clear_pages() override;
 	bool 		supports_printer_technology(const PrinterTechnology tech) const override { return tech == ptFFF; }
 
+	// Offer (Yes/No) to convert this process profile's absolute nozzle-scaled line widths to
+	// percentages for a mixed-nozzle printer. is_mixed/base are resolved by
+	// the caller via libslic3r; the conversion is applied in place to the edited process config.
+	void offer_nozzle_agnostic_conversion(bool is_mixed, std::optional<double> base)
+		{ m_config_manipulation.check_nozzle_agnostic(m_config, is_mixed, base); }
+
 private:
 	ogStaticText*	m_recommended_thin_wall_thickness_description_line = nullptr;
 	ogStaticText*	m_top_bottom_shell_thickness_explanation = nullptr;

--- a/tests/libslic3r/CMakeLists.txt
+++ b/tests/libslic3r/CMakeLists.txt
@@ -12,6 +12,7 @@ add_executable(${_TEST_NAME}_tests
     test_clipper_utils.cpp
     test_config.cpp
     test_preset_bundle_loading.cpp
+    test_nozzle_agnostic.cpp
     test_elephant_foot_compensation.cpp
     test_geometry.cpp
     test_placeholder_parser.cpp

--- a/tests/libslic3r/test_nozzle_agnostic.cpp
+++ b/tests/libslic3r/test_nozzle_agnostic.cpp
@@ -1,0 +1,173 @@
+#include <catch2/catch_all.hpp>
+
+#include <algorithm>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "libslic3r/NozzleAgnostic.hpp"
+#include "libslic3r/PrintConfig.hpp"
+#include "libslic3r/Preset.hpp"
+#include "libslic3r/PresetBundle.hpp"
+
+// Unit tests for the nozzle-agnostic conversion helpers in NozzleAgnostic.{hpp,cpp}:
+// conversion math, the in-scope tag rule, idempotency, the abs->percent->abs round-trip
+// against get_abs_value, mixed-nozzle detection, and base-nozzle resolution.
+
+using namespace Slic3r;
+
+TEST_CASE("nozzle_agnostic to_percent", "[nozzle_agnostic]")
+{
+    SECTION("to_percent divides the absolute width by the base nozzle") {
+        CHECK(nozzle_agnostic::to_percent(0.42, 0.4) == Catch::Approx(105.0));
+        CHECK(nozzle_agnostic::to_percent(0.20, 0.4) == Catch::Approx(50.0));
+        CHECK(nozzle_agnostic::to_percent(0.60, 0.4) == Catch::Approx(150.0));
+    }
+}
+
+TEST_CASE("nozzle_agnostic convert_field turns an absolute width into a percent", "[nozzle_agnostic]")
+{
+    const ConfigOptionFloatOrPercent abs(0.42, /*percent=*/false);
+    const ConfigOptionFloatOrPercent out = nozzle_agnostic::convert_field(abs, 0.4);
+    CHECK(out.percent == true);
+    CHECK(out.value == Catch::Approx(105.0));
+}
+
+TEST_CASE("nozzle_agnostic convert_field rounds the percent to 0.1", "[nozzle_agnostic]")
+{
+    // 0.45 / 0.4 = 112.5% (exact, one decimal -> unchanged).
+    CHECK(nozzle_agnostic::convert_field(ConfigOptionFloatOrPercent(0.45, false), 0.4).value
+          == Catch::Approx(112.5));
+    // 0.42 / 0.32 = 131.25% -> rounds to 131.3%.
+    CHECK(nozzle_agnostic::convert_field(ConfigOptionFloatOrPercent(0.42, false), 0.32).value
+          == Catch::Approx(131.3));
+    // 0.5 / 0.6 = 83.333...% -> rounds to 83.3%.
+    CHECK(nozzle_agnostic::convert_field(ConfigOptionFloatOrPercent(0.50, false), 0.6).value
+          == Catch::Approx(83.3));
+}
+
+TEST_CASE("nozzle_agnostic one percent value auto-scales across nozzles", "[nozzle_agnostic]")
+{
+    // A percent of nozzle_diameter resolves to the correct absolute width on every nozzle.
+    const ConfigOptionFloatOrPercent pct(105.0, /*percent=*/true);
+    CHECK(pct.get_abs_value(0.4) == Catch::Approx(0.42));
+    CHECK(pct.get_abs_value(0.2) == Catch::Approx(0.21));
+    CHECK(pct.get_abs_value(0.6) == Catch::Approx(0.63));
+    CHECK(pct.get_abs_value(0.8) == Catch::Approx(0.84));
+}
+
+TEST_CASE("nozzle_agnostic convert_field is idempotent", "[nozzle_agnostic]")
+{
+    SECTION("an already-percent field is returned unchanged") {
+        const ConfigOptionFloatOrPercent pct(105.0, /*percent=*/true);
+        const ConfigOptionFloatOrPercent once = nozzle_agnostic::convert_field(pct, 0.4);
+        CHECK(once.percent == true);
+        CHECK(once.value == Catch::Approx(105.0));
+    }
+    SECTION("converting twice does not drift") {
+        const ConfigOptionFloatOrPercent abs(0.42, /*percent=*/false);
+        const ConfigOptionFloatOrPercent once  = nozzle_agnostic::convert_field(abs, 0.4);
+        const ConfigOptionFloatOrPercent twice = nozzle_agnostic::convert_field(once, 0.4);
+        CHECK(twice.percent == once.percent);
+        CHECK(twice.value == Catch::Approx(once.value));
+    }
+    SECTION("a non-positive base nozzle leaves the value untouched") {
+        const ConfigOptionFloatOrPercent abs(0.42, /*percent=*/false);
+        const ConfigOptionFloatOrPercent out = nozzle_agnostic::convert_field(abs, 0.0);
+        CHECK(out.percent == false);
+        CHECK(out.value == Catch::Approx(0.42));
+    }
+}
+
+TEST_CASE("nozzle_agnostic abs -> percent -> abs round-trips", "[nozzle_agnostic]")
+{
+    const ConfigOptionFloatOrPercent abs(0.42, /*percent=*/false);
+    const ConfigOptionFloatOrPercent pct = nozzle_agnostic::convert_field(abs, 0.4);
+    CHECK(pct.get_abs_value(0.4) == Catch::Approx(0.42));
+}
+
+TEST_CASE("nozzle_agnostic is_mixed_nozzle detects distinct diameters", "[nozzle_agnostic]")
+{
+    CHECK_FALSE(nozzle_agnostic::is_mixed_nozzle({}));
+    CHECK_FALSE(nozzle_agnostic::is_mixed_nozzle({0.4}));
+    CHECK_FALSE(nozzle_agnostic::is_mixed_nozzle({0.4, 0.4}));
+    CHECK(nozzle_agnostic::is_mixed_nozzle({0.4, 0.2, 0.6, 0.8}));
+}
+
+TEST_CASE("nozzle_agnostic resolve_base_nozzle resolves or refuses", "[nozzle_agnostic]")
+{
+    PresetBundle bundle;
+
+    auto load_printer = [&bundle](const std::string &name, std::vector<double> nozzles) {
+        DynamicPrintConfig cfg;
+        cfg.set_key_value("nozzle_diameter", new ConfigOptionFloats(std::move(nozzles)));
+        bundle.printers.load_preset(name + ".json", name, cfg, /*select=*/false);
+    };
+    load_printer("SingleNozzle", {0.4});
+    load_printer("OtherNozzle",  {0.6});
+
+    auto make_process = [](std::vector<std::string> printers) {
+        Preset p(Preset::TYPE_PRINT, "Process");
+        p.config.set_key_value("compatible_printers", new ConfigOptionStrings(std::move(printers)));
+        return p;
+    };
+
+    SECTION("exactly one base nozzle resolves to that diameter") {
+        const Preset process = make_process({"SingleNozzle"});
+        const std::optional<double> base = nozzle_agnostic::resolve_base_nozzle(process, bundle);
+        REQUIRE(base.has_value());
+        CHECK(*base == Catch::Approx(0.4));
+    }
+    SECTION("two different bases refuse rather than guess") {
+        const Preset process = make_process({"SingleNozzle", "OtherNozzle"});
+        CHECK_FALSE(nozzle_agnostic::resolve_base_nozzle(process, bundle).has_value());
+    }
+    SECTION("no compatible printers refuses") {
+        const Preset process = make_process({});
+        CHECK_FALSE(nozzle_agnostic::resolve_base_nozzle(process, bundle).has_value());
+    }
+}
+
+TEST_CASE("nozzle_agnostic has_absolute_scoped_fields gates on absolute widths", "[nozzle_agnostic]")
+{
+    DynamicPrintConfig cfg = DynamicPrintConfig::full_print_config();
+    for (const std::string &key : nozzle_agnostic::scoped_keys(print_config_def))
+        cfg.set_deserialize_strict(key, "100%");
+    CHECK_FALSE(nozzle_agnostic::has_absolute_scoped_fields(cfg));
+
+    cfg.set_deserialize_strict("outer_wall_line_width", "0.42");
+    CHECK(nozzle_agnostic::has_absolute_scoped_fields(cfg));
+}
+
+TEST_CASE("nozzle_agnostic scoped_keys follows the ratio_over tag rule", "[nozzle_agnostic]")
+{
+    const std::vector<std::string> keys = nozzle_agnostic::scoped_keys(print_config_def);
+    auto has = [&keys](const char *k) {
+        return std::find(keys.begin(), keys.end(), std::string(k)) != keys.end();
+    };
+
+    // Known nozzle-diameter-scaled line-width fields are in scope.
+    CHECK(has("line_width"));
+    CHECK(has("outer_wall_line_width"));
+    CHECK(has("inner_wall_line_width"));
+    CHECK(has("initial_layer_line_width"));
+    CHECK(has("sparse_infill_line_width"));
+    CHECK(has("internal_solid_infill_line_width"));
+    CHECK(has("top_surface_line_width"));
+    CHECK(has("support_line_width"));
+    CHECK(has("bridge_line_width"));
+
+    // A field that is not coFloatOrPercent-over-nozzle_diameter is excluded.
+    CHECK_FALSE(has("wall_loops")); // coInt
+
+    // The rule, not a hardcoded list: every scoped key satisfies the tag predicate.
+    for (const std::string &key : keys) {
+        const ConfigOptionDef &def = print_config_def.options.at(key);
+        CHECK(def.type == coFloatOrPercent);
+        CHECK(def.ratio_over == "nozzle_diameter");
+        CHECK(nozzle_agnostic::is_in_scope(def));
+    }
+
+    // is_in_scope rejects an out-of-scope def directly.
+    CHECK_FALSE(nozzle_agnostic::is_in_scope(print_config_def.options.at("wall_loops")));
+}


### PR DESCRIPTION
## Summary

Adds a per-toolhead nozzle-size picker (one dropdown per toolhead plus an **Apply** button) under the Printer section of the sidebar, for multi-toolhead machines like the Snapmaker U1. Selecting sizes and clicking Apply either switches to the matching single-nozzle profile (uniform) or sets up a mixed-nozzle configuration (mixed).

The picker is built on OrcaSlicer's existing multi-toolhead plumbing rather than bolted on for one model:

- Each dropdown is populated from the printer's own variant diameter list (`diameters_of_selected_printer()`), the same source the existing single/dual nozzle combo uses. No new per-model data.
- It renders one dropdown per toolhead from the printer's `nozzle_diameter` vector, laid out two per row (matching the Filament section), and rebuilds itself when the extruder count changes in printer profile, so it scales to any toolhead count.
- It shows for any printer reporting more than one independent nozzle (`single_extruder_multi_material` AMS/MMU printers excluded). It is **not** gated on the model name, so existing and future toolchangers pick it up automatically with no code change.

## Motivation

Two gaps on the U1 in mainline OrcaSlicer:

- **No easy nozzle switch.** The Snapmaker fork of OrcaSlicer lets you switch the U1's nozzle profile from the UI; mainline doesn't.
- **Mixed nozzles are manual.** Mixed nozzle support has existed since v2.2.0-beta (see the [Mixed Nozzle Sizes](https://www.orcaslicer.com/wiki/guides/mixed_nozzle_sizes) guide), but the setup is manual: you set each diameter by hand and then rewrite every line-width field in the process profile as a percentage of nozzle diameter (the guide's example: a 0.48 mm line on a 0.4 nozzle becomes 120%). It works, but it's tedious and easy to get wrong.

This PR does that conversion for you and makes the workflow accessible in-app.

## What it does

Selecting sizes does nothing until **Apply** is clicked, which branches on the chosen sizes:

### Uniform (all toolheads the same size)

- Loads the matching `Snapmaker U1 (x nozzle)` profile. This is the easy nozzle-size switch the Snapmaker fork has and mainline lacks. A small note pops up confirming which profile was loaded (dismissible with "don't show again").

### Mixed Nozzle

1. Sets each toolhead to its chosen diameter.
2. Adjusts each toolhead's min/max layer height to match its nozzle.
3. Pops a **"Mixed Nozzle Sizes"** Yes/No dialog to convert the active process profile's line widths to percentages of nozzle diameter, the wiki's manual step, done for you. At most one dialog appears, no matter how many sizes differ.

The conversion covers every line-width field automatically, runs safely if applied twice, and only offers itself when there's a single nozzle size to convert from.

Pressure advance changes with different nozzle sizes, so you may need to calibrate it for each extruder and create a Filament profile for each material and nozzle-size combination. Most other settings can be shared between the different nozzle sizes.

To assign specific nozzle sizes to different features:  [Wiki](https://www.orcaslicer.com/wiki/guides/mixed_nozzle_sizes#selecting-nozzle-sizes)

A note on the **Apply** button: I'm not happy with it, it's a bit ugly and eats sidebar space. It exists because Apply needs the whole set of selections at once (it can only tell uniform from mixed once every dropdown is set) and each branch shows a dialog. Triggering per dropdown change would pop those dialogs repeatedly while you're still choosing. Open to better ideas here.

## Files changed (13 files, +820)

| File | Change |
|---|---|
| `libslic3r/NozzleAgnostic.{hpp,cpp}` | New GUI-free core: conversion math + `ratio_over` scope rule + mixed/base-nozzle helpers |
| `libslic3r/CMakeLists.txt` | Register the new source |
| `GUI/NozzlePickerPanel.{hpp,cpp}` | Per-toolhead nozzle picker + Apply |
| `GUI/ConfigManipulation.{cpp,hpp}` | `check_nozzle_agnostic` confirm-and-apply hook |
| `GUI/Plater.{cpp,hpp}` | Picker wiring, uniform/mixed Apply, visibility gate |
| `GUI/Tab.hpp` | Offer the conversion from the Print tab |
| `GUI/CMakeLists.txt` | Register the panel |
| `tests/libslic3r/test_nozzle_agnostic.cpp` (+ CMake) | Catch2 unit tests (10 cases) |

## Test plan

- [x] **Unit tests**: `tests/libslic3r/test_nozzle_agnostic.cpp` (10 Catch2 cases): conversion math, 0.1% rounding, idempotency, abs→%→abs round-trip, mixed detection, base-nozzle resolve/refuse, and the `ratio_over` scope rule. Full suite green (ctest 205/205).
- [x] **Manual GUI (Snapmaker U1)**: picker shows the right size options; uniform Apply loads the matching profile; mixed Apply fires the "Mixed Nozzle Sizes" dialog, Yes rewrites line widths to %; each toolhead's min/max layer height matches its nozzle (0.4 → 0.32/0.08, 0.6 → 0.48/0.12); user-tuned shared settings are not clobbered.
- [x] **Backward compatibility**: the slice engine is untouched and all behavior runs only on user-clicked Apply; existing presets and `.3mf` projects slice identically when no conversion is applied.

## Screenshots
### Dynamic Nozzle Dropdown
<img width="400" height="274" alt="DynamicNozzle" src="https://github.com/user-attachments/assets/d586a5e6-cf31-4ed0-9307-67751d726a0f" />

### Uniform Nozzle Profile Switch
<img width="400" height="274" alt="uniformNozzle" src="https://github.com/user-attachments/assets/374559be-329e-4717-a72b-283fb3907e9a" />

### Mix Nozzle/ Nozzle Agnostic Profile 
<img width="400" height="287" alt="MixNozzle" src="https://github.com/user-attachments/assets/73202fa8-107d-4b01-94ce-9e7eb296ff75" />

----

[How to Download](https://www.orcaslicer.com/wiki/developer_reference/how_to_download_pr_artifacts)

