### PR TITLE
ci: build macOS with 3 parallel jobs instead of 1

### DIFF
--- a/.github/workflows/build_deps.yml
+++ b/.github/workflows/build_deps.yml
@@ -151,7 +151,7 @@ jobs:
             if [ -z "${{ vars.SELF_HOSTED }}" ]; then
               brew install automake texinfo libtool
             fi
-            ./build_release_macos.sh -dx ${{ !vars.SELF_HOSTED && '-j 1' || '' }} -a ${{ inputs.arch }} -t 10.15
+            ./build_release_macos.sh -dx ${{ !vars.SELF_HOSTED && '-j 3' || '' }} -a ${{ inputs.arch }} -t 10.15
             (cd "${{ github.workspace }}/deps/build/${{ inputs.arch }}" && \
             find . -mindepth 1 -maxdepth 1 ! -name 'OrcaSlicer_dep' -exec rm -rf {} +)
 

--- a/.github/workflows/build_deps.yml
+++ b/.github/workflows/build_deps.yml
@@ -151,7 +151,7 @@ jobs:
             if [ -z "${{ vars.SELF_HOSTED }}" ]; then
               brew install automake texinfo libtool
             fi
-            ./build_release_macos.sh -dx ${{ !vars.SELF_HOSTED && '-1' || '' }} -a ${{ inputs.arch }} -t 10.15
+            ./build_release_macos.sh -dx ${{ !vars.SELF_HOSTED && '-j 1' || '' }} -a ${{ inputs.arch }} -t 10.15
             (cd "${{ github.workspace }}/deps/build/${{ inputs.arch }}" && \
             find . -mindepth 1 -maxdepth 1 ! -name 'OrcaSlicer_dep' -exec rm -rf {} +)
 

--- a/.github/workflows/build_orca.yml
+++ b/.github/workflows/build_orca.yml
@@ -145,7 +145,7 @@ jobs:
         env:
           ORCA_TESTS_BUILD_ONLY: ${{ inputs.arch == 'arm64' && '1' || '' }}
         run: |
-          ./build_release_macos.sh -s -n -x ${{ !vars.SELF_HOSTED && '-1' || '' }} -a ${{ inputs.arch }} -t 10.15 ${{ inputs.arch == 'arm64' && '-T' || '' }}
+          ./build_release_macos.sh -s -n -x ${{ !vars.SELF_HOSTED && '-j 1' || '' }} -a ${{ inputs.arch }} -t 10.15 ${{ inputs.arch == 'arm64' && '-T' || '' }}
 
       - name: Pack unit tests mac
         if: runner.os == 'macOS' && !inputs.macos-combine-only && inputs.arch == 'arm64'
@@ -204,7 +204,7 @@ jobs:
         if: runner.os == 'macOS' && inputs.macos-combine-only
         working-directory: ${{ github.workspace }}
         run: |
-          ./build_release_macos.sh -u -x ${{ !vars.SELF_HOSTED && '-1' || '' }} -a universal -t 10.15
+          ./build_release_macos.sh -u -x ${{ !vars.SELF_HOSTED && '-j 1' || '' }} -a universal -t 10.15
 
  # Thanks to RaySajuuk, it's working now
       - name: Sign app and notary

--- a/.github/workflows/build_orca.yml
+++ b/.github/workflows/build_orca.yml
@@ -145,7 +145,7 @@ jobs:
         env:
           ORCA_TESTS_BUILD_ONLY: ${{ inputs.arch == 'arm64' && '1' || '' }}
         run: |
-          ./build_release_macos.sh -s -n -x ${{ !vars.SELF_HOSTED && '-j 1' || '' }} -a ${{ inputs.arch }} -t 10.15 ${{ inputs.arch == 'arm64' && '-T' || '' }}
+          ./build_release_macos.sh -s -n -x ${{ !vars.SELF_HOSTED && '-j 3' || '' }} -a ${{ inputs.arch }} -t 10.15 ${{ inputs.arch == 'arm64' && '-T' || '' }}
 
       - name: Pack unit tests mac
         if: runner.os == 'macOS' && !inputs.macos-combine-only && inputs.arch == 'arm64'
@@ -204,7 +204,7 @@ jobs:
         if: runner.os == 'macOS' && inputs.macos-combine-only
         working-directory: ${{ github.workspace }}
         run: |
-          ./build_release_macos.sh -u -x ${{ !vars.SELF_HOSTED && '-j 1' || '' }} -a universal -t 10.15
+          ./build_release_macos.sh -u -x ${{ !vars.SELF_HOSTED && '-j 3' || '' }} -a universal -t 10.15
 
  # Thanks to RaySajuuk, it's working now
       - name: Sign app and notary

--- a/build_release_macos.sh
+++ b/build_release_macos.sh
@@ -4,7 +4,7 @@ set -e
 set -o pipefail
 SECONDS=0
 
-while getopts ":dpa:snt:xbc:i:1Tuh" opt; do
+while getopts ":dpa:snt:xbc:i:j:Tuh" opt; do
   case "${opt}" in
     d )
         export BUILD_TARGET="deps"
@@ -38,8 +38,8 @@ while getopts ":dpa:snt:xbc:i:1Tuh" opt; do
     i )
         export CMAKE_IGNORE_PREFIX_PATH="${CMAKE_IGNORE_PREFIX_PATH:+$CMAKE_IGNORE_PREFIX_PATH;}$OPTARG"
         ;;
-    1 )
-        export CMAKE_BUILD_PARALLEL_LEVEL=1
+    j )
+        export CMAKE_BUILD_PARALLEL_LEVEL="$OPTARG"
         ;;
     T )
         export BUILD_TESTS="1"
@@ -58,7 +58,7 @@ while getopts ":dpa:snt:xbc:i:1Tuh" opt; do
         echo "   -b: Build without reconfiguring CMake"
         echo "   -c: Set CMake build configuration, default is Release"
         echo "   -i: Add a prefix to ignore during CMake dependency discovery (repeatable), defaults to /opt/local:/usr/local:/opt/homebrew"
-        echo "   -1: Use single job for building"
+        echo "   -j: Set the number of parallel build jobs (CMAKE_BUILD_PARALLEL_LEVEL)"
         echo "   -T: Build and run tests (set ORCA_TESTS_BUILD_ONLY=1 to build without running)"
         exit 0
         ;;


### PR DESCRIPTION
# Description

macOS is the CI bottleneck. Public repos get 5 concurrent macOS jobs and `build_all` uses roughly 150 slot-minutes of them per run, so the pool saturates. Across 31 recent runs the median macOS queue was 7 hours and **several runs took over 10 hours** end to end (e.g. https://github.com/OrcaSlicer/OrcaSlicer/actions/runs/32888212635, 10.9h).

The macOS builds are serial: `-1` sets `CMAKE_BUILD_PARALLEL_LEVEL=1`. That arrived in #5856 alongside the macos-12 to macos-14 move and has not been revisited since. **Why 1?** Without the flag Ninja defaults to `nproc + 2`, which is 5 on a 3-core runner, and that may well be what failed at the time. 2 and 3 both build clean today on the same 7 GB runner.

This replaces `-1` with a general `-j N` and sets 3, which halves macOS slot time per run (327 min to 161 min).

| stage (macos-14, cold cache) | serial | -j2 | -j3 |
|---|---|---|---|
| deps arm64 | 70m | 43m | 36m |
| deps x86_64 | 73m | 38m | 30m |
| app arm64 | 93m | 58m | 50m |
| app x86_64 | 88m | 50m | 42m |

## Tests

Full `build_all` at both levels on a fork, all macOS jobs good, no OOM:

https://github.com/raistlin7447/OrcaSlicer/actions/runs/32999911884 (-j2)
https://github.com/raistlin7447/OrcaSlicer/actions/runs/32999914777 (-j3)

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
