### PR TITLE
Fix issue that Orca keeps asking for re-install Bambu network plugin

### DIFF
--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -1174,7 +1174,7 @@ std::string GUI_App::get_plugin_url(std::string name, std::string country_code)
     std::string url = get_http_url(country_code);
 
     std::string curr_version;
-    if (NetworkAgent::use_legacy_network) {
+    if (use_legacy_network_plugin()) {
         curr_version = BAMBU_NETWORK_AGENT_VERSION_LEGACY;
     } else if (name == "plugins" && app_config) {
         std::string user_version = app_config->get_network_plugin_version();
@@ -1229,7 +1229,7 @@ int GUI_App::download_plugin(std::string name, std::string package_name, Install
     // Determine OS type for plugin download (must be set per-request since global
     // extra headers are no longer initialised on this branch).
 #if defined(__WINDOWS__)
-    std::string os_type = (is_running_on_arm64() && !NetworkAgent::use_legacy_network) ? "windows_arm" : "windows";
+    std::string os_type = (is_running_on_arm64() && !use_legacy_network_plugin()) ? "windows_arm" : "windows";
 #elif defined(__APPLE__)
     std::string os_type = "macos";
 #elif defined(__linux__)
@@ -1908,7 +1908,7 @@ bool GUI_App::check_networking_version()
     }
 
     std::string studio_ver;
-    if (NetworkAgent::use_legacy_network) {
+    if (use_legacy_network_plugin()) {
         studio_ver = BAMBU_NETWORK_AGENT_VERSION_LEGACY;
     } else if (app_config) {
         std::string user_version = app_config->get_network_plugin_version();
@@ -1928,6 +1928,11 @@ bool GUI_App::check_networking_version()
 
     m_networking_compatible = false;
     return false;
+}
+
+bool GUI_App::use_legacy_network_plugin() const
+{
+    return app_config && BBLNetworkPlugin::is_legacy_version(app_config->get_network_plugin_version());
 }
 
 bool GUI_App::is_compatibility_version()
@@ -3024,9 +3029,8 @@ bool GUI_App::on_init_inner()
 
     // Orca: select network plugin version based on configured version string
     std::string configured_version = app_config->get_network_plugin_version();
-    NetworkAgent::use_legacy_network = (configured_version == BAMBU_NETWORK_AGENT_VERSION_LEGACY);
     BOOST_LOG_TRIVIAL(info) << "Network plugin mode: "
-        << (NetworkAgent::use_legacy_network ? ("legacy (version: " + std::string(BAMBU_NETWORK_AGENT_VERSION_LEGACY) + ")") : ("modern (version: " + configured_version + ")"));
+        << (use_legacy_network_plugin() ? ("legacy (version: " + std::string(BAMBU_NETWORK_AGENT_VERSION_LEGACY) + ")") : ("modern (version: " + configured_version + ")"));
     // Force legacy network plugin if debugger attached
     // See https://github.com/bambulab/BambuStudio/issues/6726
     /* if (!NetworkAgent::use_legacy_network) {
@@ -3305,7 +3309,7 @@ void GUI_App::copy_network_if_available()
         fs::remove(network_library);
         BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << ": Copying network library from " << network_library << " to " << network_library_dst << " successfully.";
 
-        app_config->set(SETTING_NETWORK_PLUGIN_VERSION, cached_version);
+        app_config->set_network_plugin_version(cached_version);
         app_config->save();
     }
 
@@ -3370,7 +3374,7 @@ bool GUI_App::on_init_network(bool try_backup)
                 if (config_base != loaded_version) {
                     BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << ": syncing config version from " << config_version << " to loaded "
                                             << loaded_version;
-                    app_config->set(SETTING_NETWORK_PLUGIN_VERSION, loaded_version);
+                    app_config->set_network_plugin_version(loaded_version);
                     app_config->save();
                 }
             }
@@ -3496,7 +3500,7 @@ bool GUI_App::on_init_network(bool try_backup)
             m_user_manager = new Slic3r::UserManager();
     }
 
-    if (should_load_networking_plugin && m_networking_compatible && !NetworkAgent::use_legacy_network) {
+    if (should_load_networking_plugin && m_networking_compatible && !use_legacy_network_plugin()) {
         app_config->clear_remind_network_update_later();
 
         if (has_network_update_available()) {

--- a/src/slic3r/GUI/GUI_App.hpp
+++ b/src/slic3r/GUI/GUI_App.hpp
@@ -742,6 +742,7 @@ public:
     int             install_plugin(std::string name, std::string package_name, InstallProgressFn pro_fn = nullptr, WasCancelledFn cancel_fn = nullptr);
     std::string     get_http_url(std::string country_code, std::string path = {});
     std::string     get_model_http_url(std::string country_code);
+    bool            use_legacy_network_plugin() const;
     bool            is_compatibility_version();
     bool            check_networking_version();
     void            cancel_networking_install();

--- a/src/slic3r/GUI/MediaPlayCtrl.cpp
+++ b/src/slic3r/GUI/MediaPlayCtrl.cpp
@@ -7,7 +7,7 @@
 #include "I18N.hpp"
 #include "MsgDialog.hpp"
 #include "DownloadProgressDialog.hpp"
-#include "slic3r/Utils/NetworkAgent.hpp"
+#include "slic3r/Utils/BBLNetworkPlugin.hpp"
 
 
 #include <boost/lexical_cast.hpp>
@@ -161,7 +161,7 @@ void MediaPlayCtrl::SetMachineObject(MachineObject* obj)
         m_device_busy    = obj->is_camera_busy_off();
         m_tutk_state     = obj->tutk_state;
 
-        if (DevPrinterConfigUtil::get_printer_series_str(obj->printer_type) == "series_o" && NetworkAgent::use_legacy_network) {
+        if (DevPrinterConfigUtil::get_printer_series_str(obj->printer_type) == "series_o" && BBLNetworkPlugin::instance().use_legacy_network()) {
             // Legacy plugin cannot support remote play for H2D, force using local mode
             m_remote_proto = MachineObject::LVR_None;
         }

--- a/src/slic3r/GUI/Preferences.cpp
+++ b/src/slic3r/GUI/Preferences.cpp
@@ -1251,26 +1251,17 @@ wxBoxSizer *PreferencesDialog::create_item_network_plugin_version(wxString title
                 old_version = get_latest_network_version();
             }
 
-            app_config->set(SETTING_NETWORK_PLUGIN_VERSION, new_version);
+            app_config->set_network_plugin_version(new_version);
             app_config->save();
 
             if (new_version != old_version) {
                 BOOST_LOG_TRIVIAL(info) << "Network plugin version changed from " << old_version << " to " << new_version;
 
-                // Update the use_legacy_network flag immediately
-                bool is_legacy = (new_version == BAMBU_NETWORK_AGENT_VERSION_LEGACY);
-                bool was_legacy = (old_version == BAMBU_NETWORK_AGENT_VERSION_LEGACY);
-                if (is_legacy != was_legacy) {
-                    Slic3r::NetworkAgent::use_legacy_network = is_legacy;
-                    BOOST_LOG_TRIVIAL(info) << "Updated use_legacy_network flag to " << is_legacy;
-                }
-
                 if (!selected_ver.warning.empty()) {
                     MessageDialog warn_dlg(this, wxString::FromUTF8(selected_ver.warning), _L("Warning"), wxOK | wxCANCEL | wxICON_WARNING);
                     if (warn_dlg.ShowModal() != wxID_OK) {
-                        app_config->set(SETTING_NETWORK_PLUGIN_VERSION, old_version);
+                        app_config->set_network_plugin_version(old_version);
                         app_config->save();
-                        Slic3r::NetworkAgent::use_legacy_network = was_legacy;
                         e.Skip();
                         return;
                     }

--- a/src/slic3r/Utils/BBLNetworkPlugin.cpp
+++ b/src/slic3r/Utils/BBLNetworkPlugin.cpp
@@ -79,7 +79,7 @@ int BBLNetworkPlugin::initialize(bool using_backup, const std::string& version)
 
     // Auto-migration: If loading legacy version and versioned library doesn't exist,
     // but unversioned legacy library does exist, copy it to versioned format
-    if (version == BAMBU_NETWORK_AGENT_VERSION_LEGACY) {
+    if (is_legacy_version(version)) {
         boost::filesystem::path versioned_path;
         boost::filesystem::path legacy_path;
 #if defined(_MSC_VER) || defined(_WIN32)
@@ -162,12 +162,15 @@ int BBLNetworkPlugin::initialize(bool using_backup, const std::string& version)
     // Load all function pointers
     load_all_function_pointers();
 
-    // Sync legacy network flag from NetworkAgent (set during GUI_App initialization)
-    m_use_legacy_network = NetworkAgent::use_legacy_network;
+    // Sync legacy network flag from loaded plugin
+    m_use_legacy_network = is_legacy_version(version);
 
     std::string loaded_version;
     if (m_get_version) {
         loaded_version = m_get_version();
+        if (!loaded_version.empty()) {
+            m_use_legacy_network = is_legacy_version(loaded_version);
+        }
     }
 
     BOOST_LOG_TRIVIAL(info) << "BBLNetworkPlugin::initialize: legacy_mode="
@@ -207,6 +210,8 @@ int BBLNetworkPlugin::unload()
 #endif
 
     clear_all_function_pointers();
+
+    m_use_legacy_network = false;
 
     return 0;
 }
@@ -377,7 +382,7 @@ bool BBLNetworkPlugin::versioned_library_exists(const std::string& version)
 
     if (boost::filesystem::exists(path)) return true;
 
-    if (version == BAMBU_NETWORK_AGENT_VERSION_LEGACY) {
+    if (is_legacy_version(version)) {
         return legacy_library_exists();
     }
 

--- a/src/slic3r/Utils/BBLNetworkPlugin.hpp
+++ b/src/slic3r/Utils/BBLNetworkPlugin.hpp
@@ -266,6 +266,7 @@ public:
     // Legacy Network Flag
     // ========================================================================
 
+    static bool is_legacy_version(const std::string& version) { return version == BAMBU_NETWORK_AGENT_VERSION_LEGACY; }
     bool use_legacy_network() const { return m_use_legacy_network; }
     void set_use_legacy_network(bool legacy) { m_use_legacy_network = legacy; }
 
@@ -404,7 +405,7 @@ private:
     NetworkLibraryLoadError m_load_error;
 
     // Legacy network compatibility flag
-    bool m_use_legacy_network{true};
+    bool m_use_legacy_network{false};
 
     // Function pointers
     func_check_debug_consistent m_check_debug_consistent{nullptr};

--- a/src/slic3r/Utils/NetworkAgent.cpp
+++ b/src/slic3r/Utils/NetworkAgent.cpp
@@ -32,8 +32,6 @@ int invoke_on_all_cloud_agents(const std::map<std::string, std::shared_ptr<IClou
 
 } // namespace
 
-bool NetworkAgent::use_legacy_network = true;
-
 // ============================================================================
 // Static methods - delegate to BBLNetworkPlugin
 // ============================================================================

--- a/src/slic3r/Utils/NetworkAgent.hpp
+++ b/src/slic3r/Utils/NetworkAgent.hpp
@@ -36,7 +36,6 @@ public:
 #endif
     static std::string get_version();
     static void* get_network_function(const char* name);
-    static bool use_legacy_network;
 
     static NetworkLibraryLoadError get_load_error();
     static void clear_load_error();

--- a/src/slic3r/Utils/PresetUpdater.cpp
+++ b/src/slic3r/Utils/PresetUpdater.cpp
@@ -836,7 +836,7 @@ void PresetUpdater::priv::sync_plugins(std::string http_url, std::string plugin_
         BOOST_LOG_TRIVIAL(info) << "non need to sync plugins for there is no plugins currently.";
         return;
     }
-    std::string curr_version = NetworkAgent::use_legacy_network ? BAMBU_NETWORK_AGENT_VERSION_LEGACY : get_latest_network_version();
+    std::string curr_version = GUI::wxGetApp().use_legacy_network_plugin() ? BAMBU_NETWORK_AGENT_VERSION_LEGACY : get_latest_network_version();
     std::string using_version = curr_version.substr(0, 9) + "00";
 
     std::string cached_version;
@@ -931,7 +931,7 @@ void PresetUpdater::priv::sync_plugins(std::string http_url, std::string plugin_
     }
 
 #if defined(__WINDOWS__)
-    if (GUI::wxGetApp().is_running_on_arm64() && !NetworkAgent::use_legacy_network) {
+    if (GUI::wxGetApp().is_running_on_arm64() && !GUI::wxGetApp().use_legacy_network_plugin()) {
         //set to arm64 for plugins
         std::map<std::string, std::string> current_headers = Slic3r::Http::get_extra_headers();
         current_headers["X-BBL-OS-Type"] = "windows_arm";
@@ -951,7 +951,7 @@ void PresetUpdater::priv::sync_plugins(std::string http_url, std::string plugin_
         BOOST_LOG_TRIVIAL(warning) << format("[Orca Updater] sync_plugins: %1%", e.what());
     }
 #if defined(__WINDOWS__)
-    if (GUI::wxGetApp().is_running_on_arm64() && !NetworkAgent::use_legacy_network) {
+    if (GUI::wxGetApp().is_running_on_arm64() && !GUI::wxGetApp().use_legacy_network_plugin()) {
         //set back
         std::map<std::string, std::string> current_headers = Slic3r::Http::get_extra_headers();
         current_headers["X-BBL-OS-Type"] = "windows";


### PR DESCRIPTION
# Description

There is a bug that if user used to use legacy plugin, the `NetworkAgent::use_legacy_network` will not be properly reset after user install a newer plugin version through the plugin update dialog (ie, not from selecting a plugin version from Preference screen). And in that case Orca will download the legacy plugin but instead installing it with a newer version suffix. So on next start up Orca can't find the plugin because it tries to load using legacy version suffix instead.

This PR fixes it by getting rid of that error-prone static variable, instead it always use the version number directly.

Fix #14373
Fix #14441

# Screenshots/Recordings/Graphs

<!--
> Please attach relevant screenshots to showcase the UI changes.
> Please attach images that can help explain the changes.
-->

## Tests

<!--
> Please describe the tests that you have conducted to verify the changes made in this PR.
-->

<!--
> A guide for users on how to download the artifacts from this PR.
-->

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
