### PR TITLE
Feature/align distribute tool

### DIFF
--- a/resources/images/toolbar_align.svg
+++ b/resources/images/toolbar_align.svg
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="40"
+   height="40"
+   viewBox="0 0 40 40"
+   version="1.1"
+   id="svg5"
+   sodipodi:docname="toolbar_align.svg"
+   inkscape:version="1.4 (e7c3feb100, 2024-10-09)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs5" />
+  <sodipodi:namedview
+     id="namedview5"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="15.1625"
+     inkscape:cx="0.89035449"
+     inkscape:cy="20.544106"
+     inkscape:window-width="1970"
+     inkscape:window-height="1054"
+     inkscape:window-x="2454"
+     inkscape:window-y="172"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg5" />
+  <path
+     d="M 29.236448,33.683263 H 13.351484 a 2.3827446,1.5 0 0 1 -2.382745,-1.5 v -10 a 2.3827446,1.5 0 0 1 2.382745,-1.5 h 15.884964 a 2.3827446,1.5 0 0 1 2.382744,1.5 v 10 a 2.3827446,1.5 0 0 1 -2.382744,1.5 z m -15.884964,-12 a 0.79424821,0.5 0 0 0 -0.794249,0.5 v 10 a 0.79424821,0.5 0 0 0 0.794249,0.5 h 15.884964 a 0.79424821,0.5 0 0 0 0.794248,-0.5 v -10 a 0.79424821,0.5 0 0 0 -0.794248,-0.5 z"
+     style="fill:#2b3436;stroke-width:1.26036;fill-opacity:1"
+     id="path5" />
+  <path
+     d="m 22.496057,18.291852 h -10 a 1.5,1.5 0 0 1 -1.5,-1.5 V 6.7918514 a 1.5,1.5 0 0 1 1.5,-1.5 h 10 a 1.5,1.5 0 0 1 1.5,1.5 V 16.791852 a 1.5,1.5 0 0 1 -1.5,1.5 z m -10,-12.0000006 a 0.5,0.5 0 0 0 -0.5,0.5 V 16.791852 a 0.5,0.5 0 0 0 0.5,0.5 h 10 a 0.5,0.5 0 0 0 0.5,-0.5 V 6.7918514 a 0.5,0.5 0 0 0 -0.5,-0.5 z"
+     style="fill:#2b3436;fill-opacity:1"
+     id="path5-3" />
+  <path
+     style="fill:#009688;fill-opacity:1;stroke:#009688;stroke-width:1.09207;stroke-linecap:round;stroke-dasharray:2.18415, 2.18415;stroke-dashoffset:0;stroke-opacity:1"
+     d="M 10.268821,3.8677783 V 35.858721"
+     id="path6" />
+</svg>

--- a/resources/images/toolbar_align_dark.svg
+++ b/resources/images/toolbar_align_dark.svg
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="40"
+   height="40"
+   viewBox="0 0 40 40"
+   version="1.1"
+   id="svg5"
+   sodipodi:docname="toolbar_align_dark.svg"
+   inkscape:version="1.4 (e7c3feb100, 2024-10-09)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs5" />
+  <sodipodi:namedview
+     id="namedview5"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="15.1625"
+     inkscape:cx="0.89035449"
+     inkscape:cy="20.544106"
+     inkscape:window-width="1970"
+     inkscape:window-height="1054"
+     inkscape:window-x="2454"
+     inkscape:window-y="172"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg5" />
+  <path
+     d="M 29.236448,33.683263 H 13.351484 a 2.3827446,1.5 0 0 1 -2.382745,-1.5 v -10 a 2.3827446,1.5 0 0 1 2.382745,-1.5 h 15.884964 a 2.3827446,1.5 0 0 1 2.382744,1.5 v 10 a 2.3827446,1.5 0 0 1 -2.382744,1.5 z m -15.884964,-12 a 0.79424821,0.5 0 0 0 -0.794249,0.5 v 10 a 0.79424821,0.5 0 0 0 0.794249,0.5 h 15.884964 a 0.79424821,0.5 0 0 0 0.794248,-0.5 v -10 a 0.79424821,0.5 0 0 0 -0.794248,-0.5 z"
+     style="fill:#b6b6b6;stroke-width:1.26036"
+     id="path5" />
+  <path
+     d="m 22.496057,18.291852 h -10 a 1.5,1.5 0 0 1 -1.5,-1.5 V 6.7918514 a 1.5,1.5 0 0 1 1.5,-1.5 h 10 a 1.5,1.5 0 0 1 1.5,1.5 V 16.791852 a 1.5,1.5 0 0 1 -1.5,1.5 z m -10,-12.0000006 a 0.5,0.5 0 0 0 -0.5,0.5 V 16.791852 a 0.5,0.5 0 0 0 0.5,0.5 h 10 a 0.5,0.5 0 0 0 0.5,-0.5 V 6.7918514 a 0.5,0.5 0 0 0 -0.5,-0.5 z"
+     style="fill:#b6b6b6"
+     id="path5-3" />
+  <path
+     style="fill:#009688;fill-opacity:1;stroke:#009688;stroke-width:1.09207;stroke-linecap:round;stroke-dasharray:2.18415, 2.18415;stroke-dashoffset:0;stroke-opacity:1"
+     d="M 10.268821,3.8677783 V 35.858721"
+     id="path6" />
+</svg>

--- a/src/slic3r/CMakeLists.txt
+++ b/src/slic3r/CMakeLists.txt
@@ -128,6 +128,8 @@ set(SLIC3R_GUI_SOURCES
     GUI/Gizmos/GizmoObjectManipulation.hpp
     GUI/Gizmos/GLGizmoAssembly.cpp
     GUI/Gizmos/GLGizmoAssembly.hpp
+    GUI/Gizmos/GLGizmoAlign.cpp
+    GUI/Gizmos/GLGizmoAlign.hpp
     GUI/Gizmos/GLGizmoBase.cpp
     GUI/Gizmos/GLGizmoBase.hpp
     GUI/Gizmos/GLGizmoBrimEars.cpp

--- a/src/slic3r/GUI/3DScene.cpp
+++ b/src/slic3r/GUI/3DScene.cpp
@@ -663,8 +663,12 @@ bool GLVolume::is_sla_pad() const { return this->composite_id.volume_id == -int(
 
 bool GLVolume::is_sinking() const
 {
-    if (is_modifier || GUI::wxGetApp().preset_bundle->printers.get_edited_preset().printer_technology() == ptSLA)
+    if (is_modifier)
         return false;
+    if (wxApp::GetInstance() != nullptr && GUI::wxGetApp().preset_bundle != nullptr) {
+        if (GUI::wxGetApp().preset_bundle->printers.get_edited_preset().printer_technology() == ptSLA)
+            return false;
+    }
     const BoundingBoxf3& box = transformed_convex_hull_bounding_box();
     return box.min.z() < SINKING_Z_THRESHOLD && box.max.z() >= SINKING_Z_THRESHOLD;
 }

--- a/src/slic3r/GUI/GUI_ObjectList.cpp
+++ b/src/slic3r/GUI/GUI_ObjectList.cpp
@@ -5084,35 +5084,66 @@ void ObjectList::update_selections_on_canvas()
         wxDataViewItemArray sels;
         GetSelections(sels);
 
-        // clear selection before adding new elements
-        selection.clear(); //OR remove_all()?
-
         for (auto item : sels)
         {
             add_to_selection(item, selection, instance_idx, mode);
         }
     }
 
-    if (selection.contains_all_volumes(volume_idxs))
-    {
-        // remove
-        volume_idxs = selection.get_missing_volume_idxs_from(volume_idxs);
-        if (volume_idxs.size() > 0)
-        {
+    // Compare sets to see if the selection is already identical.
+    // If it is, skip updating to preserve the click/selection order.
+    const Selection::IndicesList &current_vols = selection.get_volume_idxs();
+    std::set<unsigned int> target_vols(volume_idxs.begin(), volume_idxs.end());
+    if (current_vols == target_vols && selection.get_mode() == mode) {
+        return;
+    }
+
+    if (sel_cnt > 1) {
+        std::vector<unsigned int> vols_to_add;
+        std::vector<unsigned int> vols_to_remove;
+        for (unsigned int v : target_vols) {
+            if (current_vols.find(v) == current_vols.end()) {
+                vols_to_add.push_back(v);
+            }
+        }
+        for (unsigned int v : current_vols) {
+            if (target_vols.find(v) == target_vols.end()) {
+                vols_to_remove.push_back(v);
+            }
+        }
+
+        if (!vols_to_remove.empty()) {
             Plater::TakeSnapshot snapshot(wxGetApp().plater(), "Remove selected from list", UndoRedo::SnapshotType::Selection);
-            selection.remove_volumes(mode, volume_idxs);
+            selection.remove_volumes(mode, vols_to_remove);
+        }
+        if (!vols_to_add.empty()) {
+            Plater::TakeSnapshot snapshot(wxGetApp().plater(), "Add selected to list", UndoRedo::SnapshotType::Selection);
+            selection.add_volumes(mode, vols_to_add, false);
         }
     }
     else
     {
-        // add
-        // to avoid lost of some volumes in selection
-        // check non-selected volumes only if selection mode wasn't changed
-        // OR there is no single selection
-        if (selection.get_mode() == mode || !single_selection)
-            volume_idxs = selection.get_unselected_volume_idxs_from(volume_idxs);
-        Plater::TakeSnapshot snapshot(wxGetApp().plater(), "Add selected to list", UndoRedo::SnapshotType::Selection);
-        selection.add_volumes(mode, volume_idxs, single_selection);
+        if (selection.contains_all_volumes(volume_idxs))
+        {
+            // remove
+            volume_idxs = selection.get_missing_volume_idxs_from(volume_idxs);
+            if (volume_idxs.size() > 0)
+            {
+                Plater::TakeSnapshot snapshot(wxGetApp().plater(), "Remove selected from list", UndoRedo::SnapshotType::Selection);
+                selection.remove_volumes(mode, volume_idxs);
+            }
+        }
+        else
+        {
+            // add
+            // to avoid lost of some volumes in selection
+            // check non-selected volumes only if selection mode wasn't changed
+            // OR there is no single selection
+            if (selection.get_mode() == mode || !single_selection)
+                volume_idxs = selection.get_unselected_volume_idxs_from(volume_idxs);
+            Plater::TakeSnapshot snapshot(wxGetApp().plater(), "Add selected to list", UndoRedo::SnapshotType::Selection);
+            selection.add_volumes(mode, volume_idxs, single_selection);
+        }
     }
 
     if (canvas_type != GLCanvas3D::ECanvasType::CanvasPreview)

--- a/src/slic3r/GUI/Gizmos/GLGizmoAlign.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoAlign.cpp
@@ -1,0 +1,219 @@
+#include "GLGizmoAlign.hpp"
+#include "slic3r/GUI/GLCanvas3D.hpp"
+#include "slic3r/GUI/GUI_App.hpp"
+#include "slic3r/GUI/Plater.hpp"
+#include "slic3r/GUI/ImGuiWrapper.hpp"
+#include "slic3r/GUI/Gizmos/GLGizmosManager.hpp"
+#include "libslic3r/Color.hpp"
+
+namespace Slic3r::GUI {
+
+GLGizmoAlign::GLGizmoAlign(GLCanvas3D& parent, const std::string& icon_filename, unsigned int sprite_id)
+    : GLGizmoBase(parent, icon_filename, sprite_id)
+{
+}
+
+std::string GLGizmoAlign::on_get_name() const
+{
+    return _u8L("Align and Distribute");
+}
+
+bool GLGizmoAlign::on_is_activable() const
+{
+    return m_parent.get_selection().get_volume_idxs().size() > 1;
+}
+
+CommonGizmosDataID GLGizmoAlign::on_get_requirements() const
+{
+    return CommonGizmosDataID::None;
+}
+
+void GLGizmoAlign::on_render_input_window(float x, float y, float bottom_limit)
+{
+    if (m_parent.get_selection().get_volume_idxs().size() < 2) {
+        // Close the gizmo if selection falls below 2 items
+        m_parent.get_gizmos_manager().open_gizmo(GLGizmosManager::EType::Undefined);
+        return;
+    }
+
+    m_imgui->push_common_window_style(m_parent.get_scale());
+
+    // Position panel relative to coordinates passed
+    ImGui::SetNextWindowPos(ImVec2(x, y), ImGuiCond_Always);
+
+    int flags = ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoCollapse;
+    m_imgui->begin(on_get_name(), flags);
+
+    if (ImGui::BeginTable("AlignTable", 4, ImGuiTableFlags_None)) {
+        bool is_dark = wxGetApp().app_config->get("dark_color_mode") == "1";
+        if (is_dark) {
+            ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(70.0f / 255.f, 70.0f / 255.f, 75.0f / 255.f, 1.0f));
+            ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(0.00f, 0.59f, 0.53f, 1.00f));
+            ImGui::PushStyleColor(ImGuiCol_ButtonActive, ImVec4(0.00f, 0.59f, 0.53f, 1.00f));
+            ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.00f, 1.00f, 1.00f, 1.00f));
+        } else {
+            ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(230.0f / 255.f, 230.0f / 255.f, 235.0f / 255.f, 1.0f));
+            ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(0.00f, 0.59f, 0.53f, 1.00f));
+            ImGui::PushStyleColor(ImGuiCol_ButtonActive, ImVec4(0.00f, 0.59f, 0.53f, 1.00f));
+            ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(38.0f / 255.f, 46.0f / 255.f, 48.0f / 255.f, 1.00f));
+        }
+
+        // Calculate a uniform width for all buttons
+        float btn_width = std::max({
+            m_imgui->calc_button_size(_u8L("Min")).x,
+            m_imgui->calc_button_size(_u8L("Mid")).x,
+            m_imgui->calc_button_size(_u8L("Max")).x
+        }) + 12.0f * m_parent.get_scale();
+
+        auto render_centered_header = [&](const ImVec4& color, const std::string& text) {
+            float cell_width = ImGui::GetContentRegionAvail().x;
+            float text_width = ImGui::CalcTextSize(text.c_str()).x;
+            if (cell_width > text_width) {
+                ImGui::SetCursorPosX(ImGui::GetCursorPosX() + (cell_width - text_width) * 0.5f);
+            }
+            ImGui::TextColored(color, "%s", text.c_str());
+        };
+
+        auto render_centered_button = [&](const std::string& label, std::function<void()> onClick) {
+            float cell_width = ImGui::GetContentRegionAvail().x;
+            if (cell_width > btn_width) {
+                ImGui::SetCursorPosX(ImGui::GetCursorPosX() + (cell_width - btn_width) * 0.5f);
+            }
+            if (m_imgui->button(label, ImVec2(btn_width, 0.f), true)) {
+                onClick();
+            }
+        };
+
+        // Custom Header Row
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex(0);
+        ImGui::TextUnformatted("");
+        
+        ImGui::TableSetColumnIndex(1);
+        render_centered_header(ImGuiWrapper::to_ImVec4(ColorRGBA::X()), "X");
+        
+        ImGui::TableSetColumnIndex(2);
+        render_centered_header(ImGuiWrapper::to_ImVec4(ColorRGBA::Y()), "Y");
+        
+        ImGui::TableSetColumnIndex(3);
+        render_centered_header(ImGuiWrapper::to_ImVec4(ColorRGBA::Z()), "Z");
+
+        // Align rows
+        // Row 1: Min
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex(0);
+        ImGui::Text("%s", _u8L("Align").c_str());
+        
+        ImGui::TableSetColumnIndex(1);
+        render_centered_button((_u8L("Min") + "##a_0").c_str(), [&]() {
+            m_parent.get_selection().align(0, 0, false);
+        });
+        ImGui::TableSetColumnIndex(2);
+        render_centered_button((_u8L("Min") + "##a_1").c_str(), [&]() {
+            m_parent.get_selection().align(1, 0, false);
+        });
+        ImGui::TableSetColumnIndex(3);
+        render_centered_button((_u8L("Min") + "##a_2").c_str(), [&]() {
+            m_parent.get_selection().align(2, 0, false);
+        });
+
+        // Row 2: Mid
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex(0);
+        ImGui::TextUnformatted("");
+        
+        ImGui::TableSetColumnIndex(1);
+        render_centered_button((_u8L("Mid") + "##a_0").c_str(), [&]() {
+            m_parent.get_selection().align(0, 1, false);
+        });
+        ImGui::TableSetColumnIndex(2);
+        render_centered_button((_u8L("Mid") + "##a_1").c_str(), [&]() {
+            m_parent.get_selection().align(1, 1, false);
+        });
+        ImGui::TableSetColumnIndex(3);
+        render_centered_button((_u8L("Mid") + "##a_2").c_str(), [&]() {
+            m_parent.get_selection().align(2, 1, false);
+        });
+
+        // Row 3: Max
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex(0);
+        ImGui::TextUnformatted("");
+        
+        ImGui::TableSetColumnIndex(1);
+        render_centered_button((_u8L("Max") + "##a_0").c_str(), [&]() {
+            m_parent.get_selection().align(0, 2, false);
+        });
+        ImGui::TableSetColumnIndex(2);
+        render_centered_button((_u8L("Max") + "##a_1").c_str(), [&]() {
+            m_parent.get_selection().align(1, 2, false);
+        });
+        ImGui::TableSetColumnIndex(3);
+        render_centered_button((_u8L("Max") + "##a_2").c_str(), [&]() {
+            m_parent.get_selection().align(2, 2, false);
+        });
+
+        // Distribute rows
+        // Row 4: Min
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex(0);
+        ImGui::Text("%s", _u8L("Distribute").c_str());
+        
+        ImGui::TableSetColumnIndex(1);
+        render_centered_button((_u8L("Min") + "##d_0").c_str(), [&]() {
+            m_parent.get_selection().align(0, 0, true);
+        });
+        ImGui::TableSetColumnIndex(2);
+        render_centered_button((_u8L("Min") + "##d_1").c_str(), [&]() {
+            m_parent.get_selection().align(1, 0, true);
+        });
+        ImGui::TableSetColumnIndex(3);
+        render_centered_button((_u8L("Min") + "##d_2").c_str(), [&]() {
+            m_parent.get_selection().align(2, 0, true);
+        });
+
+        // Row 5: Mid
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex(0);
+        ImGui::TextUnformatted("");
+        
+        ImGui::TableSetColumnIndex(1);
+        render_centered_button((_u8L("Mid") + "##d_0").c_str(), [&]() {
+            m_parent.get_selection().align(0, 1, true);
+        });
+        ImGui::TableSetColumnIndex(2);
+        render_centered_button((_u8L("Mid") + "##d_1").c_str(), [&]() {
+            m_parent.get_selection().align(1, 1, true);
+        });
+        ImGui::TableSetColumnIndex(3);
+        render_centered_button((_u8L("Mid") + "##d_2").c_str(), [&]() {
+            m_parent.get_selection().align(2, 1, true);
+        });
+
+        // Row 6: Max
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex(0);
+        ImGui::TextUnformatted("");
+        
+        ImGui::TableSetColumnIndex(1);
+        render_centered_button((_u8L("Max") + "##d_0").c_str(), [&]() {
+            m_parent.get_selection().align(0, 2, true);
+        });
+        ImGui::TableSetColumnIndex(2);
+        render_centered_button((_u8L("Max") + "##d_1").c_str(), [&]() {
+            m_parent.get_selection().align(1, 2, true);
+        });
+        ImGui::TableSetColumnIndex(3);
+        render_centered_button((_u8L("Max") + "##d_2").c_str(), [&]() {
+            m_parent.get_selection().align(2, 2, true);
+        });
+
+        ImGui::PopStyleColor(4);
+        ImGui::EndTable();
+    }
+
+    m_imgui->end();
+    m_imgui->pop_common_window_style();
+}
+
+} // namespace Slic3r::GUI

--- a/src/slic3r/GUI/Gizmos/GLGizmoAlign.hpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoAlign.hpp
@@ -1,0 +1,27 @@
+#ifndef slic3r_GLGizmoAlign_hpp_
+#define slic3r_GLGizmoAlign_hpp_
+
+#include "GLGizmoBase.hpp"
+
+namespace Slic3r {
+namespace GUI {
+
+class GLGizmoAlign : public GLGizmoBase
+{
+public:
+    GLGizmoAlign(GLCanvas3D& parent, const std::string& icon_filename, unsigned int sprite_id);
+    ~GLGizmoAlign() override = default;
+
+protected:
+    std::string on_get_name() const override;
+    void on_render_input_window(float x, float y, float bottom_limit) override;
+    bool on_is_activable() const override;
+    bool on_init() override { return true; }
+    void on_render() override {}
+    CommonGizmosDataID on_get_requirements() const override;
+};
+
+} // namespace GUI
+} // namespace Slic3r
+
+#endif // slic3r_GLGizmoAlign_hpp_

--- a/src/slic3r/GUI/Gizmos/GLGizmosManager.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmosManager.cpp
@@ -13,6 +13,7 @@
 #include "slic3r/GUI/Gizmos/GLGizmoScale.hpp"
 #include "slic3r/GUI/Gizmos/GLGizmoRotate.hpp"
 #include "slic3r/GUI/Gizmos/GLGizmoFlatten.hpp"
+#include "slic3r/GUI/Gizmos/GLGizmoAlign.hpp"
 //#include "slic3r/GUI/Gizmos/GLGizmoSlaSupports.hpp"
 #include "slic3r/GUI/Gizmos/GLGizmoFdmSupports.hpp"
 #include "slic3r/GUI/Gizmos/GLGizmoFuzzySkin.hpp"
@@ -143,6 +144,9 @@ void GLGizmosManager::switch_gizmos_icon_filename()
         case(EType::Scale):
             gizmo->set_icon_filename(m_is_dark ? "toolbar_scale_dark.svg" : "toolbar_scale.svg");
             break;
+        case(EType::Align):
+            gizmo->set_icon_filename("align_horizontal_left.svg");
+            break;
         case(EType::Flatten):
             gizmo->set_icon_filename(m_is_dark ? "toolbar_flatten_dark.svg" : "toolbar_flatten.svg");
             break;
@@ -206,6 +210,7 @@ bool GLGizmosManager::init()
     m_gizmos.emplace_back(new GLGizmoMove3D(m_parent, m_is_dark ? "toolbar_move_dark.svg" : "toolbar_move.svg", EType::Move, &m_object_manipulation));
     m_gizmos.emplace_back(new GLGizmoRotate3D(m_parent, m_is_dark ? "toolbar_rotate_dark.svg" : "toolbar_rotate.svg", EType::Rotate, &m_object_manipulation));
     m_gizmos.emplace_back(new GLGizmoScale3D(m_parent, m_is_dark ? "toolbar_scale_dark.svg" : "toolbar_scale.svg", EType::Scale, &m_object_manipulation));
+    m_gizmos.emplace_back(new GLGizmoAlign(m_parent, "align_horizontal_left.svg", EType::Align));
     m_gizmos.emplace_back(new GLGizmoFlatten(m_parent, m_is_dark ? "toolbar_flatten_dark.svg" : "toolbar_flatten.svg", EType::Flatten));
     m_gizmos.emplace_back(new GLGizmoCut3D(m_parent, m_is_dark ? "toolbar_cut_dark.svg" : "toolbar_cut.svg", EType::Cut));
     m_gizmos.emplace_back(new GLGizmoMeshBoolean(m_parent, m_is_dark ? "toolbar_meshboolean_dark.svg" : "toolbar_meshboolean.svg", EType::MeshBoolean));
@@ -1470,6 +1475,8 @@ std::string get_name_from_gizmo_etype(GLGizmosManager::EType type)
         return "Rotate";
     case GLGizmosManager::EType::Scale:
         return "Scale";
+    case GLGizmosManager::EType::Align:
+        return "Align";
     case GLGizmosManager::EType::Flatten:
         return "Flatten";
     case GLGizmosManager::EType::Cut:

--- a/src/slic3r/GUI/Gizmos/GLGizmosManager.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmosManager.cpp
@@ -145,7 +145,7 @@ void GLGizmosManager::switch_gizmos_icon_filename()
             gizmo->set_icon_filename(m_is_dark ? "toolbar_scale_dark.svg" : "toolbar_scale.svg");
             break;
         case(EType::Align):
-            gizmo->set_icon_filename("align_horizontal_left.svg");
+            gizmo->set_icon_filename(m_is_dark ? "toolbar_align_dark.svg" : "toolbar_align.svg");
             break;
         case(EType::Flatten):
             gizmo->set_icon_filename(m_is_dark ? "toolbar_flatten_dark.svg" : "toolbar_flatten.svg");
@@ -210,7 +210,7 @@ bool GLGizmosManager::init()
     m_gizmos.emplace_back(new GLGizmoMove3D(m_parent, m_is_dark ? "toolbar_move_dark.svg" : "toolbar_move.svg", EType::Move, &m_object_manipulation));
     m_gizmos.emplace_back(new GLGizmoRotate3D(m_parent, m_is_dark ? "toolbar_rotate_dark.svg" : "toolbar_rotate.svg", EType::Rotate, &m_object_manipulation));
     m_gizmos.emplace_back(new GLGizmoScale3D(m_parent, m_is_dark ? "toolbar_scale_dark.svg" : "toolbar_scale.svg", EType::Scale, &m_object_manipulation));
-    m_gizmos.emplace_back(new GLGizmoAlign(m_parent, "align_horizontal_left.svg", EType::Align));
+    m_gizmos.emplace_back(new GLGizmoAlign(m_parent, m_is_dark ? "toolbar_align_dark.svg" : "toolbar_align.svg", EType::Align));
     m_gizmos.emplace_back(new GLGizmoFlatten(m_parent, m_is_dark ? "toolbar_flatten_dark.svg" : "toolbar_flatten.svg", EType::Flatten));
     m_gizmos.emplace_back(new GLGizmoCut3D(m_parent, m_is_dark ? "toolbar_cut_dark.svg" : "toolbar_cut.svg", EType::Cut));
     m_gizmos.emplace_back(new GLGizmoMeshBoolean(m_parent, m_is_dark ? "toolbar_meshboolean_dark.svg" : "toolbar_meshboolean.svg", EType::MeshBoolean));

--- a/src/slic3r/GUI/Gizmos/GLGizmosManager.hpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmosManager.hpp
@@ -77,6 +77,7 @@ public:
         Move,
         Rotate,
         Scale,
+        Align,
         Flatten,
         Cut,
         MeshBoolean,

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -11972,8 +11972,8 @@ void Plater::priv::update_after_undo_redo(const UndoRedo::Snapshot& snapshot, bo
         this->undo_redo_stack().release_least_recently_used();
     //YS_FIXME update obj_list from the deserialized model (maybe store ObjectIDs into the tree?) (no selections at this point of time)
         get_current_canvas3D()->get_canvas_type() == GLCanvas3D::CanvasAssembleView ?
-            assemble_view->get_canvas3d()->get_selection().set_deserialized(GUI::Selection::EMode(this->undo_redo_stack().selection_deserialized().mode), this->undo_redo_stack().selection_deserialized().volumes_and_instances) :
-            this->view3D->get_canvas3d()->get_selection().set_deserialized(GUI::Selection::EMode(this->undo_redo_stack().selection_deserialized().mode), this->undo_redo_stack().selection_deserialized().volumes_and_instances);
+            assemble_view->get_canvas3d()->get_selection().set_deserialized(GUI::Selection::EMode(this->undo_redo_stack().selection_deserialized().mode), this->undo_redo_stack().selection_deserialized().volumes_and_instances, this->undo_redo_stack().selection_deserialized().selection_order) :
+            this->view3D->get_canvas3d()->get_selection().set_deserialized(GUI::Selection::EMode(this->undo_redo_stack().selection_deserialized().mode), this->undo_redo_stack().selection_deserialized().volumes_and_instances, this->undo_redo_stack().selection_deserialized().selection_order);
     get_current_canvas3D()->get_canvas_type() == GLCanvas3D::CanvasAssembleView ?
         assemble_view->get_canvas3d()->get_gizmos_manager().update_after_undo_redo(snapshot) :
         this->view3D->get_canvas3d()->get_gizmos_manager().update_after_undo_redo(snapshot);

--- a/src/slic3r/GUI/Selection.cpp
+++ b/src/slic3r/GUI/Selection.cpp
@@ -116,6 +116,7 @@ Selection::Selection()
     , m_type(Empty)
     , m_valid(false)
     , m_scale_factor(1.0f)
+    , m_is_full_selection(false)
 {
     this->set_bounding_boxes_dirty();
 }
@@ -160,6 +161,8 @@ void Selection::add(unsigned int volume_idx, bool as_single_selection, bool chec
 {
     if (!m_valid || (unsigned int)m_volumes->size() <= volume_idx)
         return;
+
+    m_is_full_selection = false;
 
     const GLVolume* volume = (*m_volumes)[volume_idx];
     //BBS: multiple wipe tower case should be considered
@@ -259,6 +262,8 @@ void Selection::add_object(unsigned int object_idx, bool as_single_selection)
     if (!m_valid)
         return;
 
+    m_is_full_selection = as_single_selection;
+
     std::vector<unsigned int> volume_idxs = get_volume_idxs_from_object(object_idx);
     if ((!as_single_selection && contains_all_volumes(volume_idxs)) ||
         (as_single_selection && matches(volume_idxs)))
@@ -295,6 +300,8 @@ void Selection::add_instance(unsigned int object_idx, unsigned int instance_idx,
 {
     if (!m_valid)
         return;
+
+    m_is_full_selection = as_single_selection;
 
     const std::vector<unsigned int> volume_idxs = get_volume_idxs_from_instance(object_idx, instance_idx);
     if ((!as_single_selection && contains_all_volumes(volume_idxs)) ||
@@ -333,6 +340,8 @@ void Selection::add_volume(unsigned int object_idx, unsigned int volume_idx, int
     if (!m_valid)
         return;
 
+    m_is_full_selection = false;
+
     std::vector<unsigned int> volume_idxs = get_volume_idxs_from_volume(object_idx, instance_idx, volume_idx);
     if ((!as_single_selection && contains_all_volumes(volume_idxs)) ||
         (as_single_selection && matches(volume_idxs)))
@@ -369,6 +378,8 @@ void Selection::add_volumes(EMode mode, const std::vector<unsigned int>& volume_
 {
     if (!m_valid)
         return;
+
+    m_is_full_selection = false;
 
     if ((!as_single_selection && contains_all_volumes(volume_idxs)) ||
         (as_single_selection && matches(volume_idxs)))
@@ -460,6 +471,8 @@ void Selection::add_curr_plate()
 void Selection::add_object_from_idx(std::vector<int>& object_idxs) {
     if (!m_valid)
         return;
+
+    m_is_full_selection = true;
 
     m_mode = Instance;
     clear();
@@ -726,18 +739,20 @@ void Selection::set_deserialized(EMode mode, const std::vector<std::pair<size_t,
         }
     }
 
-    // Fallback/Backward compatibility: add any remaining volumes that are in volumes_and_instances
-    // but were not in selection_order (or if selection_order was empty)
-    for (const auto& geo_id : volumes_and_instances) {
-        auto it = geo_to_idx.find(geo_id);
-        if (it != geo_to_idx.end()) {
-            if (m_list.find(it->second) == m_list.end()) {
-                do_add_volume(it->second);
+    // Fallback/Backward compatibility: if selection_order was empty, add all volumes in volumes_and_instances
+    if (selection_order.empty()) {
+        for (const auto& geo_id : volumes_and_instances) {
+            auto it = geo_to_idx.find(geo_id);
+            if (it != geo_to_idx.end()) {
+                if (m_list.find(it->second) == m_list.end()) {
+                    do_add_volume(it->second);
+                }
             }
         }
     }
 
     update_type();
+    m_is_full_selection = (is_single_full_object() || is_single_full_instance());
     set_bounding_boxes_dirty();
 }
 
@@ -3645,10 +3660,12 @@ void Selection::align(int axis, int align_type, bool distribute)
             return;
         }
 
-        bool align_to_global = (is_single_full_object() || is_single_full_instance());
+        bool align_to_global = (m_mode == Instance) && (is_single_full_object() || is_single_full_instance());
+
+        bool is_single_object_selected = (is_single_full_object() || is_single_full_instance()) && m_is_full_selection;
 
         BoundingBoxf3 anchor_bbox;
-        if (m_mode == Instance) {
+        if (m_mode == Instance || is_single_object_selected) {
             anchor_bbox = m_model->objects[anchor_obj_idx]->instance_bounding_box(anchor_inst_idx);
         } else if (m_mode == Volume) {
             if (anchor_gl_vol_idx < m_volumes->size()) {
@@ -3717,7 +3734,7 @@ void Selection::align(int axis, int align_type, bool distribute)
         } else if (m_mode == Volume) {
             set_caches();
             for (unsigned int i : m_list) {
-                if (!align_to_global && i == anchor_gl_vol_idx) {
+                if (!align_to_global && !is_single_object_selected && i == anchor_gl_vol_idx) {
                     BOOST_LOG_TRIVIAL(info) << "Skipping anchor volume " << i;
                     continue;
                 }
@@ -3751,12 +3768,16 @@ void Selection::align(int axis, int align_type, bool distribute)
         }
     }
 
-    auto active_canvas = wxGetApp().plater()->canvas3D();
-    if (active_canvas) {
-        BOOST_LOG_TRIVIAL(info) << "Calling do_move on active canvas: " << (int)active_canvas->get_canvas_type();
-        active_canvas->do_move(L("Align objects"));
+    if (wxApp::GetInstance() != nullptr && wxGetApp().plater() != nullptr) {
+        auto active_canvas = wxGetApp().plater()->canvas3D();
+        if (active_canvas) {
+            BOOST_LOG_TRIVIAL(info) << "Calling do_move on active canvas: " << (int)active_canvas->get_canvas_type();
+            active_canvas->do_move(L("Align objects"));
+        } else {
+            BOOST_LOG_TRIVIAL(error) << "No active canvas found to call do_move!";
+        }
     } else {
-        BOOST_LOG_TRIVIAL(error) << "No active canvas found to call do_move!";
+        BOOST_LOG_TRIVIAL(info) << "No active plater. Skipping canvas update.";
     }
 
     if (mode_changed) {

--- a/src/slic3r/GUI/Selection.cpp
+++ b/src/slic3r/GUI/Selection.cpp
@@ -1,5 +1,7 @@
 #include "libslic3r/libslic3r.h"
 #include "Selection.hpp"
+#include <algorithm>
+#include <map>
 
 #include "3DScene.hpp"
 #include "GLCanvas3D.hpp"
@@ -700,7 +702,7 @@ void Selection::remove_all()
     clear();
 }
 
-void Selection::set_deserialized(EMode mode, const std::vector<std::pair<size_t, size_t>> &volumes_and_instances)
+void Selection::set_deserialized(EMode mode, const std::vector<std::pair<size_t, size_t>> &volumes_and_instances, const std::vector<std::pair<size_t, size_t>> &selection_order)
 {
     if (! m_valid)
         return;
@@ -709,9 +711,32 @@ void Selection::set_deserialized(EMode mode, const std::vector<std::pair<size_t,
     for (unsigned int i : m_list)
         (*m_volumes)[i]->selected = false;
     m_list.clear();
-    for (unsigned int i = 0; i < (unsigned int)m_volumes->size(); ++ i)
-		if (std::binary_search(volumes_and_instances.begin(), volumes_and_instances.end(), (*m_volumes)[i]->geometry_id))
-			do_add_volume(i);
+    m_selection_order.clear();
+
+    std::map<std::pair<size_t, size_t>, unsigned int> geo_to_idx;
+    for (unsigned int i = 0; i < (unsigned int)m_volumes->size(); ++ i) {
+        geo_to_idx[(*m_volumes)[i]->geometry_id] = i;
+    }
+
+    // Add volumes in the order they were selected
+    for (const auto& geo_id : selection_order) {
+        auto it = geo_to_idx.find(geo_id);
+        if (it != geo_to_idx.end()) {
+            do_add_volume(it->second);
+        }
+    }
+
+    // Fallback/Backward compatibility: add any remaining volumes that are in volumes_and_instances
+    // but were not in selection_order (or if selection_order was empty)
+    for (const auto& geo_id : volumes_and_instances) {
+        auto it = geo_to_idx.find(geo_id);
+        if (it != geo_to_idx.end()) {
+            if (m_list.find(it->second) == m_list.end()) {
+                do_add_volume(it->second);
+            }
+        }
+    }
+
     update_type();
     set_bounding_boxes_dirty();
 }
@@ -745,6 +770,7 @@ void Selection::clear()
 #endif // ENABLE_MODIFIERS_ALWAYS_TRANSPARENT
 
     m_list.clear();
+    m_selection_order.clear();
 
     update_type();
     set_bounding_boxes_dirty();
@@ -768,13 +794,61 @@ void Selection::instances_changed(const std::vector<size_t> &instance_ids_select
 {
     assert(m_valid);
     assert(m_mode == Instance);
+
+    // 1. Extract the selected instances in their selection order
+    std::vector<std::pair<int, int>> selected_instances_in_order;
+    for (unsigned int idx : m_selection_order) {
+        if (idx < m_volumes->size()) {
+            const GLVolume* volume = (*m_volumes)[idx];
+            std::pair<int, int> inst = {volume->object_idx(), volume->instance_idx()};
+            if (std::find(selected_instances_in_order.begin(), selected_instances_in_order.end(), inst) == selected_instances_in_order.end()) {
+                selected_instances_in_order.push_back(inst);
+            }
+        }
+    }
+
     m_list.clear();
+    m_selection_order.clear();
+
+    std::vector<size_t> remaining_ids = instance_ids_selected;
+
+    // 2. Add volumes for instances in their selection order
+    for (const auto& inst : selected_instances_in_order) {
+        bool found = false;
+        size_t found_id = 0;
+        std::vector<unsigned int> inst_vols;
+        for (unsigned int volume_idx = 0; volume_idx < (unsigned int)m_volumes->size(); ++volume_idx) {
+            const GLVolume *volume = (*m_volumes)[volume_idx];
+            if (volume->object_idx() == inst.first && volume->instance_idx() == inst.second) {
+                inst_vols.push_back(volume_idx);
+                auto it = std::lower_bound(remaining_ids.begin(), remaining_ids.end(), volume->geometry_id.second);
+                if (it != remaining_ids.end() && *it == volume->geometry_id.second) {
+                    found = true;
+                    found_id = volume->geometry_id.second;
+                }
+            }
+        }
+
+        if (found) {
+            for (unsigned int vol_idx : inst_vols) {
+                this->do_add_volume(vol_idx);
+            }
+            auto it = std::find(remaining_ids.begin(), remaining_ids.end(), found_id);
+            if (it != remaining_ids.end()) {
+                remaining_ids.erase(it);
+            }
+        }
+    }
+
+    // 3. Add any remaining instances (which are new)
     for (unsigned int volume_idx = 0; volume_idx < (unsigned int)m_volumes->size(); ++ volume_idx) {
         const GLVolume *volume = (*m_volumes)[volume_idx];
-        auto it = std::lower_bound(instance_ids_selected.begin(), instance_ids_selected.end(), volume->geometry_id.second);
-		if (it != instance_ids_selected.end() && *it == volume->geometry_id.second)
+        auto it = std::lower_bound(remaining_ids.begin(), remaining_ids.end(), volume->geometry_id.second);
+        if (it != remaining_ids.end() && *it == volume->geometry_id.second) {
             this->do_add_volume(volume_idx);
+        }
     }
+
     update_type();
     this->set_bounding_boxes_dirty();
 }
@@ -793,6 +867,16 @@ void Selection::volumes_changed(const std::vector<size_t> &map_volume_old_to_new
             list_new.insert(new_idx);
         }
     m_list = std::move(list_new);
+
+    // Map selection order to preserve click order!
+    std::vector<unsigned int> order_new;
+    for (unsigned int idx : m_selection_order) {
+        if (idx < map_volume_old_to_new.size() && map_volume_old_to_new[idx] != size_t(-1)) {
+            order_new.push_back((unsigned int)map_volume_old_to_new[idx]);
+        }
+    }
+    m_selection_order = std::move(order_new);
+
     update_type();
     this->set_bounding_boxes_dirty();
 }
@@ -2533,6 +2617,9 @@ void Selection::set_caches()
 void Selection::do_add_volume(unsigned int volume_idx)
 {
     m_list.insert(volume_idx);
+    if (std::find(m_selection_order.begin(), m_selection_order.end(), volume_idx) == m_selection_order.end()) {
+        m_selection_order.push_back(volume_idx);
+    }
     GLVolume* v = (*m_volumes)[volume_idx];
     v->selected = true;
     if (v->hover == GLVolume::HS_Select || v->hover == GLVolume::HS_Deselect)
@@ -2555,6 +2642,10 @@ void Selection::do_remove_volume(unsigned int volume_idx)
         return;
 
     m_list.erase(v_it);
+    auto order_it = std::find(m_selection_order.begin(), m_selection_order.end(), volume_idx);
+    if (order_it != m_selection_order.end()) {
+        m_selection_order.erase(order_it);
+    }
 
     (*m_volumes)[volume_idx]->selected = false;
 }
@@ -3384,6 +3475,293 @@ void Selection::transform_volume_relative(GLVolume& volume, const VolumeCache& v
         volume.set_volume_transformation(vol_trafo.get_matrix() * transform);
     else
         assert(false);
+}
+
+void Selection::align(int axis, int align_type, bool distribute)
+{
+    BOOST_LOG_TRIVIAL(info) << "Selection::align started: axis=" << axis << ", align_type=" << align_type << ", distribute=" << distribute;
+    std::string order_str;
+    for (unsigned int idx : m_selection_order) {
+        order_str += std::to_string(idx) + " ";
+    }
+    BOOST_LOG_TRIVIAL(info) << "m_selection_order: " << order_str;
+    BOOST_LOG_TRIVIAL(info) << "m_valid=" << m_valid << ", m_selection_order.size()=" << m_selection_order.size() << ", m_list.size()=" << m_list.size() << ", m_mode=" << (int)m_mode;
+
+    if (!m_valid || m_selection_order.empty() || m_list.empty()) {
+        BOOST_LOG_TRIVIAL(warning) << "Selection::align early exit due to invalid selection / empty list";
+        return;
+    }
+
+    BOOST_LOG_TRIVIAL(info) << "m_cache.content.size()=" << m_cache.content.size();
+
+    size_t total_selected_instances = 0;
+    for (const auto& [obj_idx, inst_list] : m_cache.content) {
+        total_selected_instances += inst_list.size();
+    }
+    BOOST_LOG_TRIVIAL(info) << "total_selected_instances=" << total_selected_instances;
+
+    EMode old_mode = m_mode;
+    bool mode_changed = false;
+    if (m_mode == Instance && total_selected_instances <= 1 && m_list.size() > 1) {
+        BOOST_LOG_TRIVIAL(info) << "align: only 1 instance selected with multiple volumes. Temporarily switching to Volume mode.";
+        m_mode = Volume;
+        mode_changed = true;
+    }
+
+    // Distribute objects along axis
+    if (distribute) {
+        if (m_mode == Instance) {
+            struct SelectedInstance {
+                int obj_idx;
+                int inst_idx;
+                double val;
+            };
+            std::vector<SelectedInstance> selected_instances;
+            for (const auto& [obj_idx, inst_list] : m_cache.content) {
+                ModelObject* mo = m_model->objects[obj_idx];
+                for (int inst_idx : inst_list) {
+                    BoundingBoxf3 inst_bbox = mo->instance_bounding_box(inst_idx);
+                    double val = 0.0;
+                    if (align_type == 0) {
+                        val = inst_bbox.min[axis];
+                    } else if (align_type == 1) {
+                        val = inst_bbox.center()[axis];
+                    } else if (align_type == 2) {
+                        val = inst_bbox.max[axis];
+                    }
+                    selected_instances.push_back({obj_idx, inst_idx, val});
+                }
+            }
+
+            BOOST_LOG_TRIVIAL(info) << "selected_instances.size()=" << selected_instances.size();
+
+            if (selected_instances.size() <= 2) {
+                BOOST_LOG_TRIVIAL(warning) << "Not enough instances to distribute (need >= 3)";
+                if (mode_changed) m_mode = old_mode;
+                return;
+            }
+
+            std::sort(selected_instances.begin(), selected_instances.end(), [](const SelectedInstance& a, const SelectedInstance& b) {
+                return a.val < b.val;
+            });
+
+            double min_val = selected_instances.front().val;
+            double max_val = selected_instances.back().val;
+            double total_dist = max_val - min_val;
+            size_t N = selected_instances.size();
+
+            BOOST_LOG_TRIVIAL(info) << "distribute min_val=" << min_val << ", max_val=" << max_val << ", total_dist=" << total_dist;
+
+            for (size_t i = 1; i < N - 1; ++i) {
+                const auto& item = selected_instances[i];
+                double target_val = min_val + i * (total_dist / (N - 1));
+                double diff = target_val - item.val;
+                BOOST_LOG_TRIVIAL(info) << "distribute instance item i=" << i << ", val=" << item.val << ", target_val=" << target_val << ", diff=" << diff;
+                if (std::abs(diff) > 1e-6) {
+                    Vec3d displacement(0.0, 0.0, 0.0);
+                    displacement[axis] = diff;
+                    this->translate(item.obj_idx, item.inst_idx, displacement);
+                }
+            }
+        } else if (m_mode == Volume) {
+            struct SelectedVolume {
+                unsigned int gl_vol_idx;
+                int obj_idx;
+                int inst_idx;
+                int vol_idx;
+                double val;
+            };
+            std::vector<SelectedVolume> selected_volumes;
+            for (unsigned int i : m_list) {
+                GLVolume& v = *(*m_volumes)[i];
+                int obj_idx = v.object_idx();
+                int inst_idx = v.instance_idx();
+                int vol_idx = v.volume_idx();
+                if (obj_idx >= 0 && vol_idx >= 0) {
+                    double val = 0.0;
+                    if (align_type == 0) {
+                        val = v.transformed_convex_hull_bounding_box().min[axis];
+                    } else if (align_type == 1) {
+                        val = v.transformed_convex_hull_bounding_box().center()[axis];
+                    } else if (align_type == 2) {
+                        val = v.transformed_convex_hull_bounding_box().max[axis];
+                    }
+                    selected_volumes.push_back({i, obj_idx, inst_idx, vol_idx, val});
+                }
+            }
+
+            BOOST_LOG_TRIVIAL(info) << "selected_volumes.size()=" << selected_volumes.size();
+
+            if (selected_volumes.size() <= 2) {
+                BOOST_LOG_TRIVIAL(warning) << "Not enough volumes to distribute (need >= 3)";
+                if (mode_changed) m_mode = old_mode;
+                return;
+            }
+
+            std::sort(selected_volumes.begin(), selected_volumes.end(), [](const SelectedVolume& a, const SelectedVolume& b) {
+                return a.val < b.val;
+            });
+
+            double min_val = selected_volumes.front().val;
+            double max_val = selected_volumes.back().val;
+            double total_dist = max_val - min_val;
+            size_t N = selected_volumes.size();
+
+            BOOST_LOG_TRIVIAL(info) << "distribute volumes min_val=" << min_val << ", max_val=" << max_val << ", total_dist=" << total_dist;
+
+            set_caches();
+
+            for (size_t i = 1; i < N - 1; ++i) {
+                const auto& item = selected_volumes[i];
+                double target_val = min_val + i * (total_dist / (N - 1));
+                double diff = target_val - item.val;
+                BOOST_LOG_TRIVIAL(info) << "distribute volume item i=" << i << ", val=" << item.val << ", target_val=" << target_val << ", diff=" << diff;
+                if (std::abs(diff) > 1e-6) {
+                    Vec3d displacement(0.0, 0.0, 0.0);
+                    displacement[axis] = diff;
+                    const VolumeCache& volume_data = m_cache.volumes_data[item.gl_vol_idx];
+                    const Vec3d local_displacement = (volume_data.get_instance_rotation_matrix() * volume_data.get_instance_scale_matrix() * volume_data.get_instance_mirror_matrix()).inverse() * displacement;
+                    this->translate(item.obj_idx, item.inst_idx, item.vol_idx, local_displacement);
+                }
+            }
+        }
+    } else {
+        int anchor_obj_idx = -1;
+        int anchor_inst_idx = -1;
+        int anchor_vol_idx = -1;
+        unsigned int anchor_gl_vol_idx = m_selection_order.front();
+        if (anchor_gl_vol_idx < m_volumes->size()) {
+            GLVolume* v = (*m_volumes)[anchor_gl_vol_idx];
+            anchor_obj_idx = v->object_idx();
+            anchor_inst_idx = v->instance_idx();
+            anchor_vol_idx = v->volume_idx();
+        }
+
+        BOOST_LOG_TRIVIAL(info) << "align anchor_gl_vol_idx=" << anchor_gl_vol_idx << ", anchor_obj=" << anchor_obj_idx << ", anchor_inst=" << anchor_inst_idx;
+
+        if (anchor_obj_idx < 0) {
+            BOOST_LOG_TRIVIAL(warning) << "Invalid anchor_obj_idx < 0";
+            if (mode_changed) m_mode = old_mode;
+            return;
+        }
+
+        bool align_to_global = (is_single_full_object() || is_single_full_instance());
+
+        BoundingBoxf3 anchor_bbox;
+        if (m_mode == Instance) {
+            anchor_bbox = m_model->objects[anchor_obj_idx]->instance_bounding_box(anchor_inst_idx);
+        } else if (m_mode == Volume) {
+            if (anchor_gl_vol_idx < m_volumes->size()) {
+                anchor_bbox = (*m_volumes)[anchor_gl_vol_idx]->transformed_convex_hull_bounding_box();
+            } else {
+                BOOST_LOG_TRIVIAL(warning) << "anchor_gl_vol_idx out of bounds";
+                if (mode_changed) m_mode = old_mode;
+                return;
+            }
+        }
+
+        double target_coord = 0.0;
+        if (align_to_global) {
+            BoundingBoxf3 global_bbox = get_bounding_box();
+            if (align_type == 0) {
+                target_coord = global_bbox.min[axis];
+            } else if (align_type == 1) {
+                target_coord = global_bbox.center()[axis];
+            } else if (align_type == 2) {
+                target_coord = global_bbox.max[axis];
+            }
+        } else {
+            if (align_type == 0) {
+                target_coord = anchor_bbox.min[axis];
+            } else if (align_type == 1) {
+                target_coord = anchor_bbox.center()[axis];
+            } else if (align_type == 2) {
+                target_coord = anchor_bbox.max[axis];
+            } else {
+                BOOST_LOG_TRIVIAL(warning) << "Invalid align_type: " << align_type;
+                if (mode_changed) m_mode = old_mode;
+                return;
+            }
+        }
+
+        BOOST_LOG_TRIVIAL(info) << "align target_coord=" << target_coord << ", align_to_global=" << align_to_global;
+
+        if (m_mode == Instance) {
+            for (const auto& [obj_idx, inst_list] : m_cache.content) {
+                ModelObject* mo = m_model->objects[obj_idx];
+                for (int inst_idx : inst_list) {
+                    if (obj_idx == anchor_obj_idx && inst_idx == anchor_inst_idx) {
+                        BOOST_LOG_TRIVIAL(info) << "Skipping anchor object " << obj_idx << ", instance " << inst_idx;
+                        continue;
+                    }
+
+                    BoundingBoxf3 inst_bbox = mo->instance_bounding_box(inst_idx);
+                    double current_coord = 0.0;
+                    if (align_type == 0) {
+                        current_coord = inst_bbox.min[axis];
+                    } else if (align_type == 1) {
+                        current_coord = inst_bbox.center()[axis];
+                    } else if (align_type == 2) {
+                        current_coord = inst_bbox.max[axis];
+                    }
+
+                    double diff = target_coord - current_coord;
+                    BOOST_LOG_TRIVIAL(info) << "align instance object=" << obj_idx << ", instance=" << inst_idx << ", coord=" << current_coord << ", diff=" << diff;
+                    if (std::abs(diff) > 1e-6) {
+                        Vec3d displacement(0.0, 0.0, 0.0);
+                        displacement[axis] = diff;
+                        this->translate(obj_idx, inst_idx, displacement);
+                    }
+                }
+            }
+        } else if (m_mode == Volume) {
+            set_caches();
+            for (unsigned int i : m_list) {
+                if (!align_to_global && i == anchor_gl_vol_idx) {
+                    BOOST_LOG_TRIVIAL(info) << "Skipping anchor volume " << i;
+                    continue;
+                }
+
+                GLVolume& v = *(*m_volumes)[i];
+                int obj_idx = v.object_idx();
+                int inst_idx = v.instance_idx();
+                int vol_idx = v.volume_idx();
+                if (obj_idx >= 0 && vol_idx >= 0) {
+                    const BoundingBoxf3& vol_bbox = v.transformed_convex_hull_bounding_box();
+                    double current_coord = 0.0;
+                    if (align_type == 0) {
+                        current_coord = vol_bbox.min[axis];
+                    } else if (align_type == 1) {
+                        current_coord = vol_bbox.center()[axis];
+                    } else if (align_type == 2) {
+                        current_coord = vol_bbox.max[axis];
+                    }
+
+                    double diff = target_coord - current_coord;
+                    BOOST_LOG_TRIVIAL(info) << "align volume gl_idx=" << i << ", object=" << obj_idx << ", volume=" << vol_idx << ", coord=" << current_coord << ", diff=" << diff;
+                    if (std::abs(diff) > 1e-6) {
+                        Vec3d displacement(0.0, 0.0, 0.0);
+                        displacement[axis] = diff;
+                        const VolumeCache& volume_data = m_cache.volumes_data[i];
+                        const Vec3d local_displacement = (volume_data.get_instance_rotation_matrix() * volume_data.get_instance_scale_matrix() * volume_data.get_instance_mirror_matrix()).inverse() * displacement;
+                        this->translate(obj_idx, inst_idx, vol_idx, local_displacement);
+                    }
+                }
+            }
+        }
+    }
+
+    auto active_canvas = wxGetApp().plater()->canvas3D();
+    if (active_canvas) {
+        BOOST_LOG_TRIVIAL(info) << "Calling do_move on active canvas: " << (int)active_canvas->get_canvas_type();
+        active_canvas->do_move(L("Align objects"));
+    } else {
+        BOOST_LOG_TRIVIAL(error) << "No active canvas found to call do_move!";
+    }
+
+    if (mode_changed) {
+        m_mode = old_mode;
+    }
 }
 
 ModelVolume *get_selected_volume(const Selection &selection)

--- a/src/slic3r/GUI/Selection.hpp
+++ b/src/slic3r/GUI/Selection.hpp
@@ -149,6 +149,8 @@ private:
     EType m_type;
     // set of indices to m_volumes
     IndicesList m_list;
+    // set of indices to keep selection order
+    std::vector<unsigned int> m_selection_order;
     Cache m_cache;
     Clipboard m_clipboard;
     std::optional<BoundingBoxf3> m_bounding_box;
@@ -245,7 +247,7 @@ public:
     void remove_all();
 
     // To be called after Undo or Redo once the volumes are updated.
-    void set_deserialized(EMode mode, const std::vector<std::pair<size_t, size_t>> &volumes_and_instances);
+    void set_deserialized(EMode mode, const std::vector<std::pair<size_t, size_t>> &volumes_and_instances, const std::vector<std::pair<size_t, size_t>> &selection_order = {});
 
     // Update the selection based on the new instance IDs.
 	void instances_changed(const std::vector<size_t> &instance_ids_selected);
@@ -298,6 +300,8 @@ public:
     const InstanceIdxsList& get_instance_idxs() const;
 
     const IndicesList& get_volume_idxs() const { return m_list; }
+    const std::vector<unsigned int>& get_selection_order() const { return m_selection_order; }
+    size_t get_volumes_size() const { return m_volumes ? m_volumes->size() : 0; }
     const GLVolume* get_volume(unsigned int volume_idx) const;
     const GLVolume* get_first_volume() const { return get_volume(*m_list.begin()); }
     GLVolume* get_volume(unsigned int volume_idx);
@@ -345,6 +349,7 @@ public:
 #endif // ENABLE_ENHANCED_PRINT_VOLUME_FIT
     void scale_and_translate(const Vec3d &scale, const Vec3d &world_translation, TransformationType transformation_type);
     void mirror(Axis axis, TransformationType transformation_type);
+    void align(int axis, int align_type, bool distribute);
 
     void translate(unsigned int object_idx, const Vec3d& displacement);
     void translate(unsigned int object_idx, unsigned int instance_idx, const Vec3d& displacement);

--- a/src/slic3r/GUI/Selection.hpp
+++ b/src/slic3r/GUI/Selection.hpp
@@ -33,6 +33,7 @@ namespace GUI {
 
 class Selection
 {
+    friend class SelectionTest;
 public:
     typedef std::set<unsigned int> IndicesList;
 
@@ -196,6 +197,7 @@ private:
     // BBS
     EMode m_volume_selection_mode{ Instance };
     bool m_volume_selection_locked { false };
+    bool m_is_full_selection { false };
 
 public:
     Selection();

--- a/src/slic3r/Utils/UndoRedo.cpp
+++ b/src/slic3r/Utils/UndoRedo.cpp
@@ -944,6 +944,13 @@ void StackImpl::take_snapshot(const std::string& snapshot_name, const Slic3r::Mo
 	m_selection.mode = selection.get_mode();
 	for (unsigned int volume_idx : selection.get_volume_idxs())
 		m_selection.volumes_and_instances.emplace_back(selection.get_volume(volume_idx)->geometry_id);
+	m_selection.selection_order.clear();
+	m_selection.selection_order.reserve(selection.get_selection_order().size());
+	for (unsigned int volume_idx : selection.get_selection_order()) {
+		if (const auto* vol = selection.get_volume(volume_idx)) {
+			m_selection.selection_order.emplace_back(vol->geometry_id);
+		}
+	}
 	this->save_mutable_object<Selection>(m_selection);
     this->save_mutable_object<Slic3r::GUI::GLGizmosManager>(gizmos);
 

--- a/src/slic3r/Utils/UndoRedo.hpp
+++ b/src/slic3r/Utils/UndoRedo.hpp
@@ -104,10 +104,11 @@ inline bool snapshot_modifies_project(const Snapshot &snapshot)
 
 // Excerpt of Slic3r::GUI::Selection for serialization onto the Undo / Redo stack.
 struct Selection : public Slic3r::ObjectBase {
-	void clear() { mode = 0; volumes_and_instances.clear(); }
+	void clear() { mode = 0; volumes_and_instances.clear(); selection_order.clear(); }
 	unsigned char							mode = 0;
 	std::vector<std::pair<size_t, size_t>>	volumes_and_instances;
-	template<class Archive> void serialize(Archive &ar) { ar(mode, volumes_and_instances); }
+	std::vector<std::pair<size_t, size_t>>	selection_order;
+	template<class Archive> void serialize(Archive &ar) { ar(mode, volumes_and_instances, selection_order); }
 };
 
 class StackImpl;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -55,6 +55,7 @@ endfunction()
 add_subdirectory(libnest2d)
 add_subdirectory(libslic3r)
 add_subdirectory(slic3rutils)
+add_subdirectory(slic3rGUI)
 add_subdirectory(fff_print)
 add_subdirectory(sla_print)
 

--- a/tests/slic3rGUI/CMakeLists.txt
+++ b/tests/slic3rGUI/CMakeLists.txt
@@ -1,0 +1,24 @@
+get_filename_component(_TEST_NAME ${CMAKE_CURRENT_LIST_DIR} NAME)
+
+if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    set(wxWidgets_CONFIG_OPTIONS "--toolkit=gtk${SLIC3R_GTK}")
+    find_package(wxWidgets 3.3 REQUIRED COMPONENTS base core adv html gl aui net media webview)
+else ()
+    find_package(wxWidgets 3.3 CONFIG REQUIRED COMPONENTS html adv gl core base webview aui net media)
+endif ()
+
+if(wxWidgets_USE_FILE)
+    include(${wxWidgets_USE_FILE})
+endif()
+
+add_executable(${_TEST_NAME}_tests
+    slic3rGUI_test_main.cpp
+    )
+
+target_link_libraries(${_TEST_NAME}_tests test_common libslic3r_gui libslic3r Catch2::Catch2WithMain ${wxWidgets_LIBRARIES})
+target_include_directories(${_TEST_NAME}_tests PRIVATE ${CMAKE_SOURCE_DIR}/src)
+set_property(TARGET ${_TEST_NAME}_tests PROPERTY FOLDER "tests")
+
+orcaslicer_copy_test_dlls()
+
+orcaslicer_discover_tests(${_TEST_NAME}_tests)

--- a/tests/slic3rGUI/slic3rGUI_test_main.cpp
+++ b/tests/slic3rGUI/slic3rGUI_test_main.cpp
@@ -1,0 +1,352 @@
+#include <catch2/catch_all.hpp>
+#include <wx/app.h>
+#include "libslic3r/Model.hpp"
+#include "libslic3r/TriangleMesh.hpp"
+#include "slic3r/GUI/Selection.hpp"
+#include "slic3r/GUI/3DScene.hpp"
+
+using namespace Slic3r;
+using namespace Slic3r::GUI;
+using Catch::Matchers::WithinAbs;
+
+namespace Slic3r {
+namespace GUI {
+struct SelectionTest {
+    static void set_valid(Selection& sel, bool valid) {
+        sel.m_valid = valid;
+    }
+    static void set_model(Selection& sel, Model* model) {
+        sel.m_model = model;
+    }
+    static void set_volumes(Selection& sel, GLVolumePtrs* volumes) {
+        sel.m_volumes = volumes;
+    }
+    static void set_mode(Selection& sel, Selection::EMode mode) {
+        sel.m_mode = mode;
+    }
+    static void set_type(Selection& sel, Selection::EType type) {
+        sel.m_type = type;
+    }
+    static void clear_selection(Selection& sel) {
+        sel.m_list.clear();
+        sel.m_selection_order.clear();
+        sel.m_cache.content.clear();
+        sel.m_cache.volumes_data.clear();
+    }
+    static void add_to_selection(Selection& sel, unsigned int vol_idx, int obj_idx, int inst_idx, int vol_id) {
+        sel.m_list.insert(vol_idx);
+        sel.m_selection_order.push_back(vol_idx);
+        sel.m_cache.content[obj_idx].insert(inst_idx);
+    }
+    static void sync_cache(Selection& sel) {
+        sel.set_caches();
+    }
+    static void set_is_full_selection(Selection& sel, bool full) {
+        sel.m_is_full_selection = full;
+    }
+};
+} // namespace GUI
+} // namespace Slic3r
+
+static GLVolume* create_mock_gl_volume(ModelObject* obj, int obj_idx, int inst_idx, int vol_idx) {
+    GLVolume* v = new GLVolume();
+    v->composite_id = GLVolume::CompositeID(obj_idx, vol_idx, inst_idx);
+    ModelInstance* inst = obj->instances[inst_idx];
+    ModelVolume* vol = obj->volumes[vol_idx];
+    v->set_instance_transformation(inst->get_transformation());
+    v->set_volume_transformation(vol->get_transformation());
+    v->set_convex_hull(vol->mesh());
+    v->geometry_id = std::make_pair(vol->id().id, inst->id().id);
+    return v;
+}
+
+TEST_CASE("Selection: align and distribute instances", "[Selection]") {
+    TriangleMesh mesh = make_cube(10.0, 10.0, 10.0);
+
+    Model model;
+
+    // Create 3 objects, each with 1 instance.
+    ModelObject* obj0 = model.add_object();
+    obj0->add_volume(mesh);
+    ModelInstance* inst0 = obj0->add_instance();
+    inst0->set_offset(Vec3d(0.0, 0.0, 0.0)); // Local bbox center initially at (5,5,5)
+
+    ModelObject* obj1 = model.add_object();
+    obj1->add_volume(mesh);
+    ModelInstance* inst1 = obj1->add_instance();
+    inst1->set_offset(Vec3d(5.0, 0.0, 0.0)); // Center at (10,5,5)
+
+    ModelObject* obj2 = model.add_object();
+    obj2->add_volume(mesh);
+    ModelInstance* inst2 = obj2->add_instance();
+    inst2->set_offset(Vec3d(20.0, 0.0, 0.0)); // Center at (25,5,5)
+
+    GLVolumePtrs volumes;
+    volumes.push_back(create_mock_gl_volume(obj0, 0, 0, 0));
+    volumes.push_back(create_mock_gl_volume(obj1, 1, 0, 0));
+    volumes.push_back(create_mock_gl_volume(obj2, 2, 0, 0));
+
+    Selection selection;
+    SelectionTest::set_model(selection, &model);
+    SelectionTest::set_volumes(selection, &volumes);
+    SelectionTest::set_valid(selection, true);
+    SelectionTest::set_mode(selection, Selection::Instance);
+    SelectionTest::set_type(selection, Selection::Mixed);
+
+    SECTION("Distribute instances along X axis with center alignment") {
+        SelectionTest::clear_selection(selection);
+        SelectionTest::add_to_selection(selection, 0, 0, 0, 0);
+        SelectionTest::add_to_selection(selection, 1, 1, 0, 0);
+        SelectionTest::add_to_selection(selection, 2, 2, 0, 0);
+        SelectionTest::sync_cache(selection);
+
+        // Distribute: axis=0, align_type=1 (center), distribute=true
+        selection.align(0, 1, true);
+
+        // Min center is 5 (vol 0), Max center is 25 (vol 2).
+        // Total distance is 20.
+        // Distributed center for middle (vol 1) should be 5 + 10 = 15.
+        // Bounding box center of vol 1 is offset.x() + 5.
+        // So offset.x() of vol 1 should become 10.
+        REQUIRE_THAT(volumes[0]->get_instance_offset().x(), WithinAbs(0.0, 1e-4));
+        REQUIRE_THAT(volumes[1]->get_instance_offset().x(), WithinAbs(10.0, 1e-4));
+        REQUIRE_THAT(volumes[2]->get_instance_offset().x(), WithinAbs(20.0, 1e-4));
+    }
+
+    SECTION("Align instances to anchor (local alignment)") {
+        SelectionTest::clear_selection(selection);
+        // Anchor is volume 0
+        SelectionTest::add_to_selection(selection, 0, 0, 0, 0);
+        SelectionTest::add_to_selection(selection, 1, 1, 0, 0);
+        SelectionTest::add_to_selection(selection, 2, 2, 0, 0);
+        SelectionTest::sync_cache(selection);
+
+        // Align center: axis=0, align_type=1, distribute=false
+        selection.align(0, 1, false);
+
+        // Anchor center is 5 (offset = 0).
+        // Vol 1 and 2 should align their centers to 5.
+        // Since local center of mesh is 5, their offset should be 0.
+        REQUIRE_THAT(volumes[0]->get_instance_offset().x(), WithinAbs(0.0, 1e-4));
+        REQUIRE_THAT(volumes[1]->get_instance_offset().x(), WithinAbs(0.0, 1e-4));
+        REQUIRE_THAT(volumes[2]->get_instance_offset().x(), WithinAbs(0.0, 1e-4));
+    }
+
+    SECTION("Align instances to global bounding box") {
+        SelectionTest::clear_selection(selection);
+        SelectionTest::add_to_selection(selection, 0, 0, 0, 0);
+        SelectionTest::add_to_selection(selection, 1, 1, 0, 0);
+        SelectionTest::add_to_selection(selection, 2, 2, 0, 0);
+        SelectionTest::sync_cache(selection);
+
+        // Force single full object to trigger global alignment
+        SelectionTest::set_type(selection, Selection::SingleFullInstance);
+
+        // Align min: axis=0, align_type=0, distribute=false
+        selection.align(0, 0, false);
+
+        // Global min is 0 (vol 0: 0 to 10, vol 1: 5 to 15, vol 2: 20 to 30).
+        // All instances should align their min boundary to X=0.
+        // Local min of mesh is 0. So offset of all volumes should become 0.
+        REQUIRE_THAT(volumes[0]->get_instance_offset().x(), WithinAbs(0.0, 1e-4));
+        REQUIRE_THAT(volumes[1]->get_instance_offset().x(), WithinAbs(0.0, 1e-4));
+        REQUIRE_THAT(volumes[2]->get_instance_offset().x(), WithinAbs(0.0, 1e-4));
+    }
+
+    // Cleanup
+    for (auto v : volumes) {
+        delete v;
+    }
+}
+
+TEST_CASE("Selection: align and distribute volumes", "[Selection]") {
+    TriangleMesh mesh = make_cube(10.0, 10.0, 10.0);
+
+    Model model;
+
+    // Create 1 object with 3 volumes.
+    ModelObject* obj = model.add_object();
+    obj->add_volume(mesh);
+    obj->add_volume(mesh);
+    obj->add_volume(mesh);
+    ModelInstance* inst = obj->add_instance();
+    inst->set_offset(Vec3d(0.0, 0.0, 0.0));
+
+    // Place volumes at offsets relative to instance
+    obj->volumes[0]->set_offset(Vec3d(0.0, 0.0, 0.0));  // local center 5
+    obj->volumes[1]->set_offset(Vec3d(5.0, 0.0, 0.0));  // local center 10
+    obj->volumes[2]->set_offset(Vec3d(20.0, 0.0, 0.0)); // local center 25
+
+    GLVolumePtrs volumes;
+    volumes.push_back(create_mock_gl_volume(obj, 0, 0, 0));
+    volumes.push_back(create_mock_gl_volume(obj, 0, 0, 1));
+    volumes.push_back(create_mock_gl_volume(obj, 0, 0, 2));
+
+    Selection selection;
+    SelectionTest::set_model(selection, &model);
+    SelectionTest::set_volumes(selection, &volumes);
+    SelectionTest::set_valid(selection, true);
+    SelectionTest::set_mode(selection, Selection::Volume);
+    SelectionTest::set_type(selection, Selection::Mixed);
+
+    SECTION("Distribute volumes along X axis") {
+        SelectionTest::clear_selection(selection);
+        SelectionTest::add_to_selection(selection, 0, 0, 0, 0);
+        SelectionTest::add_to_selection(selection, 1, 0, 0, 1);
+        SelectionTest::add_to_selection(selection, 2, 0, 0, 2);
+        SelectionTest::sync_cache(selection);
+
+        // Distribute center: axis=0, align_type=1, distribute=true
+        selection.align(0, 1, true);
+
+        // Min center is 5 (vol 0), Max center is 25 (vol 2).
+        // Total distance is 20.
+        // Distributed center for middle volume should be 15.
+        // Bounding box local center is offset.x() + 5.
+        // So offset.x() of volume 1 should become 10.
+        REQUIRE_THAT(volumes[0]->get_volume_offset().x(), WithinAbs(0.0, 1e-4));
+        REQUIRE_THAT(volumes[1]->get_volume_offset().x(), WithinAbs(10.0, 1e-4));
+        REQUIRE_THAT(volumes[2]->get_volume_offset().x(), WithinAbs(20.0, 1e-4));
+    }
+
+    SECTION("Align volumes to object bounding box") {
+        SelectionTest::clear_selection(selection);
+        SelectionTest::set_is_full_selection(selection, true);
+        // Anchor is volume 0
+        SelectionTest::add_to_selection(selection, 0, 0, 0, 0);
+        SelectionTest::add_to_selection(selection, 1, 0, 0, 1);
+        SelectionTest::add_to_selection(selection, 2, 0, 0, 2);
+        SelectionTest::sync_cache(selection);
+
+        // Align center: axis=0, align_type=1, distribute=false
+        selection.align(0, 1, false);
+
+        // Object bounding box is [0, 30], so object center is 15.
+        // All volumes should align their centers to 15.
+        // Since local centers of mesh parts are 5, 10, and 25 respectively,
+        // local volume offset of all volumes should become 10.
+        REQUIRE_THAT(volumes[0]->get_volume_offset().x(), WithinAbs(10.0, 1e-4));
+        REQUIRE_THAT(volumes[1]->get_volume_offset().x(), WithinAbs(10.0, 1e-4));
+        REQUIRE_THAT(volumes[2]->get_volume_offset().x(), WithinAbs(10.0, 1e-4));
+    }
+
+    SECTION("Align several volumes of the object (local alignment to anchor part)") {
+        SelectionTest::clear_selection(selection);
+        SelectionTest::set_is_full_selection(selection, false);
+        // Select only volume 1 and volume 2 (volume 0 is not selected)
+        // Anchor is volume 1
+        SelectionTest::add_to_selection(selection, 1, 0, 0, 1);
+        SelectionTest::add_to_selection(selection, 2, 0, 0, 2);
+        SelectionTest::sync_cache(selection);
+
+        // Align center: axis=0, align_type=1, distribute=false
+        selection.align(0, 1, false);
+
+        // Anchor is volume 1 (local center 10, offset 5, so world center is 10).
+        // Volume 2 (local center 25, offset 20, so world center is 25) should align to center 10.
+        // New offset of volume 2 should become 20 + (10 - 25) = 5.
+        // Volume 1 (anchor) should be skipped and its offset should remain 5.
+        REQUIRE_THAT(volumes[1]->get_volume_offset().x(), WithinAbs(5.0, 1e-4));
+        REQUIRE_THAT(volumes[2]->get_volume_offset().x(), WithinAbs(5.0, 1e-4));
+    }
+
+    SECTION("Align all volumes of the object selected by clicking (local alignment to anchor part)") {
+        SelectionTest::clear_selection(selection);
+        SelectionTest::set_is_full_selection(selection, false);
+        selection.set_volume_selection_mode(Selection::Volume);
+        // Anchor is volume 1 (clicked first)
+        SelectionTest::add_to_selection(selection, 1, 0, 0, 1);
+        SelectionTest::add_to_selection(selection, 0, 0, 0, 0);
+        SelectionTest::add_to_selection(selection, 2, 0, 0, 2);
+        SelectionTest::sync_cache(selection);
+
+        // Align center: axis=0, align_type=1, distribute=false
+        selection.align(0, 1, false);
+
+        // Even though all volumes are selected, since m_is_full_selection is false,
+        // it should count as clicked selection (second option).
+        // Anchor is volume 1 (local center 10, offset 5, so world center is 10).
+        // Volume 0 (local center 5, offset 0) should align to center 10. New offset: 0 + (10 - 5) = 5.
+        // Volume 2 (local center 25, offset 20) should align to center 10. New offset: 20 + (10 - 25) = 5.
+        // Volume 1 (anchor) should be skipped and remain 5.
+        REQUIRE_THAT(volumes[0]->get_volume_offset().x(), WithinAbs(5.0, 1e-4));
+        REQUIRE_THAT(volumes[1]->get_volume_offset().x(), WithinAbs(5.0, 1e-4));
+        REQUIRE_THAT(volumes[2]->get_volume_offset().x(), WithinAbs(5.0, 1e-4));
+    }
+
+    // Cleanup
+    for (auto v : volumes) {
+        delete v;
+    }
+}
+
+TEST_CASE("Selection: set_deserialized (Undo preservation)", "[Selection]") {
+    TriangleMesh mesh = make_cube(10.0, 10.0, 10.0);
+    Model model;
+    ModelObject* obj = model.add_object();
+    obj->add_volume(mesh);
+    obj->add_volume(mesh);
+    obj->add_volume(mesh);
+    ModelInstance* inst = obj->add_instance();
+    inst->set_offset(Vec3d(0.0, 0.0, 0.0));
+
+    GLVolumePtrs volumes;
+    volumes.push_back(create_mock_gl_volume(obj, 0, 0, 0));
+    volumes.push_back(create_mock_gl_volume(obj, 0, 0, 1));
+    volumes.push_back(create_mock_gl_volume(obj, 0, 0, 2));
+
+    Selection selection;
+    SelectionTest::set_model(selection, &model);
+    SelectionTest::set_volumes(selection, &volumes);
+    SelectionTest::set_valid(selection, true);
+
+    SECTION("Restore selection order correctly") {
+        std::vector<std::pair<size_t, size_t>> volumes_and_instances = {
+            volumes[0]->geometry_id,
+            volumes[1]->geometry_id,
+            volumes[2]->geometry_id
+        };
+        // Deserialize with volume 2 first, then volume 0
+        std::vector<std::pair<size_t, size_t>> selection_order = {
+            volumes[2]->geometry_id,
+            volumes[0]->geometry_id
+        };
+
+        selection.set_deserialized(Selection::Volume, volumes_and_instances, selection_order);
+
+        // Verify selection contains elements
+        REQUIRE(selection.get_volume_idxs().size() == 2);
+        REQUIRE(selection.contains_volume(2));
+        REQUIRE(selection.contains_volume(0));
+
+        // Verify order is preserved: volume 2 then volume 0
+        REQUIRE(selection.get_selection_order().size() == 2);
+        REQUIRE(selection.get_selection_order()[0] == 2);
+        REQUIRE(selection.get_selection_order()[1] == 0);
+    }
+
+    SECTION("Backward compatibility fallback when selection_order is empty") {
+        std::vector<std::pair<size_t, size_t>> volumes_and_instances = {
+            volumes[0]->geometry_id,
+            volumes[1]->geometry_id
+        };
+        std::vector<std::pair<size_t, size_t>> selection_order = {};
+
+        selection.set_deserialized(Selection::Volume, volumes_and_instances, selection_order);
+
+        // Verify selection falls back to selecting volumes in volumes_and_instances
+        REQUIRE(selection.get_volume_idxs().size() == 2);
+        REQUIRE(selection.contains_volume(0));
+        REQUIRE(selection.contains_volume(1));
+        
+        // Verify selection order lists both
+        REQUIRE(selection.get_selection_order().size() == 2);
+        REQUIRE(selection.get_selection_order()[0] == 0);
+        REQUIRE(selection.get_selection_order()[1] == 1);
+    }
+
+    // Cleanup
+    for (auto v : volumes) {
+        delete v;
+    }
+}


### PR DESCRIPTION
# Description

I've implemented feature that stops me to use OrcaSlicer for simple everyday tasks, that does not require CAD software. I do use QIDIStudio for now, but would love to switch to Orca completely.   
In this change I've added align and distribute functionality, that should align parts of the object or objects along axis.  
Under the hood: 
* Added separate structure to store section order
* Added support for that for undo actions
* Added align gizmo with icon
* Added function that do main logic for alignment/distribution
* Added some testcases 

# Screenshots/Recordings/Graphs

<img width="2045" height="1168" alt="image" src="https://github.com/user-attachments/assets/c00abdb5-ebd2-485f-b142-b51459947c3a" />

<img width="2045" height="1168" alt="image" src="https://github.com/user-attachments/assets/85201fb9-784a-45cb-99ca-592953e72891" />

https://github.com/user-attachments/assets/68385e93-9b1f-45fd-b491-df41b33c05af

## Tests

I did manual testing on my Linux  that objects are aligned, and also created some unit tests 
Since selection is touched I did run full tests and had see no errors. Also did some random tests with selection in UI. 

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
