### PR TITLE
QOL Continue to capture mouse position while dragging ImGui controls and mouse position goes to outside of window 

### DIFF
--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -4421,6 +4421,10 @@ void GLCanvas3D::on_mouse(wxMouseEvent& evt)
                     && m_gizmos.get_current_type() != GLGizmosManager::MmSegmentation
                     && m_gizmos.get_current_type() != GLGizmosManager::FuzzySkin) {
                     m_rectangle_selection.start_dragging(m_mouse.position, evt.ShiftDown() ? GLSelectionRectangle::Select : GLSelectionRectangle::Deselect);
+
+                    if (!has_mouse_capture())  // ORCA keep tracking mouse position while drag active and cursor not in window bounds
+                        m_canvas->CaptureMouse();
+
                     m_dirty = true;
                 }
             }
@@ -4547,6 +4551,10 @@ void GLCanvas3D::on_mouse(wxMouseEvent& evt)
     else if (evt.Dragging() && evt.LeftIsDown() && m_picking_enabled && m_rectangle_selection.is_dragging()) {
         //BBS not in assemble view
         if (m_canvas_type != ECanvasType::CanvasAssembleView) {
+
+            if (!has_mouse_capture()) // ORCA keep tracking mouse position while drag active and cursor not in window bounds
+                m_canvas->CaptureMouse();
+
             m_rectangle_selection.dragging(pos.cast<double>());
             m_dirty = true;
         }

--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -2186,7 +2186,7 @@ void GLCanvas3D::render(bool only_init)
 
 	// Negative coordinate means out of the window, likely because the window was deactivated.
 	// In that case the tooltip should be hidden.
-    if (m_mouse.position.x() >= 0. && m_mouse.position.y() >= 0.) {
+    if (m_mouse.position.x() >= 0. && m_mouse.position.y() >= 0. || has_mouse_capture()) { // ORCA continue to capture mouse pos mid drag
         if (tooltip.empty())
             tooltip = m_layers_editing.get_tooltip(*this);
 
@@ -4187,7 +4187,13 @@ void GLCanvas3D::on_mouse(wxMouseEvent& evt)
         // ignore left up events coming from imgui windows and not processed by them
         m_mouse.ignore_left_up = true;
     m_tooltip.set_in_imgui(false);
-    if (imgui->update_mouse_data(evt)) {
+
+    // while a non-ImGui drag is already in progress (gizmo grabber, object move, rectangle selection, layer editing),
+    // don't let ImGui/ImGuizmo claim the event just because the cursor is hovering something like the navigator cube
+    // that incorrectly suppresses the active drag's tooltip and can interrupt its processing. The active drag always takes priority.
+    const bool other_drag_active = m_gizmos.is_dragging() || m_mouse.dragging || m_rectangle_selection.is_dragging() || m_layers_editing.state == LayersEditing::Editing;
+
+    if (imgui->update_mouse_data(evt) && !other_drag_active) {
         if ((evt.LeftDown() || (evt.Moving() && (evt.AltDown() || evt.ShiftDown()))) && m_canvas != nullptr)
             m_canvas->SetFocus();
         m_mouse.position = evt.Leaving() ? Vec2d(-1.0, -1.0) : pos.cast<double>();

--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -1842,6 +1842,10 @@ void GLCanvas3D::enable_separator_toolbar(bool enable)
     m_separator_toolbar.set_enabled(enable);
 }
 
+bool GLCanvas3D::has_mouse_capture() const {
+    return m_canvas != nullptr && m_canvas->HasCapture();
+}
+
 void GLCanvas3D::zoom_to_bed()
 {
     BoundingBoxf3 box = m_bed.build_volume().bounding_volume();
@@ -4189,11 +4193,9 @@ void GLCanvas3D::on_mouse(wxMouseEvent& evt)
         m_mouse.position = evt.Leaving() ? Vec2d(-1.0, -1.0) : pos.cast<double>();
         m_tooltip.set_in_imgui(true);
 
-        // keep tracking an active ImGui drag (e.g. IMSlider handle/label) even once the mouse leaves the canvas window bounds.
-        const bool imgui_dragging_active_item =
-            (GImGui != nullptr && ImGui::GetIO().MouseDown[0] && GImGui->ActiveId != 0) || // UI controls
-            m_navigator_dragging; // Navigation Cube
-        if (m_canvas != nullptr && imgui_dragging_active_item && !m_canvas->HasCapture())
+        // keep tracking an active ImGui drag even once the mouse leaves the canvas window bounds.
+        const bool imgui_dragging_active = (GImGui != nullptr && ImGui::GetIO().MouseDown[0] && GImGui->ActiveId != 0) || m_navigator_dragging;
+        if (!has_mouse_capture() && imgui_dragging_active)
             m_canvas->CaptureMouse();
 
         // release capture as soon as the button goes up. Without this, on_mouse() may return below before ever reaching the LeftUp branch
@@ -4296,6 +4298,10 @@ void GLCanvas3D::on_mouse(wxMouseEvent& evt)
             evt2.SetLeftDown(false);
             m_main_toolbar.on_mouse(evt2, *this);
         }
+
+        // keep tracking past the window edge while a gizmo grabber is actively held
+        if (!has_mouse_capture() && evt.LeftIsDown() && m_gizmos.is_dragging())
+            m_canvas->CaptureMouse();
 
         if (evt.LeftUp() || evt.MiddleUp() || evt.RightUp())
             mouse_up_cleanup();

--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -6079,6 +6079,14 @@ void GLCanvas3D::_render_3d_navigator()
         return;
     }
 
+    // Fix stealing capture event from other drag events
+    const bool other_drag_active = !m_navigator_dragging && (m_moving || m_camera_movement || m_mouse.dragging || m_rectangle_selection.is_dragging() || m_gizmos.is_dragging());
+
+    ImGuiIO& io = ImGui::GetIO();
+    const bool saved_mouse_down0 = io.MouseDown[0];
+    if (other_drag_active)
+        io.MouseDown[0] = false;
+
     ImGuizmo::BeginFrame();
 
     auto& style                                = ImGuizmo::GetStyle();
@@ -6103,7 +6111,6 @@ void GLCanvas3D::_render_3d_navigator()
     sc *= (float) dpi / (float) DPI_DEFAULT;
 #endif // WIN32
 
-    const ImGuiIO& io              = ImGui::GetIO();
     const float viewManipulateLeft = 0;
     const float viewManipulateTop  = io.DisplaySize.y;
     const float camDistance        = 8.f;
@@ -6126,6 +6133,10 @@ void GLCanvas3D::_render_3d_navigator()
     const auto result = ImGuizmo::ViewManipulate(cameraView, cameraProjection, ImGuizmo::OPERATION::ROTATE, ImGuizmo::MODE::WORLD, nullptr,
                                                  camDistance, ImVec2(viewManipulateLeft, viewManipulateTop - size), ImVec2(size, size),
                                                  0x00101010);
+
+    // Restore the real mouse-down state
+    if (other_drag_active)
+        io.MouseDown[0] = saved_mouse_down0;
 
     if (result.changed) {
         for (unsigned int c = 0; c < 4; ++c) {

--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -9287,8 +9287,12 @@ void GLCanvas3D::_render_imgui_select_plate_toolbar()
 
     //ORCA ImGui::IsWindowHovered() returns false when left_down events on buttons that causes scrollbar disappears for a short time
     auto win_pos = ImGui::GetWindowPos();
-    bool is_win_hovered = ImGui::IsMouseHoveringRect(win_pos, win_pos + ImVec2(window_width + (show_scroll ? scrollbar_size : 0), window_height), !show_scroll); // use non clipped rectangle to reserve clickable area for scrollbar track
-    m_sel_plate_toolbar.is_display_scrollbar = is_win_hovered;
+    bool is_win_hovered = ImGui::IsMouseHoveringRect(win_pos, win_pos + ImVec2(window_width + (show_scroll ? scrollbar_size : 0), window_height), !show_scroll);
+
+    // Also show scrollbar visible and continue to capture mouse position
+    const bool is_scrollbar_active_drag = GImGui != nullptr && ImGui::GetIO().MouseDown[0] && GImGui->ActiveId != 0 && GImGui->ActiveIdWindow == ImGui::GetCurrentWindow();
+
+    m_sel_plate_toolbar.is_display_scrollbar = is_win_hovered || is_scrollbar_active_drag;
 
     imgui.end();
 }

--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -4190,7 +4190,9 @@ void GLCanvas3D::on_mouse(wxMouseEvent& evt)
         m_tooltip.set_in_imgui(true);
 
         // keep tracking an active ImGui drag (e.g. IMSlider handle/label) even once the mouse leaves the canvas window bounds.
-        const bool imgui_dragging_active_item = GImGui != nullptr && ImGui::GetIO().MouseDown[0] && GImGui->ActiveId != 0;
+        const bool imgui_dragging_active_item =
+            (GImGui != nullptr && ImGui::GetIO().MouseDown[0] && GImGui->ActiveId != 0) || // UI controls
+            m_navigator_dragging; // Navigation Cube
         if (m_canvas != nullptr && imgui_dragging_active_item && !m_canvas->HasCapture())
             m_canvas->CaptureMouse();
 
@@ -6044,6 +6046,7 @@ void GLCanvas3D::_render_3d_navigator()
 {
     if (!wxGetApp().show_3d_navigator()) {
         m_canvas_toolbar_pos[0] = 0;
+        m_navigator_dragging = false;
         return;
     }
 
@@ -6126,6 +6129,8 @@ void GLCanvas3D::_render_3d_navigator()
 
         request_extra_frame();
     }
+
+    m_navigator_dragging = result.dragging;
 }
 
 #define ENABLE_THUMBNAIL_GENERATOR_DEBUG_OUTPUT 0

--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -6080,7 +6080,7 @@ void GLCanvas3D::_render_3d_navigator()
     }
 
     // Fix stealing capture event from other drag events
-    const bool other_drag_active = !m_navigator_dragging && (m_moving || m_camera_movement || m_mouse.dragging || m_rectangle_selection.is_dragging() || m_gizmos.is_dragging());
+    const bool other_drag_active = !m_navigator_dragging && (m_moving || m_rectangle_selection.is_dragging() || m_gizmos.is_dragging());
 
     ImGuiIO& io = ImGui::GetIO();
     const bool saved_mouse_down0 = io.MouseDown[0];

--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -4188,6 +4188,17 @@ void GLCanvas3D::on_mouse(wxMouseEvent& evt)
             m_canvas->SetFocus();
         m_mouse.position = evt.Leaving() ? Vec2d(-1.0, -1.0) : pos.cast<double>();
         m_tooltip.set_in_imgui(true);
+
+        // keep tracking an active ImGui drag (e.g. IMSlider handle/label) even once the mouse leaves the canvas window bounds.
+        const bool imgui_dragging_active_item = GImGui != nullptr && ImGui::GetIO().MouseDown[0] && GImGui->ActiveId != 0;
+        if (m_canvas != nullptr && imgui_dragging_active_item && !m_canvas->HasCapture())
+            m_canvas->CaptureMouse();
+
+        // release capture as soon as the button goes up. Without this, on_mouse() may return below before ever reaching the LeftUp branch
+        // further down (since m_mouse.dragging is false for pure ImGui drags), leaving the canvas stuck with mouse capture.
+        if (evt.LeftUp() || evt.MiddleUp() || evt.RightUp())
+            mouse_up_cleanup();
+
         render();
 #ifdef SLIC3R_DEBUG_MOUSE_EVENTS
         printf((format_mouse_event_debug_message(evt) + " - Consumed by ImGUI\n").c_str());

--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -4492,6 +4492,9 @@ void GLCanvas3D::on_mouse(wxMouseEvent& evt)
                             m_mouse.drag.start_position_3D = m_mouse.scene_position;
                             m_sequential_print_clearance_first_displacement = true;
                             m_moving = true;
+
+                            if (!has_mouse_capture()) // ORCA keep tracking mouse position while drag active and cursor not in window bounds
+                                m_canvas->CaptureMouse();
                         }
                     }
                 }
@@ -4500,6 +4503,10 @@ void GLCanvas3D::on_mouse(wxMouseEvent& evt)
     }
     else if (evt.Dragging() && evt.LeftIsDown() && m_mouse.drag.move_volume_idx != -1 && m_layers_editing.state == LayersEditing::Unknown) {
         if (m_canvas_type != ECanvasType::CanvasAssembleView) {
+
+            if (!has_mouse_capture()) // ORCA keep tracking mouse position while drag active and cursor not in window bounds
+                m_canvas->CaptureMouse();
+
             if (!m_mouse.drag.move_requires_threshold) {
                 m_mouse.dragging = true;
                 Vec3d cur_pos = m_mouse.drag.start_position_3D;

--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -4174,6 +4174,23 @@ void GLCanvas3D::on_mouse(wxMouseEvent& evt)
     // BBS: single snapshot
     Plater::SingleSnapshot single(wxGetApp().plater());
 
+#ifdef __WXMAC__
+    // On macOS, the mouse key state is only present for mouse btn related events such as wxEVT_LEFT_DOWN.
+    // For other events, all buttons are reported as non-pressed, such as window leaving event. This causes
+    // imgui stopped responding if cursor moved out of window, such as
+    // https://github.com/OrcaSlicer/OrcaSlicer/pull/14999#issuecomment-5151344759
+    // We solve this by correcting the state of the event from the actual mouse state querying with `wxGetMouseState()`
+    // so it works like on other platforms.
+    {
+        const auto state = wxGetMouseState();
+        evt.SetLeftDown(state.LeftIsDown());
+        evt.SetMiddleDown(state.MiddleIsDown());
+        evt.SetRightDown(state.RightIsDown());
+        evt.SetAux1Down(state.Aux1IsDown());
+        evt.SetAux2Down(state.Aux2IsDown());
+    }
+#endif
+
 #if ENABLE_RETINA_GL
     const float scale = m_retina_helper->get_scale_factor();
     evt.SetX(evt.GetX() * scale);

--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -4193,7 +4193,7 @@ void GLCanvas3D::on_mouse(wxMouseEvent& evt)
         m_mouse.position = evt.Leaving() ? Vec2d(-1.0, -1.0) : pos.cast<double>();
         m_tooltip.set_in_imgui(true);
 
-        // keep tracking an active ImGui drag even once the mouse leaves the canvas window bounds.
+        // ORCA keep tracking mouse position while drag active and cursor not in window bounds
         const bool imgui_dragging_active = (GImGui != nullptr && ImGui::GetIO().MouseDown[0] && GImGui->ActiveId != 0) || m_navigator_dragging;
         if (!has_mouse_capture() && imgui_dragging_active)
             m_canvas->CaptureMouse();
@@ -4299,7 +4299,7 @@ void GLCanvas3D::on_mouse(wxMouseEvent& evt)
             m_main_toolbar.on_mouse(evt2, *this);
         }
 
-        // keep tracking past the window edge while a gizmo grabber is actively held
+        // ORCA keep tracking mouse position while drag active and cursor not in window bounds
         if (!has_mouse_capture() && evt.LeftIsDown() && m_gizmos.is_dragging())
             m_canvas->CaptureMouse();
 
@@ -4562,6 +4562,10 @@ void GLCanvas3D::on_mouse(wxMouseEvent& evt)
         }
         // do not process the dragging if the left mouse was set down in another canvas
         else if (is_camera_rotate(evt, button_mappings)) {
+
+            if (!has_mouse_capture()) // ORCA keep tracking mouse position while drag active and cursor not in window bounds
+                m_canvas->CaptureMouse();
+
             // Orca: Sphere rotation for painting view
             // if dragging over blank area with left button or other button mapped to rotate, then rotate
             bool middle_or_right_button_used_as_rotate = (evt.MiddleIsDown() && button_mappings[MouseButton::Middle] == MouseAction::Rotation) ||
@@ -4641,6 +4645,10 @@ void GLCanvas3D::on_mouse(wxMouseEvent& evt)
             m_mouse.drag.start_position_3D = Vec3d((double)pos(0), (double)pos(1), 0.0);
         }
         else if (is_camera_pan(evt, button_mappings)) {
+
+            if (!has_mouse_capture()) // ORCA keep tracking mouse position while drag active and cursor not in window bounds
+                m_canvas->CaptureMouse();
+
             // if dragging with right button or if button functions swapped and dragging with left button over blank area then pan
             if (m_mouse.is_start_position_2D_defined()) {
                 // get point in model space at Z = 0

--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -4198,8 +4198,7 @@ void GLCanvas3D::on_mouse(wxMouseEvent& evt)
         if (!has_mouse_capture() && imgui_dragging_active)
             m_canvas->CaptureMouse();
 
-        // release capture as soon as the button goes up. Without this, on_mouse() may return below before ever reaching the LeftUp branch
-        // further down (since m_mouse.dragging is false for pure ImGui drags), leaving the canvas stuck with mouse capture.
+        // release capture as soon as the button goes up
         if (evt.LeftUp() || evt.MiddleUp() || evt.RightUp())
             mouse_up_cleanup();
 
@@ -4408,6 +4407,9 @@ void GLCanvas3D::on_mouse(wxMouseEvent& evt)
             // Start editing the layer height.
             m_layers_editing.state = LayersEditing::Editing;
             _perform_layer_editing_action(&evt);
+
+            if (!has_mouse_capture()) // ORCA keep tracking mouse position while drag active and cursor not in window bounds
+                m_canvas->CaptureMouse();
         }
 
         else {
@@ -4571,6 +4573,9 @@ void GLCanvas3D::on_mouse(wxMouseEvent& evt)
 
         if (m_layers_editing.state != LayersEditing::Unknown && layer_editing_object_idx != -1) {
             if (m_layers_editing.state == LayersEditing::Editing) {
+                if (!has_mouse_capture()) // ORCA keep tracking mouse position while drag active and cursor not in window bounds
+                    m_canvas->CaptureMouse();
+
                 _perform_layer_editing_action(&evt);
                 m_mouse.position = pos.cast<double>();
             }
@@ -6080,7 +6085,7 @@ void GLCanvas3D::_render_3d_navigator()
     }
 
     // Fix stealing capture event from other drag events
-    const bool other_drag_active = !m_navigator_dragging && (m_moving || m_rectangle_selection.is_dragging() || m_gizmos.is_dragging());
+    const bool other_drag_active = !m_navigator_dragging && (m_moving || m_rectangle_selection.is_dragging() || m_gizmos.is_dragging() || m_layers_editing.state == LayersEditing::Editing);
 
     ImGuiIO& io = ImGui::GetIO();
     const bool saved_mouse_down0 = io.MouseDown[0];

--- a/src/slic3r/GUI/GLCanvas3D.hpp
+++ b/src/slic3r/GUI/GLCanvas3D.hpp
@@ -917,6 +917,7 @@ public:
     void update_volumes_colors_by_extruder();
 
     bool is_dragging() const { return m_gizmos.is_dragging() || m_moving; }
+    bool has_mouse_capture() const;
 
     void render(bool only_init = false);
     bool is_rendering_enabled()

--- a/src/slic3r/GUI/GLCanvas3D.hpp
+++ b/src/slic3r/GUI/GLCanvas3D.hpp
@@ -589,6 +589,7 @@ private:
     bool m_toolpath_outside{ false };
     ECursorType m_cursor_type;
     GLSelectionRectangle m_rectangle_selection;
+    bool m_navigator_dragging{ false };
 
     //BBS:add plate related logic
     mutable std::vector<int> m_hover_volume_idxs;

--- a/src/slic3r/GUI/Gizmos/GLGizmoBase.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoBase.cpp
@@ -442,7 +442,7 @@ bool GLGizmoBase::use_grabbers(const wxMouseEvent &mouse_event) {
         }
     } else if (m_dragging) {
         // when mouse cursor leave window than finish actual dragging operation
-        bool is_leaving = mouse_event.Leaving();
+        bool is_leaving = mouse_event.Leaving() && !m_parent.has_mouse_capture(); // keep tracking past the window edge while a gizmo grabber is actively held
         if (mouse_event.Dragging()) {
             Point      mouse_coord(mouse_event.GetX(), mouse_event.GetY());
             auto       ray = m_parent.mouse_ray(mouse_coord);

--- a/src/slic3r/GUI/Gizmos/GLGizmoBase.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoBase.cpp
@@ -442,7 +442,7 @@ bool GLGizmoBase::use_grabbers(const wxMouseEvent &mouse_event) {
         }
     } else if (m_dragging) {
         // when mouse cursor leave window than finish actual dragging operation
-        bool is_leaving = mouse_event.Leaving() && !m_parent.has_mouse_capture(); // keep tracking past the window edge while a gizmo grabber is actively held
+        bool is_leaving = mouse_event.Leaving() && !m_parent.has_mouse_capture(); // ORCA keep tracking mouse position while drag active and cursor not in window bounds
         if (mouse_event.Dragging()) {
             Point      mouse_coord(mouse_event.GetX(), mouse_event.GetY());
             auto       ray = m_parent.mouse_ray(mouse_coord);


### PR DESCRIPTION
## ISSUE
canvas looses capturing of mouse position if cursor goes beyond of its bounds (sidebar or outside of window frame)

## NOTES
• Tested on windows and Linux gnome
• Application releases capturing on window loosing focus (alt+tab, minimize...) as expected

## COMPARISON / RESULT
**all examples on below looses capture on current release**

## UI components

before - mouse position capturing loss if cursor goes beyond window frame. right side is outside of window
<img width="220" height="189" alt="vivaldi_ZVV04CH6Wd" src="https://github.com/user-attachments/assets/cdbf0872-9312-4215-bc20-2b3e35d23253" />

after - continues to capture mouse position without any break
<img width="233" height="278" alt="vivaldi_zG80w3WJCe" src="https://github.com/user-attachments/assets/e01f8288-5d22-4b1e-9f12-0164793e49a9" />

preview horizontal slider
<img width="311" height="210" alt="vivaldi_VZel9WnWl7" src="https://github.com/user-attachments/assets/7482a127-f12a-4994-a6d0-789e27bd3053" />

window sliders
<img width="602" height="499" alt="vivaldi_ftxx414tId" src="https://github.com/user-attachments/assets/b0aefbf6-e7ab-4054-aaef-1cdb128ed127" />

window drag
<img width="620" height="427" alt="vivaldi_JR9srSl3EE" src="https://github.com/user-attachments/assets/7075afa3-7a74-43ae-bf4a-45637554d5ba" />

text selection
<img width="626" height="238" alt="vivaldi_pQCKBDRQfj" src="https://github.com/user-attachments/assets/55bc16d9-a1ff-4f3b-8c9e-f5179f6e34aa" />

regular sliders
<img width="293" height="154" alt="vivaldi_eEeYYVA4vY" src="https://github.com/user-attachments/assets/cf7b5316-1298-439c-964e-11ed7b42161d" />

## Navigation Cube
<img width="269" height="254" alt="vivaldi_trjpwMi6sI" src="https://github.com/user-attachments/assets/945e7fed-62d5-4c79-9177-79638c2fc87a" />

## Transform widgets
<img width="455" height="406" alt="GitHubDesktop_DZL31ecwO7" src="https://github.com/user-attachments/assets/681560ea-e60e-41fd-ad47-57ed3d501b4d" />

## Camera Rotation / Pan
<img width="638" height="666" alt="vivaldi_v9lfkKzR4G" src="https://github.com/user-attachments/assets/b7e36a4c-fd8f-4f82-9449-fcc05d9a17f2" />

<img width="627" height="635" alt="vivaldi_7XepZ4Jwh8" src="https://github.com/user-attachments/assets/8075d586-8605-4e82-880a-746f3d3b6f59" />

## Object Drag
<img width="438" height="434" alt="vivaldi_x7fgnip3bW" src="https://github.com/user-attachments/assets/2ff41ee8-1e06-484d-9dc9-dd14602561ca" />

## Variable Layer Height
<img width="397" height="491" alt="vivaldi_R6ASNAcmkh" src="https://github.com/user-attachments/assets/18ade832-cb58-4dc5-a579-6d57c34dbb75" />

## Selection frame
<img width="482" height="636" alt="vivaldi_4eEOxGVSAL" src="https://github.com/user-attachments/assets/81285a8b-093b-4a0e-9310-84214d23fca1" />

# ADDITIONAL FIXES
## Navigation cube steals drag event from other type of drag events
solution; basically blocks navigation cube rotation if other drag active
didnt add comparisons but same issue exist on most drag events like selection rectangle, rotate, scale, move, object drag...

**drag object**
before
<img width="513" height="445" alt="vivaldi_zQsJzHLTVM" src="https://github.com/user-attachments/assets/20759e4b-5f0f-4af4-9fb8-eb18fbbb7836" />
after
<img width="514" height="430" alt="vivaldi_r3Tb8pmg7c" src="https://github.com/user-attachments/assets/b2579680-31df-4164-8cb4-d51c6fb37ca3" />

**transform**
before
<img width="592" height="446" alt="vivaldi_mBoAHs4bBD" src="https://github.com/user-attachments/assets/63ebf556-6ff5-43c8-a472-6ed8f4ac95d5" />

after
<img width="530" height="446" alt="vivaldi_UqCGl34VZ7" src="https://github.com/user-attachments/assets/6037fec9-ab19-47fb-abfc-ddc0ee5e6aff" />

## Plates toolbar scrollbar keeps visibility and continues to capturing mouse position while its actively dragging now
<img width="440" height="561" alt="vivaldi_HF2iq7DxLe" src="https://github.com/user-attachments/assets/f2b16b55-ab60-4b93-bc8b-cd464c1cb864" />

