### PR TITLE
feat(profiles): add Creality K1 family CFS printer profiles

### DIFF
--- a/resources/profiles/Creality.json
+++ b/resources/profiles/Creality.json
@@ -167,6 +167,22 @@
 		{
 			"name": "Creality Sermoon V1",
 			"sub_path": "machine/Creality Sermoon V1.json"
+		},
+		{
+			"name": "Creality K1 CFS",
+			"sub_path": "machine/Creality K1 CFS.json"
+		},
+		{
+			"name": "Creality K1C CFS",
+			"sub_path": "machine/Creality K1C CFS.json"
+		},
+		{
+			"name": "Creality K1 SE CFS",
+			"sub_path": "machine/Creality K1 SE CFS.json"
+		},
+		{
+			"name": "Creality K1 Max CFS",
+			"sub_path": "machine/Creality K1 Max CFS.json"
 		}
 	],
 	"process_list": [
@@ -4245,6 +4261,54 @@
 		{
 			"name": "Creality SPARKX i7 0.8 nozzle",
 			"sub_path": "machine/Creality SPARKX i7 0.8 nozzle.json"
+		},
+		{
+			"name": "Creality K1 CFS 0.4 nozzle",
+			"sub_path": "machine/Creality K1 CFS 0.4 nozzle.json"
+		},
+		{
+			"name": "Creality K1 CFS 0.6 nozzle",
+			"sub_path": "machine/Creality K1 CFS 0.6 nozzle.json"
+		},
+		{
+			"name": "Creality K1 CFS 0.8 nozzle",
+			"sub_path": "machine/Creality K1 CFS 0.8 nozzle.json"
+		},
+		{
+			"name": "Creality K1C CFS 0.4 nozzle",
+			"sub_path": "machine/Creality K1C CFS 0.4 nozzle.json"
+		},
+		{
+			"name": "Creality K1C CFS 0.6 nozzle",
+			"sub_path": "machine/Creality K1C CFS 0.6 nozzle.json"
+		},
+		{
+			"name": "Creality K1C CFS 0.8 nozzle",
+			"sub_path": "machine/Creality K1C CFS 0.8 nozzle.json"
+		},
+		{
+			"name": "Creality K1 SE CFS 0.4 nozzle",
+			"sub_path": "machine/Creality K1 SE CFS 0.4 nozzle.json"
+		},
+		{
+			"name": "Creality K1 SE CFS 0.6 nozzle",
+			"sub_path": "machine/Creality K1 SE CFS 0.6 nozzle.json"
+		},
+		{
+			"name": "Creality K1 SE CFS 0.8 nozzle",
+			"sub_path": "machine/Creality K1 SE CFS 0.8 nozzle.json"
+		},
+		{
+			"name": "Creality K1 Max CFS 0.4 nozzle",
+			"sub_path": "machine/Creality K1 Max CFS 0.4 nozzle.json"
+		},
+		{
+			"name": "Creality K1 Max CFS 0.6 nozzle",
+			"sub_path": "machine/Creality K1 Max CFS 0.6 nozzle.json"
+		},
+		{
+			"name": "Creality K1 Max CFS 0.8 nozzle",
+			"sub_path": "machine/Creality K1 Max CFS 0.8 nozzle.json"
 		}
 	]
 }

--- a/resources/profiles/Creality/machine/Creality K1 CFS 0.4 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality K1 CFS 0.4 nozzle.json
@@ -1,0 +1,17 @@
+{
+	"type": "machine",
+	"name": "Creality K1 CFS 0.4 nozzle",
+	"from": "system",
+	"setting_id": "T3ICjDfOrSxsk0zp",
+	"instantiation": "true",
+	"inherits": "Creality K1 (0.4 nozzle)",
+	"printer_model": "Creality K1 CFS",
+	"printer_variant": "0.4",
+	"single_extruder_multi_material": "1",
+	"purge_in_prime_tower": "0",
+	"machine_start_gcode": "START_PRINT EXTRUDER_TEMP=[nozzle_temperature_initial_layer] BED_TEMP=[bed_temperature_initial_layer_single]\nT[initial_no_support_extruder]\nRESPOND TYPE=command MSG=\"Loading filament from CFS slot {initial_no_support_extruder + 1}\"\nM204 S2000\nM104 S[nozzle_temperature_initial_layer]\nG1 Z3 F600\nM83\nG92 E0\nG1 Z1 F600",
+	"machine_load_filament_time": "10",
+	"machine_unload_filament_time": "14",
+	"machine_tool_change_time": "66",
+	"default_print_profile": "0.20mm Standard @Creality K1 (0.4 nozzle)"
+}

--- a/resources/profiles/Creality/machine/Creality K1 CFS 0.6 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality K1 CFS 0.6 nozzle.json
@@ -1,0 +1,17 @@
+{
+	"type": "machine",
+	"name": "Creality K1 CFS 0.6 nozzle",
+	"from": "system",
+	"setting_id": "wtT5LFeDVYO101HB",
+	"instantiation": "true",
+	"inherits": "Creality K1 (0.6 nozzle)",
+	"printer_model": "Creality K1 CFS",
+	"printer_variant": "0.6",
+	"single_extruder_multi_material": "1",
+	"purge_in_prime_tower": "0",
+	"machine_start_gcode": "START_PRINT EXTRUDER_TEMP=[nozzle_temperature_initial_layer] BED_TEMP=[bed_temperature_initial_layer_single]\nT[initial_no_support_extruder]\nRESPOND TYPE=command MSG=\"Loading filament from CFS slot {initial_no_support_extruder + 1}\"\nM204 S2000\nM104 S[nozzle_temperature_initial_layer]\nG1 Z3 F600\nM83\nG92 E0\nG1 Z1 F600",
+	"machine_load_filament_time": "10",
+	"machine_unload_filament_time": "14",
+	"machine_tool_change_time": "66",
+	"default_print_profile": "0.30mm Standard @Creality K1 (0.6 nozzle)"
+}

--- a/resources/profiles/Creality/machine/Creality K1 CFS 0.8 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality K1 CFS 0.8 nozzle.json
@@ -1,0 +1,17 @@
+{
+	"type": "machine",
+	"name": "Creality K1 CFS 0.8 nozzle",
+	"from": "system",
+	"setting_id": "bu0RyKH22P73ZJZV",
+	"instantiation": "true",
+	"inherits": "Creality K1 (0.8 nozzle)",
+	"printer_model": "Creality K1 CFS",
+	"printer_variant": "0.8",
+	"single_extruder_multi_material": "1",
+	"purge_in_prime_tower": "0",
+	"machine_start_gcode": "START_PRINT EXTRUDER_TEMP=[nozzle_temperature_initial_layer] BED_TEMP=[bed_temperature_initial_layer_single]\nT[initial_no_support_extruder]\nRESPOND TYPE=command MSG=\"Loading filament from CFS slot {initial_no_support_extruder + 1}\"\nM204 S2000\nM104 S[nozzle_temperature_initial_layer]\nG1 Z3 F600\nM83\nG92 E0\nG1 Z1 F600",
+	"machine_load_filament_time": "10",
+	"machine_unload_filament_time": "14",
+	"machine_tool_change_time": "66",
+	"default_print_profile": "0.40mm Standard @Creality K1 (0.8 nozzle)"
+}

--- a/resources/profiles/Creality/machine/Creality K1 CFS.json
+++ b/resources/profiles/Creality/machine/Creality K1 CFS.json
@@ -1,0 +1,13 @@
+{
+	"type": "machine_model",
+	"name": "Creality K1 CFS",
+	"nozzle_diameter": "0.4;0.6;0.8",
+	"bed_model": "creality_k1_buildplate_model.stl",
+	"default_bed_type": "Textured PEI Plate",
+	"bed_texture": "creality_k1_buildplate_texture.svg",
+	"family": "Creality",
+	"hotend_model": "",
+	"machine_tech": "FFF",
+	"model_id": "Creality_K1_CFS",
+	"default_materials": "Creality Generic ABS;Creality Generic ASA;Creality Generic PC @K1-all;Creality Generic PLA;Creality HF Generic PLA;Creality HF Generic Speed PLA;Creality Generic PLA High Speed @K1-all;Creality Generic PLA Matte @K1-all;Creality Generic PLA Silk @K1-all;Creality Generic PETG;Creality Generic TPU"
+}

--- a/resources/profiles/Creality/machine/Creality K1 Max CFS 0.4 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality K1 Max CFS 0.4 nozzle.json
@@ -1,0 +1,17 @@
+{
+	"type": "machine",
+	"name": "Creality K1 Max CFS 0.4 nozzle",
+	"from": "system",
+	"setting_id": "hyJuDwisDBiy2xzY",
+	"instantiation": "true",
+	"inherits": "Creality K1 Max (0.4 nozzle)",
+	"printer_model": "Creality K1 Max CFS",
+	"printer_variant": "0.4",
+	"single_extruder_multi_material": "1",
+	"purge_in_prime_tower": "0",
+	"machine_start_gcode": "START_PRINT EXTRUDER_TEMP=[nozzle_temperature_initial_layer] BED_TEMP=[bed_temperature_initial_layer_single]\nT[initial_no_support_extruder]\nRESPOND TYPE=command MSG=\"Loading filament from CFS slot {initial_no_support_extruder + 1}\"\nM204 S2000\nM104 S[nozzle_temperature_initial_layer]\nG1 Z3 F600\nM83\nG92 E0\nG1 Z1 F600",
+	"machine_load_filament_time": "10",
+	"machine_unload_filament_time": "14",
+	"machine_tool_change_time": "66",
+	"default_print_profile": "0.20mm Standard @Creality K1Max (0.4 nozzle)"
+}

--- a/resources/profiles/Creality/machine/Creality K1 Max CFS 0.6 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality K1 Max CFS 0.6 nozzle.json
@@ -1,0 +1,17 @@
+{
+	"type": "machine",
+	"name": "Creality K1 Max CFS 0.6 nozzle",
+	"from": "system",
+	"setting_id": "lBxf8hkGPc9qaFB0",
+	"instantiation": "true",
+	"inherits": "Creality K1 Max (0.6 nozzle)",
+	"printer_model": "Creality K1 Max CFS",
+	"printer_variant": "0.6",
+	"single_extruder_multi_material": "1",
+	"purge_in_prime_tower": "0",
+	"machine_start_gcode": "START_PRINT EXTRUDER_TEMP=[nozzle_temperature_initial_layer] BED_TEMP=[bed_temperature_initial_layer_single]\nT[initial_no_support_extruder]\nRESPOND TYPE=command MSG=\"Loading filament from CFS slot {initial_no_support_extruder + 1}\"\nM204 S2000\nM104 S[nozzle_temperature_initial_layer]\nG1 Z3 F600\nM83\nG92 E0\nG1 Z1 F600",
+	"machine_load_filament_time": "10",
+	"machine_unload_filament_time": "14",
+	"machine_tool_change_time": "66",
+	"default_print_profile": "0.30mm Standard @Creality K1Max (0.6 nozzle)"
+}

--- a/resources/profiles/Creality/machine/Creality K1 Max CFS 0.8 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality K1 Max CFS 0.8 nozzle.json
@@ -1,0 +1,17 @@
+{
+	"type": "machine",
+	"name": "Creality K1 Max CFS 0.8 nozzle",
+	"from": "system",
+	"setting_id": "DxaTdRLg07Rlaq1f",
+	"instantiation": "true",
+	"inherits": "Creality K1 Max (0.8 nozzle)",
+	"printer_model": "Creality K1 Max CFS",
+	"printer_variant": "0.8",
+	"single_extruder_multi_material": "1",
+	"purge_in_prime_tower": "0",
+	"machine_start_gcode": "START_PRINT EXTRUDER_TEMP=[nozzle_temperature_initial_layer] BED_TEMP=[bed_temperature_initial_layer_single]\nT[initial_no_support_extruder]\nRESPOND TYPE=command MSG=\"Loading filament from CFS slot {initial_no_support_extruder + 1}\"\nM204 S2000\nM104 S[nozzle_temperature_initial_layer]\nG1 Z3 F600\nM83\nG92 E0\nG1 Z1 F600",
+	"machine_load_filament_time": "10",
+	"machine_unload_filament_time": "14",
+	"machine_tool_change_time": "66",
+	"default_print_profile": "0.40mm Standard @Creality K1Max (0.8 nozzle)"
+}

--- a/resources/profiles/Creality/machine/Creality K1 Max CFS.json
+++ b/resources/profiles/Creality/machine/Creality K1 Max CFS.json
@@ -1,0 +1,13 @@
+{
+	"type": "machine_model",
+	"name": "Creality K1 Max CFS",
+	"nozzle_diameter": "0.4;0.6;0.8",
+	"bed_model": "creality_k1max_buildplate_model.stl",
+	"default_bed_type": "Textured PEI Plate",
+	"bed_texture": "creality_k1max_buildplate_texture.svg",
+	"family": "Creality",
+	"hotend_model": "",
+	"machine_tech": "FFF",
+	"model_id": "Creality_K1_Max_CFS",
+	"default_materials": "Creality Generic ABS;Creality Generic ASA;Creality Generic PA-CF @K1-all;Creality Generic PC @K1-all;Creality Generic PETG;Creality Generic PLA;Creality HF Generic PLA;Creality HF Generic Speed PLA;Creality Generic PLA High Speed @K1-all;Creality Generic PLA Matte @K1-all;Creality Generic PLA Silk @K1-all;Creality Generic PLA-CF @K1-all;Creality Generic TPU"
+}

--- a/resources/profiles/Creality/machine/Creality K1 SE CFS 0.4 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality K1 SE CFS 0.4 nozzle.json
@@ -1,0 +1,17 @@
+{
+	"type": "machine",
+	"name": "Creality K1 SE CFS 0.4 nozzle",
+	"from": "system",
+	"setting_id": "J5XlR970JKmdYmAh",
+	"instantiation": "true",
+	"inherits": "Creality K1 SE 0.4 nozzle",
+	"printer_model": "Creality K1 SE CFS",
+	"printer_variant": "0.4",
+	"single_extruder_multi_material": "1",
+	"purge_in_prime_tower": "0",
+	"machine_start_gcode": "START_PRINT EXTRUDER_TEMP=[nozzle_temperature_initial_layer] BED_TEMP=[bed_temperature_initial_layer_single]\nT[initial_no_support_extruder]\nRESPOND TYPE=command MSG=\"Loading filament from CFS slot {initial_no_support_extruder + 1}\"\nM204 S2000\nM104 S[nozzle_temperature_initial_layer]\nG1 Z3 F600\nM83\nG92 E0\nG1 Z1 F600",
+	"machine_load_filament_time": "10",
+	"machine_unload_filament_time": "14",
+	"machine_tool_change_time": "66",
+	"default_print_profile": "0.20mm Standard @Creality K1 SE 0.4"
+}

--- a/resources/profiles/Creality/machine/Creality K1 SE CFS 0.6 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality K1 SE CFS 0.6 nozzle.json
@@ -1,0 +1,17 @@
+{
+	"type": "machine",
+	"name": "Creality K1 SE CFS 0.6 nozzle",
+	"from": "system",
+	"setting_id": "YhYvytdA976ycG9Z",
+	"instantiation": "true",
+	"inherits": "Creality K1 SE 0.6 nozzle",
+	"printer_model": "Creality K1 SE CFS",
+	"printer_variant": "0.6",
+	"single_extruder_multi_material": "1",
+	"purge_in_prime_tower": "0",
+	"machine_start_gcode": "START_PRINT EXTRUDER_TEMP=[nozzle_temperature_initial_layer] BED_TEMP=[bed_temperature_initial_layer_single]\nT[initial_no_support_extruder]\nRESPOND TYPE=command MSG=\"Loading filament from CFS slot {initial_no_support_extruder + 1}\"\nM204 S2000\nM104 S[nozzle_temperature_initial_layer]\nG1 Z3 F600\nM83\nG92 E0\nG1 Z1 F600",
+	"machine_load_filament_time": "10",
+	"machine_unload_filament_time": "14",
+	"machine_tool_change_time": "66",
+	"default_print_profile": "0.30mm Standard @Creality K1 SE 0.6 nozzle"
+}

--- a/resources/profiles/Creality/machine/Creality K1 SE CFS 0.8 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality K1 SE CFS 0.8 nozzle.json
@@ -1,0 +1,17 @@
+{
+	"type": "machine",
+	"name": "Creality K1 SE CFS 0.8 nozzle",
+	"from": "system",
+	"setting_id": "keIX0KECdyrXWxtQ",
+	"instantiation": "true",
+	"inherits": "Creality K1 SE 0.8 nozzle",
+	"printer_model": "Creality K1 SE CFS",
+	"printer_variant": "0.8",
+	"single_extruder_multi_material": "1",
+	"purge_in_prime_tower": "0",
+	"machine_start_gcode": "START_PRINT EXTRUDER_TEMP=[nozzle_temperature_initial_layer] BED_TEMP=[bed_temperature_initial_layer_single]\nT[initial_no_support_extruder]\nRESPOND TYPE=command MSG=\"Loading filament from CFS slot {initial_no_support_extruder + 1}\"\nM204 S2000\nM104 S[nozzle_temperature_initial_layer]\nG1 Z3 F600\nM83\nG92 E0\nG1 Z1 F600",
+	"machine_load_filament_time": "10",
+	"machine_unload_filament_time": "14",
+	"machine_tool_change_time": "66",
+	"default_print_profile": "0.40mm Standard @Creality K1 SE 0.8 nozzle"
+}

--- a/resources/profiles/Creality/machine/Creality K1 SE CFS.json
+++ b/resources/profiles/Creality/machine/Creality K1 SE CFS.json
@@ -1,0 +1,13 @@
+{
+	"type": "machine_model",
+	"name": "Creality K1 SE CFS",
+	"nozzle_diameter": "0.4;0.6;0.8",
+	"bed_model": "creality_k1se_buildplate_model.stl",
+	"default_bed_type": "Textured PEI Plate",
+	"bed_texture": "creality_k1se_buildplate_texture.svg",
+	"family": "Creality",
+	"hotend_model": "",
+	"machine_tech": "FFF",
+	"model_id": "Creality_K1_SE_CFS",
+	"default_materials": "Creality Generic ABS @K1-all;Creality Generic ASA @K1-all;Creality Generic PA-CF @K1-all;Creality Generic PC @K1-all;Creality Generic PETG @K1-all;Creality Generic PLA @K1-all;Creality Generic PLA High Speed @K1-all;Creality Generic PLA Matte @K1-all;Creality Generic PLA Silk @K1-all;Creality Generic PLA-CF @K1-all;Creality Generic TPU @K1-all"
+}

--- a/resources/profiles/Creality/machine/Creality K1C CFS 0.4 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality K1C CFS 0.4 nozzle.json
@@ -1,0 +1,17 @@
+{
+	"type": "machine",
+	"name": "Creality K1C CFS 0.4 nozzle",
+	"from": "system",
+	"setting_id": "JuoLM6iRYIN3arJi",
+	"instantiation": "true",
+	"inherits": "Creality K1C 0.4 nozzle",
+	"printer_model": "Creality K1C CFS",
+	"printer_variant": "0.4",
+	"single_extruder_multi_material": "1",
+	"purge_in_prime_tower": "0",
+	"machine_start_gcode": "START_PRINT EXTRUDER_TEMP=[nozzle_temperature_initial_layer] BED_TEMP=[bed_temperature_initial_layer_single]\nT[initial_no_support_extruder]\nRESPOND TYPE=command MSG=\"Loading filament from CFS slot {initial_no_support_extruder + 1}\"\nM204 S2000\nM104 S[nozzle_temperature_initial_layer]\nG1 Z3 F600\nM83\nG92 E0\nG1 Z1 F600",
+	"machine_load_filament_time": "10",
+	"machine_unload_filament_time": "14",
+	"machine_tool_change_time": "66",
+	"default_print_profile": "0.20mm Standard @Creality K1C (0.4 nozzle)"
+}

--- a/resources/profiles/Creality/machine/Creality K1C CFS 0.6 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality K1C CFS 0.6 nozzle.json
@@ -1,0 +1,17 @@
+{
+	"type": "machine",
+	"name": "Creality K1C CFS 0.6 nozzle",
+	"from": "system",
+	"setting_id": "xYxu99cDIHni8Abw",
+	"instantiation": "true",
+	"inherits": "Creality K1C 0.6 nozzle",
+	"printer_model": "Creality K1C CFS",
+	"printer_variant": "0.6",
+	"single_extruder_multi_material": "1",
+	"purge_in_prime_tower": "0",
+	"machine_start_gcode": "START_PRINT EXTRUDER_TEMP=[nozzle_temperature_initial_layer] BED_TEMP=[bed_temperature_initial_layer_single]\nT[initial_no_support_extruder]\nRESPOND TYPE=command MSG=\"Loading filament from CFS slot {initial_no_support_extruder + 1}\"\nM204 S2000\nM104 S[nozzle_temperature_initial_layer]\nG1 Z3 F600\nM83\nG92 E0\nG1 Z1 F600",
+	"machine_load_filament_time": "10",
+	"machine_unload_filament_time": "14",
+	"machine_tool_change_time": "66",
+	"default_print_profile": "0.30mm Standard @Creality K1C (0.6 nozzle)"
+}

--- a/resources/profiles/Creality/machine/Creality K1C CFS 0.8 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality K1C CFS 0.8 nozzle.json
@@ -1,0 +1,17 @@
+{
+	"type": "machine",
+	"name": "Creality K1C CFS 0.8 nozzle",
+	"from": "system",
+	"setting_id": "q1g5N1kjYM60gT2C",
+	"instantiation": "true",
+	"inherits": "Creality K1C 0.8 nozzle",
+	"printer_model": "Creality K1C CFS",
+	"printer_variant": "0.8",
+	"single_extruder_multi_material": "1",
+	"purge_in_prime_tower": "0",
+	"machine_start_gcode": "START_PRINT EXTRUDER_TEMP=[nozzle_temperature_initial_layer] BED_TEMP=[bed_temperature_initial_layer_single]\nT[initial_no_support_extruder]\nRESPOND TYPE=command MSG=\"Loading filament from CFS slot {initial_no_support_extruder + 1}\"\nM204 S2000\nM104 S[nozzle_temperature_initial_layer]\nG1 Z3 F600\nM83\nG92 E0\nG1 Z1 F600",
+	"machine_load_filament_time": "10",
+	"machine_unload_filament_time": "14",
+	"machine_tool_change_time": "66",
+	"default_print_profile": "0.40mm Standard @Creality K1C (0.8 nozzle)"
+}

--- a/resources/profiles/Creality/machine/Creality K1C CFS.json
+++ b/resources/profiles/Creality/machine/Creality K1C CFS.json
@@ -1,0 +1,13 @@
+{
+	"type": "machine_model",
+	"name": "Creality K1C CFS",
+	"nozzle_diameter": "0.4;0.6;0.8",
+	"bed_model": "creality_k1c_buildplate_model.stl",
+	"default_bed_type": "Textured PEI Plate",
+	"bed_texture": "creality_k1c_buildplate_texture.svg",
+	"family": "Creality",
+	"hotend_model": "",
+	"machine_tech": "FFF",
+	"model_id": "Creality_K1C_CFS",
+	"default_materials": "Creality Generic ABS @K1-all;Creality Generic ASA @K1-all;Creality Generic PA-CF @K1-all;Creality Generic PC @K1-all;Creality Generic PETG @K1-all;Creality Generic PLA @K1-all;Creality Generic PLA High Speed @K1-all;Creality Generic PLA Matte @K1-all;Creality Generic PLA Silk @K1-all;Creality Generic PLA-CF @K1-all;Creality Generic TPU @K1-all"
+}


### PR DESCRIPTION
Adds machine models and 0.4 / 0.6 / 0.8 nozzle variants for the Creality Filament System (CFS) on K1, K1C, K1 SE and K1 Max. Only CFS-C profiles existed for this family so far, which is a different kit: the CFS-C purges externally while the original CFS purges internally.

Each variant inherits its non-CFS base profile and only overrides CFS specifics: single extruder multi material, prime-tower purge disabled, filament load / unload / tool-change times, and a start gcode that selects and reports the CFS slot before printing.

setting_id values generated with scripts/assign_vendor_setting_ids.py. scripts/orca_extra_profile_check.py --vendor Creality passes with 0 errors and 0 warnings.

# Description

### What
 
Adds printer profiles for the **Creality Filament System (CFS)** on the **K1 family**: `Creality K1 CFS`, `K1C CFS`, `K1 SE CFS` and `K1 Max CFS`, each with 0.4 / 0.6 / 0.8 nozzle variants.
 
Profiles only, no C++ changes.
 
### Why
 
The K1 family currently ships **only `CFS-C` profiles**, which are a different kit: the CFS-C purges externally, while the original CFS purges internally. Users with the first-generation CFS have no matching printer model, so multi-material jobs have to be set up by hand on a non-CFS profile.
 
Related: #11087, #12407.
 
### How
 
- 4 `machine_model` entries (each declaring `0.4;0.6;0.8`) + 12 `machine` variants, registered in `Creality.json`.
- Each variant `inherits` its non-CFS base profile (e.g. `Creality K1 SE 0.4 nozzle`) and only overrides CFS specifics, so the files stay ~15 lines instead of duplicating the whole base:
  - `single_extruder_multi_material` = 1
  - `purge_in_prime_tower` = 0 (the original CFS purges internally)
  - `machine_load_filament_time` / `machine_unload_filament_time` / `machine_tool_change_time`
  - `machine_start_gcode` that selects the CFS slot and reports it before printing
- `setting_id` values generated with `scripts/assign_vendor_setting_ids.py`.
### Testing
 
- `scripts/orca_extra_profile_check.py --vendor Creality` → **0 errors, 0 warnings**.
- Verified on real hardware: **Creality K1 SE + first-generation CFS** profile selected, multi-colour job sliced and printed, correct slot loaded at start.
- The other variants are mechanically identical (same inheritance, same overrides, only the base profile and nozzle differ), so they carry the already-verified base settings.
