### PR TITLE
fix: prevent out-of-bounds crash in Arachne beading interpolation

### DIFF
--- a/src/libslic3r/Arachne/SkeletalTrapezoidation.cpp
+++ b/src/libslic3r/Arachne/SkeletalTrapezoidation.cpp
@@ -1660,7 +1660,7 @@ void SkeletalTrapezoidation::propagateBeadingsDownward(edge_t* edge_to_peak, ptr
 }
 
 
-SkeletalTrapezoidation::Beading SkeletalTrapezoidation::interpolate(const Beading& left, double ratio_left_to_whole, const Beading& right, coord_t switching_radius) const
+SkeletalTrapezoidation::Beading SkeletalTrapezoidation::interpolate(const Beading& left, double ratio_left_to_whole, const Beading& right, coord_t switching_radius)
 {
     assert(ratio_left_to_whole >= 0.0 && ratio_left_to_whole <= 1.0);
     Beading ret = interpolate(left, ratio_left_to_whole, right);
@@ -1684,6 +1684,12 @@ SkeletalTrapezoidation::Beading SkeletalTrapezoidation::interpolate(const Beadin
     { // We cant adjust to fit the next edge because there is no previous one?!
         return ret;
     }
+    // ret follows the thicker of left/right, which can hold fewer insets than left when bead
+    // count and thickness disagree; skip the adjustment rather than index ret past its end.
+    if (next_inset_idx >= coord_t(ret.toolpath_locations.size()))
+    {
+        return ret;
+    }
     assert(next_inset_idx < coord_t(left.toolpath_locations.size()));
     assert(left.toolpath_locations[next_inset_idx] <= switching_radius);
     assert(left.toolpath_locations[next_inset_idx + 1] >= switching_radius);
@@ -1703,7 +1709,7 @@ SkeletalTrapezoidation::Beading SkeletalTrapezoidation::interpolate(const Beadin
 }
 
 
-SkeletalTrapezoidation::Beading SkeletalTrapezoidation::interpolate(const Beading& left, double ratio_left_to_whole, const Beading& right) const
+SkeletalTrapezoidation::Beading SkeletalTrapezoidation::interpolate(const Beading& left, double ratio_left_to_whole, const Beading& right)
 {
     assert(ratio_left_to_whole >= 0.0 && ratio_left_to_whole <= 1.0);
     float ratio_right_to_whole = 1.0 - ratio_left_to_whole;

--- a/src/libslic3r/Arachne/SkeletalTrapezoidation.hpp
+++ b/src/libslic3r/Arachne/SkeletalTrapezoidation.hpp
@@ -488,7 +488,7 @@ protected:
      * beads.
      * \return The beading at the interpolated location.
      */
-    Beading interpolate(const Beading& left, double ratio_left_to_whole, const Beading& right, coord_t switching_radius) const;
+    static Beading interpolate(const Beading& left, double ratio_left_to_whole, const Beading& right, coord_t switching_radius);
 
     /*!
      * Subroutine of \ref interpolate(const Beading&, Ratio, const Beading&, coord_t)
@@ -501,7 +501,7 @@ protected:
      * \param right One of the beadings to interpolate between.
      * \return The beading at the interpolated location.
      */
-    Beading interpolate(const Beading& left, double ratio_left_to_whole, const Beading& right) const;
+    static Beading interpolate(const Beading& left, double ratio_left_to_whole, const Beading& right);
 
     /*!
      * Get the beading at a certain node of the skeletal graph, or create one if

--- a/tests/libslic3r/test_arachne_walls.cpp
+++ b/tests/libslic3r/test_arachne_walls.cpp
@@ -18,6 +18,7 @@
 #include <catch2/catch_all.hpp>
 
 #include "libslic3r/Arachne/WallToolPaths.hpp"
+#include "libslic3r/Arachne/SkeletalTrapezoidation.hpp"
 #include "libslic3r/Arachne/utils/ExtrusionLine.hpp"
 #include "libslic3r/Arachne/BeadingStrategy/BeadingStrategyFactory.hpp"
 #include "libslic3r/Arachne/BeadingStrategy/BeadingStrategy.hpp"
@@ -264,4 +265,47 @@ TEST_CASE("Arachne widening keeps two beads in transition band (#14376)", "[Arac
     // thickness), well above the configured wall widths.
     for (const coord_t w : beading.bead_widths)
         CHECK(w <= inner_width);
+}
+
+namespace {
+// Exposes the protected static interpolate() for a focused unit test.
+struct InterpolateProbe : SkeletalTrapezoidation {
+    using SkeletalTrapezoidation::interpolate;
+};
+} // anonymous namespace
+
+// interpolate() indexes the merged beading with an index derived from `left`. The merged beading
+// follows the thicker of left/right, so when the thicker side has fewer insets the index runs past
+// its end.
+TEST_CASE("Beading interpolation tolerates a thicker side with fewer insets", "[Arachne][Regression]") {
+    using Beading = BeadingStrategy::Beading;
+
+    // Thicker side (right) has fewer insets, so the merged beading holds only 2 toolpath locations.
+    const coord_t w = scaled<coord_t>(0.42);
+    Beading left;
+    left.total_thickness = scaled<coord_t>(1.0);
+    left.bead_widths = { w, w, w, w };
+    left.toolpath_locations = { scaled<coord_t>(0.1), scaled<coord_t>(0.3), scaled<coord_t>(0.5), scaled<coord_t>(0.7) };
+    left.left_over = 0;
+
+    Beading right;
+    right.total_thickness = scaled<coord_t>(2.0);
+    right.bead_widths = { w, w };
+    right.toolpath_locations = { scaled<coord_t>(0.1), scaled<coord_t>(0.3) };
+    right.left_over = 0;
+
+    // Just past left's location [2] (0.5), so the derived index is 2, past the end of the 2-inset merged beading.
+    const coord_t switching_radius = scaled<coord_t>(0.6);
+
+    Beading result;
+    REQUIRE_NOTHROW(result = InterpolateProbe::interpolate(left, 0.5, right, switching_radius));
+
+    // With the guard the adjustment is skipped, so the result is the plain interpolation.
+    const Beading expected = InterpolateProbe::interpolate(left, 0.5, right);
+    REQUIRE(result.toolpath_locations.size() == expected.toolpath_locations.size());
+    REQUIRE(result.bead_widths.size() == expected.bead_widths.size());
+    for (size_t i = 0; i < expected.toolpath_locations.size(); ++i) {
+        CHECK(result.toolpath_locations[i] == expected.toolpath_locations[i]);
+        CHECK(result.bead_widths[i] == expected.bead_widths[i]);
+    }
 }


### PR DESCRIPTION
# Description

Fixes #14584.

`SkeletalTrapezoidation::interpolate()` derives an inset index from `left` but uses it to index the merged beading, which follows whichever of `left`/`right` has the larger `total_thickness`. When the thicker side has fewer insets, the index runs past the end and the slicer crashes during "Generating walls". Only the Arachne wall generator reaches this path, so Classic walls are unaffected.

The fix returns early when the index is out of range, the same as the two guards right above it. `interpolate()` never uses instance state, so it is now `static`, which lets the regression test call it without constructing a graph.

## Reproduction

[orca-crash.3mf](https://github.com/user-attachments/files/29667204/orca-crash.zip) from the issue, sliced with the Arachne wall generator. Reproducing the crash needs a bounds-checked standard library, such as a build with `_GLIBCXX_ASSERTIONS`. The Flatpak's GNOME runtime enables it, which is how the reporter hit it. A stock release build reads past the array without crashing.

## Tests

Added a regression test that builds the mismatched beadings and calls `interpolate()` directly. Confirmed the reproduction project slices on a bounds-checked Linux build (clang) where it previously crashed, and that it builds and slices on Windows with MSVC.

The test only fails where the standard library bounds-checks `operator[]`, and CI does not currently build the tests with that hardening, so it would not catch a reintroduction of this bug yet. A bounds-checked (`_GLIBCXX_ASSERTIONS`) or ASan test leg would close that gap, most naturally alongside the unit-test workflow in #14443.

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
