### PR TITLE
fix: multi-user slicing crash on shared temp dir

### DIFF
--- a/src/OrcaSlicer.cpp
+++ b/src/OrcaSlicer.cpp
@@ -1317,7 +1317,13 @@ int CLI::run(int argc, char **argv)
         return CLI_INVALID_PARAMS;
     }
     BOOST_LOG_TRIVIAL(info) << "finished setup params, argc="<< argc << std::endl;
-    std::string temp_path = wxFileName::GetTempDir().utf8_str().data();
+    std::string temp_path = per_user_temp_dir(wxFileName::GetTempDir().utf8_str().data(), per_user_temp_id());
+    // Some consumers write into the temp root directly, so create it up front.
+    try {
+        boost::filesystem::create_directories(temp_path);
+    } catch (const std::exception &ex) {
+        BOOST_LOG_TRIVIAL(warning) << "failed to create per-user temp dir " << temp_path << ": " << ex.what();
+    }
     set_temporary_dir(temp_path);
 
     m_extra_config.apply(m_config, true);

--- a/src/libslic3r/Utils.hpp
+++ b/src/libslic3r/Utils.hpp
@@ -300,6 +300,10 @@ std::string header_gcodeviewer_generated();
 
 // getpid platform wrapper
 extern unsigned get_current_pid();
+// Per-user id for isolating temp dirs; empty on Windows (its temp dir is already per-user).
+std::string per_user_temp_id();
+// Per-user temp root under `base`; an empty `user_id` returns `base` unchanged.
+std::string per_user_temp_dir(const std::string &base, const std::string &user_id);
 // BBS: backup & restore
 std::string get_process_name(int pid);
 

--- a/src/libslic3r/utils.cpp
+++ b/src/libslic3r/utils.cpp
@@ -1285,6 +1285,24 @@ unsigned get_current_pid()
 #endif
 }
 
+std::string per_user_temp_id()
+{
+#ifdef WIN32
+    return {};
+#else
+    return std::to_string(static_cast<unsigned long>(::getuid()));
+#endif
+}
+
+std::string per_user_temp_dir(const std::string &base, const std::string &user_id)
+{
+    if (user_id.empty())
+        return base;
+    // Keep the id at the top level so each user's dir sits directly in the world-writable temp
+    // root; a shared parent dir would be owned by whichever user created it first.
+    return base + "/orcaslicer_" + user_id;
+}
+
 // BBS: backup & restore
 std::string get_process_name(int pid)
 {

--- a/tests/libslic3r/CMakeLists.txt
+++ b/tests/libslic3r/CMakeLists.txt
@@ -23,6 +23,7 @@ add_executable(${_TEST_NAME}_tests
     test_stl.cpp
     test_meshboolean.cpp
     test_marchingsquares.cpp
+    test_utils.cpp
     test_timeutils.cpp
     test_voronoi.cpp
     test_optimizers.cpp

--- a/tests/libslic3r/test_utils.cpp
+++ b/tests/libslic3r/test_utils.cpp
@@ -1,0 +1,54 @@
+#include <catch2/catch_all.hpp>
+
+#include "libslic3r/Utils.hpp"
+
+#ifndef _WIN32
+#include <unistd.h>     // getuid
+#endif
+
+using namespace Slic3r;
+
+TEST_CASE("per_user_temp_dir composes a per-user temp root", "[utils]") {
+    const std::string base = "/tmp";
+
+    SECTION("an empty id returns base unchanged") {
+        REQUIRE(per_user_temp_dir(base, "") == base);
+    }
+    SECTION("a non-empty id is appended at the top level") {
+        REQUIRE(per_user_temp_dir(base, "1000") == base + "/orcaslicer_1000");
+    }
+    SECTION("distinct ids produce distinct roots") {
+        REQUIRE(per_user_temp_dir(base, "1000") != per_user_temp_dir(base, "1001"));
+    }
+}
+
+TEST_CASE("per_user_temp_id follows the platform contract", "[utils]") {
+    const std::string id = per_user_temp_id();
+
+    SECTION("stable across calls") {
+        REQUIRE(per_user_temp_id() == id);
+    }
+#ifdef _WIN32
+    SECTION("empty on Windows (its temp dir is already per-user)") {
+        REQUIRE(id.empty());
+    }
+#else
+    SECTION("the current uid on Linux/macOS") {
+        REQUIRE_FALSE(id.empty());
+        REQUIRE(id == std::to_string(static_cast<unsigned long>(::getuid())));
+    }
+#endif
+}
+
+// The end-to-end contract callers depend on: the temp root is left alone on
+// Windows and isolated per user on Linux/macOS.
+TEST_CASE("per-user temp root is unchanged on Windows, isolated elsewhere", "[utils]") {
+    const std::string base = "/tmp";
+    const std::string root = per_user_temp_dir(base, per_user_temp_id());
+#ifdef _WIN32
+    REQUIRE(root == base);
+#else
+    REQUIRE(root != base);
+    REQUIRE_THAT(root, Catch::Matchers::StartsWith(base + "/orcaslicer_"));
+#endif
+}


### PR DESCRIPTION
# Description

Fixes #10108. Same root cause as #5969.

On Linux every account shares `/tmp`, but slicing builds temp paths there under fixed, app-owned names read from `temporary_dir()`. The first user to slice creates and owns those directories, so the next user cannot write under them and slicing fails with "No such file or directory".

Rather than patch each consumer, this tags the app temp root with the user id once at startup, where `set_temporary_dir()` is called:

- On Linux/macOS `temporary_dir()` becomes `<system temp>/orcaslicer_<uid>`.
- On Windows it is left unchanged, since the temp dir is already per user.

Every `temporary_dir()` consumer is then isolated. Example paths for uid 1000 on Linux:

| Consumer | Before (shared)                                         | After                                                                   |
|---|---------------------------------------------------------|-------------------------------------------------------------------------|
| Model backups | `/tmp/orcaslicer_model/Sat_Jul_05/14_30_12#8123#42/...` | `/tmp/orcaslicer_1000/orcaslicer_model/Sat_Jul_05/14_30_12#8123#42/...` |
| STEP import | `/tmp/temp.step`                                        | `/tmp/orcaslicer_1000/temp.step`                                        |
| Part skip | `/tmp/bamboo_task/...`                                  | `/tmp/orcaslicer_1000/bamboo_task/...`                                  |

On Windows all three stay under `%LOCALAPPDATA%\Temp` exactly as before. These are transient temp files, so relocating the root has no project or profile compatibility impact.

Two design notes:

- The uid goes in the top-level name (`orcaslicer_<uid>`), not a nested `orcaslicer/<uid>`. Each user then creates their own directory directly in the world-writable system temp; a shared parent directory would be owned by whichever user created it first, which is the crash being fixed.
- The root is created up front because STEP import writes `temp.step` into it directly.

Supersedes #14583, which fixed only the model-backup path. Following @Noisyfox's suggestion, this moves the fix up to the temp root so STEP import and part skip are covered too.


# Screenshots/Recordings/Graphs

N/A (no UI change).

## Tests

`tests/libslic3r/test_utils.cpp` covers both helpers, with the platform split guarded by `#ifdef`:

- `per_user_temp_dir(base, id)`: an empty id returns `base` unchanged, a non-empty id is appended, distinct ids differ.
- `per_user_temp_id()`: empty on Windows; the current uid on Linux/macOS; stable across calls.
- End to end: `per_user_temp_dir(base, per_user_temp_id())` equals `base` on Windows and is isolated under `/orcaslicer_` elsewhere.


## Follow-ups

- `CalibUtils` builds a fixed shared `<temp>/calib/` directory (`temp.gcode`, `test.3mf`, `test_config.3mf`) from `temp_directory_path()`, so it has the same multi-user collision. It cannot read `temporary_dir()` because those paths are file-scope statics initialized before `set_temporary_dir()` runs, but the same helper applies directly at `src/slic3r/Utils/CalibUtils.cpp:30`:

  ```cpp
  // from:
  wxString wxstr_temp_dir = fs::path(fs::temp_directory_path() / "calib").wstring();
  // to:
  wxString wxstr_temp_dir = fs::path(fs::path(per_user_temp_dir(fs::temp_directory_path().string(), per_user_temp_id())) / "calib").wstring();
  ```

  (plus `#include "libslic3r/Utils.hpp"`). Left as a separate PR but I can fold it into this one if desired.

- The networking-plugin download (`<temp>/networking_plugins.zip`) is a milder instance of the same pattern.