### PR TITLE
fix: CI/CD build fail for arm64 windows

### DIFF
--- a/deps/python3/python3.cmake
+++ b/deps/python3/python3.cmake
@@ -8,6 +8,10 @@ set(_python_url "https://www.python.org/ftp/python/${_python_version}/Python-${_
 set(_python_sha256 "56bfef1fdfc1221ce6720e43a661e3eb41785dd914ce99698d8c7896af4bdaa1")
 
 if(WIN32)
+    set(_python_patch_args
+        PATCH_COMMAND ${PATCH_CMD} ${CMAKE_CURRENT_LIST_DIR}/windows-api-baseline-8.1.patch
+    )
+
     if(MSVC_VERSION EQUAL 1800)
         set(_python_platform_toolset v120)
     elseif(MSVC_VERSION EQUAL 1900)
@@ -223,6 +227,7 @@ ExternalProject_Add(dep_python3
     URL "${_python_url}"
     URL_HASH SHA256=${_python_sha256}
     DOWNLOAD_DIR ${DEP_DOWNLOAD_DIR}/python3
+    ${_python_patch_args}
     BUILD_IN_SOURCE ON
     CONFIGURE_COMMAND ${_conf_cmd}
     BUILD_COMMAND ${_build_cmd}

--- a/deps/python3/windows-api-baseline-8.1.patch
+++ b/deps/python3/windows-api-baseline-8.1.patch
@@ -1,0 +1,19 @@
+diff --git a/PC/pyconfig.h b/PC/pyconfig.h
+index ac878a01e1..4f8e7f0f97 100644
+--- a/PC/pyconfig.h
++++ b/PC/pyconfig.h
+@@ -161,9 +161,9 @@ WIN32 is still required for the locale module.
+ #endif /* MS_WIN64 */
+-
++
+ /* set the version macros for the windows headers */
+-/* Python 3.9+ requires Windows 8 or greater */
+-#define Py_WINVER 0x0602 /* _WIN32_WINNT_WIN8 */
+-#define Py_NTDDI NTDDI_WIN8
++/* Python 3.12+ requires Windows 8.1 or greater */
++#define Py_WINVER 0x0603 /* _WIN32_WINNT_WINBLUE (8.1) */
++#define Py_NTDDI NTDDI_WINBLUE
+-
++
+ /* We only set these values when building Python - we don't want to force
+    these values on extensions, as that will affect the prototypes and


### PR DESCRIPTION
# Description

## Summary

Fix the Windows ARM64 dependency build failing while building the bundled CPython 3.12.3 source with the newer Windows SDK on the `windows-11-arm` GitHub Actions runner.

## Problem

The Windows ARM64 dependency job configures for ARM64 correctly, and CPython is invoked with:

```text
/p:Platform=ARM64
```

However, CPython builds a host-side `_freeze_module.exe` helper before installing the final Python runtime. That helper failed with:

```text
posixmodule.obj : error LNK2019: unresolved external symbol _PssCaptureSnapshot
posixmodule.obj : error LNK2019: unresolved external symbol _PssQuerySnapshot
posixmodule.obj : error LNK2019: unresolved external symbol _PssFreeSnapshot
PCbuild\win32\_freeze_module.exe : fatal error LNK1120: 3 unresolved externals
```

This is a known CPython 3.12.3 issue with newer Windows SDKs. Python 3.12.3 still sets its Windows API baseline to Windows 8:

```c
#define Py_WINVER 0x0602
#define Py_NTDDI NTDDI_WIN8
```

The newer Windows SDK exposes the Process Snapshotting APIs used by `posixmodule.c` only for Windows 8.1 or newer, so those declarations are hidden and the `_freeze_module` link fails.

Upstream CPython fixed this by moving the Windows build API baseline to Windows 8.1:

<https://github.com/python/cpython/pull/124676>

## Fix

Add a local patch for the pinned `Python-3.12.3.tar.xz` source and apply it during the Windows `dep_python3` external project patch step.

The patch updates CPython's `PC/pyconfig.h` from:

```c
#define Py_WINVER 0x0602
#define Py_NTDDI NTDDI_WIN8
```

to:

```c
#define Py_WINVER 0x0603
#define Py_NTDDI NTDDI_WINBLUE
```

This makes the Windows SDK expose `PssCaptureSnapshot`, `PssQuerySnapshot`, and `PssFreeSnapshot`, allowing CPython's `_freeze_module` helper to link successfully.

## Scope

This does not upgrade bundled Python and does not change OrcaSlicer's embedded Python version. It only backports the upstream CPython build fix to the pinned 3.12.3 source archive.

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
