### PR TITLE
Fix manual tool change handling when loading G-code files

### DIFF
--- a/src/libslic3r/GCode/GCodeProcessor.cpp
+++ b/src/libslic3r/GCode/GCodeProcessor.cpp
@@ -3446,6 +3446,10 @@ void GCodeProcessor::apply_config(const DynamicPrintConfig& config)
     if (has_scarf_joint_seam != nullptr)
         m_detect_layer_based_on_tag = m_detect_layer_based_on_tag || has_scarf_joint_seam->value;
 
+    const ConfigOptionBool* manual_filament_change = config.option<ConfigOptionBool>("manual_filament_change");
+    if (manual_filament_change != nullptr)
+        m_manual_filament_change = manual_filament_change->value;
+
     const ConfigOptionEnumGeneric *bed_type = config.option<ConfigOptionEnumGeneric>("curr_bed_type");
     if (bed_type != nullptr)
         m_result.bed_type = (BedType)bed_type->value;

--- a/src/libslic3r/GCode/GCodeProcessor.hpp
+++ b/src/libslic3r/GCode/GCodeProcessor.hpp
@@ -1123,7 +1123,7 @@ class Print;
         // m_result.nozzle_group_result, which is handed over only after the stream for the
         // pre-heat injector's second pass and gates the richer change-time model.
         std::shared_ptr<MultiNozzleUtils::NozzleGroupResultBase> m_nozzle_group_result;
-        bool m_manual_filament_change;
+        bool m_manual_filament_change{ false };
 
         //BBS: x, y offset for gcode generated
         double          m_x_offset{ 0 };


### PR DESCRIPTION
### Summary
Fixes G-code preview tool/color assignment when loading files using manual filament changes.

### Details
The generated preview path applies manual_filament_change through PrintConfig, but the G-code loading path uses DynamicPrintConfig and did not propagate that option to GCodeProcessor. As a result, MANUAL_TOOL_CHANGE comments were parsed but ignored for opened or drag-dropped G-code files.

### Testing
- Built OrcaSlicer Release on Windows.
- Verified drag-dropping the affected G-code now shows the same filament/tool colors as the preview after slicing.