### PR TITLE
fix: multi-user slicing crash on shared temp dir

### DIFF
--- a/src/libslic3r/Model.cpp
+++ b/src/libslic3r/Model.cpp
@@ -954,22 +954,29 @@ std::string Model::get_auxiliary_file_temp_path()
     return get_backup_path("Auxiliaries");
 }
 
+std::string Model::get_model_backup_root(const std::string &temp_dir, const std::string &user_id)
+{
+    std::string root = temp_dir + "/orcaslicer_model";
+    if (!user_id.empty())
+        root += "_" + user_id;
+    return root;
+}
+
 // BBS: backup dir
 std::string Model::get_backup_path()
 {
     if (backup_path.empty())
     {
         auto pid = get_current_pid();
-        boost::filesystem::path parent_path(temporary_dir());
         std::time_t t = std::time(0);
         std::tm* now_time = std::localtime(&t);
         std::stringstream buf;
-        buf << "/orcaslicer_model/";
-        buf << std::put_time(now_time, "%a_%b_%d/%H_%M_%S#");
+        buf << get_model_backup_root(temporary_dir(), per_user_temp_id());
+        buf << "/" << std::put_time(now_time, "%a_%b_%d/%H_%M_%S#");
         buf << pid << "#";
         buf << this->id().id;
 
-        backup_path = parent_path.string() + buf.str();
+        backup_path = buf.str();
         BOOST_LOG_TRIVIAL(info) << boost::format("model %1%, id %2%, backup_path empty, set to %3%")%this%this->id().id%backup_path;
         boost::filesystem::path temp_path(backup_path);
         if (boost::filesystem::exists(temp_path))

--- a/src/libslic3r/Model.hpp
+++ b/src/libslic3r/Model.hpp
@@ -1685,6 +1685,9 @@ public:
     //BBS: add auxiliary files temp path
     std::string   get_auxiliary_file_temp_path();
 
+    // Builds the per-user backup root under a (possibly shared) temp dir; see issue #10108.
+    static std::string get_model_backup_root(const std::string &temp_dir, const std::string &user_id);
+
     // BBS: backup
     std::string   get_backup_path();
     std::string   get_backup_path(const std::string &sub_path);

--- a/src/libslic3r/Utils.hpp
+++ b/src/libslic3r/Utils.hpp
@@ -300,6 +300,8 @@ std::string header_gcodeviewer_generated();
 
 // getpid platform wrapper
 extern unsigned get_current_pid();
+// Per-user identifier for isolating temp/backup dirs (empty on Windows).
+std::string per_user_temp_id();
 // BBS: backup & restore
 std::string get_process_name(int pid);
 

--- a/src/libslic3r/utils.cpp
+++ b/src/libslic3r/utils.cpp
@@ -1285,6 +1285,15 @@ unsigned get_current_pid()
 #endif
 }
 
+std::string per_user_temp_id()
+{
+#ifdef WIN32
+    return {};
+#else
+    return std::to_string(static_cast<unsigned long>(::getuid()));
+#endif
+}
+
 // BBS: backup & restore
 std::string get_process_name(int pid)
 {

--- a/tests/libslic3r/CMakeLists.txt
+++ b/tests/libslic3r/CMakeLists.txt
@@ -23,6 +23,7 @@ add_executable(${_TEST_NAME}_tests
     test_stl.cpp
     test_meshboolean.cpp
     test_marchingsquares.cpp
+    test_model.cpp
     test_timeutils.cpp
     test_voronoi.cpp
     test_optimizers.cpp

--- a/tests/libslic3r/test_model.cpp
+++ b/tests/libslic3r/test_model.cpp
@@ -1,0 +1,22 @@
+#include <catch2/catch_all.hpp>
+
+#include "libslic3r/Model.hpp"
+
+using namespace Slic3r;
+
+// Checks that get_model_backup_root composes the backup directory name: the user
+// id is appended so each user gets a distinct root, and an empty id keeps the
+// legacy name.
+TEST_CASE("get_model_backup_root builds a per-user backup dir name", "[Model]") {
+    const std::string tmp = "/tmp";
+
+    SECTION("distinct users get distinct roots") {
+        REQUIRE(Model::get_model_backup_root(tmp, "1000") != Model::get_model_backup_root(tmp, "1001"));
+    }
+    SECTION("the user id is embedded in the root") {
+        REQUIRE_THAT(Model::get_model_backup_root(tmp, "1000"), Catch::Matchers::ContainsSubstring("1000"));
+    }
+    SECTION("an empty user id keeps the legacy path") {
+        REQUIRE(Model::get_model_backup_root(tmp, "") == tmp + "/orcaslicer_model");
+    }
+}


### PR DESCRIPTION
# Description

On Linux, user accounts share `/tmp`. `Model::get_backup_path()` put the model backup dir under a fixed `<temp>/orcaslicer_model/` root, so the first user to slice owns it and the next user can't write under it, crashing with "No such file or directory".

Fix: tag the backup root with the user id (`<temp>/orcaslicer_model_<uid>/`). Windows keeps the legacy path since its temp dir is already per-user.

Fixes #10108. Same root cause as #5969.

# Tests

`tests/libslic3r/test_model.cpp` checks the backup-dir name composition (per-user suffix, legacy fallback). Manually confirmed unchanged on Windows (legacy path, backups still create and clean up).
