### PR TITLE
fix: emit M104 after T0 in single-extruder MM set_extruder (#14753)

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -8746,6 +8746,18 @@ std::string GCode::set_extruder(unsigned int new_filament_id, double print_z, bo
         gcode += m_writer.toolchange(new_filament_id, new_extruder_id);
         if (Extruder *fil = m_writer.filament())
             fil->set_config_index((int)get_filament_config_index((int)fil->id()));
+
+        // Set the temperature after the toolchange for single-extruder multi-material
+        // (e.g. CFS/MMU) so the slicer temperature is the last command after the
+        // auto-inserted T0, matching the multi-extruder branch below. Without this,
+        // firmware/CFS temperature overrides on T-commands win because no M104 follows.
+        if (m_config.single_extruder_multi_material && !m_config.enable_prime_tower) {
+            size_t new_fi = get_filament_config_index(new_filament_id);
+            int temp = (m_layer_index <= 0 ? m_config.nozzle_temperature_initial_layer.get_at(new_fi) :
+                                             m_config.nozzle_temperature.get_at(new_fi));
+            gcode += m_writer.set_temperature(temp, false);
+        }
+
         return gcode;
     }
 

--- a/tests/fff_print/test_multifilament.cpp
+++ b/tests/fff_print/test_multifilament.cpp
@@ -5,6 +5,7 @@
 #include "test_helpers.hpp"
 
 #include <cctype>
+#include <iostream>
 #include <set>
 #include <string>
 
@@ -103,4 +104,43 @@ TEST_CASE("Multi-extruder slice stays in bounds with a short max_layer_height", 
     Print print;
     init_and_process_print({ cube(20) }, print, config);
     REQUIRE_FALSE(print.objects().front()->layers().empty());
+}
+
+// Regression for #14753: the single-extruder branch of set_extruder emits T0
+// without a follow-up M104, so firmware/CFS temperature overrides on T-commands
+// win. The fix emits M104 after T0, matching the multi-extruder branch.
+// Uses 2 filaments (single-extruder MM) with all features on filament 1 (T0),
+// so the single-extruder branch fires and emits a T0 toolchange at print start.
+TEST_CASE("Single-extruder MM emits M104 after T0 toolchange", "[MultiFilament]")
+{
+    const int expected_temp = 240;
+    const std::string gcode = slice({ cube(20) },
+        multifilament_config(2, {
+            { "nozzle_temperature",               std::to_string(expected_temp) + "," + std::to_string(expected_temp) },
+            { "nozzle_temperature_initial_layer", std::to_string(expected_temp) + "," + std::to_string(expected_temp) },
+            { "machine_start_gcode",              "" },
+            { "filament_start_gcode",             "" },
+            { "enable_prime_tower",               "0" },
+        }));
+
+    bool found_t0 = false;
+    bool found_temp_after_t0 = false;
+    int  temp_after_t0 = -1;
+    GCodeReader reader;
+    reader.parse_buffer(gcode, [&](GCodeReader&, const GCodeReader::GCodeLine& line) {
+        const std::string cmd(line.cmd());
+        if (!found_t0) {
+            if (cmd == "T0")
+                found_t0 = true;
+        } else if (!found_temp_after_t0 && (cmd == "M104" || cmd == "M109")) {
+            found_temp_after_t0 = true;
+            float s_val = 0;
+            if (line.has_value('S', s_val))
+                temp_after_t0 = int(s_val);
+        }
+    });
+
+    REQUIRE(found_t0);
+    REQUIRE(found_temp_after_t0);
+    REQUIRE(temp_after_t0 == expected_temp);
 }


### PR DESCRIPTION
## Summary

Fixes #14753.

On single-extruder multi-material setups (e.g. Creality K2 with CFS, MMU2S without prime tower), OrcaSlicer emits `filament_start_gcode` → `T0` but no follow-up `M104`. The firmware/CFS DB temperature override on T-commands then wins instead of the slicer temperature.

### Root cause

`GCode::set_extruder()` has two branches:

- **Single-extruder branch** (`!m_writer.multiple_extruders`): emits `filament_start_gcode` + `toolchange(T0)` but **no** `set_temperature` after.
- **Multi-extruder branch**: emits `set_temperature(temp, false)` after `toolchange` when `single_extruder_multi_material && !enable_prime_tower`.

The single-extruder branch was missing the equivalent `set_temperature` block.

### Fix

Add the same `set_temperature` block from the multi-extruder branch into the single-extruder branch, after `m_writer.toolchange()` and `set_config_index()`, before `return gcode`. Gated by the identical condition (`single_extruder_multi_material && !enable_prime_tower`).

### G-code before/after

Before:
```
T0 ; change extruder
;LAYER_CHANGE
```

After:
```
T0 ; change extruder
M104 S240 ; set nozzle temperature
;LAYER_CHANGE
```

## Test plan

- [x] Added regression test `Single-extruder MM emits M104 after T0 toolchange` in `tests/fff_print/test_multifilament.cpp` — verifies 2-filament single-extruder MM print with `enable_prime_tower=false` produces `M104 S<temp>` immediately after `T0`.
- [x] Full `fff_print` test suite passes (66 tests, 695 assertions, `--order rand`).
- [x] Manual G-code inspection confirms `T0` followed by `M104 S240`.

Generated with [Devin](https://devin.ai)