### PR TITLE
chore: ignore CMakeUserPresets.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ Build
 Build.bat
 /build*/
 CMakeLists.txt.user
+CMakeUserPresets.json
 **/CMakeLists.txt.autosave
 deps/build*
 MYMETA.json


### PR DESCRIPTION
# Description

CMake reads `CMakeUserPresets.json` for a developer's own generator, compiler and build directory choices. The [cmake-presets manual](https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html#introduction) says it should not be checked into version control, unlike `CMakePresets.json`.

Follow-up to [OrcaSlicer_WIKI#335](https://github.com/OrcaSlicer/OrcaSlicer_WIKI/pull/335), which recommends a `CMakeUserPresets.json` for the Windows build and promised this change.
