### PR TITLE
Add host-owned temporary G-code export API for Script plugins

### DIFF
--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -5299,6 +5299,7 @@ struct Plater::priv
 
     BackgroundSlicingProcess    background_process;
     bool suppressed_backround_processing_update { false };
+    std::optional<fs::path> plugin_temp_export_path;
 
     // TODO: A mechanism would be useful for blocking the plater interactions:
     // objects would be frozen for the user. In case of arrange, an animation
@@ -5589,6 +5590,7 @@ struct Plater::priv
     void on_process_completed(SlicingProcessCompletedEvent&);
     void on_export_began(wxCommandEvent&);
     void on_export_finished(wxCommandEvent&);
+    void cleanup_plugin_temp_export();
     void on_slicing_began();
 
     void clear_warnings();
@@ -10759,6 +10761,30 @@ void Plater::priv::on_export_finished(wxCommandEvent& evt)
         q->export_3mf(gcode_path.replace_extension(".3mf"), SaveStrategy::Silence); // BBS: silence
     }
 #endif
+    if (plugin_temp_export_path) {
+        cleanup_plugin_temp_export();
+        notification_manager->stop_delayed_notifications_of_type(NotificationType::ExportOngoing);
+        notification_manager->close_notification_of_type(NotificationType::ExportOngoing);
+    }
+}
+
+void Plater::priv::cleanup_plugin_temp_export()
+{
+    if (!plugin_temp_export_path)
+        return;
+
+    for (const fs::path& candidate : {
+             *plugin_temp_export_path,
+             fs::path(plugin_temp_export_path->string() + ".tmp")
+         }) {
+        try {
+            fs::remove(candidate);
+        } catch (const std::exception& error) {
+            BOOST_LOG_TRIVIAL(warning) << "Failed to remove plugin temporary export "
+                                       << candidate.string() << ": " << error.what();
+        }
+    }
+    plugin_temp_export_path.reset();
 }
 
 void Plater::priv::on_slicing_began()
@@ -10869,6 +10895,12 @@ void Plater::priv::on_process_completed(SlicingProcessCompletedEvent &evt)
 
     // Reset the "export G-code path" name, so that the automatic background processing will be enabled again.
     this->background_process.reset_export();
+    const bool was_plugin_temp_export = plugin_temp_export_path.has_value();
+    cleanup_plugin_temp_export();
+    if (was_plugin_temp_export) {
+        notification_manager->stop_delayed_notifications_of_type(NotificationType::ExportOngoing);
+        notification_manager->close_notification_of_type(NotificationType::ExportOngoing);
+    }
     // This bool stops showing export finished notification even when process_completed_with_error is false
     bool has_error = false;
     if (evt.error()) {
@@ -16012,6 +16044,30 @@ void Plater::export_gcode(bool prefer_removable)
         } catch (...) {}
 
     }
+}
+
+bool Plater::export_gcode_to_temp()
+{
+    if (!wxIsMainThread() || p->model.objects.empty() || printer_technology() != ptFFF ||
+        p->process_completed_with_error == p->partplate_list.get_curr_plate_index() ||
+        p->background_process.is_export_scheduled() || p->plugin_temp_export_path)
+        return false;
+
+    const fs::path output_path = fs::temp_directory_path() /
+        fs::unique_path(".orcaslicer.plugin-export.%%%%-%%%%-%%%%-%%%%.gcode");
+    p->plugin_temp_export_path = output_path;
+    try {
+        p->export_gcode(output_path, false);
+    } catch (...) {
+        p->cleanup_plugin_temp_export();
+        throw;
+    }
+
+    if (!p->background_process.is_export_scheduled()) {
+        p->cleanup_plugin_temp_export();
+        return false;
+    }
+    return true;
 }
 
 void Plater::send_to_printer(bool isall)

--- a/src/slic3r/GUI/Plater.hpp
+++ b/src/slic3r/GUI/Plater.hpp
@@ -492,6 +492,10 @@ public:
 
     void send_to_printer(bool isall = false);
     void export_gcode(bool prefer_removable);
+    // Schedule the active FFF plate through the normal slicing/export pipeline using a
+    // host-owned temporary destination. The destination is never exposed to plugins and
+    // is removed after success, failure, or cancellation.
+    bool export_gcode_to_temp();
     void export_gcode_3mf(bool export_all = false);
     void send_gcode_finish(wxString name);
     void export_core_3mf();

--- a/src/slic3r/plugin/host/PluginHostApp.cpp
+++ b/src/slic3r/plugin/host/PluginHostApp.cpp
@@ -41,15 +41,23 @@ PresetBundle* current_preset_bundle()
 } // namespace
 
 // Access to the live GUI application: the Plater and the module-level
-// plater()/model()/preset_bundle() accessors. Everything here is owned by the
-// app and only reachable once the GUI is up (the accessors throw before that).
+// plater()/model()/preset_bundle() accessors. Model and preset access is read-only;
+// export_gcode_to_temp() is the one narrow scheduling operation and keeps its
+// filesystem destination entirely host-owned. Everything here is owned by the app
+// and only reachable once the GUI is up (the accessors throw before that).
 void host_bindings::register_app(py::module_& host)
 {
     py::class_<GUI::Plater, std::unique_ptr<GUI::Plater, py::nodelete>>(host, "Plater")
         .def("model", static_cast<Model& (GUI::Plater::*)()>(&GUI::Plater::model), py::return_value_policy::reference_internal)
         .def("is_project_dirty", &GUI::Plater::is_project_dirty)
         .def("is_presets_dirty", &GUI::Plater::is_presets_dirty)
-        .def("inside_snapshot_capture", &GUI::Plater::inside_snapshot_capture);
+        .def("inside_snapshot_capture", &GUI::Plater::inside_snapshot_capture)
+        .def(
+            "export_gcode_to_temp",
+            &GUI::Plater::export_gcode_to_temp,
+            "Schedule the active FFF plate through OrcaSlicer's normal slicing and export pipeline. "
+            "OrcaSlicer owns and removes the temporary G-code destination after completion. Returns "
+            "True only when the export was scheduled.");
 
     host.def("plater", &current_plater, py::return_value_policy::reference);
     host.def("model", []() -> Model& {

--- a/tests/slic3rutils/test_plugin_host_api.cpp
+++ b/tests/slic3rutils/test_plugin_host_api.cpp
@@ -38,6 +38,7 @@ TEST_CASE("Plugin host API exposes host-owned bundle and preset surface to Pytho
     REQUIRE(has_attr(host, "Model"));
     REQUIRE(has_attr(host, "ModelObject"));
     REQUIRE(has_attr(host, "Plater"));
+    CHECK(has_attr(host.attr("Plater"), "export_gcode_to_temp"));
 
     py::object preset_bundle_type = host.attr("PresetBundle");
     CHECK(has_attr(preset_bundle_type, "prints"));


### PR DESCRIPTION
## Summary

Adds a narrow Plater.export_gcode_to_temp() Python host method for explicitly invoked Script capabilities. The method:

- schedules the active FFF plate through the existing validation, slicing, export, and post-processing pipeline
- selects an opaque unique destination below the system temporary directory
- returns only whether scheduling succeeded; the path is never exposed to Python
- removes the temporary destination after success, failure, or cancellation
- refuses empty/invalid/non-FFF projects and concurrent exports

## Motivation

Export-oriented plugins can currently inspect the model and participate in psGCodePostProcess, but a Script action cannot request that Orca run the normal export pipeline without showing a save dialog or using undocumented UI automation. A host-owned destination keeps filesystem authority in Orca while enabling actions that analyze or hand off final G-code facts.

## Security boundary

The plugin cannot choose, read, or retain the destination through this API. Existing slicing validation, plugin audit scopes, pipeline hooks, warnings, cancellation, and export concurrency checks remain in force.

## Tests

- extends the embedded Python host API surface test
- source diff passes git diff --check`n
This is a draft to collect API/lifecycle feedback and run upstream CI.