### PR TITLE
[UI] Restrict Color Range to only visible layers

### DIFF
--- a/src/libvgcode/src/ColorRange.cpp
+++ b/src/libvgcode/src/ColorRange.cpp
@@ -58,7 +58,12 @@ Color ColorRange::get_color_at(float value) const
 {
     // Input value scaled to the colors range
     float global_t = 0.0f;
+
+    if (m_count == 0) {
+        return DEFAULT_RANGES_COLORS[0];
+    }
     value = std::clamp(value, m_range[0], m_range[1]);
+
     const float step = get_step_size(*this);
     if (step > 0.0f) {
         if (m_type == EColorRangeType::Logarithmic) {
@@ -88,7 +93,10 @@ std::vector<float> ColorRange::get_values() const
 {
     std::vector<float> ret;
 
-    if (m_count == 1) {
+    if (m_count == 0) {
+        return ret;
+    }
+    else if (m_count == 1) {
         // single item use case
         ret.emplace_back(m_range[0]);
     }

--- a/src/libvgcode/src/ViewerImpl.cpp
+++ b/src/libvgcode/src/ViewerImpl.cpp
@@ -1898,7 +1898,7 @@ void ViewerImpl::update_color_ranges()
 
     for (size_t i = 0; i < m_vertices.size(); i++) {
         const PathVertex& v = m_vertices[i];
-        if (v.is_extrusion()) {
+        if ((v.is_extrusion() && is_extrusion_role_visible(v.role))) {
             m_height_range.update(round_to_bin(v.height));
             if (!v.is_custom_gcode() || m_settings.extrusion_roles_visibility[size_t(EGCodeExtrusionRole::Custom)]) {
                 m_width_range.update(round_to_bin(v.width));
@@ -1913,7 +1913,7 @@ void ViewerImpl::update_color_ranges()
         }
         if ((v.is_travel() && m_settings.options_visibility[size_t(EOptionType::Travels)]) ||
             (v.is_wipe() && m_settings.options_visibility[size_t(EOptionType::Wipes)]) ||
-             v.is_extrusion()) {
+             (v.is_extrusion() && is_extrusion_role_visible(v.role))) {
             m_speed_range.update(v.feedrate);
             m_actual_speed_range.update(v.actual_feedrate);
             // ORCA: Add Acceleration visualization support

--- a/src/slic3r/GUI/GCodeViewer.cpp
+++ b/src/slic3r/GUI/GCodeViewer.cpp
@@ -3285,6 +3285,8 @@ void GCodeViewer::render_legend(float &legend_height, int canvas_width, int canv
         {
             if(callback && !checkbox && !visible)
                 ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(172 / 255.0f, 172 / 255.0f, 172 / 255.0f, 1.00f));
+            if (!visible)
+                ImGui::PushStyleColor(ImGuiCol_Text, ImGui::GetStyle().Colors[ImGuiCol_TextDisabled]);
             float dummy_size = type == EItemType::None ? window_padding * 3 : ImGui::GetStyle().ItemSpacing.x + icon_size;
             ImGui::SameLine(dummy_size);
             imgui.text(columns_offsets[0].first);
@@ -3293,6 +3295,8 @@ void GCodeViewer::render_legend(float &legend_height, int canvas_width, int canv
                 ImGui::SameLine(columns_offsets[i].second);
                 imgui.text(columns_offsets[i].first);
             }
+            if (!visible)
+                ImGui::PopStyleColor();
             if (callback && !checkbox && !visible)
                 ImGui::PopStyleColor(1);
         }

--- a/src/slic3r/GUI/GCodeViewer.cpp
+++ b/src/slic3r/GUI/GCodeViewer.cpp
@@ -3309,7 +3309,9 @@ void GCodeViewer::render_legend(float &legend_height, int canvas_width, int canv
         };
 
         std::vector<float> values = range.get_values();
-        if (values.size() == 1)
+        if (values.size() == 0)
+            return;
+        else if (values.size() == 1)
             // single item use case
             append_range_item(0, values.front(), decimals);
         else if (values.size() == 2) {


### PR DESCRIPTION
# Description

This allows Color Range to be dynamic, depending on which Line Type is visible, so checking color should be easier.

Fixes #5945 

# Screenshots/Recordings/Graphs

<img width="810" height="541" alt="image" src="https://github.com/user-attachments/assets/7754d014-1db9-47fb-aaf5-276e75a6e8ad" />
<img width="810" height="541" alt="image" src="https://github.com/user-attachments/assets/804ede01-76f1-4de2-a790-47003c763ed3" />
<img width="810" height="541" alt="image" src="https://github.com/user-attachments/assets/652d66a9-29c8-4d56-9b68-c07dd10f35d8" />


## Tests

Disable a few Line Type, and go to any of the color-range view such as Speed, Temperature, Line Width, etc....

Now, the color range would only include visible layers instead of also including hidden layers

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
