### PR TITLE
Omit bed_temperature_formula for non-BBL printers and add tests

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -6717,7 +6717,14 @@ void GCode::append_full_config(const Print &print, std::string &str)
         "printhost_password"sv,
         "printhost_port"sv
     });
-    auto is_banned = [](const std::string &key) {
+    // Orca: firmware that prefix-matches "bed_temperature" in this block (e.g. Anycubic Kobra) picks up
+    // bed_temperature_formula and shows its enum name instead of a temperature. The key is only read at
+    // slice time from m_config, so dropping it is safe. Not a banned_keys entry like the two above: that
+    // set is static, and this key already ships in BBL dumps, so the ban must be per-call and BBL-exempt.
+    const bool ban_bed_temperature_formula = !print.is_BBL_printer();
+    auto is_banned = [ban_bed_temperature_formula](const std::string &key) {
+        if (ban_bed_temperature_formula && key == "bed_temperature_formula")
+            return true;
         return banned_keys.find(key) != banned_keys.end();
     };
     std::ostringstream ss;

--- a/tests/fff_print/test_print.cpp
+++ b/tests/fff_print/test_print.cpp
@@ -338,6 +338,25 @@ TEST_CASE("G-code lists the resolved extrusion-width settings", "[Print]")
     CHECK(with_first_layer.find("; first layer extrusion width") != std::string::npos);
 }
 
+// bed_temperature_formula serializes to an enum name, and firmware that prefix-matches
+// "bed_temperature" while scanning the config block (Anycubic Kobra) reports that name as the
+// bed temperature. The key is only read at slice time, so it is dropped from the block for
+// non-BBL printers. BBL printers have carried it in the block since it was added, so they keep
+// it and their output stays unchanged.
+TEST_CASE("The G-code config block omits bed_temperature_formula for non-BBL printers", "[Print]")
+{
+    Print print;
+    Model model;
+    Slic3r::Test::init_print({cube(20)}, print, model);
+    CHECK(Slic3r::Test::gcode(print).find("; bed_temperature_formula") == std::string::npos);
+
+    Print bbl_print;
+    Model bbl_model;
+    Slic3r::Test::init_print({cube(20)}, bbl_print, bbl_model);
+    bbl_print.is_BBL_printer() = true;
+    CHECK(Slic3r::Test::gcode(bbl_print).find("; bed_temperature_formula") != std::string::npos);
+}
+
 // Custom G-code templates substitute placeholders during export.
 TEST_CASE("Custom G-code placeholders are substituted", "[Print]")
 {


### PR DESCRIPTION
# Description

Hi all, 

This is a **shameful** AI coded PR which fixes an issue I have with my Kobra 3 after v2.3.1 when the new key/prefix was added.

Some third-party firmware parses the trailing `; key = value` config block that OrcaSlicer appends to every exported G-code file, and matches on the prefix `bed_temperature` to find the bed temperature. Since `bed_temperature_formula` was added, that prefix match hits the formula key first and because it is a `coEnum`, it serializes to its enum *name* (`by_highest_temp` / `by_first_filament`) rather than a number. Affected printers (e.g. Anycubic Kobra) then display the enum name where the bed temperature should be.

# Screenshots/Recordings/Graphs

<table>
  <tr>
    <th align="center">v2.3.1</th>
    <th align="center">v2.3.2+</th>
  </tr>
  <tr>
    <td align="center">
      <img width="275" alt="After" src="https://github.com/user-attachments/assets/fc880915-0289-4260-b6a8-d8ab1eb69e3c" />
    </td>
    <td align="center">
      <img width="270" alt="Before" src="https://github.com/user-attachments/assets/fbd595cc-58d1-4095-9c26-58ee6abb0ec8" />
    </td>
  </tr>
</table>


## Tests

Added `The G-code config block omits bed_temperature_formula for non-BBL printers` to `tests/fff_print/test_print.cpp`, alongside the existing config-block test. It slices a 20mm cube twice and asserts the `; bed_temperature_formula` token is absent for a default (non-BBL) print and still present when `is_BBL_printer()` is set — the second half locks in the BBL byte-compatibility claim so a future refactor cannot silently regress it.
