### PR TITLE
fix: use default webkitgtk User-Agent instead of MacOS User-Agent for linux builds

### DIFF
--- a/src/slic3r/GUI/Widgets/WebView.cpp
+++ b/src/slic3r/GUI/Widgets/WebView.cpp
@@ -303,8 +303,10 @@ wxWebView* WebView::CreateWebView(wxWindow * parent, wxString const & url)
             s_schemes_registered = true;
         }
         webView->Create(parent, wxID_ANY, url2, wxDefaultPosition, wxDefaultSize, wxBORDER_NONE);
+#ifndef __linux__
         webView->SetUserAgent(wxString::Format("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) BBL-Slicer/v%s (%s) BBL-Language/%s",
                                                Slic3r::GUI::wxGetApp().get_bbl_client_version(), Slic3r::GUI::wxGetApp().dark_mode() ? "dark" : "light", language_code.mb_str()));
+#endif
 #endif
 #ifdef __WXMAC__
         WKWebView * wkWebView = (WKWebView *) webView->GetNativeBackend();
@@ -425,8 +427,10 @@ void WebView::RecreateAll()
     wxString language_code = Slic3r::GUI::wxGetApp().current_language_code().BeforeFirst('_');
     language_code          = language_code.ToStdString();
     for (auto webView : g_webviews) {
+#ifndef __linux__
         webView->SetUserAgent(wxString::Format("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) BBL-Slicer/v%s (%s) BBL-Language/%s",
                                                Slic3r::GUI::wxGetApp().get_bbl_client_version(), dark ? "dark" : "light", language_code.mb_str()));
+#endif
         // A host-themed WebViewHostDialog re-themes in place (no reload). If it handles
         // the event, skip the reload; legacy pages fall through and reload as before
         // (their own dark.css swap re-themes them on reload).


### PR DESCRIPTION
# Description

> Full disclosure: this PR is submitted by an employee of SimplyPrint (me) on the basis of multiple user reports.

In the embedded browser a Safari/MacOS User-Agent header is being used, this causes Cloudflare Turnstile to reject the browser instance, causing issue with certain 3rd-party print host providers that embed websites in the device tab (like the SimplyPrint host). Cloudflare turnstile is not only used for explicit "Are you a human checks" but also run in front of many websites, being as compliant as possible increases the chances of compatibility, although i would agree we have little control over what they deem acceptable or not, as Linux embedded browsers aren't a particular first class citizen. After communicating a bit with our CF rep this appears to be a decent solution. 

A similar issue also exists on Windows in the UWP (Windows Store) application, this PR does **NOT** address that issue. 

We solve this by relying on the default User-Agent header of webkitgtk, this has been tested across multiple versions of webkitgtk with multiple different header combinations.

Failing Orca override:

BBL-Slicer/v01.10.01.50 (light) Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko)

Also failing after moving the Orca identifier:

Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) BBL-Slicer/v01.10.01.50 (light) BBL-Language/en

Passing native WebKitGTK 2.50.4 UA:

Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/60.5 Safari/605.1.15

Finally i am also open to discussing whether this should be applied ONLY on the 3rd-party host level, instead of globally as to retain maximal backwards compatibility and smallest change surface, feel free to @ me here, @cjavad on Discord or via my email to javad.asgari@simplyprint.io.

<!--
> Please provide a summary of the changes made in this PR. Include details such as:
  > * What issue does this PR address or fix?
  > * What new features or enhancements does this PR introduce?
  > * Are there any breaking changes or dependencies that need to be considered?
-->

# Screenshots/Recordings/Graphs

<!--
> Please attach relevant screenshots to showcase the UI changes.
> Please attach images that can help explain the changes.
-->
<img width="288" height="480" alt="image" src="https://github.com/user-attachments/assets/7fe35526-9bb5-467a-9bbe-12737497e56e" />

## Tests

<!--
> Please describe the tests that you have conducted to verify the changes made in this PR.
-->

The following combinations of WebKitGTK + User-Agents (result refers to cloudflare turnstile result):

| WebKitGTK | User-Agent | Result |
|---|---|---|
| 2.50.4 / 4.1 | `BBL-Slicer/v01.10.01.50 (light) Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko)` | **FAIL** |
| 2.50.4 / 4.1 | `Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/60.5 Safari/605.1.15` | **PASS** |
| 2.50.4 / 4.1 | `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) BBL-Slicer/v01.10.01.50 (light) BBL-Language/en` | **FAIL** |
| 2.52.3 / 4.1 | `BBL-Slicer/v01.10.01.50 (light) Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko)` | **FAIL** |
| 2.52.5 / 4.1 | `BBL-Slicer/v01.10.01.50 (light) Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko)` | **FAIL** |
| 2.52.5 / 4.1 | `Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/60.5 Safari/605.1.15` | **PASS** |
| 2.53.4 / 4.1 | `BBL-Slicer/v01.10.01.50 (light) Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko)` | **FAIL** |
| 2.52.3 / 6.0 | `Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/60.5 Safari/605.1.15` | **PASS** |

<!--
> A guide for users on how to download the artifacts from this PR.
-->

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
