### PR TITLE
docs(readme): use forward slashes for sponsor logo paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,12 +218,12 @@ Thank you! :)
 <tr>
 <td>
 <a href="https://qidi3d.com/" style="display:inline-block; border-radius:8px; background:#fff;">
-  <img src="SoftFever_doc\sponsor_logos\QIDI.png" alt="QIDI" width="100" height="100">
+  <img src="SoftFever_doc/sponsor_logos/QIDI.png" alt="QIDI" width="100" height="100">
 </a>
 </td>
 <td>
 <a href="https://bigtree-tech.com/" style="display:inline-block; border-radius:8px; background:#222;">
-    <img src="SoftFever_doc\sponsor_logos\BigTreeTech.png" alt="BIGTREE TECH" width="100" height="100">
+    <img src="SoftFever_doc/sponsor_logos/BigTreeTech.png" alt="BIGTREE TECH" width="100" height="100">
 </a>
 </td>
 </tr>


### PR DESCRIPTION
## Summary

The Sponsors table used Windows-style backslashes in HTML `img src` paths:

- `SoftFever_doc\sponsor_logos\QIDI.png`
- `SoftFever_doc\sponsor_logos\BigTreeTech.png`

Those paths fail on GitHub’s renderer and other POSIX/URL contexts. Both assets already exist under `SoftFever_doc/sponsor_logos/`; this switches to portable forward slashes only.

No logo files, links, or sponsorship wording changed.

## Tests

- Confirmed both PNGs exist on `main`
- Local diff is two path separators only
- Docs-only — no build required

Agent-Owner: sera
Claim: sera