### PR TITLE
fix: Resolve inheritance for machine profiles in GuideFrame

### DIFF
--- a/src/slic3r/GUI/WebGuideDialog.cpp
+++ b/src/slic3r/GUI/WebGuideDialog.cpp
@@ -1032,6 +1032,37 @@ bool GuideFrame::run()
         return false;
 }
 
+// Orca: read `key` from a machine profile, following `inherits` when the leaf does not declare
+// it. Mirrors GetFilamentInfo's chain walk for filaments; machine profiles were being read raw,
+// so an inherited key came back null. `machine_by_name` maps a profile name to its machine_list
+// entry (which carries sub_path). Depth-bounded: a malformed profile set can name a cycle, and
+// this runs before any of it has been validated.
+static json GetMachineValue(const boost::filesystem::path& vendor_dir, const json& machine_by_name, const json& profile, const char* key, int depth = 0)
+{
+    if (profile.contains(key) && !profile[key].is_null())
+        return profile[key];
+    if (depth >= 16 || !profile.contains("inherits") || !profile["inherits"].is_string())
+        return json();
+
+    const std::string parent_name = profile["inherits"].get<std::string>();
+    if (!machine_by_name.contains(parent_name) || !machine_by_name[parent_name].contains("sub_path"))
+        return json();
+
+    const boost::filesystem::path parent_path =
+        boost::filesystem::absolute(vendor_dir / machine_by_name[parent_name]["sub_path"].get<std::string>()).make_preferred();
+    if (!boost::filesystem::exists(parent_path))
+        return json();
+
+    std::string contents;
+    if (!GuideFrame::LoadFile(parent_path.string(), contents))
+        return json();
+    const json parent = json::parse(contents, nullptr, false);
+    if (parent.is_discarded())
+        return json();
+
+    return GetMachineValue(vendor_dir, machine_by_name, parent, key, depth + 1);
+}
+
 int GuideFrame::GetFilamentInfo( std::string VendorDirectory, json & pFilaList, std::string filepath, std::string &sVendor, std::string &sType)
 {
     //GetStardardFilePath(filepath);
@@ -1385,6 +1416,15 @@ int GuideFrame::LoadProfileFamily(std::string strVendor, std::string strFilePath
         json pmachine = jLocal["machine_list"];
         nsize         = pmachine.size();
         BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << boost::format(",  got %1% machines") % nsize;
+        // Orca: machine profiles inherit, so a leaf that only overrides a few settings does not
+        // repeat its parent's keys -- exactly like filament profiles, which GetFilamentInfo
+        // already walks. Index the list by name so the walk below can find each parent's file.
+        json machine_by_name = json::object();
+        for (int n = 0; n < nsize; n++) {
+            json OneMachine = pmachine.at(n);
+            if (OneMachine.contains("name") && OneMachine["name"].is_string())
+                machine_by_name[OneMachine["name"].get<std::string>()] = OneMachine;
+        }
         for (int n = 0; n < nsize; n++) {
             json OneMachine = pmachine.at(n);
 
@@ -1399,10 +1439,26 @@ int GuideFrame::LoadProfileFamily(std::string strVendor, std::string strFilePath
             LoadFile(sub_file, contents);
             json pm = json::parse(contents);
 
-            std::string strInstant = pm["instantiation"];
+            std::string strInstant = pm.value("instantiation", std::string());
             if (strInstant.compare("true") == 0) {
-                OneMachine["model"] = pm["printer_model"];
-                OneMachine["nozzle"] = pm["nozzle_diameter"][0];
+                // Resolve through the inherits chain: a printer profile is free to take its
+                // model or nozzle sizes from its parent. Reading the leaf's raw json instead
+                // yielded null here, and the null then reached the compatible_printers loop
+                // below as a std::string conversion, throwing type_error.302 and aborting the
+                // WHOLE vendor family -- which is how one printer profile silently removed
+                // every one of its vendor's filaments from this dialog.
+                const json model  = GetMachineValue(vendor_dir, machine_by_name, pm, "printer_model");
+                const json nozzle = GetMachineValue(vendor_dir, machine_by_name, pm, "nozzle_diameter");
+                if (!model.is_string() || !nozzle.is_array() || nozzle.empty() || !nozzle.at(0).is_string()) {
+                    // Still unusable after the walk (a broken or missing parent). Skip this one
+                    // printer rather than letting it take its vendor down with it.
+                    BOOST_LOG_TRIVIAL(warning)
+                        << __FUNCTION__ << ": machine " << s1
+                        << " has no usable printer_model/nozzle_diameter even through inherits; skipping";
+                    continue;
+                }
+                OneMachine["model"]  = model;
+                OneMachine["nozzle"] = nozzle.at(0);
 
                 m_ProfileJson["machine"][s1]=OneMachine;
             }

--- a/src/slic3r/GUI/WebGuideDialog.hpp
+++ b/src/slic3r/GUI/WebGuideDialog.hpp
@@ -88,7 +88,9 @@ public:
     void        StrReplace(std::string &strBase, std::string strSrc, std::string strDes);
     std::string w2s(wxString sSrc);
     void        GetStardardFilePath(std::string &FilePath);
-    bool LoadFile(std::string jPath, std::string & sContent);
+    // Orca: static -- it touches no instance state, and the machine-profile inherits walk
+    // (GetMachineValue in the .cpp) needs it from file scope. Member call sites are unaffected.
+    static bool LoadFile(std::string jPath, std::string & sContent);
 
     // install plugin
     int DownloadPlugin();


### PR DESCRIPTION

# Description

GuideFrame has its own implementation for reading JSON profiles. For filaments it correctly walks inheritance but for machine profiles it did not. This corrects the gap.

Really screams for the creation of a standard inheritance-aware profile parser class that everything uses instead of different copy/pasted implementations.

# Screenshots/Recordings/Graphs


## Tests

Verified that profiles with inherited nozzle attributes are now read correctly.


[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
