### PR TITLE
Seamless modifier boundary: let a modifier change infill without growing its own wall loops

### DIFF
--- a/src/libslic3r/Layer.cpp
+++ b/src/libslic3r/Layer.cpp
@@ -141,6 +141,18 @@ bool Layer::is_perimeter_compatible(const Print& print, const PrintRegion& a, co
     const PrintRegionConfig& config       = a.config();
     const PrintRegionConfig& other_config = b.config();
 
+    // ORCA: exactly one side declares itself a pure parameter mask (seamless modifier boundary).
+    // It wants no walls of its own, so folding it into the neighbouring region's make_perimeters()
+    // call IS the requested behaviour and the per-option comparison below must not veto it.
+    // Two guards: if BOTH sides are flagged there is no parent region to inherit walls from, so we
+    // fall through and compare normally (two masks with different wall settings must not silently
+    // share loops); and we never merge across a wall filament change, or the mask's share of the
+    // walls would be printed in the other region's material.
+    if (config.seamless_modifier_boundary.value != other_config.seamless_modifier_boundary.value
+        && config.outer_wall_filament_id == other_config.outer_wall_filament_id
+        && config.inner_wall_filament_id == other_config.inner_wall_filament_id)
+        return true;
+
         return config.outer_wall_filament_id       == other_config.outer_wall_filament_id
 		&& config.inner_wall_filament_id       == other_config.inner_wall_filament_id
 		&& config.wall_loops                  == other_config.wall_loops
@@ -231,12 +243,27 @@ void Layer::make_perimeters()
 	            {
 	                // group slices (surfaces) according to number of extra perimeters
 	                std::map<unsigned short, Surfaces> slices;  // extra_perimeters => [ surface, surface... ]
+	                // ORCA: a seamless_modifier_boundary region is a parameter mask, not a wall owner, so it
+	                // must never donate the perimeter configuration - otherwise the merged loops would adopt
+	                // the modifier's wall settings, the opposite of "inherit the parent's walls". Among the
+	                // regions that do own walls, keep the original heuristic (highest infill density).
+	                LayerRegion *layerm_wall_owner = nullptr;
 	                for (LayerRegion *layerm : layerms) {
 	                    for (const Surface &surface : layerm->slices.surfaces)
 	                        slices[surface.extra_perimeters].emplace_back(surface);
 	                    if (layerm->region().config().sparse_infill_density > layerm_config->region().config().sparse_infill_density)
 	                    	layerm_config = layerm;
+	                    if (! layerm->region().config().seamless_modifier_boundary.value &&
+	                        (layerm_wall_owner == nullptr ||
+	                         layerm->region().config().sparse_infill_density >
+	                             layerm_wall_owner->region().config().sparse_infill_density))
+	                        layerm_wall_owner = layerm;
 	                }
+	                // If every region in the group opted out - the parent region vanished on this layer
+	                // because the modifier spans the whole cross section - fall back to the original rule so
+	                // the layer still gets its outer wall.
+	                if (layerm_wall_owner != nullptr)
+	                    layerm_config = layerm_wall_owner;
 	                // merge the surfaces assigned to each group
 	                for (std::pair<const unsigned short,Surfaces> &surfaces_with_extra_perimeters : slices)
 	                    new_slices.append(offset_ex(surfaces_with_extra_perimeters.second, ClipperSafetyOffset), surfaces_with_extra_perimeters.second.front());

--- a/src/libslic3r/Layer.cpp
+++ b/src/libslic3r/Layer.cpp
@@ -141,16 +141,19 @@ bool Layer::is_perimeter_compatible(const Print& print, const PrintRegion& a, co
     const PrintRegionConfig& config       = a.config();
     const PrintRegionConfig& other_config = b.config();
 
-    // ORCA: exactly one side declares itself a pure parameter mask (seamless modifier boundary).
-    // It wants no walls of its own, so folding it into the neighbouring region's make_perimeters()
-    // call IS the requested behaviour and the per-option comparison below must not veto it.
-    // Two guards: if BOTH sides are flagged there is no parent region to inherit walls from, so we
-    // fall through and compare normally (two masks with different wall settings must not silently
-    // share loops); and we never merge across a wall filament change, or the mask's share of the
-    // walls would be printed in the other region's material.
-    if (config.seamless_modifier_boundary.value != other_config.seamless_modifier_boundary.value
-        && config.outer_wall_filament_id == other_config.outer_wall_filament_id
-        && config.inner_wall_filament_id == other_config.inner_wall_filament_id)
+    // ORCA: either side declares itself a pure parameter mask (seamless modifier boundary), so it
+    // wants no wall loops of its own along the shared boundary - neither inner nor outer. Folding it
+    // into the neighbouring region's make_perimeters() call IS the requested behaviour, and the
+    // per-option comparison below must not veto it for any reason:
+    //  - it must fire when the option is enabled globally on the print profile, where BOTH regions
+    //    carry it: an "exactly one side" test would make the global case a silent no-op;
+    //  - it must fire across a wall filament difference too. A mask owns no walls by definition, so
+    //    nothing of its own is left to print in its own material; the surviving loops belong to the
+    //    neighbour and correctly use the neighbour's filament. A modifier added through the GUI
+    //    defaults to a different extruder id than its parent part, so testing filament equality
+    //    here vetoed the merge in precisely the common case.
+    // Which region donates the perimeter parameters is decided in make_perimeters() below.
+    if (config.seamless_modifier_boundary.value || other_config.seamless_modifier_boundary.value)
         return true;
 
         return config.outer_wall_filament_id       == other_config.outer_wall_filament_id
@@ -247,10 +250,23 @@ void Layer::make_perimeters()
 	                // must never donate the perimeter configuration - otherwise the merged loops would adopt
 	                // the modifier's wall settings, the opposite of "inherit the parent's walls". Among the
 	                // regions that do own walls, keep the original heuristic (highest infill density).
+	                // When EVERY region in the group is a mask - the global case, or a modifier spanning
+	                // the whole cross section - fall back to the largest region by area rather than the
+	                // densest: the parent body is virtually always the largest and its walls are the
+	                // ones to keep.
 	                LayerRegion *layerm_wall_owner = nullptr;
+	                LayerRegion *layerm_largest    = nullptr;
+	                double       largest_area      = -1.;
 	                for (LayerRegion *layerm : layerms) {
-	                    for (const Surface &surface : layerm->slices.surfaces)
+	                    double region_area = 0.;
+	                    for (const Surface &surface : layerm->slices.surfaces) {
 	                        slices[surface.extra_perimeters].emplace_back(surface);
+	                        region_area += surface.expolygon.area();
+	                    }
+	                    if (region_area > largest_area) {
+	                        largest_area   = region_area;
+	                        layerm_largest = layerm;
+	                    }
 	                    if (layerm->region().config().sparse_infill_density > layerm_config->region().config().sparse_infill_density)
 	                    	layerm_config = layerm;
 	                    if (! layerm->region().config().seamless_modifier_boundary.value &&
@@ -259,6 +275,8 @@ void Layer::make_perimeters()
 	                             layerm_wall_owner->region().config().sparse_infill_density))
 	                        layerm_wall_owner = layerm;
 	                }
+	                if (layerm_wall_owner == nullptr && layerm_largest != nullptr)
+	                    layerm_wall_owner = layerm_largest;
 	                // If every region in the group opted out - the parent region vanished on this layer
 	                // because the modifier spans the whole cross section - fall back to the original rule so
 	                // the layer still gets its outer wall.

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -1034,6 +1034,7 @@ static std::vector<std::string> s_Preset_print_options{
     "wall_sequence",
     "is_infill_first",
     "sparse_infill_density",
+    "seamless_modifier_boundary",
     "fill_multiline",
     "gyroid_optimized",
     "sparse_infill_pattern",

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -3358,6 +3358,17 @@ void PrintConfigDef::init_fff_params()
     def->max = 100;
     def->set_default_value(new ConfigOptionPercent(20));
 
+    def = this->add("seamless_modifier_boundary", coBool);
+    def->label = L("Seamless modifier boundary");
+    def->category = L("Strength");
+    def->tooltip = L("Set this on a modifier volume to make it a pure parameter mask: it overrides infill and "
+                     "solid-layer settings inside its volume but never grows wall loops of its own, sharing the "
+                     "walls of the surrounding region instead. Intended for flexible filaments, where a wall loop "
+                     "at the modifier boundary creates a rigid internal shell. While this is enabled the "
+                     "modifier's own wall settings are ignored.");
+    def->mode = comAdvanced;
+    def->set_default_value(new ConfigOptionBool(false));
+
     def           = this->add("align_infill_direction_to_model", coBool);
     def->label    = L("Align directions to model");
     def->category = L("Strength");

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -1263,6 +1263,7 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionFloat,                infill_shift_step))
     ((ConfigOptionString,               sparse_infill_rotate_template))
     ((ConfigOptionPercent,              sparse_infill_density))
+    ((ConfigOptionBool,                 seamless_modifier_boundary))
     ((ConfigOptionEnum<InfillPattern>,  sparse_infill_pattern))
     ((ConfigOptionFloat,                lateral_lattice_angle_1))
     ((ConfigOptionFloat,                lateral_lattice_angle_2))

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -1198,6 +1198,7 @@ bool PrintObject::invalidate_state_by_config_options(
             }
         } else if (
                opt_key == "wall_loops"
+            || opt_key == "seamless_modifier_boundary"
             || opt_key == "alternate_extra_wall"
             || opt_key == "top_one_wall_type"
             || opt_key == "min_width_top_surface"
@@ -1611,10 +1612,15 @@ void PrintObject::detect_surfaces_type()
     // This is useful if one of the parts is to be dissolved, or if it is transparent and the internal shells
     // should be visible.
     bool spiral_mode      = this->print()->config().spiral_mode.value;
-    bool interface_shells = ! spiral_mode && m_config.interface_shells.value;
+    bool interface_shells_object = ! spiral_mode && m_config.interface_shells.value;
     size_t num_layers     = spiral_mode ? std::min(size_t(this->printing_region(0).config().bottom_shell_layers), m_layers.size()) : m_layers.size();
 
     for (size_t region_id = 0; region_id < this->num_printing_regions(); ++ region_id) {
+        // ORCA: a seamless modifier boundary must not build top / bottom shells against its neighbours -
+        // that is the solid-cap half of the artefact the flag removes. This is a no-op at the default
+        // interface_shells = 0, which is why a density-only modifier already slices clean today.
+        const bool interface_shells = interface_shells_object &&
+            ! this->printing_region(region_id).config().seamless_modifier_boundary.value;
         BOOST_LOG_TRIVIAL(debug) << "Detecting solid surfaces for region " << region_id << " in parallel - start";
 #ifdef SLIC3R_DEBUG_SLICE_PROCESSING
         for (Layer *layer : m_layers)

--- a/src/slic3r/GUI/GUI_Factories.cpp
+++ b/src/slic3r/GUI/GUI_Factories.cpp
@@ -58,7 +58,7 @@ static SettingsFactory::Bundle FREQ_SETTINGS_BUNDLE_FFF =
     //BBS
     { L("Quality"), { "layer_height" } },
     { L("Shell"), { "wall_loops", "top_shell_layers", "bottom_shell_layers"} },
-    { L("Infill")               , { "sparse_infill_density", "sparse_infill_pattern" } },
+    { L("Infill")               , { "sparse_infill_density", "sparse_infill_pattern", "seamless_modifier_boundary" } },
     // BBS
     { L("Support")     , { "enable_support", "support_type", "support_threshold_angle", "support_threshold_overlap",
                                     "support_base_pattern", "support_on_build_plate_only","support_critical_regions_only",

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -2813,6 +2813,7 @@ void TabPrint::build()
 
         optgroup = page->new_optgroup(L("Infill"), L"param_infill");
         optgroup->append_single_option_line("sparse_infill_density", "strength_settings_infill#sparse-infill-density");
+        optgroup->append_single_option_line("seamless_modifier_boundary", "strength_settings_infill#seamless-modifier-boundary");
         optgroup->append_single_option_line("fill_multiline", "strength_settings_infill#fill-multiline");
         optgroup->append_single_option_line("sparse_infill_pattern", "strength_settings_infill#sparse-infill-pattern");
         optgroup->append_single_option_line("gyroid_optimized", "strength_settings_patterns#gyroid-optimized");


### PR DESCRIPTION
> **TL;DR — 1/3 what the bug is.** A modifier that changes **only** infill density already slices fine today. The bug needs the modifier to *also* change a wall-affecting option (`wall_loops`, a wall speed, a wall line width…). When it does, the modifier's boundary *inside* the parent grows a full set of wall loops that nobody asked for. This PR lets a modifier act as a pure parameter mask: the loops go away, the infill override still applies.
>
> **2/3 how to reproduce.** Cube + interior modifier box, set the modifier's `wall_loops` to anything different from the parent. If you change density alone you will see nothing wrong — that path is already handled by the existing perimeter merging in `Layer::make_perimeters()`. Measured on the repro file in [this comment](https://github.com/OrcaSlicer/OrcaSlicer/pull/15011#issuecomment-5126870181): **48.7% of that model's total wall extrusion was spurious internal loops.**
>
> **3/3 what it does *not* do.** It does not take walls away from the modifier in general. Walls are donated by whichever region in the merged group is *not* a mask; on layers where the parent has no area, the modifier keeps its own wall settings. Fill configuration stays per-region throughout, so density/pattern/flow/speed overrides are unaffected.

## Summary

Adds a per-region option **`seamless_modifier_boundary`** (default **off**). When set on a modifier volume, that modifier acts as a *pure parameter mask*: it still overrides infill and solid-layer settings inside its volume, but it no longer grows wall loops of its own along its intersection with the parent object. The surrounding region's perimeters are shared instead.

With the option unset, the slicing path is byte-identical to today.

## Effect, enabled vs disabled

![OrcaSlicer preview, option off vs on](https://raw.githubusercontent.com/tommasobbianchi/snaporca-cad/assets/pr15011/docs/pr15011/seamless-gui-comparison.png)

OrcaSlicer preview, same model and same camera, toggling only the checkbox on the modifier
volume (visible in the left panel of each half). Sovol Zero profile, 30 mm cube with an
interior modifier at `sparse_infill_density = 80%` against the parent's default, and the
modifier's `wall_loops` set to 0.

**Left, option off:** a wall loop pair runs along the modifier boundary and fences the two
infill zones apart. Note this happens even with the modifier's own `wall_loops = 0` - the
loops belong to the *parent* region, which has become an annulus with a hole where the
modifier sits, so it walls that hole.

**Right, option on:** the loops are gone and the two infill densities fuse into a single
continuous region. The object's own outer and inner walls are untouched.


![seamless_modifier_boundary toolpath comparison](https://raw.githubusercontent.com/tommasobbianchi/snaporca-cad/assets/pr15011/docs/pr15011/seamless-toolpaths.png)

One sliced layer (Z = 15 mm) through a 30 mm cube carrying an interior 20x20x14 mm modifier
(`sparse_infill_density = 80%`, `wall_loops = 4`). The dashed blue outline is the modifier
footprint. These are the actual toolpaths parsed back out of the exported G-code, not a
reconstruction - red is outer wall, orange inner wall, grey sparse infill.

- **Left** - no modifier, for reference.
- **Middle - option disabled (today's behaviour):** the modifier has grown its own closed wall
  stack right on its boundary, including an *external* perimeter, buried inside the part. In a
  flexible print that ring is a rigid rib.
- **Right - option enabled:** the ring is gone, the walls are exactly the reference walls, and
  the infill inside the footprint is still visibly denser - the override is applied, the wall is
  not.

## The problem

When a modifier volume changes an option that affects perimeter generation, `Layer::is_perimeter_compatible()` returns false for that region pair. `Layer::make_perimeters()` then runs `PerimeterGenerator` separately per region, and each region emits its own **closed** loop set along the shared internal boundary — including an *external* perimeter, extruded at external-perimeter width and speed, buried inside the part.

For rigid materials this is mostly wasted extrusion. For **flexible filaments it is a functional defect**: a closed, continuous wall loop is dramatically stiffer in tension than the sparse infill it replaces, so the modifier boundary becomes a rigid rib exactly where a stiffness *transition* was intended.

Measured on a 30 mm cube with an interior 20×20×14 mm modifier box (5..25, 5..25, 8..22 — never touching the outer shell), modifier setting `wall_loops = 4` and `sparse_infill_density = 80%`:

| | wall blocks | Outer wall | Inner wall | Sparse infill |
|---|---:|---:|---:|---:|
| no modifier | 300 | 17753.9 mm | 17275.1 mm | 49492.5 mm |
| modifier, option **off** (current behaviour) | **580** | **28928.4 mm** | **38256.4 mm** | 77628.5 mm |
| modifier, option **on** | **300** | **17753.9 mm** | **17275.1 mm** | **95173.8 mm** |

With the option on, wall output returns *exactly* to the no-modifier baseline while the infill override is applied in full. Note the third column of the middle row: with the option off, the modifier's own walls also **eat into its infill area** (77628.5 vs 95173.8 mm), so the requested density is not actually delivered where it was asked for.

Worth stating clearly, because it narrows the scope: a modifier that changes **only** `sparse_infill_density` already slices cleanly today — the existing perimeter-merging in `Layer::make_perimeters()` handles it, and `interface_shells` defaults to off so no solid cap is generated either. This PR is about the case where the modifier also needs to touch a wall-affecting option.

## Why this matters: soft materials and podiatric orthotics

The motivating application is **3D-printed podiatry insoles / plantar orthotics** — custom foot orthoses printed in TPU and similar elastomers.

These devices are not uniform-stiffness parts. A prescription orthotic is defined precisely by its *zones*: a rigid or semi-rigid shell region under the medial arch, a softer heel strike zone, a compliant metatarsal pad, a graded transition at the shell edge so the device does not create a pressure ridge under the foot. The natural way to express that in a slicer is exactly one object with several modifier volumes, each setting its own infill density — and often its own wall count, since wall count is one of the strongest stiffness levers available in a flexible print.

The moment a modifier changes wall count, today's behaviour inserts a closed wall loop around the entire boundary of that zone. In an orthotic that is not a cosmetic artifact:

- **It creates a palpable ridge.** A continuous vertical wall running through the body of the insole is far stiffer than its surroundings and transmits load as a line rather than a field. The patient feels an edge under the foot exactly at the zone transition — the thing an orthotist spends effort designing *out*.
- **It defeats graded stiffness.** The whole point of a soft/stiff zone boundary is a gradient. A closed rigid loop turns a gradient into a step discontinuity, and the mechanical behaviour of the device stops matching what was prescribed.
- **It becomes a fatigue and delamination site.** An insole sees hundreds of thousands of flex cycles. A stiffness discontinuity is a stress concentrator; in TPU the boundary between a wall-bounded zone and the surrounding infill is a natural crack initiation and layer-separation path.
- **It is invisible in preview until printed.** The loops are internal, so the defect is easy to ship into a patient-facing device.

The same reasoning applies to any soft-material part with functionally graded zones — prosthetic liners, seating and pressure-relief cushions, grips, seals, vibration-damping mounts — but orthotics are where it bites hardest, because the device is prescribed by its mechanical zoning and worn against skin.

This option lets a modifier do what the orthotist actually means: *"inside this volume, change the fill; do not build me a wall."*

## Where the option can be set

It works both ways:

- **On a modifier volume** (right-click the modifier -> Infill), which is the normal use.
- **Globally on the print profile** (Strength -> Infill), which flags every region; the
  perimeter group then keeps the walls of the largest region, i.e. the parent body.

It also merges across a **wall filament difference**. A mask owns no walls, so nothing of its
own is left to print in its own material - and a modifier added through the GUI defaults to a
different extruder id than its parent part, so requiring equal filament ids would veto the
merge in precisely the common case.

## Design

The mesh boolean and region split are unchanged — that machinery is correct and is what carries the parameter override. What the option changes is *wall ownership*.

`seamless_modifier_boundary` lives in **`PrintRegionConfig`** (not `PrintObjectConfig`) so it can be set per volume.

**`Layer::is_perimeter_compatible()`** — short-circuits to `true` when exactly one of the two regions is flagged, so the flagged region is folded into its neighbour's `make_perimeters()` call. Two guards:
- If **both** sides are flagged there is no parent to inherit walls from, so it falls through to the normal per-option comparison — two masks with differing wall settings must not silently share loops.
- Never merge across a **wall filament change** (`outer_wall_filament_id` / `inner_wall_filament_id`), or the mask's share of the walls would print in the other region's material. You cannot both change the wall extruder and have no walls.

**`Layer::make_perimeters()`** — the merged call takes its perimeter configuration from one donor region, chosen today as the one with the highest infill density (because gap fill keys off infill existence). A dense modifier would win that vote and impose *its* wall settings on the merged loops, which is the opposite of the intent. The donor is now chosen among regions that actually own walls, keeping the original highest-density heuristic within that set. If **every** region in the group opted out — the parent region vanished on this layer because the modifier spans the whole cross-section — it falls back to the original rule so the layer still gets its outer wall.

**`PrintObject::detect_surfaces_type()`** — a flagged region never builds interface shells against its neighbours, which is the solid-cap half of the same artifact. This is a no-op at the default `interface_shells = 0`.

The existing fill-surface split (`intersection_ex(fill_surfaces, region slices)`) is untouched — that is what keeps the infill override working, and is why infill still changes while walls do not.

## Edge cases

**Modifier crossing the outer perimeter** — safe by construction, and verified. `PrintObjectSlice.cpp` clips every modifier to its parent (`intersection_ex(parent, source)`, with the parent getting `diff_ex`), so a modifier region can never own area outside the object; and perimeters are generated on the *union* of the merged group, whose outer contour is the object cross-section. Measured with a modifier deliberately poking through a side wall (x 15..40 on a 0..30 cube), `wall_loops = 4`:

| | wall blocks | Outer wall | Inner wall |
|---|---:|---:|---:|
| no modifier | 300 | 17753.9 mm | 17275.1 mm |
| crossing modifier, option off | 440 | 24628.9 mm | 32359.1 mm |
| crossing modifier, option **on** | **300** | **17753.9 mm** | **17275.1 mm** |

The outer shell is bit-identical to a plain cube — the modifier does not split it.

**Modifier spanning the entire cross-section on a layer** — the parent's slice becomes empty and the empty region is dropped, so the group contains only flagged regions. The fallback keeps the original donor rule, so the layer still gets its outer wall (measured: outer wall unchanged at 17753.9 mm, no crash); inner walls follow the modifier's settings on those layers. Unavoidable — on a layer where the parent does not exist, something must own the wall.

**Spiral vase** — untouched; spiral mode collapses to a single region before this path.

**Nested / multiple flagged modifiers** — both flagged means they compare normally against each other and each merges with the parent, so they land in one group. No change to the existing transitivity assumption in group building.

## Files

| file | change |
|---|---|
| `PrintConfig.hpp` | option in `PrintRegionConfig` |
| `PrintConfig.cpp` | definition, `comAdvanced`, default `false` |
| `Layer.cpp` | compatibility short-circuit + donor selection |
| `PrintObject.cpp` | per-region `interface_shells`; `posPerimeters` invalidation |
| `Preset.cpp` | `s_Preset_print_options` registration |
| `Tab.cpp` | UI line under Strength → Infill |
| `GUI_Factories.cpp` | per-volume settings bundle (Infill) |

The `Preset.cpp` and `PrintObject.cpp` registrations are the two easy to miss: without the first, the preset loader drops the key and the checkbox resets on restart; without the second, toggling does not invalidate and the preview goes stale.

## Validation

Implemented and validated on an OrcaSlicer 2.4.0-dev-based tree, built twice on two machines (Release, `-O3 -DNDEBUG`):

- All measurements above are from sliced G-code, comparing feature-type extrusion block counts and path lengths.
- With the option **off**, output is **byte-identical** to the pre-patch binary on the same inputs.
- Reproduced identically on a second machine and a second tree — same numbers to 0.1 mm.
- GUI-verified: the option appears under Strength → Infill and on a modifier's per-volume settings.

**Disclosure:** this branch is a hand-applied port of that work onto current `main` (the anchors differ between the two trees). Each hunk was re-applied against `main`'s actual sources and reviewed, but **I was not able to compile this exact branch locally** — current `main` requires the exact bundled Python from its own dependency set, which I could not build in the available environment. CI will be the first compile of this port. Happy to fix promptly if it errors.


---

*Correction to the first revision of this description: the extrusion-length figures were
originally measured in the X/Y plane. These profiles emit belt-convention G-code, where the
layer plane is spanned by X and Z, so those numbers were X-projections only. All lengths above
are now true 3D path length. Block counts, the comparisons and every conclusion are unchanged.*

