### PR TITLE
QOL Add parent preset information next to detach preset checkbox and match checkbox style on Save Preset dialog

### DIFF
--- a/src/slic3r/GUI/SavePresetDialog.cpp
+++ b/src/slic3r/GUI/SavePresetDialog.cpp
@@ -111,13 +111,46 @@ SavePresetDialog::Item::Item(Preset::Type type, const std::string &suffix, wxBox
 
     sizer->Add(m_radio_group, 0, wxEXPAND | wxTOP | wxLEFT, BORDER_W);
 
-    if (parent->m_mode == comDevelop) {
-        m_detach_checkbox = new wxCheckBox(parent, wxID_ANY, _L("Detach from parent"));
-        sizer->Add(m_detach_checkbox, 0, wxALIGN_LEFT | wxALL, BORDER_W);
+    std::string inherits_str = sel_preset.inherits();
+    if (parent->m_mode == comDevelop && !inherits_str.empty()) {
+        wxBoxSizer *detach_sizer = new wxBoxSizer(wxHORIZONTAL);
+
+        auto detach_tooltip  = _L("Copies all inherited values from the parent preset into this preset and removes the connection with the parent preset.");
+
+        auto detach_checkbox = new ::CheckBox(parent);
+        detach_checkbox->SetToolTip(detach_tooltip);
+
+        auto detach_label    = new wxStaticText(parent, wxID_ANY, _L("Detach from parent"));
+        detach_label->SetFont(::Label::Body_14);
+        detach_label->SetForegroundColour(wxColour("#363636"));
+        detach_label->SetToolTip(detach_tooltip);
+
+        detach_sizer->Add(detach_checkbox, 0, wxALIGN_LEFT | wxLEFT, BORDER_W);
+        detach_sizer->Add(detach_label   , 0, wxALIGN_CENTRE_VERTICAL | wxLEFT, FromDIP(5));
+        sizer->Add(detach_sizer, 0, wxEXPAND | wxTOP, BORDER_W);
+        sizer->AddSpacer(FromDIP(5));
+
+        auto parent_label    = new wxStaticText(parent, wxID_ANY, inherits_str);
+        parent_label->SetFont(::Label::Body_12);
+        parent_label->SetForegroundColour(wxColour("#6B6B6B"));
+        parent_label->SetToolTip(_L("Parent preset"));
+        sizer->Add(parent_label, 0, wxEXPAND | wxLEFT, BORDER_W + FromDIP(24));
+
+        sizer->AddSpacer(FromDIP(5));
+
         // Set initial state (unchecked by default)
-        m_detach_checkbox->SetValue(m_detach);
+        detach_checkbox->SetValue(m_detach);
         // Bind the checkbox event to update the detach state for this item
-        m_detach_checkbox->Bind(wxEVT_CHECKBOX, [this](wxCommandEvent&) { m_detach = m_detach_checkbox->GetValue(); });
+        detach_checkbox->Bind(wxEVT_TOGGLEBUTTON, [this, detach_checkbox](wxCommandEvent&) { m_detach = detach_checkbox->GetValue(); });
+
+        auto on_toggle = [this, detach_checkbox]() {
+            detach_checkbox->SetValue(!detach_checkbox->GetValue());
+            wxCommandEvent ev(wxEVT_TOGGLEBUTTON, detach_checkbox->GetId());
+            ev.SetEventObject(detach_checkbox);
+            detach_checkbox->GetEventHandler()->ProcessEvent(ev);
+        };
+        detach_label->Bind(wxEVT_LEFT_DOWN,   [on_toggle](wxMouseEvent& e) {if(!e.LeftDClick()) on_toggle();});
+        detach_label->Bind(wxEVT_LEFT_DCLICK, [on_toggle](wxMouseEvent& e) {on_toggle();});
     }
     
     m_radio_group->Bind(wxEVT_COMMAND_RADIOBOX_SELECTED, [this](wxCommandEvent &e) {

--- a/src/slic3r/GUI/SavePresetDialog.hpp
+++ b/src/slic3r/GUI/SavePresetDialog.hpp
@@ -75,7 +75,6 @@ class SavePresetDialog : public DPIDialog
         bool                m_save_to_project {false};
         RadioGroup*         m_radio_group; // ORCA
         bool                m_detach{false};
-        wxCheckBox*         m_detach_checkbox{nullptr};
 
         void update();
     };


### PR DESCRIPTION
Fixes https://github.com/OrcaSlicer/OrcaSlicer/issues/14988

• Adds parent profile information
• Adds tooltip to checkbox
• Matches style of checkbox
• Shows detach checkbox only when preset has a parent

**Before**
<img width="416" height="298" alt="Screenshot-20260802161139" src="https://github.com/user-attachments/assets/eb2ac4cb-b1fb-4b7e-87d3-8315de001a72" />

**After**
<img width="425" height="305" alt="Screenshot-20260802161055" src="https://github.com/user-attachments/assets/4623abd8-9a75-455e-acfa-d49ddede7a46" />
