### PR TITLE
fix(gui): startup crash in clang/LLVM builds, null pointer UB in create_scaled_bitmap

### DIFF
--- a/src/slic3r/GUI/wxExtensions.cpp
+++ b/src/slic3r/GUI/wxExtensions.cpp
@@ -436,7 +436,9 @@ wxBitmap create_scaled_bitmap(  const std::string& bmp_name_in,
         return create_scaled_bitmap2(bmp_name_in, cache, win, px_cnt, grayscale, resize, array_new_color);
     }
     unsigned int width = 0;
-    unsigned int height = (unsigned int) (win->FromDIP(px_cnt) + 0.5f);
+    // win may be nullptr; use the static overload, which falls back to the primary display DPI.
+    // Calling win->FromDIP() on a null win is UB and lets the optimizer drop later null checks.
+    unsigned int height = (unsigned int) (wxWindow::FromDIP(px_cnt, win) + 0.5f);
 
     std::string bmp_name = bmp_name_in;
     boost::replace_last(bmp_name, ".png", "");
@@ -450,7 +452,7 @@ wxBitmap create_scaled_bitmap(  const std::string& bmp_name_in,
     // Try loading an SVG first, then PNG if SVG was not found:
     wxBitmap *bmp = cache.load_svg(bmp_name, width, height, grayscale, dark_mode, new_color, resize ? em_unit(win) * 0.1f : 0.f);
     if (bmp == nullptr) {
-        bmp = cache.load_png(bmp_name, width, height, grayscale, resize ? win->FromDIP(10) * 0.1f : 0.f);
+        bmp = cache.load_png(bmp_name, width, height, grayscale, resize ? wxWindow::FromDIP(10, win) * 0.1f : 0.f);
     }
 
     if (bmp == nullptr) {
@@ -471,7 +473,8 @@ wxBitmap create_scaled_bitmap2(const std::string& bmp_name_in, Slic3r::GUI::Bitm
     const vector<std::string>& array_new_color/* = vector<std::string>()*/) // color witch will used instead of orange
 {
     unsigned int width = 0;
-    unsigned int height = (unsigned int)(win->FromDIP(px_cnt) + 0.5f);
+    // win may be nullptr; see create_scaled_bitmap() above.
+    unsigned int height = (unsigned int)(wxWindow::FromDIP(px_cnt, win) + 0.5f);
 
     std::string bmp_name = bmp_name_in;
     boost::replace_last(bmp_name, ".png", "");


### PR DESCRIPTION
## Description

`create_scaled_bitmap()` is documented to accept `win == nullptr` (and is called
that way, e.g. `BBLTopbar.cpp` and `create_menu_bitmap()`), but it called
`win->FromDIP(px_cnt)` on that pointer. Calling a member function through a null
pointer is undefined behavior.

On MSVC this happened to work, because the member `FromDIP()` just forwards
`this` to the static `wxWindow::FromDIP(d, w)`, which handles a null window.
Under clang/LLVM, however, the compiler is allowed to assume `this` is non-null
at the call site. It then propagates that assumption forward and deletes the
`win ?` null check introduced in #13117:

    bmp->SetScaleFactor(win ? win->GetDPIScaleFactor() : (wxWindow::FromDIP(100, nullptr) / 100.0));

This turns it into an unconditional virtual call `win->GetDPIScaleFactor()`, a
vtable load from address 0x0. Result: clang-cl builds crash on startup with
`Access violation reading location 0x00000000` while creating the top bar
(first `create_scaled_bitmap("topbar_file", nullptr, ...)` call).

Two things narrow the blast radius:

- It manifests in any build compiled at `/O2` or above, where clang performs
  the null check elimination. Unoptimized builds keep the check and do not
  crash, which makes the bug easy to miss.
- It only affects Windows builds compiled with clang-cl (toolchain support
  proposed in #14375). The affected line lives inside an `#ifdef __WXMSW__`
  block, so Linux and macOS builds never execute it, and MSVC does not exploit
  this UB. Still, the UB is there for any compiler and is worth fixing at the
  source.

## Fix

Replace the member calls with the static, null-safe overload
`wxWindow::FromDIP(x, win)`, which falls back to the primary display DPI when
`win` is null, which is the exact behavior MSVC builds already had. Applied in
`create_scaled_bitmap()` (two call sites) and `create_scaled_bitmap2()`.

No behavior change for non-null windows, no profile/format impact.

## Verification

- Before: clang-cl (VS 2026 LLVM toolchain, /O2) build crashed on startup,
  LLDB confirmed frame `create_scaled_bitmap` at `wxExtensions.cpp:464` with
  `win == NULL`. Unoptimized builds of the same toolchain do not crash.
- After: same build starts normally, main window opens; MSVC builds unaffected.
