### PR TITLE
Fix overhang fan speed bugs

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -5640,10 +5640,17 @@ LayerResult GCode::process_layer(
     for (const auto &layer_to_print : layers) {
         if (layer_to_print.object_layer) {
             const auto& regions = layer_to_print.object_layer->regions();
-            const bool  enable_overhang_speed = std::any_of(regions.begin(), regions.end(), [this](const LayerRegion* r) {
+            const bool has_extrusions = std::any_of(regions.begin(), regions.end(), [](const LayerRegion* r) {
+                return r->has_extrusions();
+            });
+            const bool enable_overhang_speed = std::any_of(regions.begin(), regions.end(), [this](const LayerRegion* r) {
                 return r->has_extrusions() && r->region().config().enable_overhang_speed.get_at(get_nozzle_config_index(m_writer.filament()->id()));
             });
-            if (enable_overhang_speed) {
+            const bool enable_overhang_fan = m_enable_cooling_markers && has_extrusions &&
+                std::any_of(m_config.enable_overhang_bridge_fan.values.begin(),
+                            m_config.enable_overhang_bridge_fan.values.end(),
+                            [](unsigned char value) { return value != 0; });
+            if (enable_overhang_speed || enable_overhang_fan) {
                 m_extrusion_quality_estimator.prepare_for_new_layer(layer_to_print.original_object,
                                                                     layer_to_print.object_layer);
             }
@@ -7482,7 +7489,10 @@ std::string GCode::_extrude(const ExtrusionPath &path, std::string description, 
     bool variable_speed = false;
     std::vector<ProcessedPoint> new_points {};
 
-    if (NOZZLE_CONFIG(enable_overhang_speed) && !this->on_first_layer() && !object_layer_over_raft() &&
+    const bool need_overhang_detection = NOZZLE_CONFIG(enable_overhang_speed) ||
+        (FILAMENT_CONFIG(enable_overhang_bridge_fan) && m_enable_cooling_markers);
+
+    if (need_overhang_detection && !this->on_first_layer() && !object_layer_over_raft() &&
         (is_bridge(path.role()) || is_perimeter(path.role()))) {
             bool is_external = is_external_perimeter(path.role());
             double ref_speed   = is_external ? NOZZLE_CONFIG(outer_wall_speed) : NOZZLE_CONFIG(inner_wall_speed);
@@ -7541,6 +7551,11 @@ std::string GCode::_extrude(const ExtrusionPath &path, std::string description, 
             }
             variable_speed = std::any_of(new_points.begin(), new_points.end(),
                                          [speed](const ProcessedPoint &p) { return fabs(double(p.speed) - speed) > 1; }); // Ignore small speed variations (under 1mm/sec)
+            if (!NOZZLE_CONFIG(enable_overhang_speed) && FILAMENT_CONFIG(enable_overhang_bridge_fan) && m_enable_cooling_markers) {
+                for (ProcessedPoint &point : new_points)
+                    point.speed = speed;
+                variable_speed = new_points.size() > 1;
+            }
     }
 
     double F = speed * 60;  // convert mm/sec to mm/min

--- a/src/libslic3r/GCode/CoolingBuffer.cpp
+++ b/src/libslic3r/GCode/CoolingBuffer.cpp
@@ -844,7 +844,10 @@ std::string CoolingBuffer::apply_layer_cooldown(
             ironing_fan_control = false; // ORCA: Add support for ironing fan speed control
             ironing_fan_speed = 0; // ORCA: Add support for ironing fan speed control
         }
-        if (fan_speed_new != m_fan_speed) {
+        // A tool change may keep the same configured base fan speed while the physical fan is
+        // still running at the previous filament's overhang speed. Restore the base speed before
+        // emitting G-code for the new tool in that case.
+        if (fan_speed_new != m_fan_speed || (immediately_apply && m_current_fan_speed != fan_speed_new)) {
             m_fan_speed = fan_speed_new;
             m_current_fan_speed = fan_speed_new;
             if (immediately_apply)
@@ -1040,8 +1043,10 @@ std::string CoolingBuffer::apply_layer_cooldown(
                 new_gcode += GCodeWriter::set_fan(m_config.gcode_flavor, m_current_fan_speed, part_cooling_fan_min_pwm);
                 fan_speed_change_requests[CoolingLine::TYPE_FORCE_RESUME_FAN] = false;
             }
-            else
+            else {
                 new_gcode += GCodeWriter::set_fan(m_config.gcode_flavor, m_fan_speed, part_cooling_fan_min_pwm);
+                m_current_fan_speed = m_fan_speed;
+            }
             need_set_fan = false;
         }
         pos = line_end;


### PR DESCRIPTION
### Description

The configured “Overhangs and external bridges fan speed” was only applied when “Slow down for overhangs” was also enabled.

When slowdown was disabled, overhangs and external bridges were printed using the normal fan speed instead. This made it impossible to use stronger cooling for these areas while keeping the normal printing speed.

There was also a related issue in multi-color and multi-material prints. After a filament change, the fan could continue running at the previous filament’s overhang fan speed when both filaments had the same normal fan speed. This could apply the wrong cooling setting to the new filament.

### The fixes

This PR separates overhang cooling from overhang slowdown:

* The configured overhang and external bridge fan speed is now applied even when “Slow down for overhangs” is disabled.
* Overhang speed remains unchanged when slowdown is disabled.
* The normal fan speed is restored correctly after a filament change.
* Each filament can use its own overhang fan setting without the previous filament’s setting carrying over.

This allows users to increase cooling for overhangs and external bridges without also reducing their printing speed, and makes fan control work correctly in single and multi-color/material prints.

### Screenshots (showing fan speed)

* __With “Slow down for overhangs” disabled - single material__

  |Before|After|
  |---|---|
  |<img width="1394" height="776" alt="image" src="https://github.com/user-attachments/assets/8686f667-d2ac-442d-94ce-a39370e90adc" />|<img width="1441" height="803" alt="image" src="https://github.com/user-attachments/assets/8a2be643-a93a-42a7-b77f-31a5816850aa" />|
  
<br>

* __With “Slow down for overhangs” enabled - multi material__

  |Before|After|
  |---|---|
  |<img width="1298" height="727" alt="image" src="https://github.com/user-attachments/assets/fdc91c89-f9eb-4c48-ac84-b7056463f456" />|<img width="1273" height="738" alt="image" src="https://github.com/user-attachments/assets/f775428f-b52b-4468-ba68-f221b3d5e6be" />|
  |<img width="1226" height="731" alt="image" src="https://github.com/user-attachments/assets/12a212fd-d996-4ae6-ad2c-e437e12f0cd7" />|<img width="1216" height="750" alt="image" src="https://github.com/user-attachments/assets/066497a2-bb75-45b8-bd18-c07bdf3c9e6f" />|
  |<img width="1258" height="739" alt="image" src="https://github.com/user-attachments/assets/b932d313-d32c-4662-a9ba-b2ebca44683b" />|<img width="1205" height="708" alt="image" src="https://github.com/user-attachments/assets/9155ea83-1a1d-4128-a016-c93ade441c77" />|
  
---

Fixes #14754

