### PR TITLE
fix: crash when rotating the prime tower

### DIFF
--- a/src/slic3r/GUI/Selection.cpp
+++ b/src/slic3r/GUI/Selection.cpp
@@ -535,6 +535,9 @@ void Selection::drop()
 
     for (unsigned int i : m_list) {
         GLVolume&    volume = *(*m_volumes)[i];
+        // Skip the wipe tower: its synthetic id (>= 1000) is not an index into m_model->objects.
+        if (volume.object_idx() >= 1000)
+            continue;
         ModelObject* model_object = m_model->objects[volume.object_idx()];
 
         if (model_object != nullptr) {
@@ -1848,6 +1851,9 @@ void Selection::notify_instance_update(int object_idx, int instance_idx)
         for (unsigned int i : m_list)
         {
             int obj_index = (*m_volumes)[i]->object_idx();
+            // Skip the wipe tower: its synthetic id (>= 1000) is not an index into m_model->objects.
+            if (obj_index >= 1000)
+                continue;
             //-1 means all the instance in this object
             if (instance_idx == -1)
             {


### PR DESCRIPTION
# Description

Fixes #14498

Selecting the prime tower and rotating it with PageUp / PageDown segfaults: `Selection::notify_instance_update()` indexes `m_model->objects` with the wipe tower's synthetic id (`>= 1000`), which is not a real object index, and dereferencing the result crashes. The same helper is shared by rotate, scale, and mirror, so all three were affected; `Selection::drop()` had the same latent bug via a direct index.

This adds the synthetic-id (`>= 1000`) guard to `Selection::notify_instance_update()` and `Selection::drop()` to prevent the segfault. Confirmed all other entry points are already properly guarded.

### Steps to reproduce crash
1. Set up a print that generates a prime tower.
2. Select the prime tower on the plate.
3. Press PageUp / PageDown to rotate it.
4. Crash (SIGSEGV in `Selection::notify_instance_update`).

## Tests

Manually verified: rotating the prime tower no longer crashes. No automated test: this is GUI selection/keyboard interaction with no unit-test hook.