### PR TITLE
Add custom gcode via a modifier volume 

### DIFF
--- a/build_linux.sh
+++ b/build_linux.sh
@@ -130,6 +130,23 @@ if [ ${OPTIND} -eq 1 ] ; then
     exit 1
 fi
 
+if [[ -z "${CMAKE_BUILD_PARALLEL_LEVEL}" ]] ; then
+    detected_cores=""
+    if command -v nproc >/dev/null 2>&1 ; then
+        detected_cores=$(nproc)
+    elif command -v getconf >/dev/null 2>&1 ; then
+        detected_cores=$(getconf _NPROCESSORS_ONLN 2>/dev/null || true)
+    fi
+
+    if [[ "${detected_cores}" =~ ^[0-9]+$ ]] && [[ "${detected_cores}" -gt 1 ]] ; then
+        export CMAKE_BUILD_PARALLEL_LEVEL=$(((detected_cores + 1) / 2))
+    else
+        export CMAKE_BUILD_PARALLEL_LEVEL=1
+    fi
+
+    echo "Defaulting to CMAKE_BUILD_PARALLEL_LEVEL=${CMAKE_BUILD_PARALLEL_LEVEL} (half of detected CPU cores)."
+fi
+
 if [[ -n "${CLEAN_DOCKER_IMAGE}" ]] && [[ -z "${USE_DOCKER}" ]] ; then
     echo "Error: -F requires -g."
     exit 1

--- a/src/libslic3r/Fill/Fill.cpp
+++ b/src/libslic3r/Fill/Fill.cpp
@@ -276,6 +276,16 @@ struct SurfaceFillParams
     CenterOfSurfacePattern center_of_surface_pattern{CenterOfSurfacePattern::Each_Surface};
     bool                   separated_infills{false};
 
+    // Orca: a modifier with "group together" enabled must never have its infill bucketed with
+    // *any* other region's — not the ungrouped parent, and not another grouped modifier either,
+    // even when every other infill-relevant param happens to match (e.g. two modifiers with no
+    // settings of their own besides G-code). -1 means "not grouped" (free to merge with the parent
+    // or other ungrouped regions, as before); a grouped region stores its own region_id, which is
+    // unique, so it can never compare equal to any other region's params. Otherwise group_fills()
+    // (below) would silently attribute its extrusions to another region's LayerRegion::fills — the
+    // same failure mode is_perimeter_compatible() guards against for walls.
+    int                    modifier_group_region_id{-1};
+
 	bool operator<(const SurfaceFillParams &rhs) const {
 #define RETURN_COMPARE_NON_EQUAL(KEY) if (this->KEY < rhs.KEY) return true; if (this->KEY > rhs.KEY) return false;
 #define RETURN_COMPARE_NON_EQUAL_TYPED(TYPE, KEY) if (TYPE(this->KEY) < TYPE(rhs.KEY)) return true; if (TYPE(this->KEY) > TYPE(rhs.KEY)) return false;
@@ -311,6 +321,7 @@ struct SurfaceFillParams
         RETURN_COMPARE_NON_EQUAL(anisotropic_surfaces);
         RETURN_COMPARE_NON_EQUAL(center_of_surface_pattern);
         RETURN_COMPARE_NON_EQUAL(separated_infills);
+        RETURN_COMPARE_NON_EQUAL(modifier_group_region_id);
 
 		return false;
 	}
@@ -340,7 +351,8 @@ struct SurfaceFillParams
                 this->anisotropic_surfaces    == rhs.anisotropic_surfaces &&
                 this->center_of_surface_pattern == rhs.center_of_surface_pattern &&
                 this->separated_infills       == rhs.separated_infills &&
-                this->gyroid_optimized        == rhs.gyroid_optimized;
+                this->gyroid_optimized        == rhs.gyroid_optimized &&
+                this->modifier_group_region_id == rhs.modifier_group_region_id;
 	}
 };
 
@@ -876,6 +888,8 @@ std::vector<SurfaceFill> group_fills(const Layer &layer, LockRegionParam &lock_p
 		        params.extruder 	 = layerm.region().extruder(extrusion_role);
 		        params.pattern 		 = region_config.sparse_infill_pattern.value;
 		        params.density       = float(region_config.sparse_infill_density);
+                // Orca: see the field's comment on SurfaceFillParams above.
+                params.modifier_group_region_id = region_config.modifier_group_together.value ? int(region_id) : -1;
                 params.lateral_lattice_angle_1 = region_config.lateral_lattice_angle_1;
                 params.lateral_lattice_angle_2 = region_config.lateral_lattice_angle_2;
                 params.infill_overhang_angle = region_config.infill_overhang_angle;

--- a/src/libslic3r/Format/bbs_3mf.cpp
+++ b/src/libslic3r/Format/bbs_3mf.cpp
@@ -7979,7 +7979,14 @@ void PlateData::parse_filament_info(GCodeProcessorResult *result)
 
                             // stores volume's config data
                             for (const std::string& key : volume->config.keys()) {
-                                stream << "      <" << METADATA_TAG << " "<< KEY_ATTR << "=\"" << key << "\" " << VALUE_ATTR << "=\"" << volume->config.opt_serialize(key) << "\"/>\n";
+                                // Orca: modifier_enter_gcode/modifier_exit_gcode are multiline free-text G-code.
+                                // XML attribute-value normalization silently collapses raw newlines/tabs to spaces
+                                // on reload, so escape them (and quotes/ampersands/angle brackets) before storing,
+                                // same as embossed text volumes do for their TEXT_DATA_ATTR.
+                                const std::string value = (key == "modifier_enter_gcode" || key == "modifier_exit_gcode")
+                                    ? xml_escape_double_quotes_attribute_value(volume->config.opt_serialize(key))
+                                    : volume->config.opt_serialize(key);
+                                stream << "      <" << METADATA_TAG << " "<< KEY_ATTR << "=\"" << key << "\" " << VALUE_ATTR << "=\"" << value << "\"/>\n";
                             }
 
                             if (const std::optional<EmbossShape> &es = volume->emboss_shape; es.has_value()) {

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -6199,6 +6199,27 @@ LayerResult GCode::process_layer(
                         }
                         return false;
                     };
+
+                    // Orca: regions with "group together" enabled have their infill deferred to a
+                    // contiguous block printed after everything else in this island, each bracketed
+                    // by its own enter/exit G-code, instead of interleaved wherever infill lines cross
+                    // its boundary. Walls are unaffected — they stay merged with the parent region
+                    // (never split into separate geometry) and keep using crossing detection, so no
+                    // new perimeter/seam is introduced.
+                    std::vector<int> grouped_region_ids;
+                    for (size_t region_id = 0; region_id < by_region_specific.size(); ++region_id)
+                        if (print.get_print_region(region_id).config().modifier_group_together.value)
+                            grouped_region_ids.push_back(int(region_id));
+
+                    std::vector<bool> not_grouped_mask;
+                    const std::vector<bool> *infill_mask = nullptr;
+                    if (!grouped_region_ids.empty()) {
+                        not_grouped_mask.assign(by_region_specific.size(), true);
+                        for (int region_id : grouped_region_ids)
+                            not_grouped_mask[region_id] = false;
+                        infill_mask = &not_grouped_mask;
+                    }
+
                     {
                         // Print perimeters of regions that has is_infill_first == false
                         gcode += this->extrude_perimeters(print, by_region_specific, first_layer, false);
@@ -6210,12 +6231,41 @@ LayerResult GCode::process_layer(
                             has_insert_timelapse_gcode = true;
                         }
                         // Then print infill
-                        gcode += this->extrude_infill(print, by_region_specific, false);
+                        gcode += this->extrude_infill(print, by_region_specific, false, infill_mask);
                         // Then print perimeters of regions that has is_infill_first == true
                         gcode += this->extrude_perimeters(print, by_region_specific, first_layer, true);
                     }
                     // ironing
-                    gcode += this->extrude_infill(print, by_region_specific, true);
+                    gcode += this->extrude_infill(print, by_region_specific, true, infill_mask);
+
+                    // Orca: a wall loop's crossing detection can legitimately finish this island still
+                    // "inside" a modifier (the loop just happened to end there, with nothing further
+                    // crossing out). The deferred pass below jumps straight to a specific grouped
+                    // region's block regardless, so any still-open state must be closed out first —
+                    // otherwise its exit only fires at the very end of the layer, long after the
+                    // toolpath has moved on to unrelated geometry.
+                    gcode += this->flush_open_modifiers();
+
+                    // Orca: deferred infill pass for grouped regions, one contiguous block each, only
+                    // on the representative (non wipe-priming) pass — the wipe-priming pass prints a
+                    // filtered, non-representative subset of entities, so grouping/bracketing G-code
+                    // there wouldn't be meaningful.
+                    if (!grouped_region_ids.empty() && print_wipe_extrusions == 0) {
+                        std::vector<bool> only_this(by_region_specific.size(), false);
+                        for (int region_id : grouped_region_ids) {
+                            if (by_region_specific[region_id].infills.empty())
+                                // This modifier has no infill on this layer/island (e.g. outside its Z
+                                // range) — skip the bracket entirely rather than emit an empty pair.
+                                continue;
+                            std::fill(only_this.begin(), only_this.end(), false);
+                            only_this[region_id] = true;
+                            const PrintRegionConfig &cfg = print.get_print_region(region_id).config();
+                            gcode += this->render_modifier_gcode_template("modifier_enter_gcode", cfg.modifier_enter_gcode.value);
+                            gcode += this->extrude_infill(print, by_region_specific, false, &only_this);
+                            gcode += this->extrude_infill(print, by_region_specific, true, &only_this);
+                            gcode += this->render_modifier_gcode_template("modifier_exit_gcode", cfg.modifier_exit_gcode.value);
+                        }
+                    }
                 }
 
                 if (this->config().gcode_label_objects) {
@@ -6312,20 +6362,15 @@ LayerResult GCode::process_layer(
         gcode += insert_timelapse_gcode();
     }
 
-    // Orca: flush a lingering modifier's exit G-code so it isn't dropped when the print
-    // (or, in sequential/by-object mode, this object) ends while still "inside" a modifier boundary.
-    if (last_layer) {
-        std::vector<int> still_inside;
-        for (const auto &[region_id, inside] : m_inside_modifiers)
-            if (inside)
-                still_inside.push_back(region_id);
-        for (int region_id : still_inside)
-            for (const ModifierGCodeBoundary &b : this->layer_modifier_boundaries())
-                if (b.region_id == region_id) {
-                    gcode += this->set_inside_modifier(region_id, false, *b.enter_gcode, *b.exit_gcode);
-                    break;
-                }
-    }
+    // Orca: flush any modifier(s) still marked "inside" at the end of THIS layer — not just the
+    // print's (or, in sequential/by-object mode, this object's) true last layer. A wall loop's
+    // last segment can end while genuinely still inside a modifier's XY footprint, with no further
+    // crossing before the layer change; without an unconditional per-layer flush here, that state
+    // would silently persist into the next layer. Since a layer change is a Z move, not an XY
+    // crossing, it never fires this on its own, so without this flush the exit (and the next
+    // layer's fresh enter) could be dropped or, worse, corrupt an unrelated modifier's state via a
+    // stale match/mismatch the next time resync_modifier_state() runs on the new layer.
+    gcode += this->flush_open_modifiers();
 
     result.gcode = std::move(gcode);
     result.cooling_buffer_flush = object_layer || raft_layer || last_layer;
@@ -6943,12 +6988,15 @@ std::string GCode::extrude_path(const ExtrusionPath& path, const std::string& de
 // Orca: modifier enter/exit G-code is injected by the geometric crossing-detection mechanism
 // inside GCode::_extrude, not here, so an extrusion's geometry stays untouched regardless of
 // whether its region was merged with its parent (see modifier_crossing_candidates).
-std::string GCode::extrude_perimeters(const Print &print, const std::vector<ObjectByExtruder::Island::Region> &by_region, bool is_first_layer, bool is_infill_first)
+std::string GCode::extrude_perimeters(const Print &print, const std::vector<ObjectByExtruder::Island::Region> &by_region, bool is_first_layer, bool is_infill_first,
+                                       const std::vector<bool> *region_mask)
 {
     std::string gcode;
     for (const ObjectByExtruder::Island::Region &region : by_region)
         if (! region.perimeters.empty()) {
             int region_id = int(&region - &by_region.front());
+            if (region_mask && !(*region_mask)[region_id])
+                continue;
             m_config.apply(print.get_print_region(region_id).config());
             // BBS: for first layer, we always print wall firstly to get better bed adhesive force
             // This behaviour is same with cura
@@ -6965,20 +7013,23 @@ std::string GCode::extrude_perimeters(const Print &print, const std::vector<Obje
 // Chain the paths hierarchically by a greedy algorithm to minimize a travel distance.
 // Orca: modifier enter/exit G-code is injected by the geometric crossing-detection mechanism
 // inside GCode::_extrude, not here (see extrude_perimeters above).
-std::string GCode::extrude_infill(const Print &print, const std::vector<ObjectByExtruder::Island::Region> &by_region, bool ironing)
+std::string GCode::extrude_infill(const Print &print, const std::vector<ObjectByExtruder::Island::Region> &by_region, bool ironing,
+                                   const std::vector<bool> *region_mask)
 {
     std::string 		 gcode;
     ExtrusionEntitiesPtr extrusions;
     const char*          extrusion_name = ironing ? "ironing" : "infill";
     for (const ObjectByExtruder::Island::Region &region : by_region)
         if (! region.infills.empty()) {
+            int region_id = int(&region - &by_region.front());
+            if (region_mask && !(*region_mask)[region_id])
+                continue;
             extrusions.clear();
             extrusions.reserve(region.infills.size());
             for (ExtrusionEntity *ee : region.infills)
                 if ((ee->role() == erIroning) == ironing)
                     extrusions.emplace_back(ee);
             if (! extrusions.empty()) {
-                int region_id = int(&region - &by_region.front());
                 m_config.apply(print.get_print_region(region_id).config());
                 chain_and_reorder_extrusion_entities(extrusions, m_last_pos.to_point());
                 for (const ExtrusionEntity *fill : extrusions) {
@@ -7026,9 +7077,14 @@ const std::vector<GCode::ModifierGCodeBoundary>& GCode::layer_modifier_boundarie
                 ExPolygons boundary = to_expolygons(layerm->slices.surfaces);
                 if (boundary.empty())
                     continue;
+                // Orca: "group together" only reroutes infill to the deferred-block mechanism in
+                // process_layer (walls stay merged with the parent, so there's nothing region-local
+                // to defer there) — so this region still needs to be a crossing-detection candidate
+                // for walls/support/skirt-brim; applies_to() suppresses just the infill category.
                 m_layer_modifier_boundaries.push_back({int(region_id), std::move(boundary), &cfg.modifier_enter_gcode.value, &cfg.modifier_exit_gcode.value,
                                                         cfg.modifier_gcode_on_walls.value, cfg.modifier_gcode_on_infill.value,
-                                                        cfg.modifier_gcode_on_support.value, cfg.modifier_gcode_on_skirt_brim.value});
+                                                        cfg.modifier_gcode_on_support.value, cfg.modifier_gcode_on_skirt_brim.value,
+                                                        cfg.modifier_group_together.value});
             }
         }
     }
@@ -7041,7 +7097,9 @@ bool GCode::ModifierGCodeBoundary::applies_to(ExtrusionRole role) const
     if (is_perimeter(role))
         return on_walls;
     if (is_infill(role) || role == erGapFill)
-        return on_infill;
+        // Orca: grouped infill is handled once, by the deferred block in process_layer — never
+        // also via crossing detection here, or it would double-fire.
+        return on_infill && !group_together;
     if (is_support(role))
         return on_support;
     if (role == erSkirt || role == erBrim)
@@ -7078,6 +7136,23 @@ std::string GCode::set_inside_modifier(int region_id, bool inside, const std::st
 }
 
 // Orca: see GCode.hpp.
+std::string GCode::flush_open_modifiers()
+{
+    std::string gcode;
+    std::vector<int> still_inside;
+    for (const auto &[region_id, inside] : m_inside_modifiers)
+        if (inside)
+            still_inside.push_back(region_id);
+    for (int region_id : still_inside)
+        for (const ModifierGCodeBoundary &b : this->layer_modifier_boundaries())
+            if (b.region_id == region_id) {
+                gcode += this->set_inside_modifier(region_id, false, *b.enter_gcode, *b.exit_gcode);
+                break;
+            }
+    return gcode;
+}
+
+// Orca: see GCode.hpp.
 std::string GCode::resync_modifier_state(const Point &at, const std::vector<const ModifierGCodeBoundary*> &candidates)
 {
     std::string gcode;
@@ -7094,11 +7169,33 @@ std::string GCode::extrude_line_with_modifier_crossings(const Point &from, const
                                                           const std::vector<const ModifierGCodeBoundary*> &candidates,
                                                           const std::string &description, bool no_extrusion)
 {
+    struct Crossing {
+        double t;
+        int    region_id;
+        // Orca: whether the toolpath is becoming inside this region at this point, computed
+        // directly by probing a point just past the crossing (see below) — deliberately NOT
+        // inferred by toggling a running per-region state while walking `t` in order. Two
+        // modifiers that share a boundary edge produce an exit (for the region being left) and an
+        // enter (for the one being entered) at the same physical point; the two independent
+        // line-intersection computations against their respective polygons can disagree on `t` by
+        // a tiny floating-point margin, occasionally sorting the enter before the exit. Computing
+        // `entering` geometrically makes each crossing's meaning independent of that ordering
+        // noise, so the sort-order fixup below can reliably tell them apart and fix it.
+        bool   entering;
+    };
     const Line   segment(from, to);
     const double seg_len = segment.length();
-    // (parametric t along the segment, region_id) for every boundary crossing, sorted below.
-    std::vector<std::pair<double, int>> crossings;
+    const Vec2d  dir = seg_len > 0 ? (to - from).cast<double>() / seg_len : Vec2d(0, 0);
+    // A short probe step past the crossing point, along the segment direction, used to determine
+    // whether the path is entering or exiting there; short enough to stay within the segment for
+    // any crossing not within EPSILON of `to`, long enough to clear typical polygon-edge noise.
+    const double probe_dist = std::min(seg_len, 10.0 * double(SCALED_EPSILON));
+
+    std::vector<Crossing> crossings;
     for (const ModifierGCodeBoundary *b : candidates) {
+        auto region_contains = [b](const Point &pt) {
+            return std::any_of(b->boundary.begin(), b->boundary.end(), [&pt](const ExPolygon &ex) { return ex.contains(pt); });
+        };
         for (const ExPolygon &ex : b->boundary) {
             auto test_ring = [&](const Polygon &ring) {
                 Lines lines = ring.lines();
@@ -7106,7 +7203,8 @@ std::string GCode::extrude_line_with_modifier_crossings(const Point &from, const
                     Point pt;
                     if (line_alg::intersection(segment, edge, &pt)) {
                         double t = seg_len > 0 ? (pt - from).cast<double>().norm() / seg_len : 0.;
-                        crossings.emplace_back(t, b->region_id);
+                        Point probe = pt + (dir * probe_dist).cast<coord_t>();
+                        crossings.push_back({t, b->region_id, region_contains(probe)});
                     }
                 }
             };
@@ -7115,7 +7213,13 @@ std::string GCode::extrude_line_with_modifier_crossings(const Point &from, const
                 test_ring(hole);
         }
     }
-    std::sort(crossings.begin(), crossings.end());
+    std::sort(crossings.begin(), crossings.end(), [](const Crossing &a, const Crossing &b) { return a.t < b.t; });
+    // Fix up adjacent crossings that are (numerically) at the same point but sorted the wrong way
+    // round: an exit must always be processed before an enter at a shared boundary.
+    for (size_t i = 1; i < crossings.size(); ++i)
+        if (crossings[i - 1].entering && !crossings[i].entering &&
+            std::fabs(crossings[i].t - crossings[i - 1].t) < 10.0 * double(SCALED_EPSILON) / std::max(seg_len, 1.0))
+            std::swap(crossings[i - 1], crossings[i]);
 
     std::string gcode;
     if (crossings.empty()) {
@@ -7124,20 +7228,16 @@ std::string GCode::extrude_line_with_modifier_crossings(const Point &from, const
     }
 
     double prev_t = 0.;
-    for (const auto &[t, region_id] : crossings) {
-        Point cross_point = from + ((to - from).cast<double>() * t).cast<coord_t>();
-        double sub_dE = dE * (t - prev_t);
+    for (const Crossing &c : crossings) {
+        Point cross_point = from + ((to - from).cast<double>() * c.t).cast<coord_t>();
+        double sub_dE = dE * (c.t - prev_t);
         gcode += m_writer.extrude_to_xy(this->point_to_gcode(cross_point), sub_dE, GCodeWriter::full_gcode_comment ? description : "", no_extrusion);
-        // Flip this modifier's persisted state at the exact crossing point.
-        bool &state = m_inside_modifiers[region_id];
-        state = !state;
         for (const ModifierGCodeBoundary *b : candidates)
-            if (b->region_id == region_id) {
-                gcode += state ? this->render_modifier_gcode_template("modifier_enter_gcode", *b->enter_gcode)
-                                : this->render_modifier_gcode_template("modifier_exit_gcode", *b->exit_gcode);
+            if (b->region_id == c.region_id) {
+                gcode += this->set_inside_modifier(c.region_id, c.entering, *b->enter_gcode, *b->exit_gcode);
                 break;
             }
-        prev_t = t;
+        prev_t = c.t;
     }
     gcode += m_writer.extrude_to_xy(this->point_to_gcode(to), dE * (1. - prev_t), GCodeWriter::full_gcode_comment ? description : "", no_extrusion);
     return gcode;

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -6215,7 +6215,7 @@ LayerResult GCode::process_layer(
                         gcode += this->extrude_perimeters(print, by_region_specific, first_layer, true);
                     }
                     // ironing
-                    gcode += this->extrude_infill(print,by_region_specific, true);
+                    gcode += this->extrude_infill(print, by_region_specific, true);
                 }
 
                 if (this->config().gcode_label_objects) {
@@ -6310,6 +6310,21 @@ LayerResult GCode::process_layer(
         m_writer.add_object_change_labels(gcode);
 
         gcode += insert_timelapse_gcode();
+    }
+
+    // Orca: flush a lingering modifier's exit G-code so it isn't dropped when the print
+    // (or, in sequential/by-object mode, this object) ends while still "inside" a modifier boundary.
+    if (last_layer) {
+        std::vector<int> still_inside;
+        for (const auto &[region_id, inside] : m_inside_modifiers)
+            if (inside)
+                still_inside.push_back(region_id);
+        for (int region_id : still_inside)
+            for (const ModifierGCodeBoundary &b : this->layer_modifier_boundaries())
+                if (b.region_id == region_id) {
+                    gcode += this->set_inside_modifier(region_id, false, *b.enter_gcode, *b.exit_gcode);
+                    break;
+                }
     }
 
     result.gcode = std::move(gcode);
@@ -6925,12 +6940,16 @@ std::string GCode::extrude_path(const ExtrusionPath& path, const std::string& de
 }
 
 // Extrude perimeters: Decide where to put seams (hide or align seams).
+// Orca: modifier enter/exit G-code is injected by the geometric crossing-detection mechanism
+// inside GCode::_extrude, not here, so an extrusion's geometry stays untouched regardless of
+// whether its region was merged with its parent (see modifier_crossing_candidates).
 std::string GCode::extrude_perimeters(const Print &print, const std::vector<ObjectByExtruder::Island::Region> &by_region, bool is_first_layer, bool is_infill_first)
 {
     std::string gcode;
     for (const ObjectByExtruder::Island::Region &region : by_region)
         if (! region.perimeters.empty()) {
-            m_config.apply(print.get_print_region(&region - &by_region.front()).config());
+            int region_id = int(&region - &by_region.front());
+            m_config.apply(print.get_print_region(region_id).config());
             // BBS: for first layer, we always print wall firstly to get better bed adhesive force
             // This behaviour is same with cura
             const bool should_print = is_first_layer ? !is_infill_first
@@ -6944,6 +6963,8 @@ std::string GCode::extrude_perimeters(const Print &print, const std::vector<Obje
 }
 
 // Chain the paths hierarchically by a greedy algorithm to minimize a travel distance.
+// Orca: modifier enter/exit G-code is injected by the geometric crossing-detection mechanism
+// inside GCode::_extrude, not here (see extrude_perimeters above).
 std::string GCode::extrude_infill(const Print &print, const std::vector<ObjectByExtruder::Island::Region> &by_region, bool ironing)
 {
     std::string 		 gcode;
@@ -6957,7 +6978,8 @@ std::string GCode::extrude_infill(const Print &print, const std::vector<ObjectBy
                 if ((ee->role() == erIroning) == ironing)
                     extrusions.emplace_back(ee);
             if (! extrusions.empty()) {
-                m_config.apply(print.get_print_region(&region - &by_region.front()).config());
+                int region_id = int(&region - &by_region.front());
+                m_config.apply(print.get_print_region(region_id).config());
                 chain_and_reorder_extrusion_entities(extrusions, m_last_pos.to_point());
                 for (const ExtrusionEntity *fill : extrusions) {
                     auto *eec = dynamic_cast<const ExtrusionEntityCollection*>(fill);
@@ -6969,6 +6991,155 @@ std::string GCode::extrude_infill(const Print &print, const std::vector<ObjectBy
                 }
             }
         }
+    return gcode;
+}
+
+// Orca: renders a modifier_enter_gcode/modifier_exit_gcode template; see GCode.hpp.
+std::string GCode::render_modifier_gcode_template(const char *key, const std::string &templ)
+{
+    if (templ.empty())
+        return {};
+    DynamicConfig config;
+    config.set_key_value("layer_num", new ConfigOptionInt(m_layer_index + 1));
+    config.set_key_value("layer_z", new ConfigOptionFloat(m_layer == nullptr ? m_last_height : m_layer->print_z));
+    return this->placeholder_parser_process(key, templ, m_writer.filament()->id(), &config) + "\n";
+}
+
+// Orca: rebuilds (lazily, cached per m_layer) the list of this layer's modifier regions carrying
+// enter/exit G-code, for the current object. Even though Layer::make_perimeters() may merge a
+// gcode-only modifier's perimeter *generation* into its parent's for efficiency, its own
+// LayerRegion::slices (the boundary polygon(s) we need here) stay populated regardless.
+const std::vector<GCode::ModifierGCodeBoundary>& GCode::layer_modifier_boundaries()
+{
+    if (m_layer_modifier_boundaries_layer != m_layer) {
+        m_layer_modifier_boundaries_layer = m_layer;
+        m_layer_modifier_boundaries.clear();
+        if (m_layer != nullptr && m_layer->object() != nullptr) {
+            const PrintObject &print_object = *m_layer->object();
+            for (size_t region_id = 0; region_id < print_object.num_printing_regions(); ++region_id) {
+                const PrintRegionConfig &cfg = print_object.printing_region(region_id).config();
+                if (cfg.modifier_enter_gcode.value.empty() && cfg.modifier_exit_gcode.value.empty())
+                    continue;
+                const LayerRegion *layerm = m_layer->get_region(int(region_id));
+                if (layerm == nullptr || layerm->slices.empty())
+                    continue;
+                ExPolygons boundary = to_expolygons(layerm->slices.surfaces);
+                if (boundary.empty())
+                    continue;
+                m_layer_modifier_boundaries.push_back({int(region_id), std::move(boundary), &cfg.modifier_enter_gcode.value, &cfg.modifier_exit_gcode.value,
+                                                        cfg.modifier_gcode_on_walls.value, cfg.modifier_gcode_on_infill.value,
+                                                        cfg.modifier_gcode_on_support.value, cfg.modifier_gcode_on_skirt_brim.value});
+            }
+        }
+    }
+    return m_layer_modifier_boundaries;
+}
+
+// Orca: see GCode.hpp.
+bool GCode::ModifierGCodeBoundary::applies_to(ExtrusionRole role) const
+{
+    if (is_perimeter(role))
+        return on_walls;
+    if (is_infill(role) || role == erGapFill)
+        return on_infill;
+    if (is_support(role))
+        return on_support;
+    if (role == erSkirt || role == erBrim)
+        return on_skirt_brim;
+    return false;
+}
+
+// Orca: candidate boundaries for `path` — those whose per-feature-type toggles cover its role
+// (see ModifierGCodeBoundary::applies_to) and whose bounding box comes near the path (cheap
+// common-case reject; empty for the vast majority of prints, which use no modifier G-code at all).
+std::vector<const GCode::ModifierGCodeBoundary*> GCode::modifier_crossing_candidates(const ExtrusionPath &path)
+{
+    std::vector<const ModifierGCodeBoundary*> candidates;
+    const auto &boundaries = this->layer_modifier_boundaries();
+    if (boundaries.empty())
+        return candidates;
+    const BoundingBox path_bbox = get_extents(path.polyline.to_polyline());
+    for (const ModifierGCodeBoundary &b : boundaries)
+        if (b.applies_to(path.role()) && path_bbox.overlap(get_extents(b.boundary)))
+            candidates.push_back(&b);
+    return candidates;
+}
+
+// Orca: see GCode.hpp.
+std::string GCode::set_inside_modifier(int region_id, bool inside, const std::string &enter_gcode, const std::string &exit_gcode)
+{
+    bool &state = m_inside_modifiers[region_id];
+    if (state == inside)
+        return {};
+    std::string gcode = inside ? this->render_modifier_gcode_template("modifier_enter_gcode", enter_gcode)
+                                : this->render_modifier_gcode_template("modifier_exit_gcode", exit_gcode);
+    state = inside;
+    return gcode;
+}
+
+// Orca: see GCode.hpp.
+std::string GCode::resync_modifier_state(const Point &at, const std::vector<const ModifierGCodeBoundary*> &candidates)
+{
+    std::string gcode;
+    for (const ModifierGCodeBoundary *b : candidates) {
+        bool inside = std::any_of(b->boundary.begin(), b->boundary.end(), [&at](const ExPolygon &ex) { return ex.contains(at); });
+        gcode += this->set_inside_modifier(b->region_id, inside, *b->enter_gcode, *b->exit_gcode);
+    }
+    return gcode;
+}
+
+// Orca: see GCode.hpp. Splits (from -> to) at every point it crosses one of `candidates`,
+// injecting enter/exit G-code at each crossing with proportionally interpolated extrusion.
+std::string GCode::extrude_line_with_modifier_crossings(const Point &from, const Point &to, double dE,
+                                                          const std::vector<const ModifierGCodeBoundary*> &candidates,
+                                                          const std::string &description, bool no_extrusion)
+{
+    const Line   segment(from, to);
+    const double seg_len = segment.length();
+    // (parametric t along the segment, region_id) for every boundary crossing, sorted below.
+    std::vector<std::pair<double, int>> crossings;
+    for (const ModifierGCodeBoundary *b : candidates) {
+        for (const ExPolygon &ex : b->boundary) {
+            auto test_ring = [&](const Polygon &ring) {
+                Lines lines = ring.lines();
+                for (const Line &edge : lines) {
+                    Point pt;
+                    if (line_alg::intersection(segment, edge, &pt)) {
+                        double t = seg_len > 0 ? (pt - from).cast<double>().norm() / seg_len : 0.;
+                        crossings.emplace_back(t, b->region_id);
+                    }
+                }
+            };
+            test_ring(ex.contour);
+            for (const Polygon &hole : ex.holes)
+                test_ring(hole);
+        }
+    }
+    std::sort(crossings.begin(), crossings.end());
+
+    std::string gcode;
+    if (crossings.empty()) {
+        gcode += m_writer.extrude_to_xy(this->point_to_gcode(to), dE, GCodeWriter::full_gcode_comment ? description : "", no_extrusion);
+        return gcode;
+    }
+
+    double prev_t = 0.;
+    for (const auto &[t, region_id] : crossings) {
+        Point cross_point = from + ((to - from).cast<double>() * t).cast<coord_t>();
+        double sub_dE = dE * (t - prev_t);
+        gcode += m_writer.extrude_to_xy(this->point_to_gcode(cross_point), sub_dE, GCodeWriter::full_gcode_comment ? description : "", no_extrusion);
+        // Flip this modifier's persisted state at the exact crossing point.
+        bool &state = m_inside_modifiers[region_id];
+        state = !state;
+        for (const ModifierGCodeBoundary *b : candidates)
+            if (b->region_id == region_id) {
+                gcode += state ? this->render_modifier_gcode_template("modifier_enter_gcode", *b->enter_gcode)
+                                : this->render_modifier_gcode_template("modifier_exit_gcode", *b->exit_gcode);
+                break;
+            }
+        prev_t = t;
+    }
+    gcode += m_writer.extrude_to_xy(this->point_to_gcode(to), dE * (1. - prev_t), GCodeWriter::full_gcode_comment ? description : "", no_extrusion);
     return gcode;
 }
 
@@ -7464,10 +7635,17 @@ std::string GCode::_extrude(const ExtrusionPath &path, std::string description, 
     }
 }
     
+    // Orca: modifier-boundary crossing detection (every feature type) — computed once per path,
+    // used both to skip the overhang-speed re-segmentation below (the two don't combine in v1) and
+    // to bracket G1 moves with enter/exit G-code further down, without altering the path's geometry.
+    std::vector<const ModifierGCodeBoundary*> modifier_crossings = this->modifier_crossing_candidates(path);
+    if (!modifier_crossings.empty())
+        gcode += this->resync_modifier_state(path.first_point(), modifier_crossings);
+
     bool variable_speed = false;
     std::vector<ProcessedPoint> new_points {};
 
-    if (NOZZLE_CONFIG(enable_overhang_speed) && !this->on_first_layer() && !object_layer_over_raft() &&
+    if (modifier_crossings.empty() && NOZZLE_CONFIG(enable_overhang_speed) && !this->on_first_layer() && !object_layer_over_raft() &&
         (is_bridge(path.role()) || is_perimeter(path.role()))) {
             bool is_external = is_external_perimeter(path.role());
             double ref_speed   = is_external ? NOZZLE_CONFIG(outer_wall_speed) : NOZZLE_CONFIG(inner_wall_speed);
@@ -7871,10 +8049,17 @@ std::string GCode::_extrude(const ExtrusionPath &path, std::string description, 
 
                     } else if (sloped == nullptr) {
                         // Normal extrusion
-                        gcode += m_writer.extrude_to_xy(
-                            this->point_to_gcode(line.b.to_point()),
-                            dE,
-                            GCodeWriter::full_gcode_comment ? tempDescription : "", path.is_force_no_extrusion());
+                        if (modifier_crossings.empty())
+                            gcode += m_writer.extrude_to_xy(
+                                this->point_to_gcode(line.b.to_point()),
+                                dE,
+                                GCodeWriter::full_gcode_comment ? tempDescription : "", path.is_force_no_extrusion());
+                        else
+                            // Orca: split this segment at every point it crosses a modifier boundary,
+                            // injecting enter/exit G-code there without altering the path's geometry.
+                            gcode += this->extrude_line_with_modifier_crossings(
+                                line.a.to_point(), line.b.to_point(), dE,
+                                modifier_crossings, tempDescription, path.is_force_no_extrusion());
                     } else {
                         // Sloped extrusion
                         const auto [z_ratio, e_ratio] = sloped->interpolate(path_length / total_length);

--- a/src/libslic3r/GCode.hpp
+++ b/src/libslic3r/GCode.hpp
@@ -512,6 +512,49 @@ private:
     std::string     extrude_perimeters(const Print& print, const std::vector<ObjectByExtruder::Island::Region>& by_region, bool is_first_layer, bool is_infill_first);
     std::string     extrude_infill(const Print& print, const std::vector<ObjectByExtruder::Island::Region>& by_region, bool ironing);
     std::string     extrude_support(const ExtrusionEntityCollection& support_fills, const ExtrusionRole support_extrusion_role);
+    // Renders a modifier_enter_gcode/modifier_exit_gcode template with the layer_num/layer_z
+    // placeholders these hooks expose; empty string if `templ` is empty.
+    std::string     render_modifier_gcode_template(const char *key, const std::string &templ);
+
+    // Orca: modifier-boundary crossing detection. Keeps an extrusion path's geometry/shape
+    // untouched (no wall seam, no infill boundary split) while injecting enter/exit G-code exactly
+    // where its G-code moves cross a modifier's boundary. Applies to every extrusion role/feature
+    // type by default.
+    struct ModifierGCodeBoundary {
+        int             region_id;
+        ExPolygons      boundary;
+        const std::string *enter_gcode;
+        const std::string *exit_gcode;
+        // Orca: per-feature-type toggles, set via checkboxes in the modifier G-code dialog and
+        // backed by modifier_gcode_on_walls/infill/support/skirt_brim. All default to true.
+        bool            on_walls;
+        bool            on_infill;
+        bool            on_support;
+        bool            on_skirt_brim;
+        // Whether this modifier's G-code applies to `role`, per the toggles above. Roles that fit
+        // none of the four categories (wipe tower, custom/mixed/none) are never covered.
+        bool applies_to(ExtrusionRole role) const;
+    };
+    // Rebuilds (lazily, cached per m_layer) the list of this layer's modifier regions that carry
+    // enter/exit G-code, for the current object (m_layer->object()).
+    const std::vector<ModifierGCodeBoundary>& layer_modifier_boundaries();
+    // Candidate boundaries for `path`: only those that apply to its role (see
+    // ModifierGCodeBoundary::applies_to) and whose bounding box comes near the path.
+    std::vector<const ModifierGCodeBoundary*> modifier_crossing_candidates(const ExtrusionPath &path);
+    // Emits enter/exit G-code for `region_id` when `inside` differs from the persisted state in
+    // m_inside_modifiers, and updates that state. Shared by resync, mid-segment crossings, and the
+    // trailing flush.
+    std::string     set_inside_modifier(int region_id, bool inside, const std::string &enter_gcode, const std::string &exit_gcode);
+    // Called once before a candidate path's first segment: if `at`'s containment in a candidate
+    // boundary disagrees with the persisted state (an intervening travel move silently crossed
+    // it), emits the appropriate enter/exit G-code to resync before any move is written.
+    std::string     resync_modifier_state(const Point &at, const std::vector<const ModifierGCodeBoundary*> &candidates);
+    // Emits the G1 move(s) for a single polyline segment (from -> to, total extrusion `dE`),
+    // splitting it at every point it crosses one of `candidates`, injecting enter/exit G-code at
+    // each crossing with proportionally interpolated extrusion.
+    std::string     extrude_line_with_modifier_crossings(const Point &from, const Point &to, double dE,
+                                                           const std::vector<const ModifierGCodeBoundary*> &candidates,
+                                                           const std::string &description, bool no_extrusion);
 
     // Farthest-point timelapse: find the extrusion point farthest from camera (0,0)
     void compute_farthest_point(const std::vector<LayerToPrint> &layers, int most_used_extruder,
@@ -641,6 +684,16 @@ private:
     ExtrusionRole                       m_last_extrusion_role;
     // To ignore gapfill role for retract_lift_enforce
     ExtrusionRole                       m_last_notgapfill_extrusion_role;
+    // Orca: per-layer cache of modifier regions carrying enter/exit G-code, used to bracket G1
+    // moves of any feature type at the exact point they cross a modifier's boundary, without
+    // splitting the extrusion's geometry into a separate region (which would e.g. introduce a wall
+    // seam). See the ModifierGCodeBoundary struct declared above with the crossing-detection methods.
+    std::vector<ModifierGCodeBoundary>  m_layer_modifier_boundaries;
+    // Which Layer the above cache was built for; rebuilt lazily whenever m_layer changes.
+    const Layer*                        m_layer_modifier_boundaries_layer = nullptr;
+    // Per-modifier-region "is the toolpath currently inside this boundary" state, persisted across
+    // extrusion paths (and travel moves) so a crossing is never double-counted or missed.
+    std::map<int, bool>                 m_inside_modifiers;
     // Support for G-Code Processor
     float                               m_last_height{ 0.0f };
     float                               m_last_layer_z{ 0.0f };

--- a/src/libslic3r/GCode.hpp
+++ b/src/libslic3r/GCode.hpp
@@ -509,8 +509,13 @@ private:
 		// For sequential print, the instance of the object to be printing has to be defined.
 		const size_t                     				 single_object_instance_idx);
 
-    std::string     extrude_perimeters(const Print& print, const std::vector<ObjectByExtruder::Island::Region>& by_region, bool is_first_layer, bool is_infill_first);
-    std::string     extrude_infill(const Print& print, const std::vector<ObjectByExtruder::Island::Region>& by_region, bool ironing);
+    // Orca: `region_mask`, if non-null, must be sized to `by_region.size()`; region `i` is skipped
+    // whenever `(*region_mask)[i]` is false. Used to defer "group together" modifier regions to a
+    // separate contiguous pass instead of interleaving them in native region-index order.
+    std::string     extrude_perimeters(const Print& print, const std::vector<ObjectByExtruder::Island::Region>& by_region, bool is_first_layer, bool is_infill_first,
+                                        const std::vector<bool> *region_mask = nullptr);
+    std::string     extrude_infill(const Print& print, const std::vector<ObjectByExtruder::Island::Region>& by_region, bool ironing,
+                                    const std::vector<bool> *region_mask = nullptr);
     std::string     extrude_support(const ExtrusionEntityCollection& support_fills, const ExtrusionRole support_extrusion_role);
     // Renders a modifier_enter_gcode/modifier_exit_gcode template with the layer_num/layer_z
     // placeholders these hooks expose; empty string if `templ` is empty.
@@ -531,6 +536,10 @@ private:
         bool            on_infill;
         bool            on_support;
         bool            on_skirt_brim;
+        // Orca: mirrors modifier_group_together. When set, infill is handled entirely by the
+        // deferred-block mechanism in process_layer instead of crossing detection (walls stay
+        // merged with the parent region regardless, so they keep using crossing detection here).
+        bool            group_together;
         // Whether this modifier's G-code applies to `role`, per the toggles above. Roles that fit
         // none of the four categories (wipe tower, custom/mixed/none) are never covered.
         bool applies_to(ExtrusionRole role) const;
@@ -545,6 +554,12 @@ private:
     // m_inside_modifiers, and updates that state. Shared by resync, mid-segment crossings, and the
     // trailing flush.
     std::string     set_inside_modifier(int region_id, bool inside, const std::string &enter_gcode, const std::string &exit_gcode);
+    // Emits exit G-code for every modifier region still marked "inside" in m_inside_modifiers.
+    // Crossing detection only fires exits where the toolpath geometrically leaves a region; a wall
+    // loop can legitimately finish its last segment still inside one (nothing further crosses out
+    // before the next, physically distant thing prints), so callers must flush explicitly before
+    // jumping elsewhere — the deferred grouped-infill block, and the end of every layer.
+    std::string     flush_open_modifiers();
     // Called once before a candidate path's first segment: if `at`'s containment in a candidate
     // boundary disagrees with the persisted state (an intervening travel move silently crossed
     // it), emits the appropriate enter/exit G-code to resync before any move is written.

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -4739,6 +4739,51 @@ void PrintConfigDef::init_fff_params()
     def->mode     = comExpert;
     def->set_default_value(new ConfigOptionFloat(0.05));
 
+    def = this->add("modifier_enter_gcode", coString);
+    def->label = L("Modifier enter G-code");
+    def->tooltip = L("This G-code is inserted whenever the toolpath starts printing extrusions "
+                      "that belong to this modifier's region.");
+    def->multiline = true;
+    def->full_width = true;
+    def->height = 5;
+    def->mode = comAdvanced;
+    def->set_default_value(new ConfigOptionString());
+
+    def = this->add("modifier_exit_gcode", coString);
+    def->label = L("Modifier exit G-code");
+    def->tooltip = L("This G-code is inserted whenever the toolpath stops printing extrusions "
+                      "that belong to this modifier's region.");
+    def->multiline = true;
+    def->full_width = true;
+    def->height = 5;
+    def->mode = comAdvanced;
+    def->set_default_value(new ConfigOptionString());
+
+    def = this->add("modifier_gcode_on_walls", coBool);
+    def->label = L("Apply modifier G-code to walls");
+    def->tooltip = L("Whether the modifier's enter/exit G-code fires for wall (perimeter) extrusions.");
+    def->mode = comAdvanced;
+    def->set_default_value(new ConfigOptionBool(true));
+
+    def = this->add("modifier_gcode_on_infill", coBool);
+    def->label = L("Apply modifier G-code to infill");
+    def->tooltip = L("Whether the modifier's enter/exit G-code fires for infill extrusions "
+                      "(including top/bottom surfaces, ironing, and gap fill).");
+    def->mode = comAdvanced;
+    def->set_default_value(new ConfigOptionBool(true));
+
+    def = this->add("modifier_gcode_on_support", coBool);
+    def->label = L("Apply modifier G-code to support");
+    def->tooltip = L("Whether the modifier's enter/exit G-code fires for support material extrusions.");
+    def->mode = comAdvanced;
+    def->set_default_value(new ConfigOptionBool(true));
+
+    def = this->add("modifier_gcode_on_skirt_brim", coBool);
+    def->label = L("Apply modifier G-code to skirt/brim");
+    def->tooltip = L("Whether the modifier's enter/exit G-code fires for skirt and brim extrusions.");
+    def->mode = comAdvanced;
+    def->set_default_value(new ConfigOptionBool(true));
+
     def = this->add("layer_change_gcode", coString);
     def->label = L("Layer change G-code");
     def->tooltip = L("This G-code is inserted at every layer change after the Z lift.");
@@ -12278,6 +12323,8 @@ static std::map<t_custom_gcode_key, t_config_option_keys> s_CustomGcodeSpecificP
     {"change_extrusion_role_gcode", {"layer_num", "layer_z", "extrusion_role", "last_extrusion_role"}},
     {"filament_change_extrusion_role_gcode", {"layer_num", "layer_z", "extrusion_role", "last_extrusion_role"}},
     {"process_change_extrusion_role_gcode", {"layer_num", "layer_z", "extrusion_role", "last_extrusion_role"}},
+    {"modifier_enter_gcode",        {"layer_num", "layer_z"}},
+    {"modifier_exit_gcode",         {"layer_num", "layer_z"}},
     {"printing_by_object_gcode",    {}},
     {"machine_pause_gcode",         {}},
     {"template_custom_gcode",       {}},

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -4784,6 +4784,18 @@ void PrintConfigDef::init_fff_params()
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionBool(true));
 
+    def = this->add("modifier_group_together", coBool);
+    def->label = L("Group modifier infill together");
+    def->tooltip = L("Print all of this modifier's infill as one contiguous block at the end of "
+                      "each layer's other printing, instead of interleaved wherever infill lines "
+                      "happen to cross its boundary. Useful when the modifier's G-code changes "
+                      "something slow to react (e.g. nozzle temperature) that shouldn't be toggled "
+                      "many times per layer. Walls are unaffected: they stay merged with the "
+                      "surrounding perimeter (no extra seam) and continue firing G-code wherever "
+                      "they cross the modifier's boundary.");
+    def->mode = comAdvanced;
+    def->set_default_value(new ConfigOptionBool(false));
+
     def = this->add("layer_change_gcode", coString);
     def->label = L("Layer change G-code");
     def->tooltip = L("This G-code is inserted at every layer change after the Z lift.");

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -1402,6 +1402,17 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionBool, zaa_dont_alternate_fill_direction))
     ((ConfigOptionFloat, zaa_min_z))
     ((ConfigOptionFloat, zaa_minimize_perimeter_height))
+
+    // Orca: per-modifier custom G-code, emitted when the toolpath enters/exits
+    // extrusions belonging to a modifier volume's region.
+    ((ConfigOptionString,               modifier_enter_gcode))
+    ((ConfigOptionString,               modifier_exit_gcode))
+    // Orca: which feature types the above G-code applies to. All default to true (apply
+    // everywhere); exposed as checkboxes in the modifier G-code dialog.
+    ((ConfigOptionBool,                 modifier_gcode_on_walls))
+    ((ConfigOptionBool,                 modifier_gcode_on_infill))
+    ((ConfigOptionBool,                 modifier_gcode_on_support))
+    ((ConfigOptionBool,                 modifier_gcode_on_skirt_brim))
     )
 
 PRINT_CONFIG_CLASS_DEFINE(

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -1413,6 +1413,11 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionBool,                 modifier_gcode_on_infill))
     ((ConfigOptionBool,                 modifier_gcode_on_support))
     ((ConfigOptionBool,                 modifier_gcode_on_skirt_brim))
+    // Orca: forces this modifier's infill to print as one contiguous block at the end of each
+    // layer's other printing, instead of interleaved wherever infill lines cross its boundary,
+    // trading infill print order for a single enter/exit G-code transition per layer. Walls are
+    // unaffected (stay merged with the parent region, no new seam). Default off (explicit opt-in).
+    ((ConfigOptionBool,                 modifier_group_together))
     )
 
 PRINT_CONFIG_CLASS_DEFINE(

--- a/src/slic3r/CMakeLists.txt
+++ b/src/slic3r/CMakeLists.txt
@@ -319,6 +319,8 @@ set(SLIC3R_GUI_SOURCES
     GUI/MeshUtils.hpp
     GUI/ModelMall.cpp
     GUI/ModelMall.hpp
+    GUI/ModifierGCodeDialog.cpp
+    GUI/ModifierGCodeDialog.hpp
     GUI/MonitorBasePanel.cpp
     GUI/BBLStatusBarPrint.hpp
     GUI/BBLStatusBarPrint.cpp

--- a/src/slic3r/GUI/GUI_Factories.cpp
+++ b/src/slic3r/GUI/GUI_Factories.cpp
@@ -18,6 +18,7 @@
 #include "PartPlate.hpp"
 #include "Gizmos/GLGizmoEmboss.hpp"
 #include "Gizmos/GLGizmoSVG.hpp"
+#include "ModifierGCodeDialog.hpp"
 
 #include <boost/algorithm/string.hpp>
 #include "slic3r/GUI/Tab.hpp"
@@ -1364,6 +1365,25 @@ void MenuFactory::append_menu_item_edit_svg(wxMenu *menu)
     append_menu_item(menu, wxID_ANY, name, description, open_svg, icon, nullptr, can_edit_svg, m_parent);
 }
 
+void MenuFactory::append_menu_item_modifier_gcode(wxMenu *menu)
+{
+    const wxString name = _L("Custom G-code");
+
+    // Selection-dependent visibility: rebuilt each time this menu is shown, same pattern as
+    // append_menu_item_change_filament.
+    const int menu_item_id = menu->FindItem(name);
+    if (menu_item_id != wxNOT_FOUND)
+        menu->Destroy(menu_item_id);
+
+    const ModelVolume *sel_vol = obj_list()->get_selected_model_volume();
+    if (sel_vol == nullptr || !sel_vol->is_modifier())
+        return;
+
+    append_menu_item(menu, wxID_ANY, name, _L("Insert G-code fired when the toolpath enters/exits this modifier's region"),
+        [](wxCommandEvent &) { obj_list()->edit_selected_modifier_gcode(); }, "cog", nullptr,
+        []() { return true; }, m_parent);
+}
+
 void MenuFactory::append_menu_item_invalidate_cut_info(wxMenu *menu)
 {
     const wxString menu_name = _L("Invalidate cut info");
@@ -1869,6 +1889,7 @@ wxMenu* MenuFactory::part_menu()
 {
     append_menu_items_convert_unit(&m_part_menu);
     append_menu_item_change_filament(&m_part_menu);
+    append_menu_item_modifier_gcode(&m_part_menu);
     append_menu_item_per_object_settings(&m_part_menu);
     return &m_part_menu;
 }

--- a/src/slic3r/GUI/GUI_Factories.hpp
+++ b/src/slic3r/GUI/GUI_Factories.hpp
@@ -159,6 +159,7 @@ private:
     void        append_menu_item_invalidate_cut_info(wxMenu *menu);
     void        append_menu_item_edit_text(wxMenu *menu);
     void        append_menu_item_edit_svg(wxMenu *menu);
+    void        append_menu_item_modifier_gcode(wxMenu *menu);
 
     void        append_menu_items_instance_manipulation(wxMenu *menu);
     //void        update_menu_items_instance_manipulation(MenuType type);

--- a/src/slic3r/GUI/GUI_ObjectList.cpp
+++ b/src/slic3r/GUI/GUI_ObjectList.cpp
@@ -23,6 +23,7 @@
 #include "Widgets/ProgressDialog.hpp"
 #include "SingleChoiceDialog.hpp"
 #include "StepMeshDialog.hpp"
+#include "ModifierGCodeDialog.hpp"
 
 
 #include <vector>
@@ -6666,6 +6667,65 @@ void ObjectList::set_extruder_for_selected_items(const int extruder)
 
     // BBS: update extruder/filament column
     Refresh();
+}
+
+void ObjectList::edit_selected_modifier_gcode()
+{
+    wxDataViewItem item = GetSelection();
+    if (!item)
+        return;
+
+    ModelVolume *volume = get_selected_model_volume();
+    if (volume == nullptr || !volume->is_modifier())
+        return;
+
+    ModelConfig &config = get_item_config(item);
+    const std::string enter_gcode = config.has("modifier_enter_gcode") ? config.get().opt_string("modifier_enter_gcode") : std::string();
+    const std::string exit_gcode  = config.has("modifier_exit_gcode")  ? config.get().opt_string("modifier_exit_gcode")  : std::string();
+
+    auto get_toggle = [&config](const char *key) {
+        return !config.has(key) || config.get().opt_bool(key);
+    };
+    ModifierGCodeFeatureToggles toggles;
+    toggles.walls      = get_toggle("modifier_gcode_on_walls");
+    toggles.infill     = get_toggle("modifier_gcode_on_infill");
+    toggles.support    = get_toggle("modifier_gcode_on_support");
+    toggles.skirt_brim = get_toggle("modifier_gcode_on_skirt_brim");
+
+    ModifierGCodeDialog dlg(wxGetApp().mainframe, enter_gcode, exit_gcode, toggles);
+    if (dlg.ShowModal() != wxID_OK)
+        return;
+
+    take_snapshot(_u8L("Modifier custom G-code edited"));
+
+    const std::string new_enter_gcode = dlg.get_enter_gcode();
+    const std::string new_exit_gcode  = dlg.get_exit_gcode();
+
+    if (new_enter_gcode.empty())
+        config.erase("modifier_enter_gcode");
+    else
+        config.set_key_value("modifier_enter_gcode", new ConfigOptionString(new_enter_gcode));
+
+    if (new_exit_gcode.empty())
+        config.erase("modifier_exit_gcode");
+    else
+        config.set_key_value("modifier_exit_gcode", new ConfigOptionString(new_exit_gcode));
+
+    // Sparse config: only store a toggle when it differs from the (checked/true) default.
+    auto set_toggle = [&config](const char *key, bool value) {
+        if (value)
+            config.erase(key);
+        else
+            config.set_key_value(key, new ConfigOptionBool(false));
+    };
+    const ModifierGCodeFeatureToggles new_toggles = dlg.get_feature_toggles();
+    set_toggle("modifier_gcode_on_walls", new_toggles.walls);
+    set_toggle("modifier_gcode_on_infill", new_toggles.infill);
+    set_toggle("modifier_gcode_on_support", new_toggles.support);
+    set_toggle("modifier_gcode_on_skirt_brim", new_toggles.skirt_brim);
+
+    // update scene / trigger reslice
+    wxGetApp().plater()->update();
 }
 
 void ObjectList::on_plate_added(PartPlate* part_plate)

--- a/src/slic3r/GUI/GUI_ObjectList.cpp
+++ b/src/slic3r/GUI/GUI_ObjectList.cpp
@@ -6687,10 +6687,12 @@ void ObjectList::edit_selected_modifier_gcode()
         return !config.has(key) || config.get().opt_bool(key);
     };
     ModifierGCodeFeatureToggles toggles;
-    toggles.walls      = get_toggle("modifier_gcode_on_walls");
-    toggles.infill     = get_toggle("modifier_gcode_on_infill");
-    toggles.support    = get_toggle("modifier_gcode_on_support");
-    toggles.skirt_brim = get_toggle("modifier_gcode_on_skirt_brim");
+    toggles.walls          = get_toggle("modifier_gcode_on_walls");
+    toggles.infill         = get_toggle("modifier_gcode_on_infill");
+    toggles.support        = get_toggle("modifier_gcode_on_support");
+    toggles.skirt_brim     = get_toggle("modifier_gcode_on_skirt_brim");
+    // Orca: group_together defaults to false (opt-in), unlike the four toggles above.
+    toggles.group_together = config.has("modifier_group_together") && config.get().opt_bool("modifier_group_together");
 
     ModifierGCodeDialog dlg(wxGetApp().mainframe, enter_gcode, exit_gcode, toggles);
     if (dlg.ShowModal() != wxID_OK)
@@ -6723,6 +6725,13 @@ void ObjectList::edit_selected_modifier_gcode()
     set_toggle("modifier_gcode_on_infill", new_toggles.infill);
     set_toggle("modifier_gcode_on_support", new_toggles.support);
     set_toggle("modifier_gcode_on_skirt_brim", new_toggles.skirt_brim);
+
+    // Orca: group_together defaults to false, so the sparse-storage direction is inverted versus
+    // the four toggles above: only store the key when it's checked.
+    if (new_toggles.group_together)
+        config.set_key_value("modifier_group_together", new ConfigOptionBool(true));
+    else
+        config.erase("modifier_group_together");
 
     // update scene / trigger reslice
     wxGetApp().plater()->update();

--- a/src/slic3r/GUI/GUI_ObjectList.hpp
+++ b/src/slic3r/GUI/GUI_ObjectList.hpp
@@ -463,6 +463,8 @@ public:
 
     //BBS: remove const qualifier
     void set_extruder_for_selected_items(const int extruder);
+    // Orca: opens ModifierGCodeDialog for the currently selected modifier volume and applies the result.
+    void edit_selected_modifier_gcode();
     wxDataViewItemArray reorder_volumes_and_get_selection(int obj_idx, std::function<bool(const ModelVolume*)> add_to_selection = nullptr);
     void apply_volumes_order();
 

--- a/src/slic3r/GUI/ModifierGCodeDialog.cpp
+++ b/src/slic3r/GUI/ModifierGCodeDialog.cpp
@@ -1,0 +1,118 @@
+#include "ModifierGCodeDialog.hpp"
+
+#include <wx/sizer.h>
+#include <wx/stattext.h>
+#include <wx/textctrl.h>
+#include <wx/checkbox.h>
+
+#include "GUI.hpp"
+#include "GUI_App.hpp"
+
+#include "Widgets/DialogButtons.hpp"
+
+namespace Slic3r {
+namespace GUI {
+
+static wxTextCtrl *add_gcode_editor(wxWindow *parent, wxSizer *sizer, const wxString &label, const std::string &value, int border)
+{
+    wxStaticText *label_ctrl = new wxStaticText(parent, wxID_ANY, label);
+    sizer->Add(label_ctrl, 0, wxLEFT | wxTOP | wxRIGHT, border);
+
+    wxTextCtrl *editor = new wxTextCtrl(parent, wxID_ANY, wxString::FromUTF8(value), wxDefaultPosition, wxDefaultSize, wxTE_MULTILINE
+#ifdef _WIN32
+        | wxBORDER_SIMPLE
+#endif
+    );
+    editor->SetFont(wxGetApp().code_font());
+    editor->SetInsertionPointEnd();
+    wxGetApp().UpdateDarkUI(editor);
+    sizer->Add(editor, 1, wxEXPAND | wxLEFT | wxTOP | wxRIGHT, border);
+
+    return editor;
+}
+
+ModifierGCodeDialog::ModifierGCodeDialog(wxWindow *parent, const std::string &enter_gcode, const std::string &exit_gcode,
+                                          const ModifierGCodeFeatureToggles &feature_toggles) :
+    DPIDialog(parent, wxID_ANY, _L("Modifier Custom G-code"), wxDefaultPosition, wxDefaultSize, wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER)
+{
+    SetFont(wxGetApp().normal_font());
+    SetBackgroundColour(*wxWHITE);
+    wxGetApp().UpdateDarkUI(this);
+    wxGetApp().UpdateDlgDarkUI(this);
+
+    int border = 10;
+    int em = em_unit();
+
+    wxBoxSizer *topSizer = new wxBoxSizer(wxVERTICAL);
+
+    wxStaticText *hint = new wxStaticText(this, wxID_ANY,
+        _L("These G-code snippets are inserted whenever the toolpath starts or stops printing "
+           "extrusions that belong to this modifier's region. Placeholders such as "
+           "{layer_num} and {layer_z} are supported."));
+    hint->Wrap(60 * em);
+    topSizer->Add(hint, 0, wxEXPAND | wxALL, border);
+
+    m_enter_gcode_editor = add_gcode_editor(this, topSizer, _L("Enter G-code") + ":", enter_gcode, border);
+    m_exit_gcode_editor  = add_gcode_editor(this, topSizer, _L("Exit G-code") + " (" + _L("optional") + "):", exit_gcode, border);
+
+    wxStaticText *feature_label = new wxStaticText(this, wxID_ANY, _L("Apply to:"));
+    topSizer->Add(feature_label, 0, wxEXPAND | wxLEFT | wxTOP | wxRIGHT, border);
+
+    wxBoxSizer *feature_sizer = new wxBoxSizer(wxHORIZONTAL);
+    auto add_feature_checkbox = [this, feature_sizer](const wxString &label, bool checked) {
+        wxCheckBox *checkbox = new wxCheckBox(this, wxID_ANY, label);
+        checkbox->SetValue(checked);
+        wxGetApp().UpdateDarkUI(checkbox);
+        feature_sizer->Add(checkbox, 0, wxRIGHT, FromDIP(15));
+        return checkbox;
+    };
+    m_walls_checkbox      = add_feature_checkbox(_L("Walls"), feature_toggles.walls);
+    m_infill_checkbox     = add_feature_checkbox(_L("Infill"), feature_toggles.infill);
+    m_support_checkbox    = add_feature_checkbox(_L("Support"), feature_toggles.support);
+    m_skirt_brim_checkbox = add_feature_checkbox(_L("Skirt/Brim"), feature_toggles.skirt_brim);
+    topSizer->Add(feature_sizer, 0, wxEXPAND | wxLEFT | wxTOP | wxRIGHT, border);
+
+    topSizer->AddSpacer(border);
+
+    auto dlg_btns = new DialogButtons(this, {"OK", "Cancel"});
+    topSizer->Add(dlg_btns, 0, wxEXPAND);
+
+    SetSizer(topSizer);
+    topSizer->SetSizeHints(this);
+
+    this->Fit();
+    fit_in_display(*this, {70 * em, 55 * em});
+    this->Layout();
+    this->CenterOnScreen();
+}
+
+std::string ModifierGCodeDialog::get_enter_gcode() const
+{
+    return std::string(m_enter_gcode_editor->GetValue().ToUTF8());
+}
+
+std::string ModifierGCodeDialog::get_exit_gcode() const
+{
+    return std::string(m_exit_gcode_editor->GetValue().ToUTF8());
+}
+
+ModifierGCodeFeatureToggles ModifierGCodeDialog::get_feature_toggles() const
+{
+    ModifierGCodeFeatureToggles toggles;
+    toggles.walls      = m_walls_checkbox->GetValue();
+    toggles.infill     = m_infill_checkbox->GetValue();
+    toggles.support    = m_support_checkbox->GetValue();
+    toggles.skirt_brim = m_skirt_brim_checkbox->GetValue();
+    return toggles;
+}
+
+void ModifierGCodeDialog::on_dpi_changed(const wxRect &suggested_rect)
+{
+    const int &em = em_unit();
+    SetMinSize(wxSize(50 * em, 35 * em));
+    Fit();
+    Refresh();
+}
+
+} // namespace GUI
+} // namespace Slic3r

--- a/src/slic3r/GUI/ModifierGCodeDialog.cpp
+++ b/src/slic3r/GUI/ModifierGCodeDialog.cpp
@@ -72,6 +72,17 @@ ModifierGCodeDialog::ModifierGCodeDialog(wxWindow *parent, const std::string &en
     m_skirt_brim_checkbox = add_feature_checkbox(_L("Skirt/Brim"), feature_toggles.skirt_brim);
     topSizer->Add(feature_sizer, 0, wxEXPAND | wxLEFT | wxTOP | wxRIGHT, border);
 
+    m_group_together_checkbox = new wxCheckBox(this, wxID_ANY, _L("Group modifier infill together"));
+    m_group_together_checkbox->SetValue(feature_toggles.group_together);
+    m_group_together_checkbox->SetToolTip(_L("Print all of this modifier's infill as one contiguous "
+        "block at the end of each layer's other printing, instead of interleaved wherever infill lines "
+        "happen to cross its boundary. Useful when the G-code above changes something slow to react "
+        "(e.g. nozzle temperature) that shouldn't be toggled many times per layer. Walls are unaffected: "
+        "they stay merged with the surrounding perimeter (no extra seam) and continue firing G-code "
+        "wherever they cross the modifier's boundary."));
+    wxGetApp().UpdateDarkUI(m_group_together_checkbox);
+    topSizer->Add(m_group_together_checkbox, 0, wxEXPAND | wxLEFT | wxTOP | wxRIGHT, border);
+
     topSizer->AddSpacer(border);
 
     auto dlg_btns = new DialogButtons(this, {"OK", "Cancel"});
@@ -99,10 +110,11 @@ std::string ModifierGCodeDialog::get_exit_gcode() const
 ModifierGCodeFeatureToggles ModifierGCodeDialog::get_feature_toggles() const
 {
     ModifierGCodeFeatureToggles toggles;
-    toggles.walls      = m_walls_checkbox->GetValue();
-    toggles.infill     = m_infill_checkbox->GetValue();
-    toggles.support    = m_support_checkbox->GetValue();
-    toggles.skirt_brim = m_skirt_brim_checkbox->GetValue();
+    toggles.walls          = m_walls_checkbox->GetValue();
+    toggles.infill         = m_infill_checkbox->GetValue();
+    toggles.support        = m_support_checkbox->GetValue();
+    toggles.skirt_brim     = m_skirt_brim_checkbox->GetValue();
+    toggles.group_together = m_group_together_checkbox->GetValue();
     return toggles;
 }
 

--- a/src/slic3r/GUI/ModifierGCodeDialog.hpp
+++ b/src/slic3r/GUI/ModifierGCodeDialog.hpp
@@ -15,10 +15,14 @@ namespace GUI {
 // modifier_gcode_on_walls/infill/support/skirt_brim PrintRegionConfig options.
 struct ModifierGCodeFeatureToggles
 {
-    bool walls      = true;
-    bool infill     = true;
-    bool support    = true;
-    bool skirt_brim = true;
+    bool walls          = true;
+    bool infill         = true;
+    bool support        = true;
+    bool skirt_brim     = true;
+    // Orca: mirrors modifier_group_together. Unlike the four toggles above, this defaults to
+    // false — it changes infill print order (all of it deferred to one block per layer) and
+    // should be an explicit opt-in; walls are unaffected.
+    bool group_together = false;
 };
 
 // Dialog for editing a modifier volume's "enter"/"exit" custom G-code, fired whenever
@@ -31,6 +35,7 @@ class ModifierGCodeDialog : public DPIDialog
     wxCheckBox *m_infill_checkbox{ nullptr };
     wxCheckBox *m_support_checkbox{ nullptr };
     wxCheckBox *m_skirt_brim_checkbox{ nullptr };
+    wxCheckBox *m_group_together_checkbox{ nullptr };
 
 public:
     ModifierGCodeDialog(wxWindow *parent, const std::string &enter_gcode, const std::string &exit_gcode,

--- a/src/slic3r/GUI/ModifierGCodeDialog.hpp
+++ b/src/slic3r/GUI/ModifierGCodeDialog.hpp
@@ -1,0 +1,50 @@
+#ifndef slic3r_ModifierGCodeDialog_hpp_
+#define slic3r_ModifierGCodeDialog_hpp_
+
+#include <string>
+
+#include "GUI_Utils.hpp"
+
+class wxTextCtrl;
+class wxCheckBox;
+
+namespace Slic3r {
+namespace GUI {
+
+// Which feature types a modifier's enter/exit G-code applies to. Mirrors the
+// modifier_gcode_on_walls/infill/support/skirt_brim PrintRegionConfig options.
+struct ModifierGCodeFeatureToggles
+{
+    bool walls      = true;
+    bool infill     = true;
+    bool support    = true;
+    bool skirt_brim = true;
+};
+
+// Dialog for editing a modifier volume's "enter"/"exit" custom G-code, fired whenever
+// G-code emission starts/stops printing extrusions that belong to that modifier's region.
+class ModifierGCodeDialog : public DPIDialog
+{
+    wxTextCtrl *m_enter_gcode_editor{ nullptr };
+    wxTextCtrl *m_exit_gcode_editor{ nullptr };
+    wxCheckBox *m_walls_checkbox{ nullptr };
+    wxCheckBox *m_infill_checkbox{ nullptr };
+    wxCheckBox *m_support_checkbox{ nullptr };
+    wxCheckBox *m_skirt_brim_checkbox{ nullptr };
+
+public:
+    ModifierGCodeDialog(wxWindow *parent, const std::string &enter_gcode, const std::string &exit_gcode,
+                         const ModifierGCodeFeatureToggles &feature_toggles);
+
+    std::string get_enter_gcode() const;
+    std::string get_exit_gcode() const;
+    ModifierGCodeFeatureToggles get_feature_toggles() const;
+
+protected:
+    void on_dpi_changed(const wxRect &suggested_rect) override;
+};
+
+} // namespace GUI
+} // namespace Slic3r
+
+#endif

--- a/tests/fff_print/CMakeLists.txt
+++ b/tests/fff_print/CMakeLists.txt
@@ -10,6 +10,7 @@ add_executable(${_TEST_NAME}_tests
 	test_gcode_timing.cpp
 	test_gcodewriter.cpp
 	test_model.cpp
+	test_modifier_gcode.cpp
 	test_multifilament.cpp
 	test_print.cpp
 	test_printobject.cpp

--- a/tests/fff_print/test_modifier_gcode.cpp
+++ b/tests/fff_print/test_modifier_gcode.cpp
@@ -1,5 +1,7 @@
 #include <catch2/catch_all.hpp>
 
+#include <algorithm>
+
 #include "libslic3r/libslic3r.h"
 #include "libslic3r/Print.hpp"
 #include "libslic3r/Model.hpp"
@@ -25,7 +27,7 @@ int count_occurrences(const std::string &haystack, const std::string &needle)
 // per make_cube()'s (0,0,0)-(x,y,z) convention) carrying the given enter/exit G-code.
 void slice_cube_with_modifier(Vec3d modifier_dims, Vec3d modifier_offset,
                                const std::string &enter_gcode, const std::string &exit_gcode,
-                               std::string &out_gcode)
+                               std::string &out_gcode, bool group_together = false)
 {
     DynamicPrintConfig config = DynamicPrintConfig::full_print_config();
     config.set_deserialize_strict({
@@ -42,6 +44,8 @@ void slice_cube_with_modifier(Vec3d modifier_dims, Vec3d modifier_offset,
     modifier->set_offset(modifier_offset);
     modifier->config.set_key_value("modifier_enter_gcode", new ConfigOptionString(enter_gcode));
     modifier->config.set_key_value("modifier_exit_gcode", new ConfigOptionString(exit_gcode));
+    if (group_together)
+        modifier->config.set_key_value("modifier_group_together", new ConfigOptionBool(true));
 
     object->add_instance();
     object->ensure_on_bed();
@@ -73,6 +77,47 @@ TEST_CASE("Modifier region emits balanced enter/exit G-code on every layer it sp
     CHECK(enter_count == exit_count); // every enter is matched by an exit
 }
 
+TEST_CASE("Grouped modifier's infill prints as one contiguous block per layer, walls unaffected", "[ModifierGCode]") {
+    // 5x5x10 modifier centered in X/Y (7.5mm inset from every face) and spanning the object's
+    // bottom 10mm: far enough from the outer surface that the merged, continuous wall loop never
+    // comes near its boundary, so crossing detection contributes zero wall-based firings here —
+    // isolating the property under test. With modifier_group_together set, every marker should
+    // come from the single deferred infill block per layer (5 layers spanned, at print_z
+    // 2,4,6,8,10), not from repeated infill-line crossings the way ungrouped infill would fire.
+    std::string gcode;
+    slice_cube_with_modifier(Vec3d(5, 5, 10), Vec3d(7.5, 7.5, 0), "; ENTER_MOD\n", "; EXIT_MOD\n", gcode, /*group_together=*/true);
+
+    const int enter_count = count_occurrences(gcode, "; ENTER_MOD");
+    const int exit_count  = count_occurrences(gcode, "; EXIT_MOD");
+
+    CHECK(enter_count == 5);
+    CHECK(exit_count == 5);
+
+    // No layer outside the modifier's Z range gets a (spurious, empty) bracket.
+    const int last_enter_pos = static_cast<int>(gcode.rfind("; ENTER_MOD"));
+    const int last_exit_pos  = static_cast<int>(gcode.rfind("; EXIT_MOD"));
+    CHECK(last_enter_pos >= 0);
+    CHECK(last_exit_pos > last_enter_pos);
+}
+
+TEST_CASE("Grouping a modifier's infill does not add wall geometry at its boundary", "[ModifierGCode]") {
+    // Same corner modifier used in the ungrouped test above (touching two of the base cube's own
+    // edges, so its boundary does intersect the continuous outer wall loop) — this time with
+    // modifier_group_together set. Walls must still be governed purely by crossing detection
+    // (unaffected by grouping): the same ">1 fire, balanced" shape as the ungrouped case, since
+    // is_perimeter_compatible() no longer differentiates on modifier_group_together at all.
+    std::string gcode;
+    slice_cube_with_modifier(Vec3d(10, 10, 10), Vec3d(0, 0, 0), "; ENTER_MOD\n", "; EXIT_MOD\n", gcode, /*group_together=*/true);
+
+    const int enter_count = count_occurrences(gcode, "; ENTER_MOD");
+    const int exit_count  = count_occurrences(gcode, "; EXIT_MOD");
+
+    // Wall crossings (still per-crossing) plus one deferred infill block per layer.
+    CHECK(enter_count > 5);
+    CHECK(exit_count > 5);
+    CHECK(enter_count == exit_count);
+}
+
 TEST_CASE("Modifier still active at the end of the print still emits its exit G-code", "[ModifierGCode]") {
     // Modifier is a thin slab covering the object's full footprint for its top 5mm (15mm-20mm):
     // the wall loop is "inside" it for the entirety of every layer it spans, so no crossing
@@ -97,4 +142,117 @@ TEST_CASE("Modifier exit G-code is optional", "[ModifierGCode]") {
 
     CHECK(count_occurrences(gcode, "; ENTER_MOD") > 0);
     CHECK(count_occurrences(gcode, "; EXIT_MOD") == 0);
+}
+
+TEST_CASE("Modifier enter/exit G-code never leaks across a layer change", "[ModifierGCode]") {
+    // If a wall loop's last segment ends a layer while still geometrically inside the modifier's
+    // boundary (no further crossing before the Z move to the next layer), that "inside" state must
+    // be flushed for THIS layer rather than silently carried into the next one's resync check —
+    // otherwise the dangling exit is dropped, and worse, a stale "inside" flag can desync whatever
+    // a later, unrelated resync decides for a different modifier. layer_change_gcode marks every
+    // layer boundary, so the enter/exit count can be checked for balance within each layer segment
+    // independently, not just across the whole G-code (where a later self-correction could hide
+    // a same-layer leak).
+    DynamicPrintConfig config = DynamicPrintConfig::full_print_config();
+    config.set_deserialize_strict({
+        { "layer_height",               2 },
+        { "initial_layer_print_height", 2 },
+        { "layer_change_gcode",         "; LAYER_CHANGE\n" },
+    });
+
+    Model model;
+    ModelObject *object = model.add_object();
+    object->add_volume(cube(20), ModelVolumeType::MODEL_PART, false);
+
+    ModelVolume *modifier = object->add_volume(make_cube(10, 10, 10), ModelVolumeType::PARAMETER_MODIFIER, false);
+    modifier->set_offset(Vec3d(0, 0, 0));
+    modifier->config.set_key_value("modifier_enter_gcode", new ConfigOptionString("; ENTER_MOD\n"));
+    modifier->config.set_key_value("modifier_exit_gcode", new ConfigOptionString("; EXIT_MOD\n"));
+
+    object->add_instance();
+    object->ensure_on_bed();
+
+    Print print;
+    print.auto_assign_extruders(object);
+    print.apply(model, config);
+
+    std::string gcode = Slic3r::Test::gcode(print);
+    REQUIRE(count_occurrences(gcode, "; ENTER_MOD") > 0); // sanity: the modifier is actually exercised
+
+    size_t pos = 0;
+    int checked_segments = 0;
+    for (;;) {
+        size_t next = gcode.find("; LAYER_CHANGE", pos);
+        std::string segment = gcode.substr(pos, next == std::string::npos ? std::string::npos : next - pos);
+        CHECK(count_occurrences(segment, "; ENTER_MOD") == count_occurrences(segment, "; EXIT_MOD"));
+        ++checked_segments;
+        if (next == std::string::npos)
+            break;
+        pos = next + std::string("; LAYER_CHANGE").size();
+    }
+    CHECK(checked_segments > 1); // sanity: the print actually spans multiple layers
+}
+
+TEST_CASE("Touching modifiers close the first region before opening the second", "[ModifierGCode]") {
+    // Two 5x10x10 modifiers side by side (touching along their shared X=5 plane, not
+    // overlapping), together forming the same 10x10x10 corner used in the tests above. As the
+    // continuous wall loop passes through this corner, it crosses the shared A/B boundary: the
+    // exit from whichever region it's leaving must be emitted before the enter into the other,
+    // even though the two crossings are computed independently (against two different polygons)
+    // at the same physical point, where floating-point noise could otherwise flip their order.
+    DynamicPrintConfig config = DynamicPrintConfig::full_print_config();
+    config.set_deserialize_strict({
+        { "layer_height",               2 },
+        { "initial_layer_print_height", 2 },
+    });
+
+    Model model;
+    ModelObject *object = model.add_object();
+    object->add_volume(cube(20), ModelVolumeType::MODEL_PART, false);
+
+    ModelVolume *a = object->add_volume(make_cube(5, 10, 10), ModelVolumeType::PARAMETER_MODIFIER, false);
+    a->set_offset(Vec3d(0, 0, 0));
+    a->config.set_key_value("modifier_enter_gcode", new ConfigOptionString("; ENTER_A\n"));
+    a->config.set_key_value("modifier_exit_gcode", new ConfigOptionString("; EXIT_A\n"));
+
+    ModelVolume *b = object->add_volume(make_cube(5, 10, 10), ModelVolumeType::PARAMETER_MODIFIER, false);
+    b->set_offset(Vec3d(5, 0, 0));
+    b->config.set_key_value("modifier_enter_gcode", new ConfigOptionString("; ENTER_B\n"));
+    b->config.set_key_value("modifier_exit_gcode", new ConfigOptionString("; EXIT_B\n"));
+
+    object->add_instance();
+    object->ensure_on_bed();
+
+    Print print;
+    print.auto_assign_extruders(object);
+    print.apply(model, config);
+
+    std::string gcode = Slic3r::Test::gcode(print);
+
+    // Collect every marker occurrence, in the order it appears in the G-code.
+    struct Event { size_t pos; bool is_a; bool entering; };
+    std::vector<Event> events;
+    auto collect = [&](const std::string &needle, bool is_a, bool entering) {
+        for (auto pos = gcode.find(needle); pos != std::string::npos; pos = gcode.find(needle, pos + needle.size()))
+            events.push_back({pos, is_a, entering});
+    };
+    collect("; ENTER_A", true, true);
+    collect("; EXIT_A", true, false);
+    collect("; ENTER_B", false, true);
+    collect("; EXIT_B", false, false);
+    std::sort(events.begin(), events.end(), [](const Event &l, const Event &r) { return l.pos < r.pos; });
+
+    REQUIRE(!events.empty());
+
+    // A and B are non-overlapping: replaying the events in G-code order must never show the
+    // toolpath as simultaneously "inside" both — that's exactly the bug shape (enterA, enterB,
+    // exitA, exitB) reported when the shared-boundary crossings sorted the wrong way round.
+    bool inside_a = false, inside_b = false;
+    for (const Event &e : events) {
+        if (e.is_a)
+            inside_a = e.entering;
+        else
+            inside_b = e.entering;
+        CHECK_FALSE(inside_a && inside_b);
+    }
 }

--- a/tests/fff_print/test_modifier_gcode.cpp
+++ b/tests/fff_print/test_modifier_gcode.cpp
@@ -1,0 +1,100 @@
+#include <catch2/catch_all.hpp>
+
+#include "libslic3r/libslic3r.h"
+#include "libslic3r/Print.hpp"
+#include "libslic3r/Model.hpp"
+
+#include "test_helpers.hpp"
+
+using namespace Slic3r;
+using namespace Slic3r::Test;
+
+namespace {
+
+// Count of (non-overlapping) occurrences of `needle` in `haystack`.
+int count_occurrences(const std::string &haystack, const std::string &needle)
+{
+    int count = 0;
+    for (auto pos = haystack.find(needle); pos != std::string::npos; pos = haystack.find(needle, pos + needle.size()))
+        ++count;
+    return count;
+}
+
+// Builds a 20mm base cube plus an overlapping modifier volume (also cuboid, placed at the
+// origin so its raw mesh coordinates directly define its footprint/extents within the object,
+// per make_cube()'s (0,0,0)-(x,y,z) convention) carrying the given enter/exit G-code.
+void slice_cube_with_modifier(Vec3d modifier_dims, Vec3d modifier_offset,
+                               const std::string &enter_gcode, const std::string &exit_gcode,
+                               std::string &out_gcode)
+{
+    DynamicPrintConfig config = DynamicPrintConfig::full_print_config();
+    config.set_deserialize_strict({
+        { "layer_height",               2 },
+        { "initial_layer_print_height", 2 },
+    });
+
+    Model model;
+    ModelObject *object = model.add_object();
+    object->add_volume(cube(20), ModelVolumeType::MODEL_PART, false);
+
+    ModelVolume *modifier = object->add_volume(make_cube(modifier_dims.x(), modifier_dims.y(), modifier_dims.z()),
+                                                ModelVolumeType::PARAMETER_MODIFIER, false);
+    modifier->set_offset(modifier_offset);
+    modifier->config.set_key_value("modifier_enter_gcode", new ConfigOptionString(enter_gcode));
+    modifier->config.set_key_value("modifier_exit_gcode", new ConfigOptionString(exit_gcode));
+
+    object->add_instance();
+    object->ensure_on_bed();
+
+    Print print;
+    print.auto_assign_extruders(object);
+    print.apply(model, config);
+
+    out_gcode = Slic3r::Test::gcode(print);
+}
+
+} // namespace
+
+TEST_CASE("Modifier region emits balanced enter/exit G-code on every layer it spans", "[ModifierGCode]") {
+    // 10mm modifier cube at the object's bottom corner, coincident with two of the base cube's
+    // own edges: the (merged, continuous) outer wall loop dips into and out of the modifier's
+    // footprint as it wraps the corner, crossing its boundary twice per layer, on each of the
+    // layers 1..5 (print_z 2,4,6,8,10) the modifier spans. No other setting differs from the
+    // base object, so this also regression-tests that a G-code-only modifier still gets its
+    // G-code bracketed even though its perimeter generation is merged with its parent's.
+    std::string gcode;
+    slice_cube_with_modifier(Vec3d(10, 10, 10), Vec3d(0, 0, 0), "; ENTER_MOD\n", "; EXIT_MOD\n", gcode);
+
+    const int enter_count = count_occurrences(gcode, "; ENTER_MOD");
+    const int exit_count  = count_occurrences(gcode, "; EXIT_MOD");
+
+    CHECK(enter_count > 1); // fires again each time the toolpath re-enters the region, not once for the whole volume
+    CHECK(exit_count > 1);
+    CHECK(enter_count == exit_count); // every enter is matched by an exit
+}
+
+TEST_CASE("Modifier still active at the end of the print still emits its exit G-code", "[ModifierGCode]") {
+    // Modifier is a thin slab covering the object's full footprint for its top 5mm (15mm-20mm):
+    // the wall loop is "inside" it for the entirety of every layer it spans, so no crossing
+    // occurs within those layers (enter fires once, via the resync at the first wall path whose
+    // start point is newly inside the boundary). Without a trailing flush at export end, that
+    // single "enter" would have no matching "exit" appended after it.
+    std::string gcode;
+    slice_cube_with_modifier(Vec3d(20, 20, 5), Vec3d(0, 0, 15), "; ENTER_MOD\n", "; EXIT_MOD\n", gcode);
+
+    const int enter_count = count_occurrences(gcode, "; ENTER_MOD");
+    const int exit_count  = count_occurrences(gcode, "; EXIT_MOD");
+
+    CHECK(enter_count > 0);
+    CHECK(enter_count == exit_count);
+}
+
+TEST_CASE("Modifier exit G-code is optional", "[ModifierGCode]") {
+    // Only enter G-code configured: exit should simply be skipped (empty template -> no emission),
+    // not crash or emit a stray marker.
+    std::string gcode;
+    slice_cube_with_modifier(Vec3d(10, 10, 10), Vec3d(0, 0, 0), "; ENTER_MOD\n", "", gcode);
+
+    CHECK(count_occurrences(gcode, "; ENTER_MOD") > 0);
+    CHECK(count_occurrences(gcode, "; EXIT_MOD") == 0);
+}


### PR DESCRIPTION
# Description

Adds the ability to specify custom gcode on a modifier body. Custom gcode can selectively be applied to a subset of features (just infill, perimeters, ect..).

When using the custom gcode feature, the user specified gcode is added to the output file when the extruder crosses into or out of the boundary specified by the modifier.

The custom gcode block has custom logic that works differently from other modifiers, and avoids marking the modified section as a separate region to avoid generating new perimeters or boundaries in the infill. this behavior does not trigger if other modifier settings are applied on the modifier body. The custom gcode logic will also cut perimeter moves and insert the custom gcode at the correct location for gcode that is very location specific.

finally, there is an option to set the custom gcode region to generate its infill separately (basically re-enabling the infill section to be its own region). This adds the infill artifact you normally get with modifiers, but allows the modified region to be printed contiguously, which is helpful when running custom gcode that has a time component to it (such as temperature changes)

# Screenshots/Recordings/Graphs
new menu item on modifier right click:
<img width="1217" height="1046" alt="menu" src="https://github.com/user-attachments/assets/e557b090-1e45-4e00-a4f5-61afa6efc1d4" />

popup for specifying custom gcode:
<img width="1552" height="1105" alt="popup" src="https://github.com/user-attachments/assets/3a605b9c-a94f-48aa-b2e3-f3d4655eaa9e" />

custom gcode showing in gcode preview window:
<img width="728" height="530" alt="gcode added" src="https://github.com/user-attachments/assets/729cee83-f572-408a-9f93-a05fa92f90f6" />

showing change in behavior when enabling "group modifier infill together" setting. Infill now prints in its own region to avoid multiple crossings of the modifier volume:
<img width="537" height="466" alt="custom gcode infill combining" src="https://github.com/user-attachments/assets/b28ff0da-8d16-4ef7-be0a-cb5a47996edc" />


## Tests

A lot of manual testing was done to verify that the output gcode was correct. After functional testing was done, I added a few tests (in tests/fff_print) that adds a custom gcode modifier volume, and validates that the custom gcode is in the output file. tests check for a few edge cases, such as making sure the exit gcode fires at the end of a layer, even if the extruder exits the layer inside of the modifier region, as well as making sure the enter and exit gcode commands added are equal in count.


