### PR TITLE
fix: prevent crash on startup with old presets missing newer filament options

### DIFF
--- a/src/libslic3r/PresetBundle.cpp
+++ b/src/libslic3r/PresetBundle.cpp
@@ -206,29 +206,28 @@ DynamicPrintConfig PresetBundle::construct_full_config(
                 // BBS
                 ConfigOptionVectorBase *opt_vec_dst = static_cast<ConfigOptionVectorBase *>(opt_dst);
                 {
-                    if (apply_extruder) {
-                        std::vector<const ConfigOption *> filament_opts(num_filaments, nullptr);
-                        // Setting a vector value from all filament_configs.
-                        for (size_t i = 0; i < filament_opts.size(); ++i) filament_opts[i] = filament_temp_configs[i].option(key);
-                        // Skip if any filament option has no values (old preset missing this key).
-                        const bool any_empty = std::any_of(filament_opts.begin(), filament_opts.end(),
-                            [](const ConfigOption *opt) {
-                                const auto *vec = dynamic_cast<const ConfigOptionVectorBase *>(opt);
-                                return vec && vec->size() == 0;
-                            });
-                        if (!any_empty)
+                    // Skip if any filament option has no values (old preset missing this key).
+                    const bool any_empty = std::any_of(filament_temp_configs.begin(), filament_temp_configs.end(),
+                        [&key](const DynamicPrintConfig &cfg) {
+                            const auto *vec = dynamic_cast<const ConfigOptionVectorBase *>(cfg.option(key));
+                            return vec && vec->size() == 0;
+                        });
+                    if (!any_empty) {
+                        if (apply_extruder) {
+                            std::vector<const ConfigOption *> filament_opts(num_filaments, nullptr);
+                            // Setting a vector value from all filament_configs.
+                            for (size_t i = 0; i < filament_opts.size(); ++i) filament_opts[i] = filament_temp_configs[i].option(key);
                             opt_vec_dst->set(filament_opts);
-                    } else {
-                        for (size_t i = 0; i < num_filaments; ++i) {
-                            const ConfigOptionVectorBase *filament_option = static_cast<const ConfigOptionVectorBase *>(filament_temp_configs[i].option(key));
-                            // Skip if option has no values (old preset missing this key).
-                            if (filament_option && filament_option->size() == 0) continue;
-                            if (i == 0)
-                                opt_vec_dst->set(filament_option);
-                            else
-                                opt_vec_dst->append(filament_option);
+                        } else {
+                            for (size_t i = 0; i < num_filaments; ++i) {
+                                const ConfigOptionVectorBase *filament_option = static_cast<const ConfigOptionVectorBase *>(filament_temp_configs[i].option(key));
+                                if (i == 0)
+                                    opt_vec_dst->set(filament_option);
+                                else
+                                    opt_vec_dst->append(filament_option);
 
-                            if (key == "filament_extruder_variant") filament_variant_count[i] = filament_option->size();
+                                if (key == "filament_extruder_variant") filament_variant_count[i] = filament_option->size();
+                            }
                         }
                     }
                 }
@@ -4224,32 +4223,31 @@ DynamicPrintConfig PresetBundle::full_fff_config(bool apply_extruder, std::optio
                 // BBS
                 ConfigOptionVectorBase* opt_vec_dst = static_cast<ConfigOptionVectorBase*>(opt_dst);
                 {
-                    if (apply_extruder) {
-                        std::vector<const ConfigOption*> filament_opts(num_filaments, nullptr);
-                        // Setting a vector value from all filament_configs.
-                        for (size_t i = 0; i < filament_opts.size(); ++i)
-                            filament_opts[i] = filament_temp_configs[i].option(key);
-                        // Skip if any filament option has no values (old preset missing this key).
-                        const bool any_empty = std::any_of(filament_opts.begin(), filament_opts.end(),
-                            [](const ConfigOption *opt) {
-                                const auto *vec = dynamic_cast<const ConfigOptionVectorBase *>(opt);
-                                return vec && vec->size() == 0;
-                            });
-                        if (!any_empty)
+                    // Skip if any filament option has no values (old preset missing this key).
+                    const bool any_empty = std::any_of(filament_temp_configs.begin(), filament_temp_configs.end(),
+                        [&key](const DynamicPrintConfig &cfg) {
+                            const auto *vec = dynamic_cast<const ConfigOptionVectorBase *>(cfg.option(key));
+                            return vec && vec->size() == 0;
+                        });
+                    if (!any_empty) {
+                        if (apply_extruder) {
+                            std::vector<const ConfigOption*> filament_opts(num_filaments, nullptr);
+                            // Setting a vector value from all filament_configs.
+                            for (size_t i = 0; i < filament_opts.size(); ++i)
+                                filament_opts[i] = filament_temp_configs[i].option(key);
                             opt_vec_dst->set(filament_opts);
-                    }
-                    else {
-                        for (size_t i = 0; i < num_filaments; ++i) {
-                            const ConfigOptionVectorBase* filament_option = static_cast<const ConfigOptionVectorBase*>(filament_temp_configs[i].option(key));
-                            // Skip if option has no values (old preset missing this key).
-                            if (filament_option && filament_option->size() == 0) continue;
-                            if (i == 0)
-                                opt_vec_dst->set(filament_option);
-                            else
-                                opt_vec_dst->append(filament_option);
+                        }
+                        else {
+                            for (size_t i = 0; i < num_filaments; ++i) {
+                                const ConfigOptionVectorBase* filament_option = static_cast<const ConfigOptionVectorBase*>(filament_temp_configs[i].option(key));
+                                if (i == 0)
+                                    opt_vec_dst->set(filament_option);
+                                else
+                                    opt_vec_dst->append(filament_option);
 
-                            if (key == "filament_extruder_variant")
-                                filament_variant_count[i] = filament_option->size();
+                                if (key == "filament_extruder_variant")
+                                    filament_variant_count[i] = filament_option->size();
+                            }
                         }
                     }
                 }

--- a/src/libslic3r/PresetBundle.cpp
+++ b/src/libslic3r/PresetBundle.cpp
@@ -210,10 +210,19 @@ DynamicPrintConfig PresetBundle::construct_full_config(
                         std::vector<const ConfigOption *> filament_opts(num_filaments, nullptr);
                         // Setting a vector value from all filament_configs.
                         for (size_t i = 0; i < filament_opts.size(); ++i) filament_opts[i] = filament_temp_configs[i].option(key);
-                        opt_vec_dst->set(filament_opts);
+                        // Skip if any filament option has no values (old preset missing this key).
+                        const bool any_empty = std::any_of(filament_opts.begin(), filament_opts.end(),
+                            [](const ConfigOption *opt) {
+                                const auto *vec = dynamic_cast<const ConfigOptionVectorBase *>(opt);
+                                return vec && vec->size() == 0;
+                            });
+                        if (!any_empty)
+                            opt_vec_dst->set(filament_opts);
                     } else {
                         for (size_t i = 0; i < num_filaments; ++i) {
                             const ConfigOptionVectorBase *filament_option = static_cast<const ConfigOptionVectorBase *>(filament_temp_configs[i].option(key));
+                            // Skip if option has no values (old preset missing this key).
+                            if (filament_option && filament_option->size() == 0) continue;
                             if (i == 0)
                                 opt_vec_dst->set(filament_option);
                             else
@@ -4220,11 +4229,20 @@ DynamicPrintConfig PresetBundle::full_fff_config(bool apply_extruder, std::optio
                         // Setting a vector value from all filament_configs.
                         for (size_t i = 0; i < filament_opts.size(); ++i)
                             filament_opts[i] = filament_temp_configs[i].option(key);
-                        opt_vec_dst->set(filament_opts);
+                        // Skip if any filament option has no values (old preset missing this key).
+                        const bool any_empty = std::any_of(filament_opts.begin(), filament_opts.end(),
+                            [](const ConfigOption *opt) {
+                                const auto *vec = dynamic_cast<const ConfigOptionVectorBase *>(opt);
+                                return vec && vec->size() == 0;
+                            });
+                        if (!any_empty)
+                            opt_vec_dst->set(filament_opts);
                     }
                     else {
                         for (size_t i = 0; i < num_filaments; ++i) {
                             const ConfigOptionVectorBase* filament_option = static_cast<const ConfigOptionVectorBase*>(filament_temp_configs[i].option(key));
+                            // Skip if option has no values (old preset missing this key).
+                            if (filament_option && filament_option->size() == 0) continue;
                             if (i == 0)
                                 opt_vec_dst->set(filament_option);
                             else

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -10604,7 +10604,7 @@ std::vector<int> DynamicPrintConfig::update_values_to_printer_extruders(DynamicP
             case coStrings:
             {
                 ConfigOptionStrings * opt = this->option<ConfigOptionStrings>(key);
-                if (!opt) continue;
+                if (!opt || opt->values.empty()) continue;
                 std::vector<std::string> new_values;
 
                 new_values.resize(variant_count * stride);
@@ -10619,7 +10619,7 @@ std::vector<int> DynamicPrintConfig::update_values_to_printer_extruders(DynamicP
             case coInts:
             {
                 ConfigOptionInts * opt = this->option<ConfigOptionInts>(key);
-                if (!opt) continue;
+                if (!opt || opt->values.empty()) continue;
                 std::vector<int> new_values;
 
                 new_values.resize(variant_count * stride);
@@ -10634,7 +10634,7 @@ std::vector<int> DynamicPrintConfig::update_values_to_printer_extruders(DynamicP
             case coFloats:
             {
                 ConfigOptionFloats * opt = this->option<ConfigOptionFloats>(key);
-                if (!opt) continue;
+                if (!opt || opt->values.empty()) continue;
                 std::vector<double> new_values;
 
                 new_values.resize(variant_count * stride);
@@ -10649,7 +10649,7 @@ std::vector<int> DynamicPrintConfig::update_values_to_printer_extruders(DynamicP
             case coPercents:
             {
                 ConfigOptionPercents * opt = this->option<ConfigOptionPercents>(key);
-                if (!opt) continue;
+                if (!opt || opt->values.empty()) continue;
                 std::vector<double> new_values;
 
                 new_values.resize(variant_count * stride);
@@ -10664,7 +10664,7 @@ std::vector<int> DynamicPrintConfig::update_values_to_printer_extruders(DynamicP
             case coFloatsOrPercents:
             {
                 ConfigOptionFloatsOrPercents * opt = this->option<ConfigOptionFloatsOrPercents>(key);
-                if (!opt) continue;
+                if (!opt || opt->values.empty()) continue;
                 std::vector<FloatOrPercent> new_values;
 
                 new_values.resize(variant_count * stride);
@@ -10679,7 +10679,7 @@ std::vector<int> DynamicPrintConfig::update_values_to_printer_extruders(DynamicP
             case coBools:
             {
                 ConfigOptionBools * opt = this->option<ConfigOptionBools>(key);
-                if (!opt) continue;
+                if (!opt || opt->values.empty()) continue;
                 std::vector<unsigned char> new_values;
 
                 new_values.resize(variant_count * stride);
@@ -10694,7 +10694,7 @@ std::vector<int> DynamicPrintConfig::update_values_to_printer_extruders(DynamicP
             case coEnums:
             {
                 ConfigOptionEnumsGeneric * opt = this->option<ConfigOptionEnumsGeneric>(key);
-                if (!opt) continue;
+                if (!opt || opt->values.empty()) continue;
                 std::vector<int> new_values;
 
                 new_values.resize(variant_count * stride);


### PR DESCRIPTION
Old filament presets that don't contain keys added later to 
```filament_options_with_variant``` (e.g. ```filament_retract_restart_extra```)  are loaded with an empty `values` vector for those keys, causing a crash  in two places:
- ```update_values_to_printer_extruders``` - ```get_at()``` on empty vector hits assert
- ```PresetBundle::full_fff_config``` - ```set(filament_opts)``` throws on empty source

Fix:  skip options with empty `values` at both call sites in  `PrintConfig.cpp` and `PresetBundle.cpp`. 