### PR TITLE
Newer GCCs are bitching about in-class initialisation. Lets fix that!

### DIFF
--- a/src/libslic3r/GCode/ThumbnailData.hpp
+++ b/src/libslic3r/GCode/ThumbnailData.hpp
@@ -32,7 +32,7 @@ using ThumbnailsList = std::vector<ThumbnailData>;
 
 struct ThumbnailsParams
 {
-	const Vec2ds 	sizes;
+	const Vec2ds 	sizes{};
 	bool 			printable_only;
 	bool 			parts_only;
 	bool 			show_bed;


### PR DESCRIPTION
Add in-class default initialization to `sizes` in ThumbnailData.hpp to prevent GCC from implicitly deleting the ThumbnailsParams default constructor during compilation.

Changes:

const Vec2ds sizes;

to 

const Vec2ds sizes{};

Conditions:
gcc12.2
clang 14.0
Debian 12