### PR TITLE
Fix STL export creating duplicate file extensions

### DIFF
--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -16430,10 +16430,11 @@ void Plater::export_stl(bool extended, bool selection_only, bool multi_stls, Fil
         case FT_DRC: ext = ".drc"; break;
         }
 
-        auto path = dir + name + ext;
+        std::string base_name = boost::filesystem::path(name).stem().string();
+        auto path = dir + base_name + ext;
         int n = 1;
         while (boost::filesystem::exists(path))
-            path = dir + name + "(" + std::to_string(n++) + ")"+ext;
+            path = dir + base_name + "(" + std::to_string(n++) + ")"+ext;
         return path;
     };
 


### PR DESCRIPTION
# Description

## Problem

When exporting parts to STLs (or another format), if the object's name already ended with an extension (for example `bracket.stl`), OrcaSlicer would append the format extension again, producing a filename like `bracket.stl.stl`.

## Solution

Strip any existing extension from the object name before appending the export format's extension, so a part named `bracket.stl` exports as `bracket.stl` (or `bracket(1).stl` when a file with that name already exists) instead of `bracket.stl.stl`.

In src/slic3r/GUI/Plater.cpp, Plater::export_stl now takes the base name via boost::filesystem::path(name).stem() and uses that for both the initial filename and the numbered fallback names.

<!--
> Please provide a summary of the changes made in this PR. Include details such as:
  > * What issue does this PR address or fix?
  > * What new features or enhancements does this PR introduce?
  > * Are there any breaking changes or dependencies that need to be considered?
-->

# Screenshots/Recordings/Graphs

<!--
> Please attach relevant screenshots to showcase the UI changes.
> Please attach images that can help explain the changes.
-->

## Tests

Tested on Windows x64 platform build.

<!--
> Please describe the tests that you have conducted to verify the changes made in this PR.
-->

<!--
> A guide for users on how to download the artifacts from this PR.
-->

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
