### PR TITLE
Fixed some desktop environments showing title bar on splash screen when running on Wayland

### DIFF
--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -309,7 +309,16 @@ public:
     {
         this->SetPosition(pos);
         this->CenterOnScreen();
-
+		
+		#if defined(__WXGTK__)
+        if (Slic3r::GUI::is_running_on_wayland()) {
+            GtkWidget *empty = gtk_fixed_new();
+            gtk_widget_set_size_request(empty, 0, 0);
+            gtk_window_set_titlebar(GTK_WINDOW(GetHandle()), empty);
+            gtk_window_set_decorated(GTK_WINDOW(GetHandle()), false);
+        }
+		#endif
+		
         scale_font(m_font_version, 1.65f); // only scale this one since it hasnt a preloaded font like Label::Body_24;
 
         m_bg_color = StateColor::darkModeColorFor(wxColour("#FFFFFF"));

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -309,14 +309,16 @@ public:
     {
 		// Some desktop environments ignore splash screen typed window properties
 		// when running the app through Wayland,resulting in the titlebar being shown 
-		// on the splash screen. The code below ensures hat even those environments 
-		// forcibly set their window decorations to false, making it so every 
-		// environment properly hides the titlebar for this window.
+		// on the splash screen. The code below creates a client-side window decoration
+		// when running on Wayland and then removes that decoration. This ensures every 
+		// environment correctly targets and removes the titlebar for this screen.
 		#if defined(__WXGTK__)
-		    gboolean is_decorated = gtk_window_get_decorated(GTK_WINDOW(GetHandle()));
-		    if (is_decorated) {
-		        gtk_window_set_decorated(GTK_WINDOW(GetHandle()), FALSE);
-		    }
+	        if (Slic3r::GUI::is_running_on_wayland()) {
+	            GtkWidget *empty = gtk_fixed_new();
+	            gtk_widget_set_size_request(empty, 0, 0);
+	            gtk_window_set_titlebar(GTK_WINDOW(GetHandle()), empty);
+	            gtk_window_set_decorated(GTK_WINDOW(GetHandle()), false);
+	        }
 		#endif
 		
         this->SetPosition(pos);

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -323,7 +323,7 @@ public:
 		
         this->SetPosition(pos);
         this->CenterOnScreen();
-		
+
         scale_font(m_font_version, 1.65f); // only scale this one since it hasnt a preloaded font like Label::Body_24;
 
         m_bg_color = StateColor::darkModeColorFor(wxColour("#FFFFFF"));

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -307,17 +307,20 @@ public:
 #endif // !__APPLE__
         )
     {
+		// Some desktop environments ignore splash screen typed window properties
+		// when running the app through Wayland,resulting in the titlebar being shown 
+		// on the splash screen. The code below ensures hat even those environments 
+		// forcibly set their window decorations to false, making it so every 
+		// environment properly hides the titlebar for this window.
+		#if defined(__WXGTK__)
+		    gboolean is_decorated = gtk_window_get_decorated(GTK_WINDOW(GetHandle()));
+		    if (is_decorated) {
+		        gtk_window_set_decorated(GTK_WINDOW(GetHandle()), FALSE);
+		    }
+		#endif
+		
         this->SetPosition(pos);
         this->CenterOnScreen();
-		
-		#if defined(__WXGTK__)
-        if (Slic3r::GUI::is_running_on_wayland()) {
-            GtkWidget *empty = gtk_fixed_new();
-            gtk_widget_set_size_request(empty, 0, 0);
-            gtk_window_set_titlebar(GTK_WINDOW(GetHandle()), empty);
-            gtk_window_set_decorated(GTK_WINDOW(GetHandle()), false);
-        }
-		#endif
 		
         scale_font(m_font_version, 1.65f); // only scale this one since it hasnt a preloaded font like Label::Body_24;
 


### PR DESCRIPTION
# Description

When running OrcaSlicer through Wayland, on some desktop environments the splash screen currently shows the title bar. This bug does not happen when using X11 or Xwayland, but was introduced to Wayland since support for it was introduced. This PR fixes that. When creating the splash screen, it ensures that window decorations are set to false regardless of which environment it runs in. The fix is applied purely to this one window, so no other parts of the application should be affected by this.

# Screenshots/Recordings/Graphs

Before:
<img width="654" height="701" alt="Screenshot_2026-07-29_23-49-37" src="https://github.com/user-attachments/assets/7a3a9a29-3ca2-44cb-9532-72213a5adc28" />

After:
<img width="661" height="662" alt="Screenshot_2026-07-29_23-50-59" src="https://github.com/user-attachments/assets/604bcb3d-cedc-49e1-b057-60718cf42aa7" />


## Tests
I ran the latest nightly build and my own build with this fix side by side. The above images are what I see.