### PR TITLE
Fix overhang fan control when overhang slowdown is enabled

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -7827,9 +7827,10 @@ std::string GCode::_extrude(const ExtrusionPath &path, std::string description, 
             }
             variable_speed = std::any_of(new_points.begin(), new_points.end(),
                                          [speed](const ProcessedPoint &p) { return fabs(double(p.speed) - speed) > 1; }); // Ignore small speed variations (under 1mm/sec)
-            if (!NOZZLE_CONFIG(enable_overhang_speed) && FILAMENT_CONFIG(enable_overhang_bridge_fan) && m_enable_cooling_markers) {
-                for (ProcessedPoint &point : new_points)
-                    point.speed = speed;
+            if (FILAMENT_CONFIG(enable_overhang_bridge_fan) && m_enable_cooling_markers) {
+                if (!NOZZLE_CONFIG(enable_overhang_speed))
+                    for (ProcessedPoint &point : new_points)
+                        point.speed = speed;
                 variable_speed = new_points.size() > 1;
             }
     }

--- a/src/libslic3r/GCode/CoolingBuffer.cpp
+++ b/src/libslic3r/GCode/CoolingBuffer.cpp
@@ -1024,28 +1024,29 @@ std::string CoolingBuffer::apply_layer_cooldown(
         }
 
         if (need_set_fan) {
+            const auto set_fan = [&](int speed) {
+                if (m_current_fan_speed != speed) {
+                    new_gcode += GCodeWriter::set_fan(m_config.gcode_flavor, speed, part_cooling_fan_min_pwm);
+                    m_current_fan_speed = speed;
+                }
+            };
             if (fan_speed_change_requests[CoolingLine::TYPE_OVERHANG_FAN_START]){
-                new_gcode += GCodeWriter::set_fan(m_config.gcode_flavor, overhang_fan_speed, part_cooling_fan_min_pwm);
-                m_current_fan_speed = overhang_fan_speed;
+                set_fan(overhang_fan_speed);
             } else if (fan_speed_change_requests[CoolingLine::TYPE_INTERNAL_BRIDGE_FAN_START]){ // ORCA: Add support for separate internal bridge fan speed control
-                new_gcode += GCodeWriter::set_fan(m_config.gcode_flavor, internal_bridge_fan_speed, part_cooling_fan_min_pwm);
-                m_current_fan_speed = internal_bridge_fan_speed;
+                set_fan(internal_bridge_fan_speed);
             }
             else if (fan_speed_change_requests[CoolingLine::TYPE_SUPPORT_INTERFACE_FAN_START]){
-                new_gcode += GCodeWriter::set_fan(m_config.gcode_flavor, supp_interface_fan_speed, part_cooling_fan_min_pwm);
-                m_current_fan_speed = supp_interface_fan_speed;
+                set_fan(supp_interface_fan_speed);
             }
             else if (fan_speed_change_requests[CoolingLine::TYPE_IRONING_FAN_START]){
-                new_gcode += GCodeWriter::set_fan(m_config.gcode_flavor, ironing_fan_speed, part_cooling_fan_min_pwm);
-                m_current_fan_speed = ironing_fan_speed;
+                set_fan(ironing_fan_speed);
             }
             else if(fan_speed_change_requests[CoolingLine::TYPE_FORCE_RESUME_FAN] && m_current_fan_speed != -1){
                 new_gcode += GCodeWriter::set_fan(m_config.gcode_flavor, m_current_fan_speed, part_cooling_fan_min_pwm);
                 fan_speed_change_requests[CoolingLine::TYPE_FORCE_RESUME_FAN] = false;
             }
             else {
-                new_gcode += GCodeWriter::set_fan(m_config.gcode_flavor, m_fan_speed, part_cooling_fan_min_pwm);
-                m_current_fan_speed = m_fan_speed;
+                set_fan(m_fan_speed);
             }
             need_set_fan = false;
         }

--- a/src/libslic3r/GCode/FanMover.cpp
+++ b/src/libslic3r/GCode/FanMover.cpp
@@ -170,14 +170,13 @@ void FanMover::_put_in_middle_G1(std::list<BufferData>::iterator item_to_split, 
 
 void FanMover::_print_in_middle_G1(BufferData& line_to_split, float nb_sec, const std::string &line_to_write) {
     if (nb_sec < line_to_split.time * 0.1) {
-        // doesn't really need to be split, print it after
-        m_process_output += line_to_split.raw + "\n";
+        // Doesn't need to be split: the insertion point is at the start.
         m_process_output += line_to_write + (line_to_write.back() == '\n'?"":"\n");
-    } else if (nb_sec > line_to_split.time * 0.9) {
-        // doesn't really need to be split, print it before
-        //will also print before if line_to_split.time == 0
-        m_process_output += line_to_write + (line_to_write.back() == '\n' ? "" : "\n");
         m_process_output += line_to_split.raw + "\n";
+    } else if (nb_sec > line_to_split.time * 0.9) {
+        // Doesn't need to be split: the insertion point is at the end.
+        m_process_output += line_to_split.raw + "\n";
+        m_process_output += line_to_write + (line_to_write.back() == '\n' ? "" : "\n");
     }else if(line_to_split.raw.size() > 2
         && line_to_split.raw[0] == 'G' && line_to_split.raw[1] == '1' && line_to_split.raw[2] == ' ') {
         float percent = nb_sec / line_to_split.time;

--- a/src/libslic3r/GCode/GCodeProcessor.cpp
+++ b/src/libslic3r/GCode/GCodeProcessor.cpp
@@ -531,7 +531,7 @@ void GCodeProcessor::TimeMachine::calculate_time(GCodeProcessorResult& result, P
                     const float height = interpolate ? lerp(prev_move.height, curr_move.height, t) : curr_move.height;
                     // ORCA: Fix issue with flow rate changes being visualized incorrectly
                     const float mm3_per_mm = curr_move.mm3_per_mm;
-                    const float fan_speed = interpolate ? lerp(prev_move.fan_speed, curr_move.fan_speed, t) : curr_move.fan_speed;
+                    const float fan_speed = curr_move.fan_speed;
                     const float temperature = interpolate ? lerp(prev_move.temperature, curr_move.temperature, t) : curr_move.temperature;
                     actual_speed_moves.push_back({
                         block.move_id,
@@ -562,7 +562,7 @@ void GCodeProcessor::TimeMachine::calculate_time(GCodeProcessorResult& result, P
                     const float height = interpolate ? lerp(prev_move.height, curr_move.height, t) : curr_move.height;
                     // ORCA: Fix issue with flow rate changes being visualized incorrectly
                     const float mm3_per_mm = curr_move.mm3_per_mm;
-                    const float fan_speed = interpolate ? lerp(prev_move.fan_speed, curr_move.fan_speed, t) : curr_move.fan_speed;
+                    const float fan_speed = curr_move.fan_speed;
                     const float temperature = interpolate ? lerp(prev_move.temperature, curr_move.temperature, t) : curr_move.temperature;
                     actual_speed_moves.push_back({
                         block.move_id,

--- a/tests/fff_print/test_cooling.cpp
+++ b/tests/fff_print/test_cooling.cpp
@@ -2,7 +2,10 @@
 
 #include "test_helpers.hpp"
 
+#include <algorithm>
+#include <sstream>
 #include <string>
+#include <vector>
 
 using namespace Slic3r;
 using namespace Slic3r::Test;
@@ -24,4 +27,69 @@ TEST_CASE("Cooling consumes its internal speed markers", "[Cooling]")
 {
     const std::string gcode = slice({ cube(20) }, { { "layer_height", 0.2 } });
     CHECK(gcode.find(";_EXTRUDE_SET_SPEED") == std::string::npos);
+}
+
+TEST_CASE("Overhang fan transitions do not depend on overhang speed", "[Cooling][Regression]")
+{
+    DynamicPrintConfig config = DynamicPrintConfig::full_print_config();
+    config.set_deserialize_strict({
+        { "bridge_speed",                   2.0 },
+        { "enable_arc_fitting",             false },
+        { "enable_overhang_bridge_fan",     true },
+        { "enable_overhang_speed",          false },
+        { "initial_layer_print_height",     0.3 },
+        { "inner_wall_speed",              30.0 },
+        { "layer_height",                   0.3 },
+        { "outer_wall_speed",              30.0 },
+        { "overhang_1_4_speed",            "30" },
+        { "overhang_2_4_speed",            "29" },
+        { "overhang_3_4_speed",             "6" },
+        { "overhang_4_4_speed",             "3" },
+        { "slow_down_for_layer_cooling",    false },
+        { "slowdown_for_curled_perimeters", false },
+    });
+    config.set_key_value("fan_max_speed", new ConfigOptionFloats{20.0});
+    config.set_key_value("fan_min_speed", new ConfigOptionFloats{20.0});
+    config.set_key_value("overhang_fan_speed", new ConfigOptionInts{100});
+    config.set_key_value("overhang_fan_threshold", new ConfigOptionEnumsGeneric{Overhang_threshold_2_4});
+    config.set_key_value("layer_change_gcode", new ConfigOptionString{";TEST_LAYER_Z=[layer_z]"});
+
+    const auto fan_commands = [](const std::string &gcode) {
+        std::vector<std::pair<std::string, std::string>> commands;
+        std::istringstream input(gcode);
+        std::string layer;
+        std::string line;
+        while (std::getline(input, line)) {
+            if (line.rfind(";TEST_LAYER_Z=", 0) == 0)
+                layer = line;
+            else if (!layer.empty() && (line.rfind("M106", 0) == 0 || line.rfind("M107", 0) == 0))
+                commands.emplace_back(layer, line);
+        }
+        return commands;
+    };
+    const auto feedrates = [](const std::string &gcode) {
+        std::vector<std::string> values;
+        std::istringstream input(gcode);
+        std::string word;
+        while (input >> word)
+            if (!word.empty() && word.front() == 'F')
+                values.push_back(word);
+        return values;
+    };
+
+    constexpr double sphere_radius = 50.0; // 100 mm diameter.
+    const std::string without_speed_gcode = slice({make_sphere(sphere_radius, PI / 24.0)}, config);
+    config.set_deserialize_strict({{"enable_overhang_speed", true}});
+    const std::string with_speed_gcode = slice({make_sphere(sphere_radius, PI / 24.0)}, config);
+
+    const auto without_speed_fan = fan_commands(without_speed_gcode);
+    const auto with_speed_fan = fan_commands(with_speed_gcode);
+    const auto without_speed_feedrates = feedrates(without_speed_gcode);
+    const auto with_speed_feedrates = feedrates(with_speed_gcode);
+
+    REQUIRE_FALSE(without_speed_fan.empty());
+    REQUIRE(std::any_of(without_speed_fan.begin(), without_speed_fan.end(),
+                        [](const auto &command) { return command.second.find("S255") != std::string::npos; }));
+    REQUIRE(with_speed_feedrates != without_speed_feedrates);
+    CHECK(with_speed_fan == without_speed_fan);
 }


### PR DESCRIPTION
This PR fixes two issues with fan speed change:
## 1. Incorrect overhang fan transitions when **Slow down for overhangs** is enabled.

### Observed behavior

Overhang fan transitions worked correctly while **Slow down for overhangs** was disabled.

When the setting was enabled, some transition points were treated only as speed changes and were not preserved for cooling processing. As a result, the generated fan commands could differ depending on whether overhang slowdown was enabled.

The generated G-code could also contain consecutive identical fan commands.

### Applied fix

Keep the overhang transition points available to the cooling processor whenever overhang fan control is enabled.

When **Slow down for overhangs** is disabled, their speeds are reset to the normal extrusion speed, preserving the existing behavior without applying slowdown.

The cooling processor now also skips fan commands when the requested fan speed is already active.

### Screenshots

Settings:
- regular fan speed 25%
- overhang fan speed 100% at 10% overlap
- slow down for overhangs enabled

<br>

**Overhang speed:**
<img width="2251" height="830" alt="image" src="https://github.com/user-attachments/assets/a7ee03dc-f62c-4322-96c3-682228fff138" />
 
 <br>
 <br>
 
**Fan speed change before:**
<img width="2012" height="767" alt="image" src="https://github.com/user-attachments/assets/1c977896-82c5-4214-9ee3-10c707db5d26" />

<br>
<br>

**Fan speed change after:**
<img width="1978" height="722" alt="image" src="https://github.com/user-attachments/assets/cdefc563-56e2-459f-8548-61553ad230b6" />

---

## 2. Fix fan changes placed at the wrong end of a move

### Observed behavior

When a fan change falls within 10% of either end of a move, the move is not split.

However, the fan command was emitted at the opposite end:

- a fan change near the start was emitted after the move
- a fan change near the end was emitted before the move

This could shift the fan change by almost the entire duration of the move.

The G-code preview also interpolated fan speed between consecutive moves. Since fan changes are discrete commands, this produced misleading intermediate fan-speed bands during transitions.

### Applied fix

Emit the fan command before the move when the requested position is near its start, and after the move when it is near its end.

The G-code preview now uses the active fan speed directly instead of interpolating it between moves.

### Screenshots

|Before|After|
|---|---|
|<img width="1171" height="972" alt="image" src="https://github.com/user-attachments/assets/8e12b19a-7c0f-4227-93dc-2fa5d29b932e" />|<img width="1154" height="967" alt="image" src="https://github.com/user-attachments/assets/68758117-ec1d-407b-bd61-23025925b9dd" />|

---

Fixes #9988