### PR TITLE
feat: add bridge bottom surface pattern process setting

### DIFF
--- a/src/libslic3r/Fill/Fill.cpp
+++ b/src/libslic3r/Fill/Fill.cpp
@@ -911,11 +911,25 @@ std::vector<SurfaceFill> group_fills(const Layer &layer, LockRegionParam &lock_p
                             params.density = float(region_config.top_surface_density);
                             if (params.density <= 0.0f) continue;
                         } else { // Surface is bottom
-                            params.pattern = region_config.bottom_surface_pattern.value;
+                            // Orca types a fully-supported overhang (support on, Top Z distance 0)
+                            // as stBottom, so is_bridge is false and the branch below never runs.
+                            // Honor this setting for those upper-layer bottoms when it is not Default;
+                            // Default keeps bottom_surface_pattern so existing behaviour is unchanged.
+                            if (layer.id() > 0 &&
+                                region_config.bridge_bottom_surface_pattern.value != BridgeBottomSurfacePattern::Default) {
+                                params.pattern = infill_pattern_for_bridge_bottom(region_config.bridge_bottom_surface_pattern.value,
+                                                                                 region_config.top_surface_pattern.value);
+                            } else {
+                                params.pattern = region_config.bottom_surface_pattern.value;
+                            }
                             params.density = float(region_config.bottom_surface_density);
                         }
                     } else if (surface.is_solid_infill()) {
                         params.pattern = region_config.internal_solid_infill_pattern.value;
+                        params.density = 100.f;
+                    } else if (is_bridge && surface.is_bottom()) {
+                        params.pattern = infill_pattern_for_bridge_bottom(region_config.bridge_bottom_surface_pattern.value,
+                                                                         region_config.top_surface_pattern.value);
                         params.density = 100.f;
                     } else {
                         if (region_config.top_surface_pattern == ipMonotonic || region_config.top_surface_pattern == ipMonotonicLine)

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -1062,6 +1062,7 @@ static std::vector<std::string> s_Preset_print_options{
     "top_surface_expansion_margin",
     "top_surface_expansion_direction",
     "bottom_surface_pattern",
+    "bridge_bottom_surface_pattern",
     "top_surface_fill_order",
     "bottom_surface_fill_order",
     "infill_direction",

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -280,6 +280,19 @@ static t_config_enum_values s_keys_map_InfillPattern {
 };
 CONFIG_OPTION_ENUM_DEFINE_STATIC_MAPS(InfillPattern)
 
+static t_config_enum_values s_keys_map_BridgeBottomSurfacePattern {
+    { "default",            int(BridgeBottomSurfacePattern::Default) },
+    { "monotonic",          int(BridgeBottomSurfacePattern::Monotonic) },
+    { "monotonicline",      int(BridgeBottomSurfacePattern::MonotonicLine) },
+    { "rectilinear",        int(BridgeBottomSurfacePattern::Rectilinear) },
+    { "alignedrectilinear", int(BridgeBottomSurfacePattern::AlignedRectilinear) },
+    { "concentric",         int(BridgeBottomSurfacePattern::Concentric) },
+    { "hilbertcurve",       int(BridgeBottomSurfacePattern::HilbertCurve) },
+    { "archimedeanchords",  int(BridgeBottomSurfacePattern::ArchimedeanChords) },
+    { "octagramspiral",     int(BridgeBottomSurfacePattern::OctagramSpiral) },
+};
+CONFIG_OPTION_ENUM_DEFINE_STATIC_MAPS(BridgeBottomSurfacePattern)
+
 static t_config_enum_values s_keys_map_IroningType {
     { "no ironing",     int(IroningType::NoIroning) },
     { "top",            int(IroningType::TopSurfaces) },
@@ -2366,6 +2379,19 @@ void PrintConfigDef::init_fff_params()
     def->enum_values = def_top_fill_pattern->enum_values;
     def->enum_labels = def_top_fill_pattern->enum_labels;
     def->set_default_value(new ConfigOptionEnum<InfillPattern>(ipMonotonic));
+
+    def = this->add("bridge_bottom_surface_pattern", coEnum);
+    def->label = L("Bridge bottom surface pattern");
+    def->category = L("Strength");
+    def->tooltip = L("Line pattern for the underside of bridges (overhangs printed over support or air). "
+                     "Default uses monotonic if the top surface is monotonic or monotonic line, otherwise rectilinear.");
+    def->enum_keys_map = &ConfigOptionEnum<BridgeBottomSurfacePattern>::get_enum_values();
+    def->enum_values.push_back("default");
+    def->enum_values.insert(def->enum_values.end(), def_top_fill_pattern->enum_values.begin(), def_top_fill_pattern->enum_values.end());
+    def->enum_labels.push_back(L("Default"));
+    def->enum_labels.insert(def->enum_labels.end(), def_top_fill_pattern->enum_labels.begin(), def_top_fill_pattern->enum_labels.end());
+    def->mode = comAdvanced;
+    def->set_default_value(new ConfigOptionEnum<BridgeBottomSurfacePattern>(BridgeBottomSurfacePattern::Default));
 
     def           = this->add("bottom_surface_density", coPercent);
     def->label    = L("Bottom surface density");
@@ -9057,6 +9083,7 @@ void PrintConfigDef::handle_legacy(t_config_option_key &opt_key, std::string &va
     } else if ((opt_key == "sparse_infill_pattern"         ||
                 opt_key == "top_surface_pattern"           ||
                 opt_key == "bottom_surface_pattern"        ||
+                opt_key == "bridge_bottom_surface_pattern" ||
                 opt_key == "internal_solid_infill_pattern" ||
                 opt_key == "ironing_pattern"               ||
                 opt_key == "support_ironing_pattern") && value == "zig-zag") {
@@ -11600,6 +11627,10 @@ std::map<std::string, std::string> validate(const FullPrintConfig &cfg, bool und
     // --bottom-fill-pattern
     if (! print_config_def.get("bottom_surface_pattern")->has_enum_value(cfg.bottom_surface_pattern.serialize())) {
         error_message.emplace("bottom_surface_pattern", L("invalid value ") + cfg.bottom_surface_pattern.serialize());
+    }
+
+    if (! print_config_def.get("bridge_bottom_surface_pattern")->has_enum_value(cfg.bridge_bottom_surface_pattern.serialize())) {
+        error_message.emplace("bridge_bottom_surface_pattern", L("invalid value ") + cfg.bridge_bottom_surface_pattern.serialize());
     }
 
     // --soild-fill-pattern

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -118,6 +118,37 @@ enum InfillPattern : int {
     ipCount,
 };
 
+// Pattern choices for bridge_bottom_surface_pattern. Default is setting behaviour, not a fill algorithm.
+// Order matches top/bottom surface pattern dropdowns, with Default first.
+enum class BridgeBottomSurfacePattern {
+    Default,
+    Monotonic,
+    MonotonicLine,
+    Rectilinear,
+    AlignedRectilinear,
+    Concentric,
+    HilbertCurve,
+    ArchimedeanChords,
+    OctagramSpiral,
+};
+
+inline InfillPattern infill_pattern_for_bridge_bottom(BridgeBottomSurfacePattern pattern, InfillPattern top_surface_pattern)
+{
+    switch (pattern) {
+    case BridgeBottomSurfacePattern::Default:
+        return (top_surface_pattern == ipMonotonic || top_surface_pattern == ipMonotonicLine) ? ipMonotonic : ipRectilinear;
+    case BridgeBottomSurfacePattern::Monotonic:          return ipMonotonic;
+    case BridgeBottomSurfacePattern::MonotonicLine:      return ipMonotonicLine;
+    case BridgeBottomSurfacePattern::Rectilinear:        return ipRectilinear;
+    case BridgeBottomSurfacePattern::AlignedRectilinear: return ipAlignedRectilinear;
+    case BridgeBottomSurfacePattern::Concentric:         return ipConcentric;
+    case BridgeBottomSurfacePattern::HilbertCurve:       return ipHilbertCurve;
+    case BridgeBottomSurfacePattern::ArchimedeanChords:  return ipArchimedeanChords;
+    case BridgeBottomSurfacePattern::OctagramSpiral:     return ipOctagramSpiral;
+    }
+    return ipRectilinear;
+}
+
 // Orca: Infill patterns whose alignment origin follows the fill bounding box, so the
 // "separated_infills" option can re-center them per connected body. Patterns evaluated in
 // absolute/global coordinates (Gyroid, TPMS, Honeycomb, CrossHatch, ...) or that are shape-relative
@@ -668,6 +699,7 @@ CONFIG_OPTION_ENUM_DECLARE_STATIC_MAPS(TopSurfaceExpansionDirection)
 CONFIG_OPTION_ENUM_DECLARE_STATIC_MAPS(WipeTowerType)
 CONFIG_OPTION_ENUM_DECLARE_STATIC_MAPS(NoiseType)
 CONFIG_OPTION_ENUM_DECLARE_STATIC_MAPS(InfillPattern)
+CONFIG_OPTION_ENUM_DECLARE_STATIC_MAPS(BridgeBottomSurfacePattern)
 CONFIG_OPTION_ENUM_DECLARE_STATIC_MAPS(IroningType)
 CONFIG_OPTION_ENUM_DECLARE_STATIC_MAPS(SlicingMode)
 CONFIG_OPTION_ENUM_DECLARE_STATIC_MAPS(SupportMaterialPattern)
@@ -1276,6 +1308,7 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionPercent,               bottom_surface_density))
     ((ConfigOptionEnum<InfillPattern>,  top_surface_pattern))
     ((ConfigOptionEnum<InfillPattern>,  bottom_surface_pattern))
+    ((ConfigOptionEnum<BridgeBottomSurfacePattern>, bridge_bottom_surface_pattern))
     ((ConfigOptionEnum<SurfaceFillOrder>, top_surface_fill_order))
     ((ConfigOptionEnum<SurfaceFillOrder>, bottom_surface_fill_order))
     ((ConfigOptionEnum<InfillPattern>, internal_solid_infill_pattern))

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -1393,6 +1393,7 @@ bool PrintObject::invalidate_state_by_config_options(
         } else if (
                opt_key == "top_surface_pattern"
             || opt_key == "bottom_surface_pattern"
+            || opt_key == "bridge_bottom_surface_pattern"
             || opt_key == "top_surface_fill_order"
             || opt_key == "bottom_surface_fill_order"
             || opt_key == "internal_solid_infill_pattern"

--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -755,6 +755,7 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig *config, in
     toggle_line("sparse_infill_smooth_factor", is_smoothable_infill_pattern(pattern, config->opt_int("fill_multiline")));
     toggle_field("top_surface_pattern", has_top_shell);
     toggle_field("bottom_surface_pattern", has_bottom_shell);
+    toggle_field("bridge_bottom_surface_pattern", have_infill || has_solid_infill);
     toggle_field("top_surface_density", has_top_shell_layers);
     toggle_field("bottom_surface_density", has_bottom_shell);
     toggle_field("top_layer_direction", has_top_shell);

--- a/src/slic3r/GUI/Field.cpp
+++ b/src/slic3r/GUI/Field.cpp
@@ -1746,6 +1746,7 @@ void Choice::set_value(const boost::any& value, bool change_event)
                 selection = val;
 
             if (m_opt_id == "top_surface_pattern" || m_opt_id == "bottom_surface_pattern" ||
+                m_opt_id == "bridge_bottom_surface_pattern" ||
                 m_opt_id == "internal_solid_infill_pattern" || m_opt_id == "sparse_infill_pattern" ||
                 m_opt_id == "support_base_pattern" || m_opt_id == "support_interface_pattern" ||
                 m_opt_id == "ironing_pattern" || m_opt_id == "support_ironing_pattern" ||
@@ -1849,6 +1850,7 @@ boost::any& Choice::get_value()
                 m_value = 0;
         }
         else if (   m_opt_id == "top_surface_pattern" || m_opt_id == "bottom_surface_pattern" ||
+                    m_opt_id == "bridge_bottom_surface_pattern" ||
                     m_opt_id == "internal_solid_infill_pattern" || m_opt_id == "sparse_infill_pattern" ||
                     m_opt_id == "support_base_pattern" || m_opt_id == "support_interface_pattern" ||
                     m_opt_id == "ironing_pattern" || m_opt_id == "support_ironing_pattern" ||

--- a/src/slic3r/GUI/GUI.cpp
+++ b/src/slic3r/GUI/GUI.cpp
@@ -322,6 +322,7 @@ static void add_config_substitutions(const ConfigSubstitutions& conf_substitutio
 
 			bool is_infill = def->opt_key == "top_surface_pattern"	   ||
 							 def->opt_key == "bottom_surface_pattern" ||
+							 def->opt_key == "bridge_bottom_surface_pattern" ||
 							 def->opt_key == "internal_solid_infill_pattern" ||
 							 def->opt_key == "support_base_pattern" ||
 							 def->opt_key == "support_interface_pattern" ||

--- a/src/slic3r/GUI/GUI_Factories.cpp
+++ b/src/slic3r/GUI/GUI_Factories.cpp
@@ -137,6 +137,7 @@ std::map<std::string, std::vector<SimpleSettingData>> SettingsFactory::PART_CATE
        {"top_surface_expansion_margin", "", 1},
        {"top_surface_expansion_direction", "", 1},
        {"bottom_surface_pattern", "", 1},
+       {"bridge_bottom_surface_pattern", "", 1},
        {"internal_solid_infill_pattern", "", 1},
        {"align_infill_direction_to_model", "", 1},
        {"extra_solid_infills", "", 1},

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -2780,6 +2780,7 @@ void TabPrint::build()
         optgroup->append_single_option_line("bottom_shell_thickness", "strength_settings_top_bottom_shells#shell-thickness");
         optgroup->append_single_option_line("bottom_surface_density", "strength_settings_top_bottom_shells#surface-density");
         optgroup->append_single_option_line("bottom_surface_pattern", "strength_settings_top_bottom_shells#surface-pattern");
+        optgroup->append_single_option_line("bridge_bottom_surface_pattern", "strength_settings_top_bottom_shells#surface-pattern");
         optgroup->append_single_option_line("bottom_surface_fill_order", "strength_settings_top_bottom_shells#fill-order");
         optgroup->append_single_option_line("bottom_layer_direction", "strength_settings_infill#top-bottom-direction");
         optgroup->append_single_option_line("center_of_surface_pattern", "strength_settings_top_bottom_shells#center-surface-pattern-on");

--- a/src/slic3r/GUI/UnsavedChangesDialog.cpp
+++ b/src/slic3r/GUI/UnsavedChangesDialog.cpp
@@ -1390,6 +1390,7 @@ static wxString get_string_value(std::string opt_key, const DynamicPrintConfig& 
         return get_string_from_enum(opt_key, config,
             opt_key == "top_surface_pattern" ||
             opt_key == "bottom_surface_pattern" ||
+            opt_key == "bridge_bottom_surface_pattern" ||
             opt_key == "internal_solid_infill_pattern" ||
             opt_key == "sparse_infill_pattern" ||
             opt_key == "ironing_pattern" ||
@@ -1402,6 +1403,7 @@ static wxString get_string_value(std::string opt_key, const DynamicPrintConfig& 
         return get_string_from_enum(opt_key, config,
             opt_key == "top_surface_pattern" ||
             opt_key == "bottom_surface_pattern" ||
+            opt_key == "bridge_bottom_surface_pattern" ||
             opt_key == "internal_solid_infill_pattern" ||
             opt_key == "sparse_infill_pattern" ||
             opt_key == "ironing_pattern" ||

--- a/tests/fff_print/test_fill.cpp
+++ b/tests/fff_print/test_fill.cpp
@@ -4,6 +4,7 @@
 #include <cmath>
 #include <map>
 #include <numeric>
+#include <set>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -536,6 +537,32 @@ static bool solid_role(ExtrusionRole role) { return is_solid_infill(role) && rol
 static bool sparse_role(ExtrusionRole role) { return role == erInternalInfill; }
 static bool ironing_role(ExtrusionRole role) { return role == erIroning; }
 
+// Rectilinear chains parallel lines into few paths; concentric emits one path per offset loop.
+static size_t infill_path_count(const Print &print, ExtrusionRole role, size_t min_layer_id = 0)
+{
+    size_t paths = 0;
+    for (const Layer *layer : print.objects().front()->layers()) {
+        if (layer->id() < min_layer_id)
+            continue;
+        for (const LayerRegion *region : layer->regions())
+            for (const ExtrusionEntity *entity : region->fills.flatten().entities) {
+                auto account = [&](const ExtrusionPath &path) {
+                    if (path.role() == role)
+                        ++paths;
+                };
+                if (auto *path = dynamic_cast<const ExtrusionPath *>(entity))
+                    account(*path);
+                else if (auto *multi = dynamic_cast<const ExtrusionMultiPath *>(entity))
+                    for (const ExtrusionPath &p : multi->paths)
+                        account(p);
+                else if (auto *loop = dynamic_cast<const ExtrusionLoop *>(entity))
+                    for (const ExtrusionPath &p : loop->paths)
+                        account(p);
+            }
+    }
+    return paths;
+}
+
 TEST_CASE("Infill rotation template is unaffected by a raft", "[Fill][Regression]")
 {
     // More angles than raft layers, so a raft cannot alias back to the same angle.
@@ -1021,4 +1048,73 @@ TEST_CASE("Smoothing multiline lightning infill keeps its outlines connected", "
     // The outlines are still rounded.
     REQUIRE(smooth.point_count > sharp.point_count);
     REQUIRE(smooth.sharp_turns < sharp.sharp_turns);
+}
+
+TEST_CASE("Bridge bottom surface pattern changes the underside infill of a bridge", "[Fill]")
+{
+    auto path_count_for = [](const char *pattern) {
+        Print print;
+        Slic3r::Test::init_and_process_print({Slic3r::Test::TestMesh::bridge}, print,
+                                            {{"bridge_bottom_surface_pattern", pattern},
+                                             {"top_surface_pattern", "rectilinear"},
+                                             {"enable_support", 0},
+                                             {"layer_height", 0.2},
+                                             {"sparse_infill_density", "20%"}});
+        REQUIRE_FALSE(print.objects().empty());
+        return infill_path_count(print, erBridgeInfill);
+    };
+
+    const size_t rectilinear = path_count_for("rectilinear");
+    const size_t concentric  = path_count_for("concentric");
+    REQUIRE(rectilinear > 0);
+    // Rectilinear chains parallel lines into few paths. Concentric emits one path
+    // per offset loop, so it must produce more paths if the setting switched the
+    // bridge underside pattern.
+    REQUIRE(concentric > rectilinear);
+}
+
+TEST_CASE("Bridge bottom surface pattern changes the underside of a supported overhang", "[Fill]")
+{
+    auto path_count_for = [](const char *pattern) {
+        Print print;
+        // Top Z distance 0 types the overhang as stBottom (erBottomSurface), not a bridge.
+        Slic3r::Test::init_and_process_print({Slic3r::Test::TestMesh::bridge}, print,
+                                            {{"bridge_bottom_surface_pattern", pattern},
+                                             {"top_surface_pattern", "rectilinear"},
+                                             {"bottom_surface_pattern", "rectilinear"},
+                                             {"enable_support", 1},
+                                             {"support_type", "normal(auto)"},
+                                             {"support_interface_top_layers", 3},
+                                             {"support_top_z_distance", 0},
+                                             {"bridge_no_support", 0},
+                                             {"layer_height", 0.2},
+                                             {"sparse_infill_density", "20%"}});
+        REQUIRE_FALSE(print.objects().empty());
+        return infill_path_count(print, erBottomSurface, 1);
+    };
+
+    const size_t rectilinear = path_count_for("rectilinear");
+    const size_t concentric  = path_count_for("concentric");
+    REQUIRE(rectilinear > 0);
+    REQUIRE(concentric > rectilinear);
+}
+
+TEST_CASE("Bridge bottom surface pattern does not change internal bridge infill", "[Fill]")
+{
+    auto path_count_for = [](const char *pattern) {
+        Print print;
+        Slic3r::Test::init_and_process_print({Slic3r::Test::cube(20)}, print,
+                                            {{"bridge_bottom_surface_pattern", pattern},
+                                             {"top_surface_pattern", "rectilinear"},
+                                             {"internal_solid_infill_pattern", "rectilinear"},
+                                             {"enable_support", 0},
+                                             {"layer_height", 0.2},
+                                             {"sparse_infill_density", "20%"}});
+        REQUIRE_FALSE(print.objects().empty());
+        return infill_path_count(print, erInternalBridgeInfill);
+    };
+
+    const size_t rectilinear = path_count_for("rectilinear");
+    REQUIRE(rectilinear > 0);
+    REQUIRE(path_count_for("concentric") == rectilinear);
 }

--- a/tests/libslic3r/test_config.cpp
+++ b/tests/libslic3r/test_config.cpp
@@ -828,3 +828,46 @@ SCENARIO("ConfigOptionVector::set_to_index throws on incompatible type", "[Confi
         }
     }
 }
+
+TEST_CASE("Default bridge bottom pattern follows the top surface monotonic choice", "[Config]")
+{
+    REQUIRE(infill_pattern_for_bridge_bottom(BridgeBottomSurfacePattern::Default, ipMonotonic) == ipMonotonic);
+    REQUIRE(infill_pattern_for_bridge_bottom(BridgeBottomSurfacePattern::Default, ipMonotonicLine) == ipMonotonic);
+    REQUIRE(infill_pattern_for_bridge_bottom(BridgeBottomSurfacePattern::Default, ipRectilinear) == ipRectilinear);
+    REQUIRE(infill_pattern_for_bridge_bottom(BridgeBottomSurfacePattern::Default, ipConcentric) == ipRectilinear);
+}
+
+TEST_CASE("Explicit bridge bottom pattern maps to the matching infill pattern", "[Config]")
+{
+    using BBSP = BridgeBottomSurfacePattern;
+    REQUIRE(infill_pattern_for_bridge_bottom(BBSP::Monotonic, ipRectilinear) == ipMonotonic);
+    REQUIRE(infill_pattern_for_bridge_bottom(BBSP::MonotonicLine, ipRectilinear) == ipMonotonicLine);
+    REQUIRE(infill_pattern_for_bridge_bottom(BBSP::Rectilinear, ipMonotonic) == ipRectilinear);
+    REQUIRE(infill_pattern_for_bridge_bottom(BBSP::AlignedRectilinear, ipMonotonic) == ipAlignedRectilinear);
+    REQUIRE(infill_pattern_for_bridge_bottom(BBSP::Concentric, ipMonotonic) == ipConcentric);
+    REQUIRE(infill_pattern_for_bridge_bottom(BBSP::HilbertCurve, ipMonotonic) == ipHilbertCurve);
+    REQUIRE(infill_pattern_for_bridge_bottom(BBSP::ArchimedeanChords, ipMonotonic) == ipArchimedeanChords);
+    REQUIRE(infill_pattern_for_bridge_bottom(BBSP::OctagramSpiral, ipMonotonic) == ipOctagramSpiral);
+}
+
+TEST_CASE("Bridge bottom surface pattern defaults to Default and accepts listed values", "[Config]")
+{
+    DynamicPrintConfig config = DynamicPrintConfig::full_print_config();
+    REQUIRE(config.opt_enum<BridgeBottomSurfacePattern>("bridge_bottom_surface_pattern") == BridgeBottomSurfacePattern::Default);
+    REQUIRE(config.validate().empty());
+
+    config.set_deserialize_strict("bridge_bottom_surface_pattern", "concentric");
+    REQUIRE(config.opt_enum<BridgeBottomSurfacePattern>("bridge_bottom_surface_pattern") == BridgeBottomSurfacePattern::Concentric);
+    REQUIRE(config.validate().empty());
+
+    REQUIRE_THROWS_AS(config.set_deserialize_strict("bridge_bottom_surface_pattern", "not-a-pattern"), BadOptionValueException);
+}
+
+TEST_CASE("Bridge bottom surface pattern remaps zig-zag to rectilinear", "[Config]")
+{
+    t_config_option_key key = "bridge_bottom_surface_pattern";
+    std::string value = "zig-zag";
+    PrintConfigDef::handle_legacy(key, value);
+    REQUIRE(key == "bridge_bottom_surface_pattern");
+    REQUIRE(value == "rectilinear");
+}


### PR DESCRIPTION
## Summary
- Add a process setting, **Bridge bottom surface pattern**, so users can choose the infill pattern for the underside of bridges (overhangs printed over support or air).
- Default preserves existing behaviour: monotonic when the top surface is monotonic or monotonic line, otherwise rectilinear. The dropdown matches top/bottom surface patterns, with Default first.
- Wired through print config, fill grouping, process presets, and the Strength → Top/bottom shells UI, including object/part overrides.

## Test plan
- [x] Slice a model with a bridge (or the test `bridge` mesh) and confirm Default still produces the previous monotonic/rectilinear underside infill.
- [x] Set **Bridge bottom surface pattern** to Concentric and reslice; the bridge underside should use concentric infill.
- [x] Confirm the option appears under Process → Strength → Top/bottom shells, after Bottom surface pattern, and in object/part Strength settings.
- [x] Confirm changing the option invalidates infill and does not change internal bridges.
- [x] `libslic3r_tests "[Config]"` and `fff_print_tests "[Fill]"` (CI / local if deps are built)

## Screenshots

Layer before the overhang, white layers are the support/raft interface (interface pattern set to concentric).

<img width="766" height="1253" alt="Screenshot 2026-08-21 at 16 44 09" src="https://github.com/user-attachments/assets/0924ea82-b7c2-4d00-a9b6-a1dde221650e" />

(Note: the circular artifact on the bottom model isn't caused by this change, it is caused by the modifier I added. Not sure it's an existing bug or intended behaviour.)

Layer showing the bottom of the overhang, top object has bridge bottom surface pattern left as "Default", bottom object has it set to "Concentric"

<img width="749" height="1269" alt="Screenshot 2026-08-21 at 16 44 17" src="https://github.com/user-attachments/assets/7e81a48a-554f-4e53-bc0c-64d4631c9ef5" />