### PR TITLE
Fix brim first layer speed

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -6613,8 +6613,9 @@ std::string GCode::_extrude(const ExtrusionPath &path, std::string description, 
         //BBS: for solid infill of first layer, speed can be higher as long as
         //wall lines have be attached
         if (path.role() != erBottomSurface) {
-            speed = is_perimeter(path.role()) ? NOZZLE_CONFIG(initial_layer_speed) :
-                                                NOZZLE_CONFIG(initial_layer_infill_speed);
+            const bool use_first_layer_speed = is_perimeter(path.role()) || path.role() == erBrim;
+            speed = use_first_layer_speed ? NOZZLE_CONFIG(initial_layer_speed) :
+                                            NOZZLE_CONFIG(initial_layer_infill_speed);
         }
     } else if (m_config.slow_down_layers > 1 && m_config.raft_layers == 0) {
         

--- a/tests/fff_print/test_skirt_brim.cpp
+++ b/tests/fff_print/test_skirt_brim.cpp
@@ -32,6 +32,24 @@ using namespace Slic3r;
     return brim_tool;
 }
 
+static double first_extrusion_feedrate_for_feature(const std::string &gcode, const std::string_view feature)
+{
+    double feedrate = 0.0;
+    bool feature_active = false;
+    GCodeReader parser;
+    parser.parse_buffer(gcode, [&feedrate, &feature_active, feature] (GCodeReader &self, const GCodeReader::GCodeLine &line) {
+        const std::string_view comment = line.comment();
+        if (comment.find("FEATURE:") != std::string_view::npos || comment.find("TYPE:") != std::string_view::npos)
+            feature_active = comment.find(feature) != std::string_view::npos;
+
+        if (feature_active && line.extruding(self) && line.dist_XY(self) > 0) {
+            feedrate = line.new_F(self);
+            self.quit_parsing();
+        }
+    });
+    return feedrate;
+}
+
 TEST_CASE("Skirt height is honored", "[SkirtBrim]") {
     DynamicPrintConfig config = Slic3r::DynamicPrintConfig::full_print_config();
     config.set_deserialize_strict({
@@ -50,6 +68,31 @@ TEST_CASE("Skirt height is honored", "[SkirtBrim]") {
     }
 
     REQUIRE(layers_with_role(gcode, "skirt").size() == (size_t)config.opt_int("skirt_height"));
+}
+
+TEST_CASE("Brim uses first layer speed", "[SkirtBrim]") {
+    DynamicPrintConfig config = Slic3r::DynamicPrintConfig::full_print_config();
+    config.set_deserialize_strict({
+        { "brim_type",                    "outer_only" },
+        { "brim_width",                   5 },
+        { "gcode_comments",               true },
+        { "initial_layer_speed",          10 },
+        { "initial_layer_infill_speed",   20 },
+        { "machine_start_gcode",          "" },
+        { "skirt_loops",                  0 },
+        { "slow_down_for_layer_cooling",  false },
+        { "z_hop",                        0 }
+    });
+
+    const std::string gcode = Slic3r::Test::slice({TestMesh::cube_20x20x20}, config);
+
+    const double brim_feedrate = first_extrusion_feedrate_for_feature(gcode, "Brim");
+    REQUIRE(brim_feedrate > 0.0);
+    REQUIRE_THAT(brim_feedrate, Catch::Matchers::WithinAbs(600.0, 1e-3));
+
+    const double bottom_surface_feedrate = first_extrusion_feedrate_for_feature(gcode, "Bottom surface");
+    REQUIRE(bottom_surface_feedrate > 0.0);
+    REQUIRE_THAT(bottom_surface_feedrate, Catch::Matchers::WithinAbs(1200.0, 1e-3));
 }
 
 SCENARIO("Skirt and brim generation", "[SkirtBrim]") {


### PR DESCRIPTION
## Summary
- Use the first layer speed setting for brim extrusion instead of first layer infill speed
- Add a regression test for brim feedrate versus first-layer bottom surface feedrate

Fixes #14590

## Findings
Issue #14590 reports that brim preview speed matches first-layer infill speed instead of the general first-layer speed. We reproduced this with a cube sliced with a brim: with `initial_layer_speed = 40` and `initial_layer_infill_speed = 70`, the brim emitted at 70 mm/s while first-layer walls emitted at 40 mm/s.

The current setting descriptions imply this is incorrect: `initial_layer_speed` is described as the first-layer speed except solid infill sections, while `initial_layer_infill_speed` is specifically for solid infill parts of the first layer. Brim is its own extrusion role, not solid infill.

We also compared behavior against Bambu slicer and confirmed that at least one other slicer has brim speed share the same speed as the first-layer outer wall. Unless Orca intentionally diverged to make brims print at first-layer infill speed, this change corrects the behavior to match the setting semantics and observed slicer precedent.

Previously:
<img width="2542" height="1877" alt="image" src="https://github.com/user-attachments/assets/c7e7fc79-35eb-489b-8fd3-10bfda277e84" />

Updated:
<img width="2533" height="1920" alt="image" src="https://github.com/user-attachments/assets/97f620e6-d18b-4f7c-bd3d-f68cecd9bd03" />


## Validation
- Built `libslic3r` Debug target
- Built `OrcaSlicer_app_gui` RelWithDebInfo target
- Manually confirmed brim preview speed matches first-layer outer wall speed while infill remains faster
## Copilot disclosure
This PR was prepared with assistance from GitHub Copilot. The behavior was reproduced and manually verified by the contributor, including before/after preview comparison.