### PR TITLE
refactor: access codes and device tab

### DIFF
--- a/src/slic3r/GUI/ConnectPrinter.cpp
+++ b/src/slic3r/GUI/ConnectPrinter.cpp
@@ -156,6 +156,8 @@ void ConnectPrinterDialog::on_input_enter(wxCommandEvent& evt)
 void ConnectPrinterDialog::on_button_confirm(wxCommandEvent &event)
 {
     wxString code = m_textCtrl_code->GetTextCtrl()->GetValue();
+    if (code.empty())
+        code = "88888888";
     for (char c : code) {
         if (!(('0' <= c && c <= '9') || ('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z'))) {
             show_error(this, _L("Invalid input"));
@@ -163,7 +165,7 @@ void ConnectPrinterDialog::on_button_confirm(wxCommandEvent &event)
         }
     }
     if (m_obj) {
-        m_obj->set_user_access_code(code.ToStdString());
+        m_obj->set_access_code(code.ToStdString());
     }
     EndModal(wxID_OK);
 }

--- a/src/slic3r/GUI/DeviceCore/DevManager.cpp
+++ b/src/slic3r/GUI/DeviceCore/DevManager.cpp
@@ -15,6 +15,18 @@
 
 using namespace nlohmann;
 
+namespace {
+    // Orca: access_code and user_access_code used to be separate AppConfig keys before the two
+    // fields were merged; fall back to the legacy key so existing users' saved codes aren't lost.
+    std::string get_access_code_with_legacy_fallback(Slic3r::AppConfig* config, const std::string& dev_id)
+    {
+        std::string code = config->get("access_code", dev_id);
+        if (code.empty())
+            code = config->get("user_access_code", dev_id);
+        return code;
+    }
+}
+
 namespace Slic3r
 {
     DeviceManager::DeviceManager(NetworkAgent* agent)
@@ -48,8 +60,7 @@ namespace Slic3r
             obj->bind_sec_link       = "secure";
             obj->m_is_online         = true;
             obj->last_alive          = Slic3r::Utils::get_current_time_utc();
-            obj->set_access_code(config->get("access_code", m.dev_id), false);
-            obj->set_user_access_code(config->get("user_access_code", m.dev_id), false);
+            obj->set_access_code(get_access_code_with_legacy_fallback(config, m.dev_id), false);
             if (obj->has_access_right()) {
                 localMachineList.insert(std::make_pair(m.dev_id, obj));
             } else {
@@ -339,8 +350,7 @@ namespace Slic3r
                 //load access code
                 AppConfig* config = Slic3r::GUI::wxGetApp().app_config;
                 if (config) {
-                    obj->set_access_code(Slic3r::GUI::wxGetApp().app_config->get("access_code", dev_id), false);
-                    obj->set_user_access_code(Slic3r::GUI::wxGetApp().app_config->get("user_access_code", dev_id), false);
+                    obj->set_access_code(get_access_code_with_legacy_fallback(config, dev_id), false);
                 }
                 localMachineList.insert(std::make_pair(dev_id, obj));
 
@@ -382,7 +392,6 @@ namespace Slic3r
         obj->m_is_online = true;
         obj->last_alive = Slic3r::Utils::get_current_time_utc();
         obj->set_access_code(access_code, false);
-        obj->set_user_access_code(access_code, false);
 
         update_local_machine(*obj);
 

--- a/src/slic3r/GUI/DeviceManager.cpp
+++ b/src/slic3r/GUI/DeviceManager.cpp
@@ -449,9 +449,7 @@ bool MachineObject::HasRecentLanMessage()
 
 std::string MachineObject::get_access_code() const
 {
-    if (get_user_access_code().empty())
-        return access_code;
-    return get_user_access_code();
+    return access_code;
 }
 
 void MachineObject::set_access_code(std::string code, bool only_refresh)
@@ -468,37 +466,6 @@ void MachineObject::set_access_code(std::string code, bool only_refresh)
             }
         }
     }
-}
-
-void MachineObject::erase_user_access_code()
-{
-    this->user_access_code = "";
-    AppConfig* config = GUI::wxGetApp().app_config;
-    if (config) {
-        GUI::wxGetApp().app_config->erase("user_access_code", get_dev_id());
-        //GUI::wxGetApp().app_config->save();
-    }
-}
-
-void MachineObject::set_user_access_code(std::string code, bool only_refresh)
-{
-    this->user_access_code = code;
-    if (only_refresh && !code.empty()) {
-        AppConfig* config = GUI::wxGetApp().app_config;
-        if (config && !code.empty()) {
-            GUI::wxGetApp().app_config->set_str("user_access_code", get_dev_id(), code);
-            DeviceManager::update_local_machine(*this);
-        }
-    }
-}
-
-std::string MachineObject::get_user_access_code() const
-{
-    AppConfig* config = GUI::wxGetApp().app_config;
-    if (config) {
-        return GUI::wxGetApp().app_config->get("user_access_code", get_dev_id());
-    }
-    return "";
 }
 
 std::string MachineObject::get_show_printer_type() const
@@ -2907,7 +2874,6 @@ int MachineObject::parse_json(std::string tunnel, std::string payload, bool key_
                         std::string access_code = j_pre["system"]["access_code"].get<std::string>();
                         if (!access_code.empty()) {
                             set_access_code(access_code);
-                            set_user_access_code(access_code);
                         }
                     }
                 }

--- a/src/slic3r/GUI/DeviceManager.hpp
+++ b/src/slic3r/GUI/DeviceManager.hpp
@@ -113,7 +113,6 @@ private:
     std::string dev_name;
     std::string dev_ip;
     std::string access_code;
-    std::string user_access_code;
 
     // type, time stamp, delay
     std::vector<std::tuple<std::string, uint64_t, uint64_t>> message_delay;
@@ -227,11 +226,6 @@ public:
     bool has_access_right() const { return !get_access_code().empty(); }
     std::string get_access_code() const;
     void set_access_code(std::string code, bool only_refresh = true);
-
-    /*user access code*/
-    void set_user_access_code(std::string code, bool only_refresh = true);
-    void erase_user_access_code();
-    std::string get_user_access_code() const;
 
     //PRINTER_TYPE printer_type = PRINTER_3DPrinter_UKNOWN;
     std::string printer_type;       /* model_id */

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -2166,7 +2166,6 @@ void GUI_App::init_networking_callbacks()
                     obj->is_tunnel_mqtt = tunnel;
                     obj->command_request_push_all(true);
                     obj->command_get_version();
-                    obj->erase_user_access_code();
                     obj->command_get_access_code();
                     if (m_agent)
                         m_agent->install_device_cert(obj->get_dev_id(), obj->is_lan_mode_printer());
@@ -2216,7 +2215,6 @@ void GUI_App::init_networking_callbacks()
                                 wxString text;
                                 if (msg == "5") {
                                     obj->set_access_code("");
-                                    obj->erase_user_access_code();
                                     text = wxString::Format(_L("Incorrect password"));
                                     wxGetApp().show_dialog(text);
                                 } else {
@@ -8286,7 +8284,7 @@ bool GUI_App::show_modal_ip_address_enter_dialog(bool input_sn, wxString title)
                 wxGetApp().app_config->save();
 
                 obj->set_dev_ip(ip_address.ToStdString());
-                obj->set_user_access_code(access_code.ToStdString());
+                obj->set_access_code(access_code.ToStdString());
             }
         }
     });

--- a/src/slic3r/GUI/MainFrame.cpp
+++ b/src/slic3r/GUI/MainFrame.cpp
@@ -1373,8 +1373,8 @@ void MainFrame::show_device(bool should_use_native) {
 
     const bool use_printer_agents = wxGetApp().app_config->get_bool("use_printer_agents");
 
-    // The legacy page is appended when printer agents are enabled. Remove that
-    // extra page before switching back to the normal native/legacy layout.
+    // The web page is appended when printer agents are enabled. Remove that
+    // extra page before switching back to the normal native/Web layout.
     if (!use_printer_agents) {
         if ((idx = m_tabpanel->FindPage(m_printer_view)) != wxNOT_FOUND && idx != tpMonitor) {
             m_printer_view->Show(false);
@@ -1434,10 +1434,10 @@ void MainFrame::show_device(bool should_use_native) {
 
         if ((idx = m_tabpanel->FindPage(m_printer_view)) == wxNOT_FOUND) {
             m_printer_view->Show(false);
-            m_tabpanel->AddPage(m_printer_view, _L("Device (legacy)"), std::string("tab_monitor_active"),
+            m_tabpanel->AddPage(m_printer_view, _L("Device (Web)"), std::string("tab_monitor_active"),
                                 std::string("tab_monitor_active"), false);
         } else {
-            m_tabpanel->SetPageText(idx, _L("Device (legacy)"));
+            m_tabpanel->SetPageText(idx, _L("Device (Web)"));
         }
 
 #ifdef _MSW_DARK_MODE
@@ -4333,14 +4333,26 @@ void MainFrame::load_printer_url(wxString url, wxString apikey)
 void MainFrame::load_printer_url()
 {
     PresetBundle &preset_bundle = *wxGetApp().preset_bundle;
-    if (preset_bundle.use_bbl_device_tab() || wxGetApp().app_config->get_bool("use_printer_agents"))
+    if (preset_bundle.use_bbl_device_tab() && !wxGetApp().app_config->get_bool("use_printer_agents"))
         return;
 
     auto     cfg = preset_bundle.printers.get_edited_preset().config;
+    if (cfg.opt_string("print_host").empty()) {
+        if (auto *device_manager = wxGetApp().getDeviceManager()) {
+            auto *machine = device_manager->get_selected_machine();
+            if (!machine) {
+                auto machines = device_manager->get_my_machine_list();
+                if (machines.size() == 1)
+                    machine = machines.begin()->second;
+            }
+            if (machine && !machine->get_dev_ip().empty())
+                cfg.opt_string("print_host") = machine->get_dev_ip();
+        }
+    }
     wxString url = from_u8(PrintHost::get_print_host_webui(&cfg));
     wxString apikey;
     const auto host_type = cfg.option<ConfigOptionEnum<PrintHostType>>("host_type")->value;
-    if (cfg.has("printhost_apikey") && (host_type == htPrusaLink || host_type == htPrusaConnect))
+    if (cfg.has("printhost_apikey") && host_type != htSimplyPrint)
         apikey = cfg.opt_string("printhost_apikey");
     if (!url.empty()) {
         load_printer_url(url, apikey);

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -3287,7 +3287,9 @@ void Sidebar::update_all_preset_comboboxes()
                                  : MainFrame::PrintSelectType::eSendGcode;
         }
 
-        if (!use_native_device_tab || use_printer_agents)
+        if (use_printer_agents)
+            p_mainframe->load_printer_url();
+        else if (!use_native_device_tab)
             p_mainframe->load_printer_url(url, apikey);
 
 
@@ -11236,9 +11238,14 @@ void Plater::priv::on_tab_selection_changing(wxBookCtrlEvent& e)
             }
         }
     } else {
-        if (new_sel == MainFrame::tpMonitor && wxGetApp().preset_bundle != nullptr) {
+        const bool selecting_web_device_tab = main_frame->m_printer_view &&
+            main_frame->m_tabpanel->GetPage(new_sel) == main_frame->m_printer_view;
+        if (selecting_web_device_tab) {
+            // Use the selected discovered machine when the preset has no host.
+            main_frame->load_printer_url();
+        } else if (new_sel == MainFrame::tpMonitor && wxGetApp().preset_bundle != nullptr) {
             auto     cfg = wxGetApp().preset_bundle->printers.get_edited_preset().config;
-            wxString url = cfg.opt_string("print_host_webui").empty() ? cfg.opt_string("print_host") : cfg.opt_string("print_host_webui");
+            wxString url = from_u8(PrintHost::get_print_host_webui(&cfg));
             if (main_frame->m_printer_view && url.empty()) {
                 // It's missing_connection page, reload so that we can replay the gif image
                 main_frame->m_printer_view->reload();

--- a/src/slic3r/GUI/ReleaseNote.cpp
+++ b/src/slic3r/GUI/ReleaseNote.cpp
@@ -1991,7 +1991,7 @@ void InputIpAddressDialog::workerThreadFunc(std::string str_ip, std::string str_
         if (w.expired()) return;
 
         if (m_obj) {
-            m_obj->set_user_access_code(str_access_code);
+            m_obj->set_access_code(str_access_code);
             wxGetApp().getDeviceManager()->set_selected_machine(m_obj->get_dev_id());
         }
 
@@ -2055,6 +2055,11 @@ void InputIpAddressDialog::on_text(wxCommandEvent &evt)
 {
     auto str_ip              = m_input_ip->GetTextCtrl()->GetValue();
     auto str_access_code     = m_input_access_code->GetTextCtrl()->GetValue();
+
+    if (str_access_code.empty()) {
+        str_access_code = "88888888";
+    }
+
     auto str_name            = m_input_printer_name->GetTextCtrl()->GetValue().Strip(wxString::both);
     auto str_sn              = m_input_sn->GetTextCtrl()->GetValue().Strip(wxString::both);
     bool invalid_access_code = true;
@@ -2062,7 +2067,7 @@ void InputIpAddressDialog::on_text(wxCommandEvent &evt)
     for (char c : str_access_code) {
         if (!(('0' <= c && c <= '9') || ('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z'))) {
             invalid_access_code = false;
-            return;
+            break;
         }
     }
 

--- a/src/slic3r/GUI/SelectMachinePop.cpp
+++ b/src/slic3r/GUI/SelectMachinePop.cpp
@@ -704,7 +704,6 @@ void SelectMachinePopup::update_user_devices()
                     }
 
                     mobj->set_access_code("");
-                    mobj->erase_user_access_code();
                 }
 
                 if (GUI::wxGetApp().plater())

--- a/src/slic3r/Utils/MoonrakerPrinterAgent.cpp
+++ b/src/slic3r/Utils/MoonrakerPrinterAgent.cpp
@@ -1359,7 +1359,6 @@ void MoonrakerPrinterAgent::announce_printhost_device()
     if (auto* app_config = GUI::wxGetApp().app_config) {
         const std::string access_code = device_info.api_key.empty() ? "88888888" : device_info.api_key;
         app_config->set_str("access_code", device_info.dev_id, access_code);
-        app_config->set_str("user_access_code", device_info.dev_id, access_code);
     }
 
     nlohmann::json payload;


### PR DESCRIPTION
# Description
Merged duplicate `access_code` and `user_access_code` into one
Changed UI to allow empty string as access code (optional access code)
Fixed minor issue that didn't propagate machine IP and default print host to the Device (Web) tab.

# Screenshots/Recordings/Graphs

https://github.com/user-attachments/assets/8c8562a4-ad0c-4f03-99ea-74e8d96833c3



# Testing
For reference, I tested with a plugin based on the [elegoo-link](https://github.com/elegoo-repo/elegoo-link) 
It's not fully functional, but basic features such as moving the nozzle and getting status updates seem to work fine.
[elegoo-link-plugin.py](https://github.com/user-attachments/files/30742892/elegoo-link-plugin.py)

<!--
> A guide for users on how to download the artifacts from this PR.
-->

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
