### PR TITLE
feat(plugin): expose orca.host.app_language() for plugin localization

### DIFF
--- a/src/slic3r/plugin/host/PluginHostApp.cpp
+++ b/src/slic3r/plugin/host/PluginHostApp.cpp
@@ -2,6 +2,7 @@
 
 #include <libslic3r/Model.hpp>
 #include <libslic3r/PresetBundle.hpp>
+#include <slic3r/GUI/GUI.hpp>
 #include <slic3r/GUI/GUI_App.hpp>
 #include <slic3r/GUI/Plater.hpp>
 
@@ -55,6 +56,15 @@ void host_bindings::register_app(py::module_& host)
         return current_plater()->model();
     }, py::return_value_policy::reference);
     host.def("preset_bundle", &current_preset_bundle, py::return_value_policy::reference);
+    // UI language of the running app ("en_US", "ru_RU", ...), so plugins can
+    // localize their own dialogs. The app config file that stores this value
+    // is deny-listed by the audit hook (it sits next to cloud secrets), so a
+    // read-only accessor is the supported way to get just the language.
+    host.def("app_language", []() -> std::string {
+        if (wxTheApp == nullptr)
+            throw std::runtime_error("OrcaSlicer application is not initialized");
+        return GUI::into_u8(GUI::wxGetApp().current_language_code_safe());
+    });
 }
 
 } // namespace Slic3r


### PR DESCRIPTION
# Description

Python plugins currently have no way to localize their own dialogs to match the app: the UI language is stored in `OrcaSlicer.conf`, which the plugin audit hook deny-lists by design (the file sits next to cloud secrets), and the host API exposes no app info. As a result, localized plugins have to guess the language from the OS locale, which does not always match the slicer UI (and the embedded interpreter often gets no `LANG` at all in GUI sessions).

This PR adds a minimal read-only accessor:

```python
orca.host.app_language()   # -> "en_US", "ru_RU", ...
```

It returns `GUI_App::current_language_code_safe()` — only the language code string, nothing else from the config, so the audit-hook security model is untouched.

No breaking changes; one file, +10 lines.

# Screenshots/Recordings/Graphs

(screenshots of the test dialog will be attached below)

## Tests

- Built on macOS (arm64, Ninja) with this change — compiles clean.
- Ran a minimal script-capability plugin calling `orca.host.app_language()` on a system with Russian UI: the dialog shows `'ru_RU'`.
- Guard before GUI init follows the same exception pattern as the neighbouring `plater()`/`preset_bundle()` accessors.
<img width="903" height="826" alt="Снимок экрана 2026-07-28 в 23 10 48" src="https://github.com/user-attachments/assets/27088265-b55d-4958-8602-7c3ab4993003" />
<img width="437" height="276" alt="Снимок экрана 2026-07-28 в 23 10 56" src="https://github.com/user-attachments/assets/9845b401-dc8e-4353-aa24-5ace678270d6" />
