### PR TITLE
Port Nip & Tuck seam notching feature

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -5774,6 +5774,151 @@ static std::unique_ptr<EdgeGrid::Grid> calculate_layer_edge_grid(const Layer& la
     return out;
 }
 
+// ORCA: Nip & Tuck seams (ported from preFlight).
+// Shapes the seam point of an external perimeter into a V-shaped channel that hides the
+// start/stop blobs. `loop` must already be split so that it starts and ends at the seam.
+//
+// NOTE: preFlight additionally trims the first inner perimeter to make room for the notch.
+// OrcaSlicer extrudes each perimeter loop independently (the seam is placed per-loop inside
+// extrude_loop), so there is no stage where the external and its inner perimeter are available
+// together with resolved seams. The inner-perimeter trim is therefore NOT implemented here -
+// only the external perimeter is shaped, so the pushed-in external bead overlaps the inner wall
+// at the seam (hidden inside the wall). This is a staged, contained subset of the feature.
+static void apply_seam_notch_to_external_loop(ExtrusionLoop& loop, SeamNotchType seam_type,
+                                              double seam_notch_width_mult, double seam_notch_angle_deg,
+                                              int layer_index)
+{
+    if (seam_type == SeamNotchType::Regular || loop.paths.empty())
+        return;
+
+    Points3& front_pts = loop.paths.front().polyline.points;
+    Points3& back_pts  = loop.paths.back().polyline.points;
+    if (front_pts.size() < 2 || back_pts.size() < 2)
+        return;
+
+    const double ext_width = loop.paths.front().width; // mm
+    if (ext_width <= 0.0)
+        return;
+
+    const double notch_width_mm = seam_notch_width_mult * ext_width;
+    const double half_width     = scale_(notch_width_mm);   // scaled taper length on each side of the seam
+    const double depth          = scale_(ext_width * 0.9);  // max inward offset (scaled), ~one perimeter deep
+    if (half_width <= 0.0 || depth <= 0.0)
+        return;
+
+    // Don't notch tiny loops - there isn't enough length for a clean taper.
+    if (loop.length() < scale_(notch_width_mm * 3.0))
+        return;
+
+    auto pt2d = [](const Point3& p) { return Vec2d(double(p.x()), double(p.y())); };
+
+    // Path directions leaving and arriving at the seam.
+    Vec2d dir_start = pt2d(front_pts[1]) - pt2d(front_pts[0]);
+    Vec2d dir_end   = pt2d(back_pts[back_pts.size() - 1]) - pt2d(back_pts[back_pts.size() - 2]);
+    if (dir_start.squaredNorm() < 1e-6 || dir_end.squaredNorm() < 1e-6)
+        return;
+    dir_start.normalize();
+    dir_end.normalize();
+
+    // Skip seams on corners sharper than the threshold - the geometry already hides them there.
+    if (seam_notch_angle_deg > 0.0) {
+        const double cos_dev = dir_start.dot(dir_end);
+        if (cos_dev < std::cos(seam_notch_angle_deg * M_PI / 180.0))
+            return;
+    }
+
+    // Inward direction: bisector of the two seam directions, oriented toward the loop interior.
+    // (preFlight derives the interior side from winding/reversed flags; we cross-check against the
+    // loop centroid instead, which avoids hole/orientation edge cases and can't point outward.)
+    Vec2d inward = dir_start - dir_end;
+    if (inward.squaredNorm() < 1e-6)
+        inward = Vec2d(-dir_start.y(), dir_start.x());
+    inward.normalize();
+    const Point centroid = loop.polygon().centroid();
+    if (inward.dot(Vec2d(double(centroid.x()), double(centroid.y())) - pt2d(front_pts[0])) < 0.0)
+        inward = -inward;
+
+    // Resolve the alternating mode by layer parity.
+    if (seam_type == SeamNotchType::Alternating)
+        seam_type = (layer_index % 2 == 0) ? SeamNotchType::Nip : SeamNotchType::Tuck;
+
+    // When the loop is made of several paths (e.g. an overhang perimeter), the seam-adjacent path may
+    // be shorter than the taper. In that case we must not move its far endpoint, which is a junction
+    // shared with the neighbouring path - doing so would open a gap mid-perimeter. `protect_far`
+    // leaves that shared point in place (the taper is simply truncated at the path boundary).
+    const bool protect_far = loop.paths.size() > 1;
+
+    // Taper one end of the (open) path toward the seam: the seam vertex is offset inward by the full
+    // depth, fading linearly to zero at `half_width` along the path. A split vertex is inserted at the
+    // taper boundary so the V closes cleanly back onto the wall.
+    auto taper = [&](Points3& pts, bool from_start) {
+        if (pts.size() < 2)
+            return;
+        if (from_start) {
+            double acc = 0.0;
+            for (size_t i = 1; i < pts.size(); ++i) {
+                const double seg = (pt2d(pts[i]) - pt2d(pts[i - 1])).norm();
+                if (acc + seg >= half_width) {
+                    const double frac = seg > 1e-6 ? (half_width - acc) / seg : 1.0;
+                    if (frac > 1e-3 && frac < 1.0 - 1e-3) {
+                        Point3 s = pts[i];
+                        s.x() = coord_t(double(pts[i - 1].x()) + double(pts[i].x() - pts[i - 1].x()) * frac);
+                        s.y() = coord_t(double(pts[i - 1].y()) + double(pts[i].y() - pts[i - 1].y()) * frac);
+                        pts.insert(pts.begin() + i, s);
+                    }
+                    break;
+                }
+                acc += seg;
+            }
+            double d = 0.0;
+            for (size_t i = 0; i < pts.size(); ++i) {
+                if (protect_far && i + 1 == pts.size())
+                    break; // don't move the junction shared with the next path
+                if (i > 0)
+                    d += (pt2d(pts[i]) - pt2d(pts[i - 1])).norm();
+                if (d > half_width)
+                    break;
+                const double off = depth * (1.0 - std::min(d / half_width, 1.0));
+                pts[i].x() += coord_t(inward.x() * off);
+                pts[i].y() += coord_t(inward.y() * off);
+            }
+        } else {
+            double acc = 0.0;
+            for (size_t i = pts.size() - 1; i > 0; --i) {
+                const double seg = (pt2d(pts[i]) - pt2d(pts[i - 1])).norm();
+                if (acc + seg >= half_width) {
+                    const double frac = seg > 1e-6 ? 1.0 - (half_width - acc) / seg : 0.0;
+                    if (frac > 1e-3 && frac < 1.0 - 1e-3) {
+                        Point3 s = pts[i];
+                        s.x() = coord_t(double(pts[i - 1].x()) + double(pts[i].x() - pts[i - 1].x()) * frac);
+                        s.y() = coord_t(double(pts[i - 1].y()) + double(pts[i].y() - pts[i - 1].y()) * frac);
+                        pts.insert(pts.begin() + i, s);
+                    }
+                    break;
+                }
+                acc += seg;
+            }
+            double d = 0.0;
+            for (size_t i = pts.size(); i-- > 0; ) {
+                if (protect_far && i == 0)
+                    break; // don't move the junction shared with the previous path
+                if (i + 1 < pts.size())
+                    d += (pt2d(pts[i + 1]) - pt2d(pts[i])).norm();
+                if (d > half_width)
+                    break;
+                const double off = depth * (1.0 - std::min(d / half_width, 1.0));
+                pts[i].x() += coord_t(inward.x() * off);
+                pts[i].y() += coord_t(inward.y() * off);
+            }
+        }
+    };
+
+    if (seam_type != SeamNotchType::Tuck)
+        taper(front_pts, true);   // Nip / Nip-Tuck: push the START of the external inward
+    if (seam_type != SeamNotchType::Nip)
+        taper(back_pts, false);   // Tuck / Nip-Tuck: push the END of the external inward
+}
+
 std::string GCode::extrude_loop(const ExtrusionLoop&        loop_ref,
                                 const std::string&          description,
                                 double                      speed,
@@ -5821,6 +5966,16 @@ std::string GCode::extrude_loop(const ExtrusionLoop&        loop_ref,
         const auto _line_width = loop.role() == erExternalPerimeter ? m_config.outer_wall_line_width.get_abs_value(nozzle_diameter) :
                                                                       m_config.inner_wall_line_width.get_abs_value(nozzle_diameter);
         enable_seam_slope      = seam_overhang < m_config.scarf_overhang_threshold.value * 0.01f * _line_width;
+    }
+
+    // ORCA: Nip & Tuck seams (ported from preFlight). Shape the external perimeter's seam into a
+    // V-notch. Gated so it never changes default behaviour: only external perimeters, above the
+    // first layer, when a non-Regular mode is chosen, not in spiral vase, mutually exclusive with
+    // the scarf/slope seam, and only when there is at least one inner perimeter to hide behind.
+    if (m_config.seam_type.value != SeamNotchType::Regular && !m_config.spiral_mode && !enable_seam_slope &&
+        loop.role() == erExternalPerimeter && layer_id() > 0 && region_perimeters.size() > 1) {
+        apply_seam_notch_to_external_loop(loop, m_config.seam_type.value, m_config.seam_notch_width.value,
+                                          m_config.seam_notch_angle.value, layer_id());
     }
 
     // clip the path to avoid the extruder to get exactly on the first point of the loop;

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -1290,6 +1290,10 @@ static std::vector<std::string> s_Preset_print_options{
     "small_area_infill_flow_compensation",
     "small_area_infill_flow_compensation_model",
     "enable_wrapping_detection",
+    // ORCA: Nip & Tuck seams (ported from preFlight)
+    "seam_type",
+    "seam_notch_width",
+    "seam_notch_angle",
     "seam_slope_type",
     "seam_slope_conditional",
     "scarf_angle_threshold",

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -376,6 +376,16 @@ static t_config_enum_values s_keys_map_SeamScarfType{
 };
 CONFIG_OPTION_ENUM_DEFINE_STATIC_MAPS(SeamScarfType)
 
+// ORCA: Nip & Tuck seams (ported from preFlight)
+static t_config_enum_values s_keys_map_SeamNotchType{
+    { "regular",        int(SeamNotchType::Regular) },
+    { "niptuck",        int(SeamNotchType::NipTuck) },
+    { "nip",            int(SeamNotchType::Nip) },
+    { "tuck",           int(SeamNotchType::Tuck) },
+    { "alternating",    int(SeamNotchType::Alternating) },
+};
+CONFIG_OPTION_ENUM_DEFINE_STATIC_MAPS(SeamNotchType)
+
 // Orca
 static t_config_enum_values s_keys_map_EnsureVerticalShellThickness{
     { "none",           int(EnsureVerticalShellThickness::evstNone) },
@@ -5648,6 +5658,68 @@ void PrintConfigDef::init_fff_params()
     def->min = 0;
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionFloatOrPercent(10,true));
+
+    // ORCA: Nip & Tuck seams (ported from preFlight)
+    def = this->add("seam_type", coEnum);
+    def->label = L("Seam type");
+    def->category = L("Quality");
+    def->tooltip = L("Controls how the seam point on external perimeters is shaped to hide start/stop blobs.\n\n"
+                     "Regular - No seam shaping. Standard seam behavior.\n\n"
+                     "Nip/Tuck - Creates a V-shaped channel one perimeter deep at the seam. Both the start and "
+                     "end of the external perimeter are pushed inward, and the first inner perimeter is trimmed "
+                     "to absorb the disturbance.\n\n"
+                     "Nip - Only the start of the external perimeter is pushed inward at the seam. The end "
+                     "remains on the normal path. The inner perimeter is trimmed on the start side only.\n\n"
+                     "Tuck - Only the end of the external perimeter is pushed inward at the seam. The start "
+                     "remains on the normal path. The inner perimeter is trimmed on the end side only.\n\n"
+                     "Alt. Nip/Tuck - Alternates between Nip on even layers and Tuck on odd layers. "
+                     "This distributes the seam disturbance across both sides of the junction, preventing "
+                     "a consistent bulge on one side.\n\n"
+                     "Note: All non-Regular modes require multiple perimeters and are not used in Spiral Vase mode.");
+    def->enum_keys_map = &ConfigOptionEnum<SeamNotchType>::get_enum_values();
+    def->enum_values.push_back("regular");
+    def->enum_values.push_back("niptuck");
+    def->enum_values.push_back("nip");
+    def->enum_values.push_back("tuck");
+    def->enum_values.push_back("alternating");
+    def->enum_labels.push_back(L("Regular"));
+    def->enum_labels.push_back(L("Nip/Tuck"));
+    def->enum_labels.push_back(L("Nip"));
+    def->enum_labels.push_back(L("Tuck"));
+    def->enum_labels.push_back(L("Alt. Nip/Tuck"));
+    def->mode = comAdvanced;
+    def->set_default_value(new ConfigOptionEnum<SeamNotchType>(SeamNotchType::Regular));
+
+    def = this->add("seam_notch_width", coFloat);
+    def->label = L("Seam notch width");
+    def->category = L("Quality");
+    def->tooltip = L("Width of the V-shaped notch as a multiple of the external perimeter extrusion width. "
+                     "In Nip/Tuck mode, this is the full notch width across both sides of the seam. "
+                     "In Nip or Tuck mode, only half the width is used since only one side of the seam is shaped. "
+                     "The depth is automatically calculated from perimeter spacing. "
+                     "Wider values are more forgiving for blobs but create a larger surface depression. "
+                     "Narrower values are subtler.");
+    def->sidetext = L("x ext. width");
+    def->min = 1;
+    def->max = 3;
+    def->mode = comAdvanced;
+    def->set_default_value(new ConfigOptionFloat(2.0));
+
+    def = this->add("seam_notch_angle", coFloat);
+    def->label = L("Seam notch corner threshold");
+    def->category = L("Quality");
+    def->tooltip = L("Controls where seam notching is applied based on corner sharpness. "
+                     "At sharp corners the seam is naturally hidden by the geometry, so notching "
+                     "is unnecessary.\n\n"
+                     "Seams on corners sharper than this angle are skipped. The default of 44° means any corner "
+                     "of 44° or less is considered sharp enough to hide the seam on its own - just under 45°, "
+                     "where a clean fold already conceals the junction.\n\n"
+                     "Set to 0 to apply seam notching everywhere regardless of corner angle.");
+    def->sidetext = L("°");
+    def->min = 0;
+    def->max = 90;
+    def->mode = comAdvanced;
+    def->set_default_value(new ConfigOptionFloat(44.0));
 
     def = this->add("seam_slope_type", coEnum);
     def->label = L("Scarf joint seam (beta)");

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -260,6 +260,16 @@ enum class SeamScarfType {
     All,
 };
 
+// ORCA: Nip & Tuck seams (ported from preFlight). Shapes the seam point on external
+// perimeters into a V-notch that hides start/stop blobs.
+enum class SeamNotchType {
+    Regular,
+    NipTuck,
+    Nip,
+    Tuck,
+    Alternating,
+};
+
 // Orca
 enum EnsureVerticalShellThickness {
     evstNone,
@@ -594,6 +604,7 @@ CONFIG_OPTION_ENUM_DECLARE_STATIC_MAPS(SupportMaterialInterfacePattern)
 CONFIG_OPTION_ENUM_DECLARE_STATIC_MAPS(SupportType)
 CONFIG_OPTION_ENUM_DECLARE_STATIC_MAPS(SeamPosition)
 CONFIG_OPTION_ENUM_DECLARE_STATIC_MAPS(SeamScarfType)
+CONFIG_OPTION_ENUM_DECLARE_STATIC_MAPS(SeamNotchType)
 CONFIG_OPTION_ENUM_DECLARE_STATIC_MAPS(SLADisplayOrientation)
 CONFIG_OPTION_ENUM_DECLARE_STATIC_MAPS(SLAPillarConnectionMode)
 CONFIG_OPTION_ENUM_DECLARE_STATIC_MAPS(BrimType)
@@ -1310,6 +1321,10 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionFloat,                seam_slope_min_length))
     ((ConfigOptionInt,                  seam_slope_steps))
     ((ConfigOptionBool,                 seam_slope_inner_walls))
+    // ORCA: Nip & Tuck seams (ported from preFlight)
+    ((ConfigOptionEnum<SeamNotchType>,  seam_type))
+    ((ConfigOptionFloat,                seam_notch_width))
+    ((ConfigOptionFloat,                seam_notch_angle))
     ((ConfigOptionFloatOrPercent,       scarf_joint_speed))
     ((ConfigOptionFloat,                scarf_joint_flow_ratio))
     ((ConfigOptionPercent,              scarf_overhang_threshold))

--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -1046,6 +1046,12 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig *config, in
     toggle_line("scarf_angle_threshold", has_seam_slope && config->opt_bool("seam_slope_conditional"));
     toggle_line("scarf_overhang_threshold", has_seam_slope && config->opt_bool("seam_slope_conditional"));
 
+    // ORCA: Nip & Tuck seams (ported from preFlight)
+    toggle_field("seam_type", !has_spiral_vase);
+    bool has_seam_notch = !has_spiral_vase && config->opt_enum<SeamNotchType>("seam_type") != SeamNotchType::Regular;
+    toggle_line("seam_notch_width", has_seam_notch);
+    toggle_line("seam_notch_angle", has_seam_notch);
+
     bool use_beam_interlocking = config->opt_bool("interlocking_beam");
     toggle_line("mmu_segmented_region_interlocking_depth", !use_beam_interlocking);
     toggle_line("interlocking_beam_width", use_beam_interlocking);

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -2616,6 +2616,10 @@ void TabPrint::build()
         optgroup->append_single_option_line("seam_position", "quality_settings_seam#seam-position");
         optgroup->append_single_option_line("staggered_inner_seams", "quality_settings_seam#staggered-inner-seams");
         optgroup->append_single_option_line("seam_gap","quality_settings_seam#seam-gap");
+        // ORCA: Nip & Tuck seams (ported from preFlight)
+        optgroup->append_single_option_line("seam_type", "quality_settings_seam#seam-type");
+        optgroup->append_single_option_line("seam_notch_width", "quality_settings_seam#seam-type");
+        optgroup->append_single_option_line("seam_notch_angle", "quality_settings_seam#seam-type");
         optgroup->append_single_option_line("seam_slope_type", "quality_settings_seam#scarf-joint-seam");
         optgroup->append_single_option_line("seam_slope_conditional", "quality_settings_seam#scarf-joint-seam");
         optgroup->append_single_option_line("scarf_angle_threshold", "quality_settings_seam#scarf-joint-seam");


### PR DESCRIPTION
# Description

Introduce 'Nip & Tuck' seam notching (ported from preFlight).

<img width="420" height="234" alt="image" src="https://github.com/user-attachments/assets/61d2a4c1-2173-4538-9e86-5eef8160a6f9" />
<img width="492" height="591" alt="image" src="https://github.com/user-attachments/assets/5f160bb7-824e-406a-82dc-4cb597ff837f" />

> [!NOTE]
> The inner-perimeter trim is NOT implemented

## Tests

<!--
> Please describe the tests that you have conducted to verify the changes made in this PR.
-->

<!--
> A guide for users on how to download the artifacts from this PR.
-->

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
