### PR TITLE
feat(log): enable console logging in RelWithDebInfo builds

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -184,9 +184,12 @@ if (WIN32)
     if(MSVC)
         target_link_options(OrcaSlicer_app_gui PUBLIC "$<$<CONFIG:RELEASE>:/DEBUG>")
     endif()
-    target_compile_definitions(OrcaSlicer_app_gui PRIVATE -DSLIC3R_WRAPPER_NOCONSOLE)
+    target_compile_definitions(OrcaSlicer_app_gui PRIVATE "$<$<NOT:$<CONFIG:RelWithDebInfo>>:SLIC3R_WRAPPER_NOCONSOLE>")
     add_dependencies(OrcaSlicer_app_gui OrcaSlicer)
-    set_target_properties(OrcaSlicer_app_gui PROPERTIES OUTPUT_NAME "orca-slicer")
+    set_target_properties(OrcaSlicer_app_gui PROPERTIES
+        OUTPUT_NAME "orca-slicer"
+        WIN32_EXECUTABLE "$<NOT:$<CONFIG:RelWithDebInfo>>"
+    )
     target_link_libraries(OrcaSlicer_app_gui PRIVATE boost_headeronly)
 endif ()
 

--- a/src/libslic3r/CMakeLists.txt
+++ b/src/libslic3r/CMakeLists.txt
@@ -534,6 +534,7 @@ endif ()
 encoding_check(libslic3r)
 
 target_compile_definitions(libslic3r PUBLIC -DUSE_TBB -DTBB_USE_CAPTURED_EXCEPTION=0)
+target_compile_definitions(libslic3r PRIVATE $<$<CONFIG:RelWithDebInfo>:SLIC3R_CONSOLE_LOG>)
 target_include_directories(libslic3r PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
 target_include_directories(libslic3r SYSTEM PUBLIC ${EXPAT_INCLUDE_DIRS})
 

--- a/src/libslic3r/Utils.hpp
+++ b/src/libslic3r/Utils.hpp
@@ -194,6 +194,7 @@ std::string debug_out_path(const char *name, ...);
 // smaller level means less log. level=5 means saving all logs.
 void set_log_path_and_level(const std::string& file, unsigned int level);
 void flush_logs();
+void shutdown_console_logging();
 boost::filesystem::path get_log_file_name();
 
 // A special type for strings encoded in the local Windows 8-bit code page.

--- a/src/libslic3r/utils.cpp
+++ b/src/libslic3r/utils.cpp
@@ -5,6 +5,7 @@
 #include <locale>
 #include <ctime>
 #include <cstdarg>
+#include <iostream>
 #include <stdio.h>
 #include <filesystem>
 
@@ -48,6 +49,7 @@
 #include <boost/log/expressions.hpp>
 #include <boost/log/sinks/text_file_backend.hpp>
 #include <boost/log/utility/setup/file.hpp>
+#include <boost/log/utility/setup/console.hpp>
 #include <boost/log/utility/setup/common_attributes.hpp>
 #include <boost/log/sources/severity_logger.hpp>
 #include <boost/log/sources/record_ostream.hpp>
@@ -174,6 +176,7 @@ unsigned get_logging_level()
 }
 
 boost::shared_ptr<boost::log::sinks::synchronous_sink<boost::log::sinks::text_file_backend>> g_log_sink;
+boost::shared_ptr<boost::log::sinks::synchronous_sink<boost::log::sinks::text_ostream_backend>> g_console_log_sink;
 
 // Force set_logging_level(<=error) after loading of the DLL.
 // This is currently only needed if libslic3r is loaded as a shared library into Perl interpreter
@@ -377,6 +380,19 @@ void set_log_path_and_level(const std::string& file, unsigned int level)
 		keywords::auto_flush = true
 	);
 
+	g_console_log_sink = boost::log::add_console_log(
+		std::cout,
+		keywords::format =
+		(
+			expr::stream
+			<< "[" << expr::attr< logging::trivial::severity_level >("Severity") << "]\t"
+			<< expr::format_date_time< boost::posix_time::ptime >("TimeStamp", "%Y-%m-%d %H:%M:%S.%f") << " "
+			<<"[Thread " << expr::attr<attrs::current_thread_id::value_type>("ThreadID") << "]"
+			<< ": " << expr::smessage
+		),
+		keywords::auto_flush = true
+	);
+
 	logging::add_common_attributes();
 
 	set_logging_level(level);
@@ -388,6 +404,8 @@ void flush_logs()
 {
 	if (g_log_sink)
 		g_log_sink->flush();
+	if (g_console_log_sink)
+		g_console_log_sink->flush();
 
 	return;
 }

--- a/src/libslic3r/utils.cpp
+++ b/src/libslic3r/utils.cpp
@@ -47,15 +47,19 @@
 #include <boost/log/core.hpp>
 #include <boost/log/trivial.hpp>
 #include <boost/log/expressions.hpp>
+#include <boost/log/sinks/async_frontend.hpp>
 #include <boost/log/sinks/text_file_backend.hpp>
+#include <boost/log/sinks/text_ostream_backend.hpp>
 #include <boost/log/utility/setup/file.hpp>
-#include <boost/log/utility/setup/console.hpp>
 #include <boost/log/utility/setup/common_attributes.hpp>
 #include <boost/log/sources/severity_logger.hpp>
 #include <boost/log/sources/record_ostream.hpp>
 #include <boost/log/support/date_time.hpp>
 
+#include <boost/core/null_deleter.hpp>
 #include <boost/locale.hpp>
+#include <boost/make_shared.hpp>
+#include <boost/shared_ptr.hpp>
 
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/filesystem.hpp>
@@ -176,7 +180,7 @@ unsigned get_logging_level()
 }
 
 boost::shared_ptr<boost::log::sinks::synchronous_sink<boost::log::sinks::text_file_backend>> g_log_sink;
-boost::shared_ptr<boost::log::sinks::synchronous_sink<boost::log::sinks::text_ostream_backend>> g_console_log_sink;
+boost::shared_ptr<boost::log::sinks::asynchronous_sink<boost::log::sinks::text_ostream_backend>> g_console_log_sink;
 
 // Force set_logging_level(<=error) after loading of the DLL.
 // This is currently only needed if libslic3r is loaded as a shared library into Perl interpreter
@@ -349,6 +353,19 @@ namespace src = boost::log::sources;
 namespace expr = boost::log::expressions;
 namespace keywords = boost::log::keywords;
 namespace attrs = boost::log::attributes;
+namespace sinks = boost::log::sinks;
+
+void shutdown_console_logging()
+{
+	if (!g_console_log_sink)
+		return;
+
+	auto console_sink = g_console_log_sink;
+	boost::log::core::get()->remove_sink(console_sink);
+	console_sink->stop();
+	g_console_log_sink.reset();
+}
+
 void set_log_path_and_level(const std::string& file, unsigned int level)
 {
 #ifdef __APPLE__
@@ -380,18 +397,21 @@ void set_log_path_and_level(const std::string& file, unsigned int level)
 		keywords::auto_flush = true
 	);
 
-	g_console_log_sink = boost::log::add_console_log(
-		std::cout,
-		keywords::format =
-		(
-			expr::stream
-			<< "[" << expr::attr< logging::trivial::severity_level >("Severity") << "]\t"
-			<< expr::format_date_time< boost::posix_time::ptime >("TimeStamp", "%Y-%m-%d %H:%M:%S.%f") << " "
-			<<"[Thread " << expr::attr<attrs::current_thread_id::value_type>("ThreadID") << "]"
-			<< ": " << expr::smessage
-		),
-		keywords::auto_flush = true
+	shutdown_console_logging();
+
+	auto console_backend = boost::make_shared<sinks::text_ostream_backend>();
+	console_backend->add_stream(boost::shared_ptr<std::ostream>(&std::cout, boost::null_deleter()));
+	console_backend->auto_flush(true);
+
+	g_console_log_sink = boost::make_shared<sinks::asynchronous_sink<sinks::text_ostream_backend>>(console_backend);
+	g_console_log_sink->set_formatter(
+		expr::stream
+		<< "[" << expr::attr< logging::trivial::severity_level >("Severity") << "]\t"
+		<< expr::format_date_time< boost::posix_time::ptime >("TimeStamp", "%Y-%m-%d %H:%M:%S.%f") << " "
+		<<"[Thread " << expr::attr<attrs::current_thread_id::value_type>("ThreadID") << "]"
+		<< ": " << expr::smessage
 	);
+	boost::log::core::get()->add_sink(g_console_log_sink);
 
 	logging::add_common_attributes();
 
@@ -404,8 +424,6 @@ void flush_logs()
 {
 	if (g_log_sink)
 		g_log_sink->flush();
-	if (g_console_log_sink)
-		g_console_log_sink->flush();
 
 	return;
 }

--- a/src/libslic3r/utils.cpp
+++ b/src/libslic3r/utils.cpp
@@ -399,6 +399,7 @@ void set_log_path_and_level(const std::string& file, unsigned int level)
 
 	shutdown_console_logging();
 
+#ifdef SLIC3R_CONSOLE_LOG
 	auto console_backend = boost::make_shared<sinks::text_ostream_backend>();
 	console_backend->add_stream(boost::shared_ptr<std::ostream>(&std::cout, boost::null_deleter()));
 	console_backend->auto_flush(true);
@@ -412,6 +413,7 @@ void set_log_path_and_level(const std::string& file, unsigned int level)
 		<< ": " << expr::smessage
 	);
 	boost::log::core::get()->add_sink(g_console_log_sink);
+#endif
 
 	logging::add_common_attributes();
 

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -2211,6 +2211,7 @@ GUI_App::~GUI_App()
 
 
     BOOST_LOG_TRIVIAL(info) << __FUNCTION__<< boost::format(": exit");
+    shutdown_console_logging();
 }
 
 bool GUI_App::is_blocking_printing(MachineObject *obj_)


### PR DESCRIPTION
When building with RelWithDebInfo, log output only went to the log file, making it
painful to follow what the app is doing during development without tailing the file
separately.

This adds a Boost.Log console sink so log messages also appear in the terminal when
running a RelWithDebInfo build. In Release and Debug builds the behavior is
unchanged: the console stays suppressed (WIN32_EXECUTABLE and SLIC3R_WRAPPER_NOCONSOLE
remain active), so production builds are not affected.

Changes:
- src/CMakeLists.txt: make SLIC3R_WRAPPER_NOCONSOLE and WIN32_EXECUTABLE conditional
  on build type, active in Release but not in RelWithDebInfo
- src/libslic3r/utils.cpp: add console sink alongside the existing file sink, with
  the same format (severity, timestamp, thread ID, message) and auto_flush enabled