### PR TITLE
Calibrations improvements

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -5451,7 +5451,9 @@ LayerResult GCode::process_layer(
     //Calibration Layer-specific GCode
     switch (print.calib_mode()) {
         case CalibMode::Calib_PA_Tower: {
-            gcode += writer().set_pressure_advance(print.calib_params().start + static_cast<int>(print_z) * print.calib_params().step);
+            gcode += writer().set_pressure_advance(this->interpolate_value_across_layers(static_cast<float>(print.calib_params().start),
+                                                                                         static_cast<float>(print.calib_params().end),
+                                                                                         static_cast<float>(print.calib_params().step)));
             break;
         }
         case CalibMode::Calib_Temp_Tower: {

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -5459,7 +5459,21 @@ LayerResult GCode::process_layer(
             break;
         }
         case CalibMode::Calib_VFA_Tower: {
-            auto _speed = print.calib_params().start + std::floor(print_z / 5.0) * print.calib_params().step;
+            // The VFA tower geometry is scaled by nozzle_diameter / base_nozzle_diameter in Plater::calib_VFA,
+            // so the physical height of each speed block scales with it too. Keep the speed stepping in sync.
+            constexpr double base_vfa_nozzle_diameter = 0.4;
+            constexpr double base_vfa_block_height     = 5.0;
+            const auto& nozzle_diameters = print.config().nozzle_diameter.values;
+            size_t      nozzle_id        = static_cast<size_t>(std::max(print.calib_params().extruder_id, 0));
+            double      nozzle_diameter  = base_vfa_nozzle_diameter;
+            if (!nozzle_diameters.empty()) {
+                nozzle_id       = std::min(nozzle_id, nozzle_diameters.size() - 1);
+                nozzle_diameter = nozzle_diameters[nozzle_id];
+            }
+            if (nozzle_diameter <= 0.0)
+                nozzle_diameter = base_vfa_nozzle_diameter;
+            const double block_height = base_vfa_block_height * (nozzle_diameter / base_vfa_nozzle_diameter);
+            auto _speed = print.calib_params().start + std::floor(print_z / block_height) * print.calib_params().step;
             m_calib_config.set_key_value("outer_wall_speed", new ConfigOptionFloatsNullable({std::round(_speed)}));
             break;
         }

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -5459,20 +5459,21 @@ LayerResult GCode::process_layer(
             break;
         }
         case CalibMode::Calib_VFA_Tower: {
-            // The VFA tower geometry is scaled by nozzle_diameter / base_nozzle_diameter in Plater::calib_VFA,
-            // so the physical height of each speed block scales with it too. Keep the speed stepping in sync.
-            constexpr double base_vfa_nozzle_diameter = 0.4;
-            constexpr double base_vfa_block_height     = 5.0;
-            const auto& nozzle_diameters = print.config().nozzle_diameter.values;
-            size_t      nozzle_id        = static_cast<size_t>(std::max(print.calib_params().extruder_id, 0));
-            double      nozzle_diameter  = base_vfa_nozzle_diameter;
-            if (!nozzle_diameters.empty()) {
-                nozzle_id       = std::min(nozzle_id, nozzle_diameters.size() - 1);
-                nozzle_diameter = nozzle_diameters[nozzle_id];
+            // Each speed block is vfa_layers_per_block layers tall; the tower geometry in Plater::calib_VFA is
+            // scaled so its physical block height equals vfa_layers_per_block * layer_height. Keep the speed
+            // stepping in sync with the (possibly auto-adjusted) layer height chosen there.
+            double layer_height = print.calib_params().vfa_layer_height;
+            if (layer_height <= 0.0) {
+                // Fallback for older params: default layer height is nozzle_diameter / 2.
+                const auto& nozzle_diameters = print.config().nozzle_diameter.values;
+                size_t      nozzle_id        = static_cast<size_t>(std::max(print.calib_params().extruder_id, 0));
+                double      nozzle_diameter  = nozzle_diameters.empty() ? vfa_base_nozzle_diameter
+                                                                        : nozzle_diameters[std::min(nozzle_id, nozzle_diameters.size() - 1)];
+                if (nozzle_diameter <= 0.0)
+                    nozzle_diameter = vfa_base_nozzle_diameter;
+                layer_height = nozzle_diameter / 2.0;
             }
-            if (nozzle_diameter <= 0.0)
-                nozzle_diameter = base_vfa_nozzle_diameter;
-            const double block_height = base_vfa_block_height * (nozzle_diameter / base_vfa_nozzle_diameter);
+            const double block_height = vfa_layers_per_block * layer_height;
             auto _speed = print.calib_params().start + std::floor(print_z / block_height) * print.calib_params().step;
             m_calib_config.set_key_value("outer_wall_speed", new ConfigOptionFloatsNullable({std::round(_speed)}));
             break;

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -8143,29 +8143,22 @@ std::string GCode::extrusion_role_to_string_for_parser(const ExtrusionRole & rol
 }
 
 // Calculate the interpolated value for the current layer between start_value and end_value.
-// Step will create equal layers steps from first to last value.
+// Step > 0 splits the range into equal-width bands from first to last value (both inclusive).
 // Step = 0 means gradual interpolation finishing at last value.
 float GCode::interpolate_value_across_layers(float start_value, float end_value, float step) const
 {
     if (m_layer_index <= 1) {
         return start_value;
     }
-    else {
-        bool use_steps = step > 0.f;
-        if (use_steps) {
-            if (start_value > end_value) {
-                start_value += step;
-            } else {
-                end_value += step;
-            }
-        }
-        float ratio = m_layer_index / (m_layer_count - 1.f);
-        float value = start_value + ratio * (end_value - start_value);
-        if (use_steps) {
-            value = trunc(value / step) * step;
-        }
-        return value;
+    const float ratio = m_layer_index / (m_layer_count - 1.f);
+    if (step > 0.f) {
+        // Discrete equal-width bands. band is clamped to the last band so the result can't overshoot the range:
+        // at the top layer ratio * n_bands == n_bands, which would otherwise index one band past the end.
+        const int n_bands = std::lround(std::abs(end_value - start_value) / step) + 1;
+        const int band    = std::min(n_bands - 1, static_cast<int>(ratio * n_bands));
+        return start_value + (end_value >= start_value ? 1.f : -1.f) * band * step;
     }
+    return start_value + ratio * (end_value - start_value);
 }
 
 std::string encodeBase64(uint64_t value)

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -5459,22 +5459,12 @@ LayerResult GCode::process_layer(
             break;
         }
         case CalibMode::Calib_VFA_Tower: {
-            // Each speed block is vfa_layers_per_block layers tall; the tower geometry in Plater::calib_VFA is
-            // scaled so its physical block height equals vfa_layers_per_block * layer_height. Keep the speed
-            // stepping in sync with the (possibly auto-adjusted) layer height chosen there.
-            double layer_height = print.calib_params().vfa_layer_height;
-            if (layer_height <= 0.0) {
-                // Fallback for older params: default layer height is nozzle_diameter / 2.
-                const auto& nozzle_diameters = print.config().nozzle_diameter.values;
-                size_t      nozzle_id        = static_cast<size_t>(std::max(print.calib_params().extruder_id, 0));
-                double      nozzle_diameter  = nozzle_diameters.empty() ? vfa_base_nozzle_diameter
-                                                                        : nozzle_diameters[std::min(nozzle_id, nozzle_diameters.size() - 1)];
-                if (nozzle_diameter <= 0.0)
-                    nozzle_diameter = vfa_base_nozzle_diameter;
-                layer_height = nozzle_diameter / 2.0;
-            }
-            const double block_height = vfa_layers_per_block * layer_height;
-            auto _speed = print.calib_params().start + std::floor(print_z / block_height) * print.calib_params().step;
+            // Step the outer wall speed from start to end across the tower's layers. Plater::calib_VFA sizes the
+            // geometry so each speed step spans one visual block (a fixed number of layers), so the layer-based
+            // stepping stays aligned with the blocks regardless of nozzle size / layer height.
+            float _speed = this->interpolate_value_across_layers(static_cast<float>(print.calib_params().start),
+                                                                 static_cast<float>(print.calib_params().end),
+                                                                 static_cast<float>(print.calib_params().step));
             m_calib_config.set_key_value("outer_wall_speed", new ConfigOptionFloatsNullable({std::round(_speed)}));
             break;
         }

--- a/src/libslic3r/calib.hpp
+++ b/src/libslic3r/calib.hpp
@@ -42,9 +42,18 @@ struct Calib_Params
     std::string shaper_type;
     std::vector<double> accelerations;
     std::vector<double> speeds;
+    // Resolved layer height for the VFA tower (0 = auto: nozzle_diameter / 2). Each speed block is a
+    // fixed number of layers tall, so this also determines the physical block height / tower height.
+    double vfa_layer_height = 0.0;
 
     CalibMode mode;
 };
+
+// Number of printed layers per speed block in the VFA tower. The base model has 5 mm blocks designed
+// for a 0.2 mm layer height (0.4 mm nozzle), i.e. 25 layers per block.
+static constexpr int vfa_layers_per_block = 25;
+static constexpr double vfa_base_block_height = 5.0;
+static constexpr double vfa_base_nozzle_diameter = 0.4;
 
 enum FlowRatioCalibrationType {
     COMPLETE_CALIBRATION = 0,

--- a/src/libslic3r/calib.hpp
+++ b/src/libslic3r/calib.hpp
@@ -45,6 +45,9 @@ struct Calib_Params
     // Resolved layer height for the VFA tower (0 = auto: nozzle_diameter / 2). Each speed block is a
     // fixed number of layers tall, so this also determines the physical block height / tower height.
     double vfa_layer_height = 0.0;
+    // Scale the calibration model to the nozzle diameter and set the layer height accordingly (temp tower / VFA).
+    // When false the 0.4 mm / 0.2 mm reference model is printed as-is.
+    bool nozzle_based_resize = true;
 
     CalibMode mode;
 };

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -14047,7 +14047,7 @@ void Plater::calib_temp(const Calib_Params& params) {
         }
     }
 
-    if (std::abs(nozzle_scale - 1.0) > EPSILON)
+    if (params.nozzle_based_resize && std::abs(nozzle_scale - 1.0) > EPSILON)
         model().objects[0]->scale(nozzle_scale, nozzle_scale, nozzle_scale);
 
     model().objects[0]->ensure_on_bed();
@@ -14055,7 +14055,9 @@ void Plater::calib_temp(const Calib_Params& params) {
     printer_config->set_key_value("resonance_avoidance", new ConfigOptionBool{false});
     set_config_values<int, ConfigOptionInts>(filament_config, "nozzle_temperature_initial_layer", (int) start_temp);
     set_config_values<int, ConfigOptionInts>(filament_config, "nozzle_temperature", (int) start_temp);
-    model().objects[0]->config.set_key_value("layer_height", new ConfigOptionFloat(nozzle_diameter/2));
+    // When resizing is disabled the 0.4 mm / 0.2 mm reference model is printed as-is (preset layer height kept).
+    if (params.nozzle_based_resize)
+        model().objects[0]->config.set_key_value("layer_height", new ConfigOptionFloat(nozzle_diameter/2));
     model().objects[0]->config.set_key_value("brim_type", new ConfigOptionEnum<BrimType>(btOuterOnly));
     model().objects[0]->config.set_key_value("brim_width", new ConfigOptionFloat(5.0));
     model().objects[0]->config.set_key_value("brim_object_gap", new ConfigOptionFloat(0.0));
@@ -14066,7 +14068,8 @@ void Plater::calib_temp(const Calib_Params& params) {
 
     auto print_config = &wxGetApp().preset_bundle->prints.get_edited_preset().config;
     print_config->set_key_value("enable_wrapping_detection", new ConfigOptionBool(false));
-    print_config->set_key_value("initial_layer_print_height", new ConfigOptionFloat(nozzle_diameter/2));
+    if (params.nozzle_based_resize)
+        print_config->set_key_value("initial_layer_print_height", new ConfigOptionFloat(nozzle_diameter/2));
 
 
     changed_objects({ 0 });
@@ -14251,12 +14254,15 @@ void Plater::calib_VFA(const Calib_Params& params)
         cut_horizontal(0, 0, height, ModelObjectCutAttribute::KeepLower);
     }
 
-    // XY scales with the nozzle (footprint / line width); Z scales so each base block becomes
-    // vfa_layers_per_block layers of the resolved layer height.
-    const double xy_scale = nozzle_diameter / vfa_base_nozzle_diameter;
-    const double z_scale  = (vfa_layers_per_block * layer_height) / vfa_base_block_height;
-    if (std::abs(xy_scale - 1.0) > EPSILON || std::abs(z_scale - 1.0) > EPSILON)
-        model().objects[0]->scale(xy_scale, xy_scale, z_scale);
+    // When resizing is enabled, XY scales with the nozzle (footprint / line width) and Z scales so each base
+    // block becomes vfa_layers_per_block layers of the resolved layer height. When disabled the 0.4 mm / 0.2 mm
+    // reference model is printed as-is (preset layer height kept).
+    if (params.nozzle_based_resize) {
+        const double xy_scale = nozzle_diameter / vfa_base_nozzle_diameter;
+        const double z_scale  = (vfa_layers_per_block * layer_height) / vfa_base_block_height;
+        if (std::abs(xy_scale - 1.0) > EPSILON || std::abs(z_scale - 1.0) > EPSILON)
+            model().objects[0]->scale(xy_scale, xy_scale, z_scale);
+    }
 
     model().objects[0]->ensure_on_bed();
 
@@ -14273,8 +14279,10 @@ void Plater::calib_VFA(const Calib_Params& params)
     print_config->set_key_value("spiral_mode", new ConfigOptionBool(true));
     print_config->set_key_value("enable_wrapping_detection", new ConfigOptionBool(false));
     print_config->set_key_value("precise_z_height", new ConfigOptionBool(false));
-    print_config->set_key_value("initial_layer_print_height", new ConfigOptionFloat(layer_height));
-    model().objects[0]->config.set_key_value("layer_height", new ConfigOptionFloat(layer_height));
+    if (params.nozzle_based_resize) {
+        print_config->set_key_value("initial_layer_print_height", new ConfigOptionFloat(layer_height));
+        model().objects[0]->config.set_key_value("layer_height", new ConfigOptionFloat(layer_height));
+    }
     model().objects[0]->config.set_key_value("brim_type", new ConfigOptionEnum<BrimType>(btOuterOnly));
     model().objects[0]->config.set_key_value("brim_width", new ConfigOptionFloat(3.0));
     model().objects[0]->config.set_key_value("brim_object_gap", new ConfigOptionFloat(0.0));
@@ -14285,9 +14293,10 @@ void Plater::calib_VFA(const Calib_Params& params)
     wxGetApp().get_tab(Preset::TYPE_PRINT)->update_ui_from_settings();
     wxGetApp().get_tab(Preset::TYPE_FILAMENT)->update_ui_from_settings();
 
-    // Pass the resolved layer height on so the GCode speed stepping matches the geometry.
+    // Pass the resolved layer height on (only meaningful when resized). GCode's VFA stepping is layer-based, so
+    // it does not require it, but keep it consistent with the geometry.
     Calib_Params calib_params = params;
-    calib_params.vfa_layer_height = layer_height;
+    calib_params.vfa_layer_height = params.nozzle_based_resize ? layer_height : 0.0;
     p->background_process.fff_print()->set_calib_params(calib_params);
 }
 

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -14243,8 +14243,10 @@ void Plater::calib_VFA(const Calib_Params& params)
 
     // cut upper (on the unscaled model, using the base block height); the scaling below keeps the physical
     // block height (vfa_layers_per_block * layer_height) in sync with the speed stepping in GCode::process_layer.
+    // Subtract EPSILON (as the temperature tower does) so the cut lands just below the flat block surface instead
+    // of exactly on it, which would otherwise add a degenerate extra layer.
     auto obj_bb = model().objects[0]->bounding_box_exact();
-    auto height = vfa_base_block_height * ((params.end - params.start) / params.step + 1);
+    auto height = vfa_base_block_height * ((params.end - params.start) / params.step + 1) - EPSILON;
     if (height < obj_bb.size().z()) {
         cut_horizontal(0, 0, height, ModelObjectCutAttribute::KeepLower);
     }

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -14217,9 +14217,6 @@ void Plater::calib_retraction(const Calib_Params& params)
 
 void Plater::calib_VFA(const Calib_Params& params)
 {
-    constexpr double base_vfa_nozzle_diameter = 0.4;
-    constexpr double base_vfa_block_height     = 5.0;
-
     const auto calib_vfa_name = wxString::Format(L"VFA test");
     new_project(false, false, calib_vfa_name);
     wxGetApp().mainframe->select_tab(size_t(MainFrame::tp3DEditor));
@@ -14233,25 +14230,31 @@ void Plater::calib_VFA(const Calib_Params& params)
 
     const ConfigOptionFloats* nozzle_diameter_config = printer_config->option<ConfigOptionFloats>("nozzle_diameter");
     size_t nozzle_id = static_cast<size_t>(std::max(params.extruder_id, 0));
-    double nozzle_diameter = base_vfa_nozzle_diameter;
+    double nozzle_diameter = vfa_base_nozzle_diameter;
     if (nozzle_diameter_config && !nozzle_diameter_config->values.empty()) {
         nozzle_id = std::min(nozzle_id, nozzle_diameter_config->values.size() - 1);
         nozzle_diameter = nozzle_diameter_config->values[nozzle_id];
     }
     if (nozzle_diameter <= 0.0)
-        nozzle_diameter = base_vfa_nozzle_diameter;
-    const double nozzle_scale = nozzle_diameter / base_vfa_nozzle_diameter;
+        nozzle_diameter = vfa_base_nozzle_diameter;
 
-    // cut upper (on the unscaled model, using the base block height); the scaling below keeps the
-    // physical block height in sync with the speed stepping in GCode::process_layer.
+    // Resolved layer height: use the (possibly auto-adjusted) value from the dialog, else default to nozzle/2.
+    double layer_height = params.vfa_layer_height > 0.0 ? params.vfa_layer_height : nozzle_diameter / 2.0;
+
+    // cut upper (on the unscaled model, using the base block height); the scaling below keeps the physical
+    // block height (vfa_layers_per_block * layer_height) in sync with the speed stepping in GCode::process_layer.
     auto obj_bb = model().objects[0]->bounding_box_exact();
-    auto height = base_vfa_block_height * ((params.end - params.start) / params.step + 1);
+    auto height = vfa_base_block_height * ((params.end - params.start) / params.step + 1);
     if (height < obj_bb.size().z()) {
         cut_horizontal(0, 0, height, ModelObjectCutAttribute::KeepLower);
     }
 
-    if (std::abs(nozzle_scale - 1.0) > EPSILON)
-        model().objects[0]->scale(nozzle_scale, nozzle_scale, nozzle_scale);
+    // XY scales with the nozzle (footprint / line width); Z scales so each base block becomes
+    // vfa_layers_per_block layers of the resolved layer height.
+    const double xy_scale = nozzle_diameter / vfa_base_nozzle_diameter;
+    const double z_scale  = (vfa_layers_per_block * layer_height) / vfa_base_block_height;
+    if (std::abs(xy_scale - 1.0) > EPSILON || std::abs(z_scale - 1.0) > EPSILON)
+        model().objects[0]->scale(xy_scale, xy_scale, z_scale);
 
     model().objects[0]->ensure_on_bed();
 
@@ -14268,8 +14271,8 @@ void Plater::calib_VFA(const Calib_Params& params)
     print_config->set_key_value("spiral_mode", new ConfigOptionBool(true));
     print_config->set_key_value("enable_wrapping_detection", new ConfigOptionBool(false));
     print_config->set_key_value("precise_z_height", new ConfigOptionBool(false));
-    print_config->set_key_value("initial_layer_print_height", new ConfigOptionFloat(nozzle_diameter/2));
-    model().objects[0]->config.set_key_value("layer_height", new ConfigOptionFloat(nozzle_diameter/2));
+    print_config->set_key_value("initial_layer_print_height", new ConfigOptionFloat(layer_height));
+    model().objects[0]->config.set_key_value("layer_height", new ConfigOptionFloat(layer_height));
     model().objects[0]->config.set_key_value("brim_type", new ConfigOptionEnum<BrimType>(btOuterOnly));
     model().objects[0]->config.set_key_value("brim_width", new ConfigOptionFloat(3.0));
     model().objects[0]->config.set_key_value("brim_object_gap", new ConfigOptionFloat(0.0));
@@ -14280,7 +14283,10 @@ void Plater::calib_VFA(const Calib_Params& params)
     wxGetApp().get_tab(Preset::TYPE_PRINT)->update_ui_from_settings();
     wxGetApp().get_tab(Preset::TYPE_FILAMENT)->update_ui_from_settings();
 
-    p->background_process.fff_print()->set_calib_params(params);
+    // Pass the resolved layer height on so the GCode speed stepping matches the geometry.
+    Calib_Params calib_params = params;
+    calib_params.vfa_layer_height = layer_height;
+    p->background_process.fff_print()->set_calib_params(calib_params);
 }
 
 void Plater::calib_input_shaping_freq(const Calib_Params& params)

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -14217,6 +14217,9 @@ void Plater::calib_retraction(const Calib_Params& params)
 
 void Plater::calib_VFA(const Calib_Params& params)
 {
+    constexpr double base_vfa_nozzle_diameter = 0.4;
+    constexpr double base_vfa_block_height     = 5.0;
+
     const auto calib_vfa_name = wxString::Format(L"VFA test");
     new_project(false, false, calib_vfa_name);
     wxGetApp().mainframe->select_tab(size_t(MainFrame::tp3DEditor));
@@ -14227,6 +14230,31 @@ void Plater::calib_VFA(const Calib_Params& params)
     auto print_config = &wxGetApp().preset_bundle->prints.get_edited_preset().config;
     auto filament_config = &wxGetApp().preset_bundle->filaments.get_edited_preset().config;
     auto printer_config  = &wxGetApp().preset_bundle->printers.get_edited_preset().config;
+
+    const ConfigOptionFloats* nozzle_diameter_config = printer_config->option<ConfigOptionFloats>("nozzle_diameter");
+    size_t nozzle_id = static_cast<size_t>(std::max(params.extruder_id, 0));
+    double nozzle_diameter = base_vfa_nozzle_diameter;
+    if (nozzle_diameter_config && !nozzle_diameter_config->values.empty()) {
+        nozzle_id = std::min(nozzle_id, nozzle_diameter_config->values.size() - 1);
+        nozzle_diameter = nozzle_diameter_config->values[nozzle_id];
+    }
+    if (nozzle_diameter <= 0.0)
+        nozzle_diameter = base_vfa_nozzle_diameter;
+    const double nozzle_scale = nozzle_diameter / base_vfa_nozzle_diameter;
+
+    // cut upper (on the unscaled model, using the base block height); the scaling below keeps the
+    // physical block height in sync with the speed stepping in GCode::process_layer.
+    auto obj_bb = model().objects[0]->bounding_box_exact();
+    auto height = base_vfa_block_height * ((params.end - params.start) / params.step + 1);
+    if (height < obj_bb.size().z()) {
+        cut_horizontal(0, 0, height, ModelObjectCutAttribute::KeepLower);
+    }
+
+    if (std::abs(nozzle_scale - 1.0) > EPSILON)
+        model().objects[0]->scale(nozzle_scale, nozzle_scale, nozzle_scale);
+
+    model().objects[0]->ensure_on_bed();
+
     printer_config->set_key_value("resonance_avoidance", new ConfigOptionBool{false});
     filament_config->set_key_value("slow_down_layer_time", new ConfigOptionFloats { 0.0 });
     set_config_values<bool, ConfigOptionBoolsNullable>(print_config, "enable_overhang_speed", false);
@@ -14240,6 +14268,8 @@ void Plater::calib_VFA(const Calib_Params& params)
     print_config->set_key_value("spiral_mode", new ConfigOptionBool(true));
     print_config->set_key_value("enable_wrapping_detection", new ConfigOptionBool(false));
     print_config->set_key_value("precise_z_height", new ConfigOptionBool(false));
+    print_config->set_key_value("initial_layer_print_height", new ConfigOptionFloat(nozzle_diameter/2));
+    model().objects[0]->config.set_key_value("layer_height", new ConfigOptionFloat(nozzle_diameter/2));
     model().objects[0]->config.set_key_value("brim_type", new ConfigOptionEnum<BrimType>(btOuterOnly));
     model().objects[0]->config.set_key_value("brim_width", new ConfigOptionFloat(3.0));
     model().objects[0]->config.set_key_value("brim_object_gap", new ConfigOptionFloat(0.0));
@@ -14249,13 +14279,6 @@ void Plater::calib_VFA(const Calib_Params& params)
     wxGetApp().get_tab(Preset::TYPE_FILAMENT)->update_dirty();
     wxGetApp().get_tab(Preset::TYPE_PRINT)->update_ui_from_settings();
     wxGetApp().get_tab(Preset::TYPE_FILAMENT)->update_ui_from_settings();
-
-    // cut upper
-    auto obj_bb = model().objects[0]->bounding_box_exact();
-    auto height = 5 * ((params.end - params.start) / params.step + 1);
-    if (height < obj_bb.size().z()) {
-        cut_horizontal(0, 0, height, ModelObjectCutAttribute::KeepLower);
-    }
 
     p->background_process.fff_print()->set_calib_params(params);
 }

--- a/src/slic3r/GUI/calib_dlg.cpp
+++ b/src/slic3r/GUI/calib_dlg.cpp
@@ -8,7 +8,9 @@
 #include "Widgets/HyperLink.hpp"
 #include <string>
 #include <vector>
+#include <cmath>
 #include "libslic3r/PrintConfig.hpp"
+#include "libslic3r/Flow.hpp"
 #include "libslic3r/Utils.hpp"
 
 namespace Slic3r { namespace GUI {
@@ -691,6 +693,19 @@ VFA_Test_Dlg::VFA_Test_Dlg(wxWindow* parent, wxWindowID id, Plater* plater)
     vol_step_sizer->Add(m_tiStep     , 0, wxALL | wxALIGN_CENTER_VERTICAL, FromDIP(2));
     settings_sizer->Add(vol_step_sizer, 0, wxLEFT, FromDIP(3));
 
+    // Auto-adjust parameters to the filament's max volumetric speed
+    auto auto_adjust_sizer = new wxBoxSizer(wxHORIZONTAL);
+    m_cbAutoAdjust = new CheckBox(this);
+    m_cbAutoAdjust->SetValue(true);
+    auto auto_adjust_text = new wxStaticText(this, wxID_ANY, _L("Auto-adjust to max volumetric speed"), wxDefaultPosition, wxDefaultSize, wxALIGN_LEFT);
+    m_cbAutoAdjust->SetToolTip(_L("If the end speed would exceed the filament's maximum volumetric speed, automatically lower the layer "
+                                  "height (keeping standard values and staying within the machine's limits) to reach it. If even the "
+                                  "minimum layer height is not enough, lower the end speed instead."));
+    auto_adjust_text->SetToolTip(m_cbAutoAdjust->GetToolTipText());
+    auto_adjust_sizer->Add(m_cbAutoAdjust  , 0, wxALL | wxALIGN_CENTER_VERTICAL, FromDIP(2));
+    auto_adjust_sizer->Add(auto_adjust_text, 0, wxALL | wxALIGN_CENTER_VERTICAL, FromDIP(2));
+    settings_sizer->Add(auto_adjust_sizer, 0, wxLEFT | wxTOP, FromDIP(3));
+
     settings_sizer->AddSpacer(FromDIP(5));
 
     v_sizer->Add(settings_sizer, 0, wxTOP | wxRIGHT | wxLEFT | wxEXPAND, FromDIP(10));
@@ -730,6 +745,134 @@ void VFA_Test_Dlg::on_start(wxCommandEvent& event)
         MessageDialog msg_dlg(nullptr, _L("Please input valid values:\nstart > 10\nstep >= 0\nend > start + step"), wxEmptyString, wxICON_WARNING | wxOK);
         msg_dlg.ShowModal();
         return;
+    }
+
+    // If the requested end speed would exceed the filament's maximum volumetric speed, the slicer clamps the
+    // outer wall speed, so the upper blocks of the tower would all print at the same (clamped) speed instead of
+    // the requested one. Depending on the "Auto-adjust" option, either fix it automatically or just warn.
+    m_params.vfa_layer_height = 0.0; // 0 = auto (nozzle/2); overridden below when auto-adjusting
+    if (const auto* preset_bundle = wxGetApp().preset_bundle) {
+        const auto& printer_config  = preset_bundle->printers.get_edited_preset().config;
+        const auto& print_config    = preset_bundle->prints.get_edited_preset().config;
+        const auto& filament_config = preset_bundle->filaments.get_edited_preset().config;
+
+        const int extruder_id = std::max(m_params.extruder_id, 0);
+        auto get_at = [extruder_id](const ConfigOptionFloats* opt, double fallback) {
+            if (opt == nullptr || opt->values.empty())
+                return fallback;
+            return opt->values[std::min(static_cast<size_t>(extruder_id), opt->values.size() - 1)];
+        };
+
+        const double nozzle_diameter = get_at(printer_config.option<ConfigOptionFloats>("nozzle_diameter"), vfa_base_nozzle_diameter);
+        const double default_lh      = nozzle_diameter / 2.0; // calib_VFA's default layer height
+        const double max_vol_speed   = get_at(filament_config.option<ConfigOptionFloats>("filament_max_volumetric_speed"), 0.0);
+        const double machine_min_lh  = get_at(printer_config.option<ConfigOptionFloats>("min_layer_height"), 0.0);
+        const double machine_max_lh  = get_at(printer_config.option<ConfigOptionFloats>("max_layer_height"), 0.0);
+
+        double line_width = print_config.get_abs_value("outer_wall_line_width", nozzle_diameter);
+        if (line_width <= 0.0)
+            line_width = print_config.get_abs_value("line_width", nozzle_diameter);
+        if (line_width <= 0.0)
+            line_width = nozzle_diameter;
+
+        // Max outer-wall speed printable at a given layer height without exceeding the volumetric limit.
+        auto speed_limit_for_lh = [&](double lh) -> double {
+            const double mm3_per_mm = Flow(line_width, lh, nozzle_diameter).mm3_per_mm();
+            return mm3_per_mm > 0.0 ? max_vol_speed / mm3_per_mm : 1e9;
+        };
+
+        if (max_vol_speed > 0.0 && nozzle_diameter > 0.0 && m_params.end > speed_limit_for_lh(default_lh)) {
+            if (m_cbAutoAdjust->GetValue()) {
+                // Candidate layer heights are the ones actually used by the process profiles compatible with the
+                // current printer (clamped to the machine's layer-height limits, when set). A smaller layer height
+                // means a smaller cross-section, hence a higher printable speed under the volumetric limit; pick the
+                // largest candidate that still reaches the end speed to keep the change from the default minimal.
+                std::vector<double> candidates;
+                for (const auto& preset : preset_bundle->prints.get_presets()) {
+                    if (!preset.is_compatible || preset.is_default)
+                        continue;
+                    const auto* lh_opt = preset.config.option<ConfigOptionFloat>("layer_height");
+                    if (lh_opt == nullptr || lh_opt->value <= 0.0)
+                        continue;
+                    const double lh = lh_opt->value;
+                    if ((machine_min_lh > 0.0 && lh < machine_min_lh - 1e-6) ||
+                        (machine_max_lh > 0.0 && lh > machine_max_lh + 1e-6))
+                        continue;
+                    candidates.push_back(lh);
+                }
+                std::sort(candidates.begin(), candidates.end());
+                candidates.erase(std::unique(candidates.begin(), candidates.end(),
+                                             [](double a, double b) { return std::abs(a - b) < 1e-6; }),
+                                 candidates.end());
+
+                // Largest candidate <= the default layer height that still reaches the end speed (smallest change).
+                double chosen_lh = 0.0;
+                for (auto it = candidates.rbegin(); it != candidates.rend(); ++it) {
+                    if (*it > default_lh + 1e-6)
+                        continue; // never increase the layer height above the default
+                    if (speed_limit_for_lh(*it) >= m_params.end) { chosen_lh = *it; break; }
+                }
+
+                if (chosen_lh > 0.0) {
+                    // Reducing the layer height is enough to reach the requested end speed.
+                    m_params.vfa_layer_height = chosen_lh;
+                    MessageDialog msg_dlg(nullptr,
+                        wxString::Format(_L("The end speed (%.0f mm/s) exceeds the filament's maximum volumetric speed "
+                                            "(%.1f mm³/s) at the default layer height (%.2f mm).\n\n"
+                                            "The layer height has been reduced to %.2f mm (a value used by this printer's "
+                                            "profiles) so the tower can reach the requested speed."),
+                                         m_params.end, max_vol_speed, default_lh, chosen_lh),
+                        _L("VFA test"), wxICON_INFORMATION | wxOK);
+                    msg_dlg.ShowModal();
+                } else if (!candidates.empty()) {
+                    // Even the smallest available layer height cannot reach the end speed; propose a lower end speed
+                    // based on that layer height, the line width and the maximum volumetric speed.
+                    const double min_lh    = candidates.front();
+                    const double reachable = speed_limit_for_lh(min_lh);
+                    double new_end = std::floor(reachable / m_params.step) * m_params.step; // snap down to a step multiple
+                    if (new_end < m_params.start + m_params.step)
+                        new_end = m_params.start + m_params.step;
+                    MessageDialog msg_dlg(nullptr,
+                        wxString::Format(_L("Even at the smallest layer height used by this printer's profiles (%.2f mm) the "
+                                            "end speed (%.0f mm/s) exceeds the filament's maximum volumetric speed "
+                                            "(%.1f mm³/s).\n\n"
+                                            "The layer height will be set to %.2f mm and the end speed lowered to %.0f mm/s.\n\n"
+                                            "Continue?"),
+                                         min_lh, m_params.end, max_vol_speed, min_lh, new_end),
+                        _L("VFA test"), wxICON_WARNING | wxYES_NO | wxNO_DEFAULT);
+                    if (msg_dlg.ShowModal() != wxID_YES)
+                        return;
+                    m_params.end              = new_end;
+                    m_params.vfa_layer_height = min_lh;
+                } else {
+                    // No compatible process profiles to draw layer heights from: warn and let the user decide.
+                    const double max_speed = speed_limit_for_lh(default_lh);
+                    MessageDialog msg_dlg(nullptr,
+                        wxString::Format(_L("The end speed (%.0f mm/s) exceeds the filament's maximum volumetric speed "
+                                            "(%.1f mm³/s), which limits the outer wall to about %.0f mm/s at this line width and "
+                                            "layer height. Speeds above this will be clamped, so the upper blocks of the tower "
+                                            "will not print at the requested speed.\n\n"
+                                            "Continue anyway?"),
+                                         m_params.end, max_vol_speed, max_speed),
+                        _L("VFA test"), wxICON_WARNING | wxYES_NO | wxNO_DEFAULT);
+                    if (msg_dlg.ShowModal() != wxID_YES)
+                        return;
+                }
+            } else {
+                // Auto-adjust disabled: warn and let the user decide whether to continue.
+                const double max_speed = speed_limit_for_lh(default_lh);
+                MessageDialog msg_dlg(nullptr,
+                    wxString::Format(_L("The end speed (%.0f mm/s) exceeds the filament's maximum volumetric speed "
+                                        "(%.1f mm³/s), which limits the outer wall to about %.0f mm/s at this line width and "
+                                        "layer height. Speeds above this will be clamped, so the upper blocks of the tower will "
+                                        "not print at the requested speed.\n\n"
+                                        "Enable \"Auto-adjust\" to fix this automatically, or continue anyway?"),
+                                     m_params.end, max_vol_speed, max_speed),
+                    _L("VFA test"), wxICON_WARNING | wxYES_NO | wxNO_DEFAULT);
+                if (msg_dlg.ShowModal() != wxID_YES)
+                    return;
+            }
+        }
     }
 
     m_params.mode = CalibMode::Calib_VFA_Tower;

--- a/src/slic3r/GUI/calib_dlg.cpp
+++ b/src/slic3r/GUI/calib_dlg.cpp
@@ -36,6 +36,23 @@ int GetTextMax(wxWindow* parent, const std::vector<wxString>& labels)
     return text_size.x + parent->FromDIP(10);
 }
 
+CheckBox* add_scale_checkbox(wxWindow* parent, wxSizer* settings_sizer)
+{
+    auto row  = new wxBoxSizer(wxHORIZONTAL);
+    auto cb   = new CheckBox(parent);
+    cb->SetValue(true);
+    auto text = new wxStaticText(parent, wxID_ANY, _L("Auto-scale for nozzle"), wxDefaultPosition, wxDefaultSize, wxALIGN_LEFT);
+    cb->SetToolTip(_L("This model is designed around a 0.4 mm nozzle with a 0.2 mm layer height. \n"
+                      "When the scaling option is enabled (recommended), it dynamically resizes to match your current nozzle diameter"
+                      " and an appropriate layer height, making the test both accurate and easy to read.\n"
+                      "Turn scaling off only if you wish to print the reference model exactly as-is."));
+    text->SetToolTip(cb->GetToolTipText());
+    row->Add(cb  , 0, wxALL | wxALIGN_CENTER_VERTICAL, parent->FromDIP(2));
+    row->Add(text, 0, wxALL | wxALIGN_CENTER_VERTICAL, parent->FromDIP(2));
+    settings_sizer->Add(row, 0, wxLEFT | wxTOP, parent->FromDIP(3));
+    return cb;
+}
+
 std::vector<std::string> get_shaper_type_values()
 {
     if (auto* preset_bundle = wxGetApp().preset_bundle) {
@@ -405,17 +422,7 @@ Temp_Calibration_Dlg::Temp_Calibration_Dlg(wxWindow* parent, wxWindowID id, Plat
     settings_sizer->Add(temp_step_sizer, 0, wxLEFT, FromDIP(3));
 
     // Resize the model to the nozzle diameter (recommended)
-    auto resize_sizer = new wxBoxSizer(wxHORIZONTAL);
-    m_cbResize = new CheckBox(this);
-    m_cbResize->SetValue(true);
-    auto resize_text = new wxStaticText(this, wxID_ANY, _L("Resize for nozzle diameter"), wxDefaultPosition, wxDefaultSize, wxALIGN_LEFT);
-    m_cbResize->SetToolTip(_L("The calibration model is designed for a 0.4 mm nozzle and 0.2 mm layer height. When enabled it is "
-                              "scaled to your nozzle diameter with a matching layer height, which is recommended for an accurate "
-                              "test that is easy to read. Disable only to print the reference model as-is."));
-    resize_text->SetToolTip(m_cbResize->GetToolTipText());
-    resize_sizer->Add(m_cbResize , 0, wxALL | wxALIGN_CENTER_VERTICAL, FromDIP(2));
-    resize_sizer->Add(resize_text, 0, wxALL | wxALIGN_CENTER_VERTICAL, FromDIP(2));
-    settings_sizer->Add(resize_sizer, 0, wxLEFT | wxTOP, FromDIP(3));
+    m_cbResize = add_scale_checkbox(this, settings_sizer);
 
     settings_sizer->AddSpacer(FromDIP(5));
 
@@ -708,17 +715,7 @@ VFA_Test_Dlg::VFA_Test_Dlg(wxWindow* parent, wxWindowID id, Plater* plater)
     settings_sizer->Add(vol_step_sizer, 0, wxLEFT, FromDIP(3));
 
     // Resize the model to the nozzle diameter (recommended)
-    auto resize_sizer = new wxBoxSizer(wxHORIZONTAL);
-    m_cbResize = new CheckBox(this);
-    m_cbResize->SetValue(true);
-    auto resize_text = new wxStaticText(this, wxID_ANY, _L("Resize for nozzle diameter"), wxDefaultPosition, wxDefaultSize, wxALIGN_LEFT);
-    m_cbResize->SetToolTip(_L("The calibration model is designed for a 0.4 mm nozzle and 0.2 mm layer height. When enabled it is "
-                              "scaled to your nozzle diameter with a matching layer height, which is recommended for an accurate "
-                              "test that is easy to read. Disable only to print the reference model as-is."));
-    resize_text->SetToolTip(m_cbResize->GetToolTipText());
-    resize_sizer->Add(m_cbResize , 0, wxALL | wxALIGN_CENTER_VERTICAL, FromDIP(2));
-    resize_sizer->Add(resize_text, 0, wxALL | wxALIGN_CENTER_VERTICAL, FromDIP(2));
-    settings_sizer->Add(resize_sizer, 0, wxLEFT | wxTOP, FromDIP(3));
+    m_cbResize = add_scale_checkbox(this, settings_sizer);
 
     // Auto-adjust parameters to the filament's max volumetric speed
     auto auto_adjust_sizer = new wxBoxSizer(wxHORIZONTAL);
@@ -814,6 +811,17 @@ void VFA_Test_Dlg::on_start(wxCommandEvent& event)
             return mm3_per_mm > 0.0 ? max_vol_speed / mm3_per_mm : 1e9;
         };
 
+        auto confirm_clamp = [&](const wxString& question) -> bool {
+            MessageDialog msg_dlg(nullptr,
+                wxString::Format(_L("The end speed (%.0f mm/s) exceeds the filament's maximum volumetric speed "
+                                    "(%.1f mm³/s), which limits the outer wall to about %.0f mm/s at this line width and "
+                                    "layer height.\n Speeds above this will be clamped, so the upper blocks of the tower "
+                                    "will not print at the requested speed.\n\n%s"),
+                                 m_params.end, max_vol_speed, speed_limit_for_lh(default_lh), question),
+                _L("VFA test"), wxICON_WARNING | wxYES_NO | wxNO_DEFAULT);
+            return msg_dlg.ShowModal() == wxID_YES;
+        };
+
         if (max_vol_speed > 0.0 && nozzle_diameter > 0.0 && m_params.end > speed_limit_for_lh(default_lh)) {
             // The layer-height auto-adjust only applies when resizing is enabled (it changes the layer height).
             if (m_cbAutoAdjust->GetValue() && m_params.nozzle_based_resize) {
@@ -880,32 +888,14 @@ void VFA_Test_Dlg::on_start(wxCommandEvent& event)
                     m_params.vfa_layer_height = min_lh;
                 } else {
                     // No compatible process profiles to draw layer heights from: warn and let the user decide.
-                    const double max_speed = speed_limit_for_lh(default_lh);
-                    MessageDialog msg_dlg(nullptr,
-                        wxString::Format(_L("The end speed (%.0f mm/s) exceeds the filament's maximum volumetric speed "
-                                            "(%.1f mm³/s), which limits the outer wall to about %.0f mm/s at this line width and "
-                                            "layer height. Speeds above this will be clamped, so the upper blocks of the tower "
-                                            "will not print at the requested speed.\n\n"
-                                            "Continue anyway?"),
-                                         m_params.end, max_vol_speed, max_speed),
-                        _L("VFA test"), wxICON_WARNING | wxYES_NO | wxNO_DEFAULT);
-                    if (msg_dlg.ShowModal() != wxID_YES)
+                    if (!confirm_clamp(_L("Continue anyway?")))
                         return;
                 }
             } else {
                 // Auto-adjust off, or resizing disabled (which forbids changing the layer height): just warn.
-                const double max_speed = speed_limit_for_lh(default_lh);
-                const wxString hint = m_params.nozzle_based_resize
-                    ? _L("Enable \"Auto-adjust\" to fix this automatically, or continue anyway?")
-                    : _L("Enable \"Resize for nozzle diameter\" and \"Auto-adjust\" to fix this automatically, or continue anyway?");
-                MessageDialog msg_dlg(nullptr,
-                    wxString::Format(_L("The end speed (%.0f mm/s) exceeds the filament's maximum volumetric speed "
-                                        "(%.1f mm³/s), which limits the outer wall to about %.0f mm/s at this line width and "
-                                        "layer height. Speeds above this will be clamped, so the upper blocks of the tower will "
-                                        "not print at the requested speed.\n\n%s"),
-                                     m_params.end, max_vol_speed, max_speed, hint),
-                    _L("VFA test"), wxICON_WARNING | wxYES_NO | wxNO_DEFAULT);
-                if (msg_dlg.ShowModal() != wxID_YES)
+                if (!confirm_clamp(m_params.nozzle_based_resize
+                        ? _L("Enable \"Auto-adjust\" to fix this automatically, or continue anyway?")
+                        : _L("Enable \"Auto-scale for nozzle\" and \"Auto-adjust\" to fix this automatically, or continue anyway?")))
                     return;
             }
         }

--- a/src/slic3r/GUI/calib_dlg.cpp
+++ b/src/slic3r/GUI/calib_dlg.cpp
@@ -404,6 +404,19 @@ Temp_Calibration_Dlg::Temp_Calibration_Dlg(wxWindow* parent, wxWindowID id, Plat
     temp_step_sizer->Add(m_tiStep      , 0, wxALL | wxALIGN_CENTER_VERTICAL, FromDIP(2));
     settings_sizer->Add(temp_step_sizer, 0, wxLEFT, FromDIP(3));
 
+    // Resize the model to the nozzle diameter (recommended)
+    auto resize_sizer = new wxBoxSizer(wxHORIZONTAL);
+    m_cbResize = new CheckBox(this);
+    m_cbResize->SetValue(true);
+    auto resize_text = new wxStaticText(this, wxID_ANY, _L("Resize for nozzle diameter"), wxDefaultPosition, wxDefaultSize, wxALIGN_LEFT);
+    m_cbResize->SetToolTip(_L("The calibration model is designed for a 0.4 mm nozzle and 0.2 mm layer height. When enabled it is "
+                              "scaled to your nozzle diameter with a matching layer height, which is recommended for an accurate "
+                              "test that is easy to read. Disable only to print the reference model as-is."));
+    resize_text->SetToolTip(m_cbResize->GetToolTipText());
+    resize_sizer->Add(m_cbResize , 0, wxALL | wxALIGN_CENTER_VERTICAL, FromDIP(2));
+    resize_sizer->Add(resize_text, 0, wxALL | wxALIGN_CENTER_VERTICAL, FromDIP(2));
+    settings_sizer->Add(resize_sizer, 0, wxLEFT | wxTOP, FromDIP(3));
+
     settings_sizer->AddSpacer(FromDIP(5));
 
     v_sizer->Add(settings_sizer, 0, wxTOP | wxRIGHT | wxLEFT | wxEXPAND, FromDIP(10));
@@ -477,6 +490,7 @@ void Temp_Calibration_Dlg::on_start(wxCommandEvent& event) {
     }
     m_params.start = start;
     m_params.end = end;
+    m_params.nozzle_based_resize = m_cbResize->GetValue();
     m_params.mode = CalibMode::Calib_Temp_Tower;
     m_plater->calib_temp(m_params);
     EndModal(wxID_OK);
@@ -693,6 +707,19 @@ VFA_Test_Dlg::VFA_Test_Dlg(wxWindow* parent, wxWindowID id, Plater* plater)
     vol_step_sizer->Add(m_tiStep     , 0, wxALL | wxALIGN_CENTER_VERTICAL, FromDIP(2));
     settings_sizer->Add(vol_step_sizer, 0, wxLEFT, FromDIP(3));
 
+    // Resize the model to the nozzle diameter (recommended)
+    auto resize_sizer = new wxBoxSizer(wxHORIZONTAL);
+    m_cbResize = new CheckBox(this);
+    m_cbResize->SetValue(true);
+    auto resize_text = new wxStaticText(this, wxID_ANY, _L("Resize for nozzle diameter"), wxDefaultPosition, wxDefaultSize, wxALIGN_LEFT);
+    m_cbResize->SetToolTip(_L("The calibration model is designed for a 0.4 mm nozzle and 0.2 mm layer height. When enabled it is "
+                              "scaled to your nozzle diameter with a matching layer height, which is recommended for an accurate "
+                              "test that is easy to read. Disable only to print the reference model as-is."));
+    resize_text->SetToolTip(m_cbResize->GetToolTipText());
+    resize_sizer->Add(m_cbResize , 0, wxALL | wxALIGN_CENTER_VERTICAL, FromDIP(2));
+    resize_sizer->Add(resize_text, 0, wxALL | wxALIGN_CENTER_VERTICAL, FromDIP(2));
+    settings_sizer->Add(resize_sizer, 0, wxLEFT | wxTOP, FromDIP(3));
+
     // Auto-adjust parameters to the filament's max volumetric speed
     auto auto_adjust_sizer = new wxBoxSizer(wxHORIZONTAL);
     m_cbAutoAdjust = new CheckBox(this);
@@ -750,7 +777,8 @@ void VFA_Test_Dlg::on_start(wxCommandEvent& event)
     // If the requested end speed would exceed the filament's maximum volumetric speed, the slicer clamps the
     // outer wall speed, so the upper blocks of the tower would all print at the same (clamped) speed instead of
     // the requested one. Depending on the "Auto-adjust" option, either fix it automatically or just warn.
-    m_params.vfa_layer_height = 0.0; // 0 = auto (nozzle/2); overridden below when auto-adjusting
+    m_params.vfa_layer_height    = 0.0; // 0 = auto (nozzle/2); overridden below when auto-adjusting
+    m_params.nozzle_based_resize = m_cbResize->GetValue();
     if (const auto* preset_bundle = wxGetApp().preset_bundle) {
         const auto& printer_config  = preset_bundle->printers.get_edited_preset().config;
         const auto& print_config    = preset_bundle->prints.get_edited_preset().config;
@@ -764,7 +792,12 @@ void VFA_Test_Dlg::on_start(wxCommandEvent& event)
         };
 
         const double nozzle_diameter = get_at(printer_config.option<ConfigOptionFloats>("nozzle_diameter"), vfa_base_nozzle_diameter);
-        const double default_lh      = nozzle_diameter / 2.0; // calib_VFA's default layer height
+        double preset_lh = nozzle_diameter / 2.0;
+        if (const auto* lh_opt = print_config.option<ConfigOptionFloat>("layer_height"))
+            if (lh_opt->value > 0.0)
+                preset_lh = lh_opt->value;
+        // Layer height the tower will actually print at: nozzle/2 when resizing, else the preset value.
+        const double default_lh      = m_params.nozzle_based_resize ? nozzle_diameter / 2.0 : preset_lh;
         const double max_vol_speed   = get_at(filament_config.option<ConfigOptionFloats>("filament_max_volumetric_speed"), 0.0);
         const double machine_min_lh  = get_at(printer_config.option<ConfigOptionFloats>("min_layer_height"), 0.0);
         const double machine_max_lh  = get_at(printer_config.option<ConfigOptionFloats>("max_layer_height"), 0.0);
@@ -782,7 +815,8 @@ void VFA_Test_Dlg::on_start(wxCommandEvent& event)
         };
 
         if (max_vol_speed > 0.0 && nozzle_diameter > 0.0 && m_params.end > speed_limit_for_lh(default_lh)) {
-            if (m_cbAutoAdjust->GetValue()) {
+            // The layer-height auto-adjust only applies when resizing is enabled (it changes the layer height).
+            if (m_cbAutoAdjust->GetValue() && m_params.nozzle_based_resize) {
                 // Candidate layer heights are the ones actually used by the process profiles compatible with the
                 // current printer (clamped to the machine's layer-height limits, when set). A smaller layer height
                 // means a smaller cross-section, hence a higher printable speed under the volumetric limit; pick the
@@ -859,15 +893,17 @@ void VFA_Test_Dlg::on_start(wxCommandEvent& event)
                         return;
                 }
             } else {
-                // Auto-adjust disabled: warn and let the user decide whether to continue.
+                // Auto-adjust off, or resizing disabled (which forbids changing the layer height): just warn.
                 const double max_speed = speed_limit_for_lh(default_lh);
+                const wxString hint = m_params.nozzle_based_resize
+                    ? _L("Enable \"Auto-adjust\" to fix this automatically, or continue anyway?")
+                    : _L("Enable \"Resize for nozzle diameter\" and \"Auto-adjust\" to fix this automatically, or continue anyway?");
                 MessageDialog msg_dlg(nullptr,
                     wxString::Format(_L("The end speed (%.0f mm/s) exceeds the filament's maximum volumetric speed "
                                         "(%.1f mm³/s), which limits the outer wall to about %.0f mm/s at this line width and "
                                         "layer height. Speeds above this will be clamped, so the upper blocks of the tower will "
-                                        "not print at the requested speed.\n\n"
-                                        "Enable \"Auto-adjust\" to fix this automatically, or continue anyway?"),
-                                     m_params.end, max_vol_speed, max_speed),
+                                        "not print at the requested speed.\n\n%s"),
+                                     m_params.end, max_vol_speed, max_speed, hint),
                     _L("VFA test"), wxICON_WARNING | wxYES_NO | wxNO_DEFAULT);
                 if (msg_dlg.ShowModal() != wxID_YES)
                     return;

--- a/src/slic3r/GUI/calib_dlg.hpp
+++ b/src/slic3r/GUI/calib_dlg.hpp
@@ -99,6 +99,7 @@ protected:
     TextInput* m_tiStart;
     TextInput* m_tiEnd;
     TextInput* m_tiStep;
+    CheckBox*  m_cbAutoAdjust;
     Plater* m_plater;
 };
 

--- a/src/slic3r/GUI/calib_dlg.hpp
+++ b/src/slic3r/GUI/calib_dlg.hpp
@@ -65,6 +65,7 @@ protected:
     TextInput* m_tiStart;
     TextInput* m_tiEnd;
     TextInput* m_tiStep;
+    CheckBox*  m_cbResize;
     Plater* m_plater;
 };
 
@@ -100,6 +101,7 @@ protected:
     TextInput* m_tiEnd;
     TextInput* m_tiStep;
     CheckBox*  m_cbAutoAdjust;
+    CheckBox*  m_cbResize;
     Plater* m_plater;
 };
 

--- a/src/slic3r/Utils/CalibUtils.cpp
+++ b/src/slic3r/Utils/CalibUtils.cpp
@@ -1301,8 +1301,10 @@ void CalibUtils::calib_VFA(const CalibInfo &calib_info, wxString &error_message)
 
     // cut upper (on the unscaled model, using the base block height); the scaling below keeps the physical
     // block height (vfa_layers_per_block * layer_height) in sync with the speed stepping in GCode::process_layer.
+    // Subtract EPSILON (as the temperature tower does) so the cut lands just below the flat block surface instead
+    // of exactly on it, which would otherwise add a degenerate extra layer.
     auto obj_bb = model.objects[0]->bounding_box_exact();
-    auto height = vfa_base_block_height * ((params.end - params.start) / params.step + 1);
+    auto height = vfa_base_block_height * ((params.end - params.start) / params.step + 1) - EPSILON;
     if (height < obj_bb.size().z()) {
         cut_model(model, height, ModelObjectCutAttribute::KeepLower);
     }

--- a/src/slic3r/Utils/CalibUtils.cpp
+++ b/src/slic3r/Utils/CalibUtils.cpp
@@ -1265,6 +1265,19 @@ void CalibUtils::calib_VFA(const CalibInfo &calib_info, wxString &error_message)
     DynamicPrintConfig filament_config = calib_info.filament_prest->config;
     DynamicPrintConfig printer_config  = calib_info.printer_prest->config;
 
+    constexpr double base_vfa_nozzle_diameter = 0.4;
+    constexpr double base_vfa_block_height     = 5.0;
+    const ConfigOptionFloats* nozzle_diameter_config = printer_config.option<ConfigOptionFloats>("nozzle_diameter");
+    size_t nozzle_id = static_cast<size_t>(std::max(params.extruder_id, 0));
+    double nozzle_diameter = base_vfa_nozzle_diameter;
+    if (nozzle_diameter_config && !nozzle_diameter_config->values.empty()) {
+        nozzle_id = std::min(nozzle_id, nozzle_diameter_config->values.size() - 1);
+        nozzle_diameter = nozzle_diameter_config->values[nozzle_id];
+    }
+    if (nozzle_diameter <= 0.0)
+        nozzle_diameter = base_vfa_nozzle_diameter;
+    const double nozzle_scale = nozzle_diameter / base_vfa_nozzle_diameter;
+
     filament_config.set_key_value("slow_down_layer_time", new ConfigOptionInts{0});
     filament_config.set_key_value("filament_max_volumetric_speed", new ConfigOptionFloats{200});
     filament_config.set_key_value("curr_bed_type", new ConfigOptionEnum<BedType>(calib_info.bed_type));
@@ -1280,13 +1293,16 @@ void CalibUtils::calib_VFA(const CalibInfo &calib_info, wxString &error_message)
     print_config.set_key_value("sparse_infill_density", new ConfigOptionPercent(0));
     print_config.set_key_value("overhang_reverse", new ConfigOptionBool(false));
     print_config.set_key_value("spiral_mode", new ConfigOptionBool(true));
+    print_config.set_key_value("initial_layer_print_height", new ConfigOptionFloat(nozzle_diameter / 2));
+    model.objects[0]->config.set_key_value("layer_height", new ConfigOptionFloat(nozzle_diameter / 2));
     model.objects[0]->config.set_key_value("brim_type", new ConfigOptionEnum<BrimType>(btOuterOnly));
     model.objects[0]->config.set_key_value("brim_width", new ConfigOptionFloat(3.0));
     model.objects[0]->config.set_key_value("brim_object_gap", new ConfigOptionFloat(0.0));
 
-    // cut upper
+    // cut upper (on the unscaled model, using the base block height); the scaling below keeps the
+    // physical block height in sync with the speed stepping in GCode::process_layer.
     auto obj_bb = model.objects[0]->bounding_box_exact();
-    auto height = 5 * ((params.end - params.start) / params.step + 1);
+    auto height = base_vfa_block_height * ((params.end - params.start) / params.step + 1);
     if (height < obj_bb.size().z()) {
         cut_model(model, height, ModelObjectCutAttribute::KeepLower);
     }
@@ -1294,6 +1310,10 @@ void CalibUtils::calib_VFA(const CalibInfo &calib_info, wxString &error_message)
         error_message = _L("The start, end or step is not valid value.");
         return;
     }
+
+    if (std::abs(nozzle_scale - 1.0) > EPSILON)
+        model.objects[0]->scale(nozzle_scale, nozzle_scale, nozzle_scale);
+    model.objects[0]->ensure_on_bed();
 
     DynamicPrintConfig full_config;
     full_config.apply(FullPrintConfig::defaults());

--- a/src/slic3r/Utils/CalibUtils.cpp
+++ b/src/slic3r/Utils/CalibUtils.cpp
@@ -1265,18 +1265,18 @@ void CalibUtils::calib_VFA(const CalibInfo &calib_info, wxString &error_message)
     DynamicPrintConfig filament_config = calib_info.filament_prest->config;
     DynamicPrintConfig printer_config  = calib_info.printer_prest->config;
 
-    constexpr double base_vfa_nozzle_diameter = 0.4;
-    constexpr double base_vfa_block_height     = 5.0;
     const ConfigOptionFloats* nozzle_diameter_config = printer_config.option<ConfigOptionFloats>("nozzle_diameter");
     size_t nozzle_id = static_cast<size_t>(std::max(params.extruder_id, 0));
-    double nozzle_diameter = base_vfa_nozzle_diameter;
+    double nozzle_diameter = vfa_base_nozzle_diameter;
     if (nozzle_diameter_config && !nozzle_diameter_config->values.empty()) {
         nozzle_id = std::min(nozzle_id, nozzle_diameter_config->values.size() - 1);
         nozzle_diameter = nozzle_diameter_config->values[nozzle_id];
     }
     if (nozzle_diameter <= 0.0)
-        nozzle_diameter = base_vfa_nozzle_diameter;
-    const double nozzle_scale = nozzle_diameter / base_vfa_nozzle_diameter;
+        nozzle_diameter = vfa_base_nozzle_diameter;
+
+    // Resolved layer height: use the (possibly auto-adjusted) value if provided, else default to nozzle/2.
+    double layer_height = params.vfa_layer_height > 0.0 ? params.vfa_layer_height : nozzle_diameter / 2.0;
 
     filament_config.set_key_value("slow_down_layer_time", new ConfigOptionInts{0});
     filament_config.set_key_value("filament_max_volumetric_speed", new ConfigOptionFloats{200});
@@ -1293,16 +1293,16 @@ void CalibUtils::calib_VFA(const CalibInfo &calib_info, wxString &error_message)
     print_config.set_key_value("sparse_infill_density", new ConfigOptionPercent(0));
     print_config.set_key_value("overhang_reverse", new ConfigOptionBool(false));
     print_config.set_key_value("spiral_mode", new ConfigOptionBool(true));
-    print_config.set_key_value("initial_layer_print_height", new ConfigOptionFloat(nozzle_diameter / 2));
-    model.objects[0]->config.set_key_value("layer_height", new ConfigOptionFloat(nozzle_diameter / 2));
+    print_config.set_key_value("initial_layer_print_height", new ConfigOptionFloat(layer_height));
+    model.objects[0]->config.set_key_value("layer_height", new ConfigOptionFloat(layer_height));
     model.objects[0]->config.set_key_value("brim_type", new ConfigOptionEnum<BrimType>(btOuterOnly));
     model.objects[0]->config.set_key_value("brim_width", new ConfigOptionFloat(3.0));
     model.objects[0]->config.set_key_value("brim_object_gap", new ConfigOptionFloat(0.0));
 
-    // cut upper (on the unscaled model, using the base block height); the scaling below keeps the
-    // physical block height in sync with the speed stepping in GCode::process_layer.
+    // cut upper (on the unscaled model, using the base block height); the scaling below keeps the physical
+    // block height (vfa_layers_per_block * layer_height) in sync with the speed stepping in GCode::process_layer.
     auto obj_bb = model.objects[0]->bounding_box_exact();
-    auto height = base_vfa_block_height * ((params.end - params.start) / params.step + 1);
+    auto height = vfa_base_block_height * ((params.end - params.start) / params.step + 1);
     if (height < obj_bb.size().z()) {
         cut_model(model, height, ModelObjectCutAttribute::KeepLower);
     }
@@ -1311,8 +1311,11 @@ void CalibUtils::calib_VFA(const CalibInfo &calib_info, wxString &error_message)
         return;
     }
 
-    if (std::abs(nozzle_scale - 1.0) > EPSILON)
-        model.objects[0]->scale(nozzle_scale, nozzle_scale, nozzle_scale);
+    // XY scales with the nozzle; Z scales so each base block becomes vfa_layers_per_block layers of layer_height.
+    const double xy_scale = nozzle_diameter / vfa_base_nozzle_diameter;
+    const double z_scale  = (vfa_layers_per_block * layer_height) / vfa_base_block_height;
+    if (std::abs(xy_scale - 1.0) > EPSILON || std::abs(z_scale - 1.0) > EPSILON)
+        model.objects[0]->scale(xy_scale, xy_scale, z_scale);
     model.objects[0]->ensure_on_bed();
 
     DynamicPrintConfig full_config;
@@ -1323,7 +1326,10 @@ void CalibUtils::calib_VFA(const CalibInfo &calib_info, wxString &error_message)
 
     init_multi_extruder_params_for_cali(full_config, calib_info);
 
-    process_and_store_3mf(&model, full_config, params, error_message);
+    // Pass the resolved layer height on so the GCode speed stepping matches the geometry.
+    Calib_Params store_params = params;
+    store_params.vfa_layer_height = layer_height;
+    process_and_store_3mf(&model, full_config, store_params, error_message);
     if (!error_message.empty())
         return;
 


### PR DESCRIPTION
Closes #14661

# VFA

The VFA tower was a fixed size designed for a 0.4 mm nozzle.
On other nozzle sizes that causes some issues (like #14661 ).
This PR makes the VFA test adapt to the nozzle (the same treatment the Temperature Tower already got) and adds a safeguard so the test stays valid when the requested speeds are too high for the filament.

## Nozzle-based sizing

The VFA tower is now scaled to the nozzle: footprint (XY) scales with nozzle diameter, and layer height defaults to nozzle / 2.
Each speed block always keeps 25 layers, so the tower height is recomputed from the layer height. The block-to-speed mapping in the generated G-code stays in sync with the geometry.
For a 0.4 mm nozzle the result is identical to before, so existing behavior is unchanged.

## Max volumetric speed check

The VFA dialog now detects when the end speed exceeds the filament's maximum volumetric speed and reacts based on a new "Auto-adjust to max volumetric speed" checkbox (on by default):
Auto-adjust on: lowers the layer height to a value actually used by the printer's process profiles (staying within the machine's min/max layer-height limits) so the tower can reach the requested speed with the smallest possible change. If even the smallest available layer height isn't enough, it proposes a lower end speed and asks to confirm.
Auto-adjust off: simply warns and lets the user continue anyway.

## Tests

<img width="320" height="288" alt="imagen" src="https://github.com/user-attachments/assets/abb40474-d70d-4b11-8e75-7dde00fcecc2" />
<img width="809" height="195" alt="imagen" src="https://github.com/user-attachments/assets/b34ea295-8fb0-49b2-b2aa-9391a626366f" />
<img width="1476" height="574" alt="imagen" src="https://github.com/user-attachments/assets/7f39f992-c3c7-4b36-b5e7-1182800e337e" />
<img width="1476" height="574" alt="imagen" src="https://github.com/user-attachments/assets/4d64e201-0be2-47a0-881a-19ae3b416e24" />

# PA Tower

Use the interpolator to improve the range.

The tower is cut to ceil((end−start)/step)+1 mm and the old formula stepped PA by step every 1 mm (start + floor(print_z)·step). The interpolate call produces n_bands = round((end−start)/step)+1 equal bands across the layers, giving start + band·step.

# Temp Tower

<img width="256" height="433" alt="imagen" src="https://github.com/user-attachments/assets/05a1acf9-20b5-460f-a840-f88003883f9f" />

Add a size adjustment checkbox for users that want to keep the 0.4 model size for users like the comment at #12269

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
