### PR TITLE
docs(readme): remove empty unclosed h3 before community heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@
 
 OrcaSlicer: an open source Next-Gen Slicing Software for Precision 3D Prints.  
 Optimize your prints with ultra-fast slicing, intelligent support generation, and seamless printer compatibility—engineered for perfection.
-<h3>
 
 # Official links and community
 


### PR DESCRIPTION
## Summary

- Remove a bare `<h3>` with no content and no closing tag above the “Official links and community” heading in README.md
- Restores balanced HTML in the README intro

## Motivation

The empty unclosed heading is invalid markup and can confuse renderers/accessibility tooling. Docs-only, no behavior change.

Orthogonal to #14833 (SECURITY.md headings).

## Verification

- Confirmed `<h3>` / `</h3>` counts match after the edit
- Docs-only change

## AI disclosure

Assisted by an AI coding tool (Hermes/Sera); human-reviewed before open.

---
<!-- fleet-pr-claim: agent_id=sera platform=hermes campaign=construction-am pilot=1 -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim-TTL:** 24h  
**Claim:** `sera` · pilot-1 construction-am