### PR TITLE
fix(log): tear down async console sink in OnExit to avoid lldb-dap hang

### DIFF
--- a/src/libslic3r/utils.cpp
+++ b/src/libslic3r/utils.cpp
@@ -366,6 +366,8 @@ void shutdown_console_logging()
 
 	auto console_sink = g_console_log_sink;
 	boost::log::core::get()->remove_sink(console_sink);
+	// Don't flush() here. It ties exit to the queue draining and can hang if the
+	// stdout reader stalled, and the file sink already holds the full log.
 	console_sink->stop();
 	g_console_log_sink.reset();
 }

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -2682,6 +2682,10 @@ bool GUI_App::OnInit()
 
 int GUI_App::OnExit()
 {
+    // Join the async console sink here while stdout is still drained; doing it in
+    // ~GUI_App() is late enough to wedge under lldb-dap (feeding thread blocked mid-write).
+    shutdown_console_logging();
+
     stop_http_server();
     stop_sync_user_preset();
 


### PR DESCRIPTION
# Description

Fixes the lldb-dap hang from #14439 without reverting it (alternative to #14897).

The console sink is async on purpose, it cut RelWithDebInfo startup time at debug level with many profiles. My read is the hang is about teardown timing. `shutdown_console_logging()` ran in `~GUI_App()`, late in shutdown, where `stop()` likely joins the feeding thread while it's mid-write to a stdout lldb-dap already stopped draining. That matches what @Gabriel-Hiss saw with `flush()` in the original review.

This moves the stop/join into `OnExit()`, while stdout is still drained, so the thread should join cleanly. Destructor call stays as a fallback, `flush()` stays out.

Can't repro on Windows. @peachismomo, could you check on your setup? RelWithDebInfo via LLDB-DAP, open the printer picker, close, confirm lldb-dap exits.
