### PR TITLE
fix: crash synchronizing extruder parameters on a dual-nozzle printer without variant columns

### DIFF
--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -8288,6 +8288,9 @@ void Tab::sync_excluder()
     auto dest_str = std::to_string(dest_index);
     auto dirty_options = m_presets->current_dirty_options(true);
     DynamicConfig config_origin, config_to_apply;
+    // An unresolved extruder variant gives -1, which would index set_at() out of range.
+    if (from_index < 0 || dest_index < 0)
+        return;
     for (int i = 0; i < dirty_options.size(); ++i) {
         auto &opt = dirty_options[i];
         auto n= opt.find('#');

--- a/tests/libslic3r/test_config_variant_expansion.cpp
+++ b/tests/libslic3r/test_config_variant_expansion.cpp
@@ -81,6 +81,21 @@ TEST_CASE("get_config_index_base resolves (volume type, extruder type, id) to a 
     }
 }
 
+TEST_CASE("get_index_for_extruder returns -1 when no variant column matches the extruder", "[Config]")
+{
+    DynamicPrintConfig config;
+    config.option<ConfigOptionInts>("print_extruder_id", true)->values = {1};
+    config.option<ConfigOptionStrings>("print_extruder_variant", true)->values = {"Direct Drive Standard"};
+
+    SECTION("the extruder that owns the column resolves to its slot") {
+        REQUIRE(config.get_index_for_extruder(1, "print_extruder_id", etDirectDrive, nvtStandard, "print_extruder_variant") == 0);
+    }
+
+    SECTION("an extruder with no matching column resolves to -1") {
+        REQUIRE(config.get_index_for_extruder(2, "print_extruder_id", etDirectDrive, nvtStandard, "print_extruder_variant") == -1);
+    }
+}
+
 TEST_CASE("get_extruder_nozzle_volume_count reads the per-extruder volume-type layout", "[Config]")
 {
     std::vector<std::vector<NozzleVolumeType>> nozzle_volume_types;


### PR DESCRIPTION
# Description

The extruder-sync button on the Speed/Process tab crashed with an access violation on a dual-nozzle printer that has no per-extruder variant columns. `Tab::sync_excluder()` used the `-1` returned by `get_index_for_extruder()` as an array index, unlike `switch_excluder()`, which already guards it. This adds the same guard.

These multi-extruder options probably should not appear on non-Bambu printers in the first place, but that UI gating is best left to a separate PR; this change only stops the crash.

Reported in #14912

# Screenshots/Recordings/Graphs

The Bambu-style two-nozzle selector and sync button on a non-Bambu RatRig IDEX under Speed. The arrowed button triggers the crash.

<img width="673" height="600" alt="RatRig IDEX under Speed showing the two-nozzle selector and the extruder-sync button that crashes" src="https://github.com/user-attachments/assets/91493060-f511-4cce-8a51-20be457961e7" />

## Tests

Added a `get_index_for_extruder` case in `tests/libslic3r/test_config_variant_expansion.cpp`.

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
