### PR TITLE
Fix unstable contours from triangulated planar faces

### DIFF
--- a/src/libslic3r/TriangleMeshSlicer.cpp
+++ b/src/libslic3r/TriangleMeshSlicer.cpp
@@ -1461,6 +1461,13 @@ static Polygons make_loops(
     chain_open_polylines_close_gaps(open_polylines, loops, max_gap, true);
 #endif
 
+    // Orca: A planar quad represented by two triangles contributes a point where the
+    // slicing plane crosses the shared diagonal. After rounding to coord_t this
+    // point may be very slightly off the otherwise straight contour edge. Apart
+    // from being redundant, such points make the subsequent contour
+    // simplification depend on the slice height (and may move seam candidates).
+    remove_collinear(loops);
+
 #ifdef SLIC3R_DEBUG_SLICE_PROCESSING
     {
         static int iRun = 0;


### PR DESCRIPTION
# Description

The easiest way to illustrate the problem is to use the regular Cylinder:

- Add a Cylinder primitive to the plate and slice it using the Arachne wall generator (it's also available in Classic, though less pronounced).
- So, a cylinder is a primitive figure, and it's expected that walls on each layer should be the same.
- But they are actually inconsistent.
- This PR fixes this issue, and fortunately, the fix is small.

**Notes:**
- The issue is global; it was just easier to demonstrate it using the Cylinder.
- Made with the help of AI.

# Screenshots

### Before

<img width="915" height="795" alt="before1" src="https://github.com/user-attachments/assets/5c3daf3a-0900-4584-9096-09679c986ec5" />

<img width="949" height="828" alt="before2" src="https://github.com/user-attachments/assets/6d7f0452-82e0-468a-b199-79832948707b" />

### After

<img width="832" height="852" alt="image" src="https://github.com/user-attachments/assets/b294a4e0-89bb-434c-b5a5-16d718d4f751" />

<img width="827" height="642" alt="image" src="https://github.com/user-attachments/assets/b664e13c-06ea-44e4-8339-1359695c6520" />

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
