### PR TITLE
build: clear 50 warnings - pessimizing moves and null checks that cannot fail

### DIFF
--- a/src/libslic3r/ArcFitter.cpp
+++ b/src/libslic3r/ArcFitter.cpp
@@ -57,24 +57,24 @@ void ArcFitter::do_arc_fitting(const Points& points, std::vector<PathFittingData
             //BBS: can be fit as arc, then save arc data temperarily
             last_arc = target_arc;
             if (back_index == points.size() - 1) {
-                result.emplace_back(std::move(PathFittingData{ front_index,
+                result.emplace_back(PathFittingData{ front_index,
                                    back_index,
                                    last_arc.direction == ArcDirection::Arc_Dir_CCW ? EMovePathType::Arc_move_ccw : EMovePathType::Arc_move_cw,
-                                   last_arc }));
+                                   last_arc });
                 front_index = back_index;
             }
         } else {
             if (back_index - front_index > 2) {
                 //BBS: althought current point_stack can't be fit as arc,
                 //but previous must can be fit if removing the top in stack, so save last arc
-                result.emplace_back(std::move(PathFittingData{ front_index,
+                result.emplace_back(PathFittingData{ front_index,
                                    back_index - 1,
                                    last_arc.direction == ArcDirection::Arc_Dir_CCW ? EMovePathType::Arc_move_ccw : EMovePathType::Arc_move_cw,
-                                   last_arc }));
+                                   last_arc });
             } else {
                 //BBS: save the first segment as line move when 3 point-line can't be fit as arc move
                 if (result.empty() || result.back().path_type != EMovePathType::Linear_move)
-                    result.emplace_back(std::move(PathFittingData{front_index, front_index + 1, EMovePathType::Linear_move, ArcSegment()}));
+                    result.emplace_back(PathFittingData{front_index, front_index + 1, EMovePathType::Linear_move, ArcSegment()});
                 else if(result.back().path_type == EMovePathType::Linear_move)
                     result.back().end_point_index = front_index + 1;
             }
@@ -87,7 +87,7 @@ void ArcFitter::do_arc_fitting(const Points& points, std::vector<PathFittingData
 	//BBS: handle the remain data
     if (front_index != back_index) {
         if (result.empty() || result.back().path_type != EMovePathType::Linear_move)
-            result.emplace_back(std::move(PathFittingData{front_index, back_index, EMovePathType::Linear_move, ArcSegment()}));
+            result.emplace_back(PathFittingData{front_index, back_index, EMovePathType::Linear_move, ArcSegment()});
         else if (result.back().path_type == EMovePathType::Linear_move)
             result.back().end_point_index = back_index;
     }

--- a/src/libslic3r/Clipper2Utils.cpp
+++ b/src/libslic3r/Clipper2Utils.cpp
@@ -13,8 +13,8 @@ Slic3r::Polylines Paths64_to_polylines(const Clipper2Lib::Paths64& in)
         Slic3r::Points points;
         points.reserve(path64.size());
         for (const Clipper2Lib::Point64& point64 : path64)
-            points.emplace_back(std::move(Slic3r::Point(point64.x, point64.y)));
-        out.emplace_back(std::move(Slic3r::Polyline(points)));
+            points.emplace_back(Slic3r::Point(point64.x, point64.y));
+        out.emplace_back(Slic3r::Polyline(points));
     }
     return out;
 }
@@ -29,7 +29,7 @@ Clipper2Lib::Paths64 Slic3rPoints_to_Paths64(const Container& in)
         Clipper2Lib::Path64 path;
         path.reserve(item.size());
         for (const Slic3r::Point& point : item.points)
-            path.emplace_back(std::move(Clipper2Lib::Point64(point.x(), point.y())));
+            path.emplace_back(Clipper2Lib::Point64(point.x(), point.y()));
         out.emplace_back(std::move(path));
     }
     return out;
@@ -44,7 +44,7 @@ Points Path64ToPoints(const Clipper2Lib::Path64& path64)
 {
     Points points;
     points.reserve(path64.size());
-    for (const Clipper2Lib::Point64 &point64 : path64) points.emplace_back(std::move(Slic3r::Point(point64.x, point64.y)));
+    for (const Clipper2Lib::Point64 &point64 : path64) points.emplace_back(Slic3r::Point(point64.x, point64.y));
     return points;
 }
 
@@ -99,7 +99,7 @@ Clipper2Lib::Paths64 Slic3rPolygons_to_Paths64(const Polygons &in)
     for (const Polygon &poly : in) {
         Clipper2Lib::Path64 path;
         path.reserve(poly.points.size());
-        for (const Slic3r::Point &point : poly.points) path.emplace_back(std::move(Clipper2Lib::Point64(point.x(), point.y())));
+        for (const Slic3r::Point &point : poly.points) path.emplace_back(Clipper2Lib::Point64(point.x(), point.y()));
         out.emplace_back(std::move(path));
     }
     return out;
@@ -114,7 +114,7 @@ Clipper2Lib::Paths64 Slic3rExPolygons_to_Paths64(const ExPolygons& in)
             const auto         &poly = expolygon.contour_or_hole(i);
             Clipper2Lib::Path64 path;
             path.reserve(poly.points.size());
-            for (const Slic3r::Point &point : poly.points) path.emplace_back(std::move(Clipper2Lib::Point64(point.x(), point.y())));
+            for (const Slic3r::Point &point : poly.points) path.emplace_back(Clipper2Lib::Point64(point.x(), point.y()));
             out.emplace_back(std::move(path));
         }
     }
@@ -134,8 +134,8 @@ Polylines _clipper2_pl_open(Clipper2Lib::ClipType clipType, const Slic3r::Polyli
 
     Slic3r::Polylines out;
     out.reserve(solution.size() + solution_open.size());
-    polylines_append(out, std::move(Paths64_to_polylines(solution)));
-    polylines_append(out, std::move(Paths64_to_polylines(solution_open)));
+    polylines_append(out, Paths64_to_polylines(solution));
+    polylines_append(out, Paths64_to_polylines(solution_open));
 
     return out;
 }

--- a/src/libslic3r/Format/STEP.cpp
+++ b/src/libslic3r/Format/STEP.cpp
@@ -586,7 +586,7 @@ Step::Step_Status Step::mesh(Model* model,
                     for (Standard_Integer aNodeIter = 1; aNodeIter <= aTriangulation->NbNodes(); ++aNodeIter) {
                         gp_Pnt aPnt = aTriangulation->Node(aNodeIter);
                         aPnt.Transform(aTrsf);
-                        points.emplace_back(std::move(Vec3f(aPnt.X(), aPnt.Y(), aPnt.Z())));
+                        points.emplace_back(Vec3f(aPnt.X(), aPnt.Y(), aPnt.Z()));
                     }
                     // BBS: copy triangles
                     const TopAbs_Orientation anOrientation = anExpSF.Current().Orientation();

--- a/src/libslic3r/Format/bbs_3mf.cpp
+++ b/src/libslic3r/Format/bbs_3mf.cpp
@@ -8963,7 +8963,7 @@ private:
         BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << " inital and interval = " << m_interval;
         m_next_backup = boost::get_system_time() + boost::posix_time::seconds(m_interval);
         boost::unique_lock lock(m_mutex);
-        m_thread = std::move(boost::thread(boost::ref(*this)));
+        m_thread = boost::thread(boost::ref(*this));
     }
 
     ~_BBS_Backup_Manager() {

--- a/src/libslic3r/Format/svg.cpp
+++ b/src/libslic3r/Format/svg.cpp
@@ -352,7 +352,7 @@ bool load_svg(const char *path, Model *model, std::string &message)
             for (Standard_Integer aNodeIter = 1; aNodeIter <= aTriangulation->NbNodes(); ++aNodeIter) {
                 gp_Pnt aPnt = aTriangulation->Node(aNodeIter);
                 aPnt.Transform(aTrsf);
-                points.emplace_back(std::move(Vec3f(aPnt.X(), aPnt.Y(), aPnt.Z())));
+                points.emplace_back(Vec3f(aPnt.X(), aPnt.Y(), aPnt.Z()));
             }
             // BBS: copy triangles
             const TopAbs_Orientation anOrientation = anExpSF.Current().Orientation();

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -9079,7 +9079,7 @@ bool GCode::needs_retraction(const Polyline &travel, ExtrusionRole role, LiftTyp
                     continue;
 
                 Polygons temp;
-                temp.emplace_back(std::move(instance_bbox.polygon()));
+                temp.emplace_back(instance_bbox.polygon());
                 if (intersection_pl(travel, temp).empty())
                     continue;
 

--- a/src/libslic3r/MeshBoolean.cpp
+++ b/src/libslic3r/MeshBoolean.cpp
@@ -352,7 +352,7 @@ void segment(CGALMesh& src, std::vector<CGALMesh>& dst, double smoothing_alpha =
         //}
         //else
         {
-            dst.emplace_back(std::move(CGALMesh(out)));
+            dst.emplace_back(CGALMesh(out));
         }
     }
     //if (mesh_merged.is_empty() == false) {
@@ -371,7 +371,7 @@ std::vector<TriangleMesh> segment(const TriangleMesh& src, double smoothing_alph
     std::vector<TriangleMesh> out_meshes;
     for (auto& outf_cgal_mesh: out_cgal_meshes)
     {
-        out_meshes.emplace_back(std::move(cgal_to_triangle_mesh(outf_cgal_mesh.m)));
+        out_meshes.emplace_back(cgal_to_triangle_mesh(outf_cgal_mesh.m));
     }
 
     return out_meshes;

--- a/src/libslic3r/Model.cpp
+++ b/src/libslic3r/Model.cpp
@@ -261,7 +261,7 @@ static void add_textured_mesh_to_model(Model& model, const TexturedMesh& tex_mes
     its_remove_degenerate_faces(its);
     its_compactify_vertices(its);
 
-    model.add_object(object_name.c_str(), input_file.c_str(), std::move(TriangleMesh(std::move(its))));
+    model.add_object(object_name.c_str(), input_file.c_str(), TriangleMesh(std::move(its)));
 }
 
 Model Model::read_from_file(const std::string&                                  input_file,

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -3790,7 +3790,7 @@ std::vector<Polygons> Print::get_extruder_printable_polygons() const
         Polygons ploys = {Polygon::new_scale(e_printable_area)};
         extruder_printable_polys.emplace_back(ploys);
     }
-    return std::move(extruder_printable_polys);
+    return extruder_printable_polys;
 }
 
 std::vector<Polygons> Print::get_extruder_unprintable_polygons() const
@@ -3803,7 +3803,7 @@ std::vector<Polygons> Print::get_extruder_unprintable_polygons() const
         Polygons ploys = diff(printable_poly, Polygon::new_scale(e_printable_area));
         extruder_unprintable_polys.emplace_back(ploys);
     }
-    return std::move(extruder_unprintable_polys);
+    return extruder_unprintable_polys;
 }
 
 size_t Print::get_extruder_id(unsigned int filament_id) const

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -906,7 +906,7 @@ void PrintObject::detect_overhangs_for_lift()
                     Layer& lower_layer = *layer.lower_layer;
 
                     ExPolygons overhangs = diff_ex(layer.lslices, offset_ex(lower_layer.lslices, scale_(min_overlap)));
-                    layer.loverhangs = std::move(offset2_ex(overhangs, -0.1f * scale_(line_width), 0.1f * scale_(line_width)));
+                    layer.loverhangs = offset2_ex(overhangs, -0.1f * scale_(line_width), 0.1f * scale_(line_width));
                     layer.loverhangs_bbox = get_extents(layer.loverhangs);
                 }
             });

--- a/src/libslic3r/Shape/TextShape.cpp
+++ b/src/libslic3r/Shape/TextShape.cpp
@@ -199,7 +199,7 @@ static void MakeMesh(TopoDS_Shape& theSolid, TriangleMesh& theMesh)
         for (Standard_Integer aNodeIter = 1; aNodeIter <= aTriangulation->NbNodes(); ++aNodeIter) {
             gp_Pnt aPnt = aTriangulation->Node(aNodeIter);
             aPnt.Transform(aTrsf);
-            points.emplace_back(std::move(Vec3f(aPnt.X(), aPnt.Y(), aPnt.Z())));
+            points.emplace_back(Vec3f(aPnt.X(), aPnt.Y(), aPnt.Z()));
         }
         //BBS: copy triangles
         const TopAbs_Orientation anOrientation = anExpSF.Current().Orientation();

--- a/src/libslic3r/Support/TreeSupport.cpp
+++ b/src/libslic3r/Support/TreeSupport.cpp
@@ -842,7 +842,7 @@ void TreeSupport::detect_overhangs(bool check_support_necessity/* = false*/)
 
                 // normal overhang
                 ExPolygons lower_layer_offseted = offset_ex(lower_polys, support_offset_scaled, SUPPORT_SURFACES_OFFSET_PARAMETERS);
-                overhangs_all_layers[layer_nr] = std::move(diff_ex(curr_polys, lower_layer_offseted));
+                overhangs_all_layers[layer_nr] = diff_ex(curr_polys, lower_layer_offseted);
 
                 double duration{ std::chrono::duration_cast<second_>(clock_::now() - t0).count() };
                 if (duration > 30 || overhangs_all_layers[layer_nr].size() > 100) {
@@ -1396,7 +1396,7 @@ void TreeSupport::generate_toolpaths()
             raft_areas.push_back(expoly);
     }
 
-    raft_areas = std::move(offset_ex(raft_areas, scale_(object_config.raft_first_layer_expansion)));
+    raft_areas = offset_ex(raft_areas, scale_(object_config.raft_first_layer_expansion));
 
     size_t layer_nr = 0;
     for (; layer_nr < m_slicing_params.base_raft_layers; layer_nr++) {
@@ -1522,9 +1522,9 @@ void TreeSupport::generate_toolpaths()
                                 erSupportMaterialInterface : erSupportMaterial;
                             make_perimeter_and_inner_brim(ts_layer->support_fills.entities, poly, wall_count, flow,
                                                           brim_role);
-                            polys = std::move(offset_ex(poly, -flow.scaled_spacing()));
+                            polys = offset_ex(poly, -flow.scaled_spacing());
                         } else if (area_group.type == SupportLayer::Roof1stLayer) {
-                            polys = std::move(offset_ex(poly, 0.5*support_flow.scaled_width()));
+                            polys = offset_ex(poly, 0.5*support_flow.scaled_width());
                         }
                         else {
                             polys.push_back(poly);
@@ -2269,7 +2269,7 @@ void TreeSupport::draw_circles()
                             // Inside the gap: remove only the part overlapping the contact surface, keep the rest.
                             if (bottom_gap_height > EPSILON && layer_bottom_z < band_gap_top - EPSILON) {
                                 any_gap_cleared = true;
-                                comp_poly = std::move(diff_ex(comp_poly, band.surfaces));
+                                comp_poly = diff_ex(comp_poly, band.surfaces);
                             }
 
                             // Overlaps interface band
@@ -2304,7 +2304,7 @@ void TreeSupport::draw_circles()
                                 ExPolygons comp_interface = band_ex.empty() ? ExPolygons {} : intersection_ex(comp_poly, band_ex);
                                 if (!comp_interface.empty()) {
                                     append(new_floor_areas, comp_interface);
-                                    comp_poly = std::move(diff_ex(comp_poly, offset_ex(comp_interface, 10)));
+                                    comp_poly = diff_ex(comp_poly, offset_ex(comp_interface, 10));
                                 }
                             }
 
@@ -2396,7 +2396,7 @@ void TreeSupport::draw_circles()
                         ts_layer->lslices.emplace_back(*expoly);
                 }
 
-                ts_layer->lslices = std::move(union_ex(ts_layer->lslices));
+                ts_layer->lslices = union_ex(ts_layer->lslices);
                 //Must update bounding box which is used in avoid crossing perimeter
                 ts_layer->lslices_bboxes.clear();
                 ts_layer->lslices_bboxes.reserve(ts_layer->lslices.size());
@@ -2474,7 +2474,7 @@ void TreeSupport::draw_circles()
                 if (global_lightning_infill)
                 {
                     //search overhangs globally
-                    overhang = std::move(diff_ex(offset_ex(base_areas_lower, -2.0 * scale_(support_extrusion_width)), base_areas));
+                    overhang = diff_ex(offset_ex(base_areas_lower, -2.0 * scale_(support_extrusion_width)), base_areas);
                 }
                 else
                 {
@@ -2485,13 +2485,13 @@ void TreeSupport::draw_circles()
                             Polygon rev_hole = hole;
                             rev_hole.make_counter_clockwise();
                             ExPolygons ex_hole;
-                            ex_hole.emplace_back(std::move(ExPolygon(rev_hole)));
+                            ex_hole.emplace_back(ExPolygon(rev_hole));
                             for (auto& other_area : base_areas)
                                 //if (&other_area != &base_area)
-                                    ex_hole = std::move(diff_ex(ex_hole, other_area));
-                            overhang = std::move(union_ex(overhang, ex_hole));
+                                    ex_hole = diff_ex(ex_hole, other_area);
+                            overhang = union_ex(overhang, ex_hole);
                         }
-                    overhang = std::move(intersection_ex(overhang, offset_ex(base_areas_lower, -0.5 * scale_(support_extrusion_width))));
+                    overhang = intersection_ex(overhang, offset_ex(base_areas_lower, -0.5 * scale_(support_extrusion_width)));
                 }
 
                 overhangs.emplace_back(to_polygons(overhang));
@@ -2746,7 +2746,7 @@ void TreeSupport::drop_nodes()
 
         m_object->print()->set_status(60 + int(10 * (1 - float(layer_nr) / contact_nodes.size())), _u8L("Generating support"));// (boost::format(_u8L("Support: propagate branches at layer %d")) % layer_nr).str());
 
-        Polygons layer_contours = std::move(m_ts_data->get_contours_with_holes(obj_layer_nr));
+        Polygons layer_contours = m_ts_data->get_contours_with_holes(obj_layer_nr);
         //std::unordered_map<Line, bool, LineHash>& mst_line_x_layer_contour_cache = m_mst_line_x_layer_contour_caches[layer_nr];
         tbb::concurrent_unordered_map<Line, bool, LineHash> mst_line_x_layer_contour_cache;
         auto is_line_cut_by_contour = [&mst_line_x_layer_contour_cache,&layer_contours](Point a, Point b)
@@ -3763,7 +3763,7 @@ const ExPolygons& TreeSupportData::calculate_avoidance(const RadiusLayerPair& ke
     }
     const ExPolygons &collision       = get_collision(radius, layer_nr);
     avoidance_areas.insert(avoidance_areas.end(), collision.begin(), collision.end());
-    avoidance_areas = std::move(union_ex(avoidance_areas));
+    avoidance_areas = union_ex(avoidance_areas);
     auto ret = m_avoidance_cache.insert({key, std::move(avoidance_areas)});
     //assert(ret.second);
     return ret.first->second;

--- a/src/slic3r/GUI/ImageDPIFrame.cpp
+++ b/src/slic3r/GUI/ImageDPIFrame.cpp
@@ -74,7 +74,7 @@ bool ImageDPIFrame::Show(bool show)
 }
 
 void ImageDPIFrame::set_bitmap(const wxBitmap &bit_map) {
-    if (&bit_map && bit_map.IsOk()) {
+    if (bit_map.IsOk()) {
         m_bitmap->SetBitmap(bit_map);
     }
 }

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -3870,7 +3870,7 @@ bool Sidebar::reset_bed_type_combox_choices(bool is_sidebar_init)
         }
     }
     m_last_combo_bedtype_count = p->combo_printer_bed->GetCount();
-    if (!is_sidebar_init && &p->plater->get_partplate_list()) {
+    if (!is_sidebar_init) {
         p->plater->get_partplate_list().check_all_plate_local_bed_type(m_cur_combox_bed_types);
     }
     return true;

--- a/src/slic3r/GUI/Printer/PrinterFileSystem.cpp
+++ b/src/slic3r/GUI/Printer/PrinterFileSystem.cpp
@@ -662,10 +662,10 @@ PrinterFileSystem::File const &PrinterFileSystem::GetFile(size_t index, bool &se
 void PrinterFileSystem::Attached()
 {
     boost::unique_lock lock(m_mutex);
-    m_recv_thread = std::move(boost::thread([w = weak_from_this()] {
+    m_recv_thread = boost::thread([w = weak_from_this()] {
         boost::shared_ptr<PrinterFileSystem> s = w.lock();
         if (s) s->RecvMessageThread();
-    }));
+    });
 }
 
 void PrinterFileSystem::Start()

--- a/src/slic3r/GUI/SelectMachine.cpp
+++ b/src/slic3r/GUI/SelectMachine.cpp
@@ -483,7 +483,7 @@ SelectMachineDialog::SelectMachineDialog(Plater *plater)
 
     m_link_edit_nozzle->Bind(wxEVT_LEFT_DOWN, [this](auto &e) {
 
-        if (this && this->m_is_in_sending_mode) {
+        if (m_is_in_sending_mode) {
             return;
         }
 

--- a/src/slic3r/GUI/SendToPrinter.cpp
+++ b/src/slic3r/GUI/SendToPrinter.cpp
@@ -978,18 +978,16 @@ void SendToPrinterDialog::on_ok(wxCommandEvent &event)
         m_send_job->on_check_ip_address_fail([this, token = std::weak_ptr(m_token)](int result) {
              CallAfter([token, this] {
                 if (token.expired()) { return; }
-                if (this) {
-                    SendFailedConfirm sfcDlg;
-                    auto res = sfcDlg.ShowModal();
-                    m_status_bar->cancel();
+                SendFailedConfirm sfcDlg;
+                auto res = sfcDlg.ShowModal();
+                m_status_bar->cancel();
 
-                    if (res == wxYES) {
-                        wxQueueEvent(m_button_ensure, new wxCommandEvent(wxEVT_BUTTON));
-                    } else if (res == wxAPPLY) {
-                        wxCommandEvent *evt = new wxCommandEvent(EVT_CLEAR_IPADDRESS);
-                        wxQueueEvent(this, evt);
-                        wxGetApp().show_ip_address_enter_dialog();
-                    }
+                if (res == wxYES) {
+                    wxQueueEvent(m_button_ensure, new wxCommandEvent(wxEVT_BUTTON));
+                } else if (res == wxAPPLY) {
+                    wxCommandEvent *evt = new wxCommandEvent(EVT_CLEAR_IPADDRESS);
+                    wxQueueEvent(this, evt);
+                    wxGetApp().show_ip_address_enter_dialog();
                 }
             });
         });

--- a/src/slic3r/GUI/Widgets/AxisCtrlButton.cpp
+++ b/src/slic3r/GUI/Widgets/AxisCtrlButton.cpp
@@ -124,7 +124,7 @@ void AxisCtrlButton::SetInnerBackgroundColor(StateColor const& color)
 
 void AxisCtrlButton::SetBitmap(ScalableBitmap &bmp)
 {
-    if (&bmp  && (& bmp.bmp()) && (bmp.bmp().IsOk())) {
+    if (bmp.bmp().IsOk()) {
         m_icon = bmp;
     }
 }

--- a/src/slic3r/GUI/Widgets/ComboBox.cpp
+++ b/src/slic3r/GUI/Widgets/ComboBox.cpp
@@ -208,7 +208,7 @@ bool ComboBox::SetFont(wxFont const& font)
 
 int ComboBox::Append(const wxString &item, const wxBitmap &bitmap, int style)
 {
-    if (&bitmap && bitmap.IsOk()) {
+    if (bitmap.IsOk()) {
         return Append(item, bitmap, nullptr, style);
     }
     return Append(item, wxNullBitmap, nullptr, style);
@@ -219,7 +219,7 @@ int ComboBox::Append(const wxString &text,
                      void *          clientData,
                      int style)
 {
-    if (&bitmap && bitmap.IsOk()) {
+    if (bitmap.IsOk()) {
         return Append(text, bitmap, wxString{}, clientData, style);
     }
     return Append(text, wxNullBitmap, wxString{}, clientData, style);
@@ -237,7 +237,7 @@ int ComboBox::Append(const wxString &text,
                      void *clientData,
                      int style)
 {
-    auto valid_bit_map = (&bitmap && bitmap.IsOk()) ? bitmap : wxNullBitmap;
+    auto valid_bit_map = bitmap.IsOk() ? bitmap : wxNullBitmap;
     Item item{text, wxEmptyString, valid_bit_map, valid_bit_map, clientData, group_key, group_label};
     item.style = style;
     items.push_back(item);
@@ -333,7 +333,7 @@ wxBitmap ComboBox::GetItemBitmap(unsigned int n) { return items[n].icon; }
 void ComboBox::SetItemBitmap(unsigned int n, wxBitmap const &bitmap)
 {
     if (n >= items.size()) return;
-    items[n].icon = (&bitmap && bitmap.IsOk()) ? bitmap : wxNullBitmap;
+    items[n].icon = bitmap.IsOk() ? bitmap : wxNullBitmap;
     drop.Invalidate();
 }
 

--- a/src/slic3r/Utils/PresetUpdater.cpp
+++ b/src/slic3r/Utils/PresetUpdater.cpp
@@ -1198,7 +1198,7 @@ Updates PresetUpdater::priv::get_config_updates(const Semver &old_slic3r_version
                     version.config_version = cache_ver;
                     version.comment        = description;
                     // Orca: update vendor.json
-                    updates.updates.emplace_back(std::move(file_path), std::move(path_in_vendor.string()), std::move(version), vendor_name, changelog, "", force_update, false);
+                    updates.updates.emplace_back(std::move(file_path), path_in_vendor.string(), std::move(version), vendor_name, changelog, "", force_update, false);
                     //Orca: update vendor folder
                     updates.updates.emplace_back(cache_profile_path / vendor_name, vendor_path / vendor_name, Version(), vendor_name, "", "", force_update, true);
                 } else {


### PR DESCRIPTION
# Description

Two categories from #15374. Neither changes behavior.

`-Wpessimizing-move`, 39 sites across 14 files. `std::move` wrapped around a temporary, or around a local being returned, which stops the compiler constructing it in place. Each edit is the fix clang suggests, which is to delete the `std::move` call and keep its argument. Three of the 39 save a move, the two `return std::move(local)` in `Print.cpp` and `TreeSupport.cpp:2749`; the rest are equivalent either way and match how the codebase already writes this elsewhere.

`-Wundefined-bool-conversion`, 11 warnings across 9 sites in 6 files. A null check on a reference or on `this`, neither of which can be null, so the compiler folds the condition to true and drops the guard. Seven are `if (&bitmap && bitmap.IsOk())`, where `IsOk()` already does the work; two test `this` directly. The guarded code runs either way, so removing the dead operand changes nothing.

# Screenshots/Recordings/Graphs

No visual change.

## Tests

No new tests. Neither category changes behavior.

Manually exercised all nine `-Wundefined-bool-conversion` sites in the GUI: the icon dropdowns, the bed image popup and bed type list, the machine selection and send to printer dialogs, and the axis button after a DPI change.

Clean clang-cl build of `main` at `6fdd4945c1` reports 826 warnings, and 776 with this branch, so 50 cleared and both categories reach zero. No other category moved.

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
