### PR TITLE
fix: prevent heap corruption when repairing models with auto-backup

### DIFF
--- a/src/slic3r/Utils/FixModelByCgal.cpp
+++ b/src/slic3r/Utils/FixModelByCgal.cpp
@@ -12,6 +12,7 @@
 
 #include "libslic3r/MeshBoolean.hpp"
 #include "libslic3r/Model.hpp"
+#include "libslic3r/Format/bbs_3mf.hpp"
 #include "libslic3r/format.hpp"
 #include "libslic3r/Thread.hpp"
 #include "../GUI/I18N.hpp"
@@ -69,6 +70,17 @@ public:
 // Returns false if fixing was canceled. fix_result contains error message if failed.
 bool fix_model_with_cgal_gui(ModelObject &model_object, int volume_idx, GUI::ProgressDialog &progress_dialog, const wxString &msg_header, std::string &fix_result, bool keep_painting)
 {
+    // Orca: The worker thread below repairs the mesh while mutating `model_object`
+    // (split / delete_volume / set_mesh). Those mutators transitively call
+    // save_object_mesh(), which hands the object to the auto-backup manager. The
+    // manager clones and serializes the object on its own thread through an internal
+    // Model documented "visit only in main thread" (see Format/bbs_3mf.cpp). Driving
+    // that path from the repair worker races the backup thread on the shared model
+    // and corrupts the heap (use-after-free). Hold a SaveObjectGaurd across the whole
+    // repair so the backup manager stays out of the object until we are done; a single
+    // backup is taken when the guard is released.
+    SaveObjectGaurd backup_gaurd(model_object);
+
     // Orca: Synchronization primitives for progress updates between worker thread and GUI.
     std::mutex mtx;
     std::condition_variable condition;

--- a/src/slic3r/Utils/FixModelByCgal.cpp
+++ b/src/slic3r/Utils/FixModelByCgal.cpp
@@ -70,15 +70,7 @@ public:
 // Returns false if fixing was canceled. fix_result contains error message if failed.
 bool fix_model_with_cgal_gui(ModelObject &model_object, int volume_idx, GUI::ProgressDialog &progress_dialog, const wxString &msg_header, std::string &fix_result, bool keep_painting)
 {
-    // Orca: The worker thread below repairs the mesh while mutating `model_object`
-    // (split / delete_volume / set_mesh). Those mutators transitively call
-    // save_object_mesh(), which hands the object to the auto-backup manager. The
-    // manager clones and serializes the object on its own thread through an internal
-    // Model documented "visit only in main thread" (see Format/bbs_3mf.cpp). Driving
-    // that path from the repair worker races the backup thread on the shared model
-    // and corrupts the heap (use-after-free). Hold a SaveObjectGaurd across the whole
-    // repair so the backup manager stays out of the object until we are done; a single
-    // backup is taken when the guard is released.
+    // Hold SaveObjectGaurd to prevent backup manager from racing concurrent mesh mutations (use-after-free).
     SaveObjectGaurd backup_gaurd(model_object);
 
     // Orca: Synchronization primitives for progress updates between worker thread and GUI.


### PR DESCRIPTION
# Description

### What issue does this PR address?

Fixes intermittent crashes when using **Repair** (Fix model / CGAL repair) on an object. Users perceive it as a "freeze" during the *Repairing model object* progress dialog, after which the app dies. It reproduces most easily on multi-part / splittable objects with auto-backup enabled (the default).

### Root cause

`fix_model_with_cgal_gui` (`src/slic3r/Utils/FixModelByCgal.cpp`) runs the repair on a worker thread (`cgal_fix_model`) that mutates the **live** `ModelObject` — `ModelVolume::split()`, `ModelObject::delete_volume()`, `set_mesh()`, etc.

Those mutators transitively call `Slic3r::save_object_mesh()` → `_BBS_Backup_Manager::add_object_mesh()`, which clones the object into the backup manager's `m_temp_model` and enqueues it for serialization. That member is explicitly documented as main-thread-only:

```cpp
// src/libslic3r/Format/bbs_3mf.cpp
Model m_temp_model; // visit only in main thread
```

Driving that path from the repair worker breaks the invariant: `m_temp_model` gets mutated on the worker thread while the backup manager's own background thread concurrently reads/serializes it (`_add_mesh_to_object_stream` → `tdefl_compress`). Only the task deque is mutex-protected — nothing guards the model — so this is an unsynchronized data race → use-after-free / heap corruption.

Observed on macOS 26 (arm64), three crashes, all with the `cgal_fix_model` worker on the stack:

| Exception | Worker thread was in |
|-----------|----------------------|
| `EXC_BAD_ACCESS` | `DynamicConfig` copy-ctor |
| `EXC_BAD_ACCESS` | `ModelObject::assign_copy` |
| `EXC_BREAKPOINT` — libmalloc `memory corruption of free block` | `Model::delete_object` → `memmove` |

Racing backtrace (heap-corruption case):

```
Thread cgal_fix_model:                      Thread _BBS_Backup_Manager:
  fix_model_with_cgal_gui(...)::$_1           _BBS_Backup_Manager::operator()()
  _BBS_Backup_Manager::add_object_mesh        _BBS_3MF_Exporter::save_object_mesh
  push_task -> process_ui_task                _add_mesh_to_object_stream
  Model::delete_object -> memmove   <-- race -->  tdefl_compress
```

### Fix

Wrap the repair in the codebase's existing RAII `SaveObjectGaurd`, so the backup manager ignores the object for the duration of the repair; a single backup is taken when the guard is released on the main thread after the worker joins. This is the same idiom already used for batch edits in `Model.hpp` and `GUI_ObjectList.cpp`.

```cpp
bool fix_model_with_cgal_gui(ModelObject &model_object, ...)
{
    SaveObjectGaurd backup_gaurd(model_object);   // keep auto-backup off this object during repair
    ...
}
```

Minimal change: one file, +12 lines (guard + explanatory comment + include). When auto-backup is disabled, the guard is a no-op, so behavior is unchanged there.

# Screenshots/Recordings/Graphs

N/A — crash fix; see the backtrace above.

## Tests

- **Repro (before):** open a multi-part / splittable object with auto-backup enabled (Preferences → Backup), run Repair; crashes within a few repairs.
- **After:** the repair worker no longer touches the backup manager's model; the race is eliminated.
- **Build:** full arm64 build (deps + slicer) compiles and links cleanly (`OrcaSlicer.app`, Release).
