### PR TITLE
Remove numeric concatenation when offering shared profiles

### DIFF
--- a/src/slic3r/GUI/NotificationManager.cpp
+++ b/src/slic3r/GUI/NotificationManager.cpp
@@ -2338,7 +2338,7 @@ void NotificationManager::SharedProfilesNotification::render_text(ImGuiWrapper& 
 	{
         float hyper_y     = starting_y + m_endlines.size() * shift_y + m_line_height * .5f;
 		float dont_show_y = hyper_y    + ImGui::CalcTextSize((m_hypertext + "  ").c_str()).y + m_line_height * .5f;
-		std::string dont_show_text = _u8L("Don't show again")
+		std::string dont_show_text = _u8L("Don't show again");
 		ImVec2 part_size = ImGui::CalcTextSize(dont_show_text.c_str());
 
         if (!m_multiline && m_lines_count > 2) {

--- a/src/slic3r/GUI/NotificationManager.cpp
+++ b/src/slic3r/GUI/NotificationManager.cpp
@@ -2338,7 +2338,7 @@ void NotificationManager::SharedProfilesNotification::render_text(ImGuiWrapper& 
 	{
         float hyper_y     = starting_y + m_endlines.size() * shift_y + m_line_height * .5f;
 		float dont_show_y = hyper_y    + ImGui::CalcTextSize((m_hypertext + "  ").c_str()).y + m_line_height * .5f;
-		std::string dont_show_text = _u8L("Don't show again") + std::to_string(m_endlines.size());
+		std::string dont_show_text = _u8L("Don't show again")
 		ImVec2 part_size = ImGui::CalcTextSize(dont_show_text.c_str());
 
         if (!m_multiline && m_lines_count > 2) {


### PR DESCRIPTION
Fix string concatenation for 'Don't show again' text.

# Description
Currently the notification offering shared profiles concatenates a 1 after the text "Don't show again"
<!--
> Please provide a summary of the changes made in this PR. Include details such as:
  > * What issue does this PR address or fix?
  > * What new features or enhancements does this PR introduce?
  > * Are there any breaking changes or dependencies that need to be considered?
-->

# Screenshots/Recordings/Graphs
<img width="472" height="93" alt="image" src="https://github.com/user-attachments/assets/f98dba80-153b-4860-9e34-a50ed0d734f0" />

<!--
> Please attach relevant screenshots to showcase the UI changes.
> Please attach images that can help explain the changes.
-->

## Tests

<!--
> Please describe the tests that you have conducted to verify the changes made in this PR.
-->

<!--
> A guide for users on how to download the artifacts from this PR.
-->

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
