### PR TITLE
Dynamic max height for printing sequence "by object" (gantry-axis aware)

### DIFF
--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -758,8 +758,10 @@ StringObjectException Print::sequential_print_clearance_valid(const Print &print
         }
     }
 
-    // Heights measured from the nozzle: hc2 is the clearance to the gantry rod, printable_height the build volume top.
+    // Heights measured from the nozzle: hc2 is the clearance to the gantry rod, hc1 to the lid/top cover,
+    // printable_height the build volume top.
     double hc2              = scale_(print.config().extruder_clearance_height_to_rod); // height to rod
+    double hc1              = scale_(print.config().extruder_clearance_height_to_lid); // height to lid
     double printable_height = scale_(print.config().printable_height);
 
 #if 0 //do not sort anymore, use the order in object list
@@ -871,9 +873,11 @@ StringObjectException Print::sequential_print_clearance_valid(const Print &print
         // plate at the toolhead's Y position, so an instance can only collide with the gantry while a
         // later-printed instance (already at full height) shares its Y band, i.e. the two are placed
         // side by side along the X axis. Instances in their own Y band never sit under the gantry
-        // together with another object, so they may use the full build volume height. The Y band test
-        // uses the un-inflated bounding boxes: horizontal separation is already enforced by the
-        // extruder_clearance_radius collision check above.
+        // together with another object, so they may use the full build volume height. Delta printers
+        // are excluded: their arms sweep over the whole plate, so the conservative lid-height limit
+        // keeps applying to them. The Y band test uses the un-inflated bounding boxes: horizontal
+        // separation is already enforced by the extruder_clearance_radius collision check above.
+        const bool dynamic_max_height = print_config.printer_structure.value != psDelta;
         int print_instance_count = print_instance_with_bounding_box.size();
         std::map<const PrintInstance*, std::pair<Polygon, float>> too_tall_instances;
         for (int k = 0; k < print_instance_count; k++)
@@ -883,7 +887,7 @@ StringObjectException Print::sequential_print_clearance_valid(const Print &print
             auto iy1 = bbox.min.y();
             auto iy2 = bbox.max.y();
             (const_cast<ModelInstance*>(inst->model_instance))->arrange_order = k+1;
-            double height = printable_height;
+            double height = (dynamic_max_height || k == (print_instance_count - 1)) ? printable_height : hc1;
             for (int i = k+1; i < print_instance_count; i++)
             {
                 auto& bbox2 = print_instance_with_bounding_box[i].true_bounding_box;

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -650,6 +650,7 @@ StringObjectException Print::sequential_print_clearance_valid(const Print &print
     {
         const PrintInstance *print_instance;
         BoundingBox    bounding_box;
+        BoundingBox    true_bounding_box;
         Polygon        hull_polygon;
         int                  object_index;
         double         arrange_score;
@@ -740,7 +741,7 @@ StringObjectException Print::sequential_print_clearance_valid(const Print &print
                         if (has_exception) break;
                     }
                 }
-                struct print_instance_info print_info {&instance, convex_hull.bounding_box(), convex_hull};
+                struct print_instance_info print_info {&instance, convex_hull.bounding_box(), convex_hull_no_offset.bounding_box(), convex_hull};
                 print_info.height = instance.print_object->height();
                 print_info.object_index = find_object_index(print.model(), print_object->model_object());
                 print_instance_with_bounding_box.push_back(std::move(print_info));
@@ -757,8 +758,7 @@ StringObjectException Print::sequential_print_clearance_valid(const Print &print
         }
     }
 
-    // calc sort order
-    double hc1              = scale_(print.config().extruder_clearance_height_to_lid); // height to lid
+    // Heights measured from the nozzle: hc2 is the clearance to the gantry rod, printable_height the build volume top.
     double hc2              = scale_(print.config().extruder_clearance_height_to_rod); // height to rod
     double printable_height = scale_(print.config().printable_height);
 
@@ -867,61 +867,26 @@ StringObjectException Print::sequential_print_clearance_valid(const Print &print
 #endif
     // sequential_print_vertical_clearance_valid
     {
-        // Ignore the last instance printed.
-        //print_instance_with_bounding_box.pop_back();
-        /*bool has_interlaced_objects = false;
-        for (int k = 0; k < print_instance_count; k++)
-        {
-            auto inst = print_instance_with_bounding_box[k].print_instance;
-            auto bbox = print_instance_with_bounding_box[k].bounding_box;
-            auto iy1 = bbox.min.y();
-            auto iy2 = bbox.max.y();
-
-            for (int i = 0; i < k; i++)
-            {
-                auto& p = print_instance_with_bounding_box[i].print_instance;
-                auto bbox2 = print_instance_with_bounding_box[i].bounding_box;
-                auto py1 = bbox2.min.y();
-                auto py2 = bbox2.max.y();
-                auto inter_min = std::max(iy1, py1); // min y of intersection
-                auto inter_max = std::min(iy2, py2); // max y of intersection. length=max_y-min_y>0 means intersection exists
-                if (inter_max - inter_min > 0) {
-                    has_interlaced_objects = true;
-                    break;
-                }
-            }
-            if (has_interlaced_objects)
-                break;
-        }*/
-
-        // if objects are not overlapped on y-axis, they will not collide even if they are taller than extruder_clearance_height_to_rod
+        // Dynamic max height for "by object" printing. A gantry parallel to the X axis spans the whole
+        // plate at the toolhead's Y position, so an instance can only collide with the gantry while a
+        // later-printed instance (already at full height) shares its Y band, i.e. the two are placed
+        // side by side along the X axis. Instances in their own Y band never sit under the gantry
+        // together with another object, so they may use the full build volume height. The Y band test
+        // uses the un-inflated bounding boxes: horizontal separation is already enforced by the
+        // extruder_clearance_radius collision check above.
         int print_instance_count = print_instance_with_bounding_box.size();
         std::map<const PrintInstance*, std::pair<Polygon, float>> too_tall_instances;
         for (int k = 0; k < print_instance_count; k++)
         {
             auto inst = print_instance_with_bounding_box[k].print_instance;
-            // 只需要考虑喷嘴到滑杆的偏移量，这个比整个工具头的碰撞半径要小得多
-            // Only the offset from the nozzle to the slide bar needs to be considered, which is much smaller than the collision radius of the entire tool head.
-            auto bbox = print_instance_with_bounding_box[k].bounding_box.inflated(-scale_(0.5 * print.config().extruder_clearance_radius.value + object_skirt_offset));
+            auto& bbox = print_instance_with_bounding_box[k].true_bounding_box;
             auto iy1 = bbox.min.y();
             auto iy2 = bbox.max.y();
             (const_cast<ModelInstance*>(inst->model_instance))->arrange_order = k+1;
-            double height = (k == (print_instance_count - 1))?printable_height:hc1;
-            /*if (has_interlaced_objects) {
-                if ((k < (print_instance_count - 1)) && (inst->print_object->height() > hc2)) {
-                    too_tall_instances[inst] = std::make_pair(print_instance_with_bounding_box[k].hull_polygon, unscaled<double>(hc2));
-                }
-            }
-            else {
-                if ((k < (print_instance_count - 1)) && (inst->print_object->height() > hc1)) {
-                    too_tall_instances[inst] = std::make_pair(print_instance_with_bounding_box[k].hull_polygon, unscaled<double>(hc1));
-                }
-            }*/
-
+            double height = printable_height;
             for (int i = k+1; i < print_instance_count; i++)
             {
-                auto& p = print_instance_with_bounding_box[i].print_instance;
-                auto bbox2 = print_instance_with_bounding_box[i].bounding_box;
+                auto& bbox2 = print_instance_with_bounding_box[i].true_bounding_box;
                 auto py1 = bbox2.min.y();
                 auto py2 = bbox2.max.y();
                 auto inter_min = std::max(iy1, py1); // min y of intersection

--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -5736,11 +5736,14 @@ void GLCanvas3D::update_sequential_clearance()
     // Dynamic max height for "by object" printing, mirroring Print::sequential_print_vertical_clearance_valid():
     // a gantry parallel to the X axis only collides with instances sharing their Y band with a later-printed
     // instance (side by side along X); instances in their own Y band may use the full build volume height.
-    // The bounding boxes of the cached (inflated) hulls are shrunk back by shrink_factor to the un-inflated
-    // ones, which is exact for convex hulls.
+    // Delta printers are excluded (their arms sweep over the whole plate), and the last-printed instance
+    // may always use the full height. The bounding boxes of the cached (inflated) hulls are shrunk back by
+    // shrink_factor to the un-inflated ones, which is exact for convex hulls.
     int bounding_box_count = convex_and_bounding_boxes.size();
     double printable_height = fff_print()->config().printable_height;
+    double hc1 = fff_print()->config().extruder_clearance_height_to_lid;
     double hc2 = fff_print()->config().extruder_clearance_height_to_rod;
+    const bool dynamic_max_height = fff_print()->config().printer_structure.value != psDelta;
     const coord_t shrink = static_cast<coord_t>(shrink_factor);
     for (int k = 0; k < bounding_box_count; k++)
     {
@@ -5748,7 +5751,7 @@ void GLCanvas3D::update_sequential_clearance()
         BoundingBox bbox = convex_and_bounding_boxes[k].bounding_box.inflated(-shrink);
         auto iy1 = bbox.min.y();
         auto iy2 = bbox.max.y();
-        double height = printable_height;
+        double height = (dynamic_max_height || k == (bounding_box_count - 1)) ? printable_height : hc1;
         for (int i = k+1; i < bounding_box_count; i++)
         {
             BoundingBox next_bbox = convex_and_bounding_boxes[i].bounding_box.inflated(-shrink);

--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -5635,17 +5635,20 @@ void GLCanvas3D::update_sequential_clearance()
             transform = v->get_instance_transformation();
     }
 
+    // The 2d hulls are inflated by shrink_factor (same amount as Print::sequential_print_horizontal_clearance_valid);
+    // the height check below shrinks the bounding boxes back by this amount to get the un-inflated ones.
+    auto [object_skirt_offset, _] = fff_print()->object_skirt_offset();
+    float shrink_factor;
+    if (fff_print()->is_all_objects_are_short())
+        shrink_factor = scale_(std::max(0.5f * MAX_OUTER_NOZZLE_DIAMETER, object_skirt_offset) - 0.1);
+    else
+        shrink_factor = static_cast<float>(scale_(0.5 * fff_print()->config().extruder_clearance_radius.value + object_skirt_offset - 0.1));
+
     // calculates objects 2d hulls (see also: Print::sequential_print_horizontal_clearance_valid())
     // this is done only the first time this method is called while moving the mouse,
     // the results are then cached for following displacements
     if (m_sequential_print_clearance_first_displacement) {
         m_sequential_print_clearance.m_hull_2d_cache.clear();
-        auto [object_skirt_offset, _] = fff_print()->object_skirt_offset();
-        float shrink_factor;
-        if (fff_print()->is_all_objects_are_short())
-            shrink_factor = scale_(std::max(0.5f * MAX_OUTER_NOZZLE_DIAMETER, object_skirt_offset) - 0.1);
-        else
-            shrink_factor = static_cast<float>(scale_(0.5 * fff_print()->config().extruder_clearance_radius.value + object_skirt_offset - 0.1));
 
         double mitter_limit = scale_(0.1);
         m_sequential_print_clearance.m_hull_2d_cache.reserve(m_model->objects.size());
@@ -5730,58 +5733,25 @@ void GLCanvas3D::update_sequential_clearance()
                 return (ly1 < ry1);
         });
 
-    /*bool has_interlaced_objects = false;
-    for (int k = 0; k < bounding_box_count; k++)
-    {
-        Polygon& convex = convex_and_bounding_boxes[k].hull_polygon;
-        BoundingBox& bbox = convex_and_bounding_boxes[k].bounding_box;
-        auto iy1 = bbox.min.y();
-        auto iy2 = bbox.max.y();
-
-        for (int i = k+1; i < bounding_box_count; i++)
-        {
-            Polygon&     next_convex = convex_and_bounding_boxes[i].hull_polygon;
-            BoundingBox& next_bbox   = convex_and_bounding_boxes[i].bounding_box;
-            auto py1 = next_bbox.min.y();
-            auto py2 = next_bbox.max.y();
-            auto inter_min = std::max(iy1, py1); // min y of intersection
-            auto inter_max = std::min(iy2, py2); // max y of intersection. length=max_y-min_y>0 means intersection exists
-            if (inter_max - inter_min > 0) {
-                has_interlaced_objects = true;
-                break;
-            }
-        }
-        if (has_interlaced_objects)
-            break;
-    }*/
-
+    // Dynamic max height for "by object" printing, mirroring Print::sequential_print_vertical_clearance_valid():
+    // a gantry parallel to the X axis only collides with instances sharing their Y band with a later-printed
+    // instance (side by side along X); instances in their own Y band may use the full build volume height.
+    // The bounding boxes of the cached (inflated) hulls are shrunk back by shrink_factor to the un-inflated
+    // ones, which is exact for convex hulls.
     int bounding_box_count = convex_and_bounding_boxes.size();
     double printable_height = fff_print()->config().printable_height;
-    double hc1 = fff_print()->config().extruder_clearance_height_to_lid;
     double hc2 = fff_print()->config().extruder_clearance_height_to_rod;
+    const coord_t shrink = static_cast<coord_t>(shrink_factor);
     for (int k = 0; k < bounding_box_count; k++)
     {
         Polygon& convex = convex_and_bounding_boxes[k].hull_polygon;
-        BoundingBox& bbox = convex_and_bounding_boxes[k].bounding_box;
+        BoundingBox bbox = convex_and_bounding_boxes[k].bounding_box.inflated(-shrink);
         auto iy1 = bbox.min.y();
         auto iy2 = bbox.max.y();
-        double height = (k == (bounding_box_count - 1))?printable_height:hc1;
-
-        /*if (has_interlaced_objects) {
-            if ((k < (bounding_box_count - 1)) && (convex_and_bounding_boxes[k].instance_height > hc2)) {
-                height_polygons.emplace_back(std::make_pair(convex, hc2));
-            }
-        }
-        else {
-            if ((k < (bounding_box_count - 1)) && (convex_and_bounding_boxes[k].instance_height > hc1)) {
-                height_polygons.emplace_back(std::make_pair(convex, hc1));
-            }
-        }*/
-
+        double height = printable_height;
         for (int i = k+1; i < bounding_box_count; i++)
         {
-            Polygon&     next_convex = convex_and_bounding_boxes[i].hull_polygon;
-            BoundingBox& next_bbox   = convex_and_bounding_boxes[i].bounding_box;
+            BoundingBox next_bbox = convex_and_bounding_boxes[i].bounding_box.inflated(-shrink);
             auto py1 = next_bbox.min.y();
             auto py2 = next_bbox.max.y();
             auto inter_min = std::max(iy1, py1); // min y of intersection

--- a/tests/fff_print/test_print.cpp
+++ b/tests/fff_print/test_print.cpp
@@ -456,3 +456,62 @@ TEST_CASE("Sequential printing publishes the nozzle group result", "[Print][Mult
         CHECK(gcode.find("; SEQ-ND-OK") != std::string::npos);
     }
 }
+
+// The by-object height limit is dynamic: with a gantry parallel to the X axis only instances that
+// share their Y band with a later-printed instance are limited to the gantry (rod) clearance height;
+// instances in their own Y band may use the full build volume height.
+TEST_CASE("By-object printing allows full height for objects in separate Y bands", "[Print]")
+{
+    // Two 60 mm towers whose Y bands ([80,100] and [140,160]) do not overlap, so neither ever sits
+    // under the X gantry together with the other and the rod clearance (25 mm) must not apply;
+    // 60 mm < printable_height (100 mm) so validation passes. The lid clearance is set to the rod
+    // height like on open-frame machines (e.g. Ender 3), where it used to limit every by-object
+    // instance to the gantry.
+    Print print;
+    Model model;
+    std::vector<TriangleMesh> meshes;
+    meshes.emplace_back(Slic3r::make_cube(20, 20, 60));
+    meshes.back().translate(80, 80, 0);
+    meshes.emplace_back(Slic3r::make_cube(20, 20, 60));
+    meshes.back().translate(80, 140, 0);
+    DynamicPrintConfig config = DynamicPrintConfig::full_print_config();
+    config.set_deserialize_strict({
+        { "print_sequence",                   "by object" },
+        { "extruder_clearance_height_to_lid", 25 },
+        { "extruder_clearance_height_to_rod", 25 },
+        { "extruder_clearance_radius",        30 },
+        { "printable_height",                 100 },
+        { "skirt_loops",                      0 },
+        { "use_relative_e_distances",         0 },
+    });
+    init_print(std::move(meshes), print, model, config, nullptr, /*arrange=*/false);
+    StringObjectException ret = print.validate();
+    CHECK(ret.string.empty());
+}
+
+// With the same two towers side by side along the X axis (shared Y band [80,100]) the first-printed
+// tower sits under the X gantry while the second one is printed, so the rod clearance applies.
+TEST_CASE("By-object printing limits height for objects sharing the gantry axis", "[Print]")
+{
+    Print print;
+    Model model;
+    std::vector<TriangleMesh> meshes;
+    meshes.emplace_back(Slic3r::make_cube(20, 20, 60));
+    meshes.back().translate(80, 80, 0);
+    meshes.emplace_back(Slic3r::make_cube(20, 20, 60));
+    meshes.back().translate(140, 80, 0);
+    DynamicPrintConfig config = DynamicPrintConfig::full_print_config();
+    config.set_deserialize_strict({
+        { "print_sequence",                   "by object" },
+        { "extruder_clearance_height_to_lid", 25 },
+        { "extruder_clearance_height_to_rod", 25 },
+        { "extruder_clearance_radius",        30 },
+        { "printable_height",                 100 },
+        { "skirt_loops",                      0 },
+        { "use_relative_e_distances",         0 },
+    });
+    init_print(std::move(meshes), print, model, config, nullptr, /*arrange=*/false);
+    StringObjectException ret = print.validate();
+    CHECK_FALSE(ret.string.empty());
+    CHECK(ret.string.find("too tall") != std::string::npos);
+}

--- a/tests/fff_print/test_print.cpp
+++ b/tests/fff_print/test_print.cpp
@@ -515,3 +515,31 @@ TEST_CASE("By-object printing limits height for objects sharing the gantry axis"
     CHECK_FALSE(ret.string.empty());
     CHECK(ret.string.find("too tall") != std::string::npos);
 }
+
+// Delta printers have no X-parallel gantry: their arms sweep over the whole plate, so the dynamic
+// height limit must not apply and instances keep the conservative clearance-to-lid limit.
+TEST_CASE("By-object printing keeps the conservative height limit for delta printers", "[Print]")
+{
+    Print print;
+    Model model;
+    std::vector<TriangleMesh> meshes;
+    meshes.emplace_back(Slic3r::make_cube(20, 20, 60));
+    meshes.back().translate(80, 80, 0);
+    meshes.emplace_back(Slic3r::make_cube(20, 20, 60));
+    meshes.back().translate(80, 140, 0);
+    DynamicPrintConfig config = DynamicPrintConfig::full_print_config();
+    config.set_deserialize_strict({
+        { "print_sequence",                   "by object" },
+        { "printer_structure",                "delta" },
+        { "extruder_clearance_height_to_lid", 25 },
+        { "extruder_clearance_height_to_rod", 25 },
+        { "extruder_clearance_radius",        30 },
+        { "printable_height",                 100 },
+        { "skirt_loops",                      0 },
+        { "use_relative_e_distances",         0 },
+    });
+    init_print(std::move(meshes), print, model, config, nullptr, /*arrange=*/false);
+    StringObjectException ret = print.validate();
+    CHECK_FALSE(ret.string.empty());
+    CHECK(ret.string.find("too tall") != std::string::npos);
+}


### PR DESCRIPTION
## Description

With a gantry parallel to the X axis, an object printed in "by object" sequence can only collide with the gantry while a later-printed object shares its Y band — i.e. the two objects are placed side by side along the X axis. Previously the per-object height limit only relaxed to the full build volume for the *last* printed instance; every other instance was limited to `extruder_clearance_height_to_lid`, which on open-frame machines (e.g. Ender 3) is set to the gantry height and therefore limited every instance to the gantry.

This change makes the height limit dynamic and layout-dependent:

| Layout | Before | After |
|---|---|---|
| Two towers side by side on the X axis (shared Y band) | Gantry height (`extruder_clearance_height_to_rod`) | Gantry height (unchanged) |
| Two towers side by side on the Y axis (own Y bands) | Gantry height (via `extruder_clearance_height_to_lid`) | Full build volume height (`printable_height`) |

Delta printers are excluded: their arms sweep over the whole plate, so the conservative clearance-to-lid limit keeps applying to them.

## Evidence
[demo-height.webm](https://github.com/user-attachments/assets/318c9368-8cb9-4638-ae4d-eafc56555ba2)

This shows that you cannot print multiple tall items on the same axis (because the gantry arm would collide. This change allows you to offset the objects so that printing tall objects, object-by-object, is okay.

## Changes

- `Print::sequential_print_clearance_valid()`: each instance defaults to `printable_height` and is limited to `extruder_clearance_height_to_rod` only when a later-printed instance shares its Y band. The Y-band test now uses the un-inflated bounding boxes (horizontal separation is already enforced by the `extruder_clearance_radius` collision check). The dynamic rule is gated on `printer_structure != psDelta`.
- `GLCanvas3D::update_sequential_clearance()`: mirrors the same logic for the live 3D clearance feedback.
- Tests in `tests/fff_print/test_print.cpp`: full height allowed for objects in separate Y bands, rod-height limit kept for objects sharing the gantry axis, and the conservative limit kept for delta printers.

## Verification

- `fff_print` test suite: 115/115 pass (3 new tests included).
- `GLCanvas3D.cpp` compiles standalone (MSBuild file-level build).