### PR TITLE
Prevent crash when line_width is zero

### DIFF
--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -14004,6 +14004,10 @@ void adjust_settings_for_flowrate_calib(ModelObjectPtrs& objects, bool linear, i
     double layer_height = nozzle_diameter / 2.0; // prefer 0.2 layer height for 0.4 nozzle
     first_layer_height = std::max(first_layer_height, layer_height);
 
+	// ORCA: prevent crash that happens when line_width is set to 0
+	print_config->option<ConfigOptionFloatOrPercent>("line_width")->value = 100.;
+    print_config->option<ConfigOptionFloatOrPercent>("line_width")->percent = true;
+
     const auto canvas    = wxGetApp().plater()->canvas3D();
     auto&      selection = canvas->get_selection();
     selection.setup_cache();


### PR DESCRIPTION
Added a safeguard to prevent crashes when line_width is set to 0.

# Description

Fixes #15193

Something somewhere crashes when flow ratio calibration is being tested with line_width set to 0. Unfortunately I wasn't able to hunt it down, but I was able to fix it by explicitly setting line_width.

## Tests

With Line Width > Default set to 0, go to calibration > Flow Ratio. Clicking OK would have caused application crash. With this fix it no longer crashes. Note: When there's a popup saying "Creating a new project: unsaved changes" be sure to click "Transfer".


[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
