### PR TITLE
fix: preserve PA batch speed and accel overrides

### DIFF
--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -253,18 +253,6 @@ static void set_config_values(DynamicPrintConfig *config, const std::string &key
     }
 }
 
-template <typename T, typename OptionType>
-static void set_config_values(ModelConfig& config, const std::string &key, T value)
-{
-    auto config_opt = config.get().option<OptionType>(key);
-    if (config_opt) {
-        config.set_key_value(key, new OptionType(config_opt->values.size(), value));
-    }
-    else {
-        BOOST_LOG_TRIVIAL(info) << "set_config_values: the key" << key << "is empty.";
-    }
-}
-
 bool Plater::has_illegal_filename_characters(const wxString& wxs_name)
 {
     std::string name = into_u8(wxs_name);
@@ -13325,7 +13313,7 @@ void Plater::calib_max_vol_speed(const Calib_Params& params)
     set_config_values<double, ConfigOptionFloats>(filament_config, "filament_max_volumetric_speed", 200);
     filament_config->set_key_value("slow_down_layer_time", new ConfigOptionFloats{0.0});
     printer_config->set_key_value("resonance_avoidance", new ConfigOptionBool{false});
-    set_config_values<bool, ConfigOptionBoolsNullable>(obj_cfg, "enable_overhang_speed", false);
+    obj_cfg.set_key_value("enable_overhang_speed", new ConfigOptionBoolsNullable(1, false));
     obj_cfg.set_key_value("wall_loops", new ConfigOptionInt(1));
     obj_cfg.set_key_value("alternate_extra_wall", new ConfigOptionBool(false));
     obj_cfg.set_key_value("top_shell_layers", new ConfigOptionInt(0));

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -12901,9 +12901,9 @@ void Plater::_calib_pa_pattern(const Calib_Params& params)
 
         auto &obj_config = obj->config;
         if (speeds.size() > 1)
-            set_config_values<double, ConfigOptionFloatsNullable>(obj_config, "outer_wall_speed", tspd);
+            obj_config.set_key_value("outer_wall_speed", new ConfigOptionFloatsNullable(1, tspd));
         if (accels.size() > 1)
-            set_config_values<double, ConfigOptionFloatsNullable>(obj_config, "outer_wall_acceleration", tacc);
+            obj_config.set_key_value("outer_wall_acceleration", new ConfigOptionFloatsNullable(1, tacc));
 
         auto cur_plate = get_partplate_list().get_plate(plate_idx);
         if (!cur_plate) {


### PR DESCRIPTION
# Description

Allows for batch speed and accels in PA calibration, fixing a commit that previously broke this functionality.

Fixes #14539 

This commit altered this behavior: https://github.com/OrcaSlicer/OrcaSlicer/commit/981cd599d50d1ba839f3f921a4ced83174885265

As part of this PR: https://github.com/OrcaSlicer/OrcaSlicer/pull/13712

# Screenshots/Recordings/Graphs

See issue #14539 for examples of how this works in nightly and on main currently.

With this fix in place, batch speeds and accels in PA calibration generate properly.

<img width="324" height="446" alt="Screenshot 2026-07-02 at 2 59 49 PM" src="https://github.com/user-attachments/assets/d6bfcdaf-c27a-4a05-86d5-7b3a58b1cf6c" />
<img width="976" height="852" alt="Screenshot 2026-07-02 at 2 59 39 PM" src="https://github.com/user-attachments/assets/04047c15-467f-4906-9895-1a9da5d37da3" />


## Tests

See screenshots above.

<!--
> A guide for users on how to download the artifacts from this PR.
-->

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
