### PR TITLE
Fix cannot type values to spin control if first digit of desired value is less then min value

### DIFF
--- a/src/slic3r/GUI/Field.cpp
+++ b/src/slic3r/GUI/Field.cpp
@@ -1334,27 +1334,7 @@ void SpinCtrl::BUILD() {
         if (!parsed || value < INT_MIN || value > INT_MAX)
             tmp_value = UNDEF_VALUE;
         else {
-            tmp_value = std::min(std::max((int)value, temp->GetMin()), temp->GetMax());
-#ifdef __WXOSX__
-#ifdef UNDEFINED__WXOSX__ // BBS
-            // Forcibly set the input value for SpinControl, since the value
-            // inserted from the keyboard or clipboard is not updated under OSX
-            SpinInput* spin = static_cast<SpinInput*>(window);
-            spin->SetValue(tmp_value);
-            // But in SetValue() is executed m_text_ctrl->SelectAll(), so
-            // discard this selection and set insertion point to the end of string
-            // temp->GetText()->SetInsertionPointEnd();
-#endif
-#else
-            // update value for the control only if it was changed in respect to the Min/max values
-            if (tmp_value != (int)value) {
-                temp->SetValue(tmp_value);
-                // But after SetValue() cursor ison the first position
-                // so put it to the end of string
-                // int pos = std::to_string(tmp_value).length();
-                // temp->SetSelection(pos, pos);
-            }
-#endif
+            tmp_value = (int)value;
         }
 	}), temp->GetTextCtrl()->GetId());
 
@@ -1375,6 +1355,10 @@ void SpinCtrl::propagate_value()
             on_kill_focus();
 	} else {
         auto ctrl = dynamic_cast<SpinInput *>(window);
+        tmp_value = std::min(std::max(tmp_value, ctrl->GetMin()), ctrl->GetMax());
+        if (ctrl->GetValue() != tmp_value)
+            ctrl->SetValue(tmp_value); // Clamp now when the user is done typing (kill focus / Enter / spin arrows)
+
         if (m_value.empty()
             ? !ctrl->GetTextCtrl()->GetLabel().IsEmpty()
             : ctrl->GetValue() != boost::any_cast<int>(m_value))


### PR DESCRIPTION
user cant put value 20 if controls min value is 3 because 2 (first digit of desired value) is less then controls min value

issue occurs because previous code tries to apply (clamp) value on each key input on control instead waiting for enter key or loose focus

before - trying put 20 as value. it puts "03" because clamps 2 as 3 and puts 0 to beginning

<img width="407" height="95" alt="orca-slicer_xX1e8l3rh7" src="https://github.com/user-attachments/assets/525d19b4-ac3c-4ffb-bfda-f8fe55b800b1" />

after - it apply value after pressing enter or loosing foucs
<img width="402" height="102" alt="orca-slicer_Z4a7LyQQVZ" src="https://github.com/user-attachments/assets/81d1ecff-d8ac-4277-a7ec-ebfda63d14f5" />
