### PR TITLE
Fix gizmo being closed after releasing mouse outside the gizmo floating window

### DIFF
--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -4756,7 +4756,9 @@ void GLCanvas3D::on_mouse(wxMouseEvent& evt)
                 deselect_all();
         }
         //BBS Select plate in this 3D canvas.
-        else if (evt.LeftUp() && !m_mouse.dragging && m_picking_enabled && !m_hover_plate_idxs.empty() && (m_canvas_type == CanvasView3D) && !is_layers_editing_enabled())
+        // The left up may come from an ImGui window (e.g. a drag started on the gizmo floating window and released over the bed),
+        // in which case it must not be treated as a click on the plate, otherwise the gizmo would be closed (see deselect_all below).
+        else if (evt.LeftUp() && !m_mouse.ignore_left_up && !m_mouse.dragging && m_picking_enabled && !m_hover_plate_idxs.empty() && (m_canvas_type == CanvasView3D) && !is_layers_editing_enabled())
         {
                 int hover_idx = m_hover_plate_idxs.front();
                 wxGetApp().plater()->select_plate_by_hover_id(hover_idx);

--- a/src/slic3r/GUI/GLCanvas3D.hpp
+++ b/src/slic3r/GUI/GLCanvas3D.hpp
@@ -1119,6 +1119,10 @@ public:
 
     void set_mouse_as_dragging() { m_mouse.dragging = true; }
     bool is_mouse_dragging() const { return m_mouse.dragging; }
+    // True when the current left up event comes from an ImGui window and was not processed by it
+    // (e.g. a drag that started on a gizmo floating window and was released over the 3D scene).
+    // Such a release is the end of an ImGui interaction, not a click on the scene.
+    bool is_mouse_left_up_ignored() const { return m_mouse.ignore_left_up; }
 
     double get_size_proportional_to_max_bed_size(double factor) const;
 

--- a/src/slic3r/GUI/Gizmos/GLGizmoEmboss.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoEmboss.cpp
@@ -566,8 +566,11 @@ bool GLGizmoEmboss::on_mouse_for_translate(const wxMouseEvent &mouse_event)
 
 void GLGizmoEmboss::on_mouse_change_selection(const wxMouseEvent &mouse_event)
 {
-    static bool was_dragging = true;  
-    if ((mouse_event.LeftUp() || mouse_event.RightUp()) && !was_dragging) {
+    static bool was_dragging = true;
+    // The left up may be the end of a drag that started on the gizmo floating window (e.g. selecting
+    // text in the input field). Such a release is not a click on the scene and must not close the gizmo.
+    // (The flag is only set for left up events, so right up behavior is unchanged.)
+    if ((mouse_event.LeftUp() || mouse_event.RightUp()) && !was_dragging && !m_parent.is_mouse_left_up_ignored()) {
         // is hovered volume closest hovered?
         int hovered_idx = m_parent.get_first_hover_volume_idx();
         if (hovered_idx < 0) 


### PR DESCRIPTION
# Description

When using a gizmo with a text/number input field (e.g. the Text shape gizmo), if you press the left button anywhere on the gizmo's floating window, drag the cursor out of the window and release over the bed, the gizmo closes immediately — even though the release is just the end of a text selection, not a click on the bed.

**Root cause:** the left-up event of a drag that started on an ImGui window is not consumed by ImGui (`WantCaptureMouse` is false at release: no button held and the cursor is outside all ImGui windows), so it falls through to the 3D scene handling, where it is treated as a click on the scene:

- The plate-select branch in `GLCanvas3D::on_mouse` treated it as a click on the plate and called `deselect_all()`, which resets all gizmo states. The sibling "deselect on empty space" branch already guarded against left-ups coming from ImGui windows via `m_mouse.ignore_left_up`; the plate-select branch (Bambu-era code, predates #14999) was missing the same guard.
- The Emboss gizmo additionally has its own close-on-click-away handler (`GLGizmoEmboss::on_mouse_change_selection`) with the same gap: its `was_dragging` guard never sees drags that started on the gizmo's floating window, because those events are consumed by the ImGui branch of the canvas first.

Gizmos such as Cut/Painting are not affected because their `on_mouse` consumes the release — it returns true for the bare left-up (no drag in progress), so the canvas returns early in `GLCanvas3D::on_mouse` (line 4355) and the plate-select branch is never reached.

**Fix:**
- Add the `!m_mouse.ignore_left_up` guard to the plate-select branch, matching the deselect branch above.
- Expose `GLCanvas3D::is_mouse_left_up_ignored()` to gizmos and skip the Emboss gizmo's close-on-click-away check for left-up events coming from ImGui windows.

`ignore_left_up` is only set when the preceding event was consumed by ImGui, so a normal click on the bed still selects the plate / closes the Emboss gizmo on unselect as before.

# Screenshots/Recordings/Graphs

No visual changes.

## Tests

Manual verification:
- Open the Text shape gizmo, click into the text field, drag-select text, move the cursor out of the floating window and release over the bed → the gizmo stays open and the text selection completes.
- Same for the Emboss gizmo → the gizmo stays open.
- With a gizmo open, click directly on the bed → the plate is still selected and the gizmo closes as before (unchanged behavior).
- With the Emboss gizmo open, click on empty space or a non-text volume → the gizmo still closes (unchanged behavior).
- Release fully outside the 3D viewport (the #14999 mouse-capture path) → no gizmo close.

No automated UI test covers this path (`tests/` covers libslic3r only).

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)