### PR TITLE
[Draft/RFC] FlashForge printer agent (open LAN implementation)

### DIFF
--- a/resources/profiles/Flashforge/machine/fdm_adventurer5m_common.json
+++ b/resources/profiles/Flashforge/machine/fdm_adventurer5m_common.json
@@ -4,6 +4,7 @@
 	"inherits": "fdm_flashforge_common",
 	"from": "system",
 	"instantiation": "false",
+	"printer_agent": "flashforge",
 	"gcode_flavor": "klipper",
 	"printable_area": [
 		"-110x-110",

--- a/resources/profiles/Flashforge/machine/fdm_adventurer5m_common.json
+++ b/resources/profiles/Flashforge/machine/fdm_adventurer5m_common.json
@@ -4,7 +4,6 @@
 	"inherits": "fdm_flashforge_common",
 	"from": "system",
 	"instantiation": "false",
-	"printer_agent": "flashforge",
 	"gcode_flavor": "klipper",
 	"printable_area": [
 		"-110x-110",

--- a/src/slic3r/CMakeLists.txt
+++ b/src/slic3r/CMakeLists.txt
@@ -677,6 +677,21 @@ set(SLIC3R_GUI_SOURCES
     Utils/FileTransferUtils.hpp
 )
 
+# FlashForge printer support: an OPEN implementation of IPrinterAgent that speaks
+# the classic FlashForge "M-code over TCP" LAN protocol directly (port 8899) via
+# boost::asio. No closed library. Both the source add and the factory
+# registration are gated on this option (via the ORCA_ENABLE_FLASHFORGE
+# compile definition).
+option(ORCA_ENABLE_FLASHFORGE "Enable FlashForge printer support" ON)
+if (ORCA_ENABLE_FLASHFORGE)
+    list(APPEND SLIC3R_GUI_SOURCES
+        Utils/FlashForgePrinterAgent.cpp
+        Utils/FlashForgePrinterAgent.hpp
+        Utils/FlashForge/FFLanProtocol.cpp
+        Utils/FlashForge/FFLanProtocol.hpp
+    )
+endif ()
+
 add_subdirectory(GUI/DeviceCore)
 add_subdirectory(GUI/DeviceTab)
 
@@ -747,6 +762,9 @@ else ()
     add_library(libslic3r_gui STATIC ${SLIC3R_GUI_SOURCES})
 endif ()
 target_include_directories(libslic3r_gui PRIVATE Utils ${CMAKE_CURRENT_BINARY_DIR})
+
+# Gate both the FlashForge sources and their registration in NetworkAgentFactory.
+target_compile_definitions(libslic3r_gui PRIVATE $<$<BOOL:${ORCA_ENABLE_FLASHFORGE}>:ORCA_ENABLE_FLASHFORGE>)
 
 if (WIN32)
     target_include_directories(libslic3r_gui SYSTEM PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../deps/WebView2/include)

--- a/src/slic3r/Utils/FlashForge/FFLanProtocol.cpp
+++ b/src/slic3r/Utils/FlashForge/FFLanProtocol.cpp
@@ -1,0 +1,414 @@
+#include "FFLanProtocol.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cstdlib>
+
+#include <boost/asio/buffer.hpp>
+#include <boost/asio/connect.hpp>
+#include <boost/asio/read.hpp>
+#include <boost/asio/write.hpp>
+#include <boost/algorithm/string.hpp>
+#include <boost/log/trivial.hpp>
+
+namespace Slic3r {
+
+namespace {
+
+using boost::asio::ip::tcp;
+
+// Returns true once the accumulated reply contains a terminating "ok" line.
+// FlashForge closes a response with a line that trims to exactly "ok" (some
+// firmwares append a token, e.g. "ok N"); everything before it is the payload.
+bool response_has_ok(const std::string& s)
+{
+    std::size_t pos = 0;
+    while (pos <= s.size()) {
+        const std::size_t nl   = s.find('\n', pos);
+        std::string       line = (nl == std::string::npos) ? s.substr(pos) : s.substr(pos, nl - pos);
+        boost::trim(line);
+        boost::to_lower(line);
+        if (line == "ok" || (line.rfind("ok", 0) == 0 && line.size() > 2 && line[2] == ' '))
+            return true;
+        if (nl == std::string::npos)
+            break;
+        pos = nl + 1;
+    }
+    return false;
+}
+
+// Extract the text following "<key>:" on the line that contains it, trimmed.
+std::string field_after(const std::string& body, const std::string& key)
+{
+    const std::size_t k = body.find(key);
+    if (k == std::string::npos)
+        return {};
+    std::size_t start = k + key.size();
+    std::size_t end   = body.find('\n', start);
+    std::string v     = (end == std::string::npos) ? body.substr(start) : body.substr(start, end - start);
+    boost::trim(v);
+    return v;
+}
+
+// Parse "<cur>/<tar>" temperature pair.
+void parse_temp_pair(const std::string& token, double& cur, double& tar)
+{
+    const std::size_t slash = token.find('/');
+    if (slash == std::string::npos)
+        return;
+    try {
+        cur = std::stod(token.substr(0, slash));
+        tar = std::stod(token.substr(slash + 1));
+    } catch (const std::exception&) {
+    }
+}
+
+} // namespace
+
+FFLanClient::FFLanClient() : m_socket(m_io) {}
+
+FFLanClient::~FFLanClient() { close(); }
+
+bool FFLanClient::is_connected() const
+{
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
+    return m_connected && m_socket.is_open();
+}
+
+void FFLanClient::close()
+{
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
+    close_locked();
+}
+
+void FFLanClient::close_locked()
+{
+    boost::system::error_code ignore;
+    if (m_socket.is_open()) {
+        m_socket.shutdown(tcp::socket::shutdown_both, ignore);
+        m_socket.close(ignore);
+    }
+    m_connected = false;
+}
+
+bool FFLanClient::run_until(boost::system::error_code& op_ec, std::chrono::steady_clock::time_point deadline)
+{
+    m_io.restart();
+    while (op_ec == boost::asio::error::would_block) {
+        const auto now = std::chrono::steady_clock::now();
+        if (now >= deadline)
+            break;
+        const auto slice = std::chrono::duration_cast<std::chrono::milliseconds>(deadline - now);
+        m_io.run_for(std::min<std::chrono::milliseconds>(slice, std::chrono::milliseconds(100)));
+    }
+    if (op_ec == boost::asio::error::would_block) {
+        // Deadline passed with the operation still pending: cancel it, drain the
+        // resulting operation_aborted handler, and report a timeout.
+        boost::system::error_code ignore;
+        m_socket.cancel(ignore);
+        m_io.restart();
+        m_io.run();
+        if (op_ec == boost::asio::error::would_block)
+            op_ec = boost::asio::error::timed_out;
+        return false;
+    }
+    return !op_ec;
+}
+
+bool FFLanClient::connect(const std::string& ip, unsigned short port, int timeout_ms)
+{
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
+    close_locked();
+
+    try {
+        // dev_ip is a numeric address in every OrcaSlicer LAN flow; if a hostname
+        // is ever passed, make_address throws and we report a clean failure.
+        tcp::endpoint ep(boost::asio::ip::make_address(ip), port);
+
+        boost::system::error_code op_ec = boost::asio::error::would_block;
+        m_socket.async_connect(ep, [&op_ec](const boost::system::error_code& ec) { op_ec = ec; });
+
+        const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout_ms);
+        if (!run_until(op_ec, deadline) || !m_socket.is_open()) {
+            BOOST_LOG_TRIVIAL(warning) << "FFLanClient: connect to " << ip << ":" << port
+                                       << " failed: " << op_ec.message();
+            close_locked();
+            return false;
+        }
+
+        boost::system::error_code no_delay_ec;
+        m_socket.set_option(tcp::no_delay(true), no_delay_ec);
+
+        m_connected = true;
+        m_ip        = ip;
+        m_port      = port;
+        return true;
+    } catch (const std::exception& e) {
+        BOOST_LOG_TRIVIAL(warning) << "FFLanClient: connect exception: " << e.what();
+        close_locked();
+        return false;
+    }
+}
+
+bool FFLanClient::write_all_locked(const char* data, std::size_t len, int timeout_ms)
+{
+    if (!m_connected)
+        return false;
+    boost::system::error_code op_ec = boost::asio::error::would_block;
+    boost::asio::async_write(m_socket, boost::asio::buffer(data, len),
+                             [&op_ec](const boost::system::error_code& ec, std::size_t) { op_ec = ec; });
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout_ms);
+    if (!run_until(op_ec, deadline)) {
+        if (op_ec != boost::asio::error::timed_out)
+            close_locked(); // hard socket error: drop the connection
+        return false;
+    }
+    return true;
+}
+
+bool FFLanClient::read_until_ok_locked(std::string& out, int timeout_ms)
+{
+    out.clear();
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout_ms);
+    std::array<char, 4096> buf;
+    for (;;) {
+        if (std::chrono::steady_clock::now() >= deadline)
+            return false;
+        boost::system::error_code op_ec = boost::asio::error::would_block;
+        std::size_t               nread = 0;
+        m_socket.async_read_some(boost::asio::buffer(buf),
+                                 [&op_ec, &nread](const boost::system::error_code& ec, std::size_t n) {
+                                     op_ec = ec;
+                                     nread = n;
+                                 });
+        if (!run_until(op_ec, deadline)) {
+            // eof / connection_reset means the printer dropped us: forget the
+            // socket so the next call reconnects. A plain timeout keeps it.
+            if (op_ec != boost::asio::error::timed_out && op_ec != boost::asio::error::operation_aborted)
+                close_locked();
+            return false;
+        }
+        if (nread > 0) {
+            out.append(buf.data(), nread);
+            if (response_has_ok(out))
+                return true;
+        }
+    }
+}
+
+bool FFLanClient::send_command_locked(const std::string& cmd, std::string& response, int timeout_ms)
+{
+    if (!m_connected)
+        return false;
+    const std::string wire = "~" + cmd + "\r\n";
+    if (!write_all_locked(wire.data(), wire.size(), timeout_ms))
+        return false;
+    return read_until_ok_locked(response, timeout_ms);
+}
+
+bool FFLanClient::send_command(const std::string& cmd, std::string& response, int timeout_ms)
+{
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
+    return send_command_locked(cmd, response, timeout_ms);
+}
+
+// ---------------------------------------------------------------------------
+// Session control
+// ---------------------------------------------------------------------------
+
+bool FFLanClient::control()
+{
+    std::string resp;
+    return send_command("M601 S1", resp, CMD_TIMEOUT_MS);
+}
+
+bool FFLanClient::release()
+{
+    std::string resp;
+    return send_command("M602", resp, CMD_TIMEOUT_MS);
+}
+
+// ---------------------------------------------------------------------------
+// Queries
+// ---------------------------------------------------------------------------
+
+bool FFLanClient::get_machine_info(MachineInfo& out)
+{
+    std::string body;
+    if (!send_command("M115", body, CMD_TIMEOUT_MS))
+        return false;
+
+    out.machine_type  = field_after(body, "Machine Type:");
+    out.machine_name  = field_after(body, "Machine Name:");
+    out.firmware      = field_after(body, "Firmware:");
+    out.serial_number = field_after(body, "SN:");
+    out.mac_address   = field_after(body, "Mac Address:");
+
+    // "X: 220 Y: 220 Z: 220" appears on a single line.
+    try {
+        const std::string x = field_after(body, "X:");
+        const std::string y = field_after(body, "Y:");
+        const std::string z = field_after(body, "Z:");
+        if (!x.empty()) out.dim_x = std::atoi(x.c_str());
+        if (!y.empty()) out.dim_y = std::atoi(y.c_str());
+        if (!z.empty()) out.dim_z = std::atoi(z.c_str());
+    } catch (const std::exception&) {
+    }
+    const std::string tc = field_after(body, "Tool Count:");
+    if (!tc.empty())
+        out.tool_count = std::atoi(tc.c_str());
+    return true;
+}
+
+bool FFLanClient::get_status(StatusInfo& out)
+{
+    std::string body;
+    if (!send_command("M119", body, CMD_TIMEOUT_MS))
+        return false;
+
+    out.machine_status = field_after(body, "MachineStatus:");
+    out.move_mode      = field_after(body, "MoveMode:");
+    out.current_file   = field_after(body, "CurrentFile:");
+    const std::string led = field_after(body, "LED:");
+    if (!led.empty())
+        out.led = std::atoi(led.c_str());
+    return true;
+}
+
+bool FFLanClient::get_temps(Temps& out)
+{
+    std::string body;
+    if (!send_command("M105", body, CMD_TIMEOUT_MS))
+        return false;
+
+    // "T0:29.9/0.0 T1:0.0/0.0 B:27.6/0.0"
+    const std::string t0 = field_after(body, "T0:");
+    const std::string t1 = field_after(body, "T1:");
+    const std::string b  = field_after(body, "B:");
+    // field_after returns the rest of the line; keep only the first token.
+    auto first_token = [](std::string s) {
+        const std::size_t sp = s.find(' ');
+        return sp == std::string::npos ? s : s.substr(0, sp);
+    };
+    if (!t0.empty()) parse_temp_pair(first_token(t0), out.t0_current, out.t0_target);
+    if (!t1.empty()) parse_temp_pair(first_token(t1), out.t1_current, out.t1_target);
+    if (!b.empty())  parse_temp_pair(first_token(b),  out.bed_current, out.bed_target);
+    return true;
+}
+
+bool FFLanClient::get_progress(Progress& out)
+{
+    std::string body;
+    if (!send_command("M27", body, CMD_TIMEOUT_MS))
+        return false;
+
+    // "SD printing byte 0/100"
+    const std::size_t byte_kw = body.find("byte");
+    if (byte_kw != std::string::npos) {
+        std::string rest = body.substr(byte_kw + 4);
+        boost::trim(rest);
+        const std::size_t slash = rest.find('/');
+        if (slash != std::string::npos) {
+            try {
+                out.byte_current = std::atoll(rest.substr(0, slash).c_str());
+                std::string total = rest.substr(slash + 1);
+                out.byte_total    = std::atoll(total.c_str());
+            } catch (const std::exception&) {
+            }
+        }
+    }
+    // "Layer: 0/0"
+    const std::string layer = field_after(body, "Layer:");
+    if (!layer.empty()) {
+        const std::size_t slash = layer.find('/');
+        if (slash != std::string::npos) {
+            out.layer_current = std::atoi(layer.substr(0, slash).c_str());
+            out.layer_total   = std::atoi(layer.substr(slash + 1).c_str());
+        }
+    }
+    if (out.byte_total > 0)
+        out.percent = static_cast<int>((out.byte_current * 100) / out.byte_total);
+    return true;
+}
+
+// ---------------------------------------------------------------------------
+// Job control
+// ---------------------------------------------------------------------------
+
+bool FFLanClient::upload_gcode(const std::string& remote_name, const std::string& data)
+{
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
+    if (!m_connected)
+        return false;
+
+    const std::string path = "0:/user/" + remote_name;
+
+    // 1) Announce the write and the exact byte count.
+    std::string resp;
+    const std::string cmd = "M28 " + std::to_string(data.size()) + " " + path;
+    if (!send_command_locked(cmd, resp, CMD_TIMEOUT_MS)) {
+        BOOST_LOG_TRIVIAL(error) << "FFLanClient: M28 failed for " << path;
+        return false;
+    }
+
+    // 2) Stream exactly <size> raw gcode bytes on the same socket. Scale the
+    //    timeout with the payload size (min 60s) so large files can complete.
+    const int upload_timeout = std::max<int>(UPLOAD_TIMEOUT_MS,
+                                             static_cast<int>(data.size() / 1024)); // ~1ms/KB floor
+    if (!write_all_locked(data.data(), data.size(), upload_timeout)) {
+        BOOST_LOG_TRIVIAL(error) << "FFLanClient: streaming gcode body failed for " << path;
+        return false;
+    }
+
+    // 3) Close the file.
+    if (!send_command_locked("M29", resp, CMD_TIMEOUT_MS)) {
+        BOOST_LOG_TRIVIAL(error) << "FFLanClient: M29 (save) failed for " << path;
+        return false;
+    }
+    return true;
+}
+
+bool FFLanClient::start_print(const std::string& remote_name)
+{
+    std::string resp;
+    const std::string cmd = "M23 0:/user/" + remote_name;
+    return send_command(cmd, resp, CMD_TIMEOUT_MS);
+}
+
+bool FFLanClient::stop()
+{
+    // NOTE: on AD5M Pro firmware v5.1.8, M26 did not reliably abort a malformed
+    // job. It is still the documented stop command and is issued best-effort.
+    std::string resp;
+    return send_command("M26", resp, CMD_TIMEOUT_MS);
+}
+
+// ---------------------------------------------------------------------------
+// Setters
+// ---------------------------------------------------------------------------
+
+bool FFLanClient::set_extruder_temp(int celsius)
+{
+    std::string resp;
+    return send_command("M104 S" + std::to_string(celsius), resp, CMD_TIMEOUT_MS);
+}
+
+bool FFLanClient::set_bed_temp(int celsius)
+{
+    std::string resp;
+    return send_command("M140 S" + std::to_string(celsius), resp, CMD_TIMEOUT_MS);
+}
+
+bool FFLanClient::set_fan(bool on)
+{
+    std::string resp;
+    return send_command(on ? "M106" : "M107", resp, CMD_TIMEOUT_MS);
+}
+
+bool FFLanClient::set_led(bool on)
+{
+    std::string resp;
+    return send_command(on ? "M146 r255 g255 b255" : "M146 r0 g0 b0", resp, CMD_TIMEOUT_MS);
+}
+
+} // namespace Slic3r

--- a/src/slic3r/Utils/FlashForge/FFLanProtocol.hpp
+++ b/src/slic3r/Utils/FlashForge/FFLanProtocol.hpp
@@ -1,0 +1,151 @@
+#ifndef __FF_LAN_PROTOCOL_HPP__
+#define __FF_LAN_PROTOCOL_HPP__
+
+#include <chrono>
+#include <mutex>
+#include <string>
+
+#include <boost/asio/io_context.hpp>
+#include <boost/asio/ip/tcp.hpp>
+
+namespace Slic3r {
+
+// ============================================================================
+// FFLanClient - open implementation of the classic FlashForge LAN protocol.
+//
+// FlashForge printers (Adventurer / Guider / Creator families, and the
+// Adventurer 5M / 5M Pro this was verified against, firmware v5.1.8) expose a
+// plain-TCP M-code control channel on port 8899. Each request is an ASCII line
+//
+//     ~<CMD>\r\n
+//
+// and the printer answers with one or more ASCII lines terminated by a line
+// that is exactly "ok". This class speaks that protocol directly over
+// boost::asio (already an OrcaSlicer dependency) with NO closed library.
+//
+// The protocol below was confirmed working on real hardware; see the per-method
+// comments for the exact command/response.
+//
+// Thread-safety: every public method takes an internal recursive mutex, so the
+// status-poll thread and the print/command paths can share a single connected
+// client. Only one request is ever in flight on the socket at a time.
+// ============================================================================
+class FFLanClient
+{
+public:
+    // Default control port for the FlashForge LAN M-code channel.
+    static constexpr unsigned short DEFAULT_PORT = 8899;
+
+    // Parsed ~M115 machine information.
+    struct MachineInfo
+    {
+        std::string machine_type;   // "Flashforge Adventurer 5M Pro"
+        std::string machine_name;   // "FF5M"
+        std::string firmware;       // "v5.1.8"
+        std::string serial_number;  // "SN..."
+        std::string mac_address;
+        int         dim_x = 0;      // build volume (mm)
+        int         dim_y = 0;
+        int         dim_z = 0;
+        int         tool_count = 0;
+    };
+
+    // Parsed ~M119 status snapshot.
+    struct StatusInfo
+    {
+        std::string machine_status; // READY | BUILDING_FROM_SD | BUSY | PAUSED
+        std::string move_mode;      // READY | HOMING | MOVING
+        std::string current_file;
+        int         led = -1;       // -1 = unknown
+    };
+
+    // Parsed ~M105 temperatures (current/target, degrees C).
+    struct Temps
+    {
+        double t0_current = 0.0, t0_target = 0.0; // tool 0
+        double t1_current = 0.0, t1_target = 0.0; // tool 1 (if present)
+        double bed_current = 0.0, bed_target = 0.0;
+    };
+
+    // Parsed ~M27 progress.
+    struct Progress
+    {
+        long long byte_current = 0;
+        long long byte_total   = 0;
+        int       layer_current = 0;
+        int       layer_total   = 0;
+        int       percent       = 0; // derived from byte_current/byte_total
+    };
+
+    FFLanClient();
+    ~FFLanClient();
+
+    FFLanClient(const FFLanClient&)            = delete;
+    FFLanClient& operator=(const FFLanClient&) = delete;
+
+    // Open a TCP connection to <ip>:<port>. Returns false on timeout / failure.
+    bool connect(const std::string& ip, unsigned short port = DEFAULT_PORT, int timeout_ms = 5000);
+    void close();
+    bool is_connected() const;
+
+    std::string ip() const { return m_ip; }
+    unsigned short port() const { return m_port; }
+
+    // --- session control -----------------------------------------------------
+    bool control();  // ~M601 S1  -> "Control Success ..."
+    bool release();  // ~M602
+
+    // --- queries -------------------------------------------------------------
+    bool get_machine_info(MachineInfo& out); // ~M115
+    bool get_status(StatusInfo& out);        // ~M119
+    bool get_temps(Temps& out);              // ~M105
+    bool get_progress(Progress& out);        // ~M27
+
+    // --- job control ---------------------------------------------------------
+    // Upload gcode bytes and store them as 0:/user/<remote_name>:
+    //   ~M28 <size> 0:/user/<remote_name>  -> "Writing to file: ..."
+    //   <size raw bytes streamed on the same socket>
+    //   ~M29                               -> "Done saving file."
+    // remote_name should already include the .gcode extension.
+    bool upload_gcode(const std::string& remote_name, const std::string& data);
+
+    bool start_print(const std::string& remote_name); // ~M23 0:/user/<remote_name>
+    bool stop();                                       // ~M26
+
+    // --- setters (standard M-codes) ------------------------------------------
+    bool set_extruder_temp(int celsius); // ~M104 S<t>
+    bool set_bed_temp(int celsius);      // ~M140 S<t>
+    bool set_fan(bool on);               // ~M106 / ~M107
+    bool set_led(bool on);               // ~M146 r.. g.. b..
+
+    // Low-level: write "~<cmd>\r\n" and read until an "ok" line. Fills response
+    // with the full raw reply (without the trailing "ok"). Returns false on
+    // timeout / socket error.
+    bool send_command(const std::string& cmd, std::string& response, int timeout_ms = 5000);
+
+private:
+    // Variants that assume m_mutex is already held.
+    bool send_command_locked(const std::string& cmd, std::string& response, int timeout_ms);
+    bool write_all_locked(const char* data, std::size_t len, int timeout_ms);
+    bool read_until_ok_locked(std::string& out, int timeout_ms);
+    void close_locked();
+
+    // Pump the io_context until op_ec resolves (handler ran) or the deadline
+    // passes. Mirrors the run_for loop used elsewhere in the tree (TCPConsole).
+    bool run_until(boost::system::error_code& op_ec, std::chrono::steady_clock::time_point deadline);
+
+    mutable std::recursive_mutex   m_mutex;
+    boost::asio::io_context        m_io;
+    boost::asio::ip::tcp::socket   m_socket;
+    bool                           m_connected = false;
+    std::string                    m_ip;
+    unsigned short                 m_port = DEFAULT_PORT;
+
+    // Per-request timeouts (ms). Uploads scale with payload size.
+    static constexpr int CMD_TIMEOUT_MS      = 5000;
+    static constexpr int UPLOAD_TIMEOUT_MS   = 60000;
+};
+
+} // namespace Slic3r
+
+#endif // __FF_LAN_PROTOCOL_HPP__

--- a/src/slic3r/Utils/FlashForgePrinterAgent.cpp
+++ b/src/slic3r/Utils/FlashForgePrinterAgent.cpp
@@ -1,0 +1,748 @@
+#include "FlashForgePrinterAgent.hpp"
+#include "FlashForge/FFLanProtocol.hpp"
+
+#include <algorithm>
+#include <array>
+#include <chrono>
+#include <fstream>
+#include <set>
+#include <thread>
+#include <vector>
+
+#include <boost/algorithm/string.hpp>
+#include <boost/asio/io_context.hpp>
+#include <boost/asio/ip/udp.hpp>
+#include <boost/filesystem.hpp>
+#include <boost/log/trivial.hpp>
+#include <nlohmann/json.hpp>
+
+namespace Slic3r {
+
+namespace {
+
+constexpr const char* FLASHFORGE_AGENT_VERSION = "1.0.0 (LAN/8899)";
+
+// Poll cadence for the background status thread.
+constexpr int  POLL_INTERVAL_MS = 2000;
+constexpr int  POLL_SLICE_MS    = 100; // wake granularity so stop() is responsive
+
+// FlashForge LAN discovery: broadcast a fixed 20-byte probe to UDP port 48899;
+// responders reply with a fixed-layout datagram carrying the printer name (at
+// offset 0) and serial number (at offset 0x92). This mirrors the verified probe
+// already used by Slic3r::Flashforge. Discovery is best-effort; manual-IP add
+// (dev_ip supplied by the PhysicalPrinter flow) remains the primary path.
+constexpr unsigned short FF_DISCOVERY_PORT = 48899;
+
+const std::array<unsigned char, 20> FF_DISCOVERY_MESSAGE = {
+    0x77, 0x77, 0x77, 0x2e, 0x75, 0x73, 0x72, 0x22,
+    0x65, 0x36, 0xc0, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00};
+
+// Extract a NUL-terminated ASCII field of at most len bytes at offset off.
+std::string ff_field(const unsigned char* data, std::size_t size, std::size_t off, std::size_t len)
+{
+    if (off >= size)
+        return {};
+    len = std::min(len, size - off);
+    std::string s(reinterpret_cast<const char*>(data + off), len);
+    const auto nul = s.find('\0');
+    if (nul != std::string::npos)
+        s.resize(nul);
+    boost::trim(s);
+    return s;
+}
+
+// Read a whole file into memory. Returns false if it cannot be opened.
+bool read_file_bytes(const std::string& path, std::string& out)
+{
+    std::ifstream f(path, std::ios::binary);
+    if (!f)
+        return false;
+    f.seekg(0, std::ios::end);
+    const std::streamoff len = f.tellg();
+    f.seekg(0, std::ios::beg);
+    if (len > 0)
+        out.resize(static_cast<std::size_t>(len));
+    if (len > 0)
+        f.read(&out[0], len);
+    return static_cast<bool>(f) || f.eof();
+}
+
+// Map a FlashForge MachineStatus string to a Bambu-style gcode_state, so the
+// Device tab (which parses the Bambu "print" JSON shape) can render it.
+std::string map_gcode_state(const std::string& ff_status)
+{
+    if (ff_status == "READY")            return "IDLE";
+    if (ff_status == "BUILDING_FROM_SD") return "RUNNING";
+    if (ff_status == "PAUSED")           return "PAUSE";
+    if (ff_status == "BUSY")             return "PREPARE";
+    return "IDLE";
+}
+
+int map_print_stage(const std::string& ff_status)
+{
+    if (ff_status == "BUILDING_FROM_SD") return 1; // printing
+    if (ff_status == "PAUSED")           return 2; // paused
+    return 0;
+}
+
+// Ensure a destination name that FlashForge accepts (basename + .gcode).
+std::string remote_gcode_name(const PrintParams& params)
+{
+    namespace fs = boost::filesystem;
+    std::string name;
+    if (!params.dst_file.empty())
+        name = fs::path(params.dst_file).filename().string();
+    else if (!params.task_name.empty())
+        name = params.task_name;
+    else if (!params.project_name.empty())
+        name = params.project_name;
+    else if (!params.filename.empty())
+        name = fs::path(params.filename).filename().string();
+    if (name.empty())
+        name = "orca_print";
+    if (!boost::iends_with(name, ".gcode") && !boost::iends_with(name, ".gx"))
+        name += ".gcode";
+    return name;
+}
+
+// Local gcode file to send: prefer the explicit sliced output (dst_file), else
+// the source filename.
+std::string local_gcode_path(const PrintParams& params)
+{
+    if (!params.dst_file.empty())
+        return params.dst_file;
+    return params.filename;
+}
+
+} // namespace
+
+// ============================================================================
+// Construction
+// ============================================================================
+
+FlashForgePrinterAgent::FlashForgePrinterAgent() = default;
+
+FlashForgePrinterAgent::~FlashForgePrinterAgent()
+{
+    stop_status_poll();
+    std::shared_ptr<FFLanClient> client;
+    {
+        std::lock_guard<std::mutex> lock(m_conn_mutex);
+        client = std::move(m_client);
+    }
+    if (client)
+        client->close();
+}
+
+void FlashForgePrinterAgent::set_cloud_agent(std::shared_ptr<ICloudServiceAgent> cloud)
+{
+    m_cloud_agent = std::move(cloud);
+    // LAN-only agent: the cloud handle is retained for interface parity but not
+    // used. TODO(cloud): FlashForge WAN would need its own clientId/accessToken.
+}
+
+// ============================================================================
+// Callback marshalling (mirror MoonrakerPrinterAgent)
+// ============================================================================
+
+void FlashForgePrinterAgent::dispatch_local_connect(int state, const std::string& dev_id, const std::string& msg)
+{
+    OnLocalConnectedFn fn;
+    QueueOnMainFn      queue;
+    {
+        std::lock_guard<std::mutex> lock(m_cb_mutex);
+        fn    = m_on_local_connect_fn;
+        queue = m_queue_on_main_fn;
+    }
+    if (!fn)
+        return;
+    auto call = [state, dev_id, msg, fn]() { fn(state, dev_id, msg); };
+    if (queue) queue(call); else call();
+}
+
+void FlashForgePrinterAgent::dispatch_printer_connected(const std::string& dev_id)
+{
+    OnPrinterConnectedFn fn;
+    QueueOnMainFn        queue;
+    {
+        std::lock_guard<std::mutex> lock(m_cb_mutex);
+        fn    = m_on_printer_connected_fn;
+        queue = m_queue_on_main_fn;
+    }
+    if (!fn)
+        return;
+    auto call = [dev_id, fn]() { fn(dev_id); };
+    if (queue) queue(call); else call();
+}
+
+void FlashForgePrinterAgent::dispatch_message(const std::string& dev_id, const std::string& payload)
+{
+    OnMessageFn   local_fn;
+    OnMessageFn   cloud_fn;
+    QueueOnMainFn queue;
+    {
+        std::lock_guard<std::mutex> lock(m_cb_mutex);
+        local_fn = m_on_local_message_fn;
+        cloud_fn = m_on_message_fn;
+        queue    = m_queue_on_main_fn;
+    }
+    if (!local_fn && !cloud_fn)
+        return;
+    auto call = [dev_id, payload, local_fn, cloud_fn]() {
+        if (local_fn) { local_fn(dev_id, payload); return; }
+        if (cloud_fn) cloud_fn(dev_id, payload);
+    };
+    if (queue) queue(call); else call();
+}
+
+// ============================================================================
+// Communication
+// ============================================================================
+
+int FlashForgePrinterAgent::send_message(std::string dev_id, std::string json_str, int qos, int flag)
+{
+    (void) dev_id; (void) json_str; (void) qos; (void) flag;
+    // Cloud relay: no LAN equivalent.
+    // TODO(cloud): implement over FlashForge WAN once a session exists.
+    return BAMBU_NETWORK_ERR_SEND_MSG_FAILED;
+}
+
+int FlashForgePrinterAgent::connect_printer(std::string dev_id, std::string dev_ip, std::string username,
+                                            std::string password, bool use_ssl)
+{
+    (void) username; (void) password; (void) use_ssl; // FlashForge LAN has no auth/TLS.
+    if (dev_ip.empty())
+        return BAMBU_NETWORK_ERR_INVALID_HANDLE;
+
+    // Tear down any previous connection first.
+    stop_status_poll();
+
+    auto client = std::make_shared<FFLanClient>();
+    if (!client->connect(dev_ip, FFLanClient::DEFAULT_PORT)) {
+        BOOST_LOG_TRIVIAL(error) << "FlashForgePrinterAgent: TCP connect to " << dev_ip << " failed";
+        dispatch_local_connect(ConnectStatusFailed, dev_id, "connect_failed");
+        return BAMBU_NETWORK_ERR_CONNECT_FAILED;
+    }
+    // Take control of the printer (~M601 S1). Non-fatal if it fails on some
+    // firmwares, but log it.
+    if (!client->control())
+        BOOST_LOG_TRIVIAL(warning) << "FlashForgePrinterAgent: ~M601 control handshake did not confirm";
+
+    {
+        std::lock_guard<std::mutex> lock(m_conn_mutex);
+        m_client = client;
+        m_dev_id = dev_id;
+        m_dev_ip = dev_ip;
+        if (m_selected_machine.empty())
+            m_selected_machine = dev_id;
+    }
+
+    dispatch_local_connect(ConnectStatusOk, dev_id, "0");
+    dispatch_printer_connected(dev_id);
+    start_status_poll(dev_id);
+    return BAMBU_NETWORK_SUCCESS;
+}
+
+int FlashForgePrinterAgent::disconnect_printer()
+{
+    stop_status_poll();
+
+    std::shared_ptr<FFLanClient> client;
+    {
+        std::lock_guard<std::mutex> lock(m_conn_mutex);
+        client = std::move(m_client);
+        m_dev_id.clear();
+        m_dev_ip.clear();
+    }
+    if (client) {
+        client->release(); // ~M602 relinquish control
+        client->close();
+    }
+    return BAMBU_NETWORK_SUCCESS;
+}
+
+int FlashForgePrinterAgent::send_message_to_printer(std::string dev_id, std::string json_str, int qos, int flag)
+{
+    (void) qos; (void) flag; (void) dev_id;
+    // Best-effort bridge: accept a {"cmd":"<raw M-code>"} JSON and forward it.
+    std::shared_ptr<FFLanClient> client;
+    {
+        std::lock_guard<std::mutex> lock(m_conn_mutex);
+        client = m_client;
+    }
+    if (!client || !client->is_connected())
+        return BAMBU_NETWORK_ERR_INVALID_HANDLE;
+
+    try {
+        auto j = nlohmann::json::parse(json_str, nullptr, false);
+        if (!j.is_discarded() && j.contains("cmd") && j["cmd"].is_string()) {
+            std::string resp;
+            return client->send_command(j["cmd"].get<std::string>(), resp)
+                       ? BAMBU_NETWORK_SUCCESS
+                       : BAMBU_NETWORK_ERR_SEND_MSG_FAILED;
+        }
+    } catch (const std::exception&) {
+    }
+    // TODO(cloud): full JSON->M-code command dispatcher for the Device tab.
+    return BAMBU_NETWORK_ERR_SEND_MSG_FAILED;
+}
+
+// ============================================================================
+// Certificates (no concept in the FlashForge LAN protocol)
+// ============================================================================
+
+int  FlashForgePrinterAgent::check_cert() { return BAMBU_NETWORK_SUCCESS; }
+void FlashForgePrinterAgent::install_device_cert(std::string dev_id, bool lan_only)
+{
+    (void) dev_id; (void) lan_only;
+}
+
+// ============================================================================
+// Discovery (best-effort UDP probe; manual-IP add is the primary path)
+// ============================================================================
+
+bool FlashForgePrinterAgent::start_discovery(bool start, bool sending)
+{
+    (void) sending;
+    if (!start)
+        return true;
+
+    // 1) Re-announce an already-connected device so the Device tab keeps it.
+    OnMsgArrivedFn ssdp_fn;
+    std::string    dev_id, dev_ip;
+    {
+        std::lock_guard<std::mutex> cb(m_cb_mutex);
+        ssdp_fn = m_on_ssdp_msg_fn;
+    }
+    {
+        std::lock_guard<std::mutex> lock(m_conn_mutex);
+        dev_id = m_dev_id;
+        dev_ip = m_dev_ip;
+    }
+    if (ssdp_fn && !dev_id.empty() && !dev_ip.empty()) {
+        nlohmann::json j;
+        j["dev_id"]        = dev_id;
+        j["dev_name"]      = dev_id;
+        j["dev_ip"]        = dev_ip;
+        j["connect_type"]  = "lan";
+        j["bind_state"]    = "free";
+        j["sec_link"]      = "secure";
+        j["ssdp_version"]  = "v1";
+        j["printer_agent"] = FLASHFORGE_PRINTER_AGENT_ID;
+        ssdp_fn(j.dump());
+    }
+
+    // 2) Best-effort local-subnet UDP broadcast (port 48899, verified probe).
+    //    Each responder's datagram carries the printer name and serial directly.
+    //    Runs detached; never blocks the caller.
+    std::thread([ssdp_fn]() {
+        if (!ssdp_fn)
+            return;
+        try {
+            boost::asio::io_context      io;
+            boost::asio::ip::udp::socket sock(io, boost::asio::ip::udp::endpoint(boost::asio::ip::udp::v4(), 0));
+            sock.set_option(boost::asio::socket_base::broadcast(true));
+
+            boost::asio::ip::udp::endpoint bcast(boost::asio::ip::address_v4::broadcast(), FF_DISCOVERY_PORT);
+            boost::system::error_code      ec;
+            sock.send_to(boost::asio::buffer(FF_DISCOVERY_MESSAGE), bcast, 0, ec);
+
+            // Collect responses for ~800ms, emitting each parsed printer once.
+            std::set<std::string> seen;
+            const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(800);
+            while (std::chrono::steady_clock::now() < deadline) {
+                boost::system::error_code      recv_ec = boost::asio::error::would_block;
+                std::array<unsigned char, 512> buf{};
+                boost::asio::ip::udp::endpoint from;
+                std::size_t                    n = 0;
+                sock.async_receive_from(boost::asio::buffer(buf), from,
+                                        [&recv_ec, &n](const boost::system::error_code& e, std::size_t got) {
+                                            recv_ec = e;
+                                            n       = got;
+                                        });
+                io.restart();
+                io.run_for(std::chrono::milliseconds(150));
+                if (recv_ec == boost::asio::error::would_block) {
+                    sock.cancel(recv_ec);
+                    io.restart();
+                    io.run();
+                    continue;
+                }
+                if (recv_ec || n < 0xC4)
+                    continue;
+
+                const std::string ip     = from.address().to_string();
+                const std::string name   = ff_field(buf.data(), n, 0x00, 32);
+                const std::string serial = ff_field(buf.data(), n, 0x92, 32);
+                if (name.empty() && serial.empty())
+                    continue;
+                const std::string dev_id = serial.empty() ? ip : serial;
+                if (!seen.insert(dev_id).second)
+                    continue;
+
+                nlohmann::json j;
+                j["dev_id"]        = dev_id;
+                j["dev_name"]      = name.empty() ? dev_id : name;
+                j["dev_ip"]        = ip;
+                j["connect_type"]  = "lan";
+                j["bind_state"]    = "free";
+                j["sec_link"]      = "secure";
+                j["ssdp_version"]  = "v1";
+                j["printer_agent"] = FLASHFORGE_PRINTER_AGENT_ID;
+                ssdp_fn(j.dump());
+            }
+        } catch (const std::exception& e) {
+            BOOST_LOG_TRIVIAL(debug) << "FlashForgePrinterAgent: UDP discovery probe skipped: " << e.what();
+        }
+    }).detach();
+
+    return true;
+}
+
+// ============================================================================
+// Binding (LAN has no account binding; report benign success)
+// ============================================================================
+
+int FlashForgePrinterAgent::ping_bind(std::string ping_code)
+{
+    (void) ping_code;
+    return BAMBU_NETWORK_SUCCESS;
+}
+
+int FlashForgePrinterAgent::bind_detect(std::string dev_ip, std::string sec_link, detectResult& detect)
+{
+    (void) sec_link;
+    // Confirm the device by querying it directly over the LAN protocol.
+    FFLanClient client;
+    if (!client.connect(dev_ip, FFLanClient::DEFAULT_PORT, 3000))
+        return BAMBU_NETWORK_ERR_CONNECT_FAILED;
+    FFLanClient::MachineInfo mi;
+    const bool ok = client.get_machine_info(mi);
+    client.close();
+    if (!ok)
+        return BAMBU_NETWORK_ERR_CONNECT_FAILED;
+
+    detect.dev_id       = mi.serial_number.empty() ? dev_ip : mi.serial_number;
+    detect.dev_name     = mi.machine_name.empty() ? mi.machine_type : mi.machine_name;
+    detect.model_id     = mi.machine_type;
+    detect.version      = mi.firmware;
+    detect.bind_state   = "free";
+    detect.connect_type = "lan";
+    return BAMBU_NETWORK_SUCCESS;
+}
+
+int FlashForgePrinterAgent::bind(std::string dev_ip, std::string dev_id, std::string sec_link,
+                                 std::string timezone, bool improved, OnUpdateStatusFn update_fn)
+{
+    (void) dev_ip; (void) dev_id; (void) sec_link; (void) timezone; (void) improved;
+    // LAN-only: nothing to bind against a cloud account.
+    // TODO(cloud): FlashForge WAN binding.
+    if (update_fn)
+        update_fn(BAMBU_NETWORK_SUCCESS, 0, "");
+    return BAMBU_NETWORK_SUCCESS;
+}
+
+int FlashForgePrinterAgent::unbind(std::string dev_id)
+{
+    (void) dev_id;
+    return BAMBU_NETWORK_SUCCESS; // TODO(cloud): FlashForge WAN unbind.
+}
+
+int FlashForgePrinterAgent::request_bind_ticket(std::string* ticket)
+{
+    if (ticket)
+        ticket->clear();
+    return BAMBU_NETWORK_SUCCESS;
+}
+
+int FlashForgePrinterAgent::set_server_callback(OnServerErrFn fn)
+{
+    std::lock_guard<std::mutex> lock(m_cb_mutex);
+    m_on_server_err_fn = std::move(fn);
+    return BAMBU_NETWORK_SUCCESS;
+}
+
+// ============================================================================
+// Machine Selection
+// ============================================================================
+
+std::string FlashForgePrinterAgent::get_user_selected_machine()
+{
+    std::lock_guard<std::mutex> lock(m_conn_mutex);
+    return m_selected_machine;
+}
+
+int FlashForgePrinterAgent::set_user_selected_machine(std::string dev_id)
+{
+    std::lock_guard<std::mutex> lock(m_conn_mutex);
+    m_selected_machine = std::move(dev_id);
+    return BAMBU_NETWORK_SUCCESS;
+}
+
+// ============================================================================
+// Agent Information
+// ============================================================================
+
+AgentInfo FlashForgePrinterAgent::get_agent_info_static()
+{
+    return AgentInfo{FLASHFORGE_PRINTER_AGENT_ID, "FlashForge", FLASHFORGE_AGENT_VERSION,
+                     "FlashForge printer agent (open LAN/8899 M-code protocol)"};
+}
+
+// ============================================================================
+// Print Job Operations
+// ============================================================================
+
+int FlashForgePrinterAgent::lan_send_gcode(const PrintParams& params, bool print_now,
+                                           OnUpdateStatusFn update_fn, WasCancelledFn cancel_fn)
+{
+    std::shared_ptr<FFLanClient> client;
+    {
+        std::lock_guard<std::mutex> lock(m_conn_mutex);
+        client = m_client;
+    }
+    if (!client || !client->is_connected())
+        return BAMBU_NETWORK_ERR_INVALID_HANDLE;
+
+    const std::string src = local_gcode_path(params);
+    if (src.empty() || !boost::filesystem::exists(src))
+        return BAMBU_NETWORK_ERR_FILE_NOT_EXIST;
+
+    if (cancel_fn && cancel_fn())
+        return BAMBU_NETWORK_ERR_CANCELED;
+
+    if (update_fn)
+        update_fn(PrintingStageUpload, 0, "Reading G-code...");
+
+    std::string bytes;
+    if (!read_file_bytes(src, bytes))
+        return BAMBU_NETWORK_ERR_FILE_NOT_EXIST;
+
+    const std::string remote_name = remote_gcode_name(params);
+
+    if (update_fn)
+        update_fn(PrintingStageUpload, 0, "Uploading G-code...");
+    if (!client->upload_gcode(remote_name, bytes)) {
+        if (update_fn)
+            update_fn(PrintingStageERROR, BAMBU_NETWORK_ERR_PRINT_LP_UPLOAD_FTP_FAILED, "Upload failed");
+        return BAMBU_NETWORK_ERR_PRINT_LP_UPLOAD_FTP_FAILED;
+    }
+
+    if (print_now) {
+        if (cancel_fn && cancel_fn())
+            return BAMBU_NETWORK_ERR_CANCELED;
+        if (update_fn)
+            update_fn(PrintingStageSending, 0, "Starting print...");
+        if (!client->start_print(remote_name)) {
+            if (update_fn)
+                update_fn(PrintingStageERROR, BAMBU_NETWORK_ERR_PRINT_LP_PUBLISH_MSG_FAILED, "Start failed");
+            return BAMBU_NETWORK_ERR_PRINT_LP_PUBLISH_MSG_FAILED;
+        }
+    }
+
+    if (update_fn)
+        update_fn(PrintingStageFinished, 100, print_now ? "Print started" : "File uploaded");
+    return BAMBU_NETWORK_SUCCESS;
+}
+
+int FlashForgePrinterAgent::start_print(PrintParams params, OnUpdateStatusFn update_fn,
+                                        WasCancelledFn cancel_fn, OnWaitFn wait_fn)
+{
+    (void) wait_fn;
+    // No FlashForge cloud path; treat a "managed" print as a LAN upload+start.
+    // TODO(cloud): route through FlashForge WAN when a session exists.
+    return lan_send_gcode(params, /*print_now=*/true, update_fn, cancel_fn);
+}
+
+int FlashForgePrinterAgent::start_local_print_with_record(PrintParams params, OnUpdateStatusFn update_fn,
+                                                          WasCancelledFn cancel_fn, OnWaitFn wait_fn)
+{
+    (void) wait_fn;
+    // The cloud "record" (history) half has no LAN equivalent; do the real
+    // LAN upload+start. TODO(cloud): register job history via FlashForge WAN.
+    return lan_send_gcode(params, /*print_now=*/true, update_fn, cancel_fn);
+}
+
+int FlashForgePrinterAgent::start_send_gcode_to_sdcard(PrintParams params, OnUpdateStatusFn update_fn,
+                                                       WasCancelledFn cancel_fn, OnWaitFn wait_fn)
+{
+    (void) wait_fn;
+    // Upload only (no ~M23 start).
+    return lan_send_gcode(params, /*print_now=*/false, update_fn, cancel_fn);
+}
+
+int FlashForgePrinterAgent::start_local_print(PrintParams params, OnUpdateStatusFn update_fn, WasCancelledFn cancel_fn)
+{
+    return lan_send_gcode(params, /*print_now=*/true, update_fn, cancel_fn);
+}
+
+int FlashForgePrinterAgent::start_sdcard_print(PrintParams params, OnUpdateStatusFn update_fn, WasCancelledFn cancel_fn)
+{
+    (void) cancel_fn;
+    // Start a file already resident on the printer -> ~M23.
+    std::shared_ptr<FFLanClient> client;
+    {
+        std::lock_guard<std::mutex> lock(m_conn_mutex);
+        client = m_client;
+    }
+    if (!client || !client->is_connected())
+        return BAMBU_NETWORK_ERR_INVALID_HANDLE;
+
+    const std::string remote_name = remote_gcode_name(params);
+    const bool        ok          = client->start_print(remote_name);
+    const int         rc          = ok ? BAMBU_NETWORK_SUCCESS : BAMBU_NETWORK_ERR_PRINT_LP_PUBLISH_MSG_FAILED;
+    if (update_fn)
+        update_fn(ok ? PrintingStageFinished : PrintingStageERROR, rc, ok ? "Print started" : "Start failed");
+    return rc;
+}
+
+// ============================================================================
+// Status poll thread
+// ============================================================================
+
+void FlashForgePrinterAgent::start_status_poll(const std::string& dev_id)
+{
+    m_poll_stop.store(false);
+    const uint64_t gen = ++m_poll_generation;
+    m_poll_thread = std::thread([this, dev_id, gen]() { status_poll_loop(dev_id, gen); });
+}
+
+void FlashForgePrinterAgent::stop_status_poll()
+{
+    m_poll_stop.store(true);
+    ++m_poll_generation;
+    if (m_poll_thread.joinable())
+        m_poll_thread.join();
+}
+
+void FlashForgePrinterAgent::status_poll_loop(std::string dev_id, uint64_t generation)
+{
+    while (!m_poll_stop.load() && generation == m_poll_generation.load()) {
+        std::shared_ptr<FFLanClient> client;
+        {
+            std::lock_guard<std::mutex> lock(m_conn_mutex);
+            client = m_client;
+        }
+        if (!client || !client->is_connected())
+            break;
+
+        FFLanClient::Temps      temps;
+        FFLanClient::StatusInfo status;
+        FFLanClient::Progress   progress;
+        const bool ok_t = client->get_temps(temps);
+        const bool ok_s = client->get_status(status);
+        const bool ok_p = client->get_progress(progress);
+
+        if (ok_t || ok_s || ok_p) {
+            // Status JSON modelled on the Bambu "print"/push_status shape the
+            // Device tab already parses (see MoonrakerPrinterAgent). Fields not
+            // provided by FlashForge are simply omitted.
+            // TODO(devtab): confirm exact key set DevManager expects for FF.
+            nlohmann::json payload;
+            auto& print = payload["print"];
+            print["command"]            = "push_status";
+            print["msg"]                = 0;
+            print["support_mqtt_alive"] = true;
+            print["dev_id"]             = dev_id;
+
+            if (ok_s) {
+                print["gcode_state"]    = map_gcode_state(status.machine_status);
+                print["mc_print_stage"] = map_print_stage(status.machine_status);
+                if (!status.current_file.empty()) {
+                    print["gcode_file"]   = status.current_file;
+                    print["subtask_name"] = status.current_file;
+                }
+                if (status.led >= 0)
+                    print["lights_report"] = status.led ? "on" : "off";
+            }
+            if (ok_t) {
+                print["nozzle_temper"]        = temps.t0_current;
+                print["nozzle_target_temper"] = temps.t0_target;
+                print["bed_temper"]           = temps.bed_current;
+                print["bed_target_temper"]    = temps.bed_target;
+            }
+            if (ok_p) {
+                print["mc_percent"]     = progress.percent;
+                print["layer_num"]      = progress.layer_current;
+                print["total_layer_num"] = progress.layer_total;
+            }
+            const auto now_ms = static_cast<uint64_t>(
+                std::chrono::duration_cast<std::chrono::milliseconds>(
+                    std::chrono::system_clock::now().time_since_epoch())
+                    .count());
+            print["t_utc"] = now_ms;
+
+            dispatch_message(dev_id, payload.dump());
+        }
+
+        // Sleep in small slices so stop() is responsive.
+        for (int waited = 0; waited < POLL_INTERVAL_MS && !m_poll_stop.load() &&
+                             generation == m_poll_generation.load();
+             waited += POLL_SLICE_MS) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(POLL_SLICE_MS));
+        }
+    }
+}
+
+// ============================================================================
+// Callback registration
+// ============================================================================
+
+int FlashForgePrinterAgent::set_on_ssdp_msg_fn(OnMsgArrivedFn fn)
+{
+    std::lock_guard<std::mutex> lock(m_cb_mutex);
+    m_on_ssdp_msg_fn = std::move(fn);
+    return BAMBU_NETWORK_SUCCESS;
+}
+
+int FlashForgePrinterAgent::set_on_printer_connected_fn(OnPrinterConnectedFn fn)
+{
+    std::lock_guard<std::mutex> lock(m_cb_mutex);
+    m_on_printer_connected_fn = std::move(fn);
+    return BAMBU_NETWORK_SUCCESS;
+}
+
+int FlashForgePrinterAgent::set_on_subscribe_failure_fn(GetSubscribeFailureFn fn)
+{
+    std::lock_guard<std::mutex> lock(m_cb_mutex);
+    m_on_subscribe_failure_fn = std::move(fn);
+    return BAMBU_NETWORK_SUCCESS;
+}
+
+int FlashForgePrinterAgent::set_on_message_fn(OnMessageFn fn)
+{
+    std::lock_guard<std::mutex> lock(m_cb_mutex);
+    m_on_message_fn = std::move(fn);
+    return BAMBU_NETWORK_SUCCESS;
+}
+
+int FlashForgePrinterAgent::set_on_user_message_fn(OnMessageFn fn)
+{
+    std::lock_guard<std::mutex> lock(m_cb_mutex);
+    m_on_user_message_fn = std::move(fn);
+    return BAMBU_NETWORK_SUCCESS;
+}
+
+int FlashForgePrinterAgent::set_on_local_connect_fn(OnLocalConnectedFn fn)
+{
+    std::lock_guard<std::mutex> lock(m_cb_mutex);
+    m_on_local_connect_fn = std::move(fn);
+    return BAMBU_NETWORK_SUCCESS;
+}
+
+int FlashForgePrinterAgent::set_on_local_message_fn(OnMessageFn fn)
+{
+    std::lock_guard<std::mutex> lock(m_cb_mutex);
+    m_on_local_message_fn = std::move(fn);
+    return BAMBU_NETWORK_SUCCESS;
+}
+
+int FlashForgePrinterAgent::set_queue_on_main_fn(QueueOnMainFn fn)
+{
+    std::lock_guard<std::mutex> lock(m_cb_mutex);
+    m_queue_on_main_fn = std::move(fn);
+    return BAMBU_NETWORK_SUCCESS;
+}
+
+} // namespace Slic3r

--- a/src/slic3r/Utils/FlashForgePrinterAgent.cpp
+++ b/src/slic3r/Utils/FlashForgePrinterAgent.cpp
@@ -325,6 +325,10 @@ bool FlashForgePrinterAgent::start_discovery(bool start, bool sending)
         j["dev_id"]        = dev_id;
         j["dev_name"]      = dev_id;
         j["dev_ip"]        = dev_ip;
+        // dev_type / dev_signal are read unconditionally by DeviceManager::on_machine_alive;
+        // omitting them makes it throw and the device is silently dropped from the list.
+        j["dev_type"]      = dev_id; // TODO: use the M115 machine model when available
+        j["dev_signal"]    = "0";
         j["connect_type"]  = "lan";
         j["bind_state"]    = "free";
         j["sec_link"]      = "secure";
@@ -385,6 +389,9 @@ bool FlashForgePrinterAgent::start_discovery(bool start, bool sending)
                 j["dev_id"]        = dev_id;
                 j["dev_name"]      = name.empty() ? dev_id : name;
                 j["dev_ip"]        = ip;
+                // Required by DeviceManager::on_machine_alive (throws if missing).
+                j["dev_type"]      = name.empty() ? dev_id : name;
+                j["dev_signal"]    = "0";
                 j["connect_type"]  = "lan";
                 j["bind_state"]    = "free";
                 j["sec_link"]      = "secure";
@@ -653,8 +660,11 @@ void FlashForgePrinterAgent::status_poll_loop(std::string dev_id, uint64_t gener
                     print["gcode_file"]   = status.current_file;
                     print["subtask_name"] = status.current_file;
                 }
-                if (status.led >= 0)
-                    print["lights_report"] = status.led ? "on" : "off";
+                if (status.led >= 0) {
+                    // Parser expects an array of {node, mode} objects, not a bare string.
+                    print["lights_report"] = nlohmann::json::array(
+                        { {{"node", "chamber_light"}, {"mode", status.led ? "on" : "off"}} });
+                }
             }
             if (ok_t) {
                 print["nozzle_temper"]        = temps.t0_current;
@@ -671,7 +681,8 @@ void FlashForgePrinterAgent::status_poll_loop(std::string dev_id, uint64_t gener
                 std::chrono::duration_cast<std::chrono::milliseconds>(
                     std::chrono::system_clock::now().time_since_epoch())
                     .count());
-            print["t_utc"] = now_ms;
+            // The parser reads t_utc at the TOP level of the payload, not inside "print".
+            payload["t_utc"] = now_ms;
 
             dispatch_message(dev_id, payload.dump());
         }

--- a/src/slic3r/Utils/FlashForgePrinterAgent.hpp
+++ b/src/slic3r/Utils/FlashForgePrinterAgent.hpp
@@ -1,0 +1,140 @@
+#ifndef __FLASHFORGE_PRINTER_AGENT_HPP__
+#define __FLASHFORGE_PRINTER_AGENT_HPP__
+
+#include "IPrinterAgent.hpp"
+#include "ICloudServiceAgent.hpp"
+
+#include <atomic>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+
+namespace Slic3r {
+
+class FFLanClient;
+
+// Stable identifier written into FlashForge printer profiles as
+// printer_agent="flashforge". NetworkAgentFactory keys the agent by this id.
+#define FLASHFORGE_PRINTER_AGENT_ID "flashforge"
+
+/**
+ * FlashForgePrinterAgent - OPEN implementation of IPrinterAgent for FlashForge.
+ *
+ * This talks the classic FlashForge "M-code over TCP" LAN protocol directly
+ * (see FFLanClient / FFLanProtocol) on port 8899. There is NO closed library:
+ * everything runs over boost::asio TCP sockets, so the whole path is auditable
+ * and shippable in an upstream open-source build.
+ *
+ * Verified against a real Adventurer 5M Pro (firmware v5.1.8):
+ *   connect  -> ~M601 S1 (take control)
+ *   status   -> ~M105 (temps) + ~M119 (state) + ~M27 (progress), polled
+ *   print    -> ~M28 (+ raw stream) + ~M29 (save) then ~M23 (start)
+ *   stop     -> ~M26
+ *   release  -> ~M602
+ *
+ * LAN-only by design. Cloud/bind/cert/subscribe methods have no LAN equivalent
+ * and are documented stubs (see the // TODO(cloud) notes). The agent is a
+ * Utils-layer component and is UI-free (no wxWidgets); discovered devices and
+ * live status cross the callback boundary as plain JSON strings.
+ */
+class FlashForgePrinterAgent : public IPrinterAgent
+{
+public:
+    FlashForgePrinterAgent();
+    ~FlashForgePrinterAgent() override;
+
+    // Cloud Agent Dependency
+    void set_cloud_agent(std::shared_ptr<ICloudServiceAgent> cloud) override;
+
+    // Communication
+    int send_message(std::string dev_id, std::string json_str, int qos, int flag) override;
+    int connect_printer(std::string dev_id, std::string dev_ip, std::string username, std::string password, bool use_ssl) override;
+    int disconnect_printer() override;
+    int send_message_to_printer(std::string dev_id, std::string json_str, int qos, int flag) override;
+
+    // Certificates
+    int  check_cert() override;
+    void install_device_cert(std::string dev_id, bool lan_only) override;
+
+    // Discovery
+    bool start_discovery(bool start, bool sending) override;
+
+    // Binding
+    int ping_bind(std::string ping_code) override;
+    int bind_detect(std::string dev_ip, std::string sec_link, detectResult& detect) override;
+    int bind(std::string dev_ip, std::string dev_id, std::string sec_link, std::string timezone, bool improved, OnUpdateStatusFn update_fn) override;
+    int unbind(std::string dev_id) override;
+    int request_bind_ticket(std::string* ticket) override;
+    int set_server_callback(OnServerErrFn fn) override;
+
+    // Machine Selection
+    std::string get_user_selected_machine() override;
+    int         set_user_selected_machine(std::string dev_id) override;
+
+    // Agent Information
+    static AgentInfo get_agent_info_static();
+    AgentInfo        get_agent_info() override { return get_agent_info_static(); }
+
+    // Print Job Operations
+    int start_print(PrintParams params, OnUpdateStatusFn update_fn, WasCancelledFn cancel_fn, OnWaitFn wait_fn) override;
+    int start_local_print_with_record(PrintParams params, OnUpdateStatusFn update_fn, WasCancelledFn cancel_fn, OnWaitFn wait_fn) override;
+    int start_send_gcode_to_sdcard(PrintParams params, OnUpdateStatusFn update_fn, WasCancelledFn cancel_fn, OnWaitFn wait_fn) override;
+    int start_local_print(PrintParams params, OnUpdateStatusFn update_fn, WasCancelledFn cancel_fn) override;
+    int start_sdcard_print(PrintParams params, OnUpdateStatusFn update_fn, WasCancelledFn cancel_fn) override;
+
+    // Callbacks
+    int set_on_ssdp_msg_fn(OnMsgArrivedFn fn) override;
+    int set_on_printer_connected_fn(OnPrinterConnectedFn fn) override;
+    int set_on_subscribe_failure_fn(GetSubscribeFailureFn fn) override;
+    int set_on_message_fn(OnMessageFn fn) override;
+    int set_on_user_message_fn(OnMessageFn fn) override;
+    int set_on_local_connect_fn(OnLocalConnectedFn fn) override;
+    int set_on_local_message_fn(OnMessageFn fn) override;
+    int set_queue_on_main_fn(QueueOnMainFn fn) override;
+
+private:
+    // Shared LAN upload+(optionally)start path used by the start_* entry points.
+    int lan_send_gcode(const PrintParams& params, bool print_now, OnUpdateStatusFn update_fn, WasCancelledFn cancel_fn);
+
+    // Background status-poll thread lifecycle.
+    void start_status_poll(const std::string& dev_id);
+    void stop_status_poll();
+    void status_poll_loop(std::string dev_id, uint64_t generation);
+
+    // Callback marshalling helpers (mirror MoonrakerPrinterAgent).
+    void dispatch_local_connect(int state, const std::string& dev_id, const std::string& msg);
+    void dispatch_printer_connected(const std::string& dev_id);
+    void dispatch_message(const std::string& dev_id, const std::string& payload);
+
+private:
+    std::shared_ptr<ICloudServiceAgent> m_cloud_agent;
+
+    // Active LAN connection.
+    mutable std::mutex             m_conn_mutex;
+    std::shared_ptr<FFLanClient>   m_client;
+    std::string                    m_dev_id;
+    std::string                    m_dev_ip;
+    std::string                    m_selected_machine;
+
+    // Status-poll thread.
+    std::thread           m_poll_thread;
+    std::atomic<bool>     m_poll_stop{false};
+    std::atomic<uint64_t> m_poll_generation{0};
+
+    // Stored std::function callbacks (mirrors the other agents' registration).
+    mutable std::mutex    m_cb_mutex;
+    OnMsgArrivedFn        m_on_ssdp_msg_fn;
+    OnPrinterConnectedFn  m_on_printer_connected_fn;
+    GetSubscribeFailureFn m_on_subscribe_failure_fn;
+    OnMessageFn           m_on_message_fn;
+    OnMessageFn           m_on_user_message_fn;
+    OnLocalConnectedFn    m_on_local_connect_fn;
+    OnMessageFn           m_on_local_message_fn;
+    QueueOnMainFn         m_queue_on_main_fn;
+    OnServerErrFn         m_on_server_err_fn;
+};
+
+} // namespace Slic3r
+
+#endif // __FLASHFORGE_PRINTER_AGENT_HPP__

--- a/src/slic3r/Utils/NetworkAgentFactory.cpp
+++ b/src/slic3r/Utils/NetworkAgentFactory.cpp
@@ -7,6 +7,9 @@
 #include "SnapmakerPrinterAgent.hpp"
 #include "MoonrakerPrinterAgent.hpp"
 #include "CrealityPrintAgent.hpp"
+#ifdef ORCA_ENABLE_FLASHFORGE
+#include "FlashForgePrinterAgent.hpp"
+#endif
 #include <boost/log/trivial.hpp>
 #include <map>
 #include <mutex>
@@ -151,6 +154,23 @@ void NetworkAgentFactory::register_all_agents()
                                    return agent;
                                });
     }
+
+#ifdef ORCA_ENABLE_FLASHFORGE
+    // FlashForgePrinterAgent takes no constructor args (it opens its own LAN TCP
+    // socket on demand), so register manually like BBLPrinterAgent. Only
+    // activates for profiles whose printer_agent == "flashforge".
+    {
+        auto info = FlashForgePrinterAgent::get_agent_info_static();
+        register_printer_agent(info.id, info.name,
+                               [](std::shared_ptr<ICloudServiceAgent> cloud_agent,
+                                  const std::string& /*log_dir*/) -> std::shared_ptr<IPrinterAgent> {
+                                   auto agent = std::make_shared<FlashForgePrinterAgent>();
+                                   if (cloud_agent)
+                                       agent->set_cloud_agent(cloud_agent);
+                                   return agent;
+                               });
+    }
+#endif
 }
 
 std::unique_ptr<NetworkAgent> create_agent_from_config(const std::string& log_dir, AppConfig* app_config)


### PR DESCRIPTION
**Draft / RFC — feedback welcome.** Adds FlashForge printer **LAN device support** as a new `IPrinterAgent`, using an **open** implementation of the classic FlashForge M-code-over-TCP protocol (port 8899) — **no proprietary library**.

## Approach
Current OrcaSlicer already has the multi-vendor `NetworkAgentFactory` / `IPrinterAgent` architecture (Orca, Qidi, Snapmaker, Creality, Moonraker, BBL). FlashForge slots in as one more registered agent, structured like `MoonrakerPrinterAgent` (open, socket-based):

- **`Utils/FlashForge/FFLanProtocol.{hpp,cpp}`** — a self-contained `boost::asio` TCP client (`FFLanClient`) speaking `~<Mcode>\r\n` framed commands: `M601/M602` (control), `M115` (info), `M119` (status), `M105` (temps), `M27` (progress), `M28`+stream+`M29` (upload), `M23` (print), plus `M104/M140/M106/M146` (temp/fan/led).
- **`FlashForgePrinterAgent`** implements `IPrinterAgent` on top of it: connect → `M601`; a status-poll thread marshals `M105/M119/M27` into the same Bambu-style `push_status` JSON the Device tab already consumes; `start_local_print` → upload + `M23`; discovery via UDP broadcast + manual IP.
- **Opt-in & isolated:** registered under a default-ON `ORCA_ENABLE_FLASHFORGE` build option, and only selected for presets whose `printer_agent == "flashforge"`. **Non-FlashForge users are unaffected; no changes to Plater/MainFrame/send dialogs** — send-to-printer and the Device tab work through the existing generic `getAgent()` dispatch.

Upstream footprint: ~18 lines in `src/slic3r/CMakeLists.txt` and a one-line registration; everything else is new, self-contained files.

## Hardware-validated
The protocol was verified end-to-end against a **real Adventurer 5M Pro** (firmware v5.1.8): discovery, connect (`M601`), machine info (`M115`), live status/temps/progress (`M119`/`M105`/`M27`), gcode upload (`M28`/`M29`), and print-start (`M23` → `BUILDING_FROM_SD`) all confirmed on the physical printer.

## Status (why it's a draft)
- ✅ **Builds and links** into OrcaSlicer 2.5.0-dev (macOS, Xcode 26 / clang 21); no proprietary dependency.
- ✅ **LAN protocol validated on real hardware.**
- 🚧 The activating profile field (`printer_agent = "flashforge"` on FlashForge presets) isn't included here yet.
- 🚧 Cloud/account-binding are LAN-only stubs (documented `TODO`); the AD5M-series newer HTTP API (port 8898) is intentionally not used — the open 8899 path covers LAN control.
- 🚧 The status→`DevManager` JSON keys are modeled on Moonraker's; may need alignment with a FlashForge `MachineObject`.

## Questions for maintainers
1. Is this open `IPrinterAgent` (Moonraker-style, opt-in build flag) the shape you'd want for FlashForge support?
2. Any preference on the `printer_agent="flashforge"` per-printer selector vs. another gating mechanism?
3. Would you like the FlashForge Adventurer profiles (proposed separately in #14733) to carry `printer_agent="flashforge"` so this activates automatically?

Note: this supersedes the earlier closed-lib bridge idea — it's now fully open. Happy to iterate on direction.