### PR TITLE
add space after "Arranging" message

### DIFF
--- a/src/slic3r/GUI/Jobs/ArrangeJob.cpp
+++ b/src/slic3r/GUI/Jobs/ArrangeJob.cpp
@@ -548,7 +548,7 @@ void ArrangeJob::process(Ctl &ctl)
     params.stopcondition = [&ctl]() { return ctl.was_canceled(); };
 
     params.progressind = [this, &ctl](unsigned num_finished, std::string str = "") {
-        ctl.update_status(num_finished * 100 / status_range(), _u8L("Arranging") + str);
+        ctl.update_status(num_finished * 100 / status_range(), _u8L("Arranging ") + str);
     };
 
     {


### PR DESCRIPTION
between "Arranging" and the job title

<img width="558" height="153" alt="image" src="https://github.com/user-attachments/assets/9684eb6b-71ed-4c2e-be20-e6d0590c7a80" />
