### PR TITLE
fix: PA pattern calibration crash with first layer line width 0

### DIFF
--- a/src/libslic3r/calib.cpp
+++ b/src/libslic3r/calib.cpp
@@ -756,6 +756,16 @@ Vec3d CalibPressureAdvancePattern::get_start_offset()
     return m_starting_point;
 }
 
+double CalibPressureAdvancePattern::line_width_first_layer() const
+{
+    // TODO: FIXME: find out current filament/extruder?
+    const double nozzle_diameter = m_config.opt_float("nozzle_diameter", m_params.extruder_id);
+    const double width           = m_config.get_abs_value("initial_layer_line_width", nozzle_diameter);
+    if (width <= 0.)
+        return Flow::auto_extrusion_width(frExternalPerimeter, nozzle_diameter);
+    return width;
+};
+
 double CalibPressureAdvancePattern::line_width() const
 {
     // TODO: FIXME: find out current filament/extruder?

--- a/src/libslic3r/calib.hpp
+++ b/src/libslic3r/calib.hpp
@@ -315,12 +315,7 @@ protected:
     double speed_first_layer() const { return m_config.get_abs_value_at("initial_layer_speed", m_params.extruder_id); };
     double speed_perimeter() const { return m_config.get_abs_value_at("outer_wall_speed", m_params.extruder_id); };
     double accel_perimeter() const { return m_config.get_abs_value_at("outer_wall_acceleration", m_params.extruder_id); }
-    double line_width_first_layer() const
-    {
-        // TODO: FIXME: find out current filament/extruder?
-        const double nozzle_diameter = m_config.opt_float("nozzle_diameter", m_params.extruder_id);
-        return m_config.get_abs_value("initial_layer_line_width", nozzle_diameter);
-    };
+    double line_width_first_layer() const;
     double line_width() const;
     int    wall_count() const { return m_config.option<ConfigOptionInt>("wall_loops")->value; };
 

--- a/tests/libslic3r/CMakeLists.txt
+++ b/tests/libslic3r/CMakeLists.txt
@@ -8,6 +8,7 @@ add_executable(${_TEST_NAME}_tests
     test_arachne_walls.cpp
     test_arrange.cpp
     test_bambu_networking.cpp
+    test_calib.cpp
     test_clipper_offset.cpp
     test_clipper_utils.cpp
     test_config.cpp

--- a/tests/libslic3r/test_calib.cpp
+++ b/tests/libslic3r/test_calib.cpp
@@ -1,0 +1,40 @@
+#include <catch2/catch_all.hpp>
+
+#include "libslic3r/calib.hpp"
+#include "libslic3r/Model.hpp"
+#include "libslic3r/TriangleMesh.hpp"
+#include "libslic3r/PrintConfig.hpp"
+
+using namespace Slic3r;
+
+namespace {
+
+// The width-resolution getters are protected; expose them so the resolution can be asserted directly.
+struct PaPatternProbe : public CalibPressureAdvancePattern
+{
+    using CalibPressureAdvancePattern::CalibPressureAdvancePattern;
+    using CalibPressureAdvancePattern::line_width;
+    using CalibPressureAdvancePattern::line_width_first_layer;
+};
+
+} // namespace
+
+TEST_CASE("Zero calibration line width resolves to a positive default", "[Calib][Regression]")
+{
+    DynamicPrintConfig config = DynamicPrintConfig::full_print_config();
+    config.set_deserialize_strict({
+        {"line_width", "0"},
+        {"initial_layer_line_width", "0"},
+    });
+
+    Model model;
+    model.add_object("cube", "", make_cube(20, 20, 20))->add_instance();
+
+    Calib_Params params;
+    params.mode = CalibMode::Calib_PA_Pattern;
+
+    PaPatternProbe pattern(params, config, /* is_bbl_machine */ true, *model.objects.front(), Vec3d(0, 0, 0));
+
+    REQUIRE(pattern.line_width() > 0.);
+    REQUIRE(pattern.line_width_first_layer() > 0.);
+}


### PR DESCRIPTION
# Description

Setting the first layer line width to 0 (which means "use the default") and then slicing a Pressure Advance pattern calibration crashes the whole application with an unhandled exception, still present on the nightly builds.

Fixes #13188.

Root cause: `CalibPressureAdvancePattern::line_width_first_layer()` returned the raw `initial_layer_line_width`. When that value is 0, the 0 flows into the `Flow` spacing math, which throws `FlowErrorNegativeSpacing`. The sibling `line_width()` already guards this case; the first-layer getter did not.

Fix: mirror the existing guard so a non-positive configured width falls back to `Flow::auto_extrusion_width(frExternalPerimeter, ...)`, i.e. the documented "use default" behavior.

# Screenshots/Recordings/Graphs

N/A (no UI change). With the fix, the PA pattern calibration slices normally instead of crashing when the first layer line width is 0.

## Tests

Added `tests/libslic3r/test_calib.cpp`, a libslic3r regression test asserting that a zero calibration line width resolves to a positive default. It fails before the fix and passes after.

Manually verified in the GUI: the PA pattern calibration crash reproduces on the current build with the first layer line width set to 0, and no longer occurs with this fix.

Full build and unit tests pass on all CI platforms (Linux x86_64 and aarch64, Windows x64 and arm64, macOS).

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
