### PR TITLE
Add preference to skip 3D mouse detection

### DIFF
--- a/src/libslic3r/AppConfig.cpp
+++ b/src/libslic3r/AppConfig.cpp
@@ -248,8 +248,8 @@ void AppConfig::set_defaults()
     if (get("reverse_mouse_wheel_zoom").empty())
         set_bool("reverse_mouse_wheel_zoom", false);
 
-    if (get("skip_3dmouse_detect").empty())
-        set_bool("skip_3dmouse_detect", false);
+    if (get("disable_3dmouse").empty())
+        set_bool("disable_3dmouse", false);
 
     if (get("enable_append_color_by_sync_ams").empty())
         set_bool("enable_append_color_by_sync_ams", true);

--- a/src/libslic3r/AppConfig.cpp
+++ b/src/libslic3r/AppConfig.cpp
@@ -248,6 +248,9 @@ void AppConfig::set_defaults()
     if (get("reverse_mouse_wheel_zoom").empty())
         set_bool("reverse_mouse_wheel_zoom", false);
 
+    if (get("skip_3dmouse_detect").empty())
+        set_bool("skip_3dmouse_detect", false);
+
     if (get("enable_append_color_by_sync_ams").empty())
         set_bool("enable_append_color_by_sync_ams", true);
     if (get("enable_merge_color_by_sync_ams").empty())

--- a/src/slic3r/GUI/Mouse3DController.cpp
+++ b/src/slic3r/GUI/Mouse3DController.cpp
@@ -265,6 +265,9 @@ static std::string detect_attached_device()
 // Called by Win32 HID enumeration callback.
 void Mouse3DController::device_attached(const std::string &device)
 {
+    if (m_disabled)
+        return;
+
 	int vid = 0;
 	int pid = 0;
 	if (sscanf(device.c_str(), "\\\\?\\HID#VID_%x&PID_%x&", &vid, &pid) == 2) {
@@ -291,6 +294,9 @@ void Mouse3DController::device_attached(const std::string &device)
 
 void Mouse3DController::device_detached(const std::string& device)
 {
+    if (m_disabled)
+        return;
+
     int vid = 0;
     int pid = 0;
     if (sscanf(device.c_str(), "\\\\?\\HID#VID_%x&PID_%x&", &vid, &pid) == 2) {
@@ -806,6 +812,12 @@ bool Mouse3DController::handle_input(const DataPacketAxis& packet)
 // Initialize the application.
 void Mouse3DController::init()
 {
+    m_disabled = wxGetApp().app_config->get_bool("disable_3dmouse");
+    if (m_disabled) {
+        BOOST_LOG_TRIVIAL(info) << "3D mouse support is disabled";
+        return;
+    }
+
 #ifdef _WIN32
     m_device_str = detect_attached_device();
     if (!m_device_str.empty()) {
@@ -1275,7 +1287,7 @@ void Mouse3DController::collect_input()
 #ifdef _WIN32
 bool Mouse3DController::handle_raw_input_win32(const unsigned char *data, const int packet_length)
 {
-    if (! wxGetApp().IsActive())
+    if (m_disabled || ! wxGetApp().IsActive())
         return false;
 
     if (packet_length == 7 || packet_length == 13) {

--- a/src/slic3r/GUI/Mouse3DController.hpp
+++ b/src/slic3r/GUI/Mouse3DController.hpp
@@ -153,6 +153,7 @@ class Mouse3DController
     mutable State 		m_state;
     std::atomic<bool> 	m_connected { false };
     std::string 		m_device_str;
+    bool                m_disabled { false };
 
 #if ! __APPLE__
     // Worker thread for enumerating devices, connecting, reading data from the device and closing the device.

--- a/src/slic3r/GUI/Mouse3DHandlerMac.mm
+++ b/src/slic3r/GUI/Mouse3DHandlerMac.mm
@@ -1,4 +1,6 @@
 #include "Mouse3DController.hpp"
+#include "libslic3r/AppConfig.hpp"
+#include "GUI_App.hpp"
 
 #include <stdint.h>
 #include <dlfcn.h>
@@ -190,6 +192,12 @@ namespace GUI {
 // Initialize the application.
 void Mouse3DController::init()
 {
+  m_disabled = wxGetApp().app_config->get_bool("disable_3dmouse");
+  if (m_disabled) {
+    BOOST_LOG_TRIVIAL(info) << "3D mouse support is disabled";
+    return;
+  }
+
   BOOST_LOG_TRIVIAL(info) << "3dx mac handler starts";
   if (load_driver_functions()) {
     mouse_3d_controller = this;

--- a/src/slic3r/GUI/Preferences.cpp
+++ b/src/slic3r/GUI/Preferences.cpp
@@ -1793,13 +1793,11 @@ void PreferencesDialog::create_items()
     auto reverse_mouse_zoom    = create_item_checkbox(_L("Reverse mouse zoom"), _L("If enabled, reverses the direction of zoom with mouse wheel."), "reverse_mouse_wheel_zoom");
     g_sizer->Add(reverse_mouse_zoom);
 
-#ifdef _WIN32
-    auto item_skip_3dmouse_detect = create_item_checkbox(
-        _L("Skip 3D mouse detection"),
-        _L("Prevents detection of and connection to 3D mouse devices. Enable this option if 3D mouse detection causes startup or compatibility issues."),
-        "skip_3dmouse_detect", _L("(Requires restart)"));
-    g_sizer->Add(item_skip_3dmouse_detect);
-#endif
+    auto item_disable_3dmouse = create_item_checkbox(
+        _L("Disable 3D mouse support"),
+        _L("Disables 3D mouse device detection and input."),
+        "disable_3dmouse", _L("(Requires restart)"));
+    g_sizer->Add(item_disable_3dmouse);
 
     std::vector<wxString> ButtonDragActions = {_L("None"), _L("Pan"), _L("Rotate")};
     auto item_left_mouse_drag  = create_item_combobox(_L("Left Mouse Drag"), _L("Set the action that dragging the left mouse button should perform."), "left_mouse_drag_action", ButtonDragActions);

--- a/src/slic3r/GUI/Preferences.cpp
+++ b/src/slic3r/GUI/Preferences.cpp
@@ -1793,6 +1793,14 @@ void PreferencesDialog::create_items()
     auto reverse_mouse_zoom    = create_item_checkbox(_L("Reverse mouse zoom"), _L("If enabled, reverses the direction of zoom with mouse wheel."), "reverse_mouse_wheel_zoom");
     g_sizer->Add(reverse_mouse_zoom);
 
+#ifdef _WIN32
+    auto item_skip_3dmouse_detect = create_item_checkbox(
+        _L("Skip 3D mouse detection"),
+        _L("Prevents detection of and connection to 3D mouse devices. Enable this option if 3D mouse detection causes startup or compatibility issues."),
+        "skip_3dmouse_detect", _L("(Requires restart)"));
+    g_sizer->Add(item_skip_3dmouse_detect);
+#endif
+
     std::vector<wxString> ButtonDragActions = {_L("None"), _L("Pan"), _L("Rotate")};
     auto item_left_mouse_drag  = create_item_combobox(_L("Left Mouse Drag"), _L("Set the action that dragging the left mouse button should perform."), "left_mouse_drag_action", ButtonDragActions);
     g_sizer->Add(item_left_mouse_drag);


### PR DESCRIPTION
# Description

Some users reported that scanning USB devices may cause Bluetooth headsets or speakers to disconnect. The root cause is currently unclear, but disabling the device detection avoids the issue.

The configuration already supports skipping this check, so this change adds a UI option to allow users to enable it more conveniently.

# Screenshots/Recordings/Graphs

<img width="941" height="950" alt="image" src="https://github.com/user-attachments/assets/4964f69a-c780-495a-9dbe-9c215ac919cd" />


[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
