### PR TITLE
Fix preview speeds and time estimates after firmware retract commands

### DIFF
--- a/src/libslic3r/GCode/GCodeProcessor.cpp
+++ b/src/libslic3r/GCode/GCodeProcessor.cpp
@@ -5926,8 +5926,11 @@ void GCodeProcessor::process_G10(const GCodeReader::GCodeLine& line)
     GCodeReader::GCodeLine g10;
     g10.set(Axis::E, -this->m_parser.config().retraction_length.get_at(m_extruder_id));
     g10.set(Axis::F,  this->m_parser.config().retraction_speed.get_at(m_extruder_id) * 60);
+    //Orca: Firmware retract emulation must not change the modal G1 feedrate.
+    const float feedrate = m_feedrate;
     --m_g1_line_id;
     process_G1(g10);
+    m_feedrate = feedrate;
 }
 
 void GCodeProcessor::process_G11(const GCodeReader::GCodeLine& line)
@@ -5936,8 +5939,11 @@ void GCodeProcessor::process_G11(const GCodeReader::GCodeLine& line)
     GCodeReader::GCodeLine g11;
     g11.set(Axis::E, this->m_parser.config().retraction_length.get_at(m_extruder_id) + this->m_parser.config().retract_restart_extra.get_at(m_extruder_id));
     g11.set(Axis::F, this->m_parser.config().deretraction_speed.get_at(m_extruder_id) * 60);
+    // Orca: Firmware unretract emulation must not change the modal G1 feedrate.
+    const float feedrate = m_feedrate;
     --m_g1_line_id;
     process_G1(g11);
+    m_feedrate = feedrate;
 }
 
 void GCodeProcessor::process_G20(const GCodeReader::GCodeLine& line)


### PR DESCRIPTION
## Description

This PR fixes incorrect preview speeds and overestimated print times when using firmware retraction with `G10` and `G11`.

## Problem

The issue occurred when firmware retraction was used and the extrusion speeds before and after an retraction/unretraction were the same.

Because the speed did not change, the redundant `F` value after `G10`/`G11` could be removed from the generated G-code. However, while `G10`/`G11` was internally emulated for time estimation, its speed was left as the active feedrate.

The following extrusion therefore inherited the unretraction speed instead of continuing at its previous extrusion speed.

This caused an incorrect speed in the preview and could significantly inflate the estimated print time.

## Applied fix

Preserve the active feedrate while emulating `G10` and `G11`, then restore it after processing the retract or unretract move.

## Result

Firmware retract and unretract emulation no longer changes the modal feedrate used by following moves, resulting in correct preview speeds and time estimates.

## Screenshots
__Before:__
<img width="1884" height="1846" alt="image" src="https://github.com/user-attachments/assets/4348e741-3c94-46be-894f-6ca2ec511ddf" />

<br>
<br>

__After:__
<img width="1822" height="1857" alt="image" src="https://github.com/user-attachments/assets/de4d376d-cb7e-4e21-ad93-4924e32eac7c" />

---

Fixes #15056
