### PR TITLE
fix: default-initialize WallToolPathsParams fields

### DIFF
--- a/src/libslic3r/Arachne/WallToolPaths.hpp
+++ b/src/libslic3r/Arachne/WallToolPaths.hpp
@@ -23,14 +23,14 @@ inline coord_t    meshfix_maximum_extrusion_area_deviation() { return scaled<coo
 class WallToolPathsParams
 {
 public:
-    float   min_bead_width;
-    float   min_feature_size;
-    float   min_length_factor;
-    float   wall_transition_length;
-    float   wall_transition_angle;
-    float   wall_transition_filter_deviation;
-    int     wall_distribution_count;
-    bool    is_top_or_bottom_layer;
+    float   min_bead_width                   = 0.f;
+    float   min_feature_size                 = 0.f;
+    float   min_length_factor                = 0.5f;
+    float   wall_transition_length           = 0.f;
+    float   wall_transition_angle            = 10.f;
+    float   wall_transition_filter_deviation = 0.f;
+    int     wall_distribution_count          = 1;
+    bool    is_top_or_bottom_layer           = false;
 
     coord_t wall_maximum_resolution = meshfix_maximum_resolution();
     coord_t wall_maximum_deviation  = meshfix_maximum_deviation();


### PR DESCRIPTION
# Description

There have been intermittent `test_perimeters` failures since #14929 merged, seen on the Flatpak unit-test leg in #14709. This is a real slicing-nondeterminism bug, not a flaky test.

`WallToolPathsParams::min_length_factor` and `::is_top_or_bottom_layer` had no default initializers. `FillConcentric` and `FillConcentricInternal` build the struct by hand and set every field except those two, so `WallToolPaths::removeSmallLines()` reads them uninitialized:

```cpp
if (line.is_odd && !line.is_closed &&
    shorterThan(line, m_params.is_top_or_bottom_layer ? (min_width / 2)
                                                      : (min_width * m_params.min_length_factor)))
```

Its removal threshold is stack garbage, so which short extrusion lines get dropped depends on memory layout. In testing, the per-layer fill length changed by up to ~189 mm between two slices of the same model. The perimeter path is unaffected because it builds the struct via `make_paths_params()`, which sets both fields (`0.5f` / `false`).

**Fix:** give every `WallToolPathsParams` member a default, matching the adjacent `FillParams`. The two read-uninitialized fields take the `make_paths_params()` defaults; `wall_distribution_count` and `wall_transition_angle` take the literals the callers and Cura already use; the four nozzle-derived fields, always overwritten by callers, take neutral `0.f` placeholders. Only the two fields were ever read uninitialized, so existing output is unchanged.

The bug dates to #2790, which added both fields plus the `removeSmallLines` consumer and wired `make_paths_params()` but not the two fill callers.

# Screenshots/Recordings/Graphs

N/A (non-UI change).

## Tests

- The flaky `test_perimeters` case "Top surface expansion only acts where there is a top fill" (from #14929) failed ~55% of runs before this change and 0/64 after, measured under ASLR on a bounds-checked Linux build. It has also failed on the bounds-checked Flatpak unit-test leg in #14709 (aarch64).

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
