### PR TITLE
Fix assembly parts omitted by height range modifiers

### DIFF
--- a/src/libslic3r/PrintApply.cpp
+++ b/src/libslic3r/PrintApply.cpp
@@ -559,9 +559,11 @@ static inline bool model_volume_solid_or_modifier(const ModelVolume &mv)
 
 static inline Transform3f trafo_for_bbox(const Transform3d &object_trafo, const Transform3d &volume_trafo)
 {
-    Transform3d m = object_trafo * volume_trafo;
-    m.translation().x() = 0.;
-    m.translation().y() = 0.;
+    // Orca: Keep the volume's local XY offset for multipart overlap checks, but remove the object's bed placement.
+    Transform3d object_trafo_local = object_trafo;
+    object_trafo_local.translation().x() = 0.;
+    object_trafo_local.translation().y() = 0.;
+    Transform3d m = object_trafo_local * volume_trafo;
     return m.cast<float>();
 }
 


### PR DESCRIPTION
## Description

Height range modifiers could cause some parts of a multipart assembly to be omitted from the sliced output.

## Root cause

When a Height Range Modifier is present, Orca needs to determine how the different volumes of the object overlap.
As part of this check, the object's position on the build plate is intentionally ignored.

Bounding boxes used for multipart overlap detection were calculated by combining the object and volume transforms and then clearing the final XY translation.

This removed both:

- the object's placement on the build plate, which should be ignored;
- the volume's local XY translation, which must be preserved.

As a result, the slicer could incorrectly determine that assembly parts did not overlap and assign only one part to the resulting print region.

## Fix

Clear the object's XY translation before composing it with the volume transform. This removes the build-plate placement while preserving the volume-local position.

## Screenshots

__The object to be sliced:__
<img width="1066" height="1180" alt="image" src="https://github.com/user-attachments/assets/a7f45f9e-543c-4860-8857-ff35060ffbce" />

<br>
<br>

__The sliced object before:__
<img width="1032" height="1167" alt="image" src="https://github.com/user-attachments/assets/518a1a70-7ea7-47ec-97bf-406290420e9e" />

<br>
<br>

__The sliced object after:__
<img width="1013" height="1177" alt="image" src="https://github.com/user-attachments/assets/40375827-9338-4d9f-b34e-3ee81e93379d" />

---

Fixes #15203
