### PR TITLE
Fix stale plate membership during plate grid rearrangement

### DIFF
--- a/src/slic3r/GUI/PartPlate.cpp
+++ b/src/slic3r/GUI/PartPlate.cpp
@@ -4551,6 +4551,9 @@ int PartPlateList::create_plate(bool adjust_position)
 		return -1;
 	int cols = compute_colum_count(new_index + 1);
 	int old_cols = compute_colum_count(new_index);
+	// Orca: Rebuild plate membership before moving instances during a grid reflow.
+	if (adjust_position && old_cols != cols)
+		reload_all_objects();
 
 	origin = compute_origin(new_index, cols);
 	plate = new PartPlate(this, origin, m_plate_width, m_plate_depth, m_plate_height, m_plater, m_model, true, printer_technology);
@@ -5039,6 +5042,9 @@ int PartPlateList::move_plate_to_index(int old_index, int new_index)
 		BOOST_LOG_TRIVIAL(warning) << __FUNCTION__ << boost::format(":should not happen, the same index %1%") % old_index;
 		return -1;
 	}
+
+	// Orca: Rebuild plate membership before moving the plates.
+	reload_all_objects();
 
 	if (old_index < new_index)
 	{


### PR DESCRIPTION
## Description

This PR fixes objects being **left behind** when plates are repositioned or reordered.

## Observed behavior

When **adding a new plate** changes the number of grid columns, the existing plates are moved to their new positions.

At that point, the cached object membership of a plate **could be outdated**. As a result, only some objects moved with the plate, while others stayed at their old positions.

The same issue could also happen when using **Move Plate to Front**.

## Applied fix

Reload plate membership before:

* repositioning plates during a grid reflow
* reordering plates

This ensures that all objects currently belonging to a plate move together with it.

## Tests

* Reproduced the issue using the [project](https://github.com/user-attachments/files/30160153/Micron.2026-07-18.3mf.zip) provided in bug report #14843.
* Tested the fix with the same project by adding new plates and moving plates to the front.

---

> [!NOTE]
> No screenshots are provided because the project is very crowded, making the issue difficult to see in screenshots. The description above should be enough to understand the problem.

Fixes #14843
