### PR TITLE
fix: crash in Measure tool when a plain edge is the first selection

### DIFF
--- a/src/slic3r/GUI/Gizmos/GLGizmoMeasure.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoMeasure.cpp
@@ -91,9 +91,14 @@ Vec3d GLGizmoMeasure::get_feature_offset(const Measure::SurfaceFeature &feature)
     }
     case Measure::SurfaceFeatureType::Edge:
     {
-        std::optional<Vec3d> p = feature.get_extra_point();
-        assert(p.has_value());
-        ret = *p;
+        // Only polygon edges store an extra point (the polygon centre); plain edges have none.
+        const std::optional<Vec3d> extra = feature.get_extra_point();
+        if (extra.has_value())
+            ret = *extra;
+        else {
+            const auto [pt1, pt2] = feature.get_edge();
+            ret = 0.5 * (pt1 + pt2);
+        }
         break;
     }
     case Measure::SurfaceFeatureType::Point:
@@ -1065,7 +1070,7 @@ void GLGizmoMeasure::on_render()
 
         if (requires_raycaster_update) {
             if (m_gripper_id_raycast_map.find(GripperType::SPHERE_2) != m_gripper_id_raycast_map.end()) {
-                m_gripper_id_raycast_map[GripperType::SPHERE_2]->set_transform(Geometry::translation_transform(get_feature_offset(*m_selected_features.first.feature)) *
+                m_gripper_id_raycast_map[GripperType::SPHERE_2]->set_transform(Geometry::translation_transform(get_feature_offset(*m_selected_features.second.feature)) *
                                                                                Geometry::scale_transform(inv_zoom));
             }
         }


### PR DESCRIPTION
## Description

Fixes #14018. Selecting a straight non-polygon edge as the first Measure feature, then a second feature, crashes the tool.

The second feature's gripper raycaster called `get_feature_offset()` on `.first.feature` instead of `.second.feature`. Plain planar-border edges store no extra point, so the `Edge` branch dereferenced an empty `std::optional` behind a release-stripped `assert`, which aborts on Flatpak and is undefined behavior elsewhere.

Fixed by pointing the `SPHERE_2` raycaster at `.second.feature` and falling the `Edge` branch back to the edge midpoint.

## Tests

No headless hook for the gizmo render path (like #14499). Verified manually with the reporter's project file. The crash path fires before the fix and not after, and behavior otherwise matches 2.4.1.
