### PR TITLE
Trigger auto perspective on 3D mouse rotation

### DIFF
--- a/src/slic3r/GUI/Mouse3DController.cpp
+++ b/src/slic3r/GUI/Mouse3DController.cpp
@@ -353,6 +353,7 @@ bool Mouse3DController::State::apply(const Mouse3DController::Params &params, Ca
                 rot = Vec3d(rot.x(), -rot.z(), rot.y());
             rot = Vec3d(rot.x() * pitchmult, rot.y() * yawmult, rot.z() * rollmult);
             camera.rotate_local_around_target(Vec3d(rot.x(), - rot.z(), rot.y()));
+            camera.auto_type(Camera::EType::Perspective);
 	    } else {
 	    	assert(input_queue_item.is_buttons());
 	        switch (input_queue_item.type_or_buttons) {


### PR DESCRIPTION
# Description

Automatically change to perspective view when rotation using 3D mouse.

Fix issue described here https://github.com/OrcaSlicer/OrcaSlicer/pull/8312#issuecomment-4968732465

# Screenshots/Recordings/Graphs

<!--
> Please attach relevant screenshots to showcase the UI changes.
> Please attach images that can help explain the changes.
-->

## Tests

I don't own a 3D mouse, feedback is welcome.

<!--
> A guide for users on how to download the artifacts from this PR.
-->

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
