### PR TITLE
Zero flow ironing 2

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -7270,8 +7270,11 @@ std::string GCode::extrude_infill(const Print &print, const std::vector<ObjectBy
                 if ((ee->role() == erIroning) == ironing)
                     extrusions.emplace_back(ee);
             if (! extrusions.empty()) {
-                m_config.apply(print.get_print_region(&region - &by_region.front()).config());
+                const PrintRegionConfig& region_config = print.get_print_region(&region - &by_region.front()).config();
+                m_config.apply(region_config);
                 chain_and_reorder_extrusion_entities(extrusions, m_last_pos.to_point());
+                if (ironing && region_config.ironing_flow == 0)
+                    gcode += this->writer().emit_retract(-region_config.ironing_retract, " ; ironing retract");
                 for (const ExtrusionEntity *fill : extrusions) {
                     auto *eec = dynamic_cast<const ExtrusionEntityCollection*>(fill);
                     if (eec) {
@@ -7280,6 +7283,8 @@ std::string GCode::extrude_infill(const Print &print, const std::vector<ObjectBy
                     } else
                         gcode += this->extrude_entity(*fill, extrusion_name);
                 }
+                if (ironing && region_config.ironing_flow == 0)
+                    gcode += this->writer().emit_unretract(region_config.ironing_retract + region_config.ironing_unretract_extra, " ; ironing retract");
             }
         }
     return gcode;

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -6461,11 +6461,11 @@ LayerResult GCode::process_layer(
                                             [](const ExtrusionEntity *ee) { return ee->role() == erIroning; });
                             if (zero_flow_ironing) {
                                 gcode += this->writer().ironing_e_move(-object_config.support_ironing_retract.value, "support ironing retract");
-                                this->writer().set_force_emit_zero_e(true);
+                                this->writer().set_zero_flow_ironing(true);
                             }
                             gcode += this->extrude_support(support_fills, erIroning);
                             if (zero_flow_ironing) {
-                                this->writer().set_force_emit_zero_e(false);
+                                this->writer().set_zero_flow_ironing(false);
                                 gcode += this->writer().ironing_e_move(object_config.support_ironing_retract.value + object_config.support_ironing_unretract_extra.value,
                                                                        "support ironing unretract");
                             }
@@ -7293,7 +7293,7 @@ std::string GCode::extrude_infill(const Print &print, const std::vector<ObjectBy
                 const bool zero_flow_ironing = ironing && region_config.ironing_flow == 0 && region_config.ironing_retract > 0;
                 if (zero_flow_ironing) {
                     gcode += this->writer().ironing_e_move(-region_config.ironing_retract, "ironing retract");
-                    this->writer().set_force_emit_zero_e(true);
+                    this->writer().set_zero_flow_ironing(true);
                 }
                 for (const ExtrusionEntity *fill : extrusions) {
                     auto *eec = dynamic_cast<const ExtrusionEntityCollection*>(fill);
@@ -7304,7 +7304,7 @@ std::string GCode::extrude_infill(const Print &print, const std::vector<ObjectBy
                         gcode += this->extrude_entity(*fill, extrusion_name);
                 }
                 if (zero_flow_ironing) {
-                    this->writer().set_force_emit_zero_e(false);
+                    this->writer().set_zero_flow_ironing(false);
                     gcode += this->writer().ironing_e_move(region_config.ironing_retract + region_config.ironing_unretract_extra, "ironing unretract");
                 }
             }
@@ -8847,26 +8847,31 @@ std::string GCode::retract(bool toolchange, bool is_last_retraction, LiftType li
     if (m_writer.filament() == nullptr)
         return gcode;
 
-    // wipe (if it's enabled for this extruder and we have a stored wipe path and no-zero wipe distance)
-    if (FILAMENT_CONFIG(wipe) && m_wipe.has_path() && scale_(FILAMENT_CONFIG(wipe_distance)) > SCALED_EPSILON) {
-        Wipe::RetractionValues wipeRetractions = m_wipe.calculateWipeRetractionLengths(*this, toolchange);
-        gcode += toolchange ? m_writer.retract_for_toolchange(true, wipeRetractions.retraction_length_before_wipe) :
-                              m_writer.retract(true, wipeRetractions.retraction_length_before_wipe);
-        gcode += m_wipe.wipe(*this, wipeRetractions.retraction_length_during_wipe, toolchange, is_last_retraction);
+    // ORCA: while a zero flow ironing pass is running the filament is already parked by the ironing
+    // retract, so retracting again would only wipe back over the surface just ironed and push the
+    // filament out again on arrival. Skip the filament motion; the travel and its lift still happen.
+    if (! m_writer.zero_flow_ironing()) {
+        // wipe (if it's enabled for this extruder and we have a stored wipe path and no-zero wipe distance)
+        if (FILAMENT_CONFIG(wipe) && m_wipe.has_path() && scale_(FILAMENT_CONFIG(wipe_distance)) > SCALED_EPSILON) {
+            Wipe::RetractionValues wipeRetractions = m_wipe.calculateWipeRetractionLengths(*this, toolchange);
+            gcode += toolchange ? m_writer.retract_for_toolchange(true, wipeRetractions.retraction_length_before_wipe) :
+                                  m_writer.retract(true, wipeRetractions.retraction_length_before_wipe);
+            gcode += m_wipe.wipe(*this, wipeRetractions.retraction_length_during_wipe, toolchange, is_last_retraction);
 
-        // Orca: wipeRetractions.retraction_length_after_wipe is not being used explicitly,
-        // the remaining retraction after wipe is handled by the subsequent m_writer.retract() call
+            // Orca: wipeRetractions.retraction_length_after_wipe is not being used explicitly,
+            // the remaining retraction after wipe is handled by the subsequent m_writer.retract() call
+        }
+
+        /*  The parent class will decide whether we need to perform an actual retraction
+            (the extruder might be already retracted fully or partially). We call these
+            methods even if we performed wipe, since this will ensure the entire retraction
+            length is honored in case wipe path was too short.  */
+        if ((!this->on_first_layer()  || this->config().bottom_surface_pattern != InfillPattern::ipHilbertCurve) &&
+	        (role != erTopSolidInfill || this->config().top_surface_pattern    != InfillPattern::ipHilbertCurve))
+            gcode += toolchange ? m_writer.retract_for_toolchange() : m_writer.retract();
+
+        gcode += m_writer.reset_e();
     }
-
-    /*  The parent class will decide whether we need to perform an actual retraction
-        (the extruder might be already retracted fully or partially). We call these
-        methods even if we performed wipe, since this will ensure the entire retraction
-        length is honored in case wipe path was too short.  */
-    if ((!this->on_first_layer()  || this->config().bottom_surface_pattern != InfillPattern::ipHilbertCurve) &&
-	    (role != erTopSolidInfill || this->config().top_surface_pattern    != InfillPattern::ipHilbertCurve))
-        gcode += toolchange ? m_writer.retract_for_toolchange() : m_writer.retract();
-
-    gcode += m_writer.reset_e();
     // Orca: check if should + can lift (roughly from SuperSlicer)
     RetractLiftEnforceType retract_lift_type = RetractLiftEnforceType(EXTRUDER_CONFIG(retract_lift_enforce));
 

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -6451,7 +6451,24 @@ LayerResult GCode::process_layer(
 
                         // Make sure ironing is the last
                         if (support_extrusion_role == erMixed || support_extrusion_role == erSupportMaterialInterface) {
-                            gcode += this->extrude_support(*instance_to_print.object_by_extruder.support, erIroning);
+                            const ExtrusionEntityCollection &support_fills   = *instance_to_print.object_by_extruder.support;
+                            const PrintObjectConfig         &object_config   = instance_to_print.print_object.config();
+                            // ORCA: a zero flow ironing pass only polishes the interface, so retract first to keep the
+                            // nozzle from oozing onto it. Only worth doing if this layer has ironing paths at all.
+                            const bool zero_flow_ironing = object_config.support_ironing_flow.value == 0 &&
+                                object_config.support_ironing_retract.value > 0 &&
+                                std::any_of(support_fills.entities.begin(), support_fills.entities.end(),
+                                            [](const ExtrusionEntity *ee) { return ee->role() == erIroning; });
+                            if (zero_flow_ironing) {
+                                gcode += this->writer().ironing_e_move(-object_config.support_ironing_retract.value, "support ironing retract");
+                                this->writer().set_force_emit_zero_e(true);
+                            }
+                            gcode += this->extrude_support(support_fills, erIroning);
+                            if (zero_flow_ironing) {
+                                this->writer().set_force_emit_zero_e(false);
+                                gcode += this->writer().ironing_e_move(object_config.support_ironing_retract.value + object_config.support_ironing_unretract_extra.value,
+                                                                       "support ironing unretract");
+                            }
                         }
                     }
 

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -7273,8 +7273,11 @@ std::string GCode::extrude_infill(const Print &print, const std::vector<ObjectBy
                 const PrintRegionConfig& region_config = print.get_print_region(&region - &by_region.front()).config();
                 m_config.apply(region_config);
                 chain_and_reorder_extrusion_entities(extrusions, m_last_pos.to_point());
-                if (ironing && region_config.ironing_flow == 0)
-                    gcode += this->writer().emit_retract(-region_config.ironing_retract, " ; ironing retract");
+                const bool zero_flow_ironing = ironing && region_config.ironing_flow == 0 && region_config.ironing_retract > 0;
+                if (zero_flow_ironing) {
+                    gcode += this->writer().ironing_e_move(-region_config.ironing_retract, "ironing retract");
+                    this->writer().set_force_emit_zero_e(true);
+                }
                 for (const ExtrusionEntity *fill : extrusions) {
                     auto *eec = dynamic_cast<const ExtrusionEntityCollection*>(fill);
                     if (eec) {
@@ -7283,8 +7286,10 @@ std::string GCode::extrude_infill(const Print &print, const std::vector<ObjectBy
                     } else
                         gcode += this->extrude_entity(*fill, extrusion_name);
                 }
-                if (ironing && region_config.ironing_flow == 0)
-                    gcode += this->writer().emit_unretract(region_config.ironing_retract + region_config.ironing_unretract_extra, " ; ironing retract");
+                if (zero_flow_ironing) {
+                    this->writer().set_force_emit_zero_e(false);
+                    gcode += this->writer().ironing_e_move(region_config.ironing_retract + region_config.ironing_unretract_extra, "ironing unretract");
+                }
             }
         }
     return gcode;

--- a/src/libslic3r/GCode/GCodeProcessor.cpp
+++ b/src/libslic3r/GCode/GCodeProcessor.cpp
@@ -4934,6 +4934,11 @@ void GCodeProcessor::process_G1(const std::array<std::optional<double>, 4>& axes
         return;
 
     EMoveType type = move_type(delta_pos);
+
+    if (m_extrusion_role == erIroning && m_end_position[Z] == m_extruded_last_z) {
+        type = EMoveType::Extrude;
+    }
+
     const float delta_xyz = std::sqrt(sqr(delta_pos[X]) + sqr(delta_pos[Y]) + sqr(delta_pos[Z]));
     m_travel_dist = delta_xyz;
 

--- a/src/libslic3r/GCode/GCodeProcessor.cpp
+++ b/src/libslic3r/GCode/GCodeProcessor.cpp
@@ -4935,9 +4935,8 @@ void GCodeProcessor::process_G1(const std::array<std::optional<double>, 4>& axes
 
     EMoveType type = move_type(delta_pos);
 
-    if (m_extrusion_role == erIroning && m_end_position[Z] == m_extruded_last_z) {
+    if (type == EMoveType::Travel && m_extrusion_role == erIroning && axes[E].has_value())
         type = EMoveType::Extrude;
-    }
 
     const float delta_xyz = std::sqrt(sqr(delta_pos[X]) + sqr(delta_pos[Y]) + sqr(delta_pos[Z]));
     m_travel_dist = delta_xyz;

--- a/src/libslic3r/GCodeWriter.cpp
+++ b/src/libslic3r/GCodeWriter.cpp
@@ -1099,7 +1099,7 @@ std::string GCodeWriter::extrude_to_xy(const Vec2d &point, double dE, const std:
 {
     m_pos(0) = point(0);
     m_pos(1) = point(1);
-    if(std::abs(dE) <= std::numeric_limits<double>::epsilon() && !m_force_emit_zero_e)
+    if(std::abs(dE) <= std::numeric_limits<double>::epsilon() && !m_zero_flow_ironing)
         force_no_extrusion = true;
 
     if (!force_no_extrusion)

--- a/src/libslic3r/GCodeWriter.cpp
+++ b/src/libslic3r/GCodeWriter.cpp
@@ -1202,13 +1202,7 @@ std::string GCodeWriter::_retract(double length, double restart_extra, const std
             gcode = FLAVOR_IS(gcfMachinekit) ? "G22 ; retract\n" : "G10 ; retract\n";
         }
         else {
-            // BBS
-            GCodeG1Formatter w;
-            w.emit_e(filament()->E());
-            w.emit_f(filament()->retract_speed() * 60.);
-            // BBS
-            w.emit_comment(GCodeWriter::full_gcode_comment, comment);
-            gcode = w.string();
+            gcode = this->emit_retract(filament()->E(), comment);
         }
     }
 
@@ -1231,20 +1225,39 @@ std::string GCodeWriter::unretract(float extra_retract)
             gcode += this->reset_e();
         }
         else {
-            //BBS
-            // use G1 instead of G0 because G0 will blend the restart with the previous travel move
-            GCodeG1Formatter w;
-            // extra_retract over-extrudes for the PETG pre-extrusion; 0 by
-            // default -> identical to the plain deretract E position.
-            w.emit_e(filament()->E() + extra_retract);
-            w.emit_f(filament()->deretract_speed() * 60.);
-            //BBS
-            w.emit_comment(GCodeWriter::full_gcode_comment, " ; unretract");
-            gcode += w.string();
+            gcode = this->emit_unretract(filament()->E(), " ; unretract");
         }
     }
-
+    
     return gcode;
+}
+
+std::string GCodeWriter::emit_retract(double E, std::string comment)
+{
+    //BBS
+    // use G1 instead of G0 because G0 will blend the restart with the previous travel move
+    GCodeG1Formatter w;
+    w.emit_e(E);
+    w.emit_f(filament()->retract_speed() * 60.);
+    //BBS
+    w.emit_comment(GCodeWriter::full_gcode_comment, comment);
+
+    return w.string();
+}
+
+std::string GCodeWriter::emit_unretract(double E, std::string comment)
+{
+    //BBS
+    // use G1 instead of G0 because G0 will blend the restart with the previous travel move
+    GCodeG1Formatter w;
+    // extra_retract over-extrudes for the PETG pre-extrusion; 0 by
+    // default -> identical to the plain deretract E position.
+    w.emit_e(E);
+    w.emit_f(filament()->deretract_speed() * 60.);
+    //BBS
+    w.emit_comment(GCodeWriter::full_gcode_comment, comment);
+
+    return w.string();
 }
 
 

--- a/src/libslic3r/GCodeWriter.cpp
+++ b/src/libslic3r/GCodeWriter.cpp
@@ -1099,7 +1099,7 @@ std::string GCodeWriter::extrude_to_xy(const Vec2d &point, double dE, const std:
 {
     m_pos(0) = point(0);
     m_pos(1) = point(1);
-    if(std::abs(dE) <= std::numeric_limits<double>::epsilon())
+    if(std::abs(dE) <= std::numeric_limits<double>::epsilon() && !m_force_emit_zero_e)
         force_no_extrusion = true;
 
     if (!force_no_extrusion)
@@ -1202,7 +1202,13 @@ std::string GCodeWriter::_retract(double length, double restart_extra, const std
             gcode = FLAVOR_IS(gcfMachinekit) ? "G22 ; retract\n" : "G10 ; retract\n";
         }
         else {
-            gcode = this->emit_retract(filament()->E(), comment);
+            // BBS
+            GCodeG1Formatter w;
+            w.emit_e(filament()->E());
+            w.emit_f(filament()->retract_speed() * 60.);
+            // BBS
+            w.emit_comment(GCodeWriter::full_gcode_comment, comment);
+            gcode = w.string();
         }
     }
 
@@ -1225,39 +1231,37 @@ std::string GCodeWriter::unretract(float extra_retract)
             gcode += this->reset_e();
         }
         else {
-            gcode = this->emit_unretract(filament()->E(), " ; unretract");
+            //BBS
+            // use G1 instead of G0 because G0 will blend the restart with the previous travel move
+            GCodeG1Formatter w;
+            // extra_retract over-extrudes for the PETG pre-extrusion; 0 by
+            // default -> identical to the plain deretract E position.
+            w.emit_e(filament()->E() + extra_retract);
+            w.emit_f(filament()->deretract_speed() * 60.);
+            //BBS
+            w.emit_comment(GCodeWriter::full_gcode_comment, " ; unretract");
+            gcode += w.string();
         }
     }
-    
+
     return gcode;
 }
 
-std::string GCodeWriter::emit_retract(double E, std::string comment)
+std::string GCodeWriter::ironing_e_move(double dE, const std::string &comment)
 {
-    //BBS
-    // use G1 instead of G0 because G0 will blend the restart with the previous travel move
+    // The retract state (Extruder::m_retracted) is intentionally left alone: marking the
+    // extruder as retracted would make the arrival unretract of the very next travel
+    // restore the filament before ironing even starts.
     GCodeG1Formatter w;
-    w.emit_e(E);
-    w.emit_f(filament()->retract_speed() * 60.);
-    //BBS
+    w.emit_e(this->config.use_relative_e_distances ? dE : filament()->E() + dE);
+    w.emit_f((dE < 0. ? filament()->retract_speed() : filament()->deretract_speed()) * 60.);
     w.emit_comment(GCodeWriter::full_gcode_comment, comment);
-
-    return w.string();
-}
-
-std::string GCodeWriter::emit_unretract(double E, std::string comment)
-{
-    //BBS
-    // use G1 instead of G0 because G0 will blend the restart with the previous travel move
-    GCodeG1Formatter w;
-    // extra_retract over-extrudes for the PETG pre-extrusion; 0 by
-    // default -> identical to the plain deretract E position.
-    w.emit_e(E);
-    w.emit_f(filament()->deretract_speed() * 60.);
-    //BBS
-    w.emit_comment(GCodeWriter::full_gcode_comment, comment);
-
-    return w.string();
+    std::string gcode = w.string();
+    // In absolute E mode the move above leaves the firmware E coordinate offset by dE
+    // from the tracked position; re-anchor both at zero so subsequent moves stay in sync.
+    if (! this->config.use_relative_e_distances)
+        gcode += this->reset_e(true);
+    return gcode;
 }
 
 

--- a/src/libslic3r/GCodeWriter.hpp
+++ b/src/libslic3r/GCodeWriter.hpp
@@ -92,7 +92,10 @@ public:
     // Default 0 -> byte-identical to the plain deretract.
     std::string unretract(float extra_retract = 0.f);
     std::string ironing_e_move(double dE, const std::string &comment);
-    void set_force_emit_zero_e(bool force) { m_force_emit_zero_e = force; }
+    // A zero flow ironing pass is in progress: its strokes keep an explicit E word even though they
+    // extrude nothing, and the filament stays parked where the ironing retract left it.
+    void set_zero_flow_ironing(bool active) { m_zero_flow_ironing = active; }
+    bool zero_flow_ironing() const { return m_zero_flow_ironing; }
     // do lift instantly
     std::string eager_lift(const LiftType type);
     // record a lift request, do realy lift in next travel
@@ -183,7 +186,7 @@ public:
     //BBS: x, y offset for gcode generated
     double          m_x_offset{ 0 };
     double          m_y_offset{ 0 };
-    bool            m_force_emit_zero_e = false;
+    bool            m_zero_flow_ironing = false;
 
     // Orca: slicing resolution in mm
     double          m_resolution = 0.01;

--- a/src/libslic3r/GCodeWriter.hpp
+++ b/src/libslic3r/GCodeWriter.hpp
@@ -91,6 +91,8 @@ public:
     // extra_retract adds a small over-extrusion to the deretract move (PETG pre-extrusion).
     // Default 0 -> byte-identical to the plain deretract.
     std::string unretract(float extra_retract = 0.f);
+    std::string emit_retract(double E, std::string comment);
+    std::string emit_unretract(double E, std::string comment);
     // do lift instantly
     std::string eager_lift(const LiftType type);
     // record a lift request, do realy lift in next travel

--- a/src/libslic3r/GCodeWriter.hpp
+++ b/src/libslic3r/GCodeWriter.hpp
@@ -91,8 +91,8 @@ public:
     // extra_retract adds a small over-extrusion to the deretract move (PETG pre-extrusion).
     // Default 0 -> byte-identical to the plain deretract.
     std::string unretract(float extra_retract = 0.f);
-    std::string emit_retract(double E, std::string comment);
-    std::string emit_unretract(double E, std::string comment);
+    std::string ironing_e_move(double dE, const std::string &comment);
+    void set_force_emit_zero_e(bool force) { m_force_emit_zero_e = force; }
     // do lift instantly
     std::string eager_lift(const LiftType type);
     // record a lift request, do realy lift in next travel
@@ -183,6 +183,7 @@ public:
     //BBS: x, y offset for gcode generated
     double          m_x_offset{ 0 };
     double          m_y_offset{ 0 };
+    bool            m_force_emit_zero_e = false;
 
     // Orca: slicing resolution in mm
     double          m_resolution = 0.01;

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -1075,6 +1075,8 @@ static std::vector<std::string> s_Preset_print_options{
     "ironing_type",
     "ironing_pattern",
     "ironing_flow",
+    "ironing_retract",
+    "ironing_unretract_extra",
     "ironing_speed",
     "ironing_spacing",
     "ironing_angle",

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -1085,6 +1085,8 @@ static std::vector<std::string> s_Preset_print_options{
     "support_ironing",
     "support_ironing_pattern",
     "support_ironing_flow",
+    "support_ironing_retract",
+    "support_ironing_unretract_extra",
     "support_ironing_spacing",
     "max_travel_detour_distance",
     "fuzzy_skin", "fuzzy_skin_thickness", "fuzzy_skin_point_distance", "fuzzy_skin_first_layer", "fuzzy_skin_noise_type", "fuzzy_skin_mode", "fuzzy_skin_scale", "fuzzy_skin_octaves", "fuzzy_skin_persistence", "fuzzy_skin_ripples_per_layer", "fuzzy_skin_ripple_offset", "fuzzy_skin_layers_between_ripple_offset",

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -4776,7 +4776,7 @@ void PrintConfigDef::init_fff_params()
     def->sidetext = "mm";
     def->min = -20;
     def->max = 20;
-    def->mode = comAdvanced;
+    def->mode = comExpert;
     def->set_default_value(new ConfigOptionFloat(0));
 
     def = this->add("ironing_spacing", coFloat);

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -4762,7 +4762,9 @@ void PrintConfigDef::init_fff_params()
     def = this->add("ironing_retract", coFloat);
     def->label = L("Ironing retract");
     def->category = L("Quality");
-    def->tooltip = L("Retract length before ironing with zero flow.");
+    def->tooltip = L("Retraction distance before an ironing pass with zero flow.\n"
+                     "This stops the nozzle from oozing onto the finished surface, "
+                     "and marks the ironing moves as extrusion instead of travel in the G-code.");
     def->sidetext = "mm";
     def->min = 0;
     def->max = 100;
@@ -4772,7 +4774,10 @@ void PrintConfigDef::init_fff_params()
     def = this->add("ironing_unretract_extra", coFloat);
     def->label = L("Ironing unretract extra");
     def->category = L("Quality");
-    def->tooltip = L("Extra unretract length after ironing with zero flow.");
+    def->tooltip = L("Extra length pushed out, on top of the ironing retraction, "
+                     "when unretracting after a zero flow ironing pass.\n"
+                     "Compensates for filament lost to ooze or heat creep while "
+                     "retracted; use a negative value if it over-extrudes instead.");
     def->sidetext = "mm";
     def->min = -20;
     def->max = 20;

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -7200,6 +7200,31 @@ void PrintConfigDef::init_fff_params()
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionPercent(10));
 
+    def = this->add("support_ironing_retract", coFloat);
+    def->label = L("Support ironing retract");
+    def->category = L("Support");
+    def->tooltip = L("Retraction distance before a support interface ironing pass with zero flow.\n"
+                     "This stops the nozzle from oozing onto the finished surface, "
+                     "and marks the ironing moves as extrusion instead of travel in the G-code.");
+    def->sidetext = "mm";
+    def->min = 0;
+    def->max = 100;
+    def->mode = comAdvanced;
+    def->set_default_value(new ConfigOptionFloat(20));
+
+    def = this->add("support_ironing_unretract_extra", coFloat);
+    def->label = L("Support ironing unretract extra");
+    def->category = L("Support");
+    def->tooltip = L("Extra length pushed out, on top of the support ironing retraction, "
+                     "when unretracting after a zero flow ironing pass.\n"
+                     "Compensates for filament lost to ooze or heat creep while "
+                     "retracted; use a negative value if it over-extrudes instead.");
+    def->sidetext = "mm";
+    def->min = -20;
+    def->max = 20;
+    def->mode = comExpert;
+    def->set_default_value(new ConfigOptionFloat(0));
+
     def = this->add("support_ironing_spacing", coFloat);
     def->label = L("Support Ironing line spacing");
     def->category = L("Support");

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -4759,6 +4759,26 @@ void PrintConfigDef::init_fff_params()
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionPercent(10));
 
+    def = this->add("ironing_retract", coFloat);
+    def->label = L("Ironing retract");
+    def->category = L("Quality");
+    def->tooltip = L("Retract length before ironing with zero flow.");
+    def->sidetext = "mm";
+    def->min = 0;
+    def->max = 100;
+    def->mode = comAdvanced;
+    def->set_default_value(new ConfigOptionFloat(20));
+
+    def = this->add("ironing_unretract_extra", coFloat);
+    def->label = L("Ironing unretract extra");
+    def->category = L("Quality");
+    def->tooltip = L("Extra unretract length after ironing with zero flow.");
+    def->sidetext = "mm";
+    def->min = -20;
+    def->max = 20;
+    def->mode = comAdvanced;
+    def->set_default_value(new ConfigOptionFloat(0));
+
     def = this->add("ironing_spacing", coFloat);
     def->label = L("Ironing line spacing");
     def->category = L("Quality");

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -1182,6 +1182,8 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionBool,                support_ironing))
     ((ConfigOptionEnum<InfillPattern>, support_ironing_pattern))
     ((ConfigOptionPercent,             support_ironing_flow))
+    ((ConfigOptionFloat,               support_ironing_retract))
+    ((ConfigOptionFloat,               support_ironing_unretract_extra))
     ((ConfigOptionFloat,               support_ironing_spacing))
     ((ConfigOptionFloat,               xy_hole_compensation))
     ((ConfigOptionFloat,               xy_contour_compensation))

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -1335,6 +1335,8 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionEnum<IroningType>, ironing_type))
     ((ConfigOptionEnum<InfillPattern>, ironing_pattern))
     ((ConfigOptionPercent, ironing_flow))
+    ((ConfigOptionFloat, ironing_retract))
+    ((ConfigOptionFloat, ironing_unretract_extra))
     ((ConfigOptionFloat, ironing_spacing))
     ((ConfigOptionFloat, ironing_inset))
     ((ConfigOptionFloat, ironing_direction))

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -1548,7 +1548,9 @@ bool PrintObject::invalidate_state_by_config_options(
             || opt_key == "filament_flow_ratio"
             || opt_key == "scarf_joint_flow_ratio"
             || opt_key == "spiral_starting_flow_ratio"
-            || opt_key == "spiral_finishing_flow_ratio") {
+            || opt_key == "spiral_finishing_flow_ratio"
+            || opt_key == "ironing_retract"
+            || opt_key == "ironing_unretract_extra") {
             invalidated |= m_print->invalidate_step(psGCodeExport);
         } else if (
                opt_key == "flush_into_infill"

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -1550,7 +1550,9 @@ bool PrintObject::invalidate_state_by_config_options(
             || opt_key == "spiral_starting_flow_ratio"
             || opt_key == "spiral_finishing_flow_ratio"
             || opt_key == "ironing_retract"
-            || opt_key == "ironing_unretract_extra") {
+            || opt_key == "ironing_unretract_extra"
+            || opt_key == "support_ironing_retract"
+            || opt_key == "support_ironing_unretract_extra") {
             invalidated |= m_print->invalidate_step(psGCodeExport);
         } else if (
                opt_key == "flush_into_infill"

--- a/src/libslic3r/Support/SupportCommon.cpp
+++ b/src/libslic3r/Support/SupportCommon.cpp
@@ -434,7 +434,9 @@ static inline void fill_expolygon_generate_paths(
         dst,
         std::move(polylines),
         role,
-        flow.mm3_per_mm(), flow.width(), flow.height());
+        // ORCA: a zero height flow is a zero flow ironing pass, which deliberately extrudes nothing.
+        // Flow::mm3_per_mm() rejects the resulting zero cross section, so bypass it in that case only.
+        flow.height() > 0.f ? flow.mm3_per_mm() : 0., flow.width(), flow.height());
 }
 
 static inline void fill_expolygons_generate_paths(

--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -919,6 +919,8 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig *config, in
     bool has_support_ironing = can_ironing_support && config->opt_bool("support_ironing");
     for (auto el : {"support_ironing_pattern", "support_ironing_flow", "support_ironing_spacing" })
         toggle_line(el, has_support_ironing);
+    for (auto el : {"support_ironing_retract", "support_ironing_unretract_extra"})
+        toggle_line(el, has_support_ironing && config->opt<ConfigOptionPercent>("support_ironing_flow")->value == 0);
     // Orca: Force solid support interface when using support ironing
     toggle_field("support_interface_spacing", have_support_material && have_support_interface && !has_support_ironing);
 

--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -954,6 +954,9 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig *config, in
     for (auto el : {"ironing_angle", "ironing_angle_fixed"})
         toggle_field(el, has_ironing && has_rectilinear_ironing);
     
+    for (auto el : { "ironing_retract", "ironing_unretract_extra"})
+        toggle_line(el,  has_ironing && config->opt<ConfigOptionPercent>("ironing_flow")->value == 0);
+
     toggle_line("ironing_speed", has_ironing || has_support_ironing);
 
     bool has_zaa = config->opt_bool("zaa_enabled");

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -2682,6 +2682,8 @@ void TabPrint::build()
         optgroup->append_single_option_line("ironing_type", "quality_settings_ironing#type");
         optgroup->append_single_option_line("ironing_pattern", "quality_settings_ironing#pattern");
         optgroup->append_single_option_line("ironing_flow", "quality_settings_ironing#flow");
+        optgroup->append_single_option_line("ironing_retract", "quality_settings_ironing#flow");
+        optgroup->append_single_option_line("ironing_unretract_extra", "quality_settings_ironing#flow");
         optgroup->append_single_option_line("ironing_spacing", "quality_settings_ironing#line-spacing");
         optgroup->append_single_option_line("ironing_inset", "quality_settings_ironing#inset");
         optgroup->append_single_option_line("ironing_angle", "quality_settings_ironing#angle-offset");

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -2930,6 +2930,8 @@ void TabPrint::build()
         optgroup->append_single_option_line("support_ironing", "support_settings_ironing");
         optgroup->append_single_option_line("support_ironing_pattern", "support_settings_ironing#pattern");
         optgroup->append_single_option_line("support_ironing_flow", "support_settings_ironing#flow");
+        optgroup->append_single_option_line("support_ironing_retract", "support_settings_ironing#flow");
+        optgroup->append_single_option_line("support_ironing_unretract_extra", "support_settings_ironing#flow");
         optgroup->append_single_option_line("support_ironing_spacing", "support_settings_ironing#line-spacing");
 
         //optgroup = page->new_optgroup(L("Options for support material and raft"));

--- a/tests/fff_print/test_fill.cpp
+++ b/tests/fff_print/test_fill.cpp
@@ -4,6 +4,7 @@
 #include <cmath>
 #include <map>
 #include <numeric>
+#include <fstream>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -988,4 +989,71 @@ TEST_CASE("Smoothing multiline lightning infill keeps its outlines connected", "
     // The outlines are still rounded.
     REQUIRE(smooth.point_count > sharp.point_count);
     REQUIRE(smooth.sharp_turns < sharp.sharp_turns);
+}
+
+// Lines of the first ironing block: everything between ";TYPE:Ironing" and the next
+// ";TYPE:" (or ";LAYER_CHANGE"), plus the `before` lines preceding the tag.
+static std::pair<std::vector<std::string>, std::vector<std::string>> ironing_block(const std::string &gcode, size_t before = 20)
+{
+    std::vector<std::string> lines;
+    std::istringstream stream(gcode);
+    std::string line;
+    while (std::getline(stream, line))
+        lines.emplace_back(line);
+    auto tag = std::find_if(lines.begin(), lines.end(), [](const std::string &l) { return l.rfind(";TYPE:Ironing", 0) == 0; });
+    REQUIRE(tag != lines.end());
+    auto block_end = std::find_if(tag + 1, lines.end(), [](const std::string &l) {
+        return l.rfind(";TYPE:", 0) == 0 || l.rfind(";LAYER_CHANGE", 0) == 0;
+    });
+    auto first = tag - std::min<size_t>(before, tag - lines.begin());
+    return { std::vector<std::string>(first, tag), std::vector<std::string>(tag + 1, block_end) };
+}
+
+TEST_CASE("Zero-flow ironing retracts around the ironing block and keeps E words on its strokes", "[Fill][Ironing]")
+{
+    auto sliced = [](const char *relative_e) {
+        DynamicPrintConfig config = DynamicPrintConfig::full_print_config();
+        config.set_deserialize_strict({
+            {"ironing_type", "topmost"},
+            {"ironing_flow", 0},
+            {"ironing_retract", 5},
+            {"ironing_unretract_extra", 0.5},
+            {"retraction_length", "1,1"},
+            {"layer_height", 0.2},
+            {"use_relative_e_distances", relative_e},
+        });
+        return Slic3r::Test::slice({Slic3r::Test::cube(20.)}, config);
+    };
+
+    SECTION("relative E distances") {
+        const std::string gcode = sliced("1");
+        const auto [before, block] = ironing_block(gcode);
+
+        // The 5mm ironing retract precedes the block; the unretract (5 + 0.5 extra) closes it.
+        const bool retract_before = std::any_of(before.begin(), before.end(),
+            [](const std::string &l) { return l.rfind("G1 E-5 ", 0) == 0; });
+        REQUIRE(retract_before);
+        const bool unretract_in_block = std::any_of(block.begin(), block.end(),
+            [](const std::string &l) { return l.rfind("G1 E5.5 ", 0) == 0; });
+        REQUIRE(unretract_in_block);
+
+        // Ironing strokes carry an explicit E word even at zero flow — the preview
+        // relies on it to tell strokes apart from travel moves.
+        const bool stroke_with_e = std::any_of(block.begin(), block.end(),
+            [](const std::string &l) { return l.rfind("G1 X", 0) == 0 && l.find(" E") != std::string::npos; });
+        REQUIRE(stroke_with_e);
+    }
+
+    SECTION("absolute E distances") {
+        const std::string gcode = sliced("0");
+        const auto [before, block] = ironing_block(gcode);
+
+        // The raw retract is re-anchored with G92 E0 so tracked and firmware E agree.
+        const bool reanchored = std::any_of(before.begin(), before.end(),
+            [](const std::string &l) { return l.rfind("G92 E0", 0) == 0; });
+        REQUIRE(reanchored);
+        const bool stroke_with_e = std::any_of(block.begin(), block.end(),
+            [](const std::string &l) { return l.rfind("G1 X", 0) == 0 && l.find(" E") != std::string::npos; });
+        REQUIRE(stroke_with_e);
+    }
 }

--- a/tests/fff_print/test_gcode_timing.cpp
+++ b/tests/fff_print/test_gcode_timing.cpp
@@ -418,3 +418,38 @@ TEST_CASE("Per-slot machine limits follow the active nozzle", "[GCodeTiming][Mul
         REQUIRE_THAT(times[2], Catch::Matchers::WithinRel(101.0 / 200.0, 0.10));
     }
 }
+
+TEST_CASE("Zero-flow ironing strokes classify as ironing extrusions, travels and unretracts stay themselves", "[GCodeProcessor]")
+{
+    // Zero-flow ironing strokes carry an explicit E word with zero displacement;
+    // travel moves carry no E word. The preview relies on that difference: the
+    // strokes must render as ironing, while travels between islands must not be
+    // painted as extrusions and the closing unretract must not pollute flow/stats.
+    const char* gcode =
+        "M83\n"
+        "; FEATURE: Ironing\n"
+        "G1 X10 Y10 E0 F1200\n"   // stroke
+        "G1 X20 Y10 E0\n"         // stroke
+        "G1 X30 Y30 F7200\n"      // travel to the next island
+        "G1 X40 Y30 E0 F1200\n"   // stroke
+        "G1 E25.5 F1800\n";       // ironing unretract
+
+    FullPrintConfig config = make_config(0., 0., 0.);
+    GCodeProcessor proc;
+    run_processor(proc, config, gcode);
+
+    int iron_strokes = 0, travels = 0, unretracts = 0;
+    for (const auto& mv : proc.get_result().moves) {
+        if (mv.type == EMoveType::Extrude && mv.extrusion_role == erIroning)
+            ++iron_strokes;
+        else if (mv.type == EMoveType::Travel)
+            ++travels;
+        else if (mv.type == EMoveType::Unretract)
+            ++unretracts;
+    }
+    // The processor discretizes each G1 into several vertices, so compare against
+    // lower bounds instead of exact per-line counts.
+    REQUIRE(iron_strokes >= 3);
+    REQUIRE(travels >= 1);
+    REQUIRE(unretracts == 1);
+}

--- a/tests/fff_print/test_gcodewriter.cpp
+++ b/tests/fff_print/test_gcodewriter.cpp
@@ -892,10 +892,10 @@ TEST_CASE("Ironing E moves keep the firmware and tracked E position in sync in b
         writer.config.use_relative_e_distances.value = true;
         std::string plain = writer.extrude_to_xy(Vec2d(10., 10.), 0., "");
         REQUIRE(plain.find(" E") == std::string::npos);
-        writer.set_force_emit_zero_e(true);
+        writer.set_zero_flow_ironing(true);
         std::string forced = writer.extrude_to_xy(Vec2d(20., 10.), 0., "");
         REQUIRE(forced.find(" E0") != std::string::npos);
-        writer.set_force_emit_zero_e(false);
+        writer.set_zero_flow_ironing(false);
         std::string after = writer.extrude_to_xy(Vec2d(30., 10.), 0., "");
         REQUIRE(after.find(" E") == std::string::npos);
     }

--- a/tests/fff_print/test_gcodewriter.cpp
+++ b/tests/fff_print/test_gcodewriter.cpp
@@ -847,3 +847,56 @@ TEST_CASE("Custom G-code motion limits are restored before generated moves", "[G
     REQUIRE(gcode.find("M204 S6000 ; adjust acceleration", custom_gcode_pos) != std::string::npos);
     REQUIRE(gcode.find("M205 X8 Y8 ; adjust jerk", custom_gcode_pos) != std::string::npos);
 }
+
+TEST_CASE("Ironing E moves keep the firmware and tracked E position in sync in both E modes", "[GCodeWriter]") {
+    GCodeWriter writer;
+    writer.config.retraction_speed.values   = {40.};
+    writer.config.deretraction_speed.values = {25.};
+    writer.config.filament_diameter.values  = {1.75};
+    writer.set_extruders({0});
+    writer.toolchange(0, 0);
+    REQUIRE(writer.filament() != nullptr);
+
+    SECTION("relative E distances emit the shift verbatim, without a G92 re-anchor") {
+        writer.config.use_relative_e_distances.value = true;
+
+        std::string retract = writer.ironing_e_move(-20., "ironing retract");
+        REQUIRE(retract.find("E-20") != std::string::npos);
+        REQUIRE(retract.find("F2400") != std::string::npos); // 40 mm/s retract speed
+        REQUIRE(retract.find("G92") == std::string::npos);
+
+        std::string unretract = writer.ironing_e_move(20.5, "ironing unretract");
+        REQUIRE(unretract.find("E20.5") != std::string::npos);
+        REQUIRE(unretract.find("F1500") != std::string::npos); // 25 mm/s deretract speed
+    }
+
+    SECTION("absolute E distances target tracked E + shift, then re-anchor with G92 E0") {
+        writer.config.use_relative_e_distances.value = false;
+        writer.filament()->extrude(5.); // prior extrusion: tracked E = 5
+
+        std::string retract = writer.ironing_e_move(-20., "ironing retract");
+        REQUIRE(retract.find("E-15") != std::string::npos); // 5 - 20, an absolute target
+        REQUIRE(retract.find("G92 E0") != std::string::npos);
+        // The tracked position was re-anchored with the firmware, so the next
+        // absolute E word starts from 0 instead of silently undoing the shift.
+        REQUIRE_THAT(writer.filament()->E(), Catch::Matchers::WithinAbs(0., 1e-9));
+    }
+
+    SECTION("the retract state is left alone, so travel retracts keep working on top") {
+        writer.config.use_relative_e_distances.value = true;
+        writer.ironing_e_move(-20., "ironing retract");
+        REQUIRE_THAT(writer.filament()->retracted(), Catch::Matchers::WithinAbs(0., 1e-9));
+    }
+
+    SECTION("zero-dE strokes emit an explicit E word only while forced") {
+        writer.config.use_relative_e_distances.value = true;
+        std::string plain = writer.extrude_to_xy(Vec2d(10., 10.), 0., "");
+        REQUIRE(plain.find(" E") == std::string::npos);
+        writer.set_force_emit_zero_e(true);
+        std::string forced = writer.extrude_to_xy(Vec2d(20., 10.), 0., "");
+        REQUIRE(forced.find(" E0") != std::string::npos);
+        writer.set_force_emit_zero_e(false);
+        std::string after = writer.extrude_to_xy(Vec2d(30., 10.), 0., "");
+        REQUIRE(after.find(" E") == std::string::npos);
+    }
+}

--- a/tests/fff_print/test_support_material.cpp
+++ b/tests/fff_print/test_support_material.cpp
@@ -149,18 +149,31 @@ TEST_CASE("Zero flow support ironing retracts around the ironing block", "[Suppo
         const auto [before, block] = ironing_block(sliced(0));
 
         // The 5mm ironing retract precedes the block; the unretract (5 + 0.5 extra) closes it.
-        const bool retract_before = std::any_of(before.begin(), before.end(),
+        auto ironing_retract = std::find_if(before.begin(), before.end(),
             [](const std::string &l) { return l.rfind("G1 E-5 ", 0) == 0; });
-        REQUIRE(retract_before);
-        const bool unretract_in_block = std::any_of(block.begin(), block.end(),
+        REQUIRE(ironing_retract != before.end());
+        auto ironing_unretract = std::find_if(block.begin(), block.end(),
             [](const std::string &l) { return l.rfind("G1 E5.5 ", 0) == 0; });
-        REQUIRE(unretract_in_block);
+        REQUIRE(ironing_unretract != block.end());
 
         // Ironing strokes carry an explicit E word even at zero flow — the preview
         // relies on it to tell strokes apart from travel moves.
-        const bool stroke_with_e = std::any_of(block.begin(), block.end(),
+        const bool stroke_with_e = std::any_of(block.begin(), ironing_unretract,
             [](const std::string &l) { return l.rfind("G1 X", 0) == 0 && l.find(" E") != std::string::npos; });
         REQUIRE(stroke_with_e);
+
+        // Between those two the filament stays parked, on the way in and between ironing islands.
+        // An ordinary travel retract there would wipe back over the surface just ironed, then
+        // unretract onto it.
+        const bool retracts_on_approach = std::any_of(ironing_retract + 1, before.end(),
+            [](const std::string &l) { return l.find(" E-") != std::string::npos; });
+        REQUIRE_FALSE(retracts_on_approach);
+        const bool retracts_inside = std::any_of(block.begin(), ironing_unretract,
+            [](const std::string &l) { return l.find(" E-") != std::string::npos; });
+        REQUIRE_FALSE(retracts_inside);
+        const bool unretracts_inside = std::any_of(block.begin(), ironing_unretract,
+            [](const std::string &l) { return l.find("; unretract") != std::string::npos; });
+        REQUIRE_FALSE(unretracts_inside);
     }
 
     SECTION("non-zero flow leaves the pass untouched") {

--- a/tests/fff_print/test_support_material.cpp
+++ b/tests/fff_print/test_support_material.cpp
@@ -1,5 +1,10 @@
 #include <catch2/catch_all.hpp>
 
+#include <algorithm>
+#include <sstream>
+#include <string>
+#include <vector>
+
 #include "libslic3r/GCodeReader.hpp"
 #include "libslic3r/Layer.hpp"
 
@@ -103,4 +108,69 @@ TEST_CASE("Support G-code emission survives a second slice in the same process",
 
     const std::string second = slice({ TestMesh::overhang }, { { "enable_support", 1 } });
     REQUIRE(! layers_with_role(second, "support").empty());
+}
+
+// Lines of the first ironing block: everything between ";TYPE:Ironing" and the next ";TYPE:"
+// (or ";LAYER_CHANGE"), plus the `before` lines preceding the tag.
+static std::pair<std::vector<std::string>, std::vector<std::string>> ironing_block(const std::string &gcode, size_t before = 20)
+{
+    std::vector<std::string> lines;
+    std::istringstream stream(gcode);
+    std::string line;
+    while (std::getline(stream, line))
+        lines.emplace_back(line);
+    auto tag = std::find_if(lines.begin(), lines.end(), [](const std::string &l) { return l.rfind(";TYPE:Ironing", 0) == 0; });
+    REQUIRE(tag != lines.end());
+    auto block_end = std::find_if(tag + 1, lines.end(), [](const std::string &l) {
+        return l.rfind(";TYPE:", 0) == 0 || l.rfind(";LAYER_CHANGE", 0) == 0;
+    });
+    auto first = tag - std::min<size_t>(before, tag - lines.begin());
+    return { std::vector<std::string>(first, tag), std::vector<std::string>(tag + 1, block_end) };
+}
+
+// A zero flow support ironing pass extrudes nothing, so the interface flow has no cross section
+// at all — which used to abort slicing — and the pass retracts to stop the nozzle oozing onto
+// the surface it just smoothed.
+TEST_CASE("Zero flow support ironing retracts around the ironing block", "[SupportMaterial][Ironing]")
+{
+    auto sliced = [](int ironing_flow) {
+        return slice({ TestMesh::overhang }, {
+            { "enable_support",                  1 },
+            { "support_interface_top_layers",    2 },
+            { "support_ironing",                 1 },
+            { "support_ironing_flow",            ironing_flow },
+            { "support_ironing_retract",         5 },
+            { "support_ironing_unretract_extra", 0.5 },
+            { "use_relative_e_distances",        1 },
+        });
+    };
+
+    SECTION("zero flow") {
+        const auto [before, block] = ironing_block(sliced(0));
+
+        // The 5mm ironing retract precedes the block; the unretract (5 + 0.5 extra) closes it.
+        const bool retract_before = std::any_of(before.begin(), before.end(),
+            [](const std::string &l) { return l.rfind("G1 E-5 ", 0) == 0; });
+        REQUIRE(retract_before);
+        const bool unretract_in_block = std::any_of(block.begin(), block.end(),
+            [](const std::string &l) { return l.rfind("G1 E5.5 ", 0) == 0; });
+        REQUIRE(unretract_in_block);
+
+        // Ironing strokes carry an explicit E word even at zero flow — the preview
+        // relies on it to tell strokes apart from travel moves.
+        const bool stroke_with_e = std::any_of(block.begin(), block.end(),
+            [](const std::string &l) { return l.rfind("G1 X", 0) == 0 && l.find(" E") != std::string::npos; });
+        REQUIRE(stroke_with_e);
+    }
+
+    SECTION("non-zero flow leaves the pass untouched") {
+        const auto [before, block] = ironing_block(sliced(10));
+
+        const bool retract_before = std::any_of(before.begin(), before.end(),
+            [](const std::string &l) { return l.rfind("G1 E-5 ", 0) == 0; });
+        REQUIRE_FALSE(retract_before);
+        const bool unretract_in_block = std::any_of(block.begin(), block.end(),
+            [](const std::string &l) { return l.rfind("G1 E5.5 ", 0) == 0; });
+        REQUIRE_FALSE(unretract_in_block);
+    }
 }


### PR DESCRIPTION
# Description

Based in #10350 but with some fixes and additions:

- Absolute E support — the retract/unretract were raw G1 E±20 moves that bypassed the E-position tracking, which broke g-code with absolute E distances (the E value was interpreted as an absolute target, and the next move undid the retract). They now go through a new ironing_e_move() that emits the correct value for both E modes and re-anchors with G92 E0 in absolute mode.
- Preview fix — the viewer override forced every move at ironing height to render as extrusion, painting travel moves between ironed islands as phantom ironing lines (also for normal-flow ironing). Zero-flow strokes now emit an explicit E0 word, so the preview can tell strokes (reclassified as ironing) apart from travels (unchanged). This also stops the closing unretract from being counted as used filament and breaking the flow-view color range.
- Restored _retract/unretract — the helper refactor accidentally dropped the extra_retract prime in unretract() and overwrote the MakerWare M101 line; reverted to the original bodies.
- Misc — no retract emitted when ironing_retract is 0; changing the two new options now only re-exports g-code instead of triggering a full reslice.
- Make Extrea unretract an expert option.
- Improve tooltips

# Screenshots/Recordings/Graphs

<img width="418" height="322" alt="imagen" src="https://github.com/user-attachments/assets/29e0f058-a210-48d4-9652-f6628ed25bb0" />
<img width="891" height="449" alt="imagen" src="https://github.com/user-attachments/assets/4f526260-f55d-494e-b14f-ad4ef3b508aa" />

## Tests

NO iron:
<img width="352" height="354" alt="imagen" src="https://github.com/user-attachments/assets/5748b0e3-754d-40a4-9ea1-bc58a97c2461" />

Iron 10% flow:
<img width="352" height="354" alt="imagen" src="https://github.com/user-attachments/assets/b8242e48-fdc0-43aa-9176-0b26f1583acf" />

Iron 0% flow:
<img width="352" height="354" alt="imagen" src="https://github.com/user-attachments/assets/b48367ad-5259-45a3-8f04-b9070b001f9f" />

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
