### PR TITLE
fix: restore cursor visibility after touchscreen input on Windows

### DIFF
--- a/src/slic3r/GUI/MainFrame.cpp
+++ b/src/slic3r/GUI/MainFrame.cpp
@@ -900,10 +900,30 @@ WXLRESULT MainFrame::MSWWindowProc(WXUINT nMsg, WXWPARAM wParam, WXLPARAM lParam
         }
         break;
 
+    case WM_MOUSEMOVE: {
+        // Windows hides the cursor when touch input occurs and expects real mouse
+        // hardware movement to restore it. Sometimes restoration fails when the app
+        // handles WM_NCHITTEST or gestures. Detect non-touch mouse movement and
+        // force the cursor visible if Windows has suppressed it.
+        const LONG_PTR MI_WP_SIGNATURE = 0xFF515700;
+        const LONG_PTR SIGNATURE_MASK  = 0xFFFFFF00;
+        if ((::GetMessageExtraInfo() & SIGNATURE_MASK) != MI_WP_SIGNATURE) {
+            CURSORINFO ci = { sizeof(ci) };
+            if (::GetCursorInfo(&ci) && !(ci.flags & CURSOR_SHOWING)) {
+                ::SetCursor(::LoadCursor(nullptr, IDC_ARROW));
+            }
+        }
+        break;
+    }
+
     case WM_NCHITTEST: {
         if (IsMaximized()) {
-            // When maximized, no resize border
-            return HTCAPTION;
+            // When maximized, only treat topbar as caption so WM_SETCURSOR still
+            // reaches the client area (needed for cursor restoration after touch).
+            wxPoint mouse_pos = ::wxGetMousePosition();
+            if (m_topbar && m_topbar->GetScreenRect().Contains(mouse_pos))
+                return HTCAPTION;
+            break;
         }
 
         // Allow resizing from top of the title bar

--- a/src/slic3r/GUI/SkipPartCanvas.cpp
+++ b/src/slic3r/GUI/SkipPartCanvas.cpp
@@ -450,7 +450,7 @@ void SkipPartCanvas::AutoSetCursor()
     if(is_draging_ || fixed_draging_)
         SetCursor(wxCursor(wxCURSOR_HAND));
     else
-        SetCursor(wxCursor(wxCURSOR_NONE));
+        SetCursor(wxCursor(wxCURSOR_ARROW));
 }
 
 void SkipPartCanvas::StartDrag(const wxPoint& mouse_pt)


### PR DESCRIPTION
## Summary

Fixes #7276 — cursor disappears permanently after using touchscreen input on Windows.

**Root cause**: Windows 8+ automatically hides the mouse cursor during touch input and expects genuine mouse hardware movement to restore it. OrcaSlicer's custom `WM_NCHITTEST` handler returns `HTCAPTION` for the entire window when maximized, which prevents `WM_SETCURSOR` from reaching the client area — so the cursor never gets restored.

**Changes:**
- Add `WM_MOUSEMOVE` handler in `MainFrame::MSWWindowProc()` that detects real (non-touch-synthesized) mouse movement and forces the cursor visible via `SetCursor()` when `GetCursorInfo()` reports it suppressed
- Fix `WM_NCHITTEST` to only return `HTCAPTION` for the topbar region when maximized, falling through to `DefWindowProc` (returns `HTCLIENT`) for the rest of the window
- Replace `wxCURSOR_NONE` with `wxCURSOR_ARROW` in `SkipPartCanvas::AutoSetCursor()` idle state — a hidden cursor as the default is a landmine during input mode transitions

## Test plan

- [ ] Build succeeds on Windows (x64 and ARM64) via CI
- [ ] On a Windows 11 touchscreen device: touch the 3D canvas (two-finger zoom/rotate), then move the mouse — cursor should immediately reappear
- [ ] Verify title bar drag still works when maximized (click on topbar area)
- [ ] Verify window resize from borders still works when not maximized
- [ ] Verify SkipPartCanvas hover/drag behavior unchanged (cursor shows hand when dragging, arrow otherwise)

## Related

- Same underlying issue as [BambuStudio#2619](https://github.com/bambulab/BambuStudio/issues/2619) (shared codebase lineage)
- Detailed analysis: `docs/fix-disappearing-cursor-touchscreen.md` in this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)