### PR TITLE
Enable Snapmaker U1 bed type selector

### DIFF
--- a/resources/profiles/Snapmaker.json
+++ b/resources/profiles/Snapmaker.json
@@ -1,6 +1,6 @@
 {
 	"name": "Snapmaker",
-	"version": "02.04.00.08",
+	"version": "02.04.00.09",
 	"force_update": "0",
 	"description": "Snapmaker configurations",
 	"machine_model_list": [

--- a/resources/profiles/Snapmaker/machine/Snapmaker U1 (0.2 nozzle).json
+++ b/resources/profiles/Snapmaker/machine/Snapmaker U1 (0.2 nozzle).json
@@ -186,7 +186,6 @@
 	"before_layer_change_gcode": ";BEFORE_LAYER_CHANGE\n;[layer_z]\nG92 E0\nTIMELAPSE_TAKE_FRAME\nDEFECT_DETECTION_DETECT",
 	"machine_pause_gcode": "M600",
 	"nozzle_volume": "143",
-	"support_multi_bed_types": "0",
 	"layer_change_gcode": ";AFTER_LAYER_CHANGE\n;[layer_z]\nSET_PRINT_STATS_INFO TOTAL_LAYER={total_layer_count} CURRENT_LAYER={layer_num+1}",
 	"default_print_profile": "0.10 Standard @Snapmaker U1 (0.2 nozzle)"
 }

--- a/resources/profiles/Snapmaker/machine/Snapmaker U1 (0.4 nozzle).json
+++ b/resources/profiles/Snapmaker/machine/Snapmaker U1 (0.4 nozzle).json
@@ -186,7 +186,6 @@
 	"before_layer_change_gcode": ";BEFORE_LAYER_CHANGE\n;[layer_z]\nG92 E0\nTIMELAPSE_TAKE_FRAME\nDEFECT_DETECTION_DETECT",
 	"default_print_profile": "0.20 Standard @Snapmaker U1 (0.4 nozzle)",
 	"machine_pause_gcode": "M600",
-	"default_bed_type": "Textured PEI Plate",
 	"layer_change_gcode": ";AFTER_LAYER_CHANGE\n;[layer_z]\nSET_PRINT_STATS_INFO TOTAL_LAYER={total_layer_count} CURRENT_LAYER={layer_num+1}",
 	"nozzle_volume": "143",
 	"resonance_avoidance": "1",

--- a/resources/profiles/Snapmaker/machine/Snapmaker U1 (0.6 nozzle).json
+++ b/resources/profiles/Snapmaker/machine/Snapmaker U1 (0.6 nozzle).json
@@ -187,6 +187,5 @@
 	"machine_pause_gcode": "M600",
 	"layer_change_gcode": ";AFTER_LAYER_CHANGE\n;[layer_z]\nSET_PRINT_STATS_INFO TOTAL_LAYER={total_layer_count} CURRENT_LAYER={layer_num+1}",
 	"nozzle_volume": "143",
-	"support_multi_bed_types": "0",
 	"default_print_profile": "0.30 Standard @Snapmaker U1 (0.6 nozzle)"
 }

--- a/resources/profiles/Snapmaker/machine/Snapmaker U1 (0.8 nozzle).json
+++ b/resources/profiles/Snapmaker/machine/Snapmaker U1 (0.8 nozzle).json
@@ -187,6 +187,5 @@
 	"machine_pause_gcode": "M600",
 	"layer_change_gcode": ";AFTER_LAYER_CHANGE\n;[layer_z]\nSET_PRINT_STATS_INFO TOTAL_LAYER={total_layer_count} CURRENT_LAYER={layer_num+1}",
 	"nozzle_volume": "143",
-	"support_multi_bed_types": "0",
 	"default_print_profile": "0.40 Standard @Snapmaker U1 (0.8 nozzle)"
 }

--- a/resources/profiles/Snapmaker/machine/fdm_U1.json
+++ b/resources/profiles/Snapmaker/machine/fdm_U1.json
@@ -184,7 +184,7 @@
 	"nozzle_type": "undefine",
 	"auxiliary_fan": "0",
 	"support_multi_bed_types": "1",
-	"default_bed_type": "Textured PEI Plate",
+	"default_bed_type": "4",
 	"printable_area": [
 		"0.5x1",
 		"270.5x1",

--- a/resources/profiles/Snapmaker/machine/fdm_U1.json
+++ b/resources/profiles/Snapmaker/machine/fdm_U1.json
@@ -183,6 +183,7 @@
 	"scan_first_layer": "0",
 	"nozzle_type": "undefine",
 	"auxiliary_fan": "0",
+	"support_multi_bed_types": "1",
 	"default_bed_type": "Textured PEI Plate",
 	"printable_area": [
 		"0.5x1",


### PR DESCRIPTION
# Description

Enables multiple bed types for the Snapmaker U1.  

Fixes #15132

Interestingly, in Snapmaker Orca `support_multi_bed_types` being set to `0` exposes a small default set of bed types.  When set to `1` it'll expose the whole list.  As an Orca user, I want the whole list not just a small curated set.

I think I also found a small bug with Orca's bed type selection on new printer addition, but I don't want to muddy this PR.

## Screenshots
<img width="772" height="284" alt="image" src="https://github.com/user-attachments/assets/bf352f90-72f2-4828-bf7f-c0b754d62f33" />

<!--
> A guide for users on how to download the artifacts from this PR.
-->

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
