### PR TITLE
fix: stage debug Python artifacts on Windows

### DIFF
--- a/deps/python3/stage_windows.cmake
+++ b/deps/python3/stage_windows.cmake
@@ -26,6 +26,13 @@ if(EXISTS "${PYTHON_SOURCE_DIR}/LICENSE" AND NOT EXISTS "${PYTHON_BUILD_DIR}/LIC
     configure_file("${PYTHON_SOURCE_DIR}/LICENSE" "${PYTHON_BUILD_DIR}/LICENSE.txt" COPYONLY)
 endif()
 
+# PC/layout filters artifacts by whether their name ends in _d, matched
+# against its own --debug flag, so a debug build has to pass it.
+set(_layout_debug_arg "")
+if(PYTHON_DEBUG)
+    set(_layout_debug_arg --debug)
+endif()
+
 execute_process(
     COMMAND
         "${CMAKE_COMMAND}" -E env
@@ -38,6 +45,7 @@ execute_process(
             --arch "${PYTHON_LAYOUT_ARCH}"
             --copy "${PYTHON_DEST_DIR}"
             --include-dev
+            ${_layout_debug_arg}
     WORKING_DIRECTORY "${PYTHON_SOURCE_DIR}"
     RESULT_VARIABLE _layout_result
 )


### PR DESCRIPTION
# Description

`build_release_vs.bat deps debug` reports success but never installs Python. The failure only shows up later, when configuring OrcaSlicer against the result:

```
CMake Error at .../FindPackageHandleStandardArgs.cmake:290 (message):
  Could NOT find Python3 ...
  Interpreter: Cannot run the interpreter ".../deps/build-dbg/OrcaSlicer_dep/usr/local/libpython/python.exe"
  Development: Cannot find the library ".../libpython/libs/python312.lib"
```

`deps/python3/stage_windows.cmake` already selects `python_d.exe` for a debug build, but it never passes `--debug` to CPython's `PC/layout`. That tool filters artifacts against its own flag:

```python
# PC/layout/main.py:174
if src.stem.endswith("_d") != bool(ns.debug) and src not in REQUIRED_DLLS:
```

So every `_d` artifact is filtered out, and staging fails looking for release names:

```
File "PC/layout/main.py", line 440, in copy_files
FileNotFoundError: [WinError 2] The system cannot find the file specified
CMake Error at deps/python3/stage_windows.cmake:46 (message):
  CPython Windows layout staging failed with exit code 1
```

MSBuild records that as `error MSB8066` on `dep_python3.vcxproj`, but `build_release_vs.bat` never checks `errorlevel` after the dependency build, so the remaining dependencies finish around the dead one and the run still ends `Build completed` with exit code 0.

`python3.cmake` already passes `PYTHON_DEBUG` to the staging script, which already branches on it in two places. This adds a third.

Windows-only, and only the debug dependency build. Release and RelWithDebInfo cannot reach the new code, which sits inside `if(PYTHON_DEBUG)`.

## Tests

Visual Studio 2026 (18.6.3). Two full dependency builds from an empty `deps/build-dbg`, identical apart from this commit. The control is this branch's parent.

| `build_release_vs.bat deps debug` | `python312_d.lib` staged | `python_d.exe` staged | staging error | exit |
|---|---|---|---|---|
| `550e234a37` (parent) | no | no | `FileNotFoundError` at `stage_windows.cmake:46` | 0, 20m07s |
| this branch | yes | yes | none | 0, 20m03s |

Those two artifacts are the paths the `Could NOT find Python3` error reports as missing.

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
