### PR TITLE
Fix Windows crash after using "Replace all with 3D files"

### DIFF
--- a/localization/i18n/OrcaSlicer.pot
+++ b/localization/i18n/OrcaSlicer.pot
@@ -7781,19 +7781,19 @@ msgid "Replaced with 3D files from directory:\n"
 msgstr ""
 
 #, possible-boost-format
-msgid "✖ Skipped %1%: same file.\n"
+msgid "✖ Skipped %s: same file.\n"
 msgstr ""
 
 #, possible-boost-format
-msgid "✖ Skipped %1%: file does not exist.\n"
+msgid "✖ Skipped %s: file does not exist.\n"
 msgstr ""
 
 #, possible-boost-format
-msgid "✖ Skipped %1%: failed to replace.\n"
+msgid "✖ Skipped %s: failed to replace.\n"
 msgstr ""
 
 #, possible-boost-format
-msgid "✔ Replaced %1%.\n"
+msgid "✔ Replaced %s.\n"
 msgstr ""
 
 msgid "Replaced volumes"

--- a/localization/i18n/ca/OrcaSlicer_ca.po
+++ b/localization/i18n/ca/OrcaSlicer_ca.po
@@ -8361,21 +8361,21 @@ msgstr "No s'ha seleccionat el directori per a la substitució"
 msgid "Replaced with 3D files from directory:\n"
 msgstr "Substituït amb fitxers 3D del directori:\n"
 
-#, boost-format
-msgid "✖ Skipped %1%: same file.\n"
-msgstr "✖ Omès %1%: mateix fitxer.\n"
+#, c-format
+msgid "✖ Skipped %s: same file.\n"
+msgstr "✖ Omès %s: mateix fitxer.\n"
 
-#, boost-format
-msgid "✖ Skipped %1%: file does not exist.\n"
-msgstr "✖ Omès %1%: el fitxer no existeix.\n"
+#, c-format
+msgid "✖ Skipped %s: file does not exist.\n"
+msgstr "✖ Omès %s: el fitxer no existeix.\n"
 
-#, boost-format
-msgid "✖ Skipped %1%: failed to replace.\n"
-msgstr "✖ Omès %1%: la substitució ha fallat.\n"
+#, c-format
+msgid "✖ Skipped %s: failed to replace.\n"
+msgstr "✖ Omès %s: la substitució ha fallat.\n"
 
-#, boost-format
-msgid "✔ Replaced %1%.\n"
-msgstr "✔ Substituït %1%.\n"
+#, c-format
+msgid "✔ Replaced %s.\n"
+msgstr "✔ Substituït %s.\n"
 
 msgid "Replaced volumes"
 msgstr "Volums substituïts"

--- a/localization/i18n/cs/OrcaSlicer_cs.po
+++ b/localization/i18n/cs/OrcaSlicer_cs.po
@@ -8320,21 +8320,21 @@ msgstr "Nebyla vybrána složka pro nahrazení"
 msgid "Replaced with 3D files from directory:\n"
 msgstr "Nahrazeno 3D soubory ze složky:\n"
 
-#, boost-format
-msgid "✖ Skipped %1%: same file.\n"
-msgstr "✖ Přeskočeno %1%: stejný soubor.\n"
+#, c-format
+msgid "✖ Skipped %s: same file.\n"
+msgstr "✖ Přeskočeno %s: stejný soubor.\n"
 
-#, boost-format
-msgid "✖ Skipped %1%: file does not exist.\n"
-msgstr "✖ Přeskočeno %1%: soubor neexistuje.\n"
+#, c-format
+msgid "✖ Skipped %s: file does not exist.\n"
+msgstr "✖ Přeskočeno %s: soubor neexistuje.\n"
 
-#, boost-format
-msgid "✖ Skipped %1%: failed to replace.\n"
-msgstr "✖ Přeskočeno %1%: nahrazení se nezdařilo.\n"
+#, c-format
+msgid "✖ Skipped %s: failed to replace.\n"
+msgstr "✖ Přeskočeno %s: nahrazení se nezdařilo.\n"
 
-#, boost-format
-msgid "✔ Replaced %1%.\n"
-msgstr "✔ Nahrazeno %1%.\n"
+#, c-format
+msgid "✔ Replaced %s.\n"
+msgstr "✔ Nahrazeno %s.\n"
 
 msgid "Replaced volumes"
 msgstr "Nahrazené objemy"

--- a/localization/i18n/de/OrcaSlicer_de.po
+++ b/localization/i18n/de/OrcaSlicer_de.po
@@ -8191,21 +8191,21 @@ msgstr "Verzeichnis um daraus zu ersetzen wurde nicht ausgewählt"
 msgid "Replaced with 3D files from directory:\n"
 msgstr "Ersetzt durch 3D-Dateien aus Verzeichnis:\n"
 
-#, boost-format
-msgid "✖ Skipped %1%: same file.\n"
-msgstr "✖ Übersprungen %1%: gleiche Datei.\n"
+#, c-format
+msgid "✖ Skipped %s: same file.\n"
+msgstr "✖ Übersprungen %s: gleiche Datei.\n"
 
-#, boost-format
-msgid "✖ Skipped %1%: file does not exist.\n"
-msgstr "✖ Übersprungen %1%: Datei existiert nicht.\n"
+#, c-format
+msgid "✖ Skipped %s: file does not exist.\n"
+msgstr "✖ Übersprungen %s: Datei existiert nicht.\n"
 
-#, boost-format
-msgid "✖ Skipped %1%: failed to replace.\n"
-msgstr "✖ Übersprungen %1%: Ersetzen fehlgeschlagen.\n"
+#, c-format
+msgid "✖ Skipped %s: failed to replace.\n"
+msgstr "✖ Übersprungen %s: Ersetzen fehlgeschlagen.\n"
 
-#, boost-format
-msgid "✔ Replaced %1%.\n"
-msgstr "✔ Ersetzt %1%.\n"
+#, c-format
+msgid "✔ Replaced %s.\n"
+msgstr "✔ Ersetzt %s.\n"
 
 msgid "Replaced volumes"
 msgstr "Ersetzte Volumen"

--- a/localization/i18n/en/OrcaSlicer_en.po
+++ b/localization/i18n/en/OrcaSlicer_en.po
@@ -7776,20 +7776,20 @@ msgstr ""
 msgid "Replaced with 3D files from directory:\n"
 msgstr ""
 
-#, boost-format
-msgid "✖ Skipped %1%: same file.\n"
+#, c-format
+msgid "✖ Skipped %s: same file.\n"
 msgstr ""
 
-#, boost-format
-msgid "✖ Skipped %1%: file does not exist.\n"
+#, c-format
+msgid "✖ Skipped %s: file does not exist.\n"
 msgstr ""
 
-#, boost-format
-msgid "✖ Skipped %1%: failed to replace.\n"
+#, c-format
+msgid "✖ Skipped %s: failed to replace.\n"
 msgstr ""
 
-#, boost-format
-msgid "✔ Replaced %1%.\n"
+#, c-format
+msgid "✔ Replaced %s.\n"
 msgstr ""
 
 msgid "Replaced volumes"

--- a/localization/i18n/es/OrcaSlicer_es.po
+++ b/localization/i18n/es/OrcaSlicer_es.po
@@ -7997,21 +7997,21 @@ msgstr "No se seleccionó el directorio para el reemplazo"
 msgid "Replaced with 3D files from directory:\n"
 msgstr "Reemplazado con archivos 3D desde el directorio:\n"
 
-#, boost-format
-msgid "✖ Skipped %1%: same file.\n"
-msgstr "✖ Omitido %1%: mismo archivo.\n"
+#, c-format
+msgid "✖ Skipped %s: same file.\n"
+msgstr "✖ Omitido %s: mismo archivo.\n"
 
-#, boost-format
-msgid "✖ Skipped %1%: file does not exist.\n"
-msgstr "✖ Omitido %1%: el archivo no existe.\n"
+#, c-format
+msgid "✖ Skipped %s: file does not exist.\n"
+msgstr "✖ Omitido %s: el archivo no existe.\n"
 
-#, boost-format
-msgid "✖ Skipped %1%: failed to replace.\n"
-msgstr "✖ Omitido %1%: fallo al reemplazar.\n"
+#, c-format
+msgid "✖ Skipped %s: failed to replace.\n"
+msgstr "✖ Omitido %s: fallo al reemplazar.\n"
 
-#, boost-format
-msgid "✔ Replaced %1%.\n"
-msgstr "✔ Reemplazado %1%.\n"
+#, c-format
+msgid "✔ Replaced %s.\n"
+msgstr "✔ Reemplazado %s.\n"
 
 msgid "Replaced volumes"
 msgstr "Volúmenes reemplazados"

--- a/localization/i18n/eu/OrcaSlicer_eu.po
+++ b/localization/i18n/eu/OrcaSlicer_eu.po
@@ -8064,21 +8064,21 @@ msgstr "Ez da ordezkatzeko direktoriorik hautatu"
 msgid "Replaced with 3D files from directory:\n"
 msgstr "Direktorio honetako 3D fitxategiekin ordeztuta:\n"
 
-#, boost-format
-msgid "✖ Skipped %1%: same file.\n"
-msgstr "✖ %1% saltatu da: fitxategi bera.\n"
+#, c-format
+msgid "✖ Skipped %s: same file.\n"
+msgstr "✖ %s saltatu da: fitxategi bera.\n"
 
-#, boost-format
-msgid "✖ Skipped %1%: file does not exist.\n"
-msgstr "✖ %1% saltatu da: fitxategia ez da existitzen.\n"
+#, c-format
+msgid "✖ Skipped %s: file does not exist.\n"
+msgstr "✖ %s saltatu da: fitxategia ez da existitzen.\n"
 
-#, boost-format
-msgid "✖ Skipped %1%: failed to replace.\n"
-msgstr "✖ %1% saltatu da: ezin izan da ordeztu.\n"
+#, c-format
+msgid "✖ Skipped %s: failed to replace.\n"
+msgstr "✖ %s saltatu da: ezin izan da ordeztu.\n"
 
-#, boost-format
-msgid "✔ Replaced %1%.\n"
-msgstr "✔ %1% ordezkatu da.\n"
+#, c-format
+msgid "✔ Replaced %s.\n"
+msgstr "✔ %s ordezkatu da.\n"
 
 msgid "Replaced volumes"
 msgstr "Ordeztutako bolumenak"

--- a/localization/i18n/fr/OrcaSlicer_fr.po
+++ b/localization/i18n/fr/OrcaSlicer_fr.po
@@ -8120,21 +8120,21 @@ msgstr "Le répertoire pour le remplacement n'a pas été sélectionné"
 msgid "Replaced with 3D files from directory:\n"
 msgstr "Remplacé par des fichiers 3D depuis le répertoire :\n"
 
-#, boost-format
-msgid "✖ Skipped %1%: same file.\n"
-msgstr "✖ Ignoré %1% : même fichier.\n"
+#, c-format
+msgid "✖ Skipped %s: same file.\n"
+msgstr "✖ Ignoré %s : même fichier.\n"
 
-#, boost-format
-msgid "✖ Skipped %1%: file does not exist.\n"
-msgstr "✖ Ignoré %1% : le fichier n'existe pas.\n"
+#, c-format
+msgid "✖ Skipped %s: file does not exist.\n"
+msgstr "✖ Ignoré %s : le fichier n'existe pas.\n"
 
-#, boost-format
-msgid "✖ Skipped %1%: failed to replace.\n"
-msgstr "✖ Ignoré %1% : échec du remplacement.\n"
+#, c-format
+msgid "✖ Skipped %s: failed to replace.\n"
+msgstr "✖ Ignoré %s : échec du remplacement.\n"
 
-#, boost-format
-msgid "✔ Replaced %1%.\n"
-msgstr "✔ Remplacé %1%.\n"
+#, c-format
+msgid "✔ Replaced %s.\n"
+msgstr "✔ Remplacé %s.\n"
 
 msgid "Replaced volumes"
 msgstr "Volumes remplacés"

--- a/localization/i18n/hu/OrcaSlicer_hu.po
+++ b/localization/i18n/hu/OrcaSlicer_hu.po
@@ -8244,21 +8244,21 @@ msgstr "A cseréhez nem lett mappa kiválasztva"
 msgid "Replaced with 3D files from directory:\n"
 msgstr "Cserélve a mappából származó 3D fájlokra:\n"
 
-#, boost-format
-msgid "✖ Skipped %1%: same file.\n"
-msgstr "✖ Kihagyva %1%: azonos fájl.\n"
+#, c-format
+msgid "✖ Skipped %s: same file.\n"
+msgstr "✖ %s kihagyva: azonos fájl.\n"
 
-#, boost-format
-msgid "✖ Skipped %1%: file does not exist.\n"
-msgstr "✖ Kihagyva %1%: a fájl nem létezik.\n"
+#, c-format
+msgid "✖ Skipped %s: file does not exist.\n"
+msgstr "✖ %s kihagyva: a fájl nem létezik.\n"
 
-#, boost-format
-msgid "✖ Skipped %1%: failed to replace.\n"
-msgstr "✖ Kihagyva %1%: a csere sikertelen.\n"
+#, c-format
+msgid "✖ Skipped %s: failed to replace.\n"
+msgstr "✖ %s kihagyva: a csere sikertelen.\n"
 
-#, boost-format
-msgid "✔ Replaced %1%.\n"
-msgstr "✔ Lecserélve: %1%.\n"
+#, c-format
+msgid "✔ Replaced %s.\n"
+msgstr "✔%s lecserélve.\n"
 
 msgid "Replaced volumes"
 msgstr "Lecserélt térfogatok"

--- a/localization/i18n/it/OrcaSlicer_it.po
+++ b/localization/i18n/it/OrcaSlicer_it.po
@@ -8244,21 +8244,21 @@ msgstr "La directory per la sostituzione non è stata selezionata"
 msgid "Replaced with 3D files from directory:\n"
 msgstr "Sostituito con file 3D dalla directory:\n"
 
-#, boost-format
-msgid "✖ Skipped %1%: same file.\n"
-msgstr "✖ Saltato %1%: stesso file.\n"
+#, c-format
+msgid "✖ Skipped %s: same file.\n"
+msgstr "✖ Saltato %s: stesso file.\n"
 
-#, boost-format
-msgid "✖ Skipped %1%: file does not exist.\n"
-msgstr "✖ Saltato %1%: il file non esiste.\n"
+#, c-format
+msgid "✖ Skipped %s: file does not exist.\n"
+msgstr "✖ Saltato %s: il file non esiste.\n"
 
-#, boost-format
-msgid "✖ Skipped %1%: failed to replace.\n"
-msgstr "✖ Saltato %1%: sostituzione fallita.\n"
+#, c-format
+msgid "✖ Skipped %s: failed to replace.\n"
+msgstr "✖ Saltato %s: sostituzione fallita.\n"
 
-#, boost-format
-msgid "✔ Replaced %1%.\n"
-msgstr "✔ Sostituito %1%.\n"
+#, c-format
+msgid "✔ Replaced %s.\n"
+msgstr "✔ Sostituito %s.\n"
 
 msgid "Replaced volumes"
 msgstr "Volumi sostituiti"

--- a/localization/i18n/ja/OrcaSlicer_ja.po
+++ b/localization/i18n/ja/OrcaSlicer_ja.po
@@ -8262,21 +8262,21 @@ msgstr "置換用のディレクトリが選択されていません"
 msgid "Replaced with 3D files from directory:\n"
 msgstr "ディレクトリの3Dファイルで置換しました:\n"
 
-#, boost-format
-msgid "✖ Skipped %1%: same file.\n"
-msgstr "✖ スキップ %1%: 同一ファイル。\n"
+#, c-format
+msgid "✖ Skipped %s: same file.\n"
+msgstr "✖ スキップ %s: 同一ファイル。\n"
 
-#, boost-format
-msgid "✖ Skipped %1%: file does not exist.\n"
-msgstr "✖ スキップ %1%: ファイルが存在しません。\n"
+#, c-format
+msgid "✖ Skipped %s: file does not exist.\n"
+msgstr "✖ スキップ %s: ファイルが存在しません。\n"
 
-#, boost-format
-msgid "✖ Skipped %1%: failed to replace.\n"
-msgstr "✖ スキップ %1%: 置換に失敗しました。\n"
+#, c-format
+msgid "✖ Skipped %s: failed to replace.\n"
+msgstr "✖ スキップ %s: 置換に失敗しました。\n"
 
-#, boost-format
-msgid "✔ Replaced %1%.\n"
-msgstr "✔ 置換しました %1%。\n"
+#, c-format
+msgid "✔ Replaced %s.\n"
+msgstr "✔ 置換しました %s。\n"
 
 msgid "Replaced volumes"
 msgstr "置換されたボリューム"

--- a/localization/i18n/ko/OrcaSlicer_ko.po
+++ b/localization/i18n/ko/OrcaSlicer_ko.po
@@ -8288,24 +8288,24 @@ msgid "Replaced with 3D files from directory:\n"
 msgstr "다음 디렉터리의 3D 파일로 교체했습니다:\n"
 
 # AI Translated
-#, boost-format
-msgid "✖ Skipped %1%: same file.\n"
-msgstr "✖ 건너뜀 %1%: 동일한 파일입니다.\n"
+#, c-format
+msgid "✖ Skipped %s: same file.\n"
+msgstr "✖ 건너뜀 %s: 동일한 파일입니다.\n"
 
 # AI Translated
-#, boost-format
-msgid "✖ Skipped %1%: file does not exist.\n"
-msgstr "✖ 건너뜀 %1%: 파일이 존재하지 않습니다.\n"
+#, c-format
+msgid "✖ Skipped %s: file does not exist.\n"
+msgstr "✖ 건너뜀 %s: 파일이 존재하지 않습니다.\n"
 
 # AI Translated
-#, boost-format
-msgid "✖ Skipped %1%: failed to replace.\n"
-msgstr "✖ 건너뜀 %1%: 교체하지 못했습니다.\n"
+#, c-format
+msgid "✖ Skipped %s: failed to replace.\n"
+msgstr "✖ 건너뜀 %s: 교체하지 못했습니다.\n"
 
 # AI Translated
-#, boost-format
-msgid "✔ Replaced %1%.\n"
-msgstr "✔ %1%을(를) 교체했습니다.\n"
+#, c-format
+msgid "✔ Replaced %s.\n"
+msgstr "✔ %s을(를) 교체했습니다.\n"
 
 # AI Translated
 msgid "Replaced volumes"

--- a/localization/i18n/lt/OrcaSlicer_lt.po
+++ b/localization/i18n/lt/OrcaSlicer_lt.po
@@ -8239,21 +8239,21 @@ msgstr ""
 "Pakeista 3D failais iš katalogo:\n"
 "\n"
 
-#, boost-format
-msgid "✖ Skipped %1%: same file.\n"
-msgstr "✖ Praleistas %1%: tas pats failas.\n"
+#, c-format
+msgid "✖ Skipped %s: same file.\n"
+msgstr "✖ Praleistas %s: tas pats failas.\n"
 
-#, boost-format
-msgid "✖ Skipped %1%: file does not exist.\n"
-msgstr "✖ Praleistas %1%: failas neegzistuoja.\n"
+#, c-format
+msgid "✖ Skipped %s: file does not exist.\n"
+msgstr "✖ Praleistas %s: failas neegzistuoja.\n"
 
-#, boost-format
-msgid "✖ Skipped %1%: failed to replace.\n"
-msgstr "✖ Praleistas %1%: nepavyko pakeisti.\n"
+#, c-format
+msgid "✖ Skipped %s: failed to replace.\n"
+msgstr "✖ Praleistas %s: nepavyko pakeisti.\n"
 
-#, boost-format
-msgid "✔ Replaced %1%.\n"
-msgstr "✔ Pakeistas %1%.\n"
+#, c-format
+msgid "✔ Replaced %s.\n"
+msgstr "✔ Pakeistas %s.\n"
 
 msgid "Replaced volumes"
 msgstr "Pakeisti tūriai"

--- a/localization/i18n/nl/OrcaSlicer_nl.po
+++ b/localization/i18n/nl/OrcaSlicer_nl.po
@@ -8999,24 +8999,24 @@ msgid "Replaced with 3D files from directory:\n"
 msgstr "Vervangen door 3D-bestanden uit de map:\n"
 
 # AI Translated
-#, boost-format
-msgid "✖ Skipped %1%: same file.\n"
-msgstr "✖ Overgeslagen %1%: hetzelfde bestand.\n"
+#, c-format
+msgid "✖ Skipped %s: same file.\n"
+msgstr "✖ Overgeslagen %s: hetzelfde bestand.\n"
 
 # AI Translated
-#, boost-format
-msgid "✖ Skipped %1%: file does not exist.\n"
-msgstr "✖ Overgeslagen %1%: bestand bestaat niet.\n"
+#, c-format
+msgid "✖ Skipped %s: file does not exist.\n"
+msgstr "✖ Overgeslagen %s: bestand bestaat niet.\n"
 
 # AI Translated
-#, boost-format
-msgid "✖ Skipped %1%: failed to replace.\n"
-msgstr "✖ Overgeslagen %1%: vervangen is mislukt.\n"
+#, c-format
+msgid "✖ Skipped %s: failed to replace.\n"
+msgstr "✖ Overgeslagen %s: vervangen is mislukt.\n"
 
 # AI Translated
-#, boost-format
-msgid "✔ Replaced %1%.\n"
-msgstr "✔ Vervangen %1%.\n"
+#, c-format
+msgid "✔ Replaced %s.\n"
+msgstr "✔ Vervangen %s.\n"
 
 # AI Translated
 msgid "Replaced volumes"

--- a/localization/i18n/pl/OrcaSlicer_pl.po
+++ b/localization/i18n/pl/OrcaSlicer_pl.po
@@ -8444,24 +8444,24 @@ msgid "Replaced with 3D files from directory:\n"
 msgstr "Zastąpiono plikami 3D z katalogu:\n"
 
 # AI Translated
-#, boost-format
-msgid "✖ Skipped %1%: same file.\n"
-msgstr "✖ Pominięto %1%: ten sam plik.\n"
+#, c-format
+msgid "✖ Skipped %s: same file.\n"
+msgstr "✖ Pominięto %s: ten sam plik.\n"
 
 # AI Translated
-#, boost-format
-msgid "✖ Skipped %1%: file does not exist.\n"
-msgstr "✖ Pominięto %1%: plik nie istnieje.\n"
+#, c-format
+msgid "✖ Skipped %s: file does not exist.\n"
+msgstr "✖ Pominięto %s: plik nie istnieje.\n"
 
 # AI Translated
-#, boost-format
-msgid "✖ Skipped %1%: failed to replace.\n"
-msgstr "✖ Pominięto %1%: nie udało się zastąpić.\n"
+#, c-format
+msgid "✖ Skipped %s: failed to replace.\n"
+msgstr "✖ Pominięto %s: nie udało się zastąpić.\n"
 
 # AI Translated
-#, boost-format
-msgid "✔ Replaced %1%.\n"
-msgstr "✔ Zastąpiono %1%.\n"
+#, c-format
+msgid "✔ Replaced %s.\n"
+msgstr "✔ Zastąpiono %s.\n"
 
 # AI Translated
 msgid "Replaced volumes"

--- a/localization/i18n/pt_BR/OrcaSlicer_pt_BR.po
+++ b/localization/i18n/pt_BR/OrcaSlicer_pt_BR.po
@@ -8026,21 +8026,21 @@ msgstr "Diretório para substituição não foi selecionado"
 msgid "Replaced with 3D files from directory:\n"
 msgstr "Substituído por arquivos 3D do diretório:\n"
 
-#, boost-format
-msgid "✖ Skipped %1%: same file.\n"
-msgstr "✖ %1% Ignorados: mesmo arquivo.\n"
+#, c-format
+msgid "✖ Skipped %s: same file.\n"
+msgstr "✖ %s Ignorados: mesmo arquivo.\n"
 
-#, boost-format
-msgid "✖ Skipped %1%: file does not exist.\n"
-msgstr "✖ %1% Ignorados: arquivo não existe.\n"
+#, c-format
+msgid "✖ Skipped %s: file does not exist.\n"
+msgstr "✖ %s Ignorados: arquivo não existe.\n"
 
-#, boost-format
-msgid "✖ Skipped %1%: failed to replace.\n"
-msgstr "✖ %1% Ignorados: falha ao substituir.\n"
+#, c-format
+msgid "✖ Skipped %s: failed to replace.\n"
+msgstr "✖ %s Ignorados: falha ao substituir.\n"
 
-#, boost-format
-msgid "✔ Replaced %1%.\n"
-msgstr "✔ %1% Substituídos.\n"
+#, c-format
+msgid "✔ Replaced %s.\n"
+msgstr "✔ %s Substituídos.\n"
 
 msgid "Replaced volumes"
 msgstr "Volumes substiruídos"

--- a/localization/i18n/ru/OrcaSlicer_ru.po
+++ b/localization/i18n/ru/OrcaSlicer_ru.po
@@ -8413,21 +8413,21 @@ msgstr "Расположение для замены не указано"
 msgid "Replaced with 3D files from directory:\n"
 msgstr "Заменено файлами из расположения:\n"
 
-#, boost-format
-msgid "✖ Skipped %1%: same file.\n"
-msgstr "✖ Пропущен %1%: идентичный файл.\n"
+#, c-format
+msgid "✖ Skipped %s: same file.\n"
+msgstr "✖ Пропущен %s: идентичный файл.\n"
 
-#, boost-format
-msgid "✖ Skipped %1%: file does not exist.\n"
-msgstr "✖ Пропущен %1%: файл не существует.\n"
+#, c-format
+msgid "✖ Skipped %s: file does not exist.\n"
+msgstr "✖ Пропущен %s: файл не существует.\n"
 
-#, boost-format
-msgid "✖ Skipped %1%: failed to replace.\n"
-msgstr "✖ Пропущен %1%: не удалось заменить.\n"
+#, c-format
+msgid "✖ Skipped %s: failed to replace.\n"
+msgstr "✖ Пропущен %s: не удалось заменить.\n"
 
-#, boost-format
-msgid "✔ Replaced %1%.\n"
-msgstr "✔ Заменён %1%.\n"
+#, c-format
+msgid "✔ Replaced %s.\n"
+msgstr "✔ Заменён %s.\n"
 
 msgid "Replaced volumes"
 msgstr "Модели заменены"

--- a/localization/i18n/sv/OrcaSlicer_sv.po
+++ b/localization/i18n/sv/OrcaSlicer_sv.po
@@ -9088,24 +9088,24 @@ msgid "Replaced with 3D files from directory:\n"
 msgstr "Ersatt med 3D-filer från mappen:\n"
 
 # AI Translated
-#, boost-format
-msgid "✖ Skipped %1%: same file.\n"
-msgstr "✖ Hoppade över %1%: samma fil.\n"
+#, c-format
+msgid "✖ Skipped %s: same file.\n"
+msgstr "✖ Hoppade över %s: samma fil.\n"
 
 # AI Translated
-#, boost-format
-msgid "✖ Skipped %1%: file does not exist.\n"
-msgstr "✖ Hoppade över %1%: filen finns inte.\n"
+#, c-format
+msgid "✖ Skipped %s: file does not exist.\n"
+msgstr "✖ Hoppade över %s: filen finns inte.\n"
 
 # AI Translated
-#, boost-format
-msgid "✖ Skipped %1%: failed to replace.\n"
-msgstr "✖ Hoppade över %1%: det gick inte att ersätta.\n"
+#, c-format
+msgid "✖ Skipped %s: failed to replace.\n"
+msgstr "✖ Hoppade över %s: det gick inte att ersätta.\n"
 
 # AI Translated
-#, boost-format
-msgid "✔ Replaced %1%.\n"
-msgstr "✔ Ersatte %1%.\n"
+#, c-format
+msgid "✔ Replaced %s.\n"
+msgstr "✔ Ersatte %s.\n"
 
 # AI Translated
 msgid "Replaced volumes"

--- a/localization/i18n/th/OrcaSlicer_th.po
+++ b/localization/i18n/th/OrcaSlicer_th.po
@@ -8199,21 +8199,21 @@ msgstr "ไม่ได้เลือกไดเรกทอรีสำหร
 msgid "Replaced with 3D files from directory:\n"
 msgstr "แทนที่ด้วยไฟล์ 3D จากไดเรกทอรี:\n"
 
-#, boost-format
-msgid "✖ Skipped %1%: same file.\n"
-msgstr "✖ ข้าม %1%: ไฟล์เดียวกัน\n"
+#, c-format
+msgid "✖ Skipped %s: same file.\n"
+msgstr "✖ ข้าม %s: ไฟล์เดียวกัน\n"
 
-#, boost-format
-msgid "✖ Skipped %1%: file does not exist.\n"
-msgstr "✖ ข้าม %1%: ไม่มีไฟล์อยู่\n"
+#, c-format
+msgid "✖ Skipped %s: file does not exist.\n"
+msgstr "✖ ข้าม %s: ไม่มีไฟล์อยู่\n"
 
-#, boost-format
-msgid "✖ Skipped %1%: failed to replace.\n"
-msgstr "✖ ข้าม %1%: ไม่สามารถแทนที่ได้\n"
+#, c-format
+msgid "✖ Skipped %s: failed to replace.\n"
+msgstr "✖ ข้าม %s: ไม่สามารถแทนที่ได้\n"
 
-#, boost-format
-msgid "✔ Replaced %1%.\n"
-msgstr "✔แทนที่ %1%\n"
+#, c-format
+msgid "✔ Replaced %s.\n"
+msgstr "✔แทนที่ %s\n"
 
 msgid "Replaced volumes"
 msgstr "ปริมาณที่ถูกแทนที่"

--- a/localization/i18n/tr/OrcaSlicer_tr.po
+++ b/localization/i18n/tr/OrcaSlicer_tr.po
@@ -8335,21 +8335,21 @@ msgstr "Değiştirme için dizin seçilmedi"
 msgid "Replaced with 3D files from directory:\n"
 msgstr "Dizindeki 3D dosyalarla değiştirildi:\n"
 
-#, boost-format
-msgid "✖ Skipped %1%: same file.\n"
-msgstr "✖ %1% atlandı: aynı dosya.\n"
+#, c-format
+msgid "✖ Skipped %s: same file.\n"
+msgstr "✖ %s atlandı: aynı dosya.\n"
 
-#, boost-format
-msgid "✖ Skipped %1%: file does not exist.\n"
-msgstr "✖ %1% atlandı: dosya mevcut değil.\n"
+#, c-format
+msgid "✖ Skipped %s: file does not exist.\n"
+msgstr "✖ %s atlandı: dosya mevcut değil.\n"
 
-#, boost-format
-msgid "✖ Skipped %1%: failed to replace.\n"
-msgstr "✖ %1% atlandı: değiştirilemedi.\n"
+#, c-format
+msgid "✖ Skipped %s: failed to replace.\n"
+msgstr "✖ %s atlandı: değiştirilemedi.\n"
 
-#, boost-format
-msgid "✔ Replaced %1%.\n"
-msgstr "✔ %1% değiştirildi.\n"
+#, c-format
+msgid "✔ Replaced %s.\n"
+msgstr "✔ %s değiştirildi.\n"
 
 msgid "Replaced volumes"
 msgstr "Değiştirilen birimler"

--- a/localization/i18n/uk/OrcaSlicer_uk.po
+++ b/localization/i18n/uk/OrcaSlicer_uk.po
@@ -8306,21 +8306,21 @@ msgstr "Каталог для заміни не вибрано"
 msgid "Replaced with 3D files from directory:\n"
 msgstr "Замінено 3D-файлами з каталогу:\n"
 
-#, boost-format
-msgid "✖ Skipped %1%: same file.\n"
-msgstr "✖ Пропущено %1%: той самий файл.\n"
+#, c-format
+msgid "✖ Skipped %s: same file.\n"
+msgstr "✖ Пропущено %s: той самий файл.\n"
 
-#, boost-format
-msgid "✖ Skipped %1%: file does not exist.\n"
-msgstr "✖ Пропущено %1%: файл не існує.\n"
+#, c-format
+msgid "✖ Skipped %s: file does not exist.\n"
+msgstr "✖ Пропущено %s: файл не існує.\n"
 
-#, boost-format
-msgid "✖ Skipped %1%: failed to replace.\n"
-msgstr "✖ Пропущено %1%: не вдалося замінити.\n"
+#, c-format
+msgid "✖ Skipped %s: failed to replace.\n"
+msgstr "✖ Пропущено %s: не вдалося замінити.\n"
 
-#, boost-format
-msgid "✔ Replaced %1%.\n"
-msgstr "✔ Замінено %1%.\n"
+#, c-format
+msgid "✔ Replaced %s.\n"
+msgstr "✔ Замінено %s.\n"
 
 msgid "Replaced volumes"
 msgstr "Замінені обʼєми"

--- a/localization/i18n/vi/OrcaSlicer_vi.po
+++ b/localization/i18n/vi/OrcaSlicer_vi.po
@@ -8721,24 +8721,24 @@ msgid "Replaced with 3D files from directory:\n"
 msgstr "Đã thay thế bằng file 3D từ thư mục:\n"
 
 # AI Translated
-#, boost-format
-msgid "✖ Skipped %1%: same file.\n"
-msgstr "✖ Đã bỏ qua %1%: cùng một file.\n"
+#, c-format
+msgid "✖ Skipped %s: same file.\n"
+msgstr "✖ Đã bỏ qua %s: cùng một file.\n"
 
 # AI Translated
-#, boost-format
-msgid "✖ Skipped %1%: file does not exist.\n"
-msgstr "✖ Đã bỏ qua %1%: file không tồn tại.\n"
+#, c-format
+msgid "✖ Skipped %s: file does not exist.\n"
+msgstr "✖ Đã bỏ qua %s: file không tồn tại.\n"
 
 # AI Translated
-#, boost-format
-msgid "✖ Skipped %1%: failed to replace.\n"
-msgstr "✖ Đã bỏ qua %1%: thay thế thất bại.\n"
+#, c-format
+msgid "✖ Skipped %s: failed to replace.\n"
+msgstr "✖ Đã bỏ qua %s: thay thế thất bại.\n"
 
 # AI Translated
-#, boost-format
-msgid "✔ Replaced %1%.\n"
-msgstr "✔ Đã thay thế %1%.\n"
+#, c-format
+msgid "✔ Replaced %s.\n"
+msgstr "✔ Đã thay thế %s.\n"
 
 # AI Translated
 msgid "Replaced volumes"

--- a/localization/i18n/zh_CN/OrcaSlicer_zh_CN.po
+++ b/localization/i18n/zh_CN/OrcaSlicer_zh_CN.po
@@ -8028,21 +8028,21 @@ msgstr "未选择替换目录"
 msgid "Replaced with 3D files from directory:\n"
 msgstr "替换为目录中的 3D 文件：\n"
 
-#, boost-format
-msgid "✖ Skipped %1%: same file.\n"
-msgstr "✖ 跳过 %1%：同一文件。\n"
+#, c-format
+msgid "✖ Skipped %s: same file.\n"
+msgstr "✖ 跳过 %s：同一文件。\n"
 
-#, boost-format
-msgid "✖ Skipped %1%: file does not exist.\n"
-msgstr "✖ 跳过%1%：文件不存在。\n"
+#, c-format
+msgid "✖ Skipped %s: file does not exist.\n"
+msgstr "✖ 跳过%s：文件不存在。\n"
 
-#, boost-format
-msgid "✖ Skipped %1%: failed to replace.\n"
-msgstr "✖ 跳过%1%：替换失败。\n"
+#, c-format
+msgid "✖ Skipped %s: failed to replace.\n"
+msgstr "✖ 跳过%s：替换失败。\n"
 
-#, boost-format
-msgid "✔ Replaced %1%.\n"
-msgstr "✔ 替换了 %1%。\n"
+#, c-format
+msgid "✔ Replaced %s.\n"
+msgstr "✔ 替换了 %s。\n"
 
 msgid "Replaced volumes"
 msgstr "替换的卷"

--- a/localization/i18n/zh_TW/OrcaSlicer_zh_TW.po
+++ b/localization/i18n/zh_TW/OrcaSlicer_zh_TW.po
@@ -8193,21 +8193,21 @@ msgstr "未選擇替換的目錄"
 msgid "Replaced with 3D files from directory:\n"
 msgstr "已從目錄替換為 3D 檔案：\n"
 
-#, boost-format
-msgid "✖ Skipped %1%: same file.\n"
-msgstr "✖ 已跳過 %1%：相同檔案。\n"
+#, c-format
+msgid "✖ Skipped %s: same file.\n"
+msgstr "✖ 已跳過 %s：相同檔案。\n"
 
-#, boost-format
-msgid "✖ Skipped %1%: file does not exist.\n"
-msgstr "✖ 已跳過 %1%：檔案不存在。\n"
+#, c-format
+msgid "✖ Skipped %s: file does not exist.\n"
+msgstr "✖ 已跳過 %s：檔案不存在。\n"
 
-#, boost-format
-msgid "✖ Skipped %1%: failed to replace.\n"
-msgstr "✖ 已跳過 %1%：無法替換。\n"
+#, c-format
+msgid "✖ Skipped %s: failed to replace.\n"
+msgstr "✖ 已跳過 %s：無法替換。\n"
 
-#, boost-format
-msgid "✔ Replaced %1%.\n"
-msgstr "✔ 已替換 %1%。\n"
+#, c-format
+msgid "✔ Replaced %s.\n"
+msgstr "✔ 已替換 %s。\n"
 
 msgid "Replaced volumes"
 msgstr "已替換體積"

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -9501,7 +9501,7 @@ void Plater::priv::replace_all_with_stl()
         return;
     }
 
-    std::string status = _L("Replaced with 3D files from directory:\n").ToStdString() + out_path.string() + "\n\n";
+    wxString status = _L("Replaced with 3D files from directory:\n") + from_u8(out_path.string()) + "\n\n";
 
     for (unsigned int idx : volume_idxs) {
         const GLVolume* v = selection.get_volume(idx);
@@ -9521,13 +9521,13 @@ void Plater::priv::replace_all_with_stl()
         std::string volume_name = volume->name;
 
         if (new_path == input_path) {
-            status += boost::str(boost::format(_L("✖ Skipped %1%: same file.\n").ToStdString()) % volume_name);
+            status += wxString::Format(_L("✖ Skipped %s: same file.\n"), from_u8(volume_name));
             BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << " skipping replace volume : same filename " << new_path;
             continue;
         }
 
         if (!fs::exists(new_path)) {
-            status += boost::str(boost::format(_L("✖ Skipped %1%: file does not exist.\n").ToStdString()) % volume_name);
+            status += wxString::Format(_L("✖ Skipped %s: file does not exist.\n"), from_u8(volume_name));
             BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << " cannot replace volume : filen does not exist " << new_path;
             continue;
         }
@@ -9535,12 +9535,12 @@ void Plater::priv::replace_all_with_stl()
         BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << " replacing volume : " << input_path << " with " << new_path;
 
         if (!replace_volume_with_stl(object_idx, volume_idx, new_path, _u8L("Replace with 3D file"))) {
-            status += boost::str(boost::format(_L("✖ Skipped %1%: failed to replace.\n").ToStdString()) % volume_name);
+            status += wxString::Format(_L("✖ Skipped %s: failed to replace.\n"), from_u8(volume_name));
             BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << " cannot replace volume : failed to replace with " << new_path;
             continue;
         }
 
-        status += boost::str(boost::format(_L("✔ Replaced %1%.\n").ToStdString()) % volume_name);
+        status += wxString::Format(_L("✔ Replaced %s.\n"), from_u8(volume_name));
     }
 
     // update 3D scene


### PR DESCRIPTION
## Description

This PR fixes OrcaSlicer crashing after using **Replace all with 3D files**.

## Observed behavior

When a model was skipped during replacement, the result message could contain a Unicode status icon such as `✖`, `✔`.

On Windows, converting this message to a standard string could produce an empty string. The empty string was then formatted with the volume name, which caused an uncaught exception and closed OrcaSlicer.

This could be reproduced by duplicating a model and selecting a directory containing the same source file.

## Applied fix

Keep the result text as a Unicode string and replace the volume-name placeholder directly.

This avoids the unsafe conversion and preserves the status icons in the result dialog.

## Screenshots

<img width="966" height="443" alt="image" src="https://github.com/user-attachments/assets/ad91c70e-6b19-4a82-860f-313ec0242d45" />

---

Fixes #15099