### PR TITLE
Fix: presets whose "from" reads "System" are refused by the CLI

### DIFF
--- a/src/OrcaSlicer.cpp
+++ b/src/OrcaSlicer.cpp
@@ -1992,7 +1992,13 @@ int CLI::run(int argc, char **argv)
             if (from_iter != key_values.end()) {
                 config_from = from_iter->second;
             }
-            if ((config_from != "system")&&(config_from != "User")&&(config_from != "user")) {
+            // Accept "System" as well.  183 of the shipped presets spell it
+            // with a capital S -- every SeeMeCNC profile and one Flashforge --
+            // and were refused here, so none of them could be loaded from the
+            // command line at all.  The user spelling was already accepted
+            // both ways on this very line.
+            if (!boost::iequals(config_from, "system") &&
+                !boost::iequals(config_from, "user")) {
                 boost::nowide::cerr <<__FUNCTION__ << boost::format(":file %1%'s from %2% unsupported") % file % config_from;
                 return CLI_CONFIG_FILE_ERROR;
             }
@@ -2056,7 +2062,7 @@ int CLI::run(int argc, char **argv)
                 flush_and_exit(CLI_CONFIG_FILE_ERROR);
             }
             new_printer_name = config_name;
-            if (config_from == "system") {
+            if (boost::iequals(config_from, "system")) {
                 new_printer_system_name = new_printer_name;
                 new_printer_config_is_system = true;
             }
@@ -2096,7 +2102,7 @@ int CLI::run(int argc, char **argv)
                 flush_and_exit(CLI_CONFIG_FILE_ERROR);
             }
             new_process_name = config_name;
-            if (config_from == "system") {
+            if (boost::iequals(config_from, "system")) {
                 new_process_system_name = new_process_name;
                 new_process_config_is_system = true;
             }


### PR DESCRIPTION
# Description

`load_config_file` gates every config file on

```cpp
if ((config_from != "system") && (config_from != "User") && (config_from != "user"))
```

The **user** spelling is accepted in either case; the **system** one only
in lower case. A preset whose `from` field reads `System` is refused
outright:

```
file .../SeeMeCNC_Artemis_1_0mm.json's from System unsupported
```

This is not hypothetical. Across the 8827 profiles in
`resources/profiles` the field reads:

| value | files |
|---|---|
| `system` | 8177 |
| *(absent)* | 443 |
| **`System`** | **183** |
| `User` | 22 |
| *(empty)* | 2 |

The 183 are every SeeMeCNC preset plus one Flashforge. None of them can
be passed to `--load-settings` or `--load-filaments` at all.

The fix compares case-insensitively for both spellings. The two later
branches testing `config_from == "system"` are only reached once this
gate has passed, so they are made consistent with it.

Fixing the profiles instead would work too, but the CLI would still
reject a perfectly valid `System` written by any third-party or
user-exported preset, so the check is the better place.

## Tests

Built on Windows (VS 2026 / MSVC 14.5x, CMake 4.4.2). Slicing a model
with the SeeMeCNC Artemis machine, its `0.60mm Draft` process and
`SeeMeCNC PLA`:

| | stock 2.4.2 | this branch |
|---|---|---|
| exit code | 127, refused | 0 |
| `--export-settings` | nothing produced | 704 keys |
| G-code | none | 6.06 MB |

The resolved values are the vendor's, not schema defaults -- e.g.
`outer_wall_speed 20`, `wall_loops 3`, `printer_model
'SeeMeCNC Artemis 300'`, `printable_height 500`.

Presets with `from: system` and `from: User` behave exactly as before.
