### PR TITLE
feat(moonraker): map project filaments to Creality CFS slots when sending

### DIFF
--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -17319,6 +17319,77 @@ void Plater::send_gcode_legacy(int plate_idx, Export3mfProgressFn proFn)
                                                                    supports_material_station,
                                                                    std::move(slots),
                                                                    project_filaments);
+        } else if (host_type == htMoonraker) {
+            // ORCA-CFS: If the rooted Klipper printer exposes a Creality Filament System, show the
+            //           CFS slot-mapping dialog; otherwise fall back to the generic send dialog.
+            auto* moonraker_host = dynamic_cast<Moonraker*>(upload_job.printhost.get());
+            std::vector<CFSSlot> cfs_slots;
+            bool                 supports_cfs = false;
+            if (moonraker_host != nullptr) {
+                wxBusyCursor wait;
+                wxString     msg;
+                if (!moonraker_host->fetch_cfs_slots(cfs_slots, &supports_cfs, msg))
+                    supports_cfs = false; // non-fatal: no CFS / unreachable -> generic dialog
+            }
+
+            if (moonraker_host != nullptr && supports_cfs) {
+            std::vector<FilamentInfo> project_filaments;
+            PlateDataPtrs               plate_data_list;
+            DynamicPrintConfig          cfg                 = wxGetApp().preset_bundle->full_config();
+            const auto*                 filament_color      = dynamic_cast<const ConfigOptionStrings*>(cfg.option("filament_colour"));
+            const auto*                 filament_id_opt     = dynamic_cast<const ConfigOptionStrings*>(cfg.option("filament_ids"));
+            const int                   resolved_plate_idx  = plate_idx == PLATE_CURRENT_IDX ? get_partplate_list().get_curr_plate_index() : plate_idx;
+            auto enrich_project_filaments = [&](std::vector<FilamentInfo>& filaments) {
+                for (auto& filament : filaments) {
+                    if (filament.id < 0)
+                        continue;
+
+                    std::string display_filament_type;
+                    try {
+                        filament.type = cfg.get_filament_type(display_filament_type, filament.id);
+                    } catch (...) {
+                    }
+
+                    if (filament.type.empty())
+                        filament.type = display_filament_type;
+                    if (filament.type.empty())
+                        filament.type = "Unknown";
+
+                    filament.filament_id = filament_id_opt ? filament_id_opt->get_at(static_cast<size_t>(filament.id)) : "";
+                    filament.color       = filament_color ? filament_color->get_at(static_cast<size_t>(filament.id)) : "#FFFFFF";
+                    if (filament.color.empty())
+                        filament.color = "#FFFFFF";
+                }
+            };
+
+            p->partplate_list.store_to_3mf_structure(plate_data_list, true, plate_idx);
+            PlateData* selected_plate_data = (resolved_plate_idx >= 0 && resolved_plate_idx < static_cast<int>(plate_data_list.size())) ? plate_data_list[resolved_plate_idx] : nullptr;
+            if (selected_plate_data == nullptr && !plate_data_list.empty())
+                selected_plate_data = plate_data_list.front();
+
+            if (selected_plate_data != nullptr)
+                project_filaments = selected_plate_data->slice_filaments_info;
+
+            if (project_filaments.empty()) {
+                if (PartPlate* plate = get_partplate_list().get_plate(resolved_plate_idx); plate != nullptr)
+                    project_filaments = plate->get_slice_filaments_info();
+            }
+
+            if (!project_filaments.empty())
+                enrich_project_filaments(project_filaments);
+            release_PlateData_list(plate_data_list);
+
+                pDlg = std::make_unique<MoonrakerCFSPrintHostSendDialog>(default_output_file, upload_job.printhost->get_post_upload_actions(), groups,
+                                                                         storage_paths, storage_names,
+                                                                         config->get_bool("open_device_tab_post_upload"),
+                                                                         moonraker_host,
+                                                                         supports_cfs,
+                                                                         std::move(cfs_slots),
+                                                                         project_filaments);
+            } else {
+                pDlg = std::make_unique<PrintHostSendDialog>(default_output_file, upload_job.printhost->get_post_upload_actions(), groups,
+                                                             storage_paths, storage_names, config->get_bool("open_device_tab_post_upload"));
+            }
         } else {
             pDlg = std::make_unique<PrintHostSendDialog>(default_output_file, upload_job.printhost->get_post_upload_actions(), groups,
                                                          storage_paths, storage_names, config->get_bool("open_device_tab_post_upload"));

--- a/src/slic3r/GUI/PrintHostDialogs.cpp
+++ b/src/slic3r/GUI/PrintHostDialogs.cpp
@@ -1,4 +1,5 @@
 #include "PrintHostDialogs.hpp"
+#include <set>
 
 #include <algorithm>
 #include <cctype>
@@ -30,6 +31,9 @@
 #include "GUI_App.hpp"
 #include "MsgDialog.hpp"
 #include "I18N.hpp"
+#include "../Utils/CrealityMaterialCatalog.hpp"
+#include "libslic3r/PresetBundle.hpp"
+#include "libslic3r/Preset.hpp"
 #include "MainFrame.hpp"
 #include "libslic3r/AppConfig.hpp"
 #include "NotificationManager.hpp"
@@ -519,7 +523,7 @@ void PrintHostSendDialog::init()
             if (msg_wingow.ShowModal() == wxID_NO)
                 return false;
         }
-        return true;
+        return validate_before_send();
     };
 
     auto* btn_ok = add_button(wxID_OK, true, _L("Upload"));
@@ -1162,6 +1166,451 @@ wxColour FlashforgePrintHostSendDialog::to_wx_colour(const std::string& color) c
     }
 
     return wxColour("#999999");
+}
+
+// ============================ ORCA-CFS: Moonraker CFS send dialog ============================
+
+std::vector<Slic3r::FlashforgeMaterialSlot> MoonrakerCFSPrintHostSendDialog::to_ui_slots(const std::vector<Slic3r::CFSSlot>& cfs)
+{
+    // Reuse the Flashforge slot widgets: convert CFSSlot -> FlashforgeMaterialSlot. The widgets use
+    // slot_id<=0 as "unselected", and the CFS global index is 0-based (T1A=0), so we store id+1 here
+    // and subtract 1 again in extendedInfo() when emitting the firmware-facing mapping.
+    std::vector<Slic3r::FlashforgeMaterialSlot> out;
+    out.reserve(cfs.size());
+    for (const auto& s : cfs) {
+        Slic3r::FlashforgeMaterialSlot u;
+        u.slot_id        = s.slot_id + 1;
+        u.has_filament   = s.has_filament;
+        u.material_name  = s.material_name;
+        u.material_color = s.material_color;
+        out.push_back(u);
+    }
+    return out;
+}
+
+MoonrakerCFSPrintHostSendDialog::MoonrakerCFSPrintHostSendDialog(const fs::path&             path,
+                                                                 PrintHostPostUploadActions  post_actions,
+                                                                 const wxArrayString&        groups,
+                                                                 const wxArrayString&        storage_paths,
+                                                                 const wxArrayString&        storage_names,
+                                                                 bool                        switch_to_device_tab,
+                                                                 const Slic3r::Moonraker*    host,
+                                                                 bool                        supports_cfs,
+                                                                 std::vector<Slic3r::CFSSlot> cfs_slots,
+                                                                 const std::vector<FilamentInfo>& project_filaments)
+    : PrintHostSendDialog(path, post_actions, groups, storage_paths, storage_names, switch_to_device_tab)
+    , m_host(host)
+    , m_slots(to_ui_slots(cfs_slots))
+    , m_cfs_slots(cfs_slots)
+    , m_project_filaments(project_filaments)
+{
+    m_supports_cfs = supports_cfs;
+    m_slots_loaded = !m_slots.empty();
+}
+
+void MoonrakerCFSPrintHostSendDialog::init()
+{
+    // Default the mapping to ON when the printer actually reports a CFS unit.
+    m_use_cfs = m_supports_cfs;
+
+    // Filename field, directory hint, "switch to Device tab" checkbox and the
+    // Upload / Upload and Print / Cancel buttons are all built by the base dialog.
+    // We only append the CFS section below; validation is hooked through
+    // validate_before_send().
+    PrintHostSendDialog::init();
+
+    this->SetMinSize(wxSize(560, 420));
+
+    m_cfs_options_sizer = new wxBoxSizer(wxVERTICAL);
+
+    {
+        auto row       = new wxBoxSizer(wxHORIZONTAL);
+        m_checkbox_cfs = new ::CheckBox(this);
+        m_checkbox_cfs->SetValue(m_use_cfs);
+        m_checkbox_cfs->Bind(wxEVT_TOGGLEBUTTON, [this](wxCommandEvent& e) {
+            auto* source = dynamic_cast<::CheckBox*>(e.GetEventObject());
+            if (source != nullptr)
+                source->SetValue(e.IsChecked());
+            m_use_cfs = e.IsChecked();
+            if (m_use_cfs) {
+                ensure_slots_loaded();
+                rebuild_mapping_rows();
+            }
+            sync_mapping_section_visibility();
+            e.Skip();
+        });
+        row->Add(m_checkbox_cfs, 0, wxALL | wxALIGN_CENTER, FromDIP(2));
+
+        auto text = new wxStaticText(this, wxID_ANY, _L("Use CFS (auto filament mapping)"));
+        text->SetFont(::Label::Body_13);
+        text->SetForegroundColour(StateColor::darkModeColorFor(wxColour("#323A3D")));
+        row->Add(text, 0, wxALL | wxALIGN_CENTER, FromDIP(2));
+        m_cfs_options_sizer->Add(row);
+        m_cfs_options_sizer->AddSpacer(FromDIP(6));
+    }
+
+    if (m_checkbox_cfs != nullptr && !m_supports_cfs)
+        m_checkbox_cfs->Enable(false);
+
+    m_status_text = new wxStaticText(this, wxID_ANY, wxEmptyString);
+    m_status_text->SetFont(::Label::Body_12);
+    m_cfs_options_sizer->Add(m_status_text, 0, wxTOP | wxBOTTOM, FromDIP(4));
+
+    m_mapping_section_sizer = new wxBoxSizer(wxVERTICAL);
+    m_mapping_wrap_sizer    = new wxWrapSizer(wxHORIZONTAL, wxWRAPSIZER_DEFAULT_FLAGS);
+    m_mapping_section_sizer->Add(m_mapping_wrap_sizer, 0, wxTOP | wxALIGN_LEFT, FromDIP(10));
+    m_cfs_options_sizer->Add(m_mapping_section_sizer, 0, wxEXPAND);
+
+    content_sizer->Add(m_cfs_options_sizer, 0, wxEXPAND);
+
+    if (m_supports_cfs)
+        m_status_text->SetLabel(wxString::Format(_L("Detected %d CFS slots on printer."), static_cast<int>(m_slots.size())));
+    else
+        m_status_text->SetLabel(_L("This printer does not report a CFS unit."));
+
+    rebuild_mapping_rows();
+    sync_mapping_section_visibility();
+}
+
+void MoonrakerCFSPrintHostSendDialog::EndModal(int ret)
+{
+    if (ret == wxID_OK) {
+        AppConfig* app_config = wxGetApp().app_config;
+        app_config->set("recent", CONFIG_KEY_CFS, m_use_cfs ? "1" : "0");
+    }
+    PrintHostSendDialog::EndModal(ret);
+}
+
+std::map<std::string, std::string> MoonrakerCFSPrintHostSendDialog::extendedInfo() const
+{
+    // Emit the firmware-facing mapping consumed by Moonraker::upload():
+    //   cfs_enabled = "1"/"0"
+    //   cfs_map     = "<toolId>:<globalSlot>,..."   (globalSlot is 0-based: UI slot_id - 1)
+    std::string cfs_map;
+    if (m_use_cfs) {
+        for (const auto& row : m_mapping_rows) {
+            auto* card = as_ff_map_widget(row.card);
+            if (card == nullptr || row.tool_id < 0)
+                continue;
+            const int ui_slot_id = card->selected_slot_id();
+            if (ui_slot_id <= 0)
+                continue;
+            if (!cfs_map.empty())
+                cfs_map += ",";
+            cfs_map += std::to_string(row.tool_id) + ":" + std::to_string(ui_slot_id - 1);
+        }
+    }
+
+    return {
+        {"cfs_enabled", m_use_cfs ? "1" : "0"},
+        {"cfs_map",     cfs_map}
+    };
+}
+
+void MoonrakerCFSPrintHostSendDialog::load_slots()
+{
+    m_slots.clear();
+    m_slots_loaded = false;
+    m_supports_cfs = false;
+
+    if (m_host == nullptr) {
+        m_status_text->SetLabel(_L("Moonraker host is not available."));
+        return;
+    }
+
+    wxString msg;
+    bool     supports_cfs = false;
+    std::vector<Slic3r::CFSSlot> cfs_slots;
+    if (!m_host->fetch_cfs_slots(cfs_slots, &supports_cfs, msg)) {
+        m_status_text->SetLabel(msg.empty() ? _L("Unable to read CFS slots from printer.") : msg);
+        return;
+    }
+
+    m_slots        = to_ui_slots(cfs_slots);
+    m_supports_cfs = supports_cfs;
+    m_slots_loaded = !m_slots.empty();
+    m_use_cfs      = m_supports_cfs;
+
+    if (m_supports_cfs)
+        m_status_text->SetLabel(wxString::Format(_L("Detected %d CFS slots on printer."), static_cast<int>(m_slots.size())));
+    else
+        m_status_text->SetLabel(_L("This printer does not report a CFS unit."));
+}
+
+bool MoonrakerCFSPrintHostSendDialog::ensure_slots_loaded(bool force_reload)
+{
+    if (!force_reload && (m_slots_loaded || !m_supports_cfs))
+        return m_slots_loaded;
+    if (m_status_text != nullptr)
+        m_status_text->SetLabel(_L("Loading CFS slots from printer..."));
+    wxBusyCursor wait;
+    load_slots();
+    return m_slots_loaded;
+}
+
+void MoonrakerCFSPrintHostSendDialog::rebuild_mapping_rows()
+{
+    if (m_mapping_wrap_sizer == nullptr)
+        return;
+
+    m_mapping_wrap_sizer->Clear(true);
+    m_mapping_rows.clear();
+
+    if (m_project_filaments.empty()) {
+        m_mapping_wrap_sizer->Add(new wxStaticText(this, wxID_ANY, _L("Slice the plate first to get project material information.")), 0, wxALL, FromDIP(2));
+        return;
+    }
+
+    for (const auto& filament : m_project_filaments) {
+        auto* card = new FlashforgeMaterialMapWidget(this, filament.id, to_wx_colour(filament.color), from_u8(filament.get_display_filament_type()),
+                                                     [this](FlashforgeMaterialMapWidget* changed_card) {
+                                                         if (changed_card == nullptr)
+                                                             return;
+                                                         for (auto& row : m_mapping_rows) {
+                                                             if (row.card == changed_card) {
+                                                                 refresh_mapping_card(row);
+                                                                 break;
+                                                             }
+                                                         }
+                                                     });
+        m_mapping_wrap_sizer->Add(card, 0, wxRIGHT | wxBOTTOM | wxFIXED_MINSIZE, FromDIP(10));
+
+        MappingRow row;
+        row.tool_id = filament.id;
+        row.card    = card;
+        m_mapping_rows.push_back(row);
+    }
+
+    auto_assign_mappings();
+}
+
+std::string MoonrakerCFSPrintHostSendDialog::resolve_slot_filament_id(const Slic3r::CFSSlot& slot) const
+{
+    std::string vendor, product, type;
+    if (slot.material_code.empty() ||
+        !Slic3r::creality_cfs_lookup(slot.material_code, vendor, product, type))
+        return {};
+    auto* pb = wxGetApp().preset_bundle;
+    if (pb == nullptr)
+        return {};
+
+    // Score visible/compatible filament presets of the same base type by how well
+    // the preset name matches the catalogue product + vendor; prefer system presets.
+    const std::string v = boost::to_lower_copy(vendor);
+    const std::string p = boost::to_lower_copy(product);
+    const std::string t = boost::to_lower_copy(type);
+
+    const Slic3r::Preset* best = nullptr;
+    int  best_score = 0;
+    bool best_user  = true;
+    for (const auto& pr : pb->filaments.get_presets()) {
+        if (!pr.is_visible || !pr.is_compatible)
+            continue;
+        std::string ptype;
+        if (const auto* ft = pr.config.option<ConfigOptionStrings>("filament_type"))
+            if (!ft->values.empty()) ptype = ft->values.front();
+        if (boost::to_lower_copy(ptype) != t)
+            continue;
+        const std::string nm = boost::to_lower_copy(pr.name);
+        int score = 0;
+        if (!p.empty() && nm.find(p) != std::string::npos) score += 20;
+        if (!v.empty() && nm.find(v) != std::string::npos) score += 10;
+        if (score <= 0)
+            continue;
+        const bool is_user = !pr.is_system && !pr.is_default;
+        if (best == nullptr || score > best_score || (score == best_score && best_user && !is_user)) {
+            best = &pr; best_score = score; best_user = is_user;
+        }
+    }
+    return best != nullptr ? best->filament_id : std::string();
+}
+
+void MoonrakerCFSPrintHostSendDialog::auto_assign_mappings()
+{
+    // Each physical slot can only feed one project filament, so remember what we hand out;
+    // otherwise two same-material filaments both grab the closest slot and one is left unmapped.
+    std::set<int> used_slot_ids;
+    for (size_t idx = 0; idx < m_project_filaments.size() && idx < m_mapping_rows.size(); ++idx) {
+        auto& filament = m_project_filaments[idx];
+        auto* card     = as_ff_map_widget(m_mapping_rows[idx].card);
+        if (card == nullptr)
+            continue;
+
+        const wxColour filament_color = to_wx_colour(filament.color);
+        const Slic3r::FlashforgeMaterialSlot* best_slot = nullptr;
+        long long best_distance = std::numeric_limits<long long>::max();
+        bool      best_exact    = false;
+
+        // m_slots and m_cfs_slots are parallel (same order); use the index to reach
+        // the original CFSSlot, which carries the Creality filamentId for catalogue
+        // resolution.
+        for (size_t si = 0; si < m_slots.size(); ++si) {
+            const auto& slot = m_slots[si];
+            if (!slot.has_filament || !slot_matches_filament(slot, filament))
+                continue;
+            if (used_slot_ids.count(slot.slot_id) != 0)
+                continue;
+
+            // Exact-product match: resolve the slot's filamentId to a preset and
+            // compare with the project filament's preset id. Beats nearest-colour.
+            bool exact = false;
+            if (si < m_cfs_slots.size() && !filament.filament_id.empty()) {
+                const std::string slot_fid = resolve_slot_filament_id(m_cfs_slots[si]);
+                exact = (!slot_fid.empty() && slot_fid == filament.filament_id);
+            }
+
+            const long long distance = color_distance_sq(filament_color, to_wx_colour(slot.material_color));
+            const bool better = (best_slot == nullptr)
+                             || (exact && !best_exact)
+                             || (exact == best_exact && distance < best_distance);
+            if (better) {
+                best_slot     = &slot;
+                best_distance = distance;
+                best_exact    = exact;
+            }
+        }
+
+        if (best_slot != nullptr) {
+            card->set_slot_selection(best_slot->slot_id, to_wx_colour(best_slot->material_color));
+            used_slot_ids.insert(best_slot->slot_id);
+        } else {
+            card->reset_slot();
+        }
+
+        refresh_mapping_card(m_mapping_rows[idx]);
+    }
+}
+
+void MoonrakerCFSPrintHostSendDialog::refresh_mapping_card(MappingRow& row)
+{
+    auto* card = as_ff_map_widget(row.card);
+    if (card == nullptr)
+        return;
+
+    const auto* filament = find_filament_by_tool_id(row.tool_id);
+    card->set_enable_mapping(m_use_cfs);
+    card->update_popup_slots(m_slots, [this, filament](const FlashforgeMaterialSlot& slot) {
+        return filament != nullptr && slot_matches_filament(slot, *filament);
+    });
+
+    if (card->selected_slot_id() <= 0) {
+        card->reset_slot();
+        return;
+    }
+
+    const auto* slot = find_slot_by_id(std::to_string(card->selected_slot_id()));
+    if (slot == nullptr) {
+        card->reset_slot();
+        return;
+    }
+    card->set_slot_selection(slot->slot_id, to_wx_colour(slot->material_color));
+}
+
+void MoonrakerCFSPrintHostSendDialog::sync_mapping_section_visibility()
+{
+    if (m_mapping_section_sizer == nullptr)
+        return;
+
+    m_mapping_section_sizer->ShowItems(m_use_cfs && m_supports_cfs);
+    if (wxSizer* sizer = GetSizer(); sizer != nullptr) {
+        sizer->Layout();
+        sizer->Fit(this);
+        SetMinSize(GetBestSize());
+    }
+    Layout();
+    Fit();
+}
+
+const Slic3r::FlashforgeMaterialSlot* MoonrakerCFSPrintHostSendDialog::find_slot_by_id(const std::string& slot_id_text) const
+{
+    const auto slot_it = std::find_if(m_slots.begin(), m_slots.end(), [&](const FlashforgeMaterialSlot& slot) { return std::to_string(slot.slot_id) == slot_id_text; });
+    return slot_it == m_slots.end() ? nullptr : &(*slot_it);
+}
+
+const FilamentInfo* MoonrakerCFSPrintHostSendDialog::find_filament_by_tool_id(int tool_id) const
+{
+    const auto filament_it = std::find_if(m_project_filaments.begin(), m_project_filaments.end(), [&](const FilamentInfo& filament) { return filament.id == tool_id; });
+    return filament_it == m_project_filaments.end() ? nullptr : &(*filament_it);
+}
+
+bool MoonrakerCFSPrintHostSendDialog::slot_matches_filament(const Slic3r::FlashforgeMaterialSlot& slot, const FilamentInfo& filament) const
+{
+    if (!slot.has_filament)
+        return false;
+    const std::string project_material = normalize_material(!filament.type.empty() ? filament.type : filament.get_display_filament_type());
+    const std::string slot_material    = normalize_material(slot.material_name);
+    return !project_material.empty() && !slot_material.empty() && project_material == slot_material;
+}
+
+bool MoonrakerCFSPrintHostSendDialog::validate_before_send()
+{
+    if (!m_use_cfs && m_project_filaments.size() > 1) {
+        show_error(this, _L("This plate uses multiple materials. Enable CFS and assign each tool to a printer slot."));
+        return false;
+    }
+    if (!m_use_cfs)
+        return true;
+
+    for (const auto& row : m_mapping_rows) {
+        auto* card = as_ff_map_widget(row.card);
+        if (card == nullptr || !card->is_slot_selected()) {
+            show_error(this, _L("Each project material must be assigned to a CFS slot before printing."));
+            return false;
+        }
+        const auto* slot     = find_slot_by_id(std::to_string(card->selected_slot_id()));
+        const auto* filament = find_filament_by_tool_id(row.tool_id);
+        if (slot == nullptr || filament == nullptr || !slot->has_filament) {
+            show_error(this, _L("Each project material must be assigned to a loaded CFS slot before printing."));
+            return false;
+        }
+        if (!slot_matches_filament(*slot, *filament)) {
+            show_error(this, _L("Each project material must match the material loaded in the selected CFS slot."));
+            return false;
+        }
+    }
+    return true;
+}
+
+std::string MoonrakerCFSPrintHostSendDialog::normalize_material(const std::string& material) const
+{
+    std::string normalized = boost::to_upper_copy(material);
+    normalized.erase(std::remove_if(normalized.begin(), normalized.end(), [](unsigned char ch) { return !std::isalnum(ch); }), normalized.end());
+    if (normalized.empty())
+        return {};
+    if (normalized.find("SILK") != std::string::npos)
+        return "SILK";
+    if (normalized.find("PLA") != std::string::npos && normalized.find("CF") != std::string::npos)
+        return "PLACF";
+    if (normalized.find("PETG") != std::string::npos && normalized.find("CF") != std::string::npos)
+        return "PETGCF";
+    if (normalized == "PLA" || normalized == "PLA+" || normalized == "PLAPLUS")
+        return "PLA";
+    if (normalized.find("PLA") != std::string::npos)
+        return "PLA";
+    if (normalized == "ABS" || normalized.find("ABS") != std::string::npos)
+        return "ABS";
+    if (normalized == "ASA" || normalized.find("ASA") != std::string::npos)
+        return "ABS";
+    if (normalized.find("PETG") != std::string::npos)
+        return "PETG";
+    if (normalized.find("TPU") != std::string::npos || normalized.find("TPE") != std::string::npos || normalized.find("FLEX") != std::string::npos)
+        return "TPU";
+    return normalized;
+}
+
+wxColour MoonrakerCFSPrintHostSendDialog::to_wx_colour(const std::string& color) const
+{
+    std::string normalized = boost::trim_copy(color);
+    if (boost::istarts_with(normalized, "0x"))
+        normalized = normalized.substr(2);
+    if (!normalized.empty() && normalized.front() == '#')
+        normalized.erase(normalized.begin());
+    if (!normalized.empty() && normalized.front() != '#')
+        normalized = "#" + normalized;
+    wxColour wx_color(from_u8(normalized));
+    if (wx_color.IsOk())
+        return wx_color;
+    return *wxWHITE;
 }
 
 wxDEFINE_EVENT(EVT_PRINTHOST_PROGRESS, PrintHostQueueDialog::Event);

--- a/src/slic3r/GUI/PrintHostDialogs.hpp
+++ b/src/slic3r/GUI/PrintHostDialogs.hpp
@@ -13,6 +13,7 @@
 #include "MsgDialog.hpp"
 #include "../Utils/PrintHost.hpp"
 #include "../Utils/Flashforge.hpp"
+#include "../Utils/Moonraker.hpp"
 #include "libslic3r/PrintConfig.hpp"
 #include "libslic3r/ProjectTask.hpp"
 class wxButton;
@@ -45,6 +46,10 @@ public:
     virtual void EndModal(int ret) override;
     virtual void init();
     virtual std::map<std::string, std::string> extendedInfo() const { return {}; }
+    // Extra validation run by init()'s Upload / Upload and Print handlers, after the filename
+    // suffix check. Subclasses that add their own controls (e.g. filament-to-slot mapping)
+    // override this to block sending until their input is complete. Default: nothing to check.
+    virtual bool validate_before_send() { return true; }
 
 protected:
     wxTextCtrl *txt_filename;
@@ -277,6 +282,68 @@ private:
     const char* CONFIG_KEY_LEVELING  = "flashforge_leveling_before_print";
     const char* CONFIG_KEY_TIMELAPSE = "flashforge_timelapse_video";
     const char* CONFIG_KEY_IFS       = "flashforge_use_material_station";
+};
+
+
+// ORCA-CFS: Send dialog for rooted Creality K1/K1C/K1 SE/K1 Max over Moonraker, with Creality
+// Filament System (CFS) slot mapping. Reuses the Flashforge slot widgets by storing UI slots as
+// FlashforgeMaterialSlot with slot_id = (CFS global slot)+1 (the widgets treat id<=0 as unselected).
+// Mapping is emitted as extended_info {"cfs_enabled","cfs_map"} consumed by Moonraker::upload().
+class MoonrakerCFSPrintHostSendDialog : public PrintHostSendDialog
+{
+public:
+    MoonrakerCFSPrintHostSendDialog(const boost::filesystem::path&  path,
+                                    PrintHostPostUploadActions      post_actions,
+                                    const wxArrayString&            groups,
+                                    const wxArrayString&            storage_paths,
+                                    const wxArrayString&            storage_names,
+                                    bool                            switch_to_device_tab,
+                                    const Slic3r::Moonraker*        host,
+                                    bool                            supports_cfs,
+                                    std::vector<Slic3r::CFSSlot>    cfs_slots,
+                                    const std::vector<FilamentInfo>& project_filaments);
+
+    virtual void init() override;
+    virtual void EndModal(int ret) override;
+    virtual std::map<std::string, std::string> extendedInfo() const override;
+
+private:
+    struct MappingRow { int tool_id {-1}; wxWindow* card {nullptr}; };
+
+    void load_slots();
+    bool ensure_slots_loaded(bool force_reload = false);
+    void rebuild_mapping_rows();
+    void auto_assign_mappings();
+    void refresh_mapping_card(MappingRow& row);
+    void sync_mapping_section_visibility();
+    const Slic3r::FlashforgeMaterialSlot* find_slot_by_id(const std::string& slot_id_text) const;
+    const FilamentInfo* find_filament_by_tool_id(int tool_id) const;
+    bool slot_matches_filament(const Slic3r::FlashforgeMaterialSlot& slot, const FilamentInfo& filament) const;
+    bool validate_before_send() override;
+    std::string normalize_material(const std::string& material) const;
+    // Resolve a CFS slot's Creality filamentId to an Orca filament preset id via the
+    // material catalogue + preset bundle. Empty when unknown. Used to prefer an
+    // exact-product match in auto-assign over nearest-colour.
+    std::string resolve_slot_filament_id(const Slic3r::CFSSlot& slot) const;
+    wxColour to_wx_colour(const std::string& color) const;
+    static std::vector<Slic3r::FlashforgeMaterialSlot> to_ui_slots(const std::vector<Slic3r::CFSSlot>& cfs);
+
+private:
+    const Slic3r::Moonraker*         m_host {nullptr};
+    std::vector<FilamentInfo>        m_project_filaments;
+    std::vector<Slic3r::FlashforgeMaterialSlot> m_slots; // UI slots; slot_id = CFS global + 1
+    std::vector<Slic3r::CFSSlot>     m_cfs_slots;         // original CFS slots (carry filamentId)
+    std::vector<MappingRow>          m_mapping_rows;
+    wxBoxSizer*                      m_cfs_options_sizer {nullptr};
+    wxBoxSizer*                      m_mapping_section_sizer {nullptr};
+    wxWrapSizer*                     m_mapping_wrap_sizer {nullptr};
+    wxStaticText*                    m_status_text {nullptr};
+    ::CheckBox*                      m_checkbox_cfs {nullptr};
+    bool                             m_use_cfs {false};
+    bool                             m_supports_cfs {false};
+    bool                             m_slots_loaded {false};
+
+    const char* CONFIG_KEY_CFS = "moonraker_use_cfs";
 };
 
 wxDECLARE_EVENT(EVT_PRINTHOST_PROGRESS, PrintHostQueueDialog::Event);

--- a/src/slic3r/Utils/CrealityMaterialCatalog.hpp
+++ b/src/slic3r/Utils/CrealityMaterialCatalog.hpp
@@ -1,0 +1,118 @@
+#ifndef slic3r_CrealityMaterialCatalog_hpp_
+#define slic3r_CrealityMaterialCatalog_hpp_
+
+#include <map>
+#include <string>
+
+namespace Slic3r {
+
+// Maps a Creality CFS `filamentId` to (vendor, product, base type).
+//
+// The CFS `box` object / MIFARE tag report a numeric filamentId (e.g. "103001").
+// Its last 5 digits are the catalogue id (the leading digit is a printer-series
+// prefix). Resolving the code to the exact product ("Hyper PLA", "CR-PLA Matte",
+// ...) lets auto-assign pick the precise filament preset instead of guessing by
+// nearest colour among same-type slots.
+//
+// Source: Creality's on-printer material database
+// (/mnt/UDISK/creality/userdata/box/material_database.json), mirrored by the
+// community K2-RFID project (db/{k1,k2,hi}.json). 66 entries, deduped.
+struct CrealityMaterial { const char* vendor; const char* product; const char* type; };
+
+inline const std::map<std::string, CrealityMaterial>& creality_material_catalog()
+{
+    static const std::map<std::string, CrealityMaterial> tbl = {
+        {"00001", {"Generic", "Generic PLA", "PLA"}},
+        {"00002", {"Generic", "Generic PLA-Silk", "PLA"}},
+        {"00003", {"Generic", "Generic PETG", "PETG"}},
+        {"00004", {"Generic", "Generic ABS", "ABS"}},
+        {"00005", {"Generic", "Generic TPU", "TPU"}},
+        {"00006", {"Generic", "Generic PLA-CF", "PLA-CF"}},
+        {"00007", {"Generic", "Generic ASA", "ASA"}},
+        {"00008", {"Generic", "Generic PA", "PA"}},
+        {"00009", {"Generic", "Generic PA-CF", "PA-CF"}},
+        {"00010", {"Generic", "Generic BVOH", "BVOH"}},
+        {"00011", {"Generic", "Generic PVA", "PVA"}},
+        {"00012", {"Generic", "Generic HIPS", "HIPS"}},
+        {"00013", {"Generic", "Generic PET-CF", "PET-CF"}},
+        {"00014", {"Generic", "Generic PETG-CF", "PETG-CF"}},
+        {"00015", {"Generic", "Generic PA6-CF", "PA6-CF"}},
+        {"00016", {"Generic", "Generic PAHT-CF", "PAHT-CF"}},
+        {"00017", {"Generic", "Generic PPS", "PPS"}},
+        {"00018", {"Generic", "Generic PPS-CF", "PPS-CF"}},
+        {"00019", {"Generic", "Generic PP", "PP"}},
+        {"00020", {"Generic", "Generic PET", "PET"}},
+        {"00021", {"Generic", "Generic PC", "PC"}},
+        {"00022", {"Generic", "Generic PA612-CF", "PA-CF"}},
+        {"00023", {"Generic", "Generic Support for PA", "PA"}},
+        {"00024", {"Generic", "Generic Support for PLA", "PLA"}},
+        {"00025", {"Generic", "Generic PA12-CF", "PA-CF"}},
+        {"00026", {"Generic", "Generic TPU 64D", "TPU"}},
+        {"00027", {"Generic", "Generic PETG-GF", "PETG-GF"}},
+        {"00031", {"Generic", "Generic PP-CF", "PP-CF"}},
+        {"00032", {"Generic", "Generic PCTG", "PCTG"}},
+        {"00033", {"Generic", "Generic ASA-CF", "ASA-CF"}},
+        {"00034", {"Generic", "Generic PA6-GF", "PA-GF"}},
+        {"00035", {"eSUN", "PLA-LW", "PLA"}},
+        {"01001", {"Creality", "Hyper PLA", "PLA"}},
+        {"01002", {"Creality", "Hyper L-W PLA", "PLA"}},
+        {"01004", {"Creality", "Hyper Stardust", "PLA"}},
+        {"01601", {"Creality", "Soleyin Ultra PLA", "PLA"}},
+        {"02001", {"Creality", "Hyper PLA-CF", "PLA-CF"}},
+        {"03001", {"Creality", "Hyper ABS", "ABS"}},
+        {"04001", {"Creality", "CR-PLA", "PLA"}},
+        {"05001", {"Creality", "CR-Silk", "PLA"}},
+        {"06001", {"Creality", "CR-PETG", "PETG"}},
+        {"06002", {"Creality", "Hyper PETG", "PETG"}},
+        {"06003", {"Creality", "Hyper PETG-CF", "PETG-CF"}},
+        {"07001", {"Creality", "CR-ABS", "ABS"}},
+        {"07002", {"Creality", "Hyper PC", "PC"}},
+        {"08001", {"Creality", "Ender-PLA", "PLA"}},
+        {"09001", {"Creality", "EN-PLA+", "PLA"}},
+        {"09002", {"Creality", "ENDER FAST PLA", "PLA"}},
+        {"10001", {"Creality", "HP-TPU", "TPU"}},
+        {"11001", {"Creality", "CR-Nylon", "PA"}},
+        {"12002", {"Creality", "Hyper PPA-CF", "PA-CF"}},
+        {"12003", {"Creality", "Hyper PAHT-CF", "PA-CF"}},
+        {"12004", {"Creality", "Hyper PA612-CF", "PA612-CF"}},
+        {"12005", {"Creality", "Hyper PA6-CF", "PA6-CF"}},
+        {"13001", {"Creality", "CR-PLA Carbon", "PLA-CF"}},
+        {"14001", {"Creality", "CR-PLA Matte", "PLA"}},
+        {"15001", {"Creality", "CR-PLA Fluo", "PLA"}},
+        {"16001", {"Creality", "CR-TPU", "TPU"}},
+        {"17001", {"Creality", "CR-Wood", "PLA"}},
+        {"18001", {"Creality", "HP Ultra PLA", "PLA"}},
+        {"19001", {"Creality", "HP-ASA", "ASA"}},
+        {"29001", {"Creality", "Hyper Marble", "PLA"}},
+        {"E1001", {"eSUN", "PLA+", "PLA"}},
+        {"P1001", {"Polymaker", "Panchroma PLA Satin", "PLA"}},
+        {"P1002", {"Polymaker", "PolySonic PLA Pro", "PLA"}},
+        {"P1003", {"Polymaker", "Panchroma PLA Matte", "PLA"}},
+    };
+    return tbl;
+}
+
+// Resolve a CFS filamentId (5- or 6-digit; the last 5 digits are the catalogue id)
+// to vendor/product/type. Returns false when the code is unknown.
+inline bool creality_cfs_lookup(const std::string& code,
+                                std::string&       vendor,
+                                std::string&       product,
+                                std::string&       type)
+{
+    const auto& tbl = creality_material_catalog();
+    auto try_key = [&](const std::string& k) {
+        auto it = tbl.find(k);
+        if (it == tbl.end()) return false;
+        vendor  = it->second.vendor;
+        product = it->second.product;
+        type    = it->second.type;
+        return true;
+    };
+    if (try_key(code)) return true;
+    if (code.size() > 5 && try_key(code.substr(code.size() - 5))) return true;
+    return false;
+}
+
+} // namespace Slic3r
+
+#endif // slic3r_CrealityMaterialCatalog_hpp_

--- a/src/slic3r/Utils/Moonraker.cpp
+++ b/src/slic3r/Utils/Moonraker.cpp
@@ -1,7 +1,10 @@
 #include "Moonraker.hpp"
 
 #include <sstream>
+#include <fstream>
+#include <algorithm>
 
+#include <boost/filesystem.hpp>
 #include <boost/format.hpp>
 #include <boost/log/trivial.hpp>
 #include <boost/property_tree/ptree.hpp>
@@ -233,6 +236,20 @@ bool Moonraker::upload(PrintHostUpload upload_data, ProgressFn progress_fn, Erro
     //      addition later (storage picker) needs no change to this method.
     const std::string root = upload_data.storage.empty() ? std::string("gcodes") : upload_data.storage;
 
+    //ORCA-CFS: If the send dialog resolved a filament->slot mapping, honour it by rewriting the bare
+    //          tool-change lines (T0/T1/...) in the gcode so each project filament prints from the
+    //          physical CFS slot the user chose. The Creality `box` Klipper module loads slot N when
+    //          it receives Tn (it registers Tn natively; see `t_command`), so remapping tool indices
+    //          is firmware-agnostic and needs no special macro. Identity/empty mapping -> no rewrite.
+    boost::filesystem::path effective_source = upload_data.source_path;
+    if (upload_data.extended("cfs_enabled") == "1") {
+        wxString cfs_msg;
+        if (!apply_cfs_tool_mapping(upload_data.extended("cfs_map"), upload_data.source_path, effective_source, cfs_msg)) {
+            error_fn(std::move(cfs_msg));
+            return false;
+        }
+    }
+
     std::string url = make_url("server/files/upload");
     bool result = true;
     std::string uploaded_path;
@@ -256,7 +273,7 @@ bool Moonraker::upload(PrintHostUpload upload_data, ProgressFn progress_fn, Erro
     http.form_add("root", root);
     if (!plateindex.empty())
         http.form_add("plateindex", plateindex);
-    http.form_add_file("file", upload_data.source_path.string(), upload_filename.string())
+    http.form_add_file("file", effective_source.string(), upload_filename.string())
         .on_complete([&](std::string body, unsigned status) {
             BOOST_LOG_TRIVIAL(debug) << boost::format("%1%: upload HTTP %2%: %3%") % name % status % body;
             try {
@@ -312,6 +329,289 @@ bool Moonraker::upload(PrintHostUpload upload_data, ProgressFn progress_fn, Erro
             error_fn(std::move(start_msg));
             return false;
         }
+    }
+    return true;
+}
+
+
+// ============================ ORCA-CFS: Creality Filament System ============================
+
+bool Moonraker::query_object(const std::string& object, std::string& body_out, wxString& msg) const
+{
+    //ORCA-CFS: GET /printer/objects/query?<object>  ->  {"result":{"status":{<object>:{...}}}}
+    const char* name = get_name();
+    bool res = true;
+    auto url = make_url("printer/objects/query?" + object);
+    auto http = Http::get(std::move(url));
+    set_auth(http);
+    http.on_complete([&](std::string body, unsigned) { body_out = std::move(body); })
+        .on_error([&](std::string body, std::string error, unsigned status) {
+            BOOST_LOG_TRIVIAL(debug) << boost::format("%1%-CFS: query %2% failed: %3% HTTP %4%")
+                % name % object % error % status;
+            res = false;
+            msg = format_error(body, error, status);
+        })
+#ifdef WIN32
+        .ssl_revoke_best_effort(m_ssl_revoke_best_effort)
+#endif
+        .perform_sync();
+    return res;
+}
+
+bool Moonraker::detect_cfs_object(std::string& object_name_out, wxString& msg) const
+{
+    //ORCA-CFS: GET /printer/objects/list -> {"result":{"objects":["box","gcode_macro T0",...]}}.
+    //          The CFS publishes a custom Klipper object; its exact name varies by firmware so we
+    //          match against a candidate list (refined from cfs-moonraker-probe.sh output). The
+    //          first match wins; absence simply means "no CFS" (not an error).
+    //ORCA-CFS: On rooted Creality K1/K1C/K1 SE/K1 Max the CFS publishes a single Klipper object
+    //          literally named "box" (confirmed via probe). Other names (cfs/filament_hub/...) are
+    //          NOT registered objects — querying them just echoes an empty {} — so we match against
+    //          /printer/objects/list, where only "box" appears. Extra candidates kept for forward
+    //          compatibility with other firmwares.
+    static const std::vector<std::string> kCandidates = {
+        "box", "filament_hub", "cfs", "creality_cfs", "material_station"
+    };
+    const char* name = get_name();
+    std::string body;
+    bool res = true;
+    auto url = make_url("printer/objects/list");
+    auto http = Http::get(std::move(url));
+    set_auth(http);
+    http.on_complete([&](std::string b, unsigned) { body = std::move(b); })
+        .on_error([&](std::string b, std::string error, unsigned status) {
+            res = false; msg = format_error(b, error, status);
+        })
+#ifdef WIN32
+        .ssl_revoke_best_effort(m_ssl_revoke_best_effort)
+#endif
+        .perform_sync();
+    if (!res)
+        return false;
+
+    try {
+        std::stringstream ss(body);
+        pt::ptree ptree;
+        pt::read_json(ss, ptree);
+        const auto objects = ptree.get_child_optional("result.objects");
+        if (!objects) { object_name_out.clear(); return true; }
+        std::vector<std::string> present;
+        for (const auto& o : *objects)
+            present.push_back(o.second.get_value<std::string>());
+        for (const auto& cand : kCandidates)
+            if (std::find(present.begin(), present.end(), cand) != present.end()) {
+                object_name_out = cand;
+                BOOST_LOG_TRIVIAL(info) << boost::format("%1%-CFS: detected CFS object \"%2%\"") % name % cand;
+                return true;
+            }
+        object_name_out.clear(); // no CFS present
+    } catch (const std::exception& ex) {
+        res = false;
+        msg = GUI::format_wxstr(_L("Could not parse Moonraker objects list: %s"), ex.what());
+    }
+    return res;
+}
+
+bool Moonraker::parse_cfs_slots(const std::string& object_name, const std::string& body, std::vector<CFSSlot>& slots) const
+{
+    //ORCA-CFS: Parse the Creality `box` object captured by cfs-moonraker-probe.sh. Shape:
+    //   result.status.box = {
+    //     "same_material": [ [ "<mat_code>", "<color>", ["T1A"], "<MaterialName>" ], ... ],
+    //     "T1".."T4": { "state":"connect|None", "remain_len":["45","100",..],
+    //                   "color_value":["0ffffff",..], "material_type":["006002",..] },
+    //     "t_command":"T2", ... }
+    //   `same_material` is the authoritative flat slot list for connected units: each entry carries
+    //   the material *name* (PLA/PETG/...), the color, and a slot label "T<unit><A..D>". The label
+    //   maps to a 0-based global tool index = (unit-1)*4 + ('A..D' index), matching the Tn tool
+    //   commands the slicer emits at colour changes (the `box` module registers Tn natively;
+    //   see `t_command`). Colors are 7-char "0RRGGBB" -> we keep the trailing 6 hex digits.
+    slots.clear();
+
+    auto norm_color = [](std::string c) -> std::string {
+        if (c.empty() || c == "-1" || c == "None") return "";
+        if (c.size() > 6) c = c.substr(c.size() - 6); // drop leading "0"
+        std::transform(c.begin(), c.end(), c.begin(), ::tolower);
+        return c;
+    };
+    auto label_to_global = [](const std::string& label, int& unit_out, int& global_out) -> bool {
+        // "T1A".."T4D"
+        if (label.size() < 3 || (label[0] != 'T' && label[0] != 't')) return false;
+        const int unit = label[1] - '0';
+        const int sidx = std::string("ABCD").find(static_cast<char>(::toupper(label[2])));
+        if (unit < 1 || unit > 4 || sidx < 0) return false;
+        unit_out   = unit;
+        global_out = (unit - 1) * 4 + sidx;
+        return true;
+    };
+
+    try {
+        std::stringstream ss(body);
+        pt::ptree ptree;
+        pt::read_json(ss, ptree);
+        const auto box = ptree.get_child_optional("result.status." + object_name);
+        if (!box)
+            return false;
+
+        // --- Primary source: same_material (has material names) ---
+        if (const auto same = box->get_child_optional("same_material")) {
+            for (const auto& entry_kv : *same) {
+                // entry is itself a JSON array: [code, color, [label], name]
+                std::vector<const pt::ptree*> cols;
+                for (const auto& c : entry_kv.second) cols.push_back(&c.second);
+                if (cols.size() < 4) continue;
+                const std::string code  = cols[0]->get_value<std::string>(""); // Creality filamentId
+                const std::string color = norm_color(cols[1]->get_value<std::string>(""));
+                std::string label;
+                for (const auto& lbl : *cols[2]) { label = lbl.second.get_value<std::string>(""); break; }
+                const std::string name = cols[3]->get_value<std::string>("");
+
+                CFSSlot slot;
+                slot.label          = label;
+                slot.material_name  = name;
+                slot.material_code  = code;
+                slot.material_color = color;
+                slot.has_filament   = true;
+                int unit = 1, gid = 0;
+                if (label_to_global(label, unit, gid)) { slot.unit_id = unit; slot.slot_id = gid; }
+                else                                    slot.slot_id = static_cast<int>(slots.size());
+                slots.push_back(slot);
+            }
+        }
+
+        // --- Enrich with / fall back to per-unit arrays (remain %, empty slots) ---
+        for (int unit = 1; unit <= 4; ++unit) {
+            const std::string ukey = "T" + std::to_string(unit);
+            const auto unode = box->get_child_optional(ukey);
+            if (!unode) continue;
+            const std::string ustate = unode->get<std::string>("state", "None");
+            if (ustate == "None" || ustate.empty()) continue; // unit not present
+
+            auto col_at = [&](const char* arr, int i) -> std::string {
+                const auto a = unode->get_child_optional(arr);
+                if (!a) return "";
+                int k = 0; for (const auto& v : *a) { if (k++ == i) return v.second.get_value<std::string>(""); }
+                return "";
+            };
+            for (int i = 0; i < 4; ++i) {
+                const int gid = (unit - 1) * 4 + i;
+                const std::string rl = col_at("remain_len", i);
+                const int remain = (rl.empty() || rl == "-1") ? -1 : atoi(rl.c_str());
+                auto it = std::find_if(slots.begin(), slots.end(),
+                                       [&](const CFSSlot& s){ return s.slot_id == gid; });
+                if (it != slots.end()) {
+                    it->remain = remain;                 // enrich existing
+                } else if (remain > 0) {
+                    CFSSlot slot;                        // present but absent from same_material
+                    slot.slot_id        = gid;
+                    slot.unit_id        = unit;
+                    slot.label          = ukey + static_cast<char>('A' + i);
+                    slot.material_color = norm_color(col_at("color_value", i));
+                    slot.remain         = remain;
+                    slot.has_filament   = true;
+                    slots.push_back(slot);
+                }
+            }
+        }
+    } catch (const std::exception& ex) {
+        BOOST_LOG_TRIVIAL(warning) << boost::format("%1%-CFS: parse_cfs_slots failed: %2%") % get_name() % ex.what();
+        return false;
+    }
+
+    std::sort(slots.begin(), slots.end(), [](const CFSSlot& a, const CFSSlot& b){ return a.slot_id < b.slot_id; });
+    return !slots.empty();
+}
+
+bool Moonraker::fetch_cfs_slots(std::vector<CFSSlot>& slots, bool* supports_cfs, wxString& msg) const
+{
+    if (supports_cfs) *supports_cfs = false;
+    slots.clear();
+
+    std::string object_name;
+    if (!detect_cfs_object(object_name, msg))
+        return false;          // transport error
+    if (object_name.empty())
+        return true;           // reachable, but no CFS — UI hides mapping section
+
+    std::string body;
+    if (!query_object(object_name, body, msg))
+        return false;
+    if (!parse_cfs_slots(object_name, body, slots)) {
+        msg = _L("A CFS unit was detected but its slots could not be read.");
+        return false;
+    }
+    if (supports_cfs) *supports_cfs = true;
+    BOOST_LOG_TRIVIAL(info) << boost::format("%1%-CFS: read %2% slots") % get_name() % slots.size();
+    return true;
+}
+
+bool Moonraker::apply_cfs_tool_mapping(const std::string& mapping,
+                                       const boost::filesystem::path& source,
+                                       boost::filesystem::path& effective_out,
+                                       wxString& msg) const
+{
+    //ORCA-CFS: `mapping` is "<tool>:<slot>,<tool>:<slot>,..." where <tool> is the 0-based tool index
+    //          the slicer used for a project filament and <slot> is the 0-based global CFS slot the
+    //          user chose (T1A=0..T1D=3, T2A=4, ...). We rewrite only standalone tool-change lines
+    //          ("T0", "T3 ; comment", ...) so filament i loads from its mapped slot. If the mapping
+    //          is empty or an identity, the original file is used unchanged (no copy, no overhead).
+    effective_out = source;
+    if (mapping.empty())
+        return true;
+
+    std::map<int,int> remap;
+    bool non_identity = false;
+    std::stringstream ms(mapping);
+    std::string pair;
+    while (std::getline(ms, pair, ',')) {
+        const auto colon = pair.find(':');
+        if (colon == std::string::npos) continue;
+        try {
+            const int tool = std::stoi(pair.substr(0, colon));
+            const int slot = std::stoi(pair.substr(colon + 1));
+            remap[tool] = slot;
+            if (tool != slot) non_identity = true;
+        } catch (...) { /* ignore malformed pair */ }
+    }
+    if (remap.empty() || !non_identity)
+        return true; // nothing to change
+
+    try {
+        std::ifstream in(source.string(), std::ios::binary);
+        if (!in) { msg = _L("CFS: could not open the sliced file to apply slot mapping."); return false; }
+
+        boost::filesystem::path tmp = source;
+        tmp += ".cfsmap.tmp";
+        std::ofstream out(tmp.string(), std::ios::binary | std::ios::trunc);
+        if (!out) { msg = _L("CFS: could not create a temporary file for slot mapping."); return false; }
+
+        std::string line;
+        while (std::getline(in, line)) {
+            // Match a standalone tool-change line: optional spaces, 'T', digits, then end/space/';'.
+            size_t i = 0; while (i < line.size() && (line[i] == ' ' || line[i] == '\t')) ++i;
+            if (i < line.size() && (line[i] == 'T' || line[i] == 't')) {
+                size_t d = i + 1, ds = d;
+                while (d < line.size() && std::isdigit(static_cast<unsigned char>(line[d]))) ++d;
+                const bool has_digits = d > ds;
+                const bool clean_tail = (d == line.size()) || line[d] == ' ' || line[d] == '\t'
+                                        || line[d] == ';' || line[d] == '\r';
+                if (has_digits && clean_tail) {
+                    const int tool = std::stoi(line.substr(ds, d - ds));
+                    const auto it = remap.find(tool);
+                    if (it != remap.end() && it->second != tool) {
+                        line = line.substr(0, ds) + std::to_string(it->second) + line.substr(d);
+                    }
+                }
+            }
+            out << line << '\n';
+        }
+        out.flush();
+        if (!out) { msg = _L("CFS: failed while writing the slot-mapped file."); return false; }
+        effective_out = tmp;
+        BOOST_LOG_TRIVIAL(info) << boost::format("%1%-CFS: applied tool mapping `%2%` -> %3%")
+            % get_name() % mapping % tmp.string();
+    } catch (const std::exception& ex) {
+        msg = GUI::format_wxstr(_L("CFS: error applying slot mapping: %s"), ex.what());
+        return false;
     }
     return true;
 }

--- a/src/slic3r/Utils/Moonraker.hpp
+++ b/src/slic3r/Utils/Moonraker.hpp
@@ -2,9 +2,11 @@
 #define slic3r_Moonraker_hpp_
 
 #include <string>
+#include <vector>
 #include <wx/string.h>
 #include <wx/arrstr.h>
 
+#include <boost/filesystem/path.hpp>
 #include "PrintHost.hpp"
 #include "libslic3r/PrintConfig.hpp"
 
@@ -27,6 +29,22 @@ class Http;
 // Auth: X-Api-Key header if `printhost_apikey` is non-empty; Moonraker accepts
 // unauthenticated LAN access by default, so the key is optional. HTTP Basic /
 // Digest are not part of the Moonraker spec and are not sent.
+// ORCA-CFS: A single slot in a Creality Filament System (CFS) unit as reported by the
+// printer's Klipper firmware over Moonraker. `slot_id` is 0-based and maps directly to the
+// tool index the slicer emits at colour changes (T0..T3 for a single 4-slot unit; chained
+// units extend the range). Populated by Moonraker::fetch_cfs_slots().
+struct CFSSlot
+{
+    int         slot_id {0};
+    bool        has_filament {false};
+    std::string material_name;   // e.g. "PLA", "PETG"  (empty when slot is empty)
+    std::string material_color;  // hex RGB without '#', e.g. "ffffff" (empty when unknown)
+    int         unit_id {1};     // CFS box/unit index (T1..T4); units chain for >4 colours
+    std::string label;           // human slot label as reported by firmware, e.g. "T1A".."T1D"
+    int         remain {-1};     // remaining filament %, -1 if unknown (near-empty warning)
+    std::string material_code;   // Creality filamentId, e.g. "103001" (empty if not reported)
+};
+
 class Moonraker : public PrintHost
 {
 public:
@@ -44,6 +62,13 @@ public:
     PrintHostPostUploadActions get_post_upload_actions() const override { return PrintHostPostUploadAction::StartPrint; }
     std::string get_host() const override { return m_host; }
     bool get_storage(wxArrayString &storage_path, wxArrayString &storage_name) const override;
+
+    // ORCA-CFS: Detect whether the connected Klipper/Moonraker host exposes a Creality Filament
+    // System object and, if so, read its slots. Returns false on transport error (msg set).
+    // On success, *supports_cfs reports whether a CFS object was found; `slots` is filled only
+    // when it was. Used by the send dialog to show the filament->slot mapping UI (gated on
+    // *supports_cfs), mirroring the Flashforge IFS material-station flow.
+    bool fetch_cfs_slots(std::vector<CFSSlot>& slots, bool* supports_cfs, wxString& msg) const;
     const std::string& get_apikey() const { return m_apikey; }
     const std::string& get_cafile() const { return m_cafile; }
 
@@ -56,6 +81,22 @@ protected:
     void set_auth(Http &http) const;
     std::string make_url(const std::string &path) const;
     bool start_print(wxString &error_msg, const std::string &filename) const;
+
+    // ORCA-CFS helpers.
+    // query_object(): GET /printer/objects/query?<object> -> raw JSON body.
+    // detect_cfs_object(): GET /printer/objects/list and return the CFS object name if present.
+    // parse_cfs_slots(): turn the queried object body into CFSSlot[] -- the ONLY place that
+    //   depends on the firmware-specific field names captured by cfs-moonraker-probe.sh.
+    bool query_object(const std::string& object, std::string& body_out, wxString& msg) const;
+    bool detect_cfs_object(std::string& object_name_out, wxString& msg) const;
+    bool parse_cfs_slots(const std::string& object_name, const std::string& body, std::vector<CFSSlot>& slots) const;
+    // apply_cfs_tool_mapping(): rewrite standalone Tn tool-change lines in the sliced file so each
+    //   project filament prints from its user-chosen CFS slot. effective_out receives either the
+    //   original path (identity/empty mapping) or a temp file with remapped tool indices.
+    bool apply_cfs_tool_mapping(const std::string& mapping,
+                                const boost::filesystem::path& source,
+                                boost::filesystem::path& effective_out,
+                                wxString& msg) const;
 };
 
 }


### PR DESCRIPTION
## What
 
Adds filament-to-slot mapping for the Creality Filament System when sending a job to a
Moonraker host, mirroring the Flashforge IFS workflow from #12991.
 
When the printer exposes a CFS, the send dialog now shows **"Use CFS (auto filament
mapping)"**, the number of detected slots, and one card per project filament with a slot
assigned automatically. On upload, the tool changes are rewritten so each filament prints
from the slot it was mapped to.
 
- `detect_cfs_object()` / `fetch_cfs_slots()` read the slots via `/printer/objects/list` and
  `/printer/objects/query?box`, parsing `same_material` and the per-unit `T1..T4` arrays
  (material, colour, remaining percentage).
- `MoonrakerCFSPrintHostSendDialog` reuses the existing Flashforge IFS slot widgets through
  a `CFSSlot` adapter, and is only shown when a CFS is actually detected; otherwise the
  generic dialog is used.
- `apply_cfs_tool_mapping()` rewrites the standalone `Tn` tool-change lines before upload.
  The `box` module loads slot *N* on `Tn`, so this needs no vendor macro and works on stock
  and rooted firmware alike.
- A small catalogue maps the CFS `filamentId` to the exact Creality product, so auto-assign
  picks the right preset (Hyper PLA vs CR-PLA vs CR-PLA Matte) instead of guessing by
  nearest colour, falling back to material + colour when the code is unknown. Contributed by
  @sandman21vs.

## Implementation note
 
`PrintHostSendDialog` gains a `virtual bool validate_before_send() { return true; }`, called
by its existing Upload / Upload and Print handlers after the filename check. That lets this
dialog reuse the base `init()` for the filename field, the device-tab checkbox and the
buttons instead of duplicating them, and block sending until every filament is mapped.
Default is a no-op, so no other host changes behaviour, the Flashforge dialog overrides
`init()` entirely and never reaches it.
 
## Scope
 
Local/LAN over Moonraker only; no cloud. No new printer profiles: the existing K1 profiles
already declare `single_extruder_multi_material`. Other print hosts are untouched.
 
## Tests
 
Verified on real hardware: **Creality K1 SE and K1C + first-generation CFS**, Moonraker `v0.10`:
slots detected, filaments auto-assigned, and "Upload and Print" loads the mapped slots and
prints correctly. @sandman21vs independently cross-confirmed the same `box`-over-Moonraker
approach on a **K1C**.
 
## New send print dialog
<img width="630" height="422" alt="image" src="https://github.com/user-attachments/assets/91caacf1-3d5d-44bf-ab1c-0bebb9e203fe" />

## Results on a print
<img width="673" height="457" alt="image" src="https://github.com/user-attachments/assets/227d1277-c5c9-4be8-bf26-7cfe7e5dab39" />

## New filament mapping feature
<img width="922" height="150" alt="image" src="https://github.com/user-attachments/assets/ea97631b-70c9-4db4-b617-8620a89dea5a" />

 
Related: #11087, #12407, #12991, #10783.