### PR TITLE
fix(plugin): enable slicing-pipeline and plugins options on filament presets

### DIFF
--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -466,7 +466,7 @@ void Preset::normalize(DynamicPrintConfig &config)
         // Ensure that the filament preset vector options contain the correct number of values.
         const auto &defaults = FullPrintConfig::defaults();
         for (const std::string &key : Preset::filament_options()) {
-            if (key == "compatible_prints" || key == "compatible_printers")
+            if (key == "compatible_prints" || key == "compatible_printers" || key == "slicing_pipeline_plugin" || key == "plugins")
                 continue;
             if (filament_options_with_variant.find(key) != filament_options_with_variant.end())
                 continue;
@@ -1379,6 +1379,8 @@ static std::vector<std::string> s_Preset_filament_options {/*"filament_colour", 
     "filament_change_length_nc", "filament_prime_volume_nc",
     "long_retractions_when_ec", "retraction_distances_when_ec",
     "plugin_config_overrides",
+    "slicing_pipeline_plugin",
+    "plugins",
     //ams chamber
     "filament_dev_ams_drying_ams_limitations", "filament_dev_ams_drying_temperature", "filament_dev_ams_drying_time", "filament_dev_ams_drying_heat_distortion_temperature",
     "filament_dev_chamber_drying_bed_temperature", "filament_dev_chamber_drying_time",

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -4528,6 +4528,12 @@ void TabFilament::build()
         option.opt.height = gcode_field_height;// 150;
         optgroup->append_single_option_line(option);
 
+        optgroup = page->new_optgroup(L("Slicing Pipeline Plugin"), L"param_gcode", 0);
+        optgroup->hide_labels();
+        option = optgroup->get_option("slicing_pipeline_plugin");
+        option.opt.full_width = true;
+        optgroup->append_single_option_line(option, "others_settings_plugin_picker");
+
         optgroup = page->new_optgroup(L("Plugin Configuration"), L"param_gcode");
         optgroup->append_single_option_line("plugin_config_overrides");
 


### PR DESCRIPTION
### Description
Currently, slicing-pipeline and post-process plugins can only be enabled on Print/Process presets, and printer-connection plugins on Printer presets.
However, plugins like the Spoolman integration ([orcaslicer-plugin-spoolman](https://github.com/zaosoula/orcaslicer-plugin-spoolman)) need to be configured/enabled per-filament, without requiring the user to copy and modify every single print process preset.

This PR:
1. Adds `"slicing_pipeline_plugin"` and `"plugins"` to the registered options list for Filament presets.
2. Fixes a crash in `Preset::normalize()` when checking vector options that are empty by default (`slicing_pipeline_plugin` and `plugins` are empty lists, so resizing them was trying to access `front()` of empty vectors).
3. Adds the `Slicing Pipeline Plugin` picker section in the Filament preset UI settings tab.

This allows users to enable slicing-pipeline capabilities directly on their Filament presets, and the settings will automatically merge and run during slicing.