### PR TITLE
Test Build for FromDIP on Linux

### DIFF
--- a/src/slic3r/GUI/Field.cpp
+++ b/src/slic3r/GUI/Field.cpp
@@ -298,7 +298,7 @@ void Field::PostInitialize()
 	}
 
     // initialize m_unit_value
-    m_em_unit = em_unit(m_parent);
+    m_em_unit = m_parent->FromDIP(10);
     parent_is_custom_ctrl = dynamic_cast<OG_CustomCtrl*>(m_parent) != nullptr;
 
 	BUILD();
@@ -727,7 +727,7 @@ void Field::get_value_by_opt_type(wxString& str, const bool check_value/* = true
 void Field::msw_rescale()
 {
 	// update em_unit value
-	m_em_unit = em_unit(m_parent);
+	m_em_unit = m_parent->FromDIP(10);
 }
 
 void Field::sys_color_changed()

--- a/src/slic3r/GUI/Notebook.cpp
+++ b/src/slic3r/GUI/Notebook.cpp
@@ -31,7 +31,7 @@ ButtonsListCtrl::ButtonsListCtrl(wxWindow *parent, wxBoxSizer* side_tools) :
    
     SetBackgroundColour(default_btn_bg);
 
-    int em = em_unit(this);// Slic3r::GUI::wxGetApp().em_unit();
+    int em = FromDIP(10);
     // BBS: no gap
     m_btn_margin = 0; // std::lround(0.3 * em);
     m_line_margin = std::lround(0.1 * em);
@@ -102,7 +102,7 @@ void ButtonsListCtrl::UpdateMode()
 void ButtonsListCtrl::Rescale()
 {
     //m_mode_sizer->msw_rescale();
-    int em = em_unit(this);
+    int em = FromDIP(10);
     for (Button* btn : m_pageButtons) {
         //BBS
         btn->SetMinSize({(btn->GetLabel().empty() ? 40 : 132) * em / 10, 36 * em / 10});
@@ -156,7 +156,7 @@ bool ButtonsListCtrl::InsertPage(size_t n, const wxString &text, bool bSelect /*
     Button * btn = new Button(this, text.empty() ? text : " " + text, bmp_name, wxNO_BORDER);
     btn->SetCornerRadius(0);
 
-    int em = em_unit(this);
+    int em = FromDIP(10);
     //BBS set size for button
     btn->SetMinSize({(text.empty() ? 40 : 136) * em / 10, 36 * em / 10});
 
@@ -228,7 +228,7 @@ void ButtonsListCtrl::SetPageText(size_t n, const wxString& strText)
 // ORCA
 void ButtonsListCtrl::SetCompact(size_t n, bool compact)
 {
-    int em = em_unit(this);
+    int em = FromDIP(10);
     Button* btn = m_pageButtons[n];
     btn->SetMinSize({(compact ? 40 : 136) * em / 10, 36 * em / 10});
     btn->SetLabel(compact ? "" : (" " +  m_pageLabels[n]));

--- a/src/slic3r/GUI/OG_CustomCtrl.cpp
+++ b/src/slic3r/GUI/OG_CustomCtrl.cpp
@@ -53,7 +53,7 @@ OG_CustomCtrl::OG_CustomCtrl(   wxWindow*            parent,
     // BBS: new font
     m_font = Label::Body_14;
     SetFont(m_font);
-    m_em_unit = em_unit(m_parent);
+    m_em_unit = m_parent->FromDIP(10);
     m_v_gap   = lround(1.2 * m_em_unit);
     m_v_gap2  = lround(0.8 * m_em_unit);
     m_h_gap   = lround(0.2 * m_em_unit);
@@ -595,7 +595,7 @@ void OG_CustomCtrl::msw_rescale()
     // BBS: new font
     m_font = Label::Body_14;
     SetFont(m_font);
-    m_em_unit   = em_unit(m_parent);
+    m_em_unit   = m_parent->FromDIP(10);
     m_v_gap     = lround(1.2 * m_em_unit);
     m_v_gap2    = lround(0.8 * m_em_unit);
     m_h_gap     = lround(0.2 * m_em_unit);

--- a/src/slic3r/GUI/ParamsPanel.cpp
+++ b/src/slic3r/GUI/ParamsPanel.cpp
@@ -263,7 +263,7 @@ ParamsPanel::ParamsPanel( wxWindow* parent, wxWindowID id, const wxPoint& pos, c
         //int width, height;
         // BBS: new layout
         m_mode_region = new SwitchButton(m_top_panel);
-        m_mode_region->SetMaxSize({em_unit(this) * 12, -1});
+        m_mode_region->SetMaxSize({FromDIP(120), -1});
         m_mode_region->SetLabels(_L("Global"), _L("Objects"));
         //m_mode_region->GetSize(&width, &height);
         m_tips_arrow = new ScalableButton(m_top_panel, wxID_ANY, "tips_arrow");
@@ -408,7 +408,7 @@ void ParamsPanel::create_layout()
 
     m_left_sizer = new wxBoxSizer( wxVERTICAL );
     // BBS: new layout
-    m_left_sizer->SetMinSize( wxSize(40 * em_unit(this), -1 ) );
+    m_left_sizer->SetMinSize( wxSize(FromDIP(390), -1 ) );
 
     if (m_top_panel) {
         m_mode_sizer = new wxBoxSizer( wxHORIZONTAL );
@@ -483,7 +483,7 @@ void ParamsPanel::create_layout()
 
     //m_top_sizer->Add( m_right_sizer, 1, wxEXPAND, 5 );
     // BBS: new layout
-    m_left_sizer->AddSpacer(6 * em_unit(this) / 10);
+    m_left_sizer->AddSpacer(FromDIP(6));
 #if __WXOSX__
     m_left_sizer->Add(m_tmp_panel, 1, wxEXPAND | wxALL, 0);
     m_tmp_panel->GetSizer()->Add( m_page_view, 1, wxEXPAND );
@@ -678,9 +678,9 @@ void ParamsPanel::msw_rescale()
     if (m_search_btn) m_search_btn->msw_rescale();
     if (m_compare_btn) m_compare_btn->msw_rescale();
     if (m_tips_arrow) m_tips_arrow->msw_rescale();
-    m_left_sizer->SetMinSize(wxSize(40 * em_unit(this), -1));
+    m_left_sizer->SetMinSize(wxSize(FromDIP(390), -1));
     if (m_mode_sizer)
-        m_mode_sizer->SetMinSize(-1, 3 * em_unit(this));
+        m_mode_sizer->SetMinSize(-1, FromDIP(30));
     if (m_mode_region)
         ((SwitchButton* )m_mode_region)->Rescale();
     if (m_mode_icon) m_mode_icon->msw_rescale();

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -2353,7 +2353,7 @@ void Sidebar::update_sync_ams_btn_enable(wxUpdateUIEvent &e)
  }
 
 Sidebar::Sidebar(Plater *parent)
-    : wxPanel(parent, wxID_ANY, wxDefaultPosition, wxSize(39 * wxGetApp().em_unit(), -1)), p(new priv(parent))
+    : wxPanel(parent, wxID_ANY, wxDefaultPosition, wxSize(parent->FromDIP(390), -1)), p(new priv(parent))
 {
     Choice::register_dynamic_list("support_filament", &dynamic_filament_list);
     Choice::register_dynamic_list("support_interface_filament", &dynamic_filament_list);
@@ -2384,7 +2384,6 @@ Sidebar::Sidebar(Plater *parent)
 #endif
 #endif
 
-    int em = wxGetApp().em_unit();
     //BBS refine layout and styles
     // Sizer in the scrolled area
     auto* scrolled_sizer = m_scrolled_sizer = new wxBoxSizer(wxVERTICAL);
@@ -2447,7 +2446,7 @@ Sidebar::Sidebar(Plater *parent)
         h_sizer_title->Add(p->m_printer_bbl_sync, 0, wxALIGN_CENTER | wxRIGHT, FromDIP(SidebarProps::WideSpacing())); // used larger margin to prevent accidental clicks
         h_sizer_title->Add(p->m_printer_setting, 0, wxALIGN_CENTER);
         h_sizer_title->AddSpacer(FromDIP(SidebarProps::TitlebarMargin()));
-        h_sizer_title->SetMinSize(-1, 3 * em);
+        h_sizer_title->SetMinSize(-1, FromDIP(30));
 
         p->m_panel_printer_title->SetSizer(h_sizer_title);
         p->m_panel_printer_title->Layout();
@@ -3150,13 +3149,12 @@ void Sidebar::init_filament_combo(PlaterPresetComboBox **combo, const int filame
 
     // BBS:  filament double columns
 
-    // int em = wxGetApp().em_unit();
     if ((filament_idx % 2) == 0) // Dont add right column item. this one create equal spacing on left, right & middle
         combo_and_btn_sizer->AddSpacer(FromDIP((filament_idx % 2) == 0 ? 12 : 3)); // Content Margin
 
     (*combo)->clr_picker->SetLabel(wxString::Format("%d", filament_idx + 1));
     combo_and_btn_sizer->Add((*combo)->clr_picker, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(SidebarProps::ElementSpacing()) - FromDIP(2)); // ElementSpacing - 2 (from combo box))
-    combo_and_btn_sizer->Add(*combo, 1, wxALL | wxEXPAND, FromDIP(2))->SetMinSize({-1, 30 * wxGetApp().em_unit() / 10}); // ORCA ensure height matches with PlaterPresetComboBox
+    combo_and_btn_sizer->Add(*combo, 1, wxALL | wxEXPAND, FromDIP(2))->SetMinSize({-1, FromDIP(30)}); // ORCA ensure height matches with PlaterPresetComboBox
 
     /* BBS hide del_btn
     ScalableButton* del_btn = new ScalableButton(p->m_panel_filament_content, wxID_ANY, "delete_filament");
@@ -3726,10 +3724,9 @@ void Sidebar::update_filaments_counter(bool force_layout)
 
 void Sidebar::msw_rescale()
 {
-    SetMinSize(wxSize(39 * wxGetApp().em_unit(), -1));
-    p->m_panel_printer_title->GetSizer()->SetMinSize(-1, 3 * wxGetApp().em_unit());
-    p->m_panel_filament_title->GetSizer()
-        ->SetMinSize(-1, 3 * wxGetApp().em_unit());
+    SetMinSize(wxSize(FromDIP(390), -1));
+    p->m_panel_printer_title->GetSizer()->SetMinSize(-1, FromDIP(30));
+    p->m_panel_filament_title->GetSizer()->SetMinSize(-1, FromDIP(30));
     p->m_printer_icon->msw_rescale();
     p->m_printer_connect->msw_rescale();
     p->m_printer_bbl_sync->msw_rescale();
@@ -5946,7 +5943,7 @@ Plater::priv::priv(Plater *q, MainFrame *main_frame)
                                    .CloseButton(false)
                                    .TopDockable(false)
                                    .BottomDockable(false)
-                                   .BestSize(wxSize(39 * wxGetApp().em_unit(), 90 * wxGetApp().em_unit())));
+                                   .BestSize(sidebar->FromDIP(wxSize(390, 9))));
 
     auto* panel_sizer = new wxBoxSizer(wxHORIZONTAL);
     panel_sizer->Add(view3D, 1, wxEXPAND | wxALL, 0);

--- a/src/slic3r/GUI/PresetComboBoxes.cpp
+++ b/src/slic3r/GUI/PresetComboBoxes.cpp
@@ -825,7 +825,7 @@ bool PresetComboBox::selection_is_changed_according_to_physical_printers()
 // ---------------------------------
 
 PlaterPresetComboBox::PlaterPresetComboBox(wxWindow *parent, Preset::Type preset_type) :
-    PresetComboBox(parent, preset_type, wxSize(25 * wxGetApp().em_unit(), 30 * wxGetApp().em_unit() / 10))
+    PresetComboBox(parent, preset_type, wxSize(-1, parent->FromDIP(30)))
 {
     GetDropDown().SetUseContentWidth(true,true);
 
@@ -861,7 +861,6 @@ PlaterPresetComboBox::PlaterPresetComboBox(wxWindow *parent, Preset::Type preset
 
     // BBS
     if (m_type == Preset::TYPE_FILAMENT) {
-        int em = wxGetApp().em_unit();
         clr_picker = new wxBitmapButton(parent, wxID_ANY, {}, wxDefaultPosition, wxSize(FromDIP(20), FromDIP(20)), wxBU_EXACTFIT | wxBU_AUTODRAW | wxBORDER_NONE);
         clr_picker->SetBackgroundColour(StateColor::darkModeColorFor(*wxWHITE));
         clr_picker->SetToolTip(_L("Click to select filament color"));
@@ -1525,10 +1524,10 @@ void PlaterPresetComboBox::update()
 void PlaterPresetComboBox::msw_rescale()
 {
     PresetComboBox::msw_rescale();
-    SetMinSize({-1, 30 * m_em_unit / 10});
+    SetMinSize({-1, FromDIP(30)});
 
     if (clr_picker)
-        clr_picker->SetSize(20 * m_em_unit / 10, 20 * m_em_unit / 10);
+        clr_picker->SetSize(FromDIP(20), FromDIP(20));
     // BBS
     if (edit_btn != nullptr)
         edit_btn->msw_rescale();
@@ -1626,7 +1625,7 @@ void PlaterPresetComboBox::sync_colour_config(const std::vector<std::string> &cl
 
 TabPresetComboBox::TabPresetComboBox(wxWindow* parent, Preset::Type preset_type) :
     // BBS: new layout
-    PresetComboBox(parent, preset_type, wxSize(20 * wxGetApp().em_unit(), 30 * wxGetApp().em_unit() / 10))
+    PresetComboBox(parent, preset_type, wxSize(-1, parent->FromDIP(30)))
 {
     GetDropDown().SetUseContentWidth(true,true);
 }
@@ -1893,7 +1892,7 @@ void TabPresetComboBox::msw_rescale()
 {
     PresetComboBox::msw_rescale();
     // BBS: new layout
-    wxSize sz = wxSize(20 * m_em_unit, 30 * m_em_unit / 10);
+    wxSize sz = wxSize(-1, FromDIP(30));
     SetMinSize(sz);
     SetSize(sz);
 }

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -447,7 +447,7 @@ void Tab::create_preset_tab()
 
     m_top_sizer->AddSpacer(FromDIP(SidebarProps::ContentMargin()));
 
-    m_top_sizer->SetMinSize(-1, 3 * m_em_unit);
+    m_top_sizer->SetMinSize(-1, FromDIP(30));
     m_top_panel->SetSizer(m_top_sizer);
     if (m_presets_choice)
         m_main_sizer->Add(m_top_panel, 0, wxEXPAND | wxUP | wxDOWN, FromDIP(SidebarProps::ContentMarginV()));
@@ -455,7 +455,7 @@ void Tab::create_preset_tab()
         m_top_panel->Hide();
 
     // tree
-    m_tabctrl = new TabCtrl(panel, wxID_ANY, wxDefaultPosition, wxSize(20 * m_em_unit, -1),
+    m_tabctrl = new TabCtrl(panel, wxID_ANY, wxDefaultPosition, wxSize(FromDIP(200), -1),
         wxTR_NO_BUTTONS | wxTR_HIDE_ROOT | wxTR_SINGLE | wxTR_NO_LINES | wxBORDER_NONE | wxWANTS_CHARS | wxTR_FULL_ROW_HIGHLIGHT);
     m_tabctrl->Bind(wxEVT_RIGHT_DOWN, [this](auto &e) {}); // disable right select
     m_tabctrl->SetFont(Label::Body_14);
@@ -502,7 +502,7 @@ void Tab::create_preset_tab()
 
     if (dynamic_cast<TabPrinter *>(this) || dynamic_cast<TabPrint *>(this)) {
         m_extruder_switch = new MultiSwitchButton(panel);
-        m_extruder_switch->SetMaxSize({em_unit(this) * 40, -1});
+        m_extruder_switch->SetMaxSize({FromDIP(390), -1});
         m_extruder_switch->Bind(wxCUSTOMEVT_MULTISWITCH_SELECTION, [this](auto &evt) {
             evt.Skip();
             int selection = evt.GetInt();
@@ -538,9 +538,9 @@ void Tab::create_preset_tab()
         m_variant_sizer->Add(m_extruder_switch, 0, wxALIGN_CENTER, 0);
         m_variant_sizer->Add(right_sizer, 1, wxALIGN_CENTER);
         right_sizer->AddStretchSpacer(1);
-        right_sizer->Add(m_extruder_sync_box, 0, wxALIGN_CENTER | wxRIGHT, m_em_unit);
+        right_sizer->Add(m_extruder_sync_box, 0, wxALIGN_CENTER | wxRIGHT, FromDIP(10));
 
-        m_main_sizer->Add(m_variant_sizer, 0, wxEXPAND | wxTOP, m_em_unit);
+        m_main_sizer->Add(m_variant_sizer, 0, wxEXPAND | wxTOP, FromDIP(10));
     } else if (dynamic_cast<TabFilament *>(this)) {
         m_variant_combo = new MultiSwitchButton(panel);
         m_variant_combo->Bind(wxCUSTOMEVT_MULTISWITCH_SELECTION, [this](auto &evt) {
@@ -558,10 +558,10 @@ void Tab::create_preset_tab()
         wxBoxSizer *combo_sizer = new wxBoxSizer(wxHORIZONTAL);
         combo_sizer->Add(m_variant_combo, 1, wxEXPAND);
         wxBoxSizer *top_sizer = new wxBoxSizer(wxHORIZONTAL);
-        top_sizer->Add(combo_sizer, 1, wxEXPAND | wxLEFT, m_em_unit);
+        top_sizer->Add(combo_sizer, 1, wxEXPAND | wxLEFT, FromDIP(10));
         m_variant_sizer  = new wxBoxSizer(wxVERTICAL);
-        m_variant_sizer->Add(top_sizer, 0, wxLEFT, m_em_unit);
-        m_main_sizer->Add(m_variant_sizer, 0, wxEXPAND | wxTOP, m_em_unit);
+        m_variant_sizer->Add(top_sizer, 0, wxLEFT, FromDIP(10));
+        m_main_sizer->Add(m_variant_sizer, 0, wxEXPAND | wxTOP, FromDIP(10));
     }
 
     this->SetSizer(m_main_sizer);
@@ -1587,7 +1587,7 @@ void Tab::msw_rescale()
 {
     m_em_unit = em_unit(m_parent);
 
-    m_top_sizer->SetMinSize(-1, 3 * m_em_unit);
+    m_top_sizer->SetMinSize(-1, FromDIP(30));
 
     //BBS: GUI refactor
     //if (m_mode_sizer)
@@ -1595,7 +1595,7 @@ void Tab::msw_rescale()
     if (m_presets_choice)
         m_presets_choice->msw_rescale();
 
-    m_tabctrl->SetMinSize(wxSize(20 * m_em_unit, -1));
+    m_tabctrl->SetMinSize(wxSize(FromDIP(200), -1));
 
     // rescale buttons and cached bitmaps
     for (const auto btn : m_scaled_buttons)


### PR DESCRIPTION
## NOTES
• Not covers all code yet. basically only updated few sections of code that effects main UI

## TEST METHOD
• Put current release and this PR side by side then test different scaling options like 100%, 125%, 150%, 175%, 200%

## TESTED ON
left one current - right one is this PR on comparison images

# ✔ Debian Gnome

**No issues @175% and  200%**
<img width="1568" height="1063" alt="Screenshot-20260730191256" src="https://github.com/user-attachments/assets/a231b3ab-d025-4cd2-942b-90c3006820c6" />

# ❌ KDE Neon

on_dpi_changed not working on KDE
orca runs via xwayland

**175% scaling totally broken on both scenarios but non FromDIP solution looks usable**
<img width="1445" height="1009" alt="Screenshot-20260730215643" src="https://github.com/user-attachments/assets/39a6810a-4123-40b9-89e3-06174fee34fe" />

 **200% scaling > looks ok on both**
<img width="1675" height="1110" alt="Screenshot-20260730220157" src="https://github.com/user-attachments/assets/a40be74e-693a-4ea3-a77b-d87e4ceca30d" />

**but UI looks ok if running app with** 
```GDK_SCALE=2 GDK_DPI_SCALE=0.5 ./app_path # for a display set to 200%```
**basically issue is GDK and KDE scale doesnt match if fractional is in use**
<img width="1073" height="1052" alt="Screenshot-20260730233807" src="https://github.com/user-attachments/assets/d34b69f3-51e0-4fe7-a8c6-f94b2836a488" />

# ✔ Manjaro - XFCE - X11

**175% scaling**
<img width="1552" height="1062" alt="Screenshot-20260730222600" src="https://github.com/user-attachments/assets/11655d18-e1bd-49a8-af6c-2ce76263162f" />

**200% scaling**
<img width="1771" height="1037" alt="Screenshot-20260730222814" src="https://github.com/user-attachments/assets/ed973a6d-d592-4c66-92fd-86e537d95298" />

# ✔ PopOS - Cosmos
**175% scaling**
<img width="1615" height="954" alt="Screenshot-20260730224901" src="https://github.com/user-attachments/assets/319c70e8-b03d-4487-a53a-3e9510f5390e" />

**200% scaling**
<img width="1838" height="927" alt="Screenshot-20260730225139" src="https://github.com/user-attachments/assets/0d6493ac-2eef-4231-a27e-8f66cdf1994c" />

# ✔ Lubuntu - LXQT - X11
requires "sudo apt install libwebkit2gtk-4.1-0" after fresh install 

**175% scaling (No effect on app - OS only scaled itself)**
<img width="961" height="821" alt="Screenshot-20260730230821" src="https://github.com/user-attachments/assets/2e328388-51e5-49d6-a07a-9b3077f19ab4" />

**200% scaling** 
<img width="1893" height="1092" alt="Screenshot-20260730231309" src="https://github.com/user-attachments/assets/ea9a6ff6-471e-4136-914a-7872c3129522" />


Will make tests on
**Mint - Cinnamon - X11**
requires "sudo apt install libglu1-mesa" after fresh install 
