### PR TITLE
test: fix the flaky multiline lightning smoothing assertion

### DIFF
--- a/tests/fff_print/test_fill.cpp
+++ b/tests/fff_print/test_fill.cpp
@@ -980,7 +980,11 @@ TEST_CASE("Smoothing multiline lightning infill keeps its outlines connected", "
     const SparseInfillShape smooth = shape_for("100%");
 
     REQUIRE(sharp.path_count > 0);
-    REQUIRE(smooth.path_count <= sharp.path_count);
+    // The loop count varies by a loop or two between platforms and between runs, so this is not an
+    // exact comparison. Smoothing should leave it about where it was; uncapping the smoothing
+    // reach, the regression this guards against, adds about 10%.
+    const size_t allowed_extra = sharp.path_count / 50; // 2%
+    REQUIRE(smooth.path_count <= sharp.path_count + allowed_extra);
     // The outlines are still rounded.
     REQUIRE(smooth.point_count > sharp.point_count);
     REQUIRE(smooth.sharp_turns < sharp.sharp_turns);


### PR DESCRIPTION
# Description

`Smoothing multiline lightning infill keeps its outlines connected` fails intermittently on the arm64 runners. It failed on Windows arm64 in run 32205444104 at 272 loops against 271, and on macOS arm64 in run 32205475912 at 367 against 366. The other arm64 platform passed in each of those runs, and neither pull request touches infill, so the same input is coming to different answers between runs.

`smooth.path_count <= sharp.path_count` leaves no margin. The 20 mm cube the test slices comes to exactly 368 loops rounded and unrounded on Linux x86_64, on all 57 layers that carry sparse infill, so one loop falling the other way decides the test.

The loop count does move. Slicing the same model six times per setting over cube sizes of 14 to 30 mm at 30 to 70% density, it differs between runs of one build in 10 of those 24 settings. The cube and density this test uses happens to be one of the settings that holds still on Linux x86_64, which is why only the other platforms see it.

The assertion is also not a property of the code. Sweeping those same 24 settings, five of them break it outright, by up to four loops.

Allowing 2% keeps the guard. The platform disagreements seen so far are one loop, against counts of 271 and 366, while removing the `max_reach` cap in `FillLightning.cpp`, which is the regression the test exists to catch, takes 368 loops to around 400.

This only stops the test failing. What makes the count move between runs is a separate bug in the lightning generator, which I have a fix for and will send as its own pull request.

## Tests

`ctest` under Linux/clang-18, whole `[Fill]` tag green, test itself green over 10 consecutive runs.

Checked the assertion still does its job: with the `max_reach` cap removed from `FillLightning.cpp` the test fails at 405 against an allowed 375.
