### PR TITLE
Fix Orca Cloud API requests to use HTTPS

### DIFF
--- a/src/slic3r/Utils/OrcaCloudServiceAgent.cpp
+++ b/src/slic3r/Utils/OrcaCloudServiceAgent.cpp
@@ -60,7 +60,7 @@ using json = nlohmann::json;
 namespace Slic3r {
 
 namespace {
-constexpr const char* ORCA_DEFAULT_API_URL   = "api.orcaslicer.com";
+constexpr const char* ORCA_DEFAULT_API_URL   = "https://api.orcaslicer.com";
 constexpr const char* ORCA_DEFAULT_AUTH_URL  = "https://auth.orcaslicer.com";
 constexpr const char* ORCA_DEFAULT_CLOUD_URL = "https://cloud.orcaslicer.com";
 // Orca: This is a public key with no secret, used to identify the client application to the backend.


### PR DESCRIPTION
# Description

The default Orca Cloud API URL omits its scheme, so libcurl interprets it as HTTP and follows the server redirect to HTTPS. Recent libcurl versions intentionally do not forward the `Authorization` header across protocol/port-changing redirects, causing Orca Cloud profile sync to receive HTTP 401 `missing_authorization` responses and eventually log the user out.

Use the HTTPS API URL directly. Besides restoring sync with current libcurl versions, this improves security by preventing the bearer access token from being sent in the initial unencrypted HTTP request.

# Screenshots/Recordings/Graphs

N/A — no UI changes.

## Tests

- `git diff --check`
- Confirmed with current libcurl that the scheme-less URL redirects and loses the authorization header, while the direct HTTPS URL retains it
