### PR TITLE
build: clear 227 warnings - dead private fields, malformed comments

### DIFF
--- a/src/slic3r/GUI/DeviceCore/DevFirmware.h
+++ b/src/slic3r/GUI/DeviceCore/DevFirmware.h
@@ -64,7 +64,7 @@ public:
     DevFirmware(MachineObject* obj) : m_owner(obj) {}
 
 private:
-    MachineObject* m_owner = nullptr;
+    [[maybe_unused]] MachineObject* m_owner = nullptr;
 };
 
 } // namespace Slic3r

--- a/src/slic3r/GUI/DeviceTab/uiAMSBestPositionPopup.cpp
+++ b/src/slic3r/GUI/DeviceTab/uiAMSBestPositionPopup.cpp
@@ -2,7 +2,7 @@
 /* File: uiAMSBestPositionPopup.hpp
 *  Description: The popup with suggest best ams position
 *
-//**********************************************************/
+************************************************************/
 
 #include "uiAMSBestPositionPopup.hpp"
 

--- a/src/slic3r/GUI/DeviceTab/uiAMSBestPositionPopup.hpp
+++ b/src/slic3r/GUI/DeviceTab/uiAMSBestPositionPopup.hpp
@@ -2,7 +2,7 @@
 /* File: uiAMSBestPositionPopup.hpp
 *  Description: The popup with suggest best ams position
 *
-//**********************************************************/
+************************************************************/
 
 #pragma once
 #include "slic3r/GUI/Widgets/AMSItem.hpp"

--- a/src/slic3r/GUI/DeviceTab/wgtDeviceNozzleRack.cpp
+++ b/src/slic3r/GUI/DeviceTab/wgtDeviceNozzleRack.cpp
@@ -6,7 +6,7 @@
 *  \n class wgtDeviceNozzleRackNozzleItem;
 *  \n class wgtDeviceNozzleRackToolHead;
 *  \n class wgtDeviceNozzleRackPos;
-//**********************************************************/
+************************************************************/
 
 #include "wgtDeviceNozzleRack.h"
 #include "wgtDeviceNozzleRackUpdate.h"

--- a/src/slic3r/GUI/DeviceTab/wgtDeviceNozzleRack.h
+++ b/src/slic3r/GUI/DeviceTab/wgtDeviceNozzleRack.h
@@ -6,7 +6,7 @@
 *  \n class wgtDeviceNozzleRackNozzleItem;
 *  \n class wgtDeviceNozzleRackToolHead;
 *  \n class wgtDeviceNozzleRackPos;
-//**********************************************************/
+************************************************************/
 
 #pragma once
 #include "slic3r/GUI/DeviceCore/DevNozzleRack.h"

--- a/src/slic3r/GUI/DeviceTab/wgtDeviceNozzleRackUpdate.cpp
+++ b/src/slic3r/GUI/DeviceTab/wgtDeviceNozzleRackUpdate.cpp
@@ -3,7 +3,7 @@
 *  Description: The panel with rack updating
 *
 * \n class wgtDeviceNozzleRackUpdate
-//**********************************************************/
+************************************************************/
 
 #include "wgtDeviceNozzleRackUpdate.h"
 

--- a/src/slic3r/GUI/DeviceTab/wgtDeviceNozzleRackUpdate.h
+++ b/src/slic3r/GUI/DeviceTab/wgtDeviceNozzleRackUpdate.h
@@ -3,7 +3,7 @@
 *  Description: The panel for updating hotends
 *
 *  \n class wgtDeviceNozzleRackUpdate
-//**********************************************************/
+************************************************************/
 
 #pragma once
 #include "slic3r/GUI/DeviceCore/DevNozzleRack.h"

--- a/src/slic3r/GUI/DeviceTab/wgtDeviceNozzleSelect.cpp
+++ b/src/slic3r/GUI/DeviceTab/wgtDeviceNozzleSelect.cpp
@@ -3,7 +3,7 @@
 *  Description: The panel to select nozzle
 *
 *  \n class wgtDeviceNozzleSelect;
-//**********************************************************/
+************************************************************/
 
 #include "wgtDeviceNozzleSelect.h"
 #include "wgtDeviceNozzleRack.h"

--- a/src/slic3r/GUI/DeviceTab/wgtDeviceNozzleSelect.h
+++ b/src/slic3r/GUI/DeviceTab/wgtDeviceNozzleSelect.h
@@ -3,7 +3,7 @@
 *  Description: The panel to select nozzle
 *
 *  \n class wgtDeviceNozzleSelect;
-//**********************************************************/
+************************************************************/
 
 #pragma once
 

--- a/src/slic3r/GUI/GUI_Utils.hpp
+++ b/src/slic3r/GUI/GUI_Utils.hpp
@@ -155,6 +155,9 @@ public:
                 update_dark_config();
                 on_sys_color_changed();
                 event.Skip();
+#else
+                // Not calling Skip() is what stops the event propagating on Windows.
+                (void) this;
 #endif // __WINDOWS__
 
         });

--- a/src/slic3r/GUI/SelectMachine.cpp
+++ b/src/slic3r/GUI/SelectMachine.cpp
@@ -2847,7 +2847,7 @@ void SelectMachineDialog::on_ok_btn(wxCommandEvent &event)
             });
 
         // STUDIO-9580
-        /* use warning color if there are warning and normal messages* /
+        /* use warning color if there are warning and normal messages*/
         /* use indexes if there are several messages*/
         /* add header and ending if there are several messages or has none block warnings*/
         if (confirm_text.size() > 1 || !is_printing_block)

--- a/src/slic3r/GUI/Tabbook.hpp
+++ b/src/slic3r/GUI/Tabbook.hpp
@@ -36,7 +36,6 @@ public:
     TabButton*                      pageButton;
 
 private:
-    wxWindow*                       m_parent;
     wxFlexGridSizer*                m_buttons_sizer;
     wxBoxSizer*                     m_sizer;
     ScalableBitmap                  m_arrow_img;
@@ -399,8 +398,6 @@ private:
 
     unsigned m_showTimeout,
              m_hideTimeout;
-
-    TabButtonsListCtrl *m_ctrl{nullptr};
 
 };
 //#endif // _WIN32

--- a/src/slic3r/GUI/Widgets/AMSItem.cpp
+++ b/src/slic3r/GUI/Widgets/AMSItem.cpp
@@ -2083,9 +2083,6 @@ void AMSRoad::OnPassRoad(std::vector<AMSPassRoadMode> prord_list)
     }
 }
 
-/*
-
-
 /*************************************************
 Description:AMSRoadUpPart
 **************************************************/


### PR DESCRIPTION
# Description

Clears 227 clang-cl warnings, 1,491 down to 1,264 on a full Windows build. Part of #15374. The count is large for a 14-line diff because five of the six changes are in headers, which are re-diagnosed in every translation unit that includes them.

- `Tabbook.hpp`: delete two private fields, unread since the 2022 import. `m_parent` also shadowed `wxWindowBase::m_parent`. (85)
- `GUI_Utils.hpp`: the `wxEVT_SYS_COLOUR_CHANGED` lambda body is empty on Windows, so its `this` capture is unused there. `(void) this;` leaves the handler bound, which is what stops the event propagating. (69)
- `DevFirmware.h`: mark `m_owner` `[[maybe_unused]]`. The class is never instantiated, and the file tracks BambuStudio, so this is the smallest divergence. (48)
- Eight `DeviceTab/` files: the banner comment's closing line starts with `//` inside the block comment opened above it, which reads as a nested `/*`. (23)
- `AMSItem.cpp`: stray `/*` left above a banner comment. (1)
- `SelectMachine.cpp`: `messages* /` has a space, so that comment never closes and swallows the next one. (1)

No behavior change.

# Screenshots/Recordings/Graphs

None, this is not a UI change.

## Tests

Full clang-cl builds before and after (VS clang 20.1.8, Release, `BUILD_TESTS=ON`), both exit 0. Only the three intended categories move, by exactly the amounts above:

```
-Wcomment                     25 ->     0   (-25)
-Wunused-lambda-capture      306 ->   237   (-69)
-Wunused-private-field       294 ->   161  (-133)
```

`ctest`: 598 tests, 0 failures, 5 skipped.

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
