### PR TITLE
fix: out-of-bounds read computing tool-ordering max layer height

### DIFF
--- a/src/libslic3r/GCode/ToolOrdering.cpp
+++ b/src/libslic3r/GCode/ToolOrdering.cpp
@@ -138,7 +138,8 @@ static double calc_max_layer_height(const PrintConfig &config, double max_object
 {
     double max_layer_height = std::numeric_limits<double>::max();
     for (size_t i = 0; i < config.nozzle_diameter.values.size(); ++ i) {
-        double mlh = config.max_layer_height.values[i];
+        // max_layer_height may be shorter than the extruder count; get_at() clamps.
+        double mlh = config.max_layer_height.get_at(i);
         if (mlh == 0.)
             mlh = 0.75 * config.nozzle_diameter.values[i];
         max_layer_height = std::min(max_layer_height, mlh);

--- a/tests/fff_print/test_multifilament.cpp
+++ b/tests/fff_print/test_multifilament.cpp
@@ -85,3 +85,21 @@ TEST_CASE("Per-object wall filament override is honored", "[MultiFilament]")
     CHECK(tools_for_role(gcode, "perimeter") == std::set<int>{ 0, 1 });
     CHECK(tools_for_role(gcode, "infill")    == std::set<int>{ 0 }); // infill not overridden: stays on F1
 }
+
+// max_layer_height is left one entry short of the extruder count (a mismatch a profile can
+// ship): calc_max_layer_height() in ToolOrdering indexed it by the extruder count and read
+// past the end. The other per-extruder keys are sized so slicing reaches that code.
+TEST_CASE("Multi-extruder slice stays in bounds with a short max_layer_height", "[MultiFilament]")
+{
+    DynamicPrintConfig config = multifilament_config(2);
+    config.set_deserialize_strict({
+        { "nozzle_diameter",           "0.4,0.4" },
+        { "printer_extruder_id",       "1,2" },
+        { "printer_extruder_variant",  "Direct Drive Standard,Direct Drive Standard" },
+        { "extruder_printable_height", "0,0" },
+        { "max_layer_height",          "0.3" }, // deliberately one entry short
+    });
+    Print print;
+    init_and_process_print({ cube(20) }, print, config);
+    REQUIRE_FALSE(print.objects().front()->layers().empty());
+}

--- a/tests/fff_print/test_multifilament.cpp
+++ b/tests/fff_print/test_multifilament.cpp
@@ -86,9 +86,10 @@ TEST_CASE("Per-object wall filament override is honored", "[MultiFilament]")
     CHECK(tools_for_role(gcode, "infill")    == std::set<int>{ 0 }); // infill not overridden: stays on F1
 }
 
-// max_layer_height is left one entry short of the extruder count (a mismatch a profile can
-// ship): calc_max_layer_height() in ToolOrdering indexed it by the extruder count and read
-// past the end. The other per-extruder keys are sized so slicing reaches that code.
+// max_layer_height can be shorter than the extruder count (normalization sizes it to the
+// filament count under single_extruder_multi_material). calc_max_layer_height() in ToolOrdering
+// indexed it per-nozzle and read past the end. Shortened directly here to isolate that read;
+// the other per-extruder keys stay extruder-length so slicing reaches the code under test.
 TEST_CASE("Multi-extruder slice stays in bounds with a short max_layer_height", "[MultiFilament]")
 {
     DynamicPrintConfig config = multifilament_config(2);


### PR DESCRIPTION
# Description

`calc_max_layer_height()` in `src/libslic3r/GCode/ToolOrdering.cpp` loops over the extruder count (`nozzle_diameter`) but indexes `max_layer_height` with the same counter. If that array is shorter than the extruder count, the read runs past the end.

It is silent on a stock release build and aborts under a bounds-checked standard library (`_GLIBCXX_ASSERTIONS`), which is active in the production Flatpak (GNOME runtime). I hit it while enabling bounds-checked runs of the test suite. CI does not currently build the tests with bounds checks, so it would not catch this today (intended as a follow-up after #14443 merges).

That value only feeds wipe tower and skirt layer spacing, never object geometry. Before this change an out-of-range extruder fed an undefined value into that spacing (or aborted); now `get_at()` falls back to the first entry, matching how `Slicing.cpp` reads the same option.

Normalization sizes `max_layer_height` to the filament count on the default `single_extruder_multi_material` path, since it is registered as a filament option as well as an extruder one, so it can be shorter than the extruder count. `get_at()` clamps the read either way.

# Screenshots/Recordings/Graphs

N/A (no UI changes).

## Tests

Added a regression test in `tests/fff_print/test_multifilament.cpp` that slices a two-extruder printer with a single-entry `max_layer_height`. It aborts at `ToolOrdering.cpp` under a bounds-checked build before the fix and passes after.
