### PR TITLE
Fix: JSON numbers and booleans in config files are silently discarded

### DIFF
--- a/src/libslic3r/Config.cpp
+++ b/src/libslic3r/Config.cpp
@@ -1028,6 +1028,32 @@ int ConfigBase::load_from_json(const std::string &file, ConfigSubstitutionContex
                     if (valid)
                         this->set_deserialize(opt_key, value_str, substitution_context);
                 }
+                else if (it.value().is_boolean() || it.value().is_number()) {
+                    // Orca keeps every option in its serialised, textual form,
+                    // and the profiles it ships write even booleans as "0" and
+                    // "1".  A JSON number or boolean here is therefore not the
+                    // usual shape -- but discarding it, which is what this
+                    // branch used to do, is the worst of the three options.
+                    //
+                    // The key simply vanished: no error the caller could see,
+                    // and the option then took its compiled-in default.  For
+                    // precise_outer_wall that default is true, so writing
+                    // "precise_outer_wall": 0 in a config *enabled* it.  A
+                    // boolean switched on by being set to zero is not a
+                    // corner case anybody can be expected to guess at, and
+                    // the slice still exits 0.
+                    //
+                    // So convert instead.  The intent is unambiguous in every
+                    // case, and anything genuinely unconvertible still falls
+                    // through to the error below.
+                    if (it.value().is_boolean())
+                        value_str = it.value().get<bool>() ? "1" : "0";
+                    else if (it.value().is_number_integer())
+                        value_str = std::to_string(it.value().get<int64_t>());
+                    else
+                        value_str = float_to_string_decimal_point(it.value().get<double>());
+                    this->set_deserialize(opt_key, value_str, substitution_context);
+                }
                 else {
                     //should not happen
                     BOOST_LOG_TRIVIAL(error) << __FUNCTION__<< ": parse "<<file<<" error, invalid json type for " << it.key();

--- a/src/libslic3r/Config.cpp
+++ b/src/libslic3r/Config.cpp
@@ -893,6 +893,36 @@ int ConfigBase::load_from_json(const std::string &file, ConfigSubstitutionContex
                     value_str += "\"";
                 }
             }
+            else if (iter.value().is_boolean() || iter.value().is_number()) {
+                // Same case as the scalar branch below, one level down: an
+                // unquoted number or boolean inside an array. Here it did not
+                // merely drop the key -- parse_str_arr returned false, and the
+                // caller treats that as a parse failure and breaks out of the
+                // loop over the whole file, so every remaining key is silently
+                // left unread. nlohmann iterates an object in sorted key order,
+                // so what survives depends on the alphabet: a bare number in
+                // "nozzle_temperature" stops "type" from ever being read, and
+                // the CLI then reports "unknown config type" for a file whose
+                // type field is present and correct.
+                if (!first)
+                    value_str += single_sep;
+                else
+                    first = false;
+                std::string scalar;
+                if (iter.value().is_boolean())
+                    scalar = iter.value().get<bool>() ? "1" : "0";
+                else if (iter.value().is_number_integer())
+                    scalar = std::to_string(iter.value().get<int64_t>());
+                else
+                    scalar = float_to_string_decimal_point(iter.value().get<double>());
+                if (!escape_string_style)
+                    value_str += scalar;
+                else {
+                    value_str += "\"";
+                    value_str += escape_string_cstyle(scalar);
+                    value_str += "\"";
+                }
+            }
             else {
                 //should not happen
                 return false;


### PR DESCRIPTION
# Description

`ConfigBase::load_from_json` handles a JSON string for every option and falls
through to an error for anything else. A JSON **number or boolean** therefore
never reaches `set_deserialize`. This happens in two places, and the second is
worse than the first.

## 1. A bare scalar as an option value

The key is dropped, nothing is reported, and the option silently keeps its
compiled-in default. That default is not always the harmless one:
`precise_outer_wall` defaults to `true` (`PrintConfig.cpp:1645`), so a config
containing

```json
"precise_outer_wall": 0
```

**turns the feature on.** The slice succeeds and exits `0`.

## 2. A bare scalar inside an array

`parse_str_arr` accepts only arrays and strings and returns `false` for anything
else. The caller treats that as a parse failure and **breaks out of the loop over
the whole file**, so every remaining key is left unread.

nlohmann iterates an object in sorted key order, so what survives depends on the
alphabet. Writing `"nozzle_temperature": [220]` instead of `["220"]` stops `type`
from ever being read, and the CLI then reports

```
unknown config type  of file <path> in load-settings
```

for a file whose `type` field is present and correct. Nothing in that message
points at the array, at the key, or at the line.

## The fix

Orca stores every option in its serialised textual form and the shipped profiles
write booleans as `"0"`/`"1"`, so a bare scalar is unusual — but its intent is
unambiguous in every case, which makes converting it strictly better than
discarding it. Anything genuinely unconvertible still falls through to the
existing error branch, and the array's existing consistent-type check is
untouched.

Booleans become `"1"`/`"0"`, integers go through `std::to_string`, and reals
through `float_to_string_decimal_point` so the decimal separator does not follow
the locale. Inside an array the value takes the same separator and escaping path
the string branch already uses.

## Credit

The array case is not mine. It was found by [@aceRage](https://github.com/aceRage)
while porting the first half of this PR into
[Snapmaker-Ultra](https://github.com/aceRage/Snapmaker-Ultra)
([`3dba895`](https://github.com/aceRage/Snapmaker-Ultra/commit/3dba895a4e2a9371cee3950d640d886699dbab0e)).
That fork's `Config.cpp` has diverged from this one and handles arrays inline, so
the code here is different, but the defect is the same and the finding is theirs.

## Tests

Built on Windows (VS 2026 / MSVC 14.5x, CMake 4.4.2) and compared against a stock
2.4.2 install, same model, same profiles.

**Case 1** — one config differing only in that `precise_outer_wall` is the number
`0`:

| | stock 2.4.2 | this branch |
|---|---|---|
| `--export-settings` reports | `precise_outer_wall = 1` | `= 0` |
| G-code footer | `; precise_outer_wall = 1` | `; precise_outer_wall = 0` |
| G-code size | 17.3 MB | 18.8 MB |
| `G1` moves | 350 274 | 405 287 |

542 925 toolpath lines differ, so the dropped value is not a reporting detail —
it changes what gets printed. Both builds exited `0`.

**Case 2** — a filament profile with `"nozzle_temperature": [220]`:

| | stock 2.4.2 | this branch |
|---|---|---|
| exit code | 127 | 0 |
| message | `unknown config type` | — |
| resolved `nozzle_temperature` | nothing produced | `['220']` |

A config passing the same keys as strings is unaffected, and so is every profile
shipped in `resources/profiles`, none of which use bare scalars.
