### PR TITLE
Revert "feat(log): enable console logging in RelWithDebInfo builds (#14439)"

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -201,12 +201,9 @@ if (WIN32)
     if(MSVC)
         target_link_options(OrcaSlicer_app_gui PUBLIC "$<$<CONFIG:RELEASE>:/DEBUG>")
     endif()
-    target_compile_definitions(OrcaSlicer_app_gui PRIVATE "$<$<NOT:$<CONFIG:RelWithDebInfo>>:SLIC3R_WRAPPER_NOCONSOLE>")
+    target_compile_definitions(OrcaSlicer_app_gui PRIVATE -DSLIC3R_WRAPPER_NOCONSOLE)
     add_dependencies(OrcaSlicer_app_gui OrcaSlicer)
-    set_target_properties(OrcaSlicer_app_gui PROPERTIES
-        OUTPUT_NAME "orca-slicer"
-        WIN32_EXECUTABLE "$<NOT:$<CONFIG:RelWithDebInfo>>"
-    )
+    set_target_properties(OrcaSlicer_app_gui PROPERTIES OUTPUT_NAME "orca-slicer")
     target_link_libraries(OrcaSlicer_app_gui PRIVATE boost_headeronly)
 endif ()
 

--- a/src/libslic3r/CMakeLists.txt
+++ b/src/libslic3r/CMakeLists.txt
@@ -535,7 +535,6 @@ endif ()
 encoding_check(libslic3r)
 
 target_compile_definitions(libslic3r PUBLIC -DUSE_TBB -DTBB_USE_CAPTURED_EXCEPTION=0)
-target_compile_definitions(libslic3r PRIVATE $<$<CONFIG:RelWithDebInfo>:SLIC3R_CONSOLE_LOG>)
 target_include_directories(libslic3r PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
 target_include_directories(libslic3r SYSTEM PUBLIC ${EXPAT_INCLUDE_DIRS})
 

--- a/src/libslic3r/Utils.hpp
+++ b/src/libslic3r/Utils.hpp
@@ -197,7 +197,6 @@ std::string debug_out_path(const char *name, ...);
 // smaller level means less log. level=5 means saving all logs.
 void set_log_path_and_level(const std::string& file, unsigned int level);
 void flush_logs();
-void shutdown_console_logging();
 boost::filesystem::path get_log_file_name();
 
 // A special type for strings encoded in the local Windows 8-bit code page.

--- a/src/libslic3r/utils.cpp
+++ b/src/libslic3r/utils.cpp
@@ -5,7 +5,6 @@
 #include <locale>
 #include <ctime>
 #include <cstdarg>
-#include <iostream>
 #include <stdio.h>
 #include <filesystem>
 #include <sstream>
@@ -51,19 +50,14 @@
 #include <boost/log/core.hpp>
 #include <boost/log/trivial.hpp>
 #include <boost/log/expressions.hpp>
-#include <boost/log/sinks/async_frontend.hpp>
 #include <boost/log/sinks/text_file_backend.hpp>
-#include <boost/log/sinks/text_ostream_backend.hpp>
 #include <boost/log/utility/setup/file.hpp>
 #include <boost/log/utility/setup/common_attributes.hpp>
 #include <boost/log/sources/severity_logger.hpp>
 #include <boost/log/sources/record_ostream.hpp>
 #include <boost/log/support/date_time.hpp>
 
-#include <boost/core/null_deleter.hpp>
 #include <boost/locale.hpp>
-#include <boost/make_shared.hpp>
-#include <boost/shared_ptr.hpp>
 
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/filesystem.hpp>
@@ -184,7 +178,6 @@ unsigned get_logging_level()
 }
 
 boost::shared_ptr<boost::log::sinks::synchronous_sink<boost::log::sinks::text_file_backend>> g_log_sink;
-boost::shared_ptr<boost::log::sinks::asynchronous_sink<boost::log::sinks::text_ostream_backend>> g_console_log_sink;
 
 // Force set_logging_level(<=error) after loading of the DLL.
 // This is currently only needed if libslic3r is loaded as a shared library into Perl interpreter
@@ -357,19 +350,6 @@ namespace src = boost::log::sources;
 namespace expr = boost::log::expressions;
 namespace keywords = boost::log::keywords;
 namespace attrs = boost::log::attributes;
-namespace sinks = boost::log::sinks;
-
-void shutdown_console_logging()
-{
-	if (!g_console_log_sink)
-		return;
-
-	auto console_sink = g_console_log_sink;
-	boost::log::core::get()->remove_sink(console_sink);
-	console_sink->stop();
-	g_console_log_sink.reset();
-}
-
 void set_log_path_and_level(const std::string& file, unsigned int level)
 {
 #ifdef __APPLE__
@@ -400,24 +380,6 @@ void set_log_path_and_level(const std::string& file, unsigned int level)
 		),
 		keywords::auto_flush = true
 	);
-
-	shutdown_console_logging();
-
-#ifdef SLIC3R_CONSOLE_LOG
-	auto console_backend = boost::make_shared<sinks::text_ostream_backend>();
-	console_backend->add_stream(boost::shared_ptr<std::ostream>(&std::cout, boost::null_deleter()));
-	console_backend->auto_flush(true);
-
-	g_console_log_sink = boost::make_shared<sinks::asynchronous_sink<sinks::text_ostream_backend>>(console_backend);
-	g_console_log_sink->set_formatter(
-		expr::stream
-		<< "[" << expr::attr< logging::trivial::severity_level >("Severity") << "]\t"
-		<< expr::format_date_time< boost::posix_time::ptime >("TimeStamp", "%Y-%m-%d %H:%M:%S.%f") << " "
-		<<"[Thread " << expr::attr<attrs::current_thread_id::value_type>("ThreadID") << "]"
-		<< ": " << expr::smessage
-	);
-	boost::log::core::get()->add_sink(g_console_log_sink);
-#endif
 
 	logging::add_common_attributes();
 

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -2355,7 +2355,6 @@ GUI_App::~GUI_App()
 
 
     BOOST_LOG_TRIVIAL(info) << __FUNCTION__<< boost::format(": exit");
-    shutdown_console_logging();
 }
 
 bool GUI_App::is_blocking_printing(MachineObject *obj_)


### PR DESCRIPTION
# Description

This reverts commit dbe99d0d6fa42c8f6dbaf6340bc055dd94f4f871.

The asynchronous Boost.Log console sink introduced by #14439 causes VSCode’s LLDB-DAP debugging session to remain running after OrcaSlicer has exited cleanly.

The issue is reproducible on Linux and MacOS by:

  1. Launching a `RelWithDebInfo` build through VSCode/LLDB-DAP.
  2. Opening the printer-selection dialog.
  3. Closing OrcaSlicer.

Seems to be fine on windows.

The OrcaSlicer process exits with status 0, but `lldb-dap` remains alive and blocked. Command-line LLDB does not exhibit the same behavior.

Reverting #14439 eliminates the issue. This identifies the asynchronous `std::cout` sink and its dedicated logging thread as a required trigger, although the underlying problem may be an interaction between Boost.Log, redirected stdout, and LLDB-DAP rather than a Boost.Log defect alone.

# Screenshots/Recordings/Graphs
https://github.com/user-attachments/assets/c4e0732d-6572-4f97-b87b-0571396f7496

After awhile, the following will appear.
<img width="3440" height="1440" alt="image" src="https://github.com/user-attachments/assets/d9c60cb4-ba36-4b8e-8ff5-1d64f1982083" />

<!--
> A guide for users on how to download the artifacts from this PR.
-->

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
