### PR TITLE
Disable prime tower width for rib walls

### DIFF
--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -916,7 +916,7 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig *config, in
     toggle_line("wipe_tower_extra_rib_length", have_rib_wall);
     toggle_line("wipe_tower_rib_width", have_rib_wall);
     toggle_line("wipe_tower_fillet_wall", have_rib_wall);
-    toggle_field("prime_tower_width", have_prime_tower && wipe_tower_wall_type != WipeTowerWallType::wtwRib);
+    toggle_field("prime_tower_width", have_prime_tower && !have_rib_wall);
 
     toggle_line("single_extruder_multi_material_priming", !bSEMM && have_prime_tower && supports_wipe_tower_2);
 

--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -916,7 +916,7 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig *config, in
     toggle_line("wipe_tower_extra_rib_length", have_rib_wall);
     toggle_line("wipe_tower_rib_width", have_rib_wall);
     toggle_line("wipe_tower_fillet_wall", have_rib_wall);
-    toggle_field("prime_tower_width", have_prime_tower && (supports_wipe_tower_2 || have_rib_wall));
+    toggle_field("prime_tower_width", have_prime_tower && wipe_tower_wall_type != WipeTowerWallType::wtwRib);
 
     toggle_line("single_extruder_multi_material_priming", !bSEMM && have_prime_tower && supports_wipe_tower_2);
 


### PR DESCRIPTION
## Description
Fixes #14537.

This updates the prime tower UI so the Width field is disabled when the selected wall type is Rib. Rib towers use the rib-specific controls (extra rib length, rib width, and fillet wall), so leaving Width editable implies it affects rib tower geometry when it does not.

I kept this as a minimal behavior-only fix. An alternative would be to move Width below Wall type and show/hide it alongside the wall-type-specific controls, but that would be a broader UI layout change. This PR follows the lower-risk approach of greying out the existing field in place.

Before:
<img width="2512" height="1827" alt="image" src="https://github.com/user-attachments/assets/e81faf69-95de-4ddc-b049-64d769d78c81" />

After:
<img width="2546" height="1587" alt="image" src="https://github.com/user-attachments/assets/cbe66e3b-c1e9-4d21-8682-ce12a3f4d4e2" />


## Tests
Built locally with:

```bash
cmake --build build-dbginfo --config RelWithDebInfo --target OrcaSlicer -- -m
```

Manually verified that Width is disabled for Rib and remains enabled for the standard wall type.

## Disclosure
This PR was prepared with assistance from GitHub Copilot.