### PR TITLE
Extensible printer connectivity via swappable printer agents

### DIFF
--- a/resources/orca_plugins/BBLPrinterAgentPlugin.py
+++ b/resources/orca_plugins/BBLPrinterAgentPlugin.py
@@ -1,0 +1,1243 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["paho-mqtt"]
+#
+# [tool.orcaslicer.plugin]
+# name = "BBL Printer Agent"
+# description = "Barebones Bambu Lab printer-agent plugin."
+# author = "OrcaSlicer"
+# version = "0.0.1"
+# type = "printer-connection"
+# ///
+import json
+import ftplib
+import queue
+import select
+import socket
+import ssl
+import sys
+import threading
+import uuid
+from pathlib import Path
+
+import orca
+
+from typing import Any, Callable
+
+try:
+    import paho.mqtt.client as mqtt
+except ModuleNotFoundError:
+    mqtt = None
+
+
+def _log(msg):
+    print(f"[BBLPrinterAgentPlugin] {msg}", file=sys.stderr, flush=True)
+
+
+MQTT_CONNECT_TIMEOUT_SECONDS = 10
+MQTT_KEEPALIVE_SECONDS = 60
+MQTT_PORT = 1883
+MQTT_SSL_PORT = 8883
+FTP_SSL_PORT = 990
+SSDP_GROUP = "239.255.255.250"
+SSDP_PORTS = (1990, 2021)
+SSDP_RECV_SIZE = 8192
+BAMBU_DEFAULT_USERNAME = "bblp"
+MQTT_CONNACK_MESSAGES = {
+    0: "accepted",
+    1: "unacceptable protocol version",
+    2: "identifier rejected",
+    3: "server unavailable",
+    4: "bad username or password",
+    5: "not authorized",
+}
+CONNECT_STATUS_OK = 0
+CONNECT_STATUS_FAILED = 1
+CONNECT_STATUS_LOST = 2
+BAMBU_NETWORK_ERR_INVALID_HANDLE = -1
+BAMBU_NETWORK_ERR_SEND_MSG_FAILED = -4
+BAMBU_NETWORK_ERR_BIND_FAILED = -5
+BAMBU_NETWORK_ERR_UNBIND_FAILED = -6
+BAMBU_NETWORK_ERR_FILE_NOT_EXIST = -14
+BAMBU_NETWORK_ERR_CANCELED = -18
+BAMBU_NETWORK_ERR_PRINT_WR_UPLOAD_FTP_FAILED = -2130
+BAMBU_NETWORK_ERR_PRINT_LP_UPLOAD_FTP_FAILED = -4020
+BAMBU_NETWORK_ERR_PRINT_LP_PUBLISH_MSG_FAILED = -4030
+BAMBU_NETWORK_ERR_PRINT_SG_UPLOAD_FTP_FAILED = -5010
+PRINTING_STAGE_CREATE = 0
+PRINTING_STAGE_UPLOAD = 1
+PRINTING_STAGE_SENDING = 3
+PRINTING_STAGE_FINISHED = 6
+PRINTING_STAGE_ERROR = 7
+INITIAL_PUSH_PAYLOAD = {
+    "pushing": {"command": "pushall"},
+    "info": {"command": "get_version"},
+    "upgrade": {"command": "get_history"},
+}
+
+
+class _ImplicitFTP_TLS(ftplib.FTP_TLS):
+    def __init__(self, *args, unwrap: bool = False, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._sock = None
+        self.unwrap = unwrap
+
+    def ntransfercmd(self, cmd, rest=None):
+        conn, size = ftplib.FTP.ntransfercmd(self, cmd, rest)
+        if self._prot_p:
+            conn = self.context.wrap_socket(conn, server_hostname=self.host, session=self.sock.session)
+        return conn, size
+
+    @property
+    def sock(self):
+        return self._sock
+
+    @sock.setter
+    def sock(self, value):
+        if value is not None and not isinstance(value, ssl.SSLSocket):
+            value = self.context.wrap_socket(value)
+        self._sock = value
+
+    def storbinary(self, cmd, fp, blocksize=8192, callback=None, rest=None):
+        self.voidcmd("TYPE I")
+        conn = self.transfercmd(cmd, rest)
+        try:
+            while True:
+                buf = fp.read(blocksize)
+                if not buf:
+                    break
+                conn.sendall(buf)
+                if callback:
+                    callback(buf)
+            if isinstance(conn, ssl.SSLSocket) and self.unwrap:
+                conn.unwrap()
+        finally:
+            conn.close()
+
+        # Bambu's FTPS server may leave the control channel without the usual
+        # final 226 response after the data socket has been closed. At this
+        # point transfercmd/sendall has already succeeded, so accept the known
+        # non-standard completion forms instead of reporting a false upload
+        # failure to the UI.
+        old_timeout = self.sock.gettimeout() if self.sock else None
+        try:
+            if self.sock:
+                self.sock.settimeout(2)
+            return self.voidresp()
+        except TimeoutError:
+            _log(f"FTP upload completed for {cmd}; timed out waiting for final response")
+            return "226 Transfer complete"
+        except ftplib.error_reply as exc:
+            if str(exc).startswith("200"):
+                _log(f"FTP upload completed for {cmd}; accepted non-standard response: {exc}")
+                return str(exc)
+            raise
+        finally:
+            if self.sock and old_timeout is not None:
+                self.sock.settimeout(old_timeout)
+
+
+class BBLPrinterAgentPlugin(orca.printer_agent.PrinterAgentBase):
+    def on_load(self):
+        self.on_server_err_fn: Callable[..., None] | None = None
+        self.on_printer_connected_fn: Callable[..., None] | None = None
+        self.on_subscribe_failure_fn: Callable[..., None] | None = None
+        self.on_message_fn: Callable[..., None] | None = None
+        self.on_user_message_fn: Callable[..., None] | None = None
+        self.on_local_connect_fn: Callable[..., None] | None = None
+        self.on_local_message_fn: Callable[..., None] | None = None
+        self.on_ssdp_msg_fn: Callable[..., None] | None = None
+        self.queue_on_main_fn: Callable[..., None] | None = None
+        self._selected_machine = ""
+        self._mqtt_lock = threading.RLock()
+        self._mqtt_client = None
+        self._mqtt_connected = threading.Event()
+        self._mqtt_dev_id = ""
+        self._mqtt_host = ""
+        self._mqtt_username = BAMBU_DEFAULT_USERNAME
+        self._mqtt_password = ""
+        self._mqtt_command_topic = ""
+        self._mqtt_manual_disconnect = False
+        self._printer_data: dict[str, Any] = {}
+        self._last_error = ""
+        self._last_code = BAMBU_NETWORK_ERR_INVALID_HANDLE
+        self._sequence_id = 10000000
+        self._mqtt_command_queue = queue.Queue()
+        self._mqtt_command_worker_stop = threading.Event()
+        self._mqtt_command_worker = threading.Thread(target=self._mqtt_command_loop, daemon=True)
+        self._mqtt_command_worker.start()
+        self._ssdp_stop = threading.Event()
+        self._ssdp_thread = None
+        self._ssdp_sockets = []
+        self._ssdp_seen = {}
+
+    def get_name(self):
+        return "BBL Printer Agent"
+
+    def set_server_callback(self, on_server_err_fn):
+        self.on_server_err_fn = on_server_err_fn
+        return 0
+
+    def set_on_printer_connected_fn(self, on_printer_connected_fn):
+        self.on_printer_connected_fn = on_printer_connected_fn
+        return 0
+
+    def set_on_subscribe_failure_fn(self, on_subscribe_failure_fn):
+        self.on_subscribe_failure_fn = on_subscribe_failure_fn
+        return 0
+
+    def set_on_message_fn(self, on_message_fn):
+        self.on_message_fn = on_message_fn
+        return 0
+
+    def set_on_user_message_fn(self, on_user_message_fn):
+        self.on_user_message_fn = on_user_message_fn
+        return 0
+
+    def set_on_local_connect_fn(self, on_connect_fn):
+        self.on_local_connect_fn = on_connect_fn
+        return 0
+
+    def set_on_local_message_fn(self, on_message_fn):
+        self.on_local_message_fn = on_message_fn
+        return 0
+
+    def set_on_ssdp_msg_fn(self, on_ssdp_msg_fn):
+        self.on_ssdp_msg_fn = on_ssdp_msg_fn
+        return 0
+
+    def set_queue_on_main_fn(self, queue_on_main_fn):
+        self.queue_on_main_fn = queue_on_main_fn
+        return 0
+
+    def connect_printer(self, dev_id, dev_ip, username, password, use_ssl) -> int:
+        self._ensure_state()
+        dev_id = str(dev_id or "").strip()
+        dev_ip = str(dev_ip or "").strip()
+        username = str(username or BAMBU_DEFAULT_USERNAME).strip()
+        password = str(password or "").strip()
+        _log(
+            "connect_printer requested "
+            f"dev_id={dev_id or '<missing>'} host={dev_ip or '<missing>'} "
+            f"username={username or BAMBU_DEFAULT_USERNAME} ssl={bool(use_ssl)} "
+            f"password_length={len(password)}"
+        )
+
+        if not dev_ip:
+            return self._connection_failed(dev_id, "Missing printer IP address")
+        if mqtt is None:
+            return self._connection_failed(dev_id, "paho-mqtt is required for MQTT printer connections")
+        if not dev_id:
+            return self._connection_failed(dev_id, "Missing printer serial/device id")
+        if not password:
+            return self._connection_failed(dev_id, "Missing printer access code/password")
+
+        port = MQTT_SSL_PORT if use_ssl else MQTT_PORT
+        connected = threading.Event()
+        connect_result = {"rc": None}
+        client = self._create_mqtt_client(dev_id)
+        command_topic = f"device/{dev_id}/request"
+        report_topic = f"device/{dev_id}/report"
+
+        def on_connect(client, userdata, flags, rc, *extra):
+            connect_result["rc"] = self._mqtt_result_code(rc)
+            try:
+                _log(
+                    f"MQTT on_connect dev_id={dev_id} rc={connect_result['rc']} "
+                    f"message={MQTT_CONNACK_MESSAGES.get(connect_result['rc'], 'unknown')}"
+                )
+                if connect_result["rc"] == 0:
+                    self._mqtt_connected.set()
+                    client.subscribe(report_topic)
+                    client.publish(command_topic, json.dumps(INITIAL_PUSH_PAYLOAD))
+                    _log(f"MQTT subscribed dev_id={dev_id} topic={report_topic}; requested initial push")
+            finally:
+                connected.set()
+
+        def on_disconnect(client, userdata, *args):
+            reason = self._disconnect_reason(args)
+            with self._mqtt_lock:
+                is_current_client = client is self._mqtt_client
+                if is_current_client:
+                    self._mqtt_connected.clear()
+                    current_dev_id = self._mqtt_dev_id
+                    manual_disconnect = self._mqtt_manual_disconnect
+                else:
+                    current_dev_id = ""
+                    manual_disconnect = True
+            _log(f"MQTT on_disconnect dev_id={current_dev_id or dev_id} reason={reason} manual={manual_disconnect}")
+            if self.on_local_connect_fn and current_dev_id and not manual_disconnect:
+                self.on_local_connect_fn(CONNECT_STATUS_LOST, current_dev_id, f"MQTT disconnected: {reason}")
+
+        def on_message(client, userdata, message):
+            with self._mqtt_lock:
+                if client is not self._mqtt_client:
+                    return
+            payload = message.payload.decode("utf-8", errors="replace")
+            self._handle_message_payload(payload)
+            if self.on_local_message_fn:
+                self.on_local_message_fn(dev_id, payload)
+
+        def on_log(client, userdata, level, buf):
+            text = str(buf)
+            if any(token in text.lower() for token in ("connect", "ssl", "tls", "fail", "error", "refused")):
+                _log(f"MQTT paho log dev_id={dev_id} level={level}: {text}")
+
+        client.on_connect = on_connect
+        client.on_disconnect = on_disconnect
+        client.on_message = on_message
+        client.on_log = on_log
+
+        username = username or BAMBU_DEFAULT_USERNAME
+        client.username_pw_set(username, password)
+        if use_ssl:
+            client.tls_set(tls_version=ssl.PROTOCOL_TLS, cert_reqs=ssl.CERT_NONE)
+            client.tls_insecure_set(True)
+
+        with self._mqtt_lock:
+            old_client = self._detach_mqtt_locked()
+        if old_client is not None:
+            _log("connect_printer replacing existing MQTT client")
+        self._stop_mqtt_client(old_client)
+
+        with self._mqtt_lock:
+            self._mqtt_client = client
+            self._mqtt_dev_id = dev_id
+            self._mqtt_host = dev_ip
+            self._mqtt_username = username
+            self._mqtt_password = password
+            self._mqtt_command_topic = command_topic
+            self._mqtt_manual_disconnect = False
+            self._printer_data = {}
+            self._last_error = ""
+            self._selected_machine = dev_id
+
+        try:
+            _log(f"MQTT connecting dev_id={dev_id} host={dev_ip} port={port}")
+            client.connect_async(dev_ip, port, keepalive=MQTT_KEEPALIVE_SECONDS)
+            client.loop_start()
+            _log(f"MQTT loop started dev_id={dev_id}; waiting up to {MQTT_CONNECT_TIMEOUT_SECONDS}s for CONNACK")
+        except Exception as exc:
+            client_to_stop = None
+            with self._mqtt_lock:
+                if self._mqtt_client is client:
+                    client_to_stop = self._detach_mqtt_locked()
+            self._stop_mqtt_client(client_to_stop)
+            return self._connection_failed(dev_id, str(exc))
+
+        if not connected.wait(MQTT_CONNECT_TIMEOUT_SECONDS):
+            client_to_stop = None
+            with self._mqtt_lock:
+                if self._mqtt_client is client:
+                    client_to_stop = self._detach_mqtt_locked()
+            self._stop_mqtt_client(client_to_stop)
+            return self._connection_failed(dev_id, f"Timed out connecting to MQTT broker at {dev_ip}:{port}")
+
+        with self._mqtt_lock:
+            is_current_client = client is self._mqtt_client
+        if not is_current_client:
+            return self._connection_failed(dev_id, "MQTT client was replaced before connection completed")
+
+        rc = connect_result.get("rc")
+        if rc == 0:
+            if self.on_local_connect_fn:
+                self.on_local_connect_fn(CONNECT_STATUS_OK, dev_id, "0")
+            if self.on_printer_connected_fn:
+                self.on_printer_connected_fn(report_topic)
+            _log(f"connect_printer succeeded dev_id={dev_id} host={dev_ip} port={port}")
+            return 0
+
+        reason = MQTT_CONNACK_MESSAGES.get(rc, "unknown")
+        message = (
+            f"MQTT broker rejected connection with code {rc} ({reason}); "
+            f"check LAN access code, username={username}, ssl={bool(use_ssl)}"
+        )
+        client_to_stop = None
+        with self._mqtt_lock:
+            if self._mqtt_client is client:
+                client_to_stop = self._detach_mqtt_locked()
+        self._stop_mqtt_client(client_to_stop)
+        return self._connection_failed(dev_id, message, callback_message=str(rc))
+
+    def disconnect_printer(self) -> int:
+        self._ensure_state()
+        with self._mqtt_lock:
+            client = self._detach_mqtt_locked()
+        self._stop_mqtt_client(client)
+        return 0
+
+    def start_discovery(self, start=True, sending=False) -> bool:
+        self._ensure_state()
+        if start:
+            if self._ssdp_thread and self._ssdp_thread.is_alive():
+                _log("SSDP discovery already running")
+                return True
+            self._ssdp_stop.clear()
+            self._ssdp_seen = {}
+            _log(f"Starting SSDP discovery sending={bool(sending)} ports={SSDP_PORTS}")
+            self._ssdp_thread = threading.Thread(
+                target=self._ssdp_loop,
+                args=(bool(sending),),
+                daemon=True,
+            )
+            self._ssdp_thread.start()
+            return True
+
+        if not self._ssdp_sockets and not (self._ssdp_thread and self._ssdp_thread.is_alive()):
+            return True
+
+        _log("Stopping SSDP discovery")
+        self._ssdp_stop.set()
+        for sock in list(self._ssdp_sockets):
+            try:
+                sock.close()
+            except OSError:
+                pass
+        self._ssdp_sockets = []
+        return True
+
+    def install_device_cert(self, dev_id, lan_only=True):
+        return
+
+    def get_agent_info(self):
+        return orca.printer_agent.AgentInfo(
+            "pybbl",
+            "Bambu Lab",
+            "0.0.1",
+            "Barebones Bambu Lab printer-agent plugin",
+        )
+
+    def get_user_selected_machine(self):
+        self._ensure_state()
+        return self._selected_machine
+
+    def set_user_selected_machine(self, dev_id):
+        self._ensure_state()
+        self._selected_machine = str(dev_id or "")
+        return 0
+
+    def send_message(self, dev_id, json_str, qos=0, flag=0):
+        return self.send_message_to_printer(dev_id, json_str, qos, flag)
+
+    def send_message_to_printer(self, dev_id, json_str, qos=0, flag=0):
+        self._ensure_state()
+        del dev_id, flag
+        if self._publish_payload(json_str, qos=max(0, min(2, self._int_or_default(qos, 0)))):
+            return 0
+        self._last_code = BAMBU_NETWORK_ERR_SEND_MSG_FAILED
+        return self._last_code
+
+    def check_cert(self):
+        return 0
+
+    def ping_bind(self, ping_code):
+        self._last_error = "Printer binding is not supported by this plugin"
+        self._last_code = BAMBU_NETWORK_ERR_BIND_FAILED
+        return self._last_code
+
+    def bind_detect(self, dev_ip, sec_link, detect):
+        detect.result_msg = "Printer binding is not supported by this plugin"
+        detect.command = "bind_detect"
+        detect.dev_id = ""
+        detect.model_id = ""
+        detect.dev_name = ""
+        detect.version = ""
+        detect.bind_state = "unsupported"
+        detect.connect_type = "lan"
+        self._last_error = detect.result_msg
+        self._last_code = BAMBU_NETWORK_ERR_BIND_FAILED
+        return self._last_code
+
+    def bind(self, dev_ip, dev_id, sec_link, timezone, improved, update_fn):
+        del dev_ip, dev_id, sec_link, timezone, improved
+        self._last_error = "Printer binding is not supported by this plugin"
+        self._last_code = BAMBU_NETWORK_ERR_BIND_FAILED
+        self._update_progress(update_fn, PRINTING_STAGE_ERROR, self._last_code, self._last_error)
+        return self._last_code
+
+    def unbind(self, dev_id):
+        del dev_id
+        self._last_error = "Printer unbinding is not supported by this plugin"
+        self._last_code = BAMBU_NETWORK_ERR_UNBIND_FAILED
+        return self._last_code
+
+    def request_bind_ticket(self):
+        return (BAMBU_NETWORK_ERR_BIND_FAILED, "")
+
+    def start_print(self, params=None, update_fn=None, cancel_fn=None, wait_fn=None):
+        del wait_fn
+        return self._start_local_print(params, BAMBU_NETWORK_ERR_PRINT_WR_UPLOAD_FTP_FAILED, update_fn, cancel_fn)
+
+    def start_local_print(self, params=None, update_fn=None, cancel_fn=None):
+        return self._start_local_print(params, BAMBU_NETWORK_ERR_PRINT_LP_UPLOAD_FTP_FAILED, update_fn, cancel_fn)
+
+    def start_local_print_with_record(self, params=None, update_fn=None, cancel_fn=None, wait_fn=None):
+        del wait_fn
+        return self._start_local_print(params, BAMBU_NETWORK_ERR_PRINT_WR_UPLOAD_FTP_FAILED, update_fn, cancel_fn)
+
+    def start_sdcard_print(self, params=None, update_fn=None, cancel_fn=None):
+        self._ensure_state()
+        del update_fn
+        if self._cancel_requested(cancel_fn):
+            self._last_error = "Cancelled"
+            self._last_code = BAMBU_NETWORK_ERR_CANCELED
+            return self._last_code
+        if params is None:
+            self._last_error = "Missing print params"
+            self._last_code = BAMBU_NETWORK_ERR_INVALID_HANDLE
+            return self._last_code
+        try:
+            payload = self._build_sdcard_project_file_payload(params)
+        except Exception as exc:
+            self._last_error = str(exc)
+            self._last_code = BAMBU_NETWORK_ERR_INVALID_HANDLE
+            return self._last_code
+        if self._queue_payload(payload):
+            return 0
+        self._last_code = BAMBU_NETWORK_ERR_PRINT_LP_PUBLISH_MSG_FAILED
+        return self._last_code
+
+    def start_send_gcode_to_sdcard(self, params=None, update_fn=None, cancel_fn=None, wait_fn=None):
+        self._ensure_state()
+        del wait_fn
+        if params is None:
+            self._last_error = "Missing print params"
+            self._last_code = BAMBU_NETWORK_ERR_INVALID_HANDLE
+            return self._last_code
+        if self._upload_print_file(params, update_fn, cancel_fn):
+            return 0
+        return self._last_code or BAMBU_NETWORK_ERR_PRINT_SG_UPLOAD_FTP_FAILED
+
+    def get_filament_sync_mode(self):
+        return orca.printer_agent.FilamentSyncMode.Subscription
+
+    def fetch_filament_info(self, dev_id):
+        del dev_id
+        return self._publish_payload({"pushing": {"command": "pushall"}}, require_connected=False)
+
+    def send_gcode(self, gcode, sequence_id=None):
+        self._ensure_state()
+        gcode = str(gcode or "").strip()
+        if not gcode:
+            self._last_error = "Missing G-code command"
+            self._last_code = BAMBU_NETWORK_ERR_INVALID_HANDLE
+            return self._last_code
+        payload = {
+            "print": {
+                "command": "gcode_line",
+                "param": gcode,
+                "sequence_id": str(sequence_id or self._next_sequence_id()),
+            }
+        }
+        if self._queue_payload(payload):
+            return 0
+        self._last_code = BAMBU_NETWORK_ERR_PRINT_LP_PUBLISH_MSG_FAILED
+        return self._last_code
+
+    def send_command(self, request_json):
+        return self._send_command_impl(request_json, None, None)
+
+    def send_command_with_progress(self, request_json, update_fn, cancel_fn):
+        return self._send_command_impl(request_json, update_fn, cancel_fn)
+
+    def _send_command_impl(self, request_json, update_fn=None, cancel_fn=None):
+        try:
+            request = json.loads(request_json)
+        except json.JSONDecodeError:
+            return json.dumps({
+                "status": "error",
+                "message": "Invalid printer-agent request",
+            })
+
+        command = request.get("command")
+        payload = request.get("payload") or {}
+        if not isinstance(payload, dict):
+            return json.dumps({
+                "status": "error",
+                "message": "Invalid printer-agent payload",
+            })
+
+        if command == "connect_printer":
+            dev_id = request.get("dev_id") or payload.get("dev_id") or ""
+            result = self.connect_printer(
+                dev_id,
+                payload.get("dev_ip") or "",
+                payload.get("username") or "",
+                payload.get("password") or "",
+                self._as_bool(payload.get("use_ssl")),
+            )
+            if result == 0:
+                return json.dumps({"status": "ok"})
+            return json.dumps({"status": "error", "message": self._last_error or "MQTT connection failed"})
+
+        if command == "disconnect_printer":
+            self.disconnect_printer()
+            return json.dumps({"status": "ok"})
+
+        if command == "get_filament_info":
+            self._queue_payload({"pushing": {"command": "pushall"}}, require_connected=False)
+            return json.dumps(self._build_filament_info())
+
+        if command in ("send_message", "send_message_to_printer"):
+            outbound = payload.get("message") if "message" in payload else payload
+            qos = self._int_or_default(payload.get("qos"), 0)
+            qos = max(0, min(2, qos))
+            return self._status_response(self._queue_payload(outbound, qos=qos))
+
+        if command == "start_local_print_with_record":
+            return self._status_response(
+                self._start_local_print(payload, BAMBU_NETWORK_ERR_PRINT_WR_UPLOAD_FTP_FAILED, update_fn, cancel_fn)
+            )
+
+        if command == "start_local_print":
+            return self._status_response(
+                self._start_local_print(payload, BAMBU_NETWORK_ERR_PRINT_LP_UPLOAD_FTP_FAILED, update_fn, cancel_fn)
+            )
+
+        if command == "start_send_gcode_to_sdcard":
+            result = 0 if self._upload_print_file(payload, update_fn, cancel_fn) else self._last_code
+            if result is None:
+                result = BAMBU_NETWORK_ERR_PRINT_SG_UPLOAD_FTP_FAILED
+            return self._status_response(result)
+
+        if command == "start_sdcard_print":
+            return self._status_response(self.start_sdcard_print(payload))
+
+        if command == "send_gcode":
+            gcode = payload.get("gcode") or payload.get("param") or payload.get("message")
+            return self._status_response(self.send_gcode(gcode, payload.get("sequence_id")))
+
+        if self._looks_like_bambu_payload(request):
+            return self._status_response(self._queue_payload(request, qos=0))
+
+        return json.dumps({
+            "status": "error",
+            "message": f"Unsupported printer-agent command: {command or '<missing>'}",
+        })
+
+    def on_unload(self):
+        self.start_discovery(False, False)
+        self._mqtt_command_worker_stop.set()
+        self.disconnect_printer()
+        if self._mqtt_command_worker and self._mqtt_command_worker.is_alive():
+            self._mqtt_command_worker.join(timeout=1.0)
+        self.on_server_err_fn: Callable[..., None] | None = None
+        self.on_printer_connected_fn: Callable[..., None] | None = None
+        self.on_subscribe_failure_fn: Callable[..., None] | None = None
+        self.on_message_fn: Callable[..., None] | None = None
+        self.on_user_message_fn: Callable[..., None] | None = None
+        self.on_local_connect_fn: Callable[..., None] | None = None
+        self.on_local_message_fn: Callable[..., None] | None = None
+        self.on_ssdp_msg_fn: Callable[..., None] | None = None
+        self.queue_on_main_fn: Callable[..., None] | None = None
+
+    def _ensure_state(self):
+        if hasattr(self, "_mqtt_lock"):
+            return
+        self.on_load()
+
+    def _create_mqtt_client(self, dev_id):
+        client_id = f"OrcaSlicer-{uuid.uuid4().hex[:12]}"
+        _log(f"MQTT creating client dev_id={dev_id or '<missing>'} client_id={client_id}")
+        kwargs = {
+            "client_id": client_id,
+            "clean_session": True,
+            "protocol": mqtt.MQTTv311,
+        }
+        callback_api_version = getattr(mqtt, "CallbackAPIVersion", None)
+        if callback_api_version is not None:
+            kwargs["callback_api_version"] = callback_api_version.VERSION1
+        return mqtt.Client(**kwargs)
+
+    def _detach_mqtt_locked(self):
+        client = self._mqtt_client
+        self._mqtt_manual_disconnect = True
+        self._mqtt_client = None
+        self._mqtt_dev_id = ""
+        self._mqtt_host = ""
+        self._mqtt_command_topic = ""
+        self._mqtt_connected.clear()
+        return client
+
+    def _stop_mqtt_client(self, client):
+        if client is None:
+            return
+        try:
+            client.disconnect()
+        except Exception:
+            pass
+        try:
+            client.loop_stop()
+        except Exception:
+            pass
+
+    def _stop_mqtt_client_async(self, client):
+        if client is None:
+            return
+        threading.Thread(target=self._stop_mqtt_client, args=(client,), daemon=True).start()
+
+    def _ssdp_loop(self, sending=False):
+        sockets = []
+        try:
+            for port in SSDP_PORTS:
+                try:
+                    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
+                    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+                    if hasattr(socket, "SO_REUSEPORT"):
+                        try:
+                            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
+                        except OSError:
+                            pass
+                    sock.bind(("", port))
+                    membership = socket.inet_aton(SSDP_GROUP) + socket.inet_aton("0.0.0.0")
+                    sock.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP, membership)
+                    sockets.append(sock)
+                    _log(f"SSDP listening on {SSDP_GROUP}:{port}")
+                except OSError as exc:
+                    self._last_error = f"SSDP listen failed on port {port}: {exc}"
+                    _log(self._last_error)
+
+            self._ssdp_sockets = sockets
+            if not sockets:
+                _log("SSDP discovery has no listening sockets")
+                return
+
+            if sending:
+                _log("Sending SSDP M-SEARCH")
+                for port in SSDP_PORTS:
+                    request = (
+                        "M-SEARCH * HTTP/1.1\r\n"
+                        f"HOST: {SSDP_GROUP}:{port}\r\n"
+                        'MAN: "ssdp:discover"\r\n'
+                        "MX: 1\r\n"
+                        "ST: ssdp:all\r\n"
+                        "\r\n"
+                    ).encode("utf-8")
+                    for sock in sockets:
+                        try:
+                            sock.sendto(request, (SSDP_GROUP, port))
+                        except OSError as exc:
+                            _log(f"SSDP M-SEARCH send failed port={port}: {exc}")
+
+            while not self._ssdp_stop.is_set():
+                try:
+                    readable, _, _ = select.select(sockets, [], [], 1.0)
+                except OSError as exc:
+                    _log(f"SSDP select failed: {exc}")
+                    break
+
+                for sock in readable:
+                    try:
+                        packet, addr = sock.recvfrom(SSDP_RECV_SIZE)
+                    except OSError as exc:
+                        _log(f"SSDP recv failed: {exc}")
+                        continue
+
+                    text = packet.decode("utf-8", errors="replace")
+                    headers = {}
+                    for line in text.replace("\r\n", "\n").split("\n"):
+                        if ":" not in line:
+                            continue
+                        key, value = line.split(":", 1)
+                        key = "".join(ch for ch in key.lower() if ch.isalnum())
+                        value = value.strip()
+                        headers[key] = value
+                        for suffix in ("bambucom", "bambulabcom"):
+                            if key.endswith(suffix):
+                                headers.setdefault(key[:-len(suffix)], value)
+
+                    def header(*names, default=""):
+                        for name in names:
+                            key = "".join(ch for ch in name.lower() if ch.isalnum())
+                            value = headers.get(key)
+                            if value:
+                                return value
+                        return default
+
+                    dev_id = header("dev_id", "devid", "serial", "serial_number", "usn")
+                    if dev_id.startswith("uuid:"):
+                        dev_id = dev_id[5:]
+                    if "::" in dev_id:
+                        dev_id = dev_id.split("::", 1)[0]
+                    if not dev_id:
+                        continue
+
+                    dev_name = header("dev_name", "devname", "friendly_name", "name", default=dev_id)
+                    device = {
+                        "dev_name": dev_name,
+                        "dev_id": dev_id,
+                        "dev_ip": addr[0],
+                        "dev_type": header("dev_type", "dev_model", "devmodel", "model", "printer_type", default=""),
+                        "dev_signal": header("dev_signal", "devsignal", "signal", default="0"),
+                        "connect_type": header("connect_type", "connection_type", "dev_connect", "devconnect", default="lan"),
+                        "bind_state": header("bind_state", "dev_bind", "devbind", "bind", default="free"),
+                        "sec_link": header("sec_link", "dev_sec_link", "devseclink", "secure_link", default=""),
+                        "ssdp_version": header("ssdp_version", "dev_version", "devversion", "version", default=""),
+                        "connection_name": header("connection_name", default=dev_name),
+                    }
+                    seen_key = device["dev_id"]
+                    seen_value = (
+                        device["dev_ip"],
+                        device["dev_name"],
+                        device["dev_type"],
+                        device["connect_type"],
+                        device["bind_state"],
+                        device["sec_link"],
+                        device["ssdp_version"],
+                    )
+                    if self._ssdp_seen.get(seen_key) != seen_value:
+                        self._ssdp_seen[seen_key] = seen_value
+                        _log(f"SSDP discovered printer {json.dumps(device, sort_keys=True)}")
+                    if self.on_ssdp_msg_fn:
+                        self.on_ssdp_msg_fn(json.dumps(device))
+        finally:
+            for sock in sockets:
+                try:
+                    sock.close()
+                except OSError:
+                    pass
+            self._ssdp_sockets = []
+            _log("SSDP discovery loop exited")
+
+    def _connection_failed(self, dev_id, message, callback_message=None) -> int:
+        self._last_error = message
+        _log(f"connect_printer failed dev_id={dev_id or '<missing>'}: {message}")
+        if self.on_local_connect_fn:
+            self.on_local_connect_fn(CONNECT_STATUS_FAILED, dev_id, callback_message or message)
+        return -1
+
+    def _queue_payload(self, payload, qos=1, require_connected=True) -> bool:
+        try:
+            self._mqtt_command_queue.put_nowait((payload, qos, require_connected))
+            return True
+        except Exception as exc:
+            self._last_error = str(exc)
+            return False
+
+    def _mqtt_command_loop(self):
+        while not self._mqtt_command_worker_stop.is_set():
+            try:
+                payload, qos, require_connected = self._mqtt_command_queue.get(timeout=0.25)
+            except queue.Empty:
+                continue
+
+            try:
+                if not self._publish_payload(payload, qos=qos, require_connected=require_connected):
+                    _log(f"MQTT queued command publish failed: {self._last_error}")
+            finally:
+                self._mqtt_command_queue.task_done()
+
+    def _publish_payload(self, payload, qos=1, require_connected=True) -> bool:
+        if isinstance(payload, str):
+            try:
+                payload = json.loads(payload)
+            except json.JSONDecodeError:
+                pass
+
+        with self._mqtt_lock:
+            client = self._mqtt_client
+            topic = self._mqtt_command_topic
+            connected = self._mqtt_connected.is_set()
+
+        if client is None or not topic:
+            self._last_error = "MQTT client is not connected"
+            return False
+        if require_connected and not connected:
+            self._last_error = "MQTT client is not connected"
+            return False
+
+        try:
+            message = payload if isinstance(payload, str) else json.dumps(payload)
+            info = client.publish(topic, message, qos=qos)
+            if getattr(info, "rc", 0) != 0:
+                self._last_error = f"MQTT publish failed with code {info.rc}"
+                return False
+            return True
+        except Exception as exc:
+            self._last_error = str(exc)
+            return False
+
+    def _handle_message_payload(self, payload: str):
+        try:
+            doc = json.loads(payload)
+        except json.JSONDecodeError:
+            return
+        if not isinstance(doc, dict):
+            return
+        with self._mqtt_lock:
+            self._merge_printer_data(doc)
+
+    def _merge_printer_data(self, doc: dict[str, Any]):
+        for key, value in doc.items():
+            if isinstance(value, dict) and isinstance(self._printer_data.get(key), dict):
+                self._printer_data[key].update(value)
+            else:
+                self._printer_data[key] = value
+
+    def _build_filament_info(self) -> dict[str, Any]:
+        with self._mqtt_lock:
+            data = json.loads(json.dumps(self._printer_data))
+
+        print_data = data.get("print", {})
+        if not isinstance(print_data, dict):
+            return {"units": [], "external": []}
+
+        return {
+            "units": self._build_ams_units(print_data.get("ams", {})),
+            "external": self._build_external_filaments(print_data.get("vt_tray")),
+        }
+
+    def _build_ams_units(self, ams_data) -> list[dict[str, Any]]:
+        if not isinstance(ams_data, dict):
+            return []
+        units = []
+        for unit_index, unit in enumerate(ams_data.get("ams", []) or []):
+            if not isinstance(unit, dict):
+                continue
+            unit_id = str(unit.get("id", unit_index))
+            slots = []
+            for slot_index, tray in enumerate(unit.get("tray", []) or []):
+                if not isinstance(tray, dict):
+                    continue
+                slots.append(self._convert_filament_tray(tray, slot_index))
+            units.append({
+                "id": unit_id,
+                "type": self._ams_type_name(unit),
+                "extruder": self._int_or_default(unit.get("ext_id"), 0),
+                "temperature": self._float_or_default(unit.get("temp"), 0.0),
+                "humidity_percent": self._int_or_default(unit.get("humidity_raw"), -1),
+                "dry_time_min": self._int_or_default(unit.get("dry_time"), 0),
+                "slots": slots,
+            })
+        return units
+
+    def _build_external_filaments(self, vt_tray) -> list[dict[str, Any]]:
+        if not isinstance(vt_tray, dict):
+            return []
+        return [self._convert_filament_tray(vt_tray, 0, extruder=0)]
+
+    def _convert_filament_tray(self, tray, index, extruder=None) -> dict[str, Any]:
+        color = self._normalize_color(tray.get("tray_color") or tray.get("color") or "00000000")
+        material = str(tray.get("tray_type") or tray.get("type") or "")
+        preset_id = str(tray.get("tray_info_idx") or tray.get("preset_id") or "")
+        converted = {
+            "index": self._int_or_default(tray.get("id"), index),
+            "loaded": bool(material or preset_id or tray.get("n")),
+            "material": material,
+            "preset_id": preset_id,
+            "color": color,
+            "nozzle_temp_min": self._int_or_default(tray.get("nozzle_temp_min"), 0),
+            "nozzle_temp_max": self._int_or_default(tray.get("nozzle_temp_max"), 0),
+            "remain_percent": self._int_or_default(tray.get("remain"), -1),
+            "k": self._float_or_default(tray.get("k"), 0.0),
+        }
+        if extruder is not None:
+            converted["extruder"] = extruder
+        diameter = self._float_or_none(tray.get("tray_diameter") or tray.get("diameter"))
+        if diameter is not None:
+            converted["diameter_mm"] = diameter
+        weight = self._int_or_none(tray.get("tray_weight") or tray.get("weight"))
+        if weight is not None:
+            converted["weight_g"] = weight
+        return converted
+
+    def _start_local_print(self, params, upload_error_code, update_fn=None, cancel_fn=None):
+        self._ensure_state()
+        if params is None:
+            self._last_error = "Missing print params"
+            self._last_code = BAMBU_NETWORK_ERR_INVALID_HANDLE
+            return self._last_code
+        if self._cancel_requested(cancel_fn):
+            self._last_error = "Cancelled"
+            self._last_code = BAMBU_NETWORK_ERR_CANCELED
+            return self._last_code
+
+        self._update_progress(update_fn, PRINTING_STAGE_CREATE, 0, "Preparing...")
+        if not self._upload_print_file(params, update_fn, cancel_fn, upload_error_code):
+            self._update_progress(update_fn, PRINTING_STAGE_ERROR, self._last_code, self._last_error)
+            return self._last_code
+        if self._cancel_requested(cancel_fn):
+            self._last_error = "Cancelled"
+            self._last_code = BAMBU_NETWORK_ERR_CANCELED
+            return self._last_code
+
+        try:
+            payload = self._build_project_file_payload(params)
+        except Exception as exc:
+            self._last_error = str(exc)
+            self._last_code = BAMBU_NETWORK_ERR_INVALID_HANDLE
+            self._update_progress(update_fn, PRINTING_STAGE_ERROR, self._last_code, self._last_error)
+            return self._last_code
+
+        self._update_progress(update_fn, PRINTING_STAGE_SENDING, 0, "Starting print...")
+        if not self._queue_payload(payload):
+            self._last_code = BAMBU_NETWORK_ERR_PRINT_LP_PUBLISH_MSG_FAILED
+            self._update_progress(update_fn, PRINTING_STAGE_ERROR, self._last_code, self._last_error)
+            return self._last_code
+
+        self._update_progress(update_fn, PRINTING_STAGE_FINISHED, 100, "1")
+        return 0
+
+    def _build_project_file_payload(self, params) -> dict[str, Any]:
+        filename = self._remote_print_name(params)
+        if not filename:
+            raise ValueError("Missing print filename")
+
+        plate = self._param(params, "plate_index", 1)
+        try:
+            plate = int(plate)
+        except (TypeError, ValueError):
+            plate = 1
+
+        ams_mapping = self._json_or_default(self._param(params, "ams_mapping"), [0])
+        if not isinstance(ams_mapping, list):
+            ams_mapping = [ams_mapping]
+
+        return {
+            "print": {
+                "command": "project_file",
+                "param": self._param(params, "plate_location") or f"Metadata/plate_{plate}.gcode",
+                "file": filename,
+                "bed_leveling": self._as_bool(self._param(params, "task_bed_leveling", True)),
+                "bed_type": self._param(params, "task_bed_type", "textured_plate"),
+                "flow_cali": self._as_bool(self._param(params, "task_flow_cali", True)),
+                "vibration_cali": self._as_bool(self._param(params, "task_vibration_cali", True)),
+                "url": self._param(params, "url") or f"ftp:///{filename}",
+                "layer_inspect": self._as_bool(self._param(params, "task_layer_inspect", False)),
+                "sequence_id": str(self._param(params, "sequence_id") or self._next_sequence_id()),
+                "timelapse": self._as_bool(self._param(params, "task_record_timelapse", False)),
+                "use_ams": self._as_bool(self._param(params, "task_use_ams", True)),
+                "ams_mapping": ams_mapping,
+                "skip_objects": self._json_or_default(self._param(params, "skip_objects"), None),
+            }
+        }
+
+    def _build_sdcard_project_file_payload(self, params) -> dict[str, Any]:
+        remote = (
+            self._param(params, "dst_file")
+            or self._param(params, "ftp_file")
+            or self._param(params, "file")
+            or self._param(params, "filename")
+        )
+        if not remote:
+            raise ValueError("Missing printer storage file")
+        remote = str(remote)
+        if remote.startswith("file://"):
+            file_url = remote
+        elif remote.startswith("/"):
+            file_url = f"file://{remote}"
+        else:
+            file_url = f"file:///{remote}"
+        payload_params = dict(params) if isinstance(params, dict) else {}
+        payload_params["ftp_file"] = Path(remote).name
+        payload_params["url"] = self._param(params, "url") or file_url
+        return self._build_project_file_payload(payload_params)
+
+    def _upload_print_file(self, params, update_fn=None, cancel_fn=None, error_code=BAMBU_NETWORK_ERR_PRINT_SG_UPLOAD_FTP_FAILED) -> bool:
+        source = (
+            self._param(params, "local_path")
+            or self._param(params, "source")
+            or self._param(params, "filename")
+            or self._param(params, "dst_file")
+        )
+        if not source:
+            self._last_error = "Missing local file path"
+            self._last_code = BAMBU_NETWORK_ERR_FILE_NOT_EXIST
+            return False
+        path = Path(source)
+        if not path.is_file():
+            self._last_error = f"Local file does not exist: {source}"
+            self._last_code = BAMBU_NETWORK_ERR_FILE_NOT_EXIST
+            return False
+
+        remote = self._remote_print_name(params, path)
+        host = self._param(params, "dev_ip") or self._mqtt_host
+        username = self._param(params, "username") or self._mqtt_username or BAMBU_DEFAULT_USERNAME
+        password = self._param(params, "password") or self._mqtt_password
+        use_ssl = self._as_bool(self._param(params, "use_ssl_for_ftp", True))
+        port = FTP_SSL_PORT if use_ssl else 21
+        if not host or not password:
+            self._last_error = "Missing FTP host or password"
+            self._last_code = error_code
+            return False
+
+        try:
+            self._update_progress(update_fn, PRINTING_STAGE_UPLOAD, 0, "Uploading...")
+            ftp = _ImplicitFTP_TLS() if use_ssl else ftplib.FTP()
+            _log(
+                "FTP upload starting "
+                f"host={host} port={port} ssl={use_ssl} source={path} remote={remote} "
+                f"size={path.stat().st_size}"
+            )
+            ftp.connect(host=host, port=port, timeout=30)
+            ftp.login(username, password)
+            if use_ssl:
+                ftp.prot_p()
+            total = path.stat().st_size
+            uploaded = 0
+
+            def on_upload(block):
+                nonlocal uploaded
+                if self._cancel_requested(cancel_fn):
+                    raise InterruptedError("Cancelled")
+                uploaded += len(block)
+                if total > 0:
+                    self._update_progress(update_fn, PRINTING_STAGE_UPLOAD, min(100, int(uploaded * 100 / total)), "Uploading...")
+
+            with path.open("rb") as fh:
+                ftp.storbinary(f"STOR {remote}", fh, blocksize=32768, callback=on_upload)
+            ftp.close()
+            self._update_progress(update_fn, PRINTING_STAGE_UPLOAD, 100, "Uploading...")
+            _log(f"FTP upload succeeded remote={remote} bytes={uploaded}")
+            return True
+        except InterruptedError as exc:
+            self._last_error = str(exc)
+            self._last_code = BAMBU_NETWORK_ERR_CANCELED
+            _log(f"FTP upload cancelled remote={remote}: {exc}")
+            return False
+        except Exception as exc:
+            self._last_error = str(exc)
+            self._last_code = error_code
+            _log(f"FTP upload failed remote={remote} code={error_code}: {type(exc).__name__}: {exc}")
+            return False
+
+    def _remote_print_name(self, params, source_path: Path | None = None) -> str:
+        remote = self._param(params, "ftp_file") or self._param(params, "file")
+        if remote:
+            return Path(str(remote)).name
+        candidate = self._param(params, "filename") or self._param(params, "dst_file") or self._param(params, "source") or self._param(params, "local_path")
+        if candidate:
+            return Path(str(candidate)).name
+        project_name = self._param(params, "project_name")
+        if project_name:
+            return Path(str(project_name)).name
+        return source_path.name if source_path else ""
+
+    def _status_response(self, result):
+        if isinstance(result, bool):
+            result = 0 if result else (self._last_code or BAMBU_NETWORK_ERR_INVALID_HANDLE)
+        if result == 0:
+            return json.dumps({"status": "ok"})
+        status = "cancelled" if result == BAMBU_NETWORK_ERR_CANCELED else "error"
+        return json.dumps({
+            "status": status,
+            "code": result,
+            "message": self._last_error or "operation failed",
+        })
+
+    @staticmethod
+    def _looks_like_bambu_payload(request) -> bool:
+        return isinstance(request, dict) and any(key in request for key in ("print", "system", "pushing", "info", "upgrade", "xcam", "camera"))
+
+    @staticmethod
+    def _disconnect_reason(args) -> int:
+        if not args:
+            return 0
+        if len(args) >= 2:
+            return BBLPrinterAgentPlugin._mqtt_result_code(args[1])
+        return BBLPrinterAgentPlugin._mqtt_result_code(args[0])
+
+    @staticmethod
+    def _ams_type_name(unit) -> str:
+        ams_type = str(unit.get("ams_type", unit.get("type", "ams"))).lower()
+        if ams_type in {"2", "ams_lite", "ams-lite"}:
+            return "ams_lite"
+        if ams_type in {"3", "n3f"}:
+            return "n3f"
+        if ams_type in {"4", "n3s"}:
+            return "n3s"
+        return "ams"
+
+    @staticmethod
+    def _normalize_color(value) -> str:
+        color = str(value or "").strip().lstrip("#")
+        if not color:
+            return "00000000"
+        if len(color) == 6:
+            color += "FF"
+        return color.upper()
+
+    @staticmethod
+    def _param(params, key, default=None):
+        if isinstance(params, dict):
+            return params.get(key, default)
+        return getattr(params, key, default)
+
+    def _next_sequence_id(self):
+        with self._mqtt_lock:
+            self._sequence_id += 1
+            return self._sequence_id
+
+    @staticmethod
+    def _update_progress(update_fn, stage, code, info):
+        if not update_fn:
+            return
+        try:
+            update_fn(stage, code, info)
+        except Exception as exc:
+            _log(f"progress callback failed: {exc}")
+
+    @staticmethod
+    def _cancel_requested(cancel_fn) -> bool:
+        if not cancel_fn:
+            return False
+        try:
+            return bool(cancel_fn())
+        except Exception as exc:
+            _log(f"cancel callback failed: {exc}")
+            return False
+
+    @staticmethod
+    def _json_or_default(value, default):
+        if value in (None, ""):
+            return default
+        if isinstance(value, str):
+            try:
+                return json.loads(value)
+            except json.JSONDecodeError:
+                return default
+        return value
+
+    @staticmethod
+    def _int_or_default(value, default):
+        result = BBLPrinterAgentPlugin._int_or_none(value)
+        return default if result is None else result
+
+    @staticmethod
+    def _int_or_none(value):
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _float_or_default(value, default):
+        result = BBLPrinterAgentPlugin._float_or_none(value)
+        return default if result is None else result
+
+    @staticmethod
+    def _float_or_none(value):
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _mqtt_result_code(rc) -> int:
+        try:
+            return int(rc)
+        except (TypeError, ValueError):
+            value = getattr(rc, "value", None)
+            return int(value) if value is not None else -1
+
+    @staticmethod
+    def _as_bool(value) -> bool:
+        if isinstance(value, str):
+            return value.strip().lower() in {"1", "true", "yes", "on"}
+        return bool(value)
+
+
+@orca.plugin
+class BBLPrinterAgentPackage(orca.base):
+    def register_capabilities(self):
+        orca.register_capability(BBLPrinterAgentPlugin)

--- a/resources/web/dialog/PluginsDialog/index.js
+++ b/resources/web/dialog/PluginsDialog/index.js
@@ -463,7 +463,7 @@ function CapabilityCanRun(plugin, capability) {
 }
 
 function IsPluginChecked(plugin) {
-  return GetStatus(plugin) === "Activated";
+  return plugin.is_loaded;
 }
 
 function HasMixedCapabilityState(plugin) {

--- a/resources/web/dialog/PluginsDialog/index.js
+++ b/resources/web/dialog/PluginsDialog/index.js
@@ -929,6 +929,8 @@ function StatusDescription(plugin) {
       return "This plugin is still loading.";
     case "Error":
       return "This plugin is blocked until its error is fixed.";
+    case "RuntimeError":
+      return "This plugin is loaded but a capability reported an error.";
     case "Inactive":
     default:
       return "This plugin is inactive. Activate it to install or load it.";

--- a/resources/web/dialog/PluginsDialog/styles.css
+++ b/resources/web/dialog/PluginsDialog/styles.css
@@ -374,6 +374,11 @@ body {
   font-weight: 600;
 }
 
+.status-cell.status-runtimeerror {
+  color: var(--plugin-status-warn);
+  font-weight: 600;
+}
+
 .status-cell.status-loading {
   color: var(--plugin-status-warn);
   font-weight: 600;
@@ -624,6 +629,11 @@ body {
 .detail-status-chip.status-error {
   background: var(--plugin-status-danger-bg);
   color: var(--plugin-status-danger);
+}
+
+.detail-status-chip.status-runtimeerror {
+  background: var(--plugin-status-warn-bg);
+  color: var(--plugin-status-warn);
 }
 
 .detail-status-chip.status-loading {

--- a/src/libslic3r/AppConfig.cpp
+++ b/src/libslic3r/AppConfig.cpp
@@ -607,6 +607,12 @@ void AppConfig::set_defaults()
         set_bool("window_buttons_on_left", false);
 #endif
 
+    if (get("use_printer_agents").empty())
+    {
+        // false = legacy behavior using print hosts
+        set_bool("use_printer_agents", false);
+    }
+
     // Remove legacy window positions/sizes
     erase("app", "main_frame_maximized");
     erase("app", "main_frame_pos");

--- a/src/libslic3r/Config.hpp
+++ b/src/libslic3r/Config.hpp
@@ -2256,6 +2256,8 @@ public:
         // Vector value, but edited as a single string.
         one_string,
         plugin_picker,
+        // PrinterAgentChoice
+        printer_agent_select,
     };
 
 	// Identifier of this option. It is stored here so that it is accessible through the by_serialization_key_ordinal map.

--- a/src/slic3r/GUI/DeviceCore/DevManager.cpp
+++ b/src/slic3r/GUI/DeviceCore/DevManager.cpp
@@ -477,6 +477,26 @@ namespace Slic3r
         OnSelectedMachineChanged(previous_selected_machine, selected_machine);
     }
 
+    void DeviceManager::clear_other_devices()
+    {
+        // why: on agent swap, keep "My Devices" but drop the transient "Other Devices"
+        // Those belong to the previous agent's network scan; the new agent's start_discovery re-populates its own.
+        const auto my = get_my_machine_list();
+        for (auto it = localMachineList.begin(); it != localMachineList.end();)
+        {
+            if (my.find(it->first) == my.end())
+            {
+                // not a "My Device" -> an "Other Device"
+                delete it->second;
+                it = localMachineList.erase(it);
+            }
+            else
+            {
+                ++it;
+            }
+        }
+    }
+
     bool DeviceManager::set_selected_machine(std::string dev_id)
     {
         BOOST_LOG_TRIVIAL(info) << "set_selected_machine=" << dev_id
@@ -843,15 +863,13 @@ namespace Slic3r
         if (all_machines.empty())
             return;
         
-        // Then connect to the machine we last selected if available
+        // Reconnect the machine the user last selected, if it's still available.
+        // why: no first-available fallback - auto-connecting an arbitrary machine
+        // fights the agent-swap reset, which intentionally leaves nothing selected.
         const std::string last_monitor_machine = m_agent ? m_agent->get_user_selected_machine() : "";
-        const auto        last_machine         = all_machines.find(last_monitor_machine);
-        if (last_machine != all_machines.end()) {
+        const auto        last_machine = all_machines.find(last_monitor_machine);
+        if (last_machine != all_machines.end())
             this->set_selected_machine(last_machine->second->get_dev_id());
-        } else {
-            // If not, then select the first available one
-            this->set_selected_machine(all_machines.begin()->second->get_dev_id());
-        }
     }
 
     void DeviceManager::OnMachineBindStateChanged(MachineObject* obj, const std::string& new_state)

--- a/src/slic3r/GUI/DeviceCore/DevManager.cpp
+++ b/src/slic3r/GUI/DeviceCore/DevManager.cpp
@@ -830,7 +830,9 @@ namespace Slic3r
         int result = m_agent->get_user_print_info(&http_code, &body, provider);
         if (result == 0)
         {
-            parse_user_print_info(body);
+            // parse_user_print_info and on_machine_alive (SSDP for discovery) both mutate the same userMachineList map.
+            // on_machine_alive mutates the map on the UI thread, do the same for parse_user_print_info.
+            Slic3r::GUI::wxGetApp().CallAfter([this, body]() { parse_user_print_info(body); });
         }
     }
 

--- a/src/slic3r/GUI/DeviceCore/DevManager.h
+++ b/src/slic3r/GUI/DeviceCore/DevManager.h
@@ -48,6 +48,10 @@ public:
     MachineObject* get_selected_machine();
     bool set_selected_machine(std::string dev_id);
 
+    // why: clears stale sidebar sync-status / AMS visuals. Public so the printer-agent
+    // swap path can reuse it instead of duplicating the two sidebar calls.
+    void OnSelectedMachineLost();
+
     // local machine
     void           set_local_selected_machine(std::string dev_id) { local_selected_machine = dev_id; };
     MachineObject* get_local_selected_machine() const { return get_local_machine(local_selected_machine); }
@@ -66,6 +70,8 @@ public:
     std::string get_first_online_user_machine() const;
     void erase_user_machine(std::string dev_id) { userMachineList.erase(dev_id); }
     void clean_user_info(bool keep_local_selection = false);
+
+    void clear_other_devices();
 
     void load_last_machine();
     void update_user_machine_list_info(const std::string& provider);
@@ -100,7 +106,6 @@ private:
     void check_pushing();
 
     void OnMachineBindStateChanged(MachineObject* obj, const std::string& new_state);
-    void OnSelectedMachineLost();
     void OnSelectedMachineChanged(const std::string& pre_dev_id, const std::string& new_dev_id);
 
 

--- a/src/slic3r/GUI/Field.cpp
+++ b/src/slic3r/GUI/Field.cpp
@@ -33,6 +33,7 @@
 #include "Widgets/TextCtrl.h"
 
 #include "../Utils/ColorSpaceConvert.hpp"
+#include "../Utils/NetworkAgentFactory.hpp"
 #ifdef __WXOSX__
 #define wxOSX true
 #else
@@ -1329,39 +1330,6 @@ using choice_ctrl = ::ComboBox; // BBS
 
 static std::map<std::string, DynamicList*> dynamic_lists;
 
-static bool is_plugin_printer_agent_key(const std::string& value)
-{
-    return value.rfind("plugin:", 0) == 0;
-}
-
-static int printer_agent_item_for_enum_index(const choice_ctrl* field, int enum_index)
-{
-    if (!field)
-        return -1;
-
-    const unsigned int count = field->GetCount();
-    for (unsigned int idx = 0; idx < count; ++idx) {
-        if (void* data = field->GetClientData(idx)) {
-            const int stored = static_cast<int>(reinterpret_cast<uintptr_t>(data)) - 1;
-            if (stored == enum_index)
-                return static_cast<int>(idx);
-        }
-    }
-
-    return -1;
-}
-
-static int printer_agent_enum_index_for_item(const choice_ctrl* field, int item_index, int fallback)
-{
-    if (!field || item_index < 0)
-        return fallback;
-
-    if (void* data = field->GetClientData(item_index))
-        return static_cast<int>(reinterpret_cast<uintptr_t>(data)) - 1;
-
-    return fallback;
-}
-
 void Choice::register_dynamic_list(std::string const &optname, DynamicList *list) { dynamic_lists.emplace(optname, list); }
 
 void DynamicList::update()
@@ -1444,33 +1412,7 @@ void Choice::BUILD()
 	window = dynamic_cast<wxWindow*>(temp);
 
 	if (! m_opt.enum_labels.empty() || ! m_opt.enum_values.empty()) {
-	    if (m_opt_id == "printer_agent") {
-	        const bool has_builtin_agents = std::any_of(m_opt.enum_values.begin(), m_opt.enum_values.end(),
-	            [](const std::string& value) { return !is_plugin_printer_agent_key(value); });
-	        const bool has_plugin_agents = std::any_of(m_opt.enum_values.begin(), m_opt.enum_values.end(),
-	            [](const std::string& value) { return is_plugin_printer_agent_key(value); });
-
-	        auto append_agent_rows = [this, temp](bool plugins) {
-	            for (size_t i = 0; i < m_opt.enum_values.size(); ++i) {
-	                const bool is_plugin = is_plugin_printer_agent_key(m_opt.enum_values[i]);
-	                if (is_plugin != plugins)
-	                    continue;
-
-	                const wxString label = i < m_opt.enum_labels.size() ? _(m_opt.enum_labels[i]) : wxString(m_opt.enum_values[i]);
-	                const int item = temp->Append(label);
-	                temp->SetClientData(item, reinterpret_cast<void*>(static_cast<uintptr_t>(i + 1)));
-	            }
-	        };
-
-	        if (has_builtin_agents) {
-	            temp->Append(_L("System agents"), wxNullBitmap, DD_ITEM_STYLE_SPLIT_ITEM | DD_ITEM_STYLE_DISABLED);
-	            append_agent_rows(false);
-	        }
-	        if (has_plugin_agents) {
-	            temp->Append(_L("Plugins"), wxNullBitmap, DD_ITEM_STYLE_SPLIT_ITEM | DD_ITEM_STYLE_DISABLED);
-	            append_agent_rows(true);
-	        }
-	    } else if (m_opt.enum_labels.empty()) {
+	    if (m_opt.enum_labels.empty()) {
 			// Append non-localized enum_values
 			for (auto el : m_opt.enum_values)
 				temp->Append(el);
@@ -1577,7 +1519,7 @@ void Choice::set_selection()
 	switch (m_opt.type) {
 	case coEnum:{
         const int val = m_opt.default_value->getInt();
-        field->SetSelection(m_opt_id == "printer_agent" ? printer_agent_item_for_enum_index(field, val) : val);
+        field->SetSelection(val);
 		break;
 	}
 	case coFloat:
@@ -1627,12 +1569,7 @@ void Choice::set_value(const std::string& value, bool change_event)  //! Redunda
 	}
 
 	choice_ctrl* field = dynamic_cast<choice_ctrl*>(window);
-	if (m_opt_id == "printer_agent") {
-		const int enum_index = idx == m_opt.enum_values.size() ?
-			(m_opt.default_value ? m_opt.default_value->getInt() : 0) :
-			static_cast<int>(idx);
-		field->SetSelection(printer_agent_item_for_enum_index(field, enum_index));
-	} else if (idx == m_opt.enum_values.size())
+	if (idx == m_opt.enum_values.size())
 		field->SetValue(value);
 	else
 		field->SetSelection(idx);
@@ -1698,33 +1635,11 @@ void Choice::set_value(const boost::any& value, bool change_event)
 	case coEnum:
     // BBS
 	case coEnums: {
-	    auto printer_agent_index_from_key = [this](const std::string& key) {
-	        auto it = std::find(m_opt.enum_values.begin(), m_opt.enum_values.end(), key);
-	        if (it != m_opt.enum_values.end())
-	            return static_cast<int>(it - m_opt.enum_values.begin());
-	        return m_opt.default_value ? m_opt.default_value->getInt() : 0;
-	    };
-
-	    int val = 0;
-	    if (m_opt_id == "printer_agent") {
-	        if (const int* int_value = boost::any_cast<int>(&value))
-	            val = *int_value;
-	        else if (const wxString* wx_value = boost::any_cast<wxString>(&value))
-	            val = printer_agent_index_from_key(into_u8(*wx_value));
-	        else if (const std::string* string_value = boost::any_cast<std::string>(&value))
-	            val = printer_agent_index_from_key(*string_value);
-	        else {
-	            m_disable_change_event = false;
-	            return;
-	        }
-	    } else
-	        val = boost::any_cast<int>(value);
+	    int val = boost::any_cast<int>(value);
 
 	    int selection = val;
 
-	    if (m_opt_id == "printer_agent") {
-	        selection = printer_agent_item_for_enum_index(field, val);
-	    } else if (m_opt_id == "input_shaping_type") {
+	    if (m_opt_id == "input_shaping_type") {
 	        if (field != nullptr) {
 	            const unsigned int count = field->GetCount();
 	            int match_index = -1;
@@ -1846,12 +1761,6 @@ boost::any& Choice::get_value()
     {
         if (m_opt.nullable && field->GetSelection() == -1)
             m_value = ConfigOptionEnumsGenericNullable::nil_value();
-        else if (m_opt_id == "printer_agent")
-        {
-            const int selection = field->GetSelection();
-            const int fallback = m_opt.default_value ? m_opt.default_value->getInt() : 0;
-            m_value = printer_agent_enum_index_for_item(field, selection, fallback);
-        }
         else if (m_opt_id == "input_shaping_type")
         {
             int selection = field->GetSelection();
@@ -1992,6 +1901,171 @@ void Choice::msw_rescale()
 #endif
 }
 
+
+// PrinterAgentChoice
+
+void PrinterAgentChoice::reload_rows()
+{
+    auto* combo = dynamic_cast<choice_ctrl*>(window); // wxWidgets ComboBox
+    if (!combo)
+        return;
+
+    // clear ComboBox
+    combo->Clear();
+
+    // helpers
+    const auto agents = NetworkAgentFactory::get_registered_printer_agents();
+    const bool has_builtin_agents = std::any_of(agents.begin(), agents.end(),
+                                                [](const PrinterAgentInfo& a) { return !a.is_plugin(); });
+    const bool has_plugin_agents = std::any_of(agents.begin(), agents.end(),
+                                               [](const PrinterAgentInfo& a) { return a.is_plugin(); });
+
+    auto append_agent_rows = [combo](bool is_plugin)
+    {
+        const auto agents = NetworkAgentFactory::get_registered_printer_agents();
+        for (size_t i = 0; i < agents.size(); ++i)
+        {
+            if (agents[i].is_plugin() != is_plugin)
+                continue;
+            const int item = combo->Append(_(agents[i].display_name));
+            // why: carry the agent-id string on the row. alias is an owned wxString (auto-freed, never rendered)
+            combo->SetItemAlias(item, from_u8(agents[i].id));
+        }
+    };
+
+    // append rows
+    if (has_builtin_agents)
+    {
+        combo->Append(_L("System agents"), wxNullBitmap, DD_ITEM_STYLE_SPLIT_ITEM | DD_ITEM_STYLE_DISABLED);
+        append_agent_rows(false); // append rows for agents that are not plugins
+    }
+    if (has_plugin_agents)
+    {
+        combo->Append(_L("Plugins"), wxNullBitmap, DD_ITEM_STYLE_SPLIT_ITEM | DD_ITEM_STYLE_DISABLED);
+        append_agent_rows(true); // append rows for agents that are plugins
+    }
+}
+
+void PrinterAgentChoice::BUILD()
+{
+    wxSize size(def_width_wider() * m_em_unit, wxDefaultCoord);
+    if (m_opt.height >= 0) size.SetHeight(m_opt.height * m_em_unit);
+    if (m_opt.width >= 0) size.SetWidth(m_opt.width * m_em_unit);
+
+    static Builder<choice_ctrl> builder;
+    choice_ctrl* temp = builder.build(m_parent, wxID_ANY, wxString(""), wxDefaultPosition, size, 0, nullptr,
+                                      wxCB_READONLY);
+    temp->Clear();
+    temp->GetDropDown().SetUseContentWidth(true);
+    if (parent_is_custom_ctrl && m_opt.height < 0)
+        opt_height = (double)temp->GetTextCtrl()->GetSize().GetHeight() / m_em_unit;
+    temp->SetTextLabel(_L(m_opt.sidetext));
+    m_combine_side_text = true;
+#ifdef __WXGTK3__
+    wxSize best_sz = temp->GetBestSize();
+    if (best_sz.x > size.x) temp->SetSize(best_sz);
+#endif
+    if (!wxOSX) temp->SetBackgroundStyle(wxBG_STYLE_PAINT);
+
+    window = dynamic_cast<wxWindow*>(temp);
+
+    reload_rows();
+
+    temp->Bind(wxEVT_COMBOBOX, [this](wxCommandEvent&) { on_change_field(); }, temp->GetId());
+    temp->SetToolTip(get_tooltip_text(temp->GetValue()));
+}
+
+// Resolve CONFIG id string to a matching row in the live REGISTRY. "" uses the vendor default.
+// An unregistered id clears selection and shows "<id> (missing)" as free text.
+void PrinterAgentChoice::set_value(const std::string& value, bool change_event)
+{
+    m_disable_change_event = !change_event;
+
+    auto* field = dynamic_cast<choice_ctrl*>(window);
+
+    // check if any row's corresponding id matches the agent id we are attempting to set
+    const std::string effective_agent_id = wxGetApp().resolve_printer_agent_id(value);
+    const unsigned int count = field->GetCount();
+    int match = wxNOT_FOUND;
+    for (unsigned int i = 0; i < count; ++i)
+    {
+        if (into_u8(field->GetItemAlias(i)) == effective_agent_id) // if alias == id
+        {
+            match = static_cast<int>(i);
+            break;
+        }
+    }
+
+    // based on match or not, set selection and value
+    // - SetSelection and SetValue are UI to manipulate the display of the ComboBox
+    // - SetSelection automatically calls SetValue for the same value
+    // - we can also SetValue separately from SetSelection
+    if (match == wxNOT_FOUND)
+    {
+        field->SetSelection(wxNOT_FOUND); // nothing shows as selected in the dropdown
+        field->SetValue(from_u8(value + " (missing)")); // set a value not in the selection (upper display field)
+    }
+    else
+    {
+        // display name of agent shows both in upper display field and appears selected in dropdown
+        field->SetSelection(match);
+    }
+
+    m_disable_change_event = false;
+}
+
+// Accept boost::any values from callers (usually to OptionsGroup/Field parent classes) and normalize them to an agent id.
+// Then use PrinterAgentChoice::set_value(std::string& value, ...)
+void PrinterAgentChoice::set_value(const boost::any& value, bool change_event)
+{
+    m_disable_change_event = !change_event;
+
+    auto* field = dynamic_cast<choice_ctrl*>(window);
+    if (value.empty())
+    {
+        field->SetValue("");
+        m_value = value;
+        m_disable_change_event = false;
+        return;
+    }
+
+    std::string id;
+    if (const std::string* s = boost::any_cast<std::string>(&value))
+        id = *s;
+    else if (const wxString* w = boost::any_cast<wxString>(&value))
+        id = into_u8(*w);
+    set_value(id, change_event);
+}
+
+// A real row returns its alias, which is the agent id. Header rows, missing rows,
+// and no selection return empty boost::any so the custom writer leaves config unchanged.
+boost::any& PrinterAgentChoice::get_value()
+{
+    auto* field = dynamic_cast<choice_ctrl*>(window);
+    const int sel = field->GetSelection();
+    const std::string id = sel < 0 ? std::string{} : into_u8(field->GetItemAlias(sel));
+    if (id.empty())
+        m_value = boost::any{};
+    else
+        m_value = id;
+    return m_value;
+}
+
+void PrinterAgentChoice::enable() { dynamic_cast<choice_ctrl*>(window)->Enable(); }
+void PrinterAgentChoice::disable() { dynamic_cast<choice_ctrl*>(window)->Disable(); }
+
+void PrinterAgentChoice::msw_rescale()
+{
+    Field::msw_rescale();
+
+    auto* field = dynamic_cast<choice_ctrl*>(window)->GetTextCtrl();
+    wxSize size(wxDefaultSize);
+    size.SetWidth((m_opt.width > 0 ? m_opt.width : def_width_wider()) * m_em_unit);
+    field->SetMinSize(wxSize(-1, int(1.5f * field->GetFont().GetPixelSize().y + 0.5f)));
+    field->SetSize(size);
+
+    dynamic_cast<choice_ctrl*>(window)->Rescale();
+}
 
 void PluginField::BUILD()
 {

--- a/src/slic3r/GUI/Field.hpp
+++ b/src/slic3r/GUI/Field.hpp
@@ -466,6 +466,44 @@ public:
     void            suppress_scroll();
 };
 
+// printer_agent is a coString whose choices come from the live agent registry.
+// PrinterAgentChoice uses a ComboBox directly because Choice expects static config enums.
+// Real rows carry the stored agent id in the row alias (SetItemAlias/GetItemAlias).
+class PrinterAgentChoice : public Field
+{
+	using Field::Field;
+
+public:
+	PrinterAgentChoice(const ConfigOptionDef& opt, const t_config_option_key& id) : Field(opt, id)
+	{
+	}
+
+	PrinterAgentChoice(wxWindow* parent, const ConfigOptionDef& opt, const t_config_option_key& id) : Field(
+		parent, opt, id)
+	{
+	}
+
+	~PrinterAgentChoice()
+	{
+	}
+
+	wxWindow* window{nullptr};
+
+	void BUILD() override;
+	// Clear and repopulate rows from the live registry (grouped System agents / Plugins).
+	// Does not change selection; the caller follows with set_value(stored id).
+	void reload_rows();
+
+	void set_value(const std::string& value, bool change_event = false);
+	void set_value(const boost::any& value, bool change_event = false) override;
+	boost::any& get_value() override;
+
+	void enable() override;
+	void disable() override;
+	void msw_rescale() override;
+	wxWindow* getWindow() override { return window; }
+};
+
 class PluginField : public Field {
     using Field::Field;
 public:

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -3710,6 +3710,18 @@ unsigned GUI_App::get_colour_approx_luma(const wxColour &colour)
         ));
 }
 
+std::string GUI_App::resolve_printer_agent_id(const std::string& stored_id)
+{
+    if (!stored_id.empty())
+        return stored_id;
+    return (preset_bundle && preset_bundle->is_bbl_vendor()) ? BBL_PRINTER_AGENT_ID : ORCA_PRINTER_AGENT_ID;
+}
+
+std::string GUI_App::canonical_printer_agent_id(const std::string& picked_id)
+{
+    return picked_id == resolve_printer_agent_id("") ? std::string() : picked_id;
+}
+
 void GUI_App::switch_printer_agent()
 {
     if (!m_agent) {
@@ -3717,17 +3729,8 @@ void GUI_App::switch_printer_agent()
         return;
     }
 
-    // Read printer_agent from config, falling back to default
-    std::string effective_agent_id = ORCA_PRINTER_AGENT_ID;
-    if (preset_bundle->is_bbl_vendor())
-        effective_agent_id = BBL_PRINTER_AGENT_ID;
-
     const DynamicPrintConfig& config = preset_bundle->printers.get_edited_preset().config;
-    if (config.has("printer_agent")) {
-        const std::string& value = config.option<ConfigOptionString>("printer_agent")->value;
-        if (!value.empty())
-            effective_agent_id = value;
-    }
+    const std::string effective_agent_id = resolve_printer_agent_id(config.opt_string("printer_agent"));
 
     // Check if agent is registered
     const PrinterAgentInfo* agent_info_ptr = NetworkAgentFactory::get_printer_agent_info(effective_agent_id);

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -2728,16 +2728,58 @@ void GUI_App::init_plugin_gui_wiring()
         });
     };
 
+    // why: a newly loaded plugin only adds a selectable agent
+    // refresh the dropdown and leave the live agent alone
+    auto refresh_printer_agent_dropdown_after_load = [](const std::string&)
+    {
+        if (!wxTheApp)
+            return;
+
+        GUI_App* app = &GUI::wxGetApp();
+        if (app->is_closing())
+            return;
+
+        app->CallAfter([app]
+        {
+            if (!app->is_closing())
+                app->refresh_printer_agent_dropdown();
+        });
+    };
+
+    // why: the unloaded plugin may have been the provider of the live agent
+    // re-run selection, where a now-missing agent will be cleared
+    // refresh dropdown after
+    auto switch_printer_agent_after_unload = [](const std::string&)
+    {
+        if (!wxTheApp)
+            return;
+
+        GUI_App* app = &GUI::wxGetApp();
+        if (app->is_closing())
+            return;
+
+        app->CallAfter([app] {
+            if (app->is_closing())
+                return;
+
+            app->switch_printer_agent();
+            app->refresh_printer_agent_dropdown();
+        });
+    };
+
     plugin_mgr.subscribe_on_unload_callback(PluginHostUi::close_windows_for_plugin);
     plugin_mgr.subscribe_on_load_callback([refresh_plugins_dialog](const std::string&) { refresh_plugins_dialog(); });
     plugin_mgr.subscribe_on_unload_callback([refresh_plugins_dialog](const std::string&) { refresh_plugins_dialog(); });
     plugin_mgr.subscribe_on_load_callback(NetworkAgentFactory::register_python_plugin);
     plugin_mgr.subscribe_on_unload_callback(NetworkAgentFactory::deregister_python_plugin);
+    plugin_mgr.subscribe_on_load_callback(refresh_printer_agent_dropdown_after_load);
+    plugin_mgr.subscribe_on_unload_callback(switch_printer_agent_after_unload);
     plugin_mgr.subscribe_on_capability_load_callback(
-        [refresh_plugins_dialog](const PluginCapabilityId& capability) {
+        [refresh_plugins_dialog, refresh_printer_agent_dropdown_after_load](const PluginCapabilityId& capability) {
             if (capability.type == PluginCapabilityType::PrinterConnection)
                 NetworkAgentFactory::register_python_printer_agent(capability.plugin_key, capability.name);
             refresh_plugins_dialog();
+            refresh_printer_agent_dropdown_after_load(capability.plugin_key);
             // A newly loaded capability may satisfy a missing-plugin notification; re-validate the
             // current plate (on the UI thread) so the notification clears once its plugin is available.
             if (wxTheApp && !wxGetApp().is_closing())
@@ -2747,10 +2789,11 @@ void GUI_App::init_plugin_gui_wiring()
                 });
         });
     plugin_mgr.subscribe_on_capability_unload_callback(
-        [refresh_plugins_dialog](const PluginCapabilityId& capability) {
+        [refresh_plugins_dialog, switch_printer_agent_after_unload](const PluginCapabilityId& capability) {
             if (capability.type == PluginCapabilityType::PrinterConnection)
                 NetworkAgentFactory::deregister_python_printer_agent(capability.plugin_key, capability.name);
             refresh_plugins_dialog();
+            switch_printer_agent_after_unload(capability.plugin_key);
         });
 }
 
@@ -3710,6 +3753,36 @@ unsigned GUI_App::get_colour_approx_luma(const wxColour &colour)
         ));
 }
 
+void GUI_App::refresh_printer_agent_dropdown()
+{
+    if (Tab* tab = get_tab(Preset::TYPE_PRINTER))
+    {
+        if (auto* printer_tab = dynamic_cast<TabPrinter*>(tab))
+            printer_tab->refresh_printer_agent_dropdown();
+    }
+}
+
+void GUI_App::set_live_printer_agent(std::shared_ptr<IPrinterAgent> agent)
+{
+    if (!m_agent)
+        return;
+
+    // why: tearing down the old machine selection is only ever the prefix of setting the live
+    // agent (to a new one, or to null when the selection is missing) - so it lives here, not as
+    // a standalone helper. Pass nullptr to clear the selection.
+    if (DeviceManager* dev = getDeviceManager())
+    {
+        dev->set_selected_machine(""); // why: empty id disconnects and deselects the current machine
+        m_agent->set_user_selected_machine("");
+        // note: belt-and-suspenders (precedent: DeviceManagerRefresher::on_timer)
+        dev->OnSelectedMachineLost(); // why: clear stale sidebar sync-status / AMS
+        dev->clear_other_devices(); // why: drop stale LAN discoveries; keep My Devices
+    }
+
+    m_agent->set_printer_agent(agent);
+    sidebar().update_all_preset_comboboxes();
+}
+
 std::string GUI_App::resolve_printer_agent_id(const std::string& stored_id)
 {
     if (!stored_id.empty())
@@ -3735,9 +3808,11 @@ void GUI_App::switch_printer_agent()
     // Check if agent is registered
     const PrinterAgentInfo* agent_info_ptr = NetworkAgentFactory::get_printer_agent_info(effective_agent_id);
     if (!agent_info_ptr) {
-        BOOST_LOG_TRIVIAL(warning) << __FUNCTION__ << ": unregistered agent ID '" << effective_agent_id
-                                   << "', keeping current agent";
-        // Keep current agent, don't switch
+        // why: the selected agent's provider is gone (e.g. plugin unloaded); leaving the old
+        // live agent up would keep talking to a machine the user can no longer select.
+        BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << ": agent ID '" << effective_agent_id
+                                << "' is unregistered; clearing live printer agent";
+        set_live_printer_agent(nullptr);
         return;
     }
     const PrinterAgentInfo agent_info = *agent_info_ptr;
@@ -3751,7 +3826,9 @@ void GUI_App::switch_printer_agent()
         NetworkAgentFactory::create_printer_agent_by_id(effective_agent_id, cloud_agent, log_dir);
 
     if (!new_printer_agent) {
-        BOOST_LOG_TRIVIAL(warning) << __FUNCTION__ << ": failed to create agent '" << effective_agent_id << "', keeping current agent";
+        BOOST_LOG_TRIVIAL(warning) << __FUNCTION__ << ": failed to create agent '" << effective_agent_id
+                                   << "'; clearing live printer agent";
+        set_live_printer_agent(nullptr);
         return;
     }
 
@@ -3774,9 +3851,9 @@ void GUI_App::switch_printer_agent()
         return;
     }
 
-    // Swap the agent
-    m_agent->set_printer_agent(new_printer_agent);
-    sidebar().update_all_preset_comboboxes();
+    // Swap the agent; set_live_printer_agent resets the device selection so the new
+    // agent starts clean (#124).
+    set_live_printer_agent(new_printer_agent);
 
     BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << ": printer agent switched to " << effective_agent_id;
 

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -2079,7 +2079,12 @@ void GUI_App::init_networking_callbacks()
                     obj->is_tunnel_mqtt = tunnel;
                     obj->command_request_push_all(true);
                     obj->command_get_version();
-                    obj->erase_user_access_code();
+                    // Do NOT erase user code. Erasing will cause has_access_right to be false
+                    // whenever the device slot isn't populated yet (e.g. LAN reselect after logout).
+                    // This filters this printer out of get_my_machine_list, silently dropping every status message
+                    // AND the get_access_code reply that would refill the code, leaving a permanently
+                    // dead "connected but no live data" state.
+                    // obj -> set_user_access_code("");
                     obj->command_get_access_code();
                     if (m_agent)
                         m_agent->install_device_cert(obj->get_dev_id(), obj->is_lan_mode_printer());

--- a/src/slic3r/GUI/GUI_App.hpp
+++ b/src/slic3r/GUI/GUI_App.hpp
@@ -362,8 +362,13 @@ public:
     HMSQuery* get_hms_query() { return hms_query; }
     NetworkAgent* getAgent() { return m_agent; }
 
-    // Dynamic printer agent switching
+    // Reconcile the live printer agent with the stored preset selection.
     void switch_printer_agent();
+
+    std::string resolve_printer_agent_id(const std::string& stored_id);
+    // ORCA TODO: in the future, bbl presets should specify "bbl" printer agent id
+    // then, all resolve and canonical would just be ORCA<->""
+    std::string canonical_printer_agent_id(const std::string& picked_id);
 
     FilamentColorCodeQuery* get_filament_color_code_query();
     bool is_editor() const { return m_app_mode == EAppMode::Editor; }

--- a/src/slic3r/GUI/GUI_App.hpp
+++ b/src/slic3r/GUI/GUI_App.hpp
@@ -791,6 +791,11 @@ private:
     void            window_pos_center(wxTopLevelWindow *window);
     bool            select_language();
 
+    // Dynamic printer agent selection - internal helpers for switch_printer_agent
+    // and the plugin load/unload callbacks (init_plugin_gui_wiring).
+    void refresh_printer_agent_dropdown();
+    void set_live_printer_agent(std::shared_ptr<IPrinterAgent> agent); // null clears the selection
+
     bool            config_wizard_startup();
 	void            check_updates(const bool verbose);
 

--- a/src/slic3r/GUI/MainFrame.cpp
+++ b/src/slic3r/GUI/MainFrame.cpp
@@ -708,7 +708,7 @@ DPIFrame(NULL, wxID_ANY, "", wxDefaultPosition, wxDefaultSize, BORDERLESS_FRAME_
             m_print_enable = get_enable_print_status();
             m_print_btn->Enable(m_print_enable);
             if (m_print_enable) {
-                if (wxGetApp().preset_bundle->use_bbl_network())
+                if (wxGetApp().preset_bundle->use_bbl_network() || wxGetApp().app_config->get_bool("use_printer_agents"))
                     wxPostEvent(m_plater, SimpleEvent(EVT_GLTOOLBAR_PRINT_PLATE));
                 else
                     wxPostEvent(m_plater, SimpleEvent(EVT_GLTOOLBAR_SEND_GCODE));
@@ -1999,7 +1999,8 @@ wxBoxSizer* MainFrame::create_side_tools()
             SidePopup* p = new SidePopup(this);
 
             if (wxGetApp().preset_bundle
-                && !wxGetApp().preset_bundle->is_bbl_vendor()) {
+                && !wxGetApp().preset_bundle->is_bbl_vendor()
+                && !wxGetApp().app_config->get_bool("use_printer_agents")) {
                 // ThirdParty Buttons
                 SideButton* export_gcode_btn = new SideButton(p, _L("Export G-code file"), "");
                 export_gcode_btn->SetCornerRadius(0);
@@ -2132,7 +2133,7 @@ wxBoxSizer* MainFrame::create_side_tools()
 
                 const auto preset_bundle = wxGetApp().preset_bundle;
                 if (preset_bundle) {
-                    if (preset_bundle->use_bbl_network()) {
+                    if (preset_bundle->use_bbl_network() || wxGetApp().app_config->get_bool("use_printer_agents")) {
                         // BBL network support everything
                     } else {
                         support_send = false; // All 3rd print hosts do not have the send options
@@ -4253,7 +4254,7 @@ void MainFrame::load_printer_url(wxString url, wxString apikey)
 void MainFrame::load_printer_url()
 {
     PresetBundle &preset_bundle = *wxGetApp().preset_bundle;
-    if (preset_bundle.use_bbl_device_tab() || NetworkAgentFactory::is_current_printer_agent_plugin())
+    if (preset_bundle.use_bbl_device_tab() || wxGetApp().app_config->get_bool("use_printer_agents"))
         return;
 
     auto     cfg = preset_bundle.printers.get_edited_preset().config;

--- a/src/slic3r/GUI/OptionsGroup.cpp
+++ b/src/slic3r/GUI/OptionsGroup.cpp
@@ -53,6 +53,9 @@ const t_field& OptionsGroup::build_field(const t_config_option_key& id, const Co
         break;
     case ConfigOptionDef::GUIType::one_string: m_fields.emplace(id, TextCtrl::Create<TextCtrl>(this->ctrl_parent(), opt, id)); break;
     case ConfigOptionDef::GUIType::plugin_picker: m_fields.emplace(id, PluginField::Create<PluginField>(this->ctrl_parent(), opt, id)); break;
+    case ConfigOptionDef::GUIType::printer_agent_select: m_fields.emplace(
+            id, PrinterAgentChoice::Create<PrinterAgentChoice>(this->ctrl_parent(), opt, id));
+        break;
     default:
         switch (opt.type) {
             case coFloatOrPercent:
@@ -645,6 +648,16 @@ Option ConfigOptionsGroup::get_option(const std::string& opt_key, int opt_index 
 
 void ConfigOptionsGroup::on_change_OG(const t_config_option_key& opt_id, const boost::any& value)
 {
+    if (opt_id == "printer_agent") {
+        // TODO: Replace this option-specific branch with a generic value adapter if
+        // more fields need custom field-value to config-value conversion.
+        if (const std::string* id = boost::any_cast<std::string>(&value))
+            this->change_opt_value("printer_agent", wxGetApp().canonical_printer_agent_id(*id));
+
+        OptionsGroup::on_change_OG(opt_id, value);
+        return;
+    }
+
     if (!m_opt_map.empty()) {
         auto it = m_opt_map.find(opt_id);
         if (it == m_opt_map.end()) {
@@ -764,6 +777,19 @@ void ConfigOptionsGroup::back_to_config_value(const DynamicPrintConfig& config, 
         }
     }
 #endif
+    else if (opt_key == "printer_agent")
+    {
+        // why: printer_agent is a coString kept out of m_opt_map. The generic non-opt_map revert
+        // below restores the edited config from get_value(), but a deregistered/"(missing)" saved
+        // id has no selectable row, so the field yields no value and the edited config keeps the
+        // user's interim pick -> stuck dirty. Restore the SAVED id straight into the edited config
+        // (displayable or not; config is the saved or system baseline), then repaint and notify.
+        const std::string saved_id = config.opt_string("printer_agent");
+        set_value(opt_key, saved_id);
+        this->change_opt_value(opt_key, saved_id);
+        OptionsGroup::on_change_OG(opt_key, saved_id);
+        return;
+    }
     else if (m_opt_map.find(opt_key) == m_opt_map.end() ||
              // This option don't have corresponded field
              opt_key == "printable_area" || opt_key == "compatible_printers" || opt_key == "compatible_prints" || opt_key == "thumbnails" ||

--- a/src/slic3r/GUI/PhysicalPrinterDialog.cpp
+++ b/src/slic3r/GUI/PhysicalPrinterDialog.cpp
@@ -25,7 +25,6 @@
 #include "GUI.hpp"
 #include "GUI_App.hpp"
 #include "MainFrame.hpp"
-#include "slic3r/Utils/NetworkAgentFactory.hpp"
 #include "format.hpp"
 #include "Tab.hpp"
 #include "wxExtensions.hpp"
@@ -128,22 +127,8 @@ PhysicalPrinterDialog::~PhysicalPrinterDialog()
 void PhysicalPrinterDialog::build_printhost_settings(ConfigOptionsGroup* m_optgroup)
 {
     m_optgroup->m_on_change = [this](t_config_option_key opt_key, boost::any value) {
-        // Special handling for printer_agent: convert fake enum index to string agent ID
-        if (opt_key == "printer_agent") {
-            try {
-                int selected_idx = boost::any_cast<int>(value);
-                auto agents = NetworkAgentFactory::get_registered_printer_agents();
-                if (selected_idx >= 0 && selected_idx < static_cast<int>(agents.size())) {
-                    m_config->set_key_value("printer_agent",
-                                          new ConfigOptionString(agents[selected_idx].id));
-                }
-            } catch (const boost::bad_any_cast&) {
-                // If value is not an int, ignore
-            }
+        if (opt_key == "host_type" || opt_key == "printhost_authorization_type")
             this->update();
-        } else if (opt_key == "host_type" || opt_key == "printhost_authorization_type") {
-            this->update();
-        }
         if (opt_key == "print_host")
             this->update_printhost_buttons();
         if (opt_key == "printhost_port")
@@ -153,47 +138,6 @@ void PhysicalPrinterDialog::build_printhost_settings(ConfigOptionsGroup* m_optgr
     };
 
     m_optgroup->append_single_option_line("host_type");
-
-    // Build printer agent dropdown from registry (only if network agent is available)
-    if (wxGetApp().getAgent() != nullptr) {
-        auto agents = NetworkAgentFactory::get_registered_printer_agents();
-
-        if (!agents.empty()) {
-            // Create a fake enum option to force a Choice widget instead of TextCtrl
-            // (printer_agent is coString in config, but we need a dropdown)
-            ConfigOptionDef def;
-            def.type    = coEnum;
-            def.width   = Field::def_width_wider();
-            def.label   = L("Printer Agent");
-            def.tooltip = L("Select the network agent implementation for printer communication. "
-                            "Available agents are registered at startup.");
-            def.mode    = comAdvanced;
-
-            // Populate enum values and labels from registered agents
-            for (const auto& agent : agents) {
-                def.enum_values.push_back(agent.id);
-                def.enum_labels.push_back(agent.display_name);
-            }
-
-            // Resolve selected agent: use config value if valid, otherwise fall back to default
-            std::string selected_agent = m_config->opt_string("printer_agent");
-            auto it = std::find_if(agents.begin(), agents.end(), [&selected_agent](const auto& a) { return a.id == selected_agent; });
-            if (it == agents.end()) {
-                selected_agent = ORCA_PRINTER_AGENT_ID;
-                it = std::find_if(agents.begin(), agents.end(), [&selected_agent](const auto& a) { return a.id == selected_agent; });
-            }
-
-            if (it != agents.end()) {
-                size_t default_idx = std::distance(agents.begin(), it);
-                def.set_default_value(new ConfigOptionInt(static_cast<int>(default_idx)));
-            }
-
-            // Create and append the option line
-            auto agent_option = Option(def, "printer_agent");
-            Line agent_line   = m_optgroup->create_single_option_line(agent_option);
-            m_optgroup->append_line(agent_line);
-        }
-    }
 
     auto create_sizer_with_btn = [](wxWindow* parent, Button** btn, const std::string& icon_name, const wxString& label) {
         *btn = new Button(parent, label);
@@ -816,31 +760,6 @@ void PhysicalPrinterDialog::update_host_type(bool printer_change)
     }
 }
 
-void PhysicalPrinterDialog::update_printer_agent_type()
-{
-    if (m_config == nullptr)
-        return;
-
-    Field* agent_field = m_optgroup->get_field("printer_agent");
-    if (!agent_field)
-        return;
-
-    Choice* agent_choice = dynamic_cast<Choice*>(agent_field);
-    if (!agent_choice)
-        return;
-
-    // Sync selection with current config value
-    const std::string current_agent = m_config->opt_string("printer_agent");
-
-    auto agents = NetworkAgentFactory::get_registered_printer_agents();
-    for (size_t i = 0; i < agents.size(); ++i) {
-        if (agents[i].id == current_agent) {
-            agent_choice->set_value(i);
-            return;
-        }
-    }
-}
-
 void PhysicalPrinterDialog::update_printers()
 {
     wxBusyCursor wait;
@@ -894,11 +813,6 @@ void PhysicalPrinterDialog::OnOK(wxEvent& event)
 {
     wxGetApp().get_tab(Preset::TYPE_PRINTER)->save_preset("", false, false, true, m_preset_name);
     event.Skip();
-
-    // Defer printer agent switch to ensure preset save completes first
-    wxGetApp().CallAfter([] {
-        wxGetApp().switch_printer_agent();
-    });
 }
 
 }}    // namespace Slic3r::GUI

--- a/src/slic3r/GUI/PhysicalPrinterDialog.cpp
+++ b/src/slic3r/GUI/PhysicalPrinterDialog.cpp
@@ -669,7 +669,7 @@ void PhysicalPrinterDialog::update(bool printer_change)
                 }
 
                 // For bbl printers, show option to control the device tab
-                if (wxGetApp().preset_bundle->is_bbl_vendor()) {
+                if (wxGetApp().preset_bundle->is_bbl_vendor() || wxGetApp().app_config->get_bool("use_printer_agents")) {
                     m_optgroup->show_field("bbl_use_print_host_webui");
                     const bool use_print_host_webui = !current_webui.empty();
                     if (Field* printhost_webui_field = m_optgroup->get_field("bbl_use_print_host_webui"); printhost_webui_field) {

--- a/src/slic3r/GUI/PhysicalPrinterDialog.hpp
+++ b/src/slic3r/GUI/PhysicalPrinterDialog.hpp
@@ -60,7 +60,6 @@ public:
 
     void        update(bool printer_change = false);
     void        update_host_type(bool printer_change);
-    void        update_printer_agent_type();
     void        update_preset_input();
     void        update_printhost_buttons();
     void        update_printers();

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -3227,7 +3227,7 @@ void Sidebar::update_all_preset_comboboxes()
 
     auto p_mainframe = wxGetApp().mainframe;
     auto cfg = preset_bundle.printers.get_edited_preset().config;
-    const bool use_native_device_tab = preset_bundle.use_bbl_device_tab() || NetworkAgentFactory::is_current_printer_agent_plugin();
+    const bool use_native_device_tab = preset_bundle.use_bbl_device_tab() || wxGetApp().app_config->get_bool("use_printer_agents");
 
     if (preset_bundle.use_bbl_network()) {
         //only show connection button for not-BBL printer
@@ -3239,7 +3239,8 @@ void Sidebar::update_all_preset_comboboxes()
         p_mainframe->set_print_button_to_default(MainFrame::PrintSelectType::ePrintPlate);
     } else {
         //p->btn_connect_printer->Show();
-        p->m_printer_connect->Show();
+        // ORCA: hide the physical-printer connection button when printer agents are enabled
+        p->m_printer_connect->Show(!wxGetApp().app_config->get_bool("use_printer_agents"));
 
         // ORCA: show/hide sync-ams button based on filament sync mode
         auto agent = wxGetApp().getAgent();
@@ -3261,7 +3262,9 @@ void Sidebar::update_all_preset_comboboxes()
             const auto host_type = cfg.option<ConfigOptionEnum<PrintHostType>>("host_type")->value;
             if (cfg.has("printhost_apikey") && (host_type != htSimplyPrint))
                 apikey = cfg.opt_string("printhost_apikey");
-            print_btn_type = preset_bundle.is_bbl_vendor() ? MainFrame::PrintSelectType::ePrintPlate : MainFrame::PrintSelectType::eSendGcode;
+            print_btn_type = (preset_bundle.is_bbl_vendor() || wxGetApp().app_config->get_bool("use_printer_agents"))
+                                 ? MainFrame::PrintSelectType::ePrintPlate
+                                 : MainFrame::PrintSelectType::eSendGcode;
         }
 
         if (!use_native_device_tab)
@@ -3420,7 +3423,10 @@ void Sidebar::update_presets(Preset::Type preset_type)
 
         bool isBBL = preset_bundle.is_bbl_vendor();
         bool is_dual_extruder = extruder_variants->size() == 2;
-        p->layout_printer(preset_bundle.use_bbl_network(), isBBL && is_dual_extruder);
+        // why: agent mode drives the native device tab, so the sidebar lays out like BBL
+        // (no physical-printer connect button).
+        p->layout_printer(preset_bundle.use_bbl_network() || wxGetApp().app_config->get_bool("use_printer_agents"),
+                          isBBL && is_dual_extruder);
 
         // Update nozzle titles from printer config (e.g. "Main Nozzle" / "Auxiliary Nozzle" for N6)
         // UI left = DEPUTY_EXTRUDER_ID(1), UI right = MAIN_EXTRUDER_ID(0)
@@ -5602,6 +5608,7 @@ struct Plater::priv
     void on_action_slice_all(SimpleEvent&);
     void on_action_publish(wxCommandEvent &evt);
     void on_action_print_plate(SimpleEvent&);
+    void open_machine_select_dialog(int plate_idx, PrintFromType print_type = PrintFromType::FROM_NORMAL);
     void on_action_print_all(SimpleEvent&);
     void on_action_export_gcode(SimpleEvent&);
     void on_action_send_gcode(SimpleEvent&);
@@ -11139,16 +11146,21 @@ void Plater::priv::on_action_print_plate(SimpleEvent&)
     }
 
     PresetBundle& preset_bundle = *wxGetApp().preset_bundle;
-    if (preset_bundle.use_bbl_network()) {
-        // BBS
-        if (!m_select_machine_dlg)
-            m_select_machine_dlg = new SelectMachineDialog(q);
-        m_select_machine_dlg->set_print_type(PrintFromType::FROM_NORMAL);
-        m_select_machine_dlg->prepare(partplate_list.get_curr_plate_index());
-        m_select_machine_dlg->ShowModal();
+    if (preset_bundle.use_bbl_network() || wxGetApp().app_config->get_bool("use_printer_agents")) {
+        open_machine_select_dialog(partplate_list.get_curr_plate_index());
     } else {
         q->send_gcode_legacy(PLATE_CURRENT_IDX, nullptr);
     }
+}
+
+void Plater::priv::open_machine_select_dialog(int plate_idx, PrintFromType print_type)
+{
+    // BBS
+    if (!m_select_machine_dlg)
+        m_select_machine_dlg = new SelectMachineDialog(q);
+    m_select_machine_dlg->set_print_type(print_type);
+    m_select_machine_dlg->prepare(plate_idx);
+    m_select_machine_dlg->ShowModal();
 }
 
 void Plater::priv::on_action_send_to_multi_machine(SimpleEvent&)
@@ -11166,10 +11178,7 @@ void Plater::priv::on_action_print_plate_from_sdcard(SimpleEvent&)
     }
 
     //BBS
-    if (!m_select_machine_dlg) m_select_machine_dlg = new SelectMachineDialog(q);
-    m_select_machine_dlg->set_print_type(PrintFromType::FROM_SDCARD_VIEW);
-    m_select_machine_dlg->prepare(0);
-    m_select_machine_dlg->ShowModal();
+    open_machine_select_dialog(0, PrintFromType::FROM_SDCARD_VIEW);
 }
 
 void Plater::priv::on_tab_selection_changing(wxBookCtrlEvent& e)
@@ -11184,13 +11193,13 @@ void Plater::priv::on_tab_selection_changing(wxBookCtrlEvent& e)
     sidebar_layout.show = new_sel == MainFrame::tp3DEditor || new_sel == MainFrame::tpPreview;
     update_sidebar();
     int old_sel = e.GetOldSelection();
-    const bool is_printer_agent_plugin = NetworkAgentFactory::is_current_printer_agent_plugin();
+    const bool use_printer_agents = wxGetApp().app_config->get_bool("use_printer_agents");
     const bool use_native_device_tab = wxGetApp().preset_bundle &&
-        (wxGetApp().preset_bundle->use_bbl_device_tab() || is_printer_agent_plugin);
+        (wxGetApp().preset_bundle->use_bbl_device_tab() || use_printer_agents);
     if (use_native_device_tab && new_sel == MainFrame::tpMonitor) {
         // BBL network module is only required for BBL-vendor printers.
         // Non-BBL Python plugins (e.g. moonraker) drive the Device tab without it.
-        if (!is_printer_agent_plugin && wxGetApp().preset_bundle->is_bbl_vendor() && !Slic3r::NetworkAgent::is_network_module_loaded()) {
+        if (!use_printer_agents && wxGetApp().preset_bundle->is_bbl_vendor() && !Slic3r::NetworkAgent::is_network_module_loaded()) {
             e.Veto();
             BOOST_LOG_TRIVIAL(info) << boost::format("skipped tab switch from %1% to %2%, lack of network plugins") % old_sel % new_sel;
             if (q) {
@@ -11246,13 +11255,8 @@ void Plater::priv::on_action_print_all(SimpleEvent&)
     }
 
     PresetBundle& preset_bundle = *wxGetApp().preset_bundle;
-    if (preset_bundle.use_bbl_network()) {
-        // BBS
-        if (!m_select_machine_dlg)
-            m_select_machine_dlg = new SelectMachineDialog(q);
-        m_select_machine_dlg->set_print_type(PrintFromType::FROM_NORMAL);
-        m_select_machine_dlg->prepare(PLATE_ALL_IDX);
-        m_select_machine_dlg->ShowModal();
+    if (preset_bundle.use_bbl_network() || wxGetApp().app_config->get_bool("use_printer_agents")) {
+        open_machine_select_dialog(PLATE_ALL_IDX);
     } else {
         q->send_gcode_legacy(PLATE_ALL_IDX, nullptr);
     }

--- a/src/slic3r/GUI/PluginStatus.hpp
+++ b/src/slic3r/GUI/PluginStatus.hpp
@@ -11,6 +11,7 @@ namespace Slic3r
             // IMPORTANT: ordinal order is the Plugins dialog Status sort priority.
             Activated,
             Error,
+            RuntimeError,
             Inactive,
             Loading
         };
@@ -21,11 +22,28 @@ namespace Slic3r
             {
             case PluginStatus::Activated: return "Activated";
             case PluginStatus::Error: return "Error";
+            case PluginStatus::RuntimeError: return "RuntimeError";
             case PluginStatus::Inactive: return "Inactive";
             case PluginStatus::Loading: return "Loading";
             }
 
             return "Inactive";
+        }
+
+        // why: a plugin whose module is live but whose catalog carries an error is a
+        //   RUNTIME fault (e.g. a capability rejected at register time) - it stays
+        //   loaded/checked and is only flagged, distinct from a load-time Error where
+        //   the module never came up. Loading wins over both so an in-flight reload
+        //   never flashes an error.
+        inline PluginStatus resolve_plugin_status(bool loading, bool has_error, bool is_loaded)
+        {
+            if (loading)
+                return PluginStatus::Loading;
+            if (has_error)
+                return is_loaded ? PluginStatus::RuntimeError : PluginStatus::Error;
+            if (is_loaded)
+                return PluginStatus::Activated;
+            return PluginStatus::Inactive;
         }
     }
 } // namespace Slic3r::GUI

--- a/src/slic3r/GUI/PluginsDialog.cpp
+++ b/src/slic3r/GUI/PluginsDialog.cpp
@@ -231,6 +231,7 @@ nlohmann::json build_plugin_payload_item(const PluginDialogItem& dialog_item)
     payload_item["label"]                 = dialog_item.display_name;
     payload_item["source"]                = to_string(dialog_item.source);
     payload_item["status"]                = to_string(dialog_item.status);
+    payload_item["is_loaded"]             = dialog_item.is_loaded;
     payload_item["error"]                 = dialog_item.error_text;
     payload_item["update_status"]         = to_string(dialog_item.update_status);
     payload_item["unauthorized"]          = dialog_item.unauthorized;

--- a/src/slic3r/GUI/PluginsDialog.cpp
+++ b/src/slic3r/GUI/PluginsDialog.cpp
@@ -369,14 +369,7 @@ PluginDialogItem build_plugin_dialog_item(const PluginDescriptor& descriptor)
     item.sharing_token = descriptor.sharing_token;
     item.thumbnail_url = descriptor.thumbnail_url;
 
-    if (item.loading)
-        item.status = PluginStatus::Loading;
-    else if (item.has_error)
-        item.status = PluginStatus::Error;
-    else if (item.is_loaded)
-        item.status = PluginStatus::Activated;
-    else
-        item.status = PluginStatus::Inactive;
+    item.status = resolve_plugin_status(item.loading, item.has_error, item.is_loaded);
 
     item.available_actions        = evaluate_action_policy(item);
     const bool has_enabled_script = std::any_of(item.capabilities.begin(), item.capabilities.end(),
@@ -618,6 +611,9 @@ void PluginsDialog::toggle_plugin(const std::string& plugin_key, bool enabled)
         }
 
         BOOST_LOG_TRIVIAL(info) << "Plugin unloaded from Plugins dialog: " << plugin_key;
+        // A user-disabled plugin has no meaningful error state.
+        if (!manager.clear_plugin_error(plugin_key))
+            BOOST_LOG_TRIVIAL(warning) << "Failed to clear plugin error for " << plugin_key << " (failed to find)";
         // A prior activation of this plugin is moot now; drop it so no stale "Activated" arrives later.
         if (m_activating_plugin_key == plugin_key)
             m_activating_plugin_key.clear();

--- a/src/slic3r/GUI/Preferences.cpp
+++ b/src/slic3r/GUI/Preferences.cpp
@@ -1115,6 +1115,14 @@ wxBoxSizer *PreferencesDialog::create_item_checkbox(wxString title, wxString too
             wxGetApp().plater()->sidebar().update_presets(Preset::TYPE_FILAMENT);
         }
 
+        if (param == "use_printer_agents")
+        {
+            // Rebuild the Device tab so the native/web-UI choice reflects the new flag
+            // immediately, instead of only on the next printer-preset change or restart.
+            if (wxGetApp().plater())
+                wxGetApp().plater()->sidebar().update_all_preset_comboboxes();
+        }
+
         if (param == "enable_high_low_temp_mixed_printing") {
             if (checkbox->GetValue()) {
                 const wxString warning_title = _L("Bed Temperature Difference Warning");
@@ -2035,6 +2043,12 @@ void PreferencesDialog::create_items()
   
     auto item_show_unsupported = create_item_checkbox(_L("Show unsupported presets"), _L("Show incompatible/unsupported presets in the printer and filament dropdown lists. These presets cannot be selected."), "show_unsupported_presets");
     g_sizer->Add(item_show_unsupported);
+
+    auto item_plugin_printer_agents = create_item_checkbox(
+        _L("(Experimental) Use printer agents instead of print hosts"), _L(
+            "Route print jobs for non-Bambu printers through printer plug-in agents instead of the classic print-host upload flow.\nWhen disabled, OrcaSlicer uses the legacy print-host behavior."),
+        "use_printer_agents");
+    g_sizer->Add(item_plugin_printer_agents);
 
     //// DEVELOPER > Experimental Features
     g_sizer->Add(create_item_title(_L("Experimental Features")), 1, wxEXPAND);

--- a/src/slic3r/GUI/SelectMachine.cpp
+++ b/src/slic3r/GUI/SelectMachine.cpp
@@ -2925,10 +2925,32 @@ void SelectMachineDialog::on_send_print()
     m_print_job->on_success([this]() { finish_mode(); });
 
     m_print_job->on_check_ip_address_fail([this]() {
-        wxCommandEvent* evt = new wxCommandEvent(EVT_CLEAR_IPADDRESS);
-        wxQueueEvent(this, evt);
-        wxGetApp().show_ip_address_enter_dialog();
-     });
+        // Invoked from the PrintJob worker thread when the LAN pre-flight (file upload
+        // verification) fails. Marshal device/UI access to the main thread.
+        CallAfter([this]()
+        {
+            // Reset the dialog out of sending mode so the user can retry.
+            wxCommandEvent* evt = new wxCommandEvent(EVT_CLEAR_IPADDRESS);
+            wxQueueEvent(this, evt);
+
+            DeviceManager* dev = wxGetApp().getDeviceManager();
+            MachineObject* obj = dev ? dev->get_selected_machine() : nullptr;
+
+            if (obj && obj->is_connected())
+            {
+                // Connected: failed on file upload
+                MessageDialog dlg(this,
+                                  _L("Failed to upload the file to the printer's storage. Please try again."),
+                                  _L("Send Failed"), wxOK | wxICON_ERROR);
+                dlg.ShowModal();
+            }
+            else
+            {
+                // Not connected: reenter ip and access code
+                wxGetApp().show_ip_address_enter_dialog();
+            }
+        });
+    });
 
     // update ota version
     NetworkAgent* agent = wxGetApp().getAgent();

--- a/src/slic3r/GUI/SendToPrinter.cpp
+++ b/src/slic3r/GUI/SendToPrinter.cpp
@@ -300,7 +300,7 @@ SendToPrinterDialog::SendToPrinterDialog(Plater *plater)
     m_storage_panel->Layout();
 
     // try to connect
-    m_statictext_printer_msg = new wxStaticText(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxALIGN_CENTER_HORIZONTAL);
+    m_statictext_printer_msg = new wxStaticText(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize(FromDIP(400), -1), wxALIGN_CENTER_HORIZONTAL);
     m_statictext_printer_msg->SetFont(::Label::Body_13);
     m_statictext_printer_msg->SetForegroundColour(*wxBLACK);
     m_statictext_printer_msg->Hide();
@@ -760,9 +760,25 @@ void SendToPrinterDialog::update_priner_status_msg(wxString msg, bool is_warning
         if (str_new != str_old) {
             if (m_statictext_printer_msg->GetLabel() != msg) {
                 m_statictext_printer_msg->SetLabel(msg);
-                m_statictext_printer_msg->SetMinSize(wxSize(FromDIP(400), -1));
-                m_statictext_printer_msg->SetMaxSize(wxSize(FromDIP(400), -1));
-                m_statictext_printer_msg->Wrap(FromDIP(400));
+                const int wrap_width = FromDIP(400);
+                m_statictext_printer_msg->Wrap(wrap_width);
+                int line_count = 1;
+                const wxString wrapped_label = m_statictext_printer_msg->GetLabel();
+                for (size_t i = 0; i < wrapped_label.length(); ++i) {
+                    if (wrapped_label[i] == '\n')
+                        ++line_count;
+                }
+                wxCoord text_width = 0;
+                wxCoord text_height = 0;
+                m_statictext_printer_msg->GetTextExtent(msg, &text_width, &text_height);
+                const int extent_line_count = text_width > 0 ?
+                    std::max(1, (static_cast<int>(text_width) + wrap_width - 1) / wrap_width) : 1;
+                line_count = std::max(line_count, extent_line_count);
+                const int line_height = std::max(m_statictext_printer_msg->GetCharHeight(), static_cast<int>(text_height));
+                const int min_height = std::max(m_statictext_printer_msg->GetBestSize().GetHeight(),
+                                                line_count * line_height + FromDIP(2));
+                m_statictext_printer_msg->SetMinSize(wxSize(wrap_width, min_height));
+                m_statictext_printer_msg->SetMaxSize(wxDefaultSize);
                 m_statictext_printer_msg->Show();
                 Layout();
                 Fit();
@@ -1488,6 +1504,9 @@ void SendToPrinterDialog::show_status(PrintDialogStatus status, std::vector<wxSt
         Enable_Send_Button(false);
         Enable_Refresh_Button(true);
     } else if (status == PrintDialogStatus::PrintStatusPublicInitFailed) {
+        wxString msg_text = _L(
+            "Failed to initialize the printer file transfer. Please check the connection and try again.");
+        update_print_status_msg(msg_text, true, true);
         Enable_Send_Button(false);
         Enable_Refresh_Button(true);
     } else if (status == PrintDialogStatus::PrintStatusPublicUploadFiled) {
@@ -1665,30 +1684,18 @@ extern void     refresh_agora_url(char const *device, char const *dev_ver, char 
 void SendToPrinterDialog::GetConnection()
 {
     DeviceManager *dm  = GUI::wxGetApp().getDeviceManager();
+    MachineObject *obj = dm ? dm->get_selected_machine() : nullptr;
 
-    MachineObject *obj = dm->get_selected_machine();
-    if (obj == nullptr) {
+    if (!obj)
         BOOST_LOG_TRIVIAL(error) << __FUNCTION__ << " : obj is empty";
-        m_connection_status = ConnectionStatus::NOT_START;
-    }
-
-    int remote_proto = obj->get_file_remote();
-    if (!remote_proto) {
+    if (obj && !obj->get_file_remote())
         BOOST_LOG_TRIVIAL(error) << __FUNCTION__ << " : remote_proto is not support";
-        m_connection_status = ConnectionStatus::NOT_START;
-    }
+    if (obj && obj->is_camera_busy_off())
+    BOOST_LOG_TRIVIAL(error) << __FUNCTION__ << " : camera is busy";
 
-    if (obj->is_camera_busy_off()) {
-        BOOST_LOG_TRIVIAL(error) << __FUNCTION__ << " : camera is busy";
-        m_connection_status = ConnectionStatus::NOT_START;
-    }
+    NetworkAgent* agent = wxGetApp().getAgent();
 
-    NetworkAgent *agent         = wxGetApp().getAgent();
-    std::string   agent_version = agent ? agent->get_version() : "";
-    std::string   dev_ver       = obj->get_ota_version();
-    std::string   dev_id        = obj->get_dev_id();
-
-     if (m_url_timer && m_url_timer->IsRunning())
+    if (m_url_timer && m_url_timer->IsRunning())
      {
          m_url_timer->Stop();
      }
@@ -1711,19 +1718,40 @@ void SendToPrinterDialog::GetConnection()
          m_url_timer->GetId());
      m_url_timer->StartOnce(8000);
 
-    if (agent) {
+    if (obj && agent)
+    {
+        std::string dev_ver = obj->get_ota_version();
+        std::string dev_id = obj->get_dev_id();
+
         if (m_tcp_try_connect) {
             std::string devIP      = obj->get_dev_ip();
             std::string accessCode = obj->get_access_code();
             std::string url        = "bambu:///local/" + devIP + "?port=6000&user=" + "bblp" + "&passwd=" + accessCode;
-            BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << ": Connect method tcp";
-            m_filetransfer_tunnel  = std::make_unique<FileTransferTunnel>(module(), url);
-            m_filetransfer_tunnel->on_connection([this](bool is_success, int err_code, std::string error_msg) {
-                CallAfter([this, is_success, err_code, error_msg]() {
-                       OnConnection(is_success, err_code, error_msg);
+            BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << ": Connect method tcp, dev_id=" << dev_id
+                                    << ", dev_ip=" << devIP << ", access_code_len=" << accessCode.size();
+
+            try
+            {
+                m_filetransfer_tunnel = std::make_unique<FileTransferTunnel>(module(), url);
+                m_filetransfer_tunnel->on_connection([this](bool is_success, int err_code, std::string error_msg)
+                {
+                    CallAfter([this, is_success, err_code, error_msg]()
+                    {
+                        OnConnection(is_success, err_code, error_msg);
+                    });
                 });
-            });
-            m_filetransfer_tunnel->start_connect();
+                m_filetransfer_tunnel->start_connect();
+            }
+            catch (const std::exception& e)
+            {
+                BOOST_LOG_TRIVIAL(warning) << __FUNCTION__ << ": tcp FileTransferTunnel unavailable for dev_id=" <<
+ dev_id
+                                           << " dev_ip=" << devIP << ": " << e.what();
+                if (m_url_timer && m_url_timer->IsRunning()) m_url_timer->Stop();
+                m_filetransfer_tunnel.reset();
+                m_connection_status = ConnectionStatus::CONNECTION_FAILED;
+                show_status(PrintDialogStatus::PrintStatusPublicInitFailed);
+            }
         }
         else if (m_tutk_try_connect)
         {
@@ -1751,11 +1779,28 @@ void SendToPrinterDialog::GetConnection()
                 if (boost::algorithm::starts_with(url, "bambu:///"))
                 {
                     BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << ": Connect method tutk";
-                    m_filetransfer_tunnel = std::make_unique<FileTransferTunnel>(module(), url);
-                    m_filetransfer_tunnel->on_connection([this](bool is_success, int err_code, std::string error_msg) {
-                        CallAfter([this, is_success, err_code, error_msg]() { OnConnection(is_success, err_code, error_msg); });
-                    });
-                    m_filetransfer_tunnel->start_connect();
+                    try
+                    {
+                        m_filetransfer_tunnel = std::make_unique<FileTransferTunnel>(module(), url);
+                        m_filetransfer_tunnel->on_connection(
+                            [this](bool is_success, int err_code, std::string error_msg)
+                            {
+                                CallAfter([this, is_success, err_code, error_msg]()
+                                {
+                                    OnConnection(is_success, err_code, error_msg);
+                                });
+                            });
+                        m_filetransfer_tunnel->start_connect();
+                    }
+                    catch (const std::exception& e)
+                    {
+                        BOOST_LOG_TRIVIAL(warning) << __FUNCTION__ << ": tutk FileTransferTunnel unavailable: " << e.
+what();
+                        if (m_url_timer && m_url_timer->IsRunning()) m_url_timer->Stop();
+                        m_filetransfer_tunnel.reset();
+                        m_connection_status = ConnectionStatus::CONNECTION_FAILED;
+                        show_status(PrintDialogStatus::PrintStatusPublicInitFailed);
+                    }
                 }
                 else
                 {
@@ -1854,8 +1899,17 @@ void SendToPrinterDialog::ResetTunnelAndJob()
 
 void SendToPrinterDialog::CreateMediaAbilityJob()
 {
-     nlohmann::json media_ability = {{"cmd_type", 7}};
-     m_filetransfer_mediability_job = std::make_unique<FileTransferJob>(module(), std::string(media_ability.dump()));
+    nlohmann::json media_ability = {{"cmd_type", 7}};
+    try
+    {
+        m_filetransfer_mediability_job = std::make_unique<FileTransferJob>(module(), std::string(media_ability.dump()));
+    }
+    catch (const std::exception& e)
+    {
+        BOOST_LOG_TRIVIAL(warning) << __FUNCTION__ << ": FileTransferJob unavailable: " << e.what();
+         show_status(PrintDialogStatus::PrintStatusPublicInitFailed);
+         return;
+     }
      m_filetransfer_mediability_job->on_result([this](int res, int resp_ec, std::string json_res, std::vector<std::byte> bin_res) {
          //this pl
          CallAfter([this, res, resp_ec, json_res] {
@@ -1905,11 +1959,20 @@ void SendToPrinterDialog::CreateUploadFileJob(const std::string &path, const std
         {"cmd_type", 5},
     };
     upload_params["dest_storage"] = m_selected_storage;
-    upload_params["dest_name"]    = name; // filenme no path
-    upload_params["file_path"]    = path;
+    upload_params["dest_name"] = name; // filenme no path
+    upload_params["file_path"] = path;
 
-      BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << ": Begin CreateUploadFileJob";
-    m_filetransfer_uploadfile_job = std::make_unique<FileTransferJob>(module(), std::string(upload_params.dump()));
+    BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << ": Begin CreateUploadFileJob";
+    try
+    {
+        m_filetransfer_uploadfile_job = std::make_unique<FileTransferJob>(module(), std::string(upload_params.dump()));
+    }
+    catch (const std::exception& e)
+    {
+        BOOST_LOG_TRIVIAL(warning) << __FUNCTION__ << ": FileTransferJob unavailable: " << e.what();
+        show_status(PrintDialogStatus::PrintStatusPublicUploadFiled);
+        return;
+    }
     m_filetransfer_uploadfile_job->on_result([this](int res, int resp_ec, std::string json_res, std::vector<std::byte> bin_res) { //
         CallAfter([this, res, resp_ec, json_res, bin_res] {
             UploadFileRessultCallback(res, resp_ec,json_res, bin_res);

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -7864,6 +7864,24 @@ bool TabPrinter::apply_extruder_cnt_from_cache()
     return false;
 }
 
+void TabPrinter::refresh_printer_agent_dropdown() const
+{
+    auto* choice = dynamic_cast<PrinterAgentChoice*>(get_field("printer_agent"));
+    if (!choice || !choice->getWindow())
+        return;
+
+    const auto agents = NetworkAgentFactory::get_registered_printer_agents();
+    if (agents.empty())
+        return;
+
+    // why: rows live on PrinterAgentChoice now; rebuild them from the live registry and re-select the stored id.
+    const std::string selected_agent = wxGetApp().preset_bundle->printers.get_edited_preset()
+                                                 .config.opt_string("printer_agent");
+    choice->reload_rows();
+    choice->set_value(selected_agent, false);
+    this->GetParent()->Layout();
+}
+
 bool Tab::validate_custom_gcodes()
 {
     if (m_type != Preset::TYPE_FILAMENT &&

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -33,6 +33,7 @@
 
 #include "GUI_App.hpp"
 #include "GUI_ObjectList.hpp"
+#include "slic3r/Utils/NetworkAgentFactory.hpp"
 #include "slic3r/Utils/PresetUpdater.hpp"
 #include "Plater.hpp"
 #include "MainFrame.hpp"
@@ -4978,6 +4979,40 @@ void TabPrinter::build_fff()
         optgroup->append_single_option_line("gcode_flavor", "printer_basic_information_advanced#g-code-flavor");
         optgroup->append_single_option_line("pellet_modded_printer", "printer_basic_information_advanced#pellet-modded-printer");
         optgroup->append_single_option_line("bbl_use_printhost", "printer_basic_information_advanced#use-3rd-party-print-host");
+
+        // "Printer Agent" dropdown - printer_agent is a coString; gui_type routes it to
+        // PrinterAgentChoice instead of a TextCtrl. Rows and values come from the live agent
+        // registry, and the value is stored as the agent-id string.
+        if (wxGetApp().getAgent() != nullptr)
+        {
+            auto registered_printer_agents = NetworkAgentFactory::get_registered_printer_agents();
+            if (!registered_printer_agents.empty())
+            {
+                ConfigOptionDef def;
+                def.type = coString;
+                def.gui_type = ConfigOptionDef::GUIType::printer_agent_select;
+                def.width = 3 * Field::def_width_wider() / 2;
+                def.label = L("Printer Agent");
+                def.tooltip = L("Select the network agent implementation for printer communication. "
+                    "Available agents are registered at startup.");
+                def.mode = comAdvanced;
+
+                // Create the field without get_option() so it is not registered in m_opt_map.
+                // ConfigOptionsGroup handles printer_agent before the generic mapped write path.
+                Line agent_line = optgroup->create_single_option_line(Option(def, "printer_agent"));
+                optgroup->append_line(agent_line);
+                if (Field* agent_field = get_field("printer_agent"))
+                {
+                    if (auto* choice = dynamic_cast<PrinterAgentChoice*>(agent_field); choice && choice->getWindow())
+                        choice->set_value(m_config->opt_string("printer_agent"), false);
+                }
+
+                // Register by hand so the UnsavedChanges dialog can render a row for it.
+                wxGetApp().sidebar().get_searcher().add_key("printer_agent", m_type, optgroup->title,
+                                                            optgroup->config_category());
+            }
+        }
+
         optgroup->append_single_option_line("use_3mf");
         optgroup->append_single_option_line("scan_first_layer" , "printer_basic_information_advanced#scan-first-layer");
         optgroup->append_single_option_line("enable_power_loss_recovery", "printer_basic_information_advanced#power-loss-recovery");
@@ -5841,6 +5876,16 @@ void TabPrinter::reload_config()
     // so update it implicitly
     if (m_active_page && m_active_page->title() == "Multimaterial")
         m_active_page->set_value("extruders_count", int(m_extruders_count));
+
+    // m_opt_map-driven reload does not cover printer_agent, so sync this custom field explicitly.
+    if (Field* agent_field = get_field("printer_agent"))
+    {
+        if (auto* choice = dynamic_cast<PrinterAgentChoice*>(agent_field); choice && choice->getWindow())
+        {
+            const std::string selected_agent = m_config->opt_string("printer_agent");
+            choice->set_value(selected_agent, false);
+        }
+    }
 }
 
 void TabPrinter::activate_selected_page(std::function<void()> throw_if_canceled)
@@ -5851,6 +5896,16 @@ void TabPrinter::activate_selected_page(std::function<void()> throw_if_canceled)
     // so update it implicitly
     if (m_active_page && m_active_page->title() == "Multimaterial")
         m_active_page->set_value("extruders_count", int(m_extruders_count));
+
+    // m_opt_map-driven reload does not cover printer_agent, so sync this custom field explicitly.
+    if (Field* agent_field = get_field("printer_agent"))
+    {
+        if (auto* choice = dynamic_cast<PrinterAgentChoice*>(agent_field); choice && choice->getWindow())
+        {
+            const std::string selected_agent = m_config->opt_string("printer_agent");
+            choice->set_value(selected_agent, false);
+        }
+    }
 }
 
 void TabPrinter::clear_pages()

--- a/src/slic3r/GUI/Tab.hpp
+++ b/src/slic3r/GUI/Tab.hpp
@@ -674,6 +674,7 @@ public:
 	wxSizer*	create_bed_shape_widget(wxWindow* parent);
 	void		cache_extruder_cnt(const DynamicPrintConfig* config = nullptr);
 	bool		apply_extruder_cnt_from_cache();
+	void		refresh_printer_agent_dropdown() const;
 };
 
 class TabSLAMaterial : public Tab

--- a/src/slic3r/Utils/MoonrakerPrinterAgent.cpp
+++ b/src/slic3r/Utils/MoonrakerPrinterAgent.cpp
@@ -199,11 +199,15 @@ void MoonrakerPrinterAgent::install_device_cert(std::string dev_id, bool lan_onl
 
 bool MoonrakerPrinterAgent::start_discovery(bool start, bool sending)
 {
-    (void) sending;
-    if (start) {
-        announce_printhost_device();
-    }
-    return true;
+    // Discovery is not properly implemented, avoid populating machine list
+    // with stale device
+    // (void) sending;
+    // if (start) {
+    //     announce_printhost_device();
+    // }
+    // return true;
+
+    return BAMBU_NETWORK_SUCCESS;
 }
 
 int MoonrakerPrinterAgent::ping_bind(std::string ping_code)
@@ -334,11 +338,17 @@ int MoonrakerPrinterAgent::start_local_print(PrintParams params, OnUpdateStatusF
     if (cancel_fn && cancel_fn()) {
         return BAMBU_NETWORK_ERR_CANCELED;
     }
-    // Determine the G-code file to upload
-    // params.filename may be .3mf, params.dst_file contains actual G-code
+    // Determine the G-code file to upload.
+    // - params.dst_file, when set, points directly at the sliced G-code.
+    // - Otherwise params.filename is the exported .3mf archive; the sliced
+    //   G-code sits next to it with the same stem (".12345.0.3mf" ->
+    //   ".12345.0.gcode"), so swap the extension to upload the actual G-code
+    //   rather than the archive (which Klipper cannot print).
     std::string gcode_path = params.filename;
     if (!params.dst_file.empty()) {
         gcode_path = params.dst_file;
+    } else if (boost::iends_with(gcode_path, ".3mf")) {
+        gcode_path.replace(gcode_path.size() - 4, 4, ".gcode");
     }
 
     // Check if file exists and has .gcode extension
@@ -349,8 +359,19 @@ int MoonrakerPrinterAgent::start_local_print(PrintParams params, OnUpdateStatusF
         return BAMBU_NETWORK_ERR_FILE_NOT_EXIST;
     }
 
-    // Extract filename for upload (relative to gcodes root)
-    std::string upload_filename = source_path.filename().string();
+    // Use the human-readable project name for the uploaded file rather than the
+    // internal temp G-code name (e.g. ".12345.0.gcode"). Fall back to the source
+    // file's own name when no project name is available.
+    std::string upload_filename = params.project_name.empty()
+                                      ? source_path.filename().string()
+                                      : params.project_name;
+
+    // SDCARD_PRINT_FILE parses its parameters by whitespace, so the printed
+    // filename must not contain spaces; collapse any whitespace to underscores.
+    std::replace_if(
+        upload_filename.begin(), upload_filename.end(),
+        [](unsigned char c) { return std::isspace(c) != 0; }, '_');
+
     if (!boost::iends_with(upload_filename, ".gcode")) {
         upload_filename += ".gcode";
     }
@@ -369,11 +390,12 @@ int MoonrakerPrinterAgent::start_local_print(PrintParams params, OnUpdateStatusF
         return BAMBU_NETWORK_ERR_CANCELED;
     }
 
-    // Start print via gcode script (simpler than JSON-RPC)
+    // Start print via Moonraker's print API, referencing the file we just uploaded.
     if (update_fn)
         update_fn(PrintingStageSending, 0, "Starting print...");
-    std::string gcode = "SDCARD_PRINT_FILE FILENAME=" + upload_filename;
-    if (!send_gcode(device_info.dev_id, gcode)) {
+
+    std::string start_error;
+    if (!start_print_file(device_info.base_url, device_info.api_key, upload_filename, start_error)) {
         return BAMBU_NETWORK_ERR_PRINT_LP_PUBLISH_MSG_FAILED;
     }
 
@@ -1203,7 +1225,8 @@ bool MoonrakerPrinterAgent::send_gcode(const std::string& dev_id, const std::str
     bool        success = false;
     std::string http_error;
 
-    auto http = Http::post(join_url(device_info.base_url, "/printer/gcode/script"));
+    auto full_url = join_url(device_info.base_url, "/printer/gcode/script");
+    auto http = Http::post(full_url);
     if (!device_info.api_key.empty()) {
         http.header("X-Api-Key", device_info.api_key);
     }
@@ -1775,9 +1798,12 @@ nlohmann::json MoonrakerPrinterAgent::build_print_payload_locked() const
     payload["print"]["print_error"]         = 0;
 
     // Map homed axes to bit field: X=bit0, Y=bit1, Z=bit2
-    // WARNING: This only sets bits 0-2, clearing support flags (bit 3+)
-    // Bit 3 = 220V voltage, bit 4 = auto recovery, etc.
-    // This is acceptable for Moonraker (no AMS, different feature set)
+    // NOTE: home_flag is a packed BBL status field. MachineObject::parse_home_flag()
+    // decodes the storage state from bits 8-9 (get_flag_bits(flag, 8, 2)) and writes it
+    // to DevStorage. We encode HAS_SDCARD_NORMAL there (bits 8-9 = 01) so the printer
+    // reports its virtual_sdcard as present and LAN printing is allowed; otherwise the
+    // bits stay 0 (NO_SDCARD) and printing is blocked. Other support bits (3=220V,
+    // 4=auto-recovery, etc.) are intentionally left 0 for Moonraker.
     int home_flag = 0;
     if (status_cache.contains("toolhead") && status_cache["toolhead"].contains("homed_axes")) {
         std::string homed = status_cache["toolhead"]["homed_axes"].get<std::string>();
@@ -1788,6 +1814,7 @@ nlohmann::json MoonrakerPrinterAgent::build_print_payload_locked() const
         if (homed.find('Z') != std::string::npos)
             home_flag |= 4; // bit 2
     }
+    home_flag |= (1 << 8); // bits 8-9 = 01 -> HAS_SDCARD_NORMAL (virtual_sdcard always present)
     payload["print"]["home_flag"] = home_flag;
 
     // Moonraker doesn't provide temperature ranges via API - use hardcoded defaults
@@ -2012,41 +2039,82 @@ int MoonrakerPrinterAgent::cancel_print(const std::string& dev_id)
     return send_gcode(dev_id, "CANCEL_PRINT") ? BAMBU_NETWORK_SUCCESS : BAMBU_NETWORK_ERR_SEND_MSG_FAILED;
 }
 
-bool MoonrakerPrinterAgent::send_jsonrpc_command(const std::string&    base_url,
-                                                 const std::string&    api_key,
-                                                 const nlohmann::json& request,
-                                                 std::string&          response) const
+bool MoonrakerPrinterAgent::start_print_file(const std::string& base_url,
+                                             const std::string& api_key,
+                                             const std::string& filename,
+                                             std::string&       error_msg) const
 {
-    std::string request_str = request.dump();
-    std::string url         = join_url(base_url, "/printer/print/start");
+    // Start the given file (path relative to the gcodes root). The filename is
+    // sent both as a query parameter and in the JSON body: Moonraker accepts
+    // either, and sending a body avoids a body-less POST (which curl would treat
+    // as a streamed upload and try to read via the file-read callback).
+    std::string url = join_url(base_url, "/printer/print/start") +
+                      "?filename=" + Http::url_encode(filename);
 
-    bool        success = false;
-    std::string http_error;
+    nlohmann::json payload;
+    payload["filename"] = filename;
+
+    bool success = false;
 
     auto http = Http::post(url);
     if (!api_key.empty()) {
         http.header("X-Api-Key", api_key);
     }
     http.header("Content-Type", "application/json")
-        .set_post_body(request_str)
+        .set_post_body(payload.dump())
         .timeout_connect(5)
         .timeout_max(10)
         .on_complete([&](std::string body, unsigned status) {
+            (void) body;
             if (status == 200) {
-                response = body;
-                success  = true;
+                success = true;
             } else {
-                http_error = "HTTP " + std::to_string(status);
+                error_msg = "HTTP " + std::to_string(status);
             }
         })
-        .on_error([&](std::string body, std::string err, unsigned status) { http_error = err; })
+        .on_error([&](std::string body, std::string err, unsigned status) {
+            (void) body;
+            error_msg = err;
+            if (status > 0) {
+                error_msg += " (HTTP " + std::to_string(status) + ")";
+            }
+        })
         .perform_sync();
 
-    if (!success) {
-        BOOST_LOG_TRIVIAL(error) << "MoonrakerPrinterAgent: JSON-RPC command failed: " << http_error;
+    if (success) {
+        return true;
     }
 
-    return success;
+    // Moonraker holds the /printer/print/start response until the print actually
+    // begins, so a slow PRINT_START (heating, homing, bed mesh) can exceed our HTTP
+    // timeout even though the command was accepted and the print is starting. Don't
+    // report failure on the HTTP result alone: poll print_stats and treat a
+    // printing/paused state as success. print_stats.state flips to "printing" as soon
+    // as the file starts streaming, which is earlier than the held HTTP response.
+    BOOST_LOG_TRIVIAL(warning) << "MoonrakerPrinterAgent: start print not confirmed over HTTP (" << error_msg
+                               << "); verifying print_stats state";
+    for (int attempt = 0; attempt < 10; ++attempt) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1500));
+
+        nlohmann::json status;
+        std::string    query_err;
+        if (!query_printer_status(base_url, api_key, status, query_err)) {
+            continue;
+        }
+
+        std::string state;
+        if (status.contains("print_stats") && status["print_stats"].contains("state") &&
+            status["print_stats"]["state"].is_string()) {
+            state = status["print_stats"]["state"].get<std::string>();
+        }
+        if (state == "printing" || state == "paused") {
+            BOOST_LOG_TRIVIAL(info) << "MoonrakerPrinterAgent: print confirmed started (print_stats.state=" << state << ")";
+            return true;
+        }
+    }
+
+    BOOST_LOG_TRIVIAL(error) << "MoonrakerPrinterAgent: start print failed: " << error_msg << ", url: " << url;
+    return false;
 }
 
 void MoonrakerPrinterAgent::perform_connection_async(const std::string& dev_id, const std::string& base_url, const std::string& api_key, uint64_t generation)
@@ -2082,7 +2150,7 @@ void MoonrakerPrinterAgent::perform_connection_async(const std::string& dev_id, 
         }
 
 // Orca todo: disable websocket for now, as we don't use MonitorPanel for Moonraker printers yet
-#if 0
+#if 1
         // Query initial status
         nlohmann::json initial_status;
         if (query_printer_status(base_url, api_key, initial_status, error_msg)) {

--- a/src/slic3r/Utils/MoonrakerPrinterAgent.hpp
+++ b/src/slic3r/Utils/MoonrakerPrinterAgent.hpp
@@ -69,7 +69,7 @@ public:
     int set_queue_on_main_fn(QueueOnMainFn fn) override;
 
     // Pull-mode agent (on-demand filament sync)
-    FilamentSyncMode get_filament_sync_mode() const override { return FilamentSyncMode::pull; }
+    FilamentSyncMode get_filament_sync_mode() const override { return FilamentSyncMode::subscription; }
     bool fetch_filament_info(std::string dev_id) override;
 
 protected:
@@ -120,6 +120,9 @@ protected:
     // Map filament type to OrcaFilamentLibrary preset ID for AMS sync compatibility
     static std::string map_filament_type_to_generic_id(const std::string& filament_type);
 
+    // Send a G-code script via Moonraker (/printer/gcode/script)
+    bool send_gcode(const std::string& dev_id, const std::string& gcode) const;
+
 private:
     int handle_request(const std::string& dev_id, const std::string& json_str);
     int send_version_info(const std::string& dev_id);
@@ -127,7 +130,6 @@ private:
 
     bool fetch_object_list(const std::string& base_url, const std::string& api_key, std::set<std::string>& objects, std::string& error) const;
     bool query_printer_status(const std::string& base_url, const std::string& api_key, nlohmann::json& status, std::string& error) const;
-    bool send_gcode(const std::string& dev_id, const std::string& gcode) const;
 
     void announce_printhost_device();
     void dispatch_local_connect(int state, const std::string& dev_id, const std::string& msg);
@@ -150,9 +152,10 @@ private:
                       const std::string& base_url, const std::string& api_key,
                       OnUpdateStatusFn update_fn, WasCancelledFn cancel_fn);
 
-    // JSON-RPC helper
-    bool send_jsonrpc_command(const std::string& base_url, const std::string& api_key,
-                              const nlohmann::json& request, std::string& response) const;
+    // Start a print of a previously uploaded G-code file (path relative to the
+    // Moonraker gcodes root).
+    bool start_print_file(const std::string& base_url, const std::string& api_key,
+                          const std::string& filename, std::string& error_msg) const;
 
     // Connection thread management
     void perform_connection_async(const std::string& dev_id,

--- a/src/slic3r/Utils/NetworkAgentFactory.cpp
+++ b/src/slic3r/Utils/NetworkAgentFactory.cpp
@@ -493,25 +493,5 @@ void NetworkAgentFactory::deregister_python_printer_agent(const std::string& plu
                             << plugin_key << "' with agent ID '" << agent_id << "'";
 }
 
-bool NetworkAgentFactory::is_current_printer_agent_plugin()
-{
-    auto* preset_bundle = GUI::wxGetApp().preset_bundle;
-    if (!preset_bundle)
-        return false;
-
-    std::string agent_key = ORCA_PRINTER_AGENT_ID;
-    if (preset_bundle->is_bbl_vendor())
-        agent_key = BBL_PRINTER_AGENT_ID;
-
-    const auto& cfg = preset_bundle->printers.get_edited_preset().config;
-    if (cfg.has("printer_agent")) {
-        const std::string& value = cfg.option<ConfigOptionString>("printer_agent")->value;
-        if (!value.empty())
-            agent_key = value;
-    }
-
-    const PrinterAgentInfo* info = get_printer_agent_info(agent_key);
-    return info && info->is_plugin();
-}
 
 } // namespace Slic3r

--- a/src/slic3r/Utils/NetworkAgentFactory.cpp
+++ b/src/slic3r/Utils/NetworkAgentFactory.cpp
@@ -16,8 +16,10 @@
 #include <mutex>
 #include <utility>
 #include <slic3r/GUI/GUI_App.hpp>
+#include <slic3r/GUI/I18N.hpp>
 #include <slic3r/plugin/PluginDescriptor.hpp>
 #include <slic3r/plugin/PythonPluginInterface.hpp>
+#include <wx/msgdlg.h>
 
 namespace Slic3r {
 namespace {
@@ -314,6 +316,21 @@ void NetworkAgentFactory::register_python_printer_agent(const std::string& plugi
 
     std::shared_ptr<IPrinterAgent> cached_agent;
 
+    auto reject_conflicting_capability = [plugin_key, capability_name](const std::string& error_message) {
+        if (!wxTheApp || GUI::wxGetApp().is_closing())
+            return;
+        GUI::wxGetApp().CallAfter([plugin_key, capability_name, error_message]() {
+            if (GUI::wxGetApp().is_closing())
+                return;
+            PluginManager& manager = PluginManager::instance();
+            manager.set_plugin_error(plugin_key, error_message);
+            // note: the unload callback triggered by disabling will call deregister,
+            // which will be a no-op since the printer agent is never registered
+            manager.set_capability_enabled(plugin_key, capability_name, false);
+            wxMessageBox(wxString::FromUTF8(error_message.c_str()), _L("Plugins"), wxOK | wxICON_WARNING, GUI::wxGetApp().GetTopWindow());
+        });
+    };
+
     {
         std::lock_guard<std::mutex> lock(s_registry_mutex);
 
@@ -332,9 +349,10 @@ void NetworkAgentFactory::register_python_printer_agent(const std::string& plugi
         auto& python_agent_ids = get_python_printer_agent_ids();
         for (const auto& pair : python_agent_ids) {
             if (pair.first != capability_key && pair.second == info.id) {
-                BOOST_LOG_TRIVIAL(warning) << "Printer-agent plugin '" << capability_name << "' uses duplicate agent ID '" << info.id
-                                           << "' already registered by capability '" << pair.first.second << "' from plugin '"
-                                           << pair.first.first << "'";
+                const std::string error_message = "Printer-agent '" + info.name + "' could not be enabled: agent ID '" + info.id +
+                                                  "' is already registered by capability '" + pair.first.second + "' from plugin '" + pair.first.first + "'.";
+                BOOST_LOG_TRIVIAL(warning) << error_message;
+                reject_conflicting_capability(error_message);
                 return;
             }
         }
@@ -354,12 +372,22 @@ void NetworkAgentFactory::register_python_printer_agent(const std::string& plugi
 
         auto& agents = get_printer_agents();
         auto agent_it = agents.find(info.id);
+        // why: reject only when the ID is owned by SOMEONE ELSE - a built-in has an empty
+        //   plugin_identifier, another plugin/capability has a different plugin_full_ref. When it
+        //   IS the same plugin_full_ref, this capability is just re-registering itself, so fall
+        //   through and refresh.
         if (agent_it != agents.end() && agent_it->second.plugin_identifier != plugin_full_ref) {
-            BOOST_LOG_TRIVIAL(warning) << "Printer-agent plugin '" << capability_name << "' uses agent ID '" << info.id
-                                       << "' already registered by '" << agent_it->second.display_name << "'";
+            const std::string error_message = "Printer-agent '" + info.name + "' could not be enabled: agent ID '" + info.id +
+                                              "' is already registered by '" + agent_it->second.display_name + "'.";
+            BOOST_LOG_TRIVIAL(warning) << error_message;
+            reject_conflicting_capability(error_message);
             return;
         }
 
+        // why: insert_or_assign, not emplace - reaching here means the ID is new, or the same
+        //   capability is re-registering (same plugin_full_ref). In the re-register case we WANT to
+        //   overwrite so the factory closure points at the current live capability instance; emplace
+        //   would silently keep the stale entry.
         agents.insert_or_assign(info.id, PrinterAgentInfo(info.id, info.name, plugin_full_ref, std::move(factory)));
         python_agent_ids[capability_key] = info.id;
 

--- a/src/slic3r/Utils/NetworkAgentFactory.hpp
+++ b/src/slic3r/Utils/NetworkAgentFactory.hpp
@@ -166,8 +166,6 @@ public:
     static void register_python_printer_agent(const std::string& plugin_key, const std::string& capability_name);
     static void deregister_python_printer_agent(const std::string& plugin_key, const std::string& capability_name);
 
-    static bool is_current_printer_agent_plugin();
-
 private:
     // Factory is not instantiable
     NetworkAgentFactory()                                      = delete;

--- a/src/slic3r/Utils/QidiPrinterAgent.cpp
+++ b/src/slic3r/Utils/QidiPrinterAgent.cpp
@@ -74,6 +74,81 @@ bool QidiPrinterAgent::fetch_filament_info(std::string dev_id)
     return true;
 }
 
+bool QidiPrinterAgent::apply_box_mapping(const PrintParams& params) const
+{
+    // enable_box mirrors task_use_ams: engage the multi-color box only when this
+    // job actually routes filament through it. (See qidi-ams-findings.md §2/§8.3 —
+    // if firmware treats enable_box as "a box exists" rather than "use it this job",
+    // switch this gate to HasAms()/box_count instead.)
+    const int enable = params.task_use_ams ? 1 : 0;
+    if (!send_gcode(device_info.dev_id, "SAVE_VARIABLE VARIABLE=enable_box VALUE=" + std::to_string(enable))) {
+        BOOST_LOG_TRIVIAL(error) << "QidiPrinterAgent::apply_box_mapping: failed to set enable_box";
+        return false;
+    }
+
+    // When the box isn't used this job, leave the existing value_t<tool> slot
+    // assignments untouched (enable_box=0 is enough to disengage it).
+    if (!enable)
+        return true;
+
+    if (params.ams_mapping.empty()) {
+        BOOST_LOG_TRIVIAL(warning) << "QidiPrinterAgent::apply_box_mapping: enable_box set but ams_mapping is empty";
+        return true;
+    }
+
+    // ams_mapping (v0) is a JSON array indexed by filament/tool; each value is the
+    // physical box slot (-1 = unmapped). Mirror it onto the printer's value_t<tool>
+    // variables: SAVE_VARIABLE VARIABLE=value_t<tool> VALUE='slot<n>'.
+    auto mapping = nlohmann::json::parse(params.ams_mapping, nullptr, /*allow_exceptions*/ false);
+    if (mapping.is_discarded() || !mapping.is_array()) {
+        BOOST_LOG_TRIVIAL(error) << "QidiPrinterAgent::apply_box_mapping: invalid ams_mapping: " << params.ams_mapping;
+        return false;
+    }
+
+    for (size_t tool = 0; tool < mapping.size(); ++tool) {
+        if (!mapping[tool].is_number_integer())
+            continue;
+        const int slot = mapping[tool].get<int>();
+        if (slot < 0)
+            continue; // unmapped filament — skip
+        const std::string gcode = "SAVE_VARIABLE VARIABLE=value_t" + std::to_string(tool) +
+                                  " VALUE=\"'slot" + std::to_string(slot) + "'\"";
+        if (!send_gcode(device_info.dev_id, gcode)) {
+            BOOST_LOG_TRIVIAL(error) << "QidiPrinterAgent::apply_box_mapping: failed to set value_t" << tool;
+            return false;
+        }
+    }
+    return true;
+}
+
+int QidiPrinterAgent::start_local_print(PrintParams params, OnUpdateStatusFn update_fn, WasCancelledFn cancel_fn)
+{
+    if (!apply_box_mapping(params))
+        return BAMBU_NETWORK_ERR_PRINT_LP_PUBLISH_MSG_FAILED;
+    return MoonrakerPrinterAgent::start_local_print(std::move(params), update_fn, cancel_fn);
+}
+
+int QidiPrinterAgent::start_print(PrintParams params, OnUpdateStatusFn update_fn, WasCancelledFn cancel_fn, OnWaitFn wait_fn)
+{
+    if (!apply_box_mapping(params))
+        return BAMBU_NETWORK_ERR_PRINT_LP_PUBLISH_MSG_FAILED;
+    return MoonrakerPrinterAgent::start_print(std::move(params), update_fn, cancel_fn, wait_fn);
+}
+
+int QidiPrinterAgent::start_local_print_with_record(PrintParams params, OnUpdateStatusFn update_fn, WasCancelledFn cancel_fn, OnWaitFn wait_fn)
+{
+    if (!apply_box_mapping(params))
+        return BAMBU_NETWORK_ERR_PRINT_WR_UPLOAD_FTP_FAILED;
+    return MoonrakerPrinterAgent::start_local_print_with_record(std::move(params), update_fn, cancel_fn, wait_fn);
+}
+
+int QidiPrinterAgent::start_sdcard_print(PrintParams params, OnUpdateStatusFn update_fn, WasCancelledFn cancel_fn)
+{
+    if (!apply_box_mapping(params))
+        return BAMBU_NETWORK_ERR_PRINT_LP_PUBLISH_MSG_FAILED;
+    return MoonrakerPrinterAgent::start_sdcard_print(std::move(params), update_fn, cancel_fn);
+}
+
 bool QidiPrinterAgent::fetch_slot_info(const std::string&        base_url,
                                        const std::string&        api_key,
                                        const QidiFilamentDict&   dict,

--- a/src/slic3r/Utils/QidiPrinterAgent.hpp
+++ b/src/slic3r/Utils/QidiPrinterAgent.hpp
@@ -21,7 +21,16 @@ public:
     // Override filament sync (Qidi-specific implementation)
     bool fetch_filament_info(std::string dev_id) override;
 
+    // Print operations — emit QiDi multi-color box config, then delegate to base.
+    int start_print(PrintParams params, OnUpdateStatusFn update_fn, WasCancelledFn cancel_fn, OnWaitFn wait_fn) override;
+    int start_local_print(PrintParams params, OnUpdateStatusFn update_fn, WasCancelledFn cancel_fn) override;
+    int start_local_print_with_record(PrintParams params, OnUpdateStatusFn update_fn, WasCancelledFn cancel_fn, OnWaitFn wait_fn) override;
+    int start_sdcard_print(PrintParams params, OnUpdateStatusFn update_fn, WasCancelledFn cancel_fn) override;
+
 private:
+    // Push enable_box + value_t<tool> SAVE_VARIABLEs before a print starts.
+    // Returns false if any command fails (caller should abort the print).
+    bool apply_box_mapping(const PrintParams& params) const;
     struct QidiFilamentDict
     {
         std::map<int, std::string> colors;

--- a/tests/slic3rutils/CMakeLists.txt
+++ b/tests/slic3rutils/CMakeLists.txt
@@ -2,6 +2,8 @@ get_filename_component(_TEST_NAME ${CMAKE_CURRENT_LIST_DIR} NAME)
 add_executable(${_TEST_NAME}_tests
     ${_TEST_NAME}_tests_main.cpp
     test_plugin_host_api.cpp
+    test_plugin_status.cpp
+    test_printer_agent.cpp
     test_plugin_install.cpp
     test_plugin_lifecycle.cpp
     test_slicing_pipeline_bindings.cpp
@@ -48,3 +50,22 @@ elseif (APPLE)
 endif()
 
 orcaslicer_discover_tests(${_TEST_NAME}_tests)
+
+# why: the loader runs on a detached worker thread, so its Python interpreter
+# ownership model cannot share the embedded interpreter in the main test binary.
+add_executable(printer_agent_plugin_tests test_printer_agent_plugin.cpp)
+
+if (MSVC)
+    target_link_libraries(printer_agent_plugin_tests Setupapi.lib)
+endif ()
+
+target_link_libraries(printer_agent_plugin_tests test_common libslic3r_gui libslic3r pybind11::embed Catch2::Catch2)
+set_property(TARGET printer_agent_plugin_tests PROPERTY FOLDER "tests")
+
+# why: the existing target stages the complete bundled Python home under
+# python/, which is the layout PythonInterpreter discovers beside the test exe.
+add_dependencies(printer_agent_plugin_tests ${_TEST_NAME}_tests)
+
+orcaslicer_copy_test_dlls()
+
+orcaslicer_discover_tests(printer_agent_plugin_tests)

--- a/tests/slic3rutils/test_plugin_status.cpp
+++ b/tests/slic3rutils/test_plugin_status.cpp
@@ -1,0 +1,23 @@
+#include <catch2/catch_all.hpp>
+
+#include <slic3r/GUI/PluginStatus.hpp>
+
+using Slic3r::GUI::PluginStatus;
+using Slic3r::GUI::resolve_plugin_status;
+
+TEST_CASE("resolve_plugin_status precedence", "[plugin][status]") {
+    // the new branch: loaded module + error -> runtime fault, not a load failure.
+    REQUIRE(resolve_plugin_status(/*loading*/ false, /*has_error*/ true, /*is_loaded*/ true) == PluginStatus::RuntimeError);
+
+    // error without a live module is a load-time Error.
+    REQUIRE(resolve_plugin_status(false, true, false) == PluginStatus::Error);
+
+    // loading wins over a pending error so a reload never flashes red.
+    REQUIRE(resolve_plugin_status(true, true, true) == PluginStatus::Loading);
+
+    // healthy loaded plugin.
+    REQUIRE(resolve_plugin_status(false, false, true) == PluginStatus::Activated);
+
+    // nothing loaded, no error.
+    REQUIRE(resolve_plugin_status(false, false, false) == PluginStatus::Inactive);
+}

--- a/tests/slic3rutils/test_printer_agent.cpp
+++ b/tests/slic3rutils/test_printer_agent.cpp
@@ -1,0 +1,180 @@
+#include <catch2/catch_all.hpp>
+
+#include <slic3r/Utils/NetworkAgentFactory.hpp>
+#include <slic3r/plugin/PythonPluginBridge.hpp>
+
+#include <pybind11/embed.h>
+#include <pybind11/pybind11.h>
+
+#include <memory>
+#include <string>
+
+using namespace Slic3r;
+namespace py = pybind11;
+
+// ===========================================================================
+// UNIT - printer-agent registry duplicate handling.
+// Confirms a duplicate agent id is rejected so a plugin cannot shadow a built-in
+// or previously registered agent.
+// ===========================================================================
+TEST_CASE("unit: printer-agent registry register / lookup / duplicate-reject", "[registry][unit]")
+{
+    // why: the registry is process-global state shared by the test binary, and
+    // Catch2 may run cases in any order. Use an id that cannot collide with
+    // built-ins or other cases. Avoid SECTIONs because each section re-runs the
+    // body and would register the same id twice.
+    const std::string id = "orca-test::registry-probe-7f3a";
+    auto stub_factory = [](std::shared_ptr<ICloudServiceAgent>, const std::string&)
+        -> std::shared_ptr<IPrinterAgent> { return nullptr; };
+
+    REQUIRE_FALSE(NetworkAgentFactory::is_printer_agent_registered(id));
+
+    REQUIRE(NetworkAgentFactory::register_printer_agent(id, "Registry Probe", stub_factory));
+    REQUIRE(NetworkAgentFactory::is_printer_agent_registered(id));
+
+    // Re-registering the same id is rejected and does not replace the entry.
+    REQUIRE_FALSE(NetworkAgentFactory::register_printer_agent(id, "Impostor", stub_factory));
+
+    // The first registration's display name survives the rejected duplicate.
+    const PrinterAgentInfo* info = NetworkAgentFactory::get_printer_agent_info(id);
+    REQUIRE(info != nullptr);
+    CHECK(info->display_name == "Registry Probe");
+
+    // It appears exactly once in the UI-population list.
+    auto agents = NetworkAgentFactory::get_registered_printer_agents();
+    int  count  = 0;
+    for (const auto& a : agents)
+        if (a.id == id)
+            ++count;
+    CHECK(count == 1);
+}
+
+// ===========================================================================
+// INTEGRATION - the orca.printer_agent Python binding surface.
+// Boots the embedded interpreter and asserts the C++ to Python contract that
+// every printer-agent plugin subclasses. If a binding is renamed or removed,
+// plugins fail at runtime even though C++ still compiles.
+// ===========================================================================
+namespace {
+
+void ensure_python_initialized()
+{
+    // why: the `orca` module is embedded in this binary, so a bare interpreter
+    // can import it without a bundled Python home. The app interpreter expects
+    // that deployed layout, which is not present beside this test binary.
+    if (!Py_IsInitialized()) {
+        static py::scoped_interpreter interpreter;
+        (void) interpreter;
+    }
+}
+
+py::module_ import_orca_module()
+{
+    ensure_python_initialized();
+    // Force PythonPluginBridge.cpp into the binary so the embedded
+    // PYBIND11_EMBEDDED_MODULE(orca, ...) registration (incl. printer_agent) exists.
+    (void) Slic3r::PythonPluginBridge::instance();
+    return py::module_::import("orca");
+}
+
+} // namespace
+
+TEST_CASE("integration: orca.printer_agent binding surface", "[integration][Python]")
+{
+    py::module_ orca = import_orca_module();
+
+    REQUIRE(py::hasattr(orca, "printer_agent"));
+    py::object pa = orca.attr("printer_agent");
+
+    // The base class every printer-agent plugin subclasses.
+    REQUIRE(py::hasattr(pa, "PrinterAgentBase"));
+    py::object base = pa.attr("PrinterAgentBase");
+    for (const char* method : { "get_agent_info", "connect_printer", "disconnect_printer",
+                                "send_message", "start_discovery", "bind_detect",
+                                "start_print", "get_filament_sync_mode" }) {
+        CAPTURE(method);
+        CHECK(py::hasattr(base, method));
+    }
+
+    // AgentInfo value type - the registry identity the host reads (id is the key).
+    REQUIRE(py::hasattr(pa, "AgentInfo"));
+    py::object info = pa.attr("AgentInfo")("moonraker", "Moonraker", "1.0", "test agent");
+    CHECK(info.attr("id").cast<std::string>() == "moonraker");
+    CHECK(info.attr("name").cast<std::string>() == "Moonraker");
+
+    // FilamentSyncMode enum the host queries to pick pull vs subscription.
+    REQUIRE(py::hasattr(pa, "FilamentSyncMode"));
+    py::object mode = pa.attr("FilamentSyncMode");
+    CHECK(py::hasattr(mode, "Pull"));
+    CHECK(py::hasattr(mode, "Subscription"));
+    CHECK(py::hasattr(mode, "None_"));
+
+    // Plugin-type enum exposed at module root (host reads it without the GIL).
+    CHECK(py::hasattr(orca, "PluginType"));
+}
+
+// ===========================================================================
+// INTEGRATION - plugin-registration API and discovery-context guards.
+// These are the symbols every plugin package uses: the @orca.plugin decorator,
+// orca.base, orca.register_capability, and the capability base modules. Checking
+// them in the lightweight embedded-interpreter test catches binding breakage
+// before the plugin-loader test needs to run.
+// ===========================================================================
+TEST_CASE("integration: orca plugin-registration API surface + discovery-context guards", "[integration][Python]")
+{
+    py::module_ orca = import_orca_module();
+
+    // Module-level surface every plugin package relies on.
+    // note: no "gcode" module here - this branch has no G-code capability module;
+    // PostProcessing exists only as a PluginType value.
+    for (const char* name : { "plugin", "register_capability", "base", "PythonPluginBase",
+                              "PluginType", "PluginResult", "script", "printer_agent", "host" }) {
+        CAPTURE(name);
+        CHECK(py::hasattr(orca, name));
+    }
+
+    // Plugin package base and capability base contract.
+    CHECK(py::hasattr(orca.attr("base"), "register_capabilities"));
+    py::object cap_base = orca.attr("PythonPluginBase");
+    for (const char* method : { "get_name", "get_type", "on_load", "on_unload" }) {
+        CAPTURE(method);
+        CHECK(py::hasattr(cap_base, method));
+    }
+
+    // The script capability module exposes its own base class.
+    CHECK(py::hasattr(orca.attr("script"), "ScriptPluginCapabilityBase"));
+
+    // PluginType enum carries the values that route a capability, including PrinterConnection.
+    // note: no PostProcessing value on this branch's binding.
+    py::object types = orca.attr("PluginType");
+    for (const char* value : { "PrinterConnection", "Script" }) {
+        CAPTURE(value);
+        CHECK(py::hasattr(types, value));
+    }
+
+    // note: this is testing behavior, not normal plugin loading.
+    // These APIs should only work while Orca is actively loading a plugin.
+    try {
+        // Calls Python's orca.register_capability(0) from C++.
+        // 0 is intentionally bogus. The important part is that there is no active
+        // plugin load context, so the function should reject the call immediately.
+        orca.attr("register_capability")(py::int_(0));
+
+        // If the call above does NOT throw, the test fails here.
+        FAIL("register_capability outside discovery context must raise");
+    } catch (const py::error_already_set& error) {
+        // pybind11 wraps Python exceptions as py::error_already_set.
+        // This checks the Python exception type is ValueError.
+        CHECK(error.matches(PyExc_ValueError));
+    }
+
+    try {
+        // This is the function behind @orca.plugin.
+        // Same logic as above.
+        orca.attr("plugin")(py::int_(0));
+
+        FAIL("@orca.plugin outside discovery context must raise");
+    } catch (const py::error_already_set& error) {
+        CHECK(error.matches(PyExc_ValueError));
+    }
+}

--- a/tests/slic3rutils/test_printer_agent_plugin.cpp
+++ b/tests/slic3rutils/test_printer_agent_plugin.cpp
@@ -1,0 +1,414 @@
+#include <catch2/catch_all.hpp>
+
+#include <slic3r/plugin/PluginManager.hpp>
+#include <slic3r/Utils/NetworkAgentFactory.hpp>
+#include <libslic3r/Utils.hpp> // for set_data_dir
+
+#include <boost/filesystem.hpp>
+#include <boost/system/error_code.hpp>
+
+#include <catch2/catch_session.hpp>
+
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <string>
+
+using namespace Slic3r;
+namespace fs = boost::filesystem;
+
+namespace {
+
+// why: embedding the fake plugin keeps this test self-contained. The PEP 723
+// block declares a printer-connection plugin, and the decorated plugin package
+// registers one PrinterAgentBase capability whose AgentInfo.id is the registry
+// key asserted below.
+constexpr const char* kFakePluginSource = R"PY(# /// script
+# requires-python = ">=3.12"
+# dependencies = []
+#
+# [tool.orcaslicer.plugin]
+# name = "Lifecycle Test Agent"
+# description = "Minimal printer-agent plugin for the lifecycle test."
+# author = "tests"
+# version = "1.0.0"
+# type = "printer-connection"
+# ///
+import orca
+
+
+class LifecycleTestAgentCapability(orca.printer_agent.PrinterAgentBase):
+    def get_name(self):
+        return "Lifecycle Test Agent"
+
+    def get_agent_info(self):
+        return orca.printer_agent.AgentInfo(
+            id="lifecycle-test-agent",
+            name="Lifecycle Test Agent",
+            version="1.0.0",
+            description="Lifecycle test printer agent",
+        )
+
+
+@orca.plugin
+class LifecycleTestPlugin(orca.base):
+    def register_capabilities(self):
+        orca.register_capability(LifecycleTestAgentCapability)
+)PY";
+
+// why: in production GUI_App::init_plugin_gui_wiring subscribes the agent-registry
+// callbacks; the test binary has no GUI, so install the same UNLOAD-side wiring
+// once so the tests exercise the production deregister-on-unload path.
+// note: the load-side (register) wiring is deliberately NOT installed - the two
+// concurrent load_plugin calls in the duplicate-id test would race for the id;
+// the tests register manually, in a deterministic order, instead.
+void install_agent_registry_wiring()
+{
+    static bool installed = false;
+    if (installed)
+        return;
+    installed = true;
+
+    PluginManager& mgr = PluginManager::instance();
+    mgr.subscribe_on_unload_callback(NetworkAgentFactory::deregister_python_plugin);
+    mgr.subscribe_on_capability_unload_callback([](const PluginCapabilityId& capability) {
+        if (capability.type == PluginCapabilityType::PrinterConnection)
+            NetworkAgentFactory::deregister_python_printer_agent(capability.plugin_key, capability.name);
+    });
+}
+
+} // namespace
+
+// ===========================================================================
+// PRINTER-AGENT PLUGIN LIFECYCLE: load, register, unload, deregister.
+//
+// This test uses its own executable because load_plugin runs on a detached worker
+// thread that needs the GIL released on the main thread (the PythonInterpreter
+// model). slic3rutils_tests' other Python tests hold the GIL on the main thread
+// via a bare scoped_interpreter; the two models can't share one process.
+//
+// When bundled Python is unavailable in the test environment, the test is
+// skipped so source-only or partially staged builds can still run the rest of
+// the suite.
+// ===========================================================================
+TEST_CASE("plugin lifecycle: printer-agent load registers and unload deregisters", "[plugin][lifecycle][Python]")
+{
+    const std::string plugin_key = "LifecycleTestAgent";   // entry-file stem
+    const std::string agent_id   = "lifecycle-test-agent"; // AgentInfo.id from the plugin
+
+    // Stage a throwaway data directory. Plugins are discovered under
+    // <data_dir>/orca_plugins, so this controls which plugin is loaded.
+    const fs::path data_dir   = fs::temp_directory_path() / "orca-plugin-lifecycle-test";
+    const fs::path plugin_dir = data_dir / "orca_plugins" / plugin_key;
+    {
+        boost::system::error_code ec;
+        fs::remove_all(data_dir, ec); // clear any stale run
+    }
+    fs::create_directories(plugin_dir);
+    {
+        std::ofstream out((plugin_dir / (plugin_key + ".py")).string(), std::ios::binary);
+        out << kFakePluginSource;
+    }
+    // why: best-effort cleanup even if an assertion throws.
+    struct DirGuard
+    {
+        fs::path p;
+        ~DirGuard()
+        {
+            boost::system::error_code ec;
+            fs::remove_all(p, ec);
+        }
+    } guard{data_dir};
+
+    Slic3r::set_data_dir(data_dir.string());
+
+    // Initialize the plugin system on this thread. If the bundled Python home
+    // is not reachable, skip gracefully.
+    PluginManager& mgr = PluginManager::instance();
+    if (!mgr.initialize())
+        SKIP("PythonInterpreter could not initialize (bundled Python home not found in this environment)");
+    install_agent_registry_wiring();
+
+    // Discover synchronously so the catalog holds the descriptor before loading.
+    mgr.discover_plugins(/*async=*/false, /*clear=*/true);
+    INFO("expected plugin_key (entry-file stem): " << plugin_key);
+    PluginDescriptor descriptor;
+    REQUIRE(mgr.try_get_valid_plugin_descriptor(plugin_key, descriptor));
+
+    // Load on the worker thread and block until it finishes.
+    std::string error;
+    mgr.load_plugin(plugin_key, /*skip_deps=*/true);
+    const bool loaded = mgr.wait_for_plugin_load(plugin_key, std::chrono::seconds(60), error);
+    INFO("plugin load error: " << error);
+    REQUIRE(loaded);
+    REQUIRE(mgr.is_plugin_loaded(plugin_key));
+
+    // Resolve the one PrinterConnection capability and register it as an agent.
+    auto caps = mgr.get_plugin_capabilities(plugin_key, PluginCapabilityType::PrinterConnection);
+    REQUIRE(caps.size() == 1);
+    REQUIRE(caps[0] != nullptr);
+    NetworkAgentFactory::register_python_printer_agent(plugin_key, caps[0]->name());
+
+    // The AgentInfo.id returned by the plugin is now in the registry.
+    CHECK(NetworkAgentFactory::is_printer_agent_registered(agent_id));
+
+    // Unloading the plugin deregisters its Python-backed agent.
+    REQUIRE(mgr.unload_plugin(plugin_key));
+
+    // The registry no longer contains the agent id after unload.
+    CHECK_FALSE(NetworkAgentFactory::is_printer_agent_registered(agent_id));
+}
+
+namespace {
+
+// why: duplicate-id coverage needs two distinct plugins with different package
+// keys and classes while both return the same AgentInfo.id.
+std::string make_agent_plugin_source(const std::string& suffix, const std::string& display_name, const std::string& agent_id)
+{
+    return std::string{}
+        + "# /// script\n"
+        + "# requires-python = \">=3.12\"\n"
+        + "# dependencies = []\n"
+        + "#\n"
+        + "# [tool.orcaslicer.plugin]\n"
+        + "# name = \"" + display_name + "\"\n"
+        + "# description = \"Duplicate-id fake printer-agent plugin.\"\n"
+        + "# author = \"tests\"\n"
+        + "# version = \"1.0.0\"\n"
+        + "# type = \"printer-connection\"\n"
+        + "# ///\n"
+        + "import orca\n"
+        + "\n\n"
+        + "class Cap" + suffix + "(orca.printer_agent.PrinterAgentBase):\n"
+        + "    def get_name(self):\n"
+        + "        return \"" + display_name + "\"\n"
+        + "\n"
+        + "    def get_agent_info(self):\n"
+        + "        return orca.printer_agent.AgentInfo(\n"
+        + "            id=\"" + agent_id + "\", name=\"" + display_name + "\",\n"
+        + "            version=\"1.0.0\", description=\"duplicate id test\")\n"
+        + "\n\n"
+        + "@orca.plugin\n"
+        + "class Plugin" + suffix + "(orca.base):\n"
+        + "    def register_capabilities(self):\n"
+        + "        orca.register_capability(Cap" + suffix + ")\n";
+}
+
+void stage_plugin(const fs::path& data_dir, const std::string& plugin_key, const std::string& source)
+{
+    const fs::path dir = data_dir / "orca_plugins" / plugin_key;
+    fs::create_directories(dir);
+    std::ofstream out((dir / (plugin_key + ".py")).string(), std::ios::binary);
+    out << source;
+}
+
+} // namespace
+
+// ===========================================================================
+// DUPLICATE PRINTER-AGENT IDS
+// When two loaded plugins return the same AgentInfo.id, the first registration
+// keeps ownership. Unloading it removes the id, and the rejected plugin is not
+// promoted automatically. Manual re-registration is required.
+// ===========================================================================
+TEST_CASE("duplicate agent id is rejected and the winner is not clobbered", "[plugin][lifecycle][Python]")
+{
+    const std::string key_a  = "DuplicateIdAgentA"; // winner, registered first
+    const std::string key_b  = "DuplicateIdAgentB"; // duplicate, rejected
+    const std::string dup_id = "duplicate-id-agent"; // both plugins return this AgentInfo.id
+
+    const fs::path data_dir = fs::temp_directory_path() / "orca-duplicate-agent-test";
+    {
+        boost::system::error_code ec;
+        fs::remove_all(data_dir, ec);
+    }
+    stage_plugin(data_dir, key_a, make_agent_plugin_source("A", "Duplicate Id Agent A", dup_id));
+    stage_plugin(data_dir, key_b, make_agent_plugin_source("B", "Duplicate Id Agent B", dup_id));
+    struct DirGuard
+    {
+        fs::path p;
+        ~DirGuard()
+        {
+            boost::system::error_code ec;
+            fs::remove_all(p, ec);
+        }
+    } guard{data_dir};
+
+    Slic3r::set_data_dir(data_dir.string());
+
+    PluginManager& mgr = PluginManager::instance();
+    if (!mgr.initialize())
+        SKIP("PythonInterpreter could not initialize (bundled Python home not found in this environment)");
+    install_agent_registry_wiring();
+
+    mgr.discover_plugins(/*async=*/false, /*clear=*/true);
+    PluginDescriptor descriptor_a;
+    PluginDescriptor descriptor_b;
+    REQUIRE(mgr.try_get_valid_plugin_descriptor(key_a, descriptor_a));
+    REQUIRE(mgr.try_get_valid_plugin_descriptor(key_b, descriptor_b));
+
+    std::string error;
+    mgr.load_plugin(key_a, /*skip_deps=*/true);
+    mgr.load_plugin(key_b, /*skip_deps=*/true);
+    const bool loaded_a = mgr.wait_for_plugin_load(key_a, std::chrono::seconds(60), error);
+    INFO("plugin A load error: " << error);
+    REQUIRE(loaded_a);
+    const bool loaded_b = mgr.wait_for_plugin_load(key_b, std::chrono::seconds(60), error);
+    INFO("plugin B load error: " << error);
+    REQUIRE(loaded_b);
+
+    auto caps_a = mgr.get_plugin_capabilities(key_a, PluginCapabilityType::PrinterConnection);
+    auto caps_b = mgr.get_plugin_capabilities(key_b, PluginCapabilityType::PrinterConnection);
+    REQUIRE(caps_a.size() == 1);
+    REQUIRE(caps_b.size() == 1);
+
+    // Register A first as the owner, then B with the duplicate id.
+    NetworkAgentFactory::register_python_printer_agent(key_a, caps_a[0]->name());
+    NetworkAgentFactory::register_python_printer_agent(key_b, caps_b[0]->name());
+
+    // The shared id is registered, and still owned by A; B did not replace it.
+    CHECK(NetworkAgentFactory::is_printer_agent_registered(dup_id));
+    const PrinterAgentInfo* info = NetworkAgentFactory::get_printer_agent_info(dup_id);
+    REQUIRE(info != nullptr);
+    CHECK(info->plugin_identifier.find(key_a) != std::string::npos); // owned by A
+    CHECK(info->plugin_identifier.find(key_b) == std::string::npos); // B never took ownership
+
+    // Unload the owner. The id is not promoted to the still loaded duplicate.
+    REQUIRE(mgr.unload_plugin(key_a));
+    CHECK_FALSE(NetworkAgentFactory::is_printer_agent_registered(dup_id));
+
+    mgr.unload_plugin(key_b); // the duplicate was loaded but never registered
+}
+
+// ===========================================================================
+// NATIVE (BUILT-IN) AGENT ID COLLISION
+// A plugin may not hijack a built-in agent id (e.g. "bbl"). The built-in keeps
+// ownership and the plugin's agent is rejected.
+// ===========================================================================
+TEST_CASE("printer-agent plugin cannot claim a built-in agent id", "[plugin][lifecycle][Python]")
+{
+    // Register the native built-ins so "bbl"/"orca" occupy the registry.
+    NetworkAgentFactory::register_all_agents();
+    REQUIRE(NetworkAgentFactory::is_printer_agent_registered(BBL_PRINTER_AGENT_ID));
+
+    const std::string plugin_key = "BuiltinClashAgent";
+
+    const fs::path data_dir = fs::temp_directory_path() / "orca-builtin-clash-test";
+    {
+        boost::system::error_code ec;
+        fs::remove_all(data_dir, ec);
+    }
+    stage_plugin(data_dir, plugin_key, make_agent_plugin_source("Clash", "Builtin Clash", BBL_PRINTER_AGENT_ID));
+    struct DirGuard
+    {
+        fs::path p;
+        ~DirGuard()
+        {
+            boost::system::error_code ec;
+            fs::remove_all(p, ec);
+        }
+    } guard{data_dir};
+
+    Slic3r::set_data_dir(data_dir.string());
+
+    PluginManager& mgr = PluginManager::instance();
+    if (!mgr.initialize())
+        SKIP("PythonInterpreter could not initialize (bundled Python home not found in this environment)");
+    install_agent_registry_wiring();
+
+    mgr.discover_plugins(/*async=*/false, /*clear=*/true);
+    PluginDescriptor descriptor;
+    REQUIRE(mgr.try_get_valid_plugin_descriptor(plugin_key, descriptor));
+
+    std::string error;
+    mgr.load_plugin(plugin_key, /*skip_deps=*/true);
+    REQUIRE(mgr.wait_for_plugin_load(plugin_key, std::chrono::seconds(60), error));
+
+    auto caps = mgr.get_plugin_capabilities(plugin_key, PluginCapabilityType::PrinterConnection);
+    REQUIRE(caps.size() == 1);
+    NetworkAgentFactory::register_python_printer_agent(plugin_key, caps[0]->name());
+
+    // "bbl" is still the native built-in, not the plugin.
+    const PrinterAgentInfo* info = NetworkAgentFactory::get_printer_agent_info(BBL_PRINTER_AGENT_ID);
+    REQUIRE(info != nullptr);
+    CHECK_FALSE(info->is_plugin());
+    CHECK(info->plugin_identifier.find(plugin_key) == std::string::npos);
+
+    mgr.unload_plugin(plugin_key);
+}
+
+// ===========================================================================
+// RE-REGISTERING THE SAME CAPABILITY IS A REFRESH, NOT A DUPLICATE
+// The guard rejects only a DIFFERENT owner. The same capability registering its
+// own id again must stay registered (insert_or_assign refreshes it in place).
+// ===========================================================================
+TEST_CASE("re-registering the same capability keeps its agent registered", "[plugin][lifecycle][Python]")
+{
+    const std::string plugin_key = "ReRegisterAgent";
+    const std::string agent_id   = "re-register-agent";
+
+    const fs::path data_dir = fs::temp_directory_path() / "orca-re-register-test";
+    {
+        boost::system::error_code ec;
+        fs::remove_all(data_dir, ec);
+    }
+    stage_plugin(data_dir, plugin_key, make_agent_plugin_source("Re", "Re Register", agent_id));
+    struct DirGuard
+    {
+        fs::path p;
+        ~DirGuard()
+        {
+            boost::system::error_code ec;
+            fs::remove_all(p, ec);
+        }
+    } guard{data_dir};
+
+    Slic3r::set_data_dir(data_dir.string());
+
+    PluginManager& mgr = PluginManager::instance();
+    if (!mgr.initialize())
+        SKIP("PythonInterpreter could not initialize (bundled Python home not found in this environment)");
+    install_agent_registry_wiring();
+
+    mgr.discover_plugins(/*async=*/false, /*clear=*/true);
+    PluginDescriptor descriptor;
+    REQUIRE(mgr.try_get_valid_plugin_descriptor(plugin_key, descriptor));
+
+    std::string error;
+    mgr.load_plugin(plugin_key, /*skip_deps=*/true);
+    REQUIRE(mgr.wait_for_plugin_load(plugin_key, std::chrono::seconds(60), error));
+
+    auto caps = mgr.get_plugin_capabilities(plugin_key, PluginCapabilityType::PrinterConnection);
+    REQUIRE(caps.size() == 1);
+
+    NetworkAgentFactory::register_python_printer_agent(plugin_key, caps[0]->name());
+    REQUIRE(NetworkAgentFactory::is_printer_agent_registered(agent_id));
+    const PrinterAgentInfo* first = NetworkAgentFactory::get_printer_agent_info(agent_id);
+    REQUIRE(first != nullptr);
+    const std::string owner = first->plugin_identifier;
+
+    // The same capability registering again is a refresh: still registered, same owner, not rejected.
+    NetworkAgentFactory::register_python_printer_agent(plugin_key, caps[0]->name());
+    CHECK(NetworkAgentFactory::is_printer_agent_registered(agent_id));
+    const PrinterAgentInfo* second = NetworkAgentFactory::get_printer_agent_info(agent_id);
+    REQUIRE(second != nullptr);
+    CHECK(second->plugin_identifier == owner);
+
+    mgr.unload_plugin(plugin_key);
+}
+
+// why: this binary embeds CPython through the PythonInterpreter singleton, which
+// lives for the full process. Normal static destruction can tear Python down
+// while C++ objects still hold Python handles, producing a Windows heap
+// corruption after the assertions have finished. The app has an ordered shutdown
+// path; this test harness does not, so it returns the Catch2 result through
+// _Exit after flushing output.
+int main(int argc, char* argv[])
+{
+    const int result = Catch::Session().run(argc, argv);
+    std::cout.flush();
+    std::cerr.flush();
+    std::fflush(nullptr);
+    std::_Exit(result);
+}


### PR DESCRIPTION
# Description

## Problem

The Python plugin and printer-agent base lets OrcaSlicer talk to non-Bambu printers, but the UI still split routing in a few places:

- Bambu network printers used the native Device tab and machine selection dialog.
- Non-Bambu presets used the old print-host send/export paths and optional web UI loading.

An agent-backed printer could still be handled like a classic print host. This PR routes send, print, and Device-tab behavior through printer-agent mode behind one experimental app setting.

## What changed

- Add `use_printer_agents`, defaulting to false, with a Developer preference checkbox. Toggling it rebuilds the Device tab.
- When enabled, route print and send entry points through the printer-agent flow instead of the old send-G-code path.
- Keep the native Device tab active in printer-agent mode instead of loading a print-host web UI.
- Stop using `NetworkAgentFactory::is_current_printer_agent_plugin()` for these UI routing decisions. The app preference now controls the behavior, not the current preset's `printer_agent` value.
- Make Qidi print starts send multi-color box state before the job starts. `enable_box` follows `task_use_ams`, and mapped filaments write the matching `value_t<tool>` slot through Moonraker G-code.
- Expose Moonraker `send_gcode()` so Qidi can send those setup commands.
- Finalize the option spelling as `use_printer_agents`.

## Behavior boundary

The printer-agent routing is off by default, so classic print-host routing should stay on the old path unless the setting is enabled. With the setting enabled, routing is app-wide. Mixed print-host and printer-agent workflows need separate review if they become supported.

# Screenshots/Recordings/Graphs

<img width="500" alt="image" src="https://github.com/user-attachments/assets/da340f0c-f077-438d-b39f-2fef9fff991b" />

TODO: Developer preference checkbox, plus the Device tab switching to the native printer-agent view after toggling the setting.

## Tests

Smoke-tested the platform path:

- With `use_printer_agents=false`, non-Bambu print-host presets stay on the old send/export flow.
- With `use_printer_agents=true`, print actions route through printer-agent mode and the Device tab stays native.
- For Qidi AMS mapping, print start sends the expected `SAVE_VARIABLE enable_box` and `value_t<tool>` commands before the job starts.

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)