### PR TITLE
Silence CMake configure warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -853,7 +853,6 @@ foreach(po_file ${BBL_L10N_PO_FILES})
     add_custom_command(
         TARGET gettext_merge_po_with_pot PRE_BUILD
         COMMAND msgmerge -N -o ${po_file} ${po_file} "${BBL_L18N_DIR}/OrcaSlicer.pot"
-        DEPENDS ${po_file}
     )
 endforeach()
 add_custom_target(gettext_po_to_mo
@@ -869,7 +868,6 @@ foreach(po_file ${BBL_L10N_PO_FILES})
         TARGET gettext_po_to_mo PRE_BUILD
         COMMAND msgfmt ARGS --check-format -o ${mo_file} ${po_file}
         #COMMAND msgfmt ARGS --check-compatibility -o ${mo_file} ${po_file}
-        DEPENDS ${po_file}
     )
 endforeach()
 

--- a/cmake/modules/FindOpenVDB.cmake
+++ b/cmake/modules/FindOpenVDB.cmake
@@ -128,6 +128,10 @@ cmake_minimum_required(VERSION 3.13)
 if(POLICY CMP0074)
   cmake_policy(SET CMP0074 NEW)
 endif()
+# Re-set after cmake_minimum_required above cleared it; use BoostConfig, not the removed FindBoost.
+if(POLICY CMP0167)
+  cmake_policy(SET CMP0167 NEW)
+endif()
 
 if(OpenVDB_FIND_QUIETLY)
   set (_quiet "QUIET")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -283,10 +283,6 @@ else ()
             COMMAND ln -sf OrcaSlicer orca-slicer
             WORKING_DIRECTORY "$<TARGET_FILE_DIR:OrcaSlicer>"
             VERBATIM)
-    else ()
-        add_custom_command(TARGET OrcaSlicer POST_BUILD
-            WORKING_DIRECTORY "$<TARGET_FILE_DIR:OrcaSlicer>"
-            VERBATIM)
     endif ()
     if (XCODE)
         # Because of Debug/Release/etc. configurations (similar to MSVC) the slic3r binary is located in an extra level

--- a/src/libslic3r/CMakeLists.txt
+++ b/src/libslic3r/CMakeLists.txt
@@ -497,8 +497,12 @@ set(CGAL_DO_NOT_WARN_ABOUT_CMAKE_BUILD_TYPE ON CACHE BOOL "" FORCE)
 
 cmake_policy(PUSH)
 cmake_policy(SET CMP0011 NEW)
+# CGAL's config resets policies (cmake_minimum_required ...3.23), so a plain SET
+# can't reach it; the default opts its Boost lookup into BoostConfig (CMP0167).
+set(CMAKE_POLICY_DEFAULT_CMP0167 NEW)
 find_package(CGAL REQUIRED)
 find_package(OpenCV REQUIRED core)
+unset(CMAKE_POLICY_DEFAULT_CMP0167)
 cmake_policy(POP)
 
 add_library(libslic3r_cgal STATIC
@@ -545,7 +549,7 @@ find_package(OpenCASCADE REQUIRED)
 target_include_directories(libslic3r SYSTEM PUBLIC ${OpenCASCADE_INCLUDE_DIR})
 
 find_package(JPEG REQUIRED)
-find_package(draco REQUIRED)
+find_package(Draco REQUIRED)
 
 set(OCCT_LIBS
     TKXDESTEP


### PR DESCRIPTION
# Description

Remove DEPENDS/empty-COMMAND args that are invalid in the add_custom_command(TARGET) form (CMP0175), fix the FindDraco.cmake case mismatch, and opt Boost lookup into upstream BoostConfig via CMP0167 for the OpenVDB module and the CGAL find.
# Screenshots/Recordings/Graphs

<!--
> Please attach relevant screenshots to showcase the UI changes.
> Please attach images that can help explain the changes.
-->

## Tests

<!--
> Please describe the tests that you have conducted to verify the changes made in this PR.
-->

<!--
> A guide for users on how to download the artifacts from this PR.
-->

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
