### PR TITLE
Fixes #14387 KVM switching crash - Add opt-in X11 backend workaround for Wayland

### DIFF
--- a/src/OrcaSlicer.cpp
+++ b/src/OrcaSlicer.cpp
@@ -19,6 +19,7 @@
 #endif /* WIN32 */
 
 #include <cstdio>
+#include <cstdlib>
 #include <string>
 #include <cstring>
 #include <iostream>
@@ -51,6 +52,7 @@ using namespace nlohmann;
 
 #include "libslic3r/libslic3r.h"
 #include "libslic3r/Config.hpp"
+#include "libslic3r/AppConfig.hpp"
 #include "libslic3r/Geometry.hpp"
 #include "libslic3r/GCode.hpp"
 #include "libslic3r/Model.hpp"
@@ -98,9 +100,82 @@ using namespace nlohmann;
 
 #ifdef SLIC3R_GUI
     #include "slic3r/GUI/GUI_Init.hpp"
+    #include "slic3r/GUI/GUI_Utils.hpp"
 #endif /* SLIC3R_GUI */
 
 using namespace Slic3r;
+
+#ifdef __WXGTK__
+namespace {
+
+bool has_env_value(const char *value)
+{
+    return value != nullptr && value[0] != '\0';
+}
+
+boost::filesystem::path default_linux_config_dir()
+{
+    if (const char *xdg_config_home = ::getenv("XDG_CONFIG_HOME"); has_env_value(xdg_config_home))
+        return boost::filesystem::path(xdg_config_home) / SLIC3R_APP_KEY;
+
+    if (const char *home = ::getenv("HOME"); has_env_value(home))
+        return boost::filesystem::path(home) / ".config" / SLIC3R_APP_KEY;
+
+    return {};
+}
+
+boost::filesystem::path early_linux_app_config_path()
+{
+    try {
+        const boost::filesystem::path app_dir = boost::dll::program_location().parent_path();
+        const boost::filesystem::path portable_data_dir = app_dir / "data_dir";
+        if (boost::filesystem::exists(portable_data_dir))
+            return (portable_data_dir / (SLIC3R_APP_KEY ".conf")).make_preferred();
+    } catch (const std::exception&) {
+        // Fall back to the normal XDG config path below. Logging is not initialized yet.
+    }
+
+    const boost::filesystem::path config_dir = default_linux_config_dir();
+    return config_dir.empty() ? boost::filesystem::path() : (config_dir / (SLIC3R_APP_KEY ".conf")).make_preferred();
+}
+
+bool read_early_app_config_bool(const char *key, bool default_value)
+{
+    const boost::filesystem::path path = early_linux_app_config_path();
+    if (path.empty() || !boost::filesystem::exists(path))
+        return default_value;
+
+    try {
+        boost::nowide::ifstream ifs(path.string());
+        if (!ifs)
+            return default_value;
+
+        nlohmann::json config = nlohmann::json::parse(ifs, nullptr, true, true);
+        const auto app_it = config.find("app");
+        if (app_it == config.end() || !app_it->is_object())
+            return default_value;
+
+        const auto value_it = app_it->find(key);
+        if (value_it == app_it->end())
+            return default_value;
+
+        if (value_it->is_boolean())
+            return value_it->get<bool>();
+        if (value_it->is_string()) {
+            const std::string value = value_it->get<std::string>();
+            return value == "true" || value == "1";
+        }
+        if (value_it->is_number_integer())
+            return value_it->get<int>() != 0;
+    } catch (const std::exception&) {
+        // Corrupted config handling happens later in AppConfig::load(); do not block startup here.
+    }
+
+    return default_value;
+}
+
+} // namespace
+#endif // __WXGTK__
 
 /*typedef struct _error_message{
     int code;
@@ -1194,40 +1269,38 @@ int CLI::run(int argc, char **argv)
 
 #ifdef __WXGTK__
     // ------------------------------------------------------------------
-    // Linux backend selection — runtime, based on GDK_BACKEND env var.
+    // Linux backend selection — must run before wx/GTK initializes.
     //
-    //   GDK_BACKEND unset (DEFAULT)    Wayland path.
-    //                                  GTK auto-picks Wayland on Wayland
-    //                                  sessions and X11 otherwise. WebKit
-    //                                  XWayland-compositing workaround
-    //                                  applied only when actually on
-    //                                  XWayland. XInitThreads gated on
-    //                                  DISPLAY presence.
+    // Native Wayland remains the default. Users affected by rare KVM or
+    // display-hotplug crashes can enable the Linux preference
+    // SETTING_LINUX_USE_X11_BACKEND_ON_WAYLAND; on the next launch, when an
+    // XWayland display is available, OrcaSlicer forces GDK_BACKEND=x11 before
+    // GTK connects to the display.
     //
-    //   GDK_BACKEND=x11   (OPT-IN)     X11/XWayland mode. Applies the
-    //                                  v2.3.2 workarounds that the X11
-    //                                  path benefits from: DRI_PRIME for
-    //                                  AMD/nouveau PRIME, NVIDIA PRIME
-    //                                  render offload (when nvidia.ko is
-    //                                  loaded), XInitThreads. 
-    //                                  Multi monitor is compromised
-    //
-    // WEBKIT_DISABLE_COMPOSITING_MODE is deliberately NOT set on the X11
-    // opt-in path. The ~2020-era WebKit2GTK XWayland compositor bug it
-    // worked around appears fixed in WebKit2GTK >= 2.42; leaving it
-    // unset preserves WebKit hardware acceleration on Device / Setup
-    // Wizard / login / store. The default path still applies it on
-    // XWayland sessions as a conservative fallback for older WebKit.
+    // Explicit GDK_BACKEND values are respected unless the preference is
+    // enabled. This keeps the workaround opt-in and reversible.
     // ------------------------------------------------------------------
     {
+        const bool x11_wayland_workaround_enabled = read_early_app_config_bool(SETTING_LINUX_USE_X11_BACKEND_ON_WAYLAND, false);
         const char* gdk_backend = ::getenv("GDK_BACKEND");
-        // Match "x11" and comma-prefixed forms like "x11,wayland" (GTK
-        // honours the first backend in the comma-separated list).
-        const bool x11_opt_in = gdk_backend && boost::starts_with(gdk_backend, "x11");
+        const char* display_env = ::getenv("DISPLAY");
+        const char* wayland_env = ::getenv("WAYLAND_DISPLAY");
 
-        if (x11_opt_in) {
-            // ===== X11 / XWayland (opted in via GDK_BACKEND=x11) =====
-            BOOST_LOG_TRIVIAL(info) << "GDK_BACKEND=x11 detected; applying v2.3.2 X11/XWayland workarounds.";
+        if (Slic3r::GUI::detail::should_force_x11_backend_for_wayland_kvm(gdk_backend, display_env, wayland_env, x11_wayland_workaround_enabled)) {
+            BOOST_LOG_TRIVIAL(warning) << "Linux Wayland X11-backend workaround is enabled; forcing GDK_BACKEND=x11 to avoid KVM/display-hotplug crashes.";
+            ::setenv("GDK_BACKEND", "x11", true);
+            gdk_backend = ::getenv("GDK_BACKEND");
+        } else if (gdk_backend && *gdk_backend) {
+            BOOST_LOG_TRIVIAL(info) << "GDK_BACKEND=" << gdk_backend << " detected; respecting GTK backend selection.";
+        }
+
+        // Match "x11" and comma-prefixed forms like "x11,wayland" (GTK
+        // honours the first backend in the comma-separated list). Apply the
+        // X11/XWayland workarounds to both explicit and preference-forced X11.
+        const bool x11_backend = gdk_backend && boost::starts_with(gdk_backend, "x11");
+
+        if (x11_backend) {
+            BOOST_LOG_TRIVIAL(info) << "GDK_BACKEND=x11 active; applying v2.3.2 X11/XWayland workarounds.";
 
             // On Linux dual-GPU systems, request the high-performance
             // discrete GPU. DRI_PRIME=1 handles AMD and nouveau PRIME
@@ -1243,14 +1316,11 @@ int CLI::run(int argc, char **argv)
             }
 
             // Tell Xlib we will be using threads, lest we crash when
-            // GStreamer fires up. Safe to call here since the user has
-            // explicitly opted into X11.
+            // GStreamer fires up. Safe to call here before GTK initializes.
             #if __has_include(<X11/Xlib.h>)
             XInitThreads();
             #endif
         } else {
-            // ===== Wayland default =====
-
             // Safety fallback: if wxWidgets was not built with EGL
             // support, native Wayland will crash in
             // wxGLCanvas::IsDisplaySupported() because the GLX backend
@@ -1259,12 +1329,9 @@ int CLI::run(int argc, char **argv)
             // wxHAS_EGL in the build — it protects against builds where
             // deps were not rebuilt.
             #if !defined(wxHAS_EGL) || !wxHAS_EGL
-            {
-                const char* wayland_env = ::getenv("WAYLAND_DISPLAY");
-                if (wayland_env && *wayland_env) {
-                    BOOST_LOG_TRIVIAL(warning) << "Wayland detected but wxWidgets has no EGL support (wxHAS_EGL is OFF). Forcing X11 backend.";
-                    ::setenv("GDK_BACKEND", "x11", true);
-                }
+            if (wayland_env && *wayland_env) {
+                BOOST_LOG_TRIVIAL(warning) << "Wayland detected but wxWidgets has no EGL support (wxHAS_EGL is OFF). Forcing X11 backend.";
+                ::setenv("GDK_BACKEND", "x11", true);
             }
             #endif
 
@@ -1273,23 +1340,16 @@ int CLI::run(int argc, char **argv)
             // WAYLAND_DISPLAY are set (i.e. an XWayland session is in
             // use). On pure X11 or native Wayland, compositing is left
             // enabled so WebKit retains HW acceleration.
-            {
-                const char* display_env_wk = ::getenv("DISPLAY");
-                const char* wayland_env_wk = ::getenv("WAYLAND_DISPLAY");
-                if (display_env_wk && *display_env_wk && wayland_env_wk && *wayland_env_wk) {
-                    ::setenv("WEBKIT_DISABLE_COMPOSITING_MODE", "1", /* replace */ false);
-                }
+            if (display_env && *display_env && wayland_env && *wayland_env) {
+                ::setenv("WEBKIT_DISABLE_COMPOSITING_MODE", "1", /* replace */ false);
             }
 
             // XInitThreads is needed before GStreamer may use Xlib. On
             // native Wayland without DISPLAY, GStreamer uses waylandsink
             // (no Xlib involved), so the call is skipped.
             #if __has_include(<X11/Xlib.h>)
-            {
-                const char* display_env = ::getenv("DISPLAY");
-                if (display_env && *display_env) {
-                    XInitThreads();
-                }
+            if (display_env && *display_env) {
+                XInitThreads();
             }
             #endif
         }

--- a/src/libslic3r/AppConfig.cpp
+++ b/src/libslic3r/AppConfig.cpp
@@ -624,6 +624,8 @@ void AppConfig::set_defaults()
 #ifdef __linux__
     if (get("window_buttons_on_left").empty())
         set_bool("window_buttons_on_left", false);
+    if (get(SETTING_LINUX_USE_X11_BACKEND_ON_WAYLAND).empty())
+        set_bool(SETTING_LINUX_USE_X11_BACKEND_ON_WAYLAND, false);
 #endif
 
     if (get("use_printer_agents").empty())

--- a/src/libslic3r/AppConfig.hpp
+++ b/src/libslic3r/AppConfig.hpp
@@ -40,6 +40,7 @@ using namespace nlohmann;
 #define SETTING_OPENGL_PHONG_BASIC_PLATE_SHADOWS "opengl_phong_basic_plate_shadows"
 #define SETTING_OPENGL_PHONG_SSAO "opengl_phong_ssao"
 #define SETTING_OPENGL_PHONG_SMOOTH_NORMALS "opengl_phong_smooth_normals"
+#define SETTING_LINUX_USE_X11_BACKEND_ON_WAYLAND "linux_use_x11_backend_on_wayland"
 
 #if defined(_WIN32) || defined(_WIN64)
 #define BAMBU_NETWORK_AGENT_VERSION_LEGACY "01.10.01.09"

--- a/src/slic3r/GUI/AmsMappingPopup.cpp
+++ b/src/slic3r/GUI/AmsMappingPopup.cpp
@@ -6,6 +6,7 @@
 #include "slic3r/Utils/WxFontUtils.hpp"
 #include "GUI.hpp"
 #include "GUI_App.hpp"
+#include "GUI_Utils.hpp"
 #include "DeviceCore/DevConfigUtil.h"
 #include "GUI_Preview.hpp"
 #include "MainFrame.hpp"
@@ -975,12 +976,7 @@ AmsMapingPopup::AmsMapingPopup(wxWindow *parent, bool use_in_sync_dialog) :
          if (e.IsShown() && m_parent_item)
          {
              auto show_pos = m_parent_item->ClientToScreen(wxPoint(0, 0));
-             int  display_idx = wxDisplay::GetFromWindow(m_parent_item);
-
-             if (display_idx == wxNOT_FOUND)
-                 display_idx = 0;
-
-             wxRect screen_size = wxDisplay(display_idx).GetClientArea();
+             wxRect screen_size = safe_display_client_area(m_parent_item);
              auto   parent_size = m_parent_item->GetRect();
              auto   content_size = m_sizer_main_h->GetMinSize();
              int    popup_width  = content_size.x + FromDIP(28);

--- a/src/slic3r/GUI/ConfigWizard.cpp
+++ b/src/slic3r/GUI/ConfigWizard.cpp
@@ -1814,10 +1814,7 @@ void ConfigWizard::priv::init_dialog_size()
 {
     // Clamp the Wizard size based on screen dimensions
 
-    const auto idx = wxDisplay::GetFromWindow(q);
-    wxDisplay display(idx != wxNOT_FOUND ? idx : 0u);
-
-    const auto disp_rect = display.GetClientArea();
+    const auto disp_rect = safe_display_client_area(q);
     wxRect window_rect(
         disp_rect.x + disp_rect.width / 20,
         disp_rect.y + disp_rect.height / 20,

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -9600,13 +9600,10 @@ bool GUI_App::window_pos_restore(wxTopLevelWindow* window, const std::string &na
 
 void GUI_App::window_pos_sanitize(wxTopLevelWindow* window)
 {
-    /*unsigned*/int display_idx = wxDisplay::GetFromWindow(window);
-    wxRect display;
+    const int display_idx = safe_display_index(window);
+    wxRect display = safe_display_client_area(window);
     if (display_idx == wxNOT_FOUND) {
-        display = wxDisplay(0u).GetClientArea();
         window->Move(display.GetTopLeft());
-    } else {
-        display = wxDisplay(display_idx).GetClientArea();
     }
 
     auto metrics = WindowMetrics::from_window(window);
@@ -9618,13 +9615,10 @@ void GUI_App::window_pos_sanitize(wxTopLevelWindow* window)
 
 void GUI_App::window_pos_center(wxTopLevelWindow *window)
 {
-    /*unsigned*/int display_idx = wxDisplay::GetFromWindow(window);
-    wxRect display;
+    const int display_idx = safe_display_index(window);
+    wxRect display = safe_display_client_area(window);
     if (display_idx == wxNOT_FOUND) {
-        display = wxDisplay(0u).GetClientArea();
         window->Move(display.GetTopLeft());
-    } else {
-        display = wxDisplay(display_idx).GetClientArea();
     }
 
     auto metrics = WindowMetrics::from_window(window);

--- a/src/slic3r/GUI/GUI_ObjectTable.cpp
+++ b/src/slic3r/GUI/GUI_ObjectTable.cpp
@@ -11,6 +11,7 @@
 #include "Widgets/Label.hpp"
 #include "GUI.hpp"
 #include "GUI_App.hpp"
+#include "GUI_Utils.hpp"
 #include "MainFrame.hpp"
 #include "Tab.hpp"
 #include "format.hpp"
@@ -3356,9 +3357,7 @@ ObjectTableDialog::ObjectTableDialog(wxWindow* parent, Plater* platerObj, Model 
     wxSize panel_size = m_obj_panel->get_init_size();
     g_max_size_from_parent = maxSize;
     if ((maxSize.GetWidth() == -1) || (maxSize.GetHeight() == -1)) {
-        wxDisplay display(this);
-        //auto drect = display.GetGeometry();
-        wxRect 	client_area = display.GetClientArea ();
+        wxRect 	client_area = safe_display_client_area(this);
         g_max_size_from_parent.SetWidth(client_area.GetWidth());
         g_max_size_from_parent.SetHeight(client_area.GetHeight());
     }

--- a/src/slic3r/GUI/GUI_Utils.cpp
+++ b/src/slic3r/GUI/GUI_Utils.cpp
@@ -4,6 +4,7 @@
 #include "I18N.hpp"
 
 #include <algorithm>
+#include <boost/algorithm/string/predicate.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/format.hpp>
 
@@ -24,6 +25,7 @@
 #include <wx/font.h>
 #include <wx/fontutil.h>
 #include <wx/display.h>
+#include <wx/settings.h>
 #include <wx/utils.h>
 
 #include "libslic3r/Config.hpp"
@@ -524,9 +526,100 @@ bool generate_image(const std::string &filename, wxImage &image, wxSize img_size
 
 std::deque<wxDialog*> dialogStack;
 
+namespace {
+
+wxRect fallback_display_rect()
+{
+    const int width  = wxSystemSettings::GetMetric(wxSYS_SCREEN_X);
+    const int height = wxSystemSettings::GetMetric(wxSYS_SCREEN_Y);
+    return wxRect(wxPoint(0, 0), wxSize(width > 0 ? width : 1, height > 0 ? height : 1));
+}
+
+int primary_display_index()
+{
+    return wxDisplay::GetCount() > 0 ? 0 : wxNOT_FOUND;
+}
+
+} // namespace
+
+namespace detail {
+
+int safe_display_index(int window_display_idx, unsigned display_count)
+{
+    if (display_count == 0)
+        return wxNOT_FOUND;
+
+    if (window_display_idx != wxNOT_FOUND && window_display_idx >= 0 && static_cast<unsigned>(window_display_idx) < display_count)
+        return window_display_idx;
+
+    return wxNOT_FOUND;
+}
+
+bool should_force_x11_backend_for_wayland_kvm(const char* gdk_backend, const char* display, const char* wayland_display, bool preference_enabled)
+{
+    const auto has_value = [](const char* value) { return value != nullptr && value[0] != '\0'; };
+
+    if (!preference_enabled)
+        return false;
+
+    if (!has_value(display) || !has_value(wayland_display))
+        return false;
+
+    // If the user enabled OrcaSlicer's workaround, prefer X11/XWayland even
+    // when the launcher or desktop supplied a Wayland-first backend list.
+    // Already-X11 selections need no change.
+    return !has_value(gdk_backend) || !boost::starts_with(gdk_backend, "x11");
+}
+
+}
+
+int safe_display_index(wxWindow* window)
+{
+    const unsigned display_count = wxDisplay::GetCount();
+    const int window_display_idx = window != nullptr ? wxDisplay::GetFromWindow(window) : wxNOT_FOUND;
+    return detail::safe_display_index(window_display_idx, display_count);
+}
+
+wxRect safe_display_client_area(wxWindow* window)
+{
+    int display_idx = safe_display_index(window);
+    if (display_idx == wxNOT_FOUND)
+        display_idx = primary_display_index();
+
+    if (display_idx != wxNOT_FOUND)
+        return wxDisplay(static_cast<unsigned>(display_idx)).GetClientArea();
+
+    return fallback_display_rect();
+}
+
+wxRect safe_display_geometry(wxWindow* window)
+{
+    int display_idx = safe_display_index(window);
+    if (display_idx == wxNOT_FOUND)
+        display_idx = primary_display_index();
+
+    if (display_idx != wxNOT_FOUND)
+        return wxDisplay(static_cast<unsigned>(display_idx)).GetGeometry();
+
+    return fallback_display_rect();
+}
+
+double safe_display_scale_factor(wxWindow* window)
+{
+    int display_idx = safe_display_index(window);
+    if (display_idx == wxNOT_FOUND)
+        display_idx = primary_display_index();
+
+    if (display_idx == wxNOT_FOUND)
+        return 1.0;
+
+    const double scale_factor = wxDisplay(static_cast<unsigned>(display_idx)).GetScaleFactor();
+    return scale_factor > 0.0 ? scale_factor : 1.0;
+}
+
 void fit_in_display(wxTopLevelWindow& window, wxSize desired_size)
 {
-    const auto display_size = wxDisplay(window.GetParent()).GetClientArea();
+    const auto display_size = safe_display_client_area(window.GetParent());
     if (desired_size.GetWidth() > display_size.GetWidth()) {
         desired_size.SetWidth(display_size.GetWidth() * 4 / 5);
     }

--- a/src/slic3r/GUI/GUI_Utils.hpp
+++ b/src/slic3r/GUI/GUI_Utils.hpp
@@ -489,6 +489,15 @@ bool is_debugger_present();
 /// <summary>
 /// Make sure the given window fits inside current display
 /// </summary>
+namespace detail {
+int safe_display_index(int window_display_idx, unsigned display_count);
+bool should_force_x11_backend_for_wayland_kvm(const char* gdk_backend, const char* display, const char* wayland_display, bool preference_enabled);
+}
+
+int safe_display_index(wxWindow* window);
+wxRect safe_display_client_area(wxWindow* window);
+wxRect safe_display_geometry(wxWindow* window);
+double safe_display_scale_factor(wxWindow* window);
 void fit_in_display(wxTopLevelWindow& window, wxSize desired_size);
 
 

--- a/src/slic3r/GUI/Gizmos/GLGizmoEmboss.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoEmboss.cpp
@@ -1,6 +1,7 @@
 #include "GLGizmoEmboss.hpp"
 #include "slic3r/GUI/GLCanvas3D.hpp"
 #include "slic3r/GUI/GUI_App.hpp"
+#include "slic3r/GUI/GUI_Utils.hpp"
 #include "slic3r/GUI/GUI_ObjectList.hpp"
 #include "slic3r/GUI/Gizmos/GizmoObjectManipulation.hpp"
 #include "slic3r/GUI/MainFrame.hpp" // to update title when add text
@@ -858,7 +859,7 @@ void GLGizmoEmboss::on_render_input_window(float x, float y, float bottom_limit)
     else if (!m_is_unknown_font && !m_style_manager.get_wx_font().IsOk())
         create_notification_not_valid_font("WxFont is not loaded properly.");
 
-    double screen_scale = wxDisplay(wxGetApp().plater()).GetScaleFactor();
+    double screen_scale = safe_display_scale_factor(wxGetApp().plater());
 
     // Orca
     ImGuiWrapper::push_toolbar_style(m_parent.get_scale());
@@ -1550,7 +1551,7 @@ void GLGizmoEmboss::draw_text_input()
     ImFont *imgui_font = m_style_manager.get_imgui_font();
     if (imgui_font == nullptr) {
         // try create new imgui font
-        double screen_scale = wxDisplay(wxGetApp().plater()).GetScaleFactor();
+        double screen_scale = safe_display_scale_factor(wxGetApp().plater());
         double imgui_scale = scale * screen_scale;
         m_style_manager.create_imgui_font(create_range_text_prep(), imgui_scale);
         imgui_font = m_style_manager.get_imgui_font();

--- a/src/slic3r/GUI/Gizmos/GLGizmoSVG.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoSVG.cpp
@@ -1,6 +1,7 @@
 #include "GLGizmoSVG.hpp"
 #include "slic3r/GUI/GLCanvas3D.hpp"
 #include "slic3r/GUI/GUI_App.hpp"
+#include "slic3r/GUI/GUI_Utils.hpp"
 #include "slic3r/GUI/GUI_ObjectList.hpp"
 #include "slic3r/GUI/Gizmos/GizmoObjectManipulation.hpp"
 #include "slic3r/GUI/MainFrame.hpp" // to update title when add text
@@ -446,7 +447,7 @@ void GLGizmoSVG::on_render_input_window(float x, float y, float bottom_limit)
 {
     set_volume_by_selection();
 
-    double screen_scale = wxDisplay(wxGetApp().plater()).GetScaleFactor();
+    double screen_scale = safe_display_scale_factor(wxGetApp().plater());
 
     // Orca
     ImGuiWrapper::push_toolbar_style(m_parent.get_scale());

--- a/src/slic3r/GUI/MainFrame.cpp
+++ b/src/slic3r/GUI/MainFrame.cpp
@@ -30,6 +30,7 @@
 #include "ParamsDialog.hpp"
 #include "PrintHostDialogs.hpp"
 #include "wxExtensions.hpp"
+#include "GUI_Utils.hpp"
 #include "GUI_ObjectList.hpp"
 #include "Mouse3DController.hpp"
 //#include "RemovableDriveManager.hpp"
@@ -542,9 +543,9 @@ DPIFrame(NULL, wxID_ANY, "", wxDefaultPosition, wxDefaultSize, BORDERLESS_FRAME_
     // https://forums.wxwidgets.org/viewtopic.php?t=50634
     // Fix it here
     this->Bind(wxEVT_MAXIMIZE, [this](auto &e) {
-        wxDisplay display(this);
-        auto      size = display.GetClientArea().GetSize();
-        auto      pos  = display.GetClientArea().GetPosition();
+        auto client_area = safe_display_client_area(this);
+        auto size = client_area.GetSize();
+        auto pos  = client_area.GetPosition();
         HWND      hWnd = GetHandle();
         RECT      borderThickness;
         SetRectEmpty(&borderThickness);

--- a/src/slic3r/GUI/MarkdownTip.cpp
+++ b/src/slic3r/GUI/MarkdownTip.cpp
@@ -1,6 +1,7 @@
 #include "MarkdownTip.hpp"
 #include "GUI_App.hpp"
 #include "GUI.hpp"
+#include "GUI_Utils.hpp"
 #include "MainFrame.hpp"
 #include "Widgets/WebView.hpp"
 
@@ -143,7 +144,7 @@ bool MarkdownTip::ShowTip(wxPoint pos, std::string const &tip, std::string const
             this->Hide();
     }
     if (_tipView->GetParent() == this) {
-        wxSize size = wxDisplay(this).GetClientArea().GetSize();
+        wxSize size = safe_display_client_area(this).GetSize();
         _requestPos = pos;
         if (pos.y + this->GetSize().y > size.y)
             pos.y = size.y - this->GetSize().y;
@@ -256,7 +257,7 @@ void MarkdownTip::OnTitleChanged(wxWebViewEvent& event)
             return;
         _lastHeight = height;
         height *= 1.25; height += 50;
-        wxSize size = wxDisplay(this).GetClientArea().GetSize();
+        wxSize size = safe_display_client_area(this).GetSize();
         if (height > size.y)
             height = size.y;
         wxPoint pos = _requestPos;

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -4786,7 +4786,7 @@ template<typename T> void setup_dialog_position(T& info)
     } else {
         // If sidebar is too close to screen right edge, then move the dialog to the left side instead
 
-        auto screen_width = wxDisplay(&sidebar).GetClientArea().GetSize().x;
+        auto screen_width = safe_display_client_area(&sidebar).GetSize().x;
         auto right_space  = screen_width - sidebar.get_sidebar_pos_right_x();
         if (right_space < sidebar.FromDIP(400)) {
             on_right = false;

--- a/src/slic3r/GUI/Preferences.cpp
+++ b/src/slic3r/GUI/Preferences.cpp
@@ -1649,6 +1649,13 @@ void PreferencesDialog::create_items()
 #ifdef __linux__
     auto item_window_button_pos  = create_item_checkbox(_L("Use window buttons on left side"), "", "window_buttons_on_left", _L("(Requires restart)"));
     g_sizer->Add(item_window_button_pos);
+
+    auto item_x11_backend_on_wayland = create_item_checkbox(
+        _L("Use X11 backend on Wayland"),
+        _L("Workaround for rare crashes after KVM or monitor switching on Wayland. Enables XWayland when available."),
+        SETTING_LINUX_USE_X11_BACKEND_ON_WAYLAND,
+        _L("(Requires restart)"));
+    g_sizer->Add(item_x11_backend_on_wayland);
 #endif
 
     //auto item_hints            = create_item_checkbox(_L("Show \"Daily Tips\" after start"), page, _L("If enabled, useful hints are displayed at startup."), "show_daily_tips");

--- a/src/slic3r/GUI/SpeedDialDialog.cpp
+++ b/src/slic3r/GUI/SpeedDialDialog.cpp
@@ -3,6 +3,7 @@
 #include "ActionRegistry.hpp"
 #include "GUI.hpp"
 #include "GUI_App.hpp"
+#include "GUI_Utils.hpp"
 #include "MainFrame.hpp"
 #include "MsgDialog.hpp"
 #include "NotificationManager.hpp"
@@ -117,10 +118,7 @@ void SpeedDialWebDialog::resize_to_content(int height)
     if (height <= 0)
         return;
 
-    int display_index = wxDisplay::GetFromWindow(this);
-    if (display_index == wxNOT_FOUND)
-        display_index = 0;
-    const int screen_dip = ToDIP(wxDisplay(display_index).GetClientArea().GetHeight());
+    const int screen_dip = ToDIP(safe_display_client_area(this).GetHeight());
     const int max_dip    = std::max(kPopupMinHeight, screen_dip * 85 / 100);
     const int height_dip = std::max(kPopupMinHeight, std::min(height, max_dip));
     SetClientSize(FromDIP(wxSize(kPopupWidth, height_dip)));

--- a/src/slic3r/GUI/StatusPanel.cpp
+++ b/src/slic3r/GUI/StatusPanel.cpp
@@ -8,6 +8,7 @@
 
 #include "BitmapCache.hpp"
 #include "GUI_App.hpp"
+#include "GUI_Utils.hpp"
 #include "MainFrame.hpp"
 
 #include "MsgDialog.hpp"
@@ -4512,7 +4513,7 @@ void StatusPanel::on_filament_edit(wxCommandEvent &event)
 
     int current_position_x = m_ams_control->GetScreenPosition().x;
     int current_position_y = m_ams_control->GetScreenPosition().y - FromDIP(40);
-    auto drect = wxDisplay(GetParent()).GetGeometry().GetHeight() - FromDIP(50);
+    auto drect = safe_display_geometry(GetParent()).GetHeight() - FromDIP(50);
     current_position_y = current_position_y + m_filament_setting_dlg->GetSize().GetHeight() > drect ? drect - m_filament_setting_dlg->GetSize().GetHeight() : current_position_y;
 
     if (obj) {
@@ -4582,7 +4583,7 @@ void StatusPanel::on_ext_spool_edit(wxCommandEvent &event)
 
     int current_position_x = m_ams_control->GetScreenPosition().x;
     int current_position_y = m_ams_control->GetScreenPosition().y - FromDIP(40);
-    auto drect = wxDisplay(GetParent()).GetGeometry().GetHeight() - FromDIP(50);
+    auto drect = safe_display_geometry(GetParent()).GetHeight() - FromDIP(50);
     current_position_y = current_position_y + m_filament_setting_dlg->GetSize().GetHeight() > drect ? drect - m_filament_setting_dlg->GetSize().GetHeight() : current_position_y;
 
     if (obj) {
@@ -4890,9 +4891,7 @@ void StatusPanel::on_nozzle_fan_switch(wxCommandEvent &event)
     auto pos = m_switch_fan->GetScreenPosition();
     pos.y = pos.y + m_switch_fan->GetSize().y;
 
-    int display_idx = wxDisplay::GetFromWindow(this);
-    auto display = wxDisplay(display_idx).GetClientArea();
-
+    auto display = safe_display_client_area(this);
 
     wxSize screenSize = wxSize(display.GetWidth(), display.GetHeight());
     wxSize fan_popup_size = m_fan_control_popup->GetSize();

--- a/src/slic3r/GUI/WebGuideDialog.cpp
+++ b/src/slic3r/GUI/WebGuideDialog.cpp
@@ -12,6 +12,7 @@
 #include "libslic3r/PresetBundle.hpp"
 #include "slic3r/GUI/wxExtensions.hpp"
 #include "slic3r/GUI/GUI_App.hpp"
+#include "slic3r/GUI/GUI_Utils.hpp"
 #include "libslic3r_version.h"
 
 #include <wx/sizer.h>
@@ -977,11 +978,10 @@ bool GuideFrame::run()
 
     BOOST_LOG_TRIVIAL(info) << "GuideFrame before ShowModal";
     // display position
-    int main_frame_display_index = wxDisplay::GetFromWindow(wxGetApp().mainframe);
-    int guide_display_index = wxDisplay::GetFromWindow(this);
+    int main_frame_display_index = safe_display_index(wxGetApp().mainframe);
+    int guide_display_index = safe_display_index(this);
     if (main_frame_display_index != guide_display_index) {
-        wxDisplay display    = wxDisplay(main_frame_display_index);
-        wxRect    screenRect = display.GetGeometry();
+        wxRect    screenRect = safe_display_geometry(wxGetApp().mainframe);
         int       guide_x    = screenRect.x + (screenRect.width - this->GetSize().GetWidth()) / 2;
         int       guide_y    = screenRect.y + (screenRect.height - this->GetSize().GetHeight()) / 2;
         this->SetPosition(wxPoint(guide_x, guide_y));

--- a/src/slic3r/GUI/Widgets/DropDown.cpp
+++ b/src/slic3r/GUI/Widgets/DropDown.cpp
@@ -5,6 +5,7 @@
 #include <wx/display.h>
 #include <wx/dcbuffer.h>
 #include <wx/dcgraph.h>
+#include "../GUI_Utils.hpp"
 
 #ifdef __WXGTK__
 #include <gtk/gtk.h>
@@ -654,7 +655,7 @@ void DropDown::autoPosition()
     }
     if (GetPosition().y > pos.y) {
         // may exceed
-        auto drect = wxDisplay(GetParent()).GetGeometry();
+        auto drect = Slic3r::GUI::safe_display_geometry(GetParent());
         if (GetPosition().y + size.y + 10 > drect.GetBottom()) {
             int available_height = drect.GetBottom() - GetPosition().y - 10;
             if (available_height < rowSize.y * 2)

--- a/src/slic3r/GUI/Widgets/SideMenuPopup.cpp
+++ b/src/slic3r/GUI/Widgets/SideMenuPopup.cpp
@@ -4,6 +4,7 @@
 #include <wx/display.h>
 #include <wx/dcgraph.h>
 #include "../GUI_App.hpp"
+#include "../GUI_Utils.hpp"
 
 
 
@@ -44,7 +45,7 @@ bool SidePopup::Show( bool show )
 void SidePopup::Popup(wxWindow* focus)
 {
     Create();
-    auto drect = wxDisplay(GetParent()).GetGeometry();
+    auto drect = Slic3r::GUI::safe_display_geometry(GetParent());
     int screenwidth = drect.x + drect.width;
     //int screenwidth = wxSystemSettings::GetMetric(wxSYS_SCREEN_X,NULL);
 

--- a/src/slic3r/GUI/WipeTowerDialog.cpp
+++ b/src/slic3r/GUI/WipeTowerDialog.cpp
@@ -6,6 +6,7 @@
 #include "GUI.hpp"
 #include "I18N.hpp"
 #include "GUI_App.hpp"
+#include "GUI_Utils.hpp"
 #include "MsgDialog.hpp"
 #include "format.hpp"
 #include "libslic3r/Color.hpp"
@@ -387,7 +388,7 @@ WipingDialog::WipingDialog(wxWindow* parent, const int max_flush_volume) :
 
     // Clamp to screen size (leave some margin for window decorations)
     wxSize scaled_screen_size = wxGetDisplaySize();
-    double scale_factor = wxDisplay().GetScaleFactor();
+    double scale_factor = safe_display_scale_factor(parent);
     scaled_screen_size = { (int)(scaled_screen_size.x / scale_factor), (int)(scaled_screen_size.y / scale_factor) };
     wxSize screen_margin = { FromDIP(40), FromDIP(60) };
     scaled_screen_size -= screen_margin;

--- a/tests/slic3rutils/CMakeLists.txt
+++ b/tests/slic3rutils/CMakeLists.txt
@@ -2,6 +2,7 @@ get_filename_component(_TEST_NAME ${CMAKE_CURRENT_LIST_DIR} NAME)
 add_executable(${_TEST_NAME}_tests
     ${_TEST_NAME}_tests_main.cpp
     test_dev_mapping.cpp
+    test_gui_display_utils.cpp
     test_network_versions.cpp
     test_action_source.cpp
     test_plugin_host_api.cpp

--- a/tests/slic3rutils/test_gui_display_utils.cpp
+++ b/tests/slic3rutils/test_gui_display_utils.cpp
@@ -1,0 +1,69 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "slic3r/GUI/GUI_Utils.hpp"
+
+#include <wx/defs.h>
+
+TEST_CASE("Display lookup rejects detached window display indexes", "[GUI][Display][Regression]")
+{
+    using Slic3r::GUI::detail::safe_display_index;
+
+    CHECK(safe_display_index(wxNOT_FOUND, 2) == wxNOT_FOUND);
+    CHECK(safe_display_index(-2, 2) == wxNOT_FOUND);
+    CHECK(safe_display_index(2, 2) == wxNOT_FOUND);
+    CHECK(safe_display_index(100, 2) == wxNOT_FOUND);
+}
+
+TEST_CASE("Display lookup preserves valid window display indexes", "[GUI][Display][Regression]")
+{
+    using Slic3r::GUI::detail::safe_display_index;
+
+    CHECK(safe_display_index(0, 1) == 0);
+    CHECK(safe_display_index(1, 2) == 1);
+}
+
+TEST_CASE("Display lookup reports no display when the toolkit has none", "[GUI][Display][Regression]")
+{
+    using Slic3r::GUI::detail::safe_display_index;
+
+    CHECK(safe_display_index(0, 0) == wxNOT_FOUND);
+    CHECK(safe_display_index(wxNOT_FOUND, 0) == wxNOT_FOUND);
+}
+
+TEST_CASE("GTK backend selection stays native Wayland by default", "[GUI][Display][Regression]")
+{
+    using Slic3r::GUI::detail::should_force_x11_backend_for_wayland_kvm;
+
+    CHECK_FALSE(should_force_x11_backend_for_wayland_kvm(nullptr, ":0", "wayland-0", false));
+    CHECK_FALSE(should_force_x11_backend_for_wayland_kvm("wayland", ":0", "wayland-0", false));
+    CHECK_FALSE(should_force_x11_backend_for_wayland_kvm("wayland,x11", ":0", "wayland-0", false));
+}
+
+TEST_CASE("GTK backend selection forces X11 when Wayland KVM workaround preference is enabled", "[GUI][Display][Regression]")
+{
+    using Slic3r::GUI::detail::should_force_x11_backend_for_wayland_kvm;
+
+    CHECK(should_force_x11_backend_for_wayland_kvm(nullptr, ":0", "wayland-0", true));
+    CHECK(should_force_x11_backend_for_wayland_kvm("", ":0", "wayland-0", true));
+    CHECK(should_force_x11_backend_for_wayland_kvm("wayland", ":0", "wayland-0", true));
+    CHECK(should_force_x11_backend_for_wayland_kvm("wayland,x11", ":0", "wayland-0", true));
+}
+
+TEST_CASE("GTK backend selection keeps existing X11 backend", "[GUI][Display][Regression]")
+{
+    using Slic3r::GUI::detail::should_force_x11_backend_for_wayland_kvm;
+
+    CHECK_FALSE(should_force_x11_backend_for_wayland_kvm("x11", ":0", "wayland-0", false));
+    CHECK_FALSE(should_force_x11_backend_for_wayland_kvm("x11", ":0", "wayland-0", true));
+    CHECK_FALSE(should_force_x11_backend_for_wayland_kvm("x11,wayland", ":0", "wayland-0", true));
+}
+
+TEST_CASE("GTK backend selection requires XWayland for the workaround", "[GUI][Display][Regression]")
+{
+    using Slic3r::GUI::detail::should_force_x11_backend_for_wayland_kvm;
+
+    CHECK_FALSE(should_force_x11_backend_for_wayland_kvm(nullptr, nullptr, "wayland-0", true));
+    CHECK_FALSE(should_force_x11_backend_for_wayland_kvm(nullptr, "", "wayland-0", true));
+    CHECK_FALSE(should_force_x11_backend_for_wayland_kvm(nullptr, ":0", nullptr, true));
+    CHECK_FALSE(should_force_x11_backend_for_wayland_kvm(nullptr, ":0", "", true));
+}


### PR DESCRIPTION
# Description

Add a Linux-only preference that lets users affected by rare KVM or monitor-switching crashes force GTK onto X11/XWayland on the next launch. Native Wayland remains the default.

Also harden display lookups against detached monitor indexes and cover the backend-selection/display-index logic with slic3rutils regression tests.

Fixes #14387, which the reporter has closed however I replicated the issue with a self built package from the latest main branch.

# Screenshots/Recordings/Graphs

<img width="753" height="660" alt="image" src="https://github.com/user-attachments/assets/edb2b2f0-791f-4f7c-8c8b-071c4d63a5b9" />

## Tests

Validation: ctest --test-dir build/tests/slic3rutils -C Release -R 'GTK backend selection|Display lookup' --output-on-failure

Manually tested by enabling the option, restarting OrcaSlicer, and disconnecting my displays via KVM. OrcaSlicer remains operational on re-connecting monitors to the target machine.

<!--
> A guide for users on how to download the artifacts from this PR.
-->

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
