### PR TITLE
Check for nullptr to avoid crash in BackgroundSlicingProcess

### DIFF
--- a/src/slic3r/GUI/BackgroundSlicingProcess.cpp
+++ b/src/slic3r/GUI/BackgroundSlicingProcess.cpp
@@ -718,7 +718,8 @@ Print::ApplyStatus BackgroundSlicingProcess::apply(const Model& model, const Dyn
 
     // Orca: prevent resetting under gcode viewer mode
     if (invalidated != PrintBase::APPLY_STATUS_UNCHANGED) {
-        const auto plater = GUI::wxGetApp().mainframe->m_plater;
+        const auto mainframe = GUI::wxGetApp().mainframe;
+        const auto plater = mainframe ? mainframe->m_plater : nullptr;
         if (plater && plater->only_gcode_mode()) {
             invalidated = PrintBase::APPLY_STATUS_UNCHANGED;
         }


### PR DESCRIPTION
# Description

I don't remember how to reproduce the original problem, but when using Orca around version 2.3 through the CLI, some (bad?) inputs would trigger this nullptr crash.  Just checking the pointer avoided the problem.  The proposed change avoids an immediate crash, so it shouldn't be controversial.

# Screenshots/Recordings/Graphs

None

## Tests

See Description

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
