### PR TITLE
fix: slicing fails when filament_end_gcode uses layer_z with a wipe tower

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -781,6 +781,7 @@ static std::vector<Vec2d> get_path_of_change_filament(const Print& print)
             if (gcodegen.writer().filament() != nullptr && !filament_end_gcode.empty()) {
                 DynamicConfig config;
                 config.set_key_value("layer_num", new ConfigOptionInt(gcodegen.m_layer_index));
+                config.set_key_value("layer_z", new ConfigOptionFloat(tcr.print_z));
                 if (!gcodegen.m_filament_instances_code.empty()) {
                     end_filament_gcode_str += ("M624 " + gcodegen.m_filament_instances_code + "\n");
                     gcodegen.m_filament_instances_code = "";


### PR DESCRIPTION
# Description

Fixes #10119. One-line fix.

A `filament_end_gcode` referencing `{layer_z}` (e.g. the common "lift to clear the print") aborts slicing on any multi-filament print whose tool changes go through the prime/wipe tower, such as a print using a separate support filament.

`WipeTowerIntegration::append_tcr` built the placeholder config for `filament_end_gcode` with only `layer_num`, so `{layer_z}` had no value and the parser aborted the slice. The same macro works in `machine_end_gcode` and on the non-wipe-tower `GCode::set_extruder` path because both define `layer_z`. The fix sets `layer_z` to `tcr.print_z`, the value this function already passes to its `change_filament_gcode` and `tcr_rotated_gcode` placeholders. No behavior change when the macro does not reference `layer_z`.

## Steps to reproduce

1. Select a printer with the prime tower enabled (e.g. Bambu X1C/H2D).
2. Use two filaments and enable supports with the second filament as the support filament (so tool changes go through the wipe tower).
3. Filament Settings > Advanced > Filament end G-code: add `G1 Z{layer_z + 0.4}`.
4. Load a model that generates support and slice.

Before the fix slicing aborts on `{layer_z}`; after, it completes with the lift emitted at each tool change.

# Screenshots/Recordings/Graphs

N/A (slicing/G-code change).

## Tests

Verified with the #10119 project file via the headless CLI:
- Before: slicing aborts with `G1 Z{layer_z + 0.4} ^ Please check the custom G-code` and writes no G-code.
- After: slicing completes; the lift is emitted with `layer_z` resolved at each of the wipe-tower tool changes (26 in the sample, e.g. `G1 Z0.6`).

A unit-level regression test needs a multi-filament + wipe-tower slice, which the `fff_print` harness gains in #14426; a test for this path can follow once that lands.
