### PR TITLE
Fix issue that unable to open 3mf again once the 3mf action dialog is cancelled

### DIFF
--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -12212,8 +12212,9 @@ void Plater::load_project(wxString const& filename2,
         BOOST_LOG_TRIVIAL(warning) << __FUNCTION__ << boost::format(": current loading other project, return directly");
         return;
     }
-    else
-        m_loading_project = true;
+
+    m_loading_project = true;
+    ScopeGuard loading_project_sc([this]() { m_loading_project = false; }); // Make sure state restored on any early return
 
     m_only_gcode = false;
     m_exported_file = false;
@@ -12307,7 +12308,6 @@ void Plater::load_project(wxString const& filename2,
     sidebar().set_flushing_volume_warning(has_modify);
 
     BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << __LINE__ << " load project done";
-    m_loading_project = false;
 }
 
 // BBS: save logic


### PR DESCRIPTION
# Description

1. Set 3mf loading behavior to "Always ask"
2. Click a recent 3mf file, which pops up the 3mf action dialog.
3. Click cancel.
4. Then attempt to open a 3mf file, nothing happens
5. Log shows "current loading other project, return directly" everytime you attempt to open a project again

The problematic code is
https://github.com/OrcaSlicer/OrcaSlicer/blob/4b7182b048a979a3aca40782d9d1685a99f632c4/src/slic3r/GUI/Plater.cpp#L12239-L12243
Which early returns without clear the `m_loading_project` flag set early above at https://github.com/OrcaSlicer/OrcaSlicer/blob/4b7182b048a979a3aca40782d9d1685a99f632c4/src/slic3r/GUI/Plater.cpp#L12213-L12219

This PR fix this by clear the flag using a `ScopeGuard` so the flag will be reset no matter where this function is returned at.

# Screenshots/Recordings/Graphs

<!--
> Please attach relevant screenshots to showcase the UI changes.
> Please attach images that can help explain the changes.
-->

## Tests

Be able to see the 3mf dialog again after cancelled the previous one.

<!--
> A guide for users on how to download the artifacts from this PR.
-->

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
