### PR TITLE
Preset: apply scalar user overrides that update_diff_values_to_child_config drops

### DIFF
--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -1739,6 +1739,16 @@ void PresetCollection::load_presets(
                         preset.filament_id = inherit_preset->filament_id;
                         extend_default_config_length(config, false, {});
                         preset.config.update_diff_values_to_child_config(config, extruder_id_name, extruder_variant_name, *key_set1, *key_set2);
+                        // Re-apply scalar user overrides that the diff-merge above dropped
+                        // (gcode_flavor, machine_start_gcode, …). Vectors stay with the
+                        // diff-merge to preserve its extruder/variant striding.
+                        for (const std::string &key : config.keys()) {
+                            const ConfigOption *src = config.option(key);
+                            if (!src || !src->is_scalar()) continue;
+                            ConfigOption *dst = preset.config.option(key);
+                            if (dst && *dst != *src)
+                                dst->set(src);
+                        }
                     }
                     else {
                         auto inherits_config2 = dynamic_cast<ConfigOptionString *>(inherits_config);


### PR DESCRIPTION
# Description

`PresetCollection::load_presets` silently drops the user's override on
some scalar options (`gcode_flavor`, `machine_start_gcode`,
`machine_end_gcode`, …) when a user preset inherits from a system
preset. The CLI's `--load-settings` code path uses a plain `apply()`
and gets the override right; the GUI path uses
`update_diff_values_to_child_config()` which drops these silently.

## Symptom

A user machine profile inheriting from a Prusa vendor and setting
`"gcode_flavor": "klipper"` + `"machine_start_gcode": "PRINT_START …"`
slices via the GUI with the *parent's* Marlin dialect (`M17`, `M862.x`)
instead of the child's `PRINT_START`. The G-code Flavor dropdown in
Printer Settings even shows the modified-marker arrow — the diff-diff
tracker knows there's an override — but the effective value fed to
the slicer is the parent's.

Workaround the user found: open Printer Settings, click the enum in
the dropdown, hit Save. That path writes through `Preset::config`
directly and sticks.

## Fix

After the existing `update_diff_values_to_child_config()` call in
`Preset.cpp`, walk the child config's keys once and re-apply every
**scalar** override on top of the merged config. Vectors stay with the
diff-merge (its extruder/variant striding is intentional and correct).

Idempotent for keys the diff-merge already applied; repairs the ones
it missed.

## Scope

- `src/libslic3r/Preset.cpp` — 10-line loop inside the existing
  `if (inherit_preset) { … }` branch, guarded on `is_scalar()`.
- No signature changes, no dependency changes, no behaviour change
  for presets without an `inherits` chain.
- Vector-typed overrides still go through the existing diff-merge
  (extruder/variant length handling unchanged).

## Verification

Manually verified on a Klipper machine profile inheriting from
`Prusa CORE One HF 0.4 nozzle` with:
- `gcode_flavor: "klipper"`
- `machine_start_gcode: "PRINT_START EXTRUDER=… BED=… CHAMBER=…"`

Before: emitted G-code starts with the vendor's `M17` / `M862.x`
sequence; Klipper aborts on the first unrecognised command.
After: emitted G-code starts with `PRINT_START EXTRUDER=…`.
