### PR TITLE
fix: pass douglas_peucker tolerance in scaled units so the cancel-object outline is actually simplified

### DIFF
--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -5827,7 +5827,7 @@ BoundingBoxf3 PrintInstance::get_bounding_box() const {
 
 Polygon PrintInstance::get_convex_hull_2d() {
     Polygon poly = print_object->model_object()->convex_hull_2d(model_instance->get_matrix());
-    poly.douglas_peucker(0.1);
+    poly.douglas_peucker(scale_(0.1));
     return poly;
 }
 


### PR DESCRIPTION
# Description

`PrintInstance::get_convex_hull_2d()` has one caller in the tree: `GCode::set_object_info()`, which builds the `POLYGON=` argument of `EXCLUDE_OBJECT_DEFINE`. It asks for the hull to be simplified:

```cpp
poly.douglas_peucker(0.1);
```

`douglas_peucker()` takes its tolerance in scaled units and `SCALING_FACTOR` is `1e-6`, so this asks for 0.1 nm — below the 1 nm coordinate quantum, which makes the call incapable of dropping a vertex. It has been inert since e567afdc *"ENH: support exclude objects for klipper printer"*, the commit that added both this helper and the `EXCLUDE_OBJECT_DEFINE` output, so the simplification was meant to do something. The same file uses the convention correctly at `Print.cpp:2743` (`SCALED_RESOLUTION`) and writes `scale_(0.1)` verbatim at `Print.cpp:691`; PrusaSlicer simplifies the same polygon with `50000.f`, i.e. 0.05 mm.

It matters because Klipper parses every `EXCLUDE_OBJECT_DEFINE` in the header before the print starts, so a plate of many parts pays for each vertex in host time at exactly the wrong moment.

The polygon is only the outline drawn when cancelling an object; cancelling itself runs off `EXCLUDE_OBJECT_START` / `_END`. There is no other caller, so no arrangement or clearance check is affected, and the simplified hull stays within the tolerance.

# Tests

One plate, 54 instances of a 22 × 32 mm part, sliced with an unmodified 2.4.2 (Linux CLI, Klipper flavor):

| | hull vertices | header size | job start → finish |
|---|---|---|---|
| before | 13392 | 234.9 KiB | 13.6 s |
| after | 1404 | 28.6 KiB | 2.5 s |

* Feeding those polygons to the project's own `_douglas_peucker()` with the current `0.1` returns all 13392 vertices — nothing is removed. With `scale_(0.1)` it returns 1404, and no original vertex ends up further than 0.0975 mm from the simplified outline.
* The timing column is the header alone — the definitions plus `M400`, so nothing heats and nothing moves — sent to a FlashForge AD5X (Klipper) as a job. The 2.5 s is upload and dispatch overhead measured the same way, so the block itself costs about 11 s of host time before the first move. A header of this size, on top of the rest of the work Klipper does at print start, is enough to end in `MCU shutdown: Timer too close`.
* Parts whose hull is already coarse are unaffected: a rectangular part emits the same 4 points as before.
