### PR TITLE
fix(linux): build deps on older GCC and Ubuntu 22.04

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,13 @@ cmake --build build --config RelWithDebInfo --target all --
 cmake --build . --config %build_type% --target ALL_BUILD -- -m
 ```
 
+Minimum Linux build environment: Ubuntu 22.04 LTS, GCC 12+. GCC 9 (Ubuntu 20.04's
+default) cannot build the vendored deps: GMP 6.2.1's `configure` fails a compiler
+probe under GCC 9 with `error: parameter name omitted` across every ABI, aborting
+with "could not find a working compiler". Ubuntu 22.04's default GCC 11 is also
+untested/unsupported — install GCC 12+ explicitly
+(`CC=gcc-12 CXX=g++-12 ./build_linux.sh -dst`, matching the project's Ubuntu 24.04 CI).
+
 ## Testing
 
 Catch2 framework. Tests in `tests/`; see [tests/AGENTS.md](tests/AGENTS.md) for where a new test belongs and the conventions to follow.

--- a/scripts/linux.d/debian
+++ b/scripts/linux.d/debian
@@ -9,6 +9,7 @@ REQUIRED_DEV_PACKAGES=(
     file
     g++
     gettext
+    gfortran
     git
     gstreamer1.0-gtk3
     libcurl4-openssl-dev
@@ -16,6 +17,7 @@ REQUIRED_DEV_PACKAGES=(
     libglew-dev
     libgstreamerd-3-dev
     libgtk-3-dev
+    libhwloc-dev
     libmspack-dev
     libsecret-1-dev
     libspnav-dev
@@ -39,6 +41,9 @@ then
         then
             # Some extra packages needed on Ubuntu 22.x and 23.x:
             REQUIRED_DEV_PACKAGES+=(curl libfuse-dev m4)
+            # Ubuntu 22.x's default GCC (11) can't build the vendored deps
+            # (GMP's configure fails under it); the project requires GCC 12+.
+            REQUIRED_DEV_PACKAGES+=(gcc-12 g++-12)
         fi
     fi
 
@@ -47,12 +52,14 @@ then
         REQUIRED_DEV_PACKAGES+=(libssl-dev libcurl4-openssl-dev)
     fi
 
-    # check which version of libwebkit2gtk is available
-    if [ "$(apt show --quiet libwebkit2gtk-4.0-dev 2>/dev/null)" != "" ]
+    # src/slic3r/CMakeLists.txt requires webkit2gtk-4.1 unconditionally (no
+    # 4.0 fallback), so prefer it; only fall back to 4.0-dev when 4.1 isn't
+    # packaged for this distro.
+    if [ "$(apt show --quiet libwebkit2gtk-4.1-dev 2>/dev/null)" != "" ]
     then
-        REQUIRED_DEV_PACKAGES+=(libwebkit2gtk-4.0-dev)
-    else
         REQUIRED_DEV_PACKAGES+=(libwebkit2gtk-4.1-dev)
+    else
+        REQUIRED_DEV_PACKAGES+=(libwebkit2gtk-4.0-dev)
     fi
 
     # install them all at once


### PR DESCRIPTION
Follow-up to the review. The gcc-12, gfortran and libhwloc-dev packages are
dropped; the causes are fixed in deps/ instead.

- GMP: name the parameters in the configure probe from
  0001-GMP_GCC15.patch. Unnamed parameters are a hard error on GCC 10
  and older, so configure failed there.
- TBB: turn off the automatic hwloc search so a system libhwloc-dev is
  not picked up.
- Eigen needs no change; the EIGEN_BUILD_* flags are already off on main.
- scripts/linux.d/debian: run apt update before checking which
  webkit2gtk package exists, and prefer webkit2gtk-4.1 since the build
  requires it. Add automake, which MPFR's autoreconf needs.

Tested in Docker without gfortran, libhwloc-dev or gcc-12:

- GMP configure and make, and the TBB build, pass on GCC 9 to 16 across
  Ubuntu 22.04, 24.04, 25.10, 26.04 and 26.10. GMP configure failed on GCC 9
  and 10 before this change.
- A full deps build, OrcaSlicer and ctest (1230 passed, 0 failed) from
  scratch: 22.04 with GCC 9, 24.04 with GCC 13, 26.04 with GCC 15.
  22.04 with GCC 11 was rebuilt on top of existing deps and also passed.
- With libhwloc-dev installed, TBB picked up hwloc without the flag and
  does not with it.

GCC 11 was not affected by the GMP issue, and TBB builds without
libhwloc-dev, so the earlier description was wrong on both.
