### PR TITLE
Add a Plugins shortcut to the Home page side panel

### DIFF
--- a/resources/web/homepage/index.html
+++ b/resources/web/homepage/index.html
@@ -81,6 +81,12 @@
 			<div class="BtnIcon "><img class="LeftIcon" src="img/i2.png" /></div>
 			<div class="trans" tid="t28">recent</div> 
 		</div>
+	    <div class="BtnItem" onClick="OnClickPlugins()">
+			<div class="BtnIcon "><svg class="LeftIcon" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+				<path d="M8 2.5a1.75 1.75 0 0 1 3.5 0v.75h2.25c.55 0 1 .45 1 1V6.5h.75a1.75 1.75 0 0 1 0 3.5h-.75v2.25c0 .55-.45 1-1 1H11.5v.75a1.75 1.75 0 0 1-3.5 0v-.75H5.75c-.55 0-1-.45-1-1V10h-.75a1.75 1.75 0 0 1 0-3.5h.75V4.25c0-.55.45-1 1-1H8V2.5Z" stroke="currentColor" stroke-width="1.25" stroke-linejoin="round"/>
+			</svg></div>
+			<div>Plugins</div>
+		</div>
 	    <div class="BtnItem BtnShortcut" onClick="OpenUrlInLocalBrowser('https://cloud.orcaslicer.com')">
 			<div class="BtnIcon "><img class="ShortcutBrandIcon" src="../image/logo.png" /></div>
 			<div class="ShortcutTextRow">

--- a/resources/web/homepage/js/home.js
+++ b/resources/web/homepage/js/home.js
@@ -312,6 +312,15 @@ function OnClickModelDepot()
 	SendWXMessage( JSON.stringify(tSend) );		
 }
 
+function OnClickPlugins()
+{
+	var tSend={};
+	tSend['sequence_id']=Math.round(new Date() / 1000);
+	tSend['command']="homepage_plugins";
+
+	SendWXMessage( JSON.stringify(tSend) );
+}
+
 function OnClickNewProject()
 {
 	var tSend={};

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -5165,6 +5165,9 @@ std::string GUI_App::handle_web_request(std::string cmd)
             else if (command_str.compare("homepage_modeldepot") == 0) {
                 CallAfter([this] { open_mall_page_dialog(); });
             }
+            else if (command_str.compare("homepage_plugins") == 0) {
+                CallAfter([this] { open_plugins_dialog(); });
+            }
             else if (command_str.compare("homepage_newproject") == 0) {
                 this->request_open_project("<new>");
             }


### PR DESCRIPTION
### What

Adds a **Plugins** entry to the Home page side panel, between *Recent* and *OrcaCloud*, that opens the plugins dialog.

### Why

The plugins dialog is currently reachable only from the menu bar (`Tools ▸ Plugins`, and the File menu entry). Now that plugins are a first-class part of the app, running one means a detour through a menu — the Home panel is where the other entry points already live.

### How

Three small pieces, mirroring the existing `homepage_*` commands:

- `resources/web/homepage/index.html` — one `BtnItem` with an inline puzzle SVG. It uses `currentColor`, so it follows the theme, and adds no new asset file.
- `resources/web/homepage/js/home.js` — `OnClickPlugins()` posts `{command: "homepage_plugins"}` through `SendWXMessage`, the same shape as `OnClickNewProject()`.
- `src/slic3r/GUI/GUI_App.cpp` — `homepage_plugins` → `CallAfter([this] { open_plugins_dialog(); })`, the same call the menu item makes.

The label is plain text rather than a `trans`/`tid` pair, because a new tid would need an entry no catalogue has yet. Happy to add one if you'd prefer it localized from the start.

### Testing

Built and run on Linux (GTK3 / WebKitGTK). The entry renders in both light and dark themes, and clicking it opens the same dialog as the menu item — verified against the log line `Prepared N plugin rows for Plugins dialog`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
