### PR TITLE
fix: resolve inherits chain when loading CLI --load-settings/--load-filaments

### DIFF
--- a/src/OrcaSlicer.cpp
+++ b/src/OrcaSlicer.cpp
@@ -25,6 +25,7 @@
 #include <math.h>
 #include <csignal>
 #include <set>
+#include <map>
 #include <algorithm>
 
 #if defined(__linux__) || defined(__LINUX__)
@@ -1964,34 +1965,96 @@ int CLI::run(int argc, char **argv)
     // ConfigOptionDef default instead of the value defined by its ancestor profile(s) - producing
     // wrong speeds/acceleration/etc. for any profile that relies on inheritance (which is the norm
     // for BBL profiles: e.g. "0.20mm Standard @BBL A1M" -> "fdm_process_single_0.20" ->
-    // "fdm_process_single_common" -> "fdm_process_common"). Walk the chain ourselves, scoped to the
-    // same directory as the leaf file (this also avoids ambiguity between same-named base profiles
-    // that exist per-vendor, e.g. every vendor ships its own "fdm_process_common.json").
-    auto resolve_inherits_chain = [](const std::string& file) -> std::vector<std::string> {
+    // "fdm_process_single_common" -> "fdm_process_common").
+    // Resolve the chain the way the shipped profile data is organized: preset names map to files
+    // through the vendor's manifest (<profiles>/<Vendor>.json machine/process/filament lists), with
+    // the shared OrcaFilamentLibrary consulted for filament bases that live outside the vendor tree
+    // (e.g. "COEX PCTG PRIME @BBL X1C" -> "COEX PCTG PRIME @base" in OrcaFilamentLibrary). A
+    // same-directory sibling is used as fallback for profile folders without a manifest.
+    auto load_json_file = [](const std::string& path, json& j) -> bool {
+        try {
+            boost::nowide::ifstream ifs(path);
+            if (! ifs.good())
+                return false;
+            ifs >> j;
+            return true;
+        } catch (...) {
+            return false;
+        }
+    };
+
+    auto manifest_name_map = [&load_json_file](const std::string& manifest_path, std::map<std::string, std::string>& out) {
+        json m;
+        if (! load_json_file(manifest_path, m))
+            return;
+        for (const char* key : {"machine_list", "process_list", "filament_list"}) {
+            auto it = m.find(key);
+            if (it == m.end() || ! it->is_array())
+                continue;
+            for (auto& e : *it) {
+                if (e.contains("name") && e.contains("sub_path"))
+                    out.emplace(e["name"].get<std::string>(), e["sub_path"].get<std::string>());
+            }
+        }
+    };
+
+    auto resolve_inherits_chain = [&load_json_file, &manifest_name_map](const std::string& file) -> std::vector<std::string> {
+        namespace fs = boost::filesystem;
+        // locate the vendor root: the ancestor directory that has a sibling "<dirname>.json" manifest
+        fs::path vendor_dir;
+        std::string vendor_manifest;
+        for (fs::path p = fs::path(file).parent_path(); ! p.empty() && p.has_parent_path(); p = p.parent_path()) {
+            fs::path manifest = p.parent_path() / (p.filename().string() + ".json");
+            if (fs::exists(manifest)) {
+                vendor_dir = p;
+                vendor_manifest = manifest.string();
+                break;
+            }
+        }
+        std::map<std::string, std::string> vendor_map, library_map;
+        fs::path library_dir;
+        if (! vendor_manifest.empty()) {
+            manifest_name_map(vendor_manifest, vendor_map);
+            fs::path lib_manifest = vendor_dir.parent_path() / "OrcaFilamentLibrary.json";
+            if (fs::exists(lib_manifest)) {
+                library_dir = vendor_dir.parent_path() / "OrcaFilamentLibrary";
+                manifest_name_map(lib_manifest.string(), library_map);
+            }
+        }
+
         std::vector<std::string> chain;
         std::set<std::string> visited;
-        boost::filesystem::path dir = boost::filesystem::path(file).parent_path();
         std::string current = file;
         while (true) {
             json j;
-            try {
-                boost::nowide::ifstream ifs(current);
-                if (! ifs.good())
-                    break;
-                ifs >> j;
-            } catch (...) {
+            if (! load_json_file(current, j))
                 break;
-            }
             auto it = j.find(BBL_JSON_KEY_INHERITS);
             if (it == j.end() || ! it->is_string())
                 break;
             std::string parent_name = it->get<std::string>();
             if (parent_name.empty())
                 break;
-            boost::filesystem::path parent_path = dir / (parent_name + ".json");
+
+            fs::path parent_path;
+            auto vi = vendor_map.find(parent_name);
+            if (vi != vendor_map.end() && fs::exists(vendor_dir / vi->second)) {
+                parent_path = vendor_dir / vi->second;
+            } else if (fs::exists(fs::path(current).parent_path() / (parent_name + ".json"))) {
+                parent_path = fs::path(current).parent_path() / (parent_name + ".json");
+            } else {
+                auto li = library_map.find(parent_name);
+                if (li != library_map.end() && fs::exists(library_dir / li->second))
+                    parent_path = library_dir / li->second;
+            }
+            if (parent_path.empty()) {
+                // missing parent: stop rather than fail the whole load
+                BOOST_LOG_TRIVIAL(warning) << __FUNCTION__ << ": can not resolve inherits parent \"" << parent_name << "\" of " << current;
+                break;
+            }
             std::string parent_str = parent_path.string();
-            if (! boost::filesystem::exists(parent_path) || visited.count(parent_str))
-                break; // missing file or inherits cycle: stop rather than fail the whole load
+            if (visited.count(parent_str))
+                break; // inherits cycle
             visited.insert(parent_str);
             chain.push_back(parent_str);
             current = parent_str;

--- a/src/OrcaSlicer.cpp
+++ b/src/OrcaSlicer.cpp
@@ -24,6 +24,8 @@
 #include <iostream>
 #include <math.h>
 #include <csignal>
+#include <set>
+#include <algorithm>
 
 #if defined(__linux__) || defined(__LINUX__)
 #include <condition_variable>
@@ -1956,7 +1958,49 @@ int CLI::run(int argc, char **argv)
         }
     }
 
-    auto load_config_file = [config_substitution_rule](const std::string& file, DynamicPrintConfig& config, std::string& config_type,
+    // Orca CLI issue: `--load-settings`/`--load-filaments` load a single JSON file verbatim and
+    // never resolve its "inherits" chain, unlike the GUI's PresetBundle-backed preset selection.
+    // Any option absent from the leaf file therefore silently falls back to the option's hardcoded
+    // ConfigOptionDef default instead of the value defined by its ancestor profile(s) - producing
+    // wrong speeds/acceleration/etc. for any profile that relies on inheritance (which is the norm
+    // for BBL profiles: e.g. "0.20mm Standard @BBL A1M" -> "fdm_process_single_0.20" ->
+    // "fdm_process_single_common" -> "fdm_process_common"). Walk the chain ourselves, scoped to the
+    // same directory as the leaf file (this also avoids ambiguity between same-named base profiles
+    // that exist per-vendor, e.g. every vendor ships its own "fdm_process_common.json").
+    auto resolve_inherits_chain = [](const std::string& file) -> std::vector<std::string> {
+        std::vector<std::string> chain;
+        std::set<std::string> visited;
+        boost::filesystem::path dir = boost::filesystem::path(file).parent_path();
+        std::string current = file;
+        while (true) {
+            json j;
+            try {
+                boost::nowide::ifstream ifs(current);
+                if (! ifs.good())
+                    break;
+                ifs >> j;
+            } catch (...) {
+                break;
+            }
+            auto it = j.find(BBL_JSON_KEY_INHERITS);
+            if (it == j.end() || ! it->is_string())
+                break;
+            std::string parent_name = it->get<std::string>();
+            if (parent_name.empty())
+                break;
+            boost::filesystem::path parent_path = dir / (parent_name + ".json");
+            std::string parent_str = parent_path.string();
+            if (! boost::filesystem::exists(parent_path) || visited.count(parent_str))
+                break; // missing file or inherits cycle: stop rather than fail the whole load
+            visited.insert(parent_str);
+            chain.push_back(parent_str);
+            current = parent_str;
+        }
+        std::reverse(chain.begin(), chain.end()); // root-first, so callers can apply parents before the leaf
+        return chain;
+    };
+
+    auto load_config_file = [config_substitution_rule, resolve_inherits_chain](const std::string& file, DynamicPrintConfig& config, std::string& config_type,
                                 std::string& config_name, std::string& filament_id, std::string& config_from) {
         if (! boost::filesystem::exists(file)) {
             boost::nowide::cerr << __FUNCTION__<< ": can not find setting file: " << file << std::endl;
@@ -1964,6 +2008,15 @@ int CLI::run(int argc, char **argv)
         }
         ConfigSubstitutions config_substitutions;
         try {
+            for (const std::string& ancestor_file : resolve_inherits_chain(file)) {
+                std::map<std::string, std::string> ancestor_key_values;
+                std::string ancestor_reason;
+                BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << ":load ancestor setting file " << ancestor_file << " (inherited by " << file << ")" << std::endl;
+                config.load_from_json(ancestor_file, config_substitution_rule, ancestor_key_values, ancestor_reason);
+                if (! ancestor_reason.empty())
+                    BOOST_LOG_TRIVIAL(error) << __FUNCTION__ << ":Can not load ancestor config from file " << ancestor_file << "\n";
+            }
+
             BOOST_LOG_TRIVIAL(info) << __FUNCTION__<< ":load setting file "<< file << ", with rule "<< config_substitution_rule << std::endl;
             std::map<std::string, std::string> key_values;
             std::string reason;


### PR DESCRIPTION
Fixes #14718

## Problem

`CLI::run`'s `load_config_file` (`src/OrcaSlicer.cpp`) loads a JSON preset file passed to `--load-settings`/`--load-filaments` via `DynamicPrintConfig::load_from_json` directly, and never resolves the file's `"inherits"` field. The GUI resolves presets through `PresetBundle`'s in-memory collection instead, which does walk the chain — so the two paths diverge for any profile that relies on inheritance (the norm for BBL profiles, which chain 3-4 levels deep to avoid duplicating settings per printer/nozzle/quality).

Any config option missing from the leaf file silently falls back to that option's hardcoded `ConfigOptionDef` default (`PrintConfig.cpp`) instead of the value defined by its ancestor profile(s) — e.g. `inner_wall_speed` defaults to `60`, but the real BBL chain resolves it to `300` via `fdm_process_single_0.20`. This produces genuinely-slower gcode (confirmed by inspecting the actual `F` values in the output, not just a misreported time estimate) when slicing via CLI with the identical preset selection a GUI user would pick.

Full repro + analysis in #14718.

## Fix

`load_config_file` now walks `"inherits"` itself before loading the leaf file:
1. Read the leaf's `inherits` value from its raw JSON.
2. Look for `<same-directory>/<inherits-name>.json` — scoped to the same directory as the file being loaded, since every vendor ships same-named base profiles (e.g. `fdm_process_common.json` exists per-vendor with different content; resolving by bare name across all vendor directories would just trade one bug for another).
3. Recurse up until no further `inherits` or the named parent isn't found (missing/cycle → stop rather than fail the whole load).
4. Apply the resolved ancestors **root-first** into the same `DynamicPrintConfig`, then perform the existing leaf-file load last, so the leaf's own values still take precedence — this reuses the existing `load_from_json` call/option-setting machinery for each ancestor rather than introducing a second merge mechanism.

This is scoped to the CLI `--load-settings`/`--load-filaments` loading path only; GUI preset resolution (`PresetBundle`/`find_preset2`) is untouched.

## Testing

**I don't have a C++ toolchain available in the environment I used to write this patch, so this has not been locally compiled or run.** I'd very much appreciate a maintainer or CI verifying it builds and passes the existing test suite before merging — happy to iterate on review feedback.

What I did verify: I manually resolved the same inheritance chain in Python for the affected profiles (`0.20mm Standard @BBL A1M` → `fdm_process_single_0.20` → `fdm_process_single_common` → `fdm_process_common`, and the equivalent machine/filament chains) and confirmed the flattened values match the GUI's resolved output. I then re-sliced the same STL/plate via CLI using these pre-flattened files as a stand-in for what this code change should produce at runtime:

| | `--load-settings` as-is (main) | pre-flattened stand-in (this fix's intended output) | GUI (ground truth) |
|---|---|---|---|
| Base tray (172×173×24mm) | 17h32m | 3h23m | 3h17m |
| Lid + latch plate | (same bug) | 1h30m | 1h26m |

Feedrates in the resulting gcode also matched the profile's intended speeds (F12000/F18000 for 200/300mm/s walls, F42000 for 700mm/s travel) rather than the hardcoded-default speeds seen on `main`.

## Note

This may also be the root cause of the separately-reported #12890 (CLI-only `"Relative extruder addressing requires resetting..."` validation error) — a partially-resolved config (missing whatever companion fields the GUI's full chain resolution would have applied alongside `use_relative_e_distances`) is a plausible explanation for that inconsistency too, though I haven't specifically re-tested #12890's repro against this fix.