### PR TITLE
Fix Qidi X-Max 4 chamber heating profiles

### DIFF
--- a/resources/profiles/Qidi.json
+++ b/resources/profiles/Qidi.json
@@ -1,6 +1,6 @@
 {
 	"name": "Qidi",
-	"version": "02.04.00.10",
+	"version": "02.04.00.11",
 	"force_update": "0",
 	"description": "Qidi configurations",
 	"machine_model_list": [

--- a/resources/profiles/Qidi/filament/X4/QIDI PA12-CF @X-Max 4.json
+++ b/resources/profiles/Qidi/filament/X4/QIDI PA12-CF @X-Max 4.json
@@ -20,6 +20,9 @@
 	"close_fan_the_first_x_layers": [
 		"3"
 	],
+	"during_print_exhaust_fan_speed": [
+		"0"
+	],
 	"fan_cooling_layer_time": [
 		"10"
 	],

--- a/resources/profiles/Qidi/filament/X4/QIDI PAHT-CF @X-Max 4.json
+++ b/resources/profiles/Qidi/filament/X4/QIDI PAHT-CF @X-Max 4.json
@@ -20,6 +20,9 @@
 	"close_fan_the_first_x_layers": [
 		"3"
 	],
+	"during_print_exhaust_fan_speed": [
+		"0"
+	],
 	"fan_cooling_layer_time": [
 		"10"
 	],

--- a/resources/profiles/Qidi/filament/X4/QIDI PAHT-GF @X-Max 4.json
+++ b/resources/profiles/Qidi/filament/X4/QIDI PAHT-GF @X-Max 4.json
@@ -20,6 +20,9 @@
 	"close_fan_the_first_x_layers": [
 		"3"
 	],
+	"during_print_exhaust_fan_speed": [
+		"0"
+	],
 	"fan_cooling_layer_time": [
 		"10"
 	],


### PR DESCRIPTION
# Description

These Max 4 Qidi profiles run the exhaust fan during printing, which turns off the chamber heater (which these profiles also have turned on).  Other profiles correctly override this by setting it to 0, these somehow got missed.

End result is a user using these profiles will see their chamber heat at the start of a print, then it will turn off chamber heat and run the exhaust fan at 100%.

This is bad. :)

I found this because I had users reaching out to me asking why their printer's chamber heater was unable to stay on the whole time, thinking their printer was broken.

Qidi...  You're not doing yourself any favors.

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
