### PR TITLE
[macOS] Avoid AppKit abort in headless 3MF export

### DIFF
--- a/src/OrcaSlicer.cpp
+++ b/src/OrcaSlicer.cpp
@@ -6595,6 +6595,20 @@ int CLI::run(int argc, char **argv)
             }
         }
 
+        // Headless CLI exports do not enter the wxWidgets application loop.
+        // On macOS GLFW initializes NSApplication in its Cocoa backend, and
+        // recent macOS versions may abort inside AppKit before glfwInit() can
+        // report an error. Thumbnails are optional in a 3MF export, so skip
+        // only the OpenGL rendering for headless macOS CLI invocations.
+#if defined(__APPLE__)
+        if (!start_gui && (need_regenerate_thumbnail || need_regenerate_no_light_thumbnail || need_regenerate_top_thumbnail)) {
+            BOOST_LOG_TRIVIAL(warning) << "Skipping OpenGL thumbnail rendering for headless macOS CLI export" << std::endl;
+            need_create_thumbnail_group = false;
+            need_create_no_light_group = false;
+            need_create_top_group = false;
+        }
+        else
+#endif
         if (need_regenerate_thumbnail || need_regenerate_no_light_thumbnail || need_regenerate_top_thumbnail) {
             std::vector<std::string> colors;
             if (filament_color) {


### PR DESCRIPTION
## Summary

- Skip optional OpenGL thumbnail rendering for headless macOS CLI 3MF exports.
- Keep the normal GUI path and non-macOS behavior unchanged.

## Problem

When `--export-3mf` needs to regenerate thumbnails, the headless CLI path initializes GLFW. On macOS, the Cocoa backend initializes `NSApplication`; on affected systems AppKit aborts inside that initialization before `glfwInit()` can return an error. The existing `GLFW_FALSE` check therefore cannot handle this failure.

The 3MF exporter accepts empty thumbnail data, so thumbnail rendering can be skipped while preserving the model, metadata, and export itself.

## Testing

Built the arm64 macOS application from current main and verified:

- `--export-3mf` exits 0.
- `--export-3mf --min-save` exits 0.
- The generated 3MF passes `unzip -t`.
- The log reports the intentional thumbnail skip.
- The patch applies cleanly to the v2.4.2 source context.

No printer or installed OrcaSlicer files were modified.