### PR TITLE
💥Crash Fix Object settings table

### DIFF
--- a/src/slic3r/GUI/GUI_ObjectTable.cpp
+++ b/src/slic3r/GUI/GUI_ObjectTable.cpp
@@ -1737,8 +1737,8 @@ void ObjectGridTable::SetValueAsDouble(int row, int col, double value)
             return;
     }
 
-    if (auto option_values = dynamic_cast<ConfigOptionFloatsNullable*>(&(*grid_row)[(GridColType) col])) {
-        ConfigOptionFloatsNullable& option_ori_values = dynamic_cast<ConfigOptionFloatsNullable&>((*grid_row)[(GridColType) (col + 1)]);
+    if (auto option_values = dynamic_cast<ConfigOptionFloatsNullable *>(&(*grid_row)[(GridColType) col])) {
+        ConfigOptionFloatsNullable &option_ori_values = dynamic_cast<ConfigOptionFloatsNullable &>((*grid_row)[(GridColType) (col + 1)]);
 
         option_values->values.at(0) = (float) value;
 
@@ -1746,6 +1746,15 @@ void ObjectGridTable::SetValueAsDouble(int row, int col, double value)
 
         return;
     }
+
+    ConfigOptionFloat &option_value = dynamic_cast<ConfigOptionFloat &>((*grid_row)[(GridColType)col]);
+    ConfigOptionFloat &option_ori_value = dynamic_cast<ConfigOptionFloat &>((*grid_row)[(GridColType)(col+1)]);
+
+    option_value.value = (float)value;
+
+    update_value_to_config(grid_row->config, grid_col->key, option_value, option_ori_value);
+
+    return;
 }
 
 void ObjectGridTable::SetColLabelValue( int col, const wxString& value )

--- a/src/slic3r/GUI/GUI_ObjectTable.cpp
+++ b/src/slic3r/GUI/GUI_ObjectTable.cpp
@@ -1393,8 +1393,10 @@ wxString ObjectGridTable::GetValue (int row, int col)
     else if (grid_col->type == coInt) {
         ConfigOptionInt& option_value = dynamic_cast<ConfigOptionInt&>(option);
         return wxString::Format("%d", option_value.value);
-    }
-    else if (grid_col->type == coFloat) {
+    } else if (grid_col->type == coFloat) {
+        if (auto option_values = dynamic_cast<ConfigOptionFloatsNullable*>(&option)) {
+            return wxString::Format("%.2f", option_values->get_at(0));
+        }
         ConfigOptionFloat& option_value = dynamic_cast<ConfigOptionFloat&>(option);
         return wxString::Format("%.2f", option_value.value);
     }
@@ -1592,16 +1594,25 @@ void ObjectGridTable::SetValue( int row, int col, const wxString& value )
         else {
             update_value_to_object(m_panel->m_model, grid_row, col);
         }
-    }
-    else if (grid_col->type == coFloat) {
-        ConfigOptionFloat &option_value = dynamic_cast<ConfigOptionFloat &>((*grid_row)[(GridColType)col]);
-        ConfigOptionFloat &option_ori_value = dynamic_cast<ConfigOptionFloat &>((*grid_row)[(GridColType)(col+1)]);
+    } else if (grid_col->type == coFloat) {
+        if (auto option_values = dynamic_cast<ConfigOptionFloatsNullable*>(&(*grid_row)[(GridColType) col])) {
+            ConfigOptionFloatsNullable& option_ori_values = dynamic_cast<ConfigOptionFloatsNullable&>((*grid_row)[(GridColType) (col + 1)]);
 
-        double  double_value;
-        value.ToDouble(&double_value);
-        option_value.value = (float)double_value;
+            double double_value;
+            value.ToDouble(&double_value);
+            option_values->values.at(0) = (float) double_value;
 
-        update_value_to_config(grid_row->config, grid_col->key, option_value, option_ori_value);
+            update_value_to_config(grid_row->config, grid_col->key, *option_values, option_ori_values);
+        } else {
+            ConfigOptionFloat& option_value     = dynamic_cast<ConfigOptionFloat&>((*grid_row)[(GridColType) col]);
+            ConfigOptionFloat& option_ori_value = dynamic_cast<ConfigOptionFloat&>((*grid_row)[(GridColType) (col + 1)]);
+
+            double double_value;
+            value.ToDouble(&double_value);
+            option_value.value = (float) double_value;
+
+            update_value_to_config(grid_row->config, grid_col->key, option_value, option_ori_value);
+        }
     }
     else if (grid_col->type == coInt) {
         ConfigOptionInt &option_value = dynamic_cast<ConfigOptionInt &>((*grid_row)[(GridColType)col]);
@@ -1676,8 +1687,11 @@ double ObjectGridTable::GetValueAsDouble( int row, int col )
         return 0;
 
     ObjectGridRow* grid_row = m_grid_data[row - 1];
-    ConfigOptionFloat &option_value = dynamic_cast<ConfigOptionFloat &>((*grid_row)[(GridColType)col]);
-    return (double )option_value.getFloat();
+    if (auto option_values = dynamic_cast<ConfigOptionFloatsNullable*>(&(*grid_row)[(GridColType) col])) {
+        return (double) option_values->get_at(0);
+    }
+    ConfigOptionFloat& option_value = dynamic_cast<ConfigOptionFloat&>((*grid_row)[(GridColType) col]);
+    return (double) option_value.getFloat();
 }
 
 void ObjectGridTable::SetValueAsLong( int row, int col, long value )
@@ -1722,14 +1736,16 @@ void ObjectGridTable::SetValueAsDouble(int row, int col, double value)
         if ((value > 100.f) || (value < 0.f))
             return;
     }
-    ConfigOptionFloat &option_value = dynamic_cast<ConfigOptionFloat &>((*grid_row)[(GridColType)col]);
-    ConfigOptionFloat &option_ori_value = dynamic_cast<ConfigOptionFloat &>((*grid_row)[(GridColType)(col+1)]);
 
-    option_value.value = (float)value;
+    if (auto option_values = dynamic_cast<ConfigOptionFloatsNullable*>(&(*grid_row)[(GridColType) col])) {
+        ConfigOptionFloatsNullable& option_ori_values = dynamic_cast<ConfigOptionFloatsNullable&>((*grid_row)[(GridColType) (col + 1)]);
 
-    update_value_to_config(grid_row->config, grid_col->key, option_value, option_ori_value);
+        option_values->values.at(0) = (float) value;
 
-    return;
+        update_value_to_config(grid_row->config, grid_col->key, *option_values, option_ori_values);
+
+        return;
+    }
 }
 
 void ObjectGridTable::SetColLabelValue( int col, const wxString& value )
@@ -1981,8 +1997,8 @@ void ObjectGridTable::construct_object_configs(ObjectGrid *object_grid)
         object_grid->ori_enable_support = *(global_config.option<ConfigOptionBool>(m_col_data[col_enable_support]->key));
         object_grid->brim_type = *(get_object_config_value<ConfigOptionEnum<BrimType>>(global_config, object_grid->config, m_col_data[col_brim_type]->key));
         object_grid->ori_brim_type = *(global_config.option<ConfigOptionEnum<BrimType>>(m_col_data[col_brim_type]->key));
-        object_grid->speed_perimeter = *(get_object_config_value<ConfigOptionFloat>(global_config, object_grid->config, m_col_data[col_speed_perimeter]->key));
-        object_grid->ori_speed_perimeter = *(global_config.option<ConfigOptionFloat>(m_col_data[col_speed_perimeter]->key));
+        object_grid->speed_perimeter       = *(get_object_config_value<ConfigOptionFloatsNullable>(global_config, object_grid->config, m_col_data[col_speed_perimeter]->key));
+        object_grid->ori_speed_perimeter   = *(global_config.option<ConfigOptionFloatsNullable>(m_col_data[col_speed_perimeter]->key));
         m_grid_data.push_back(object_grid);
 
         int volume_count = object->volumes.size();
@@ -2031,7 +2047,7 @@ void ObjectGridTable::construct_object_configs(ObjectGrid *object_grid)
             volume_grid->ori_enable_support = object_grid->enable_support;
             volume_grid->brim_type = *(get_volume_config_value<ConfigOptionEnum<BrimType>>(global_config, object_grid->config, volume_grid->config, m_col_data[col_brim_type]->key));
             volume_grid->ori_brim_type = object_grid->brim_type;
-            volume_grid->speed_perimeter = *(get_volume_config_value<ConfigOptionFloat>(global_config, object_grid->config, volume_grid->config, m_col_data[col_speed_perimeter]->key));
+            volume_grid->speed_perimeter = *(get_volume_config_value<ConfigOptionFloatsNullable>(global_config, object_grid->config, volume_grid->config, m_col_data[col_speed_perimeter]->key));
             volume_grid->ori_speed_perimeter = object_grid->speed_perimeter;
             m_grid_data.push_back(volume_grid);
         }
@@ -2077,8 +2093,8 @@ void ObjectGridTable::reload_object_data(ObjectGridRow* grid_row, const std::str
         grid_row->ori_enable_support = *(global_config.option<ConfigOptionBool>(m_col_data[col_enable_support]->key));
         grid_row->brim_type = *(get_object_config_value<ConfigOptionEnum<BrimType>>(global_config, grid_row->config, m_col_data[col_brim_type]->key));
         grid_row->ori_brim_type = *(global_config.option<ConfigOptionEnum<BrimType>>(m_col_data[col_brim_type]->key));
-        grid_row->speed_perimeter = *(get_object_config_value<ConfigOptionFloat>(global_config, grid_row->config, m_col_data[col_speed_perimeter]->key));
-        grid_row->ori_speed_perimeter = *(global_config.option<ConfigOptionFloat>(m_col_data[col_speed_perimeter]->key));
+        grid_row->speed_perimeter       = *(get_object_config_value<ConfigOptionFloatsNullable>(global_config, grid_row->config, m_col_data[col_speed_perimeter]->key));
+        grid_row->ori_speed_perimeter   = *(global_config.option<ConfigOptionFloatsNullable>(m_col_data[col_speed_perimeter]->key));
     }
     else if (category == L("Quality")) {
         grid_row->layer_height = *(get_object_config_value<ConfigOptionFloat>(global_config, grid_row->config, m_col_data[col_layer_height]->key));
@@ -2099,8 +2115,8 @@ void ObjectGridTable::reload_object_data(ObjectGridRow* grid_row, const std::str
         grid_row->ori_brim_type = *(global_config.option<ConfigOptionEnum<BrimType>>(m_col_data[col_brim_type]->key));
     }
     else if (category == L("Speed")) {
-        grid_row->speed_perimeter = *(get_object_config_value<ConfigOptionFloat>(global_config, grid_row->config, m_col_data[col_speed_perimeter]->key));
-        grid_row->ori_speed_perimeter = *(global_config.option<ConfigOptionFloat>(m_col_data[col_speed_perimeter]->key));
+        grid_row->speed_perimeter = *(get_object_config_value<ConfigOptionFloatsNullable>(global_config, grid_row->config, m_col_data[col_speed_perimeter]->key));
+        grid_row->ori_speed_perimeter = *(global_config.option<ConfigOptionFloatsNullable>(m_col_data[col_speed_perimeter]->key));
     }
 }
 
@@ -2117,7 +2133,7 @@ void ObjectGridTable::reload_part_data(ObjectGridRow* volume_row, ObjectGridRow*
         volume_row->ori_enable_support = object_row->enable_support;
         volume_row->brim_type = *(get_volume_config_value<ConfigOptionEnum<BrimType>>(global_config, object_row->config, volume_row->config, m_col_data[col_brim_type]->key));
         volume_row->ori_brim_type = object_row->brim_type;
-        volume_row->speed_perimeter = *(get_volume_config_value<ConfigOptionFloat>(global_config, object_row->config, volume_row->config, m_col_data[col_speed_perimeter]->key));
+        volume_row->speed_perimeter = *(get_volume_config_value<ConfigOptionFloatsNullable>(global_config, object_row->config, volume_row->config, m_col_data[col_speed_perimeter]->key));
         volume_row->ori_speed_perimeter = object_row->speed_perimeter;
     }
     else if (category == L("Quality")) {
@@ -2154,7 +2170,7 @@ void ObjectGridTable::reload_part_data(ObjectGridRow* volume_row, ObjectGridRow*
         volume_row->ori_brim_type = object_row->brim_type;
     }
     else if (category == L("Speed")) {
-        volume_row->speed_perimeter = *(get_volume_config_value<ConfigOptionFloat>(global_config, object_row->config, volume_row->config, m_col_data[col_speed_perimeter]->key));
+        volume_row->speed_perimeter = *(get_volume_config_value<ConfigOptionFloatsNullable>(global_config, object_row->config, volume_row->config, m_col_data[col_speed_perimeter]->key));
         if (volume_row->speed_perimeter == object_row->speed_perimeter) {
             volume_row->config->erase(m_col_data[col_speed_perimeter]->key);
         }
@@ -2549,6 +2565,8 @@ bool ObjectGridTable::OnCellLeftClick(int row, int col, ConfigOptionType &type)
 void ObjectGridTable::OnSelectCell(int row, int col)
 {
     m_selected_cells.clear();
+    if (!m_panel->m_side_window)
+        return;
     m_panel->m_side_window->Freeze();
     if (row == 0 || col == col_filaments) {
         m_panel->m_object_settings->UpdateAndShow(row, false, false, false, nullptr, nullptr, std::string());

--- a/src/slic3r/GUI/GUI_ObjectTable.hpp
+++ b/src/slic3r/GUI/GUI_ObjectTable.hpp
@@ -344,8 +344,8 @@ public:
         ConfigOptionBool            ori_enable_support;
         ConfigOptionEnum<BrimType>  brim_type;
         ConfigOptionEnum<BrimType>  ori_brim_type;
-        ConfigOptionFloat           speed_perimeter;
-        ConfigOptionFloat           ori_speed_perimeter;
+        ConfigOptionFloatsNullable  speed_perimeter;
+        ConfigOptionFloatsNullable  ori_speed_perimeter;
 
         ModelConfig*                config;
         ModelVolumeType             model_volume_type;


### PR DESCRIPTION
# Description

Fix a crash introduced in #13712 when clicking 'View all object settings" Table.
Cherry Picked from Bambu Studio Comits:

https://github.com/bambulab/BambuStudio/commit/a3ef69dfa419436ee8220f27e0d7cafe120c2921
https://github.com/bambulab/BambuStudio/commit/3b7bbe741f30c14459d113b27c592ecf907282f5
https://github.com/bambulab/BambuStudio/commit/35046d76f18c227e50630a5095a0aa868b3f4f9d

<img width="1681" height="1065" alt="image" src="https://github.com/user-attachments/assets/8e6ae339-1083-4d9e-b19f-3267aa0d46c9" />

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
