### PR TITLE
Report settings a config file names and this build does not know, add --strict-config

### DIFF
--- a/src/OrcaSlicer.cpp
+++ b/src/OrcaSlicer.cpp
@@ -1358,6 +1358,7 @@ int CLI::run(int argc, char **argv)
     float old_max_radius = 0.f, old_height_to_rod = 0.f, old_height_to_lid = 0.f;
     std::vector<double> old_max_layer_height, old_min_layer_height;
     std::string outfile_dir              =  m_config.opt_string("outputdir", true);
+    const bool                                  strict_config              = m_config.opt_bool("strict_config");
     const std::vector<std::string>              &load_configs               = m_config.option<ConfigOptionStrings>("load_settings", true)->values;
     const std::vector<std::string>              &uptodate_configs          = m_config.option<ConfigOptionStrings>("uptodate_settings", true)->values;
     const std::vector<std::string>              &uptodate_filaments          = m_config.option<ConfigOptionStrings>("uptodate_filaments", true)->values;
@@ -1969,7 +1970,7 @@ int CLI::run(int argc, char **argv)
         }
     }
 
-    auto load_config_file = [config_substitution_rule](const std::string& file, DynamicPrintConfig& config, std::string& config_type,
+    auto load_config_file = [config_substitution_rule, strict_config](const std::string& file, DynamicPrintConfig& config, std::string& config_type,
                                 std::string& config_name, std::string& filament_id, std::string& config_from) {
         if (! boost::filesystem::exists(file)) {
             boost::nowide::cerr << __FUNCTION__<< ": can not find setting file: " << file << std::endl;
@@ -1981,10 +1982,42 @@ int CLI::run(int argc, char **argv)
             std::map<std::string, std::string> key_values;
             std::string reason;
 
-            config_substitutions = config.load_from_json(file, config_substitution_rule, key_values, reason);
-            if (!reason.empty()) {
+            // Keep the substitution context rather than only its result:
+            // unrecogized_keys is the sole record of settings the file named
+            // and this build does not know, and it is otherwise dropped
+            // without a word.
+            ConfigSubstitutionContext subst_ctxt(config_substitution_rule);
+            int json_ret = config.load_from_json(file, subst_ctxt, true, key_values, reason);
+            config_substitutions = std::move(subst_ctxt.substitutions);
+            if (json_ret != 0 || !reason.empty()) {
                 BOOST_LOG_TRIVIAL(error) <<__FUNCTION__<<  ":Can not load config from file "<<file<<"\n";
                 return CLI_CONFIG_FILE_ERROR;
+            }
+            if (! subst_ctxt.unrecogized_keys.empty()) {
+                // Two very different things end up in this list, because
+                // handle_legacy() clears the key for both: settings this
+                // version retired on purpose, and settings whose name is
+                // simply wrong.  Only the second is worth saying anything
+                // about -- the shipped profiles still carry retired keys, and
+                // warning about those would be noise on Orca's own data.
+                //
+                // A misspelled key is not a harmless no-op: the setting its
+                // author meant to change does not change, and a scripted
+                // pipeline has no way to find that out.
+                std::vector<std::string> unknown;
+                for (const std::string &k : subst_ctxt.unrecogized_keys)
+                    if (! PrintConfigDef::is_obsolete_key(k))
+                        unknown.push_back(k);
+                for (const std::string &k : unknown)
+                    boost::nowide::cerr << "warning: " << file
+                        << ": unknown setting \"" << k << "\", ignored"
+                        << std::endl;
+                if (strict_config && ! unknown.empty()) {
+                    boost::nowide::cerr << __FUNCTION__
+                        << ": refusing to slice with unknown settings"
+                           " (--strict-config)" << std::endl;
+                    return CLI_CONFIG_FILE_ERROR;
+                }
             }
 
             config_name = key_values[BBL_JSON_KEY_NAME];

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -8886,6 +8886,34 @@ void PrintConfigDef::init_sla_params()
     def->set_default_value(new ConfigOptionEnum<SLAMaterialSpeed>(slamsFast));
 }
 
+// Configuration keys this version no longer has and never will: they were
+// retired deliberately, unlike a key that is simply misspelled. Both are
+// cleared by handle_legacy() below, so anything wanting to tell a dropped
+// setting from a typo has to ask which kind it was.
+    static const std::set<std::string> s_obsolete_keys = {
+        "acceleration", "scale", "rotate", "duplicate", "duplicate_grid",
+        "bed_size",
+        "print_center", "g0", "wipe_tower_per_color_wipe", 
+        "support_sharp_tails","support_remove_small_overhangs", "support_with_sheath",
+        "tree_support_collision_resolution", "tree_support_with_infill",
+        "max_volumetric_speed", "max_print_speed",
+        "support_closing_radius",
+        "remove_freq_sweep", "remove_bed_leveling", "remove_extrusion_calibration",
+        "support_transition_line_width", "support_transition_speed", "bed_temperature", "bed_temperature_initial_layer",
+        "can_switch_nozzle_type", "can_add_auxiliary_fan", "extra_flush_volume", "spaghetti_detector", "adaptive_layer_height",
+        "z_hop_type", "z_lift_type", "bed_temperature_difference","long_retraction_when_cut",
+        "retraction_distance_when_cut",
+        "internal_bridge_support_thickness", "top_area_threshold", "reduce_wall_solid_infill","filament_load_time","filament_unload_time",
+        "smooth_coefficient", "overhang_totally_speed", "silent_mode",
+        "overhang_speed_classic",
+        "anisotropic_surfaces", // superseded by top_surface_fill_order / bottom_surface_fill_order
+    };
+
+bool PrintConfigDef::is_obsolete_key(const t_config_option_key &opt_key)
+{
+    return s_obsolete_keys.find(opt_key) != s_obsolete_keys.end();
+}
+
 void PrintConfigDef::handle_legacy(t_config_option_key &opt_key, std::string &value)
 {
     //BBS: handle legacy options
@@ -9110,27 +9138,9 @@ void PrintConfigDef::handle_legacy(t_config_option_key &opt_key, std::string &va
         value = "ccw";
     }
 
-    // Ignore the following obsolete configuration keys:
-    static std::set<std::string> ignore = {
-        "acceleration", "scale", "rotate", "duplicate", "duplicate_grid",
-        "bed_size",
-        "print_center", "g0", "wipe_tower_per_color_wipe", 
-        "support_sharp_tails","support_remove_small_overhangs", "support_with_sheath",
-        "tree_support_collision_resolution", "tree_support_with_infill",
-        "max_volumetric_speed", "max_print_speed",
-        "support_closing_radius",
-        "remove_freq_sweep", "remove_bed_leveling", "remove_extrusion_calibration",
-        "support_transition_line_width", "support_transition_speed", "bed_temperature", "bed_temperature_initial_layer",
-        "can_switch_nozzle_type", "can_add_auxiliary_fan", "extra_flush_volume", "spaghetti_detector", "adaptive_layer_height",
-        "z_hop_type", "z_lift_type", "bed_temperature_difference","long_retraction_when_cut",
-        "retraction_distance_when_cut",
-        "internal_bridge_support_thickness", "top_area_threshold", "reduce_wall_solid_infill","filament_load_time","filament_unload_time",
-        "smooth_coefficient", "overhang_totally_speed", "silent_mode",
-        "overhang_speed_classic",
-        "anisotropic_surfaces", // superseded by top_surface_fill_order / bottom_surface_fill_order
-    };
+    // Retired on purpose -- see s_obsolete_keys above.
 
-    if (ignore.find(opt_key) != ignore.end()) {
+    if (is_obsolete_key(opt_key)) {
         opt_key = "";
         return;
     }
@@ -12080,6 +12090,14 @@ CLIMiscConfigDef::CLIMiscConfigDef()
     def->tooltip = L("Load filament settings from the specified file list.");
     def->cli_params = "\"filament1.json;filament2.json;...\"";
     def->set_default_value(new ConfigOptionStrings());
+
+    def = this->add("strict_config", coBool);
+    def->label = L("Strict config");
+    def->tooltip = L("Refuse to slice when a configuration file names a setting "
+                     "this build does not know. Without it such a setting is "
+                     "reported and then ignored, which for a scripted pipeline "
+                     "means the intended change silently does not happen.");
+    def->set_default_value(new ConfigOptionBool(false));
 
     def = this->add("skip_objects", coInts);
     def->label = L("Skip Objects");

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -708,6 +708,9 @@ public:
     PrintConfigDef();
 
     static void handle_legacy(t_config_option_key &opt_key, std::string &value);
+    // True for a key this version retired on purpose, as opposed to one
+    // it simply does not recognise.  handle_legacy() clears both.
+    static bool is_obsolete_key(const t_config_option_key &opt_key);
     static void handle_legacy_composite(DynamicPrintConfig &config);
 
     // Array options growing with the number of extruders


### PR DESCRIPTION
# Description

`load_config_file` keeps only the substitutions out of the
`ConfigSubstitutionContext` and discards the context itself, so
`unrecogized_keys` -- the record of keys the file named that this build
could not place -- is thrown away. A misspelled or invented setting is
therefore accepted in silence: the slice succeeds, exits `0`, and the
change its author intended simply never happens.

```json
"outer_wall_speeed": "999"      accepted, no output, no effect
```

This branch keeps the context and reports those keys on stderr, naming
the file each came from.

### Not everything in that list is a mistake

`handle_legacy()` clears `opt_key` for two different reasons: the key is
in the obsolete set (retired on purpose), or `print_config_def` has never
heard of it (a typo, or a setting from a newer build). Both land in
`unrecogized_keys`, so warning about all of them would fire on Orca's own
shipped profiles -- they still carry `filament_load_time`,
`adaptive_layer_height` and others that were deliberately dropped.

So the obsolete set is lifted to file scope and exposed as
`PrintConfigDef::is_obsolete_key()`, and only keys that are *not*
obsolete are reported. Retired settings stay silent, as they should.

### `--strict-config`

Turns those warnings into a refusal. The default is unchanged, so
interactive use is unaffected; a CI or scripted pipeline can ask to be
told rather than guess. It is deliberately separate from `--no-check`,
which concerns slicing warnings rather than whether the configuration was
understood at all. It only triggers on genuinely unknown keys, so it does
not fail on the shipped profiles.

## Tests

Built on Windows (VS 2026 / MSVC 14.5x, CMake 4.4.2).

A process config carrying two bogus keys, `outer_wall_speeed` and
`totally_made_up_option`:

| | stock 2.4.2 | this branch |
|---|---|---|
| output about them | none | both named as warnings |
| exit code | 0 | 0 (unchanged) |
| with `--strict-config` | n/a | refuses, non-zero exit |

Slicing the shipped Creality and SeeMeCNC profiles no longer reports the
keys they carry that were retired on purpose -- `filament_load_time` and
`filament_unload_time` are in the obsolete set and now stay quiet, which
is what prompted the split.

What it does still report on those profiles turned out to be worth
having. Two keys appear in the shipped data and **nowhere in `src/`**:

| key | shipped profiles carrying it | occurrences in `src/` |
|---|---|---|
| `material_flow_dependent_temperature` | 514 | 0 |
| `material_flow_temp_graph` | 401 | 0 |

They are not declared, not aliased and not in the obsolete set, so every
load quietly drops them and nothing says so. I have deliberately not
added them to the obsolete set here -- whether they are dead weight or a
setting that was meant to land is a call for whoever owns that data, and
this PR should not decide it. The warning is what makes the question
visible.


---

Two things travel together here because the flag is meaningless without
the reporting: the warning is what `--strict-config` acts on. Happy to
split them into separate PRs if reviewers would rather.

The predicate is added to `PrintConfigDef` because that is where the
obsolete set already lives; it does mean `PrintConfig.hpp` changes and
`libslic3r` rebuilds. Filtering inside `set_deserialize_nothrow()`
instead would avoid the header, but `ConfigBase` cannot tell why
`handle_legacy()` cleared the key -- both reasons look identical from
there -- so the distinction has to come from `PrintConfigDef` either way.
