### PR TITLE
Add copy/paste for variable layer height profiles

### DIFF
--- a/src/slic3r/GUI/GUI_Factories.cpp
+++ b/src/slic3r/GUI/GUI_Factories.cpp
@@ -1023,6 +1023,17 @@ void MenuFactory::append_menu_item_replace_all_with_stl(wxMenu *menu)
         []() { return plater()->can_replace_all_with_stl(); }, m_parent);
 }
 
+void MenuFactory::append_menu_items_variable_layer_height(wxMenu* menu)
+{
+    append_menu_item(menu, wxID_ANY, _L("Copy Variable Layer Height"), _L("Copy the selected object's variable layer height profile"),
+        [](wxCommandEvent&) { obj_list()->copy_variable_layer_height_profile_to_clipboard(); }, "", menu,
+        []() { return obj_list()->can_copy_variable_layer_height_profile(); }, m_parent);
+
+    append_menu_item(menu, wxID_ANY, _L("Paste Variable Layer Height to Selected Objects"), _L("Paste the copied variable layer height profile to selected objects"),
+        [](wxCommandEvent&) { obj_list()->paste_variable_layer_height_profile_to_selection(); }, "", menu,
+        []() { return obj_list()->can_paste_variable_layer_height_profile(); }, m_parent);
+}
+
 void MenuFactory::append_menu_item_change_extruder(wxMenu* menu)
 {
     // BBS
@@ -1463,6 +1474,7 @@ void MenuFactory::create_extra_object_menu()
     //append_menu_item_fill_bed(&m_object_menu);
     // Object Clone
     append_menu_item_clone(&m_object_menu);
+    append_menu_items_variable_layer_height(&m_object_menu);
     // Object Repair
     append_menu_item_fix_through_cgal(&m_object_menu);
     // Object Simplify
@@ -1824,6 +1836,7 @@ void MenuFactory::init(wxWindow* parent)
 
     // create "Instance to Object" menu item
     append_menu_item_instance_to_object(&m_instance_menu);
+    append_menu_items_variable_layer_height(&m_instance_menu);
 }
 
 void MenuFactory::update()
@@ -1929,6 +1942,8 @@ wxMenu* MenuFactory::multi_selection_menu()
             append_menu_item_merge_to_multipart_object(menu);
             index++;
         }
+        append_menu_items_variable_layer_height(menu);
+        menu->AppendSeparator();
         append_menu_item_center(menu);
         append_menu_item_drop(menu);
         append_menu_item_fix_through_cgal(menu);
@@ -1954,6 +1969,8 @@ wxMenu* MenuFactory::multi_selection_menu()
         append_menu_item_export_drc(menu, true);
     }
     else {
+        append_menu_items_variable_layer_height(menu);
+        menu->AppendSeparator();
         append_menu_item_center(menu);
         append_menu_item_drop(menu);
         append_menu_item_fix_through_cgal(menu);

--- a/src/slic3r/GUI/GUI_Factories.hpp
+++ b/src/slic3r/GUI/GUI_Factories.hpp
@@ -146,6 +146,7 @@ private:
     void        append_menu_item_reload_from_disk(wxMenu* menu);
     void        append_menu_item_replace_with_stl(wxMenu* menu);
     void        append_menu_item_replace_all_with_stl(wxMenu* menu);
+    void        append_menu_items_variable_layer_height(wxMenu* menu);
     void        append_menu_item_change_extruder(wxMenu* menu);
     void        append_menu_item_set_visible(wxMenu* menu);
     void        append_menu_item_delete(wxMenu* menu);

--- a/src/slic3r/GUI/GUI_ObjectList.cpp
+++ b/src/slic3r/GUI/GUI_ObjectList.cpp
@@ -1347,6 +1347,86 @@ void ObjectList::copy_settings_to_clipboard()
     m_clipboard.set_type(ItemType(m_objects_model->GetItemType(item) | itSettings));
 }
 
+void ObjectList::get_selected_object_idxs(std::vector<int>& obj_idxs) const
+{
+    wxDataViewItemArray sels;
+    GetSelections(sels);
+    if (sels.IsEmpty() || m_objects_model == nullptr || m_objects == nullptr)
+        return;
+
+    std::set<int> unique_obj_idxs;
+    for (const wxDataViewItem& item : sels) {
+        const int obj_idx = m_objects_model->GetObjectIdByItem(item);
+        if (obj_idx >= 0 && obj_idx < int(m_objects->size()) && (*m_objects)[obj_idx] != nullptr)
+            unique_obj_idxs.insert(obj_idx);
+    }
+
+    obj_idxs.assign(unique_obj_idxs.begin(), unique_obj_idxs.end());
+}
+
+bool ObjectList::can_copy_variable_layer_height_profile() const
+{
+    if (printer_technology() != ptFFF || GetSelectedItemsCount() != 1 || m_objects_model == nullptr || m_objects == nullptr)
+        return false;
+
+    const wxDataViewItem item = GetSelection();
+    const int obj_idx = item ? m_objects_model->GetObjectIdByItem(item) : -1;
+    if (obj_idx < 0 || obj_idx >= int(m_objects->size()) || (*m_objects)[obj_idx] == nullptr)
+        return false;
+
+    return (*m_objects)[obj_idx]->layer_height_profile.get().size() > 4;
+}
+
+bool ObjectList::can_paste_variable_layer_height_profile() const
+{
+    if (printer_technology() != ptFFF || m_variable_layer_height_profile_clipboard.size() <= 4)
+        return false;
+
+    std::vector<int> obj_idxs;
+    get_selected_object_idxs(obj_idxs);
+    return !obj_idxs.empty();
+}
+
+void ObjectList::copy_variable_layer_height_profile_to_clipboard()
+{
+    if (!can_copy_variable_layer_height_profile())
+        return;
+
+    const int obj_idx = m_objects_model->GetObjectIdByItem(GetSelection());
+    m_variable_layer_height_profile_clipboard = (*m_objects)[obj_idx]->layer_height_profile.get();
+}
+
+void ObjectList::paste_variable_layer_height_profile_to_selection()
+{
+    if (!can_paste_variable_layer_height_profile())
+        return;
+
+    std::vector<int> obj_idxs;
+    get_selected_object_idxs(obj_idxs);
+    if (obj_idxs.empty())
+        return;
+
+    std::vector<size_t> changed_obj_idxs;
+    for (int obj_idx : obj_idxs) {
+        ModelObject* model_object = object(obj_idx);
+        if (model_object != nullptr && model_object->layer_height_profile.get() != m_variable_layer_height_profile_clipboard)
+            changed_obj_idxs.emplace_back(size_t(obj_idx));
+    }
+
+    if (changed_obj_idxs.empty())
+        return;
+
+    take_snapshot("Paste variable layer height profile");
+
+    for (size_t obj_idx : changed_obj_idxs) {
+        ModelObject* model_object = object(int(obj_idx));
+        model_object->layer_height_profile.set(m_variable_layer_height_profile_clipboard);
+        update_info_items(obj_idx);
+    }
+
+    wxGetApp().plater()->changed_objects(changed_obj_idxs);
+}
+
 bool GUI::ObjectList::can_paste_settings_into_list()
 {
     wxDataViewItemArray sels;

--- a/src/slic3r/GUI/GUI_ObjectList.hpp
+++ b/src/slic3r/GUI/GUI_ObjectList.hpp
@@ -126,6 +126,7 @@ private:
     int             m_selected_layers_range_idx {-1};
 
     Clipboard       m_clipboard;
+    std::vector<coordf_t> m_variable_layer_height_profile_clipboard;
 
     struct dragged_item_data
     {
@@ -447,6 +448,10 @@ public:
     void copy_settings_to_clipboard();
     void paste_settings_into_list();
     bool can_paste_settings_into_list();
+    bool can_copy_variable_layer_height_profile() const;
+    bool can_paste_variable_layer_height_profile() const;
+    void copy_variable_layer_height_profile_to_clipboard();
+    void paste_variable_layer_height_profile_to_selection();
     bool clipboard_is_empty() const { return m_clipboard.empty(); }
     void paste_volumes_into_list(int obj_idx, const ModelVolumePtrs& volumes);
     void paste_objects_into_list(const std::vector<size_t>& object_idxs);
@@ -487,6 +492,7 @@ private:
 #endif /* __WXOSX__ */
     void OnContextMenu(wxDataViewEvent &event);
     void list_manipulation(const wxPoint& mouse_pos, bool evt_context_menu = false);
+    void get_selected_object_idxs(std::vector<int>& obj_idxs) const;
 
     // BBS
     void update_name_column_width() const;


### PR DESCRIPTION
# Description

Adds object-level Copy/Paste actions for Variable Layer Height profiles.

This PR allows users to copy an existing `ModelObject::layer_height_profile` from one object and paste it to other selected objects without assembling or merging them.

This addresses the current workflow limitation where users often need to use **Assemble** to apply the same Variable Layer Height profile across multiple objects. That workaround makes the objects behave as a single assembly and removes object-level flexibility.

## Changes

- Adds **Copy Variable Layer Height** action.
- Adds **Paste Variable Layer Height to Selected Objects** action.
- Stores the copied Variable Layer Height profile in `ObjectList`.
- Applies the copied profile only to selected objects whose current profile differs.
- Keeps objects separate and independent.
- Updates object list state after paste.
- Invalidates changed objects through the existing plater change flow.

## Scope

This PR does **not** change the Adaptive Layer Height algorithm.

This PR does **not** change slicing logic, Prime Tower behavior, object assembly, object merging, materials, transforms, extruders, or process settings.

It only exposes an existing object-level profile copy workflow through the UI.

# Screenshots/Recordings/Graphs

No screenshots attached yet.

UI entries added:

- Object context menu:
  - `Copy Variable Layer Height`
  - `Paste Variable Layer Height to Selected Objects`

- Multi-selection context menu:
  - `Paste Variable Layer Height to Selected Objects`

# Tests

Manual validation planned with PR artifact:

- Add two separate objects.
- Apply Variable Layer Height to object A.
- Use `Copy Variable Layer Height` on object A.
- Select object B.
- Use `Paste Variable Layer Height to Selected Objects`.
- Slice and verify both objects show the same Layer Height profile in Preview.
- Verify the objects remain separate.
- Verify transforms, materials, extruders, and process settings are unchanged.
- Test multi-object paste.
- Test Undo/Redo after paste.
- Save as `.3mf`, reopen, and verify the pasted Variable Layer Height profile persists.

Local validation already done:

- `git diff --check`
- Diff confirmed limited to 4 files:
  - `src/slic3r/GUI/GUI_Factories.cpp`
  - `src/slic3r/GUI/GUI_Factories.hpp`
  - `src/slic3r/GUI/GUI_ObjectList.cpp`
  - `src/slic3r/GUI/GUI_ObjectList.hpp`

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)