### PR TITLE
Fixes Compiler warnings [-Warray-bounds=]

### DIFF
--- a/src/libslic3r/Config.hpp
+++ b/src/libslic3r/Config.hpp
@@ -444,14 +444,20 @@ public:
         }
         if (rhs->type() == this->type()) {
             // Assign the first value of the rhs vector.
-            auto other = static_cast<const ConfigOptionVector<T>*>(rhs);
+            auto other = dynamic_cast<const ConfigOptionVector<T>*>(rhs);
+            if (other == nullptr)
+                throw ConfigurationError("ConfigOptionVector::set_at(): Assigning an incompatible type");
             if (other->values.empty())
                 throw ConfigurationError("ConfigOptionVector::set_at(): Assigning from an empty vector");
             this->values[i] = other->get_at(j);
-        } else if (rhs->type() == this->scalar_type())
-            this->values[i] = static_cast<const ConfigOptionSingle<T>*>(rhs)->value;
-        else
+        } else if (rhs->type() == this->scalar_type()) {
+            auto other = dynamic_cast<const ConfigOptionSingle<T>*>(rhs);
+            if (other == nullptr)
+                throw ConfigurationError("ConfigOptionVector::set_at(): Assigning an incompatible type");
+            this->values[i] = other->value;
+        } else {
             throw ConfigurationError("ConfigOptionVector::set_at(): Assigning an incompatible type");
+        }
     }
 
     //BBS


### PR DESCRIPTION
# Description

Fixes https://github.com/OrcaSlicer/OrcaSlicer/issues/15081

The OrcaSlicher config-system has its own runtime typing method and GCC cannot verify the correctness of `::type()`.

`[-Warray-bounds=]` warning triggered by `::set_at()` in

```
void PartPlateList::set_default_wipe_tower_pos_for_plate(int plate_idx, bool init_pos) {
...
    ConfigOptionFloat wt_x_opt(x);
    ConfigOptionFloat wt_y_opt(y);
    
    dynamic_cast<ConfigOptionFloats *>(proj_cfg.option("wipe_tower_x"))->set_at(&wt_x_opt, plate_idx, 0);
    dynamic_cast<ConfigOptionFloats *>(proj_cfg.option("wipe_tower_y"))->set_at(&wt_y_opt, plate_idx, 0);
}
```

and in

```
void GLCanvas3D::do_move(const std::string& snapshot_type) {
   ...

  ConfigOptionFloat wipe_tower_x(wipe_tower_origin(0) - plate_origin(0));
  ConfigOptionFloat wipe_tower_y(wipe_tower_origin(1) - plate_origin(1));
        
  ConfigOptionFloats* wipe_tower_x_opt = proj_cfg.option<ConfigOptionFloats>("wipe_tower_x", true);
  ConfigOptionFloats* wipe_tower_y_opt = proj_cfg.option<ConfigOptionFloats>("wipe_tower_y", true);
  wipe_tower_x_opt->set_at(&wipe_tower_x, plate_id, 0);
  wipe_tower_y_opt->set_at(&wipe_tower_y, plate_id, 0);
   ...
}
```

If `ConfigOptionVector::set_at()` is inlined gcc sees both branches and that `rhs` is `ConfigOptionFloat` (scalar, not a vector). It cannot verify the correctness of `::type()`, hence does not know if type() resolves is similar to what the RTTI would do. It verifies also the first branch and knows `rhs` is scalar (because inlined).

```
if (rhs->type() == this->type()) { // set value from same type: vector
  // gcc does not know this branch will not happen

  // here it thinks the satic_cast might be wrong because rhs is a scalar (only if inlined)
  auto other = static_cast<const ConfigOptionVector<T>*>(rhs);
  if (other->values.empty()) // warning: potential access to object with wrong offset
  ...
} else if (rhs->type() == this->scalar_type()) {   // set value from scalar of same type
  ...
} else {
  throw ConfigurationError("ConfigOptionVector::set_at(): Assigning an incompatible type");
}
```

I suggest to accept a slight overhead and use `dynamic_cast<>()`. It will silence this warning for the cost of minimal impact.

I monitored the calls to both branches of `::set_at()` and found that  the "vector"-branch is passed 0 times and the "scalar" branch 6 times. I minimally tested it like so:

1. Start OrcaSlicer, // all calls to `::set_at()` were triggered during start
2. manually changed values in Multimaterial -> Prime tower, then
3. Save current process, and
4. close OrcaSlicer
