### PR TITLE
Fix reload from disk for STEP models after reopening a project (#12992)

### DIFF
--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -8959,7 +8959,14 @@ void Plater::priv::reload_from_disk()
                 if (has_source && old_volume->source.object_idx < int(new_model.objects.size())) {
                     const ModelObject *obj = new_model.objects[old_volume->source.object_idx];
                     if (old_volume->source.volume_idx < int(obj->volumes.size())) {
-                        if (obj->volumes[old_volume->source.volume_idx]->source.input_file == old_volume->source.input_file) {
+                        const std::string &new_input_file = obj->volumes[old_volume->source.volume_idx]->source.input_file;
+                        const std::string &old_input_file = old_volume->source.input_file;
+                        // Orca: match on the exact source path first, then fall back to filename-only so reload
+                        // still matches when the project stored a bare filename and the file was found next to
+                        // the project (same-folder fallback) or picked via the locate dialog (#12992).
+                        if (new_input_file == old_input_file ||
+                            boost::algorithm::iequals(fs::path(new_input_file).filename().string(),
+                                                      fs::path(old_input_file).filename().string())) {
                             new_volume_idx = old_volume->source.volume_idx;
                             new_object_idx = old_volume->source.object_idx;
                             match_found    = true;

--- a/src/slic3r/GUI/Preferences.cpp
+++ b/src/slic3r/GUI/Preferences.cpp
@@ -1664,6 +1664,13 @@ void PreferencesDialog::create_items()
     );
     g_sizer->Add(item_draco_bits);
 
+    auto item_full_source_paths = create_item_checkbox(_L("Store full source file paths in projects"),
+        _L("If enabled, saved projects store the absolute path to imported source files (STEP/STL/...), so "
+           "\"Reload from disk\" still works when the source file is kept in a different folder than the project. "
+           "If disabled, only the filename is stored, which keeps projects portable and avoids embedding absolute paths."),
+        "export_sources_full_pathnames");
+    g_sizer->Add(item_full_source_paths);
+
     //// GENERAL > Preset
     g_sizer->Add(create_item_title(_L("Preset")), 1, wxEXPAND);
 


### PR DESCRIPTION
# Description

Fixes #12992

After a project was saved and reopened, **Reload from Disk** no longer worked for STEP‑imported models: it failed with **"Error during reload" ("Unable to reload…")**, and if the STEP wasn't kept next to the project it first kept prompting to locate the file (regressed in 2.3.2).

Reload now matches the source by filename as a fallback to the exact path, so it correctly reloads the model found next to the project file (or picked via the locate dialog) and updates it in place. Projects that stored absolute source paths are unaffected, and there is no `.3mf` format change.

NOTE: If you keep the STEP and the project in **different folders**, enable full source paths (set `export_sources_full_pathnames = true` in the app config) so the project stores the STEP's absolute path and reload can find it regardless of where the project lives.

Update:
I just realized the `export_source_full_patnames" is not exposed in preference dialog.
This PR also expose it.

# Screenshots/Recordings/Graphs
<img width="642" height="537" alt="Screenshot 2026-07-05 at 16 36 48" src="https://github.com/user-attachments/assets/506dfe74-c119-4f98-bfd5-fb6bd9d3e5a4" />

<!--
> Please attach relevant screenshots to showcase the UI changes.
> Please attach images that can help explain the changes.
-->

## Tests

<!--
> Please describe the tests that you have conducted to verify the changes made in this PR.
-->

<!--
> A guide for users on how to download the artifacts from this PR.
-->

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
