### PR TITLE
[2.4] Backport profile OTA endpoint updates

### DIFF
--- a/src/libslic3r/AppConfig.cpp
+++ b/src/libslic3r/AppConfig.cpp
@@ -42,6 +42,9 @@ namespace Slic3r {
 
 static const std::string VERSION_CHECK_URL = "https://check-version.orcaslicer.com/latest";
 static const std::string PROFILE_UPDATE_URL = "https://check-version.orcaslicer.com/profile";
+
+constexpr const char* CONFIG_ORCA_UPDATER_URL = "orca_updater_url";
+
 static const std::string MODELS_STR = "models";
 
 const std::string AppConfig::SECTION_FILAMENTS = "filaments";
@@ -1747,7 +1750,10 @@ std::string AppConfig::version_check_url() const
 
 std::string AppConfig::profile_update_url() const
 {
-    return PROFILE_UPDATE_URL;
+    std::string orca_updater_url = get(CONFIG_ORCA_UPDATER_URL);
+    if (orca_updater_url.empty())
+        return PROFILE_UPDATE_URL;
+    return orca_updater_url;
 }
 
 bool AppConfig::exists()

--- a/src/slic3r/Utils/PresetUpdater.cpp
+++ b/src/slic3r/Utils/PresetUpdater.cpp
@@ -374,10 +374,18 @@ bool PresetUpdater::priv::extract_file(const fs::path &source_path, const fs::pa
 // Remove leftover paritally downloaded files, if any.
 void PresetUpdater::priv::prune_tmps() const
 {
-    for (auto &dir_entry : boost::filesystem::directory_iterator(cache_path))
+	boost::system::error_code ec;
+	auto dir_it = boost::filesystem::directory_iterator(cache_path, ec);
+	if (ec) {
+		BOOST_LOG_TRIVIAL(warning) << "[Orca Updater]failed to list cache dir " << cache_path.string() << ": " << ec.message();
+		return;
+	}
+	for (auto &dir_entry : dir_it)
 		if (is_plain_file(dir_entry) && dir_entry.path().extension() == TMP_EXTENSION) {
 			BOOST_LOG_TRIVIAL(debug) << "[Orca Updater]remove old cached files: " << dir_entry.path().string();
-			fs::remove(dir_entry.path());
+			fs::remove(dir_entry.path(), ec);
+			if (ec)
+				BOOST_LOG_TRIVIAL(warning) << "[Orca Updater]failed to remove " << dir_entry.path().string() << ": " << ec.message();
 		}
 }
 

--- a/src/slic3r/Utils/PresetUpdater.cpp
+++ b/src/slic3r/Utils/PresetUpdater.cpp
@@ -5,7 +5,6 @@
 #include <boost/nowide/fstream.hpp>
 #include <functional>
 #include <atomic>
-#include <mutex>
 #include <set>
 #include <thread>
 #include <unordered_map>
@@ -204,7 +203,6 @@ struct PresetUpdater::priv
 
     // Per-vendor update checking
     std::set<std::string> checked_vendors;
-    std::mutex vendor_check_mutex;
     std::vector<std::thread> vendor_check_threads;
     std::atomic<bool> vendor_check_cancel{false};
 
@@ -221,10 +219,10 @@ struct PresetUpdater::priv
     priv();
 
 	void set_download_prefs(AppConfig *app_config);
-	bool get_file(const std::string &url, const fs::path &target_path) const;
-	//BBS: refine preset update logic
+    bool get_file(const std::string &url, const fs::path &target_path) const;
+    //BBS: refine preset update logic
     bool extract_file(const fs::path &source_path, const fs::path &dest_path = {});
-	void prune_tmps() const;
+    void prune_tmp(const std::string& vendor_id) const;
 	void sync_version() const;
 	void parse_version_string(const std::string& body) const;
     void sync_resources(std::string http_url, std::map<std::string, Resource> &resources, bool check_patch = false,  std::string current_version="", std::string changelog_file="");
@@ -371,22 +369,14 @@ bool PresetUpdater::priv::extract_file(const fs::path &source_path, const fs::pa
 	return true;
 }
 
-// Remove leftover paritally downloaded files, if any.
-void PresetUpdater::priv::prune_tmps() const
+// Remove a leftover partial archive for the vendor about to be synchronized.
+void PresetUpdater::priv::prune_tmp(const std::string& vendor_id) const
 {
-	boost::system::error_code ec;
-	auto dir_it = boost::filesystem::directory_iterator(cache_path, ec);
-	if (ec) {
-		BOOST_LOG_TRIVIAL(warning) << "[Orca Updater]failed to list cache dir " << cache_path.string() << ": " << ec.message();
-		return;
-	}
-	for (auto &dir_entry : dir_it)
-		if (is_plain_file(dir_entry) && dir_entry.path().extension() == TMP_EXTENSION) {
-			BOOST_LOG_TRIVIAL(debug) << "[Orca Updater]remove old cached files: " << dir_entry.path().string();
-			fs::remove(dir_entry.path(), ec);
-			if (ec)
-				BOOST_LOG_TRIVIAL(warning) << "[Orca Updater]failed to remove " << dir_entry.path().string() << ": " << ec.message();
-		}
+    boost::system::error_code ec;
+    const fs::path tmp_path = cache_path / (vendor_id + TMP_EXTENSION);
+    fs::remove(tmp_path, ec);
+    if (ec)
+        BOOST_LOG_TRIVIAL(warning) << "[Orca Updater]failed to remove " << tmp_path.string() << ": " << ec.message();
 }
 
 //BBS: refine the Preset Updater logic
@@ -1346,49 +1336,29 @@ PresetUpdater::~PresetUpdater()
 
 //BBS: change directories by design
 //BBS: refine the preset updater logic
-void PresetUpdater::sync(std::string http_url, std::string language, std::string plugin_version, PresetBundle *preset_bundle)
+void PresetUpdater::sync(std::string http_url, std::string language, std::string plugin_version, PresetBundle * /*preset_bundle*/)
 {
 	//p->set_download_prefs(GUI::wxGetApp().app_config);
 	if (!p->enabled_version_check && !p->enabled_config_update) { return; }
 
-	// Copy the whole vendors data for use in the background thread
-	// Unfortunatelly as of C++11, it needs to be copied again
-	// into the closure (but perhaps the compiler can elide this).
-    VendorMap vendors = preset_bundle ? preset_bundle->vendors : VendorMap{};
-
-    // Determine active vendor before entering the thread
-    std::string active_vendor;
-    if (preset_bundle) {
-        const Preset& printer = preset_bundle->printers.get_edited_preset();
-        if (printer.vendor)
-            active_vendor = printer.vendor->id;
-    }
-
-	p->thread = std::thread([this, vendors, active_vendor, http_url, language, plugin_version]() {
-		this->p->prune_tmps();
-		if (p->cancel)
-			return;
-		this->p->sync_version();
-		if (p->cancel)
-			return;
-        // Per-vendor config check for the active vendor at startup
-        if (!active_vendor.empty() && !vendors.empty()) {
-            this->p->sync_vendor_config(active_vendor);
-            if (p->cancel)
-                return;
-            {
-                std::lock_guard<std::mutex> lock(this->p->vendor_check_mutex);
-                this->p->checked_vendors.insert(active_vendor);
-            }
-        }
-		if (p->cancel)
-			return;
-        this->p->sync_plugins(http_url, plugin_version);
-        this->p->sync_printer_config(http_url);
-		//if (p->cancel)
-		//	return;
-		//remove the tooltip currently
-		//this->p->sync_tooltip(http_url, language);
+	p->thread = std::thread([this, http_url, language, plugin_version]() {
+		try {
+			this->p->sync_version();
+			if (p->cancel)
+				return;
+			// Vendor profile updates are triggered by check_vendor_update()
+			// after the startup printer preset has been restored.
+            this->p->sync_plugins(http_url, plugin_version);
+            this->p->sync_printer_config(http_url);
+			//if (p->cancel)
+			//	return;
+			//remove the tooltip currently
+			//this->p->sync_tooltip(http_url, language);
+		} catch (const std::exception &e) {
+			BOOST_LOG_TRIVIAL(error) << "[Orca Updater] background sync failed: " << e.what();
+		} catch (...) {
+			BOOST_LOG_TRIVIAL(error) << "[Orca Updater] background sync failed with an unknown exception";
+		}
 	});
 }
 
@@ -1397,16 +1367,17 @@ void PresetUpdater::check_vendor_update(const std::string& vendor_id)
     if (!p->enabled_config_update) return;
     if (vendor_id.empty()) return;
 
-    std::lock_guard<std::mutex> lock(p->vendor_check_mutex);
-
     if (!p->checked_vendors.insert(vendor_id).second)
         return;
 
     p->vendor_check_threads.emplace_back([this, vendor_id]() {
         try {
+            this->p->prune_tmp(vendor_id);
             this->p->sync_vendor_config(vendor_id);
         } catch (const std::exception& e) {
             BOOST_LOG_TRIVIAL(error) << "[Orca Updater] vendor update failed for " << vendor_id << ": " << e.what();
+        } catch (...) {
+            BOOST_LOG_TRIVIAL(error) << "[Orca Updater] vendor update failed for " << vendor_id << " with an unknown exception";
         }
     });
 }

--- a/src/slic3r/Utils/PresetUpdater.cpp
+++ b/src/slic3r/Utils/PresetUpdater.cpp
@@ -1094,10 +1094,9 @@ void PresetUpdater::priv::check_installed_vendor_profiles() const
                         Semver resource_ver = get_version_from_json(file_path);
                         Semver vendor_ver = get_version_from_json(path_in_vendor.string());
 
-                        bool version_match = ((resource_ver.maj() == vendor_ver.maj()) && (resource_ver.min() == vendor_ver.min()));
-
-                        if (!version_match || (vendor_ver < resource_ver)) {
-                            BOOST_LOG_TRIVIAL(info) << "[Orca Updater]:found vendor "<<vendor_name<<" newer version "<<resource_ver.to_string() <<" from resource, old version "<<vendor_ver.to_string();
+                        if (vendor_ver < resource_ver) {
+                            BOOST_LOG_TRIVIAL(info) << "[Orca Updater]:found vendor " << vendor_name << " newer version "
+                                                    << resource_ver.to_string() << " from resource, old version " << vendor_ver.to_string();
                             bundles.insert(vendor_name);
                         }
                     }

--- a/src/slic3r/Utils/PresetUpdater.cpp
+++ b/src/slic3r/Utils/PresetUpdater.cpp
@@ -1,12 +1,15 @@
 #include "PresetUpdater.hpp"
 
 #include <algorithm>
+#include <boost/filesystem/directory.hpp>
 #include <boost/filesystem/operations.hpp>
+#include <boost/filesystem/path.hpp>
 #include <boost/nowide/fstream.hpp>
 #include <functional>
 #include <atomic>
 #include <mutex>
 #include <set>
+#include <string>
 #include <thread>
 #include <unordered_map>
 #include <ostream>
@@ -19,6 +22,7 @@
 #include <boost/lexical_cast.hpp>
 #include <boost/log/trivial.hpp>
 
+#include <vector>
 #include <wx/app.h>
 #include <wx/msgdlg.h>
 
@@ -229,6 +233,8 @@ struct PresetUpdater::priv
 	void parse_version_string(const std::string& body) const;
     void sync_resources(std::string http_url, std::map<std::string, Resource> &resources, bool check_patch = false,  std::string current_version="", std::string changelog_file="");
     void sync_vendor_config(const std::string& vendor_id);
+    std::vector<std::string> check_new_vendors();
+	std::set<std::string> get_all_system_vendors();
     void sync_tooltip(std::string http_url, std::string language);
     void sync_plugins(std::string http_url, std::string plugin_version);
     void sync_printer_config(std::string http_url);
@@ -1402,6 +1408,76 @@ void PresetUpdater::check_vendor_update(const std::string& vendor_id)
             BOOST_LOG_TRIVIAL(error) << "[Orca Updater] vendor update failed for " << vendor_id << ": " << e.what();
         }
     });
+}
+
+// TBD the actual shape of the reponse before using this.
+std::vector<std::string> PresetUpdater::priv::check_new_vendors()
+{
+    AppConfig* app_config = GUI::wxGetApp().app_config;
+    std::string url       = app_config->profile_update_url() + "/new?orca_version=" + Http::url_encode(SoftFever_VERSION);
+
+    auto check_cancel = [this](Http::Progress, bool& cancel_http) {
+        if (cancel || vendor_check_cancel)
+            cancel_http = true;
+    };
+
+    std::vector<std::string> vendor_ids;
+    const auto system_vendors = get_all_system_vendors();
+    const std::vector<std::string> system_vendor_list(system_vendors.begin(), system_vendors.end());
+
+    auto post = Http::post(url);
+
+    post.timeout_connect(5);
+    post.on_progress(check_cancel);
+    post.on_error([](std::string body, std::string error, unsigned http_status) {
+            BOOST_LOG_TRIVIAL(warning) << "[Orca Updater] new vendor check HTTP error: " << error;
+        })
+        .on_complete([&vendor_ids](std::string body, unsigned http_status) {
+            if (http_status != 200)
+                return;
+            try {
+                json j = json::parse(body);
+                if (j.is_array()) {
+                    vendor_ids = j.get<std::vector<std::string>>();
+                }
+            } catch (const std::exception& e) {
+                BOOST_LOG_TRIVIAL(warning) << "[Orca Updater] vendor check JSON parse failed: " << e.what();
+            }
+        });
+
+    post.set_post_body(json(system_vendor_list).dump());
+    post.perform_sync();
+
+    return vendor_ids;
+}
+
+std::set<std::string> PresetUpdater::priv::get_all_system_vendors() {
+    std::set<std::string> vendors;
+
+    PresetBundle temp_bundle;
+    boost::filesystem::path dir = boost::filesystem::path(resources_dir()) / "profiles";
+
+    for (auto& entry : boost::filesystem::directory_iterator(dir)) {
+        if (!Slic3r::is_json_file(entry.path().string()))
+            continue;
+        std::string vendor_name = entry.path().filename().stem().string();
+        temp_bundle.load_vendor_configs_from_json(dir.string(), vendor_name, PresetBundle::LoadSystem,
+                                                  ForwardCompatibilitySubstitutionRule::EnableSystemSilent);
+    }
+
+    for (auto& preset : temp_bundle.printers)
+        if (preset.is_system)
+            vendors.insert(preset.vendor->name);
+
+    for (auto& preset : temp_bundle.prints)
+        if (preset.is_system)
+            vendors.insert(preset.vendor->name);
+
+    for (auto& preset : temp_bundle.filaments)
+        if (preset.is_system)
+            vendors.insert(preset.vendor->name);
+
+    return vendors;
 }
 
 void PresetUpdater::slic3r_update_notify()

--- a/src/slic3r/Utils/PresetUpdater.cpp
+++ b/src/slic3r/Utils/PresetUpdater.cpp
@@ -208,6 +208,8 @@ struct PresetUpdater::priv
 
     // Per-vendor update checking
     std::set<std::string> checked_vendors;
+    std::unordered_map<std::string, std::string> vendor_changelogs;
+    mutable std::mutex vendor_changelogs_mutex;
     std::mutex vendor_check_mutex;
     std::vector<std::thread> vendor_check_threads;
     std::atomic<bool> vendor_check_cancel{false};
@@ -675,6 +677,9 @@ void PresetUpdater::priv::sync_vendor_config(const std::string& vendor_id)
 
     std::string online_version_str; // this represents the PROFILE VERSION, not ORCA VERSION
     std::string download_url_str;
+    std::string changelog;
+
+    BOOST_LOG_TRIVIAL(info) << "[Orca Updater] fetching vendor update status from " << url;
 
     Http::get(url)
         .timeout_connect(5)
@@ -687,9 +692,13 @@ void PresetUpdater::priv::sync_vendor_config(const std::string& vendor_id)
             if (http_status != 200) return;
             try {
                 json j = json::parse(body);
-                if (j.contains("vendor_version") && j.contains("download_url")) {
-                    online_version_str = j["vendor_version"].get<std::string>();
+                BOOST_LOG_TRIVIAL(info) << "[Orca Updater] url: " << url << " returned:" << body;
+
+                if ((j.contains("version") || j.contains("vendor_version")) && j.contains("download_url")) {
+                    online_version_str = j.contains("version") ? j["version"].get<std::string>()
+                                                               : j["vendor_version"].get<std::string>();
                     download_url_str = j["download_url"].get<std::string>();
+                    changelog        = j.value("changelog", std::string());
                 }
             } catch (const std::exception& e) {
                 BOOST_LOG_TRIVIAL(warning) << "[Orca Updater] vendor check JSON parse failed: " << e.what();
@@ -711,7 +720,6 @@ void PresetUpdater::priv::sync_vendor_config(const std::string& vendor_id)
     boost::system::error_code ec;
     fs::remove_all(cache_profile_path / vendor_id, ec);
     fs::remove(cache_profile_path / (vendor_id + ".json"), ec);
-    fs::remove(cache_profile_path / (vendor_id + ".changelog"), ec);
 
     // Download the zip
     BOOST_LOG_TRIVIAL(info) << "[Orca Updater] downloading update for " << vendor_id
@@ -748,6 +756,11 @@ void PresetUpdater::priv::sync_vendor_config(const std::string& vendor_id)
     fs::remove(download_file, ec);
 
     if (cancel || vendor_check_cancel) return;
+
+    {
+        std::lock_guard<std::mutex> lock(vendor_changelogs_mutex);
+        vendor_changelogs[vendor_id] = std::move(changelog);
+    }
 
     BOOST_LOG_TRIVIAL(info) << "[Orca Updater] vendor " << vendor_id << " update cached, notifying UI";
     GUI::wxGetApp().CallAfter([] {
@@ -1190,6 +1203,12 @@ Updates PresetUpdater::priv::get_config_updates(const Semver &old_slic3r_version
     if (!fs::exists(cache_profile_path))
         return updates;
 
+    std::unordered_map<std::string, std::string> changelogs;
+    {
+        std::lock_guard<std::mutex> lock(vendor_changelogs_mutex);
+        changelogs = vendor_changelogs;
+    }
+
     for (auto &dir_entry : boost::filesystem::directory_iterator(cache_profile_path)) {
         const auto &path = dir_entry.path();
         std::string file_path = path.string();
@@ -1223,15 +1242,8 @@ Updates PresetUpdater::priv::get_config_updates(const Semver &old_slic3r_version
                 if (config_version)
                     cache_ver = *config_version;
 
-                std::string changelog;
-                std::string changelog_file = (cache_profile_path / (vendor_name + ".changelog")).string();
-                boost::nowide::ifstream ifs(changelog_file);
-                if (ifs) {
-                    std::ostringstream oss;
-                    oss<< ifs.rdbuf();
-                    changelog = oss.str();
-                    ifs.close();
-                }
+                const auto changelog_it = changelogs.find(vendor_name);
+                std::string changelog = changelog_it != changelogs.end() ? changelog_it->second : std::string();
 
                 if (vendor_ver < cache_ver) {
                     BOOST_LOG_TRIVIAL(info) << "[Orca Updater]:need to update settings from " << vendor_ver.to_string()

--- a/src/slic3r/Utils/PresetUpdater.cpp
+++ b/src/slic3r/Utils/PresetUpdater.cpp
@@ -1,15 +1,12 @@
 #include "PresetUpdater.hpp"
 
 #include <algorithm>
-#include <boost/filesystem/directory.hpp>
 #include <boost/filesystem/operations.hpp>
-#include <boost/filesystem/path.hpp>
 #include <boost/nowide/fstream.hpp>
 #include <functional>
 #include <atomic>
 #include <mutex>
 #include <set>
-#include <string>
 #include <thread>
 #include <unordered_map>
 #include <ostream>
@@ -22,7 +19,6 @@
 #include <boost/lexical_cast.hpp>
 #include <boost/log/trivial.hpp>
 
-#include <vector>
 #include <wx/app.h>
 #include <wx/msgdlg.h>
 
@@ -233,8 +229,6 @@ struct PresetUpdater::priv
 	void parse_version_string(const std::string& body) const;
     void sync_resources(std::string http_url, std::map<std::string, Resource> &resources, bool check_patch = false,  std::string current_version="", std::string changelog_file="");
     void sync_vendor_config(const std::string& vendor_id);
-    std::vector<std::string> check_new_vendors();
-	std::set<std::string> get_all_system_vendors();
     void sync_tooltip(std::string http_url, std::string language);
     void sync_plugins(std::string http_url, std::string plugin_version);
     void sync_printer_config(std::string http_url);
@@ -1408,76 +1402,6 @@ void PresetUpdater::check_vendor_update(const std::string& vendor_id)
             BOOST_LOG_TRIVIAL(error) << "[Orca Updater] vendor update failed for " << vendor_id << ": " << e.what();
         }
     });
-}
-
-// TBD the actual shape of the reponse before using this.
-std::vector<std::string> PresetUpdater::priv::check_new_vendors()
-{
-    AppConfig* app_config = GUI::wxGetApp().app_config;
-    std::string url       = app_config->profile_update_url() + "/new?orca_version=" + Http::url_encode(SoftFever_VERSION);
-
-    auto check_cancel = [this](Http::Progress, bool& cancel_http) {
-        if (cancel || vendor_check_cancel)
-            cancel_http = true;
-    };
-
-    std::vector<std::string> vendor_ids;
-    const auto system_vendors = get_all_system_vendors();
-    const std::vector<std::string> system_vendor_list(system_vendors.begin(), system_vendors.end());
-
-    auto post = Http::post(url);
-
-    post.timeout_connect(5);
-    post.on_progress(check_cancel);
-    post.on_error([](std::string body, std::string error, unsigned http_status) {
-            BOOST_LOG_TRIVIAL(warning) << "[Orca Updater] new vendor check HTTP error: " << error;
-        })
-        .on_complete([&vendor_ids](std::string body, unsigned http_status) {
-            if (http_status != 200)
-                return;
-            try {
-                json j = json::parse(body);
-                if (j.is_array()) {
-                    vendor_ids = j.get<std::vector<std::string>>();
-                }
-            } catch (const std::exception& e) {
-                BOOST_LOG_TRIVIAL(warning) << "[Orca Updater] vendor check JSON parse failed: " << e.what();
-            }
-        });
-
-    post.set_post_body(json(system_vendor_list).dump());
-    post.perform_sync();
-
-    return vendor_ids;
-}
-
-std::set<std::string> PresetUpdater::priv::get_all_system_vendors() {
-    std::set<std::string> vendors;
-
-    PresetBundle temp_bundle;
-    boost::filesystem::path dir = boost::filesystem::path(resources_dir()) / "profiles";
-
-    for (auto& entry : boost::filesystem::directory_iterator(dir)) {
-        if (!Slic3r::is_json_file(entry.path().string()))
-            continue;
-        std::string vendor_name = entry.path().filename().stem().string();
-        temp_bundle.load_vendor_configs_from_json(dir.string(), vendor_name, PresetBundle::LoadSystem,
-                                                  ForwardCompatibilitySubstitutionRule::EnableSystemSilent);
-    }
-
-    for (auto& preset : temp_bundle.printers)
-        if (preset.is_system)
-            vendors.insert(preset.vendor->name);
-
-    for (auto& preset : temp_bundle.prints)
-        if (preset.is_system)
-            vendors.insert(preset.vendor->name);
-
-    for (auto& preset : temp_bundle.filaments)
-        if (preset.is_system)
-            vendors.insert(preset.vendor->name);
-
-    return vendors;
 }
 
 void PresetUpdater::slic3r_update_notify()

--- a/src/slic3r/Utils/PresetUpdater.cpp
+++ b/src/slic3r/Utils/PresetUpdater.cpp
@@ -208,8 +208,6 @@ struct PresetUpdater::priv
 
     // Per-vendor update checking
     std::set<std::string> checked_vendors;
-    std::unordered_map<std::string, std::string> vendor_changelogs;
-    mutable std::mutex vendor_changelogs_mutex;
     std::mutex vendor_check_mutex;
     std::vector<std::thread> vendor_check_threads;
     std::atomic<bool> vendor_check_cancel{false};
@@ -677,9 +675,6 @@ void PresetUpdater::priv::sync_vendor_config(const std::string& vendor_id)
 
     std::string online_version_str; // this represents the PROFILE VERSION, not ORCA VERSION
     std::string download_url_str;
-    std::string changelog;
-
-    BOOST_LOG_TRIVIAL(info) << "[Orca Updater] fetching vendor update status from " << url;
 
     Http::get(url)
         .timeout_connect(5)
@@ -692,13 +687,9 @@ void PresetUpdater::priv::sync_vendor_config(const std::string& vendor_id)
             if (http_status != 200) return;
             try {
                 json j = json::parse(body);
-                BOOST_LOG_TRIVIAL(info) << "[Orca Updater] url: " << url << " returned:" << body;
-
-                if ((j.contains("version") || j.contains("vendor_version")) && j.contains("download_url")) {
-                    online_version_str = j.contains("version") ? j["version"].get<std::string>()
-                                                               : j["vendor_version"].get<std::string>();
+                if (j.contains("vendor_version") && j.contains("download_url")) {
+                    online_version_str = j["vendor_version"].get<std::string>();
                     download_url_str = j["download_url"].get<std::string>();
-                    changelog        = j.value("changelog", std::string());
                 }
             } catch (const std::exception& e) {
                 BOOST_LOG_TRIVIAL(warning) << "[Orca Updater] vendor check JSON parse failed: " << e.what();
@@ -720,6 +711,7 @@ void PresetUpdater::priv::sync_vendor_config(const std::string& vendor_id)
     boost::system::error_code ec;
     fs::remove_all(cache_profile_path / vendor_id, ec);
     fs::remove(cache_profile_path / (vendor_id + ".json"), ec);
+    fs::remove(cache_profile_path / (vendor_id + ".changelog"), ec);
 
     // Download the zip
     BOOST_LOG_TRIVIAL(info) << "[Orca Updater] downloading update for " << vendor_id
@@ -756,11 +748,6 @@ void PresetUpdater::priv::sync_vendor_config(const std::string& vendor_id)
     fs::remove(download_file, ec);
 
     if (cancel || vendor_check_cancel) return;
-
-    {
-        std::lock_guard<std::mutex> lock(vendor_changelogs_mutex);
-        vendor_changelogs[vendor_id] = std::move(changelog);
-    }
 
     BOOST_LOG_TRIVIAL(info) << "[Orca Updater] vendor " << vendor_id << " update cached, notifying UI";
     GUI::wxGetApp().CallAfter([] {
@@ -1203,12 +1190,6 @@ Updates PresetUpdater::priv::get_config_updates(const Semver &old_slic3r_version
     if (!fs::exists(cache_profile_path))
         return updates;
 
-    std::unordered_map<std::string, std::string> changelogs;
-    {
-        std::lock_guard<std::mutex> lock(vendor_changelogs_mutex);
-        changelogs = vendor_changelogs;
-    }
-
     for (auto &dir_entry : boost::filesystem::directory_iterator(cache_profile_path)) {
         const auto &path = dir_entry.path();
         std::string file_path = path.string();
@@ -1242,8 +1223,15 @@ Updates PresetUpdater::priv::get_config_updates(const Semver &old_slic3r_version
                 if (config_version)
                     cache_ver = *config_version;
 
-                const auto changelog_it = changelogs.find(vendor_name);
-                std::string changelog = changelog_it != changelogs.end() ? changelog_it->second : std::string();
+                std::string changelog;
+                std::string changelog_file = (cache_profile_path / (vendor_name + ".changelog")).string();
+                boost::nowide::ifstream ifs(changelog_file);
+                if (ifs) {
+                    std::ostringstream oss;
+                    oss<< ifs.rdbuf();
+                    changelog = oss.str();
+                    ifs.close();
+                }
 
                 if (vendor_ver < cache_ver) {
                     BOOST_LOG_TRIVIAL(info) << "[Orca Updater]:need to update settings from " << vendor_ver.to_string()


### PR DESCRIPTION
## Summary

- make the profile updater endpoint configurable through `orca_updater_url`

## Notes
For 2.4.x, changelog isn't available on OrcaSlicer.
