### PR TITLE
Fix idle-temperature cooldowns with rib prime towers

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -717,6 +717,7 @@ static std::vector<Vec2d> get_path_of_change_filament(const Print& print)
         int new_extruder_id = get_extruder_index(*m_print_config, new_filament_id);
 
         bool is_nozzle_change = !tcr.nozzle_change_result.gcode.empty() && (gcodegen.config().nozzle_diameter.size() > 1);
+        const bool needs_toolchange = new_filament_id >= 0 && gcodegen.writer().need_toolchange(new_filament_id);
 
         std::string gcode;
 
@@ -836,6 +837,9 @@ static std::vector<Vec2d> get_path_of_change_filament(const Print& print)
         }
 
         end_filament_gcode_str = toolchange_retract_str + object_end_label_temp + end_filament_gcode_str;
+
+        if (needs_toolchange && gcodegen.m_ooze_prevention.enable && gcodegen.writer().filament() != nullptr)
+            end_filament_gcode_str += gcodegen.m_ooze_prevention.pre_toolchange(gcodegen);
 
         std::string wipe_next_start_point_str;
         bool        need_travel_after_change_filament_gcode = false; // travel need be after the filament changed to get the correct "m_curr_extruder_id"
@@ -991,7 +995,7 @@ static std::vector<Vec2d> get_path_of_change_filament(const Print& print)
         }
 
         std::string toolchange_command;
-        if (tcr.priming || (new_filament_id >= 0 && gcodegen.writer().need_toolchange(new_filament_id)))
+        if (tcr.priming || needs_toolchange)
             toolchange_command = gcodegen.writer().toolchange(new_filament_id);
         if (!custom_gcode_changes_tool(toolchange_gcode_str, gcodegen.writer().toolchange_prefix(), new_filament_id))
             toolchange_gcode_str += toolchange_command;

--- a/tests/fff_print/test_gcodewriter.cpp
+++ b/tests/fff_print/test_gcodewriter.cpp
@@ -13,6 +13,36 @@
 using namespace Slic3r;
 using namespace Slic3r::Test;
 
+TEST_CASE("Prime-tower tool changes honor idle temperature", "[GCodeWriter][Regression]")
+{
+    const std::string gcode = slice({ cube(20) },
+        multifilament_config(2, {
+            { "nozzle_diameter",                    "0.4,0.4" },
+            { "printer_extruder_id",                "1,2" },
+            { "filament_map",                       "1,1" },
+            { "single_extruder_multi_material",     "0" },
+            { "enable_prime_tower",                 "1" },
+            { "wipe_tower_x",                       "165" },
+            { "wipe_tower_y",                       "250" },
+            { "prime_tower_width",                  "20" },
+            { "ooze_prevention",                    "1" },
+            { "idle_temperature",                   "150,160" },
+            { "preheat_time",                       "0" },
+            { "nozzle_temperature",                 "220,230" },
+            { "nozzle_temperature_initial_layer",   "220,230" },
+            { "sparse_infill_filament_id",          "2" },
+            { "internal_solid_infill_filament_id",  "2" },
+            { "top_surface_filament_id",            "2" },
+            { "bottom_surface_filament_id",         "2" },
+            { "outer_wall_filament_id",             "1" },
+            { "inner_wall_filament_id",             "1" },
+            { "skirt_loops",                        "0" },
+            { "brim_type",                          "no_brim" },
+        }));
+
+    REQUIRE_THAT(gcode, Catch::Matchers::ContainsSubstring("M104 S150 T0 ; set nozzle temperature ;cooldown"));
+}
+
 SCENARIO("set_speed emits values with fixed-point output.", "[GCodeWriter]") {
 
     GIVEN("GCodeWriter instance") {

--- a/tests/fff_print/test_gcodewriter.cpp
+++ b/tests/fff_print/test_gcodewriter.cpp
@@ -22,6 +22,7 @@ TEST_CASE("Prime-tower tool changes honor idle temperature", "[GCodeWriter][Regr
             { "filament_map",                       "1,1" },
             { "single_extruder_multi_material",     "0" },
             { "enable_prime_tower",                 "1" },
+            { "wipe_tower_type",                    "type1" },
             { "wipe_tower_x",                       "165" },
             { "wipe_tower_y",                       "250" },
             { "prime_tower_width",                  "20" },


### PR DESCRIPTION
## Summary
- Emit Ooze Prevention's idle-temperature command for prime-tower tool changes.
- Add a regression test covering the prime-tower path.

## Underlying cause
At every normal tool change, OrcaSlicer first tells the nozzle that is finishing its work to cool to its configured idle temperature. The standard tool-change code emits that `M104 ... ;cooldown` command.

The tested configuration uses a rib prime tower. Its tool-change code assembles the change manually rather than using the standard path, so it skipped the existing cooldown step. As a result, the same slow multi-nozzle project produced 36 cooldown commands without the prime tower and none with it.

## Fix
Use the existing Ooze Prevention cooldown step when the prime-tower code performs a real tool change. This preserves the established behavior rather than duplicating temperature-selection rules.

## Verification
Automated:
```powershell
build-dbginfo\tests\fff_print\RelWithDebInfo\fff_print_tests.exe "Prime-tower tool changes honor idle temperature" --order rand --warn NoAssertions
build-dbginfo\tests\fff_print\RelWithDebInfo\fff_print_tests.exe "[GCodeWriter]" --order rand --warn NoAssertions
```

Manual: load a multi-nozzle project with Ooze Prevention, explicit idle temperatures, and a rib prime tower; slice it and inspect the G-code. Long inactive intervals must contain `M104 S<idle> T<n> ; set nozzle temperature ;cooldown`. For the supplied slow test project, the fixed prime-tower export has 36 cooldowns (T0=9, T1=12, T2=8, T3=7), matching the no-prime-tower control. Time-aware preheat scheduling remains present for imminent reuse.

Closes #14710

## Copilot disclosure
GitHub Copilot was used to investigate the G-code paths, implement the change, add the regression test, and analyze the generated G-code; the behavior and output were manually validated.