### PR TITLE
FilAr PLA-mate: lower bed temperature to 50 C

### DIFF
--- a/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA-mate @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FilAr/FilAr PLA-mate @base.json
@@ -33,15 +33,15 @@
         "210"
     ],
     "hot_plate_temp": [
-        "60"
+        "50"
     ],
     "hot_plate_temp_initial_layer": [
-        "60"
+        "50"
     ],
     "textured_plate_temp": [
-        "60"
+        "50"
     ],
     "textured_plate_temp_initial_layer": [
-        "60"
+        "50"
     ]
 }


### PR DESCRIPTION
Lowers the bed temperature for **FilAr PLA-mate** from 60 °C to **50 °C** (per updated manufacturer guidance) in `FilAr PLA-mate @base`. All FilAr PLA-mate color presets inherit from this base, so the change applies to the whole line.

Affects `hot_plate_temp`, `hot_plate_temp_initial_layer`, `textured_plate_temp` and `textured_plate_temp_initial_layer`. Follow-up to #13977.
