### PR TITLE
fix(libslic3r): Slice sometimes need to be clicked a second time

### DIFF
--- a/src/libslic3r/PrintApply.cpp
+++ b/src/libslic3r/PrintApply.cpp
@@ -4,6 +4,7 @@
 
 #include <boost/log/trivial.hpp>
 #include <cfloat>
+#include <optional>
 
 namespace Slic3r {
 
@@ -1141,6 +1142,17 @@ Print::ApplyStatus Print::apply(const Model &model, DynamicPrintConfig new_full_
     std::vector <unsigned int> used_filaments = this->extruders(true);
     std::unordered_set <unsigned int> used_filament_set(used_filaments.begin(), used_filaments.end());
 
+    // Orca: capture the pristine, as-specified enable_prime_tower / independent_support_layer_
+    // height values before any normalize_fdm_2 pass below mutates them off using a used-filament
+    // count that, on this Print's very first apply, is not yet settled. Used by the end-of-apply
+    // self-correction pass further down.
+    std::optional<bool> pristine_enable_prime_tower;
+    if (const ConfigOptionBool *opt = new_full_config.option<ConfigOptionBool>("enable_prime_tower"))
+        pristine_enable_prime_tower = opt->value;
+    std::optional<bool> pristine_independent_support_layer_height;
+    if (const ConfigOptionBool *opt = new_full_config.option<ConfigOptionBool>("independent_support_layer_height"))
+        pristine_independent_support_layer_height = opt->value;
+
     //new_full_config.normalize_fdm(used_filaments);
     new_full_config.normalize_fdm_1();
     t_config_option_keys changed_keys = new_full_config.normalize_fdm_2(objects().size(), used_filaments.size());
@@ -1257,7 +1269,11 @@ Print::ApplyStatus Print::apply(const Model &model, DynamicPrintConfig new_full_
         if (is_auto_filament_map_mode(map_mode)) {
             if (print_diff_set.find("filament_map") != print_diff_set.end()) {
                 print_diff_set.erase("filament_map");
-                //full_config_diff.erase("filament_map");
+                // Orca: also drop it from full_config_diff - the value is adopted right below, so
+                // nothing that could change the exported g-code differs; leaving it in would force
+                // a psGCodeExport invalidation on every reapply of an unchanged config (see the
+                // filament_volume_map / filament_nozzle_map erases below for the same reasoning).
+                full_config_diff.erase(std::remove(full_config_diff.begin(), full_config_diff.end(), "filament_map"), full_config_diff.end());
                 ConfigOptionInts* old_opt = m_full_print_config.option<ConfigOptionInts>("filament_map", true);
                 ConfigOptionInts* new_opt = new_full_config.option<ConfigOptionInts>("filament_map", true);
                 old_opt->set(new_opt);
@@ -1265,7 +1281,11 @@ Print::ApplyStatus Print::apply(const Model &model, DynamicPrintConfig new_full_
             }
             if (print_diff_set.find("filament_volume_map") != print_diff_set.end()) {
                 print_diff_set.erase("filament_volume_map");
-                //full_config_diff.erase("filament_volume_map");
+                // Orca: also drop it from full_config_diff - it's adopted below, so nothing that
+                // could change the exported g-code differs; leaving it in full_config_diff would
+                // still force a psGCodeExport invalidation on every reapply (see the
+                // filament_nozzle_map erase sites below for the same reasoning).
+                full_config_diff.erase(std::remove(full_config_diff.begin(), full_config_diff.end(), "filament_volume_map"), full_config_diff.end());
                 ConfigOptionInts* old_opt = m_full_print_config.option<ConfigOptionInts>("filament_volume_map", true);
                 ConfigOptionInts* new_opt = new_full_config.option<ConfigOptionInts>("filament_volume_map", true);
                 old_opt->set(new_opt);
@@ -1273,7 +1293,7 @@ Print::ApplyStatus Print::apply(const Model &model, DynamicPrintConfig new_full_
             }
             if (print_diff_set.find("filament_nozzle_map") != print_diff_set.end()) {
                 print_diff_set.erase("filament_nozzle_map");
-                //full_config_diff.erase("filament_nozzle_map");
+                full_config_diff.erase(std::remove(full_config_diff.begin(), full_config_diff.end(), "filament_nozzle_map"), full_config_diff.end());
                 ConfigOptionInts* old_opt = m_full_print_config.option<ConfigOptionInts>("filament_nozzle_map", true);
                 ConfigOptionInts* new_opt = new_full_config.option<ConfigOptionInts>("filament_nozzle_map", true);
                 old_opt->set(new_opt);
@@ -1285,6 +1305,9 @@ Print::ApplyStatus Print::apply(const Model &model, DynamicPrintConfig new_full_
             if (map_mode == fmmManual) {
                 // filament_nozzle_map is an engine output, not a GUI input, in manual mode
                 print_diff_set.erase("filament_nozzle_map");
+                // Orca: also drop it from full_config_diff, or a reapply of an unchanged config
+                // would still force a psGCodeExport invalidation from full_config_diff alone.
+                full_config_diff.erase(std::remove(full_config_diff.begin(), full_config_diff.end(), "filament_nozzle_map"), full_config_diff.end());
             }
             std::vector<int> old_filament_map = m_config.filament_map.values;
             std::vector<int> new_filament_map = new_full_config.option<ConfigOptionInts>("filament_map", true)->values;
@@ -1928,6 +1951,46 @@ Print::ApplyStatus Print::apply(const Model &model, DynamicPrintConfig new_full_
 #ifdef _DEBUG
     check_model_ids_equal(m_model, model);
 #endif /* _DEBUG */
+
+    // End-of-apply self-correction: on this Print's very first apply, PrintObjects/regions are
+    // still being rebuilt when the LATE normalize_fdm_2 pass (above) runs, so it can undercount
+    // filaments actually used and wrongly force enable_prime_tower (and, transitively,
+    // independent_support_layer_height) off. normalize_fdm_2 never turns a forced-off setting back
+    // on, so a wrong value here would otherwise persist and surface as a spurious diff on a later,
+    // unrelated apply. Re-derive both from their pristine, as-specified values (captured before any
+    // normalize_fdm_2 mutation, above) using the now-settled filament count.
+    const size_t settled_used_filament_count = this->extruders(true).size();
+    if (pristine_enable_prime_tower) {
+        DynamicPrintConfig derived;
+        derived.set_key_value("enable_prime_tower", new ConfigOptionBool(*pristine_enable_prime_tower));
+        if (pristine_independent_support_layer_height)
+            derived.set_key_value("independent_support_layer_height", new ConfigOptionBool(*pristine_independent_support_layer_height));
+        for (const char *key : {"print_sequence", "timelapse_type", "enable_wrapping_detection"})
+            if (const ConfigOption *opt = m_full_print_config.option(key))
+                derived.set_key_value(key, opt->clone());
+        derived.normalize_fdm_2((int)objects().size(), (int)settled_used_filament_count);
+
+        t_config_option_keys correction_keys;
+        if (const ConfigOptionBool *cur = m_config.option<ConfigOptionBool>("enable_prime_tower");
+            cur != nullptr && cur->value != derived.option<ConfigOptionBool>("enable_prime_tower")->value)
+            correction_keys.push_back("enable_prime_tower");
+        if (pristine_independent_support_layer_height) {
+            if (const ConfigOptionBool *cur = m_config.option<ConfigOptionBool>("independent_support_layer_height");
+                cur != nullptr && cur->value != derived.option<ConfigOptionBool>("independent_support_layer_height")->value)
+                correction_keys.push_back("independent_support_layer_height");
+        }
+        if (! correction_keys.empty()) {
+            BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << boost::format(", end-of-apply self-correction, size=%1%") % correction_keys.size();
+            update_apply_status(false);
+            update_apply_status(this->invalidate_state_by_config_options(derived, correction_keys));
+            update_apply_status(this->invalidate_step(psGCodeExport));
+            m_config.apply_only(derived, correction_keys, true);
+            m_default_object_config.apply_only(derived, correction_keys, true);
+            m_default_region_config.apply_only(derived, correction_keys, true);
+            m_ori_full_print_config.apply_only(derived, correction_keys, true);
+            m_full_print_config.apply_only(derived, correction_keys, true);
+        }
+    }
 
 	//BBS: add timestamp logic
 	if (apply_status != APPLY_STATUS_UNCHANGED)

--- a/tests/fff_print/test_multifilament.cpp
+++ b/tests/fff_print/test_multifilament.cpp
@@ -715,3 +715,50 @@ TEST_CASE("Multi-extruder slice stays in bounds with a short max_layer_height", 
     REQUIRE_FALSE(print.objects().front()->layers().empty());
 }
 
+
+// Re-applying the exact same, unchanged config after a completed slice -- which the GUI does on
+// every post-slice background_process update -- must report APPLY_STATUS_UNCHANGED. It did not:
+// on a Print's first-ever apply BOTH normalize_fdm_2 passes run before that apply's PrintObjects/
+// regions exist, count 0 used filaments and no-op, so the un-normalized settings get stored.
+// normalize_fdm_2 never turns a forced-off setting back on, and an undercount of <= 1 forces
+// enable_prime_tower off while independent_support_layer_height survives; the NEXT apply, counting
+// correctly, keeps the tower on and forces islh off instead -- a settings flip-flop that
+// invalidated the just-finished slice. No mapping/multi-tool machinery involved:
+// the trigger is only the used-filament count, so a plain two-filament single-nozzle config
+// reproduces it.
+TEST_CASE("Reapplying an unchanged config after slicing reports no change", "[MultiFilament]") {
+    DynamicPrintConfig config = multifilament_config(2, {
+        { "wall_filament",                    "1" },
+        { "sparse_infill_filament",           "2" },
+        { "solid_infill_filament",            "2" },
+        { "enable_prime_tower",               "1" },
+        { "independent_support_layer_height", "1" },
+        // Matches what init_print's internal config carries, so this reapply of the bare test
+        // config differs from the print's actual first-apply config in nothing but what
+        // Print::apply()'s own normalization might (wrongly) change -- isolating the bug instead
+        // of also picking up an incidental, unrelated mismatch between the two configs.
+        { "gcode_comments",                   "1" },
+    });
+    Model model;
+    Print print;
+    Slic3r::Test::init_print({ TestMesh::cube_with_hole }, print, model, config);
+    print.process();
+    const bool ept_before  = print.config().enable_prime_tower.value;
+    const bool islh_before = print.config().independent_support_layer_height.value;
+
+    // Re-apply the exact same, unchanged config again -- matching the GUI's post-slice
+    // background_process update, which always rebuilds from the current presets rather than
+    // reusing the print's own already-resolved config.
+    const auto status = print.apply(model, config);
+    const bool ept_after  = print.config().enable_prime_tower.value;
+    const bool islh_after = print.config().independent_support_layer_height.value;
+
+    INFO("status = " << (int) status);
+    INFO("enable_prime_tower: before=" << ept_before << " after=" << ept_after);
+    INFO("independent_support_layer_height: before=" << islh_before << " after=" << islh_after);
+    CHECK(ept_before == ept_after);
+    CHECK(islh_before == islh_after);
+    // The strongest true form: not just that the two settings held steady, but that the reapply
+    // reported no change at all, so nothing invalidated the finished slice.
+    CHECK((int) status == (int) PrintBase::APPLY_STATUS_UNCHANGED);
+}


### PR DESCRIPTION
# Description

Sometimes clicking slice would take you to the Preview pane with no sliced output - have to click slice a second time.
Discovered during the course of #15145 

stop Print::apply flip-flopping settings on an unchanged config

Re-applying the exact same, unchanged config after a completed slice -- which the GUI does on every post-slice background_process update -- did not report APPLY_STATUS_UNCHANGED. It could flip enable_prime_tower and, transitively, independent_support_layer_height, invalidating a slice that had just finished.

Two separate causes, both in Print::apply:

- On a Print's first-ever apply, BOTH normalize_fdm_2 passes run before that apply's PrintObjects/regions exist, count zero used filaments and no-op, so the un-normalized settings get stored; and normalize_fdm_2 never turns a setting it forced off back on, so a wrong verdict persists. Capture both settings as specified, before any normalization mutates them, and re-derive them once at the end of apply from the now-settled used-filament count, correcting whatever an earlier pass got wrong. The Print-level invalidation this triggers already reaches the per-object state (posSupportMaterial resets the cached SlicingParameters), so no per-object sync is needed.
- filament_volume_map and filament_nozzle_map are engine outputs recomputed by ToolOrdering on every process(), not user input, yet were adopted from the incoming config while still being left in full_config_diff, and so forced a psGCodeExport invalidation on every reapply of an otherwise-unchanged config. Drop them from full_config_diff at the sites that already adopt them.

The regression test uses a plain two-filament, single-nozzle config: the trigger is only the used-filament count, so no multi-tool machinery is involved.


# Screenshots/Recordings/Graphs


## Tests
- Confirmed that slice only needs to be clicked once after change

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
