### PR TITLE
Unify colinear simplify tolerance in Arachne

### DIFF
--- a/src/libslic3r/Arachne/WallToolPaths.cpp
+++ b/src/libslic3r/Arachne/WallToolPaths.cpp
@@ -154,8 +154,8 @@ void simplify(Polygon &thiss, const int64_t smallest_line_segment_squared, const
         //h^2 = L^2 / b^2     [factor the divisor]
         const int64_t height_2 = double(area_removed_so_far) * double(area_removed_so_far) / double(base_length_2);
         // Orca: The value of `height_2` is squared, so we need to compare it with the squared value
-        if ((height_2 <= Slic3r::sqr(scaled<coord_t>(0.005)) //Almost exactly colinear (barring rounding errors).
-             && Line::distance_to_infinite(current, previous, next) <= scaled<double>(0.005))) // make sure that height_2 is not small because of cancellation of positive and negative areas
+        if ((height_2 <= Slic3r::sqr(colinear_vertex_tolerance()) //Almost exactly colinear (barring rounding errors).
+             && Line::distance_to_infinite(current, previous, next) <= double(colinear_vertex_tolerance()))) // make sure that height_2 is not small because of cancellation of positive and negative areas
             continue;
 
         if (length2 < smallest_line_segment_squared

--- a/src/libslic3r/Arachne/utils/ExtrusionLine.cpp
+++ b/src/libslic3r/Arachne/utils/ExtrusionLine.cpp
@@ -133,8 +133,8 @@ void ExtrusionLine::simplify(const int64_t smallest_line_segment_squared, const 
         const auto    height_2 = int64_t(double(area_removed_so_far) * double(area_removed_so_far) / double(base_length_2));
         const int64_t extrusion_area_error = calculateExtrusionAreaDeviationError(previous, current, next);
         // Orca: The value of `height_2` is squared, so we need to compare it with the squared value
-        if ((height_2 <= Slic3r::sqr(scaled<coord_t>(0.005)) // Almost exactly colinear (barring rounding errors).
-             && Line::distance_to_infinite(current.p, previous.p, next.p) <= scaled<double>(0.005)) // Make sure that height_2 is not small because of cancellation of positive and negative areas
+        if ((height_2 <= Slic3r::sqr(colinear_vertex_tolerance()) // Almost exactly colinear (barring rounding errors).
+             && Line::distance_to_infinite(current.p, previous.p, next.p) <= double(colinear_vertex_tolerance())) // Make sure that height_2 is not small because of cancellation of positive and negative areas
             // We shouldn't remove middle junctions of colinear segments if the area changed for the C-P segment is exceeding the maximum allowed
              && extrusion_area_error <= maximum_extrusion_area_deviation)
         {

--- a/src/libslic3r/Arachne/utils/ExtrusionLine.hpp
+++ b/src/libslic3r/Arachne/utils/ExtrusionLine.hpp
@@ -32,6 +32,14 @@ class Flow;
 namespace Slic3r::Arachne
 {
 
+// ORCA: Tolerance of the "almost exactly colinear" early-out shared by the two simplify() passes
+// (this file and WallToolPaths.cpp). That test drops a vertex regardless of the user's Maximum wall
+// resolution/deviation, so it has to stay at the scale of coordinate rounding noise. A larger value
+// silently decimates finely tessellated curves: on a circle, one vertex may be removed whenever the
+// sagitta of the resulting chord falls below the tolerance, which halves the point count and turns
+// smooth arcs into corners the firmware has to decelerate through.
+inline coord_t colinear_vertex_tolerance() { return coord_t(SCALED_EPSILON); }
+
 /*!
  * Represents a polyline (not just a line) that is to be extruded with variable
  * line width.


### PR DESCRIPTION
Fix Arachne ignoring the Maximum wall resolution/deviation settings on curved walls.
Reported by corgi108 at discord server.

Classic / Arachne
Before
<img width="2560" height="1305" alt="Captura de pantalla_20260820_192456" src="https://github.com/user-attachments/assets/6b4324d4-9012-49e5-88f3-13bbdbc7f380" />

After
<img width="1414" height="1006" alt="imagen" src="https://github.com/user-attachments/assets/babe63c8-0b54-40b8-9c8f-458cc30ab210" />

## Problem

Both Arachne `simplify()` passes drop a vertex when it looks "almost exactly
colinear" — without consulting `wall_maximum_resolution` or
`wall_maximum_deviation`. That tolerance was hardcoded to 5 µm, a print-scale
distance rather than the rounding noise the comment describes, so no user
setting could reach below it.

On a circle a vertex is dropped whenever the chord it spans is shorter than
`sqrt(8·r·tol)/2` — 0.27 mm at r = 7.4 mm. A 180-facet cylinder therefore
loses exactly every other point before Arachne even runs, doubling segment
length and turn angle. On the small inner rings of a heavily walled part that
means 25–48° corners, which firmware using junction deviation must decelerate
through. That is why an Arachne object looks mottled in the **Actual Speed**
preview next to a geometrically identical Classic one.

Slicing a Ø15 mm cylinder with 99 wall loops (Klipper, JD 0.01), Arachne spent
33 % of its wall length accelerating or decelerating against 0.03 % for
Classic, from the same mesh.

## Cause

#11925 correctly fixed a units bug here (`height_2` is squared, so it needs a
squared tolerance) but raised the value from `0.001` to `0.005` in the same
edit. Squaring *and* raising it turned an effective ~0.03 µm epsilon into a
real 5 µm one.

## Fix

Compare against `SCALED_EPSILON`, the constant this codebase already uses for
"same point, barring rounding", shared from one helper so the two copies of the
check can't drift apart.

## Verification

- **Stock defaults (0.5 / 0.025): G-code byte-identical** apart from the
  timestamp — the length/deviation rule already removed those vertices, so no
  regression for existing projects or profiles.
- **At 0.005 / 0.005**: Arachne walls now match Classic exactly (90 → 180
  points, 4.01° → 2.04° median turn). Ramping length 3.4 % → 0.0 %, estimated
  plate time 17 → 15 min.
- **Adversarial case** — rounded-rectangle prism with straight walls
  tessellated at 0.3 mm, at defaults: wall segment counts unchanged, +0.6 %
  G-code lines, identical time.
- **ctest**: same 23 pre-existing failures as unmodified `main`.

## Trade-off

Models with long, finely tessellated straight walls keep a few more vertices
(+0.6 % G-code worst case measured). Anyone wanting the old decimation still
has it — that is what `wall_maximum_resolution` at 0.5 mm does, untouched.


[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
