### PR TITLE
docs(readme): document macOS Homebrew cask install

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,14 @@ winget install --id=SoftFever.OrcaSlicer -e
             ![mac_security_setting](./SoftFever_doc/mac_security_setting.png)
     </details>
 
+Homebrew Cask
+
+```shell
+brew install --cask orcaslicer
+```
+
+The [Homebrew cask](https://formulae.brew.sh/cask/orcaslicer) installs the official macOS DMG published on [GitHub Releases](https://github.com/OrcaSlicer/OrcaSlicer/releases) (community-maintained formula; not a third-party binary fork).
+
 ## Linux
 
 ### Flathub (Recommended)


### PR DESCRIPTION
## Summary

Document the macOS Homebrew Cask install path in `README.md`, parallel to the existing Windows `winget` and Linux Flathub one-liners.

## Motivation

#14664 asks for a simple macOS package-manager install. A Homebrew cask already exists (`orcaslicer`) and pulls the **official** GitHub Releases universal DMG — it is not a third-party binary fork. Without a README mention, users assume it is unofficial and stick to manual DMG installs.

## Change

Under **How to install → Mac**, after the DMG / quarantine instructions:

```shell
brew install --cask orcaslicer
```

Plus one sentence noting the cask installs the official release DMG (community-maintained formula).

## Verification

- Cask source (`Homebrew/homebrew-cask` `Casks/o/orcaslicer.rb`): `url` = `https://github.com/OrcaSlicer/OrcaSlicer/releases/download/v#{version}/OrcaSlicer_Mac_universal_V#{version}.dmg`
- formulae.brew.sh/cask/orcaslicer resolves
- No open PR already documents brew / closes #14664
- Hunk is in the Mac install section only; orthogonal to #14834 (bare `<h3>` removal near the top of README)

Closes #14664

---
<!-- fleet-pr-claim: agent_id=sera platform=hermes campaign=construction-am pilot=1 -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim-TTL:** 72h  
**Claim:** `sera` · pilot-1 construction-am
