### PR TITLE
docs(security): fix SECURITY.md heading hierarchy and list formatting

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,47 +1,48 @@
 # Security Policy
 
 At OrcaSlicer, we are committed to maintaining the security of our ecosystem. Our policy is to ensure that we do not introduce vulnerabilities and that any security issues are addressed promptly and responsibly. We appreciate your help in improving the security of OrcaSlicer and thank you for your responsible disclosure.
-Reporting Security Bugs
 
-## To report a security bug, please follow these guidelines:
+## Reporting Security Bugs
 
-  * Email Security Bugs:
-        Send an email to the lead maintainer at softfeverever@gmail.com.
-        Include the word "SECURITY" in the subject line of your email.
+To report a security bug, please follow these guidelines:
 
-  * Response Times:
-        The lead maintainer will acknowledge receipt of your email within one week (7 days).
-        A detailed response will follow within 48 hours, outlining the next steps for handling your report.
-        After the initial reply, the security team will keep you informed about the progress toward a fix and any announcements.
+* **Email Security Bugs:**
+  * Send an email to the lead maintainer at softfeverever@gmail.com.
+  * Include the word "SECURITY" in the subject line of your email.
 
-  * Information and Collaboration:
-        We may request additional information or guidance as we work on addressing the issue.
+* **Response Times:**
+  * The lead maintainer will acknowledge receipt of your email within one week (7 days).
+  * A detailed response will follow within 48 hours, outlining the next steps for handling your report.
+  * After the initial reply, the security team will keep you informed about the progress toward a fix and any announcements.
 
-  * Handling the Report:
-        OrcaSlicer will confirm the problem and determine the affected versions.
-        We will audit the code to find any similar issues and prepare fixes for all releases still under maintenance.
-        Fixes will be released as quickly as possible.
+* **Information and Collaboration:**
+  * We may request additional information or guidance as we work on addressing the issue.
 
-  * Third-Party Modules:
-        Report security issues in third-party modules to the respective maintainer of those modules.
+* **Handling the Report:**
+  * OrcaSlicer will confirm the problem and determine the affected versions.
+  * We will audit the code to find any similar issues and prepare fixes for all releases still under maintenance.
+  * Fixes will be released as quickly as possible.
+
+* **Third-Party Modules:**
+  * Report security issues in third-party modules to the respective maintainer of those modules.
 
 ## Security Disclosure Guidelines
 
 When disclosing a vulnerability, please follow these steps to ensure your report is clear and actionable:
 
-  * Provide Detailed Information:
-        Scope: Clearly define the scope of the vulnerability.
-        Potential Impact: Let us know who could be affected by this exploit.
-        Reproduction Steps: Document detailed steps to reproduce the vulnerability.
+* **Provide Detailed Information:**
+  * **Scope:** Clearly define the scope of the vulnerability.
+  * **Potential Impact:** Let us know who could be affected by this exploit.
+  * **Reproduction Steps:** Document detailed steps to reproduce the vulnerability.
 
-    Reference OWASP Guidelines:
-        Follow the <a href="https://cheatsheetseries.owasp.org/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.html">OWASP Vulnerability Disclosure Cheat Sheet</a> for best practices in vulnerability disclosure.
+* **Reference OWASP Guidelines:**
+  * Follow the [OWASP Vulnerability Disclosure Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.html) for best practices in vulnerability disclosure.
 
 ## Security Recommendations
 
 To enhance security when using OrcaSlicer, we recommend following these steps:
 
-  * SEE SOMETHING: If you notice anything suspicious or have concerns, please report it.
-  * SAY SOMETHING: If you have any doubts or need assistance, do not hesitate to contact us.
+* **SEE SOMETHING:** If you notice anything suspicious or have concerns, please report it.
+* **SAY SOMETHING:** If you have any doubts or need assistance, do not hesitate to contact us.
 
 ### Thank you for your commitment to the security of OrcaSlicer. Your efforts help us maintain a safe and reliable ecosystem.


### PR DESCRIPTION
## Summary
- Promote "Reporting Security Bugs" to a proper markdown heading.
- Normalize nested list formatting and use a markdown link for the OWASP cheat sheet.
- No policy or contact-address changes.

## Verification
- Rendered SECURITY.md headings/lists read cleanly in GitHub preview.

## Claim
`Claim: bartok` (seed). Follow-ups: `Claim: sera`.
