### PR TITLE
Ensure Snapmaker U1 filename respects filament selection

### DIFF
--- a/resources/profiles/Snapmaker/process/fdm_process_U1_common.json
+++ b/resources/profiles/Snapmaker/process/fdm_process_U1_common.json
@@ -29,7 +29,7 @@
 	"ironing_type": "no ironing",
 	"layer_height": "0.2",
 	"reduce_infill_retraction": "1",
-	"filename_format": "{input_filename_base}_{filament_type[0]}_{print_time}.gcode",
+	"filename_format": "{input_filename_base}_{filament_type[initial_no_support_extruder]}_{int(total_weight*10) / 10.0}g_{print_time}.gcode",
 	"detect_overhang_wall": "1",
 	"overhang_1_4_speed": "0",
 	"overhang_2_4_speed": "50",


### PR DESCRIPTION


Improved filename format to ensure that the selected filament is included in the filename and not the [0] filament

# Description
Fixes https://github.com/OrcaSlicer/OrcaSlicer/issues/13311

# Screenshots/Recordings/Graphs

<!--
> Please attach relevant screenshots to showcase the UI changes.
> Please attach images that can help explain the changes.
-->

## Tests
Very lightweight change. Shouldn't break anything

<!--
> A guide for users on how to download the artifacts from this PR.
-->

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
