### PR TITLE
profile: Wondermaker - reorganize the ZR Ultra family and fix the Ultra S tool count

### DIFF
--- a/resources/profiles/WonderMaker.json
+++ b/resources/profiles/WonderMaker.json
@@ -1,7 +1,7 @@
 {
 	"name": "WonderMaker",
 	"url": "",
-	"version": "02.04.00.01",
+	"version": "02.04.00.02",
 	"force_update": "0",
 	"description": "WonderMaker configurations",
 	"machine_model_list": [
@@ -426,6 +426,10 @@
 		{
 			"name": "fdm_klipper_common",
 			"sub_path": "machine/fdm_klipper_common.json"
+		},
+		{
+			"name": "fdm_ultra_common",
+			"sub_path": "machine/fdm_ultra_common.json"
 		},
 		{
 			"name": "WonderMaker ZR 0.4 nozzle",

--- a/resources/profiles/WonderMaker/machine/WonderMaker ZR Ultra 0.2 nozzle.json
+++ b/resources/profiles/WonderMaker/machine/WonderMaker ZR Ultra 0.2 nozzle.json
@@ -1,21 +1,22 @@
 {
 	"type": "machine",
 	"name": "WonderMaker ZR Ultra 0.2 nozzle",
-	"inherits": "WonderMaker ZR Ultra 0.4 nozzle",
+	"inherits": "fdm_ultra_common",
 	"from": "system",
 	"setting_id": "AX42zNj8YsJ94ilv",
 	"instantiation": "true",
+	"printer_model": "WonderMaker ZR Ultra",
+	"printer_variant": "0.2",
+	"default_print_profile": "0.10mm Standard @WonderMaker ZR Ultra 0.2 nozzle",
+	"default_bed_type": "4",
+	"max_layer_height": [
+		"0.14"
+	],
 	"nozzle_diameter": [
 		"0.2",
 		"0.2",
 		"0.2",
 		"0.2"
-	],
-	"printer_model": "WonderMaker ZR Ultra",
-	"printer_variant": "0.2",
-	"default_print_profile": "0.10mm Standard @WonderMaker ZR Ultra 0.2 nozzle",
-	"max_layer_height": [
-		"0.14"
 	],
 	"min_layer_height": [
 		"0.04"

--- a/resources/profiles/WonderMaker/machine/WonderMaker ZR Ultra 0.4 nozzle.json
+++ b/resources/profiles/WonderMaker/machine/WonderMaker ZR Ultra 0.4 nozzle.json
@@ -1,65 +1,17 @@
 {
 	"type": "machine",
 	"name": "WonderMaker ZR Ultra 0.4 nozzle",
-	"inherits": "fdm_klipper_common",
+	"inherits": "fdm_ultra_common",
 	"from": "system",
 	"setting_id": "xJBdCljSZVDINXnP",
 	"instantiation": "true",
 	"printer_model": "WonderMaker ZR Ultra",
 	"default_print_profile": "0.20mm Standard @WonderMaker ZR Ultra",
 	"default_bed_type": "4",
-	"default_filament_profile": [
-		"WonderMaker PLA Basic"
-	],
-	"single_extruder_multi_material": "0",
 	"nozzle_diameter": [
 		"0.4",
 		"0.4",
 		"0.4",
 		"0.4"
-	],
-	"printable_area": [
-		"0x0",
-		"300x0",
-		"300x270",
-		"0x270"
-	],
-	"bed_exclude_area": [],
-	"printable_height": "290",
-	"extruder_clearance_radius": "134",
-	"bed_mesh_min": [
-		"10",
-		"10"
-	],
-	"bed_mesh_max": [
-		"290",
-		"260"
-	],
-	"bed_mesh_probe_distance": [
-		"50",
-		"50"
-	],
-	"support_air_filtration": "0",
-	"support_chamber_temp_control": "0",
-	"machine_tool_change_time": "10",
-	"machine_load_filament_time": "0",
-	"machine_unload_filament_time": "0",
-	"retract_lift_below": [
-		"279",
-		"279",
-		"279",
-		"279"
-	],
-	"enable_long_retraction_when_cut": [
-		"0",
-		"0",
-		"0",
-		"0"
-	],
-	"long_retractions_when_cut": [
-		"0",
-		"0",
-		"0",
-		"0"
 	]
 }

--- a/resources/profiles/WonderMaker/machine/WonderMaker ZR Ultra 0.6 nozzle.json
+++ b/resources/profiles/WonderMaker/machine/WonderMaker ZR Ultra 0.6 nozzle.json
@@ -1,21 +1,22 @@
 {
 	"type": "machine",
 	"name": "WonderMaker ZR Ultra 0.6 nozzle",
-	"inherits": "WonderMaker ZR Ultra 0.4 nozzle",
+	"inherits": "fdm_ultra_common",
 	"from": "system",
 	"setting_id": "6OWxZLFn3RD54QfX",
 	"instantiation": "true",
+	"printer_model": "WonderMaker ZR Ultra",
+	"printer_variant": "0.6",
+	"default_print_profile": "0.30mm Standard @WonderMaker ZR Ultra 0.6 nozzle",
+	"default_bed_type": "4",
+	"max_layer_height": [
+		"0.42"
+	],
 	"nozzle_diameter": [
 		"0.6",
 		"0.6",
 		"0.6",
 		"0.6"
-	],
-	"printer_model": "WonderMaker ZR Ultra",
-	"printer_variant": "0.6",
-	"default_print_profile": "0.30mm Standard @WonderMaker ZR Ultra 0.6 nozzle",
-	"max_layer_height": [
-		"0.42"
 	],
 	"min_layer_height": [
 		"0.12"

--- a/resources/profiles/WonderMaker/machine/WonderMaker ZR Ultra 0.8 nozzle.json
+++ b/resources/profiles/WonderMaker/machine/WonderMaker ZR Ultra 0.8 nozzle.json
@@ -1,21 +1,22 @@
 {
 	"type": "machine",
 	"name": "WonderMaker ZR Ultra 0.8 nozzle",
-	"inherits": "WonderMaker ZR Ultra 0.4 nozzle",
+	"inherits": "fdm_ultra_common",
 	"from": "system",
 	"setting_id": "SY9snlsMkurhEYWP",
 	"instantiation": "true",
+	"printer_model": "WonderMaker ZR Ultra",
+	"printer_variant": "0.8",
+	"default_print_profile": "0.40mm Standard @WonderMaker ZR Ultra 0.8 nozzle",
+	"default_bed_type": "4",
+	"max_layer_height": [
+		"0.56"
+	],
 	"nozzle_diameter": [
 		"0.8",
 		"0.8",
 		"0.8",
 		"0.8"
-	],
-	"printer_model": "WonderMaker ZR Ultra",
-	"printer_variant": "0.8",
-	"default_print_profile": "0.40mm Standard @WonderMaker ZR Ultra 0.8 nozzle",
-	"max_layer_height": [
-		"0.56"
 	],
 	"min_layer_height": [
 		"0.16"

--- a/resources/profiles/WonderMaker/machine/WonderMaker ZR Ultra S 0.2 nozzle.json
+++ b/resources/profiles/WonderMaker/machine/WonderMaker ZR Ultra S 0.2 nozzle.json
@@ -1,29 +1,19 @@
 {
 	"type": "machine",
 	"name": "WonderMaker ZR Ultra S 0.2 nozzle",
-	"inherits": "WonderMaker ZR Ultra S 0.4 nozzle",
+	"inherits": "WonderMaker ZR Ultra 0.2 nozzle",
 	"from": "system",
 	"setting_id": "ZNAx3f7tX3DatiK1",
 	"instantiation": "true",
+	"printer_model": "WonderMaker ZR Ultra S",
 	"nozzle_diameter": [
 		"0.2",
 		"0.2",
 		"0.2",
 		"0.2"
 	],
-	"printer_model": "WonderMaker ZR Ultra S",
-	"printer_variant": "0.2",
 	"default_print_profile": "0.10mm Standard @WonderMaker ZR Ultra 0.2 nozzle",
-	"max_layer_height": [
-		"0.14"
-	],
-	"min_layer_height": [
-		"0.04"
-	],
-	"retraction_length": [
-		"0.4",
-		"0.4",
-		"0.4",
-		"0.4"
-	]
+	"printer_variant": "0.2",
+	"support_air_filtration": "1",
+	"support_chamber_temp_control": "1"
 }

--- a/resources/profiles/WonderMaker/machine/WonderMaker ZR Ultra S 0.4 nozzle.json
+++ b/resources/profiles/WonderMaker/machine/WonderMaker ZR Ultra S 0.4 nozzle.json
@@ -1,65 +1,18 @@
 {
 	"type": "machine",
 	"name": "WonderMaker ZR Ultra S 0.4 nozzle",
-	"inherits": "fdm_klipper_common",
+	"inherits": "WonderMaker ZR Ultra 0.4 nozzle",
 	"from": "system",
 	"setting_id": "8xoZ6vYv9ws0J97u",
 	"instantiation": "true",
 	"printer_model": "WonderMaker ZR Ultra S",
-	"default_print_profile": "0.20mm Standard @WonderMaker ZR Ultra",
-	"default_bed_type": "4",
-	"default_filament_profile": [
-		"WonderMaker PLA Basic"
-	],
-	"single_extruder_multi_material": "0",
 	"nozzle_diameter": [
 		"0.4",
 		"0.4",
 		"0.4",
 		"0.4"
 	],
-	"printable_area": [
-		"0x0",
-		"300x0",
-		"300x270",
-		"0x270"
-	],
-	"bed_exclude_area": [],
-	"printable_height": "290",
-	"extruder_clearance_radius": "134",
-	"bed_mesh_min": [
-		"10",
-		"10"
-	],
-	"bed_mesh_max": [
-		"290",
-		"260"
-	],
-	"bed_mesh_probe_distance": [
-		"50",
-		"50"
-	],
+	"default_print_profile": "0.20mm Standard @WonderMaker ZR Ultra",
 	"support_air_filtration": "1",
-	"support_chamber_temp_control": "1",
-	"machine_tool_change_time": "10",
-	"machine_load_filament_time": "0",
-	"machine_unload_filament_time": "0",
-	"retract_lift_below": [
-		"279",
-		"279",
-		"279",
-		"279"
-	],
-	"enable_long_retraction_when_cut": [
-		"0",
-		"0",
-		"0",
-		"0"
-	],
-	"long_retractions_when_cut": [
-		"0",
-		"0",
-		"0",
-		"0"
-	]
+	"support_chamber_temp_control": "1"
 }

--- a/resources/profiles/WonderMaker/machine/WonderMaker ZR Ultra S 0.6 nozzle.json
+++ b/resources/profiles/WonderMaker/machine/WonderMaker ZR Ultra S 0.6 nozzle.json
@@ -1,32 +1,19 @@
 {
 	"type": "machine",
 	"name": "WonderMaker ZR Ultra S 0.6 nozzle",
-	"inherits": "WonderMaker ZR Ultra S 0.4 nozzle",
+	"inherits": "WonderMaker ZR Ultra 0.6 nozzle",
 	"from": "system",
 	"setting_id": "xuJnOPTmSW1BMo6p",
 	"instantiation": "true",
 	"printer_model": "WonderMaker ZR Ultra S",
-	"default_print_profile": "0.30mm Standard @WonderMaker ZR Ultra 0.6 nozzle",
-	"printer_variant": "0.6",
 	"nozzle_diameter": [
+		"0.6",
+		"0.6",
+		"0.6",
 		"0.6"
 	],
-	"max_layer_height": [
-		"0.42"
-	],
-	"min_layer_height": [
-		"0.12"
-	],
-	"retraction_length": [
-		"1.4",
-		"1.4",
-		"1.4",
-		"1.4"
-	],
-	"retraction_minimum_travel": [
-		"3",
-		"3",
-		"3",
-		"3"
-	]
+	"default_print_profile": "0.30mm Standard @WonderMaker ZR Ultra 0.6 nozzle",
+	"printer_variant": "0.6",
+	"support_air_filtration": "1",
+	"support_chamber_temp_control": "1"
 }

--- a/resources/profiles/WonderMaker/machine/WonderMaker ZR Ultra S 0.8 nozzle.json
+++ b/resources/profiles/WonderMaker/machine/WonderMaker ZR Ultra S 0.8 nozzle.json
@@ -1,32 +1,19 @@
 {
 	"type": "machine",
 	"name": "WonderMaker ZR Ultra S 0.8 nozzle",
-	"inherits": "WonderMaker ZR Ultra S 0.4 nozzle",
+	"inherits": "WonderMaker ZR Ultra 0.8 nozzle",
 	"from": "system",
 	"setting_id": "0BPLKMspArilfkGT",
 	"instantiation": "true",
 	"printer_model": "WonderMaker ZR Ultra S",
-	"default_print_profile": "0.40mm Standard @WonderMaker ZR Ultra 0.8 nozzle",
-	"printer_variant": "0.8",
 	"nozzle_diameter": [
+		"0.8",
+		"0.8",
+		"0.8",
 		"0.8"
 	],
-	"max_layer_height": [
-		"0.56"
-	],
-	"min_layer_height": [
-		"0.16"
-	],
-	"retract_length_toolchange": [
-		"3",
-		"3",
-		"3",
-		"3"
-	],
-	"retraction_length": [
-		"3",
-		"3",
-		"3",
-		"3"
-	]
+	"default_print_profile": "0.40mm Standard @WonderMaker ZR Ultra 0.8 nozzle",
+	"printer_variant": "0.8",
+	"support_air_filtration": "1",
+	"support_chamber_temp_control": "1"
 }

--- a/resources/profiles/WonderMaker/machine/fdm_ultra_common.json
+++ b/resources/profiles/WonderMaker/machine/fdm_ultra_common.json
@@ -1,0 +1,64 @@
+{
+	"type": "machine",
+	"name": "fdm_ultra_common",
+	"inherits": "fdm_klipper_common",
+	"from": "system",
+	"instantiation": "false",
+	"default_bed_type": "4",
+	"default_filament_profile": [
+		"WonderMaker PLA Basic"
+	],
+	"single_extruder_multi_material": "0",
+	"enable_filament_mapping": "1",
+	"filament_swap_gcode": "M117 Swap filament for tool {next_extruder}\nPAUSE",
+	"nozzle_diameter": [
+		"0.4",
+		"0.4",
+		"0.4",
+		"0.4"
+	],
+	"printable_area": [
+		"0x0",
+		"300x0",
+		"300x270",
+		"0x270"
+	],
+	"bed_exclude_area": [],
+	"printable_height": "290",
+	"extruder_clearance_radius": "134",
+	"bed_mesh_min": [
+		"10",
+		"10"
+	],
+	"bed_mesh_max": [
+		"290",
+		"260"
+	],
+	"bed_mesh_probe_distance": [
+		"50",
+		"50"
+	],
+	"support_air_filtration": "0",
+	"support_chamber_temp_control": "0",
+	"machine_tool_change_time": "10",
+	"machine_load_filament_time": "0",
+	"machine_unload_filament_time": "0",
+	"retract_lift_below": [
+		"279",
+		"279",
+		"279",
+		"279"
+	],
+	"enable_long_retraction_when_cut": [
+		"0",
+		"0",
+		"0",
+		"0"
+	],
+	"long_retractions_when_cut": [
+		"0",
+		"0",
+		"0",
+		"0"
+	]
+}


### PR DESCRIPTION


# Description

- Adds a new fdm_ultra_common profile to hold all common ZR Ultra toolchanger attributes.
- The S variants are the base machines plus an enclosure heater and filtration, so each now inherits its matching ZR Ultra profile instead of duplicating the per-nozzle values
- Also fixes Ultra S 0.6 and 0.8 - original were declared a single nozzle_diameter entry, so OrcaSlicer treated four-tool machines as single-extruder.
- ZR Ultra S 0.8's retraction_minimum_travel now matches the base Ultra.

# Screenshots/Recordings/Graphs

This is what the current broken 0.6 / 0.8 profile does:
<img width="949" height="460" alt="image" src="https://github.com/user-attachments/assets/ffbc95b5-63b0-47e5-b9bf-32b63df1c526" />


## Tests

After:
<img width="866" height="463" alt="image" src="https://github.com/user-attachments/assets/5d4809db-1992-40e0-a062-636ebc0affc1" />


[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
