### PR TITLE
profiles: fix belt printer CI failures (slice check + setting_id)

### DIFF
--- a/resources/profiles/Custom.json
+++ b/resources/profiles/Custom.json
@@ -1,6 +1,6 @@
 {
 	"name": "Custom Printer",
-	"version": "02.04.00.03",
+	"version": "02.04.00.04",
 	"force_update": "0",
 	"description": "My configurations",
 	"machine_model_list": [
@@ -65,6 +65,14 @@
 		{
 			"name": "0.16mm Optimal @MyKlipper",
 			"sub_path": "process/0.16mm Optimal @MyKlipper.json"
+		},
+		{
+			"name": "0.12mm Fine @MyBeltPrinter",
+			"sub_path": "process/0.12mm Fine @MyBeltPrinter.json"
+		},
+		{
+			"name": "0.20mm Standard @MyBeltPrinter",
+			"sub_path": "process/0.20mm Standard @MyBeltPrinter.json"
 		},
 		{
 			"name": "0.20mm Standard @MyKlipper",

--- a/resources/profiles/Custom/machine/MyBeltPrinter 0.2 nozzle.json
+++ b/resources/profiles/Custom/machine/MyBeltPrinter 0.2 nozzle.json
@@ -3,9 +3,10 @@
 	"name": "MyBeltPrinter 0.2 nozzle",
 	"inherits": "fdm_belt_common",
 	"from": "system",
-	"setting_id": "GM_BELT_001",
+	"setting_id": "3w1uyJdmm14QhDnH",
 	"instantiation": "true",
 	"printer_model": "Generic Belt Printer",
+	"default_print_profile": "0.12mm Fine @MyBeltPrinter",
 	"nozzle_diameter": [
 		"0.2"
 	],

--- a/resources/profiles/Custom/machine/MyBeltPrinter 0.4 nozzle.json
+++ b/resources/profiles/Custom/machine/MyBeltPrinter 0.4 nozzle.json
@@ -3,7 +3,7 @@
 	"name": "MyBeltPrinter 0.4 nozzle",
 	"inherits": "fdm_belt_common",
 	"from": "system",
-	"setting_id": "GM_BELT_002",
+	"setting_id": "6nRHUtvJOUffocbu",
 	"instantiation": "true",
 	"printer_model": "Generic Belt Printer",
 	"nozzle_diameter": [

--- a/resources/profiles/Custom/machine/MyBeltPrinter 0.6 nozzle.json
+++ b/resources/profiles/Custom/machine/MyBeltPrinter 0.6 nozzle.json
@@ -3,7 +3,7 @@
 	"name": "MyBeltPrinter 0.6 nozzle",
 	"inherits": "fdm_belt_common",
 	"from": "system",
-	"setting_id": "GM_BELT_003",
+	"setting_id": "K0m9HbUNwKT4UCJV",
 	"instantiation": "true",
 	"printer_model": "Generic Belt Printer",
 	"nozzle_diameter": [

--- a/resources/profiles/Custom/machine/MyBeltPrinter 0.8 nozzle.json
+++ b/resources/profiles/Custom/machine/MyBeltPrinter 0.8 nozzle.json
@@ -3,7 +3,7 @@
 	"name": "MyBeltPrinter 0.8 nozzle",
 	"inherits": "fdm_belt_common",
 	"from": "system",
-	"setting_id": "GM_BELT_004",
+	"setting_id": "rHAweDz4eNwttPNA",
 	"instantiation": "true",
 	"printer_model": "Generic Belt Printer",
 	"nozzle_diameter": [

--- a/resources/profiles/Custom/machine/fdm_belt_common.json
+++ b/resources/profiles/Custom/machine/fdm_belt_common.json
@@ -9,7 +9,7 @@
 	"default_filament_profile": [
 		"Generic PLA @System"
 	],
-	"default_print_profile": "0.20mm Standard @System",
+	"default_print_profile": "0.20mm Standard @MyBeltPrinter",
 	"max_layer_height": [
 		"0.32"
 	],

--- a/resources/profiles/Custom/process/0.12mm Fine @MyBeltPrinter.json
+++ b/resources/profiles/Custom/process/0.12mm Fine @MyBeltPrinter.json
@@ -1,0 +1,20 @@
+{
+	"type": "process",
+	"name": "0.12mm Fine @MyBeltPrinter",
+	"inherits": "fdm_process_klipper_common",
+	"from": "system",
+	"setting_id": "EugqqdLJ423bgEwN",
+	"instantiation": "true",
+	"layer_height": "0.12",
+	"initial_layer_print_height": "0.12",
+	"bottom_shell_layers": "5",
+	"top_shell_layers": "6",
+	"support_top_z_distance": "0.08",
+	"support_bottom_z_distance": "0.08",
+	"skirt_loops": "0",
+	"skirt_distance": "0",
+	"compatible_printers": [
+		"MyBeltPrinter 0.2 nozzle",
+		"MyBeltPrinter 0.4 nozzle"
+	]
+}

--- a/resources/profiles/Custom/process/0.20mm Standard @MyBeltPrinter.json
+++ b/resources/profiles/Custom/process/0.20mm Standard @MyBeltPrinter.json
@@ -1,0 +1,17 @@
+{
+	"type": "process",
+	"name": "0.20mm Standard @MyBeltPrinter",
+	"inherits": "fdm_process_klipper_common",
+	"from": "system",
+	"setting_id": "YzCDAgH3uLOM53pF",
+	"instantiation": "true",
+	"layer_height": "0.2",
+	"initial_layer_print_height": "0.2",
+	"skirt_loops": "0",
+	"skirt_distance": "0",
+	"compatible_printers": [
+		"MyBeltPrinter 0.4 nozzle",
+		"MyBeltPrinter 0.6 nozzle",
+		"MyBeltPrinter 0.8 nozzle"
+	]
+}

--- a/resources/profiles/IdeaFormer.json
+++ b/resources/profiles/IdeaFormer.json
@@ -1,6 +1,6 @@
 {
     "name": "IdeaFormer",
-    "version": "02.00.00.02",
+    "version": "02.00.00.03",
     "force_update": "0",
     "description": "IdeaFormer belt printer configurations",
     "machine_model_list": [

--- a/resources/profiles/IdeaFormer/filament/Generic PETG @IdeaFormer IR3 V2.json
+++ b/resources/profiles/IdeaFormer/filament/Generic PETG @IdeaFormer IR3 V2.json
@@ -3,6 +3,7 @@
 	"name": "Generic PETG @IdeaFormer IR3 V2",
 	"inherits": "Generic PETG @System",
 	"from": "system",
+	"setting_id": "n4zaXcUUzTqAxq5f",
 	"instantiation": "true",
 	"compatible_printers": [
 		"IdeaFormer IR3 V2 0.4 nozzle"

--- a/resources/profiles/IdeaFormer/filament/Generic PLA @IdeaFormer IR3 V2.json
+++ b/resources/profiles/IdeaFormer/filament/Generic PLA @IdeaFormer IR3 V2.json
@@ -3,6 +3,7 @@
 	"name": "Generic PLA @IdeaFormer IR3 V2",
 	"inherits": "Generic PLA @System",
 	"from": "system",
+	"setting_id": "1xjycsEAFh6KQIhp",
 	"instantiation": "true",
 	"compatible_printers": [
 		"IdeaFormer IR3 V2 0.4 nozzle"

--- a/resources/profiles/IdeaFormer/filament/eSUN PLA @IdeaFormer IR3 V2.json
+++ b/resources/profiles/IdeaFormer/filament/eSUN PLA @IdeaFormer IR3 V2.json
@@ -3,6 +3,7 @@
 	"name": "eSUN PLA @IdeaFormer IR3 V2",
 	"inherits": "Generic PLA @IdeaFormer IR3 V2",
 	"from": "system",
+	"setting_id": "XqkviBmFHEglXueX",
 	"instantiation": "true",
 	"compatible_printers": [
 		"IdeaFormer IR3 V2 0.4 nozzle"

--- a/resources/profiles/IdeaFormer/machine/IdeaFormer IR3 V2 0.4 nozzle.json
+++ b/resources/profiles/IdeaFormer/machine/IdeaFormer IR3 V2 0.4 nozzle.json
@@ -3,7 +3,7 @@
 	"name": "IdeaFormer IR3 V2 0.4 nozzle",
 	"inherits": "fdm_belt_common",
 	"from": "system",
-	"setting_id": "GMIF001",
+	"setting_id": "MDQZgwRgg72lmjtu",
 	"instantiation": "true",
 	"printer_model": "IdeaFormer IR3 V2",
 	"printer_variant": "0.4",

--- a/resources/profiles/IdeaFormer/machine/fdm_belt_common.json
+++ b/resources/profiles/IdeaFormer/machine/fdm_belt_common.json
@@ -9,7 +9,7 @@
 	"default_filament_profile": [
 		"Generic PLA @System"
 	],
-	"default_print_profile": "0.20mm Standard @System",
+	"default_print_profile": "0.20mm Standard @IdeaFormer IR3 V2",
 	"max_layer_height": [
 		"0.32"
 	],

--- a/resources/profiles/IdeaFormer/process/0.20mm Standard @IdeaFormer IR3 V2.json
+++ b/resources/profiles/IdeaFormer/process/0.20mm Standard @IdeaFormer IR3 V2.json
@@ -3,6 +3,7 @@
 	"name": "0.20mm Standard @IdeaFormer IR3 V2",
 	"inherits": "fdm_process_common",
 	"from": "system",
+	"setting_id": "91atcIwv5728phqX",
 	"instantiation": "true",
 	"layer_height": "0.2",
 	"initial_layer_print_height": "0.2",

--- a/resources/profiles/Printcepts.json
+++ b/resources/profiles/Printcepts.json
@@ -1,6 +1,6 @@
 {
 	"name": "Printcepts",
-	"version": "01.00.00.00",
+	"version": "01.00.00.01",
 	"force_update": "0",
 	"description": "Printcepts belt printer configurations",
 	"machine_model_list": [

--- a/resources/profiles/Printcepts/filament/Generic PETG @BabyBelt Pro.json
+++ b/resources/profiles/Printcepts/filament/Generic PETG @BabyBelt Pro.json
@@ -3,6 +3,7 @@
 	"name": "Generic PETG @BabyBelt Pro",
 	"inherits": "Generic PETG @System",
 	"from": "system",
+	"setting_id": "gCzHpDNgVwQR6tgk",
 	"instantiation": "true",
 	"compatible_printers": [
 		"BabyBelt Pro 0.4 nozzle"

--- a/resources/profiles/Printcepts/filament/Generic PLA @BabyBelt Pro.json
+++ b/resources/profiles/Printcepts/filament/Generic PLA @BabyBelt Pro.json
@@ -3,6 +3,7 @@
 	"name": "Generic PLA @BabyBelt Pro",
 	"inherits": "Generic PLA @System",
 	"from": "system",
+	"setting_id": "24PpcnhVx9v5f4fD",
 	"instantiation": "true",
 	"compatible_printers": [
 		"BabyBelt Pro 0.4 nozzle"

--- a/resources/profiles/Printcepts/filament/eSUN PLA @BabyBelt Pro.json
+++ b/resources/profiles/Printcepts/filament/eSUN PLA @BabyBelt Pro.json
@@ -3,6 +3,7 @@
 	"name": "eSUN PLA @BabyBelt Pro",
 	"inherits": "Generic PLA @BabyBelt Pro",
 	"from": "system",
+	"setting_id": "EH3X7oE0DU5tSpjW",
 	"instantiation": "true",
 	"compatible_printers": [
 		"BabyBelt Pro 0.4 nozzle"

--- a/resources/profiles/Printcepts/machine/BabyBelt Pro 0.4 nozzle.json
+++ b/resources/profiles/Printcepts/machine/BabyBelt Pro 0.4 nozzle.json
@@ -3,7 +3,7 @@
 	"name": "BabyBelt Pro 0.4 nozzle",
 	"inherits": "fdm_belt_common",
 	"from": "system",
-	"setting_id": "GMPC0BBP01",
+	"setting_id": "34OWINlJpJgA9DwQ",
 	"instantiation": "true",
 	"printer_model": "BabyBelt Pro",
 	"printer_variant": "0.4",

--- a/resources/profiles/Printcepts/machine/fdm_belt_common.json
+++ b/resources/profiles/Printcepts/machine/fdm_belt_common.json
@@ -9,7 +9,7 @@
 	"default_filament_profile": [
 		"Generic PLA @System"
 	],
-	"default_print_profile": "0.20mm Standard @System",
+	"default_print_profile": "0.20mm Standard @BabyBelt Pro",
 	"max_layer_height": [
 		"0.32"
 	],

--- a/resources/profiles/Printcepts/process/0.20mm Standard @BabyBelt Pro.json
+++ b/resources/profiles/Printcepts/process/0.20mm Standard @BabyBelt Pro.json
@@ -3,6 +3,7 @@
 	"name": "0.20mm Standard @BabyBelt Pro",
 	"inherits": "fdm_process_common",
 	"from": "system",
+	"setting_id": "JGfGtqX6CWjCt437",
 	"instantiation": "true",
 	"layer_height": "0.2",
 	"initial_layer_print_height": "0.2",


### PR DESCRIPTION
The belt-printer branch is failing two profile gates. Both stem from the three belt-only vendors (Custom's generic belt printer, IdeaFormer, Printcepts) not existing upstream, so upstream maintenance passed them by.

Slice check: 4 of 1015 printers failed - Custom's MyBeltPrinter 0.2/0.4/ 0.6/0.8 nozzle all fell back to "Default Setting". No process profile in the Custom vendor listed any MyBeltPrinter in compatible_printers, and Custom's fdm_belt_common pointed default_print_profile at "0.20mm Standard @System", which does not exist in that vendor's index, so the generic belt printer had no usable process at all. This gap dates to when MyBeltPrinter was added (2026-04-07); it only started failing now because the slice-check job is newer than that.

Adds two process profiles modelled on the sibling @MyKlipper ones:
  - 0.20mm Standard @MyBeltPrinter - 0.4/0.6/0.8 nozzles
  - 0.12mm Fine @MyBeltPrinter     - 0.2/0.4 nozzles
The split is forced by hardware: the 0.2 nozzle preset caps
max_layer_height at 0.16, so a single 0.20mm profile cannot legally cover
it. fdm_belt_common now defaults to the standard profile and the 0.2
nozzle preset overrides to the fine one.

setting_id: 14 files failed the rules introduced in #14432. That migration renumbered 7425 files across 61 vendors but skipped these three, leaving BabyBelt Pro, IdeaFormer IR3 V2 and MyBeltPrinter squatting the "G*" id space reserved for Bambu (GMPC0BBP01, GMIF001, GM_BELT_00x) and four instantiated filament/process presets carrying no setting_id at all. Regenerated with scripts/assign_vendor_setting_ids.py.

Also repoints the identical dangling "0.20mm Standard @System" in Printcepts' and IdeaFormer's fdm_belt_common at their own real process profiles. That is a no-op today because both concrete printers override it, but it is the same landmine that took out MyBeltPrinter.

Vendor index versions bumped so check_installed_vendor_profiles() will re-install the corrected profiles over an existing install.

Note: changing a shipped preset's setting_id can orphan user presets that reference it as base_id. #14432 accepted that tradeoff for 61 vendors; this keeps these three consistent with the rest.

Verified: orca_extra_profile_check.py reports 0 errors across 66 vendors (was 14 files with errors), and OrcaSlicer_profile_validator -s slices all 1015 printer presets successfully (was 4 failures).


[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
