### PR TITLE
Fix exported filename showing slot-1 material instead of the printed one (Qidi) and add printing_filament_types placeholder

### DIFF
--- a/resources/profiles/Qidi/process/fdm_process_qidi_x3_common.json
+++ b/resources/profiles/Qidi/process/fdm_process_qidi_x3_common.json
@@ -63,7 +63,7 @@
 	"ironing_type": "no ironing",
 	"layer_height": "0.2",
 	"reduce_infill_retraction": "0",
-	"filename_format": "{input_filename_base}_{filament_type[0]}_{print_time}.gcode",
+	"filename_format": "{input_filename_base}_{filament_type[initial_tool]}_{print_time}.gcode",
 	"detect_overhang_wall": "1",
 	"overhang_1_4_speed": "0",
 	"overhang_2_4_speed": "50",

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -3540,7 +3540,8 @@ void GCode::_do_export(Print& print, GCodeOutputStream &file, ThumbnailsGenerato
             if (std::find(printing_filament_types.begin(), printing_filament_types.end(), type) == printing_filament_types.end())
                 printing_filament_types.emplace_back(std::move(type));
         }
-        print.m_print_statistics.printing_filament_types = boost::algorithm::join(printing_filament_types, ",");
+        // joined with '-' rather than ',' to stay safe in URLs and on print hosts
+        print.m_print_statistics.printing_filament_types = boost::algorithm::join(printing_filament_types, "-");
     }
     if (!is_bbl_printers) {
         file.write_format("; total filament used [g] = %.2lf\n",

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -3532,6 +3532,16 @@ void GCode::_do_export(Print& print, GCodeOutputStream &file, ThumbnailsGenerato
         // Const input (tool-change fallback for non-wipe-tower prints)
         print.tool_ordering()));
     print.m_print_statistics.initial_tool = initial_extruder_id;
+    {
+        // Orca: only the filaments extruded on this plate, deduplicated, in filament id order
+        std::vector<std::string> printing_filament_types;
+        for (const Extruder &extruder : m_writer.extruders()) {
+            std::string type = m_config.filament_type.get_at(extruder.id());
+            if (std::find(printing_filament_types.begin(), printing_filament_types.end(), type) == printing_filament_types.end())
+                printing_filament_types.emplace_back(std::move(type));
+        }
+        print.m_print_statistics.printing_filament_types = boost::algorithm::join(printing_filament_types, ",");
+    }
     if (!is_bbl_printers) {
         file.write_format("; total filament used [g] = %.2lf\n",
             print.m_print_statistics.total_weight);

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -3838,6 +3838,7 @@ DynamicConfig PrintStatistics::config() const
     config.set_key_value("total_wipe_tower_filament", new ConfigOptionFloat(this->total_wipe_tower_filament));
     config.set_key_value("initial_tool",              new ConfigOptionInt(static_cast<int>(this->initial_tool)));
     config.set_key_value("initial_extruder",          new ConfigOptionInt(static_cast<int>(this->initial_tool)));
+    config.set_key_value("printing_filament_types",   new ConfigOptionString(this->printing_filament_types));
     return config;
 }
 
@@ -3847,7 +3848,8 @@ DynamicConfig PrintStatistics::placeholders()
     for (const std::string key : {
         "print_time", "normal_print_time", "silent_print_time",
         "used_filament", "extruded_volume", "extruded_volume_total", "total_cost", "total_weight", "extruded_weight_total",
-        "initial_tool", "initial_extruder", "total_toolchanges", "total_wipe_tower_cost", "total_wipe_tower_filament"})
+        "initial_tool", "initial_extruder", "total_toolchanges", "total_wipe_tower_cost", "total_wipe_tower_filament",
+        "printing_filament_types"})
         config.set_key_value(key, new ConfigOptionString(std::string("{") + key + "}"));
     return config;
 }

--- a/src/libslic3r/Print.hpp
+++ b/src/libslic3r/Print.hpp
@@ -799,7 +799,7 @@ struct PrintStatistics
     double                          total_wipe_tower_cost;
     double                          total_wipe_tower_filament;
     unsigned int                    initial_tool;
-    // Orca: comma-separated list of the filament types really extruded on the plate, for the filename template.
+    // Orca: hyphen-separated list of the filament types really extruded on the plate, for the filename template.
     std::string                     printing_filament_types;
     std::map<size_t, double>        filament_stats;
 

--- a/src/libslic3r/Print.hpp
+++ b/src/libslic3r/Print.hpp
@@ -799,6 +799,8 @@ struct PrintStatistics
     double                          total_wipe_tower_cost;
     double                          total_wipe_tower_filament;
     unsigned int                    initial_tool;
+    // Orca: comma-separated list of the filament types really extruded on the plate, for the filename template.
+    std::string                     printing_filament_types;
     std::map<size_t, double>        filament_stats;
 
     // Config with the filled in print statistics.
@@ -817,6 +819,7 @@ struct PrintStatistics
         total_wipe_tower_cost  = 0.;
         total_wipe_tower_filament = 0.;
         initial_tool           = 0;
+        printing_filament_types.clear();
         filament_stats.clear();
     }
     static const std::string FilamentUsedG;

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -11353,9 +11353,9 @@ PrintStatisticsConfigDef::PrintStatisticsConfigDef()
     def->label = L("Print time (normal mode)");
     def->tooltip = L("Estimated print time when printed in normal mode (i.e. not in silent mode). Same as normal_print_time.");
 
-    //def = this->add("printing_filament_types", coString);
-    //def->label = L("Used filament types");
-    //def->tooltip = L("Comma-separated list of all filament types used during the print.");
+    def = this->add("printing_filament_types", coString);
+    def->label = L("Used filament types");
+    def->tooltip = L("Comma-separated list of all filament types used during the print.");
 
     def = this->add("silent_print_time", coString);
     def->label = L("Print time (silent mode)");

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -11355,7 +11355,7 @@ PrintStatisticsConfigDef::PrintStatisticsConfigDef()
 
     def = this->add("printing_filament_types", coString);
     def->label = L("Used filament types");
-    def->tooltip = L("Comma-separated list of all filament types used during the print.");
+    def->tooltip = L("Hyphen-separated list of all filament types used during the print.");
 
     def = this->add("silent_print_time", coString);
     def->label = L("Print time (silent mode)");


### PR DESCRIPTION
## Problem

On printers whose process profiles inherit `fdm_process_qidi_x3_common` (Qidi X3 family, Q2, Q2 Combo…), the exported/uploaded file is always named after the material of **filament slot 1**, not the material actually printed.

Example (Qidi Q2 Combo + Qidi Box, SEMM): slots = ABS / ABS / PLA / ABS, a single-color plate assigned to filament 3 (PLA, `T2` in the G-code, correct PLA temperatures) is exported as `..._ABS_2h9m.gcode.3mf`. Misleading — it looks like an ABS print.

Related reports: #13311 (Snapmaker U1, same symptom), #8917 (closed stale).

## Cause

The common profile hardcodes the vector index:

```json
"filename_format": "{input_filename_base}_{filament_type[0]}_{print_time}.gcode"
```

The placeholder machinery itself is fine: `initial_tool` is filled from the first really-used extruder during G-code export (`GCode.cpp`) and is already used by the Orca default template and by the Qidi Draft/Extra Draft profiles.

## Changes

1. **Profile fix** — `fdm_process_qidi_x3_common.json`: `{filament_type[0]}` → `{filament_type[initial_tool]}`. Single-material plates now show the printed material; multi-material plates show the first printed material.

2. **New filename placeholder `printing_filament_types`** — hyphen-separated list of the filament types really extruded on the plate (deduplicated, filament id order), mirroring PrusaSlicer's placeholder of the same name (its definition was already present but commented out in `PrintConfig.cpp`). Lets multi-material users put *all* used materials in the name:
   `{input_filename_base}_{printing_filament_types}_{print_time}.gcode` → `model_ABS-PLA_2h9m.gcode`.
   Filled in `GCode::_do_export` next to `initial_tool`, exposed through `PrintStatistics::config()`, and resolved lazily via `PrintStatistics::placeholders()` before slicing, like `print_time`.

## Notes

- No behavior change for any template that does not use the new placeholder; defaults untouched except the Qidi profile fix.
- ~140 other occurrences of hardcoded `{filament_type[0]}` remain in other vendors' profiles (Flashforge, Anycubic, Ratrig, Geeetech, Blocks…). I kept this PR scoped to Qidi; happy to do the project-wide sweep in a follow-up if desired.

## Verification

- Traced the filename path: `Plater` → `BackgroundSlicingProcess::output_filepath_for_project` → `Print::output_filename` → `PlaceholderParser::process` with the profile's `filename_format`; confirmed `PrintStatistics::initial_tool` is set from `initial_extruder_id` during export.
- Reproduced the wrong name with the shipped 2.4.2 Qidi profiles (inheritance chain `0.20mm Standard @Qidi Q2` → `0.20mm Standard @Qidi X3` → `fdm_process_qidi_x3_common`).
- Confirmed switching the template to `{filament_type[initial_tool]}` on the affected setup produces the correct material in the name.

