### PR TITLE
Fix: Only one wall top surfaces

### DIFF
--- a/src/libslic3r/PerimeterGenerator.cpp
+++ b/src/libslic3r/PerimeterGenerator.cpp
@@ -579,14 +579,22 @@ static ExtrusionEntityCollection traverse_extrusions(const PerimeterGenerator& p
     return extrusion_coll;
 }
 
-// ORCA: only_one_wall_top removes the inner walls over a top surface and lets the top fill take their space.
-// Without a top fill they would print as a void, so fall back to the original generation (re-onion the not-top
-// region). Zero top shell layers retypes the top fill as internal, see LayerRegion::prepare_fill_surfaces().
-// The top fill only reaches the freed space when top_surface_expansion grows it there, so without expansion the
-// original generation is kept as well - it is what users of only_one_wall_top alone have always got.
+// ORCA: only_one_wall_top drops the inner walls over a top surface and lets the top solid infill take their space,
+// so it needs that fill to exist. Zero top shell layers retypes the top surfaces as internal (see
+// LayerRegion::prepare_fill_surfaces()) and a 0% top surface density leaves them unfilled; either way the walls
+// would be given up over a void, so the feature is off. ConfigManipulation::toggle_print_fff_options() hides the
+// option under the same condition, so a profile that left it enabled does not act behind a hidden checkbox.
+static bool top_surface_is_filled(const PrintRegionConfig &config)
+{
+    return config.top_shell_layers.value > 0 && config.top_surface_density.value > 0;
+}
+
+// ORCA: the walls can only be handed over where the top fill actually reaches, which is what top_surface_expansion
+// grows it to do. Without the expansion the original generation is kept (re-onion the not-top region) - that is what
+// users of only_one_wall_top alone have always got.
 static bool top_fill_replaces_inner_walls(const PrintRegionConfig &config)
 {
-    return config.top_shell_layers.value > 0 && config.top_surface_density.value > 0 && config.top_surface_expansion.value > 0;
+    return top_surface_is_filled(config) && config.top_surface_expansion.value > 0;
 }
 
 // ORCA: only_one_wall_top - cheap per-vertex classification of a wall against the top surface. Only Partial
@@ -1362,6 +1370,9 @@ void PerimeterGenerator::process_classic()
     for (const Surface &surface : all_surfaces)
         surface_exp.push_back(surface.expolygon);
     std::vector<size_t> surface_order = chain_expolygons(surface_exp);
+    // ORCA: only_one_wall_top has no top fill to give the inner walls to unless the region gets one, see
+    // top_surface_is_filled(). Gated here so every use below - including the topmost layer - sees the same answer.
+    const bool only_one_wall_top = this->config->only_one_wall_top && top_surface_is_filled(*this->config);
     for (size_t order_idx = 0; order_idx < surface_order.size(); order_idx++) {
         const Surface &surface = all_surfaces[surface_order[order_idx]];
         // detect how many perimeters must be generated for this island
@@ -1372,7 +1383,7 @@ void PerimeterGenerator::process_classic()
         if (this->layer_id == object_config->raft_layers && this->config->only_one_wall_first_layer)
             loop_number = 0;
         // Set the topmost layer to be one wall
-        if (loop_number > 0 && config->only_one_wall_top && this->upper_slices == nullptr)
+        if (loop_number > 0 && only_one_wall_top && this->upper_slices == nullptr)
             loop_number = 0;
 
         ExPolygons last        = union_ex(surface.expolygon.simplify_p(surface_simplify_resolution));
@@ -1524,7 +1535,7 @@ void PerimeterGenerator::process_classic()
 
                 //BBS: refer to superslicer
                 //store surface for top infill if only_one_wall_top
-                if (i == 0 && i!=loop_number && config->only_one_wall_top && !surface.is_bridge() && this->upper_slices != NULL) {
+                if (i == 0 && i!=loop_number && only_one_wall_top && !surface.is_bridge() && this->upper_slices != NULL) {
                     if (top_fill_replaces_inner_walls(*this->config)) {
                         // ORCA: take the top fill and the keep-out region but leave `last` as the real geometry,
                         // so the onion follows it and the walls over the top are reduced in one step below.
@@ -2335,6 +2346,9 @@ void PerimeterGenerator::process_arachne()
     process_no_bridge(all_surfaces, perimeter_spacing, ext_perimeter_width);
     // BBS: don't simplify too much which influence arc fitting when export gcode if arc_fitting is enabled
     double surface_simplify_resolution = (print_config->enable_arc_fitting && !this->has_fuzzy_skin) ? 0.2 * m_scaled_resolution : m_scaled_resolution;
+    // ORCA: only_one_wall_top has no top fill to give the inner walls to unless the region gets one, see
+    // top_surface_is_filled(). Gated here so every use below - including the topmost layer - sees the same answer.
+    const bool only_one_wall_top = this->config->only_one_wall_top && top_surface_is_filled(*this->config);
     // we need to process each island separately because we might have different
     // extra perimeters for each one
     for (const Surface& surface : all_surfaces) {
@@ -2352,7 +2366,7 @@ void PerimeterGenerator::process_arachne()
 
         // Orca: set the topmost layer to be one wall according to the config
         const bool is_topmost_layer = (this->upper_slices == nullptr) ? true : false;
-        if (is_topmost_layer && loop_number > 0 && config->only_one_wall_top)
+        if (is_topmost_layer && loop_number > 0 && only_one_wall_top)
             loop_number = 0;
         
         auto apply_precise_outer_wall = config->precise_outer_wall && config->wall_sequence == WallSequence::InnerOuter;
@@ -2372,10 +2386,10 @@ void PerimeterGenerator::process_arachne()
         //PS: One wall top surface for Arachne
         ExPolygons top_expolygons;
         // Calculate how many inner loops remain when TopSurfaces is selected.
-        const int inner_loop_number = (config->only_one_wall_top && upper_slices != nullptr) ? loop_number - 1 : -1;
+        const int inner_loop_number = (only_one_wall_top && upper_slices != nullptr) ? loop_number - 1 : -1;
 
         // Set one perimeter when TopSurfaces is selected.
-        if (config->only_one_wall_top && loop_number > 0)
+        if (only_one_wall_top && loop_number > 0)
             loop_number = 0;
 
         Arachne::WallToolPathsParams input_params_tmp = input_params;

--- a/src/libslic3r/PerimeterGenerator.cpp
+++ b/src/libslic3r/PerimeterGenerator.cpp
@@ -579,22 +579,23 @@ static ExtrusionEntityCollection traverse_extrusions(const PerimeterGenerator& p
     return extrusion_coll;
 }
 
-// ORCA: only_one_wall_top drops the inner walls over a top surface and lets the top solid infill take their space,
-// so it needs that fill to exist. Zero top shell layers retypes the top surfaces as internal (see
-// LayerRegion::prepare_fill_surfaces()) and a 0% top surface density leaves them unfilled; either way the walls
-// would be given up over a void, so the feature is off. ConfigManipulation::toggle_print_fff_options() hides the
-// option under the same condition, so a profile that left it enabled does not act behind a hidden checkbox.
-static bool top_surface_is_filled(const PrintRegionConfig &config)
+// ORCA: only_one_wall_top acts on top surfaces, so without a top shell there is nothing for it to act on: zero top
+// shell layers retype the top surfaces as internal, see LayerRegion::prepare_fill_surfaces(). A 0% top surface
+// density does leave a top surface - just an unfilled one - so it does not disable the feature.
+// ConfigManipulation::toggle_print_fff_options() hides the option under the same condition, so a profile that left
+// it enabled does not act behind a hidden checkbox.
+static bool has_top_shell_layers(const PrintRegionConfig &config)
 {
-    return config.top_shell_layers.value > 0 && config.top_surface_density.value > 0;
+    return config.top_shell_layers.value > 0;
 }
 
-// ORCA: the walls can only be handed over where the top fill actually reaches, which is what top_surface_expansion
-// grows it to do. Without the expansion the original generation is kept (re-onion the not-top region) - that is what
-// users of only_one_wall_top alone have always got.
+// ORCA: the inner walls are only given up when a top fill takes their space, and it has to actually reach it -
+// a 0% top surface density leaves no fill at all, and without top_surface_expansion the fill never grows over
+// them. Either way the original generation is kept (re-onion the not-top region), which is what users of
+// only_one_wall_top alone have always got.
 static bool top_fill_replaces_inner_walls(const PrintRegionConfig &config)
 {
-    return top_surface_is_filled(config) && config.top_surface_expansion.value > 0;
+    return has_top_shell_layers(config) && config.top_surface_density.value > 0 && config.top_surface_expansion.value > 0;
 }
 
 // ORCA: only_one_wall_top - cheap per-vertex classification of a wall against the top surface. Only Partial
@@ -1370,9 +1371,9 @@ void PerimeterGenerator::process_classic()
     for (const Surface &surface : all_surfaces)
         surface_exp.push_back(surface.expolygon);
     std::vector<size_t> surface_order = chain_expolygons(surface_exp);
-    // ORCA: only_one_wall_top has no top fill to give the inner walls to unless the region gets one, see
-    // top_surface_is_filled(). Gated here so every use below - including the topmost layer - sees the same answer.
-    const bool only_one_wall_top = this->config->only_one_wall_top && top_surface_is_filled(*this->config);
+    // ORCA: only_one_wall_top has no top surface to act on without a top shell, see has_top_shell_layers().
+    // Gated here so every use below - including the topmost layer - sees the same answer.
+    const bool only_one_wall_top = this->config->only_one_wall_top && has_top_shell_layers(*this->config);
     for (size_t order_idx = 0; order_idx < surface_order.size(); order_idx++) {
         const Surface &surface = all_surfaces[surface_order[order_idx]];
         // detect how many perimeters must be generated for this island
@@ -2346,9 +2347,9 @@ void PerimeterGenerator::process_arachne()
     process_no_bridge(all_surfaces, perimeter_spacing, ext_perimeter_width);
     // BBS: don't simplify too much which influence arc fitting when export gcode if arc_fitting is enabled
     double surface_simplify_resolution = (print_config->enable_arc_fitting && !this->has_fuzzy_skin) ? 0.2 * m_scaled_resolution : m_scaled_resolution;
-    // ORCA: only_one_wall_top has no top fill to give the inner walls to unless the region gets one, see
-    // top_surface_is_filled(). Gated here so every use below - including the topmost layer - sees the same answer.
-    const bool only_one_wall_top = this->config->only_one_wall_top && top_surface_is_filled(*this->config);
+    // ORCA: only_one_wall_top has no top surface to act on without a top shell, see has_top_shell_layers().
+    // Gated here so every use below - including the topmost layer - sees the same answer.
+    const bool only_one_wall_top = this->config->only_one_wall_top && has_top_shell_layers(*this->config);
     // we need to process each island separately because we might have different
     // extra perimeters for each one
     for (const Surface& surface : all_surfaces) {

--- a/src/libslic3r/PerimeterGenerator.cpp
+++ b/src/libslic3r/PerimeterGenerator.cpp
@@ -360,6 +360,14 @@ static ClipperLib_Z::Paths clip_extrusion(const ClipperLib_Z::Path& subject, con
     return clipped_paths;
 }
 
+static double clipper_z_path_length(const ClipperLib_Z::Path &path)
+{
+    double len = 0.;
+    for (size_t i = 1; i < path.size(); ++ i)
+        len += (Vec2d(double(path[i].x()), double(path[i].y())) - Vec2d(double(path[i - 1].x()), double(path[i - 1].y()))).norm();
+    return len;
+}
+
 struct PerimeterGeneratorArachneExtrusion
 {
     Arachne::ExtrusionLine* extrusion = nullptr;
@@ -2343,7 +2351,43 @@ void PerimeterGenerator::process_arachne()
                         subject.reserve(el.size());
                         for (const Arachne::ExtrusionJunction &j : el.junctions)
                             subject.emplace_back(j.p.x(), j.p.y(), j.w);
-                        for (const ClipperLib_Z::Path &path : clip_extrusion(subject, top_paths_z, ClipperLib_Z::ctDifference)) {
+                        ClipperLib_Z::Paths pieces = clip_extrusion(subject, top_paths_z, ClipperLib_Z::ctDifference);
+
+                        // Clipper treats the subject as an open polyline: it also cuts a closed loop at its
+                        // (arbitrary) start vertex and may reverse pieces. Stitch pieces that share an endpoint
+                        // back together so the wall is only divided where it actually crosses the top surface.
+                        auto same_pt = [](const ClipperLib_Z::IntPoint &p, const ClipperLib_Z::IntPoint &q) {
+                            return std::abs(p.x() - q.x()) <= SCALED_EPSILON && std::abs(p.y() - q.y()) <= SCALED_EPSILON;
+                        };
+                        for (size_t i = 0; i < pieces.size(); ++ i) {
+                            for (size_t j = i + 1; j < pieces.size();) {
+                                ClipperLib_Z::Path &a = pieces[i];
+                                ClipperLib_Z::Path &b = pieces[j];
+                                if (same_pt(a.front(), b.front()) || same_pt(a.front(), b.back()))
+                                    std::reverse(a.begin(), a.end());
+                                if (same_pt(a.back(), b.back()))
+                                    std::reverse(b.begin(), b.end());
+                                if (same_pt(a.back(), b.front())) {
+                                    a.insert(a.end(), b.begin() + 1, b.end());
+                                    pieces.erase(pieces.begin() + j);
+                                    // Restart the scan: the merged path has new endpoints.
+                                    j = i + 1;
+                                } else
+                                    ++ j;
+                            }
+                        }
+
+                        // If the clip removed next to nothing (the wall only grazed the expanded top margin),
+                        // keep the loop untouched instead of slitting it open.
+                        double kept_length = 0.;
+                        for (const ClipperLib_Z::Path &path : pieces)
+                            kept_length += clipper_z_path_length(path);
+                        if (clipper_z_path_length(subject) - kept_length < double(perimeter_width)) {
+                            kept.emplace_back(std::move(el));
+                            continue;
+                        }
+
+                        for (const ClipperLib_Z::Path &path : pieces) {
                             Arachne::ExtrusionLine clipped(el.inset_idx, el.is_odd);
                             clipped.junctions.reserve(path.size());
                             for (const ClipperLib_Z::IntPoint &pt : path)

--- a/src/libslic3r/PerimeterGenerator.cpp
+++ b/src/libslic3r/PerimeterGenerator.cpp
@@ -589,23 +589,11 @@ static bool top_fill_replaces_inner_walls(const PrintRegionConfig &config)
     return config.top_surface_density.value > 0;
 }
 
-// ORCA: only_one_wall_top detects the top as "slice − upper", so a feature rising from the middle of a
-// top surface becomes an enclosed hole. Fill those holes back into the top so the top surface stays solid
-// (avoids leaving thin, unfillable slivers once the inner perimeters are removed). Only holes that are both
-// covered by the upper layer (excludes bridges) and backed by solid material (excludes voids) are filled.
-static ExPolygons fill_enclosed_top_feature_holes(const ExPolygons &top, const Polygons &covered_by_upper, const ExPolygons &solid)
-{
-    ExPolygons filled = top;
-    for (ExPolygon &ex : filled)
-        ex.holes.clear();
-    const ExPolygons feature_holes = intersection_ex(intersection_ex(diff_ex(filled, top), covered_by_upper), solid);
-    return feature_holes.empty() ? top : union_ex(top, feature_holes);
-}
-
 // ORCA: only_one_wall_top keeps a single wall on top surfaces. The walls are generated from the real geometry
 // (as when the feature is off) and the parts that fall over the top surface are then removed, so no wall is
-// ever invented along the top/non-top boundary. A wall counts as touching the top as soon as one of its
-// vertices lands on it (a segment crossing the top with no vertex inside is rare enough to ignore).
+// ever invented along the top/non-top boundary. This is the cheap first pass: a wall is a candidate for removal
+// as soon as one of its vertices lands on the top (a segment crossing the top with no vertex inside is rare
+// enough to ignore). How much of it is actually removed is decided by the caller.
 static bool loop_kept_for_one_wall_top(const Points &pts, const ExPolygons &top_region, const BoundingBox &top_region_bbox)
 {
     for (const Point &p : pts) {
@@ -632,10 +620,21 @@ static bool loop_kept_for_one_wall_top(const Arachne::ExtrusionLine &el, const E
 
 // ORCA: only_one_wall_top for Arachne - remove from the already generated inner walls the parts that run over the
 // top surface. Walls that merely graze the top are clipped rather than dropped whole, so the geometry that continues
-// upward keeps its walls; only the pieces over the top disappear.
-static void clip_inner_walls_over_top(std::vector<Arachne::VariableWidthLines> &inner_perimeters, const ExPolygons &top_region, coord_t perimeter_width)
+// upward keeps its walls; only the pieces over the top disappear. A wall too short over the top to be worth slitting
+// open is left whole and its footprint reported in kept_over_top, for the caller to withhold from the top fill.
+static void clip_inner_walls_over_top(std::vector<Arachne::VariableWidthLines> &inner_perimeters, const ExPolygons &top_region, coord_t perimeter_width, Polygons &kept_over_top)
 {
     const BoundingBox top_region_bbox = get_extents(top_region).inflated(SCALED_EPSILON);
+    auto covered_by = [](const Arachne::ExtrusionLine &el) {
+        Polyline centerline;
+        centerline.points.reserve(el.junctions.size());
+        coord_t width = 0;
+        for (const Arachne::ExtrusionJunction &j : el.junctions) {
+            centerline.points.emplace_back(j.p);
+            width = std::max(width, j.w);
+        }
+        return offset(centerline, float(width) / 2.f);
+    };
     // The cut is pulled back by half a wall width: the clip severs the centerline, but the bead's
     // rounded end extends half a width past its endpoint and would otherwise overlap the top fill.
     ClipperLib_Z::Paths top_paths_z;
@@ -693,6 +692,7 @@ static void clip_inner_walls_over_top(std::vector<Arachne::VariableWidthLines> &
             for (const ClipperLib_Z::Path &path : pieces)
                 kept_length += clipper_z_path_length(path);
             if (clipper_z_path_length(subject) - kept_length < 2. * double(perimeter_width)) {
+                append(kept_over_top, covered_by(el));
                 kept.emplace_back(std::move(el));
                 continue;
             }
@@ -776,8 +776,6 @@ void PerimeterGenerator::split_top_surfaces(const ExPolygons &orig_polygons, ExP
     ExPolygons delete_bridge = diff_ex(orig_polygons, bridge_checker, ApplySafetyOffset::Yes);
 
     ExPolygons top_polygons = diff_ex(delete_bridge, upper_polygons_series_clipped, ApplySafetyOffset::Yes);
-    if (top_fill_replaces_inner_walls(*this->config))
-        top_polygons = fill_enclosed_top_feature_holes(top_polygons, upper_polygons_series_clipped, orig_polygons);
 
     // get the not-top surface, from the "real top" but enlarged by external_infill_margin (and the
     // min_width_top_surface we removed a bit before)
@@ -1385,6 +1383,9 @@ void PerimeterGenerator::process_classic()
         // ORCA: only_one_wall_top - footprint of the dropped walls that the top fill does not cover; handed over
         // to the infill so a wall that merely grazed the top does not leave a void where it used to be.
         ExPolygons one_wall_top_reclaimed;
+        // ORCA: only_one_wall_top - footprint of the walls that were kept although they graze the top; withheld
+        // from the top fill so the two never claim the same space.
+        Polygons   one_wall_top_kept_bands;
         bool       apply_one_wall_top = false;
         if (loop_number >= 0) {
             // In case no perimeters are to be generated, loop_number will equal to -1.
@@ -1547,27 +1548,39 @@ void PerimeterGenerator::process_classic()
                 }
             }
 
-            // ORCA: only_one_wall_top reduction - drop the inner walls (depth > 0) that fall over the top surface
+            // ORCA: only_one_wall_top reduction - drop the inner walls (depth > 0) that run over the top surface
             // and take that space back from the gaps, leaving the top with just the outer wall and top infill.
+            // Classic perimeters are closed loops, so unlike the Arachne path a wall can only be kept or dropped
+            // whole; one that merely grazes the top (same tolerance as the Arachne clip) is kept, and its band is
+            // withheld from the top fill instead, so a kept wall and the fill never claim the same space.
             if (apply_one_wall_top) {
-                const BoundingBox top_region_bbox = get_extents(one_wall_top_region).inflated(SCALED_EPSILON);
+                const BoundingBox top_region_bbox     = get_extents(one_wall_top_region).inflated(SCALED_EPSILON);
+                const double      grazing_tolerance   = 2. * double(perimeter_width);
+                // The band a wall covers, taken around its centerline so the orientation of holes does not matter.
+                auto wall_band = [perimeter_spacing](const Polygon &poly) {
+                    Polygon centerline = poly;
+                    centerline.make_counter_clockwise();
+                    return diff(offset(centerline, float(perimeter_spacing) / 2.f),
+                                offset(centerline, -float(perimeter_spacing) / 2.f));
+                };
                 Polygons dropped_wall_bands;
-                auto drop_over_top = [&](PerimeterGeneratorLoops &loops) {
+                auto reduce_over_top = [&](PerimeterGeneratorLoops &loops) {
                     loops.erase(std::remove_if(loops.begin(), loops.end(), [&](const PerimeterGeneratorLoop &loop) {
                         if (loop_kept_for_one_wall_top(loop.polygon.points, one_wall_top_region, top_region_bbox))
                             return false;
+                        if (total_length(intersection_pl(Polylines{ loop.polygon.split_at_first_point() }, one_wall_top_region)) < grazing_tolerance) {
+                            append(one_wall_top_kept_bands, wall_band(loop.polygon));
+                            return false;
+                        }
                         // Remember the band this wall would have covered; whatever ends up outside the top fill
                         // must be filled by infill instead of being left as a void.
-                        Polygon centerline = loop.polygon;
-                        centerline.make_counter_clockwise();
-                        append(dropped_wall_bands, diff(offset(centerline, float(perimeter_spacing) / 2.f),
-                                                        offset(centerline, -float(perimeter_spacing) / 2.f)));
+                        append(dropped_wall_bands, wall_band(loop.polygon));
                         return true;
                     }), loops.end());
                 };
                 for (int d = 1; d <= loop_number; ++ d) {
-                    drop_over_top(contours[d]);
-                    drop_over_top(holes[d]);
+                    reduce_over_top(contours[d]);
+                    reduce_over_top(holes[d]);
                 }
                 if (! gaps.empty())
                     gaps = diff_ex(gaps, one_wall_top_region);
@@ -1857,6 +1870,9 @@ void PerimeterGenerator::process_classic()
         // append infill areas to fill_surfaces
         //if any top_fills, grow them by ext_perimeter_spacing/2 to have the real un-anchored fill
         ExPolygons top_infill_exp = intersection_ex(fill_clip, offset_ex(top_fills, double(ext_perimeter_spacing / 2)));
+        // ORCA: only_one_wall_top - route the top fill around the walls that were kept despite grazing the top.
+        if (!one_wall_top_kept_bands.empty())
+            top_infill_exp = diff_ex(top_infill_exp, one_wall_top_kept_bands);
         if (!top_fills.empty()) {
             infill_exp = union_ex(infill_exp, offset_ex(top_infill_exp, double(top_infill_peri_overlap)));
         }
@@ -2428,8 +2444,13 @@ void PerimeterGenerator::process_arachne()
                 Arachne::WallToolPaths inner_wall_tool_paths(inner_region, perimeter_spacing, perimeter_spacing, coord_t(inner_loop_number + 1), 0, layer_height, input_params_tmp);
                 std::vector<Arachne::VariableWidthLines> inner_perimeters = inner_wall_tool_paths.getToolPaths();
 
-                if (clip_walls_over_top)
-                    clip_inner_walls_over_top(inner_perimeters, top_expolygons, perimeter_width);
+                if (clip_walls_over_top) {
+                    Polygons kept_over_top;
+                    clip_inner_walls_over_top(inner_perimeters, top_expolygons, perimeter_width, kept_over_top);
+                    // Route the top fill around the walls that were kept although they graze the top.
+                    if (! kept_over_top.empty())
+                        top_expolygons = diff_ex(top_expolygons, kept_over_top);
+                }
 
                 // Recalculate indexes of inner perimeters before merging them: they come after the single outer wall.
                 if (!perimeters.empty())

--- a/src/libslic3r/PerimeterGenerator.cpp
+++ b/src/libslic3r/PerimeterGenerator.cpp
@@ -579,22 +579,16 @@ static ExtrusionEntityCollection traverse_extrusions(const PerimeterGenerator& p
     return extrusion_coll;
 }
 
-// ORCA: the reworked only_one_wall_top generates the inner walls from the real geometry and then removes the
-// parts that fall over the top surface, handing that space over to the (expandable) top solid fill. Without a
-// top fill to take it over the removed walls would simply print as a void, so in that case keep the original
-// generation, which re-onions the not-top region and therefore keeps walls right up to the top boundary. There
-// is no top fill either when the top surface density is 0% or when no top shell is requested at all - zero top
-// shell layers retypes every top fill surface as internal (LayerRegion::prepare_fill_surfaces).
+// ORCA: only_one_wall_top removes the inner walls over a top surface and lets the top fill take their space.
+// Without a top fill they would print as a void, so fall back to the original generation (re-onion the not-top
+// region). Zero top shell layers retypes the top fill as internal, see LayerRegion::prepare_fill_surfaces().
 static bool top_fill_replaces_inner_walls(const PrintRegionConfig &config)
 {
     return config.top_shell_layers.value > 0 && config.top_surface_density.value > 0;
 }
 
-// ORCA: only_one_wall_top keeps a single wall on top surfaces. The walls are generated from the real geometry
-// (as when the feature is off) and the parts that fall over the top surface are then removed, so no wall is
-// ever invented along the top/non-top boundary. This is the cheap per-vertex classification both wall
-// generators start from: None and Full are decided here, and only Partial needs the geometry clipped or
-// measured (a segment crossing the top with no vertex inside is rare enough to ignore).
+// ORCA: only_one_wall_top - cheap per-vertex classification of a wall against the top surface. Only Partial
+// needs the geometry clipped or measured; a segment crossing the top with no vertex inside is rare enough to ignore.
 enum class TopOverlap { None, Partial, Full };
 
 static bool point_over_top(const Point &p, const ExPolygons &top_region, const BoundingBox &top_region_bbox)
@@ -625,10 +619,9 @@ static TopOverlap classify_over_top(const Arachne::ExtrusionLine &el, const ExPo
     return inside == 0 ? TopOverlap::None : inside == el.junctions.size() ? TopOverlap::Full : TopOverlap::Partial;
 }
 
-// ORCA: only_one_wall_top for Arachne - remove from the already generated inner walls the parts that run over the
-// top surface. Walls that merely graze the top are clipped rather than dropped whole, so the geometry that continues
-// upward keeps its walls; only the pieces over the top disappear. A wall too short over the top to be worth slitting
-// open is left whole and its footprint reported in kept_over_top, for the caller to withhold from the top fill.
+// ORCA: only_one_wall_top for Arachne - cut out of the already generated inner walls the parts running over the top
+// surface, so geometry that continues upward keeps its walls. A wall too short over the top to be worth slitting open
+// is left whole, its footprint reported in kept_over_top for the caller to withhold from the top fill.
 static void clip_inner_walls_over_top(std::vector<Arachne::VariableWidthLines> &inner_perimeters, const ExPolygons &top_region, coord_t perimeter_width, Polygons &kept_over_top)
 {
     const BoundingBox top_region_bbox = get_extents(top_region).inflated(SCALED_EPSILON);
@@ -642,8 +635,8 @@ static void clip_inner_walls_over_top(std::vector<Arachne::VariableWidthLines> &
         }
         return offset(centerline, float(width) / 2.f);
     };
-    // The cut is pulled back by half a wall width: the clip severs the centerline, but the bead's
-    // rounded end extends half a width past its endpoint and would otherwise overlap the top fill.
+    // Pull the cut back by half a wall width: the clip severs the centerline, but the bead's rounded end
+    // extends half a width past its endpoint and would otherwise overlap the top fill.
     ClipperLib_Z::Paths top_paths_z;
     for (const Polygon &poly : to_polygons(offset_ex(top_region, float(perimeter_width) / 2.f))) {
         top_paths_z.emplace_back();
@@ -664,16 +657,15 @@ static void clip_inner_walls_over_top(std::vector<Arachne::VariableWidthLines> &
                 continue;
             }
             if (overlap == TopOverlap::Full)
-                continue; // entirely over the top - the clip below would return nothing anyway
+                continue; // the clip below would return nothing anyway
             ClipperLib_Z::Path subject;
             subject.reserve(el.size());
             for (const Arachne::ExtrusionJunction &j : el.junctions)
                 subject.emplace_back(j.p.x(), j.p.y(), j.w);
             ClipperLib_Z::Paths pieces = clip_extrusion(subject, top_paths_z, ClipperLib_Z::ctDifference);
 
-            // Clipper treats the subject as an open polyline: it also cuts a closed loop at its
-            // (arbitrary) start vertex and may reverse pieces. Stitch pieces that share an endpoint
-            // back together so the wall is only divided where it actually crosses the top surface.
+            // Clipper treats the subject as an open polyline, so it also cuts a closed loop at its (arbitrary)
+            // start vertex and may reverse pieces. Stitch pieces sharing an endpoint back together.
             auto same_pt = [](const ClipperLib_Z::IntPoint &p, const ClipperLib_Z::IntPoint &q) {
                 return std::abs(p.x() - q.x()) <= SCALED_EPSILON && std::abs(p.y() - q.y()) <= SCALED_EPSILON;
             };
@@ -688,16 +680,14 @@ static void clip_inner_walls_over_top(std::vector<Arachne::VariableWidthLines> &
                     if (same_pt(a.back(), b.front())) {
                         a.insert(a.end(), b.begin() + 1, b.end());
                         pieces.erase(pieces.begin() + j);
-                        // Restart the scan: the merged path has new endpoints.
-                        j = i + 1;
+                        j = i + 1; // the merged path has new endpoints, restart the scan
                     } else
                         ++ j;
                 }
             }
 
-            // If the clip removed next to nothing (the wall only grazed the expanded top margin),
-            // keep the loop untouched instead of slitting it open. The half-width pull-back above
-            // already costs about one width per crossing, hence the two-width threshold.
+            // If the clip removed next to nothing, keep the loop untouched instead of slitting it open. The
+            // half-width pull-back above already costs about one width per crossing, hence two widths.
             double kept_length = 0.;
             for (const ClipperLib_Z::Path &path : pieces)
                 kept_length += clipper_z_path_length(path);
@@ -1387,14 +1377,11 @@ void PerimeterGenerator::process_classic()
         ExPolygons gaps;
         ExPolygons top_fills;
         ExPolygons fill_clip;
-        // ORCA: only_one_wall_top - the top-surface region to keep clear of inner walls, applied in one post-onion
-        // reduction step (see below). Empty / false unless this island has a top surface on this layer.
+        // ORCA: only_one_wall_top, all empty unless this island has a top surface on this layer. See the
+        // post-onion reduction below: the region to keep clear of inner walls, the space freed by the dropped
+        // walls (goes to infill, not left as a void) and the space held by the kept ones (withheld from the fill).
         ExPolygons one_wall_top_region;
-        // ORCA: only_one_wall_top - footprint of the dropped walls that the top fill does not cover; handed over
-        // to the infill so a wall that merely grazed the top does not leave a void where it used to be.
         ExPolygons one_wall_top_reclaimed;
-        // ORCA: only_one_wall_top - footprint of the walls that were kept although they graze the top; withheld
-        // from the top fill so the two never claim the same space.
         Polygons   one_wall_top_kept_bands;
         bool       apply_one_wall_top = false;
         if (loop_number >= 0) {
@@ -1537,16 +1524,15 @@ void PerimeterGenerator::process_classic()
                 //store surface for top infill if only_one_wall_top
                 if (i == 0 && i!=loop_number && config->only_one_wall_top && !surface.is_bridge() && this->upper_slices != NULL) {
                     if (top_fill_replaces_inner_walls(*this->config)) {
-                        // ORCA: only_one_wall_top - compute the top fill and the top keep-out region, but leave `last`
-                        // as the real geometry; the walls/gaps over the top are reduced in one post-onion step below.
+                        // ORCA: take the top fill and the keep-out region but leave `last` as the real geometry,
+                        // so the onion follows it and the walls over the top are reduced in one step below.
                         ExPolygons non_top_polygons;
                         this->split_top_surfaces(last, top_fills, non_top_polygons, fill_clip);
                         apply_one_wall_top = !top_fills.empty();
                         if (apply_one_wall_top)
                             one_wall_top_region = diff_ex(last, non_top_polygons);
                     } else {
-                        // Reduce `last` to the not-top region, so the remaining walls are onioned from it and
-                        // stop at the top boundary.
+                        // Onion the not-top region only, so the remaining walls stop at the top boundary.
                         this->split_top_surfaces(last, top_fills, last, fill_clip);
                     }
                 }
@@ -1558,14 +1544,13 @@ void PerimeterGenerator::process_classic()
                 }
             }
 
-            // ORCA: only_one_wall_top reduction - drop the inner walls (depth > 0) that run over the top surface
-            // and take that space back from the gaps, leaving the top with just the outer wall and top infill.
-            // Classic perimeters are closed loops, so unlike the Arachne path a wall can only be kept or dropped
-            // whole; one that merely grazes the top (same tolerance as the Arachne clip) is kept, and its band is
-            // withheld from the top fill instead, so a kept wall and the fill never claim the same space.
+            // ORCA: only_one_wall_top reduction - drop the inner walls (depth > 0) running over the top surface and
+            // take that space back from the gaps, leaving the top with the outer wall and the top infill. Classic
+            // perimeters are closed loops, so a wall can only be kept or dropped whole; one that merely grazes the
+            // top (same tolerance as the Arachne clip) is kept and withheld from the top fill instead.
             if (apply_one_wall_top) {
-                const BoundingBox top_region_bbox     = get_extents(one_wall_top_region).inflated(SCALED_EPSILON);
-                const double      grazing_tolerance   = 2. * double(perimeter_width);
+                const BoundingBox top_region_bbox   = get_extents(one_wall_top_region).inflated(SCALED_EPSILON);
+                const double      grazing_tolerance = 2. * double(perimeter_width);
                 // The band a wall covers, taken around its centerline so the orientation of holes does not matter.
                 auto wall_band = [perimeter_spacing](const Polygon &poly) {
                     Polygon centerline = poly;
@@ -1579,14 +1564,12 @@ void PerimeterGenerator::process_classic()
                         const TopOverlap overlap = classify_over_top(loop.polygon.points, one_wall_top_region, top_region_bbox);
                         if (overlap == TopOverlap::None)
                             return false;
-                        // Only a wall straddling the boundary is worth measuring; one lying wholly over the top goes.
+                        // Only a wall straddling the boundary is worth measuring; a wall wholly over the top goes.
                         if (overlap == TopOverlap::Partial &&
                             total_length(intersection_pl(Polylines{ loop.polygon.split_at_first_point() }, one_wall_top_region)) < grazing_tolerance) {
                             append(one_wall_top_kept_bands, wall_band(loop.polygon));
                             return false;
                         }
-                        // Remember the band this wall would have covered; whatever ends up outside the top fill
-                        // must be filled by infill instead of being left as a void.
                         append(dropped_wall_bands, wall_band(loop.polygon));
                         return true;
                     }), loops.end());
@@ -1883,13 +1866,13 @@ void PerimeterGenerator::process_classic()
         // append infill areas to fill_surfaces
         //if any top_fills, grow them by ext_perimeter_spacing/2 to have the real un-anchored fill
         ExPolygons top_infill_exp = intersection_ex(fill_clip, offset_ex(top_fills, double(ext_perimeter_spacing / 2)));
-        // ORCA: only_one_wall_top - route the top fill around the walls that were kept despite grazing the top.
+        // ORCA: only_one_wall_top - route the top fill around the walls kept despite grazing the top.
         if (!one_wall_top_kept_bands.empty())
             top_infill_exp = diff_ex(top_infill_exp, one_wall_top_kept_bands);
         if (!top_fills.empty()) {
             infill_exp = union_ex(infill_exp, offset_ex(top_infill_exp, double(top_infill_peri_overlap)));
         }
-        // ORCA: only_one_wall_top - the space of the dropped walls that the top fill does not cover goes to infill.
+        // ORCA: only_one_wall_top - what the top fill does not cover of the dropped walls goes to infill.
         if (!one_wall_top_reclaimed.empty())
             infill_exp = union_ex(infill_exp, one_wall_top_reclaimed);
         this->fill_surfaces->append(infill_exp, stInternal);
@@ -2444,12 +2427,10 @@ void PerimeterGenerator::process_arachne()
                 // Get final top ExPolygons (bridges were excluded above, so they stay walled).
                 top_expolygons = intersection_ex(top_expolygons, infill_contour);
 
-                // ORCA: onion the real region (inside the outer wall) for the remaining walls so they follow the
-                // actual geometry, then remove the parts that fall over the top surface. This replaces re-onioning the
-                // non-top complement, which walled the top/non-top interface and ringed top-surface islands (e.g. a
-                // recess floor) with inner walls that don't exist when the feature is disabled. Without a top fill to
-                // take over the freed space the original complement onioning is used instead - see
-                // top_fill_replaces_inner_walls().
+                // ORCA: onion the real region (inside the outer wall) so the remaining walls follow the actual
+                // geometry, then cut away the parts over the top surface. Re-onioning the non-top complement
+                // instead - the fallback when there is no top fill - walls the top/non-top interface and rings
+                // top-surface islands with inner walls that don't exist when the feature is disabled.
                 const bool     clip_walls_over_top = top_fill_replaces_inner_walls(*this->config);
                 const Polygons inner_region        = to_polygons(offset_ex(clip_walls_over_top ? infill_contour
                                                                                                : diff_ex(infill_contour, top_expolygons),
@@ -2460,7 +2441,7 @@ void PerimeterGenerator::process_arachne()
                 if (clip_walls_over_top) {
                     Polygons kept_over_top;
                     clip_inner_walls_over_top(inner_perimeters, top_expolygons, perimeter_width, kept_over_top);
-                    // Route the top fill around the walls that were kept although they graze the top.
+                    // Route the top fill around the walls kept despite grazing the top.
                     if (! kept_over_top.empty())
                         top_expolygons = diff_ex(top_expolygons, kept_over_top);
                 }

--- a/src/libslic3r/PerimeterGenerator.cpp
+++ b/src/libslic3r/PerimeterGenerator.cpp
@@ -589,6 +589,15 @@ static bool has_top_shell_layers(const PrintRegionConfig &config)
     return config.top_shell_layers.value > 0;
 }
 
+// ORCA: only_one_wall_first_layer thins the first layer to a single wall, the bottom counterpart of the above and
+// gated the same way: zero bottom shell layers retype the bottom surfaces as internal, so that wall would ring
+// sparse infill on the bed. The bottom surface density plays no part - an unfilled bottom surface is still a bottom
+// surface, exactly as for the top - and it cannot reach zero anyway, being capped at a 10% minimum.
+static bool has_bottom_shell_layers(const PrintRegionConfig &config)
+{
+    return config.bottom_shell_layers.value > 0;
+}
+
 // ORCA: the inner walls are only given up when a top fill takes their space, and it has to actually reach it -
 // a 0% top surface density leaves no fill at all, and without top_surface_expansion the fill never grows over
 // them. Either way the original generation is kept (re-onion the not-top region), which is what users of
@@ -1371,9 +1380,11 @@ void PerimeterGenerator::process_classic()
     for (const Surface &surface : all_surfaces)
         surface_exp.push_back(surface.expolygon);
     std::vector<size_t> surface_order = chain_expolygons(surface_exp);
-    // ORCA: only_one_wall_top has no top surface to act on without a top shell, see has_top_shell_layers().
-    // Gated here so every use below - including the topmost layer - sees the same answer.
-    const bool only_one_wall_top = this->config->only_one_wall_top && has_top_shell_layers(*this->config);
+    // ORCA: neither one-wall option has a surface to act on without the shell behind it, see
+    // has_top_shell_layers() / has_bottom_shell_layers(). Gated here so every use below - including the
+    // topmost and first layers - sees the same answer.
+    const bool only_one_wall_top         = this->config->only_one_wall_top && has_top_shell_layers(*this->config);
+    const bool only_one_wall_first_layer = this->config->only_one_wall_first_layer && has_bottom_shell_layers(*this->config);
     for (size_t order_idx = 0; order_idx < surface_order.size(); order_idx++) {
         const Surface &surface = all_surfaces[surface_order[order_idx]];
         // detect how many perimeters must be generated for this island
@@ -1381,7 +1392,7 @@ void PerimeterGenerator::process_classic()
         int sparse_infill_density = this->config->sparse_infill_density.value;
         if (this->config->alternate_extra_wall && this->layer_id % 2 == 1 && !m_spiral_vase && sparse_infill_density > 0) // add alternating extra wall
             loop_number++;
-        if (this->layer_id == object_config->raft_layers && this->config->only_one_wall_first_layer)
+        if (this->layer_id == object_config->raft_layers && only_one_wall_first_layer)
             loop_number = 0;
         // Set the topmost layer to be one wall
         if (loop_number > 0 && only_one_wall_top && this->upper_slices == nullptr)
@@ -2347,9 +2358,11 @@ void PerimeterGenerator::process_arachne()
     process_no_bridge(all_surfaces, perimeter_spacing, ext_perimeter_width);
     // BBS: don't simplify too much which influence arc fitting when export gcode if arc_fitting is enabled
     double surface_simplify_resolution = (print_config->enable_arc_fitting && !this->has_fuzzy_skin) ? 0.2 * m_scaled_resolution : m_scaled_resolution;
-    // ORCA: only_one_wall_top has no top surface to act on without a top shell, see has_top_shell_layers().
-    // Gated here so every use below - including the topmost layer - sees the same answer.
-    const bool only_one_wall_top = this->config->only_one_wall_top && has_top_shell_layers(*this->config);
+    // ORCA: neither one-wall option has a surface to act on without the shell behind it, see
+    // has_top_shell_layers() / has_bottom_shell_layers(). Gated here so every use below - including the
+    // topmost and first layers - sees the same answer.
+    const bool only_one_wall_top         = this->config->only_one_wall_top && has_top_shell_layers(*this->config);
+    const bool only_one_wall_first_layer = this->config->only_one_wall_first_layer && has_bottom_shell_layers(*this->config);
     // we need to process each island separately because we might have different
     // extra perimeters for each one
     for (const Surface& surface : all_surfaces) {
@@ -2362,7 +2375,7 @@ void PerimeterGenerator::process_arachne()
 
         // Set the bottommost layer to be one wall
         const bool is_bottom_layer = (this->layer_id == object_config->raft_layers) ? true : false;
-        if (is_bottom_layer && this->config->only_one_wall_first_layer)
+        if (is_bottom_layer && only_one_wall_first_layer)
             loop_number = 0;
 
         // Orca: set the topmost layer to be one wall according to the config

--- a/src/libslic3r/PerimeterGenerator.cpp
+++ b/src/libslic3r/PerimeterGenerator.cpp
@@ -585,23 +585,30 @@ static ExPolygons fill_enclosed_top_feature_holes(const ExPolygons &top, const P
 }
 
 // ORCA: only_one_wall_top keeps a single wall on top surfaces. The walls are generated from the real geometry
-// (as when the feature is off) and the inner walls that fall over the top surface are then dropped, so no wall
-// is ever invented along the top/non-top boundary. A loop is dropped as soon as any vertex lands on the top.
-static bool loop_kept_for_one_wall_top(const Points &pts, const ExPolygons &top_region)
+// (as when the feature is off) and the parts that fall over the top surface are then removed, so no wall is
+// ever invented along the top/non-top boundary. A wall counts as touching the top as soon as one of its
+// vertices lands on it (a segment crossing the top with no vertex inside is rare enough to ignore).
+static bool loop_kept_for_one_wall_top(const Points &pts, const ExPolygons &top_region, const BoundingBox &top_region_bbox)
 {
-    for (const Point &p : pts)
+    for (const Point &p : pts) {
+        if (! top_region_bbox.contains(p))
+            continue;
         for (const ExPolygon &ex : top_region)
             if (ex.contains(p, false))
                 return false;
+    }
     return true;
 }
 
-static bool loop_kept_for_one_wall_top(const Arachne::ExtrusionLine &el, const ExPolygons &top_region)
+static bool loop_kept_for_one_wall_top(const Arachne::ExtrusionLine &el, const ExPolygons &top_region, const BoundingBox &top_region_bbox)
 {
-    for (const Arachne::ExtrusionJunction &j : el.junctions)
+    for (const Arachne::ExtrusionJunction &j : el.junctions) {
+        if (! top_region_bbox.contains(j.p))
+            continue;
         for (const ExPolygon &ex : top_region)
             if (ex.contains(j.p, false))
                 return false;
+    }
     return true;
 }
 
@@ -1275,6 +1282,9 @@ void PerimeterGenerator::process_classic()
         // ORCA: only_one_wall_top - the top-surface region to keep clear of inner walls, applied in one post-onion
         // reduction step (see below). Empty / false unless this island has a top surface on this layer.
         ExPolygons one_wall_top_region;
+        // ORCA: only_one_wall_top - footprint of the dropped walls that the top fill does not cover; handed over
+        // to the infill so a wall that merely grazed the top does not leave a void where it used to be.
+        ExPolygons one_wall_top_reclaimed;
         bool       apply_one_wall_top = false;
         if (loop_number >= 0) {
             // In case no perimeters are to be generated, loop_number will equal to -1.
@@ -1434,9 +1444,19 @@ void PerimeterGenerator::process_classic()
             // ORCA: only_one_wall_top reduction - drop the inner walls (depth > 0) that fall over the top surface
             // and take that space back from the gaps, leaving the top with just the outer wall and top infill.
             if (apply_one_wall_top) {
+                const BoundingBox top_region_bbox = get_extents(one_wall_top_region).inflated(SCALED_EPSILON);
+                Polygons dropped_wall_bands;
                 auto drop_over_top = [&](PerimeterGeneratorLoops &loops) {
                     loops.erase(std::remove_if(loops.begin(), loops.end(), [&](const PerimeterGeneratorLoop &loop) {
-                        return !loop_kept_for_one_wall_top(loop.polygon.points, one_wall_top_region);
+                        if (loop_kept_for_one_wall_top(loop.polygon.points, one_wall_top_region, top_region_bbox))
+                            return false;
+                        // Remember the band this wall would have covered; whatever ends up outside the top fill
+                        // must be filled by infill instead of being left as a void.
+                        Polygon centerline = loop.polygon;
+                        centerline.make_counter_clockwise();
+                        append(dropped_wall_bands, diff(offset(centerline, float(perimeter_spacing) / 2.f),
+                                                        offset(centerline, -float(perimeter_spacing) / 2.f)));
+                        return true;
                     }), loops.end());
                 };
                 for (int d = 1; d <= loop_number; ++ d) {
@@ -1445,6 +1465,8 @@ void PerimeterGenerator::process_classic()
                 }
                 if (! gaps.empty())
                     gaps = diff_ex(gaps, one_wall_top_region);
+                if (! dropped_wall_bands.empty())
+                    one_wall_top_reclaimed = diff_ex(dropped_wall_bands, one_wall_top_region);
             }
 
             // nest loops: holes first
@@ -1681,7 +1703,10 @@ void PerimeterGenerator::process_classic()
                     and use zigzag).  */
                 //FIXME Vojtech: This grows by a rounded extrusion width, not by line spacing,
                 // therefore it may cover the area, but no the volume.
-                last = diff_ex(last, gap_fill.polygons_covered_by_width(10.f));
+                Polygons gap_fill_covered = gap_fill.polygons_covered_by_width(10.f);
+                last = diff_ex(last, gap_fill_covered);
+                if (! one_wall_top_reclaimed.empty())
+                    one_wall_top_reclaimed = diff_ex(one_wall_top_reclaimed, gap_fill_covered);
                 this->gap_fill->append(std::move(gap_fill.entities));
 
 			}
@@ -1729,6 +1754,9 @@ void PerimeterGenerator::process_classic()
         if (!top_fills.empty()) {
             infill_exp = union_ex(infill_exp, offset_ex(top_infill_exp, double(top_infill_peri_overlap)));
         }
+        // ORCA: only_one_wall_top - the space of the dropped walls that the top fill does not cover goes to infill.
+        if (!one_wall_top_reclaimed.empty())
+            infill_exp = union_ex(infill_exp, one_wall_top_reclaimed);
         this->fill_surfaces->append(infill_exp, stInternal);
 
         apply_extra_perimeters(infill_exp);
@@ -1747,6 +1775,8 @@ void PerimeterGenerator::process_classic()
                     double(-inset - infill_peri_overlap));
             if (!top_fills.empty())
                 polyWithoutOverlap = union_ex(polyWithoutOverlap, top_infill_exp);
+            if (!one_wall_top_reclaimed.empty())
+                polyWithoutOverlap = union_ex(polyWithoutOverlap, one_wall_top_reclaimed);
             this->fill_no_overlap->insert(this->fill_no_overlap->end(), polyWithoutOverlap.begin(), polyWithoutOverlap.end());
         }
 
@@ -2281,23 +2311,56 @@ void PerimeterGenerator::process_arachne()
                 top_expolygons = intersection_ex(top_expolygons, infill_contour);
 
                 // ORCA: onion the real region (inside the outer wall) for the remaining walls so they follow the
-                // actual geometry, then drop the ones that fall over the top surface. This replaces re-onioning the
+                // actual geometry, then remove the parts that fall over the top surface. This replaces re-onioning the
                 // non-top complement, which walled the top/non-top interface and ringed top-surface islands (e.g. a
                 // recess floor) with inner walls that don't exist when the feature is disabled.
                 const Polygons inner_region = to_polygons(offset_ex(infill_contour, wall_0_inset));
                 Arachne::WallToolPaths inner_wall_tool_paths(inner_region, perimeter_spacing, perimeter_spacing, coord_t(inner_loop_number + 1), 0, layer_height, input_params_tmp);
                 std::vector<Arachne::VariableWidthLines> inner_perimeters = inner_wall_tool_paths.getToolPaths();
 
-                for (Arachne::VariableWidthLines &inner_perimeter : inner_perimeters) {
-                    inner_perimeter.erase(std::remove_if(inner_perimeter.begin(), inner_perimeter.end(),
-                                              [&top_expolygons](const Arachne::ExtrusionLine &el) {
-                                                  return el.empty() || !loop_kept_for_one_wall_top(el, top_expolygons);
-                                              }),
-                                          inner_perimeter.end());
-                    // These are inner walls, so their inset index comes after the single outer wall.
-                    for (Arachne::ExtrusionLine &el : inner_perimeter)
-                        ++el.inset_idx;
+                // Walls that merely graze the top surface are clipped against it rather than dropped whole, so the
+                // geometry that continues upward keeps its walls; only the pieces over the top disappear.
+                const BoundingBox top_region_bbox = get_extents(top_expolygons).inflated(SCALED_EPSILON);
+                ClipperLib_Z::Paths top_paths_z;
+                for (const Polygon &poly : to_polygons(top_expolygons)) {
+                    top_paths_z.emplace_back();
+                    ClipperLib_Z::Path &out = top_paths_z.back();
+                    out.reserve(poly.points.size());
+                    for (const Point &pt : poly.points)
+                        out.emplace_back(pt.x(), pt.y(), 0);
                 }
+                for (Arachne::VariableWidthLines &inner_perimeter : inner_perimeters) {
+                    Arachne::VariableWidthLines kept;
+                    kept.reserve(inner_perimeter.size());
+                    for (Arachne::ExtrusionLine &el : inner_perimeter) {
+                        if (el.empty())
+                            continue;
+                        if (loop_kept_for_one_wall_top(el, top_expolygons, top_region_bbox)) {
+                            kept.emplace_back(std::move(el));
+                            continue;
+                        }
+                        ClipperLib_Z::Path subject;
+                        subject.reserve(el.size());
+                        for (const Arachne::ExtrusionJunction &j : el.junctions)
+                            subject.emplace_back(j.p.x(), j.p.y(), j.w);
+                        for (const ClipperLib_Z::Path &path : clip_extrusion(subject, top_paths_z, ClipperLib_Z::ctDifference)) {
+                            Arachne::ExtrusionLine clipped(el.inset_idx, el.is_odd);
+                            clipped.junctions.reserve(path.size());
+                            for (const ClipperLib_Z::IntPoint &pt : path)
+                                clipped.junctions.emplace_back(Point(pt.x(), pt.y()), coord_t(pt.z()), el.inset_idx);
+                            // Discard tiny leftovers that would print as zits.
+                            if (clipped.size() >= 2 && clipped.getLength() >= perimeter_width)
+                                kept.emplace_back(std::move(clipped));
+                        }
+                    }
+                    inner_perimeter = std::move(kept);
+                }
+
+                // Recalculate indexes of inner perimeters before merging them: they come after the single outer wall.
+                if (!perimeters.empty())
+                    for (Arachne::VariableWidthLines &inner_perimeter : inner_perimeters)
+                        for (Arachne::ExtrusionLine &el : inner_perimeter)
+                            ++el.inset_idx;
 
                 perimeters.insert(perimeters.end(), inner_perimeters.begin(), inner_perimeters.end());
                 infill_contour = union_ex(top_expolygons, inner_wall_tool_paths.getInnerContour());

--- a/src/libslic3r/PerimeterGenerator.cpp
+++ b/src/libslic3r/PerimeterGenerator.cpp
@@ -2294,7 +2294,6 @@ void PerimeterGenerator::process_arachne()
                 upper_slices_clipped = ClipperUtils::clip_clipper_polygons_with_subject_bbox(*upper_slices, infill_contour_bbox);
 
             top_expolygons = diff_ex(infill_contour, upper_slices_clipped);
-            top_expolygons = fill_enclosed_top_feature_holes(top_expolygons, upper_slices_clipped, infill_contour);
 
             if (!top_expolygons.empty()) {
                 if (lower_slices != nullptr) {

--- a/src/libslic3r/PerimeterGenerator.cpp
+++ b/src/libslic3r/PerimeterGenerator.cpp
@@ -2329,8 +2329,10 @@ void PerimeterGenerator::process_arachne()
                 // Walls that merely graze the top surface are clipped against it rather than dropped whole, so the
                 // geometry that continues upward keeps its walls; only the pieces over the top disappear.
                 const BoundingBox top_region_bbox = get_extents(top_expolygons).inflated(SCALED_EPSILON);
+                // The cut is pulled back by half a wall width: the clip severs the centerline, but the bead's
+                // rounded end extends half a width past its endpoint and would otherwise overlap the top fill.
                 ClipperLib_Z::Paths top_paths_z;
-                for (const Polygon &poly : to_polygons(top_expolygons)) {
+                for (const Polygon &poly : to_polygons(offset_ex(top_expolygons, float(perimeter_width) / 2.f))) {
                     top_paths_z.emplace_back();
                     ClipperLib_Z::Path &out = top_paths_z.back();
                     out.reserve(poly.points.size());
@@ -2378,11 +2380,12 @@ void PerimeterGenerator::process_arachne()
                         }
 
                         // If the clip removed next to nothing (the wall only grazed the expanded top margin),
-                        // keep the loop untouched instead of slitting it open.
+                        // keep the loop untouched instead of slitting it open. The half-width pull-back above
+                        // already costs about one width per crossing, hence the two-width threshold.
                         double kept_length = 0.;
                         for (const ClipperLib_Z::Path &path : pieces)
                             kept_length += clipper_z_path_length(path);
-                        if (clipper_z_path_length(subject) - kept_length < double(perimeter_width)) {
+                        if (clipper_z_path_length(subject) - kept_length < 2. * double(perimeter_width)) {
                             kept.emplace_back(std::move(el));
                             continue;
                         }

--- a/src/libslic3r/PerimeterGenerator.cpp
+++ b/src/libslic3r/PerimeterGenerator.cpp
@@ -580,42 +580,49 @@ static ExtrusionEntityCollection traverse_extrusions(const PerimeterGenerator& p
 }
 
 // ORCA: the reworked only_one_wall_top generates the inner walls from the real geometry and then removes the
-// parts that fall over the top surface, handing that space over to the (expandable) top solid fill. With
-// top_surface_density == 0 there is no top fill to take it over, so the removed walls would simply print as a
-// void. In that case keep the original generation, which re-onions the not-top region and therefore keeps
-// walls right up to the top boundary.
+// parts that fall over the top surface, handing that space over to the (expandable) top solid fill. Without a
+// top fill to take it over the removed walls would simply print as a void, so in that case keep the original
+// generation, which re-onions the not-top region and therefore keeps walls right up to the top boundary. There
+// is no top fill either when the top surface density is 0% or when no top shell is requested at all - zero top
+// shell layers retypes every top fill surface as internal (LayerRegion::prepare_fill_surfaces).
 static bool top_fill_replaces_inner_walls(const PrintRegionConfig &config)
 {
-    return config.top_surface_density.value > 0;
+    return config.top_shell_layers.value > 0 && config.top_surface_density.value > 0;
 }
 
 // ORCA: only_one_wall_top keeps a single wall on top surfaces. The walls are generated from the real geometry
 // (as when the feature is off) and the parts that fall over the top surface are then removed, so no wall is
-// ever invented along the top/non-top boundary. This is the cheap first pass: a wall is a candidate for removal
-// as soon as one of its vertices lands on the top (a segment crossing the top with no vertex inside is rare
-// enough to ignore). How much of it is actually removed is decided by the caller.
-static bool loop_kept_for_one_wall_top(const Points &pts, const ExPolygons &top_region, const BoundingBox &top_region_bbox)
+// ever invented along the top/non-top boundary. This is the cheap per-vertex classification both wall
+// generators start from: None and Full are decided here, and only Partial needs the geometry clipped or
+// measured (a segment crossing the top with no vertex inside is rare enough to ignore).
+enum class TopOverlap { None, Partial, Full };
+
+static bool point_over_top(const Point &p, const ExPolygons &top_region, const BoundingBox &top_region_bbox)
 {
-    for (const Point &p : pts) {
-        if (! top_region_bbox.contains(p))
-            continue;
-        for (const ExPolygon &ex : top_region)
-            if (ex.contains(p, false))
-                return false;
-    }
-    return true;
+    if (! top_region_bbox.contains(p))
+        return false;
+    for (const ExPolygon &ex : top_region)
+        if (ex.contains(p, false))
+            return true;
+    return false;
 }
 
-static bool loop_kept_for_one_wall_top(const Arachne::ExtrusionLine &el, const ExPolygons &top_region, const BoundingBox &top_region_bbox)
+static TopOverlap classify_over_top(const Points &pts, const ExPolygons &top_region, const BoundingBox &top_region_bbox)
 {
-    for (const Arachne::ExtrusionJunction &j : el.junctions) {
-        if (! top_region_bbox.contains(j.p))
-            continue;
-        for (const ExPolygon &ex : top_region)
-            if (ex.contains(j.p, false))
-                return false;
-    }
-    return true;
+    size_t inside = 0;
+    for (const Point &p : pts)
+        if (point_over_top(p, top_region, top_region_bbox))
+            ++ inside;
+    return inside == 0 ? TopOverlap::None : inside == pts.size() ? TopOverlap::Full : TopOverlap::Partial;
+}
+
+static TopOverlap classify_over_top(const Arachne::ExtrusionLine &el, const ExPolygons &top_region, const BoundingBox &top_region_bbox)
+{
+    size_t inside = 0;
+    for (const Arachne::ExtrusionJunction &j : el.junctions)
+        if (point_over_top(j.p, top_region, top_region_bbox))
+            ++ inside;
+    return inside == 0 ? TopOverlap::None : inside == el.junctions.size() ? TopOverlap::Full : TopOverlap::Partial;
 }
 
 // ORCA: only_one_wall_top for Arachne - remove from the already generated inner walls the parts that run over the
@@ -651,10 +658,13 @@ static void clip_inner_walls_over_top(std::vector<Arachne::VariableWidthLines> &
         for (Arachne::ExtrusionLine &el : inner_perimeter) {
             if (el.empty())
                 continue;
-            if (loop_kept_for_one_wall_top(el, top_region, top_region_bbox)) {
+            const TopOverlap overlap = classify_over_top(el, top_region, top_region_bbox);
+            if (overlap == TopOverlap::None) {
                 kept.emplace_back(std::move(el));
                 continue;
             }
+            if (overlap == TopOverlap::Full)
+                continue; // entirely over the top - the clip below would return nothing anyway
             ClipperLib_Z::Path subject;
             subject.reserve(el.size());
             for (const Arachne::ExtrusionJunction &j : el.junctions)
@@ -1566,9 +1576,12 @@ void PerimeterGenerator::process_classic()
                 Polygons dropped_wall_bands;
                 auto reduce_over_top = [&](PerimeterGeneratorLoops &loops) {
                     loops.erase(std::remove_if(loops.begin(), loops.end(), [&](const PerimeterGeneratorLoop &loop) {
-                        if (loop_kept_for_one_wall_top(loop.polygon.points, one_wall_top_region, top_region_bbox))
+                        const TopOverlap overlap = classify_over_top(loop.polygon.points, one_wall_top_region, top_region_bbox);
+                        if (overlap == TopOverlap::None)
                             return false;
-                        if (total_length(intersection_pl(Polylines{ loop.polygon.split_at_first_point() }, one_wall_top_region)) < grazing_tolerance) {
+                        // Only a wall straddling the boundary is worth measuring; one lying wholly over the top goes.
+                        if (overlap == TopOverlap::Partial &&
+                            total_length(intersection_pl(Polylines{ loop.polygon.split_at_first_point() }, one_wall_top_region)) < grazing_tolerance) {
                             append(one_wall_top_kept_bands, wall_band(loop.polygon));
                             return false;
                         }

--- a/src/libslic3r/PerimeterGenerator.cpp
+++ b/src/libslic3r/PerimeterGenerator.cpp
@@ -582,9 +582,11 @@ static ExtrusionEntityCollection traverse_extrusions(const PerimeterGenerator& p
 // ORCA: only_one_wall_top removes the inner walls over a top surface and lets the top fill take their space.
 // Without a top fill they would print as a void, so fall back to the original generation (re-onion the not-top
 // region). Zero top shell layers retypes the top fill as internal, see LayerRegion::prepare_fill_surfaces().
+// The top fill only reaches the freed space when top_surface_expansion grows it there, so without expansion the
+// original generation is kept as well - it is what users of only_one_wall_top alone have always got.
 static bool top_fill_replaces_inner_walls(const PrintRegionConfig &config)
 {
-    return config.top_shell_layers.value > 0 && config.top_surface_density.value > 0;
+    return config.top_shell_layers.value > 0 && config.top_surface_density.value > 0 && config.top_surface_expansion.value > 0;
 }
 
 // ORCA: only_one_wall_top - cheap per-vertex classification of a wall against the top surface. Only Partial

--- a/src/libslic3r/PerimeterGenerator.cpp
+++ b/src/libslic3r/PerimeterGenerator.cpp
@@ -579,6 +579,16 @@ static ExtrusionEntityCollection traverse_extrusions(const PerimeterGenerator& p
     return extrusion_coll;
 }
 
+// ORCA: the reworked only_one_wall_top generates the inner walls from the real geometry and then removes the
+// parts that fall over the top surface, handing that space over to the (expandable) top solid fill. With
+// top_surface_density == 0 there is no top fill to take it over, so the removed walls would simply print as a
+// void. In that case keep the original generation, which re-onions the not-top region and therefore keeps
+// walls right up to the top boundary.
+static bool top_fill_replaces_inner_walls(const PrintRegionConfig &config)
+{
+    return config.top_surface_density.value > 0;
+}
+
 // ORCA: only_one_wall_top detects the top as "slice − upper", so a feature rising from the middle of a
 // top surface becomes an enclosed hole. Fill those holes back into the top so the top surface stays solid
 // (avoids leaving thin, unfillable slivers once the inner perimeters are removed). Only holes that are both
@@ -618,6 +628,87 @@ static bool loop_kept_for_one_wall_top(const Arachne::ExtrusionLine &el, const E
                 return false;
     }
     return true;
+}
+
+// ORCA: only_one_wall_top for Arachne - remove from the already generated inner walls the parts that run over the
+// top surface. Walls that merely graze the top are clipped rather than dropped whole, so the geometry that continues
+// upward keeps its walls; only the pieces over the top disappear.
+static void clip_inner_walls_over_top(std::vector<Arachne::VariableWidthLines> &inner_perimeters, const ExPolygons &top_region, coord_t perimeter_width)
+{
+    const BoundingBox top_region_bbox = get_extents(top_region).inflated(SCALED_EPSILON);
+    // The cut is pulled back by half a wall width: the clip severs the centerline, but the bead's
+    // rounded end extends half a width past its endpoint and would otherwise overlap the top fill.
+    ClipperLib_Z::Paths top_paths_z;
+    for (const Polygon &poly : to_polygons(offset_ex(top_region, float(perimeter_width) / 2.f))) {
+        top_paths_z.emplace_back();
+        ClipperLib_Z::Path &out = top_paths_z.back();
+        out.reserve(poly.points.size());
+        for (const Point &pt : poly.points)
+            out.emplace_back(pt.x(), pt.y(), 0);
+    }
+    for (Arachne::VariableWidthLines &inner_perimeter : inner_perimeters) {
+        Arachne::VariableWidthLines kept;
+        kept.reserve(inner_perimeter.size());
+        for (Arachne::ExtrusionLine &el : inner_perimeter) {
+            if (el.empty())
+                continue;
+            if (loop_kept_for_one_wall_top(el, top_region, top_region_bbox)) {
+                kept.emplace_back(std::move(el));
+                continue;
+            }
+            ClipperLib_Z::Path subject;
+            subject.reserve(el.size());
+            for (const Arachne::ExtrusionJunction &j : el.junctions)
+                subject.emplace_back(j.p.x(), j.p.y(), j.w);
+            ClipperLib_Z::Paths pieces = clip_extrusion(subject, top_paths_z, ClipperLib_Z::ctDifference);
+
+            // Clipper treats the subject as an open polyline: it also cuts a closed loop at its
+            // (arbitrary) start vertex and may reverse pieces. Stitch pieces that share an endpoint
+            // back together so the wall is only divided where it actually crosses the top surface.
+            auto same_pt = [](const ClipperLib_Z::IntPoint &p, const ClipperLib_Z::IntPoint &q) {
+                return std::abs(p.x() - q.x()) <= SCALED_EPSILON && std::abs(p.y() - q.y()) <= SCALED_EPSILON;
+            };
+            for (size_t i = 0; i < pieces.size(); ++ i) {
+                for (size_t j = i + 1; j < pieces.size();) {
+                    ClipperLib_Z::Path &a = pieces[i];
+                    ClipperLib_Z::Path &b = pieces[j];
+                    if (same_pt(a.front(), b.front()) || same_pt(a.front(), b.back()))
+                        std::reverse(a.begin(), a.end());
+                    if (same_pt(a.back(), b.back()))
+                        std::reverse(b.begin(), b.end());
+                    if (same_pt(a.back(), b.front())) {
+                        a.insert(a.end(), b.begin() + 1, b.end());
+                        pieces.erase(pieces.begin() + j);
+                        // Restart the scan: the merged path has new endpoints.
+                        j = i + 1;
+                    } else
+                        ++ j;
+                }
+            }
+
+            // If the clip removed next to nothing (the wall only grazed the expanded top margin),
+            // keep the loop untouched instead of slitting it open. The half-width pull-back above
+            // already costs about one width per crossing, hence the two-width threshold.
+            double kept_length = 0.;
+            for (const ClipperLib_Z::Path &path : pieces)
+                kept_length += clipper_z_path_length(path);
+            if (clipper_z_path_length(subject) - kept_length < 2. * double(perimeter_width)) {
+                kept.emplace_back(std::move(el));
+                continue;
+            }
+
+            for (const ClipperLib_Z::Path &path : pieces) {
+                Arachne::ExtrusionLine clipped(el.inset_idx, el.is_odd);
+                clipped.junctions.reserve(path.size());
+                for (const ClipperLib_Z::IntPoint &pt : path)
+                    clipped.junctions.emplace_back(Point(pt.x(), pt.y()), coord_t(pt.z()), el.inset_idx);
+                // Discard tiny leftovers that would print as zits.
+                if (clipped.size() >= 2 && clipped.getLength() >= perimeter_width)
+                    kept.emplace_back(std::move(clipped));
+            }
+        }
+        inner_perimeter = std::move(kept);
+    }
 }
 
 void PerimeterGenerator::split_top_surfaces(const ExPolygons &orig_polygons, ExPolygons &top_fills,
@@ -685,7 +776,8 @@ void PerimeterGenerator::split_top_surfaces(const ExPolygons &orig_polygons, ExP
     ExPolygons delete_bridge = diff_ex(orig_polygons, bridge_checker, ApplySafetyOffset::Yes);
 
     ExPolygons top_polygons = diff_ex(delete_bridge, upper_polygons_series_clipped, ApplySafetyOffset::Yes);
-    top_polygons = fill_enclosed_top_feature_holes(top_polygons, upper_polygons_series_clipped, orig_polygons);
+    if (top_fill_replaces_inner_walls(*this->config))
+        top_polygons = fill_enclosed_top_feature_holes(top_polygons, upper_polygons_series_clipped, orig_polygons);
 
     // get the not-top surface, from the "real top" but enlarged by external_infill_margin (and the
     // min_width_top_surface we removed a bit before)
@@ -1433,13 +1525,19 @@ void PerimeterGenerator::process_classic()
                 //BBS: refer to superslicer
                 //store surface for top infill if only_one_wall_top
                 if (i == 0 && i!=loop_number && config->only_one_wall_top && !surface.is_bridge() && this->upper_slices != NULL) {
-                    // ORCA: only_one_wall_top - compute the top fill and the top keep-out region, but leave `last`
-                    // as the real geometry; the walls/gaps over the top are reduced in one post-onion step below.
-                    ExPolygons non_top_polygons;
-                    this->split_top_surfaces(last, top_fills, non_top_polygons, fill_clip);
-                    apply_one_wall_top = !top_fills.empty();
-                    if (apply_one_wall_top)
-                        one_wall_top_region = diff_ex(last, non_top_polygons);
+                    if (top_fill_replaces_inner_walls(*this->config)) {
+                        // ORCA: only_one_wall_top - compute the top fill and the top keep-out region, but leave `last`
+                        // as the real geometry; the walls/gaps over the top are reduced in one post-onion step below.
+                        ExPolygons non_top_polygons;
+                        this->split_top_surfaces(last, top_fills, non_top_polygons, fill_clip);
+                        apply_one_wall_top = !top_fills.empty();
+                        if (apply_one_wall_top)
+                            one_wall_top_region = diff_ex(last, non_top_polygons);
+                    } else {
+                        // Reduce `last` to the not-top region, so the remaining walls are onioned from it and
+                        // stop at the top boundary.
+                        this->split_top_surfaces(last, top_fills, last, fill_clip);
+                    }
                 }
 
                 if (i == loop_number && (! has_gap_fill || this->config->sparse_infill_density.value == 0)) {
@@ -2320,87 +2418,18 @@ void PerimeterGenerator::process_arachne()
                 // ORCA: onion the real region (inside the outer wall) for the remaining walls so they follow the
                 // actual geometry, then remove the parts that fall over the top surface. This replaces re-onioning the
                 // non-top complement, which walled the top/non-top interface and ringed top-surface islands (e.g. a
-                // recess floor) with inner walls that don't exist when the feature is disabled.
-                const Polygons inner_region = to_polygons(offset_ex(infill_contour, wall_0_inset));
+                // recess floor) with inner walls that don't exist when the feature is disabled. Without a top fill to
+                // take over the freed space the original complement onioning is used instead - see
+                // top_fill_replaces_inner_walls().
+                const bool     clip_walls_over_top = top_fill_replaces_inner_walls(*this->config);
+                const Polygons inner_region        = to_polygons(offset_ex(clip_walls_over_top ? infill_contour
+                                                                                               : diff_ex(infill_contour, top_expolygons),
+                                                                          wall_0_inset));
                 Arachne::WallToolPaths inner_wall_tool_paths(inner_region, perimeter_spacing, perimeter_spacing, coord_t(inner_loop_number + 1), 0, layer_height, input_params_tmp);
                 std::vector<Arachne::VariableWidthLines> inner_perimeters = inner_wall_tool_paths.getToolPaths();
 
-                // Walls that merely graze the top surface are clipped against it rather than dropped whole, so the
-                // geometry that continues upward keeps its walls; only the pieces over the top disappear.
-                const BoundingBox top_region_bbox = get_extents(top_expolygons).inflated(SCALED_EPSILON);
-                // The cut is pulled back by half a wall width: the clip severs the centerline, but the bead's
-                // rounded end extends half a width past its endpoint and would otherwise overlap the top fill.
-                ClipperLib_Z::Paths top_paths_z;
-                for (const Polygon &poly : to_polygons(offset_ex(top_expolygons, float(perimeter_width) / 2.f))) {
-                    top_paths_z.emplace_back();
-                    ClipperLib_Z::Path &out = top_paths_z.back();
-                    out.reserve(poly.points.size());
-                    for (const Point &pt : poly.points)
-                        out.emplace_back(pt.x(), pt.y(), 0);
-                }
-                for (Arachne::VariableWidthLines &inner_perimeter : inner_perimeters) {
-                    Arachne::VariableWidthLines kept;
-                    kept.reserve(inner_perimeter.size());
-                    for (Arachne::ExtrusionLine &el : inner_perimeter) {
-                        if (el.empty())
-                            continue;
-                        if (loop_kept_for_one_wall_top(el, top_expolygons, top_region_bbox)) {
-                            kept.emplace_back(std::move(el));
-                            continue;
-                        }
-                        ClipperLib_Z::Path subject;
-                        subject.reserve(el.size());
-                        for (const Arachne::ExtrusionJunction &j : el.junctions)
-                            subject.emplace_back(j.p.x(), j.p.y(), j.w);
-                        ClipperLib_Z::Paths pieces = clip_extrusion(subject, top_paths_z, ClipperLib_Z::ctDifference);
-
-                        // Clipper treats the subject as an open polyline: it also cuts a closed loop at its
-                        // (arbitrary) start vertex and may reverse pieces. Stitch pieces that share an endpoint
-                        // back together so the wall is only divided where it actually crosses the top surface.
-                        auto same_pt = [](const ClipperLib_Z::IntPoint &p, const ClipperLib_Z::IntPoint &q) {
-                            return std::abs(p.x() - q.x()) <= SCALED_EPSILON && std::abs(p.y() - q.y()) <= SCALED_EPSILON;
-                        };
-                        for (size_t i = 0; i < pieces.size(); ++ i) {
-                            for (size_t j = i + 1; j < pieces.size();) {
-                                ClipperLib_Z::Path &a = pieces[i];
-                                ClipperLib_Z::Path &b = pieces[j];
-                                if (same_pt(a.front(), b.front()) || same_pt(a.front(), b.back()))
-                                    std::reverse(a.begin(), a.end());
-                                if (same_pt(a.back(), b.back()))
-                                    std::reverse(b.begin(), b.end());
-                                if (same_pt(a.back(), b.front())) {
-                                    a.insert(a.end(), b.begin() + 1, b.end());
-                                    pieces.erase(pieces.begin() + j);
-                                    // Restart the scan: the merged path has new endpoints.
-                                    j = i + 1;
-                                } else
-                                    ++ j;
-                            }
-                        }
-
-                        // If the clip removed next to nothing (the wall only grazed the expanded top margin),
-                        // keep the loop untouched instead of slitting it open. The half-width pull-back above
-                        // already costs about one width per crossing, hence the two-width threshold.
-                        double kept_length = 0.;
-                        for (const ClipperLib_Z::Path &path : pieces)
-                            kept_length += clipper_z_path_length(path);
-                        if (clipper_z_path_length(subject) - kept_length < 2. * double(perimeter_width)) {
-                            kept.emplace_back(std::move(el));
-                            continue;
-                        }
-
-                        for (const ClipperLib_Z::Path &path : pieces) {
-                            Arachne::ExtrusionLine clipped(el.inset_idx, el.is_odd);
-                            clipped.junctions.reserve(path.size());
-                            for (const ClipperLib_Z::IntPoint &pt : path)
-                                clipped.junctions.emplace_back(Point(pt.x(), pt.y()), coord_t(pt.z()), el.inset_idx);
-                            // Discard tiny leftovers that would print as zits.
-                            if (clipped.size() >= 2 && clipped.getLength() >= perimeter_width)
-                                kept.emplace_back(std::move(clipped));
-                        }
-                    }
-                    inner_perimeter = std::move(kept);
-                }
+                if (clip_walls_over_top)
+                    clip_inner_walls_over_top(inner_perimeters, top_expolygons, perimeter_width);
 
                 // Recalculate indexes of inner perimeters before merging them: they come after the single outer wall.
                 if (!perimeters.empty())

--- a/src/libslic3r/PerimeterGenerator.cpp
+++ b/src/libslic3r/PerimeterGenerator.cpp
@@ -572,9 +572,9 @@ static ExtrusionEntityCollection traverse_extrusions(const PerimeterGenerator& p
 }
 
 // ORCA: only_one_wall_top detects the top as "slice − upper", so a feature rising from the middle of a
-// top surface becomes an enclosed hole that gets ringed with extra inner walls. Fill those holes back
-// into the top. Only holes that are both covered by the upper layer (excludes bridges) and backed by
-// solid material (excludes voids) are filled.
+// top surface becomes an enclosed hole. Fill those holes back into the top so the top surface stays solid
+// (avoids leaving thin, unfillable slivers once the inner perimeters are removed). Only holes that are both
+// covered by the upper layer (excludes bridges) and backed by solid material (excludes voids) are filled.
 static ExPolygons fill_enclosed_top_feature_holes(const ExPolygons &top, const Polygons &covered_by_upper, const ExPolygons &solid)
 {
     ExPolygons filled = top;
@@ -582,6 +582,27 @@ static ExPolygons fill_enclosed_top_feature_holes(const ExPolygons &top, const P
         ex.holes.clear();
     const ExPolygons feature_holes = intersection_ex(intersection_ex(diff_ex(filled, top), covered_by_upper), solid);
     return feature_holes.empty() ? top : union_ex(top, feature_holes);
+}
+
+// ORCA: only_one_wall_top keeps a single wall on top surfaces. The walls are generated from the real geometry
+// (as when the feature is off) and the inner walls that fall over the top surface are then dropped, so no wall
+// is ever invented along the top/non-top boundary. A loop is dropped as soon as any vertex lands on the top.
+static bool loop_kept_for_one_wall_top(const Points &pts, const ExPolygons &top_region)
+{
+    for (const Point &p : pts)
+        for (const ExPolygon &ex : top_region)
+            if (ex.contains(p, false))
+                return false;
+    return true;
+}
+
+static bool loop_kept_for_one_wall_top(const Arachne::ExtrusionLine &el, const ExPolygons &top_region)
+{
+    for (const Arachne::ExtrusionJunction &j : el.junctions)
+        for (const ExPolygon &ex : top_region)
+            if (ex.contains(j.p, false))
+                return false;
+    return true;
 }
 
 void PerimeterGenerator::split_top_surfaces(const ExPolygons &orig_polygons, ExPolygons &top_fills,
@@ -1251,6 +1272,10 @@ void PerimeterGenerator::process_classic()
         ExPolygons gaps;
         ExPolygons top_fills;
         ExPolygons fill_clip;
+        // ORCA: only_one_wall_top - the top-surface region to keep clear of inner walls, applied in one post-onion
+        // reduction step (see below). Empty / false unless this island has a top surface on this layer.
+        ExPolygons one_wall_top_region;
+        bool       apply_one_wall_top = false;
         if (loop_number >= 0) {
             // In case no perimeters are to be generated, loop_number will equal to -1.
             std::vector<PerimeterGeneratorLoops> contours(loop_number+1);    // depth => loops
@@ -1390,7 +1415,13 @@ void PerimeterGenerator::process_classic()
                 //BBS: refer to superslicer
                 //store surface for top infill if only_one_wall_top
                 if (i == 0 && i!=loop_number && config->only_one_wall_top && !surface.is_bridge() && this->upper_slices != NULL) {
-                    this->split_top_surfaces(last, top_fills, last, fill_clip);
+                    // ORCA: only_one_wall_top - compute the top fill and the top keep-out region, but leave `last`
+                    // as the real geometry; the walls/gaps over the top are reduced in one post-onion step below.
+                    ExPolygons non_top_polygons;
+                    this->split_top_surfaces(last, top_fills, non_top_polygons, fill_clip);
+                    apply_one_wall_top = !top_fills.empty();
+                    if (apply_one_wall_top)
+                        one_wall_top_region = diff_ex(last, non_top_polygons);
                 }
 
                 if (i == loop_number && (! has_gap_fill || this->config->sparse_infill_density.value == 0)) {
@@ -1398,6 +1429,22 @@ void PerimeterGenerator::process_classic()
                 	// As the gap fill is either disabled or not
                 	break;
                 }
+            }
+
+            // ORCA: only_one_wall_top reduction - drop the inner walls (depth > 0) that fall over the top surface
+            // and take that space back from the gaps, leaving the top with just the outer wall and top infill.
+            if (apply_one_wall_top) {
+                auto drop_over_top = [&](PerimeterGeneratorLoops &loops) {
+                    loops.erase(std::remove_if(loops.begin(), loops.end(), [&](const PerimeterGeneratorLoop &loop) {
+                        return !loop_kept_for_one_wall_top(loop.polygon.points, one_wall_top_region);
+                    }), loops.end());
+                };
+                for (int d = 1; d <= loop_number; ++ d) {
+                    drop_over_top(contours[d]);
+                    drop_over_top(holes[d]);
+                }
+                if (! gaps.empty())
+                    gaps = diff_ex(gaps, one_wall_top_region);
             }
 
             // nest loops: holes first
@@ -2230,24 +2277,26 @@ void PerimeterGenerator::process_arachne()
                 // due to thin lines being generated
                 top_expolygons = offset2_ex(top_expolygons, -top_surface_min_width, top_surface_min_width + float(perimeter_width * 0.85));
 
-                // Get the not-top ExPolygons (including bridges) from current slices and expanded real top ExPolygons (without bridges).
-                const ExPolygons not_top_expolygons = diff_ex(infill_contour, top_expolygons);
-
-                // Get final top ExPolygons.
+                // Get final top ExPolygons (bridges were excluded above, so they stay walled).
                 top_expolygons = intersection_ex(top_expolygons, infill_contour);
 
-                const Polygons not_top_polygons = to_polygons(offset_ex(not_top_expolygons,wall_0_inset));
-                Arachne::WallToolPaths inner_wall_tool_paths(not_top_polygons, perimeter_spacing, perimeter_spacing, coord_t(inner_loop_number + 1), 0, layer_height, input_params_tmp);
+                // ORCA: onion the real region (inside the outer wall) for the remaining walls so they follow the
+                // actual geometry, then drop the ones that fall over the top surface. This replaces re-onioning the
+                // non-top complement, which walled the top/non-top interface and ringed top-surface islands (e.g. a
+                // recess floor) with inner walls that don't exist when the feature is disabled.
+                const Polygons inner_region = to_polygons(offset_ex(infill_contour, wall_0_inset));
+                Arachne::WallToolPaths inner_wall_tool_paths(inner_region, perimeter_spacing, perimeter_spacing, coord_t(inner_loop_number + 1), 0, layer_height, input_params_tmp);
                 std::vector<Arachne::VariableWidthLines> inner_perimeters = inner_wall_tool_paths.getToolPaths();
 
-                // Recalculate indexes of inner perimeters before merging them.
-                if (!perimeters.empty()) {
-                    for (Arachne::VariableWidthLines &inner_perimeter : inner_perimeters) {
-                        if (inner_perimeter.empty())
-                            continue;
-                        for (Arachne::ExtrusionLine &el : inner_perimeter)
-                            ++el.inset_idx;
-                    }
+                for (Arachne::VariableWidthLines &inner_perimeter : inner_perimeters) {
+                    inner_perimeter.erase(std::remove_if(inner_perimeter.begin(), inner_perimeter.end(),
+                                              [&top_expolygons](const Arachne::ExtrusionLine &el) {
+                                                  return el.empty() || !loop_kept_for_one_wall_top(el, top_expolygons);
+                                              }),
+                                          inner_perimeter.end());
+                    // These are inner walls, so their inset index comes after the single outer wall.
+                    for (Arachne::ExtrusionLine &el : inner_perimeter)
+                        ++el.inset_idx;
                 }
 
                 perimeters.insert(perimeters.end(), inner_perimeters.begin(), inner_perimeters.end());

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -1434,8 +1434,9 @@ bool PrintObject::invalidate_state_by_config_options(
                 steps.emplace_back(posPerimeters);
             steps.emplace_back(posPrepareInfill);
         } else if (opt_key == "top_surface_density") {
-            // ORCA: only_one_wall_top only removes the inner walls over a top surface when that top gets a solid
-            // fill to take their place, so switching the top fill on/off changes the perimeters too.
+            // ORCA: a 0% top surface density means no top solid fill at all, which switches off both the top
+            // surface expansion (detect_surfaces_type) and the wall removal over top surfaces (PerimeterGenerator
+            // only_one_wall_top). Only crossing zero matters - posPerimeters cascades to posPrepareInfill.
             const auto *old_density = old_config.option<ConfigOptionPercent>(opt_key);
             const auto *new_density = new_config.option<ConfigOptionPercent>(opt_key);
             assert(old_density && new_density);
@@ -1776,23 +1777,27 @@ void PrintObject::detect_surfaces_type()
                     // clipped to it - growing one island's top across the gap into another island (which may have
                     // no top surface, leaving a partially filled layer) is never allowed. The top infill sits
                     // inside the perimeters, so the margin is measured from the walls: the island is inset by the
-                    // band the walls consume (outer wall + inner walls) plus the configured margin, making that
-                    // value the real clearance between the expanded top and the walls (avoiding a hull line). The
-                    // original top is unioned back in, so where it already sits within that band it is kept as-is.
-                    // Never claims a bottom surface.
-                    const double top_expansion = layerm->region().config().top_surface_expansion.value;
-                    if (top_expansion > 0. && ! top.empty()) {
-                        const double     d        = scale_(top_expansion);
-                        const auto       jt       = Clipper2Lib::JoinType::Miter;
-                        const ExPolygons T        = union_ex(to_expolygons(top));
-                        const int    wall_loops = layerm->region().config().wall_loops.value;
+                    // band the walls consume (outer wall + inner walls) plus the configured margin, which is the
+                    // clearance between the expanded top and the walls over the top surface (avoiding a hull line).
+                    // The original top is unioned back in, so where it already sits within that band it is kept
+                    // as-is. Never claims a bottom surface.
+                    const PrintRegionConfig &region_config  = layerm->region().config();
+                    const double             top_expansion  = region_config.top_surface_expansion.value;
+                    // A top surface density of 0% leaves the top layer with walls only - no fill to expand.
+                    if (top_expansion > 0. && region_config.top_surface_density.value > 0. && ! top.empty()) {
+                        const double     d = scale_(top_expansion);
+                        const ExPolygons T = union_ex(to_expolygons(top));
+                        // Walls are laid out on spacing, not width; and only_one_wall_top leaves a single wall over
+                        // a top surface, which is exactly the situation handled here.
+                        const int    wall_loops = region_config.only_one_wall_top.value ? std::min(region_config.wall_loops.value, 1)
+                                                                                        : region_config.wall_loops.value;
                         const double wall_band  = wall_loops <= 0 ? 0. :
                             double(layerm->flow(frExternalPerimeter).scaled_width()) +
-                            double(layerm->flow(frPerimeter).scaled_width()) * double(wall_loops - 1);
-                        const double margin     = scale_(layerm->region().config().top_surface_expansion_margin.value);
+                            double(layerm->flow(frPerimeter).scaled_spacing()) * double(wall_loops - 1);
+                        const double margin     = scale_(region_config.top_surface_expansion_margin.value);
                         // minimum real top to act on: ignore anything thinner than ~2 top-infill lines
                         const float  min_top    = float(layerm->flow(frTopSolidInfill).scaled_width());
-                        const auto   direction  = layerm->region().config().top_surface_expansion_direction.value;
+                        const auto   direction  = region_config.top_surface_expansion_direction.value;
 
                         ExPolygons grown;
                         for (const ExPolygon &island : union_ex(layerm_slices_surfaces)) {
@@ -1801,8 +1806,12 @@ void PrintObject::detect_surfaces_type()
                             // exposed top lies in the wall band - i.e. a layer where the top is just the walls
                             // themselves - has no infill here and is skipped, instead of being flooded inward by
                             // the expansion. Thin slivers inside the infill region are dropped by the opening too.
+                            // Only this island's share of the layer's tops is relevant, so clip by its bounding box
+                            // first and keep the boolean ops proportional to the island rather than to the layer.
                             const ExPolygons infill_region = wall_band > 0. ? offset_ex(island, -float(wall_band)) : ExPolygons{ island };
-                            const ExPolygons island_top    = intersection_ex(T, infill_region);
+                            const ExPolygons island_top    = intersection_ex(
+                                ClipperUtils::clip_clipper_polygons_with_subject_bbox(T, get_extents(island).inflated(SCALED_EPSILON)),
+                                infill_region);
                             if (opening_ex(island_top, min_top).empty())
                                 continue; // no real top infill in this section - never expand into it
 
@@ -1810,7 +1819,7 @@ void PrintObject::detect_surfaces_type()
                             // the holes/gaps left by features (clip the growth back to the top's own filled outline,
                             // which leaves the outer edge fixed), outward grows the outer edge toward the walls (drop
                             // the growth that fell into the original holes), and inward+outward keeps both.
-                            ExPolygons expanded = offset_ex_2(island_top, d, jt);
+                            ExPolygons expanded = offset_ex_2(island_top, d, Clipper2Lib::JoinType::Miter);
                             if (direction != TopSurfaceExpansionDirection::InwardAndOutward) {
                                 ExPolygons outline; // the top with its holes filled (same outer edge)
                                 outline.reserve(island_top.size());

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -1783,8 +1783,10 @@ void PrintObject::detect_surfaces_type()
                     // as-is. Never claims a bottom surface.
                     const PrintRegionConfig &region_config  = layerm->region().config();
                     const double             top_expansion  = region_config.top_surface_expansion.value;
-                    // A top surface density of 0% leaves the top layer with walls only - no fill to expand.
-                    if (top_expansion > 0. && region_config.top_surface_density.value > 0. && ! top.empty()) {
+                    // Nothing to expand without a top fill: a 0% top surface density leaves the top layer with
+                    // walls only, and zero top shell layers retypes it as internal in prepare_fill_surfaces().
+                    if (top_expansion > 0. && region_config.top_shell_layers.value > 0 &&
+                        region_config.top_surface_density.value > 0. && ! top.empty()) {
                         const double     d = scale_(top_expansion);
                         const ExPolygons T = union_ex(to_expolygons(top));
                         // Walls are laid out on spacing, not width; and only_one_wall_top leaves a single wall over

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -1434,9 +1434,8 @@ bool PrintObject::invalidate_state_by_config_options(
                 steps.emplace_back(posPerimeters);
             steps.emplace_back(posPrepareInfill);
         } else if (opt_key == "top_surface_density") {
-            // ORCA: a 0% top surface density means no top solid fill at all, which switches off both the top
-            // surface expansion (detect_surfaces_type) and the wall removal over top surfaces (PerimeterGenerator
-            // only_one_wall_top). Only crossing zero matters - posPerimeters cascades to posPrepareInfill.
+            // ORCA: 0% means no top solid fill, which switches off both the top surface expansion and the wall
+            // removal over top surfaces. Only crossing zero matters; posPerimeters cascades to posPrepareInfill.
             const auto *old_density = old_config.option<ConfigOptionPercent>(opt_key);
             const auto *new_density = new_config.option<ConfigOptionPercent>(opt_key);
             assert(old_density && new_density);
@@ -1769,18 +1768,12 @@ void PrintObject::detect_surfaces_type()
                         }
                     }
 
-                    // ORCA: Expand the top surfaces outward by top_surface_expansion in every direction. This
-                    // enlarges the top solid infill and, in particular, grows it over the covered material left
-                    // by features rising from the middle of a top surface (filling holes and joining tops so the
-                    // features rest on it). The expansion stays inside the section it belongs to: each connected
-                    // solid island has its own outer wall, so the top is grown within each island separately and
-                    // clipped to it - growing one island's top across the gap into another island (which may have
-                    // no top surface, leaving a partially filled layer) is never allowed. The top infill sits
-                    // inside the perimeters, so the margin is measured from the walls: the island is inset by the
-                    // band the walls consume (outer wall + inner walls) plus the configured margin, which is the
-                    // clearance between the expanded top and the walls over the top surface (avoiding a hull line).
-                    // The original top is unioned back in, so where it already sits within that band it is kept
-                    // as-is. Never claims a bottom surface.
+                    // ORCA: Grow the top surfaces by top_surface_expansion, so the top solid infill also covers the
+                    // material left by features rising from the middle of a top surface (filling the holes and
+                    // joining the tops, so the features rest on solid infill). Each connected island is grown and
+                    // clipped separately: growing one island's top across a gap into another - which may have no top
+                    // surface at all, leaving a partially filled layer - is never allowed. The original top is
+                    // unioned back in and bottom surfaces are never claimed, so this can only add area.
                     const PrintRegionConfig &region_config  = layerm->region().config();
                     const double             top_expansion  = region_config.top_surface_expansion.value;
                     // Nothing to expand without a top fill: a 0% top surface density leaves the top layer with
@@ -1804,12 +1797,9 @@ void PrintObject::detect_surfaces_type()
                         ExPolygons grown;
                         for (const ExPolygon &island : union_ex(layerm_slices_surfaces)) {
                             // The top infill only exists inside the perimeters, so seed and measure from the infill
-                            // region (the island minus the wall band), not the raw slice. A section whose only
-                            // exposed top lies in the wall band - i.e. a layer where the top is just the walls
-                            // themselves - has no infill here and is skipped, instead of being flooded inward by
-                            // the expansion. Thin slivers inside the infill region are dropped by the opening too.
-                            // Only this island's share of the layer's tops is relevant, so clip by its bounding box
-                            // first and keep the boolean ops proportional to the island rather than to the layer.
+                            // region (the island minus the wall band), not the raw slice: a section whose exposed top
+                            // is just the walls themselves is then skipped instead of being flooded inward. Clip the
+                            // layer's tops to the island first, to keep the boolean ops proportional to the island.
                             const ExPolygons infill_region = wall_band > 0. ? offset_ex(island, -float(wall_band)) : ExPolygons{ island };
                             const ExPolygons island_top    = intersection_ex(
                                 ClipperUtils::clip_clipper_polygons_with_subject_bbox(T, get_extents(island).inflated(SCALED_EPSILON)),
@@ -1817,13 +1807,11 @@ void PrintObject::detect_surfaces_type()
                             if (opening_ex(island_top, min_top).empty())
                                 continue; // no real top infill in this section - never expand into it
 
-                            // grow by d, then keep only the part allowed by the configured direction: inward fills
-                            // the holes/gaps left by features (clip the growth back to the top's own filled outline,
-                            // which leaves the outer edge fixed), outward grows the outer edge toward the walls (drop
-                            // the growth that fell into the original holes), and inward+outward keeps both.
+                            // Grow, then keep only what the configured direction allows, using the top's own filled
+                            // outline (same outer edge, holes closed) to tell the two apart.
                             ExPolygons expanded = offset_ex_2(island_top, d, Clipper2Lib::JoinType::Miter);
                             if (direction != TopSurfaceExpansionDirection::InwardAndOutward) {
-                                ExPolygons outline; // the top with its holes filled (same outer edge)
+                                ExPolygons outline;
                                 outline.reserve(island_top.size());
                                 for (const ExPolygon &ex : island_top)
                                     outline.emplace_back(ex.contour);

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -1400,7 +1400,6 @@ bool PrintObject::invalidate_state_by_config_options(
             || opt_key == "infill_anchor"
             || opt_key == "infill_anchor_max"
             || opt_key == "top_surface_line_width"
-            || opt_key == "top_surface_density"
             || opt_key == "bottom_surface_density"
             || opt_key == "center_of_surface_pattern"
             || opt_key == "separated_infills" 
@@ -1434,6 +1433,15 @@ bool PrintObject::invalidate_state_by_config_options(
                 is_approx(new_density->value, 0.) || is_approx(new_density->value, 100.))
                 steps.emplace_back(posPerimeters);
             steps.emplace_back(posPrepareInfill);
+        } else if (opt_key == "top_surface_density") {
+            // ORCA: only_one_wall_top only removes the inner walls over a top surface when that top gets a solid
+            // fill to take their place, so switching the top fill on/off changes the perimeters too.
+            const auto *old_density = old_config.option<ConfigOptionPercent>(opt_key);
+            const auto *new_density = new_config.option<ConfigOptionPercent>(opt_key);
+            assert(old_density && new_density);
+            if (is_approx(old_density->value, 0.) || is_approx(new_density->value, 0.))
+                steps.emplace_back(posPerimeters);
+            steps.emplace_back(posInfill);
         } else if (opt_key == "internal_solid_infill_line_width") {
             // This value is used for calculating perimeter - infill overlap, thus perimeters need to be recalculated.
             steps.emplace_back(posPerimeters);

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -1364,7 +1364,6 @@ bool PrintObject::invalidate_state_by_config_options(
             || opt_key == "infill_combination_max_layer_height"
             || opt_key == "bottom_shell_thickness"
             || opt_key == "top_shell_thickness"
-            || opt_key == "top_surface_expansion"
             || opt_key == "top_surface_expansion_margin"
             || opt_key == "top_surface_expansion_direction"
             || opt_key == "minimum_sparse_infill_area"
@@ -1442,6 +1441,15 @@ bool PrintObject::invalidate_state_by_config_options(
             if (is_approx(old_density->value, 0.) || is_approx(new_density->value, 0.))
                 steps.emplace_back(posPerimeters);
             steps.emplace_back(posInfill);
+        } else if (opt_key == "top_surface_expansion") {
+            // ORCA: without the expansion the top fill never reaches the space freed by only_one_wall_top, so the
+            // walls over top surfaces are kept. Only crossing zero matters; posPerimeters cascades to posPrepareInfill.
+            const auto *old_expansion = old_config.option<ConfigOptionFloat>(opt_key);
+            const auto *new_expansion = new_config.option<ConfigOptionFloat>(opt_key);
+            assert(old_expansion && new_expansion);
+            if (old_expansion->value <= 0. || new_expansion->value <= 0.)
+                steps.emplace_back(posPerimeters);
+            steps.emplace_back(posPrepareInfill);
         } else if (opt_key == "internal_solid_infill_line_width") {
             // This value is used for calculating perimeter - infill overlap, thus perimeters need to be recalculated.
             steps.emplace_back(posPerimeters);

--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -1009,8 +1009,10 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig *config, in
     toggle_line("make_overhang_printable_angle", have_make_overhang_printable);
     toggle_line("make_overhang_printable_hole_size", have_make_overhang_printable);
 
-    toggle_line("only_one_wall_top", has_top_shell);
-    toggle_line("min_width_top_surface", (has_top_shell && config->opt_bool("only_one_wall_top")) || ((config->opt_float("min_length_factor") > 0.5f) && have_arachne)); // 0.5 is default value
+    // Orca: only_one_wall_top acts on top surfaces, which exist only with a top shell. An unfilled top surface
+    // (0% top surface density) is still a top surface, so this is gated on the layer count alone.
+    toggle_line("only_one_wall_top", has_top_shell_layers);
+    toggle_line("min_width_top_surface", (has_top_shell_layers && config->opt_bool("only_one_wall_top")) || ((config->opt_float("min_length_factor") > 0.5f) && have_arachne)); // 0.5 is default value
 
     for (auto el : { "hole_to_polyhole_threshold", "hole_to_polyhole_twisted", "hole_to_polyhole_max_edges" })
         toggle_line(el, config->opt_bool("hole_to_polyhole"));

--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -1009,8 +1009,9 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig *config, in
     toggle_line("make_overhang_printable_angle", have_make_overhang_printable);
     toggle_line("make_overhang_printable_hole_size", have_make_overhang_printable);
 
-    // Orca: only_one_wall_top acts on top surfaces, which exist only with a top shell. An unfilled top surface
-    // (0% top surface density) is still a top surface, so this is gated on the layer count alone.
+    // Orca: the one-wall options act on top/bottom surfaces, which exist only with a shell. An unfilled surface
+    // (0% surface density) is still a surface, so these are gated on the layer counts alone.
+    toggle_line("only_one_wall_first_layer", has_bottom_shell);
     toggle_line("only_one_wall_top", has_top_shell_layers);
     toggle_line("min_width_top_surface", (has_top_shell_layers && config->opt_bool("only_one_wall_top")) || ((config->opt_float("min_length_factor") > 0.5f) && have_arachne)); // 0.5 is default value
 

--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -1009,7 +1009,8 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig *config, in
     toggle_line("make_overhang_printable_angle", have_make_overhang_printable);
     toggle_line("make_overhang_printable_hole_size", have_make_overhang_printable);
 
-    toggle_line("min_width_top_surface", config->opt_bool("only_one_wall_top") || ((config->opt_float("min_length_factor") > 0.5f) && have_arachne)); // 0.5 is default value
+    toggle_line("only_one_wall_top", has_top_shell);
+    toggle_line("min_width_top_surface", (has_top_shell && config->opt_bool("only_one_wall_top")) || ((config->opt_float("min_length_factor") > 0.5f) && have_arachne)); // 0.5 is default value
 
     for (auto el : { "hole_to_polyhole_threshold", "hole_to_polyhole_twisted", "hole_to_polyhole_max_edges" })
         toggle_line(el, config->opt_bool("hole_to_polyhole"));

--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -703,12 +703,13 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig *config, in
     toggle_line("spiral_mode_max_xy_smoothing", has_spiral_vase && config->opt_bool("spiral_mode_smooth"));
     toggle_line("spiral_starting_flow_ratio", has_spiral_vase);
     toggle_line("spiral_finishing_flow_ratio", has_spiral_vase);
-    bool has_top_shell    = config->opt_int("top_shell_layers") > 0 || (has_spiral_vase && config->opt_int("bottom_shell_layers") > 1);
+    bool has_top_shell_layers = config->opt_int("top_shell_layers") > 0 || (has_spiral_vase && config->opt_int("bottom_shell_layers") > 1);
+    bool has_top_shell    = has_top_shell_layers && config->option<ConfigOptionPercent>("top_surface_density")->value > 0;
     bool has_bottom_shell = config->opt_int("bottom_shell_layers") > 0;
     bool has_solid_infill = has_top_shell || has_bottom_shell;
     toggle_field("top_surface_pattern", has_top_shell);
     toggle_field("bottom_surface_pattern", has_bottom_shell);
-    toggle_field("top_surface_density", has_top_shell);
+    toggle_field("top_surface_density", has_top_shell_layers);
     toggle_field("bottom_surface_density", has_bottom_shell);
     toggle_field("top_layer_direction", has_top_shell);
     toggle_field("bottom_layer_direction", has_bottom_shell);
@@ -751,7 +752,7 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig *config, in
     for (auto el : { "sparse_infill_speed", "bridge_speed", "internal_bridge_speed"})
         toggle_field(el, have_infill || has_solid_infill, variant_index);
 
-    toggle_field("top_shell_thickness", ! has_spiral_vase && has_top_shell);
+    toggle_field("top_shell_thickness", ! has_spiral_vase && has_top_shell_layers);
     toggle_field("bottom_shell_thickness", ! has_spiral_vase && has_bottom_shell);
 
     // Gap fill is newly allowed in between perimeter lines even for empty infill (see GH #1476).

--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -706,7 +706,7 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig *config, in
     bool has_top_shell_layers = config->opt_int("top_shell_layers") > 0 || (has_spiral_vase && config->opt_int("bottom_shell_layers") > 1);
     bool has_top_shell    = has_top_shell_layers && config->option<ConfigOptionPercent>("top_surface_density")->value > 0;
     bool has_bottom_shell = config->opt_int("bottom_shell_layers") > 0;
-    bool has_solid_infill = has_top_shell || has_bottom_shell;
+    bool has_solid_infill = has_top_shell_layers || has_bottom_shell;
     toggle_field("top_surface_pattern", has_top_shell);
     toggle_field("bottom_surface_pattern", has_bottom_shell);
     toggle_field("top_surface_density", has_top_shell_layers);

--- a/tests/fff_print/CMakeLists.txt
+++ b/tests/fff_print/CMakeLists.txt
@@ -11,6 +11,7 @@ add_executable(${_TEST_NAME}_tests
 	test_gcodewriter.cpp
 	test_model.cpp
 	test_multifilament.cpp
+	test_perimeters.cpp
 	test_print.cpp
 	test_printobject.cpp
 	test_skirt_brim.cpp

--- a/tests/fff_print/test_perimeters.cpp
+++ b/tests/fff_print/test_perimeters.cpp
@@ -19,6 +19,9 @@ namespace {
 // The layer at this Z is the last one of the base, so its top surface is the ledge.
 const double ledge_z = 5.0;
 
+// The first layer, at initial_layer_print_height.
+const double first_layer_z = 0.2;
+
 // TestMesh::step scaled 3x in X/Y: a 60x60x5 base carrying a 54x54 column up to z=10, leaving a 3mm
 // top ledge around a feature that keeps rising. That is the geometry both only_one_wall_top and the
 // top surface expansion act on. The ledge has to stay wider than the wall band plus two top-infill
@@ -45,6 +48,7 @@ DynamicPrintConfig base_config(const char *wall_generator)
         { "top_surface_density",        "100%" },
         { "top_surface_expansion",      0.0 },
         { "only_one_wall_top",          false },
+        { "only_one_wall_first_layer",  false },
         // Do not let the one-wall threshold discard the 3mm ledge before the feature sees it.
         { "min_width_top_surface",      0.0 },
     });
@@ -217,4 +221,37 @@ TEST_CASE("Only one wall on top surfaces drops inner walls only where a top fill
     CHECK(one_wall_no_fill < plain);
     CHECK(one_wall_no_expand > one_wall);
     CHECK(one_wall_no_expand < plain);
+}
+
+// The bottom counterpart: the first layer is thinned to a single wall only where a bottom shell fills the
+// space behind it. With no bottom shell layers the bottom surfaces are retyped as internal, so that wall
+// would ring sparse infill on the bed - the option is switched off instead, and the GUI hides it in that
+// state so a profile that left it enabled cannot act behind a hidden checkbox.
+TEST_CASE("Only one wall on the first layer needs a bottom shell", "[Perimeters]")
+{
+    const char *wall_generator = GENERATE("classic", "arachne");
+    CAPTURE(wall_generator);
+
+    auto first_layer_perimeters_for = [wall_generator](bool only_one_wall_first_layer, int bottom_shell_layers) {
+        DynamicPrintConfig config = base_config(wall_generator);
+        config.set_deserialize_strict({
+            { "only_one_wall_first_layer", only_one_wall_first_layer },
+            { "bottom_shell_layers",       bottom_shell_layers },
+        });
+        Print print;
+        init_and_process_print({ step_with_ledge() }, print, config);
+        REQUIRE_FALSE(print.objects().empty());
+        return perimeter_length_at(print, first_layer_z);
+    };
+
+    const double plain             = first_layer_perimeters_for(false, 3);
+    const double one_wall          = first_layer_perimeters_for(true,  3);
+    // Both at zero bottom shell layers, so everything else that setting changes cancels out between them.
+    const double plain_no_shell    = first_layer_perimeters_for(false, 0);
+    const double one_wall_no_shell = first_layer_perimeters_for(true,  0);
+
+    REQUIRE(plain > 0.);
+    CHECK(one_wall < plain);
+    // No bottom shell: the option is inert, down to the same walls an unchecked box gives.
+    CHECK_THAT(one_wall_no_shell, Catch::Matchers::WithinAbs(plain_no_shell, 1.0));
 }

--- a/tests/fff_print/test_perimeters.cpp
+++ b/tests/fff_print/test_perimeters.cpp
@@ -182,18 +182,21 @@ TEST_CASE("Top surface density does not affect a slice without a top shell", "[P
 }
 
 // On the ledge layer the inner walls are given up to the top fill, so that layer loses wall length.
-// At a top surface density of 0% there is no fill to take their place, so the original generation is
-// kept and the inner walls stay - putting that layer back above the one-wall slice.
+// The handover needs a top fill that reaches the freed space: at a top surface density of 0% there is
+// no top fill at all, and without top_surface_expansion the fill never grows over the walls. Either
+// way the original generation is kept and the inner walls stay - putting that layer back above the
+// one-wall slice.
 TEST_CASE("Only one wall on top surfaces drops inner walls only where a top fill replaces them", "[Perimeters]")
 {
     const char *wall_generator = GENERATE("classic", "arachne");
     CAPTURE(wall_generator);
 
-    auto ledge_perimeters_for = [wall_generator](bool only_one_wall_top, const char *top_surface_density) {
+    auto ledge_perimeters_for = [wall_generator](bool only_one_wall_top, const char *top_surface_density, double expansion) {
         DynamicPrintConfig config = base_config(wall_generator);
         config.set_deserialize_strict({
-            { "only_one_wall_top",   only_one_wall_top },
-            { "top_surface_density", top_surface_density },
+            { "only_one_wall_top",     only_one_wall_top },
+            { "top_surface_density",   top_surface_density },
+            { "top_surface_expansion", expansion },
         });
         Print print;
         init_and_process_print({ step_with_ledge() }, print, config);
@@ -201,11 +204,13 @@ TEST_CASE("Only one wall on top surfaces drops inner walls only where a top fill
         return perimeter_length_at(print, ledge_z);
     };
 
-    const double plain            = ledge_perimeters_for(false, "100%");
-    const double one_wall         = ledge_perimeters_for(true,  "100%");
-    const double one_wall_no_fill = ledge_perimeters_for(true,  "0%");
+    const double plain              = ledge_perimeters_for(false, "100%", 2.0);
+    const double one_wall           = ledge_perimeters_for(true,  "100%", 2.0);
+    const double one_wall_no_fill   = ledge_perimeters_for(true,  "0%",   2.0);
+    const double one_wall_no_expand = ledge_perimeters_for(true,  "100%", 0.0);
 
     REQUIRE(plain > 0.);
     CHECK(one_wall < plain);
     CHECK(one_wall_no_fill > one_wall);
+    CHECK(one_wall_no_expand > one_wall);
 }

--- a/tests/fff_print/test_perimeters.cpp
+++ b/tests/fff_print/test_perimeters.cpp
@@ -155,7 +155,7 @@ TEST_CASE("Top surface expansion only acts where there is a top fill", "[Perimet
 }
 
 // With no top shell the top surfaces are retyped as internal, so the top surface density has nothing
-// left to control - neither the fill nor, through top_fill_replaces_inner_walls(), the perimeters.
+// left to control - neither the fill nor, through top_surface_is_filled(), the perimeters.
 TEST_CASE("Top surface density does not affect a slice without a top shell", "[Perimeters]")
 {
     const char *wall_generator = GENERATE("classic", "arachne");
@@ -182,10 +182,12 @@ TEST_CASE("Top surface density does not affect a slice without a top shell", "[P
 }
 
 // On the ledge layer the inner walls are given up to the top fill, so that layer loses wall length.
-// The handover needs a top fill that reaches the freed space: at a top surface density of 0% there is
-// no top fill at all, and without top_surface_expansion the fill never grows over the walls. Either
-// way the original generation is kept and the inner walls stay - putting that layer back above the
-// one-wall slice.
+// The handover needs a top fill that reaches the freed space, and the two ways it can be missing are
+// not the same. At a top surface density of 0% there is no top fill at all, so the feature is off and
+// the ledge is walled exactly as if it were unchecked - the GUI hides the option in that state, and a
+// profile that left it enabled must not act behind the hidden checkbox. With a top fill but no
+// top_surface_expansion the feature still runs, only through the original generation, which keeps the
+// inner walls up to the top boundary - between the two.
 TEST_CASE("Only one wall on top surfaces drops inner walls only where a top fill replaces them", "[Perimeters]")
 {
     const char *wall_generator = GENERATE("classic", "arachne");
@@ -211,6 +213,9 @@ TEST_CASE("Only one wall on top surfaces drops inner walls only where a top fill
 
     REQUIRE(plain > 0.);
     CHECK(one_wall < plain);
-    CHECK(one_wall_no_fill > one_wall);
+    // No top fill: the option is inert, down to the same walls an unchecked box gives.
+    CHECK_THAT(one_wall_no_fill, Catch::Matchers::WithinAbs(plain, 1.0));
+    // A top fill that does not expand: the walls are still cut back to the top boundary, just not past it.
     CHECK(one_wall_no_expand > one_wall);
+    CHECK(one_wall_no_expand < plain);
 }

--- a/tests/fff_print/test_perimeters.cpp
+++ b/tests/fff_print/test_perimeters.cpp
@@ -1,0 +1,211 @@
+#include <catch2/catch_all.hpp>
+
+#include "libslic3r/ExtrusionEntity.hpp"
+#include "libslic3r/ExtrusionEntityCollection.hpp"
+#include "libslic3r/Layer.hpp"
+#include "libslic3r/Print.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <vector>
+
+#include "test_helpers.hpp"
+
+using namespace Slic3r;
+using namespace Slic3r::Test;
+
+namespace {
+
+// The layer at this Z is the last one of the base, so its top surface is the ledge.
+const double ledge_z = 5.0;
+
+// TestMesh::step scaled 3x in X/Y: a 60x60x5 base carrying a 54x54 column up to z=10, leaving a 3mm
+// top ledge around a feature that keeps rising. That is the geometry both only_one_wall_top and the
+// top surface expansion act on. The ledge has to stay wider than the wall band plus two top-infill
+// lines, or the expansion discards it as a sliver and the tests below assert nothing.
+TriangleMesh step_with_ledge()
+{
+    TriangleMesh m = Slic3r::Test::mesh(TestMesh::step);
+    m.scale(Vec3f(3.f, 3.f, 1.f));
+    return m;
+}
+
+// Every setting the assertions depend on, so none of them rests on a default.
+DynamicPrintConfig base_config(const char *wall_generator)
+{
+    DynamicPrintConfig config = DynamicPrintConfig::full_print_config();
+    config.set_deserialize_strict({
+        { "wall_generator",             wall_generator },
+        { "layer_height",               0.2 },  // puts a layer boundary exactly on ledge_z
+        { "initial_layer_print_height", 0.2 },
+        { "wall_loops",                 3 },
+        { "sparse_infill_density",      "15%" },
+        { "top_shell_layers",           3 },
+        { "bottom_shell_layers",        3 },
+        { "top_surface_density",        "100%" },
+        { "top_surface_expansion",      0.0 },
+        { "only_one_wall_top",          false },
+        // Do not let the one-wall threshold discard the 3mm ledge before the feature sees it.
+        { "min_width_top_surface",      0.0 },
+    });
+    return config;
+}
+
+double collection_length(const ExtrusionEntityCollection &coll)
+{
+    double len = 0.;
+    for (const ExtrusionEntity *entity : coll.flatten().entities)
+        if (! entity->is_collection())
+            len += entity->length();
+    return len;
+}
+
+// Extruded length per layer. Two slices are compared through this rather than through their G-code,
+// because the G-code carries a config block that differs whenever any setting differs.
+struct SliceLengths {
+    std::vector<double> perimeters;
+    std::vector<double> fills;
+};
+
+SliceLengths slice_lengths(const Print &print)
+{
+    SliceLengths out;
+    for (const Layer *layer : print.objects().front()->layers()) {
+        double perimeters = 0., fills = 0.;
+        for (const LayerRegion *region : layer->regions()) {
+            perimeters += collection_length(region->perimeters);
+            fills      += collection_length(region->fills);
+        }
+        out.perimeters.push_back(perimeters);
+        out.fills.push_back(fills);
+    }
+    return out;
+}
+
+double perimeter_length_at(const Print &print, double print_z)
+{
+    for (const Layer *layer : print.objects().front()->layers())
+        if (std::abs(layer->print_z - print_z) < 1e-4) {
+            double len = 0.;
+            for (const LayerRegion *region : layer->regions())
+                len += collection_length(region->perimeters);
+            return len;
+        }
+    return 0.;
+}
+
+// Largest per-layer difference between two series; a negative result means they are not comparable.
+double max_difference(const std::vector<double> &a, const std::vector<double> &b)
+{
+    if (a.size() != b.size() || a.empty())
+        return -1.;
+    double worst = 0.;
+    for (size_t i = 0; i < a.size(); ++ i)
+        worst = std::max(worst, std::abs(a[i] - b[i]));
+    return worst;
+}
+
+} // namespace
+
+// The expansion only retypes area as top solid infill, so it can do nothing where there is no top
+// fill to begin with: zero top shell layers retypes the top surfaces as internal, and a top surface
+// density of 0% leaves the top layer with walls only. The last section is the control - the same
+// expansion on the same model does change the slice once a top fill exists - without which the two
+// equality checks above it would hold for an unrelated reason.
+TEST_CASE("Top surface expansion only acts where there is a top fill", "[Perimeters]")
+{
+    const char *wall_generator = GENERATE("classic", "arachne");
+    CAPTURE(wall_generator);
+
+    auto lengths_for = [wall_generator](int top_shell_layers, const char *top_surface_density, double expansion) {
+        DynamicPrintConfig config = base_config(wall_generator);
+        config.set_deserialize_strict({
+            { "top_shell_layers",      top_shell_layers },
+            { "top_surface_density",   top_surface_density },
+            { "top_surface_expansion", expansion },
+        });
+        Print print;
+        init_and_process_print({ step_with_ledge() }, print, config);
+        REQUIRE_FALSE(print.objects().empty());
+        return slice_lengths(print);
+    };
+
+    SECTION("no top shell layers") {
+        const SliceLengths off = lengths_for(0, "100%", 0.0);
+        const SliceLengths on  = lengths_for(0, "100%", 2.0);
+        REQUIRE(off.perimeters.size() == on.perimeters.size());
+        CHECK_THAT(max_difference(off.perimeters, on.perimeters), Catch::Matchers::WithinAbs(0., 1.0));
+        CHECK_THAT(max_difference(off.fills,      on.fills),      Catch::Matchers::WithinAbs(0., 1.0));
+    }
+
+    SECTION("zero top surface density") {
+        const SliceLengths off = lengths_for(3, "0%", 0.0);
+        const SliceLengths on  = lengths_for(3, "0%", 2.0);
+        REQUIRE(off.perimeters.size() == on.perimeters.size());
+        CHECK_THAT(max_difference(off.perimeters, on.perimeters), Catch::Matchers::WithinAbs(0., 1.0));
+        CHECK_THAT(max_difference(off.fills,      on.fills),      Catch::Matchers::WithinAbs(0., 1.0));
+    }
+
+    SECTION("with a top fill the same expansion does change the slice") {
+        const SliceLengths off = lengths_for(3, "100%", 0.0);
+        const SliceLengths on  = lengths_for(3, "100%", 2.0);
+        REQUIRE(off.fills.size() == on.fills.size());
+        CHECK(max_difference(off.fills, on.fills) > scale_(0.5));
+    }
+}
+
+// With no top shell the top surfaces are retyped as internal, so the top surface density has nothing
+// left to control - neither the fill nor, through top_fill_replaces_inner_walls(), the perimeters.
+TEST_CASE("Top surface density does not affect a slice without a top shell", "[Perimeters]")
+{
+    const char *wall_generator = GENERATE("classic", "arachne");
+    CAPTURE(wall_generator);
+
+    auto lengths_for = [wall_generator](const char *top_surface_density) {
+        DynamicPrintConfig config = base_config(wall_generator);
+        config.set_deserialize_strict({
+            { "top_shell_layers",    0 },
+            { "only_one_wall_top",   true },
+            { "top_surface_density", top_surface_density },
+        });
+        Print print;
+        init_and_process_print({ step_with_ledge() }, print, config);
+        REQUIRE_FALSE(print.objects().empty());
+        return slice_lengths(print);
+    };
+
+    const SliceLengths solid = lengths_for("100%");
+    const SliceLengths none  = lengths_for("0%");
+    REQUIRE(solid.perimeters.size() == none.perimeters.size());
+    CHECK_THAT(max_difference(solid.perimeters, none.perimeters), Catch::Matchers::WithinAbs(0., 1.0));
+    CHECK_THAT(max_difference(solid.fills,      none.fills),      Catch::Matchers::WithinAbs(0., 1.0));
+}
+
+// On the ledge layer the inner walls are given up to the top fill, so that layer loses wall length.
+// At a top surface density of 0% there is no fill to take their place, so the original generation is
+// kept and the inner walls stay - putting that layer back above the one-wall slice.
+TEST_CASE("Only one wall on top surfaces drops inner walls only where a top fill replaces them", "[Perimeters]")
+{
+    const char *wall_generator = GENERATE("classic", "arachne");
+    CAPTURE(wall_generator);
+
+    auto ledge_perimeters_for = [wall_generator](bool only_one_wall_top, const char *top_surface_density) {
+        DynamicPrintConfig config = base_config(wall_generator);
+        config.set_deserialize_strict({
+            { "only_one_wall_top",   only_one_wall_top },
+            { "top_surface_density", top_surface_density },
+        });
+        Print print;
+        init_and_process_print({ step_with_ledge() }, print, config);
+        REQUIRE_FALSE(print.objects().empty());
+        return perimeter_length_at(print, ledge_z);
+    };
+
+    const double plain            = ledge_perimeters_for(false, "100%");
+    const double one_wall         = ledge_perimeters_for(true,  "100%");
+    const double one_wall_no_fill = ledge_perimeters_for(true,  "0%");
+
+    REQUIRE(plain > 0.);
+    CHECK(one_wall < plain);
+    CHECK(one_wall_no_fill > one_wall);
+}

--- a/tests/fff_print/test_perimeters.cpp
+++ b/tests/fff_print/test_perimeters.cpp
@@ -155,7 +155,8 @@ TEST_CASE("Top surface expansion only acts where there is a top fill", "[Perimet
 }
 
 // With no top shell the top surfaces are retyped as internal, so the top surface density has nothing
-// left to control - neither the fill nor, through top_surface_is_filled(), the perimeters.
+// left to control: there is no top fill, and only_one_wall_top - the one route from the density to the
+// perimeters - is itself switched off for want of a top surface to act on.
 TEST_CASE("Top surface density does not affect a slice without a top shell", "[Perimeters]")
 {
     const char *wall_generator = GENERATE("classic", "arachne");
@@ -182,12 +183,10 @@ TEST_CASE("Top surface density does not affect a slice without a top shell", "[P
 }
 
 // On the ledge layer the inner walls are given up to the top fill, so that layer loses wall length.
-// The handover needs a top fill that reaches the freed space, and the two ways it can be missing are
-// not the same. At a top surface density of 0% there is no top fill at all, so the feature is off and
-// the ledge is walled exactly as if it were unchecked - the GUI hides the option in that state, and a
-// profile that left it enabled must not act behind the hidden checkbox. With a top fill but no
-// top_surface_expansion the feature still runs, only through the original generation, which keeps the
-// inner walls up to the top boundary - between the two.
+// The handover needs a top fill that reaches the freed space: at a top surface density of 0% there is
+// no top fill at all, and without top_surface_expansion the fill never grows over the walls. Either
+// way the feature still runs, through the original generation, which keeps the inner walls up to the
+// top boundary - putting that layer back between the plain and the one-wall slice.
 TEST_CASE("Only one wall on top surfaces drops inner walls only where a top fill replaces them", "[Perimeters]")
 {
     const char *wall_generator = GENERATE("classic", "arachne");
@@ -213,9 +212,9 @@ TEST_CASE("Only one wall on top surfaces drops inner walls only where a top fill
 
     REQUIRE(plain > 0.);
     CHECK(one_wall < plain);
-    // No top fill: the option is inert, down to the same walls an unchecked box gives.
-    CHECK_THAT(one_wall_no_fill, Catch::Matchers::WithinAbs(plain, 1.0));
-    // A top fill that does not expand: the walls are still cut back to the top boundary, just not past it.
+    // Both fall back to the original generation, which cuts the walls back to the top boundary but not past it.
+    CHECK(one_wall_no_fill > one_wall);
+    CHECK(one_wall_no_fill < plain);
     CHECK(one_wall_no_expand > one_wall);
     CHECK(one_wall_no_expand < plain);
 }


### PR DESCRIPTION
TL:DR;
Only one wall use the legacy (before #14296) path if NOT using Top Surface Expansion.
When using it it will generate a new strategies described down here:

# Description

When using more than 1 wall the inner walls were redirected when a top surface was present.
This created some artifacts like creating inner walls where no wall was needed or dividing the top surface expansion (or worst, overlapping with them).

When having 0% top surface density the perimeters will be generated as always to keep internal support.

Now it removes those lines and remplace them with Internal Solid Infill for classic wall and cutted versions of the inner wall for arachne if top_surface_density is bigger than 0 and has some top surface expansion.

Also removed the ability to use "only_one_wall_top" if it doesnt have top shells, and simmilar for bottom.

# Screenshots/Recordings/Graphs

Before:
<img width="489" height="401" alt="imagen" src="https://github.com/user-attachments/assets/ea883852-002c-489a-9a3e-07817963725d" />

After:
<img width="426" height="367" alt="imagen" src="https://github.com/user-attachments/assets/c46e1516-78f4-40b8-ad35-6e9e185dc9a8" />

When using big amount of walls now it generates an infill to avoid the inner wall redirection
Before
<img width="1194" height="673" alt="imagen" src="https://github.com/user-attachments/assets/71b1ca9e-0dfa-4056-910b-fab23b44428d" />
After Classic
<img width="1194" height="673" alt="imagen" src="https://github.com/user-attachments/assets/a32f2b26-8cf3-46bd-8f83-b9a69b764575" />
After Arachne:
<img width="1110" height="725" alt="imagen" src="https://github.com/user-attachments/assets/e7889362-0901-4490-942b-0759b073020a" />

So expanding top surfaces now keep continuous

Before
<img width="1194" height="673" alt="imagen" src="https://github.com/user-attachments/assets/069b3181-2d32-4c75-8ea3-558d4c0470de" />

After Classic
<img width="1194" height="673" alt="imagen" src="https://github.com/user-attachments/assets/b80e3b3a-b0b0-4ae3-af28-9c525e479f9c" />

After Arachne
<img width="1110" height="725" alt="imagen" src="https://github.com/user-attachments/assets/e49f80e5-e40a-4ac7-945c-e79eb45235a8" />

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
