### PR TITLE
Implement plugin sorting functionality

### DIFF
--- a/resources/web/dialog/PluginsDialog/index.html
+++ b/resources/web/dialog/PluginsDialog/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Plugins</title>
   <link rel="stylesheet" href="./styles.css" />
+  <link rel="stylesheet" href="./plugin-sort.css" />
   <link rel="stylesheet" type="text/css" href="../../include/global.css" />
   <link rel="stylesheet" type="text/css" href="../css/common.css" />
   <link rel="stylesheet" type="text/css" href="../css/dark.css" />
@@ -14,6 +15,7 @@
   <script type="text/javascript" src="../js/globalapi.js"></script>
   <script type="text/javascript" src="../js/common.js"></script>
   <script src="./index.js"></script>
+  <script src="./plugin-sort.js"></script>
 </head>
 <body onLoad="OnInit()">
   <div class="app">
@@ -21,6 +23,45 @@
 <!--        <button id="open_terminal" class="ButtonStyleRegular ButtonTypeChoice left-btn">-->
 <!--            Open Terminal-->
 <!--        </button>-->
+      <div id="sortDropdown" class="sort-dropdown">
+        <button id="sort_menu_btn" class="ButtonStyleRegular ButtonTypeChoice sort-menu-btn" type="button"
+          aria-haspopup="true" aria-expanded="false" aria-controls="sortMenu" title="Sort plugins">
+          <svg class="sort-order-icon" viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor"
+            stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M2.5 4.5h3.5M2.5 8h5.5M2.5 11.5h7.5" />
+            <path d="M12.5 11.5V4.5M10 7l2.5-2.5L15 7" />
+          </svg>
+          <span id="sort_current_label"></span>
+          <span class="sort-caret" aria-hidden="true"></span>
+        </button>
+        <div id="sortMenu" class="sort-menu" role="menu" hidden>
+          <div class="sort-group-label" id="sortByLabel">Sort by</div>
+          <div role="group" aria-labelledby="sortByLabel">
+            <button type="button" class="sort-menu-item" role="menuitemradio" data-sort-field="status">Status</button>
+            <button type="button" class="sort-menu-item" role="menuitemradio" data-sort-field="name">Name</button>
+            <button type="button" class="sort-menu-item" role="menuitemradio" data-sort-field="source">Source</button>
+          </div>
+          <div class="sort-group-label" id="sortOrderLabel">Order</div>
+          <div role="group" aria-labelledby="sortOrderLabel">
+            <button type="button" class="sort-menu-item" role="menuitemradio" data-sort-order="asc">
+              <svg class="sort-order-icon" viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor"
+                stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <path d="M2.5 4.5h3.5M2.5 8h5.5M2.5 11.5h7.5" />
+                <path d="M12.5 11.5V4.5M10 7l2.5-2.5L15 7" />
+              </svg>
+              Ascending
+            </button>
+            <button type="button" class="sort-menu-item" role="menuitemradio" data-sort-order="desc">
+              <svg class="sort-order-icon desc" viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor"
+                stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <path d="M2.5 4.5h3.5M2.5 8h5.5M2.5 11.5h7.5" />
+                <path d="M12.5 11.5V4.5M10 7l2.5-2.5L15 7" />
+              </svg>
+              Descending
+            </button>
+          </div>
+        </div>
+      </div>
       <button id="refresh_btn" class="ButtonStyleRegular ButtonTypeChoice">
         Refresh
       </button>

--- a/resources/web/dialog/PluginsDialog/index.js
+++ b/resources/web/dialog/PluginsDialog/index.js
@@ -118,6 +118,10 @@ function ShowExploreMenu() {
   if (!exploreMenu || !exploreMenuButton)
     return;
 
+  // why: our stopPropagation blocks the outside-click handler, so close the sibling sort menu ourselves (mirror of ToggleSortMenu).
+  if (typeof HideSortMenu === "function")
+    HideSortMenu();
+
   exploreMenu.hidden = false;
   exploreMenuButton.setAttribute("aria-expanded", "true");
 }
@@ -214,6 +218,10 @@ function HandleStudio(value) {
 
   if (payload.command === "list_plugins") {
     SetSelectedInstallAction(payload.install_action, false);
+    if (typeof NormalizePluginSort === "function") {
+      pluginSort = NormalizePluginSort(payload.sort_key, payload.sort_order);
+      RenderSortMenuState();
+    }
     ApplyPlugins(payload.data || []);
   } else if (payload.command === "status_message") {
     ShowStatusMessage(String(payload.message || ""), String(payload.level || "info"));

--- a/resources/web/dialog/PluginsDialog/plugin-sort.css
+++ b/resources/web/dialog/PluginsDialog/plugin-sort.css
@@ -1,0 +1,89 @@
+/* why: isolate dropdown styling from the existing plugin dialog styles. */
+
+.sort-dropdown {
+  position: relative;
+  display: inline-flex;
+  margin-right: auto;
+}
+
+.sort-menu-btn {
+  height: 32px !important;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  /* why: global .ButtonTypeChoice adds margin-left:15px (dialog button rows); as the leftmost
+     toolbar item that stacks on .app's 8px padding - kill it like .explore-dropdown does. */
+  margin-left: 0 !important;
+}
+
+/* note: asc is bars growing downward + up arrow; a vertical flip yields the desc icon. */
+.sort-order-icon {
+  display: block;
+  flex: none;
+}
+
+.sort-menu-btn.order-desc .sort-order-icon,
+.sort-order-icon.desc {
+  transform: scaleY(-1);
+}
+
+.sort-caret {
+  width: 7px;
+  height: 7px;
+  border-right: 1.5px solid currentColor;
+  border-bottom: 1.5px solid currentColor;
+  transform: translateY(-2px) rotate(45deg);
+}
+
+.sort-menu {
+  position: absolute;
+  left: 0;
+  top: calc(100% + 2px);
+  z-index: 20;
+  min-width: 200px;
+  padding: 4px 0;
+  background: var(--main-color);
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.18);
+}
+
+.sort-menu[hidden] {
+  display: none !important;
+}
+
+.sort-group-label {
+  padding: 8px 10px 4px;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: rgba(255, 255, 255, 0.55);
+}
+
+.sort-menu-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 8px 10px 8px 28px; /* why: reserve space for the active-row checkmark. */
+  border: 0;
+  background: transparent;
+  color: #ffffff;
+  box-sizing: border-box;
+  text-align: left;
+  font: inherit;
+  cursor: pointer;
+  position: relative;
+}
+
+/* note: same tint as .explore-menu-item hover/.selected, so the two menus match */
+.sort-menu-item:hover,
+.sort-menu-item:focus-visible,
+.sort-menu-item[aria-checked="true"] {
+  outline: none;
+  background: rgba(255, 255, 255, 0.14);
+}
+
+.sort-menu-item[aria-checked="true"]::before {
+  content: "\2713"; /* note: checkmark on the active field/order. */
+  position: absolute;
+  left: 10px;
+}

--- a/resources/web/dialog/PluginsDialog/plugin-sort.js
+++ b/resources/web/dialog/PluginsDialog/plugin-sort.js
@@ -1,0 +1,90 @@
+// why: C++ owns ordering; this file only sends and reflects sort state.
+
+const DEFAULT_PLUGIN_SORT = { key: "status", order: "asc" };
+const SORT_FIELDS = new Set(["status", "name", "source"]);
+let pluginSort = { ...DEFAULT_PLUGIN_SORT };
+
+// why: C++ returns canonical sort state; guard stale or malformed values before reflecting them.
+function NormalizePluginSort(sortKey, sortOrder) {
+  const key = String(sortKey || "");
+  return {
+    key: SORT_FIELDS.has(key) ? key : DEFAULT_PLUGIN_SORT.key,
+    order: sortOrder === "desc" ? "desc" : DEFAULT_PLUGIN_SORT.order,
+  };
+}
+
+function RequestPluginSort(sortKey, sortOrder) {
+  pluginSort = NormalizePluginSort(sortKey, sortOrder);
+  RenderSortMenuState();
+
+  if (typeof SendMessage === "function")
+    SendMessage("set_plugin_sort", {
+      sort_key: pluginSort.key,
+      sort_order: pluginSort.order,
+    });
+}
+
+let sortMenuEl = null;
+let sortMenuButton = null;
+let sortCurrentLabel = null;
+
+function InitSortDropdown() {
+  sortMenuEl = document.getElementById("sortMenu");
+  sortMenuButton = document.getElementById("sort_menu_btn");
+  sortCurrentLabel = document.getElementById("sort_current_label");
+  if (!sortMenuButton || !sortMenuEl)
+    return;
+  sortMenuButton.addEventListener("click", ToggleSortMenu);
+  sortMenuEl.addEventListener("click", OnSortMenuClick);
+  RenderSortMenuState();
+}
+
+function ToggleSortMenu(event) {
+  event.preventDefault();
+  event.stopPropagation();
+  if (!sortMenuEl)
+    return;
+  const willShow = sortMenuEl.hidden;
+  // why: our stopPropagation blocks index.js's outside-click handler, so close the sibling explore menu ourselves.
+  if (willShow && typeof HideExploreMenu === "function")
+    HideExploreMenu();
+  sortMenuEl.hidden = !willShow;
+  sortMenuButton.setAttribute("aria-expanded", willShow ? "true" : "false");
+}
+
+function HideSortMenu() {
+  if (!sortMenuEl || sortMenuEl.hidden)
+    return;
+  sortMenuEl.hidden = true;
+  sortMenuButton.setAttribute("aria-expanded", "false");
+}
+
+function OnSortMenuClick(event) {
+  const item = event.target.closest("[data-sort-field],[data-sort-order]");
+  if (!item)
+    return;
+  event.preventDefault();
+  const sortKey = item.dataset.sortField || pluginSort.key;
+  const sortOrder = item.dataset.sortOrder || pluginSort.order;
+  // why: leave the menu open so the user can set field then order in one visit; outside-click/Escape close it.
+  RequestPluginSort(sortKey, sortOrder);
+}
+
+function RenderSortMenuState() {
+  const field = sortMenuEl?.querySelector(`[data-sort-field="${pluginSort.key}"]`);
+  if (sortCurrentLabel)
+    sortCurrentLabel.textContent = field?.textContent.trim() || "Status";
+  sortMenuButton?.classList.toggle("order-desc", pluginSort.order === "desc");
+  sortMenuEl?.querySelectorAll("[data-sort-field]").forEach((el) =>
+    el.setAttribute("aria-checked", el.dataset.sortField === pluginSort.key ? "true" : "false"));
+  sortMenuEl?.querySelectorAll("[data-sort-order]").forEach((el) =>
+    el.setAttribute("aria-checked", el.dataset.sortOrder === pluginSort.order ? "true" : "false"));
+}
+
+// why: guarded so the module can be loaded in headless syntax checks.
+// note: owns its own lifecycle + outside-click/Escape, so index.js's OnInit needs no edit.
+if (typeof document !== "undefined") {
+  document.addEventListener("DOMContentLoaded", InitSortDropdown);
+  document.addEventListener("click", (event) => { if (!event.target.closest(".sort-dropdown")) HideSortMenu(); });
+  document.addEventListener("keydown", (event) => { if (event.key === "Escape") HideSortMenu(); });
+}

--- a/src/slic3r/CMakeLists.txt
+++ b/src/slic3r/CMakeLists.txt
@@ -109,6 +109,9 @@ set(SLIC3R_GUI_SOURCES
     GUI/Downloader.hpp
     GUI/DownloadProgressDialog.cpp
     GUI/DownloadProgressDialog.hpp
+    GUI/PluginSource.hpp
+    GUI/PluginSort.hpp
+    GUI/PluginStatus.hpp
     GUI/PluginPickerDialog.cpp
     GUI/PluginPickerDialog.hpp
     GUI/PluginsDialog.cpp

--- a/src/slic3r/GUI/PluginSort.hpp
+++ b/src/slic3r/GUI/PluginSort.hpp
@@ -1,0 +1,175 @@
+#pragma once
+
+#include "PluginSource.hpp"
+#include "PluginStatus.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace Slic3r::GUI
+{
+    enum class PluginSortKey
+    {
+        Status,
+        Name,
+        Source
+    };
+
+    enum class PluginSortOrder
+    {
+        Asc,
+        Desc
+    };
+
+    inline std::string to_string(PluginSortKey sort_key)
+    {
+        switch (sort_key)
+        {
+        case PluginSortKey::Status: return "status";
+        case PluginSortKey::Name: return "name";
+        case PluginSortKey::Source: return "source";
+        }
+
+        return "status";
+    }
+
+    inline std::string to_string(PluginSortOrder sort_order)
+    {
+        return sort_order == PluginSortOrder::Desc ? "desc" : "asc";
+    }
+
+    inline PluginSortKey plugin_sort_key_from_string(const std::string& sort_key, PluginSortKey fallback)
+    {
+        if (sort_key == "status")
+            return PluginSortKey::Status;
+        if (sort_key == "name")
+            return PluginSortKey::Name;
+        if (sort_key == "source")
+            return PluginSortKey::Source;
+        return fallback;
+    }
+
+    inline PluginSortOrder plugin_sort_order_from_string(const std::string& sort_order, PluginSortOrder fallback)
+    {
+        if (sort_order == "asc")
+            return PluginSortOrder::Asc;
+        if (sort_order == "desc")
+            return PluginSortOrder::Desc;
+        return fallback;
+    }
+
+    // Natural, case-insensitive ASCII compare returning -1 / 0 / +1. Digit runs compare by
+    // numeric value; other chars compare lowercased; on a prefix tie the shorter string is less.
+    //   e.g. "item2"  < "item10"   (2 < 10, not '2' > '1')
+    //        "Camera" == "camera"  (case ignored)
+    //        "app"    < "apple"    (prefix is shorter)
+    //        "1"      < "01"       (equal value, fewer leading zeros wins the tie)
+    // note: ASCII only - no locale/Unicode; accented or non-Latin names fall back to byte order.
+    inline int compare_ascii_case_insensitive_natural(const std::string& lhs, const std::string& rhs)
+    {
+        std::size_t li = 0;
+        std::size_t ri = 0;
+
+        while (li < lhs.size() && ri < rhs.size())
+        {
+            const unsigned char lc = static_cast<unsigned char>(lhs[li]);
+            const unsigned char rc = static_cast<unsigned char>(rhs[ri]);
+
+            if (std::isdigit(lc) && std::isdigit(rc))
+            {
+                const std::size_t lhs_digit_begin = li;
+                const std::size_t rhs_digit_begin = ri;
+                while (li < lhs.size() && std::isdigit(static_cast<unsigned char>(lhs[li])))
+                    ++li;
+                while (ri < rhs.size() && std::isdigit(static_cast<unsigned char>(rhs[ri])))
+                    ++ri;
+
+                const std::string_view lhs_run(lhs.data() + lhs_digit_begin, li - lhs_digit_begin);
+                const std::string_view rhs_run(rhs.data() + rhs_digit_begin, ri - rhs_digit_begin);
+                // why: digit runs compare numerically; leading zeros only break exact ties ("1" < "01").
+                const std::string_view lhs_num = lhs_run.substr(std::min(lhs_run.find_first_not_of('0'), lhs_run.size()));
+                const std::string_view rhs_num = rhs_run.substr(std::min(rhs_run.find_first_not_of('0'), rhs_run.size()));
+                if (lhs_num.size() != rhs_num.size())
+                    return lhs_num.size() < rhs_num.size() ? -1 : 1;
+                if (const int cmp = lhs_num.compare(rhs_num); cmp != 0)
+                    return cmp;
+                // note: fewer-leading-zeros-first is our convention, not an industry standard (impls
+                //   diverge here); it only matters as a deterministic total order for unstable std::sort.
+                if (lhs_run.size() != rhs_run.size())
+                    return lhs_run.size() < rhs_run.size() ? -1 : 1;
+                continue;
+            }
+
+            const int lower_lhs = std::tolower(lc);
+            const int lower_rhs = std::tolower(rc);
+            if (lower_lhs != lower_rhs)
+                return lower_lhs < lower_rhs ? -1 : 1;
+
+            ++li;
+            ++ri;
+        }
+
+        if (li == lhs.size() && ri == rhs.size())
+            return 0;
+        return li == lhs.size() ? -1 : 1;
+    }
+
+    // Neutral baseline order used as the tie-breaker under every primary sort key. Always
+    // ascending: source priority, then type_key, then display_name, then plugin_key.
+    //   e.g. two items with equal Status sort by source priority (Mine, then Subscribed,
+    //        then Local), then by name.
+    template <class PluginItem>
+    int compare_plugin_base_order(const PluginItem& lhs, const PluginItem& rhs)
+    {
+        // why: source ties use the declared PluginSource ordinal priority - the same order the
+        //   Source sort key uses - so the neutral baseline never contradicts it.
+        if (const int cmp = static_cast<int>(lhs.source) - static_cast<int>(rhs.source); cmp != 0)
+            return cmp;
+        if (const int cmp = lhs.type_key.compare(rhs.type_key); cmp != 0)
+            return cmp;
+        if (const int cmp = lhs.display_name.compare(rhs.display_name); cmp != 0)
+            return cmp;
+        return lhs.plugin_key.compare(rhs.plugin_key);
+    }
+
+    // Compares two items by the chosen primary key, returning -1 / 0 / +1. Status and Source
+    // rank by enum ordinal (the declared dialog priority); Name uses the natural compare above.
+    //   e.g. Status: an enabled item (lower ordinal) sorts before a disabled one.
+    //        Name:   "Plugin 2" sorts before "Plugin 10".
+    template <class PluginItem>
+    int compare_plugin_sort_key(const PluginItem& lhs, const PluginItem& rhs, PluginSortKey sort_key)
+    {
+        switch (sort_key)
+        {
+        case PluginSortKey::Status:
+            // why: PluginStatus/PluginSource declare the dialog sort priority as their ordinal order.
+            return static_cast<int>(lhs.status) - static_cast<int>(rhs.status);
+        case PluginSortKey::Name:
+            return compare_ascii_case_insensitive_natural(lhs.display_name, rhs.display_name);
+        case PluginSortKey::Source:
+            return static_cast<int>(lhs.source) - static_cast<int>(rhs.source);
+        }
+
+        return 0;
+    }
+
+    // Sorts the dialog list in place by primary key + direction. Ties always fall back to the
+    // ascending base order, so the result is deterministic regardless of the primary direction.
+    //   e.g. sort_key=Name, order=Desc -> names Z..A, but equal names keep the stable base order.
+    template <class PluginItem>
+    void sort_plugin_items_for_dialog(std::vector<PluginItem>& items, PluginSortKey sort_key,
+                                      PluginSortOrder sort_order)
+    {
+        std::sort(items.begin(), items.end(),
+                  [sort_key, sort_order](const PluginItem& lhs, const PluginItem& rhs)
+                  {
+                      if (const int cmp = compare_plugin_sort_key(lhs, rhs, sort_key); cmp != 0)
+                          return sort_order == PluginSortOrder::Asc ? cmp < 0 : cmp > 0;
+                      // why: ties fall back to ascending base order regardless of the primary direction.
+                      return compare_plugin_base_order(lhs, rhs) < 0;
+                  });
+    }
+} // namespace Slic3r::GUI

--- a/src/slic3r/GUI/PluginSource.hpp
+++ b/src/slic3r/GUI/PluginSource.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <string>
+
+namespace Slic3r
+{
+    namespace GUI
+    {
+        enum class PluginSource
+        {
+            // IMPORTANT: ordinal order is the Plugins dialog Source sort priority.
+            Mine,
+            Subscribed,
+            Local
+        };
+
+        inline std::string to_string(PluginSource source)
+        {
+            switch (source)
+            {
+            case PluginSource::Mine: return "mine";
+            case PluginSource::Subscribed: return "subscribed";
+            case PluginSource::Local: return "local";
+            }
+
+            return "local";
+        }
+    }
+} // namespace Slic3r::GUI

--- a/src/slic3r/GUI/PluginStatus.hpp
+++ b/src/slic3r/GUI/PluginStatus.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <string>
+
+namespace Slic3r
+{
+    namespace GUI
+    {
+        enum class PluginStatus
+        {
+            // IMPORTANT: ordinal order is the Plugins dialog Status sort priority.
+            Activated,
+            Error,
+            Inactive,
+            Loading
+        };
+
+        inline std::string to_string(PluginStatus status)
+        {
+            switch (status)
+            {
+            case PluginStatus::Activated: return "Activated";
+            case PluginStatus::Error: return "Error";
+            case PluginStatus::Inactive: return "Inactive";
+            case PluginStatus::Loading: return "Loading";
+            }
+
+            return "Inactive";
+        }
+    }
+} // namespace Slic3r::GUI

--- a/src/slic3r/GUI/PluginsDialog.cpp
+++ b/src/slic3r/GUI/PluginsDialog.cpp
@@ -25,7 +25,6 @@
 #include <boost/log/trivial.hpp>
 
 #include <algorithm>
-#include <cctype>
 #include <memory>
 #include <mutex>
 #include <vector>
@@ -103,7 +102,7 @@ struct PluginDialogItem
     PluginUpdateStatus update_status = PluginUpdateStatus::Normal;
     std::string error_text;
     bool has_error = false;
-    bool loaded    = false;
+    bool is_loaded    = false;
     bool loading   = false;
 
     // Installation and capability flags
@@ -187,27 +186,62 @@ void refresh_plugin_catalog_blocking(bool fetch_cloud)
     }
 }
 
-std::string to_string(PluginSource source)
+std::string to_string(PluginUpdateStatus status);
+nlohmann::json build_context_actions_payload(const PluginAvailableActions& available_actions);
+
+nlohmann::json build_plugin_payload_item(const PluginDialogItem& dialog_item)
 {
-    switch (source) {
-    case PluginSource::Local: return "local";
-    case PluginSource::Mine: return "mine";
-    case PluginSource::Subscribed: return "subscribed";
+    nlohmann::json payload_item;
+    payload_item["plugin_key"]  = dialog_item.plugin_key;
+    payload_item["plugin_id"]   = dialog_item.plugin_id;
+    payload_item["name"]        = dialog_item.display_name;
+    payload_item["description"] = dialog_item.description;
+    payload_item["author"]      = dialog_item.author;
+    payload_item["version"]     = dialog_item.version;
+    payload_item["type"]        = dialog_item.type_label;
+    payload_item["type_key"]    = dialog_item.type_key;
+    payload_item["types"]       = dialog_item.type_labels;
+
+    nlohmann::json caps = nlohmann::json::array();
+    for (const PluginCapabilityView& capability : dialog_item.capabilities) {
+        nlohmann::json c;
+        c["name"]       = capability.name;
+        c["type"]       = capability.type_label;
+        c["type_key"]   = capability.type_key;
+        c["enabled"]    = capability.enabled;
+        c["can_toggle"] = capability.can_toggle;
+        c["can_run"]    = capability.can_run;
+        caps.push_back(std::move(c));
     }
+    payload_item["capabilities"] = std::move(caps);
 
-    return "local";
-}
-
-std::string to_string(PluginStatus status)
-{
-    switch (status) {
-    case PluginStatus::Inactive: return "Inactive";
-    case PluginStatus::Error: return "Error";
-    case PluginStatus::Loading: return "Loading";
-    case PluginStatus::Activated: return "Activated";
+    nlohmann::json changelog = nlohmann::json::array();
+    for (const PluginChangelogView& entry : dialog_item.changelog) {
+        nlohmann::json c;
+        c["version"]      = entry.version;
+        c["changelog"]    = entry.changelog;
+        c["created_time"] = entry.created_time;
+        changelog.push_back(std::move(c));
     }
+    payload_item["changelog"] = std::move(changelog);
 
-    return "Inactive";
+    payload_item["label"]                 = dialog_item.display_name;
+    payload_item["source"]                = to_string(dialog_item.source);
+    payload_item["status"]                = to_string(dialog_item.status);
+    payload_item["error"]                 = dialog_item.error_text;
+    payload_item["update_status"]         = to_string(dialog_item.update_status);
+    payload_item["unauthorized"]          = dialog_item.unauthorized;
+    payload_item["context_actions"]       = build_context_actions_payload(dialog_item.available_actions);
+    payload_item["update_available"]      = dialog_item.update_status == PluginUpdateStatus::UpdateAvailable;
+    payload_item["can_toggle"]            = dialog_item.available_actions.can_toggle;
+    payload_item["has_script_capability"] = dialog_item.has_script_capability;
+    payload_item["can_run_script"]        = dialog_item.can_run_script;
+    payload_item["sharing_token"]         = dialog_item.sharing_token;
+    payload_item["thumbnail_url"]         = dialog_item.thumbnail_url;
+    payload_item["installed"]             = dialog_item.has_local_package;
+    payload_item["installed_version"]     = dialog_item.installed_version;
+    payload_item["latest_version"]        = dialog_item.latest_version;
+    return payload_item;
 }
 
 std::string to_string(PluginUpdateStatus status)
@@ -311,9 +345,9 @@ PluginDialogItem build_plugin_dialog_item(const PluginDescriptor& descriptor)
     item.has_local_package     = descriptor.has_local_package();
     item.unauthorized          = descriptor.is_unauthorized();
     item.has_script_capability = descriptor.has_capability_type(Slic3r::PluginCapabilityType::Script);
-    item.loaded                = loader.is_plugin_loaded(descriptor.plugin_key);
+    item.is_loaded                = loader.is_plugin_loaded(descriptor.plugin_key);
     item.loading               = loader.is_plugin_load_in_progress(descriptor.plugin_key);
-    if (item.loaded) {
+    if (item.is_loaded) {
         for (const auto& cap : loader.get_loaded_plugin_capabilities(descriptor.plugin_key)) {
             if (cap) {
                 item.capabilities.push_back({cap->name, plugin_capability_type_display_name(cap->type),
@@ -342,7 +376,7 @@ PluginDialogItem build_plugin_dialog_item(const PluginDescriptor& descriptor)
         item.status = PluginStatus::Loading;
     else if (item.has_error)
         item.status = PluginStatus::Error;
-    else if (item.loaded)
+    else if (item.is_loaded)
         item.status = PluginStatus::Activated;
     else
         item.status = PluginStatus::Inactive;
@@ -352,7 +386,7 @@ PluginDialogItem build_plugin_dialog_item(const PluginDescriptor& descriptor)
                                                 [](const PluginCapabilityView& capability) {
                                                     return capability.type_key == "script" && capability.enabled;
                                                 });
-    item.can_run_script = descriptor.is_metadata_valid() && !descriptor.has_error() && item.has_script_capability && item.loaded &&
+    item.can_run_script = descriptor.is_metadata_valid() && !descriptor.has_error() && item.has_script_capability && item.is_loaded &&
                           !item.loading && has_enabled_script;
     for (PluginCapabilityView& capability : item.capabilities) {
         capability.can_run = item.can_run_script && capability.type_key == "script" && capability.enabled;
@@ -478,6 +512,8 @@ void PluginsDialog::on_script_message(const nlohmann::json& payload)
         open_plugin_on_cloud(payload.value("sharing_token", ""));
     } else if (command == "open_plugin_hub") {
         open_plugin_hub();
+    } else if (command == "set_plugin_sort") {
+        set_plugin_sort(payload.value("sort_key", ""), payload.value("sort_order", ""));
     } else if (command == "set_plugin_install_action") {
         const std::string action = payload.value("action", "");
         if (action == "explore" || action == "install-local")
@@ -487,92 +523,41 @@ void PluginsDialog::on_script_message(const nlohmann::json& payload)
 
 void PluginsDialog::send_plugins() { call_web_handler(build_plugins_payload()); }
 
+void PluginsDialog::set_plugin_sort(const std::string& sort_key, const std::string& sort_order)
+{
+    m_plugin_sort_key   = plugin_sort_key_from_string(sort_key, m_plugin_sort_key);
+    m_plugin_sort_order = plugin_sort_order_from_string(sort_order, m_plugin_sort_order);
+    send_plugins();
+}
+
 nlohmann::json PluginsDialog::build_plugins_payload() const
 {
     nlohmann::json response;
     response["command"]        = "list_plugins";
     response["install_action"] = s_selected_plugin_install_action;
+    response["sort_key"]       = to_string(m_plugin_sort_key);
+    response["sort_order"]     = to_string(m_plugin_sort_order);
     response["data"]           = nlohmann::json::array();
-
-    auto append_plugin = [&response](const PluginDescriptor& row) {
-        const PluginDialogItem dialog_item = build_plugin_dialog_item(row);
-
-        nlohmann::json payload_item;
-        payload_item["plugin_key"]  = dialog_item.plugin_key;
-        payload_item["plugin_id"]   = dialog_item.plugin_id;
-        payload_item["name"]        = row.name;
-        payload_item["description"] = dialog_item.description;
-        payload_item["author"]      = dialog_item.author;
-        payload_item["version"]     = dialog_item.version;
-        payload_item["installed_version"] = dialog_item.installed_version;
-        payload_item["latest_version"]    = dialog_item.latest_version;
-        payload_item["installed"]         = dialog_item.has_local_package;
-        payload_item["type"]        = dialog_item.type_label;
-        payload_item["type_key"]    = dialog_item.type_key;
-        payload_item["types"]       = dialog_item.type_labels;
-        nlohmann::json caps         = nlohmann::json::array();
-        for (const PluginCapabilityView& capability : dialog_item.capabilities) {
-            nlohmann::json c;
-            c["name"]       = capability.name;
-            c["type"]       = capability.type_label;
-            c["type_key"]   = capability.type_key;
-            c["enabled"]    = capability.enabled;
-            c["can_toggle"] = capability.can_toggle;
-            c["can_run"]    = capability.can_run;
-            caps.push_back(std::move(c));
-        }
-        payload_item["capabilities"] = std::move(caps);
-        nlohmann::json changelog     = nlohmann::json::array();
-        for (const PluginChangelogView& entry : dialog_item.changelog) {
-            nlohmann::json c;
-            c["version"]      = entry.version;
-            c["changelog"]    = entry.changelog;
-            c["created_time"] = entry.created_time;
-            changelog.push_back(std::move(c));
-        }
-        payload_item["changelog"]             = std::move(changelog);
-        payload_item["label"]                 = dialog_item.display_name;
-        payload_item["source"]                = to_string(dialog_item.source);
-        payload_item["status"]                = to_string(dialog_item.status);
-        payload_item["error"]                 = dialog_item.error_text;
-        payload_item["update_status"]         = to_string(dialog_item.update_status);
-        payload_item["unauthorized"]          = dialog_item.unauthorized;
-        payload_item["context_actions"]       = build_context_actions_payload(dialog_item.available_actions);
-        payload_item["update_available"]      = dialog_item.update_status == PluginUpdateStatus::UpdateAvailable;
-        payload_item["can_toggle"]            = dialog_item.available_actions.can_toggle;
-        payload_item["has_script_capability"] = dialog_item.has_script_capability;
-        payload_item["can_run_script"]        = dialog_item.can_run_script;
-        payload_item["sharing_token"]         = dialog_item.sharing_token;
-        payload_item["thumbnail_url"]         = dialog_item.thumbnail_url;
-        response["data"].push_back(std::move(payload_item));
-    };
 
     const auto& catalog = PluginManager::instance().get_catalog();
     const auto valid    = catalog.get_all_plugin_descriptors();
     const auto invalid  = catalog.get_invalid_plugins();
     BOOST_LOG_TRIVIAL(info) << "Prepared " << valid.size() + invalid.size() << " plugin rows for Plugins dialog";
 
+    std::vector<PluginDialogItem> items;
+    items.reserve(valid.size() + invalid.size());
+
     for (const PluginDescriptor& row : valid)
-        append_plugin(row);
+        items.push_back(build_plugin_dialog_item(row));
 
     for (const PluginDescriptor& row : invalid)
-        append_plugin(row);
+        items.push_back(build_plugin_dialog_item(row));
 
-    auto sort_value = [](const nlohmann::json& payload_item, const char* key) { return payload_item.value(key, std::string{}); };
+    // In-place sort
+    sort_plugin_items_for_dialog(items, m_plugin_sort_key, m_plugin_sort_order);
 
-    std::sort(response["data"].begin(), response["data"].end(), [&sort_value](const nlohmann::json& lhs, const nlohmann::json& rhs) {
-        const std::string lhs_source = sort_value(lhs, "source");
-        const std::string rhs_source = sort_value(rhs, "source");
-        if (lhs_source != rhs_source)
-            return lhs_source < rhs_source;
-
-        const std::string lhs_type = sort_value(lhs, "type_key");
-        const std::string rhs_type = sort_value(rhs, "type_key");
-        if (lhs_type != rhs_type)
-            return lhs_type < rhs_type;
-
-        return sort_value(lhs, "name") < sort_value(rhs, "name");
-    });
+    for (const PluginDialogItem& item : items)
+        response["data"].push_back(build_plugin_payload_item(item));
 
     return response;
 }
@@ -1274,7 +1259,7 @@ void PluginsDialog::delete_mine_local_and_cloud_plugin(const std::string& plugin
 
     // delete_mine_local_and_cloud_plugin already updated the in-memory catalog
     // (finalize_cloud_plugin_removal removes the row and, when a local package existed,
-    // re-syncs the cloud list itself), so a UI refresh is sufficient here — an extra
+    // re-syncs the cloud list itself), so a UI refresh is sufficient here - an extra
     // clearing rescan + cloud fetch would be redundant.
     send_plugins();
     show_status(wxString::Format(_L("Deleted \"%s\"."), plugin_name), "success");

--- a/src/slic3r/GUI/PluginsDialog.hpp
+++ b/src/slic3r/GUI/PluginsDialog.hpp
@@ -2,6 +2,9 @@
 #define slic3r_PluginsDialog_hpp_
 
 #include "Widgets/WebViewHostDialog.hpp"
+#include "PluginSource.hpp"
+#include "PluginStatus.hpp"
+#include "PluginSort.hpp"
 #include "slic3r/plugin/PluginDescriptor.hpp"
 
 #include <exception>
@@ -27,21 +30,6 @@ enum class PluginCapabilityType;
 
 namespace GUI {
 
-enum class PluginSource
-{
-    Local,
-    Mine,
-    Subscribed
-};
-
-enum class PluginStatus
-{
-    Inactive,
-    Error,
-    Loading,
-    Activated
-};
-
 class PluginsDialog : public Slic3r::GUI::WebViewHostDialog
 {
 public:
@@ -63,6 +51,7 @@ private:
     void on_script_message(const nlohmann::json& payload) override;
 
     void send_plugins();
+    void set_plugin_sort(const std::string& sort_key, const std::string& sort_order);
     nlohmann::json build_plugins_payload() const;
 
     bool get_descriptor(const std::string& plugin_key, Slic3r::PluginDescriptor& descriptor) const;
@@ -221,6 +210,8 @@ private:
     }
 
     std::function<void()> m_open_terminal_dlg_fn;
+    PluginSortKey m_plugin_sort_key       = PluginSortKey::Status;
+    PluginSortOrder m_plugin_sort_order   = PluginSortOrder::Asc;
 
     // Serializes run_script_plugin. With main-thread execution a plugin's orca.host.ui modal
     // (message/show_dialog) or the result message box pumps a nested event loop, which could

--- a/tests/slic3rutils/CMakeLists.txt
+++ b/tests/slic3rutils/CMakeLists.txt
@@ -4,6 +4,7 @@ add_executable(${_TEST_NAME}_tests
     test_plugin_host_api.cpp
     test_plugin_capability_identifier.cpp
     test_plugin_install.cpp
+    test_plugin_sort.cpp
     )
 
 if (MSVC)

--- a/tests/slic3rutils/test_plugin_sort.cpp
+++ b/tests/slic3rutils/test_plugin_sort.cpp
@@ -1,0 +1,146 @@
+#include <catch2/catch_all.hpp>
+
+#include <slic3r/GUI/PluginSort.hpp>
+
+#include <string>
+#include <vector>
+
+using Slic3r::GUI::compare_ascii_case_insensitive_natural;
+using Slic3r::GUI::PluginSortKey;
+using Slic3r::GUI::PluginSortOrder;
+using Slic3r::GUI::PluginSource;
+using Slic3r::GUI::PluginStatus;
+using Slic3r::GUI::plugin_sort_key_from_string;
+using Slic3r::GUI::plugin_sort_order_from_string;
+using Slic3r::GUI::sort_plugin_items_for_dialog;
+
+namespace {
+
+struct SortFixtureItem
+{
+    std::string plugin_key;
+    PluginSource source;
+    PluginStatus status;
+    std::string type_key;
+    std::string display_name;
+};
+
+std::vector<std::string> keys(const std::vector<SortFixtureItem>& items)
+{
+    std::vector<std::string> result;
+    result.reserve(items.size());
+    for (const SortFixtureItem& item : items)
+        result.push_back(item.plugin_key);
+    return result;
+}
+
+} // namespace
+
+TEST_CASE("plugin dialog status sort uses requested priority and base-order ties", "[plugin][sort]")
+{
+    std::vector<SortFixtureItem> items = {
+        {"local_inactive", PluginSource::Local, PluginStatus::Inactive, "script", "Local Inactive"},
+        {"mine_error", PluginSource::Mine, PluginStatus::Error, "script", "Mine Error"},
+        {"mine_activated", PluginSource::Mine, PluginStatus::Activated, "script", "Mine Activated"},
+        {"local_activated", PluginSource::Local, PluginStatus::Activated, "script", "Local Activated"},
+        {"subscribed_loading", PluginSource::Subscribed, PluginStatus::Loading, "script", "Subscribed Loading"},
+    };
+
+    sort_plugin_items_for_dialog(items, PluginSortKey::Status, PluginSortOrder::Asc);
+
+    // why: local_activated and mine_activated tie on Status, so base order breaks the tie by
+    //   declared source priority - Mine (ordinal 0) before Local (ordinal 2).
+    const std::vector<std::string> expected = {
+        "mine_activated",
+        "local_activated",
+        "mine_error",
+        "local_inactive",
+        "subscribed_loading",
+    };
+    CHECK(keys(items) == expected);
+
+    sort_plugin_items_for_dialog(items, PluginSortKey::Status, PluginSortOrder::Desc);
+
+    // why: Desc reverses the status ordinal, but the Activated tie still resolves by ascending
+    //   base order (Mine before Local) - the direction only flips the primary key.
+    const std::vector<std::string> desc_expected = {
+        "subscribed_loading",
+        "local_inactive",
+        "mine_error",
+        "mine_activated",
+        "local_activated",
+    };
+    CHECK(keys(items) == desc_expected);
+}
+
+TEST_CASE("plugin dialog source sort uses enum priority", "[plugin][sort]")
+{
+    std::vector<SortFixtureItem> items = {
+        {"local", PluginSource::Local, PluginStatus::Activated, "script", "Local"},
+        {"mine", PluginSource::Mine, PluginStatus::Activated, "script", "Mine"},
+        {"subscribed", PluginSource::Subscribed, PluginStatus::Activated, "script", "Subscribed"},
+    };
+
+    sort_plugin_items_for_dialog(items, PluginSortKey::Source, PluginSortOrder::Asc);
+    const std::vector<std::string> asc_expected = {"mine", "subscribed", "local"};
+    CHECK(keys(items) == asc_expected);
+
+    sort_plugin_items_for_dialog(items, PluginSortKey::Source, PluginSortOrder::Desc);
+    const std::vector<std::string> desc_expected = {"local", "subscribed", "mine"};
+    CHECK(keys(items) == desc_expected);
+}
+
+TEST_CASE("plugin dialog name sort is case-insensitive and numeric-aware", "[plugin][sort]")
+{
+    std::vector<SortFixtureItem> items = {
+        {"rig10", PluginSource::Local, PluginStatus::Activated, "script", "Rig 10"},
+        {"ada_lower", PluginSource::Local, PluginStatus::Activated, "script", "ada"},
+        {"rig2", PluginSource::Local, PluginStatus::Activated, "script", "Rig 2"},
+        {"ada_upper", PluginSource::Local, PluginStatus::Activated, "script", "Ada"},
+    };
+
+    sort_plugin_items_for_dialog(items, PluginSortKey::Name, PluginSortOrder::Asc);
+
+    const std::vector<std::string> expected = {"ada_upper", "ada_lower", "rig2", "rig10"};
+    CHECK(keys(items) == expected);
+
+    sort_plugin_items_for_dialog(items, PluginSortKey::Name, PluginSortOrder::Desc);
+
+    // why: names reverse ("Rig 10" before "Rig 2"), but "Ada"/"ada" tie on the case-insensitive
+    //   key and keep ascending base order (case-sensitive "Ada" < "ada").
+    const std::vector<std::string> desc_expected = {"rig10", "rig2", "ada_upper", "ada_lower"};
+    CHECK(keys(items) == desc_expected);
+}
+
+TEST_CASE("natural compare handles digits, case, prefixes and leading zeros", "[plugin][sort]")
+{
+    // numeric runs compare by value, not lexically
+    CHECK(compare_ascii_case_insensitive_natural("item2", "item10") < 0);
+    CHECK(compare_ascii_case_insensitive_natural("item10", "item2") > 0);
+    CHECK(compare_ascii_case_insensitive_natural("2", "10") < 0);
+
+    // case is ignored on the primary comparison
+    CHECK(compare_ascii_case_insensitive_natural("Camera", "camera") == 0);
+
+    // a prefix is less than the longer string it prefixes
+    CHECK(compare_ascii_case_insensitive_natural("app", "apple") < 0);
+    CHECK(compare_ascii_case_insensitive_natural("apple", "app") > 0);
+
+    // equal numeric value: fewer leading zeros wins the tie
+    CHECK(compare_ascii_case_insensitive_natural("1", "01") < 0);
+    CHECK(compare_ascii_case_insensitive_natural("01", "1") > 0);
+
+    // reflexivity and empty-string boundaries
+    CHECK(compare_ascii_case_insensitive_natural("plugin", "plugin") == 0);
+    CHECK(compare_ascii_case_insensitive_natural("", "") == 0);
+    CHECK(compare_ascii_case_insensitive_natural("", "a") < 0);
+}
+
+TEST_CASE("plugin dialog sort request parsing keeps previous state on invalid values", "[plugin][sort]")
+{
+    CHECK(plugin_sort_key_from_string("source", PluginSortKey::Status) == PluginSortKey::Source);
+    CHECK(plugin_sort_key_from_string("missing", PluginSortKey::Name) == PluginSortKey::Name);
+
+    CHECK(plugin_sort_order_from_string("desc", PluginSortOrder::Asc) == PluginSortOrder::Desc);
+    CHECK(plugin_sort_order_from_string("down", PluginSortOrder::Asc) == PluginSortOrder::Asc);
+}


### PR DESCRIPTION
# Description

Adds a GitHub-style **Sort** dropdown to the Plugins dialog toolbar. Users can reorder the plugin list by Status, Name, or Source with an independent Ascending / Descending order selector.

**What changed**
- New **Sort** control in the toolbar with two groups: **Sort by** (Status / Name / Source) and **Order** (Ascending / Descending). Single-select with a checkmark on the active choice. Field and order are independent.
- JS is only the dropdown controller. It sends `set_plugin_sort` with `sort_key` and `sort_order`, then reflects the canonical sort state returned by C++ in `list_plugins`.
- C++ owns ordering. `PluginsDialog::build_plugins_payload()` builds a temporary `PluginDialogItem` vector, applies the dialog-local sort, and serializes the sorted `list_plugins` payload. It does not mutate `PluginManager`, catalog order, descriptors, config, project files, or profiles.
- Status and Source use dialog-local rank helpers that take enum values, so UI priority is decoupled from enum declaration order. Status ascending is Activated, RuntimeError, Error, Inactive, Loading. Source ascending is Mine, Subscribed, Local. Name uses a case-insensitive, numeric-aware ASCII comparison.
- The old source -> type -> name order remains the base tie-breaker inside equal primary sort values.

**Behavior notes and caveats**
- Default is **Status, Ascending**. This intentionally changes the on-open order from the previous source-grouped order to a status-grouped one.
- Sort state is in-memory for the open dialog. Refresh keeps it. Closing and reopening resets to the default.
- The new labels are English literals. The Plugins dialog is currently all hardcoded English. Localizing the whole dialog is a separate follow-up.

**Base branch:** targets `feature/printer-agent-port` (stacked on that work), not `main`.

# Screenshots/Recordings/Graphs

https://github.com/user-attachments/assets/25fa76fa-010f-404c-9c4e-0245fb7dbff9

## Tests

- `node --check resources/web/dialog/PluginsDialog/plugin-sort.js`
- `node --check resources/web/dialog/PluginsDialog/index.js`
- `git diff --check`
- Manual in-app verification is still pending. It needs a local build.

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
