### PR TITLE
fix: dangling static lambda crashes support G-code export on repeated slices

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -6215,7 +6215,8 @@ std::string GCode::extrude_support(const ExtrusionEntityCollection &support_fill
     static constexpr const char* support_transition_label = "support transition";
     static constexpr const char* support_ironing_label    = "support ironing";
 
-    static const auto speed_for_path = [&](double length, ExtrusionRole role, double default_speed = -1.0) {
+    // Not static: it captures `this` by reference.
+    const auto speed_for_path = [&](double length, ExtrusionRole role, double default_speed = -1.0) {
         if (!is_support(role) || length > SMALL_PERIMETER_LENGTH(NOZZLE_CONFIG(small_support_perimeter_threshold)))
             return default_speed;
 

--- a/tests/fff_print/test_support_material.cpp
+++ b/tests/fff_print/test_support_material.cpp
@@ -93,3 +93,14 @@ SCENARIO("Support layer Z honors contact distance", "[SupportMaterial]")
         }
     }
 }
+
+// extrude_support once held a `static` lambda capturing `this`, so a second export in the
+// same process dereferenced a returned stack frame (ASan: stack-use-after-return).
+TEST_CASE("Support G-code emission survives a second slice in the same process", "[SupportMaterial][Regression]")
+{
+    const std::string first = slice({ TestMesh::overhang }, { { "enable_support", 1 } });
+    REQUIRE(! layers_with_role(first, "support").empty());
+
+    const std::string second = slice({ TestMesh::overhang }, { { "enable_support", 1 } });
+    REQUIRE(! layers_with_role(second, "support").empty());
+}


### PR DESCRIPTION
# Description

`GCode::extrude_support` declared its per-path speed helper as a `static` local lambda that captures `this` by reference. A `static` local is initialized once, so the closure holds the `this` from the first `extrude_support` call for the rest of the process. The next G-code export builds a new `GCode` on the stack in `Print::export_gcode`, and the old closure now points at a frame that has already returned.

The helper uses `this` for `cur_extruder_index()` and `GCodeWriter::filament()`, so it reads whatever now sits on that stack. If the new export lands on the same stack slot it reads the live object and nothing breaks; otherwise it reads garbage and usually segfaults (in a narrow case it just picks the wrong support speed). AddressSanitizer flags it as a `stack-use-after-return`.

So any second slice of a support print in the same session can crash. This is a plausible source of some random, unreproducible crashes people report in production.

I found it while checking the crash noted in #14671: an order-dependent SIGSEGV at `test_skirt_brim.cpp:308` under `--rng-seed 0xBEEF`.

**Fix:** drop `static` so the lambda is rebuilt each call against the current frame. It's the only `static` capturing lambda in `libslic3r` and there's no state to keep.

# Tests

New `[SupportMaterial][Regression]` test slices a support object twice in one process and checks both emit support G-code. Under AddressSanitizer it fails without the fix (`stack-use-after-return` in `GCodeWriter::filament()`) and passes with it. The full `fff_print` suite also passes in Release at the reported seed, which crashed before.
