### PR TITLE
Improve dimmed layers

### DIFF
--- a/src/libslic3r/AppConfig.cpp
+++ b/src/libslic3r/AppConfig.cpp
@@ -206,6 +206,20 @@ void AppConfig::set_defaults()
     if (get("preview_dim_previous_layers").empty())
         set_bool("preview_dim_previous_layers", false);
 
+    // ORCA: brightness of those dimmed layers, in percent. 100 = unchanged, 0 = black
+    if (get("preview_dim_previous_layers_brightness").empty())
+        set("preview_dim_previous_layers_brightness", "40");
+    else {
+        int brightness = 40;
+        try {
+            brightness = std::stoi(get("preview_dim_previous_layers_brightness"));
+        }
+        catch (...) {
+            brightness = 40;
+        }
+        set("preview_dim_previous_layers_brightness", std::to_string(std::max(0, std::min(brightness, 100))));
+    }
+
     if (get("filaments_area_preferred_count").empty())
         set("filaments_area_preferred_count", "10");
 

--- a/src/libslic3r/AppConfig.cpp
+++ b/src/libslic3r/AppConfig.cpp
@@ -202,7 +202,7 @@ void AppConfig::set_defaults()
     if (get("seq_top_layer_only").empty())
         set("seq_top_layer_only", "1");
 
-    // ORCA: darken layers below the current one while scrubbing the preview (ported from preFlight)
+    // ORCA: darken the layers the preview layer slider is not scrubbed to
     if (get("preview_dim_previous_layers").empty())
         set_bool("preview_dim_previous_layers", false);
 

--- a/src/libslic3r/AppConfig.cpp
+++ b/src/libslic3r/AppConfig.cpp
@@ -206,7 +206,8 @@ void AppConfig::set_defaults()
     if (get("preview_dim_previous_layers").empty())
         set_bool("preview_dim_previous_layers", false);
 
-    // ORCA: brightness of those dimmed layers, in percent. 100 = unchanged, 0 = black
+    // ORCA: brightness of those dimmed layers, in percent. 0 = black, capped at 99 because
+    // 100 would render them unchanged, which is what disabling the option already does
     if (get("preview_dim_previous_layers_brightness").empty())
         set("preview_dim_previous_layers_brightness", "40");
     else {
@@ -217,7 +218,7 @@ void AppConfig::set_defaults()
         catch (...) {
             brightness = 40;
         }
-        set("preview_dim_previous_layers_brightness", std::to_string(std::max(0, std::min(brightness, 100))));
+        set("preview_dim_previous_layers_brightness", std::to_string(std::max(0, std::min(brightness, 99))));
     }
 
     if (get("filaments_area_preferred_count").empty())

--- a/src/libvgcode/include/Viewer.hpp
+++ b/src/libvgcode/include/Viewer.hpp
@@ -92,10 +92,9 @@ public:
     void toggle_top_layer_only_view_range();
     //
     // Dim previous layers (ORCA, ported from preFlight)
-    // Whether the layers below the current top layer are rendered darkened while
-    // scrubbing below the full print, so only the current layer is shown at full brightness.
-    //
-    // How bright those layers are rendered, 1.0 = unchanged, 0.0 = black.
+    // Whether the layers the layer slider is not scrubbed to are rendered darkened while
+    // showing less than the full print, so only the inspected layer(s) are at full brightness.
+    // How bright those darkened layers are rendered, 1.0 = unchanged, 0.0 = black.
     //
     bool is_dim_previous_layers() const;
     void set_dim_previous_layers(bool value);

--- a/src/libvgcode/include/Viewer.hpp
+++ b/src/libvgcode/include/Viewer.hpp
@@ -95,8 +95,12 @@ public:
     // Whether the layers below the current top layer are rendered darkened while
     // scrubbing below the full print, so only the current layer is shown at full brightness.
     //
+    // How bright those layers are rendered, 1.0 = unchanged, 0.0 = black.
+    //
     bool is_dim_previous_layers() const;
     void set_dim_previous_layers(bool value);
+    float get_dim_previous_layers_brightness() const;
+    void set_dim_previous_layers_brightness(float value);
     //
     // Returns true if the given option is visible.
     //

--- a/src/libvgcode/include/Viewer.hpp
+++ b/src/libvgcode/include/Viewer.hpp
@@ -91,7 +91,7 @@ public:
     //
     void toggle_top_layer_only_view_range();
     //
-    // Dim previous layers (ORCA, ported from preFlight)
+    // Dim previous layers (ORCA)
     // Whether the layers the layer slider is not scrubbed to are rendered darkened while
     // showing less than the full print, so only the inspected layer(s) are at full brightness.
     // How bright those darkened layers are rendered, 1.0 = unchanged, 0.0 = black.

--- a/src/libvgcode/src/Settings.hpp
+++ b/src/libvgcode/src/Settings.hpp
@@ -20,7 +20,7 @@ struct Settings
 		ETimeMode time_mode{ ETimeMode::Normal };
 		bool top_layer_only_view_range{ false };
 		// ORCA: when enabled, every layer the layer slider is not scrubbed to is rendered
-		// darkened (keeping its color) while showing less than the full print (ported from preFlight)
+		// darkened (keeping its color) while showing less than the full print
 		bool dim_previous_layers{ false };
 		// ORCA: how bright those darkened layers are rendered, 1.0 = unchanged, 0.0 = black
 		float dim_previous_layers_brightness{ 0.4f };

--- a/src/libvgcode/src/Settings.hpp
+++ b/src/libvgcode/src/Settings.hpp
@@ -19,10 +19,10 @@ struct Settings
 		EViewType view_type{ EViewType::FeatureType };
 		ETimeMode time_mode{ ETimeMode::Normal };
 		bool top_layer_only_view_range{ false };
-		// ORCA: when enabled, all layers below the current top layer are rendered
-		// darkened (keeping their color) while scrubbing below the full print (ported from preFlight)
+		// ORCA: when enabled, every layer the layer slider is not scrubbed to is rendered
+		// darkened (keeping its color) while showing less than the full print (ported from preFlight)
 		bool dim_previous_layers{ false };
-		// ORCA: how bright those layers are rendered, 1.0 = unchanged, 0.0 = black
+		// ORCA: how bright those darkened layers are rendered, 1.0 = unchanged, 0.0 = black
 		float dim_previous_layers_brightness{ 0.4f };
 		bool spiral_vase_mode{ false };
 		//

--- a/src/libvgcode/src/Settings.hpp
+++ b/src/libvgcode/src/Settings.hpp
@@ -22,6 +22,8 @@ struct Settings
 		// ORCA: when enabled, all layers below the current top layer are rendered
 		// darkened (keeping their color) while scrubbing below the full print (ported from preFlight)
 		bool dim_previous_layers{ false };
+		// ORCA: how bright those layers are rendered, 1.0 = unchanged, 0.0 = black
+		float dim_previous_layers_brightness{ 0.4f };
 		bool spiral_vase_mode{ false };
 		//
 		// Required update flags

--- a/src/libvgcode/src/Viewer.cpp
+++ b/src/libvgcode/src/Viewer.cpp
@@ -82,6 +82,16 @@ void Viewer::set_dim_previous_layers(bool value)
     m_impl->set_dim_previous_layers(value);
 }
 
+float Viewer::get_dim_previous_layers_brightness() const
+{
+    return m_impl->get_dim_previous_layers_brightness();
+}
+
+void Viewer::set_dim_previous_layers_brightness(float value)
+{
+    m_impl->set_dim_previous_layers_brightness(value);
+}
+
 bool Viewer::is_option_visible(EOptionType type) const
 {
     return m_impl->is_option_visible(type);

--- a/src/libvgcode/src/ViewerImpl.cpp
+++ b/src/libvgcode/src/ViewerImpl.cpp
@@ -1245,9 +1245,9 @@ void ViewerImpl::update_colors_texture()
     const bool color_top_layer_only = m_view_range.get_full()[1] != m_view_range.get_visible()[1];
 
     // ORCA: when dim_previous_layers is enabled, darken every layer (keeping its color) except the
-    // one(s) the layer slider is being scrubbed to, so that only those are shown at full brightness
-    // (ported from preFlight). A slider thumb marks a layer as inspected only once it is moved away
-    // from its end of the print: the upper one while it is below the last layer (or while the moves
+    // one(s) the layer slider is being scrubbed to, so that only those are shown at full brightness.
+    // A slider thumb marks a layer as inspected only once it is moved away from
+    // its end of the print: the upper one while it is below the last layer (or while the moves
     // slider is not at the end of the layer), the lower one while it is above the first layer, so
     // trimming the print from the bottom lights up the lowest visible layer and using the slider as
     // a range lights up both ends. When neither thumb is moved the whole print is rendered normally.
@@ -1384,7 +1384,7 @@ void ViewerImpl::toggle_top_layer_only_view_range()
     update_colors_texture();
 }
 
-// ORCA: enable/disable darkening of the layers the layer slider is not scrubbed to (ported from preFlight)
+// ORCA: enable/disable darkening of the layers the layer slider is not scrubbed to
 void ViewerImpl::set_dim_previous_layers(bool value)
 {
     if (m_settings.dim_previous_layers == value)

--- a/src/libvgcode/src/ViewerImpl.cpp
+++ b/src/libvgcode/src/ViewerImpl.cpp
@@ -1244,15 +1244,20 @@ void ViewerImpl::update_colors_texture()
     const size_t top_layer_id = m_settings.top_layer_only_view_range ? m_layers.get_view_range()[1] : 0;
     const bool color_top_layer_only = m_view_range.get_full()[1] != m_view_range.get_visible()[1];
 
-    // ORCA: when dim_previous_layers is enabled, darken every layer below the current top layer
-    // (keeping its color) whenever we are not rendering the whole print, so that only the layer
-    // being scrubbed to is shown at full brightness (ported from preFlight). This shares
-    // top_layer_id with the greying path, so it only applies while in top-layer-only mode - that
-    // way the moves slider still animates normally across all layers when that mode is disabled.
-    const bool dim_previous_layers = m_settings.dim_previous_layers && !m_layers.empty();
-    const bool full_render = (m_layers.get_view_range()[0] == 0) &&
-                             (m_layers.get_view_range()[1] >= static_cast<uint32_t>(m_layers.count()) - 1) &&
-                             (m_view_range.get_visible()[1] == m_view_range.get_full()[1]);
+    // ORCA: when dim_previous_layers is enabled, darken every layer (keeping its color) except the
+    // one(s) the layer slider is being scrubbed to, so that only those are shown at full brightness
+    // (ported from preFlight). A slider thumb marks a layer as inspected only once it is moved away
+    // from its end of the print: the upper one while it is below the last layer (or while the moves
+    // slider is not at the end of the layer), the lower one while it is above the first layer, so
+    // trimming the print from the bottom lights up the lowest visible layer and using the slider as
+    // a range lights up both ends. When neither thumb is moved the whole print is rendered normally.
+    // Gated on top-layer-only mode, which the greying path below also keys off of, so that the moves
+    // slider still animates normally across all layers when that mode is disabled.
+    const Interval& layers_range = m_layers.get_view_range();
+    const bool inspecting_top_layer = layers_range[1] + 1 < m_layers.count() || color_top_layer_only;
+    const bool inspecting_bottom_layer = layers_range[0] > 0;
+    const bool dim_previous_layers = m_settings.dim_previous_layers && m_settings.top_layer_only_view_range &&
+                                     !m_layers.empty() && (inspecting_top_layer || inspecting_bottom_layer);
 
     // Based on current settings and slider position, we might want to render some
     // vertices as dark grey (or darkened, see above). Use either that or the normal color (from the cache).
@@ -1261,9 +1266,13 @@ void ViewerImpl::update_colors_texture()
     for (size_t i=0; i<m_vertices.size(); ++i) {
         const PathVertex& v = m_vertices[i];
         const bool keep_spiral_seam = m_settings.spiral_vase_mode && i == m_view_range.get_enabled()[0];
-        if (dim_previous_layers && !full_render && v.layer_id < top_layer_id && !keep_spiral_seam)
+        // ORCA: layers kept at full brightness by the dimming above are excluded from the greying below too
+        const bool inspected_layer = dim_previous_layers &&
+                                     ((inspecting_top_layer && v.layer_id == layers_range[1]) ||
+                                      (inspecting_bottom_layer && v.layer_id == layers_range[0]));
+        if (dim_previous_layers && !inspected_layer && !keep_spiral_seam)
             colors[i] = encode_color_dimmed(get_vertex_color(v), m_settings.dim_previous_layers_brightness);
-        else if (color_top_layer_only && v.layer_id < top_layer_id && !keep_spiral_seam)
+        else if (!inspected_layer && color_top_layer_only && v.layer_id < top_layer_id && !keep_spiral_seam)
             colors[i] = encode_color(DUMMY_COLOR);
         else
             colors[i] = m_vertices_colors[i];
@@ -1375,7 +1384,7 @@ void ViewerImpl::toggle_top_layer_only_view_range()
     update_colors_texture();
 }
 
-// ORCA: enable/disable darkening of the layers below the current top layer (ported from preFlight)
+// ORCA: enable/disable darkening of the layers the layer slider is not scrubbed to (ported from preFlight)
 void ViewerImpl::set_dim_previous_layers(bool value)
 {
     if (m_settings.dim_previous_layers == value)
@@ -1386,7 +1395,7 @@ void ViewerImpl::set_dim_previous_layers(bool value)
     m_settings.update_colors = true;
 }
 
-// ORCA: set how bright the layers below the current top layer are rendered, 1.0 = unchanged, 0.0 = black
+// ORCA: set how bright the darkened layers are rendered, 1.0 = unchanged, 0.0 = black
 void ViewerImpl::set_dim_previous_layers_brightness(float value)
 {
     value = std::clamp(value, 0.0f, 1.0f);

--- a/src/libvgcode/src/ViewerImpl.cpp
+++ b/src/libvgcode/src/ViewerImpl.cpp
@@ -1223,16 +1223,12 @@ static float encode_color(const Color& color) {
     return static_cast<float>(i_color);
 }
 
-// ORCA: how much the layers below the current top layer are darkened when
-// Settings::dim_previous_layers is enabled (ported from preFlight). 0.0 = no change, 1.0 = black.
-static constexpr float PREVIOUS_LAYER_DARKEN_FACTOR = 0.60f;
-
-// ORCA: returns the encoded color scaled towards black by 'factor', preserving its hue
-static float encode_color_darkened(const Color& color, float factor) {
-    const float keep = 1.0f - factor;
-    const int r = static_cast<int>(color[0] * keep);
-    const int g = static_cast<int>(color[1] * keep);
-    const int b = static_cast<int>(color[2] * keep);
+// ORCA: returns the encoded color scaled towards black by 'brightness', preserving its hue.
+// 1.0 = no change, 0.0 = black.
+static float encode_color_dimmed(const Color& color, float brightness) {
+    const int r = static_cast<int>(color[0] * brightness);
+    const int g = static_cast<int>(color[1] * brightness);
+    const int b = static_cast<int>(color[2] * brightness);
     const int i_color = r << 16 | g << 8 | b;
     return static_cast<float>(i_color);
 }
@@ -1266,7 +1262,7 @@ void ViewerImpl::update_colors_texture()
         const PathVertex& v = m_vertices[i];
         const bool keep_spiral_seam = m_settings.spiral_vase_mode && i == m_view_range.get_enabled()[0];
         if (dim_previous_layers && !full_render && v.layer_id < top_layer_id && !keep_spiral_seam)
-            colors[i] = encode_color_darkened(get_vertex_color(v), PREVIOUS_LAYER_DARKEN_FACTOR);
+            colors[i] = encode_color_dimmed(get_vertex_color(v), m_settings.dim_previous_layers_brightness);
         else if (color_top_layer_only && v.layer_id < top_layer_id && !keep_spiral_seam)
             colors[i] = encode_color(DUMMY_COLOR);
         else
@@ -1387,6 +1383,16 @@ void ViewerImpl::set_dim_previous_layers(bool value)
     m_settings.dim_previous_layers = value;
     // defer the actual color/texture rebuild to the next render(), when the GL context is current
     // (this may be toggled from the Preferences dialog, outside the canvas context)
+    m_settings.update_colors = true;
+}
+
+// ORCA: set how bright the layers below the current top layer are rendered, 1.0 = unchanged, 0.0 = black
+void ViewerImpl::set_dim_previous_layers_brightness(float value)
+{
+    value = std::clamp(value, 0.0f, 1.0f);
+    if (m_settings.dim_previous_layers_brightness == value)
+        return;
+    m_settings.dim_previous_layers_brightness = value;
     m_settings.update_colors = true;
 }
 

--- a/src/libvgcode/src/ViewerImpl.hpp
+++ b/src/libvgcode/src/ViewerImpl.hpp
@@ -85,7 +85,10 @@ public:
     bool is_top_layer_only_view_range() const { return m_settings.top_layer_only_view_range; }
     void toggle_top_layer_only_view_range();
 
-    // ORCA: darken layers below the current top layer while scrubbing (ported from preFlight)
+    // ORCA: darken every layer the layer slider is not scrubbed to, so that only the inspected
+    // one(s) - the top thumb's layer, the bottom thumb's layer, or both - stay at full
+    // brightness. dim_previous_layers_brightness sets how dark the rest go, 1.0 = unchanged,
+    // 0.0 = black
     bool is_dim_previous_layers() const { return m_settings.dim_previous_layers; }
     void set_dim_previous_layers(bool value);
     float get_dim_previous_layers_brightness() const { return m_settings.dim_previous_layers_brightness; }

--- a/src/libvgcode/src/ViewerImpl.hpp
+++ b/src/libvgcode/src/ViewerImpl.hpp
@@ -88,6 +88,8 @@ public:
     // ORCA: darken layers below the current top layer while scrubbing (ported from preFlight)
     bool is_dim_previous_layers() const { return m_settings.dim_previous_layers; }
     void set_dim_previous_layers(bool value);
+    float get_dim_previous_layers_brightness() const { return m_settings.dim_previous_layers_brightness; }
+    void set_dim_previous_layers_brightness(float value);
 
     bool is_spiral_vase_mode() const { return m_settings.spiral_vase_mode; }
 

--- a/src/slic3r/GUI/GCodeViewer.cpp
+++ b/src/slic3r/GUI/GCodeViewer.cpp
@@ -1134,7 +1134,7 @@ void GCodeViewer::load_as_gcode(const GCodeProcessorResult& gcode_result, const 
     if (current_top_layer_only != required_top_layer_only)
         m_viewer.toggle_top_layer_only_view_range();
 
-    // ORCA: darken layers below the current one while scrubbing the preview (ported from preFlight)
+    // ORCA: darken the layers the preview layer slider is not scrubbed to
     m_viewer.set_dim_previous_layers(get_app_config()->get_bool("preview_dim_previous_layers"));
     m_viewer.set_dim_previous_layers_brightness(0.01f * std::stoi(get_app_config()->get("preview_dim_previous_layers_brightness")));
 

--- a/src/slic3r/GUI/GCodeViewer.cpp
+++ b/src/slic3r/GUI/GCodeViewer.cpp
@@ -1136,6 +1136,7 @@ void GCodeViewer::load_as_gcode(const GCodeProcessorResult& gcode_result, const 
 
     // ORCA: darken layers below the current one while scrubbing the preview (ported from preFlight)
     m_viewer.set_dim_previous_layers(get_app_config()->get_bool("preview_dim_previous_layers"));
+    m_viewer.set_dim_previous_layers_brightness(0.01f * std::stoi(get_app_config()->get("preview_dim_previous_layers_brightness")));
 
     // avoid processing if called with the same gcode_result
     if (m_last_result_id == gcode_result.id && wxGetApp().is_editor()) {

--- a/src/slic3r/GUI/GCodeViewer.hpp
+++ b/src/slic3r/GUI/GCodeViewer.hpp
@@ -333,10 +333,10 @@ public:
 
     libvgcode::EViewType get_view_type() const { return m_viewer.get_view_type(); }
 
-    // ORCA: darken layers below the current top layer while scrubbing the preview (ported from preFlight)
+    // ORCA: darken the layers not scrubbed to while using the preview layer slider (ported from preFlight)
     void set_dim_previous_layers(bool value) { m_viewer.set_dim_previous_layers(value); }
     bool is_dim_previous_layers() const { return m_viewer.is_dim_previous_layers(); }
-    // ORCA: brightness of those layers, 1.0 = unchanged, 0.0 = black
+    // ORCA: brightness of those darkened layers, 1.0 = unchanged, 0.0 = black
     void set_dim_previous_layers_brightness(float value) { m_viewer.set_dim_previous_layers_brightness(value); }
     float get_dim_previous_layers_brightness() const { return m_viewer.get_dim_previous_layers_brightness(); }
 

--- a/src/slic3r/GUI/GCodeViewer.hpp
+++ b/src/slic3r/GUI/GCodeViewer.hpp
@@ -333,7 +333,7 @@ public:
 
     libvgcode::EViewType get_view_type() const { return m_viewer.get_view_type(); }
 
-    // ORCA: darken the layers not scrubbed to while using the preview layer slider (ported from preFlight)
+    // ORCA: darken the layers not scrubbed to while using the preview layer slider
     void set_dim_previous_layers(bool value) { m_viewer.set_dim_previous_layers(value); }
     bool is_dim_previous_layers() const { return m_viewer.is_dim_previous_layers(); }
     // ORCA: brightness of those darkened layers, 1.0 = unchanged, 0.0 = black

--- a/src/slic3r/GUI/GCodeViewer.hpp
+++ b/src/slic3r/GUI/GCodeViewer.hpp
@@ -336,6 +336,9 @@ public:
     // ORCA: darken layers below the current top layer while scrubbing the preview (ported from preFlight)
     void set_dim_previous_layers(bool value) { m_viewer.set_dim_previous_layers(value); }
     bool is_dim_previous_layers() const { return m_viewer.is_dim_previous_layers(); }
+    // ORCA: brightness of those layers, 1.0 = unchanged, 0.0 = black
+    void set_dim_previous_layers_brightness(float value) { m_viewer.set_dim_previous_layers_brightness(value); }
+    float get_dim_previous_layers_brightness() const { return m_viewer.get_dim_previous_layers_brightness(); }
 
     void set_layers_z_range(const std::array<unsigned int, 2>& layers_z_range);
 

--- a/src/slic3r/GUI/Preferences.cpp
+++ b/src/slic3r/GUI/Preferences.cpp
@@ -1056,7 +1056,7 @@ wxBoxSizer *PreferencesDialog::create_item_checkbox(wxString title, wxString too
                 wxGetApp().mainframe->m_webview->SendCloudProvidersInfo();
             }
         }
-        // ORCA: apply the preview dimming change immediately to the currently loaded preview (ported from preFlight)
+        // ORCA: apply the preview dimming change immediately to the currently loaded preview
         else if (param == "preview_dim_previous_layers") {
             if (m_dim_previous_layers_brightness_input)
                 m_dim_previous_layers_brightness_input->Enable(app_config->get_bool(param));

--- a/src/slic3r/GUI/Preferences.cpp
+++ b/src/slic3r/GUI/Preferences.cpp
@@ -1919,10 +1919,10 @@ void PreferencesDialog::create_items()
         "",
         _L("%"),
         _L("How brightly the dimmed layers are rendered when \"Dim lower layers\" is enabled.\n"
-           "100% leaves them fully illuminated, 0% renders them black."),
+           "99% is barely darkened, 0% renders them black. Capped at 99% because 100% would be the same as disabling the option."),
         "preview_dim_previous_layers_brightness",
         0,
-        100,
+        99,
         // ORCA: apply the new brightness immediately to the currently loaded preview
         [](int value) {
             if (Plater* plater = wxGetApp().plater()) {

--- a/src/slic3r/GUI/Preferences.cpp
+++ b/src/slic3r/GUI/Preferences.cpp
@@ -700,6 +700,12 @@ wxBoxSizer *PreferencesDialog::create_item_spinctrl(wxString title, wxString tit
     auto input = new SpinInput(m_parent, wxEmptyString, side_label, wxDefaultPosition, DESIGN_INPUT_SIZE, wxSP_ARROW_KEYS, min, max, stoi(app_config->get(param)));
     input->SetToolTip(tip);
 
+    // ORCA: this one is only meaningful while the dimming it controls is enabled
+    if (param == "preview_dim_previous_layers_brightness") {
+        m_dim_previous_layers_brightness_input = input;
+        input->Enable(app_config->get_bool("preview_dim_previous_layers"));
+    }
+
     m_sizer->Add(input, 0, wxALIGN_CENTER_VERTICAL);
 
     if(!title2.empty()){
@@ -1052,6 +1058,8 @@ wxBoxSizer *PreferencesDialog::create_item_checkbox(wxString title, wxString too
         }
         // ORCA: apply the preview dimming change immediately to the currently loaded preview (ported from preFlight)
         else if (param == "preview_dim_previous_layers") {
+            if (m_dim_previous_layers_brightness_input)
+                m_dim_previous_layers_brightness_input->Enable(app_config->get_bool(param));
             if (Plater* plater = wxGetApp().plater()) {
                 if (GLCanvas3D* canvas = plater->get_preview_canvas3D()) {
                     canvas->get_gcode_viewer().set_dim_previous_layers(app_config->get_bool(param));

--- a/src/slic3r/GUI/Preferences.cpp
+++ b/src/slic3r/GUI/Preferences.cpp
@@ -1915,10 +1915,10 @@ void PreferencesDialog::create_items()
     g_sizer->Add(item_dim_previous_layers);
 
     auto item_dim_previous_layers_brightness = create_item_spinctrl(
-        _L("Lower layer brightness"),
+        _L("Dimmed layer brightness"),
         "",
         _L("%"),
-        _L("How brightly the layers below the current one are rendered when \"Dim lower layers\" is enabled.\n"
+        _L("How brightly the dimmed layers are rendered when \"Dim lower layers\" is enabled.\n"
            "100% leaves them fully illuminated, 0% renders them black."),
         "preview_dim_previous_layers_brightness",
         0,

--- a/src/slic3r/GUI/Preferences.cpp
+++ b/src/slic3r/GUI/Preferences.cpp
@@ -1914,6 +1914,28 @@ void PreferencesDialog::create_items()
     );
     g_sizer->Add(item_dim_previous_layers);
 
+    auto item_dim_previous_layers_brightness = create_item_spinctrl(
+        _L("Lower layer brightness"),
+        "",
+        _L("%"),
+        _L("How brightly the layers below the current one are rendered when \"Dim lower layers\" is enabled.\n"
+           "100% leaves them fully illuminated, 0% renders them black."),
+        "preview_dim_previous_layers_brightness",
+        0,
+        100,
+        // ORCA: apply the new brightness immediately to the currently loaded preview
+        [](int value) {
+            if (Plater* plater = wxGetApp().plater()) {
+                if (GLCanvas3D* canvas = plater->get_preview_canvas3D()) {
+                    canvas->get_gcode_viewer().set_dim_previous_layers_brightness(0.01f * value);
+                    canvas->set_as_dirty();
+                    canvas->request_extra_frame();
+                }
+            }
+        }
+    );
+    g_sizer->Add(item_dim_previous_layers_brightness);
+
     g_sizer->AddSpacer(FromDIP(10));
     sizer_page->Add(g_sizer, 0, wxEXPAND);
 

--- a/src/slic3r/GUI/Preferences.hpp
+++ b/src/slic3r/GUI/Preferences.hpp
@@ -13,6 +13,7 @@
 #include "Widgets/ComboBox.hpp"
 #include "Widgets/CheckBox.hpp"
 #include "Widgets/TextInput.hpp"
+#include "Widgets/SpinInput.hpp"
 #include "Widgets/TabCtrl.hpp"
 #include "slic3r/Utils/bambu_networking.hpp"
 
@@ -71,6 +72,7 @@ public:
     ::CheckBox * m_sync_user_preset_checkbox = {nullptr};
     ::CheckBox * m_bambu_cloud_checkbox      = {nullptr};
     ::TextInput *m_backup_interval_textinput = {nullptr};
+    ::SpinInput *m_dim_previous_layers_brightness_input = {nullptr};
     ::ComboBox * m_network_version_combo     = {nullptr};
     std::vector<NetworkLibraryVersionInfo> m_available_versions;
 


### PR DESCRIPTION
# Description

## Configurable brightness 

Replaces the hardcoded 40% brightness for dimmed previous layers with a user-configurable setting (0–100%).
The preference is stored in AppConfig, exposed via a spinctrl in the Preferences dialog, and applied live to the GCode preview without requiring a reload.

## Bottom inspected

When inspecting a layer from the bottom if the inspected section is not the bottom it will also be illuminated.

# Screenshots/Recordings/Graphs

<img width="1050" height="830" alt="imagen" src="https://github.com/user-attachments/assets/0511f440-4ef1-4347-b9c0-fc475bdb0865" />
<img width="796" height="788" alt="imagen" src="https://github.com/user-attachments/assets/48a4b01d-9532-447a-b210-877981679f90" />
<img width="796" height="788" alt="imagen" src="https://github.com/user-attachments/assets/19b1de25-497f-46e5-9a6e-849dec97b222" />
<img width="796" height="788" alt="imagen" src="https://github.com/user-attachments/assets/e6d68779-b05c-4279-91e9-2db9c60e6aba" />
<img width="796" height="788" alt="imagen" src="https://github.com/user-attachments/assets/0a579056-ac5d-4089-935c-f1e380ad25d5" />
<img width="796" height="788" alt="imagen" src="https://github.com/user-attachments/assets/c4850dc5-0d14-424e-998f-67c329a1f071" />

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
