### PR TITLE
Fix Celsius symbol rendering in Preview

### DIFF
--- a/deps_src/imgui/imgui_draw.cpp
+++ b/deps_src/imgui/imgui_draw.cpp
@@ -2856,6 +2856,7 @@ const ImWchar*   ImFontAtlas::GetGlyphRangesDefault()
     {
         0x0020, 0x00FF, // Basic Latin + Latin Supplement
         0x2000, 0x206F, // General Punctuation
+        0x2103, 0x2103, // ℃ Celsius symbol
         0x3000, 0x30FF, // CJK Symbols and Punctuations, Hiragana, Katakana
         0x31F0, 0x31FF, // Katakana Phonetic Extensions
         0xFF00, 0xFFEF, // Half-width characters

--- a/src/slic3r/GUI/ImGuiWrapper.cpp
+++ b/src/slic3r/GUI/ImGuiWrapper.cpp
@@ -2809,10 +2809,24 @@ void ImGuiWrapper::init_font(bool compress)
         }
     }
 
+    if (m_glyph_ranges == ImGui::GetIO().Fonts->GetGlyphRangesThai()) {
+        ImFontConfig fallback_cfg = cfg;
+        fallback_cfg.MergeMode = true;
+        static constexpr ImWchar celsius_range[] = { 0x2103, 0x2103, 0 };
+        io.Fonts->AddFontFromFileTTF((Slic3r::resources_dir() + "/fonts/HarmonyOS_Sans_SC_Regular.ttf").c_str(), m_font_size, &fallback_cfg, celsius_range);
+    }
+
     bold_font        = io.Fonts->AddFontFromFileTTF((Slic3r::resources_dir() + "/fonts/" + font_name_bold).c_str(), m_font_size, &cfg, ranges.Data);
     if (bold_font == nullptr) {
         bold_font = io.Fonts->AddFontDefault();
         if (bold_font == nullptr) { throw Slic3r::RuntimeError("ImGui: Could not load deafult font"); }
+    }
+
+    if (m_glyph_ranges == ImGui::GetIO().Fonts->GetGlyphRangesThai()) {
+        ImFontConfig fallback_cfg = cfg;
+        fallback_cfg.MergeMode = true;
+        static constexpr ImWchar celsius_range[] = { 0x2103, 0x2103, 0 };
+        io.Fonts->AddFontFromFileTTF((Slic3r::resources_dir() + "/fonts/HarmonyOS_Sans_SC_Bold.ttf").c_str(), m_font_size, &fallback_cfg, celsius_range);
     }
 
     if (m_glyph_ranges == ImGui::GetIO().Fonts->GetGlyphRangesThai()) {


### PR DESCRIPTION
## Summary

Fixes Preview rendering `℃` as `?` after the unit standardization in #14631.

- Add U+2103 (`℃`) to ImGui's default glyph range.
- Merge the existing HarmonyOS Sans Celsius glyph into Thai Sarabun regular and bold font atlases, as Sarabun does not provide it.

## Screenshots

|Before|After|
|---|---|
|<img width="437" height="550" alt="image" src="https://github.com/user-attachments/assets/b89d9de3-a5ce-4528-80cf-b71ad8638cc0" />|<img width="437" height="547" alt="image" src="https://github.com/user-attachments/assets/606993dc-2144-4b6c-b399-d622e584d461" />|

<br>
<br>

|Before|After|
|---|---|
|<img width="463" height="307" alt="image" src="https://github.com/user-attachments/assets/04a1c835-5aec-4439-8e53-18583e118b38" />|<img width="464" height="307" alt="image" src="https://github.com/user-attachments/assets/fcc70854-620a-4fc3-8c6e-15775e85e4b6" />|

<br>

---

Fixes https://github.com/OrcaSlicer/OrcaSlicer/pull/14631#issuecomment-5171637822
