### PR TITLE
Continue to capture mouse position for circle / sphere painting when cursor goes outside of canvas

### DIFF
--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -4322,7 +4322,7 @@ void GLCanvas3D::on_mouse(wxMouseEvent& evt)
         }
 
         // ORCA keep tracking mouse position while drag active and cursor not in window bounds
-        if (!has_mouse_capture() && evt.LeftIsDown() && m_gizmos.is_dragging())
+        if (!has_mouse_capture() && (evt.LeftIsDown() || evt.RightIsDown()) && m_gizmos.is_dragging())
             m_canvas->CaptureMouse();
 
         if (evt.LeftUp() || evt.MiddleUp() || evt.RightUp())

--- a/src/slic3r/GUI/Gizmos/GLGizmoBase.hpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoBase.hpp
@@ -198,7 +198,7 @@ public:
     int get_hover_id() const { return m_hover_id; }
     void set_hover_id(int id);
     
-    bool is_dragging() const { return m_dragging; }
+    virtual bool is_dragging() const { return m_dragging; }
 
     // returns True when Gizmo changed its state
     bool update_items_state();

--- a/src/slic3r/GUI/Gizmos/GLGizmoPainterBase.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoPainterBase.cpp
@@ -991,6 +991,14 @@ bool GLGizmoPainterBase::on_mouse(const wxMouseEvent &mouse_event)
         return false;
     }
 
+    // while a stroke is active and mouse capture is held, treat a Leaving() event as "still painting, cursor is temporarily outside the window"
+    // rather than letting it fall through to `return false` (which would misroute the event to camera rotate/pan in GLCanvas3D::on_mouse).
+    if (mouse_event.Leaving()) {
+        if (m_button_down != Button::None && m_parent.has_mouse_capture())
+            return true;
+        return false;
+    }
+
     // when control is down we allow scene pan and rotation even when clicking
     // over some object
     bool control_down           = mouse_event.CmdDown();

--- a/src/slic3r/GUI/Gizmos/GLGizmoPainterBase.hpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoPainterBase.hpp
@@ -217,6 +217,8 @@ public:
     /// propagate it otherwise False.</returns>
     bool on_mouse(const wxMouseEvent &mouse_event) override;
 
+    bool is_dragging() const override { return m_button_down != Button::None; }
+
 protected:
     virtual void render_triangles(const Selection& selection) const;
     void render_cursor();


### PR DESCRIPTION
TODO
• Fix behaviour while using Horizontal / Vertical axis lock

forgot this part

this adds ability to track mouse position while using circle / sphere brush and cursor on outside of canvas

also fixes stuck drag event for painting when cursor goes outside of canvas

Before - cannot capture mouse position if cursor goes outside of canvas
<img width="370" height="745" alt="vivaldi_mBR7DfAuMA" src="https://github.com/user-attachments/assets/e74f272e-bc22-4c3e-b243-bc7d48d7096a" />

After - continues to capture mouse position for painting with left and right click
<img width="368" height="631" alt="orca-slicer_iNxg6tu3k6" src="https://github.com/user-attachments/assets/6b561066-1755-4e87-b1b6-eb249f6d45d5" />


BEFORE - drag event stuck sometimes until next click
<img width="343" height="718" alt="orca-slicer_RpxjWmQd0n" src="https://github.com/user-attachments/assets/7568592d-e8fd-4666-8ad3-2a8aa65a72b1" />
