### PR TITLE
fix: Slice all crash on a multi-plate project with an uninitialized toolbar

### DIFF
--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -6999,7 +6999,7 @@ void GLCanvas3D::_update_select_plate_toolbar_stats_item(bool force_selected) {
     else
         m_sel_plate_toolbar.show_stats_item = false;
 
-    if (force_selected && m_sel_plate_toolbar.show_stats_item)
+    if (force_selected && m_sel_plate_toolbar.show_stats_item && m_sel_plate_toolbar.m_all_plates_stats_item)
         m_sel_plate_toolbar.m_all_plates_stats_item->selected = true;
 }
 


### PR DESCRIPTION
# Description

**Slice all** on a multi-plate project can crash with a SIGSEGV. Reported in #15116 with two coredumps, both faulting at the same instruction.

The crash is in `_update_select_plate_toolbar_stats_item`, called from `on_action_slice_all`:

```cpp
if (force_selected && m_sel_plate_toolbar.show_stats_item)
    m_sel_plate_toolbar.m_all_plates_stats_item->selected = true;
```

`m_all_plates_stats_item` is null until `_init_select_plate_toolbar()` runs. If you slice a multi-plate project before the Preview tab has rendered, the pointer is still null but `show_stats_item` is true (more than one non-empty plate), so this line writes through null. Single-plate projects skip the branch, so they never hit it.

The other three dereferences of this pointer (`GLCanvas3D.cpp:1819`, `GLCanvas3D.hpp:790`, `GLCanvas3D.cpp:8903`) already null-check it. This adds the same check to the one that didn't. No change when the pointer is valid; when it's null the all-plates item stays unselected until the toolbar initializes.

Fixes #15116

# Screenshots/Recordings/Graphs

N/A, this removes a crash.

## Tests

No headless seam for a GUI-timing crash. The fix mirrors the three existing null-guards on the same pointer.
