### PR TITLE
Fix internal bridges over Hilbert Curve/Octagram Spiral sparse infill

### DIFF
--- a/src/libslic3r/Fill/Fill.cpp
+++ b/src/libslic3r/Fill/Fill.cpp
@@ -11,7 +11,7 @@
 
 #include "AABBTreeLines.hpp"
 #include "ExtrusionEntity.hpp"
-#include "FillBase.hpp"
+#include "Fill.hpp"
 #include "FillRectilinear.hpp"
 #include "FillLightning.hpp"
 #include "FillConcentricInternal.hpp"
@@ -1583,6 +1583,10 @@ Polylines Layer::generate_sparse_infill_polylines_for_anchoring(FillAdaptive::Oc
         params.multiline         = surface_fill.params.multiline;
         params.gyroid_optimized          = surface_fill.params.gyroid_optimized;
         params.smooth_factor             = surface_fill.params.smooth_factor;
+        // Orca: Match make_fills() when choosing the origin of plane-path patterns.
+        // Without the sparse extrusion role, the filler uses each surface's bounds
+        // instead of the object's bounds, so bridge anchors shift away from printed infill.
+        params.extrusion_role            = surface_fill.params.extrusion_role;
 
         for (ExPolygon &expoly : surface_fill.expolygons) {
             // Spacing is modified by the filler to indicate adjustments. Reset it for each expolygon.

--- a/src/libslic3r/Fill/Fill.cpp
+++ b/src/libslic3r/Fill/Fill.cpp
@@ -1234,6 +1234,33 @@ std::vector<SurfaceFill> group_fills(const Layer &layer, LockRegionParam &lock_p
 	return surface_fills;
 }
 
+// Orca: Anchors and printed infill must share the same body origin. Keep the choice
+// here so per-model surface centering and separated sparse infill cannot drift apart.
+static BoundingBox infill_bounding_box(const Layer &layer, const SurfaceFill &fill, const ExPolygon &expoly, BoundingBox bbox)
+{
+    const auto &params = fill.params;
+    const auto &config = layer.regions()[fill.region_id]->region().config();
+    const bool external = params.extrusion_role == erTopSolidInfill || params.extrusion_role == erBottomSurface;
+    const bool per_model = external && params.center_of_surface_pattern == CenterOfSurfacePattern::Each_Model &&
+                           (params.pattern == ipArchimedeanChords || params.pattern == ipOctagramSpiral);
+    const bool separate = !external && params.separated_infills &&
+                          (is_separable_infill_pattern(params.pattern) || !config.solid_infill_rotate_template.value.empty() ||
+                           !config.sparse_infill_rotate_template.value.empty());
+    if (per_model || separate) {
+        double best_overlap = 0.;
+        for (size_t i = 0; i < layer.lslices.size() && i < layer.lslices_separated_component_bboxes.size(); ++i) {
+            const double overlap = area(intersection_ex(layer.lslices[i], expoly));
+            if (overlap > best_overlap) {
+                best_overlap = overlap;
+                const Point center = layer.lslices_separated_component_bboxes[i].center();
+                bbox = layer.object()->bounding_box();
+                bbox.translate(center.x(), center.y());
+            }
+        }
+    }
+    return bbox;
+}
+
 #ifdef SLIC3R_DEBUG_SLICE_PROCESSING
 void export_group_fills_to_svg(const char *path, const std::vector<SurfaceFill> &fills)
 {
@@ -1353,19 +1380,9 @@ void Layer::make_fills(FillAdaptive::Octree* adaptive_fill_octree, FillAdaptive:
 
         // Orca: Checking the filling of a centered surface by drawing for each model parts
         bool is_top_or_bottom = params.extrusion_role == erTopSolidInfill || params.extrusion_role == erBottomSurface;
-        bool is_centered_infill = surface_fill.params.pattern == ipArchimedeanChords || surface_fill.params.pattern == ipOctagramSpiral;
         if (is_top_or_bottom) {
             params.center_of_surface_pattern = surface_fill.params.center_of_surface_pattern; // Orca: center of surface pattern
         }
-        // Orca: Each_Model centers the pattern on each model part's bbox; Each_Surface / Each_Assembly
-        // fall through to the default (whole-object) bounding box below.
-        bool is_per_model_center = is_top_or_bottom && params.center_of_surface_pattern == CenterOfSurfacePattern::Each_Model && is_centered_infill;
-        bool is_separate_infill = !is_top_or_bottom && surface_fill.params.separated_infills &&
-                                  (
-                                  is_separable_infill_pattern(surface_fill.params.pattern) ||
-                                  params.config->solid_infill_rotate_template != "" ||
-                                  params.config->sparse_infill_rotate_template != "" );
-
         if( surface_fill.params.pattern == ipLockedZag ) {
 			params.locked_zag = true;
             params.infill_lock_depth = surface_fill.params.infill_lock_depth;
@@ -1389,34 +1406,8 @@ void Layer::make_fills(FillAdaptive::Octree* adaptive_fill_octree, FillAdaptive:
 			params.can_reverse = false;
 		for (ExPolygon& expoly : surface_fill.expolygons) {
 
-            // Orca: separate infill / per-model pattern centering.
-            //
-            // Center the pattern on each connected body of the object independently, so every piece
-            // is filled exactly as if it were sliced on its own: touching/overlapping parts merge
-            // into one body sharing a center, while separate parts and disconnected islands (even
-            // interleaved-but-not-touching ones, e.g. chain links) each get their own. The body each
-            // island belongs to, and its full bounding box, were resolved in 3D by PrintObject::
-            // infill() (lslices_separated_component_bboxes, aligned with this layer's lslices). We
-            // match this fill region to the island it overlaps most, then re-use the whole-object
-            // bounding box (origin-centered — identical extent to the default, so coverage and cost
-            // are unchanged) re-centered on that body.
-            if (is_per_model_center || is_separate_infill) {
-                double      best_overlap = 0.;
-                BoundingBox best_component;
-                for (size_t r = 0; r < this->lslices.size() && r < this->lslices_separated_component_bboxes.size(); ++ r) {
-                    const double overlap = area(intersection_ex(this->lslices[r], expoly));
-                    if (overlap > best_overlap) {
-                        best_overlap   = overlap;
-                        best_component = this->lslices_separated_component_bboxes[r];
-                    }
-                }
-                if (best_component.defined) {
-                    const Point c         = best_component.center();
-                    BoundingBox part_bbox = bbox; // origin-centered, whole-object extent (from above)
-                    part_bbox.translate(c.x(), c.y()); // re-center on this body
-                    f->set_bounding_box(part_bbox);
-                }
-            } // - End: separate infill / per-model pattern centering
+            // Orca: Reuse the body origin used for bridge anchoring, resetting it for each surface.
+            f->set_bounding_box(infill_bounding_box(*this, surface_fill, expoly, bbox));
 
             f->no_overlap_expolygons = intersection_ex(surface_fill.no_overlap_expolygons, ExPolygons() = {expoly}, ApplySafetyOffset::Yes);
             if (params.symmetric_infill_y_axis) {
@@ -1589,6 +1580,8 @@ Polylines Layer::generate_sparse_infill_polylines_for_anchoring(FillAdaptive::Oc
         params.extrusion_role            = surface_fill.params.extrusion_role;
 
         for (ExPolygon &expoly : surface_fill.expolygons) {
+            // Orca: Match the per-body origin of make_fills() before generating physical anchors.
+            f->set_bounding_box(infill_bounding_box(*this, surface_fill, expoly, bbox));
             // Spacing is modified by the filler to indicate adjustments. Reset it for each expolygon.
             f->spacing                     = surface_fill.params.spacing;
             surface_fill.surface.expolygon = std::move(expoly);

--- a/src/libslic3r/Fill/Fill.hpp
+++ b/src/libslic3r/Fill/Fill.hpp
@@ -14,6 +14,12 @@ namespace Slic3r {
 
 class ExtrusionEntityCollection;
 class LayerRegion;
+class PrintObject;
+
+// Orca: Share the layer rotation calculation between infill generation and internal
+// bridge angle selection so both interpret rotation templates in the same way.
+double calculate_infill_rotation_angle(const PrintObject *object, size_t layer_id,
+                                      const double &fixed_infill_angle, const std::string &template_string);
 
 // An interface class to Perl, aggregating an instance of a Fill and a FillData.
 class Filler

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -21,6 +21,7 @@
 #include "TriangleMeshSlicer.hpp"
 #include "Utils.hpp"
 #include "Fill/FillAdaptive.hpp"
+#include "Fill/Fill.hpp"
 #include "Fill/FillLightning.hpp"
 #include "Format/STL.hpp"
 #include "format.hpp"
@@ -3009,29 +3010,11 @@ void PrintObject::bridge_over_infill()
         return diff(layers_sparse_infill, not_sparse_infill);
     };
 
-    // LAMBDA do determine optimal bridging angle
-    auto determine_bridging_angle = [](const Polygons &bridged_area, const Lines &anchors, InfillPattern dominant_pattern, double infill_direction) {
+    // Orca: Derive the fallback bridge direction from the supplied anchor geometry.
+    // Pattern-specific angle selection belongs at the call site, where the supporting
+    // layer and region are known; this helper must not override it with a base config angle.
+    auto determine_bridging_angle = [](const Polygons &bridged_area, const Lines &anchors) {
         AABBTreeLines::LinesDistancer<Line> lines_tree(anchors);
-
-        // Orca: since 3D Honeycomb was "fixed" by forcing coordf_t layerHeight = scale_(1.0), this is no longer needed.
-        // CorssHatch also does not need fixed angle.
-        //
-        // Check it the infill that require a fixed infill angle.
-        //switch (dominant_pattern) {
-        //case ip3DHoneycomb:
-        //case ipCrossHatch:
-        //    return (infill_direction + 45.0) * 2.0 * M_PI / 360.;
-        //default: break;
-        //}
-
-        // Orca: For patterns with non-straight infill lines (Hilbert Curve, Octagram Spiral),
-        // the anchor lines curve and turn at many angles. Sampling their orientation produces
-        // noise across all turning directions rather than a single dominant one, which leads
-        // to unstable/incorrect bridging angles. For these patterns, use the configured
-        // infill_direction as the primary anchor orientation and compute the bridging angle
-        // perpendicular to it (bridges should cross the infill lines at 90° so each bridge
-        // segment rests on top of an infill line at its endpoints).
-        const bool pattern_has_curved_anchors = (dominant_pattern == ipHilbertCurve || dominant_pattern == ipOctagramSpiral);
 
         std::map<double, int> counted_directions;
         for (const Polygon &p : bridged_area) {
@@ -3099,23 +3082,13 @@ void PrintObject::bridge_over_infill()
             bridging_angle = 0.001;
         }
 
-        // Orca: For patterns with curved/turning anchor lines (Hilbert Curve, Octagram
-        // Spiral), the sampled-anchor approach above produces unreliable angles because
-        // the anchors turn at many directions. Replace the computed angle with the
-        // configured infill direction rotated by 90° — bridges run perpendicular to the
-        // dominant infill axis, so each bridge endpoint rests on an infill line.
-        if (pattern_has_curved_anchors) {
-            // infill_direction is stored in degrees in the config (default 45°).
-            // The bridge should be perpendicular to the infill: angle = infill_direction + 90°.
-            bridging_angle = Geometry::deg2rad(infill_direction) + 0.5 * PI;
-        }
-
         return bridging_angle;
     };
 
-    // LAMBDA that will fill given polygons with lines, exapand the lines to the nearest anchor, and reconstruct polygons from the newly
-    // generated lines
-    auto construct_anchored_polygon = [](Polygons bridged_area, Lines anchors, const Flow &bridging_flow, double bridging_angle) {
+    // Orca: Extend scan sections to the nearest anchors and reconstruct the bridge area.
+    // scan_spacing controls boundary sampling independently of the extrusion spacing;
+    // anchoring overlap and smoothing thresholds still use the physical bridging flow.
+    auto construct_anchored_polygon = [](Polygons bridged_area, Lines anchors, const Flow &bridging_flow, double bridging_angle, coord_t scan_spacing) {
         auto lines_rotate = [](Lines &lines, double cos_angle, double sin_angle) {
             for (Line &l : lines) {
                 double ax = double(l.a.x());
@@ -3142,12 +3115,12 @@ void PrintObject::bridge_over_infill()
             BoundingBox bb_x = get_extents(bridged_area);
             BoundingBox bb_y = get_extents(anchors);
 
-            const size_t n_vlines = (bb_x.max.x() - bb_x.min.x() + bridging_flow.scaled_spacing() - 1) / bridging_flow.scaled_spacing();
+            const size_t n_vlines = (bb_x.max.x() - bb_x.min.x() + scan_spacing - 1) / scan_spacing;
             std::vector<Line> vertical_lines(n_vlines);
             for (size_t i = 0; i < n_vlines; i++) {
-                // Orca: Make sure the line is placed in the middle of the extrusion
-                // coord_t x           = bb_x.min.x() + i * bridging_flow.scaled_spacing();
-                coord_t x           = bb_x.min.x() + (i + 0.5) * bridging_flow.scaled_spacing();
+                // Orca: Sample the center of each reconstructed strip. Its edges lie
+                // half a scan step away, even when the sampling is finer than extrusion.
+                coord_t x           = bb_x.min.x() + (i + 0.5) * scan_spacing;
                 coord_t y_min       = bb_y.min.y() - bridging_flow.scaled_spacing();
                 coord_t y_max       = bb_y.max.y() + bridging_flow.scaled_spacing();
                 vertical_lines[i].a = Point{x, y_min};
@@ -3209,7 +3182,9 @@ void PrintObject::bridge_over_infill()
                           });
             }
 
-            // reconstruct polygon from polygon sections
+            // Orca: Reconstruct the polygon from scan sections. At discontinuities and
+            // strip starts/ends, use half the scan step for the X offsets; using half an
+            // extrusion spacing would overlap the finer strips and distort curved anchors.
             struct TracedPoly
             {
                 Points lows;
@@ -3235,8 +3210,8 @@ void PrintObject::bridge_over_infill()
                             36.0 * double(bridging_flow.scaled_spacing()) * bridging_flow.scaled_spacing()) {
                             traced_poly.lows.push_back(candidate->a);
                         } else {
-                            traced_poly.lows.push_back(traced_poly.lows.back() + Point{bridging_flow.scaled_spacing() / 2, 0});
-                            traced_poly.lows.push_back(candidate->a - Point{bridging_flow.scaled_spacing() / 2, 0});
+                            traced_poly.lows.push_back(traced_poly.lows.back() + Point{scan_spacing / 2, 0});
+                            traced_poly.lows.push_back(candidate->a - Point{scan_spacing / 2, 0});
                             traced_poly.lows.push_back(candidate->a);
                         }
 
@@ -3244,8 +3219,8 @@ void PrintObject::bridge_over_infill()
                             36.0 * double(bridging_flow.scaled_spacing()) * bridging_flow.scaled_spacing()) {
                             traced_poly.highs.push_back(candidate->b);
                         } else {
-                            traced_poly.highs.push_back(traced_poly.highs.back() + Point{bridging_flow.scaled_spacing() / 2, 0});
-                            traced_poly.highs.push_back(candidate->b - Point{bridging_flow.scaled_spacing() / 2, 0});
+                            traced_poly.highs.push_back(traced_poly.highs.back() + Point{scan_spacing / 2, 0});
+                            traced_poly.highs.push_back(candidate->b - Point{scan_spacing / 2, 0});
                             traced_poly.highs.push_back(candidate->b);
                         }
                         segment_added = true;
@@ -3253,9 +3228,9 @@ void PrintObject::bridge_over_infill()
                     }
 
                     if (!segment_added) {
-                        // Zero overlapping segments, we just close this polygon
-                        traced_poly.lows.push_back(traced_poly.lows.back() + Point{bridging_flow.scaled_spacing() / 2, 0});
-                        traced_poly.highs.push_back(traced_poly.highs.back() + Point{bridging_flow.scaled_spacing() / 2, 0});
+                        // Orca: No section continues this strip; close at its right edge.
+                        traced_poly.lows.push_back(traced_poly.lows.back() + Point{scan_spacing / 2, 0});
+                        traced_poly.highs.push_back(traced_poly.highs.back() + Point{scan_spacing / 2, 0});
                         Polygon &new_poly = expanded_bridged_area.emplace_back(std::move(traced_poly.lows));
                         new_poly.points.insert(new_poly.points.end(), traced_poly.highs.rbegin(), traced_poly.highs.rend());
                         traced_poly.lows.clear();
@@ -3270,9 +3245,9 @@ void PrintObject::bridge_over_infill()
                 for (const auto &segment : polygon_slice) {
                     if (used_segments.find(&segment) == used_segments.end()) {
                         TracedPoly &new_tp = current_traced_polys.emplace_back();
-                        new_tp.lows.push_back(segment.a - Point{bridging_flow.scaled_spacing() / 2, 0});
+                        new_tp.lows.push_back(segment.a - Point{scan_spacing / 2, 0});
                         new_tp.lows.push_back(segment.a);
-                        new_tp.highs.push_back(segment.b - Point{bridging_flow.scaled_spacing() / 2, 0});
+                        new_tp.highs.push_back(segment.b - Point{scan_spacing / 2, 0});
                         new_tp.highs.push_back(segment.b);
                     }
                 }
@@ -3379,7 +3354,10 @@ void PrintObject::bridge_over_infill()
                 total_fill_area   = closing(total_fill_area, float(SCALED_EPSILON));
                 expansion_area    = closing(expansion_area, float(SCALED_EPSILON));
                 expansion_area    = intersection(expansion_area, deep_infill_area);
-                Polylines anchors = intersection_pl(infill_lines[lidx - 1], shrink(expansion_area, spacing));
+                // Orca: Preserve the real lower-layer anchors for every candidate in this
+                // layer. Replacing this shared set for one pattern also changes later regions,
+                // and synthetic straight lines can claim support where no infill is printed.
+                const Polylines anchors = intersection_pl(infill_lines[lidx - 1], shrink(expansion_area, spacing));
                 Polygons internal_unsupported_area = shrink(deep_infill_area, spacing * 4.5);
 
 #ifdef DEBUG_BRIDGE_OVER_INFILL
@@ -3390,6 +3368,9 @@ void PrintObject::bridge_over_infill()
                 std::vector<CandidateSurface> expanded_surfaces;
                 expanded_surfaces.reserve(surfaces_by_layer[lidx].size());
                 for (const CandidateSurface &candidate : surfaces_by_layer[lidx]) {
+                    const auto &region_config = candidate.region->region().config();
+                    const bool turning_pattern = region_config.sparse_infill_pattern == ipHilbertCurve ||
+                                                 region_config.sparse_infill_pattern == ipOctagramSpiral;
                     const Flow &flow              = candidate.region->bridging_flow(frSolidInfill, true);
                     Polygons    area_to_be_bridge = expand(candidate.new_polys, flow.scaled_spacing());
                     area_to_be_bridge             = intersection(area_to_be_bridge, deep_infill_area);
@@ -3418,20 +3399,40 @@ void PrintObject::bridge_over_infill()
                                to_lines(area_to_be_bridge), to_lines(boundary_plines), to_lines(anchors), to_lines(expansion_area));
 #endif
 
-                    double bridging_angle = 0;
-                    if (!anchors.empty()) {
-                        bridging_angle = determine_bridging_angle(area_to_be_bridge, to_lines(anchors),
-                                                                  candidate.region->region().config().sparse_infill_pattern.value,
-                                                                  candidate.region->region().config().infill_direction.value);
-                    } else {
-                        // use expansion boundaries as anchors.
-                        // Also, use Infill pattern that is neutral for angle determination, since there are no infill lines.
-                        bridging_angle = determine_bridging_angle(area_to_be_bridge, to_lines(boundary_plines), InfillPattern::ipLine, 0);
+                    double bridging_angle = -1.;
+                    if (!anchors.empty() && turning_pattern) {
+                        // Orca: Keep adjacent bridges over Hilbert/Octagram aligned despite
+                        // their many local turning directions. Use the lower layer's rotation,
+                        // since that is the infill supporting the bridge, not the current layer's.
+                        for (const LayerRegion *lower_region : layer->lower_layer->regions()) {
+                            // Orca: Apply the configured direction only if the same region has
+                            // sparse infill below this bridge. A height modifier may put another
+                            // pattern underneath, requiring the geometry-based fallback below.
+                            if (&lower_region->region() != &candidate.region->region() ||
+                                intersection(area_to_be_bridge, to_polygons(lower_region->fill_surfaces.filter_by_type(stInternal))).empty())
+                                continue;
+                            bridging_angle = calculate_infill_rotation_angle(po, layer->lower_layer->id(), region_config.infill_direction.value,
+                                                                            region_config.sparse_infill_rotate_template.value) + 0.5 * PI;
+                            // Orca: Apply model alignment as infill generation does, then normalize
+                            // the undirected bridge angle to [0, PI), including negative rotations.
+                            if (region_config.align_infill_direction_to_model) {
+                                const auto &m = po->trafo().matrix();
+                                bridging_angle += std::atan2(double(m(1, 0)), double(m(0, 0)));
+                            }
+                            bridging_angle = std::fmod(bridging_angle, PI);
+                            if (bridging_angle < 0.)
+                                bridging_angle += PI;
+                            break;
+                        }
                     }
+                    // Orca: A different region below (e.g. a height modifier) needs the actual anchor
+                    // directions. When there are no sparse anchors, use the expansion boundaries.
+                    if (bridging_angle < 0.)
+                        bridging_angle = determine_bridging_angle(area_to_be_bridge, to_lines(anchors.empty() ? boundary_plines : anchors));
                     
-                    // ORCA: Internal bridge angle override
+                    // Orca: Preserve the user's absolute or relative internal bridge angle
+                    // override after automatic direction selection.
                     if (candidate.region->region().config().internal_bridge_angle.value > 0) {
-                        const auto  &region_config      = candidate.region->region().config();
                         const double custom_angle_rad   = Geometry::deg2rad(region_config.internal_bridge_angle.value);
                         if (region_config.relative_bridge_angle.value)
                             bridging_angle += custom_angle_rad;
@@ -3444,111 +3445,19 @@ void PrintObject::bridge_over_infill()
                         }
                     }
 
-                    // Orca: For patterns with curved/turning anchor lines (Hilbert Curve,
-                    // Octagram Spiral), the actual infill polylines curve and turn at many
-                    // angles. When construct_anchored_polygon scans these curved anchors
-                    // with vertical lines, each scan line intersects the same anchor many
-                    // times at wildly different Y positions, producing chaotic polygon
-                    // sections — holes in random places, bridges over air, etc. Replace
-                    // the curved anchors with synthetic straight lines parallel to the
-                    // configured infill_direction, spaced at the real infill line spacing.
-                    // These straight lines intersect each scan line exactly once, giving
-                    // construct_anchored_polygon clean, predictable anchor points.
-                    {
-                        const InfillPattern pattern = candidate.region->region().config().sparse_infill_pattern.value;
-                        if (pattern == ipHilbertCurve || pattern == ipOctagramSpiral) {
-                            const auto &rcfg   = candidate.region->region().config();
-                            const double density = 0.01 * rcfg.sparse_infill_density.value; // fraction (0..1)
-                            if (density > 0.) {
-                                // Infill line spacing = flow_spacing / density (same as Fill.cpp).
-                                const double infill_spacing = candidate.region->flow(frInfill).spacing() / density;
-                                const coord_t scaled_spacing = coord_t(scale_(infill_spacing));
-                                const double infill_angle_rad = Geometry::deg2rad(rcfg.infill_direction.value);
-                                // Generate parallel lines across the limiting_area bbox.
-                                // limiting_area = union_(area_to_be_bridge, expansion_area),
-                                // so it covers the full extent of both the bridge and the
-                                // infill beneath it. Using this (not just expansion_area)
-                                // ensures anchors reach every edge of the bridge.
-                                BoundingBox bbox = get_extents(limiting_area);
-                                // Expand bbox by at least one infill spacing so anchor lines
-                                // extend beyond the limiting_area edges. After rotation in
-                                // construct_anchored_polygon, limiting_area becomes a diamond
-                                // and anchor lines near the tips need extra length to reach
-                                // scan lines at the edges of bridged_area.
-                                coord_t margin = std::max(coord_t(scale_(2.0)), scaled_spacing);
-                                bbox.min -= Point{margin, margin};
-                                bbox.max += Point{margin, margin};
-                                // Line direction unit vector.
-                                double dir_x = std::cos(infill_angle_rad);
-                                double dir_y = std::sin(infill_angle_rad);
-                                // Perpendicular direction (for spacing).
-                                double perp_x = -dir_y;
-                                double perp_y =  dir_x;
-                                // Center of the bbox — lines are centered here so
-                                // that after rotation they span the full bridged_area.
-                                double bbox_cx = (bbox.min.x() + bbox.max.x()) * 0.5;
-                                double bbox_cy = (bbox.min.y() + bbox.max.y()) * 0.5;
-                                // Project bbox corners onto the perpendicular axis
-                                // (relative to bbox center) to find the range of
-                                // line offsets needed.
-                                double corners[4] = {
-                                    (bbox.min.x() - bbox_cx) * perp_x + (bbox.min.y() - bbox_cy) * perp_y,
-                                    (bbox.max.x() - bbox_cx) * perp_x + (bbox.min.y() - bbox_cy) * perp_y,
-                                    (bbox.min.x() - bbox_cx) * perp_x + (bbox.max.y() - bbox_cy) * perp_y,
-                                    (bbox.max.x() - bbox_cx) * perp_x + (bbox.max.y() - bbox_cy) * perp_y
-                                };
-                                double perp_min = corners[0], perp_max = corners[0];
-                                for (int i = 1; i < 4; i++) {
-                                    perp_min = std::min(perp_min, corners[i]);
-                                    perp_max = std::max(perp_max, corners[i]);
-                                }
-                                // Line length: project onto the line direction and take the span.
-                                double proj_corners[4] = {
-                                    bbox.min.x() * dir_x + bbox.min.y() * dir_y,
-                                    bbox.max.x() * dir_x + bbox.min.y() * dir_y,
-                                    bbox.min.x() * dir_x + bbox.max.y() * dir_y,
-                                    bbox.max.x() * dir_x + bbox.max.y() * dir_y
-                                };
-                                double line_len = *std::max_element(proj_corners, proj_corners + 4) -
-                                                  *std::min_element(proj_corners, proj_corners + 4) + 2 * margin;
-                                // Generate lines at each offset.
-                                Lines synthetic_anchors;
-                                int n_lines = int((perp_max - perp_min) / scaled_spacing) + 2;
-                                for (int i = 0; i < n_lines; i++) {
-                                    double offset = perp_min + i * scaled_spacing;
-                                    // Center of the line: bbox center + offset along perpendicular.
-                                    double cx = bbox_cx + offset * perp_x;
-                                    double cy = bbox_cy + offset * perp_y;
-                                    // Extend line by line_len/2 in each direction.
-                                    Line l;
-                                    l.a = Point(coord_t(cx - dir_x * line_len * 0.5), coord_t(cy - dir_y * line_len * 0.5));
-                                    l.b = Point(coord_t(cx + dir_x * line_len * 0.5), coord_t(cy + dir_y * line_len * 0.5));
-                                    synthetic_anchors.push_back(l);
-                                }
-                                // Clip to expansion_area (same as real anchors are clipped).
-                                Polylines synthetic_polylines;
-                                for (const Line &l : synthetic_anchors) {
-                                    synthetic_polylines.emplace_back(Points{l.a, l.b});
-                                }
-                                // Do NOT clip synthetic anchors to any area — leave them
-                                // at full bbox length. construct_anchored_polygon finds
-                                // the nearest anchor intersection for each scan line
-                                // section; long anchor lines guarantee every scan line
-                                // through bridged_area finds an anchor, so bridge edges
-                                // never hang in air. Clipping to limiting_area/expand(...)
-                                // shortens lines at the diamond tips after rotation,
-                                // causing edge scan lines to miss all anchors.
-                                // Replace anchors with synthetic straight lines.
-                                anchors = synthetic_polylines;
-                            }
-                        }
-                    }
-
+                    // Orca: Changing the bridge direction must not change its physical supports.
+                    // Extend to actual sparse infill or the existing boundary anchors, never to
+                    // a synthetic grid that merely has the same nominal angle and spacing.
                     boundary_plines.insert(boundary_plines.end(), anchors.begin(), anchors.end());
                     if (!lightning_area.empty() && !intersection(area_to_be_bridge, lightning_area).empty()) {
                         boundary_plines = intersection_pl(boundary_plines, expand(area_to_be_bridge, scale_(10)));
                     }
-                    Polygons bridging_area = construct_anchored_polygon(area_to_be_bridge, to_lines(boundary_plines), flow, bridging_angle);
+                    // Orca: Use four samples per extrusion spacing for Hilbert/Octagram so the
+                    // reconstructed boundary follows rounded anchors instead of cutting corners.
+                    // Keep the original step for other patterns and at least one coordinate unit
+                    // after integer division. This changes boundary accuracy, not infill density.
+                    const coord_t scan_spacing = std::max(coord_t(1), flow.scaled_spacing() / (turning_pattern ? 4 : 1));
+                    Polygons bridging_area = construct_anchored_polygon(area_to_be_bridge, to_lines(boundary_plines), flow, bridging_angle, scan_spacing);
 
                     // Check collision with other expanded surfaces
                     {
@@ -3562,7 +3471,9 @@ void PrintObject::bridge_over_infill()
                             }
                         }
                         if (reconstruct) {
-                            bridging_area = construct_anchored_polygon(area_to_be_bridge, to_lines(boundary_plines), flow, bridging_angle);
+                            // Orca: Retain the same sampling accuracy when matching a nearby
+                            // bridge's direction; rebuilding must not lose the curved supports.
+                            bridging_area = construct_anchored_polygon(area_to_be_bridge, to_lines(boundary_plines), flow, bridging_angle, scan_spacing);
                         }
                     }
 

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -673,6 +673,71 @@ void PrintObject::prepare_infill()
     } // for each region
 #endif /* SLIC3R_DEBUG_SLICE_PROCESSING */
 
+    // Orca: precompute the object's 3D connected bodies for separated infills / per-model
+    // centering. Two islands belong to the same body when their slices overlap on adjacent
+    // layers; islands that only overlap in top-down projection but never touch (e.g. interleaved
+    // chain links) stay separate, matching "split to objects". Each layer island then records
+    // the full bounding box of its body, so its infill is centered on that body as if it were
+    // sliced alone. Compute this before bridges so anchors and extrusion share the same origin.
+    bool needs_separated_components = false;
+    for (size_t i = 0; i < this->num_printing_regions(); ++ i) {
+        const PrintRegionConfig &rc = this->printing_region(i).config();
+        if (rc.separated_infills || rc.center_of_surface_pattern == CenterOfSurfacePattern::Each_Model) {
+            needs_separated_components = true;
+            break;
+        }
+    }
+    // Orca: Fast path: the feature only changes anything when the object is made of more than one
+    // connected body. Detect that cheaply the same way as "Split to objects" — more than one
+    // model part, or a single part whose mesh is splittable (is_splittable() is cached). A single
+    // body already shares the object center, i.e. the default, so skip the connectivity pass.
+    if (needs_separated_components) {
+        int                parts      = 0;
+        const ModelVolume *first_part = nullptr;
+        for (const ModelVolume *v : this->model_object()->volumes)
+            if (v->is_model_part()) { ++ parts; first_part = v; }
+        if (parts <= 1 && ! (first_part != nullptr && first_part->is_splittable()))
+            needs_separated_components = false;
+    }
+    for (Layer *layer : m_layers)
+        layer->lslices_separated_component_bboxes.clear();
+    if (needs_separated_components) {
+        const size_t        nl = m_layers.size();
+        std::vector<size_t> offset(nl + 1, 0); // Orca: flat index of the first island of each layer
+        for (size_t i = 0; i < nl; ++ i)
+            offset[i + 1] = offset[i] + m_layers[i]->lslices.size();
+        const size_t nreg = offset[nl];
+        // Orca: Union-find over every (layer, island).
+        std::vector<size_t> parent(nreg);
+        for (size_t i = 0; i < nreg; ++ i) parent[i] = i;
+        auto find = [&parent](size_t x) {
+            while (parent[x] != x) { parent[x] = parent[parent[x]]; x = parent[x]; }
+            return x;
+        };
+        auto unite = [&](size_t a, size_t b) { a = find(a); b = find(b); if (a != b) parent[a] = b; };
+        // Orca: Join islands that overlap between two consecutive layers.
+        for (size_t i = 0; i + 1 < nl; ++ i) {
+            const Layer *la = m_layers[i], *lb = m_layers[i + 1];
+            for (size_t a = 0; a < la->lslices.size(); ++ a)
+                for (size_t b = 0; b < lb->lslices.size(); ++ b)
+                    if (la->lslices_bboxes[a].overlap(lb->lslices_bboxes[b]) &&
+                        ! intersection_ex(la->lslices[a], lb->lslices[b]).empty())
+                        unite(offset[i] + a, offset[i + 1] + b);
+        }
+        // Orca: Full bounding box of each body, indexed by its union-find root.
+        std::vector<BoundingBox> body_bbox(nreg);
+        for (size_t i = 0; i < nl; ++ i)
+            for (size_t a = 0; a < m_layers[i]->lslices.size(); ++ a)
+                body_bbox[find(offset[i] + a)].merge(m_layers[i]->lslices_bboxes[a]);
+        // Orca: Store the body bbox for every island.
+        for (size_t i = 0; i < nl; ++ i) {
+            Layer *layer = m_layers[i];
+            layer->lslices_separated_component_bboxes.resize(layer->lslices.size());
+            for (size_t a = 0; a < layer->lslices.size(); ++ a)
+                layer->lslices_separated_component_bboxes[a] = body_bbox[find(offset[i] + a)];
+        }
+    }
+
     // the following step needs to be done before combination because it may need
     // to remove only half of the combined infill
     this->bridge_over_infill();
@@ -706,71 +771,6 @@ void PrintObject::infill()
 
     if (this->set_started(posInfill)) {
         m_print->set_status(35, L("Generating infill toolpath"));
-
-        // Orca: precompute the object's 3D connected bodies for separated infills / per-model
-        // centering. Two islands belong to the same body when their slices overlap on adjacent
-        // layers; islands that only overlap in top-down projection but never touch (e.g. interleaved
-        // chain links) stay separate, matching "split to objects". Each layer island then records
-        // the full bounding box of its body, so its infill is centered on that body as if it were
-        // sliced alone. Done once here, before the parallel fill, and only when a region needs it.
-        bool needs_separated_components = false;
-        for (size_t i = 0; i < this->num_printing_regions(); ++ i) {
-            const PrintRegionConfig &rc = this->printing_region(i).config();
-            if (rc.separated_infills || rc.center_of_surface_pattern == CenterOfSurfacePattern::Each_Model) {
-                needs_separated_components = true;
-                break;
-            }
-        }
-        // Fast path: the feature only changes anything when the object is made of more than one
-        // connected body. Detect that cheaply the same way as "Split to objects" — more than one
-        // model part, or a single part whose mesh is splittable (is_splittable() is cached). A single
-        // body already shares the object center, i.e. the default, so skip the connectivity pass.
-        if (needs_separated_components) {
-            int                parts      = 0;
-            const ModelVolume *first_part = nullptr;
-            for (const ModelVolume *v : this->model_object()->volumes)
-                if (v->is_model_part()) { ++ parts; first_part = v; }
-            if (parts <= 1 && ! (first_part != nullptr && first_part->is_splittable()))
-                needs_separated_components = false;
-        }
-        for (Layer *layer : m_layers)
-            layer->lslices_separated_component_bboxes.clear();
-        if (needs_separated_components) {
-            const size_t        nl = m_layers.size();
-            std::vector<size_t> offset(nl + 1, 0); // flat index of the first island of each layer
-            for (size_t i = 0; i < nl; ++ i)
-                offset[i + 1] = offset[i] + m_layers[i]->lslices.size();
-            const size_t nreg = offset[nl];
-            // Union-find over every (layer, island).
-            std::vector<size_t> parent(nreg);
-            for (size_t i = 0; i < nreg; ++ i) parent[i] = i;
-            auto find = [&parent](size_t x) {
-                while (parent[x] != x) { parent[x] = parent[parent[x]]; x = parent[x]; }
-                return x;
-            };
-            auto unite = [&](size_t a, size_t b) { a = find(a); b = find(b); if (a != b) parent[a] = b; };
-            // Join islands that overlap between two consecutive layers.
-            for (size_t i = 0; i + 1 < nl; ++ i) {
-                const Layer *la = m_layers[i], *lb = m_layers[i + 1];
-                for (size_t a = 0; a < la->lslices.size(); ++ a)
-                    for (size_t b = 0; b < lb->lslices.size(); ++ b)
-                        if (la->lslices_bboxes[a].overlap(lb->lslices_bboxes[b]) &&
-                            ! intersection_ex(la->lslices[a], lb->lslices[b]).empty())
-                            unite(offset[i] + a, offset[i + 1] + b);
-            }
-            // Full bounding box of each body, indexed by its union-find root.
-            std::vector<BoundingBox> body_bbox(nreg);
-            for (size_t i = 0; i < nl; ++ i)
-                for (size_t a = 0; a < m_layers[i]->lslices.size(); ++ a)
-                    body_bbox[find(offset[i] + a)].merge(m_layers[i]->lslices_bboxes[a]);
-            // Store the body bbox for every island.
-            for (size_t i = 0; i < nl; ++ i) {
-                Layer *layer = m_layers[i];
-                layer->lslices_separated_component_bboxes.resize(layer->lslices.size());
-                for (size_t a = 0; a < layer->lslices.size(); ++ a)
-                    layer->lslices_separated_component_bboxes[a] = body_bbox[find(offset[i] + a)];
-            }
-        }
 
         const auto& adaptive_fill_octree = this->m_adaptive_fill_octrees.first;
         const auto& support_fill_octree = this->m_adaptive_fill_octrees.second;
@@ -1402,8 +1402,6 @@ bool PrintObject::invalidate_state_by_config_options(
             || opt_key == "infill_anchor_max"
             || opt_key == "top_surface_line_width"
             || opt_key == "bottom_surface_density"
-            || opt_key == "center_of_surface_pattern"
-            || opt_key == "separated_infills" 
             || opt_key == "initial_layer_line_width"
             || opt_key == "small_area_infill_flow_compensation"
             || opt_key == "lateral_lattice_angle_1"
@@ -1411,6 +1409,9 @@ bool PrintObject::invalidate_state_by_config_options(
             || opt_key == "infill_overhang_angle") {
             steps.emplace_back(posInfill);
         } else if (opt_key == "sparse_infill_pattern"
+                   // Orca: Body centering now also determines bridge anchors during preparation.
+                   || opt_key == "center_of_surface_pattern"
+                   || opt_key == "separated_infills"
                    || opt_key == "sparse_infill_smooth_factor"
                    || opt_key == "symmetric_infill_y_axis"
                    || opt_key == "infill_shift_step"
@@ -3088,7 +3089,8 @@ void PrintObject::bridge_over_infill()
     // Orca: Extend scan sections to the nearest anchors and reconstruct the bridge area.
     // scan_spacing controls boundary sampling independently of the extrusion spacing;
     // anchoring overlap and smoothing thresholds still use the physical bridging flow.
-    auto construct_anchored_polygon = [](Polygons bridged_area, Lines anchors, const Flow &bridging_flow, double bridging_angle, coord_t scan_spacing) {
+    auto construct_anchored_polygon = [](Polygons bridged_area, Lines anchors, const Flow &bridging_flow, double bridging_angle,
+                                         coord_t scan_spacing, bool restore_anchors = false) {
         auto lines_rotate = [](Lines &lines, double cos_angle, double sin_angle) {
             for (Line &l : lines) {
                 double ax = double(l.a.x());
@@ -3143,7 +3145,11 @@ void PrintObject::bridge_over_infill()
                 auto anchors_intersections = anchors_and_walls_tree.intersections_with_line<true>(vertical_lines[i]);
 
                 for (Line &section : polygon_sections[i]) {
-                    auto maybe_below_anchor = std::upper_bound(anchors_intersections.rbegin(), anchors_intersections.rend(), section.a,
+                    // Orca: A repaired boundary may already overlap its anchor by one flow width.
+                    // Include that overlap in the search so restoring rounded corners does not
+                    // extend every already anchored section into the next sparse infill cell.
+                    const coord_t overlap = restore_anchors ? bridging_flow.scaled_width() + SCALED_EPSILON : 0;
+                    auto maybe_below_anchor = std::upper_bound(anchors_intersections.rbegin(), anchors_intersections.rend(), section.a + Point{0, overlap},
                                                                [](const Point &a, const std::pair<Point, size_t> &b) {
                                                                    return a.y() > b.first.y();
                                                                });
@@ -3152,7 +3158,7 @@ void PrintObject::bridge_over_infill()
                         section.a.y() -= bridging_flow.scaled_width() * (0.5 + 0.5);
                     }
 
-                    auto maybe_upper_anchor = std::upper_bound(anchors_intersections.begin(), anchors_intersections.end(), section.b,
+                    auto maybe_upper_anchor = std::upper_bound(anchors_intersections.begin(), anchors_intersections.end(), section.b - Point{0, overlap},
                                                                [](const Point &a, const std::pair<Point, size_t> &b) {
                                                                    return a.y() < b.first.y();
                                                                });
@@ -3481,6 +3487,13 @@ void PrintObject::bridge_over_infill()
                     // bridging_area         = opening(bridging_area, flow.scaled_spacing());
                     bridging_area          = opening(bridging_area, flow.scaled_spacing() * 0.75);
                     bridging_area          = closing(bridging_area, flow.scaled_spacing());
+                    // Orca: Opening/closing can pull rounded bridge ends away from their real
+                    // supports. Restore those contacts after smoothing, preserving the cleaned
+                    // area and the selected angle; do not smooth the restored contacts again.
+                    if (turning_pattern && !bridging_area.empty()) {
+                        bridging_area = union_(bridging_area, construct_anchored_polygon(bridging_area, to_lines(boundary_plines), flow,
+                                                                                       bridging_angle, scan_spacing, true));
+                    }
                     bridging_area          = intersection(bridging_area, limiting_area);
                     bridging_area          = intersection(bridging_area, total_fill_area);
                     bridging_area          = diff(bridging_area, total_top_area);

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -3024,6 +3024,15 @@ void PrintObject::bridge_over_infill()
         //default: break;
         //}
 
+        // Orca: For patterns with non-straight infill lines (Hilbert Curve, Octagram Spiral),
+        // the anchor lines curve and turn at many angles. Sampling their orientation produces
+        // noise across all turning directions rather than a single dominant one, which leads
+        // to unstable/incorrect bridging angles. For these patterns, use the configured
+        // infill_direction as the primary anchor orientation and compute the bridging angle
+        // perpendicular to it (bridges should cross the infill lines at 90° so each bridge
+        // segment rests on top of an infill line at its endpoints).
+        const bool pattern_has_curved_anchors = (dominant_pattern == ipHilbertCurve || dominant_pattern == ipOctagramSpiral);
+
         std::map<double, int> counted_directions;
         for (const Polygon &p : bridged_area) {
             double acc_distance = 0;
@@ -3089,10 +3098,16 @@ void PrintObject::bridge_over_infill()
         if (bridging_angle == 0) {
             bridging_angle = 0.001;
         }
-        switch (dominant_pattern) {
-        case ipHilbertCurve: bridging_angle += 0.25 * PI; break;
-        case ipOctagramSpiral: bridging_angle += (1.0 / 16.0) * PI; break;
-        default: break;
+
+        // Orca: For patterns with curved/turning anchor lines (Hilbert Curve, Octagram
+        // Spiral), the sampled-anchor approach above produces unreliable angles because
+        // the anchors turn at many directions. Replace the computed angle with the
+        // configured infill direction rotated by 90° — bridges run perpendicular to the
+        // dominant infill axis, so each bridge endpoint rests on an infill line.
+        if (pattern_has_curved_anchors) {
+            // infill_direction is stored in degrees in the config (default 45°).
+            // The bridge should be perpendicular to the infill: angle = infill_direction + 90°.
+            bridging_angle = Geometry::deg2rad(infill_direction) + 0.5 * PI;
         }
 
         return bridging_angle;
@@ -3425,6 +3440,106 @@ void PrintObject::bridge_over_infill()
                             if (region_config.align_infill_direction_to_model) {
                                 auto m = po->trafo().matrix();
                                 bridging_angle += std::atan2((double)m(1, 0), (double)m(0, 0));
+                            }
+                        }
+                    }
+
+                    // Orca: For patterns with curved/turning anchor lines (Hilbert Curve,
+                    // Octagram Spiral), the actual infill polylines curve and turn at many
+                    // angles. When construct_anchored_polygon scans these curved anchors
+                    // with vertical lines, each scan line intersects the same anchor many
+                    // times at wildly different Y positions, producing chaotic polygon
+                    // sections — holes in random places, bridges over air, etc. Replace
+                    // the curved anchors with synthetic straight lines parallel to the
+                    // configured infill_direction, spaced at the real infill line spacing.
+                    // These straight lines intersect each scan line exactly once, giving
+                    // construct_anchored_polygon clean, predictable anchor points.
+                    {
+                        const InfillPattern pattern = candidate.region->region().config().sparse_infill_pattern.value;
+                        if (pattern == ipHilbertCurve || pattern == ipOctagramSpiral) {
+                            const auto &rcfg   = candidate.region->region().config();
+                            const double density = 0.01 * rcfg.sparse_infill_density.value; // fraction (0..1)
+                            if (density > 0.) {
+                                // Infill line spacing = flow_spacing / density (same as Fill.cpp).
+                                const double infill_spacing = candidate.region->flow(frInfill).spacing() / density;
+                                const coord_t scaled_spacing = coord_t(scale_(infill_spacing));
+                                const double infill_angle_rad = Geometry::deg2rad(rcfg.infill_direction.value);
+                                // Generate parallel lines across the limiting_area bbox.
+                                // limiting_area = union_(area_to_be_bridge, expansion_area),
+                                // so it covers the full extent of both the bridge and the
+                                // infill beneath it. Using this (not just expansion_area)
+                                // ensures anchors reach every edge of the bridge.
+                                BoundingBox bbox = get_extents(limiting_area);
+                                // Expand bbox by at least one infill spacing so anchor lines
+                                // extend beyond the limiting_area edges. After rotation in
+                                // construct_anchored_polygon, limiting_area becomes a diamond
+                                // and anchor lines near the tips need extra length to reach
+                                // scan lines at the edges of bridged_area.
+                                coord_t margin = std::max(coord_t(scale_(2.0)), scaled_spacing);
+                                bbox.min -= Point{margin, margin};
+                                bbox.max += Point{margin, margin};
+                                // Line direction unit vector.
+                                double dir_x = std::cos(infill_angle_rad);
+                                double dir_y = std::sin(infill_angle_rad);
+                                // Perpendicular direction (for spacing).
+                                double perp_x = -dir_y;
+                                double perp_y =  dir_x;
+                                // Center of the bbox — lines are centered here so
+                                // that after rotation they span the full bridged_area.
+                                double bbox_cx = (bbox.min.x() + bbox.max.x()) * 0.5;
+                                double bbox_cy = (bbox.min.y() + bbox.max.y()) * 0.5;
+                                // Project bbox corners onto the perpendicular axis
+                                // (relative to bbox center) to find the range of
+                                // line offsets needed.
+                                double corners[4] = {
+                                    (bbox.min.x() - bbox_cx) * perp_x + (bbox.min.y() - bbox_cy) * perp_y,
+                                    (bbox.max.x() - bbox_cx) * perp_x + (bbox.min.y() - bbox_cy) * perp_y,
+                                    (bbox.min.x() - bbox_cx) * perp_x + (bbox.max.y() - bbox_cy) * perp_y,
+                                    (bbox.max.x() - bbox_cx) * perp_x + (bbox.max.y() - bbox_cy) * perp_y
+                                };
+                                double perp_min = corners[0], perp_max = corners[0];
+                                for (int i = 1; i < 4; i++) {
+                                    perp_min = std::min(perp_min, corners[i]);
+                                    perp_max = std::max(perp_max, corners[i]);
+                                }
+                                // Line length: project onto the line direction and take the span.
+                                double proj_corners[4] = {
+                                    bbox.min.x() * dir_x + bbox.min.y() * dir_y,
+                                    bbox.max.x() * dir_x + bbox.min.y() * dir_y,
+                                    bbox.min.x() * dir_x + bbox.max.y() * dir_y,
+                                    bbox.max.x() * dir_x + bbox.max.y() * dir_y
+                                };
+                                double line_len = *std::max_element(proj_corners, proj_corners + 4) -
+                                                  *std::min_element(proj_corners, proj_corners + 4) + 2 * margin;
+                                // Generate lines at each offset.
+                                Lines synthetic_anchors;
+                                int n_lines = int((perp_max - perp_min) / scaled_spacing) + 2;
+                                for (int i = 0; i < n_lines; i++) {
+                                    double offset = perp_min + i * scaled_spacing;
+                                    // Center of the line: bbox center + offset along perpendicular.
+                                    double cx = bbox_cx + offset * perp_x;
+                                    double cy = bbox_cy + offset * perp_y;
+                                    // Extend line by line_len/2 in each direction.
+                                    Line l;
+                                    l.a = Point(coord_t(cx - dir_x * line_len * 0.5), coord_t(cy - dir_y * line_len * 0.5));
+                                    l.b = Point(coord_t(cx + dir_x * line_len * 0.5), coord_t(cy + dir_y * line_len * 0.5));
+                                    synthetic_anchors.push_back(l);
+                                }
+                                // Clip to expansion_area (same as real anchors are clipped).
+                                Polylines synthetic_polylines;
+                                for (const Line &l : synthetic_anchors) {
+                                    synthetic_polylines.emplace_back(Points{l.a, l.b});
+                                }
+                                // Do NOT clip synthetic anchors to any area — leave them
+                                // at full bbox length. construct_anchored_polygon finds
+                                // the nearest anchor intersection for each scan line
+                                // section; long anchor lines guarantee every scan line
+                                // through bridged_area finds an anchor, so bridge edges
+                                // never hang in air. Clipping to limiting_area/expand(...)
+                                // shortens lines at the diamond tips after rotation,
+                                // causing edge scan lines to miss all anchors.
+                                // Replace anchors with synthetic straight lines.
+                                anchors = synthetic_polylines;
                             }
                         }
                     }

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -1410,6 +1410,7 @@ bool PrintObject::invalidate_state_by_config_options(
             steps.emplace_back(posInfill);
         } else if (opt_key == "sparse_infill_pattern"
                    // Orca: Body centering now also determines bridge anchors during preparation.
+                   // Invalidating preparation also invalidates infill, including top/bottom surfaces.
                    || opt_key == "center_of_surface_pattern"
                    || opt_key == "separated_infills"
                    || opt_key == "sparse_infill_smooth_factor"

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -25,6 +25,7 @@
 #include "Fill/FillLightning.hpp"
 #include "Format/STL.hpp"
 #include "format.hpp"
+#include "AABBTreeIndirect.hpp"
 #include "AABBTreeLines.hpp"
 
 #include <cstddef>
@@ -715,14 +716,41 @@ void PrintObject::prepare_infill()
             return x;
         };
         auto unite = [&](size_t a, size_t b) { a = find(a); b = find(b); if (a != b) parent[a] = b; };
-        // Orca: Join islands that overlap between two consecutive layers.
+        // Orca: Index the smaller of two consecutive layers instead of scanning every
+        // pair of islands. The tree prunes distant boxes on fragmented models; exact
+        // polygon intersections still decide connectivity for the remaining candidates.
         for (size_t i = 0; i + 1 < nl; ++ i) {
-            const Layer *la = m_layers[i], *lb = m_layers[i + 1];
-            for (size_t a = 0; a < la->lslices.size(); ++ a)
-                for (size_t b = 0; b < lb->lslices.size(); ++ b)
-                    if (la->lslices_bboxes[a].overlap(lb->lslices_bboxes[b]) &&
-                        ! intersection_ex(la->lslices[a], lb->lslices[b]).empty())
-                        unite(offset[i] + a, offset[i + 1] + b);
+            m_print->throw_if_canceled();
+            size_t layer_a = i, layer_b = i + 1;
+            if (m_layers[layer_a]->lslices.size() < m_layers[layer_b]->lslices.size())
+                std::swap(layer_a, layer_b);
+            const Layer *la = m_layers[layer_a], *lb = m_layers[layer_b];
+            if (lb->lslices.empty())
+                continue;
+
+            using IslandTree = AABBTreeIndirect::Tree<2, coord_t>;
+            std::vector<AABBTreeIndirect::BoundingBoxWrapper> bboxes;
+            bboxes.reserve(lb->lslices.size());
+            for (size_t b = 0; b < lb->lslices.size(); ++ b)
+                bboxes.emplace_back(b, lb->lslices_bboxes[b]);
+            IslandTree tree;
+            tree.build_modify_input(bboxes);
+            for (size_t a = 0; a < la->lslices.size(); ++ a) {
+                const IslandTree::BoundingBox query(la->lslices_bboxes[a].min, la->lslices_bboxes[a].max);
+                AABBTreeIndirect::traverse(tree,
+                    [&query](const IslandTree::Node &node) { return node.bbox.intersects(query); },
+                    [&](const IslandTree::Node &node) {
+                        const size_t b = node.idx;
+                        // Orca: Tree boxes include an epsilon, so retain the original box
+                        // filter. Already-connected islands cannot change the partition
+                        // and need no further polygon intersection.
+                        if (la->lslices_bboxes[a].overlap(lb->lslices_bboxes[b]) &&
+                            find(offset[layer_a] + a) != find(offset[layer_b] + b) &&
+                            ! intersection_ex(la->lslices[a], lb->lslices[b]).empty())
+                            unite(offset[layer_a] + a, offset[layer_b] + b);
+                        return true;
+                    });
+            }
         }
         // Orca: Full bounding box of each body, indexed by its union-find root.
         std::vector<BoundingBox> body_bbox(nreg);

--- a/tests/fff_print/test_fill.cpp
+++ b/tests/fff_print/test_fill.cpp
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "libslic3r/ClipperUtils.hpp"
+#include "libslic3r/AABBTreeLines.hpp"
 #include "libslic3r/Fill/Fill.hpp"
 #include "libslic3r/Flow.hpp"
 #include "libslic3r/Geometry.hpp"
@@ -1228,4 +1229,61 @@ TEST_CASE("Smoothing multiline lightning infill keeps its outlines connected", "
     // The outlines are still rounded.
     REQUIRE(smooth.point_count > sharp.point_count);
     REQUIRE(smooth.sharp_turns < sharp.sharp_turns);
+}
+
+TEST_CASE("Sparse plane-path anchors match the printed infill", "[Fill][InternalBridge][Regression]")
+{
+    // Orca: Compare generated anchors with actual extrusion across plane-path patterns,
+    // smoothing, multiline and rotations; an origin shift must not pass as valid support.
+    const std::string pattern = GENERATE("hilbertcurve", "octagramspiral", "archimedeanchords");
+    const std::string smoothing = GENERATE("0%", "100%");
+    const int multiline = GENERATE(1, 2);
+    const bool rotated = GENERATE(false, true);
+    CAPTURE(pattern, smoothing, multiline, rotated);
+
+    auto config = DynamicPrintConfig::full_print_config();
+    config.set_deserialize_strict({{"sparse_infill_pattern", pattern},
+                                   {"sparse_infill_density", "15%"},
+                                   {"sparse_infill_smooth_factor", smoothing},
+                                   {"fill_multiline", multiline},
+                                   {"infill_direction", 45},
+                                   {"sparse_infill_rotate_template", rotated ? "0,25,50" : ""},
+                                   {"align_infill_direction_to_model", rotated},
+                                   {"separated_infills", false},
+                                   {"top_shell_layers", 0},
+                                   {"bottom_shell_layers", 0},
+                                   {"top_shell_thickness", 0},
+                                   {"bottom_shell_thickness", 0},
+                                   {"layer_height", 0.2},
+                                   {"initial_layer_print_height", 0.2},
+                                   {"resolution", 0.012}});
+    Print print;
+    Model model;
+    Slic3r::Test::init_print({make_cube(30, 24, 1)}, print, model, config, nullptr, false);
+    if (rotated) {
+        model.objects.front()->instances.front()->set_rotation(Vec3d(0., 0., Geometry::deg2rad(23.)));
+        print.apply(model, config);
+    }
+    print.process();
+
+    const Layer &layer = *print.objects().front()->get_layer(4);
+    Polylines printed;
+    for (const LayerRegion *region : layer.regions())
+        for (const ExtrusionEntity *entity : region->fills.flatten().entities)
+            if (entity->role() == erInternalInfill)
+                entity->collect_polylines(printed);
+    REQUIRE_FALSE(printed.empty());
+    const AABBTreeLines::LinesDistancer<Line> printed_tree(to_lines(printed));
+
+    // Orca: Exclude perimeter connections: anchoring and extrusion can trim those differently.
+    const Polylines anchors = intersection_pl(layer.generate_sparse_infill_polylines_for_anchoring(nullptr, nullptr, nullptr),
+                                              shrink(to_polygons(layer.lslices), scale_(3.)));
+    REQUIRE_FALSE(anchors.empty());
+    double max_distance = 0.;
+    for (const Polyline &path : anchors)
+        for (const Point &point : path.equally_spaced_points(scale_(0.25)))
+            max_distance = std::max(max_distance, printed_tree.distance_from_lines<false>(point));
+    // Orca: Allow only the configured simplification tolerance; infill-scale offsets
+    // would hide anchors that no longer coincide with printed lines.
+    CHECK(unscale<double>(max_distance) <= config.opt_float("resolution"));
 }

--- a/tests/fff_print/test_fill.cpp
+++ b/tests/fff_print/test_fill.cpp
@@ -1239,7 +1239,8 @@ TEST_CASE("Sparse plane-path anchors match the printed infill", "[Fill][Internal
     const std::string smoothing = GENERATE("0%", "100%");
     const int multiline = GENERATE(1, 2);
     const bool rotated = GENERATE(false, true);
-    CAPTURE(pattern, smoothing, multiline, rotated);
+    const bool separated = GENERATE(false, true);
+    CAPTURE(pattern, smoothing, multiline, rotated, separated);
 
     auto config = DynamicPrintConfig::full_print_config();
     config.set_deserialize_strict({{"sparse_infill_pattern", pattern},
@@ -1249,7 +1250,7 @@ TEST_CASE("Sparse plane-path anchors match the printed infill", "[Fill][Internal
                                    {"infill_direction", 45},
                                    {"sparse_infill_rotate_template", rotated ? "0,25,50" : ""},
                                    {"align_infill_direction_to_model", rotated},
-                                   {"separated_infills", false},
+                                   {"separated_infills", separated},
                                    {"top_shell_layers", 0},
                                    {"bottom_shell_layers", 0},
                                    {"top_shell_thickness", 0},
@@ -1259,7 +1260,14 @@ TEST_CASE("Sparse plane-path anchors match the printed infill", "[Fill][Internal
                                    {"resolution", 0.012}});
     Print print;
     Model model;
-    Slic3r::Test::init_print({make_cube(30, 24, 1)}, print, model, config, nullptr, false);
+    TriangleMesh mesh = make_cube(30, 24, 1);
+    if (separated) {
+        // Orca: Two disconnected bodies in one object must each use their own infill origin.
+        TriangleMesh second = make_cube(30, 24, 1);
+        second.translate(50, 0, 0);
+        mesh.merge(second);
+    }
+    Slic3r::Test::init_print({mesh}, print, model, config, nullptr, false);
     if (rotated) {
         model.objects.front()->instances.front()->set_rotation(Vec3d(0., 0., Geometry::deg2rad(23.)));
         print.apply(model, config);

--- a/tests/fff_print/test_printobject.cpp
+++ b/tests/fff_print/test_printobject.cpp
@@ -4,6 +4,7 @@
 #include "libslic3r/Print.hpp"
 #include "libslic3r/Layer.hpp"
 #include "libslic3r/GCodeReader.hpp"
+#include "libslic3r/ClipperUtils.hpp"
 
 #include "test_helpers.hpp"
 
@@ -129,4 +130,103 @@ TEST_CASE("Initial layer height is honored", "[PrintObject]")
     REQUIRE(layer_zs.size() > 1);
     REQUIRE_THAT(*layer_zs.begin(),            Catch::Matchers::WithinAbs(0.3, 1e-4));
     REQUIRE_THAT(*std::next(layer_zs.begin()), Catch::Matchers::WithinAbs(0.5, 1e-4));
+}
+
+static TriangleMesh internal_bridge_step()
+{
+    // Orca: The smaller tower leaves a shoulder whose solid skin needs internal bridges
+    // over the sparse infill in the base, without relying on an external model file.
+    TriangleMesh mesh = make_cube(30, 24, 3);
+    TriangleMesh tower = make_cube(14, 10, 1);
+    tower.translate(8, 7, 3);
+    mesh.merge(tower);
+    return mesh;
+}
+
+static DynamicPrintConfig internal_bridge_config(const std::string &pattern)
+{
+    auto config = DynamicPrintConfig::full_print_config();
+    config.set_deserialize_strict({{"sparse_infill_pattern", pattern},
+                                   {"sparse_infill_density", "15%"},
+                                   {"sparse_infill_smooth_factor", "100%"},
+                                   {"infill_direction", 45},
+                                   {"internal_bridge_angle", 0},
+                                   {"thick_internal_bridges", true},
+                                   {"top_shell_layers", 3},
+                                   {"bottom_shell_layers", 2},
+                                   {"top_shell_thickness", 0},
+                                   {"bottom_shell_thickness", 0},
+                                   {"layer_height", 0.2},
+                                   {"initial_layer_print_height", 0.2}});
+    return config;
+}
+
+TEST_CASE("Internal bridge angles follow the lower infill layer and model rotation", "[PrintObject][InternalBridge][Regression]")
+{
+    const std::string pattern = GENERATE("hilbertcurve", "octagramspiral");
+    const double rotation = GENERATE(23., -123.);
+    const std::vector<double> cycle{10., 30., 70.};
+    auto config = internal_bridge_config(pattern);
+    config.set_deserialize_strict({{"sparse_infill_rotate_template", "10,30,70"},
+                                   {"align_infill_direction_to_model", true},
+                                   {"separated_infills", false}});
+    Print print;
+    Model model;
+    init_print({internal_bridge_step()}, print, model, config, nullptr, false);
+    model.objects.front()->instances.front()->set_rotation(Vec3d(0., 0., Geometry::deg2rad(rotation)));
+    print.apply(model, config);
+    print.process();
+    const PrintObject &object = *print.objects().front();
+    size_t bridges = 0;
+    for (size_t i = 1; i < object.layer_count(); ++i) {
+        // Orca: The support is one layer below the bridge. Check the template and model
+        // rotation together, including normalization when the resulting angle is negative.
+        double expected = std::fmod(cycle[(i - 1) % cycle.size()] + 90. + rotation, 180.);
+        if (expected < 0.) expected += 180.;
+        for (const LayerRegion *region : object.get_layer(i)->regions())
+            for (const Surface *surface : region->fill_surfaces.filter_by_type(stInternalBridge)) {
+                CAPTURE(pattern, rotation, i);
+                CHECK_THAT(Geometry::rad2deg(surface->bridge_angle), Catch::Matchers::WithinAbs(expected, 0.001));
+                ++bridges;
+            }
+    }
+    REQUIRE(bridges > 0);
+}
+
+TEST_CASE("Turning infill does not replace the anchors of another region", "[PrintObject][InternalBridge][Regression]")
+{
+    // Orca: Keep the right-hand region fixed while changing the left-hand pattern in the
+    // same object. Its bridge areas must be independent of a previous candidate's anchors.
+    auto right_bridges = [](const std::string &left_pattern) {
+        auto config = internal_bridge_config(left_pattern);
+        Print print;
+        Model model;
+        init_print({internal_bridge_step()}, print, model, config, nullptr, false);
+        TriangleMesh right = internal_bridge_step();
+        right.translate(50, 0, 0);
+        ModelVolume *volume = model.objects.front()->add_volume(std::move(right));
+        volume->config.set_key_value("sparse_infill_pattern", new ConfigOptionEnum<InfillPattern>(ipRectilinear));
+        volume->config.set_key_value("infill_direction", new ConfigOptionFloat(17.));
+        print.apply(model, config);
+        print.process();
+        std::map<size_t, Polygons> result;
+        const PrintObject &object = *print.objects().front();
+        for (size_t i = 0; i < object.layer_count(); ++i)
+            for (const LayerRegion *region : object.get_layer(i)->regions())
+                if (region->region().config().infill_direction == 17.)
+                    polygons_append(result[i], to_polygons(region->fill_surfaces.filter_by_type(stInternalBridge)));
+        return result;
+    };
+    const auto baseline = right_bridges("rectilinear");
+    const auto actual = right_bridges(GENERATE("hilbertcurve", "octagramspiral"));
+    REQUIRE(actual.size() == baseline.size());
+    double total_area = 0.;
+    for (const auto &[layer, expected] : baseline) {
+        CAPTURE(layer);
+        const auto &polys = actual.at(layer);
+        CHECK(area(diff(expected, polys)) < scaled<double>(1.) * scaled<double>(1.) * 1e-6);
+        CHECK(area(diff(polys, expected)) < scaled<double>(1.) * scaled<double>(1.) * 1e-6);
+        total_area += area(expected);
+    }
+    REQUIRE(total_area > 0.);
 }

--- a/tests/fff_print/test_printobject.cpp
+++ b/tests/fff_print/test_printobject.cpp
@@ -5,6 +5,7 @@
 #include "libslic3r/Layer.hpp"
 #include "libslic3r/GCodeReader.hpp"
 #include "libslic3r/ClipperUtils.hpp"
+#include "libslic3r/AABBTreeLines.hpp"
 
 #include "test_helpers.hpp"
 
@@ -143,10 +144,11 @@ static TriangleMesh internal_bridge_step()
     return mesh;
 }
 
-static DynamicPrintConfig internal_bridge_config(const std::string &pattern)
+static DynamicPrintConfig internal_bridge_config(const std::string &pattern, int multiline)
 {
     auto config = DynamicPrintConfig::full_print_config();
     config.set_deserialize_strict({{"sparse_infill_pattern", pattern},
+                                   {"fill_multiline", multiline},
                                    {"sparse_infill_density", "15%"},
                                    {"sparse_infill_smooth_factor", "100%"},
                                    {"infill_direction", 45},
@@ -164,9 +166,12 @@ static DynamicPrintConfig internal_bridge_config(const std::string &pattern)
 TEST_CASE("Internal bridge angles follow the lower infill layer and model rotation", "[PrintObject][InternalBridge][Regression]")
 {
     const std::string pattern = GENERATE("hilbertcurve", "octagramspiral");
+    // Orca: Cover both a central line (odd counts) and offset pairs (even counts).
+    const int multiline = GENERATE(1, 2, 3);
+    CAPTURE(multiline);
     const double rotation = GENERATE(23., -123.);
     const std::vector<double> cycle{10., 30., 70.};
-    auto config = internal_bridge_config(pattern);
+    auto config = internal_bridge_config(pattern, multiline);
     config.set_deserialize_strict({{"sparse_infill_rotate_template", "10,30,70"},
                                    {"align_infill_direction_to_model", true},
                                    {"separated_infills", false}});
@@ -197,8 +202,10 @@ TEST_CASE("Turning infill does not replace the anchors of another region", "[Pri
 {
     // Orca: Keep the right-hand region fixed while changing the left-hand pattern in the
     // same object. Its bridge areas must be independent of a previous candidate's anchors.
-    auto right_bridges = [](const std::string &left_pattern) {
-        auto config = internal_bridge_config(left_pattern);
+    const int multiline = GENERATE(1, 2, 3);
+    CAPTURE(multiline);
+    auto right_bridges = [multiline](const std::string &left_pattern) {
+        auto config = internal_bridge_config(left_pattern, multiline);
         Print print;
         Model model;
         init_print({internal_bridge_step()}, print, model, config, nullptr, false);
@@ -229,4 +236,95 @@ TEST_CASE("Turning infill does not replace the anchors of another region", "[Pri
         total_area += area(expected);
     }
     REQUIRE(total_area > 0.);
+}
+
+TEST_CASE("Rounded internal bridges end on printed support", "[PrintObject][InternalBridge][Regression]")
+{
+    const std::string pattern = GENERATE("hilbertcurve", "octagramspiral");
+    const bool separated = GENERATE(false, true);
+    CAPTURE(pattern, separated);
+    auto config = internal_bridge_config(pattern, 1);
+    config.set_deserialize_strict({{"infill_wall_overlap", "0%"}, {"separated_infills", separated}});
+    TriangleMesh mesh = internal_bridge_step();
+    if (separated) {
+        TriangleMesh second = internal_bridge_step();
+        second.translate(50, 0, 0);
+        mesh.merge(second);
+    }
+    Print print;
+    Model model;
+    init_print({mesh}, print, model, config, nullptr, false);
+    print.process();
+
+    // Orca: Check final extrusion endpoints after polygon cleanup and fill generation.
+    // A correct bridge angle and correct sparse anchors alone do not guarantee contact.
+    const PrintObject &object = *print.objects().front();
+    size_t checked = 0;
+    for (size_t i = 1; i < object.layer_count(); ++i) {
+        Polygons support;
+        Polylines walls;
+        for (const LayerRegion *region : object.get_layer(i - 1)->regions()) {
+            region->perimeters.polygons_covered_by_width(support, 0.f);
+            region->fills.polygons_covered_by_width(support, 0.f);
+            region->perimeters.collect_polylines(walls);
+        }
+        REQUIRE_FALSE(support.empty());
+        const AABBTreeLines::LinesDistancer<Line> support_tree(to_lines(union_(support)));
+        const AABBTreeLines::LinesDistancer<Line> wall_tree(to_lines(walls));
+        for (const LayerRegion *region : object.get_layer(i)->regions())
+            for (const ExtrusionEntity *entity : region->fills.flatten().entities) {
+                if (entity->role() != erInternalBridgeInfill)
+                    continue;
+                const auto *path = dynamic_cast<const ExtrusionPath *>(entity);
+                REQUIRE(path != nullptr);
+                for (const Line &line : path->polyline.to_polyline().lines()) {
+                    // Orca: Sample span ends, excluding short connectors and wall overlap.
+                    if (line.length() < scale_(std::max(0.7, 3. * path->width)))
+                        continue;
+                    for (const Point &point : {line.a, line.b}) {
+                        if (wall_tree.distance_from_lines<false>(point) <= scale_(0.5))
+                            continue;
+                        CAPTURE(i, point.x(), point.y());
+                        const double gap = unscale<double>(support_tree.distance_from_lines<true>(point)) - 0.5 * path->width;
+                        CHECK(gap <= 0.1);
+                        ++checked;
+                    }
+                }
+            }
+    }
+    REQUIRE(checked > 0);
+}
+
+TEST_CASE("Enabling separated infill recomputes body origins", "[PrintObject][InternalBridge][Regression]")
+{
+    const std::string pattern = GENERATE("hilbertcurve", "octagramspiral", "archimedeanchords");
+    CAPTURE(pattern);
+    auto footprint = [&](bool reslice) {
+        auto config = internal_bridge_config(pattern, 2);
+        config.set_deserialize_strict({{"separated_infills", !reslice}});
+        TriangleMesh mesh = internal_bridge_step();
+        TriangleMesh second = internal_bridge_step();
+        second.translate(50, 0, 0);
+        mesh.merge(second);
+        Print print;
+        Model model;
+        init_print({mesh}, print, model, config, nullptr, false);
+        print.process();
+        if (reslice) {
+            // Orca: Enabling centering after a completed slice must rebuild the body
+            // origins now shared by bridge preparation and printed infill.
+            config.set_deserialize_strict({{"separated_infills", true}});
+            print.apply(model, config);
+            print.process();
+        }
+        Polygons result;
+        for (const LayerRegion *region : print.objects().front()->get_layer(4)->regions())
+            region->fills.polygons_covered_by_width(result, 0.f);
+        return union_(result);
+    };
+    const Polygons fresh = footprint(false);
+    const Polygons resliced = footprint(true);
+    REQUIRE_FALSE(fresh.empty());
+    CHECK(area(diff(fresh, resliced)) < scaled<double>(1.) * scaled<double>(1.) * 1e-6);
+    CHECK(area(diff(resliced, fresh)) < scaled<double>(1.) * scaled<double>(1.) * 1e-6);
 }

--- a/tests/fff_print/test_printobject.cpp
+++ b/tests/fff_print/test_printobject.cpp
@@ -9,8 +9,11 @@
 
 #include "test_helpers.hpp"
 
+#include <cmath>
 #include <iterator>
+#include <map>
 #include <set>
+#include <vector>
 
 using namespace Slic3r;
 using namespace Slic3r::Test;

--- a/tests/fff_print/test_printobject.cpp
+++ b/tests/fff_print/test_printobject.cpp
@@ -486,8 +486,9 @@ TEST_CASE("Separated infill keeps fragmented and nested bodies independent", "[P
     Print print;
     Model model;
     init_print({mesh}, print, model, config, nullptr, false);
-    PrintObject &object = *print.objects().front();
-    object.prepare_infill();
+    // Orca: Prepare body bounds through the public pipeline, then inspect the object read-only.
+    print.process();
+    const PrintObject &object = *print.objects().front();
     REQUIRE(object.layer_count() > 1);
     for (const Layer *layer : object.layers()) {
         REQUIRE(layer->lslices.size() == grid_size * grid_size + 2);
@@ -543,8 +544,9 @@ TEST_CASE("Body centering survives islands merging and splitting between layers"
     Print print;
     Model model;
     init_print({mesh}, print, model, config, nullptr, false);
-    PrintObject &object = *print.objects().front();
-    object.prepare_infill();
+    // Orca: Prepare body bounds through the public pipeline, then inspect the object read-only.
+    print.process();
+    const PrintObject &object = *print.objects().front();
     REQUIRE(object.layer_count() == 5);
     REQUIRE(object.get_layer(0)->lslices.size() == 5);
     REQUIRE(object.get_layer(1)->lslices.size() == 3);

--- a/tests/fff_print/test_printobject.cpp
+++ b/tests/fff_print/test_printobject.cpp
@@ -340,12 +340,19 @@ TEST_CASE("Surface centering survives changes to separated infill settings", "[P
     const std::string initial_center = GENERATE("each_surface", "each_model", "each_assembly");
     const std::string final_center = GENERATE("each_surface", "each_model", "each_assembly");
     const bool separated = GENERATE(false, true);
+    const std::string top_order = GENERATE("default", "outward", "inward");
+    const std::string bottom_order = top_order == "outward" ? "inward" : top_order == "inward" ? "outward" : "default";
+    const std::string density = GENERATE("80%", "100%");
     const bool change_center = initial_center != final_center;
-    CAPTURE(pattern, initial_center, final_center, separated);
+    CAPTURE(pattern, initial_center, final_center, separated, top_order, bottom_order, density);
 
     auto config = DynamicPrintConfig::full_print_config();
     config.set_deserialize_strict({{"top_surface_pattern", pattern},
                                    {"bottom_surface_pattern", pattern},
+                                   {"top_surface_fill_order", top_order},
+                                   {"bottom_surface_fill_order", bottom_order},
+                                   {"top_surface_density", density},
+                                   {"bottom_surface_density", density},
                                    {"center_of_surface_pattern", initial_center},
                                    {"separated_infills", change_center ? separated : !separated},
                                    {"sparse_infill_pattern", "rectilinear"},
@@ -367,18 +374,35 @@ TEST_CASE("Surface centering survives changes to separated infill settings", "[P
     second.translate(50, 0, 0);
     mesh.merge(second);
 
-    auto surface_footprints = [](const Print &print) {
-        std::map<std::pair<size_t, ExtrusionRole>, Polygons> result;
+    // Orca: Equal footprints can hide reordered or reversed paths. Retain their point
+    // sequences and ordering protection to cover the directional surface behavior too.
+    struct SurfaceFillSnapshot {
+        std::map<bool, std::vector<Points>> paths;
+        bool protected_order = true;
+    };
+    auto surface_fills = [](const Print &print) {
+        std::map<std::pair<size_t, ExtrusionRole>, SurfaceFillSnapshot> result;
         const PrintObject &object = *print.objects().front();
-        for (size_t i = 0; i < object.layer_count(); ++i)
-            for (const LayerRegion *region : object.get_layer(i)->regions()) {
-                const ExtrusionEntityCollection flattened = region->fills.flatten();
-                for (const ExtrusionEntity *entity : flattened.entities)
-                    if (entity->role() == erTopSolidInfill || entity->role() == erBottomSurface)
-                        entity->polygons_covered_by_width(result[{i, entity->role()}], 0.f);
-            }
-        for (auto &entry : result)
-            entry.second = union_(entry.second);
+        for (size_t i = 0; i < object.layer_count(); ++i) {
+            auto collect = [&](const auto &self, const ExtrusionEntity &entity, bool no_sort) -> void {
+                if (const auto *collection = dynamic_cast<const ExtrusionEntityCollection *>(&entity)) {
+                    for (const ExtrusionEntity *child : collection->entities)
+                        self(self, *child, no_sort || collection->no_sort);
+                } else if (entity.role() == erTopSolidInfill || entity.role() == erBottomSurface) {
+                    const auto *path = dynamic_cast<const ExtrusionPath *>(&entity);
+                    REQUIRE(path != nullptr);
+                    auto &snapshot = result[{i, entity.role()}];
+                    // Orca: The centered test model has one body on either side of X=0.
+                    // Their traversal order may vary; preserve path order within each body.
+                    Points points = path->polyline.to_polyline().points;
+                    REQUIRE_FALSE(points.empty());
+                    snapshot.paths[points.front().x() > 0].push_back(std::move(points));
+                    snapshot.protected_order &= no_sort && !path->can_reverse();
+                }
+            };
+            for (const LayerRegion *region : object.get_layer(i)->regions())
+                collect(collect, region->fills, false);
+        }
         return result;
     };
 
@@ -386,7 +410,7 @@ TEST_CASE("Surface centering survives changes to separated infill settings", "[P
     Model model;
     init_print({mesh}, print, model, config, nullptr, false);
     print.process();
-    const auto initial = surface_footprints(print);
+    const auto initial = surface_fills(print);
     config.set_deserialize_strict({{"center_of_surface_pattern", final_center}, {"separated_infills", separated}});
     print.apply(model, config);
     // Orca: Preparation owns the body origins, and its invalidation must also force
@@ -394,34 +418,39 @@ TEST_CASE("Surface centering survives changes to separated infill settings", "[P
     CHECK_FALSE(print.objects().front()->is_step_done(posPrepareInfill));
     CHECK_FALSE(print.objects().front()->is_step_done(posInfill));
     print.process();
-    const auto resliced = surface_footprints(print);
+    const auto resliced = surface_fills(print);
 
     Print fresh_print;
     Model fresh_model;
     init_print({mesh}, fresh_print, fresh_model, config, nullptr, false);
     fresh_print.process();
-    const auto fresh = surface_footprints(fresh_print);
+    const auto fresh = surface_fills(fresh_print);
     REQUIRE_FALSE(fresh.empty());
     REQUIRE(resliced.size() == fresh.size());
     std::set<ExtrusionRole> roles;
-    double changed_area = 0.;
+    bool changed_paths = false;
     for (const auto &entry : fresh) {
         CAPTURE(entry.first.first, entry.first.second);
-        REQUIRE_FALSE(entry.second.empty());
+        REQUIRE_FALSE(entry.second.paths.empty());
         roles.insert(entry.first.second);
         REQUIRE(resliced.count(entry.first) == 1);
         REQUIRE(initial.count(entry.first) == 1);
         const auto &actual = resliced.at(entry.first);
-        CHECK(area(diff(entry.second, actual)) < scaled<double>(1.) * scaled<double>(1.) * 1e-6);
-        CHECK(area(diff(actual, entry.second)) < scaled<double>(1.) * scaled<double>(1.) * 1e-6);
-        changed_area += area(diff(entry.second, initial.at(entry.first))) + area(diff(initial.at(entry.first), entry.second));
+        const auto &expected = entry.second;
+        const auto &before = initial.at(entry.first);
+        CHECK((actual.paths == expected.paths));
+        if (!change_center)
+            CHECK((actual.paths == before.paths));
+        if (top_order != "default") {
+            CHECK(expected.protected_order);
+            CHECK(actual.protected_order);
+            CHECK(before.protected_order);
+        }
+        changed_paths |= expected.paths != before.paths;
     }
     CHECK(roles.count(erTopSolidInfill) == 1);
     CHECK(roles.count(erBottomSurface) == 1);
     // Orca: Guard against a vacuous comparison: changing surface centering must change
     // the printed pattern, while toggling separated sparse infill must leave it alone.
-    if (change_center)
-        CHECK(changed_area > scaled<double>(1.) * scaled<double>(1.));
-    else
-        CHECK(changed_area < scaled<double>(1.) * scaled<double>(1.) * 1e-6);
+    CHECK(changed_paths == change_center);
 }

--- a/tests/fff_print/test_printobject.cpp
+++ b/tests/fff_print/test_printobject.cpp
@@ -13,6 +13,8 @@
 #include <iterator>
 #include <map>
 #include <set>
+#include <string>
+#include <utility>
 #include <vector>
 
 using namespace Slic3r;
@@ -330,4 +332,96 @@ TEST_CASE("Enabling separated infill recomputes body origins", "[PrintObject][In
     REQUIRE_FALSE(fresh.empty());
     CHECK(area(diff(fresh, resliced)) < scaled<double>(1.) * scaled<double>(1.) * 1e-6);
     CHECK(area(diff(resliced, fresh)) < scaled<double>(1.) * scaled<double>(1.) * 1e-6);
+}
+
+TEST_CASE("Surface centering survives changes to separated infill settings", "[PrintObject][SurfaceInfill][Regression]")
+{
+    const std::string pattern = GENERATE("archimedeanchords", "octagramspiral");
+    const std::string initial_center = GENERATE("each_surface", "each_model", "each_assembly");
+    const std::string final_center = GENERATE("each_surface", "each_model", "each_assembly");
+    const bool separated = GENERATE(false, true);
+    const bool change_center = initial_center != final_center;
+    CAPTURE(pattern, initial_center, final_center, separated);
+
+    auto config = DynamicPrintConfig::full_print_config();
+    config.set_deserialize_strict({{"top_surface_pattern", pattern},
+                                   {"bottom_surface_pattern", pattern},
+                                   {"center_of_surface_pattern", initial_center},
+                                   {"separated_infills", change_center ? separated : !separated},
+                                   {"sparse_infill_pattern", "rectilinear"},
+                                   {"sparse_infill_density", "15%"},
+                                   {"top_shell_layers", 2},
+                                   {"bottom_shell_layers", 2},
+                                   {"top_shell_thickness", 0},
+                                   {"bottom_shell_thickness", 0},
+                                   {"layer_height", 0.2},
+                                   {"initial_layer_print_height", 0.2}});
+
+    // Orca: Two disconnected bodies exercise per-body centering. The offset tower also
+    // makes each-surface and each-model centering differ on the top surfaces.
+    TriangleMesh mesh = make_cube(30, 24, 2);
+    TriangleMesh tower = make_cube(12, 10, 1);
+    tower.translate(4, 3, 2);
+    mesh.merge(tower);
+    TriangleMesh second = mesh;
+    second.translate(50, 0, 0);
+    mesh.merge(second);
+
+    auto surface_footprints = [](const Print &print) {
+        std::map<std::pair<size_t, ExtrusionRole>, Polygons> result;
+        const PrintObject &object = *print.objects().front();
+        for (size_t i = 0; i < object.layer_count(); ++i)
+            for (const LayerRegion *region : object.get_layer(i)->regions()) {
+                const ExtrusionEntityCollection flattened = region->fills.flatten();
+                for (const ExtrusionEntity *entity : flattened.entities)
+                    if (entity->role() == erTopSolidInfill || entity->role() == erBottomSurface)
+                        entity->polygons_covered_by_width(result[{i, entity->role()}], 0.f);
+            }
+        for (auto &entry : result)
+            entry.second = union_(entry.second);
+        return result;
+    };
+
+    Print print;
+    Model model;
+    init_print({mesh}, print, model, config, nullptr, false);
+    print.process();
+    const auto initial = surface_footprints(print);
+    config.set_deserialize_strict({{"center_of_surface_pattern", final_center}, {"separated_infills", separated}});
+    print.apply(model, config);
+    // Orca: Preparation owns the body origins, and its invalidation must also force
+    // regeneration of top/bottom extrusion paths, even when sparse infill is unchanged.
+    CHECK_FALSE(print.objects().front()->is_step_done(posPrepareInfill));
+    CHECK_FALSE(print.objects().front()->is_step_done(posInfill));
+    print.process();
+    const auto resliced = surface_footprints(print);
+
+    Print fresh_print;
+    Model fresh_model;
+    init_print({mesh}, fresh_print, fresh_model, config, nullptr, false);
+    fresh_print.process();
+    const auto fresh = surface_footprints(fresh_print);
+    REQUIRE_FALSE(fresh.empty());
+    REQUIRE(resliced.size() == fresh.size());
+    std::set<ExtrusionRole> roles;
+    double changed_area = 0.;
+    for (const auto &entry : fresh) {
+        CAPTURE(entry.first.first, entry.first.second);
+        REQUIRE_FALSE(entry.second.empty());
+        roles.insert(entry.first.second);
+        REQUIRE(resliced.count(entry.first) == 1);
+        REQUIRE(initial.count(entry.first) == 1);
+        const auto &actual = resliced.at(entry.first);
+        CHECK(area(diff(entry.second, actual)) < scaled<double>(1.) * scaled<double>(1.) * 1e-6);
+        CHECK(area(diff(actual, entry.second)) < scaled<double>(1.) * scaled<double>(1.) * 1e-6);
+        changed_area += area(diff(entry.second, initial.at(entry.first))) + area(diff(initial.at(entry.first), entry.second));
+    }
+    CHECK(roles.count(erTopSolidInfill) == 1);
+    CHECK(roles.count(erBottomSurface) == 1);
+    // Orca: Guard against a vacuous comparison: changing surface centering must change
+    // the printed pattern, while toggling separated sparse infill must leave it alone.
+    if (change_center)
+        CHECK(changed_area > scaled<double>(1.) * scaled<double>(1.));
+    else
+        CHECK(changed_area < scaled<double>(1.) * scaled<double>(1.) * 1e-6);
 }

--- a/tests/fff_print/test_printobject.cpp
+++ b/tests/fff_print/test_printobject.cpp
@@ -454,3 +454,119 @@ TEST_CASE("Surface centering survives changes to separated infill settings", "[P
     // the printed pattern, while toggling separated sparse infill must leave it alone.
     CHECK(changed_paths == change_center);
 }
+
+TEST_CASE("Separated infill keeps fragmented and nested bodies independent", "[PrintObject][SurfaceInfill][Regression]")
+{
+    constexpr size_t grid_size = 8;
+    TriangleMesh mesh;
+    auto add_box = [&](double x, double y, double width, double depth) {
+        TriangleMesh box = make_cube(width, depth, 0.6);
+        box.translate(x, y, 0);
+        mesh.merge(box);
+    };
+    // Orca: Many small islands exercise spatial pruning and the tree's original
+    // island indices. A pillar inside a frame also overlaps its bounding box,
+    // but must remain a separate body because it lies entirely inside the hole.
+    for (size_t x = 0; x < grid_size; ++ x)
+        for (size_t y = 0; y < grid_size; ++ y)
+            add_box(6 * x, 6 * y, 3, 3);
+    add_box(54, 0, 20, 4);
+    add_box(54, 16, 20, 4);
+    add_box(54, 0, 4, 20);
+    add_box(70, 0, 4, 20);
+    add_box(62, 8, 4, 4);
+
+    auto config = DynamicPrintConfig::full_print_config();
+    config.set_deserialize_strict({{"separated_infills", true},
+                                   {"center_of_surface_pattern", "each_surface"},
+                                   {"layer_height", 0.2},
+                                   {"initial_layer_print_height", 0.2},
+                                   {"elefant_foot_compensation", 0},
+                                   {"wall_loops", 1}});
+    Print print;
+    Model model;
+    init_print({mesh}, print, model, config, nullptr, false);
+    PrintObject &object = *print.objects().front();
+    object.prepare_infill();
+    REQUIRE(object.layer_count() > 1);
+    for (const Layer *layer : object.layers()) {
+        REQUIRE(layer->lslices.size() == grid_size * grid_size + 2);
+        REQUIRE(layer->lslices_separated_component_bboxes.size() == layer->lslices.size());
+        size_t holes = 0;
+        for (size_t i = 0; i < layer->lslices.size(); ++ i) {
+            const BoundingBox &body = layer->lslices_separated_component_bboxes[i];
+            const BoundingBox &island = layer->lslices_bboxes[i];
+            CHECK(body.min == island.min);
+            CHECK(body.max == island.max);
+            holes += layer->lslices[i].holes.size();
+        }
+        CHECK(holes == 1);
+    }
+}
+
+TEST_CASE("Body centering survives islands merging and splitting between layers", "[PrintObject][SurfaceInfill][Regression]")
+{
+    const bool separated = GENERATE(false, true);
+    CAPTURE(separated);
+    // Orca: Four posts join through horizontal then vertical rails, creating a
+    // cycle of overlaps before splitting into four islands again. This exercises
+    // redundant connections and indexing either adjacent layer. A fifth post
+    // stays separate at every height.
+    TriangleMesh mesh;
+    for (int x : {0, 8})
+        for (int y : {0, 8}) {
+            TriangleMesh post = make_cube(4, 4, 1);
+            post.translate(x, y, 0);
+            mesh.merge(post);
+        }
+    for (int y : {0, 8}) {
+        TriangleMesh rail = make_cube(12, 4, 0.2);
+        rail.translate(0, y, 0.2);
+        mesh.merge(rail);
+    }
+    for (int x : {0, 8}) {
+        TriangleMesh rail = make_cube(4, 12, 0.2);
+        rail.translate(x, 0, 0.4);
+        mesh.merge(rail);
+    }
+    TriangleMesh isolated = make_cube(4, 4, 1);
+    isolated.translate(20, 0, 0);
+    mesh.merge(isolated);
+
+    auto config = DynamicPrintConfig::full_print_config();
+    config.set_deserialize_strict({{"separated_infills", separated},
+                                   {"center_of_surface_pattern", separated ? "each_surface" : "each_model"},
+                                   {"layer_height", 0.2},
+                                   {"initial_layer_print_height", 0.2},
+                                   {"elefant_foot_compensation", 0},
+                                   {"wall_loops", 1}});
+    Print print;
+    Model model;
+    init_print({mesh}, print, model, config, nullptr, false);
+    PrintObject &object = *print.objects().front();
+    object.prepare_infill();
+    REQUIRE(object.layer_count() == 5);
+    REQUIRE(object.get_layer(0)->lslices.size() == 5);
+    REQUIRE(object.get_layer(1)->lslices.size() == 3);
+    REQUIRE(object.get_layer(2)->lslices.size() == 3);
+    REQUIRE(object.get_layer(4)->lslices.size() == 5);
+
+    BoundingBox isolated_bbox = object.get_layer(0)->lslices_bboxes.front();
+    for (const BoundingBox &bbox : object.get_layer(0)->lslices_bboxes)
+        if (bbox.min.x() > isolated_bbox.min.x())
+            isolated_bbox = bbox;
+    BoundingBox connected_bbox;
+    for (const Layer *layer : object.layers())
+        for (const BoundingBox &bbox : layer->lslices_bboxes)
+            if (bbox.min.x() < isolated_bbox.min.x())
+                connected_bbox.merge(bbox);
+    for (const Layer *layer : object.layers()) {
+        REQUIRE(layer->lslices_separated_component_bboxes.size() == layer->lslices.size());
+        for (size_t i = 0; i < layer->lslices.size(); ++ i) {
+            const BoundingBox &expected = layer->lslices_bboxes[i].min.x() < isolated_bbox.min.x() ? connected_bbox : isolated_bbox;
+            const BoundingBox &actual = layer->lslices_separated_component_bboxes[i];
+            CHECK(actual.min == expected.min);
+            CHECK(actual.max == expected.max);
+        }
+    }
+}


### PR DESCRIPTION
# Description

Problem: Some internal bridges can be generated in mid-air. Especially for Hilbert Curve/Octagram Spiral sparse infill.
Fix: Internal bridges are extended until the next available sparse infill wall.

With the help of AI.

# Screenshots

### Before

<img width="1577" height="1000" alt="image" src="https://github.com/user-attachments/assets/ad89c38f-1822-49e3-b146-4929fecbb0a2" />

<img width="1609" height="942" alt="image" src="https://github.com/user-attachments/assets/d40dbbd8-97a6-466e-80bf-8da82143f7f9" />

<img width="1523" height="901" alt="image" src="https://github.com/user-attachments/assets/9f08c524-c64f-43a6-85ef-ec995a4c308f" />

<img width="868" height="748" alt="image" src="https://github.com/user-attachments/assets/eea380ec-51d9-470b-b668-1791dd9d2815" />

### After

<img width="899" height="836" alt="image" src="https://github.com/user-attachments/assets/c7c35ca3-bd28-4eba-ae99-2c96f98057a0" />

<img width="945" height="863" alt="image" src="https://github.com/user-attachments/assets/0f34cc67-0d70-4895-83b2-9c43fcb0f29d" />

<img width="924" height="807" alt="image" src="https://github.com/user-attachments/assets/1b6bb8d6-e9db-4060-9bbb-14f4292990d4" />

<img width="907" height="757" alt="image" src="https://github.com/user-attachments/assets/a6806599-bfe4-4500-963a-cdb4231d8a01" />

Still has rare issues:
<img width="955" height="854" alt="image" src="https://github.com/user-attachments/assets/971cf9a7-19cf-46c8-a842-b30334f02d9c" />

<img width="971" height="815" alt="image" src="https://github.com/user-attachments/assets/8ff75c50-c3f7-471b-9c6d-3b93175cb94f" />

# Test Project

[test_internal_bridges_project.zip](https://github.com/user-attachments/files/32026982/test_internal_bridges_project.zip)

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
