### PR TITLE
Fix 32-bit build in LayerResult::make_nop_layer_result

### DIFF
--- a/src/libslic3r/GCode.hpp
+++ b/src/libslic3r/GCode.hpp
@@ -181,7 +181,7 @@ struct LayerResult {
     // It is used for the pressure equalizer because it needs to buffer one layer back.
     bool        nop_layer_result { false };
 
-    static LayerResult make_nop_layer_result() { return {"", std::numeric_limits<coord_t>::max(), false, false, true}; }
+    static LayerResult make_nop_layer_result() { return {"", std::numeric_limits<size_t>::max(), false, false, true}; }
 };
 
 class GCode {


### PR DESCRIPTION
LayerResult's second field is typed size_t, so std::numeric_limits::max should also use size_t and not something related to coordinates for the layer_id.

Fixes the following build errors on i386 (and other 32-bit architectures for the same reason):
```
/wrkdirs/usr/ports/cad/OrcaSlicer/work/OrcaSlicer-2.3.2/src/libslic3r/GCode.hpp:179:62: error: constant expression evaluates to 9223372036854775807 which cannot be narrowed to type 'size_t' (aka 'unsigned int') [-Wc++11-narrowing]
  179 |     static LayerResult make_nop_layer_result() { return {"", std::numeric_limits<coord_t>::max(), false, false, true}; }
      |                                                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/wrkdirs/usr/ports/cad/OrcaSlicer/work/OrcaSlicer-2.3.2/src/libslic3r/GCode.hpp:179:62: note: insert an explicit cast to silence this issue
  179 |     static LayerResult make_nop_layer_result() { return {"", std::numeric_limits<coord_t>::max(), false, false, true}; }
      |                                                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                                              static_cast<size_t>(               )
/wrkdirs/usr/ports/cad/OrcaSlicer/work/OrcaSlicer-2.3.2/src/libslic3r/GCode.hpp:179:62: warning: implicit conversion from 'type' (aka 'long long') to 'size_t' (aka 'unsigned int') changes value from 9223372036854775807 to 4294967295 [-Wconstant-conversion]
  179 |     static LayerResult make_nop_layer_result() { return {"", std::numeric_limits<coord_t>::max(), false, false, true}; }
      |                                                         ~    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```