### PR TITLE
fix: recursive include between HMS.hpp and GUI_App.hpp

### DIFF
--- a/src/slic3r/GUI/HMS.cpp
+++ b/src/slic3r/GUI/HMS.cpp
@@ -1,6 +1,7 @@
 #include "HMS.hpp"
 
 #include "GUI.hpp"
+#include "GUI_App.hpp"
 #include "DeviceManager.hpp"
 #include "DeviceCore/DevManager.h"
 #include "DeviceCore/DevUtil.h"

--- a/src/slic3r/GUI/HMS.hpp
+++ b/src/slic3r/GUI/HMS.hpp
@@ -1,7 +1,6 @@
 #ifndef slic3r_HMS_hpp_
 #define slic3r_HMS_hpp_
 
-#include "GUI_App.hpp"
 #include "GUI.hpp"
 #include "I18N.hpp"
 #include "Widgets/Label.hpp"
@@ -11,7 +10,11 @@
 #include "slic3r/Utils/Http.hpp"
 #include "libslic3r/Thread.hpp"
 #include "nlohmann/json.hpp"
+#include <ctime>
 #include <mutex>
+#include <string>
+#include <unordered_map>
+#include <vector>
 
 namespace Slic3r {
 
@@ -26,12 +29,12 @@ namespace GUI {
 class HMSQuery {
 
 protected:
-    std::unordered_map<string, json> m_hms_info_jsons;  // key-> device id type, the first three digits of SN number
-    std::unordered_map<string, json> m_hms_action_jsons;// key-> device id type
+    std::unordered_map<std::string, nlohmann::json> m_hms_info_jsons;  // key-> device id type, the first three digits of SN number
+    std::unordered_map<std::string, nlohmann::json> m_hms_action_jsons;// key-> device id type
     std::unordered_map<wxString, wxImage> m_hms_local_images; // key-> image name
     mutable std::mutex m_hms_mutex;
 
-    std::unordered_map<string, time_t> m_cloud_hms_last_update_time;
+    std::unordered_map<std::string, std::time_t> m_cloud_hms_last_update_time;
 
 public:
     HMSQuery() { }
@@ -61,18 +64,18 @@ private:
     // load hms
     void init_hms_info(const std::string& dev_type_id);
     void copy_from_data_dir_to_local();
-    int  download_hms_related(const std::string& hms_type, const std::string& dev_id_type, json* receive_json);
-    int  load_from_local(const std::string& hms_type, const std::string& dev_id_type, json* receive_json, std::string& version_info);
-    int  save_to_local(std::string lang, std::string hms_type, std::string dev_id_type, json save_json);
+    int  download_hms_related(const std::string& hms_type, const std::string& dev_id_type, nlohmann::json* receive_json);
+    int  load_from_local(const std::string& hms_type, const std::string& dev_id_type, nlohmann::json* receive_json, std::string& version_info);
+    int  save_to_local(std::string lang, std::string hms_type, std::string dev_id_type, nlohmann::json save_json);
     std::string get_hms_file(std::string hms_type, std::string lang = std::string("en"), std::string dev_id_type = "");
 
     // internal query
-    string    get_dev_id_type(const MachineObject* obj) const;
-    wxString _query_hms_msg(const string& dev_id_type, const string& long_error_code, const string& lang_code = std::string("en"));
+    std::string get_dev_id_type(const MachineObject* obj) const;
+    wxString _query_hms_msg(const std::string& dev_id_type, const std::string& long_error_code, const std::string& lang_code = std::string("en"));
 
-    bool     _is_internal_error(const string &dev_id_type, const string &long_error_code, const string &lang_code = std::string("en"));
-    wxString _query_error_msg(const string& dev_id_type, const std::string& long_error_code, const std::string& lang_code = std::string("en"));
-    wxString _query_error_image_action(const string& dev_id_type, const std::string& long_error_code, std::vector<int>& button_action);
+    bool     _is_internal_error(const std::string &dev_id_type, const std::string &long_error_code, const std::string &lang_code = std::string("en"));
+    wxString _query_error_msg(const std::string& dev_id_type, const std::string& long_error_code, const std::string& lang_code = std::string("en"));
+    wxString _query_error_image_action(const std::string& dev_id_type, const std::string& long_error_code, std::vector<int>& button_action);
 };
 
 int get_hms_info_version(std::string &version);


### PR DESCRIPTION
# Description

Break the recursive include dependency by moving GUI_App.hpp from HMS.hpp into HMS.cpp. Add the required standard headers and use explicit std/nlohmann types to remove reliance on transitive includes.

This prevents recursive header inclusion while preserving HMS functionality.

# Screenshots/Recordings/Graphs

<!--
> Please attach relevant screenshots to showcase the UI changes.
> Please attach images that can help explain the changes.
-->

## Tests

<!--
> Please describe the tests that you have conducted to verify the changes made in this PR.
-->

<!--
> A guide for users on how to download the artifacts from this PR.
-->

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
