### PR TITLE
Fix stale flush matrix after enabling SEMM

### DIFF
--- a/src/libslic3r/PresetBundle.cpp
+++ b/src/libslic3r/PresetBundle.cpp
@@ -5378,7 +5378,7 @@ void PresetBundle::update_multi_material_filament_presets(size_t to_delete_filam
         f_multiplier.resize(nozzle_nums, 1.f);
     }
 
-    if ( (num_filaments * num_filaments) != size_t(old_matrix.size() / old_nozzle_nums) ) {
+    if (old_matrix.size() != num_filaments * num_filaments * nozzle_nums) {
         // First verify if purging volumes presets for each extruder matches number of extruders
         std::vector<double>& filaments = this->project_config.option<ConfigOptionFloats>("flush_volumes_vector")->values;
         while (filaments.size() < 2* num_filaments) {


### PR DESCRIPTION
## Description

Fixes the `Flush volumes matrix do not match to the correct size!` slicing error that could occur when enabling **Single Extruder Multi Material** after using a multi-extruder configuration.

## Cause

Enabling **Single Extruder Multi Material** reduces the physical extruder count to one while keeping multiple filament slots available.

The flush matrix was still validated using the **previous extruder count**. As a result, a matrix created for the former multi-extruder configuration could incorrectly be considered valid and remain unchanged.

This could also be triggered by resetting a printer profile when the reset re-enabled **Single Extruder Multi Material**.

## Applied fix

Validate the complete flush matrix size against the **current** configuration:

```text
filament count × filament count × current extruder count
```

This ensures that when switching to Single Extruder Multi Material, a matrix created for the previous extruder layout is rebuilt with the correct dimensions before G-code export.

## Screenshots

__Before:__
<img width="2024" height="1153" alt="image" src="https://github.com/user-attachments/assets/a5f41777-f3a0-4393-be5b-12e5b424c911" />

<br>
<br>

__After:__
<img width="2017" height="1141" alt="image" src="https://github.com/user-attachments/assets/6161e0e9-712e-4384-b09b-6bec174469a1" />

---

Fixes #15222