### PR TITLE
View and edit the filaments on the printer

### DIFF
--- a/localization/i18n/list.txt
+++ b/localization/i18n/list.txt
@@ -259,6 +259,8 @@ src/slic3r/GUI/MultiMachine.cpp
 src/slic3r/GUI/FilamentMapDialog.cpp
 src/slic3r/GUI/FilamentGroupPopup.cpp
 src/slic3r/GUI/FilamentMapPanel.cpp
+src/slic3r/GUI/FilamentInventoryEditor.cpp
+src/slic3r/GUI/FilamentInventoryEditor.hpp
 src/slic3r/Utils/Obico.cpp
 src/slic3r/Utils/SimplyPrint.cpp
 src/slic3r/Utils/Flashforge.cpp

--- a/src/OrcaSlicer.cpp
+++ b/src/OrcaSlicer.cpp
@@ -1268,6 +1268,35 @@ int CLI::run(int argc, char **argv)
             }
             #endif
 
+            // WSLg fallback: WSL's compositor is a fork of old Weston, the strictest
+            // xdg-shell implementation around. It terminates the client (Gdk "Error 71
+            // (Protocol error)") on the nested popup windows wx builds for cascading
+            // dropdowns/flyouts, and its Mesa stack cannot provide a hardware EGL context
+            // on native Wayland either (zink "failed to choose pdev"), so the 3D view runs
+            // degraded at best. XWayland is fully functional there and is what WSLg
+            // actually optimizes for. Detect WSL (kernel osrelease carries "microsoft")
+            // on a Wayland session and select the X11 path before GTK initializes.
+            // GDK_BACKEND set by the user still wins: this runs only when it was unset.
+            {
+                const char* wayland_env = ::getenv("WAYLAND_DISPLAY");
+                if (wayland_env && *wayland_env) {
+                    bool is_wsl = false;
+                    if (boost::nowide::ifstream osrelease("/proc/sys/kernel/osrelease"); osrelease) {
+                        std::string kernel_release;
+                        std::getline(osrelease, kernel_release);
+                        is_wsl = boost::algorithm::icontains(kernel_release, "microsoft");
+                    }
+                    if (is_wsl) {
+                        BOOST_LOG_TRIVIAL(warning) << "WSL detected on a Wayland session; forcing the X11/XWayland backend "
+                                                      "(WSLg's compositor rejects nested popup windows and lacks native-Wayland EGL).";
+                        ::setenv("GDK_BACKEND", "x11", true);
+                        #if __has_include(<X11/Xlib.h>)
+                        XInitThreads();
+                        #endif
+                    }
+                }
+            }
+
             // WebKit2GTK compositing can fail under XWayland on older
             // WebKit releases. Disable it only when both DISPLAY and
             // WAYLAND_DISPLAY are set (i.e. an XWayland session is in

--- a/src/libslic3r/CMakeLists.txt
+++ b/src/libslic3r/CMakeLists.txt
@@ -478,6 +478,8 @@ set(lisbslic3r_sources
     GCode/ToolOrderUtils.cpp
     FlushVolPredictor.hpp
     FlushVolPredictor.cpp
+    FilamentInventory.hpp
+    FilamentInventory.cpp
 )
 
 if (APPLE)

--- a/src/libslic3r/FilamentInventory.cpp
+++ b/src/libslic3r/FilamentInventory.cpp
@@ -1,0 +1,746 @@
+#include "FilamentInventory.hpp"
+
+#include <nlohmann/json.hpp>
+
+#include <algorithm>
+#include <cctype>
+#include <iomanip>
+#include <limits>
+#include <sstream>
+#include <unordered_set>
+
+#include <boost/log/trivial.hpp>
+
+namespace Slic3r {
+
+using json = nlohmann::json;
+
+static const char* kind_to_string(PhysicalFilament::Kind kind)
+{
+    return kind == PhysicalFilament::Kind::Mmu ? "mmu" : "manual";
+}
+
+static PhysicalFilament::Kind kind_from_string(const std::string& s)
+{
+    return s == "mmu" ? PhysicalFilament::Kind::Mmu : PhysicalFilament::Kind::Manual;
+}
+
+std::string FilamentInventory::serialize() const
+{
+    json jtools = json::array();
+    for (const auto& tool : tools) {
+        json jtool = json::array();
+        for (const auto& pf : tool)
+            jtool.push_back({ {"id", pf.id}, {"color", pf.color}, {"type", pf.type}, {"preset", pf.preset}, {"kind", kind_to_string(pf.kind)} });
+        jtools.push_back(std::move(jtool));
+    }
+    json j;
+    j["next_id"] = next_id;
+    j["tools"]   = std::move(jtools);
+    return j.dump();
+}
+
+FilamentInventory FilamentInventory::deserialize(const std::string& s, size_t tool_count)
+{
+    auto empty_inventory = [tool_count]() {
+        FilamentInventory inv;
+        inv.tools.assign(tool_count, std::vector<PhysicalFilament>(1));
+        inv.next_id = 1;
+        return inv;
+    };
+
+    json j;
+    try {
+        j = json::parse(s);
+    } catch (...) {
+        return empty_inventory();
+    }
+
+    if (!j.is_object() || !j.contains("tools") || !j["tools"].is_array())
+        return empty_inventory();
+
+    FilamentInventory inv;
+    inv.tools.assign(tool_count, std::vector<PhysicalFilament>(1));
+    const json& jtools = j["tools"];
+    for (size_t i = 0; i < tool_count && i < jtools.size(); ++i) {
+        if (!jtools[i].is_array())
+            continue;
+        std::vector<PhysicalFilament> slots;
+        for (const auto& jpf : jtools[i]) {
+            if (!jpf.is_object())
+                continue;
+            PhysicalFilament pf;
+            if (jpf.contains("id") && jpf["id"].is_number_integer())
+                pf.id = jpf["id"].get<int>();
+            if (jpf.contains("color") && jpf["color"].is_string())
+                pf.color = jpf["color"].get<std::string>();
+            if (jpf.contains("type") && jpf["type"].is_string())
+                pf.type = jpf["type"].get<std::string>();
+            if (jpf.contains("preset") && jpf["preset"].is_string())
+                pf.preset = jpf["preset"].get<std::string>();
+            if (jpf.contains("kind") && jpf["kind"].is_string())
+                pf.kind = kind_from_string(jpf["kind"].get<std::string>());
+            slots.push_back(pf);
+        }
+        if (slots.empty())
+            slots.resize(1); // slot 0 (loaded) must always be present
+        inv.tools[i] = std::move(slots);
+    }
+
+    // Reconcile ids from untrusted input: find()/tool_of() key on id, so a duplicate would make
+    // one entry unreachable, and a next_id at or below an id already in use would let the
+    // allocator mint a fresh collision the moment it's used. Renumber the colliding or
+    // missing/invalid (<=0) id via the allocator rather than dropping the entry -- that preserves
+    // the caller's color/type data. Empty slots (nothing recorded) keep whatever id parsed,
+    // including 0/absent; they carry no data to collide over.
+    int max_id = 0;
+    for (const auto& tool : inv.tools)
+        for (const auto& pf : tool)
+            max_id = std::max(max_id, pf.id);
+    int parsed_next_id = (j.contains("next_id") && j["next_id"].is_number_integer()) ? j["next_id"].get<int>() : 1;
+    int next_id = std::max(1, std::max(parsed_next_id, max_id + 1));
+
+    std::unordered_set<int> seen_ids;
+    for (auto& tool : inv.tools) {
+        for (auto& pf : tool) {
+            if (pf.empty())
+                continue;
+            if (pf.id > 0 && seen_ids.insert(pf.id).second)
+                continue; // first time we've seen this id; keep it
+            pf.id = next_id++;
+            seen_ids.insert(pf.id);
+        }
+    }
+    inv.next_id = next_id;
+    return inv;
+}
+
+void FilamentInventory::ensure_ids()
+{
+    int max_id = 0;
+    for (const auto& tool : tools)
+        for (const auto& pf : tool)
+            max_id = std::max(max_id, pf.id);
+    next_id = std::max({1, next_id, max_id + 1});
+    for (auto& tool : tools)
+        for (auto& pf : tool) {
+            if (!pf.empty() && pf.id <= 0)
+                pf.id = next_id++;
+            else if (pf.empty() && pf.id > 0)
+                pf.id = 0; // a cleared slot round-trips as canonically empty, not a stale reference
+        }
+}
+
+void FilamentInventory::ensure_tool_count(size_t tool_count)
+{
+    while (tools.size() < tool_count)
+        tools.emplace_back(1);
+}
+
+void FilamentInventory::apply_synced_loaded_slot(size_t tool_idx, const PhysicalFilament& slot)
+{
+    ensure_tool_count(tool_idx + 1);
+    tools[tool_idx][0] = slot;
+}
+
+const PhysicalFilament* FilamentInventory::find(int id) const
+{
+    if (id <= 0)
+        return nullptr;
+    for (const auto& tool : tools)
+        for (const auto& pf : tool)
+            if (pf.id == id)
+                return &pf;
+    return nullptr;
+}
+
+int FilamentInventory::tool_of(int id) const
+{
+    if (id <= 0)
+        return -1;
+    for (size_t ti = 0; ti < tools.size(); ++ti)
+        for (const auto& pf : tools[ti])
+            if (pf.id == id)
+                return static_cast<int>(ti);
+    return -1;
+}
+
+// --- auto_map_filaments helpers -------------------------------------------------------------
+
+static std::string trim_lower(const std::string& s)
+{
+    size_t begin = s.find_first_not_of(" \t\r\n");
+    if (begin == std::string::npos)
+        return {};
+    size_t end = s.find_last_not_of(" \t\r\n");
+    std::string out = s.substr(begin, end - begin + 1);
+    std::transform(out.begin(), out.end(), out.begin(), [](unsigned char c) { return (char) std::tolower(c); });
+    return out;
+}
+
+// Table-driven family compatibility, deliberately small and explicit so it is trivial to extend.
+// CF/GF/wood/etc variants are their own normalized types (never in a family table entry), so they
+// only match themselves exactly -- never a plain base type.
+static bool same_material_family(const std::string& a, const std::string& b)
+{
+    static const std::vector<std::vector<const char*>> families = {
+        {"pla", "pla+"},
+        {"petg", "petg+"},
+    };
+    for (const auto& family : families) {
+        bool has_a = std::find(family.begin(), family.end(), a) != family.end();
+        bool has_b = std::find(family.begin(), family.end(), b) != family.end();
+        if (has_a && has_b)
+            return true;
+    }
+    return false;
+}
+
+static bool type_compatible(const std::string& project_type, const std::string& slot_type)
+{
+    std::string a = trim_lower(project_type);
+    std::string b = trim_lower(slot_type);
+    if (a.empty() || b.empty())
+        return false;
+    if (a == b)
+        return true;
+    return same_material_family(a, b);
+}
+
+// Squared-RGB distance (not a perceptual ΔE), used for the auto-mapper's color matching. Accepts "#RRGGBB" or
+// "#RRGGBBAA" (alpha ignored). An unparseable/missing color on either
+// side is treated as maximally far so it never outranks a real color match, while still letting a
+// type-only candidate win when it is the only compatible one.
+static bool parse_hex_rgb(const std::string& s, int& r, int& g, int& b)
+{
+    if ((s.size() != 7 && s.size() != 9) || s[0] != '#')
+        return false;
+    try {
+        r = std::stoi(s.substr(1, 2), nullptr, 16);
+        g = std::stoi(s.substr(3, 2), nullptr, 16);
+        b = std::stoi(s.substr(5, 2), nullptr, 16);
+    } catch (...) {
+        return false;
+    }
+    return true;
+}
+
+static float auto_map_color_distance(const std::string& a, const std::string& b)
+{
+    int ar, ag, ab, br, bg, bb;
+    if (!parse_hex_rgb(a, ar, ag, ab) || !parse_hex_rgb(b, br, bg, bb))
+        return std::numeric_limits<float>::max();
+    float dr = float(ar - br), dg = float(ag - bg), db = float(ab - bb);
+    return dr * dr + dg * dg + db * db;
+}
+
+// A gross color mismatch must not be auto-proposed without confirmation -- the user may still
+// choose red-for-blue by hand, but auto-map must not propose it unasked. Colors farther apart
+// than this squared-RGB distance disqualify an otherwise family-compatible candidate at the
+// family/color tier, and an otherwise exact-preset match at the preset tier (a matching preset
+// string alone doesn't prove the spool in front of the user is the one meant when its color is
+// nowhere close). A durable assignment is exempt (an explicit user pick, not a derived match), as
+// is a slot/filament with no color recorded (never disqualified, only ranked last).
+static constexpr float kMaxFamilyColorDistance = 10000.f;
+
+// First whitespace-delimited token of a slot's preset display name, i.e. its vendor per the
+// "<Vendor> <Type> <SubType>" convention documented on derive_filament_subtype above. Empty when
+// the slot carries no preset (unknown vendor).
+static std::string preset_vendor_token(const std::string& preset)
+{
+    size_t space = preset.find(' ');
+    return trim_lower(space == std::string::npos ? preset : preset.substr(0, space));
+}
+
+AutoMapResult auto_map_filaments(
+    const std::vector<ProjectFilamentInfo>& project,
+    const FilamentInventory&                inventory,
+    const std::vector<SlotAssignment>&      assignments)
+{
+    AutoMapResult result;
+    result.filament_map.assign(project.size(), 1);   // fallback tool, overwritten below on match
+    result.physical_map.assign(project.size(), -1);
+
+    std::map<int, SlotAssignment> assignment_by_filament;
+    for (const auto& a : assignments)
+        assignment_by_filament[a.filament_idx] = a; // last one wins on a duplicate filament_idx
+
+    for (size_t i = 0; i < project.size(); ++i) {
+        auto ait = assignment_by_filament.find((int) i);
+        if (ait != assignment_by_filament.end()) {
+            const SlotAssignment& a = ait->second;
+            if (a.tool >= 0 && (size_t) a.tool < inventory.tools.size() &&
+                a.slot >= 0 && (size_t) a.slot < inventory.tools[a.tool].size() &&
+                !inventory.tools[a.tool][a.slot].empty()) {
+                result.filament_map[i] = a.tool + 1;
+                result.physical_map[i] = inventory.tools[a.tool][a.slot].id;
+                continue; // durable assignment wins outright, even over a closer color match
+            }
+            // Stale (tool/slot no longer exist, or the slot has since gone empty -- e.g. a printer
+            // sync cleared the tool this assignment was written against): fall through to matching.
+        }
+
+        // An exact profile match is trusted over anything derived from type/color -- checked
+        // before family/color matching, but only after a durable assignment (which still wins
+        // outright even over an exact-preset slot). Among several exact-preset slots (e.g. the
+        // same preset loaded in two tools with different spool colors), the nearest color wins --
+        // an unknown color on either side is neutral, same tie-break rule as the family/color
+        // tier below -- then a loaded slot over a swappable one, then the lowest tool index.
+        if (!project[i].preset.empty()) {
+            bool  found_exact  = false;
+            float exact_dist   = std::numeric_limits<float>::max();
+            bool  exact_loaded = false;
+            int   exact_tool   = -1;
+            int   exact_id     = 0;
+            for (size_t ti = 0; ti < inventory.tools.size(); ++ti) {
+                for (size_t si = 0; si < inventory.tools[ti].size(); ++si) {
+                    const PhysicalFilament& pf = inventory.tools[ti][si];
+                    if (pf.empty() || pf.preset.empty() || pf.preset != project[i].preset)
+                        continue;
+                    float dist   = auto_map_color_distance(project[i].color, pf.color);
+                    bool  loaded = si == 0;
+
+                    bool better;
+                    if (!found_exact)
+                        better = true;
+                    else if (dist < exact_dist)
+                        better = true;
+                    else if (dist > exact_dist)
+                        better = false;
+                    else
+                        better = loaded && !exact_loaded; // color tie: loaded breaks it
+                    // A strict non-improvement keeps the current best, so a full tie naturally
+                    // keeps the lowest tool index, same rationale as the family/color tier.
+
+                    if (better) {
+                        found_exact  = true;
+                        exact_dist   = dist;
+                        exact_loaded = loaded;
+                        exact_tool   = (int) ti;
+                        exact_id     = pf.id;
+                    }
+                }
+            }
+            // A gross color mismatch must not be auto-proposed without confirmation,
+            // even when the preset matches exactly -- a preset match whose color is a known,
+            // out-of-range distance from the project filament's is not taken here; it falls
+            // through to the family/color tier instead (itself cutoff-guarded), so red-project
+            // vs. teal-spool doesn't sail through just because the preset string happens to match.
+            bool exact_beyond_cutoff = exact_dist != std::numeric_limits<float>::max() && exact_dist > kMaxFamilyColorDistance;
+            if (found_exact && !exact_beyond_cutoff) {
+                result.filament_map[i] = exact_tool + 1;
+                result.physical_map[i] = exact_id;
+                continue;
+            }
+        }
+
+        bool   found      = false;
+        float  best_dist  = 0.f;
+        bool   best_vendor = false;
+        bool   best_loaded = false;
+        int    best_tool  = -1;
+        int    best_id    = 0;
+        const std::string project_vendor = trim_lower(project[i].vendor);
+
+        for (size_t ti = 0; ti < inventory.tools.size(); ++ti) {
+            for (size_t si = 0; si < inventory.tools[ti].size(); ++si) {
+                const PhysicalFilament& pf = inventory.tools[ti][si];
+                if (pf.empty())
+                    continue;
+                if (!type_compatible(project[i].type, pf.type))
+                    continue;
+
+                float dist = auto_map_color_distance(project[i].color, pf.color);
+                // A known, finite distance beyond the cutoff disqualifies the candidate; an
+                // unknown color on either side (the color_distance sentinel) still qualifies on
+                // type alone, same as before -- it's simply ranked last since it never wins a
+                // distance comparison against a real, close color match.
+                if (dist != std::numeric_limits<float>::max() && dist > kMaxFamilyColorDistance)
+                    continue;
+                bool  vendor_match = !project_vendor.empty() && project_vendor == preset_vendor_token(pf.preset);
+                bool  loaded       = si == 0;
+
+                bool better;
+                if (!found)
+                    better = true;
+                else if (dist < best_dist)
+                    better = true;
+                else if (dist > best_dist)
+                    better = false;
+                else if (vendor_match != best_vendor)
+                    better = vendor_match && !best_vendor; // equal distance: vendor breaks the tie
+                else
+                    better = loaded && !best_loaded; // equal distance and vendor: loaded breaks the tie
+                // Anything else (a strict non-improvement) keeps the current best -- since tools
+                // are scanned in ascending order, a full tie naturally keeps the lowest tool
+                // index (and, within a tool, the lowest slot index).
+
+                if (better) {
+                    found       = true;
+                    best_dist   = dist;
+                    best_vendor = vendor_match;
+                    best_loaded = loaded;
+                    best_tool   = (int) ti;
+                    best_id     = pf.id;
+                }
+            }
+        }
+
+        if (found) {
+            result.filament_map[i] = best_tool + 1;
+            result.physical_map[i] = best_id;
+        } else {
+            result.unmatched.push_back((int) i);
+        }
+    }
+
+    return result;
+}
+
+std::string dump_slot_assignments(const std::map<std::string, std::vector<SlotAssignment>>& by_device)
+{
+    json j = json::object();
+    for (const auto& [device_key, assignments] : by_device) {
+        json jassignments = json::array();
+        for (const auto& a : assignments)
+            jassignments.push_back({ {"filament", a.filament_idx}, {"tool", a.tool}, {"slot", a.slot} });
+        j[device_key] = std::move(jassignments);
+    }
+    return j.dump();
+}
+
+std::map<std::string, std::vector<SlotAssignment>> load_slot_assignments(const std::string& s)
+{
+    std::map<std::string, std::vector<SlotAssignment>> result;
+
+    json j;
+    try {
+        j = json::parse(s);
+    } catch (...) {
+        return result;
+    }
+    if (!j.is_object())
+        return result;
+
+    for (const auto& [device_key, jassignments] : j.items()) {
+        if (!jassignments.is_array())
+            continue;
+        std::vector<SlotAssignment> assignments;
+        for (const auto& ja : jassignments) {
+            if (!ja.is_object())
+                continue;
+            if (!ja.contains("filament") || !ja["filament"].is_number_integer())
+                continue;
+            if (!ja.contains("tool") || !ja["tool"].is_number_integer())
+                continue;
+            if (!ja.contains("slot") || !ja["slot"].is_number_integer())
+                continue;
+            SlotAssignment a;
+            a.filament_idx = ja["filament"].get<int>();
+            a.tool         = ja["tool"].get<int>();
+            a.slot         = ja["slot"].get<int>();
+            if (a.filament_idx < 0 || a.tool < 0 || a.slot < 0)
+                continue; // corrupt entry: skip rather than fabricate a plausible-looking one
+            assignments.push_back(a);
+        }
+        result[device_key] = std::move(assignments);
+    }
+    return result;
+}
+
+std::vector<ManualMapViolation> validate_manual_map(
+    const std::vector<ProjectFilamentInfo>& project,
+    const std::vector<int>&                 filament_map,
+    const std::vector<int>&                 physical_map,
+    const FilamentInventory&                inventory)
+{
+    std::vector<ManualMapViolation> violations;
+
+    for (size_t i = 0; i < project.size(); ++i) {
+        int physical_id = i < physical_map.size() ? physical_map[i] : 0;
+        const PhysicalFilament* target = nullptr;
+        if (physical_id > 0) {
+            target = inventory.find(physical_id);
+        } else {
+            int tool = i < filament_map.size() ? filament_map[i] : 0;
+            if (tool >= 1 && (size_t) tool <= inventory.tools.size() && !inventory.tools[tool - 1].empty())
+                target = &inventory.tools[tool - 1][0]; // loaded slot
+        }
+
+        if (target == nullptr || target->empty()) {
+            violations.push_back({(int) i, ManualMapViolationKind::EmptyTarget});
+            continue; // an empty target has neither type nor color to compare
+        }
+
+        if (!project[i].type.empty() && !target->type.empty() && !type_compatible(project[i].type, target->type))
+            violations.push_back({(int) i, ManualMapViolationKind::FamilyMismatch});
+
+        float dist = auto_map_color_distance(project[i].color, target->color);
+        if (dist != std::numeric_limits<float>::max() && dist > kMaxFamilyColorDistance)
+            violations.push_back({(int) i, ManualMapViolationKind::GrossColorMismatch});
+    }
+
+    return violations;
+}
+
+std::string inventory_confirmation_fingerprint(const FilamentInventory& inventory)
+{
+    // Plain FNV-1a over a delimited encoding of the confirmed content -- not cryptographic, just
+    // needs to be stable within a process/build and sensitive to every field this doc promises.
+    // Delimiters (both between fields and between slots/tools) prevent adjacent-field concatenation
+    // collisions (e.g. type "A"+color "BC" must not hash the same as type "AB"+color "C").
+    static constexpr uint64_t kFnvOffset = 14695981039346656037ull;
+    static constexpr uint64_t kFnvPrime  = 1099511628211ull;
+    uint64_t h = kFnvOffset;
+    auto mix = [&h](const std::string& s) {
+        for (unsigned char c : s) {
+            h ^= c;
+            h *= kFnvPrime;
+        }
+        h ^= '\x1f'; // field/record delimiter
+        h *= kFnvPrime;
+    };
+
+    mix(std::to_string(inventory.tools.size()));
+    for (const auto& tool : inventory.tools) {
+        mix(std::to_string(tool.size()));
+        for (const auto& pf : tool) {
+            mix(pf.type);
+            mix(pf.color);
+            mix(pf.preset);
+        }
+    }
+
+    std::ostringstream oss;
+    oss << std::hex << std::setw(16) << std::setfill('0') << h;
+    return oss.str();
+}
+
+std::string dump_manual_map_confirmations(const std::map<std::string, std::map<int, std::string>>& by_device_plate)
+{
+    json j = json::object();
+    for (const auto& [device_key, by_plate] : by_device_plate) {
+        json jplates = json::object();
+        for (const auto& [plate_index, fingerprint] : by_plate)
+            jplates[std::to_string(plate_index)] = fingerprint;
+        j[device_key] = std::move(jplates);
+    }
+    return j.dump();
+}
+
+std::map<std::string, std::map<int, std::string>> load_manual_map_confirmations(const std::string& s)
+{
+    std::map<std::string, std::map<int, std::string>> result;
+
+    json j;
+    try {
+        j = json::parse(s);
+    } catch (...) {
+        return result;
+    }
+    if (!j.is_object())
+        return result;
+
+    for (const auto& [device_key, jplates] : j.items()) {
+        if (!jplates.is_object())
+            continue;
+        std::map<int, std::string> by_plate;
+        for (const auto& [plate_str, jfingerprint] : jplates.items()) {
+            if (!jfingerprint.is_string())
+                continue;
+            int plate_index = 0;
+            try {
+                plate_index = std::stoi(plate_str);
+            } catch (...) {
+                continue; // non-numeric key: corrupt entry, skip rather than fabricate index 0
+            }
+            by_plate[plate_index] = jfingerprint.get<std::string>();
+        }
+        if (!by_plate.empty())
+            result[device_key] = std::move(by_plate);
+    }
+    return result;
+}
+
+std::string derive_filament_subtype(const std::string& display_name, const std::string& vendor, const std::string& type)
+{
+    auto lower = [](std::string v) {
+        std::transform(v.begin(), v.end(), v.begin(), [](unsigned char c) { return (char) std::tolower(c); });
+        return v;
+    };
+    const std::string vendor_l = lower(vendor);
+    const std::string type_l   = lower(type);
+
+    std::string result;
+    size_t pos = 0;
+    while (pos < display_name.size()) {
+        size_t space = display_name.find(' ', pos);
+        if (space == std::string::npos)
+            space = display_name.size();
+        std::string token = display_name.substr(pos, space - pos);
+        std::string token_l = lower(token);
+        if (!token.empty() && token_l != vendor_l && token_l != type_l) {
+            if (!result.empty())
+                result += ' ';
+            result += token;
+        }
+        pos = space + 1;
+    }
+    return result;
+}
+
+bool inventory_all_unset(const FilamentInventory& inv)
+{
+    for (const auto& tool : inv.tools)
+        for (const auto& pf : tool)
+            if (!pf.empty())
+                return false;
+    return true;
+}
+
+std::vector<ProjectFilamentInfo> build_project_filament_info(
+    const std::vector<std::string>& filament_colors,
+    const std::vector<std::string>& filament_types,
+    const std::vector<std::string>& filament_vendors,
+    const std::vector<std::string>& filament_presets)
+{
+    std::vector<ProjectFilamentInfo> project(filament_colors.size());
+    for (size_t i = 0; i < project.size(); ++i) {
+        project[i].color  = filament_colors[i];
+        project[i].type   = i < filament_types.size() ? filament_types[i] : std::string();
+        project[i].vendor = i < filament_vendors.size() ? filament_vendors[i] : std::string();
+        project[i].preset = i < filament_presets.size() ? filament_presets[i] : std::string();
+    }
+    return project;
+}
+
+std::vector<int> compute_physical_map_proposal(
+    const std::vector<std::string>& filament_colors,
+    const std::vector<std::string>& filament_types,
+    const std::vector<std::string>& filament_vendors,
+    const std::vector<std::string>& filament_presets,
+    const std::vector<int>&         plate_filaments,
+    const std::vector<int>&         stored_physical_map,
+    const std::vector<int>&         stored_filament_map,
+    const FilamentInventory&        inventory,
+    bool                             stored_map_confirmed)
+{
+    // Orca: bootstrap (nothing recorded anywhere) has no physical filament to propose -- a
+    // confirmed row instead reproposes its previously-stored TOOL, sentinel-encoded as
+    // -(tool) so FilamentMapRowsPanel (which derives the same bootstrap/not split from this
+    // same inventory) can tell it apart from a real (positive) physical id. This covers a plate
+    // confirmed via bootstrap with the "record as loaded" offer left unchecked: its physical map
+    // stays all-0 (nothing was ever recorded to point at), so without this fallback every reopen
+    // would silently reset every row instead of honoring filament_map.
+    if (inventory_all_unset(inventory)) {
+        const int tool_count = (int) inventory.tools.size();
+        std::vector<int> proposal(plate_filaments.size(), 0);
+        for (size_t i = 0; i < plate_filaments.size(); ++i) {
+            int f    = plate_filaments[i];
+            int tool = (stored_map_confirmed && f >= 1 && f <= (int) stored_filament_map.size()) ? stored_filament_map[f - 1] : 0;
+            proposal[i] = (tool >= 1 && tool <= tool_count) ? -tool : 0;
+        }
+        return proposal;
+    }
+
+    // Matching is delegated to auto_map_filaments -- the same core the slice-time auto-mapper
+    // uses, so the dialog's proposal and slice-time mapping never disagree. Built through the
+    // shared build_project_filament_info (not a second inline copy) so this ProjectFilamentInfo
+    // list -- vendor included -- matches slice-time's exactly; no durable SlotAssignments are
+    // passed here, since this proposal has its own (richer) stored-map handling below.
+    std::vector<ProjectFilamentInfo> project = build_project_filament_info(filament_colors, filament_types, filament_vendors, filament_presets);
+    AutoMapResult auto_result = auto_map_filaments(project, inventory, {});
+
+    std::vector<int> proposal(plate_filaments.size(), 0);
+    for (size_t i = 0; i < plate_filaments.size(); ++i) {
+        int f      = plate_filaments[i];
+        int stored = (stored_map_confirmed && f >= 1 && f <= (int) stored_physical_map.size()) ? stored_physical_map[f - 1] : 0;
+        const PhysicalFilament* pf = stored > 0 ? inventory.find(stored) : nullptr;
+        bool stored_valid = pf != nullptr && !pf->empty();
+        if (stored_valid) {
+            proposal[i] = stored;
+            continue;
+        }
+        // Mixed mode: a confirmed pick of a tool with NOTHING recorded stores physical 0 plus
+        // the tool in filament_map. As long as that tool is still empty, repropose the pick as
+        // the -(tool) sentinel (same encoding as bootstrap) instead of auto-matching it away;
+        // once the tool gains a recorded filament, auto-match takes over below.
+        if (stored_map_confirmed && stored == 0 && f >= 1 && f <= (int) stored_filament_map.size()) {
+            int tool = stored_filament_map[f - 1];
+            if (tool >= 1 && tool <= (int) inventory.tools.size()) {
+                const auto& slots = inventory.tools[tool - 1];
+                bool tool_empty = std::all_of(slots.begin(), slots.end(),
+                                              [](const PhysicalFilament& s) { return s.empty(); });
+                if (tool_empty) {
+                    proposal[i] = -tool;
+                    continue;
+                }
+            }
+        }
+        int filament_id = f - 1; // stored 1-based, arrays are 0-based
+        int matched = (filament_id >= 0 && (size_t) filament_id < auto_result.physical_map.size())
+                          ? auto_result.physical_map[filament_id] : -1;
+        proposal[i] = matched > 0 ? matched : 0;
+    }
+    return proposal;
+}
+
+std::string FilamentInventories::serialize() const
+{
+    json jpresets = json::object();
+    for (const auto& [preset_name, inv] : by_preset)
+        jpresets[preset_name] = json::parse(inv.serialize());
+    json j;
+    j["version"] = 1;
+    j["presets"] = std::move(jpresets);
+    return j.dump();
+}
+
+FilamentInventories FilamentInventories::deserialize(const std::string& s)
+{
+    FilamentInventories store;
+
+    json j;
+    try {
+        j = json::parse(s);
+    } catch (...) {
+        store.parse_error = true;
+        BOOST_LOG_TRIVIAL(error) << "FilamentInventories::deserialize: could not parse the stored "
+            "inventory blob (" << s.size() << " bytes) as JSON; returning an empty store without "
+            "touching the saved blob";
+        return store;
+    }
+    if (!j.is_object()) {
+        store.parse_error = true;
+        BOOST_LOG_TRIVIAL(error) << "FilamentInventories::deserialize: stored inventory blob's "
+            "top level is not a JSON object (is " << j.type_name() << "); returning an empty "
+            "store without touching the saved blob";
+        return store;
+    }
+
+    // An envelope is only recognized when BOTH "version" (an integer) and "presets" (an object)
+    // are present. A legacy (pre-envelope) store is itself an object keyed by preset name, whose
+    // VALUES are always inventory objects (see FilamentInventory::serialize) -- never integers --
+    // so a legacy preset literally named "version" can never make j["version"] an integer, and
+    // this rule still classifies that store as legacy, loading it correctly.
+    const bool  is_envelope = j.contains("version") && j["version"].is_number_integer() &&
+                               j.contains("presets") && j["presets"].is_object();
+    const json& jpresets    = is_envelope ? j["presets"] : j;
+
+    for (const auto& [preset_name, jinv] : jpresets.items()) {
+        if (!jinv.is_object())
+            continue;
+        size_t tool_count = (jinv.contains("tools") && jinv["tools"].is_array()) ? jinv["tools"].size() : 0;
+        store.by_preset[preset_name] = FilamentInventory::deserialize(jinv.dump(), tool_count);
+    }
+    return store;
+}
+
+FilamentInventory& FilamentInventories::for_preset(const std::string& printer_preset_name, size_t tool_count)
+{
+    FilamentInventory& inv = by_preset[printer_preset_name]; // default-constructed (no tools yet) on first use
+    inv.ensure_tool_count(tool_count);
+    return inv;
+}
+
+} // namespace Slic3r

--- a/src/libslic3r/FilamentInventory.hpp
+++ b/src/libslic3r/FilamentInventory.hpp
@@ -1,0 +1,285 @@
+#ifndef slic3r_FilamentInventory_hpp_
+#define slic3r_FilamentInventory_hpp_
+
+#include <map>
+#include <string>
+#include <vector>
+
+namespace Slic3r {
+
+// A single physical filament known to a printer: either the filament currently loaded into a
+// tool (slot 0 of that tool's list, see FilamentInventory::tools) or a swappable filament
+// recorded for later use on that tool.
+struct PhysicalFilament
+{
+    int         id   = 0;        // stable per-machine id, > 0; 0 = invalid/unassigned
+    std::string color;           // "#RRGGBB" (may be empty = unknown)
+    std::string type;            // e.g. "PLA" (may be empty = unknown)
+    std::string preset;          // exact filament preset name (may be empty = profile unknown)
+    enum class Kind { Manual, Mmu } kind = Kind::Manual; // Mmu reserved for future AMS-style slots
+    bool empty() const { return color.empty() && type.empty() && preset.empty(); }
+};
+
+// Alias retained for source compatibility with call sites not yet reworked to the multi-slot
+// model (see the physical-filaments-merge plan); refers to the same type.
+using LoadedFilament = PhysicalFilament;
+
+// The set of physical filaments known to a printer, grouped by tool. Element 0 of each tool's
+// list is always present and is the currently loaded filament for that tool (possibly empty());
+// further elements are swappable filaments recorded for that tool.
+struct FilamentInventory
+{
+    std::vector<std::vector<PhysicalFilament>> tools; // index = physical tool
+    int next_id = 1;                                   // id allocator for new entries, persisted
+
+    std::string serialize() const;
+    // Tolerant: malformed or short input yields an inventory of one empty loaded slot per tool,
+    // sized to tool_count.
+    static FilamentInventory deserialize(const std::string& s, size_t tool_count);
+
+    // Lookup helpers used by dialog/engine plumbing.
+    const PhysicalFilament* find(int id) const; // nullptr if absent
+    int tool_of(int id) const;                  // 0-based tool index, -1 if absent
+
+    // Mint an id for every non-empty slot that lacks one (id <= 0), flooring next_id above every
+    // id already in use first. GUI write paths MUST call this before save_filament_inventories:
+    // a non-empty slot persisted with id 0 (e.g. a loaded row first filled on a fresh inventory)
+    // would be renumbered by deserialize's reconcile pass on the NEXT load, silently invalidating
+    // every plate filament_physical_map entry that pointed at it. Also zeroes the id of any EMPTY
+    // slot that still carries one (e.g. a row the editor just cleared, which keeps the id it was
+    // loaded with -- see FilamentInventoryEditor::on_ok): find()/tool_of() key on id alone and
+    // don't check empty(), so a lingering id would let a stale stored reference (an old plate's
+    // filament_physical_map entry, or a durable SlotAssignment) keep resolving to a slot that no
+    // longer represents any physical filament. compute_physical_map_proposal's own !pf->empty()
+    // guard already covers this for the row's proposal, but a cleared slot should round-trip as
+    // canonically empty (id 0) for every consumer, not rely on each one re-deriving that guard.
+    void ensure_ids();
+
+    // Pads tools with single-empty-slot entries up to tool_count; existing tools (and any extra
+    // beyond tool_count) are never dropped.
+    void ensure_tool_count(size_t tool_count);
+
+    // Orca: write-through seam for a single tool's loaded slot (always favor what's reported
+    // from the printer -- FilamentInventoryEditor::
+    // do_sync_from_printer calls this immediately for every tool a sync actually covers, instead
+    // of waiting for the dialog's OK, so the mapping dialog/auto-mapper/summary always mirror the
+    // LAST sync rather than whatever was last saved). Overwrites tools[tool_idx][0] with `slot`
+    // (pass a default-constructed PhysicalFilament for a printer-reported empty tray); every
+    // other tool, and this tool's own swappable rows (index 1+), are left untouched. Grows tools
+    // first via ensure_tool_count if tool_idx is out of range. The caller must still call
+    // ensure_ids() afterward (same as any other inventory mutation) before saving.
+    void apply_synced_loaded_slot(size_t tool_idx, const PhysicalFilament& slot);
+};
+
+// All known physical filament inventories, one per printer preset (an inventory follows the same
+// thing Orca's own connection settings follow, the printer preset -- print_host/printhost_apikey
+// are preset options, and one preset per physical machine is already Orca's own convention).
+// Persisted as a single JSON blob (see serialize/deserialize): serialize() always writes the
+// versioned envelope {"version": 1, "presets": {<preset name> -> FilamentInventory::serialize()
+// output, ...}}. deserialize() also accepts the pre-versioning shape (a bare object keyed
+// directly by preset name, no "version"/"presets" wrapper) and treats it as this same content --
+// an object is only read as the envelope when it carries an integer "version" AND an object
+// "presets"; anything else, including a legacy store whose preset names happen to collide with
+// those two words, is read as the bare legacy shape (see deserialize's own comment).
+struct FilamentInventories
+{
+    std::map<std::string, FilamentInventory> by_preset; // printer preset name -> inventory
+    // Set by deserialize() when `s` could not be read as either shape above (invalid JSON, or a
+    // non-object top level). by_preset is empty in that case. Callers that persist store back to
+    // the same key MUST check this first and preserve the original `s` (e.g. to a backup key)
+    // before doing so, or a transient/corrupt read silently destroys the saved data on next save.
+    bool parse_error = false;
+
+    std::string                serialize() const;
+    static FilamentInventories deserialize(const std::string& s); // malformed -> empty store, parse_error = true
+
+    // Resolves the inventory for `printer_preset_name`, creating an empty one on first use. Pads
+    // the returned inventory to at least tool_count tools (never truncates). This is the pure
+    // core of Slic3r::GUI::current_inventory_for_preset (src/slic3r/GUI/FilamentInventoryStore.hpp),
+    // which resolves the preset name from a Preset and delegates here -- kept in libslic3r so it
+    // is unit-testable without a Preset/GUI dependency.
+    FilamentInventory& for_preset(const std::string& printer_preset_name, size_t tool_count);
+};
+
+// Strip the vendor and material-type tokens (case-insensitive, whole tokens) from a filament
+// preset display name, returning the product-line remainder -- the inverse of the
+// "<Vendor> <Type> <SubType>" naming convention. "Snapmaker PLA SnapSpeed" (vendor Snapmaker,
+// type PLA) -> "SnapSpeed"; "Generic PLA" -> "".
+std::string derive_filament_subtype(const std::string& display_name, const std::string& vendor, const std::string& type);
+
+// True when nothing is recorded anywhere in the inventory (every slot, loaded and swappable, on
+// every tool is empty()) -- a fresh machine profile that was never populated. Used both to decide
+// whether the mapping dialog can target real physical filaments or must fall back to
+// picking a bare tool (FilamentMapRowsPanel's bootstrap mode), and to gate FilamentMapDialog's
+// "record these as loaded" offer: checking every slot (not just slot 0/loaded) matters because a
+// tool can have an empty loaded slot but a real swappable one (cleared via the Physical Filaments
+// editor's per-tool Clear button, which only touches slot 0) -- treating that as "all unset"
+// would let the record write silently discard the swappable entry.
+bool inventory_all_unset(const FilamentInventory& inv);
+
+// A single durable slot assignment for one physical device in one project: project filament
+// filament_idx (0-based) is routed to physical tool `tool` (0-based), slot `slot` within that
+// tool's PhysicalFilament list (0 = the tool's loaded slot). Persisted on the Model, keyed by
+// printer preset name (the same key FilamentInventories uses), so a toolchanger's tray mapping
+// survives closing and reopening the project even before the device reconnects.
+struct SlotAssignment
+{
+    int filament_idx = 0;
+    int tool         = 0;
+    int slot         = 0;
+};
+
+// Serializes a device-key -> assignment-list map to JSON:
+// {"<device_key>": [{"filament":0,"tool":1,"slot":0}, ...], ...}
+std::string dump_slot_assignments(const std::map<std::string, std::vector<SlotAssignment>>& by_device);
+// Tolerant inverse of dump_slot_assignments: malformed JSON, a non-object top level, or an empty
+// string all yield an empty map, never throw. An entry missing a required field, or with a
+// negative filament/tool/slot, is skipped rather than defaulted -- a fabricated (0,0,0) would look
+// like a plausible real assignment instead of surfacing the corruption.
+std::map<std::string, std::vector<SlotAssignment>> load_slot_assignments(const std::string& json);
+
+// Builds the mapping dialog's per-row proposal: one entry per plate_filaments entry (same
+// order), used to seed FilamentMapRowsPanel. Meaning of an entry depends on whether the
+// inventory has anything recorded (see inventory_all_unset):
+//  - normal (inventory has real targets): the proposed physical filament id, or 0 for no
+//    target. stored_physical_map (full-length, 0-based by filament id) is only consulted when
+//    stored_map_confirmed is true (the plate has actually been through a confirmed manual
+//    mapping before); a stored entry is only kept as-is when it still resolves to a real,
+//    non-empty physical filament -- inventory.find(id) returning a slot whose empty() is true
+//    (e.g. a loaded/swap slot the user cleared in the Physical Filaments editor after this
+//    plate's map was saved, which keeps its id but drops its content) must fall through to
+//    auto-match exactly like a missing id, not be treated as a valid stored target.
+//  - bootstrap (inventory has nothing recorded anywhere): there is no physical filament to
+//    target, so a confirmed row instead reproposes its previously-stored TOOL
+//    (stored_filament_map, full-length 1-based project filament -> tool map), encoded as
+//    -(tool) so it can never collide with a real (positive) physical id; 0 still means no
+//    proposal. FilamentMapRowsPanel decodes this the same way it independently derives
+//    bootstrap mode -- from this same inventory.
+// Matching itself (the "normal" branch above) is delegated to auto_map_filaments, the same core
+// the slice-time auto-mapper uses -- there is exactly one matching implementation, so a
+// filament_presets[id] that exactly equals a slot's PhysicalFilament::preset is trusted the same
+// way here as it is at slice time, and PLA/PLA+ (etc, see type_compatible's family table) are
+// treated as compatible here too.
+std::vector<int> compute_physical_map_proposal(
+    const std::vector<std::string>& filament_colors,
+    const std::vector<std::string>& filament_types,
+    const std::vector<std::string>& filament_vendors,
+    const std::vector<std::string>& filament_presets,
+    const std::vector<int>&         plate_filaments,
+    const std::vector<int>&         stored_physical_map,
+    const std::vector<int>&         stored_filament_map,
+    const FilamentInventory&        inventory,
+    bool                             stored_map_confirmed);
+
+// One project filament's identity, as needed by auto_map_filaments -- deliberately narrower than
+// the full project filament_colour/filament_type/filament_vendor config lists so the matcher
+// itself never touches config machinery (spec: pure, fully unit-testable).
+struct ProjectFilamentInfo
+{
+    std::string type;   // e.g. "PLA", "PLA-CF" (may be empty = unknown)
+    std::string color;  // "#RRGGBB" or "#RRGGBBAA" (may be empty = unknown)
+    std::string vendor;
+    std::string preset; // exact filament preset name (may be empty = unknown); see auto_map_filaments
+};
+
+// One ProjectFilamentInfo per project filament (0-based, filament_colors' length is
+// authoritative for count), assembled from the raw parallel per-filament lists. The single place
+// this assembly happens: the GUI's build_project_filament_info (FilamentInventoryStore) extracts
+// these lists from a DynamicPrintConfig and delegates here, and compute_physical_map_proposal
+// below builds its ProjectFilamentInfo list the same way -- so the slice-time auto-mapper and the
+// dialog's proposal can never disagree over what a project filament looks like.
+std::vector<ProjectFilamentInfo> build_project_filament_info(
+    const std::vector<std::string>& filament_colors,
+    const std::vector<std::string>& filament_types,
+    const std::vector<std::string>& filament_vendors,
+    const std::vector<std::string>& filament_presets);
+
+// Slice-time auto-mapping result: one entry per project filament (same order/length as the
+// `project` argument to auto_map_filaments).
+struct AutoMapResult
+{
+    std::vector<int> filament_map;  // 1-based tool per filament (matches the plate filament_map
+                                     // convention); a fallback of 1 for an unmatched entry -- the
+                                     // caller decides what to do with it, see `unmatched` below.
+    std::vector<int> physical_map;  // physical filament id per filament (from the inventory slot
+                                     // that resolved the entry), or -1 when nothing resolved.
+    std::vector<int> unmatched;     // indices (into `project`) that resolved to neither a valid
+                                     // stored assignment nor a compatible inventory slot.
+};
+
+// Slice-time auto-mapper -- also the sole matching core behind
+// compute_physical_map_proposal's dialog-facing proposal, so the dialog and slice-time mapping
+// always agree. Resolves each project filament to a physical tool by priority: (1) a stored
+// SlotAssignment whose tool/slot still exist in `inventory` and are non-empty; (2) the
+// color-nearest slot with an exactly-matching, non-empty preset, only if within
+// kMaxFamilyColorDistance (or color unknown on either side); (3) the color-nearest
+// family-compatible slot (type_compatible) within kMaxFamilyColorDistance, tie-broken by vendor
+// then by preferring a loaded slot (index 0) over swappable, then lowest tool index; (4)
+// otherwise unmatched -- filament_map keeps its fallback of 1 and the index is recorded in
+// `unmatched`. A preset match beyond the color cutoff at tier 2 is treated as absent and falls
+// through to tier 3, rather than ever auto-proposing a color it can't stand behind.
+// Multiple project filaments may legitimately resolve to the same tool/physical filament -- a
+// merge, not an error. Pure: no GUI or config-singleton reads.
+AutoMapResult auto_map_filaments(
+    const std::vector<ProjectFilamentInfo>& project,
+    const FilamentInventory&                inventory,
+    const std::vector<SlotAssignment>&      assignments);
+
+// Kinds of problem a MANUAL (already-confirmed) mapping can have against the CURRENT inventory --
+// see validate_manual_map below. EmptyTarget is the "impossible" case (the target no longer holds
+// any filament at all); FamilyMismatch and GrossColorMismatch are both "confirm before proceeding"
+// cases, same as auto_map_filaments would refuse to propose them unasked.
+enum class ManualMapViolationKind { EmptyTarget, FamilyMismatch, GrossColorMismatch };
+
+struct ManualMapViolation
+{
+    int                    filament_index = 0; // index into `project` (0-based)
+    ManualMapViolationKind kind           = ManualMapViolationKind::EmptyTarget;
+};
+
+// Slice-time re-validation of a MANUAL (fmmManual) mapping against the CURRENT inventory. A
+// manual map is a frozen pick from a prior dialog OK; nothing re-checks it
+// against the inventory afterward, so a printer sync/edit that empties or repurposes its target
+// tool between confirmation and slice previously flowed straight to gcode unnoticed. This shares
+// the exact predicates auto_map_filaments uses to decide compatibility (type_compatible's family
+// table, the empty() rule, kMaxFamilyColorDistance) -- it does not restate them, so a target this
+// validator accepts is one auto_map_filaments itself would have been willing to propose.
+//
+// For each project filament i, the target physical filament is resolved as:
+//   - physical_map[i] > 0: inventory.find(physical_map[i]) (the confirmed physical pick).
+//   - otherwise (bootstrap-style manual pick, no physical filament existed to target at
+//     confirmation time): filament_map[i]'s tool's loaded slot (tools[filament_map[i]-1][0]).
+// A target that fails to resolve, or resolves to an empty() slot, raises EmptyTarget and skips the
+// type/color checks below (an empty slot has neither to compare). Otherwise: a known, non-empty
+// project type incompatible with the target's (type_compatible false) raises FamilyMismatch; a
+// known, non-empty project color further than kMaxFamilyColorDistance from the target's raises
+// GrossColorMismatch. A single filament may raise more than one kind. Does not consult
+// SlotAssignment -- those inform the auto/bootstrap PATHS to a target, not the validity of a
+// target a manual map already names explicitly. Pure: no GUI or config-singleton reads.
+std::vector<ManualMapViolation> validate_manual_map(
+    const std::vector<ProjectFilamentInfo>& project,
+    const std::vector<int>&                 filament_map,  // 1-based tool per filament, same length/order as project
+    const std::vector<int>&                 physical_map,  // physical filament id per filament (0/absent = no explicit pick, see resolution above)
+    const FilamentInventory&                inventory);
+
+// Stable fingerprint of the parts of `inventory` a user actually confirmed when OKing a manual
+// map: the (type, color, preset) tuple of every slot, in tool/slot order, plus the tool/slot
+// counts. Deliberately excludes `id`/`next_id` -- an id is a storage detail (e.g. renumbered by
+// ensure_ids on save), not something the user looked at when confirming a pairing. Two inventories
+// with identical tuples in the same order fingerprint identically; any tuple, tool-count, or
+// slot-count difference changes it. Used to gate slice-time re-validation: a plate whose
+// stored fingerprint still matches the current inventory needn't be re-validated or re-prompted,
+// since the standing confirmation still describes what is physically loaded.
+std::string inventory_confirmation_fingerprint(const FilamentInventory& inventory);
+
+// Persistence for inventory_confirmation_fingerprint, following dump_slot_assignments/
+// load_slot_assignments' pattern one level deeper: {"<device_key>": {"<plate_index>": "<fingerprint>"}}
+// (Model metadata_items key "filament_map_confirmed_inventory", set on the mapping dialog's OK for
+// a manual map -- see FilamentMapDialog.cpp). Tolerant: malformed JSON, a non-object top level, or
+// a malformed inner value all yield/skip cleanly rather than throw or fabricate a fingerprint.
+std::string dump_manual_map_confirmations(const std::map<std::string, std::map<int, std::string>>& by_device_plate);
+std::map<std::string, std::map<int, std::string>> load_manual_map_confirmations(const std::string& s);
+
+} // namespace Slic3r
+
+#endif // slic3r_FilamentInventory_hpp_

--- a/src/slic3r/CMakeLists.txt
+++ b/src/slic3r/CMakeLists.txt
@@ -272,6 +272,8 @@ set(SLIC3R_GUI_SOURCES
     GUI/ActivePrinterSession.hpp
     GUI/FilamentInventoryStore.cpp
     GUI/FilamentInventoryStore.hpp
+    GUI/FilamentInventoryEditor.cpp
+    GUI/FilamentInventoryEditor.hpp
     GUI/IconManager.cpp
     GUI/IconManager.hpp
     GUI/ImageGrid.cpp

--- a/src/slic3r/CMakeLists.txt
+++ b/src/slic3r/CMakeLists.txt
@@ -268,6 +268,10 @@ set(SLIC3R_GUI_SOURCES
     GUI/FilamentMapPanel.hpp
     GUI/FilamentMapDialog.cpp
     GUI/FilamentMapDialog.hpp
+    GUI/ActivePrinterSession.cpp
+    GUI/ActivePrinterSession.hpp
+    GUI/FilamentInventoryStore.cpp
+    GUI/FilamentInventoryStore.hpp
     GUI/IconManager.cpp
     GUI/IconManager.hpp
     GUI/ImageGrid.cpp

--- a/src/slic3r/GUI/ActivePrinterSession.cpp
+++ b/src/slic3r/GUI/ActivePrinterSession.cpp
@@ -1,0 +1,107 @@
+#include "ActivePrinterSession.hpp"
+
+#include <boost/algorithm/string/predicate.hpp>
+
+#include "DeviceCore/DevManager.h" // full DeviceManager definition -- DeviceManager.hpp only forward-declares it
+#include "DeviceManager.hpp"
+#include "GUI_App.hpp"
+#include "libslic3r/PresetBundle.hpp"
+#include "slic3r/Utils/NetworkAgent.hpp"
+
+namespace Slic3r { namespace GUI {
+
+const Preset& ActivePrinterSession::profile() const
+{
+    return wxGetApp().preset_bundle->printers.get_edited_preset();
+}
+
+std::string ActivePrinterSession::printer_type() const
+{
+    PresetBundle* preset_bundle = wxGetApp().preset_bundle;
+    return preset_bundle->printers.get_edited_preset().get_printer_type(preset_bundle);
+}
+
+ActivePrinterSession::Connection ActivePrinterSession::connection() const
+{
+    const DynamicPrintConfig& config = profile().config;
+
+    Connection conn;
+    conn.host    = config.opt_string("print_host");
+    conn.port    = config.opt_string("printhost_port");
+    conn.api_key = config.opt_string("printhost_apikey");
+    if (conn.host.empty())
+        return conn;
+
+    conn.dev_id  = MachineObject::dev_id_from_address(conn.host, conn.port);
+    conn.use_ssl = boost::istarts_with(conn.host, "https://");
+    return conn;
+}
+
+MachineObject* ActivePrinterSession::live_machine() const
+{
+    DeviceManager* dev_mgr = wxGetApp().getDeviceManager();
+    MachineObject* machine = dev_mgr ? dev_mgr->get_selected_machine() : nullptr;
+    if (wxGetApp().getAgent() == nullptr || machine == nullptr)
+        return nullptr;
+
+    // DeviceManager::selected_machine outlives a printer-preset switch, so a non-null selected
+    // machine doesn't by itself mean the edited profile still corresponds to it. Reuse
+    // GUI_App::is_blocking_printing's profile<->machine correspondence check (also used to gate
+    // AMS sync and the extruder-separator icon) rather than a second rule that could disagree with
+    // it. Deliberately not Plater::is_same_printer_for_connected_and_selected: that additionally
+    // requires check_printer_initialized, which must keep reporting "connected, sync unavailable"
+    // for a stale heartbeat rather than falling back to "offline".
+    if (wxGetApp().is_blocking_printing(machine))
+        return nullptr;
+
+    // Model correspondence alone is not enough: every preset of the connected machine's model
+    // (including a factory default with no connection settings at all) would read as live.
+    const Connection conn = connection();
+    if (!conn.configured())
+        return nullptr;
+
+    // When both sides expose an address, they must be the same machine -- two same-model profiles
+    // pointing at different printers must not read each other's connection as their own. Compare
+    // just the host part (the profile's host may carry a scheme or port; the machine stores a bare
+    // ip). A machine with no ip (e.g. a cloud-bound connection) is left to the model check above.
+    const std::string machine_ip = machine->get_dev_ip();
+    if (!machine_ip.empty()) {
+        std::string h = conn.host;
+        if (size_t p = h.find("://"); p != std::string::npos)
+            h = h.substr(p + 3);
+        if (size_t p = h.find_first_of(":/"); p != std::string::npos)
+            h = h.substr(0, p);
+        if (h != machine_ip)
+            return nullptr;
+    }
+    return machine;
+}
+
+bool ActivePrinterSession::live() const { return live_machine() != nullptr; }
+
+bool ActivePrinterSession::bind_agent() const
+{
+    NetworkAgent* agent = wxGetApp().getAgent();
+    if (agent == nullptr)
+        return false;
+    const Connection conn = connection();
+    if (!conn.configured())
+        return false;
+    return agent->bind_device_connection(conn.dev_id, conn.dev_id, conn.access_code(), conn.use_ssl);
+}
+
+NetworkAgent* ActivePrinterSession::sync_agent() const
+{
+    if (!live())
+        return nullptr;
+    bind_agent();
+    return wxGetApp().getAgent();
+}
+
+const ActivePrinterSession& active_printer_session()
+{
+    static const ActivePrinterSession session;
+    return session;
+}
+
+}} // namespace Slic3r::GUI

--- a/src/slic3r/GUI/ActivePrinterSession.hpp
+++ b/src/slic3r/GUI/ActivePrinterSession.hpp
@@ -1,0 +1,105 @@
+#ifndef slic3r_GUI_ActivePrinterSession_hpp_
+#define slic3r_GUI_ActivePrinterSession_hpp_
+
+#include <string>
+
+#include "libslic3r/Preset.hpp"
+
+namespace Slic3r {
+
+class MachineObject;
+class NetworkAgent;
+
+namespace GUI {
+
+// The one accessor for "which printer is the user working with, and how do we reach it".
+//
+// INVARIANT: this class holds no state of its own. The printer PROFILE is the sole source of
+// truth, and this is the only place that reads it for connection purposes. Every accessor below
+// derives its answer from the live preset bundle on the call, so there is nothing here that can
+// go stale, nothing to invalidate when the user switches or edits a preset, and no second copy of
+// the truth for anything to disagree with. Adding a data member that stores a host, a key or a
+// printer identity would break that guarantee and turn this into a second owner.
+//
+// The two pieces of connection state that DO persist elsewhere are subordinated to the profile,
+// never read as truth:
+//   - the printer agent's device_info is a cache of connection(), written only through
+//     bind_agent() (see IPrinterAgent::bind_device_connection);
+//   - DeviceManager's machine selection is only ever COMPARED against the profile
+//     (live_machine()), never used to answer "which printer is this": it outlives a preset
+//     switch, so it cannot be trusted as identity.
+class ActivePrinterSession
+{
+public:
+    // How to reach the active profile's printer, read from that profile ALONE. Never from a
+    // MachineObject: a MachineObject's dev_ip can be a value restored from a previous session's
+    // AppConfig entry, and it is never refreshed against the preset afterwards, so it can name a
+    // real but wrong address. The preset is the value the user actually edited and can verify.
+    struct Connection
+    {
+        std::string host;    ///< print_host verbatim (may carry a scheme and/or a port)
+        std::string port;    ///< printhost_port
+        std::string api_key; ///< printhost_apikey ("" when unset)
+        std::string dev_id;  ///< host+port as a device id (MachineObject::dev_id_from_address)
+        bool        use_ssl = false;
+
+        /// A profile only addresses a printer once it carries its own connection settings.
+        /// print_host is a per-preset option and one preset per physical machine is how
+        /// connections are organized throughout, so no host means "no printer to talk to",
+        /// not "the printer someone connected to earlier".
+        bool configured() const { return !host.empty(); }
+
+        /// The access code Orca's device layer expects, which must be non-empty even when the
+        /// printer needs no key. Kept here so the substitution can't differ between call sites.
+        std::string access_code() const { return api_key.empty() ? std::string("88888888") : api_key; }
+    };
+
+    // THE resolution of "the current printer profile", deliberately the EDITED preset rather than
+    // the selected one. An unsaved printer edit must reach every surface at once: slice-time
+    // mapping resolves tool counts against the edited preset, so a dialog resolving the selected
+    // preset instead could show a different tool count than the mapper that actually slices, and
+    // an inventory is only ever padded (never truncated), so that mismatch would persist on disk.
+    // Nothing else in this feature repeats this choice -- it is made here, once.
+    const Preset& profile() const;
+
+    // profile()'s printer type (the model id the device layer identifies a machine by). Exists
+    // because Preset::get_printer_type() needs a mutable Preset and the bundle it belongs to,
+    // which profile()'s const reference deliberately doesn't hand out.
+    std::string printer_type() const;
+
+    Connection connection() const;
+
+    // Whether a connected machine currently corresponds to profile(): an agent exists, a machine
+    // is selected, that machine matches the profile by model AND by address, and the profile is
+    // configured at all. An unconfigured profile is never live.
+    //
+    // Deliberately NOT "is this printer reachable right now" or "does it support filament sync" --
+    // either can be false for a printer that still corresponds to the profile (a momentarily stale
+    // heartbeat, a model that can't report loaded filaments), and those keep reading as live so a
+    // failure surfaces as a failed sync rather than as "offline".
+    bool live() const;
+
+    // The selected machine, but only once it is confirmed to correspond to profile() -- otherwise
+    // nullptr. For machine-side DATA only (its filament system, its heartbeat); identity and
+    // addressing come from profile()/connection(), never from what this returns.
+    MachineObject* live_machine() const;
+
+    // The agent to run printer I/O through, with its connection state already pointed at
+    // connection(). nullptr when there is nothing live to talk to. This is the only supported way
+    // for this feature to reach the agent for a fetch/push.
+    NetworkAgent* sync_agent() const;
+
+    // Pushes connection() into the printer agent, whose device_info is a CACHE of it -- so its
+    // REST calls dial the address the active profile names. The single place preset connection
+    // settings reach an agent; agents do not read presets themselves. No-op when the profile is
+    // unconfigured or no agent exists.
+    bool bind_agent() const;
+};
+
+// The app-wide session. Stateless by the invariant above, so this is just the one name every call
+// site shares -- not an object that owns anything.
+const ActivePrinterSession& active_printer_session();
+
+}} // namespace Slic3r::GUI
+
+#endif // slic3r_GUI_ActivePrinterSession_hpp_

--- a/src/slic3r/GUI/DeviceCore/DevDefs.h
+++ b/src/slic3r/GUI/DeviceCore/DevDefs.h
@@ -59,6 +59,9 @@ enum DevAmsType : int
     N3F = 3,            // N3F, AMS 2PRO
     N3S = 4,            // N3S, AMS HT
     AMS_LITE_MIXED = 5, // AMS-Lite for N9
+    // Orca: honest per-tool unit for Moonraker toolchangers (e.g. Snapmaker U1) -- one unit
+    // per physical tool, 1 slot each, instead of faking AMS_LITE groups of 4.
+    TOOLCHANGER = 6,
 };
 
 enum DevFilamentStep

--- a/src/slic3r/GUI/DeviceCore/DevFilaSystem.cpp
+++ b/src/slic3r/GUI/DeviceCore/DevFilaSystem.cpp
@@ -118,7 +118,7 @@ DevAms::DevAms(const std::string& ams_id, int nozzle_id, int type)
     m_ams_id = ams_id;
     m_ext_id = nozzle_id;
     m_ams_type = (AmsType)type;
-    assert(EXT_SPOOL < type && m_ams_type <= AMS_LITE_MIXED);
+    assert(EXT_SPOOL < type && m_ams_type <= TOOLCHANGER);
 }
 
 DevAms::~DevAms()
@@ -135,10 +135,13 @@ DevAms::~DevAms()
 }
 
 static unordered_map<int, wxString> s_ams_display_formats = {
-    {DevAms::AMS,      "AMS-%d"},
-    {DevAms::AMS_LITE, "AMS Lite-%d"},
-    {DevAms::N3F,      "AMS 2 PRO-%d"},
-    {DevAms::N3S,      "AMS HT-%d"}
+    {DevAms::AMS,         "AMS-%d"},
+    {DevAms::AMS_LITE,    "AMS Lite-%d"},
+    {DevAms::N3F,         "AMS 2 PRO-%d"},
+    {DevAms::N3S,         "AMS HT-%d"},
+    // Orca: Moonraker toolchanger units (Snapmaker U1 and similar) -- one unit per tool.
+    // Left unlocalized like the other device-model formats in this table.
+    {DevAms::TOOLCHANGER, "Tool %d"}
 };
 
 wxString DevAms::GetDisplayName() const
@@ -180,7 +183,7 @@ int DevAms::GetSlotCount() const
     {
         return 4;
     }
-    else if (ams_type == N3S)
+    else if (ams_type == N3S || ams_type == TOOLCHANGER)
     {
         return 1;
     }
@@ -309,7 +312,8 @@ std::map<int, DevAmsSlotId> DevFilaSystem::GetTrayIndexMap()
                     int ams_id_int  = stoi(ams_id);
                     int slot_id_int = stoi(slot_id);
                     int tray_index  = -1;
-                    if (ams_item->GetAmsType() == DevAms::N3S) {
+                    if (ams_item->GetAmsType() == DevAms::N3S || ams_item->GetAmsType() == DevAms::TOOLCHANGER) {
+                        // One slot per unit for both: global tray index == unit index.
                         tray_index = ams_id_int;
                     } else if(ams_item->GetAmsType() == DevAms::AMS_LITE && ams_item->IsAmsLiteMixed()) {
                         tray_index = 24 + slot_id_int;
@@ -336,6 +340,15 @@ bool DevFilaSystem::IsAmsSettingUp() const
     }
 
     return false;
+}
+
+bool DevFilaSystem::IsAllToolchanger() const
+{
+    if (amsList.empty()) return false;
+    for (const auto& [id, ams] : amsList) {
+        if (!ams || ams->GetAmsType() != DevAms::TOOLCHANGER) return false;
+    }
+    return true;
 }
 
 bool DevFilaSystem::IsBBL_Filament(std::string tag_uid)
@@ -530,6 +543,14 @@ void DevFilaSystemParser::ParseV1_0(const json& jj, MachineObject* obj, DevFilaS
                             {
                                 // Mixed AMS-Lite (A2L / N9) exist flag lives at bit 12.
                                 curr_ams->m_exist = DevUtil::get_flag_bits(obj->ams_exist_bits, 12);
+                            }
+                            else if (type_id == DevAms::TOOLCHANGER)
+                            {
+                                // Orca: MoonrakerPrinterAgent::build_ams_payload publishes 0-based bits
+                                // (`ams_exist_bits |= 1 << ams_id`) rather than real N3S hardware's
+                                // ams_id-128 scheme handled below. One toolchanger unit per physical
+                                // tool, so bit ams_id_int marks that unit directly.
+                                curr_ams->m_exist = (obj->ams_exist_bits & (1 << ams_id_int)) != 0 ? true : false;
                             }
                             else
                             {
@@ -772,6 +793,14 @@ void DevFilaSystemParser::ParseV1_0(const json& jj, MachineObject* obj, DevFilaS
                                     {
                                         // Mixed AMS-Lite (A2L / N9) trays occupy tray-exist bits 24..27.
                                         curr_tray->is_exists = DevUtil::get_flag_bits(obj->tray_exist_bits, AMS_LITE_MIXED_TRAY_INDEX_OFFSET + tray_id_int);
+                                    }
+                                    else if (type_id == DevAms::TOOLCHANGER)
+                                    {
+                                        // Orca: build_ams_payload publishes 0-based bits
+                                        // (`tray_exist_bits |= 1 << slot_index`, slot_index == ams_id, one
+                                        // slot per unit), rather than real N3S hardware's ams_id-128 scheme
+                                        // handled below.
+                                        curr_tray->is_exists = (obj->tray_exist_bits & (1 << ams_id_int)) != 0 ? true : false;
                                     }
                                     else
                                     {

--- a/src/slic3r/GUI/DeviceCore/DevFilaSystem.h
+++ b/src/slic3r/GUI/DeviceCore/DevFilaSystem.h
@@ -146,6 +146,7 @@ public:
     static constexpr AmsType N3F = DevAmsType::N3F;
     static constexpr AmsType N3S = DevAmsType::N3S;
     static constexpr AmsType AMS_LITE_MIXED = DevAmsType::AMS_LITE_MIXED;
+    static constexpr AmsType TOOLCHANGER = DevAmsType::TOOLCHANGER;
 
 public:
 
@@ -338,6 +339,9 @@ public:
 
     bool        HasAms() const { return !amsList.empty(); }
     bool        IsAmsSettingUp() const;
+    // Orca: true when every reported unit is a Moonraker TOOLCHANGER unit (see DevAmsType).
+    // Used by the sync/mapping dialogs to present "Tool" wording instead of "AMS".
+    bool        IsAllToolchanger() const;
 
     /* ams */
     DevAms*                         GetAmsById(const std::string& ams_id) const;

--- a/src/slic3r/GUI/DeviceCore/DevMapping.cpp
+++ b/src/slic3r/GUI/DeviceCore/DevMapping.cpp
@@ -91,8 +91,9 @@ namespace Slic3r
         }
         else
         {
-            if (type == DevAms::N3S)
+            if (type == DevAms::N3S || type == DevAms::TOOLCHANGER)
             {
+                // One slot per unit for both: global tray index == unit index.
                 result.id = ams_id + slot_id;
             }
             else if (type == DevAms::AMS_LITE_MIXED)
@@ -139,8 +140,9 @@ namespace Slic3r
                 {
                     tray_index = AMS_LITE_MIXED_TRAY_INDEX_OFFSET + tray_id;
                 }
-                else if (ams_type == DevAms::N3S)
+                else if (ams_type == DevAms::N3S || ams_type == DevAms::TOOLCHANGER)
                 {
+                    // One slot per unit for both: global tray index == unit index.
                     tray_index = ams_id + tray_id;
                 }
                 else

--- a/src/slic3r/GUI/FilamentInventoryEditor.cpp
+++ b/src/slic3r/GUI/FilamentInventoryEditor.cpp
@@ -1,0 +1,836 @@
+#include "FilamentInventoryEditor.hpp"
+
+#include <algorithm>
+#include <functional>
+
+#include <wx/clrpicker.h>
+#include <wx/dcgraph.h>
+#include <wx/msgdlg.h>
+#include <wx/panel.h>
+#include <wx/sizer.h>
+
+#include "ActivePrinterSession.hpp"
+#include "DeviceCore/DevFilaSystem.h"
+#include "DeviceCore/DevManager.h"
+#include "DeviceManager.hpp"
+#include "FilamentInventoryStore.hpp"
+#include "GUI_App.hpp"
+#include "I18N.hpp"
+#include "MsgDialog.hpp"
+#include "PresetComboBoxes.hpp"
+#include "Widgets/Button.hpp"
+#include "Widgets/DialogButtons.hpp"
+#include "Widgets/Label.hpp"
+#include "Widgets/StateColor.hpp"
+#include "libslic3r/PrintConfig.hpp"
+#include "slic3r/Utils/IPrinterAgent.hpp"
+#include "slic3r/Utils/NetworkAgent.hpp"
+#include "wxExtensions.hpp"
+
+namespace Slic3r { namespace GUI {
+
+// Orca: neutral placeholder for a slot with no color recorded yet. Distinct from the "unset"
+// signal itself -- that's carried by Row::color_touched/type_touched -- this is just what the
+// picker/card shows so an empty slot doesn't look like a real black/white pick.
+static const wxColour UNSET_COLOR(0xD9, 0xD9, 0xD9);
+
+// One tile in the card strip: a tool's loaded filament (slot 0, "main" size) or one of its
+// the tool's loaded filament.
+// Whole-card background is the filament color (or UNSET_COLOR for an untouched slot); text color
+// is auto-contrast off that background, then adjusted for the app's dark/light UI via
+// StateColor::darkModeColorFor, matching the house pattern used throughout AmsMappingPopup.cpp's
+// MaterialItem/MappingItem family. Purely a paint+click widget -- it owns no filament data itself,
+// FilamentInventoryEditor pushes content into it via set_content()/set_on_edit()/set_on_remove().
+class FilamentCard : public wxPanel
+{
+public:
+    // All cards share this width so the column's cards line up.
+    // in height (less vertical content: no "T%d" top label).
+    static constexpr int CARD_WIDTH = 96;
+
+    // Height includes room for the material-type and vendor lines shown in set_content().
+    FilamentCard(wxWindow* parent)
+        : wxPanel(parent, wxID_ANY, wxDefaultPosition, parent->FromDIP(wxSize(CARD_WIDTH, 82)))
+    {
+#ifdef __WXMSW__
+        SetDoubleBuffered(true);
+#endif
+        m_edit_btn = new ScalableButton(this, wxID_ANY, "edit", wxEmptyString, wxDefaultSize, wxDefaultPosition,
+                                         wxBU_EXACTFIT | wxNO_BORDER, true, 14);
+        m_edit_btn->Bind(wxEVT_BUTTON, [this](wxCommandEvent&) { if (m_on_edit) m_on_edit(); });
+
+        wxBoxSizer* overlay = new wxBoxSizer(wxHORIZONTAL);
+        overlay->AddStretchSpacer();
+        overlay->Add(m_edit_btn, 0, wxTOP | wxRIGHT, FromDIP(2));
+
+        wxBoxSizer* v = new wxBoxSizer(wxVERTICAL);
+        v->Add(overlay, 0, wxEXPAND);
+        // Not SetSizerAndFit: the card's footprint is the fixed size passed to the wxPanel ctor
+        // above (the whole point of the card is a filled color swatch, not a shrink-wrap around
+        // the icon row) -- SetSizer only, so the icon row overlays the top-right corner without
+        // resizing the panel.
+        SetSizer(v);
+
+        Bind(wxEVT_PAINT, &FilamentCard::paintEvent, this);
+    }
+
+    // color/top_label/type_line/vendor_line/edit_disabled mirror one Row's current plain data;
+    // top_label is the "T%d" slot label. type_line/vendor_line are the
+    // material type ("PLA") and the vendor/brand ("PolyTerra"), shown on their own lines below
+    // top_label so both can be read without opening the row editor -- a single truncated line
+    // used to hide whichever of the two didn't fit first. edit_disabled covers both an NFC-tag
+    // lock and a printer-reported empty tool; disabled_reason is the tooltip shown in either
+    // case (ignored when edit_disabled is false).
+    void set_content(const wxColour& color, const wxString& top_label, const wxString& type_line,
+                      const wxString& vendor_line, bool edit_disabled, const wxString& disabled_reason = wxString())
+    {
+        m_color      = color;
+        m_top_label  = top_label;
+        m_type_line  = type_line;
+        m_vendor_line = vendor_line;
+        m_locked    = edit_disabled;
+        m_edit_btn->Enable(!edit_disabled);
+        m_edit_btn->SetToolTip(edit_disabled ? disabled_reason : _L("Edit filament"));
+        m_edit_btn->SetBackgroundColour(color);
+        Refresh();
+    }
+
+    void set_on_edit(std::function<void()> cb) { m_on_edit = std::move(cb); }
+
+private:
+    void paintEvent(wxPaintEvent&)
+    {
+        wxPaintDC dc(this);
+        render(dc);
+    }
+
+    // Orca: MSW GDI backend flicker mitigation -- every custom-painted tile in AmsMappingPopup.cpp
+    // (MaterialItem::render, MappingItem::render, MappingContainer::render) redirects through an
+    // offscreen wxMemoryDC + wxGCDC before blitting; mirrored here for the same reason.
+    void render(wxDC& dc)
+    {
+#ifdef __WXMSW__
+        wxSize     size = GetSize();
+        wxMemoryDC memdc;
+        wxBitmap   bmp(size.x, size.y);
+        memdc.SelectObject(bmp);
+        memdc.Blit({0, 0}, size, &dc, {0, 0});
+        {
+            wxGCDC dc2(memdc);
+            doRender(dc2);
+        }
+        memdc.SelectObject(wxNullBitmap);
+        dc.DrawBitmap(bmp, 0, 0);
+#else
+        doRender(dc);
+#endif
+    }
+
+    void doRender(wxDC& dc)
+    {
+        const wxSize size = GetSize();
+        // Orca: a white/near-white filament (or an untouched slot, UNSET_COLOR) is barely
+        // distinguishable from the dialog's white background without an outline -- house pattern
+        // for a subtle themed border (DragCanvas.cpp:21, CapsuleButton.cpp:75) is
+        // StateColor::darkModeColorFor on a fixed light-gray hex; "#DBDBDB" is already the
+        // registered "Input/Combo Box Border Color" pair (-> "#4A4A51" in dark mode), so every
+        // card, including a white one, always shows a visible rounded-rect edge.
+        dc.SetPen(wxPen(StateColor::darkModeColorFor(wxColour("#DBDBDB")), 1));
+        dc.SetBrush(wxBrush(m_color));
+        dc.DrawRoundedRectangle(0, 0, size.x - 1, size.y - 1, FromDIP(6));
+
+        // Auto-contrast text off the card's own background color, then run it through
+        // StateColor::darkModeColorFor per the house pattern (AmsMappingPopup.cpp:377 et al.)
+        // so the same tile still reads correctly when the app is switched to dark mode.
+        wxColour text_color = m_color.GetLuminance() < 0.6 ? *wxWHITE : wxColour(0x26, 0x2E, 0x30);
+        text_color = StateColor::darkModeColorFor(text_color);
+        dc.SetTextForeground(text_color);
+        dc.SetFont(GetFont());
+
+        // Orca: label sits at the top-left, the edit/remove icons at the top-right (overlay
+        // sizer, ctor above) -- reserve their cluster width plus a small gap so long names
+        // truncate with an ellipsis instead of running underneath the icons (was especially
+        // visible on swap cards: "Gene…" colliding with the pencil/cross). wxControl::Ellipsize
+        // is the same house-consistent DC-text-truncation entry point BBLTopbar.cpp and
+        // CreatePresetsDialog.cpp already use for custom-painted labels.
+        int icon_cluster_width = m_edit_btn->GetSize().GetWidth() + FromDIP(2);
+        const int max_text_width = std::max(0, size.x - FromDIP(6) - FromDIP(4) - icon_cluster_width);
+
+        int y = FromDIP(8);
+        if (!m_top_label.empty()) {
+            wxString top_label = wxControl::Ellipsize(m_top_label, dc, wxELLIPSIZE_END, max_text_width);
+            dc.DrawText(top_label, FromDIP(6), y);
+            y += dc.GetTextExtent(top_label).GetHeight() + FromDIP(2);
+        }
+        // Material type and vendor/brand each get their own line (both independently
+        // ellipsized to the icon-safe width) instead of being squeezed into one -- see
+        // set_content's doc for why.
+        if (!m_type_line.empty()) {
+            wxString type_line = wxControl::Ellipsize(m_type_line, dc, wxELLIPSIZE_END, max_text_width);
+            dc.DrawText(type_line, FromDIP(6), y);
+            y += dc.GetTextExtent(type_line).GetHeight() + FromDIP(2);
+        }
+        if (!m_vendor_line.empty()) {
+            wxString vendor_line = wxControl::Ellipsize(m_vendor_line, dc, wxELLIPSIZE_END, max_text_width);
+            dc.DrawText(vendor_line, FromDIP(6), y);
+        }
+    }
+
+    wxColour               m_color{UNSET_COLOR};
+    wxString               m_top_label;
+    wxString               m_type_line;
+    wxString               m_vendor_line;
+    bool                   m_locked{false};
+    ScalableButton*        m_edit_btn{nullptr};
+    std::function<void()>  m_on_edit;
+};
+
+FilamentInventoryEditor::FilamentInventoryEditor(wxWindow* parent, const std::string& printer_preset_name, size_t tool_count)
+    : wxDialog(parent, wxID_ANY, _L("Printer Material Settings"), wxDefaultPosition, wxDefaultSize, wxDEFAULT_DIALOG_STYLE)
+    , m_printer_preset_name(printer_preset_name)
+{
+    SetBackgroundColour(*wxWHITE);
+
+    // Addressable tool count, resolved by the caller (addressable_tool_count_of) -- normally the
+    // printer's physical nozzle count; devices that address more logical tools than nozzles
+    // report their logical count. Fixed for the dialog's lifetime: the device itself can't change
+    // mid-dialog anymore (its identity is this printer preset), so there's nothing that could
+    // need a different tool count later.
+    m_tool_count  = tool_count;
+
+    // device() already sizes inv.tools to at least tool_count with slot 0 present per tool
+    // (FilamentInventory::deserialize's invariant, preserved by for_preset's padding). This is
+    // the load-modify-save working model: every row's id/kind is copied from it verbatim and
+    // never touched again unless the row is brand new (added via "Add filament" in this session,
+    // see Row::is_new).
+    m_store = load_filament_inventories();
+    m_store.for_preset(printer_preset_name, tool_count); // creates the entry on first use
+    const Preset *printer_preset = wxGetApp().preset_bundle->printers.find_preset(printer_preset_name, false);
+    if (printer_preset) {
+    }
+    // Editing is only offered when the bound agent can actually deliver the edits to the
+    // printer (supports_filament_push, today the Snapmaker U1 dialect). Printers we can only
+    // READ from -- e.g. an mmu-shaped bridge like WonderSync -- open read-only: inventory and
+    // sync stay useful, but nothing is editable that could never reach the machine. This is
+    // an agent-capability gate, so a future AFC write dialect lifts it with no UI change.
+    {
+        const NetworkAgent* agent = active_printer_session().sync_agent();
+        m_read_only = agent == nullptr || !agent->supports_filament_push();
+    }
+
+    wxBoxSizer* main_sizer = new wxBoxSizer(wxVERTICAL);
+    main_sizer->AddSpacer(FromDIP(15));
+
+    // Static label: which printer preset's inventory the cards below edit. The device combo/
+    // Add/Rename affordances were dropped -- the printer preset IS the
+    // device identity now, so there is nothing left to switch between from inside this dialog.
+    wxBoxSizer* device_sizer = new wxBoxSizer(wxHORIZONTAL);
+    device_sizer->Add(new Label(this, wxString::Format(_L("Printer: %s"), from_u8(printer_preset_name))),
+                       0, wxALIGN_CENTER_VERTICAL);
+    main_sizer->Add(device_sizer, 0, wxEXPAND | wxLEFT | wxRIGHT | wxTOP, FromDIP(15));
+    main_sizer->AddSpacer(FromDIP(15));
+
+    // Horizontal card strip: one column per tool, each holding the tool's loaded-filament card.
+    wxBoxSizer* strip_sizer = new wxBoxSizer(wxHORIZONTAL);
+    main_sizer->Add(strip_sizer, 0, wxLEFT | wxRIGHT | wxTOP, FromDIP(15));
+
+    m_tools.resize(tool_count);
+    for (size_t i = 0; i < tool_count; ++i) {
+        ToolGroup& group = m_tools[i];
+
+        wxBoxSizer* col_sizer = new wxBoxSizer(wxVERTICAL);
+
+        group.main_card = new FilamentCard(this);
+        col_sizer->Add(group.main_card, 0, wxALIGN_CENTER_HORIZONTAL);
+        col_sizer->AddSpacer(FromDIP(6));
+
+        strip_sizer->Add(col_sizer, 0, wxALIGN_TOP | wxRIGHT, FromDIP(15));
+    }
+    main_sizer->AddSpacer(FromDIP(15));
+
+    // Seeds every tool group's rows from the current device and paints their cards.
+    reload_rows_from_device();
+
+    wxPanel* bottom_panel = new wxPanel(this);
+    bottom_panel->SetBackgroundColour(*wxWHITE);
+    wxBoxSizer* bottom_sizer = new wxBoxSizer(wxHORIZONTAL);
+    bottom_panel->SetSizer(bottom_sizer);
+    bottom_sizer->AddStretchSpacer();
+
+    // Orca: "Sync from printer" is the leftmost entry; OK/Cancel stay last. left_aligned_buttons_count
+    // = 1 keeps it pinned left of the stretch spacer while OK/Cancel are pushed right as usual.
+    auto* dlg_btns = new DialogButtons(bottom_panel, {"Sync from printer", "OK", "Cancel"}, "", 1);
+    bottom_sizer->Add(dlg_btns, 0, wxEXPAND);
+    main_sizer->Add(bottom_panel, 0, wxEXPAND);
+
+    // Orca: only offer sync when a connected machine actually supports it ("Sync from
+    // printer" is best-effort, offline editing stays the baseline). Recomputed once here; if the
+    // machine connects/disconnects while the dialog is open the button state won't follow it.
+    Button* sync_btn = dlg_btns->GetButtonFromIndex(0);
+    const ActivePrinterSession& session   = active_printer_session();
+    MachineObject*              machine   = session.live_machine();
+    NetworkAgent*               net_agent = session.sync_agent();
+    // is_connected() is a liveness heartbeat (last status update within a timeout). Pull-mode
+    // agents fetch on demand over REST, so a stale heartbeat (app just started, poll interval
+    // elapsed) must not disable the button -- a selected machine is enough, and a truly
+    // unreachable printer surfaces through fetch_filament_info's own error dialog. Only
+    // subscription mode, whose data freshness comes from the live connection, keeps the
+    // heartbeat requirement.
+    FilamentSyncMode sync_mode = net_agent ? net_agent->get_filament_sync_mode() : FilamentSyncMode::none;
+    // A live session is the same "is there anyone to sync/push against at all" bar
+    // do_sync_from_printer's own guard uses. A live printer that just doesn't support sync (wrong
+    // sync_mode, or a subscription-mode printer with a stale heartbeat) keeps its own, more
+    // specific tooltip below -- only a genuinely offline project (no printer corresponding to the
+    // active profile) gets the "saved locally" wording, since that's the only case where there is
+    // truly nothing to connect to.
+    const bool live_context = net_agent != nullptr;
+    m_sync_available = live_context && sync_mode != FilamentSyncMode::none &&
+                       (sync_mode == FilamentSyncMode::pull || machine->is_connected());
+    sync_btn->Enable(m_sync_available);
+    if (!m_sync_available)
+        sync_btn->SetToolTip(live_context
+            ? _L("Connect to a printer that supports reading loaded filaments to use this.")
+            : _L("No printer connected — settings are saved locally."));
+    sync_btn->Bind(wxEVT_BUTTON, &FilamentInventoryEditor::on_sync_from_printer, this);
+
+    // The printer is the source of truth for what's physically loaded: when a connection is
+    // available, always read on open (after the dialog paints). The read also records each
+    // tool's baseline so OK can push back only what the user actually changed.
+    if (m_sync_available)
+        CallAfter([this]() {
+            wxBusyCursor busy;
+            do_sync_from_printer(/*interactive=*/false);
+        });
+
+    dlg_btns->GetOK()->Bind(wxEVT_BUTTON, &FilamentInventoryEditor::on_ok, this);
+    dlg_btns->GetCANCEL()->Bind(wxEVT_BUTTON, [this](wxCommandEvent&) { EndModal(wxID_CANCEL); });
+    SetEscapeId(wxID_CANCEL);
+
+    SetSizer(main_sizer);
+    Layout();
+    Fit();
+
+    CenterOnParent();
+    wxGetApp().UpdateDlgDarkUI(this);
+}
+
+void FilamentInventoryEditor::update_clear_enabled(Row& row)
+{
+    row.action_btn->Enable(row.color_touched || row.type_touched);
+}
+
+const Preset* FilamentInventoryEditor::resolved_preset_of(const Row& row) const
+{
+    if (!row.type_touched || row.picked_preset.empty())
+        return nullptr;
+    return wxGetApp().preset_bundle->filaments.find_preset(row.picked_preset, false);
+}
+
+wxColour FilamentInventoryEditor::effective_color_of(const Row& row) const
+{
+    return row.color_picker ? row.color_picker->GetColour() : row.last_color;
+}
+
+std::string FilamentInventoryEditor::material_type_of(const Row& row) const
+{
+    // Prefer the resolved preset's own filament_type option (matches slot_from_row's type
+    // resolution) so a preset whose type differs from the row's stale loaded_type still shows
+    // the current value; fall back to loaded_type for an unresolved/legacy row.
+    if (const Preset* p = resolved_preset_of(row)) {
+        const ConfigOptionStrings* ft = p->config.option<ConfigOptionStrings>("filament_type");
+        if (ft && !ft->values.empty())
+            return ft->values.front();
+    }
+    return row.loaded_type;
+}
+
+std::string FilamentInventoryEditor::vendor_of(const Row& row) const
+{
+    // Orca: delegates to the single shared filament_vendor_of (FilamentInventoryStore) --
+    // also used by PhysicalFilamentComboBox's vendor grouping, so the two can never disagree on
+    // the same preset. A bare loaded_type (no resolved preset) carries no vendor to show.
+    const Preset* p = resolved_preset_of(row);
+    return p ? filament_vendor_of(*p) : std::string();
+}
+
+void FilamentInventoryEditor::update_card(size_t tool_idx, size_t row_idx, FilamentCard* card)
+{
+    const Row& row      = m_tools[tool_idx].rows[row_idx];
+    const bool is_loaded = (row_idx == 0);
+    const bool empty     = !row.color_touched && !row.type_touched && row.loaded_type.empty();
+    const wxColour color = row.color_touched ? row.last_color : UNSET_COLOR;
+    const std::string type_str   = material_type_of(row);
+    const std::string vendor_str = vendor_of(row);
+    const bool tag_locked = is_loaded && m_tag_locked_tools.count(tool_idx) != 0;
+    // Orca: "no filament present" rule -- the last sync explicitly reported this tool's loaded
+    // slot as empty, so there's nothing to set a material/color on. Only a live printer's
+    // explicit report blocks editing this way; a tool never covered by a sync (offline
+    // pre-configuration) is unaffected and stays fully editable, matching m_empty_on_printer's
+    // per-sync-pass population in do_sync_from_printer. Superseded by tag_locked (NFC tags always
+    // carry filament, so the two are not expected to overlap, but tag wording takes priority).
+    const bool printer_empty = is_loaded && !tag_locked && m_empty_on_printer.count(tool_idx) != 0;
+    const bool edit_disabled = m_read_only || tag_locked || printer_empty;
+    wxString disabled_reason;
+    if (m_read_only)
+        disabled_reason = _L("This printer doesn't support writing filament settings back; the inventory is read-only.");
+    else if (tag_locked)
+        disabled_reason = _L("This tool's filament is set by an NFC tag and can't be edited here.");
+    else if (printer_empty)
+        disabled_reason = _L("No filament is loaded on this tool.");
+    const wxString top_label = is_loaded ? wxString::Format("T%d", (int) tool_idx + 1) : wxString();
+
+    card->set_content(color, top_label, empty ? _L("(empty)") : from_u8(type_str),
+                       empty ? wxString() : from_u8(vendor_str), edit_disabled, disabled_reason);
+    card->set_on_edit([this, tool_idx, row_idx]() { open_row_editor(tool_idx, row_idx); });
+}
+
+void FilamentInventoryEditor::rebuild_tool_rows(size_t tool_idx)
+{
+    ToolGroup& group = m_tools[tool_idx];
+
+    // Capture each row's current widget state into plain data *before* destroying any live
+    // row-edit widgets below -- this only matters for a row whose small editor dialog happens to
+    // be open (its widgets are children of that dialog, not of this rebuild's targets), but is
+    // harmless (a no-op) for every other row since their widget pointers are already null.
+    for (Row& row : group.rows) {
+        if (row.color_picker)
+            row.last_color = row.color_picker->GetColour();
+        if (row.type_choice) {
+            const Preset* p    = row.type_choice->get_selected_preset();
+            row.picked_preset  = p ? p->name : std::string();
+        }
+    }
+
+    update_card(tool_idx, 0, group.main_card);
+
+    Layout();
+    Fit();
+}
+
+void FilamentInventoryEditor::add_row_widgets(size_t tool_idx, size_t row_idx, wxWindow* parent, wxSizer* target_sizer)
+{
+    ToolGroup& group = m_tools[tool_idx];
+    Row& row = group.rows[row_idx];
+    const bool is_loaded = (row_idx == 0); // slot 0 = loaded, always present, gets a Clear button
+
+    wxBoxSizer* row_sizer = new wxBoxSizer(wxHORIZONTAL);
+
+    row.color_picker = new wxColourPickerCtrl(parent, wxID_ANY, row.last_color);
+
+    // The same grouped preset selector as the sidebar's filament section (user/system groups,
+    // color chips) -- selection is row state only, never the project's filament_presets. Bare
+    // material types are not offered: every material has a Generic <type> preset.
+    row.type_choice = new PhysicalFilamentComboBox(parent);
+    row.type_choice->select_preset(row.type_touched ? row.picked_preset : std::string());
+
+    if (is_loaded) {
+        auto* clear_btn = new Button(parent, _L("Clear"));
+        clear_btn->SetStyle(ButtonStyle::Regular, ButtonType::Compact);
+        row.action_btn = clear_btn;
+    }
+    // Swap rows (row_idx > 0) get no action button here -- their Remove affordance lives on the
+    // card itself (FilamentCard's own remove icon), not inside this per-row editor.
+
+    row.color_picker->Bind(wxEVT_COLOURPICKER_CHANGED, [this, tool_idx, row_idx](wxColourPickerEvent&) {
+        Row& r = m_tools[tool_idx].rows[row_idx];
+        r.color_touched = true;
+        r.last_color    = r.color_picker->GetColour();
+        if (row_idx == 0)
+            update_clear_enabled(r);
+    });
+    row.type_choice->on_preset_picked = [this, tool_idx, row_idx]() {
+        Row& r = m_tools[tool_idx].rows[row_idx];
+        const Preset* p = r.type_choice->get_selected_preset();
+        r.picked_preset = p ? p->name : std::string();
+        r.type_touched  = p != nullptr;
+        if (row_idx == 0)
+            update_clear_enabled(r);
+    };
+    if (is_loaded) {
+        row.action_btn->Bind(wxEVT_BUTTON, [this, tool_idx](wxCommandEvent&) {
+            Row& r = m_tools[tool_idx].rows[0];
+            r.color_picker->SetColour(UNSET_COLOR);
+            r.type_choice->select_preset(std::string());
+            r.picked_preset.clear();
+            r.loaded_type.clear(); // an explicit Clear also drops an unresolvable legacy type
+            r.color_touched = false;
+            r.type_touched  = false;
+            r.last_color    = UNSET_COLOR;
+            update_clear_enabled(r);
+        });
+        update_clear_enabled(row);
+    }
+
+    row_sizer->Add(row.color_picker, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(8));
+    row_sizer->Add(row.type_choice, 1, wxEXPAND | wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(8));
+    if (row.action_btn)
+        row_sizer->Add(row.action_btn, 0, wxALIGN_CENTER_VERTICAL);
+
+    target_sizer->Add(row_sizer, 0, wxEXPAND | wxBOTTOM, FromDIP(6));
+}
+
+void FilamentInventoryEditor::open_row_editor(size_t tool_idx, size_t row_idx)
+{
+    ToolGroup& group = m_tools[tool_idx];
+    Row&       row   = group.rows[row_idx];
+    const bool is_loaded = (row_idx == 0);
+
+    // The row-edit machinery below writes live into `row` as the user interacts with it; on
+    // Cancel, restore this snapshot so an edit the user backs out of doesn't stick.
+    const Row snapshot = row;
+
+    wxDialog dlg(this, wxID_ANY, is_loaded ? wxString::Format(_L("Edit tool %d filament"), (int) tool_idx + 1)
+                                            : wxString::Format(_L("Edit swap filament (tool %d)"), (int) tool_idx + 1));
+    wxGetApp().UpdateDlgDarkUI(&dlg);
+
+    wxBoxSizer* sizer = new wxBoxSizer(wxVERTICAL);
+    sizer->AddSpacer(dlg.FromDIP(10));
+    add_row_widgets(tool_idx, row_idx, &dlg, sizer);
+
+    auto* dlg_btns = new DialogButtons(&dlg, {"OK", "Cancel"});
+    sizer->Add(dlg_btns, 0, wxEXPAND | wxTOP, dlg.FromDIP(10));
+    dlg_btns->GetOK()->Bind(wxEVT_BUTTON, [&dlg](wxCommandEvent&) { dlg.EndModal(wxID_OK); });
+    dlg_btns->GetCANCEL()->Bind(wxEVT_BUTTON, [&dlg](wxCommandEvent&) { dlg.EndModal(wxID_CANCEL); });
+    dlg.SetEscapeId(wxID_CANCEL);
+
+    wxBoxSizer* outer = new wxBoxSizer(wxVERTICAL);
+    outer->Add(sizer, 1, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, dlg.FromDIP(15));
+    dlg.SetSizerAndFit(outer);
+    dlg.CenterOnParent();
+
+    const int result = dlg.ShowModal();
+
+    // The row's widgets are children of `dlg` and are destroyed with it; row-edit lambdas bound
+    // above (color_picker/type_choice/Clear) must never fire again after this point.
+    row.color_picker = nullptr;
+    row.type_choice   = nullptr;
+    row.action_btn    = nullptr;
+
+    if (result != wxID_OK) {
+        row.color_touched = snapshot.color_touched;
+        row.type_touched  = snapshot.type_touched;
+        row.last_color     = snapshot.last_color;
+        row.picked_preset  = snapshot.picked_preset;
+        row.loaded_type     = snapshot.loaded_type;
+    }
+
+    rebuild_tool_rows(tool_idx);
+}
+
+FilamentInventory& FilamentInventoryEditor::device()
+{
+    // m_printer_preset_name never changes mid-dialog now that the device combo is gone, so this
+    // always resolves the same entry -- for_preset just pads it to m_tool_count on every call.
+    return m_store.for_preset(m_printer_preset_name, m_tool_count);
+}
+
+void FilamentInventoryEditor::reload_rows_from_device()
+{
+    const FilamentInventory& inv = device();
+    m_next_id = inv.next_id;
+
+    for (size_t i = 0; i < m_tool_count; ++i) {
+        ToolGroup& group = m_tools[i];
+        group.rows.clear();
+        group.rows.resize(inv.tools[i].size());
+        for (size_t s = 0; s < inv.tools[i].size(); ++s) {
+            const PhysicalFilament& slot = inv.tools[i][s];
+            Row& row = group.rows[s];
+            row.id            = slot.id;
+            row.is_new        = false;
+            row.kind          = slot.kind;
+            row.color_touched = !slot.color.empty();
+            row.loaded_type   = slot.type;
+            if (row.color_touched) {
+                wxColour c(slot.color);
+                if (c.IsOk())
+                    row.last_color = c;
+            }
+
+            // Row seeding: the slot's preset if installed, else "Generic <type>" (deleted
+            // profile / legacy type-only slot), else unselected -- exactly resolve_slot_preset's
+            // contract. loaded_type (above) keeps an unresolvable legacy type alive for on_ok.
+            row.picked_preset = resolve_slot_preset(slot, wxGetApp().preset_bundle->filaments);
+            row.type_touched  = !row.picked_preset.empty();
+        }
+        rebuild_tool_rows(i);
+    }
+
+    Layout();
+    Fit();
+}
+
+void FilamentInventoryEditor::on_sync_from_printer(wxCommandEvent&)
+{
+    do_sync_from_printer(/*interactive=*/true);
+}
+
+FilamentInventoryEditor::SlotSnapshot FilamentInventoryEditor::snapshot_of(const Row& row) const
+{
+    SlotSnapshot snap;
+    snap.picked_preset = row.picked_preset;
+    snap.loaded_type   = row.loaded_type;
+    if (row.color_touched)
+        snap.color = effective_color_of(row).GetAsString(wxC2S_HTML_SYNTAX).ToStdString();
+    return snap;
+}
+
+void FilamentInventoryEditor::do_sync_from_printer(bool interactive)
+{
+    // Orca: best-effort sync. Any failure is non-blocking and leaves the editor
+    // untouched -- offline manual editing stays the baseline workflow. Sync only ever targets
+    // each tool's slot-0 (loaded) row; swappable rows and their ids are left exactly as they
+    // were, since the printer only ever reports what's currently loaded.
+    const ActivePrinterSession& session   = active_printer_session();
+    NetworkAgent*               net_agent = session.sync_agent();
+    MachineObject*              machine   = session.live_machine();
+    if (net_agent == nullptr) {
+        if (interactive)
+            MessageDialog(this, _L("No connected printer is available to sync from."), _L("Sync from printer"), wxOK | wxICON_INFORMATION).ShowModal();
+        return;
+    }
+
+    // fetch_filament_info() is a synchronous/blocking REST call (see IPrinterAgent.hpp); pull-mode
+    // agents populate the machine's DevFilaSystem before returning. Subscription-mode agents keep
+    // DevFilaSystem current via MQTT pushes already, so there's nothing to fetch here. Mirrors the
+    // existing pattern in Sidebar::build_filament_ams_list/load_ams_list (Plater.cpp).
+    if (net_agent->get_filament_sync_mode() == FilamentSyncMode::pull) {
+        if (!net_agent->fetch_filament_info(machine->get_dev_id())) {
+            if (interactive)
+                MessageDialog(this, _L("Failed to read filament info from the printer."), _L("Sync from printer"), wxOK | wxICON_INFORMATION).ShowModal();
+            return;
+        }
+    }
+
+    std::shared_ptr<DevFilaSystem> fila_system = machine->GetFilaSystem();
+    std::map<int, DevAmsSlotId> tray_map = fila_system ? fila_system->GetTrayIndexMap() : std::map<int, DevAmsSlotId>();
+
+    // Orca: tray -> physical tool correspondence is ambiguous for toolchangers (DevFilaSystem's
+    // trays are AMS-shaped, not tool-shaped). Best-effort: real AMS trays, sorted by tray index,
+    // map 1:1 onto tool rows up to tool_count. Rows beyond the reported tray count, and trays
+    // beyond the row count, are left alone.
+    //
+    // GetTrayIndexMap() unconditionally seeds two virtual/external-spool pseudo-tray entries
+    // (VIRTUAL_TRAY_MAIN_ID/DEPUTY_ID) alongside any real AMS trays, so the map is never actually
+    // empty -- it can't be used as an "any data?" signal. Those pseudo-trays live in
+    // MachineObject::vt_slot, not in DevFilaSystem's amsList, so GetAmsTray() below can never
+    // resolve them anyway; skip them explicitly (rather than relying on that null result) so they
+    // don't silently consume a tool row on AMS-less toolchangers, and count rows actually applied
+    // to know whether the sync produced anything.
+    size_t tool_idx     = 0;
+    size_t rows_applied = 0;
+    m_synced_baseline.clear();
+    m_tag_locked_tools.clear();
+    m_empty_on_printer.clear();
+    std::set<size_t> tools_to_refresh; // cards to repaint once, after all tray data is applied
+    for (const auto& [tray_index, slot_id] : tray_map) {
+        if (devPrinterUtil::IsVirtualSlot(slot_id.first))
+            continue;
+        if (tool_idx >= m_tools.size())
+            break;
+        Row&   row       = m_tools[tool_idx].rows[0]; // slot 0 = loaded; sync never touches swappable rows
+        size_t this_tool = tool_idx;
+        ++tool_idx;
+        tools_to_refresh.insert(this_tool);
+
+        DevAmsTray* tray = fila_system->GetAmsTray(std::to_string(slot_id.first), std::to_string(slot_id.second));
+        if (!tray || !tray->is_exists) {
+            // The printer reported this slot with no filament loaded. Sync mirrors the machine:
+            // clear the row rather than leaving stale data (an unreported slot never reaches
+            // here -- tray_map only carries what the agent published). Also block editing this
+            // tool's material/color until a later sync reports filament (m_empty_on_printer,
+            // consumed by update_card) -- there's nothing physically present to set either on.
+            bool was_set = row.color_touched || row.type_touched || !row.loaded_type.empty();
+            if (was_set) {
+                row.last_color     = UNSET_COLOR;
+                row.picked_preset.clear();
+                row.loaded_type.clear();
+                row.color_touched = false;
+                row.type_touched  = false;
+                ++rows_applied;
+            }
+            m_empty_on_printer.insert(this_tool);
+            m_synced_baseline[this_tool] = snapshot_of(row); // baseline: empty slot
+            continue;
+        }
+
+        bool applied = false;
+        if (!tray->color.empty()) {
+            row.last_color     = tray->get_color();
+            row.color_touched = true;
+            applied = true;
+        }
+        const std::string type = tray->get_filament_type();
+        {
+            // Best target first: the agent may have resolved an exact profile for this spool
+            // (DevAmsTray::setting_id carries the filament_id it matched -- see e.g.
+            // SnapmakerPrinterAgent::fetch_filament_info's vendor/type/color lookup). Fall back
+            // to the material's Generic preset (alias-aware); if neither is installed, remember
+            // the type for save (loaded_type) without changing the visible selection.
+            const PresetCollection& filaments = wxGetApp().preset_bundle->filaments;
+            const Preset* target = nullptr;
+            if (!tray->setting_id.empty())
+                for (auto it = filaments.begin(); it != filaments.end(); ++it)
+                    if (it->filament_id == tray->setting_id && it->is_visible && it->is_compatible) { target = &*it; break; }
+            if (target == nullptr)
+                target = find_generic_filament_preset(type, filaments);
+
+            if (target != nullptr) {
+                row.picked_preset = target->name;
+                row.type_touched  = true;
+                applied = true;
+            }
+            if (!type.empty())
+                row.loaded_type = type;
+        }
+        if (applied)
+            ++rows_applied;
+        m_synced_baseline[this_tool] = snapshot_of(row);
+        // Non-zero tag_uid = the slot's data came from an NFC tag (see SnapmakerPrinterAgent's
+        // fetch); the tag is authoritative, so this tool is excluded from push_changes_to_printer.
+        if (!tray->tag_uid.empty() && tray->tag_uid.find_first_not_of('0') != std::string::npos)
+            m_tag_locked_tools.insert(this_tool);
+    }
+
+    // Orca: write-through to the registry immediately, for every tool this sync actually covered
+    // (always favor what's reported from the printer over a stale local
+    // view -- OK's local-save role becomes redundant for these tools; its real job when connected
+    // is the push_changes_to_printer diff below, unchanged). Without this, every consumer that
+    // reads the registry (the mapping dialog's target options, compute_physical_map_proposal, the
+    // auto-mapper, the Slicing Result summary) would keep seeing whatever was last saved by OK
+    // until the user opens this dialog and presses OK again. Tools never covered by this sync
+    // (tray_map ran out, or the printer never reported them) are untouched, matching the class's
+    // existing "no baseline = no connection-known state" rule for push_changes_to_printer.
+    if (!tools_to_refresh.empty()) {
+        FilamentInventory& inv = device();
+        for (size_t t : tools_to_refresh)
+            inv.apply_synced_loaded_slot(t, slot_from_row(m_tools[t].rows[0]));
+        inv.next_id = m_next_id;
+        inv.ensure_ids();
+        m_next_id = inv.next_id;
+        // Adopt whatever id ensure_ids settled on (freshly minted for a new filament, or zeroed
+        // for a clear) so a later on_ok save -- which rebuilds its own PhysicalFilament from
+        // row.id -- reuses the same id this write-through just persisted, instead of minting a
+        // second, different one for the same physical slot.
+        for (size_t t : tools_to_refresh)
+            m_tools[t].rows[0].id = inv.tools[t][0].id;
+        save_filament_inventories(m_store);
+    }
+
+    for (size_t t : tools_to_refresh)
+        rebuild_tool_rows(t);
+
+    if (rows_applied == 0 && interactive)
+        MessageDialog(this, _L("The printer did not report any filament information."), _L("Sync from printer"), wxOK | wxICON_INFORMATION).ShowModal();
+}
+
+PhysicalFilament FilamentInventoryEditor::slot_from_row(const Row& row) const
+{
+    // The row's plain data IS the "set" signal (kept live-synchronized by add_row_widgets'
+    // bindings and reconciled on modal Cancel by open_row_editor), so a stale flag can
+    // never silently drop a pick. No selection keeps the row's unresolvable legacy type
+    // (loaded_type), which an explicit Clear empties.
+    const std::string color = row.color_touched ? effective_color_of(row).GetAsString(wxC2S_HTML_SYNTAX).ToStdString() : std::string();
+    const Preset*     p     = resolved_preset_of(row);
+    std::string        preset, type;
+    if (p != nullptr) {
+        preset = p->name;
+        const ConfigOptionStrings* ft = p->config.option<ConfigOptionStrings>("filament_type");
+        type   = (ft && !ft->values.empty()) ? ft->values.front() : row.loaded_type;
+    } else {
+        type = row.loaded_type;
+    }
+    return build_physical_filament(color, type, preset, row.id, row.kind);
+}
+
+void FilamentInventoryEditor::on_ok(wxCommandEvent&)
+{
+    // Load-modify-save: rows keep the id they were loaded with; ensure_ids below mints one for
+    // every non-empty slot that lacks one -- rows added this session AND slot-0 rows first
+    // filled on a fresh inventory (which load as id 0; saving them as id 0 would make
+    // deserialize's reconcile pass renumber them on the next launch, silently invalidating
+    // every plate filament_physical_map entry that pointed at them). A cancelled dialog never
+    // advances the on-disk allocator. Every synced tool's slot 0 was already write-through-saved
+    // by do_sync_from_printer as the sync happened (see its own comment) -- this pass still
+    // recomputes and saves it from the row again, which is redundant but harmless (same data,
+    // same id) whenever nothing was edited since; it stays authoritative for anything the sync
+    // path doesn't cover (offline edits, swap rows, tools never synced).
+    FilamentInventory inv;
+    inv.next_id = m_next_id;
+    inv.tools.resize(m_tools.size());
+    for (size_t i = 0; i < m_tools.size(); ++i) {
+        const ToolGroup& group = m_tools[i];
+        inv.tools[i].resize(1); // slot 0 (loaded) always present
+        for (size_t r = 0; r < group.rows.size(); ++r) {
+            const Row& row = group.rows[r];
+            PhysicalFilament slot = slot_from_row(row);
+            if (r == 0)
+                inv.tools[i][0] = slot;
+            else if (!slot.empty())
+                inv.tools[i].push_back(slot); // an added row left fully empty isn't a filament
+        }
+    }
+    inv.ensure_ids();
+    device() = inv;
+    save_filament_inventories(m_store);
+    push_changes_to_printer();
+    EndModal(wxID_OK);
+}
+
+void FilamentInventoryEditor::push_changes_to_printer()
+{
+    // Best-effort write-back of USER CHANGES only: a tool is pushed when a sync recorded its
+    // baseline this session (no baseline = no known printer state = nothing to diff against)
+    // and the slot-0 row now differs from it. Swappable rows are never pushed -- the printer
+    // models one loaded filament per tool. Tag-locked tools are skipped: the NFC tag is
+    // authoritative. Cleared rows are skipped too -- slot config can't unload filament.
+    if (m_synced_baseline.empty())
+        return;
+    const ActivePrinterSession& session   = active_printer_session();
+    NetworkAgent*               net_agent = session.sync_agent();
+    MachineObject*              machine   = session.live_machine();
+    if (net_agent == nullptr || !net_agent->supports_filament_push())
+        return;
+
+    wxString     failures, tag_kept;
+    wxBusyCursor busy;
+
+    for (const auto& [tool, baseline] : m_synced_baseline) {
+        if (tool >= m_tools.size() || m_tools[tool].rows.empty())
+            continue;
+        const Row&   row     = m_tools[tool].rows[0];
+        SlotSnapshot current = snapshot_of(row);
+        if (current == baseline)
+            continue;
+        if (m_tag_locked_tools.count(tool)) {
+            tag_kept += wxString::Format(" %d", (int) tool + 1);
+            continue;
+        }
+        const Preset* p = resolved_preset_of(row);
+        if (p == nullptr)
+            continue; // cleared/unresolvable row: nothing representable to write
+
+        IPrinterAgent::FilamentSlotInfo info;
+        info.slot   = (int) tool;
+        info.vendor = p->config.opt_string("filament_vendor", 0u);
+        const ConfigOptionStrings* ft = p->config.option<ConfigOptionStrings>("filament_type");
+        info.type = (ft && !ft->values.empty()) ? ft->values.front() : row.loaded_type;
+        if (info.type.empty())
+            continue;
+        info.sub_type = derive_filament_subtype(p->alias.empty() ? p->name : p->alias, info.vendor, info.type);
+        const wxColour c = row.color_touched ? effective_color_of(row) : wxColour();
+        info.color_rgba = wxString::Format("%02X%02X%02XFF", c.Red(), c.Green(), c.Blue()).ToStdString();
+
+        if (!net_agent->push_filament_info(machine->get_dev_id(), info))
+            failures += wxString::Format(" %d", (int) tool + 1);
+    }
+
+    if (!failures.empty())
+        MessageDialog(this, wxString::Format(_L("Could not update the printer's filament settings for these tools:%s. Your changes are saved locally."), failures),
+                       _L("Printer Material Settings"), wxOK | wxICON_WARNING).ShowModal();
+    if (!tag_kept.empty())
+        MessageDialog(this, wxString::Format(_L("These tools read their filament from an NFC tag; the tag's values were kept on the printer:%s"), tag_kept),
+                       _L("Printer Material Settings"), wxOK | wxICON_INFORMATION).ShowModal();
+}
+
+}} // namespace Slic3r::GUI

--- a/src/slic3r/GUI/FilamentInventoryEditor.hpp
+++ b/src/slic3r/GUI/FilamentInventoryEditor.hpp
@@ -1,0 +1,183 @@
+#ifndef slic3r_GUI_FilamentInventoryEditor_hpp_
+#define slic3r_GUI_FilamentInventoryEditor_hpp_
+
+#include <map>
+#include <set>
+#include <string>
+#include <vector>
+
+#include <wx/colour.h>
+#include <wx/dialog.h>
+
+#include "libslic3r/FilamentInventory.hpp"
+
+class wxColourPickerCtrl;
+class wxBoxSizer;
+class wxSizer;
+class Button;
+
+namespace Slic3r {
+class Preset;
+namespace GUI {
+
+// "Printer Material Settings" editor: per tool, the currently loaded physical filament (slot 0)
+// plus zero or more swappable ones (Slic3r::FilamentInventory, libslic3r/FilamentInventory.hpp),
+// so the mapping dialog (FilamentMapDialog) can target a specific physical filament -- not just a
+// tool -- when auto-suggesting or letting the user pick a plate-filament assignment.
+// Persistence goes through GUI::load_filament_inventories / save_filament_inventories /
+// current_inventory_for_preset (FilamentInventoryStore.hpp), which route to the inventory keyed
+// by THIS printer preset (see current_inventory_for_preset's doc), and follows load-modify-save: the
+// inventory loaded from disk is kept as the working model for the whole session, edited in place,
+// and written back unchanged except for the edits the user actually made -- ids of rows the user
+// didn't touch never change, since plate mappings reference physical filaments by id across
+// sessions.
+class PhysicalFilamentComboBox;
+class FilamentCard;
+
+class FilamentInventoryEditor : public wxDialog
+{
+public:
+    FilamentInventoryEditor(wxWindow* parent, const std::string& printer_preset_name, size_t tool_count);
+
+private:
+    // One physical filament row: the tool's loaded slot (slot 0, always present) or a swappable
+    // slot. color_touched/type_touched are tracked independently -- picking only a type must not
+    // also persist the untouched picker's neutral placeholder color as if it were a real color
+    // pick, and vice versa.
+    //
+    // is_new is true only for rows created via "Add filament" in this session; such a row's `id`
+    // stays 0 until OK, when it is minted from the inventory's next_id allocator. Every row
+    // loaded from disk has is_new == false and keeps whatever `id` it already had (including 0
+    // for a never-set loaded slot) for the rest of the session, regardless of edits -- ids are
+    // never reassigned to a pre-existing row.
+    //
+    // last_color/picked_preset/loaded_type/color_touched/type_touched are the authoritative,
+    // always-current data for the row; color_picker/type_choice/action_btn are non-null only
+    // while this row's small editor dialog (opened from its card's pencil icon, see
+    // open_row_editor) is on screen -- the card strip itself never keeps row widgets alive, it
+    // paints straight from the plain data.
+    struct Row
+    {
+        int                   id{0};
+        bool                  is_new{false};
+        Slic3r::PhysicalFilament::Kind kind{Slic3r::PhysicalFilament::Kind::Manual};
+        bool                  color_touched{false};
+        bool                  type_touched{false};
+        wxColour              last_color{0xD9, 0xD9, 0xD9};
+        std::string           picked_preset; // canonical filament preset name ("" = none)
+        // The filament_type as loaded (or as last derived from a resolved preset), used by on_ok
+        // to keep the previous type when a newly picked preset's filament_type can't be resolved.
+        std::string           loaded_type;
+        wxColourPickerCtrl*   color_picker{nullptr};
+        PhysicalFilamentComboBox* type_choice{nullptr};
+        wxWindow*             action_btn{nullptr}; // Clear (slot 0 only); swap rows have none here
+    };
+
+    // A tool's rows (rows[0] = loaded, rows[1..] = swappable) plus the card widgets that render
+    // them: main_card shows rows[0] (the editor renders one card per tool; rows beyond 0 are
+    // carried as data only and round-trip through save untouched).
+    // torn down/rebuilt whenever a row is added or removed (rebuild_tool_rows).
+    struct ToolGroup
+    {
+        std::vector<Row> rows;
+        FilamentCard*     main_card{nullptr};
+    };
+
+    // Converts one row's live plain data into the PhysicalFilament shape saved to the registry
+    // (kind/id passthrough; color only if color_touched; preset+type resolved from picked_preset
+    // when type_touched and it still resolves, else the row's loaded_type). Shared by on_ok
+    // (every row, including swaps) and do_sync_from_printer's immediate write-through of a synced
+    // tool's loaded slot (row 0 only) -- both must agree on exactly what "this row's current
+    // state" means as a PhysicalFilament.
+    Slic3r::PhysicalFilament slot_from_row(const Row& row) const;
+    void on_ok(wxCommandEvent& event);
+    void on_sync_from_printer(wxCommandEvent& event);
+    void update_clear_enabled(Row& row);
+    void rebuild_tool_rows(size_t tool_idx);
+    // Builds the color-picker/PhysicalFilamentComboBox/Clear-button row-edit machinery for one
+    // row into `parent`/`target_sizer` -- used only by open_row_editor to host it inside that
+    // row's small modal editor; the card strip itself never calls this.
+    void add_row_widgets(size_t tool_idx, size_t row_idx, wxWindow* parent, wxSizer* target_sizer);
+    // Opens the small modal editor (color picker + PhysicalFilamentComboBox + Clear for slot 0)
+    // for one row, hosted via add_row_widgets; reverts the row's plain data to its pre-edit
+    // snapshot on Cancel, since the row-edit machinery writes live into it as the user interacts.
+    void open_row_editor(size_t tool_idx, size_t row_idx);
+    // Pushes one row's current plain data onto its card (color/label/lock state) and (re)binds
+    // the card's pencil/remove callbacks to this tool/row index.
+    void update_card(size_t tool_idx, size_t row_idx, FilamentCard* card);
+    // Orca: the row's picked preset, resolved once -- shared by material_type_of, vendor_of,
+    // slot_from_row and push_changes_to_printer instead of each independently re-running
+    // type_touched/picked_preset/find_preset. nullptr for an unresolved/legacy row (bare
+    // loaded_type only, or nothing touched at all).
+    const Preset* resolved_preset_of(const Row& row) const;
+    // Orca: the row's current color -- the live picker's value while one is open (so an
+    // uncommitted pick is seen immediately, matching what the user sees on screen), else the
+    // row's last committed last_color. Shared by snapshot_of, slot_from_row and
+    // push_changes_to_printer so a save mid-pick can never persist a different color than what
+    // was last compared against. Callers still gate on row.color_touched themselves for "has a
+    // color actually been set".
+    wxColour effective_color_of(const Row& row) const;
+    // Card-content helpers for the two-line material cards: material type ("PLA") and
+    // vendor/brand ("PolyTerra", the leading token of the resolved preset's display name --
+    // same convention as libslic3r's preset_vendor_token). Both return "" for an unresolved/
+    // legacy row (bare loaded_type only, or nothing touched at all).
+    std::string material_type_of(const Row& row) const;
+    std::string vendor_of(const Row& row) const;
+
+    // Reseeds every tool group's row data from m_store's inventory for m_printer_preset_name and
+    // rebuilds their widgets. Shared by the ctor and the device-switch/sync rebuild path
+    // (via rebuild_tool_rows, not this -- this one is ctor-only now that the printer preset
+    // itself can never change mid-dialog), so the seeding logic lives in exactly one place.
+    void reload_rows_from_device();
+    // The inventory this dialog edits, in m_store, keyed by m_printer_preset_name -- resolved once
+    // in the ctor via current_inventory_for_preset, never re-resolved since the printer preset
+    // can't change mid-dialog. Pads the inventory to m_tool_count on every call, same as
+    // current_inventory_for_preset itself.
+    FilamentInventory& device();
+
+    std::string               m_printer_preset_name;
+    // Orca: inventory-store routing (see FilamentInventoryStore.hpp). m_store is loaded in the
+    // ctor (current_inventory_for_preset) and saved back to by on_ok, keyed throughout by
+    // m_printer_preset_name.
+    FilamentInventories        m_store;
+    size_t                    m_tool_count{0};
+    // True when the bound agent cannot deliver edits to the printer (no supports_filament_push)
+    // -- every card renders edit-disabled with a tooltip naming why.
+    bool                      m_read_only{false};
+    bool                      m_sync_available{false};
+
+    // Bidirectional sync state. After a successful read from the printer, each visited tool's
+    // slot-0 row snapshot becomes its baseline; OK pushes back only tools whose row DIFFERS
+    // from that baseline (no baseline = no connection-known state = no push). Swappable rows
+    // (slot 1+) are never pushed. Tag-locked tools (NFC-backed, DevAmsTray::tag_uid) are read
+    // but never written -- the tag is authoritative; their card's pencil is disabled.
+    struct SlotSnapshot
+    {
+        std::string picked_preset;
+        std::string loaded_type;
+        std::string color; // "#RRGGBB" when set, "" when unset
+        bool operator==(const SlotSnapshot& o) const
+        { return picked_preset == o.picked_preset && loaded_type == o.loaded_type && color == o.color; }
+    };
+    std::map<size_t, SlotSnapshot> m_synced_baseline;   // tool index -> post-sync row snapshot
+    std::set<size_t>               m_tag_locked_tools;  // tool indexes backed by an NFC tag
+    // Tool indexes whose last sync reported the loaded slot as not present -- there's no
+    // filament to set a material/color on, so update_card disables that tool's slot-0 pencil
+    // (no editing an empty tool). Repopulated from scratch on every
+    // do_sync_from_printer call, so it naturally resets once a later sync reports filament; a
+    // tool never covered by any sync never enters this set and stays fully editable (in-session
+    // only -- not persisted across dialog restarts).
+    std::set<size_t>               m_empty_on_printer;
+
+    SlotSnapshot snapshot_of(const Row& row) const;
+    // interactive=false (auto-sync on open) suppresses the informational dialogs.
+    void do_sync_from_printer(bool interactive);
+    void push_changes_to_printer();
+    std::vector<ToolGroup>    m_tools;
+    // Compatible filament preset names for the selected printer, in ComboBox order. Combo layout
+    int                       m_next_id{1};   // FilamentInventory::next_id at load; advances only at save
+};
+
+}} // namespace Slic3r::GUI
+
+#endif // slic3r_GUI_FilamentInventoryEditor_hpp_

--- a/src/slic3r/GUI/FilamentInventoryStore.cpp
+++ b/src/slic3r/GUI/FilamentInventoryStore.cpp
@@ -1,0 +1,118 @@
+#include "FilamentInventoryStore.hpp"
+
+#include "ActivePrinterSession.hpp"
+#include "GUI_App.hpp"
+
+namespace Slic3r { namespace GUI {
+
+static const char *FILAMENT_INVENTORIES_KEY = "filament_inventories";
+// Written once, the first time deserialize() reports a parse failure, so the unparsable blob
+// survives the next save_filament_inventories() overwrite of FILAMENT_INVENTORIES_KEY -- never
+// overwritten again afterward, so it always keeps the FIRST corrupt blob seen, not the latest.
+static const char *FILAMENT_INVENTORIES_CORRUPT_BACKUP_KEY = "filament_inventories_corrupt_backup";
+
+FilamentInventory& current_inventory_for_preset(const Preset &printer_preset, FilamentInventories &store, size_t tool_count)
+{
+    return store.for_preset(printer_preset.name, tool_count);
+}
+
+size_t addressable_tool_count_of(const Preset &printer_preset, FilamentInventories &/*store*/)
+{
+    const auto  *nozzle_diameters = printer_preset.config.option<ConfigOptionFloats>("nozzle_diameter");
+    return nozzle_diameters && !nozzle_diameters->empty() ? nozzle_diameters->size() : 1;
+}
+
+std::string resolve_slot_preset(const PhysicalFilament &pf, const PresetCollection &filaments)
+{
+    // Orca: the Generic-<type> fallback only stands in for a RECORDED preset that no longer
+    // resolves (e.g. the preset was deleted/renamed since the slot was saved) -- it must not
+    // fire for a slot that never had a preset recorded at all (pf.preset empty), such as a
+    // legacy slot migrated without preset data. Those slots resolve to "" (bare-type label,
+    // no profile-mismatch warning) instead of being degraded to a synthetic Generic identity.
+    if (pf.preset.empty())
+        return std::string();
+    if (filaments.find_preset(pf.preset, false) != nullptr)
+        return pf.preset;
+    if (const Preset* generic = find_generic_filament_preset(pf.type, filaments))
+        return generic->name;
+    return std::string();
+}
+
+size_t resolve_active_printer_tool_count(FilamentInventories &store)
+{
+    store = load_filament_inventories();
+    return addressable_tool_count_of(active_printer_session().profile(), store);
+}
+
+std::string filament_vendor_of(const Preset &preset)
+{
+    if (const auto *vendor = preset.config.option<ConfigOptionStrings>("filament_vendor"))
+        if (!vendor->values.empty() && !vendor->values.front().empty())
+            return vendor->values.front();
+    const std::string name = preset.alias.empty() ? preset.name : preset.alias;
+    const size_t       space = name.find(' ');
+    return space == std::string::npos ? std::string() : name.substr(0, space);
+}
+
+PhysicalFilament build_physical_filament(const std::string &color, const std::string &type,
+                                          const std::string &preset, int id, PhysicalFilament::Kind kind)
+{
+    PhysicalFilament slot;
+    slot.kind   = kind;
+    slot.id     = id;
+    slot.color  = color;
+    slot.type   = type;
+    slot.preset = preset;
+    return slot;
+}
+
+std::string slot_display_name(const PhysicalFilament &pf, const PresetCollection &filaments)
+{
+    std::string resolved = resolve_slot_preset(pf, filaments);
+    if (resolved.empty())
+        return resolved;
+    if (const Preset *p = filaments.find_preset(resolved, false); p != nullptr && !p->alias.empty())
+        return p->alias;
+    return resolved.substr(0, resolved.find(" @"));
+}
+
+const Preset* find_generic_filament_preset(const std::string& type, const PresetCollection& filaments)
+{
+    if (type.empty())
+        return nullptr;
+    // "Generic <type>" is usually an ALIAS -- the canonical system preset name carries a
+    // suffix (e.g. "Generic PLA @System"), so resolve through the alias map first and fall
+    // back to a literal name match for bundles that don't alias.
+    const std::string wanted = "Generic " + type;
+    return filaments.find_preset(filaments.get_preset_name_by_alias(wanted), false);
+}
+
+FilamentInventories load_filament_inventories()
+{
+    std::string serialized = wxGetApp().app_config->get(FILAMENT_INVENTORIES_KEY);
+    if (serialized.empty())
+        return FilamentInventories{};
+    FilamentInventories store = FilamentInventories::deserialize(serialized);
+    if (store.parse_error && wxGetApp().app_config->get(FILAMENT_INVENTORIES_CORRUPT_BACKUP_KEY).empty())
+        wxGetApp().app_config->set(FILAMENT_INVENTORIES_CORRUPT_BACKUP_KEY, serialized);
+    return store;
+}
+
+void save_filament_inventories(const FilamentInventories &store)
+{
+    wxGetApp().app_config->set(FILAMENT_INVENTORIES_KEY, store.serialize());
+}
+
+std::vector<ProjectFilamentInfo> build_project_filament_info(const DynamicPrintConfig &full_config,
+                                                               const std::vector<std::string> &filament_presets)
+{
+    const auto *colors  = full_config.option<ConfigOptionStrings>("filament_colour");
+    const auto *types   = full_config.option<ConfigOptionStrings>("filament_type");
+    const auto *vendors = full_config.option<ConfigOptionStrings>("filament_vendor");
+
+    static const std::vector<std::string> empty;
+    return Slic3r::build_project_filament_info(colors ? colors->values : empty, types ? types->values : empty,
+                                                 vendors ? vendors->values : empty, filament_presets);
+}
+
+}} // namespace Slic3r::GUI

--- a/src/slic3r/GUI/FilamentInventoryStore.hpp
+++ b/src/slic3r/GUI/FilamentInventoryStore.hpp
@@ -1,0 +1,79 @@
+#ifndef slic3r_GUI_FilamentInventoryStore_hpp_
+#define slic3r_GUI_FilamentInventoryStore_hpp_
+
+#include <string>
+
+#include "libslic3r/FilamentInventory.hpp"
+#include "libslic3r/Preset.hpp"
+
+namespace Slic3r {
+namespace GUI {
+
+// Persistence layer for the per-machine physical filament inventories, stored in a
+// Slic3r::FilamentInventories (src/libslic3r/FilamentInventory.hpp) as a single JSON blob via
+// AppConfig's root key "filament_inventories" (wxGetApp().app_config->get/set).
+FilamentInventories load_filament_inventories();
+void                save_filament_inventories(const FilamentInventories& store);
+
+// One store/tool-count resolution preamble: loads the store into `store` and resolves the
+// addressable tool count for the active printer profile (ActivePrinterSession::profile(), which
+// owns the edited-vs-selected choice) in one call. Follow with
+// current_inventory_for_preset(active_printer_session().profile(), store, tool_count) for the
+// inventory itself.
+size_t resolve_active_printer_tool_count(FilamentInventories& store);
+
+// Resolves the inventory entry for THIS printer preset -- an inventory follows the same thing
+// Orca's connection settings follow, the printer preset (print_host/printhost_apikey are preset
+// options, and one preset copy per physical machine is already Orca's own convention). Creates an
+// empty entry on first resolution. Pads the returned inventory to at least tool_count tools
+// (never truncates). `store` is taken by reference because resolution may create/pad the entry.
+FilamentInventory& current_inventory_for_preset(const Preset& printer_preset, FilamentInventories& store, size_t tool_count);
+
+// How many tools this printer preset addresses: the physical nozzle count. `store` is unused
+// here (kept so callers that also need the resolved inventory -- via
+// current_inventory_for_preset -- can pass the same one through both calls without an unrelated
+// signature split).
+size_t addressable_tool_count_of(const Preset& printer_preset, FilamentInventories& store);
+
+// Resolution for display/use: the slot's preset if it still exists in `filaments`, else
+// "Generic <type>" if that preset exists, else "".
+// The installed "Generic <type>" preset for a material type, resolved alias-aware (canonical
+// system names carry a suffix, e.g. "Generic PLA @System"). nullptr when absent or type empty.
+const Preset* find_generic_filament_preset(const std::string& type, const PresetCollection& filaments);
+
+std::string resolve_slot_preset(const PhysicalFilament& pf, const PresetCollection& filaments);
+
+// A physical slot's short display name: resolve_slot_preset's raw preset name, shortened for
+// a compact UI -- the preset's short alias when it has one (e.g. "Snapmaker PLA SnapSpeed" instead
+// of "Snapmaker PLA SnapSpeed @U1"), else the same trim-at-first-" @" idiom CaliHistoryDialog uses
+// for a preset with no alias (system/vendor presets carry an " @<vendor>" suffix on the raw name).
+// "" when the slot's preset doesn't resolve at all -- callers that want a type-only fallback (e.g.
+// pf.type) apply it themselves. Used by FilamentMapDialog's combo labels and the Slicing Result
+// summary row, so the same physical slot renders identically in both.
+std::string slot_display_name(const PhysicalFilament& pf, const PresetCollection& filaments);
+
+// The single vendor derivation for a live filament preset: prefers the actual
+// filament_vendor config option (the authoritative field), falling back to the first whitespace
+// token of the preset's alias-or-name -- the same convention libslic3r's preset_vendor_token
+// (FilamentInventory.cpp) uses when only a raw preset-name string is available, e.g. inside the
+// pure auto-mapper, which cannot depend on a live Preset/config. Returns "" when neither yields
+// anything. Used everywhere this dialog stack needs a preset's vendor for display or grouping
+// (FilamentInventoryEditor's card, the Physical Filament combo box's vendor grouping) so they can
+// never disagree on the same preset.
+std::string filament_vendor_of(const Preset& preset);
+
+// One PhysicalFilament assembly: color/type/preset/id/kind assigned the same way at every
+// GUI write site (FilamentInventoryEditor::slot_from_row and FilamentMapDialog's bootstrap
+// "remember these as the loaded filaments" write).
+PhysicalFilament build_physical_filament(const std::string& color, const std::string& type,
+                                          const std::string& preset, int id, PhysicalFilament::Kind kind);
+
+// GUI-side adapter for Slic3r::build_project_filament_info (FilamentInventory.hpp): extracts the
+// filament_colour/filament_type/filament_vendor config-option lists from `full_config` and
+// delegates, pairing them with the caller's filament_presets list (0-based, same order/length).
+std::vector<ProjectFilamentInfo> build_project_filament_info(const DynamicPrintConfig& full_config,
+                                                               const std::vector<std::string>& filament_presets);
+
+}} // namespace Slic3r::GUI
+
+#endif // slic3r_GUI_FilamentInventoryStore_hpp_

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -3,6 +3,7 @@
 #include "libslic3r/Technologies.hpp"
 #include "libslic3r/Platform.hpp"
 #include "GUI_App.hpp"
+#include "ActivePrinterSession.hpp"
 #include "GUI_Init.hpp"
 #include "GUI_ObjectList.hpp"
 #include "slic3r/GUI/UserManager.hpp"
@@ -3930,9 +3931,7 @@ void GUI_App::set_live_printer_agent(std::shared_ptr<IPrinterAgent> agent)
     if (!m_agent)
         return;
 
-    // why: tearing down the old machine selection is only ever the prefix of setting the live
-    // agent (to a new one, or to null when the selection is missing) - so it lives here, not as
-    // a standalone helper. Pass nullptr to clear the selection.
+    // why: pass nullptr to clear the selection (e.g. when the agent's provider is gone).
     if (DeviceManager* dev = getDeviceManager())
     {
         dev->set_selected_machine(""); // why: empty id disconnects and deselects the current machine
@@ -4003,19 +4002,17 @@ void GUI_App::switch_printer_agent()
         // preset targets a different host, otherwise filament sync keeps hitting the old
         // printer. (#12506)
         if (effective_agent_id != BBL_PRINTER_AGENT_ID && m_device_manager && preset_bundle) {
-            const std::string print_host = config.opt_string("print_host");
-            if (!print_host.empty()) {
-                const std::string dev_id = MachineObject::dev_id_from_address(print_host, config.opt_string("printhost_port"));
-                MachineObject*    sel    = m_device_manager->get_selected_machine();
-                if (!sel || sel->get_dev_id() != dev_id)
+            const auto conn = active_printer_session().connection();
+            if (conn.configured()) {
+                MachineObject* sel = m_device_manager->get_selected_machine();
+                if (!sel || sel->get_dev_id() != conn.dev_id)
                     select_machine(effective_agent_id);
             }
         }
         return;
     }
 
-    // Swap the agent; set_live_printer_agent resets the device selection so the new
-    // agent starts clean (#124).
+    // Swap the agent; set_live_printer_agent resets the device selection so the new agent starts clean.
     set_live_printer_agent(new_printer_agent);
 
     BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << ": printer agent switched to " << effective_agent_id;
@@ -4040,18 +4037,12 @@ void GUI_App::select_machine(const std::string& agent_id)
         return;
     }
 
-    // Get config source (preset or physical printer)
-    const auto& preset = preset_bundle->printers.get_edited_preset();
-    const DynamicPrintConfig* host_cfg = &preset.config;
-
-    std::string print_host = host_cfg->opt_string("print_host");
-    if (print_host.empty()) {
+    const ActivePrinterSession&            session = active_printer_session();
+    const ActivePrinterSession::Connection conn    = session.connection();
+    if (!conn.configured()) {
         return;
     }
-    std::string port = host_cfg->opt_string("printhost_port");
-
-    // Generate dev_id from host and port
-    std::string dev_id = MachineObject::dev_id_from_address(print_host, port);
+    const std::string& dev_id = conn.dev_id;
 
     // Check if already exists by dev_id
     MachineObject* existing = m_device_manager->get_local_machine(dev_id);
@@ -4074,15 +4065,10 @@ void GUI_App::select_machine(const std::string& agent_id)
         // We use dev_id as dev_ip to store the address (host:port)
         machine.dev_ip = dev_id;
         machine.dev_name = dev_id;
-        machine.printer_type = preset.config.opt_string("printer_model");
-        auto access_code = preset.config.opt_string("printhost_apikey");
-        // Orca expect non empty access code
-        if (access_code.empty()) {
-            access_code = "88888888";
-        }
+        machine.printer_type = session.profile().config.opt_string("printer_model");
 
         existing = m_device_manager->insert_local_device(
-            machine, "lan", "free", "", access_code);
+            machine, "lan", "free", "", conn.access_code());
 
         if (!existing) {
             BOOST_LOG_TRIVIAL(error) << __FUNCTION__ << ": failed to create machine dev_id=" << dev_id;
@@ -4090,7 +4076,12 @@ void GUI_App::select_machine(const std::string& agent_id)
         }
         BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << ": created new machine dev_id=" << dev_id;
     }
-    existing->local_use_ssl = boost::istarts_with(print_host, "https://");
+    existing->local_use_ssl = conn.use_ssl;
+
+    // The agent's REST calls have to dial the same address this selection just resolved, so bind
+    // it here rather than leaving each REST entry point to work it out from the machine's own
+    // (possibly restored-from-a-previous-session) dev_ip.
+    session.bind_agent();
 
     // Use MonitorPanel::select_machine() to trigger full selection flow
     // This reuses existing logic for machine switching (UI updates, callbacks, etc.)

--- a/src/slic3r/GUI/GUI_App.hpp
+++ b/src/slic3r/GUI/GUI_App.hpp
@@ -369,8 +369,6 @@ public:
     void switch_printer_agent();
 
     std::string resolve_printer_agent_id(const std::string& stored_id);
-    // ORCA TODO: in the future, bbl presets should specify "bbl" printer agent id
-    // then, all resolve and canonical would just be ORCA<->""
     std::string canonical_printer_agent_id(const std::string& picked_id);
 
     FilamentColorCodeQuery* get_filament_color_code_query();

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -134,6 +134,9 @@
 #include "InstanceCheck.hpp"
 #include "NotificationManager.hpp"
 #include "PresetComboBoxes.hpp"
+#include "ActivePrinterSession.hpp"
+#include "FilamentInventoryEditor.hpp"
+#include "FilamentInventoryStore.hpp"
 #include "MsgDialog.hpp"
 #include "Widgets/MultiNozzleSync.hpp"           // NozzleOption, tryPopUpMultiNozzleDialog, setExtruderNozzleCount
 #include "DeviceCore/DevNozzleSystem.h"          // DevNozzle, GetExtNozzles / GetRackNozzles
@@ -735,6 +738,10 @@ struct Sidebar::priv
     ScalableButton* m_printer_connect = nullptr;
     ScalableButton* m_printer_bbl_sync = nullptr;
     ScalableButton* m_printer_setting = nullptr;
+    // Orca: opens FilamentInventoryEditor; only shown for non-SEMM multi-tool non-BBL printers
+    // (the only shape whose per-tool loaded-filament record means anything), see the Show()
+    // gate in Sidebar::update_all_preset_comboboxes.
+    ScalableButton* m_printer_inventory = nullptr;
     wxStaticText *  m_text_printer_settings = nullptr;
     wxPanel* m_panel_printer_content = nullptr;
     // Filament Track Switch status overlay: an icon floated over the left/single extruder AMS area,
@@ -2438,6 +2445,23 @@ Sidebar::Sidebar(Plater *parent)
             wxGetApp().run_wizard(ConfigWizard::RR_USER, ConfigWizard::SP_PRINTERS);
             });
 
+        p->m_printer_inventory = new ScalableButton(p->m_panel_printer_title, wxID_ANY, "menu_filament");
+        p->m_printer_inventory->SetToolTip(_L("Printer Material Settings"));
+        p->m_printer_inventory->Bind(wxEVT_BUTTON, [this](wxCommandEvent &e) {
+            // Defer past the click: the title panel this button sits on collapses on any
+            // LEFT_UP it receives, and opening a modal dialog inside the button's own
+            // release processing can leave that release to be re-delivered to the panel
+            // when the modal loop exits -- observed as the printer section folding after
+            // the dialog closed. CallAfter lets the click finish before the modal starts.
+            CallAfter([this]() {
+                FilamentInventories store;
+                size_t         tool_count     = resolve_active_printer_tool_count(store);
+                const Preset  &printer_preset = active_printer_session().profile();
+                FilamentInventoryEditor dlg(this, printer_preset.name, tool_count);
+                dlg.ShowModal();
+            });
+        });
+
         wxBoxSizer* h_sizer_title = new wxBoxSizer(wxHORIZONTAL);
         h_sizer_title->Add(p->m_printer_icon, 0, wxALIGN_CENTRE | wxLEFT, FromDIP(SidebarProps::TitlebarMargin()));
         h_sizer_title->AddSpacer(FromDIP(SidebarProps::ElementSpacing()));
@@ -2445,6 +2469,7 @@ Sidebar::Sidebar(Plater *parent)
         //h_sizer_title->AddStretchSpacer();
         h_sizer_title->Add(p->m_printer_connect , 0, wxALIGN_CENTER | wxRIGHT, FromDIP(SidebarProps::WideSpacing())); // used larger margin to prevent accidental clicks
         h_sizer_title->Add(p->m_printer_bbl_sync, 0, wxALIGN_CENTER | wxRIGHT, FromDIP(SidebarProps::WideSpacing())); // used larger margin to prevent accidental clicks
+        h_sizer_title->Add(p->m_printer_inventory, 0, wxALIGN_CENTER | wxRIGHT, FromDIP(SidebarProps::WideSpacing())); // used larger margin to prevent accidental clicks
         h_sizer_title->Add(p->m_printer_setting, 0, wxALIGN_CENTER);
         h_sizer_title->AddSpacer(FromDIP(SidebarProps::TitlebarMargin()));
         h_sizer_title->SetMinSize(-1, 3 * em);
@@ -4609,6 +4634,25 @@ bool Sidebar::should_show_SEMM_buttons()
 
 void Sidebar::show_SEMM_buttons()
 {
+    // Orca: the printer-materials button is only meaningful where each physical tool holds its
+    // own filament: multi-tool, not SEMM (one shared hotend), not BBL (its AMS has its own sync
+    // UI). Gated here because this runs on every printer-preset switch.
+    if (p && p->m_printer_inventory) {
+        PresetBundle &preset_bundle = *wxGetApp().preset_bundle;
+        const auto   &cfg           = preset_bundle.printers.get_edited_preset().config;
+        const auto   *nozzle_diams  = cfg.option<ConfigOptionFloats>("nozzle_diameter");
+        const bool    multi_tool    = nozzle_diams != nullptr && nozzle_diams->values.size() > 1;
+        // A configured connection (print_host set on this preset) is required: the editor's
+        // whole point is reading/writing the printer's loaded filaments, and without a host
+        // there is no printer to talk to -- a toolchanger profile alone doesn't warrant the
+        // button. Deliberately NOT gated on host_type: the printer-agent layer picks its own
+        // transport and several shipped profiles still carry a legacy host_type value.
+        const bool    has_connection = active_printer_session().connection().configured();
+        p->m_printer_inventory->Show(multi_tool && has_connection &&
+                                     !cfg.opt_bool("single_extruder_multi_material") &&
+                                     !preset_bundle.is_bbl_vendor());
+    }
+
     // ORCA
     if (!p || p->combos_filament.empty() || !p->m_bpButton_add_filament || !p->m_bpButton_del_filament || !p->m_flushing_volume_btn)
         return;

--- a/src/slic3r/GUI/PresetComboBoxes.cpp
+++ b/src/slic3r/GUI/PresetComboBoxes.cpp
@@ -44,6 +44,7 @@
 #include "MsgDialog.hpp"
 #include "ParamsDialog.hpp"
 #include "FilamentPickerDialog.hpp"
+#include "FilamentInventoryStore.hpp"
 #include "wxExtensions.hpp"
 
 #include "DeviceCore/DevManager.h"
@@ -1944,6 +1945,90 @@ void TabPresetComboBox::update_dirty()
 }
 
 } // namespace GUI
+GUI::PhysicalFilamentComboBox::PhysicalFilamentComboBox(wxWindow* parent)
+    : PresetComboBox(parent, Preset::TYPE_FILAMENT, wxSize(25 * wxGetApp().em_unit(), 30 * wxGetApp().em_unit() / 10))
+{
+    GetDropDown().SetUseContentWidth(true, true);
+    // The base's OnSelect ignores group markers and calls this only for real items.
+    on_selection_changed = [this](int item) {
+        auto it  = m_item_presets.find(item);
+        m_wanted = it != m_item_presets.end() ? it->second : std::string();
+        if (on_preset_picked)
+            on_preset_picked();
+    };
+}
+
+void GUI::PhysicalFilamentComboBox::update()
+{
+    Freeze();
+    Clear();
+    invalidate_selection();
+    m_item_presets.clear();
+
+    // Mirror the sidebar filament selector's presentation: short alias display names and a
+    // vendor sub-menu per group (the extended Append(text, bmp, group, ...) overload renders
+    // `group` as a cascading flyout), under the same "User presets"/"System presets" split
+    // markers. Presets that yield no vendor at all (see filament_vendor_of) land in a catch-all
+    // group.
+    std::vector<const Preset*> system_presets, user_presets;
+    for (const Preset& preset : m_collection->get_presets()) {
+        if (!preset.is_visible || preset.is_default || !preset.is_compatible)
+            continue;
+        (preset.is_system ? system_presets : user_presets).push_back(&preset);
+    }
+    auto display_name = [](const Preset* p) { return from_u8(p->alias.empty() ? p->name : p->alias); };
+    // Orca: delegates to the single shared filament_vendor_of (FilamentInventoryStore) --
+    // also used by FilamentInventoryEditor's vendor card, so the two can never disagree on the
+    // same preset.
+    auto vendor_of = [](const Preset* p) {
+        const std::string v = filament_vendor_of(*p);
+        return v.empty() ? _L("Unspecified") : from_u8(v);
+    };
+    auto append_group = [&, this](const wxString& label, std::vector<const Preset*>& presets) {
+        if (presets.empty())
+            return;
+        std::sort(presets.begin(), presets.end(), [&](const Preset* l, const Preset* r) {
+            wxString lv = vendor_of(l), rv = vendor_of(r);
+            return lv != rv ? lv < rv : display_name(l) < display_name(r);
+        });
+        set_label_marker(Append(label, wxNullBitmap, DD_ITEM_STYLE_SPLIT_ITEM));
+        for (const Preset* preset : presets) {
+            wxBitmap* bmp  = get_bmp(*preset);
+            int       item = Append(display_name(preset), bmp ? *bmp : wxNullBitmap, vendor_of(preset));
+            SetItemTooltip(item, from_u8(preset->name));
+            m_item_presets[item] = preset->name;
+            validate_selection(preset->name == m_wanted);
+        }
+    };
+    append_group(_L("User presets"), user_presets);
+    append_group(_L("System presets"), system_presets);
+
+    if (m_last_selected == INT_MAX) {
+        // Nothing to select (m_wanted empty, or its preset is gone): show an EMPTY picker.
+        // The base update_selection() force-picks a real item when nothing validated -- it was
+        // written for the sidebar, where some preset is always selected. For a physical slot,
+        // "nothing recorded" is a legitimate state and must not display as whatever entry
+        // happens to sort first (a cleared/empty tool head showed as "Generic ABS @System").
+        SetSelection(-1);
+        SetValue(wxEmptyString);
+    } else {
+        update_selection();
+    }
+    Thaw();
+}
+
+void GUI::PhysicalFilamentComboBox::select_preset(const std::string& name)
+{
+    m_wanted = name;
+    update();
+}
+
+const Preset* GUI::PhysicalFilamentComboBox::get_selected_preset() const
+{
+    auto it = m_item_presets.find(GetSelection());
+    return it != m_item_presets.end() ? m_collection->find_preset(it->second, false) : nullptr;
+}
+
 GUI::CalibrateFilamentComboBox::CalibrateFilamentComboBox(wxWindow *parent)
 : PlaterPresetComboBox(parent, Preset::TYPE_FILAMENT)
 {

--- a/src/slic3r/GUI/PresetComboBoxes.hpp
+++ b/src/slic3r/GUI/PresetComboBoxes.hpp
@@ -246,6 +246,33 @@ public:
 };
 
 // ---------------------------------
+// ***  PhysicalFilamentComboBox  ***
+// ---------------------------------
+
+// Grouped filament-preset picker for the Physical Filaments editor: same rendering as the
+// sidebar selector (user/system groups, color bitmaps, tooltips) but selection is plain row
+// state -- it never touches the project's filament_presets. Same pattern as
+// CalibrateFilamentComboBox, minus the sidebar chrome (built on the base PresetComboBox).
+class PhysicalFilamentComboBox : public PresetComboBox
+{
+public:
+    PhysicalFilamentComboBox(wxWindow* parent);
+
+    void update() override;
+    // Seed/replace the selection by canonical preset name; "" clears the selection.
+    void select_preset(const std::string& name);
+    const Preset* get_selected_preset() const;
+
+    // Invoked after the user picks a preset row (never for group markers or programmatic
+    // selection); the row owner reads get_selected_preset() from it.
+    std::function<void()> on_preset_picked;
+
+private:
+    std::map<int, std::string> m_item_presets; // item index -> canonical preset name
+    std::string                m_wanted;       // current selection by name ("" = none)
+};
+
+// ---------------------------------
 // ***  CalibrateFilamentComboBox  ***
 // ---------------------------------
 

--- a/src/slic3r/Utils/IPrinterAgent.hpp
+++ b/src/slic3r/Utils/IPrinterAgent.hpp
@@ -2,10 +2,10 @@
 #define __I_PRINTER_AGENT_HPP__
 
 #include "bambu_networking.hpp"
-// why: these extend the BAMBU_NETWORK_* return space rather than opening a new one - the value
+// These extend the BAMBU_NETWORK_* return space rather than opening a new one - the value
 // flows through the same int domain callers already compare against BAMBU_NETWORK_SUCCESS.
 // They live here and not in bambu_networking.hpp because that file is a vendor header replaced
-// wholesale by header-sync commits (see c09252ce11), which would silently clobber them.
+// wholesale by header-sync commits, which would silently clobber them.
 // -70xx is free: the vendor occupies -1..-25 and -10xx through -60xx.
 #define ORCA_NETWORK_ERR_CMD_NOT_SUPPORTED -7010 // no translation exists for this command
 #define ORCA_NETWORK_ERR_CAP_NOT_AVAILABLE -7020 // a translation exists; this printer lacks the capability
@@ -290,6 +290,43 @@ public:
      * Populates the MachineObject's DevFilaSystem with fetched filament data.
      */
     virtual bool fetch_filament_info(std::string dev_id) { return false; }
+
+    /**
+     * A physical filament assignment for one tool/slot, in printer-neutral terms. Used by
+     * push_filament_info(); agents translate to their own dialect (e.g. Snapmaker's
+     * SET_PRINT_FILAMENT_CONFIG, Bambu's ams_filament_setting).
+     */
+    struct FilamentSlotInfo
+    {
+        int         slot = 0;    ///< 0-based physical tool / lane index
+        std::string vendor;      ///< filament vendor ("" = unspecified)
+        std::string type;        ///< base material type, e.g. "PLA"
+        std::string sub_type;    ///< vendor product line, e.g. "SnapSpeed" ("" = none)
+        std::string color_rgba;  ///< RRGGBBAA
+    };
+
+    /**
+     * Whether this agent can write filament slot configuration back to the printer.
+     * Mirror of the fetch_filament_info() read seam. Slots whose read-side data came from an
+     * NFC/RFID tag (DevAmsTray::tag_uid non-zero) should not be pushed -- the tag is
+     * authoritative.
+     */
+    virtual bool supports_filament_push() const { return false; }
+
+    /**
+     * Write one slot's filament configuration to the printer. Blocking, like
+     * fetch_filament_info(). Returns true on printer-confirmed success.
+     */
+    virtual bool push_filament_info(std::string dev_id, const FilamentSlotInfo& info) { return false; }
+
+    /**
+     * Point this agent's REST state at a printer's address, without opening the status stream
+     * connect_printer() does. The caller owns the printer's connection settings and pushes them
+     * here; an agent must not go looking for them itself. Returns true once the agent is able to
+     * address dev_id. No-op (true) when it already is.
+     */
+    virtual bool bind_device_connection(const std::string& dev_id, const std::string& address,
+                                        const std::string& access_code, bool use_ssl) { return false; }
 };
 
 } // namespace Slic3r

--- a/src/slic3r/Utils/MoonrakerPrinterAgent.cpp
+++ b/src/slic3r/Utils/MoonrakerPrinterAgent.cpp
@@ -2,6 +2,7 @@
 #include "Http.hpp"
 #include "libslic3r/Preset.hpp"
 #include "libslic3r/PresetBundle.hpp"
+#include "slic3r/GUI/ActivePrinterSession.hpp"
 #include "slic3r/GUI/GUI_App.hpp"
 #include "slic3r/GUI/DeviceCore/DevFilaSystem.h"
 #include "slic3r/GUI/DeviceCore/DevManager.h"
@@ -458,7 +459,8 @@ int MoonrakerPrinterAgent::set_queue_on_main_fn(QueueOnMainFn fn)
     return BAMBU_NETWORK_SUCCESS;
 }
 
-void MoonrakerPrinterAgent::build_ams_payload(int ams_count, int max_lane_index, const std::vector<AmsTrayData>& trays)
+void MoonrakerPrinterAgent::build_ams_payload(int ams_count, int max_lane_index, const std::vector<AmsTrayData>& trays,
+                                               AmsUnitShape shape)
 {
 
     // Look up MachineObject via DeviceManager
@@ -479,17 +481,31 @@ void MoonrakerPrinterAgent::build_ams_payload(int ams_count, int max_lane_index,
     unsigned long ams_exist_bits = 0;
     unsigned long tray_exist_bits = 0;
 
+    // Orca: honest per-tool presentation. Each physical tool becomes its own 1-slot AMS unit
+    // typed TOOLCHANGER, instead of being faked as AMS_LITE units chunked in groups of 4.
+    // ams_count is the tool count here (== max_lane_index + 1, see callers). Index identity is
+    // preserved: unit `ams_id` has exactly one slot (id "0"), so tool n == unit n slot 0 ==
+    // global tray index n, same as slot_index below and in DevFilaSystem::GetTrayIndexMap.
+    char toolchanger_info[5];
+    snprintf(toolchanger_info, sizeof(toolchanger_info), "%04X", static_cast<unsigned>(DevAms::TOOLCHANGER));
+
     for (int ams_id = 0; ams_id < ams_count; ++ams_id) {
         ams_exist_bits |= (1 << ams_id);
 
         nlohmann::json ams_unit = nlohmann::json::object();
         ams_unit["id"] = std::to_string(ams_id);
-        ams_unit["info"] = "0002";  // treat as AMS_LITE 
+        ams_unit["info"] = (shape == AmsUnitShape::Toolchanger) ? std::string(toolchanger_info) : std::string("0002"); // 0002: treat as AMS_LITE
 
         nlohmann::json tray_array = nlohmann::json::array();
-        int max_slot_in_this_ams = std::min(3, max_lane_index - ams_id * 4);
-        for (int slot_id = 0; slot_id <= max_slot_in_this_ams; ++slot_id) {
-            int slot_index = ams_id * 4 + slot_id;
+
+        // Toolchanger: exactly one slot per unit (unit index == tool index).
+        // Box4: up to 4 slots per unit, chunked (legacy MMU-box presentation).
+        int first_slot = (shape == AmsUnitShape::Toolchanger) ? ams_id : ams_id * 4;
+        int last_slot = (shape == AmsUnitShape::Toolchanger) ? ams_id
+                                                              : ams_id * 4 + std::min(3, max_lane_index - ams_id * 4);
+
+        for (int slot_index = first_slot; slot_index <= last_slot; ++slot_index) {
+            int slot_id = (shape == AmsUnitShape::Toolchanger) ? 0 : (slot_index - ams_id * 4);
 
             // Find tray with matching slot_index
             const AmsTrayData* tray = nullptr;
@@ -502,7 +518,7 @@ void MoonrakerPrinterAgent::build_ams_payload(int ams_count, int max_lane_index,
 
             nlohmann::json tray_json = nlohmann::json::object();
             tray_json["id"] = std::to_string(slot_id);
-            tray_json["tag_uid"] = "0000000000000000";
+            tray_json["tag_uid"] = (tray && !tray->tag_uid.empty()) ? tray->tag_uid : "0000000000000000";
 
             if (tray && tray->has_filament) {
                 tray_exist_bits |= (1 << slot_index);
@@ -576,8 +592,62 @@ void MoonrakerPrinterAgent::build_ams_payload(int ams_count, int max_lane_index,
     }
 }
 
+bool MoonrakerPrinterAgent::bind_device_connection(const std::string& dev_id, const std::string& address,
+                                                   const std::string& access_code, bool use_ssl)
+{
+    if (dev_id.empty() || address.empty())
+        return false;
+    // No-op only when the existing binding agrees with the requested one IN FULL: matching on
+    // dev_id alone would keep a stale binding whose scheme disagrees with the profile (e.g.
+    // MachineObject::local_use_ssl defaults to true, which is wrong for a plain-HTTP Moonraker
+    // printer). The caller owns the connection; a disagreeing binding gets replaced, not kept.
+    const std::string expected_base_url = (use_ssl ? "https://" : "http://") + address;
+    if (device_info.base_url == expected_base_url && device_info.dev_id == dev_id)
+        return true;
+
+    BOOST_LOG_TRIVIAL(info) << "MoonrakerPrinterAgent::bind_device_connection: device_info for dev_id=" << dev_id
+                            << " bound to address=" << address << " ssl=" << use_ssl;
+    // username is unused by init_device_info; the access code is what authenticates the REST calls.
+    return init_device_info(dev_id, address, "bblp", access_code, use_ssl);
+}
+
+bool MoonrakerPrinterAgent::ensure_device_info(const std::string& dev_id)
+{
+    if (dev_id.empty())
+        return false;
+    if (!device_info.base_url.empty() && device_info.dev_id == dev_id)
+        return true;
+
+    // Last-resort fallback for a dev_id that was never bound through bind_device_connection() --
+    // e.g. a REST call for a background machine that isn't the one the user is working with. A
+    // MachineObject's dev_ip is a weaker source than the address the caller would have bound:
+    // load_local_machines_from_config() can restore it from a *previous* session's AppConfig entry
+    // and insert_local_device() never overwrites it for an existing dev_id, so it can name a real
+    // but wrong address (host moved / port changed) with nothing to refresh it.
+    auto* dev_manager = GUI::wxGetApp().getDeviceManager();
+    if (!dev_manager) {
+        BOOST_LOG_TRIVIAL(warning) << "MoonrakerPrinterAgent::ensure_device_info: no DeviceManager, dev_id=" << dev_id;
+        return false;
+    }
+    MachineObject* obj = dev_manager->get_my_machine(dev_id);
+    if (!obj || obj->get_dev_ip().empty()) {
+        BOOST_LOG_TRIVIAL(warning) << "MoonrakerPrinterAgent::ensure_device_info: no known IP for dev_id=" << dev_id;
+        return false;
+    }
+
+    // Same source connect_printer's caller uses (MachineObject::connect() in DeviceManager.cpp):
+    // username is unused by init_device_info, the access code is the printer's stored API key.
+    BOOST_LOG_TRIVIAL(info) << "MoonrakerPrinterAgent::ensure_device_info: rebuilding device_info for dev_id=" << dev_id
+                             << " from MachineObject::get_dev_ip()=" << obj->get_dev_ip()
+                             << " (this dev_id was never bound from a printer profile)";
+    return init_device_info(dev_id, obj->get_dev_ip(), "bblp", obj->get_access_code(), obj->local_use_ssl);
+}
+
 bool MoonrakerPrinterAgent::fetch_filament_info(std::string dev_id)
 {
+    if (!ensure_device_info(dev_id))
+        return false;
+
     std::vector<AmsTrayData> trays;
     int max_lane_index = 0;
 
@@ -587,8 +657,9 @@ bool MoonrakerPrinterAgent::fetch_filament_info(std::string dev_id)
     if (fetch_moonraker_filament_data(trays, max_lane_index)) {
         BOOST_LOG_TRIVIAL(info) << "MoonrakerPrinterAgent::fetch_filament_info: Detected Moonraker filament system with "
                                 << (max_lane_index + 1) << " lanes";
-        int ams_count = (max_lane_index + 4) / 4;
-        build_ams_payload(ams_count, max_lane_index, trays);
+        // Orca: one unit per physical tool now (see build_ams_payload), so ams_count is the tool count.
+        int ams_count = max_lane_index + 1;
+        build_ams_payload(ams_count, max_lane_index, trays, AmsUnitShape::Toolchanger);
         return true;
     }
 
@@ -596,8 +667,9 @@ bool MoonrakerPrinterAgent::fetch_filament_info(std::string dev_id)
     if (fetch_hh_filament_info(trays, max_lane_index)) {
         BOOST_LOG_TRIVIAL(info) << "MoonrakerPrinterAgent::fetch_filament_info: Detected Happy Hare MMU with "
                                 << (max_lane_index + 1) << " gates";
-        int ams_count = (max_lane_index + 4) / 4;
-        build_ams_payload(ams_count, max_lane_index, trays);
+        // Orca: one unit per physical tool now (see build_ams_payload), so ams_count is the tool count.
+        int ams_count = max_lane_index + 1;
+        build_ams_payload(ams_count, max_lane_index, trays, AmsUnitShape::Toolchanger);
         return true;
     }
 
@@ -766,7 +838,8 @@ bool MoonrakerPrinterAgent::fetch_moonraker_filament_data(std::vector<AmsTrayDat
         .perform_sync();
 
     if (!success) {
-        BOOST_LOG_TRIVIAL(warning) << "MoonrakerPrinterAgent::fetch_moonraker_filament_data: Failed to fetch lane data: " << http_error;
+        BOOST_LOG_TRIVIAL(warning) << "MoonrakerPrinterAgent::fetch_moonraker_filament_data: Failed to fetch lane data: "
+                                   << http_error << " url=" << url << " dev_ip=" << device_info.dev_ip;
         return false;
     }
 
@@ -1076,13 +1149,14 @@ bool MoonrakerPrinterAgent::init_device_info(std::string dev_id, std::string dev
         return false;
     }
 
-    auto&       preset      = preset_bundle->printers.get_edited_preset();
-    const auto& printer_cfg = preset.config;
-    device_info.dev_ip      = dev_ip;
+    // The model fields describe the same profile the caller's address came from, so they are read
+    // through the one accessor for it rather than resolving the active preset a second way here.
+    const GUI::ActivePrinterSession& session = GUI::active_printer_session();
+    device_info.dev_ip     = dev_ip;
 
     device_info.api_key    = password;
-    device_info.model_name = printer_cfg.opt_string("printer_model");
-    device_info.model_id   = preset.get_printer_type(preset_bundle);
+    device_info.model_name = session.profile().config.opt_string("printer_model");
+    device_info.model_id   = session.printer_type();
     device_info.base_url   = use_ssl ? "https://" + dev_ip : "http://" + dev_ip;
     device_info.dev_id     = dev_id;
     device_info.version    = "";

--- a/src/slic3r/Utils/MoonrakerPrinterAgent.hpp
+++ b/src/slic3r/Utils/MoonrakerPrinterAgent.hpp
@@ -72,6 +72,7 @@ public:
     // Pull-mode agent (on-demand filament sync)
     FilamentSyncMode get_filament_sync_mode() const override { return FilamentSyncMode::pull; }
     bool fetch_filament_info(std::string dev_id) override;
+    bool bind_device_connection(const std::string& dev_id, const std::string& address, const std::string& access_code, bool use_ssl) override;
 
 protected:
     struct MoonrakerDeviceInfo
@@ -97,14 +98,31 @@ protected:
         std::string tray_info_idx;       // Setting ID (optional)
         int         bed_temp = 0;        // Optional
         int         nozzle_temp = 0;     // Optional
+        std::string tag_uid;             // Non-empty when the slot's data came from an NFC/RFID
+                                         // tag (Bambu tag_uid convention); such slots are
+                                         // authoritative and excluded from filament pushes.
     };
 
+    // Shape of the AMS units build_ams_payload() emits:
+    //  - Toolchanger: one 1-slot TOOLCHANGER unit per lane (honest per-tool presentation).
+    //    ams_count is the tool/lane count.
+    //  - Box4: one AMS_LITE unit per up-to-4 lanes, chunked (legacy MMU-box presentation).
+    //    ams_count is the number of 4-slot boxes.
+    enum class AmsUnitShape { Toolchanger, Box4 };
+
     // Build ams JSON and call parser
-    void build_ams_payload(int ams_count, int max_lane_index, const std::vector<AmsTrayData>& trays);
+    void build_ams_payload(int ams_count, int max_lane_index, const std::vector<AmsTrayData>& trays,
+                            AmsUnitShape shape = AmsUnitShape::Box4);
 
     // Methods that derived classes may need to override or access
     virtual bool init_device_info(std::string dev_id, std::string dev_ip, std::string username, std::string password, bool use_ssl);
     virtual bool fetch_device_info(const std::string& base_url, const std::string& api_key, MoonrakerDeviceInfo& info, std::string& error) const;
+
+    // Fallback for a REST entry point reached with a dev_id that was never bound through
+    // bind_device_connection(): rebuilds device_info from the MachineObject's persisted state.
+    // No-op if device_info is already current. See bind_device_connection() for why the bound
+    // address is the better source, and ActivePrinterSession for who binds it.
+    bool ensure_device_info(const std::string& dev_id);
 
     // State access for derived classes
     mutable std::recursive_mutex       state_mutex;

--- a/src/slic3r/Utils/NetworkAgent.cpp
+++ b/src/slic3r/Utils/NetworkAgent.cpp
@@ -929,6 +929,25 @@ bool NetworkAgent::fetch_filament_info(std::string dev_id)
     return false;
 }
 
+bool NetworkAgent::supports_filament_push() const
+{
+    return m_printer_agent && m_printer_agent->supports_filament_push();
+}
+
+bool NetworkAgent::push_filament_info(std::string dev_id, const IPrinterAgent::FilamentSlotInfo& info)
+{
+    if (m_printer_agent)
+        return m_printer_agent->push_filament_info(dev_id, info);
+    return false;
+}
+
+bool NetworkAgent::bind_device_connection(const std::string& dev_id, const std::string& address, const std::string& access_code, bool use_ssl)
+{
+    if (m_printer_agent)
+        return m_printer_agent->bind_device_connection(dev_id, address, access_code, use_ssl);
+    return false;
+}
+
 int NetworkAgent::request_bind_ticket(std::string* ticket)
 {
     if (m_printer_agent)

--- a/src/slic3r/Utils/NetworkAgent.hpp
+++ b/src/slic3r/Utils/NetworkAgent.hpp
@@ -165,6 +165,9 @@ public:
     int start_sdcard_print(PrintParams params, OnUpdateStatusFn update_fn, WasCancelledFn cancel_fn);
     FilamentSyncMode get_filament_sync_mode() const;
     bool fetch_filament_info(std::string dev_id);
+    bool supports_filament_push() const;
+    bool push_filament_info(std::string dev_id, const IPrinterAgent::FilamentSlotInfo& info);
+    bool bind_device_connection(const std::string& dev_id, const std::string& address, const std::string& access_code, bool use_ssl);
     int request_bind_ticket(std::string* ticket);
     int get_hms_snapshot(std::string dev_id, std::string file_name, std::function<void(std::string, int)> callback);
 

--- a/src/slic3r/Utils/QidiPrinterAgent.cpp
+++ b/src/slic3r/Utils/QidiPrinterAgent.cpp
@@ -40,6 +40,9 @@ AgentInfo QidiPrinterAgent::get_agent_info_static()
 
 bool QidiPrinterAgent::fetch_filament_info(std::string dev_id)
 {
+    if (!ensure_device_info(dev_id))
+        return false;
+
     std::string error;
 
     // 1. Fetch device info and infer series_id
@@ -70,6 +73,7 @@ bool QidiPrinterAgent::fetch_filament_info(std::string dev_id)
     }
 
     // 4. Build the AMS payload
+    // Qidi boxes are 4-slot MMU units, chunked like AMS_LITE.
     build_ams_payload(box_count, box_count * 4 - 1, trays);
     return true;
 }

--- a/src/slic3r/Utils/SnapmakerPrinterAgent.cpp
+++ b/src/slic3r/Utils/SnapmakerPrinterAgent.cpp
@@ -261,4 +261,52 @@ bool SnapmakerPrinterAgent::fetch_filament_info(std::string dev_id)
     return true;
 }
 
+bool SnapmakerPrinterAgent::push_filament_info(std::string dev_id, const FilamentSlotInfo& info)
+{
+    if (!ensure_device_info(dev_id))
+        return false;
+
+    // Dialect: the same command the printer's own device UI sends (see Snapmaker's device tab).
+    // ALL parameters are mandatory -- omitting one both errors AND partially applies on current
+    // firmware -- so empty values are sent as quoted-empty. Sub-type and vendor may contain
+    // spaces; type and color are plain tokens.
+    auto quoted = [](std::string v) {
+        v.erase(std::remove(v.begin(), v.end(), '"'), v.end());
+        return "\"" + v + "\"";
+    };
+    std::string color = info.color_rgba.empty() ? "FFFFFFFF" : info.color_rgba;
+    std::string script = "SET_PRINT_FILAMENT_CONFIG CONFIG_EXTRUDER=" + std::to_string(info.slot) +
+                         " FILAMENT_TYPE=" + info.type +
+                         " FILAMENT_SUBTYPE=" + quoted(info.sub_type) +
+                         " FILAMENT_COLOR_RGBA=" + color +
+                         " VENDOR=" + quoted(info.vendor) + " SAVE=1";
+
+    std::string url = join_url(device_info.base_url, "/printer/gcode/script");
+    nlohmann::json body;
+    body["script"] = script;
+
+    bool        success = false;
+    std::string http_error;
+    auto        http = Http::post(url);
+    if (!device_info.api_key.empty())
+        http.header("X-Api-Key", device_info.api_key);
+    http.header("Content-Type", "application/json")
+        .set_post_body(body.dump())
+        .timeout_connect(5)
+        .timeout_max(10)
+        .on_complete([&](std::string, unsigned status) { success = (status == 200); })
+        .on_error([&](std::string, std::string err, unsigned status) {
+            http_error = err + " (HTTP " + std::to_string(status) + ")";
+        })
+        .perform_sync();
+
+    if (!success)
+        BOOST_LOG_TRIVIAL(warning) << "SnapmakerPrinterAgent::push_filament_info failed: " << http_error
+                                   << " url=" << url << " dev_id=" << dev_id << " dev_ip=" << device_info.dev_ip
+                                   << ", script: " << script;
+    else
+        BOOST_LOG_TRIVIAL(info) << "SnapmakerPrinterAgent::push_filament_info ok: " << script;
+    return success;
+}
+
 } // namespace Slic3r

--- a/src/slic3r/Utils/SnapmakerPrinterAgent.cpp
+++ b/src/slic3r/Utils/SnapmakerPrinterAgent.cpp
@@ -5,6 +5,12 @@
 
 #include "nlohmann/json.hpp"
 #include <boost/log/trivial.hpp>
+#include <iomanip>
+#include <sstream>
+#include <boost/algorithm/string.hpp>
+#include <limits>
+#include <cctype>
+#include <algorithm>
 
 namespace Slic3r {
 
@@ -21,43 +27,58 @@ T safe_at(const std::vector<T>& vec, int index, const T& fallback)
 
 std::string find_closest_color_preset_by_vendor_and_type(const PresetCollection& filaments,
                                                          const std::string&      vendor_name,
-                                                         const std::string&      filament_type,
+                                                         const std::string&      base_type,
+                                                         const std::string&      sub_type,
                                                          const std::string&      color_rgba)
 {
-    std::string best_match_id       = "";
-    int         best_color_distance = 0xffffffff;
+    auto upper = [](std::string v) {
+        boost::trim(v);
+        std::transform(v.begin(), v.end(), v.begin(), [](unsigned char c) { return static_cast<char>(std::toupper(c)); });
+        return v;
+    };
+    const std::string want_type = upper(base_type);
+    const std::string want_sub  = upper(sub_type);
+
+    std::string best_match_id;
+    long long   best_score = std::numeric_limits<long long>::min();
 
     for (const auto& p : filaments.get_presets()) {
-        if (p.is_visible && p.is_compatible &&
-            // Filament profile must be detached from parent to be considered for matching
-            filaments.get_preset_base(p) == &p && p.config.opt_string("filament_vendor", 0u) == vendor_name &&
-            p.config.opt_string("filament_type", 0u) == filament_type) {
-            // The printer returns RGBA in the format RRGGBBAA, but profiles store color as #RRGGBB,
-            // so we must remove # and ignore alpha channel for distance calculation
-            unsigned int target_color_value = std::stoul(color_rgba.substr(0, color_rgba.length() - 2), nullptr, 16);
+        // System vendor presets inherit from a shared base, so a detached-from-parent
+        // requirement would exclude the very profiles we want (e.g. "Snapmaker PLA SnapSpeed").
+        if (!p.is_visible || !p.is_compatible)
+            continue;
+        if (p.config.opt_string("filament_vendor", 0u) != vendor_name)
+            continue;
+        // Match on the firmware's BASE type: a "PLA SnapSpeed" spool reports type PLA, and the
+        // matching preset's filament_type is PLA too. Allow prefixed variants ("PLA-CF") so a
+        // CF/GF sub-type can still find its dashed-type preset.
+        const std::string p_type = upper(p.config.opt_string("filament_type", 0u));
+        if (p_type != want_type && p_type.rfind(want_type, 0) != 0)
+            continue;
 
-            std::string  p_color = p.config.opt_string("default_filament_colour", 0u);
-            unsigned int p_color_value;
-            if (!p_color.empty()) {
-                unsigned int hash_pos = p_color.find("#");
-                p_color_value         = std::stoul(p_color.substr(hash_pos != std::string::npos ? hash_pos + 1 : 0), nullptr, 16);
-            } else {
-                // Default to black if no color specified in profile. Assume other profiles might be a closer color match.
-                // Could be a problem if the target color is also black and there exist a specific profile for that type, vendor and color
-                // combination.
-                p_color_value = 0;
-            }
+        // The reported sub-type names the product line ("SnapSpeed", "PolyTerra", "Matte");
+        // a preset whose name carries it is a far stronger signal than any color proximity.
+        const bool sub_match = !want_sub.empty() && want_sub != "NONE" &&
+                               (upper(p.alias.empty() ? p.name : p.alias).find(want_sub) != std::string::npos);
 
-            // Calculate Euclidean color distance in RGB space
-            int dr = ((target_color_value & 0xff) - (p_color_value & 0xff));
-            int dg = (((target_color_value >> 8) & 0xff) - ((p_color_value >> 8) & 0xff));
-            int db = (((target_color_value >> 16) & 0xff) - ((p_color_value >> 16) & 0xff));
-            unsigned int distance = dr * dr + dg * dg + db * db;
+        // The printer returns RGBA as RRGGBBAA; profiles store #RRGGBB. Compare ignoring alpha;
+        // a preset without a default color scores as black (worst case: ties broken by name).
+        unsigned int target_color_value = std::stoul(color_rgba.substr(0, color_rgba.length() - 2), nullptr, 16);
+        std::string  p_color            = p.config.opt_string("default_filament_colour", 0u);
+        unsigned int p_color_value      = 0;
+        if (!p_color.empty()) {
+            size_t hash_pos = p_color.find('#');
+            p_color_value   = std::stoul(p_color.substr(hash_pos != std::string::npos ? hash_pos + 1 : 0), nullptr, 16);
+        }
+        int dr = ((target_color_value & 0xff) - (p_color_value & 0xff));
+        int dg = (((target_color_value >> 8) & 0xff) - ((p_color_value >> 8) & 0xff));
+        int db = (((target_color_value >> 16) & 0xff) - ((p_color_value >> 16) & 0xff));
+        long long distance = (long long) dr * dr + (long long) dg * dg + (long long) db * db;
 
-            if (distance < best_color_distance) {
-                best_color_distance = distance;
-                best_match_id       = p.filament_id;
-            }
+        long long score = (sub_match ? (1LL << 40) : 0) - distance;
+        if (score > best_score) {
+            best_score    = score;
+            best_match_id = p.filament_id;
         }
     }
     return best_match_id;
@@ -104,6 +125,9 @@ std::string SnapmakerPrinterAgent::combine_filament_type(const std::string& type
 
 bool SnapmakerPrinterAgent::fetch_filament_info(std::string dev_id)
 {
+    if (!ensure_device_info(dev_id))
+        return false;
+
     std::string url = join_url(device_info.base_url, "/printer/objects/query?print_task_config&filament_detect");
 
     std::string response_body;
@@ -133,7 +157,7 @@ bool SnapmakerPrinterAgent::fetch_filament_info(std::string dev_id)
         .perform_sync();
 
     if (!success) {
-        BOOST_LOG_TRIVIAL(warning) << "SnapmakerPrinterAgent::fetch_filament_info: HTTP request failed: " << http_error;
+        BOOST_LOG_TRIVIAL(warning) << "SnapmakerPrinterAgent::fetch_filament_info: HTTP request failed: " << http_error << " url=" << url << " dev_id=" << dev_id << " dev_ip=" << device_info.dev_ip;
         return false;
     }
 
@@ -193,7 +217,9 @@ bool SnapmakerPrinterAgent::fetch_filament_info(std::string dev_id)
             // If not found, default to traditional search by type only or generic type mapping.
             if (bundle) {
                 std::string vendor      = safe_at(filament_vendor, i, empty_str);
-                std::string filament_id = find_closest_color_preset_by_vendor_and_type(bundle->filaments, vendor, tray.tray_type,
+                std::string filament_id = find_closest_color_preset_by_vendor_and_type(bundle->filaments, vendor,
+                                                                                       safe_at(filament_type, i, empty_str),
+                                                                                       safe_at(filament_sub_type, i, empty_str),
                                                                                        tray.tray_color);
 
                 if (!filament_id.empty()) {
@@ -207,13 +233,22 @@ bool SnapmakerPrinterAgent::fetch_filament_info(std::string dev_id)
                 tray.tray_info_idx = map_filament_type_to_generic_id(tray.tray_type);
             }
 
-            // Extract NFC temperature data if available
+            // Extract NFC data if available. A slot whose data comes from an NFC tag is
+            // authoritative: stamp its CARD_UID into tag_uid (Bambu RFID convention) so
+            // consumers can tell tag-backed slots from manually configured ones and honor
+            // the tag on any write path.
             if (nfc_info.is_array() && i < static_cast<int>(nfc_info.size()) && nfc_info[i].is_object()) {
                 auto& nfc_slot = nfc_info[i];
                 std::string vendor = nfc_slot.value("VENDOR", "NONE");
                 if (vendor != "NONE" && !vendor.empty()) {
                     tray.bed_temp    = nfc_slot.value("BED_TEMP", 0);
                     tray.nozzle_temp = nfc_slot.value("FIRST_LAYER_TEMP", 0);
+                    uint64_t card_uid = nfc_slot.value("CARD_UID", (uint64_t) 0);
+                    if (card_uid != 0) {
+                        std::ostringstream uid;
+                        uid << std::hex << std::uppercase << std::setw(16) << std::setfill('0') << card_uid;
+                        tray.tag_uid = uid.str();
+                    }
                 }
             }
         }
@@ -221,7 +256,8 @@ bool SnapmakerPrinterAgent::fetch_filament_info(std::string dev_id)
         trays.emplace_back(std::move(tray));
     }
 
-    build_ams_payload(1, slot_count - 1, trays);
+    // U1 is a physical toolchanger: one 1-slot unit per tool, not a chunked 4-slot MMU box.
+    build_ams_payload(slot_count, slot_count - 1, trays, AmsUnitShape::Toolchanger);
     return true;
 }
 

--- a/src/slic3r/Utils/SnapmakerPrinterAgent.hpp
+++ b/src/slic3r/Utils/SnapmakerPrinterAgent.hpp
@@ -17,6 +17,7 @@ public:
 
     bool fetch_filament_info(std::string dev_id) override;
 
+
 private:
     // Combine filament_type + filament_sub_type into a unified type string
     static std::string combine_filament_type(const std::string& type, const std::string& sub_type);

--- a/src/slic3r/Utils/SnapmakerPrinterAgent.hpp
+++ b/src/slic3r/Utils/SnapmakerPrinterAgent.hpp
@@ -17,6 +17,10 @@ public:
 
     bool fetch_filament_info(std::string dev_id) override;
 
+    // Write path: the printer accepts SET_PRINT_FILAMENT_CONFIG via the local Moonraker
+    // gcode-script endpoint (same command its own device UI sends over MQTT).
+    bool supports_filament_push() const override { return true; }
+    bool push_filament_info(std::string dev_id, const FilamentSlotInfo& info) override;
 
 private:
     // Combine filament_type + filament_sub_type into a unified type string

--- a/tests/libslic3r/CMakeLists.txt
+++ b/tests/libslic3r/CMakeLists.txt
@@ -37,6 +37,7 @@ add_executable(${_TEST_NAME}_tests
     test_ordering_strategies.cpp
     # test_png_io.cpp
     test_indexed_triangle_set.cpp
+    test_filament_inventory.cpp
     ../libnest2d/printer_parts.cpp
     )
 

--- a/tests/libslic3r/test_appconfig.cpp
+++ b/tests/libslic3r/test_appconfig.cpp
@@ -43,3 +43,35 @@ TEST_CASE("AppConfig network version helpers", "[AppConfig]") {
         REQUIRE(config.is_network_version_skipped("02.01.01.52"));
     }
 }
+
+// The GUI-layer FilamentInventoryStore (src/slic3r/GUI/FilamentInventoryStore.hpp) is a thin
+// wrapper over get/set_printer_setting(printer, "loaded_filaments", ...); this exercises the
+// AppConfig side of that contract directly, since AppConfig has no GUI dependency and is
+// constructible in this suite.
+TEST_CASE("Per-printer loaded_filaments setting round-trips through AppConfig", "[AppConfig]") {
+    AppConfig config;
+
+    SECTION("absent for a printer that was never set") {
+        REQUIRE_FALSE(config.has_printer_setting("Test Printer", "loaded_filaments"));
+        REQUIRE(config.get_printer_setting("Test Printer", "loaded_filaments").empty());
+    }
+
+    SECTION("set/get round-trip") {
+        config.set_printer_setting("Test Printer", "loaded_filaments", "#FF0000;PLA|#00FF00;PETG");
+        REQUIRE(config.has_printer_setting("Test Printer", "loaded_filaments"));
+        REQUIRE(config.get_printer_setting("Test Printer", "loaded_filaments") == "#FF0000;PLA|#00FF00;PETG");
+    }
+
+    SECTION("distinct printers keep independent values") {
+        config.set_printer_setting("Printer A", "loaded_filaments", "value-a");
+        config.set_printer_setting("Printer B", "loaded_filaments", "value-b");
+        REQUIRE(config.get_printer_setting("Printer A", "loaded_filaments") == "value-a");
+        REQUIRE(config.get_printer_setting("Printer B", "loaded_filaments") == "value-b");
+    }
+
+    SECTION("clearing the printer's settings drops the key") {
+        config.set_printer_setting("Test Printer", "loaded_filaments", "value");
+        config.clear_printer_settings("Test Printer");
+        REQUIRE_FALSE(config.has_printer_setting("Test Printer", "loaded_filaments"));
+    }
+}

--- a/tests/libslic3r/test_filament_inventory.cpp
+++ b/tests/libslic3r/test_filament_inventory.cpp
@@ -1,0 +1,1146 @@
+#include <catch2/catch_test_macros.hpp>
+#include "libslic3r/FilamentInventory.hpp"
+#include <nlohmann/json.hpp>
+using namespace Slic3r;
+using json = nlohmann::json;
+
+TEST_CASE("Inventory v2 round-trips ids, kinds, and next_id", "[FilamentInventory]") {
+    FilamentInventory inv;
+    inv.tools.resize(2);
+    inv.tools[0] = { {1, "#FF0000", "PLA"}, {5, "#FFFF00", "PLA"} }; // loaded red + swappable yellow
+    inv.tools[1] = { {2, "#FFFFFF", "PETG"} };                       // loaded white
+    inv.next_id = 6;
+
+    FilamentInventory back = FilamentInventory::deserialize(inv.serialize(), 2);
+    REQUIRE(back.next_id == 6);
+    REQUIRE(back.tools.size() == 2);
+    REQUIRE(back.tools[0].size() == 2);
+    REQUIRE(back.tools[0][0].id == 1);
+    REQUIRE(back.tools[0][0].color == "#FF0000");
+    REQUIRE(back.tools[0][0].kind == PhysicalFilament::Kind::Manual);
+    REQUIRE(back.tools[0][1].id == 5);
+    REQUIRE(back.tools[0][1].color == "#FFFF00");
+    REQUIRE(back.tools[1].size() == 1);
+    REQUIRE(back.tools[1][0].id == 2);
+    REQUIRE(back.tools[1][0].type == "PETG");
+}
+
+TEST_CASE("Deserialize dedupes colliding v2 ids and floors next_id above the max", "[FilamentInventory]") {
+    // Two slots claim the same id 1 -- the later one must be renumbered, not silently shadowed
+    // (find()/tool_of() key on id, so a collision would make one entry unreachable).
+    std::string v2 = R"({"next_id":2,"tools":[[{"id":1,"color":"#FF0000","type":"PLA"}],[{"id":1,"color":"#FFFFFF","type":"PETG"}]]})";
+    FilamentInventory inv = FilamentInventory::deserialize(v2, 2);
+    REQUIRE(inv.tools[0][0].id == 1);
+    REQUIRE(inv.tools[1][0].id != 1);
+    REQUIRE(inv.tools[1][0].id > 0);
+    REQUIRE(inv.tools[0][0].color == "#FF0000");   // data preserved, not dropped
+    REQUIRE(inv.tools[1][0].color == "#FFFFFF");
+    REQUIRE(inv.next_id > inv.tools[1][0].id);
+    REQUIRE(inv.next_id > 1);
+}
+
+TEST_CASE("Deserialize clamps a stale next_id above every id already in use", "[FilamentInventory]") {
+    std::string v2 = R"({"next_id":1,"tools":[[{"id":7,"color":"#FF0000","type":"PLA"}]]})";
+    FilamentInventory inv = FilamentInventory::deserialize(v2, 1);
+    REQUIRE(inv.tools[0][0].id == 7);
+    REQUIRE(inv.next_id > 7);
+}
+
+TEST_CASE("Deserialize assigns a fresh id to a non-empty v2 slot missing its id", "[FilamentInventory]") {
+    std::string v2 = R"({"next_id":1,"tools":[[{"color":"#FF0000","type":"PLA"}]]})";
+    FilamentInventory inv = FilamentInventory::deserialize(v2, 1);
+    REQUIRE(inv.tools[0][0].id > 0);
+    REQUIRE(inv.next_id > inv.tools[0][0].id);
+}
+
+TEST_CASE("Deserialize tolerates a v2 object missing the tools key", "[FilamentInventory]") {
+    FilamentInventory inv = FilamentInventory::deserialize(R"({"next_id":5})", 3);
+    REQUIRE(inv.tools.size() == 3);
+    for (const auto& t : inv.tools) {
+        REQUIRE(t.size() == 1);
+        REQUIRE(t[0].empty());
+    }
+    REQUIRE(inv.next_id == 1);
+}
+
+TEST_CASE("Inventory tolerates junk and sizes to tool_count", "[FilamentInventory]") {
+    FilamentInventory junk = FilamentInventory::deserialize("not json{", 3);
+    REQUIRE(junk.tools.size() == 3);
+    for (const auto& t : junk.tools) {
+        REQUIRE(t.size() == 1);
+        REQUIRE(t[0].empty());
+    }
+    REQUIRE(junk.next_id == 1);
+}
+
+// Orca (exactly one mapping suggestor): match_filaments_to_
+// inventory (the GUI dialog's own matcher) is retired -- compute_physical_map_proposal now
+// delegates matching to auto_map_filaments, same as the slice-time auto-mapper. The color/type/
+// loaded-preference/merge coverage the retired matcher had is exercised via compute_physical_map_
+// proposal's own tests below (same behavior, single underlying implementation now) and via the
+// [AutoMap]-tagged auto_map_filaments tests further down (nearest-RGB, family-compatible,
+// loaded-vs-swappable, vendor tiebreak, merge). The one signal the retired matcher had that
+// auto_map_filaments didn't is exact-preset trust -- ported below, see "Auto-map trusts an exact
+// preset match over color/type" and "...even when the slot's type looks incompatible".
+
+TEST_CASE("find and tool_of look up physical filaments by id", "[FilamentInventory]") {
+    FilamentInventory inv;
+    inv.tools = {{{1, "#FF0000", "PLA"}, {5, "#FFFF00", "PLA"}}, {{2, "#FFFFFF", "PETG"}}};
+    const PhysicalFilament* pf = inv.find(5);
+    REQUIRE(pf != nullptr);
+    REQUIRE(pf->color == "#FFFF00");
+    REQUIRE(inv.tool_of(5) == 0);
+    REQUIRE(inv.tool_of(2) == 1);
+    REQUIRE(inv.find(99) == nullptr);
+    REQUIRE(inv.tool_of(99) == -1);
+    REQUIRE(inv.find(0) == nullptr);
+}
+
+TEST_CASE("Proposal keeps a confirmed stored id that still resolves to a non-empty physical filament", "[FilamentInventory]") {
+    FilamentInventory inv;
+    inv.tools = {{{1, "#FF0000", "PLA"}}, {{2, "#00FF00", "PLA"}}};
+    std::vector<std::string> colors = {"#0000FF"}; // would not auto-match either slot
+    std::vector<std::string> types  = {"PLA"};
+    std::vector<int> plate = {1};
+    std::vector<int> stored(1, 0);
+    stored[0] = 2; // filament id 1 (0-based index 0) stored as physical id 2
+    std::vector<int> res = compute_physical_map_proposal(colors, types, {}, {}, plate, stored, {}, inv, /*stored_map_confirmed=*/true);
+    REQUIRE(res == std::vector<int>{2});
+}
+
+TEST_CASE("Proposal re-matches when the stored id points at a slot the editor cleared", "[FilamentInventory]") {
+    // A cleared slot keeps its live id but drops its content, so
+    // find(id) succeeds while empty() is true -- that must still fall through to auto-match,
+    // not be trusted as a valid stored target.
+    FilamentInventory inv;
+    inv.tools = {{{1, "#FF0000", "PLA"}}, {{2, "", ""}}}; // tool 1's slot 0 was cleared
+    std::vector<std::string> colors = {"#FE0101"}; // near-red, should auto-match id 1
+    std::vector<std::string> types  = {"PLA"};
+    std::vector<int> plate = {1};
+    std::vector<int> stored(1, 2); // stale reference to the now-cleared slot
+    std::vector<int> res = compute_physical_map_proposal(colors, types, {}, {}, plate, stored, {}, inv, /*stored_map_confirmed=*/true);
+    REQUIRE(res == std::vector<int>{1}); // re-matched, not the stale cleared id
+}
+
+TEST_CASE("Proposal re-matches when the stored id no longer exists in the inventory", "[FilamentInventory]") {
+    FilamentInventory inv;
+    inv.tools = {{{1, "#FF0000", "PLA"}}};
+    std::vector<std::string> colors = {"#FE0101"};
+    std::vector<std::string> types  = {"PLA"};
+    std::vector<int> plate = {1};
+    std::vector<int> stored(1, 99); // id no longer present (e.g. removed via the editor)
+    std::vector<int> res = compute_physical_map_proposal(colors, types, {}, {}, plate, stored, {}, inv, /*stored_map_confirmed=*/true);
+    REQUIRE(res == std::vector<int>{1});
+}
+
+TEST_CASE("Proposal ignores the stored map entirely on an unconfirmed (fresh) plate", "[FilamentInventory]") {
+    FilamentInventory inv;
+    inv.tools = {{{1, "#FF0000", "PLA"}}, {{2, "#00FF00", "PLA"}}};
+    std::vector<std::string> colors = {"#FF0000"}; // matches id 1 exactly
+    std::vector<std::string> types  = {"PLA"};
+    std::vector<int> plate = {1};
+    std::vector<int> stored(1, 2); // present and valid, but the plate was never actually confirmed
+    std::vector<int> res = compute_physical_map_proposal(colors, types, {}, {}, plate, stored, {}, inv, /*stored_map_confirmed=*/false);
+    REQUIRE(res == std::vector<int>{1}); // auto-match wins, stored id 2 is not trusted
+}
+
+TEST_CASE("Proposal falls back to no-match when auto-match also fails", "[FilamentInventory]") {
+    // Every slot is genuinely empty here (not the inventory_all_unset/bootstrap case below --
+    // matcher still runs and legitimately finds nothing compatible).
+    FilamentInventory inv;
+    inv.tools = {{{1, "", ""}}, {{2, "", ""}}}; // ids present, but nothing recorded
+    std::vector<std::string> colors = {"#FF0000"};
+    std::vector<std::string> types  = {"PLA"};
+    std::vector<int> plate = {1};
+    std::vector<int> res = compute_physical_map_proposal(colors, types, {}, {}, plate, {0}, {}, inv, false);
+    REQUIRE(res == std::vector<int>{0});
+}
+
+TEST_CASE("inventory_all_unset is true only when every slot on every tool is empty", "[FilamentInventory]") {
+    FilamentInventory empty_inv; empty_inv.tools.resize(2);
+    REQUIRE(inventory_all_unset(empty_inv));
+
+    FilamentInventory loaded_inv; loaded_inv.tools = {{{1, "#FF0000", "PLA"}}, {}};
+    REQUIRE_FALSE(inventory_all_unset(loaded_inv));
+
+    // The hazard this exists to catch: tool 0's loaded slot (index 0) is empty, but a swappable
+    // slot on the same tool (index 1) still carries real data -- a tool-level/loaded-only check
+    // would misreport this as "all unset".
+    FilamentInventory swap_only_inv;
+    swap_only_inv.tools = {{{0, "", ""}, {5, "#00FF00", "PETG"}}};
+    REQUIRE_FALSE(inventory_all_unset(swap_only_inv));
+}
+
+TEST_CASE("Proposal reproposes the stored tool (not a physical id) on a bootstrap reopen", "[FilamentInventory]") {
+    // Regression: a plate confirmed via bootstrap mode (inventory was entirely empty when first
+    // mapped) with the "record as loaded" offer left unchecked keeps an all-0 physical map
+    // forever -- there was never anything to record it against. Reopening such a plate must
+    // still honor its confirmed tool-level filament_map, not silently reset every row.
+    FilamentInventory inv; inv.tools.resize(2); // still entirely empty -- bootstrap
+    std::vector<std::string> colors = {"#FF0000", "#00FF00"};
+    std::vector<std::string> types  = {"PLA", "PLA"};
+    std::vector<int> plate = {1, 2}; // two plate filaments, 1-based ids
+    std::vector<int> stored_physical(2, 0); // never recorded -- see the scenario above
+    std::vector<int> stored_filament = {2, 1}; // filament 1 -> tool 2, filament 2 -> tool 1
+    std::vector<int> res = compute_physical_map_proposal(colors, types, {}, {}, plate, stored_physical, stored_filament, inv, /*stored_map_confirmed=*/true);
+    REQUIRE(res == std::vector<int>{-2, -1}); // sentinel-encoded tool picks, not physical ids
+}
+
+TEST_CASE("Bootstrap reopen ignores the stored tool when the plate was never confirmed", "[FilamentInventory]") {
+    FilamentInventory inv; inv.tools.resize(2);
+    std::vector<std::string> colors = {"#FF0000"};
+    std::vector<std::string> types  = {"PLA"};
+    std::vector<int> plate = {1};
+    std::vector<int> stored_filament = {2};
+    std::vector<int> res = compute_physical_map_proposal(colors, types, {}, {}, plate, {0}, stored_filament, inv, /*stored_map_confirmed=*/false);
+    REQUIRE(res == std::vector<int>{0});
+}
+
+TEST_CASE("ensure_ids mints ids for non-empty slots only and floors next_id", "[FilamentInventory]") {
+    FilamentInventory inv;
+    // Tool 1: loaded slot filled but never given an id (fresh-inventory editor save);
+    // tool 2: loaded slot already owns id 7; tool 2 also has an id-less swappable and an
+    // untouched (empty) trailing slot.
+    inv.tools = {{{0, "#FF0000", "PLA"}},
+                 {{7, "#00FF00", "PETG"}, {0, "#0000FF", "PLA"}, {0, "", ""}}};
+    inv.next_id = 3; // stale: below the highest id in use (7)
+
+    inv.ensure_ids();
+
+    // Existing id kept; the two id-less non-empty slots got fresh ids above every id in use.
+    CHECK(inv.tools[1][0].id == 7);
+    CHECK(inv.tools[0][0].id == 8);
+    CHECK(inv.tools[1][1].id == 9);
+    // The empty slot carries no data to reference, so it stays unminted.
+    CHECK(inv.tools[1][2].id == 0);
+    REQUIRE(inv.next_id == 10);
+}
+
+TEST_CASE("ensure_ids zeroes a cleared slot's stale id", "[FilamentInventory]") {
+    // Regression: FilamentInventoryEditor::on_ok never resets Row::id (sync-clear and the manual
+    // Clear button only blank color/type/preset), so a slot that used to hold a real filament and
+    // was then cleared kept its old id. find()/tool_of() key on id without checking empty(), so
+    // that stale id let a plate's old filament_physical_map entry (or a durable SlotAssignment)
+    // keep resolving to the cleared slot -- e.g. the mapping dialog's picker re-offering a tool
+    // as if it still held the filament that used to be there. ensure_ids is the single choke
+    // point every GUI write path already calls before saving, so it canonicalizes id 0 there.
+    FilamentInventory inv;
+    inv.tools = {{{7, "", ""}}}; // tool 1's loaded slot was cleared but kept id 7
+    inv.next_id = 8;
+
+    inv.ensure_ids();
+
+    CHECK(inv.tools[0][0].id == 0);
+    CHECK(inv.find(7) == nullptr);
+    CHECK(inv.tool_of(7) == -1);
+}
+
+TEST_CASE("Ids survive a save/load round-trip when ensure_ids ran before saving", "[FilamentInventory]") {
+    // Regression: the Physical Filaments editor's first-ever save wrote loaded rows with id 0
+    // (only rows *added* that session were minted). deserialize's reconcile pass then renumbered
+    // them on the next launch, so ids churned across restarts and every plate
+    // filament_physical_map entry pointing at them went stale. With ensure_ids applied before
+    // serialize, a reload must hand back exactly the ids that were saved.
+    FilamentInventory inv;
+    inv.tools = {{{0, "#E01B24", "PLA"}},
+                 {{0, "#FFFFFF", "PLA"}},
+                 {{0, "#33D17A", "PLA"}, {1, "#9141AC", ""}}}; // the added row was minted (id 1)
+    inv.next_id = 2;
+
+    inv.ensure_ids();
+    FilamentInventory reloaded = FilamentInventory::deserialize(inv.serialize(), inv.tools.size());
+
+    for (size_t t = 0; t < inv.tools.size(); ++t)
+        for (size_t s = 0; s < inv.tools[t].size(); ++s)
+            CHECK(reloaded.tools[t][s].id == inv.tools[t][s].id);
+    REQUIRE(reloaded.next_id == inv.next_id);
+}
+
+TEST_CASE("Slot preset field round-trips and is optional on read", "[FilamentInventory]") {
+    FilamentInventory inv;
+    inv.tools = {{{1, "#FF0000", "PLA"}}};
+    inv.tools[0][0].preset = "Snapmaker PLA SnapSpeed @U1";
+    inv.next_id = 2;
+    FilamentInventory back = FilamentInventory::deserialize(inv.serialize(), 1);
+    REQUIRE(back.tools[0][0].preset == "Snapmaker PLA SnapSpeed @U1");
+
+    // v2 string (no preset field) reads back with an empty preset.
+    std::string v2 = R"({"next_id":2,"tools":[[{"id":1,"color":"#FF0000","type":"PLA","kind":"manual"}]]})";
+    FilamentInventory old = FilamentInventory::deserialize(v2, 1);
+    REQUIRE(old.tools[0][0].preset.empty());
+    REQUIRE(old.tools[0][0].id == 1);
+}
+
+TEST_CASE("A slot with only a preset recorded is not empty", "[FilamentInventory]") {
+    PhysicalFilament pf;
+    pf.preset = "Generic PLA";
+    REQUIRE_FALSE(pf.empty());
+}
+
+TEST_CASE("FilamentInventories round-trips inventories keyed by printer preset", "[FilamentInventory]") {
+    FilamentInventories store;
+    FilamentInventory& inv = store.for_preset("Snapmaker U1 (0.4 nozzle)", 4);
+    inv.tools[0][0] = {1, "#FF0000", "PLA"};
+    inv.tools[0][0].preset = "Snapmaker PLA SnapSpeed @U1";
+    inv.next_id = 2;
+
+    FilamentInventories back = FilamentInventories::deserialize(store.serialize());
+    REQUIRE(back.by_preset.count("Snapmaker U1 (0.4 nozzle)") == 1);
+    const FilamentInventory& back_inv = back.by_preset.at("Snapmaker U1 (0.4 nozzle)");
+    CHECK(back_inv.tools[0][0].preset == "Snapmaker PLA SnapSpeed @U1");
+    CHECK(back_inv.tools[0][0].color == "#FF0000");
+    CHECK_FALSE(back.parse_error);
+}
+
+TEST_CASE("FilamentInventories::serialize writes the versioned envelope", "[FilamentInventory]") {
+    FilamentInventories store;
+    store.for_preset("My Printer", 1).tools[0][0] = {1, "#FF0000", "PLA"};
+    json j = json::parse(store.serialize());
+    REQUIRE(j["version"] == 1);
+    REQUIRE(j["presets"].is_object());
+    REQUIRE(j["presets"].contains("My Printer"));
+}
+
+TEST_CASE("FilamentInventories::deserialize loads a legacy bare-object store", "[FilamentInventory]") {
+    // Pre-envelope shape: no "version"/"presets" wrapper, top level keyed directly by preset name.
+    std::string legacy = R"({"My Printer":{"next_id":2,"tools":[[{"id":1,"color":"#FF0000","type":"PLA"}]]}})";
+    FilamentInventories store = FilamentInventories::deserialize(legacy);
+    CHECK_FALSE(store.parse_error);
+    REQUIRE(store.by_preset.count("My Printer") == 1);
+    CHECK(store.by_preset.at("My Printer").tools[0][0].color == "#FF0000");
+}
+
+TEST_CASE("FilamentInventories::deserialize loads a legacy store with presets literally named version/presets", "[FilamentInventory]") {
+    // Both named entries are themselves inventory OBJECTS (as any real preset's value always is),
+    // so j["version"] is never an integer here and the whole store correctly reads as legacy.
+    std::string legacy = R"({
+        "version": {"next_id":2,"tools":[[{"id":1,"color":"#FF0000","type":"PLA"}]]},
+        "presets": {"next_id":3,"tools":[[{"id":2,"color":"#00FF00","type":"PETG"}]]}
+    })";
+    FilamentInventories store = FilamentInventories::deserialize(legacy);
+    CHECK_FALSE(store.parse_error);
+    REQUIRE(store.by_preset.count("version") == 1);
+    REQUIRE(store.by_preset.count("presets") == 1);
+    CHECK(store.by_preset.at("version").tools[0][0].color == "#FF0000");
+    CHECK(store.by_preset.at("presets").tools[0][0].color == "#00FF00");
+}
+
+TEST_CASE("FilamentInventories::deserialize reports a parse failure without fabricating data", "[FilamentInventory]") {
+    FilamentInventories junk = FilamentInventories::deserialize("not json{");
+    CHECK(junk.parse_error);
+    CHECK(junk.by_preset.empty());
+
+    FilamentInventories not_object = FilamentInventories::deserialize("[1,2,3]");
+    CHECK(not_object.parse_error);
+    CHECK(not_object.by_preset.empty());
+}
+
+TEST_CASE("for_preset creates an empty, padded inventory on first use", "[FilamentInventory]") {
+    FilamentInventories store;
+    FilamentInventory& inv = store.for_preset("Brand New Printer", 3);
+    REQUIRE(inv.tools.size() == 3);
+    for (const auto& tool : inv.tools)
+        for (const auto& pf : tool)
+            CHECK(pf.empty());
+    CHECK(store.by_preset.size() == 1);
+}
+
+TEST_CASE("for_preset is idempotent and pads without truncating on later calls", "[FilamentInventory]") {
+    FilamentInventories store;
+    store.for_preset("My Printer", 2).tools[0][0] = {1, "#0000FF", "ABS"};
+    REQUIRE(store.by_preset.size() == 1);
+
+    // A later call (e.g. a fresh dialog open) returns the SAME entry, padded up if tool_count grew.
+    FilamentInventory& inv = store.for_preset("My Printer", 4);
+    CHECK(inv.tools[0][0].color == "#0000FF");
+    REQUIRE(inv.tools.size() == 4);
+    CHECK(store.by_preset.size() == 1); // still one entry, not duplicated
+}
+
+TEST_CASE("ensure_tool_count pads and never truncates", "[FilamentInventory]") {
+    FilamentInventory inv;
+    inv.tools = {{{1, "#FF0000", "PLA"}}};
+    inv.ensure_tool_count(4);
+    REQUIRE(inv.tools.size() == 4);
+    CHECK(inv.tools[0][0].color == "#FF0000");
+    REQUIRE(inv.tools[3].size() == 1); // slot 0 present
+    inv.ensure_tool_count(2);
+    REQUIRE(inv.tools.size() == 4); // never truncates
+}
+
+TEST_CASE("apply_synced_loaded_slot overwrites only the target tool's loaded slot", "[FilamentInventory]") {
+    FilamentInventory inv;
+    inv.tools = {{{1, "#FF0000", "PLA"}, {2, "#00FF00", "PETG"}}, // tool 1: loaded + one swap row
+                 {{3, "#0000FF", "PLA"}}};                        // tool 2: loaded only
+    inv.next_id = 4;
+
+    // A fresh sync report replaces tool 1's loaded slot; its swap row and tool 2 are untouched.
+    // apply_synced_loaded_slot is a verbatim overwrite -- callers (slot_from_row) decide what id
+    // to carry over; here the caller explicitly keeps the slot's existing id (1).
+    PhysicalFilament synced;
+    synced.id    = 1;
+    synced.color = "#FFFF00";
+    synced.type  = "PETG";
+    inv.apply_synced_loaded_slot(0, synced);
+    CHECK(inv.tools[0][0].color == "#FFFF00");
+    CHECK(inv.tools[0][0].type == "PETG");
+    CHECK(inv.tools[0][0].id == 1);
+    CHECK(inv.tools[0][1].color == "#00FF00"); // swap row untouched
+    CHECK(inv.tools[1][0].color == "#0000FF"); // other tool untouched
+
+    // The printer reporting a tool's tray as empty is represented by a default-constructed slot
+    // (id 0) -- it's the caller's job (via ensure_ids, exercised in the next test) to reconcile
+    // that against whatever id the slot used to carry.
+    inv.apply_synced_loaded_slot(1, PhysicalFilament{});
+    CHECK(inv.tools[1][0].empty());
+    CHECK(inv.tools[1][0].id == 0);
+}
+
+TEST_CASE("apply_synced_loaded_slot grows tools for an out-of-range tool index", "[FilamentInventory]") {
+    FilamentInventory inv;
+    PhysicalFilament synced;
+    synced.color = "#123456";
+    inv.apply_synced_loaded_slot(2, synced);
+    REQUIRE(inv.tools.size() == 3);
+    CHECK(inv.tools[2][0].color == "#123456");
+    CHECK(inv.tools[0][0].empty());
+    CHECK(inv.tools[1][0].empty());
+}
+
+TEST_CASE("A synced-then-cleared tool round-trips as canonically empty after ensure_ids", "[FilamentInventory]") {
+    // End-to-end of the write-through seam: sync applies a real filament (id-less, as a freshly
+    // reported tray would be), ensure_ids mints it; a later sync reports the same tool as empty,
+    // ensure_ids must zero that id right back out.
+    FilamentInventory inv;
+    inv.tools = {{{0, "", ""}}};
+
+    PhysicalFilament loaded;
+    loaded.color = "#AABBCC";
+    loaded.type  = "PLA";
+    inv.apply_synced_loaded_slot(0, loaded);
+    inv.ensure_ids();
+    int minted_id = inv.tools[0][0].id;
+    REQUIRE(minted_id > 0);
+
+    inv.apply_synced_loaded_slot(0, PhysicalFilament{}); // printer now reports the tray empty
+    inv.ensure_ids();
+    CHECK(inv.tools[0][0].empty());
+    CHECK(inv.tools[0][0].id == 0);
+    CHECK(inv.find(minted_id) == nullptr);
+}
+
+TEST_CASE("Proposal reproposes a confirmed pick of an empty tool as a tool sentinel", "[FilamentInventory]") {
+    // Mixed mode: the inventory has real records on some tools,
+    // but the user confirmed routing a filament to a tool with NOTHING recorded (physical id 0,
+    // tool set in filament_map). Reopening must keep that pick (sentinel-encoded -(tool)),
+    // not silently auto-match it away.
+    FilamentInventory inv;
+    inv.tools = {{{1, "#FF0000", "PLA"}}, {{0, "", ""}}}; // tool 1 recorded; tool 2 empty
+    std::vector<std::string> colors = {"#FF0000", "#0000FF"};
+    std::vector<std::string> types  = {"PLA", "PLA"};
+    std::vector<int> plate = {1, 2};
+    std::vector<int> stored_physical = {1, 0};  // filament 2 confirmed onto the EMPTY tool 2
+    std::vector<int> stored_filament = {1, 2};
+    std::vector<int> res = compute_physical_map_proposal(colors, types, {}, {}, plate,
+                                                          stored_physical, stored_filament, inv,
+                                                          /*stored_map_confirmed=*/true);
+    REQUIRE(res.size() == 2);
+    CHECK(res[0] == 1);   // stored real id kept
+    CHECK(res[1] == -2);  // empty-tool pick preserved as sentinel
+}
+
+TEST_CASE("Proposal does not sentinel a stored empty-tool pick once that tool gains a record", "[FilamentInventory]") {
+    FilamentInventory inv;
+    inv.tools = {{{1, "#FF0000", "PLA"}}, {{2, "#0000FF", "PLA"}}}; // tool 2 now has a recorded filament
+    std::vector<int> res = compute_physical_map_proposal({"#FF0000", "#0000FF"}, {"PLA", "PLA"}, {}, {},
+                                                          {1, 2}, {1, 0}, {1, 2}, inv,
+                                                          /*stored_map_confirmed=*/true);
+    REQUIRE(res.size() == 2);
+    CHECK(res[1] == 2); // auto-match takes over: the recorded filament is the better proposal
+}
+
+TEST_CASE("derive_filament_subtype strips vendor and type tokens from a display name", "[FilamentInventory]") {
+    CHECK(derive_filament_subtype("Snapmaker PLA SnapSpeed", "Snapmaker", "PLA") == "SnapSpeed");
+    CHECK(derive_filament_subtype("PolyTerra PLA", "Polymaker", "PLA") == "PolyTerra");
+    CHECK(derive_filament_subtype("Generic PLA", "Generic", "PLA") == "");
+    CHECK(derive_filament_subtype("Snapmaker PLA Matte", "Snapmaker", "PLA") == "Matte");
+    // Case-insensitive token matching; remainder keeps its original casing and order.
+    CHECK(derive_filament_subtype("SNAPMAKER pla SnapSpeed", "Snapmaker", "PLA") == "SnapSpeed");
+    // A dashed type variant is one token: not stripped by its base type.
+    CHECK(derive_filament_subtype("Generic PLA-CF", "Generic", "PLA-CF") == "");
+    CHECK(derive_filament_subtype("", "Generic", "PLA") == "");
+}
+
+// Durable per-(physical device x project) slot assignments.
+// dump_slot_assignments/load_slot_assignments are the (de)serialization pair for the
+// device-key -> assignment-list map persisted on the Model as JSON.
+
+TEST_CASE("Slot assignments round-trip through dump and load", "[FilamentInventory][SlotAssignment]") {
+    std::map<std::string, std::vector<SlotAssignment>> devices;
+    devices["My Printer"] = { {0, 1, 0}, {1, 2, 0} };
+    devices["Snapmaker U1 (0.4 nozzle) - garage"] = { {2, 0, 0} };
+
+    std::string json = dump_slot_assignments(devices);
+    std::map<std::string, std::vector<SlotAssignment>> back = load_slot_assignments(json);
+
+    REQUIRE(back.size() == 2);
+    REQUIRE(back.count("My Printer") == 1);
+    REQUIRE(back["My Printer"].size() == 2);
+    CHECK(back["My Printer"][0].filament_idx == 0);
+    CHECK(back["My Printer"][0].tool == 1);
+    CHECK(back["My Printer"][0].slot == 0);
+    CHECK(back["My Printer"][1].filament_idx == 1);
+    CHECK(back["My Printer"][1].tool == 2);
+    REQUIRE(back.count("Snapmaker U1 (0.4 nozzle) - garage") == 1);
+    CHECK(back["Snapmaker U1 (0.4 nozzle) - garage"][0].filament_idx == 2);
+}
+
+TEST_CASE("An empty slot-assignments string loads to an empty map", "[FilamentInventory][SlotAssignment]") {
+    std::map<std::string, std::vector<SlotAssignment>> back = load_slot_assignments("");
+    CHECK(back.empty());
+}
+
+TEST_CASE("Malformed slot-assignments JSON loads to an empty map without throwing", "[FilamentInventory][SlotAssignment]") {
+    std::map<std::string, std::vector<SlotAssignment>> back;
+    REQUIRE_NOTHROW(back = load_slot_assignments("{not json"));
+    CHECK(back.empty());
+
+    REQUIRE_NOTHROW(back = load_slot_assignments("[1,2,3]"));
+    CHECK(back.empty());
+
+    REQUIRE_NOTHROW(back = load_slot_assignments("\"just a string\""));
+    CHECK(back.empty());
+}
+
+TEST_CASE("Unknown device keys are preserved through a load/dump cycle", "[FilamentInventory][SlotAssignment]") {
+    // A device this build has never heard of (e.g. from a newer Orca or a machine unplugged
+    // right now) must survive a load -> dump round-trip untouched, so re-saving a project never
+    // silently drops another device's assignments.
+    std::string json = R"({"Future Printer":[{"filament":4,"tool":1,"slot":0}]})";
+    std::map<std::string, std::vector<SlotAssignment>> loaded = load_slot_assignments(json);
+    REQUIRE(loaded.count("Future Printer") == 1);
+
+    std::string dumped = dump_slot_assignments(loaded);
+    std::map<std::string, std::vector<SlotAssignment>> back = load_slot_assignments(dumped);
+    REQUIRE(back.count("Future Printer") == 1);
+    REQUIRE(back["Future Printer"].size() == 1);
+    CHECK(back["Future Printer"][0].filament_idx == 4);
+    CHECK(back["Future Printer"][0].tool == 1);
+}
+
+TEST_CASE("Multiple devices in one blob load independently", "[FilamentInventory][SlotAssignment]") {
+    std::string json = R"({
+        "Printer A": [{"filament":0,"tool":0,"slot":0}],
+        "Printer B": [{"filament":0,"tool":3,"slot":0},{"filament":1,"tool":1,"slot":0}]
+    })";
+    std::map<std::string, std::vector<SlotAssignment>> back = load_slot_assignments(json);
+    REQUIRE(back.size() == 2);
+    CHECK(back["Printer A"].size() == 1);
+    CHECK(back["Printer B"].size() == 2);
+}
+
+// Slice-time auto-mapper. auto_map_filaments is the pure
+// matcher: assignment (if still valid) wins, else family-compatible nearest-color match with a
+// vendor tiebreak, else unmatched.
+
+TEST_CASE("Auto-map honors a valid stored assignment over a better color match", "[FilamentInventory][AutoMap]") {
+    FilamentInventory inv;
+    inv.tools = {{{1, "#FF0000", "PLA"}}, {{2, "#000000", "PLA"}}}; // tool 0 exact color match
+    std::vector<ProjectFilamentInfo> project = {{"PLA", "#FF0000", "Generic"}};
+    std::vector<SlotAssignment> assignments = {{0, 1, 0}}; // filament 0 explicitly routed to tool 1 (worse color)
+    AutoMapResult res = auto_map_filaments(project, inv, assignments);
+    REQUIRE(res.filament_map.size() == 1);
+    CHECK(res.filament_map[0] == 2);       // 1-based tool 2 (assignment.tool == 1)
+    CHECK(res.physical_map[0] == 2);       // physical id of tool 1's slot 0
+    CHECK(res.unmatched.empty());
+}
+
+TEST_CASE("Auto-map falls through to matching when the stored assignment's tool no longer exists", "[FilamentInventory][AutoMap]") {
+    FilamentInventory inv;
+    inv.tools = {{{1, "#FF0000", "PLA"}}}; // only one tool now
+    std::vector<ProjectFilamentInfo> project = {{"PLA", "#FF0000", "Generic"}};
+    std::vector<SlotAssignment> assignments = {{0, 5, 0}}; // stale: tool 5 is out of range
+    AutoMapResult res = auto_map_filaments(project, inv, assignments);
+    REQUIRE(res.filament_map.size() == 1);
+    CHECK(res.filament_map[0] == 1);
+    CHECK(res.physical_map[0] == 1);
+    CHECK(res.unmatched.empty());
+}
+
+TEST_CASE("Auto-map falls through to matching when the stored assignment's slot no longer exists", "[FilamentInventory][AutoMap]") {
+    FilamentInventory inv;
+    inv.tools = {{{1, "#FF0000", "PLA"}}}; // tool 0 has only slot 0
+    std::vector<ProjectFilamentInfo> project = {{"PLA", "#FF0000", "Generic"}};
+    std::vector<SlotAssignment> assignments = {{0, 0, 3}}; // stale: slot 3 does not exist on tool 0
+    AutoMapResult res = auto_map_filaments(project, inv, assignments);
+    CHECK(res.filament_map[0] == 1);
+    CHECK(res.physical_map[0] == 1);
+    CHECK(res.unmatched.empty());
+}
+
+TEST_CASE("Auto-map falls through to matching when the stored assignment's slot is empty", "[FilamentInventory][AutoMap]") {
+    // Real Snapmaker U1 bug: an assignment was written while tool 1 still had a filament, then a
+    // printer sync cleared that tool's loaded slot (see FilamentInventory::apply_synced_loaded_
+    // slot). The assignment's tool/slot indices are still in range, so it must not be honored
+    // outright -- an empty slot has nothing physically loaded, so the auto-mapper must fall
+    // through to matching (which finds tool 0's exact match) instead of routing to the empty tool.
+    FilamentInventory inv;
+    inv.tools = {{{1, "#FF0000", "PLA"}}, {{}}}; // tool 1's slot 0 is empty (id 0, no color/type/preset)
+    std::vector<ProjectFilamentInfo> project = {{"PLA", "#FF0000", "Generic"}};
+    std::vector<SlotAssignment> assignments = {{0, 1, 0}}; // stale: tool 1 slot 0 is empty
+    AutoMapResult res = auto_map_filaments(project, inv, assignments);
+    REQUIRE(res.filament_map.size() == 1);
+    CHECK(res.filament_map[0] == 1);   // falls through to the matcher, which finds tool 0
+    CHECK(res.physical_map[0] == 1);
+    CHECK(res.unmatched.empty());
+}
+
+TEST_CASE("Auto-map leaves a filament unmatched when the only stored assignment's slot is empty and nothing else matches", "[FilamentInventory][AutoMap]") {
+    FilamentInventory inv;
+    inv.tools = {{{}}}; // one tool, its only slot is empty
+    std::vector<ProjectFilamentInfo> project = {{"PLA", "#FF0000", "Generic"}};
+    std::vector<SlotAssignment> assignments = {{0, 0, 0}}; // stale: tool 0 slot 0 is empty
+    AutoMapResult res = auto_map_filaments(project, inv, assignments);
+    REQUIRE(res.unmatched == std::vector<int>{0});
+    CHECK(res.physical_map[0] == -1);
+}
+
+TEST_CASE("Auto-map matcher never selects an empty slot even when it is the only slot", "[FilamentInventory][AutoMap]") {
+    FilamentInventory inv;
+    inv.tools = {{{}}}; // one tool, its only slot is empty -- nothing physically present
+    std::vector<ProjectFilamentInfo> project = {{"PLA", "#FF0000", ""}};
+    AutoMapResult res = auto_map_filaments(project, inv, {});
+    REQUIRE(res.unmatched == std::vector<int>{0});
+    CHECK(res.physical_map[0] == -1);
+}
+
+TEST_CASE("Auto-map never family-matches an empty-type slot to a project filament with no type either", "[FilamentInventory][AutoMap]") {
+    FilamentInventory inv;
+    inv.tools = {{{1, "#FF0000", ""}}}; // slot has a color/id but no type recorded -- not empty()
+    std::vector<ProjectFilamentInfo> project = {{"", "#FF0000", ""}}; // project type also unknown
+    AutoMapResult res = auto_map_filaments(project, inv, {});
+    REQUIRE(res.unmatched == std::vector<int>{0}); // unknown-vs-unknown type must never be treated as compatible
+    CHECK(res.physical_map[0] == -1);
+}
+
+TEST_CASE("Auto-map treats PLA and PLA+ as family-compatible", "[FilamentInventory][AutoMap]") {
+    FilamentInventory inv;
+    inv.tools = {{{1, "#FF0000", "PLA+"}}};
+    std::vector<ProjectFilamentInfo> project = {{"PLA", "#FF0000", ""}};
+    AutoMapResult res = auto_map_filaments(project, inv, {});
+    REQUIRE(res.unmatched.empty());
+    CHECK(res.filament_map[0] == 1);
+    CHECK(res.physical_map[0] == 1);
+}
+
+TEST_CASE("Auto-map never matches PLA to PLA-CF", "[FilamentInventory][AutoMap]") {
+    FilamentInventory inv;
+    inv.tools = {{{1, "#FF0000", "PLA-CF"}}};
+    std::vector<ProjectFilamentInfo> project = {{"PLA", "#FF0000", ""}};
+    AutoMapResult res = auto_map_filaments(project, inv, {});
+    REQUIRE(res.unmatched == std::vector<int>{0});
+    CHECK(res.filament_map[0] == 1); // fallback default, caller decides what to do with it
+    CHECK(res.physical_map[0] == -1);
+}
+
+TEST_CASE("Auto-map never matches PETG to PLA even at identical color", "[FilamentInventory][AutoMap]") {
+    FilamentInventory inv;
+    inv.tools = {{{1, "#FF0000", "PLA"}}};
+    std::vector<ProjectFilamentInfo> project = {{"PETG", "#FF0000", ""}};
+    AutoMapResult res = auto_map_filaments(project, inv, {});
+    REQUIRE(res.unmatched == std::vector<int>{0});
+}
+
+TEST_CASE("Auto-map picks the nearest-RGB family-compatible candidate", "[FilamentInventory][AutoMap]") {
+    FilamentInventory inv;
+    inv.tools = {{{1, "#FF0000", "PLA"}}, {{2, "#FE0101", "PLA"}}, {{3, "#000000", "PLA"}}};
+    std::vector<ProjectFilamentInfo> project = {{"PLA", "#FE0101", ""}}; // nearest is tool 1 (id 2), not the exact-but-farther tool 0
+    AutoMapResult res = auto_map_filaments(project, inv, {});
+    CHECK(res.filament_map[0] == 2);
+    CHECK(res.physical_map[0] == 2);
+}
+
+TEST_CASE("Auto-map uses vendor to break an exact color tie", "[FilamentInventory][AutoMap]") {
+    FilamentInventory inv;
+    inv.tools = {{{1, "#FF0000", "PLA"}}, {{2, "#FF0000", "PLA"}}};
+    inv.tools[1][0].preset = "Snapmaker PLA SnapSpeed"; // vendor token "Snapmaker"
+    std::vector<ProjectFilamentInfo> project = {{"PLA", "#FF0000", "Snapmaker"}};
+    AutoMapResult res = auto_map_filaments(project, inv, {});
+    CHECK(res.filament_map[0] == 2); // tool 1 wins on vendor despite identical color distance
+    CHECK(res.physical_map[0] == 2);
+}
+
+// Regression guard: compute_physical_map_proposal (the dialog's proposal) used to build its
+// ProjectFilamentInfo list inline and silently drop vendor, so it disagreed with auto_map_filaments
+// (slice-time's core) on this exact scenario -- the dialog would propose tool 1 while a live-auto
+// slice routed to tool 2. Both now go through the same build_project_filament_info, so this must
+// resolve identically to "Auto-map uses vendor to break an exact color tie" above.
+TEST_CASE("Proposal uses vendor to break an exact color tie, same as slice-time auto-map", "[FilamentInventory]") {
+    FilamentInventory inv;
+    inv.tools = {{{1, "#FF0000", "PLA"}}, {{2, "#FF0000", "PLA"}}};
+    inv.tools[0][0].preset = "Generic PLA";
+    inv.tools[1][0].preset = "Snapmaker PLA SnapSpeed"; // vendor token "Snapmaker"
+    std::vector<std::string> colors  = {"#FF0000"};
+    std::vector<std::string> types   = {"PLA"};
+    std::vector<std::string> vendors = {"Snapmaker"};
+    std::vector<int>         plate   = {1};
+    std::vector<int> res = compute_physical_map_proposal(colors, types, vendors, {}, plate, {}, {}, inv,
+                                                          /*stored_map_confirmed=*/false);
+    REQUIRE(res.size() == 1);
+    CHECK(res[0] == 2); // tool 2 wins on vendor, matching auto_map_filaments exactly
+}
+
+// Orca: ported from the retired match_filaments_to_inventory -- an exact preset match is
+// the strongest signal the old GUI-only matcher trusted, carried forward into the single
+// suggestor rather than silently dropped.
+TEST_CASE("Auto-map trusts an exact preset match over a closer color match", "[FilamentInventory][AutoMap]") {
+    // slot 1's color is deliberately kept within kMaxFamilyColorDistance of the project color
+    // (#FF0000 vs #C80000: dr=255-200=55, 55*55=3025 < 10000) -- a preset match beyond
+    // the cutoff falls through instead of winning outright, so this test's own point (preset still
+    // outranks a closer but preset-less color match, PROVIDED it clears the cutoff) needs the
+    // preset candidate to clear it. See "...falls through to the family/color tier" below for the
+    // beyond-cutoff case.
+    FilamentInventory inv;
+    inv.tools = {{{1, "#FF0000", "PLA"}}, {{2, "#C80000", "PLA"}}}; // slot 0: exact color, no preset; slot 1: a further-but-still-in-cutoff color...
+    inv.tools[1][0].preset = "Snapmaker PLA SnapSpeed @U1";         // ...but exact preset
+    std::vector<ProjectFilamentInfo> project = {{"PLA", "#FF0000", "", "Snapmaker PLA SnapSpeed @U1"}};
+    AutoMapResult res = auto_map_filaments(project, inv, {});
+    CHECK(res.filament_map[0] == 2);
+    CHECK(res.physical_map[0] == 2);
+}
+
+TEST_CASE("Auto-map's exact-preset tier ignores a type mismatch on the slot record", "[FilamentInventory][AutoMap]") {
+    // A stale/miscategorized type on the slot must not veto an exact profile match.
+    FilamentInventory inv;
+    inv.tools = {{{1, "", "PETG"}}};
+    inv.tools[0][0].preset = "Snapmaker PLA SnapSpeed @U1";
+    std::vector<ProjectFilamentInfo> project = {{"PLA", "#FF0000", "", "Snapmaker PLA SnapSpeed @U1"}};
+    AutoMapResult res = auto_map_filaments(project, inv, {});
+    CHECK(res.filament_map[0] == 1);
+    CHECK(res.physical_map[0] == 1);
+}
+
+TEST_CASE("Auto-map's exact-preset tier is color-aware for the U1 five-filament repro (fix15)", "[FilamentInventory][AutoMap]") {
+    // Real-world bug report: a project with 5 filaments, all sharing preset "Snapmaker PLA
+    // SnapSpeed" but 5 different colors (red/white/black/green/tan), against an inventory of
+    // T1 blue PolyTerra PLA (no matching preset), T2 teal SnapSpeed PLA, T4 white SnapSpeed PLA
+    // (T3 empty). Previously, auto_map_filaments sent ALL FIVE to T2 (first preset match found,
+    // no color awareness, no cutoff at the preset tier). Before this fix: filament_map
+    // == {2, 2, 2, 2, 2} for all five, unconditionally.
+    //
+    // Squared-RGB distances (dr^2+dg^2+db^2), teal = #008080 = (0,128,128), white spool =
+    // #FFFFFF, blue PolyTerra = #0000FF:
+    //   red   #FF0000 (255,0,0)   -> teal:  255^2+128^2+128^2 = 65025+16384+16384 =  97793
+    //                              -> white: 0^2+255^2+255^2  =     0+65025+65025 = 130050
+    //                              -> blue:  255^2+0+255^2    = 65025+0+65025     = 130050
+    //   white #FFFFFF (255,255,255) -> teal: 255^2+127^2+127^2 = 65025+16129+16129 =  97283
+    //                                -> white: 0                                    =      0
+    //   black #000000 (0,0,0)     -> teal:  0+128^2+128^2     =     0+16384+16384 =  32768
+    //                              -> white: 255^2*3           = 195075
+    //                              -> blue:  255^2             =  65025
+    //   green #00FF00 (0,255,0)   -> teal:  0+127^2+128^2     =     0+16129+16384 =  32513
+    //                              -> white: 255^2+0+255^2    = 130050
+    //                              -> blue:  255^2+255^2      = 130050
+    //   tan   #D2B48C (210,180,140) -> teal: 210^2+52^2+12^2  = 44100+2704+144    =  46948
+    //                                -> white: 45^2+75^2+115^2 = 2025+5625+13225   =  20875
+    //                                -> blue: 210^2+180^2+115^2 = 44100+32400+13225 =  89725
+    // kMaxFamilyColorDistance is 10000. Only white's distance to the white spool (0) clears it --
+    // every other filament's nearest candidate (preset or family/color, teal/white/blue alike) is
+    // over the cutoff, so white->T4 and the other four are UNMATCHED (the dialog then prompts for
+    // confirmation instead of silently proposing a wrong color).
+    FilamentInventory inv;
+    inv.tools = {{{1, "#0000FF", "PolyTerra PLA"}},   // T1: no matching preset
+                 {{2, "#008080", "PLA"}},             // T2: SnapSpeed preset, teal
+                 {},                                  // T3: empty
+                 {{4, "#FFFFFF", "PLA"}}};             // T4: SnapSpeed preset, white
+    inv.tools[1][0].preset = "Snapmaker PLA SnapSpeed";
+    inv.tools[3][0].preset = "Snapmaker PLA SnapSpeed";
+    std::vector<ProjectFilamentInfo> project = {
+        {"PLA", "#FF0000", "", "Snapmaker PLA SnapSpeed"}, // red
+        {"PLA", "#FFFFFF", "", "Snapmaker PLA SnapSpeed"}, // white
+        {"PLA", "#000000", "", "Snapmaker PLA SnapSpeed"}, // black
+        {"PLA", "#00FF00", "", "Snapmaker PLA SnapSpeed"}, // green
+        {"PLA", "#D2B48C", "", "Snapmaker PLA SnapSpeed"}, // tan
+    };
+    AutoMapResult res = auto_map_filaments(project, inv, {});
+    CHECK(res.filament_map[1] == 4);   // white -> T4, the color-nearest preset match
+    CHECK(res.physical_map[1] == 4);
+    REQUIRE(res.unmatched == std::vector<int>{0, 2, 3, 4}); // red, black, green, tan: no in-cutoff candidate anywhere
+}
+
+TEST_CASE("Auto-map honors a durable assignment even over an exact-preset slot", "[FilamentInventory][AutoMap]") {
+    // Ordering pin: assignment > exact-preset > family/color/vendor. A durable pick still wins
+    // outright even when a different slot would have matched the project filament's preset exactly.
+    FilamentInventory inv;
+    inv.tools = {{{1, "#FF0000", "PLA"}}, {{2, "#800000", "PLA"}}};
+    inv.tools[1][0].preset = "Snapmaker PLA SnapSpeed @U1";
+    std::vector<ProjectFilamentInfo> project = {{"PLA", "#FF0000", "", "Snapmaker PLA SnapSpeed @U1"}};
+    std::vector<SlotAssignment> assignments = {{0, 0, 0}}; // filament 0 explicitly routed to tool 0
+    AutoMapResult res = auto_map_filaments(project, inv, assignments);
+    CHECK(res.filament_map[0] == 1);  // tool 0 (the assignment), not tool 1 (the exact preset)
+    CHECK(res.physical_map[0] == 1);
+}
+
+TEST_CASE("Auto-map prefers a loaded slot over an equally-close swappable one", "[FilamentInventory][AutoMap]") {
+    // Ported from the retired match_filaments_to_inventory, which had this same loaded-over-
+    // swappable tie-break; promoted into auto_map_filaments's family/color tier since there is now
+    // only one matcher.
+    FilamentInventory inv;
+    // Tool 0: nothing loaded, but a swappable red PLA (id 5). Tool 1: loaded red PLA (id 9).
+    inv.tools = {{{0, "", ""}, {5, "#FF0000", "PLA"}}, {{9, "#FF0000", "PLA"}}};
+    std::vector<ProjectFilamentInfo> project = {{"PLA", "#FF0000", ""}};
+    AutoMapResult res = auto_map_filaments(project, inv, {});
+    CHECK(res.filament_map[0] == 2);  // tool 1's loaded slot wins over tool 0's swappable one
+    CHECK(res.physical_map[0] == 9);
+}
+
+TEST_CASE("Auto-map leaves a filament unmatched rather than propose a wildly different color", "[FilamentInventory][AutoMap]") {
+    // KEPT from the retired match_filaments_to_inventory (its ΔE cutoff), reimplemented as a
+    // squared-RGB kMaxFamilyColorDistance in auto_map_filaments' family/color tier: silently
+    // auto-proposing blue for a red filament just because it's the only same-type slot around is
+    // the exact failure auto-mapping must not commit. Unmatched is the safe outcome -- the caller
+    // (dialog or slice-time) then prompts instead of committing a wrong color.
+    FilamentInventory inv;
+    inv.tools = {{{1, "#0000FF", "PLA"}}}; // the only PLA slot, and it's blue
+    std::vector<ProjectFilamentInfo> project = {{"PLA", "#FF0000", ""}}; // project filament is red
+    AutoMapResult res = auto_map_filaments(project, inv, {});
+    REQUIRE(res.unmatched == std::vector<int>{0});
+    CHECK(res.physical_map[0] == -1);
+}
+
+TEST_CASE("Proposal leaves a row unproposed rather than a wildly different color, through the dialog path", "[FilamentInventory]") {
+    // Same cutoff, exercised through compute_physical_map_proposal (the dialog's proposal/
+    // Automatic-button path) rather than auto_map_filaments directly, since both now share one
+    // matcher and this is the path the original bug report came through.
+    FilamentInventory inv;
+    inv.tools = {{{1, "#0000FF", "PLA"}}};
+    std::vector<std::string> colors = {"#FF0000"};
+    std::vector<std::string> types  = {"PLA"};
+    std::vector<int> plate = {1};
+    std::vector<int> res = compute_physical_map_proposal(colors, types, {}, {}, plate, {0}, {}, inv, /*stored_map_confirmed=*/false);
+    REQUIRE(res == std::vector<int>{0});
+}
+
+TEST_CASE("Auto-map's color cutoff still lets an unknown-color slot qualify on type alone", "[FilamentInventory][AutoMap]") {
+    // The cutoff only disqualifies a KNOWN, out-of-range color -- an unknown color on either side
+    // (unparseable/absent) must still qualify when it's the only compatible candidate, same as
+    // before the cutoff existed.
+    FilamentInventory inv;
+    inv.tools = {{{1, "", "PLA"}}}; // type matches, color unrecorded
+    std::vector<ProjectFilamentInfo> project = {{"PLA", "#FF0000", ""}};
+    AutoMapResult res = auto_map_filaments(project, inv, {});
+    REQUIRE(res.unmatched.empty());
+    CHECK(res.physical_map[0] == 1);
+}
+
+TEST_CASE("Auto-map still matches a moderately different shade of the same color family", "[FilamentInventory][AutoMap]") {
+    // The cutoff must not overcorrect into rejecting ordinary batch-to-batch variation -- only a
+    // genuinely different hue should require confirmation, not a darker/lighter version of the
+    // same color. #FF0000 vs #AB0000 measures 7056 in this file's squared-RGB metric, comfortably
+    // under kMaxFamilyColorDistance (10000).
+    FilamentInventory inv;
+    inv.tools = {{{1, "#AB0000", "PLA"}}}; // a noticeably darker red, still clearly "red"
+    std::vector<ProjectFilamentInfo> project = {{"PLA", "#FF0000", ""}};
+    AutoMapResult res = auto_map_filaments(project, inv, {});
+    REQUIRE(res.unmatched.empty());
+    CHECK(res.physical_map[0] == 1);
+}
+
+// Two-way pin for kMaxFamilyColorDistance's actual boundary (the moderate-shade test above only
+// pins the calibration FLOOR -- it passes with or without the cutoff, since 7056 < 10000 either
+// way). #FF0000 vs #9A0000: dr = 255-154 = 101, 101*101 = 10201, just over the 10000 cutoff. This
+// must go RED if the cutoff is ever removed or its distance metric changes, unlike the moderate-
+// shade test.
+TEST_CASE("Auto-map's color cutoff disqualifies a shade just past the threshold", "[FilamentInventory][AutoMap]") {
+    FilamentInventory inv;
+    inv.tools = {{{1, "#9A0000", "PLA"}}}; // squared-RGB distance to #FF0000 is 10201 (> 10000)
+    std::vector<ProjectFilamentInfo> project = {{"PLA", "#FF0000", ""}};
+    AutoMapResult res = auto_map_filaments(project, inv, {});
+    REQUIRE(res.unmatched == std::vector<int>{0});
+    CHECK(res.physical_map[0] == -1);
+}
+
+TEST_CASE("Auto-map's exact-preset tier falls through to unmatched when the color is a gross mismatch", "[FilamentInventory][AutoMap]") {
+    // Supersedes "...wins regardless of how far the color is" -- that pinned an earlier
+    // behavior where a preset match was trusted no matter the color. That was extended: a preset
+    // match beyond kMaxFamilyColorDistance is no longer trusted outright; it falls through to the
+    // family/color tier (itself cutoff-guarded). Here that's the very same slot, so it's
+    // disqualified there too and the filament ends up unmatched -- same outcome as "Auto-map
+    // leaves a filament unmatched rather than propose a wildly different color" above, which pins
+    // the identical red-vs-blue distance with no preset involved at all.
+    FilamentInventory inv;
+    inv.tools = {{{1, "#0000FF", "PLA"}}};
+    inv.tools[0][0].preset = "Snapmaker PLA SnapSpeed @U1";
+    std::vector<ProjectFilamentInfo> project = {{"PLA", "#FF0000", "", "Snapmaker PLA SnapSpeed @U1"}};
+    AutoMapResult res = auto_map_filaments(project, inv, {});
+    REQUIRE(res.unmatched == std::vector<int>{0});
+    CHECK(res.physical_map[0] == -1);
+}
+
+TEST_CASE("Auto-map's exact-preset tier falls through to the family/color tier when beyond the cutoff and a family candidate is in range", "[FilamentInventory][AutoMap]") {
+    // A preset match beyond the cutoff is treated as absent, not as a hard failure -- if a
+    // family-compatible, cutoff-in-range candidate exists elsewhere, tier 3 still finds it.
+    FilamentInventory inv;
+    inv.tools = {{{1, "#FF0000", "PLA"}}, {{2, "#0000FF", "PLA"}}}; // tool 0: no preset, exact color; tool 1: exact preset, blue (gross mismatch)
+    inv.tools[1][0].preset = "Snapmaker PLA SnapSpeed @U1";
+    std::vector<ProjectFilamentInfo> project = {{"PLA", "#FF0000", "", "Snapmaker PLA SnapSpeed @U1"}};
+    AutoMapResult res = auto_map_filaments(project, inv, {});
+    REQUIRE(res.unmatched.empty());
+    CHECK(res.filament_map[0] == 1);  // tool 0 (family/color tier), not tool 1 (the disqualified preset match)
+    CHECK(res.physical_map[0] == 1);
+}
+
+TEST_CASE("Auto-map's exact-preset tier breaks a tie between two preset matches by nearest color", "[FilamentInventory][AutoMap]") {
+    // With several slots sharing the same preset (e.g. one preset loaded into
+    // several different-colored spools), the tier used to break ties by tool index alone -- a
+    // white project filament could land on a teal spool just because it was scanned first. Now the
+    // nearest color wins: #FFFFFF vs #008080 (teal) = 255^2+127^2+127^2 = 65025+16129+16129 =
+    // 97283; #FFFFFF vs #F0F0F0 (near-white) = 15^2*3 = 675. Tool 1 (near-white) must win despite
+    // tool 0 being scanned first.
+    FilamentInventory inv;
+    inv.tools = {{{1, "#008080", "PLA"}}, {{2, "#F0F0F0", "PLA"}}};
+    inv.tools[0][0].preset = "Snapmaker PLA SnapSpeed";
+    inv.tools[1][0].preset = "Snapmaker PLA SnapSpeed";
+    std::vector<ProjectFilamentInfo> project = {{"PLA", "#FFFFFF", "", "Snapmaker PLA SnapSpeed"}};
+    AutoMapResult res = auto_map_filaments(project, inv, {});
+    CHECK(res.filament_map[0] == 2);
+    CHECK(res.physical_map[0] == 2);
+}
+
+TEST_CASE("Auto-map's durable assignment wins regardless of how far the color is", "[FilamentInventory][AutoMap]") {
+    // Same principle as the exact-preset case above: a durable SlotAssignment is an explicit user
+    // choice, resolved before the family/color tier even runs, so the color cutoff never
+    // applies to it -- the same red-vs-blue pairing that would otherwise be unmatched still
+    // resolves when the user has explicitly routed this filament to that tool.
+    FilamentInventory inv;
+    inv.tools = {{{1, "#0000FF", "PLA"}}};
+    std::vector<ProjectFilamentInfo> project = {{"PLA", "#FF0000", ""}};
+    std::vector<SlotAssignment> assignments = {{0, 0, 0}};
+    AutoMapResult res = auto_map_filaments(project, inv, assignments);
+    REQUIRE(res.unmatched.empty());
+    CHECK(res.filament_map[0] == 1);
+    CHECK(res.physical_map[0] == 1);
+}
+
+TEST_CASE("Proposal matches a PLA+ project filament to a plain PLA slot", "[FilamentInventory]") {
+    // The bug that motivated this consolidation: the dialog's own matcher required an exact type
+    // match (PLA+ vs PLA disqualified), while the slice-time auto-mapper already treated them as
+    // family-compatible. Both paths now share auto_map_filaments, so the dialog's proposal (and,
+    // by extension, its Automatic button) gets the same family match slice-time mapping always had.
+    FilamentInventory inv;
+    inv.tools = {{{1, "#FF0000", "PLA"}}};
+    std::vector<std::string> colors = {"#FF0000"};
+    std::vector<std::string> types  = {"PLA+"};
+    std::vector<int> plate = {1};
+    std::vector<int> res = compute_physical_map_proposal(colors, types, {}, {}, plate, {0}, {}, inv, /*stored_map_confirmed=*/false);
+    REQUIRE(res == std::vector<int>{1});
+}
+
+TEST_CASE("Auto-map breaks a full tie (color and vendor) with the lowest tool index", "[FilamentInventory][AutoMap]") {
+    FilamentInventory inv;
+    inv.tools = {{{1, "#FF0000", "PLA"}}, {{2, "#FF0000", "PLA"}}};
+    std::vector<ProjectFilamentInfo> project = {{"PLA", "#FF0000", ""}};
+    AutoMapResult res = auto_map_filaments(project, inv, {});
+    CHECK(res.filament_map[0] == 1);
+    CHECK(res.physical_map[0] == 1);
+}
+
+TEST_CASE("Auto-map surfaces unmatched filaments with a fallback tool of 1", "[FilamentInventory][AutoMap]") {
+    FilamentInventory inv;
+    inv.tools = {{{1, "#FF0000", "PETG"}}};
+    std::vector<ProjectFilamentInfo> project = {{"PLA", "#FF0000", ""}, {"PETG", "#FF0000", ""}};
+    AutoMapResult res = auto_map_filaments(project, inv, {});
+    REQUIRE(res.unmatched == std::vector<int>{0});
+    CHECK(res.filament_map[0] == 1);   // fallback
+    CHECK(res.physical_map[0] == -1);
+    CHECK(res.filament_map[1] == 1);   // real match
+    CHECK(res.physical_map[1] == 1);
+}
+
+TEST_CASE("Auto-map on an empty inventory marks every filament unmatched", "[FilamentInventory][AutoMap]") {
+    FilamentInventory inv;
+    inv.tools.resize(2); // no physical filaments recorded
+    std::vector<ProjectFilamentInfo> project = {{"PLA", "#FF0000", ""}, {"PETG", "#00FF00", ""}};
+    AutoMapResult res = auto_map_filaments(project, inv, {});
+    REQUIRE(res.unmatched == std::vector<int>{0, 1});
+    CHECK(res.filament_map == std::vector<int>{1, 1});
+    CHECK(res.physical_map == std::vector<int>{-1, -1});
+}
+
+TEST_CASE("Auto-map allows two project filaments to merge onto the same tool", "[FilamentInventory][AutoMap]") {
+    FilamentInventory inv;
+    inv.tools = {{{1, "#FF0000", "PLA"}}};
+    std::vector<ProjectFilamentInfo> project = {{"PLA", "#FF0000", ""}, {"PLA", "#FE0101", ""}};
+    AutoMapResult res = auto_map_filaments(project, inv, {});
+    REQUIRE(res.unmatched.empty());
+    CHECK(res.filament_map[0] == 1);
+    CHECK(res.filament_map[1] == 1); // legal merge, not an error
+    CHECK(res.physical_map[0] == 1);
+    CHECK(res.physical_map[1] == 1);
+}
+
+TEST_CASE("An assignment entry with a missing field is skipped, not defaulted", "[FilamentInventory][SlotAssignment]") {
+    // Missing/invalid fields must not silently coerce to 0 -- that would fabricate a plausible-
+    // looking (filament 0, tool 0, slot 0) assignment out of corrupt data. Skip the entry instead.
+    std::string json = R"({"My Printer":[{"filament":0,"tool":1},{"filament":-1,"tool":2,"slot":0},
+                                       {"tool":1,"slot":0},{"filament":1,"tool":-2,"slot":0},
+                                       {"filament":2,"tool":1,"slot":0}]})";
+    std::map<std::string, std::vector<SlotAssignment>> back = load_slot_assignments(json);
+    REQUIRE(back.count("My Printer") == 1);
+    // Only the fully-valid, non-negative entry survives.
+    REQUIRE(back["My Printer"].size() == 1);
+    CHECK(back["My Printer"][0].filament_idx == 2);
+    CHECK(back["My Printer"][0].tool == 1);
+    CHECK(back["My Printer"][0].slot == 0);
+}
+
+// --- validate_manual_map (slice-time re-validation of a confirmed manual mapping) ---
+
+TEST_CASE("Manual map validator flags a target tool that has since gone empty", "[FilamentInventory][ManualMapValidate]") {
+    FilamentInventory inv;
+    inv.tools = {{{1, "#FF0000", "PLA"}}, {{}}}; // tool 1 loaded red PLA, tool 2 empty
+    std::vector<ProjectFilamentInfo> project = {{"PLA", "#FF0000", "", ""}};
+    // Confirmed onto tool 2 (physical id 2, which no longer exists -- the sync/edit that emptied
+    // the tool also drops its old id).
+    std::vector<int> filament_map = {2};
+    std::vector<int> physical_map = {2};
+    auto violations = validate_manual_map(project, filament_map, physical_map, inv);
+    REQUIRE(violations.size() == 1);
+    CHECK(violations[0].filament_index == 0);
+    CHECK(violations[0].kind == ManualMapViolationKind::EmptyTarget);
+}
+
+TEST_CASE("Manual map validator flags a bootstrap-style pick (physical_map<=0) onto a now-empty tool", "[FilamentInventory][ManualMapValidate]") {
+    FilamentInventory inv;
+    inv.tools = {{{}}}; // single tool, empty
+    std::vector<ProjectFilamentInfo> project = {{"PLA", "#FF0000", "", ""}};
+    std::vector<int> filament_map = {1};
+    std::vector<int> physical_map = {0}; // no physical pick recorded
+    auto violations = validate_manual_map(project, filament_map, physical_map, inv);
+    REQUIRE(violations.size() == 1);
+    CHECK(violations[0].kind == ManualMapViolationKind::EmptyTarget);
+}
+
+TEST_CASE("Manual map validator flags a family mismatch against the live inventory", "[FilamentInventory][ManualMapValidate]") {
+    FilamentInventory inv;
+    inv.tools = {{{1, "#FF0000", "PETG"}}}; // tool now holds PETG, not what was confirmed
+    std::vector<ProjectFilamentInfo> project = {{"PLA", "#FF0000", "", ""}};
+    std::vector<int> filament_map = {1};
+    std::vector<int> physical_map = {1};
+    auto violations = validate_manual_map(project, filament_map, physical_map, inv);
+    REQUIRE(violations.size() == 1);
+    CHECK(violations[0].kind == ManualMapViolationKind::FamilyMismatch);
+}
+
+TEST_CASE("Manual map validator flags a gross color mismatch using the shared cutoff", "[FilamentInventory][ManualMapValidate]") {
+    FilamentInventory inv;
+    inv.tools = {{{1, "#0000FF", "PLA"}}}; // blue tool
+    std::vector<ProjectFilamentInfo> project = {{"PLA", "#FF0000", "", ""}}; // red project filament
+    std::vector<int> filament_map = {1};
+    std::vector<int> physical_map = {1};
+    auto violations = validate_manual_map(project, filament_map, physical_map, inv);
+    REQUIRE(violations.size() == 1);
+    CHECK(violations[0].kind == ManualMapViolationKind::GrossColorMismatch);
+}
+
+TEST_CASE("Manual map validator flags a gross color mismatch even when the target's preset matches the project filament's", "[FilamentInventory][ManualMapValidate]") {
+    // The same rule extends to the validator: a matching preset does not exempt a
+    // MANUAL map from the color-mismatch confirmation either -- validate_manual_map never reads
+    // preset at all, so a preset match here still gets flagged, same as it would with no preset.
+    // This test documents that the auto-map and validator paths agree.
+    FilamentInventory inv;
+    inv.tools = {{{1, "#008080", "PLA"}}}; // teal spool, preset-matching
+    inv.tools[0][0].preset = "Snapmaker PLA SnapSpeed";
+    std::vector<ProjectFilamentInfo> project = {{"PLA", "#FF0000", "", "Snapmaker PLA SnapSpeed"}}; // red project filament
+    std::vector<int> filament_map = {1};
+    std::vector<int> physical_map = {1};
+    auto violations = validate_manual_map(project, filament_map, physical_map, inv);
+    REQUIRE(violations.size() == 1);
+    CHECK(violations[0].kind == ManualMapViolationKind::GrossColorMismatch);
+}
+
+TEST_CASE("Manual map validator passes a clean map through untouched", "[FilamentInventory][ManualMapValidate]") {
+    FilamentInventory inv;
+    inv.tools = {{{1, "#FF0000", "PLA"}}, {{2, "#00FF00", "PETG"}}};
+    std::vector<ProjectFilamentInfo> project = {{"PLA", "#FF0000", "", ""}, {"PETG", "#00FF00", "", ""}};
+    std::vector<int> filament_map = {1, 2};
+    std::vector<int> physical_map = {1, 2};
+    auto violations = validate_manual_map(project, filament_map, physical_map, inv);
+    CHECK(violations.empty());
+}
+
+TEST_CASE("Manual map validator ignores an unknown color or type rather than flagging it", "[FilamentInventory][ManualMapValidate]") {
+    FilamentInventory inv;
+    PhysicalFilament pf;
+    pf.id     = 1;
+    pf.preset = "Generic PLA"; // preset known, but color/type not recorded -- not empty()
+    inv.tools = {{pf}};
+    std::vector<ProjectFilamentInfo> project = {{"PLA", "#FF0000", "", ""}};
+    std::vector<int> filament_map = {1};
+    std::vector<int> physical_map = {1};
+    auto violations = validate_manual_map(project, filament_map, physical_map, inv);
+    CHECK(violations.empty());
+}
+
+// --- inventory_confirmation_fingerprint ---
+
+TEST_CASE("Inventory fingerprint is stable across calls on the same inventory", "[FilamentInventory][ManualMapValidate]") {
+    FilamentInventory inv;
+    inv.tools = {{{1, "#FF0000", "PLA"}, {5, "#FFFF00", "PLA"}}, {{2, "#FFFFFF", "PETG"}}};
+    CHECK(inventory_confirmation_fingerprint(inv) == inventory_confirmation_fingerprint(inv));
+}
+
+TEST_CASE("Inventory fingerprint ignores id, only the confirmed content", "[FilamentInventory][ManualMapValidate]") {
+    FilamentInventory a, b;
+    a.tools = {{{1, "#FF0000", "PLA"}}};
+    b.tools = {{{99, "#FF0000", "PLA"}}}; // same content, different id (e.g. re-numbered on save)
+    CHECK(inventory_confirmation_fingerprint(a) == inventory_confirmation_fingerprint(b));
+}
+
+TEST_CASE("Inventory fingerprint changes when a slot's color changes", "[FilamentInventory][ManualMapValidate]") {
+    FilamentInventory a, b;
+    a.tools = {{{1, "#FF0000", "PLA"}}};
+    b.tools = {{{1, "#00FF00", "PLA"}}};
+    CHECK(inventory_confirmation_fingerprint(a) != inventory_confirmation_fingerprint(b));
+}
+
+TEST_CASE("Inventory fingerprint changes when a slot's type changes", "[FilamentInventory][ManualMapValidate]") {
+    FilamentInventory a, b;
+    a.tools = {{{1, "#FF0000", "PLA"}}};
+    b.tools = {{{1, "#FF0000", "PETG"}}};
+    CHECK(inventory_confirmation_fingerprint(a) != inventory_confirmation_fingerprint(b));
+}
+
+TEST_CASE("Inventory fingerprint changes when a tool goes from loaded to empty", "[FilamentInventory][ManualMapValidate]") {
+    FilamentInventory a, b;
+    a.tools = {{{1, "#FF0000", "PLA"}}};
+    b.tools = {{{}}}; // same slot, now empty
+    CHECK(inventory_confirmation_fingerprint(a) != inventory_confirmation_fingerprint(b));
+}
+
+TEST_CASE("Inventory fingerprint changes when the tool count changes", "[FilamentInventory][ManualMapValidate]") {
+    FilamentInventory a, b;
+    a.tools = {{{1, "#FF0000", "PLA"}}};
+    b.tools = {{{1, "#FF0000", "PLA"}}, {{}}};
+    CHECK(inventory_confirmation_fingerprint(a) != inventory_confirmation_fingerprint(b));
+}
+
+// --- confirmation metadata dump/load ---
+
+TEST_CASE("Manual map confirmations round-trip device key, plate index, and fingerprint", "[FilamentInventory][ManualMapValidate]") {
+    std::map<std::string, std::map<int, std::string>> by_device_plate;
+    by_device_plate["My Printer"][0] = "deadbeef";
+    by_device_plate["My Printer"][2] = "cafef00d";
+    std::string dumped = dump_manual_map_confirmations(by_device_plate);
+    auto back = load_manual_map_confirmations(dumped);
+    REQUIRE(back.count("My Printer") == 1);
+    REQUIRE(back["My Printer"].size() == 2);
+    CHECK(back["My Printer"][0] == "deadbeef");
+    CHECK(back["My Printer"][2] == "cafef00d");
+}
+
+TEST_CASE("Manual map confirmations tolerate malformed JSON", "[FilamentInventory][ManualMapValidate]") {
+    CHECK(load_manual_map_confirmations("{not json").empty());
+    CHECK(load_manual_map_confirmations("[1,2,3]").empty());
+    CHECK(load_manual_map_confirmations("").empty());
+}

--- a/tests/slic3rutils/test_dev_mapping.cpp
+++ b/tests/slic3rutils/test_dev_mapping.cpp
@@ -193,3 +193,174 @@ TEST_CASE("Switch-bound AMS with an invalid track is excluded from mapping", "[D
     DevFilaSystemParser::ParseV1_0(print_push, &obj_no_switch, obj_no_switch.GetFilaSystem().get(), false);
     REQUIRE(obj_no_switch.GetFilaSystem()->GetAmsList().count("0") == 0);
 }
+
+TEST_CASE("A toolchanger's tools all resolve in filament mapping", "[DevMapping]")
+{
+    // Regression guard for two independent defects that both hid tools behind a "tool 0 works
+    // by coincidence" facade for Moonraker toolchangers (Snapmaker U1 and similar):
+    //
+    // 1) DevMapping.cpp's tray-index arms (_parse_tray_info and the tray_index computation in
+    //    ams_filament_mapping) originally didn't match DevAms::TOOLCHANGER, so every unit fell
+    //    through to the AMS-group formula/assert(0) and only unit 0 (index 0) ended up
+    //    distinguishable; tools 1-3 collided or were dropped and stayed unmapped (tray_id == -1).
+    //    Fixed by routing TOOLCHANGER through the same "ams_id + slot_id" arm as N3S.
+    //
+    // 2) is_valid_mapping_result (called internally by ams_filament_mapping with
+    //    check_empty_slot=true) rejects a result whose tray no longer reports is_exists. For any
+    //    unit type >= 4 that isn't AMS_LITE_MIXED, DevFilaSystem.cpp computed is_exists via a
+    //    "some_bit + (ams_id - 128)" formula that assumes real N3S hardware's ams_id-128 wire
+    //    scheme. MoonrakerPrinterAgent::build_ams_payload instead publishes 0-based
+    //    ams_exist_bits/tray_exist_bits (`1 << ams_id`), so that shift went out of range and
+    //    is_exists always came back false, invalidating the first tray is_valid_mapping_result
+    //    examined (mutating just that entry to tray_id == -1 before returning early). Fixed by
+    //    giving TOOLCHANGER its own arm that reads bit ams_id directly, leaving the N3S
+    //    128-offset arithmetic untouched.
+    //
+    // Both defects independently reduce the same observable symptom: with only one of the two
+    // fixes in place, either tools 1-3 stay at tray_id -1 (defect 1) or tool 0 does (defect 2).
+    MachineObject obj(nullptr, nullptr, "test", "test_dev", "127.0.0.1");
+
+    // info bits 0-3 = 6 (DevAms::TOOLCHANGER), matching the "%04X" of TOOLCHANGER that
+    // MoonrakerPrinterAgent::build_ams_payload writes into each unit's "info" field.
+    // tray_exist_bits bit n marks unit n / slot 0, mirroring build_ams_payload's
+    // `tray_exist_bits |= (1 << slot_index)` where slot_index == ams_id for these units.
+    json print_push = json::parse(R"({
+        "ams": {
+            "tray_exist_bits": "F",
+            "ams": [
+                { "id": "0", "info": "0006", "tray": [ { "id": "0", "tray_color": "FF0000FF" } ] },
+                { "id": "1", "info": "0006", "tray": [ { "id": "0", "tray_color": "00FF00FF" } ] },
+                { "id": "2", "info": "0006", "tray": [ { "id": "0", "tray_color": "0000FFFF" } ] },
+                { "id": "3", "info": "0006", "tray": [ { "id": "0", "tray_color": "FFFF00FF" } ] }
+            ]
+        }
+    })");
+    DevFilaSystemParser::ParseV1_0(print_push, &obj, obj.GetFilaSystem().get(), false);
+
+    const auto& ams_list = obj.GetFilaSystem()->GetAmsList();
+    std::vector<std::string> colors = {"FF0000FF", "00FF00FF", "0000FFFF", "FFFF00FF"};
+    std::vector<FilamentInfo> filaments;
+    for (int i = 0; i < 4; ++i) {
+        REQUIRE(ams_list.count(std::to_string(i)) == 1);
+        // TOOLCHANGER units carry no extruder nibble, so DevFilaSystemParser defaults them to
+        // MAIN_EXTRUDER_ID; select them via the right-AMS mapping option below.
+        REQUIRE(ams_list.at(std::to_string(i))->GetExtruderId() == MAIN_EXTRUDER_ID);
+
+        // tray_info_idx/tray_type are omitted from the payload above (as in the other tests in
+        // this file) because resolving them needs the GUI preset bundle, unavailable headless.
+        // Set the display filament type directly, as the other tests here do.
+        DevAmsTray* tray = obj.GetFilaSystem()->GetAmsTray(std::to_string(i), "0");
+        REQUIRE(tray != nullptr);
+        tray->m_fila_type = "PLA";
+
+        FilamentInfo fila;
+        fila.id    = i;
+        fila.type  = "PLA";
+        fila.color = colors[i];
+        filaments.push_back(fila);
+    }
+
+    std::vector<FilamentInfo> result;
+    std::vector<bool> map_opt(4, false);
+    map_opt[MappingOption::USE_RIGHT_AMS] = true;
+    DevMappingUtil::ams_filament_mapping(&obj, filaments, result, map_opt, {}, false);
+
+    // The defining property both fixes restore: every tool resolves, not just tool 0, and the
+    // result is accepted as valid (exercises the is_exists check both fixes touch).
+    REQUIRE(result.size() == 4);
+    for (int i = 0; i < 4; ++i) {
+        INFO("filament " << i);
+        REQUIRE(result[i].tray_id >= 0);
+        CHECK(result[i].tray_id == i);
+    }
+    CHECK(DevMappingUtil::is_valid_mapping_result(&obj, result, true));
+}
+
+TEST_CASE("Both AMS unit shapes MoonrakerPrinterAgent::build_ams_payload emits parse into the right unit/tray layout", "[DevMapping]")
+{
+    // Regression guard for the vendor-caller mismatch after MoonrakerPrinterAgent::build_ams_payload
+    // grew a per-vendor unit shape: SnapmakerPrinterAgent (a physical toolchanger) must use one
+    // 1-slot TOOLCHANGER unit per tool, while CrealityPrintAgent/QidiPrinterAgent (4-slot MMU boxes)
+    // must keep chunking into AMS_LITE units of up to 4 slots. This pins the parser's view of both
+    // payload shapes so a future caller regression (e.g. a vendor reverting to the wrong shape, or
+    // a hardcoded unit count) shows up as a wrong unit/tray count here.
+    SECTION("Toolchanger shape: 4 lanes become 4 one-slot units")
+    {
+        // Mirrors what SnapmakerPrinterAgent::fetch_filament_info now requests via
+        // build_ams_payload(slot_count, slot_count - 1, trays, AmsUnitShape::Toolchanger) for a
+        // 4-tool U1: one unit per tool, each with a single tray at id "0" (info 0006 ==
+        // DevAms::TOOLCHANGER). Before the fix, Snapmaker's caller passed a hardcoded ams_count of
+        // 1 into the (by-then-toolchanger-shaped) builder, which emits exactly `ams_count` units,
+        // so this payload would have collapsed to ONE unit / ONE tray instead of four -- this
+        // SECTION fails with `ams_list.size() == 1` if that regresses.
+        json print_push = json::parse(R"({
+            "ams": {
+                "tray_exist_bits": "F",
+                "ams": [
+                    { "id": "0", "info": "0006", "tray": [ { "id": "0", "tray_color": "FF0000FF" } ] },
+                    { "id": "1", "info": "0006", "tray": [ { "id": "0", "tray_color": "00FF00FF" } ] },
+                    { "id": "2", "info": "0006", "tray": [ { "id": "0", "tray_color": "0000FFFF" } ] },
+                    { "id": "3", "info": "0006", "tray": [ { "id": "0", "tray_color": "FFFF00FF" } ] }
+                ]
+            }
+        })");
+
+        MachineObject obj(nullptr, nullptr, "test", "test_dev", "127.0.0.1");
+        DevFilaSystemParser::ParseV1_0(print_push, &obj, obj.GetFilaSystem().get(), false);
+
+        const auto& ams_list = obj.GetFilaSystem()->GetAmsList();
+        REQUIRE(ams_list.size() == 4);
+        for (int i = 0; i < 4; ++i) {
+            INFO("unit " << i);
+            REQUIRE(ams_list.count(std::to_string(i)) == 1);
+            CHECK(ams_list.at(std::to_string(i))->GetTrays().size() == 1);
+        }
+
+        // Global tray index == unit index for TOOLCHANGER (DevFilaSystem.cpp GetTrayIndexMap).
+        auto tray_index_map = obj.GetFilaSystem()->GetTrayIndexMap();
+        for (int i = 0; i < 4; ++i) {
+            INFO("tray index " << i);
+            REQUIRE(tray_index_map.count(i) == 1);
+            CHECK(tray_index_map.at(i).first == i);   // ams_id
+            CHECK(tray_index_map.at(i).second == 0);  // slot_id
+        }
+    }
+
+    SECTION("Box4 shape: 4 slots stay chunked into a single AMS_LITE unit")
+    {
+        // Mirrors what CrealityPrintAgent/QidiPrinterAgent now request via
+        // build_ams_payload(box_count, ..., trays, AmsUnitShape::Box4): one unit per up-to-4
+        // slots (info 0002 == DevAms::AMS_LITE), byte-identical to the payload shape
+        // build_ams_payload produced before it grew a per-tool TOOLCHANGER arm.
+        json print_push = json::parse(R"({
+            "ams": {
+                "tray_exist_bits": "F",
+                "ams": [
+                    { "id": "0", "info": "0002", "tray": [
+                        { "id": "0", "tray_color": "FF0000FF" },
+                        { "id": "1", "tray_color": "00FF00FF" },
+                        { "id": "2", "tray_color": "0000FFFF" },
+                        { "id": "3", "tray_color": "FFFF00FF" }
+                    ] }
+                ]
+            }
+        })");
+
+        MachineObject obj(nullptr, nullptr, "test", "test_dev", "127.0.0.1");
+        DevFilaSystemParser::ParseV1_0(print_push, &obj, obj.GetFilaSystem().get(), false);
+
+        const auto& ams_list = obj.GetFilaSystem()->GetAmsList();
+        REQUIRE(ams_list.size() == 1);
+        REQUIRE(ams_list.count("0") == 1);
+        CHECK(ams_list.at("0")->GetTrays().size() == 4);
+
+        // Global tray index == ams_id*4 + slot_id for AMS_LITE (DevFilaSystem.cpp GetTrayIndexMap).
+        auto tray_index_map = obj.GetFilaSystem()->GetTrayIndexMap();
+        for (int i = 0; i < 4; ++i) {
+            INFO("tray index " << i);
+            REQUIRE(tray_index_map.count(i) == 1);
+            CHECK(tray_index_map.at(i).first == 0);   // ams_id
+            CHECK(tray_index_map.at(i).second == i);  // slot_id
+        }
+    }
+}


### PR DESCRIPTION
# Description

Initially supports reading AFC/HappyHare/Snapmaker slot data but only writing via Snapmaker.

Initially only what was built as part of #15145 

More robust AFC support to come in subsequent PR. Will need to incorporate discussion from #14068

# Screenshots/Recordings/Graphs

<img width="1438" height="999" alt="image" src="https://github.com/user-attachments/assets/c1d8a50f-ed2a-4c1e-8e45-2543de2a5a8a" />

## Tests

Have verified I can read filaments from a connected printer and write changes back to the printer. Verified the changes are visible on the printer.

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
