### PR TITLE
calib: default-init Calib_Params scalar fields

### DIFF
--- a/src/libslic3r/calib.hpp
+++ b/src/libslic3r/calib.hpp
@@ -35,10 +35,10 @@ struct Calib_Params
 {
     Calib_Params() : mode(CalibMode::Calib_None){};
     int extruder_id = 0;
-    double    start, end, step;
-    bool      print_numbers;
-    double freqStartX, freqEndX, freqStartY, freqEndY;
-    int test_model;
+    double    start = 0.0, end = 1.0, step = 0.1;
+    bool      print_numbers = false;
+    double freqStartX = 0.0, freqEndX = 1.0, freqStartY = 0.0, freqEndY = 1.0;
+    int test_model = 0;
     std::string shaper_type;
     std::vector<double> accelerations;
     std::vector<double> speeds;


### PR DESCRIPTION
# Description

`Calib_Params`'s user-provided default constructor only initializes `mode`. The
other scalar fields — `start`, `end`, `step`, `print_numbers`, `freqStartX/Y`,
`freqEndX/Y`, `test_model` — are left with indeterminate values.

This is fine when a caller fully populates the struct before reading from it
(today's GUI calibration paths do), but the moment any caller relies on
value-initialization semantics (`Calib_Params{}`) the indeterminate fields
become an actual read of uninitialized memory.

Reading an uninitialized scalar is UB and GCC's `-Wuninitialized` correctly
flags it. The warning had been latent; it became loud once code started using
`out = Calib_Params{};` to reset the struct between calls.

# Fix

Add neutral default-initializers to every scalar field (`0.0` / `false` /
`0`). The user-provided default constructor still sets `mode` explicitly, so
its behavior is unchanged. Real callers (PA tower, input shaping, etc.) keep
overriding these fields explicitly, so the defaults are never observed in
practice — but the warning is silenced and the UB is gone.

# Verification

- GCC `-Wuninitialized` no longer flags `Calib_Params` from the
  value-init usage site.
- PA tower / input-shaping / VFA flow regression-tested with the GUI
  wizard — no behavior change.

# Scope

Single file, +9/-4 lines. No behavior change, no API change.