### PR TITLE
Fix incorrect filament type showing in BBL AMS (PLA -> ABS)

### DIFF
--- a/src/slic3r/GUI/AMSMaterialsSetting.cpp
+++ b/src/slic3r/GUI/AMSMaterialsSetting.cpp
@@ -537,15 +537,15 @@ void AMSMaterialsSetting::on_select_reset(wxCommandEvent& event) {
 // Nozzle-context builder for the AMS-edit blacklist check. Factors the blacklist evaluation out of
 // on_select_ok and threads rack-gated per-nozzle context (extruder id + nozzle flow + nozzle diameter)
 // into CheckFilamentInfo, returning the accumulate-all CheckResult. As a side effect it resolves
-// ams_filament_id/ams_setting_id from the matched preset. fila_name is kept as the preset name (not
-// the short alias) so the name / name_suffix rules match on the non-rack fleet (no unintended
-// activation of e.g. the PLA Glow rule).
+// ams_filament_id/ams_setting_id from the preset named by preset_name. fila_name is kept as the
+// preset name (not the short alias) so the name / name_suffix rules match on the non-rack fleet (no
+// unintended activation of e.g. the PLA Glow rule).
 static DevFilaBlacklist::CheckResult
 sCheckFilamentInfo(PresetBundle*      preset_bundle,
                    MachineObject*     obj,
                    int                ams_id,
                    int                slot_id,
-                   const std::string& filament_id,
+                   const std::string& preset_name,
                    std::string&       ams_filament_id,
                    std::string&       ams_setting_id)
 {
@@ -553,15 +553,10 @@ sCheckFilamentInfo(PresetBundle*      preset_bundle,
     if (!preset_bundle || !obj)
         return result;
 
-    // Orca: there is no lookup struct that also carries setting_id, so resolve the (root) preset by
-    // scanning the filaments collection for a matching filament_id.
-    Preset* fila_preset = nullptr;
-    for (auto it = preset_bundle->filaments.begin(); it != preset_bundle->filaments.end(); ++it) {
-        if (it->filament_id == filament_id) {
-            fila_preset = &(*it);
-            break;
-        }
-    }
+    // why: filament_id is NOT unique across vendors (several vendor ABS/ASA profiles ship Generic
+    //      PLA's "GFL99"), so a scan for the first filament_id match can resolve a preset of a
+    //      different material type. Look up the exact preset the combo item was built from.
+    Preset* fila_preset = preset_bundle->filaments.find_preset(preset_name);
     if (!fila_preset)
         return result;
 
@@ -629,7 +624,7 @@ void AMSMaterialsSetting::on_select_ok(wxCommandEvent &event)
     // check filament info (rack-gated per-nozzle blacklist evaluation)
     PresetBundle* preset_bundle = wxGetApp().preset_bundle;
     const auto& fila_check_res = sCheckFilamentInfo(preset_bundle, obj, ams_id, slot_id,
-                                                    filament_item.filament_id, ams_filament_id, ams_setting_id);
+                                                    filament_item.preset_name, ams_filament_id, ams_setting_id);
 
     if (const auto& prohibit_items = fila_check_res.get_items_by_action("prohibition"); !prohibit_items.empty()) {
         wxString info_msg;
@@ -971,6 +966,7 @@ void AMSMaterialsSetting::Popup(wxString filament, wxString sn, wxString temp_mi
                             FilamentInfos filament_infos;
                             filament_infos.filament_id             = filament_it->filament_id;
                             filament_infos.setting_id              = filament_it->setting_id;
+                            filament_infos.preset_name             = filament_it->name;
                             map_filament_items[filament_it->alias] = filament_infos;
                         } else {
                             char   target = '@';
@@ -986,6 +982,7 @@ void AMSMaterialsSetting::Popup(wxString filament, wxString sn, wxString temp_mi
                                 FilamentInfos filament_infos;
                                 filament_infos.filament_id            = filament_it->filament_id;
                                 filament_infos.setting_id             = filament_it->setting_id;
+                                filament_infos.preset_name            = filament_it->name;
                                 map_filament_items[user_preset_alias] = filament_infos;
                             }
                         }
@@ -1175,70 +1172,34 @@ void AMSMaterialsSetting::on_select_filament(wxCommandEvent &evt)
 
     m_filament_type = "";
     PresetBundle* preset_bundle = wxGetApp().preset_bundle;
-    if (preset_bundle) {
-        std::ostringstream stream;
-        if (obj) {
-            // Defensive: this dialog is opened only from StatusPanel (BBL-only) today, so the fallback fires
-            // only during the brief BBL startup window before firmware reports nozzle info. Without this,
-            // the "0.0" lookup string returns an empty set and filament lookup yields no results.
-            float machine_diameter = obj->GetExtderSystem()->GetNozzleDiameter(0);
-            if (machine_diameter == 0.0f) {
-                const ConfigOption *opt = preset_bundle->printers.get_selected_preset().config.option("nozzle_diameter");
-                if (opt) machine_diameter = static_cast<const ConfigOptionFloats *>(opt)->values[0];
-            }
-            stream << std::fixed << std::setprecision(1) << machine_diameter;
-        }
-        std::string nozzle_diameter_str = stream.str();
-        std::set<std::string> printer_names = preset_bundle->get_printer_names_by_printer_type_and_nozzle(DevPrinterConfigUtil::get_printer_display_name(obj->printer_type),
-                                                                                                          nozzle_diameter_str);
-        for (auto it = preset_bundle->filaments.begin(); it != preset_bundle->filaments.end(); it++) {
-            if (!m_comboBox_filament->GetValue().IsEmpty()) {
-                auto filament_item = map_filament_items[m_comboBox_filament->GetValue().ToStdString()];
-                std::string filament_id   = filament_item.filament_id;
-                if (it->filament_id.compare(filament_id) == 0) {
-                    ConfigOption *       printer_opt  = it->config.option("compatible_printers");
-                    ConfigOptionStrings *printer_strs = dynamic_cast<ConfigOptionStrings *>(printer_opt);
-                    bool has_compatible_printer = false;
-                    for (auto printer_str : printer_strs->values) {
-                        if (printer_names.find(printer_str) != printer_names.end()) {
-                            has_compatible_printer = true;
-                            break;
-                        }
-                    }
-                    if (!it->is_system && !has_compatible_printer) continue;
-                    // ) if nozzle_temperature_range is found
-                    ConfigOption* opt_min = it->config.option("nozzle_temperature_range_low");
-                    if (opt_min) {
-                        ConfigOptionInts* opt_min_ints = dynamic_cast<ConfigOptionInts*>(opt_min);
-                        if (opt_min_ints) {
-                            wxString text_nozzle_temp_min = wxString::Format("%d", opt_min_ints->get_at(0));
-                            m_input_nozzle_min->GetTextCtrl()->SetValue(text_nozzle_temp_min);
-                        }
-                    }
-                    ConfigOption* opt_max = it->config.option("nozzle_temperature_range_high");
-                    if (opt_max) {
-                        ConfigOptionInts* opt_max_ints = dynamic_cast<ConfigOptionInts*>(opt_max);
-                        if (opt_max_ints) {
-                            wxString text_nozzle_temp_max = wxString::Format("%d", opt_max_ints->get_at(0));
-                            m_input_nozzle_max->GetTextCtrl()->SetValue(text_nozzle_temp_max);
-                        }
-                    }
-                    ConfigOption* opt_type = it->config.option("filament_type");
-                    bool found_filament_type = false;
-                    if (opt_type) {
-                        ConfigOptionStrings* opt_type_strs = dynamic_cast<ConfigOptionStrings*>(opt_type);
-                        if (opt_type_strs) {
-                            found_filament_type = true;
-                            //m_filament_type = opt_type_strs->get_at(0);
-                            std::string display_filament_type;
-                            m_filament_type = it->config.get_filament_type(display_filament_type);
-                        }
-                    }
-                    if (!found_filament_type)
-                        m_filament_type = "";
-
-                    break;
+    if (preset_bundle && !m_comboBox_filament->GetValue().IsEmpty()) {
+        // filament_id is not unique across vendor profiles (see FilamentInfos::preset_name),
+        // so resolve the exact preset recorded when the combo was populated.
+        auto item = map_filament_items.find(m_comboBox_filament->GetValue().ToStdString());
+        Preset* preset = item != map_filament_items.end() ? preset_bundle->filaments.find_preset(item->second.preset_name) : nullptr;
+        if (preset) {
+            // ) if nozzle_temperature_range is found
+            ConfigOption* opt_min = preset->config.option("nozzle_temperature_range_low");
+            if (opt_min) {
+                ConfigOptionInts* opt_min_ints = dynamic_cast<ConfigOptionInts*>(opt_min);
+                if (opt_min_ints) {
+                    wxString text_nozzle_temp_min = wxString::Format("%d", opt_min_ints->get_at(0));
+                    m_input_nozzle_min->GetTextCtrl()->SetValue(text_nozzle_temp_min);
                 }
+            }
+            ConfigOption* opt_max = preset->config.option("nozzle_temperature_range_high");
+            if (opt_max) {
+                ConfigOptionInts* opt_max_ints = dynamic_cast<ConfigOptionInts*>(opt_max);
+                if (opt_max_ints) {
+                    wxString text_nozzle_temp_max = wxString::Format("%d", opt_max_ints->get_at(0));
+                    m_input_nozzle_max->GetTextCtrl()->SetValue(text_nozzle_temp_max);
+                }
+            }
+            ConfigOption* opt_type = preset->config.option("filament_type");
+            if (opt_type && dynamic_cast<ConfigOptionStrings*>(opt_type)) {
+                //m_filament_type = opt_type_strs->get_at(0);
+                std::string display_filament_type;
+                m_filament_type = preset->config.get_filament_type(display_filament_type);
             }
         }
     }

--- a/src/slic3r/GUI/AMSMaterialsSetting.cpp
+++ b/src/slic3r/GUI/AMSMaterialsSetting.cpp
@@ -476,8 +476,8 @@ void AMSMaterialsSetting::on_select_reset(wxCommandEvent& event) {
     PresetBundle *preset_bundle = wxGetApp().preset_bundle;
     if (preset_bundle) {
         for (auto it = preset_bundle->filaments.begin(); it != preset_bundle->filaments.end(); it++) {
-            auto        filament_item = map_filament_items[m_comboBox_filament->GetValue().ToStdString()];
-            std::string filament_id   = filament_item.filament_id;
+            int         sel          = m_comboBox_filament->GetSelection();
+            std::string filament_id  = (sel >= 0 && sel < (int) m_filament_infos.size()) ? m_filament_infos[sel].filament_id : std::string();
             if (it->filament_id.compare(filament_id) == 0) {
                 selected_ams_id = it->filament_id;
                 break;
@@ -556,7 +556,8 @@ sCheckFilamentInfo(PresetBundle*      preset_bundle,
     // why: filament_id is NOT unique across vendors (several vendor ABS/ASA profiles ship Generic
     //      PLA's "GFL99"), so a scan for the first filament_id match can resolve a preset of a
     //      different material type. Look up the exact preset the combo item was built from.
-    Preset* fila_preset = preset_bundle->filaments.find_preset(preset_name);
+    // note: real=true so an unsaved edit to the currently-selected filament doesn't leak in via m_edited_preset.
+    Preset* fila_preset = preset_bundle->filaments.find_preset(preset_name, false, true);
     if (!fila_preset)
         return result;
 
@@ -618,8 +619,9 @@ void AMSMaterialsSetting::on_select_ok(wxCommandEvent &event)
     ams_filament_id = "";
     ams_setting_id = "";
 
-    // the combobox item
-    auto filament_item = map_filament_items[m_comboBox_filament->GetValue().ToStdString()];
+    // the combobox item - keyed by selection index, not the (possibly duplicated) alias text
+    int sel = m_comboBox_filament->GetSelection();
+    FilamentInfos filament_item = (sel >= 0 && sel < (int) m_filament_infos.size()) ? m_filament_infos[sel] : FilamentInfos();
 
     // check filament info (rack-gated per-nozzle blacklist evaluation)
     PresetBundle* preset_bundle = wxGetApp().preset_bundle;
@@ -916,14 +918,20 @@ void AMSMaterialsSetting::Popup(wxString filament, wxString sn, wxString temp_mi
     m_input_k_val->GetTextCtrl()->SetValue(k);
     m_input_n_val->GetTextCtrl()->SetValue(n);
 
-    int idx = 0;
     wxArrayString filament_items;
     wxString bambu_filament_name;
     wxString hint_filament_name; // the hint type to be selected
+    std::string hint_preset_name;
     std::unordered_map<wxString, wxString> query_filament_vendors;// some information for sort
     std::unordered_map<wxString, wxString> query_filament_types;  //
 
-    std::set<std::string> filament_id_set;
+    // why: keyed on preset name, not filament_id - filament_id (e.g. "GFL99") is shared across
+    //      vendors/materials, so deduping on it drops distinct presets from the dropdown. Preset
+    //      names are unique in the collection, so this still collapses the same preset being
+    //      matched twice (e.g. a duplicated compatible_printers entry).
+    std::set<std::string> seen_preset_names;
+    // why: repopulated every Popup() call; must match filament_items index-for-index (see below).
+    m_filament_infos.clear();
     PresetBundle *        preset_bundle = wxGetApp().preset_bundle;
     std::ostringstream    stream;
     // Defensive: this dialog is opened only from StatusPanel (BBL-only) today, so the fallback fires
@@ -937,6 +945,11 @@ void AMSMaterialsSetting::Popup(wxString filament, wxString sn, wxString temp_mi
     stream << std::fixed << std::setprecision(1) << machine_diameter;
     std::string nozzle_diameter_str = stream.str();
     std::set<std::string> printer_names = preset_bundle->get_printer_names_by_printer_type_and_nozzle(DevPrinterConfigUtil::get_printer_display_name(obj->printer_type), nozzle_diameter_str);
+    std::string tray_filament_type;
+    const std::string ams_id_str  = std::to_string(ams_id);
+    const std::string slot_id_str = std::to_string(slot_id);
+    if (obj->contains_tray(ams_id_str, slot_id_str))
+        tray_filament_type = obj->get_filament_type(ams_id_str, slot_id_str);
 
     if (preset_bundle) {
         BOOST_LOG_TRIVIAL(trace) << "system_preset_bundle filament number=" << preset_bundle->filaments.size();
@@ -954,10 +967,10 @@ void AMSMaterialsSetting::Popup(wxString filament, wxString sn, wxString temp_mi
             ConfigOptionStrings *printer_strs = dynamic_cast<ConfigOptionStrings *>(printer_opt);
             for (auto printer_str : printer_strs->values) {
                 if (printer_names.find(printer_str) != printer_names.end()) {
-                    if (filament_id_set.find(filament_it->filament_id) != filament_id_set.end()) {
+                    if (seen_preset_names.find(filament_it->name) != seen_preset_names.end()) {
                         continue;
                     } else {
-                        filament_id_set.insert(filament_it->filament_id);
+                        seen_preset_names.insert(filament_it->name);
                         // name matched
                         if (filament_it->is_system) {
                             filament_items.push_back(filament_it->alias);
@@ -967,7 +980,7 @@ void AMSMaterialsSetting::Popup(wxString filament, wxString sn, wxString temp_mi
                             filament_infos.filament_id             = filament_it->filament_id;
                             filament_infos.setting_id              = filament_it->setting_id;
                             filament_infos.preset_name             = filament_it->name;
-                            map_filament_items[filament_it->alias] = filament_infos;
+                            m_filament_infos.push_back(filament_infos);
                         } else {
                             char   target = '@';
                             size_t pos    = filament_it->name.find(target);
@@ -983,13 +996,26 @@ void AMSMaterialsSetting::Popup(wxString filament, wxString sn, wxString temp_mi
                                 filament_infos.filament_id            = filament_it->filament_id;
                                 filament_infos.setting_id             = filament_it->setting_id;
                                 filament_infos.preset_name            = filament_it->name;
-                                map_filament_items[user_preset_alias] = filament_infos;
+                                m_filament_infos.push_back(filament_infos);
                             }
                         }
 
-                        if (filament_it->filament_id == ams_filament_id) {
+                        // why: filament_id is shared by profiles from different material types;
+                        //      the tray's reported type is the signal that disambiguates GFL99.
+                        std::string displayed_filament_type;
+                        std::string preset_filament_type = filament_it->config.get_filament_type(displayed_filament_type);
+                        // note: the overload normalizes PLA/PA support but still exposes ABS support as
+                        //      ABS, while the printer can report the normalized ABS-S form.
+                        if (preset_filament_type == "ABS" && tray_filament_type == "ABS-S") {
+                            const ConfigOptionBools* support_opt = dynamic_cast<const ConfigOptionBools*>(filament_it->config.option("filament_is_support"));
+                            if (support_opt && support_opt->get_at(0))
+                                preset_filament_type = "ABS-S";
+                        }
+                        if (!tray_filament_type.empty() && filament_it->filament_id == ams_filament_id &&
+                            preset_filament_type == tray_filament_type) {
                             hint_filament_name = from_u8(filament_it->alias);
                             bambu_filament_name = from_u8(filament_it->alias);
+                            hint_preset_name = filament_it->name;
 
 
                             // update if nozzle_temperature_range is found
@@ -1010,7 +1036,6 @@ void AMSMaterialsSetting::Popup(wxString filament, wxString sn, wxString temp_mi
                                 }
                             }
                         }
-                        idx++;
                     }
                 }
             }
@@ -1112,7 +1137,24 @@ void AMSMaterialsSetting::Popup(wxString filament, wxString sn, wxString temp_mi
             return left < right;
         };
 
-        std::sort(filament_items.begin(), filament_items.end(), _filament_sorter);
+        // why: m_filament_infos is index-aligned with filament_items (see population loop above);
+        //      sort a permutation of indices instead of the wxArrayString alone, so the two stay
+        //      in lockstep and a combo row still resolves to its own preset after reordering.
+        std::vector<int> sorted_idx(filament_items.size());
+        for (size_t i = 0; i < sorted_idx.size(); i++) sorted_idx[i] = int(i);
+        std::sort(sorted_idx.begin(), sorted_idx.end(), [&filament_items, &_filament_sorter](int a, int b) {
+            return _filament_sorter(filament_items[a], filament_items[b]);
+        });
+
+        wxArrayString sorted_items;
+        std::vector<FilamentInfos> sorted_infos;
+        sorted_infos.reserve(sorted_idx.size());
+        for (int idx : sorted_idx) {
+            sorted_items.push_back(filament_items[idx]);
+            sorted_infos.push_back(m_filament_infos[idx]);
+        }
+        filament_items   = sorted_items;
+        m_filament_infos = std::move(sorted_infos);
     }
 
     // traverse the hint selection idx
@@ -1120,7 +1162,7 @@ void AMSMaterialsSetting::Popup(wxString filament, wxString sn, wxString temp_mi
     {
         for(int i = 0; i < filament_items.size(); i++)
         {
-            if (hint_filament_name == filament_items[i])
+            if (!hint_preset_name.empty() && hint_preset_name == m_filament_infos[i].preset_name)
             {
                 selection_idx = i;
                 break;
@@ -1173,10 +1215,42 @@ void AMSMaterialsSetting::on_select_filament(wxCommandEvent &evt)
     m_filament_type = "";
     PresetBundle* preset_bundle = wxGetApp().preset_bundle;
     if (preset_bundle && !m_comboBox_filament->GetValue().IsEmpty()) {
-        // filament_id is not unique across vendor profiles (see FilamentInfos::preset_name),
-        // so resolve the exact preset recorded when the combo was populated.
-        auto item = map_filament_items.find(m_comboBox_filament->GetValue().ToStdString());
-        Preset* preset = item != map_filament_items.end() ? preset_bundle->filaments.find_preset(item->second.preset_name) : nullptr;
+        // why: filament_id is not unique across vendor profiles (see FilamentInfos::preset_name),
+        //      so resolve the exact preset recorded when the combo was populated. Keyed by
+        //      selection index since the alias text itself can also collide across presets.
+        // note: real=true so an unsaved edit to the currently-selected filament doesn't leak in via m_edited_preset.
+        int sel = m_comboBox_filament->GetSelection();
+        Preset* preset = (sel >= 0 && sel < (int) m_filament_infos.size())
+                             ? preset_bundle->filaments.find_preset(m_filament_infos[sel].preset_name, false, true)
+                             : nullptr;
+        // why: Popup() gates a user preset into the list using the nozzle diameter known when the
+        //      dialog opened (with a startup fallback to the printer preset's nozzle_diameter). If
+        //      firmware resolves the real diameter later while this modal dialog is still open, a
+        //      user preset that was only compatible with the stale guess must not have its
+        //      temps/type applied - re-check against the current diameter, same as Popup().
+        if (preset && !preset->is_system && obj) {
+            float machine_diameter = obj->GetExtderSystem()->GetNozzleDiameter(0);
+            if (machine_diameter == 0.0f) {
+                const ConfigOption* opt = preset_bundle->printers.get_selected_preset().config.option("nozzle_diameter");
+                if (opt) machine_diameter = static_cast<const ConfigOptionFloats*>(opt)->values[0];
+            }
+            std::ostringstream stream;
+            stream << std::fixed << std::setprecision(1) << machine_diameter;
+            std::set<std::string> printer_names = preset_bundle->get_printer_names_by_printer_type_and_nozzle(
+                DevPrinterConfigUtil::get_printer_display_name(obj->printer_type), stream.str());
+
+            ConfigOptionStrings* printer_strs = dynamic_cast<ConfigOptionStrings*>(preset->config.option("compatible_printers"));
+            bool has_compatible_printer = false;
+            if (printer_strs) {
+                for (const auto& printer_str : printer_strs->values) {
+                    if (printer_names.find(printer_str) != printer_names.end()) {
+                        has_compatible_printer = true;
+                        break;
+                    }
+                }
+            }
+            if (!has_compatible_printer) preset = nullptr;
+        }
         if (preset) {
             // ) if nozzle_temperature_range is found
             ConfigOption* opt_min = preset->config.option("nozzle_temperature_range_low");
@@ -1195,12 +1269,9 @@ void AMSMaterialsSetting::on_select_filament(wxCommandEvent &evt)
                     m_input_nozzle_max->GetTextCtrl()->SetValue(text_nozzle_temp_max);
                 }
             }
-            ConfigOption* opt_type = preset->config.option("filament_type");
-            if (opt_type && dynamic_cast<ConfigOptionStrings*>(opt_type)) {
-                //m_filament_type = opt_type_strs->get_at(0);
-                std::string display_filament_type;
-                m_filament_type = preset->config.get_filament_type(display_filament_type);
-            }
+            // why: get_filament_type() already null-checks the filament_type option internally.
+            std::string display_filament_type;
+            m_filament_type = preset->config.get_filament_type(display_filament_type);
         }
     }
     if (m_input_nozzle_min->GetTextCtrl()->GetValue().IsEmpty()) {
@@ -1235,11 +1306,11 @@ void AMSMaterialsSetting::on_select_filament(wxCommandEvent &evt)
     ams_setting_id = "";
 
     if (preset_bundle) {
+        int sel = m_comboBox_filament->GetSelection();
         for (auto it = preset_bundle->filaments.begin(); it != preset_bundle->filaments.end(); it++) {
-            auto itor = map_filament_items.find(m_comboBox_filament->GetValue().ToStdString());
-            if ( itor != map_filament_items.end()) {
-                ams_filament_id = itor->second.filament_id;
-                ams_setting_id  = itor->second.setting_id;
+            if (sel >= 0 && sel < (int) m_filament_infos.size()) {
+                ams_filament_id = m_filament_infos[sel].filament_id;
+                ams_setting_id  = m_filament_infos[sel].setting_id;
                 break;
             }
 

--- a/src/slic3r/GUI/AMSMaterialsSetting.hpp
+++ b/src/slic3r/GUI/AMSMaterialsSetting.hpp
@@ -194,6 +194,11 @@ protected:
     struct FilamentInfos {
         std::string filament_id;
         std::string setting_id;
+        // Name of the exact preset this combo item was built from. filament_id is NOT
+        // unique across vendors (e.g. several vendor ABS/ASA profiles ship Generic PLA's
+        // "GFL99"), so resolving the selection by scanning for the first filament_id match
+        // can land on a preset of a different material type. Look up by name instead.
+        std::string preset_name;
     };
     std::map<std::string, FilamentInfos> map_filament_items;
 };

--- a/src/slic3r/GUI/AMSMaterialsSetting.hpp
+++ b/src/slic3r/GUI/AMSMaterialsSetting.hpp
@@ -194,13 +194,16 @@ protected:
     struct FilamentInfos {
         std::string filament_id;
         std::string setting_id;
-        // Name of the exact preset this combo item was built from. filament_id is NOT
-        // unique across vendors (e.g. several vendor ABS/ASA profiles ship Generic PLA's
-        // "GFL99"), so resolving the selection by scanning for the first filament_id match
-        // can land on a preset of a different material type. Look up by name instead.
+        // why: filament_id is NOT unique across vendors (e.g. several vendor ABS/ASA profiles ship
+        //      Generic PLA's "GFL99"), so resolving the selection by scanning for the first
+        //      filament_id match can land on a preset of a different material type. Look up by
+        //      name instead.
         std::string preset_name;
     };
-    std::map<std::string, FilamentInfos> map_filament_items;
+    // why: alias text is not unique (two presets can share a display alias, see
+    //      PresetCollection::set_custom_preset_alias), so a combo row must be identified by its
+    //      list position, not by the possibly-duplicated alias string.
+    std::vector<FilamentInfos> m_filament_infos;
 };
 
 wxDECLARE_EVENT(EVT_SELECTED_COLOR, wxCommandEvent);

--- a/src/slic3r/GUI/DeviceCore/DevFilaSystem.cpp
+++ b/src/slic3r/GUI/DeviceCore/DevFilaSystem.cpp
@@ -651,8 +651,14 @@ void DevFilaSystemParser::ParseV1_0(const json& jj, MachineObject* obj, DevFilaS
                                 curr_tray->tag_uid = "0";
                             if (tray_it->contains("tray_info_idx") && tray_it->contains("tray_type"))
                             {
+                                // note: despite the names, `tray_info_idx` is a filament_id and
+                                // DevAmsTray::setting_id is where we keep it (the real setting_id
+                                // lives in filament_setting_id). So this reads
+                                // setting_id_to_type(setting_id, ...) but is really
+                                // filament_id -> type.
                                 curr_tray->setting_id = (*tray_it)["tray_info_idx"].get<std::string>();
-                                //std::string type            = (*tray_it)["tray_type"].get<std::string>();
+                                // note: tray_type wins here; the lookup only resolves a type when the
+                                //       printer reported none.
                                 std::string type = MachineObject::setting_id_to_type(curr_tray->setting_id, (*tray_it)["tray_type"].get<std::string>());
                                 if (curr_tray->setting_id == "GFS00")
                                 {

--- a/src/slic3r/GUI/DeviceManager.cpp
+++ b/src/slic3r/GUI/DeviceManager.cpp
@@ -2579,7 +2579,14 @@ int MachineObject::local_publish_json(std::string json_str, int qos, int flag)
 
 std::string MachineObject::setting_id_to_type(std::string setting_id, std::string tray_type)
 {
-    std::string type;
+    // why: the printer already reported the material type, so trust it. setting_id is a
+    //      filament_id, which is not unique across vendors - the scan below can match a
+    //      preset of a different material and mislabel the tray (issue #14365).
+    if (!tray_type.empty())
+        return tray_type;
+
+    // why: fallback only - the printer told us nothing, so a first match by filament_id
+    //      beats showing an empty type.
     PresetBundle* preset_bundle = GUI::wxGetApp().preset_bundle;
     if (preset_bundle) {
         for (auto it = preset_bundle->filaments.begin(); it != preset_bundle->filaments.end(); it++) {
@@ -2587,17 +2594,12 @@ std::string MachineObject::setting_id_to_type(std::string setting_id, std::strin
             if (it->filament_id.compare(setting_id) == 0 && it->is_system) {
                 std::string display_filament_type;
                 it->config.get_filament_type(display_filament_type);
-                type = display_filament_type;
-                break;
+                return display_filament_type;
             }
         }
     }
 
-    if (tray_type != type || type.empty()) {
-        if (type.empty()) { type = tray_type; }
-        BOOST_LOG_TRIVIAL(info) << "The values of tray_info_idx and tray_type do not match tray_info_idx " << setting_id << " tray_type " << tray_type << " system_type" << type;
-    }
-    return type;
+    return tray_type;
 }
 
 template <class ENUM>

--- a/src/slic3r/GUI/DeviceManager.cpp
+++ b/src/slic3r/GUI/DeviceManager.cpp
@@ -1,5 +1,6 @@
 #include "libslic3r/libslic3r.h"
 #include "DeviceManager.hpp"
+#include "libslic3r/MaterialType.hpp"
 #include "libslic3r/Time.hpp"
 #include "libslic3r/Thread.hpp"
 #include "slic3r/Utils/NetworkAgent.hpp"
@@ -2585,8 +2586,16 @@ std::string MachineObject::setting_id_to_type(std::string setting_id, std::strin
     // note: "Support" is a generic label the firmware sends for any support filament,
     //       not a material - fall through to the preset lookup below so ABS/PLA/PA
     //       support trays keep their real (or Sup.*-normalized) type.
-    if (!tray_type.empty() && tray_type != "Support")
+    if (!tray_type.empty() && tray_type != "Support") {
+        // why: tray_type flows unvalidated into filament_type (an open enum), then into AMS
+        //      mapping and the slice config. A name the firmware knows and MaterialType
+        //      does not is survivable but silently wrong downstream - log it rather than
+        //      assert, since new Bambu materials are expected, not a programming error.
+        if (!MaterialType::find(tray_type))
+            BOOST_LOG_TRIVIAL(warning) << "setting_id_to_type: printer reported unknown material type "
+                                       << tray_type << " (tray_info_idx " << setting_id << ")";
         return tray_type;
+    }
 
     // why: fallback only - the printer told us nothing, so a first match by filament_id
     //      beats showing an empty type.

--- a/src/slic3r/GUI/DeviceManager.cpp
+++ b/src/slic3r/GUI/DeviceManager.cpp
@@ -2582,7 +2582,10 @@ std::string MachineObject::setting_id_to_type(std::string setting_id, std::strin
     // why: the printer already reported the material type, so trust it. setting_id is a
     //      filament_id, which is not unique across vendors - the scan below can match a
     //      preset of a different material and mislabel the tray (issue #14365).
-    if (!tray_type.empty())
+    // note: "Support" is a generic label the firmware sends for any support filament,
+    //       not a material - fall through to the preset lookup below so ABS/PLA/PA
+    //       support trays keep their real (or Sup.*-normalized) type.
+    if (!tray_type.empty() && tray_type != "Support")
         return tray_type;
 
     // why: fallback only - the printer told us nothing, so a first match by filament_id


### PR DESCRIPTION
# Description
Based on #14638 
Fixes #14365. Selecting **Generic PLA** for an AMS slot can set and display **ABS**.

The root cause is that `filament_id` is treated as if it uniquely identifies a preset. It doesn't - 148 shipped presets carry Bambu's `GFL99`, and four of them are not PLA. Both the AMS dialog and the status parser scan the filament collection for the first `filament_id` match, so they can land on a preset of a completely different material.

The collider is `Generic ABS @Sovol SV08 MAX`, a shipped system preset that declares `GFL99` but is ABS (230-300). It wins the scan because `filament_preset_less` hoists `Generic `-prefixed presets to the front and then sorts alphabetically within that group, so `Generic ABS` beats `Generic PLA`. The issue reporter has a Sovol SV08 installed, which is why they hit it and a Bambu-only setup doesn't. Every other `GFL99` collider is either vendor-prefixed (unreachable) or coincidentally PLA, which is why this looks random.

There are two separate defects, so this PR has two commits.

**1. Outbound - the dialog (`Search not only by filament_id`, by @ExPikaPaka, cherry-picked from #14638)**

`Popup()` recorded only `{filament_id, setting_id}` for each combo entry and discarded the preset it was looking at. Selection then had to recover the preset from a non-unique key. This adds `preset_name` to `FilamentInfos` and resolves via `find_preset()`, so the temps, material type and setting id come off the preset the user actually picked. All credit to @ExPikaPaka - I've only rebased it.

**2. Inbound - the status path (`Trust printer-reported material type over filament_id`)**

`MachineObject::setting_id_to_type` did the same first-match scan on every status refresh, then preferred its own guess over the printer's reported `tray_type`, logging the disagreement at info level. So even with the dialog fixed, the tray tile flips back to ABS on the next poll.

The printer already tells us the material, so this now trusts `tray_type` and keeps the lookup only as a fallback for when the printer reports nothing. `DevFilaSystem.cpp` had the original `//std::string type = tray_type;` still commented out above the call - this restores that behaviour while keeping the fallback that presumably motivated the scan.

Worth noting: the `is_system` check in that loop reads like a safety guard but is the opposite - `Generic ABS @Sovol SV08 MAX` ships with Orca so it passes, while the check excludes user presets, which could never be the culprit.

No behaviour change for anyone without a colliding vendor profile installed. No protocol, profile or format changes.

Related: #14398 fixed the same family of bug in the setup guide's filament picker, but doesn't touch these two paths.

# Screenshots/Recordings/Graphs

<!-- TODO:
  1. Before: AMS dialog with Generic PLA selected, showing ABS / 230 / 300
  2. After: same dialog showing PLA / 190 / 240
  3. After: tray tile still reading PLA following a status refresh
-->

## Tests

Tested on a **Bambu Lab H2C** with AMS, over LAN.

Repro, if you want to reproduce it yourself:

1. Configuration Wizard -> Printers -> install the **Sovol** vendor (tick `Sovol SV08 MAX`). This is what loads the colliding preset; the vendor must be installed via the wizard because `data_dir/system/` is rebuilt from the installed-vendor list on every launch.
2. Restart, connect a Bambu printer with AMS, click an AMS tray.
3. Select **Generic PLA**.

| | Before | After |
| --- | --- | --- |
| Dialog type / temps | ABS, 230-300 | PLA, 190-240 |
| Sent `tray_type` | `ABS` | `PLA` |
| Tray tile after refresh | ABS | PLA |

Without the Sovol vendor installed, the same steps show PLA before and after - the bug is not reachable, which matches why it has been hard to reproduce.

No new automated tests. There is no existing coverage for AMS material selection, and both paths depend on `wxGetApp().preset_bundle` plus live device state, so a targeted test needs a seam that doesn't exist yet. Happy to add one if a maintainer can point at the preferred approach - the cheapest is probably a pure exact-preset resolution helper covering both directions.

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
