### PR TITLE
Define WXINSPECTOR_DISABLE globally to prevent include-order-dependent class layout

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,8 +80,12 @@ endif()
 
 if (DEFINED BBL_RELEASE_TO_PUBLIC)
     add_compile_definitions("BBL_RELEASE_TO_PUBLIC=${BBL_RELEASE_TO_PUBLIC}")
+    if (BBL_RELEASE_TO_PUBLIC)
+        add_compile_definitions(WXINSPECTOR_DISABLE)
+    endif ()
 else ()
     add_compile_definitions("BBL_RELEASE_TO_PUBLIC=$<CONFIG:Release>")
+    add_compile_definitions("$<$<CONFIG:Release>:WXINSPECTOR_DISABLE>")
 endif ()
 
 find_package(Git)

--- a/src/libslic3r/Technologies.hpp
+++ b/src/libslic3r/Technologies.hpp
@@ -51,9 +51,4 @@
 // Enable extension of tool position imgui dialog to show actual speed profile
 #define ENABLE_ACTUAL_SPEED_DEBUG 1
 
-// Disable layout inspector for public release
-#if BBL_RELEASE_TO_PUBLIC
-#define WXINSPECTOR_DISABLE
-#endif
-
 #endif // _prusaslicer_technologies_h_


### PR DESCRIPTION

# Description

This PR fixes a bug where the wrong include order of `Technologies.hpp` determines different class layouts of
- `class SettingsDialog : public DPIDialog`  and 
- `class ParamsDialog : public DPIDialog`. 

Both would see `m_panel` at a different offset if `WXINSPECTOR_DISABLE` is resolved differently in the two compilation units. Hence in `void MainFrame::create_preset_tabs()` at line `m_param_dialog = new ParamsDialog(m_plater);` has an unexpected layout (ODR is viloated).

Relates to https://github.com/OrcaSlicer/OrcaSlicer/pull/14919

The wrong order happens in `GUI_Utils.cpp`
```
#ifndef slic3r_GUI_Utils_hpp_
#define slic3r_GUI_Utils_hpp_
...
#include <wx/inspector/inspector.h> // the implemenation detail depends on `Technologies.hpp` namely on WXINSPECTOR_DISABLE
...
#include "libslic3r/Utils.hpp" // this includes `Technologies.hpp` and sees WXINSPECTOR_DISABLE too late
```

Simply swapping the include would fix the `MainFrame.cpp` / `ParamsDialog.cpp` mismatch but i recommend to pull the `WXINSPECTOR_DISABLE definition up to CMake level, to make the include indifferent (i.e. if clang format change order it impacts the compilation without noticing).

**Note:** 
If my conclusion above is correct, i have no clue why such a severe bug was not affecting others since merge of https://github.com/OrcaSlicer/OrcaSlicer/pull/14919. I did a clean release bulid without PCH and use ccache. 

**How to reproduce:**

1. `git checkout main && git pull` at rev. 95b781745dfffd458b703f6a743ba93416d5d354
2. `rm -rf build`
3. `./build_linux.sh -spCj 20`
4. 
```
build/package/orca-slicer 
Segmentation fault         (core dumped) build/package/orca-slicer
``` 
