### PR TITLE
CLI: --allow-rotations defaults OFF (opt-in as its name implies)

### DIFF
--- a/src/OrcaSlicer.cpp
+++ b/src/OrcaSlicer.cpp
@@ -1451,7 +1451,7 @@ int CLI::run(int argc, char **argv)
     //int arrange_option;
     int plate_to_slice = 0, filament_count = 0, duplicate_count = 0, real_duplicate_count = 0, current_extruder_count = 1, new_extruder_count = 1, current_printer_variant_count = 1, current_print_variant_count = 1, new_printer_variant_count = 1;
     bool first_file = true, is_bbl_3mf = false, need_arrange = true, has_thumbnails = false, up_config_to_date = false, normative_check = true, duplicate_single_object = false, use_first_fila_as_default = false, minimum_save = false, enable_timelapse = false;
-    bool allow_rotations = true, skip_modified_gcodes = false, avoid_extrusion_cali_region = false, skip_useless_pick = false, allow_newer_file = false, current_is_multi_extruder = false, new_is_multi_extruder = false, allow_mix_temp = false, enable_wrapping_detect = false;
+    bool allow_rotations = false, skip_modified_gcodes = false, avoid_extrusion_cali_region = false, skip_useless_pick = false, allow_newer_file = false, current_is_multi_extruder = false, new_is_multi_extruder = false, allow_mix_temp = false, enable_wrapping_detect = false;
     Semver file_version;
     std::map<size_t, bool> orients_requirement;
     std::vector<Preset*> project_presets;

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -12103,7 +12103,8 @@ CLIMiscConfigDef::CLIMiscConfigDef()
     def = this->add("allow_rotations", coBool);
     def->label = L("Allow rotation when arranging");
     def->tooltip = L("If enabled, Arrange will allow rotation when placing objects.");
-    def->set_default_value(new ConfigOptionBool(true));
+    // Default OFF so --arrange is translate-only unless the caller opts in.
+    def->set_default_value(new ConfigOptionBool(false));
 
     def = this->add("avoid_extrusion_cali_region", coBool);
     def->label = L("Avoid extrusion calibrate region when arranging");


### PR DESCRIPTION
# Description

`--arrange 1` silently rotates loaded objects about Z even when
`--allow-rotations` is not passed. Since that flag exists specifically to
*enable* rotation, arrange should be translate-only by default.

## Root cause

`allow_rotations` is registered in `CLIMiscConfigDef` with a default of
`true` (`src/libslic3r/PrintConfig.cpp:12103`), so any CLI invocation
that omits the flag still resolves to `true`. The internal
`ArrangeParams::allow_rotations` defaults to `false` (`Arrange.hpp:121`);
the CLI-side default was the outlier and was overriding the safer
internal default.

## Symptom

Baked orientations from `--ground-face-*` / `--rotate-*` are lost when
arrange runs. A concrete report: two mirrored parts (left/right blocker,
each pre-oriented on its own 45° bevel so they lean in opposite
directions) get rotated ~90° about Z by arrange — tilt swaps from X
axis to Y axis and both parts end up leaning the *same* way, destroying
the mirror. The rotation is silent (no warning, no error), only
detectable by measuring the sliced output.

## Fix

Default the CLI option to `false`. `--arrange 1` is now translate-only
unless the caller explicitly passes `--allow-rotations 1`. Aligns the
CLI default with `ArrangeParams::allow_rotations = false` and matches
the flag's own tooltip ("If enabled, Arrange will allow rotation …").

The CLI-local's initial value in `CLI::run` is also flipped to `false`
for consistency in case the config lookup ever falls through.

## Scope

- `src/libslic3r/PrintConfig.cpp` — 1 line (default `false`) + 1
  one-line comment
- `src/OrcaSlicer.cpp` — 1 word (local default `false`)

No behaviour change for callers that pass `--allow-rotations 1` (or GUI
users, since this option is CLI-only in `CLIMiscConfigDef`).
