### PR TITLE
Improve wipe tower preview and footprint handling

### DIFF
--- a/src/OrcaSlicer.cpp
+++ b/src/OrcaSlicer.cpp
@@ -1120,7 +1120,8 @@ static int construct_assemble_list(std::vector<assemble_plate_info_t> &assemble_
             }
         }
 
-        assemble_plate_info.filaments_count = used_filaments.size();
+        assemble_plate_info.filaments.assign(used_filaments.begin(), used_filaments.end());
+        assemble_plate_info.filaments_count = int(assemble_plate_info.filaments.size());
         assemble_plate_info.assemble_obj_list.clear();
         assemble_plate_info.assemble_obj_list.shrink_to_fit();
         assemble_plate_info.plate_params.clear();
@@ -3945,27 +3946,25 @@ int CLI::run(int argc, char **argv)
         plate_obj_size_info.wipe_x = wipe_x_option->get_at(plate_index);
         plate_obj_size_info.wipe_y = wipe_y_option->get_at(plate_index);
 
-        ConfigOptionFloat* width_option = print_config.option<ConfigOptionFloat>("prime_tower_width", true);
-        plate_obj_size_info.wipe_width = width_option->value;
+        const WipeTowerFootprint tower_footprint = plate->wipe_tower_preview(print_config, extruders, false, false).footprint;
+        const ConfigOptionFloat* rotation_opt = print_config.option<ConfigOptionFloat>("wipe_tower_rotation_angle");
+        const double rotation = rotation_opt != nullptr ? Geometry::deg2rad(rotation_opt->value) : 0.;
+        const Vec3d origin = plate->get_origin();
+        const Polygon outline = transformed_wipe_tower_outline(tower_footprint, rotation, Vec2d(origin.x() + plate_obj_size_info.wipe_x, origin.y() + plate_obj_size_info.wipe_y));
+        if (outline.points.empty()) {
+            plate_obj_size_info.has_wipe_tower = false;
+            return;
+        }
 
-        ConfigOptionFloat* brim_width_option = print_config.option<ConfigOptionFloat>("prime_tower_brim_width", true);
-        float brim_width = brim_width_option->value;
-        if (brim_width < 0) brim_width = WipeTower::get_auto_brim_by_height((float)plate_obj_size_info.obj_bbox.max.z());
+        const BoundingBox tower_bbox = get_extents(outline);
+        const Vec2d tower_min = unscale(tower_bbox.min);
+        const Vec2d tower_max = unscale(tower_bbox.max);
+        plate_obj_size_info.wipe_width = tower_max.x() - tower_min.x();
+        plate_obj_size_info.wipe_depth = tower_max.y() - tower_min.y();
 
-        ConfigOptionFloat* volume_option = print_config.option<ConfigOptionFloat>("prime_volume", true);
-        float wipe_volume = volume_option->value;
-
-        const ConfigOptionBool * wrapping_detection = print_config.option<ConfigOptionBool>("enable_wrapping_detection");
-        bool enable_wrapping = (wrapping_detection != nullptr) && wrapping_detection->value;
-
-        Vec3d wipe_tower_size = plate->estimate_wipe_tower_size(print_config, plate_obj_size_info.wipe_width, wipe_volume, new_extruder_count, filaments_cnt, false, enable_wrapping);
-        plate_obj_size_info.wipe_width = wipe_tower_size(0);
-        plate_obj_size_info.wipe_depth = wipe_tower_size(1);
-
-        Vec3d origin = plate->get_origin();
-        Vec3d start(origin(0) + plate_obj_size_info.wipe_x - brim_width, origin(1) + plate_obj_size_info.wipe_y, 0.f);
+        Vec3d start(tower_min.x(), tower_min.y(), 0.f);
         plate_obj_size_info.obj_bbox.merge(start);
-        Vec3d end(origin(0) + plate_obj_size_info.wipe_x + plate_obj_size_info.wipe_width + brim_width, origin(1) + plate_obj_size_info.wipe_y + plate_obj_size_info.wipe_depth, 0.f);
+        Vec3d end(tower_max.x(), tower_max.y(), 0.f);
         plate_obj_size_info.obj_bbox.merge(end);
         plate_obj_size_info.has_wipe_tower = true;
         BOOST_LOG_TRIVIAL(info) << boost::format("plate %1%, has wipe tower, wipe bbox: min {%2%, %3%, %4%} - max {%5%, %6%, %7%}")
@@ -4760,7 +4759,7 @@ int CLI::run(int argc, char **argv)
                     wipe_y_option->set_at(&wt_y_opt, i, 0);
 
                     Vec3d wipe_tower_size, wipe_tower_pos;
-                    ArrangePolygon wipe_tower_ap = cur_plate->estimate_wipe_tower_polygon(m_print_config, i, wipe_tower_pos, wipe_tower_size, new_extruder_count, assemble_plate.filaments_count, true);
+                    ArrangePolygon wipe_tower_ap = cur_plate->estimate_wipe_tower_polygon(m_print_config, i, wipe_tower_pos, wipe_tower_size, assemble_plate.filaments, true);
 
                     //update the new wp position
                     wt_x_opt.value = wipe_tower_pos(0);
@@ -5018,8 +5017,6 @@ int CLI::run(int argc, char **argv)
                     {
                         //prepare the wipe tower
                         int plate_count = partplate_list.get_plate_count();
-                        int extruder_size = used_filament_set.size();
-
                         auto printer_structure_opt = m_print_config.option<ConfigOptionEnum<PrinterStructure>>("printer_structure");
                         const float tower_brim_width      = m_print_config.option<ConfigOptionFloat>("prime_tower_width", true)->value;
                         const float tower_margin          = WIPE_TOWER_MARGIN + tower_brim_width;
@@ -5058,7 +5055,8 @@ int CLI::run(int argc, char **argv)
                             }
 
                             Vec3d wipe_tower_size, wipe_tower_pos;
-                            ArrangePolygon wipe_tower_ap = partplate_list.get_plate(plate_index_valid)->estimate_wipe_tower_polygon(m_print_config, plate_index_valid, wipe_tower_pos, wipe_tower_size, new_extruder_count, extruder_size, true);
+                            const std::vector<int> tower_filaments(used_filament_set.begin(), used_filament_set.end());
+                            ArrangePolygon wipe_tower_ap = partplate_list.get_plate(plate_index_valid)->estimate_wipe_tower_polygon(m_print_config, plate_index_valid, wipe_tower_pos, wipe_tower_size, tower_filaments, true);
 
                             //update the new wp position
                             if (bedid < plate_count) {
@@ -5134,17 +5132,20 @@ int CLI::run(int argc, char **argv)
                             x = dynamic_cast<const ConfigOptionFloats *>(m_print_config.option("wipe_tower_x"))->get_at(plate_to_slice-1);
                             y = dynamic_cast<const ConfigOptionFloats *>(m_print_config.option("wipe_tower_y"))->get_at(plate_to_slice-1);
                         }
-                        float w = dynamic_cast<const ConfigOptionFloat *>(m_print_config.option("prime_tower_width"))->value;
                         float a = dynamic_cast<const ConfigOptionFloat *>(m_print_config.option("wipe_tower_rotation_angle"))->value;
-                        float v = dynamic_cast<const ConfigOptionFloat *>(m_print_config.option("prime_volume"))->value;
-                        unsigned int filaments_cnt = plate_data_src[plate_to_slice-1]->slice_filaments_info.size();
-                        if ((filaments_cnt == 0) || need_skip)
-                        {
-                            // slice filaments info invalid
-                            std::vector<int> extruders = cur_plate->get_extruders_under_cli(true, m_print_config);
-                            filaments_cnt = extruders.size();
-                            BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << boost::format("arrange: slice filaments info invalid or need_skip, get from partplate: filament_count %1%")%filaments_cnt;
+                        // Prefer the current model/config mapping. Saved slice filament IDs may
+                        // be stale after CLI filament remapping or object filtering.
+                        std::vector<int> tower_filaments =
+                            cur_plate->get_extruders_under_cli(true, m_print_config);
+                        if (tower_filaments.empty()) {
+                            tower_filaments.reserve(plate_data_src[plate_to_slice-1]->slice_filaments_info.size());
+                            for (const FilamentInfo& filament : plate_data_src[plate_to_slice-1]->slice_filaments_info)
+                                tower_filaments.emplace_back(filament.id + 1);
+                            BOOST_LOG_TRIVIAL(info) << __FUNCTION__
+                                << boost::format("arrange: no current filament mapping, use saved slice info: filament_count %1%")
+                                    % tower_filaments.size();
                         }
+                        const size_t filaments_cnt = tower_filaments.size();
 
                         if ((filaments_cnt <= 1) && !is_smooth_timelapse && (!enable_wrapping_detect || current_wrapping_exclude_area.empty()))
                         {
@@ -5152,75 +5153,51 @@ int CLI::run(int argc, char **argv)
                         }
                         else
                         {
-                            float layer_height = 0.2;
-                            ConfigOption* layer_height_opt = m_print_config.option("layer_height");
-                            if (layer_height_opt)
-                                layer_height = layer_height_opt->getFloat();
+                            const WipeTowerFootprint tower_footprint = cur_plate->wipe_tower_preview(m_print_config, tower_filaments, false, false).footprint;
+                            if (tower_footprint.empty()) {
+                                BOOST_LOG_TRIVIAL(warning) << __FUNCTION__
+                                    << ": unable to build the wipe tower footprint before arrange.";
+                            } else {
+                                Polygon local_outline = transformed_wipe_tower_outline(
+                                    tower_footprint, Geometry::deg2rad(a));
+                                int plate_width, plate_depth, plate_height;
+                                partplate_list.get_plate_size(plate_width, plate_depth, plate_height);
+                                const float margin = 15.f;
+                                const BoundingBoxf local_bbox =
+                                    rotated_wipe_tower_bbox(tower_footprint, Geometry::deg2rad(a));
+                                const Vec2d clamped_position = clamp_wipe_tower_position(
+                                    local_bbox, BoundingBoxf(Vec2d::Zero(), Vec2d(plate_width, plate_depth)),
+                                    Vec2d(x, y), margin);
+                                x = float(clamped_position.x());
+                                y = float(clamped_position.y());
 
-                            //float depth = v * (filaments_cnt - 1) / (layer_height * w);
+                                BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << boost::format("arrange wipe_tower: x=%1%, y=%2%, width=%3%, depth=%4%, angle=%5%, prime_volume=%6%, filaments_cnt=%7%, layer_height=%8%, plate_width=%9%, plate_depth=%10%")
+                                                                %x %y %local_bbox.size().x() %local_bbox.size().y() %a
+                                                                %m_print_config.opt_float("prime_volume") %filaments_cnt
+                                                                %m_print_config.opt_float("layer_height") %plate_width %plate_depth;
+                                //update wipe_tower_x and wipe_tower_y
+                                ConfigOptionFloat wt_x_opt(x);
+                                ConfigOptionFloat wt_y_opt(y);
+                                ConfigOptionFloats* wipe_x_option = m_print_config.option<ConfigOptionFloats>("wipe_tower_x", true);
+                                ConfigOptionFloats* wipe_y_option = m_print_config.option<ConfigOptionFloats>("wipe_tower_y", true);
 
-                            const ConfigOptionBool *wrapping_detection = m_print_config.option<ConfigOptionBool>("enable_wrapping_detection");
-                            bool   enable_wrapping    = (wrapping_detection != nullptr) && wrapping_detection->value;
+                                wipe_x_option->set_at(&wt_x_opt, plate_to_slice-1, 0);
+                                wipe_y_option->set_at(&wt_y_opt, plate_to_slice-1, 0);
 
-                            Vec3d wipe_tower_size = cur_plate->estimate_wipe_tower_size(m_print_config, w, v, new_extruder_count, filaments_cnt, false, enable_wrapping);
-                            Vec3d plate_origin = cur_plate->get_origin();
-                            int plate_width, plate_depth, plate_height;
-                            partplate_list.get_plate_size(plate_width, plate_depth, plate_height);
-                            float depth = wipe_tower_size(1);
-                            float margin = 15.f, wp_brim_width = 0.f;
-                            ConfigOption *wipe_tower_brim_width_opt = m_print_config.option("prime_tower_brim_width");
-                            if (wipe_tower_brim_width_opt ) {
-                                wp_brim_width = wipe_tower_brim_width_opt->getFloat();
-                                if (wp_brim_width < 0) wp_brim_width = WipeTower::get_auto_brim_by_height((float) wipe_tower_size.z());
-                                BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << boost::format("arrange wipe_tower: wp_brim_width %1%")%wp_brim_width;
+                                ArrangePolygon wipe_tower_ap;
+
+                                local_outline.translate(Point(scale_(x), scale_(y)));
+                                wipe_tower_ap.bed_idx = 0;
+                                wipe_tower_ap.setter = NULL; // do not move wipe tower
+
+                                wipe_tower_ap.poly.contour = std::move(local_outline);
+                                wipe_tower_ap.translation  = {scaled(0.f), scaled(0.f)};
+                                wipe_tower_ap.name = "WipeTower";
+                                wipe_tower_ap.is_virt_object = true;
+                                wipe_tower_ap.is_wipe_tower = true;
+                                ++wipe_tower_ap.priority;
+                                unselected.emplace_back(std::move(wipe_tower_ap));
                             }
-                            w = wipe_tower_size(0);
-
-                            BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << boost::format("arrange wipe_tower: x=%1%, y=%2%, width=%3%, depth=%4%, angle=%5%, prime_volume=%6%, filaments_cnt=%7%, layer_height=%8%, plate_width=%9%, plate_depth=%10%")
-                                                            %x %y %w %depth %a %v %filaments_cnt %layer_height %plate_width %plate_depth;
-                            if ((y + depth + margin + wp_brim_width) > (float)plate_depth) {
-                                y = (float)plate_depth - depth - margin - wp_brim_width;
-                                BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << boost::format("arrange wipe_tower: exceeds the border, change y to %1%, plate_depth=%2%")%y %plate_depth;
-                            }
-
-                            if ((x + w + margin + wp_brim_width) > (float)plate_width) {
-                                x = (float)plate_width - w - margin - wp_brim_width;
-                                BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << boost::format("arrange wipe_tower: exceeds the border, change x to %1%, plate_width=%2%")%y %plate_width;
-                            }
-                            if (x < margin) {
-                                x = margin;
-                            }
-                            if (y < margin) {
-                                y = margin;
-                            }
-                            //update wipe_tower_x and wipe_tower_y
-                            ConfigOptionFloat wt_x_opt(x);
-                            ConfigOptionFloat wt_y_opt(y);
-                            ConfigOptionFloats* wipe_x_option = m_print_config.option<ConfigOptionFloats>("wipe_tower_x", true);
-                            ConfigOptionFloats* wipe_y_option = m_print_config.option<ConfigOptionFloats>("wipe_tower_y", true);
-
-                            wipe_x_option->set_at(&wt_x_opt, plate_to_slice-1, 0);
-                            wipe_y_option->set_at(&wt_y_opt, plate_to_slice-1, 0);
-
-                            ArrangePolygon wipe_tower_ap;
-
-                            Polygon ap({
-                                {scaled(x - wp_brim_width), scaled(y - wp_brim_width)},
-                                {scaled(x + w + wp_brim_width), scaled(y - wp_brim_width)},
-                                {scaled(x + w + wp_brim_width), scaled(y + depth + wp_brim_width)},
-                                {scaled(x - wp_brim_width), scaled(y + depth + wp_brim_width)}
-                                });
-                            wipe_tower_ap.bed_idx = 0;
-                            wipe_tower_ap.setter = NULL; // do not move wipe tower
-
-                            wipe_tower_ap.poly.contour = std::move(ap);
-                            wipe_tower_ap.translation  = {scaled(0.f), scaled(0.f)};
-                            wipe_tower_ap.rotation     = a;
-                            wipe_tower_ap.name = "WipeTower";
-                            wipe_tower_ap.is_virt_object = true;
-                            wipe_tower_ap.is_wipe_tower = true;
-                            ++wipe_tower_ap.priority;
-                            unselected.emplace_back(std::move(wipe_tower_ap));
                         }
                     }
 

--- a/src/OrcaSlicer.hpp
+++ b/src/OrcaSlicer.hpp
@@ -67,6 +67,7 @@ typedef struct _assemble_plate_info {
     std::string         plate_name;
     bool                need_arrange {false};
     int                 filaments_count {0};
+    std::vector<int>    filaments;
 
     std::map<std::string, std::string> plate_params;
     std::vector<assemble_object_info_t> assemble_obj_list;

--- a/src/libslic3r/GCode/WipeTower.cpp
+++ b/src/libslic3r/GCode/WipeTower.cpp
@@ -1849,27 +1849,29 @@ WipeTower::Footprint WipeTower::make_conservative_footprint(const PrintConfig&  
     const float volume = prime_volume * float(transition_count);
     const float minimum_depth = get_limit_depth_by_height(height);
 
-    float body_width = width;
-    float body_depth = volume * extra_spacing / (effective_layer_height * width);
-    float planned_depth = std::max(body_depth, minimum_depth);
+    const float rectangular_depth = volume * extra_spacing / (effective_layer_height * width);
+    float planned_depth = std::max(rectangular_depth, minimum_depth);
+    Polygon body_outline;
     if (config.wipe_tower_wall_type.value == WipeTowerWallType::wtwRib) {
         const float volume_depth = std::sqrt(volume * extra_spacing / effective_layer_height);
         planned_depth = std::max(volume_depth, minimum_depth);
         const float rib_width =
             std::min(float(config.wipe_tower_rib_width.value), planned_depth / 2.f);
-        body_depth = rib_width / float(std::sqrt(2.)) + planned_depth +
-                     std::max(0.f, float(config.wipe_tower_extra_rib_length.value));
-        body_width = body_depth;
+        const float rib_length =
+            std::hypot(planned_depth, planned_depth) +
+            std::max(0.f, float(config.wipe_tower_extra_rib_length.value));
+        body_outline = rib_section(
+            planned_depth, planned_depth, rib_length, rib_width,
+            config.wipe_tower_fillet_wall.value);
     } else {
-        body_depth = planned_depth;
+        body_outline = Polygon({
+            Point::new_scale(0.f, 0.f),
+            Point::new_scale(width, 0.f),
+            Point::new_scale(width, planned_depth),
+            Point::new_scale(0.f, planned_depth)
+        });
     }
 
-    Polygon body_outline({
-        Point::new_scale(0.f, 0.f),
-        Point::new_scale(body_width, 0.f),
-        Point::new_scale(body_width, body_depth),
-        Point::new_scale(0.f, body_depth)
-    });
     const float configured_brim_width =
         config.prime_tower_brim_width.value < 0.f ?
             get_auto_brim_by_height(height) :

--- a/src/libslic3r/GCode/WipeTower.cpp
+++ b/src/libslic3r/GCode/WipeTower.cpp
@@ -12,6 +12,7 @@
 #include "BoundingBox.hpp"
 #include "ClipperUtils.hpp"
 #include "LocalesUtils.hpp"
+#include "PrintConfig.hpp"
 #include "Triangulation.hpp"
 
 
@@ -1689,6 +1690,195 @@ void WipeTower::set_extruder(size_t idx, const PrintConfig& config)
     m_filpar[idx].wipe_dist      = config.wipe_distance.get_at(idx);
 }
 
+WipeTowerPreviewMeshes make_wipe_tower_preview_meshes(const WipeTowerFootprint& footprint)
+{
+    if (footprint.empty() || footprint.height < EPSILON)
+        return {};
+
+    return {
+        WipeTower::its_make_rib_brim(footprint.body_outline, footprint.height),
+        WipeTower::its_make_rib_brim(footprint.outer_outline, WIPE_TOWER_PREVIEW_BRIM_HEIGHT)
+    };
+}
+
+Polygon transformed_wipe_tower_outline(
+    const WipeTowerFootprint& footprint, double rotation, const Vec2d& translation)
+{
+    Polygon outline = footprint.outer_outline;
+    if (outline.points.empty())
+        return outline;
+
+    outline.rotate(rotation);
+    outline.translate(Point::new_scale(translation.x(), translation.y()));
+    return outline;
+}
+
+BoundingBoxf rotated_wipe_tower_bbox(const WipeTowerFootprint& footprint, double rotation)
+{
+    const Polygon outline = transformed_wipe_tower_outline(footprint, rotation);
+    if (outline.points.empty())
+        return {};
+
+    const BoundingBox bbox = get_extents(outline);
+    return BoundingBoxf(unscale(bbox.min), unscale(bbox.max));
+}
+
+Vec2f local_wipe_tower_offset(const Vec2f& post_rotation_offset, double rotation)
+{
+    return Eigen::Rotation2Df(float(-rotation)) * post_rotation_offset;
+}
+
+Vec2d clamp_wipe_tower_position(
+    const BoundingBoxf& local_bbox, const BoundingBoxf& allowed_bbox,
+    const Vec2d& requested_position, double margin)
+{
+    const double min_x = allowed_bbox.min.x() + margin - local_bbox.min.x();
+    const double max_x = allowed_bbox.max.x() - margin - local_bbox.max.x();
+    const double min_y = allowed_bbox.min.y() + margin - local_bbox.min.y();
+    const double max_y = allowed_bbox.max.y() - margin - local_bbox.max.y();
+
+    return Vec2d(max_x < min_x ? min_x : std::clamp(requested_position.x(), min_x, max_x),
+                 max_y < min_y ? min_y : std::clamp(requested_position.y(), min_y, max_y));
+}
+
+std::vector<unsigned int> normalize_wipe_tower_preview_filaments(
+    size_t filament_count, const std::vector<unsigned int>& used_filaments, bool force_tower)
+{
+    std::vector<unsigned int> filaments;
+    filaments.reserve(used_filaments.size());
+    for (const unsigned int filament : used_filaments)
+        if (filament < filament_count)
+            filaments.emplace_back(filament);
+
+    std::sort(filaments.begin(), filaments.end());
+    filaments.erase(std::unique(filaments.begin(), filaments.end()), filaments.end());
+    if (filaments.empty() && force_tower && filament_count > 0)
+        filaments.emplace_back(0);
+    if (filaments.size() == 1 && !force_tower)
+        filaments.clear();
+    return filaments;
+}
+
+WipeTowerFootprint finalize_wipe_tower_footprint(
+    Polygon body_outline, Polygon outer_outline, float height, float brim_width,
+    WipeTowerFootprint::Accuracy accuracy, float planned_depth)
+{
+    WipeTowerFootprint footprint;
+    footprint.body_outline  = std::move(body_outline);
+    footprint.outer_outline = std::move(outer_outline);
+    footprint.height        = height;
+    footprint.brim_width    = brim_width;
+    footprint.accuracy      = accuracy;
+    footprint.planned_depth = planned_depth;
+
+    if (!footprint.outer_outline.points.empty()) {
+        const BoundingBox box = get_extents(footprint.outer_outline);
+        footprint.bbox  = BoundingBoxf(unscale(box.min), unscale(box.max));
+        footprint.width = float(footprint.bbox.size().x());
+        footprint.depth = float(footprint.bbox.size().y());
+    }
+    if (footprint.planned_depth <= EPSILON && !footprint.body_outline.points.empty()) {
+        const BoundingBox body_box = get_extents(footprint.body_outline);
+        footprint.planned_depth =
+            float(unscale<double>(body_box.max.y() - body_box.min.y()));
+    }
+    return footprint;
+}
+
+WipeTowerFootprint make_wipe_tower_footprint_with_brim(
+    Polygon body_outline, float height, float brim_width,
+    WipeTowerFootprint::Accuracy accuracy, float planned_depth)
+{
+    Polygon outer_outline = body_outline;
+    brim_width = std::max(0.f, brim_width);
+    if (brim_width > EPSILON) {
+        const Polygons expanded = offset(body_outline, scale_(brim_width));
+        if (!expanded.empty())
+            outer_outline = expanded.front();
+    }
+
+    return finalize_wipe_tower_footprint(
+        std::move(body_outline), std::move(outer_outline), height, brim_width,
+        accuracy, planned_depth);
+}
+
+WipeTower::Footprint WipeTower::make_conservative_footprint(const PrintConfig&               config,
+                                                             const std::vector<unsigned int>& used_filaments,
+                                                             float                            tower_height,
+                                                             float                            layer_height,
+                                                             bool                             force_tower)
+{
+    const size_t filament_count = config.filament_type.size();
+    if (filament_count == 0)
+        return {};
+
+    const std::vector<unsigned int> filaments =
+        normalize_wipe_tower_preview_filaments(filament_count, used_filaments, force_tower);
+    if (filaments.empty())
+        return {};
+
+    const float nozzle_diameter = config.nozzle_diameter.values.empty() ?
+                                      0.4f :
+                                      float(*std::max_element(config.nozzle_diameter.values.begin(),
+                                                              config.nozzle_diameter.values.end()));
+    const float spacing = std::max(0.01f, nozzle_diameter * 1.25f);
+    const float width = std::max(float(config.prime_tower_width.value), 4.f * spacing);
+    const float effective_layer_height = std::max(layer_height, 0.01f);
+    const float height = std::max(tower_height,
+                                  float(config.initial_layer_print_height.value) + effective_layer_height);
+
+    float prime_volume = config.prime_volume_mode.value == PrimeVolumeMode::pvmSaving ?
+                             15.f :
+                             float(config.prime_volume.value);
+    if (config.prime_volume_mode.value != PrimeVolumeMode::pvmSaving) {
+        for (const unsigned int filament : filaments) {
+            if (filament < config.filament_prime_volume.values.size())
+                prime_volume = std::max(prime_volume, float(config.filament_prime_volume.values[filament]));
+            if (filament < config.filament_prime_volume_nc.values.size())
+                prime_volume = std::max(prime_volume, float(config.filament_prime_volume_nc.values[filament]));
+        }
+    }
+
+    // Keep the original Type1 preview model: N - 1 changes for a single nozzle,
+    // one section per filament for a dual nozzle, and one section for a forced single-filament tower.
+    size_t transition_count =
+        config.nozzle_diameter.size() == 2 ? filaments.size() : filaments.size() - 1;
+    if (filaments.size() == 1 && force_tower)
+        transition_count = 1;
+    const float extra_spacing = std::max(1.f, float(config.prime_tower_infill_gap.value) / 100.f);
+    const float volume = prime_volume * float(transition_count);
+    const float minimum_depth = get_limit_depth_by_height(height);
+
+    float body_width = width;
+    float body_depth = volume * extra_spacing / (effective_layer_height * width);
+    float planned_depth = std::max(body_depth, minimum_depth);
+    if (config.wipe_tower_wall_type.value == WipeTowerWallType::wtwRib) {
+        const float volume_depth = std::sqrt(volume * extra_spacing / effective_layer_height);
+        planned_depth = std::max(volume_depth, minimum_depth);
+        const float rib_width =
+            std::min(float(config.wipe_tower_rib_width.value), planned_depth / 2.f);
+        body_depth = rib_width / float(std::sqrt(2.)) + planned_depth +
+                     std::max(0.f, float(config.wipe_tower_extra_rib_length.value));
+        body_width = body_depth;
+    } else {
+        body_depth = planned_depth;
+    }
+
+    Polygon body_outline({
+        Point::new_scale(0.f, 0.f),
+        Point::new_scale(body_width, 0.f),
+        Point::new_scale(body_width, body_depth),
+        Point::new_scale(0.f, body_depth)
+    });
+    const float configured_brim_width =
+        config.prime_tower_brim_width.value < 0.f ?
+            get_auto_brim_by_height(height) :
+            float(config.prime_tower_brim_width.value);
+    return make_wipe_tower_footprint_with_brim(
+        std::move(body_outline), height, configured_brim_width,
+        Footprint::Accuracy::Estimated, planned_depth);
+}
+
 
 
 // Returns gcode to prime the nozzles at the front edge of the print bed.
@@ -3354,6 +3544,7 @@ WipeTower::ToolChangeResult WipeTower::finish_layer_new(bool extrude_perimeter, 
     //}
     Polygon outer_wall;
     outer_wall = generate_support_wall_new(writer, wt_box, feedrate, first_layer, m_use_rib_wall, extrude_perimeter, m_use_gap_wall);
+    const Polygon first_layer_body_outline = first_layer ? outer_wall : Polygon{};
     if (extrude_perimeter) {
         Polyline shift_polyline = to_polyline(outer_wall);
         shift_polyline.translate(0, scaled(m_y_shift));
@@ -3396,6 +3587,21 @@ WipeTower::ToolChangeResult WipeTower::finish_layer_new(bool extrude_perimeter, 
             //m_wipe_tower_brim_width_real = wt_box.ld.x() - box.ld.x() + spacing / 2.f;
         }
         //wt_box = box;
+    }
+
+    if (first_layer && !outer_wall.points.empty()) {
+        Polygon body_outline  = first_layer_body_outline;
+        Polygon outer_outline = outer_wall;
+        if (m_use_rib_wall) {
+            const Vec2f local_offset = local_wipe_tower_offset(
+                m_rib_offset, double(m_wipe_tower_rotation_angle) * M_PI / 180.);
+            const Point rib_translation = Point::new_scale(local_offset);
+            body_outline.translate(rib_translation);
+            outer_outline.translate(rib_translation);
+        }
+        m_footprint = finalize_wipe_tower_footprint(
+            std::move(body_outline), std::move(outer_outline), m_wipe_tower_height,
+            m_wipe_tower_brim_width_real, Footprint::Accuracy::Exact, m_wipe_tower_depth);
     }
 
     if (extrude_perimeter || loops_num > 0) {
@@ -4224,6 +4430,7 @@ void WipeTower::generate_new(std::vector<std::vector<WipeTower::ToolChangeResult
 {
     if (m_plan.empty())
         return;
+    m_footprint = {};
     //m_extra_spacing = 1.f;
     m_wipe_tower_height = m_plan.back().z;//real wipe_tower_height
     plan_tower_new();

--- a/src/libslic3r/GCode/WipeTower.hpp
+++ b/src/libslic3r/GCode/WipeTower.hpp
@@ -10,20 +10,96 @@
 #include "libslic3r/Point.hpp"
 #include "libslic3r/Polygon.hpp"
 #include "libslic3r/Polyline.hpp"
+#include "libslic3r/BoundingBox.hpp"
 #include "libslic3r/TriangleMesh.hpp"
 #include <unordered_set>
 
 namespace Slic3r
 {
 
+inline constexpr float WIPE_TOWER_PREVIEW_BRIM_HEIGHT = 0.08f;
+
 class WipeTowerWriter;
 class PrintConfig;
 enum GCodeFlavor : unsigned char;
 
+struct WipeTowerFootprint
+{
+    // Tower-local XY before rotation and placement. Polygons are scaled; other values are in mm.
+    enum class Accuracy {
+        Estimated, // Conservative pre-slice outline.
+        Exact      // Outline captured from the generated first layer.
+    };
+
+    // Outlines bound path centerlines, not the full extruded bead width.
+    // First-layer body, including ribs/cone walls but excluding brim.
+    Polygon      body_outline;
+    // Complete first-layer outline, including generated brim.
+    Polygon      outer_outline;
+    // Unrotated AABB of outer_outline; undefined when empty.
+    BoundingBoxf bbox;
+    // bbox extents, including body features and brim.
+    float        width      = 0.f;
+    float        depth      = 0.f;
+    // Planned rectangular depth, excluding brim and rib/cone extensions.
+    float        planned_depth = 0.f;
+    // Preview Z extent.
+    float        height     = 0.f;
+    // Brim expansion represented by outer_outline.
+    float        brim_width = 0.f;
+    Accuracy     accuracy   = Accuracy::Estimated;
+
+    bool empty() const { return outer_outline.points.empty(); }
+};
+
+struct WipeTowerPreviewMeshes
+{
+    TriangleMesh body;
+    TriangleMesh brim;
+};
+
+// Origin of the 3D preview mesh; independent of footprint accuracy.
+enum class WipeTowerPreviewSource {
+    None,
+    Generated, // Extruded from the selected footprint.
+    Sliced     // Produced by wipe tower slicing.
+};
+
+// Extrudes separate display-only body and brim meshes from a footprint.
+WipeTowerPreviewMeshes make_wipe_tower_preview_meshes(const WipeTowerFootprint& footprint);
+
+// Transforms the outer outline to print coordinates; rotation is in radians.
+Polygon transformed_wipe_tower_outline(const WipeTowerFootprint& footprint, double rotation,
+                                        const Vec2d& translation = Vec2d::Zero());
+
+// AABB in mm of the rotated outer outline, without placement translation.
+BoundingBoxf rotated_wipe_tower_bbox(const WipeTowerFootprint& footprint, double rotation);
+
+// Converts a post-rotation G-code offset to tower-local coordinates.
+Vec2f local_wipe_tower_offset(const Vec2f& post_rotation_offset, double rotation);
+
+// Clamps the tower origin so local_bbox remains inside allowed_bbox; all values are in mm.
+Vec2d clamp_wipe_tower_position(const BoundingBoxf& local_bbox, const BoundingBoxf& allowed_bbox,
+                                const Vec2d& requested_position, double margin);
+
+// Normalizes filament ids for conservative preview planning.
+std::vector<unsigned int> normalize_wipe_tower_preview_filaments(
+    size_t filament_count, const std::vector<unsigned int>& used_filaments, bool force_tower);
+
+WipeTowerFootprint finalize_wipe_tower_footprint(
+    Polygon body_outline, Polygon outer_outline, float height, float brim_width,
+    WipeTowerFootprint::Accuracy accuracy, float planned_depth = 0.f);
+
+// Adds a fixed brim offset to an estimated body outline and completes its metadata.
+WipeTowerFootprint make_wipe_tower_footprint_with_brim(
+    Polygon body_outline, float height, float brim_width,
+    WipeTowerFootprint::Accuracy accuracy, float planned_depth = 0.f);
 
 class WipeTower
 {
 public:
+    using Footprint = WipeTowerFootprint;
+
     friend class WipeTowerWriter;
     static const std::string never_skip_tag() { return "_GCODE_WIPE_TOWER_NEVER_SKIP_TAG"; }
 
@@ -180,6 +256,12 @@ public:
 	// BBS: add partplate logic
 	WipeTower(const PrintConfig& config, int plate_idx, Vec3d plate_origin, size_t initial_tool, const float wipe_tower_height, const std::vector<unsigned int>& slice_used_filaments);
 
+    static Footprint make_conservative_footprint(const PrintConfig&               config,
+                                                 const std::vector<unsigned int>& used_filaments,
+                                                 float                            tower_height,
+                                                 float                            layer_height,
+                                                 bool                             force_tower);
+
 
 	// Set the extruder properties.
     void set_extruder(size_t idx, const PrintConfig& config);
@@ -198,6 +280,7 @@ public:
     Polygon generate_rib_polygon(const box_coordinates &wt_box);
     float get_depth() const { return m_wipe_tower_depth; }
     float get_brim_width() const { return m_wipe_tower_brim_width_real; }
+    const Footprint& footprint() const { return m_footprint; }
     BoundingBoxf get_bbx() const {
         if (m_outer_wall.empty()) return BoundingBoxf({Vec2d(0,0)});
         BoundingBox  box = get_extents(m_outer_wall.begin()->second);
@@ -469,6 +552,7 @@ private:
     bool               m_is_multi_extruder{false};
     bool               m_use_gap_wall{false};
     bool               m_use_rib_wall{false};
+    Footprint           m_footprint;
     float              m_rib_length=0.f;
     float              m_rib_width=0.f;
     float              m_extra_rib_length=0.f;

--- a/src/libslic3r/GCode/WipeTower2.cpp
+++ b/src/libslic3r/GCode/WipeTower2.cpp
@@ -2281,6 +2281,20 @@ WipeTower2::Footprint WipeTower2::make_conservative_footprint(const PrintConfig&
     return wipe_tower.m_footprint;
 }
 
+WipeTowerFootprint make_conservative_wipe_tower_footprint(WipeTowerType wipe_tower_type,
+                                                          const PrintConfig& config,
+                                                          const PrintRegionConfig& default_region_config,
+                                                          const std::vector<unsigned int>& used_filaments,
+                                                          float tower_height,
+                                                          float layer_height,
+                                                          bool force_tower)
+{
+    return wipe_tower_type == WipeTowerType::Type2 ?
+               WipeTower2::make_conservative_footprint(config, default_region_config, used_filaments, tower_height, layer_height,
+                                                       force_tower) :
+               WipeTower::make_conservative_footprint(config, used_filaments, tower_height, layer_height, force_tower);
+}
+
 // Appends a toolchange into m_plan and calculates neccessary depth of the corresponding box
 void WipeTower2::plan_toolchange(float z_par, float layer_height_par, unsigned int old_tool,
                                 unsigned int new_tool, float wipe_volume)

--- a/src/libslic3r/GCode/WipeTower2.cpp
+++ b/src/libslic3r/GCode/WipeTower2.cpp
@@ -2110,8 +2110,11 @@ WipeTower::ToolChangeResult WipeTower2::finish_layer()
         poly = generate_support_cone_wall(writer, wt_box, feedrate, infill_cone, spacing);
     } else {
         WipeTower::box_coordinates wt_box(Vec2f(0.f, 0.f), m_wipe_tower_width, m_layer_info->depth + m_perimeter_width);
-        poly = generate_support_rib_wall(writer, wt_box, feedrate, first_layer, m_wall_type == (int)wtwRib, true, false);
+        poly = generate_support_rib_wall(writer, wt_box, feedrate, m_wall_type == (int)wtwRib, true, false);
     }
+
+    const bool capture_footprint = is_first_layer();
+    const Polygon body_outline = capture_footprint ? poly : Polygon{};
 
     // brim (first layer only)
     if (first_layer) {
@@ -2139,10 +2142,12 @@ WipeTower::ToolChangeResult WipeTower2::finish_layer()
         // for skirt calculation and pass it to GLCanvas for precise preview box
         m_wipe_tower_brim_width_real = loops_num * spacing;
 
-        // Compute actual first-layer bounding box from the outermost brim polygon,
-        // matching how WipeTower::get_bbx() uses m_outer_wall extents.
-        BoundingBox first_layer_box = get_extents(poly);
-        m_first_layer_bbx = BoundingBoxf(unscale(first_layer_box.min), unscale(first_layer_box.max));
+        Footprint generated_footprint = finalize_wipe_tower_footprint(
+            body_outline, poly, m_wipe_tower_height, m_wipe_tower_brim_width_real,
+            Footprint::Accuracy::Exact, m_wipe_tower_depth);
+        m_first_layer_bbx = generated_footprint.bbox;
+        if (capture_footprint)
+            m_footprint = std::move(generated_footprint);
     }
 
     // Now prepare future wipe.
@@ -2212,6 +2217,70 @@ static float get_wipe_depth(float volume, float layer_height, float perimeter_wi
 	return (int(length_to_extrude / width) + 1) * perimeter_width * extra_spacing;
 }
 
+WipeTower2::Footprint WipeTower2::make_conservative_footprint(const PrintConfig&               config,
+                                                              const PrintRegionConfig&         default_region_config,
+                                                              const std::vector<unsigned int>& used_filaments,
+                                                              float                            tower_height,
+                                                              float                            layer_height,
+                                                              bool                             force_tower)
+{
+    const size_t filament_count = config.filament_type.values.size();
+    if (filament_count == 0)
+        return {};
+
+    const std::vector<unsigned int> filaments =
+        normalize_wipe_tower_preview_filaments(filament_count, used_filaments, force_tower);
+    if (filaments.empty())
+        return {};
+
+    // Conservative layout planning always uses the configured fixed prime volume.
+    // The wiping matrix is only needed while generating the real tower.
+    WipeTower2 wipe_tower(config, default_region_config, 0, Vec3d::Zero(), {}, filaments.front());
+    for (size_t filament = 0; filament < filament_count; ++filament)
+        wipe_tower.set_extruder(filament, config);
+
+    const float first_layer_height = std::max(float(config.initial_layer_print_height.value), 0.01f);
+    // Use the thinner relevant layer for a conservative fixed-volume estimate.
+    const float worst_layer_height = std::max(std::min(layer_height, first_layer_height), 0.01f);
+    const float worst_layer_z = first_layer_height + worst_layer_height;
+
+    // The real first layer establishes coordinate semantics. The following layer evaluates one
+    // representative change from every used filament, then retains the largest N - 1 sections.
+    wipe_tower.plan_toolchange(first_layer_height, first_layer_height, filaments.front(), filaments.front());
+    if (filaments.size() > 1) {
+        const float prime_volume = float(config.prime_volume.value);
+        for (size_t filament_idx = 0; filament_idx < filaments.size(); ++filament_idx) {
+            const unsigned int old_filament = filaments[filament_idx];
+            const unsigned int new_filament = filaments[(filament_idx + 1) % filaments.size()];
+            wipe_tower.plan_toolchange(
+                worst_layer_z, worst_layer_height, old_filament, new_filament, prime_volume);
+        }
+
+        // A layer visiting N filaments contains at most N - 1 changes. Evaluating every source
+        // filament still accounts for their individual ramming settings.
+        std::vector<WipeTowerInfo::ToolChange>& worst_layer_changes = wipe_tower.m_plan.back().tool_changes;
+        if (worst_layer_changes.size() == filaments.size()) {
+            const auto least_demanding = std::min_element(
+                worst_layer_changes.begin(), worst_layer_changes.end(),
+                [](const WipeTowerInfo::ToolChange& lhs, const WipeTowerInfo::ToolChange& rhs) {
+                    return lhs.required_depth < rhs.required_depth;
+                });
+            worst_layer_changes.erase(least_demanding);
+        }
+    }
+
+    const float top_z = std::max(tower_height, worst_layer_z);
+    wipe_tower.plan_toolchange(top_z, worst_layer_height, filaments.front(), filaments.front());
+    wipe_tower.plan_tower();
+    wipe_tower.m_rib_length = std::max(wipe_tower.m_rib_length,
+                                       std::hypot(wipe_tower.m_wipe_tower_depth, wipe_tower.m_wipe_tower_width));
+    wipe_tower.m_rib_length = std::max(0.f, wipe_tower.m_rib_length + wipe_tower.m_extra_rib_length);
+    wipe_tower.m_rib_width = std::min(wipe_tower.m_rib_width,
+                                      std::min(wipe_tower.m_wipe_tower_depth, wipe_tower.m_wipe_tower_width) / 2.f);
+    wipe_tower.m_footprint = wipe_tower.build_first_layer_footprint(Footprint::Accuracy::Estimated);
+    return wipe_tower.m_footprint;
+}
+
 // Appends a toolchange into m_plan and calculates neccessary depth of the corresponding box
 void WipeTower2::plan_toolchange(float z_par, float layer_height_par, unsigned int old_tool,
                                 unsigned int new_tool, float wipe_volume)
@@ -2278,6 +2347,32 @@ void WipeTower2::plan_tower()
 				m_plan[i].depth = this_layer_depth;
 		}
 	}
+}
+
+WipeTower2::Footprint WipeTower2::build_first_layer_footprint(Footprint::Accuracy accuracy) const
+{
+    if (m_first_layer_idx >= m_plan.size()) {
+        Footprint footprint;
+        footprint.accuracy = accuracy;
+        return footprint;
+    }
+
+    const WipeTowerInfo& first_layer = m_plan[m_first_layer_idx];
+    const WipeTower::box_coordinates wt_box(Vec2f::Zero(), m_wipe_tower_width, first_layer.depth + m_perimeter_width);
+    Polygon body_outline;
+    if (m_wall_type == int(wtwCone)) {
+        const double effective_z = m_no_sparse_layers ? first_layer.height : first_layer.z;
+        body_outline = build_cone_wall_geometry(wt_box, effective_z).polygon;
+    } else {
+        body_outline = build_rib_wall_polygon(wt_box, m_wall_type == int(wtwRib), first_layer.z, 0.f);
+    }
+
+    float configured_brim_width = m_wipe_tower_brim_width;
+    if (configured_brim_width < 0.f)
+        configured_brim_width = WipeTower::get_auto_brim_by_height(m_wipe_tower_height);
+    return make_wipe_tower_footprint_with_brim(
+        std::move(body_outline), m_wipe_tower_height, configured_brim_width,
+        accuracy, m_wipe_tower_depth);
 }
 
 void WipeTower2::save_on_last_wipe()
@@ -2462,65 +2557,54 @@ std::vector<std::pair<float, float>> WipeTower2::get_z_and_depth_pairs() const
     return out;
 }
 
-
-Polygon WipeTower2::generate_rib_polygon(const WipeTower::box_coordinates& wt_box)
+Polygon WipeTower2::build_rib_wall_polygon(
+    const WipeTower::box_coordinates& wt_box, bool rib_wall, float z, float y_shift) const
 {
+    Polygon rectangle = generate_rectange_polygon(wt_box.ld, wt_box.ru);
+    if (!rib_wall)
+        return rectangle;
 
-    auto get_current_layer_rib_len = [](float cur_height, float max_height, float max_len) -> float {
-        return std::abs(max_height - cur_height) / max_height * max_len;
-    };
-    coord_t diagonal_width = scaled(m_rib_width) / 2;
-    float   a = this->m_wipe_tower_width, b = this->m_wipe_tower_depth;
-    Line    line_1(Point::new_scale(Vec2f{0, 0}), Point::new_scale(Vec2f{a, b}));
-    Line    line_2(Point::new_scale(Vec2f{a, 0}), Point::new_scale(Vec2f{0, b}));
-    float   diagonal_extra_length = std::max(0.f, m_rib_length - (float) unscaled(line_1.length())) / 2.f;
-    diagonal_extra_length         = scaled(get_current_layer_rib_len(this->m_z_pos, this->m_wipe_tower_height, diagonal_extra_length));
-    Point y_shift{0, scaled(this->m_y_shift)};
+    const coord_t diagonal_width = scaled(m_rib_width) / 2;
+    Line line_1(Point::new_scale(Vec2f{0.f, 0.f}),
+                Point::new_scale(Vec2f{m_wipe_tower_width, m_wipe_tower_depth}));
+    Line line_2(Point::new_scale(Vec2f{m_wipe_tower_width, 0.f}),
+                Point::new_scale(Vec2f{0.f, m_wipe_tower_depth}));
+    const float max_extra_length =
+        std::max(0.f, m_rib_length - float(unscaled(line_1.length()))) / 2.f;
+    const float layer_extra_length =
+        m_wipe_tower_height > EPSILON ?
+            std::abs(m_wipe_tower_height - z) / m_wipe_tower_height * max_extra_length :
+            0.f;
+    const Point shift{0, scaled(y_shift)};
 
-    line_1.extend(double(diagonal_extra_length));
-    line_2.extend(double(diagonal_extra_length));
-    line_1.translate(-y_shift);
-    line_2.translate(-y_shift);
+    line_1.extend(double(scaled(layer_extra_length)));
+    line_2.extend(double(scaled(layer_extra_length)));
+    line_1.translate(-shift);
+    line_2.translate(-shift);
 
-    Polygon poly_1 = generate_rectange(line_1, diagonal_width);
-    Polygon poly_2 = generate_rectange(line_2, diagonal_width);
-    Polygon poly;
-    poly.points.push_back(Point::new_scale(wt_box.ld));
-    poly.points.push_back(Point::new_scale(wt_box.rd));
-    poly.points.push_back(Point::new_scale(wt_box.ru));
-    poly.points.push_back(Point::new_scale(wt_box.lu));
-
-    Polygons p_1_2 = union_({poly_1, poly_2, poly});
-    // Polygon            res_poly = p_1_2.front();
-    // for (auto &p : res_poly.points) res.push_back(unscale(p).cast<float>());
-    /*if (p_1_2.front().points.size() != 16)
-        std::cout << "error " << std::endl;*/
-    return p_1_2.front();
-};
+    Polygon wall_polygon =
+        union_({generate_rectange(line_1, diagonal_width),
+                generate_rectange(line_2, diagonal_width),
+                rectangle}).front();
+    if (m_used_fillet) {
+        wall_polygon = rounding_polygon(wall_polygon);
+        wall_polygon = union_({wall_polygon, rectangle}).front();
+    }
+    return wall_polygon;
+}
 
 Polygon WipeTower2::generate_support_rib_wall(WipeTowerWriter2&                 writer,
                                               const WipeTower::box_coordinates& wt_box,
                                              double                 feedrate,
-                                             bool                   first_layer,
                                              bool                   rib_wall,
                                              bool                   extrude_perimeter,
                                              bool                   skip_points)
 {
-
     float     retract_length = m_filpar[m_current_tool].retract_length;
     float     retract_speed  = m_filpar[m_current_tool].retract_speed * 60;
-    Polygon   wall_polygon   = rib_wall ? generate_rib_polygon(wt_box) : generate_rectange_polygon(wt_box.ld, wt_box.ru);
+    Polygon   wall_polygon   = build_rib_wall_polygon(wt_box, rib_wall, m_z_pos, m_y_shift);
     Polylines result_wall;
     Polygon   insert_skip_polygon;
-    if (m_used_fillet) {
-        if (!rib_wall && m_y_shift > EPSILON) // do nothing because the fillet will cause it to be suspended.
-        {
-        } else {
-            wall_polygon           = rib_wall ? rounding_polygon(wall_polygon) : wall_polygon; // rectangle_wall do nothing
-            Polygon wt_box_polygon = generate_rectange_polygon(wt_box.ld, wt_box.ru);
-            wall_polygon           = union_({wall_polygon, wt_box_polygon}).front();
-        }
-    }
     if (!extrude_perimeter)
         return wall_polygon;
 
@@ -2541,43 +2625,72 @@ Polygon WipeTower2::generate_support_rib_wall(WipeTowerWriter2&                 
 }
 
 
+WipeTower2::ConeWallGeometry WipeTower2::build_cone_wall_geometry(
+    const WipeTower::box_coordinates& wt_box, double z) const
+{
+    ConeWallGeometry geometry;
+    geometry.center = (wt_box.lu + wt_box.rd) / 2.f;
+
+    const double support_scale =
+        get_wipe_tower_cone_base(m_wipe_tower_width, m_wipe_tower_height,
+                                 m_wipe_tower_depth, m_wipe_tower_cone_angle).second;
+    const double radius =
+        std::tan(Geometry::deg2rad(m_wipe_tower_cone_angle / 2.f)) *
+        (m_wipe_tower_height - z);
+    const double depth = wt_box.lu.y() - wt_box.ld.y();
+
+    std::vector<ConeWallPoint>& points = geometry.boundary;
+    points.push_back({wt_box.ru, ConePointType::Corner});
+    if (radius > 0.5 * depth + 0.01) {
+        const double alpha_start = std::asin(0.5 * depth / radius);
+        bool first_arc_point = true;
+        for (double alpha = alpha_start; alpha < M_PI - alpha_start + 0.001;
+             alpha += (M_PI - 2. * alpha_start) / 40.) {
+            points.push_back({
+                Vec2f(geometry.center.x() + radius * std::cos(alpha) / support_scale,
+                      geometry.center.y() + radius * std::sin(alpha)),
+                first_arc_point ? ConePointType::ArcStart : ConePointType::Arc
+            });
+            first_arc_point = false;
+        }
+        points.back().type = ConePointType::ArcEnd;
+    }
+
+    points.push_back({wt_box.lu, ConePointType::Corner});
+    points.push_back({wt_box.ld, ConePointType::Corner});
+    const int last_upper_arc = int(points.size()) - 3;
+    for (int i = last_upper_arc; i > 0; --i) {
+        const ConePointType type =
+            i == last_upper_arc ? ConePointType::ArcStart :
+            i == 1              ? ConePointType::ArcEnd :
+                                  ConePointType::Arc;
+        points.push_back({
+            Vec2f(points[i].position.x(),
+                  2.f * geometry.center.y() - points[i].position.y()),
+            type
+        });
+    }
+    points.push_back({wt_box.rd, ConePointType::Corner});
+
+    geometry.polygon.points.reserve(points.size());
+    for (const ConeWallPoint& point : points)
+        geometry.polygon.points.push_back(Point::new_scale(point.position));
+    return geometry;
+}
+
 // This block creates the stabilization cone.
 // First define a lambda to draw the rectangle with stabilization.
 Polygon WipeTower2::generate_support_cone_wall(
-    WipeTowerWriter2& writer, const WipeTower::box_coordinates& wt_box, double feedrate, bool infill_cone, float spacing){
-
-    const auto [R, support_scale] = get_wipe_tower_cone_base(m_wipe_tower_width, m_wipe_tower_height, m_wipe_tower_depth,
-                                                             m_wipe_tower_cone_angle);
-
-    double z = m_no_sparse_layers ?
-                   (m_current_height + m_layer_info->height) :
-                   m_layer_info->z; // the former should actually work in both cases, but let's stay on the safe side (the 2.6.0 is close)
-
-    double r      = std::tan(Geometry::deg2rad(m_wipe_tower_cone_angle / 2.f)) * (m_wipe_tower_height - z);
-    Vec2f  center = (wt_box.lu + wt_box.rd) / 2.;
-    double w      = wt_box.lu.y() - wt_box.ld.y();
-    enum Type { Arc, Corner, ArcStart, ArcEnd };
-
-    // First generate vector of annotated point which form the boundary.
-    std::vector<std::pair<Vec2f, Type>> pts = {{wt_box.ru, Corner}};
-    if (double alpha_start = std::asin((0.5 * w) / r); !std::isnan(alpha_start) && r > 0.5 * w + 0.01) {
-        for (double alpha = alpha_start; alpha < M_PI - alpha_start + 0.001; alpha += (M_PI - 2 * alpha_start) / 40.)
-            pts.emplace_back(Vec2f(center.x() + r * std::cos(alpha) / support_scale, center.y() + r * std::sin(alpha)),
-                             alpha == alpha_start ? ArcStart : Arc);
-        pts.back().second = ArcEnd;
-    }
-    pts.emplace_back(wt_box.lu, Corner);
-    pts.emplace_back(wt_box.ld, Corner);
-    for (int i = int(pts.size()) - 3; i > 0; --i)
-        pts.emplace_back(Vec2f(pts[i].first.x(), 2 * center.y() - pts[i].first.y()), i == int(pts.size()) - 3 ? ArcStart :
-                                                                                     i == 1                   ? ArcEnd :
-                                                                                                                Arc);
-    pts.emplace_back(wt_box.rd, Corner);
-
-    // Create a Polygon from the points.
-    Polygon poly;
-    for (const auto& [pt, tag] : pts)
-        poly.points.push_back(Point::new_scale(pt));
+    WipeTowerWriter2& writer, const WipeTower::box_coordinates& wt_box,
+    double feedrate, bool infill_cone, float spacing)
+{
+    const double z = m_no_sparse_layers ?
+                         m_current_height + m_layer_info->height :
+                         m_layer_info->z;
+    const ConeWallGeometry geometry = build_cone_wall_geometry(wt_box, z);
+    const std::vector<ConeWallPoint>& points = geometry.boundary;
+    const Polygon& poly = geometry.polygon;
+    const Vec2f& center = geometry.center;
 
     // Prepare polygons to be filled by infill.
     Polylines polylines;
@@ -2614,38 +2727,39 @@ Polygon WipeTower2::generate_support_cone_wall(
     // Find the closest corner and travel to it.
     int    start_i  = 0;
     double min_dist = std::numeric_limits<double>::max();
-    for (int i = 0; i < int(pts.size()); ++i) {
-        if (pts[i].second == Corner) {
-            double dist = (pts[i].first - Vec2f(writer.x(), writer.y())).squaredNorm();
+    for (int i = 0; i < int(points.size()); ++i) {
+        if (points[i].type == ConePointType::Corner) {
+            double dist = (points[i].position - Vec2f(writer.x(), writer.y())).squaredNorm();
             if (dist < min_dist) {
                 min_dist = dist;
                 start_i  = i;
             }
         }
     }
-    writer.travel(pts[start_i].first);
+    writer.travel(points[start_i].position);
 
     // Now actually extrude the boundary (and possibly infill):
-    int i = start_i + 1 == int(pts.size()) ? 0 : start_i + 1;
+    int i = start_i + 1 == int(points.size()) ? 0 : start_i + 1;
     while (i != start_i) {
-        writer.extrude(pts[i].first, feedrate);
-        if (pts[i].second == ArcEnd) {
+        writer.extrude(points[i].position, feedrate);
+        if (points[i].type == ConePointType::ArcEnd) {
             // Extrude the infill.
             if (!polylines.empty()) {
                 // Extrude the infill and travel back to where we were.
-                bool mirror = ((pts[i].first.y() - center.y()) * (unscale(polylines.front().points.front()).y() - center.y())) < 0.;
+                bool mirror = ((points[i].position.y() - center.y()) *
+                               (unscale(polylines.front().points.front()).y() - center.y())) < 0.;
                 for (const Polyline& line : polylines) {
                     writer.travel(center - (mirror ? 1.f : -1.f) * (unscale(line.points.front()).cast<float>() - center));
                     for (size_t i = 0; i < line.points.size(); ++i)
                         writer.extrude(center - (mirror ? 1.f : -1.f) * (unscale(line.points[i]).cast<float>() - center));
                 }
-                writer.travel(pts[i].first);
+                writer.travel(points[i].position);
             }
         }
-        if (++i == int(pts.size()))
+        if (++i == int(points.size()))
             i = 0;
     }
-    writer.extrude(pts[start_i].first, feedrate);
+    writer.extrude(points[start_i].position, feedrate);
     return poly;
 }
 } // namespace Slic3r

--- a/src/libslic3r/GCode/WipeTower2.hpp
+++ b/src/libslic3r/GCode/WipeTower2.hpp
@@ -11,6 +11,7 @@
 
 #include "libslic3r/Point.hpp"
 #include "libslic3r/Polygon.hpp"
+#include "libslic3r/BoundingBox.hpp"
 #include "WipeTower.hpp"
 namespace Slic3r
 {
@@ -21,11 +22,19 @@ class PrintRegionConfig;
 class WipeTower2
 {
 public:
+    using Footprint = WipeTowerFootprint;
+
     static const std::string never_skip_tag() { return "_GCODE_WIPE_TOWER_NEVER_SKIP_TAG"; }
 	static std::pair<double, double> get_wipe_tower_cone_base(double width, double height, double depth, double angle_deg);
 	static std::vector<std::vector<float>> extract_wipe_volumes(const PrintConfig& config);
+    static Footprint make_conservative_footprint(const PrintConfig&              config,
+                                                 const PrintRegionConfig&        default_region_config,
+                                                 const std::vector<unsigned int>& used_filaments,
+                                                 float                           tower_height,
+                                                 float                           layer_height,
+                                                 bool                            force_tower);
 
-    
+
     // Construct ToolChangeResult from current state of WipeTower2 and WipeTowerWriter2.
     // WipeTowerWriter2 is moved from !
     WipeTower::ToolChangeResult construct_tcr(WipeTowerWriter2& writer,
@@ -69,6 +78,7 @@ public:
         const float brim = m_wipe_tower_brim_width_real;
         return BoundingBoxf(Vec2d(-brim, -brim), Vec2d(double(m_wipe_tower_width) + brim, double(m_wipe_tower_depth) + brim));
     }
+    const Footprint& footprint() const { return m_footprint; }
     // WT2 doesn't currently compute a rib-origin compensation like WipeTower (m_rib_offset),
     // so expose a zero offset for consistency purposes (to maintain API parity).
     Vec2f get_rib_offset() const { return Vec2f::Zero(); }
@@ -207,6 +217,7 @@ private:
     float  m_wipe_tower_brim_width      = 0.f; 	// Width of brim (mm) from config
     float  m_wipe_tower_brim_width_real = 0.f; 	// Width of brim (mm) after generation
     BoundingBoxf m_first_layer_bbx;              // Actual first-layer bounding box (incl. brim/ribs)
+    Footprint m_footprint;
 	float  m_wipe_tower_rotation_angle = 0.f; // Wipe tower rotation angle in degrees (with respect to x axis)
     float  m_internal_rotation  = 0.f;
 	float  m_y_shift			= 0.f;  // y shift passed to writer
@@ -290,6 +301,8 @@ private:
 	// Calculates depth for all layers and propagates them downwards
 	void plan_tower();
 
+    Footprint build_first_layer_footprint(Footprint::Accuracy accuracy) const;
+
     // Goes through m_plan, calculates border and finish_layer extrusions and subtracts them from last wipe
     void save_on_last_wipe();
 
@@ -359,7 +372,6 @@ private:
     Polygon generate_support_rib_wall(WipeTowerWriter2&                 writer,
                                       const WipeTower::box_coordinates& wt_box,
                                       double                 feedrate,
-                                      bool                   first_layer,
                                       bool                   rib_wall,
                                       bool                   extrude_perimeter,
                                       bool                   skip_points);
@@ -371,7 +383,28 @@ private:
 		bool infill_cone, 
 		float spacing);
 
-    Polygon generate_rib_polygon(const WipeTower::box_coordinates& wt_box);
+    enum class ConePointType {
+        Arc,
+        Corner,
+        ArcStart,
+        ArcEnd
+    };
+
+    struct ConeWallPoint {
+        Vec2f         position;
+        ConePointType type;
+    };
+
+    struct ConeWallGeometry {
+        std::vector<ConeWallPoint> boundary;
+        Polygon                    polygon;
+        Vec2f                      center = Vec2f::Zero();
+    };
+
+    Polygon build_rib_wall_polygon(const WipeTower::box_coordinates& wt_box, bool rib_wall,
+                                   float z, float y_shift) const;
+    ConeWallGeometry build_cone_wall_geometry(const WipeTower::box_coordinates& wt_box,
+                                              double z) const;
 };
 
 

--- a/src/libslic3r/GCode/WipeTower2.hpp
+++ b/src/libslic3r/GCode/WipeTower2.hpp
@@ -17,7 +17,17 @@ namespace Slic3r
 {
 
 class WipeTowerWriter2;
+class PrintConfig;
 class PrintRegionConfig;
+enum class WipeTowerType;
+
+WipeTowerFootprint make_conservative_wipe_tower_footprint(WipeTowerType wipe_tower_type,
+                                                          const PrintConfig& config,
+                                                          const PrintRegionConfig& default_region_config,
+                                                          const std::vector<unsigned int>& used_filaments,
+                                                          float tower_height,
+                                                          float layer_height,
+                                                          bool force_tower);
 
 class WipeTower2
 {

--- a/src/libslic3r/PresetBundle.cpp
+++ b/src/libslic3r/PresetBundle.cpp
@@ -653,7 +653,7 @@ Semver PresetBundle::get_vendor_profile_version(std::string vendor_name)
     return result_ver;
 }
 
-VendorType PresetBundle::get_current_vendor_type()
+VendorType PresetBundle::get_current_vendor_type() const
 {
     auto        t      = VendorType::Unknown;
     auto        config = &printers.get_edited_preset().config;
@@ -4318,6 +4318,12 @@ DynamicPrintConfig PresetBundle::full_fff_config(bool apply_extruder, std::optio
     add_if_some_non_empty(std::move(different_settings),            "different_settings_to_system");
     add_if_some_non_empty(std::move(print_compatible_printers),     "print_compatible_printers");
     out.option<ConfigOptionStrings>("extruder_ams_count", true)->values   = save_extruder_ams_count_to_string(this->extruder_ams_counts);
+
+    // Bambu profiles historically relied on Print::is_BBL_printer() to force the Type1
+    // implementation even though the generic option defaults to Type2. Resolve that policy
+    // while composing the effective config so preview and slicing consumers see one value.
+    if (is_bbl_vendor())
+        out.option<ConfigOptionEnum<WipeTowerType>>("wipe_tower_type", true)->value = WipeTowerType::Type1;
 
 	out.option<ConfigOptionEnumGeneric>("printer_technology", true)->value = ptFFF;
     return out;

--- a/src/libslic3r/PresetBundle.hpp
+++ b/src/libslic3r/PresetBundle.hpp
@@ -275,9 +275,9 @@ public:
     std::optional<FilamentBaseInfo> get_filament_by_filament_id(const std::string& filament_id, const std::string& printer_name = std::string()) const;
 
     // Orca: get vendor type
-    VendorType get_current_vendor_type();
+    VendorType get_current_vendor_type() const;
     // Vendor related handy functions
-    bool is_bbl_vendor() { return get_current_vendor_type() == VendorType::Marlin_BBL; }
+    bool is_bbl_vendor() const { return get_current_vendor_type() == VendorType::Marlin_BBL; }
 
     // Whether using bbl network for print upload
     bool use_bbl_network();

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -1021,34 +1021,21 @@ static StringObjectException layered_print_cleareance_valid(const Print &print, 
     const Vec3d         plate_origin = print.get_plate_origin();
     float               x            = config.wipe_tower_x.get_at(plate_index) + plate_origin(0);
     float               y            = config.wipe_tower_y.get_at(plate_index) + plate_origin(1);
-    float               width        = config.prime_tower_width.value;
     float               a            = config.wipe_tower_rotation_angle.value;
-    //float               v            = config.wiping_volume.value;
-
-    float        depth                     = print.wipe_tower_data(filaments_count).depth;
-    //float        brim_width                = print.wipe_tower_data(filaments_count).brim_width;
-
-    if (config.wipe_tower_wall_type.value == WipeTowerWallType::wtwRib)
-        width = depth;
 
     Polygons convex_hulls_temp;
     if (print.has_wipe_tower()) {
-        if (!print.is_step_done(psWipeTower)) {
-            Polygon wipe_tower_convex_hull;
-            wipe_tower_convex_hull.points.emplace_back(scale_(x), scale_(y));
-            wipe_tower_convex_hull.points.emplace_back(scale_(x + width), scale_(y));
-            wipe_tower_convex_hull.points.emplace_back(scale_(x + width), scale_(y + depth));
-            wipe_tower_convex_hull.points.emplace_back(scale_(x), scale_(y + depth));
-            wipe_tower_convex_hull.rotate(a);
-            convex_hulls_temp.push_back(wipe_tower_convex_hull);
-        } else {
-            //here, wipe_tower_polygon is not always convex.
-            Polygon wipe_tower_polygon;
-            if (print.wipe_tower_data().wipe_tower_mesh_data)
-                wipe_tower_polygon = print.wipe_tower_data().wipe_tower_mesh_data->bottom;
-            wipe_tower_polygon.translate(Point(scale_(x), scale_(y)));
-            convex_hulls_temp.push_back(wipe_tower_polygon);
+        const WipeTowerData& tower_data = print.wipe_tower_data(filaments_count);
+        Polygon wipe_tower_polygon = transformed_wipe_tower_outline(
+            tower_data.footprint, Geometry::deg2rad(a), Vec2d(x, y));
+        if (wipe_tower_polygon.points.empty() && tower_data.wipe_tower_mesh_data) {
+            // Preserve collision checking if a sliced tower cannot provide a footprint.
+            wipe_tower_polygon = tower_data.wipe_tower_mesh_data->bottom;
+            wipe_tower_polygon.rotate(Geometry::deg2rad(a));
+            wipe_tower_polygon.translate(Point::new_scale(x, y));
         }
+        if (!wipe_tower_polygon.points.empty())
+            convex_hulls_temp.push_back(std::move(wipe_tower_polygon));
     }
     if (!intersection(convex_hulls_other, convex_hulls_temp).empty()) {
         if (warning) {
@@ -3878,79 +3865,35 @@ const WipeTowerData &Print::wipe_tower_data(size_t filaments_cnt) const
 {
     // If the wipe tower wasn't created yet, make sure the depth and brim_width members are set to default.
     double max_height = 0;
+    double preview_layer_height = std::numeric_limits<double>::max();
     for (size_t obj_idx = 0; obj_idx < m_objects.size(); obj_idx++) {
         double object_z = (double) m_objects[obj_idx]->size().z();
         max_height      = std::max(unscale_(object_z), max_height);
+        const double object_layer_height = m_objects[obj_idx]->config().layer_height.value;
+        if (object_layer_height > EPSILON)
+            preview_layer_height = std::min(preview_layer_height, object_layer_height);
     }
     if (max_height < EPSILON) return m_wipe_tower_data;
+    if (preview_layer_height == std::numeric_limits<double>::max())
+        preview_layer_height = m_config.initial_layer_print_height.value;
 
-    double layer_height                  = 0.08f; // hard code layer height
-    layer_height        = m_objects.front()->config().layer_height.value;
-
-    auto   timelapse_type  = config().option<ConfigOptionEnum<TimelapseType>>("timelapse_type");
-    bool   need_wipe_tower = (timelapse_type ? (timelapse_type->value == TimelapseType::tlSmooth) : false) | (m_config.wipe_tower_wall_type.value == WipeTowerWallType::wtwRib);
-    double extra_spacing = config().option("prime_tower_infill_gap")->getFloat() / 100.;
-    double rib_width     = config().option("wipe_tower_rib_width")->getFloat();
-
-    double filament_change_volume = 0.;
-    {
-        std::vector<double> filament_change_lengths;
-        auto                filament_change_lengths_opt = config().option<ConfigOptionFloats>("filament_change_length");
-        if (filament_change_lengths_opt) filament_change_lengths = filament_change_lengths_opt->values;
-        double              length   = filament_change_lengths.empty() ? 0 : *std::max_element(filament_change_lengths.begin(), filament_change_lengths.end());
-        double              diameter = 1.75;
-        std::vector<double> diameters;
-        auto                filament_diameter_opt = config().option<ConfigOptionFloats>("filament_diameter");
-        if (filament_diameter_opt) diameters = filament_diameter_opt->values;
-        diameter               = diameters.empty() ? diameter : *std::max_element(diameters.begin(), diameters.end());
-        filament_change_volume = length * PI * diameter * diameter / 4.;
-    }
-
-
-    if (! is_step_done(psWipeTower) && filaments_cnt !=0) {
-        double wipe_volume  = m_config.prime_volume;
-        int filament_depth_count = m_config.nozzle_diameter.values.size() == 2 ? filaments_cnt : filaments_cnt - 1;
-        if (filaments_cnt == 1 && enable_timelapse_print()) filament_depth_count = 1;
-        double volume = wipe_volume * filament_depth_count;
-        if (m_config.nozzle_diameter.values.size() == 2) volume += filament_change_volume * (int) (filaments_cnt / 2);
-
-        if (m_config.wipe_tower_wall_type.value == WipeTowerWallType::wtwRib) {
-            double depth = std::sqrt(volume / layer_height * extra_spacing);
-            if (need_wipe_tower || filaments_cnt > 1) {
-                float min_wipe_tower_depth = WipeTower::get_limit_depth_by_height(max_height);
-                depth  = std::max((double) min_wipe_tower_depth, depth);
-                depth += rib_width / std::sqrt(2) + config().wipe_tower_extra_rib_length.value;
-                const_cast<Print *>(this)->m_wipe_tower_data.depth = depth;
-                const_cast<Print *>(this)->m_wipe_tower_data.brim_width = m_config.prime_tower_brim_width;
-            }
-        }
-        else {
-        double width        = m_config.prime_tower_width;
-        if (m_config.purge_in_prime_tower && m_config.single_extruder_multi_material) {
-            // Calculating depth should take into account currently set wiping volumes.
-            // For a long time, the initial preview would just use 900/width per toolchange (15mm on a 60mm wide tower)
-            // and it worked well enough. Let's try to do slightly better by accounting for the purging volumes.
-            std::vector<std::vector<float>> wipe_volumes = WipeTower2::extract_wipe_volumes(m_config);
-            std::vector<float>              max_wipe_volumes;
-            for (const std::vector<float> &v : wipe_volumes)
-                max_wipe_volumes.emplace_back(*std::max_element(v.begin(), v.end()));
-            float maximum = std::accumulate(max_wipe_volumes.begin(), max_wipe_volumes.end(), 0.f);
-            maximum       = maximum * filaments_cnt / max_wipe_volumes.size();
-            
-            // Orca: it's overshooting a bit, so let's reduce it a bit
-            maximum *= 0.6; 
-            const_cast<Print *>(this)->m_wipe_tower_data.depth = maximum / (layer_height * width);
-        } else {
-            double depth = volume / (layer_height * width) * extra_spacing;
-            if (need_wipe_tower || m_wipe_tower_data.depth > EPSILON) {
-                float min_wipe_tower_depth = WipeTower::get_limit_depth_by_height(max_height);
-                depth = std::max((double) min_wipe_tower_depth, depth);
-            }
-            const_cast<Print *>(this)->m_wipe_tower_data.depth = depth;
-        }
-        const_cast<Print *>(this)->m_wipe_tower_data.brim_width = m_config.prime_tower_brim_width;
-        }
-        if (m_config.prime_tower_brim_width < 0) const_cast<Print *>(this)->m_wipe_tower_data.brim_width = WipeTower::get_auto_brim_by_height(max_height);
+    if (!is_step_done(psWipeTower) && filaments_cnt != 0) {
+        const bool force_tower = enable_timelapse_print() ||
+                                 (m_config.enable_wrapping_detection.value && m_config.wrapping_exclude_area.values.size() > 2);
+        const std::vector<unsigned int> used_filaments = extruders(true);
+        WipeTowerFootprint footprint =
+            wipe_tower_type() == WipeTowerType::Type2 ?
+                WipeTower2::make_conservative_footprint(
+                    m_config, m_default_region_config, used_filaments,
+                    float(max_height), float(preview_layer_height), force_tower) :
+                WipeTower::make_conservative_footprint(
+                    m_config, used_filaments, float(max_height), float(preview_layer_height), force_tower);
+        WipeTowerData& data = const_cast<Print *>(this)->m_wipe_tower_data;
+        data.depth = footprint.planned_depth;
+        data.height = footprint.height;
+        data.brim_width = footprint.brim_width;
+        data.bbx = footprint.bbox;
+        data.construct_mesh(footprint);
     }
     return m_wipe_tower_data;
 }
@@ -4191,6 +4134,7 @@ void Print::_make_wipe_tower()
         m_wipe_tower_data.brim_width = wipe_tower.get_brim_width();
         m_wipe_tower_data.bbx = wipe_tower.get_bbx();
         m_wipe_tower_data.rib_offset = wipe_tower.get_rib_offset();
+        m_wipe_tower_data.footprint = wipe_tower.footprint();
 
         // Unload the current filament over the purge tower.
         coordf_t layer_height = m_objects.front()->config().layer_height.value;
@@ -4217,8 +4161,16 @@ void Print::_make_wipe_tower()
 
         m_wipe_tower_data.used_filament         = wipe_tower.get_used_filament();
         m_wipe_tower_data.number_of_toolchanges = wipe_tower.get_number_of_toolchanges();
-        m_wipe_tower_data.construct_mesh(wipe_tower.width(), wipe_tower.get_depth(), wipe_tower.get_height(), wipe_tower.get_brim_width(), config().wipe_tower_wall_type.value == WipeTowerWallType::wtwRib,
-                                         wipe_tower.get_rib_width(), wipe_tower.get_rib_length(), config().wipe_tower_fillet_wall.value);
+        if (!m_wipe_tower_data.footprint.empty()) {
+            m_wipe_tower_data.construct_mesh(m_wipe_tower_data.footprint);
+        } else {
+            m_wipe_tower_data.construct_mesh(
+                wipe_tower.width(), wipe_tower.get_depth(), wipe_tower.get_height(),
+                wipe_tower.get_brim_width(),
+                config().wipe_tower_wall_type.value == WipeTowerWallType::wtwRib,
+                wipe_tower.get_rib_width(), wipe_tower.get_rib_length(),
+                config().wipe_tower_fillet_wall.value);
+        }
         const Vec3d origin                      = this->get_plate_origin();
         m_fake_wipe_tower.rib_offset = wipe_tower.get_rib_offset();
         m_fake_wipe_tower.set_fake_extrusion_data(wipe_tower.position() + m_fake_wipe_tower.rib_offset, wipe_tower.width(), wipe_tower.get_height(), wipe_tower.get_layer_height(),
@@ -4332,11 +4284,7 @@ void Print::_make_wipe_tower()
 
         m_wipe_tower_data.used_filament         = wipe_tower.get_used_filament();
         m_wipe_tower_data.number_of_toolchanges = wipe_tower.get_number_of_toolchanges();
-        m_wipe_tower_data.construct_mesh(wipe_tower.width(), wipe_tower.get_depth(),
-                                         wipe_tower.get_wipe_tower_height(), wipe_tower.get_brim_width(),
-                                         config().wipe_tower_wall_type.value == WipeTowerWallType::wtwRib,
-                                         wipe_tower.get_rib_width(), wipe_tower.get_rib_length(),
-                                         config().wipe_tower_fillet_wall.value);
+        m_wipe_tower_data.construct_mesh(wipe_tower.footprint());
         const Vec3d origin                      = Vec3d::Zero();
         m_fake_wipe_tower.set_fake_extrusion_data(wipe_tower.position(), wipe_tower.width(), wipe_tower.get_wipe_tower_height(),
                                                   config().initial_layer_print_height, m_wipe_tower_data.depth,
@@ -5895,7 +5843,7 @@ ExtrusionLayers FakeWipeTower::getTrueExtrusionLayersFromWipeTower() const
 void WipeTowerData::construct_mesh(float width, float depth, float height, float brim_width, bool is_rib_wipe_tower, float rib_width, float rib_length,bool fillet_wall)
 {
     wipe_tower_mesh_data = WipeTowerMeshData{};
-    float first_layer_height=0.08; //brim height
+    float first_layer_height=WIPE_TOWER_PREVIEW_BRIM_HEIGHT; //brim height
     if (width < EPSILON || depth < EPSILON || height < EPSILON) return;
     if (!is_rib_wipe_tower || rib_length < EPSILON) {
         wipe_tower_mesh_data->real_wipe_tower_mesh = make_cube(width, depth, height);
@@ -5916,6 +5864,19 @@ void WipeTowerData::construct_mesh(float width, float depth, float height, float
     }
     //wipe_tower_mesh_data->real_wipe_tower_mesh.write_ascii("../wipe_tower_mesh.obj");
    //wipe_tower_mesh_data->real_brim_mesh.write_ascii("../wipe_tower_brim_mesh.obj");
+}
+
+void WipeTowerData::construct_mesh(const WipeTowerFootprint& tower_footprint)
+{
+    footprint = tower_footprint;
+    wipe_tower_mesh_data = WipeTowerMeshData{};
+    if (footprint.empty() || footprint.height < EPSILON)
+        return;
+
+    WipeTowerPreviewMeshes preview_meshes = make_wipe_tower_preview_meshes(footprint);
+    wipe_tower_mesh_data->bottom = footprint.outer_outline;
+    wipe_tower_mesh_data->real_wipe_tower_mesh = std::move(preview_meshes.body);
+    wipe_tower_mesh_data->real_brim_mesh = std::move(preview_meshes.brim);
 }
 
 } // namespace Slic3r

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -3881,13 +3881,9 @@ const WipeTowerData &Print::wipe_tower_data(size_t filaments_cnt) const
         const bool force_tower = enable_timelapse_print() ||
                                  (m_config.enable_wrapping_detection.value && m_config.wrapping_exclude_area.values.size() > 2);
         const std::vector<unsigned int> used_filaments = extruders(true);
-        WipeTowerFootprint footprint =
-            wipe_tower_type() == WipeTowerType::Type2 ?
-                WipeTower2::make_conservative_footprint(
-                    m_config, m_default_region_config, used_filaments,
-                    float(max_height), float(preview_layer_height), force_tower) :
-                WipeTower::make_conservative_footprint(
-                    m_config, used_filaments, float(max_height), float(preview_layer_height), force_tower);
+        WipeTowerFootprint footprint = make_conservative_wipe_tower_footprint(
+            wipe_tower_type(), m_config, m_default_region_config, used_filaments,
+            float(max_height), float(preview_layer_height), force_tower);
         WipeTowerData& data = const_cast<Print *>(this)->m_wipe_tower_data;
         data.depth = footprint.planned_depth;
         data.height = footprint.height;

--- a/src/libslic3r/Print.hpp
+++ b/src/libslic3r/Print.hpp
@@ -774,6 +774,7 @@ struct WipeTowerData
     float                                                 height;
     BoundingBoxf                                          bbx;//including brim
     Vec2f                                                 rib_offset;
+    WipeTowerFootprint                                   footprint;
     std::optional<WipeTowerMeshData>                      wipe_tower_mesh_data;//added rib_offset
     void clear() {
         priming.reset(nullptr);
@@ -784,10 +785,14 @@ struct WipeTowerData
         depth = 0.f;
         brim_width = 0.f;
         height = 0.f;
+        z_and_depth_pairs.clear();
+        bbx = BoundingBoxf();
         rib_offset = Vec2f::Zero();
+        footprint = {};
         wipe_tower_mesh_data  = std::nullopt;
     }
     void construct_mesh(float width, float depth, float height, float brim_width, bool is_rib_wipe_tower, float rib_width, float rib_length, bool fillet_wall);
+    void construct_mesh(const WipeTowerFootprint& footprint);
 
 private:
 	// Only allow the WipeTowerData to be instantiated internally by Print, 

--- a/src/slic3r/GUI/3DScene.cpp
+++ b/src/slic3r/GUI/3DScene.cpp
@@ -12,6 +12,7 @@
 #include "libslic3r/ExtrusionEntity.hpp"
 #include "libslic3r/ExtrusionEntityCollection.hpp"
 #include "libslic3r/Geometry.hpp"
+#include "libslic3r/GCode/WipeTower.hpp"
 #include "libslic3r/Print.hpp"
 #include "libslic3r/SLAPrint.hpp"
 #include "libslic3r/Slicing.hpp"
@@ -851,80 +852,90 @@ void GLVolumeCollection::load_object_auxiliary(
     }
 }
 
-int GLVolumeCollection::load_wipe_tower_preview(
-    int obj_idx, float pos_x, float pos_y, float width, float depth, float height,
-    float rotation_angle, bool size_unknown, float brim_width)
+static std::vector<TriangleMesh> make_wipe_tower_body_color_meshes(
+    const WipeTowerFootprint& footprint, size_t color_count)
 {
-    int plate_idx = obj_idx - 1000;
+    if (color_count <= 1 || footprint.empty())
+        return {};
 
-    if (depth < 0.01f)
-        return int(this->volumes.size() - 1);
-    if (height == 0.0f)
-        height = 0.1f;
+    const BoundingBox bbox = get_extents(footprint.body_outline);
+    const coord_t min_x = bbox.min.x();
+    const coord_t max_x = bbox.max.x();
+    const coord_t min_y = bbox.min.y();
+    const coord_t max_y = bbox.max.y();
+    const coord_t depth = max_y - min_y;
+    if (depth <= 0)
+        return {};
 
-    std::vector<ColorRGBA> extruder_colors = GUI::wxGetApp().plater()->get_extruders_colors();
-    std::vector<ColorRGBA> colors;
-    GUI::PartPlateList& ppl = GUI::wxGetApp().plater()->get_partplate_list();
-    std::vector<int> plate_extruders = ppl.get_plate(plate_idx)->get_extruders(true);
-    TriangleMesh wipe_tower_shell = make_cube(width, depth, height);
-    for (int extruder_id : plate_extruders) {
-        if (extruder_id <= extruder_colors.size())
-            colors.push_back(extruder_colors[extruder_id - 1]);
-        else
-            colors.push_back(extruder_colors[0]);
+    std::vector<TriangleMesh> color_meshes(color_count);
+    for (size_t color_idx = 0; color_idx < color_count; ++color_idx) {
+        const coord_t y0 = min_y + depth * coord_t(color_idx) / coord_t(color_count);
+        const coord_t y1 = min_y + depth * coord_t(color_idx + 1) / coord_t(color_count);
+        const Polygon band{{min_x, y0}, {max_x, y0}, {max_x, y1}, {min_x, y1}};
+
+        for (const Polygon& polygon : intersection(footprint.body_outline, band))
+            color_meshes[color_idx].merge(WipeTower::its_make_rib_brim(polygon, footprint.height));
     }
-
-    // Orca: make it transparent
-    for(auto& color : colors)
-        color.a(0.66f);
-    volumes.emplace_back(new GLWipeTowerVolume(colors));
-    GLWipeTowerVolume& v = *dynamic_cast<GLWipeTowerVolume*>(volumes.back());
-    v.model_per_colors.resize(colors.size());
-    for (int i = 0; i < colors.size(); i++) {
-        TriangleMesh color_part = make_cube(width, depth / colors.size(), height);
-        color_part.translate({ 0.f, depth * i / colors.size(), 0. });
-        v.model_per_colors[i].init_from(color_part);
-    }
-    v.model.init_from(wipe_tower_shell);
-    v.mesh_raycaster = std::make_unique<GUI::MeshRaycaster>(std::make_shared<const TriangleMesh>(wipe_tower_shell));
-    v.set_convex_hull(wipe_tower_shell);
-    v.set_volume_offset(Vec3d(pos_x, pos_y, 0.0));
-    v.set_volume_rotation(Vec3d(0., 0., (M_PI / 180.) * rotation_angle));
-    v.composite_id = GLVolume::CompositeID(obj_idx, 0, 0);
-    v.geometry_id.first = 0;
-    v.geometry_id.second = wipe_tower_instance_id().id + (obj_idx - 1000);
-    v.is_wipe_tower = true;
-    v.shader_outside_printer_detection_enabled = !size_unknown;
-    return int(volumes.size() - 1);
+    return color_meshes;
 }
 
-int GLVolumeCollection::load_real_wipe_tower_preview(
-    int obj_idx, float pos_x, float pos_y, const TriangleMesh& wt_mesh,const TriangleMesh &brim_mesh,bool render_brim, float rotation_angle, bool size_unknown,  bool opengl_initialized)
+int GLVolumeCollection::load_wipe_tower_preview(
+    int obj_idx, float pos_x, float pos_y, const TriangleMesh& tower_mesh, const TriangleMesh& brim_mesh,
+    float rotation_angle, WipeTowerPreviewSource source, const WipeTowerFootprint& footprint)
 {
-    int plate_idx = obj_idx - 1000;
-    if (wt_mesh.its.vertices.empty()) return int(this->volumes.size() - 1);
+    const int plate_idx = obj_idx - 1000;
+    if (tower_mesh.its.vertices.empty())
+        return -1;
 
-    std::vector<Slic3r::ColorRGBA> extruder_colors = GUI::wxGetApp().plater()->get_extruders_colors();
-    GUI::PartPlateList               &ppl              = GUI::wxGetApp().plater()->get_partplate_list();
-    std::vector<int>                  plate_extruders  = ppl.get_plate(plate_idx)->get_extruders(true);
-    std::vector<Slic3r::ColorRGBA>    colors;
-    if (!plate_extruders.empty()) {
-        if (plate_extruders.front() <= extruder_colors.size())
-            colors.push_back(extruder_colors[plate_extruders.front() - 1]);
-        else
-            colors.push_back(extruder_colors[0]);
+    const bool is_generated = source == WipeTowerPreviewSource::Generated;
+
+    const std::vector<ColorRGBA> extruder_colors = GUI::wxGetApp().plater()->get_extruders_colors();
+    const std::vector<int> plate_extruders =
+        GUI::wxGetApp().plater()->get_partplate_list().get_plate(plate_idx)->get_extruders(true);
+    if (extruder_colors.empty() || plate_extruders.empty())
+        return -1;
+
+    const auto filament_color = [&extruder_colors, is_generated](size_t filament_idx) {
+        ColorRGBA color = filament_idx < extruder_colors.size() ?
+                              extruder_colors[filament_idx] :
+                              extruder_colors.front();
+        if (is_generated)
+            color.a(0.66f);
+        return color;
+    };
+
+    const size_t body_color_count = is_generated ? plate_extruders.size() : 1;
+    std::vector<ColorRGBA> colors;
+    colors.reserve(body_color_count + 1);
+    for (size_t color_idx = 0; color_idx < body_color_count; ++color_idx) {
+        const int filament_id = plate_extruders[color_idx];
+        colors.emplace_back(filament_color(filament_id > 0 ? size_t(filament_id - 1) : 0));
     }
-    if (colors.empty()) return int(this->volumes.size() - 1);
-    volumes.emplace_back(new GLWipeTowerVolume({colors}));
+
+    std::vector<TriangleMesh> render_meshes;
+    if (is_generated && body_color_count > 1)
+        render_meshes = make_wipe_tower_body_color_meshes(footprint, body_color_count);
+
+    if (render_meshes.size() != body_color_count) {
+        colors.resize(1);
+        render_meshes = {tower_mesh};
+    }
+
+    if (!brim_mesh.its.vertices.empty()) {
+        const int first_filament_id = plate_extruders.front();
+        colors.emplace_back(filament_color(
+            first_filament_id > 0 ? size_t(first_filament_id - 1) : 0));
+        render_meshes.emplace_back(brim_mesh);
+    }
+
+    volumes.emplace_back(new GLWipeTowerVolume(colors));
     GLWipeTowerVolume &v = *dynamic_cast<GLWipeTowerVolume *>(volumes.back());
-    auto mesh = wt_mesh;
-    if (render_brim) {
-        mesh.merge(brim_mesh);
-    }
-    if (!colors.empty()) {
-        v.model_per_colors.resize(1);
-        v.model_per_colors[0].init_from(mesh);
-    }
+    v.model_per_colors.resize(render_meshes.size());
+    for (size_t mesh_idx = 0; mesh_idx < render_meshes.size(); ++mesh_idx)
+        v.model_per_colors[mesh_idx].init_from(render_meshes[mesh_idx]);
+
+    TriangleMesh mesh = tower_mesh;
+    mesh.merge(brim_mesh);
     TriangleMesh wipe_tower_shell = mesh.convex_hull_3d();
     v.model.init_from(wipe_tower_shell);
     v.mesh_raycaster = std::make_unique<GUI::MeshRaycaster>(std::make_shared<const TriangleMesh>(wipe_tower_shell));
@@ -935,7 +946,9 @@ int GLVolumeCollection::load_real_wipe_tower_preview(
     v.geometry_id.first                        = 0;
     v.geometry_id.second                       = wipe_tower_instance_id().id + (obj_idx - 1000);
     v.is_wipe_tower                            = true;
-    v.shader_outside_printer_detection_enabled = !size_unknown;
+    // Wipe towers use a synthetic object ID and are checked separately by
+    // check_wipe_tower_outside_state(). They must not enter the model-volume check.
+    v.shader_outside_printer_detection_enabled = false;
     return int(volumes.size() - 1);
 }
 
@@ -1228,8 +1241,11 @@ bool GLVolumeCollection::check_wipe_tower_outside_state(const Slic3r::BuildVolum
                     extruder_polys.emplace_back(Polygon::new_scale(extruder_areas[i]));
                 }
                 extruder_polys = union_(extruder_polys);
-                if (extruder_polys.empty())
+                if (extruder_polys.empty()) {
+                    volume->is_outside = true;
+                    volume->partly_inside = true;
                     return false;
+                }
 
                 printable_poly = extruder_polys[0];
             }
@@ -1238,7 +1254,9 @@ bool GLVolumeCollection::check_wipe_tower_outside_state(const Slic3r::BuildVolum
             Polygon wipe_tower_polygon = bbox.polygon(true);
 
             Polygons diff_res = diff(wipe_tower_polygon, printable_poly);
-            return diff_res.empty();
+            volume->is_outside = !diff_res.empty();
+            volume->partly_inside = volume->is_outside;
+            return !volume->is_outside;
         }
     }
     return true;

--- a/src/slic3r/GUI/3DScene.hpp
+++ b/src/slic3r/GUI/3DScene.hpp
@@ -55,6 +55,8 @@ class ExtrusionEntityCollection;
 class ModelObject;
 class ModelVolume;
 class GLShaderProgram;
+struct WipeTowerFootprint;
+enum class WipeTowerPreviewSource;
 enum ModelInstanceEPrintVolumeState : unsigned char;
 
 using ModelObjectPtrs = std::vector<ModelObject*>;
@@ -482,9 +484,8 @@ public:
         size_t                          timestamp);
 
     int load_wipe_tower_preview(
-        int obj_idx, float pos_x, float pos_y, float width, float depth, float height, float rotation_angle, bool size_unknown, float brim_width);
-    int load_real_wipe_tower_preview(
-    int obj_idx, float pos_x, float pos_y,const TriangleMesh& wt_mesh,const TriangleMesh &brim_mesh,bool render_brim, float rotation_angle, bool size_unknown,  bool opengl_initialized);
+        int obj_idx, float pos_x, float pos_y, const TriangleMesh& wt_mesh, const TriangleMesh& brim_mesh,
+        float rotation_angle, WipeTowerPreviewSource source, const WipeTowerFootprint& footprint);
     GLVolume* new_toolpath_volume(const ColorRGBA& rgba);
     GLVolume* new_nontoolpath_volume(const ColorRGBA& rgba);
 

--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -916,7 +916,7 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig *config, in
     toggle_field("single_extruder_multi_material", !is_BBL_Printer);
 
     auto bSEMM = preset_bundle->printers.get_edited_preset().config.opt_bool("single_extruder_multi_material");
-    const bool supports_wipe_tower_2 = !is_BBL_Printer && preset_bundle->printers.get_edited_preset().config.opt_enum<WipeTowerType>("wipe_tower_type") == WipeTowerType::Type2;
+    const bool use_wipe_tower_2 = !is_BBL_Printer && preset_bundle->printers.get_edited_preset().config.opt_enum<WipeTowerType>("wipe_tower_type") == WipeTowerType::Type2;
 
     toggle_field("ooze_prevention", !bSEMM);
     bool have_ooze_prevention = config->opt_bool("ooze_prevention");
@@ -925,30 +925,36 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig *config, in
     int preheat_steps = config->opt_int("preheat_steps");
     toggle_line("preheat_steps", have_ooze_prevention && (preheat_steps > 0));
 
-    bool have_prime_tower = config->opt_bool("enable_prime_tower");
-    for (auto el : {"prime_tower_width", "prime_tower_brim_width", "prime_tower_skip_points", "wipe_tower_wall_type", "prime_tower_infill_gap","prime_tower_enable_framework", "enable_tower_interface_features"})
+    const bool have_prime_tower  = config->opt_bool("enable_prime_tower");
+    const bool have_wipe_tower_1 = have_prime_tower && !use_wipe_tower_2;
+    const bool have_wipe_tower_2 = have_prime_tower && use_wipe_tower_2;
+
+    for (auto el : {"prime_tower_width", "prime_tower_brim_width", "wipe_tower_wall_type",
+                    "enable_tower_interface_features", "wipe_tower_rotation_angle", "wipe_tower_no_sparse_layers"})
         toggle_line(el, have_prime_tower);
+
+    for (auto el : {"prime_tower_skip_points", "prime_tower_infill_gap", "prime_tower_enable_framework"})
+        toggle_line(el, have_wipe_tower_1);
+
+    for (auto el : {"wipe_tower_bridging", "wipe_tower_extra_spacing", "wipe_tower_extra_flow",
+                    "wipe_tower_max_purge_speed"})
+        toggle_line(el, have_wipe_tower_2);
 
     toggle_line("enable_tower_interface_cooldown_during_tower",
                 have_prime_tower && config->opt_bool("enable_tower_interface_features"));
 
     bool purge_in_primetower = preset_bundle->printers.get_edited_preset().config.opt_bool("purge_in_prime_tower");
 
-    for (auto el : {"wipe_tower_rotation_angle", "wipe_tower_cone_angle",
-                    "wipe_tower_extra_spacing", "wipe_tower_max_purge_speed",
-                    "wipe_tower_bridging", "wipe_tower_extra_flow",
-                    "wipe_tower_no_sparse_layers"})
-            toggle_line(el, have_prime_tower && supports_wipe_tower_2);
-
     WipeTowerWallType wipe_tower_wall_type = config->opt_enum<WipeTowerWallType>("wipe_tower_wall_type");
-    bool have_rib_wall = (wipe_tower_wall_type == WipeTowerWallType::wtwRib)&&have_prime_tower;
-    toggle_line("wipe_tower_cone_angle", have_prime_tower && supports_wipe_tower_2 && wipe_tower_wall_type == WipeTowerWallType::wtwCone);
+    bool have_rib_wall = wipe_tower_wall_type == WipeTowerWallType::wtwRib && have_prime_tower;
+    toggle_line("wipe_tower_cone_angle", have_wipe_tower_2 && wipe_tower_wall_type == WipeTowerWallType::wtwCone);
     toggle_line("wipe_tower_extra_rib_length", have_rib_wall);
     toggle_line("wipe_tower_rib_width", have_rib_wall);
     toggle_line("wipe_tower_fillet_wall", have_rib_wall);
-    toggle_field("prime_tower_width", have_prime_tower && !have_rib_wall);
+    const bool auto_sized_rib_tower = have_wipe_tower_1 && have_rib_wall;
+    toggle_field("prime_tower_width", have_prime_tower && !auto_sized_rib_tower);
 
-    toggle_line("single_extruder_multi_material_priming", !bSEMM && have_prime_tower && supports_wipe_tower_2);
+    toggle_line("single_extruder_multi_material_priming", !bSEMM && have_wipe_tower_2);
 
     toggle_line("prime_volume",have_prime_tower && (!purge_in_primetower || !bSEMM));
 

--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -2879,64 +2879,36 @@ void GLCanvas3D::reload_scene(bool refresh_immediately, bool force_full_scene_re
                 DynamicPrintConfig& proj_cfg = wxGetApp().preset_bundle->project_config;
                 float x = dynamic_cast<const ConfigOptionFloats*>(proj_cfg.option("wipe_tower_x"))->get_at(plate_id);
                 float y = dynamic_cast<const ConfigOptionFloats*>(proj_cfg.option("wipe_tower_y"))->get_at(plate_id);
-                float w = dynamic_cast<const ConfigOptionFloat*>(m_config->option("prime_tower_width"))->value;
                 float a = dynamic_cast<const ConfigOptionFloat*>(proj_cfg.option("wipe_tower_rotation_angle"))->value;
-                // BBS
-                float v = dynamic_cast<const ConfigOptionFloat*>(m_config->option("prime_volume"))->value;
                 Vec3d plate_origin = ppl.get_plate(plate_id)->get_origin();
 
-                const Print* print = m_process->fff_print();
-                const Print* current_print = part_plate->fff_print();
-                if (!need_wipe_tower && part_plate->get_extruders(true).size() < 2) continue;
+                const size_t used_filament_count = part_plate->get_extruders(true).size();
+                if (!need_wipe_tower && used_filament_count < 2) continue;
                 if (part_plate->get_objects_on_this_plate().empty()) continue;
-
-                float brim_width = print->wipe_tower_data(filaments_count).brim_width;
-                const DynamicPrintConfig &print_cfg   = wxGetApp().preset_bundle->prints.get_edited_preset().config;
-                int nozzle_nums = wxGetApp().preset_bundle->get_printer_extruder_count();
-                Vec3d wipe_tower_size = ppl.get_plate(plate_id)->estimate_wipe_tower_size(print_cfg, w, v, nozzle_nums, 0, false, dynamic_cast<const ConfigOptionBool*>(dconfig.option("enable_wrapping_detection"))->value);
-
-                {
-                    const float                 margin     = WIPE_TOWER_MARGIN + brim_width;
-                    BoundingBoxf3               plate_bbox = part_plate->get_bounding_box();
-                    BoundingBoxf                plate_bbox_2d(Vec2d(plate_bbox.min(0), plate_bbox.min(1)), Vec2d(plate_bbox.max(0), plate_bbox.max(1)));
-                    const std::vector<Pointfs> &extruder_areas = part_plate->get_extruder_areas();
-                    for (Pointfs points : extruder_areas) {
-                        BoundingBoxf bboxf(points);
-                        plate_bbox_2d.min = plate_bbox_2d.min(0) >= bboxf.min(0) ? plate_bbox_2d.min : bboxf.min;
-                        plate_bbox_2d.max = plate_bbox_2d.max(0) <= bboxf.max(0) ? plate_bbox_2d.max : bboxf.max;
-                    }
-
-                    coordf_t plate_bbox_x_min_local_coord = plate_bbox_2d.min(0) - plate_origin(0);
-                    coordf_t plate_bbox_x_max_local_coord = plate_bbox_2d.max(0) - plate_origin(0);
-                    coordf_t plate_bbox_y_max_local_coord = plate_bbox_2d.max(1) - plate_origin(1);
-
-                    if (!current_print->is_step_done(psWipeTower) || !current_print->wipe_tower_data().wipe_tower_mesh_data) {
-                        // update for wipe tower position
-                        {
-                            int volume_idx_wipe_tower_new = m_volumes.load_wipe_tower_preview(1000 + plate_id, x + plate_origin(0), y + plate_origin(1),
-                                                                                              (float) wipe_tower_size(0), (float) wipe_tower_size(1), (float) wipe_tower_size(2),
-                                                                                              a,
-                                                                                              /*!print->is_step_done(psWipeTower)*/ true, brim_width);
-                            int volume_idx_wipe_tower_old = volume_idxs_wipe_tower_old[plate_id];
-                            if (volume_idx_wipe_tower_old != -1) map_glvolume_old_to_new[volume_idx_wipe_tower_old] = volume_idx_wipe_tower_new;
-                        }
+                const PartPlate::WipeTowerPreview tower_preview = part_plate->wipe_tower_preview();
+                const WipeTowerFootprint& preview_footprint = tower_preview.footprint;
+                int volume_idx_wipe_tower_new = -1;
+                if (!preview_footprint.empty()) {
+                    if (tower_preview.source == WipeTowerPreviewSource::Sliced) {
+                        const WipeTowerData& tower_data = part_plate->fff_print()->wipe_tower_data(used_filament_count);
+                        volume_idx_wipe_tower_new = m_volumes.load_wipe_tower_preview(
+                            1000 + plate_id, x + plate_origin(0), y + plate_origin(1),
+                            tower_data.wipe_tower_mesh_data->real_wipe_tower_mesh,
+                            tower_data.wipe_tower_mesh_data->real_brim_mesh,
+                            a, tower_preview.source, preview_footprint);
                     } else {
-                        const float margin                    = 2.f;
-                        auto        tower_bottom = current_print->wipe_tower_data().wipe_tower_mesh_data->bottom;
-                        tower_bottom.translate(scaled(Vec2d{x, y}));
-                        tower_bottom.translate(scaled(Vec2d{plate_origin[0], plate_origin[1]}));
-                        auto tower_bottom_bbox = get_extents(tower_bottom);
-                        BoundingBoxf3 plate_bbox        = wxGetApp().plater()->get_partplate_list().get_plate(plate_id)->get_build_volume(true);
-                        BoundingBox   plate_bbox2d      = BoundingBox(scaled(Vec2f(plate_bbox.min[0], plate_bbox.min[1])), scaled(Vec2f(plate_bbox.max[0], plate_bbox.max[1])));
-                        Vec2f         offset            = WipeTower::move_box_inside_box(tower_bottom_bbox, plate_bbox2d, scaled(margin));
-                        int volume_idx_wipe_tower_new = m_volumes.load_real_wipe_tower_preview(1000 + plate_id, x + plate_origin(0), y + plate_origin(1),
-                                                                                               current_print->wipe_tower_data().wipe_tower_mesh_data->real_wipe_tower_mesh,
-                                                                                               current_print->wipe_tower_data().wipe_tower_mesh_data->real_brim_mesh,
-                                                                                            true,a,/*!print->is_step_done(psWipeTower)*/ true, m_initialized);
-                        int volume_idx_wipe_tower_old = volume_idxs_wipe_tower_old[plate_id];
-                        if (volume_idx_wipe_tower_old != -1) map_glvolume_old_to_new[volume_idx_wipe_tower_old] = volume_idx_wipe_tower_new;
+                        const WipeTowerPreviewMeshes preview_meshes =
+                            make_wipe_tower_preview_meshes(preview_footprint);
+                        volume_idx_wipe_tower_new = m_volumes.load_wipe_tower_preview(
+                            1000 + plate_id, x + plate_origin(0), y + plate_origin(1),
+                            preview_meshes.body, preview_meshes.brim, a, tower_preview.source,
+                            preview_footprint);
                     }
                 }
+
+                const int volume_idx_wipe_tower_old = volume_idxs_wipe_tower_old[plate_id];
+                if (volume_idx_wipe_tower_old != -1 && volume_idx_wipe_tower_new != -1)
+                    map_glvolume_old_to_new[volume_idx_wipe_tower_old] = volume_idx_wipe_tower_new;
             }
         }
     }
@@ -5403,23 +5375,24 @@ GLCanvas3D::WipeTowerInfo GLCanvas3D::get_wipe_tower_info(int plate_idx) const
             // BBS: don't support rotation
             //wti.m_rotation = (M_PI/180.) * proj_cfg->opt_float("wipe_tower_rotation_angle");
 
-            auto& preset = wxGetApp().preset_bundle->prints.get_edited_preset();
-            float wt_brim_width = preset.config.opt_float("prime_tower_brim_width");
-
-            const BoundingBoxf3& bb = vol->bounding_box();
-            if (wt_brim_width < 0) wt_brim_width = WipeTower::get_auto_brim_by_height((float)bb.max.z());
-            wti.m_bb = BoundingBoxf{to_2d(bb.min), to_2d(bb.max)};
-            wti.m_bb.offset(wt_brim_width);
-
-            float brim_width = wxGetApp().preset_bundle->prints.get_edited_preset().config.opt_float("prime_tower_brim_width");
-            if (brim_width < 0) brim_width = WipeTower::get_auto_brim_by_height((float) bb.max.z());
-            wti.m_bb.offset((brim_width));
+            PartPlate* plate = wxGetApp().plater()->get_partplate_list().get_plate(plate_idx);
+            const PartPlate::WipeTowerPreview tower_preview = plate->wipe_tower_preview();
+            const bool use_footprint =
+                !tower_preview.footprint.empty() &&
+                (tower_preview.source != WipeTowerPreviewSource::Sliced ||
+                 tower_preview.footprint.accuracy == WipeTowerFootprint::Accuracy::Exact);
+            if (use_footprint) {
+                const ConfigOptionFloat *rotation_opt = proj_cfg.option<ConfigOptionFloat>("wipe_tower_rotation_angle");
+                const double rotation = rotation_opt != nullptr ? Geometry::deg2rad(rotation_opt->value) : 0.;
+                wti.m_bb = rotated_wipe_tower_bbox(tower_preview.footprint, rotation);
+            } else {
+                const BoundingBoxf3 &bb = vol->bounding_box();
+                wti.m_bb = BoundingBoxf{to_2d(bb.min), to_2d(bb.max)};
+            }
 
             // BBS: the wipe tower pos might be outside bed
-            PartPlate* plate = wxGetApp().plater()->get_partplate_list().get_plate(plate_idx);
             Vec2d plate_size = plate->get_size();
-            wti.m_pos.x() = std::clamp(wti.m_pos.x(), 0.0, plate_size(0) - wti.m_bb.size().x());
-            wti.m_pos.y() = std::clamp(wti.m_pos.y(), 0.0, plate_size(1) - wti.m_bb.size().y());
+            wti.m_pos = clamp_wipe_tower_position(wti.m_bb, BoundingBoxf(Vec2d::Zero(), plate_size), wti.m_pos, 0.);
 
             // BBS: add partplate logic
             wti.m_plate_idx = plate_idx;

--- a/src/slic3r/GUI/Jobs/ArrangeJob.cpp
+++ b/src/slic3r/GUI/Jobs/ArrangeJob.cpp
@@ -261,12 +261,9 @@ arrangement::ArrangePolygon estimate_wipe_tower_info(int plate_index, std::set<i
     int plate_count = ppl.get_plate_count();
     int plate_index_valid = std::min(plate_index, plate_count - 1);
 
-    // we have to estimate the depth using the extruder number of all plates
-    int extruder_size = extruder_ids.size();
-
     Vec3d wipe_tower_size, wipe_tower_pos;
-    int nozzle_nums = wxGetApp().preset_bundle->get_printer_extruder_count();
-    auto arrange_poly = ppl.get_plate(plate_index_valid)->estimate_wipe_tower_polygon(full_config, plate_index, wipe_tower_pos, wipe_tower_size, nozzle_nums, extruder_size);
+    const std::vector<int> plate_extruders(extruder_ids.begin(), extruder_ids.end());
+    auto arrange_poly = ppl.get_plate(plate_index_valid)->estimate_wipe_tower_polygon(full_config, plate_index, wipe_tower_pos, wipe_tower_size, plate_extruders);
     arrange_poly.bed_idx = plate_index;
     return arrange_poly;
 }

--- a/src/slic3r/GUI/PartPlate.cpp
+++ b/src/slic3r/GUI/PartPlate.cpp
@@ -2246,9 +2246,7 @@ PartPlate::WipeTowerPreview PartPlate::wipe_tower_preview(const DynamicPrintConf
         m_print != nullptr ? m_print->default_region_config() : PrintRegionConfig{};
     preview_region_config.apply(full_config, true);
 
-    const bool is_bbl_printer =
-        m_print != nullptr ? m_print->is_BBL_printer() :
-        wxGetApp().preset_bundle != nullptr && wxGetApp().preset_bundle->is_bbl_vendor();
+    const bool is_bbl_printer = wxGetApp().preset_bundle != nullptr && wxGetApp().preset_bundle->is_bbl_vendor();
     const bool is_type2 = !is_bbl_printer && preview_config.wipe_tower_type.value == WipeTowerType::Type2;
 
     float tower_height = 0.f;

--- a/src/slic3r/GUI/PartPlate.cpp
+++ b/src/slic3r/GUI/PartPlate.cpp
@@ -24,6 +24,7 @@
 #include "libslic3r/Geometry.hpp"
 #include "libslic3r/Tesselate.hpp"
 #include "libslic3r/GCode/ThumbnailData.hpp"
+#include "libslic3r/GCode/WipeTower2.hpp"
 #include "libslic3r/Utils.hpp"
 
 #include "I18N.hpp"
@@ -2211,115 +2212,129 @@ bool PartPlate::check_compatible_of_nozzle_and_filament(const DynamicPrintConfig
     return wipe_tower_size;
 }*/
 
-Vec3d PartPlate::estimate_wipe_tower_size(const DynamicPrintConfig & config, const double w, const double wipe_volume, int extruder_count, int plate_extruder_size, bool use_global_objects, bool enable_wrapping_detection) const
+PartPlate::WipeTowerPreview PartPlate::wipe_tower_preview() const
 {
-    Vec3d wipe_tower_size;
-    double layer_height = 0.08f; // hard code layer height
-    double max_height = 0.f;
-    wipe_tower_size.setZero();
+    DynamicConfig& project_config = wxGetApp().preset_bundle->project_config;
+    std::vector<int> filament_maps = get_real_filament_maps(project_config);
+    std::vector<int> filament_volume_maps = get_filament_volume_maps();
+    if (filament_volume_maps.empty())
+        filament_volume_maps =
+            wxGetApp().preset_bundle->get_default_nozzle_volume_types_for_filaments(filament_maps);
+    const DynamicPrintConfig full_config =
+        wxGetApp().preset_bundle->full_config(false, filament_maps, filament_volume_maps);
 
-    const ConfigOption* layer_height_opt = config.option("layer_height");
-    if (layer_height_opt)
-        layer_height = layer_height_opt->getFloat();
-
-    // empty plate
-    if (plate_extruder_size == 0)
-    {
-        std::vector<int> plate_extruders = get_extruders(true);
-        plate_extruder_size = plate_extruders.size();
-    }
-    if (plate_extruder_size == 0)
-        return wipe_tower_size;
-
-    for (int obj_idx = 0; obj_idx < m_model->objects.size(); obj_idx++) {
-        if (!use_global_objects && !contain_instance_totally(obj_idx, 0))
-            continue;
-
-		BoundingBoxf3 bbox = m_model->objects[obj_idx]->bounding_box_exact();
-        max_height = std::max(bbox.size().z(), max_height);
-    }
-    wipe_tower_size(2) = max_height;
-    //const DynamicPrintConfig &dconfig = wxGetApp().preset_bundle->prints.get_edited_preset().config;
-    auto timelapse_type    = config.option<ConfigOptionEnum<TimelapseType>>("timelapse_type");
-    bool need_wipe_tower = (timelapse_type ? (timelapse_type->value == TimelapseType::tlSmooth) : false) | enable_wrapping_detection;
-    double extra_spacing     = config.option("prime_tower_infill_gap")->getFloat() / 100.;
-    const ConfigOptionEnum<WipeTowerWallType>* use_rib_wall_opt = config.option<ConfigOptionEnum<WipeTowerWallType>>("wipe_tower_wall_type");
-    bool use_rib_wall = use_rib_wall_opt ? use_rib_wall_opt->value == WipeTowerWallType::wtwRib: false;
-    double rib_width = config.option("wipe_tower_rib_width")->getFloat();
-    double depth;
-    double filament_change_volume=0.;
-    {
-        std::vector<double>             filament_change_lengths;
-        auto                filament_change_lengths_opt = m_print->config().option<ConfigOptionFloats>("filament_change_length");
-        if (filament_change_lengths_opt) filament_change_lengths = filament_change_lengths_opt->values;
-        double length = filament_change_lengths.empty() ? 0 : *std::max_element(filament_change_lengths.begin(), filament_change_lengths.end());
-        double diameter = 1.75;
-        std::vector<double> diameters;
-        auto                filament_diameter_opt = m_print->config().option<ConfigOptionFloats>("filament_diameter");
-        if (filament_diameter_opt) diameters = filament_diameter_opt->values;
-        diameter = diameters.empty() ? diameter : *std::max_element(diameters.begin(), diameters.end());
-        filament_change_volume = length * PI * diameter * diameter / 4.;
-    }
-    double volume = wipe_volume * (extruder_count == 2 ? plate_extruder_size : (plate_extruder_size - 1));
-    if (extruder_count == 2) volume += filament_change_volume * (int) (plate_extruder_size / 2);
-    if (use_rib_wall) {
-        depth = std::sqrt(volume / layer_height * extra_spacing);
-        if (need_wipe_tower || plate_extruder_size > 1) {
-            float min_wipe_tower_depth = WipeTower::get_limit_depth_by_height(max_height);
-            double volume_depth         = depth;
-            depth = std::max((double) min_wipe_tower_depth, depth);
-            rib_width = std::min(rib_width, depth / 2);
-            depth = rib_width / std::sqrt(2) + std::max(depth + m_print->config().wipe_tower_extra_rib_length.value, volume_depth);
-            wipe_tower_size(0) = wipe_tower_size(1) = depth;
-        }
-    }
-    else {
-        depth  =  volume/ (layer_height * w) *extra_spacing;
-        if (need_wipe_tower || depth > EPSILON) {
-            float min_wipe_tower_depth = WipeTower::get_limit_depth_by_height(max_height);
-            depth = std::max((double)min_wipe_tower_depth, depth);
-        }
-        wipe_tower_size(0) = w;
-        wipe_tower_size(1) = depth;
-    }
-
-    return wipe_tower_size;
+    return wipe_tower_preview(full_config, get_extruders(true), false, true);
 }
 
-arrangement::ArrangePolygon PartPlate::estimate_wipe_tower_polygon(const DynamicPrintConfig& config, int plate_index, Vec3d& wt_pos, Vec3d& wt_size, int extruder_count, int plate_extruder_size, bool use_global_objects) const
+PartPlate::WipeTowerPreview PartPlate::wipe_tower_preview(const DynamicPrintConfig& full_config, const std::vector<int>& plate_extruders, bool use_global_objects, bool allow_sliced_mesh) const
+{
+    WipeTowerPreview result;
+
+    std::vector<unsigned int> used_filaments;
+    used_filaments.reserve(plate_extruders.size());
+    for (const int filament : plate_extruders)
+        if (filament > 0)
+            used_filaments.emplace_back(unsigned(filament - 1));
+    std::sort(used_filaments.begin(), used_filaments.end());
+    used_filaments.erase(std::unique(used_filaments.begin(), used_filaments.end()),
+                         used_filaments.end());
+
+    PrintConfig preview_config = m_print != nullptr ? m_print->config() : PrintConfig{};
+    preview_config.apply(full_config, true);
+
+    PrintRegionConfig preview_region_config =
+        m_print != nullptr ? m_print->default_region_config() : PrintRegionConfig{};
+    preview_region_config.apply(full_config, true);
+
+    const bool is_bbl_printer =
+        m_print != nullptr ? m_print->is_BBL_printer() :
+        wxGetApp().preset_bundle != nullptr && wxGetApp().preset_bundle->is_bbl_vendor();
+    const bool is_type2 = !is_bbl_printer && preview_config.wipe_tower_type.value == WipeTowerType::Type2;
+
+    float tower_height = 0.f;
+    if (m_model != nullptr) {
+        for (int object_idx = 0; object_idx < int(m_model->objects.size()); ++object_idx) {
+            const ModelObject* object = m_model->objects[object_idx];
+            for (int instance_idx = 0; instance_idx < int(object->instances.size()); ++instance_idx) {
+                if (!use_global_objects && !contain_instance_totally(object_idx, instance_idx))
+                    continue;
+                tower_height = std::max(
+                    tower_height, float(object->instance_bounding_box(instance_idx).size().z()));
+            }
+        }
+    }
+
+    const ConfigOption* layer_height_opt = full_config.option("layer_height");
+    const float layer_height = layer_height_opt != nullptr ? float(layer_height_opt->getFloat()) : 0.2f;
+    const bool force_tower = preview_config.timelapse_type.value == TimelapseType::tlSmooth ||
+                             (preview_config.enable_wrapping_detection.value && preview_config.wrapping_exclude_area.values.size() > 2);
+
+    // psWipeTower is invalidated whenever an input affecting the sliced tower changes.
+    // It is therefore the authoritative signal for reusing the real post-slice mesh;
+    // comparing a reconstructed full config here is stricter and may reject valid results.
+    const WipeTowerData* tower_data =
+        allow_sliced_mesh && m_print != nullptr && m_print->is_step_done(psWipeTower) ?
+            &m_print->wipe_tower_data() : nullptr;
+    if (tower_data != nullptr &&
+        tower_data->footprint.accuracy == WipeTowerFootprint::Accuracy::Exact) {
+        result.footprint = tower_data->footprint;
+    } else if (is_type2) {
+        result.footprint = WipeTower2::make_conservative_footprint(
+            preview_config, preview_region_config, used_filaments, tower_height, layer_height, force_tower);
+    } else {
+        result.footprint = WipeTower::make_conservative_footprint(
+            preview_config, used_filaments, tower_height, layer_height, force_tower);
+    }
+    const bool use_sliced_mesh =
+        tower_data != nullptr &&
+        tower_data->wipe_tower_mesh_data.has_value() &&
+        (!is_type2 || result.footprint.accuracy == WipeTowerFootprint::Accuracy::Exact);
+    if (!result.footprint.empty())
+        result.source = use_sliced_mesh ? WipeTowerPreviewSource::Sliced :
+                                         WipeTowerPreviewSource::Generated;
+    return result;
+}
+
+arrangement::ArrangePolygon PartPlate::estimate_wipe_tower_polygon(const DynamicPrintConfig& config, int plate_index, Vec3d& wt_pos, Vec3d& wt_size, const std::vector<int>& plate_extruders, bool use_global_objects) const
 {
 	float x = dynamic_cast<const ConfigOptionFloats*>(config.option("wipe_tower_x"))->get_at(plate_index);
 	float y = dynamic_cast<const ConfigOptionFloats*>(config.option("wipe_tower_y"))->get_at(plate_index);
-	float w = dynamic_cast<const ConfigOptionFloat*>(config.option("prime_tower_width"))->value;
-	//float a = dynamic_cast<const ConfigOptionFloat*>(config.option("wipe_tower_rotation_angle"))->value;
-	float v = dynamic_cast<const ConfigOptionFloat*>(config.option("prime_volume"))->value;
-    float tower_brim_width = dynamic_cast<const ConfigOptionFloat*>(config.option("prime_tower_brim_width"))->value;
-    const ConfigOptionBool * wrapping_opt = dynamic_cast<const ConfigOptionBool *>(config.option("enable_wrapping_detection"));
-	bool enable_wrapping = (wrapping_opt != nullptr) && wrapping_opt->value;
-	wt_size = estimate_wipe_tower_size(config, w, v, extruder_count, plate_extruder_size, use_global_objects, enable_wrapping);
+    const WipeTowerFootprint tower_footprint = wipe_tower_preview(config, plate_extruders, use_global_objects, false).footprint;
+    const bool use_outline = !tower_footprint.empty();
+    wt_size = use_outline ? Vec3d(tower_footprint.width, tower_footprint.depth, tower_footprint.height) :
+                            Vec3d::Zero();
 	int plate_width=m_width, plate_depth=m_depth;
-	float depth = wt_size(1);
-	float margin = WIPE_TOWER_MARGIN + tower_brim_width, wp_brim_width = 0.f;
-	const ConfigOption* wipe_tower_brim_width_opt = config.option("prime_tower_brim_width");
-	if (wipe_tower_brim_width_opt) {
-		wp_brim_width = wipe_tower_brim_width_opt->getFloat();
-        if (wp_brim_width < 0) wp_brim_width = WipeTower::get_auto_brim_by_height((float) wt_size.z());
-		BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << boost::format("arrange wipe_tower: wp_brim_width %1%") % wp_brim_width;
-	}
 
-	x = std::clamp(x, margin, (float)plate_width - w - margin - wp_brim_width);
-    y = std::clamp(y, margin, (float)plate_depth - depth - margin - wp_brim_width);
+    Polygon local_outline;
+    BoundingBoxf footprint(Vec2d(0., 0.), Vec2d(std::max(0., wt_size.x()), std::max(0., wt_size.y())));
+    if (use_outline) {
+        const ConfigOptionFloat *rotation_opt = config.option<ConfigOptionFloat>("wipe_tower_rotation_angle");
+        const double rotation = rotation_opt != nullptr ? Geometry::deg2rad(rotation_opt->value) : 0.;
+        local_outline = transformed_wipe_tower_outline(tower_footprint, rotation);
+        footprint = rotated_wipe_tower_bbox(tower_footprint, rotation);
+    }
+    const float margin = WIPE_TOWER_MARGIN;
+
+    const Vec2d clamped_position = clamp_wipe_tower_position(footprint, BoundingBoxf(Vec2d::Zero(), Vec2d(plate_width, plate_depth)), Vec2d(x, y), margin);
+    x = float(clamped_position.x());
+    y = float(clamped_position.y());
     wt_pos(0) = x;
     wt_pos(1) = y;
     wt_pos(2) = 0.f;
 
 	arrangement::ArrangePolygon wipe_tower_ap;
-	Polygon ap({
-		{scaled(x - wp_brim_width), scaled(y - wp_brim_width)},
-		{scaled(x + w + wp_brim_width), scaled(y - wp_brim_width)},
-		{scaled(x + w + wp_brim_width), scaled(y + depth + wp_brim_width)},
-		{scaled(x - wp_brim_width), scaled(y + depth + wp_brim_width)}
-		});
+    Polygon ap;
+    if (use_outline && !local_outline.points.empty()) {
+        ap = std::move(local_outline);
+        ap.translate(Point(scale_(x), scale_(y)));
+    } else {
+        ap = Polygon({
+            {scaled(x + float(footprint.min.x())), scaled(y + float(footprint.min.y()))},
+            {scaled(x + float(footprint.max.x())), scaled(y + float(footprint.min.y()))},
+            {scaled(x + float(footprint.max.x())), scaled(y + float(footprint.max.y()))},
+            {scaled(x + float(footprint.min.x())), scaled(y + float(footprint.max.y()))}
+        });
+    }
 	wipe_tower_ap.bed_idx = plate_index;
 	wipe_tower_ap.setter = NULL; // do not move wipe tower
 
@@ -4363,6 +4378,7 @@ void PartPlateList::set_default_wipe_tower_pos_for_plate(int plate_idx, bool ini
 
     coordf_t plate_bbox_x_min_local_coord = plate_bbox_2d.min(0) - plate_origin(0);
     coordf_t plate_bbox_x_max_local_coord = plate_bbox_2d.max(0) - plate_origin(0);
+    coordf_t plate_bbox_y_min_local_coord = plate_bbox_2d.min(1) - plate_origin(1);
     coordf_t plate_bbox_y_max_local_coord = plate_bbox_2d.max(1) - plate_origin(1);
 
     std::vector<int> filament_maps = part_plate->get_real_filament_maps(proj_cfg);
@@ -4374,42 +4390,33 @@ void PartPlateList::set_default_wipe_tower_pos_for_plate(int plate_idx, bool ini
         f_volume_maps = wxGetApp().preset_bundle->get_default_nozzle_volume_types_for_filaments(filament_maps);
     }
     DynamicPrintConfig full_config = wxGetApp().preset_bundle->full_config(false, filament_maps, f_volume_maps);
-    const DynamicPrintConfig &print_cfg = wxGetApp().preset_bundle->prints.get_edited_preset().config;
-    float w = dynamic_cast<const ConfigOptionFloat *>(print_cfg.option("prime_tower_width"))->value;
-    float v = dynamic_cast<const ConfigOptionFloat *>(full_config.option("prime_volume"))->value;
-    bool enable_wrapping = false;
-    const ConfigOptionBool *wrapping_opt = dynamic_cast<const ConfigOptionBool *>(full_config.option("enable_wrapping_detection"));
-    if (wrapping_opt) enable_wrapping = wrapping_opt->value;
-    int nozzle_nums = wxGetApp().preset_bundle->get_printer_extruder_count();
-    Vec3d wipe_tower_size = part_plate->estimate_wipe_tower_size(print_cfg, w, v, nozzle_nums, init_pos ? 2 : 0, false, enable_wrapping);
-
-    if (!init_pos && (is_approx(wipe_tower_size(0), 0.0) || is_approx(wipe_tower_size(1), 0.0))) {
-        wipe_tower_size = part_plate->estimate_wipe_tower_size(print_cfg, w, v, nozzle_nums, 2, false, enable_wrapping);
+    WipeTowerFootprint tower_footprint;
+    if (!init_pos) {
+        const std::vector<int> plate_extruders = part_plate->get_extruders(true);
+        tower_footprint = part_plate->wipe_tower_preview(full_config, plate_extruders, false, false).footprint;
+    }
+    if (tower_footprint.empty()) {
+        // Initial positioning, or a plate without a current tower, uses a representative
+        // two-filament tower. Actual preview and slicing always use real filament IDs.
+        static const std::vector<int> default_position_filaments{1, 2};
+        tower_footprint = part_plate->wipe_tower_preview(full_config, default_position_filaments, false, false).footprint;
     }
 
-    // Compute brim-aware margin: brim extends outward from tower position
-    float brim_width = 0.f;
-    const ConfigOptionFloat *brim_opt = print_cfg.option<ConfigOptionFloat>("prime_tower_brim_width");
-    if (brim_opt) {
-        brim_width = brim_opt->value;
-        if (brim_width < 0) brim_width = WipeTower::get_auto_brim_by_height((float) wipe_tower_size.z());
+    BoundingBoxf footprint(Vec2d::Zero(), Vec2d::Zero());
+    if (!tower_footprint.empty()) {
+        const ConfigOptionFloat *rotation_opt = full_config.option<ConfigOptionFloat>("wipe_tower_rotation_angle");
+        const double rotation = rotation_opt != nullptr ? Geometry::deg2rad(rotation_opt->value) : 0.;
+        footprint = rotated_wipe_tower_bbox(tower_footprint, rotation);
     }
-    const float margin = WIPE_TOWER_MARGIN + brim_width;
 
-    // clamp wipe tower position within plate boundaries
-    {
-        if (x + margin + wipe_tower_size(0) > plate_bbox_x_max_local_coord) {
-            x = plate_bbox_x_max_local_coord - wipe_tower_size(0) - margin;
-        } else if (x < margin + plate_bbox_x_min_local_coord) {
-            x = margin + plate_bbox_x_min_local_coord;
-        }
+    const float margin = WIPE_TOWER_MARGIN;
 
-        if (y + margin + wipe_tower_size(1) > plate_bbox_y_max_local_coord) {
-            y = plate_bbox_y_max_local_coord - wipe_tower_size(1) - margin;
-        } else if (y < margin) {
-            y = margin;
-        }
-    }
+    const Vec2d clamped_position = clamp_wipe_tower_position(footprint,
+		BoundingBoxf(Vec2d(plate_bbox_x_min_local_coord, plate_bbox_y_min_local_coord),
+                     Vec2d(plate_bbox_x_max_local_coord, plate_bbox_y_max_local_coord)),
+        Vec2d(x, y), margin);
+    x = float(clamped_position.x());
+    y = float(clamped_position.y());
 
     ConfigOptionFloat wt_x_opt(x);
     ConfigOptionFloat wt_y_opt(y);

--- a/src/slic3r/GUI/PartPlate.cpp
+++ b/src/slic3r/GUI/PartPlate.cpp
@@ -2239,15 +2239,13 @@ PartPlate::WipeTowerPreview PartPlate::wipe_tower_preview(const DynamicPrintConf
     used_filaments.erase(std::unique(used_filaments.begin(), used_filaments.end()),
                          used_filaments.end());
 
-    PrintConfig preview_config = m_print != nullptr ? m_print->config() : PrintConfig{};
+    PrintConfig preview_config;
     preview_config.apply(full_config, true);
 
-    PrintRegionConfig preview_region_config =
-        m_print != nullptr ? m_print->default_region_config() : PrintRegionConfig{};
+    PrintRegionConfig preview_region_config;
     preview_region_config.apply(full_config, true);
 
-    const bool is_bbl_printer = wxGetApp().preset_bundle != nullptr && wxGetApp().preset_bundle->is_bbl_vendor();
-    const bool is_type2 = !is_bbl_printer && preview_config.wipe_tower_type.value == WipeTowerType::Type2;
+    const bool is_type2 = preview_config.wipe_tower_type.value == WipeTowerType::Type2;
 
     float tower_height = 0.f;
     if (m_model != nullptr) {
@@ -2276,12 +2274,10 @@ PartPlate::WipeTowerPreview PartPlate::wipe_tower_preview(const DynamicPrintConf
     if (tower_data != nullptr &&
         tower_data->footprint.accuracy == WipeTowerFootprint::Accuracy::Exact) {
         result.footprint = tower_data->footprint;
-    } else if (is_type2) {
-        result.footprint = WipeTower2::make_conservative_footprint(
-            preview_config, preview_region_config, used_filaments, tower_height, layer_height, force_tower);
     } else {
-        result.footprint = WipeTower::make_conservative_footprint(
-            preview_config, used_filaments, tower_height, layer_height, force_tower);
+        result.footprint = make_conservative_wipe_tower_footprint(
+            preview_config.wipe_tower_type.value, preview_config, preview_region_config,
+            used_filaments, tower_height, layer_height, force_tower);
     }
     const bool use_sliced_mesh =
         tower_data != nullptr &&

--- a/src/slic3r/GUI/PartPlate.hpp
+++ b/src/slic3r/GUI/PartPlate.hpp
@@ -339,8 +339,18 @@ public:
 
     Vec3d get_origin() { return m_origin; }
     //Vec3d calculate_wipe_tower_size(const DynamicPrintConfig &config, const double w, const double wipe_volume, int plate_extruder_size = 0, bool use_global_objects = false) const;
-    Vec3d estimate_wipe_tower_size(const DynamicPrintConfig & config, const double w, const double wipe_volume, int extruder_count = 1, int plate_extruder_size = 0, bool use_global_objects = false, bool enable_wrapping_detection = false) const;
-    arrangement::ArrangePolygon estimate_wipe_tower_polygon(const DynamicPrintConfig & config, int plate_index, Vec3d& wt_pos, Vec3d& wt_size, int extruder_count = 1, int plate_extruder_size = 0, bool use_global_objects = false) const;
+    struct WipeTowerPreview {
+        WipeTowerFootprint     footprint;
+        WipeTowerPreviewSource source = WipeTowerPreviewSource::None;
+    };
+
+    // Build the current GUI preview, preferring current sliced data and falling back to a
+    // Generated mesh from an estimated footprint. An empty footprint uses source == None.
+    WipeTowerPreview wipe_tower_preview() const;
+    // Shared preview implementation. plate_extruders contains 1-based IDs; allow_sliced_mesh
+    // controls whether current sliced geometry may be selected instead of a conservative estimate.
+    WipeTowerPreview wipe_tower_preview(const DynamicPrintConfig& full_config, const std::vector<int>& plate_extruders, bool use_global_objects, bool allow_sliced_mesh) const;
+    arrangement::ArrangePolygon estimate_wipe_tower_polygon(const DynamicPrintConfig& config, int plate_index, Vec3d& wt_pos, Vec3d& wt_size, const std::vector<int>& plate_extruders, bool use_global_objects = false) const;
     bool check_objects_empty_and_gcode3mf(std::vector<int> &result) const;
     // get used filaments from config, 1 based idx
     std::vector<int> get_extruders(bool conside_custom_gcode = false) const;

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -5821,8 +5821,8 @@ Plater::priv::priv(Plater *q, MainFrame *main_frame)
 		"nozzle_height", "skirt_type", "skirt_loops", "skirt_speed","min_skirt_length", "skirt_distance", "skirt_start_angle",
         "brim_width", "brim_object_gap", "brim_flow_ratio", "brim_use_efc_outline", "combine_brims", "brim_type", "nozzle_diameter", "single_extruder_multi_material", "preferred_orientation",
         "enable_prime_tower", "wipe_tower_x", "wipe_tower_y", "prime_tower_width", "prime_tower_brim_width", "prime_tower_skip_points", "prime_tower_enable_framework",
-        "prime_tower_infill_gap", "prime_volume",
-        "extruder_colour", "filament_colour", "filament_type", "material_colour", "printable_height", "extruder_printable_height", "printer_model", "printer_technology",
+        "prime_tower_infill_gap", "prime_volume", "prime_volume_mode", "purge_in_prime_tower", "flush_volumes_matrix", "flush_multiplier", "filament_minimal_purge_on_wipe_tower",
+        "extruder_colour", "filament_colour", "filament_type", "filament_diameter", "filament_change_length", "filament_adhesiveness_category", "filament_map", "material_colour", "printable_height", "extruder_printable_height", "printer_model", "printer_technology",
         // These values are necessary to construct SlicingParameters by the Canvas3D variable layer height editor.
         "layer_height", "initial_layer_print_height", "min_layer_height", "max_layer_height",
         "wall_loops", "outer_wall_filament_id", "inner_wall_filament_id", "sparse_infill_density", "sparse_infill_filament_id", "top_shell_layers",
@@ -5830,7 +5830,11 @@ Plater::priv::priv(Plater *q, MainFrame *main_frame)
         "support_top_z_distance", "support_bottom_z_distance", "raft_layers",
         "wipe_tower_rotation_angle", "wipe_tower_cone_angle", "wipe_tower_extra_spacing", "wipe_tower_extra_flow", "wipe_tower_max_purge_speed",
         "wipe_tower_wall_type", "wipe_tower_extra_rib_length","wipe_tower_rib_width","wipe_tower_fillet_wall",
-        "wipe_tower_filament",
+        "wipe_tower_filament", "wipe_tower_no_sparse_layers", "wipe_tower_type",
+        "enable_filament_ramming", "filament_ramming_parameters",
+        "filament_multitool_ramming", "filament_multitool_ramming_volume", "filament_multitool_ramming_flow",
+        "enable_tower_interface_features", "filament_tower_interface_purge_volume",
+        "timelapse_type", "enable_wrapping_detection", "wrapping_detection_layers",
         "best_object_pos",  "master_extruder_id"
         }))
     , sidebar(new Sidebar(q))
@@ -17742,6 +17746,7 @@ void Plater::on_config_change(const DynamicPrintConfig &config)
         }
         if (opt_key == "filament_type") {
             update_filament_colors_in_full_config();
+            update_scheduled = true;
             continue;
         }
         if (opt_key == "material_colour") {
@@ -17776,6 +17781,18 @@ void Plater::on_config_change(const DynamicPrintConfig &config)
             boost::starts_with(opt_key, "wipe_tower") ||
             opt_key == "filament_minimal_purge_on_wipe_tower" ||
             opt_key == "single_extruder_multi_material" ||
+            opt_key == "purge_in_prime_tower" ||
+            opt_key == "flush_volumes_matrix" || opt_key == "flush_multiplier" ||
+            opt_key == "enable_filament_ramming" || opt_key == "filament_ramming_parameters" ||
+            opt_key == "filament_multitool_ramming" || opt_key == "filament_multitool_ramming_volume" ||
+            opt_key == "filament_multitool_ramming_flow" ||
+            opt_key == "enable_tower_interface_features" || opt_key == "filament_tower_interface_purge_volume" ||
+            opt_key == "filament_diameter" || opt_key == "filament_change_length" || opt_key == "nozzle_diameter" ||
+            opt_key == "filament_adhesiveness_category" || opt_key == "filament_map" ||
+            opt_key == "layer_height" || opt_key == "initial_layer_print_height" ||
+            opt_key == "timelapse_type" || opt_key == "enable_wrapping_detection" ||
+            opt_key == "wrapping_detection_layers" || opt_key == "wrapping_exclude_area" ||
+            opt_key == "prime_volume_mode" ||
             // BBS
             opt_key == "prime_volume") {
             update_scheduled = true;

--- a/src/slic3r/GUI/Selection.cpp
+++ b/src/slic3r/GUI/Selection.cpp
@@ -1275,10 +1275,7 @@ void Selection::translate(const Vec3d &displacement, TransformationType transfor
                 Vec3d         tower_size          = v.bounding_box().size();
                 Vec3d         tower_origin        = m_cache.volumes_data[i].get_volume_position();
                 Vec3d         actual_displacement = displacement;
-                bool show_read_wipe_tower = wxGetApp().plater()->get_partplate_list().get_plate(plate_idx)->fff_print()->is_step_done(psWipeTower);
-                float brim_width = wxGetApp().preset_bundle->prints.get_edited_preset().config.opt_float("prime_tower_brim_width");
-
-                const double margin = show_read_wipe_tower ? WIPE_TOWER_MARGIN : brim_width + 0.5; // 0.5 is the line width of wipe tower
+                const double margin = WIPE_TOWER_MARGIN;
 
                 actual_displacement = (m_cache.volumes_data[i].get_instance_rotation_matrix() * m_cache.volumes_data[i].get_instance_scale_matrix() *
                                         m_cache.volumes_data[i].get_instance_mirror_matrix())

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -1874,7 +1874,7 @@ void Tab::on_value_change(const std::string& opt_key, const boost::any& value)
         wxGetApp().get_tab(Preset::TYPE_PRINT)->update();
     }
 
-    if(opt_key == "purge_in_prime_tower")
+    if (opt_key == "purge_in_prime_tower" || opt_key == "wipe_tower_type")
         wxGetApp().get_tab(Preset::TYPE_PRINT)->update();
 
 
@@ -3269,8 +3269,11 @@ void TabPrint::update()
     m_update_cnt--;
 
     if (m_update_cnt==0) {
-        if (m_active_page && !(m_active_page->title() == "Dependencies"))
+        if (m_active_page && !(m_active_page->title() == "Dependencies")) {
             toggle_options();
+            m_active_page->update_visibility(m_mode, true);
+            m_parent->Layout();
+        }
         // update() could be called during undo/redo execution
         // Update of objectList can cause a crash in this case (because m_objects doesn't match ObjectList)
         if (m_type != Preset::TYPE_MODEL && !wxGetApp().plater()->inside_snapshot_capture())

--- a/tests/libslic3r/CMakeLists.txt
+++ b/tests/libslic3r/CMakeLists.txt
@@ -31,6 +31,7 @@ add_executable(${_TEST_NAME}_tests
     test_utils.cpp
     test_timeutils.cpp
     test_voronoi.cpp
+    test_wipe_tower.cpp
     test_optimizers.cpp
     test_ordering_strategies.cpp
     # test_png_io.cpp

--- a/tests/libslic3r/test_wipe_tower.cpp
+++ b/tests/libslic3r/test_wipe_tower.cpp
@@ -1,0 +1,153 @@
+#include <catch2/catch_all.hpp>
+
+#include "libslic3r/GCode/WipeTower.hpp"
+#include "libslic3r/PrintConfig.hpp"
+
+using namespace Slic3r;
+using Catch::Matchers::WithinAbs;
+
+namespace {
+
+Polygon rectangle(float width, float depth)
+{
+    return Polygon({
+        Point::new_scale(0.f, 0.f),
+        Point::new_scale(width, 0.f),
+        Point::new_scale(width, depth),
+        Point::new_scale(0.f, depth)
+    });
+}
+
+} // namespace
+
+TEST_CASE("Wipe tower preview filament ids are normalized", "[WipeTower]")
+{
+    CHECK(normalize_wipe_tower_preview_filaments(4, {3, 7, 1, 3}, false) ==
+          std::vector<unsigned int>{1, 3});
+    CHECK(normalize_wipe_tower_preview_filaments(4, {2}, false).empty());
+    CHECK(normalize_wipe_tower_preview_filaments(4, {2}, true) ==
+          std::vector<unsigned int>{2});
+    CHECK(normalize_wipe_tower_preview_filaments(4, {}, true) ==
+          std::vector<unsigned int>{0});
+    CHECK(normalize_wipe_tower_preview_filaments(0, {}, true).empty());
+}
+
+TEST_CASE("Wipe tower footprint includes the fixed brim offset", "[WipeTower]")
+{
+    const WipeTowerFootprint footprint = make_wipe_tower_footprint_with_brim(
+        rectangle(20.f, 10.f), 12.f, 0.6f,
+        WipeTowerFootprint::Accuracy::Estimated, 7.f);
+
+    REQUIRE_FALSE(footprint.empty());
+    CHECK(footprint.accuracy == WipeTowerFootprint::Accuracy::Estimated);
+    CHECK_THAT(footprint.height, WithinAbs(12.f, 1e-5f));
+    CHECK_THAT(footprint.brim_width, WithinAbs(0.6f, 1e-5f));
+    CHECK_THAT(footprint.width, WithinAbs(21.2f, 1e-5f));
+    CHECK_THAT(footprint.depth, WithinAbs(11.2f, 1e-5f));
+    CHECK_THAT(footprint.planned_depth, WithinAbs(7.f, 1e-5f));
+    CHECK_THAT(footprint.bbox.min.x(), WithinAbs(-0.6, 1e-5));
+    CHECK_THAT(footprint.bbox.min.y(), WithinAbs(-0.6, 1e-5));
+    CHECK_THAT(footprint.bbox.max.x(), WithinAbs(20.6, 1e-5));
+    CHECK_THAT(footprint.bbox.max.y(), WithinAbs(10.6, 1e-5));
+}
+
+TEST_CASE("Wipe tower post-rotation offset is baked into local footprint coordinates", "[WipeTower]")
+{
+    constexpr double rotation = 0.5 * M_PI;
+    const Vec2f post_rotation_offset(5.f, 3.f);
+    const Vec2f local_offset = local_wipe_tower_offset(post_rotation_offset, rotation);
+    CHECK_THAT(local_offset.x(), WithinAbs(3.f, 1e-5f));
+    CHECK_THAT(local_offset.y(), WithinAbs(-5.f, 1e-5f));
+
+    Polygon outline = rectangle(20.f, 10.f);
+    outline.translate(Point::new_scale(-5.f, -3.f));
+    outline.translate(Point::new_scale(local_offset));
+    const WipeTowerFootprint footprint = finalize_wipe_tower_footprint(
+        outline, outline, 5.f, 0.f, WipeTowerFootprint::Accuracy::Exact, 10.f);
+
+    const Polygon transformed =
+        transformed_wipe_tower_outline(footprint, rotation, Vec2d(100., 100.));
+    const BoundingBox bbox = get_extents(transformed);
+    CHECK_THAT(unscale<double>(bbox.min.x()), WithinAbs(98., 1e-5));
+    CHECK_THAT(unscale<double>(bbox.min.y()), WithinAbs(98., 1e-5));
+    CHECK_THAT(unscale<double>(bbox.max.x()), WithinAbs(108., 1e-5));
+    CHECK_THAT(unscale<double>(bbox.max.y()), WithinAbs(118., 1e-5));
+}
+
+TEST_CASE("Wipe tower footprint rotation and clamping preserve its margin", "[WipeTower]")
+{
+    const WipeTowerFootprint footprint = finalize_wipe_tower_footprint(
+        rectangle(20.f, 10.f), rectangle(20.f, 10.f), 5.f, 0.f,
+        WipeTowerFootprint::Accuracy::Exact);
+    const BoundingBoxf rotated = rotated_wipe_tower_bbox(footprint, 0.5 * M_PI);
+
+    CHECK_THAT(rotated.min.x(), WithinAbs(-10., 1e-5));
+    CHECK_THAT(rotated.min.y(), WithinAbs(0., 1e-5));
+    CHECK_THAT(rotated.max.x(), WithinAbs(0., 1e-5));
+    CHECK_THAT(rotated.max.y(), WithinAbs(20., 1e-5));
+
+    const Vec2d clamped = clamp_wipe_tower_position(
+        rotated, BoundingBoxf(Vec2d::Zero(), Vec2d(100., 100.)), Vec2d(-50., 200.), 2.);
+    CHECK_THAT(clamped.x(), WithinAbs(12., 1e-5));
+    CHECK_THAT(clamped.y(), WithinAbs(78., 1e-5));
+
+    const Polygon transformed =
+        transformed_wipe_tower_outline(footprint, 0.5 * M_PI, Vec2d(12., 78.));
+    const BoundingBox transformed_bbox = get_extents(transformed);
+    CHECK_THAT(unscale<double>(transformed_bbox.min.x()), WithinAbs(2., 1e-5));
+    CHECK_THAT(unscale<double>(transformed_bbox.min.y()), WithinAbs(78., 1e-5));
+    CHECK_THAT(unscale<double>(transformed_bbox.max.x()), WithinAbs(12., 1e-5));
+    CHECK_THAT(unscale<double>(transformed_bbox.max.y()), WithinAbs(98., 1e-5));
+}
+
+TEST_CASE("Type1 conservative footprint uses per-filament change volume", "[WipeTower]")
+{
+    PrintConfig config;
+    config.filament_type.values = {"PLA", "PLA"};
+    config.filament_map.values = {1, 1};
+    config.filament_nozzle_map.values = {1, 1};
+    config.filament_adhesiveness_category.values = {0, 0};
+    config.filament_change_length.values = {0., 0.};
+    config.prime_tower_width.value = 40.;
+    config.prime_tower_brim_width.value = 0.;
+    config.prime_volume.value = 10.;
+    config.filament_prime_volume.values = {10., 10.};
+    config.filament_prime_volume_nc.values = {10., 10.};
+
+    const WipeTowerFootprint small =
+        WipeTower::make_conservative_footprint(config, {0, 1}, 1.f, 0.2f, false);
+
+    config.filament_prime_volume.values[1] = 1000.;
+    const WipeTowerFootprint large =
+        WipeTower::make_conservative_footprint(config, {0, 1}, 1.f, 0.2f, false);
+
+    REQUIRE_FALSE(small.empty());
+    REQUIRE_FALSE(large.empty());
+    CHECK(large.depth > small.depth);
+}
+
+TEST_CASE("Type1 conservative footprint uses nozzle-change prime volume", "[WipeTower]")
+{
+    PrintConfig config;
+    config.filament_type.values = {"PLA", "PLA"};
+    config.filament_map.values = {1, 1};
+    config.filament_nozzle_map.values = {1, 1};
+    config.filament_adhesiveness_category.values = {0, 0};
+    config.filament_change_length.values = {500., 500.};
+    config.prime_tower_width.value = 40.;
+    config.prime_tower_brim_width.value = 0.;
+    config.prime_volume.value = 10.;
+    config.filament_prime_volume.values = {10., 10.};
+    config.filament_prime_volume_nc.values = {10., 10.};
+
+    const WipeTowerFootprint small =
+        WipeTower::make_conservative_footprint(config, {0, 1}, 1.f, 0.2f, false);
+
+    config.filament_prime_volume_nc.values[1] = 1000.;
+    const WipeTowerFootprint large =
+        WipeTower::make_conservative_footprint(config, {0, 1}, 1.f, 0.2f, false);
+
+    REQUIRE_FALSE(small.empty());
+    REQUIRE_FALSE(large.empty());
+    CHECK(large.depth > small.depth);
+}


### PR DESCRIPTION

## Summary

This PR improves wipe tower preview accuracy and makes the same footprint available to rendering, arrangement, CLI checks, and post-slice validation.

## Changes

- Add a shared polygon-based `WipeTowerFootprint`. Use a lightweight estimate before slicing and the exact generated first-layer outline after slicing.
- Simplify estimation: Type 1 uses a direct conservative formula; Type 2 uses fixed `prime_volume` with linear transition analysis; estimated brim uses one fixed-width expansion.
- Unify estimated and sliced preview rendering, including rib/cone geometry, rotation, brim, and colors from the filaments actually used on the plate.
## Impact

- Does not change actual wipe tower slicing, purge/toolchange planning, or G-code generation.
- Only affects wipe tower preview, arrangement, placement clamping, outside-bed checks, CLI bounds, and clearance validation.


# Screenshots/Recordings/Graphs

<img width="1736" height="1194" alt="20260729-142926" src="https://github.com/user-attachments/assets/afb070f8-7d3d-4e91-8e82-b0a0bd666e75" />

<img width="1736" height="1194" alt="20260729-143126" src="https://github.com/user-attachments/assets/ab94fc24-04c4-4639-8af7-70a3a21c5eab" />


## Tests

<!--
> Please describe the tests that you have conducted to verify the changes made in this PR.
-->

<!--
> A guide for users on how to download the artifacts from this PR.
-->

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
