### PR TITLE
feat(snapmaker): add filament mapping and calibration options for Snapmaker U1

### DIFF
--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -17249,6 +17249,11 @@ void Plater::send_gcode_legacy(int plate_idx, Export3mfProgressFn proFn)
                                                                  storage_paths, storage_names,
                                                                  config->get_bool("open_device_tab_post_upload"),
                                                                  upload_job.printhost.get());
+        } else if (preset_bundle->printers.get_edited_preset().config.opt_string("printer_agent") == "snapmaker") {
+            pDlg = std::make_unique<SnapmakerPrintHostSendDialog>(default_output_file, upload_job.printhost->get_post_upload_actions(), groups,
+                                                                  storage_paths, storage_names,
+                                                                  config->get_bool("open_device_tab_post_upload"),
+                                                                  upload_job.printhost.get());
         } else if (flashforge_local_api) {
             auto* flashforge_host = dynamic_cast<Flashforge*>(upload_job.printhost.get());
             if (flashforge_host == nullptr) {

--- a/src/slic3r/GUI/PrintHostDialogs.cpp
+++ b/src/slic3r/GUI/PrintHostDialogs.cpp
@@ -36,6 +36,7 @@
 #include "ExtraRenderers.hpp"
 #include "format.hpp"
 #include "../Utils/CrealityPrint.hpp"
+#include "../Utils/Moonraker.hpp"
 #include "BitmapComboBox.hpp"
 #include "wxExtensions.hpp"
 
@@ -2103,6 +2104,255 @@ std::map<std::string, std::string> CrealityPrintHostSendDialog::extendedInfo() c
         }
     }
 
+    return info;
+}
+
+SnapmakerPrintHostSendDialog::SnapmakerPrintHostSendDialog(const boost::filesystem::path& path,
+                                                         PrintHostPostUploadActions     post_actions,
+                                                         const wxArrayString&           groups,
+                                                         const wxArrayString&           storage_paths,
+                                                         const wxArrayString&           storage_names,
+                                                         bool                           switch_to_device_tab,
+                                                         PrintHost*                     printhost)
+    : PrintHostSendDialog(path, post_actions, groups, storage_paths, storage_names, switch_to_device_tab)
+    , m_autoBedLeveling(false)
+    , m_flowCalibrate(false)
+    , m_printhost(printhost)
+{}
+
+void SnapmakerPrintHostSendDialog::init()
+{
+    PrintHostSendDialog::init();
+
+    auto* moonraker_host = static_cast<Moonraker*>(m_printhost);
+    std::string api_key = moonraker_host->get_apikey();
+    std::string host = moonraker_host->get_host();
+
+    std::string url = host;
+    if (url.find("http://") != 0 && url.find("https://") != 0) {
+        url = "http://" + url;
+    }
+    if (url.back() == '/') {
+        url += "printer/objects/query?print_task_config";
+    } else {
+        url += "/printer/objects/query?print_task_config";
+    }
+
+    {
+        wxBusyCursor wait;
+        std::string response_body;
+        bool success = false;
+        auto http = Http::get(url);
+        if (!api_key.empty()) {
+            http.header("X-Api-Key", api_key);
+        }
+        if (!moonraker_host->get_cafile().empty()) {
+            http.ca_file(moonraker_host->get_cafile());
+        }
+        http.timeout_connect(5)
+            .timeout_max(10)
+            .on_complete([&](std::string body, unsigned status) {
+                if (status == 200) {
+                    response_body = body;
+                    success = true;
+                }
+            })
+            .perform_sync();
+
+        if (success && !response_body.empty()) {
+            try {
+                auto resp = nlohmann::json::parse(response_body);
+                if (resp.contains("result") && resp["result"].contains("status") && resp["result"]["status"].contains("print_task_config")) {
+                    auto& ptc = resp["result"]["status"]["print_task_config"];
+                    auto filament_exist = ptc.value("filament_exist", std::vector<bool>{});
+                    auto filament_type = ptc.value("filament_type", std::vector<std::string>{});
+                    auto filament_sub_type = ptc.value("filament_sub_type", std::vector<std::string>{});
+                    auto filament_color = ptc.value("filament_color_rgba", std::vector<std::string>{});
+                    auto filament_vendor = ptc.value("filament_vendor", std::vector<std::string>{});
+
+                    for (size_t i = 0; i < filament_exist.size(); ++i) {
+                        if (!filament_exist[i]) continue;
+                        
+                        std::string type = (i < filament_type.size()) ? filament_type[i] : "";
+                        std::string sub_type = (i < filament_sub_type.size()) ? filament_sub_type[i] : "";
+                        std::string color = (i < filament_color.size()) ? filament_color[i] : "FFFFFFFF";
+                        std::string vendor = (i < filament_vendor.size()) ? filament_vendor[i] : "";
+
+                        // Normalize color from RRGGBBAA to #RRGGBB
+                        if (color.size() == 8) {
+                            color = "#" + color.substr(0, 6);
+                        } else if (color.size() == 9 && color[0] == '#') {
+                            color = color.substr(0, 7);
+                        } else if (color.size() == 7 && color[0] == '#') {
+                            // already ok
+                        } else {
+                            color = "#FFFFFF";
+                        }
+
+                        // Combine type and sub_type
+                        std::string combined_type = type;
+                        if (!sub_type.empty() && sub_type != "NONE") {
+                            combined_type += " " + sub_type;
+                        }
+
+                        std::string tool_id = "T" + std::to_string(i);
+                        m_printer_slots.push_back({ tool_id, combined_type, color, (int)i });
+                    }
+                }
+            } catch (...) {
+                BOOST_LOG_TRIVIAL(error) << "SnapmakerPrint dialog: Failed to parse print_task_config";
+            }
+        }
+    }
+
+    auto* group_box = new wxStaticBox(this, wxID_ANY, _L("Printer: Snapmaker"));
+    auto* group_sizer = new wxStaticBoxSizer(group_box, wxVERTICAL);
+    content_sizer->Add(group_sizer, 0, wxEXPAND);
+
+    const AppConfig* app_config = wxGetApp().app_config;
+    std::string saved_leveling = app_config->get("recent", CONFIG_KEY_AUTOLEVELING);
+    if (!saved_leveling.empty()) {
+        try { m_autoBedLeveling = std::stoi(saved_leveling) != 0; } catch (...) {}
+    }
+    std::string saved_flow = app_config->get("recent", CONFIG_KEY_FLOWCALIB);
+    if (!saved_flow.empty()) {
+        try { m_flowCalibrate = std::stoi(saved_flow) != 0; } catch (...) {}
+    }
+
+    // Checkbox for Auto Bed Leveling
+    {
+        auto checkbox_sizer = new wxBoxSizer(wxHORIZONTAL);
+        auto checkbox       = new ::CheckBox(this);
+        checkbox->SetValue(m_autoBedLeveling);
+        checkbox->Bind(wxEVT_TOGGLEBUTTON, [this, checkbox](wxCommandEvent& e) {
+            m_autoBedLeveling = checkbox->GetValue();
+            AppConfig* ac = wxGetApp().app_config;
+            ac->set("recent", CONFIG_KEY_AUTOLEVELING, m_autoBedLeveling ? "1" : "0");
+            e.Skip();
+        });
+        checkbox_sizer->Add(checkbox, 0, wxALL | wxALIGN_CENTER, FromDIP(2));
+        auto checkbox_text = new wxStaticText(this, wxID_ANY, _L("Calibrate bed before printing"), wxDefaultPosition, wxDefaultSize, 0);
+        checkbox_sizer->Add(checkbox_text, 0, wxALL | wxALIGN_CENTER, FromDIP(2));
+        checkbox_text->SetFont(::Label::Body_13);
+        checkbox_text->SetForegroundColour(StateColor::darkModeColorFor(wxColour("#323A3D")));
+        group_sizer->Add(checkbox_sizer);
+        group_sizer->AddSpacer(VERT_SPACING);
+    }
+    // Checkbox for Flow Calibration
+    {
+        auto checkbox_sizer = new wxBoxSizer(wxHORIZONTAL);
+        auto checkbox       = new ::CheckBox(this);
+        checkbox->SetValue(m_flowCalibrate);
+        checkbox->Bind(wxEVT_TOGGLEBUTTON, [this, checkbox](wxCommandEvent& e) {
+            m_flowCalibrate = checkbox->GetValue();
+            AppConfig* ac = wxGetApp().app_config;
+            ac->set("recent", CONFIG_KEY_FLOWCALIB, m_flowCalibrate ? "1" : "0");
+            e.Skip();
+        });
+        checkbox_sizer->Add(checkbox, 0, wxALL | wxALIGN_CENTER, FromDIP(2));
+        auto checkbox_text = new wxStaticText(this, wxID_ANY, _L("Calibrate filament flow before printing"), wxDefaultPosition, wxDefaultSize, 0);
+        checkbox_sizer->Add(checkbox_text, 0, wxALL | wxALIGN_CENTER, FromDIP(2));
+        checkbox_text->SetFont(::Label::Body_13);
+        checkbox_text->SetForegroundColour(StateColor::darkModeColorFor(wxColour("#323A3D")));
+        group_sizer->Add(checkbox_sizer);
+        group_sizer->AddSpacer(VERT_SPACING);
+    }
+
+    auto  preset_bundle    = wxGetApp().preset_bundle;
+    auto  full_config      = preset_bundle->full_config();
+    auto* filament_colors  = full_config.option<ConfigOptionStrings>("filament_colour");
+    auto* filament_types   = full_config.option<ConfigOptionStrings>("filament_type");
+    int   gcode_filament_count = filament_colors ? (int)filament_colors->values.size() : 0;
+
+    if (gcode_filament_count > 0 && !m_printer_slots.empty()) {
+        auto* label = new wxStaticText(this, wxID_ANY, _L("Filament Mapping:"));
+        label->SetFont(::Label::Body_13);
+        label->SetForegroundColour(StateColor::darkModeColorFor(wxColour("#323A3D")));
+        group_sizer->Add(label);
+        group_sizer->AddSpacer(4);
+
+        for (int i = 0; i < gcode_filament_count; i++) {
+            auto* row_sizer = new wxBoxSizer(wxHORIZONTAL);
+
+            // Left side: G-code filament color swatch + type
+            std::string gc_color = (filament_colors && i < (int)filament_colors->values.size())
+                                   ? filament_colors->values[i] : "#FFFFFF";
+            std::string gc_type  = (filament_types && i < (int)filament_types->values.size())
+                                   ? filament_types->values[i] : "?";
+
+            auto* color_panel = new wxPanel(this, wxID_ANY, wxDefaultPosition, wxSize(FromDIP(16), FromDIP(16)));
+            color_panel->SetBackgroundColour(wxColour(gc_color));
+            color_panel->SetMinSize(wxSize(FromDIP(16), FromDIP(16)));
+            row_sizer->Add(color_panel, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(4));
+
+            auto* type_label = new wxStaticText(this, wxID_ANY,
+                wxString::Format("%d (%s)", i + 1, gc_type.c_str()));
+            type_label->SetFont(::Label::Body_13);
+            type_label->SetForegroundColour(StateColor::darkModeColorFor(wxColour("#323A3D")));
+            type_label->SetMinSize(wxSize(FromDIP(80), -1));
+            row_sizer->Add(type_label, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(8));
+
+            // Arrow
+            auto* arrow_label = new wxStaticText(this, wxID_ANY, wxString::FromUTF8("\xe2\x86\x92"));
+            arrow_label->SetFont(::Label::Body_13);
+            row_sizer->Add(arrow_label, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(8));
+
+            // Right side: dropdown with color icons per slot
+            int icon_sz = FromDIP(16);
+            auto* combo = new BitmapComboBox(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0, nullptr, wxCB_READONLY);
+            for (auto& slot : m_printer_slots) {
+                wxBitmap* bmp = get_extruder_color_icon(slot.color, "", icon_sz, icon_sz);
+                wxString label_str = wxString::Format("%s - %s", slot.tool_id.c_str(), slot.type.c_str());
+                combo->Append(label_str, bmp ? *bmp : wxNullBitmap);
+            }
+
+            int default_sel = (i < (int)m_printer_slots.size()) ? i : 0;
+            // Match logic (type & color)
+            bool matched = false;
+            for (int pass = 0; pass < 2 && !matched; pass++) {
+                for (int s = 0; s < (int)m_printer_slots.size(); s++) {
+                    bool type_match = (m_printer_slots[s].type == gc_type);
+                    bool color_match = (wxColour(m_printer_slots[s].color) == wxColour(gc_color));
+                    bool hit = false;
+                    switch (pass) {
+                    case 0: hit = type_match && color_match; break;
+                    case 1: hit = type_match; break;
+                    }
+                    if (hit) {
+                        default_sel = s;
+                        matched = true;
+                        break;
+                    }
+                }
+            }
+            combo->SetSelection(default_sel);
+            row_sizer->Add(combo, 0, wxALIGN_CENTER_VERTICAL);
+
+            group_sizer->Add(row_sizer);
+            group_sizer->AddSpacer(4);
+            m_slot_combos.push_back(combo);
+        }
+    }
+
+    this->Layout();
+    this->Fit();
+}
+
+std::map<std::string, std::string> SnapmakerPrintHostSendDialog::extendedInfo() const
+{
+    std::map<std::string, std::string> info;
+    info["is_snapmaker"] = "1";
+    info["auto_bed_leveling"] = m_autoBedLeveling ? "1" : "0";
+    info["flow_calibrate"] = m_flowCalibrate ? "1" : "0";
+
+    for (int i = 0; i < (int)m_slot_combos.size(); i++) {
+        int sel = m_slot_combos[i]->GetSelection();
+        if (sel >= 0 && sel < (int)m_printer_slots.size()) {
+            info["colorMatch_" + std::to_string(i)] = std::to_string(m_printer_slots[sel].slot_id);
+        } else {
+            info["colorMatch_" + std::to_string(i)] = "-1";
+        }
+    }
     return info;
 }
 

--- a/src/slic3r/GUI/PrintHostDialogs.hpp
+++ b/src/slic3r/GUI/PrintHostDialogs.hpp
@@ -219,6 +219,38 @@ private:
     std::vector<BitmapComboBox*> m_slot_combos; // one per gcode filament
 };
 
+class SnapmakerPrintHostSendDialog : public PrintHostSendDialog
+{
+public:
+    SnapmakerPrintHostSendDialog(const boost::filesystem::path& path,
+                                 PrintHostPostUploadActions     post_actions,
+                                 const wxArrayString&           groups,
+                                 const wxArrayString&           storage_paths,
+                                 const wxArrayString&           storage_names,
+                                 bool                           switch_to_device_tab,
+                                 PrintHost*                     printhost);
+
+    virtual void                               init() override;
+    virtual std::map<std::string, std::string> extendedInfo() const;
+
+private:
+    static constexpr const char* CONFIG_KEY_AUTOLEVELING = "snapmaker_auto_bed_leveling";
+    static constexpr const char* CONFIG_KEY_FLOWCALIB    = "snapmaker_flow_calibrate";
+
+    bool        m_autoBedLeveling;
+    bool        m_flowCalibrate;
+    PrintHost*  m_printhost;
+
+    struct SlotInfo {
+        std::string tool_id;   // e.g. "T0"
+        std::string type;      // e.g. "PLA"
+        std::string color;     // e.g. "#ffffff"
+        int         slot_id;
+    };
+    std::vector<SlotInfo>   m_printer_slots;
+    std::vector<BitmapComboBox*> m_slot_combos; // one per gcode filament
+};
+
 class FlashforgePrintHostSendDialog : public PrintHostSendDialog
 {
 public:

--- a/src/slic3r/Utils/Moonraker.cpp
+++ b/src/slic3r/Utils/Moonraker.cpp
@@ -1,12 +1,15 @@
 #include "Moonraker.hpp"
 
 #include <sstream>
+#include <fstream>
+#include <algorithm>
 
 #include <boost/format.hpp>
 #include <boost/log/trivial.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/json_parser.hpp>
 
+#include <nlohmann/json.hpp>
 #include "libslic3r/PrintConfig.hpp"
 #include "slic3r/GUI/I18N.hpp"
 #include "slic3r/GUI/GUI.hpp"
@@ -210,6 +213,40 @@ bool Moonraker::start_print(wxString &error_msg, const std::string &filename) co
     return res;
 }
 
+static void parse_filament_stats(const boost::filesystem::path& path, std::map<std::string, std::string>& extended_info)
+{
+    std::ifstream file(path.string(), std::ios::binary | std::ios::ate);
+    if (!file.is_open()) return;
+
+    std::streamsize size = file.tellg();
+    std::streamsize read_size = std::min(size, (std::streamsize)65536);
+    file.seekg(size - read_size);
+
+    std::string buffer(read_size, '\0');
+    if (!file.read(&buffer[0], read_size)) return;
+
+    auto extract_list = [](const std::string& buf, const std::string& prefix) -> std::string {
+        size_t pos = buf.rfind(prefix);
+        if (pos == std::string::npos) return "";
+        size_t start = pos + prefix.length();
+        size_t end = buf.find('\n', start);
+        if (end == std::string::npos) end = buf.length();
+        std::string line = buf.substr(start, end - start);
+        if (!line.empty() && line.back() == '\r') line.pop_back();
+        return "[" + line + "]";
+    };
+
+    std::string used_mm = extract_list(buffer, "; filament used [mm] = ");
+    std::string used_g = extract_list(buffer, "; filament used [g] = ");
+
+    if (!used_mm.empty()) {
+        extended_info["filament_used_mm"] = used_mm;
+    }
+    if (!used_g.empty()) {
+        extended_info["filament_used_g"] = used_g;
+    }
+}
+
 bool Moonraker::upload(PrintHostUpload upload_data, ProgressFn progress_fn, ErrorFn error_fn, InfoFn info_fn) const
 {
     //ORCA: POST /server/files/upload as multipart/form-data with:
@@ -308,12 +345,107 @@ bool Moonraker::upload(PrintHostUpload upload_data, ProgressFn progress_fn, Erro
 
     if (upload_data.post_action == PrintHostPostUploadAction::StartPrint && !uploaded_path.empty()) {
         wxString start_msg;
-        if (!start_print(start_msg, uploaded_path)) {
+        parse_filament_stats(upload_data.source_path, upload_data.extended_info);
+        if (!start_print(start_msg, uploaded_path, upload_data.extended_info)) {
             error_fn(std::move(start_msg));
             return false;
         }
     }
     return true;
+}
+
+bool Moonraker::start_print(wxString &error_msg, const std::string &filename, const std::map<std::string, std::string>& extended_info) const
+{
+    auto it_is_sm = extended_info.find("is_snapmaker");
+    bool is_snapmaker = (it_is_sm != extended_info.end() && it_is_sm->second == "1");
+
+    if (!is_snapmaker) {
+        return start_print(error_msg, filename);
+    }
+
+    const char *name = get_name();
+    bool res = true;
+    auto url = make_url("printer/gcode/script");
+
+    std::string safe_filename = filename;
+    if (!safe_filename.empty() && safe_filename[0] == '/') {
+        safe_filename = safe_filename.substr(1);
+    }
+
+    std::string escaped_filename;
+    for (char c : safe_filename) {
+        if (c == '"') escaped_filename += "\\\"";
+        else escaped_filename += c;
+    }
+
+    std::string script = "SDCARD_PRINT_FILE_WITH_PARAMETERS FILENAME=\"" + escaped_filename + "\"";
+
+    std::string map_table_str = "[";
+    bool first = true;
+    for (int i = 0; ; i++) {
+        auto it_map = extended_info.find("colorMatch_" + std::to_string(i));
+        if (it_map == extended_info.end())
+            break;
+        try {
+            int physical_slot = std::stoi(it_map->second);
+            if (physical_slot != -1) {
+                if (!first) map_table_str += ",";
+                map_table_str += "[" + std::to_string(i) + "," + std::to_string(physical_slot) + "]";
+                first = false;
+            }
+        } catch (...) {}
+    }
+    map_table_str += "]";
+    if (map_table_str != "[]") {
+        script += " MAP_TABLE=\"" + map_table_str + "\"";
+    }
+
+    auto it_abl = extended_info.find("auto_bed_leveling");
+    int bed_level = (it_abl != extended_info.end() && it_abl->second == "1") ? 1 : 0;
+    script += " BED_LEVEL=" + std::to_string(bed_level);
+
+    auto it_flow = extended_info.find("flow_calibrate");
+    int flow_calibrate = (it_flow != extended_info.end() && it_flow->second == "1") ? 1 : 0;
+    script += " FLOW_CALIBRATE=" + std::to_string(flow_calibrate);
+
+    script += " SHAPER_CALIBRATE=0";
+
+    auto it_used_g = extended_info.find("filament_used_g");
+    if (it_used_g != extended_info.end()) {
+        script += " FILAMENT_USED_G=\"" + it_used_g->second + "\"";
+    }
+
+    auto it_used_mm = extended_info.find("filament_used_mm");
+    if (it_used_mm != extended_info.end()) {
+        script += " FILAMENT_USED_MM=\"" + it_used_mm->second + "\"";
+    }
+
+    nlohmann::json json_payload;
+    json_payload["script"] = script;
+    std::string body = json_payload.dump();
+
+    BOOST_LOG_TRIVIAL(info) << boost::format("%1%: Starting Snapmaker print of %2% via gcode script at %3%") % name % filename % url;
+    BOOST_LOG_TRIVIAL(debug) << boost::format("%1%: Snapmaker print payload: %2%") % name % body;
+
+    auto http = Http::post(std::move(url));
+    set_auth(http);
+    http.header("Content-Type", "application/json")
+        .set_post_body(body)
+        .on_complete([&](std::string body, unsigned status) {
+            BOOST_LOG_TRIVIAL(debug) << boost::format("%1%: start_local_print HTTP %2%: %3%") % name % status % body;
+        })
+        .on_error([&](std::string body, std::string error, unsigned status) {
+            BOOST_LOG_TRIVIAL(error) << boost::format("%1%: Error starting Snapmaker print at %2%: %3%, HTTP %4%, body: `%5%`")
+                % name % url % error % status % body;
+            res = false;
+            error_msg = format_error(body, error, status);
+        })
+#ifdef WIN32
+        .ssl_revoke_best_effort(m_ssl_revoke_best_effort)
+#endif
+        .perform_sync();
+
+    return res;
 }
 
 }

--- a/src/slic3r/Utils/Moonraker.hpp
+++ b/src/slic3r/Utils/Moonraker.hpp
@@ -56,6 +56,7 @@ protected:
     void set_auth(Http &http) const;
     std::string make_url(const std::string &path) const;
     bool start_print(wxString &error_msg, const std::string &filename) const;
+    bool start_print(wxString &error_msg, const std::string &filename, const std::map<std::string, std::string>& extended_info) const;
 };
 
 }


### PR DESCRIPTION
**NOTE: There is this PR https://github.com/OrcaSlicer/OrcaSlicer/pull/15145 which does something similar and is probably more polished than mine. This one is much simpler. Please cancel this PR at your consideration.**

This PR adds native filament mapping and calibration options for Snapmaker U1 printers. It allows users to map logical extruders to physical extruder slots and configure bed leveling, shaper calibration, and flow calibration.

#### **Key Features & Bug Fixes Included:**
1. **Material Mapping & Custom Settings Dialog:** Native C++ implementation of the Snapmaker slot selection dialog and widget mapping.
2. **Start Print API Integration:** Uses the standard `/printer/gcode/script` HTTP API with the Klipper macro `SDCARD_PRINT_FILE_WITH_PARAMETERS` to execute print jobs over HTTP (bypassing WebSocket-only methods which returned `-32601 Method not found for transport HTTP` errors).
3. **Active Extruder Flow Calibration:** Parsed G-code filament statistics (grams and millimeters) from the generated file before upload to send to Klipper via `FILAMENT_USED_G` and `FILAMENT_USED_MM`. This informs Klipper which extruders are actually active in the print job, preventing it from skipping flow calibration.

#### **Files Modified**
* `src/slic3r/GUI/Plater.cpp`
* `src/slic3r/GUI/PrintHostDialogs.cpp`
* `src/slic3r/GUI/PrintHostDialogs.hpp`
* `src/slic3r/Utils/Moonraker.cpp`
* `src/slic3r/Utils/Moonraker.hpp`

#### **How to Verify**
1. Connect a Snapmaker U1 printer via Moonraker print host.
2. Slice a model, open the Send dialog, and select "Calibrate bed before printing" and "Calibrate filament flow before printing".
3. Map the filaments to active physical slots and send to print.
4. Verify that:
   - The print starts automatically without HTTP errors.
   - The printer successfully initiates bed leveling and runs filament flow calibration on the active tool(s).

<img width="645" height="631" alt="imagen" src="https://github.com/user-attachments/assets/c6c1bbf9-aeca-4cef-be6a-9e7b41d7ec0b" />
