### PR TITLE
fix: restore compile parallelism for clang-cl builds with the Visual Studio generator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -343,7 +343,10 @@ else ()
 endif ()
 
 if (MSVC)
-    if (SLIC3R_MSVC_COMPILE_PARALLEL AND NOT IS_CLANG_CL)
+    # /MP only matters for the VS generators, where CMake turns it into the
+    # MultiProcessorCompilation property. Ninja parallelises on its own, and
+    # clang-cl warns "argument unused" if the flag reaches it.
+    if (SLIC3R_MSVC_COMPILE_PARALLEL AND CMAKE_GENERATOR MATCHES "Visual Studio")
            add_compile_options(/MP)
     endif ()
     # /bigobj (Increase Number of Sections in .Obj file)


### PR DESCRIPTION
# Description

`/MP` was gated on `NOT IS_CLANG_CL`, so Visual Studio generator builds using the ClangCL toolset compile serially.

Under the VS generators CMake never passes `/MP` to the compiler. It sets the `MultiProcessorCompilation` project property and MSBuild acts on that, so skipping clang-cl removed the property and the parallelism with it.

Gating on the generator fixes that, and drops `/MP` from the Ninja path where it does nothing for either compiler and makes clang-cl warn `argument unused during compilation: '/MP'` once per translation unit.

Found by @RF47 while using the clang-cl support from #14375.

## Tests

Configure only, comparing what each generator emits. `MultiProcessorCompilation` counted in `src/libslic3r/libslic3r.vcxproj` (4 = one per configuration), `/MP` counted as a standalone flag in `build.ninja`.

| Generator + compiler | Before | After |
| --- | --- | --- |
| Visual Studio 18 2026 + cl.exe | x4 | x4 |
| Visual Studio 18 2026 + `-T ClangCL` | absent | x4 |
| Ninja + cl.exe | `/MP` on 744 command lines | 0 |
| Ninja + clang-cl | 0 | 0 |
