### PR TITLE
Fix cloud features staying off after login when the setup wizard was closed

### DIFF
--- a/src/libslic3r/AppConfig.cpp
+++ b/src/libslic3r/AppConfig.cpp
@@ -86,8 +86,17 @@ std::string AppConfig::get_hms_host()
 
 bool AppConfig::get_stealth_mode()
 {
-    // always return true when user did not finish setup wizard yet
-    if (!get_bool("firstguide","finish")) {
+    // Before the setup wizard has been completed the user has not been asked whether the app may
+    // use the network, so default to no. Signing in to a cloud account IS that answer, though, and
+    // the latch must not survive it: a user who closes the wizard and logs in from the account menu
+    // — the workaround people share for the wizard never offering login — otherwise gets every
+    // cloud feature silently switched off. No post-login sync prompt, no user presets fetched, and
+    // "Sync Presets" greyed out with nothing to say why, because on_user_login_handle() returns
+    // early on stealth. Upstream #15239.
+    //
+    // This releases the pre-wizard DEFAULT only. An explicit Stealth mode setting still wins, so a
+    // user who deliberately turned it on stays offline whether or not they are signed in.
+    if (!m_cloud_logged_in && !get_bool("firstguide","finish")) {
         return true;
     }
     return get_bool("stealth_mode");

--- a/src/libslic3r/AppConfig.hpp
+++ b/src/libslic3r/AppConfig.hpp
@@ -91,6 +91,10 @@ public:
 	std::string get_language_code();
 	std::string get_hms_host();
 	bool get_stealth_mode();
+	// The user's OWN Stealth mode setting, without the pre-wizard default that get_stealth_mode()
+	// applies. Use this wherever "the wizard is unfinished" must not count as stealth — blocking
+	// sign-in above all, since signing in is how a user leaves that state in the first place.
+	bool get_stealth_mode_setting() { return get_bool("stealth_mode"); }
 	// Session state, not a setting: mirrors whether a cloud account is currently signed in, so
 	// get_stealth_mode() can tell "the user has not been asked yet" from "the user said no".
 	void set_cloud_logged_in(bool logged_in) { m_cloud_logged_in = logged_in; }

--- a/src/libslic3r/AppConfig.hpp
+++ b/src/libslic3r/AppConfig.hpp
@@ -91,6 +91,9 @@ public:
 	std::string get_language_code();
 	std::string get_hms_host();
 	bool get_stealth_mode();
+	// Session state, not a setting: mirrors whether a cloud account is currently signed in, so
+	// get_stealth_mode() can tell "the user has not been asked yet" from "the user said no".
+	void set_cloud_logged_in(bool logged_in) { m_cloud_logged_in = logged_in; }
 	bool get_hide_login_side_panel();
 
 	// Clear and reset to defaults.
@@ -424,6 +427,9 @@ private:
 	Semver                                                      m_orig_version;
 	// Whether the existing version is before system profiles & configuration updating
 	bool                                                        m_legacy_datadir;
+	// A cloud account is signed in right now. Deliberately NOT persisted: it is mirrored from the
+	// network agent on login/logout, so a stale value cannot outlive the session that set it.
+	bool                                                        m_cloud_logged_in{false};
 
 	std::string                                                 m_loading_path;
 

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -3834,6 +3834,10 @@ bool GUI_App::on_init_network(bool try_backup)
         std::string country_code = app_config->get_country_code();
         m_agent->set_country_code(country_code);
         m_agent->start();
+        // A session restored from a saved token fires no login event, so seed the flag here too —
+        // otherwise the pre-wizard stealth default would come back on the next launch for a user
+        // who is already signed in.
+        app_config->set_cloud_logged_in(m_agent->is_user_login(ORCA_CLOUD_PROVIDER));
         // Orca: disable Bambu telemetry up-front (before any login) so it never starts.
         check_track_enable();
     }
@@ -5003,6 +5007,7 @@ void GUI_App::request_user_logout(const std::string& provider/* = ORCA_CLOUD_PRO
 {
     if (m_agent && m_agent->is_user_login(provider)) {
         m_agent->user_logout(true, provider);
+        app_config->set_cloud_logged_in(m_agent->is_user_login(ORCA_CLOUD_PROVIDER));
 
         if (provider == get_printer_cloud_provider()) {
             m_agent->set_user_selected_machine("");
@@ -5588,6 +5593,12 @@ void GUI_App::on_update_machine_list(wxCommandEvent &evt)
 void GUI_App::on_user_login_handle(wxCommandEvent &evt)
 {
     if (!m_agent) { return; }
+    // Tell AppConfig a cloud account is signed in BEFORE asking about stealth: an unfinished setup
+    // wizard makes get_stealth_mode() report stealth by default, and without this the early return
+    // below would swallow the whole post-login flow — presets, plugins and the sync prompt — for
+    // anyone who closed the wizard and signed in afterwards. An explicit Stealth mode setting is
+    // unaffected and still returns here.
+    app_config->set_cloud_logged_in(m_agent->is_user_login(ORCA_CLOUD_PROVIDER));
     if (app_config->get_stealth_mode()) {
         BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << ": stealth mode enabled, skipping cloud connection";
         return;

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -5084,7 +5084,12 @@ std::string GUI_App::handle_web_request(std::string cmd)
                 });
                 return "";
             }
-            if (app_config->get_stealth_mode() && stealth_blocked_login_commands.count(command_str)) {
+            // The user's own setting only. Blocking sign-in because the setup wizard is unfinished
+            // is backwards — signing in is how you leave that state — and it told a user who had
+            // never touched the toggle "You are currently in Stealth Mode", then offered a Quit
+            // button that writes stealth_mode=false when it was already false and leaves the
+            // pre-wizard default exactly where it was.
+            if (app_config->get_stealth_mode_setting() && stealth_blocked_login_commands.count(command_str)) {
                 CallAfter([this, command_str] {
                     MessageDialog dlg(mainframe,
                         _L("You are currently in Stealth Mode. To log into the Cloud, you need to disable Stealth Mode first."),

--- a/src/slic3r/GUI/MainFrame.cpp
+++ b/src/slic3r/GUI/MainFrame.cpp
@@ -3376,14 +3376,22 @@ void MainFrame::init_menubar_as_editor()
                 info_dlg.ShowModal();
                 return;
             }
+            if (wxGetApp().app_config->get_stealth_mode()) {
+                MessageDialog info_dlg(this,
+                    _L("Stealth mode is on, so Orca Cloud syncing is switched off. "
+                       "Turn Stealth mode off in Preferences to sync your presets."),
+                    _L("Sync Presets"), wxOK | wxICON_INFORMATION);
+                info_dlg.ShowModal();
+                return;
+            }
             if (m_plater)
                 m_plater->get_notification_manager()->push_notification(
                     into_u8(_L("Syncing presets from cloud\u2026")));
             wxGetApp().restart_sync_user_preset();
         }, "", nullptr,
-        [this]() {
-            return wxGetApp().is_user_login() && !wxGetApp().app_config->get_stealth_mode();
-        }, this);
+        // Stays ENABLED whatever the cloud state: both refusals above name their reason, and a
+        // greyed-out item names none. A user who could not sync had no way to find out why.
+        []() { return true; }, this);
 
     top_menu->AppendSeparator();
     append_menu_item(
@@ -3513,14 +3521,22 @@ void MainFrame::init_menubar_as_editor()
                 info_dlg.ShowModal();
                 return;
             }
+            if (wxGetApp().app_config->get_stealth_mode()) {
+                MessageDialog info_dlg(this,
+                    _L("Stealth mode is on, so Orca Cloud syncing is switched off. "
+                       "Turn Stealth mode off in Preferences to sync your presets."),
+                    _L("Sync Presets"), wxOK | wxICON_INFORMATION);
+                info_dlg.ShowModal();
+                return;
+            }
             if (m_plater)
                 m_plater->get_notification_manager()->push_notification(
                     into_u8(_L("Syncing presets from cloud\u2026")));
             wxGetApp().restart_sync_user_preset();
         }, "", nullptr,
-        [this]() {
-            return wxGetApp().is_user_login() && !wxGetApp().app_config->get_stealth_mode();
-        }, this);
+        // Stays ENABLED whatever the cloud state: both refusals above name their reason, and a
+        // greyed-out item names none. A user who could not sync had no way to find out why.
+        []() { return true; }, this);
 
     fileMenu->AppendSeparator();
     append_menu_item(


### PR DESCRIPTION
Closing the setup wizard instead of completing it puts the user in a Stealth mode they never chose, and every cloud feature silently switches off — no post-login sync prompt, no user presets fetched, and **Sync Presets** greyed out with nothing to explain why.

Reported in https://github.com/OrcaSlicer/OrcaSlicer/issues/15239#issuecomment-5303431374 — *"you have to know to close the setup wizard and login that way… i get nothing and i cant even manually sync from the file menu after logging in"*. That workaround is itself the trigger.

## Cause

`AppConfig::get_stealth_mode()` returns `true` whenever `firstguide/finish` is unset:

```cpp
bool AppConfig::get_stealth_mode()
{
    // always return true when user did not finish setup wizard yet
    if (!get_bool("firstguide","finish")) {
        return true;
    }
    return get_bool("stealth_mode");
}
```

`firstguide/finish` is written in exactly one place — `GuideFrame::SaveProfile()` — i.e. only when the wizard is **completed**. Close it and the flag never appears, so the pre-wizard default latches forever, indistinguishable from the real setting. Everything gated on `get_stealth_mode()` then switches off, in particular:

* `GUI_App::on_user_login_handle()` returns **early** on stealth, skipping the entire post-login flow: preset migration, plugin fetch, `load_user_presets()` and `show_sync_dialog()`. That is the missing sync prompt.
* the `Sync Presets` items (top menu and File menu), whose enable lambda was `is_user_login() && !get_stealth_mode()`. That is the greyed item in the report.

The one place that *does* explain stealth — the "Quit Stealth Mode" dialog in `handle_web_request()` — makes it worse. It blocks sign-in with **"You are currently in Stealth Mode"** for a user who never touched the toggle, and its Quit button writes `stealth_mode = false` when it is *already* false, leaving the latch untouched. The user believes stealth is off, signs in, and still finds every cloud feature dead.

## Fix

**1. The pre-wizard value is a default for "the user has not been asked yet", not a setting, so it must not survive the user answering — and signing in to a cloud account is that answer.** `AppConfig` gains a session-only `m_cloud_logged_in`, mirrored from the network agent on login, on logout, and at agent start so a restored session counts. An explicit Stealth mode setting is untouched and still wins: a user who deliberately turned it on stays offline whether or not they sign in.

**2. Don't block sign-in because the wizard is unfinished** — that is backwards, since signing in is how a user leaves that state. The login guard now reads the user's own setting through a new `get_stealth_mode_setting()`. A genuine Stealth-mode user still gets the dialog and the working Quit button.

**3. `Sync Presets` no longer greys itself out.** Both refusal paths already had a message to show — "You must be logged in…", and now one for Stealth mode naming the Preferences toggle — and the enable lambda was making both unreachable. A disabled item that cannot say why is the reason this needed a bug report to find.

## Verification

Driven on Xvfb with a **fresh datadir and the wizard closed, not completed** (`firstguide` absent from `OrcaSlicer.conf`, `stealth_mode: false`) — the reporter's exact state:

| check | before | after |
|---|---|---|
| click **Login / Register** | "You are currently in Stealth Mode" dialog | opens the Login window directly |
| "Quit Stealth Mode" button | config byte-identical, latch untouched | not reached |
| **Sync Presets**, signed out | greyed, no explanation | enabled → *"You must be logged in to sync presets from cloud."* |

Then with a **real Orca Cloud sign-in** on that same unfinished-wizard profile, `firstguide` still absent afterwards:

* `sync_user_preset: true` appears in the config — written only by `on_select_default_preset`, so **the sync prompt fired**;
* the per-user preset folder `user/<user-id>/` is created — `enable_user_preset_folder()` + `load_user_presets()` ran;
* **Sync Presets** syncs with no refusal dialog.

All three live *after* the early return that used to swallow them.

Builds clean (`libslic3r`, `libslic3r_gui`, full `OrcaSlicer` target).

## Note on scope

This fixes the *consequence* reported in that comment. It deliberately does **not** close #15239 itself, which asks for the wizard to offer login in the first place — worth keeping open, since the whole failure mode starts with users closing the wizard to find the login.
