### PR TITLE
Fix missing plate thumbnails in Preview on macOS

### DIFF
--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -6452,7 +6452,10 @@ void GLCanvas3D::render_thumbnail_framebuffer(ThumbnailData& thumbnail_data, uns
             if (::glCheckFramebufferStatus(GL_FRAMEBUFFER) == GL_FRAMEBUFFER_COMPLETE) {
                 glsafe(::glBindFramebuffer(GL_READ_FRAMEBUFFER, render_fbo));
                 glsafe(::glBindFramebuffer(GL_DRAW_FRAMEBUFFER, resolve_fbo));
-                glsafe(::glBlitFramebuffer(0, 0, w, h, 0, 0, w, h, GL_COLOR_BUFFER_BIT, GL_LINEAR));
+                // A multisample resolve must not use linear filtering. macOS's
+                // core-profile driver rejects this blit and leaves the resolve
+                // texture transparent, while some Windows drivers tolerate it.
+                glsafe(::glBlitFramebuffer(0, 0, w, h, 0, 0, w, h, GL_COLOR_BUFFER_BIT, GL_NEAREST));
 
                 glsafe(::glBindFramebuffer(GL_READ_FRAMEBUFFER, resolve_fbo));
                 glsafe(::glReadPixels(0, 0, w, h, GL_RGBA, GL_UNSIGNED_BYTE, (void*)thumbnail_data.pixels.data()));
@@ -6565,7 +6568,7 @@ void GLCanvas3D::render_thumbnail_framebuffer_ext(ThumbnailData& thumbnail_data,
             if (::glCheckFramebufferStatus(GL_FRAMEBUFFER) == GL_FRAMEBUFFER_COMPLETE) {
                 glsafe(::glBindFramebuffer(GL_READ_FRAMEBUFFER, render_fbo));
                 glsafe(::glBindFramebuffer(GL_DRAW_FRAMEBUFFER, resolve_fbo));
-                glsafe(::glBlitFramebuffer(0, 0, w, h, 0, 0, w, h, GL_COLOR_BUFFER_BIT, GL_LINEAR));
+                glsafe(::glBlitFramebuffer(0, 0, w, h, 0, 0, w, h, GL_COLOR_BUFFER_BIT, GL_NEAREST));
 
                 glsafe(::glBindFramebuffer(GL_READ_FRAMEBUFFER, resolve_fbo));
                 glsafe(::glReadPixels(0, 0, w, h, GL_RGBA, GL_UNSIGNED_BYTE, (void*)thumbnail_data.pixels.data()));

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -10195,7 +10195,6 @@ void Plater::priv::set_current_panel(wxPanel* panel, bool no_slice)
             notification_manager->set_in_preview(false);
     }
     else if (current_panel == preview) {
-        q->invalid_all_plate_thumbnails();
         if (old_panel == view3D)
             view3D->get_canvas3d()->unbind_event_handlers();
         else if (old_panel == assemble_view)
@@ -10233,6 +10232,8 @@ void Plater::priv::set_current_panel(wxPanel* panel, bool no_slice)
             if (wxGetApp().is_editor() && !q->only_gcode_mode())
                 do_reslice();
         }
+
+        q->force_update_all_plate_thumbnails();
 
         // reset cached size to force a resize on next call to render() to keep imgui in synch with canvas size
         preview->get_canvas3d()->reset_old_size();


### PR DESCRIPTION
# Description
Fixes an issue on macOS where plate thumbnails could remain black after switching from the Editor to the sliced Preview. 

# Root Cause

1. OpenGL framebuffer support was detected only through GLAD_GL_ARB_framebuffer_object. On macOS Core Profile contexts, framebuffer objects are core functionality in OpenGL 3.0+, but the ARB extension flag may not be exposed. 
2. Switching to Preview invalidated the thumbnail cache but did not rebuild it immediately. Thumbnail generation depended on the Preview canvas receiving focus. however, switching to the Preview tab does not trigger a Preview focus event, so the thumbnail is never regenerated.

Additionally, the multisample framebuffer resolve used GL_LINEAR, which is less reliable across Core Profile drivers.

# Changes

1. Detect framebuffer support through either OpenGL 3.0+ or the ARB framebuffer extension. [14769](https://github.com/OrcaSlicer/OrcaSlicer/pull/14769)
4. Use GL_NEAREST when resolving multisampled thumbnail framebuffers.
5. Force an immediate thumbnail refresh by calling force_update_all_plate_thumbnails when switching to the Preview tab.

# Notes
Thumbnail regeneration now occurs synchronously when entering Preview. This may add a small transition cost for projects with many plates, but it replaces work that previously occurred later when the canvas received focus.

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
