### PR TITLE
Fix Windows camera deadlock on hybrid-GPU systems

### DIFF
--- a/src/OrcaSlicer_app_msvc.cpp
+++ b/src/OrcaSlicer_app_msvc.cpp
@@ -12,10 +12,9 @@
 #ifdef SLIC3R_GUI
 extern "C"
 {
-    // Let the NVIDIA and AMD know we want to use their graphics card
-    // on a dual graphics card system.
-    __declspec(dllexport) DWORD NvOptimusEnablement = 0x00000001;
-    __declspec(dllexport) int AmdPowerXpressRequestHighPerformance = 1;
+    // Avoid forcing the discrete GPU because WMP/EVR live view may deadlock on hybrid-GPU systems.
+    __declspec(dllexport) DWORD NvOptimusEnablement = 0x00000000;
+    __declspec(dllexport) int AmdPowerXpressRequestHighPerformance = 0;
 }
 #endif /* SLIC3R_GUI */
 


### PR DESCRIPTION
# Description

Fixes #13023.

The Windows GUI launcher currently exports `NvOptimusEnablement = 1` and `AmdPowerXpressRequestHighPerformance = 1`, forcing the high-performance GPU before the application and WMP/EVR media backend initialize.

On an affected Intel + NVIDIA hybrid-GPU system, starting a Bambu P1S LAN-only camera blocks the WMP/EVR graph while allocating the DXVA2 video processor. The observed blocked stack was:

```
D3D9!CDxva2Container::GetVideoProcessorRenderTargetCount
DXVA2!CVideoAccelerationService::GetVideoProcessorRenderTargets
evr!CMFVideoMixer9::AllocateResources
evr!CEVRFilter::StartStreaming
quartz!CFilterGraph::Pause
```

This restores the GPU preference values used before the regression, avoiding the forced discrete-GPU path that deadlocks EVR on the affected hybrid system. It does not change printer discovery, LAN-only connection handling, network plug-in behavior, camera URLs, or vendor-specific camera code.

There are no new dependencies or breaking API changes.

# Screenshots/Recordings/Graphs

No UI changes.

- Before: the current official Windows x64 nightly remains on a black camera frame and becomes unresponsive immediately after pressing Play.
- After: the patched build displays the live P1S camera stream and remains responsive.

## Tests

- Configured and built current `main` (`33909a51cd064c45bde8e6719c606210c9c4087c`) with Visual Studio 2022, Windows x64 Release, target `ALL_BUILD`.
- Reproduced the freeze with the official Windows x64 nightly updated on 2026-07-17: the printer connects normally, but pressing camera Play leaves a black frame and the process reports `Responding=False`.
- Tested the patched build with the same printer and configuration: live video starts successfully and the process remains responsive after more than 20 seconds of playback.
- Test environment: Windows 11, Intel + NVIDIA hybrid graphics, Bambu P1S, Developer Mode, LAN-only connection, firmware `01.09.01.00`, network plug-in `v02.03.00.62`.
- `git diff --check origin/main...HEAD` passes.