### PR TITLE
Fix Slice All crash on multi-plate projects (null m_all_plates_stats_item)

### DIFF
--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -6977,7 +6977,10 @@ void GLCanvas3D::_update_select_plate_toolbar_stats_item(bool force_selected) {
     else
         m_sel_plate_toolbar.show_stats_item = false;
 
-    if (force_selected && m_sel_plate_toolbar.show_stats_item)
+    // m_all_plates_stats_item is null until _init_select_plate_toolbar() runs, and is set back to
+    // null by IMToolbar::del_stats_item(). Slice All can reach here in either state, so guard the
+    // deref the way reset_select_plate_toolbar_selection() and is_all_plates_selected() already do.
+    if (force_selected && m_sel_plate_toolbar.show_stats_item && m_sel_plate_toolbar.m_all_plates_stats_item)
         m_sel_plate_toolbar.m_all_plates_stats_item->selected = true;
 }
 


### PR DESCRIPTION
# Description

Fixes #15166.

**Slice All** segfaults on any project with more than one non-empty plate.

`GLCanvas3D::_update_select_plate_toolbar_stats_item()` dereferences `m_sel_plate_toolbar.m_all_plates_stats_item` without a null check. That pointer defaults to `nullptr` (`IMToolbar.hpp`), is set back to `nullptr` by `IMToolbar::del_stats_item()`, and is only allocated in `_init_select_plate_toolbar()`. `Plater::priv::on_action_slice_all()` calls this with `force_selected = true`, so Slice All can reach the dereference while the pointer is still null.

The `show_stats_item` guard is why this is multi-plate specific — it is only set when `get_nonempty_plate_list().size() > 1`, so single-plate projects never reach the dereference.

This change adds the same null check the other two access sites already use, rather than introducing a new convention:

- `reset_select_plate_toolbar_selection()` — `if (m_sel_plate_toolbar.m_all_plates_stats_item)`
- `is_all_plates_selected()` — `return m_sel_plate_toolbar.m_all_plates_stats_item && ...`

No behavior change when the pointer is valid; when it is null the selection flag is simply not set, which is the same state the toolbar would render anyway.

# Screenshots/Recordings/Graphs

Not applicable — no UI change. The relevant artifact is the generated code, below.

## Tests

Diagnosed from a core dump on 2.4.2 (Fedora 44, Release + LTO). The faulting address was exactly null:

```
si_addr = 0x0
rax     = 0x0
rip     = 0x182ffef <_update_select_plate_toolbar_stats_item(bool)+111>
```

Rebuilt with the patch and verified the guard reached the emitted code by disassembling the same symbol before and after:

```
before:
  182ffe8:  mov  0x1168(%rbx),%rax
  182ffef:  movb $0x1,(%rax)        <-- SIGSEGV when rax = 0

after:
  182ffe8:  mov   0x1168(%rbx),%rax
  182ffef:  test  %rax,%rax
  182fff2:  je    182fff7
  182fff4:  movb  $0x1,(%rax)
```

Patched build launches and slices normally. Note the crash was reproduced and analysed from the core dump rather than under a debugger, so the null path is confirmed by the recorded fault state (`si_addr`/`rax` both zero) rather than by a live single-step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)