### PR TITLE
Show dual-extruder nozzle panel for all dual-extruder printers (re-opened)

### DIFF
--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -2645,7 +2645,7 @@ void Sidebar::update_presets(Preset::Type preset_type)
         auto* nozzle_diameter = dynamic_cast<const ConfigOptionFloats*>(printer_preset.config.option("nozzle_diameter"));
 
         bool is_dual_extruder = nozzle_diameter->size() == 2;
-        p->layout_printer(preset_bundle.use_bbl_network(), isBBL && is_dual_extruder);
+        p->layout_printer(preset_bundle.use_bbl_network(), is_dual_extruder);
         auto diameters = wxGetApp().preset_bundle->printers.diameters_of_selected_printer();
         auto diameter = printer_preset.config.opt_string("printer_variant");
         auto update_extruder_diameter = [&diameters, &diameter, &nozzle_diameter](int extruder_index,ExtruderGroup & extruder) {

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -434,7 +434,7 @@ struct ExtruderGroup : StaticGroup
     std::vector<AMSinfo> ams_4;
     std::vector<AMSinfo> ams_1;
     wxString          diameter;
-
+    bool              ams_enabled{true};
     void set_ams_count(int n4, int n1)
     {
         if (n4 == ams_n4 && n1 == ams_n1)
@@ -647,7 +647,15 @@ void Sidebar::priv::layout_printer(bool isBBL, bool isDual)
 
     extruder_dual_sizer->Show(isDual);
 
-    // NEEDFIX requires AMS check or any type of ???
+    // Hide AMS section in nozzle panels for printers without a material system (no AMS/MMU)
+    bool has_material_system = preset_bundle.is_bbl_vendor() || cfg.opt_bool("single_extruder_multi_material");
+    left_extruder->ams_enabled = has_material_system;
+    right_extruder->ams_enabled = has_material_system;
+    if (isDual) {
+        left_extruder->update_ams();
+        right_extruder->update_ams();
+    }
+
     // Single nozzle & non ams
     panel_nozzle_dia->Show(!isDual && preset_bundle.get_printer_extruder_count() < 2);
     extruder_single_sizer->Show(false);
@@ -1141,6 +1149,24 @@ ExtruderGroup::ExtruderGroup(wxWindow * parent, int index, wxString const &title
 
 void ExtruderGroup::update_ams()
 {
+        // Hide entire AMS section for printers without a material system
+    if (!ams_enabled) {
+        ams_not_installed_msg->Hide();
+        for (size_t i = 0; i < 4; ++i) ams[i]->Close();
+        btn_up->Hide();
+        btn_down->Hide();
+        while (hsizer_ams->GetItemCount() > 2) hsizer_ams->Remove(2);
+        hsizer_ams->Show(size_t(0), false);
+        if (btn_edit && hsizer_ams->GetItemCount() > 1) hsizer_ams->Show(size_t(1), false);
+        hsizer_ams->SetMinSize(0, 0);
+        sizer->Layout();
+        return;
+    }
+
+    // Restore AMS label visibility (may have been hidden when ams_enabled was false)
+    hsizer_ams->Show(size_t(0), true);
+    hsizer_ams->SetMinSize(0, ams[0]->GetMinHeight());
+    
     static AMSinfo info4;
     static AMSinfo info1;
     if (info4.cans.empty()) {


### PR DESCRIPTION
# Description
Re-opened from https://github.com/OrcaSlicer/OrcaSlicer/pull/13050 due to accidental deletion. 
## Problem statement
* Currently, only BBL printers have access to the dual-extruder panel to select nozzle size. 
## Proposed Changes
* Make the left and right nozzle dual-extruder panel show for every (is_dual_extruder) printer instead of just (is_bbl && is_dual_extruder) printers.
* Hides AMS content when single_extruder_multi_material = false.

# Screenshots/Recordings/Graphs
BBL dual-extruder panel:
<img width="233" height="147" alt="image" src="https://github.com/user-attachments/assets/ac5ceffa-c6d8-4715-852e-c84819073653" />

Before: 
<img width="292" height="149" alt="image" src="https://github.com/user-attachments/assets/7815c05a-d14d-4f74-8963-e50bd1882332" />
<img width="293" height="142" alt="image" src="https://github.com/user-attachments/assets/2c77b362-6a1c-4487-8934-b834ddef84e7" />

After:
<img width="233" height="130" alt="image" src="https://github.com/user-attachments/assets/93179afc-a876-4d94-bd2c-33185c7ecf46" />
<img width="233" height="130" alt="image" src="https://github.com/user-attachments/assets/d4569aff-b6c5-41eb-86c8-a3aa4bf4925c" />


## Tests
* Built on Linux Ubuntu.
* Verified nozzle value change correctly updates machine settings. 
