### PR TITLE
Moonraker: pass print=true in upload — fix Upload & Print race (fixes #14945)

### DIFF
--- a/src/slic3r/Utils/Moonraker.cpp
+++ b/src/slic3r/Utils/Moonraker.cpp
@@ -212,13 +212,10 @@ bool Moonraker::start_print(wxString &error_msg, const std::string &filename) co
 
 bool Moonraker::upload(PrintHostUpload upload_data, ProgressFn progress_fn, ErrorFn error_fn, InfoFn info_fn) const
 {
-    //ORCA: POST /server/files/upload as multipart/form-data with:
-    //          file = <gcode file>
-    //          root = <storage root>     (Moonraker default: "gcodes")
-    //      Successful response shape:
-    //          { "result": { "item": { "path": "<name>.gcode", "root": "<root>" }, "print_started": <bool> } }
-    //      We always start the print explicitly via /printer/print/start regardless of `print_started`
-    //      so the user can rely on a single call site for state.
+    // POST /server/files/upload with `print=true` so Moonraker queues the print
+    // itself and respects [power] on_when_upload_queued (issue #14945). Older
+    // Moonrakers that ignore the flag return print_started=false and we fall
+    // back to the explicit /printer/print/start below.
     wxString test_msg;
     if (!test(test_msg)) {
         error_fn(std::move(test_msg));
@@ -233,9 +230,12 @@ bool Moonraker::upload(PrintHostUpload upload_data, ProgressFn progress_fn, Erro
     //      addition later (storage picker) needs no change to this method.
     const std::string root = upload_data.storage.empty() ? std::string("gcodes") : upload_data.storage;
 
+    const bool want_start = upload_data.post_action == PrintHostPostUploadAction::StartPrint;
+
     std::string url = make_url("server/files/upload");
     bool result = true;
     std::string uploaded_path;
+    bool moonraker_started_print = false;
 
     //ORCA: gcode inside a .gcode.3mf is index-coded (Metadata/plate_<N>.gcode), so the upload names the
     //      plate via a 1-based `plateindex` (set only in the .3mf path, see Plater::send_gcode_legacy);
@@ -249,13 +249,14 @@ bool Moonraker::upload(PrintHostUpload upload_data, ProgressFn progress_fn, Erro
         % root
         % upload_filename.string()
         % (plateindex.empty() ? "-" : plateindex)
-        % (upload_data.post_action == PrintHostPostUploadAction::StartPrint ? "true" : "false");
+        % (want_start ? "true" : "false");
 
     auto http = Http::post(std::move(url));
     set_auth(http);
     http.form_add("root", root);
     if (!plateindex.empty())
         http.form_add("plateindex", plateindex);
+    http.form_add("print", want_start ? "true" : "false");
     http.form_add_file("file", upload_data.source_path.string(), upload_filename.string())
         .on_complete([&](std::string body, unsigned status) {
             BOOST_LOG_TRIVIAL(debug) << boost::format("%1%: upload HTTP %2%: %3%") % name % status % body;
@@ -278,6 +279,7 @@ bool Moonraker::upload(PrintHostUpload upload_data, ProgressFn progress_fn, Erro
                         "%1%: upload response missing result.item.path, falling back to original filename `%2%`")
                         % name % uploaded_path;
                 }
+                moonraker_started_print = ptree.get<bool>("result.print_started", false);
             } catch (const std::exception &ex) {
                 BOOST_LOG_TRIVIAL(warning) << boost::format(
                     "%1%: could not parse upload response (%2%); falling back to original filename")
@@ -306,7 +308,8 @@ bool Moonraker::upload(PrintHostUpload upload_data, ProgressFn progress_fn, Erro
     if (!result)
         return false;
 
-    if (upload_data.post_action == PrintHostPostUploadAction::StartPrint && !uploaded_path.empty()) {
+    // Fallback when Moonraker ignored the `print` flag or reported print_started=false.
+    if (want_start && !uploaded_path.empty() && !moonraker_started_print) {
         wxString start_msg;
         if (!start_print(start_msg, uploaded_path)) {
             error_fn(std::move(start_msg));


### PR DESCRIPTION
# Description

Closes #14945.

Upload & Print on the Moonraker (Klipper) host type failed with
`HTTP 503: Klippy Host not connected` on printers that Moonraker powers
up for a queued job. The file landed on disk, the print never started,
and the user got an error dialog.

## Root cause

Orca did a two-step sequence:

1. `POST /server/files/upload`: the file lands in the gcodes root
2. `POST /printer/print/start` with the returned filename, immediately

With `[file_manager] queue_gcode_uploads` and a `[power <device>]` section
using `on_when_job_queued`, the upload queues a job and switches the printer
on. Step 2 then fires while Klippy is still coming up, and Moonraker answers
503.

## Fix

Send `print=true` with the upload, so Moonraker starts the print itself, or
queues it when it cannot start yet. The reply says which happened in two
flags: `print_started` and `print_queued`. When either is set, Orca skips its
own `/printer/print/start`. When both are false (no job queue, a non-G-code
upload, or a server that ignores `print`), the explicit start runs as before,
and its error is what the user sees.

The upload reply is a bare object: Moonraker's `FileUploadHandler` writes the
result straight to the response, unlike the endpoints that are wrapped in
`{"result": ...}`. So `item.path`, `print_started` and `print_queued` are read
at the top level. `item.path` is what Orca passes to `/printer/print/start`,
which matters when Moonraker renames the upload (`.ufp` stored as `.gcode`,
surrounding whitespace and leading slashes stripped).

## Reproducer

Setup: a Klipper printer with `queue_gcode_uploads: True`, a `[power]` device
with `on_when_job_queued: True` and `[job_queue] load_on_startup: True`,
printer power off.

- Before: Upload & Print → HTTP 503 dialog; file uploaded, print not started.
- After: Upload & Print → file uploads, printer powers on, the queued job
  starts once Klippy is ready.

On a printer that is already on, Moonraker starts the print immediately
(`print_started: true`) and Orca no longer sends a second start, which
Klipper would otherwise refuse while the print runs.

## Scope

`src/slic3r/Utils/Moonraker.cpp` and its header comment. The Moonraker
host type comes from #13991; this restores the Moonraker-native flow.

Checked against Moonraker v0.11.0 with a printer already powered: an upload
with `print=true` returns `print_started: true` and `print_queued: false` at
the top level of the reply. The power-on path needs a `[power]` device, which
I don't have.

Reporter: @RubenOllesch, thanks for the debugging and for pointing at the fix.
