### PR TITLE
fix: Restrict upload targets to printable 'gcodes' root only

### DIFF
--- a/src/slic3r/Utils/Moonraker.cpp
+++ b/src/slic3r/Utils/Moonraker.cpp
@@ -155,6 +155,10 @@ bool Moonraker::get_storage(wxArrayString &storage_path, wxArrayString &storage_
                 const std::string &perms = child.second.get<std::string>("permissions", "");
                 if (root.empty() || perms.find('w') == std::string::npos)
                     continue;
+                //ORCA: only the "gcodes" root can hold printable files; "config" or "logs"
+                //      would silently accept an upload the printer never prints.
+                if (root != "gcodes")
+                    continue;
                 storage_path.Add(wxString::FromUTF8(root));
                 storage_name.Add(wxString::FromUTF8(root));
                 got_any = true;
@@ -168,6 +172,13 @@ bool Moonraker::get_storage(wxArrayString &storage_path, wxArrayString &storage_
 #endif
     .perform_sync();
 
+    //ORCA: with "gcodes" as the only valid target there is nothing to choose, so report no
+    //      storage and let the dialog hide the picker; upload() already defaults to "gcodes".
+    if (storage_path.GetCount() <= 1) {
+        storage_path.Clear();
+        storage_name.Clear();
+        return false;
+    }
     return got_any;
 }
 


### PR DESCRIPTION
## Problem
 
`Moonraker::get_storage()` enumerates every writable root reported by
`/server/files/roots`, so the send dialog offers `config`, `logs` and `docs` alongside
`gcodes`. None of those can hold a printable file, and `config` sorts first, so it is easy
to upload a job to a location the printer will never read the upload reports success and
nothing happens.
 
## Fix
 
Keep only the `gcodes` root. Since that leaves a single option, report no storage at all so
the picker is hidden entirely; `upload()` already falls back to the `gcodes` root when no
storage is selected, so behaviour is unchanged for everyone else.

**Storage target restrictions and UI improvements:**

* Restricted storage targets to only allow the `"gcodes"` root for printable files, preventing uploads to `"config"` or `"logs"` which would not be printable.
* Improved the UI logic so that if only `"gcodes"` is available, the storage picker is hidden and no storage is reported, since uploads already default to `"gcodes"`.
 
## Tests
 
Verified against Moonraker `v0.10` on a Creality K1 SE and K1C: before, the dialog showed a
storage dropdown defaulting to `config`; after, the dropdown is gone and uploads land in
`gcodes` as expected.
This pull request updates the logic for handling storage targets in the `Moonraker::get_storage` method to ensure only valid storage locations are selectable for printable files. The main focus is to restrict uploads to the `"gcodes"` root and improve the user experience when only one storage option is available.


 