### PR TITLE
fix: hide the extruder switch on single-variant printers

### DIFF
--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -7999,7 +7999,9 @@ void Tab::update_extruder_variants(int extruder_id, bool reload)
         m_actual_nozzle_volumes.resize(extruder_nums, NozzleVolumeType::nvtStandard);
         for (int i = 0; i < extruder_nums; i++) m_actual_nozzle_volumes[i] = (NozzleVolumeType)nozzle_volumes->values[i];
 
-        if (extruder_nums == 2) {
+        // Orca: a non-Bambu dual-nozzle printer has two extruders but a single variant column, so
+        // the nozzle switch and sync button have nothing to act on. Only enable with real variants.
+        if (extruder_nums == 2 && m_preset_bundle->support_different_extruders()) {
             auto options = generate_extruder_options();
             m_extruder_switch->SetOptions(options);
 

--- a/tests/libslic3r/test_config_variant_expansion.cpp
+++ b/tests/libslic3r/test_config_variant_expansion.cpp
@@ -58,6 +58,40 @@ TEST_CASE("apply_override fills nil entries from the 0-based default index", "[C
     }
 }
 
+TEST_CASE("support_different_extruders is true only when the printer defines more than one variant column", "[Config]")
+{
+    int extruder_count = 0;
+
+    SECTION("a non-Bambu dual-nozzle printer with one variant column reports false") {
+        DynamicPrintConfig config;
+        config.option<ConfigOptionFloats>("nozzle_diameter", true)->values = {0.4, 0.4};
+        // Both extruders resolve to the same default variant, so there is only one column.
+        config.option<ConfigOptionStrings>("extruder_variant_list", true)->values = {"Direct Drive Standard",
+                                                                                     "Direct Drive Standard"};
+        REQUIRE(config.support_different_extruders(extruder_count) == false);
+        REQUIRE(extruder_count == 2);
+    }
+
+    SECTION("a Bambu H2D-style printer with distinct variants reports true") {
+        DynamicPrintConfig config;
+        config.option<ConfigOptionFloats>("nozzle_diameter", true)->values = {0.4, 0.4};
+        config.option<ConfigOptionStrings>("extruder_variant_list", true)->values = {
+            "Direct Drive Standard,Direct Drive High Flow",
+            "Direct Drive Standard,Direct Drive High Flow,Direct Drive TPU High Flow"};
+        REQUIRE(config.support_different_extruders(extruder_count) == true);
+        REQUIRE(extruder_count == 2);
+    }
+
+    SECTION("a many-toolhead printer that never opts into variants reports false") {
+        // A Snapmaker U1 has four identical toolheads and never defines extruder_variant_list,
+        // so the config falls back to a single default variant token.
+        DynamicPrintConfig config;
+        config.option<ConfigOptionFloats>("nozzle_diameter", true)->values = {0.4, 0.4, 0.4, 0.4};
+        REQUIRE(config.support_different_extruders(extruder_count) == false);
+        REQUIRE(extruder_count == 4);
+    }
+}
+
 TEST_CASE("get_config_index_base resolves (volume type, extruder type, id) to a slot", "[Config]")
 {
     const std::vector<std::string> variant_list = {"Direct Drive Standard", "Direct Drive High Flow",


### PR DESCRIPTION
# Description

On a dual-nozzle printer the settings pages show a Left/Right nozzle switch and a sync button for copying settings from one nozzle to the other. These only work on printers that define separate variant columns per extruder, which today means Bambu (like the H2D). They were shown based on extruder count alone, so a non-Bambu IDEX printer like the RatRig V-Core 4 IDEX 300 got them too, with no second column to switch to and nothing for sync to copy. Hitting sync in that state is what crashed in #14926.

Now they only show when `support_different_extruders()` returns true. Despite the name it doesn't count extruders, it checks whether the printer has more than one variant column, which is the condition we actually want. Everything downstream already keys off the enabled state, so the row hides itself when the controls are disabled.

Before this change the switch was the only dual-nozzle UI that appeared on a non-Bambu printer. The sibling controls were already gated on real variant columns:

| UI | Gate | H2D | RatRig |
|---|---|---|---|
| Sidebar Left/Right nozzle panel | `is_bbl_vendor() && extruder_variant_list.size() == 2` | shown | hidden (not BBL) |
| Sidebar flow combo (single-nozzle) | `support_different_extruders()` | n/a | hidden |
| Filament tab variant selector | `options.size() > 1` | shown | hidden |
| Settings-tab nozzle switch + sync (this PR) | `extruder_nums == 2 && support_different_extruders()` | shown | hidden (was shown) |

Fixes #14912

# Screenshots/Recordings/Graphs

**RatRig V-Core 4 IDEX 300** — the switch and sync button are gone.

Speed page (Process tab):

| Before | After |
|---|---|
| <img width="360" src="https://github.com/user-attachments/assets/0835eca5-861b-41d1-9970-251da42827cd"> | <img width="360" src="https://github.com/user-attachments/assets/b0efab26-ff20-455e-96c2-d067bdf53c3c"> |

Motion ability page (Printer tab):

| Before | After |
|---|---|
| <img width="360" src="https://github.com/user-attachments/assets/6894af1d-8c9d-4b5e-9985-3d2a383e9a4b"> | <img width="360" src="https://github.com/user-attachments/assets/e46fc26c-ee40-4943-b9e8-59f53da1a881"> |

**Bambu H2D** — unchanged, switch still present.

| Speed page | Motion ability page |
|---|---|
| <img width="320" src="https://github.com/user-attachments/assets/b08d3c1f-b6c6-4b57-a172-cdaca6a5e59c"> | <img width="360" src="https://github.com/user-attachments/assets/9785e66a-a6c4-4ed2-b72b-6c323dbcb997"> |

## Tests

Added a `libslic3r` unit test that checks `support_different_extruders()` on three printers: a non-Bambu dual-nozzle (false), a Bambu H2D (true), and a four-toolhead printer with no variants set (false).
