### PR TITLE
CLI: guard 4 null derefs when loading a 3mf without preset ids

### DIFF
--- a/src/OrcaSlicer.cpp
+++ b/src/OrcaSlicer.cpp
@@ -1697,11 +1697,13 @@ int CLI::run(int argc, char **argv)
                             const Vec3d &instance_offset = model_instance->get_offset();
                             BOOST_LOG_TRIVIAL(info) << boost::format("instance %1% transform {%2%,%3%,%4%} at %5%:%6%")% model_object->name % instance_offset.x() % instance_offset.y() %instance_offset.z() % __FUNCTION__ % __LINE__<< std::endl;
                         }*/
-                    current_printer_name = config.option<ConfigOptionString>("printer_settings_id")->value;
-                    current_process_name = config.option<ConfigOptionString>("print_settings_id")->value;
+                    // Read defensively — a 3mf missing preset ids (e.g. one produced
+                    // by a non-GUI writer) would otherwise crash here on the deref.
+                    if (const auto *o = config.option<ConfigOptionString>("printer_settings_id"))  current_printer_name  = o->value;
+                    if (const auto *o = config.option<ConfigOptionString>("print_settings_id"))    current_process_name  = o->value;
                     current_printer_model = config.option<ConfigOptionString>("printer_model", true)->value;
-                    current_filaments_name = config.option<ConfigOptionStrings>("filament_settings_id")->values;
-                    current_extruder_count = config.option<ConfigOptionFloats>("nozzle_diameter")->values.size();
+                    if (const auto *o = config.option<ConfigOptionStrings>("filament_settings_id")) current_filaments_name = o->values;
+                    if (const auto *o = config.option<ConfigOptionFloats>("nozzle_diameter"))       current_extruder_count = o->values.size();
                     current_printer_variant_count = config.option<ConfigOptionStrings>("printer_extruder_variant", true)->values.size();
                     current_print_variant_count = config.option<ConfigOptionStrings>("print_extruder_variant", true)->values.size();
                     current_is_multi_extruder = current_extruder_count > 1;


### PR DESCRIPTION
# Description

The post-load block in `Slic3r::CLI::run` at [`OrcaSlicer.cpp:1700-1704`](https://github.com/OrcaSlicer/OrcaSlicer/blob/main/src/OrcaSlicer.cpp#L1700-L1704) reads preset identifiers off the config that the loaded 3mf carries:

```cpp
current_printer_name  = config.option<ConfigOptionString>("printer_settings_id")->value;
current_process_name  = config.option<ConfigOptionString>("print_settings_id")->value;
current_printer_model = config.option<ConfigOptionString>("printer_model", true)->value;
current_filaments_name = config.option<ConfigOptionStrings>("filament_settings_id")->values;
current_extruder_count = config.option<ConfigOptionFloats>("nozzle_diameter")->values.size();
```

If the 3mf is a BBL/BBS-flavored 3mf but was produced by a non-GUI writer (e.g. an `orca-slicer --export-3mf` call that isn't paired with `--load-settings`), any of `printer_settings_id` / `print_settings_id` / `filament_settings_id` / `nozzle_diameter` can be absent from the config. `config.option<T>(key)` then returns `nullptr` and the following `->value` / `->values` dereferences SIGSEGV.

`printer_model`, `printer_extruder_variant`, and `print_extruder_variant` pass `create_if_missing=true` and are already safe — those three lines are left as-is.

# Reproducer

Any `--info`-class action on a preset-less BBL 3mf:

```sh
$ orca-slicer --export-3mf out.3mf model.stl     # produces preset-less 3mf
$ orca-slicer --info out.3mf                     # SIGSEGV
Segmentation fault (core dumped)
```

gdb backtrace:

```
Thread 1 "orcaslicer_main" received signal SIGSEGV, Segmentation fault.
#0  std::__cxx11::basic_string::_M_assign
#1  std::__cxx11::basic_string::operator=
#2  Slic3r::CLI::run at src/OrcaSlicer.cpp:1700
#3  main         at src/OrcaSlicer.cpp:8225
```

The crash also fires from `--inspect-mesh`, and any other read-only action that has to walk the loaded model's config after loading; `--slice` typically escapes because the caller injects a printer via `--load-settings`.

# Fix

Wrap each optional lookup in an `if (const auto *o = …)` — matches the defensive-read pattern approved by @raistlin7447 in #14413 / #14414 / #14415.

```cpp
if (const auto *o = config.option<ConfigOptionString>("printer_settings_id"))  current_printer_name   = o->value;
if (const auto *o = config.option<ConfigOptionString>("print_settings_id"))    current_process_name   = o->value;
current_printer_model = config.option<ConfigOptionString>("printer_model", true)->value;  // create_if_missing → safe
if (const auto *o = config.option<ConfigOptionStrings>("filament_settings_id")) current_filaments_name = o->values;
if (const auto *o = config.option<ConfigOptionFloats>("nozzle_diameter"))       current_extruder_count = o->values.size();
```

Absent keys leave the local defaults untouched: empty strings, empty vectors, and `current_extruder_count = 0`. The downstream `current_is_multi_extruder = current_extruder_count > 1` remains false; subsequent code that iterates on those vectors already treats empty as no-op.

# Scope

`src/OrcaSlicer.cpp` — 4 lines guarded, 1 line of leading comment. No behavior change on well-formed 3mfs (the guard evaluates the same option pointer, then falls through to the same assignment).