### PR TITLE
Fix "Label object id error!" when a per-feature filament prints nothing

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -5288,7 +5288,8 @@ LayerResult GCode::process_layer(
         if (print.config().print_sequence == PrintSequence::ByLayer && m_enable_exclude_object && print.config().support_object_skip_flush.value) {
             std::vector<size_t> filament_instances_id;
             for (InstanceToPrint &instance : filament_to_print_instances[extruder_id]) filament_instances_id.emplace_back(instance.label_object_id);
-            m_filament_instances_code = _encode_label_ids_to_base64(filament_instances_id);
+            // Orca: tool ordering may schedule a filament with no object instance on this layer, emit no skip-flush object list for it instead of failing the export.
+            m_filament_instances_code = filament_instances_id.empty() ? std::string() : _encode_label_ids_to_base64(filament_instances_id);
         }
 
         std::string gcode_toolchange;

--- a/src/libslic3r/GCode/ToolOrdering.cpp
+++ b/src/libslic3r/GCode/ToolOrdering.cpp
@@ -111,7 +111,11 @@ unsigned int LayerTools::extruder(const ExtrusionEntityCollection &extrusions, c
     if (this->extruder_override == 0) {
         if (extrusions.has_infill()) {
             if (extrusions.has_solid_infill()) {
-                ExtrusionRole role = extrusions.role();
+                // Classify ignoring gap fill: Fill::_create_gap_fill() appends erGapFill entities into the surface's own collection, which would turn role() into erMixed and misroute e.g. a top surface to the internal solid filament.
+                ExtrusionRole role = erNone;
+                for (const ExtrusionEntity *ee : extrusions.entities)
+                    if (ExtrusionRole er = ee->role(); er != erGapFill)
+                        role = (role == erNone || role == er) ? er : erMixed;
                 if (role == erTopSolidInfill || role == erIroning)
                     extruder = region.config().top_surface_filament_id;
                 else if (role == erBottomSurface)
@@ -697,7 +701,19 @@ void ToolOrdering::collect_extruders(const PrintObject &object, const std::vecto
 
                 if (something_nonoverriddable){
                		layer_tools.extruders.emplace_back((extruder_override == 0) ? region.config().outer_wall_filament_id.value : extruder_override);
-                    if (extruder_override == 0 && region.config().wall_loops.value > 1)
+                    // Schedule the inner wall filament only when an inner wall actually exists: narrow regions may fit a single loop no matter the wall_loops setting (see GCode::process_layer split_mixed_perimeters for the matching assignment).
+                    bool has_inner_wall = false;
+                    for (const ExtrusionEntity *eec : layerm->perimeters.entities) {
+                        const auto *island = dynamic_cast<const ExtrusionEntityCollection*>(eec);
+                        for (const ExtrusionEntity *ee : island->entities)
+                            if (is_internal_perimeter(ee->role())) {
+                                has_inner_wall = true;
+                                break;
+                            }
+                        if (has_inner_wall)
+                            break;
+                    }
+                    if (extruder_override == 0 && has_inner_wall)
                         layer_tools.extruders.emplace_back(region.config().inner_wall_filament_id.value);
                     if (layerCount == 0) {
                         firstLayerExtruders.emplace_back((extruder_override == 0) ? region.config().outer_wall_filament_id.value : extruder_override);
@@ -711,6 +727,7 @@ void ToolOrdering::collect_extruders(const PrintObject &object, const std::vecto
             bool has_internal_solid     = false;
             bool has_top_solid_surface  = false;
             bool has_bottom_surface     = false;
+            bool has_gap_fill           = false;
             bool something_nonoverriddable = false;
             for (const ExtrusionEntity *ee : layerm->fills.entities) {
                 // fill represents infill extrusions of a single island.
@@ -722,6 +739,9 @@ void ToolOrdering::collect_extruders(const PrintObject &object, const std::vecto
                     has_bottom_surface = true;
                 else if (is_solid_infill(role))
                     has_internal_solid = true;
+                else if (role == erGapFill)
+                    // Gap fill is printed with the wall filament (see LayerTools::extruder()), so it must not schedule the sparse infill filament.
+                    has_gap_fill = true;
                 else if (role != erNone)
                     has_infill = true;
 
@@ -741,10 +761,12 @@ void ToolOrdering::collect_extruders(const PrintObject &object, const std::vecto
                         layer_tools.extruders.emplace_back(region.config().bottom_surface_filament_id);
 	                if (has_infill)
 	                    layer_tools.extruders.emplace_back(region.config().sparse_infill_filament_id);
-                } else if (has_internal_solid || has_top_solid_surface || has_bottom_surface || has_infill)
+                    if (has_gap_fill)
+                        layer_tools.extruders.emplace_back(region.config().outer_wall_filament_id);
+                } else if (has_internal_solid || has_top_solid_surface || has_bottom_surface || has_infill || has_gap_fill)
             		layer_tools.extruders.emplace_back(extruder_override);
             }
-            if (has_internal_solid || has_top_solid_surface || has_bottom_surface || has_infill)
+            if (has_internal_solid || has_top_solid_surface || has_bottom_surface || has_infill || has_gap_fill)
                 layer_tools.has_object = true;
         }
         layerCount++;

--- a/src/libslic3r/GCode/ToolOrdering.cpp
+++ b/src/libslic3r/GCode/ToolOrdering.cpp
@@ -728,11 +728,15 @@ void ToolOrdering::collect_extruders(const PrintObject &object, const std::vecto
             bool has_top_solid_surface  = false;
             bool has_bottom_surface     = false;
             bool has_gap_fill           = false;
+            // Any fill extrusion regardless of role. Drives has_object and override scheduling, which care about existence, not about which filament the role maps to.
+            bool has_fills              = false;
             bool something_nonoverriddable = false;
             for (const ExtrusionEntity *ee : layerm->fills.entities) {
                 // fill represents infill extrusions of a single island.
                 const auto *fill = dynamic_cast<const ExtrusionEntityCollection*>(ee);
                 ExtrusionRole role = fill->entities.empty() ? erNone : fill->entities.front()->role();
+                if (role != erNone)
+                    has_fills = true;
                 if (role == erTopSolidInfill || role == erIroning)
                     has_top_solid_surface = true;
                 else if (role == erBottomSurface)
@@ -763,10 +767,10 @@ void ToolOrdering::collect_extruders(const PrintObject &object, const std::vecto
 	                    layer_tools.extruders.emplace_back(region.config().sparse_infill_filament_id);
                     if (has_gap_fill)
                         layer_tools.extruders.emplace_back(region.config().outer_wall_filament_id);
-                } else if (has_internal_solid || has_top_solid_surface || has_bottom_surface || has_infill || has_gap_fill)
+                } else if (has_fills)
             		layer_tools.extruders.emplace_back(extruder_override);
             }
-            if (has_internal_solid || has_top_solid_surface || has_bottom_surface || has_infill || has_gap_fill)
+            if (has_fills)
                 layer_tools.has_object = true;
         }
         layerCount++;

--- a/tests/fff_print/test_helpers.cpp
+++ b/tests/fff_print/test_helpers.cpp
@@ -7,7 +7,9 @@
 #include "libslic3r/Format/OBJ.hpp"
 #include "libslic3r/Format/STL.hpp"
 
+#include <cctype>
 #include <cstdlib>
+#include <map>
 #include <string>
 
 #include <boost/filesystem.hpp>
@@ -408,6 +410,39 @@ std::set<double> layers_with_role(const std::string &gcode, const std::string &r
             layers.insert(self.z());
     });
     return layers;
+}
+
+std::map<std::string, std::set<int>> tools_by_feature(const std::string &gcode)
+{
+    std::map<std::string, std::set<int>> features;
+    int current_tool = 0;
+    std::string current_feature;
+    GCodeReader parser;
+    parser.parse_buffer(gcode, [&](GCodeReader &self, const GCodeReader::GCodeLine &line) {
+        const std::string cmd(line.cmd());
+        const std::string comment(line.comment());
+        if (cmd.size() >= 2 && cmd[0] == 'T' && std::isdigit((unsigned char)cmd[1]))
+            current_tool = std::stoi(cmd.substr(1));
+        else if (const std::string bbl_tag = " FEATURE: "; comment.rfind(bbl_tag, 0) == 0)
+            current_feature = comment.substr(bbl_tag.size());
+        else if (const std::string tag = "TYPE:"; comment.rfind(tag, 0) == 0)
+            current_feature = comment.substr(tag.size());
+        else if (line.extruding(self) && line.dist_XY(self) > 0 && !current_feature.empty())
+            features[current_feature].insert(current_tool);
+    });
+    return features;
+}
+
+std::set<int> selected_tools(const std::string &gcode)
+{
+    std::set<int> tools{ 0 };
+    GCodeReader parser;
+    parser.parse_buffer(gcode, [&](GCodeReader &, const GCodeReader::GCodeLine &line) {
+        const std::string cmd(line.cmd());
+        if (cmd.size() >= 2 && cmd[0] == 'T' && std::isdigit((unsigned char)cmd[1]))
+            tools.insert(std::stoi(cmd.substr(1)));
+    });
+    return tools;
 }
 
 double max_z(const std::string &gcode)

--- a/tests/fff_print/test_helpers.hpp
+++ b/tests/fff_print/test_helpers.hpp
@@ -8,6 +8,7 @@
 #include "libslic3r/Print.hpp"
 #include "libslic3r/TriangleMesh.hpp"
 
+#include <map>
 #include <set>
 #include <string>
 #include <unordered_map>
@@ -119,6 +120,12 @@ int role_passes(const std::string &gcode, const std::string &role);
 
 // The `roles` in the order their extrusion blocks first appear, consecutive repeats collapsed.
 std::vector<std::string> role_sequence(const std::string &gcode, const std::vector<std::string> &roles);
+
+// 0-based tool indices extruding within each role-tag block ("; FEATURE: <name>" or ";TYPE:<name>"), keyed by feature name.
+std::map<std::string, std::set<int>> tools_by_feature(const std::string &gcode);
+
+// All 0-based tools ever selected by a T command (the initial implicit tool 0 included).
+std::set<int> selected_tools(const std::string &gcode);
 
 } } // namespace Slic3r::Test
 

--- a/tests/fff_print/test_multifilament.cpp
+++ b/tests/fff_print/test_multifilament.cpp
@@ -11,6 +11,10 @@
 using namespace Slic3r;
 using namespace Slic3r::Test;
 
+// A 1mm-thick upright plate: one wall loop per side plus a gap too narrow for any
+// infill, so layers have gap fill (classic wall generator) and no sparse infill.
+static TriangleMesh thin_plate() { return make_cube(20.0, 1.0, 5.0); }
+
 // 0-based tool indices used by extrusions whose role comment contains `role` (needs gcode_comments).
 static std::set<int> tools_for_role(const std::string& gcode, const std::string& role)
 {
@@ -68,6 +72,147 @@ TEST_CASE("Each feature prints with its assigned filament (three filaments)", "[
         }));
     CHECK(tools_for_role(gcode, "perimeter") == std::set<int>{ 2 }); // filament 3
     CHECK(tools_for_role(gcode, "infill")    == std::set<int>{ 1 }); // filament 2
+}
+
+// Tool ordering may schedule a filament that ends up printing nothing on a layer
+// (gap fill is classified as sparse infill when scheduling). The object-skip flush
+// encoder must tolerate that instead of aborting the export with
+// "Label object id error!".
+TEST_CASE("Object-skip flush encoding survives a scheduled filament that prints nothing", "[MultiFilament][Regression]")
+{
+    Print print;
+    Model model;
+    init_print({ thin_plate() }, print, model,
+        multifilament_config(2, {
+            { "wall_generator",            "classic" },
+            { "wall_loops",                1 },
+            { "sparse_infill_filament_id", 2 },
+            { "skirt_loops",               0 },
+            { "brim_type",                 "no_brim" },
+            { "support_object_skip_flush", 1 },
+        }));
+    print.is_BBL_printer() = true;
+    std::string out;
+    REQUIRE_NOTHROW(out = Test::gcode(print));
+    REQUIRE(tools_by_feature(out).count("Gap infill") == 1); // geometry must exercise gap fill
+}
+
+// Gap fill is printed with the wall filament, so scheduling must not bring in the
+// sparse-infill filament (a pointless filament change) on layers without sparse infill.
+TEST_CASE("Gap fill does not activate the sparse infill filament", "[MultiFilament][Regression]")
+{
+    const std::string gcode = slice({ thin_plate() },
+        multifilament_config(2, {
+            { "wall_generator",            "classic" },
+            { "wall_loops",                1 },
+            { "sparse_infill_filament_id", 2 },
+            { "skirt_loops",               0 },
+            { "brim_type",                 "no_brim" },
+        }));
+    const auto features = tools_by_feature(gcode);
+    REQUIRE(features.count("Gap infill") == 1);    // geometry must exercise gap fill
+    REQUIRE(features.count("Sparse infill") == 0); // and produce no true sparse infill
+    CHECK(features.at("Gap infill") == std::set<int>{ 0 });
+    CHECK(selected_tools(gcode) == std::set<int>{ 0 }); // filament 2 never activated
+}
+
+// Redirecting a single feature to filament 2 must route exactly that feature's
+// extrusions to tool 1, and every filament the print activates must extrude something.
+// Concentric top/bottom surfaces leave gaps, so their fill collections also contain
+// gap fill; classification of those mixed collections must agree between scheduling
+// (ToolOrdering::collect_extruders) and assignment (LayerTools::extruder()).
+TEST_CASE("A feature filament override routes only that feature and never activates an idle filament", "[MultiFilament][Regression]")
+{
+    const char* generator = GENERATE("classic", "arachne");
+    auto [key, feature] = GENERATE(table<const char*, const char*>({
+        { "sparse_infill_filament_id",  "Sparse infill" },
+        { "internal_solid_filament_id", "Internal solid infill" },
+        { "top_surface_filament_id",    "Top surface" },
+        { "bottom_surface_filament_id", "Bottom surface" },
+        { "outer_wall_filament_id",     "Outer wall" },
+        { "inner_wall_filament_id",     "Inner wall" },
+    }));
+    DYNAMIC_SECTION(generator << " | " << key << " = 2") {
+        const std::string gcode = slice({ TestMesh::cube_with_hole },
+            multifilament_config(2, {
+                { "wall_generator",      generator },
+                { "gap_fill_target",     "everywhere" },
+                { "top_surface_pattern", "concentric" },
+                { "infill_wall_overlap", 0 },
+                { key,                      2 },
+                { "skirt_loops",            0 },
+                { "brim_type",              "no_brim" },
+            }));
+        const auto features = tools_by_feature(gcode);
+        REQUIRE(features.count("Gap infill") == 1); // geometry must exercise gap fill inside solid surfaces
+        REQUIRE(features.count(feature) == 1);      // and must print the redirected feature
+
+        // The redirected feature prints on tool 1.
+        CHECK(features.at(feature) == std::set<int>{ 1 });
+
+        // Every filament the print switches to extrudes something.
+        std::set<int> extruding;
+        for (const auto& [name, tools] : features)
+            extruding.insert(tools.begin(), tools.end());
+        const std::set<int> selected = selected_tools(gcode);
+        CAPTURE(selected, extruding);
+        CHECK(std::includes(extruding.begin(), extruding.end(), selected.begin(), selected.end()));
+    }
+}
+
+// Gap fill generated inside a top surface (gap_fill_target) lands in the same extrusion
+// collection as the surface fill, turning the collection's role into erMixed. Assignment
+// must still follow the top-surface filament, not fall back to the internal-solid one,
+// which would print the top surface with the wrong filament and leave the top-surface
+// filament scheduled with nothing to print.
+TEST_CASE("Top surface filament override survives gap fill inside the top surface", "[MultiFilament][Regression]")
+{
+    const char* generator = GENERATE("classic", "arachne");
+    DYNAMIC_SECTION(generator) {
+        const std::string gcode = slice({ TestMesh::cube_with_hole },
+            multifilament_config(2, {
+                { "wall_generator",             generator },
+                { "gap_fill_target",            "everywhere" },
+                { "top_surface_pattern",        "concentric" },
+                { "infill_wall_overlap",        0 },
+                { "top_surface_filament_id",    2 },
+                { "internal_solid_filament_id", 1 }, // explicit, so it does not inherit the top filament
+                { "skirt_loops",                0 },
+                { "brim_type",                  "no_brim" },
+            }));
+        const auto features = tools_by_feature(gcode);
+        REQUIRE(features.count("Top surface") == 1);
+        CHECK(features.at("Top surface") == std::set<int>{ 1 });
+        CHECK(features.at("Internal solid infill") == std::set<int>{ 0 });
+
+        // Every filament the print switches to extrudes something.
+        std::set<int> extruding;
+        for (const auto& [name, tools] : features)
+            extruding.insert(tools.begin(), tools.end());
+        const std::set<int> selected = selected_tools(gcode);
+        CAPTURE(selected, extruding);
+        CHECK(std::includes(extruding.begin(), extruding.end(), selected.begin(), selected.end()));
+    }
+}
+
+// Scheduling used to request the inner wall filament whenever wall_loops > 1, but on
+// geometry too narrow for a second loop no inner wall is ever printed, activating the
+// filament for nothing (and, on object-skip-flush printers, aborting the export with
+// "Label object id error!" -- reported as issue #14225).
+TEST_CASE("Inner wall filament is not activated when only the outer loop fits", "[MultiFilament][Regression]")
+{
+    const std::string gcode = slice({ thin_plate() },
+        multifilament_config(2, {
+            { "wall_generator",         "classic" },
+            { "wall_loops",             2 },
+            { "inner_wall_filament_id", 2 },
+            { "skirt_loops",            0 },
+            { "brim_type",              "no_brim" },
+        }));
+    const auto features = tools_by_feature(gcode);
+    REQUIRE(features.count("Outer wall") == 1);
+    REQUIRE(features.count("Inner wall") == 0); // the plate only fits the outer loop
+    CHECK(selected_tools(gcode) == std::set<int>{ 0 }); // filament 2 never activated
 }
 
 // The override must survive tool ordering: object 1's walls print on their filament's


### PR DESCRIPTION
# Description

Fixes #14225 (reported there as "Lable object id error!" with different outer/inner wall filaments; incorrectly auto-closed as a duplicate of the unrelated #13444).

Using *Filament for Features* to assign a feature (sparse infill, walls, top/bottom surfaces) to a different filament can make slicing abort at G-code export with **"Label object id error!"** on printers that enable `support_object_skip_flush` (Bambu Lab H2D / H2D Pro / H2S / P2S 0.4-nozzle profiles), whenever the layer's tool schedule includes a filament that ends up printing nothing on that layer.

**Root cause.** Tool scheduling (`ToolOrdering::collect_extruders`) and extrusion assignment (`LayerTools::extruder()`, used by `GCode::process_layer`) disagreed about which filament prints what, in three ways:

1. **Wall gap fill scheduled as sparse infill.** Gap fill from the classic wall generator (`erGapFill`, stored in `LayerRegion::thin_fills` and copied into the layer's `fills` by `Layer::make_fills`) fell into scheduling's catch-all `has_infill` branch, scheduling **`sparse_infill_filament_id`** — while assignment routes those collections to **`outer_wall_filament_id`**.
2. **Solid-surface gap fill turns collections `erMixed`.** With *Apply gap fill* (`gap_fill_target`) enabled, `Fill::_create_gap_fill()` appends `erGapFill` entities into the surface's own extrusion collection. The mixed collection's `role()` becomes `erMixed`, which assignment routed to **`internal_solid_filament_id`** even for top/bottom surfaces — while scheduling used the surface's own filament. With e.g. `top_surface_filament_id = 2` and `internal_solid_filament_id = 1` set explicitly, top surfaces printed with the **wrong filament** and filament 2 was scheduled with nothing to print.
3. **Inner wall scheduled from the `wall_loops` setting, not the geometry** (the #14225 trigger). Scheduling requested `inner_wall_filament_id` whenever `wall_loops > 1`, but narrow regions may only fit the outer loop, so layers with thin features scheduled the inner-wall filament with no inner wall to print. Now it is scheduled only when an inner-wall extrusion actually exists on the layer.

The remaining per-feature ids were audited and are consistent: `internal_solid_filament_id` is the `erMixed` fallback itself, and `outer_wall_filament_id` is scheduled from the same condition assignment uses.

A filament scheduled with nothing to print causes:

- a pointless filament change (and its flush) on every such layer — long-standing, affects all printers and print sequences;
- since ca34800cad ("Object skipping supports skipping flushing of filament change"), the skip-flush encoder calls `_encode_label_ids_to_base64()` with the (empty) list of object instances printed by that filament, hits the `bitset == 0` guard, and aborts the export with `Label object id error!`.

**Fix.**

- `ToolOrdering::collect_extruders`: classify `erGapFill` fills separately and schedule them under `outer_wall_filament_id`, matching assignment; schedule `inner_wall_filament_id` only when the layer region actually contains an inner-wall extrusion.
- `LayerTools::extruder()`: classify solid-infill collections ignoring `erGapFill` entities, so a top/bottom surface with embedded gap fill keeps its own feature filament instead of degrading to `erMixed` → internal solid.
- `GCode::process_layer`: if tool ordering still schedules a filament with no object instances on a layer, emit no skip-flush object list for it instead of throwing (defense in depth; the invariant is not locally enforceable).

**Breaking changes / compatibility.** None: no config, profile, or 3MF format changes. Single-filament prints are unaffected (all per-feature filament ids resolve to the same filament, so every classification lands on the same tool). The `normalize_fdm` fallback propagation between feature ids (e.g. top → internal solid when the latter is unset) is unchanged and covered by the new sweep test.

# Screenshots/Recordings/Graphs

No UI changes. Before/after is observable in exported G-code: previously, layers with gap fill and no sparse infill contained a toolchange to the sparse-infill filament with no extrusions attributed to it (and on H2D-class profiles the export failed outright); with this PR those layers contain no such toolchange, and top/bottom surfaces containing gap fill print with their configured feature filament.

## Tests

Five regression tests added to `tests/fff_print/test_multifilament.cpp` (the file owning `GCode/ToolOrdering.cpp` coverage), written test-first — each watched to fail for its own reason before the corresponding fix:

- **"Object-skip flush encoding survives a scheduled filament that prints nothing"** — reproduced the exact `Label object id error!` throw (BBL printer, `support_object_skip_flush`, thin-plate geometry yielding gap fill and no sparse infill); passes with the encoder fix.
- **"Gap fill does not activate the sparse infill filament"** — pinned the spurious toolchange (`selected_tools == {0, 1}` before the fix); passes with the scheduling fix.
- **"A feature filament override routes only that feature and never activates an idle filament"** — sweeps all six per-feature ids (`sparse_infill`, `internal_solid`, `top_surface`, `bottom_surface`, `outer_wall`, `inner_wall`) × both wall generators (classic and Arachne) over geometry with gap fill in solid surfaces, asserting the redirected feature prints on its filament and that every filament the print activates extrudes something.
- **"Top surface filament override survives gap fill inside the top surface"** — pinned the `erMixed` misrouting (`Top surface == {0}` and an idle filament activation before the fix); passes with the assignment fix. Runs under both wall generators (the `gap_fill_target` path is wall-generator-independent).
- **"Inner wall filament is not activated when only the outer loop fits"** — pinned the #14225 mechanism (`selected_tools == {0, 1}` with no inner wall printed, before the fix); passes with the geometry-based scheduling fix.

Guard assertions verify each fixture really produces gap fill (and, where relevant, no sparse infill), so the tests cannot go vacuously green. Two G-code analysis helpers (`tools_by_feature`, `selected_tools`, parsing the always-emitted `;TYPE:` / `; FEATURE:` role tags) were promoted into the suite harness (`test_helpers.{hpp,cpp}`) per the suite README's reuse rule.

Verification performed:

- Full `fff_print_tests` and `libslic3r_tests` suites pass. (One pre-existing, order-dependent SIGSEGV in `test_skirt_brim.cpp:308` reproduces identically on unmodified `main` with the same rng seed `0xBEEF`; unrelated to this change.)
- End-to-end: a real-world failing project (H2D, two filaments, TPU sparse infill, classic walls) slices successfully with a binary built from this branch; the same project without the sparse-infill override produces G-code as before.
- End-to-end: the project attached to #14225 (H2D Pro, `inner_wall_filament_id` redirected, `wall_loops = 2`) reproduces `Label object id error!` on OrcaSlicer 2.4.2 and slices successfully with this branch; the resulting G-code activates no filament that does not extrude.

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
