### PR TITLE
Port over Prusament filament profiles for MK3/S and MK4/S from PrusaSlicer

### DIFF
--- a/resources/profiles/Prusa.json
+++ b/resources/profiles/Prusa.json
@@ -1,6 +1,6 @@
 {
 	"name": "Prusa",
-	"version": "02.04.00.03",
+	"version": "02.04.00.04",
 	"force_update": "0",
 	"description": "Prusa configurations",
 	"machine_model_list": [
@@ -2483,6 +2483,294 @@
 		{
 			"name": "Prusa Generic PLA Silk @MK4S 0.8",
 			"sub_path": "filament/Prusa Generic PLA Silk @MK4S 0.8.json"
+		},
+		{
+			"name": "Prusament PLA @MK3S",
+			"sub_path": "filament/Prusament PLA @MK3S.json"
+		},
+		{
+			"name": "Prusament PLA @MK4",
+			"sub_path": "filament/Prusament PLA @MK4.json"
+		},
+		{
+			"name": "Prusament PLA @MK4S",
+			"sub_path": "filament/Prusament PLA @MK4S.json"
+		},
+		{
+			"name": "Prusament PLA @MK4S 0.6",
+			"sub_path": "filament/Prusament PLA @MK4S 0.6.json"
+		},
+		{
+			"name": "Prusament PLA @MK4S 0.8",
+			"sub_path": "filament/Prusament PLA @MK4S 0.8.json"
+		},
+		{
+			"name": "Prusament PLA @MK4S HF0.4",
+			"sub_path": "filament/Prusament PLA @MK4S HF0.4.json"
+		},
+		{
+			"name": "Prusament PLA @MK4S HF0.5",
+			"sub_path": "filament/Prusament PLA @MK4S HF0.5.json"
+		},
+		{
+			"name": "Prusament PLA @MK4S HF0.6",
+			"sub_path": "filament/Prusament PLA @MK4S HF0.6.json"
+		},
+		{
+			"name": "Prusament PLA @MK4S HF0.8",
+			"sub_path": "filament/Prusament PLA @MK4S HF0.8.json"
+		},
+		{
+			"name": "Prusament rPLA @MK3S",
+			"sub_path": "filament/Prusament rPLA @MK3S.json"
+		},
+		{
+			"name": "Prusament rPLA @MK4",
+			"sub_path": "filament/Prusament rPLA @MK4.json"
+		},
+		{
+			"name": "Prusament rPLA @MK4S",
+			"sub_path": "filament/Prusament rPLA @MK4S.json"
+		},
+		{
+			"name": "Prusament rPLA @MK4S 0.6",
+			"sub_path": "filament/Prusament rPLA @MK4S 0.6.json"
+		},
+		{
+			"name": "Prusament rPLA @MK4S 0.8",
+			"sub_path": "filament/Prusament rPLA @MK4S 0.8.json"
+		},
+		{
+			"name": "Prusament rPLA @MK4S HF0.4",
+			"sub_path": "filament/Prusament rPLA @MK4S HF0.4.json"
+		},
+		{
+			"name": "Prusament rPLA @MK4S HF0.5",
+			"sub_path": "filament/Prusament rPLA @MK4S HF0.5.json"
+		},
+		{
+			"name": "Prusament rPLA @MK4S HF0.6",
+			"sub_path": "filament/Prusament rPLA @MK4S HF0.6.json"
+		},
+		{
+			"name": "Prusament rPLA @MK4S HF0.8",
+			"sub_path": "filament/Prusament rPLA @MK4S HF0.8.json"
+		},
+		{
+			"name": "Prusament PETG @MK3S",
+			"sub_path": "filament/Prusament PETG @MK3S.json"
+		},
+		{
+			"name": "Prusament PETG @MK4",
+			"sub_path": "filament/Prusament PETG @MK4.json"
+		},
+		{
+			"name": "Prusament PETG @MK4S",
+			"sub_path": "filament/Prusament PETG @MK4S.json"
+		},
+		{
+			"name": "Prusament PETG @MK4S 0.6",
+			"sub_path": "filament/Prusament PETG @MK4S 0.6.json"
+		},
+		{
+			"name": "Prusament PETG @MK4S 0.8",
+			"sub_path": "filament/Prusament PETG @MK4S 0.8.json"
+		},
+		{
+			"name": "Prusament PETG @MK4S HF0.4",
+			"sub_path": "filament/Prusament PETG @MK4S HF0.4.json"
+		},
+		{
+			"name": "Prusament PETG @MK4S HF0.5",
+			"sub_path": "filament/Prusament PETG @MK4S HF0.5.json"
+		},
+		{
+			"name": "Prusament PETG @MK4S HF0.6",
+			"sub_path": "filament/Prusament PETG @MK4S HF0.6.json"
+		},
+		{
+			"name": "Prusament PETG @MK4S HF0.8",
+			"sub_path": "filament/Prusament PETG @MK4S HF0.8.json"
+		},
+		{
+			"name": "Prusament ASA @MK3S",
+			"sub_path": "filament/Prusament ASA @MK3S.json"
+		},
+		{
+			"name": "Prusament ASA @MK4",
+			"sub_path": "filament/Prusament ASA @MK4.json"
+		},
+		{
+			"name": "Prusament ASA @MK4S",
+			"sub_path": "filament/Prusament ASA @MK4S.json"
+		},
+		{
+			"name": "Prusament ASA @MK4S 0.6",
+			"sub_path": "filament/Prusament ASA @MK4S 0.6.json"
+		},
+		{
+			"name": "Prusament ASA @MK4S 0.8",
+			"sub_path": "filament/Prusament ASA @MK4S 0.8.json"
+		},
+		{
+			"name": "Prusament ASA @MK4S HF0.4",
+			"sub_path": "filament/Prusament ASA @MK4S HF0.4.json"
+		},
+		{
+			"name": "Prusament ASA @MK4S HF0.5",
+			"sub_path": "filament/Prusament ASA @MK4S HF0.5.json"
+		},
+		{
+			"name": "Prusament ASA @MK4S HF0.6",
+			"sub_path": "filament/Prusament ASA @MK4S HF0.6.json"
+		},
+		{
+			"name": "Prusament ASA @MK4S HF0.8",
+			"sub_path": "filament/Prusament ASA @MK4S HF0.8.json"
+		},
+		{
+			"name": "Prusament PC Blend @MK3S",
+			"sub_path": "filament/Prusament PC Blend @MK3S.json"
+		},
+		{
+			"name": "Prusament PC Blend @MK4",
+			"sub_path": "filament/Prusament PC Blend @MK4.json"
+		},
+		{
+			"name": "Prusament PC Blend @MK4S",
+			"sub_path": "filament/Prusament PC Blend @MK4S.json"
+		},
+		{
+			"name": "Prusament PC Blend @MK4S 0.6",
+			"sub_path": "filament/Prusament PC Blend @MK4S 0.6.json"
+		},
+		{
+			"name": "Prusament PC Blend @MK4S 0.8",
+			"sub_path": "filament/Prusament PC Blend @MK4S 0.8.json"
+		},
+		{
+			"name": "Prusament PC Blend @MK4S HF0.4",
+			"sub_path": "filament/Prusament PC Blend @MK4S HF0.4.json"
+		},
+		{
+			"name": "Prusament PC Blend @MK4S HF0.5",
+			"sub_path": "filament/Prusament PC Blend @MK4S HF0.5.json"
+		},
+		{
+			"name": "Prusament PC Blend @MK4S HF0.6",
+			"sub_path": "filament/Prusament PC Blend @MK4S HF0.6.json"
+		},
+		{
+			"name": "Prusament PC Blend @MK4S HF0.8",
+			"sub_path": "filament/Prusament PC Blend @MK4S HF0.8.json"
+		},
+		{
+			"name": "Prusament PVB @MK3S",
+			"sub_path": "filament/Prusament PVB @MK3S.json"
+		},
+		{
+			"name": "Prusament PVB @MK4",
+			"sub_path": "filament/Prusament PVB @MK4.json"
+		},
+		{
+			"name": "Prusament PVB @MK4S",
+			"sub_path": "filament/Prusament PVB @MK4S.json"
+		},
+		{
+			"name": "Prusament PVB @MK4S 0.6",
+			"sub_path": "filament/Prusament PVB @MK4S 0.6.json"
+		},
+		{
+			"name": "Prusament PVB @MK4S 0.8",
+			"sub_path": "filament/Prusament PVB @MK4S 0.8.json"
+		},
+		{
+			"name": "Prusament PVB @MK4S HF0.4",
+			"sub_path": "filament/Prusament PVB @MK4S HF0.4.json"
+		},
+		{
+			"name": "Prusament PVB @MK4S HF0.5",
+			"sub_path": "filament/Prusament PVB @MK4S HF0.5.json"
+		},
+		{
+			"name": "Prusament PVB @MK4S HF0.6",
+			"sub_path": "filament/Prusament PVB @MK4S HF0.6.json"
+		},
+		{
+			"name": "Prusament PVB @MK4S HF0.8",
+			"sub_path": "filament/Prusament PVB @MK4S HF0.8.json"
+		},
+		{
+			"name": "Prusament PC Blend Carbon Fiber @MK3S",
+			"sub_path": "filament/Prusament PC Blend Carbon Fiber @MK3S.json"
+		},
+		{
+			"name": "Prusament PC Blend Carbon Fiber @MK4",
+			"sub_path": "filament/Prusament PC Blend Carbon Fiber @MK4.json"
+		},
+		{
+			"name": "Prusament PC Blend Carbon Fiber @MK4S",
+			"sub_path": "filament/Prusament PC Blend Carbon Fiber @MK4S.json"
+		},
+		{
+			"name": "Prusament PC Blend Carbon Fiber @MK4S 0.6",
+			"sub_path": "filament/Prusament PC Blend Carbon Fiber @MK4S 0.6.json"
+		},
+		{
+			"name": "Prusament PC Blend Carbon Fiber @MK4S 0.8",
+			"sub_path": "filament/Prusament PC Blend Carbon Fiber @MK4S 0.8.json"
+		},
+		{
+			"name": "Prusament PC Blend Carbon Fiber @MK4S HF0.4",
+			"sub_path": "filament/Prusament PC Blend Carbon Fiber @MK4S HF0.4.json"
+		},
+		{
+			"name": "Prusament PC Blend Carbon Fiber @MK4S HF0.5",
+			"sub_path": "filament/Prusament PC Blend Carbon Fiber @MK4S HF0.5.json"
+		},
+		{
+			"name": "Prusament PC Blend Carbon Fiber @MK4S HF0.6",
+			"sub_path": "filament/Prusament PC Blend Carbon Fiber @MK4S HF0.6.json"
+		},
+		{
+			"name": "Prusament PC Blend Carbon Fiber @MK4S HF0.8",
+			"sub_path": "filament/Prusament PC Blend Carbon Fiber @MK4S HF0.8.json"
+		},
+		{
+			"name": "Prusament PA11 Carbon Fiber @MK3S",
+			"sub_path": "filament/Prusament PA11 Carbon Fiber @MK3S.json"
+		},
+		{
+			"name": "Prusament PA11 Carbon Fiber @MK4",
+			"sub_path": "filament/Prusament PA11 Carbon Fiber @MK4.json"
+		},
+		{
+			"name": "Prusament PA11 Carbon Fiber @MK4S",
+			"sub_path": "filament/Prusament PA11 Carbon Fiber @MK4S.json"
+		},
+		{
+			"name": "Prusament PA11 Carbon Fiber @MK4S 0.6",
+			"sub_path": "filament/Prusament PA11 Carbon Fiber @MK4S 0.6.json"
+		},
+		{
+			"name": "Prusament PA11 Carbon Fiber @MK4S 0.8",
+			"sub_path": "filament/Prusament PA11 Carbon Fiber @MK4S 0.8.json"
+		},
+		{
+			"name": "Prusament PA11 Carbon Fiber @MK4S HF0.4",
+			"sub_path": "filament/Prusament PA11 Carbon Fiber @MK4S HF0.4.json"
+		},
+		{
+			"name": "Prusament PA11 Carbon Fiber @MK4S HF0.5",
+			"sub_path": "filament/Prusament PA11 Carbon Fiber @MK4S HF0.5.json"
+		},
+		{
+			"name": "Prusament PA11 Carbon Fiber @MK4S HF0.6",
+			"sub_path": "filament/Prusament PA11 Carbon Fiber @MK4S HF0.6.json"
+		},
+		{
+			"name": "Prusament PA11 Carbon Fiber @MK4S HF0.8",
+			"sub_path": "filament/Prusament PA11 Carbon Fiber @MK4S HF0.8.json"
 		}
 	],
 	"machine_list": [

--- a/resources/profiles/Prusa/filament/Prusament ASA @MK3S.json
+++ b/resources/profiles/Prusa/filament/Prusament ASA @MK3S.json
@@ -1,0 +1,39 @@
+{
+    "type": "filament",
+    "name": "Prusament ASA @MK3S",
+    "inherits": "fdm_filament_asa",
+    "from": "system",
+    "setting_id": "6axLRDqyMzSKivpv",
+    "filament_id": "Prusament ASA @MK3S",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Prusa MK3S 0.25 nozzle",
+        "Prusa MK3S 0.4 nozzle",
+        "Prusa MK3S 0.6 nozzle",
+        "Prusa MK3S 0.8 nozzle"
+    ],
+    "filament_cost": [
+        "35.28"
+    ],
+    "filament_density": [
+        "1.07"
+    ],
+    "filament_flow_ratio": [
+        "0.93"
+    ],
+    "filament_max_volumetric_speed": [
+        "11"
+    ],
+    "filament_spool_weight": [
+        "278"
+    ],
+    "filament_start_gcode": [
+        "; Filament gcode\nM900 K{if printer_notes=~/.*PRINTER_MODEL_MINI.*/ and nozzle_diameter[0]==0.6}0.12{elsif printer_notes=~/.*PRINTER_MODEL_MINI.*/ and nozzle_diameter[0]==0.8}0.06{elsif printer_notes=~/.*PRINTER_MODEL_MINI.*/}0.2{elsif nozzle_diameter[0]==0.8}0.01{elsif nozzle_diameter[0]==0.6}0.02{else}0.04{endif} ; Filament gcode LA 1.5\n{if printer_notes=~/.*PRINTER_MODEL_MINI.*/};{elsif printer_notes=~/.*PRINTER_HAS_BOWDEN.*/}M900 K200{elsif nozzle_diameter[0]==0.6}M900 K12{elsif nozzle_diameter[0]==0.8};{else}M900 K20{endif} ; Filament gcode LA 1.0"
+    ],
+    "filament_type": [
+        "ASA"
+    ],
+    "filament_vendor": [
+        "Prusa Polymers"
+    ]
+}

--- a/resources/profiles/Prusa/filament/Prusament ASA @MK4.json
+++ b/resources/profiles/Prusa/filament/Prusament ASA @MK4.json
@@ -1,0 +1,39 @@
+{
+    "type": "filament",
+    "name": "Prusament ASA @MK4",
+    "inherits": "fdm_filament_asa",
+    "from": "system",
+    "setting_id": "S4liaSXDqOT1o64k",
+    "filament_id": "Prusament ASA @MK4",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Prusa MK4 0.25 nozzle",
+        "Prusa MK4 0.4 nozzle",
+        "Prusa MK4 0.6 nozzle",
+        "Prusa MK4 0.8 nozzle"
+    ],
+    "filament_cost": [
+        "35.28"
+    ],
+    "filament_density": [
+        "1.07"
+    ],
+    "filament_flow_ratio": [
+        "0.93"
+    ],
+    "filament_max_volumetric_speed": [
+        "12"
+    ],
+    "filament_spool_weight": [
+        "278"
+    ],
+    "filament_start_gcode": [
+        "; Filament gcode\nM900 K{if nozzle_diameter[0]==0.4}0.03{elsif nozzle_diameter[0]==0.25}0.1{elsif nozzle_diameter[0]==0.3}0.06{elsif nozzle_diameter[0]==0.35}0.05{elsif nozzle_diameter[0]==0.5}0.03{elsif nozzle_diameter[0]==0.6}0.02{elsif nozzle_diameter[0]==0.8}0.01{else}0{endif} ; Filament gcode\n\n{if printer_notes=~/.*PRINTER_MODEL_MK4IS.*/}\nM572 S{if nozzle_diameter[0]==0.4}0.02{elsif nozzle_diameter[0]==0.5}0.018{elsif nozzle_diameter[0]==0.6}0.012{elsif nozzle_diameter[0]==0.8}0.01{elsif nozzle_diameter[0]==0.25}0.09{elsif nozzle_diameter[0]==0.3}0.065{else}0{endif} ; Filament gcode\n{endif}\n\nM142 S40 ; set heatbreak target temp"
+    ],
+    "filament_type": [
+        "ASA"
+    ],
+    "filament_vendor": [
+        "Prusa Polymers"
+    ]
+}

--- a/resources/profiles/Prusa/filament/Prusament ASA @MK4S 0.6.json
+++ b/resources/profiles/Prusa/filament/Prusament ASA @MK4S 0.6.json
@@ -1,0 +1,14 @@
+{
+    "type": "filament",
+    "name": "Prusament ASA @MK4S 0.6",
+    "inherits": "Prusament ASA @MK4S",
+    "from": "system",
+    "setting_id": "NjWtcE6qB6wUa6pc",
+    "filament_id": "Prusament ASA @MK4S 0.6",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Prusa MK4S 0.6 nozzle"
+    ],
+    "nozzle_temperature": "255",
+    "slow_down_layer_time": "15"
+}

--- a/resources/profiles/Prusa/filament/Prusament ASA @MK4S 0.8.json
+++ b/resources/profiles/Prusa/filament/Prusament ASA @MK4S 0.8.json
@@ -1,0 +1,15 @@
+{
+    "type": "filament",
+    "name": "Prusament ASA @MK4S 0.8",
+    "inherits": "Prusament ASA @MK4S",
+    "from": "system",
+    "setting_id": "Xeqlb6XMZBWZtRkd",
+    "filament_id": "Prusament ASA @MK4S 0.8",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Prusa MK4S 0.8 nozzle"
+    ],
+    "fan_max_speed": "15",
+    "fan_min_speed": "15",
+    "slow_down_layer_time": "18"
+}

--- a/resources/profiles/Prusa/filament/Prusament ASA @MK4S HF0.4.json
+++ b/resources/profiles/Prusa/filament/Prusament ASA @MK4S HF0.4.json
@@ -1,0 +1,21 @@
+{
+    "type": "filament",
+    "name": "Prusament ASA @MK4S HF0.4",
+    "inherits": "Prusament ASA @MK4S",
+    "from": "system",
+    "setting_id": "1N3BqmbZKCKh8v9N",
+    "filament_id": "Prusament ASA @MK4S HF0.4",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Prusa MK4S HF0.4 nozzle"
+    ],
+    "filament_max_volumetric_speed": [
+        "26"
+    ],
+    "filament_start_gcode": [
+        "M572 S{if nozzle_diameter[0]==0.4}0.02{elsif nozzle_diameter[0]==0.5}0.018{elsif nozzle_diameter[0]==0.6}0.015{elsif nozzle_diameter[0]==0.8}0.01{elsif nozzle_diameter[0]==0.25}0.09{elsif nozzle_diameter[0]==0.3}0.065{else}0{endif} ; Filament gcode\nM142 S40 ; set heatbreak target temp"
+    ],
+    "nozzle_temperature": "265",
+    "nozzle_temperature_initial_layer": "265",
+    "slow_down_layer_time": "15"
+}

--- a/resources/profiles/Prusa/filament/Prusament ASA @MK4S HF0.5.json
+++ b/resources/profiles/Prusa/filament/Prusament ASA @MK4S HF0.5.json
@@ -1,0 +1,15 @@
+{
+    "type": "filament",
+    "name": "Prusament ASA @MK4S HF0.5",
+    "inherits": "Prusament ASA @MK4S",
+    "from": "system",
+    "setting_id": "Se12CQUzRlCv6pHb",
+    "filament_id": "Prusament ASA @MK4S HF0.5",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Prusa MK4S HF0.5 nozzle"
+    ],
+    "filament_max_volumetric_speed": [
+        "27"
+    ]
+}

--- a/resources/profiles/Prusa/filament/Prusament ASA @MK4S HF0.6.json
+++ b/resources/profiles/Prusa/filament/Prusament ASA @MK4S HF0.6.json
@@ -1,0 +1,17 @@
+{
+    "type": "filament",
+    "name": "Prusament ASA @MK4S HF0.6",
+    "inherits": "Prusament ASA @MK4S",
+    "from": "system",
+    "setting_id": "ejFx8rfOt0hqS3kG",
+    "filament_id": "Prusament ASA @MK4S HF0.6",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Prusa MK4S HF0.6 nozzle"
+    ],
+    "fan_max_speed": "15",
+    "fan_min_speed": "15",
+    "filament_max_volumetric_speed": [
+        "34"
+    ]
+}

--- a/resources/profiles/Prusa/filament/Prusament ASA @MK4S HF0.8.json
+++ b/resources/profiles/Prusa/filament/Prusament ASA @MK4S HF0.8.json
@@ -1,0 +1,20 @@
+{
+    "type": "filament",
+    "name": "Prusament ASA @MK4S HF0.8",
+    "inherits": "Prusament ASA @MK4S",
+    "from": "system",
+    "setting_id": "fEVn3NwNrLU1NeWg",
+    "filament_id": "Prusament ASA @MK4S HF0.8",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Prusa MK4S HF0.8 nozzle"
+    ],
+    "fan_max_speed": "15",
+    "fan_min_speed": "15",
+    "filament_max_volumetric_speed": [
+        "36"
+    ],
+    "nozzle_temperature": "270",
+    "nozzle_temperature_initial_layer": "270",
+    "slow_down_layer_time": "20"
+}

--- a/resources/profiles/Prusa/filament/Prusament ASA @MK4S.json
+++ b/resources/profiles/Prusa/filament/Prusament ASA @MK4S.json
@@ -1,0 +1,52 @@
+{
+    "type": "filament",
+    "name": "Prusament ASA @MK4S",
+    "inherits": "fdm_filament_asa",
+    "from": "system",
+    "setting_id": "Gciz1m8uMxV9wogi",
+    "filament_id": "Prusament ASA @MK4S",
+    "instantiation": "true",
+    "close_fan_the_first_x_layers": "4",
+    "compatible_printers": [
+        "Prusa MK4S 0.25 nozzle",
+        "Prusa MK4S 0.3 nozzle",
+        "Prusa MK4S 0.4 nozzle",
+        "Prusa MK4S 0.5 nozzle"
+    ],
+    "default_filament_colour": "#FFF2EC",
+    "fan_cooling_layer_time": "20",
+    "fan_max_speed": "12",
+    "fan_min_speed": "12",
+    "filament_cost": [
+        "35.28"
+    ],
+    "filament_density": [
+        "1.07"
+    ],
+    "filament_end_gcode": [
+        "; Filament-specific end gcode"
+    ],
+    "filament_max_volumetric_speed": [
+        "15"
+    ],
+    "filament_minimal_purge_on_wipe_tower": "35",
+    "filament_notes": [
+        ""
+    ],
+    "filament_spool_weight": [
+        "278"
+    ],
+    "filament_start_gcode": [
+        "M900 K{if nozzle_diameter[filament_extruder_id]==0.4}0.04{elsif nozzle_diameter[filament_extruder_id]==0.25}0.1{elsif nozzle_diameter[filament_extruder_id]==0.3}0.06{elsif nozzle_diameter[filament_extruder_id]==0.35}0.05{elsif nozzle_diameter[filament_extruder_id]==0.5}0.03{elsif nozzle_diameter[filament_extruder_id]==0.6}0.02{elsif nozzle_diameter[filament_extruder_id]==0.8}0.01{else}0{endif} ; Filament gcode\n\n{if printer_notes=~/.*(MK4IS|XLIS|MK4S|MK3.9S).*/}\nM572 S{if nozzle_diameter[filament_extruder_id]==0.4}0.02{elsif nozzle_diameter[filament_extruder_id]==0.5}0.018{elsif nozzle_diameter[filament_extruder_id]==0.6}0.012{elsif nozzle_diameter[filament_extruder_id]==0.8}0.01{elsif nozzle_diameter[filament_extruder_id]==0.25}0.09{elsif nozzle_diameter[filament_extruder_id]==0.3}0.065{else}0{endif} ; Filament gcode\n{endif}\n\nM142 S40 ; set heatbreak target temp"
+    ],
+    "filament_type": [
+        "ASA"
+    ],
+    "filament_vendor": [
+        "Prusa Polymers"
+    ],
+    "hot_plate_temp": "110",
+    "overhang_fan_speed": "20",
+    "slow_down_layer_time": "10",
+    "slow_down_min_speed": "15"
+}

--- a/resources/profiles/Prusa/filament/Prusament PA11 Carbon Fiber @MK3S.json
+++ b/resources/profiles/Prusa/filament/Prusament PA11 Carbon Fiber @MK3S.json
@@ -1,0 +1,48 @@
+{
+    "type": "filament",
+    "name": "Prusament PA11 Carbon Fiber @MK3S",
+    "inherits": "fdm_filament_pa11cf",
+    "from": "system",
+    "setting_id": "NwYUwfN9nhSfE2C1",
+    "filament_id": "Prusament PA11 Carbon Fiber @MK3S",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Prusa MK3S 0.25 nozzle",
+        "Prusa MK3S 0.4 nozzle",
+        "Prusa MK3S 0.6 nozzle",
+        "Prusa MK3S 0.8 nozzle"
+    ],
+    "filament_cost": [
+        "124.99"
+    ],
+    "filament_density": [
+        "1.11"
+    ],
+    "filament_max_volumetric_speed": [
+        "6.5"
+    ],
+    "filament_spool_weight": [
+        "197"
+    ],
+    "filament_start_gcode": [
+        "; Filament gcode\nM900 K{if printer_notes=~/.*PRINTER_MODEL_MINI.*/ and nozzle_diameter[0]==0.6}0.12{elsif printer_notes=~/.*PRINTER_MODEL_MINI.*/ and nozzle_diameter[0]==0.8}0.06{elsif printer_notes=~/.*PRINTER_MODEL_MINI.*/}0.2{elsif nozzle_diameter[0]==0.8}0.01{elsif nozzle_diameter[0]==0.6}0.02{else}0.04{endif} ; Filament gcode LA 1.5\n{if printer_notes=~/.*PRINTER_MODEL_MINI.*/};{elsif printer_notes=~/.*PRINTER_HAS_BOWDEN.*/}M900 K200{elsif nozzle_diameter[0]==0.6}M900 K12{elsif nozzle_diameter[0]==0.8};{else}M900 K20{endif} ; Filament gcode LA 1.0"
+    ],
+    "filament_type": [
+        "PA11-CF"
+    ],
+    "filament_vendor": [
+        "Prusa Polymers"
+    ],
+    "hot_plate_temp": [
+        "115"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "90"
+    ],
+    "nozzle_temperature": [
+        "285"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "275"
+    ]
+}

--- a/resources/profiles/Prusa/filament/Prusament PA11 Carbon Fiber @MK4.json
+++ b/resources/profiles/Prusa/filament/Prusament PA11 Carbon Fiber @MK4.json
@@ -1,0 +1,48 @@
+{
+    "type": "filament",
+    "name": "Prusament PA11 Carbon Fiber @MK4",
+    "inherits": "fdm_filament_pa11cf",
+    "from": "system",
+    "setting_id": "a7kxY0dJGsGZn47w",
+    "filament_id": "Prusament PA11 Carbon Fiber @MK4",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Prusa MK4 0.25 nozzle",
+        "Prusa MK4 0.4 nozzle",
+        "Prusa MK4 0.6 nozzle",
+        "Prusa MK4 0.8 nozzle"
+    ],
+    "filament_cost": [
+        "124.99"
+    ],
+    "filament_density": [
+        "1.11"
+    ],
+    "filament_max_volumetric_speed": [
+        "6.5"
+    ],
+    "filament_spool_weight": [
+        "197"
+    ],
+    "filament_start_gcode": [
+        "; Filament gcode\nM900 K{if nozzle_diameter[0]==0.4}0.03{elsif nozzle_diameter[0]==0.25}0.1{elsif nozzle_diameter[0]==0.3}0.06{elsif nozzle_diameter[0]==0.35}0.05{elsif nozzle_diameter[0]==0.5}0.03{elsif nozzle_diameter[0]==0.6}0.02{elsif nozzle_diameter[0]==0.8}0.01{else}0{endif} ; Filament gcode\n\n{if printer_notes=~/.*PRINTER_MODEL_MK4IS.*/}\nM572 S{if nozzle_diameter[0]==0.4}0.02{elsif nozzle_diameter[0]==0.5}0.018{elsif nozzle_diameter[0]==0.6}0.012{elsif nozzle_diameter[0]==0.8}0.01{elsif nozzle_diameter[0]==0.25}0.09{elsif nozzle_diameter[0]==0.3}0.065{else}0{endif} ; Filament gcode\n{endif}\n\nM142 S40 ; set heatbreak target temp"
+    ],
+    "filament_type": [
+        "PA11-CF"
+    ],
+    "filament_vendor": [
+        "Prusa Polymers"
+    ],
+    "hot_plate_temp": [
+        "115"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "90"
+    ],
+    "nozzle_temperature": [
+        "285"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "275"
+    ]
+}

--- a/resources/profiles/Prusa/filament/Prusament PA11 Carbon Fiber @MK4S 0.6.json
+++ b/resources/profiles/Prusa/filament/Prusament PA11 Carbon Fiber @MK4S 0.6.json
@@ -1,0 +1,13 @@
+{
+    "type": "filament",
+    "name": "Prusament PA11 Carbon Fiber @MK4S 0.6",
+    "inherits": "Prusament PA11 Carbon Fiber @MK4S",
+    "from": "system",
+    "setting_id": "FBlyfsI1Ma2iAPNK",
+    "filament_id": "Prusament PA11 Carbon Fiber @MK4S 0.6",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Prusa MK4S 0.6 nozzle"
+    ],
+    "slow_down_layer_time": "15"
+}

--- a/resources/profiles/Prusa/filament/Prusament PA11 Carbon Fiber @MK4S 0.8.json
+++ b/resources/profiles/Prusa/filament/Prusament PA11 Carbon Fiber @MK4S 0.8.json
@@ -1,0 +1,15 @@
+{
+    "type": "filament",
+    "name": "Prusament PA11 Carbon Fiber @MK4S 0.8",
+    "inherits": "Prusament PA11 Carbon Fiber @MK4S",
+    "from": "system",
+    "setting_id": "0NFWsNglK5k71qTn",
+    "filament_id": "Prusament PA11 Carbon Fiber @MK4S 0.8",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Prusa MK4S 0.8 nozzle"
+    ],
+    "fan_max_speed": "15",
+    "fan_min_speed": "15",
+    "slow_down_layer_time": "18"
+}

--- a/resources/profiles/Prusa/filament/Prusament PA11 Carbon Fiber @MK4S HF0.4.json
+++ b/resources/profiles/Prusa/filament/Prusament PA11 Carbon Fiber @MK4S HF0.4.json
@@ -1,0 +1,16 @@
+{
+    "type": "filament",
+    "name": "Prusament PA11 Carbon Fiber @MK4S HF0.4",
+    "inherits": "Prusament PA11 Carbon Fiber @MK4S",
+    "from": "system",
+    "setting_id": "aye0FxF8I7iBveqa",
+    "filament_id": "Prusament PA11 Carbon Fiber @MK4S HF0.4",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Prusa MK4S HF0.4 nozzle"
+    ],
+    "filament_start_gcode": [
+        "M572 S{if nozzle_diameter[0]==0.4}0.02{elsif nozzle_diameter[0]==0.5}0.018{elsif nozzle_diameter[0]==0.6}0.015{elsif nozzle_diameter[0]==0.8}0.01{elsif nozzle_diameter[0]==0.25}0.09{elsif nozzle_diameter[0]==0.3}0.065{else}0{endif} ; Filament gcode\nM142 S40 ; set heatbreak target temp"
+    ],
+    "slow_down_layer_time": "15"
+}

--- a/resources/profiles/Prusa/filament/Prusament PA11 Carbon Fiber @MK4S HF0.5.json
+++ b/resources/profiles/Prusa/filament/Prusament PA11 Carbon Fiber @MK4S HF0.5.json
@@ -1,0 +1,12 @@
+{
+    "type": "filament",
+    "name": "Prusament PA11 Carbon Fiber @MK4S HF0.5",
+    "inherits": "Prusament PA11 Carbon Fiber @MK4S",
+    "from": "system",
+    "setting_id": "dKNDJrwKoWYdTM5u",
+    "filament_id": "Prusament PA11 Carbon Fiber @MK4S HF0.5",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Prusa MK4S HF0.5 nozzle"
+    ]
+}

--- a/resources/profiles/Prusa/filament/Prusament PA11 Carbon Fiber @MK4S HF0.6.json
+++ b/resources/profiles/Prusa/filament/Prusament PA11 Carbon Fiber @MK4S HF0.6.json
@@ -1,0 +1,14 @@
+{
+    "type": "filament",
+    "name": "Prusament PA11 Carbon Fiber @MK4S HF0.6",
+    "inherits": "Prusament PA11 Carbon Fiber @MK4S",
+    "from": "system",
+    "setting_id": "CwGIOx1Nds9lAZ2V",
+    "filament_id": "Prusament PA11 Carbon Fiber @MK4S HF0.6",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Prusa MK4S HF0.6 nozzle"
+    ],
+    "fan_max_speed": "15",
+    "fan_min_speed": "15"
+}

--- a/resources/profiles/Prusa/filament/Prusament PA11 Carbon Fiber @MK4S HF0.8.json
+++ b/resources/profiles/Prusa/filament/Prusament PA11 Carbon Fiber @MK4S HF0.8.json
@@ -1,0 +1,15 @@
+{
+    "type": "filament",
+    "name": "Prusament PA11 Carbon Fiber @MK4S HF0.8",
+    "inherits": "Prusament PA11 Carbon Fiber @MK4S",
+    "from": "system",
+    "setting_id": "GXVNLqFRsWlDtQzZ",
+    "filament_id": "Prusament PA11 Carbon Fiber @MK4S HF0.8",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Prusa MK4S HF0.8 nozzle"
+    ],
+    "fan_max_speed": "15",
+    "fan_min_speed": "15",
+    "slow_down_layer_time": "20"
+}

--- a/resources/profiles/Prusa/filament/Prusament PA11 Carbon Fiber @MK4S.json
+++ b/resources/profiles/Prusa/filament/Prusament PA11 Carbon Fiber @MK4S.json
@@ -1,0 +1,62 @@
+{
+    "type": "filament",
+    "name": "Prusament PA11 Carbon Fiber @MK4S",
+    "inherits": "fdm_filament_pa11cf",
+    "from": "system",
+    "setting_id": "bUXItT9R8S8cC0zq",
+    "filament_id": "Prusament PA11 Carbon Fiber @MK4S",
+    "instantiation": "true",
+    "close_fan_the_first_x_layers": "4",
+    "compatible_printers": [
+        "Prusa MK4S 0.25 nozzle",
+        "Prusa MK4S 0.3 nozzle",
+        "Prusa MK4S 0.4 nozzle",
+        "Prusa MK4S 0.5 nozzle"
+    ],
+    "fan_cooling_layer_time": "20",
+    "fan_max_speed": "12",
+    "fan_min_speed": "12",
+    "filament_cost": [
+        "124.99"
+    ],
+    "filament_density": [
+        "1.11"
+    ],
+    "filament_end_gcode": [
+        "; Filament-specific end gcode"
+    ],
+    "filament_max_volumetric_speed": [
+        "6.5"
+    ],
+    "filament_minimal_purge_on_wipe_tower": "35",
+    "filament_notes": [
+        ""
+    ],
+    "filament_spool_weight": [
+        "197"
+    ],
+    "filament_start_gcode": [
+        "M900 K{if nozzle_diameter[filament_extruder_id]==0.4}0.04{elsif nozzle_diameter[filament_extruder_id]==0.25}0.1{elsif nozzle_diameter[filament_extruder_id]==0.3}0.06{elsif nozzle_diameter[filament_extruder_id]==0.35}0.05{elsif nozzle_diameter[filament_extruder_id]==0.5}0.03{elsif nozzle_diameter[filament_extruder_id]==0.6}0.02{elsif nozzle_diameter[filament_extruder_id]==0.8}0.01{else}0{endif} ; Filament gcode\n\n{if printer_notes=~/.*(MK4IS|XLIS|MK4S|MK3.9S).*/}\nM572 S{if nozzle_diameter[filament_extruder_id]==0.4}0.02{elsif nozzle_diameter[filament_extruder_id]==0.5}0.018{elsif nozzle_diameter[filament_extruder_id]==0.6}0.012{elsif nozzle_diameter[filament_extruder_id]==0.8}0.01{elsif nozzle_diameter[filament_extruder_id]==0.25}0.09{elsif nozzle_diameter[filament_extruder_id]==0.3}0.065{else}0{endif} ; Filament gcode\n{endif}\n\nM142 S40 ; set heatbreak target temp"
+    ],
+    "filament_type": [
+        "PA11-CF"
+    ],
+    "filament_vendor": [
+        "Prusa Polymers"
+    ],
+    "hot_plate_temp": [
+        "115"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "90"
+    ],
+    "nozzle_temperature": [
+        "285"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "275"
+    ],
+    "overhang_fan_speed": "20",
+    "slow_down_layer_time": "10",
+    "slow_down_min_speed": "15"
+}

--- a/resources/profiles/Prusa/filament/Prusament PC Blend @MK3S.json
+++ b/resources/profiles/Prusa/filament/Prusament PC Blend @MK3S.json
@@ -1,0 +1,48 @@
+{
+    "type": "filament",
+    "name": "Prusament PC Blend @MK3S",
+    "inherits": "fdm_filament_pc",
+    "from": "system",
+    "setting_id": "CXCOX0SxF2ayfzJq",
+    "filament_id": "Prusament PC Blend @MK3S",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Prusa MK3S 0.25 nozzle",
+        "Prusa MK3S 0.4 nozzle",
+        "Prusa MK3S 0.6 nozzle",
+        "Prusa MK3S 0.8 nozzle"
+    ],
+    "filament_cost": [
+        "51.53"
+    ],
+    "filament_density": [
+        "1.22"
+    ],
+    "filament_max_volumetric_speed": [
+        "8"
+    ],
+    "filament_spool_weight": [
+        "278"
+    ],
+    "filament_start_gcode": [
+        "; Filament gcode\nM900 K{if printer_notes=~/.*PRINTER_MODEL_MINI.*/ and nozzle_diameter[0]==0.6}0.12{elsif printer_notes=~/.*PRINTER_MODEL_MINI.*/ and nozzle_diameter[0]==0.8}0.06{elsif printer_notes=~/.*PRINTER_MODEL_MINI.*/}0.2{elsif nozzle_diameter[0]==0.8}0.01{elsif nozzle_diameter[0]==0.6}0.02{else}0.04{endif} ; Filament gcode LA 1.5\n{if printer_notes=~/.*PRINTER_MODEL_MINI.*/};{elsif printer_notes=~/.*PRINTER_HAS_BOWDEN.*/}M900 K200{elsif nozzle_diameter[0]==0.6}M900 K12{elsif nozzle_diameter[0]==0.8};{else}M900 K20{endif} ; Filament gcode LA 1.0"
+    ],
+    "filament_type": [
+        "PC"
+    ],
+    "filament_vendor": [
+        "Prusa Polymers"
+    ],
+    "hot_plate_temp": [
+        "115"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "110"
+    ],
+    "nozzle_temperature": [
+        "275"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "275"
+    ]
+}

--- a/resources/profiles/Prusa/filament/Prusament PC Blend @MK4.json
+++ b/resources/profiles/Prusa/filament/Prusament PC Blend @MK4.json
@@ -1,0 +1,48 @@
+{
+    "type": "filament",
+    "name": "Prusament PC Blend @MK4",
+    "inherits": "fdm_filament_pc",
+    "from": "system",
+    "setting_id": "ZGYW1dcpquZnrAvh",
+    "filament_id": "Prusament PC Blend @MK4",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Prusa MK4 0.25 nozzle",
+        "Prusa MK4 0.4 nozzle",
+        "Prusa MK4 0.6 nozzle",
+        "Prusa MK4 0.8 nozzle"
+    ],
+    "filament_cost": [
+        "51.53"
+    ],
+    "filament_density": [
+        "1.22"
+    ],
+    "filament_max_volumetric_speed": [
+        "8"
+    ],
+    "filament_spool_weight": [
+        "278"
+    ],
+    "filament_start_gcode": [
+        "; Filament gcode\nM900 K{if nozzle_diameter[0]==0.4}0.03{elsif nozzle_diameter[0]==0.25}0.1{elsif nozzle_diameter[0]==0.3}0.06{elsif nozzle_diameter[0]==0.35}0.05{elsif nozzle_diameter[0]==0.5}0.03{elsif nozzle_diameter[0]==0.6}0.02{elsif nozzle_diameter[0]==0.8}0.01{else}0{endif} ; Filament gcode\n\n{if printer_notes=~/.*PRINTER_MODEL_MK4IS.*/}\nM572 S{if nozzle_diameter[0]==0.4}0.02{elsif nozzle_diameter[0]==0.5}0.018{elsif nozzle_diameter[0]==0.6}0.012{elsif nozzle_diameter[0]==0.8}0.01{elsif nozzle_diameter[0]==0.25}0.09{elsif nozzle_diameter[0]==0.3}0.065{else}0{endif} ; Filament gcode\n{endif}\n\nM142 S40 ; set heatbreak target temp"
+    ],
+    "filament_type": [
+        "PC"
+    ],
+    "filament_vendor": [
+        "Prusa Polymers"
+    ],
+    "hot_plate_temp": [
+        "115"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "110"
+    ],
+    "nozzle_temperature": [
+        "275"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "275"
+    ]
+}

--- a/resources/profiles/Prusa/filament/Prusament PC Blend @MK4S 0.6.json
+++ b/resources/profiles/Prusa/filament/Prusament PC Blend @MK4S 0.6.json
@@ -1,0 +1,13 @@
+{
+    "type": "filament",
+    "name": "Prusament PC Blend @MK4S 0.6",
+    "inherits": "Prusament PC Blend @MK4S",
+    "from": "system",
+    "setting_id": "xDACbSXabUy8mLgz",
+    "filament_id": "Prusament PC Blend @MK4S 0.6",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Prusa MK4S 0.6 nozzle"
+    ],
+    "slow_down_layer_time": "15"
+}

--- a/resources/profiles/Prusa/filament/Prusament PC Blend @MK4S 0.8.json
+++ b/resources/profiles/Prusa/filament/Prusament PC Blend @MK4S 0.8.json
@@ -1,0 +1,15 @@
+{
+    "type": "filament",
+    "name": "Prusament PC Blend @MK4S 0.8",
+    "inherits": "Prusament PC Blend @MK4S",
+    "from": "system",
+    "setting_id": "D9aLjfFHsSeQKmCN",
+    "filament_id": "Prusament PC Blend @MK4S 0.8",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Prusa MK4S 0.8 nozzle"
+    ],
+    "fan_max_speed": "15",
+    "fan_min_speed": "15",
+    "slow_down_layer_time": "18"
+}

--- a/resources/profiles/Prusa/filament/Prusament PC Blend @MK4S HF0.4.json
+++ b/resources/profiles/Prusa/filament/Prusament PC Blend @MK4S HF0.4.json
@@ -1,0 +1,16 @@
+{
+    "type": "filament",
+    "name": "Prusament PC Blend @MK4S HF0.4",
+    "inherits": "Prusament PC Blend @MK4S",
+    "from": "system",
+    "setting_id": "F9ojwwNwOFimrvA7",
+    "filament_id": "Prusament PC Blend @MK4S HF0.4",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Prusa MK4S HF0.4 nozzle"
+    ],
+    "filament_start_gcode": [
+        "M572 S{if nozzle_diameter[0]==0.4}0.02{elsif nozzle_diameter[0]==0.5}0.018{elsif nozzle_diameter[0]==0.6}0.015{elsif nozzle_diameter[0]==0.8}0.01{elsif nozzle_diameter[0]==0.25}0.09{elsif nozzle_diameter[0]==0.3}0.065{else}0{endif} ; Filament gcode\nM142 S40 ; set heatbreak target temp"
+    ],
+    "slow_down_layer_time": "15"
+}

--- a/resources/profiles/Prusa/filament/Prusament PC Blend @MK4S HF0.5.json
+++ b/resources/profiles/Prusa/filament/Prusament PC Blend @MK4S HF0.5.json
@@ -1,0 +1,12 @@
+{
+    "type": "filament",
+    "name": "Prusament PC Blend @MK4S HF0.5",
+    "inherits": "Prusament PC Blend @MK4S",
+    "from": "system",
+    "setting_id": "rnFCKXWalTbb1kCq",
+    "filament_id": "Prusament PC Blend @MK4S HF0.5",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Prusa MK4S HF0.5 nozzle"
+    ]
+}

--- a/resources/profiles/Prusa/filament/Prusament PC Blend @MK4S HF0.6.json
+++ b/resources/profiles/Prusa/filament/Prusament PC Blend @MK4S HF0.6.json
@@ -1,0 +1,14 @@
+{
+    "type": "filament",
+    "name": "Prusament PC Blend @MK4S HF0.6",
+    "inherits": "Prusament PC Blend @MK4S",
+    "from": "system",
+    "setting_id": "dCBGHyldKgJPtI58",
+    "filament_id": "Prusament PC Blend @MK4S HF0.6",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Prusa MK4S HF0.6 nozzle"
+    ],
+    "fan_max_speed": "15",
+    "fan_min_speed": "15"
+}

--- a/resources/profiles/Prusa/filament/Prusament PC Blend @MK4S HF0.8.json
+++ b/resources/profiles/Prusa/filament/Prusament PC Blend @MK4S HF0.8.json
@@ -1,0 +1,15 @@
+{
+    "type": "filament",
+    "name": "Prusament PC Blend @MK4S HF0.8",
+    "inherits": "Prusament PC Blend @MK4S",
+    "from": "system",
+    "setting_id": "7gGAWA0q7ZbcUg9l",
+    "filament_id": "Prusament PC Blend @MK4S HF0.8",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Prusa MK4S HF0.8 nozzle"
+    ],
+    "fan_max_speed": "15",
+    "fan_min_speed": "15",
+    "slow_down_layer_time": "20"
+}

--- a/resources/profiles/Prusa/filament/Prusament PC Blend @MK4S.json
+++ b/resources/profiles/Prusa/filament/Prusament PC Blend @MK4S.json
@@ -1,0 +1,62 @@
+{
+    "type": "filament",
+    "name": "Prusament PC Blend @MK4S",
+    "inherits": "fdm_filament_pc",
+    "from": "system",
+    "setting_id": "PnkaoPoBRavoeMJm",
+    "filament_id": "Prusament PC Blend @MK4S",
+    "instantiation": "true",
+    "close_fan_the_first_x_layers": "4",
+    "compatible_printers": [
+        "Prusa MK4S 0.25 nozzle",
+        "Prusa MK4S 0.3 nozzle",
+        "Prusa MK4S 0.4 nozzle",
+        "Prusa MK4S 0.5 nozzle"
+    ],
+    "fan_cooling_layer_time": "20",
+    "fan_max_speed": "12",
+    "fan_min_speed": "12",
+    "filament_cost": [
+        "51.53"
+    ],
+    "filament_density": [
+        "1.22"
+    ],
+    "filament_end_gcode": [
+        "; Filament-specific end gcode"
+    ],
+    "filament_max_volumetric_speed": [
+        "8"
+    ],
+    "filament_minimal_purge_on_wipe_tower": "35",
+    "filament_notes": [
+        ""
+    ],
+    "filament_spool_weight": [
+        "278"
+    ],
+    "filament_start_gcode": [
+        "M900 K{if nozzle_diameter[filament_extruder_id]==0.4}0.04{elsif nozzle_diameter[filament_extruder_id]==0.25}0.1{elsif nozzle_diameter[filament_extruder_id]==0.3}0.06{elsif nozzle_diameter[filament_extruder_id]==0.35}0.05{elsif nozzle_diameter[filament_extruder_id]==0.5}0.03{elsif nozzle_diameter[filament_extruder_id]==0.6}0.02{elsif nozzle_diameter[filament_extruder_id]==0.8}0.01{else}0{endif} ; Filament gcode\n\n{if printer_notes=~/.*(MK4IS|XLIS|MK4S|MK3.9S).*/}\nM572 S{if nozzle_diameter[filament_extruder_id]==0.4}0.02{elsif nozzle_diameter[filament_extruder_id]==0.5}0.018{elsif nozzle_diameter[filament_extruder_id]==0.6}0.012{elsif nozzle_diameter[filament_extruder_id]==0.8}0.01{elsif nozzle_diameter[filament_extruder_id]==0.25}0.09{elsif nozzle_diameter[filament_extruder_id]==0.3}0.065{else}0{endif} ; Filament gcode\n{endif}\n\nM142 S40 ; set heatbreak target temp"
+    ],
+    "filament_type": [
+        "PC"
+    ],
+    "filament_vendor": [
+        "Prusa Polymers"
+    ],
+    "hot_plate_temp": [
+        "115"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "110"
+    ],
+    "nozzle_temperature": [
+        "275"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "275"
+    ],
+    "overhang_fan_speed": "20",
+    "slow_down_layer_time": "10",
+    "slow_down_min_speed": "15"
+}

--- a/resources/profiles/Prusa/filament/Prusament PC Blend Carbon Fiber @MK3S.json
+++ b/resources/profiles/Prusa/filament/Prusament PC Blend Carbon Fiber @MK3S.json
@@ -1,0 +1,48 @@
+{
+    "type": "filament",
+    "name": "Prusament PC Blend Carbon Fiber @MK3S",
+    "inherits": "fdm_filament_pccf",
+    "from": "system",
+    "setting_id": "d9bHnNlPCrWYi9qR",
+    "filament_id": "Prusament PC Blend Carbon Fiber @MK3S",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Prusa MK3S 0.25 nozzle",
+        "Prusa MK3S 0.4 nozzle",
+        "Prusa MK3S 0.6 nozzle",
+        "Prusa MK3S 0.8 nozzle"
+    ],
+    "filament_cost": [
+        "74.99"
+    ],
+    "filament_density": [
+        "1.22"
+    ],
+    "filament_max_volumetric_speed": [
+        "8"
+    ],
+    "filament_spool_weight": [
+        "278"
+    ],
+    "filament_start_gcode": [
+        "; Filament gcode\nM900 K{if printer_notes=~/.*PRINTER_MODEL_MINI.*/ and nozzle_diameter[0]==0.6}0.12{elsif printer_notes=~/.*PRINTER_MODEL_MINI.*/ and nozzle_diameter[0]==0.8}0.06{elsif printer_notes=~/.*PRINTER_MODEL_MINI.*/}0.2{elsif nozzle_diameter[0]==0.8}0.01{elsif nozzle_diameter[0]==0.6}0.02{else}0.04{endif} ; Filament gcode LA 1.5\n{if printer_notes=~/.*PRINTER_MODEL_MINI.*/};{elsif printer_notes=~/.*PRINTER_HAS_BOWDEN.*/}M900 K200{elsif nozzle_diameter[0]==0.6}M900 K12{elsif nozzle_diameter[0]==0.8};{else}M900 K20{endif} ; Filament gcode LA 1.0"
+    ],
+    "filament_type": [
+        "PC-CF"
+    ],
+    "filament_vendor": [
+        "Prusa Polymers"
+    ],
+    "hot_plate_temp": [
+        "115"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "110"
+    ],
+    "nozzle_temperature": [
+        "285"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "285"
+    ]
+}

--- a/resources/profiles/Prusa/filament/Prusament PC Blend Carbon Fiber @MK4.json
+++ b/resources/profiles/Prusa/filament/Prusament PC Blend Carbon Fiber @MK4.json
@@ -1,0 +1,48 @@
+{
+    "type": "filament",
+    "name": "Prusament PC Blend Carbon Fiber @MK4",
+    "inherits": "fdm_filament_pccf",
+    "from": "system",
+    "setting_id": "AmzsXSosYtRhIQ4G",
+    "filament_id": "Prusament PC Blend Carbon Fiber @MK4",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Prusa MK4 0.25 nozzle",
+        "Prusa MK4 0.4 nozzle",
+        "Prusa MK4 0.6 nozzle",
+        "Prusa MK4 0.8 nozzle"
+    ],
+    "filament_cost": [
+        "74.99"
+    ],
+    "filament_density": [
+        "1.22"
+    ],
+    "filament_max_volumetric_speed": [
+        "8"
+    ],
+    "filament_spool_weight": [
+        "278"
+    ],
+    "filament_start_gcode": [
+        "; Filament gcode\nM900 K{if nozzle_diameter[0]==0.4}0.03{elsif nozzle_diameter[0]==0.25}0.1{elsif nozzle_diameter[0]==0.3}0.06{elsif nozzle_diameter[0]==0.35}0.05{elsif nozzle_diameter[0]==0.5}0.03{elsif nozzle_diameter[0]==0.6}0.02{elsif nozzle_diameter[0]==0.8}0.01{else}0{endif} ; Filament gcode\n\n{if printer_notes=~/.*PRINTER_MODEL_MK4IS.*/}\nM572 S{if nozzle_diameter[0]==0.4}0.02{elsif nozzle_diameter[0]==0.5}0.018{elsif nozzle_diameter[0]==0.6}0.012{elsif nozzle_diameter[0]==0.8}0.01{elsif nozzle_diameter[0]==0.25}0.09{elsif nozzle_diameter[0]==0.3}0.065{else}0{endif} ; Filament gcode\n{endif}\n\nM142 S40 ; set heatbreak target temp"
+    ],
+    "filament_type": [
+        "PC-CF"
+    ],
+    "filament_vendor": [
+        "Prusa Polymers"
+    ],
+    "hot_plate_temp": [
+        "115"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "110"
+    ],
+    "nozzle_temperature": [
+        "285"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "285"
+    ]
+}

--- a/resources/profiles/Prusa/filament/Prusament PC Blend Carbon Fiber @MK4S 0.6.json
+++ b/resources/profiles/Prusa/filament/Prusament PC Blend Carbon Fiber @MK4S 0.6.json
@@ -1,0 +1,13 @@
+{
+    "type": "filament",
+    "name": "Prusament PC Blend Carbon Fiber @MK4S 0.6",
+    "inherits": "Prusament PC Blend Carbon Fiber @MK4S",
+    "from": "system",
+    "setting_id": "cWC8gJcldfVtxPX6",
+    "filament_id": "Prusament PC Blend Carbon Fiber @MK4S 0.6",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Prusa MK4S 0.6 nozzle"
+    ],
+    "slow_down_layer_time": "15"
+}

--- a/resources/profiles/Prusa/filament/Prusament PC Blend Carbon Fiber @MK4S 0.8.json
+++ b/resources/profiles/Prusa/filament/Prusament PC Blend Carbon Fiber @MK4S 0.8.json
@@ -1,0 +1,15 @@
+{
+    "type": "filament",
+    "name": "Prusament PC Blend Carbon Fiber @MK4S 0.8",
+    "inherits": "Prusament PC Blend Carbon Fiber @MK4S",
+    "from": "system",
+    "setting_id": "00MDpPdEKLFIKRaD",
+    "filament_id": "Prusament PC Blend Carbon Fiber @MK4S 0.8",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Prusa MK4S 0.8 nozzle"
+    ],
+    "fan_max_speed": "15",
+    "fan_min_speed": "15",
+    "slow_down_layer_time": "18"
+}

--- a/resources/profiles/Prusa/filament/Prusament PC Blend Carbon Fiber @MK4S HF0.4.json
+++ b/resources/profiles/Prusa/filament/Prusament PC Blend Carbon Fiber @MK4S HF0.4.json
@@ -1,0 +1,16 @@
+{
+    "type": "filament",
+    "name": "Prusament PC Blend Carbon Fiber @MK4S HF0.4",
+    "inherits": "Prusament PC Blend Carbon Fiber @MK4S",
+    "from": "system",
+    "setting_id": "KGuzaSeGZHauDImP",
+    "filament_id": "Prusament PC Blend Carbon Fiber @MK4S HF0.4",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Prusa MK4S HF0.4 nozzle"
+    ],
+    "filament_start_gcode": [
+        "M572 S{if nozzle_diameter[0]==0.4}0.02{elsif nozzle_diameter[0]==0.5}0.018{elsif nozzle_diameter[0]==0.6}0.015{elsif nozzle_diameter[0]==0.8}0.01{elsif nozzle_diameter[0]==0.25}0.09{elsif nozzle_diameter[0]==0.3}0.065{else}0{endif} ; Filament gcode\nM142 S40 ; set heatbreak target temp"
+    ],
+    "slow_down_layer_time": "15"
+}

--- a/resources/profiles/Prusa/filament/Prusament PC Blend Carbon Fiber @MK4S HF0.5.json
+++ b/resources/profiles/Prusa/filament/Prusament PC Blend Carbon Fiber @MK4S HF0.5.json
@@ -1,0 +1,12 @@
+{
+    "type": "filament",
+    "name": "Prusament PC Blend Carbon Fiber @MK4S HF0.5",
+    "inherits": "Prusament PC Blend Carbon Fiber @MK4S",
+    "from": "system",
+    "setting_id": "OaosyMTYopgexb4a",
+    "filament_id": "Prusament PC Blend Carbon Fiber @MK4S HF0.5",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Prusa MK4S HF0.5 nozzle"
+    ]
+}

--- a/resources/profiles/Prusa/filament/Prusament PC Blend Carbon Fiber @MK4S HF0.6.json
+++ b/resources/profiles/Prusa/filament/Prusament PC Blend Carbon Fiber @MK4S HF0.6.json
@@ -1,0 +1,14 @@
+{
+    "type": "filament",
+    "name": "Prusament PC Blend Carbon Fiber @MK4S HF0.6",
+    "inherits": "Prusament PC Blend Carbon Fiber @MK4S",
+    "from": "system",
+    "setting_id": "6Y8rtcvi7pHhZZWc",
+    "filament_id": "Prusament PC Blend Carbon Fiber @MK4S HF0.6",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Prusa MK4S HF0.6 nozzle"
+    ],
+    "fan_max_speed": "15",
+    "fan_min_speed": "15"
+}

--- a/resources/profiles/Prusa/filament/Prusament PC Blend Carbon Fiber @MK4S HF0.8.json
+++ b/resources/profiles/Prusa/filament/Prusament PC Blend Carbon Fiber @MK4S HF0.8.json
@@ -1,0 +1,15 @@
+{
+    "type": "filament",
+    "name": "Prusament PC Blend Carbon Fiber @MK4S HF0.8",
+    "inherits": "Prusament PC Blend Carbon Fiber @MK4S",
+    "from": "system",
+    "setting_id": "ZV1h1rvEia2iAtzD",
+    "filament_id": "Prusament PC Blend Carbon Fiber @MK4S HF0.8",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Prusa MK4S HF0.8 nozzle"
+    ],
+    "fan_max_speed": "15",
+    "fan_min_speed": "15",
+    "slow_down_layer_time": "20"
+}

--- a/resources/profiles/Prusa/filament/Prusament PC Blend Carbon Fiber @MK4S.json
+++ b/resources/profiles/Prusa/filament/Prusament PC Blend Carbon Fiber @MK4S.json
@@ -1,0 +1,62 @@
+{
+    "type": "filament",
+    "name": "Prusament PC Blend Carbon Fiber @MK4S",
+    "inherits": "fdm_filament_pccf",
+    "from": "system",
+    "setting_id": "hsgqC40IgFV1nBFs",
+    "filament_id": "Prusament PC Blend Carbon Fiber @MK4S",
+    "instantiation": "true",
+    "close_fan_the_first_x_layers": "4",
+    "compatible_printers": [
+        "Prusa MK4S 0.25 nozzle",
+        "Prusa MK4S 0.3 nozzle",
+        "Prusa MK4S 0.4 nozzle",
+        "Prusa MK4S 0.5 nozzle"
+    ],
+    "fan_cooling_layer_time": "20",
+    "fan_max_speed": "12",
+    "fan_min_speed": "12",
+    "filament_cost": [
+        "74.99"
+    ],
+    "filament_density": [
+        "1.22"
+    ],
+    "filament_end_gcode": [
+        "; Filament-specific end gcode"
+    ],
+    "filament_max_volumetric_speed": [
+        "8"
+    ],
+    "filament_minimal_purge_on_wipe_tower": "35",
+    "filament_notes": [
+        ""
+    ],
+    "filament_spool_weight": [
+        "278"
+    ],
+    "filament_start_gcode": [
+        "M900 K{if nozzle_diameter[filament_extruder_id]==0.4}0.04{elsif nozzle_diameter[filament_extruder_id]==0.25}0.1{elsif nozzle_diameter[filament_extruder_id]==0.3}0.06{elsif nozzle_diameter[filament_extruder_id]==0.35}0.05{elsif nozzle_diameter[filament_extruder_id]==0.5}0.03{elsif nozzle_diameter[filament_extruder_id]==0.6}0.02{elsif nozzle_diameter[filament_extruder_id]==0.8}0.01{else}0{endif} ; Filament gcode\n\n{if printer_notes=~/.*(MK4IS|XLIS|MK4S|MK3.9S).*/}\nM572 S{if nozzle_diameter[filament_extruder_id]==0.4}0.02{elsif nozzle_diameter[filament_extruder_id]==0.5}0.018{elsif nozzle_diameter[filament_extruder_id]==0.6}0.012{elsif nozzle_diameter[filament_extruder_id]==0.8}0.01{elsif nozzle_diameter[filament_extruder_id]==0.25}0.09{elsif nozzle_diameter[filament_extruder_id]==0.3}0.065{else}0{endif} ; Filament gcode\n{endif}\n\nM142 S40 ; set heatbreak target temp"
+    ],
+    "filament_type": [
+        "PC-CF"
+    ],
+    "filament_vendor": [
+        "Prusa Polymers"
+    ],
+    "hot_plate_temp": [
+        "115"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "110"
+    ],
+    "nozzle_temperature": [
+        "285"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "285"
+    ],
+    "overhang_fan_speed": "20",
+    "slow_down_layer_time": "10",
+    "slow_down_min_speed": "15"
+}

--- a/resources/profiles/Prusa/filament/Prusament PETG @MK3S.json
+++ b/resources/profiles/Prusa/filament/Prusament PETG @MK3S.json
@@ -1,0 +1,78 @@
+{
+    "type": "filament",
+    "name": "Prusament PETG @MK3S",
+    "inherits": "fdm_filament_pet",
+    "from": "system",
+    "setting_id": "1Lq1vO0EjKGK7JnD",
+    "filament_id": "Prusament PETG @MK3S",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Prusa MK3S 0.25 nozzle",
+        "Prusa MK3S 0.4 nozzle",
+        "Prusa MK3S 0.6 nozzle",
+        "Prusa MK3S 0.8 nozzle"
+    ],
+    "fan_cooling_layer_time": [
+        "30"
+    ],
+    "fan_max_speed": [
+        "90"
+    ],
+    "fan_min_speed": [
+        "40"
+    ],
+    "filament_cost": [
+        "29.99"
+    ],
+    "filament_density": [
+        "1.27"
+    ],
+    "filament_flow_ratio": [
+        "0.98"
+    ],
+    "filament_max_volumetric_speed": [
+        "8"
+    ],
+    "filament_spool_weight": [
+        "278"
+    ],
+    "filament_start_gcode": [
+        "; filament start gcode\nM900 K{if printer_notes=~/.*PRINTER_MODEL_MINI.*/ and nozzle_diameter[0]==0.6}0.12{elsif printer_notes=~/.*PRINTER_MODEL_MINI.*/ and nozzle_diameter[0]==0.8}0.06{elsif printer_notes=~/.*PRINTER_MODEL_MINI.*/}0.2{elsif nozzle_diameter[0]==0.8}0.02{elsif nozzle_diameter[0]==0.6}0.04{else}0.08{endif} ; Filament gcode LA 1.5\n{if printer_notes=~/.*PRINTER_MODEL_MINI.*/};{elsif printer_notes=~/.*PRINTER_HAS_BOWDEN.*/}M900 K200{elsif nozzle_diameter[0]==0.6}M900 K24{elsif nozzle_diameter[0]==0.8};{else}M900 K45{endif} ; Filament gcode LA 1.0"
+    ],
+    "filament_type": [
+        "PETG"
+    ],
+    "filament_vendor": [
+        "Prusa Polymers"
+    ],
+    "hot_plate_temp": [
+        "85"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "85"
+    ],
+    "nozzle_temperature": [
+        "240"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "230"
+    ],
+    "overhang_fan_speed": [
+        "90"
+    ],
+    "overhang_fan_threshold": [
+        "25%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "slow_down_for_layer_cooling": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "8"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ]
+}

--- a/resources/profiles/Prusa/filament/Prusament PETG @MK4.json
+++ b/resources/profiles/Prusa/filament/Prusament PETG @MK4.json
@@ -1,0 +1,69 @@
+{
+    "type": "filament",
+    "name": "Prusament PETG @MK4",
+    "inherits": "fdm_filament_pet",
+    "from": "system",
+    "setting_id": "YB1aMpM57M1Wrhnw",
+    "filament_id": "Prusament PETG @MK4",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Prusa MK4 0.25 nozzle",
+        "Prusa MK4 0.4 nozzle",
+        "Prusa MK4 0.6 nozzle",
+        "Prusa MK4 0.8 nozzle"
+    ],
+    "fan_cooling_layer_time": [
+        "30"
+    ],
+    "fan_max_speed": [
+        "90"
+    ],
+    "fan_min_speed": [
+        "40"
+    ],
+    "filament_cost": [
+        "29.99"
+    ],
+    "filament_density": [
+        "1.27"
+    ],
+    "filament_flow_ratio": [
+        "0.95"
+    ],
+    "filament_max_volumetric_speed": [
+        "10"
+    ],
+    "filament_ramming_parameters": [
+        "250 100 42.4 42.4 42.4 42.4 42.4 | 0.05 42.4 0.45 42.4 0.95 42.4 1.45 42.4 1.95 42.4 2.45 42.4 2.95 42.4 3.45 42.4 3.95 42.4 4.45 42.4 4.95 42.4"
+    ],
+    "filament_spool_weight": [
+        "278"
+    ],
+    "filament_start_gcode": [
+        "; filament start gcode\nM900 K{if nozzle_diameter[0]==0.4}0.035{elsif nozzle_diameter[0]==0.25}0.12{elsif nozzle_diameter[0]==0.3}0.09{elsif nozzle_diameter[0]==0.35}0.08{elsif nozzle_diameter[0]==0.6}0.04{elsif nozzle_diameter[0]==0.5}0.05{elsif nozzle_diameter[0]==0.8}0.02{else}0{endif} ; Filament gcode\n\n{if printer_notes=~/.*PRINTER_MODEL_MK4IS.*/}\nM572 S{if nozzle_diameter[0]==0.4}0.055{elsif nozzle_diameter[0]==0.5}0.042{elsif nozzle_diameter[0]==0.6}0.025{elsif nozzle_diameter[0]==0.8}0.018{elsif nozzle_diameter[0]==0.25}0.18{elsif nozzle_diameter[0]==0.3}0.1{else}0{endif} ; Filament gcode\n{endif}\n\nM142 S36 ; set heatbreak target temp"
+    ],
+    "filament_type": [
+        "PETG"
+    ],
+    "filament_vendor": [
+        "Prusa Polymers"
+    ],
+    "overhang_fan_speed": [
+        "90"
+    ],
+    "overhang_fan_threshold": [
+        "25%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "slow_down_for_layer_cooling": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "8"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ]
+}

--- a/resources/profiles/Prusa/filament/Prusament PETG @MK4S 0.6.json
+++ b/resources/profiles/Prusa/filament/Prusament PETG @MK4S 0.6.json
@@ -1,0 +1,18 @@
+{
+    "type": "filament",
+    "name": "Prusament PETG @MK4S 0.6",
+    "inherits": "Prusament PETG @MK4S",
+    "from": "system",
+    "setting_id": "4IeTOEFPCTCEBwU1",
+    "filament_id": "Prusament PETG @MK4S 0.6",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Prusa MK4S 0.6 nozzle"
+    ],
+    "fan_cooling_layer_time": "22",
+    "filament_max_volumetric_speed": [
+        "17"
+    ],
+    "overhang_fan_speed": "45",
+    "slow_down_layer_time": "10"
+}

--- a/resources/profiles/Prusa/filament/Prusament PETG @MK4S 0.8.json
+++ b/resources/profiles/Prusa/filament/Prusament PETG @MK4S 0.8.json
@@ -1,0 +1,23 @@
+{
+    "type": "filament",
+    "name": "Prusament PETG @MK4S 0.8",
+    "inherits": "Prusament PETG @MK4S",
+    "from": "system",
+    "setting_id": "bbyfFv8Lm1scbO48",
+    "filament_id": "Prusament PETG @MK4S 0.8",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Prusa MK4S 0.8 nozzle"
+    ],
+    "fan_cooling_layer_time": "25",
+    "fan_max_speed": "45",
+    "fan_min_speed": "25",
+    "filament_max_volumetric_speed": [
+        "22"
+    ],
+    "filament_retract_before_wipe": "50",
+    "nozzle_temperature": "245",
+    "nozzle_temperature_initial_layer": "240",
+    "overhang_fan_speed": "45",
+    "slow_down_layer_time": "18"
+}

--- a/resources/profiles/Prusa/filament/Prusament PETG @MK4S HF0.4.json
+++ b/resources/profiles/Prusa/filament/Prusament PETG @MK4S HF0.4.json
@@ -1,0 +1,23 @@
+{
+    "type": "filament",
+    "name": "Prusament PETG @MK4S HF0.4",
+    "inherits": "Prusament PETG @MK4S",
+    "from": "system",
+    "setting_id": "PCkfLeCKekadlalX",
+    "filament_id": "Prusament PETG @MK4S HF0.4",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Prusa MK4S HF0.4 nozzle"
+    ],
+    "filament_max_volumetric_speed": [
+        "24"
+    ],
+    "filament_ramming_parameters": [
+        "250 100 42.4 42.4 | 0.05 42.4 0.45 42.4 0.95 42.4 1.45 42.4 1.95 42.4 2.45 42.4 2.95 42.4 3.45 42.4 3.95 42.4 4.45 42.4 4.95 42.4"
+    ],
+    "filament_start_gcode": [
+        "M572 S{if nozzle_diameter[0]==0.4}0.05{elsif nozzle_diameter[0]==0.5}0.044{elsif nozzle_diameter[0]==0.6}0.035{elsif nozzle_diameter[0]==0.8}0.022{elsif nozzle_diameter[0]==0.25}0.18{elsif nozzle_diameter[0]==0.3}0.1{else}0{endif} ; Filament gcode\n\nM142 S36 ; set heatbreak target temp"
+    ],
+    "nozzle_temperature": "245",
+    "nozzle_temperature_initial_layer": "235"
+}

--- a/resources/profiles/Prusa/filament/Prusament PETG @MK4S HF0.5.json
+++ b/resources/profiles/Prusa/filament/Prusament PETG @MK4S HF0.5.json
@@ -1,0 +1,15 @@
+{
+    "type": "filament",
+    "name": "Prusament PETG @MK4S HF0.5",
+    "inherits": "Prusament PETG @MK4S",
+    "from": "system",
+    "setting_id": "HayDpO5Htl0tfaym",
+    "filament_id": "Prusament PETG @MK4S HF0.5",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Prusa MK4S HF0.5 nozzle"
+    ],
+    "filament_max_volumetric_speed": [
+        "29"
+    ]
+}

--- a/resources/profiles/Prusa/filament/Prusament PETG @MK4S HF0.6.json
+++ b/resources/profiles/Prusa/filament/Prusament PETG @MK4S HF0.6.json
@@ -1,0 +1,20 @@
+{
+    "type": "filament",
+    "name": "Prusament PETG @MK4S HF0.6",
+    "inherits": "Prusament PETG @MK4S",
+    "from": "system",
+    "setting_id": "WtNF07X5vNklj181",
+    "filament_id": "Prusament PETG @MK4S HF0.6",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Prusa MK4S HF0.6 nozzle"
+    ],
+    "fan_cooling_layer_time": "22",
+    "filament_max_volumetric_speed": [
+        "33"
+    ],
+    "nozzle_temperature": "240",
+    "nozzle_temperature_initial_layer": "230",
+    "overhang_fan_speed": "45",
+    "slow_down_layer_time": "10"
+}

--- a/resources/profiles/Prusa/filament/Prusament PETG @MK4S HF0.8.json
+++ b/resources/profiles/Prusa/filament/Prusament PETG @MK4S HF0.8.json
@@ -1,0 +1,21 @@
+{
+    "type": "filament",
+    "name": "Prusament PETG @MK4S HF0.8",
+    "inherits": "Prusament PETG @MK4S",
+    "from": "system",
+    "setting_id": "wQHkNi9PUdQBELEy",
+    "filament_id": "Prusament PETG @MK4S HF0.8",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Prusa MK4S HF0.8 nozzle"
+    ],
+    "fan_cooling_layer_time": "25",
+    "fan_max_speed": "45",
+    "filament_max_volumetric_speed": [
+        "37"
+    ],
+    "filament_retract_before_wipe": "50",
+    "nozzle_temperature_initial_layer": "240",
+    "overhang_fan_speed": "45",
+    "slow_down_layer_time": "18"
+}

--- a/resources/profiles/Prusa/filament/Prusament PETG @MK4S.json
+++ b/resources/profiles/Prusa/filament/Prusament PETG @MK4S.json
@@ -1,0 +1,60 @@
+{
+    "type": "filament",
+    "name": "Prusament PETG @MK4S",
+    "inherits": "fdm_filament_pet",
+    "from": "system",
+    "setting_id": "J83RtTwoqDdTBPW2",
+    "filament_id": "Prusament PETG @MK4S",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Prusa MK4S 0.25 nozzle",
+        "Prusa MK4S 0.3 nozzle",
+        "Prusa MK4S 0.4 nozzle",
+        "Prusa MK4S 0.5 nozzle"
+    ],
+    "default_filament_colour": "#FF8000",
+    "fan_max_speed": "40",
+    "filament_cost": [
+        "29.99"
+    ],
+    "filament_density": [
+        "1.27"
+    ],
+    "filament_end_gcode": [
+        "; Filament-specific end gcode"
+    ],
+    "filament_max_volumetric_speed": [
+        "12"
+    ],
+    "filament_minimal_purge_on_wipe_tower": "35",
+    "filament_notes": [
+        ""
+    ],
+    "filament_ramming_parameters": [
+        "250 100 42.4 42.4 42.4 42.4 42.4 | 0.05 42.4 0.45 42.4 0.95 42.4 1.45 42.4 1.95 42.4 2.45 42.4 2.95 42.4 3.45 42.4 3.95 42.4 4.45 42.4 4.95 42.4"
+    ],
+    "filament_retract_before_wipe": "20",
+    "filament_retraction_length": "0.8",
+    "filament_spool_weight": [
+        "278"
+    ],
+    "filament_start_gcode": [
+        "M900 K{if nozzle_diameter[filament_extruder_id]==0.4}0.07{elsif nozzle_diameter[filament_extruder_id]==0.25}0.12{elsif nozzle_diameter[filament_extruder_id]==0.3}0.09{elsif nozzle_diameter[filament_extruder_id]==0.35}0.08{elsif nozzle_diameter[filament_extruder_id]==0.6}0.04{elsif nozzle_diameter[filament_extruder_id]==0.5}0.05{elsif nozzle_diameter[filament_extruder_id]==0.8}0.02{else}0{endif} ; Filament gcode\n\n{if printer_notes=~/.*(MK4IS|XLIS|MK4S|MK3.9S).*/}\nM572 S{if nozzle_diameter[filament_extruder_id]==0.4}0.053{elsif nozzle_diameter[filament_extruder_id]==0.5}0.042{elsif nozzle_diameter[filament_extruder_id]==0.6}0.032{elsif nozzle_diameter[filament_extruder_id]==0.8}0.018{elsif nozzle_diameter[filament_extruder_id]==0.25}0.18{elsif nozzle_diameter[filament_extruder_id]==0.3}0.1{else}0{endif} ; Filament gcode\n{endif}\n\nM142 S36 ; set heatbreak target temp"
+    ],
+    "filament_type": [
+        "PETG"
+    ],
+    "filament_vendor": [
+        "Prusa Polymers"
+    ],
+    "filament_wipe": "1",
+    "filament_z_hop": "0.15",
+    "full_fan_speed_layer": "5",
+    "hot_plate_temp": "90",
+    "hot_plate_temp_initial_layer": "85",
+    "nozzle_temperature": "240",
+    "nozzle_temperature_initial_layer": "230",
+    "overhang_fan_speed": "40",
+    "slow_down_layer_time": "7",
+    "slow_down_min_speed": "15"
+}

--- a/resources/profiles/Prusa/filament/Prusament PLA @MK3S.json
+++ b/resources/profiles/Prusa/filament/Prusament PLA @MK3S.json
@@ -1,0 +1,42 @@
+{
+    "type": "filament",
+    "name": "Prusament PLA @MK3S",
+    "inherits": "fdm_filament_pla",
+    "from": "system",
+    "setting_id": "jd5bJxkA2tV0xWMh",
+    "filament_id": "Prusament PLA @MK3S",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Prusa MK3S 0.25 nozzle",
+        "Prusa MK3S 0.4 nozzle",
+        "Prusa MK3S 0.6 nozzle",
+        "Prusa MK3S 0.8 nozzle"
+    ],
+    "filament_cost": [
+        "27.99"
+    ],
+    "filament_density": [
+        "1.24"
+    ],
+    "filament_flow_ratio": [
+        "0.98"
+    ],
+    "filament_max_volumetric_speed": [
+        "12"
+    ],
+    "filament_spool_weight": [
+        "278"
+    ],
+    "filament_start_gcode": [
+        "; filament start gcode\nM900 K{if printer_notes=~/.*PRINTER_MODEL_MINI.*/ and nozzle_diameter[0]==0.6}0.12{elsif printer_notes=~/.*PRINTER_MODEL_MINI.*/ and nozzle_diameter[0]==0.8}0.06{elsif printer_notes=~/.*PRINTER_MODEL_MINI.*/}0.2{elsif nozzle_diameter[0]==0.8}0.01{elsif nozzle_diameter[0]==0.6}0.04{else}0.05{endif} ; Filament gcode LA 1.5\n{if printer_notes=~/.*PRINTER_MODEL_MINI.*/};{elsif printer_notes=~/.*PRINTER_HAS_BOWDEN.*/}M900 K200{elsif nozzle_diameter[0]==0.6}M900 K18{elsif nozzle_diameter[0]==0.8};{else}M900 K30{endif} ; Filament gcode LA 1.0"
+    ],
+    "filament_type": [
+        "PLA"
+    ],
+    "filament_vendor": [
+        "Prusa Polymers"
+    ],
+    "slow_down_layer_time": [
+        "8"
+    ]
+}

--- a/resources/profiles/Prusa/filament/Prusament PLA @MK4.json
+++ b/resources/profiles/Prusa/filament/Prusament PLA @MK4.json
@@ -1,0 +1,45 @@
+{
+    "type": "filament",
+    "name": "Prusament PLA @MK4",
+    "inherits": "fdm_filament_pla",
+    "from": "system",
+    "setting_id": "NcoTSmHCXFp32Loh",
+    "filament_id": "Prusament PLA @MK4",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Prusa MK4 0.25 nozzle",
+        "Prusa MK4 0.4 nozzle",
+        "Prusa MK4 0.6 nozzle",
+        "Prusa MK4 0.8 nozzle"
+    ],
+    "filament_cost": [
+        "27.99"
+    ],
+    "filament_density": [
+        "1.24"
+    ],
+    "filament_flow_ratio": [
+        "0.98"
+    ],
+    "filament_max_volumetric_speed": [
+        "12"
+    ],
+    "filament_ramming_parameters": [
+        "250 100 40 40 40 40 40 | 0.05 40 0.45 40 0.95 40 1.45 40 1.95 40 2.45 40 2.95 40 3.45 40 3.95 40 4.45 40 4.95 40"
+    ],
+    "filament_spool_weight": [
+        "278"
+    ],
+    "filament_start_gcode": [
+        "; filament start gcode\nM900 K{if nozzle_diameter[0]==0.4}0.026{elsif nozzle_diameter[0]==0.25}0.14{elsif nozzle_diameter[0]==0.3}0.07{elsif nozzle_diameter[0]==0.35}0.06{elsif nozzle_diameter[0]==0.6}0.03{elsif nozzle_diameter[0]==0.5}0.035{elsif nozzle_diameter[0]==0.8}0.015{else}0{endif} ; Filament gcode\n\n{if printer_notes=~/.*PRINTER_MODEL_MK4IS.*/}\nM572 S{if nozzle_diameter[0]==0.4}0.026{elsif nozzle_diameter[0]==0.5}0.025{elsif nozzle_diameter[0]==0.6}0.02{elsif nozzle_diameter[0]==0.8}0.014{elsif nozzle_diameter[0]==0.25}0.12{elsif nozzle_diameter[0]==0.3}0.08{else}0{endif} ; Filament gcode\n{endif}\n\nM142 S36 ; set heatbreak target temp"
+    ],
+    "filament_type": [
+        "PLA"
+    ],
+    "filament_vendor": [
+        "Prusa Polymers"
+    ],
+    "slow_down_layer_time": [
+        "8"
+    ]
+}

--- a/resources/profiles/Prusa/filament/Prusament PLA @MK4S 0.6.json
+++ b/resources/profiles/Prusa/filament/Prusament PLA @MK4S 0.6.json
@@ -1,0 +1,15 @@
+{
+    "type": "filament",
+    "name": "Prusament PLA @MK4S 0.6",
+    "inherits": "Prusament PLA @MK4S",
+    "from": "system",
+    "setting_id": "ZEBOwRtl5qpCb9IG",
+    "filament_id": "Prusament PLA @MK4S 0.6",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Prusa MK4S 0.6 nozzle"
+    ],
+    "fan_cooling_layer_time": "22",
+    "nozzle_temperature": "210",
+    "slow_down_layer_time": "10"
+}

--- a/resources/profiles/Prusa/filament/Prusament PLA @MK4S 0.8.json
+++ b/resources/profiles/Prusa/filament/Prusament PLA @MK4S 0.8.json
@@ -1,0 +1,19 @@
+{
+    "type": "filament",
+    "name": "Prusament PLA @MK4S 0.8",
+    "inherits": "Prusament PLA @MK4S",
+    "from": "system",
+    "setting_id": "CzKCsSyqjLn2UfXr",
+    "filament_id": "Prusament PLA @MK4S 0.8",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Prusa MK4S 0.8 nozzle"
+    ],
+    "fan_cooling_layer_time": "25",
+    "fan_min_speed": "80",
+    "filament_max_volumetric_speed": [
+        "19"
+    ],
+    "nozzle_temperature": "225",
+    "slow_down_layer_time": "15"
+}

--- a/resources/profiles/Prusa/filament/Prusament PLA @MK4S HF0.4.json
+++ b/resources/profiles/Prusa/filament/Prusament PLA @MK4S HF0.4.json
@@ -1,0 +1,22 @@
+{
+    "type": "filament",
+    "name": "Prusament PLA @MK4S HF0.4",
+    "inherits": "Prusament PLA @MK4S",
+    "from": "system",
+    "setting_id": "LnduHI0DPjZ5GUrI",
+    "filament_id": "Prusament PLA @MK4S HF0.4",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Prusa MK4S HF0.4 nozzle"
+    ],
+    "filament_max_volumetric_speed": [
+        "22"
+    ],
+    "filament_ramming_parameters": [
+        "250 100 40 40| 0.05 40 0.45 40 0.95 40 1.45 40 1.95 40 2.45 40 2.95 40 3.45 40 3.95 40 4.45 40 4.95 40"
+    ],
+    "filament_start_gcode": [
+        "M572 S{if nozzle_diameter[0]==0.4}0.036{elsif nozzle_diameter[0]==0.5}0.026{elsif nozzle_diameter[0]==0.6}0.02{elsif nozzle_diameter[0]==0.8}0.015{elsif nozzle_diameter[0]==0.25}0.12{elsif nozzle_diameter[0]==0.3}0.08{else}0{endif} ; Filament gcode\n\nM142 S36 ; set heatbreak target temp"
+    ],
+    "nozzle_temperature": "225"
+}

--- a/resources/profiles/Prusa/filament/Prusament PLA @MK4S HF0.5.json
+++ b/resources/profiles/Prusa/filament/Prusament PLA @MK4S HF0.5.json
@@ -1,0 +1,17 @@
+{
+    "type": "filament",
+    "name": "Prusament PLA @MK4S HF0.5",
+    "inherits": "Prusament PLA @MK4S",
+    "from": "system",
+    "setting_id": "3NoQEhv9aaqhuZkV",
+    "filament_id": "Prusament PLA @MK4S HF0.5",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Prusa MK4S HF0.5 nozzle"
+    ],
+    "fan_cooling_layer_time": "20",
+    "filament_max_volumetric_speed": [
+        "24"
+    ],
+    "slow_down_layer_time": "8"
+}

--- a/resources/profiles/Prusa/filament/Prusament PLA @MK4S HF0.6.json
+++ b/resources/profiles/Prusa/filament/Prusament PLA @MK4S HF0.6.json
@@ -1,0 +1,18 @@
+{
+    "type": "filament",
+    "name": "Prusament PLA @MK4S HF0.6",
+    "inherits": "Prusament PLA @MK4S",
+    "from": "system",
+    "setting_id": "gc7etYK4E5aNlE8r",
+    "filament_id": "Prusament PLA @MK4S HF0.6",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Prusa MK4S HF0.6 nozzle"
+    ],
+    "fan_cooling_layer_time": "22",
+    "filament_max_volumetric_speed": [
+        "30"
+    ],
+    "slow_down_layer_time": "10",
+    "slow_down_min_speed": "15"
+}

--- a/resources/profiles/Prusa/filament/Prusament PLA @MK4S HF0.8.json
+++ b/resources/profiles/Prusa/filament/Prusament PLA @MK4S HF0.8.json
@@ -1,0 +1,19 @@
+{
+    "type": "filament",
+    "name": "Prusament PLA @MK4S HF0.8",
+    "inherits": "Prusament PLA @MK4S",
+    "from": "system",
+    "setting_id": "7RNQ9AxcL9zZVpqX",
+    "filament_id": "Prusament PLA @MK4S HF0.8",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Prusa MK4S HF0.8 nozzle"
+    ],
+    "fan_cooling_layer_time": "25",
+    "fan_min_speed": "80",
+    "filament_max_volumetric_speed": [
+        "35"
+    ],
+    "slow_down_layer_time": "15",
+    "slow_down_min_speed": "15"
+}

--- a/resources/profiles/Prusa/filament/Prusament PLA @MK4S.json
+++ b/resources/profiles/Prusa/filament/Prusament PLA @MK4S.json
@@ -1,0 +1,52 @@
+{
+    "type": "filament",
+    "name": "Prusament PLA @MK4S",
+    "inherits": "fdm_filament_pla",
+    "from": "system",
+    "setting_id": "Zhgox3YIOqKlJpI7",
+    "filament_id": "Prusament PLA @MK4S",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Prusa MK4S 0.25 nozzle",
+        "Prusa MK4S 0.3 nozzle",
+        "Prusa MK4S 0.4 nozzle",
+        "Prusa MK4S 0.5 nozzle"
+    ],
+    "default_filament_colour": "#FF8000",
+    "fan_cooling_layer_time": "17",
+    "fan_min_speed": "70",
+    "filament_cost": [
+        "27.99"
+    ],
+    "filament_density": [
+        "1.24"
+    ],
+    "filament_end_gcode": [
+        "; Filament-specific end gcode"
+    ],
+    "filament_max_volumetric_speed": [
+        "15"
+    ],
+    "filament_notes": [
+        ""
+    ],
+    "filament_ramming_parameters": [
+        "250 100 40 40 40 40 40 | 0.05 40 0.45 40 0.95 40 1.45 40 1.95 40 2.45 40 2.95 40 3.45 40 3.95 40 4.45 40 4.95 40"
+    ],
+    "filament_spool_weight": [
+        "278"
+    ],
+    "filament_start_gcode": [
+        "M900 K{if nozzle_diameter[filament_extruder_id]==0.4}0.05{elsif nozzle_diameter[filament_extruder_id]==0.25}0.14{elsif nozzle_diameter[filament_extruder_id]==0.3}0.07{elsif nozzle_diameter[filament_extruder_id]==0.35}0.06{elsif nozzle_diameter[filament_extruder_id]==0.6}0.03{elsif nozzle_diameter[filament_extruder_id]==0.5}0.035{elsif nozzle_diameter[filament_extruder_id]==0.8}0.015{else}0{endif} ; Filament gcode\n\n{if printer_notes=~/.*(MK4IS|XLIS|MK4S|MK3.9S).*/}\nM572 S{if nozzle_diameter[filament_extruder_id]==0.4}0.036{elsif nozzle_diameter[filament_extruder_id]==0.5}0.025{elsif nozzle_diameter[filament_extruder_id]==0.6}0.02{elsif nozzle_diameter[filament_extruder_id]==0.8}0.014{elsif nozzle_diameter[filament_extruder_id]==0.25}0.12{elsif nozzle_diameter[filament_extruder_id]==0.3}0.08{else}0{endif} ; Filament gcode\n{endif}\n\nM142 S36 ; set heatbreak target temp"
+    ],
+    "filament_type": [
+        "PLA"
+    ],
+    "filament_vendor": [
+        "Prusa Polymers"
+    ],
+    "full_fan_speed_layer": "3",
+    "nozzle_temperature_initial_layer": "230",
+    "slow_down_layer_time": "6",
+    "slow_down_min_speed": "20"
+}

--- a/resources/profiles/Prusa/filament/Prusament PVB @MK3S.json
+++ b/resources/profiles/Prusa/filament/Prusament PVB @MK3S.json
@@ -1,0 +1,51 @@
+{
+    "type": "filament",
+    "name": "Prusament PVB @MK3S",
+    "inherits": "fdm_filament_pvb",
+    "from": "system",
+    "setting_id": "kO3wM0M7J1PagKmj",
+    "filament_id": "Prusament PVB @MK3S",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Prusa MK3S 0.25 nozzle",
+        "Prusa MK3S 0.4 nozzle",
+        "Prusa MK3S 0.6 nozzle",
+        "Prusa MK3S 0.8 nozzle"
+    ],
+    "filament_cost": [
+        "49.98"
+    ],
+    "filament_density": [
+        "1.09"
+    ],
+    "filament_max_volumetric_speed": [
+        "8"
+    ],
+    "filament_spool_weight": [
+        "278"
+    ],
+    "filament_start_gcode": [
+        "; filament start gcode\nM900 K{if printer_notes=~/.*PRINTER_MODEL_MINI.*/ and nozzle_diameter[0]==0.6}0.12{elsif printer_notes=~/.*PRINTER_MODEL_MINI.*/ and nozzle_diameter[0]==0.8}0.06{elsif printer_notes=~/.*PRINTER_MODEL_MINI.*/}0.2{elsif nozzle_diameter[0]==0.8}0.01{elsif nozzle_diameter[0]==0.6}0.04{else}0.05{endif} ; Filament gcode LA 1.5\n{if printer_notes=~/.*PRINTER_MODEL_MINI.*/};{elsif printer_notes=~/.*PRINTER_HAS_BOWDEN.*/}M900 K200{elsif nozzle_diameter[0]==0.6}M900 K18{elsif nozzle_diameter[0]==0.8};{else}M900 K30{endif} ; Filament gcode LA 1.0"
+    ],
+    "filament_type": [
+        "PVB"
+    ],
+    "filament_vendor": [
+        "Prusa Polymers"
+    ],
+    "hot_plate_temp": [
+        "75"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "75"
+    ],
+    "nozzle_temperature": [
+        "215"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "215"
+    ],
+    "slow_down_layer_time": [
+        "8"
+    ]
+}

--- a/resources/profiles/Prusa/filament/Prusament PVB @MK4.json
+++ b/resources/profiles/Prusa/filament/Prusament PVB @MK4.json
@@ -1,0 +1,54 @@
+{
+    "type": "filament",
+    "name": "Prusament PVB @MK4",
+    "inherits": "fdm_filament_pvb",
+    "from": "system",
+    "setting_id": "Ef8S7ZBjRdBICgMN",
+    "filament_id": "Prusament PVB @MK4",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Prusa MK4 0.25 nozzle",
+        "Prusa MK4 0.4 nozzle",
+        "Prusa MK4 0.6 nozzle",
+        "Prusa MK4 0.8 nozzle"
+    ],
+    "filament_cost": [
+        "49.98"
+    ],
+    "filament_density": [
+        "1.09"
+    ],
+    "filament_max_volumetric_speed": [
+        "8"
+    ],
+    "filament_ramming_parameters": [
+        "250 100 40 40 40 40 40 | 0.05 40 0.45 40 0.95 40 1.45 40 1.95 40 2.45 40 2.95 40 3.45 40 3.95 40 4.45 40 4.95 40"
+    ],
+    "filament_spool_weight": [
+        "278"
+    ],
+    "filament_start_gcode": [
+        "; filament start gcode\nM900 K{if nozzle_diameter[0]==0.4}0.026{elsif nozzle_diameter[0]==0.25}0.14{elsif nozzle_diameter[0]==0.3}0.07{elsif nozzle_diameter[0]==0.35}0.06{elsif nozzle_diameter[0]==0.6}0.03{elsif nozzle_diameter[0]==0.5}0.035{elsif nozzle_diameter[0]==0.8}0.015{else}0{endif} ; Filament gcode\n\n{if printer_notes=~/.*PRINTER_MODEL_MK4IS.*/}\nM572 S{if nozzle_diameter[0]==0.4}0.026{elsif nozzle_diameter[0]==0.5}0.025{elsif nozzle_diameter[0]==0.6}0.02{elsif nozzle_diameter[0]==0.8}0.014{elsif nozzle_diameter[0]==0.25}0.12{elsif nozzle_diameter[0]==0.3}0.08{else}0{endif} ; Filament gcode\n{endif}\n\nM142 S36 ; set heatbreak target temp"
+    ],
+    "filament_type": [
+        "PVB"
+    ],
+    "filament_vendor": [
+        "Prusa Polymers"
+    ],
+    "hot_plate_temp": [
+        "75"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "75"
+    ],
+    "nozzle_temperature": [
+        "215"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "215"
+    ],
+    "slow_down_layer_time": [
+        "8"
+    ]
+}

--- a/resources/profiles/Prusa/filament/Prusament PVB @MK4S 0.6.json
+++ b/resources/profiles/Prusa/filament/Prusament PVB @MK4S 0.6.json
@@ -1,0 +1,14 @@
+{
+    "type": "filament",
+    "name": "Prusament PVB @MK4S 0.6",
+    "inherits": "Prusament PVB @MK4S",
+    "from": "system",
+    "setting_id": "d3jPKsT0pNyA81gj",
+    "filament_id": "Prusament PVB @MK4S 0.6",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Prusa MK4S 0.6 nozzle"
+    ],
+    "fan_cooling_layer_time": "22",
+    "slow_down_layer_time": "10"
+}

--- a/resources/profiles/Prusa/filament/Prusament PVB @MK4S 0.8.json
+++ b/resources/profiles/Prusa/filament/Prusament PVB @MK4S 0.8.json
@@ -1,0 +1,15 @@
+{
+    "type": "filament",
+    "name": "Prusament PVB @MK4S 0.8",
+    "inherits": "Prusament PVB @MK4S",
+    "from": "system",
+    "setting_id": "YHoqMYnFgw3tp4uV",
+    "filament_id": "Prusament PVB @MK4S 0.8",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Prusa MK4S 0.8 nozzle"
+    ],
+    "fan_cooling_layer_time": "25",
+    "fan_min_speed": "80",
+    "slow_down_layer_time": "15"
+}

--- a/resources/profiles/Prusa/filament/Prusament PVB @MK4S HF0.4.json
+++ b/resources/profiles/Prusa/filament/Prusament PVB @MK4S HF0.4.json
@@ -1,0 +1,18 @@
+{
+    "type": "filament",
+    "name": "Prusament PVB @MK4S HF0.4",
+    "inherits": "Prusament PVB @MK4S",
+    "from": "system",
+    "setting_id": "Sds69fscdMiTlHlX",
+    "filament_id": "Prusament PVB @MK4S HF0.4",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Prusa MK4S HF0.4 nozzle"
+    ],
+    "filament_ramming_parameters": [
+        "250 100 40 40| 0.05 40 0.45 40 0.95 40 1.45 40 1.95 40 2.45 40 2.95 40 3.45 40 3.95 40 4.45 40 4.95 40"
+    ],
+    "filament_start_gcode": [
+        "M572 S{if nozzle_diameter[0]==0.4}0.036{elsif nozzle_diameter[0]==0.5}0.026{elsif nozzle_diameter[0]==0.6}0.02{elsif nozzle_diameter[0]==0.8}0.015{elsif nozzle_diameter[0]==0.25}0.12{elsif nozzle_diameter[0]==0.3}0.08{else}0{endif} ; Filament gcode\n\nM142 S36 ; set heatbreak target temp"
+    ]
+}

--- a/resources/profiles/Prusa/filament/Prusament PVB @MK4S HF0.5.json
+++ b/resources/profiles/Prusa/filament/Prusament PVB @MK4S HF0.5.json
@@ -1,0 +1,14 @@
+{
+    "type": "filament",
+    "name": "Prusament PVB @MK4S HF0.5",
+    "inherits": "Prusament PVB @MK4S",
+    "from": "system",
+    "setting_id": "HRME1Zm3QWVNOM7D",
+    "filament_id": "Prusament PVB @MK4S HF0.5",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Prusa MK4S HF0.5 nozzle"
+    ],
+    "fan_cooling_layer_time": "20",
+    "slow_down_layer_time": "8"
+}

--- a/resources/profiles/Prusa/filament/Prusament PVB @MK4S HF0.6.json
+++ b/resources/profiles/Prusa/filament/Prusament PVB @MK4S HF0.6.json
@@ -1,0 +1,15 @@
+{
+    "type": "filament",
+    "name": "Prusament PVB @MK4S HF0.6",
+    "inherits": "Prusament PVB @MK4S",
+    "from": "system",
+    "setting_id": "dMKhLR5eOYhQusUg",
+    "filament_id": "Prusament PVB @MK4S HF0.6",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Prusa MK4S HF0.6 nozzle"
+    ],
+    "fan_cooling_layer_time": "22",
+    "slow_down_layer_time": "10",
+    "slow_down_min_speed": "15"
+}

--- a/resources/profiles/Prusa/filament/Prusament PVB @MK4S HF0.8.json
+++ b/resources/profiles/Prusa/filament/Prusament PVB @MK4S HF0.8.json
@@ -1,0 +1,16 @@
+{
+    "type": "filament",
+    "name": "Prusament PVB @MK4S HF0.8",
+    "inherits": "Prusament PVB @MK4S",
+    "from": "system",
+    "setting_id": "E41yKP1EQp91Dhbm",
+    "filament_id": "Prusament PVB @MK4S HF0.8",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Prusa MK4S HF0.8 nozzle"
+    ],
+    "fan_cooling_layer_time": "25",
+    "fan_min_speed": "80",
+    "slow_down_layer_time": "15",
+    "slow_down_min_speed": "15"
+}

--- a/resources/profiles/Prusa/filament/Prusament PVB @MK4S.json
+++ b/resources/profiles/Prusa/filament/Prusament PVB @MK4S.json
@@ -1,0 +1,62 @@
+{
+    "type": "filament",
+    "name": "Prusament PVB @MK4S",
+    "inherits": "fdm_filament_pvb",
+    "from": "system",
+    "setting_id": "eIhnQsQrrCKHjCIy",
+    "filament_id": "Prusament PVB @MK4S",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Prusa MK4S 0.25 nozzle",
+        "Prusa MK4S 0.3 nozzle",
+        "Prusa MK4S 0.4 nozzle",
+        "Prusa MK4S 0.5 nozzle"
+    ],
+    "fan_cooling_layer_time": "17",
+    "fan_min_speed": "70",
+    "filament_cost": [
+        "49.98"
+    ],
+    "filament_density": [
+        "1.09"
+    ],
+    "filament_end_gcode": [
+        "; Filament-specific end gcode"
+    ],
+    "filament_max_volumetric_speed": [
+        "8"
+    ],
+    "filament_notes": [
+        ""
+    ],
+    "filament_ramming_parameters": [
+        "250 100 40 40 40 40 40 | 0.05 40 0.45 40 0.95 40 1.45 40 1.95 40 2.45 40 2.95 40 3.45 40 3.95 40 4.45 40 4.95 40"
+    ],
+    "filament_spool_weight": [
+        "278"
+    ],
+    "filament_start_gcode": [
+        "M900 K{if nozzle_diameter[filament_extruder_id]==0.4}0.05{elsif nozzle_diameter[filament_extruder_id]==0.25}0.14{elsif nozzle_diameter[filament_extruder_id]==0.3}0.07{elsif nozzle_diameter[filament_extruder_id]==0.35}0.06{elsif nozzle_diameter[filament_extruder_id]==0.6}0.03{elsif nozzle_diameter[filament_extruder_id]==0.5}0.035{elsif nozzle_diameter[filament_extruder_id]==0.8}0.015{else}0{endif} ; Filament gcode\n\n{if printer_notes=~/.*(MK4IS|XLIS|MK4S|MK3.9S).*/}\nM572 S{if nozzle_diameter[filament_extruder_id]==0.4}0.036{elsif nozzle_diameter[filament_extruder_id]==0.5}0.025{elsif nozzle_diameter[filament_extruder_id]==0.6}0.02{elsif nozzle_diameter[filament_extruder_id]==0.8}0.014{elsif nozzle_diameter[filament_extruder_id]==0.25}0.12{elsif nozzle_diameter[filament_extruder_id]==0.3}0.08{else}0{endif} ; Filament gcode\n{endif}\n\nM142 S36 ; set heatbreak target temp"
+    ],
+    "filament_type": [
+        "PVB"
+    ],
+    "filament_vendor": [
+        "Prusa Polymers"
+    ],
+    "full_fan_speed_layer": "3",
+    "hot_plate_temp": [
+        "75"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "75"
+    ],
+    "nozzle_temperature": [
+        "215"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "215"
+    ],
+    "slow_down_layer_time": "6",
+    "slow_down_min_speed": "20"
+}

--- a/resources/profiles/Prusa/filament/Prusament rPLA @MK3S.json
+++ b/resources/profiles/Prusa/filament/Prusament rPLA @MK3S.json
@@ -1,0 +1,51 @@
+{
+    "type": "filament",
+    "name": "Prusament rPLA @MK3S",
+    "inherits": "fdm_filament_pla",
+    "from": "system",
+    "setting_id": "DvZ1JFdQmxSvwekh",
+    "filament_id": "Prusament rPLA @MK3S",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Prusa MK3S 0.25 nozzle",
+        "Prusa MK3S 0.4 nozzle",
+        "Prusa MK3S 0.6 nozzle",
+        "Prusa MK3S 0.8 nozzle"
+    ],
+    "filament_cost": [
+        "37.49"
+    ],
+    "filament_density": [
+        "1.24"
+    ],
+    "filament_max_volumetric_speed": [
+        "10"
+    ],
+    "filament_spool_weight": [
+        "278"
+    ],
+    "filament_start_gcode": [
+        "; filament start gcode\nM900 K{if printer_notes=~/.*PRINTER_MODEL_MINI.*/ and nozzle_diameter[0]==0.6}0.12{elsif printer_notes=~/.*PRINTER_MODEL_MINI.*/ and nozzle_diameter[0]==0.8}0.06{elsif printer_notes=~/.*PRINTER_MODEL_MINI.*/}0.2{elsif nozzle_diameter[0]==0.8}0.01{elsif nozzle_diameter[0]==0.6}0.04{else}0.05{endif} ; Filament gcode LA 1.5\n{if printer_notes=~/.*PRINTER_MODEL_MINI.*/};{elsif printer_notes=~/.*PRINTER_HAS_BOWDEN.*/}M900 K200{elsif nozzle_diameter[0]==0.6}M900 K18{elsif nozzle_diameter[0]==0.8};{else}M900 K30{endif} ; Filament gcode LA 1.0"
+    ],
+    "filament_type": [
+        "PLA"
+    ],
+    "filament_vendor": [
+        "Prusa Polymers"
+    ],
+    "hot_plate_temp": [
+        "60"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "60"
+    ],
+    "nozzle_temperature": [
+        "205"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "205"
+    ],
+    "slow_down_layer_time": [
+        "8"
+    ]
+}

--- a/resources/profiles/Prusa/filament/Prusament rPLA @MK4.json
+++ b/resources/profiles/Prusa/filament/Prusament rPLA @MK4.json
@@ -1,0 +1,54 @@
+{
+    "type": "filament",
+    "name": "Prusament rPLA @MK4",
+    "inherits": "fdm_filament_pla",
+    "from": "system",
+    "setting_id": "SnMLCgJupdA5BURx",
+    "filament_id": "Prusament rPLA @MK4",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Prusa MK4 0.25 nozzle",
+        "Prusa MK4 0.4 nozzle",
+        "Prusa MK4 0.6 nozzle",
+        "Prusa MK4 0.8 nozzle"
+    ],
+    "filament_cost": [
+        "37.49"
+    ],
+    "filament_density": [
+        "1.24"
+    ],
+    "filament_max_volumetric_speed": [
+        "10"
+    ],
+    "filament_ramming_parameters": [
+        "250 100 40 40 40 40 40 | 0.05 40 0.45 40 0.95 40 1.45 40 1.95 40 2.45 40 2.95 40 3.45 40 3.95 40 4.45 40 4.95 40"
+    ],
+    "filament_spool_weight": [
+        "278"
+    ],
+    "filament_start_gcode": [
+        "; filament start gcode\nM900 K{if nozzle_diameter[0]==0.4}0.026{elsif nozzle_diameter[0]==0.25}0.14{elsif nozzle_diameter[0]==0.3}0.07{elsif nozzle_diameter[0]==0.35}0.06{elsif nozzle_diameter[0]==0.6}0.03{elsif nozzle_diameter[0]==0.5}0.035{elsif nozzle_diameter[0]==0.8}0.015{else}0{endif} ; Filament gcode\n\n{if printer_notes=~/.*PRINTER_MODEL_MK4IS.*/}\nM572 S{if nozzle_diameter[0]==0.4}0.026{elsif nozzle_diameter[0]==0.5}0.025{elsif nozzle_diameter[0]==0.6}0.02{elsif nozzle_diameter[0]==0.8}0.014{elsif nozzle_diameter[0]==0.25}0.12{elsif nozzle_diameter[0]==0.3}0.08{else}0{endif} ; Filament gcode\n{endif}\n\nM142 S36 ; set heatbreak target temp"
+    ],
+    "filament_type": [
+        "PLA"
+    ],
+    "filament_vendor": [
+        "Prusa Polymers"
+    ],
+    "hot_plate_temp": [
+        "60"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "60"
+    ],
+    "nozzle_temperature": [
+        "205"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "205"
+    ],
+    "slow_down_layer_time": [
+        "8"
+    ]
+}

--- a/resources/profiles/Prusa/filament/Prusament rPLA @MK4S 0.6.json
+++ b/resources/profiles/Prusa/filament/Prusament rPLA @MK4S 0.6.json
@@ -1,0 +1,14 @@
+{
+    "type": "filament",
+    "name": "Prusament rPLA @MK4S 0.6",
+    "inherits": "Prusament rPLA @MK4S",
+    "from": "system",
+    "setting_id": "Jsb4d55uh5AiilFy",
+    "filament_id": "Prusament rPLA @MK4S 0.6",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Prusa MK4S 0.6 nozzle"
+    ],
+    "fan_cooling_layer_time": "22",
+    "slow_down_layer_time": "10"
+}

--- a/resources/profiles/Prusa/filament/Prusament rPLA @MK4S 0.8.json
+++ b/resources/profiles/Prusa/filament/Prusament rPLA @MK4S 0.8.json
@@ -1,0 +1,15 @@
+{
+    "type": "filament",
+    "name": "Prusament rPLA @MK4S 0.8",
+    "inherits": "Prusament rPLA @MK4S",
+    "from": "system",
+    "setting_id": "ETHdABOm1ngNTAwE",
+    "filament_id": "Prusament rPLA @MK4S 0.8",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Prusa MK4S 0.8 nozzle"
+    ],
+    "fan_cooling_layer_time": "25",
+    "fan_min_speed": "80",
+    "slow_down_layer_time": "15"
+}

--- a/resources/profiles/Prusa/filament/Prusament rPLA @MK4S HF0.4.json
+++ b/resources/profiles/Prusa/filament/Prusament rPLA @MK4S HF0.4.json
@@ -1,0 +1,18 @@
+{
+    "type": "filament",
+    "name": "Prusament rPLA @MK4S HF0.4",
+    "inherits": "Prusament rPLA @MK4S",
+    "from": "system",
+    "setting_id": "KqG308Vq6NlSFvBq",
+    "filament_id": "Prusament rPLA @MK4S HF0.4",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Prusa MK4S HF0.4 nozzle"
+    ],
+    "filament_ramming_parameters": [
+        "250 100 40 40| 0.05 40 0.45 40 0.95 40 1.45 40 1.95 40 2.45 40 2.95 40 3.45 40 3.95 40 4.45 40 4.95 40"
+    ],
+    "filament_start_gcode": [
+        "M572 S{if nozzle_diameter[0]==0.4}0.036{elsif nozzle_diameter[0]==0.5}0.026{elsif nozzle_diameter[0]==0.6}0.02{elsif nozzle_diameter[0]==0.8}0.015{elsif nozzle_diameter[0]==0.25}0.12{elsif nozzle_diameter[0]==0.3}0.08{else}0{endif} ; Filament gcode\n\nM142 S36 ; set heatbreak target temp"
+    ]
+}

--- a/resources/profiles/Prusa/filament/Prusament rPLA @MK4S HF0.5.json
+++ b/resources/profiles/Prusa/filament/Prusament rPLA @MK4S HF0.5.json
@@ -1,0 +1,14 @@
+{
+    "type": "filament",
+    "name": "Prusament rPLA @MK4S HF0.5",
+    "inherits": "Prusament rPLA @MK4S",
+    "from": "system",
+    "setting_id": "yWMgM2m6Vhmgcz3o",
+    "filament_id": "Prusament rPLA @MK4S HF0.5",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Prusa MK4S HF0.5 nozzle"
+    ],
+    "fan_cooling_layer_time": "20",
+    "slow_down_layer_time": "8"
+}

--- a/resources/profiles/Prusa/filament/Prusament rPLA @MK4S HF0.6.json
+++ b/resources/profiles/Prusa/filament/Prusament rPLA @MK4S HF0.6.json
@@ -1,0 +1,15 @@
+{
+    "type": "filament",
+    "name": "Prusament rPLA @MK4S HF0.6",
+    "inherits": "Prusament rPLA @MK4S",
+    "from": "system",
+    "setting_id": "rG5LhqOyuhtVsJA5",
+    "filament_id": "Prusament rPLA @MK4S HF0.6",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Prusa MK4S HF0.6 nozzle"
+    ],
+    "fan_cooling_layer_time": "22",
+    "slow_down_layer_time": "10",
+    "slow_down_min_speed": "15"
+}

--- a/resources/profiles/Prusa/filament/Prusament rPLA @MK4S HF0.8.json
+++ b/resources/profiles/Prusa/filament/Prusament rPLA @MK4S HF0.8.json
@@ -1,0 +1,16 @@
+{
+    "type": "filament",
+    "name": "Prusament rPLA @MK4S HF0.8",
+    "inherits": "Prusament rPLA @MK4S",
+    "from": "system",
+    "setting_id": "4aW3ShLVlu345ILy",
+    "filament_id": "Prusament rPLA @MK4S HF0.8",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Prusa MK4S HF0.8 nozzle"
+    ],
+    "fan_cooling_layer_time": "25",
+    "fan_min_speed": "80",
+    "slow_down_layer_time": "15",
+    "slow_down_min_speed": "15"
+}

--- a/resources/profiles/Prusa/filament/Prusament rPLA @MK4S.json
+++ b/resources/profiles/Prusa/filament/Prusament rPLA @MK4S.json
@@ -1,0 +1,62 @@
+{
+    "type": "filament",
+    "name": "Prusament rPLA @MK4S",
+    "inherits": "fdm_filament_pla",
+    "from": "system",
+    "setting_id": "RT3cyjS4ZsddCiM9",
+    "filament_id": "Prusament rPLA @MK4S",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Prusa MK4S 0.25 nozzle",
+        "Prusa MK4S 0.3 nozzle",
+        "Prusa MK4S 0.4 nozzle",
+        "Prusa MK4S 0.5 nozzle"
+    ],
+    "fan_cooling_layer_time": "17",
+    "fan_min_speed": "70",
+    "filament_cost": [
+        "37.49"
+    ],
+    "filament_density": [
+        "1.24"
+    ],
+    "filament_end_gcode": [
+        "; Filament-specific end gcode"
+    ],
+    "filament_max_volumetric_speed": [
+        "10"
+    ],
+    "filament_notes": [
+        ""
+    ],
+    "filament_ramming_parameters": [
+        "250 100 40 40 40 40 40 | 0.05 40 0.45 40 0.95 40 1.45 40 1.95 40 2.45 40 2.95 40 3.45 40 3.95 40 4.45 40 4.95 40"
+    ],
+    "filament_spool_weight": [
+        "278"
+    ],
+    "filament_start_gcode": [
+        "M900 K{if nozzle_diameter[filament_extruder_id]==0.4}0.05{elsif nozzle_diameter[filament_extruder_id]==0.25}0.14{elsif nozzle_diameter[filament_extruder_id]==0.3}0.07{elsif nozzle_diameter[filament_extruder_id]==0.35}0.06{elsif nozzle_diameter[filament_extruder_id]==0.6}0.03{elsif nozzle_diameter[filament_extruder_id]==0.5}0.035{elsif nozzle_diameter[filament_extruder_id]==0.8}0.015{else}0{endif} ; Filament gcode\n\n{if printer_notes=~/.*(MK4IS|XLIS|MK4S|MK3.9S).*/}\nM572 S{if nozzle_diameter[filament_extruder_id]==0.4}0.036{elsif nozzle_diameter[filament_extruder_id]==0.5}0.025{elsif nozzle_diameter[filament_extruder_id]==0.6}0.02{elsif nozzle_diameter[filament_extruder_id]==0.8}0.014{elsif nozzle_diameter[filament_extruder_id]==0.25}0.12{elsif nozzle_diameter[filament_extruder_id]==0.3}0.08{else}0{endif} ; Filament gcode\n{endif}\n\nM142 S36 ; set heatbreak target temp"
+    ],
+    "filament_type": [
+        "PLA"
+    ],
+    "filament_vendor": [
+        "Prusa Polymers"
+    ],
+    "full_fan_speed_layer": "3",
+    "hot_plate_temp": [
+        "60"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "60"
+    ],
+    "nozzle_temperature": [
+        "205"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "205"
+    ],
+    "slow_down_layer_time": "6",
+    "slow_down_min_speed": "20"
+}

--- a/resources/profiles/Prusa/machine/Prusa MK3S.json
+++ b/resources/profiles/Prusa/machine/Prusa MK3S.json
@@ -8,5 +8,5 @@
 	"bed_model": "mk3_bed.stl",
 	"bed_texture": "mk3.svg",
 	"hotend_model": "",
-	"default_materials": "Prusa Generic ABS;Prusa Generic PLA;Prusa Generic PLA-CF;Prusa Generic PETG;Prusa Generic TPU;Prusa Generic ASA;Prusa Generic PC;Prusa Generic PVA;Prusa Generic PA;Prusa Generic PA-CF"
+	"default_materials": "Prusa Generic ABS;Prusa Generic PLA;Prusa Generic PLA-CF;Prusa Generic PETG;Prusa Generic TPU;Prusa Generic ASA;Prusa Generic PC;Prusa Generic PVA;Prusa Generic PA;Prusa Generic PA-CF;Prusament PLA @MK3S;Prusament rPLA @MK3S;Prusament PETG @MK3S;Prusament ASA @MK3S;Prusament PC Blend @MK3S;Prusament PVB @MK3S;Prusament PC Blend Carbon Fiber @MK3S;Prusament PA11 Carbon Fiber @MK3S"
 }

--- a/resources/profiles/Prusa/machine/Prusa MK4.json
+++ b/resources/profiles/Prusa/machine/Prusa MK4.json
@@ -8,5 +8,5 @@
 	"bed_model": "mk4_bed.stl",
 	"bed_texture": "mk4is.svg",
 	"hotend_model": "",
-	"default_materials": "Prusa Generic PLA-CF;Prusa Generic PC;Prusa Generic PVA;Prusa Generic PA;Prusa Generic PA-CF;Prusa Generic ABS @MK4;Prusa Generic PLA @MK4;Prusa Generic PETG @MK4;Prusa Generic TPU @MK4;Prusa Generic ASA @MK4;"
+	"default_materials": "Prusa Generic PLA-CF;Prusa Generic PC;Prusa Generic PVA;Prusa Generic PA;Prusa Generic PA-CF;Prusa Generic ABS @MK4;Prusa Generic PLA @MK4;Prusa Generic PETG @MK4;Prusa Generic TPU @MK4;Prusa Generic ASA @MK4;Prusament PLA @MK4;Prusament rPLA @MK4;Prusament PETG @MK4;Prusament ASA @MK4;Prusament PC Blend @MK4;Prusament PVB @MK4;Prusament PC Blend Carbon Fiber @MK4;Prusament PA11 Carbon Fiber @MK4"
 }

--- a/resources/profiles/Prusa/machine/Prusa MK4S.json
+++ b/resources/profiles/Prusa/machine/Prusa MK4S.json
@@ -3,7 +3,7 @@
 	"name": "Prusa MK4S",
 	"bed_model": "mk4_bed.stl",
 	"bed_texture": "mk4s.svg",
-	"default_materials": "Prusa Generic ABS @MK4S;Prusa Generic ASA @MK4S;Prusa Generic PETG @MK4S;Prusa Generic PLA @MK4S;Prusa Generic PLA Silk @MK4S;Prusa Generic TPU @MK4S",
+	"default_materials": "Prusa Generic ABS @MK4S;Prusa Generic ASA @MK4S;Prusa Generic PETG @MK4S;Prusa Generic PLA @MK4S;Prusa Generic PLA Silk @MK4S;Prusa Generic TPU @MK4S;Prusament PLA @MK4S;Prusament rPLA @MK4S;Prusament PETG @MK4S;Prusament ASA @MK4S;Prusament PC Blend @MK4S;Prusament PVB @MK4S;Prusament PC Blend Carbon Fiber @MK4S;Prusament PA11 Carbon Fiber @MK4S",
 	"family": "Prusa",
 	"hotend_model": "",
 	"machine_tech": "FFF",


### PR DESCRIPTION
# Description

OrcaSlicer supports Prusa MK3/S and MK4/S printers but doesn't have many filament profiles for them.

This PR ports over the Prusament filament profiles for these printers from PrusaSlicer (https://github.com/prusa3d/PrusaSlicer/blob/master/resources/profiles/PrusaResearch.ini)

# Screenshots/Recordings/Graphs

<!--
> Please attach relevant screenshots to showcase the UI changes.
> Please attach images that can help explain the changes.
-->

## Tests

### Verified Fresh Install Works
1. Compiled OrcaSlicer locally
2. Deleted user data (on macOS this is: `~/Library/Application Support/OrcaSlicer`)
3. Launch local build of OrcaSlicer and go through initial setup to add a Prusa MK3/S or MK4/S printer
4. Verify Prusament filaments are available for selection

### Verified Profiles Work
1. Launch the fresh OrcaSlicer install set up in the previous test
2. Load a model, select a Prusament filament, and slice
3. Export the gcode and print the model
4. Verify print works as expected


<!--
> A guide for users on how to download the artifacts from this PR.
-->

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
