### PR TITLE
Fix CHB parciall bridge

### DIFF
--- a/src/libslic3r/PerimeterGenerator.cpp
+++ b/src/libslic3r/PerimeterGenerator.cpp
@@ -2127,7 +2127,7 @@ void PerimeterGenerator::process_no_bridge(Surfaces& all_surfaces, coord_t perim
                                 bridgeable_filtered = union_ex(offset_ex(remaining, perimeter_spacing), bridgeable_filtered);
                                 bridgeable_filtered = offset_ex(bridgeable_filtered, -perimeter_spacing);
                                 bridgeable_filtered = diff_ex(bridgeable_filtered, remaining, ApplySafetyOffset::Yes);
-                                bridgeable_filtered = opening_ex(bridgeable_filtered, perimeter_spacing); // filter noise from the diff_ex
+                                bridgeable_filtered = opening_ex(bridgeable_filtered, ext_perimeter_width / 2); // filter noise from the diff_ex
                                 bridgeable_filtered = offset_ex(bridgeable_filtered, perimeter_spacing);  // restore the size to the original bridgeable area
                                 // Safety measure: Keep the bridge mask from intruding deeper into the
                                 // supported anchor region than the explicit anchor overlap.


### PR DESCRIPTION
Fixing this comment https://github.com/OrcaSlicer/OrcaSlicer/issues/13828#issuecomment-4682204549

# DISCLAIMER

THIS IS JUST A QUICK ONE LINER FIX!!!
The partial bridge still has many problems; I think we should rethink it from scratch by taking a simpler approach: starting with the shortest possible line tangent to the hole to be covered, and then completing it with the bridge pattern up to the adjacent wall, using a line width that ensures proper anchoring.
Im working on it in a new PR.

# Description

Adjust the morphology opening step in `PerimeterGenerator::process_no_bridge` to use `ext_perimeter_width / 2` instead of `perimeter_spacing` when filtering `diff_ex` artifacts. This makes bridgeable-area cleanup scale with actual external perimeter width and avoids overly aggressive filtering tied to spacing.

# Screenshots/Recordings/Graphs

Before
<img width="972" height="928" alt="imagen" src="https://github.com/user-attachments/assets/a41f4875-e0b1-4982-ad59-aa385d9a40ef" />

After
<img width="972" height="928" alt="imagen" src="https://github.com/user-attachments/assets/9f7a4734-d299-48c5-bcb9-b767f3e8f5ba" />


## Tests

<!--
> Please describe the tests that you have conducted to verify the changes made in this PR.
-->

<!--
> A guide for users on how to download the artifacts from this PR.
-->

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
