### PR TITLE
fix: bounds-check the toolchange flush-volume and HRC per-filament lookups

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -9115,12 +9115,14 @@ std::string GCode::set_extruder(unsigned int new_filament_id, double print_z, bo
             if (old_filament_id_in_new_extruder == -1)
                 wipe_volume = 0;
             else {
-                wipe_volume = flush_matrix[old_filament_id_in_new_extruder * number_of_extruders + new_filament_id];
+                size_t flush_idx = size_t(old_filament_id_in_new_extruder) * number_of_extruders + new_filament_id;
+                wipe_volume = flush_idx < flush_matrix.size() ? flush_matrix[flush_idx] : 0.f;
                 wipe_volume *= m_config.flush_multiplier.get_at(new_extruder_id);
             }
         }
         else {
-            wipe_volume = flush_matrix[old_filament_id * number_of_extruders + new_filament_id];
+            size_t flush_idx = size_t(old_filament_id) * number_of_extruders + new_filament_id;
+            wipe_volume = flush_idx < flush_matrix.size() ? flush_matrix[flush_idx] : 0.f;
             wipe_volume *= m_config.flush_multiplier.get_at(new_extruder_id);  // if is multi_extruder only use the fist extruder matrix
         }
         wipe_volume = std::max(0.f, wipe_volume-grab_purge_volume);

--- a/src/libslic3r/GCode/GCodeProcessor.cpp
+++ b/src/libslic3r/GCode/GCodeProcessor.cpp
@@ -7478,8 +7478,8 @@ void GCodeProcessor::update_slice_warnings()
         if (used_filaments[idx] < m_result.required_nozzle_HRC.size())
             filament_hrc = m_result.required_nozzle_HRC[used_filaments[idx]];
 
-        int filament_extruder_id = m_filament_maps[used_filaments[idx]];
-        int extruder_hrc = nozzle_hrc_lists[filament_extruder_id];
+        int filament_extruder_id = used_filaments[idx] < m_filament_maps.size() ? m_filament_maps[used_filaments[idx]] : -1;
+        int extruder_hrc = (filament_extruder_id >= 0 && (size_t) filament_extruder_id < nozzle_hrc_lists.size()) ? nozzle_hrc_lists[filament_extruder_id] : 0;
 
         BOOST_LOG_TRIVIAL(debug) << __FUNCTION__ << boost::format(": Check HRC: filament:%1%, hrc=%2%, extruder:%3%, hrc:%4%") % used_filaments[idx] % filament_hrc % filament_extruder_id % extruder_hrc;
 


### PR DESCRIPTION
# Description

`GCode::set_extruder`'s toolchange flush-volume lookup and `GCodeProcessor::update_slice_warnings`'s HRC check index per-filament and per-extruder arrays (`flush_volumes_matrix`, the filament map, the nozzle list) by filament/extruder id. When a config leaves one of those arrays shorter than the filament count (partial or legacy multi-extruder projects, minimal configs), the reads run off the end. On a normal build the read just returns garbage; the Flatpak build compiles with a bounds-checked STL (`_GLIBCXX_ASSERTIONS`) that catches it and crashes.

The bounds-checked Flatpak test leg in #14709 caught these once the wipe-tower tests merged in #15144.

Both reads now check the index first. The flush lookup falls back to no flush, the same as the unknown-old-filament branch beside it. The HRC check skips a filament it can't map, which is what the `required_nozzle_HRC` guard on the line above already does.

# Screenshots/Recordings/Graphs

No UI changes.

## Tests

The new wipe-tower temperature tests in `test_multifilament.cpp` exercise both paths. Without this change they abort under `_GLIBCXX_ASSERTIONS`; the guards make them pass. Verified on a local Linux build with `-D_GLIBCXX_ASSERTIONS`.

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
