### PR TITLE
calib: defensive guards in find_optimal_PA_speed (fix CLI pa-tower SIGSEGV)

### DIFF
--- a/src/libslic3r/Config.cpp
+++ b/src/libslic3r/Config.cpp
@@ -772,7 +772,9 @@ double ConfigBase::get_abs_value(const t_config_option_key &opt_key, double rati
 {
     // Get stored option value.
     const ConfigOption *raw_opt = this->option(opt_key);
-    assert(raw_opt != nullptr);
+    // Mirror the single-arg overload — assert() is a no-op under NDEBUG.
+    if (raw_opt == nullptr)
+        throw ConfigurationError("ConfigBase::get_abs_value(): \"" + opt_key + "\" is not defined");
     if (raw_opt->type() != coFloatOrPercent)
         throw ConfigurationError("ConfigBase::get_abs_value(): opt_key is not of coFloatOrPercent");
     // Compute absolute value.

--- a/src/libslic3r/calib.cpp
+++ b/src/libslic3r/calib.cpp
@@ -11,12 +11,23 @@ namespace Slic3r {
 float CalibPressureAdvance::find_optimal_PA_speed(const DynamicPrintConfig &config, double line_width, double layer_height, int extruder_id, int filament_idx)
 {
     const double general_suggested_min_speed   = 100.0;
-    double       filament_max_volumetric_speed = config.option<ConfigOptionFloats>("filament_max_volumetric_speed")->get_at(filament_idx);
+    // Read defensively — CLI callers may hand us a config missing optional keys.
+    auto vector_at = [&config](const char *key, int idx) -> double {
+        if (const auto *o = config.option<ConfigOptionFloats>(key)) return o->get_at(idx);
+        const ConfigOptionDef *d = config.def() ? config.def()->get(key) : nullptr;
+        return (d && d->default_value) ? d->get_default_value<ConfigOptionFloats>()->get_at(idx) : 0.0;
+    };
+    auto nullable_at = [&config](const char *key, int idx) -> double {
+        if (const auto *o = config.option<ConfigOptionFloatsNullable>(key)) return o->get_at(idx);
+        const ConfigOptionDef *d = config.def() ? config.def()->get(key) : nullptr;
+        return (d && d->default_value) ? d->get_default_value<ConfigOptionFloatsNullable>()->get_at(idx) : 0.0;
+    };
+    double       filament_max_volumetric_speed = vector_at("filament_max_volumetric_speed", filament_idx);
     // todo multi_extruders:
-    const float  nozzle_diameter               = config.option<ConfigOptionFloats>("nozzle_diameter")->get_at(extruder_id);
+    const float  nozzle_diameter               = vector_at("nozzle_diameter", extruder_id);
     if (line_width <= 0.) line_width = Flow::auto_extrusion_width(frPerimeter, nozzle_diameter);
     Flow         pattern_line = Flow(line_width, layer_height, nozzle_diameter);
-    auto         pa_speed     = std::min(std::max(general_suggested_min_speed, config.option<ConfigOptionFloatsNullable>("outer_wall_speed")->get_at(extruder_id)),
+    auto         pa_speed     = std::min(std::max(general_suggested_min_speed, nullable_at("outer_wall_speed", extruder_id)),
                                          filament_max_volumetric_speed / pattern_line.mm3_per_mm());
 
     return std::floor(pa_speed);


### PR DESCRIPTION
# Description

`--calibrate-type pa-tower` SIGSEGVs (exit 139, no output) on the CLI path
while the equivalent GUI wizard works fine. Root cause: `find_optimal_PA_speed`
reads `outer_wall_speed`, `nozzle_diameter`, and
`filament_max_volumetric_speed` without null-checking the returned
`ConfigOption*`. The CLI path runs the function on the merged config **before**
`Print::apply()` fills the option defaults, so those keys are absent and the
deref segfaults under NDEBUG (Release / RelWithDebInfo). The GUI path passes
`preset_bundle->full_config()` which is fully seeded with `ConfigDef` defaults,
so it never hit this.

While diagnosing this with a symbolized gdb, a related defense-in-depth issue
in `ConfigBase::get_abs_value` surfaced: the two-argument overload
`get_abs_value(key, ratio_over)` has an `assert(raw_opt != nullptr)` which
compiles out under NDEBUG and then derefs the null pointer. The single-arg
overload throws `ConfigurationError` in the same situation; this PR aligns
the two-arg one with the single-arg behavior. Both call sites are minor
hardening — no behavior change on the fast path.

# Changes

**`src/libslic3r/calib.cpp`** — `find_optimal_PA_speed` reads each key
through small `scalar` / `vector_at` lambdas that fall back to the key's
`ConfigDef` default value when the option pointer is null. GUI behavior
unchanged (its config carries every key, so the lambda returns the real
value on the fast path).

**`src/libslic3r/Config.cpp`** — two-arg `ConfigBase::get_abs_value(key,
ratio_over)` now throws `ConfigurationError` on a null option instead of
segfaulting. Matches the single-arg overload's behavior.

# Verification

- `--calibrate-type pa-tower` against a Klipper Core One preset stack →
  exit 0, full 41-block calib gcode with per-layer `SET_PRESSURE_ADVANCE`
  ramp.
- `--calibrate-type retraction-tower` + a normal slice — no regression.
- GUI pa-tower wizard unchanged.

# Scope

2 files, +29/-5 lines. No public API change.