### PR TITLE
Fix issue that extruder 2 tab in printer settings uses the wrong nozzle variant id after loading 3mf

### DIFF
--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -7712,6 +7712,11 @@ void Tab::update_extruder_variants(int extruder_id, bool reload)
         auto    nozzle_volumes = m_preset_bundle->project_config.option<ConfigOptionEnumsGeneric>("nozzle_volume_type");
         int extruder_nums = m_preset_bundle->get_printer_extruder_count();
         nozzle_volumes->values.resize(extruder_nums);
+
+        // Orca: update `m_actual_nozzle_volumes` to current selected ones
+        m_actual_nozzle_volumes.resize(extruder_nums, NozzleVolumeType::nvtStandard);
+        for (int i = 0; i < extruder_nums; i++) m_actual_nozzle_volumes[i] = (NozzleVolumeType)nozzle_volumes->values[i];
+
         if (extruder_nums == 2) {
             auto options = generate_extruder_options();
             m_extruder_switch->SetOptions(options);


### PR DESCRIPTION
# Description

Fix issue described here https://github.com/OrcaSlicer/OrcaSlicer/pull/13712#issuecomment-4877629327

There is a bug that with a 3mf file that uses Bambu dual nozzle printers with the second nozzle flow set to High Flow, and if you open that 3mf then immediately open the printer settings and switch to Extruder 2 tab, you will notice this page shows values for Standard Flow variant instead:

1. Run the current main version, and make sure your current printer profile is H2D, with both nozzle flow variant set to Standard
2. Open 3mf file from https://github.com/OrcaSlicer/OrcaSlicer/pull/13712#issuecomment-4869361440, and you'll notice that both nozzle are set to High Flow
    <img width="300" alt="image" src="https://github.com/user-attachments/assets/8fb3410e-f744-4af6-9409-ebddb9f4e5ba" />

3. Open printer settings, switch to tab Right Extruder, scroll down to **Traveling angle** option, and you'll notice that the value is 3:
    <img width="500" alt="image" src="https://github.com/user-attachments/assets/0ba67c4f-a296-4bab-abcf-d699a2e24cef" />

4. However, if you unzip the 3mf file and open the `Metadata\project_settings.config` file, and search for `travel_slope`, you will notice it's 4th value (which corrsponding to Extruder 2 High Flow) is 0:
    <img width="500" alt="image" src="https://github.com/user-attachments/assets/646476f2-b264-48c0-857f-c98eb31af773" />

5. And if you go back to Orca, select the High Flow option again from the Right Nozzle Flow drop down <img width="200" alt="image" src="https://github.com/user-attachments/assets/260d68c8-0436-4857-aac8-2ebc7ab9cfac" />, then open the printer settings, go to the Right Extruder tab, scroll down to **Traveling angle** option again, you will notice that this time it shows the value 0, which matches the project file:
     <img width="500" alt="image" src="https://github.com/user-attachments/assets/9d001f01-c275-48b4-b94f-34df55f5902a" />


# Screenshots/Recordings/Graphs

<!--
> Please attach relevant screenshots to showcase the UI changes.
> Please attach images that can help explain the changes.
-->

## Tests
With this PR, if you open the 3mf and go to the Right Extruder tab immediately, it shows the correct value.

<!--
> A guide for users on how to download the artifacts from this PR.
-->

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
