### PR TITLE
test(fff_print): re-enable tests disabled by the m_origin clipper throw

### DIFF
--- a/tests/fff_print/test_printgcode.cpp
+++ b/tests/fff_print/test_printgcode.cpp
@@ -31,10 +31,7 @@ boost::regex perimeters_regex("G1 X[-0-9.]* Y[-0-9.]* E[-0-9.]* ; perimeter");
 boost::regex infill_regex("G1 X[-0-9.]* Y[-0-9.]* E[-0-9.]* ; infill");
 boost::regex skirt_regex("G1 X[-0-9.]* Y[-0-9.]* E[-0-9.]* ; skirt");
 
-// [NotWorking]: slice() intermittently throws clipper's "Coordinate outside allowed
-// range" in CI (Linux) while passing locally. Disabled pending a root-cause fix in a
-// follow-up PR.
-SCENARIO( "PrintGCode basic functionality", "[PrintGCode][NotWorking]") {
+SCENARIO( "PrintGCode basic functionality", "[PrintGCode]") {
     GIVEN("A default configuration and a print test object") {
         WHEN("the output is executed with no support material") {
             Slic3r::Print print;

--- a/tests/fff_print/test_skirt_brim.cpp
+++ b/tests/fff_print/test_skirt_brim.cpp
@@ -32,10 +32,7 @@ using namespace Slic3r;
     return brim_tool;
 }
 
-// [NotWorking]: slice() intermittently throws clipper's "Coordinate outside allowed
-// range" in CI (Linux) while passing locally. Disabled pending a root-cause fix in a
-// follow-up PR.
-TEST_CASE("Skirt height is honored", "[SkirtBrim][NotWorking]") {
+TEST_CASE("Skirt height is honored", "[SkirtBrim]") {
     DynamicPrintConfig config = Slic3r::DynamicPrintConfig::full_print_config();
     config.set_deserialize_strict({
         { "skirt_loops",    1 },
@@ -55,8 +52,7 @@ TEST_CASE("Skirt height is honored", "[SkirtBrim][NotWorking]") {
     REQUIRE(layers_with_role(gcode, "skirt").size() == (size_t)config.opt_int("skirt_height"));
 }
 
-// [NotWorking]: see "Skirt height is honored" above; same CI-only clipper range throw.
-SCENARIO("Skirt and brim generation", "[SkirtBrim][NotWorking]") {
+SCENARIO("Skirt and brim generation", "[SkirtBrim]") {
     GIVEN("A default configuration") {
 	    DynamicPrintConfig config = Slic3r::DynamicPrintConfig::full_print_config();
 		config.set_num_extruders(4);


### PR DESCRIPTION
[#13712](https://github.com/OrcaSlicer/OrcaSlicer/pull/13712) fixed the uninitialized `Print::m_origin` that caused the intermittent ClipperLib "Coordinate outside allowed range" throw in headless slicing.

With that fixed, the three tests tagged `[NotWorking]` for this throw pass again. Re-enable them (tag + stale-comment removal only):

- `Skirt height is honored` (test_skirt_brim.cpp)
- `Scenario: Skirt and brim generation` (test_skirt_brim.cpp)
- `PrintGCode basic functionality` (test_printgcode.cpp)
