### PR TITLE
Fix ignored filament-specific ironing speed override

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -7633,8 +7633,7 @@ std::string GCode::_extrude(const ExtrusionPath &path, std::string description, 
             if (sloped) {
                 speed = std::min(speed, m_config.scarf_joint_speed.get_abs_value(speed));
             }
-        } 
-        else if(path.role() == erInternalBridgeInfill) {
+        } else if(path.role() == erInternalBridgeInfill) {
             speed = m_config.get_abs_value_at("internal_bridge_speed", get_nozzle_config_index(m_writer.filament()->id()));
         } else if (path.role() == erOverhangPerimeter || path.role() == erSupportTransition || path.role() == erBridgeInfill) {
             speed = NOZZLE_CONFIG(bridge_speed);
@@ -7645,7 +7644,10 @@ std::string GCode::_extrude(const ExtrusionPath &path, std::string description, 
         } else if (path.role() == erTopSolidInfill) {
             speed = NOZZLE_CONFIG(top_surface_speed);
         } else if (path.role() == erIroning) {
-            speed = m_config.get_abs_value("ironing_speed");
+            const size_t filament_idx = get_filament_config_index(m_writer.filament()->id());
+            speed = m_config.filament_ironing_speed.is_nil(filament_idx)
+                ? m_config.get_abs_value("ironing_speed")
+                : m_config.filament_ironing_speed.get_at(filament_idx);
         } else if (path.role() == erBottomSurface) {
             speed = NOZZLE_CONFIG(initial_layer_infill_speed);
         } else if (path.role() == erGapFill) {


### PR DESCRIPTION
## Description

This PR fixes the filament-specific ironing speed being ignored during G-code generation.

The filament override was already considered while preparing the ironing paths, but the final G-code feed rate always used the process-level **Ironing speed** setting.

The active filament’s **Ironing speed** override is now used when it is configured. Otherwise, the existing process-level setting remains in effect.

## Behavior

* **Filament override not set:** behavior is unchanged; the process-level ironing speed is used.
* **Filament override set:** ironing G-code uses the override configured for the active filament.


## Screenshots

__Before:__
<img width="2219" height="1661" alt="image" src="https://github.com/user-attachments/assets/936a9e3b-aada-46c4-b77d-01c015fad8aa" />

<br>
<br>

__After:__
<img width="2227" height="1656" alt="image" src="https://github.com/user-attachments/assets/030e452c-31e2-47b8-aa0c-857a01f4b534" />

---

Fixes #15075