### PR TITLE
disable arc_fitting for K1 potato mcu

### DIFF
--- a/resources/profiles/Creality/process/0.08mm SuperDetail @Creality K1 (0.4 nozzle).json
+++ b/resources/profiles/Creality/process/0.08mm SuperDetail @Creality K1 (0.4 nozzle).json
@@ -39,7 +39,7 @@
 	"draft_shield": "disabled",
 	"elefant_foot_compensation": "0.15",
 	"elefant_foot_compensation_layers": "1",
-	"enable_arc_fitting": "1",
+	"enable_arc_fitting": "0",
 	"enable_overhang_speed": "1",
 	"enable_prime_tower": "1",
 	"enable_support": "0",

--- a/resources/profiles/Creality/process/0.08mm SuperDetail @Creality K1 Max_CFS-C 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.08mm SuperDetail @Creality K1 Max_CFS-C 0.4 nozzle.json
@@ -39,7 +39,7 @@
 	"draft_shield": "disabled",
 	"elefant_foot_compensation": "0.15",
 	"elefant_foot_compensation_layers": "1",
-	"enable_arc_fitting": "1",
+	"enable_arc_fitting": "0",
 	"enable_overhang_speed": "1",
 	"enable_prime_tower": "1",
 	"enable_support": "0",

--- a/resources/profiles/Creality/process/0.08mm SuperDetail @Creality K1C 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.08mm SuperDetail @Creality K1C 0.4 nozzle.json
@@ -39,7 +39,7 @@
 	"draft_shield": "disabled",
 	"elefant_foot_compensation": "0.15",
 	"elefant_foot_compensation_layers": "1",
-	"enable_arc_fitting": "1",
+	"enable_arc_fitting": "0",
 	"enable_overhang_speed": "1",
 	"enable_prime_tower": "1",
 	"enable_support": "0",

--- a/resources/profiles/Creality/process/0.08mm SuperDetail @Creality K1C_CFS-C 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.08mm SuperDetail @Creality K1C_CFS-C 0.4 nozzle.json
@@ -39,7 +39,7 @@
 	"draft_shield": "disabled",
 	"elefant_foot_compensation": "0.15",
 	"elefant_foot_compensation_layers": "1",
-	"enable_arc_fitting": "1",
+	"enable_arc_fitting": "0",
 	"enable_overhang_speed": "1",
 	"enable_prime_tower": "1",
 	"enable_support": "0",

--- a/resources/profiles/Creality/process/0.08mm SuperDetail @Creality K1Max (0.4 nozzle).json
+++ b/resources/profiles/Creality/process/0.08mm SuperDetail @Creality K1Max (0.4 nozzle).json
@@ -39,7 +39,7 @@
 	"draft_shield": "disabled",
 	"elefant_foot_compensation": "0.15",
 	"elefant_foot_compensation_layers": "1",
-	"enable_arc_fitting": "1",
+	"enable_arc_fitting": "0",
 	"enable_overhang_speed": "1",
 	"enable_prime_tower": "1",
 	"enable_support": "0",

--- a/resources/profiles/Creality/process/0.08mm SuperDetail @Creality K1_CFS-C 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.08mm SuperDetail @Creality K1_CFS-C 0.4 nozzle.json
@@ -39,7 +39,7 @@
 	"draft_shield": "disabled",
 	"elefant_foot_compensation": "0.15",
 	"elefant_foot_compensation_layers": "1",
-	"enable_arc_fitting": "1",
+	"enable_arc_fitting": "0",
 	"enable_overhang_speed": "1",
 	"enable_prime_tower": "1",
 	"enable_support": "0",

--- a/resources/profiles/Creality/process/0.16mm Optimal @Creality K1 (0.4 nozzle).json
+++ b/resources/profiles/Creality/process/0.16mm Optimal @Creality K1 (0.4 nozzle).json
@@ -39,7 +39,7 @@
 	"draft_shield": "disabled",
 	"elefant_foot_compensation": "0.15",
 	"elefant_foot_compensation_layers": "1",
-	"enable_arc_fitting": "1",
+	"enable_arc_fitting": "0",
 	"enable_overhang_speed": "1",
 	"enable_prime_tower": "1",
 	"enable_support": "0",

--- a/resources/profiles/Creality/process/0.16mm Optimal @Creality K1 Max_CFS-C 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.16mm Optimal @Creality K1 Max_CFS-C 0.4 nozzle.json
@@ -39,7 +39,7 @@
 	"draft_shield": "disabled",
 	"elefant_foot_compensation": "0.15",
 	"elefant_foot_compensation_layers": "1",
-	"enable_arc_fitting": "1",
+	"enable_arc_fitting": "0",
 	"enable_overhang_speed": "1",
 	"enable_prime_tower": "1",
 	"enable_support": "0",

--- a/resources/profiles/Creality/process/0.16mm Optimal @Creality K1 SE 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.16mm Optimal @Creality K1 SE 0.4 nozzle.json
@@ -38,7 +38,7 @@
 	"draft_shield": "disabled",
 	"elefant_foot_compensation": "0.15",
 	"elefant_foot_compensation_layers": "1",
-	"enable_arc_fitting": "1",
+	"enable_arc_fitting": "0",
 	"enable_overhang_speed": "1",
 	"enable_prime_tower": "1",
 	"enable_support": "0",

--- a/resources/profiles/Creality/process/0.16mm Optimal @Creality K1 SE_CFS-C 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.16mm Optimal @Creality K1 SE_CFS-C 0.4 nozzle.json
@@ -38,7 +38,7 @@
 	"draft_shield": "disabled",
 	"elefant_foot_compensation": "0.15",
 	"elefant_foot_compensation_layers": "1",
-	"enable_arc_fitting": "1",
+	"enable_arc_fitting": "0",
 	"enable_overhang_speed": "1",
 	"enable_prime_tower": "1",
 	"enable_support": "0",

--- a/resources/profiles/Creality/process/0.16mm Optimal @Creality K1C 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.16mm Optimal @Creality K1C 0.4 nozzle.json
@@ -39,7 +39,7 @@
 	"draft_shield": "disabled",
 	"elefant_foot_compensation": "0.15",
 	"elefant_foot_compensation_layers": "1",
-	"enable_arc_fitting": "1",
+	"enable_arc_fitting": "0",
 	"enable_overhang_speed": "1",
 	"enable_prime_tower": "1",
 	"enable_support": "0",

--- a/resources/profiles/Creality/process/0.16mm Optimal @Creality K1C_CFS-C 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.16mm Optimal @Creality K1C_CFS-C 0.4 nozzle.json
@@ -39,7 +39,7 @@
 	"draft_shield": "disabled",
 	"elefant_foot_compensation": "0.15",
 	"elefant_foot_compensation_layers": "1",
-	"enable_arc_fitting": "1",
+	"enable_arc_fitting": "0",
 	"enable_overhang_speed": "1",
 	"enable_prime_tower": "1",
 	"enable_support": "0",

--- a/resources/profiles/Creality/process/0.16mm Optimal @Creality K1Max (0.4 nozzle).json
+++ b/resources/profiles/Creality/process/0.16mm Optimal @Creality K1Max (0.4 nozzle).json
@@ -39,7 +39,7 @@
 	"draft_shield": "disabled",
 	"elefant_foot_compensation": "0.15",
 	"elefant_foot_compensation_layers": "1",
-	"enable_arc_fitting": "1",
+	"enable_arc_fitting": "0",
 	"enable_overhang_speed": "1",
 	"enable_prime_tower": "1",
 	"enable_support": "0",

--- a/resources/profiles/Creality/process/0.16mm Optimal @Creality K1_CFS-C 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.16mm Optimal @Creality K1_CFS-C 0.4 nozzle.json
@@ -39,7 +39,7 @@
 	"draft_shield": "disabled",
 	"elefant_foot_compensation": "0.15",
 	"elefant_foot_compensation_layers": "1",
-	"enable_arc_fitting": "1",
+	"enable_arc_fitting": "0",
 	"enable_overhang_speed": "1",
 	"enable_prime_tower": "1",
 	"enable_support": "0",

--- a/resources/profiles/Creality/process/0.20mm Standard @Creality K1 (0.4 nozzle).json
+++ b/resources/profiles/Creality/process/0.20mm Standard @Creality K1 (0.4 nozzle).json
@@ -128,7 +128,7 @@
 	"detect_narrow_internal_solid_infill": "1",
 	"dont_filter_internal_bridges": "disabled",
 	"elefant_foot_compensation_layers": "1",
-	"enable_arc_fitting": "1",
+	"enable_arc_fitting": "0",
 	"enable_overhang_speed": "1",
 	"enforce_support_layers": "0",
 	"ensure_vertical_shell_thickness": "ensure_all",

--- a/resources/profiles/Creality/process/0.20mm Standard @Creality K1 Max_CFS-C 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.20mm Standard @Creality K1 Max_CFS-C 0.4 nozzle.json
@@ -39,7 +39,7 @@
 	"draft_shield": "disabled",
 	"elefant_foot_compensation": "0.15",
 	"elefant_foot_compensation_layers": "1",
-	"enable_arc_fitting": "1",
+	"enable_arc_fitting": "0",
 	"enable_overhang_speed": "1",
 	"enable_prime_tower": "1",
 	"enable_support": "0",

--- a/resources/profiles/Creality/process/0.20mm Standard @Creality K1 SE 0.4.json
+++ b/resources/profiles/Creality/process/0.20mm Standard @Creality K1 SE 0.4.json
@@ -124,7 +124,7 @@
 	"detect_narrow_internal_solid_infill": "1",
 	"dont_filter_internal_bridges": "disabled",
 	"elefant_foot_compensation_layers": "1",
-	"enable_arc_fitting": "1",
+	"enable_arc_fitting": "0",
 	"enable_overhang_speed": "1",
 	"enforce_support_layers": "0",
 	"ensure_vertical_shell_thickness": "ensure_all",

--- a/resources/profiles/Creality/process/0.20mm Standard @Creality K1 SE_CFS-C 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.20mm Standard @Creality K1 SE_CFS-C 0.4 nozzle.json
@@ -38,7 +38,7 @@
 	"draft_shield": "disabled",
 	"elefant_foot_compensation": "0.15",
 	"elefant_foot_compensation_layers": "1",
-	"enable_arc_fitting": "1",
+	"enable_arc_fitting": "0",
 	"enable_overhang_speed": "1",
 	"enable_prime_tower": "1",
 	"enable_support": "0",

--- a/resources/profiles/Creality/process/0.20mm Standard @Creality K1C 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.20mm Standard @Creality K1C 0.4 nozzle.json
@@ -128,7 +128,7 @@
 	"detect_narrow_internal_solid_infill": "1",
 	"dont_filter_internal_bridges": "disabled",
 	"elefant_foot_compensation_layers": "1",
-	"enable_arc_fitting": "1",
+	"enable_arc_fitting": "0",
 	"enable_overhang_speed": "1",
 	"enforce_support_layers": "0",
 	"ensure_vertical_shell_thickness": "ensure_all",

--- a/resources/profiles/Creality/process/0.20mm Standard @Creality K1C_CFS-C 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.20mm Standard @Creality K1C_CFS-C 0.4 nozzle.json
@@ -39,7 +39,7 @@
 	"draft_shield": "disabled",
 	"elefant_foot_compensation": "0.15",
 	"elefant_foot_compensation_layers": "1",
-	"enable_arc_fitting": "1",
+	"enable_arc_fitting": "0",
 	"enable_overhang_speed": "1",
 	"enable_prime_tower": "1",
 	"enable_support": "0",

--- a/resources/profiles/Creality/process/0.20mm Standard @Creality K1Max (0.4 nozzle).json
+++ b/resources/profiles/Creality/process/0.20mm Standard @Creality K1Max (0.4 nozzle).json
@@ -128,7 +128,7 @@
 	"detect_narrow_internal_solid_infill": "1",
 	"dont_filter_internal_bridges": "disabled",
 	"elefant_foot_compensation_layers": "1",
-	"enable_arc_fitting": "1",
+	"enable_arc_fitting": "0",
 	"enable_overhang_speed": "1",
 	"enforce_support_layers": "0",
 	"ensure_vertical_shell_thickness": "ensure_all",

--- a/resources/profiles/Creality/process/0.20mm Standard @Creality K1_CFS-C 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.20mm Standard @Creality K1_CFS-C 0.4 nozzle.json
@@ -39,7 +39,7 @@
 	"draft_shield": "disabled",
 	"elefant_foot_compensation": "0.15",
 	"elefant_foot_compensation_layers": "1",
-	"enable_arc_fitting": "1",
+	"enable_arc_fitting": "0",
 	"enable_overhang_speed": "1",
 	"enable_prime_tower": "1",
 	"enable_support": "0",

--- a/resources/profiles/Creality/process/0.24mm Draft @Creality K1 (0.4 nozzle).json
+++ b/resources/profiles/Creality/process/0.24mm Draft @Creality K1 (0.4 nozzle).json
@@ -39,7 +39,7 @@
 	"draft_shield": "disabled",
 	"elefant_foot_compensation": "0.15",
 	"elefant_foot_compensation_layers": "1",
-	"enable_arc_fitting": "1",
+	"enable_arc_fitting": "0",
 	"enable_overhang_speed": "1",
 	"enable_prime_tower": "1",
 	"enable_support": "0",

--- a/resources/profiles/Creality/process/0.24mm Draft @Creality K1 Max_CFS-C 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.24mm Draft @Creality K1 Max_CFS-C 0.4 nozzle.json
@@ -39,7 +39,7 @@
 	"draft_shield": "disabled",
 	"elefant_foot_compensation": "0.15",
 	"elefant_foot_compensation_layers": "1",
-	"enable_arc_fitting": "1",
+	"enable_arc_fitting": "0",
 	"enable_overhang_speed": "1",
 	"enable_prime_tower": "1",
 	"enable_support": "0",

--- a/resources/profiles/Creality/process/0.24mm Draft @Creality K1 SE 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.24mm Draft @Creality K1 SE 0.4 nozzle.json
@@ -38,7 +38,7 @@
 	"draft_shield": "disabled",
 	"elefant_foot_compensation": "0.15",
 	"elefant_foot_compensation_layers": "1",
-	"enable_arc_fitting": "1",
+	"enable_arc_fitting": "0",
 	"enable_overhang_speed": "1",
 	"enable_prime_tower": "1",
 	"enable_support": "0",

--- a/resources/profiles/Creality/process/0.24mm Draft @Creality K1 SE_CFS-C 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.24mm Draft @Creality K1 SE_CFS-C 0.4 nozzle.json
@@ -38,7 +38,7 @@
 	"draft_shield": "disabled",
 	"elefant_foot_compensation": "0.15",
 	"elefant_foot_compensation_layers": "1",
-	"enable_arc_fitting": "1",
+	"enable_arc_fitting": "0",
 	"enable_overhang_speed": "1",
 	"enable_prime_tower": "1",
 	"enable_support": "0",

--- a/resources/profiles/Creality/process/0.24mm Draft @Creality K1C 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.24mm Draft @Creality K1C 0.4 nozzle.json
@@ -39,7 +39,7 @@
 	"draft_shield": "disabled",
 	"elefant_foot_compensation": "0.15",
 	"elefant_foot_compensation_layers": "1",
-	"enable_arc_fitting": "1",
+	"enable_arc_fitting": "0",
 	"enable_overhang_speed": "1",
 	"enable_prime_tower": "1",
 	"enable_support": "0",

--- a/resources/profiles/Creality/process/0.24mm Draft @Creality K1C_CFS-C 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.24mm Draft @Creality K1C_CFS-C 0.4 nozzle.json
@@ -39,7 +39,7 @@
 	"draft_shield": "disabled",
 	"elefant_foot_compensation": "0.15",
 	"elefant_foot_compensation_layers": "1",
-	"enable_arc_fitting": "1",
+	"enable_arc_fitting": "0",
 	"enable_overhang_speed": "1",
 	"enable_prime_tower": "1",
 	"enable_support": "0",

--- a/resources/profiles/Creality/process/0.24mm Draft @Creality K1Max (0.4 nozzle).json
+++ b/resources/profiles/Creality/process/0.24mm Draft @Creality K1Max (0.4 nozzle).json
@@ -39,7 +39,7 @@
 	"draft_shield": "disabled",
 	"elefant_foot_compensation": "0.15",
 	"elefant_foot_compensation_layers": "1",
-	"enable_arc_fitting": "1",
+	"enable_arc_fitting": "0",
 	"enable_overhang_speed": "1",
 	"enable_prime_tower": "1",
 	"enable_support": "0",

--- a/resources/profiles/Creality/process/0.24mm Draft @Creality K1_CFS-C 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.24mm Draft @Creality K1_CFS-C 0.4 nozzle.json
@@ -39,7 +39,7 @@
 	"draft_shield": "disabled",
 	"elefant_foot_compensation": "0.15",
 	"elefant_foot_compensation_layers": "1",
-	"enable_arc_fitting": "1",
+	"enable_arc_fitting": "0",
 	"enable_overhang_speed": "1",
 	"enable_prime_tower": "1",
 	"enable_support": "0",

--- a/resources/profiles/Creality/process/0.30mm Standard @Creality K1 (0.6 nozzle).json
+++ b/resources/profiles/Creality/process/0.30mm Standard @Creality K1 (0.6 nozzle).json
@@ -126,7 +126,7 @@
 	"detect_narrow_internal_solid_infill": "1",
 	"dont_filter_internal_bridges": "disabled",
 	"elefant_foot_compensation_layers": "1",
-	"enable_arc_fitting": "1",
+	"enable_arc_fitting": "0",
 	"enable_overhang_speed": "1",
 	"enforce_support_layers": "0",
 	"ensure_vertical_shell_thickness": "ensure_all",

--- a/resources/profiles/Creality/process/0.30mm Standard @Creality K1 SE 0.6 nozzle.json
+++ b/resources/profiles/Creality/process/0.30mm Standard @Creality K1 SE 0.6 nozzle.json
@@ -38,7 +38,7 @@
 	"draft_shield": "disabled",
 	"elefant_foot_compensation": "0.15",
 	"elefant_foot_compensation_layers": "1",
-	"enable_arc_fitting": "1",
+	"enable_arc_fitting": "0",
 	"enable_overhang_speed": "1",
 	"enable_prime_tower": "0",
 	"enable_support": "0",

--- a/resources/profiles/Creality/process/0.30mm Standard @Creality K1C 0.6 nozzle.json
+++ b/resources/profiles/Creality/process/0.30mm Standard @Creality K1C 0.6 nozzle.json
@@ -126,7 +126,7 @@
 	"detect_narrow_internal_solid_infill": "1",
 	"dont_filter_internal_bridges": "disabled",
 	"elefant_foot_compensation_layers": "1",
-	"enable_arc_fitting": "1",
+	"enable_arc_fitting": "0",
 	"enable_overhang_speed": "1",
 	"enforce_support_layers": "0",
 	"ensure_vertical_shell_thickness": "ensure_all",

--- a/resources/profiles/Creality/process/0.30mm Standard @Creality K1Max (0.6 nozzle).json
+++ b/resources/profiles/Creality/process/0.30mm Standard @Creality K1Max (0.6 nozzle).json
@@ -126,7 +126,7 @@
 	"detect_narrow_internal_solid_infill": "1",
 	"dont_filter_internal_bridges": "disabled",
 	"elefant_foot_compensation_layers": "1",
-	"enable_arc_fitting": "1",
+	"enable_arc_fitting": "0",
 	"enable_overhang_speed": "1",
 	"enforce_support_layers": "0",
 	"ensure_vertical_shell_thickness": "ensure_all",

--- a/resources/profiles/Creality/process/0.40mm Standard @Creality K1 (0.8 nozzle).json
+++ b/resources/profiles/Creality/process/0.40mm Standard @Creality K1 (0.8 nozzle).json
@@ -126,7 +126,7 @@
 	"detect_narrow_internal_solid_infill": "1",
 	"dont_filter_internal_bridges": "disabled",
 	"elefant_foot_compensation_layers": "1",
-	"enable_arc_fitting": "1",
+	"enable_arc_fitting": "0",
 	"enable_overhang_speed": "1",
 	"enforce_support_layers": "0",
 	"ensure_vertical_shell_thickness": "ensure_all",

--- a/resources/profiles/Creality/process/0.40mm Standard @Creality K1C 0.8 nozzle.json
+++ b/resources/profiles/Creality/process/0.40mm Standard @Creality K1C 0.8 nozzle.json
@@ -126,7 +126,7 @@
 	"detect_narrow_internal_solid_infill": "1",
 	"dont_filter_internal_bridges": "disabled",
 	"elefant_foot_compensation_layers": "1",
-	"enable_arc_fitting": "1",
+	"enable_arc_fitting": "0",
 	"enable_overhang_speed": "1",
 	"enforce_support_layers": "0",
 	"ensure_vertical_shell_thickness": "ensure_all",

--- a/resources/profiles/Creality/process/0.40mm Standard @Creality K1Max (0.8 nozzle).json
+++ b/resources/profiles/Creality/process/0.40mm Standard @Creality K1Max (0.8 nozzle).json
@@ -126,7 +126,7 @@
 	"detect_narrow_internal_solid_infill": "1",
 	"dont_filter_internal_bridges": "disabled",
 	"elefant_foot_compensation_layers": "1",
-	"enable_arc_fitting": "1",
+	"enable_arc_fitting": "0",
 	"enable_overhang_speed": "1",
 	"enforce_support_layers": "0",
 	"ensure_vertical_shell_thickness": "ensure_all",


### PR DESCRIPTION
# Description

The K1 Series, whether it's K1, K1C, K1 Max, or whatever K1 models are out there, have an MCU that literally is a potato. Tons of internet reporting on "Timer too close" issues, which literally shut down the MCU or even crash it with no proper debug options, due to the K1 potato board not having a JTAG port. Gigatons of Filament were wasted worldwide.

All the K1* process profiles have "enable_arc_fitting" enabled by default in some recent OrcaSlicer release.

This PR helps to reduce TTC errors mentioned above significantly, by disabling it by default. It is too rewource heavy for that, i repeat it again, potato MCU, and thus help save the planet.


/bot add-label profile, bug-fix
