### PR TITLE
CLI: --inspect-paint — dump per-facet paint state as JSON

### DIFF
--- a/src/OrcaSlicer.cpp
+++ b/src/OrcaSlicer.cpp
@@ -79,6 +79,7 @@ using namespace nlohmann;
 #ifdef WIN32
 #include "dev-utils/BaseException.h"
 #endif
+#include "slic3r/Utils/PaintCLI.hpp"
 #include "slic3r/GUI/PartPlate.hpp"
 #include "slic3r/GUI/BitmapCache.hpp"
 #include "slic3r/GUI/OpenGLManager.hpp"
@@ -5580,6 +5581,16 @@ int CLI::run(int argc, char **argv)
                 model.add_default_instances();
                 model.print_info();
             }
+        } else if (opt_key == "inspect_paint") {
+            // --inspect-paint — read the per-facet enforcer/blocker/extruder/
+            // fuzzy state from the loaded model and emit a JSON summary.
+            // Machine-readable alternative to opening the paint gizmos.
+            const std::string source = m_input_files.empty() ? std::string("<no input>") : m_input_files.front();
+            for (Model &model : m_models) {
+                model.add_default_instances();
+                Slic3r::PaintCLI::inspect_to_json(model, source, boost::nowide::cout);
+            }
+            boost::nowide::cout.flush();
         } else if (opt_key == "uptodate") {
             //already processed before
         } else if (opt_key == "min_save") {

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -10759,6 +10759,19 @@ CLIActionsConfigDef::CLIActionsConfigDef()
     def->tooltip = L("This outputs the model\u2019s information.");
     def->set_default_value(new ConfigOptionBool(false));
 
+    // --inspect-paint \u2014 dump the per-facet enforcer/blocker/extruder/fuzzy
+    // paint state stored on the loaded model (supports, seam, MMU color,
+    // fuzzy-skin) as JSON. Read-only; lets CI / scripted / AI tooling
+    // reason about existing paint on a .3mf without loading the GUI.
+    def = this->add("inspect_paint", coBool);
+    def->label = L("Inspect paint (JSON to stdout)");
+    def->tooltip = L("Print a structured JSON summary of every painted layer "
+                     "(supports, seam, MMU color, fuzzy-skin) already stored on "
+                     "the loaded model \u2014 per-state facet count, surface area, "
+                     "and mesh-local bounding box \u2014 then exit. Machine-readable "
+                     "alternative to opening the paint gizmos in the GUI.");
+    def->set_default_value(new ConfigOptionBool(false));
+
     def = this->add("export_settings", coString);
     def->label = L("Export Settings");
     def->tooltip = L("This exports settings to a file.");

--- a/src/slic3r/CMakeLists.txt
+++ b/src/slic3r/CMakeLists.txt
@@ -578,6 +578,8 @@ set(SLIC3R_GUI_SOURCES
     Utils/bambu_networking.hpp
     Utils/Bonjour.cpp
     Utils/Bonjour.hpp
+    Utils/PaintCLI.cpp
+    Utils/PaintCLI.hpp
     Utils/CalibUtils.cpp
     Utils/CalibUtils.hpp
     Utils/ColorSpaceConvert.cpp

--- a/src/slic3r/Utils/PaintCLI.cpp
+++ b/src/slic3r/Utils/PaintCLI.cpp
@@ -1,0 +1,201 @@
+// PaintCLI.cpp — CLI paint-inspection primitives. See PaintCLI.hpp.
+#include "PaintCLI.hpp"
+
+#include "libslic3r/Model.hpp"
+#include "libslic3r/TriangleMesh.hpp"
+#include "libslic3r/TriangleSelector.hpp"
+
+#include <nlohmann/json.hpp>
+
+#include <cmath>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace Slic3r {
+namespace PaintCLI {
+
+namespace {
+
+using json = nlohmann::json;
+
+double its_surface_area(const indexed_triangle_set &its)
+{
+    double total = 0.0;
+    for (const stl_triangle_vertex_indices &t : its.indices) {
+        const Vec3f &a = its.vertices[t(0)];
+        const Vec3f &b = its.vertices[t(1)];
+        const Vec3f &c = its.vertices[t(2)];
+        total += 0.5 * (b - a).cross(c - a).norm();
+    }
+    return total;
+}
+
+// Bbox over triangle-referenced vertices only. get_facets_strict() returns
+// an itset with the full source vertex list — using bounding_box() on it
+// would report the whole mesh's bbox even when only a few facets are painted.
+BoundingBoxf3 its_referenced_bbox(const indexed_triangle_set &its)
+{
+    BoundingBoxf3 bb;
+    bool first = true;
+    for (const stl_triangle_vertex_indices &t : its.indices) {
+        for (int k = 0; k < 3; ++k) {
+            const Vec3d v = its.vertices[t(k)].cast<double>();
+            if (first) { bb.min = bb.max = v; first = false; }
+            else       bb.merge(v);
+        }
+    }
+    return bb;
+}
+
+json vec3_to_json(const Vec3d &v)
+{
+    return json::array({ v.x(), v.y(), v.z() });
+}
+
+json bbox_to_json(const BoundingBoxf3 &bb)
+{
+    return {
+        { "min",  vec3_to_json(bb.min) },
+        { "max",  vec3_to_json(bb.max) },
+        { "size", vec3_to_json(Vec3d(bb.max - bb.min)) },
+    };
+}
+
+// One (layer, state) row — empty ones are omitted at the caller level.
+json state_entry(const std::string &label, const indexed_triangle_set &its)
+{
+    return {
+        { "state",    label },
+        { "facets",   its.indices.size() },
+        { "area_mm2", its_surface_area(its) },
+        { "bbox",     bbox_to_json(its_referenced_bbox(its)) },
+    };
+}
+
+// Iterate the states relevant to one FacetsAnnotation kind, collecting
+// non-empty entries. Empty layer → {"empty": true}. `n_facets_out` is the
+// running total of painted facets — bumped for the summary.
+json inspect_layer(const ModelVolume &mv, const FacetsAnnotation &fa,
+                   const std::vector<std::pair<EnforcerBlockerType, std::string>> &states,
+                   size_t &n_facets_out)
+{
+    if (fa.empty())
+        return { { "empty", true } };
+
+    json entries = json::array();
+    for (const auto &st : states) {
+        if (!fa.has_facets(mv, st.first))
+            continue;
+        indexed_triangle_set its = fa.get_facets_strict(mv, st.first);
+        if (its.indices.empty())
+            continue;
+        n_facets_out += its.indices.size();
+        entries.push_back(state_entry(st.second, its));
+    }
+    return {
+        { "empty",  entries.empty() },
+        { "states", std::move(entries) },
+    };
+}
+
+const std::vector<std::pair<EnforcerBlockerType, std::string>> &supports_states()
+{
+    static const std::vector<std::pair<EnforcerBlockerType, std::string>> s = {
+        { EnforcerBlockerType::ENFORCER, "ENFORCER" },
+        { EnforcerBlockerType::BLOCKER,  "BLOCKER"  },
+    };
+    return s;
+}
+
+const std::vector<std::pair<EnforcerBlockerType, std::string>> &fuzzy_states()
+{
+    // FUZZY_SKIN is an enum alias for ENFORCER; the layer is single-state.
+    static const std::vector<std::pair<EnforcerBlockerType, std::string>> s = {
+        { EnforcerBlockerType::FUZZY_SKIN, "FUZZY_SKIN" },
+    };
+    return s;
+}
+
+const std::vector<std::pair<EnforcerBlockerType, std::string>> &mmu_states()
+{
+    static std::vector<std::pair<EnforcerBlockerType, std::string>> s = []{
+        std::vector<std::pair<EnforcerBlockerType, std::string>> v;
+        for (int i = 1; i <= int(EnforcerBlockerType::ExtruderMax); ++i)
+            v.emplace_back(EnforcerBlockerType(i), "extruder_" + std::to_string(i));
+        return v;
+    }();
+    return s;
+}
+
+} // namespace
+
+void inspect_to_json(const Model &model, const std::string &source_path,
+                     std::ostream &out)
+{
+    json root;
+    root["source"] = source_path;
+    root["frame"]  = "mesh_local";
+    root["note"]   = "Coordinates are mesh-local (each volume's own frame). "
+                     "Paint gizmos operate in this frame.";
+
+    json objects = json::array();
+    size_t total_objects = 0, total_volumes = 0, total_painted = 0, total_facets = 0;
+
+    for (size_t oi = 0; oi < model.objects.size(); ++oi) {
+        const ModelObject *mo = model.objects[oi];
+        if (!mo) continue;
+        ++total_objects;
+
+        json obj;
+        obj["index"] = oi;
+        obj["name"]  = mo->name;
+
+        json volumes = json::array();
+        for (size_t vi = 0; vi < mo->volumes.size(); ++vi) {
+            const ModelVolume *mv = mo->volumes[vi];
+            if (!mv) continue;
+            ++total_volumes;
+
+            const indexed_triangle_set &its = mv->mesh().its;
+            json vol;
+            vol["index"]    = vi;
+            vol["name"]     = mv->name;
+            vol["n_facets"] = its.indices.size();
+            vol["is_model_part"] = mv->is_model_part();
+            vol["bbox_mesh_local"] = bbox_to_json(bounding_box(its));
+
+            size_t vol_painted = 0;
+            json paints;
+            paints["supports"]         = inspect_layer(*mv, mv->supported_facets,
+                                                      supports_states(),  vol_painted);
+            paints["seam"]             = inspect_layer(*mv, mv->seam_facets,
+                                                      supports_states(),  vol_painted);
+            paints["mmu_segmentation"] = inspect_layer(*mv, mv->mmu_segmentation_facets,
+                                                      mmu_states(),       vol_painted);
+            paints["fuzzy_skin"]       = inspect_layer(*mv, mv->fuzzy_skin_facets,
+                                                      fuzzy_states(),     vol_painted);
+            vol["paints"] = std::move(paints);
+            vol["painted_facets_total"] = vol_painted;
+
+            if (vol_painted > 0) ++total_painted;
+            total_facets += vol_painted;
+
+            volumes.push_back(std::move(vol));
+        }
+        obj["volumes"] = std::move(volumes);
+        objects.push_back(std::move(obj));
+    }
+    root["objects"] = std::move(objects);
+    root["summary"] = {
+        { "objects",                    total_objects },
+        { "volumes",                    total_volumes },
+        { "volumes_with_paint",         total_painted },
+        { "painted_facets_total",       total_facets  },
+    };
+
+    out << root.dump(2) << std::endl;
+}
+
+} // namespace PaintCLI
+} // namespace Slic3r

--- a/src/slic3r/Utils/PaintCLI.hpp
+++ b/src/slic3r/Utils/PaintCLI.hpp
@@ -1,0 +1,29 @@
+// PaintCLI.hpp — CLI paint-inspection primitives.
+//
+// Backs the --inspect-paint CLI action. Reads the per-facet enforcer /
+// blocker / extruder / fuzzy-skin state that OrcaSlicer stores on every
+// ModelVolume (supports, seam, MMU color, fuzzy-skin) and emits a
+// structured JSON summary — facet count, surface area, and mesh-local
+// bounding box per state — so CI / scripted / AI tooling can reason
+// about existing paint on a .3mf without opening the GUI.
+//
+// Coordinates are mesh-local (each volume's own frame), matching the
+// frame that the paint gizmos operate in.
+#ifndef slic3r_PaintCLI_hpp_
+#define slic3r_PaintCLI_hpp_
+
+#include <iosfwd>
+#include <string>
+
+namespace Slic3r {
+class Model;
+
+namespace PaintCLI {
+
+void inspect_to_json(const Model &model, const std::string &source_path,
+                     std::ostream &out);
+
+} // namespace PaintCLI
+} // namespace Slic3r
+
+#endif


### PR DESCRIPTION
# Description

Add `--inspect-paint`: read the per-facet enforcer/blocker/extruder/fuzzy
state stored on the loaded model (supports, seam, MMU color, fuzzy-skin),
print a JSON summary to stdout, then exit. A machine-readable alternative to
opening the paint gizmos, for CI and scripted checks of painted `.3mf` files.

## What it emits

Per object → volume → paint layer, with a top-level `summary`:

```json
{
  "sources": ["/home/user/prints/part.3mf"],
  "frame": "mesh_local",
  "note": "Coordinates are mesh-local (each volume's own frame). Paint gizmos operate in this frame.",
  "objects": [
    {
      "index": 0,
      "name": "part",
      "volumes": [
        {
          "index": 0,
          "name": "part",
          "n_facets": 6474,
          "is_model_part": true,
          "bbox_mesh_local": { "min": [-36, -31.18, -13.13], "max": [36, 31.18, 13.13], "size": [72, 62.35, 26.26] },
          "paints": {
            "supports": {
              "empty": false,
              "states": [
                { "state": "ENFORCER", "facets": 6,
                  "area_mm2": 420.0,
                  "bbox": { "min": [-15.5, -20.1, -13.13], "max": [15.5, 20.1, -12.4], "size": [31, 40.2, 0.7] } }
              ]
            },
            "seam":              { "empty": true },
            "mmu_segmentation":  { "empty": true },
            "fuzzy_skin":        { "empty": true }
          },
          "painted_facets_total": 6
        }
      ]
    }
  ],
  "summary": { "objects": 1, "volumes": 1, "volumes_with_paint": 1, "painted_facets_total": 6 }
}
```

- Empty paint layers collapse to `{"empty": true}`. Non-empty ones list each
  present state with its facet count, area in mm² and mesh-local bounding box.
- `bbox` covers only the painted triangles' vertices.
  `FacetsAnnotation::get_facets_strict` returns the whole source vertex list
  with only the painted triangles indexed, so a plain `bounding_box(its)` would
  report the whole mesh.
- `sources` lists every input file, as absolute paths; the CLI merges inputs
  into one model before actions run.
- Object names and paths are arbitrary bytes, so invalid UTF-8 is written as
  U+FFFD, keeping the output valid JSON.

## Layer semantics

| Layer key | Backed by | States enumerated |
|---|---|---|
| `supports` | `mv.supported_facets` | `ENFORCER`, `BLOCKER` |
| `seam` | `mv.seam_facets` | `ENFORCER`, `BLOCKER` |
| `mmu_segmentation` | `mv.mmu_segmentation_facets` | `extruder_1` .. `extruder_16` |
| `fuzzy_skin` | `mv.fuzzy_skin_facets` | `FUZZY_SKIN` (enum alias for `ENFORCER`) |

## Behaviour

- Registered as an action, like `--info`, so it bypasses the GUI fallback.
- It exits after printing, finishing like the end of `CLI::run`
  (`flush_and_exit` is not used because it prints to stdout).
- Actions that do real work (`--slice`, `--export-3mf`, ...) are rejected up
  front with `CLI_INVALID_PARAMS` instead of being skipped silently. Load-time
  options such as `--uptodate` are still accepted. `--strict` is rejected too:
  it only escalates slicing warnings, and this action never slices, which
  matches what `--inspect-mesh` and `--export-settings -` already do.
- The `--ground-*` transforms are accepted and have no effect on the output:
  they move instance transforms, while the reported paint state is mesh-local.
- Without an input file (or `--load-assemble-list`) it is rejected the same
  way, so a consumer never gets empty stdout with exit 0.

```
$ orca-slicer --inspect-paint painted.3mf | jq '.summary'
$ orca-slicer --inspect-paint --slice 0 painted.3mf   # rejected, exit status 254
```

## Scope

- New `src/slic3r/Utils/PaintCLI.{hpp,cpp}`, depending only on `Model`,
  `TriangleMesh`, `TriangleSelector` and nlohmann/json.
- `src/slic3r/CMakeLists.txt`, `src/libslic3r/PrintConfig.cpp` (the option),
  `src/OrcaSlicer.cpp` (the handler and the up-front check).
- No behaviour change when the flag is absent.

## Verification

Built and run on Linux (GCC 14) on current `main` (93c8b3f2b0, i.e. after #15073
and #14601 merged), exit 0 with no compiler errors:
- Valid JSON (parsed with Python) on an unpainted STL, exit 0, `sources` holding
  the absolute input path.
- `--inspect-mesh` still works in the same binary, and `[LayOnFace]` passes.
- Status 254 for: no input file, `--slice 0`, `--strict`, `--export-settings -`,
  and `--inspect-paint --inspect-mesh` (there the `--inspect-mesh` check fires first).

The touched files compile clean under Clang with `-Werror`.
