### PR TITLE
build: check for ninja in macOS script

### DIFF
--- a/build_release_macos.sh
+++ b/build_release_macos.sh
@@ -54,7 +54,7 @@ while getopts ":dpa:snt:xbc:i:1Tuh" opt; do
         echo "   -u: Build universal app only (requires existing arm64 and x86_64 app bundles)"
         echo "   -n: Nightly build"
         echo "   -t: Specify minimum version of the target platform, default is 11.3"
-        echo "   -x: Use Ninja Multi-Config CMake generator, default is Xcode"
+        echo "   -x: Use Ninja Multi-Config CMake generator, default is Xcode (requires ninja; install with 'brew install ninja')"
         echo "   -b: Build without reconfiguring CMake"
         echo "   -c: Set CMake build configuration, default is Release"
         echo "   -i: Add a prefix to ignore during CMake dependency discovery (repeatable), defaults to /opt/local:/usr/local:/opt/homebrew"
@@ -100,6 +100,12 @@ fi
 
 if [ -z "$CMAKE_IGNORE_PREFIX_PATH" ]; then
   export CMAKE_IGNORE_PREFIX_PATH="/opt/local:/usr/local:/opt/homebrew"
+fi
+
+if [[ "$SLICER_CMAKE_GENERATOR" == Ninja* || "$DEPS_CMAKE_GENERATOR" == Ninja* ]] && ! command -v ninja >/dev/null 2>&1; then
+  echo "Error: Ninja is required when using the -x generator option."
+  echo "Install it with Homebrew: brew install ninja"
+  exit 1
 fi
 
 CMAKE_VERSION=$(cmake --version | head -1 | sed 's/[^0-9]*\([0-9]*\).*/\1/')


### PR DESCRIPTION
 # Description

   Adds an early macOS build-script preflight for the `-x` generator option.

   When `./build_release_macos.sh` is run with `-x`, the script switches CMake to the Ninja / Ninja Multi-Config generators. On a clean macOS machine
 without Ninja installed, CMake currently fails later with a generic “unable to find a build program corresponding to Ninja” error.

   This PR makes the requirement explicit by:

   - Updating the `-x` help text to mention that Ninja is required
   - Checking for `ninja` before CMake configuration starts
   - Printing a direct Homebrew install hint: `brew install ninja`

   No app behavior, build outputs, or dependency versions are changed.

   # Screenshots/Recordings/Graphs

   N/A — build-script error handling only.

   ## Tests

   - `bash -n build_release_macos.sh`
   - `./build_release_macos.sh -h`
   - Simulated missing Ninja by running the script with a restricted `PATH` and verified it exits early with:

   ```text
   Error: Ninja is required when using the -x generator option.
   Install it with Homebrew: brew install ninja