### PR TITLE
PartPlate::check_outside: guard m_plater null deref (fix CLI rotate SIGSEGV)

### DIFF
--- a/src/slic3r/GUI/PartPlate.cpp
+++ b/src/slic3r/GUI/PartPlate.cpp
@@ -2628,7 +2628,8 @@ bool PartPlate::check_outside(int obj_id, int instance_id, BoundingBoxf3* boundi
 
 	if (instance_box.min.z() < SINKING_Z_THRESHOLD) {
 		// Orca: For sinking object, we use a more expensive algorithm so part below build plate won't be considered
-		if (plate_box.intersects(instance_box)) {
+		// m_plater is null in CLI mode.
+		if (m_plater && plate_box.intersects(instance_box)) {
 			// TODO: FIXME: this does not take exclusion area into account
             const BuildVolume build_volume(get_shape(), m_plater->build_volume().printable_height(), m_extruder_areas, m_extruder_heights);
 			const auto state = instance->calc_print_volume_state(build_volume);


### PR DESCRIPTION
# Description

`PartPlate::check_outside` dereferences `m_plater` unconditionally at the
sinking-instance sub-case (`PartPlate.cpp:2633`):

```cpp
const BuildVolume build_volume(get_shape(),
    m_plater->build_volume().printable_height(), …);
```

`m_plater` is null in CLI mode (no GUI Plater exists). Any headless invocation
that rotates a part to extend below Z=0 — e.g. `--rotate-y 90`, the new
lay-flat operations, or anything that dips an instance below
`SINKING_Z_THRESHOLD` — triggers a SIGSEGV in:

```
Plater::build_volume(this=0x0)            ← here
↑ PartPlate::check_outside
↑ PartPlate::add_instance
↑ PartPlateList::reload_all_objects
↑ PartPlateList::rebuild_plates_after_arrangement
↑ CLI::run
```

Easy reproducer: `orcaslicer-dev --slice 0 --rotate-y 90 <some.stl>`.

# Fix

Gate the sinking-instance branch on `m_plater != nullptr`, parallel to the
existing null-check pattern already used at `PartPlate.cpp:196` and `:672` in
the same file:

```cpp
if (instance_box.min.z() < SINKING_Z_THRESHOLD) {
    if (m_plater && plate_box.intersects(instance_box)) {   // ← guard
        const BuildVolume build_volume(get_shape(),
            m_plater->build_volume().printable_height(), …);
        …
    }
}
```

When `m_plater` is null, the cheaper non-sinking path takes over, which is
the right behavior for CLI (it doesn't need the GUI's special handling of
parts that hang off the plate visually).

# Verification

- `orcaslicer-dev --slice 0 --rotate-y 90 part.stl` no longer SIGSEGVs.
- Non-sinking GUI invocations and slicing flows unchanged (the fast path
  is the early-exit `if (instance_box.min.z() >= SINKING_Z_THRESHOLD)` so
  the guard is never reached).

# Scope

1 file, +5/-1 lines.

Fixes #13328
