### PR TITLE
Add used_filament_volume placeholder support

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -2883,6 +2883,7 @@ void GCode::_do_export(Print& print, GCodeOutputStream &file, ThumbnailsGenerato
             PlaceholderParser::update_user_name(top_config);
             top_config.set_key_value("print_time_sec", new ConfigOptionString(GCodeProcessor::reserved_tag(GCodeProcessor::ETags::Print_Time_Sec_Placeholder)));
             top_config.set_key_value("used_filament_length", new ConfigOptionString(GCodeProcessor::reserved_tag(GCodeProcessor::ETags::Used_Filament_Length_Placeholder)));
+            top_config.set_key_value("used_filament_volume", new ConfigOptionString(GCodeProcessor::reserved_tag(GCodeProcessor::ETags::Used_Filament_Volume_Placeholder)));
             std::string top_gcode = print.placeholder_parser().process(top_gcode_template, 0, &top_config);
             if (!top_gcode.empty())
                 file.writeln(top_gcode);
@@ -3503,6 +3504,7 @@ void GCode::_do_export(Print& print, GCodeOutputStream &file, ThumbnailsGenerato
 
     this->placeholder_parser().set("print_time_sec", new ConfigOptionString(GCodeProcessor::reserved_tag(GCodeProcessor::ETags::Print_Time_Sec_Placeholder)));
     this->placeholder_parser().set("used_filament_length", new ConfigOptionString(GCodeProcessor::reserved_tag(GCodeProcessor::ETags::Used_Filament_Length_Placeholder)));
+    this->placeholder_parser().set("used_filament_volume", new ConfigOptionString(GCodeProcessor::reserved_tag(GCodeProcessor::ETags::Used_Filament_Volume_Placeholder)));
 
     // Sync variant-mapped params into placeholder_parser before processing start gcode
     update_placeholder_parser_with_variant_params();

--- a/src/libslic3r/GCode/GCodeProcessor.cpp
+++ b/src/libslic3r/GCode/GCodeProcessor.cpp
@@ -1263,7 +1263,7 @@ void GCodeProcessor::run_post_process()
                 used_filament_volume += filament_mm[id] * static_cast<double>(M_PI) * sqr(0.5 * diameter);
             }
             char buf[64];
-            sprintf(buf, "%.2f", used_filament_volume);
+            snprintf(buf, sizeof(buf), "%.2f", used_filament_volume);
             gcode_line.replace(pos, used_filament_volume_placeholder.length(), buf);
             processed = true;
             pos = gcode_line.find(used_filament_volume_placeholder, pos + strlen(buf));

--- a/src/libslic3r/GCode/GCodeProcessor.cpp
+++ b/src/libslic3r/GCode/GCodeProcessor.cpp
@@ -1263,7 +1263,7 @@ void GCodeProcessor::run_post_process()
                 used_filament_volume += filament_mm[id] * static_cast<double>(M_PI) * sqr(0.5 * diameter);
             }
             char buf[64];
-            sprintf(buf, "%.0f", used_filament_volume);
+            sprintf(buf, "%.2f", used_filament_volume);
             gcode_line.replace(pos, used_filament_volume_placeholder.length(), buf);
             processed = true;
             pos = gcode_line.find(used_filament_volume_placeholder, pos + strlen(buf));

--- a/src/libslic3r/GCode/GCodeProcessor.cpp
+++ b/src/libslic3r/GCode/GCodeProcessor.cpp
@@ -76,7 +76,8 @@ const std::vector<std::string> GCodeProcessor::Reserved_Tags = {
     " WIPE_TOWER_END",
     " PA_CHANGE:",
     "@PRINT_TIME_SEC@",
-    "@USED_FILAMENT_LENGTH@"
+    "@USED_FILAMENT_LENGTH@",
+    "@USED_FILAMENT_VOLUME@"
 };
 
 const std::vector<std::string> GCodeProcessor::Reserved_Tags_compatible = {
@@ -99,7 +100,8 @@ const std::vector<std::string> GCodeProcessor::Reserved_Tags_compatible = {
     " WIPE_TOWER_END",
     " PA_CHANGE:",
     "@PRINT_TIME_SEC@",
-    "@USED_FILAMENT_LENGTH@"
+    "@USED_FILAMENT_LENGTH@",
+    "@USED_FILAMENT_VOLUME@"
 };
 
 
@@ -1214,12 +1216,13 @@ void GCodeProcessor::run_post_process()
         return ret;
     };
 
-    // Process inline placeholders (print_time_sec and used_filament_length)
+    // Process inline placeholders (print_time_sec, used_filament_length and used_filament_volume)
     auto process_inline_placeholders = [&](std::string& gcode_line) {
         bool processed = false;
 
         const std::string& print_time_placeholder = reserved_tag(ETags::Print_Time_Sec_Placeholder);
         const std::string& used_filament_placeholder = reserved_tag(ETags::Used_Filament_Length_Placeholder);
+        const std::string& used_filament_volume_placeholder = reserved_tag(ETags::Used_Filament_Volume_Placeholder);
 
         // Replace print_time_sec
         size_t pos = gcode_line.find(print_time_placeholder);
@@ -1245,6 +1248,25 @@ void GCodeProcessor::run_post_process()
             gcode_line.replace(pos, used_filament_placeholder.length(), buf);
             processed = true;
             pos = gcode_line.find(used_filament_placeholder, pos + strlen(buf));
+        }
+
+        // Replace used_filament_volume
+        pos = gcode_line.find(used_filament_volume_placeholder);
+        while (pos != std::string::npos) {
+            // Volume of filament used, in mm^3, computed per filament as
+            // used_filament_length * 1000 * filament_diameter^2 * pi / 4
+            // i.e. length (mm) times the filament cross-section area.
+            double used_filament_volume = 0.0; // mm^3
+            for (size_t id = 0; id < filament_mm.size(); ++id) {
+                const double diameter = (id < m_result.filament_diameters.size()) ?
+                    m_result.filament_diameters[id] : m_result.filament_diameters.back();
+                used_filament_volume += filament_mm[id] * static_cast<double>(M_PI) * sqr(0.5 * diameter);
+            }
+            char buf[64];
+            sprintf(buf, "%.2f", used_filament_volume);
+            gcode_line.replace(pos, used_filament_volume_placeholder.length(), buf);
+            processed = true;
+            pos = gcode_line.find(used_filament_volume_placeholder, pos + strlen(buf));
         }
 
         return processed;

--- a/src/libslic3r/GCode/GCodeProcessor.cpp
+++ b/src/libslic3r/GCode/GCodeProcessor.cpp
@@ -1254,8 +1254,8 @@ void GCodeProcessor::run_post_process()
         pos = gcode_line.find(used_filament_volume_placeholder);
         while (pos != std::string::npos) {
             // Volume of filament used, in mm^3, computed per filament as
-            // used_filament_length * 1000 * filament_diameter^2 * pi / 4
-            // i.e. length (mm) times the filament cross-section area.
+            // used_filament_length_mm * pi * (filament_diameter / 2)^2
+            // i.e. length in millimeters times the filament cross-section area.
             double used_filament_volume = 0.0; // mm^3
             for (size_t id = 0; id < filament_mm.size(); ++id) {
                 const double diameter = (id < m_result.filament_diameters.size()) ?

--- a/src/libslic3r/GCode/GCodeProcessor.cpp
+++ b/src/libslic3r/GCode/GCodeProcessor.cpp
@@ -1263,7 +1263,7 @@ void GCodeProcessor::run_post_process()
                 used_filament_volume += filament_mm[id] * static_cast<double>(M_PI) * sqr(0.5 * diameter);
             }
             char buf[64];
-            sprintf(buf, "%.2f", used_filament_volume);
+            sprintf(buf, "%.0f", used_filament_volume);
             gcode_line.replace(pos, used_filament_volume_placeholder.length(), buf);
             processed = true;
             pos = gcode_line.find(used_filament_volume_placeholder, pos + strlen(buf));

--- a/src/libslic3r/GCode/GCodeProcessor.hpp
+++ b/src/libslic3r/GCode/GCodeProcessor.hpp
@@ -510,6 +510,7 @@ class Print;
             PA_Change,
             Print_Time_Sec_Placeholder,
             Used_Filament_Length_Placeholder,
+            Used_Filament_Volume_Placeholder,
         };
 
         static const std::string& reserved_tag(ETags tag) { return s_IsBBLPrinter ? Reserved_Tags[static_cast<unsigned char>(tag)] : Reserved_Tags_compatible[static_cast<unsigned char>(tag)]; }

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -6444,7 +6444,7 @@ void PrintConfigDef::init_fff_params()
     def->tooltip = L("G-code written at the very top of the output file, before any other content. "
                      "Useful for adding metadata that printer firmware reads from the first lines of the file "
                      "(e.g. estimated print time, filament usage). "
-                     "Supports placeholders like {print_time_sec} and {used_filament_length}.");
+                     "Supports placeholders like {print_time_sec}, {used_filament_length} and {used_filament_volume}.");
     def->multiline = true;
     def->full_width = true;
     def->height = 8;
@@ -12301,6 +12301,10 @@ PrintStatisticsConfigDef::PrintStatisticsConfigDef()
     def = this->add("used_filament_length", coString);
     def->label = L("Filament length (meters)");
     def->tooltip = L("Total filament length used in meters. Replaced with actual value during post-processing.");
+
+    def = this->add("used_filament_volume", coString);
+    def->label = L("Filament volume (mm³)");
+    def->tooltip = L("Total filament volume used in cubic millimeters. Replaced with actual value during post-processing.");
 }
 
 ObjectsInfoConfigDef::ObjectsInfoConfigDef()


### PR DESCRIPTION
# Description

This PR adds support for a new `@USED_FILAMENT_VOLUME@` placeholder that can be used in G-code headers and templates to display the total filament volume used during printing, measured in cubic millimeters (mm³).

This needed for uploading proper gcode files to Digital Factory (Ultimaker cloud) and have correct statistics of printer usage.

To be clear: the existing "extruded_volume_total" is not available in the machine start g-code, it always results in 0.

If preferred, extruded_volume_total could be modified into a placeholder so it works at the end just like at the beginning.

## Changes Made

- **GCodeProcessor**: Added `Used_Filament_Volume_Placeholder` enum tag and implemented volume calculation logic that computes filament volume per filament as: `length (mm) × π × (diameter/2)²`, accounting for different filament diameters
- **PrintConfig**: Added new `used_filament_volume` configuration option with tooltip documentation
- **GCode**: Integrated the new placeholder into the placeholder parser for both top-level G-code and general G-code processing
- **Documentation**: Updated tooltip text to mention the new `{used_filament_volume}` placeholder alongside existing placeholders

The volume calculation properly handles multi-filament scenarios by iterating through each filament's length and diameter to compute the total volume used.


## Tests

No additional testing needed - this is a straightforward feature addition that follows the existing pattern for the `used_filament_length` placeholder. The implementation mirrors the established placeholder replacement mechanism and will be validated through standard G-code generation workflows.

https://claude.ai/code/session_01WK99BVatrR9dpg3bnoyneG

## Summary by Sourcery

Add support for a new used filament volume placeholder in G-code generation and print statistics.

New Features:
- Introduce @USED_FILAMENT_VOLUME@ as a reserved inline placeholder in G-code post-processing to display total filament volume used.
- Expose a new print statistics config option used_filament_volume representing total filament volume in cubic millimeters for use in templates and headers.

Enhancements:
- Extend G-code placeholder parsing for top-level and general G-code to handle the new used_filament_volume value alongside existing placeholders.
- Update tooltip documentation for custom top G-code and print statistics to mention the new filament volume placeholder.