### PR TITLE
docs: add Microsoft Store install path for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,10 @@ Download the **Windows Installer exe** for your preferred version from the [rele
     - This file may already be available on your computer if you've installed visual studio.  Check the following location: `%VCINSTALLDIR%Redist\MSVC\v142`
     </details>
 
+### Microsoft Store
+
+Install from the [Microsoft Store](https://apps.microsoft.com/detail/9mv6gl23xm59) when you prefer a Store-signed package (helps on Windows 11 Smart App Control). Store builds use the official MSIX packaging path.
+
 ### Windows Package Manager
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Download the **Windows Installer exe** for your preferred version from the [rele
 
 ### Microsoft Store
 
-Install from the [Microsoft Store](https://apps.microsoft.com/detail/9mv6gl23xm59) when you prefer a Store-signed package (helps on Windows 11 Smart App Control). Store builds use the official MSIX packaging path.
+Install from the [Microsoft Store](https://apps.microsoft.com/detail/9mv6gl23xm59) when you prefer a Store-signed package (helps on Windows 11 Smart App Control).
 
 ### Windows Package Manager
 


### PR DESCRIPTION
## Summary

Add a short **Microsoft Store** install note under Windows, linking the official Store listing.

## Motivation

- SoftFever already ships MSIX Store packaging (`#14142`).
- On `#14810`, SoftFever recommended the Store as an alternative while code signing is still in progress, for Windows Smart App Control.
- README already documents winget / Homebrew / Flathub / AppImage, but not the Store path.

## Changes

- `README.md` only: one subsection before **Windows Package Manager**.
- Does not touch packaging scripts (`scripts/msix/**`) — orthogonal to open `#14799`.
- Does not change sponsor image path separators.

## Verification

- Store product page title resolves to OrcaSlicer (`apps.microsoft.com/detail/9mv6gl23xm59`).
- Diff is README-only; sponsor `SoftFever_doc\…` paths unchanged.
- Path free of competing open docs PRs (SECURITY owned by seed `#14833` only).

Closes nothing (docs discoverability; prior maintainer guidance on #14810).

---
<!-- fleet-pr-claim: agent_id=sera platform=hermes -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim:** `sera` · **Claim-TTL:** 72h
