### PR TITLE
feat(plugin): add orca.host.reload_presets() to refresh presets at runtime

### DIFF
--- a/src/slic3r/plugin/host/PluginHostApp.cpp
+++ b/src/slic3r/plugin/host/PluginHostApp.cpp
@@ -78,8 +78,14 @@ void host_bindings::register_app(py::module_& host)
         auto& app = GUI::wxGetApp();
         if (app.preset_bundle == nullptr)
             throw std::runtime_error("Preset bundle is not available");
-        app.preset_bundle->load_user_presets(DEFAULT_USER_FOLDER_NAME,
-                                             ForwardCompatibilitySubstitutionRule::Enable);
+        // Reload the active user's preset folder: a signed-in user's presets
+        // live under their user id, otherwise the default folder — same choice
+        // GUI_App makes when loading presets.
+        NetworkAgent* agent = app.getAgent();
+        const std::string user = (agent != nullptr && agent->is_user_login())
+                                     ? agent->get_user_id()
+                                     : DEFAULT_USER_FOLDER_NAME;
+        app.preset_bundle->load_user_presets(user, ForwardCompatibilitySubstitutionRule::Enable);
         if (app.mainframe != nullptr)
             app.mainframe->update_side_preset_ui();
     });

--- a/src/slic3r/plugin/host/PluginHostApp.cpp
+++ b/src/slic3r/plugin/host/PluginHostApp.cpp
@@ -4,6 +4,7 @@
 #include <libslic3r/PresetBundle.hpp>
 #include <slic3r/GUI/GUI.hpp>
 #include <slic3r/GUI/GUI_App.hpp>
+#include <slic3r/GUI/MainFrame.hpp>
 #include <slic3r/GUI/Plater.hpp>
 
 #include <memory>
@@ -64,6 +65,23 @@ void host_bindings::register_app(py::module_& host)
         if (wxTheApp == nullptr)
             throw std::runtime_error("OrcaSlicer application is not initialized");
         return GUI::into_u8(GUI::wxGetApp().current_language_code_safe());
+    });
+    // Re-read user preset files from disk and refresh the filament dropdown,
+    // without restarting the app. Plugins that write preset/spool files (see
+    // preset_bundle().filaments) otherwise require a restart to make them
+    // visible. This mirrors exactly what OrcaCloud sync does after pulling
+    // presets (GUI_App: load_user_presets + update_side_preset_ui); the loader
+    // preserves the currently selected presets.
+    host.def("reload_presets", []() {
+        if (wxTheApp == nullptr)
+            throw std::runtime_error("OrcaSlicer application is not initialized");
+        auto& app = GUI::wxGetApp();
+        if (app.preset_bundle == nullptr)
+            throw std::runtime_error("Preset bundle is not available");
+        app.preset_bundle->load_user_presets(DEFAULT_USER_FOLDER_NAME,
+                                             ForwardCompatibilitySubstitutionRule::Enable);
+        if (app.mainframe != nullptr)
+            app.mainframe->update_side_preset_ui();
     });
 }
 


### PR DESCRIPTION
# Description

Python plugins currently have no way to surface newly written presets/spools without restarting OrcaSlicer. Plugins that write preset files (via `preset_bundle().filaments`) have to ask the user to restart the app — poor UX (both the Spoolman plugin and FilamentHub do exactly this).

Yet OrcaSlicer already reloads presets at runtime — that is how Orca Cloud sync works: after pulling presets from the cloud it calls `load_user_presets()` + `update_side_preset_ui()`, and the filament list refreshes without a restart.

This PR exposes the same capability to plugins via a minimal method:

```python
orca.host.reload_presets()
```

It re-reads the active user's presets from disk and refreshes the filament dropdown — exactly what cloud sync does. The loader preserves the currently selected presets, so the user's selection is not reset.

No breaking changes; one file.

**Update:** following review feedback (https://github.com/OrcaSlicer/OrcaSlicer/pull/15048#issuecomment-5151806492), `reload_presets()` now reloads the **active** user's preset folder — the signed-in user's id, falling back to the default folder — instead of hard-coding `DEFAULT_USER_FOLDER_NAME`, matching how `GUI_App` loads presets.

# Screenshots

<img width="691" height="352" alt="1" src="https://github.com/user-attachments/assets/c9446d0c-93d7-4eb8-a6bf-07786fed1847" />


## Tests

- Built on macOS (arm64, Ninja) with this change — compiles clean.
- A script-capability plugin wrote a new filament preset to disk and called `orca.host.reload_presets()`: the new preset appeared in the filament list **without a restart**, and the previously selected preset stayed selected.
- Verified the guard before GUI init (same exception pattern as the neighbouring `plater()`/`preset_bundle()` accessors).
