### PR TITLE
Fix updating IP when re-adding a LAN printer

### DIFF
--- a/src/slic3r/GUI/DeviceCore/DevManager.cpp
+++ b/src/slic3r/GUI/DeviceCore/DevManager.cpp
@@ -348,6 +348,7 @@ namespace Slic3r
         auto           it = localMachineList.find(machine.dev_id);
         if (it != localMachineList.end()) {
             obj = it->second;
+            obj->set_dev_ip(machine.dev_ip);
         } else {
             obj = new MachineObject(this, m_agent, machine.dev_name, machine.dev_id, machine.dev_ip);
             localMachineList.insert(std::make_pair(machine.dev_id, obj));


### PR DESCRIPTION
## Summary

- update an existing local printer object's IP when it is re-added manually
- allow the existing `update_local_machine` call to persist the new address

## Root cause

`DeviceManager::insert_local_device` used the supplied IP only when constructing a new `MachineObject`. If the printer serial number already existed, it reused the old object and immediately persisted its stale IP. Re-entering a printer after its address changed therefore continued connecting to the previous address when discovery could not refresh it.

Closes #12886.

## Testing

- `git diff --check`
- reproduced the stale saved-IP behavior on macOS with OrcaSlicer 2.4.2; manually correcting the persisted IP restored the LAN connection

A full OrcaSlicer GUI build was not run because this fresh checkout has no configured dependency/build directory.
