### PR TITLE
Fix overlapping brims

### DIFF
--- a/src/libslic3r/Brim.cpp
+++ b/src/libslic3r/Brim.cpp
@@ -32,15 +32,13 @@ static void append_and_translate(ExPolygons &dst, const ExPolygons &src, const P
     for (; dst_idx < dst.size(); ++dst_idx)
         dst[dst_idx].translate(instance_shift);
 }
-// BBS: generate brim area by objs
-static void append_and_translate(ExPolygons& dst, const ExPolygons& src,
-    const PrintInstance& instance, size_t instance_idx, std::map<ObjectInstanceID, ExPolygons>& brimAreaMap) {
+// Orca: Translate the brim area into print coordinates and store it per instance.
+static void append_and_translate(const ExPolygons& src, const PrintInstance& instance,
+    size_t instance_idx, std::map<ObjectInstanceID, ExPolygons>& brimAreaMap) {
     ExPolygons srcShifted = src;
     Point instance_shift = instance.shift_without_plate_offset();
-    for (size_t src_idx = 0; src_idx < srcShifted.size(); ++src_idx)
-        srcShifted[src_idx].translate(instance_shift);
-    srcShifted = diff_ex(srcShifted, dst);
-    //expolygons_append(dst, temp2);
+    for (ExPolygon& expoly : srcShifted)
+        expoly.translate(instance_shift);
     expolygons_append(brimAreaMap[{ instance.print_object->id(), instance_idx }], std::move(srcShifted));
 }
 
@@ -572,7 +570,7 @@ static ExPolygons outer_inner_brim_area(const Print& print,
                 for (size_t instance_idx = 0; instance_idx < object->instances().size(); ++instance_idx) {
                     const PrintInstance& instance = object->instances()[instance_idx];
                     if (!brim_area_object.empty())
-                        append_and_translate(brim_area, brim_area_object, instance, instance_idx, brimAreaMap);
+                        append_and_translate(brim_area_object, instance, instance_idx, brimAreaMap);
                     append_and_translate(no_brim_area, no_brim_area_object, instance);
                     append_and_translate(holes, holes_object, instance);
                     append_and_translate(objectIslands, objectIsland, instance);
@@ -874,6 +872,14 @@ void make_brim(const Print& print, PrintTryCancel try_cancel, Polygons& islands_
     Flow                 flow = print.brim_flow();
     ExPolygons           islands_area_ex = outer_inner_brim_area(print,
         float(flow.scaled_spacing()), brimAreaMap, objPrintVec, printExtruders);
+
+    if (!print.config().combine_brims) {
+        ExPolygons claimed_area;
+        for (auto& [_, areas] : brimAreaMap) {
+            areas = diff_ex(areas, claimed_area);
+            expolygons_append(claimed_area, areas);
+        }
+    }
 
     // BBS: Find boundingbox of the first layer
     for (const ObjectID printObjID : print.print_object_ids()) {

--- a/tests/fff_print/test_skirt_brim.cpp
+++ b/tests/fff_print/test_skirt_brim.cpp
@@ -153,6 +153,24 @@ TEST_CASE("Object brims are generated per instance", "[SkirtBrim]")
     }
 }
 
+TEST_CASE("Uncombined neighboring brims precede their respective objects", "[SkirtBrim]")
+{
+    Print print;
+    Model model;
+    place_two_cubes_apart(0, {
+        { "skirt_loops",   0 },
+        { "brim_type",     "outer_only" },
+        { "brim_width",    5 },
+        { "combine_brims", 0 },
+    }, print, model);
+    print.process();
+
+    REQUIRE(print.skirt_brim_groups().size() == 1);
+    REQUIRE(print.skirt_brim_groups().front().brims.size() == 2);
+    CHECK(role_sequence(gcode(print), { "brim", "perimeter" }) ==
+          std::vector<std::string>{ "brim", "perimeter", "brim", "perimeter" });
+}
+
 TEST_CASE("Combine brims merges neighboring object instances", "[SkirtBrim]")
 {
     Print print;


### PR DESCRIPTION
## Description

This PR fixes overlapping brims when **Combine brims** is disabled.

The issue could occur whenever separately generated brims of neighboring object instances overlapped, causing the same region to be printed multiple times.

## Applied fix

Brim areas are now collected for each object instance before overlaps are resolved.

After all brims are available, areas already assigned to an earlier brim are removed from the following ones. This ensures that each shared region belongs to only one brim while preserving the expected print order:

```text
brim → object → brim → object
```

## Sceenshots

__Before:__
<img width="1182" height="1181" alt="image" src="https://github.com/user-attachments/assets/7755143c-3c91-475c-8dbd-6c68194d97ec" />

<br>
<br>

__After:__
<img width="1181" height="1177" alt="image" src="https://github.com/user-attachments/assets/c302c6b2-dfc9-4f0d-b786-4259df02963d" />

<br>

---

Fixes #14980