### PR TITLE
Fix single-value object overrides on multi-nozzle printers

### DIFF
--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -10426,6 +10426,16 @@ int DynamicPrintConfig::update_values_from_multi_to_multi_2(const std::vector<st
 
 }
 
+void set_variant_override(ConfigOptionVectorBase &target, const ConfigOptionVectorBase &source,
+                          const std::vector<int> &variant_index, int stride)
+{
+    // A single-value object or region override applies to every nozzle variant.
+    std::vector<int> indices = variant_index;
+    if (source.size() == 1 && !source.is_nil(0))
+        std::fill(indices.begin(), indices.end(), 0);
+    target.set_to_index(&source, indices, stride);
+}
+
 
 //used for object/region config
 //use the smallest of multiple to single
@@ -11503,7 +11513,7 @@ void update_static_print_config_from_dynamic(ConfigBase& config, const DynamicPr
                 else {
                     ConfigOptionVectorBase* opt_vec_src = static_cast<ConfigOptionVectorBase*>(opt_src);
                     const ConfigOptionVectorBase* opt_vec_dest = static_cast<const ConfigOptionVectorBase*>(opt_dest);
-                    opt_vec_src->set_to_index(opt_vec_dest, variant_index, stride);
+                    set_variant_override(*opt_vec_src, *opt_vec_dest, variant_index, stride);
                 }
             }
         }

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -842,6 +842,9 @@ extern std::set<std::string> printer_options_with_variant_1;
 extern std::set<std::string> printer_options_with_variant_2;
 extern std::set<std::string> empty_options;
 
+void set_variant_override(ConfigOptionVectorBase &target, const ConfigOptionVectorBase &source,
+                          const std::vector<int> &variant_index, int stride = 1);
+
 extern std::set<std::string> filament_dev_options;
 
 extern void update_static_print_config_from_dynamic(ConfigBase& config, const DynamicPrintConfig& dest_config, std::vector<int> variant_index, std::set<std::string>& key_set1, int stride = 1);

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -3812,7 +3812,7 @@ static void apply_to_print_region_config(PrintRegionConfig &out, const DynamicPr
                         else {
                             ConfigOptionVectorBase* opt_vec_src = static_cast<ConfigOptionVectorBase*>(my_opt);
                             const ConfigOptionVectorBase* opt_vec_dest = static_cast<const ConfigOptionVectorBase*>(it->second.get());
-                            opt_vec_src->set_to_index(opt_vec_dest, variant_index, 1);
+                            set_variant_override(*opt_vec_src, *opt_vec_dest, variant_index);
                         }
                     }
                 }


### PR DESCRIPTION
## Description

This PR fixes single-value object and region overrides on printers with multiple nozzle/tool variants.

## Observed behavior

A one-value object or region override means “use this value for the entire object or region.”
After the variant-aware configuration changes, that value was copied only to the first variant slot. Other slots kept their process defaults.

For example:

```text
override: [100]
defaults: [500, 500]
result:   [100, 500]
```

As a result, G-code for an object printed with a later nozzle/tool variant could use the default acceleration, speed, or other variant-aware setting instead of the override.

## Applied fix

The expansion is centralized and used by both configuration paths:
- Object settings, including acceleration and jerk.
- Region settings, including outer/inner wall speed, infill, bridge, support, travel, and overhang settings.

This keeps object and region overrides consistent and prevents the two paths from diverging again.

The same example now becomes:

```text
override: [100]
defaults: [500, 500]
result:   [100, 100]
```

This preserves the intended meaning of a single-value override: the value applies to the whole object or region.

## Screenshots

__Before__:
<img width="1611" height="1329" alt="image" src="https://github.com/user-attachments/assets/b4a57381-a479-4c76-8d62-1c1a6df76164" />

<br>
<br>

__After:__
<img width="1612" height="1330" alt="image" src="https://github.com/user-attachments/assets/23332bab-485b-4247-8fb1-4f01d37baf31" />

<br>
<br>

__Before:__
<img width="2091" height="1110" alt="image" src="https://github.com/user-attachments/assets/da002e8f-3bfa-4b72-9eb6-af48fd0405d8" />

<br>
<br>

__After:__
<img width="2099" height="1117" alt="image" src="https://github.com/user-attachments/assets/6d811267-4a9f-4e16-9a88-0171699d2cea" />

---
Fixes #15208.
