### PR TITLE
build: mark missing overrides and drop unused lambda captures (1,156 clang warnings)

### DIFF
--- a/src/libslic3r/Print.hpp
+++ b/src/libslic3r/Print.hpp
@@ -930,8 +930,8 @@ public:
     // If preview_data is not null, the preview_data is filled in for the G-code visualization (not used by the command line Slic3r).
     std::string         export_gcode(const std::string& path_template, GCodeProcessorResult* result, ThumbnailsGeneratorCallback thumbnail_cb = nullptr);
     //return 0 means successful
-    int                 export_cached_data(const std::string& dir_path, bool with_space=false);
-    int                 load_cached_data(const std::string& directory);
+    int                 export_cached_data(const std::string& dir_path, bool with_space=false) override;
+    int                 load_cached_data(const std::string& directory) override;
 
     // methods for handling state
     bool                is_step_done(PrintStep step) const { return Inherited::is_step_done(step); }

--- a/src/slic3r/GUI/CalibrationWizardSavePage.hpp
+++ b/src/slic3r/GUI/CalibrationWizardSavePage.hpp
@@ -193,7 +193,7 @@ public:
 
     void show_panels(CalibrationMethod method, const PrinterSeries printer_ser);
 
-    void on_device_connected(MachineObject* obj);
+    void on_device_connected(MachineObject* obj) override;
 
     void update(MachineObject* obj) override;
 

--- a/src/slic3r/GUI/CalibrationWizardStartPage.hpp
+++ b/src/slic3r/GUI/CalibrationWizardStartPage.hpp
@@ -48,8 +48,8 @@ public:
 
     void create_page(wxWindow* parent);
 
-    void on_reset_page();
-    void on_device_connected(MachineObject* obj);
+    void on_reset_page() override;
+    void on_device_connected(MachineObject* obj) override;
     void msw_rescale() override;
 };
 
@@ -63,8 +63,8 @@ public:
         long style = wxTAB_TRAVERSAL);
 
     void create_page(wxWindow* parent);
-    void on_reset_page();
-    void on_device_connected(MachineObject* obj);
+    void on_reset_page() override;
+    void on_device_connected(MachineObject* obj) override;
     void msw_rescale() override;
 };
 

--- a/src/slic3r/GUI/Field.hpp
+++ b/src/slic3r/GUI/Field.hpp
@@ -385,7 +385,7 @@ public:
 	wxWindow*		window{ nullptr };
 	void			BUILD() override;
     /// Propagate value from field to the OptionGroupe and Config after kill_focus/ENTER
-    void	        propagate_value() ;
+    void	        propagate_value() override;
 
     void			set_value(const std::string& value, bool change_event = false) {
 		m_disable_change_event = !change_event;
@@ -440,7 +440,7 @@ public:
 	wxWindow*		window{ nullptr };
 	void			BUILD() override;
 	// Propagate value from field to the OptionGroupe and Config after kill_focus/ENTER
-	void			propagate_value();
+	void			propagate_value() override;
 
     /* Under OSX: wxBitmapComboBox->GetWindowStyle() returns some weard value, 
      * so let use a flag, which has TRUE value for a control without wxCB_READONLY style

--- a/src/slic3r/GUI/Gizmos/GLGizmoBrimEars.hpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoBrimEars.hpp
@@ -85,7 +85,7 @@ public:
     void update_model_object();
     //ClippingPlane get_sla_clipping_plane() const;
 
-    bool is_selection_rectangle_dragging() const { return m_selection_rectangle.is_dragging(); }
+    bool is_selection_rectangle_dragging() const override { return m_selection_rectangle.is_dragging(); }
 
     bool wants_enter_leave_snapshots() const override { return true; }
     std::string get_gizmo_entering_text() const override { return _u8L("Entering Brim Ears"); }

--- a/src/slic3r/GUI/Gizmos/GLGizmoMeshBoolean.hpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoMeshBoolean.hpp
@@ -75,7 +75,7 @@ protected:
     virtual void on_render() override;
     virtual void on_set_state() override;
     virtual CommonGizmosDataID on_get_requirements() const override;
-    virtual void on_render_input_window(float x, float y, float bottom_limit);
+    virtual void on_render_input_window(float x, float y, float bottom_limit) override;
 
     void on_load(cereal::BinaryInputArchive &ar) override;
     void on_save(cereal::BinaryOutputArchive &ar) const override;

--- a/src/slic3r/GUI/Gizmos/GLGizmoMove.hpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoMove.hpp
@@ -67,7 +67,7 @@ protected:
     void on_register_raycasters_for_picking() override;
     void on_unregister_raycasters_for_picking() override;
     //BBS: GUI refactor: add object manipulation
-    virtual void on_render_input_window(float x, float y, float bottom_limit);
+    virtual void on_render_input_window(float x, float y, float bottom_limit) override;
 
 private:
     double calc_projection(const UpdateData& data) const;

--- a/src/slic3r/GUI/Gizmos/GLGizmoScale.hpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoScale.hpp
@@ -89,7 +89,7 @@ protected:
     virtual void on_register_raycasters_for_picking() override;
     virtual void on_unregister_raycasters_for_picking() override;
     //BBS: GUI refactor: add object manipulation
-    virtual void on_render_input_window(float x, float y, float bottom_limit);
+    virtual void on_render_input_window(float x, float y, float bottom_limit) override;
 
 private:
     void render_grabbers_connection(unsigned int id_1, unsigned int id_2, const ColorRGBA& color);

--- a/src/slic3r/GUI/Preferences.cpp
+++ b/src/slic3r/GUI/Preferences.cpp
@@ -79,7 +79,7 @@ public:
         Bind(wxEVT_LEFT_DOWN,    &WikiLabel::OnLeftDown, this);
     }
 
-    void SetLabel(const wxString& label)
+    void SetLabel(const wxString& label) override
     {
         m_label = label;
         m_last_wrap_width = -1; // force re-wrap

--- a/src/slic3r/GUI/PrintHostDialogs.hpp
+++ b/src/slic3r/GUI/PrintHostDialogs.hpp
@@ -163,7 +163,7 @@ public:
     BedType      bedType() const { return m_BedType; }
 
     virtual void                               init() override;
-    virtual std::map<std::string, std::string> extendedInfo() const
+    virtual std::map<std::string, std::string> extendedInfo() const override
     {
         return {{"bedType", std::to_string(static_cast<int>(m_BedType))},
                 {"timeLapse", std::to_string(m_timeLapse)},
@@ -200,7 +200,7 @@ public:
                                 PrintHost*                     printhost);
 
     virtual void                               init() override;
-    virtual std::map<std::string, std::string> extendedInfo() const;
+    virtual std::map<std::string, std::string> extendedInfo() const override;
 
 private:
     static constexpr const char* CONFIG_KEY_ENABLESELFTEST = "crealityprint_enable_self_test";

--- a/src/slic3r/GUI/SelectMachine.hpp
+++ b/src/slic3r/GUI/SelectMachine.hpp
@@ -522,7 +522,7 @@ public:
     bool is_timeout();
     int  update_print_required_data(Slic3r::DynamicPrintConfig config, Slic3r::Model model, Slic3r::PlateDataPtrs plate_data_list, std::string file_name, std::string file_path);
     void set_print_type(PrintFromType type) {m_print_type = type;};
-    bool Show(bool show);
+    bool Show(bool show) override;
     void show_init();
     bool do_ams_mapping(MachineObject *obj_,bool use_ams);
     bool get_ams_mapping_result(std::string& mapping_array_str, std::string& mapping_array_str2, std::string& ams_mapping_info) const;

--- a/src/slic3r/GUI/SendToPrinter.hpp
+++ b/src/slic3r/GUI/SendToPrinter.hpp
@@ -180,7 +180,7 @@ public:
     SendToPrinterDialog(Plater *plater = nullptr);
     ~SendToPrinterDialog();
 
-    bool Show(bool show);
+    bool Show(bool show) override;
     bool is_timeout();
     void on_rename_click(wxCommandEvent& event);
     void on_rename_enter();

--- a/src/slic3r/GUI/SyncAmsInfoDialog.hpp
+++ b/src/slic3r/GUI/SyncAmsInfoDialog.hpp
@@ -371,7 +371,7 @@ public:
     };
     FinishSyncAmsDialog(InputInfo &input_info);
     ~FinishSyncAmsDialog() override;
-    void deal_ok();
+    void deal_ok() override;
     void update_info(InputInfo& info);
     bool Layout() override;
 

--- a/src/slic3r/GUI/Tab.hpp
+++ b/src/slic3r/GUI/Tab.hpp
@@ -515,13 +515,13 @@ public:
 	bool has_key(std::string const &key);
 
 protected:
-	virtual void    activate_selected_page(std::function<void()> throw_if_canceled);
+	virtual void    activate_selected_page(std::function<void()> throw_if_canceled) override;
 
 	virtual void    on_value_change(const std::string& opt_key, const boost::any& value) override;
 
 	virtual void    notify_changed(ObjectBase * object) = 0;
 
-	virtual void	reload_config();
+	virtual void	reload_config() override;
 
 	virtual void	update_custom_dirty(std::vector<std::string> &dirty_options, std::vector<std::string> &nonsys_options) override;
 

--- a/src/slic3r/GUI/TabButton.hpp
+++ b/src/slic3r/GUI/TabButton.hpp
@@ -40,7 +40,7 @@ public:
 
     void SetBitmap(ScalableBitmap &bitmap);
 
-    bool Enable(bool enable = true);
+    bool Enable(bool enable = true) override;
 
     void Rescale();
 

--- a/src/slic3r/GUI/Tabbook.hpp
+++ b/src/slic3r/GUI/Tabbook.hpp
@@ -166,7 +166,7 @@ public:
         return true;
     }
 
-    bool RemovePage(size_t n)
+    bool RemovePage(size_t n) override
     {
         if (!wxBookCtrlBase::RemovePage(n))
             return false;

--- a/src/slic3r/GUI/UnsavedChangesDialog.hpp
+++ b/src/slic3r/GUI/UnsavedChangesDialog.hpp
@@ -343,7 +343,7 @@ public:
     UnsavedChangesDialog(const wxString &caption, const wxString &header, DynamicConfig *config, int from, int to, bool left_to_right, NozzleVolumeType nozzle);
     ~UnsavedChangesDialog() override = default;
 
-    int ShowModal();
+    int ShowModal() override;
 
     void        build(Preset::Type type, PresetCollection *dependent_presets, const std::string &new_selected_preset, const wxString &header = "");
     void update(Preset::Type type, PresetCollection* dependent_presets, const std::string& new_selected_preset, const wxString& header);

--- a/src/slic3r/GUI/Widgets/MultiNozzleSync.cpp
+++ b/src/slic3r/GUI/Widgets/MultiNozzleSync.cpp
@@ -630,7 +630,7 @@ NozzleListTable::NozzleListTable(wxWindow* parent) : wxPanel(parent,wxID_ANY,wxD
     SetSizer(sizer);
     Layout();
 
-    m_web_view->Bind(wxEVT_WEBVIEW_SCRIPT_MESSAGE_RECEIVED, [this,sizer](wxWebViewEvent& evt) {
+    m_web_view->Bind(wxEVT_WEBVIEW_SCRIPT_MESSAGE_RECEIVED, [this](wxWebViewEvent& evt) {
         std::string message = evt.GetString().ToStdString();
         BOOST_LOG_TRIVIAL(debug) << __FUNCTION__ << "Received message: " << message;
         try {
@@ -1168,8 +1168,8 @@ void MultiNozzleSyncDialog::UpdateButton(std::weak_ptr<DevNozzleRack> rack, bool
         m_cancel_btn->SetLabel(_L("Ignore"));
         m_confirm_btn->SetLabel(_L("Refresh"));
 
-        m_cancel_btn->Bind(wxEVT_LEFT_DOWN, [this, rack, ignore_opt](auto& e) {ignore_opt(); });
-        m_confirm_btn->Bind(wxEVT_LEFT_DOWN, [this, rack, refresh_cmd](auto& e) {refresh_cmd(); });
+        m_cancel_btn->Bind(wxEVT_LEFT_DOWN, [rack, ignore_opt](auto& e) {ignore_opt(); });
+        m_confirm_btn->Bind(wxEVT_LEFT_DOWN, [rack, refresh_cmd](auto& e) {refresh_cmd(); });
     }
     else if (has_unknown) {
         m_cancel_btn->Show();
@@ -1178,8 +1178,8 @@ void MultiNozzleSyncDialog::UpdateButton(std::weak_ptr<DevNozzleRack> rack, bool
         m_cancel_btn->SetLabel(_L("Ignore"));
         m_confirm_btn->SetLabel(_L("Refresh"));
 
-        m_cancel_btn->Bind(wxEVT_LEFT_DOWN, [this, rack, ignore_opt](auto& e) {ignore_opt(); });
-        m_confirm_btn->Bind(wxEVT_LEFT_DOWN, [this, rack, refresh_cmd](auto& e) {refresh_cmd(); });
+        m_cancel_btn->Bind(wxEVT_LEFT_DOWN, [rack, ignore_opt](auto& e) {ignore_opt(); });
+        m_confirm_btn->Bind(wxEVT_LEFT_DOWN, [rack, refresh_cmd](auto& e) {refresh_cmd(); });
     }
     else if (has_unreliable) {
         m_cancel_btn->Show();
@@ -1188,8 +1188,8 @@ void MultiNozzleSyncDialog::UpdateButton(std::weak_ptr<DevNozzleRack> rack, bool
         m_cancel_btn->SetLabel(_L("Refresh"));
         m_confirm_btn->SetLabel(_L("Confirm"));
 
-        m_cancel_btn->Bind(wxEVT_LEFT_DOWN, [this, rack, refresh_cmd](auto& e) {refresh_cmd(); });
-        m_confirm_btn->Bind(wxEVT_LEFT_DOWN, [this, rack, trust_cmd](auto& e) {trust_cmd(); });
+        m_cancel_btn->Bind(wxEVT_LEFT_DOWN, [rack, refresh_cmd](auto& e) {refresh_cmd(); });
+        m_confirm_btn->Bind(wxEVT_LEFT_DOWN, [rack, trust_cmd](auto& e) {trust_cmd(); });
 
     }
     else {

--- a/src/slic3r/GUI/Widgets/MultiNozzleSync.hpp
+++ b/src/slic3r/GUI/Widgets/MultiNozzleSync.hpp
@@ -167,7 +167,7 @@ class MultiNozzleSyncDialog : public DPIDialog
 {
 public:
     MultiNozzleSyncDialog(wxWindow* parent, std::weak_ptr<DevNozzleRack> rack);
-    virtual void on_dpi_changed(const wxRect& suggested_rect) {};
+    virtual void on_dpi_changed(const wxRect& suggested_rect) override {};
     std::vector<NozzleOption> GetNozzleOptions(const std::vector<MultiNozzleUtils::NozzleGroupInfo>& group_infos);
 
     std::optional<NozzleOption> GetSelectedOption() {

--- a/src/slic3r/GUI/Widgets/ProgressBar.hpp
+++ b/src/slic3r/GUI/Widgets/ProgressBar.hpp
@@ -56,7 +56,7 @@ protected:
     void         paintEvent(wxPaintEvent &evt);
     void         render(wxDC &dc);
     void         doRender(wxDC &dc);
-    virtual void DoSetSize(int x, int y, int width, int height, int sizeFlags = wxSIZE_AUTO);
+    virtual void DoSetSize(int x, int y, int width, int height, int sizeFlags = wxSIZE_AUTO) override;
 
 
 

--- a/src/slic3r/GUI/Widgets/ProgressDialog.hpp
+++ b/src/slic3r/GUI/Widgets/ProgressDialog.hpp
@@ -33,7 +33,7 @@ public:
 	void OnPaint(wxPaintEvent &evt);
     virtual ~ProgressDialog();
 
-    virtual void DoSetSize(int x, int y, int width, int height, int sizeFlags = wxSIZE_AUTO);
+    virtual void DoSetSize(int x, int y, int width, int height, int sizeFlags = wxSIZE_AUTO) override;
     bool Create(const wxString &title, const wxString &message, int maximum = 100, wxWindow *parent = NULL, int style = wxPD_APP_MODAL | wxPD_AUTO_HIDE);
 
     virtual bool Update(int value, const wxString &newmsg = wxEmptyString, bool *skip = NULL);

--- a/src/slic3r/GUI/Widgets/SideButton.hpp
+++ b/src/slic3r/GUI/Widgets/SideButton.hpp
@@ -31,7 +31,7 @@ public:
 
     void SetLayoutStyle(int style);
 
-    void SetLabel(const wxString& label);
+    void SetLabel(const wxString& label) override;
 
     bool SetForegroundColour(wxColour const & colour) override;
 
@@ -47,7 +47,7 @@ public:
 
     void SetBackgroundColor(StateColor const &color);
 
-    bool Enable(bool enable = true);
+    bool Enable(bool enable = true) override;
 
     void Rescale();
 

--- a/src/slic3r/GUI/Widgets/SpinInput.cpp
+++ b/src/slic3r/GUI/Widgets/SpinInput.cpp
@@ -75,7 +75,7 @@ void SpinInput::Create(wxWindow *parent,
     text_ctrl->Bind(wxEVT_KILL_FOCUS, &SpinInput::onTextLostFocus, this);
     text_ctrl->Bind(wxEVT_TEXT_ENTER, &SpinInput::onTextEnter, this);
     text_ctrl->Bind(wxEVT_KEY_DOWN, &SpinInput::keyPressed, this);
-    text_ctrl->Bind(wxEVT_RIGHT_DOWN, [this](auto &e) {}); // disable context menu
+    text_ctrl->Bind(wxEVT_RIGHT_DOWN, [](auto &e) {}); // disable context menu
     button_inc = createButton(true);
     button_dec = createButton(false);
     delta      = 0;

--- a/src/slic3r/GUI/Widgets/TabCtrl.hpp
+++ b/src/slic3r/GUI/Widgets/TabCtrl.hpp
@@ -63,7 +63,7 @@ public:
     bool IsVisible(unsigned int item) const;
 
 private:
-    virtual void DoSetSize(int x, int y, int width, int height, int sizeFlags = wxSIZE_AUTO);
+    virtual void DoSetSize(int x, int y, int width, int height, int sizeFlags = wxSIZE_AUTO) override;
 
 #ifdef __WIN32__
     WXLRESULT MSWWindowProc(WXUINT nMsg, WXWPARAM wParam, WXLPARAM lParam) override;

--- a/src/slic3r/GUI/Widgets/TempInput.cpp
+++ b/src/slic3r/GUI/Widgets/TempInput.cpp
@@ -134,7 +134,7 @@ void TempInput::Create(wxWindow *parent, wxString text, wxString label, wxString
             }
         }
     });
-    text_ctrl->Bind(wxEVT_RIGHT_DOWN, [this](auto &e) {}); // disable context menu
+    text_ctrl->Bind(wxEVT_RIGHT_DOWN, [](auto &e) {}); // disable context menu
     text_ctrl->Bind(wxEVT_LEFT_DOWN, [this](auto &e) {
         if (m_read_only) {
             return;

--- a/src/slic3r/GUI/Widgets/TempInput.hpp
+++ b/src/slic3r/GUI/Widgets/TempInput.hpp
@@ -107,7 +107,7 @@ public:
     wxString GetTagTemp() { return text_ctrl->GetValue(); }
     wxString GetCurrTemp() { return GetLabel(); }
     int get_max_temp() { return max_temp; }
-    void SetLabel(const wxString &label);
+    void SetLabel(const wxString &label) override;
 
     void SetTextColor(StateColor const &color);
 
@@ -128,7 +128,7 @@ public:
     void  ReSetOnChanging() { m_on_changing = false; }
 
 protected:
-    virtual void DoSetSize(int x, int y, int width, int height, int sizeFlags = wxSIZE_AUTO);
+    virtual void DoSetSize(int x, int y, int width, int height, int sizeFlags = wxSIZE_AUTO) override;
 
     void DoSetToolTipText(wxString const &tip) override;
 

--- a/src/slic3r/GUI/Widgets/TextInput.cpp
+++ b/src/slic3r/GUI/Widgets/TextInput.cpp
@@ -85,7 +85,7 @@ void TextInput::Create(wxWindow *     parent,
         e.SetId(GetId());
         ProcessEventLocally(e);
     });
-    text_ctrl->Bind(wxEVT_RIGHT_DOWN, [this](auto &e) {}); // disable context menu
+    text_ctrl->Bind(wxEVT_RIGHT_DOWN, [](auto &e) {}); // disable context menu
     if (!icon.IsEmpty()) {
         this->icon = ScalableBitmap(this, icon.ToStdString(), 16);
     }

--- a/src/slic3r/GUI/Widgets/TextInput.hpp
+++ b/src/slic3r/GUI/Widgets/TextInput.hpp
@@ -46,7 +46,7 @@ public:
     // Only meant to be used by inspector, not public API
     int GetCornerRadius() const { return static_cast<int>(radius); }
 
-    void SetLabel(const wxString& label);
+    void SetLabel(const wxString& label) override;
 
     void SetStaticTips(const wxString& tips, const wxBitmap& bitmap);
 
@@ -73,7 +73,7 @@ protected:
     virtual void OnEdit() {}
 
     virtual void DoSetSize(
-        int x, int y, int width, int height, int sizeFlags = wxSIZE_AUTO);
+        int x, int y, int width, int height, int sizeFlags = wxSIZE_AUTO) override;
 
     void DoSetToolTipText(wxString const &tip) override;
 

--- a/src/slic3r/GUI/Widgets/WebView.cpp
+++ b/src/slic3r/GUI/Widgets/WebView.cpp
@@ -104,7 +104,7 @@ DWORD DownloadAndInstallWV2RT() {
 class WebViewEdge : public wxWebViewEdge
 {
 public:
-    bool SetUserAgent(const wxString &userAgent)
+    bool SetUserAgent(const wxString &userAgent) override
     {
         bool dark = userAgent.Contains("dark");
         SetColorScheme(dark ? COREWEBVIEW2_PREFERRED_COLOR_SCHEME_DARK : COREWEBVIEW2_PREFERRED_COLOR_SCHEME_LIGHT);

--- a/src/slic3r/Utils/CrealityPrint.hpp
+++ b/src/slic3r/Utils/CrealityPrint.hpp
@@ -21,14 +21,14 @@ public:
     ~CrealityPrint() override = default;
 
     const char* get_name() const override;
-    virtual bool can_test() const { return true; };
+    virtual bool can_test() const override { return true; };
     std::string  get_host() const override;
     bool has_auto_discovery() const override { return true; }
 
     wxString                           get_test_ok_msg() const override;
     wxString                           get_test_failed_msg(wxString& msg) const override;
     virtual bool                       test(wxString& curl_msg) const override;
-    PrintHostPostUploadActions         get_post_upload_actions() const;
+    PrintHostPostUploadActions         get_post_upload_actions() const override;
     bool upload(PrintHostUpload upload_data, ProgressFn prorgess_fn, ErrorFn error_fn, InfoFn info_fn) const override;
     bool supports_multi_color_print() const;
     std::string query_boxes_info() const;

--- a/src/slic3r/Utils/ElegooLink.hpp
+++ b/src/slic3r/Utils/ElegooLink.hpp
@@ -32,10 +32,10 @@ public:
     PrintHostPostUploadActions get_post_upload_actions() const override;
 protected:
 #ifdef WIN32
-    virtual bool upload_inner_with_resolved_ip(PrintHostUpload upload_data, ProgressFn prorgess_fn, ErrorFn error_fn, InfoFn info_fn, const boost::asio::ip::address& resolved_addr) const;
+    virtual bool upload_inner_with_resolved_ip(PrintHostUpload upload_data, ProgressFn prorgess_fn, ErrorFn error_fn, InfoFn info_fn, const boost::asio::ip::address& resolved_addr) const override;
 #endif
-    virtual bool validate_version_text(const boost::optional<std::string> &version_text) const;
-    virtual bool upload_inner_with_host(PrintHostUpload upload_data, ProgressFn prorgess_fn, ErrorFn error_fn, InfoFn info_fn) const;
+    virtual bool validate_version_text(const boost::optional<std::string> &version_text) const override;
+    virtual bool upload_inner_with_host(PrintHostUpload upload_data, ProgressFn prorgess_fn, ErrorFn error_fn, InfoFn info_fn) const override;
 
 #ifdef WIN32
     virtual bool test_with_resolved_ip(wxString& curl_msg) const override;

--- a/src/slic3r/Utils/Obico.hpp
+++ b/src/slic3r/Utils/Obico.hpp
@@ -20,7 +20,7 @@ public:
     ~Obico() override = default;
 
     const char* get_name() const override;
-    virtual bool can_test() const { return true; };
+    virtual bool can_test() const override { return true; };
     bool has_auto_discovery() const override { return false; }
     bool is_cloud() const override { return true; }
     bool get_login_url(wxString& auth_url) const override;
@@ -30,7 +30,7 @@ public:
     wxString                           get_test_failed_msg(wxString& msg) const override;
     virtual bool                       test(wxString& curl_msg) const override;
     bool                               get_printers(wxArrayString& printers) const override;
-    PrintHostPostUploadActions         get_post_upload_actions() const;
+    PrintHostPostUploadActions         get_post_upload_actions() const override;
     bool upload(PrintHostUpload upload_data, ProgressFn prorgess_fn, ErrorFn error_fn, InfoFn info_fn) const override;
 
 protected:


### PR DESCRIPTION
# Description

Clears two mechanical clang warning categories. 52 one-token edits, no behaviour change.

`-Winconsistent-missing-override` is down to zero repo-wide, 42 declarations across 28 files. That makes `-Werror=inconsistent-missing-override` a one-line follow-up, so it can't come back. Each keyword goes only where clang had already resolved the declaration to a base virtual, so it records what the compiler already worked out. If any of them hadn't really overridden anything, the build would have failed rather than warned. The 1,146 lines come from 42 declarations because headers get re-diagnosed per translation unit.

`-Wunused-lambda-capture` is cleared in `src/slic3r/GUI/Widgets` only, 10 captures, leaving 235 sites elsewhere. clang doesn't report a capture whose type has a non-trivial destructor, since those can be held for their effect on a lifetime. The six `MultiNozzleSync.cpp` lambdas capture `[this, rack, ...]` where `rack` is a `std::weak_ptr`, and clang flags `this` but never `rack`. So only `this` and one raw `wxBoxSizer*` come out.

I used plain `override` rather than the `wxOVERRIDE` macro, which `wx/defs.h` marks obsolete and which `src/slic3r` already avoids 1742 to 113. Two of the lines sit inside `#ifdef` and only compile on Windows, `SetUserAgent` in `WebView.cpp` and `upload_inner_with_resolved_ip` in `ElegooLink.hpp`.

Measured on `upstream/main` as it stands, whose clang-cl leg still builds with a very wide warning set, which is why the totals under Tests are so large. #15328 narrows that policy. The two are independent, share no files, and can land in either order. `-Winconsistent-missing-override` is on by clang's default and `-Wunused-lambda-capture` comes in with `/W4`, so both categories are still reported under the narrower set and this PR takes the same 1,156 lines out of it.

# Screenshots/Recordings/Graphs

Not applicable, no user-visible change.

## Tests

Full clang-cl builds (VS clang 20.1.8, Ninja, Release) with and without the change, each from a wiped tree so everything is recompiled.

| category | before | after |
| --- | --- | --- |
| `-Winconsistent-missing-override` | 1,146 | 0 |
| `-Wunused-lambda-capture` | 312 | 302 |
| every category, whole build | 117,056 | 115,900 |

Both builds exited 0 and ran the same 760 build steps. The total dropped by exactly 1,156, which is 1,146 + 10, and no other category moved by even one warning. Windows clang-cl only, other platforms left to CI.

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
