### PR TITLE
Add bottom fillet option for spiral vase mode

### DIFF
--- a/src/libslic3r/LayerRegion.cpp
+++ b/src/libslic3r/LayerRegion.cpp
@@ -93,6 +93,26 @@ void LayerRegion::make_perimeters(const SurfaceCollection &slices, const LayerRe
         (this->layer()->id() >= size_t(region_config.bottom_shell_layers.value) &&
          this->layer()->print_z >= region_config.bottom_shell_thickness - EPSILON);
 
+    // Orca: spiral vase bottom fillet — extra tapering inner walls right above the bottom shell.
+    coord_t spiral_fillet_inset = 0;
+    if (spiral_mode && print_config.spiral_mode_bottom_fillet_radius.value > 0.) {
+        const double r = print_config.spiral_mode_bottom_fillet_radius.value;
+        // Top Z of the last layer below the spiral (in sync with the spiral_mode flag above).
+        double z_base = 0.;
+        const PrintObject &object = *this->layer()->object();
+        for (size_t i = 0; i < object.layer_count(); ++ i) {
+            const Layer *layer = object.get_layer(int(i));
+            if (i >= size_t(region_config.bottom_shell_layers.value) &&
+                layer->print_z >= region_config.bottom_shell_thickness - EPSILON)
+                break;
+            z_base = layer->print_z;
+        }
+        // Quarter-circle profile evaluated at this layer's bottom Z, so every ring rests on the wider ring below.
+        const double h = std::max(0., this->layer()->print_z - this->layer()->height - z_base);
+        if (h < r - EPSILON)
+            spiral_fillet_inset = scale_(r - std::sqrt(r * r - (r - h) * (r - h)));
+    }
+
     double model_rotation_rad = 0.0;
     if (region_config.align_infill_direction_to_model) {
         auto m = this->layer()->object()->trafo().matrix();
@@ -131,6 +151,7 @@ void LayerRegion::make_perimeters(const SurfaceCollection &slices, const LayerRe
         g.upper_slices_same_region = &this->layer()->upper_layer->get_region(region_id)->slices;
 
     g.layer_id              = (int)this->layer()->id();
+    g.spiral_fillet_inset   = spiral_fillet_inset;
     g.ext_perimeter_flow    = this->flow(frExternalPerimeter);
     g.overhang_flow         = this->bridging_flow(frPerimeter, object_config.thick_bridges);
     g.solid_infill_flow     = this->flow(frSolidInfill);

--- a/src/libslic3r/PerimeterGenerator.cpp
+++ b/src/libslic3r/PerimeterGenerator.cpp
@@ -1232,6 +1232,10 @@ void PerimeterGenerator::process_classic()
         if (loop_number > 0 && config->only_one_wall_top && this->upper_slices == nullptr)
             loop_number = 0;
 
+        // Orca: spiral vase bottom fillet — extra inner walls filling the fillet band of this layer.
+        if (m_spiral_vase && spiral_fillet_inset > 0)
+            loop_number = std::max(loop_number, int(std::lround(double(spiral_fillet_inset) / double(perimeter_spacing))));
+
         ExPolygons last        = union_ex(surface.expolygon.simplify_p(surface_simplify_resolution));
         ExPolygons gaps;
         ExPolygons top_fills;

--- a/src/libslic3r/PerimeterGenerator.hpp
+++ b/src/libslic3r/PerimeterGenerator.hpp
@@ -80,6 +80,8 @@ public:
     const ExPolygons            *lower_slices;
     double                       layer_height;
     int                          layer_id;
+    // Orca: spiral vase bottom fillet — how far the fillet extends inward from the wall on this layer.
+    coord_t                      spiral_fillet_inset = 0;
     coordf_t                     slice_z;
     Flow                         perimeter_flow;
     Flow                         ext_perimeter_flow;

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -1009,6 +1009,7 @@ static std::vector<std::string> s_Preset_print_options{
     "alternate_extra_wall",
     "slice_closing_radius",
     "spiral_mode",
+    "spiral_mode_bottom_fillet_radius",
     "spiral_mode_smooth",
     "spiral_mode_max_xy_smoothing",
     "spiral_starting_flow_ratio",

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -391,6 +391,7 @@ bool Print::invalidate_state_by_config_options(const ConfigOptionResolver & /* n
             //BBS: when enable arc fitting, we must re-generate perimeter
             || opt_key == "enable_arc_fitting"
             || opt_key == "print_order"
+            || opt_key == "spiral_mode_bottom_fillet_radius"
             || opt_key == "wall_sequence") {
             osteps.emplace_back(posPerimeters);
             osteps.emplace_back(posEstimateCurledExtrusions);

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -5899,6 +5899,18 @@ void PrintConfigDef::init_fff_params()
     def->mode = comSimple;
     def->set_default_value(new ConfigOptionBool(false));
 
+    def = this->add("spiral_mode_bottom_fillet_radius", coFloat);
+    def->label = L("Bottom fillet radius");
+    def->tooltip = L("Print a fillet of this radius between the bottom shell and the vase wall, to strengthen "
+                     "and smooth the transition. The fillet is built from extra concentric walls on the inside "
+                     "of the vase, tapering with height along a quarter-circle profile. Layers within the fillet "
+                     "are printed as regular layers, so the seam is still visible there; the spiral starts right "
+                     "above the fillet. 0 disables the fillet.");
+    def->sidetext = L("mm");
+    def->min = 0;
+    def->mode = comAdvanced;
+    def->set_default_value(new ConfigOptionFloat(0));
+
     def = this->add("spiral_mode_smooth", coBool);
     def->label = L("Smooth Spiral");
     def->tooltip = L("Smooth Spiral smooths out X and Y moves as well, "

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -1589,6 +1589,7 @@ PRINT_CONFIG_CLASS_DERIVED_DEFINE(
     ((ConfigOptionFloat,              min_skirt_length))
     ((ConfigOptionFloats,             slow_down_layer_time))
     ((ConfigOptionBool,               spiral_mode))
+    ((ConfigOptionFloat,              spiral_mode_bottom_fillet_radius))
     ((ConfigOptionBool,               spiral_mode_smooth))
     ((ConfigOptionFloatOrPercent,     spiral_mode_max_xy_smoothing))
     ((ConfigOptionFloat,              spiral_finishing_flow_ratio))

--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -699,6 +699,7 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig *config, in
     toggle_line("symmetric_infill_y_axis", is_zig_zag || is_cross_zag || is_locked_zig);
 
     bool has_spiral_vase         = config->opt_bool("spiral_mode");
+    toggle_line("spiral_mode_bottom_fillet_radius", has_spiral_vase);
     toggle_line("spiral_mode_smooth", has_spiral_vase);
     toggle_line("spiral_mode_max_xy_smoothing", has_spiral_vase && config->opt_bool("spiral_mode_smooth"));
     toggle_line("spiral_starting_flow_ratio", has_spiral_vase);

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -13335,6 +13335,7 @@ void Plater::calib_max_vol_speed(const Calib_Params& params)
     obj_cfg.set_key_value("precise_z_height", new ConfigOptionBool(false));
     print_config->set_key_value("timelapse_type", new ConfigOptionEnum<TimelapseType>(tlTraditional));
     print_config->set_key_value("spiral_mode", new ConfigOptionBool(true));
+    print_config->set_key_value("spiral_mode_bottom_fillet_radius", new ConfigOptionFloat(0));
     print_config->set_key_value("max_volumetric_extrusion_rate_slope", new ConfigOptionFloat(0));
     print_config->set_key_value("enable_wrapping_detection", new ConfigOptionBool(false));
 
@@ -13444,6 +13445,7 @@ void Plater::calib_VFA(const Calib_Params& params)
     print_config->set_key_value("sparse_infill_density", new ConfigOptionPercent(0));
     print_config->set_key_value("detect_thin_wall", new ConfigOptionBool(false));
     print_config->set_key_value("spiral_mode", new ConfigOptionBool(true));
+    print_config->set_key_value("spiral_mode_bottom_fillet_radius", new ConfigOptionFloat(0));
     print_config->set_key_value("enable_wrapping_detection", new ConfigOptionBool(false));
     print_config->set_key_value("precise_z_height", new ConfigOptionBool(false));
     model().objects[0]->config.set_key_value("brim_type", new ConfigOptionEnum<BrimType>(btOuterOnly));
@@ -13510,6 +13512,7 @@ void Plater::calib_input_shaping_freq(const Calib_Params& params)
     print_config->set_key_value("sparse_infill_density", new ConfigOptionPercent(0));
     print_config->set_key_value("detect_thin_wall", new ConfigOptionBool(false));
     print_config->set_key_value("spiral_mode", new ConfigOptionBool(true));
+    print_config->set_key_value("spiral_mode_bottom_fillet_radius", new ConfigOptionFloat(0));
     print_config->set_key_value("spiral_mode_smooth", new ConfigOptionBool(false));
     print_config->set_key_value("bottom_surface_pattern", new ConfigOptionEnum<InfillPattern>(ipRectilinear));
     const double machine_max_speed = std::min(printer_config->option<ConfigOptionFloats>("machine_max_speed_x")->get_at(0), printer_config->option<ConfigOptionFloats>("machine_max_speed_y")->get_at(0));
@@ -13574,6 +13577,7 @@ void Plater::calib_input_shaping_damp(const Calib_Params& params)
     print_config->set_key_value("sparse_infill_density", new ConfigOptionPercent(0));
     print_config->set_key_value("detect_thin_wall", new ConfigOptionBool(false));
     print_config->set_key_value("spiral_mode", new ConfigOptionBool(true));
+    print_config->set_key_value("spiral_mode_bottom_fillet_radius", new ConfigOptionFloat(0));
     print_config->set_key_value("spiral_mode_smooth", new ConfigOptionBool(false));
     print_config->set_key_value("bottom_surface_pattern", new ConfigOptionEnum<InfillPattern>(ipRectilinear));
     const double machine_max_speed = std::min(printer_config->option<ConfigOptionFloats>("machine_max_speed_x")->get_at(0), printer_config->option<ConfigOptionFloats>("machine_max_speed_y")->get_at(0));
@@ -13642,6 +13646,7 @@ void Plater::Calib_Cornering(const Calib_Params& params)
     print_config->set_key_value("sparse_infill_density", new ConfigOptionPercent(0));
     print_config->set_key_value("detect_thin_wall", new ConfigOptionBool(false));
     print_config->set_key_value("spiral_mode", new ConfigOptionBool(true));
+    print_config->set_key_value("spiral_mode_bottom_fillet_radius", new ConfigOptionFloat(0));
     print_config->set_key_value("spiral_mode_smooth", new ConfigOptionBool(false));
     print_config->set_key_value("bottom_surface_pattern", new ConfigOptionEnum<InfillPattern>(ipRectilinear));
     const double machine_max_speed = std::min(printer_config->option<ConfigOptionFloats>("machine_max_speed_x")->get_at(0), printer_config->option<ConfigOptionFloats>("machine_max_speed_y")->get_at(0));

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -3012,6 +3012,7 @@ void TabPrint::build()
         optgroup->append_single_option_line("print_sequence", "others_settings_special_mode#print-sequence");
         optgroup->append_single_option_line("print_order", "others_settings_special_mode#intra-layer-order");
         optgroup->append_single_option_line("spiral_mode", "others_settings_special_mode#spiral-vase");
+        optgroup->append_single_option_line("spiral_mode_bottom_fillet_radius", "others_settings_special_mode#spiral-vase");
         optgroup->append_single_option_line("spiral_mode_smooth", "others_settings_special_mode#smooth-spiral");
         optgroup->append_single_option_line("spiral_mode_max_xy_smoothing", "others_settings_special_mode#max-xy-smoothing");
         optgroup->append_single_option_line("spiral_starting_flow_ratio", "others_settings_special_mode#spiral-starting-flow-ratio");

--- a/src/slic3r/Utils/CalibUtils.cpp
+++ b/src/slic3r/Utils/CalibUtils.cpp
@@ -1203,6 +1203,7 @@ void CalibUtils::calib_max_vol_speed(const CalibInfo &calib_info, wxString &erro
     print_config.set_key_value("sparse_infill_density", new ConfigOptionPercent(0));
     print_config.set_key_value("overhang_reverse", new ConfigOptionBool(false));
     print_config.set_key_value("spiral_mode", new ConfigOptionBool(true));
+    print_config.set_key_value("spiral_mode_bottom_fillet_radius", new ConfigOptionFloat(0));
     print_config.set_key_value("outer_wall_line_width", new ConfigOptionFloat(line_width));
     print_config.set_key_value("initial_layer_print_height", new ConfigOptionFloat(layer_height));
     print_config.set_key_value("layer_height", new ConfigOptionFloat(layer_height));
@@ -1267,6 +1268,7 @@ void CalibUtils::calib_VFA(const CalibInfo &calib_info, wxString &error_message)
     print_config.set_key_value("sparse_infill_density", new ConfigOptionPercent(0));
     print_config.set_key_value("overhang_reverse", new ConfigOptionBool(false));
     print_config.set_key_value("spiral_mode", new ConfigOptionBool(true));
+    print_config.set_key_value("spiral_mode_bottom_fillet_radius", new ConfigOptionFloat(0));
     model.objects[0]->config.set_key_value("brim_type", new ConfigOptionEnum<BrimType>(btOuterOnly));
     model.objects[0]->config.set_key_value("brim_width", new ConfigOptionFloat(3.0));
     model.objects[0]->config.set_key_value("brim_object_gap", new ConfigOptionFloat(0.0));

--- a/tests/fff_print/CMakeLists.txt
+++ b/tests/fff_print/CMakeLists.txt
@@ -14,6 +14,7 @@ add_executable(${_TEST_NAME}_tests
 	test_print.cpp
 	test_printobject.cpp
 	test_skirt_brim.cpp
+	test_spiral_vase.cpp
 	test_support_material.cpp
 	test_trianglemesh.cpp
 	)

--- a/tests/fff_print/test_spiral_vase.cpp
+++ b/tests/fff_print/test_spiral_vase.cpp
@@ -1,0 +1,142 @@
+#include <catch2/catch_all.hpp>
+
+#include "libslic3r/libslic3r.h"
+#include "libslic3r/Print.hpp"
+#include "libslic3r/Layer.hpp"
+#include "libslic3r/Model.hpp"
+
+#include "test_helpers.hpp"
+
+#include <limits>
+#include <sstream>
+
+using namespace Slic3r;
+using namespace Slic3r::Test;
+
+// 20mm cube in spiral mode: 0.25mm layers (80 total), 3 bottom shell layers, so the
+// fillet base sits at z = 0.75. Explicit line widths keep the wall spacing, and with
+// it the expected fillet wall counts, independent of default changes.
+static Slic3r::DynamicPrintConfig spiral_vase_config(double bottom_fillet_radius)
+{
+    Slic3r::DynamicPrintConfig config = Slic3r::DynamicPrintConfig::full_print_config();
+    config.set_deserialize_strict({
+        { "spiral_mode",                      1 },
+        { "spiral_mode_bottom_fillet_radius", bottom_fillet_radius },
+        { "wall_loops",                       1 },
+        { "top_shell_layers",                 0 },
+        { "sparse_infill_density",            0 },
+        { "bottom_shell_layers",              3 },
+        { "bottom_shell_thickness",           0 },
+        { "layer_height",                     0.25 },
+        { "initial_layer_print_height",       0.25 },
+        { "line_width",                       0.45 },
+        { "inner_wall_line_width",            0.45 },
+        { "skirt_loops",                      0 },
+        { "brim_type",                        "no_brim" }
+    });
+    return config;
+}
+
+// A move that changes X/Y, ramps Z and extrudes all at once only occurs inside a spiral.
+static double min_spiral_move_z(const std::string &gcode, bool &found_any)
+{
+    double min_z = std::numeric_limits<double>::max();
+    found_any = false;
+    std::istringstream stream(gcode);
+    std::string line;
+    while (std::getline(stream, line)) {
+        if (line.rfind("G1 ", 0) != 0)
+            continue;
+        if (size_t comment = line.find(';'); comment != std::string::npos)
+            line.erase(comment);
+        size_t z_pos = line.find('Z');
+        size_t e_pos = line.find('E');
+        if (line.find('X') == std::string::npos || line.find('Y') == std::string::npos ||
+            z_pos == std::string::npos || e_pos == std::string::npos)
+            continue;
+        if (atof(line.c_str() + e_pos + 1) > 0.) {
+            found_any = true;
+            min_z = std::min(min_z, atof(line.c_str() + z_pos + 1));
+        }
+    }
+    return min_z;
+}
+
+// First layer eligible for spiraling: a single perimeter loop and no fill extrusions.
+static const Layer *first_spiral_candidate(const PrintObject &object)
+{
+    for (const Layer *layer : object.layers()) {
+        const LayerRegion *region = layer->regions().front();
+        if (region->perimeters.items_count() == 1 && region->fills.items_count() == 0)
+            return layer;
+    }
+    return nullptr;
+}
+
+TEST_CASE("Spiral layers keep a single perimeter and no fill without a bottom fillet", "[SpiralVase]") {
+    Slic3r::Print print;
+    Slic3r::Model model;
+    init_print({cube(20)}, print, model, spiral_vase_config(0.));
+    print.process();
+    const PrintObject &object = *print.objects().front();
+    REQUIRE(object.layer_count() == 80);
+    for (const Layer *layer : object.layers()) {
+        const LayerRegion *region = layer->regions().front();
+        if (layer->id() >= 3) {
+            CHECK(region->perimeters.items_count() == 1);
+            CHECK(region->fills.items_count() == 0);
+        } else {
+            CHECK(region->fills.items_count() > 0);
+        }
+    }
+}
+
+TEST_CASE("Bottom fillet adds inner walls that taper away with height", "[SpiralVase]") {
+    Slic3r::Print print;
+    Slic3r::Model model;
+    init_print({cube(20)}, print, model, spiral_vase_config(2.));
+    print.process();
+    // Fillet base z = 3 * 0.25 = 0.75; a 2mm fillet spans layers whose bottom z is in
+    // [0.75, 2.75), i.e. layer ids 3..10.
+    const PrintObject &object = *print.objects().front();
+    // The first fillet layers carry extra inner walls (id 3 holds the full 2mm band).
+    CHECK(object.get_layer(3)->regions().front()->perimeters.items_count() >= 3);
+    CHECK(object.get_layer(4)->regions().front()->perimeters.items_count() >= 2);
+    // The wall count tapers monotonically through the fillet.
+    size_t previous = std::numeric_limits<size_t>::max();
+    for (int i = 3; i <= 11; ++ i) {
+        size_t count = object.get_layer(i)->regions().front()->perimeters.items_count();
+        CHECK(count <= previous);
+        previous = count;
+    }
+    // Above the fillet the spiral wall is back to a single loop without fill.
+    for (const Layer *layer : object.layers())
+        if (layer->id() >= 11) {
+            const LayerRegion *region = layer->regions().front();
+            CHECK(region->perimeters.items_count() == 1);
+            CHECK(region->fills.items_count() == 0);
+        }
+    // The bottom shell layers are still fully filled.
+    for (int i = 0; i < 3; ++ i)
+        CHECK(object.get_layer(i)->regions().front()->fills.items_count() > 0);
+}
+
+TEST_CASE("Spiral Z ramp starts right above the last non-spiral layer", "[SpiralVase]") {
+    // Without a fillet the spiral starts right above the 3 bottom shell layers; a 2mm
+    // fillet (layer ids 3..10, minus taper quantization) delays it into id 7..11.
+    auto [fillet_radius, min_transition_id, max_transition_id] =
+        GENERATE(table<double, size_t, size_t>({ {0., 3, 3}, {2., 7, 11} }));
+    Slic3r::Print print;
+    Slic3r::Model model;
+    init_print({cube(20)}, print, model, spiral_vase_config(fillet_radius));
+    print.process();
+    const Layer *transition = first_spiral_candidate(*print.objects().front());
+    REQUIRE(transition != nullptr);
+    CHECK(transition->id() >= min_transition_id);
+    CHECK(transition->id() <= max_transition_id);
+    // Spiral moves never dip below the top of the last non-spiral layer.
+    bool found_spiral_moves = false;
+    double min_z = min_spiral_move_z(Slic3r::Test::gcode(print), found_spiral_moves);
+    CHECK(found_spiral_moves);
+    CHECK(min_z > transition->print_z - transition->height - 0.01);
+}


### PR DESCRIPTION
# Description

Adds a **"Bottom fillet radius"** option (`spiral_mode_bottom_fillet_radius`) to spiral vase mode.

In vase mode, the single-extrusion wall meets the solid bottom at an abrupt 90° corner — a weak
point and a hard edge on an otherwise smooth print. With this option set, the slicer prints extra
concentric inner walls in the layers right above the bottom shell, tapering along a **quarter-circle
profile**, forming a fillet that reinforces and smooths the floor-to-wall transition. Works on
ordinary solid models — no CAD changes needed.

The fillet layers print as regular layers (a spiraled layer must be a single continuous loop), and
the existing per-layer gate in `GCode::process_layer()` starts the spiral right above the fillet
automatically — no new threshold plumbing. Each fillet ring is fully supported by the wider ring below.

Found under **Print settings → Others → Special mode**, visible only when Spiral vase is enabled
(Advanced mode). `0` (default) disables the fillet.

## Changes

- `PrintConfig`: new `coFloat` option `spiral_mode_bottom_fillet_radius` (mm, min 0, default 0, comAdvanced).
- `LayerRegion::make_perimeters()`: computes the per-layer fillet inset from the quarter-circle
  profile, evaluated at the layer's bottom Z, in sync with the existing per-layer spiral flag.
- `PerimeterGenerator::process_classic()`: raises `loop_number` for spiral layers with a nonzero
  inset (`round(inset / perimeter_spacing)` extra walls).
- `Print::invalidate_state_by_config_options()`: the new key invalidates `posPerimeters`.
- `Preset.cpp`: option registered in `s_Preset_print_options`.
- GUI: option row in the Special mode group; shown only while spiral mode is on.
- Calibration flows (`Plater.cpp`, `CalibUtils.cpp`) pin the option to 0 so calibration towers are unaffected.

## Scope

- **No behavior change at the default.** Every new code path is gated behind
  `spiral_mode && spiral_mode_bottom_fillet_radius > 0`; with the option at 0 the generated
  toolpaths are identical to master (covered by a regression test).
- Does **not** touch the SpiralVase G-code transform, the vase-mode slicing mode
  (`PositiveLargestContour`), the forced vase settings (1 wall / 0 top layers / 0 infill),
  surface typing, or the plate-level spiral toggle.
- Known tradeoff (documented in the tooltip): fillet layers cannot be spiraled, so the seam
  remains visible through the fillet height — same as the existing bottom shell layers.

# Screenshot

<img width="1448" height="631" alt="image" src="https://github.com/user-attachments/assets/ce73f468-54a3-4b49-88f8-e8b5749fc7a1" />

# Tests

- New `tests/fff_print/test_spiral_vase.cpp` (first spiral vase tests in the repo), 3 scenarios / 324 assertions:
  - **Default-0 regression**: with the option at 0, every layer above the bottom shell has exactly
    1 perimeter and 0 fills, and the G-code spiral transition stays right above the bottom shell.
  - **Fillet taper**: extra walls appear right above the bottom shell, wall count decreases
    monotonically with height, single spiral wall restored above the fillet.
  - **G-code level**: combined X/Y/Z/E spiral ramp moves appear only above the fillet.
- Full test suite passes (fff_print 46/46, libslic3r 129/129, sla_print 21/21, slic3rutils 5/5).
- Printed a real vase with the fillet enabled — transition comes out reinforced and clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
