### PR TITLE
fix: out-of-memory on Windows crashes with no dialog and a misleading stack

### DIFF
--- a/src/OrcaSlicer.cpp
+++ b/src/OrcaSlicer.cpp
@@ -24,6 +24,8 @@
 #include <iostream>
 #include <math.h>
 #include <csignal>
+#include <atomic>
+#include <new>
 
 #if defined(__linux__) || defined(__LINUX__)
 #include <condition_variable>
@@ -7609,6 +7611,9 @@ LONG WINAPI VectoredExceptionHandler(PEXCEPTION_POINTERS pExceptionInfo)
 }*/
 
 #if defined(_MSC_VER) || defined(__MINGW32__)
+// Guards against a failed allocation inside the dump re-entering the new-handler.
+static std::atomic<bool> g_dump_in_progress{false};
+
 extern "C" {
     __declspec(dllexport) int __stdcall orcaslicer_main(int argc, wchar_t **argv)
     {
@@ -7627,10 +7632,22 @@ extern "C" {
         //AddVectoredExceptionHandler(1, CBaseException::UnhandledExceptionFilter);
         SET_DEFULTER_HANDLER();
 #endif
+        // Dump before unwinding, while the stack still names what asked for the memory. Throwing
+        // std::bad_alloc is standard-permitted here and is what reaches generic_exception_handle().
         std::set_new_handler([]() {
-            int *a = nullptr;
-            *a     = 0;
-            });
+            if (!g_dump_in_progress.exchange(true)) {
+                try {
+                    // A null EXCEPTION_POINTERS walks the calling thread as it stands.
+                    CBaseException base(GetCurrentProcess(), GetCurrentProcessId(), NULL, nullptr);
+                    base.ShowCallstack();
+                } catch (...) {
+                    // A failed dump must not displace the std::bad_alloc owed to the caller.
+                }
+                // ObjParser recovers from std::bad_alloc, so let a later one dump again.
+                g_dump_in_progress = false;
+            }
+            throw std::bad_alloc();
+        });
         // Call the UTF8 main.
         return CLI().run(argc, argv_ptrs.data());
     }


### PR DESCRIPTION
# Description

Refs #14795, not Fixes. This restores the missing dialog but doesn't stop the memory exhaustion behind that report, so the issue should stay open.

On Windows `orcaslicer_main` installs a `std::set_new_handler` that deliberately writes to a null pointer. `operator new` calls the new-handler whenever an allocation fails, so every out-of-memory becomes a write access violation at `0x0`. The process dies with no dialog, and since release builds ship without PDBs the crash log blames whatever exported symbol sits nearest the fault. In #14795 that pointed at `cereal` and undo/redo, when the real cause was a failed allocation on the GUI thread.

It also makes existing error handling dead code. `generic_exception_handle()` in `GUI_App.cpp` already catches `std::bad_alloc` and shows a localized "running out of memory" message, reachable from `GUI_App::OnInit()` and `OnExceptionInMainLoop()`, and `BackgroundSlicingProcess` has the equivalent for the slicing thread. The new-handler crashes the process before `operator new` can throw, so none of it runs.

This wasn't intentional. The handler came from BambuStudio in d8dd8fa634, where it probed for memory and threw `std::bad_alloc` when the machine was genuinely out. The 1.8.2 merge (bba367cde8) dropped the probe and the throw, leaving only the null write.

The handler now dumps a callstack and throws `std::bad_alloc` instead. Throwing is what reaches the dialog. Dumping from the handler, before unwinding, is the only point where the stack still names what asked for the memory.

A worker thread with no `std::bad_alloc` catch of its own now reaches `std::terminate` rather than the SEH handler, so it gets the callstack but no dialog. TBB rethrows task exceptions on the joining thread, which for slicing work is already guarded.

# Screenshots/Recordings/Graphs

Before, the process just disappears, so there is nothing to capture.

After:

<img width="361" height="224" alt="oom-modal" src="https://github.com/user-attachments/assets/6c06eaf1-0f80-443d-91ce-c92dd594bccc" />

## Tests

Built RelWithDebInfo and forced a failing allocation on the GUI thread with a temporary Help menu item calling `::operator new(1 << 46)`. The dialog above appears, and the `crash_*.log` names the allocation site rather than a nearest-export guess:

```
<lambda>::operator()   OrcaSlicer.cpp:7642     <- new-handler
callnewh               ucrtbase
operator new           new_scalar.cpp:41
<lambda>::operator()   MainFrame.cpp:2569      <- the forcing menu item
...
orcaslicer_main        OrcaSlicer.cpp:7658
```

On current main the same click kills the process with no dialog and writes a `crash_*.log` reading `Exception Code :c0000005 ACCESS_VIOLATION`, matching the logs in #14795.
