### PR TITLE
Accordion tabs feature for TabCtrl (Sidebar tabs, Preferences Tabs, Printer/Filament Settings dialog tabs)

### DIFF
--- a/src/slic3r/GUI/Widgets/TabCtrl.cpp
+++ b/src/slic3r/GUI/Widgets/TabCtrl.cpp
@@ -17,9 +17,9 @@ END_EVENT_TABLE()
  * calling Refresh()/Update().
  */
 
-#define TAB_BUTTON_SPACE 2
-#define TAB_BUTTON_PADDING_X 2
-#define TAB_BUTTON_PADDING_Y 2
+#define TAB_LEADING_SPACE    FromDIP(5)
+#define TAB_BUTTON_PADDING_X FromDIP(8)
+#define TAB_BUTTON_PADDING_Y FromDIP(2)
 #define TAB_BUTTON_PADDING TAB_BUTTON_PADDING_X, TAB_BUTTON_PADDING_Y
 
 TabCtrl::TabCtrl(wxWindow *      parent,
@@ -37,10 +37,13 @@ TabCtrl::TabCtrl(wxWindow *      parent,
     border_width = 1;
     SetBorderColor(0xcecece);
     sizer = new wxBoxSizer(wxHORIZONTAL);
-    sizer->AddSpacer(10);
+    sizer->AddSpacer(TAB_LEADING_SPACE);
     auto hsizer = new wxBoxSizer(wxVERTICAL);
     hsizer->Add(sizer, 0, wxEXPAND | wxBOTTOM, border_width * 4);
     SetSizer(hsizer);
+
+    UpdateCompactWidth();
+
     Bind(wxEVT_COMMAND_BUTTON_CLICKED, &TabCtrl::buttonClicked, this);
     //wxString reason;
     //IsTransparentBackgroundSupported(&reason);
@@ -80,8 +83,17 @@ void TabCtrl::Unselect()
     SelectItem(-1);
 }
 
+void TabCtrl::UpdateCompactWidth()
+{
+    wxClientDC dc(this);
+    dc.SetFont(GetFont());
+    m_compact_width = dc.GetTextExtent("MM...").x + TAB_BUTTON_PADDING_X * 2;
+}
+
 void TabCtrl::Rescale()
 {
+    UpdateCompactWidth();
+
     for (auto & b : btns)
         b->Rescale();
 }
@@ -92,6 +104,9 @@ bool TabCtrl::SetFont(wxFont const& font)
     bold = font.Bold();
     for (size_t i = 0; i < btns.size(); ++i)
         btns[i]->SetFont(i == sel ? bold : font);
+
+    UpdateCompactWidth();
+
     return true;
 }
 
@@ -109,9 +124,7 @@ int TabCtrl::AppendItem(const wxString &item,
     btn->SetCornerRadius(0);
     btn->SetPaddingSize({TAB_BUTTON_PADDING});
     btns.push_back(btn);
-    if (btns.size() > 1)
-        sizer->GetItem(sizer->GetItemCount() - 1)->SetMinSize({0, 0});
-    sizer->Add(btn, 0, wxALIGN_CENTER_VERTICAL | wxLEFT | wxRIGHT, TAB_BUTTON_SPACE * 2);
+    sizer->Add(btn, 0, wxALIGN_CENTER_VERTICAL);
     sizer->AddStretchSpacer(1);
     relayout();
     return btns.size() - 1;
@@ -132,8 +145,6 @@ bool TabCtrl::DeleteItem(int item)
     btn->Destroy();
     btns.erase(btns.begin() + item);
     sizer->Remove(item * 2);
-    if (btns.size() > 1)
-        sizer->GetItem(sizer->GetItemCount() - 1)->SetMinSize({0, 0});
 
     if (selection_changed) {
         sel--;  // `relayout()` uses `sel` so we need to update this before calling `relayout()`
@@ -149,7 +160,7 @@ bool TabCtrl::DeleteItem(int item)
 void TabCtrl::DeleteAllItems()
 {
     sizer->Clear(true);
-    sizer->AddSpacer(10);
+    sizer->AddSpacer(TAB_LEADING_SPACE);
     btns.clear();
     if (sel >= 0) {
         sel = -1;
@@ -242,40 +253,40 @@ WXLRESULT TabCtrl::MSWWindowProc(WXUINT nMsg, WXWPARAM wParam, WXLPARAM lParam)
 
 void TabCtrl::relayout()
 {
-    int offset = 10;
-    int item = sel + 1;
-    int first = 0;
-    for (int i = 0; i < item; ++i)
-        offset += btns[i]->GetMinSize().x + TAB_BUTTON_SPACE * 2;
-    if (item < btns.size())
-        offset += btns[item]->GetMinSize().x + TAB_BUTTON_SPACE * 2;
-    int  width = GetSize().x;
-    for (int i = 0; i < btns.size(); ++i) {
-        auto size = btns[i]->GetMinSize().x + TAB_BUTTON_SPACE * 2;
-        if (i < sel && offset > width) {
-            sizer->Show(i * 2 + 1, false);
-            sizer->Show(i * 2 + 2, false);
-            offset -= size;
-            first = i + 1;
-        } else if (i <= item) {
-            sizer->Show(i * 2 + 1, true);
-            sizer->Show(i * 2 + 2, true);
-        } else if (offset <= width) {
-            sizer->Show(i * 2 + 1, true);
-            sizer->Show(i * 2 + 2, true);
-            offset += size;
-            item = i;
-        } else {
-            sizer->Show(i * 2 + 1, false);
-            sizer->Show(i * 2 + 2, false);
-        }
-        sizer->GetItem(i * 2 + 2)->SetMinSize({0, 0});
+    const int count = (int)btns.size();
+    if (count == 0) {
+        Layout();
+        return;
     }
-    if (item >= btns.size())
-        -- item;
-    // Keep spacing 2 ~ 10 TAB_BUTTON_SPACE
-    int b = GetSize().x - offset - 10 - (item + 1 - first) * TAB_BUTTON_SPACE * 8;
-    sizer->GetItem(item * 2 + 2)->SetMinSize({b > 0 ? b : 0, 0});
+
+    const int ctrl_width = GetSize().x;
+
+    // reset size limits for all buttons first
+    for (int i = 0; i < count; ++i)
+        btns[i]->SetMaxSize(wxDefaultSize);
+
+    int total_width = TAB_LEADING_SPACE;
+
+    // calculate total width
+    for (int i = 0; i < count; ++i)
+        total_width += btns[i]->GetMinSize().x;
+
+    int btns_width = total_width;
+
+    // starting from the last button, clamp widths one by one until everything fits
+    for (int i = count - 1; i >= 0 && total_width > ctrl_width; --i) {
+        sizer->GetItem(i * 2 + 2)->SetMinSize({0, 0}); // reset all stretch spacer width
+        int btn_width = btns[i]->GetMinSize().x;
+        if (btn_width <= m_compact_width)
+            continue; // already narrow enough
+
+        total_width -= (btn_width - m_compact_width);
+        btns[i]->SetMaxSize({m_compact_width, -1});
+    }
+
+    int b = ctrl_width - (TAB_LEADING_SPACE + btns_width + count * TAB_BUTTON_PADDING_X); // keep it left aligned with resizing last stretch spacer
+    sizer->GetItem(sizer->GetItemCount() - 1)->SetMinSize({b > 0 ? b : 0, 0});
+
     Layout();
 }
 

--- a/src/slic3r/GUI/Widgets/TabCtrl.cpp
+++ b/src/slic3r/GUI/Widgets/TabCtrl.cpp
@@ -179,6 +179,7 @@ void TabCtrl::SetItemText(unsigned int item, wxString const &value)
 {
     if (item >= btns.size()) return;
     btns[item]->SetLabel(value);
+    btns[item]->SetToolTip(value); // ensure tooltip matches with tab
 }
 
 bool TabCtrl::GetItemBold(unsigned int item) const

--- a/src/slic3r/GUI/Widgets/TabCtrl.hpp
+++ b/src/slic3r/GUI/Widgets/TabCtrl.hpp
@@ -79,6 +79,9 @@ private:
     // some useful events
     bool sendTabCtrlEvent(bool changing = false);
 
+    void UpdateCompactWidth();
+    int m_compact_width;
+
     DECLARE_EVENT_TABLE()
 };
 


### PR DESCRIPTION
Requested few times

# NOTES
• All screenshots taken with minimum sidebar width
• No need to worry about ellipsized strings because all have tooltips
<img width="193" height="84" alt="Screenshot-20260712213911" src="https://github.com/user-attachments/assets/3ee38ce1-0b04-4baf-bfba-9c55c07ad27b" />

# CHANGES
• Removes unnecessary clicks to reach last tab or first tab etc
• Buttons now uses wider paddings so bottom line is a bit wider and leading space narrower
• Fixes tab positions and makes UI more predictable
• Improves scaling support

# FIX
• Fixed tooltips not matches after printer change
<img width="127" height="80" alt="Screenshot-20260712220529" src="https://github.com/user-attachments/assets/9e0e681e-ce28-407f-92c5-74f1079b3018" />

# COMPARISON
**Before** - Other Tab disappears until neighbor tab selected
<img width="408" height="65" alt="orca-slicer_FyGq5S9oAW" src="https://github.com/user-attachments/assets/6a869ee0-7090-4477-8d6f-d4a124aafa73" />

**After** - It starts to ellipsize tabs from end if its wider compared to given size
all tabs visible at once
<img width="405" height="70" alt="orca-slicer_KALddc0OR2" src="https://github.com/user-attachments/assets/ae0b4347-9ea2-43c6-8ddf-b5687d7a617b" />

# ENGLISH
**Before** - Last tab overflows
<img width="428" height="105" alt="Screenshot-20260712213503" src="https://github.com/user-attachments/assets/831179b2-1e8e-41c2-8396-8d35d4c813a6" />

**After** - Only has one ellipsized tab and all accessible with one click
<img width="405" height="84" alt="Screenshot-20260712213416" src="https://github.com/user-attachments/assets/2a1bd341-48c7-449a-a0ca-caa6fcffce34" />

# TURKISH
**Before** - Slightly overflowing last tab
<img width="413" height="104" alt="Screenshot-20260712215414" src="https://github.com/user-attachments/assets/e5f5c838-d960-422c-b1c1-7f891d198e37" />

**After** - Only has one ellipsized tab and all accessible with one click
<img width="411" height="107" alt="Screenshot-20260712215344" src="https://github.com/user-attachments/assets/617f6c1e-3f69-4d36-a50c-6abc8c7bb33c" />

# RUSSIAN
**Before** - Last tab overflows and before tab is also overflows
<img width="414" height="106" alt="Screenshot-20260712215526" src="https://github.com/user-attachments/assets/29744437-f7ca-4d9f-9848-01bc873cd818" />

**After** - Ellipsizes last 3 tabs but all still can be accessible with one click
<img width="402" height="113" alt="Screenshot-20260712215450" src="https://github.com/user-attachments/assets/a7758047-61cb-4123-8bfe-e3c6dc956e9f" />

# GERMAN
**Before** - Last tab overflows and before tab is also overflows
<img width="417" height="110" alt="Screenshot-20260712215022" src="https://github.com/user-attachments/assets/7249101d-cca6-474c-ae0e-4a1a8f8b688c" />

**After** - Ellipsizes last 4 tabs but all still can be accessible with one click
<img width="413" height="129" alt="Screenshot-20260712214908" src="https://github.com/user-attachments/assets/d1da0729-db21-437d-8e84-330c2460905b" />

# SPANISH
**Before** - Last tab overflows
<img width="411" height="98" alt="Screenshot-20260712215753" src="https://github.com/user-attachments/assets/9f581266-9b45-4d48-a5fc-7b01f7fdc3c6" />

**After** - Ellipsizes 2 tabs
<img width="403" height="97" alt="Screenshot-20260712215646" src="https://github.com/user-attachments/assets/ad10728c-cdaf-43e8-a695-46516b9073ca" />

# PRINTER TAB - DUAL EXTRUDER
**Before**
<img width="758" height="132" alt="Screenshot-20260712213759" src="https://github.com/user-attachments/assets/e88ee72c-8c0d-4181-8f4a-39e7ba8df259" />
**After**
<img width="763" height="140" alt="Screenshot-20260712213750" src="https://github.com/user-attachments/assets/ab36ac2b-ce25-475f-9a85-f97daa5d87a7" />

# PRINTER TAB - MULTI EXTRUDER
• This one is only problematic section for now
**Before**
<img width="750" height="149" alt="Screenshot-20260712214119" src="https://github.com/user-attachments/assets/a3b5577a-5a26-4532-8caf-f84a7fda739c" />

**After**
<img width="775" height="148" alt="Screenshot-20260712214105" src="https://github.com/user-attachments/assets/bccce343-d54f-4d20-b991-b33f3e7ef780" />

But no worry. it will be solved after implementing sub pages for extruders
<img width="1023" height="274" alt="Screenshot-20260712214358" src="https://github.com/user-attachments/assets/8f59a30e-fc71-41a8-86e9-d25a9a8c24fb" />

alternatively extruder tabs can be called as E1, E2... etc temporaryly
<img width="759" height="129" alt="Screenshot-20260713041058" src="https://github.com/user-attachments/assets/78b60976-677f-45f9-8fc4-f373670f3ceb" />
