### PR TITLE
Update list of BBL print status messages

### DIFF
--- a/src/slic3r/GUI/DeviceManager.cpp
+++ b/src/slic3r/GUI/DeviceManager.cpp
@@ -233,8 +233,44 @@ wxString Slic3r::get_stage_string(int stage)
         return _L("Measuring Surface");
     case 58:
         return _L("Thermal Preconditioning for first layer optimization");
+    case 59:
+        return _L("Homing Blade Holder");
+    case 60:
+        return _L("Calibrating Camera Offset");
+    case 61:
+        return _L("Calibrating Blade Holder Position");
+    case 62:
+        return _L("Hotend Pick and Place Test");
+    case 63:
+        return _L("Waiting for the Chamber temperature to equalize");
+    case 64:
+        return _L("Preparing Hotend");
     case 65:
-        return _L("Calibrating the detection position of nozzle clumping"); // N7
+        return _L("Calibrating the detection position of nozzle clumping");
+    case 66:
+        return _L("Purifying the chamber air");
+    case 67:
+        return _L("Measuring Rotary Attachment");
+    case 68:
+        return _L("The toolhead moves above the purge chute");
+    case 69:
+        return _L("Cooling down the nozzle");
+    case 70:
+        return _L("The toolhead moves to the center of the heatbed");
+    case 71:
+        return _L("Active Arc Fitting");
+    case 72:
+        return _L("Hotend Type Detection");
+    case 73:
+        return _L("Build plate alignment detection");
+    case 74:
+        return _L("Heatbed surface foreign object detection");
+    case 75:
+        return _L("Heatbed underside foreign object detection");
+    case 76:
+        return _L("Pre-extrusion before printing");
+    case 77:
+        return _L("Preparing AMS");
     default:
         BOOST_LOG_TRIVIAL(info) << "stage = " << stage;
     }

--- a/src/slic3r/GUI/DeviceManager.cpp
+++ b/src/slic3r/GUI/DeviceManager.cpp
@@ -216,7 +216,7 @@ wxString Slic3r::get_stage_string(int stage)
     case 49:
         return _L("Heating chamber");
     case 50:
-        return _L("Cooling heatbed");
+        return _L("Adjusting heatbed temperature");
     case 51:
         return _L("Printing calibration lines");
     case 52:
@@ -1076,7 +1076,7 @@ bool MachineObject::is_filament_at_extruder()
 
 wxString MachineObject::get_curr_stage()
 {
-    if (stage_list_info.empty()) {
+    if (stage_curr < 0 || stage_list_info.empty()) {
         return "";
     }
     return get_stage_string(stage_curr);


### PR DESCRIPTION
# Description

This PR brings the print status messages in DeviceManager.cpp in line with those found in Bambu Studio, which allows the device screen for BBL printers to show all `M1002 gcode_claim_action` messages used in the machine gcode for those devices. 

# Screenshots/Recordings/Graphs
Will add once actions actually work during or at the end of a print. Investigating right now why this is not the case.

## Tests
Currently the new claim actions show up as expected during preprint. however during printing or at the end of printing they do not get processed properly it seems. Investigating this at the moment.