### PR TITLE
fix: guard Bambu Lab dev-mode dialog against repeat spam

### DIFF
--- a/src/slic3r/GUI/DeviceCore/DevManager.cpp
+++ b/src/slic3r/GUI/DeviceCore/DevManager.cpp
@@ -539,6 +539,7 @@ namespace Slic3r
             }
             else
             {
+                Slic3r::GUI::wxGetApp().reset_unsigned_plugin_warning();
                 if (m_agent)
                 {
                     if (it->second->connection_type() != "lan" || it->second->connection_type().empty())

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -5868,18 +5868,23 @@ bool GUI_App::process_network_msg(std::string dev_id, std::string msg)
         }
         else if (msg == "unsigned_studio") {
             BOOST_LOG_TRIVIAL(info) << "process_network_msg, unsigned_studio";
-            MessageDialog
-                msg_dlg(nullptr,
-                        _L("To use OrcaSlicer with Bambu Lab printers, you need to enable LAN mode and Developer mode on your printer.\n\n"
-                           "Please go to your printer's settings and:\n"
-                           "1. Turn on LAN mode\n"
-                           "2. Enable Developer mode\n\n"
-                           "Developer mode allows the printer to work exclusively through local network access, "
-                           "enabling full functionality with OrcaSlicer."),
-                        _L("Network Plug-in Restriction"), wxAPPLY | wxOK);
-            m_show_error_msgdlg = true;
-            msg_dlg.ShowModal();
-            m_show_error_msgdlg = false;
+            // Plugin re-emits this on every subscribe retry; latch it so it shows
+            // once per connection episode.
+            if (!m_show_error_msgdlg && !m_unsigned_plugin_warning_shown) {
+                m_unsigned_plugin_warning_shown = true;
+                MessageDialog
+                    msg_dlg(nullptr,
+                            _L("To use OrcaSlicer with Bambu Lab printers, you need to enable LAN mode and Developer mode on your printer.\n\n"
+                               "Please go to your printer's settings and:\n"
+                               "1. Turn on LAN mode\n"
+                               "2. Enable Developer mode\n\n"
+                               "Developer mode allows the printer to work exclusively through local network access, "
+                               "enabling full functionality with OrcaSlicer."),
+                            _L("Network Plug-in Restriction"), wxAPPLY | wxOK);
+                m_show_error_msgdlg = true;
+                msg_dlg.ShowModal();
+                m_show_error_msgdlg = false;
+            }
             return true;
         }
     }

--- a/src/slic3r/GUI/GUI_App.hpp
+++ b/src/slic3r/GUI/GUI_App.hpp
@@ -339,6 +339,7 @@ private:
 public:
     //try again when subscription fails
     void            on_start_subscribe_again(std::string dev_id);
+    void            reset_unsigned_plugin_warning() { m_unsigned_plugin_warning_shown = false; }
     std::string     get_local_models_path();
     bool            OnInit() override;
     int             OnExit() override;


### PR DESCRIPTION
# Description

When a Bambu Lab printer is not in Developer/LAN mode, the network plug-in emits `unsigned_studio` and `process_network_msg()` opens the "Network Plug-in Restriction" modal telling the user to enable LAN + Developer mode.

The cloud subscribe path retries every ~5s (`on_start_subscribe_again`), and each retry re-emits `unsigned_studio`, so the dialog reappeared endlessly: dismiss one and the next popped up seconds later (and without a guard they stacked on top of each other too).

This latches the notice with `m_unsigned_plugin_warning_shown`, a member that already existed but was never wired up:

- It shows at most once per connection episode, and reuses the shared `m_show_error_msgdlg` guard so it can't stack over or under another error dialog.
- Selecting a different printer (`DeviceManager::set_selected_machine`, new-machine path) re-arms it, so a fresh user-initiated connection can surface the notice again instead of it staying suppressed until restart. The re-arm is on the new-machine path only, not the same-machine reconnect or the periodic re-selection, so it can't reopen the spam.

Dialog text is unchanged; no effect for printers already in Developer/LAN mode. Reported on Discord for the H2C, but the behavior predates H2C support.

# Screenshots/Recordings/Graphs

Reported behavior (before the fix):

https://github.com/user-attachments/assets/1d125496-f949-48d5-877e-1e40053ee64c

## Tests

Manual verification that the dialog only pops up once on printer change.
