### PR TITLE
Skip arm64 Linux and Windows builds on self-hosted runners

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -57,17 +57,13 @@ jobs:
   build_linux:
     strategy:
       fail-fast: false
-      # Build both arches on every event (PRs included), through the same
-      # build_check_cache -> build_deps -> build_orca chain (the AppImage).
-      # aarch64 always uses the GitHub-hosted arm runner (there is no arm
-      # self-hosted server). amd64's empty arch is load-bearing: it keeps the
-      # historical 'linux-clang' deps cache key and the unsuffixed asset names.
+      # SELF_HOSTED skips arm64 (no arm self-hosted server). amd64's empty arch
+      # is load-bearing: it keeps the historical 'linux-clang' deps cache key and
+      # the unsuffixed asset names.
       matrix:
-        include:
-          - arch: ""
-            os: ${{ vars.SELF_HOSTED && 'orca-lnx-server' || 'ubuntu-24.04' }}
-          - arch: "aarch64"
-            os: ubuntu-24.04-arm
+        include: ${{ fromJSON(vars.SELF_HOSTED
+          && '[{"arch":"","os":"orca-lnx-server"}]'
+          || '[{"arch":"","os":"ubuntu-24.04"},{"arch":"aarch64","os":"ubuntu-24.04-arm"}]') }}
     # Don't run scheduled builds on forks:
     if: ${{ !cancelled() && (github.event_name != 'schedule' || github.repository == 'OrcaSlicer/OrcaSlicer') }}
     uses: ./.github/workflows/build_check_cache.yml
@@ -80,18 +76,16 @@ jobs:
     name: Build Windows ${{ matrix.arch }}
     strategy:
       fail-fast: false
+      # SELF_HOSTED skips arm64 (the self-hosted Windows server is x64-only).
       matrix:
-        include:
-          - arch: x64
-            os: windows-latest
-          - arch: arm64
-            os: windows-11-arm
+        include: ${{ fromJSON(vars.SELF_HOSTED
+          && '[{"arch":"x64","os":"orca-win-server"}]'
+          || '[{"arch":"x64","os":"windows-latest"},{"arch":"arm64","os":"windows-11-arm"}]') }}
     # Don't run scheduled builds on forks:
     if: ${{ !cancelled() && (github.event_name != 'schedule' || github.repository == 'OrcaSlicer/OrcaSlicer') }}
     uses: ./.github/workflows/build_check_cache.yml
     with:
-      # Self-hosted runner is x64-only; ARM64 always uses the GitHub-hosted runner.
-      os: ${{ (matrix.arch == 'x64' && vars.SELF_HOSTED) && 'orca-win-server' || matrix.os }}
+      os: ${{ matrix.os }}
       arch: ${{ matrix.arch }}
       build-deps-only: ${{ inputs.build-deps-only || false }}
       force-build: ${{ github.event_name == 'schedule' }}
@@ -134,7 +128,7 @@ jobs:
   unit_tests_linux_aarch64:
     name: Linux aarch64
     needs: build_linux
-    if: ${{ !cancelled() && success() }}
+    if: ${{ !cancelled() && success() && !vars.SELF_HOSTED }}
     uses: ./.github/workflows/unit_tests.yml
     with:
       os: ubuntu-24.04-arm
@@ -150,7 +144,7 @@ jobs:
   unit_tests_windows_arm64:
     name: Windows arm64
     needs: build_windows
-    if: ${{ !cancelled() && success() }}
+    if: ${{ !cancelled() && success() && !vars.SELF_HOSTED }}
     uses: ./.github/workflows/unit_tests.yml
     with:
       os: windows-11-arm
@@ -165,24 +159,24 @@ jobs:
       os: ${{ vars.SELF_HOSTED && 'orca-macos-arm64' || 'macos-14' }}
       artifact: ${{ github.sha }}-tests-macos-arm64
       test-dir: build/arm64/tests
-  # Slice a two-colour cube through every shipped printer with this PR's engine
-  # so all custom g-code (change_filament_gcode, machine start/end, etc.) is
-  # expanded - catches slicing regressions the static profile checks and unit
-  # tests can't see. Profile-only PRs are covered by check_profiles.yml (nightly
-  # binary); this covers src/engine PRs with the PR-built binary. Runs in
-  # parallel off build_linux's artifact so it doesn't lengthen the build leg.
+  # Slice a two-colour cube through every shipped printer so all custom g-code
+  # (change_filament_gcode, machine start/end, etc.) is expanded - catches
+  # slicing regressions the static profile checks and unit tests can't see.
+  # Profile-only PRs are covered by check_profiles.yml's nightly binary; this
+  # covers src/engine PRs with the PR-built binary.
   slice_check_linux:
-    name: Slice check (Linux aarch64)
+    name: Slice check (Linux ${{ vars.SELF_HOSTED && 'x86_64' || 'aarch64' }})
     needs: build_linux
     if: ${{ !cancelled() && success() }}
-    runs-on: ubuntu-24.04-arm
+    # Follows whichever Linux leg built the validator.
+    runs-on: ${{ vars.SELF_HOSTED && 'orca-lnx-server' || 'ubuntu-24.04-arm' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
       - name: Download profile validator
         uses: actions/download-artifact@v8
         with:
-          name: ${{ github.sha }}-profile-validator-linux-aarch64
+          name: ${{ github.sha }}-profile-validator-linux-${{ vars.SELF_HOSTED && 'x86_64' || 'aarch64' }}
           path: validator-bin
       - name: Validate slice (expand custom g-code)
         timeout-minutes: 60

--- a/.github/workflows/build_orca.yml
+++ b/.github/workflows/build_orca.yml
@@ -508,17 +508,15 @@ jobs:
           retention-days: 5
           if-no-files-found: error
 
-        # Ship the freshly-built validator so the parallel slice_check_linux job
-        # (build_all.yml) can slice-sweep the shipped profiles with this PR's
-        # engine. Taken from the aarch64 leg so the sweep runs on arm64 (its
-        # GitHub-hosted runner is free, and it also exercises the arm build).
-        # Stable sha-based name mirrors the tests artifact above so the
-        # downstream job downloads it by exact name.
+        # Ship the freshly-built validator so slice_check_linux (build_all.yml)
+        # can slice-sweep the shipped profiles with this PR's engine. Taken from
+        # the aarch64 leg so the sweep also exercises the arm build; x86_64 on
+        # SELF_HOSTED, which skips arm64.
       - name: Upload profile validator (for slice check)
-        if: runner.os == 'Linux' && inputs.arch == 'aarch64'
+        if: ${{ runner.os == 'Linux' && (vars.SELF_HOSTED && inputs.arch != 'aarch64' || !vars.SELF_HOSTED && inputs.arch == 'aarch64') }}
         uses: actions/upload-artifact@v7
         with:
-          name: ${{ github.sha }}-profile-validator-linux-aarch64
+          name: ${{ github.sha }}-profile-validator-linux-${{ inputs.arch == 'aarch64' && 'aarch64' || 'x86_64' }}
           overwrite: true
           path: ./build/src/Release/OrcaSlicer_profile_validator
           retention-days: 5


### PR DESCRIPTION
There is no arm64 self-hosted build server, so when \`vars.SELF_HOSTED\` is set the arm64 Linux and Windows legs previously fell back to GitHub-hosted runners. Drop those legs entirely instead, along with the unit test jobs that consume their artifacts.

**Changes:**

- **Linux / Windows builds:** matrices switch from a static \`include:\` list to \`fromJSON(vars.SELF_HOSTED && ... || ...)\`, so self-hosted runs build x86_64/x64 only. The Windows job's per-arch runner conditional is gone — the runner is now baked into each matrix entry.
- **Unit tests:** \`unit_tests_linux_aarch64\` and \`unit_tests_windows_arm64\` are gated on \`!vars.SELF_HOSTED\`; their \`needs\` still succeed, so \`success()\` alone would not skip them.
- **Slice check:** the profile validator artifact is now named per-arch and uploaded from the aarch64 leg normally, or x86_64 on self-hosted. The job's runner and download name follow the same switch, keeping the gate alive rather than failing on a missing artifact.
- **Comments:** trimmed across the touched blocks.

No change when \`SELF_HOSTED\` is unset — an unset variable is falsy, so GitHub-hosted runs keep both arches, the same runners, and the aarch64 slice check.