### PR TITLE
Fix access violation during travel generation before initial tool selection

### DIFF
--- a/src/libslic3r/GCodeWriter.cpp
+++ b/src/libslic3r/GCodeWriter.cpp
@@ -110,6 +110,7 @@ void GCodeWriter::set_extruders(std::vector<unsigned int> extruder_ids)
     m_filament_extruders.clear();
     //ORCA: Reset current extruder ID and clear pointers to prevent dangling pointers when extruders are recreated.
     m_curr_extruder_id = -1;
+    m_cached_extruder_idx = 0;
     std::fill(m_curr_filament_extruder.begin(), m_curr_filament_extruder.end(), nullptr);
     m_filament_extruders.reserve(extruder_ids.size());
     for (unsigned int extruder_id : extruder_ids)
@@ -617,6 +618,7 @@ std::string GCodeWriter::toolchange(unsigned int filament_id)
     assert(filament_extruder_iter != m_filament_extruders.end() && filament_extruder_iter->id() == filament_id);
     m_curr_extruder_id = filament_extruder_iter->extruder_id();
     m_curr_filament_extruder[m_curr_extruder_id] = &*filament_extruder_iter;
+    m_cached_extruder_idx = get_extruder_index(this->config, filament_id);
 
     // return the toolchange command
     // if we are running a single-extruder setup, just set the extruder and return nothing
@@ -658,7 +660,7 @@ std::string GCodeWriter::travel_to_xy(const Vec2d &point, const std::string &com
     GCodeG1Formatter w;
     w.emit_xy(point_on_plate);
     auto speed = m_is_first_layer
-        ? this->config.get_abs_value_at("initial_layer_travel_speed", get_extruder_index(this->config, filament()->id())) : this->config.travel_speed.get_at(get_extruder_index(this->config, filament()->id()));
+        ? this->config.get_abs_value_at("initial_layer_travel_speed", m_cached_extruder_idx) : this->config.travel_speed.get_at(m_cached_extruder_idx);
     w.emit_f(speed * 60.0);
     //BBS
     w.emit_comment(GCodeWriter::full_gcode_comment, comment);
@@ -744,7 +746,7 @@ std::string GCodeWriter::travel_to_xyz(const Vec3d &point, const std::string &co
         // BBS
     Vec3d dest_point = point;
     auto travel_speed =
-        m_is_first_layer ? this->config.get_abs_value_at("initial_layer_travel_speed", get_extruder_index(this->config, filament()->id())) : this->config.travel_speed.get_at(get_extruder_index(this->config, filament()->id()));
+        m_is_first_layer ? this->config.get_abs_value_at("initial_layer_travel_speed", m_cached_extruder_idx) : this->config.travel_speed.get_at(m_cached_extruder_idx);
     //BBS: a z_hop need to be handle when travel
     if (std::abs(m_to_lift) > EPSILON) {
         assert(std::abs(m_lifted) < EPSILON);
@@ -841,13 +843,13 @@ std::string GCodeWriter::travel_to_xyz(const Vec3d &point, const std::string &co
     {
         //force to move xy first then z after filament change
         w.emit_xy(Vec2d(point_on_plate.x(), point_on_plate.y()));
-        w.emit_f(this->config.travel_speed.get_at(get_extruder_index(this->config, filament()->id())) * 60.0);
+        w.emit_f(this->config.travel_speed.get_at(m_cached_extruder_idx) * 60.0);
         w.emit_comment(GCodeWriter::full_gcode_comment, comment);
         out_string = w.string() + _travel_to_z(point_on_plate.z(), comment);
     } else {
         GCodeG1Formatter w;
         w.emit_xyz(point_on_plate);
-        w.emit_f(this->config.travel_speed.get_at(get_extruder_index(this->config, filament()->id())) * 60.0);
+        w.emit_f(this->config.travel_speed.get_at(m_cached_extruder_idx) * 60.0);
         w.emit_comment(GCodeWriter::full_gcode_comment, comment);
         out_string = w.string();
     }
@@ -880,10 +882,10 @@ std::string GCodeWriter::_travel_to_z(double z, const std::string &comment)
 {
     m_pos(2) = z;
 
-    double speed = this->config.travel_speed_z.get_at(get_extruder_index(this->config, filament()->id()));
+    double speed = this->config.travel_speed_z.get_at(m_cached_extruder_idx);
     if (speed == 0.) {
-        speed = m_is_first_layer ? this->config.get_abs_value_at("initial_layer_travel_speed", get_extruder_index(this->config, filament()->id()))
-                                 : this->config.travel_speed.get_at(get_extruder_index(this->config, filament()->id()));
+        speed = m_is_first_layer ? this->config.get_abs_value_at("initial_layer_travel_speed", m_cached_extruder_idx)
+                                 : this->config.travel_speed.get_at(m_cached_extruder_idx);
     }
 
     GCodeG1Formatter w;
@@ -897,11 +899,11 @@ std::string GCodeWriter::_travel_to_z(double z, const std::string &comment)
 std::string GCodeWriter::_spiral_travel_to_z(double z, const Vec2d &ij_offset, const std::string &comment)
 {
     std::string output;
-    double speed = this->config.travel_speed_z.get_at(get_extruder_index(this->config, filament()->id()));
+    double speed = this->config.travel_speed_z.get_at(m_cached_extruder_idx);
 
     if (speed == 0.) {
-        speed = m_is_first_layer ? this->config.get_abs_value_at("initial_layer_travel_speed", get_extruder_index(this->config, filament()->id()))
-                                 : this->config.travel_speed.get_at(get_extruder_index(this->config, filament()->id()));
+        speed = m_is_first_layer ? this->config.get_abs_value_at("initial_layer_travel_speed", m_cached_extruder_idx)
+                                 : this->config.travel_speed.get_at(m_cached_extruder_idx);
     }
 
     if (!this->config.enable_arc_fitting) { // Orca: if arc fitting is disabled, approximate the arc with small linear segments
@@ -1261,6 +1263,7 @@ void GCodeWriter::init_extruder(unsigned int filament_id)
         assert(filament_extruder_iter != m_filament_extruders.end() && filament_extruder_iter->id() == filament_id);
         m_curr_extruder_id = filament_extruder_iter->extruder_id();
         m_curr_filament_extruder[m_curr_extruder_id] = &*filament_extruder_iter;
+        m_cached_extruder_idx = get_extruder_index(this->config, filament_id);
     }
 }
 

--- a/src/libslic3r/GCodeWriter.hpp
+++ b/src/libslic3r/GCodeWriter.hpp
@@ -19,6 +19,7 @@ public:
     GCodeWriter() :
         multiple_extruders(false), m_curr_filament_extruder(MAXIMUM_EXTRUDER_NUMBER, nullptr),
         m_curr_extruder_id (-1),
+        m_cached_extruder_idx(0),
         m_single_extruder_multi_material(false),
         m_last_acceleration(0), m_max_acceleration(0),m_last_travel_acceleration(0), m_max_travel_acceleration(0),
         m_last_jerk(0), m_max_jerk_x(0), m_max_jerk_y(0),
@@ -135,6 +136,8 @@ public:
     bool            m_single_extruder_multi_material;
     std::vector<Extruder*> m_curr_filament_extruder;
     int        m_curr_extruder_id;
+    // Motion uses the global/base process variant until a filament becomes active.
+    size_t     m_cached_extruder_idx;
     unsigned int              m_last_acceleration;
     unsigned int              m_last_travel_acceleration;
     std::vector<unsigned int> m_max_travel_acceleration;


### PR DESCRIPTION
## Description

This PR fixes an __access violation__ that could occur while generating G-code for certain multi-extruder, non-Bambu printer configurations.

The problem occurred when Orca needed to generate a travel movement __before the first filament had been initialized__. This can happen during the startup sequence, for example when an initial retraction schedules a Z lift.

Travel settings may vary between extruder variants. Previously, Orca determined which variant to use by checking the currently active filament each time a travel movement was generated. During startup, however, there may intentionally be no active filament yet. Attempting to retrieve it in that state __caused the access violation__.

## Changes

The G-code writer now keeps the currently applicable extruder index __cached__.

Before the first tool is selected, the cache points to the base process settings. This gives startup travel movements a valid and deterministic source for their speed settings without assuming that a particular filament or tool is already active.

When a filament is initialized or a toolchange completes, __the cached index is updated__ to the corresponding extruder variant. Subsequent travel movements therefore continue to use the correct extruder-specific settings.

The cached value is used for:

- XY travel
- Combined XYZ travel
- Vertical travel and Z lifts
- Spiral Z lifts
- First-layer travel-speed selection

This also __avoids__ repeatedly resolving the filament-to-extruder mapping for every travel movement during G-code generation.

## Behavior

Before tool selection:

- Travel movements use the base process settings.
- No filament or tool is assumed to be active.
- Startup G-code generation can __safely__ perform travel movements.

After tool selection:

- Travel movements use the settings associated with the active extruder variant.
- The cached selection is refreshed whenever the active filament changes.
- Existing per-extruder travel behavior is preserved.

## Reasoning

The change preserves the initial filament-loading behavior introduced for non-Bambu printers. __It does not initialize the first filament early__ or cause its startup sequence to be skipped, as that behavior previously caused other issues and was corrected in PR #11350.

## Screenshots (I know you love them ☺️)

| Before | After |
|---|---|
| “Active extruder? Anyone?” | “It’s in the cache.” |
| <img width="1171" height="721" alt="image" src="https://github.com/user-attachments/assets/4642004b-0f7a-4cf2-9c16-c98fe4562c49" /> | <img width="1120" height="749" alt="image" src="https://github.com/user-attachments/assets/83a64b33-7779-47fa-b005-cf53d8b68dd7" /> |

---

Fixes #14641