### PR TITLE
Fix AMS overwrite sync showing filaments in wrong order (#14335)

### DIFF
--- a/src/slic3r/GUI/SelectMachine.hpp
+++ b/src/slic3r/GUI/SelectMachine.hpp
@@ -100,7 +100,11 @@ enum class ConfigNozzleIdx : int
 };
 
 
-WX_DECLARE_HASH_MAP(int, Material *, wxIntegerHash, wxIntegerEqual, MaterialHash);
+// Orca: MaterialHash is keyed by material/extruder index and is iterated in key order in
+// several places (e.g. the AMS override preview), so it must be an ordered container.
+// std::unordered_map (what WX_DECLARE_HASH_MAP expands to under wxUSE_STD_CONTAINERS=1)
+// iterates in an unspecified, implementation-dependent order, which scrambled that preview.
+using MaterialHash = std::map<int, Material *>;
 
 #define SELECT_MACHINE_DIALOG_BUTTON_SIZE wxSize(FromDIP(57), FromDIP(32))
 #define SELECT_MACHINE_DIALOG_BUTTON_SIZE2 wxSize(FromDIP(80), FromDIP(32))


### PR DESCRIPTION
# Description

Syncing the filament list from AMS with the "Overwriting" option displayed the AMS filaments in the wrong (reversed) order in the preview, even though the filament mapping that was actually applied was correct. 
The preview depends on MaterialHash being iterated in material-indexorder. MaterialHash is a WX_DECLARE_HASH_MAP, which under OrcaSlicer'scurrent wxWidgets 3.3 build (wxUSE_STD_CONTAINERS=1) resolves tostd::unordered_map; its iteration order is unspecified and on macOS(libc++) comes out reversed, which scrambled the preview. 
The original implementation is ported from BambuStudio and works only by luck — bucket collisions don't occur because the numbers are small and continuous. However, the order is not guaranteed.
Fixes #14335

# Screenshots/Recordings/Graphs

<!--
> Please attach relevant screenshots to showcase the UI changes.
> Please attach images that can help explain the changes.
-->

## Tests

<!--
> Please describe the tests that you have conducted to verify the changes made in this PR.
-->
