### PR TITLE
Localization refactor pt 2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -835,7 +835,7 @@ endif ()
 set(L10N_DIR "${SLIC3R_RESOURCES_DIR}/i18n")
 set(BBL_L18N_DIR "${CMAKE_CURRENT_SOURCE_DIR}/localization/i18n")
 add_custom_target(gettext_make_pot
-    COMMAND xgettext --keyword=L --keyword=_L --keyword=_u8L --keyword=L_CONTEXT:1,2c --keyword=_CTX:1,2c --keyword=_CTX_utf8:1,2c --keyword=_L_PLURAL:1,2 --add-comments=TRN --from-code=UTF-8 --no-location --debug --boost
+    COMMAND xgettext --keyword=L --keyword=_L --keyword=_u8L --keyword=L_CONTEXT:1,2c --keyword=_L_CONTEXT:1,2c --keyword=_u8L_CONTEXT:1,2c --keyword=_L_PLURAL:1,2 --add-comments=TRN --from-code=UTF-8 --no-location --debug --boost
         -f "${BBL_L18N_DIR}/list.txt"
         -o "${BBL_L18N_DIR}/OrcaSlicer.pot"
     COMMAND hintsToPot ${SLIC3R_RESOURCES_DIR} ${BBL_L18N_DIR}

--- a/localization/i18n/OrcaSlicer.pot
+++ b/localization/i18n/OrcaSlicer.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-23 14:21-0300\n"
+"POT-Creation-Date: 2026-07-23 15:24-0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -552,6 +552,7 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
+msgctxt "Keyboard Shortcut"
 msgid "Enter"
 msgstr ""
 
@@ -1733,12 +1734,14 @@ msgstr ""
 msgid "Select point"
 msgstr ""
 
+msgctxt "Keyboard Shortcut"
 msgid "Delete"
 msgstr ""
 
 msgid "Restart selection"
 msgstr ""
 
+msgctxt "Keyboard Shortcut"
 msgid "Esc"
 msgstr ""
 
@@ -2350,6 +2353,9 @@ msgstr ""
 msgid "Import File"
 msgstr ""
 
+msgid "Delete"
+msgstr ""
+
 msgid "Choose files"
 msgstr ""
 
@@ -2468,12 +2474,14 @@ msgstr ""
 msgid "Show"
 msgstr ""
 
+msgctxt "Keyboard Shortcut"
 msgid "Del"
 msgstr ""
 
 msgid "Delete the selected object"
 msgstr ""
 
+msgctxt "Keyboard Shortcut"
 msgid "Backspace"
 msgstr ""
 
@@ -10839,24 +10847,28 @@ msgstr ""
 msgid "Select objects by rectangle"
 msgstr ""
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Up"
 msgstr ""
 
 msgid "Move selection 10mm in positive Y direction"
 msgstr ""
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Down"
 msgstr ""
 
 msgid "Move selection 10mm in negative Y direction"
 msgstr ""
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Left"
 msgstr ""
 
 msgid "Move selection 10mm in negative X direction"
 msgstr ""
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Right"
 msgstr ""
 
@@ -10941,7 +10953,15 @@ msgstr ""
 msgid "Toggle printable for object/part"
 msgstr ""
 
+msgctxt "Keyboard Shortcut"
+msgid "Tab"
+msgstr ""
+
 msgid "Switch between Prepare/Preview"
+msgstr ""
+
+msgctxt "Keyboard Shortcut"
+msgid "Space"
 msgstr ""
 
 msgid "Open actions speed dial"
@@ -11001,9 +11021,14 @@ msgstr ""
 msgid "Move slider 5x faster"
 msgstr ""
 
+msgctxt "Keyboard Shortcut"
+msgid "Home"
+msgstr ""
+
 msgid "Horizontal slider - Move to start position"
 msgstr ""
 
+msgctxt "Keyboard Shortcut"
 msgid "End"
 msgstr ""
 

--- a/localization/i18n/OrcaSlicer.pot
+++ b/localization/i18n/OrcaSlicer.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-20 10:39-0300\n"
+"POT-Creation-Date: 2026-07-22 19:11-0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -3403,6 +3403,7 @@ msgctxt "air_duct"
 msgid "Left(Aux)"
 msgstr ""
 
+msgctxt "Hotend Heat Breaker Fan"
 msgid "Hotend"
 msgstr ""
 
@@ -8615,6 +8616,15 @@ msgstr ""
 msgid "Displays current viewport FPS in the top-right corner."
 msgstr ""
 
+msgid "G-code Preview"
+msgstr ""
+
+msgid "Dim lower layers"
+msgstr ""
+
+msgid "When scrubbing the layer slider in the sliced preview, render the layers below the current one darkened so that only the layer being viewed is shown at full brightness."
+msgstr ""
+
 msgid "Login region"
 msgstr ""
 
@@ -9178,6 +9188,9 @@ msgid "When spiral vase mode is enabled, machines with I3 structure will not gen
 msgstr ""
 
 msgid "The current printer does not support timelapse in Traditional Mode when printing By-Object."
+msgstr ""
+
+msgid "I have checked the installed nozzle and want to print anyway."
 msgstr ""
 
 msgid "Errors"
@@ -16001,6 +16014,12 @@ msgstr ""
 msgid "Whether this printer supports fast purge mode with optimized temperature and multiplier."
 msgstr ""
 
+msgid "Filament change"
+msgstr ""
+
+msgid "The volume of material required to prime the extruder on the tower, excluding a hotend change."
+msgstr ""
+
 msgid "The volume of material required to prime the extruder for a hotend change on the tower."
 msgstr ""
 
@@ -19049,13 +19068,13 @@ msgstr ""
 msgid "Show details"
 msgstr ""
 
+msgid "Hide details"
+msgstr ""
+
 msgid "Version to install:"
 msgstr ""
 
 msgid "Download and Install"
-msgstr ""
-
-msgid "Skip for Now"
 msgstr ""
 
 msgid "A new version of the Bambu Network Plug-in is available."
@@ -19068,16 +19087,10 @@ msgstr ""
 msgid "Update to version:"
 msgstr ""
 
-msgid "Update Now"
-msgstr ""
-
-msgid "Remind Later"
-msgstr ""
-
-msgid "Skip Version"
-msgstr ""
-
 msgid "Don't Ask Again"
+msgstr ""
+
+msgid "Update Now"
 msgstr ""
 
 msgid "(Latest)"
@@ -19093,9 +19106,6 @@ msgid "A restart is required to load the new plug-in. Would you like to restart 
 msgstr ""
 
 msgid "Restart Now"
-msgstr ""
-
-msgid "Restart Later"
 msgstr ""
 
 msgid "NO RAMMING AT ALL"

--- a/localization/i18n/OrcaSlicer.pot
+++ b/localization/i18n/OrcaSlicer.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-22 19:11-0300\n"
+"POT-Creation-Date: 2026-07-23 14:21-0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -877,6 +877,7 @@ msgstr ""
 msgid "Select all connectors"
 msgstr ""
 
+msgctxt "Cut tool"
 msgid "Cut"
 msgstr ""
 
@@ -1838,6 +1839,7 @@ msgstr ""
 msgid "Leaving Measure gizmo"
 msgstr ""
 
+msgctxt "Assembly tool"
 msgid "Assemble"
 msgstr ""
 
@@ -2657,6 +2659,9 @@ msgid "Convert from Meters"
 msgstr ""
 
 msgid "Restore to Meter"
+msgstr ""
+
+msgid "Assemble"
 msgstr ""
 
 msgid "Assemble the selected objects into an object with multiple parts"
@@ -4121,6 +4126,14 @@ msgstr ""
 msgid "Print with filament in AMS"
 msgstr ""
 
+msgctxt "Nozzle position"
+msgid "Left"
+msgstr ""
+
+msgctxt "Nozzle position"
+msgid "Right"
+msgstr ""
+
 msgid "When the current material run out, the printer will continue to print in the following order."
 msgstr ""
 
@@ -5348,6 +5361,7 @@ msgstr ""
 msgid "Quality / Speed"
 msgstr ""
 
+msgctxt "Mesh action"
 msgid "Smooth"
 msgstr ""
 
@@ -5956,6 +5970,9 @@ msgstr ""
 msgid "Redo"
 msgstr ""
 
+msgid "Cut"
+msgstr ""
+
 msgid "Cut selection to clipboard"
 msgstr ""
 
@@ -6053,6 +6070,10 @@ msgid "Show outline around selected object in 3D scene."
 msgstr ""
 
 msgid "Preferences"
+msgstr ""
+
+msgctxt "Menu"
+msgid "Edit"
 msgstr ""
 
 msgid "View"
@@ -8907,6 +8928,7 @@ msgstr ""
 msgid "The selected preset is null!"
 msgstr ""
 
+msgctxt "Layer range"
 msgid "End"
 msgstr ""
 
@@ -10980,6 +11002,9 @@ msgid "Move slider 5x faster"
 msgstr ""
 
 msgid "Horizontal slider - Move to start position"
+msgstr ""
+
+msgid "End"
 msgstr ""
 
 msgid "Horizontal slider - Move to last position"
@@ -15109,6 +15134,9 @@ msgid "If smooth or traditional mode is selected, a timelapse video will be gene
 msgstr ""
 
 msgid "Traditional"
+msgstr ""
+
+msgid "Smooth"
 msgstr ""
 
 msgid "Farthest point timelapse"

--- a/localization/i18n/ca/OrcaSlicer_ca.po
+++ b/localization/i18n/ca/OrcaSlicer_ca.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-20 10:39-0300\n"
+"POT-Creation-Date: 2026-07-22 19:11-0300\n"
 "PO-Revision-Date: 2025-03-15 10:55+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -3527,8 +3527,9 @@ msgctxt "air_duct"
 msgid "Left(Aux)"
 msgstr "Esquerra (Aux)"
 
+msgctxt "Hotend Heat Breaker Fan"
 msgid "Hotend"
-msgstr "Hotend"
+msgstr ""
 
 msgid "Parts"
 msgstr ""
@@ -9012,6 +9013,15 @@ msgstr ""
 msgid "Displays current viewport FPS in the top-right corner."
 msgstr ""
 
+msgid "G-code Preview"
+msgstr ""
+
+msgid "Dim lower layers"
+msgstr ""
+
+msgid "When scrubbing the layer slider in the sliced preview, render the layers below the current one darkened so that only the layer being viewed is shown at full brightness."
+msgstr ""
+
 msgid "Login region"
 msgstr "Regió d'inici de sessió"
 
@@ -9599,6 +9609,9 @@ msgstr "Quan s'habilita el mode Gerro Espiral, les màquines amb estructura I3 n
 
 msgid "The current printer does not support timelapse in Traditional Mode when printing By-Object."
 msgstr "La impressora actual no admet el timelapse en mode tradicional quan s'imprimeix per objecte."
+
+msgid "I have checked the installed nozzle and want to print anyway."
+msgstr ""
 
 msgid "Errors"
 msgstr ""
@@ -16994,6 +17007,12 @@ msgstr ""
 msgid "Whether this printer supports fast purge mode with optimized temperature and multiplier."
 msgstr ""
 
+msgid "Filament change"
+msgstr ""
+
+msgid "The volume of material required to prime the extruder on the tower, excluding a hotend change."
+msgstr ""
+
 msgid "The volume of material required to prime the extruder for a hotend change on the tower."
 msgstr ""
 
@@ -20217,14 +20236,14 @@ msgstr ""
 msgid "Show details"
 msgstr "Mostra detalls"
 
+msgid "Hide details"
+msgstr ""
+
 msgid "Version to install:"
 msgstr "Versió a instal·lar:"
 
 msgid "Download and Install"
 msgstr "Descarrega i instal·la"
-
-msgid "Skip for Now"
-msgstr "Omet per ara"
 
 msgid "A new version of the Bambu Network Plug-in is available."
 msgstr "Hi ha disponible una nova versió del connector de xarxa Bambu."
@@ -20236,17 +20255,11 @@ msgstr "Versió actual: %s"
 msgid "Update to version:"
 msgstr "Actualitza a la versió:"
 
-msgid "Update Now"
-msgstr "Actualitza ara"
-
-msgid "Remind Later"
-msgstr "Recorda més tard"
-
-msgid "Skip Version"
-msgstr "Omet versió"
-
 msgid "Don't Ask Again"
 msgstr "No tornis a preguntar"
+
+msgid "Update Now"
+msgstr "Actualitza ara"
 
 msgid "(Latest)"
 msgstr "(Última)"
@@ -20262,9 +20275,6 @@ msgstr "Cal un reinici per carregar el nou connector. Voleu reiniciar ara?"
 
 msgid "Restart Now"
 msgstr "Reinicia ara"
-
-msgid "Restart Later"
-msgstr "Reinicia més tard"
 
 msgid "NO RAMMING AT ALL"
 msgstr "SENSE EMPENTA"
@@ -20848,6 +20858,21 @@ msgid ""
 msgstr ""
 "Evitar la deformació( warping )\n"
 "Sabíeu que quan imprimiu materials propensos a deformar-se, com ara l'ABS, augmentar adequadament la temperatura del llit pot reduir la probabilitat de deformació?"
+
+#~ msgid "Hotend"
+#~ msgstr "Hotend"
+
+#~ msgid "Skip for Now"
+#~ msgstr "Omet per ara"
+
+#~ msgid "Remind Later"
+#~ msgstr "Recorda més tard"
+
+#~ msgid "Skip Version"
+#~ msgstr "Omet versió"
+
+#~ msgid "Restart Later"
+#~ msgstr "Reinicia més tard"
 
 #~ msgid "Select filament that installed to the left nozzle"
 #~ msgstr "Seleccioneu el filament instal·lat al broquet esquerre"

--- a/localization/i18n/ca/OrcaSlicer_ca.po
+++ b/localization/i18n/ca/OrcaSlicer_ca.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-23 14:21-0300\n"
+"POT-Creation-Date: 2026-07-23 15:24-0300\n"
 "PO-Revision-Date: 2025-03-15 10:55+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -559,8 +559,9 @@ msgstr "Remapa"
 msgid "Reset"
 msgstr "Restablir"
 
+msgctxt "Keyboard Shortcut"
 msgid "Enter"
-msgstr "Retorn"
+msgstr ""
 
 msgid "Shortcut Key "
 msgstr "Tecla de drecera "
@@ -1766,12 +1767,14 @@ msgstr "Seleccionar"
 msgid "Select point"
 msgstr "Seleccionar el punt"
 
+msgctxt "Keyboard Shortcut"
 msgid "Delete"
-msgstr "Esborrar"
+msgstr ""
 
 msgid "Restart selection"
 msgstr "Reinicia la selecció"
 
+msgctxt "Keyboard Shortcut"
 msgid "Esc"
 msgstr ""
 
@@ -2416,6 +2419,9 @@ msgstr "No s'ha pogut iniciar la descàrrega d'URL. La carpeta de destinació no
 msgid "Import File"
 msgstr "Importar arxiu"
 
+msgid "Delete"
+msgstr "Esborrar"
+
 msgid "Choose files"
 msgstr "Trieu fitxers"
 
@@ -2546,14 +2552,16 @@ msgstr "Amagar"
 msgid "Show"
 msgstr "Mostrar"
 
+msgctxt "Keyboard Shortcut"
 msgid "Del"
-msgstr "Esborrar"
+msgstr ""
 
 msgid "Delete the selected object"
 msgstr "Eliminar l'objecte seleccionat"
 
+msgctxt "Keyboard Shortcut"
 msgid "Backspace"
-msgstr "Retrocés"
+msgstr ""
 
 msgid "Load..."
 msgstr "Carregar..."
@@ -11337,29 +11345,33 @@ msgstr "Seleccionar múltiples objectes"
 msgid "Select objects by rectangle"
 msgstr "Seleccionar objectes per rectangle"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Up"
-msgstr "Fletxa cap amunt"
+msgstr ""
 
 # TODO: Review, changed by lang refactor. PR 14254
 msgid "Move selection 10mm in positive Y direction"
 msgstr "Moure la selecció 10 mm en direcció Y positiva"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Down"
-msgstr "Fletxa cap avall"
+msgstr ""
 
 # TODO: Review, changed by lang refactor. PR 14254
 msgid "Move selection 10mm in negative Y direction"
 msgstr "Moure la selecció 10 mm en direcció Y negativa"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Left"
-msgstr "Fletxa cap a l’esquerra"
+msgstr ""
 
 # TODO: Review, changed by lang refactor. PR 14254
 msgid "Move selection 10mm in negative X direction"
 msgstr "Moure la selecció 10 mm en direcció X negativa"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Right"
-msgstr "Fletxa cap a la dreta"
+msgstr ""
 
 # TODO: Review, changed by lang refactor. PR 14254
 msgid "Move selection 10mm in positive X direction"
@@ -11445,8 +11457,16 @@ msgstr "Reduir zoom"
 msgid "Toggle printable for object/part"
 msgstr ""
 
+msgctxt "Keyboard Shortcut"
+msgid "Tab"
+msgstr ""
+
 msgid "Switch between Prepare/Preview"
 msgstr "Canviar entre Preparar/Previsualitzar"
+
+msgctxt "Keyboard Shortcut"
+msgid "Space"
+msgstr ""
 
 msgid "Open actions speed dial"
 msgstr ""
@@ -11506,11 +11526,16 @@ msgstr "Activar/Desactivar finestra de Codi-G"
 msgid "Move slider 5x faster"
 msgstr "Moure la barra de desplaçament 5 vegades més ràpid"
 
+msgctxt "Keyboard Shortcut"
+msgid "Home"
+msgstr ""
+
 msgid "Horizontal slider - Move to start position"
 msgstr "Control lliscant horitzontal - Mou fins a la posició inicial"
 
+msgctxt "Keyboard Shortcut"
 msgid "End"
-msgstr "Final"
+msgstr ""
 
 msgid "Horizontal slider - Move to last position"
 msgstr "Control lliscant horitzontal - Mou a l'última posició"
@@ -20886,6 +20911,30 @@ msgid ""
 msgstr ""
 "Evitar la deformació( warping )\n"
 "Sabíeu que quan imprimiu materials propensos a deformar-se, com ara l'ABS, augmentar adequadament la temperatura del llit pot reduir la probabilitat de deformació?"
+
+#~ msgid "Enter"
+#~ msgstr "Retorn"
+
+#~ msgid "Del"
+#~ msgstr "Esborrar"
+
+#~ msgid "Backspace"
+#~ msgstr "Retrocés"
+
+#~ msgid "Arrow Up"
+#~ msgstr "Fletxa cap amunt"
+
+#~ msgid "Arrow Down"
+#~ msgstr "Fletxa cap avall"
+
+#~ msgid "Arrow Left"
+#~ msgstr "Fletxa cap a l’esquerra"
+
+#~ msgid "Arrow Right"
+#~ msgstr "Fletxa cap a la dreta"
+
+#~ msgid "End"
+#~ msgstr "Final"
 
 #~ msgid "Hotend"
 #~ msgstr "Hotend"

--- a/localization/i18n/ca/OrcaSlicer_ca.po
+++ b/localization/i18n/ca/OrcaSlicer_ca.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-22 19:11-0300\n"
+"POT-Creation-Date: 2026-07-23 14:21-0300\n"
 "PO-Revision-Date: 2025-03-15 10:55+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -896,8 +896,9 @@ msgstr "Suprimeix el connector de la selecció"
 msgid "Select all connectors"
 msgstr "Seleccioneu tots els connectors"
 
+msgctxt "Cut tool"
 msgid "Cut"
-msgstr "Retalla"
+msgstr ""
 
 msgid "Rotate cut plane"
 msgstr "Girar el pla tallat"
@@ -1877,8 +1878,9 @@ msgstr ""
 msgid "Leaving Measure gizmo"
 msgstr ""
 
+msgctxt "Assembly tool"
 msgid "Assemble"
-msgstr "Ensamblar"
+msgstr ""
 
 msgid "Please confirm explosion ratio = 1 and select at least two volumes."
 msgstr "Confirmeu que la proporció d'explosió = 1 i seleccioneu almenys dos volums."
@@ -2749,6 +2751,9 @@ msgstr "Convertir des de metres"
 # TODO: Review, changed by lang refactor. PR 14254
 msgid "Restore to Meter"
 msgstr "Restaurar a metres"
+
+msgid "Assemble"
+msgstr "Ensamblar"
 
 msgid "Assemble the selected objects into an object with multiple parts"
 msgstr "Ensamblar els objectes seleccionats a un objecte amb diverses peces"
@@ -4288,6 +4293,14 @@ msgstr "Imprimir amb materials muntats a la part posterior de la carcassa"
 msgid "Print with filament in AMS"
 msgstr "Imprimir amb filaments en ams"
 
+msgctxt "Nozzle position"
+msgid "Left"
+msgstr ""
+
+msgctxt "Nozzle position"
+msgid "Right"
+msgstr ""
+
 msgid "When the current material run out, the printer will continue to print in the following order."
 msgstr "Quan s'esgoti el material actual, la impressora continuarà imprimint en l'ordre següent."
 
@@ -5606,8 +5619,9 @@ msgstr "Adaptativa"
 msgid "Quality / Speed"
 msgstr "Qualitat / Velocitat"
 
+msgctxt "Mesh action"
 msgid "Smooth"
-msgstr "Suau"
+msgstr ""
 
 msgid "Radius"
 msgstr "Radi"
@@ -6229,6 +6243,9 @@ msgstr "Desfer"
 msgid "Redo"
 msgstr "Refer"
 
+msgid "Cut"
+msgstr "Retalla"
+
 msgid "Cut selection to clipboard"
 msgstr "Tallar la selecció al porta-retalls"
 
@@ -6329,6 +6346,10 @@ msgstr "Mostrar el contorn al voltant de l'objecte seleccionat a l'escena 3D"
 
 msgid "Preferences"
 msgstr "Preferències"
+
+msgctxt "Menu"
+msgid "Edit"
+msgstr ""
 
 msgid "View"
 msgstr "Vista"
@@ -9317,8 +9338,9 @@ msgstr ""
 msgid "The selected preset is null!"
 msgstr "El perfil seleccionat és nul!"
 
+msgctxt "Layer range"
 msgid "End"
-msgstr "Final"
+msgstr ""
 
 msgid "Customize"
 msgstr "Personalitzar"
@@ -11486,6 +11508,9 @@ msgstr "Moure la barra de desplaçament 5 vegades més ràpid"
 
 msgid "Horizontal slider - Move to start position"
 msgstr "Control lliscant horitzontal - Mou fins a la posició inicial"
+
+msgid "End"
+msgstr "Final"
 
 msgid "Horizontal slider - Move to last position"
 msgstr "Control lliscant horitzontal - Mou a l'última posició"
@@ -16018,6 +16043,9 @@ msgstr "Si se selecciona el mode suau o tradicional, es generarà un vídeo time
 
 msgid "Traditional"
 msgstr "Tradicional"
+
+msgid "Smooth"
+msgstr "Suau"
 
 msgid "Farthest point timelapse"
 msgstr ""

--- a/localization/i18n/cs/OrcaSlicer_cs.po
+++ b/localization/i18n/cs/OrcaSlicer_cs.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Orca Slicer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-20 10:39-0300\n"
+"POT-Creation-Date: 2026-07-22 19:11-0300\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Jakub Hencl\n"
 "Language-Team: \n"
@@ -3528,8 +3528,9 @@ msgctxt "air_duct"
 msgid "Left(Aux)"
 msgstr "Levý (Aux)"
 
+msgctxt "Hotend Heat Breaker Fan"
 msgid "Hotend"
-msgstr "Hotend"
+msgstr ""
 
 msgid "Parts"
 msgstr "Díly"
@@ -9009,6 +9010,15 @@ msgstr ""
 msgid "Displays current viewport FPS in the top-right corner."
 msgstr ""
 
+msgid "G-code Preview"
+msgstr ""
+
+msgid "Dim lower layers"
+msgstr ""
+
+msgid "When scrubbing the layer slider in the sliced preview, render the layers below the current one darkened so that only the layer being viewed is shown at full brightness."
+msgstr ""
+
 msgid "Login region"
 msgstr "Oblast přihlášení"
 
@@ -9593,6 +9603,9 @@ msgstr "Při zapnutém režimu spirálové vázy nebudou stroje s konstrukcí I3
 
 msgid "The current printer does not support timelapse in Traditional Mode when printing By-Object."
 msgstr "Aktuální tiskárna nepodporuje časosběr v tradičním režimu při tisku „Podle objektu“."
+
+msgid "I have checked the installed nozzle and want to print anyway."
+msgstr ""
 
 msgid "Errors"
 msgstr "Chyby"
@@ -17035,6 +17048,12 @@ msgstr ""
 msgid "Whether this printer supports fast purge mode with optimized temperature and multiplier."
 msgstr ""
 
+msgid "Filament change"
+msgstr ""
+
+msgid "The volume of material required to prime the extruder on the tower, excluding a hotend change."
+msgstr ""
+
 msgid "The volume of material required to prime the extruder for a hotend change on the tower."
 msgstr "Objem materiálu potřebný k předplnění extruderu při výměně hotendu na věži."
 
@@ -20251,13 +20270,13 @@ msgstr ""
 msgid "Show details"
 msgstr ""
 
+msgid "Hide details"
+msgstr ""
+
 msgid "Version to install:"
 msgstr ""
 
 msgid "Download and Install"
-msgstr ""
-
-msgid "Skip for Now"
 msgstr ""
 
 msgid "A new version of the Bambu Network Plug-in is available."
@@ -20270,16 +20289,10 @@ msgstr ""
 msgid "Update to version:"
 msgstr ""
 
-msgid "Update Now"
-msgstr ""
-
-msgid "Remind Later"
-msgstr ""
-
-msgid "Skip Version"
-msgstr ""
-
 msgid "Don't Ask Again"
+msgstr ""
+
+msgid "Update Now"
 msgstr ""
 
 msgid "(Latest)"
@@ -20295,9 +20308,6 @@ msgid "A restart is required to load the new plug-in. Would you like to restart 
 msgstr ""
 
 msgid "Restart Now"
-msgstr ""
-
-msgid "Restart Later"
 msgstr ""
 
 msgid "NO RAMMING AT ALL"
@@ -20882,6 +20892,9 @@ msgid ""
 msgstr ""
 "Zamezte kroucení\n"
 "Víte, že při tisku materiálů náchylných ke kroucení, jako je ABS, může vhodné zvýšení teploty vyhřívané desky snížit pravděpodobnost kroucení?"
+
+#~ msgid "Hotend"
+#~ msgstr "Hotend"
 
 #~ msgid "Select filament that installed to the left nozzle"
 #~ msgstr "Vyberte filament nainstalovaný v levé trysce"

--- a/localization/i18n/cs/OrcaSlicer_cs.po
+++ b/localization/i18n/cs/OrcaSlicer_cs.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Orca Slicer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-23 14:21-0300\n"
+"POT-Creation-Date: 2026-07-23 15:24-0300\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Jakub Hencl\n"
 "Language-Team: \n"
@@ -554,6 +554,7 @@ msgstr "Přemapovat"
 msgid "Reset"
 msgstr "Obnovit"
 
+msgctxt "Keyboard Shortcut"
 msgid "Enter"
 msgstr ""
 
@@ -1762,12 +1763,14 @@ msgstr "Vybrat"
 msgid "Select point"
 msgstr "Vyberte bod"
 
+msgctxt "Keyboard Shortcut"
 msgid "Delete"
-msgstr "Smazat"
+msgstr ""
 
 msgid "Restart selection"
 msgstr "Restartovat výběr"
 
+msgctxt "Keyboard Shortcut"
 msgid "Esc"
 msgstr ""
 
@@ -2414,6 +2417,9 @@ msgstr "Nelze zahájit stahování URL. Cílová složka není nastavena. Vybert
 msgid "Import File"
 msgstr "Importovat soubor"
 
+msgid "Delete"
+msgstr "Smazat"
+
 msgid "Choose files"
 msgstr "Vyberte soubory"
 
@@ -2543,12 +2549,14 @@ msgstr "Skrýt"
 msgid "Show"
 msgstr "Zobrazit"
 
+msgctxt "Keyboard Shortcut"
 msgid "Del"
 msgstr ""
 
 msgid "Delete the selected object"
 msgstr "Smazat vybraný objekt"
 
+msgctxt "Keyboard Shortcut"
 msgid "Backspace"
 msgstr ""
 
@@ -11339,29 +11347,33 @@ msgstr "Vyberte více objektů"
 msgid "Select objects by rectangle"
 msgstr "Vyberte objekty obdélníkem"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Up"
-msgstr "Šipka nahoru"
+msgstr ""
 
 # TODO: Review, changed by lang refactor. PR 14254
 msgid "Move selection 10mm in positive Y direction"
 msgstr "Přesuňte výběr o 10 mm v kladném směru osy Y"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Down"
-msgstr "Šipka dolů"
+msgstr ""
 
 # TODO: Review, changed by lang refactor. PR 14254
 msgid "Move selection 10mm in negative Y direction"
 msgstr "Přesuňte výběr o 10 mm v záporném směru osy Y"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Left"
-msgstr "Šipka vlevo"
+msgstr ""
 
 # TODO: Review, changed by lang refactor. PR 14254
 msgid "Move selection 10mm in negative X direction"
 msgstr "Přesuňte výběr o 10 mm v záporném směru osy X"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Right"
-msgstr "Šipka vpravo"
+msgstr ""
 
 # TODO: Review, changed by lang refactor. PR 14254
 msgid "Move selection 10mm in positive X direction"
@@ -11447,8 +11459,16 @@ msgstr "Oddálit"
 msgid "Toggle printable for object/part"
 msgstr "Přepnout tisknutelnost objektu/části"
 
+msgctxt "Keyboard Shortcut"
+msgid "Tab"
+msgstr ""
+
 msgid "Switch between Prepare/Preview"
 msgstr "Přepnout mezi Přípravou/Náhledem"
+
+msgctxt "Keyboard Shortcut"
+msgid "Space"
+msgstr ""
 
 msgid "Open actions speed dial"
 msgstr ""
@@ -11508,11 +11528,16 @@ msgstr "Zapnout/vypnout okno G-code"
 msgid "Move slider 5x faster"
 msgstr "Posouvejte posuvník 5× rychleji"
 
+msgctxt "Keyboard Shortcut"
+msgid "Home"
+msgstr ""
+
 msgid "Horizontal slider - Move to start position"
 msgstr "Vodorovný posuvník – přesunout na začátek"
 
+msgctxt "Keyboard Shortcut"
 msgid "End"
-msgstr "Konec"
+msgstr ""
 
 msgid "Horizontal slider - Move to last position"
 msgstr "Vodorovný posuvník – přesunout na poslední pozici"
@@ -20920,6 +20945,21 @@ msgid ""
 msgstr ""
 "Zamezte kroucení\n"
 "Víte, že při tisku materiálů náchylných ke kroucení, jako je ABS, může vhodné zvýšení teploty vyhřívané desky snížit pravděpodobnost kroucení?"
+
+#~ msgid "Arrow Up"
+#~ msgstr "Šipka nahoru"
+
+#~ msgid "Arrow Down"
+#~ msgstr "Šipka dolů"
+
+#~ msgid "Arrow Left"
+#~ msgstr "Šipka vlevo"
+
+#~ msgid "Arrow Right"
+#~ msgstr "Šipka vpravo"
+
+#~ msgid "End"
+#~ msgstr "Konec"
 
 #~ msgid "Hotend"
 #~ msgstr "Hotend"

--- a/localization/i18n/cs/OrcaSlicer_cs.po
+++ b/localization/i18n/cs/OrcaSlicer_cs.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Orca Slicer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-22 19:11-0300\n"
+"POT-Creation-Date: 2026-07-23 14:21-0300\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Jakub Hencl\n"
 "Language-Team: \n"
@@ -891,8 +891,9 @@ msgstr "Odstranit konektor z výběru"
 msgid "Select all connectors"
 msgstr "Vybrat všechny konektory"
 
+msgctxt "Cut tool"
 msgid "Cut"
-msgstr "Řezat"
+msgstr ""
 
 msgid "Rotate cut plane"
 msgstr "Otočit rovinu řezu"
@@ -1873,8 +1874,9 @@ msgstr ""
 msgid "Leaving Measure gizmo"
 msgstr ""
 
+msgctxt "Assembly tool"
 msgid "Assemble"
-msgstr "Sestavit"
+msgstr ""
 
 msgid "Please confirm explosion ratio = 1 and select at least two volumes."
 msgstr "Potvrďte, že poměr rozložení = 1, a vyberte alespoň dva objemy."
@@ -2746,6 +2748,9 @@ msgstr "Převést z metrů"
 # TODO: Review, changed by lang refactor. PR 14254
 msgid "Restore to Meter"
 msgstr "Obnovit na metry"
+
+msgid "Assemble"
+msgstr "Sestavit"
 
 msgid "Assemble the selected objects into an object with multiple parts"
 msgstr "Sestavit vybrané objekty do objektu s více částmi"
@@ -4287,6 +4292,14 @@ msgstr "Tisk z materiálů umístěných na zadní straně krytu"
 msgid "Print with filament in AMS"
 msgstr "Tisk s filamenty v AMS"
 
+msgctxt "Nozzle position"
+msgid "Left"
+msgstr ""
+
+msgctxt "Nozzle position"
+msgid "Right"
+msgstr ""
+
 msgid "When the current material run out, the printer will continue to print in the following order."
 msgstr "Když dojde aktuální materiál, tiskárna bude pokračovat v tisku v tomto pořadí."
 
@@ -5603,8 +5616,9 @@ msgstr "Adaptivní"
 msgid "Quality / Speed"
 msgstr "Kvalita / Rychlost"
 
+msgctxt "Mesh action"
 msgid "Smooth"
-msgstr "Vyhladit"
+msgstr ""
 
 msgid "Radius"
 msgstr "Poloměr"
@@ -6225,6 +6239,9 @@ msgstr "Zpět"
 msgid "Redo"
 msgstr "Znovu provést"
 
+msgid "Cut"
+msgstr "Řezat"
+
 msgid "Cut selection to clipboard"
 msgstr "Vyjmout výběr do schránky"
 
@@ -6325,6 +6342,10 @@ msgstr "Zobrazit obrys kolem vybraného objektu ve 3D scéně."
 
 msgid "Preferences"
 msgstr "Předvolby"
+
+msgctxt "Menu"
+msgid "Edit"
+msgstr ""
 
 msgid "View"
 msgstr "Zobrazit"
@@ -9311,8 +9332,9 @@ msgstr "Nekompatibilní"
 msgid "The selected preset is null!"
 msgstr "Zvolená předvolba je nulová!"
 
+msgctxt "Layer range"
 msgid "End"
-msgstr "Konec"
+msgstr ""
 
 msgid "Customize"
 msgstr "Přizpůsobit"
@@ -11488,6 +11510,9 @@ msgstr "Posouvejte posuvník 5× rychleji"
 
 msgid "Horizontal slider - Move to start position"
 msgstr "Vodorovný posuvník – přesunout na začátek"
+
+msgid "End"
+msgstr "Konec"
 
 msgid "Horizontal slider - Move to last position"
 msgstr "Vodorovný posuvník – přesunout na poslední pozici"
@@ -16067,6 +16092,9 @@ msgstr "Pokud je vybrán plynulý nebo tradiční režim, bude pro každý tisk 
 
 msgid "Traditional"
 msgstr "Tradiční"
+
+msgid "Smooth"
+msgstr "Vyhladit"
 
 msgid "Farthest point timelapse"
 msgstr ""

--- a/localization/i18n/de/OrcaSlicer_de.po
+++ b/localization/i18n/de/OrcaSlicer_de.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Orca Slicer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-22 19:11-0300\n"
+"POT-Creation-Date: 2026-07-23 14:21-0300\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Heiko Liebscher <hliebschergmail.com>\n"
 "Language-Team: \n"
@@ -891,8 +891,9 @@ msgstr "Verbinder aus der Auswahl entfernen"
 msgid "Select all connectors"
 msgstr "Alle Verbinder auswählen"
 
+msgctxt "Cut tool"
 msgid "Cut"
-msgstr "Schneiden"
+msgstr ""
 
 msgid "Rotate cut plane"
 msgstr "Schnittfläche drehen"
@@ -1873,8 +1874,9 @@ msgstr "Measure Gizmo benutzen"
 msgid "Leaving Measure gizmo"
 msgstr "Measure Gizmo verlassen"
 
+msgctxt "Assembly tool"
 msgid "Assemble"
-msgstr "Zusammenbauen"
+msgstr ""
 
 msgid "Please confirm explosion ratio = 1 and select at least two volumes."
 msgstr "Bitte bestätigen Sie das Explosionsverhältnis = 1 und wählen Sie mindestens zwei Volumen aus."
@@ -2751,6 +2753,9 @@ msgstr "Von Metern umrechnen"
 # TODO: Review, changed by lang refactor. PR 14254
 msgid "Restore to Meter"
 msgstr "Auf Meter zurücksetzen"
+
+msgid "Assemble"
+msgstr "Zusammenbauen"
 
 msgid "Assemble the selected objects into an object with multiple parts"
 msgstr "Die ausgewählten Objekte zu einem Objekt mit mehreren Teilen zusammenfügen"
@@ -4290,6 +4295,14 @@ msgstr "Drucken mit Materialien, die an der Rückseite des Gehäuses montiert si
 msgid "Print with filament in AMS"
 msgstr "Drucken mit Materialien im AMS"
 
+msgctxt "Nozzle position"
+msgid "Left"
+msgstr ""
+
+msgctxt "Nozzle position"
+msgid "Right"
+msgstr ""
+
 msgid "When the current material run out, the printer will continue to print in the following order."
 msgstr "Wenn das aktuelle Material leer ist, druckt der Drucker in folgender Reihenfolge weiter."
 
@@ -5607,8 +5620,9 @@ msgstr "Adaptiv"
 msgid "Quality / Speed"
 msgstr "Qualität / Geschwindigkeit"
 
+msgctxt "Mesh action"
 msgid "Smooth"
-msgstr "Höhenunterschiede glätten"
+msgstr ""
 
 msgid "Radius"
 msgstr "Radius"
@@ -6227,6 +6241,9 @@ msgstr "Rückgängig machen"
 msgid "Redo"
 msgstr "Wiederholen"
 
+msgid "Cut"
+msgstr "Schneiden"
+
 msgid "Cut selection to clipboard"
 msgstr "Auswahl in die Zwischenablage ausschneiden"
 
@@ -6327,6 +6344,10 @@ msgstr "Kontur um das ausgewählte Objekt in der 3D-Szene anzeigen."
 
 msgid "Preferences"
 msgstr "Einstellungen"
+
+msgctxt "Menu"
+msgid "Edit"
+msgstr ""
 
 msgid "View"
 msgstr "Ansicht"
@@ -9336,8 +9357,9 @@ msgstr "Inkompatibel"
 msgid "The selected preset is null!"
 msgstr "Das selektierte Profil ist leer!"
 
+msgctxt "Layer range"
 msgid "End"
-msgstr "Ende"
+msgstr ""
 
 msgid "Customize"
 msgstr "Anpassen"
@@ -11517,6 +11539,9 @@ msgstr "Schieberegler 5x schneller bewegen"
 
 msgid "Horizontal slider - Move to start position"
 msgstr "Horizontaler Schieberegler - Zur Startposition bewegen"
+
+msgid "End"
+msgstr "Ende"
 
 msgid "Horizontal slider - Move to last position"
 msgstr "Horizontaler Schieberegler - Zur letzten Position bewegen"
@@ -16170,6 +16195,9 @@ msgstr "Wenn der Modus \"Gleichmäßig\" oder \"Traditionell\" ausgewählt ist, 
 
 msgid "Traditional"
 msgstr "Traditionell"
+
+msgid "Smooth"
+msgstr "Höhenunterschiede glätten"
 
 msgid "Farthest point timelapse"
 msgstr ""

--- a/localization/i18n/de/OrcaSlicer_de.po
+++ b/localization/i18n/de/OrcaSlicer_de.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Orca Slicer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-20 10:39-0300\n"
+"POT-Creation-Date: 2026-07-22 19:11-0300\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Heiko Liebscher <hliebschergmail.com>\n"
 "Language-Team: \n"
@@ -3530,8 +3530,9 @@ msgctxt "air_duct"
 msgid "Left(Aux)"
 msgstr "Links(Aux)"
 
+msgctxt "Hotend Heat Breaker Fan"
 msgid "Hotend"
-msgstr "Hotend"
+msgstr ""
 
 msgid "Parts"
 msgstr "Teile"
@@ -9028,6 +9029,15 @@ msgstr "FPS-Overlay anzeigen"
 msgid "Displays current viewport FPS in the top-right corner."
 msgstr "Zeigt die aktuelle FPS des Viewports in der oberen rechten Ecke an."
 
+msgid "G-code Preview"
+msgstr ""
+
+msgid "Dim lower layers"
+msgstr ""
+
+msgid "When scrubbing the layer slider in the sliced preview, render the layers below the current one darkened so that only the layer being viewed is shown at full brightness."
+msgstr ""
+
 msgid "Login region"
 msgstr "Anmeldungsregion"
 
@@ -9618,6 +9628,9 @@ msgstr "Wenn der Spiral-Vase-Modus aktiviert ist, werden bei Maschinen mit I3-St
 
 msgid "The current printer does not support timelapse in Traditional Mode when printing By-Object."
 msgstr "Der aktuelle Drucker unterstützt im traditionellen Modus keinen Zeitraffer beim Drucken nach Objekt."
+
+msgid "I have checked the installed nozzle and want to print anyway."
+msgstr ""
 
 msgid "Errors"
 msgstr "Fehler"
@@ -17151,6 +17164,12 @@ msgstr ""
 msgid "Whether this printer supports fast purge mode with optimized temperature and multiplier."
 msgstr ""
 
+msgid "Filament change"
+msgstr ""
+
+msgid "The volume of material required to prime the extruder on the tower, excluding a hotend change."
+msgstr ""
+
 msgid "The volume of material required to prime the extruder for a hotend change on the tower."
 msgstr "Das Materialvolumen, das erforderlich ist, um den Extruder für einen Hotend-Wechsel am Turm vorzubereiten."
 
@@ -20378,14 +20397,14 @@ msgstr "Fehler: %s"
 msgid "Show details"
 msgstr "Zeige Details"
 
+msgid "Hide details"
+msgstr ""
+
 msgid "Version to install:"
 msgstr "Version zum Installieren:"
 
 msgid "Download and Install"
 msgstr "Herunterladen und installieren"
-
-msgid "Skip for Now"
-msgstr "Jetzt überspringen"
 
 msgid "A new version of the Bambu Network Plug-in is available."
 msgstr "Eine neue Version des Bambu Network Plug-ins ist verfügbar."
@@ -20397,17 +20416,11 @@ msgstr "Aktuelle Version: %s"
 msgid "Update to version:"
 msgstr "Auf Version aktualisieren:"
 
-msgid "Update Now"
-msgstr "Jetzt aktualisieren"
-
-msgid "Remind Later"
-msgstr "Später erinnern"
-
-msgid "Skip Version"
-msgstr "Version überspringen"
-
 msgid "Don't Ask Again"
 msgstr "Nicht mehr fragen"
+
+msgid "Update Now"
+msgstr "Jetzt aktualisieren"
 
 msgid "(Latest)"
 msgstr "(Neueste)"
@@ -20423,9 +20436,6 @@ msgstr "Ein Neustart ist erforderlich, um das neue Plug-in zu laden. Möchten Si
 
 msgid "Restart Now"
 msgstr "Jetzt neu starten"
-
-msgid "Restart Later"
-msgstr "Später neu starten"
 
 msgid "NO RAMMING AT ALL"
 msgstr "KEIN RAMMING ÜBERALL"
@@ -21014,6 +21024,21 @@ msgid ""
 msgstr ""
 "Verwerfungen vermeiden\n"
 "Wussten Sie, dass beim Drucken von Materialien, die zu Verwerfungen neigen, wie z.B. ABS, durch eine entsprechende Erhöhung der Heizbetttemperatur die Wahrscheinlichkeit von Verwerfungen verringert werden kann?"
+
+#~ msgid "Hotend"
+#~ msgstr "Hotend"
+
+#~ msgid "Skip for Now"
+#~ msgstr "Jetzt überspringen"
+
+#~ msgid "Remind Later"
+#~ msgstr "Später erinnern"
+
+#~ msgid "Skip Version"
+#~ msgstr "Version überspringen"
+
+#~ msgid "Restart Later"
+#~ msgstr "Später neu starten"
 
 #~ msgid "Select filament that installed to the left nozzle"
 #~ msgstr "wählen Sie das Filament aus, das in die linke Düse eingesetzt ist"

--- a/localization/i18n/de/OrcaSlicer_de.po
+++ b/localization/i18n/de/OrcaSlicer_de.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Orca Slicer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-23 14:21-0300\n"
+"POT-Creation-Date: 2026-07-23 15:24-0300\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Heiko Liebscher <hliebschergmail.com>\n"
 "Language-Team: \n"
@@ -554,8 +554,9 @@ msgstr "Zuordnung"
 msgid "Reset"
 msgstr "Zurücksetzen"
 
+msgctxt "Keyboard Shortcut"
 msgid "Enter"
-msgstr "Eingabe"
+msgstr ""
 
 msgid "Shortcut Key "
 msgstr "Tastenkürzel"
@@ -1762,14 +1763,16 @@ msgstr "Auswählen"
 msgid "Select point"
 msgstr "Punkt auswählen"
 
+msgctxt "Keyboard Shortcut"
 msgid "Delete"
-msgstr "Löschen"
+msgstr ""
 
 msgid "Restart selection"
 msgstr "Auswahl neu starten"
 
+msgctxt "Keyboard Shortcut"
 msgid "Esc"
-msgstr "Esc"
+msgstr ""
 
 msgid "Cancel a feature until exit"
 msgstr "Abbrechen einer Funktion bis zum Verlassen"
@@ -2419,6 +2422,9 @@ msgstr "Der URL-Download konnte nicht gestartet werden. Der Zielordner ist nicht
 msgid "Import File"
 msgstr "Datei importieren"
 
+msgid "Delete"
+msgstr "Löschen"
+
 msgid "Choose files"
 msgstr "Dateien auswählen"
 
@@ -2548,14 +2554,16 @@ msgstr "Ausblenden"
 msgid "Show"
 msgstr "Anzeigen"
 
+msgctxt "Keyboard Shortcut"
 msgid "Del"
-msgstr "Entf"
+msgstr ""
 
 msgid "Delete the selected object"
 msgstr "Ausgewähltes Objekt löschen"
 
+msgctxt "Keyboard Shortcut"
 msgid "Backspace"
-msgstr "Rücktaste"
+msgstr ""
 
 msgid "Load..."
 msgstr "Laden..."
@@ -11368,29 +11376,33 @@ msgstr "Mehrere Objekte auswählen"
 msgid "Select objects by rectangle"
 msgstr "Objekte per Rechteck auswählen"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Up"
-msgstr "Pfeil hoch"
+msgstr ""
 
 # TODO: Review, changed by lang refactor. PR 14254
 msgid "Move selection 10mm in positive Y direction"
 msgstr "Auswahl 10 mm in positiver Y-Richtung verschieben"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Down"
-msgstr "Pfeil runter"
+msgstr ""
 
 # TODO: Review, changed by lang refactor. PR 14254
 msgid "Move selection 10mm in negative Y direction"
 msgstr "Auswahl 10 mm in negativer Y-Richtung verschieben"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Left"
-msgstr "Pfeil links"
+msgstr ""
 
 # TODO: Review, changed by lang refactor. PR 14254
 msgid "Move selection 10mm in negative X direction"
 msgstr "Auswahl 10 mm in negativer X-Richtung verschieben"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Right"
-msgstr "Pfeil rechts"
+msgstr ""
 
 # TODO: Review, changed by lang refactor. PR 14254
 msgid "Move selection 10mm in positive X direction"
@@ -11476,8 +11488,16 @@ msgstr "Verkleinern"
 msgid "Toggle printable for object/part"
 msgstr "Druckbar für Objekt/Teil umschalten"
 
+msgctxt "Keyboard Shortcut"
+msgid "Tab"
+msgstr ""
+
 msgid "Switch between Prepare/Preview"
 msgstr "Zwischen Vorbereiten/ Vorschau wechseln"
+
+msgctxt "Keyboard Shortcut"
+msgid "Space"
+msgstr ""
 
 msgid "Open actions speed dial"
 msgstr ""
@@ -11537,11 +11557,16 @@ msgstr "Ein-/Ausblenden des G-Code-Fensters"
 msgid "Move slider 5x faster"
 msgstr "Schieberegler 5x schneller bewegen"
 
+msgctxt "Keyboard Shortcut"
+msgid "Home"
+msgstr ""
+
 msgid "Horizontal slider - Move to start position"
 msgstr "Horizontaler Schieberegler - Zur Startposition bewegen"
 
+msgctxt "Keyboard Shortcut"
 msgid "End"
-msgstr "Ende"
+msgstr ""
 
 msgid "Horizontal slider - Move to last position"
 msgstr "Horizontaler Schieberegler - Zur letzten Position bewegen"
@@ -21052,6 +21077,33 @@ msgid ""
 msgstr ""
 "Verwerfungen vermeiden\n"
 "Wussten Sie, dass beim Drucken von Materialien, die zu Verwerfungen neigen, wie z.B. ABS, durch eine entsprechende Erhöhung der Heizbetttemperatur die Wahrscheinlichkeit von Verwerfungen verringert werden kann?"
+
+#~ msgid "Enter"
+#~ msgstr "Eingabe"
+
+#~ msgid "Esc"
+#~ msgstr "Esc"
+
+#~ msgid "Del"
+#~ msgstr "Entf"
+
+#~ msgid "Backspace"
+#~ msgstr "Rücktaste"
+
+#~ msgid "Arrow Up"
+#~ msgstr "Pfeil hoch"
+
+#~ msgid "Arrow Down"
+#~ msgstr "Pfeil runter"
+
+#~ msgid "Arrow Left"
+#~ msgstr "Pfeil links"
+
+#~ msgid "Arrow Right"
+#~ msgstr "Pfeil rechts"
+
+#~ msgid "End"
+#~ msgstr "Ende"
 
 #~ msgid "Hotend"
 #~ msgstr "Hotend"

--- a/localization/i18n/en/OrcaSlicer_en.po
+++ b/localization/i18n/en/OrcaSlicer_en.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Orca Slicer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-22 19:11-0300\n"
+"POT-Creation-Date: 2026-07-23 14:21-0300\n"
 "PO-Revision-Date: 2026-06-17 15:44-0300\n"
 "Last-Translator: Alexandre Folle de Menezes\n"
 "Language-Team: \n"
@@ -873,6 +873,7 @@ msgstr ""
 msgid "Select all connectors"
 msgstr ""
 
+msgctxt "Cut tool"
 msgid "Cut"
 msgstr ""
 
@@ -1834,6 +1835,7 @@ msgstr ""
 msgid "Leaving Measure gizmo"
 msgstr ""
 
+msgctxt "Assembly tool"
 msgid "Assemble"
 msgstr ""
 
@@ -2653,6 +2655,9 @@ msgid "Convert from Meters"
 msgstr ""
 
 msgid "Restore to Meter"
+msgstr ""
+
+msgid "Assemble"
 msgstr ""
 
 msgid "Assemble the selected objects into an object with multiple parts"
@@ -4117,6 +4122,14 @@ msgstr ""
 msgid "Print with filament in AMS"
 msgstr ""
 
+msgctxt "Nozzle position"
+msgid "Left"
+msgstr ""
+
+msgctxt "Nozzle position"
+msgid "Right"
+msgstr ""
+
 msgid "When the current material run out, the printer will continue to print in the following order."
 msgstr ""
 
@@ -5344,6 +5357,7 @@ msgstr ""
 msgid "Quality / Speed"
 msgstr ""
 
+msgctxt "Mesh action"
 msgid "Smooth"
 msgstr ""
 
@@ -5952,6 +5966,9 @@ msgstr ""
 msgid "Redo"
 msgstr ""
 
+msgid "Cut"
+msgstr ""
+
 msgid "Cut selection to clipboard"
 msgstr ""
 
@@ -6049,6 +6066,10 @@ msgid "Show outline around selected object in 3D scene."
 msgstr ""
 
 msgid "Preferences"
+msgstr ""
+
+msgctxt "Menu"
+msgid "Edit"
 msgstr ""
 
 msgid "View"
@@ -8903,6 +8924,7 @@ msgstr ""
 msgid "The selected preset is null!"
 msgstr ""
 
+msgctxt "Layer range"
 msgid "End"
 msgstr ""
 
@@ -10976,6 +10998,9 @@ msgid "Move slider 5x faster"
 msgstr ""
 
 msgid "Horizontal slider - Move to start position"
+msgstr ""
+
+msgid "End"
 msgstr ""
 
 msgid "Horizontal slider - Move to last position"
@@ -15105,6 +15130,9 @@ msgid "If smooth or traditional mode is selected, a timelapse video will be gene
 msgstr ""
 
 msgid "Traditional"
+msgstr ""
+
+msgid "Smooth"
 msgstr ""
 
 msgid "Farthest point timelapse"

--- a/localization/i18n/en/OrcaSlicer_en.po
+++ b/localization/i18n/en/OrcaSlicer_en.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Orca Slicer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-20 10:39-0300\n"
+"POT-Creation-Date: 2026-07-22 19:11-0300\n"
 "PO-Revision-Date: 2026-06-17 15:44-0300\n"
 "Last-Translator: Alexandre Folle de Menezes\n"
 "Language-Team: \n"
@@ -3399,6 +3399,7 @@ msgctxt "air_duct"
 msgid "Left(Aux)"
 msgstr ""
 
+msgctxt "Hotend Heat Breaker Fan"
 msgid "Hotend"
 msgstr ""
 
@@ -8611,6 +8612,15 @@ msgstr ""
 msgid "Displays current viewport FPS in the top-right corner."
 msgstr ""
 
+msgid "G-code Preview"
+msgstr ""
+
+msgid "Dim lower layers"
+msgstr ""
+
+msgid "When scrubbing the layer slider in the sliced preview, render the layers below the current one darkened so that only the layer being viewed is shown at full brightness."
+msgstr ""
+
 msgid "Login region"
 msgstr ""
 
@@ -9174,6 +9184,9 @@ msgid "When spiral vase mode is enabled, machines with I3 structure will not gen
 msgstr ""
 
 msgid "The current printer does not support timelapse in Traditional Mode when printing By-Object."
+msgstr ""
+
+msgid "I have checked the installed nozzle and want to print anyway."
 msgstr ""
 
 msgid "Errors"
@@ -15997,6 +16010,12 @@ msgstr ""
 msgid "Whether this printer supports fast purge mode with optimized temperature and multiplier."
 msgstr ""
 
+msgid "Filament change"
+msgstr ""
+
+msgid "The volume of material required to prime the extruder on the tower, excluding a hotend change."
+msgstr ""
+
 msgid "The volume of material required to prime the extruder for a hotend change on the tower."
 msgstr ""
 
@@ -19045,13 +19064,13 @@ msgstr ""
 msgid "Show details"
 msgstr ""
 
+msgid "Hide details"
+msgstr ""
+
 msgid "Version to install:"
 msgstr ""
 
 msgid "Download and Install"
-msgstr ""
-
-msgid "Skip for Now"
 msgstr ""
 
 msgid "A new version of the Bambu Network Plug-in is available."
@@ -19064,16 +19083,10 @@ msgstr ""
 msgid "Update to version:"
 msgstr ""
 
-msgid "Update Now"
-msgstr ""
-
-msgid "Remind Later"
-msgstr ""
-
-msgid "Skip Version"
-msgstr ""
-
 msgid "Don't Ask Again"
+msgstr ""
+
+msgid "Update Now"
 msgstr ""
 
 msgid "(Latest)"
@@ -19089,9 +19102,6 @@ msgid "A restart is required to load the new plug-in. Would you like to restart 
 msgstr ""
 
 msgid "Restart Now"
-msgstr ""
-
-msgid "Restart Later"
 msgstr ""
 
 msgid "NO RAMMING AT ALL"

--- a/localization/i18n/en/OrcaSlicer_en.po
+++ b/localization/i18n/en/OrcaSlicer_en.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Orca Slicer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-23 14:21-0300\n"
+"POT-Creation-Date: 2026-07-23 15:24-0300\n"
 "PO-Revision-Date: 2026-06-17 15:44-0300\n"
 "Last-Translator: Alexandre Folle de Menezes\n"
 "Language-Team: \n"
@@ -548,6 +548,7 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
+msgctxt "Keyboard Shortcut"
 msgid "Enter"
 msgstr ""
 
@@ -1729,12 +1730,14 @@ msgstr ""
 msgid "Select point"
 msgstr ""
 
+msgctxt "Keyboard Shortcut"
 msgid "Delete"
 msgstr ""
 
 msgid "Restart selection"
 msgstr ""
 
+msgctxt "Keyboard Shortcut"
 msgid "Esc"
 msgstr ""
 
@@ -2346,6 +2349,9 @@ msgstr ""
 msgid "Import File"
 msgstr ""
 
+msgid "Delete"
+msgstr ""
+
 msgid "Choose files"
 msgstr ""
 
@@ -2464,12 +2470,14 @@ msgstr ""
 msgid "Show"
 msgstr ""
 
+msgctxt "Keyboard Shortcut"
 msgid "Del"
 msgstr ""
 
 msgid "Delete the selected object"
 msgstr ""
 
+msgctxt "Keyboard Shortcut"
 msgid "Backspace"
 msgstr ""
 
@@ -10835,24 +10843,28 @@ msgstr ""
 msgid "Select objects by rectangle"
 msgstr ""
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Up"
 msgstr ""
 
 msgid "Move selection 10mm in positive Y direction"
 msgstr ""
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Down"
 msgstr ""
 
 msgid "Move selection 10mm in negative Y direction"
 msgstr ""
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Left"
 msgstr ""
 
 msgid "Move selection 10mm in negative X direction"
 msgstr ""
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Right"
 msgstr ""
 
@@ -10937,7 +10949,15 @@ msgstr ""
 msgid "Toggle printable for object/part"
 msgstr ""
 
+msgctxt "Keyboard Shortcut"
+msgid "Tab"
+msgstr ""
+
 msgid "Switch between Prepare/Preview"
+msgstr ""
+
+msgctxt "Keyboard Shortcut"
+msgid "Space"
 msgstr ""
 
 msgid "Open actions speed dial"
@@ -10997,9 +11017,14 @@ msgstr ""
 msgid "Move slider 5x faster"
 msgstr ""
 
+msgctxt "Keyboard Shortcut"
+msgid "Home"
+msgstr ""
+
 msgid "Horizontal slider - Move to start position"
 msgstr ""
 
+msgctxt "Keyboard Shortcut"
 msgid "End"
 msgstr ""
 

--- a/localization/i18n/es/OrcaSlicer_es.po
+++ b/localization/i18n/es/OrcaSlicer_es.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Orca Slicer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-22 19:11-0300\n"
+"POT-Creation-Date: 2026-07-23 14:21-0300\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Ian A. Bassi <>\n"
 "Language-Team: \n"
@@ -878,8 +878,9 @@ msgstr "Borrar conector de la selección"
 msgid "Select all connectors"
 msgstr "Seleccionar todos los conectores"
 
+msgctxt "Cut tool"
 msgid "Cut"
-msgstr "Cortar"
+msgstr ""
 
 msgid "Rotate cut plane"
 msgstr "Rotar plano de corte"
@@ -1857,8 +1858,9 @@ msgstr "Entrando al mecanismo de medición"
 msgid "Leaving Measure gizmo"
 msgstr "Saliendo del mecanismo de medición"
 
+msgctxt "Assembly tool"
 msgid "Assemble"
-msgstr "Agrupar"
+msgstr ""
 
 msgid "Please confirm explosion ratio = 1 and select at least two volumes."
 msgstr "Confirme que la relación de explosión es 1 y seleccione al menos dos volúmenes."
@@ -2728,6 +2730,9 @@ msgstr "Convertir de metros"
 
 msgid "Restore to Meter"
 msgstr "Restaurar a metros"
+
+msgid "Assemble"
+msgstr "Agrupar"
 
 msgid "Assemble the selected objects into an object with multiple parts"
 msgstr "Ensamblar los objetos seleccionados en un objeto con múltiples piezas"
@@ -4218,6 +4223,14 @@ msgstr "Imprimir utilizando filamento de una bobina externa."
 msgid "Print with filament in AMS"
 msgstr "Imprimir usando filamentos en AMS"
 
+msgctxt "Nozzle position"
+msgid "Left"
+msgstr ""
+
+msgctxt "Nozzle position"
+msgid "Right"
+msgstr ""
+
 msgid "When the current material run out, the printer will continue to print in the following order."
 msgstr "Cuando se termine el filamento actual, la impresora continuará imprimiendo en el siguiente orden."
 
@@ -5508,8 +5521,9 @@ msgstr "Adaptativo"
 msgid "Quality / Speed"
 msgstr "Calidad / Velocidad"
 
+msgctxt "Mesh action"
 msgid "Smooth"
-msgstr "Suave"
+msgstr ""
 
 msgid "Radius"
 msgstr "Radio"
@@ -6122,6 +6136,9 @@ msgstr "Deshacer"
 msgid "Redo"
 msgstr "Rehacer"
 
+msgid "Cut"
+msgstr "Cortar"
+
 msgid "Cut selection to clipboard"
 msgstr "Cortar selección al portapapeles"
 
@@ -6220,6 +6237,10 @@ msgstr "Mostrar el contorno alrededor del objeto seleccionado en la escena 3D."
 
 msgid "Preferences"
 msgstr "Preferencias"
+
+msgctxt "Menu"
+msgid "Edit"
+msgstr ""
 
 msgid "View"
 msgstr "Vista"
@@ -9179,8 +9200,9 @@ msgstr "Incompatible"
 msgid "The selected preset is null!"
 msgstr "¡El ajuste seleccionado es nulo!"
 
+msgctxt "Layer range"
 msgid "End"
-msgstr "Final"
+msgstr ""
 
 msgid "Customize"
 msgstr "Personalizar"
@@ -11330,6 +11352,9 @@ msgstr "Mover el deslizador 5 veces más rápido"
 
 msgid "Horizontal slider - Move to start position"
 msgstr "Deslizador horizontal - Desplazarse a la posición inicial"
+
+msgid "End"
+msgstr "Final"
 
 msgid "Horizontal slider - Move to last position"
 msgstr "Deslizador horizontal - Desplazarse a la última posición"
@@ -15894,6 +15919,9 @@ msgstr "Si se selecciona el modo suave o tradicional, se generará un vídeo tim
 
 msgid "Traditional"
 msgstr "Tradicional"
+
+msgid "Smooth"
+msgstr "Suave"
 
 msgid "Farthest point timelapse"
 msgstr "Timelapse del punto más lejano"

--- a/localization/i18n/es/OrcaSlicer_es.po
+++ b/localization/i18n/es/OrcaSlicer_es.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Orca Slicer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-23 14:21-0300\n"
+"POT-Creation-Date: 2026-07-23 15:24-0300\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Ian A. Bassi <>\n"
 "Language-Team: \n"
@@ -548,8 +548,9 @@ msgstr "Remapear"
 msgid "Reset"
 msgstr "Reiniciar"
 
+msgctxt "Keyboard Shortcut"
 msgid "Enter"
-msgstr "Enter"
+msgstr "Intro"
 
 msgid "Shortcut Key "
 msgstr "Tecla de acceso directo "
@@ -880,7 +881,7 @@ msgstr "Seleccionar todos los conectores"
 
 msgctxt "Cut tool"
 msgid "Cut"
-msgstr ""
+msgstr "Cortar"
 
 msgid "Rotate cut plane"
 msgstr "Rotar plano de corte"
@@ -1746,12 +1747,14 @@ msgstr "Seleccionar"
 msgid "Select point"
 msgstr "Seleccionar punto"
 
+msgctxt "Keyboard Shortcut"
 msgid "Delete"
-msgstr "Borrar"
+msgstr "Supr"
 
 msgid "Restart selection"
 msgstr "Reiniciar selección"
 
+msgctxt "Keyboard Shortcut"
 msgid "Esc"
 msgstr "Esc"
 
@@ -1860,7 +1863,7 @@ msgstr "Saliendo del mecanismo de medición"
 
 msgctxt "Assembly tool"
 msgid "Assemble"
-msgstr ""
+msgstr "Ensamblar"
 
 msgid "Please confirm explosion ratio = 1 and select at least two volumes."
 msgstr "Confirme que la relación de explosión es 1 y seleccione al menos dos volúmenes."
@@ -2417,6 +2420,9 @@ msgstr "No se pudo iniciar la descarga del URL. La carpeta de destino no se sele
 msgid "Import File"
 msgstr "Importar archivo"
 
+msgid "Delete"
+msgstr "Borrar"
+
 msgid "Choose files"
 msgstr "Elija los archivos"
 
@@ -2535,12 +2541,14 @@ msgstr "Ocultar"
 msgid "Show"
 msgstr "Mostrar"
 
+msgctxt "Keyboard Shortcut"
 msgid "Del"
-msgstr "Borrar"
+msgstr "Supr"
 
 msgid "Delete the selected object"
 msgstr "Eliminar el objeto seleccionado"
 
+msgctxt "Keyboard Shortcut"
 msgid "Backspace"
 msgstr "Retroceso"
 
@@ -4225,11 +4233,11 @@ msgstr "Imprimir usando filamentos en AMS"
 
 msgctxt "Nozzle position"
 msgid "Left"
-msgstr ""
+msgstr "Izquierda"
 
 msgctxt "Nozzle position"
 msgid "Right"
-msgstr ""
+msgstr "Derecha"
 
 msgid "When the current material run out, the printer will continue to print in the following order."
 msgstr "Cuando se termine el filamento actual, la impresora continuará imprimiendo en el siguiente orden."
@@ -5523,7 +5531,7 @@ msgstr "Calidad / Velocidad"
 
 msgctxt "Mesh action"
 msgid "Smooth"
-msgstr ""
+msgstr "Suavizar"
 
 msgid "Radius"
 msgstr "Radio"
@@ -6240,7 +6248,7 @@ msgstr "Preferencias"
 
 msgctxt "Menu"
 msgid "Edit"
-msgstr ""
+msgstr "Edición"
 
 msgid "View"
 msgstr "Vista"
@@ -9202,7 +9210,7 @@ msgstr "¡El ajuste seleccionado es nulo!"
 
 msgctxt "Layer range"
 msgid "End"
-msgstr ""
+msgstr "Fin"
 
 msgid "Customize"
 msgstr "Personalizar"
@@ -11188,26 +11196,30 @@ msgstr "Seleccionar varios objetos"
 msgid "Select objects by rectangle"
 msgstr "Seleccionar objetos por rectángulo"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Up"
-msgstr "Flecha hacia arriba"
+msgstr "Flecha arriba"
 
 msgid "Move selection 10mm in positive Y direction"
 msgstr "Mover la selección 10 mm en dirección Y positiva"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Down"
-msgstr "Flecha hacia abajo"
+msgstr "Flecha abajo"
 
 msgid "Move selection 10mm in negative Y direction"
 msgstr "Mover la selección 10 mm en dirección Y negativa"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Left"
-msgstr "Flecha hacia izquierda"
+msgstr "Flecha izquierda"
 
 msgid "Move selection 10mm in negative X direction"
 msgstr "Mover la selección 10 mm en dirección X negativa"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Right"
-msgstr "Flecha hacia derecha"
+msgstr "Flecha derecha"
 
 msgid "Move selection 10mm in positive X direction"
 msgstr "Mover la selección 10 mm en dirección X positiva"
@@ -11290,8 +11302,16 @@ msgstr "Alejar"
 msgid "Toggle printable for object/part"
 msgstr "Activar/desactivar la impresión para el objeto/pieza"
 
+msgctxt "Keyboard Shortcut"
+msgid "Tab"
+msgstr "Tab"
+
 msgid "Switch between Prepare/Preview"
 msgstr "Cambiar entre Preparar/Previsualizar"
+
+msgctxt "Keyboard Shortcut"
+msgid "Space"
+msgstr "Espacio"
 
 msgid "Open actions speed dial"
 msgstr "Abrir el menú rápido de acciones"
@@ -11350,11 +11370,16 @@ msgstr "Activar/Desactivar ventana de G-Code"
 msgid "Move slider 5x faster"
 msgstr "Mover el deslizador 5 veces más rápido"
 
+msgctxt "Keyboard Shortcut"
+msgid "Home"
+msgstr "Inicio"
+
 msgid "Horizontal slider - Move to start position"
 msgstr "Deslizador horizontal - Desplazarse a la posición inicial"
 
+msgctxt "Keyboard Shortcut"
 msgid "End"
-msgstr "Final"
+msgstr "Fin"
 
 msgid "Horizontal slider - Move to last position"
 msgstr "Deslizador horizontal - Desplazarse a la última posición"
@@ -20707,6 +20732,33 @@ msgid ""
 msgstr ""
 "Evita la deformación\n"
 "¿Sabías que al imprimir materiales propensos a la deformación como el ABS, aumentar adecuadamente la temperatura de la cama térmica puede reducir la probabilidad de deformaciones?"
+
+#~ msgid "Enter"
+#~ msgstr "Enter"
+
+#~ msgid "Esc"
+#~ msgstr "Esc"
+
+#~ msgid "Del"
+#~ msgstr "Borrar"
+
+#~ msgid "Backspace"
+#~ msgstr "Retroceso"
+
+#~ msgid "Arrow Up"
+#~ msgstr "Flecha hacia arriba"
+
+#~ msgid "Arrow Down"
+#~ msgstr "Flecha hacia abajo"
+
+#~ msgid "Arrow Left"
+#~ msgstr "Flecha hacia izquierda"
+
+#~ msgid "Arrow Right"
+#~ msgstr "Flecha hacia derecha"
+
+#~ msgid "End"
+#~ msgstr "Final"
 
 #~ msgid "Hotend"
 #~ msgstr "Hotend"

--- a/localization/i18n/es/OrcaSlicer_es.po
+++ b/localization/i18n/es/OrcaSlicer_es.po
@@ -15645,77 +15645,77 @@ msgstr ""
 "Esta cantidad puede especificarse en milímetros o como porcentaje del diámetro actual del extrusor. El valor por defecto de este parámetro es 10%."
 
 msgid "Scarf joint seam (beta)"
-msgstr "Unión de bufanda en costuras (beta)"
+msgstr "Costura en bisel en costuras (beta)"
 
 msgid "Use scarf joint to minimize seam visibility and increase seam strength."
-msgstr "Utilice la unión de bufanda para minimizar la visibilidad de la costura y aumentar su resistencia."
+msgstr "Utilice la costura en bisel para minimizar la visibilidad de la costura y aumentar su resistencia."
 
 msgid "Conditional scarf joint"
-msgstr "Unión de bufanda condicional"
+msgstr "Costura en bisel condicional"
 
 msgid "Apply scarf joints only to smooth perimeters where traditional seams do not conceal the seams at sharp corners effectively."
-msgstr "Aplique juntas de bufanda sólo en perímetros lisos en los que las juntas tradicionales no oculten eficazmente las juntas en vértices pronunciados."
+msgstr "Aplique costuras en bisel sólo en perímetros lisos en los que las juntas tradicionales no oculten eficazmente las juntas en vértices pronunciados."
 
 msgid "Conditional angle threshold"
-msgstr "Umbral angular para union de bufanda condicional"
+msgstr "Umbral angular para costura en bisel condicional"
 
 msgid ""
 "This option sets the threshold angle for applying a conditional scarf joint seam.\n"
 "If the maximum angle within the perimeter loop exceeds this value (indicating the absence of sharp corners), a scarf joint seam will be used. The default value is 155°."
 msgstr ""
-"Esta opción establece el ángulo umbral para aplicar una costura de junta de bufanda condicional.\n"
-"Si el ángulo máximo dentro del bucle perimetral supera este valor (indicando la ausencia de esquinas afiladas), se utilizará una costura de junta de bufanda. El valor por defecto es 155°."
+"Esta opción establece el ángulo umbral para aplicar una costura en bisel condicional.\n"
+"Si el ángulo máximo dentro del bucle perimetral supera este valor (indicando la ausencia de esquinas afiladas), se utilizará una costura en bisel. El valor por defecto es 155°."
 
 msgid "Conditional overhang threshold"
-msgstr "Umbral de voladizo para unión de bufanda condicional"
+msgstr "Umbral de voladizo para costura en bisel condicional"
 
 #, no-c-format, no-boost-format
 msgid "This option determines the overhang threshold for the application of scarf joint seams. If the unsupported portion of the perimeter is less than this threshold, scarf joint seams will be applied. The default threshold is set at 40% of the external wall's width. Due to performance considerations, the degree of overhang is estimated."
-msgstr "Esta opción establece el umbral de voladizo para aplicar una costura de unión de bufanda condicional. Si el área sin soporte del perémetro es menor a este valor se utilizará una costura de unión de bufanda. El valor por defecto está configurado como un 40% del grosor del perímetro exterior. El ángulo de voladizo es estimado automáticamente por razones de optimización."
+msgstr "Esta opción establece el umbral de voladizo para aplicar una costura en bisel condicional. Si el área sin soporte del perémetro es menor a este valor se utilizará una costura en bisel. El valor por defecto está configurado como un 40% del grosor del perímetro exterior. El ángulo de voladizo es estimado automáticamente por razones de optimización."
 
 msgid "Scarf joint speed"
-msgstr "Velocidad de unión de bufanda"
+msgstr "Velocidad de costura en bisel"
 
 msgid "This option sets the printing speed for scarf joints. It is recommended to print scarf joints at a slow speed (less than 100 mm/s). It's also advisable to enable 'Extrusion rate smoothing' if the set speed varies significantly from the speed of the outer or inner walls. If the speed specified here is higher than the speed of the outer or inner walls, the printer will default to the slower of the two speeds. When specified as a percentage (e.g., 80%), the speed is calculated based on the respective outer or inner wall speed. The default value is set to 100%."
-msgstr "Esta opción ajusta la velocidad de impresión para las uniones de bufanda. Se recomienda imprimir las uniones de bufanda a una velocidad lenta (inferior a 100 mm/s). También es aconsejable activar la opción \"Suavizado de la velocidad de extrusión\" si la velocidad configurada varía significativamente de la velocidad de los perímetros exteriores o interiores. Si la velocidad especificada aquí es superior a la velocidad de los perímetros exteriores o interiores, la impresora utilizará por defecto la velocidad más lenta de las dos. Si se especifica como porcentaje (por ejemplo, 80%), la velocidad se calcula en función de la velocidad del perímetro exterior o interior. El valor predeterminado es 100%."
+msgstr "Esta opción ajusta la velocidad de impresión para las costuras en bisel. Se recomienda imprimir las costuras en bisel a una velocidad lenta (inferior a 100 mm/s). También es aconsejable activar la opción \"Suavizado de la velocidad de extrusión\" si la velocidad configurada varía significativamente de la velocidad de los perímetros exteriores o interiores. Si la velocidad especificada aquí es superior a la velocidad de los perímetros exteriores o interiores, la impresora utilizará por defecto la velocidad más lenta de las dos. Si se especifica como porcentaje (por ejemplo, 80%), la velocidad se calcula en función de la velocidad del perímetro exterior o interior. El valor predeterminado es 100%."
 
 msgid "Scarf joint flow ratio"
-msgstr "Factor de flujo de la unión de bufanda"
+msgstr "Factor de flujo de la costura en bisel"
 
 msgid "This factor affects the amount of material for scarf joints."
-msgstr "Este factor afecta a la cantidad de material para las uniones de bufanda."
+msgstr "Este factor afecta a la cantidad de material para las costuras en bisel."
 
 msgid "Scarf start height"
-msgstr "Altura de inicio de la bufanda"
+msgstr "Altura de inicio del bisel"
 
 msgid ""
 "Start height of the scarf.\n"
 "This amount can be specified in millimeters or as a percentage of the current layer height. The default value for this parameter is 0."
-msgstr "Altura inicial de la bufanda . Esta cantidad puede especificarse en milímetros o como porcentaje de la altura de la capa actual. El valor por defecto de este parámetro es 0."
+msgstr "Altura inicial del bisel . Esta cantidad puede especificarse en milímetros o como porcentaje de la altura de la capa actual. El valor por defecto de este parámetro es 0."
 
 msgid "Scarf around entire wall"
-msgstr "Bufanda en todo el perímetro"
+msgstr "Bisel en todo el perímetro"
 
 msgid "The scarf extends to the entire length of the wall."
-msgstr "La bufanda se extiende a lo largo de todo el perímetro."
+msgstr "El bisel se extiende a lo largo de todo el perímetro."
 
 msgid "Scarf length"
-msgstr "Largo de la bufanda"
+msgstr "Largo del bisel"
 
 msgid "Length of the scarf. Setting this parameter to zero effectively disables the scarf."
-msgstr "Longitud de la bufanda. Si este parámetro se pone a cero, se desactiva la bufanda."
+msgstr "Longitud del bisel. Si este parámetro se pone a cero, se desactiva el bisel."
 
 msgid "Scarf steps"
-msgstr "Pasos de la bufanda"
+msgstr "Pasos del bisel"
 
 msgid "Minimum number of segments of each scarf."
-msgstr "Número mínimo de segmentos de cada bufanda."
+msgstr "Número mínimo de segmentos de cada bisel."
 
 msgid "Scarf joint for inner walls"
-msgstr "Unión de bufanda para perímetros interiores"
+msgstr "Costura en bisel para perímetros interiores"
 
 msgid "Use scarf joint for inner walls as well."
-msgstr "Utilice también una unión de bufanda para perímetros internos."
+msgstr "Utilice también una costura en bisel para perímetros internos."
 
 msgid "Role base wipe speed"
 msgstr "Velocidad de purga según tipo de línea"

--- a/localization/i18n/es/OrcaSlicer_es.po
+++ b/localization/i18n/es/OrcaSlicer_es.po
@@ -258,7 +258,7 @@ msgid "Tungsten Carbide"
 msgstr "Carburo de tungsteno"
 
 msgid "The toolhead and hotend rack may move. Please keep your hands away from the chamber."
-msgstr "Es posible que el cabezal y el rack del hotend se muevan. Mantenga las manos alejadas de la cámara."
+msgstr "Es posible que el cabezal y el rack del hotend se muevan. Mantenga las manos alejadas de la recámara."
 
 msgid "Warning"
 msgstr "Advertencia"
@@ -276,7 +276,7 @@ msgid "Reading the hotends, please wait."
 msgstr "Leyendo los hotends, por favor espere."
 
 msgid "During the hotend upgrade, the toolhead will move. Don't reach into the chamber."
-msgstr "Durante la actualización del hotend, el cabezal se moverá. No meta la mano en la cámara."
+msgstr "Durante la actualización del hotend, el cabezal se moverá. No meta la mano en la recámara."
 
 msgid "Update"
 msgstr "Actualizar"
@@ -3454,7 +3454,7 @@ msgid "The fan controls the temperature during printing to improve print quality
 msgstr "El ventilador controla la temperatura durante la impresión para mejorar la calidad de impresión. El sistema ajusta automáticamente el encendido y la velocidad del ventilador según los diferentes materiales de impresión."
 
 msgid "Cooling mode is suitable for printing PLA/PETG/TPU materials and filters the chamber air."
-msgstr "El modo de refrigeración es adecuado para imprimir materiales PLA/PETG/TPU y filtra el aire de la cámara."
+msgstr "El modo de refrigeración es adecuado para imprimir materiales PLA/PETG/TPU y filtra el aire de la recámara."
 
 msgid "Heating mode is suitable for printing ABS/ASA/PC/PA materials and circulates filters the chamber air."
 msgstr "El modo de calefacción es adecuado para imprimir materiales ABS/ASA/PC/PA y hace circular y filtra el aire de la recámara."
@@ -4534,11 +4534,11 @@ msgstr ""
 
 #, c-format, boost-format
 msgid "Current chamber temperature is higher than the material's safe temperature; this may result in material softening and nozzle clogs. The maximum safe temperature for the material is %d"
-msgstr "La temperatura actual de la cámara es superior a la temperatura de seguridad del material, puede provocar que el material se ablande y se atasque. La temperatura máxima de seguridad para el material es %d"
+msgstr "La temperatura actual de la recámara es superior a la temperatura de seguridad del material, puede provocar que el material se ablande y se atasque. La temperatura máxima de seguridad para el material es %d"
 
 #, c-format, boost-format
 msgid "The minimal chamber temperature (%d℃) is higher than the target chamber temperature (%d℃). The minimal value is the threshold at which printing starts while the chamber keeps heating toward the target, so it should not exceed it. It will be clamped to the target."
-msgstr "La temperatura mínima de la cámara (%d℃) es superior a la temperatura objetivo de la cámara (%d℃). El valor mínimo es el umbral en el que comienza la impresión mientras la cámara continúa calentándose hacia el objetivo, por lo que no debería superarlo. Se ajustará al valor objetivo."
+msgstr "La temperatura mínima de la recámara (%d℃) es superior a la temperatura objetivo de la recámara (%d℃). El valor mínimo es el umbral en el que comienza la impresión mientras la recámara continúa calentándose hacia el objetivo, por lo que no debería superarlo. Se ajustará al valor objetivo."
 
 msgid ""
 "Layer height too small\n"
@@ -4763,7 +4763,7 @@ msgid "Pause (chamber temperature control problem)"
 msgstr "Pausa (problema con el control de temperatura de la recámara)"
 
 msgid "Cooling chamber"
-msgstr "Enfriando cámara"
+msgstr "Enfriando recámara"
 
 msgid "Pause (G-code inserted by user)"
 msgstr "Pausa (código G insertado por el usuario)"
@@ -4881,20 +4881,20 @@ msgstr "Para garantizar su seguridad, ciertas tareas de procesamiento (como el l
 
 #, c-format, boost-format
 msgid "The chamber temperature is too high, which may cause the filament to soften. Please wait until the chamber temperature drops below %d℃. You may open the front door or enable fans to cool down."
-msgstr "La temperatura de la cámara es demasiado alta, lo que puede hacer que el filamento se ablande. Espere hasta que la temperatura de la cámara baje por debajo de %d℃. Puede abrir la puerta frontal o activar los ventiladores para enfriar."
+msgstr "La temperatura de la recámara es demasiado alta, lo que puede hacer que el filamento se ablande. Espere hasta que la temperatura de la recámara baje por debajo de %d℃. Puede abrir la puerta frontal o activar los ventiladores para enfriar."
 
 #, c-format, boost-format
 msgid "AMS temperature is too high, which may cause the filament to soften. Please wait until the AMS temperature drops below %d℃."
 msgstr "La temperatura del AMS es demasiado alta, lo que puede hacer que el filamento se ablande. Espere hasta que la temperatura del AMS baje por debajo de %d℃."
 
 msgid "The current chamber temperature or the target chamber temperature exceeds 45℃. In order to avoid extruder clogging, low temperature filament(PLA/PETG/TPU) is not allowed to be loaded."
-msgstr "La temperatura actual de la cámara o la temperatura objetivo de la cámara supera los 45℃. Para evitar atascos del extrusor, no está permitido cargar filamento de baja temperatura (PLA/PETG/TPU)."
+msgstr "La temperatura actual de la recámara o la temperatura objetivo de la recámara supera los 45℃. Para evitar atascos del extrusor, no está permitido cargar filamento de baja temperatura (PLA/PETG/TPU)."
 
 msgid "Low temperature filament(PLA/PETG/TPU) is loaded in the extruder. In order to avoid extruder clogging, it is not allowed to set the chamber temperature."
-msgstr "Se ha cargado filamento de baja temperatura (PLA/PETG/TPU) en el extrusor. Para evitar atascos del extrusor, no está permitido ajustar la temperatura de la cámara."
+msgstr "Se ha cargado filamento de baja temperatura (PLA/PETG/TPU) en el extrusor. Para evitar atascos del extrusor, no está permitido ajustar la temperatura de la recámara."
 
 msgid "When you set the chamber temperature below 40℃, the chamber temperature control will not be activated, and the target chamber temperature will automatically be set to 0℃."
-msgstr "Cuando se ajusta la temperatura de la cámara por debajo de 40℃, el control de la temperatura de la cámara no será activado. La temperatura objetivo de la cámara se ajustará automáticamente a 0℃."
+msgstr "Cuando se ajusta la temperatura de la recámara por debajo de 40℃, el control de la temperatura de la recámara no será activado. La temperatura objetivo de la recámara se ajustará automáticamente a 0℃."
 
 msgid "Failed to start print job"
 msgstr "Fallo iniciando el trabajo de impresión"
@@ -6901,10 +6901,10 @@ msgid "Please heat the nozzle to above 170℃ before loading or unloading filame
 msgstr "Por favor, caliente la boquilla por encima de 170℃ antes de cargar o descargar filamento."
 
 msgid "Chamber temperature cannot be changed in cooling mode while printing."
-msgstr "No se puede cambiar la temperatura de la cámara en modo de refrigeración mientras se imprime."
+msgstr "No se puede cambiar la temperatura de la recámara en modo de refrigeración mientras se imprime."
 
 msgid "If the chamber temperature exceeds 40℃, the system will automatically switch to heating mode. Please confirm whether to switch."
-msgstr "Si la temperatura de la cámara excede los 40℃, el sistema cambiará automáticamente al modo de calefacción. Confirme si desea cambiar."
+msgstr "Si la temperatura de la recámara excede los 40℃, el sistema cambiará automáticamente al modo de calefacción. Confirme si desea cambiar."
 
 msgid "Please select an AMS slot before calibration"
 msgstr "Seleccione una ranura AMS antes de la calibración"
@@ -7335,10 +7335,10 @@ msgid "Identifies the type and position of the build plate on the heatbed. Pausi
 msgstr "Identifica el tipo y la posición de la placa de construcción sobre la cama calefactada. Pausa la impresión si se detecta una discrepancia."
 
 msgid "Purifies the chamber air as the print finishes, based on the selected mode."
-msgstr "Purifica el aire de la cámara al finalizar la impresión, según el modo seleccionado."
+msgstr "Purifica el aire de la recámara al finalizar la impresión, según el modo seleccionado."
 
 msgid "Purifies the chamber air through internal circulation as each print finishes."
-msgstr "Purifica el aire de la cámara mediante circulación interna al finalizar cada impresión."
+msgstr "Purifica el aire de la recámara mediante circulación interna al finalizar cada impresión."
 
 msgid "Automatically match the corresponding switch strategy for leak-prone filaments (disable blob detection) and regular filaments (enable blob detection)."
 msgstr "Aplica automáticamente la estrategia de conmutación correspondiente para filamentos propensos a fugas (desactiva la detección de acumulación) y filamentos normales (activa la detección de acumulación)."
@@ -10191,13 +10191,13 @@ msgid "Flow ratio and Pressure Advance"
 msgstr "Factor de flujo y Pressure advance"
 
 msgid "Print chamber temperature"
-msgstr "Temperatura de la cámara"
+msgstr "Temperatura de la recámara"
 
 msgid "Chamber temperature"
-msgstr "Temperatura de cámara"
+msgstr "Temperatura de recámara"
 
 msgid "Target chamber temperature, and the minimal chamber temperature at which printing should start"
-msgstr "Temperatura objetivo de la cámara y temperatura mínima de la cámara a la que debe comenzar la impresión"
+msgstr "Temperatura objetivo de la recámara y temperatura mínima de la recámara a la que debe comenzar la impresión"
 
 msgid "Target"
 msgstr "Objetivo"
@@ -14407,12 +14407,12 @@ msgid "money/h"
 msgstr "dinero/hora"
 
 msgid "Support controlling chamber temperature"
-msgstr "Función de control de temperatura de cámara"
+msgstr "Función de control de temperatura de recámara"
 
 msgid ""
 "This option is enabled if machine support controlling chamber temperature\n"
 "G-code command: M141 S(0-255)"
-msgstr "Esta opción se activa si la máquina admite el control de la temperatura de la cámara"
+msgstr "Esta opción se activa si la máquina admite el control de la temperatura de la recámara"
 
 msgid "Support air filtration"
 msgstr "Función de filtración de aire"
@@ -16362,10 +16362,10 @@ msgid ""
 "\n"
 "This option relies on the firmware supporting the M191 and M141 commands either via macros or natively and is usually used when an active chamber heater is installed."
 msgstr ""
-"Habilite esta función para usar un control automático de la temperatura de la cámara. Cuando está habilitada, se emitirá un comando M191 antes de \"machine_start_gcode\".\n"
-"Este comando especifica la temperatura objetivo de la cámara y mantendrá la impresora en espera hasta que se alcance dicha temperatura. Adicionalmente, se emite un comando M141 al finalizar la impresión para apagar el sistema de calentamiento de cámara, en caso de existir.\n"
+"Habilite esta función para usar un control automático de la temperatura de la recámara. Cuando está habilitada, se emitirá un comando M191 antes de \"machine_start_gcode\".\n"
+"Este comando especifica la temperatura objetivo de la recámara y mantendrá la impresora en espera hasta que se alcance dicha temperatura. Adicionalmente, se emite un comando M141 al finalizar la impresión para apagar el sistema de calentamiento de recámara, en caso de existir.\n"
 "\n"
-"Esta función requiere de que el firmware de la impresora sea compatible con los comandos M191 y M141, ya sea nativamente o mediante el uso de macros. Esta función se usa generalmente con impresoras con sistema de calentamiento de cámara activo."
+"Esta función requiere de que el firmware de la impresora sea compatible con los comandos M191 y M141, ya sea nativamente o mediante el uso de macros. Esta función se usa generalmente con impresoras con sistema de calentamiento de recámara activo."
 
 msgid ""
 "For high-temperature materials like ABS, ASA, PC, and PA, a higher chamber temperature can help suppress or reduce warping and potentially lead to higher interlayer bonding strength. However, at the same time, a higher chamber temperature will reduce the efficiency of air filtration for ABS and ASA.\n"
@@ -16374,13 +16374,13 @@ msgid ""
 "\n"
 "If enabled, this parameter also sets a G-code variable named chamber_temperature, which can be used to pass the desired chamber temperature to your print start macro, or a heat soak macro like this: PRINT_START (other variables) CHAMBER_TEMP=[chamber_temperature]. This may be useful if your printer does not support M141/M191 commands, or if you desire to handle heat soaking in the print start macro if no active chamber heater is installed."
 msgstr ""
-"Una mayor temperatura de la cámara puede ayudar a suprimir o reducir la deformación y potencialmente conducir a una mayor resistencia de unión entre capas para materiales de alta temperatura como ABS, ASA, PC, PA, etc. Al mismo tiempo, la filtración de aire de ABS y ASA empeorará.\n"
+"Una mayor temperatura de la recámara puede ayudar a suprimir o reducir la deformación y potencialmente conducir a una mayor resistencia de unión entre capas para materiales de alta temperatura como ABS, ASA, PC, PA, etc. Al mismo tiempo, la filtración de aire de ABS y ASA empeorará.\n"
 "\n"
-"Por otro lado, materiales como PLA, PETG, TPU, PVA y otros materiales de baja temperatura, la temperatura real de la cámara no debe ser alta para evitar obstrucciones causadas por reblandecimiento del filamento en el disipador.\n"
+"Por otro lado, materiales como PLA, PETG, TPU, PVA y otros materiales de baja temperatura, la temperatura real de la recámara no debe ser alta para evitar obstrucciones causadas por reblandecimiento del filamento en el disipador.\n"
 "\n"
-"Cuando se activa, este parámetro crea una variable de G-Code llamada chamber_temperature, que puede ser utilizada en macros personalizados, por ejemplo el macro de PRINT_START, para controlar el precalentamiento en impresoras encapsuladas que cuenten con un sensor de temperatura de cámara. Ejemplo de uso: \n"
+"Cuando se activa, este parámetro crea una variable de G-Code llamada chamber_temperature, que puede ser utilizada en macros personalizados, por ejemplo el macro de PRINT_START, para controlar el precalentamiento en impresoras encapsuladas que cuenten con un sensor de temperatura de recámara. Ejemplo de uso: \n"
 "PRINT_START (otras variables) CHAMBER_TEMP=[chamber_temperature] \n"
-"Esta funciuón es útil para imrpesoras no compatibles con los comandos M141 o M191, o si prefiere realizar un precalentamiento usando un macro si no dispone de un sistema de calentamiento activo de cámara."
+"Esta funciuón es útil para imrpesoras no compatibles con los comandos M141 o M191, o si prefiere realizar un precalentamiento usando un macro si no dispone de un sistema de calentamiento activo de recámara."
 
 msgid ""
 "This is the chamber temperature at which printing should start, while the chamber continues heating toward the \"Target\" chamber temperature. For example, set the Target to 60 and the Minimal to 50 to begin printing once the chamber reaches 50℃, without waiting for the full 60℃.\n"
@@ -16389,14 +16389,14 @@ msgid ""
 "\n"
 "Unlike the \"Target\" chamber temperature, this option does not emit any M141/M191 commands; it only exposes the value to your custom G-code. It should not exceed the \"Target\" chamber temperature."
 msgstr ""
-"Esta es la temperatura de la cámara a la que debe comenzar la impresión, mientras la cámara continúa calentándose hacia la temperatura objetivo (\"Objetivo\") de la cámara. Por ejemplo, ajuste «Objetivo» a 60 y «Mínima» a 50 para empezar a imprimir cuando la cámara alcance los 50 °C, sin esperar a los 60 °C completos.\n"
+"Esta es la temperatura de la recámara a la que debe comenzar la impresión, mientras la recámara continúa calentándose hacia la temperatura objetivo (\"Objetivo\") de la recámara. Por ejemplo, ajuste «Objetivo» a 60 y «Mínima» a 50 para empezar a imprimir cuando la recámara alcance los 50 °C, sin esperar a los 60 °C completos.\n"
 "\n"
 "Crea una variable de G-code llamada chamber_minimal_temperature, que puede pasarse a su macro de inicio de impresión o a una macro de precalentamiento, de esta forma: PRINT_START (otras variables) CHAMBER_MIN_TEMP=[chamber_minimal_temperature].\n"
 "\n"
-"A diferencia de la temperatura objetivo (\"Objetivo\") de la cámara, esta opción no emite ningún comando M141/M191; solo expone el valor a su G-code personalizado. No debería superar la temperatura objetivo (\"Objetivo\") de la cámara."
+"A diferencia de la temperatura objetivo (\"Objetivo\") de la recámara, esta opción no emite ningún comando M141/M191; solo expone el valor a su G-code personalizado. No debería superar la temperatura objetivo (\"Objetivo\") de la recámara."
 
 msgid "Chamber minimal temperature"
-msgstr "Temperatura mínima de cámara"
+msgstr "Temperatura mínima de recámara"
 
 msgid "Nozzle temperature after the first layer"
 msgstr "Temperatura de la boquilla después de la primera capa"
@@ -16500,7 +16500,7 @@ msgstr ""
 "Fijando un valor en la cantidad de retracción antes del purgado se realizará cualquier exceso de retracción antes del purgado, de lo contrario se realizará después."
 
 msgid "The wiping tower can be used to clean up residue on the nozzle and stabilize the chamber pressure inside the nozzle in order to avoid appearance defects when printing objects."
-msgstr "La torre de purga puede utilizarse para limpiar los residuos de la boquilla y estabilizar la presión de la cámara en el interior de la boquilla, con el fin de evitar defectos visuales al imprimir objetos."
+msgstr "La torre de purga puede utilizarse para limpiar los residuos de la boquilla y estabilizar la presión de la recámara en el interior de la boquilla, con el fin de evitar defectos visuales al imprimir objetos."
 
 msgid "Internal ribs"
 msgstr "Refuerzos internos"
@@ -20401,8 +20401,8 @@ msgid ""
 "Chamber temperature\n"
 "Did you know that OrcaSlicer supports chamber temperature?"
 msgstr ""
-"Temperatura de la cámara \n"
-"¿Sabías que OrcaSlicer tiene la función de control de temperatura de cámara?"
+"Temperatura de la recámara \n"
+"¿Sabías que OrcaSlicer tiene la función de control de temperatura de recámara?"
 
 #: resources/data/hints.ini: [hint:Calibration]
 msgid ""

--- a/localization/i18n/es/OrcaSlicer_es.po
+++ b/localization/i18n/es/OrcaSlicer_es.po
@@ -2027,15 +2027,15 @@ msgid "Learn more"
 msgstr "Más información"
 
 msgid "Reloading network plug-in..."
-msgstr "Recargando el complemento de red..."
+msgstr "Recargando el plugin de red..."
 
 msgid "Downloading Network Plug-in"
-msgstr "Descarga del complemento de red"
+msgstr "Descarga del plugin de red"
 
 # msgid "OrcaSlicer got an unhandled exception: %1%"
 # msgstr "OrcaSlicer obtuvo una excepción no manejada: %1%"
 msgid "Downloading Bambu Network Plug-in"
-msgstr "Descarga del complemento de red Bambu Network"
+msgstr "Descarga del plugin de red Bambu Network"
 
 msgid "Login information expired. Please login again."
 msgstr "La sesión ha caducado. Por favor, inicie sesión de nuevo."
@@ -2278,7 +2278,7 @@ msgstr ""
 "El modo desarrollador permite que la impresora funcione exclusivamente a través del acceso a la red local, lo que habilita todas las funciones con OrcaSlicer."
 
 msgid "Network Plug-in Restriction"
-msgstr "Restricción del complemento de red"
+msgstr "Restricción del plugin de red"
 
 msgid "Privacy Policy Update"
 msgstr "Actualización de política de privacidad"
@@ -4319,16 +4319,16 @@ msgid "Calibration"
 msgstr "Calibración"
 
 msgid "Failed to download the plug-in. Please check your firewall settings and VPN software and retry."
-msgstr "Fallo al descargar el complemento. Por favor, compruebe el cortafuegos y la vpn, e inténtelo de nuevo."
+msgstr "Fallo al descargar el plugin. Por favor, compruebe el cortafuegos y la vpn, e inténtelo de nuevo."
 
 msgid "Failed to install the plug-in. The plug-in file may be in use. Please restart OrcaSlicer and try again. Also check whether it is blocked or has been deleted by anti-virus software."
-msgstr "No se ha podido instalar el complemento. Es posible que el archivo del complemento esté en uso. Reinicie OrcaSlicer e inténtelo de nuevo. Compruebe también si está bloqueado o ha sido eliminado por el software antivirus."
+msgstr "No se ha podido instalar el plugin. Es posible que el archivo del plugin esté en uso. Reinicie OrcaSlicer e inténtelo de nuevo. Compruebe también si está bloqueado o ha sido eliminado por el software antivirus."
 
 msgid "Click here to see more info"
 msgstr "Presiona aquí para mostrar más información"
 
 msgid "The network plug-in was installed but could not be loaded. Please restart the application."
-msgstr "El complemento de red se instaló, pero no se pudo cargar. Reinicie la aplicación."
+msgstr "El plugin de red se instaló, pero no se pudo cargar. Reinicie la aplicación."
 
 msgid "Restart Required"
 msgstr "Se requiere reiniciar"
@@ -7159,7 +7159,7 @@ msgid "Undo integration was successful."
 msgstr "La operación de deshacer se ha realizado con éxito."
 
 msgid "New network plug-in available."
-msgstr "Nuevo complemento de red disponible."
+msgstr "Nuevo plugin de red disponible."
 
 msgid "Details"
 msgstr "Detalles"
@@ -8022,7 +8022,7 @@ msgid "Failed to load network plug-in. Please restart the application."
 msgstr "Error al cargar el plugin de red. Por favor, reinicie la aplicación."
 
 msgid "The network plug-in was not detected. Network related features are unavailable."
-msgstr "Complemento de red no detectado. Características de red no disponibles."
+msgstr "Plugin de red no detectado. Características de red no disponibles."
 
 msgid ""
 "Preview only mode:\n"
@@ -11056,7 +11056,7 @@ msgid "Please choose the filament colour"
 msgstr "Por favor, elija el color del filamento"
 
 msgid "Native Wayland liveview requires the GStreamer GTK video sink. Please install the gtksink plugin for GStreamer, then restart OrcaSlicer."
-msgstr "La función de visualización en directo nativa de Wayland requiere el receptor de vídeo GTK de GStreamer. Instale el complemento gtksink para GStreamer y, a continuación, reinicie OrcaSlicer."
+msgstr "La función de visualización en directo nativa de Wayland requiere el receptor de vídeo GTK de GStreamer. Instale el plugin gtksink para GStreamer y, a continuación, reinicie OrcaSlicer."
 
 msgid "Failed to initialize the native Wayland GStreamer video sink. Please check your GStreamer GTK plugin installation."
 msgstr "No se pudo inicializar el receptor de vídeo nativo de Wayland GStreamer. Compruebe la instalación del plugin GTK de GStreamer."
@@ -11345,10 +11345,10 @@ msgid "Network plug-in update"
 msgstr "Actualizar plug-in de red"
 
 msgid "Click OK to update the Network plug-in now. If a file is in use, the update will be applied the next time Orca Slicer launches."
-msgstr "Haga clic en Aceptar para actualizar ahora el complemento de red. Si hay un archivo en uso, la actualización se aplicará la próxima vez que se inicie Orca Slicer."
+msgstr "Haga clic en Aceptar para actualizar ahora el plugin de red. Si hay un archivo en uso, la actualización se aplicará la próxima vez que se inicie Orca Slicer."
 
 msgid "A new Network plug-in is available. Do you want to install it?"
-msgstr "Hay disponible un nuevo complemento de red. ¿Desea instalarlo?"
+msgstr "Hay disponible un nuevo plugin de red. ¿Desea instalarlo?"
 
 #, c-format, boost-format
 msgid "A new Network plug-in (%s) is available. Do you want to install it?"

--- a/localization/i18n/es/OrcaSlicer_es.po
+++ b/localization/i18n/es/OrcaSlicer_es.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Orca Slicer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-20 10:39-0300\n"
+"POT-Creation-Date: 2026-07-22 19:11-0300\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Ian A. Bassi <>\n"
 "Language-Team: \n"
@@ -15,22 +15,22 @@ msgstr ""
 "X-Generator: Poedit 3.9\n"
 
 msgid "Main Extruder"
-msgstr ""
+msgstr "Extrusor principal"
 
 msgid "Main extruder"
-msgstr ""
+msgstr "Extrusor principal"
 
 msgid "main extruder"
-msgstr ""
+msgstr "extrusor principal"
 
 msgid "Auxiliary Extruder"
-msgstr ""
+msgstr "Extrusor auxiliar"
 
 msgid "Auxiliary extruder"
-msgstr ""
+msgstr "Extrusor auxiliar"
 
 msgid "auxiliary extruder"
-msgstr ""
+msgstr "extrusor auxiliar"
 
 msgid "Left Extruder"
 msgstr "Extrusor izquierdo"
@@ -51,22 +51,22 @@ msgid "right extruder"
 msgstr "extrusor derecho"
 
 msgid "Main Nozzle"
-msgstr ""
+msgstr "Boquilla principal"
 
 msgid "Main nozzle"
-msgstr ""
+msgstr "Boquilla principal"
 
 msgid "main nozzle"
-msgstr ""
+msgstr "boquilla principal"
 
 msgid "Auxiliary Nozzle"
-msgstr ""
+msgstr "Boquilla auxiliar"
 
 msgid "Auxiliary nozzle"
-msgstr ""
+msgstr "Boquilla auxiliar"
 
 msgid "auxiliary nozzle"
-msgstr ""
+msgstr "boquilla auxiliar"
 
 msgid "Left Nozzle"
 msgstr "Boquilla izquierda"
@@ -87,52 +87,52 @@ msgid "right nozzle"
 msgstr "boquilla derecha"
 
 msgid "Main Hotend"
-msgstr ""
+msgstr "Hotend principal"
 
 msgid "Main hotend"
-msgstr ""
+msgstr "Hotend principal"
 
 msgid "main hotend"
-msgstr ""
+msgstr "hotend principal"
 
 msgid "Auxiliary Hotend"
-msgstr ""
+msgstr "Hotend auxiliar"
 
 msgid "Auxiliary hotend"
-msgstr ""
+msgstr "Hotend auxiliar"
 
 msgid "auxiliary hotend"
-msgstr ""
+msgstr "hotend auxiliar"
 
 msgid "Left Hotend"
-msgstr ""
+msgstr "Hotend izquierdo"
 
 msgid "Left hotend"
-msgstr ""
+msgstr "Hotend izquierdo"
 
 msgid "left hotend"
-msgstr ""
+msgstr "hotend izquierdo"
 
 msgid "Right Hotend"
-msgstr ""
+msgstr "Hotend derecho"
 
 msgid "Right hotend"
-msgstr ""
+msgstr "Hotend derecho"
 
 msgid "right hotend"
-msgstr ""
+msgstr "hotend derecho"
 
 msgid "main"
-msgstr ""
+msgstr "principal"
 
 msgid "auxiliary"
-msgstr ""
+msgstr "auxiliar"
 
 msgid "Main"
-msgstr ""
+msgstr "Principal"
 
 msgid "Auxiliary"
-msgstr ""
+msgstr "Auxiliar"
 
 msgid "left"
 msgstr "izquierda"
@@ -342,7 +342,7 @@ msgid "Please wait"
 msgstr "Espere por favor"
 
 msgid "Reading"
-msgstr ""
+msgstr "Leyendo"
 
 msgid "Running..."
 msgstr "En ejecución..."
@@ -3477,6 +3477,7 @@ msgctxt "air_duct"
 msgid "Left(Aux)"
 msgstr "Izquierda (Auxiliar)"
 
+msgctxt "Hotend Heat Breaker Fan"
 msgid "Hotend"
 msgstr "Hotend"
 
@@ -4148,7 +4149,7 @@ msgstr "Seleccione uno de los siguientes filamentos"
 
 #, c-format, boost-format
 msgid "Select filament that installed to the %s"
-msgstr ""
+msgstr "Seleccione el filamento instalado en %s"
 
 msgid "Left AMS"
 msgstr "AMS izquierdo"
@@ -4168,18 +4169,18 @@ msgstr "La impresión con la boquilla actual puede producir un extra de %0.2f g 
 
 #, c-format, boost-format
 msgid "Tips: the filament type(%s) does not match with the filament type(%s) in the slicing file. If you want to use this slot, you can install %s instead of %s and change slot information on the 'Device' page."
-msgstr ""
+msgstr "Consejo: el tipo de filamento (%s) no coincide con el tipo de filamento (%s) del archivo laminado. Si desea usar esta ranura, puede instalar %s en lugar de %s y cambiar la información de la ranura en la página «Dispositivo»."
 
 #, c-format, boost-format
 msgid "Cannot select: the filament type(%s) does not match with the filament type(%s) in the slicing file. If you want to use this slot, you can install %s instead of %s and change slot information on the 'Device' page."
-msgstr ""
+msgstr "No se puede seleccionar: el tipo de filamento (%s) no coincide con el tipo de filamento (%s) del archivo laminado. Si desea usar esta ranura, puede instalar %s en lugar de %s y cambiar la información de la ranura en la página «Dispositivo»."
 
 #, c-format, boost-format
 msgid "Cannot select: the slot is empty or undefined. If you want to use this slot, you can install %s and change slot information on the 'Device' page."
-msgstr ""
+msgstr "No se puede seleccionar: la ranura está vacía o sin definir. Si desea usar esta ranura, puede instalar %s y cambiar la información de la ranura en la página «Dispositivo»."
 
 msgid "Cannot select: No filament loaded in current slot."
-msgstr ""
+msgstr "No se puede seleccionar: no hay filamento cargado en la ranura actual."
 
 msgid "Enable AMS"
 msgstr "Activar AMS"
@@ -4914,7 +4915,7 @@ msgid "Calibration error"
 msgstr "Error de calibración"
 
 msgid "Network unavailable"
-msgstr ""
+msgstr "Red no disponible"
 
 msgid "Resume Printing"
 msgstr "Continuar Imprimiendo"
@@ -4950,7 +4951,7 @@ msgid "No Reminder Next Time"
 msgstr "No recordar la próxima vez"
 
 msgid "Recheck"
-msgstr ""
+msgstr "Volver a comprobar"
 
 msgid "Ignore. Don't Remind Next Time"
 msgstr "Ignorar. No recordar la próxima vez"
@@ -4974,13 +4975,13 @@ msgid "Proceed"
 msgstr "Continuar"
 
 msgid "Abort"
-msgstr ""
+msgstr "Abortar"
 
 msgid "Disable Purification for This Print"
-msgstr ""
+msgstr "Desactivar la purificación para esta impresión"
 
 msgid "Don't Remind Me"
-msgstr ""
+msgstr "No recordármelo"
 
 msgid "Retry"
 msgstr "Reintentar"
@@ -4992,7 +4993,7 @@ msgid "Unknown error."
 msgstr "Error desconocido."
 
 msgid "Loading ..."
-msgstr ""
+msgstr "Cargando ..."
 
 msgid "default"
 msgstr "por defecto"
@@ -7310,16 +7311,16 @@ msgstr ""
 "Active o instale alguna para usarla."
 
 msgid "There is stringing-prone filament in the current print job. Enabling nozzle clumping detection now may degrade print quality. Are you sure you want to enable it?"
-msgstr ""
+msgstr "El trabajo de impresión actual contiene filamento propenso a formar hilos. Habilitar ahora la detección de acumulación en la boquilla puede reducir la calidad de impresión. ¿Seguro que desea habilitarla?"
 
 msgid "Enable Nozzle Clumping Detection"
-msgstr ""
+msgstr "Habilitar la detección de acumulación en la boquilla"
 
 msgid "When enabled, the printer will automatically capture photos of printed parts and upload them to the cloud. Would you like to enable this option?"
-msgstr ""
+msgstr "Cuando está habilitada, la impresora capturará automáticamente fotos de las piezas impresas y las subirá a la nube. ¿Desea habilitar esta opción?"
 
 msgid "Confirm Enable Print Status Snapshot"
-msgstr ""
+msgstr "Confirmar la activación de la captura del estado de impresión"
 
 msgid "Enable detection of build plate position"
 msgstr "Activar detección de posición de cama"
@@ -7334,19 +7335,19 @@ msgid "Identifies the type and position of the build plate on the heatbed. Pausi
 msgstr "Identifica el tipo y la posición de la placa de construcción sobre la cama calefactada. Pausa la impresión si se detecta una discrepancia."
 
 msgid "Purifies the chamber air as the print finishes, based on the selected mode."
-msgstr ""
+msgstr "Purifica el aire de la cámara al finalizar la impresión, según el modo seleccionado."
 
 msgid "Purifies the chamber air through internal circulation as each print finishes."
-msgstr ""
+msgstr "Purifica el aire de la cámara mediante circulación interna al finalizar cada impresión."
 
 msgid "Automatically match the corresponding switch strategy for leak-prone filaments (disable blob detection) and regular filaments (enable blob detection)."
-msgstr ""
+msgstr "Aplica automáticamente la estrategia de conmutación correspondiente para filamentos propensos a fugas (desactiva la detección de acumulación) y filamentos normales (activa la detección de acumulación)."
 
 msgid "Detect whether the nozzle is wrapped by filament or other foreign matter."
-msgstr ""
+msgstr "Detecta si la boquilla está envuelta por filamento u otro material extraño."
 
 msgid "After disabling, nozzle wrapping cannot be detected, which may lead to print failure or nozzle damage."
-msgstr ""
+msgstr "Tras desactivarla, no se podrá detectar el envolvimiento de la boquilla, lo que puede provocar fallos de impresión o daños en la boquilla."
 
 msgid "AI Detections"
 msgstr "Detecciones de IA"
@@ -7391,7 +7392,7 @@ msgid "Store Sent Files on External Storage"
 msgstr "Guardar archivos enviados en almacenamiento externo"
 
 msgid "Save the printing files sent from the slicer and other apps on External Storage"
-msgstr ""
+msgstr "Guardar en el almacenamiento externo los archivos de impresión enviados desde el laminador y otras aplicaciones"
 
 msgid "Allow Prompt Sound"
 msgstr "Permitir Sonido de Aviso"
@@ -7403,31 +7404,31 @@ msgid "Check if the nozzle is clumping by filament or other foreign objects."
 msgstr "Comprobar si la boquilla está obstruida por filamento u otros objetos extraños.Compruebe si la boquilla está atascada por el filamento u otros objetos extraños."
 
 msgid "Purify Air at Print End"
-msgstr ""
+msgstr "Purificar el aire al finalizar la impresión"
 
 msgid "Internal Circulation"
-msgstr ""
+msgstr "Circulación interna"
 
 msgid "Alignment Detection"
-msgstr ""
+msgstr "Detección de alineación"
 
 msgid "Pauses printing when build plate misalignment is detected."
-msgstr ""
+msgstr "Pausa la impresión cuando se detecta una desalineación de la cama."
 
 msgid "Foreign Object Detection"
-msgstr ""
+msgstr "Detección de objetos extraños"
 
 msgid "Checks for any objects on the build plate at the start of a print to avoid collisions."
-msgstr ""
+msgstr "Comprueba si hay objetos en la cama al inicio de la impresión para evitar colisiones."
 
 msgid "Printed Part Displacement Detection"
-msgstr ""
+msgstr "Detección de desplazamiento de la pieza impresa"
 
 msgid "Monitors the printed part during printing and alerts immediately if it shifts or collapses."
-msgstr ""
+msgstr "Supervisa la pieza impresa durante la impresión y avisa de inmediato si se desplaza o se derrumba."
 
 msgid "Checks if the nozzle is clumping by filament or other foreign objects."
-msgstr ""
+msgstr "Comprueba si la boquilla acumula filamento u otros objetos extraños."
 
 msgid "On"
 msgstr "Activado"
@@ -7442,10 +7443,10 @@ msgid "Pause printing"
 msgstr "Pausar impresión"
 
 msgid "Print Status Snapshot"
-msgstr ""
+msgstr "Captura del estado de impresión"
 
 msgid "Automatically capture and upload print photos, showing defects during printing and the final result for remote viewing."
-msgstr ""
+msgstr "Captura y sube automáticamente fotos de la impresión, mostrando los defectos durante el proceso y el resultado final para verlos de forma remota."
 
 msgctxt "Nozzle Type"
 msgid "Type"
@@ -8881,6 +8882,15 @@ msgstr "Mostrar FPS en pantalla"
 msgid "Displays current viewport FPS in the top-right corner."
 msgstr "Muestra los FPS en la esquina superior derecha."
 
+msgid "G-code Preview"
+msgstr "Vista previa del G-code"
+
+msgid "Dim lower layers"
+msgstr "Atenuar las capas inferiores"
+
+msgid "When scrubbing the layer slider in the sliced preview, render the layers below the current one darkened so that only the layer being viewed is shown at full brightness."
+msgstr "Al desplazar el control deslizante de capas en la vista previa laminada, oscurece las capas inferiores a la actual para que solo la capa visualizada se muestre a pleno brillo."
+
 msgid "Login region"
 msgstr "Región de inicio de sesión"
 
@@ -9356,7 +9366,7 @@ msgid "To ensure print quality, the drying temperature will be lowered during pr
 msgstr "Para garantizar la calidad de impresión, la temperatura de secado se reducirá durante la impresión."
 
 msgid "Select timelapse storage location"
-msgstr ""
+msgstr "Seleccionar la ubicación de almacenamiento del timelapse"
 
 msgid "Auto Bed Leveling"
 msgstr "Nivelado automático de cama"
@@ -9389,10 +9399,10 @@ msgstr ""
 "*Modo automático: Compruebe la calibración antes de imprimir. Omitir si no es necesario."
 
 msgid "Shared PA Profile"
-msgstr ""
+msgstr "Perfil PA compartido"
 
 msgid "Nozzles and filaments of the same type share the same PA profile."
-msgstr ""
+msgstr "Las boquillas y los filamentos del mismo tipo comparten el mismo perfil PA."
 
 msgid "Send complete"
 msgstr "Envío completo"
@@ -9439,7 +9449,7 @@ msgstr "El mapeo de boquillas actual puede producir %0.2f g adicionales de resid
 
 #, c-format, boost-format
 msgid "Recommended filament arrangement saves %s->"
-msgstr ""
+msgstr "La disposición de filamento recomendada ahorra %s->"
 
 #, c-format, boost-format
 msgid "Filament %s does not match the filament in AMS slot %s. Please update the printer firmware to support AMS slot assignment."
@@ -9457,6 +9467,9 @@ msgstr "Cuando active el modo vaso en espiral, las máquinas con estructura I3 n
 
 msgid "The current printer does not support timelapse in Traditional Mode when printing By-Object."
 msgstr "La impresora actual no admite timelapse en Modo Tradicional al imprimir Por Objeto."
+
+msgid "I have checked the installed nozzle and want to print anyway."
+msgstr "He comprobado la boquilla instalada y quiero imprimir de todos modos."
 
 msgid "Errors"
 msgstr "Errores"
@@ -9493,31 +9506,31 @@ msgstr "Interno"
 
 #, c-format, boost-format
 msgid "%s space less than 20MB. Timelapse may not save properly. You can turn it off or"
-msgstr ""
+msgstr "Espacio de %s inferior a 20 MB. Es posible que el timelapse no se guarde correctamente. Puede desactivarlo o"
 
 msgid "Clean up files"
-msgstr ""
+msgstr "Limpiar archivos"
 
 msgid "Low internal storage. This timelapse will overwrite the oldest video files."
-msgstr ""
+msgstr "Almacenamiento interno bajo. Este timelapse sobrescribirá los archivos de vídeo más antiguos."
 
 msgid "Low external storage. This timelapse will overwrite the oldest video files."
-msgstr ""
+msgstr "Almacenamiento externo bajo. Este timelapse sobrescribirá los archivos de vídeo más antiguos."
 
 msgid "Insufficient external storage for time-lapse photography. Connect to computer to delete files, or use a larger memory card."
-msgstr ""
+msgstr "Almacenamiento externo insuficiente para la fotografía timelapse. Conecte el equipo para eliminar archivos o use una tarjeta de memoria más grande."
 
 msgid "Storage Space Not Enough"
-msgstr ""
+msgstr "Espacio de almacenamiento insuficiente"
 
 msgid "Confirm & Print"
-msgstr ""
+msgstr "Confirmar e imprimir"
 
 msgid "Cancel Timelapse & Print"
-msgstr ""
+msgstr "Cancelar timelapse e imprimir"
 
 msgid "Clean Up"
-msgstr ""
+msgstr "Limpiar"
 
 msgid "Preparing print job"
 msgstr "Preparando el trabajo de impresión"
@@ -9584,20 +9597,20 @@ msgid "The hardness of current material (%s) exceeds the hardness of %s(%s). Ple
 msgstr "La dureza del material actual (%s) supera la dureza de %s(%s). Verifique la boquilla o la configuración del material e inténtelo de nuevo."
 
 msgid "Your current firmware version cannot start this print job. Please update to the latest version and try again."
-msgstr ""
+msgstr "La versión actual del firmware no puede iniciar este trabajo de impresión. Actualice a la última versión e inténtelo de nuevo."
 
 #, c-format, boost-format
 msgid "The hardness of current material (%s) exceeds the hardness of %s(%s). It may cause nozzle wear, leading to material leakage and unstable flow. Please exercise caution when using it."
 msgstr "La dureza del material actual (%s) supera la dureza de %s(%s). Puede provocar el desgaste de la boquilla, dando lugar a fugas de material y flujo inestable. Tenga precaución al utilizarlo."
 
 msgid "Some filaments may switch between extruders during printing. Manual K-value calibration cannot be applied throughout the entire print, which may affect print quality. Enabling Flow Dynamics Calibration is recommended."
-msgstr ""
+msgstr "Algunos filamentos pueden cambiar de extrusor durante la impresión. La calibración manual del valor K no puede aplicarse durante toda la impresión, lo que puede afectar a la calidad de impresión. Se recomienda habilitar la Calibración de Dinámica de Flujo."
 
 msgid "There is stringing-prone filament in this file. For best print quality, we recommend switching nozzle clumping detection to Auto mode."
-msgstr ""
+msgstr "Este archivo contiene filamento propenso a formar hilos. Para obtener la mejor calidad de impresión, recomendamos cambiar la detección de acumulación en la boquilla al modo automático."
 
 msgid "If 'Dynamic Flow Calibration' is set to Auto/On, the system will use the manual calibration value or the default value and skip the flow calibration process. You can perform a manual flow calibration for TPU filament on the 'Calibration' page."
-msgstr ""
+msgstr "Si «Calibración de Flujo Dinámico» está en Auto/Activado, el sistema usará el valor de calibración manual o el valor predeterminado y omitirá el proceso de calibración de flujo. Puede realizar una calibración de flujo manual para el filamento TPU en la página «Calibración»."
 
 #, c-format, boost-format
 msgid "[ %s ] requires printing in a high-temperature environment. Please close the door."
@@ -9704,16 +9717,16 @@ msgstr "Esta impresora no soporta la impresión de todas las camas."
 
 #, c-format, boost-format
 msgid "The current firmware supports a maximum of %s materials. You can either reduce the number of materials to %s or fewer on the Preparation Page, or try updating the firmware. If you are still restricted after the update, please wait for subsequent firmware support."
-msgstr ""
+msgstr "El firmware actual admite un máximo de %s materiales. Puede reducir el número de materiales a %s o menos en la página de Preparación, o intentar actualizar el firmware. Si tras la actualización sigue estando limitado, espere a que el firmware lo admita en el futuro."
 
 msgid "The type of external filament is unknown or does not match with the filament type in the slicing file. Please make sure you have installed the correct filament in the external spool."
 msgstr "Se desconoce el tipo de filamento externo o no coincide con el tipo de filamento indicado en el archivo de corte. Asegúrate de haber colocado el filamento correcto en la bobina externa."
 
 msgid "TPU 90A/TPU 85A are too soft. It is recommended to perform manual flow calibration on the 'Calibration' page. If 'Dynamic Flow Calibration' is set to auto/on, the system will use the previous calibration value and skip the flow calibration process."
-msgstr ""
+msgstr "El TPU 90A/TPU 85A son demasiado blandos. Se recomienda realizar una calibración de flujo manual en la página «Calibración». Si «Calibración de Flujo Dinámico» está en auto/activado, el sistema usará el valor de calibración anterior y omitirá el proceso de calibración de flujo."
 
 msgid "The filament in the AMS may be insufficient for this print. Please refill or replace it."
-msgstr ""
+msgstr "Puede que el filamento del AMS sea insuficiente para esta impresión. Recárguelo o reemplácelo."
 
 msgid "Current firmware does not support file transfer to internal storage."
 msgstr "El firmware actual no admite la transferencia de archivos al almacenamiento interno."
@@ -11332,10 +11345,10 @@ msgid "Network plug-in update"
 msgstr "Actualizar plug-in de red"
 
 msgid "Click OK to update the Network plug-in now. If a file is in use, the update will be applied the next time Orca Slicer launches."
-msgstr ""
+msgstr "Haga clic en Aceptar para actualizar ahora el complemento de red. Si hay un archivo en uso, la actualización se aplicará la próxima vez que se inicie Orca Slicer."
 
 msgid "A new Network plug-in is available. Do you want to install it?"
-msgstr ""
+msgstr "Hay disponible un nuevo complemento de red. ¿Desea instalarlo?"
 
 #, c-format, boost-format
 msgid "A new Network plug-in (%s) is available. Do you want to install it?"
@@ -16857,6 +16870,12 @@ msgstr "Compatible con el modo de purga rápida"
 msgid "Whether this printer supports fast purge mode with optimized temperature and multiplier."
 msgstr "Indica si esta impresora es compatible con el modo de purga rápida con temperatura y multiplicador optimizados."
 
+msgid "Filament change"
+msgstr "Cambio de filamento"
+
+msgid "The volume of material required to prime the extruder on the tower, excluding a hotend change."
+msgstr "El volumen de material necesario para cebar el extrusor en la torre, sin incluir un cambio de hotend."
+
 msgid "The volume of material required to prime the extruder for a hotend change on the tower."
 msgstr "El volumen de material necesario para cebar el extrusor al cambiar el Hotend en la torre."
 
@@ -20042,14 +20061,14 @@ msgstr "Error: %s"
 msgid "Show details"
 msgstr "Mostrar detalles"
 
+msgid "Hide details"
+msgstr "Ocultar detalles"
+
 msgid "Version to install:"
 msgstr "Versión a instalar:"
 
 msgid "Download and Install"
 msgstr "Descargar e instalar"
-
-msgid "Skip for Now"
-msgstr "Omitir por ahora"
 
 msgid "A new version of the Bambu Network Plug-in is available."
 msgstr "Hay disponible una nueva versión del plug-in Bambu Network."
@@ -20061,23 +20080,17 @@ msgstr "Versión actual: %s"
 msgid "Update to version:"
 msgstr "Actualización a la versión:"
 
-msgid "Update Now"
-msgstr "Actualizar ahora"
-
-msgid "Remind Later"
-msgstr "Recordar más tarde"
-
-msgid "Skip Version"
-msgstr "Omitir versión"
-
 msgid "Don't Ask Again"
 msgstr "No volver a preguntar"
+
+msgid "Update Now"
+msgstr "Actualizar ahora"
 
 msgid "(Latest)"
 msgstr "(Última)"
 
 msgid "(installed)"
-msgstr ""
+msgstr "(instalado)"
 
 msgid "The Bambu Network Plug-in has been installed successfully."
 msgstr "El Plug-in de Bambu Network se ha instalado correctamente."
@@ -20087,9 +20100,6 @@ msgstr "Es necesario reiniciar el sistema para cargar el nuevo plug-in. ¿Desea 
 
 msgid "Restart Now"
 msgstr "Reiniciar ahora"
-
-msgid "Restart Later"
-msgstr "Reiniciar más tarde"
 
 msgid "NO RAMMING AT ALL"
 msgstr "NO CHOCAR EN ABSOLUTO"
@@ -20669,6 +20679,21 @@ msgid ""
 msgstr ""
 "Evita la deformación\n"
 "¿Sabías que al imprimir materiales propensos a la deformación como el ABS, aumentar adecuadamente la temperatura de la cama térmica puede reducir la probabilidad de deformaciones?"
+
+#~ msgid "Hotend"
+#~ msgstr "Hotend"
+
+#~ msgid "Skip for Now"
+#~ msgstr "Omitir por ahora"
+
+#~ msgid "Remind Later"
+#~ msgstr "Recordar más tarde"
+
+#~ msgid "Skip Version"
+#~ msgstr "Omitir versión"
+
+#~ msgid "Restart Later"
+#~ msgstr "Reiniciar más tarde"
 
 #~ msgid "Select filament that installed to the left nozzle"
 #~ msgstr "Selecciona el filamento instalado en la boquilla izquierda"

--- a/localization/i18n/eu/OrcaSlicer_eu.po
+++ b/localization/i18n/eu/OrcaSlicer_eu.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-23 14:21-0300\n"
+"POT-Creation-Date: 2026-07-23 15:24-0300\n"
 "PO-Revision-Date: 2026-07-20 13:33+0200\n"
 "Last-Translator: Manu Goiogana <mgoiogana@gmail.com>\n"
 "Language-Team: \n"
@@ -553,8 +553,9 @@ msgstr "Berriro esleitu"
 msgid "Reset"
 msgstr "Berrezarri"
 
+msgctxt "Keyboard Shortcut"
 msgid "Enter"
-msgstr "Sartu"
+msgstr ""
 
 msgid "Shortcut Key "
 msgstr "Lasterbideko tekla "
@@ -1749,14 +1750,16 @@ msgstr "Hautatu"
 msgid "Select point"
 msgstr "Hautatu puntua"
 
+msgctxt "Keyboard Shortcut"
 msgid "Delete"
-msgstr "Ezabatu"
+msgstr ""
 
 msgid "Restart selection"
 msgstr "Berrabiarazi hautaketa"
 
+msgctxt "Keyboard Shortcut"
 msgid "Esc"
-msgstr "Esc"
+msgstr ""
 
 msgid "Cancel a feature until exit"
 msgstr "Ezaugarri bat bertan behera utzi irten arte"
@@ -2418,6 +2421,9 @@ msgstr "Ezin izan da URLa deskargatzen hasi. Helburuko karpeta ez dago ezarrita.
 msgid "Import File"
 msgstr "Inportatu fitxategia"
 
+msgid "Delete"
+msgstr "Ezabatu"
+
 msgid "Choose files"
 msgstr "Hautatu fitxategiak"
 
@@ -2536,14 +2542,16 @@ msgstr "Eskutatu"
 msgid "Show"
 msgstr "Erakutsi"
 
+msgctxt "Keyboard Shortcut"
 msgid "Del"
-msgstr "Ezabatu"
+msgstr ""
 
 msgid "Delete the selected object"
 msgstr "Ezabatu hautatutako elementuak"
 
+msgctxt "Keyboard Shortcut"
 msgid "Backspace"
-msgstr "Atzera-tekla"
+msgstr ""
 
 msgid "Load..."
 msgstr "Kargatu..."
@@ -11178,26 +11186,30 @@ msgstr "Hautatu objektu bat baino gehiago"
 msgid "Select objects by rectangle"
 msgstr "Hautatu objektuak laukizuzen bidez"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Up"
-msgstr "Gora gezia"
+msgstr ""
 
 msgid "Move selection 10mm in positive Y direction"
 msgstr "Mugitu hautapena 10 mm Y noranzko positiboan"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Down"
-msgstr "Behera gezia"
+msgstr ""
 
 msgid "Move selection 10mm in negative Y direction"
 msgstr "Mugitu hautapena 10 mm Y noranzko negatiboan"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Left"
-msgstr "Ezker gezia"
+msgstr ""
 
 msgid "Move selection 10mm in negative X direction"
 msgstr "Mugitu hautapena 10 mm X noranzko negatiboan"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Right"
-msgstr "Eskuin gezia"
+msgstr ""
 
 msgid "Move selection 10mm in positive X direction"
 msgstr "Mugitu hautapena 10 mm X noranzko positiboan"
@@ -11280,8 +11292,16 @@ msgstr "Txikiagotu zooma"
 msgid "Toggle printable for object/part"
 msgstr "Txandakatu objektuaren/piezaren inprimagarritasuna"
 
+msgctxt "Keyboard Shortcut"
+msgid "Tab"
+msgstr ""
+
 msgid "Switch between Prepare/Preview"
 msgstr "Aldatu Prestatu/Aurrebista artean"
+
+msgctxt "Keyboard Shortcut"
+msgid "Space"
+msgstr ""
 
 msgid "Open actions speed dial"
 msgstr "Ekintzen markatze azkarra ireki"
@@ -11340,11 +11360,16 @@ msgstr "G-code leihoa aktibatu/desaktibatu"
 msgid "Move slider 5x faster"
 msgstr "Mugitu graduatzailea 5 aldiz azkarrago"
 
+msgctxt "Keyboard Shortcut"
+msgid "Home"
+msgstr ""
+
 msgid "Horizontal slider - Move to start position"
 msgstr "Graduatzaile horizontala - Mugitu hasierako posiziora"
 
+msgctxt "Keyboard Shortcut"
 msgid "End"
-msgstr "Amaiera"
+msgstr ""
 
 msgid "Horizontal slider - Move to last position"
 msgstr "Graduatzaile horizontala - Mugitu azken posiziora"
@@ -20694,6 +20719,33 @@ msgid ""
 msgstr ""
 "Saihestu okertzea\n"
 "Ba al zenekien ABS bezalako okertzeko joera duten materialak inprimatzean ohe beroaren tenperatura egoki igotzeak okertzeko probabilitatea murriztu dezakeela?"
+
+#~ msgid "Enter"
+#~ msgstr "Sartu"
+
+#~ msgid "Esc"
+#~ msgstr "Esc"
+
+#~ msgid "Del"
+#~ msgstr "Ezabatu"
+
+#~ msgid "Backspace"
+#~ msgstr "Atzera-tekla"
+
+#~ msgid "Arrow Up"
+#~ msgstr "Gora gezia"
+
+#~ msgid "Arrow Down"
+#~ msgstr "Behera gezia"
+
+#~ msgid "Arrow Left"
+#~ msgstr "Ezker gezia"
+
+#~ msgid "Arrow Right"
+#~ msgstr "Eskuin gezia"
+
+#~ msgid "End"
+#~ msgstr "Amaiera"
 
 #~ msgid "Hotend"
 #~ msgstr "Hotend-a"

--- a/localization/i18n/eu/OrcaSlicer_eu.po
+++ b/localization/i18n/eu/OrcaSlicer_eu.po
@@ -15636,16 +15636,16 @@ msgstr ""
 "Kantitate hau milimetrotan edo uneko estrusorearen diametroaren ehuneko gisa zehaztu daiteke. Parametro honen balio lehenetsia %10 da."
 
 msgid "Scarf joint seam (beta)"
-msgstr "Bufanda junturako jostura (beta)"
+msgstr "Alaka junturako jostura (beta)"
 
 msgid "Use scarf joint to minimize seam visibility and increase seam strength."
-msgstr "Erabili bufanda junturako josturaren ikusgarritasuna minimizatzeko etajosturaren sendotasuna handitzeko."
+msgstr "Erabili alaka junturako josturaren ikusgarritasuna minimizatzeko etajosturaren sendotasuna handitzeko."
 
 msgid "Conditional scarf joint"
-msgstr "Baldintzapeko bufanda-juntura"
+msgstr "Baldintzapeko alaka-juntura"
 
 msgid "Apply scarf joints only to smooth perimeters where traditional seams do not conceal the seams at sharp corners effectively."
-msgstr "Aplikatu bufanda junturak perimetro leunetan bakarrik, jostura tradizionalek izkina zorrotzetako josturak ondo ezkutatzen ez dituztenean."
+msgstr "Aplikatu alaka junturak perimetro leunetan bakarrik, jostura tradizionalek izkina zorrotzetako josturak ondo ezkutatzen ez dituztenean."
 
 msgid "Conditional angle threshold"
 msgstr "Baldintzapeko angeluaren atalasea"
@@ -15654,7 +15654,7 @@ msgid ""
 "This option sets the threshold angle for applying a conditional scarf joint seam.\n"
 "If the maximum angle within the perimeter loop exceeds this value (indicating the absence of sharp corners), a scarf joint seam will be used. The default value is 155°."
 msgstr ""
-"Aukera honek baldintzapeko bufanda junturako jostura aplikatzeko angelu-atalasea ezartzen du.\n"
+"Aukera honek baldintzapeko alaka junturako jostura aplikatzeko angelu-atalasea ezartzen du.\n"
 "Perimetro-begiztaren barruko gehieneko angelua balio hau baino handiagoa bada (izkina zorrotzik ez dagoela adieraziz), juntura zeiharreko jostura erabiliko da. Balio lehenetsia 155° da."
 
 msgid "Conditional overhang threshold"
@@ -15665,19 +15665,19 @@ msgid "This option determines the overhang threshold for the application of scar
 msgstr "Aukera honek juntura zeiharreko josturak aplikatzeko irtenguneen atalasea zehazten du. Perimetroaren euskarririk gabeko zatia atalase hau baino txikiagoa bada, juntura zeiharreko josturak aplikatuko dira. Atalase lehenetsia kanpoko hormaren zabaleraren %40 da. Errendimendu-arrazoiengatik, irtengunearen maila estimatu egiten da."
 
 msgid "Scarf joint speed"
-msgstr "Bufanda junturako abiadura"
+msgstr "Alaka junturako abiadura"
 
 msgid "This option sets the printing speed for scarf joints. It is recommended to print scarf joints at a slow speed (less than 100 mm/s). It's also advisable to enable 'Extrusion rate smoothing' if the set speed varies significantly from the speed of the outer or inner walls. If the speed specified here is higher than the speed of the outer or inner walls, the printer will default to the slower of the two speeds. When specified as a percentage (e.g., 80%), the speed is calculated based on the respective outer or inner wall speed. The default value is set to 100%."
-msgstr "Aukera honek bufanda junturako inprimatze-abiadura ezartzen du. Gomendagarria da juntura zeiharrak abiadura motelean inprimatzea (100 mm/s baino gutxiago). 'Estrusio-tasaren leuntzea' gaitzea ere komeni da ezarritako abiadura kanpoko edo barruko hormen abiaduratik nabarmen aldentzen bada. Hemen zehaztutako abiadura kanpoko edo barruko hormen abiadura baino handiagoa bada, inprimagailuak bietako motelena erabiliko du. Ehuneko gisa zehazten bada (adibidez, %80), abiadura dagokion kanpoko edo barruko hormaren abiaduraren arabera kalkulatuko da. Balio lehenetsia %100 da."
+msgstr "Aukera honek alaka junturako inprimatze-abiadura ezartzen du. Gomendagarria da juntura zeiharrak abiadura motelean inprimatzea (100 mm/s baino gutxiago). 'Estrusio-tasaren leuntzea' gaitzea ere komeni da ezarritako abiadura kanpoko edo barruko hormen abiaduratik nabarmen aldentzen bada. Hemen zehaztutako abiadura kanpoko edo barruko hormen abiadura baino handiagoa bada, inprimagailuak bietako motelena erabiliko du. Ehuneko gisa zehazten bada (adibidez, %80), abiadura dagokion kanpoko edo barruko hormaren abiaduraren arabera kalkulatuko da. Balio lehenetsia %100 da."
 
 msgid "Scarf joint flow ratio"
-msgstr "Bufanda junturako fluxu-erlazioa"
+msgstr "Alaka junturako fluxu-erlazioa"
 
 msgid "This factor affects the amount of material for scarf joints."
-msgstr "Faktore honek bufanda junturako material kantitateari eragiten dio."
+msgstr "Faktore honek alaka junturako material kantitateari eragiten dio."
 
 msgid "Scarf start height"
-msgstr "Bufandaren hasierako altuera"
+msgstr "Alakaren hasierako altuera"
 
 msgid ""
 "Start height of the scarf.\n"
@@ -15687,7 +15687,7 @@ msgstr ""
 "Kantitate hau milimetrotan edo uneko geruza-altueraren ehuneko gisa zehaztu daiteke. Parametro honen balio lehenetsia 0 da."
 
 msgid "Scarf around entire wall"
-msgstr "Bufanda horma osoan zehar"
+msgstr "Alaka horma osoan zehar"
 
 msgid "The scarf extends to the entire length of the wall."
 msgstr "Juntura hormaren luzera osora hedatzen da."
@@ -15705,10 +15705,10 @@ msgid "Minimum number of segments of each scarf."
 msgstr "Juntura bakoitzaren gutxieneko segmentu kopurua."
 
 msgid "Scarf joint for inner walls"
-msgstr "Barruko hormetarako bufanda juntura"
+msgstr "Barruko hormetarako alaka juntura"
 
 msgid "Use scarf joint for inner walls as well."
-msgstr "Erabili bufanda juntura barruko hormetan ere."
+msgstr "Erabili alaka juntura barruko hormetan ere."
 
 msgid "Role base wipe speed"
 msgstr "Eginkizunaren araberako purgatze-abiadura"

--- a/localization/i18n/eu/OrcaSlicer_eu.po
+++ b/localization/i18n/eu/OrcaSlicer_eu.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-20 10:39-0300\n"
+"POT-Creation-Date: 2026-07-22 19:11-0300\n"
 "PO-Revision-Date: 2026-07-20 13:33+0200\n"
 "Last-Translator: Manu Goiogana <mgoiogana@gmail.com>\n"
 "Language-Team: \n"
@@ -3478,8 +3478,9 @@ msgctxt "air_duct"
 msgid "Left(Aux)"
 msgstr "Ezkerrekoa (Osag.)"
 
+msgctxt "Hotend Heat Breaker Fan"
 msgid "Hotend"
-msgstr "Hotend-a"
+msgstr ""
 
 msgid "Parts"
 msgstr "Piezak"
@@ -8871,6 +8872,15 @@ msgstr "Erakutsi FPS gainjartzea"
 msgid "Displays current viewport FPS in the top-right corner."
 msgstr "Uneko ikuspegiaren FPSa goiko eskuineko izkinan erakusten du."
 
+msgid "G-code Preview"
+msgstr ""
+
+msgid "Dim lower layers"
+msgstr ""
+
+msgid "When scrubbing the layer slider in the sliced preview, render the layers below the current one darkened so that only the layer being viewed is shown at full brightness."
+msgstr ""
+
 msgid "Login region"
 msgstr "Saio-hasierako eskualdea"
 
@@ -9447,6 +9457,9 @@ msgstr "Espiral formako loreontziaren modua gaituta dagoenean, I3 egitura duten 
 
 msgid "The current printer does not support timelapse in Traditional Mode when printing By-Object."
 msgstr "Uneko inprimagailuak ez du timelapsea onartzen Modu tradizionalean objektuz objektu inprimatzean."
+
+msgid "I have checked the installed nozzle and want to print anyway."
+msgstr ""
 
 msgid "Errors"
 msgstr "Erroreak"
@@ -16846,6 +16859,12 @@ msgstr "Euskarriaren purgatze-modu azkarra"
 msgid "Whether this printer supports fast purge mode with optimized temperature and multiplier."
 msgstr "Inprimagailu honek tenperatura eta biderkatzaile optimizatuak dituen purgatze azkarreko modua onartzen duen."
 
+msgid "Filament change"
+msgstr ""
+
+msgid "The volume of material required to prime the extruder on the tower, excluding a hotend change."
+msgstr ""
+
 msgid "The volume of material required to prime the extruder for a hotend change on the tower."
 msgstr "Hotenda aldatzean estrusorea dorrean prestatzeko behar den material-bolumena."
 
@@ -20029,14 +20048,14 @@ msgstr "Errorea: %s"
 msgid "Show details"
 msgstr "Erakutsi xehetasunak"
 
+msgid "Hide details"
+msgstr ""
+
 msgid "Version to install:"
 msgstr "Instalatu beharreko bertsioa:"
 
 msgid "Download and Install"
 msgstr "Deskargatu eta instalatu"
-
-msgid "Skip for Now"
-msgstr "Saltatu oraingoz"
 
 msgid "A new version of the Bambu Network Plug-in is available."
 msgstr "Bambu Network Plug-inaren bertsio berria erabilgarri dago."
@@ -20048,17 +20067,11 @@ msgstr "Uneko Bertsioa: %s"
 msgid "Update to version:"
 msgstr "Eguneratu bertsio honetara:"
 
-msgid "Update Now"
-msgstr "Eguneratu orain"
-
-msgid "Remind Later"
-msgstr "Gogorarazi geroago"
-
-msgid "Skip Version"
-msgstr "Saltatu bertsioa"
-
 msgid "Don't Ask Again"
 msgstr "Ez galdetu berriro"
+
+msgid "Update Now"
+msgstr "Eguneratu orain"
 
 msgid "(Latest)"
 msgstr "(Berriena)"
@@ -20074,9 +20087,6 @@ msgstr "Berrabiarazi egin behar da plugin berria kargatzeko. Orain berrabiarazi 
 
 msgid "Restart Now"
 msgstr "Berrabiarazi orain"
-
-msgid "Restart Later"
-msgstr "Berrabiarazi geroago"
 
 msgid "NO RAMMING AT ALL"
 msgstr "MUTURRAREN MOLDAKETARIK EZ INONDIK INORA"
@@ -20656,6 +20666,21 @@ msgid ""
 msgstr ""
 "Saihestu okertzea\n"
 "Ba al zenekien ABS bezalako okertzeko joera duten materialak inprimatzean ohe beroaren tenperatura egoki igotzeak okertzeko probabilitatea murriztu dezakeela?"
+
+#~ msgid "Hotend"
+#~ msgstr "Hotend-a"
+
+#~ msgid "Skip for Now"
+#~ msgstr "Saltatu oraingoz"
+
+#~ msgid "Remind Later"
+#~ msgstr "Gogorarazi geroago"
+
+#~ msgid "Skip Version"
+#~ msgstr "Saltatu bertsioa"
+
+#~ msgid "Restart Later"
+#~ msgstr "Berrabiarazi geroago"
 
 #~ msgid "Invalid spacing supplied to Flow::with_spacing(), check your layer height and extrusion width."
 #~ msgstr "Flow::with_spacing() funtzioari tarte baliogabea eman zaio; egiaztatu geruza-altuera eta estrusio-zabalera"

--- a/localization/i18n/eu/OrcaSlicer_eu.po
+++ b/localization/i18n/eu/OrcaSlicer_eu.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-22 19:11-0300\n"
+"POT-Creation-Date: 2026-07-23 14:21-0300\n"
 "PO-Revision-Date: 2026-07-20 13:33+0200\n"
 "Last-Translator: Manu Goiogana <mgoiogana@gmail.com>\n"
 "Language-Team: \n"
@@ -883,8 +883,9 @@ msgstr "Hautaketatik konektorea ezabatu"
 msgid "Select all connectors"
 msgstr "Hautatu konektore guztiak"
 
+msgctxt "Cut tool"
 msgid "Cut"
-msgstr "Ebaki"
+msgstr ""
 
 msgid "Rotate cut plane"
 msgstr "Ebaketa-planoa biratu"
@@ -1860,8 +1861,9 @@ msgstr "Neurketa tresnan sartzen"
 msgid "Leaving Measure gizmo"
 msgstr "Neurketa tresna irteten"
 
+msgctxt "Assembly tool"
 msgid "Assemble"
-msgstr "Multzokatu"
+msgstr ""
 
 msgid "Please confirm explosion ratio = 1 and select at least two volumes."
 msgstr "Mesedez, baieztatu esplosio-erlazioa = 1 dela, eta hautatu objektu bat gutxienez."
@@ -2729,6 +2731,9 @@ msgstr "Bihurtu metroetatik"
 
 msgid "Restore to Meter"
 msgstr "Leheneratu metroetara"
+
+msgid "Assemble"
+msgstr "Multzokatu"
 
 msgid "Assemble the selected objects into an object with multiple parts"
 msgstr "Multzokatu hautatutako objektuak pieza ugariko objektu bakarrean"
@@ -4219,6 +4224,14 @@ msgstr "Inprimatu kanpoko harileko filamentua erabiliz."
 msgid "Print with filament in AMS"
 msgstr "AMSko filamentuarekin inprimatu"
 
+msgctxt "Nozzle position"
+msgid "Left"
+msgstr ""
+
+msgctxt "Nozzle position"
+msgid "Right"
+msgstr ""
+
 msgid "When the current material run out, the printer will continue to print in the following order."
 msgstr "Uneko materiala agortzen denean, inprimagailuak hurrengo ordenean inprimatzen jarraituko du."
 
@@ -5505,8 +5518,9 @@ msgstr "Egokigarria"
 msgid "Quality / Speed"
 msgstr "Kalitatea / Abiadura"
 
+msgctxt "Mesh action"
 msgid "Smooth"
-msgstr "Leuna"
+msgstr ""
 
 msgid "Radius"
 msgstr "Erradioa"
@@ -6115,6 +6129,9 @@ msgstr "Desegin"
 msgid "Redo"
 msgstr "Berregin"
 
+msgid "Cut"
+msgstr "Ebaki"
+
 msgid "Cut selection to clipboard"
 msgstr "Ebaki hautaketa arbelean"
 
@@ -6213,6 +6230,10 @@ msgstr "Erakutsi hautatutako objektuaren inguruko ingerada 3D eszenan."
 
 msgid "Preferences"
 msgstr "Hobespenak"
+
+msgctxt "Menu"
+msgid "Edit"
+msgstr ""
 
 msgid "View"
 msgstr "Bista"
@@ -9169,8 +9190,9 @@ msgstr "Bateraezina"
 msgid "The selected preset is null!"
 msgstr "Hautatutako aurrezarpena hutsa da!"
 
+msgctxt "Layer range"
 msgid "End"
-msgstr "Amaiera"
+msgstr ""
 
 msgid "Customize"
 msgstr "Pertsonalizatu"
@@ -11320,6 +11342,9 @@ msgstr "Mugitu graduatzailea 5 aldiz azkarrago"
 
 msgid "Horizontal slider - Move to start position"
 msgstr "Graduatzaile horizontala - Mugitu hasierako posiziora"
+
+msgid "End"
+msgstr "Amaiera"
 
 msgid "Horizontal slider - Move to last position"
 msgstr "Graduatzaile horizontala - Mugitu azken posiziora"
@@ -15887,6 +15912,9 @@ msgstr "Modu leuna edo tradizionala hautatzen bada, timelapse bideo bat sortuko 
 
 msgid "Traditional"
 msgstr "Tradizionala"
+
+msgid "Smooth"
+msgstr "Leuna"
 
 msgid "Farthest point timelapse"
 msgstr "Puntu urruneneko timelapsea"

--- a/localization/i18n/fr/OrcaSlicer_fr.po
+++ b/localization/i18n/fr/OrcaSlicer_fr.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Orca Slicer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-20 10:39-0300\n"
+"POT-Creation-Date: 2026-07-22 19:11-0300\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: Guislain Cyril, Thomas Lété\n"
@@ -3475,8 +3475,9 @@ msgctxt "air_duct"
 msgid "Left(Aux)"
 msgstr "Gauche (Aux)"
 
+msgctxt "Hotend Heat Breaker Fan"
 msgid "Hotend"
-msgstr "Hotend"
+msgstr ""
 
 msgid "Parts"
 msgstr "Pièces"
@@ -8869,6 +8870,15 @@ msgstr "Afficher la superposition des FPS"
 msgid "Displays current viewport FPS in the top-right corner."
 msgstr "Affiche les FPS actuels de la vue dans le coin supérieur droit."
 
+msgid "G-code Preview"
+msgstr ""
+
+msgid "Dim lower layers"
+msgstr ""
+
+msgid "When scrubbing the layer slider in the sliced preview, render the layers below the current one darkened so that only the layer being viewed is shown at full brightness."
+msgstr ""
+
 msgid "Login region"
 msgstr "Région d'origine"
 
@@ -9445,6 +9455,9 @@ msgstr "Lorsque vous activez le mode vase, les machines avec une structure I3 ne
 
 msgid "The current printer does not support timelapse in Traditional Mode when printing By-Object."
 msgstr "L'imprimante actuelle ne prend pas en charge le timelapse en mode traditionnel lors de l'impression par objet."
+
+msgid "I have checked the installed nozzle and want to print anyway."
+msgstr ""
 
 msgid "Errors"
 msgstr "Erreurs"
@@ -16808,6 +16821,12 @@ msgstr ""
 msgid "Whether this printer supports fast purge mode with optimized temperature and multiplier."
 msgstr ""
 
+msgid "Filament change"
+msgstr ""
+
+msgid "The volume of material required to prime the extruder on the tower, excluding a hotend change."
+msgstr ""
+
 msgid "The volume of material required to prime the extruder for a hotend change on the tower."
 msgstr "Le volume de matériau nécessaire pour amorcer l'extrudeur lors d'un changement de hotend sur la tourelle."
 
@@ -19994,14 +20013,14 @@ msgstr "Erreur : %s"
 msgid "Show details"
 msgstr "Afficher les détails"
 
+msgid "Hide details"
+msgstr ""
+
 msgid "Version to install:"
 msgstr "Version à installer :"
 
 msgid "Download and Install"
 msgstr "Télécharger et installer"
-
-msgid "Skip for Now"
-msgstr "Ignorer pour le moment"
 
 msgid "A new version of the Bambu Network Plug-in is available."
 msgstr "Une nouvelle version du plug-in réseau Bambu est disponible."
@@ -20013,17 +20032,11 @@ msgstr "Version actuelle : %s"
 msgid "Update to version:"
 msgstr "Mettre à jour vers la version :"
 
-msgid "Update Now"
-msgstr "Mettre à jour maintenant"
-
-msgid "Remind Later"
-msgstr "Rappeler plus tard"
-
-msgid "Skip Version"
-msgstr "Ignorer la version"
-
 msgid "Don't Ask Again"
 msgstr "Ne plus demander"
+
+msgid "Update Now"
+msgstr "Mettre à jour maintenant"
 
 msgid "(Latest)"
 msgstr "(Dernière)"
@@ -20039,9 +20052,6 @@ msgstr "Un redémarrage est nécessaire pour charger le nouveau plug-in. Souhait
 
 msgid "Restart Now"
 msgstr "Redémarrer maintenant"
-
-msgid "Restart Later"
-msgstr "Redémarrer plus tard"
 
 msgid "NO RAMMING AT ALL"
 msgstr "AUCUN BOURRAGE"
@@ -20621,6 +20631,21 @@ msgid ""
 msgstr ""
 "Éviter la déformation\n"
 "Saviez-vous que lors de l’impression de matériaux susceptibles de se déformer, tels que l’ABS, une augmentation appropriée de la température du plateau chauffant peut réduire la probabilité de déformation?"
+
+#~ msgid "Hotend"
+#~ msgstr "Hotend"
+
+#~ msgid "Skip for Now"
+#~ msgstr "Ignorer pour le moment"
+
+#~ msgid "Remind Later"
+#~ msgstr "Rappeler plus tard"
+
+#~ msgid "Skip Version"
+#~ msgstr "Ignorer la version"
+
+#~ msgid "Restart Later"
+#~ msgstr "Redémarrer plus tard"
 
 #~ msgid "Select filament that installed to the left nozzle"
 #~ msgstr "Sélectionner le filament installé sur la buse gauche"

--- a/localization/i18n/fr/OrcaSlicer_fr.po
+++ b/localization/i18n/fr/OrcaSlicer_fr.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Orca Slicer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-23 14:21-0300\n"
+"POT-Creation-Date: 2026-07-23 15:24-0300\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: Guislain Cyril, Thomas Lété\n"
@@ -551,8 +551,9 @@ msgstr "Réassigner"
 msgid "Reset"
 msgstr "Réinitialiser"
 
+msgctxt "Keyboard Shortcut"
 msgid "Enter"
-msgstr "Entrée"
+msgstr ""
 
 msgid "Shortcut Key "
 msgstr "Raccourci "
@@ -1747,14 +1748,16 @@ msgstr "Sélectionner"
 msgid "Select point"
 msgstr "Sélectionner un point"
 
+msgctxt "Keyboard Shortcut"
 msgid "Delete"
-msgstr "Supprimer"
+msgstr ""
 
 msgid "Restart selection"
 msgstr "Recommencer la sélection"
 
+msgctxt "Keyboard Shortcut"
 msgid "Esc"
-msgstr "Échap"
+msgstr ""
 
 msgid "Cancel a feature until exit"
 msgstr "Annuler une fonction jusqu’à ce qu’on la quitte"
@@ -2414,6 +2417,9 @@ msgstr "Impossible de lancer le téléchargement de l’URL. Le dossier de desti
 msgid "Import File"
 msgstr "Importer un Fichier"
 
+msgid "Delete"
+msgstr "Supprimer"
+
 msgid "Choose files"
 msgstr "Choisir des fichiers"
 
@@ -2532,14 +2538,16 @@ msgstr "Masquer"
 msgid "Show"
 msgstr "Afficher"
 
+msgctxt "Keyboard Shortcut"
 msgid "Del"
-msgstr "Eff"
+msgstr ""
 
 msgid "Delete the selected object"
 msgstr "Supprimer l'objet sélectionné"
 
+msgctxt "Keyboard Shortcut"
 msgid "Backspace"
-msgstr "Retour arrière"
+msgstr ""
 
 msgid "Load..."
 msgstr "Charger…"
@@ -11181,26 +11189,30 @@ msgstr "Sélectionner plusieurs objets"
 msgid "Select objects by rectangle"
 msgstr "Sélectionner les objets par rectangle"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Up"
-msgstr "Flèche Haut"
+msgstr ""
 
 msgid "Move selection 10mm in positive Y direction"
 msgstr "Déplacer la sélection de 10 mm dans la direction positive Y"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Down"
-msgstr "Flèche Bas"
+msgstr ""
 
 msgid "Move selection 10mm in negative Y direction"
 msgstr "Déplacer la sélection de 10 mm dans la direction négative Y"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Left"
-msgstr "Flèche Gauche"
+msgstr ""
 
 msgid "Move selection 10mm in negative X direction"
 msgstr "Déplacer la sélection de 10 mm dans la direction négative X"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Right"
-msgstr "Flèche Droite"
+msgstr ""
 
 msgid "Move selection 10mm in positive X direction"
 msgstr "Déplacer la sélection de 10 mm dans la direction positive X"
@@ -11283,8 +11295,16 @@ msgstr "Zoom arrière"
 msgid "Toggle printable for object/part"
 msgstr "Basculer l’état imprimable de l’objet/de la pièce"
 
+msgctxt "Keyboard Shortcut"
+msgid "Tab"
+msgstr ""
+
 msgid "Switch between Prepare/Preview"
 msgstr "Basculer entre Préparer/Aperçu"
+
+msgctxt "Keyboard Shortcut"
+msgid "Space"
+msgstr ""
 
 msgid "Open actions speed dial"
 msgstr ""
@@ -11343,11 +11363,16 @@ msgstr "On/Off Fenêtre G-code"
 msgid "Move slider 5x faster"
 msgstr "Déplacez le curseur 5 fois plus vite"
 
+msgctxt "Keyboard Shortcut"
+msgid "Home"
+msgstr ""
+
 msgid "Horizontal slider - Move to start position"
 msgstr "Curseur horizontal - Déplacement vers la position de départ"
 
+msgctxt "Keyboard Shortcut"
 msgid "End"
-msgstr "Fin"
+msgstr ""
 
 msgid "Horizontal slider - Move to last position"
 msgstr "Curseur horizontal - Déplacer vers la dernière position"
@@ -20659,6 +20684,33 @@ msgid ""
 msgstr ""
 "Éviter la déformation\n"
 "Saviez-vous que lors de l’impression de matériaux susceptibles de se déformer, tels que l’ABS, une augmentation appropriée de la température du plateau chauffant peut réduire la probabilité de déformation?"
+
+#~ msgid "Enter"
+#~ msgstr "Entrée"
+
+#~ msgid "Esc"
+#~ msgstr "Échap"
+
+#~ msgid "Del"
+#~ msgstr "Eff"
+
+#~ msgid "Backspace"
+#~ msgstr "Retour arrière"
+
+#~ msgid "Arrow Up"
+#~ msgstr "Flèche Haut"
+
+#~ msgid "Arrow Down"
+#~ msgstr "Flèche Bas"
+
+#~ msgid "Arrow Left"
+#~ msgstr "Flèche Gauche"
+
+#~ msgid "Arrow Right"
+#~ msgstr "Flèche Droite"
+
+#~ msgid "End"
+#~ msgstr "Fin"
 
 #~ msgid "Hotend"
 #~ msgstr "Hotend"

--- a/localization/i18n/fr/OrcaSlicer_fr.po
+++ b/localization/i18n/fr/OrcaSlicer_fr.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Orca Slicer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-22 19:11-0300\n"
+"POT-Creation-Date: 2026-07-23 14:21-0300\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: Guislain Cyril, Thomas Lété\n"
@@ -881,8 +881,9 @@ msgstr "Retirer le connecteur de la sélection"
 msgid "Select all connectors"
 msgstr "Sélectionner tous les connecteurs"
 
+msgctxt "Cut tool"
 msgid "Cut"
-msgstr "Couper"
+msgstr ""
 
 msgid "Rotate cut plane"
 msgstr "Rotation du plan de coupe"
@@ -1858,8 +1859,9 @@ msgstr "Entrée dans l’outil Mesurer"
 msgid "Leaving Measure gizmo"
 msgstr "Quitter l’outil Mesurer"
 
+msgctxt "Assembly tool"
 msgid "Assemble"
-msgstr "Assembler"
+msgstr ""
 
 msgid "Please confirm explosion ratio = 1 and select at least two volumes."
 msgstr "Veuillez confirmer que le ratio d'explosion = 1 et sélectionner au moins deux volumes."
@@ -2725,6 +2727,9 @@ msgstr "Convertir en mètre"
 
 msgid "Restore to Meter"
 msgstr "Restaurer en mètres"
+
+msgid "Assemble"
+msgstr "Assembler"
 
 msgid "Assemble the selected objects into an object with multiple parts"
 msgstr "Assembler les objets sélectionnés à un objet en plusieurs parties"
@@ -4216,6 +4221,14 @@ msgstr "Imprimez en utilisant le filament de la bobine externe"
 msgid "Print with filament in AMS"
 msgstr "Imprimer avec du filament de l'AMS"
 
+msgctxt "Nozzle position"
+msgid "Left"
+msgstr ""
+
+msgctxt "Nozzle position"
+msgid "Right"
+msgstr ""
+
 msgid "When the current material run out, the printer will continue to print in the following order."
 msgstr "Lorsque le filament actuel est épuisé, l’imprimante continue d’imprimer dans l’ordre suivant."
 
@@ -5503,8 +5516,9 @@ msgstr "Adaptatif"
 msgid "Quality / Speed"
 msgstr "Qualité / Vitesse"
 
+msgctxt "Mesh action"
 msgid "Smooth"
-msgstr "Lisse"
+msgstr ""
 
 msgid "Radius"
 msgstr "Rayon"
@@ -6117,6 +6131,9 @@ msgstr "Annuler"
 msgid "Redo"
 msgstr "Recommencer"
 
+msgid "Cut"
+msgstr "Couper"
+
 msgid "Cut selection to clipboard"
 msgstr "Couper la sélection dans le presse-papiers"
 
@@ -6215,6 +6232,10 @@ msgstr "Afficher le tracé contour de l’objet sélectionné dans la scène 3D.
 
 msgid "Preferences"
 msgstr "Préférences"
+
+msgctxt "Menu"
+msgid "Edit"
+msgstr ""
 
 msgid "View"
 msgstr "Affichage"
@@ -9167,8 +9188,9 @@ msgstr "Incompatible"
 msgid "The selected preset is null!"
 msgstr "Le préréglage sélectionné est invalide !"
 
+msgctxt "Layer range"
 msgid "End"
-msgstr "Fin"
+msgstr ""
 
 msgid "Customize"
 msgstr "Personnaliser"
@@ -11323,6 +11345,9 @@ msgstr "Déplacez le curseur 5 fois plus vite"
 
 msgid "Horizontal slider - Move to start position"
 msgstr "Curseur horizontal - Déplacement vers la position de départ"
+
+msgid "End"
+msgstr "Fin"
 
 msgid "Horizontal slider - Move to last position"
 msgstr "Curseur horizontal - Déplacer vers la dernière position"
@@ -15860,6 +15885,9 @@ msgstr "Si le mode fluide ou traditionnel est sélectionné, une vidéo en timel
 
 msgid "Traditional"
 msgstr "Traditionnel"
+
+msgid "Smooth"
+msgstr "Lisse"
 
 msgid "Farthest point timelapse"
 msgstr ""

--- a/localization/i18n/hu/OrcaSlicer_hu.po
+++ b/localization/i18n/hu/OrcaSlicer_hu.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Orca Slicer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-22 19:11-0300\n"
+"POT-Creation-Date: 2026-07-23 14:21-0300\n"
 "Language: hu\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -888,8 +888,9 @@ msgstr "Csatlakozó eltávolítása a kijelölésből"
 msgid "Select all connectors"
 msgstr "Összes csatlakozó kijelölése"
 
+msgctxt "Cut tool"
 msgid "Cut"
-msgstr "Vágás"
+msgstr ""
 
 msgid "Rotate cut plane"
 msgstr "Vágósík forgatása"
@@ -1868,8 +1869,9 @@ msgstr ""
 msgid "Leaving Measure gizmo"
 msgstr ""
 
+msgctxt "Assembly tool"
 msgid "Assemble"
-msgstr "Összeállítás"
+msgstr ""
 
 msgid "Please confirm explosion ratio = 1 and select at least two volumes."
 msgstr "Erősítsd meg, hogy a terjedési arány = 1, és válassz ki legalább két térfogatot."
@@ -2742,6 +2744,9 @@ msgstr "Átváltás méterről"
 # TODO: Review, changed by lang refactor. PR 14254
 msgid "Restore to Meter"
 msgstr "Visszaállítás méterre"
+
+msgid "Assemble"
+msgstr "Összeállítás"
 
 msgid "Assemble the selected objects into an object with multiple parts"
 msgstr "Összeállítja a kijelölt objektumot egy több részből álló objektummá"
@@ -4281,6 +4286,14 @@ msgstr "Nyomtatás külső tartón lévő filamenttel."
 msgid "Print with filament in AMS"
 msgstr "Nyomtatás az AMS-ben lévő filamentekkel"
 
+msgctxt "Nozzle position"
+msgid "Left"
+msgstr ""
+
+msgctxt "Nozzle position"
+msgid "Right"
+msgstr ""
+
 msgid "When the current material run out, the printer will continue to print in the following order."
 msgstr "Amikor az aktuális filament elfogy, a nyomtató a következő sorrendben folytatja a nyomtatást."
 
@@ -5597,8 +5610,9 @@ msgstr "Adaptív"
 msgid "Quality / Speed"
 msgstr "Minőség / sebesség"
 
+msgctxt "Mesh action"
 msgid "Smooth"
-msgstr "Sima"
+msgstr ""
 
 msgid "Radius"
 msgstr "Sugár"
@@ -6219,6 +6233,9 @@ msgstr "Visszavonás"
 msgid "Redo"
 msgstr "Mégis"
 
+msgid "Cut"
+msgstr "Vágás"
+
 msgid "Cut selection to clipboard"
 msgstr "Kijelölés kivágása a vágólapra"
 
@@ -6319,6 +6336,10 @@ msgstr "Körvonal megjelenítése a kijelölt objektum körül a 3D nézetben."
 
 msgid "Preferences"
 msgstr "Beállítások"
+
+msgctxt "Menu"
+msgid "Edit"
+msgstr ""
 
 msgid "View"
 msgstr "Nézet"
@@ -9314,8 +9335,9 @@ msgstr "Nem kompatibilis"
 msgid "The selected preset is null!"
 msgstr "A kiválasztott beállítás nulla!"
 
+msgctxt "Layer range"
 msgid "End"
-msgstr "Vége"
+msgstr ""
 
 msgid "Customize"
 msgstr "Testreszabás"
@@ -11500,6 +11522,9 @@ msgstr "Csúszka 5x gyorsabb mozgatása"
 
 msgid "Horizontal slider - Move to start position"
 msgstr "Vízszintes csúszka - Ugrás a kezdőpozícióra"
+
+msgid "End"
+msgstr "Vége"
 
 msgid "Horizontal slider - Move to last position"
 msgstr "Vízszintes csúszka - Ugrás az utolsó pozícióra"
@@ -16096,6 +16121,9 @@ msgstr "Ha a sima vagy a hagyományos mód van kiválasztva, minden nyomtatásn�
 
 msgid "Traditional"
 msgstr "Hagyományos"
+
+msgid "Smooth"
+msgstr "Sima"
 
 msgid "Farthest point timelapse"
 msgstr ""

--- a/localization/i18n/hu/OrcaSlicer_hu.po
+++ b/localization/i18n/hu/OrcaSlicer_hu.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Orca Slicer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-23 14:21-0300\n"
+"POT-Creation-Date: 2026-07-23 15:24-0300\n"
 "Language: hu\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -551,6 +551,7 @@ msgstr "Újrakiosztás"
 msgid "Reset"
 msgstr "Visszaállítás"
 
+msgctxt "Keyboard Shortcut"
 msgid "Enter"
 msgstr ""
 
@@ -1757,12 +1758,14 @@ msgstr "Kiválasztás"
 msgid "Select point"
 msgstr "Pont kiválasztása"
 
+msgctxt "Keyboard Shortcut"
 msgid "Delete"
-msgstr "Törlés"
+msgstr ""
 
 msgid "Restart selection"
 msgstr "Kijelölés újrakezdése"
 
+msgctxt "Keyboard Shortcut"
 msgid "Esc"
 msgstr ""
 
@@ -2409,6 +2412,9 @@ msgstr "Az URL letöltése nem indítható. A célmappa nincs beállítva. Vála
 msgid "Import File"
 msgstr "Fájl importálása"
 
+msgid "Delete"
+msgstr "Törlés"
+
 msgid "Choose files"
 msgstr "Fájlok kiválasztása"
 
@@ -2539,14 +2545,16 @@ msgstr "Elrejtés"
 msgid "Show"
 msgstr "Megjelenítés"
 
+msgctxt "Keyboard Shortcut"
 msgid "Del"
 msgstr ""
 
 msgid "Delete the selected object"
 msgstr "Kiválasztott objektum törlése"
 
+msgctxt "Keyboard Shortcut"
 msgid "Backspace"
-msgstr "Visszatörlés"
+msgstr ""
 
 msgid "Load..."
 msgstr "Betöltés..."
@@ -11351,29 +11359,33 @@ msgstr "Több objektum kijelölése"
 msgid "Select objects by rectangle"
 msgstr "Objektumok kijelölése téglalapok alapján"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Up"
-msgstr "Felfelé nyíl"
+msgstr ""
 
 # TODO: Review, changed by lang refactor. PR 14254
 msgid "Move selection 10mm in positive Y direction"
 msgstr "Kijelölés mozgatása 10 mm-rel pozitív Y irányban"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Down"
-msgstr "Lefelé nyíl"
+msgstr ""
 
 # TODO: Review, changed by lang refactor. PR 14254
 msgid "Move selection 10mm in negative Y direction"
 msgstr "Kijelölés mozgatása 10 mm-rel negatív Y irányban"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Left"
-msgstr "Balra nyíl"
+msgstr ""
 
 # TODO: Review, changed by lang refactor. PR 14254
 msgid "Move selection 10mm in negative X direction"
 msgstr "Kijelölés mozgatása 10 mm-rel negatív X irányban"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Right"
-msgstr "Jobbra nyíl"
+msgstr ""
 
 # TODO: Review, changed by lang refactor. PR 14254
 msgid "Move selection 10mm in positive X direction"
@@ -11459,8 +11471,16 @@ msgstr "Zoom távolítás"
 msgid "Toggle printable for object/part"
 msgstr "Nyomtathatóság váltása objektumhoz/alkatrészhez"
 
+msgctxt "Keyboard Shortcut"
+msgid "Tab"
+msgstr ""
+
 msgid "Switch between Prepare/Preview"
 msgstr "Váltás előkészítés/előnézet között"
+
+msgctxt "Keyboard Shortcut"
+msgid "Space"
+msgstr ""
 
 msgid "Open actions speed dial"
 msgstr ""
@@ -11520,11 +11540,16 @@ msgstr "G-kód ablak be/ki"
 msgid "Move slider 5x faster"
 msgstr "Csúszka 5x gyorsabb mozgatása"
 
+msgctxt "Keyboard Shortcut"
+msgid "Home"
+msgstr ""
+
 msgid "Horizontal slider - Move to start position"
 msgstr "Vízszintes csúszka - Ugrás a kezdőpozícióra"
 
+msgctxt "Keyboard Shortcut"
 msgid "End"
-msgstr "Vége"
+msgstr ""
 
 msgid "Horizontal slider - Move to last position"
 msgstr "Vízszintes csúszka - Ugrás az utolsó pozícióra"
@@ -20951,6 +20976,24 @@ msgid ""
 msgstr ""
 "Kunkorodás elkerülése\n"
 "Tudtad, hogy a kunkorodásra hajlamos anyagok (például ABS) nyomtatásakor a tárgyasztal hőmérsékletének növelése csökkentheti a kunkorodás valószínűségét?"
+
+#~ msgid "Backspace"
+#~ msgstr "Visszatörlés"
+
+#~ msgid "Arrow Up"
+#~ msgstr "Felfelé nyíl"
+
+#~ msgid "Arrow Down"
+#~ msgstr "Lefelé nyíl"
+
+#~ msgid "Arrow Left"
+#~ msgstr "Balra nyíl"
+
+#~ msgid "Arrow Right"
+#~ msgstr "Jobbra nyíl"
+
+#~ msgid "End"
+#~ msgstr "Vége"
 
 #~ msgid "Hotend"
 #~ msgstr "Fejegység"

--- a/localization/i18n/hu/OrcaSlicer_hu.po
+++ b/localization/i18n/hu/OrcaSlicer_hu.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Orca Slicer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-20 10:39-0300\n"
+"POT-Creation-Date: 2026-07-22 19:11-0300\n"
 "Language: hu\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -3520,8 +3520,9 @@ msgctxt "air_duct"
 msgid "Left(Aux)"
 msgstr "Bal(Aux)"
 
+msgctxt "Hotend Heat Breaker Fan"
 msgid "Hotend"
-msgstr "Fejegység"
+msgstr ""
 
 msgid "Parts"
 msgstr "Alkatrészek"
@@ -9007,6 +9008,15 @@ msgstr "FPS fedvény megjelenítése"
 msgid "Displays current viewport FPS in the top-right corner."
 msgstr "Megjeleníti az aktuális nézetablak FPS-t a jobb felső sarokban."
 
+msgid "G-code Preview"
+msgstr ""
+
+msgid "Dim lower layers"
+msgstr ""
+
+msgid "When scrubbing the layer slider in the sliced preview, render the layers below the current one darkened so that only the layer being viewed is shown at full brightness."
+msgstr ""
+
 msgid "Login region"
 msgstr "Régió"
 
@@ -9595,6 +9605,9 @@ msgstr ""
 
 msgid "The current printer does not support timelapse in Traditional Mode when printing By-Object."
 msgstr "Az aktuális nyomtató nem támogatja az időfelvételt hagyományos módban, ha a nyomtatás objektumonként történik."
+
+msgid "I have checked the installed nozzle and want to print anyway."
+msgstr ""
 
 msgid "Errors"
 msgstr "Hibák"
@@ -17073,6 +17086,12 @@ msgstr ""
 msgid "Whether this printer supports fast purge mode with optimized temperature and multiplier."
 msgstr ""
 
+msgid "Filament change"
+msgstr ""
+
+msgid "The volume of material required to prime the extruder on the tower, excluding a hotend change."
+msgstr ""
+
 msgid "The volume of material required to prime the extruder for a hotend change on the tower."
 msgstr "Az extruder átöblítéséhez szükséges anyagmennyiség a hotend cseréjekor."
 
@@ -20279,14 +20298,14 @@ msgstr "Hiba: %s"
 msgid "Show details"
 msgstr "Részletek megjelenítése"
 
+msgid "Hide details"
+msgstr ""
+
 msgid "Version to install:"
 msgstr "Telepítendő verzió:"
 
 msgid "Download and Install"
 msgstr "Letöltés és telepítés"
-
-msgid "Skip for Now"
-msgstr "Kihagyás most"
 
 msgid "A new version of the Bambu Network Plug-in is available."
 msgstr "Létezik új verzió a Bambu hálózati bővítményre."
@@ -20298,17 +20317,11 @@ msgstr "Jelenlegi verzió: %s"
 msgid "Update to version:"
 msgstr "Frissítés erre a verzióra:"
 
-msgid "Update Now"
-msgstr "Frissítés most"
-
-msgid "Remind Later"
-msgstr "Emlékeztessen később"
-
-msgid "Skip Version"
-msgstr "Verzió kihagyása"
-
 msgid "Don't Ask Again"
 msgstr "Ne kérdezz újra"
+
+msgid "Update Now"
+msgstr "Frissítés most"
 
 msgid "(Latest)"
 msgstr "(Legfrissebb)"
@@ -20324,9 +20337,6 @@ msgstr "Az új plug-in betöltéséhez újraindítás szükséges. Szeretnéd mo
 
 msgid "Restart Now"
 msgstr "Újraindítás most"
-
-msgid "Restart Later"
-msgstr "Újraindítás később"
 
 msgid "NO RAMMING AT ALL"
 msgstr "EGYÁLTALÁN NINCS TÖMÖRÍTÉS"
@@ -20913,6 +20923,21 @@ msgid ""
 msgstr ""
 "Kunkorodás elkerülése\n"
 "Tudtad, hogy a kunkorodásra hajlamos anyagok (például ABS) nyomtatásakor a tárgyasztal hőmérsékletének növelése csökkentheti a kunkorodás valószínűségét?"
+
+#~ msgid "Hotend"
+#~ msgstr "Fejegység"
+
+#~ msgid "Skip for Now"
+#~ msgstr "Kihagyás most"
+
+#~ msgid "Remind Later"
+#~ msgstr "Emlékeztessen később"
+
+#~ msgid "Skip Version"
+#~ msgstr "Verzió kihagyása"
+
+#~ msgid "Restart Later"
+#~ msgstr "Újraindítás később"
 
 #~ msgid "Select filament that installed to the left nozzle"
 #~ msgstr "Válaszd ki a bal fúvókába betöltött filamentet"

--- a/localization/i18n/it/OrcaSlicer_it.po
+++ b/localization/i18n/it/OrcaSlicer_it.po
@@ -15814,16 +15814,16 @@ msgstr ""
 "Questa quantità può essere specificata in millimetri o come percentuale del diametro corrente dell'estrusore. Il valore predefinito per questo parametro è 10%."
 
 msgid "Scarf joint seam (beta)"
-msgstr "Cucitura a sciarpa (beta)"
+msgstr "Cucitura obliqua (beta)"
 
 msgid "Use scarf joint to minimize seam visibility and increase seam strength."
-msgstr "Utilizza il giunto a sciarpa per ridurre al minimo la visibilità della cucitura e aumentarne la resistenza."
+msgstr "Utilizza il giunto obliquo per ridurre al minimo la visibilità della cucitura e aumentarne la resistenza."
 
 msgid "Conditional scarf joint"
-msgstr "Cucitura a sciarpa condizionale"
+msgstr "Cucitura obliqua condizionale"
 
 msgid "Apply scarf joints only to smooth perimeters where traditional seams do not conceal the seams at sharp corners effectively."
-msgstr "Applica le cuciture a sciarpa solo sui perimetri lisci e curvi, dove le cuciture tradizionali risulterebbero molto evidenti. Gli angoli netti continueranno a utilizzare le cuciture normali per mantenere la precisione dimensionale."
+msgstr "Applica le cuciture oblique solo sui perimetri lisci e curvi, dove le cuciture tradizionali risulterebbero molto evidenti. Gli angoli netti continueranno a utilizzare le cuciture normali per mantenere la precisione dimensionale."
 
 msgid "Conditional angle threshold"
 msgstr "Soglia angolo condizionale"
@@ -15832,61 +15832,61 @@ msgid ""
 "This option sets the threshold angle for applying a conditional scarf joint seam.\n"
 "If the maximum angle within the perimeter loop exceeds this value (indicating the absence of sharp corners), a scarf joint seam will be used. The default value is 155°."
 msgstr ""
-"Questa opzione imposta la soglia dell'angolo per l'applicazione di una cucitura a sciarpa condizionale.\n"
-"Se l'angolo massimo all'interno dell'anello perimetrale supera questo valore (che indica l'assenza di spigoli vivi), si utilizzerà una cucitura a sciarpa. Il valore predefinito è 155°."
+"Questa opzione imposta la soglia dell'angolo per l'applicazione di una cucitura obliqua condizionale.\n"
+"Se l'angolo massimo all'interno dell'anello perimetrale supera questo valore (che indica l'assenza di spigoli vivi), si utilizzerà una cucitura obliqua. Il valore predefinito è 155°."
 
 msgid "Conditional overhang threshold"
 msgstr "Soglia di sporgenza condizionale"
 
 #, no-c-format, no-boost-format
 msgid "This option determines the overhang threshold for the application of scarf joint seams. If the unsupported portion of the perimeter is less than this threshold, scarf joint seams will be applied. The default threshold is set at 40% of the external wall's width. Due to performance considerations, the degree of overhang is estimated."
-msgstr "Questa opzione determina la soglia di sporgenza per l'applicazione di cuciture a sciarpa. Se la porzione non supportata del perimetro è inferiore a questa soglia, verranno applicate cuciture a sciarpa. La soglia predefinita è impostata al 40% della larghezza della parete esterna. Per motivi di prestazioni, il grado di sporgenza viene stimato."
+msgstr "Questa opzione determina la soglia di sporgenza per l'applicazione di cuciture oblique. Se la porzione non supportata del perimetro è inferiore a questa soglia, verranno applicate cuciture oblique. La soglia predefinita è impostata al 40% della larghezza della parete esterna. Per motivi di prestazioni, il grado di sporgenza viene stimato."
 
 msgid "Scarf joint speed"
-msgstr "Velocità cucitura a sciarpa"
+msgstr "Velocità cucitura obliqua"
 
 msgid "This option sets the printing speed for scarf joints. It is recommended to print scarf joints at a slow speed (less than 100 mm/s). It's also advisable to enable 'Extrusion rate smoothing' if the set speed varies significantly from the speed of the outer or inner walls. If the speed specified here is higher than the speed of the outer or inner walls, the printer will default to the slower of the two speeds. When specified as a percentage (e.g., 80%), the speed is calculated based on the respective outer or inner wall speed. The default value is set to 100%."
-msgstr "Questa opzione imposta la velocità di stampa per le cuciture a sciarpa. È consigliabile stampare le cuciture a a sciarpa a una velocità bassa (inferiore a 100 mm/s). È anche opportuno attivare l'opzione 'Livellamento velocità di estrusione' se la velocità impostata varia in modo significativo rispetto alla velocità delle pareti esterne o interne. Se la velocità specificata qui è superiore alla velocità delle pareti esterne o interne, la stampante utilizzerà per impostazione predefinita la velocità più lenta delle due. Se specificata come percentuale (ad esempio 80%), la velocità viene calcolata in base alla velocità della parete esterna o interna. Il valore predefinito è impostato su 100%."
+msgstr "Questa opzione imposta la velocità di stampa per le cuciture oblique. È consigliabile stampare le cuciture oblique a una velocità bassa (inferiore a 100 mm/s). È anche opportuno attivare l'opzione 'Livellamento velocità di estrusione' se la velocità impostata varia in modo significativo rispetto alla velocità delle pareti esterne o interne. Se la velocità specificata qui è superiore alla velocità delle pareti esterne o interne, la stampante utilizzerà per impostazione predefinita la velocità più lenta delle due. Se specificata come percentuale (ad esempio 80%), la velocità viene calcolata in base alla velocità della parete esterna o interna. Il valore predefinito è impostato su 100%."
 
 msgid "Scarf joint flow ratio"
-msgstr "Flusso di stampa cucitura a sciarpa"
+msgstr "Flusso di stampa cucitura obliqua"
 
 msgid "This factor affects the amount of material for scarf joints."
-msgstr "Questo fattore influisce sulla quantità di materiale utilizzata per le cucitura a sciarpa."
+msgstr "Questo fattore influisce sulla quantità di materiale utilizzata per le cucitura obliqua."
 
 msgid "Scarf start height"
-msgstr "Altezza iniziale cucitura a sciarpa"
+msgstr "Altezza iniziale cucitura obliqua"
 
 msgid ""
 "Start height of the scarf.\n"
 "This amount can be specified in millimeters or as a percentage of the current layer height. The default value for this parameter is 0."
 msgstr ""
-"Altezza iniziale della cucitura a sciarpa.\n"
+"Altezza iniziale della cucitura obliqua.\n"
 "Questo valore può essere specificato in millimetri o come percentuale dell'altezza dello strato corrente. Il valore predefinito per questo parametro è 0."
 
 msgid "Scarf around entire wall"
-msgstr "Cucitura a sciarpa su intera parete"
+msgstr "Cucitura obliqua su intera parete"
 
 msgid "The scarf extends to the entire length of the wall."
-msgstr "La cucitura a sciarpa si estende lungo tutto il perimetro della parete."
+msgstr "La cucitura obliqua si estende lungo tutto il perimetro della parete."
 
 msgid "Scarf length"
-msgstr "Lunghezza cucitura a sciarpa"
+msgstr "Lunghezza cucitura obliqua"
 
 msgid "Length of the scarf. Setting this parameter to zero effectively disables the scarf."
-msgstr "Lunghezza della cucitura a sciarpa. Impostando questo parametro su zero, la cucitura a sciarpa viene disabilitata."
+msgstr "Lunghezza della cucitura obliqua. Impostando questo parametro su zero, la cucitura obliqua viene disabilitata."
 
 msgid "Scarf steps"
-msgstr "Incrementi cucitura a sciarpa"
+msgstr "Incrementi cucitura obliqua"
 
 msgid "Minimum number of segments of each scarf."
-msgstr "Numero minimo di segmenti utilizzati per la creazione della sfumatura della cucitura a sciarpa."
+msgstr "Numero minimo di segmenti utilizzati per la creazione della sfumatura della cucitura obliqua."
 
 msgid "Scarf joint for inner walls"
-msgstr "Cucitura a sciarpa per pareti interne"
+msgstr "Cucitura obliqua per pareti interne"
 
 msgid "Use scarf joint for inner walls as well."
-msgstr "Utilizza la cucitura a sciarpa anche per le pareti interne."
+msgstr "Utilizza la cucitura obliqua anche per le pareti interne."
 
 msgid "Role base wipe speed"
 msgstr "Velocità di spurgo basata su ruolo"

--- a/localization/i18n/it/OrcaSlicer_it.po
+++ b/localization/i18n/it/OrcaSlicer_it.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Orca Slicer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-22 19:11-0300\n"
+"POT-Creation-Date: 2026-07-23 14:21-0300\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -891,8 +891,9 @@ msgstr "Rimuovi connettore dalla selezione"
 msgid "Select all connectors"
 msgstr "Seleziona tutti i connettori"
 
+msgctxt "Cut tool"
 msgid "Cut"
-msgstr "Taglia"
+msgstr ""
 
 msgid "Rotate cut plane"
 msgstr "Ruota il piano di taglio"
@@ -1871,8 +1872,9 @@ msgstr ""
 msgid "Leaving Measure gizmo"
 msgstr ""
 
+msgctxt "Assembly tool"
 msgid "Assemble"
-msgstr "Assembla"
+msgstr ""
 
 msgid "Please confirm explosion ratio = 1 and select at least two volumes."
 msgstr "Confermare il rapporto di esplosione = 1 e selezionare almeno due volumi."
@@ -2744,6 +2746,9 @@ msgstr "Converti da metri"
 # TODO: Review, changed by lang refactor. PR 14254
 msgid "Restore to Meter"
 msgstr "Ripristina in metri"
+
+msgid "Assemble"
+msgstr "Assembla"
 
 msgid "Assemble the selected objects into an object with multiple parts"
 msgstr "Assembla gli oggetti selezionati in un oggetto composto da più parti"
@@ -4282,6 +4287,14 @@ msgstr "Stampa filamento con bobina esterna"
 msgid "Print with filament in AMS"
 msgstr "Stampa con filamento nell'AMS"
 
+msgctxt "Nozzle position"
+msgid "Left"
+msgstr ""
+
+msgctxt "Nozzle position"
+msgid "Right"
+msgstr ""
+
 msgid "When the current material run out, the printer will continue to print in the following order."
 msgstr "Quando si esaurisce il materiale corrente, la stampante continuerà a stampare nel seguente ordine."
 
@@ -5598,8 +5611,9 @@ msgstr "Adattiva"
 msgid "Quality / Speed"
 msgstr "Qualità / Velocità"
 
+msgctxt "Mesh action"
 msgid "Smooth"
-msgstr "Leviga"
+msgstr ""
 
 msgid "Radius"
 msgstr "Raggio"
@@ -6220,6 +6234,9 @@ msgstr "Annulla"
 msgid "Redo"
 msgstr "Ripeti"
 
+msgid "Cut"
+msgstr "Taglia"
+
 msgid "Cut selection to clipboard"
 msgstr "Taglia la selezione negli appunti"
 
@@ -6320,6 +6337,10 @@ msgstr "Mostra il contorno attorno all'oggetto selezionato nella scena 3D."
 
 msgid "Preferences"
 msgstr "Preferenze"
+
+msgctxt "Menu"
+msgid "Edit"
+msgstr ""
 
 msgid "View"
 msgstr "Vista"
@@ -9304,8 +9325,9 @@ msgstr "Non compatibile"
 msgid "The selected preset is null!"
 msgstr "Il profilo selezionato è nullo!"
 
+msgctxt "Layer range"
 msgid "End"
-msgstr "Fine"
+msgstr ""
 
 msgid "Customize"
 msgstr "Personalizza"
@@ -11482,6 +11504,9 @@ msgstr "Sposta il cursore 5 volte più velocemente"
 
 msgid "Horizontal slider - Move to start position"
 msgstr "Cursore di scorrimento orizzontale - Sposta alla posizione iniziale"
+
+msgid "End"
+msgstr "Fine"
 
 msgid "Horizontal slider - Move to last position"
 msgstr "Cursore di scorrimento orizzontale - Sposta alla posizione finale"
@@ -16066,6 +16091,9 @@ msgstr "Se si seleziona la modalità fluida o tradizionale, per ogni stampa verr
 
 msgid "Traditional"
 msgstr "Tradizionale"
+
+msgid "Smooth"
+msgstr "Leviga"
 
 msgid "Farthest point timelapse"
 msgstr ""

--- a/localization/i18n/it/OrcaSlicer_it.po
+++ b/localization/i18n/it/OrcaSlicer_it.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Orca Slicer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-23 14:21-0300\n"
+"POT-Creation-Date: 2026-07-23 15:24-0300\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -554,8 +554,9 @@ msgstr "Rimappa"
 msgid "Reset"
 msgstr "Reimposta"
 
+msgctxt "Keyboard Shortcut"
 msgid "Enter"
-msgstr "Invio"
+msgstr ""
 
 msgid "Shortcut Key "
 msgstr "Tasto di scelta rapida "
@@ -1760,12 +1761,14 @@ msgstr "Seleziona"
 msgid "Select point"
 msgstr "Seleziona punto"
 
+msgctxt "Keyboard Shortcut"
 msgid "Delete"
-msgstr "Elimina"
+msgstr ""
 
 msgid "Restart selection"
 msgstr "Riavvio della selezione"
 
+msgctxt "Keyboard Shortcut"
 msgid "Esc"
 msgstr ""
 
@@ -2411,6 +2414,9 @@ msgstr "Impossibile avviare il download dell'URL. La cartella di destinazione no
 msgid "Import File"
 msgstr "Importa File"
 
+msgid "Delete"
+msgstr "Elimina"
+
 msgid "Choose files"
 msgstr "Scegli file"
 
@@ -2541,12 +2547,14 @@ msgstr "Nascondi"
 msgid "Show"
 msgstr "Mostra"
 
+msgctxt "Keyboard Shortcut"
 msgid "Del"
-msgstr "Elimina"
+msgstr ""
 
 msgid "Delete the selected object"
 msgstr "Elimina l'oggetto selezionato"
 
+msgctxt "Keyboard Shortcut"
 msgid "Backspace"
 msgstr ""
 
@@ -11333,29 +11341,33 @@ msgstr "Seleziona più oggetti"
 msgid "Select objects by rectangle"
 msgstr "Seleziona oggetti per rettangolo"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Up"
-msgstr "Freccia Su"
+msgstr ""
 
 # TODO: Review, changed by lang refactor. PR 14254
 msgid "Move selection 10mm in positive Y direction"
 msgstr "Sposta selezione di 10 mm in direzione Y positiva"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Down"
-msgstr "Freccia Giù"
+msgstr ""
 
 # TODO: Review, changed by lang refactor. PR 14254
 msgid "Move selection 10mm in negative Y direction"
 msgstr "Sposta selezione di 10 mm in direzione Y negativa"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Left"
-msgstr "Freccia Sinistra"
+msgstr ""
 
 # TODO: Review, changed by lang refactor. PR 14254
 msgid "Move selection 10mm in negative X direction"
 msgstr "Sposta selezione di 10 mm in direzione X negativa"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Right"
-msgstr "Freccia Destra"
+msgstr ""
 
 # TODO: Review, changed by lang refactor. PR 14254
 msgid "Move selection 10mm in positive X direction"
@@ -11441,8 +11453,16 @@ msgstr "Rimpicciolisci"
 msgid "Toggle printable for object/part"
 msgstr "Attiva/disattiva stampa per oggetto/parte"
 
+msgctxt "Keyboard Shortcut"
+msgid "Tab"
+msgstr ""
+
 msgid "Switch between Prepare/Preview"
 msgstr "Passa tra Prepara e Anteprima"
+
+msgctxt "Keyboard Shortcut"
+msgid "Space"
+msgstr ""
 
 msgid "Open actions speed dial"
 msgstr ""
@@ -11502,11 +11522,16 @@ msgstr "Attiva/Disattiva finestra G-code"
 msgid "Move slider 5x faster"
 msgstr "Sposta il cursore 5 volte più velocemente"
 
+msgctxt "Keyboard Shortcut"
+msgid "Home"
+msgstr ""
+
 msgid "Horizontal slider - Move to start position"
 msgstr "Cursore di scorrimento orizzontale - Sposta alla posizione iniziale"
 
+msgctxt "Keyboard Shortcut"
 msgid "End"
-msgstr "Fine"
+msgstr ""
 
 msgid "Horizontal slider - Move to last position"
 msgstr "Cursore di scorrimento orizzontale - Sposta alla posizione finale"
@@ -20931,6 +20956,27 @@ msgid ""
 msgstr ""
 "Evita le deformazioni\n"
 "Sapevi che quando si stampano materiali soggetti a deformazioni come l'ABS, aumentare in modo appropriato la temperatura del piano riscaldato può ridurre la probabilità di deformazione?"
+
+#~ msgid "Enter"
+#~ msgstr "Invio"
+
+#~ msgid "Del"
+#~ msgstr "Elimina"
+
+#~ msgid "Arrow Up"
+#~ msgstr "Freccia Su"
+
+#~ msgid "Arrow Down"
+#~ msgstr "Freccia Giù"
+
+#~ msgid "Arrow Left"
+#~ msgstr "Freccia Sinistra"
+
+#~ msgid "Arrow Right"
+#~ msgstr "Freccia Destra"
+
+#~ msgid "End"
+#~ msgstr "Fine"
 
 #~ msgid "Hotend"
 #~ msgstr "Hotend"

--- a/localization/i18n/it/OrcaSlicer_it.po
+++ b/localization/i18n/it/OrcaSlicer_it.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Orca Slicer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-20 10:39-0300\n"
+"POT-Creation-Date: 2026-07-22 19:11-0300\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -3521,8 +3521,9 @@ msgctxt "air_duct"
 msgid "Left(Aux)"
 msgstr "Sinistra (Aux)"
 
+msgctxt "Hotend Heat Breaker Fan"
 msgid "Hotend"
-msgstr "Hotend"
+msgstr ""
 
 msgid "Parts"
 msgstr "Parti"
@@ -9002,6 +9003,15 @@ msgstr ""
 msgid "Displays current viewport FPS in the top-right corner."
 msgstr ""
 
+msgid "G-code Preview"
+msgstr ""
+
+msgid "Dim lower layers"
+msgstr ""
+
+msgid "When scrubbing the layer slider in the sliced preview, render the layers below the current one darkened so that only the layer being viewed is shown at full brightness."
+msgstr ""
+
 msgid "Login region"
 msgstr "Regione di accesso"
 
@@ -9586,6 +9596,9 @@ msgstr "Quando si abilita la modalità vaso a spirale, le macchine con struttura
 
 msgid "The current printer does not support timelapse in Traditional Mode when printing By-Object."
 msgstr "La stampante corrente non supporta il timelapse in modalità tradizionale quando si stampa per oggetto."
+
+msgid "I have checked the installed nozzle and want to print anyway."
+msgstr ""
 
 msgid "Errors"
 msgstr "Errori"
@@ -17040,6 +17053,12 @@ msgstr ""
 msgid "Whether this printer supports fast purge mode with optimized temperature and multiplier."
 msgstr ""
 
+msgid "Filament change"
+msgstr ""
+
+msgid "The volume of material required to prime the extruder on the tower, excluding a hotend change."
+msgstr ""
+
 msgid "The volume of material required to prime the extruder for a hotend change on the tower."
 msgstr "Volume di materiale necessario per innescare l'estrusore in vista di una sostituzione dell'hotend sulla torre."
 
@@ -20262,14 +20281,14 @@ msgstr "Errore: %s"
 msgid "Show details"
 msgstr "Mostra dettagli"
 
+msgid "Hide details"
+msgstr ""
+
 msgid "Version to install:"
 msgstr "Versione da installare:"
 
 msgid "Download and Install"
 msgstr "Scarica e installa"
-
-msgid "Skip for Now"
-msgstr "Salta per ora"
 
 msgid "A new version of the Bambu Network Plug-in is available."
 msgstr "È disponibile una nuova versione del modulo di rete Bambu."
@@ -20281,17 +20300,11 @@ msgstr "Versione corrente: %s"
 msgid "Update to version:"
 msgstr "Aggiorna alla versione:"
 
-msgid "Update Now"
-msgstr "Aggiorna ora"
-
-msgid "Remind Later"
-msgstr "Ricorda più tardi"
-
-msgid "Skip Version"
-msgstr "Salta versione"
-
 msgid "Don't Ask Again"
 msgstr "Non chiedere più"
+
+msgid "Update Now"
+msgstr "Aggiorna ora"
 
 msgid "(Latest)"
 msgstr "(Ultima)"
@@ -20307,9 +20320,6 @@ msgstr "È necessario un riavvio per caricare il nuovo modulo. Vuoi riavviare or
 
 msgid "Restart Now"
 msgstr "Riavvia ora"
-
-msgid "Restart Later"
-msgstr "Riavvia più tardi"
 
 msgid "NO RAMMING AT ALL"
 msgstr "NESSUNA SPINTA"
@@ -20893,6 +20903,21 @@ msgid ""
 msgstr ""
 "Evita le deformazioni\n"
 "Sapevi che quando si stampano materiali soggetti a deformazioni come l'ABS, aumentare in modo appropriato la temperatura del piano riscaldato può ridurre la probabilità di deformazione?"
+
+#~ msgid "Hotend"
+#~ msgstr "Hotend"
+
+#~ msgid "Skip for Now"
+#~ msgstr "Salta per ora"
+
+#~ msgid "Remind Later"
+#~ msgstr "Ricorda più tardi"
+
+#~ msgid "Skip Version"
+#~ msgstr "Salta versione"
+
+#~ msgid "Restart Later"
+#~ msgstr "Riavvia più tardi"
 
 #~ msgid "Select filament that installed to the left nozzle"
 #~ msgstr "Selezionare il filamento installato nell'ugello sinistro"

--- a/localization/i18n/ja/OrcaSlicer_ja.po
+++ b/localization/i18n/ja/OrcaSlicer_ja.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Orca Slicer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-23 14:21-0300\n"
+"POT-Creation-Date: 2026-07-23 15:24-0300\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -554,6 +554,7 @@ msgstr "再割り当て"
 msgid "Reset"
 msgstr "リセット"
 
+msgctxt "Keyboard Shortcut"
 msgid "Enter"
 msgstr ""
 
@@ -1760,12 +1761,14 @@ msgstr "選択"
 msgid "Select point"
 msgstr "点を選択"
 
+msgctxt "Keyboard Shortcut"
 msgid "Delete"
-msgstr "削除"
+msgstr ""
 
 msgid "Restart selection"
 msgstr "選択をリセット"
 
+msgctxt "Keyboard Shortcut"
 msgid "Esc"
 msgstr ""
 
@@ -2405,6 +2408,9 @@ msgstr "URLのダウンロードを開始できませんでした。保存先フ
 msgid "Import File"
 msgstr "ファイルインポート"
 
+msgid "Delete"
+msgstr "削除"
+
 msgid "Choose files"
 msgstr "ファイルを選択"
 
@@ -2535,12 +2541,14 @@ msgstr "非表示"
 msgid "Show"
 msgstr "表示"
 
+msgctxt "Keyboard Shortcut"
 msgid "Del"
 msgstr ""
 
 msgid "Delete the selected object"
 msgstr "選択したオブジェクトを削除"
 
+msgctxt "Keyboard Shortcut"
 msgid "Backspace"
 msgstr ""
 
@@ -11266,29 +11274,33 @@ msgstr "複数のオブジェクトを選択"
 msgid "Select objects by rectangle"
 msgstr "矩形でオブジェクトを選択"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Up"
-msgstr "↑"
+msgstr ""
 
 # TODO: Review, changed by lang refactor. PR 14254
 msgid "Move selection 10mm in positive Y direction"
 msgstr "Y方向 10mm"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Down"
-msgstr "↓"
+msgstr ""
 
 # TODO: Review, changed by lang refactor. PR 14254
 msgid "Move selection 10mm in negative Y direction"
 msgstr "Y方向 -10mm"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Left"
-msgstr "←"
+msgstr ""
 
 # TODO: Review, changed by lang refactor. PR 14254
 msgid "Move selection 10mm in negative X direction"
 msgstr "X方向 -10mm"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Right"
-msgstr "→"
+msgstr ""
 
 # TODO: Review, changed by lang refactor. PR 14254
 msgid "Move selection 10mm in positive X direction"
@@ -11374,8 +11386,16 @@ msgstr "縮小"
 msgid "Toggle printable for object/part"
 msgstr ""
 
+msgctxt "Keyboard Shortcut"
+msgid "Tab"
+msgstr ""
+
 msgid "Switch between Prepare/Preview"
 msgstr "準備/プレビュー間の切り替え"
+
+msgctxt "Keyboard Shortcut"
+msgid "Space"
+msgstr ""
 
 msgid "Open actions speed dial"
 msgstr ""
@@ -11435,11 +11455,16 @@ msgstr "G-codeウィンドウのオン/オフ"
 msgid "Move slider 5x faster"
 msgstr "5x"
 
+msgctxt "Keyboard Shortcut"
+msgid "Home"
+msgstr ""
+
 msgid "Horizontal slider - Move to start position"
 msgstr "水平スライダー - 開始位置に移動"
 
+msgctxt "Keyboard Shortcut"
 msgid "End"
-msgstr "終了"
+msgstr ""
 
 msgid "Horizontal slider - Move to last position"
 msgstr "水平スライダー - 最後の位置に移動"
@@ -20399,6 +20424,21 @@ msgid ""
 msgstr ""
 "反りを避ける\n"
 "ABSのような反りやすい素材を印刷する場合、ヒートベッドの温度を適切に上げることで、反りが発生する確率を下げることができることをご存知ですか？"
+
+#~ msgid "Arrow Up"
+#~ msgstr "↑"
+
+#~ msgid "Arrow Down"
+#~ msgstr "↓"
+
+#~ msgid "Arrow Left"
+#~ msgstr "←"
+
+#~ msgid "Arrow Right"
+#~ msgstr "→"
+
+#~ msgid "End"
+#~ msgstr "終了"
 
 #~ msgid "Hotend"
 #~ msgstr "ホットエンド"

--- a/localization/i18n/ja/OrcaSlicer_ja.po
+++ b/localization/i18n/ja/OrcaSlicer_ja.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Orca Slicer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-22 19:11-0300\n"
+"POT-Creation-Date: 2026-07-23 14:21-0300\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -891,8 +891,9 @@ msgstr "選択からコネクタを削除"
 msgid "Select all connectors"
 msgstr "すべてのコネクタを選択"
 
+msgctxt "Cut tool"
 msgid "Cut"
-msgstr "カット"
+msgstr ""
 
 msgid "Rotate cut plane"
 msgstr "カット面の回転"
@@ -1869,8 +1870,9 @@ msgstr ""
 msgid "Leaving Measure gizmo"
 msgstr ""
 
+msgctxt "Assembly tool"
 msgid "Assemble"
-msgstr "組立てる"
+msgstr ""
 
 msgid "Please confirm explosion ratio = 1 and select at least two volumes."
 msgstr "分解比率が1であることを確認し、少なくとも2つのボリュームを選択してください。"
@@ -2738,6 +2740,9 @@ msgstr "メートルから変換"
 # TODO: Review, changed by lang refactor. PR 14254
 msgid "Restore to Meter"
 msgstr "メータル単位に復元"
+
+msgid "Assemble"
+msgstr "組立てる"
 
 msgid "Assemble the selected objects into an object with multiple parts"
 msgstr "選択したオブジェクトを一つオブジェクトに組み立てます（複数パーツ）"
@@ -4265,6 +4270,14 @@ msgstr "外部スプールホルダーのフィラメントで造形します"
 msgid "Print with filament in AMS"
 msgstr "AMSのフィラメントで造形します"
 
+msgctxt "Nozzle position"
+msgid "Left"
+msgstr ""
+
+msgctxt "Nozzle position"
+msgid "Right"
+msgstr ""
+
 msgid "When the current material run out, the printer will continue to print in the following order."
 msgstr "現在の材料がなくなると、プリンターは次の順序で印刷を続けます。"
 
@@ -5571,8 +5584,9 @@ msgstr "アダプティブ"
 msgid "Quality / Speed"
 msgstr "品質/速度"
 
+msgctxt "Mesh action"
 msgid "Smooth"
-msgstr "滑らか目"
+msgstr ""
 
 msgid "Radius"
 msgstr "半径"
@@ -6187,6 +6201,9 @@ msgstr "元に戻す"
 msgid "Redo"
 msgstr "やり直す"
 
+msgid "Cut"
+msgstr "カット"
+
 msgid "Cut selection to clipboard"
 msgstr "選択範囲をカット"
 
@@ -6287,6 +6304,10 @@ msgstr "3Dシーンで選択したオブジェクトの周りにアウトライ�
 
 msgid "Preferences"
 msgstr "設定"
+
+msgctxt "Menu"
+msgid "Edit"
+msgstr ""
 
 msgid "View"
 msgstr "表示"
@@ -9265,8 +9286,9 @@ msgstr "互換性なし"
 msgid "The selected preset is null!"
 msgstr "選択したプリセットがnullです！"
 
+msgctxt "Layer range"
 msgid "End"
-msgstr "終了"
+msgstr ""
 
 msgid "Customize"
 msgstr "カスタマイズ"
@@ -11415,6 +11437,9 @@ msgstr "5x"
 
 msgid "Horizontal slider - Move to start position"
 msgstr "水平スライダー - 開始位置に移動"
+
+msgid "End"
+msgstr "終了"
 
 msgid "Horizontal slider - Move to last position"
 msgstr "水平スライダー - 最後の位置に移動"
@@ -15696,6 +15721,9 @@ msgstr "有効にした場合、タイムラプスビデオを録画します。
 
 msgid "Traditional"
 msgstr "通常"
+
+msgid "Smooth"
+msgstr "滑らか目"
 
 msgid "Farthest point timelapse"
 msgstr ""

--- a/localization/i18n/ja/OrcaSlicer_ja.po
+++ b/localization/i18n/ja/OrcaSlicer_ja.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Orca Slicer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-20 10:39-0300\n"
+"POT-Creation-Date: 2026-07-22 19:11-0300\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -3511,8 +3511,9 @@ msgctxt "air_duct"
 msgid "Left(Aux)"
 msgstr "左（補助）"
 
+msgctxt "Hotend Heat Breaker Fan"
 msgid "Hotend"
-msgstr "ホットエンド"
+msgstr ""
 
 msgid "Parts"
 msgstr "パーツ"
@@ -8960,6 +8961,15 @@ msgstr ""
 msgid "Displays current viewport FPS in the top-right corner."
 msgstr ""
 
+msgid "G-code Preview"
+msgstr ""
+
+msgid "Dim lower layers"
+msgstr ""
+
+msgid "When scrubbing the layer slider in the sliced preview, render the layers below the current one darkened so that only the layer being viewed is shown at full brightness."
+msgstr ""
+
 msgid "Login region"
 msgstr "地域"
 
@@ -9547,6 +9557,9 @@ msgstr "スパイラル花瓶モードを有効にすると、I3構造のマシ�
 
 msgid "The current printer does not support timelapse in Traditional Mode when printing By-Object."
 msgstr "現在のプリンターはオブジェクト別印刷時のトラディショナルモードでのタイムラプスをサポートしていません。"
+
+msgid "I have checked the installed nozzle and want to print anyway."
+msgstr ""
 
 msgid "Errors"
 msgstr "エラー"
@@ -16625,6 +16638,12 @@ msgstr ""
 msgid "Whether this printer supports fast purge mode with optimized temperature and multiplier."
 msgstr ""
 
+msgid "Filament change"
+msgstr ""
+
+msgid "The volume of material required to prime the extruder on the tower, excluding a hotend change."
+msgstr ""
+
 msgid "The volume of material required to prime the extruder for a hotend change on the tower."
 msgstr "ホットエンド変更を伴う場合に、プライムタワー上で押出機を初期化するために必要な材料量です。"
 
@@ -19753,14 +19772,14 @@ msgstr "エラー: %s"
 msgid "Show details"
 msgstr "詳細を表示"
 
+msgid "Hide details"
+msgstr ""
+
 msgid "Version to install:"
 msgstr "インストールするバージョン:"
 
 msgid "Download and Install"
 msgstr "ダウンロードしてインストール"
-
-msgid "Skip for Now"
-msgstr "今はスキップ"
 
 msgid "A new version of the Bambu Network Plug-in is available."
 msgstr "Bambuネットワークプラグインの新しいバージョンが利用可能です。"
@@ -19772,17 +19791,11 @@ msgstr "現在のバージョン: %s"
 msgid "Update to version:"
 msgstr "アップデートするバージョン:"
 
-msgid "Update Now"
-msgstr "今すぐアップデート"
-
-msgid "Remind Later"
-msgstr "後で通知"
-
-msgid "Skip Version"
-msgstr "バージョンをスキップ"
-
 msgid "Don't Ask Again"
 msgstr "今後は確認しない"
+
+msgid "Update Now"
+msgstr "今すぐアップデート"
 
 msgid "(Latest)"
 msgstr "（最新）"
@@ -19798,9 +19811,6 @@ msgstr "新しいプラグインをロードするには再起動が必要です
 
 msgid "Restart Now"
 msgstr "今すぐ再起動"
-
-msgid "Restart Later"
-msgstr "後で再起動"
 
 msgid "NO RAMMING AT ALL"
 msgstr "ラミングなし"
@@ -20361,6 +20371,21 @@ msgid ""
 msgstr ""
 "反りを避ける\n"
 "ABSのような反りやすい素材を印刷する場合、ヒートベッドの温度を適切に上げることで、反りが発生する確率を下げることができることをご存知ですか？"
+
+#~ msgid "Hotend"
+#~ msgstr "ホットエンド"
+
+#~ msgid "Skip for Now"
+#~ msgstr "今はスキップ"
+
+#~ msgid "Remind Later"
+#~ msgstr "後で通知"
+
+#~ msgid "Skip Version"
+#~ msgstr "バージョンをスキップ"
+
+#~ msgid "Restart Later"
+#~ msgstr "後で再起動"
 
 #~ msgid "Select filament that installed to the left nozzle"
 #~ msgstr "左ノズルに取り付けたフィラメントを選択"

--- a/localization/i18n/ko/OrcaSlicer_ko.po
+++ b/localization/i18n/ko/OrcaSlicer_ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Orca Slicer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-22 19:11-0300\n"
+"POT-Creation-Date: 2026-07-23 14:21-0300\n"
 "PO-Revision-Date: 2025-06-02 17:12+0900\n"
 "Last-Translator: crwusiz <crwusiz@gmail.com>\n"
 "Language-Team: \n"
@@ -895,8 +895,9 @@ msgstr "선택 항목에서 커넥터 제거"
 msgid "Select all connectors"
 msgstr "모든 커넥터 선택"
 
+msgctxt "Cut tool"
 msgid "Cut"
-msgstr "잘라내기"
+msgstr ""
 
 msgid "Rotate cut plane"
 msgstr "절단면 회전"
@@ -1875,8 +1876,9 @@ msgstr ""
 msgid "Leaving Measure gizmo"
 msgstr ""
 
+msgctxt "Assembly tool"
 msgid "Assemble"
-msgstr "병합"
+msgstr ""
 
 msgid "Please confirm explosion ratio = 1 and select at least two volumes."
 msgstr "분해 비율이 1인지 확인하고 최소 두 개의 볼륨을 선택하세요."
@@ -2745,6 +2747,9 @@ msgstr "미터에서 변환"
 # TODO: Review, changed by lang refactor. PR 14254
 msgid "Restore to Meter"
 msgstr "미터로 복원"
+
+msgid "Assemble"
+msgstr "병합"
 
 msgid "Assemble the selected objects into an object with multiple parts"
 msgstr "선택한 객체를 여러 부품이 있는 객체로 조립"
@@ -4280,6 +4285,14 @@ msgstr "케이스 뒷면에 장착된 재료를 사용하여 출력"
 msgid "Print with filament in AMS"
 msgstr "AMS의 필라멘트로 출력"
 
+msgctxt "Nozzle position"
+msgid "Left"
+msgstr ""
+
+msgctxt "Nozzle position"
+msgid "Right"
+msgstr ""
+
 msgid "When the current material run out, the printer will continue to print in the following order."
 msgstr "현재 재료가 소진되면 프린터는 다음 순서로 계속 출력합니다."
 
@@ -5597,8 +5610,9 @@ msgstr "적응형"
 msgid "Quality / Speed"
 msgstr "품질 / 속도"
 
+msgctxt "Mesh action"
 msgid "Smooth"
-msgstr "유연"
+msgstr ""
 
 msgid "Radius"
 msgstr "반경"
@@ -6215,6 +6229,9 @@ msgstr "실행 취소"
 msgid "Redo"
 msgstr "다시 실행"
 
+msgid "Cut"
+msgstr "잘라내기"
+
 msgid "Cut selection to clipboard"
 msgstr "잘라낸 항목을 클립보드에 복사"
 
@@ -6315,6 +6332,10 @@ msgstr "3D 장면에서 선택한 객체 주변에 윤곽선 표시"
 
 msgid "Preferences"
 msgstr "기본 설정"
+
+msgctxt "Menu"
+msgid "Edit"
+msgstr ""
 
 msgid "View"
 msgstr "시점"
@@ -9287,8 +9308,9 @@ msgstr "호환되지 않음"
 msgid "The selected preset is null!"
 msgstr "선택한 사전 설정의 값이 존재하지 않습니다!"
 
+msgctxt "Layer range"
 msgid "End"
-msgstr "끝"
+msgstr ""
 
 msgid "Customize"
 msgstr "사용자 정의"
@@ -11448,6 +11470,9 @@ msgstr "슬라이더를 5배 빠르게 이동"
 
 msgid "Horizontal slider - Move to start position"
 msgstr "수평 슬라이더 - 시작 위치로 이동"
+
+msgid "End"
+msgstr "끝"
 
 msgid "Horizontal slider - Move to last position"
 msgstr "수평 슬라이더 - 마지막 위치로 이동"
@@ -15933,6 +15958,9 @@ msgstr "유연 또는 기존 모드를 선택한 경우 각 출력에 대해 타
 
 msgid "Traditional"
 msgstr "기존"
+
+msgid "Smooth"
+msgstr "유연"
 
 msgid "Farthest point timelapse"
 msgstr ""

--- a/localization/i18n/ko/OrcaSlicer_ko.po
+++ b/localization/i18n/ko/OrcaSlicer_ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Orca Slicer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-20 10:39-0300\n"
+"POT-Creation-Date: 2026-07-22 19:11-0300\n"
 "PO-Revision-Date: 2025-06-02 17:12+0900\n"
 "Last-Translator: crwusiz <crwusiz@gmail.com>\n"
 "Language-Team: \n"
@@ -3518,8 +3518,9 @@ msgctxt "air_duct"
 msgid "Left(Aux)"
 msgstr "왼쪽(보조)"
 
+msgctxt "Hotend Heat Breaker Fan"
 msgid "Hotend"
-msgstr "핫엔드"
+msgstr ""
 
 msgid "Parts"
 msgstr "파트"
@@ -8984,6 +8985,15 @@ msgstr ""
 msgid "Displays current viewport FPS in the top-right corner."
 msgstr ""
 
+msgid "G-code Preview"
+msgstr ""
+
+msgid "Dim lower layers"
+msgstr ""
+
+msgid "When scrubbing the layer slider in the sliced preview, render the layers below the current one darkened so that only the layer being viewed is shown at full brightness."
+msgstr ""
+
 msgid "Login region"
 msgstr "로그인 지역"
 
@@ -9569,6 +9579,9 @@ msgstr "나선형 꽃병 모드를 활성화하면 I3 구조의 장치는 타임
 
 msgid "The current printer does not support timelapse in Traditional Mode when printing By-Object."
 msgstr "현재 프린터는 개체별 출력 시 기존 모드에서 타임랩스를 지원하지 않습니다."
+
+msgid "I have checked the installed nozzle and want to print anyway."
+msgstr ""
 
 msgid "Errors"
 msgstr "오류"
@@ -16899,6 +16912,12 @@ msgstr ""
 msgid "Whether this printer supports fast purge mode with optimized temperature and multiplier."
 msgstr ""
 
+msgid "Filament change"
+msgstr ""
+
+msgid "The volume of material required to prime the extruder on the tower, excluding a hotend change."
+msgstr ""
+
 msgid "The volume of material required to prime the extruder for a hotend change on the tower."
 msgstr "타워에서 핫엔드를 교체하기 위해 압출기를 준비하는 데 필요한 재료 부피."
 
@@ -20098,13 +20117,13 @@ msgstr ""
 msgid "Show details"
 msgstr ""
 
+msgid "Hide details"
+msgstr ""
+
 msgid "Version to install:"
 msgstr ""
 
 msgid "Download and Install"
-msgstr ""
-
-msgid "Skip for Now"
 msgstr ""
 
 msgid "A new version of the Bambu Network Plug-in is available."
@@ -20117,16 +20136,10 @@ msgstr ""
 msgid "Update to version:"
 msgstr ""
 
-msgid "Update Now"
-msgstr ""
-
-msgid "Remind Later"
-msgstr ""
-
-msgid "Skip Version"
-msgstr ""
-
 msgid "Don't Ask Again"
+msgstr ""
+
+msgid "Update Now"
 msgstr ""
 
 msgid "(Latest)"
@@ -20142,9 +20155,6 @@ msgid "A restart is required to load the new plug-in. Would you like to restart 
 msgstr ""
 
 msgid "Restart Now"
-msgstr ""
-
-msgid "Restart Later"
 msgstr ""
 
 msgid "NO RAMMING AT ALL"
@@ -20729,6 +20739,9 @@ msgid ""
 msgstr ""
 "뒤틀림 방지\n"
 "ABS와 같이 뒤틀림이 발생하기 쉬운 소재를 출력할 때, 히트베드 온도를 적절하게 높이면 뒤틀림 가능성을 줄일 수 있다는 사실을 알고 계셨나요?"
+
+#~ msgid "Hotend"
+#~ msgstr "핫엔드"
 
 #~ msgid "Select filament that installed to the left nozzle"
 #~ msgstr "왼쪽 노즐에 설치된 필라멘트를 선택합니다"

--- a/localization/i18n/ko/OrcaSlicer_ko.po
+++ b/localization/i18n/ko/OrcaSlicer_ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Orca Slicer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-23 14:21-0300\n"
+"POT-Creation-Date: 2026-07-23 15:24-0300\n"
 "PO-Revision-Date: 2025-06-02 17:12+0900\n"
 "Last-Translator: crwusiz <crwusiz@gmail.com>\n"
 "Language-Team: \n"
@@ -558,6 +558,7 @@ msgstr "재매핑"
 msgid "Reset"
 msgstr "초기화"
 
+msgctxt "Keyboard Shortcut"
 msgid "Enter"
 msgstr ""
 
@@ -1764,12 +1765,14 @@ msgstr "선택"
 msgid "Select point"
 msgstr "위치 선택"
 
+msgctxt "Keyboard Shortcut"
 msgid "Delete"
-msgstr "삭제"
+msgstr ""
 
 msgid "Restart selection"
 msgstr "다시 선택"
 
+msgctxt "Keyboard Shortcut"
 msgid "Esc"
 msgstr ""
 
@@ -2411,6 +2414,9 @@ msgstr "URL 다운로드를 시작할 수 없습니다. 대상 폴더가 설정�
 msgid "Import File"
 msgstr "파일 가져오기"
 
+msgid "Delete"
+msgstr "삭제"
+
 msgid "Choose files"
 msgstr "파일 선택"
 
@@ -2541,13 +2547,14 @@ msgstr "숨기기"
 msgid "Show"
 msgstr "보이기"
 
-# 단축키
+msgctxt "Keyboard Shortcut"
 msgid "Del"
 msgstr ""
 
 msgid "Delete the selected object"
 msgstr "선택된 객체 삭제"
 
+msgctxt "Keyboard Shortcut"
 msgid "Backspace"
 msgstr ""
 
@@ -11299,29 +11306,33 @@ msgstr "여러 객체 선택"
 msgid "Select objects by rectangle"
 msgstr "사각형으로 객체 선택"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Up"
-msgstr "화살표 위로"
+msgstr ""
 
 # TODO: Review, changed by lang refactor. PR 14254
 msgid "Move selection 10mm in positive Y direction"
 msgstr "선택 항목을 +Y 방향으로 10mm 이동"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Down"
-msgstr "화살표 아래로"
+msgstr ""
 
 # TODO: Review, changed by lang refactor. PR 14254
 msgid "Move selection 10mm in negative Y direction"
 msgstr "선택 항목을 -Y 방향으로 10mm 이동"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Left"
-msgstr "화살표 왼쪽으로"
+msgstr ""
 
 # TODO: Review, changed by lang refactor. PR 14254
 msgid "Move selection 10mm in negative X direction"
 msgstr "선택 항목을 -X 방향으로 10mm 이동"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Right"
-msgstr "화살표 오른쪽으로"
+msgstr ""
 
 # TODO: Review, changed by lang refactor. PR 14254
 msgid "Move selection 10mm in positive X direction"
@@ -11407,8 +11418,16 @@ msgstr "축소"
 msgid "Toggle printable for object/part"
 msgstr ""
 
+msgctxt "Keyboard Shortcut"
+msgid "Tab"
+msgstr ""
+
 msgid "Switch between Prepare/Preview"
 msgstr "준비 하기/미리 보기 전환"
+
+msgctxt "Keyboard Shortcut"
+msgid "Space"
+msgstr ""
 
 msgid "Open actions speed dial"
 msgstr ""
@@ -11468,11 +11487,16 @@ msgstr "Gcode 창 켜기/끄기"
 msgid "Move slider 5x faster"
 msgstr "슬라이더를 5배 빠르게 이동"
 
+msgctxt "Keyboard Shortcut"
+msgid "Home"
+msgstr ""
+
 msgid "Horizontal slider - Move to start position"
 msgstr "수평 슬라이더 - 시작 위치로 이동"
 
+msgctxt "Keyboard Shortcut"
 msgid "End"
-msgstr "끝"
+msgstr ""
 
 msgid "Horizontal slider - Move to last position"
 msgstr "수평 슬라이더 - 마지막 위치로 이동"
@@ -20767,6 +20791,21 @@ msgid ""
 msgstr ""
 "뒤틀림 방지\n"
 "ABS와 같이 뒤틀림이 발생하기 쉬운 소재를 출력할 때, 히트베드 온도를 적절하게 높이면 뒤틀림 가능성을 줄일 수 있다는 사실을 알고 계셨나요?"
+
+#~ msgid "Arrow Up"
+#~ msgstr "화살표 위로"
+
+#~ msgid "Arrow Down"
+#~ msgstr "화살표 아래로"
+
+#~ msgid "Arrow Left"
+#~ msgstr "화살표 왼쪽으로"
+
+#~ msgid "Arrow Right"
+#~ msgstr "화살표 오른쪽으로"
+
+#~ msgid "End"
+#~ msgstr "끝"
 
 #~ msgid "Hotend"
 #~ msgstr "핫엔드"

--- a/localization/i18n/lt/OrcaSlicer_lt.po
+++ b/localization/i18n/lt/OrcaSlicer_lt.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-22 19:11-0300\n"
+"POT-Creation-Date: 2026-07-23 14:21-0300\n"
 "PO-Revision-Date: 2026-07-02 14:13+0300\n"
 "Last-Translator: Gintaras Kučinskas <sharanchius@gmail.com>\n"
 "Language-Team: \n"
@@ -883,8 +883,9 @@ msgstr "Pašalinti jungtį iš parinkties"
 msgid "Select all connectors"
 msgstr "Pasirinkti visas jungtis"
 
+msgctxt "Cut tool"
 msgid "Cut"
-msgstr "Iškirpti"
+msgstr ""
 
 msgid "Rotate cut plane"
 msgstr "Sukti pjovimo plokštumą"
@@ -1861,8 +1862,9 @@ msgstr "Įjungiamas matavimo manipuliatorius"
 msgid "Leaving Measure gizmo"
 msgstr "Išjungiamas matavimo manipuliatorius"
 
+msgctxt "Assembly tool"
 msgid "Assemble"
-msgstr "Surinkti"
+msgstr ""
 
 msgid "Please confirm explosion ratio = 1 and select at least two volumes."
 msgstr "Įsitikinkite, kad išskaidymo koeficientas = 1, ir pasirinkite bent du tūrius."
@@ -2729,6 +2731,9 @@ msgstr "Konvertuoti iš metrų"
 
 msgid "Restore to Meter"
 msgstr "Grąžinti į metrus"
+
+msgid "Assemble"
+msgstr "Surinkti"
 
 msgid "Assemble the selected objects into an object with multiple parts"
 msgstr "Sujungti pasirinktus objektus į objektą iš kelių detalių"
@@ -4224,6 +4229,14 @@ msgstr "Spausdinti išorinės ritės gija"
 msgid "Print with filament in AMS"
 msgstr "Spausdinti AMS gijomis"
 
+msgctxt "Nozzle position"
+msgid "Left"
+msgstr ""
+
+msgctxt "Nozzle position"
+msgid "Right"
+msgstr ""
+
 msgid "When the current material run out, the printer will continue to print in the following order."
 msgstr "Pasibaigus esamai medžiagai, spausdintuvas toliau spausdins šia tvarka."
 
@@ -5515,8 +5528,9 @@ msgstr "Adaptyvus"
 msgid "Quality / Speed"
 msgstr "Kokybė / Greitis"
 
+msgctxt "Mesh action"
 msgid "Smooth"
-msgstr "Glotnus"
+msgstr ""
 
 msgid "Radius"
 msgstr "Spindulys"
@@ -6133,6 +6147,9 @@ msgstr "Atšaukti"
 msgid "Redo"
 msgstr "Perdaryti"
 
+msgid "Cut"
+msgstr "Iškirpti"
+
 msgid "Cut selection to clipboard"
 msgstr "Iškirpti pasirinkimą į mainų sritį"
 
@@ -6231,6 +6248,10 @@ msgstr "Rodyti kontūrą aplink pasirinktą objektą 3D scenoje."
 
 msgid "Preferences"
 msgstr "Parinktys"
+
+msgctxt "Menu"
+msgid "Edit"
+msgstr ""
 
 msgid "View"
 msgstr "Vaizdas"
@@ -9202,8 +9223,9 @@ msgstr "Nesuderinama"
 msgid "The selected preset is null!"
 msgstr "Pasirinktas profilis yra tuščias (null)!"
 
+msgctxt "Layer range"
 msgid "End"
-msgstr "Pabaiga"
+msgstr ""
 
 msgid "Customize"
 msgstr "Pritaikyti"
@@ -11359,6 +11381,9 @@ msgstr "Judinkite slankiklį 5 kartus greičiau"
 
 msgid "Horizontal slider - Move to start position"
 msgstr "Horizontalus slankiklis – perkelti į pradinę padėtį"
+
+msgid "End"
+msgstr "Pabaiga"
 
 msgid "Horizontal slider - Move to last position"
 msgstr "Horizontalus slankiklis – perkelti į paskutinę padėtį"
@@ -15887,6 +15912,9 @@ msgstr "Jei pasirinktas sklandus (\"smooth\") arba tradicinis (\"traditional\") 
 
 msgid "Traditional"
 msgstr "Tradicinis"
+
+msgid "Smooth"
+msgstr "Glotnus"
 
 msgid "Farthest point timelapse"
 msgstr ""

--- a/localization/i18n/lt/OrcaSlicer_lt.po
+++ b/localization/i18n/lt/OrcaSlicer_lt.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-20 10:39-0300\n"
+"POT-Creation-Date: 2026-07-22 19:11-0300\n"
 "PO-Revision-Date: 2026-07-02 14:13+0300\n"
 "Last-Translator: Gintaras Kučinskas <sharanchius@gmail.com>\n"
 "Language-Team: \n"
@@ -3483,8 +3483,9 @@ msgctxt "air_duct"
 msgid "Left(Aux)"
 msgstr "Kairysis (papildomas)"
 
+msgctxt "Hotend Heat Breaker Fan"
 msgid "Hotend"
-msgstr "Kaitinimo blokas (Hotend)"
+msgstr ""
 
 msgid "Parts"
 msgstr "Detalės"
@@ -8904,6 +8905,15 @@ msgstr "Rodyti KPS (FPS) indikatorių"
 msgid "Displays current viewport FPS in the top-right corner."
 msgstr "Viršutiniame dešiniajame kampe rodo esamą vaizdo srities kadrų dažnį."
 
+msgid "G-code Preview"
+msgstr ""
+
+msgid "Dim lower layers"
+msgstr ""
+
+msgid "When scrubbing the layer slider in the sliced preview, render the layers below the current one darkened so that only the layer being viewed is shown at full brightness."
+msgstr ""
+
 msgid "Login region"
 msgstr "Prisijungimo regionas"
 
@@ -9480,6 +9490,9 @@ msgstr "Įjungus spiralinės vazos režimą, I3 struktūros įrenginiai negeneru
 
 msgid "The current printer does not support timelapse in Traditional Mode when printing By-Object."
 msgstr "Dabartinis spausdintuvas nepalaiko laiko tarpų (timelapse) vaizdo įrašų tradiciniu režimu, kai spausdinama pagal objektą."
+
+msgid "I have checked the installed nozzle and want to print anyway."
+msgstr ""
 
 msgid "Errors"
 msgstr "Klaidos"
@@ -16830,6 +16843,12 @@ msgstr ""
 msgid "Whether this printer supports fast purge mode with optimized temperature and multiplier."
 msgstr ""
 
+msgid "Filament change"
+msgstr ""
+
+msgid "The volume of material required to prime the extruder on the tower, excluding a hotend change."
+msgstr ""
+
 msgid "The volume of material required to prime the extruder for a hotend change on the tower."
 msgstr ""
 
@@ -20022,14 +20041,14 @@ msgstr "Klaida: %s"
 msgid "Show details"
 msgstr "Rodyti išsamiau"
 
+msgid "Hide details"
+msgstr ""
+
 msgid "Version to install:"
 msgstr "Diegiama versija:"
 
 msgid "Download and Install"
 msgstr "Atsisiųsti ir įdiegti"
-
-msgid "Skip for Now"
-msgstr "Kol kas praleisti"
 
 msgid "A new version of the Bambu Network Plug-in is available."
 msgstr "Išleista nauja „Bambu“ tinklo papildinio versija."
@@ -20041,17 +20060,11 @@ msgstr "Dabartinė versija: %s"
 msgid "Update to version:"
 msgstr "Atnaujinti iki versijos:"
 
-msgid "Update Now"
-msgstr "Atnaujinti dabar"
-
-msgid "Remind Later"
-msgstr "Priminti vėliau"
-
-msgid "Skip Version"
-msgstr "Praleisti šią versiją"
-
 msgid "Don't Ask Again"
 msgstr "Daugiau neklausti"
+
+msgid "Update Now"
+msgstr "Atnaujinti dabar"
 
 msgid "(Latest)"
 msgstr "(Naujausia)"
@@ -20067,9 +20080,6 @@ msgstr "Norint įkelti naują papildinį, programą reikia paleisti iš naujo. A
 
 msgid "Restart Now"
 msgstr "Paleisti iš naujo dabar"
-
-msgid "Restart Later"
-msgstr "Paleisti iš naujo vėliau"
 
 msgid "NO RAMMING AT ALL"
 msgstr "VISIŠKAI NENAUDOTI SUTANKINIMO"
@@ -20649,6 +20659,21 @@ msgid ""
 msgstr ""
 "Venkite deformacijų (warping)\n"
 "Ar žinojote, kad spausdinant medžiagas, kurios yra linkusios trauktis ir riestis (pvz., ABS), tinkamas kaitinamojo pagrindo temperatūros padidinimas gali sumažinti deformacijų (warping) tikimybę?"
+
+#~ msgid "Hotend"
+#~ msgstr "Kaitinimo blokas (Hotend)"
+
+#~ msgid "Skip for Now"
+#~ msgstr "Kol kas praleisti"
+
+#~ msgid "Remind Later"
+#~ msgstr "Priminti vėliau"
+
+#~ msgid "Skip Version"
+#~ msgstr "Praleisti šią versiją"
+
+#~ msgid "Restart Later"
+#~ msgstr "Paleisti iš naujo vėliau"
 
 #~ msgid "Select filament that installed to the left nozzle"
 #~ msgstr "Pasirinkite giją, įstatytą į kairįjį purkštuką"

--- a/localization/i18n/lt/OrcaSlicer_lt.po
+++ b/localization/i18n/lt/OrcaSlicer_lt.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-23 14:21-0300\n"
+"POT-Creation-Date: 2026-07-23 15:24-0300\n"
 "PO-Revision-Date: 2026-07-02 14:13+0300\n"
 "Last-Translator: Gintaras Kučinskas <sharanchius@gmail.com>\n"
 "Language-Team: \n"
@@ -553,8 +553,9 @@ msgstr "Priskirti iš naujo"
 msgid "Reset"
 msgstr "Nustatyti iš naujo"
 
+msgctxt "Keyboard Shortcut"
 msgid "Enter"
-msgstr "Įvesti"
+msgstr ""
 
 msgid "Shortcut Key "
 msgstr "Spartusis klavišas "
@@ -1750,14 +1751,16 @@ msgstr "Pasirinkti"
 msgid "Select point"
 msgstr "Pasirinkti tašką"
 
+msgctxt "Keyboard Shortcut"
 msgid "Delete"
-msgstr "Ištrinti"
+msgstr ""
 
 msgid "Restart selection"
 msgstr "Pasirinkti iš naujo"
 
+msgctxt "Keyboard Shortcut"
 msgid "Esc"
-msgstr "Esc"
+msgstr ""
 
 msgid "Cancel a feature until exit"
 msgstr "Atmesti elementą iki išėjimo"
@@ -2417,6 +2420,9 @@ msgstr "Nepavyko pradėti atsisiuntimo iš interneto adreso. Nėra nurodytas pas
 msgid "Import File"
 msgstr "Importuoti failą"
 
+msgid "Delete"
+msgstr "Ištrinti"
+
 msgid "Choose files"
 msgstr "Pasirinkite failus"
 
@@ -2535,14 +2541,16 @@ msgstr "Paslėpti"
 msgid "Show"
 msgstr "Rodyti"
 
+msgctxt "Keyboard Shortcut"
 msgid "Del"
-msgstr "Del"
+msgstr ""
 
 msgid "Delete the selected object"
 msgstr "Ištrinti pasirinktą objektą"
 
+msgctxt "Keyboard Shortcut"
 msgid "Backspace"
-msgstr "Backspace"
+msgstr ""
 
 msgid "Load..."
 msgstr "Įkelti..."
@@ -11217,26 +11225,30 @@ msgstr "Pasirinkite kelis objektus"
 msgid "Select objects by rectangle"
 msgstr "Pasirinkti objektus stačiakampio rėmeliu"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Up"
-msgstr "Rodyklė aukštyn"
+msgstr ""
 
 msgid "Move selection 10mm in positive Y direction"
 msgstr "Perkelti pasirinkimą 10 mm teigiama Y kryptimi"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Down"
-msgstr "Rodyklė žemyn"
+msgstr ""
 
 msgid "Move selection 10mm in negative Y direction"
 msgstr "Perkelti pasirinkimą 10 mm neigiama Y kryptimi"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Left"
-msgstr "Rodyklė Kairėn"
+msgstr ""
 
 msgid "Move selection 10mm in negative X direction"
 msgstr "Perkelti pasirinkimą 10 mm neigiama X kryptimi"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Right"
-msgstr "Rodyklė dešinėn"
+msgstr ""
 
 msgid "Move selection 10mm in positive X direction"
 msgstr "Perkelti pasirinkimą 10 mm teigiama X kryptimi"
@@ -11319,8 +11331,16 @@ msgstr "Nutolinti"
 msgid "Toggle printable for object/part"
 msgstr "Perjungti objekto / dalies spausdinimą"
 
+msgctxt "Keyboard Shortcut"
+msgid "Tab"
+msgstr ""
+
 msgid "Switch between Prepare/Preview"
 msgstr "Perjungimas tarp Paruošti / Peržiūrėti"
+
+msgctxt "Keyboard Shortcut"
+msgid "Space"
+msgstr ""
 
 msgid "Open actions speed dial"
 msgstr ""
@@ -11379,11 +11399,16 @@ msgstr "G-kodo lango įjungimas / išjungimas"
 msgid "Move slider 5x faster"
 msgstr "Judinkite slankiklį 5 kartus greičiau"
 
+msgctxt "Keyboard Shortcut"
+msgid "Home"
+msgstr ""
+
 msgid "Horizontal slider - Move to start position"
 msgstr "Horizontalus slankiklis – perkelti į pradinę padėtį"
 
+msgctxt "Keyboard Shortcut"
 msgid "End"
-msgstr "Pabaiga"
+msgstr ""
 
 msgid "Horizontal slider - Move to last position"
 msgstr "Horizontalus slankiklis – perkelti į paskutinę padėtį"
@@ -20687,6 +20712,33 @@ msgid ""
 msgstr ""
 "Venkite deformacijų (warping)\n"
 "Ar žinojote, kad spausdinant medžiagas, kurios yra linkusios trauktis ir riestis (pvz., ABS), tinkamas kaitinamojo pagrindo temperatūros padidinimas gali sumažinti deformacijų (warping) tikimybę?"
+
+#~ msgid "Enter"
+#~ msgstr "Įvesti"
+
+#~ msgid "Esc"
+#~ msgstr "Esc"
+
+#~ msgid "Del"
+#~ msgstr "Del"
+
+#~ msgid "Backspace"
+#~ msgstr "Backspace"
+
+#~ msgid "Arrow Up"
+#~ msgstr "Rodyklė aukštyn"
+
+#~ msgid "Arrow Down"
+#~ msgstr "Rodyklė žemyn"
+
+#~ msgid "Arrow Left"
+#~ msgstr "Rodyklė Kairėn"
+
+#~ msgid "Arrow Right"
+#~ msgstr "Rodyklė dešinėn"
+
+#~ msgid "End"
+#~ msgstr "Pabaiga"
 
 #~ msgid "Hotend"
 #~ msgstr "Kaitinimo blokas (Hotend)"

--- a/localization/i18n/nl/OrcaSlicer_nl.po
+++ b/localization/i18n/nl/OrcaSlicer_nl.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Orca Slicer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-22 19:11-0300\n"
+"POT-Creation-Date: 2026-07-23 14:21-0300\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -886,8 +886,9 @@ msgstr "Verbinding verwijderen uit selectie"
 msgid "Select all connectors"
 msgstr "Selecteer alle verbindingen"
 
+msgctxt "Cut tool"
 msgid "Cut"
-msgstr "Knippen"
+msgstr ""
 
 msgid "Rotate cut plane"
 msgstr ""
@@ -1856,8 +1857,9 @@ msgstr ""
 msgid "Leaving Measure gizmo"
 msgstr ""
 
+msgctxt "Assembly tool"
 msgid "Assemble"
-msgstr "Monteren"
+msgstr ""
 
 msgid "Please confirm explosion ratio = 1 and select at least two volumes."
 msgstr ""
@@ -2712,6 +2714,9 @@ msgstr "Omzetten vanuit meter"
 # TODO: Review, changed by lang refactor. PR 14254
 msgid "Restore to Meter"
 msgstr "Terugzetten naar meter"
+
+msgid "Assemble"
+msgstr "Monteren"
 
 msgid "Assemble the selected objects into an object with multiple parts"
 msgstr "Monteer de geselecteerde objecten tot een object bestaande uit meerdere delen"
@@ -4238,6 +4243,14 @@ msgstr "Print met filament op een externe spoel."
 msgid "Print with filament in AMS"
 msgstr "Printen met filament in AMS"
 
+msgctxt "Nozzle position"
+msgid "Left"
+msgstr ""
+
+msgctxt "Nozzle position"
+msgid "Right"
+msgstr ""
+
 msgid "When the current material run out, the printer will continue to print in the following order."
 msgstr "Als het huidige materiaal op is, gaat de printer verder met afdrukken in de volgende volgorde."
 
@@ -5537,8 +5550,9 @@ msgstr "Adaptief"
 msgid "Quality / Speed"
 msgstr "Kwaliteit/snelheid"
 
+msgctxt "Mesh action"
 msgid "Smooth"
-msgstr "Vloeiend"
+msgstr ""
 
 msgid "Radius"
 msgstr "Straal"
@@ -6155,6 +6169,9 @@ msgstr "Ongedaan maken"
 msgid "Redo"
 msgstr "Opnieuw doen"
 
+msgid "Cut"
+msgstr "Knippen"
+
 msgid "Cut selection to clipboard"
 msgstr "Selectie naar klembord knippen"
 
@@ -6255,6 +6272,10 @@ msgstr ""
 
 msgid "Preferences"
 msgstr "Voorkeuren"
+
+msgctxt "Menu"
+msgid "Edit"
+msgstr ""
 
 msgid "View"
 msgstr "Weergave"
@@ -9204,8 +9225,9 @@ msgstr "Incompatibel"
 msgid "The selected preset is null!"
 msgstr "De geselecteerde preset is nul!"
 
+msgctxt "Layer range"
 msgid "End"
-msgstr "Einde"
+msgstr ""
 
 msgid "Customize"
 msgstr "Aanpassen"
@@ -11342,6 +11364,9 @@ msgstr "Schuifregelaar 5x sneller verplaatsen"
 
 msgid "Horizontal slider - Move to start position"
 msgstr ""
+
+msgid "End"
+msgstr "Einde"
 
 msgid "Horizontal slider - Move to last position"
 msgstr ""
@@ -15622,6 +15647,9 @@ msgstr "Als de vloeiende of traditionele modus is geselecteerd, wordt voor elke 
 
 msgid "Traditional"
 msgstr "Traditioneel"
+
+msgid "Smooth"
+msgstr "Vloeiend"
 
 msgid "Farthest point timelapse"
 msgstr ""

--- a/localization/i18n/nl/OrcaSlicer_nl.po
+++ b/localization/i18n/nl/OrcaSlicer_nl.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Orca Slicer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-20 10:39-0300\n"
+"POT-Creation-Date: 2026-07-22 19:11-0300\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -3490,8 +3490,9 @@ msgctxt "air_duct"
 msgid "Left(Aux)"
 msgstr ""
 
+msgctxt "Hotend Heat Breaker Fan"
 msgid "Hotend"
-msgstr "Hotend"
+msgstr ""
 
 msgid "Parts"
 msgstr "Onderdelen"
@@ -8901,6 +8902,15 @@ msgstr ""
 msgid "Displays current viewport FPS in the top-right corner."
 msgstr ""
 
+msgid "G-code Preview"
+msgstr ""
+
+msgid "Dim lower layers"
+msgstr ""
+
+msgid "When scrubbing the layer slider in the sliced preview, render the layers below the current one darkened so that only the layer being viewed is shown at full brightness."
+msgstr ""
+
 msgid "Login region"
 msgstr "Inlogregio"
 
@@ -9478,6 +9488,9 @@ msgid "When spiral vase mode is enabled, machines with I3 structure will not gen
 msgstr "When enable spiral vase mode, machines with I3 structure will not generate timelapse videos."
 
 msgid "The current printer does not support timelapse in Traditional Mode when printing By-Object."
+msgstr ""
+
+msgid "I have checked the installed nozzle and want to print anyway."
 msgstr ""
 
 msgid "Errors"
@@ -16554,6 +16567,12 @@ msgstr ""
 msgid "Whether this printer supports fast purge mode with optimized temperature and multiplier."
 msgstr ""
 
+msgid "Filament change"
+msgstr ""
+
+msgid "The volume of material required to prime the extruder on the tower, excluding a hotend change."
+msgstr ""
+
 msgid "The volume of material required to prime the extruder for a hotend change on the tower."
 msgstr "Het volume materiaal dat nodig is om de extruder te primen voor een hot-end wissel op de toren."
 
@@ -19685,13 +19704,13 @@ msgstr "Fout: %s"
 msgid "Show details"
 msgstr ""
 
+msgid "Hide details"
+msgstr ""
+
 msgid "Version to install:"
 msgstr ""
 
 msgid "Download and Install"
-msgstr ""
-
-msgid "Skip for Now"
 msgstr ""
 
 msgid "A new version of the Bambu Network Plug-in is available."
@@ -19704,16 +19723,10 @@ msgstr "Huidige versie: %s"
 msgid "Update to version:"
 msgstr ""
 
-msgid "Update Now"
-msgstr ""
-
-msgid "Remind Later"
-msgstr ""
-
-msgid "Skip Version"
-msgstr ""
-
 msgid "Don't Ask Again"
+msgstr ""
+
+msgid "Update Now"
 msgstr ""
 
 msgid "(Latest)"
@@ -19729,9 +19742,6 @@ msgid "A restart is required to load the new plug-in. Would you like to restart 
 msgstr ""
 
 msgid "Restart Now"
-msgstr ""
-
-msgid "Restart Later"
 msgstr ""
 
 msgid "NO RAMMING AT ALL"
@@ -20316,6 +20326,9 @@ msgid ""
 msgstr ""
 "Kromtrekken voorkomen\n"
 "Wist je dat bij het printen van materialen die gevoelig zijn voor kromtrekken, zoals ABS, een juiste verhoging van de temperatuur van het warmtebed de kans op kromtrekken kan verkleinen?"
+
+#~ msgid "Hotend"
+#~ msgstr "Hotend"
 
 #~ msgid "Select Filament && Hotends"
 #~ msgstr "Selecteer Filament && hot-ends"

--- a/localization/i18n/nl/OrcaSlicer_nl.po
+++ b/localization/i18n/nl/OrcaSlicer_nl.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Orca Slicer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-23 14:21-0300\n"
+"POT-Creation-Date: 2026-07-23 15:24-0300\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -554,6 +554,7 @@ msgstr "Opnieuw toewijzen"
 msgid "Reset"
 msgstr "Terugzetten"
 
+msgctxt "Keyboard Shortcut"
 msgid "Enter"
 msgstr ""
 
@@ -1749,12 +1750,14 @@ msgstr "Selecteren"
 msgid "Select point"
 msgstr "Kies punt"
 
+msgctxt "Keyboard Shortcut"
 msgid "Delete"
-msgstr "Verwijderen"
+msgstr ""
 
 msgid "Restart selection"
 msgstr "Selectie herstarten"
 
+msgctxt "Keyboard Shortcut"
 msgid "Esc"
 msgstr ""
 
@@ -2382,6 +2385,9 @@ msgstr ""
 msgid "Import File"
 msgstr "Importeer bestand"
 
+msgid "Delete"
+msgstr "Verwijderen"
+
 msgid "Choose files"
 msgstr "Kies bestanden"
 
@@ -2512,12 +2518,14 @@ msgstr "Verbergen"
 msgid "Show"
 msgstr "Weergeven"
 
+msgctxt "Keyboard Shortcut"
 msgid "Del"
 msgstr ""
 
 msgid "Delete the selected object"
 msgstr "Verwijder het geselecteerde object"
 
+msgctxt "Keyboard Shortcut"
 msgid "Backspace"
 msgstr ""
 
@@ -11193,29 +11201,33 @@ msgstr "Selecteer meerdere objecten"
 msgid "Select objects by rectangle"
 msgstr "Objecten selecteren door rechthoek"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Up"
-msgstr "Pijl naar boven"
+msgstr ""
 
 # TODO: Review, changed by lang refactor. PR 14254
 msgid "Move selection 10mm in positive Y direction"
 msgstr "Verplaats de selectie 10mm in een positieve Y richting"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Down"
-msgstr "Pijl omlaag"
+msgstr ""
 
 # TODO: Review, changed by lang refactor. PR 14254
 msgid "Move selection 10mm in negative Y direction"
 msgstr "Verplaats de selectie 10mm in een negatieve Y richting"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Left"
-msgstr "Pijl naar links"
+msgstr ""
 
 # TODO: Review, changed by lang refactor. PR 14254
 msgid "Move selection 10mm in negative X direction"
 msgstr "Verplaats de selectie 10mm in een negatieve X richting"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Right"
-msgstr "Pijl naar rechts"
+msgstr ""
 
 # TODO: Review, changed by lang refactor. PR 14254
 msgid "Move selection 10mm in positive X direction"
@@ -11301,7 +11313,15 @@ msgstr "Zoom uit"
 msgid "Toggle printable for object/part"
 msgstr ""
 
+msgctxt "Keyboard Shortcut"
+msgid "Tab"
+msgstr ""
+
 msgid "Switch between Prepare/Preview"
+msgstr ""
+
+msgctxt "Keyboard Shortcut"
+msgid "Space"
 msgstr ""
 
 msgid "Open actions speed dial"
@@ -11362,11 +11382,16 @@ msgstr ""
 msgid "Move slider 5x faster"
 msgstr "Schuifregelaar 5x sneller verplaatsen"
 
+msgctxt "Keyboard Shortcut"
+msgid "Home"
+msgstr ""
+
 msgid "Horizontal slider - Move to start position"
 msgstr ""
 
+msgctxt "Keyboard Shortcut"
 msgid "End"
-msgstr "Einde"
+msgstr ""
 
 msgid "Horizontal slider - Move to last position"
 msgstr ""
@@ -20354,6 +20379,21 @@ msgid ""
 msgstr ""
 "Kromtrekken voorkomen\n"
 "Wist je dat bij het printen van materialen die gevoelig zijn voor kromtrekken, zoals ABS, een juiste verhoging van de temperatuur van het warmtebed de kans op kromtrekken kan verkleinen?"
+
+#~ msgid "Arrow Up"
+#~ msgstr "Pijl naar boven"
+
+#~ msgid "Arrow Down"
+#~ msgstr "Pijl omlaag"
+
+#~ msgid "Arrow Left"
+#~ msgstr "Pijl naar links"
+
+#~ msgid "Arrow Right"
+#~ msgstr "Pijl naar rechts"
+
+#~ msgid "End"
+#~ msgstr "Einde"
 
 #~ msgid "Hotend"
 #~ msgstr "Hotend"

--- a/localization/i18n/pl/OrcaSlicer_pl.po
+++ b/localization/i18n/pl/OrcaSlicer_pl.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OrcaSlicer 2.3.0-rc\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-22 19:11-0300\n"
+"POT-Creation-Date: 2026-07-23 14:21-0300\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Krzysztof Morga <<tlumaczeniebs@gmail.com>>\n"
 "Language-Team: \n"
@@ -893,8 +893,9 @@ msgstr "Usuń łącznik z zaznaczenia"
 msgid "Select all connectors"
 msgstr "Zaznacz wszystkie łączniki"
 
+msgctxt "Cut tool"
 msgid "Cut"
-msgstr "Wytnij"
+msgstr ""
 
 msgid "Rotate cut plane"
 msgstr "Obróć przekrój"
@@ -1876,8 +1877,9 @@ msgstr "Otwieranie uchwytu pomiaru"
 msgid "Leaving Measure gizmo"
 msgstr "Zamykanie uchwytu wytłaczania"
 
+msgctxt "Assembly tool"
 msgid "Assemble"
-msgstr "Złożenie"
+msgstr ""
 
 msgid "Please confirm explosion ratio = 1 and select at least two volumes."
 msgstr "Proszę potwierdzić współczynnik eksplozji = 1 i wybrać co najmniej dwie objętości."
@@ -2738,6 +2740,9 @@ msgstr "Konwertuj z metra"
 # TODO: Review, changed by lang refactor. PR 14254
 msgid "Restore to Meter"
 msgstr "Przywróć do metra"
+
+msgid "Assemble"
+msgstr "Złożenie"
 
 msgid "Assemble the selected objects into an object with multiple parts"
 msgstr "Zmontuj wybrane obiekty w obiekt wieloczęściowy"
@@ -4285,6 +4290,14 @@ msgstr "Drukowanie przy użyciu materiałów zamontowanych na tylnej części ob
 msgid "Print with filament in AMS"
 msgstr "Drukowanie filamentem z AMS"
 
+msgctxt "Nozzle position"
+msgid "Left"
+msgstr ""
+
+msgctxt "Nozzle position"
+msgid "Right"
+msgstr ""
+
 msgid "When the current material run out, the printer will continue to print in the following order."
 msgstr "Gdy obecny filament się skończy, drukarka będzie kontynuować druk w następującej kolejności."
 
@@ -5594,8 +5607,9 @@ msgstr "Adaptacyjne"
 msgid "Quality / Speed"
 msgstr "Jakość / Prędkość"
 
+msgctxt "Mesh action"
 msgid "Smooth"
-msgstr "Wygładź"
+msgstr ""
 
 msgid "Radius"
 msgstr "Promień"
@@ -6216,6 +6230,9 @@ msgstr "Cofnij"
 msgid "Redo"
 msgstr "Ponów"
 
+msgid "Cut"
+msgstr "Wytnij"
+
 msgid "Cut selection to clipboard"
 msgstr "Przenosi zaznaczone obiekty do schowka"
 
@@ -6316,6 +6333,10 @@ msgstr "Przełącza wyświetlanie konturu wokół zaznaczonego obiektu w scenie 
 
 msgid "Preferences"
 msgstr "Preferencje"
+
+msgctxt "Menu"
+msgid "Edit"
+msgstr ""
 
 msgid "View"
 msgstr "Widok"
@@ -9294,8 +9315,9 @@ msgstr "Niekompatybilne"
 msgid "The selected preset is null!"
 msgstr "Wybrany profil jest pusty!"
 
+msgctxt "Layer range"
 msgid "End"
-msgstr "Koniec"
+msgstr ""
 
 msgid "Customize"
 msgstr "Dostosuj"
@@ -11465,6 +11487,9 @@ msgstr "Przesuń suwak 5x szybciej"
 
 msgid "Horizontal slider - Move to start position"
 msgstr "Suwak poziomy - Przesuń do pozycji początkowej"
+
+msgid "End"
+msgstr "Koniec"
 
 msgid "Horizontal slider - Move to last position"
 msgstr "Suwak poziomy - Przesuń do ostatniej pozycji"
@@ -15951,6 +15976,9 @@ msgstr "Jeśli wybrany jest tryb „Tradycyjny”, dla każdego wydruku będzie 
 
 msgid "Traditional"
 msgstr "Tradycyjny"
+
+msgid "Smooth"
+msgstr "Wygładź"
 
 msgid "Farthest point timelapse"
 msgstr ""

--- a/localization/i18n/pl/OrcaSlicer_pl.po
+++ b/localization/i18n/pl/OrcaSlicer_pl.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OrcaSlicer 2.3.0-rc\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-23 14:21-0300\n"
+"POT-Creation-Date: 2026-07-23 15:24-0300\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Krzysztof Morga <<tlumaczeniebs@gmail.com>>\n"
 "Language-Team: \n"
@@ -556,8 +556,9 @@ msgstr ""
 msgid "Reset"
 msgstr "Resetuj"
 
+msgctxt "Keyboard Shortcut"
 msgid "Enter"
-msgstr "Drukarka"
+msgstr ""
 
 msgid "Shortcut Key "
 msgstr "Skrót klawiszowy "
@@ -1765,12 +1766,14 @@ msgstr "Wybierz"
 msgid "Select point"
 msgstr "Wybierz punkt"
 
+msgctxt "Keyboard Shortcut"
 msgid "Delete"
-msgstr "Usuń"
+msgstr ""
 
 msgid "Restart selection"
 msgstr "Restartuj wybór"
 
+msgctxt "Keyboard Shortcut"
 msgid "Esc"
 msgstr ""
 
@@ -2405,6 +2408,9 @@ msgstr "Nie można rozpocząć pobierania pliku z adresu URL. Folder docelowy ni
 msgid "Import File"
 msgstr "Importuj plik"
 
+msgid "Delete"
+msgstr "Usuń"
+
 msgid "Choose files"
 msgstr "Wybierz pliki"
 
@@ -2535,14 +2541,16 @@ msgstr "Ukryj"
 msgid "Show"
 msgstr "Pokaż"
 
+msgctxt "Keyboard Shortcut"
 msgid "Del"
 msgstr ""
 
 msgid "Delete the selected object"
 msgstr "Usuń wybrany obiekt"
 
+msgctxt "Keyboard Shortcut"
 msgid "Backspace"
-msgstr "Wstecz"
+msgstr ""
 
 msgid "Load..."
 msgstr "Wczytaj..."
@@ -11316,29 +11324,33 @@ msgstr "Wybierz wiele obiektów"
 msgid "Select objects by rectangle"
 msgstr "Wybierz obiekty prostokątem"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Up"
-msgstr "Strzałka w górę"
+msgstr ""
 
 # TODO: Review, changed by lang refactor. PR 14254
 msgid "Move selection 10mm in positive Y direction"
 msgstr "Przesuń wybrane o 10 mm w kierunku dodatnim osi Y"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Down"
-msgstr "Strzałka w dół"
+msgstr ""
 
 # TODO: Review, changed by lang refactor. PR 14254
 msgid "Move selection 10mm in negative Y direction"
 msgstr "Przesuń wybrane o 10 mm w kierunku ujemnym osi Y"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Left"
-msgstr "Strzałka w lewo"
+msgstr ""
 
 # TODO: Review, changed by lang refactor. PR 14254
 msgid "Move selection 10mm in negative X direction"
 msgstr "Przesuń wybrane o 10 mm w kierunku ujemnym osi X"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Right"
-msgstr "Strzałka w prawo"
+msgstr ""
 
 # TODO: Review, changed by lang refactor. PR 14254
 msgid "Move selection 10mm in positive X direction"
@@ -11424,8 +11436,16 @@ msgstr "Oddalenie"
 msgid "Toggle printable for object/part"
 msgstr ""
 
+msgctxt "Keyboard Shortcut"
+msgid "Tab"
+msgstr ""
+
 msgid "Switch between Prepare/Preview"
 msgstr "Przełączanie między przygotowaniem/podglądem"
+
+msgctxt "Keyboard Shortcut"
+msgid "Space"
+msgstr ""
 
 msgid "Open actions speed dial"
 msgstr ""
@@ -11485,11 +11505,16 @@ msgstr "Włącz/Wyłącz okno G-code"
 msgid "Move slider 5x faster"
 msgstr "Przesuń suwak 5x szybciej"
 
+msgctxt "Keyboard Shortcut"
+msgid "Home"
+msgstr ""
+
 msgid "Horizontal slider - Move to start position"
 msgstr "Suwak poziomy - Przesuń do pozycji początkowej"
 
+msgctxt "Keyboard Shortcut"
 msgid "End"
-msgstr "Koniec"
+msgstr ""
 
 msgid "Horizontal slider - Move to last position"
 msgstr "Suwak poziomy - Przesuń do ostatniej pozycji"
@@ -20781,6 +20806,27 @@ msgid ""
 msgstr ""
 "Unikaj odkształceń\n"
 "Czy wiesz, że podczas drukowania filamentami podatnymi na odkształcenia, takimi jak ABS, odpowiednie zwiększenie temperatury podgrzewanej płyty może zmniejszyć prawdopodobieństwo odkształceń?"
+
+#~ msgid "Enter"
+#~ msgstr "Drukarka"
+
+#~ msgid "Backspace"
+#~ msgstr "Wstecz"
+
+#~ msgid "Arrow Up"
+#~ msgstr "Strzałka w górę"
+
+#~ msgid "Arrow Down"
+#~ msgstr "Strzałka w dół"
+
+#~ msgid "Arrow Left"
+#~ msgstr "Strzałka w lewo"
+
+#~ msgid "Arrow Right"
+#~ msgstr "Strzałka w prawo"
+
+#~ msgid "End"
+#~ msgstr "Koniec"
 
 #~ msgid "Hotend"
 #~ msgstr "Hotend"

--- a/localization/i18n/pl/OrcaSlicer_pl.po
+++ b/localization/i18n/pl/OrcaSlicer_pl.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OrcaSlicer 2.3.0-rc\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-20 10:39-0300\n"
+"POT-Creation-Date: 2026-07-22 19:11-0300\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Krzysztof Morga <<tlumaczeniebs@gmail.com>>\n"
 "Language-Team: \n"
@@ -3521,8 +3521,9 @@ msgctxt "air_duct"
 msgid "Left(Aux)"
 msgstr "Lewy (Aux)"
 
+msgctxt "Hotend Heat Breaker Fan"
 msgid "Hotend"
-msgstr "Hotend"
+msgstr ""
 
 msgid "Parts"
 msgstr "Wydruk"
@@ -8994,6 +8995,15 @@ msgstr ""
 msgid "Displays current viewport FPS in the top-right corner."
 msgstr ""
 
+msgid "G-code Preview"
+msgstr ""
+
+msgid "Dim lower layers"
+msgstr ""
+
+msgid "When scrubbing the layer slider in the sliced preview, render the layers below the current one darkened so that only the layer being viewed is shown at full brightness."
+msgstr ""
+
 msgid "Login region"
 msgstr "Region logowania"
 
@@ -9576,6 +9586,9 @@ msgstr "Po włączeniu trybu wazy, maszyny o strukturze I3 nie będą generować
 
 msgid "The current printer does not support timelapse in Traditional Mode when printing By-Object."
 msgstr "Bieżąca drukarka nie wspiera funkcji timelapse w trybie tradycyjnym, podczas drukowania według obiektu."
+
+msgid "I have checked the installed nozzle and want to print anyway."
+msgstr ""
 
 msgid "Errors"
 msgstr "Błędy"
@@ -16916,6 +16929,12 @@ msgstr ""
 msgid "Whether this printer supports fast purge mode with optimized temperature and multiplier."
 msgstr ""
 
+msgid "Filament change"
+msgstr ""
+
+msgid "The volume of material required to prime the extruder on the tower, excluding a hotend change."
+msgstr ""
+
 msgid "The volume of material required to prime the extruder for a hotend change on the tower."
 msgstr "Objętość materiału wymagana do oczyszczania ekstrudera na wieży przed zmianą hotendu."
 
@@ -20109,13 +20128,13 @@ msgstr "Błąd: %s"
 msgid "Show details"
 msgstr ""
 
+msgid "Hide details"
+msgstr ""
+
 msgid "Version to install:"
 msgstr ""
 
 msgid "Download and Install"
-msgstr ""
-
-msgid "Skip for Now"
 msgstr ""
 
 msgid "A new version of the Bambu Network Plug-in is available."
@@ -20128,16 +20147,10 @@ msgstr ""
 msgid "Update to version:"
 msgstr ""
 
-msgid "Update Now"
-msgstr ""
-
-msgid "Remind Later"
-msgstr ""
-
-msgid "Skip Version"
-msgstr ""
-
 msgid "Don't Ask Again"
+msgstr ""
+
+msgid "Update Now"
 msgstr ""
 
 msgid "(Latest)"
@@ -20153,9 +20166,6 @@ msgid "A restart is required to load the new plug-in. Would you like to restart 
 msgstr ""
 
 msgid "Restart Now"
-msgstr ""
-
-msgid "Restart Later"
 msgstr ""
 
 msgid "NO RAMMING AT ALL"
@@ -20743,6 +20753,9 @@ msgid ""
 msgstr ""
 "Unikaj odkształceń\n"
 "Czy wiesz, że podczas drukowania filamentami podatnymi na odkształcenia, takimi jak ABS, odpowiednie zwiększenie temperatury podgrzewanej płyty może zmniejszyć prawdopodobieństwo odkształceń?"
+
+#~ msgid "Hotend"
+#~ msgstr "Hotend"
 
 #~ msgid "Select filament that installed to the left nozzle"
 #~ msgstr "Wybierz filament załadowany do lewej dyszy."

--- a/localization/i18n/pt_BR/OrcaSlicer_pt_BR.po
+++ b/localization/i18n/pt_BR/OrcaSlicer_pt_BR.po
@@ -3472,6 +3472,7 @@ msgctxt "air_duct"
 msgid "Left(Aux)"
 msgstr "Esquerda(Aux)"
 
+msgctxt "Hotend Heat Breaker Fan"
 msgid "Hotend"
 msgstr "Hotend"
 
@@ -8919,6 +8920,15 @@ msgstr "Mostrar painel de FPS"
 msgid "Displays current viewport FPS in the top-right corner."
 msgstr "Exibe o FPS atual da janela de visualização no canto superior direito."
 
+msgid "G-code Preview"
+msgstr ""
+
+msgid "Dim lower layers"
+msgstr ""
+
+msgid "When scrubbing the layer slider in the sliced preview, render the layers below the current one darkened so that only the layer being viewed is shown at full brightness."
+msgstr ""
+
 msgid "Login region"
 msgstr "Região de login"
 
@@ -9502,6 +9512,9 @@ msgstr "Quando o modo vaso espiral está ativado, máquinas com estrutura I3 nã
 
 msgid "The current printer does not support timelapse in Traditional Mode when printing By-Object."
 msgstr "A impressora atual não suporta timelapse no Modo Tradicional ao imprimir Por Objeto."
+
+msgid "I have checked the installed nozzle and want to print anyway."
+msgstr ""
 
 msgid "Errors"
 msgstr "Erros"
@@ -16897,6 +16910,12 @@ msgstr "Quando este valor de retração for modificado, ele será usado como a q
 msgid "Support fast purge mode"
 msgstr "Suporte ao modo de purga rápida"
 
+msgid "Filament change"
+msgstr ""
+
+msgid "The volume of material required to prime the extruder on the tower, excluding a hotend change."
+msgstr ""
+
 msgid "The volume of material required to prime the extruder for a hotend change on the tower."
 msgstr "O volume de material necessário para preparar o extrusor para uma troca do hotend na torre."
 
@@ -20083,14 +20102,14 @@ msgstr "Erro: %s"
 msgid "Show details"
 msgstr "Mostrar detalhes"
 
+msgid "Hide details"
+msgstr ""
+
 msgid "Version to install:"
 msgstr "Versão para instalar:"
 
 msgid "Download and Install"
 msgstr "Baixar e Instalar"
-
-msgid "Skip for Now"
-msgstr "Pular por Enquanto"
 
 msgid "A new version of the Bambu Network Plug-in is available."
 msgstr "Uma nova versão do Plug-in de Rede Bambu está disponível."
@@ -20102,17 +20121,11 @@ msgstr "Versão atual: %s"
 msgid "Update to version:"
 msgstr "Atualizar para versão:"
 
-msgid "Update Now"
-msgstr "Atualizar Agora"
-
-msgid "Remind Later"
-msgstr "Lembre-me Depois"
-
-msgid "Skip Version"
-msgstr "Pular Versão"
-
 msgid "Don't Ask Again"
 msgstr "Não Perguntar Novamente"
+
+msgid "Update Now"
+msgstr "Atualizar Agora"
 
 msgid "(Latest)"
 msgstr "(Mais recente)"
@@ -20128,9 +20141,6 @@ msgstr "É necessário reiniciar para carregar o novo plug-in. Deseja reiniciar 
 
 msgid "Restart Now"
 msgstr "Reiniciar Agora"
-
-msgid "Restart Later"
-msgstr "Reiniciar Depois"
 
 msgid "NO RAMMING AT ALL"
 msgstr "SEM NENHUM MOLDEAMENTO"
@@ -20705,6 +20715,21 @@ msgid ""
 msgstr ""
 "Evitar empenamento\n"
 "Você sabia que ao imprimir materiais propensos ao empenamento como ABS, aumentar adequadamente a temperatura da mesa aquecida pode reduzir a probabilidade de empenamento?"
+
+#~ msgid "Hotend"
+#~ msgstr "Extrusora"
+
+#~ msgid "Skip for Now"
+#~ msgstr "Pular por Enquanto"
+
+#~ msgid "Remind Later"
+#~ msgstr "Lembre-me Depois"
+
+#~ msgid "Skip Version"
+#~ msgstr "Pular Versão"
+
+#~ msgid "Restart Later"
+#~ msgstr "Reiniciar Depois"
 
 #~ msgid "Select filament that installed to the left nozzle"
 #~ msgstr "Selecione o filamento instalado no bico esquerdo"

--- a/localization/i18n/pt_BR/OrcaSlicer_pt_BR.po
+++ b/localization/i18n/pt_BR/OrcaSlicer_pt_BR.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Orca Slicer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-23 14:21-0300\n"
+"POT-Creation-Date: 2026-07-23 15:24-0300\n"
 "PO-Revision-Date: 2026-07-22 20:39-0300\n"
 "Last-Translator: Alexandre Folle de Menezes\n"
 "Language-Team: Portuguese, Brazilian\n"
@@ -553,8 +553,9 @@ msgstr "Remapear"
 msgid "Reset"
 msgstr "Reiniciar"
 
+msgctxt "Keyboard Shortcut"
 msgid "Enter"
-msgstr "Enter"
+msgstr ""
 
 msgid "Shortcut Key "
 msgstr "Tecla de atalho "
@@ -1746,14 +1747,16 @@ msgstr "Selecionar"
 msgid "Select point"
 msgstr "Selecionar ponto"
 
+msgctxt "Keyboard Shortcut"
 msgid "Delete"
-msgstr "Excluir"
+msgstr ""
 
 msgid "Restart selection"
 msgstr "Reiniciar seleção"
 
+msgctxt "Keyboard Shortcut"
 msgid "Esc"
-msgstr "Esc"
+msgstr ""
 
 msgid "Cancel a feature until exit"
 msgstr "Cancelar um recurso até sair"
@@ -2412,6 +2415,9 @@ msgstr "Não foi possível baixar da URL. A pasta de destino não está definida
 msgid "Import File"
 msgstr "Importar Arquivo"
 
+msgid "Delete"
+msgstr "Excluir"
+
 msgid "Choose files"
 msgstr "Escolher arquivos"
 
@@ -2530,12 +2536,14 @@ msgstr "Ocultar"
 msgid "Show"
 msgstr "Mostrar"
 
+msgctxt "Keyboard Shortcut"
 msgid "Del"
-msgstr "Del"
+msgstr ""
 
 msgid "Delete the selected object"
 msgstr "Apagar o objeto selecionado"
 
+msgctxt "Keyboard Shortcut"
 msgid "Backspace"
 msgstr ""
 
@@ -11247,26 +11255,30 @@ msgstr "Selecionar vários objetos"
 msgid "Select objects by rectangle"
 msgstr "Selecionar objetos por retângulo"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Up"
-msgstr "Seta para cima"
+msgstr ""
 
 msgid "Move selection 10mm in positive Y direction"
 msgstr "Mover seleção 10mm na direção Y positiva"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Down"
-msgstr "Seta para baixo"
+msgstr ""
 
 msgid "Move selection 10mm in negative Y direction"
 msgstr "Mover seleção 10mm na direção Y negativa"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Left"
-msgstr "Seta para esquerda"
+msgstr ""
 
 msgid "Move selection 10mm in negative X direction"
 msgstr "Mover seleção 10mm na direção X negativa"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Right"
-msgstr "Seta para direita"
+msgstr ""
 
 msgid "Move selection 10mm in positive X direction"
 msgstr "Mover seleção 10mm na direção X positiva"
@@ -11349,8 +11361,16 @@ msgstr "Afastar zoom"
 msgid "Toggle printable for object/part"
 msgstr "Alternar modo de impressão para objeto/peça"
 
+msgctxt "Keyboard Shortcut"
+msgid "Tab"
+msgstr ""
+
 msgid "Switch between Prepare/Preview"
 msgstr "Alternar entre Preparar/Pré-visualizar"
+
+msgctxt "Keyboard Shortcut"
+msgid "Space"
+msgstr ""
 
 msgid "Open actions speed dial"
 msgstr ""
@@ -11409,11 +11429,16 @@ msgstr "Ativar/Desativar janela de G-code"
 msgid "Move slider 5x faster"
 msgstr "Mover o controle deslizante 5 vezes mais rápido"
 
+msgctxt "Keyboard Shortcut"
+msgid "Home"
+msgstr ""
+
 msgid "Horizontal slider - Move to start position"
 msgstr "Barra deslizante horizontal — Mover para a posição inicial"
 
+msgctxt "Keyboard Shortcut"
 msgid "End"
-msgstr "Fim"
+msgstr ""
 
 msgid "Horizontal slider - Move to last position"
 msgstr "Barra deslizante horizontal — Mover para a última posição"
@@ -20748,6 +20773,30 @@ msgid ""
 msgstr ""
 "Evitar empenamento\n"
 "Você sabia que ao imprimir materiais propensos ao empenamento como ABS, aumentar adequadamente a temperatura da mesa aquecida pode reduzir a probabilidade de empenamento?"
+
+#~ msgid "Enter"
+#~ msgstr "Enter"
+
+#~ msgid "Esc"
+#~ msgstr "Esc"
+
+#~ msgid "Del"
+#~ msgstr "Del"
+
+#~ msgid "Arrow Up"
+#~ msgstr "Seta para cima"
+
+#~ msgid "Arrow Down"
+#~ msgstr "Seta para baixo"
+
+#~ msgid "Arrow Left"
+#~ msgstr "Seta para esquerda"
+
+#~ msgid "Arrow Right"
+#~ msgstr "Seta para direita"
+
+#~ msgid "End"
+#~ msgstr "Fim"
 
 #~ msgid "Hotend"
 #~ msgstr "Extrusora"

--- a/localization/i18n/pt_BR/OrcaSlicer_pt_BR.po
+++ b/localization/i18n/pt_BR/OrcaSlicer_pt_BR.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Orca Slicer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-20 10:39-0300\n"
+"POT-Creation-Date: 2026-07-23 14:21-0300\n"
 "PO-Revision-Date: 2026-07-22 20:39-0300\n"
 "Last-Translator: Alexandre Folle de Menezes\n"
 "Language-Team: Portuguese, Brazilian\n"
@@ -883,8 +883,9 @@ msgstr "Remover conector da seleção"
 msgid "Select all connectors"
 msgstr "Selecionar todos os conectores"
 
+msgctxt "Cut tool"
 msgid "Cut"
-msgstr "Cortar"
+msgstr ""
 
 msgid "Rotate cut plane"
 msgstr "Rotacionar plano de corte"
@@ -1857,8 +1858,9 @@ msgstr "Entrando no gizmo de Medida"
 msgid "Leaving Measure gizmo"
 msgstr "Saindo do gizmo de Medida"
 
+msgctxt "Assembly tool"
 msgid "Assemble"
-msgstr "Montar"
+msgstr ""
 
 msgid "Please confirm explosion ratio = 1 and select at least two volumes."
 msgstr "Por favor, confirme a taxa de explosão = 1 e selecione pelo menos dois volumes."
@@ -2723,6 +2725,9 @@ msgstr "Converter de Metros"
 
 msgid "Restore to Meter"
 msgstr "Restaurar para Metros"
+
+msgid "Assemble"
+msgstr "Montar"
 
 msgid "Assemble the selected objects into an object with multiple parts"
 msgstr "Montar os objetos selecionados em um objeto com várias peças"
@@ -4227,6 +4232,14 @@ msgstr "Imprimir usando filamento no carretel externo."
 msgid "Print with filament in AMS"
 msgstr "Imprimir com filamentos no AMS"
 
+msgctxt "Nozzle position"
+msgid "Left"
+msgstr ""
+
+msgctxt "Nozzle position"
+msgid "Right"
+msgstr ""
+
 msgid "When the current material run out, the printer will continue to print in the following order."
 msgstr "Quando o material atual acabar, a impressora continuará a imprimir na seguinte ordem."
 
@@ -5523,8 +5536,9 @@ msgstr "Adaptativo"
 msgid "Quality / Speed"
 msgstr "Qualidade / Velocidade"
 
+msgctxt "Mesh action"
 msgid "Smooth"
-msgstr "Suave"
+msgstr ""
 
 msgid "Radius"
 msgstr "Raio"
@@ -6144,6 +6158,9 @@ msgstr "Desfazer"
 msgid "Redo"
 msgstr "Refazer"
 
+msgid "Cut"
+msgstr "Cortar"
+
 msgid "Cut selection to clipboard"
 msgstr "Recortar seleção para área de transferência"
 
@@ -6244,6 +6261,10 @@ msgstr "Mostrar contorno ao redor do objeto selecionado na cena 3D."
 
 msgid "Preferences"
 msgstr "Preferências"
+
+msgctxt "Menu"
+msgid "Edit"
+msgstr ""
 
 msgid "View"
 msgstr "Visualizar"
@@ -9220,8 +9241,9 @@ msgstr "Incompatível"
 msgid "The selected preset is null!"
 msgstr "A predefinição selecionada é nula!"
 
+msgctxt "Layer range"
 msgid "End"
-msgstr "Fim"
+msgstr ""
 
 msgid "Customize"
 msgstr "Personalizar"
@@ -11389,6 +11411,9 @@ msgstr "Mover o controle deslizante 5 vezes mais rápido"
 
 msgid "Horizontal slider - Move to start position"
 msgstr "Barra deslizante horizontal — Mover para a posição inicial"
+
+msgid "End"
+msgstr "Fim"
 
 msgid "Horizontal slider - Move to last position"
 msgstr "Barra deslizante horizontal — Mover para a última posição"
@@ -15952,6 +15977,9 @@ msgstr "Se o modo suave ou tradicional for selecionado, um vídeo em timelapse s
 msgid "Traditional"
 msgstr "Tradicional"
 
+msgid "Smooth"
+msgstr "Suave"
+
 msgid "Farthest point timelapse"
 msgstr ""
 
@@ -16909,6 +16937,9 @@ msgstr "Quando este valor de retração for modificado, ele será usado como a q
 
 msgid "Support fast purge mode"
 msgstr "Suporte ao modo de purga rápida"
+
+msgid "Whether this printer supports fast purge mode with optimized temperature and multiplier."
+msgstr ""
 
 msgid "Filament change"
 msgstr ""
@@ -20628,7 +20659,8 @@ msgstr ""
 "Divida suas impressões em placas\n"
 "Você sabia que pode dividir um modelo que tem diversas peças em placas individuais distintas prontas para imprimir? Isso simplifica o processo de manter o controle de todas as peças."
 
-#: resources/data/hints.ini: [hint:Speed up your print with Adaptive Layer Height]
+#: resources/data/hints.ini: [hint:Speed up your print with Adaptive Layer
+#: Height]
 msgid ""
 "Speed up your print with Adaptive Layer Height\n"
 "Did you know that you can print a model even faster by using the Adaptive Layer Height option? Check it out!"
@@ -20700,7 +20732,8 @@ msgstr ""
 "Melhorar a resistência\n"
 "Você sabia que pode usar mais voltas de parede e maior densidade de preenchimento esparso mais alta para melhorar a resistência do modelo?"
 
-#: resources/data/hints.ini: [hint:When do you need to print with the printer door opened]
+#: resources/data/hints.ini: [hint:When do you need to print with the printer
+#: door opened]
 msgid ""
 "When do you need to print with the printer door opened?\n"
 "Did you know that opening the printer door can reduce the probability of extruder/hotend clogging when printing lower temperature filament with a higher enclosure temperature? There is more info about this in the Wiki."

--- a/localization/i18n/pt_BR/OrcaSlicer_pt_BR.po
+++ b/localization/i18n/pt_BR/OrcaSlicer_pt_BR.po
@@ -15693,16 +15693,16 @@ msgstr ""
 "Esta quantidade pode ser especificada em milímetros ou como uma porcentagem do diâmetro atual da extrusora. O valor padrão para este parâmetro é 10%."
 
 msgid "Scarf joint seam (beta)"
-msgstr "Costura junta cachecol (beta)"
+msgstr "Costura em bisel (beta)"
 
 msgid "Use scarf joint to minimize seam visibility and increase seam strength."
-msgstr "Usar a junta cachecol para minimizar a visibilidade da costura e aumentar a resistência da costura."
+msgstr "Use a junta em bisel para minimizar a visibilidade da costura e aumentar a resistência da costura."
 
 msgid "Conditional scarf joint"
-msgstr "Junta cachecol condicional"
+msgstr "Junta em bisel condicional"
 
 msgid "Apply scarf joints only to smooth perimeters where traditional seams do not conceal the seams at sharp corners effectively."
-msgstr "Aplique juntas cachecol apenas em perímetros suaves onde costuras tradicionais não escondem as costuras em cantos agudos de forma eficaz."
+msgstr "Aplique juntas em bisel apenas em perímetros suaves onde costuras tradicionais não escondem as costuras em cantos agudos de forma eficaz."
 
 msgid "Conditional angle threshold"
 msgstr "Limiar de ângulo condicional"
@@ -15711,61 +15711,61 @@ msgid ""
 "This option sets the threshold angle for applying a conditional scarf joint seam.\n"
 "If the maximum angle within the perimeter loop exceeds this value (indicating the absence of sharp corners), a scarf joint seam will be used. The default value is 155°."
 msgstr ""
-"Esta opção define o ângulo limiar para aplicar uma costura junta cachecol condicional.\n"
-"Se o ângulo máximo dentro da volta do perímetro exceder esse valor (indicando a ausência de cantos afiados), será usada uma costura junta cachecol. O valor padrão é 155°."
+"Esta opção define o ângulo limiar para aplicar uma costura em bisel condicional.\n"
+"Se o ângulo máximo dentro da volta do perímetro exceder esse valor (indicando a ausência de cantos afiados), será usada uma costura em bisel. O valor padrão é 155°."
 
 msgid "Conditional overhang threshold"
 msgstr "Limiar de saliência condicional"
 
 #, no-c-format, no-boost-format
 msgid "This option determines the overhang threshold for the application of scarf joint seams. If the unsupported portion of the perimeter is less than this threshold, scarf joint seams will be applied. The default threshold is set at 40% of the external wall's width. Due to performance considerations, the degree of overhang is estimated."
-msgstr "Esta opção determina o limiar de saliência para a aplicação de juntas cachecol. Se a parte sem suporte do perímetro for inferior a esse limiar, as costuras junta cachecol serão aplicadas. O limiar padrão é definido em 40% da largura da parede externa. Devido a considerações de desempenho, o grau de saliência é estimado."
+msgstr "Esta opção determina o limiar de saliência para a aplicação de juntas em bisel. Se a parte sem suporte do perímetro for inferior a esse limiar, as costuras junta em bisel serão aplicadas. O limiar padrão é definido em 40% da largura da parede externa. Devido a considerações de desempenho, o grau de saliência é estimado."
 
 msgid "Scarf joint speed"
-msgstr "Velocidade da junta cachecol"
+msgstr "Velocidade da junta em bisel"
 
 msgid "This option sets the printing speed for scarf joints. It is recommended to print scarf joints at a slow speed (less than 100 mm/s). It's also advisable to enable 'Extrusion rate smoothing' if the set speed varies significantly from the speed of the outer or inner walls. If the speed specified here is higher than the speed of the outer or inner walls, the printer will default to the slower of the two speeds. When specified as a percentage (e.g., 80%), the speed is calculated based on the respective outer or inner wall speed. The default value is set to 100%."
-msgstr "Esta opção define a velocidade de impressão para as juntas cachecol. É recomendável imprimir as juntas cachecol em uma velocidade baixa (menor que 100 mm/s). Também é aconselhável habilitar 'Suavização da taxa de extrusão' se a velocidade definida variar significativamente da velocidade das paredes externas ou internas. Se a velocidade especificada aqui for maior que a velocidade das paredes externas ou internas, a impressora utilizará a mais lenta das duas velocidades. Quando especificado como uma porcentagem (por exemplo, 80%), a velocidade é calculada com base na velocidade do perímetro externo ou interna respectiva. O valor padrão é definido como 100%."
+msgstr "Esta opção define a velocidade de impressão para as juntas em bisel. É recomendável imprimir as juntas em bisel em uma velocidade baixa (menor que 100 mm/s). Também é aconselhável habilitar 'Suavização da taxa de extrusão' se a velocidade definida variar significativamente da velocidade das paredes externas ou internas. Se a velocidade especificada aqui for maior que a velocidade das paredes externas ou internas, a impressora utilizará a mais lenta das duas velocidades. Quando especificado como uma porcentagem (por exemplo, 80%), a velocidade é calculada com base na velocidade do perímetro externo ou interna respectiva. O valor padrão é definido como 100%."
 
 msgid "Scarf joint flow ratio"
-msgstr "Taxa de fluxo em junta cachecol"
+msgstr "Taxa de fluxo da junta em bisel"
 
 msgid "This factor affects the amount of material for scarf joints."
-msgstr "Este fator afeta a quantidade de material para as juntas cachecol."
+msgstr "Este fator afeta a quantidade de material para as juntas em bisel."
 
 msgid "Scarf start height"
-msgstr "Altura inicial do cachecol"
+msgstr "Altura inicial do bisel"
 
 msgid ""
 "Start height of the scarf.\n"
 "This amount can be specified in millimeters or as a percentage of the current layer height. The default value for this parameter is 0."
 msgstr ""
-"Altura inicial do cachecol.\n"
+"Altura inicial do bisel.\n"
 "Esta quantidade pode ser especificada em milímetros ou como uma porcentagem da altura atual da camada. O valor padrão para este parâmetro é 0."
 
 msgid "Scarf around entire wall"
-msgstr "Cachecol em torno de toda a parede"
+msgstr "Bisel em torno de toda a parede"
 
 msgid "The scarf extends to the entire length of the wall."
-msgstr "O cachecol se estende por todo o comprimento da parede."
+msgstr "O bisel se estende por todo o comprimento da parede."
 
 msgid "Scarf length"
-msgstr "Comprimento do cachecol"
+msgstr "Comprimento do bisel"
 
 msgid "Length of the scarf. Setting this parameter to zero effectively disables the scarf."
-msgstr "Comprimento do cachecol. Definir este parâmetro como zero efetivamente desabilita o cachecol."
+msgstr "Comprimento do bisel. Definir este parâmetro como zero efetivamente desabilita o bisel."
 
 msgid "Scarf steps"
-msgstr "Degraus do cachecol"
+msgstr "Degraus do bisel"
 
 msgid "Minimum number of segments of each scarf."
-msgstr "Número mínimo de segmentos de cada cachecol."
+msgstr "Número mínimo de segmentos de cada bisel."
 
 msgid "Scarf joint for inner walls"
-msgstr "Junta cachecol em paredes internas"
+msgstr "Junta em bisel em paredes internas"
 
 msgid "Use scarf joint for inner walls as well."
-msgstr "Usar junta cachecol em paredes internas também."
+msgstr "Usar junta em bisel em paredes internas também."
 
 msgid "Role base wipe speed"
 msgstr "Velocidade de limpeza baseada na função"

--- a/localization/i18n/ru/OrcaSlicer_ru.po
+++ b/localization/i18n/ru/OrcaSlicer_ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OrcaSlicer V2.5.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-20 10:39-0300\n"
+"POT-Creation-Date: 2026-07-22 19:11-0300\n"
 "PO-Revision-Date: 2026-02-25 13:38+0300\n"
 "Last-Translator: Felix14_v2\n"
 "Language-Team: Felix14_v2 (ДС/ТГ: @felix14_v2, почта: aleks111001@list.ru), Andylg <andylg@yandex.ru>\n"
@@ -3606,9 +3606,10 @@ msgctxt "air_duct"
 msgid "Left(Aux)"
 msgstr "Левый (вспом.)"
 
-# FAN_HEAT_BREAK_0_IDX - охлаждение термобарьера в первом хотэнде 
+# FAN_HEAT_BREAK_0_IDX - охлаждение термобарьера в первом хотэнде
+msgctxt "Hotend Heat Breaker Fan"
 msgid "Hotend"
-msgstr "Термобарьер"
+msgstr ""
 
 msgid "Parts"
 msgstr "Основной"
@@ -9190,6 +9191,15 @@ msgstr "Отображать частоту кадров"
 msgid "Displays current viewport FPS in the top-right corner."
 msgstr "Выводить частоту кадров рабочего пространства в правом верхнем углу."
 
+msgid "G-code Preview"
+msgstr ""
+
+msgid "Dim lower layers"
+msgstr ""
+
+msgid "When scrubbing the layer slider in the sliced preview, render the layers below the current one darkened so that only the layer being viewed is shown at full brightness."
+msgstr ""
+
 msgid "Login region"
 msgstr "Регион входа"
 
@@ -9778,6 +9788,9 @@ msgstr "При включении режима вазы принтеры с ки
 
 msgid "The current printer does not support timelapse in Traditional Mode when printing By-Object."
 msgstr "Принтер не поддерживает таймлапс в режиме по умолчанию при печати моделей по очереди."
+
+msgid "I have checked the installed nozzle and want to print anyway."
+msgstr ""
 
 msgid "Errors"
 msgstr "Ошибок"
@@ -17764,6 +17777,12 @@ msgstr ""
 msgid "Whether this printer supports fast purge mode with optimized temperature and multiplier."
 msgstr ""
 
+msgid "Filament change"
+msgstr ""
+
+msgid "The volume of material required to prime the extruder on the tower, excluding a hotend change."
+msgstr ""
+
 msgid "The volume of material required to prime the extruder for a hotend change on the tower."
 msgstr ""
 
@@ -21047,16 +21066,14 @@ msgstr "Ошибка: %s"
 msgid "Show details"
 msgstr "Подробнее"
 
+msgid "Hide details"
+msgstr ""
+
 msgid "Version to install:"
 msgstr "Версия для установки:"
 
 msgid "Download and Install"
 msgstr "Загрузить и установить"
-
-# Делает то же самое, что и Remind Later, просто выводится при обнаружении
-# повреждения, а не при обновлении
-msgid "Skip for Now"
-msgstr "Напомнить позже"
 
 msgid "A new version of the Bambu Network Plug-in is available."
 msgstr "Доступна новая версия сетевого плагина Bambu."
@@ -21068,17 +21085,11 @@ msgstr "Текущая версия: %s"
 msgid "Update to version:"
 msgstr "Обновление до версии:"
 
-msgid "Update Now"
-msgstr "Установить обновление"
-
-msgid "Remind Later"
-msgstr "Напомнить позже"
-
-msgid "Skip Version"
-msgstr "Пропустить версию"
-
 msgid "Don't Ask Again"
 msgstr "Не напоминать"
+
+msgid "Update Now"
+msgstr "Установить обновление"
 
 msgid "(Latest)"
 msgstr "(новейшая)"
@@ -21095,9 +21106,6 @@ msgstr "Для загрузки плагина требуется перезап
 
 msgid "Restart Now"
 msgstr "Перезапустить сейчас"
-
-msgid "Restart Later"
-msgstr "Перезапустить позже"
 
 msgid "NO RAMMING AT ALL"
 msgstr "Рэмминг отключён"
@@ -21694,6 +21702,24 @@ msgid ""
 msgstr ""
 "Предотвращение коробления материала\n"
 "Знаете ли вы, что при печати материалами, склонными к короблению, таких как ABS, повышение температуры подогреваемого стола может снизить эту вероятность?"
+
+# FAN_HEAT_BREAK_0_IDX
+#~ msgid "Hotend"
+#~ msgstr "Термобарьер"
+
+# Делает то же самое, что и Remind Later, просто выводится при обнаружении
+# повреждения, а не при обновлении
+#~ msgid "Skip for Now"
+#~ msgstr "Напомнить позже"
+
+#~ msgid "Remind Later"
+#~ msgstr "Напомнить позже"
+
+#~ msgid "Skip Version"
+#~ msgstr "Пропустить версию"
+
+#~ msgid "Restart Later"
+#~ msgstr "Перезапустить позже"
 
 #~ msgid "Select filament that installed to the left nozzle"
 #~ msgstr "Выберите филамент, установленный в левое сопло"

--- a/localization/i18n/ru/OrcaSlicer_ru.po
+++ b/localization/i18n/ru/OrcaSlicer_ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OrcaSlicer V2.5.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-23 14:21-0300\n"
+"POT-Creation-Date: 2026-07-23 15:24-0300\n"
 "PO-Revision-Date: 2026-02-25 13:38+0300\n"
 "Last-Translator: Felix14_v2\n"
 "Language-Team: Felix14_v2 (ДС/ТГ: @felix14_v2, почта: aleks111001@list.ru), Andylg <andylg@yandex.ru>\n"
@@ -570,7 +570,7 @@ msgstr "Применить"
 msgid "Reset"
 msgstr "Сброс"
 
-# Пока только в двух местах в значении названия клавиши
+msgctxt "Keyboard Shortcut"
 msgid "Enter"
 msgstr "Enter"
 
@@ -1796,12 +1796,14 @@ msgstr "Выбрать"
 msgid "Select point"
 msgstr "Выбрать точку"
 
+msgctxt "Keyboard Shortcut"
 msgid "Delete"
 msgstr "Удалить"
 
 msgid "Restart selection"
 msgstr "Выбрать заново"
 
+msgctxt "Keyboard Shortcut"
 msgid "Esc"
 msgstr "Esc"
 
@@ -2488,6 +2490,9 @@ msgstr "Не удалось запустить загрузку по URL-адр�
 msgid "Import File"
 msgstr "Импорт файла"
 
+msgid "Delete"
+msgstr "Удалить"
+
 msgid "Choose files"
 msgstr "Выберите файлы"
 
@@ -2606,12 +2611,14 @@ msgstr "Скрыть"
 msgid "Show"
 msgstr "Показать"
 
+msgctxt "Keyboard Shortcut"
 msgid "Del"
 msgstr "Del"
 
 msgid "Delete the selected object"
 msgstr "Удаление выбранных моделей"
 
+msgctxt "Keyboard Shortcut"
 msgid "Backspace"
 msgstr "Backspace"
 
@@ -11571,24 +11578,28 @@ msgstr "Выбор нескольких моделей"
 msgid "Select objects by rectangle"
 msgstr "Выбор прямоугольником"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Up"
 msgstr "Стрелка вверх"
 
 msgid "Move selection 10mm in positive Y direction"
 msgstr "Перемещение выбранного на +10 мм по оси Y"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Down"
 msgstr "Стрелка вниз"
 
 msgid "Move selection 10mm in negative Y direction"
 msgstr "Перемещение выбранного на -10 мм по оси Y"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Left"
 msgstr "Стрелка влево"
 
 msgid "Move selection 10mm in negative X direction"
 msgstr "Перемещение выбранного на -10 мм по оси X"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Right"
 msgstr "Стрелка вправо"
 
@@ -11674,8 +11685,16 @@ msgstr "Отдалить"
 msgid "Toggle printable for object/part"
 msgstr "Переключить печать модели"
 
+msgctxt "Keyboard Shortcut"
+msgid "Tab"
+msgstr "Tab"
+
 msgid "Switch between Prepare/Preview"
 msgstr "Переключение между подготовкой и просмотром нарезки"
+
+msgctxt "Keyboard Shortcut"
+msgid "Space"
+msgstr "Пробел"
 
 msgid "Open actions speed dial"
 msgstr ""
@@ -11735,12 +11754,16 @@ msgstr "Показать/скрыть окно отображения G-кода
 msgid "Move slider 5x faster"
 msgstr "Перемещение ползунка быстрее в 5 раз"
 
+msgctxt "Keyboard Shortcut"
+msgid "Home"
+msgstr "Home"
+
 msgid "Horizontal slider - Move to start position"
 msgstr "Горизонтальный ползунок - перемещение в начальную позицию"
 
-# ?????? не переводим, пока #6970 не исправят
+msgctxt "Keyboard Shortcut"
 msgid "End"
-msgstr ""
+msgstr "End"
 
 msgid "Horizontal slider - Move to last position"
 msgstr "Горизонтальный ползунок - перемещение в конечную позицию"
@@ -21730,6 +21753,16 @@ msgid ""
 msgstr ""
 "Предотвращение коробления материала\n"
 "Знаете ли вы, что при печати материалами, склонными к короблению, таких как ABS, повышение температуры подогреваемого стола может снизить эту вероятность?"
+
+# Пока только в двух местах в значении названия клавиши
+#~ msgid "Enter"
+#~ msgstr "Enter"
+
+#~ msgid "Esc"
+#~ msgstr "Esc"
+
+#~ msgid "Backspace"
+#~ msgstr "Backspace"
 
 # FAN_HEAT_BREAK_0_IDX
 #~ msgid "Hotend"

--- a/localization/i18n/ru/OrcaSlicer_ru.po
+++ b/localization/i18n/ru/OrcaSlicer_ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OrcaSlicer V2.5.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-22 19:11-0300\n"
+"POT-Creation-Date: 2026-07-23 14:21-0300\n"
 "PO-Revision-Date: 2026-02-25 13:38+0300\n"
 "Last-Translator: Felix14_v2\n"
 "Language-Team: Felix14_v2 (ДС/ТГ: @felix14_v2, почта: aleks111001@list.ru), Andylg <andylg@yandex.ru>\n"
@@ -906,10 +906,9 @@ msgstr "Снять выбор"
 msgid "Select all connectors"
 msgstr "Выбрать все соединения"
 
-# Разный перевод одного слова -Одно название действия Разрезать в другой в
-# Правке -> Вырезать
+msgctxt "Cut tool"
 msgid "Cut"
-msgstr "Разрезать/вырезать"
+msgstr ""
 
 msgid "Rotate cut plane"
 msgstr "Поворот секущей плоскости"
@@ -1910,9 +1909,9 @@ msgstr "Запуск режима измерения"
 msgid "Leaving Measure gizmo"
 msgstr "Выход из режима измерения"
 
-# при выборе на столе
+msgctxt "Assembly tool"
 msgid "Assemble"
-msgstr "Объединить в сборку"
+msgstr ""
 
 msgid "Please confirm explosion ratio = 1 and select at least two volumes."
 msgstr "Отключите разнесение и выберите несколько частей."
@@ -2805,6 +2804,10 @@ msgstr "Преобразовать миллиметры в дюймы"
 
 msgid "Restore to Meter"
 msgstr "Восстановить в миллиметры"
+
+# при выборе на столе
+msgid "Assemble"
+msgstr "Объединить в сборку"
 
 msgid "Assemble the selected objects into an object with multiple parts"
 msgstr "Объединение выбранных объектов в модель, состоящую из нескольких частей"
@@ -4361,6 +4364,14 @@ msgstr "Использовать для печати материал с вне�
 msgid "Print with filament in AMS"
 msgstr "Печать материалом из AMS"
 
+msgctxt "Nozzle position"
+msgid "Left"
+msgstr ""
+
+msgctxt "Nozzle position"
+msgid "Right"
+msgstr ""
+
 msgid "When the current material run out, the printer will continue to print in the following order."
 msgstr "Когда текущий материал закончится, принтер продолжит печать в указанном порядке."
 
@@ -5711,8 +5722,9 @@ msgstr "Адаптировать"
 msgid "Quality / Speed"
 msgstr "Качество/Скорость"
 
+msgctxt "Mesh action"
 msgid "Smooth"
-msgstr "Сгладить"
+msgstr ""
 
 msgid "Radius"
 msgstr "Радиус"
@@ -6365,6 +6377,11 @@ msgstr "Отменить"
 msgid "Redo"
 msgstr "Повторить"
 
+# Разный перевод одного слова -Одно название действия Разрезать в другой в
+# Правке -> Вырезать
+msgid "Cut"
+msgstr "Разрезать/вырезать"
+
 msgid "Cut selection to clipboard"
 msgstr "Вырезать выбранное в буфер обмена"
 
@@ -6463,6 +6480,10 @@ msgstr "Отображение контура вокруг выбранных м
 
 msgid "Preferences"
 msgstr "Настройки"
+
+msgctxt "Menu"
+msgid "Edit"
+msgstr ""
 
 msgid "View"
 msgstr "Вид"
@@ -9497,7 +9518,7 @@ msgstr "Несовместимы"
 msgid "The selected preset is null!"
 msgstr "Выбранный профиль пуст!"
 
-# ?????? не переводим, пока #6970 не исправят
+msgctxt "Layer range"
 msgid "End"
 msgstr ""
 
@@ -11717,6 +11738,10 @@ msgstr "Перемещение ползунка быстрее в 5 раз"
 msgid "Horizontal slider - Move to start position"
 msgstr "Горизонтальный ползунок - перемещение в начальную позицию"
 
+# ?????? не переводим, пока #6970 не исправят
+msgid "End"
+msgstr ""
+
 msgid "Horizontal slider - Move to last position"
 msgstr "Горизонтальный ползунок - перемещение в конечную позицию"
 
@@ -13523,8 +13548,7 @@ msgid ""
 "Using “Top surface expansion” may cause a surface that did not previously touch the model's outer walls to now do so.\n"
 "This can cause contraction marks (such as the hull line) on the outer walls.\n"
 "By adding a small margin, this contraction will not occur directly on the walls, thereby preventing a visible mark."
-msgstr ""
-"Расширение закрытой поверхности (например, окружённой стенками впадины) может привести к её сцеплению с внешним контуром модели, что повышает риск возникновения дефектов усадки. Добавление отступа позволяет избежать этого."
+msgstr "Расширение закрытой поверхности (например, окружённой стенками впадины) может привести к её сцеплению с внешним контуром модели, что повышает риск возникновения дефектов усадки. Добавление отступа позволяет избежать этого."
 
 msgid "Top expansion direction"
 msgstr "Направление расширения"
@@ -14329,7 +14353,8 @@ msgstr "Относительные углы"
 msgid ""
 "Aligns infill, bridge, ironing, and top/bottom surface directions to follow the model's orientation on the build plate.\n"
 "When enabled, these directions rotate together with the model so the printed features keep their intended orientation relative to the part, preserving optimal strength and surface characteristics regardless of how the model is placed."
-msgstr "Учитывать вращение модели при расчёте угла мостов, заполнения и разглаживания.\n"
+msgstr ""
+"Учитывать вращение модели при расчёте угла мостов, заполнения и разглаживания.\n"
 "Позволяет сохранять направленность линий относительно модели независимо от её поворота на столе."
 
 msgid "Insert solid layers"
@@ -16676,6 +16701,9 @@ msgstr "На протяжении всей печати встроенная к�
 
 msgid "Traditional"
 msgstr "По умолчанию"
+
+msgid "Smooth"
+msgstr "Сгладить"
 
 msgid "Farthest point timelapse"
 msgstr ""

--- a/localization/i18n/sv/OrcaSlicer_sv.po
+++ b/localization/i18n/sv/OrcaSlicer_sv.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Orca Slicer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-22 19:11-0300\n"
+"POT-Creation-Date: 2026-07-23 14:21-0300\n"
 "Language: sv\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -882,8 +882,9 @@ msgstr "Ta bort kontakten från urvalet"
 msgid "Select all connectors"
 msgstr "Välj alla kontakter"
 
+msgctxt "Cut tool"
 msgid "Cut"
-msgstr "Beskär"
+msgstr ""
 
 msgid "Rotate cut plane"
 msgstr ""
@@ -1847,8 +1848,9 @@ msgstr ""
 msgid "Leaving Measure gizmo"
 msgstr ""
 
+msgctxt "Assembly tool"
 msgid "Assemble"
-msgstr "Montera"
+msgstr ""
 
 msgid "Please confirm explosion ratio = 1 and select at least two volumes."
 msgstr ""
@@ -2701,6 +2703,9 @@ msgstr "Konvertera ifrån meter"
 # TODO: Review, changed by lang refactor. PR 14254
 msgid "Restore to Meter"
 msgstr "Återställ till meter"
+
+msgid "Assemble"
+msgstr "Montera"
 
 msgid "Assemble the selected objects into an object with multiple parts"
 msgstr "Montera de valda objekten till ett objekt med multipla delar"
@@ -4230,6 +4235,14 @@ msgstr "Skriv ut med filament på en extern spole."
 msgid "Print with filament in AMS"
 msgstr "Skriv ut med filament i AMS"
 
+msgctxt "Nozzle position"
+msgid "Left"
+msgstr ""
+
+msgctxt "Nozzle position"
+msgid "Right"
+msgstr ""
+
 msgid "When the current material run out, the printer will continue to print in the following order."
 msgstr "När det aktuella materialet tar slut, fortsätter printern att skriva ut material i följande ordning."
 
@@ -5528,6 +5541,7 @@ msgstr "Adaptiv"
 msgid "Quality / Speed"
 msgstr "Kvalitet/Hastighet"
 
+msgctxt "Mesh action"
 msgid "Smooth"
 msgstr ""
 
@@ -6146,6 +6160,9 @@ msgstr "Ångra"
 msgid "Redo"
 msgstr "Gör om"
 
+msgid "Cut"
+msgstr "Beskär"
+
 msgid "Cut selection to clipboard"
 msgstr "Klipp ut markeringen till urklipp"
 
@@ -6246,6 +6263,10 @@ msgstr ""
 
 msgid "Preferences"
 msgstr "Inställningar"
+
+msgctxt "Menu"
+msgid "Edit"
+msgstr ""
 
 msgid "View"
 msgstr "Vy"
@@ -9188,8 +9209,9 @@ msgstr "Inkompatibel"
 msgid "The selected preset is null!"
 msgstr "Den valda förinställningen är noll!"
 
+msgctxt "Layer range"
 msgid "End"
-msgstr "Slut"
+msgstr ""
 
 msgid "Customize"
 msgstr "Anpassa"
@@ -11318,6 +11340,9 @@ msgstr "Flytta reglage 5x snabbare"
 
 msgid "Horizontal slider - Move to start position"
 msgstr ""
+
+msgid "End"
+msgstr "Slut"
 
 msgid "Horizontal slider - Move to last position"
 msgstr ""
@@ -15595,6 +15620,9 @@ msgstr "Om Smooth eller Traditionellt läge väljs genereras en timelapse-video 
 
 msgid "Traditional"
 msgstr "Traditionell"
+
+msgid "Smooth"
+msgstr ""
 
 msgid "Farthest point timelapse"
 msgstr ""

--- a/localization/i18n/sv/OrcaSlicer_sv.po
+++ b/localization/i18n/sv/OrcaSlicer_sv.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Orca Slicer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-23 14:21-0300\n"
+"POT-Creation-Date: 2026-07-23 15:24-0300\n"
 "Language: sv\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -551,6 +551,7 @@ msgstr "Mappa om"
 msgid "Reset"
 msgstr "Återställ"
 
+msgctxt "Keyboard Shortcut"
 msgid "Enter"
 msgstr ""
 
@@ -1742,12 +1743,14 @@ msgstr "Välj"
 msgid "Select point"
 msgstr ""
 
+msgctxt "Keyboard Shortcut"
 msgid "Delete"
-msgstr "Radera"
+msgstr ""
 
 msgid "Restart selection"
 msgstr ""
 
+msgctxt "Keyboard Shortcut"
 msgid "Esc"
 msgstr ""
 
@@ -2371,6 +2374,9 @@ msgstr ""
 msgid "Import File"
 msgstr "Importera fil"
 
+msgid "Delete"
+msgstr "Radera"
+
 msgid "Choose files"
 msgstr "Välj filer"
 
@@ -2501,14 +2507,16 @@ msgstr "Dölj"
 msgid "Show"
 msgstr "Visa"
 
+msgctxt "Keyboard Shortcut"
 msgid "Del"
 msgstr ""
 
 msgid "Delete the selected object"
 msgstr "Radera det valda objektet"
 
+msgctxt "Keyboard Shortcut"
 msgid "Backspace"
-msgstr "Backsteg"
+msgstr ""
 
 msgid "Load..."
 msgstr "Ladda..."
@@ -11169,29 +11177,33 @@ msgstr "Välj flera objekt"
 msgid "Select objects by rectangle"
 msgstr "Välj objekt efter rektangel"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Up"
-msgstr "Pil Upp"
+msgstr ""
 
 # TODO: Review, changed by lang refactor. PR 14254
 msgid "Move selection 10mm in positive Y direction"
 msgstr "Flytta markeringen 10mm i positiv Y riktning"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Down"
-msgstr "Pil Ner"
+msgstr ""
 
 # TODO: Review, changed by lang refactor. PR 14254
 msgid "Move selection 10mm in negative Y direction"
 msgstr "Flytta markeringen 10mm i negativ Y riktning"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Left"
-msgstr "Pil Vänster"
+msgstr ""
 
 # TODO: Review, changed by lang refactor. PR 14254
 msgid "Move selection 10mm in negative X direction"
 msgstr "Flytta markeringen 10mm i negativ X riktning"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Right"
-msgstr "Pil Höger"
+msgstr ""
 
 # TODO: Review, changed by lang refactor. PR 14254
 msgid "Move selection 10mm in positive X direction"
@@ -11277,8 +11289,16 @@ msgstr "Zooma ut"
 msgid "Toggle printable for object/part"
 msgstr ""
 
+msgctxt "Keyboard Shortcut"
+msgid "Tab"
+msgstr ""
+
 msgid "Switch between Prepare/Preview"
 msgstr "Växla mellan Förbered/Förhandsgranska"
+
+msgctxt "Keyboard Shortcut"
+msgid "Space"
+msgstr ""
 
 msgid "Open actions speed dial"
 msgstr ""
@@ -11338,11 +11358,16 @@ msgstr ""
 msgid "Move slider 5x faster"
 msgstr "Flytta reglage 5x snabbare"
 
+msgctxt "Keyboard Shortcut"
+msgid "Home"
+msgstr ""
+
 msgid "Horizontal slider - Move to start position"
 msgstr ""
 
+msgctxt "Keyboard Shortcut"
 msgid "End"
-msgstr "Slut"
+msgstr ""
 
 msgid "Horizontal slider - Move to last position"
 msgstr ""
@@ -20294,6 +20319,24 @@ msgid ""
 msgstr ""
 "Undvik vridning\n"
 "Visste du att när du skriver ut material som är benägna att vrida, såsom ABS, kan en lämplig ökning av värmebäddens temperatur minska sannolikheten för vridning?"
+
+#~ msgid "Backspace"
+#~ msgstr "Backsteg"
+
+#~ msgid "Arrow Up"
+#~ msgstr "Pil Upp"
+
+#~ msgid "Arrow Down"
+#~ msgstr "Pil Ner"
+
+#~ msgid "Arrow Left"
+#~ msgstr "Pil Vänster"
+
+#~ msgid "Arrow Right"
+#~ msgstr "Pil Höger"
+
+#~ msgid "End"
+#~ msgstr "Slut"
 
 #~ msgid "Hotend"
 #~ msgstr "Hotend"

--- a/localization/i18n/sv/OrcaSlicer_sv.po
+++ b/localization/i18n/sv/OrcaSlicer_sv.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Orca Slicer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-20 10:39-0300\n"
+"POT-Creation-Date: 2026-07-22 19:11-0300\n"
 "Language: sv\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -3479,8 +3479,9 @@ msgctxt "air_duct"
 msgid "Left(Aux)"
 msgstr ""
 
+msgctxt "Hotend Heat Breaker Fan"
 msgid "Hotend"
-msgstr "Hotend"
+msgstr ""
 
 msgid "Parts"
 msgstr "Delar"
@@ -8887,6 +8888,15 @@ msgstr ""
 msgid "Displays current viewport FPS in the top-right corner."
 msgstr ""
 
+msgid "G-code Preview"
+msgstr ""
+
+msgid "Dim lower layers"
+msgstr ""
+
+msgid "When scrubbing the layer slider in the sliced preview, render the layers below the current one darkened so that only the layer being viewed is shown at full brightness."
+msgstr ""
+
 msgid "Login region"
 msgstr "Logga in region"
 
@@ -9463,6 +9473,9 @@ msgid "When spiral vase mode is enabled, machines with I3 structure will not gen
 msgstr "When enable spiral vase mode, machines with I3 structure will not generate timelapse videos."
 
 msgid "The current printer does not support timelapse in Traditional Mode when printing By-Object."
+msgstr ""
+
+msgid "I have checked the installed nozzle and want to print anyway."
 msgstr ""
 
 msgid "Errors"
@@ -16525,6 +16538,12 @@ msgstr ""
 msgid "Whether this printer supports fast purge mode with optimized temperature and multiplier."
 msgstr ""
 
+msgid "Filament change"
+msgstr ""
+
+msgid "The volume of material required to prime the extruder on the tower, excluding a hotend change."
+msgstr ""
+
 msgid "The volume of material required to prime the extruder for a hotend change on the tower."
 msgstr "Volymen av material som krävs för att prima extrudern för en hotend förändring på tower."
 
@@ -19652,13 +19671,13 @@ msgstr ""
 msgid "Show details"
 msgstr ""
 
+msgid "Hide details"
+msgstr ""
+
 msgid "Version to install:"
 msgstr ""
 
 msgid "Download and Install"
-msgstr ""
-
-msgid "Skip for Now"
 msgstr ""
 
 msgid "A new version of the Bambu Network Plug-in is available."
@@ -19671,16 +19690,10 @@ msgstr ""
 msgid "Update to version:"
 msgstr ""
 
-msgid "Update Now"
-msgstr ""
-
-msgid "Remind Later"
-msgstr ""
-
-msgid "Skip Version"
-msgstr ""
-
 msgid "Don't Ask Again"
+msgstr ""
+
+msgid "Update Now"
 msgstr ""
 
 msgid "(Latest)"
@@ -19696,9 +19709,6 @@ msgid "A restart is required to load the new plug-in. Would you like to restart 
 msgstr ""
 
 msgid "Restart Now"
-msgstr ""
-
-msgid "Restart Later"
 msgstr ""
 
 msgid "NO RAMMING AT ALL"
@@ -20256,6 +20266,9 @@ msgid ""
 msgstr ""
 "Undvik vridning\n"
 "Visste du att när du skriver ut material som är benägna att vrida, såsom ABS, kan en lämplig ökning av värmebäddens temperatur minska sannolikheten för vridning?"
+
+#~ msgid "Hotend"
+#~ msgstr "Hotend"
 
 #~ msgid "Select Filament && Hotends"
 #~ msgstr "Välj Filament && Hotends"

--- a/localization/i18n/th/OrcaSlicer_th.po
+++ b/localization/i18n/th/OrcaSlicer_th.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Orca Slicer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-20 10:39-0300\n"
+"POT-Creation-Date: 2026-07-22 19:11-0300\n"
 "PO-Revision-Date: 2026-06-19 13:40+0700\n"
 "Last-Translator: Icezaza\n"
 "Language-Team: Thai\n"
@@ -3449,8 +3449,9 @@ msgctxt "air_duct"
 msgid "Left(Aux)"
 msgstr "ซ้าย(เสริม)"
 
+msgctxt "Hotend Heat Breaker Fan"
 msgid "Hotend"
-msgstr "ฮอตเอนด์"
+msgstr ""
 
 msgid "Parts"
 msgstr "ชิ้นส่วน"
@@ -8823,6 +8824,15 @@ msgstr "แสดงการซ้อนทับ FPS"
 msgid "Displays current viewport FPS in the top-right corner."
 msgstr "แสดงวิวพอร์ต FPS ปัจจุบันที่มุมขวาบน"
 
+msgid "G-code Preview"
+msgstr ""
+
+msgid "Dim lower layers"
+msgstr ""
+
+msgid "When scrubbing the layer slider in the sliced preview, render the layers below the current one darkened so that only the layer being viewed is shown at full brightness."
+msgstr ""
+
 msgid "Login region"
 msgstr "เข้าสู่ระบบภูมิภาค"
 
@@ -9399,6 +9409,9 @@ msgstr "เมื่อเปิดใช้งานโหมดแจกัน
 
 msgid "The current printer does not support timelapse in Traditional Mode when printing By-Object."
 msgstr "เครื่องพิมพ์ปัจจุบันไม่รองรับไทม์แลปส์ในโหมดดั้งเดิมเมื่อพิมพ์ By-Object"
+
+msgid "I have checked the installed nozzle and want to print anyway."
+msgstr ""
 
 msgid "Errors"
 msgstr "ข้อผิดพลาด"
@@ -16720,6 +16733,12 @@ msgstr ""
 msgid "Whether this printer supports fast purge mode with optimized temperature and multiplier."
 msgstr ""
 
+msgid "Filament change"
+msgstr ""
+
+msgid "The volume of material required to prime the extruder on the tower, excluding a hotend change."
+msgstr ""
+
 msgid "The volume of material required to prime the extruder for a hotend change on the tower."
 msgstr ""
 
@@ -19900,14 +19919,14 @@ msgstr "ข้อผิดพลาด: %s"
 msgid "Show details"
 msgstr "แสดงรายละเอียด"
 
+msgid "Hide details"
+msgstr ""
+
 msgid "Version to install:"
 msgstr "เวอร์ชันที่จะติดตั้ง:"
 
 msgid "Download and Install"
 msgstr "ดาวน์โหลดและติดตั้ง"
-
-msgid "Skip for Now"
-msgstr "ข้ามไปก่อน"
 
 msgid "A new version of the Bambu Network Plug-in is available."
 msgstr "ปลั๊กอิน Bambu Network Plug-in เวอร์ชันใหม่พร้อมใช้งานแล้ว"
@@ -19919,17 +19938,11 @@ msgstr "เวอร์ชันปัจจุบัน: %s"
 msgid "Update to version:"
 msgstr "อัปเดตเป็นเวอร์ชัน:"
 
-msgid "Update Now"
-msgstr "อัปเดตตอนนี้"
-
-msgid "Remind Later"
-msgstr "เตือนทีหลัง"
-
-msgid "Skip Version"
-msgstr "ข้ามเวอร์ชัน"
-
 msgid "Don't Ask Again"
 msgstr "อย่าถามอีก"
+
+msgid "Update Now"
+msgstr "อัปเดตตอนนี้"
 
 msgid "(Latest)"
 msgstr "(ล่าสุด)"
@@ -19945,9 +19958,6 @@ msgstr "จำเป็นต้องรีสตาร์ทเพื่อโ
 
 msgid "Restart Now"
 msgstr "เริ่มใหม่ตอนนี้"
-
-msgid "Restart Later"
-msgstr "เริ่มใหม่ภายหลัง"
 
 msgid "NO RAMMING AT ALL"
 msgstr "ไม่มีการกระแทกเลย"
@@ -20527,6 +20537,21 @@ msgid ""
 msgstr ""
 "หลีกเลี่ยงการบิดเบี้ยว\n"
 "คุณรู้หรือไม่ว่าเมื่อพิมพ์วัสดุที่มีแนวโน้มที่จะเกิดการบิดเบี้ยว เช่น ABS การเพิ่มอุณหภูมิฐานพิมพ์อย่างเหมาะสมสามารถลดความน่าจะเป็นของการบิดเบี้ยวได้"
+
+#~ msgid "Hotend"
+#~ msgstr "ฮอตเอนด์"
+
+#~ msgid "Skip for Now"
+#~ msgstr "ข้ามไปก่อน"
+
+#~ msgid "Remind Later"
+#~ msgstr "เตือนทีหลัง"
+
+#~ msgid "Skip Version"
+#~ msgstr "ข้ามเวอร์ชัน"
+
+#~ msgid "Restart Later"
+#~ msgstr "เริ่มใหม่ภายหลัง"
 
 #~ msgid "Select filament that installed to the left nozzle"
 #~ msgstr "เลือกเส้นพลาสติกที่ติดตั้งไว้ที่หัวฉีดด้านซ้าย"

--- a/localization/i18n/th/OrcaSlicer_th.po
+++ b/localization/i18n/th/OrcaSlicer_th.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Orca Slicer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-22 19:11-0300\n"
+"POT-Creation-Date: 2026-07-23 14:21-0300\n"
 "PO-Revision-Date: 2026-06-19 13:40+0700\n"
 "Last-Translator: Icezaza\n"
 "Language-Team: Thai\n"
@@ -881,8 +881,9 @@ msgstr "ลบตัวเชื่อมต่อออกจากการเ
 msgid "Select all connectors"
 msgstr "เลือกตัวเชื่อมต่อทั้งหมด"
 
+msgctxt "Cut tool"
 msgid "Cut"
-msgstr "ตัด"
+msgstr ""
 
 msgid "Rotate cut plane"
 msgstr "หมุนระนาบการตัด"
@@ -1853,8 +1854,9 @@ msgstr "เข้าสู่กิซโมวัด"
 msgid "Leaving Measure gizmo"
 msgstr "ออกจากกิซโมวัด"
 
+msgctxt "Assembly tool"
 msgid "Assemble"
-msgstr "ประกอบ"
+msgstr ""
 
 msgid "Please confirm explosion ratio = 1 and select at least two volumes."
 msgstr "โปรดยืนยันอัตราส่วนการระเบิด = 1 และเลือกอย่างน้อยสองวอลุ่ม"
@@ -2705,6 +2707,9 @@ msgstr "แปลงจากเมตร"
 
 msgid "Restore to Meter"
 msgstr "คืนค่าเป็นเมตร"
+
+msgid "Assemble"
+msgstr "ประกอบ"
 
 msgid "Assemble the selected objects into an object with multiple parts"
 msgstr "ประกอบวัตถุที่เลือกให้เป็นวัตถุที่มีหลายส่วน"
@@ -4190,6 +4195,14 @@ msgstr "พิมพ์โดยใช้เส้นพลาสติกจา
 msgid "Print with filament in AMS"
 msgstr "พิมพ์ด้วยเส้นพลาสติกในระบบ AMS"
 
+msgctxt "Nozzle position"
+msgid "Left"
+msgstr ""
+
+msgctxt "Nozzle position"
+msgid "Right"
+msgstr ""
+
 msgid "When the current material run out, the printer will continue to print in the following order."
 msgstr "เมื่อวัสดุปัจจุบันหมด เครื่องพิมพ์จะพิมพ์ต่อตามลำดับต่อไปนี้"
 
@@ -5478,8 +5491,9 @@ msgstr "ปรับตัวได้"
 msgid "Quality / Speed"
 msgstr "คุณภาพ/ความเร็ว"
 
+msgctxt "Mesh action"
 msgid "Smooth"
-msgstr "เรียบ"
+msgstr ""
 
 msgid "Radius"
 msgstr "รัศมี"
@@ -6092,6 +6106,9 @@ msgstr "เลิกทำ"
 msgid "Redo"
 msgstr "ทำซ้ำ"
 
+msgid "Cut"
+msgstr "ตัด"
+
 msgid "Cut selection to clipboard"
 msgstr "ตัดส่วนที่เลือกไปที่คลิปบอร์ด"
 
@@ -6190,6 +6207,10 @@ msgstr "แสดงเค้าร่างรอบๆ วัตถุที�
 
 msgid "Preferences"
 msgstr "การตั้งค่า"
+
+msgctxt "Menu"
+msgid "Edit"
+msgstr ""
 
 msgid "View"
 msgstr "มุมมอง"
@@ -9121,8 +9142,9 @@ msgstr "เข้ากันไม่ได้"
 msgid "The selected preset is null!"
 msgstr "ค่าที่ตั้งล่วงหน้าที่เลือกเป็นโมฆะ!"
 
+msgctxt "Layer range"
 msgid "End"
-msgstr "จบ"
+msgstr ""
 
 msgid "Customize"
 msgstr "ปรับแต่ง"
@@ -11271,6 +11293,9 @@ msgstr "เลื่อนตัวเลื่อนเร็วขึ้น 5 
 
 msgid "Horizontal slider - Move to start position"
 msgstr "แถบเลื่อนแนวนอน - เลื่อนไปยังตำแหน่งเริ่มต้น"
+
+msgid "End"
+msgstr "จบ"
 
 msgid "Horizontal slider - Move to last position"
 msgstr "แถบเลื่อนแนวนอน - เลื่อนไปยังตำแหน่งสุดท้าย"
@@ -15783,6 +15808,9 @@ msgstr "หากเลือกโหมดเรียบหรือโหม
 
 msgid "Traditional"
 msgstr "แบบดั้งเดิม"
+
+msgid "Smooth"
+msgstr "เรียบ"
 
 msgid "Farthest point timelapse"
 msgstr ""

--- a/localization/i18n/th/OrcaSlicer_th.po
+++ b/localization/i18n/th/OrcaSlicer_th.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Orca Slicer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-23 14:21-0300\n"
+"POT-Creation-Date: 2026-07-23 15:24-0300\n"
 "PO-Revision-Date: 2026-06-19 13:40+0700\n"
 "Last-Translator: Icezaza\n"
 "Language-Team: Thai\n"
@@ -551,8 +551,9 @@ msgstr "รีแมป"
 msgid "Reset"
 msgstr "รีเซ็ต"
 
+msgctxt "Keyboard Shortcut"
 msgid "Enter"
-msgstr "เข้า"
+msgstr ""
 
 msgid "Shortcut Key "
 msgstr "ปุ่มลัด"
@@ -1742,14 +1743,16 @@ msgstr "เลือก"
 msgid "Select point"
 msgstr "เลือกจุด"
 
+msgctxt "Keyboard Shortcut"
 msgid "Delete"
-msgstr "ลบ"
+msgstr ""
 
 msgid "Restart selection"
 msgstr "เริ่มการเลือกใหม่"
 
+msgctxt "Keyboard Shortcut"
 msgid "Esc"
-msgstr "Esc"
+msgstr ""
 
 msgid "Cancel a feature until exit"
 msgstr "ยกเลิกคุณลักษณะจนกว่าจะออก"
@@ -2394,6 +2397,9 @@ msgstr "ไม่สามารถเริ่มการดาวน์โห
 msgid "Import File"
 msgstr "นำเข้าไฟล์"
 
+msgid "Delete"
+msgstr "ลบ"
+
 msgid "Choose files"
 msgstr "ไฟล์เลือก"
 
@@ -2512,14 +2518,16 @@ msgstr "ซ่อน"
 msgid "Show"
 msgstr "แสดง"
 
+msgctxt "Keyboard Shortcut"
 msgid "Del"
-msgstr "เดล"
+msgstr ""
 
 msgid "Delete the selected object"
 msgstr "ลบวัตถุที่เลือก"
 
+msgctxt "Keyboard Shortcut"
 msgid "Backspace"
-msgstr "แบ็คสเปซ"
+msgstr ""
 
 msgid "Load..."
 msgstr "โหลด..."
@@ -11129,26 +11137,30 @@ msgstr "เลือกหลายวัตถุ"
 msgid "Select objects by rectangle"
 msgstr "เลือกวัตถุตามสี่เหลี่ยม"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Up"
-msgstr "ลูกศรขึ้น"
+msgstr ""
 
 msgid "Move selection 10mm in positive Y direction"
 msgstr "เลื่อนส่วนที่เลือกไป 10 มม. ในทิศทางบวก Y"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Down"
-msgstr "ลูกศรลง"
+msgstr ""
 
 msgid "Move selection 10mm in negative Y direction"
 msgstr "ย้ายส่วนที่เลือกไป 10 มม. ในทิศทางลบ Y"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Left"
-msgstr "ลูกศรซ้าย"
+msgstr ""
 
 msgid "Move selection 10mm in negative X direction"
 msgstr "ย้ายส่วนที่เลือกไป 10 มม. ในทิศทาง X ลบ"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Right"
-msgstr "ลูกศรขวา"
+msgstr ""
 
 msgid "Move selection 10mm in positive X direction"
 msgstr "เลื่อนส่วนที่เลือกไป 10 มม. ในทิศทาง X บวก"
@@ -11231,8 +11243,16 @@ msgstr "ซูมออก"
 msgid "Toggle printable for object/part"
 msgstr "สลับการพิมพ์สำหรับวัตถุ/ชิ้นส่วน"
 
+msgctxt "Keyboard Shortcut"
+msgid "Tab"
+msgstr ""
+
 msgid "Switch between Prepare/Preview"
 msgstr "สลับระหว่างการเตรียม/ดูตัวอย่าง"
+
+msgctxt "Keyboard Shortcut"
+msgid "Space"
+msgstr ""
 
 msgid "Open actions speed dial"
 msgstr ""
@@ -11291,11 +11311,16 @@ msgstr "เปิด/ปิดหน้าต่างรหัส G"
 msgid "Move slider 5x faster"
 msgstr "เลื่อนตัวเลื่อนเร็วขึ้น 5 เท่า"
 
+msgctxt "Keyboard Shortcut"
+msgid "Home"
+msgstr ""
+
 msgid "Horizontal slider - Move to start position"
 msgstr "แถบเลื่อนแนวนอน - เลื่อนไปยังตำแหน่งเริ่มต้น"
 
+msgctxt "Keyboard Shortcut"
 msgid "End"
-msgstr "จบ"
+msgstr ""
 
 msgid "Horizontal slider - Move to last position"
 msgstr "แถบเลื่อนแนวนอน - เลื่อนไปยังตำแหน่งสุดท้าย"
@@ -20565,6 +20590,33 @@ msgid ""
 msgstr ""
 "หลีกเลี่ยงการบิดเบี้ยว\n"
 "คุณรู้หรือไม่ว่าเมื่อพิมพ์วัสดุที่มีแนวโน้มที่จะเกิดการบิดเบี้ยว เช่น ABS การเพิ่มอุณหภูมิฐานพิมพ์อย่างเหมาะสมสามารถลดความน่าจะเป็นของการบิดเบี้ยวได้"
+
+#~ msgid "Enter"
+#~ msgstr "เข้า"
+
+#~ msgid "Esc"
+#~ msgstr "Esc"
+
+#~ msgid "Del"
+#~ msgstr "เดล"
+
+#~ msgid "Backspace"
+#~ msgstr "แบ็คสเปซ"
+
+#~ msgid "Arrow Up"
+#~ msgstr "ลูกศรขึ้น"
+
+#~ msgid "Arrow Down"
+#~ msgstr "ลูกศรลง"
+
+#~ msgid "Arrow Left"
+#~ msgstr "ลูกศรซ้าย"
+
+#~ msgid "Arrow Right"
+#~ msgstr "ลูกศรขวา"
+
+#~ msgid "End"
+#~ msgstr "จบ"
 
 #~ msgid "Hotend"
 #~ msgstr "ฮอตเอนด์"

--- a/localization/i18n/th/OrcaSlicer_th.po
+++ b/localization/i18n/th/OrcaSlicer_th.po
@@ -15532,16 +15532,16 @@ msgstr ""
 "ปริมาณนี้สามารถระบุได้ในหน่วยมิลลิเมตรหรือเป็นเปอร์เซ็นต์ของเส้นผ่านศูนย์กลางของชุดดันเส้นในปัจจุบัน ค่าเริ่มต้นสำหรับพารามิเตอร์นี้คือ 10%"
 
 msgid "Scarf joint seam (beta)"
-msgstr "รอยต่อผ้าพันคอ (เบต้า)"
+msgstr "รอยต่อเฉียง (เบต้า)"
 
 msgid "Use scarf joint to minimize seam visibility and increase seam strength."
-msgstr "ใช้ข้อต่อผ้าพันคอเพื่อลดการมองเห็นรอยตะเข็บและเพิ่มความแข็งแรงของรอยตะเข็บ"
+msgstr "ใช้ข้อต่อเฉียงเพื่อลดการมองเห็นรอยตะเข็บและเพิ่มความแข็งแรงของรอยตะเข็บ"
 
 msgid "Conditional scarf joint"
-msgstr "ข้อต่อผ้าพันคอแบบมีเงื่อนไข"
+msgstr "ข้อต่อเฉียงแบบมีเงื่อนไข"
 
 msgid "Apply scarf joints only to smooth perimeters where traditional seams do not conceal the seams at sharp corners effectively."
-msgstr "ใช้ข้อต่อผ้าพันคอกับขอบเรียบเท่านั้น โดยที่รอยตะเข็บแบบเดิมไม่สามารถปกปิดรอยตะเข็บที่มุมแหลมคมได้อย่างมีประสิทธิภาพ"
+msgstr "ใช้ข้อต่อเฉียงกับขอบเรียบเท่านั้น โดยที่รอยตะเข็บแบบเดิมไม่สามารถปกปิดรอยตะเข็บที่มุมแหลมคมได้อย่างมีประสิทธิภาพ"
 
 msgid "Conditional angle threshold"
 msgstr "เกณฑ์มุมแบบมีเงื่อนไข"
@@ -15550,61 +15550,61 @@ msgid ""
 "This option sets the threshold angle for applying a conditional scarf joint seam.\n"
 "If the maximum angle within the perimeter loop exceeds this value (indicating the absence of sharp corners), a scarf joint seam will be used. The default value is 155°."
 msgstr ""
-"ตัวเลือกนี้จะกำหนดมุมเกณฑ์สำหรับการใช้รอยตะเข็บข้อต่อผ้าพันคอแบบมีเงื่อนไข\n"
-"หากมุมสูงสุดภายในวงรอบปริมณฑลเกินค่านี้ (แสดงว่าไม่มีมุมแหลมคม) จะใช้รอยตะเข็บข้อต่อผ้าพันคอ ค่าเริ่มต้นคือ 155°"
+"ตัวเลือกนี้จะกำหนดมุมเกณฑ์สำหรับการใช้รอยตะเข็บข้อต่อเฉียงแบบมีเงื่อนไข\n"
+"หากมุมสูงสุดภายในวงรอบปริมณฑลเกินค่านี้ (แสดงว่าไม่มีมุมแหลมคม) จะใช้รอยตะเข็บข้อต่อเฉียง ค่าเริ่มต้นคือ 155°"
 
 msgid "Conditional overhang threshold"
 msgstr "เกณฑ์ระยะยื่นแบบมีเงื่อนไข"
 
 #, no-c-format, no-boost-format
 msgid "This option determines the overhang threshold for the application of scarf joint seams. If the unsupported portion of the perimeter is less than this threshold, scarf joint seams will be applied. The default threshold is set at 40% of the external wall's width. Due to performance considerations, the degree of overhang is estimated."
-msgstr "ตัวเลือกนี้จะกำหนดเกณฑ์ส่วนยื่นสำหรับการใช้รอยตะเข็บข้อต่อผ้าพันคอ หากส่วนที่ไม่ได้รับส่วนรองรับของเส้นรอบวงน้อยกว่าเกณฑ์นี้ จะมีการเย็บรอยตะเข็บผ้าพันคอ เกณฑ์เริ่มต้นตั้งไว้ที่ 40% ของความกว้างของผนังภายนอก เมื่อพิจารณาถึงประสิทธิภาพแล้ว ระดับของระยะยื่นจึงถูกประมาณไว้"
+msgstr "ตัวเลือกนี้จะกำหนดเกณฑ์ส่วนยื่นสำหรับการใช้รอยตะเข็บข้อต่อเฉียง หากส่วนที่ไม่ได้รับส่วนรองรับของเส้นรอบวงน้อยกว่าเกณฑ์นี้ จะมีการเย็บรอยตะเข็บเฉียง เกณฑ์เริ่มต้นตั้งไว้ที่ 40% ของความกว้างของผนังภายนอก เมื่อพิจารณาถึงประสิทธิภาพแล้ว ระดับของระยะยื่นจึงถูกประมาณไว้"
 
 msgid "Scarf joint speed"
-msgstr "ความเร็วของข้อต่อผ้าพันคอ"
+msgstr "ความเร็วของข้อต่อเฉียง"
 
 msgid "This option sets the printing speed for scarf joints. It is recommended to print scarf joints at a slow speed (less than 100 mm/s). It's also advisable to enable 'Extrusion rate smoothing' if the set speed varies significantly from the speed of the outer or inner walls. If the speed specified here is higher than the speed of the outer or inner walls, the printer will default to the slower of the two speeds. When specified as a percentage (e.g., 80%), the speed is calculated based on the respective outer or inner wall speed. The default value is set to 100%."
-msgstr "ตัวเลือกนี้จะตั้งค่าความเร็วในการพิมพ์สำหรับข้อต่อผ้าพันคอ ขอแนะนำให้พิมพ์ข้อต่อผ้าพันคอด้วยความเร็วต่ำ (น้อยกว่า 100 มม./วินาที) ขอแนะนำให้เปิดใช้งาน 'การปรับอัตราการอัดรีดให้เรียบ' หากความเร็วที่ตั้งไว้แตกต่างอย่างมากจากความเร็วของผนังด้านนอกหรือด้านใน หากความเร็วที่ระบุที่นี่สูงกว่าความเร็วของผนังด้านนอกหรือด้านใน เครื่องพิมพ์จะตั้งค่าเริ่มต้นไว้ที่ความเร็วที่ช้ากว่าทั้งสอง เมื่อระบุเป็นเปอร์เซ็นต์ (เช่น 80%) ความเร็วจะคำนวณตามความเร็วผนังด้านนอกหรือด้านในตามลำดับ ค่าเริ่มต้นตั้งไว้ที่ 100%"
+msgstr "ตัวเลือกนี้จะตั้งค่าความเร็วในการพิมพ์สำหรับข้อต่อเฉียง ขอแนะนำให้พิมพ์ข้อต่อเฉียงด้วยความเร็วต่ำ (น้อยกว่า 100 มม./วินาที) ขอแนะนำให้เปิดใช้งาน 'การปรับอัตราการอัดรีดให้เรียบ' หากความเร็วที่ตั้งไว้แตกต่างอย่างมากจากความเร็วของผนังด้านนอกหรือด้านใน หากความเร็วที่ระบุที่นี่สูงกว่าความเร็วของผนังด้านนอกหรือด้านใน เครื่องพิมพ์จะตั้งค่าเริ่มต้นไว้ที่ความเร็วที่ช้ากว่าทั้งสอง เมื่อระบุเป็นเปอร์เซ็นต์ (เช่น 80%) ความเร็วจะคำนวณตามความเร็วผนังด้านนอกหรือด้านในตามลำดับ ค่าเริ่มต้นตั้งไว้ที่ 100%"
 
 msgid "Scarf joint flow ratio"
-msgstr "อัตราการไหลของข้อต่อผ้าพันคอ"
+msgstr "อัตราการไหลของข้อต่อเฉียง"
 
 msgid "This factor affects the amount of material for scarf joints."
-msgstr "ปัจจัยนี้ส่งผลต่อปริมาณวัสดุสำหรับข้อต่อผ้าพันคอ"
+msgstr "ปัจจัยนี้ส่งผลต่อปริมาณวัสดุสำหรับข้อต่อเฉียง"
 
 msgid "Scarf start height"
-msgstr "ความสูงเริ่มต้นของผ้าพันคอ"
+msgstr "ความสูงเริ่มต้นของเฉียง"
 
 msgid ""
 "Start height of the scarf.\n"
 "This amount can be specified in millimeters or as a percentage of the current layer height. The default value for this parameter is 0."
 msgstr ""
-"เริ่มต้นความสูงของผ้าพันคอ\n"
+"เริ่มต้นความสูงของเฉียง\n"
 "จำนวนนี้สามารถระบุได้ในหน่วยมิลลิเมตรหรือเป็นเปอร์เซ็นต์ของความสูงของเลเยอร์ปัจจุบัน ค่าเริ่มต้นสำหรับพารามิเตอร์นี้คือ 0"
 
 msgid "Scarf around entire wall"
-msgstr "ผ้าพันคอพันรอบผนังทั้งหมด"
+msgstr "เฉียงพันรอบผนังทั้งหมด"
 
 msgid "The scarf extends to the entire length of the wall."
-msgstr "ผ้าพันคอยาวตลอดความยาวของผนัง"
+msgstr "เฉียงยาวตลอดความยาวของผนัง"
 
 msgid "Scarf length"
-msgstr "ความยาวผ้าพันคอ"
+msgstr "ความยาวเฉียง"
 
 msgid "Length of the scarf. Setting this parameter to zero effectively disables the scarf."
-msgstr "ความยาวของผ้าพันคอ. การตั้งค่าพารามิเตอร์นี้เป็นศูนย์จะปิดใช้ผ้าพันคออย่างมีประสิทธิภาพ"
+msgstr "ความยาวของเฉียง. การตั้งค่าพารามิเตอร์นี้เป็นศูนย์จะปิดใช้เฉียงอย่างมีประสิทธิภาพ"
 
 msgid "Scarf steps"
-msgstr "ขั้นตอนผ้าพันคอ"
+msgstr "ขั้นตอนเฉียง"
 
 msgid "Minimum number of segments of each scarf."
-msgstr "จำนวนขั้นต่ำของส่วนผ้าพันคอแต่ละอัน"
+msgstr "จำนวนขั้นต่ำของส่วนเฉียงแต่ละอัน"
 
 msgid "Scarf joint for inner walls"
-msgstr "ข้อต่อผ้าพันคอสำหรับผนังด้านใน"
+msgstr "ข้อต่อเฉียงสำหรับผนังด้านใน"
 
 msgid "Use scarf joint for inner walls as well."
-msgstr "ใช้ข้อต่อผ้าพันคอสำหรับผนังด้านในด้วย"
+msgstr "ใช้ข้อต่อเฉียงสำหรับผนังด้านในด้วย"
 
 msgid "Role base wipe speed"
 msgstr "ความเร็วในการล้างฐานบทบาท"

--- a/localization/i18n/tr/OrcaSlicer_tr.po
+++ b/localization/i18n/tr/OrcaSlicer_tr.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Orca Slicer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-23 14:21-0300\n"
+"POT-Creation-Date: 2026-07-23 15:24-0300\n"
 "PO-Revision-Date: 2026-04-08 23:59+0300\n"
 "Last-Translator: GlauTech\n"
 "Language-Team: \n"
@@ -554,6 +554,7 @@ msgstr "Yeniden eşleştir"
 msgid "Reset"
 msgstr "Sıfırla"
 
+msgctxt "Keyboard Shortcut"
 msgid "Enter"
 msgstr ""
 
@@ -1760,12 +1761,14 @@ msgstr "Seç"
 msgid "Select point"
 msgstr "Nokta seç"
 
+msgctxt "Keyboard Shortcut"
 msgid "Delete"
-msgstr "Sil"
+msgstr ""
 
 msgid "Restart selection"
 msgstr "Seçimi sıfırla"
 
+msgctxt "Keyboard Shortcut"
 msgid "Esc"
 msgstr ""
 
@@ -2408,6 +2411,9 @@ msgstr "URL indirme işlemi başlatılamadı. Hedef klasör ayarlanmamış. Lüt
 msgid "Import File"
 msgstr "Dosya İçe Aktar"
 
+msgid "Delete"
+msgstr "Sil"
+
 msgid "Choose files"
 msgstr "Dosyaları seç"
 
@@ -2538,12 +2544,14 @@ msgstr "Gizle"
 msgid "Show"
 msgstr "Göster"
 
+msgctxt "Keyboard Shortcut"
 msgid "Del"
-msgstr "Sil"
+msgstr ""
 
 msgid "Delete the selected object"
 msgstr "Seçilen nesneyi sil"
 
+msgctxt "Keyboard Shortcut"
 msgid "Backspace"
 msgstr ""
 
@@ -11316,29 +11324,33 @@ msgstr "Birden fazla nesne seç"
 msgid "Select objects by rectangle"
 msgstr "Nesneleri dikdörtgene göre seç"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Up"
-msgstr "Yukarı ok"
+msgstr ""
 
 # TODO: Review, changed by lang refactor. PR 14254
 msgid "Move selection 10mm in positive Y direction"
 msgstr "Seçimi pozitif Y yönünde 10 mm taşı"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Down"
-msgstr "Aşağı ok"
+msgstr ""
 
 # TODO: Review, changed by lang refactor. PR 14254
 msgid "Move selection 10mm in negative Y direction"
 msgstr "Seçimi negatif Y yönünde 10 mm taşı"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Left"
-msgstr "Sol Yön Tuşu"
+msgstr ""
 
 # TODO: Review, changed by lang refactor. PR 14254
 msgid "Move selection 10mm in negative X direction"
 msgstr "Seçimi negatif X yönünde 10 mm taşı"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Right"
-msgstr "Sağ Yön Tuşu"
+msgstr ""
 
 # TODO: Review, changed by lang refactor. PR 14254
 msgid "Move selection 10mm in positive X direction"
@@ -11424,8 +11436,16 @@ msgstr "Uzaklaştır"
 msgid "Toggle printable for object/part"
 msgstr ""
 
+msgctxt "Keyboard Shortcut"
+msgid "Tab"
+msgstr ""
+
 msgid "Switch between Prepare/Preview"
 msgstr "Hazırlama/Önizleme arasında geçiş yap"
+
+msgctxt "Keyboard Shortcut"
+msgid "Space"
+msgstr ""
 
 msgid "Open actions speed dial"
 msgstr ""
@@ -11485,11 +11505,16 @@ msgstr "G-kodu penceresini aç/kapat"
 msgid "Move slider 5x faster"
 msgstr "Kaydırıcıyı 5 kat daha hızlı hareket ettirin"
 
+msgctxt "Keyboard Shortcut"
+msgid "Home"
+msgstr ""
+
 msgid "Horizontal slider - Move to start position"
 msgstr "Yatay kaydırıcı - Başlangıç konumuna taşıyın"
 
+msgctxt "Keyboard Shortcut"
 msgid "End"
-msgstr "Son"
+msgstr ""
 
 msgid "Horizontal slider - Move to last position"
 msgstr "Yatay kaydırıcı - Son konuma git"
@@ -20849,6 +20874,24 @@ msgid ""
 msgstr ""
 "Eğilmeyi önleyin\n"
 "ABS gibi bükülmeye yatkın malzemelere baskı yaparken, ısıtma yatağı sıcaklığının uygun şekilde arttırılmasının bükülme olasılığını azaltabileceğini biliyor muydunuz?"
+
+#~ msgid "Del"
+#~ msgstr "Sil"
+
+#~ msgid "Arrow Up"
+#~ msgstr "Yukarı ok"
+
+#~ msgid "Arrow Down"
+#~ msgstr "Aşağı ok"
+
+#~ msgid "Arrow Left"
+#~ msgstr "Sol Yön Tuşu"
+
+#~ msgid "Arrow Right"
+#~ msgstr "Sağ Yön Tuşu"
+
+#~ msgid "End"
+#~ msgstr "Son"
 
 #~ msgid "Hotend"
 #~ msgstr "Hotend"

--- a/localization/i18n/tr/OrcaSlicer_tr.po
+++ b/localization/i18n/tr/OrcaSlicer_tr.po
@@ -15736,16 +15736,16 @@ msgstr ""
 "Bu miktar milimetre cinsinden veya mevcut ekstruder çapının yüzdesi olarak belirtilebilir. Bu parametrenin varsayılan değeri %10'dur."
 
 msgid "Scarf joint seam (beta)"
-msgstr "Atkı birleşim dikişi (beta)"
+msgstr "Eğik birleşim dikişi (beta)"
 
 msgid "Use scarf joint to minimize seam visibility and increase seam strength."
-msgstr "Dikiş görünürlüğünü en aza indirmek ve dikiş mukavemetini arttırmak için atkı birleşimini kullanın."
+msgstr "Dikiş görünürlüğünü en aza indirmek ve dikiş mukavemetini arttırmak için eğik birleşimini kullanın."
 
 msgid "Conditional scarf joint"
-msgstr "Koşullu atkı birleşimi"
+msgstr "Koşullu eğik birleşimi"
 
 msgid "Apply scarf joints only to smooth perimeters where traditional seams do not conceal the seams at sharp corners effectively."
-msgstr "Atkı bağlantılarını yalnızca geleneksel dikişlerin keskin köşelerdeki dikişleri etkili bir şekilde gizleyemediği düzgün kenarlara uygulayın."
+msgstr "Eğik bağlantılarını yalnızca geleneksel dikişlerin keskin köşelerdeki dikişleri etkili bir şekilde gizleyemediği düzgün kenarlara uygulayın."
 
 msgid "Conditional angle threshold"
 msgstr "Koşullu açı eşiği"
@@ -15754,61 +15754,61 @@ msgid ""
 "This option sets the threshold angle for applying a conditional scarf joint seam.\n"
 "If the maximum angle within the perimeter loop exceeds this value (indicating the absence of sharp corners), a scarf joint seam will be used. The default value is 155°."
 msgstr ""
-"Bu seçenek, koşullu bir atkı eklem dikişi uygulamak için eşik açısını ayarlar.\n"
-"Çevre halkası içindeki maksimum açı bu değeri aşarsa (keskin köşelerin bulunmadığını gösterir), bir atkı birleştirme dikişi kullanılacaktır. Varsayılan değer 155°'dir."
+"Bu seçenek, koşullu bir eğik eklem dikişi uygulamak için eşik açısını ayarlar.\n"
+"Çevre halkası içindeki maksimum açı bu değeri aşarsa (keskin köşelerin bulunmadığını gösterir), bir eğik birleştirme dikişi kullanılacaktır. Varsayılan değer 155°'dir."
 
 msgid "Conditional overhang threshold"
 msgstr "Koşullu çıkıntı eşiği"
 
 #, no-c-format, no-boost-format
 msgid "This option determines the overhang threshold for the application of scarf joint seams. If the unsupported portion of the perimeter is less than this threshold, scarf joint seams will be applied. The default threshold is set at 40% of the external wall's width. Due to performance considerations, the degree of overhang is estimated."
-msgstr "Bu seçenek, atkı bağlantı dikişlerinin uygulanması için sarkma eşiğini belirler. Çevrenin desteklenmeyen kısmı bu eşikten az ise atkı birleştirme dikişleri uygulanacaktır. Varsayılan eşik, dış duvar genişliğinin %40'ına ayarlanmıştır. Performans değerlendirmeleri nedeniyle çıkıntının derecesi tahmin edilir."
+msgstr "Bu seçenek, eğik bağlantı dikişlerinin uygulanması için sarkma eşiğini belirler. Çevrenin desteklenmeyen kısmı bu eşikten az ise eğik birleştirme dikişleri uygulanacaktır. Varsayılan eşik, dış duvar genişliğinin %40'ına ayarlanmıştır. Performans değerlendirmeleri nedeniyle çıkıntının derecesi tahmin edilir."
 
 msgid "Scarf joint speed"
-msgstr "Atkı birleşim hızı"
+msgstr "Eğik birleşim hızı"
 
 msgid "This option sets the printing speed for scarf joints. It is recommended to print scarf joints at a slow speed (less than 100 mm/s). It's also advisable to enable 'Extrusion rate smoothing' if the set speed varies significantly from the speed of the outer or inner walls. If the speed specified here is higher than the speed of the outer or inner walls, the printer will default to the slower of the two speeds. When specified as a percentage (e.g., 80%), the speed is calculated based on the respective outer or inner wall speed. The default value is set to 100%."
-msgstr "Bu seçenek, atkı bağlantılarının yazdırma hızını ayarlar. Atkı bağlantılarının yavaş bir hızda (100 mm/s'den az) yazdırılması tavsiye edilir. Ayarlanan hızın dış veya iç duvarların hızından önemli ölçüde farklı olması durumunda 'Ekstrüzyon hızı yumuşatma' seçeneğinin etkinleştirilmesi de tavsiye edilir. Burada belirtilen hız, dış veya iç duvarların hızından daha yüksekse, yazıcı varsayılan olarak iki hızdan daha yavaş olanı seçecektir. Yüzde olarak belirtildiğinde (örn. %80), hız, ilgili dış veya iç duvar hızına göre hesaplanır. Varsayılan değer %100 olarak ayarlanmıştır."
+msgstr "Bu seçenek, eğik bağlantılarının yazdırma hızını ayarlar. Eğik bağlantılarının yavaş bir hızda (100 mm/s'den az) yazdırılması tavsiye edilir. Ayarlanan hızın dış veya iç duvarların hızından önemli ölçüde farklı olması durumunda 'Ekstrüzyon hızı yumuşatma' seçeneğinin etkinleştirilmesi de tavsiye edilir. Burada belirtilen hız, dış veya iç duvarların hızından daha yüksekse, yazıcı varsayılan olarak iki hızdan daha yavaş olanı seçecektir. Yüzde olarak belirtildiğinde (örn. %80), hız, ilgili dış veya iç duvar hızına göre hesaplanır. Varsayılan değer %100 olarak ayarlanmıştır."
 
 msgid "Scarf joint flow ratio"
-msgstr "Atkı birleşimi akış oranı"
+msgstr "Eğik birleşimi akış oranı"
 
 msgid "This factor affects the amount of material for scarf joints."
-msgstr "Bu faktör atkı birleşimlerinde kullanılacak materyal miktarını değiştirir."
+msgstr "Bu faktör eğik birleşimlerinde kullanılacak materyal miktarını değiştirir."
 
 msgid "Scarf start height"
-msgstr "Atkı başlangıç yüksekliği"
+msgstr "Eğik başlangıç yüksekliği"
 
 msgid ""
 "Start height of the scarf.\n"
 "This amount can be specified in millimeters or as a percentage of the current layer height. The default value for this parameter is 0."
 msgstr ""
-"Atkı başlangıç yüksekliği.\n"
+"Eğik başlangıç yüksekliği.\n"
 "Bu miktar milimetre cinsinden veya geçerli katman yüksekliğinin yüzdesi olarak belirtilebilir. Bu parametrenin varsayılan değeri 0'dır."
 
 msgid "Scarf around entire wall"
 msgstr "Tüm duvarın etrafına atkıla"
 
 msgid "The scarf extends to the entire length of the wall."
-msgstr "Atkı duvarın tüm uzunluğu boyunca uzanır."
+msgstr "Eğik duvarın tüm uzunluğu boyunca uzanır."
 
 msgid "Scarf length"
-msgstr "Atkı uzunluğu"
+msgstr "Eğik uzunluğu"
 
 msgid "Length of the scarf. Setting this parameter to zero effectively disables the scarf."
 msgstr "Atkının uzunluğu. Bu parametrenin 0 a ayarlanması atkıyı dolaylı yoldan devre dışı bırakır."
 
 msgid "Scarf steps"
-msgstr "Atkı kademesi"
+msgstr "Eğik kademesi"
 
 msgid "Minimum number of segments of each scarf."
 msgstr "Her atkının minimum segment sayısı."
 
 msgid "Scarf joint for inner walls"
-msgstr "İç duvarlar için atkı birleşimi"
+msgstr "İç duvarlar için eğik birleşimi"
 
 msgid "Use scarf joint for inner walls as well."
-msgstr "İç duvarlar için de atkı birleşimini kullanın."
+msgstr "İç duvarlar için de eğik birleşimini kullanın."
 
 msgid "Role base wipe speed"
 msgstr "Otomatik temizleme hızı"

--- a/localization/i18n/tr/OrcaSlicer_tr.po
+++ b/localization/i18n/tr/OrcaSlicer_tr.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Orca Slicer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-22 19:11-0300\n"
+"POT-Creation-Date: 2026-07-23 14:21-0300\n"
 "PO-Revision-Date: 2026-04-08 23:59+0300\n"
 "Last-Translator: GlauTech\n"
 "Language-Team: \n"
@@ -891,8 +891,9 @@ msgstr "Bağlayıcıyı seçimden kaldır"
 msgid "Select all connectors"
 msgstr "Tüm bağlayıcıları seç"
 
+msgctxt "Cut tool"
 msgid "Cut"
-msgstr "Kes"
+msgstr ""
 
 msgid "Rotate cut plane"
 msgstr "Kesim düzlemini döndür"
@@ -1871,8 +1872,9 @@ msgstr ""
 msgid "Leaving Measure gizmo"
 msgstr ""
 
+msgctxt "Assembly tool"
 msgid "Assemble"
-msgstr "Birleştir"
+msgstr ""
 
 msgid "Please confirm explosion ratio = 1 and select at least two volumes."
 msgstr "Lütfen patlama oranının = 1 olduğunu doğrulayın ve en az iki cilt seçin."
@@ -2741,6 +2743,9 @@ msgstr "Metreden dönüştür"
 # TODO: Review, changed by lang refactor. PR 14254
 msgid "Restore to Meter"
 msgstr "Metreye geri çevir"
+
+msgid "Assemble"
+msgstr "Birleştir"
 
 msgid "Assemble the selected objects into an object with multiple parts"
 msgstr "Seçilen nesneleri birden çok parçalı bir nesneyle birleştirin"
@@ -4280,6 +4285,14 @@ msgstr "Kasanın arkasına monte edilen malzemeleri kullanarak yazdırma"
 msgid "Print with filament in AMS"
 msgstr "AMS içerisindeki filamentlerle yazdırma"
 
+msgctxt "Nozzle position"
+msgid "Left"
+msgstr ""
+
+msgctxt "Nozzle position"
+msgid "Right"
+msgstr ""
+
 msgid "When the current material run out, the printer will continue to print in the following order."
 msgstr "Mevcut malzeme bittiğinde yazıcı aşağıdaki sırayla yazdırmaya devam edecektir."
 
@@ -5598,8 +5611,9 @@ msgstr "Uyarlanabilir"
 msgid "Quality / Speed"
 msgstr "Kalite / Hız"
 
+msgctxt "Mesh action"
 msgid "Smooth"
-msgstr "Pürüzsüz"
+msgstr ""
 
 msgid "Radius"
 msgstr "Yarıçap"
@@ -6220,6 +6234,9 @@ msgstr "Geri al"
 msgid "Redo"
 msgstr "İleri Al"
 
+msgid "Cut"
+msgstr "Kes"
+
 msgid "Cut selection to clipboard"
 msgstr "Seçimi panoya kes"
 
@@ -6320,6 +6337,10 @@ msgstr "3D sahnede seçilen nesnenin etrafındaki ana hatları göster."
 
 msgid "Preferences"
 msgstr "Tercihler"
+
+msgctxt "Menu"
+msgid "Edit"
+msgstr ""
 
 msgid "View"
 msgstr "Görünüm"
@@ -9297,8 +9318,9 @@ msgstr "Uyumsuz"
 msgid "The selected preset is null!"
 msgstr "Seçilen ön ayar boş!"
 
+msgctxt "Layer range"
 msgid "End"
-msgstr "Son"
+msgstr ""
 
 msgid "Customize"
 msgstr "Özelleştir"
@@ -11465,6 +11487,9 @@ msgstr "Kaydırıcıyı 5 kat daha hızlı hareket ettirin"
 
 msgid "Horizontal slider - Move to start position"
 msgstr "Yatay kaydırıcı - Başlangıç konumuna taşıyın"
+
+msgid "End"
+msgstr "Son"
 
 msgid "Horizontal slider - Move to last position"
 msgstr "Yatay kaydırıcı - Son konuma git"
@@ -15988,6 +16013,9 @@ msgstr "Düzgün veya geleneksel mod seçilirse her baskı için bir hızlandır
 
 msgid "Traditional"
 msgstr "Geleneksel"
+
+msgid "Smooth"
+msgstr "Pürüzsüz"
 
 msgid "Farthest point timelapse"
 msgstr ""

--- a/localization/i18n/tr/OrcaSlicer_tr.po
+++ b/localization/i18n/tr/OrcaSlicer_tr.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Orca Slicer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-20 10:39-0300\n"
+"POT-Creation-Date: 2026-07-22 19:11-0300\n"
 "PO-Revision-Date: 2026-04-08 23:59+0300\n"
 "Last-Translator: GlauTech\n"
 "Language-Team: \n"
@@ -3518,8 +3518,9 @@ msgctxt "air_duct"
 msgid "Left(Aux)"
 msgstr "Sol (Yardımcı)"
 
+msgctxt "Hotend Heat Breaker Fan"
 msgid "Hotend"
-msgstr "Hotend"
+msgstr ""
 
 msgid "Parts"
 msgstr "Parçalar"
@@ -8995,6 +8996,15 @@ msgstr ""
 msgid "Displays current viewport FPS in the top-right corner."
 msgstr ""
 
+msgid "G-code Preview"
+msgstr ""
+
+msgid "Dim lower layers"
+msgstr ""
+
+msgid "When scrubbing the layer slider in the sliced preview, render the layers below the current one darkened so that only the layer being viewed is shown at full brightness."
+msgstr ""
+
 msgid "Login region"
 msgstr "Giriş bölgesi"
 
@@ -9579,6 +9589,9 @@ msgstr "Spiral vazo modu etkinleştirildiğinde, I3 yapısına sahip makineler z
 
 msgid "The current printer does not support timelapse in Traditional Mode when printing By-Object."
 msgstr "Geçerli yazıcı, Nesneye Göre yazdırırken Geleneksel Modda hızlandırılmış geçişi desteklememektedir."
+
+msgid "I have checked the installed nozzle and want to print anyway."
+msgstr ""
 
 msgid "Errors"
 msgstr "Hatalar"
@@ -16962,6 +16975,12 @@ msgstr ""
 msgid "Whether this printer supports fast purge mode with optimized temperature and multiplier."
 msgstr ""
 
+msgid "Filament change"
+msgstr ""
+
+msgid "The volume of material required to prime the extruder on the tower, excluding a hotend change."
+msgstr ""
+
 msgid "The volume of material required to prime the extruder for a hotend change on the tower."
 msgstr ""
 
@@ -20180,14 +20199,14 @@ msgstr "Hata: %s"
 msgid "Show details"
 msgstr "Ayrıntıları göster"
 
+msgid "Hide details"
+msgstr ""
+
 msgid "Version to install:"
 msgstr "Yüklenecek sürüm:"
 
 msgid "Download and Install"
 msgstr "İndirin ve Yükleyin"
-
-msgid "Skip for Now"
-msgstr "Şimdilik Atla"
 
 msgid "A new version of the Bambu Network Plug-in is available."
 msgstr "Bambu Ağ Eklentisinin yeni bir sürümü mevcut."
@@ -20199,17 +20218,11 @@ msgstr "Güncel sürüm: %s"
 msgid "Update to version:"
 msgstr "Sürüme güncelleme:"
 
-msgid "Update Now"
-msgstr "Şimdi Güncelle"
-
-msgid "Remind Later"
-msgstr "Daha Sonra Hatırlat"
-
-msgid "Skip Version"
-msgstr "Sürümü Atla"
-
 msgid "Don't Ask Again"
 msgstr "Bir daha sorma"
+
+msgid "Update Now"
+msgstr "Şimdi Güncelle"
 
 msgid "(Latest)"
 msgstr "(En sonuncu)"
@@ -20225,9 +20238,6 @@ msgstr "Yeni eklentiyi yüklemek için yeniden başlatma gerekiyor. Şimdi yenid
 
 msgid "Restart Now"
 msgstr "Şimdi Yeniden Başlat"
-
-msgid "Restart Later"
-msgstr "Daha Sonra Yeniden Başlat"
 
 msgid "NO RAMMING AT ALL"
 msgstr "HİÇBİR ŞEKİLDE ÇARPMA YOK"
@@ -20811,6 +20821,21 @@ msgid ""
 msgstr ""
 "Eğilmeyi önleyin\n"
 "ABS gibi bükülmeye yatkın malzemelere baskı yaparken, ısıtma yatağı sıcaklığının uygun şekilde arttırılmasının bükülme olasılığını azaltabileceğini biliyor muydunuz?"
+
+#~ msgid "Hotend"
+#~ msgstr "Hotend"
+
+#~ msgid "Skip for Now"
+#~ msgstr "Şimdilik Atla"
+
+#~ msgid "Remind Later"
+#~ msgstr "Daha Sonra Hatırlat"
+
+#~ msgid "Skip Version"
+#~ msgstr "Sürümü Atla"
+
+#~ msgid "Restart Later"
+#~ msgstr "Daha Sonra Yeniden Başlat"
 
 #~ msgid "Select filament that installed to the left nozzle"
 #~ msgstr "Sol nozüle takılan filamanı seçin"

--- a/localization/i18n/uk/OrcaSlicer_uk.po
+++ b/localization/i18n/uk/OrcaSlicer_uk.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: orcaslicerua\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-22 19:11-0300\n"
+"POT-Creation-Date: 2026-07-23 14:21-0300\n"
 "PO-Revision-Date: 2026-07-17 16:25+0300\n"
 "Last-Translator: Andrij Mizyk <andm1zyk@proton.me>\n"
 "Language-Team: Ukrainian\n"
@@ -896,8 +896,9 @@ msgstr "Вилучити зʼєднання з вибраного"
 msgid "Select all connectors"
 msgstr "Вибрати всі зʼєднання"
 
+msgctxt "Cut tool"
 msgid "Cut"
-msgstr "Вирізати"
+msgstr ""
 
 msgid "Rotate cut plane"
 msgstr "Поверніть площину розрізу"
@@ -1881,8 +1882,9 @@ msgstr "Вхід у gizmo-вимірювання"
 msgid "Leaving Measure gizmo"
 msgstr "Вихід з gizmo-вимірювання"
 
+msgctxt "Assembly tool"
 msgid "Assemble"
-msgstr "Збирання"
+msgstr ""
 
 msgid "Please confirm explosion ratio = 1 and select at least two volumes."
 msgstr "Будь ласка, підтвердіть коефіцієнт вибуху = 1 та виберіть принаймні два об’єми."
@@ -2755,6 +2757,9 @@ msgstr "Конвертувати з метричної"
 # TODO: Review, changed by lang refactor. PR 14254
 msgid "Restore to Meter"
 msgstr "Відновити в метричну"
+
+msgid "Assemble"
+msgstr "Збирання"
 
 msgid "Assemble the selected objects into an object with multiple parts"
 msgstr "Зібрати вибрані обʼєкти в обʼєкт з кількома частинами"
@@ -4301,6 +4306,14 @@ msgstr "Друк із використанням матеріалів, закр�
 msgid "Print with filament in AMS"
 msgstr "Друк філаментами в ams"
 
+msgctxt "Nozzle position"
+msgid "Left"
+msgstr ""
+
+msgctxt "Nozzle position"
+msgid "Right"
+msgstr ""
+
 msgid "When the current material run out, the printer will continue to print in the following order."
 msgstr "Коли поточний матеріал закінчується, принтер буде продовжувати друк у наступному порядку."
 
@@ -5613,8 +5626,9 @@ msgstr "Адаптивні"
 msgid "Quality / Speed"
 msgstr "Якість/Швидкість"
 
+msgctxt "Mesh action"
 msgid "Smooth"
-msgstr "Згладити"
+msgstr ""
 
 msgid "Radius"
 msgstr "Радіус"
@@ -6235,6 +6249,9 @@ msgstr "Скасувати"
 msgid "Redo"
 msgstr "Повторити"
 
+msgid "Cut"
+msgstr "Вирізати"
+
 msgid "Cut selection to clipboard"
 msgstr "Вирізати виділення в буфер обміну"
 
@@ -6335,6 +6352,10 @@ msgstr "Показувати контур навколо виділеного о
 
 msgid "Preferences"
 msgstr "Налаштування"
+
+msgctxt "Menu"
+msgid "Edit"
+msgstr ""
 
 msgid "View"
 msgstr "Вигляд"
@@ -9330,8 +9351,9 @@ msgstr "Несумісний"
 msgid "The selected preset is null!"
 msgstr "Обраний пресет є порожнім!"
 
+msgctxt "Layer range"
 msgid "End"
-msgstr "Кінець"
+msgstr ""
 
 msgid "Customize"
 msgstr "Пристосувати"
@@ -11495,6 +11517,9 @@ msgstr "Переміщення повзунка в 5 разів швидше"
 
 msgid "Horizontal slider - Move to start position"
 msgstr "Горизонтальний повзунок - Перемістити в початкове положення"
+
+msgid "End"
+msgstr "Кінець"
 
 msgid "Horizontal slider - Move to last position"
 msgstr "Горизонтальний повзунок - Перемістити в останню позицію"
@@ -15989,6 +16014,9 @@ msgstr "Якщо вибрано плавний або традиційний р�
 
 msgid "Traditional"
 msgstr "Традиційний"
+
+msgid "Smooth"
+msgstr "Згладити"
 
 msgid "Farthest point timelapse"
 msgstr "Таймлапс найдальшої точки"

--- a/localization/i18n/uk/OrcaSlicer_uk.po
+++ b/localization/i18n/uk/OrcaSlicer_uk.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: orcaslicerua\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-23 14:21-0300\n"
+"POT-Creation-Date: 2026-07-23 15:24-0300\n"
 "PO-Revision-Date: 2026-07-17 16:25+0300\n"
 "Last-Translator: Andrij Mizyk <andm1zyk@proton.me>\n"
 "Language-Team: Ukrainian\n"
@@ -559,8 +559,9 @@ msgstr "Переорганізувати"
 msgid "Reset"
 msgstr "Скинути"
 
+msgctxt "Keyboard Shortcut"
 msgid "Enter"
-msgstr "Ввести"
+msgstr ""
 
 msgid "Shortcut Key "
 msgstr "Комбінація клавіш "
@@ -1770,14 +1771,16 @@ msgstr "Вибір"
 msgid "Select point"
 msgstr "Виберіть точку"
 
+msgctxt "Keyboard Shortcut"
 msgid "Delete"
-msgstr "Видалити"
+msgstr ""
 
 msgid "Restart selection"
 msgstr "Вибрати заново"
 
+msgctxt "Keyboard Shortcut"
 msgid "Esc"
-msgstr "Esc"
+msgstr ""
 
 msgid "Cancel a feature until exit"
 msgstr "Скасувати функцію до виходу"
@@ -2422,6 +2425,9 @@ msgstr "Не вдалося розпочати завантаження URL-ад
 msgid "Import File"
 msgstr "Імпортувати файл"
 
+msgid "Delete"
+msgstr "Видалити"
+
 msgid "Choose files"
 msgstr "Вибрати файли"
 
@@ -2552,14 +2558,16 @@ msgstr "Приховати"
 msgid "Show"
 msgstr "Показати"
 
+msgctxt "Keyboard Shortcut"
 msgid "Del"
-msgstr "Видалити"
+msgstr ""
 
 msgid "Delete the selected object"
 msgstr "Видалення вибраних моделей"
 
+msgctxt "Keyboard Shortcut"
 msgid "Backspace"
-msgstr "Назад"
+msgstr ""
 
 msgid "Load..."
 msgstr "Завантажити..."
@@ -11346,29 +11354,33 @@ msgstr "Вибрати кілька обʼєктів"
 msgid "Select objects by rectangle"
 msgstr "Виділити обʼєкти прямокутником"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Up"
-msgstr "Стрілка вгору"
+msgstr ""
 
 # TODO: Review, changed by lang refactor. PR 14254
 msgid "Move selection 10mm in positive Y direction"
 msgstr "Перемістити виділення на 10 мм у позитивному напрямку Y"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Down"
-msgstr "Стрілка вниз"
+msgstr ""
 
 # TODO: Review, changed by lang refactor. PR 14254
 msgid "Move selection 10mm in negative Y direction"
 msgstr "Перемістити виділення на 10 мм у негативному напрямку Y"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Left"
-msgstr "Стрілка вліво"
+msgstr ""
 
 # TODO: Review, changed by lang refactor. PR 14254
 msgid "Move selection 10mm in negative X direction"
 msgstr "Перемістити виділення на 10 мм у негативному напрямку по осі X"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Right"
-msgstr "Стрілка праворуч"
+msgstr ""
 
 # TODO: Review, changed by lang refactor. PR 14254
 msgid "Move selection 10mm in positive X direction"
@@ -11454,8 +11466,16 @@ msgstr "Віддалити"
 msgid "Toggle printable for object/part"
 msgstr ""
 
+msgctxt "Keyboard Shortcut"
+msgid "Tab"
+msgstr ""
+
 msgid "Switch between Prepare/Preview"
 msgstr "Переключення між Підготовка/Попередній перегляд"
+
+msgctxt "Keyboard Shortcut"
+msgid "Space"
+msgstr ""
 
 msgid "Open actions speed dial"
 msgstr ""
@@ -11515,11 +11535,16 @@ msgstr "Увімкнення/вимкнення вікна G-коду"
 msgid "Move slider 5x faster"
 msgstr "Переміщення повзунка в 5 разів швидше"
 
+msgctxt "Keyboard Shortcut"
+msgid "Home"
+msgstr ""
+
 msgid "Horizontal slider - Move to start position"
 msgstr "Горизонтальний повзунок - Перемістити в початкове положення"
 
+msgctxt "Keyboard Shortcut"
 msgid "End"
-msgstr "Кінець"
+msgstr ""
 
 msgid "Horizontal slider - Move to last position"
 msgstr "Горизонтальний повзунок - Перемістити в останню позицію"
@@ -20832,6 +20857,33 @@ msgid ""
 msgstr ""
 "Уникнення деформації\n"
 "Чи знаєте ви, що при друку матеріалами, схильними до деформації, такими як ABS, відповідне підвищення температури гарячого ліжка може зменшити ймовірність деформації?"
+
+#~ msgid "Enter"
+#~ msgstr "Ввести"
+
+#~ msgid "Esc"
+#~ msgstr "Esc"
+
+#~ msgid "Del"
+#~ msgstr "Видалити"
+
+#~ msgid "Backspace"
+#~ msgstr "Назад"
+
+#~ msgid "Arrow Up"
+#~ msgstr "Стрілка вгору"
+
+#~ msgid "Arrow Down"
+#~ msgstr "Стрілка вниз"
+
+#~ msgid "Arrow Left"
+#~ msgstr "Стрілка вліво"
+
+#~ msgid "Arrow Right"
+#~ msgstr "Стрілка праворуч"
+
+#~ msgid "End"
+#~ msgstr "Кінець"
 
 #~ msgid "Hotend"
 #~ msgstr "Хотенд"

--- a/localization/i18n/uk/OrcaSlicer_uk.po
+++ b/localization/i18n/uk/OrcaSlicer_uk.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: orcaslicerua\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-20 10:39-0300\n"
+"POT-Creation-Date: 2026-07-22 19:11-0300\n"
 "PO-Revision-Date: 2026-07-17 16:25+0300\n"
 "Last-Translator: Andrij Mizyk <andm1zyk@proton.me>\n"
 "Language-Team: Ukrainian\n"
@@ -3545,8 +3545,9 @@ msgctxt "air_duct"
 msgid "Left(Aux)"
 msgstr "Лівий(Вент)"
 
+msgctxt "Hotend Heat Breaker Fan"
 msgid "Hotend"
-msgstr "Хотенд"
+msgstr ""
 
 msgid "Parts"
 msgstr "Частини"
@@ -9027,6 +9028,15 @@ msgstr ""
 msgid "Displays current viewport FPS in the top-right corner."
 msgstr ""
 
+msgid "G-code Preview"
+msgstr ""
+
+msgid "Dim lower layers"
+msgstr ""
+
+msgid "When scrubbing the layer slider in the sliced preview, render the layers below the current one darkened so that only the layer being viewed is shown at full brightness."
+msgstr ""
+
 msgid "Login region"
 msgstr "Регіон входу"
 
@@ -9605,6 +9615,9 @@ msgid "When spiral vase mode is enabled, machines with I3 structure will not gen
 msgstr "При увімкненні режиму спіралі для вази машини з I3 структурою не будуть створювати відео в режимі таймлапсу."
 
 msgid "The current printer does not support timelapse in Traditional Mode when printing By-Object."
+msgstr ""
+
+msgid "I have checked the installed nozzle and want to print anyway."
 msgstr ""
 
 msgid "Errors"
@@ -16956,6 +16969,12 @@ msgstr "Підтримка режиму швидкого очищення"
 msgid "Whether this printer supports fast purge mode with optimized temperature and multiplier."
 msgstr ""
 
+msgid "Filament change"
+msgstr ""
+
+msgid "The volume of material required to prime the extruder on the tower, excluding a hotend change."
+msgstr ""
+
 msgid "The volume of material required to prime the extruder for a hotend change on the tower."
 msgstr ""
 
@@ -20163,14 +20182,14 @@ msgstr "Помилка: %s"
 msgid "Show details"
 msgstr "Показати подробиці"
 
+msgid "Hide details"
+msgstr ""
+
 msgid "Version to install:"
 msgstr "Версія для встановлення:"
 
 msgid "Download and Install"
 msgstr "Завантажити і встановити"
-
-msgid "Skip for Now"
-msgstr "Пропустити поки що"
 
 msgid "A new version of the Bambu Network Plug-in is available."
 msgstr "Доступна нова версія мережевого плагіна Bambu."
@@ -20182,17 +20201,11 @@ msgstr "Поточна версія: %s"
 msgid "Update to version:"
 msgstr "Оновити до версії:"
 
-msgid "Update Now"
-msgstr "Оновити зараз"
-
-msgid "Remind Later"
-msgstr "Нагадати пізніше"
-
-msgid "Skip Version"
-msgstr "Пропустити версію"
-
 msgid "Don't Ask Again"
 msgstr "Не запитувати знову"
+
+msgid "Update Now"
+msgstr "Оновити зараз"
 
 msgid "(Latest)"
 msgstr "(Останній)"
@@ -20208,9 +20221,6 @@ msgstr "Для завантаження нового плагіна потріб
 
 msgid "Restart Now"
 msgstr "Перезапустити зараз"
-
-msgid "Restart Later"
-msgstr "Перезапустити пізніше"
 
 msgid "NO RAMMING AT ALL"
 msgstr "ВЗАГАЛІ БЕЗ УТРАМБУВАННЯ"
@@ -20794,6 +20804,21 @@ msgid ""
 msgstr ""
 "Уникнення деформації\n"
 "Чи знаєте ви, що при друку матеріалами, схильними до деформації, такими як ABS, відповідне підвищення температури гарячого ліжка може зменшити ймовірність деформації?"
+
+#~ msgid "Hotend"
+#~ msgstr "Хотенд"
+
+#~ msgid "Skip for Now"
+#~ msgstr "Пропустити поки що"
+
+#~ msgid "Remind Later"
+#~ msgstr "Нагадати пізніше"
+
+#~ msgid "Skip Version"
+#~ msgstr "Пропустити версію"
+
+#~ msgid "Restart Later"
+#~ msgstr "Перезапустити пізніше"
 
 #~ msgid "Select filament that installed to the left nozzle"
 #~ msgstr "Вибрати філамент, що встановлений на ліве сопло"

--- a/localization/i18n/vi/OrcaSlicer_vi.po
+++ b/localization/i18n/vi/OrcaSlicer_vi.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Orca Slicer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-23 14:21-0300\n"
+"POT-Creation-Date: 2026-07-23 15:24-0300\n"
 "PO-Revision-Date: 2025-10-02 17:43+0700\n"
 "Last-Translator: \n"
 "Language-Team: hainguyen.ts13@gmail.com\n"
@@ -555,6 +555,7 @@ msgstr "Ánh xạ lại"
 msgid "Reset"
 msgstr "Đặt lại"
 
+msgctxt "Keyboard Shortcut"
 msgid "Enter"
 msgstr ""
 
@@ -1761,12 +1762,14 @@ msgstr "Chọn"
 msgid "Select point"
 msgstr "Chọn điểm"
 
+msgctxt "Keyboard Shortcut"
 msgid "Delete"
-msgstr "Xóa"
+msgstr ""
 
 msgid "Restart selection"
 msgstr "Khởi động lại lựa chọn"
 
+msgctxt "Keyboard Shortcut"
 msgid "Esc"
 msgstr ""
 
@@ -2401,6 +2404,9 @@ msgstr "Không thể bắt đầu tải URL. Thư mục đích chưa được đ
 msgid "Import File"
 msgstr "Nhập file"
 
+msgid "Delete"
+msgstr "Xóa"
+
 msgid "Choose files"
 msgstr "Chọn file"
 
@@ -2530,12 +2536,14 @@ msgstr "Ẩn"
 msgid "Show"
 msgstr "Hiện"
 
+msgctxt "Keyboard Shortcut"
 msgid "Del"
 msgstr ""
 
 msgid "Delete the selected object"
 msgstr "Xóa vật thể đã chọn"
 
+msgctxt "Keyboard Shortcut"
 msgid "Backspace"
 msgstr ""
 
@@ -11239,29 +11247,33 @@ msgstr "Chọn nhiều đối tượng"
 msgid "Select objects by rectangle"
 msgstr "Chọn đối tượng bằng hình chữ nhật"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Up"
-msgstr "Mũi tên lên"
+msgstr ""
 
 # TODO: Review, changed by lang refactor. PR 14254
 msgid "Move selection 10mm in positive Y direction"
 msgstr "Di chuyển lựa chọn 10 mm theo hướng Y dương"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Down"
-msgstr "Mũi tên xuống"
+msgstr ""
 
 # TODO: Review, changed by lang refactor. PR 14254
 msgid "Move selection 10mm in negative Y direction"
 msgstr "Di chuyển lựa chọn 10 mm theo hướng Y âm"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Left"
-msgstr "Mũi tên trái"
+msgstr ""
 
 # TODO: Review, changed by lang refactor. PR 14254
 msgid "Move selection 10mm in negative X direction"
 msgstr "Di chuyển lựa chọn 10 mm theo hướng X âm"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Right"
-msgstr "Mũi tên phải"
+msgstr ""
 
 # TODO: Review, changed by lang refactor. PR 14254
 msgid "Move selection 10mm in positive X direction"
@@ -11347,8 +11359,16 @@ msgstr "Thu nhỏ"
 msgid "Toggle printable for object/part"
 msgstr ""
 
+msgctxt "Keyboard Shortcut"
+msgid "Tab"
+msgstr ""
+
 msgid "Switch between Prepare/Preview"
 msgstr "Chuyển đổi giữa Chuẩn bị/Xem trước"
+
+msgctxt "Keyboard Shortcut"
+msgid "Space"
+msgstr ""
 
 msgid "Open actions speed dial"
 msgstr ""
@@ -11408,11 +11428,16 @@ msgstr "Bật/Tắt cửa sổ G-code"
 msgid "Move slider 5x faster"
 msgstr "Di chuyển thanh trượt nhanh hơn 5 lần"
 
+msgctxt "Keyboard Shortcut"
+msgid "Home"
+msgstr ""
+
 msgid "Horizontal slider - Move to start position"
 msgstr "Thanh trượt ngang - Di chuyển đến vị trí bắt đầu"
 
+msgctxt "Keyboard Shortcut"
 msgid "End"
-msgstr "Kết thúc"
+msgstr ""
 
 msgid "Horizontal slider - Move to last position"
 msgstr "Thanh trượt ngang - Di chuyển đến vị trí cuối cùng"
@@ -20714,6 +20739,21 @@ msgid ""
 msgstr ""
 "Tránh cong vênh\n"
 "Bạn có biết rằng khi in vật liệu dễ cong vênh như ABS, tăng nhiệt độ bàn nóng một cách thích hợp có thể giảm xác suất cong vênh không?"
+
+#~ msgid "Arrow Up"
+#~ msgstr "Mũi tên lên"
+
+#~ msgid "Arrow Down"
+#~ msgstr "Mũi tên xuống"
+
+#~ msgid "Arrow Left"
+#~ msgstr "Mũi tên trái"
+
+#~ msgid "Arrow Right"
+#~ msgstr "Mũi tên phải"
+
+#~ msgid "End"
+#~ msgstr "Kết thúc"
 
 #~ msgid "Hotend"
 #~ msgstr "Hotend"

--- a/localization/i18n/vi/OrcaSlicer_vi.po
+++ b/localization/i18n/vi/OrcaSlicer_vi.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Orca Slicer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-22 19:11-0300\n"
+"POT-Creation-Date: 2026-07-23 14:21-0300\n"
 "PO-Revision-Date: 2025-10-02 17:43+0700\n"
 "Last-Translator: \n"
 "Language-Team: hainguyen.ts13@gmail.com\n"
@@ -892,8 +892,9 @@ msgstr "Xóa connector khỏi lựa chọn"
 msgid "Select all connectors"
 msgstr "Chọn tất cả connector"
 
+msgctxt "Cut tool"
 msgid "Cut"
-msgstr "Cắt"
+msgstr ""
 
 msgid "Rotate cut plane"
 msgstr "Xoay mặt cắt"
@@ -1872,8 +1873,9 @@ msgstr ""
 msgid "Leaving Measure gizmo"
 msgstr ""
 
+msgctxt "Assembly tool"
 msgid "Assemble"
-msgstr "Lắp ráp"
+msgstr ""
 
 msgid "Please confirm explosion ratio = 1 and select at least two volumes."
 msgstr ""
@@ -2733,6 +2735,9 @@ msgstr "Chuyển đổi từ mét"
 # TODO: Review, changed by lang refactor. PR 14254
 msgid "Restore to Meter"
 msgstr "Khôi phục về mét"
+
+msgid "Assemble"
+msgstr "Lắp ráp"
 
 msgid "Assemble the selected objects into an object with multiple parts"
 msgstr "Lắp ráp các vật thể đã chọn thành vật thể có nhiều phần"
@@ -4257,6 +4262,14 @@ msgstr "In bằng vật liệu gắn ở mặt sau của vỏ"
 msgid "Print with filament in AMS"
 msgstr "In với filament trong AMS"
 
+msgctxt "Nozzle position"
+msgid "Left"
+msgstr ""
+
+msgctxt "Nozzle position"
+msgid "Right"
+msgstr ""
+
 msgid "When the current material run out, the printer will continue to print in the following order."
 msgstr "Khi vật liệu hiện tại hết, máy in sẽ tiếp tục in theo thứ tự sau."
 
@@ -5570,8 +5583,9 @@ msgstr "Thích ứng"
 msgid "Quality / Speed"
 msgstr "Chất lượng / Tốc độ"
 
+msgctxt "Mesh action"
 msgid "Smooth"
-msgstr "Mượt"
+msgstr ""
 
 msgid "Radius"
 msgstr "Bán kính"
@@ -6188,6 +6202,9 @@ msgstr "Hoàn tác"
 msgid "Redo"
 msgstr "Làm lại"
 
+msgid "Cut"
+msgstr "Cắt"
+
 msgid "Cut selection to clipboard"
 msgstr "Cắt lựa chọn vào clipboard"
 
@@ -6288,6 +6305,10 @@ msgstr "Hiện đường viền xung quanh vật thể đã chọn trong cảnh 
 
 msgid "Preferences"
 msgstr "Tùy chọn"
+
+msgctxt "Menu"
+msgid "Edit"
+msgstr ""
 
 msgid "View"
 msgstr "Xem"
@@ -9244,8 +9265,9 @@ msgstr "Không tương thích"
 msgid "The selected preset is null!"
 msgstr "Preset đã chọn rỗng!"
 
+msgctxt "Layer range"
 msgid "End"
-msgstr "Kết thúc"
+msgstr ""
 
 msgid "Customize"
 msgstr "Tùy chỉnh"
@@ -11388,6 +11410,9 @@ msgstr "Di chuyển thanh trượt nhanh hơn 5 lần"
 
 msgid "Horizontal slider - Move to start position"
 msgstr "Thanh trượt ngang - Di chuyển đến vị trí bắt đầu"
+
+msgid "End"
+msgstr "Kết thúc"
 
 msgid "Horizontal slider - Move to last position"
 msgstr "Thanh trượt ngang - Di chuyển đến vị trí cuối cùng"
@@ -15880,6 +15905,9 @@ msgstr "Nếu chế độ mịn hoặc truyền thống được chọn, video t
 
 msgid "Traditional"
 msgstr "Truyền thống"
+
+msgid "Smooth"
+msgstr "Mượt"
 
 msgid "Farthest point timelapse"
 msgstr ""

--- a/localization/i18n/vi/OrcaSlicer_vi.po
+++ b/localization/i18n/vi/OrcaSlicer_vi.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Orca Slicer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-20 10:39-0300\n"
+"POT-Creation-Date: 2026-07-22 19:11-0300\n"
 "PO-Revision-Date: 2025-10-02 17:43+0700\n"
 "Last-Translator: \n"
 "Language-Team: hainguyen.ts13@gmail.com\n"
@@ -3506,8 +3506,9 @@ msgctxt "air_duct"
 msgid "Left(Aux)"
 msgstr ""
 
+msgctxt "Hotend Heat Breaker Fan"
 msgid "Hotend"
-msgstr "Hotend"
+msgstr ""
 
 msgid "Parts"
 msgstr ""
@@ -8944,6 +8945,15 @@ msgstr ""
 msgid "Displays current viewport FPS in the top-right corner."
 msgstr ""
 
+msgid "G-code Preview"
+msgstr ""
+
+msgid "Dim lower layers"
+msgstr ""
+
+msgid "When scrubbing the layer slider in the sliced preview, render the layers below the current one darkened so that only the layer being viewed is shown at full brightness."
+msgstr ""
+
 msgid "Login region"
 msgstr ""
 
@@ -9519,6 +9529,9 @@ msgid "When spiral vase mode is enabled, machines with I3 structure will not gen
 msgstr "Khi bật chế độ bình xoắn ốc, máy có cấu trúc I3 sẽ không tạo video timelapse."
 
 msgid "The current printer does not support timelapse in Traditional Mode when printing By-Object."
+msgstr ""
+
+msgid "I have checked the installed nozzle and want to print anyway."
 msgstr ""
 
 msgid "Errors"
@@ -16850,6 +16863,12 @@ msgstr ""
 msgid "Whether this printer supports fast purge mode with optimized temperature and multiplier."
 msgstr ""
 
+msgid "Filament change"
+msgstr ""
+
+msgid "The volume of material required to prime the extruder on the tower, excluding a hotend change."
+msgstr ""
+
 msgid "The volume of material required to prime the extruder for a hotend change on the tower."
 msgstr ""
 
@@ -20045,13 +20064,13 @@ msgstr ""
 msgid "Show details"
 msgstr ""
 
+msgid "Hide details"
+msgstr ""
+
 msgid "Version to install:"
 msgstr ""
 
 msgid "Download and Install"
-msgstr ""
-
-msgid "Skip for Now"
 msgstr ""
 
 msgid "A new version of the Bambu Network Plug-in is available."
@@ -20064,16 +20083,10 @@ msgstr ""
 msgid "Update to version:"
 msgstr ""
 
-msgid "Update Now"
-msgstr ""
-
-msgid "Remind Later"
-msgstr ""
-
-msgid "Skip Version"
-msgstr ""
-
 msgid "Don't Ask Again"
+msgstr ""
+
+msgid "Update Now"
 msgstr ""
 
 msgid "(Latest)"
@@ -20089,9 +20102,6 @@ msgid "A restart is required to load the new plug-in. Would you like to restart 
 msgstr ""
 
 msgid "Restart Now"
-msgstr ""
-
-msgid "Restart Later"
 msgstr ""
 
 msgid "NO RAMMING AT ALL"
@@ -20676,6 +20686,9 @@ msgid ""
 msgstr ""
 "Tránh cong vênh\n"
 "Bạn có biết rằng khi in vật liệu dễ cong vênh như ABS, tăng nhiệt độ bàn nóng một cách thích hợp có thể giảm xác suất cong vênh không?"
+
+#~ msgid "Hotend"
+#~ msgstr "Hotend"
 
 # TODO: Review, changed by lang refactor. PR 14254
 #~ msgid "Click OK to update the Network plug-in the next time Orca Slicer launches."

--- a/localization/i18n/zh_CN/OrcaSlicer_zh_CN.po
+++ b/localization/i18n/zh_CN/OrcaSlicer_zh_CN.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Slic3rPE\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-22 19:11-0300\n"
+"POT-Creation-Date: 2026-07-23 14:21-0300\n"
 "PO-Revision-Date: 2026-06-11 12:37-0300\n"
 "Last-Translator: Handle <mail@bysb.net>\n"
 "Language-Team: \n"
@@ -894,8 +894,9 @@ msgstr "取消选择连接件"
 msgid "Select all connectors"
 msgstr "选择所有连接件"
 
+msgctxt "Cut tool"
 msgid "Cut"
-msgstr "剪切"
+msgstr ""
 
 msgid "Rotate cut plane"
 msgstr "旋转剖切面"
@@ -1867,8 +1868,9 @@ msgstr "进入测量小工具"
 msgid "Leaving Measure gizmo"
 msgstr "离开测量小工具"
 
+msgctxt "Assembly tool"
 msgid "Assemble"
-msgstr "组合"
+msgstr ""
 
 msgid "Please confirm explosion ratio = 1 and select at least two volumes."
 msgstr "请确认爆炸比例 = 1 并选择至少两个部件。"
@@ -2761,6 +2763,9 @@ msgstr "从米转换"
 # TODO: Review, changed by lang refactor. PR 14254
 msgid "Restore to Meter"
 msgstr "恢复到米"
+
+msgid "Assemble"
+msgstr "组合"
 
 msgid "Assemble the selected objects into an object with multiple parts"
 msgstr "组合所选对象为一个多零件对象"
@@ -4287,6 +4292,14 @@ msgstr "使用安装在机箱背面的材料进行打印"
 msgid "Print with filament in AMS"
 msgstr "采用AMS里的材料打印"
 
+msgctxt "Nozzle position"
+msgid "Left"
+msgstr ""
+
+msgctxt "Nozzle position"
+msgid "Right"
+msgstr ""
+
 msgid "When the current material run out, the printer will continue to print in the following order."
 msgstr "当前材料耗尽时，打印机将按照以下顺序继续打印。"
 
@@ -5597,8 +5610,9 @@ msgstr "自适应"
 msgid "Quality / Speed"
 msgstr "细节/速度"
 
+msgctxt "Mesh action"
 msgid "Smooth"
-msgstr "平滑模式"
+msgstr ""
 
 msgid "Radius"
 msgstr "半径"
@@ -6220,6 +6234,9 @@ msgstr "撤销"
 msgid "Redo"
 msgstr "重做"
 
+msgid "Cut"
+msgstr "剪切"
+
 msgid "Cut selection to clipboard"
 msgstr "剪切所选项到剪贴板"
 
@@ -6320,6 +6337,10 @@ msgstr "在3D场景中显示选中对象的轮廓"
 
 msgid "Preferences"
 msgstr "偏好设置"
+
+msgctxt "Menu"
+msgid "Edit"
+msgstr ""
 
 msgid "View"
 msgstr "视图"
@@ -9292,8 +9313,9 @@ msgstr "不兼容的预设"
 msgid "The selected preset is null!"
 msgstr "选择的预设为空！"
 
+msgctxt "Layer range"
 msgid "End"
-msgstr "结束"
+msgstr ""
 
 msgid "Customize"
 msgstr "自定义"
@@ -11481,6 +11503,9 @@ msgstr "5倍速移动滑动条"
 
 msgid "Horizontal slider - Move to start position"
 msgstr "水平滑块 - 移动到起始位置"
+
+msgid "End"
+msgstr "结束"
 
 msgid "Horizontal slider - Move to last position"
 msgstr "水平滑块 - 移动到末尾位置"
@@ -16105,6 +16130,9 @@ msgstr "如果启用平滑模式或者传统模式，将在每次打印时生成
 
 msgid "Traditional"
 msgstr "传统模式"
+
+msgid "Smooth"
+msgstr "平滑模式"
 
 msgid "Farthest point timelapse"
 msgstr ""

--- a/localization/i18n/zh_CN/OrcaSlicer_zh_CN.po
+++ b/localization/i18n/zh_CN/OrcaSlicer_zh_CN.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Slic3rPE\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-20 10:39-0300\n"
+"POT-Creation-Date: 2026-07-22 19:11-0300\n"
 "PO-Revision-Date: 2026-06-11 12:37-0300\n"
 "Last-Translator: Handle <mail@bysb.net>\n"
 "Language-Team: \n"
@@ -3532,8 +3532,9 @@ msgctxt "air_duct"
 msgid "Left(Aux)"
 msgstr "左（辅助）"
 
+msgctxt "Hotend Heat Breaker Fan"
 msgid "Hotend"
-msgstr "热端"
+msgstr ""
 
 msgid "Parts"
 msgstr "打印件"
@@ -8986,6 +8987,15 @@ msgstr "显示 FPS 叠加层"
 msgid "Displays current viewport FPS in the top-right corner."
 msgstr "在右上角显示当前视口的 FPS。"
 
+msgid "G-code Preview"
+msgstr ""
+
+msgid "Dim lower layers"
+msgstr ""
+
+msgid "When scrubbing the layer slider in the sliced preview, render the layers below the current one darkened so that only the layer being viewed is shown at full brightness."
+msgstr ""
+
 msgid "Login region"
 msgstr "登录区域"
 
@@ -9574,6 +9584,9 @@ msgstr "当启用旋转花瓶模式时，I3结构的机器将不会生成延时�
 
 msgid "The current printer does not support timelapse in Traditional Mode when printing By-Object."
 msgstr "当前打印机在按对象打印时不支持传统模式下的延时拍摄。"
+
+msgid "I have checked the installed nozzle and want to print anyway."
+msgstr ""
 
 msgid "Errors"
 msgstr "错误"
@@ -17080,6 +17093,12 @@ msgstr ""
 msgid "Whether this printer supports fast purge mode with optimized temperature and multiplier."
 msgstr ""
 
+msgid "Filament change"
+msgstr ""
+
+msgid "The volume of material required to prime the extruder on the tower, excluding a hotend change."
+msgstr ""
+
 msgid "The volume of material required to prime the extruder for a hotend change on the tower."
 msgstr "换热端所需的擦料塔上的清理量。"
 
@@ -20293,14 +20312,14 @@ msgstr "错误：%s"
 msgid "Show details"
 msgstr "显示详情"
 
+msgid "Hide details"
+msgstr ""
+
 msgid "Version to install:"
 msgstr "将安装的版本："
 
 msgid "Download and Install"
 msgstr "下载并安装"
-
-msgid "Skip for Now"
-msgstr "暂时跳过"
 
 msgid "A new version of the Bambu Network Plug-in is available."
 msgstr "Bambu 网络插件有新版本可用。"
@@ -20312,17 +20331,11 @@ msgstr "当前版本：%s"
 msgid "Update to version:"
 msgstr "更新到版本："
 
-msgid "Update Now"
-msgstr "立即更新"
-
-msgid "Remind Later"
-msgstr "稍后提醒"
-
-msgid "Skip Version"
-msgstr "跳过此版本"
-
 msgid "Don't Ask Again"
 msgstr "不再询问"
+
+msgid "Update Now"
+msgstr "立即更新"
 
 msgid "(Latest)"
 msgstr "（最新的）"
@@ -20338,9 +20351,6 @@ msgstr "需要重新启动以加载新插件。您要立即重启吗？"
 
 msgid "Restart Now"
 msgstr "立即重启"
-
-msgid "Restart Later"
-msgstr "稍后重启"
 
 msgid "NO RAMMING AT ALL"
 msgstr "完全不挤压"
@@ -20929,6 +20939,21 @@ msgid ""
 msgstr ""
 "避免翘曲\n"
 "您知道吗？打印ABS这类易翘曲材料时，适当提高热床温度可以降低翘曲的概率。"
+
+#~ msgid "Hotend"
+#~ msgstr "热端"
+
+#~ msgid "Skip for Now"
+#~ msgstr "暂时跳过"
+
+#~ msgid "Remind Later"
+#~ msgstr "稍后提醒"
+
+#~ msgid "Skip Version"
+#~ msgstr "跳过此版本"
+
+#~ msgid "Restart Later"
+#~ msgstr "稍后重启"
 
 #~ msgid "Select filament that installed to the left nozzle"
 #~ msgstr "选择安装在左侧喷嘴的耗材"

--- a/localization/i18n/zh_CN/OrcaSlicer_zh_CN.po
+++ b/localization/i18n/zh_CN/OrcaSlicer_zh_CN.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Slic3rPE\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-23 14:21-0300\n"
+"POT-Creation-Date: 2026-07-23 15:24-0300\n"
 "PO-Revision-Date: 2026-06-11 12:37-0300\n"
 "Last-Translator: Handle <mail@bysb.net>\n"
 "Language-Team: \n"
@@ -557,8 +557,9 @@ msgstr "重映射"
 msgid "Reset"
 msgstr "重置"
 
+msgctxt "Keyboard Shortcut"
 msgid "Enter"
-msgstr "回车"
+msgstr ""
 
 msgid "Shortcut Key "
 msgstr "快捷键 "
@@ -1758,14 +1759,16 @@ msgstr "选择"
 msgid "Select point"
 msgstr "选择点"
 
+msgctxt "Keyboard Shortcut"
 msgid "Delete"
-msgstr "删除"
+msgstr ""
 
 msgid "Restart selection"
 msgstr "重新选择"
 
+msgctxt "Keyboard Shortcut"
 msgid "Esc"
-msgstr "Esc"
+msgstr ""
 
 msgid "Cancel a feature until exit"
 msgstr "取消一个特征直到退出"
@@ -2425,6 +2428,9 @@ msgstr "无法启动URL下载。目标文件夹没有设置。请在配置向导
 msgid "Import File"
 msgstr "导入文件"
 
+msgid "Delete"
+msgstr "删除"
+
 msgid "Choose files"
 msgstr "选择文件"
 
@@ -2555,14 +2561,16 @@ msgstr "隐藏"
 msgid "Show"
 msgstr "显示"
 
+msgctxt "Keyboard Shortcut"
 msgid "Del"
-msgstr "删除"
+msgstr ""
 
 msgid "Delete the selected object"
 msgstr "删除所选对象"
 
+msgctxt "Keyboard Shortcut"
 msgid "Backspace"
-msgstr "回退键"
+msgstr ""
 
 msgid "Load..."
 msgstr "加载..."
@@ -11332,29 +11340,33 @@ msgstr "选择多个对象"
 msgid "Select objects by rectangle"
 msgstr "框选多个零件"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Up"
-msgstr "上箭头"
+msgstr ""
 
 # TODO: Review, changed by lang refactor. PR 14254
 msgid "Move selection 10mm in positive Y direction"
 msgstr "Y方向移动 10mm"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Down"
-msgstr "下箭头"
+msgstr ""
 
 # TODO: Review, changed by lang refactor. PR 14254
 msgid "Move selection 10mm in negative Y direction"
 msgstr "Y方向移动 10mm"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Left"
-msgstr "左箭头"
+msgstr ""
 
 # TODO: Review, changed by lang refactor. PR 14254
 msgid "Move selection 10mm in negative X direction"
 msgstr "X方向移动 10mm"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Right"
-msgstr "右箭头"
+msgstr ""
 
 # TODO: Review, changed by lang refactor. PR 14254
 msgid "Move selection 10mm in positive X direction"
@@ -11440,8 +11452,16 @@ msgstr "缩小"
 msgid "Toggle printable for object/part"
 msgstr "切换对象/零件的可打印状态"
 
+msgctxt "Keyboard Shortcut"
+msgid "Tab"
+msgstr ""
+
 msgid "Switch between Prepare/Preview"
 msgstr "准备/预览之间的切换"
+
+msgctxt "Keyboard Shortcut"
+msgid "Space"
+msgstr ""
 
 msgid "Open actions speed dial"
 msgstr ""
@@ -11501,11 +11521,16 @@ msgstr "开启/关闭G-code窗口"
 msgid "Move slider 5x faster"
 msgstr "5倍速移动滑动条"
 
+msgctxt "Keyboard Shortcut"
+msgid "Home"
+msgstr ""
+
 msgid "Horizontal slider - Move to start position"
 msgstr "水平滑块 - 移动到起始位置"
 
+msgctxt "Keyboard Shortcut"
 msgid "End"
-msgstr "结束"
+msgstr ""
 
 msgid "Horizontal slider - Move to last position"
 msgstr "水平滑块 - 移动到末尾位置"
@@ -20967,6 +20992,33 @@ msgid ""
 msgstr ""
 "避免翘曲\n"
 "您知道吗？打印ABS这类易翘曲材料时，适当提高热床温度可以降低翘曲的概率。"
+
+#~ msgid "Enter"
+#~ msgstr "回车"
+
+#~ msgid "Esc"
+#~ msgstr "Esc"
+
+#~ msgid "Del"
+#~ msgstr "删除"
+
+#~ msgid "Backspace"
+#~ msgstr "回退键"
+
+#~ msgid "Arrow Up"
+#~ msgstr "上箭头"
+
+#~ msgid "Arrow Down"
+#~ msgstr "下箭头"
+
+#~ msgid "Arrow Left"
+#~ msgstr "左箭头"
+
+#~ msgid "Arrow Right"
+#~ msgstr "右箭头"
+
+#~ msgid "End"
+#~ msgstr "结束"
 
 #~ msgid "Hotend"
 #~ msgstr "热端"

--- a/localization/i18n/zh_TW/OrcaSlicer_zh_TW.po
+++ b/localization/i18n/zh_TW/OrcaSlicer_zh_TW.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Orca Slicer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-20 10:39-0300\n"
+"POT-Creation-Date: 2026-07-22 19:11-0300\n"
 "PO-Revision-Date: 2025-11-28 13:48-0600\n"
 "Last-Translator: tntchn <15895303+tntchn@users.noreply.github.com>\n"
 "Language-Team: \n"
@@ -3525,8 +3525,9 @@ msgctxt "air_duct"
 msgid "Left(Aux)"
 msgstr "左側（輔助）"
 
+msgctxt "Hotend Heat Breaker Fan"
 msgid "Hotend"
-msgstr "熱端"
+msgstr ""
 
 msgid "Parts"
 msgstr "零件"
@@ -9036,6 +9037,15 @@ msgstr "顯示 FPS 疊加層"
 msgid "Displays current viewport FPS in the top-right corner."
 msgstr "在右上角顯示目前視埠的 FPS。"
 
+msgid "G-code Preview"
+msgstr ""
+
+msgid "Dim lower layers"
+msgstr ""
+
+msgid "When scrubbing the layer slider in the sliced preview, render the layers below the current one darkened so that only the layer being viewed is shown at full brightness."
+msgstr ""
+
 msgid "Login region"
 msgstr "登入區域"
 
@@ -9624,6 +9634,9 @@ msgstr "當啟用螺旋花瓶模式時，龍門結構的裝置不會產生縮時
 
 msgid "The current printer does not support timelapse in Traditional Mode when printing By-Object."
 msgstr "目前的列印裝置在使用逐件列印時不支援傳統模式的縮時攝影。"
+
+msgid "I have checked the installed nozzle and want to print anyway."
+msgstr ""
 
 msgid "Errors"
 msgstr "錯誤"
@@ -17112,6 +17125,12 @@ msgstr ""
 msgid "Whether this printer supports fast purge mode with optimized temperature and multiplier."
 msgstr ""
 
+msgid "Filament change"
+msgstr ""
+
+msgid "The volume of material required to prime the extruder on the tower, excluding a hotend change."
+msgstr ""
+
 msgid "The volume of material required to prime the extruder for a hotend change on the tower."
 msgstr "換熱端所需的擦料塔上的清理量。"
 
@@ -20331,14 +20350,14 @@ msgstr "錯誤：%s"
 msgid "Show details"
 msgstr "顯示詳細資訊"
 
+msgid "Hide details"
+msgstr ""
+
 msgid "Version to install:"
 msgstr "將安裝的版本："
 
 msgid "Download and Install"
 msgstr "下載並安裝"
-
-msgid "Skip for Now"
-msgstr "暫時略過"
 
 msgid "A new version of the Bambu Network Plug-in is available."
 msgstr "Bambu 網路外掛程式有新版本可用。"
@@ -20350,17 +20369,11 @@ msgstr "目前版本：%s"
 msgid "Update to version:"
 msgstr "更新到版本："
 
-msgid "Update Now"
-msgstr "立即更新"
-
-msgid "Remind Later"
-msgstr "稍後提醒"
-
-msgid "Skip Version"
-msgstr "略過此版本"
-
 msgid "Don't Ask Again"
 msgstr "不再詢問"
+
+msgid "Update Now"
+msgstr "立即更新"
 
 msgid "(Latest)"
 msgstr "（最新版）"
@@ -20376,9 +20389,6 @@ msgstr "需要重新啟動以載入新的外掛程式。您要立即重新啟動
 
 msgid "Restart Now"
 msgstr "立即重新啟動"
-
-msgid "Restart Later"
-msgstr "稍後重新啟動"
 
 msgid "NO RAMMING AT ALL"
 msgstr "完全不擠壓"
@@ -20988,6 +20998,21 @@ msgstr ""
 "避免翹曲\n"
 "您知道嗎？當列印容易翹曲的材料（如 ABS）時，適當提高熱床溫度\n"
 "可以降低翹曲的機率。"
+
+#~ msgid "Hotend"
+#~ msgstr "熱端"
+
+#~ msgid "Skip for Now"
+#~ msgstr "暫時略過"
+
+#~ msgid "Remind Later"
+#~ msgstr "稍後提醒"
+
+#~ msgid "Skip Version"
+#~ msgstr "略過此版本"
+
+#~ msgid "Restart Later"
+#~ msgstr "稍後重新啟動"
 
 #~ msgid "Select filament that installed to the left nozzle"
 #~ msgstr "選擇安裝到左側噴嘴的線材"

--- a/localization/i18n/zh_TW/OrcaSlicer_zh_TW.po
+++ b/localization/i18n/zh_TW/OrcaSlicer_zh_TW.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Orca Slicer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-23 14:21-0300\n"
+"POT-Creation-Date: 2026-07-23 15:24-0300\n"
 "PO-Revision-Date: 2025-11-28 13:48-0600\n"
 "Last-Translator: tntchn <15895303+tntchn@users.noreply.github.com>\n"
 "Language-Team: \n"
@@ -560,8 +560,9 @@ msgstr "重新配置"
 msgid "Reset"
 msgstr "重設"
 
+msgctxt "Keyboard Shortcut"
 msgid "Enter"
-msgstr "Enter"
+msgstr ""
 
 msgid "Shortcut Key "
 msgstr "快速鍵 "
@@ -1762,14 +1763,16 @@ msgstr "選擇"
 msgid "Select point"
 msgstr "選點"
 
+msgctxt "Keyboard Shortcut"
 msgid "Delete"
-msgstr "刪除"
+msgstr ""
 
 msgid "Restart selection"
 msgstr "重新開始選取"
 
+msgctxt "Keyboard Shortcut"
 msgid "Esc"
-msgstr "Esc"
+msgstr ""
 
 msgid "Cancel a feature until exit"
 msgstr "在退出前取消功能"
@@ -2415,6 +2418,9 @@ msgstr "無法開始 URL 下載。未設定目標資料夾。請在設定精靈�
 msgid "Import File"
 msgstr "匯入檔案"
 
+msgid "Delete"
+msgstr "刪除"
+
 msgid "Choose files"
 msgstr "選擇檔案"
 
@@ -2545,14 +2551,16 @@ msgstr "隱藏"
 msgid "Show"
 msgstr "顯示"
 
+msgctxt "Keyboard Shortcut"
 msgid "Del"
-msgstr "刪除"
+msgstr ""
 
 msgid "Delete the selected object"
 msgstr "刪除所選物件"
 
+msgctxt "Keyboard Shortcut"
 msgid "Backspace"
-msgstr "Backspace"
+msgstr ""
 
 msgid "Load..."
 msgstr "載入..."
@@ -11381,29 +11389,33 @@ msgstr "選擇多個物件"
 msgid "Select objects by rectangle"
 msgstr "框選多個零件"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Up"
-msgstr "上箭頭"
+msgstr ""
 
 # TODO: Review, changed by lang refactor. PR 14254
 msgid "Move selection 10mm in positive Y direction"
 msgstr "Y 方向移動 10mm"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Down"
-msgstr "下箭頭"
+msgstr ""
 
 # TODO: Review, changed by lang refactor. PR 14254
 msgid "Move selection 10mm in negative Y direction"
 msgstr "Y 方向移動 10mm"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Left"
-msgstr "左箭頭"
+msgstr ""
 
 # TODO: Review, changed by lang refactor. PR 14254
 msgid "Move selection 10mm in negative X direction"
 msgstr "X 方向移動 10mm"
 
+msgctxt "Keyboard Shortcut"
 msgid "Arrow Right"
-msgstr "右箭頭"
+msgstr ""
 
 # TODO: Review, changed by lang refactor. PR 14254
 msgid "Move selection 10mm in positive X direction"
@@ -11489,8 +11501,16 @@ msgstr "縮小"
 msgid "Toggle printable for object/part"
 msgstr "切換物件/零件的可列印屬性"
 
+msgctxt "Keyboard Shortcut"
+msgid "Tab"
+msgstr ""
+
 msgid "Switch between Prepare/Preview"
 msgstr "在準備/預覽模式之中切換"
+
+msgctxt "Keyboard Shortcut"
+msgid "Space"
+msgstr ""
 
 msgid "Open actions speed dial"
 msgstr ""
@@ -11550,11 +11570,16 @@ msgstr "開啟/關閉 G-code 視窗"
 msgid "Move slider 5x faster"
 msgstr "5 倍速移動滑動條"
 
+msgctxt "Keyboard Shortcut"
+msgid "Home"
+msgstr ""
+
 msgid "Horizontal slider - Move to start position"
 msgstr "水平滑動條 - 移動到起始位置"
 
+msgctxt "Keyboard Shortcut"
 msgid "End"
-msgstr "結束"
+msgstr ""
 
 msgid "Horizontal slider - Move to last position"
 msgstr "水平滑動條 - 移動到最後位置"
@@ -21026,6 +21051,33 @@ msgstr ""
 "避免翹曲\n"
 "您知道嗎？當列印容易翹曲的材料（如 ABS）時，適當提高熱床溫度\n"
 "可以降低翹曲的機率。"
+
+#~ msgid "Enter"
+#~ msgstr "Enter"
+
+#~ msgid "Esc"
+#~ msgstr "Esc"
+
+#~ msgid "Del"
+#~ msgstr "刪除"
+
+#~ msgid "Backspace"
+#~ msgstr "Backspace"
+
+#~ msgid "Arrow Up"
+#~ msgstr "上箭頭"
+
+#~ msgid "Arrow Down"
+#~ msgstr "下箭頭"
+
+#~ msgid "Arrow Left"
+#~ msgstr "左箭頭"
+
+#~ msgid "Arrow Right"
+#~ msgstr "右箭頭"
+
+#~ msgid "End"
+#~ msgstr "結束"
 
 #~ msgid "Hotend"
 #~ msgstr "熱端"

--- a/localization/i18n/zh_TW/OrcaSlicer_zh_TW.po
+++ b/localization/i18n/zh_TW/OrcaSlicer_zh_TW.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Orca Slicer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-22 19:11-0300\n"
+"POT-Creation-Date: 2026-07-23 14:21-0300\n"
 "PO-Revision-Date: 2025-11-28 13:48-0600\n"
 "Last-Translator: tntchn <15895303+tntchn@users.noreply.github.com>\n"
 "Language-Team: \n"
@@ -897,8 +897,9 @@ msgstr "取消選擇連接件"
 msgid "Select all connectors"
 msgstr "選擇所有連接件"
 
+msgctxt "Cut tool"
 msgid "Cut"
-msgstr "切割"
+msgstr ""
 
 msgid "Rotate cut plane"
 msgstr "旋轉切割面"
@@ -1869,8 +1870,9 @@ msgstr "進入測量工具模式"
 msgid "Leaving Measure gizmo"
 msgstr "退出測量工具模式"
 
+msgctxt "Assembly tool"
 msgid "Assemble"
-msgstr "組合"
+msgstr ""
 
 msgid "Please confirm explosion ratio = 1 and select at least two volumes."
 msgstr "請確認爆炸比例 = 1 並選擇至少兩個零件。"
@@ -2750,6 +2752,9 @@ msgstr "從公尺轉換"
 # TODO: Review, changed by lang refactor. PR 14254
 msgid "Restore to Meter"
 msgstr "還原到公尺"
+
+msgid "Assemble"
+msgstr "組合"
 
 msgid "Assemble the selected objects into an object with multiple parts"
 msgstr "組合所選物件為一個多零件物件"
@@ -4286,6 +4291,14 @@ msgstr "使用安裝在機箱背面的線材進行列印"
 msgid "Print with filament in AMS"
 msgstr "使用 AMS 裡的線材列印"
 
+msgctxt "Nozzle position"
+msgid "Left"
+msgstr ""
+
+msgctxt "Nozzle position"
+msgid "Right"
+msgstr ""
+
 msgid "When the current material run out, the printer will continue to print in the following order."
 msgstr "當目前線材用完時，列印裝置將按照以下順序繼續列印。"
 
@@ -5627,8 +5640,9 @@ msgstr "適應性"
 msgid "Quality / Speed"
 msgstr "細節/速度"
 
+msgctxt "Mesh action"
 msgid "Smooth"
-msgstr "平滑模式"
+msgstr ""
 
 msgid "Radius"
 msgstr "半徑"
@@ -6251,6 +6265,9 @@ msgstr "復原"
 msgid "Redo"
 msgstr "重做"
 
+msgid "Cut"
+msgstr "切割"
+
 msgid "Cut selection to clipboard"
 msgstr "剪下所選項目到剪貼簿"
 
@@ -6351,6 +6368,10 @@ msgstr "在 3D 場景中顯示選定物件的輪廓"
 
 msgid "Preferences"
 msgstr "偏好設定"
+
+msgctxt "Menu"
+msgid "Edit"
+msgstr ""
 
 msgid "View"
 msgstr "視角"
@@ -9342,8 +9363,9 @@ msgstr "不相容的預設"
 msgid "The selected preset is null!"
 msgstr "選擇的預設為空！"
 
+msgctxt "Layer range"
 msgid "End"
-msgstr "結束"
+msgstr ""
 
 msgid "Customize"
 msgstr "自訂"
@@ -11530,6 +11552,9 @@ msgstr "5 倍速移動滑動條"
 
 msgid "Horizontal slider - Move to start position"
 msgstr "水平滑動條 - 移動到起始位置"
+
+msgid "End"
+msgstr "結束"
 
 msgid "Horizontal slider - Move to last position"
 msgstr "水平滑動條 - 移動到最後位置"
@@ -16143,6 +16168,9 @@ msgstr "選擇平滑模式或傳統模式時，列印過程將產生縮時影片
 
 msgid "Traditional"
 msgstr "傳統模式"
+
+msgid "Smooth"
+msgstr "平滑模式"
 
 msgid "Farthest point timelapse"
 msgstr ""

--- a/scripts/run_gettext.bat
+++ b/scripts/run_gettext.bat
@@ -23,7 +23,7 @@ if %FULL_MODE%==1 (
     call :prepareGettextList "%list_file%" "%filtered_list%" "%missing_list%"
     if "!has_sources!"=="1" (
         if not exist "%generated_i18n%" mkdir "%generated_i18n%"
-        .\tools\xgettext.exe --keyword=L --keyword=_L --keyword=_u8L --keyword=L_CONTEXT:1,2c --keyword=_CTX:1,2c --keyword=_CTX_utf8:1,2c --keyword=_L_PLURAL:1,2 --add-comments=TRN --from-code=UTF-8 --no-location --debug --boost --no-wrap -f "%filtered_list%" -o "%generated_pot%"
+        .\tools\xgettext.exe --keyword=L --keyword=_L --keyword=_u8L --keyword=L_CONTEXT:1,2c --keyword=_L_CONTEXT:1,2c --keyword=_u8L_CONTEXT:1,2c --keyword=_L_PLURAL:1,2 --add-comments=TRN --from-code=UTF-8 --no-location --debug --boost --no-wrap -f "%filtered_list%" -o "%generated_pot%"
         if errorlevel 1 (
             set "script_exit_code=1"
         ) else (

--- a/scripts/run_gettext.sh
+++ b/scripts/run_gettext.sh
@@ -85,7 +85,7 @@ if $FULL_MODE; then
         generated_pot_file="${generated_i18n_dir}/OrcaSlicer.pot"
 
         mkdir -p "$generated_i18n_dir"
-        xgettext --keyword=L --keyword=_L --keyword=_u8L --keyword=L_CONTEXT:1,2c --keyword=_CTX:1,2c --keyword=_CTX_utf8:1,2c --keyword=_L_PLURAL:1,2 --add-comments=TRN --from-code=UTF-8 --no-location --debug --boost --no-wrap -f "$filtered_list" -o "$generated_pot_file"
+        xgettext --keyword=L --keyword=_L --keyword=_u8L --keyword=L_CONTEXT:1,2c --keyword=_L_CONTEXT:1,2c --keyword=_u8L_CONTEXT:1,2c --keyword=_L_PLURAL:1,2 --add-comments=TRN --from-code=UTF-8 --no-location --debug --boost --no-wrap -f "$filtered_list" -o "$generated_pot_file"
         python3 scripts/HintsToPot.py ./resources "$generated_i18n_dir"
 
         if [ -f "$pot_file" ] && files_equal_ignoring_pot_date "$pot_file" "$generated_pot_file"; then

--- a/src/slic3r/GUI/AMSDryControl.cpp
+++ b/src/slic3r/GUI/AMSDryControl.cpp
@@ -736,7 +736,7 @@ wxBoxSizer* AMSDryCtrWin::create_guide_right_section(wxPanel* parent)
 
     m_back_button = create_button(
         parent,
-        wxString::FromUTF8(_CTX_utf8(L_CONTEXT("Back", "amsdrying"), "amsdrying")),
+        wxString::FromUTF8(_u8L_CONTEXT(L_CONTEXT("Back", "amsdrying"), "amsdrying")),
         wxColour("#F8F8F8"),       // Background color - light gray
         wxColour("#D0D0D0"),       // Border color - gray
         *wxBLACK                   // Text color - black

--- a/src/slic3r/GUI/AmsMappingPopup.cpp
+++ b/src/slic3r/GUI/AmsMappingPopup.cpp
@@ -2100,7 +2100,7 @@ void AmsReplaceMaterialDialog::create()
     m_top_line->SetBackgroundColour(wxColour(166, 169, 170));
     m_main_sizer->Add(m_top_line, 0, wxEXPAND, 0);
 
-    m_nozzle_btn_panel = new SwitchBoard(this, _CTX("Left", "Nozzle position"), _CTX("Right", "Nozzle position"), wxSize(FromDIP(126), FromDIP(26)));
+    m_nozzle_btn_panel = new SwitchBoard(this, _L_CONTEXT("Left", "Nozzle position"), _L_CONTEXT("Right", "Nozzle position"), wxSize(FromDIP(126), FromDIP(26)));
     m_nozzle_btn_panel->Hide();
     m_nozzle_btn_panel->Connect(wxCUSTOMEVT_SWITCH_POS, wxCommandEventHandler(AmsReplaceMaterialDialog::on_nozzle_selected), NULL, this);
 

--- a/src/slic3r/GUI/AmsMappingPopup.cpp
+++ b/src/slic3r/GUI/AmsMappingPopup.cpp
@@ -2100,7 +2100,7 @@ void AmsReplaceMaterialDialog::create()
     m_top_line->SetBackgroundColour(wxColour(166, 169, 170));
     m_main_sizer->Add(m_top_line, 0, wxEXPAND, 0);
 
-    m_nozzle_btn_panel = new SwitchBoard(this, _L("Left"), _L("Right"), wxSize(FromDIP(126), FromDIP(26)));
+    m_nozzle_btn_panel = new SwitchBoard(this, _CTX("Left", "Nozzle position"), _CTX("Right", "Nozzle position"), wxSize(FromDIP(126), FromDIP(26)));
     m_nozzle_btn_panel->Hide();
     m_nozzle_btn_panel->Connect(wxCUSTOMEVT_SWITCH_POS, wxCommandEventHandler(AmsReplaceMaterialDialog::on_nozzle_selected), NULL, this);
 

--- a/src/slic3r/GUI/DeviceTab/uiAMSBestPositionPopup.cpp
+++ b/src/slic3r/GUI/DeviceTab/uiAMSBestPositionPopup.cpp
@@ -637,7 +637,7 @@ ReselectMachineDialog::ReselectMachineDialog(wxWindow* parent)
 
     wxBoxSizer* okGroupSizer = new wxBoxSizer(wxHORIZONTAL);
     UiAMSSlot* amsSlotOK= new UiAMSSlot(statusBar, colourOK, wxString("Ax\nPLA"), DataStatusType::OK, wxID_ANY, wxDefaultPosition, wxSize(FromDIP(58), FromDIP(90)), 1.0, 1.0);
-    wxStaticText* okLabel = new wxStaticText(statusBar, wxID_ANY, _CTX(L_CONTEXT("OK", "FilamentTrack"), "FilamentTrack"));
+    wxStaticText* okLabel = new wxStaticText(statusBar, wxID_ANY, _L_CONTEXT(L_CONTEXT("OK", "FilamentTrack"), "FilamentTrack"));
     okLabel->SetFont(wxGetApp().normal_font());
     okLabel->SetForegroundColour(wxColour("#6B6B6B"));
 

--- a/src/slic3r/GUI/ExtrusionCalibration.cpp
+++ b/src/slic3r/GUI/ExtrusionCalibration.cpp
@@ -239,7 +239,7 @@ void ExtrusionCalibration::create()
     m_button_save_result->SetStyle(ButtonStyle::Confirm, ButtonType::Choice);
     m_button_save_result->Bind(wxEVT_BUTTON, &ExtrusionCalibration::on_click_save, this);
 
-    m_button_last_step = new Button(m_step_2_panel, _CTX("Back", "Navigation")); // Back for english
+    m_button_last_step = new Button(m_step_2_panel, _L_CONTEXT("Back", "Navigation")); // Back for english
     m_button_last_step->SetStyle(ButtonStyle::Regular, ButtonType::Choice);
     m_button_last_step->Bind(wxEVT_BUTTON, &ExtrusionCalibration::on_click_last, this);
 

--- a/src/slic3r/GUI/FilamentMapPanel.cpp
+++ b/src/slic3r/GUI/FilamentMapPanel.cpp
@@ -105,7 +105,7 @@ void FilamentMapManualPanel::OnTimer(wxTimerEvent &)
             m_suggestion_panel->Hide();
         } else {
             m_errors->SetLabel(wxString::Format(_L("Error: %s extruder has no available %s nozzle, current group result is invalid."),
-                                                invalid_eid == 0 ? _L("Left") : _L("Right"),
+                                                invalid_eid == 0 ? _CTX("Left", "Nozzle position") : _CTX("Right", "Nozzle position"),
                                                 invalid_nozzle == NozzleVolumeType::nvtStandard ? _L("Standard") : _L("High Flow")));
             // Re-wrap: wrapping only applies to the label text present when Wrap is called,
             // and the label was empty at construction time.

--- a/src/slic3r/GUI/FilamentMapPanel.cpp
+++ b/src/slic3r/GUI/FilamentMapPanel.cpp
@@ -105,7 +105,7 @@ void FilamentMapManualPanel::OnTimer(wxTimerEvent &)
             m_suggestion_panel->Hide();
         } else {
             m_errors->SetLabel(wxString::Format(_L("Error: %s extruder has no available %s nozzle, current group result is invalid."),
-                                                invalid_eid == 0 ? _CTX("Left", "Nozzle position") : _CTX("Right", "Nozzle position"),
+                                                invalid_eid == 0 ? _L_CONTEXT("Left", "Nozzle position") : _L_CONTEXT("Right", "Nozzle position"),
                                                 invalid_nozzle == NozzleVolumeType::nvtStandard ? _L("Standard") : _L("High Flow")));
             // Re-wrap: wrapping only applies to the label text present when Wrap is called,
             // and the label was empty at construction time.

--- a/src/slic3r/GUI/GCodeViewer.cpp
+++ b/src/slic3r/GUI/GCodeViewer.cpp
@@ -4268,7 +4268,7 @@ void GCodeViewer::render_legend(float &legend_height, int canvas_width, int canv
         };
 
         auto append_print = [&imgui, imperial_units](const ColorRGBA& color, const std::array<float, 4>& offsets, const Times& times, std::pair<double, double> used_filament) {
-            imgui.text(_CTX_utf8("Print", "Noun"));
+            imgui.text(_u8L_CONTEXT("Print", "Noun"));
             ImGui::SameLine();
 
             float icon_size = ImGui::GetTextLineHeight();
@@ -4302,7 +4302,7 @@ void GCodeViewer::render_legend(float &legend_height, int canvas_width, int canv
             for (const PartialTime& item : partial_times) {
                 switch (item.type)
                 {
-                case PartialTime::EType::Print:       { labels.push_back(_CTX_utf8("Print", "Noun")); break; }
+                case PartialTime::EType::Print:       { labels.push_back(_u8L_CONTEXT("Print", "Noun")); break; }
                 case PartialTime::EType::Pause:       { labels.push_back(_u8L("Pause")); break; }
                 case PartialTime::EType::ColorChange: { labels.push_back(_u8L("Color change")); break; }
                 }

--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -282,7 +282,7 @@ void GLCanvas3D::LayersEditing::render_variable_layer_height_dialog(GLCanvas3D& 
     ImGui::SetCursorPosX(input_align);
     ImGui::BBLDragFloat("##adaptive_input", &m_adaptive_quality, 0.05f, 0.0f, 0.0f, "%.2f");
 
-    if (imgui.button(_CTX("Smooth", "Mesh action")))
+    if (imgui.button(_L_CONTEXT("Smooth", "Mesh action")))
         wxPostEvent((wxEvtHandler*)canvas.get_wxglcanvas(), HeightProfileSmoothEvent(EVT_GLCANVAS_SMOOTH_LAYER_HEIGHT_PROFILE, m_smooth_params));
     ImGui::SameLine();
     text_align = std::max(text_align, ImGui::GetCursorPosX());
@@ -6048,11 +6048,11 @@ void GLCanvas3D::_render_3d_navigator()
     strcpy(style.AxisLabels[ImGuizmo::Axis::Axis_Y], "Z"); // ORCA use uppercase to match text on tranform widgets
     strcpy(style.AxisLabels[ImGuizmo::Axis::Axis_Z], "X"); // ORCA use uppercase to match text on tranform widgets
     strcpy(style.FaceLabels[ImGuizmo::FACES::FACE_FRONT], _utf8("Front").c_str());
-    strcpy(style.FaceLabels[ImGuizmo::FACES::FACE_BACK], _CTX_utf8("Back", "Camera View").c_str());
+    strcpy(style.FaceLabels[ImGuizmo::FACES::FACE_BACK], _u8L_CONTEXT("Back", "Camera View").c_str());
     strcpy(style.FaceLabels[ImGuizmo::FACES::FACE_TOP], _utf8("Top").c_str());
     strcpy(style.FaceLabels[ImGuizmo::FACES::FACE_BOTTOM], _utf8("Bottom").c_str());
-    strcpy(style.FaceLabels[ImGuizmo::FACES::FACE_LEFT], _CTX_utf8("Left", "Camera View").c_str());
-    strcpy(style.FaceLabels[ImGuizmo::FACES::FACE_RIGHT], _CTX_utf8("Right", "Camera View").c_str());
+    strcpy(style.FaceLabels[ImGuizmo::FACES::FACE_LEFT], _u8L_CONTEXT("Left", "Camera View").c_str());
+    strcpy(style.FaceLabels[ImGuizmo::FACES::FACE_RIGHT], _u8L_CONTEXT("Right", "Camera View").c_str());
 
     float sc = get_scale();
 #ifdef WIN32

--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -282,7 +282,7 @@ void GLCanvas3D::LayersEditing::render_variable_layer_height_dialog(GLCanvas3D& 
     ImGui::SetCursorPosX(input_align);
     ImGui::BBLDragFloat("##adaptive_input", &m_adaptive_quality, 0.05f, 0.0f, 0.0f, "%.2f");
 
-    if (imgui.button(_L("Smooth")))
+    if (imgui.button(_CTX("Smooth", "Mesh action")))
         wxPostEvent((wxEvtHandler*)canvas.get_wxglcanvas(), HeightProfileSmoothEvent(EVT_GLCANVAS_SMOOTH_LAYER_HEIGHT_PROFILE, m_smooth_params));
     ImGui::SameLine();
     text_align = std::max(text_align, ImGui::GetCursorPosX());

--- a/src/slic3r/GUI/GUI_Factories.cpp
+++ b/src/slic3r/GUI/GUI_Factories.cpp
@@ -533,11 +533,11 @@ void MenuFactory::append_menu_item_set_visible(wxMenu* menu)
 void MenuFactory::append_menu_item_delete(wxMenu* menu)
 {
 #ifdef __WINDOWS__
-    append_menu_item(menu, wxID_ANY, _L("Delete") + "\t" + _CTX("Del", "Keyboard Shortcut"), _L("Delete the selected object"),
+    append_menu_item(menu, wxID_ANY, _L("Delete") + "\t" + _L_CONTEXT("Del", "Keyboard Shortcut"), _L("Delete the selected object"),
         [](wxCommandEvent&) { plater()->remove_selected(); }, "menu_delete", nullptr,
         []() { return plater()->can_delete(); }, m_parent);
 #else
-    append_menu_item(menu, wxID_ANY, _L("Delete") + "\t" + _CTX("Backspace", "Keyboard Shortcut"), _L("Delete the selected object"),
+    append_menu_item(menu, wxID_ANY, _L("Delete") + "\t" + _L_CONTEXT("Backspace", "Keyboard Shortcut"), _L("Delete the selected object"),
         [](wxCommandEvent&) { plater()->remove_selected(); }, "", nullptr,
         []() { return plater()->can_delete(); }, m_parent);
 #endif

--- a/src/slic3r/GUI/GUI_Factories.cpp
+++ b/src/slic3r/GUI/GUI_Factories.cpp
@@ -533,11 +533,11 @@ void MenuFactory::append_menu_item_set_visible(wxMenu* menu)
 void MenuFactory::append_menu_item_delete(wxMenu* menu)
 {
 #ifdef __WINDOWS__
-    append_menu_item(menu, wxID_ANY, _L("Delete") + "\t" + _L("Del"), _L("Delete the selected object"),
+    append_menu_item(menu, wxID_ANY, _L("Delete") + "\t" + _CTX("Del", "Keyboard Shortcut"), _L("Delete the selected object"),
         [](wxCommandEvent&) { plater()->remove_selected(); }, "menu_delete", nullptr,
         []() { return plater()->can_delete(); }, m_parent);
 #else
-    append_menu_item(menu, wxID_ANY, _L("Delete") + "\t" + _L("Backspace"), _L("Delete the selected object"),
+    append_menu_item(menu, wxID_ANY, _L("Delete") + "\t" + _CTX("Backspace", "Keyboard Shortcut"), _L("Delete the selected object"),
         [](wxCommandEvent&) { plater()->remove_selected(); }, "", nullptr,
         []() { return plater()->can_delete(); }, m_parent);
 #endif

--- a/src/slic3r/GUI/Gizmos/GLGizmoAdvancedCut.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoAdvancedCut.cpp
@@ -372,7 +372,7 @@ bool GLGizmoAdvancedCut::on_init()
 
 std::string GLGizmoAdvancedCut::on_get_name() const
 {
-    return (_(L("Cut"))).ToUTF8().data();
+    return (_CTX("Cut", "Cut tool")).ToUTF8().data();
 }
 
 void GLGizmoAdvancedCut::on_load(cereal::BinaryInputArchive &ar)

--- a/src/slic3r/GUI/Gizmos/GLGizmoAdvancedCut.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoAdvancedCut.cpp
@@ -372,7 +372,7 @@ bool GLGizmoAdvancedCut::on_init()
 
 std::string GLGizmoAdvancedCut::on_get_name() const
 {
-    return (_CTX("Cut", "Cut tool")).ToUTF8().data();
+    return (_L_CONTEXT("Cut", "Cut tool")).ToUTF8().data();
 }
 
 void GLGizmoAdvancedCut::on_load(cereal::BinaryInputArchive &ar)
@@ -1905,7 +1905,7 @@ bool GLGizmoAdvancedCut::render_slider_double_input(const std::string &label, fl
         mean_size *= float(units_mm_to_in);
         min_size *= float(units_mm_to_in);
     }
-    std::string format = value_in < 0.f ? " " : m_imperial_units ? "%.4f  " + _CTX_utf8("in", "inches") : "%.2f  " + _u8L("mm");
+    std::string format = value_in < 0.f ? " " : m_imperial_units ? "%.4f  " + _u8L_CONTEXT("in", "inches") : "%.2f  " + _u8L("mm");
 
     m_imgui->bbl_slider_float_style(("##" + label).c_str(), &value, min_size, mean_size, format.c_str());
 

--- a/src/slic3r/GUI/Gizmos/GLGizmoAssembly.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoAssembly.cpp
@@ -32,13 +32,13 @@ std::string GLGizmoAssembly::on_get_name() const
 {
     if (!on_is_activable() && m_state == EState::Off) {
         if (wxGetApp().plater()->canvas3D()->get_canvas_type() == GLCanvas3D::ECanvasType::CanvasAssembleView) {
-            return _CTX_utf8("Assemble", "Assembly tool") + ":\n" + _u8L("Please confirm explosion ratio = 1 and select at least two volumes.");
+            return _u8L_CONTEXT("Assemble", "Assembly tool") + ":\n" + _u8L("Please confirm explosion ratio = 1 and select at least two volumes.");
         }
         else {
-            return _CTX_utf8("Assemble", "Assembly tool") + ":\n" + _u8L("Please select at least two volumes.");
+            return _u8L_CONTEXT("Assemble", "Assembly tool") + ":\n" + _u8L("Please select at least two volumes.");
         }
     } else {
-        return _CTX_utf8("Assemble", "Assembly tool");
+        return _u8L_CONTEXT("Assemble", "Assembly tool");
     }
 }
 

--- a/src/slic3r/GUI/Gizmos/GLGizmoAssembly.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoAssembly.cpp
@@ -32,13 +32,13 @@ std::string GLGizmoAssembly::on_get_name() const
 {
     if (!on_is_activable() && m_state == EState::Off) {
         if (wxGetApp().plater()->canvas3D()->get_canvas_type() == GLCanvas3D::ECanvasType::CanvasAssembleView) {
-            return _u8L("Assemble") + ":\n" + _u8L("Please confirm explosion ratio = 1 and select at least two volumes.");
+            return _CTX_utf8("Assemble", "Assembly tool") + ":\n" + _u8L("Please confirm explosion ratio = 1 and select at least two volumes.");
         }
         else {
-            return _u8L("Assemble") + ":\n" + _u8L("Please select at least two volumes.");
+            return _CTX_utf8("Assemble", "Assembly tool") + ":\n" + _u8L("Please select at least two volumes.");
         }
     } else {
-        return _u8L("Assemble");
+        return _CTX_utf8("Assemble", "Assembly tool");
     }
 }
 

--- a/src/slic3r/GUI/Gizmos/GLGizmoCut.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoCut.cpp
@@ -1386,7 +1386,7 @@ void GLGizmoCut3D::on_save(cereal::BinaryOutputArchive& ar) const
 
 std::string GLGizmoCut3D::on_get_name() const
 {
-    return _u8L("Cut");
+    return _CTX_utf8("Cut", "Cut tool");
 }
 
 void GLGizmoCut3D::apply_color_clip_plane_colors()

--- a/src/slic3r/GUI/Gizmos/GLGizmoCut.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoCut.cpp
@@ -241,7 +241,7 @@ std::string GLGizmoCut3D::get_tooltip() const
     std::string tooltip;
     if (m_hover_id == Z || (m_dragging && m_hover_id == CutPlane)) {
         double koef = m_imperial_units ? GizmoObjectManipulation::mm_to_in : 1.0;
-        std::string unit_str = " " + (m_imperial_units ? _CTX_utf8("in", "inches") : _u8L("mm"));
+        std::string unit_str = " " + (m_imperial_units ? _u8L_CONTEXT("in", "inches") : _u8L("mm"));
         const BoundingBoxf3& tbb = m_transformed_bounding_box;
 
         const std::string name = m_keep_as_parts ? _u8L("Part") : _u8L("Object");
@@ -541,7 +541,7 @@ bool GLGizmoCut3D::render_double_input(const std::string& label, double& value_i
     ImGui::InputDouble(("##" + label).c_str(), &value, 0.0f, 0.0f, "%.2f", ImGuiInputTextFlags_CharsDecimal);
 
     ImGui::SameLine();
-    m_imgui->text(m_imperial_units ? _CTX("in", "inches") : _L("mm"));
+    m_imgui->text(m_imperial_units ? _L_CONTEXT("in", "inches") : _L("mm"));
 
     value_in = value * (m_imperial_units ? GizmoObjectManipulation::in_to_mm : 1.0);
     return !is_approx(old_val, value);
@@ -582,7 +582,7 @@ bool GLGizmoCut3D::render_slider_two_input(const std::string& label, float& valu
     if (m_imperial_units) {
         min_size *= f_mm_to_in;
     }
-    std::string format = value_in < 0.f ? " " : m_imperial_units ? "%.4f " + _CTX_utf8("in", "inches") : "%.2f " + _u8L("mm");
+    std::string format = value_in < 0.f ? " " : m_imperial_units ? "%.4f " + _u8L_CONTEXT("in", "inches") : "%.2f " + _u8L("mm");
 
     m_imgui->bbl_slider_float_style(("##" + label).c_str(), &value, min_size, mean_size, format.c_str());
 
@@ -653,7 +653,7 @@ bool GLGizmoCut3D::render_slider_input(const std::string& label, float& value_in
     if (m_imperial_units) {
         min_size *= f_mm_to_in;
     }
-    std::string format = value_in < 0.f ? " " : m_imperial_units ? "%.4f  " + _CTX_utf8("in", "inches") : "%.2f  " + _u8L("mm");
+    std::string format = value_in < 0.f ? " " : m_imperial_units ? "%.4f  " + _u8L_CONTEXT("in", "inches") : "%.2f  " + _u8L("mm");
 
     m_imgui->bbl_slider_float_style(("##" + label).c_str(), &value, min_size, max_value, format.c_str());
 
@@ -1386,7 +1386,7 @@ void GLGizmoCut3D::on_save(cereal::BinaryOutputArchive& ar) const
 
 std::string GLGizmoCut3D::on_get_name() const
 {
-    return _CTX_utf8("Cut", "Cut tool");
+    return _u8L_CONTEXT("Cut", "Cut tool");
 }
 
 void GLGizmoCut3D::apply_color_clip_plane_colors()
@@ -2472,7 +2472,7 @@ void GLGizmoCut3D::render_connectors_input_window(CutConnectors &connectors, flo
 void GLGizmoCut3D::render_build_size()
 {
     double   koef     = m_imperial_units ? GizmoObjectManipulation::mm_to_in : 1.0;
-    wxString unit_str = m_imperial_units ? _CTX("in", "inches") : _L("mm");
+    wxString unit_str = m_imperial_units ? _L_CONTEXT("in", "inches") : _L("mm");
     Vec3d    tbb_sz   = m_transformed_bounding_box.size() * koef; // ORCA 
 
     ImGui::AlignTextToFramePadding();

--- a/src/slic3r/GUI/Gizmos/GLGizmoEmboss.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoEmboss.cpp
@@ -1961,7 +1961,7 @@ void GLGizmoEmboss::draw_model_type()
 
     ImGui::SameLine();
     std::string last_solid_part_hint = _u8L("You can't change a type of the last solid part of the object.");
-    if (ImGui::RadioButton(_CTX_utf8(L_CONTEXT("Cut", "EmbossOperation"), "EmbossOperation").c_str(), type == negative))
+    if (ImGui::RadioButton(_u8L_CONTEXT(L_CONTEXT("Cut", "EmbossOperation"), "EmbossOperation").c_str(), type == negative))
         new_type = negative;
     else if (ImGui::IsItemHovered()) {
         if (is_last_solid_part)
@@ -2811,29 +2811,29 @@ void GLGizmoEmboss::draw_advanced()
         ImGui::SameLine(input_offset);
         if (align.first==FontProp::HorizontalAlign::left) draw(get_icon(icons, IconType::align_horizontal_left, IconState::hovered));
         else if (draw_button(icons, IconType::align_horizontal_left)) { align.first=FontProp::HorizontalAlign::left; is_change = true; }
-        else if (ImGui::IsItemHovered()) m_imgui->tooltip(_CTX_utf8(L_CONTEXT("Left", "Alignment"), "Alignment"), m_gui_cfg->max_tooltip_width);
+        else if (ImGui::IsItemHovered()) m_imgui->tooltip(_u8L_CONTEXT(L_CONTEXT("Left", "Alignment"), "Alignment"), m_gui_cfg->max_tooltip_width);
         ImGui::SameLine();
         if (align.first==FontProp::HorizontalAlign::center) draw(get_icon(icons, IconType::align_horizontal_center, IconState::hovered));
         else if (draw_button(icons, IconType::align_horizontal_center)) { align.first=FontProp::HorizontalAlign::center; is_change = true; }
-        else if (ImGui::IsItemHovered()) m_imgui->tooltip(_CTX_utf8(L_CONTEXT("Center", "Alignment"), "Alignment"), m_gui_cfg->max_tooltip_width);
+        else if (ImGui::IsItemHovered()) m_imgui->tooltip(_u8L_CONTEXT(L_CONTEXT("Center", "Alignment"), "Alignment"), m_gui_cfg->max_tooltip_width);
         ImGui::SameLine();
         if (align.first==FontProp::HorizontalAlign::right) draw(get_icon(icons, IconType::align_horizontal_right, IconState::hovered));
         else if (draw_button(icons, IconType::align_horizontal_right)) { align.first=FontProp::HorizontalAlign::right; is_change = true; }
-        else if (ImGui::IsItemHovered()) m_imgui->tooltip(_CTX_utf8(L_CONTEXT("Right", "Alignment"), "Alignment"), m_gui_cfg->max_tooltip_width);
+        else if (ImGui::IsItemHovered()) m_imgui->tooltip(_u8L_CONTEXT(L_CONTEXT("Right", "Alignment"), "Alignment"), m_gui_cfg->max_tooltip_width);
 
         ImGui::SameLine(0, ImGui::GetStyle().ItemSpacing.x * 2.f); // ORCA use wider spacing for separation between horizontal / vertical alignment
 
         if (align.second==FontProp::VerticalAlign::top) draw(get_icon(icons, IconType::align_vertical_top, IconState::hovered));
         else if (draw_button(icons, IconType::align_vertical_top)) { align.second=FontProp::VerticalAlign::top; is_change = true; }
-        else if (ImGui::IsItemHovered()) m_imgui->tooltip(_CTX_utf8(L_CONTEXT("Top", "Alignment"), "Alignment"), m_gui_cfg->max_tooltip_width);
+        else if (ImGui::IsItemHovered()) m_imgui->tooltip(_u8L_CONTEXT(L_CONTEXT("Top", "Alignment"), "Alignment"), m_gui_cfg->max_tooltip_width);
         ImGui::SameLine();
         if (align.second==FontProp::VerticalAlign::center) draw(get_icon(icons, IconType::align_vertical_center, IconState::hovered));
         else if (draw_button(icons, IconType::align_vertical_center)) { align.second=FontProp::VerticalAlign::center; is_change = true; }
-        else if (ImGui::IsItemHovered()) m_imgui->tooltip(_CTX_utf8(L_CONTEXT("Middle", "Alignment"), "Alignment"), m_gui_cfg->max_tooltip_width);
+        else if (ImGui::IsItemHovered()) m_imgui->tooltip(_u8L_CONTEXT(L_CONTEXT("Middle", "Alignment"), "Alignment"), m_gui_cfg->max_tooltip_width);
         ImGui::SameLine();
         if (align.second==FontProp::VerticalAlign::bottom) draw(get_icon(icons, IconType::align_vertical_bottom, IconState::hovered));
         else if (draw_button(icons, IconType::align_vertical_bottom)) { align.second=FontProp::VerticalAlign::bottom; is_change = true; }
-        else if (ImGui::IsItemHovered()) m_imgui->tooltip(_CTX_utf8(L_CONTEXT("Bottom", "Alignment"), "Alignment"), m_gui_cfg->max_tooltip_width);
+        else if (ImGui::IsItemHovered()) m_imgui->tooltip(_u8L_CONTEXT(L_CONTEXT("Bottom", "Alignment"), "Alignment"), m_gui_cfg->max_tooltip_width);
         return is_change;
     };
     const FontProp::Align * def_align = stored_style ? &stored_style->prop.align : nullptr;

--- a/src/slic3r/GUI/Gizmos/GLGizmoMeasure.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoMeasure.cpp
@@ -455,8 +455,8 @@ bool GLGizmoMeasure::on_init()
     m_shortcuts = {
         {_L("Left mouse button"),           _L("Select")},
         {shift + _L("Left mouse button"),   _L("Select point")},
-        {_L("Delete"),                      _L("Restart selection")},
-        {_L("Esc"),                         _L("Cancel a feature until exit")},
+        {_CTX("Delete", "Keyboard Shortcut"),                      _L("Restart selection")},
+        {_CTX("Esc", "Keyboard Shortcut"),                         _L("Cancel a feature until exit")},
     };
 
     return true;

--- a/src/slic3r/GUI/Gizmos/GLGizmoMeasure.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoMeasure.cpp
@@ -455,8 +455,8 @@ bool GLGizmoMeasure::on_init()
     m_shortcuts = {
         {_L("Left mouse button"),           _L("Select")},
         {shift + _L("Left mouse button"),   _L("Select point")},
-        {_CTX("Delete", "Keyboard Shortcut"),                      _L("Restart selection")},
-        {_CTX("Esc", "Keyboard Shortcut"),                         _L("Cancel a feature until exit")},
+        {_L_CONTEXT("Delete", "Keyboard Shortcut"),                      _L("Restart selection")},
+        {_L_CONTEXT("Esc", "Keyboard Shortcut"),                         _L("Cancel a feature until exit")},
     };
 
     return true;
@@ -1252,7 +1252,7 @@ void GLGizmoMeasure::render_dimensioning()
         const bool use_inches = wxGetApp().app_config->get_bool("use_inches");
         const double curr_value = use_inches ? GizmoObjectManipulation::mm_to_in * distance : distance;
         const std::string curr_value_str = format_double(curr_value);
-        const std::string units = use_inches ? _CTX_utf8("in", "inches") : _u8L("mm");
+        const std::string units = use_inches ? _u8L_CONTEXT("in", "inches") : _u8L("mm");
         const float value_str_width = 20.0f + ImGui::CalcTextSize(curr_value_str.c_str()).x;
         static double edit_value = 0.0;
 
@@ -1303,7 +1303,7 @@ void GLGizmoMeasure::render_dimensioning()
                     return;
 
                 const double ratio = new_value / old_value;
-                wxGetApp().plater()->take_snapshot(_CTX_utf8("Scale", "Verb"), UndoRedo::SnapshotType::GizmoAction);
+                wxGetApp().plater()->take_snapshot(_u8L_CONTEXT("Scale", "Verb"), UndoRedo::SnapshotType::GizmoAction);
                 // apply scale
                 TransformationType type;
                 type.set_world();
@@ -1359,10 +1359,10 @@ void GLGizmoMeasure::render_dimensioning()
 
             ImGui::SameLine();
             ImGuiWrapper::push_confirm_button_style();
-            //if (m_imgui->button(_CTX(L_CONTEXT("Scale part", "Verb"), "Verb")))
+            //if (m_imgui->button(_L_CONTEXT(L_CONTEXT("Scale part", "Verb"), "Verb")))
                 //action_scale(edit_value, curr_value, true);
             //ImGui::SameLine();
-            if (m_imgui->button(_CTX(L_CONTEXT("Scale all", "Verb"), "Verb")))
+            if (m_imgui->button(_L_CONTEXT(L_CONTEXT("Scale all", "Verb"), "Verb")))
                 action_scale(edit_value, curr_value, false);
             ImGuiWrapper::pop_confirm_button_style();
             ImGui::SameLine();
@@ -2130,7 +2130,7 @@ void GLGizmoMeasure::show_face_face_assembly_senior()
 void GLGizmoMeasure::init_render_input_window()
 {
     m_use_inches        = wxGetApp().app_config->get_bool("use_inches");
-    m_units             = " " + (m_use_inches ? _CTX_utf8("in", "inches") : _u8L("mm"));
+    m_units             = " " + (m_use_inches ? _u8L_CONTEXT("in", "inches") : _u8L("mm"));
     m_space_size        = ImGui::CalcTextSize("  ").x * 2;
     m_input_size_max    = ImGui::CalcTextSize("-100.00").x * 1.2;
     m_same_model_object = is_two_volume_in_same_model_object();

--- a/src/slic3r/GUI/Gizmos/GLGizmoMmuSegmentation.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoMmuSegmentation.cpp
@@ -122,7 +122,7 @@ bool GLGizmoMmuSegmentation::on_init()
     std::pair<wxString, wxString> paint_shortcut            = {_L("Left mouse button"),         m_desc["paint"]};
     std::pair<wxString, wxString> erase_shortcut            = {shift + _L("Left mouse button"), m_desc["erase"]};
     std::pair<wxString, wxString> clipping_shortcut         = {alt + _L("Mouse wheel"),         m_desc["clipping_of_view"]};
-    std::pair<wxString, wxString> toggle_wireframe_shortcut = {alt + shift + _L("Enter"),       m_desc["toggle_wireframe"]};
+    std::pair<wxString, wxString> toggle_wireframe_shortcut = {alt + shift + _CTX("Enter", "Keyboard Shortcut"),       m_desc["toggle_wireframe"]};
 
     m_shortcuts_brush = {
         paint_shortcut,

--- a/src/slic3r/GUI/Gizmos/GLGizmoMmuSegmentation.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoMmuSegmentation.cpp
@@ -122,7 +122,7 @@ bool GLGizmoMmuSegmentation::on_init()
     std::pair<wxString, wxString> paint_shortcut            = {_L("Left mouse button"),         m_desc["paint"]};
     std::pair<wxString, wxString> erase_shortcut            = {shift + _L("Left mouse button"), m_desc["erase"]};
     std::pair<wxString, wxString> clipping_shortcut         = {alt + _L("Mouse wheel"),         m_desc["clipping_of_view"]};
-    std::pair<wxString, wxString> toggle_wireframe_shortcut = {alt + shift + _CTX("Enter", "Keyboard Shortcut"),       m_desc["toggle_wireframe"]};
+    std::pair<wxString, wxString> toggle_wireframe_shortcut = {alt + shift + _L_CONTEXT("Enter", "Keyboard Shortcut"),       m_desc["toggle_wireframe"]};
 
     m_shortcuts_brush = {
         paint_shortcut,

--- a/src/slic3r/GUI/Gizmos/GLGizmoSVG.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoSVG.cpp
@@ -1704,7 +1704,7 @@ void GLGizmoSVG::draw_size()
 
     if (m_keep_ratio) {
         std::stringstream ss;
-        ss << std::setprecision(2) << std::fixed << width << " x " << height << " " << (use_inch ? _CTX("in", "inches") : _L("mm"));
+        ss << std::setprecision(2) << std::fixed << width << " x " << height << " " << (use_inch ? _L_CONTEXT("in", "inches") : _L("mm"));
 
         ImGui::SameLine(m_gui_cfg->input_offset);
         ImGui::SetNextItemWidth(m_gui_cfg->input_width);
@@ -2016,7 +2016,7 @@ void GLGizmoSVG::draw_model_type()
     ImGui::SameLine();
 
     std::string last_solid_part_hint = _u8L("You can't change a type of the last solid part of the object.");
-    if (ImGui::RadioButton(_CTX_utf8(L_CONTEXT("Cut", "EmbossOperation"), "EmbossOperation").c_str(), type == negative))
+    if (ImGui::RadioButton(_u8L_CONTEXT(L_CONTEXT("Cut", "EmbossOperation"), "EmbossOperation").c_str(), type == negative))
         new_type = negative;
     else if (ImGui::IsItemHovered()) {
         if (is_last_solid_part)

--- a/src/slic3r/GUI/Gizmos/GLGizmoScale.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoScale.cpp
@@ -143,9 +143,9 @@ bool GLGizmoScale3D::on_init()
 std::string GLGizmoScale3D::on_get_name() const
 {
     if (!on_is_activable() && m_state == EState::Off) {
-        return _CTX_utf8("Scale", "Verb") + ":\n" + _u8L("Please select at least one object.");
+        return _u8L_CONTEXT("Scale", "Verb") + ":\n" + _u8L("Please select at least one object.");
     } else {
-        return _CTX_utf8("Scale", "Verb");
+        return _u8L_CONTEXT("Scale", "Verb");
     }
 }
 

--- a/src/slic3r/GUI/Gizmos/GLGizmoSlaSupports.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoSlaSupports.cpp
@@ -1213,8 +1213,8 @@ SlaGizmoHelpDialog::SlaGizmoHelpDialog()
     shortcuts.push_back(std::make_pair(_L"Del",                       _L("Remove selected points")));
     shortcuts.push_back(std::make_pair(ctrl+_L("Mouse wheel"),        _L("Move clipping plane")));
     shortcuts.push_back(std::make_pair("R",                           _L("Reset clipping plane")));
-    shortcuts.push_back(std::make_pair(_L("Enter"),                   _L("Apply changes")));
-    shortcuts.push_back(std::make_pair(_L("Esc"),                     _L("Discard changes")));
+    shortcuts.push_back(std::make_pair(_CTX("Enter", "Keyboard Shortcut"),                   _L("Apply changes")));
+    shortcuts.push_back(std::make_pair(_CTX("Esc", "Keyboard Shortcut"),                     _L("Discard changes")));
     shortcuts.push_back(std::make_pair("M",                           _L("Switch to editing mode")));
     shortcuts.push_back(std::make_pair("A",                           _L("Auto-generate points")));
 

--- a/src/slic3r/GUI/Gizmos/GLGizmoSlaSupports.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoSlaSupports.cpp
@@ -1213,8 +1213,8 @@ SlaGizmoHelpDialog::SlaGizmoHelpDialog()
     shortcuts.push_back(std::make_pair(_L"Del",                       _L("Remove selected points")));
     shortcuts.push_back(std::make_pair(ctrl+_L("Mouse wheel"),        _L("Move clipping plane")));
     shortcuts.push_back(std::make_pair("R",                           _L("Reset clipping plane")));
-    shortcuts.push_back(std::make_pair(_CTX("Enter", "Keyboard Shortcut"),                   _L("Apply changes")));
-    shortcuts.push_back(std::make_pair(_CTX("Esc", "Keyboard Shortcut"),                     _L("Discard changes")));
+    shortcuts.push_back(std::make_pair(_L_CONTEXT("Enter", "Keyboard Shortcut"),                   _L("Apply changes")));
+    shortcuts.push_back(std::make_pair(_L_CONTEXT("Esc", "Keyboard Shortcut"),                     _L("Discard changes")));
     shortcuts.push_back(std::make_pair("M",                           _L("Switch to editing mode")));
     shortcuts.push_back(std::make_pair("A",                           _L("Auto-generate points")));
 

--- a/src/slic3r/GUI/Gizmos/GizmoObjectManipulation.cpp
+++ b/src/slic3r/GUI/Gizmos/GizmoObjectManipulation.cpp
@@ -1161,7 +1161,7 @@ void GizmoObjectManipulation::do_render_scale_input_window(ImGuiWrapper* imgui_w
         imgui_wrapper->calc_text_size(_L("Part")).x
     }) + imgui_wrapper->calc_text_size("xxx"sv).x + imgui_wrapper->scaled(3.5f);
     float label_max = std::max({
-        imgui_wrapper->calc_text_size(_CTX("Scale", "Noun")).x,
+        imgui_wrapper->calc_text_size(_L_CONTEXT("Scale", "Noun")).x,
         imgui_wrapper->calc_text_size(_L("Size")).x
     });
     float caption_max = std::max(label_max, coord_combo_width - 3 * space_size);
@@ -1218,7 +1218,7 @@ void GizmoObjectManipulation::do_render_scale_input_window(ImGuiWrapper* imgui_w
 
     //ImGui::PushItemWidth(unit_size * 2);
     ImGui::AlignTextToFramePadding();
-    imgui_wrapper->text(_CTX("Scale", "Noun"));
+    imgui_wrapper->text(_L_CONTEXT("Scale", "Noun"));
     ImGui::SameLine(caption_max + space_size);
     ImGui::PushItemWidth(unit_size);
     ImGui::BBLInputDouble(label_scale_values[0][0], &scale[0], 0.0f, 0.0f, "%.2f");

--- a/src/slic3r/GUI/I18N.hpp
+++ b/src/slic3r/GUI/I18N.hpp
@@ -7,9 +7,9 @@
 #define _u8L(s)     Slic3r::GUI::I18N::translate_utf8((s))
 #endif /* _ */
 
-#ifndef _CTX
-#define _CTX(s, ctx) 	  Slic3r::GUI::I18N::translate((s), (ctx))
-#define _CTX_utf8(s, ctx) Slic3r::GUI::I18N::translate_utf8((s), (ctx))
+#ifndef _L_CONTEXT
+#define _L_CONTEXT(s, ctx) 	 Slic3r::GUI::I18N::translate((s), (ctx))
+#define _u8L_CONTEXT(s, ctx) Slic3r::GUI::I18N::translate_utf8((s), (ctx))
 #endif /* _ */
 
 #ifndef L

--- a/src/slic3r/GUI/ImageGrid.cpp
+++ b/src/slic3r/GUI/ImageGrid.cpp
@@ -644,7 +644,7 @@ void Slic3r::GUI::ImageGrid::renderContent1(wxDC &dc, wxPoint const &pt, int ind
         if (m_file_sys->GetFileType() == PrinterFileSystem::F_MODEL) {
             if (secondAction != _L("Play"))
                 thirdAction = secondAction;
-            secondAction = _CTX("Print", "Verb");
+            secondAction = _L_CONTEXT("Print", "Verb");
         }
         // Draw buttons on hovered item
         wxRect rect{pt.x, pt.y + m_content_rect.GetBottom() - m_buttons_background.GetHeight(), m_content_rect.GetWidth(), m_buttons_background.GetHeight()};

--- a/src/slic3r/GUI/KBShortcutsDialog.cpp
+++ b/src/slic3r/GUI/KBShortcutsDialog.cpp
@@ -344,7 +344,7 @@ wxPanel* KBShortcutsDialog::create_page(wxWindow* parent, const ShortcutsItem& s
         // Keyboard keys carry a "Keyboard Shortcut" context so translators keep them in English;
         // mouse-input labels are ordinary phrases and use the plain lookup.
         const bool is_mouse = shortcut.find("Mouse") != std::string::npos || shortcut.find("mouse") != std::string::npos;
-        auto key = new wxStaticText(scrollable_panel, wxID_ANY, is_mouse ? _(shortcut) : _CTX(shortcut, "Keyboard Shortcut"));
+        auto key = new wxStaticText(scrollable_panel, wxID_ANY, is_mouse ? _(shortcut) : _L_CONTEXT(shortcut, "Keyboard Shortcut"));
         key->SetForegroundColour(wxColour(50, 58, 61));
         key->SetFont(bold_font);
         grid_sizer->Add(key, 0, wxALIGN_CENTRE_VERTICAL);

--- a/src/slic3r/GUI/KBShortcutsDialog.cpp
+++ b/src/slic3r/GUI/KBShortcutsDialog.cpp
@@ -201,7 +201,7 @@ void KBShortcutsDialog::fill_shortcuts()
             #ifdef __APPLE__
                 {"fn+⌫", L("Delete Selected")},
             #else
-                {L("Del"), L("Delete Selected")},
+                {L_CONTEXT("Del", "Keyboard Shortcut"), L("Delete Selected")},
             #endif
             // Help
             { "?", L("Show keyboard shortcuts list") }
@@ -231,12 +231,12 @@ void KBShortcutsDialog::fill_shortcuts()
             {alt + L("Left mouse button"), L("Select a part")},
             {ctrl + L("Left mouse button"), L("Select multiple objects")},
             {shift + L("Left mouse button"), L("Select objects by rectangle")},
-            {L("Arrow Up"), L("Move selection 10mm in positive Y direction")},
-            {L("Arrow Down"), L("Move selection 10mm in negative Y direction")},
-            {L("Arrow Left"), L("Move selection 10mm in negative X direction")},
-            {L("Arrow Right"), L("Move selection 10mm in positive X direction")},
+            {L_CONTEXT("Arrow Up", "Keyboard Shortcut"), L("Move selection 10mm in positive Y direction")},
+            {L_CONTEXT("Arrow Down", "Keyboard Shortcut"), L("Move selection 10mm in negative Y direction")},
+            {L_CONTEXT("Arrow Left", "Keyboard Shortcut"), L("Move selection 10mm in negative X direction")},
+            {L_CONTEXT("Arrow Right", "Keyboard Shortcut"), L("Move selection 10mm in positive X direction")},
             {shift + L("Any arrow"), L("Movement step set to 1mm")},
-            {L("Esc"), L("Deselect All")},
+            {L_CONTEXT("Esc", "Keyboard Shortcut"), L("Deselect All")},
             {"1-9", L("Keyboard 1-9: set filament for object/part")},
             {ctrl + "0", L("Camera view - Default")},
             {ctrl + "1", L("Camera view - Top")},
@@ -266,14 +266,14 @@ void KBShortcutsDialog::fill_shortcuts()
             { "I", L("Zoom in") },
             { "O", L("Zoom out") },
             { "V", L("Toggle printable for object/part") },
-            { L("Tab"), L("Switch between Prepare/Preview") },
-            { L("Space"), L("Open actions speed dial") },
+            { L_CONTEXT("Tab", "Keyboard Shortcut"), L("Switch between Prepare/Preview") },
+            { L_CONTEXT("Space", "Keyboard Shortcut"), L("Open actions speed dial") },
 
         };
         m_full_shortcuts.push_back({ { _L("Plater"), "" }, plater_shortcuts });
 
         Shortcuts gizmos_shortcuts = {
-            {L("Esc"), L("Deselect All")},
+            {L_CONTEXT("Esc", "Keyboard Shortcut"), L("Deselect All")},
             {shift, L("Move: press to snap by 1mm")},
             {ctrl + L("Mouse wheel"), L("Support/Color Painting: adjust pen radius")},
             {alt + L("Mouse wheel"), L("Support/Color Painting: adjust section position")},
@@ -282,8 +282,8 @@ void KBShortcutsDialog::fill_shortcuts()
 
         Shortcuts object_list_shortcuts = {
             {"1-9", L("Set extruder number for the objects and parts") },
-            {L("Del"), L("Delete objects, parts, modifiers")},
-            {L("Esc"), L("Deselect All")},
+            {L_CONTEXT("Del", "Keyboard Shortcut"), L("Delete objects, parts, modifiers")},
+            {L_CONTEXT("Esc", "Keyboard Shortcut"), L("Deselect All")},
             {ctrl + "C", L("Copy to clipboard")},
             {ctrl + "V", L("Paste from clipboard")},
             {ctrl + "X", L("Cut")},
@@ -291,26 +291,26 @@ void KBShortcutsDialog::fill_shortcuts()
             {ctrl + "K", L("Clone Selected")},
             {ctrl + "Z", L("Undo")},
             {ctrl + "Y", L("Redo")},
-            {L("Space"), L("Select the object/part and press space to change the name")},
+            {L_CONTEXT("Space", "Keyboard Shortcut"), L("Select the object/part and press space to change the name")},
             {L("Mouse click"), L("Select the object/part and mouse click to change the name")},
         };
         m_full_shortcuts.push_back({ { _L("Objects List"), "" }, object_list_shortcuts });
     }
 
     Shortcuts preview_shortcuts = {
-        { L("Arrow Up"),    L("Vertical slider - Move active thumb Up")},
-        { L("Arrow Down"),  L("Vertical slider - Move active thumb Down")},
-        { L("Arrow Left"),  L("Horizontal slider - Move active thumb Left")},
-        { L("Arrow Right"), L("Horizontal slider - Move active thumb Right")},
+        { L_CONTEXT("Arrow Up", "Keyboard Shortcut"),    L("Vertical slider - Move active thumb Up")},
+        { L_CONTEXT("Arrow Down", "Keyboard Shortcut"),  L("Vertical slider - Move active thumb Down")},
+        { L_CONTEXT("Arrow Left", "Keyboard Shortcut"),  L("Horizontal slider - Move active thumb Left")},
+        { L_CONTEXT("Arrow Right", "Keyboard Shortcut"), L("Horizontal slider - Move active thumb Right")},
         { "L", L("On/Off one layer mode of the vertical slider")},
         { "C", L("On/Off G-code window")},
-        { L("Tab"), L("Switch between Prepare/Preview")},
+        { L_CONTEXT("Tab", "Keyboard Shortcut"), L("Switch between Prepare/Preview")},
         {shift + L("Any arrow"), L("Move slider 5x faster")},
         {shift + L("Mouse wheel"), L("Move slider 5x faster")},
         {ctrl + L("Any arrow"), L("Move slider 5x faster")},
         {ctrl + L("Mouse wheel"), L("Move slider 5x faster")},
-        { L("Home"),        L("Horizontal slider - Move to start position")},
-        { L("End"),         L("Horizontal slider - Move to last position")},
+        { L_CONTEXT("Home", "Keyboard Shortcut"),        L("Horizontal slider - Move to start position")},
+        { L_CONTEXT("End", "Keyboard Shortcut"),         L("Horizontal slider - Move to last position")},
     };
     m_full_shortcuts.push_back({ { _L("Preview"), "" }, preview_shortcuts });
 }
@@ -341,7 +341,10 @@ wxPanel* KBShortcutsDialog::create_page(wxWindow* parent, const ShortcutsItem& s
 
     for (int i = 0; i < items_count; ++i) {
         const auto &[shortcut, description] = shortcuts.second[i];
-        auto key                            = new wxStaticText(scrollable_panel, wxID_ANY, _(shortcut));
+        // Keyboard keys carry a "Keyboard Shortcut" context so translators keep them in English;
+        // mouse-input labels are ordinary phrases and use the plain lookup.
+        const bool is_mouse = shortcut.find("Mouse") != std::string::npos || shortcut.find("mouse") != std::string::npos;
+        auto key = new wxStaticText(scrollable_panel, wxID_ANY, is_mouse ? _(shortcut) : _CTX(shortcut, "Keyboard Shortcut"));
         key->SetForegroundColour(wxColour(50, 58, 61));
         key->SetFont(bold_font);
         grid_sizer->Add(key, 0, wxALIGN_CENTRE_VERTICAL);

--- a/src/slic3r/GUI/MainFrame.cpp
+++ b/src/slic3r/GUI/MainFrame.cpp
@@ -2856,7 +2856,7 @@ void MainFrame::init_menubar_as_editor()
             _L("Paste clipboard"), [this](wxCommandEvent&) { m_plater->paste_from_clipboard(); },
             "menu_paste", nullptr, [this](){return m_plater->can_paste_from_clipboard(); }, this);
         // BBS Delete selected
-        append_menu_item(editMenu, wxID_ANY, _L("Delete Selected") + "\t" + _L("Del"),
+        append_menu_item(editMenu, wxID_ANY, _L("Delete Selected") + "\t" + _CTX("Del", "Keyboard Shortcut"),
             _L("Deletes the current selection"),[this](wxCommandEvent&) { m_plater->remove_selected(); },
             "menu_remove", nullptr, [this](){return can_delete(); }, this);
         //BBS: delete all
@@ -2941,7 +2941,7 @@ void MainFrame::init_menubar_as_editor()
             "", nullptr, [this](){return m_plater->can_paste_from_clipboard(); }, this);
 #if 0
         // BBS Delete selected
-        append_menu_item(editMenu, wxID_ANY, _L("Delete Selected") + "\t" + _L("Backspace"),
+        append_menu_item(editMenu, wxID_ANY, _L("Delete Selected") + "\t" + _CTX("Backspace", "Keyboard Shortcut"),
             _L("Deletes the current selection"),[this](wxCommandEvent&) {
                 m_plater->remove_selected();
             },
@@ -2996,7 +2996,7 @@ void MainFrame::init_menubar_as_editor()
                 m_plater->select_all(); },
             "", nullptr, [this](){return can_select(); }, this);
         // BBS Deslect All
-        append_menu_item(editMenu, wxID_ANY, _L("Deselect All") + sep + _L("Esc"),
+        append_menu_item(editMenu, wxID_ANY, _L("Deselect All") + sep + _CTX("Esc", "Keyboard Shortcut"),
             _L("Deselects all objects"), [this, handle_key_event](wxCommandEvent&) {
                 wxKeyEvent e;
                 e.SetEventType(wxEVT_KEY_DOWN);

--- a/src/slic3r/GUI/MainFrame.cpp
+++ b/src/slic3r/GUI/MainFrame.cpp
@@ -2014,10 +2014,10 @@ wxBoxSizer* MainFrame::create_side_tools()
                     });
 
                 // upload and print
-                SideButton* send_gcode_btn = new SideButton(p, _CTX("Print", "Verb"), "");
+                SideButton* send_gcode_btn = new SideButton(p, _L_CONTEXT("Print", "Verb"), "");
                 send_gcode_btn->SetCornerRadius(0);
                 send_gcode_btn->Bind(wxEVT_BUTTON, [this, p](wxCommandEvent&) {
-                    m_print_btn->SetLabel(_CTX("Print", "Verb"));
+                    m_print_btn->SetLabel(_L_CONTEXT("Print", "Verb"));
                     m_print_select = eSendGcode;
                     m_print_enable = get_enable_print_status();
                     m_print_btn->Enable(m_print_enable);
@@ -2663,9 +2663,9 @@ static void add_common_view_menu_items(wxMenu* view_menu, MainFrame* mainFrame, 
         "", nullptr, [can_change_view]() { return can_change_view(); }, mainFrame);
     append_menu_item(view_menu, wxID_ANY, _L("Rear") + "\t" + ctrl + "4", _L("Rear View"), [mainFrame](wxCommandEvent&) { mainFrame->select_view("rear"); },
         "", nullptr, [can_change_view]() { return can_change_view(); }, mainFrame);
-    append_menu_item(view_menu, wxID_ANY, _CTX("Left", "Camera View") + "\t" + ctrl + "5", _L("Left View"),[mainFrame](wxCommandEvent &) {mainFrame->select_view("left"); },
+    append_menu_item(view_menu, wxID_ANY, _L_CONTEXT("Left", "Camera View") + "\t" + ctrl + "5", _L("Left View"),[mainFrame](wxCommandEvent &) {mainFrame->select_view("left"); },
         "", nullptr, [can_change_view]() { return can_change_view(); }, mainFrame);
-    append_menu_item(view_menu, wxID_ANY, _CTX("Right", "Camera View") + "\t" + ctrl + "6", _L("Right View"),[mainFrame](wxCommandEvent &) { mainFrame->select_view("right"); },
+    append_menu_item(view_menu, wxID_ANY, _L_CONTEXT("Right", "Camera View") + "\t" + ctrl + "6", _L("Right View"),[mainFrame](wxCommandEvent &) { mainFrame->select_view("right"); },
         "", nullptr, [can_change_view]() { return can_change_view(); }, mainFrame);
 }
 
@@ -2856,7 +2856,7 @@ void MainFrame::init_menubar_as_editor()
             _L("Paste clipboard"), [this](wxCommandEvent&) { m_plater->paste_from_clipboard(); },
             "menu_paste", nullptr, [this](){return m_plater->can_paste_from_clipboard(); }, this);
         // BBS Delete selected
-        append_menu_item(editMenu, wxID_ANY, _L("Delete Selected") + "\t" + _CTX("Del", "Keyboard Shortcut"),
+        append_menu_item(editMenu, wxID_ANY, _L("Delete Selected") + "\t" + _L_CONTEXT("Del", "Keyboard Shortcut"),
             _L("Deletes the current selection"),[this](wxCommandEvent&) { m_plater->remove_selected(); },
             "menu_remove", nullptr, [this](){return can_delete(); }, this);
         //BBS: delete all
@@ -2941,7 +2941,7 @@ void MainFrame::init_menubar_as_editor()
             "", nullptr, [this](){return m_plater->can_paste_from_clipboard(); }, this);
 #if 0
         // BBS Delete selected
-        append_menu_item(editMenu, wxID_ANY, _L("Delete Selected") + "\t" + _CTX("Backspace", "Keyboard Shortcut"),
+        append_menu_item(editMenu, wxID_ANY, _L("Delete Selected") + "\t" + _L_CONTEXT("Backspace", "Keyboard Shortcut"),
             _L("Deletes the current selection"),[this](wxCommandEvent&) {
                 m_plater->remove_selected();
             },
@@ -2996,7 +2996,7 @@ void MainFrame::init_menubar_as_editor()
                 m_plater->select_all(); },
             "", nullptr, [this](){return can_select(); }, this);
         // BBS Deslect All
-        append_menu_item(editMenu, wxID_ANY, _L("Deselect All") + sep + _CTX("Esc", "Keyboard Shortcut"),
+        append_menu_item(editMenu, wxID_ANY, _L("Deselect All") + sep + _L_CONTEXT("Esc", "Keyboard Shortcut"),
             _L("Deselects all objects"), [this, handle_key_event](wxCommandEvent&) {
                 wxKeyEvent e;
                 e.SetEventType(wxEVT_KEY_DOWN);
@@ -3262,7 +3262,7 @@ void MainFrame::init_menubar_as_editor()
 #ifndef __APPLE__
     m_topbar->SetFileMenu(fileMenu);
     if (editMenu)
-        m_topbar->AddDropDownSubMenu(editMenu, _CTX("Edit", "Menu"));
+        m_topbar->AddDropDownSubMenu(editMenu, _L_CONTEXT("Edit", "Menu"));
     if (viewMenu)
         m_topbar->AddDropDownSubMenu(viewMenu, _L("View"));
     //BBS add Preference
@@ -3451,7 +3451,7 @@ void MainFrame::init_menubar_as_editor()
 
     m_menubar->Append(fileMenu, wxString::Format("&%s", _L("File")));
     if (editMenu)
-        m_menubar->Append(editMenu, wxString::Format("&%s", _CTX("Edit", "Menu")));
+        m_menubar->Append(editMenu, wxString::Format("&%s", _L_CONTEXT("Edit", "Menu")));
     if (viewMenu)
         m_menubar->Append(viewMenu, wxString::Format("&%s", _L("View")));
     /*if (publishMenu)
@@ -4064,7 +4064,7 @@ void MainFrame::set_print_button_to_default(PrintSelectType select_type)
         m_print_btn->Enable(m_print_enable);
         this->Layout();
     } else if (select_type == PrintSelectType::eSendGcode) {
-        m_print_btn->SetLabel(_CTX("Print", "Verb"));
+        m_print_btn->SetLabel(_L_CONTEXT("Print", "Verb"));
         m_print_select = eSendGcode;
         if (m_print_enable)
             m_print_enable = get_enable_print_status() && can_send_gcode();

--- a/src/slic3r/GUI/MainFrame.cpp
+++ b/src/slic3r/GUI/MainFrame.cpp
@@ -3262,7 +3262,7 @@ void MainFrame::init_menubar_as_editor()
 #ifndef __APPLE__
     m_topbar->SetFileMenu(fileMenu);
     if (editMenu)
-        m_topbar->AddDropDownSubMenu(editMenu, _L("Edit"));
+        m_topbar->AddDropDownSubMenu(editMenu, _CTX("Edit", "Menu"));
     if (viewMenu)
         m_topbar->AddDropDownSubMenu(viewMenu, _L("View"));
     //BBS add Preference
@@ -3451,7 +3451,7 @@ void MainFrame::init_menubar_as_editor()
 
     m_menubar->Append(fileMenu, wxString::Format("&%s", _L("File")));
     if (editMenu)
-        m_menubar->Append(editMenu, wxString::Format("&%s", _L("Edit")));
+        m_menubar->Append(editMenu, wxString::Format("&%s", _CTX("Edit", "Menu")));
     if (viewMenu)
         m_menubar->Append(viewMenu, wxString::Format("&%s", _L("View")));
     /*if (publishMenu)

--- a/src/slic3r/GUI/MediaFilePanel.cpp
+++ b/src/slic3r/GUI/MediaFilePanel.cpp
@@ -556,7 +556,7 @@ void MediaFilePanel::doAction(size_t index, int action)
     } else if (action == 1) {
         if (fs->GetFileType() == PrinterFileSystem::F_MODEL) {
             if (index != -1) {
-                auto dlg = new MediaProgressDialog(_CTX("Print", "Verb"), this, [fs] { fs->FetchModelCancel(); });
+                auto dlg = new MediaProgressDialog(_L_CONTEXT("Print", "Verb"), this, [fs] { fs->FetchModelCancel(); });
                 dlg->Update(0, _L("Fetching model information..."));
                 fs->FetchModel(index, [this, fs, dlg, index](int result, std::string const &data) {
                     dlg->Destroy();
@@ -566,7 +566,7 @@ void MediaFilePanel::doAction(size_t index, int action)
                         wxString msg = data.empty() ? _L("Failed to fetch model information from printer.") :
                                                       from_u8(data);
                         CallAfter([this, msg] {
-                            MessageDialog(this, msg, _CTX("Print", "Verb"), wxOK).ShowModal();
+                            MessageDialog(this, msg, _L_CONTEXT("Print", "Verb"), wxOK).ShowModal();
                         });
                         return;
                     }
@@ -579,7 +579,7 @@ void MediaFilePanel::doAction(size_t index, int action)
                             || plate_data_list.empty()) {
                         MessageDialog(this,
                             _L("Failed to parse model information."),
-                            _CTX("Print", "Verb"), wxOK).ShowModal();
+                            _L_CONTEXT("Print", "Verb"), wxOK).ShowModal();
                         return;
                     }
 

--- a/src/slic3r/GUI/Monitor.cpp
+++ b/src/slic3r/GUI/Monitor.cpp
@@ -193,7 +193,7 @@ void MonitorPanel::init_tabpanel()
     //m_tabpanel->AddPage(m_media_file_panel, _L("Internal Storage"), "", false);
 
     m_upgrade_panel = new UpgradePanel(m_tabpanel);
-    m_tabpanel->AddPage(m_upgrade_panel, _CTX(L_CONTEXT("Update", "Firmware"), "Firmware"), "", false);
+    m_tabpanel->AddPage(m_upgrade_panel, _L_CONTEXT(L_CONTEXT("Update", "Firmware"), "Firmware"), "", false);
 
     m_hms_panel = new HMSPanel(m_tabpanel);
     m_tabpanel->AddPage(m_hms_panel, _L("Assistant(HMS)"),    "", false);

--- a/src/slic3r/GUI/MsgDialog.cpp
+++ b/src/slic3r/GUI/MsgDialog.cpp
@@ -632,7 +632,7 @@ wxBoxSizer *Newer3mfVersionDialog::get_btn_sizer()
 
     bool       file_version_newer = (*m_file_version) > (*m_cloud_version);
     if (!file_version_newer) {
-        m_update_btn = new Button(this, _CTX(L_CONTEXT("Update", "Software"), "Software"));
+        m_update_btn = new Button(this, _L_CONTEXT(L_CONTEXT("Update", "Software"), "Software"));
         m_update_btn->SetStyle(ButtonStyle::Regular, ButtonType::Choice);
         horizontal_sizer->Add(m_update_btn, 0, wxRIGHT, FromDIP(ButtonProps::ChoiceButtonGap()));
 

--- a/src/slic3r/GUI/OG_CustomCtrl.cpp
+++ b/src/slic3r/GUI/OG_CustomCtrl.cpp
@@ -230,7 +230,7 @@ wxPoint OG_CustomCtrl::get_pos(const Line& line, Field* field_in/* = nullptr*/)
                     // add label if any
                     if (is_multioption_line && !option.label.empty()) {
                         //!            To correct translation by context have to use wxGETTEXT_IN_CONTEXT macro from wxWidget 3.1.1
-                        auto label = (option.label == L_CONTEXT("Top", "Layers") || option.label == L_CONTEXT("Bottom", "Layers")) ? _CTX(option.label, "Layers") :
+                        auto label = (option.label == L_CONTEXT("Top", "Layers") || option.label == L_CONTEXT("Bottom", "Layers")) ? _L_CONTEXT(option.label, "Layers") :
                                                                                                                                      _(option.label);
                         // BBS
                         // label += ":";
@@ -882,7 +882,7 @@ void OG_CustomCtrl::CtrlLine::render(wxDC& dc, wxCoord h_pos, wxCoord v_pos)
         if (is_multioption_line && !option.label.empty()) {
             //!            To correct translation by context have to use wxGETTEXT_IN_CONTEXT macro from wxWidget 3.1.1
             label = (option.label == L_CONTEXT("Top", "Layers") || option.label == L_CONTEXT("Bottom", "Layers")) ?
-                    _CTX(option.label, "Layers") : _(option.label);
+                    _L_CONTEXT(option.label, "Layers") : _(option.label);
             //if (!ctrl->opt_group->option_label_at_right) // BBS
                 //label += ":";
 

--- a/src/slic3r/GUI/OptionsGroup.cpp
+++ b/src/slic3r/GUI/OptionsGroup.cpp
@@ -432,7 +432,7 @@ void OptionsGroup::activate_line(Line& line)
         if ((is_multioption_line || line.label.IsEmpty()) && !option.label.empty() && !custom_ctrl) {
             //!			To correct translation by context have to use wxGETTEXT_IN_CONTEXT macro from wxWidget 3.1.1
             wxString str_label = (option.label == L_CONTEXT("Top", "Layers") || option.label == L_CONTEXT("Bottom", "Layers")) ?
-                                     _CTX(option.label, "Layers") :
+                                     _L_CONTEXT(option.label, "Layers") :
                                      _(option.label);
             label = new wxStaticText(this->ctrl_parent(), wxID_ANY, str_label + ": ", wxDefaultPosition, // wxDefaultSize);
                                      wxSize(sublabel_width != -1 ? sublabel_width * wxGetApp().em_unit() : -1, -1), wxALIGN_RIGHT);

--- a/src/slic3r/GUI/PhysicalPrinterDialog.cpp
+++ b/src/slic3r/GUI/PhysicalPrinterDialog.cpp
@@ -62,7 +62,7 @@ PhysicalPrinterDialog::PhysicalPrinterDialog(wxWindow* parent) :
     Tab *tab = wxGetApp().get_tab(Preset::TYPE_PRINTER);
     m_presets = tab->get_presets();
     const Preset &sel_preset  = m_presets->get_selected_preset();
-    std::string suffix = _CTX_utf8(L_CONTEXT("Copy", "PresetName"), "PresetName");
+    std::string suffix = _u8L_CONTEXT(L_CONTEXT("Copy", "PresetName"), "PresetName");
     std::string   preset_name = sel_preset.is_default ? "Untitled" : sel_preset.is_system ? (boost::format(("%1% - %2%")) % sel_preset.name % suffix).str() : sel_preset.name;
 
     auto input_sizer = new wxBoxSizer(wxVERTICAL);

--- a/src/slic3r/GUI/PlateSettingsDialog.cpp
+++ b/src/slic3r/GUI/PlateSettingsDialog.cpp
@@ -33,7 +33,7 @@ LayerNumberTextInput::LayerNumberTextInput(wxWindow* parent, int layer_number, w
 {
     GetTextCtrl()->SetValidator(wxTextValidator(wxFILTER_DIGITS));
     GetTextCtrl()->SetFont(::Label::Body_14);
-    Append(_CTX("End", "Layer range"));
+    Append(_L_CONTEXT("End", "Layer range"));
     Append(_L("Customize"));
     if (m_value_type == ValueType::End)
         SetSelection(0);
@@ -45,7 +45,7 @@ LayerNumberTextInput::LayerNumberTextInput(wxWindow* parent, int layer_number, w
     Bind(wxEVT_TEXT, [this](auto& evt) {
             if (m_value_type == ValueType::End) {
                 // TextCtrl->SetValue() will generate a wxEVT_TEXT event
-                GetTextCtrl()->ChangeValue(_CTX("End", "Layer range"));
+                GetTextCtrl()->ChangeValue(_L_CONTEXT("End", "Layer range"));
                 return;
             }
             evt.Skip();

--- a/src/slic3r/GUI/PlateSettingsDialog.cpp
+++ b/src/slic3r/GUI/PlateSettingsDialog.cpp
@@ -33,7 +33,7 @@ LayerNumberTextInput::LayerNumberTextInput(wxWindow* parent, int layer_number, w
 {
     GetTextCtrl()->SetValidator(wxTextValidator(wxFILTER_DIGITS));
     GetTextCtrl()->SetFont(::Label::Body_14);
-    Append(_L("End"));
+    Append(_CTX("End", "Layer range"));
     Append(_L("Customize"));
     if (m_value_type == ValueType::End)
         SetSelection(0);
@@ -45,7 +45,7 @@ LayerNumberTextInput::LayerNumberTextInput(wxWindow* parent, int layer_number, w
     Bind(wxEVT_TEXT, [this](auto& evt) {
             if (m_value_type == ValueType::End) {
                 // TextCtrl->SetValue() will generate a wxEVT_TEXT event
-                GetTextCtrl()->ChangeValue(_L("End"));
+                GetTextCtrl()->ChangeValue(_CTX("End", "Layer range"));
                 return;
             }
             evt.Skip();

--- a/src/slic3r/GUI/PrintHostDialogs.cpp
+++ b/src/slic3r/GUI/PrintHostDialogs.cpp
@@ -1234,7 +1234,7 @@ PrintHostQueueDialog::PrintHostQueueDialog(wxWindow *parent)
     job_list->AppendProgressColumn(_L("Progress"),      wxDATAVIEW_CELL_INERT, widths[1], wxALIGN_LEFT, wxDATAVIEW_COL_RESIZABLE | wxDATAVIEW_COL_SORTABLE);
     append_text_column(_L("Status"),widths[2]);
     append_text_column(_L("Host"),  widths[3]);
-    append_text_column(_CTX(L_CONTEXT("Size", "OfFile"), "OfFile"), widths[4]);
+    append_text_column(_L_CONTEXT(L_CONTEXT("Size", "OfFile"), "OfFile"), widths[4]);
     append_text_column(_L("Filename"),      widths[5]);
     append_text_column(_L("Message"), widths[6]);
     //append_text_column(_L("Error Message"), -1, wxALIGN_CENTER, wxDATAVIEW_COL_HIDDEN);

--- a/src/slic3r/GUI/PrintOptionsDialog.cpp
+++ b/src/slic3r/GUI/PrintOptionsDialog.cpp
@@ -1469,7 +1469,7 @@ PrinterPartsDialog::PrinterPartsDialog(wxWindow* parent)
     //nozzle type
     wxBoxSizer* line_sizer_nozzle_type = new wxBoxSizer(wxHORIZONTAL);
 
-    auto nozzle_type = new Label(single_panel, _CTX(L_CONTEXT("Type", "Nozzle Type"), "Nozzle Type"));
+    auto nozzle_type = new Label(single_panel, _L_CONTEXT(L_CONTEXT("Type", "Nozzle Type"), "Nozzle Type"));
     nozzle_type->SetFont(Label::Body_14);
     nozzle_type->SetMinSize(wxSize(FromDIP(180), -1));
     nozzle_type->SetMaxSize(wxSize(FromDIP(180), -1));
@@ -1485,7 +1485,7 @@ PrinterPartsDialog::PrinterPartsDialog(wxWindow* parent)
 
     //nozzle diameter
     wxBoxSizer* line_sizer_nozzle_diameter = new wxBoxSizer(wxHORIZONTAL);
-    auto nozzle_diameter  = new Label(single_panel, _CTX(L_CONTEXT("Diameter", "Nozzle Diameter"), "Nozzle Diameter"));
+    auto nozzle_diameter  = new Label(single_panel, _L_CONTEXT(L_CONTEXT("Diameter", "Nozzle Diameter"), "Nozzle Diameter"));
     nozzle_diameter->SetFont(Label::Body_14);
     nozzle_diameter->SetMinSize(wxSize(FromDIP(180), -1));
     nozzle_diameter->SetMaxSize(wxSize(FromDIP(180), -1));
@@ -1500,7 +1500,7 @@ PrinterPartsDialog::PrinterPartsDialog(wxWindow* parent)
 
     //nozzle flow type
     wxBoxSizer* line_sizer_nozzle_flowtype = new wxBoxSizer(wxHORIZONTAL);
-    nozzle_flow_type_label = new Label(single_panel, _CTX(L_CONTEXT("Flow", "Nozzle Flow"), "Nozzle Flow"));
+    nozzle_flow_type_label = new Label(single_panel, _L_CONTEXT(L_CONTEXT("Flow", "Nozzle Flow"), "Nozzle Flow"));
     nozzle_flow_type_label->SetFont(Label::Body_14);
     nozzle_flow_type_label->SetMinSize(wxSize(FromDIP(180), -1));
     nozzle_flow_type_label->SetMaxSize(wxSize(FromDIP(180), -1));
@@ -1563,18 +1563,18 @@ PrinterPartsDialog::PrinterPartsDialog(wxWindow* parent)
     leftTitle->SetForegroundColour(StateColor::darkModeColorFor(wxColour("#2C2C2E")));
 
     wxBoxSizer *multiple_left_line_sizer = new wxBoxSizer(wxHORIZONTAL);
-    auto multiple_left_nozzle_type = new Label(multiple_panel, _CTX(L_CONTEXT("Type", "Nozzle Type"), "Nozzle Type"));
+    auto multiple_left_nozzle_type = new Label(multiple_panel, _L_CONTEXT(L_CONTEXT("Type", "Nozzle Type"), "Nozzle Type"));
     multiple_left_nozzle_type->SetFont(Label::Body_14);
     multiple_left_nozzle_type->SetForegroundColour(STATIC_TEXT_CAPTION_COL);
 
     multiple_left_nozzle_type_checkbox = new ComboBox(multiple_panel, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize(FromDIP(180), -1), 0, NULL, wxCB_READONLY);
 
-    auto multiple_left_nozzle_diameter = new Label(multiple_panel, _CTX(L_CONTEXT("Diameter", "Nozzle Diameter"), "Nozzle Diameter"));
+    auto multiple_left_nozzle_diameter = new Label(multiple_panel, _L_CONTEXT(L_CONTEXT("Diameter", "Nozzle Diameter"), "Nozzle Diameter"));
     multiple_left_nozzle_diameter->SetFont(Label::Body_14);
     multiple_left_nozzle_diameter->SetForegroundColour(STATIC_TEXT_CAPTION_COL);
     multiple_left_nozzle_diameter_checkbox = new ComboBox(multiple_panel, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize(FromDIP(140), -1), 0, NULL, wxCB_READONLY);
 
-    auto multiple_left_nozzle_flow = new Label(multiple_panel, _CTX(L_CONTEXT("Flow", "Nozzle Flow"), "Nozzle Flow"));
+    auto multiple_left_nozzle_flow = new Label(multiple_panel, _L_CONTEXT(L_CONTEXT("Flow", "Nozzle Flow"), "Nozzle Flow"));
     multiple_left_nozzle_flow->SetFont(Label::Body_14);
     multiple_left_nozzle_flow->SetForegroundColour(STATIC_TEXT_CAPTION_COL);
     multiple_left_nozzle_flow_checkbox = new ComboBox(multiple_panel, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize(FromDIP(140), -1), 0, NULL, wxCB_READONLY);
@@ -1597,18 +1597,18 @@ PrinterPartsDialog::PrinterPartsDialog(wxWindow* parent)
     rightTitle->SetForegroundColour(StateColor::darkModeColorFor(wxColour("#2C2C2E")));
 
     wxBoxSizer *multiple_right_line_sizer  = new wxBoxSizer(wxHORIZONTAL);
-    auto        multiple_right_nozzle_type = new Label(multiple_panel, _CTX(L_CONTEXT("Type", "Nozzle Type"), "Nozzle Type"));
+    auto        multiple_right_nozzle_type = new Label(multiple_panel, _L_CONTEXT(L_CONTEXT("Type", "Nozzle Type"), "Nozzle Type"));
     multiple_right_nozzle_type->SetFont(Label::Body_14);
     multiple_right_nozzle_type->SetForegroundColour(STATIC_TEXT_CAPTION_COL);
 
     multiple_right_nozzle_type_checkbox = new ComboBox(multiple_panel, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize(FromDIP(180), -1), 0, NULL, wxCB_READONLY);
 
-    auto multiple_right_nozzle_diameter = new Label(multiple_panel, _CTX(L_CONTEXT("Diameter", "Nozzle Diameter"), "Nozzle Diameter"));
+    auto multiple_right_nozzle_diameter = new Label(multiple_panel, _L_CONTEXT(L_CONTEXT("Diameter", "Nozzle Diameter"), "Nozzle Diameter"));
     multiple_right_nozzle_diameter->SetFont(Label::Body_14);
     multiple_right_nozzle_diameter->SetForegroundColour(STATIC_TEXT_CAPTION_COL);
     multiple_right_nozzle_diameter_checkbox = new ComboBox(multiple_panel, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize(FromDIP(140), -1), 0, NULL, wxCB_READONLY);
 
-    auto multiple_right_nozzle_flow = new Label(multiple_panel, _CTX(L_CONTEXT("Flow", "Nozzle Flow"), "Nozzle Flow"));
+    auto multiple_right_nozzle_flow = new Label(multiple_panel, _L_CONTEXT(L_CONTEXT("Flow", "Nozzle Flow"), "Nozzle Flow"));
     multiple_right_nozzle_flow->SetFont(Label::Body_14);
     multiple_right_nozzle_flow->SetForegroundColour(STATIC_TEXT_CAPTION_COL);
     multiple_right_nozzle_flow_checkbox = new ComboBox(multiple_panel, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize(FromDIP(140), -1), 0, NULL, wxCB_READONLY);

--- a/src/slic3r/GUI/SavePresetDialog.cpp
+++ b/src/slic3r/GUI/SavePresetDialog.cpp
@@ -274,7 +274,7 @@ void SavePresetDialog::build(std::vector<Preset::Type> types, std::string suffix
     SetBackgroundColour(SAVE_PRESET_DIALOG_DEF_COLOUR);
     SetFont(wxGetApp().normal_font());
 
-    if (suffix.empty()) suffix = _CTX_utf8(L_CONTEXT("Copy", "PresetName"), "PresetName");
+    if (suffix.empty()) suffix = _u8L_CONTEXT(L_CONTEXT("Copy", "PresetName"), "PresetName");
 
     wxBoxSizer *m_Sizer_main = new wxBoxSizer(wxVERTICAL);
 

--- a/src/slic3r/GUI/SelectMachine.cpp
+++ b/src/slic3r/GUI/SelectMachine.cpp
@@ -157,7 +157,7 @@ SelectMachineDialog::SelectMachineDialog(Plater *plater)
 
     /*mode switch*/
      /*auto m_sizer_mode_switch = new wxBoxSizer(wxHORIZONTAL);
-     m_mode_print = new SendModeSwitchButton(scroll_area, _CTX("Print", "Verb"), true);
+     m_mode_print = new SendModeSwitchButton(scroll_area, _L_CONTEXT("Print", "Verb"), true);
      m_mode_send = new SendModeSwitchButton(scroll_area,_L("Save to printer"), false);
      m_sizer_mode_switch->Add(m_mode_print, 0, wxALIGN_CENTER, 0);
      m_sizer_mode_switch->Add(0, 0, 0, wxLEFT, FromDIP(8));

--- a/src/slic3r/GUI/StatusPanel.cpp
+++ b/src/slic3r/GUI/StatusPanel.cpp
@@ -358,7 +358,7 @@ ExtruderSwithingStatus::ExtruderSwithingStatus(wxWindow *parent)
     { m_switching_status_label->SetBackgroundColour(parent->GetBackgroundColour());
     }
 
-    m_button_quit = new Button(this, _CTX(L_CONTEXT("Quit", "Quit_Switching"), "Quit_Switching"), "", 0, FromDIP(22));
+    m_button_quit = new Button(this, _L_CONTEXT(L_CONTEXT("Quit", "Quit_Switching"), "Quit_Switching"), "", 0, FromDIP(22));
     m_button_quit->SetStyle(ButtonStyle::Regular, ButtonType::Window);
     m_button_quit->Bind(wxEVT_BUTTON, &ExtruderSwithingStatus::on_quit, this);
 
@@ -1986,7 +1986,7 @@ wxBoxSizer *StatusBasePanel::create_extruder_control(wxWindow *parent)
     StateColor e_ctrl_bg(std::pair<wxColour, int>(BUTTON_PRESS_COL, StateColor::Pressed), std::pair<wxColour, int>(BUTTON_NORMAL1_COL, StateColor::Normal));
     StateColor e_ctrl_bd(std::pair<wxColour, int>(BUTTON_HOVER_COL, StateColor::Hovered), std::pair<wxColour, int>(BUTTON_NORMAL1_COL, StateColor::Normal));
 
-    m_nozzle_btn_panel = new SwitchBoard(panel, _CTX("Left", "Nozzle position"), _CTX("Right", "Nozzle position"), wxSize(FromDIP(126), FromDIP(26)));
+    m_nozzle_btn_panel = new SwitchBoard(panel, _L_CONTEXT("Left", "Nozzle position"), _L_CONTEXT("Right", "Nozzle position"), wxSize(FromDIP(126), FromDIP(26)));
     m_nozzle_btn_panel->SetAutoDisableWhenSwitch();
 
     m_bpButton_e_10 = new Button(panel, "", "monitor_extruder_up", 0, 22); // Orca Dont scale icon size 

--- a/src/slic3r/GUI/StatusPanel.cpp
+++ b/src/slic3r/GUI/StatusPanel.cpp
@@ -1986,7 +1986,7 @@ wxBoxSizer *StatusBasePanel::create_extruder_control(wxWindow *parent)
     StateColor e_ctrl_bg(std::pair<wxColour, int>(BUTTON_PRESS_COL, StateColor::Pressed), std::pair<wxColour, int>(BUTTON_NORMAL1_COL, StateColor::Normal));
     StateColor e_ctrl_bd(std::pair<wxColour, int>(BUTTON_HOVER_COL, StateColor::Hovered), std::pair<wxColour, int>(BUTTON_NORMAL1_COL, StateColor::Normal));
 
-    m_nozzle_btn_panel = new SwitchBoard(panel, _L("Left"), _L("Right"), wxSize(FromDIP(126), FromDIP(26)));
+    m_nozzle_btn_panel = new SwitchBoard(panel, _CTX("Left", "Nozzle position"), _CTX("Right", "Nozzle position"), wxSize(FromDIP(126), FromDIP(26)));
     m_nozzle_btn_panel->SetAutoDisableWhenSwitch();
 
     m_bpButton_e_10 = new Button(panel, "", "monitor_extruder_up", 0, 22); // Orca Dont scale icon size 

--- a/src/slic3r/GUI/SyncAmsInfoDialog.cpp
+++ b/src/slic3r/GUI/SyncAmsInfoDialog.cpp
@@ -283,7 +283,7 @@ wxBoxSizer *SyncAmsInfoDialog::create_sizer_thumbnail(wxButton *image_button, bo
     auto sizer_thumbnail = new wxBoxSizer(wxVERTICAL);
     if (left) {
         wxBoxSizer *text_sizer = new wxBoxSizer(wxHORIZONTAL);
-        auto        sync_text  = new Label(image_button->GetParent(), _CTX(L_CONTEXT("Original", "Sync_AMS"), "Sync_AMS"));
+        auto        sync_text  = new Label(image_button->GetParent(), _L_CONTEXT(L_CONTEXT("Original", "Sync_AMS"), "Sync_AMS"));
         sync_text->SetForegroundColour(StateColor::darkModeColorFor(wxColour("#363636"))); // ORCA match label colors
         text_sizer->Add(sync_text, 0, wxALIGN_CENTER | wxALL, 0);
         sizer_thumbnail->Add(sync_text, FromDIP(0), wxALIGN_CENTER | wxALL, FromDIP(4));
@@ -550,7 +550,7 @@ void SyncAmsInfoDialog::add_two_image_control()
     m_choose_plate_sizer         = new wxBoxSizer(wxHORIZONTAL);
     m_choose_plate_sizer->AddStretchSpacer();
 
-    wxStaticText *chose_combox_title = new wxStaticText(m_two_thumbnail_panel, wxID_ANY, _CTX(L_CONTEXT("Plate", "Sync_AMS"), "Sync_AMS"));
+    wxStaticText *chose_combox_title = new wxStaticText(m_two_thumbnail_panel, wxID_ANY, _L_CONTEXT(L_CONTEXT("Plate", "Sync_AMS"), "Sync_AMS"));
     m_choose_plate_sizer->Add(chose_combox_title, 0, wxEXPAND | wxTOP, FromDIP(6));
     m_choose_plate_sizer->AddSpacer(FromDIP(10));
 
@@ -2598,7 +2598,7 @@ void SyncAmsInfoDialog::reset_and_sync_ams_list()
             if (is_first_row) {
                 is_first_row              = false;
                 if (!m_original_in_colormap) {
-                    m_original_in_colormap = new wxStaticText(m_filament_panel, wxID_ANY, _CTX(L_CONTEXT("Original", "Sync_AMS"), "Sync_AMS") + ":");
+                    m_original_in_colormap = new wxStaticText(m_filament_panel, wxID_ANY, _L_CONTEXT(L_CONTEXT("Original", "Sync_AMS"), "Sync_AMS") + ":");
                     m_original_in_colormap->SetForegroundColour(StateColor::darkModeColorFor(wxColour("#363636"))); // ORCA match label colors
                     m_original_in_colormap->SetFont(::Label::Head_12);
                 }
@@ -2816,7 +2816,7 @@ void SyncAmsInfoDialog::generate_override_fix_ams_list()
             if (is_first_row) {
                 is_first_row   = false;
                 if (!m_original_in_override) {
-                    m_original_in_override = new wxStaticText(m_fix_filament_panel, wxID_ANY, _CTX(L_CONTEXT("Original", "Sync_AMS"), "Sync_AMS") + ":");
+                    m_original_in_override = new wxStaticText(m_fix_filament_panel, wxID_ANY, _L_CONTEXT(L_CONTEXT("Original", "Sync_AMS"), "Sync_AMS") + ":");
                     m_original_in_override->SetForegroundColour(StateColor::darkModeColorFor(wxColour("#363636"))); // ORCA match label colors
                     m_original_in_override->SetFont(::Label::Head_12);
                 }
@@ -3218,7 +3218,7 @@ SyncNozzleAndAmsDialog::SyncNozzleAndAmsDialog(InputInfo &input_info)
                                                                                             _L("Successfully synchronized nozzle and AMS number information.")
                               ) + "\n\n" + _L("Do you want to continue to sync filaments?"),
                               _L("Yes"), // ORCA use shorter text for buttons
-                              _CTX(L_CONTEXT(_L("No"), "Sync_Nozzle_AMS"), "Sync_Nozzle_AMS"),
+                              _L_CONTEXT(L_CONTEXT(_L("No"), "Sync_Nozzle_AMS"), "Sync_Nozzle_AMS"),
                               DisappearanceMode::TimedDisappearance)
     , m_input_info(input_info)
 {
@@ -3266,7 +3266,7 @@ FinishSyncAmsDialog::FinishSyncAmsDialog(InputInfo &input_info)
                               wxGetApp().app_config->get("sync_ams_filament_mode") == "1" ?
                                   _L("Successfully synchronized filament color from printer.") :
                                   _L("Successfully synchronized color and type of filament from printer."),
-                              _CTX(L_CONTEXT("OK", "FinishSyncAms"), "FinishSyncAms"),
+                              _L_CONTEXT(L_CONTEXT("OK", "FinishSyncAms"), "FinishSyncAms"),
                               "",
                               DisappearanceMode::TimedDisappearance)
     , m_input_info(input_info)

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -7958,7 +7958,7 @@ bool Tab::validate_filament_temperature_pairs()
 
     RichMessageDialog dialog(parent(), msg_text, _L("Temperature Safety Check"), wxYES | wxNO | wxICON_WARNING);
     dialog.SetButtonLabel(wxID_YES, _L("Continue"), true);
-    dialog.SetButtonLabel(wxID_NO, _CTX("Back", "Navigation"));
+    dialog.SetButtonLabel(wxID_NO, _L_CONTEXT("Back", "Navigation"));
     dialog.ShowCheckBox(_L("Don't warn again for this preset"));
     const int answer = dialog.ShowModal();
     // Session-only suppression (does not modify/save filament preset data).

--- a/src/slic3r/GUI/WebViewDialog.cpp
+++ b/src/slic3r/GUI/WebViewDialog.cpp
@@ -47,7 +47,7 @@ WebViewPanel::WebViewPanel(wxWindow *parent)
     // Create the button
     bSizer_toolbar = new wxBoxSizer(wxHORIZONTAL);
 
-    m_button_back = new wxButton(this, wxID_ANY, _CTX("Back", "Navigation"), wxDefaultPosition, wxDefaultSize, 0);
+    m_button_back = new wxButton(this, wxID_ANY, _L_CONTEXT("Back", "Navigation"), wxDefaultPosition, wxDefaultSize, 0);
     m_button_back->Enable(false);
     bSizer_toolbar->Add(m_button_back, 0, wxALL, 5);
 

--- a/src/slic3r/GUI/Widgets/FanControl.cpp
+++ b/src/slic3r/GUI/Widgets/FanControl.cpp
@@ -1031,13 +1031,13 @@ wxString FanControlPopupNew::get_fan_func_name(int mode, int submode, AIR_FUN fu
             L_CONTEXT("Right(Aux)", "air_duct");
             L_CONTEXT("Right(Filter)", "air_duct");
             L_CONTEXT("Left(Aux)", "air_duct");
-            return _CTX(func_text, "air_duct");
+            return _L_CONTEXT(func_text, "air_duct");
         }
     }
 
     static std::map<AIR_FUN, wxString> s_fan_func_name
     {
-        { AIR_FUN::FAN_HEAT_BREAK_0_IDX,     _CTX("Hotend", "Hotend Heat Breaker Fan") },
+        { AIR_FUN::FAN_HEAT_BREAK_0_IDX,     _L_CONTEXT("Hotend", "Hotend Heat Breaker Fan") },
         { AIR_FUN::FAN_COOLING_0_AIRDOOR,     _L("Parts") },
         { AIR_FUN::FAN_REMOTE_COOLING_0_IDX,  _L("Aux") },
         { AIR_FUN::FAN_CHAMBER_0_IDX,         _L("Exhaust") },

--- a/src/slic3r/GUI/Widgets/FanControl.cpp
+++ b/src/slic3r/GUI/Widgets/FanControl.cpp
@@ -1037,7 +1037,7 @@ wxString FanControlPopupNew::get_fan_func_name(int mode, int submode, AIR_FUN fu
 
     static std::map<AIR_FUN, wxString> s_fan_func_name
     {
-        { AIR_FUN::FAN_HEAT_BREAK_0_IDX,     _L("Hotend") },
+        { AIR_FUN::FAN_HEAT_BREAK_0_IDX,     _CTX("Hotend", "Hotend Heat Breaker Fan") },
         { AIR_FUN::FAN_COOLING_0_AIRDOOR,     _L("Parts") },
         { AIR_FUN::FAN_REMOTE_COOLING_0_IDX,  _L("Aux") },
         { AIR_FUN::FAN_CHAMBER_0_IDX,         _L("Exhaust") },


### PR DESCRIPTION
- Based in https://github.com/OrcaSlicer/OrcaSlicer/pull/14642#issuecomment-4920250223 change the context macros symmetric.
- Added context for a lot of words.
- Updates based in last glossary.
- Scarf joint — .po fix list (the clothing-scarf bug)
	- 6 catalogues translate the woodworking scarf joint (a sloped/lapped seam) using their word for the clothing scarf/muffler.

Lang | File | Wrong word (sense) | count | Correct sense
-- | -- | -- | -- | --
es | localization/i18n/es/OrcaSlicer_es.po | bufanda (muffler) | 23 | a beveled/diagonal seam — e.g. unión/costura en bisel
pt_BR | …/pt_BR/OrcaSlicer_pt_BR.po | cachecol (muffler) | 21 | junta em bisel / chanfrada
it | …/it/OrcaSlicer_it.po | sciarpa (scarf garment) | 21 | giunto a becco / smussato
tr | …/tr/OrcaSlicer_tr.po | atkı (weft/muffler) | 18 | eğik/gömme birleşim
th | …/th/OrcaSlicer_th.po | ผ้าพันคอ (muffler) | 21 | a beveled-joint term
eu | …/eu/OrcaSlicer_eu.po | bufanda (Spanish loan, muffler) | 13 | ebakidura-juntura / bevel term