### PR TITLE
build: clear 143 -Woverloaded-virtual warnings in GUI widgets

### DIFF
--- a/src/slic3r/GUI/CalibrationWizardPresetPage.cpp
+++ b/src/slic3r/GUI/CalibrationWizardPresetPage.cpp
@@ -1015,7 +1015,7 @@ wxBoxSizer* CalibrationPresetPage::create_ams_items_sizer(MachineObject* obj, wx
     auto ams_items_sizer = new wxBoxSizer(wxHORIZONTAL);
     for (auto &info : ams_info) {
         auto preview_ams_item = new AMSPreview(ams_preview_panel, wxID_ANY, info, info.ams_type);
-        preview_ams_item->Update(info);
+        preview_ams_item->UpdateInfo(info);
         preview_ams_item->Open();
         ams_preview_list.push_back(preview_ams_item);
         std::string ams_id = preview_ams_item->get_ams_id();

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -1467,12 +1467,12 @@ void ExtruderGroup::update_ams()
     size_t left  = 4;
     size_t index = 0;
     for (size_t i = i4; i < ams_n4 && left > 0; ++i, ++index, left -= 2) {
-        ams[index]->Update(i < ams_4.size() ? ams_4[i] : info4);
+        ams[index]->UpdateInfo(i < ams_4.size() ? ams_4[i] : info4);
         ams[index]->Refresh();
         ams[index]->Open();
     }
     for (size_t i = i1; i < ams_n1 && left > 0; ++i, ++index, --left) {
-        ams[index]->Update(i < ams_1.size() ? ams_1[i] : info1);
+        ams[index]->UpdateInfo(i < ams_1.size() ? ams_1[i] : info1);
         ams[index]->Refresh();
         ams[index]->Open();
     }

--- a/src/slic3r/GUI/Widgets/AMSControl.cpp
+++ b/src/slic3r/GUI/Widgets/AMSControl.cpp
@@ -984,7 +984,7 @@ void AMSControl::UpdateAms(const std::string   &series_name,
             if (cans->get_ams_id() == std::to_string(VIRTUAL_TRAY_MAIN_ID) || cans->get_ams_id() == std::to_string(VIRTUAL_TRAY_DEPUTY_ID)) {
                 for (auto ifo : m_ext_info) {
                     if (ifo.ams_id == ams_id) {
-                        cans->Update(ifo);
+                        cans->UpdateInfo(ifo);
                         cans->show_sn_value(m_ams_model == AMSModel::AMS_LITE ? false : true);
                     }
                 }
@@ -992,7 +992,7 @@ void AMSControl::UpdateAms(const std::string   &series_name,
             else{
                 for (auto ifo : m_ams_info) {
                     if (ifo.ams_id == ams_id) {
-                        cans->Update(ifo);
+                        cans->UpdateInfo(ifo);
                         cans->show_sn_value(m_ams_model == AMSModel::AMS_LITE ? false : true);
                     }
                 }
@@ -1015,7 +1015,7 @@ void AMSControl::UpdateAms(const std::string   &series_name,
             std::string id = ams_prv.second->get_ams_id();
             auto item = m_ams_item_list.find(id);
             if (item != m_ams_item_list.end())
-            { ams_prv.second->Update(item->second->get_ams_info());
+            { ams_prv.second->UpdateInfo(item->second->get_ams_info());
             }
         }
     }

--- a/src/slic3r/GUI/Widgets/AMSItem.cpp
+++ b/src/slic3r/GUI/Widgets/AMSItem.cpp
@@ -325,7 +325,7 @@ AMSrefresh::AMSrefresh(wxWindow *parent, std::string ams_id, wxString can_id, Ca
     m_can_id = can_id.ToStdString();
     create(parent, wxID_ANY, pos, size);
 
-    Update(ams_id, info);
+    UpdateInfo(ams_id, info);
 }
 
 AMSrefresh::AMSrefresh(wxWindow *parent, std::string ams_id, int can_id, Caninfo info, const wxPoint &pos, const wxSize &size) : AMSrefresh()
@@ -333,7 +333,7 @@ AMSrefresh::AMSrefresh(wxWindow *parent, std::string ams_id, int can_id, Caninfo
     m_can_id = wxString::Format("%d", can_id).ToStdString();
     create(parent, wxID_ANY, pos, size);
 
-    Update(ams_id, info);
+    UpdateInfo(ams_id, info);
 }
 
  AMSrefresh::~AMSrefresh()
@@ -482,7 +482,7 @@ void AMSrefresh::paintEvent(wxPaintEvent &evt)
     dc.DrawText(m_refresh_id, pot);
 }
 
-void AMSrefresh::Update(std::string ams_id, Caninfo info)
+void AMSrefresh::UpdateInfo(std::string ams_id, Caninfo info)
 {
     if (m_ams_id == ams_id && m_info == info)
     {
@@ -945,7 +945,7 @@ AMSLib::AMSLib(wxWindow *parent, std::string ams_idx, Caninfo info, AMSModelOrig
     Bind(wxEVT_LEAVE_WINDOW, &AMSLib::on_leave_window, this);
     Bind(wxEVT_LEFT_DOWN, &AMSLib::on_left_down, this);
 
-    Update(info, ams_idx, false);
+    UpdateInfo(info, ams_idx, false);
 }
 
 AMSLib::~AMSLib()
@@ -1730,7 +1730,7 @@ void AMSLib::on_pass_road(bool pass)
     }
 }
 
-void AMSLib::Update(Caninfo info, std::string ams_idx, bool refresh)
+void AMSLib::UpdateInfo(Caninfo info, std::string ams_idx, bool refresh)
 {
     DeviceManager* dev = Slic3r::GUI::wxGetApp().getDeviceManager();
     if (!dev) return;
@@ -1868,7 +1868,7 @@ AMSRoad::AMSRoad(wxWindow *parent, wxWindowID id, Caninfo info, int canindex, in
 
 void AMSRoad::create(wxWindow *parent, wxWindowID id, const wxPoint &pos, const wxSize &size) { wxWindow::Create(parent, id, pos, size); }
 
-void AMSRoad::Update(AMSinfo amsinfo, Caninfo info, int canindex, int maxcan)
+void AMSRoad::UpdateInfo(AMSinfo amsinfo, Caninfo info, int canindex, int maxcan)
 {
     m_amsinfo = amsinfo;
     m_info     = info;
@@ -2124,7 +2124,7 @@ void AMSRoadUpPart::create(wxWindow* parent, wxWindowID id, const wxPoint& pos, 
     Refresh();
 }
 
-void AMSRoadUpPart::Update(AMSinfo amsinfo)
+void AMSRoadUpPart::UpdateInfo(AMSinfo amsinfo)
 {
     if (m_amsinfo != amsinfo)
     {
@@ -2616,7 +2616,7 @@ void AMSPreview::Close()
     Hide();
 }
 
-void AMSPreview::Update(AMSinfo amsinfo)
+void AMSPreview::UpdateInfo(AMSinfo amsinfo)
 {
     if (m_amsinfo == amsinfo)
     {
@@ -2954,7 +2954,7 @@ AMSHumidity::AMSHumidity(wxWindow* parent, wxWindowID id, AMSinfo info, const wx
         }
         });
 
-    Update(info);
+    UpdateInfo(info);
 }
 
 void AMSHumidity::create(wxWindow* parent, wxWindowID id, const wxPoint& pos, const wxSize& size) {
@@ -2963,7 +2963,7 @@ void AMSHumidity::create(wxWindow* parent, wxWindowID id, const wxPoint& pos, co
 }
 
 
-void AMSHumidity::Update(AMSinfo amsinfo)
+void AMSHumidity::UpdateInfo(AMSinfo amsinfo)
 {
     if (m_amsinfo != amsinfo)
     {
@@ -3380,7 +3380,7 @@ void AmsItem::AddLiteCan(Caninfo caninfo, int canindex, wxGridSizer* sizer)
     //m_can_road_list[caninfo.can_id] = m_panel_road;
 }
 
-void AmsItem::Update(AMSinfo info)
+void AmsItem::UpdateInfo(AMSinfo info)
 {
     if (m_info == info)
     {
@@ -3392,7 +3392,7 @@ void AmsItem::Update(AMSinfo info)
 
     if (m_humidity)
     {
-        m_humidity->Update(m_info);
+        m_humidity->UpdateInfo(m_info);
     }
 
     for (int i = 0; i < m_can_count; i++) {
@@ -3401,7 +3401,7 @@ void AmsItem::Update(AMSinfo info)
 
         auto refresh = it->second;
         if (refresh != nullptr){
-            refresh->Update(info.ams_id, info.cans[i]);
+            refresh->UpdateInfo(info.ams_id, info.cans[i]);
             refresh->Show();
         }
     }
@@ -3410,7 +3410,7 @@ void AmsItem::Update(AMSinfo info)
         AMSLib* lib = m_can_lib_list[std::to_string(i)];
         if (lib != nullptr){
             if (i < m_can_count){
-                lib->Update(info.cans[i], info.ams_id);
+                lib->UpdateInfo(info.cans[i], info.ams_id);
                 lib->Show();
             }
             else{
@@ -3419,12 +3419,7 @@ void AmsItem::Update(AMSinfo info)
         }
     }
     if (m_panel_road != nullptr){
-        m_panel_road->Update(m_info);
-    }
-
-    if (true || m_ams_model == AMSModel::GENERIC_AMS) {
-        /*m_panel_road->Update(m_info, info.cans[0]);
-        m_panel_road->Show();*/
+        m_panel_road->UpdateInfo(m_info);
     }
 
     Layout();

--- a/src/slic3r/GUI/Widgets/AMSItem.hpp
+++ b/src/slic3r/GUI/Widgets/AMSItem.hpp
@@ -312,7 +312,7 @@ public:
     ~AMSrefresh();
 
 public:
-    void        Update(std::string ams_id, Caninfo info);
+    void        UpdateInfo(std::string ams_id, Caninfo info);
 
     std::string GetCanId() const { return m_info.can_id; };
 
@@ -492,7 +492,7 @@ public:
     AMSModel     m_ams_model;
     AMSModelOriginType m_ext_type = { AMSModelOriginType::GENERIC_EXT };
 
-    void         Update(Caninfo info, std::string ams_idx, bool refresh = true);
+    void         UpdateInfo(Caninfo info, std::string ams_idx, bool refresh = true);
     void         UnableSelected() { m_unable_selected = true; };
     void         EableSelected() { m_unable_selected = false; };
     void         OnSelected();
@@ -581,7 +581,7 @@ public:
     double                       m_radius         = {4};
     wxColour                     m_road_def_color;
     wxColour                     m_road_color;
-    void                         Update(AMSinfo amsinfo, Caninfo info, int canindex, int maxcan);
+    void                         UpdateInfo(AMSinfo amsinfo, Caninfo info, int canindex, int maxcan);
 
     std::vector<ScalableBitmap> ams_humidity_img;
 
@@ -614,7 +614,7 @@ public:
     void create(wxWindow* parent, wxWindowID id = wxID_ANY, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize);
 
 public:
-    void Update(AMSinfo amsinfo);
+    void UpdateInfo(AMSinfo amsinfo);
 
     void OnVamsLoading(bool load, wxColour col = AMS_CONTROL_GRAY500);
     void SetPassRoadColour(wxColour col);
@@ -715,7 +715,7 @@ public:
     void Open();
     void Close();
 
-    void         Update(AMSinfo amsinfo);
+    void         UpdateInfo(AMSinfo amsinfo);
     void         create(wxWindow *parent, wxWindowID id, const wxPoint &pos, const wxSize &size);
     void         OnEnterWindow(wxMouseEvent &evt);
     void         OnLeaveWindow(wxMouseEvent &evt);
@@ -768,7 +768,7 @@ public:
     int                          m_canindex = { 0 };
     bool                         m_selected = { false };
     double                       m_radius = { 12 };
-    void                         Update(AMSinfo amsinfo);
+    void                         UpdateInfo(AMSinfo amsinfo);
 
     std::vector<ScalableBitmap> ams_humidity_imgs;
     std::vector<ScalableBitmap> ams_humidity_dark_imgs;
@@ -801,7 +801,7 @@ public:
     AmsItem(wxWindow *parent, AMSinfo info, AMSModel model, AMSPanelPos pos);
     ~AmsItem();
 
-    void     Update(AMSinfo info);
+    void     UpdateInfo(AMSinfo info);
     void     create(wxWindow *parent);
     void     AddCan(Caninfo caninfo, int canindex, int maxcan, wxBoxSizer* sizer);
     void     AddLiteCan(Caninfo caninfo, int canindex, wxGridSizer* sizer);

--- a/src/slic3r/GUI/Widgets/ScrolledWindow.cpp
+++ b/src/slic3r/GUI/Widgets/ScrolledWindow.cpp
@@ -110,17 +110,6 @@ void ScrolledWindow::SetTipColor(wxColour color)
     if (m_bottomScrollbar) m_bottomScrollbar->SetTipColor(color);
 }
 
-void ScrolledWindow::Refresh()
-{
-    // m_rightScrollbar->SetViewStart(0);
-    // m_rightScrollbar->Refresh();
-    // m_rightScrollbar->Update();
-    // m_userPanel->Refresh();
-    // m_bottomScrollbar->SetViewStart(0);
-    // m_rightScrollbar->Refresh();
-    // m_bottomScrollbar->Refresh();
-}
-
 void ScrolledWindow::SetBackgroundColour(wxColour color)
 {
     wxWindow::SetBackgroundColour(color); 

--- a/src/slic3r/GUI/Widgets/ScrolledWindow.hpp
+++ b/src/slic3r/GUI/Widgets/ScrolledWindow.hpp
@@ -15,7 +15,6 @@ public:
     ScrolledWindow(wxWindow *parent, wxWindowID id, wxPoint position, wxSize size, long style, int marginWidth = 0, int scrollbarWidth = 4, int tipLength = 0);
     void OnMouseWheel(wxMouseEvent &event);
     void SetTipColor(wxColour color);
-    void Refresh();
     void SetBackgroundColour(wxColour color);
 
     void         SetMarginColor(wxColour color);


### PR DESCRIPTION
# Description

Clears 143 of the 553 `-Woverloaded-virtual` warnings, taking a full clang-cl build from 1,491 to 1,348. Part of #15374. The two widgets below are unrelated, but both hit the same defect, a derived member hiding a base virtual of the same name.

`AMSItem.hpp` declares seven `Update(...)` methods that push device state into a widget. `wxWindow::Update()` means something unrelated, repaint the invalidated area immediately, and any member named `Update` in a derived class hides every base declaration of that name. Renamed the seven to `UpdateInfo`, matching `uiDeviceUpdateVersion::UpdateInfo` and `wgtDeviceNozzleRackHotendUpdate::UpdateInfo` elsewhere in the device UI, and updated the 14 call sites. One dead `if (true || ...)` block in `AMSItem.cpp`, body already commented out, held a stale reference to the old name, so it goes too.

A `using wxWindow::Update;` declaration silences the warning too, but it leaves both meanings on one name, so `item->Update()` would repaint and `item->Update(info)` would rebind data. The collision is the problem, so I changed the name.

`ScrolledWindow::Refresh()` was an empty function, body entirely commented out, hiding `wxWindow::Refresh(bool, const wxRect*)`. Nothing called it, so it is gone. That one declaration is worth 73 of the 143, since the header is included widely and the warning repeats in every translation unit that pulls it in.

No behavior change.

# Screenshots/Recordings/Graphs

No visual change.

## Tests

Full clang-cl builds before and after (VS clang 20.1.8, Release, `BUILD_TESTS=ON`), both exit 0.

```
-Woverloaded-virtual         553 ->   410  (-143)
```

No other warning category changed.

`ctest`: 598 tests, 0 failures, 5 skipped.

Smoke tested the AMS panel with a printer connected.

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
