### PR TITLE
fix: save 3d mouse settings

### DIFF
--- a/src/libslic3r/AppConfig.cpp
+++ b/src/libslic3r/AppConfig.cpp
@@ -1440,7 +1440,7 @@ void AppConfig::set_mouse_device(const std::string& name, double translation_spe
     it->second["invert_yaw"] = invert_yaw ? "1" : "0";
     it->second["invert_pitch"] = invert_pitch ? "1" : "0";
     it->second["invert_roll"] = invert_roll ? "1" : "0";
-	m_dirty = true;
+    m_dirty = true;
 }
 
 std::vector<std::string> AppConfig::get_mouse_device_names() const

--- a/src/libslic3r/AppConfig.cpp
+++ b/src/libslic3r/AppConfig.cpp
@@ -1440,6 +1440,7 @@ void AppConfig::set_mouse_device(const std::string& name, double translation_spe
     it->second["invert_yaw"] = invert_yaw ? "1" : "0";
     it->second["invert_pitch"] = invert_pitch ? "1" : "0";
     it->second["invert_roll"] = invert_roll ? "1" : "0";
+	m_dirty = true;
 }
 
 std::vector<std::string> AppConfig::get_mouse_device_names() const


### PR DESCRIPTION
# Description

Fixes #4879 — settings made in the 3Dconnexion dialog are lost on restart, or persist only sporadically.

AppConfig::set_mouse_device() function writes into m_storage but never sets m_dirty thus almost never becomes saved.

This sets m_dirty in set_mouse_device(), matching every other setter in AppConfig.

# Screenshots/Recordings/Graphs

N/A — no UI change.