### PR TITLE
AI parametric shape generator (opt-in, experimental)

### DIFF
--- a/doc/ai-slicer/README.md
+++ b/doc/ai-slicer/README.md
@@ -1,0 +1,83 @@
+# AI Slicer
+
+An optional, printer-agnostic AI assistant built into OrcaSlicer: register an LLM
+gateway (OpenAI, Anthropic, or any OpenAI-compatible endpoint), then **generate 3D
+shapes from a text description** or **search the web for a model and import it** — with
+the generation grounded in your *real* machine (bed size, nozzle, material, live
+temperatures, and a camera frame when available).
+
+The feature is entirely **opt-in**: nothing contacts a network until you configure a
+provider and invoke it from the **AI** menu.
+
+## User guide
+
+### 1. Register a provider — *AI ▸ AI Settings…*
+- **Provider**: `OpenAI`, `Anthropic`, or `OpenAI-compatible (custom gateway)`.
+- **API key**: stored locally (see *Security* below).
+- **Gateway URL**: required only for the compatible provider (Ollama, LiteLLM, an
+  Azure/OpenAI proxy, …); ignored otherwise.
+- **Model**: type it, or click **Fetch models** to list what the key can access.
+- **Test connection** verifies the key/endpoint before you save. **OK** persists the
+  settings.
+
+### 2. Generate a shape — *AI ▸ Generate 3D Shape…* → *Generate shape* tab
+Describe the object (“a 40 mm hex knob with a 6 mm shaft hole”) and press **Generate**.
+The assistant receives your machine context, returns a shape, and it is dropped on the
+plate. If the result exceeds the build volume it is still added, with a warning, so you
+can rescale.
+
+### 3. Find a model on the web — *…* → *Search & import* tab
+Enter a query, **Search**, pick a result, and **Import selected**. Only direct,
+downloadable model files (`.stl/.3mf/.obj/.step/.stp`) are listed; the chosen file is
+downloaded to your OrcaSlicer *download path* and loaded like any other import.
+
+## Architecture
+
+All AI code lives beside the rest of the slicer sources and links into the normal GUI
+library — there are no new dependencies (HTTP via `Slic3r::Http`, JSON via
+`nlohmann::json`).
+
+| Component | Files | Role |
+|---|---|---|
+| **Providers** | `src/slic3r/Utils/AIProvider.{hpp,cpp}` | Abstract `AIProvider` + factory. Concrete OpenAI / Anthropic / OpenAI-compatible backends behind `chat()`, `test_connection()`, `get_models()`. Mirrors the `PrintHost::get_print_host` pattern. |
+| **Machine context** | `src/slic3r/Utils/AIPrinterContext.{hpp,cpp}` | Assembles a structured snapshot: active slicer settings (always), live Moonraker/OctoPrint telemetry (when a Physical Printer is configured), and a camera JPEG (base64). Degrades gracefully offline. |
+| **Text-to-shape** | `src/slic3r/Utils/AIShapeGen.{hpp,cpp}` | Pure libslic3r. Validates a JSON *shape spec* (primitives + CSG + transforms) or raw STL and bakes it into a `Model`; plus a bed-fit check. |
+| **Settings UI** | `src/slic3r/GUI/AISettingsDialog.{hpp,cpp}` | Registers provider / key / gateway / model into the `ai_slicer` AppConfig section. |
+| **Workspace UI** | `src/slic3r/GUI/AISlicerDialog.{hpp,cpp}` | *Generate shape* and *Search & import* tabs; wires context → provider → geometry → plate. |
+| **Menu** | `src/slic3r/GUI/MainFrame.cpp` | The top-level **AI** menu. |
+
+### How machine context reaches the model
+On every generation `AIPrinterContext::gather()` builds a compact JSON blob that becomes
+part of the system prompt, so the LLM knows the bed shape/size, nozzle, material and
+temperatures, live sensor state, and (for vision models) sees a camera frame passed as a
+multimodal image. `AIShapeGen::ai_model_fits_bed()` then checks the result against the
+active build volume. This is what keeps generated geometry *printable on this machine*
+rather than generically sized.
+
+### Configuration keys (`ai_slicer` section of the OrcaSlicer config)
+| Key | Meaning |
+|---|---|
+| `provider` | `openai` \| `anthropic` \| `compatible` (empty = disabled) |
+| `api_key` | provider API key |
+| `gateway_url` | base URL for the compatible provider |
+| `model` | model id (e.g. `gpt-4o-mini`, `claude-3-5-sonnet-latest`) |
+
+### Adding a provider
+Implement a subclass of `AIProvider` (see `OpenAIProvider` / `AnthropicProvider` in
+`AIProvider.cpp`), then add a branch to `AIProvider::create()` keyed on the `provider`
+string. Nothing else needs to change — the dialogs and context flow are provider-agnostic.
+
+## Security & privacy
+- The API key is stored **in cleartext** in the OrcaSlicer config file, like other host
+  credentials in the app. Treat that file accordingly; prefer a scoped/revocable key.
+- Prompts include your machine context and (if a camera is configured) a snapshot — this
+  is sent to the provider you configured. Nothing is sent until you invoke an AI action.
+- *Search & import* downloads a file from a URL the model returned; only recognized model
+  extensions are offered, and the file goes through the normal importer.
+
+## Upstreaming notes
+- Self-contained and opt-in; no new third-party dependencies.
+- Delivered as a stack of small, compile-verified PRs: providers → context+multimodal →
+  settings dialog → shape core → generate dialog → AI menu → search & import → docs.
+- Known follow-ups: run the LLM round-trips on a background `Job` (currently a
+  `wxBusyCursor`), and add a secret-store option for the API key.

--- a/src/slic3r/CMakeLists.txt
+++ b/src/slic3r/CMakeLists.txt
@@ -22,6 +22,11 @@ set(SLIC3R_GUI_SOURCES
     GUI/Widgets/FilamentLoad.hpp
     GUI/AboutDialog.cpp
     GUI/AboutDialog.hpp
+    GUI/AISettingsDialog.cpp
+    GUI/AISettingsDialog.hpp
+    GUI/AISlicerDialog.cpp
+    GUI/AISlicerDialog.hpp
+    GUI/AIGenerate.hpp
     GUI/AmsMappingPopup.cpp
     GUI/AmsMappingPopup.hpp
     GUI/AMSMaterialsSetting.cpp
@@ -575,6 +580,12 @@ set(SLIC3R_GUI_SOURCES
     GUI/wxExtensions.hpp
     pchheader.cpp
     pchheader.hpp
+    Utils/AIProvider.cpp
+    Utils/AIProvider.hpp
+    Utils/AIPrinterContext.cpp
+    Utils/AIPrinterContext.hpp
+    Utils/AIShapeGen.cpp
+    Utils/AIShapeGen.hpp
     Utils/ASCIIFolding.cpp
     Utils/ASCIIFolding.hpp
     Utils/AstroBox.cpp

--- a/src/slic3r/GUI/AIGenerate.hpp
+++ b/src/slic3r/GUI/AIGenerate.hpp
@@ -1,0 +1,20 @@
+#ifndef slic3r_AIGenerate_hpp_
+#define slic3r_AIGenerate_hpp_
+
+#include <functional>
+#include <string>
+
+namespace Slic3r { namespace GUI {
+
+// Generate a 3D shape from a text prompt and drop it on the plate, reusing the
+// full pipeline (machine context -> forced create_model tool call -> geometry ->
+// repair loop -> Plater injection) on a background Job. Safe to call from the
+// main thread; `on_done` is invoked on the main thread with (ok, message).
+//
+// Shared by the AI menu dialog and the compact in-panel Generate control.
+void ai_generate_shape_to_plate(const std::string &prompt,
+                                std::function<void(bool ok, const std::string &message)> on_done);
+
+}} // namespace Slic3r::GUI
+
+#endif // slic3r_AIGenerate_hpp_

--- a/src/slic3r/GUI/AISettingsDialog.cpp
+++ b/src/slic3r/GUI/AISettingsDialog.cpp
@@ -1,0 +1,309 @@
+#include "AISettingsDialog.hpp"
+
+#include <memory>
+
+#include <wx/sizer.h>
+#include <wx/stattext.h>
+#include <wx/textctrl.h>
+
+#include "GUI.hpp"
+#include "GUI_App.hpp"
+#include "I18N.hpp"
+#include "Widgets/ComboBox.hpp"
+#include "Widgets/Button.hpp"
+#include "Widgets/DialogButtons.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <chrono>
+
+#include "libslic3r/AppConfig.hpp"
+#include "libslic3r/Model.hpp"
+#include "slic3r/Utils/AIProvider.hpp"
+#include "slic3r/Utils/AIShapeGen.hpp"
+
+namespace Slic3r { namespace GUI {
+
+// Provider dropdown order <-> AppConfig provider key.
+static std::string provider_key_for_index(int idx)
+{
+    switch (idx) {
+        case 0:  return "openai";
+        case 1:  return "anthropic";
+        case 2:  return "compatible";
+        default: return "";
+    }
+}
+
+static int index_for_provider_key(const std::string &key)
+{
+    if (key == "anthropic")                                return 1;
+    if (key == "compatible" || key == "openai_compatible") return 2;
+    return 0; // default: openai
+}
+
+// Qualification test: force a create_model tool call on a canonical prompt and
+// see whether the model returns a buildable shape. This is how we tell a model
+// suitable for 3D generation from one that merely talks. Fills `msg` either way.
+static bool run_qualification(const AIConfig &cfg, wxString &msg)
+{
+    std::unique_ptr<AIProvider> provider(AIProvider::create(cfg));
+    if (! provider) { msg = _L("Configure a provider, API key, and model first."); return false; }
+
+    nlohmann::json tool = {
+        {"type", "function"},
+        {"function", {
+            {"name", "create_model"},
+            {"description", "Create a printable 3D shape as a parametric tree. Never explain in prose. "
+                            "Node \"type\": box{size:[x,y,z]}, cylinder{radius,height}, cone{radius,height}, "
+                            "sphere{radius}, or union|difference|intersection{children:[...]}."},
+            {"parameters", {{"type", "object"},
+                            {"properties", {{"shape", {{"type", "object"}}}}},
+                            {"required", nlohmann::json::array({"shape"})}}}
+        }}
+    };
+    nlohmann::json params;
+    params["tools"]       = nlohmann::json::array({tool});
+    params["tool_choice"] = {{"type", "function"}, {"function", {{"name", "create_model"}}}};
+    params["temperature"] = 0.1;
+
+    std::vector<AIMessage> msgs;
+    msgs.push_back({"system", "You design printable 3D shapes by calling create_model."});
+    msgs.push_back({"user", "a 30mm cube with a 10mm hole through the center"});
+
+    const auto t0 = std::chrono::steady_clock::now();
+    AIResponse resp = provider->chat(msgs, params);
+    const double secs = std::chrono::duration<double>(std::chrono::steady_clock::now() - t0).count();
+
+    if (! resp.ok) {
+        msg = _L("Not suitable — request failed: ") + from_u8(resp.error);
+        return false;
+    }
+    if (resp.tool_call_arguments.empty()) {
+        msg = _L("Not suitable — the model replied with text instead of a create_model tool call.");
+        return false;
+    }
+    Model m;
+    std::string err;
+    if (! ai_build_model_from_tool_call(resp.tool_call_arguments, "qualify", m, err) || m.objects.empty()) {
+        msg = _L("Returned a tool call, but its shape wasn't buildable: ") + from_u8(err);
+        return false;
+    }
+    msg = wxString::Format(_L("Qualified for 3D generation (%.1fs). This model works."), secs);
+    return true;
+}
+
+AISettingsDialog::AISettingsDialog(wxWindow *parent)
+    : DPIDialog(parent, wxID_ANY, _L("AI Settings"), wxDefaultPosition,
+                wxSize(46 * wxGetApp().em_unit(), -1), wxDEFAULT_DIALOG_STYLE)
+{
+    SetFont(wxGetApp().normal_font());
+    SetBackgroundColour(*wxWHITE);
+
+    const int em     = wxGetApp().em_unit();
+    const wxSize ctl = wxSize(FromDIP(300), -1);
+
+    auto *grid = new wxFlexGridSizer(0, 2, FromDIP(8), FromDIP(10));
+    grid->AddGrowableCol(1, 1);
+
+    auto add_row = [&](const wxString &label, wxWindow *ctrl) {
+        auto *st = new wxStaticText(this, wxID_ANY, label);
+        grid->Add(st, 0, wxALIGN_CENTER_VERTICAL);
+        grid->Add(ctrl, 1, wxEXPAND);
+    };
+
+    m_provider = new ComboBox(this, wxID_ANY, "", wxDefaultPosition, ctl, 0, nullptr, wxCB_READONLY);
+    m_provider->Append(_L("OpenAI"));
+    m_provider->Append(_L("Anthropic"));
+    m_provider->Append(_L("OpenAI-compatible (custom gateway)"));
+    add_row(_L("Provider"), m_provider);
+
+    m_api_key = new wxTextCtrl(this, wxID_ANY, "", wxDefaultPosition, ctl, wxTE_PASSWORD);
+    add_row(_L("API key"), m_api_key);
+
+    m_gateway_url = new wxTextCtrl(this, wxID_ANY, "", wxDefaultPosition, ctl);
+    add_row(_L("Gateway URL"), m_gateway_url);
+
+    m_model = new ComboBox(this, wxID_ANY, "", wxDefaultPosition, ctl, 0, nullptr, 0);
+    add_row(_L("Model"), m_model);
+
+    // Test / Fetch / Qualify buttons.
+    m_test_btn  = new Button(this, _L("Test connection"));
+    m_fetch_btn = new Button(this, _L("Fetch models"));
+    auto *qualify_btn = new Button(this, _L("Qualify for 3D"));
+    qualify_btn->SetToolTip(_L("Check whether the selected model can actually generate 3D shapes."));
+    auto *btn_row = new wxBoxSizer(wxHORIZONTAL);
+    btn_row->Add(m_test_btn, 0, wxRIGHT, FromDIP(8));
+    btn_row->Add(m_fetch_btn, 0, wxRIGHT, FromDIP(8));
+    btn_row->Add(qualify_btn, 0);
+
+    m_gateway_hint = new wxStaticText(this, wxID_ANY,
+        _L("Gateway URL is used only for an OpenAI-compatible provider (Ollama, LiteLLM, a proxy...)."));
+    auto *rec_hint = new wxStaticText(this, wxID_ANY,
+        _L("Model tip: use a mid/large instruct or code model (e.g. a llama-3.x-instruct or qwen-*-instruct). "
+           "Avoid embedding, reranker, and tiny models. Click \"Qualify for 3D\" to test the current one."));
+    m_status = new wxStaticText(this, wxID_ANY, "");
+
+    // Assemble.
+    auto *top = new wxBoxSizer(wxVERTICAL);
+    top->Add(grid,           0, wxEXPAND | wxALL, FromDIP(16));
+    top->Add(m_gateway_hint, 0, wxLEFT | wxRIGHT | wxBOTTOM, FromDIP(16));
+    top->Add(rec_hint,       0, wxLEFT | wxRIGHT | wxBOTTOM, FromDIP(16));
+    top->Add(btn_row,        0, wxLEFT | wxRIGHT | wxBOTTOM, FromDIP(16));
+    top->Add(m_status,       0, wxLEFT | wxRIGHT | wxBOTTOM | wxEXPAND, FromDIP(16));
+
+    auto *dlg_btns = new DialogButtons(this, {"OK", "Cancel"});
+    top->Add(dlg_btns, 0, wxEXPAND);
+
+    // Wiring.
+    m_provider->Bind(wxEVT_COMBOBOX, [this](wxCommandEvent &) { on_provider_changed(); });
+    m_test_btn->Bind(wxEVT_BUTTON,   [this](wxCommandEvent &) { on_test(); });
+    m_fetch_btn->Bind(wxEVT_BUTTON,  [this](wxCommandEvent &) { on_fetch_models(); });
+    qualify_btn->Bind(wxEVT_BUTTON,  [this](wxCommandEvent &) {
+        AIConfig cfg;
+        cfg.provider = provider_key_for_index(m_provider->GetSelection());
+        cfg.api_key  = into_u8(m_api_key->GetValue());
+        cfg.base_url = into_u8(m_gateway_url->GetValue());
+        cfg.model    = into_u8(m_model->GetValue());
+        set_status(_L("Qualifying the selected model for 3D (this runs a real generation)..."));
+        wxString msg; bool ok;
+        { wxBusyCursor wait; ok = run_qualification(cfg, msg); }
+        set_status(msg, ! ok);
+    });
+    dlg_btns->GetOK()->Bind(wxEVT_BUTTON, [this](wxCommandEvent &) { save_to_config(); EndModal(wxID_OK); });
+    dlg_btns->GetCANCEL()->Bind(wxEVT_BUTTON, [this](wxCommandEvent &) { EndModal(wxID_CANCEL); });
+
+    load_from_config();
+    on_provider_changed();
+
+    SetSizer(top);
+    top->SetSizeHints(this);
+    CenterOnParent();
+    wxGetApp().UpdateDlgDarkUI(this);
+
+    (void) em;
+}
+
+void AISettingsDialog::load_from_config()
+{
+    auto *ac = wxGetApp().app_config;
+    if (ac == nullptr)
+        return;
+    m_provider->SetSelection(index_for_provider_key(ac->get("ai_slicer", "provider")));
+    m_api_key->SetValue(from_u8(ac->get("ai_slicer", "api_key")));
+    m_gateway_url->SetValue(from_u8(ac->get("ai_slicer", "gateway_url")));
+    const std::string model = ac->get("ai_slicer", "model");
+    if (! model.empty()) {
+        m_model->Append(from_u8(model));
+        m_model->SetValue(from_u8(model));
+    }
+}
+
+void AISettingsDialog::save_to_config()
+{
+    auto *ac = wxGetApp().app_config;
+    if (ac == nullptr)
+        return;
+    ac->set("ai_slicer", "provider",    provider_key_for_index(m_provider->GetSelection()));
+    ac->set("ai_slicer", "api_key",     into_u8(m_api_key->GetValue()));
+    ac->set("ai_slicer", "gateway_url", into_u8(m_gateway_url->GetValue()));
+    ac->set("ai_slicer", "model",       into_u8(m_model->GetValue()));
+    ac->save();
+}
+
+void AISettingsDialog::on_provider_changed()
+{
+    const bool compatible = m_provider->GetSelection() == 2;
+    m_gateway_url->Enable(compatible);
+    m_gateway_hint->Enable(compatible);
+}
+
+static AIConfig make_config_from_fields(ComboBox *provider, wxTextCtrl *key, wxTextCtrl *url, ComboBox *model)
+{
+    AIConfig cfg;
+    cfg.provider = provider_key_for_index(provider->GetSelection());
+    cfg.api_key  = into_u8(key->GetValue());
+    cfg.base_url = into_u8(url->GetValue());
+    cfg.model    = into_u8(model->GetValue());
+    return cfg;
+}
+
+void AISettingsDialog::on_test()
+{
+    std::unique_ptr<AIProvider> provider(AIProvider::create(
+        make_config_from_fields(m_provider, m_api_key, m_gateway_url, m_model)));
+    if (! provider) {
+        set_status(_L("Select a provider and enter an API key (and a gateway URL for the compatible provider)."), true);
+        return;
+    }
+    set_status(_L("Testing..."));
+    std::string error;
+    bool ok = false;
+    {
+        wxBusyCursor wait; // the round-trip briefly blocks the UI, as the printer Test button does
+        ok = provider->test_connection(error);
+    }
+    if (ok)
+        set_status(_L("Connection OK."));
+    else
+        set_status(_L("Failed: ") + from_u8(error), true);
+}
+
+void AISettingsDialog::on_fetch_models()
+{
+    std::unique_ptr<AIProvider> provider(AIProvider::create(
+        make_config_from_fields(m_provider, m_api_key, m_gateway_url, m_model)));
+    if (! provider) {
+        set_status(_L("Select a provider and enter an API key first."), true);
+        return;
+    }
+    set_status(_L("Fetching models..."));
+    std::vector<AIModelInfo> models;
+    std::string error;
+    bool ok = false;
+    {
+        wxBusyCursor wait;
+        ok = provider->get_models(models, error);
+    }
+    if (! ok) {
+        set_status(_L("Fetch failed: ") + from_u8(error), true);
+        return;
+    }
+    const wxString keep = m_model->GetValue();
+    m_model->Clear();
+    int shown = 0, hidden = 0;
+    for (const auto &m : models) {
+        // Hide models that can't do chat/geometry at all (embeddings, rerankers,
+        // guardrails, speech, OCR, ...). They only clutter the picker.
+        std::string low = m.id;
+        std::transform(low.begin(), low.end(), low.begin(), [](unsigned char c) { return (char) std::tolower(c); });
+        bool skip = false;
+        for (const char *bad : {"embed", "rerank", "reward", "guard", "moderation", "ocr",
+                                "whisper", "riva", "clip", "-tts", "-stt", "speech"})
+            if (low.find(bad) != std::string::npos) { skip = true; break; }
+        if (skip) { ++hidden; continue; }
+        m_model->Append(from_u8(m.id));
+        ++shown;
+    }
+    if (! keep.IsEmpty())
+        m_model->SetValue(keep);
+    set_status(wxString::Format(_L("Fetched %d usable models (hid %d embedding/reranker/etc.). "
+                                   "Use \"Qualify for 3D\" to confirm one works."), shown, hidden));
+}
+
+void AISettingsDialog::set_status(const wxString &msg, bool error)
+{
+    if (m_status == nullptr)
+        return;
+    m_status->SetForegroundColour(error ? wxColour(0xC0, 0x30, 0x30) : wxColour(0x30, 0x80, 0x30));
+    m_status->SetLabel(msg);
+    Layout();
+}
+
+void AISettingsDialog::on_dpi_changed(const wxRect & /*suggested_rect*/)
+{
+    Fit();
+    Refresh();
+}
+
+}} // namespace Slic3r::GUI

--- a/src/slic3r/GUI/AISettingsDialog.hpp
+++ b/src/slic3r/GUI/AISettingsDialog.hpp
@@ -1,0 +1,49 @@
+#ifndef slic3r_AISettingsDialog_hpp_
+#define slic3r_AISettingsDialog_hpp_
+
+#include "GUI_Utils.hpp"
+
+class ComboBox;
+class Button;
+class wxTextCtrl;
+class wxStaticText;
+
+namespace Slic3r { namespace GUI {
+
+// ---------------------------------------------------------------------------
+// AISettingsDialog
+//
+// Registers the AI provider + gateway/API key/model that the AIProvider factory
+// reads back from the "ai_slicer" AppConfig section. Lets the user Test the
+// connection and Fetch the available model list before saving.
+// ---------------------------------------------------------------------------
+class AISettingsDialog : public DPIDialog
+{
+public:
+    explicit AISettingsDialog(wxWindow *parent);
+    ~AISettingsDialog() override = default;
+
+protected:
+    void on_dpi_changed(const wxRect &suggested_rect) override;
+
+private:
+    void load_from_config();
+    void save_to_config();
+    void on_provider_changed();
+    void on_test();
+    void on_fetch_models();
+    void set_status(const wxString &msg, bool error = false);
+
+    ComboBox     *m_provider    { nullptr };
+    wxTextCtrl   *m_api_key     { nullptr };
+    wxTextCtrl   *m_gateway_url { nullptr };
+    ComboBox     *m_model       { nullptr };
+    Button       *m_test_btn    { nullptr };
+    Button       *m_fetch_btn   { nullptr };
+    wxStaticText *m_status      { nullptr };
+    wxStaticText *m_gateway_hint{ nullptr };
+};
+
+}} // namespace Slic3r::GUI
+
+#endif // slic3r_AISettingsDialog_hpp_

--- a/src/slic3r/GUI/AISlicerDialog.cpp
+++ b/src/slic3r/GUI/AISlicerDialog.cpp
@@ -1,0 +1,402 @@
+#include "AISlicerDialog.hpp"
+#include "AIGenerate.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <cstring>
+#include <fstream>
+#include <memory>
+#include <vector>
+
+#include <boost/filesystem.hpp>
+
+#include <wx/listbox.h>
+#include <wx/notebook.h>
+#include <wx/panel.h>
+#include <wx/sizer.h>
+#include <wx/stattext.h>
+#include <wx/textctrl.h>
+#include <wx/utils.h>
+
+#include <wx/weakref.h>
+
+#include "GUI.hpp"
+#include "GUI_App.hpp"
+#include "GUI_ObjectList.hpp"
+#include "I18N.hpp"
+#include "Plater.hpp"
+#include "GLCanvas3D.hpp"
+#include "Widgets/Button.hpp"
+#include "Jobs/Worker.hpp"
+#include "Jobs/Job.hpp"
+
+#include "libslic3r/Model.hpp"
+#include "libslic3r/PresetBundle.hpp"
+#include "libslic3r/PrintConfig.hpp"
+#include "libslic3r/Utils.hpp"
+#include "libslic3r/Format/bbs_3mf.hpp"
+
+#include "slic3r/Utils/AIProvider.hpp"
+#include "slic3r/Utils/AIPrinterContext.hpp"
+#include "slic3r/Utils/AIShapeGen.hpp"
+#include "slic3r/Utils/Http.hpp"
+
+namespace Slic3r { namespace GUI {
+
+// Bed extents (mm) from the active machine config, for the printable-fit check.
+static void compute_bed_dims(const DynamicPrintConfig &cfg, double &x, double &y, double &z)
+{
+    z = (cfg.option("printable_height") != nullptr) ? cfg.opt_float("printable_height") : 250.0;
+    x = y = 220.0;
+    if (auto *pa = cfg.option<ConfigOptionPoints>("printable_area")) {
+        double minx = 1e30, miny = 1e30, maxx = -1e30, maxy = -1e30;
+        for (const Vec2d &p : pa->values) {
+            minx = std::min(minx, p.x()); maxx = std::max(maxx, p.x());
+            miny = std::min(miny, p.y()); maxy = std::max(maxy, p.y());
+        }
+        if (maxx > minx && maxy > miny) { x = maxx - minx; y = maxy - miny; }
+    }
+}
+
+AISlicerDialog::AISlicerDialog(wxWindow *parent)
+    : DPIDialog(parent, wxID_ANY, _L("AI"), wxDefaultPosition,
+                wxSize(52 * wxGetApp().em_unit(), -1), wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER)
+{
+    SetFont(wxGetApp().normal_font());
+    SetBackgroundColour(*wxWHITE);
+
+    auto *nb = new wxNotebook(this, wxID_ANY);
+    nb->AddPage(build_generate_tab(nb), _L("Generate shape"), true);
+    nb->AddPage(build_search_tab(nb),   _L("Find models"), false);
+
+    auto *close_btn = new Button(this, _L("Close"));
+    close_btn->Bind(wxEVT_BUTTON, [this](wxCommandEvent &) { EndModal(wxID_CLOSE); });
+    auto *btn_row = new wxBoxSizer(wxHORIZONTAL);
+    btn_row->AddStretchSpacer(1);
+    btn_row->Add(close_btn, 0);
+
+    auto *top = new wxBoxSizer(wxVERTICAL);
+    top->Add(nb,      1, wxEXPAND | wxALL, FromDIP(12));
+    top->Add(btn_row, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, FromDIP(12));
+
+    SetSizer(top);
+    top->SetSizeHints(this);
+    CenterOnParent();
+    wxGetApp().UpdateDlgDarkUI(this);
+}
+
+wxWindow *AISlicerDialog::build_generate_tab(wxNotebook *nb)
+{
+    auto *panel = new wxPanel(nb, wxID_ANY);
+    auto *s = new wxBoxSizer(wxVERTICAL);
+
+    s->Add(new wxStaticText(panel, wxID_ANY, _L("Describe a mechanical part to generate:")),
+           0, wxALL, FromDIP(10));
+
+    m_prompt = new wxTextCtrl(panel, wxID_ANY, "", wxDefaultPosition,
+                              wxSize(FromDIP(420), FromDIP(110)), wxTE_MULTILINE);
+    s->Add(m_prompt, 1, wxEXPAND | wxLEFT | wxRIGHT, FromDIP(10));
+
+    s->Add(new wxStaticText(panel, wxID_ANY,
+               _L("Builds parametric parts from primitives + boolean cuts (brackets, knobs, boxes, holders, "
+                  "adapters) sized to your printer. Not for organic/sculptural shapes (animals, figurines) — "
+                  "for those, use the Find models tab. Your printer's settings and sensors are sent with each request.")),
+           0, wxALL, FromDIP(10));
+
+    m_generate_btn = new Button(panel, _L("Generate"));
+    m_generate_btn->Bind(wxEVT_BUTTON, [this](wxCommandEvent &) { on_generate(); });
+    s->Add(m_generate_btn, 0, wxLEFT | wxRIGHT | wxBOTTOM, FromDIP(10));
+
+    m_status = new wxStaticText(panel, wxID_ANY, "");
+    s->Add(m_status, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, FromDIP(10));
+
+    panel->SetSizer(s);
+    return panel;
+}
+
+// Result shared between the worker thread (fills it) and the finish handler
+// (consumes it on the main thread).
+namespace { struct AIGenResult { Model model; std::string error; std::string warn; bool ok = false; }; }
+
+// Shared generation entry point (see AIGenerate.hpp). Runs the full pipeline on
+// a background Job and calls on_done(ok, message) on the main thread.
+void ai_generate_shape_to_plate(const std::string &prompt,
+                                std::function<void(bool, const std::string &)> on_done)
+{
+    auto *ac = wxGetApp().app_config;
+    AIConfig cfg = ac ? AIProvider::config_from_app_config(*ac) : AIConfig();
+    if (! std::unique_ptr<AIProvider>(AIProvider::create(cfg))) {
+        on_done(false, "No AI provider is configured. Open Preferences > General > AI and register a provider and API key first.");
+        return;
+    }
+
+    // Everything that touches the GUI must happen HERE, on the main thread:
+    // gather machine context, build the request, read the bed dimensions.
+    AIPrinterContext ctx = AIPrinterContext::gather();
+    auto messages = std::make_shared<std::vector<AIMessage>>();
+    {
+        AIMessage sys;
+        sys.role    = "system";
+        sys.content = "You design small, printable 3D shapes and return them ONLY by calling the "
+                      "create_model tool (never reply in prose). Respect this printer's constraints; "
+                      "never exceed the build volume.\n\nPrinter context:\n" + ctx.to_prompt();
+        messages->push_back(std::move(sys));
+        AIMessage user;
+        user.role    = "user";
+        user.content = prompt;
+        if (ctx.has_image())
+            user.images.push_back(ctx.to_image());
+        messages->push_back(std::move(user));
+    }
+    const std::string name = prompt.substr(0, 40);
+
+    // Force a create_model tool call so the model MUST return a structured shape
+    // spec rather than prose. A model that replies with text instead is
+    // unsuitable — which is exactly how we tell capable models from talky ones.
+    auto params = std::make_shared<nlohmann::json>();
+    {
+        nlohmann::json tool = {
+            {"type", "function"},
+            {"function", {
+                {"name", "create_model"},
+                {"description", std::string("Create a printable 3D shape as a parametric tree. Never explain in prose. ")
+                               + ai_shape_spec_instructions()},
+                {"parameters", {
+                    {"type", "object"},
+                    {"properties", {
+                        {"shape", {{"type", "object"}, {"description", "The root shape node (type + params + children)."}}},
+                        {"design_summary", {{"type", "string"}}}
+                    }},
+                    {"required", nlohmann::json::array({"shape"})}
+                }}
+            }}
+        };
+        (*params)["tools"]       = nlohmann::json::array({tool});
+        (*params)["tool_choice"] = {{"type", "function"}, {"function", {{"name", "create_model"}}}};
+        (*params)["temperature"] = 0.2;
+    }
+
+    double bx = 220, by = 220, bz = 250;
+    if (auto *bundle = wxGetApp().preset_bundle)
+        compute_bed_dims(bundle->full_config(), bx, by, bz);
+
+    auto result = std::make_shared<AIGenResult>();
+
+    Worker &worker = wxGetApp().plater()->get_ui_job_worker();
+    replace_job(worker,
+        // ---- worker thread: LLM round-trip + geometry build, with a repair loop
+        // (generate -> build/validate -> feed the error back -> regenerate) ----
+        [cfg, messages, params, name, result, bx, by, bz](Job::Ctl &ctl) {
+            std::unique_ptr<AIProvider> provider(AIProvider::create(cfg));
+            if (! provider) { result->error = "No AI provider configured."; return; }
+
+            const int MAX_REPAIRS = 2;
+            for (int attempt = 0; attempt <= MAX_REPAIRS; ++attempt) {
+                ctl.update_status(attempt == 0 ? 15 : 45,
+                                  attempt == 0 ? "Contacting the AI..." : "Fixing the design...");
+                AIResponse resp = provider->chat(*messages, *params);
+                if (ctl.was_canceled()) return;
+                if (! resp.ok) { result->error = "AI request failed: " + resp.error; return; } // network: no retry
+
+                ctl.update_status(70, "Building geometry...");
+                Model candidate;
+                std::string berr, produced = resp.tool_call_arguments;
+                bool built = false;
+                if (! resp.tool_call_arguments.empty())
+                    built = ai_build_model_from_tool_call(resp.tool_call_arguments, name, candidate, berr);
+                else if (! resp.content.empty()) {
+                    produced = resp.content;
+                    built = ai_build_model_from_response(resp.content, name, candidate, berr);
+                } else {
+                    // Talky model — no point retrying; this is the unsuitable-model signal.
+                    result->error = "This model returned no shape (it didn't call the create_model tool), "
+                                    "so it isn't suitable for 3D generation. Try a recommended model such as "
+                                    "a llama-3.x-instruct or a code model.";
+                    return;
+                }
+
+                // Validate: did it build, and does it fit the bed?
+                std::string problem;
+                if (! built || candidate.objects.empty())
+                    problem = berr.empty() ? "the shape could not be built" : berr;
+                else {
+                    std::string warn;
+                    if (! ai_model_fits_bed(candidate, bx, by, bz, warn))
+                        problem = warn + " Make it smaller so it fits.";
+                }
+
+                if (problem.empty()) {                       // success
+                    result->model = std::move(candidate);
+                    result->ok    = true;
+                    ctl.update_status(100, "");
+                    return;
+                }
+                if (attempt == MAX_REPAIRS) {                // give up repairing
+                    if (built && ! candidate.objects.empty()) { // over-volume but usable: accept + warn
+                        result->model = std::move(candidate);
+                        result->ok    = true;
+                        result->warn  = problem;
+                    } else {
+                        result->error = "Couldn't produce a valid shape after " + std::to_string(MAX_REPAIRS + 1) +
+                                        " tries. Last problem: " + problem;
+                    }
+                    return;
+                }
+                // Feed the problem back and let the model correct itself.
+                AIMessage fix;
+                fix.role    = "user";
+                fix.content = "Your previous create_model result had a problem: " + problem +
+                              "\nCall create_model again with a corrected shape. Your previous attempt was:\n" +
+                              produced.substr(0, 1500);
+                messages->push_back(std::move(fix));
+            }
+        },
+        // ---- main thread: drop the object on the plate + report ----
+        [result, on_done](bool canceled, std::exception_ptr &eptr) {
+            wxString msg; bool err = false;
+            if (canceled) { msg = _L("Generation canceled."); err = true; }
+            else if (eptr) {
+                try { std::rethrow_exception(eptr); }
+                catch (std::exception &e) { msg = from_u8(std::string("Error: ") + e.what()); }
+                catch (...)               { msg = _L("Unknown error during generation."); }
+                err = true;
+            }
+            else if (! result->ok) { msg = from_u8(result->error); err = true; }
+            else {
+                Plater *plater = wxGetApp().plater();
+                plater->take_snapshot(into_u8(_L("Add AI generated object")));
+                Model &model = plater->model();
+                std::vector<size_t> idxs;
+                for (const ModelObject *src : result->model.objects) {
+                    ModelObject *dst = model.add_object(*src);
+                    dst->ensure_on_bed();
+                    idxs.push_back(model.objects.size() - 1);
+                }
+                wxGetApp().obj_list()->paste_objects_into_list(idxs);
+                if (auto *canvas = plater->get_view3D_canvas3D())
+                    canvas->reload_scene(true);
+                if (result->warn.empty())
+                    msg = _L("Added the generated object to the plate.");
+                else { msg = from_u8(result->warn) + " " + _L("Added anyway — scale it to fit."); err = true; }
+            }
+            on_done(! err, into_u8(msg));
+        });
+}
+
+void AISlicerDialog::on_generate()
+{
+    const wxString promptw = m_prompt->GetValue();
+    if (promptw.IsEmpty()) { set_status(_L("Enter a description first."), true); return; }
+
+    set_status(_L("Generating in the background..."));
+    if (m_generate_btn) m_generate_btn->Disable();
+
+    wxWeakRef<AISlicerDialog> self(this);   // survives the dialog closing mid-generation
+    ai_generate_shape_to_plate(into_u8(promptw), [self](bool ok, const std::string &message) {
+        if (self) {
+            self->set_status(from_u8(message), ! ok);
+            if (self->m_generate_btn) self->m_generate_btn->Enable();
+        }
+    });
+}
+
+void AISlicerDialog::set_status(const wxString &msg, bool error)
+{
+    if (m_status == nullptr)
+        return;
+    m_status->SetForegroundColour(error ? wxColour(0xC0, 0x30, 0x30) : wxColour(0x30, 0x80, 0x30));
+    m_status->SetLabel(msg);
+    Layout();
+}
+
+// --- Search on the web (open the site's own search in the browser) ----------
+//
+// A plain LLM cannot return working download URLs: it has no live web access, and
+// the model repositories gate downloads behind sign-in / anti-bot. So rather than
+// try to fetch a file directly (which yields 403/404/DNS errors), we hand the
+// query to each site's real search page in the user's browser, where their normal
+// (signed-in) download flow works. The file is then loaded via File > Import.
+
+static std::string url_encode(const std::string &s)
+{
+    static const char *hex = "0123456789ABCDEF";
+    std::string out;
+    for (unsigned char c : s) {
+        if (std::isalnum(c) || c == '-' || c == '_' || c == '.' || c == '~')
+            out += static_cast<char>(c);
+        else { out += '%'; out += hex[c >> 4]; out += hex[c & 0x0F]; }
+    }
+    return out;
+}
+
+wxWindow *AISlicerDialog::build_search_tab(wxNotebook *nb)
+{
+    auto *panel = new wxPanel(nb, wxID_ANY);
+    auto *s = new wxBoxSizer(wxVERTICAL);
+
+    s->Add(new wxStaticText(panel, wxID_ANY,
+               _L("Find a model on a printing site, then download it there and load it with File > Import:")),
+           0, wxALL, FromDIP(10));
+
+    m_query = new wxTextCtrl(panel, wxID_ANY, "", wxDefaultPosition, wxSize(FromDIP(420), -1), wxTE_PROCESS_ENTER);
+    s->Add(m_query, 0, wxEXPAND | wxLEFT | wxRIGHT, FromDIP(10));
+
+    // One button per repository — each opens that site's search results in the browser.
+    struct Site { const wchar_t *name; const char *prefix; const char *suffix; };
+    static const Site kSites[] = {
+        { L"Printables",  "https://www.printables.com/search/models?q=",      ""             },
+        { L"MakerWorld",  "https://makerworld.com/en/search/models?keyword=", ""             },
+        { L"Thingiverse", "https://www.thingiverse.com/search?q=",            "&type=things" },
+        { L"Thangs",      "https://thangs.com/search/",                       "?scope=all"   },
+    };
+    auto *btn_row = new wxBoxSizer(wxHORIZONTAL);
+    for (const auto &site : kSites) {
+        auto *b = new Button(panel, wxString(site.name));
+        const std::string prefix = site.prefix, suffix = site.suffix;
+        b->Bind(wxEVT_BUTTON, [this, prefix, suffix](wxCommandEvent &) { open_model_search(prefix, suffix); });
+        btn_row->Add(b, 0, wxRIGHT, FromDIP(8));
+    }
+    s->Add(btn_row, 0, wxLEFT | wxRIGHT | wxTOP, FromDIP(10));
+
+    // Enter opens the first site (Printables).
+    m_query->Bind(wxEVT_TEXT_ENTER, [this](wxCommandEvent &) {
+        open_model_search("https://www.printables.com/search/models?q=", "");
+    });
+
+    s->Add(new wxStaticText(panel, wxID_ANY,
+               _L("These are community model sites; most let you download after a free sign-in. "
+                  "Save the .stl/.3mf, then load it with File > Import.")),
+           0, wxALL, FromDIP(10));
+
+    m_search_status = new wxStaticText(panel, wxID_ANY, "");
+    s->Add(m_search_status, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, FromDIP(10));
+
+    panel->SetSizer(s);
+    return panel;
+}
+
+void AISlicerDialog::open_model_search(const std::string &url_prefix, const std::string &url_suffix)
+{
+    const std::string q = into_u8(m_query->GetValue());
+    if (q.empty()) { set_search_status(_L("Type what you're looking for first."), true); return; }
+    const std::string url = url_prefix + url_encode(q) + url_suffix;
+    wxLaunchDefaultBrowser(from_u8(url));
+    set_search_status(_L("Opened the search in your browser."));
+}
+
+void AISlicerDialog::set_search_status(const wxString &msg, bool error)
+{
+    if (m_search_status == nullptr)
+        return;
+    m_search_status->SetForegroundColour(error ? wxColour(0xC0, 0x30, 0x30) : wxColour(0x30, 0x80, 0x30));
+    m_search_status->SetLabel(msg);
+    Layout();
+}
+
+void AISlicerDialog::on_dpi_changed(const wxRect & /*suggested_rect*/)
+{
+    Fit();
+    Refresh();
+}
+
+}} // namespace Slic3r::GUI

--- a/src/slic3r/GUI/AISlicerDialog.hpp
+++ b/src/slic3r/GUI/AISlicerDialog.hpp
@@ -1,0 +1,54 @@
+#ifndef slic3r_AISlicerDialog_hpp_
+#define slic3r_AISlicerDialog_hpp_
+
+#include <string>
+#include <vector>
+
+#include "GUI_Utils.hpp"
+
+class Button;
+class wxTextCtrl;
+class wxStaticText;
+class wxNotebook;
+
+namespace Slic3r { namespace GUI {
+
+// ---------------------------------------------------------------------------
+// AISlicerDialog
+//
+// The user-facing "AI" workspace. Increment 1: a "Generate shape" tab that
+// sends the prompt + live machine context (AIPrinterContext) to the configured
+// AIProvider, turns the reply into geometry (AIShapeGen), and drops it on the
+// plate. A "Search & Import" tab is added in a later increment.
+// ---------------------------------------------------------------------------
+class AISlicerDialog : public DPIDialog
+{
+public:
+    explicit AISlicerDialog(wxWindow *parent);
+    ~AISlicerDialog() override = default;
+
+protected:
+    void on_dpi_changed(const wxRect &suggested_rect) override;
+
+private:
+    wxWindow *build_generate_tab(wxNotebook *nb);
+    wxWindow *build_search_tab(wxNotebook *nb);
+    void      on_generate();
+    // Open the query on a model repository's own search page in the browser.
+    void      open_model_search(const std::string &url_prefix, const std::string &url_suffix);
+    void      set_status(const wxString &msg, bool error = false);
+    void      set_search_status(const wxString &msg, bool error = false);
+
+    // Generate tab
+    wxTextCtrl   *m_prompt       { nullptr };
+    Button       *m_generate_btn { nullptr };
+    wxStaticText *m_status       { nullptr };
+
+    // Search tab
+    wxTextCtrl   *m_query         { nullptr };
+    wxStaticText *m_search_status { nullptr };
+};
+
+}} // namespace Slic3r::GUI
+
+#endif // slic3r_AISlicerDialog_hpp_

--- a/src/slic3r/GUI/MainFrame.cpp
+++ b/src/slic3r/GUI/MainFrame.cpp
@@ -3539,13 +3539,9 @@ void MainFrame::init_menubar_as_editor()
 
     m_menubar->Append(calib_menu,wxString::Format("&%s", _L("Calibration")));
 
-    // AI menu — generate shapes from text. (AI provider setup lives in
-    // Preferences > General > AI.)
-    auto* ai_menu = new wxMenu();
-    append_menu_item(ai_menu, wxID_ANY, _L("Generate 3D Shape..."),
-        _L("Generate a 3D shape from a text description with AI"),
-        [this](wxCommandEvent&) { AISlicerDialog dlg(this); dlg.ShowModal(); });
-    m_menubar->Append(ai_menu, wxString::Format("&%s", _L("AI")));
+    // AI shape generation is reached from the Prepare sidebar ("AI part
+    // generator"); provider setup lives in Preferences > General > AI. No
+    // dedicated top-level menu is needed.
 
     if (helpMenu)
         m_menubar->Append(helpMenu, wxString::Format("&%s", _L("Help")));

--- a/src/slic3r/GUI/MainFrame.cpp
+++ b/src/slic3r/GUI/MainFrame.cpp
@@ -31,6 +31,8 @@
 #include "PrintHostDialogs.hpp"
 #include "wxExtensions.hpp"
 #include "GUI_ObjectList.hpp"
+#include "AISlicerDialog.hpp"
+#include "AISettingsDialog.hpp"
 #include "Mouse3DController.hpp"
 //#include "RemovableDriveManager.hpp"
 #include "InstanceCheck.hpp"
@@ -3536,6 +3538,15 @@ void MainFrame::init_menubar_as_editor()
         [this]() {return m_plater->is_view3D_shown();; }, this);
 
     m_menubar->Append(calib_menu,wxString::Format("&%s", _L("Calibration")));
+
+    // AI menu — generate shapes from text. (AI provider setup lives in
+    // Preferences > General > AI.)
+    auto* ai_menu = new wxMenu();
+    append_menu_item(ai_menu, wxID_ANY, _L("Generate 3D Shape..."),
+        _L("Generate a 3D shape from a text description with AI"),
+        [this](wxCommandEvent&) { AISlicerDialog dlg(this); dlg.ShowModal(); });
+    m_menubar->Append(ai_menu, wxString::Format("&%s", _L("AI")));
+
     if (helpMenu)
         m_menubar->Append(helpMenu, wxString::Format("&%s", _L("Help")));
     SetMenuBar(m_menubar);

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -140,6 +140,7 @@
 #include "Widgets/RadioGroup.hpp"
 #include "Widgets/CheckBox.hpp"
 #include "Widgets/Button.hpp"
+#include "AIGenerate.hpp"
 #include "Widgets/StaticGroup.hpp"
 
 #include "GUI_ObjectTable.hpp"
@@ -2342,6 +2343,42 @@ Sidebar::Sidebar(Plater *parent)
     // Sizer in the scrolled area
     auto* scrolled_sizer = m_scrolled_sizer = new wxBoxSizer(wxVERTICAL);
     p->scrolled->SetSizer(scrolled_sizer);
+
+    // AI: compact in-panel shape generator (prompt + adjacent Generate button).
+    // Uses the shared ai_generate_shape_to_plate() pipeline; the sidebar controls
+    // live for the app's lifetime so raw captures are safe.
+    {
+        auto *ai_prompt = new wxTextCtrl(p->scrolled, wxID_ANY, wxEmptyString, wxDefaultPosition,
+                                         wxSize(FromDIP(150), -1), wxTE_PROCESS_ENTER);
+        ai_prompt->SetHint(_L("e.g. a bracket with four M3 holes"));
+        auto *ai_btn = new Button(p->scrolled, _L("Generate"));
+        ai_btn->SetStyle(ButtonStyle::Regular, ButtonType::Parameter);
+        auto *ai_status = new wxStaticText(p->scrolled, wxID_ANY, wxEmptyString);
+        auto do_gen = [ai_prompt, ai_btn, ai_status]() {
+            const wxString q = ai_prompt->GetValue();
+            if (q.IsEmpty()) return;
+            ai_btn->Disable();
+            ai_status->SetForegroundColour(wxColour(0x60, 0x60, 0x60));
+            ai_status->SetLabel(_L("Generating..."));
+            ai_status->GetParent()->Layout();
+            ai_generate_shape_to_plate(into_u8(q), [ai_btn, ai_status](bool ok, const std::string &m) {
+                ai_status->SetForegroundColour(ok ? wxColour(0x2E, 0x7D, 0x32) : wxColour(0xC0, 0x30, 0x30));
+                ai_status->SetLabel(from_u8(m));
+                ai_status->GetParent()->Layout();
+                ai_btn->Enable();
+            });
+        };
+        ai_btn->Bind(wxEVT_BUTTON, [do_gen](wxCommandEvent &) { do_gen(); });
+        ai_prompt->Bind(wxEVT_TEXT_ENTER, [do_gen](wxCommandEvent &) { do_gen(); });
+        auto *ai_row = new wxBoxSizer(wxHORIZONTAL);
+        ai_row->Add(ai_prompt, 1, wxALIGN_CENTER_VERTICAL | wxLEFT | wxRIGHT, FromDIP(4));
+        ai_row->Add(ai_btn,    0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(4));
+        auto *ai_box = new wxBoxSizer(wxVERTICAL);
+        ai_box->Add(new wxStaticText(p->scrolled, wxID_ANY, _L("AI part generator (mechanical shapes)")), 0, wxLEFT | wxTOP, FromDIP(6));
+        ai_box->Add(ai_row,    0, wxEXPAND | wxTOP, FromDIP(2));
+        ai_box->Add(ai_status, 0, wxLEFT | wxRIGHT | wxBOTTOM, FromDIP(4));
+        scrolled_sizer->Add(ai_box, 0, wxEXPAND | wxBOTTOM, FromDIP(4));
+    }
 
     wxColour title_bg = wxColour(248, 248, 248);
     wxColour inactive_text = wxColour(86, 86, 86);

--- a/src/slic3r/GUI/Preferences.cpp
+++ b/src/slic3r/GUI/Preferences.cpp
@@ -1762,7 +1762,7 @@ void PreferencesDialog::create_items()
         // Provider
         {
             auto sizer = create_item_label(_L("AI provider"), _L("LLM provider used by the AI shape generator (AI menu)."), "");
-            auto combo = new ::ComboBox(m_parent, wxID_ANY, wxEmptyString, wxDefaultPosition, DESIGN_LARGE_COMBOBOX_SIZE, 0, nullptr, wxCB_READONLY);
+            auto combo = new ::ComboBox(m_parent, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize(FromDIP(320), -1), 0, nullptr, wxCB_READONLY);
             combo->Append(_L("Disabled"));
             combo->Append(_L("OpenAI"));
             combo->Append(_L("Anthropic"));
@@ -1778,7 +1778,7 @@ void PreferencesDialog::create_items()
         // Text fields (API key / gateway / model), each bound to an ai_slicer key.
         auto ai_text_row = [this, g_sizer](const wxString &label, const wxString &tip, const std::string &key, long extra_style) {
             auto sizer = create_item_label(label, tip, "");
-            auto input = new ::TextInput(m_parent, wxEmptyString, wxEmptyString, wxEmptyString, wxDefaultPosition, DESIGN_INPUT_SIZE, wxTE_PROCESS_ENTER | extra_style);
+            auto input = new ::TextInput(m_parent, wxEmptyString, wxEmptyString, wxEmptyString, wxDefaultPosition, wxSize(FromDIP(320), -1), wxTE_PROCESS_ENTER | extra_style);
             input->GetTextCtrl()->SetValue(from_u8(app_config->get("ai_slicer", key)));
             auto save = [this, input, key]() {
                 app_config->set("ai_slicer", key, into_u8(input->GetTextCtrl()->GetValue()));
@@ -1817,9 +1817,13 @@ void PreferencesDialog::create_items()
                 status->GetParent()->Layout();
             });
             sizer->Add(test_btn, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(8));
-            sizer->Add(qual_btn, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(8));
-            sizer->Add(status,   0, wxALIGN_CENTER_VERTICAL);
+            sizer->Add(qual_btn, 0, wxALIGN_CENTER_VERTICAL);
             g_sizer->Add(sizer);
+            // Result text on its own full-width row: a long "Failed: ..." message
+            // must not stretch the button row and clip the General page.
+            auto status_row = create_item_label(wxEmptyString, wxEmptyString, "");
+            status_row->Add(status, 0, wxALIGN_CENTER_VERTICAL);
+            g_sizer->Add(status_row);
         }
     }
 

--- a/src/slic3r/GUI/Preferences.cpp
+++ b/src/slic3r/GUI/Preferences.cpp
@@ -1,12 +1,17 @@
 #include "Preferences.hpp"
 #include "OptionsGroup.hpp"
+#include "GUI.hpp"
 #include "GUI_App.hpp"
 #include "MainFrame.hpp"
 #include "Plater.hpp"
 #include "MsgDialog.hpp"
 #include "I18N.hpp"
 #include "libslic3r/AppConfig.hpp"
+#include "libslic3r/Model.hpp"
 #include "libslic3r/Format/DRC.hpp"
+#include "slic3r/Utils/AIProvider.hpp"
+#include "slic3r/Utils/AIShapeGen.hpp"
+#include <chrono>
 #include <wx/language.h>
 #include "OG_CustomCtrl.hpp"
 #include "wx/graphics.h"
@@ -1554,6 +1559,64 @@ void PreferencesDialog::Split(const std::string &src, const std::string &separat
     dest.push_back(substring);
 }
 
+// --- AI provider helpers (used by the Preferences "AI" section) --------------
+static int ai_provider_index(const std::string &key)
+{
+    if (key == "anthropic")                                return 2;
+    if (key == "compatible" || key == "openai_compatible") return 3;
+    if (key == "openai")                                   return 1;
+    return 0; // disabled
+}
+static std::string ai_provider_key(int idx)
+{
+    switch (idx) { case 1: return "openai"; case 2: return "anthropic"; case 3: return "compatible"; default: return ""; }
+}
+
+// Run the create_model qualification test: does the model return a buildable
+// shape via a forced tool call? Fills `msg` either way; returns true on pass.
+static bool ai_qualify_model(const AIConfig &cfg, wxString &msg)
+{
+    std::unique_ptr<AIProvider> provider(AIProvider::create(cfg));
+    if (! provider) { msg = _L("Configure a provider, API key, and model first."); return false; }
+
+    nlohmann::json tool = {
+        {"type", "function"},
+        {"function", {
+            {"name", "create_model"},
+            {"description", "Create a printable 3D shape as a parametric tree. Never explain in prose. "
+                            "Node \"type\": box{size:[x,y,z]}, cylinder{radius,height}, cone{radius,height}, "
+                            "sphere{radius}, or union|difference|intersection{children:[...]}."},
+            {"parameters", {{"type", "object"}, {"properties", {{"shape", {{"type", "object"}}}}},
+                            {"required", nlohmann::json::array({"shape"})}}}
+        }}
+    };
+    nlohmann::json params;
+    params["tools"]       = nlohmann::json::array({tool});
+    params["tool_choice"] = {{"type", "function"}, {"function", {{"name", "create_model"}}}};
+    params["temperature"] = 0.1;
+
+    std::vector<AIMessage> msgs;
+    msgs.push_back({"system", "You design printable 3D shapes by calling create_model."});
+    msgs.push_back({"user", "a 30mm cube with a 10mm hole through the center"});
+
+    const auto t0 = std::chrono::steady_clock::now();
+    AIResponse resp = provider->chat(msgs, params);
+    const double secs = std::chrono::duration<double>(std::chrono::steady_clock::now() - t0).count();
+
+    if (! resp.ok) { msg = _L("Not suitable — request failed: ") + from_u8(resp.error); return false; }
+    if (resp.tool_call_arguments.empty()) {
+        msg = _L("Not suitable — the model replied with text instead of a create_model tool call.");
+        return false;
+    }
+    Model m; std::string err;
+    if (! ai_build_model_from_tool_call(resp.tool_call_arguments, "qualify", m, err) || m.objects.empty()) {
+        msg = _L("Returned a tool call, but its shape wasn't buildable: ") + from_u8(err);
+        return false;
+    }
+    msg = wxString::Format(_L("Qualified for 3D generation (%.1fs). This model works."), secs);
+    return true;
+}
+
 void PreferencesDialog::create_items()
 {
     // ORCA
@@ -1692,6 +1755,73 @@ void PreferencesDialog::create_items()
 
     auto item_shared_profiles  = create_item_checkbox(_L("Show shared profiles notification"), _L("Show a notification with a link to browse shared profiles when the selected printer is changed."), "show_shared_profiles_notification");
     g_sizer->Add(item_shared_profiles);
+
+    //// GENERAL > AI
+    g_sizer->Add(create_item_title(_L("AI")), 1, wxEXPAND);
+    {
+        // Provider
+        {
+            auto sizer = create_item_label(_L("AI provider"), _L("LLM provider used by the AI shape generator (AI menu)."), "");
+            auto combo = new ::ComboBox(m_parent, wxID_ANY, wxEmptyString, wxDefaultPosition, DESIGN_LARGE_COMBOBOX_SIZE, 0, nullptr, wxCB_READONLY);
+            combo->Append(_L("Disabled"));
+            combo->Append(_L("OpenAI"));
+            combo->Append(_L("Anthropic"));
+            combo->Append(_L("OpenAI-compatible (custom gateway)"));
+            combo->SetSelection(ai_provider_index(app_config->get("ai_slicer", "provider")));
+            combo->Bind(wxEVT_COMBOBOX, [this, combo](wxCommandEvent &) {
+                app_config->set("ai_slicer", "provider", ai_provider_key(combo->GetSelection()));
+                app_config->save();
+            });
+            sizer->Add(combo, 0, wxALIGN_CENTER);
+            g_sizer->Add(sizer);
+        }
+        // Text fields (API key / gateway / model), each bound to an ai_slicer key.
+        auto ai_text_row = [this, g_sizer](const wxString &label, const wxString &tip, const std::string &key, long extra_style) {
+            auto sizer = create_item_label(label, tip, "");
+            auto input = new ::TextInput(m_parent, wxEmptyString, wxEmptyString, wxEmptyString, wxDefaultPosition, DESIGN_INPUT_SIZE, wxTE_PROCESS_ENTER | extra_style);
+            input->GetTextCtrl()->SetValue(from_u8(app_config->get("ai_slicer", key)));
+            auto save = [this, input, key]() {
+                app_config->set("ai_slicer", key, into_u8(input->GetTextCtrl()->GetValue()));
+                app_config->save();
+            };
+            input->GetTextCtrl()->Bind(wxEVT_KILL_FOCUS, [save](wxFocusEvent &e) { save(); e.Skip(); });
+            input->GetTextCtrl()->Bind(wxEVT_TEXT_ENTER, [save](wxCommandEvent &e) { save(); e.Skip(); });
+            sizer->Add(input, 0, wxALIGN_CENTER_VERTICAL);
+            g_sizer->Add(sizer);
+        };
+        ai_text_row(_L("API key"), _L("Provider API key (stored locally in the config file)."), "api_key", wxTE_PASSWORD);
+        ai_text_row(_L("Gateway URL"), _L("Base URL for an OpenAI-compatible gateway, e.g. https://host/v1/"), "gateway_url", 0);
+        ai_text_row(_L("Model"), _L("Model id. Use a mid/large instruct or code model; avoid embedding/reranker/tiny models."), "model", 0);
+        // Test connection + Qualify-for-3D
+        {
+            auto sizer  = create_item_label(_L("AI connection"), _L("Verify the settings and whether the model can generate 3D shapes."), "");
+            auto status = new wxStaticText(m_parent, wxID_ANY, wxEmptyString);
+            auto test_btn = new Button(m_parent, _L("Test connection"));
+            test_btn->SetStyle(ButtonStyle::Regular, ButtonType::Parameter);
+            test_btn->Bind(wxEVT_BUTTON, [this, status](wxCommandEvent &) {
+                std::unique_ptr<AIProvider> p(AIProvider::create(AIProvider::config_from_app_config(*app_config)));
+                if (! p) { status->SetForegroundColour(wxColour(0xC0, 0x30, 0x30)); status->SetLabel(_L("Configure a provider and API key first.")); status->GetParent()->Layout(); return; }
+                std::string err; bool ok;
+                { wxBusyCursor wait; ok = p->test_connection(err); }
+                status->SetForegroundColour(ok ? wxColour(0x2E, 0x7D, 0x32) : wxColour(0xC0, 0x30, 0x30));
+                status->SetLabel(ok ? _L("Connection OK.") : _L("Failed: ") + from_u8(err));
+                status->GetParent()->Layout();
+            });
+            auto qual_btn = new Button(m_parent, _L("Qualify for 3D"));
+            qual_btn->SetStyle(ButtonStyle::Regular, ButtonType::Parameter);
+            qual_btn->Bind(wxEVT_BUTTON, [this, status](wxCommandEvent &) {
+                wxString msg; bool ok;
+                { wxBusyCursor wait; ok = ai_qualify_model(AIProvider::config_from_app_config(*app_config), msg); }
+                status->SetForegroundColour(ok ? wxColour(0x2E, 0x7D, 0x32) : wxColour(0xC0, 0x30, 0x30));
+                status->SetLabel(msg);
+                status->GetParent()->Layout();
+            });
+            sizer->Add(test_btn, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(8));
+            sizer->Add(qual_btn, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(8));
+            sizer->Add(status,   0, wxALIGN_CENTER_VERTICAL);
+            g_sizer->Add(sizer);
+        }
+    }
 
     //// GENERAL > Features
     g_sizer->Add(create_item_title(_L("Features")), 1, wxEXPAND);

--- a/src/slic3r/GUI/Widgets/TextInput.cpp
+++ b/src/slic3r/GUI/Widgets/TextInput.cpp
@@ -56,7 +56,12 @@ void TextInput::Create(wxWindow *     parent,
     StaticBox::Create(parent, wxID_ANY, pos, size, style);
     wxWindow::SetLabel(label);
     assert((style & wxRIGHT) == 0);
+    // wxTE_PASSWORD (0x0800) shares a bit with wxALIGN_CENTER_VERTICAL and would
+    // be discarded by the wxALIGN_MASK strip below, silently defeating password
+    // masking. Preserve it explicitly.
+    const long keep_password = style & wxTE_PASSWORD;
     style &= ~wxALIGN_MASK;
+    style |= keep_password;
     state_handler.attach({&label_color, & text_color});
     state_handler.update_binds();
     text_ctrl = new TextCtrl(this, wxID_ANY, text, {4, 4}, wxDefaultSize, style | wxBORDER_NONE | wxTE_PROCESS_ENTER);

--- a/src/slic3r/Utils/AIPrinterContext.cpp
+++ b/src/slic3r/Utils/AIPrinterContext.cpp
@@ -1,0 +1,192 @@
+#include "AIPrinterContext.hpp"
+
+#include <boost/log/trivial.hpp>
+#include <boost/beast/core/detail/base64.hpp>
+
+#include "libslic3r/PrintConfig.hpp"
+#include "libslic3r/PresetBundle.hpp"
+#include "libslic3r/Preset.hpp"
+
+#include "slic3r/GUI/GUI_App.hpp"
+#include "Http.hpp"
+
+namespace Slic3r {
+
+// ---------------------------------------------------------------------------
+// Slicer context (pure, testable — no GUI, no network)
+// ---------------------------------------------------------------------------
+
+nlohmann::json AIPrinterContext::slicer_context_from_config(const DynamicPrintConfig &cfg)
+{
+    // opt_serialize() renders ANY option type (scalar, per-extruder vector,
+    // enum, point-list) to a stable string, so we never guess a C++ type and
+    // never dereference a missing option. Guard on existence first.
+    auto put = [&cfg](nlohmann::json &dst, const char *out, const char *key) {
+        if (cfg.option(key) != nullptr)
+            dst[out] = cfg.opt_serialize(key);
+    };
+
+    nlohmann::json machine = nlohmann::json::object();
+    put(machine, "nozzle_diameter",   "nozzle_diameter");     // per-extruder (mm)
+    put(machine, "nozzle_type",       "nozzle_type");
+    put(machine, "printable_height",  "printable_height");    // max Z (mm)
+    put(machine, "printable_area",    "printable_area");      // bed polygon (NOT "bed_shape")
+    put(machine, "gcode_flavor",      "gcode_flavor");        // e.g. klipper / marlin
+    put(machine, "max_speed_x",       "machine_max_speed_x");
+    put(machine, "max_speed_y",       "machine_max_speed_y");
+    put(machine, "max_speed_z",       "machine_max_speed_z");
+    put(machine, "max_speed_e",       "machine_max_speed_e");
+    put(machine, "max_accel",         "machine_max_acceleration_extruding");
+    put(machine, "max_accel_travel",  "machine_max_acceleration_travel");
+
+    nlohmann::json filament = nlohmann::json::object();
+    put(filament, "type",                    "filament_type");
+    put(filament, "diameter",                "filament_diameter");
+    put(filament, "flow_ratio",              "filament_flow_ratio");
+    put(filament, "nozzle_temperature",      "nozzle_temperature");
+    put(filament, "nozzle_temp_first_layer", "nozzle_temperature_initial_layer");
+    put(filament, "bed_temperature",         "hot_plate_temp");
+    put(filament, "bed_temp_first_layer",    "hot_plate_temp_initial_layer");
+
+    nlohmann::json process = nlohmann::json::object();
+    put(process, "layer_height",         "layer_height");
+    put(process, "first_layer_height",   "initial_layer_print_height"); // NOT "first_layer_height"
+    put(process, "sparse_infill_density","sparse_infill_density");
+
+    nlohmann::json j = nlohmann::json::object();
+    j["machine"]  = std::move(machine);
+    j["filament"] = std::move(filament);
+    j["process"]  = std::move(process);
+    return j;
+}
+
+// ---------------------------------------------------------------------------
+// Assembly helpers (GUI + network)
+// ---------------------------------------------------------------------------
+
+namespace {
+
+// "192.168.1.11" / "http://192.168.1.11:7125/" -> "http://192.168.1.11:7125"
+std::string normalize_base(std::string host)
+{
+    if (host.empty())
+        return host;
+    if (host.find("://") == std::string::npos)
+        host = "http://" + host;
+    while (! host.empty() && host.back() == '/')
+        host.pop_back();
+    return host;
+}
+
+// Extract just the bare host (no scheme, no port, no path): used to reach the
+// camera on its own port. "http://192.168.1.11:7125/x" -> "192.168.1.11"
+std::string extract_hostname(const std::string &host)
+{
+    std::string h = host;
+    auto scheme = h.find("://");
+    if (scheme != std::string::npos)
+        h = h.substr(scheme + 3);
+    h = h.substr(0, h.find_first_of("/"));   // drop path
+    h = h.substr(0, h.find_first_of(":"));   // drop port
+    return h;
+}
+
+std::string base64_jpeg(const std::string &bytes)
+{
+    namespace b64 = boost::beast::detail::base64;
+    std::string out;
+    out.resize(b64::encoded_size(bytes.size()));
+    out.resize(b64::encode(&out[0], bytes.data(), bytes.size()));
+    return out;
+}
+
+} // namespace
+
+AIPrinterContext AIPrinterContext::gather()
+{
+    AIPrinterContext ctx;
+
+    auto *bundle = GUI::wxGetApp().preset_bundle;
+    if (bundle == nullptr)
+        return ctx; // nothing available (shouldn't happen in a running GUI)
+
+    // 1) Slicer settings — always.
+    try {
+        ctx.slicer = slicer_context_from_config(bundle->full_config());
+    } catch (const std::exception &e) {
+        BOOST_LOG_TRIVIAL(warning) << "AIPrinterContext: slicer context failed: " << e.what();
+    }
+
+    // 2/3) Live host + camera — only when a Physical Printer is selected.
+    DynamicPrintConfig *pcfg = bundle->physical_printers.get_selected_printer_config();
+    if (pcfg == nullptr)
+        return ctx;
+
+    const std::string host = pcfg->opt_string("print_host");
+    if (host.empty())
+        return ctx;
+
+    PrintHostType host_type = htOctoPrint;
+    if (auto *ht = pcfg->option<ConfigOptionEnum<PrintHostType>>("host_type"))
+        host_type = ht->value;
+
+    // Live telemetry is Moonraker/OctoPrint-shaped; degrade for other hosts.
+    if (host_type == htMoonraker || host_type == htOctoPrint) {
+        const std::string url = normalize_base(host) +
+            "/printer/objects/query?extruder&heater_bed&toolhead&print_stats"
+            "&bed_mesh&gcode_move&probe&configfile";
+        std::string body; bool ok = false;
+        Http::get(url)
+            .timeout_connect(3)
+            .on_complete([&](std::string b, unsigned status) { if (status >= 200 && status < 300) { body = std::move(b); ok = true; } })
+            .on_error([](std::string, std::string error, unsigned status) {
+                BOOST_LOG_TRIVIAL(info) << "AIPrinterContext: live query failed (" << status << "): " << error;
+            })
+            .perform_sync();
+        if (ok) {
+            try {
+                nlohmann::json j = nlohmann::json::parse(body);
+                if (j.contains("result") && j["result"].contains("status")) {
+                    ctx.live = j["result"]["status"];
+                    ctx.live_available = true;
+                }
+            } catch (const std::exception &e) {
+                BOOST_LOG_TRIVIAL(info) << "AIPrinterContext: live parse failed: " << e.what();
+            }
+        }
+    }
+
+    // 3) Camera snapshot (mjpg-streamer convention: :8080/?action=snapshot).
+    const std::string cam_host = extract_hostname(host);
+    if (! cam_host.empty()) {
+        const std::string cam_url = "http://" + cam_host + ":8080/?action=snapshot";
+        std::string jpeg; bool ok = false;
+        Http::get(cam_url)
+            .timeout_connect(3)
+            .on_complete([&](std::string b, unsigned status) { if (status >= 200 && status < 300 && ! b.empty()) { jpeg = std::move(b); ok = true; } })
+            .on_error([](std::string, std::string, unsigned) { /* no camera: fine */ })
+            .perform_sync();
+        if (ok) {
+            ctx.camera_jpeg_base64 = base64_jpeg(jpeg);
+            ctx.camera_available   = ! ctx.camera_jpeg_base64.empty();
+        }
+    }
+
+    return ctx;
+}
+
+// ---------------------------------------------------------------------------
+// Prompt rendering
+// ---------------------------------------------------------------------------
+
+std::string AIPrinterContext::to_prompt() const
+{
+    nlohmann::json j = nlohmann::json::object();
+    j["slicer"] = slicer;
+    if (live_available)
+        j["live_printer"] = live;
+    j["camera_available"] = camera_available;
+    return j.dump(2);
+}
+
+} // namespace Slic3r

--- a/src/slic3r/Utils/AIPrinterContext.hpp
+++ b/src/slic3r/Utils/AIPrinterContext.hpp
@@ -1,0 +1,57 @@
+#ifndef slic3r_AIPrinterContext_hpp_
+#define slic3r_AIPrinterContext_hpp_
+
+#include <string>
+
+#include <nlohmann/json.hpp>
+
+namespace Slic3r {
+
+class DynamicPrintConfig;
+
+// ---------------------------------------------------------------------------
+// AIPrinterContext
+//
+// A structured snapshot of the machine + material + process settings, plus
+// (when a Physical Printer host is configured and reachable) live telemetry
+// and an optional camera frame. It accompanies every AI request so generated
+// geometry / g-code respects the REAL printer (bed size, nozzle, material,
+// build volume, live temps, bed mesh, ...).
+//
+// Assembly never throws and never blocks the UI indefinitely: each source
+// degrades gracefully when unavailable (offline slicing still yields the full
+// slicer context; no host -> no live/camera).
+// ---------------------------------------------------------------------------
+struct AIPrinterContext
+{
+    // Slicer-side settings — ALWAYS available, even fully offline.
+    nlohmann::json slicer = nlohmann::json::object();
+
+    // Live printer telemetry — only when a Physical Printer host is configured
+    // and answered (temps, bed mesh, homed axes, job state, ...).
+    nlohmann::json live = nlohmann::json::object();
+    bool           live_available = false;
+
+    // A single camera frame as a base64-encoded JPEG (for vision models).
+    std::string camera_jpeg_base64;
+    bool        camera_available = false;
+
+    // Assemble from the active slicer presets, plus live host + camera when a
+    // Physical Printer is selected. GUI entry point (uses wxGetApp()).
+    static AIPrinterContext gather();
+
+    // Assemble ONLY the slicer portion from an explicit merged config. No GUI,
+    // no network — this is the unit-testable core.
+    static nlohmann::json slicer_context_from_config(const DynamicPrintConfig &full_config);
+
+    // Compact JSON text suitable for a system prompt.
+    std::string to_prompt() const;
+
+    // The camera frame as base64 JPEG (empty when none). For multimodal calls.
+    const std::string &to_image() const { return camera_jpeg_base64; }
+    bool has_image() const { return camera_available && ! camera_jpeg_base64.empty(); }
+};
+
+} // namespace Slic3r
+
+#endif // slic3r_AIPrinterContext_hpp_

--- a/src/slic3r/Utils/AIProvider.cpp
+++ b/src/slic3r/Utils/AIProvider.cpp
@@ -1,0 +1,335 @@
+#include "AIProvider.hpp"
+
+#include <sstream>
+#include <utility>
+
+#include <boost/log/trivial.hpp>
+
+#include "libslic3r/AppConfig.hpp"
+
+namespace Slic3r {
+
+// ---------------------------------------------------------------------------
+// Default non-pure implementations
+// ---------------------------------------------------------------------------
+
+AIResponse AIProvider::complete(const std::string    &prompt,
+                                const nlohmann::json &params) const
+{
+    std::vector<AIMessage> messages;
+    messages.push_back({"user", prompt});
+    return chat(messages, params);
+}
+
+AIConfig AIProvider::config_from_app_config(const AppConfig &app_config)
+{
+    AIConfig cfg;
+    cfg.provider = app_config.get("ai_slicer", "provider");
+    cfg.base_url = app_config.get("ai_slicer", "gateway_url");
+    cfg.api_key  = app_config.get("ai_slicer", "api_key");
+    cfg.model    = app_config.get("ai_slicer", "model");
+    return cfg;
+}
+
+// ---------------------------------------------------------------------------
+// Concrete providers (internal — reachable only through AIProvider::create())
+// ---------------------------------------------------------------------------
+
+namespace {
+
+// Result of one synchronous HTTP round-trip.
+struct HttpResult
+{
+    bool        ok     { false };   ///< transport-level success (a response arrived)
+    unsigned    status { 0 };
+    std::string body;
+    std::string error;              ///< transport error text (empty on ok)
+};
+
+// Run an already-configured Http request synchronously and collect the result.
+HttpResult http_send(Http &&http)
+{
+    HttpResult r;
+    http.on_complete([&r](std::string body, unsigned status) {
+            r.ok = true; r.status = status; r.body = std::move(body);
+        })
+        .on_error([&r](std::string body, std::string error, unsigned status) {
+            r.ok = false; r.status = status; r.body = std::move(body); r.error = std::move(error);
+        })
+        .perform_sync();
+    return r;
+}
+
+std::string strip_trailing_slash(std::string s)
+{
+    while (! s.empty() && s.back() == '/') s.pop_back();
+    return s;
+}
+
+// Join an API base URL with a versioned path without doubling the "/v1" segment.
+// OpenAI's base is given without it ("https://api.openai.com"), but many gateways
+// are entered WITH it ("https://.../v1"). `path` is like "/chat/completions".
+std::string api_url(const std::string &base, const std::string &path)
+{
+    std::string b = strip_trailing_slash(base);
+    if (b.size() >= 3 && b.compare(b.size() - 3, 3, "/v1") == 0)
+        return b + path;
+    return b + "/v1" + path;
+}
+
+// Turn any failed HttpResult into a concise, user-facing message.
+std::string http_error_message(const HttpResult &r)
+{
+    switch (r.status) {
+        case 401: case 403: return "Authentication failed (" + std::to_string(r.status) +
+                                   ") — check the API key and gateway URL.";
+        case 404:           return "Endpoint not found (404) — check the gateway URL.";
+        case 429:           return "Rate limited (429) — slow down or check your quota.";
+        default: break;
+    }
+    if (! r.error.empty())
+        return r.error;
+    std::ostringstream os;
+    os << "HTTP " << r.status;
+    if (! r.body.empty())
+        os << ": " << r.body.substr(0, 300);
+    return os.str();
+}
+
+bool status_ok(unsigned s) { return s >= 200 && s < 300; }
+
+// --- OpenAI, and any OpenAI-compatible gateway (Ollama, LiteLLM, Azure proxy...) ---
+class OpenAIProvider : public AIProvider
+{
+public:
+    OpenAIProvider(AIConfig cfg, std::string default_base, const char *name)
+        : m_cfg(std::move(cfg))
+        , m_name(name)
+        , m_base(strip_trailing_slash(m_cfg.base_url.empty() ? std::move(default_base) : m_cfg.base_url))
+    {}
+
+    const char *get_name() const override { return m_name; }
+
+    AIResponse chat(const std::vector<AIMessage> &messages,
+                    const nlohmann::json         &params) const override
+    {
+        AIResponse res;
+        nlohmann::json body = (params.is_object()) ? params : nlohmann::json::object();
+        body["model"] = default_model();
+        nlohmann::json msgs = nlohmann::json::array();
+        for (const auto &m : messages) {
+            if (m.images.empty()) {
+                msgs.push_back({{"role", m.role}, {"content", m.content}});
+            } else {
+                // OpenAI multimodal: content is an array of text/image_url parts.
+                nlohmann::json parts = nlohmann::json::array();
+                if (! m.content.empty())
+                    parts.push_back({{"type", "text"}, {"text", m.content}});
+                for (const auto &img : m.images)
+                    parts.push_back({{"type", "image_url"},
+                                     {"image_url", {{"url", "data:image/jpeg;base64," + img}}}});
+                msgs.push_back({{"role", m.role}, {"content", std::move(parts)}});
+            }
+        }
+        body["messages"] = std::move(msgs);
+
+        auto http = Http::post(api_url(m_base, "/chat/completions"));
+        http.header("Authorization", "Bearer " + m_cfg.api_key);
+        http.header("Content-Type", "application/json");
+        http.set_post_body(body.dump());
+        HttpResult r = http_send(std::move(http));
+
+        if (! r.ok || ! status_ok(r.status)) { res.error = http_error_message(r); return res; }
+        try {
+            nlohmann::json j = nlohmann::json::parse(r.body);
+            res.raw = j;
+            const nlohmann::json &msg = j.at("choices").at(0).at("message");
+            // Preferred path: a tool/function call (forced via the "tools" +
+            // "tool_choice" chat params). Arguments are a JSON string.
+            if (msg.contains("tool_calls") && msg["tool_calls"].is_array() && ! msg["tool_calls"].empty()) {
+                const nlohmann::json &fn = msg["tool_calls"][0].at("function");
+                res.tool_call_name      = fn.value("name", std::string());
+                res.tool_call_arguments = fn.value("arguments", std::string());
+            }
+            // Plain assistant text (may be null when a tool was called).
+            if (msg.contains("content") && msg["content"].is_string())
+                res.content = msg["content"].get<std::string>();
+            res.ok = true;
+        } catch (const std::exception &e) {
+            res.error = std::string("Could not parse response: ") + e.what();
+        }
+        return res;
+    }
+
+    bool test_connection(std::string &error_msg) const override
+    {
+        std::vector<AIModelInfo> models;
+        return get_models(models, error_msg);
+    }
+
+    bool get_models(std::vector<AIModelInfo> &models, std::string &error_msg) const override
+    {
+        auto http = Http::get(api_url(m_base, "/models"));
+        http.header("Authorization", "Bearer " + m_cfg.api_key);
+        HttpResult r = http_send(std::move(http));
+        if (! r.ok || ! status_ok(r.status)) { error_msg = http_error_message(r); return false; }
+        try {
+            nlohmann::json j = nlohmann::json::parse(r.body);
+            for (const auto &m : j.value("data", nlohmann::json::array())) {
+                std::string id = m.value("id", std::string());
+                if (! id.empty()) models.push_back({id, id});
+            }
+            return true;
+        } catch (const std::exception &e) {
+            error_msg = std::string("Could not parse model list: ") + e.what();
+            return false;
+        }
+    }
+
+private:
+    std::string default_model() const { return m_cfg.model.empty() ? "gpt-4o-mini" : m_cfg.model; }
+
+    AIConfig    m_cfg;
+    const char *m_name;
+    std::string m_base;
+};
+
+// --- Anthropic (Messages API) ---
+class AnthropicProvider : public AIProvider
+{
+public:
+    explicit AnthropicProvider(AIConfig cfg)
+        : m_cfg(std::move(cfg))
+        , m_base(strip_trailing_slash(m_cfg.base_url.empty() ? "https://api.anthropic.com" : m_cfg.base_url))
+    {}
+
+    const char *get_name() const override { return "Anthropic"; }
+
+    AIResponse chat(const std::vector<AIMessage> &messages,
+                    const nlohmann::json         &params) const override
+    {
+        AIResponse res;
+        nlohmann::json body = (params.is_object()) ? params : nlohmann::json::object();
+        body["model"] = m_cfg.model.empty() ? "claude-3-5-sonnet-latest" : m_cfg.model;
+        if (! body.contains("max_tokens"))
+            body["max_tokens"] = 1024;
+
+        // Anthropic keeps the system prompt as a top-level field, not a message role.
+        nlohmann::json msgs = nlohmann::json::array();
+        std::string system;
+        for (const auto &m : messages) {
+            if (m.role == "system") { system += (system.empty() ? "" : "\n") + m.content; continue; }
+            if (m.images.empty()) {
+                msgs.push_back({{"role", m.role}, {"content", m.content}});
+            } else {
+                // Anthropic multimodal: content is an array of text/image blocks.
+                nlohmann::json parts = nlohmann::json::array();
+                if (! m.content.empty())
+                    parts.push_back({{"type", "text"}, {"text", m.content}});
+                for (const auto &img : m.images)
+                    parts.push_back({{"type", "image"},
+                                     {"source", {{"type", "base64"},
+                                                 {"media_type", "image/jpeg"},
+                                                 {"data", img}}}});
+                msgs.push_back({{"role", m.role}, {"content", std::move(parts)}});
+            }
+        }
+        body["messages"] = std::move(msgs);
+        if (! system.empty())
+            body["system"] = system;
+
+        auto http = Http::post(api_url(m_base, "/messages"));
+        http.header("x-api-key", m_cfg.api_key);
+        http.header("anthropic-version", "2023-06-01");
+        http.header("Content-Type", "application/json");
+        http.set_post_body(body.dump());
+        HttpResult r = http_send(std::move(http));
+
+        if (! r.ok || ! status_ok(r.status)) { res.error = http_error_message(r); return res; }
+        try {
+            nlohmann::json j = nlohmann::json::parse(r.body);
+            res.raw = j;
+            // content is an array of blocks: text blocks + optional tool_use.
+            std::string text;
+            for (const auto &block : j.value("content", nlohmann::json::array())) {
+                const std::string btype = block.value("type", std::string());
+                if (btype == "text")
+                    text += block.value("text", std::string());
+                else if (btype == "tool_use" && res.tool_call_arguments.empty()) {
+                    res.tool_call_name      = block.value("name", std::string());
+                    res.tool_call_arguments = block.contains("input") ? block["input"].dump() : std::string();
+                }
+            }
+            res.content = std::move(text);
+            res.ok      = true;
+        } catch (const std::exception &e) {
+            res.error = std::string("Could not parse response: ") + e.what();
+        }
+        return res;
+    }
+
+    bool test_connection(std::string &error_msg) const override
+    {
+        std::vector<AIModelInfo> models;
+        return get_models(models, error_msg);
+    }
+
+    bool get_models(std::vector<AIModelInfo> &models, std::string &error_msg) const override
+    {
+        auto http = Http::get(api_url(m_base, "/models"));
+        http.header("x-api-key", m_cfg.api_key);
+        http.header("anthropic-version", "2023-06-01");
+        HttpResult r = http_send(std::move(http));
+        if (! r.ok || ! status_ok(r.status)) { error_msg = http_error_message(r); return false; }
+        try {
+            nlohmann::json j = nlohmann::json::parse(r.body);
+            for (const auto &m : j.value("data", nlohmann::json::array())) {
+                std::string id = m.value("id", std::string());
+                if (! id.empty()) models.push_back({id, m.value("display_name", id)});
+            }
+            return true;
+        } catch (const std::exception &e) {
+            error_msg = std::string("Could not parse model list: ") + e.what();
+            return false;
+        }
+    }
+
+private:
+    AIConfig    m_cfg;
+    std::string m_base;
+};
+
+} // anonymous namespace
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+AIProvider *AIProvider::create(const AIConfig &config)
+{
+    const std::string &provider = config.provider;
+
+    if (provider.empty() || provider == "none")
+        return nullptr;
+
+    if (provider == "openai")
+        return new OpenAIProvider(config, "https://api.openai.com", "OpenAI");
+
+    if (provider == "anthropic")
+        return new AnthropicProvider(config);
+
+    if (provider == "compatible" || provider == "openai_compatible") {
+        if (config.base_url.empty()) {
+            BOOST_LOG_TRIVIAL(error)
+                << "AIProvider::create: 'compatible' provider requires a gateway URL (base_url).";
+            return nullptr;
+        }
+        return new OpenAIProvider(config, config.base_url, "OpenAI-compatible");
+    }
+
+    BOOST_LOG_TRIVIAL(warning)
+        << "AIProvider::create: unknown provider '" << provider << "'; treating as disabled.";
+    return nullptr;
+}
+
+} // namespace Slic3r

--- a/src/slic3r/Utils/AIProvider.hpp
+++ b/src/slic3r/Utils/AIProvider.hpp
@@ -1,0 +1,145 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+#include <functional>
+
+#include <nlohmann/json.hpp>
+
+#include "Http.hpp"
+
+namespace Slic3r {
+
+class AppConfig;   // libslic3r; used by AIProvider::config_from_app_config()
+
+/// Configuration passed to AIProvider::create().
+struct AIConfig
+{
+    std::string provider;   ///< Provider key: "openai", "anthropic", "none", etc.
+    std::string api_key;
+    std::string model;
+    std::string base_url;   ///< Optional override for the API endpoint.
+};
+
+/// A single chat message (role + text content, plus optional images).
+struct AIMessage
+{
+    std::string role;       ///< "system", "user", or "assistant"
+    std::string content;
+
+    /// Optional base64-encoded JPEG frames (no data-URI prefix) for vision
+    /// models. When non-empty, providers send multimodal content parts.
+    std::vector<std::string> images;
+};
+
+/// Describes a model returned by get_models().
+struct AIModelInfo
+{
+    std::string id;
+    std::string display_name;
+};
+
+/// Response returned by chat() / complete().
+struct AIResponse
+{
+    bool        ok      { false };
+    std::string content;          ///< The assistant reply (on success).
+    std::string error;            ///< Human-readable error description (on failure).
+    nlohmann::json raw;           ///< Full JSON payload from the provider.
+
+    /// When the model answered with a tool/function call (see chat params
+    /// "tools" + "tool_choice"), this holds the raw JSON arguments string of the
+    /// first tool call. Empty if the model replied with prose instead — which,
+    /// for a forced tool call, means the model is unsuitable for the task.
+    std::string tool_call_arguments;
+    std::string tool_call_name;
+};
+
+/**
+ * Abstract base class for AI-provider back-ends.
+ *
+ * Mirror of PrintHost::get_print_host() pattern: callers obtain a concrete
+ * instance through the static factory AIProvider::create() and then work
+ * exclusively through the virtual interface below.
+ *
+ * Concrete provider implementations live in separate translation units
+ * (separate tasks); this file defines only the interface and factory stub.
+ */
+class AIProvider
+{
+public:
+    virtual ~AIProvider() = default;
+
+    // --- Identity -----------------------------------------------------------
+
+    /// Human-readable provider name (e.g. "OpenAI", "Anthropic").
+    virtual const char *get_name() const = 0;
+
+    // --- Core API -----------------------------------------------------------
+
+    /**
+     * Send a list of messages and return the assistant's response.
+     *
+     * @param messages  Conversation history (system + user + assistant turns).
+     * @param params    Optional extra JSON parameters forwarded to the API
+     *                  (e.g. {"temperature": 0.7, "max_tokens": 512}).
+     * @return          AIResponse with ok==true on success.
+     */
+    virtual AIResponse chat(const std::vector<AIMessage> &messages,
+                            const nlohmann::json         &params = {}) const = 0;
+
+    /**
+     * Convenience wrapper: single-turn completion from a plain prompt string.
+     *
+     * Default implementation wraps the prompt in a user message and calls chat().
+     * Concrete providers may override for provider-specific single-turn endpoints.
+     */
+    virtual AIResponse complete(const std::string    &prompt,
+                                const nlohmann::json &params = {}) const;
+
+    // --- Diagnostics --------------------------------------------------------
+
+    /**
+     * Verify that the provider is reachable and the credentials are valid.
+     *
+     * @param error_msg  Populated with a human-readable error on failure.
+     * @return           true on success.
+     */
+    virtual bool test_connection(std::string &error_msg) const = 0;
+
+    /**
+     * Return the list of models available for this provider/key combination.
+     *
+     * @param models     Populated on success.
+     * @param error_msg  Populated with a human-readable error on failure.
+     * @return           true on success.
+     */
+    virtual bool get_models(std::vector<AIModelInfo> &models,
+                            std::string              &error_msg) const = 0;
+
+    // --- Factory ------------------------------------------------------------
+
+    /**
+     * Instantiate the correct concrete AIProvider for the given AIConfig.
+     *
+     * Mirrors PrintHost::get_print_host(DynamicPrintConfig *).
+     * Selects the implementation based on config.provider:
+     *   "openai"     -> (future) OpenAIProvider
+     *   "anthropic"  -> (future) AnthropicProvider
+     *   "none" / ""  -> returns nullptr
+     *   unknown      -> returns nullptr; callers should treat as disabled.
+     *
+     * @return  Heap-allocated concrete provider, or nullptr when disabled.
+     */
+    static AIProvider *create(const AIConfig &config);
+
+    /**
+     * Build an AIConfig from the "ai_slicer" section of AppConfig:
+     *   ai_slicer/provider, ai_slicer/gateway_url (-> base_url),
+     *   ai_slicer/api_key, ai_slicer/model.
+     */
+    static AIConfig config_from_app_config(const AppConfig &app_config);
+};
+
+} // namespace Slic3r

--- a/src/slic3r/Utils/AIShapeGen.cpp
+++ b/src/slic3r/Utils/AIShapeGen.cpp
@@ -1,0 +1,379 @@
+#include "AIShapeGen.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <cmath>
+#include <cstdio>
+#include <fstream>
+
+#include <boost/filesystem.hpp>
+#include <boost/log/trivial.hpp>
+
+#include "libslic3r/Model.hpp"
+#include "libslic3r/TriangleMesh.hpp"
+#include "libslic3r/MeshBoolean.hpp"
+#include "libslic3r/Geometry.hpp"
+#include "libslic3r/Utils.hpp"
+
+namespace Slic3r {
+
+using json = nlohmann::json;
+
+namespace {
+
+constexpr int    MAX_DEPTH = 64;    // guard against pathological nesting
+constexpr double FA        = 2.0 * PI / 180.0;   // facet angle: ~1 deg -> smooth
+
+double getnum(const json &n, const char *key, double def)
+{
+    return (n.contains(key) && n[key].is_number()) ? n[key].get<double>() : def;
+}
+
+// Reads [x,y,z]; a bare number is broadcast to all three (handy for scale).
+Vec3d getvec3(const json &n, const char *key, const Vec3d &def)
+{
+    if (! n.contains(key))
+        return def;
+    const json &v = n[key];
+    if (v.is_array() && v.size() == 3 && v[0].is_number())
+        return Vec3d(v[0].get<double>(), v[1].get<double>(), v[2].get<double>());
+    if (v.is_number()) {
+        double d = v.get<double>();
+        return Vec3d(d, d, d);
+    }
+    return def;
+}
+
+// radius, honoring an alternative "diameter".
+double get_radius(const json &n, double def_radius)
+{
+    if (n.contains("radius"))
+        return getnum(n, "radius", def_radius);
+    if (n.contains("diameter"))
+        return 0.5 * getnum(n, "diameter", 2.0 * def_radius);
+    return def_radius;
+}
+
+// A = A (op) B. Tries CGAL first, falls back to mcut. Returns false on failure.
+bool csg_combine(TriangleMesh &acc, const TriangleMesh &b, char op, std::string &error)
+{
+    try {
+        switch (op) {
+            case 'u': MeshBoolean::cgal::plus(acc, b);      break;
+            case 'd': MeshBoolean::cgal::minus(acc, b);     break;
+            default:  MeshBoolean::cgal::intersect(acc, b); break;
+        }
+        return true;
+    } catch (const std::exception &e) {
+        BOOST_LOG_TRIVIAL(info) << "AIShapeGen: CGAL boolean failed (" << e.what() << "), trying mcut";
+    } catch (...) {
+        BOOST_LOG_TRIVIAL(info) << "AIShapeGen: CGAL boolean crashed, trying mcut";
+    }
+    try {
+        const std::string opts = op == 'u' ? "UNION" : op == 'd' ? "A_NOT_B" : "INTERSECTION";
+        std::vector<TriangleMesh> out;
+        MeshBoolean::mcut::make_boolean(acc, b, out, opts);
+        if (out.empty()) { error = "boolean operation produced an empty result"; return false; }
+        acc = out.front();   // extra disjoint volumes (rare) are dropped; logged below
+        if (out.size() > 1)
+            BOOST_LOG_TRIVIAL(info) << "AIShapeGen: boolean produced " << out.size() << " volumes; keeping the first";
+        return true;
+    } catch (const std::exception &e) {
+        error = std::string("boolean operation failed: ") + e.what();
+        return false;
+    } catch (...) {
+        error = "boolean operation failed";
+        return false;
+    }
+}
+
+bool build_mesh(const json &node, TriangleMesh &out, std::string &error, int depth)
+{
+    if (depth > MAX_DEPTH)     { error = "shape spec nested too deeply";     return false; }
+    if (! node.is_object())    { error = "each shape node must be an object"; return false; }
+
+    // Accept common key variations models emit for the node kind.
+    std::string type = node.value("type", std::string());
+    if (type.empty()) type = node.value("operation", std::string());
+    if (type.empty()) type = node.value("op", std::string());
+    if (type.empty()) type = node.value("shape", std::string());
+    if (type.empty()) { error = "a shape node is missing its \"type\""; return false; }
+
+    if (type == "box" || type == "cube") {
+        Vec3d s = getvec3(node, "size", Vec3d(20, 20, 20));
+        if (s.x() <= 0 || s.y() <= 0 || s.z() <= 0) { error = "box \"size\" must be positive"; return false; }
+        out = TriangleMesh(its_make_cube(s.x(), s.y(), s.z()));
+        out.transform(Geometry::translation_transform(Vec3d(-0.5 * s.x(), -0.5 * s.y(), -0.5 * s.z()))); // center
+    } else if (type == "cylinder") {
+        double r = get_radius(node, 10.0), h = getnum(node, "height", 20.0);
+        if (r <= 0 || h <= 0) { error = "cylinder needs positive radius/diameter and height"; return false; }
+        out = TriangleMesh(its_make_cylinder(r, h, FA));
+        out.transform(Geometry::translation_transform(Vec3d(0, 0, -0.5 * h))); // center on Z
+    } else if (type == "cone") {
+        double r = get_radius(node, 10.0), h = getnum(node, "height", 20.0);
+        if (r <= 0 || h <= 0) { error = "cone needs positive radius/diameter and height"; return false; }
+        out = TriangleMesh(its_make_cone(r, h, FA));
+        out.transform(Geometry::translation_transform(Vec3d(0, 0, -0.5 * h)));
+    } else if (type == "sphere") {
+        double r = get_radius(node, 10.0);
+        if (r <= 0) { error = "sphere needs a positive radius/diameter"; return false; }
+        out = TriangleMesh(its_make_sphere(r, FA));
+    } else if (type == "union" || type == "difference" || type == "intersection") {
+        if (! node.contains("children") || ! node["children"].is_array() || node["children"].empty()) {
+            error = type + " requires a non-empty \"children\" array";
+            return false;
+        }
+        const json &ch = node["children"];
+        if (! build_mesh(ch[0], out, error, depth + 1))
+            return false;
+        const char op = type == "union" ? 'u' : type == "difference" ? 'd' : 'i';
+        for (size_t i = 1; i < ch.size(); ++i) {
+            TriangleMesh b;
+            if (! build_mesh(ch[i], b, error, depth + 1))
+                return false;
+            if (! csg_combine(out, b, op, error))
+                return false;
+        }
+    } else {
+        error = "unknown shape type \"" + type + "\"";
+        return false;
+    }
+
+    // Per-node affine: scale, then rotate (degrees), then translate.
+    const Vec3d t     = getvec3(node, "translate", Vec3d::Zero());
+    const Vec3d r_deg = getvec3(node, "rotate",    Vec3d::Zero());
+    const Vec3d scale = getvec3(node, "scale",     Vec3d(1, 1, 1));
+    if (scale.x() == 0 || scale.y() == 0 || scale.z() == 0) { error = "scale factors must be non-zero"; return false; }
+    const Vec3d r_rad = r_deg * (PI / 180.0);
+    out.transform(Geometry::assemble_transform(t, r_rad, scale), /*fix_left_handed=*/true);
+    return true;
+}
+
+// Remove <think>...</think> reasoning blocks. Reasoning models (Nemotron,
+// DeepSeek-R1, QwQ, ...) emit their chain-of-thought in these tags and put the
+// real answer AFTER </think>; the block itself often contains draft JSON + prose
+// that would otherwise corrupt our extraction.
+std::string strip_think_blocks(const std::string &in)
+{
+    std::string s = in;
+    for (const char *open : {"<think>", "<thinking>", "<reasoning>"}) {
+        const std::string close = std::string("</") + (open + 1);   // "</think>" etc.
+        std::size_t pos;
+        while ((pos = s.find(open)) != std::string::npos) {
+            std::size_t end = s.find(close, pos);
+            if (end == std::string::npos) { s.erase(pos); break; }   // unterminated: drop the tail
+            s.erase(pos, (end + close.size()) - pos);
+        }
+    }
+    return s;
+}
+
+// Strip a leading/trailing ``` or ```json/```stl code fence, if present.
+std::string strip_code_fence(const std::string &in)
+{
+    std::string s = in;
+    auto not_space = [](unsigned char c) { return ! std::isspace(c); };
+    // trim
+    s.erase(s.begin(), std::find_if(s.begin(), s.end(), not_space));
+    s.erase(std::find_if(s.rbegin(), s.rend(), not_space).base(), s.end());
+    if (s.rfind("```", 0) == 0) {
+        auto nl = s.find('\n');
+        if (nl != std::string::npos) s = s.substr(nl + 1);         // drop the ```lang line
+        auto close = s.rfind("```");
+        if (close != std::string::npos) s = s.substr(0, close);
+    }
+    return s;
+}
+
+Model *finalize_object(Model &model, TriangleMesh &&mesh, const std::string &name, std::string &error)
+{
+    if (mesh.facets_count() == 0) { error = "generated mesh has no facets"; return nullptr; }
+    ModelObject *obj = model.add_object();
+    obj->name = name;
+    obj->add_instance();
+    ModelVolume *vol = obj->add_volume(std::move(mesh));
+    vol->name = name;
+    obj->ensure_on_bed();
+    return &model;
+}
+
+} // namespace
+
+std::string ai_shape_spec_instructions()
+{
+    return
+        "Output ONLY one JSON object for the 3D shape and nothing else. Units are millimeters.\n"
+        "RULES:\n"
+        "- EVERY node uses the key \"type\" (never \"operation\" or \"shape\").\n"
+        "- Every shape is ALREADY centered at the origin. Add \"translate\" ONLY to move a shape "
+        "off-center; a hole through the center needs NO translate.\n"
+        "- Primitives:\n"
+        "    {\"type\":\"box\",\"size\":[x,y,z]}\n"
+        "    {\"type\":\"cylinder\",\"radius\":r,\"height\":h}   (or \"diameter\":d)\n"
+        "    {\"type\":\"cone\",\"radius\":r,\"height\":h}\n"
+        "    {\"type\":\"sphere\",\"radius\":r}                  (or \"diameter\":d)\n"
+        "- Combine with CSG:\n"
+        "    {\"type\":\"union|difference|intersection\",\"children\":[ ...nodes... ]}\n"
+        "    (\"difference\" subtracts every later child from the first)\n"
+        "- Optional per-node transform: \"translate\":[x,y,z], \"rotate\":[deg,deg,deg], \"scale\":[sx,sy,sz]\n"
+        "- Cylinders/cones stand along Z. To bore a hole along Z through a centered box, a same-height "
+        "centered cylinder is correct with NO translate.\n"
+        "- Only geometric primitives + booleans are possible; you cannot model organic or freeform "
+        "objects (animals, faces, characters).\n"
+        "Example — a 30mm cube with a 10mm hole through its center:\n"
+        "  {\"type\":\"difference\",\"children\":["
+        "{\"type\":\"box\",\"size\":[30,30,30]},"
+        "{\"type\":\"cylinder\",\"radius\":5,\"height\":30}]}";
+}
+
+bool ai_build_model_from_spec(const json &spec, const std::string &name, Model &out_model, std::string &error)
+{
+    TriangleMesh mesh;
+    try {
+        if (! build_mesh(spec, mesh, error, 0))
+            return false;
+    } catch (const std::exception &e) {
+        error = std::string("shape build failed: ") + e.what();
+        return false;
+    }
+
+    // Make the result watertight/manifold: CSG booleans can leave non-manifold
+    // edges (coincident faces, flush cuts) that make the mesh un-printable. First
+    // a cheap cleanup, then a CGAL self-union — which resolves self-intersections
+    // and is a no-op on already-clean meshes. Best-effort: keep the cleaned mesh
+    // if self-union fails.
+    its_merge_vertices(mesh.its);
+    its_remove_degenerate_faces(mesh.its);
+    mesh = TriangleMesh(mesh.its);
+    try {
+        TriangleMesh repaired = mesh;
+        MeshBoolean::self_union(repaired);
+        if (repaired.facets_count() > 0)
+            mesh = std::move(repaired);
+    } catch (const std::exception &e) {
+        BOOST_LOG_TRIVIAL(info) << "AIShapeGen: manifold repair (self-union) failed: " << e.what();
+    } catch (...) {
+        BOOST_LOG_TRIVIAL(info) << "AIShapeGen: manifold repair (self-union) crashed";
+    }
+
+    return finalize_object(out_model, std::move(mesh), name.empty() ? "AI shape" : name, error) != nullptr;
+}
+
+bool ai_build_model_from_stl(const std::string &stl_bytes, const std::string &name, Model &out_model, std::string &error)
+{
+    if (stl_bytes.empty()) { error = "empty STL data"; return false; }
+    try {
+        boost::filesystem::path path =
+            boost::filesystem::path(temporary_dir()) / boost::filesystem::unique_path("ai_shape_%%%%%%.stl");
+        {
+            std::ofstream f(path.string(), std::ios::binary);
+            if (! f) { error = "could not open a temp file for the STL"; return false; }
+            f.write(stl_bytes.data(), static_cast<std::streamsize>(stl_bytes.size()));
+        }
+        TriangleMesh mesh;
+        const bool ok = mesh.ReadSTLFile(path.string().c_str(), true, nullptr);
+        boost::filesystem::remove(path);
+        if (! ok) { error = "could not parse the STL data"; return false; }
+        return finalize_object(out_model, std::move(mesh), name.empty() ? "AI shape" : name, error) != nullptr;
+    } catch (const std::exception &e) {
+        error = std::string("STL load failed: ") + e.what();
+        return false;
+    }
+}
+
+// One-line snippet of arbitrary text for user-facing error messages / logs.
+static std::string snippet_of(const std::string &s, std::size_t n = 240)
+{
+    std::string out = s.substr(0, n);
+    for (char &c : out) if (c == '\n' || c == '\r' || c == '\t') c = ' ';
+    if (s.size() > n) out += "...";
+    return out;
+}
+
+bool ai_build_model_from_response(const std::string &response, const std::string &name, Model &out_model, std::string &error)
+{
+    // Always log the raw response so failures are diagnosable from the log file.
+    BOOST_LOG_TRIVIAL(info) << "AIShapeGen: raw AI response (" << response.size()
+                            << " bytes): " << snippet_of(response, 4000);
+
+    const std::string s = strip_code_fence(strip_think_blocks(response));
+    if (s.empty()) { error = "The AI returned an empty response."; return false; }
+
+    // Locate a JSON object anywhere in the reply — models often wrap the spec in
+    // prose or a code fence, so don't require it to be the very first character.
+    std::size_t lb = s.find('{');
+    std::size_t rb = s.rfind('}');
+    if (lb != std::string::npos && rb != std::string::npos && rb > lb) {
+        const std::string candidate = s.substr(lb, rb - lb + 1);
+        try {
+            json spec = json::parse(candidate);
+            std::string spec_err;
+            if (ai_build_model_from_spec(spec, name, out_model, spec_err))
+                return true;
+            // Valid JSON, but not a usable shape spec — report the specific reason.
+            BOOST_LOG_TRIVIAL(warning) << "AIShapeGen: JSON is not a valid shape spec: " << spec_err
+                                       << " | json: " << snippet_of(candidate, 1500);
+            error = "The AI returned JSON, but it isn't a valid shape spec: " + spec_err;
+            return false;
+        } catch (const std::exception &e) {
+            BOOST_LOG_TRIVIAL(info) << "AIShapeGen: JSON parse failed (" << e.what()
+                                    << ") on: " << snippet_of(candidate, 1500);
+        }
+    }
+
+    // Raw STL fallback (ASCII STL contains both "solid" and "facet").
+    if (s.find("solid") != std::string::npos && s.find("facet") != std::string::npos)
+        return ai_build_model_from_stl(s, name, out_model, error);
+
+    // Nothing usable — surface what the model actually said, plus a scope hint.
+    error = "The AI didn't return a usable shape. It replied: \"" + snippet_of(s) + "\"  "
+            "This generator builds parametric shapes (boxes, cylinders, spheres, and boolean cuts), "
+            "so mechanical parts work best — organic shapes (animals, faces, etc.) aren't supported.";
+    return false;
+}
+
+bool ai_build_model_from_tool_call(const std::string &args_json, const std::string &name, Model &out_model, std::string &error)
+{
+    BOOST_LOG_TRIVIAL(info) << "AIShapeGen: create_model tool args (" << args_json.size()
+                            << " bytes): " << snippet_of(args_json, 2000);
+    try {
+        json args = json::parse(args_json);
+        json spec;
+        if (args.is_object() && args.contains("shape") && args["shape"].is_object())
+            spec = args["shape"];
+        else if (args.is_object() && (args.contains("type") || args.contains("operation") ||
+                                      args.contains("op") || args.contains("children")))
+            spec = args;                       // the model put the node at the top level
+        else { error = "The create_model call didn't contain a shape."; return false; }
+        return ai_build_model_from_spec(spec, name, out_model, error);
+    } catch (const std::exception &e) {
+        error = std::string("Could not parse the create_model arguments: ") + e.what();
+        return false;
+    }
+}
+
+bool ai_model_fits_bed(const Model &model, double bed_x, double bed_y, double bed_z, std::string &warning)
+{
+    BoundingBoxf3 bb;
+    bool any = false;
+    for (const ModelObject *o : model.objects)
+        for (const ModelVolume *v : o->volumes) {
+            BoundingBoxf3 vb = v->mesh().bounding_box();
+            if (! any) { bb = vb; any = true; } else bb.merge(vb);
+        }
+    if (! any)
+        return true;
+
+    const Vec3d sz = bb.size();
+    if (sz.x() > bed_x || sz.y() > bed_y || sz.z() > bed_z) {
+        char buf[192];
+        std::snprintf(buf, sizeof(buf),
+                      "Generated object is %.1f x %.1f x %.1f mm, which exceeds the build volume of %.0f x %.0f x %.0f mm.",
+                      sz.x(), sz.y(), sz.z(), bed_x, bed_y, bed_z);
+        warning = buf;
+        return false;
+    }
+    return true;
+}
+
+} // namespace Slic3r

--- a/src/slic3r/Utils/AIShapeGen.hpp
+++ b/src/slic3r/Utils/AIShapeGen.hpp
@@ -1,0 +1,64 @@
+#ifndef slic3r_AIShapeGen_hpp_
+#define slic3r_AIShapeGen_hpp_
+
+#include <string>
+
+#include <nlohmann/json.hpp>
+
+namespace Slic3r {
+
+class Model;
+
+// ---------------------------------------------------------------------------
+// Text-to-shape core (pure libslic3r — no GUI, no network).
+//
+// The LLM returns a compact JSON "shape spec": parametric primitives
+// (box / cylinder / cone / sphere) combined with CSG (union / difference /
+// intersection) and per-node affine transforms (translate / rotate / scale).
+// A raw-STL fallback is also accepted. These helpers validate a spec and bake
+// it into an in-memory Slic3r::Model ready for the Plater.
+// ---------------------------------------------------------------------------
+
+// Human/LLM-readable description of the shape-spec contract; embed in the
+// system prompt so the model returns something we can parse.
+std::string ai_shape_spec_instructions();
+
+// Build a Model from a validated shape-spec JSON tree.
+// Returns false and fills `error` on any validation/geometry failure.
+bool ai_build_model_from_spec(const nlohmann::json &spec,
+                              const std::string    &name,
+                              Model                &out_model,
+                              std::string          &error);
+
+// Build a Model from raw STL bytes (ASCII or binary) by staging a temp file.
+bool ai_build_model_from_stl(const std::string &stl_bytes,
+                             const std::string &name,
+                             Model             &out_model,
+                             std::string       &error);
+
+// Parse an LLM response that is EITHER a JSON shape-spec (optionally wrapped in
+// a ``` code fence) OR raw STL, and build a Model from whichever it is.
+bool ai_build_model_from_response(const std::string &response,
+                                  const std::string &name,
+                                  Model             &out_model,
+                                  std::string       &error);
+
+// Build a Model from the JSON arguments of a forced create_model tool call.
+// Accepts either {"shape": <node>} or a bare <node>. This is the reliable path:
+// a model that returns a tool call is producing structured geometry, not prose.
+bool ai_build_model_from_tool_call(const std::string &args_json,
+                                   const std::string &name,
+                                   Model             &out_model,
+                                   std::string       &error);
+
+// Bed-fit check: false (with a warning) if the model's XY/Z extent exceeds the
+// given build volume in mm. Used to keep generated geometry printable.
+bool ai_model_fits_bed(const Model &model,
+                       double       bed_x,
+                       double       bed_y,
+                       double       bed_z,
+                       std::string &warning);
+
+} // namespace Slic3r
+
+#endif // slic3r_AIShapeGen_hpp_


### PR DESCRIPTION
# Description

Adds an **optional, printer-agnostic AI assistant** that generates printable
**parametric 3D parts** from a text description, using the user's *own*
OpenAI/Anthropic-compatible LLM gateway (OpenAI, Anthropic, OpenRouter, a local
Ollama/LiteLLM, an NVIDIA endpoint, etc.). It is **entirely opt-in** — nothing
contacts a network until a provider is configured and the feature is invoked.

**No new third-party dependencies:** HTTP via `Slic3r::Http`, JSON via
`nlohmann::json`, geometry via the existing `TriangleMesh` / `MeshBoolean` / CGAL.

### How it works (the design principle: turn an unreliable conversational
capability into a compiler-like, verifiable one)

- **Providers** — abstract `AIProvider` + factory (OpenAI / Anthropic /
  OpenAI-compatible), mirroring the `PrintHost::get_print_host` pattern.
- **Machine context** (`AIPrinterContext`) — active printer/filament/process
  settings + optional live Moonraker/OctoPrint telemetry + a camera frame
  (multimodal) are sent with each request so parts fit the real machine and
  never exceed the build volume.
- **Forced tool call** — the model *must* return a structured geometry spec via a
  `create_model` tool (`tools` + `tool_choice`); a prose reply is treated as an
  **unsuitable model**. This is also the on-demand *model-qualification* signal
  (a "Qualify for 3D" button runs a canonical test per model).
- **Constrained geometry** (`AIShapeGen`) — a small geometry-op JSON DSL
  (primitives `box`/`cylinder`/`cone`/`sphere` + CSG `union`/`difference`/
  `intersection` + affine transforms), compiled to a `Slic3r::Model`. **Not**
  arbitrary code or a raw triangle mesh from the model. Output is made
  watertight/manifold (`its_merge_vertices` + `its_remove_degenerate_faces` +
  `MeshBoolean::self_union`) so it slices cleanly.
- **Reliability** — runs on a background `Job` (no UI freeze; progress + cancel),
  a bed-fit validation pass, and a **self-repair loop** (build/fit errors are fed
  back to the model, up to 2 retries).

### UI
- **AI** menu → *Generate 3D Shape…* (dialog with Generate + a browser-based
  *Find models* tab).
- **Compact generator in the Prepare sidebar** (prompt + adjacent Generate).
- **Preferences → General → AI**: provider / API key / gateway / model, plus
  *Test connection* and *Qualify for 3D*.

## Strengths
- **Genuinely useful for mechanical/parametric parts** — brackets, knobs, boxes,
  holders, adapters, spacers, washers — where "download the exact part" isn't an
  option and CAD is tedious.
- **Model-agnostic + self-qualifying**: works with any tool-calling OpenAI/Anthropic
  gateway; the forced tool call + qualification cleanly separate capable models
  from ones that just talk (validated across a 200+ model gateway).
- **Machine-aware & print-ready**: respects bed/nozzle/material; manifold repair
  makes output slice without "non-manifold edges".
- **Safe & self-contained**: constrained geometry DSL (no arbitrary code
  execution), opt-in, no new dependencies, background-threaded.

## Weaknesses / honest limitations
- **Parametric only.** It cannot produce organic/sculptural shapes (an LLM
  emitting CSG primitives can't sculpt a figurine or animal). The UI states this
  and points users to community model sites for those. A native text-to-3D
  backend (Meshy/Tripo/Hunyuan3D/TRELLIS) would be a separate, larger effort.
- **Depends on a user-supplied LLM gateway + API key.** The key is persisted in
  the app config the same way OrcaSlicer already stores `printhost_apikey` (a
  plain `coString`, i.e. cleartext on disk). This is consistent with existing
  host-credential handling; an encrypted shared secret store would be a
  worthwhile *project-wide* improvement, but is intentionally out of scope here.
- **DSL is minimal** (primitives + boolean CSG + transforms) — no fillets,
  patterns, threads, or OpenSCAD/CadQuery backend yet.
- **No automated unit tests added** — validation to date is manual + live-gateway.
- **AI-assisted implementation.** This feature was largely written with an AI
  coding assistant; it has been read, built, and runtime-tested by a human, but
  reviewers should weigh that.

# Screenshots/Recordings/Graphs
UI locations: an **AI** menu item; a compact **"AI part generator (mechanical
shapes)"** control at the top of the **Prepare** sidebar; and an **AI** section
under **Preferences → General**. (Happy to attach screenshots/recordings — the
feature has been exercised end-to-end producing parts on the plate.)

## Tests
- **Built + runtime-tested** on the OrcaSlicer 2.5.0-dev base (macOS/arm64),
  driving a live OpenAI-compatible gateway (200+ models). Verified: provider
  connect + model fetch, forced tool-calling (incl. rescuing reasoning models
  from timeouts/`<think>` leakage), per-model qualification, the self-repair loop
  (e.g. a "300 mm cube" auto-corrected to fit a 220 mm bed), manifold/print-ready
  output, and end-to-end generation onto the plate for mechanical prompts.
- This branch is rebased onto current upstream `main`; **CI verifies the build**
  against `main` (green across all platforms). Organic prompts intentionally
  produce crude approximations (see limitations).

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)

🤖 Opened as a draft for discussion + CI. Generated with AI assistance.
