### PR TITLE
fix STEP progress message percent format

### DIFF
--- a/src/libslic3r/Format/STEP.hpp
+++ b/src/libslic3r/Format/STEP.hpp
@@ -78,7 +78,7 @@ public:
     Standard_Boolean UserBreak() override { return should_stop.load(); }
 
     void Show(const Message_ProgressScope&, const Standard_Boolean) override {
-        std::cout << "Progress: " << GetPosition() << "%" << std::endl;
+        std::cout << "Progress: " << std::fixed << std::setprecision(2) << 100.0 * GetPosition() << "%" << std::endl;
     }
 private:
     std::atomic<bool>& should_stop;


### PR DESCRIPTION
Fixes the output to show properly the percentage (0 -> 100), rather than `0%` -> `1%`.

`GetPosition()` returns a `double` ranged from `0` to `1` -- https://github.com/Open-Cascade-SAS/OCCT/blob/master/src/FoundationClasses/TKernel/Message/Message_ProgressIndicator.hxx#L118
```cxx
  //! Returns total progress position ranged from 0 to 1.
  //! Should not be called concurrently while the progress is advancing,
  //! except from implementation of method Show().
  double GetPosition() const { return myPosition; }
```