### PR TITLE
Fix crashes from object-level small perimeter speed overrides

### DIFF
--- a/src/libslic3r/Config.hpp
+++ b/src/libslic3r/Config.hpp
@@ -2982,6 +2982,8 @@ public:
     const double &      opt_float(const t_config_option_key &opt_key, unsigned int idx) const;
     double &            opt_float_nullable(const t_config_option_key &opt_key, unsigned int idx) { return this->option<ConfigOptionFloatsNullable>(opt_key)->get_at(idx); }
     const double &      opt_float_nullable(const t_config_option_key &opt_key, unsigned int idx) const { return dynamic_cast<const ConfigOptionFloatsNullable *>(this->option(opt_key))->get_at(idx); }
+    FloatOrPercent &    opt_float_or_percent_nullable(const t_config_option_key &opt_key, unsigned int idx) { return this->option<ConfigOptionFloatsOrPercentsNullable>(opt_key)->get_at(idx); }
+    const FloatOrPercent & opt_float_or_percent_nullable(const t_config_option_key &opt_key, unsigned int idx) const { return dynamic_cast<const ConfigOptionFloatsOrPercentsNullable *>(this->option(opt_key))->get_at(idx); }
 
     int&                opt_int(const t_config_option_key &opt_key)                             { return this->option<ConfigOptionInt>(opt_key)->value; }
     int                 opt_int(const t_config_option_key &opt_key) const                       { return dynamic_cast<const ConfigOptionInt*>(this->option(opt_key))->value; }

--- a/src/libslic3r/Model.cpp
+++ b/src/libslic3r/Model.cpp
@@ -3243,9 +3243,9 @@ double Model::findMaxSpeed(const ModelObject* object) {
         if (objectKey == "outer_wall_speed")
             externalPerimeterSpeedObj = object->config.get().opt_float_nullable(objectKey, 0);
         if (objectKey == "small_perimeter_speed")
-            smallPerimeterSpeedObj = object->config.get().opt_float_nullable(objectKey, 0);
+            smallPerimeterSpeedObj = object->config.get().opt_float_or_percent_nullable(objectKey, 0).get_abs_value(externalPerimeterSpeedObj);
         if (objectKey == "small_support_perimeter_speed")
-            smallSupportPerimeterSpeedObj = object->config.get().opt_float_nullable(objectKey, 0);
+            smallSupportPerimeterSpeedObj = object->config.get().opt_float_or_percent_nullable(objectKey, 0).get_abs_value(supportSpeedObj);
     }
     objMaxSpeed = std::max(perimeterSpeedObj, std::max(externalPerimeterSpeedObj, std::max(infillSpeedObj, std::max(solidInfillSpeedObj, std::max(topSolidInfillSpeedObj, std::max(supportSpeedObj, std::max(smallPerimeterSpeedObj, std::max(smallSupportPerimeterSpeedObj, objMaxSpeed))))))));
     if (objMaxSpeed <= 0) objMaxSpeed = 250.;


### PR DESCRIPTION
## Description

This PR fixes crashes when object settings override either **Small perimeters speed** or **Small support perimeters speed**.

Both settings accept either an absolute speed or a percentage. When reading object-level overrides, Orca treated them as plain nullable speed values instead of float-or-percent values, which could cause a crash.

## Applied fix

Read both overrides using their correct value type and resolve percentage values against the corresponding base speed:

* **Small perimeters speed** → **Outer wall speed**
* **Small support perimeters speed** → **Support speed**

Absolute speed values are used directly as before.

## Screenshots

__Before:__
<img width="1960" height="1257" alt="image" src="https://github.com/user-attachments/assets/bd130930-bfa5-466d-8928-c612d6b28d9a" />

<br>
<br>

__After:__
<img width="1954" height="1260" alt="image" src="https://github.com/user-attachments/assets/0927758e-2f83-4c55-8843-41340a1d9f4e" />
