### PR TITLE
fix: use bambu's network plugin

### DIFF
--- a/src/slic3r/GUI/MediaFilePanel.cpp
+++ b/src/slic3r/GUI/MediaFilePanel.cpp
@@ -520,7 +520,7 @@ void MediaFilePanel::fetchUrl(boost::weak_ptr<PrinterFileSystem> wfs)
                     fs->SetUrl(res);
                 }
             });
-        });
+        }, wxGetApp().get_printer_cloud_provider());
     }
 }
 


### PR DESCRIPTION
Description
Fixes a regression where Timelapse and SD Card media failed to load on Bambu devices.

During the dual-cloud-agent refactor, NetworkAgent was updated to require an explicit provider argument. The call site in MediaFilePanel::fetchUrl() was missing this argument, causing it to silently fall back to the default Orca stub instead of routing to the Bambu network plugin.

This explicitly passes wxGetApp().get_printer_cloud_provider() to get_camera_url to correctly route the request and restore functionality.