### PR TITLE
Fix bridge_flow/internal_bridge_flow changes not taking effect without a support Z gap

### DIFF
--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -1480,13 +1480,11 @@ bool PrintObject::invalidate_state_by_config_options(
             steps.emplace_back(posPerimeters);
             steps.emplace_back(posSupportMaterial);
         } else if (opt_key == "bridge_flow" || opt_key == "internal_bridge_flow") {
-            if (m_config.support_top_z_distance > 0.) {
-            	// Only invalidate due to bridging if bridging is enabled.
-            	// If later "support_top_z_distance" is modified, the complete PrintObject is invalidated anyway.
-            	steps.emplace_back(posPerimeters);
-            	steps.emplace_back(posInfill);
-	            steps.emplace_back(posSupportMaterial);
-	        }
+            // Bridges can occur without support (e.g. spans between walls), so always invalidate
+            // rather than only when support_top_z_distance > 0.
+            steps.emplace_back(posPerimeters);
+            steps.emplace_back(posInfill);
+            steps.emplace_back(posSupportMaterial);
         } else if (
                 opt_key == "wall_generator"
             || opt_key == "wall_transition_length"


### PR DESCRIPTION
## Summary
- `PrintObject::invalidate_state_by_config_options()` only invalidated `posPerimeters`/`posInfill`/`posSupportMaterial` for `bridge_flow` and `internal_bridge_flow` changes when `support_top_z_distance > 0`.
- Bridges also occur without any support involved (e.g. spans between walls), so changing `bridge_flow` with `support_top_z_distance == 0` silently had no effect until an unrelated setting triggered a full reslice.
- This removes the incorrect condition so these options always invalidate the relevant steps, matching the fact that bridging can happen independent of support settings.

## Test plan
- [x] Reproduced: with `support_top_z_distance = 0`, changing `bridge_flow` from 1.0 to 1.5 on a bridge test model produced no visible change until an unrelated setting was changed.
- [x] Confirmed: setting `support_top_z_distance = 0.2` made the same `bridge_flow` change take effect immediately, isolating the root cause to this invalidation condition.
- [x] Re-sliced with the fix applied and `support_top_z_distance = 0` to confirm `bridge_flow` now takes effect immediately.
