### PR TITLE
Pin OpenSSL libdir so the bundled Python finds it

### DIFF
--- a/deps/OpenSSL/OpenSSL.cmake
+++ b/deps/OpenSSL/OpenSSL.cmake
@@ -52,6 +52,14 @@ ExternalProject_Add(dep_OpenSSL
 	CONFIGURE_COMMAND ${_conf_cmd} ${_cross_arch}
         "--openssldir=${DESTDIR}"
         "--prefix=${DESTDIR}"
+        # OpenSSL's linux-x86_64 target sets multilib=64, so it installs to
+        # <prefix>/lib64 while every other dep uses <prefix>/lib. CPython's
+        # --with-openssl only ever emits -L<dir>/lib, so it misses the bundled
+        # static libs and silently links the system OpenSSL instead -- which,
+        # against 1.1.1w headers, leaves _ssl.so with an undefined
+        # SSL_get_peer_certificate (removed in OpenSSL 3.x). Pin libdir so the
+        # prefix stays single-layout.
+        "--libdir=lib"
         ${_cross_comp_prefix_line}
         no-shared
         no-asm


### PR DESCRIPTION
# Description

Fixes the dependency build on distributions where OpenSSL selects the `lib64`
layout. On those systems the bundled CPython silently links the **system**
OpenSSL rather than the one built in `deps/`, and the build then fails:

```
install: cannot stat 'Modules/_ssl.cpython-312-x86_64-linux-gnu.so':
         No such file or directory
```

### The chain

1. OpenSSL's `linux-x86_64` target sets `multilib=64`, so `make install_sw`
   installs the static libraries to `<prefix>/lib64` — while every other
   dependency in the prefix uses `<prefix>/lib`.
2. CPython's `--with-openssl=<dir>` only ever emits `-L<dir>/lib`. It does not
   check `lib64`, so `-lssl` falls through to the system OpenSSL.
3. `gcc -shared` does not error on unresolved symbols, so the link *appears* to
   succeed. But `_ssl.c` was compiled against the bundled 1.1.1w headers, which
   map `SSL_get1_peer_certificate` onto the pre-3.0 `SSL_get_peer_certificate` —
   a symbol OpenSSL 3.x removed:

   ```
   [ERROR] _ssl failed to import: .../_ssl.cpython-312-x86_64-linux-gnu.so:
           undefined symbol: SSL_get_peer_certificate
   Could not build the ssl module!
   Python requires a OpenSSL 1.1.1 or newer
   ```
4. With no `_ssl` produced, `make install` cannot stat it and the build stops.

### The fix

Passing `--libdir=lib` keeps the prefix single-layout, so CPython's
`-L<dir>/lib` finds the bundled static libraries and links against the same
headers it compiled with.

CMake-based dependencies were never affected, because CMake's `FindOpenSSL`
searches `lib64` on its own — only CPython's autoconf path is sensitive to this.
That is why the failure looks like a Python problem rather than an OpenSSL one.

### Who this affects

Distributions where OpenSSL picks the `lib64` layout: the Fedora, openSUSE and
Arch families. Debian and Ubuntu are unaffected, which is why CI has not caught
it.

I could not find an existing issue or PR for this — searched for
`SSL_get_peer_certificate`, `_ssl`, `libdir` and `Could not build the ssl module`.
Apologies if I missed one.

## Tests

Verified on Arch Linux (GCC 16.1.1, CMake 4.4.2), where the build reproducibly
failed before this change and completes after it.

The decisive check is which OpenSSL the bundled interpreter actually links,
since the failure mode is a *silent* fallback to the system library:

```
$ deps/build/OrcaSlicer_dep/usr/local/libpython/bin/python3.12 \
    -c 'import ssl; print(ssl.OPENSSL_VERSION)'
OpenSSL 1.1.1w  11 Sep 2023
```

That reports the bundled 1.1.1w rather than the host's OpenSSL 3.6.3, and
`_ssl.cpython-312-x86_64-linux-gnu.so` is produced and installed. The full
dependency build then completes, and the application builds and runs.

**Not verified on macOS or Windows.** `--libdir` is accepted by OpenSSL's
`Configure` on all platforms, and Darwin targets do not set `multilib`, so this
should be a no-op there — but I have only tested Linux and would rather say so
than imply otherwise. CI's multi-platform dependency build is the real check.
