### PR TITLE
dedupe-issues.yml remove unsupported claude_args option

### DIFF
--- a/.github/workflows/dedupe-issues.yml
+++ b/.github/workflows/dedupe-issues.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           prompt: "/dedupe ${{ github.repository }}/issues/${{ github.event.issue.number || inputs.issue_number }}"
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--model claude-sonnet-4-5-20250929"
+          model: "claude-sonnet-4-5-20250929"
           claude_env: |
             GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
# Description

claude_args: is causing an error 
`Unexpected input(s) 'claude_args'`
Only calling for "--model" anyway, so replaced with model: option.