### PR TITLE
fix: wipe tower height crash triggered by H2C/A2L support

### DIFF
--- a/src/libslic3r/Print.hpp
+++ b/src/libslic3r/Print.hpp
@@ -774,6 +774,7 @@ struct WipeTowerData
         number_of_toolchanges = -1;
         depth = 0.f;
         brim_width = 0.f;
+        height = 0.f;
         rib_offset = Vec2f::Zero();
         wipe_tower_mesh_data  = std::nullopt;
     }


### PR DESCRIPTION
# Description

The new "Prime-tower visits..." test from #14685 (H2C/A2L support) throws "Coordinate outside allowed range" at random on CI, on both Windows arm64 and Linux x86_64. It's an uninitialized read of WipeTowerData::height.

#10780 (H2D/H2S) added a second wipe tower path, generate_new(), that fills in depth, bbx, brim_width and rib_offset but not height. The older generate() sets height, and clear() never did, so on the generate_new path it stays garbage.

first_layer_wipe_tower_corners() passes height to get_wipe_tower_cone_base() as R = tan(cone_angle/2) * height. The stray bytes are usually zero, so R is zero and the slice is fine, which is why it passes most runs on every platform. When they aren't zero the cone radius runs past ClipperLib's limit and the slice throws. Nothing selects for it, so it just flakes around.

#14685's test is the first to exercise this path, so that's when it started showing up.

Initializing height in clear() fixes it, same as the m_origin fix in #13712. The BBL generate_new path has no stabilization cone, so height = 0 is right.

## Tests

The existing "Prime-tower visits..." gcodewriter test (#14685) covers this path; the fix stops it flaking on CI.

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
