### PR TITLE
fix: preserve POSIX refresh lock ownership

### DIFF
--- a/src/slic3r/Utils/OrcaCloudServiceAgent.cpp
+++ b/src/slic3r/Utils/OrcaCloudServiceAgent.cpp
@@ -41,6 +41,7 @@
 #if !defined(_WIN32)
 #include <unistd.h>
 #include <fcntl.h>
+#include <sys/file.h>
 #include <cerrno>
 #endif
 
@@ -104,10 +105,8 @@ public:
 #else
         m_fd = ::open(path.c_str(), O_RDWR | O_CREAT | O_CLOEXEC, 0600);
         if (m_fd == -1) { m_locked = true; return; }              // can't open -> don't block
-        struct flock fl{};
-        fl.l_type = F_WRLCK; fl.l_whence = SEEK_SET; fl.l_start = 0; fl.l_len = 0;
         int rc;
-        do { rc = ::fcntl(m_fd, F_SETLKW, &fl); } while (rc == -1 && errno == EINTR); // blocks in kernel
+        do { rc = ::flock(m_fd, LOCK_EX); } while (rc == -1 && errno == EINTR); // blocks in kernel
         m_locked = (rc != -1);
 #endif
     }


### PR DESCRIPTION
# Description

Issue only on POSIX, Windows path OK.

Fix a low-frequency POSIX cloud synchronization race caused by using `fcntl(fd, ...)` for file locking.

[Linux `fcntl` locking](https://man7.org/linux/man-pages/man2/fcntl_locking.2.html)  
[Linux `flock`](https://man7.org/linux/man-pages/man2/flock.2.html)  
[Linux `open`](https://man7.org/linux/man-pages/man2/open.2.html)

Apparently, using `fcntl(fd, ...)` stores `(file, process owner)` locked byte ranges in the lock table, meaning the lock is per process. Two threads from the same process would not conflict with each other as intended, even if they call `fcntl(fd, ...)` with two different file descriptors.

Instead, use `flock(...)`. This stores `(file, open file description)` whole-file locks in the lock table, so threads have distinct locks on the file and correctly block each other.

This ensures cloud operations follow the intended sequence:

```text
// -- INTENDED --
Thread A:
lock -> read R0 -> POST R0 -> store R1 -> unlock
Thread B:
lock -> read R1 -> POST R1 -> store R2 -> unlock
Process 2:
lock -> read R2 -> POST R2 -> store R3 -> unlock
```

Previously, Thread B could acquire the `fcntl` lock while Thread A was still running, read stale state, and close its descriptor. This could release Thread A's process lock and allow another process to read and post stale state.

```
// -- BROKEN --
Thread A:
lock -> read R0 -> POST R0
R1 not stored yet

Thread B:
fcntl succeeds -> read R0
refresh_running is already true
POST nothing
close fd B
accidentally releases A's process lock

Process 2:
lock -> read R0 -> POST R0
```

The affected OrcaSlicer instance could unexpectedly sign the user out, fail the current cloud operation, and require another login before cloud sync or other cloud features worked again.

No breaking changes or new dependencies.

# Screenshots/Recordings/Graphs

Not applicable. This is an internal POSIX file-locking change.

## Tests

- Verified that POSIX locking now uses blocking `flock(LOCK_EX)`.
- Preserved retry behavior when the system call is interrupted by `EINTR`.
- No automated tests were run.