### PR TITLE
Preserve disabled filament overrides (nil) through cloud sync

### DIFF
--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -1857,6 +1857,26 @@ int PresetCollection::get_differed_values_to_update(Preset& preset, std::map<std
             if (opt_src)
                 key_values[option] = opt_src->serialize();
         }
+
+        // Orca: force-emit nullable filament override keys whenever they hold a nil ("off")
+        // value, even when the diff dropped them because the parent is nil too. Otherwise the
+        // key is absent from the synced profile and the cloud re-materializes it against the
+        // option's non-nil default (e.g. filament_retract_before_wipe -> 100%), silently
+        // resurrecting an override the user turned off. See GitHub issue on Retract Before Wipe.
+        if (m_type == Preset::TYPE_FILAMENT) {
+            for (const std::string& opt_key : filament_extruder_override_keys) {
+                if (key_values.count(opt_key))
+                    continue; // already carried by the diff
+                const auto* opt_vec = dynamic_cast<const ConfigOptionVectorBase*>(preset.config.option(opt_key));
+                if (opt_vec == nullptr)
+                    continue;
+                bool has_nil = false;
+                for (size_t i = 0; i < opt_vec->size(); ++i)
+                    if (opt_vec->is_nil(i)) { has_nil = true; break; }
+                if (has_nil)
+                    key_values[opt_key] = opt_vec->serialize();
+            }
+        }
     }
     else {
         for (auto iter = preset.config.cbegin(); iter != preset.config.cend(); ++iter)


### PR DESCRIPTION
# Description

Disabling a filament override such as **Retract Before Wipe** does not survive
cloud sync. After syncing/restarting, the toggle is forced back ON and the value
resets to its default (100%). Reported by users; reproducible on brand-new
filament profiles.

## Root cause

Filament override keys (`filament_extruder_override_keys`) are *nullable*: the
"off" state is stored as `nil`, not a boolean. `filament_retract_before_wipe` is
a `coPercents` option whose hardcoded default is **100%**, and system presets
ship it as `["nil"]` (off by default).

User presets upload only the **diff against their parent**
(`PresetCollection::get_differed_values_to_update`). When the user's "off" value
equals the parent's `nil`, the key produces no diff and is omitted from the
synced profile. The cloud then re-materializes the absent key against the
option's non-nil default (100%), silently resurrecting an override the user
turned off.

This is why the known workaround - leaving the toggle ON with the percentage at
`0%` - survives: `0%` differs from the parent `nil`, so it becomes a real diff
and is uploaded.

The local save/load path already preserves `nil` correctly (guarded in
`extend_default_config_length` via `filament_extruder_override_keys`), so the
default-resurrection happens on the cloud side when the key is absent.

## Fix

In `get_differed_values_to_update`, for filament presets, force-emit any
`filament_extruder_override_keys` option that contains a `nil` entry - even when
the diff dropped it because the parent is `nil` too. The synced profile now
always carries an explicit `"nil"`, so a disabled override can no longer fall
back to the default.

- Scoped to `TYPE_FILAMENT` and the ~16 override keys only.
- Uses the read-only config accessor (`create = false`); no config mutation.
- Handles multi-extruder partial-nil vectors (emits if any entry is `nil`).

## Related issues
Fixes #13943
