### PR TITLE
Fix: resolve 23 MSVC compiler warnings

### DIFF
--- a/src/OrcaSlicer.cpp
+++ b/src/OrcaSlicer.cpp
@@ -3,7 +3,9 @@
     #define _WIN32_WINNT 0x0502
     // The standard Windows includes.
     #define WIN32_LEAN_AND_MEAN
+    #ifndef NOMINMAX
     #define NOMINMAX
+    #endif
     #include <Windows.h>
     #include <wchar.h>
     #include <commctrl.h>

--- a/src/OrcaSlicer_app_msvc.cpp
+++ b/src/OrcaSlicer_app_msvc.cpp
@@ -2,7 +2,9 @@
 #define _WIN32_WINNT 0x0502
 // The standard Windows includes.
 #define WIN32_LEAN_AND_MEAN
+#ifndef NOMINMAX
 #define NOMINMAX
+#endif
 #include <Windows.h>
 #include <shellapi.h>
 #include <wchar.h>

--- a/src/libslic3r/Config.cpp
+++ b/src/libslic3r/Config.cpp
@@ -2031,7 +2031,8 @@ const double& DynamicConfig::opt_float(const t_config_option_key &opt_key, unsig
         return opt_floats_nullable->get_at(idx);
     } else {
         assert(false);
-        return 0;
+        static const double zero = 0.0;
+        return zero;
     }
 }
 

--- a/src/libslic3r/FilamentGroup.cpp
+++ b/src/libslic3r/FilamentGroup.cpp
@@ -1021,7 +1021,7 @@ namespace Slic3r
             if (FGMode::MatchMode == ctx.group_info.mode)
                 return calc_filament_group_for_match(cost);
         }
-        catch (const FilamentGroupException& e) {
+        catch (const FilamentGroupException&) {
         }
 
         return calc_filament_group_for_flush(cost);

--- a/src/libslic3r/Format/STEP.cpp
+++ b/src/libslic3r/Format/STEP.cpp
@@ -712,7 +712,7 @@ unsigned int Step::get_triangle_num(double linear_deflection, double angle_defle
                 return 0;
             }
         }
-    } catch(const Exception &e) {
+    } catch(const Exception &) {
         return 0;
     }
     

--- a/src/libslic3r/OpenVDBUtils.cpp
+++ b/src/libslic3r/OpenVDBUtils.cpp
@@ -1,4 +1,6 @@
+#ifndef NOMINMAX
 #define NOMINMAX
+#endif
 #include "OpenVDBUtils.hpp"
 
 #ifdef _MSC_VER

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -8,7 +8,9 @@
 
 #ifdef _MSC_VER
     #define WIN32_LEAN_AND_MEAN
+    #ifndef NOMINMAX
     #define NOMINMAX
+    #endif
     #include <Windows.h>
 #endif /* _MSC_VER */
 

--- a/src/libslic3r/SLA/SupportTreeBuilder.cpp
+++ b/src/libslic3r/SLA/SupportTreeBuilder.cpp
@@ -1,4 +1,6 @@
+#ifndef NOMINMAX
 #define NOMINMAX
+#endif
 
 #include <libslic3r/SLA/SupportTreeBuilder.hpp>
 #include <libslic3r/SLA/SupportTreeBuildsteps.hpp>

--- a/src/slic3r/GUI/DeviceCore/DevStatus.cpp
+++ b/src/slic3r/GUI/DeviceCore/DevStatus.cpp
@@ -27,6 +27,7 @@ void DevStatus::ParseStatus(const nlohmann::json& print_jj)
 #else
         BOOST_LOG_TRIVIAL(error) << __FUNCTION__ << ": get exception=" << e.what();
 #endif
+        (void)e; // suppress C4101 when BBL_RELEASE_TO_PUBLIC
     }
 }
 

--- a/src/slic3r/GUI/DownloadProgressDialog.cpp
+++ b/src/slic3r/GUI/DownloadProgressDialog.cpp
@@ -26,7 +26,8 @@
 
 #include "Widgets/HyperLink.hpp" // ORCA
 
-#define DESIGN_INPUT_SIZE wxSize(FromDIP(100), -1)
+// DESIGN_INPUT_SIZE is defined in Preferences.hpp / ExportPresetBundleDialog.hpp
+// and not used in this file — remove the conflicting redefinition.
 
 namespace Slic3r {
 namespace GUI {

--- a/src/slic3r/GUI/DownloadProgressDialog.cpp
+++ b/src/slic3r/GUI/DownloadProgressDialog.cpp
@@ -26,9 +26,6 @@
 
 #include "Widgets/HyperLink.hpp" // ORCA
 
-// DESIGN_INPUT_SIZE is defined in Preferences.hpp / ExportPresetBundleDialog.hpp
-// and not used in this file — remove the conflicting redefinition.
-
 namespace Slic3r {
 namespace GUI {
 

--- a/src/slic3r/GUI/GUI.cpp
+++ b/src/slic3r/GUI/GUI.cpp
@@ -18,7 +18,9 @@
 #import <IOKit/pwr_mgt/IOPMLib.h>
 #elif _WIN32
 #define WIN32_LEAN_AND_MEAN
+#ifndef NOMINMAX
 #define NOMINMAX
+#endif
 #include <Windows.h>
 #include "boost/nowide/convert.hpp"
 #endif

--- a/src/slic3r/GUI/Gizmos/GLGizmoMeasure.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoMeasure.cpp
@@ -597,7 +597,6 @@ void GLGizmoMeasure::on_render()
         }
     }
     Vec3d  position_on_model;
-    Vec3d  direction_on_model;
     size_t model_facet_idx = -1;
     double closest_hit_distance = std::numeric_limits<double>::max();
     {

--- a/src/slic3r/GUI/ImGuiWrapper.cpp
+++ b/src/slic3r/GUI/ImGuiWrapper.cpp
@@ -3332,7 +3332,7 @@ const char* ImGuiWrapper::clipboard_get(void* user_data)
             wxTextDataObject data;
             wxTheClipboard->GetData(data);
 
-            if (data.GetTextLength() > 0) {
+            if (data.GetText().Length() > 0) {
                 self->m_clipboard_text = into_u8(data.GetText());
                 res = self->m_clipboard_text.c_str();
             }

--- a/src/slic3r/GUI/ImGuiWrapper.cpp
+++ b/src/slic3r/GUI/ImGuiWrapper.cpp
@@ -3332,8 +3332,9 @@ const char* ImGuiWrapper::clipboard_get(void* user_data)
             wxTextDataObject data;
             wxTheClipboard->GetData(data);
 
-            if (data.GetText().Length() > 0) {
-                self->m_clipboard_text = into_u8(data.GetText());
+            const wxString text = data.GetText();
+            if (text.Length() > 0) {
+                self->m_clipboard_text = into_u8(text);
                 res = self->m_clipboard_text.c_str();
             }
         }

--- a/src/slic3r/GUI/PartPlate.cpp
+++ b/src/slic3r/GUI/PartPlate.cpp
@@ -4445,8 +4445,6 @@ void PartPlateList::set_default_wipe_tower_pos_for_plate(int plate_idx, bool ini
 //this may be happened after machine changed
 void PartPlateList::reset_size(int width, int depth, int height, bool reload_objects, bool update_shapes)
 {
-	Vec3d origin1, origin2;
-
 	BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << boost::format(":before size: plate_width %1%, plate_depth %2%, plate_height %3%") % m_plate_width % m_plate_depth % m_plate_height;
 	BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << boost::format(":after size: plate_width %1%, plate_depth %2%, plate_height %3%") % width % depth % height;
 	if ((m_plate_width != width) || (m_plate_depth != depth) || (m_plate_height != height))

--- a/src/slic3r/GUI/SysInfoDialog.cpp
+++ b/src/slic3r/GUI/SysInfoDialog.cpp
@@ -21,9 +21,9 @@
 #ifdef _WIN32
 	// The standard Windows includes.
 	#define WIN32_LEAN_AND_MEAN
-    #ifndef NOMINMAX
+	#ifndef NOMINMAX
 	#define NOMINMAX
-    #endif
+	#endif
 	#include <Windows.h>
 	#include <psapi.h>
 #endif /* _WIN32 */

--- a/src/slic3r/GUI/SysInfoDialog.cpp
+++ b/src/slic3r/GUI/SysInfoDialog.cpp
@@ -21,7 +21,9 @@
 #ifdef _WIN32
 	// The standard Windows includes.
 	#define WIN32_LEAN_AND_MEAN
+    #ifndef NOMINMAX
 	#define NOMINMAX
+    #endif
 	#include <Windows.h>
 	#include <psapi.h>
 #endif /* _WIN32 */

--- a/src/slic3r/GUI/Widgets/Button.cpp
+++ b/src/slic3r/GUI/Widgets/Button.cpp
@@ -504,6 +504,7 @@ void Button::OnParentMotion(wxMouseEvent& event)
         if (!tipWindow)
         {
             tipWindow = wxTipWindow::New(this, tip);
+            if (!tipWindow) return event.Skip();
             tipWindow->Enable(false);
         }
 
@@ -521,7 +522,7 @@ void Button::OnParentMotion(wxMouseEvent& event)
     {
         if (tipWindow)
         {
-            delete tipWindow.operator->();
+            tipWindow->Destroy();
             tipWindow = nullptr;
         }
     }
@@ -542,7 +543,7 @@ void Button::OnParentLeave(wxMouseEvent& event)
         if (!screen_rect.Contains(pos))
         {
             tipWindow->Dismiss();
-            delete tipWindow.operator->();
+            tipWindow->Destroy();
             tipWindow = nullptr;
         }
     }

--- a/src/slic3r/GUI/Widgets/Button.cpp
+++ b/src/slic3r/GUI/Widgets/Button.cpp
@@ -522,6 +522,7 @@ void Button::OnParentMotion(wxMouseEvent& event)
     {
         if (tipWindow)
         {
+            tipWindow->Dismiss();
             tipWindow->Destroy();
             tipWindow = nullptr;
         }

--- a/src/slic3r/GUI/Widgets/Button.cpp
+++ b/src/slic3r/GUI/Widgets/Button.cpp
@@ -503,8 +503,7 @@ void Button::OnParentMotion(wxMouseEvent& event)
     {
         if (!tipWindow)
         {
-            tipWindow = new wxTipWindow(this, tip);
-            tipWindow->Bind(wxEVT_DESTROY, [this](wxEvent& event) { this->tipWindow = nullptr;});
+            tipWindow = wxTipWindow::New(this, tip);
             tipWindow->Enable(false);
         }
 
@@ -522,7 +521,7 @@ void Button::OnParentMotion(wxMouseEvent& event)
     {
         if (tipWindow)
         {
-            delete tipWindow;
+            delete tipWindow.operator->();
             tipWindow = nullptr;
         }
     }
@@ -543,7 +542,7 @@ void Button::OnParentLeave(wxMouseEvent& event)
         if (!screen_rect.Contains(pos))
         {
             tipWindow->Dismiss();
-            delete tipWindow;
+            delete tipWindow.operator->();
             tipWindow = nullptr;
         }
     }

--- a/src/slic3r/GUI/Widgets/Button.hpp
+++ b/src/slic3r/GUI/Widgets/Button.hpp
@@ -3,6 +3,7 @@
 
 #include "../wxExtensions.hpp"
 #include "StaticBox.hpp"
+#include <wx/tipwin.h>
 
 class ButtonProps
 {
@@ -27,9 +28,9 @@ enum class ButtonType{
     Expanded , // Font14  Semi-Rounded  For full length buttons. ex. buttons in static box
 };
 
-class wxTipWindow;
 class Button : public StaticBox
 {
+    wxTipWindow::Ref tipWindow;
     wxRect textSize;
     wxSize minSize; // set by outer
     wxSize paddingSize;
@@ -42,8 +43,6 @@ class Button : public StaticBox
     bool canFocus  = true;
     bool isCenter    = true;
     bool vertical    = false;
-
-    wxTipWindow* tipWindow = nullptr;
 
     static const int buttonWidth = 200;
     static const int buttonHeight = 50;

--- a/src/slic3r/Utils/ASCIIFolding.cpp
+++ b/src/slic3r/Utils/ASCIIFolding.cpp
@@ -4,7 +4,6 @@
 #include <string.h>
 #include <locale>
 #include <boost/locale/encoding_utf.hpp>
-#include <codecvt>
 #include <regex>
 
 namespace Slic3r {

--- a/src/slic3r/Utils/ASCIIFolding.cpp
+++ b/src/slic3r/Utils/ASCIIFolding.cpp
@@ -1953,8 +1953,7 @@ std::string fold_utf8_to_ascii(const std::string &src, bool is_convert_for_filen
 	for (wchar_t c : wstr)
 		fold_to_ascii(c, out);
 	if (is_convert_for_filename) {
-		std::wstring_convert<std::codecvt_utf8<wchar_t>> converter;
-		auto   dstStr = converter.to_bytes(dst);
+		auto   dstStr = boost::locale::conv::utf_to_utf<char>(dst.c_str(), dst.c_str() + dst.size());
 
 		std::size_t found = dstStr.find_last_of("/\\");
 		if (found != std::string::npos) {
@@ -1964,7 +1963,7 @@ std::string fold_utf8_to_ascii(const std::string &src, bool is_convert_for_filen
 			std::string newFileName = regex_replace(filename, reg, "");
 			dstStr  = dir + "\\" + newFileName;
         }
-		dst = converter.from_bytes(dstStr);
+		dst = boost::locale::conv::utf_to_utf<wchar_t>(dstStr.c_str(), dstStr.c_str() + dstStr.size());
 	}
 
 	return boost::locale::conv::utf_to_utf<char>(dst.c_str(), dst.c_str() + dst.size());

--- a/src/slic3r/Utils/OrcaCloudServiceAgent.cpp
+++ b/src/slic3r/Utils/OrcaCloudServiceAgent.cpp
@@ -572,7 +572,7 @@ int OrcaCloudServiceAgent::set_config_dir(std::string cfg_dir)
 {
     config_dir = cfg_dir;
     wxFileName fallback(wxString::FromUTF8(cfg_dir.c_str()), secret_constants::USER_SECRET_FILENAME);
-    fallback.Normalize();
+    fallback.Normalize(wxPATH_NORM_DOTS | wxPATH_NORM_ABSOLUTE | wxPATH_NORM_ENV_VARS | wxPATH_NORM_LONG | wxPATH_NORM_SHORTCUT);
     secret_fallback_path = fallback.GetFullPath().ToStdString();
     return BAMBU_NETWORK_SUCCESS;
 }
@@ -1564,7 +1564,7 @@ void OrcaCloudServiceAgent::persist_user_secret(const std::string& secret)
             return;
         }
         wxFileName path(wxString::FromUTF8(secret_fallback_path.c_str()));
-        path.Normalize();
+        path.Normalize(wxPATH_NORM_DOTS | wxPATH_NORM_ABSOLUTE | wxPATH_NORM_ENV_VARS | wxPATH_NORM_LONG | wxPATH_NORM_SHORTCUT);
         if (!wxFileName::DirExists(path.GetPath())) {
             wxFileName::Mkdir(path.GetPath(), wxS_DIR_DEFAULT, wxPATH_MKDIR_FULL);
         }
@@ -2487,7 +2487,7 @@ void OrcaCloudServiceAgent::compute_fallback_path()
     if (wxTheApp == nullptr)
         return;
     wxFileName fallback(wxStandardPaths::Get().GetUserDataDir(), "orca_refresh_token.sec");
-    fallback.Normalize();
+    fallback.Normalize(wxPATH_NORM_DOTS | wxPATH_NORM_ABSOLUTE | wxPATH_NORM_ENV_VARS | wxPATH_NORM_LONG | wxPATH_NORM_SHORTCUT);
     secret_fallback_path = fallback.GetFullPath().ToStdString();
 }
 
@@ -3581,7 +3581,7 @@ std::string OrcaCloudServiceAgent::token_lock_path() const
     if (config_dir.empty())
         return {};
     wxFileName lock(wxString::FromUTF8(config_dir.c_str()), "orca_refresh_token.lock");
-    lock.Normalize();
+    lock.Normalize(wxPATH_NORM_DOTS | wxPATH_NORM_ABSOLUTE | wxPATH_NORM_ENV_VARS | wxPATH_NORM_LONG | wxPATH_NORM_SHORTCUT);
     return lock.GetFullPath().ToStdString();
 }
 

--- a/src/slic3r/Utils/OrcaCloudServiceAgent.cpp
+++ b/src/slic3r/Utils/OrcaCloudServiceAgent.cpp
@@ -572,7 +572,7 @@ int OrcaCloudServiceAgent::set_config_dir(std::string cfg_dir)
 {
     config_dir = cfg_dir;
     wxFileName fallback(wxString::FromUTF8(cfg_dir.c_str()), secret_constants::USER_SECRET_FILENAME);
-    fallback.Normalize(wxPATH_NORM_DOTS | wxPATH_NORM_ABSOLUTE | wxPATH_NORM_ENV_VARS | wxPATH_NORM_LONG | wxPATH_NORM_SHORTCUT);
+    fallback.MakeAbsolute();
     secret_fallback_path = fallback.GetFullPath().ToStdString();
     return BAMBU_NETWORK_SUCCESS;
 }
@@ -1564,7 +1564,7 @@ void OrcaCloudServiceAgent::persist_user_secret(const std::string& secret)
             return;
         }
         wxFileName path(wxString::FromUTF8(secret_fallback_path.c_str()));
-        path.Normalize(wxPATH_NORM_DOTS | wxPATH_NORM_ABSOLUTE | wxPATH_NORM_ENV_VARS | wxPATH_NORM_LONG | wxPATH_NORM_SHORTCUT);
+        path.MakeAbsolute();
         if (!wxFileName::DirExists(path.GetPath())) {
             wxFileName::Mkdir(path.GetPath(), wxS_DIR_DEFAULT, wxPATH_MKDIR_FULL);
         }
@@ -2487,7 +2487,7 @@ void OrcaCloudServiceAgent::compute_fallback_path()
     if (wxTheApp == nullptr)
         return;
     wxFileName fallback(wxStandardPaths::Get().GetUserDataDir(), "orca_refresh_token.sec");
-    fallback.Normalize(wxPATH_NORM_DOTS | wxPATH_NORM_ABSOLUTE | wxPATH_NORM_ENV_VARS | wxPATH_NORM_LONG | wxPATH_NORM_SHORTCUT);
+    fallback.MakeAbsolute();
     secret_fallback_path = fallback.GetFullPath().ToStdString();
 }
 
@@ -3581,7 +3581,7 @@ std::string OrcaCloudServiceAgent::token_lock_path() const
     if (config_dir.empty())
         return {};
     wxFileName lock(wxString::FromUTF8(config_dir.c_str()), "orca_refresh_token.lock");
-    lock.Normalize(wxPATH_NORM_DOTS | wxPATH_NORM_ABSOLUTE | wxPATH_NORM_ENV_VARS | wxPATH_NORM_LONG | wxPATH_NORM_SHORTCUT);
+    lock.MakeAbsolute();
     return lock.GetFullPath().ToStdString();
 }
 


### PR DESCRIPTION
# Description

Fixed 23 warnings in the Windows build.

**C4101** - unreferenced local variables:
  - `STEP.cpp`, `FilamentGroup.cpp`: remove unused catch variable `e`
  - `GLGizmoMeasure.cpp`: remove unused `direction_on_model`
  - `PartPlate.cpp`: remove unused `origin1, origin2`
  - `DevStatus.cpp`: suppress unused `e` via `(void)e`

**C4005** - macro redefinition:
  - Wrap `NOMINMAX` defines in `#ifndef` guards (`OrcaSlicer.cpp`, `Preset.cpp`, `SupportTreeBuilder.cpp`, `OpenVDBUtils.cpp`, `GUI.cpp`)
  - Remove conflicting `DESIGN_INPUT_SIZE` redefine in `DownloadProgressDialog.cpp`

**C4172** - return address of local/temporary:
  - `Config.cpp`: return static const double instead of temporary `0`

**C4996** - deprecated API usage:
  - `ImGuiWrapper.cpp`: use `GetText().Length()` instead of `GetTextLength()`
  - `OrcaCloudServiceAgent.cpp`: fixing the deprecated in the `Normalize` function by using the explicit flags as parameters, matching old default behavior
  - `ASCIIFolding.cpp`: replace deprecated `std::wstring_convert/codecvt_utf8` with `boost::locale::conv::utf_to_utf` (already used in same function)

**C2440** - build error from deprecated wxTipWindow constructor:
  - `Button.hpp/cpp`: replace raw `wxTipWindow*` with `wxTipWindow::Ref` (weak reference). Ref auto-nulls when the tip window closes, eliminating the manual `Bind(wxEVT_DESTROY)` handler. `delete` uses `operator->()` to access the raw pointer since Ref is non-owning.

### After code review
 - All the places with the `NOMINMAX` definition were guarded
 - The `tipWindow` deletion: deletion of the raw pointer was replaced with a pair of calls to `tipWindow->Dismiss();` and `tipWindow->Destroy();`
 - `Normalize()` calls were replaced with `MakeAbsolute()` calls in `src/slic3r/Utils/OrcaCloudServiceAgent.cpp`

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
