### PR TITLE
Standardize release artifact filenames

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -256,6 +256,9 @@ jobs:
         echo "ver_pure=$ver_pure" >> $GITHUB_ENV
         echo "date=$(date +'%Y%m%d')" >> $GITHUB_ENV
         echo "git_commit_hash=$git_commit_hash" >> $GITHUB_ENV
+        # Standardized arch token for the asset filename (x86_64 -> x86-64); the
+        # flatpak-builder `arch:` input below still uses the real matrix arch.
+        echo "arch_std=${{ matrix.variant.arch == 'x86_64' && 'x86-64' || matrix.variant.arch }}" >> $GITHUB_ENV
       shell: bash
     # Manage flatpak-builder cache externally so PRs restore but never upload
     - name: Restore flatpak-builder cache
@@ -284,7 +287,7 @@ jobs:
       shell: bash
     - uses: flatpak/flatpak-github-actions/flatpak-builder@master
       with:
-        bundle: OrcaSlicer-Linux-flatpak_${{ env.ver }}_${{ matrix.variant.arch }}.flatpak
+        bundle: OrcaSlicer_Linux_Flatpak_${{ env.arch_std }}_${{ env.ver }}.flatpak
         manifest-path: scripts/flatpak/com.orcaslicer.OrcaSlicer.yml
         cache: false
         arch: ${{ matrix.variant.arch }}
@@ -292,15 +295,15 @@ jobs:
     - name: Upload artifacts Flatpak
       uses: actions/upload-artifact@v7
       with:
-        name: OrcaSlicer-Linux-flatpak_${{ env.ver }}_${{ matrix.variant.arch }}.flatpak
-        path: '/__w/OrcaSlicer/OrcaSlicer/OrcaSlicer-Linux-flatpak_${{ env.ver }}_${{ matrix.variant.arch }}.flatpak'
+        name: OrcaSlicer_Linux_Flatpak_${{ env.arch_std }}_${{ env.ver }}.flatpak
+        path: '/__w/OrcaSlicer/OrcaSlicer/OrcaSlicer_Linux_Flatpak_${{ env.arch_std }}_${{ env.ver }}.flatpak'
     - name: Deploy Flatpak to nightly release
       if: github.repository == 'OrcaSlicer/OrcaSlicer' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/belt-printer')
       uses: WebFreak001/deploy-nightly@v3.2.0
       with:
         upload_url: https://uploads.github.com/repos/OrcaSlicer/OrcaSlicer/releases/137995723/assets{?name,label}
         release_id: 137995723
-        asset_path: /__w/OrcaSlicer/OrcaSlicer/OrcaSlicer-Linux-flatpak_${{ env.ver }}_${{ matrix.variant.arch }}.flatpak
-        asset_name: OrcaSlicer-Linux-flatpak_nightly${{ env.nightly_suffix }}_${{ matrix.variant.arch }}.flatpak
+        asset_path: /__w/OrcaSlicer/OrcaSlicer/OrcaSlicer_Linux_Flatpak_${{ env.arch_std }}_${{ env.ver }}.flatpak
+        asset_name: OrcaSlicer_Linux_Flatpak_${{ env.arch_std }}${{ env.nightly_suffix }}_nightly.flatpak
         asset_content_type: application/octet-stream
         max_releases: 1 # optional, if there are more releases than this matching the asset_name, the oldest ones are going to be deleted

--- a/.github/workflows/build_orca.yml
+++ b/.github/workflows/build_orca.yml
@@ -26,8 +26,6 @@ jobs:
       date:
       ver:
       ver_pure:
-      ubuntu-ver: '2404'
-      ubuntu-ver-str: '_Ubuntu2404'
       ORCA_UPDATER_SIG_KEY: ${{ secrets.ORCA_UPDATER_SIG_KEY }}
       # Branches whose builds are published to the nightly release. The
       # belt-printer branch ships alongside main but its assets carry a `_belt`
@@ -87,10 +85,12 @@ jobs:
           echo "ver_pure=$ver_pure" >> $GITHUB_ENV
           echo "date=$(date +'%Y%m%d')" >> $GITHUB_ENV
           echo "git_commit_hash=$git_commit_hash" >> $GITHUB_ENV
-          # Per-arch Linux AppImage naming: amd64 keeps the historical unsuffixed
-          # name (arch_suffix empty). Unused on macOS/Windows.
+          # arch_std is the standardized arch token used in the Linux asset
+          # names (x86-64 / aarch64); unused on macOS.
           if [ '${{ inputs.arch }}' = 'aarch64' ]; then
-            echo "arch_suffix=_aarch64" >> $GITHUB_ENV
+            echo "arch_std=aarch64" >> $GITHUB_ENV
+          else
+            echo "arch_std=x86-64" >> $GITHUB_ENV
           fi
         shell: bash
 
@@ -263,8 +263,8 @@ jobs:
           rm -rf ${{ github.workspace }}/build/universal/OrcaSlicer_dmg/*
           cp -R ${{ github.workspace }}/build/universal/OrcaSlicer/OrcaSlicer.app ${{ github.workspace }}/build/universal/OrcaSlicer_dmg/
           ln -sfn /Applications ${{ github.workspace }}/build/universal/OrcaSlicer_dmg/Applications
-          retry hdiutil create -volname "OrcaSlicer" -srcfolder ${{ github.workspace }}/build/universal/OrcaSlicer_dmg -ov -format UDZO OrcaSlicer_Mac_universal_${{ env.ver }}.dmg
-          codesign --deep --force --verbose --options runtime --timestamp --entitlements "$ENTITLEMENTS" --sign "$CERTIFICATE_ID" OrcaSlicer_Mac_universal_${{ env.ver }}.dmg
+          retry hdiutil create -volname "OrcaSlicer" -srcfolder ${{ github.workspace }}/build/universal/OrcaSlicer_dmg -ov -format UDZO OrcaSlicer_Mac_Universal_${{ env.ver }}.dmg
+          codesign --deep --force --verbose --options runtime --timestamp --entitlements "$ENTITLEMENTS" --sign "$CERTIFICATE_ID" OrcaSlicer_Mac_Universal_${{ env.ver }}.dmg
           
           # Create separate OrcaSlicer_profile_validator DMG if the app exists
           if [ -f "${{ github.workspace }}/build/universal/OrcaSlicer/OrcaSlicer_profile_validator.app/Contents/MacOS/OrcaSlicer_profile_validator" ]; then
@@ -272,18 +272,18 @@ jobs:
             rm -rf ${{ github.workspace }}/build/universal/OrcaSlicer_profile_validator_dmg/*
             cp -R ${{ github.workspace }}/build/universal/OrcaSlicer/OrcaSlicer_profile_validator.app ${{ github.workspace }}/build/universal/OrcaSlicer_profile_validator_dmg/
             ln -sfn /Applications ${{ github.workspace }}/build/universal/OrcaSlicer_profile_validator_dmg/Applications
-            retry hdiutil create -volname "OrcaSlicer Profile Validator" -srcfolder ${{ github.workspace }}/build/universal/OrcaSlicer_profile_validator_dmg -ov -format UDZO OrcaSlicer_profile_validator_Mac_universal_${{ env.ver }}.dmg
-            codesign --deep --force --verbose --options runtime --timestamp --entitlements "$ENTITLEMENTS" --sign "$CERTIFICATE_ID" OrcaSlicer_profile_validator_Mac_universal_${{ env.ver }}.dmg
+            retry hdiutil create -volname "OrcaSlicer Profile Validator" -srcfolder ${{ github.workspace }}/build/universal/OrcaSlicer_profile_validator_dmg -ov -format UDZO OrcaSlicer_Mac_Validator_${{ env.ver }}.dmg
+            codesign --deep --force --verbose --options runtime --timestamp --entitlements "$ENTITLEMENTS" --sign "$CERTIFICATE_ID" OrcaSlicer_Mac_Validator_${{ env.ver }}.dmg
           fi
           
           # Notarize main DMG
-          xcrun notarytool submit "OrcaSlicer_Mac_universal_${{ env.ver }}.dmg" --apple-id "${{ secrets.APPLE_DEV_ACCOUNT }}" --team-id "${{ secrets.TEAM_ID }}" --password "${{ secrets.APP_PWD }}" --wait
-          xcrun stapler staple OrcaSlicer_Mac_universal_${{ env.ver }}.dmg
+          xcrun notarytool submit "OrcaSlicer_Mac_Universal_${{ env.ver }}.dmg" --apple-id "${{ secrets.APPLE_DEV_ACCOUNT }}" --team-id "${{ secrets.TEAM_ID }}" --password "${{ secrets.APP_PWD }}" --wait
+          xcrun stapler staple OrcaSlicer_Mac_Universal_${{ env.ver }}.dmg
 
           # Notarize profile validator DMG if it exists
-          if [ -f "OrcaSlicer_profile_validator_Mac_universal_${{ env.ver }}.dmg" ]; then
-            xcrun notarytool submit "OrcaSlicer_profile_validator_Mac_universal_${{ env.ver }}.dmg" --apple-id "${{ secrets.APPLE_DEV_ACCOUNT }}" --team-id "${{ secrets.TEAM_ID }}" --password "${{ secrets.APP_PWD }}" --wait
-            xcrun stapler staple OrcaSlicer_profile_validator_Mac_universal_${{ env.ver }}.dmg
+          if [ -f "OrcaSlicer_Mac_Validator_${{ env.ver }}.dmg" ]; then
+            xcrun notarytool submit "OrcaSlicer_Mac_Validator_${{ env.ver }}.dmg" --apple-id "${{ secrets.APPLE_DEV_ACCOUNT }}" --team-id "${{ secrets.TEAM_ID }}" --password "${{ secrets.APP_PWD }}" --wait
+            xcrun stapler staple OrcaSlicer_Mac_Validator_${{ env.ver }}.dmg
           fi
 
       - name: Create DMG without notary
@@ -296,7 +296,7 @@ jobs:
           rm -rf ${{ github.workspace }}/build/universal/OrcaSlicer_dmg/*
           cp -R ${{ github.workspace }}/build/universal/OrcaSlicer/OrcaSlicer.app ${{ github.workspace }}/build/universal/OrcaSlicer_dmg/
           ln -sfn /Applications ${{ github.workspace }}/build/universal/OrcaSlicer_dmg/Applications
-          retry hdiutil create -volname "OrcaSlicer" -srcfolder ${{ github.workspace }}/build/universal/OrcaSlicer_dmg -ov -format UDZO OrcaSlicer_Mac_universal_${{ env.ver }}.dmg
+          retry hdiutil create -volname "OrcaSlicer" -srcfolder ${{ github.workspace }}/build/universal/OrcaSlicer_dmg -ov -format UDZO OrcaSlicer_Mac_Universal_${{ env.ver }}.dmg
           
           # Create separate OrcaSlicer_profile_validator DMG if the app exists
           if [ -f "${{ github.workspace }}/build/universal/OrcaSlicer/OrcaSlicer_profile_validator.app/Contents/MacOS/OrcaSlicer_profile_validator" ]; then
@@ -304,7 +304,7 @@ jobs:
             rm -rf ${{ github.workspace }}/build/universal/OrcaSlicer_profile_validator_dmg/*
             cp -R ${{ github.workspace }}/build/universal/OrcaSlicer/OrcaSlicer_profile_validator.app ${{ github.workspace }}/build/universal/OrcaSlicer_profile_validator_dmg/
             ln -sfn /Applications ${{ github.workspace }}/build/universal/OrcaSlicer_profile_validator_dmg/Applications
-            retry hdiutil create -volname "OrcaSlicer Profile Validator" -srcfolder ${{ github.workspace }}/build/universal/OrcaSlicer_profile_validator_dmg -ov -format UDZO OrcaSlicer_profile_validator_Mac_universal_${{ env.ver }}.dmg
+            retry hdiutil create -volname "OrcaSlicer Profile Validator" -srcfolder ${{ github.workspace }}/build/universal/OrcaSlicer_profile_validator_dmg -ov -format UDZO OrcaSlicer_Mac_Validator_${{ env.ver }}.dmg
           fi
 
       # Delete the per-arch bundles only after signing/DMG creation succeeded, so a
@@ -321,15 +321,15 @@ jobs:
         if: runner.os == 'macOS' && inputs.macos-combine-only
         uses: actions/upload-artifact@v7
         with:
-          name: OrcaSlicer_Mac_universal_${{ env.ver }}
-          path: ${{ github.workspace }}/OrcaSlicer_Mac_universal_${{ env.ver }}.dmg
+          name: OrcaSlicer_Mac_Universal_${{ env.ver }}
+          path: ${{ github.workspace }}/OrcaSlicer_Mac_Universal_${{ env.ver }}.dmg
 
       - name: Upload OrcaSlicer_profile_validator DMG mac
         if: runner.os == 'macOS' && inputs.macos-combine-only && !vars.SELF_HOSTED
         uses: actions/upload-artifact@v7
         with:
-          name: OrcaSlicer_profile_validator_Mac_universal_DMG_${{ env.ver }}
-          path: ${{ github.workspace }}/OrcaSlicer_profile_validator_Mac_universal_${{ env.ver }}.dmg
+          name: OrcaSlicer_Mac_Validator_${{ env.ver }}
+          path: ${{ github.workspace }}/OrcaSlicer_Mac_Validator_${{ env.ver }}.dmg
           if-no-files-found: ignore
 
       - name: Deploy Mac release
@@ -338,8 +338,8 @@ jobs:
         with:
           upload_url: https://uploads.github.com/repos/OrcaSlicer/OrcaSlicer/releases/137995723/assets{?name,label}
           release_id: 137995723
-          asset_path: ${{ github.workspace }}/OrcaSlicer_Mac_universal_${{ env.ver }}.dmg
-          asset_name: OrcaSlicer_Mac_universal_nightly${{ env.nightly_suffix }}.dmg
+          asset_path: ${{ github.workspace }}/OrcaSlicer_Mac_Universal_${{ env.ver }}.dmg
+          asset_name: OrcaSlicer_Mac_Universal${{ env.nightly_suffix }}_nightly.dmg
           asset_content_type: application/octet-stream
           max_releases: 1 # optional, if there are more releases than this matching the asset_name, the oldest ones are going to be deleted
 
@@ -349,8 +349,8 @@ jobs:
         with:
           upload_url: https://uploads.github.com/repos/OrcaSlicer/OrcaSlicer/releases/137995723/assets{?name,label}
           release_id: 137995723
-          asset_path: ${{ github.workspace }}/OrcaSlicer_profile_validator_Mac_universal_${{ env.ver }}.dmg
-          asset_name: OrcaSlicer_profile_validator_Mac_universal_nightly.dmg
+          asset_path: ${{ github.workspace }}/OrcaSlicer_Mac_Validator_${{ env.ver }}.dmg
+          asset_name: OrcaSlicer_Mac_Validator_nightly.dmg
           asset_content_type: application/octet-stream
           max_releases: 1
 
@@ -359,12 +359,13 @@ jobs:
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
+          # ARCH_STD is the standardized arch token used in the asset names.
           if ("${{ inputs.arch }}" -eq "arm64") {
             "BUILD_DIR=build-arm64"  | Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
-            "ARCH_SUFFIX=_arm64"     | Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
+            "ARCH_STD=arm64"         | Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
           } else {
             "BUILD_DIR=build"        | Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
-            "ARCH_SUFFIX=_x64"       | Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
+            "ARCH_STD=x64"           | Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
           }
 
       - name: setup MSVC
@@ -418,7 +419,7 @@ jobs:
         if: runner.os == 'Windows'
         working-directory: ${{ github.workspace }}/${{ env.BUILD_DIR }}
         shell: cmd
-        run: '"C:/Program Files/7-Zip/7z.exe" a -tzip OrcaSlicer_Windows_${{ env.ver }}${{ env.ARCH_SUFFIX }}_portable.zip ${{ github.workspace }}/${{ env.BUILD_DIR }}/OrcaSlicer'
+        run: '"C:/Program Files/7-Zip/7z.exe" a -tzip OrcaSlicer_Windows_Portable_${{ env.ARCH_STD }}_${{ env.ver }}.zip ${{ github.workspace }}/${{ env.BUILD_DIR }}/OrcaSlicer'
 
       - name: Pack PDB
         if: runner.os == 'Windows' && inputs.arch != 'arm64' && !vars.SELF_HOSTED
@@ -430,14 +431,14 @@ jobs:
         if: runner.os == 'Windows'
         uses: actions/upload-artifact@v7
         with:
-          name: OrcaSlicer_Windows_${{ env.ver }}${{ env.ARCH_SUFFIX }}_portable
+          name: OrcaSlicer_Windows_Portable_${{ env.ARCH_STD }}_${{ env.ver }}
           path: ${{ github.workspace }}/${{ env.BUILD_DIR }}/OrcaSlicer
 
       - name: Upload artifacts Win installer
         if: runner.os == 'Windows' && !vars.SELF_HOSTED
         uses: actions/upload-artifact@v7
         with:
-          name: OrcaSlicer_Windows_${{ env.ver }}${{ env.ARCH_SUFFIX }}
+          name: OrcaSlicer_Windows_Installer_${{ env.ARCH_STD }}_${{ env.ver }}
           path: ${{ github.workspace }}/${{ env.BUILD_DIR }}/OrcaSlicer*.exe
 
       - name: Upload artifacts Win PDB
@@ -451,7 +452,7 @@ jobs:
         if: runner.os == 'Windows' && inputs.arch != 'arm64' && !vars.SELF_HOSTED
         uses: actions/upload-artifact@v7
         with:
-          name: OrcaSlicer_profile_validator_Windows_${{ env.ver }}
+          name: OrcaSlicer_Windows_Validator_${{ env.ver }}
           path: ${{ github.workspace }}/build/src/Release/OrcaSlicer_profile_validator.exe
 
       - name: Deploy Windows release portable
@@ -460,8 +461,8 @@ jobs:
         with:
           upload_url: https://uploads.github.com/repos/OrcaSlicer/OrcaSlicer/releases/137995723/assets{?name,label}
           release_id: 137995723
-          asset_path: ${{ github.workspace }}/${{ env.BUILD_DIR }}/OrcaSlicer_Windows_${{ env.ver }}${{ env.ARCH_SUFFIX }}_portable.zip
-          asset_name: OrcaSlicer_Windows${{ env.ARCH_SUFFIX }}_nightly${{ env.nightly_suffix }}_portable.zip
+          asset_path: ${{ github.workspace }}/${{ env.BUILD_DIR }}/OrcaSlicer_Windows_Portable_${{ env.ARCH_STD }}_${{ env.ver }}.zip
+          asset_name: OrcaSlicer_Windows_Portable_${{ env.ARCH_STD }}${{ env.nightly_suffix }}_nightly.zip
           asset_content_type: application/x-zip-compressed
           max_releases: 1
 
@@ -471,8 +472,8 @@ jobs:
         with:
           upload_url: https://uploads.github.com/repos/OrcaSlicer/OrcaSlicer/releases/137995723/assets{?name,label}
           release_id: 137995723
-          asset_path: ${{ github.workspace }}/${{ env.BUILD_DIR }}/OrcaSlicer_Windows_Installer_${{ env.ver }}${{ env.ARCH_SUFFIX }}.exe
-          asset_name: OrcaSlicer_Windows_Installer${{ env.ARCH_SUFFIX }}_nightly${{ env.nightly_suffix }}.exe
+          asset_path: ${{ github.workspace }}/${{ env.BUILD_DIR }}/OrcaSlicer_Windows_Installer_${{ env.ARCH_STD }}_${{ env.ver }}.exe
+          asset_name: OrcaSlicer_Windows_Installer_${{ env.ARCH_STD }}${{ env.nightly_suffix }}_nightly.exe
           asset_content_type: application/x-msdownload
           max_releases: 1
 
@@ -483,7 +484,7 @@ jobs:
           upload_url: https://uploads.github.com/repos/OrcaSlicer/OrcaSlicer/releases/137995723/assets{?name,label}
           release_id: 137995723
           asset_path: ${{ github.workspace }}/build/src/Release/OrcaSlicer_profile_validator.exe
-          asset_name: OrcaSlicer_profile_validator_Windows_nightly.exe
+          asset_name: OrcaSlicer_Windows_Validator_nightly.exe
           asset_content_type: application/x-msdownload
           max_releases: 1
 
@@ -494,7 +495,7 @@ jobs:
         run: |
           ./scripts/msix/build_msix.ps1 `
             -InstallDir "${{ github.workspace }}/${{ env.BUILD_DIR }}/OrcaSlicer" `
-            -OutputPath "${{ github.workspace }}/${{ env.BUILD_DIR }}/OrcaSlicer_Windows_MSIX_${{ env.ver }}${{ env.ARCH_SUFFIX }}.msix" `
+            -OutputPath "${{ github.workspace }}/${{ env.BUILD_DIR }}/OrcaSlicer_Windows_MSIX_${{ env.ARCH_STD }}_${{ env.ver }}.msix" `
             -Architecture "${{ inputs.arch }}" `
             -IdentityName "${{ vars.ORCA_MSIX_IDENTITY_NAME || 'OrcaSlicer.OrcaSlicer' }}" `
             -Publisher "${{ vars.ORCA_MSIX_PUBLISHER || 'CN=38F7EA55-C73B-4072-B3B2-C8E0EA15BB82' }}" `
@@ -504,8 +505,8 @@ jobs:
         if: runner.os == 'Windows' && !vars.SELF_HOSTED
         uses: actions/upload-artifact@v7
         with:
-          name: OrcaSlicer_Windows_MSIX_${{ env.ver }}${{ env.ARCH_SUFFIX }}
-          path: ${{ github.workspace }}/${{ env.BUILD_DIR }}/OrcaSlicer_Windows_MSIX_${{ env.ver }}${{ env.ARCH_SUFFIX }}.msix
+          name: OrcaSlicer_Windows_MSIX_${{ env.ARCH_STD }}_${{ env.ver }}
+          path: ${{ github.workspace }}/${{ env.BUILD_DIR }}/OrcaSlicer_Windows_MSIX_${{ env.ARCH_STD }}_${{ env.ver }}.msix
 
 # Ubuntu
       - name: Apt-Install Dependencies
@@ -522,7 +523,7 @@ jobs:
           # (x86_64 + aarch64) gets tested by its own unit_tests_linux_* job.
           ./build_linux.sh -istrlL
           ./scripts/check_appimage_libs.sh ./build/package ./build/package/bin/orca-slicer
-          appimage=./build/OrcaSlicer_Linux_AppImage${{ env.ubuntu-ver-str }}${{ env.arch_suffix }}_${{ env.ver }}.AppImage
+          appimage=./build/OrcaSlicer_Linux_AppImage_${{ env.arch_std }}_${{ env.ver }}.AppImage
           mv -n ./build/OrcaSlicer_Linux_V${{ env.ver_pure }}.AppImage "$appimage"
           chmod +x "$appimage"
           tar -cvf build_tests.tar build/tests
@@ -576,14 +577,14 @@ jobs:
         if: ${{ ! env.ACT && runner.os == 'Linux' }}
         uses: actions/upload-artifact@v7
         with:
-          name: OrcaSlicer_Linux_ubuntu_${{ env.ubuntu-ver }}${{ env.arch_suffix }}_${{ env.ver }}
-          path: "./build/OrcaSlicer_Linux_AppImage${{ env.ubuntu-ver-str }}${{ env.arch_suffix }}_${{ env.ver }}.AppImage"
+          name: OrcaSlicer_Linux_AppImage_${{ env.arch_std }}_${{ env.ver }}
+          path: "./build/OrcaSlicer_Linux_AppImage_${{ env.arch_std }}_${{ env.ver }}.AppImage"
 
       - name: Upload OrcaSlicer_profile_validator Ubuntu
         if: ${{ ! env.ACT && runner.os == 'Linux' && !vars.SELF_HOSTED && inputs.arch != 'aarch64' }}
         uses: actions/upload-artifact@v7
         with:
-          name: OrcaSlicer_profile_validator_Linux_ubuntu_${{ env.ubuntu-ver }}_${{ env.ver }}
+          name: OrcaSlicer_Linux_Validator_${{ env.ver }}
           path: './build/src/Release/OrcaSlicer_profile_validator'
 
       - name: Deploy Ubuntu release
@@ -592,8 +593,8 @@ jobs:
         with:
           upload_url: https://uploads.github.com/repos/OrcaSlicer/OrcaSlicer/releases/137995723/assets{?name,label}
           release_id: 137995723
-          asset_path: ./build/OrcaSlicer_Linux_AppImage${{ env.ubuntu-ver-str }}${{ env.arch_suffix }}_${{ env.ver }}.AppImage
-          asset_name: OrcaSlicer_Linux_AppImage${{ env.ubuntu-ver-str }}${{ env.arch_suffix }}_nightly${{ env.nightly_suffix }}.AppImage
+          asset_path: ./build/OrcaSlicer_Linux_AppImage_${{ env.arch_std }}_${{ env.ver }}.AppImage
+          asset_name: OrcaSlicer_Linux_AppImage_${{ env.arch_std }}${{ env.nightly_suffix }}_nightly.AppImage
           asset_content_type: application/octet-stream
           max_releases: 1 # optional, if there are more releases than this matching the asset_name, the oldest ones are going to be deleted
       - name: Deploy Ubuntu release
@@ -612,7 +613,7 @@ jobs:
           upload_url: https://uploads.github.com/repos/OrcaSlicer/OrcaSlicer/releases/137995723/assets{?name,label}
           release_id: 137995723
           asset_path: ./build/src/Release/OrcaSlicer_profile_validator
-          asset_name: OrcaSlicer_profile_validator_Linux${{ env.ubuntu-ver-str }}_nightly
+          asset_name: OrcaSlicer_Linux_Validator_nightly
           asset_content_type: application/octet-stream
           max_releases: 1
 

--- a/.github/workflows/check_profiles.yml
+++ b/.github/workflows/check_profiles.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Download
         working-directory: ${{ github.workspace }}
         run: |
-          curl -L -o OrcaSlicer_profile_validator https://github.com/OrcaSlicer/OrcaSlicer/releases/download/nightly-builds/OrcaSlicer_profile_validator_Linux_Ubuntu2404_nightly
+          curl -L -o OrcaSlicer_profile_validator https://github.com/OrcaSlicer/OrcaSlicer/releases/download/nightly-builds/OrcaSlicer_Linux_Validator_nightly
           chmod +x ./OrcaSlicer_profile_validator
 
       # Validate all system profiles.

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -73,12 +73,14 @@ jobs:
 
       - name: Download release artifacts from build run
         run: |
-          # Windows_V* (not Windows_*) keeps the MSIX Store artifact out: it goes to Partner Center, not GitHub releases.
+          # Explicit Installer_/Portable_ prefixes keep the MSIX Store artifact
+          # (OrcaSlicer_Windows_MSIX_*) out: it goes to Partner Center, not GitHub releases.
           gh run download "$RUN_ID" --repo "$GITHUB_REPOSITORY" --dir artifacts \
-            -p 'OrcaSlicer_Windows_V*' \
-            -p 'OrcaSlicer_Mac_universal_*' \
-            -p 'OrcaSlicer_Linux_ubuntu_*' \
-            -p 'OrcaSlicer-Linux-flatpak_*' \
+            -p 'OrcaSlicer_Windows_Installer_*' \
+            -p 'OrcaSlicer_Windows_Portable_*' \
+            -p 'OrcaSlicer_Mac_Universal_*' \
+            -p 'OrcaSlicer_Linux_AppImage_*' \
+            -p 'OrcaSlicer_Linux_Flatpak_*' \
             -p 'PDB'
           echo "Downloaded artifact folders:"
           ls -1 artifacts
@@ -92,13 +94,14 @@ jobs:
           # binaries are already unzipped. Copy the inner binary for each platform.
           # -type f is required (some artifact *folders* are named "*.flatpak").
 
-          # Windows installers (x64 + arm64): the .exe inside each installer
-          # artifact, NOT the orca-slicer.exe in the portable app folder. CPack
-          # now bakes the arch into the filename (…_x64.exe / …_arm64.exe), so
-          # copy them straight through.
-          find artifacts -type f -name '*.exe' -path '*OrcaSlicer_Windows_V*' ! -path '*_portable*' -exec cp -v {} upload/ \;
+          # Windows installers (x64 + arm64): the .exe inside each Installer_
+          # artifact. CPack bakes the arch and version into the filename
+          # (…_Installer_x64_V*.exe / …_Installer_arm64_V*.exe), so copy them
+          # straight through. The distinct Portable_ prefix keeps portable app
+          # exes out on its own.
+          find artifacts -type f -name '*.exe' -path '*OrcaSlicer_Windows_Installer_*' -exec cp -v {} upload/ \;
           # macOS universal DMG (profile-validator DMG isn't downloaded).
-          find artifacts -type f -name '*.dmg' -path '*OrcaSlicer_Mac_universal_*' -exec cp -v {} upload/ \;
+          find artifacts -type f -name '*.dmg' -path '*OrcaSlicer_Mac_Universal_*' -exec cp -v {} upload/ \;
           # Linux AppImage.
           find artifacts -type f -name '*.AppImage' -exec cp -v {} upload/ \;
           # Flatpak bundles (x86_64 + aarch64).
@@ -108,7 +111,7 @@ jobs:
 
           # Portable Windows builds (x64 + arm64) are unzipped folder artifacts;
           # re-zip each to its released filename (these stay .zip on the release).
-          mapfile -t portable_dirs < <(find artifacts -maxdepth 1 -type d -name 'OrcaSlicer_Windows_*_portable')
+          mapfile -t portable_dirs < <(find artifacts -maxdepth 1 -type d -name 'OrcaSlicer_Windows_Portable_*')
           if [ ${#portable_dirs[@]} -eq 0 ]; then
             echo "::warning::Windows portable artifact not found."
           fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1151,10 +1151,11 @@ set (CPACK_PACKAGE_VENDOR "SoftFever")
 set (CPACK_PACKAGE_VERSION_MAJOR "${ORCA_VERSION_MAJOR}")
 set (CPACK_PACKAGE_VERSION_MINOR "${ORCA_VERSION_MINOR}")
 set (CPACK_PACKAGE_VERSION_PATCH "${ORCA_VERSION_PATCH}")
-set (CPACK_PACKAGE_FILE_NAME "OrcaSlicer_Windows_Installer_V${SoftFever_VERSION}")
-# Suffix the Windows installer with its target arch so the x64 and arm64 builds
-# produce distinct filenames (matches ARCH_SUFFIX in build_orca.yml). Same
-# CMAKE_SYSTEM_PROCESSOR mapping used by orcaslicer_copy_dlls() above.
+set (CPACK_PACKAGE_FILE_NAME "OrcaSlicer_Windows_Installer")
+# Standardized asset naming: OrcaSlicer_Windows_Installer_<arch>_<version>. The
+# arch goes before the version so x64 and arm64 builds produce distinct filenames
+# and match the ARCH_STD token in build_orca.yml. Same CMAKE_SYSTEM_PROCESSOR
+# mapping used by orcaslicer_copy_dlls() above.
 if (WIN32)
     if (CMAKE_SYSTEM_PROCESSOR STREQUAL "ARM64")
         string (APPEND CPACK_PACKAGE_FILE_NAME "_arm64")
@@ -1162,6 +1163,7 @@ if (WIN32)
         string (APPEND CPACK_PACKAGE_FILE_NAME "_x64")
     endif ()
 endif ()
+string (APPEND CPACK_PACKAGE_FILE_NAME "_V${SoftFever_VERSION}")
 set (CPACK_PACKAGE_DESCRIPTION_SUMMARY "Orca Slicer is an open source slicer for FDM printers")
 set (CPACK_PACKAGE_HOMEPAGE_URL "https://github.com/OrcaSlicer/OrcaSlicer")
 set (CPACK_PACKAGE_INSTALL_DIRECTORY ${CPACK_PACKAGE_NAME})

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ It can also be installed through graphical software managers (KDE Discover, GNOM
 
 ### AppImage
 
-AppImages are published for both **x86_64** and **aarch64** (ARM64). Pick the file matching your CPU — the ARM64 build has `aarch64` in its name (e.g. `OrcaSlicer_Linux_AppImage_Ubuntu2404_aarch64_*.AppImage`).
+AppImages are published for both **x86_64** and **aarch64** (ARM64). Pick the file matching your CPU — the ARM64 build has `aarch64` in its name (e.g. `OrcaSlicer_Linux_AppImage_aarch64_*.AppImage`).
 
  1. Download App image from the [releases page](https://github.com/OrcaSlicer/OrcaSlicer/releases).
  2. Double click the downloaded file to run it.

--- a/build_flatpak.sh
+++ b/build_flatpak.sh
@@ -265,7 +265,10 @@ echo -e "${YELLOW}Building Flatpak package...${NC}"
 echo -e "This may take a while (30+ minutes depending on your system)..."
 echo ""
 
-BUNDLE_NAME="OrcaSlicer-Linux-flatpak_${VER}_${ARCH}.flatpak"
+# Standardized asset naming: OrcaSlicer_Linux_Flatpak_<arch>_<version>.flatpak
+# (x86_64 -> x86-64 to match the CI asset names).
+ARCH_STD="${ARCH/x86_64/x86-64}"
+BUNDLE_NAME="OrcaSlicer_Linux_Flatpak_${ARCH_STD}_${VER}.flatpak"
 
 # Remove any existing bundle
 rm -f "$BUNDLE_NAME"

--- a/scripts/build_flatpak_with_docker.sh
+++ b/scripts/build_flatpak_with_docker.sh
@@ -84,7 +84,10 @@ if [ -z "$VER_PURE" ]; then
 fi
 VER="V${VER_PURE}"
 GIT_COMMIT_HASH=$(git rev-parse HEAD)
-BUNDLE_NAME="OrcaSlicer-Linux-flatpak_${VER}_${ARCH}.flatpak"
+# Standardized asset naming: OrcaSlicer_Linux_Flatpak_<arch>_<version>.flatpak
+# (x86_64 -> x86-64 to match the CI asset names).
+ARCH_STD="${ARCH/x86_64/x86-64}"
+BUNDLE_NAME="OrcaSlicer_Linux_Flatpak_${ARCH_STD}_${VER}.flatpak"
 
 echo "=== OrcaSlicer Flatpak Build ==="
 echo "  Version:    ${VER} (${VER_PURE})"


### PR DESCRIPTION
Unify release asset naming across CI and build scripts. Introduces a standardized arch token (x86-64 / aarch64 / x64 / arm64) and updates workflow, publish, flatpak and build scripts to use the new patterns. 

| Position | Field | Possible values | Omitted when |
|:---:|:---:|:---:|:---:|
| 1 | Prefix | OrcaSlicer | never |
| 2 | OS | Linux · Mac · Windows | never |
| 3 | Type | Flatpak · AppImage · Universal · Installer · Portable · Validator · MSIX | never |
| 4 | Arch | x86-64 · aarch64 (Linux) · x64 · arm64 (Windows) | Mac (Universal is arch-agnostic); all Validators |
| 5 | Variation | belt, others (futureproofing) | normal builds |
| 6 | Version | nightly · V<x.y.z> (release, e.g. V2.4.0) · PR-<n> (CI) | never |
| — | ext | .flatpak · .AppImage · .dmg · .exe · .zip · .msix · (none for the Linux validator binary) | — |

Changes include: standardized Flatpak/AppImage/DMG/MSIX/Windows installer and portable names, Mac DMG and validator DMG renames, CPack package filename updated to include arch before version, README AppImage example updated, and related publish/download logic adjusted.

This makes asset names consistent across platforms and simplifies release automation.

> [!IMPORTANT]
> The `Profile Validation` Errors will be present until merge.
> After merge and first build this should work fine.