### PR TITLE
build: clear 295 more -Woverloaded-virtual warnings in GUI widgets

### DIFF
--- a/src/slic3r/GUI/Search.cpp
+++ b/src/slic3r/GUI/Search.cpp
@@ -681,7 +681,7 @@ SearchDialog::SearchDialog(OptionsSearcher *searcher, Preset::Type type, wxWindo
 
 SearchDialog::~SearchDialog() {}
 
-void SearchDialog::Popup(wxPoint position /*= wxDefaultPosition*/)
+void SearchDialog::Popup(wxWindow *focus /*= nullptr*/)
 {
     /* const std::string& line = searcher->search_string();
      search_line->SetValue(line.empty() ? default_string : from_u8(line));
@@ -696,17 +696,19 @@ void SearchDialog::Popup(wxPoint position /*= wxDefaultPosition*/)
     search_line2->SetValue(wxString(""));
     //const std::string &line = searcher->search_string();
     //searcher->search(into_u8(line), true);
-    PopupWindow::Popup();
+    PopupWindow::Popup(focus);
     search_line2->SetFocus();
     update_list();
 }
 
 
+#ifdef __WXMSW__
 void SearchDialog::MSWDismissUnfocusedPopup()
 {
     Dismiss();
     OnDismiss();
 }
+#endif // __WXMSW__
 
 void SearchDialog::OnDismiss() { }
 
@@ -926,7 +928,7 @@ SearchObjectDialog::SearchObjectDialog(GUI::ObjectList* object_list, wxWindow* p
 
 SearchObjectDialog::~SearchObjectDialog() {}
 
-void SearchObjectDialog::Popup(wxPoint position /*= wxDefaultPosition*/)
+void SearchObjectDialog::Popup(wxWindow *focus /*= nullptr*/)
 {
     if (m_is_dismissing || this->IsShown()) {
         return;
@@ -937,7 +939,7 @@ void SearchObjectDialog::Popup(wxPoint position /*= wxDefaultPosition*/)
     // dropdown list, otherwise the text input won't be usable
     m_object_list->SetFocus();
 #endif
-    PopupWindow::Popup();
+    PopupWindow::Popup(focus);
     search_line2->SetFocus();
 
     m_object_list->assembly_plate_object_name();
@@ -945,11 +947,13 @@ void SearchObjectDialog::Popup(wxPoint position /*= wxDefaultPosition*/)
     update_list();
 }
 
+#ifdef __WXMSW__
 void SearchObjectDialog::MSWDismissUnfocusedPopup()
 {
     Dismiss();
     OnDismiss();
 }
+#endif // __WXMSW__
 
 void SearchObjectDialog::OnDismiss() {}
 

--- a/src/slic3r/GUI/Search.hpp
+++ b/src/slic3r/GUI/Search.hpp
@@ -216,10 +216,12 @@ public:
     SearchDialog(OptionsSearcher *searcher, Preset::Type type, wxWindow *parent, TextInput *input, wxWindow *search_btn);
     ~SearchDialog();
 
-    void MSWDismissUnfocusedPopup();
-    void Popup(wxPoint position = wxDefaultPosition);
-    void OnDismiss();
-    void Dismiss();
+#ifdef __WXMSW__
+    void MSWDismissUnfocusedPopup() override;
+#endif // __WXMSW__
+    void Popup(wxWindow *focus = nullptr) override;
+    void OnDismiss() override;
+    void Dismiss() override;
     void Die();
     void msw_rescale();
 
@@ -260,10 +262,12 @@ public:
     SearchObjectDialog(GUI::ObjectList* object_list, wxWindow* parent, TextInput* input);
     ~SearchObjectDialog();
 
-    void MSWDismissUnfocusedPopup();
-    void Popup(wxPoint position = wxDefaultPosition);
-    void OnDismiss();
-    void Dismiss();
+#ifdef __WXMSW__
+    void MSWDismissUnfocusedPopup() override;
+#endif // __WXMSW__
+    void Popup(wxWindow *focus = nullptr) override;
+    void OnDismiss() override;
+    void Dismiss() override;
     void Die();
 
     void OnInputText(wxCommandEvent& event);

--- a/src/slic3r/GUI/Widgets/LabeledStaticBox.cpp
+++ b/src/slic3r/GUI/Widgets/LabeledStaticBox.cpp
@@ -98,7 +98,7 @@ void LabeledStaticBox::SetBorderColor(StateColor const &color)
     Refresh();
 }
 
-void LabeledStaticBox::SetFont(wxFont set_font)
+bool LabeledStaticBox::SetFont(const wxFont &set_font)
 {
     m_font = set_font;
 
@@ -109,6 +109,7 @@ void LabeledStaticBox::SetFont(wxFont set_font)
     m_label_width  = tW;
 
     Refresh();
+    return true;
 }
 
 bool LabeledStaticBox::Enable(bool enable)

--- a/src/slic3r/GUI/Widgets/LabeledStaticBox.hpp
+++ b/src/slic3r/GUI/Widgets/LabeledStaticBox.hpp
@@ -42,7 +42,7 @@ public:
 
     void SetBorderColor(StateColor const &color);
 
-    void SetFont(wxFont set_font);
+    bool SetFont(const wxFont &set_font) override;
 
     bool Enable(bool enable) override;
 

--- a/src/slic3r/GUI/Widgets/ScrolledWindow.cpp
+++ b/src/slic3r/GUI/Widgets/ScrolledWindow.cpp
@@ -21,6 +21,8 @@ ScrolledWindow::ScrolledWindow(wxWindow *parent, wxWindowID id, wxPoint position
     m_bottomScrollbar    = NULL;
     m_verticalSplitter   = NULL;
     m_horizontalSplitter = NULL;
+    m_userPanel          = NULL;
+    m_scroll_win         = NULL;
 
     m_marginWidth        = marginWidth;
 
@@ -121,12 +123,13 @@ void ScrolledWindow::Refresh()
     // m_bottomScrollbar->Refresh();
 }
 
-void ScrolledWindow::SetBackgroundColour(wxColour color)
+bool ScrolledWindow::SetBackgroundColour(const wxColour &color)
 {
-    wxWindow::SetBackgroundColour(color); 
+    const bool result = wxWindow::SetBackgroundColour(color);
     m_verticalSplitter->SetBackgroundColour(color); 
     m_userPanel->SetBackgroundColour(color);
     m_scroll_win->SetBackgroundColour(color);
+    return result;
 }
 
 void ScrolledWindow::SetMarginColor(wxColour color)

--- a/src/slic3r/GUI/Widgets/ScrolledWindow.hpp
+++ b/src/slic3r/GUI/Widgets/ScrolledWindow.hpp
@@ -16,7 +16,7 @@ public:
     void OnMouseWheel(wxMouseEvent &event);
     void SetTipColor(wxColour color);
     void Refresh();
-    void SetBackgroundColour(wxColour color);
+    bool SetBackgroundColour(const wxColour &color) override;
 
     void         SetMarginColor(wxColour color);
     void         SetScrollbarColor(wxColour color);
@@ -27,7 +27,7 @@ public:
     // wxSplitterWindow* GetVerticalSplitter() { return m_verticalSplitter; }
     // wxSplitterWindow* GetHorizontalSplitter() { return m_horizontalSplitter; }
     bool         IsBothDirections() { return m_bothDirections; }
-    virtual void SetScrollbars(int pixelsPerUnitX, int pixelsPerUnitY, int noUnitsX, int noUnitsY, int xPos = 0, int yPos = 0, bool noRefresh = false);
+    virtual void SetScrollbars(int pixelsPerUnitX, int pixelsPerUnitY, int noUnitsX, int noUnitsY, int xPos = 0, int yPos = 0, bool noRefresh = false) override;
 
 private:
     wxPanel *    m_userPanel; // the panel targeted by the scrolled window


### PR DESCRIPTION
# Description

Clears 295 of the 553 `-Woverloaded-virtual` warnings, taking a full clang-cl build from 1,264 to 969. Part of #15374. Three widgets hit the same defect. Each declares a method that hides a base virtual instead of overriding it, so the derived work only runs for callers holding the concrete type.

`SearchDialog::Popup` and `SearchObjectDialog::Popup` took an unused `wxPoint` parameter, hiding `wxPopupTransientWindow::Popup(wxWindow*)`. Both clear the input, call the base, set focus and refill the list, and `SearchObjectDialog` also guards re-entry, so none of that ran when the window was popped through a base pointer. They now override and forward `focus`.

`LabeledStaticBox::SetFont` and `ScrolledWindow::SetBackgroundColour` hid their base virtuals the same way, so the label metrics recompute and the child colour propagation were skipped on base-pointer calls. Both now override.

Also in the diff:

- Seven sibling declarations are marked `override`. Marking one member makes clang flag every other unmarked override in the same class.
- `MSWDismissUnfocusedPopup` is declared only inside `#ifdef __WXMSW__` in `wx/popupwin.h`, so off Windows there is no base virtual and the keyword does not compile. Declarations and definitions are guarded, the way wxWidgets declares `MSWWindowProc` in `wx/nativewin.h` and this repo already does in `BBLTopbar`, `MainFrame`, `Button`, `ComboBox` and `TabCtrl`.
- `ScrolledWindow`'s constructor left `m_userPanel` and `m_scroll_win` uninitialised unless the style requested a vertical scrollbar, while `SetBackgroundColour` dereferences both. No caller hits that today, since every instantiation passes `wxVSCROLL`, but the override widens who can reach them.

# Screenshots/Recordings/Graphs

No visual change.

## Tests

Full clang-cl builds before and after (VS clang 20.1.8, Release, `BUILD_TESTS=ON`), both exit 0.

```
-Woverloaded-virtual         553 ->   258  (-295)
```

No other warning category changed.

Manually exercised the settings search and object search open, type, select, reopen and dismiss cycles, the parameter panel group boxes in both themes, and the calibration dialogs.

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
