### PR TITLE
CLI: --inspect-mesh — machine-readable JSON summary

### DIFF
--- a/src/OrcaSlicer.cpp
+++ b/src/OrcaSlicer.cpp
@@ -79,6 +79,7 @@ using namespace nlohmann;
 #ifdef WIN32
 #include "dev-utils/BaseException.h"
 #endif
+#include "slic3r/Utils/MeshInspect.hpp"
 #include "slic3r/GUI/PartPlate.hpp"
 #include "slic3r/GUI/BitmapCache.hpp"
 #include "slic3r/GUI/OpenGLManager.hpp"
@@ -5580,6 +5581,17 @@ int CLI::run(int argc, char **argv)
                 model.add_default_instances();
                 model.print_info();
             }
+        } else if (opt_key == "inspect_mesh") {
+            // --inspect-mesh — machine-readable JSON alternative to --info.
+            // Registered as an action so it satisfies the "needs an action"
+            // check and bypasses the GUI fallback. Control falls through the
+            // normal post-action path to a clean exit 0.
+            const std::string source = m_input_files.empty() ? std::string("<no input>") : m_input_files.front();
+            for (Model &model : m_models) {
+                model.add_default_instances();
+                Slic3r::MeshInspect::inspect_to_json(model, source, boost::nowide::cout);
+            }
+            boost::nowide::cout.flush();
         } else if (opt_key == "uptodate") {
             //already processed before
         } else if (opt_key == "min_save") {

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -10759,6 +10759,19 @@ CLIActionsConfigDef::CLIActionsConfigDef()
     def->tooltip = L("This outputs the model\u2019s information.");
     def->set_default_value(new ConfigOptionBool(false));
 
+    // --inspect-mesh \u2014 structured JSON summary of the loaded model. Parallels
+    // --info but emits machine-readable output (per-object mesh-local + world
+    // bboxes, plus a top-N ranking of planar-face clusters by area) so
+    // CI/AI/scripted tooling can plan orientation, choose a natural sit-flat
+    // face, or verify mesh characteristics without opening the GUI.
+    def = this->add("inspect_mesh", coBool);
+    def->label = L("Inspect mesh (JSON to stdout)");
+    def->tooltip = L("Print a structured JSON summary of the loaded model(s) to stdout \u2014 "
+                     "per-object mesh-local bbox + centroid, world bbox, and the top-N "
+                     "largest planar-face clusters with their normals, areas, and triangle "
+                     "counts. Then exit. Machine-readable alternative to --info.");
+    def->set_default_value(new ConfigOptionBool(false));
+
     def = this->add("export_settings", coString);
     def->label = L("Export Settings");
     def->tooltip = L("This exports settings to a file.");

--- a/src/slic3r/CMakeLists.txt
+++ b/src/slic3r/CMakeLists.txt
@@ -578,6 +578,8 @@ set(SLIC3R_GUI_SOURCES
     Utils/bambu_networking.hpp
     Utils/Bonjour.cpp
     Utils/Bonjour.hpp
+    Utils/MeshInspect.cpp
+    Utils/MeshInspect.hpp
     Utils/CalibUtils.cpp
     Utils/CalibUtils.hpp
     Utils/ColorSpaceConvert.cpp

--- a/src/slic3r/Utils/MeshInspect.cpp
+++ b/src/slic3r/Utils/MeshInspect.cpp
@@ -1,0 +1,219 @@
+// MeshInspect.cpp — CLI mesh-inspection primitives. See MeshInspect.hpp.
+#include "MeshInspect.hpp"
+
+#include "libslic3r/Model.hpp"
+#include "libslic3r/TriangleMesh.hpp"
+#include "libslic3r/Point.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace Slic3r {
+namespace MeshInspect {
+
+namespace {
+
+// Per-triangle data: unit outward normal + area (mm²). Iterated once per
+// object to feed the planar-face clusterer.
+struct TriInfo {
+    Vec3d  normal;
+    double area;
+};
+
+std::vector<TriInfo> collect_triangles_object(const ModelObject &mo)
+{
+    std::vector<TriInfo> tris;
+    for (const ModelVolume *mv : mo.volumes) {
+        if (!mv || !mv->is_model_part()) continue;
+        const indexed_triangle_set &its = mv->mesh().its;
+        tris.reserve(tris.size() + its.indices.size());
+        for (const Vec3i32 &tri : its.indices) {
+            const Vec3f &a = its.vertices[tri[0]];
+            const Vec3f &b = its.vertices[tri[1]];
+            const Vec3f &c = its.vertices[tri[2]];
+            const Vec3d ab = (b - a).cast<double>();
+            const Vec3d ac = (c - a).cast<double>();
+            const Vec3d cross  = ab.cross(ac);
+            const double mag   = cross.norm();
+            if (mag < 1e-12) continue;          // degenerate
+            tris.push_back({ cross / mag, 0.5 * mag });
+        }
+    }
+    return tris;
+}
+
+// One planar-face cluster: every triangle whose normal quantized to the same
+// 0.001-precision (≈ 0.06° angular) lattice point. `normal` is the
+// area-weighted mean of the cluster's triangle normals (smoother than any
+// raw triangle normal).
+struct FaceCluster {
+    Vec3d  normal;
+    double area_mm2;
+    int    n_triangles;
+};
+
+// Cluster triangles by quantized normal direction; return sorted by area
+// (largest first). Coplanar triangles from triangulation share a normal to
+// many decimals — quantizing to 0.001 groups them while keeping distinct
+// face orientations apart.
+std::vector<FaceCluster> compute_face_clusters(const std::vector<TriInfo> &tris)
+{
+    struct QKey { int x, y, z; };
+    struct QKeyHash { size_t operator()(const QKey &k) const noexcept {
+        return (size_t(uint32_t(k.x)) * 73856093u)
+             ^ (size_t(uint32_t(k.y)) * 19349663u)
+             ^ (size_t(uint32_t(k.z)) * 83492791u);
+    }};
+    struct QKeyEq { bool operator()(const QKey &a, const QKey &b) const noexcept {
+        return a.x == b.x && a.y == b.y && a.z == b.z;
+    }};
+    auto quantize = [](const Vec3d &n) -> QKey {
+        return { int(std::lround(n.x() * 1000.0)),
+                 int(std::lround(n.y() * 1000.0)),
+                 int(std::lround(n.z() * 1000.0)) };
+    };
+
+    struct Bucket { double area = 0.0; int n = 0; Vec3d weighted_normal = Vec3d::Zero(); };
+    std::unordered_map<QKey, Bucket, QKeyHash, QKeyEq> buckets;
+    buckets.reserve(tris.size() / 4 + 1);
+
+    for (const TriInfo &t : tris) {
+        Bucket &b = buckets[quantize(t.normal)];
+        b.area            += t.area;
+        b.n               += 1;
+        b.weighted_normal += t.area * t.normal;
+    }
+
+    std::vector<FaceCluster> clusters;
+    clusters.reserve(buckets.size());
+    for (const auto &kv : buckets)
+        clusters.push_back({ kv.second.weighted_normal.normalized(),
+                             kv.second.area, kv.second.n });
+
+    std::sort(clusters.begin(), clusters.end(),
+              [](const FaceCluster &a, const FaceCluster &b) { return a.area_mm2 > b.area_mm2; });
+    return clusters;
+}
+
+// Minimal JSON emitter. Output is small and flat — hand-formatting beats
+// pulling in a JSON library for this scope. Floats use %.6g (enough for
+// mesh coords, no trailing noise); strings backslash-escape quotes and
+// backslashes only — mesh-local numbers and file paths don't carry control
+// characters in this pipeline.
+std::string json_str(const std::string &s)
+{
+    std::string out;
+    out.reserve(s.size() + 2);
+    out += '"';
+    for (char c : s) {
+        if (c == '"' || c == '\\') out += '\\';
+        out += c;
+    }
+    out += '"';
+    return out;
+}
+
+std::string json_num(double v)
+{
+    char buf[32];
+    std::snprintf(buf, sizeof(buf), "%.6g", v);
+    return buf;
+}
+
+std::string json_vec3(const Vec3d &v)
+{
+    return "[" + json_num(v.x()) + ", " + json_num(v.y()) + ", " + json_num(v.z()) + "]";
+}
+
+} // namespace
+
+void inspect_to_json(const Model &model, const std::string &source_path,
+                     std::ostream &out, int top_n_clusters)
+{
+    out << "{\n";
+    out << "  " << json_str("source") << ": " << json_str(source_path) << ",\n";
+    out << "  " << json_str("note") << ": " << json_str(
+        "Coordinates are mesh-local. bbox_world reflects instance 0's transform.") << ",\n";
+    out << "  " << json_str("objects") << ": [";
+
+    bool first_obj = true;
+    for (size_t oi = 0; oi < model.objects.size(); ++oi) {
+        const ModelObject *mo = model.objects[oi];
+        if (!mo) continue;
+
+        const std::vector<TriInfo>     tris     = collect_triangles_object(*mo);
+        const std::vector<FaceCluster> clusters = compute_face_clusters(tris);
+
+        // Mesh-local bbox (raw vertices, no instance transform).
+        BoundingBoxf3 bbox;
+        bool have_box = false;
+        for (const ModelVolume *mv : mo->volumes) {
+            if (!mv || !mv->is_model_part()) continue;
+            for (const Vec3f &v : mv->mesh().its.vertices) {
+                if (!have_box) { bbox.min = bbox.max = v.cast<double>(); have_box = true; }
+                else            bbox.merge(v.cast<double>());
+            }
+        }
+        Vec3d size     = have_box ? Vec3d(bbox.max - bbox.min) : Vec3d::Zero();
+        Vec3d centroid = have_box ? Vec3d(0.5 * (bbox.min + bbox.max)) : Vec3d::Zero();
+
+        // World bbox = mesh + instance offset of instance 0 (typical CLI case
+        // is one instance). Skipped if there are no instances.
+        BoundingBoxf3 world_bbox;
+        bool have_world = false;
+        if (!mo->instances.empty()) {
+            world_bbox = mo->instance_bounding_box(0, false);
+            have_world = true;
+        }
+
+        out << (first_obj ? "\n" : ",\n");
+        first_obj = false;
+        out << "    {\n";
+        out << "      " << json_str("name")           << ": " << json_str(mo->name) << ",\n";
+        out << "      " << json_str("triangle_count") << ": " << tris.size() << ",\n";
+        out << "      " << json_str("instance_count") << ": " << mo->instances.size() << ",\n";
+        out << "      " << json_str("bbox_mesh_local") << ": {\n"
+            << "        " << json_str("min")  << ": " << json_vec3(bbox.min)  << ",\n"
+            << "        " << json_str("max")  << ": " << json_vec3(bbox.max)  << ",\n"
+            << "        " << json_str("size") << ": " << json_vec3(size)      << ",\n"
+            << "        " << json_str("centroid") << ": " << json_vec3(centroid) << "\n"
+            << "      },\n";
+        if (have_world) {
+            out << "      " << json_str("bbox_world") << ": {\n"
+                << "        " << json_str("min") << ": " << json_vec3(world_bbox.min) << ",\n"
+                << "        " << json_str("max") << ": " << json_vec3(world_bbox.max) << "\n"
+                << "      },\n";
+            out << "      " << json_str("instance_offset") << ": "
+                << json_vec3(mo->instances[0]->get_offset()) << ",\n";
+        }
+
+        // Top-N planar-face clusters. Ranked by total area; the largest is
+        // almost always the natural "sit-flat" candidate for orientation.
+        const int n = std::min<int>(top_n_clusters, int(clusters.size()));
+        out << "      " << json_str("face_clusters") << ": [";
+        for (int i = 0; i < n; ++i) {
+            const FaceCluster &c = clusters[i];
+            out << (i == 0 ? "\n" : ",\n");
+            out << "        {"
+                << json_str("normal")      << ": " << json_vec3(c.normal)       << ", "
+                << json_str("area_mm2")    << ": " << json_num(c.area_mm2)      << ", "
+                << json_str("n_triangles") << ": " << c.n_triangles
+                << "}";
+        }
+        if (n > 0) out << "\n      ";
+        out << "],\n";
+        out << "      " << json_str("total_cluster_count") << ": " << clusters.size() << "\n";
+        out << "    }";
+    }
+    if (!first_obj) out << "\n  ";
+    out << "]\n";
+    out << "}\n";
+}
+
+} // namespace MeshInspect
+} // namespace Slic3r

--- a/src/slic3r/Utils/MeshInspect.hpp
+++ b/src/slic3r/Utils/MeshInspect.hpp
@@ -1,0 +1,33 @@
+// MeshInspect.hpp — CLI mesh-inspection primitives.
+//
+// Backs the --inspect-mesh CLI action. Emits a structured JSON summary of
+// the loaded Model — per-object mesh-local bbox, world bbox, and the top-N
+// largest planar-face clusters ranked by area — so external tooling can
+// reason about a model's geometry without opening the GUI. Useful for CI
+// pipelines, scripted preprocessing, and AI-assisted orientation planning
+// (the largest face's normal is almost always the natural "sit-on-the-bed"
+// candidate).
+#ifndef slic3r_MeshInspect_hpp_
+#define slic3r_MeshInspect_hpp_
+
+#include <iosfwd>
+#include <string>
+
+namespace Slic3r {
+class Model;
+
+namespace MeshInspect {
+
+// Emit a structured JSON inspection of `model` to `out`:
+//   - per-object mesh-local bbox + centroid,
+//   - world bbox (via instance 0's transform) + instance_offset,
+//   - top_n_clusters largest planar-face clusters, each with the
+//     area-weighted mean normal, total area (mm²), and triangle count.
+// Coordinates are mesh-local unless the field name says otherwise.
+void inspect_to_json(const Model &model, const std::string &source_path,
+                     std::ostream &out, int top_n_clusters = 8);
+
+} // namespace MeshInspect
+} // namespace Slic3r
+
+#endif


### PR DESCRIPTION
# Description

Add `--inspect-mesh`: a machine-readable JSON alternative to `--info`.
For CI pipelines, scripted preprocessing, and AI-assisted orientation
planning — anywhere the caller needs to reason about a model's geometry
without opening the GUI.

## What it emits

Per loaded model, per object:

- `bbox_mesh_local` — min / max / size / centroid in the object's own frame.
- `bbox_world` + `instance_offset` — the same bbox after instance 0's transform.
- `face_clusters` — the **top-N largest planar-face clusters** (default N=8),
  each with an area-weighted mean normal, total area (mm²), and triangle
  count. Cluster normals are quantized to 0.001 (≈ 0.06° angular) so
  coplanar triangles from triangulation group into a single logical face.
  Ranked by area — the largest is almost always the natural "sit-flat"
  candidate for orientation.
- `total_cluster_count` — sanity metric so the caller knows whether the
  N-cap truncated the ranking.

Sample output (rounded for readability):

```json
{
  "source": "camera_mount_90.stl",
  "note": "Coordinates are mesh-local. bbox_world reflects instance 0's transform.",
  "objects": [
    {
      "name": "camera_mount_90.stl",
      "triangle_count": 6474,
      "instance_count": 1,
      "bbox_mesh_local": {
        "min": [-36, -31.18, -13.13],
        "max": [ 36,  31.18,  13.13],
        "size": [72, 62.35, 26.26],
        "centroid": [0, 0, 0]
      },
      "bbox_world": {
        "min": [89, 78.82, 3.4e-08],
        "max": [161, 141.18, 26.26]
      },
      "instance_offset": [125, 110, 13.13],
      "face_clusters": [
        {"normal": [0, 0, -1], "area_mm2": 2449.42, "n_triangles": 1022},
        {"normal": [0, 0, 1],  "area_mm2": 1517.05, "n_triangles":   14},
        {"normal": [0.5, -0.29, 0.82], "area_mm2": 848.22, "n_triangles": 225}
      ],
      "total_cluster_count": 47
    }
  ]
}
```

## Why not just `--info`?

`--info` prints a human-oriented summary via `Model::print_info()` — max_x,
max_y, max_z, facet count, manifoldness, volume. It's not designed for
parsing (mixed formatting, no per-cluster geometry). A regex-and-hope
parse of `--info` is what CI/AI callers do today; `--inspect-mesh`
replaces that with a stable schema.

## Why face clusters?

Every CLI orientation workflow — whether hand-rolled `--rotate-*` chains
or an AI planning `orient` calls — needs to know the model's dominant
planar faces. Right now that's a two-step outside the CLI: export STL to
a temp mesh, run trimesh / open3d / a custom analyzer. Face clusters
close that loop inside the slicer that's already loaded the geometry.

## Reproducer

```
$ orca-slicer --inspect-mesh some_model.stl | jq '.objects[0].face_clusters[0]'
{
  "normal": [0, 0, -1],
  "area_mm2": 2449.42,
  "n_triangles": 1022
}
```

## Scope

- **New**: `src/slic3r/Utils/MeshInspect.{hpp,cpp}` — self-contained. No
  new dependencies (JSON is hand-formatted; the output is small and
  flat — the existing `--info` / `save_to_json` sidecars do the same).
- `src/slic3r/CMakeLists.txt` — 2 lines to register the new file.
- `src/libslic3r/PrintConfig.cpp` — 13 lines to add the `inspect_mesh`
  option.
- `src/OrcaSlicer.cpp` — 12 lines to wire the action handler + include.
- No new signatures, no changes to existing helpers, no behavior change
  when the flag is absent.

Registered as an action (parallel to `--info`) so it satisfies the
"needs an action" check and bypasses the GUI fallback; control falls
through the normal post-action path to a clean exit 0.

## Verification

- Emits the schema above on a variety of STL / 3MF inputs.
- Exit 0 on success; malformed input follows the existing loader
  error paths unchanged.
- No effect on existing actions.
