### PR TITLE
BBS Port: Merge into Single Part

### DIFF
--- a/src/libslic3r/Model.cpp
+++ b/src/libslic3r/Model.cpp
@@ -2281,11 +2281,22 @@ ModelObjectPtrs ModelObject::merge_volumes(std::vector<int>& vol_indeces)
     upper->clear_volumes();
     upper->input_file.clear();
 
-#if 1
     TriangleMesh mesh;
+    // BBS: preserve painting across the merge. its_merge() appends faces in
+    // order (only vertex indices are offset), so face f of the merged mesh maps
+    // exactly to the captured per-part triangles below. Capture before
+    // reset_mesh() empties the source volumes.
+    std::vector<std::string> merged_supported, merged_seam, merged_mmu, merged_fuzzy;
     for (int i : vol_indeces) {
         auto volume = volumes[i];
         if (!volume->mesh().empty()) {
+            const size_t nf = volume->mesh().its.indices.size();
+            for (size_t f = 0; f < nf; ++f) {
+                merged_supported.emplace_back(volume->supported_facets.get_triangle_as_string((int)f));
+                merged_seam.emplace_back(volume->seam_facets.get_triangle_as_string((int)f));
+                merged_mmu.emplace_back(volume->mmu_segmentation_facets.get_triangle_as_string((int)f));
+                merged_fuzzy.emplace_back(volume->fuzzy_skin_facets.get_triangle_as_string((int)f));
+            }
             const auto volume_matrix = volume->get_matrix();
             TriangleMesh mesh_(volume->mesh());
             mesh_.transform(volume_matrix, true);
@@ -2294,20 +2305,18 @@ ModelObjectPtrs ModelObject::merge_volumes(std::vector<int>& vol_indeces)
             mesh.merge(mesh_);
         }
     }
-#else
-    std::vector<TriangleMesh> meshes;
-    for (int i : vol_indeces) {
-        auto volume = volumes[i];
-        if (!volume->mesh().empty())
-            meshes.emplace_back(volume->mesh());
-    }
-    TriangleMesh mesh = MeshBoolean::cgal::merge(meshes);
-#endif
 
     ModelVolume* vol = upper->add_volume(mesh);
+    // BBS: re-apply the painting captured above onto the merged volume.
+    for (size_t f = 0; f < merged_mmu.size() && f < mesh.its.indices.size(); ++f) {
+        if (!merged_supported[f].empty()) vol->supported_facets.set_triangle_from_string((int)f, merged_supported[f]);
+        if (!merged_seam[f].empty())      vol->seam_facets.set_triangle_from_string((int)f, merged_seam[f]);
+        if (!merged_mmu[f].empty())       vol->mmu_segmentation_facets.set_triangle_from_string((int)f, merged_mmu[f]);
+        if (!merged_fuzzy[f].empty())     vol->fuzzy_skin_facets.set_triangle_from_string((int)f, merged_fuzzy[f]);
+    }
     for (int i = 0; i < volumes.size();i++) {
         if (std::find(vol_indeces.begin(), vol_indeces.end(), i) != vol_indeces.end()) {
-            vol->name = volumes[i]->name + "_merged";
+            vol->name = "Merged Parts";
             vol->config.assign_config(volumes[i]->config);
         }
         else

--- a/src/libslic3r/Model.cpp
+++ b/src/libslic3r/Model.cpp
@@ -2267,7 +2267,7 @@ void ModelObject::merge()
 ModelObjectPtrs ModelObject::merge_volumes(std::vector<int>& vol_indeces)
 {
     ModelObjectPtrs res;
-    if (this->volumes.size() == 1) {
+    if (this->volumes.size() == 1 || vol_indeces.empty()) {
         // We can't merge meshes if there's just one volume
         return res;
     }
@@ -2306,9 +2306,15 @@ ModelObjectPtrs ModelObject::merge_volumes(std::vector<int>& vol_indeces)
         }
     }
 
-    ModelVolume* vol = upper->add_volume(mesh);
+    // Keep the part type: the default add_volume() overload would make the result
+    // a normal part, which would turn a merged negative part or modifier into
+    // printed geometry.
+    const ModelVolumeType merged_type = volumes[vol_indeces.front()]->type();
+    const size_t merged_face_count = mesh.its.indices.size();
+
+    ModelVolume* vol = upper->add_volume(std::move(mesh), merged_type);
     // BBS: re-apply the painting captured above onto the merged volume.
-    for (size_t f = 0; f < merged_mmu.size() && f < mesh.its.indices.size(); ++f) {
+    for (size_t f = 0; f < merged_mmu.size() && f < merged_face_count; ++f) {
         if (!merged_supported[f].empty()) vol->supported_facets.set_triangle_from_string((int)f, merged_supported[f]);
         if (!merged_seam[f].empty())      vol->seam_facets.set_triangle_from_string((int)f, merged_seam[f]);
         if (!merged_mmu[f].empty())       vol->mmu_segmentation_facets.set_triangle_from_string((int)f, merged_mmu[f]);

--- a/src/slic3r/GUI/GUI_Factories.cpp
+++ b/src/slic3r/GUI/GUI_Factories.cpp
@@ -1273,6 +1273,20 @@ void MenuFactory::append_menu_item_merge_parts_to_single_part(wxMenu* menu)
         []() { return obj_list()->can_mesh_boolean(); }, m_parent);
 }
 
+// BBS: merge the selected parts into one part, keeping the other parts of the object
+void MenuFactory::append_menu_item_merge_some_parts_to_single_part(wxMenu* menu)
+{
+    menu->AppendSeparator();
+    append_menu_item(menu, wxID_ANY, _L("Merge into Single Part"), _L("Merge the selected parts into one part"),
+        [](wxCommandEvent&) { obj_list()->merge_volumes(); }, "", menu,
+        []() {
+            if (plater()->canvas3D()->get_canvas_type() != GLCanvas3D::ECanvasType::CanvasView3D)
+                return false;
+            return !obj_list()->has_selected_cut_object();
+        },
+        m_parent);
+}
+
 void MenuFactory::append_menu_items_mirror(wxMenu* menu)
 {
     wxMenu* mirror_menu = new wxMenu();
@@ -1967,6 +1981,7 @@ wxMenu* MenuFactory::multi_selection_menu()
     else {
         append_menu_item_center(menu);
         append_menu_item_drop(menu);
+        append_menu_item_merge_some_parts_to_single_part(menu);
         append_menu_item_fix_through_cgal(menu);
         //append_menu_item_simplify(menu);
         append_menu_item_delete(menu);

--- a/src/slic3r/GUI/GUI_Factories.hpp
+++ b/src/slic3r/GUI/GUI_Factories.hpp
@@ -155,6 +155,7 @@ private:
     void        append_menu_item_merge_to_multipart_object(wxMenu *menu);
     void        append_menu_item_merge_to_single_object(wxMenu* menu);
     void        append_menu_item_merge_parts_to_single_part(wxMenu *menu);
+    void        append_menu_item_merge_some_parts_to_single_part(wxMenu *menu);
     void        append_menu_items_mirror(wxMenu *menu);
     void        append_menu_item_invalidate_cut_info(wxMenu *menu);
     void        append_menu_item_edit_text(wxMenu *menu);

--- a/src/slic3r/GUI/GUI_ObjectList.cpp
+++ b/src/slic3r/GUI/GUI_ObjectList.cpp
@@ -3197,39 +3197,24 @@ void ObjectList::merge(bool to_multipart_object)
     }
 }
 
-/*void ObjectList::merge_volumes()
+// BBS: merge parts to single part
+void ObjectList::merge_volumes()
 {
     std::vector<int> obj_idxs, vol_idxs;
     get_selection_indexes(obj_idxs, vol_idxs);
-    if (obj_idxs.empty() && vol_idxs.empty())
+    // Merging is defined only for two or more parts of one object; a selection
+    // spanning several objects would silently apply the volume indices of the
+    // other objects to the first one. A mixed object+volume selection yields -1
+    // for the object item (GetVolumeIdByItem on a non-volume node).
+    if (obj_idxs.size() != 1 || vol_idxs.size() < 2)
         return;
+    for (int vol_idx : vol_idxs)
+        if (vol_idx < 0)
+            return;
 
     wxBusyCursor wait;
-#if 0
-    ModelObjectPtrs objects;
-    for (int obj_idx : obj_idxs) {
-        ModelObject* object = (*m_objects)[obj_idx];
-        object->merge_volumes(vol_idxs);
-        //changed_object(obj_idx);
-        //remove();
-    }
-   // wxGetApp().plater()->load_model_objects(objects);
-
-    Selection& selection = p->view3D->get_canvas3d()->get_selection();
-    size_t last_obj_idx = p->model.objects.size() - 1;
-
-    if (vol_idxs.empty()) {
-        for (size_t i = 0; i < objects.size(); ++i)
-            selection.add_object((unsigned int)(last_obj_idx - i), i == 0);
-    }
-    else {
-        for (int vol_idx : vol_idxs)
-            selection.add_volume(last_obj_idx, vol_idx, 0, false);
-    }#1#
-#else
     wxGetApp().plater()->merge(obj_idxs[0], vol_idxs);
-#endif
-}*/
+}
 
 void ObjectList::layers_editing()
 {

--- a/src/slic3r/GUI/GUI_ObjectList.cpp
+++ b/src/slic3r/GUI/GUI_ObjectList.cpp
@@ -3208,8 +3208,15 @@ void ObjectList::merge_volumes()
     // for the object item (GetVolumeIdByItem on a non-volume node).
     if (obj_idxs.size() != 1 || vol_idxs.size() < 2)
         return;
+    const ModelObject* object = (*m_objects)[obj_idxs.front()];
     for (int vol_idx : vol_idxs)
-        if (vol_idx < 0)
+        if (vol_idx < 0 || vol_idx >= (int)object->volumes.size())
+            return;
+    // Merging parts of different types has no meaning: the result can only carry
+    // one type, so a negative part or modifier would end up printed as solid.
+    const ModelVolumeType type = object->volumes[vol_idxs.front()]->type();
+    for (int vol_idx : vol_idxs)
+        if (object->volumes[vol_idx]->type() != type)
             return;
 
     wxBusyCursor wait;

--- a/src/slic3r/GUI/GUI_ObjectList.hpp
+++ b/src/slic3r/GUI/GUI_ObjectList.hpp
@@ -310,7 +310,7 @@ public:
     void                del_info_item(const int obj_idx, InfoItemType type);
     void                split();
     void                merge(bool to_multipart_object);
-    // void                merge_volumes(); // BBS: merge parts to single part
+    void                merge_volumes(); // BBS: merge parts to single part
     void                layers_editing();
 
     void                boolean();    // BBS: Boolean Operation of parts

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -17834,6 +17834,31 @@ void Plater::apply_cut_object_to_model(size_t obj_idx, const ModelObjectPtrs& ne
     // w.wait_for_idle();
 }
 
+// BBS: merge the selected volumes of one object into a single volume, in place.
+void Plater::merge(size_t obj_idx, std::vector<int>& vol_indeces)
+{
+    wxCHECK_RET(obj_idx < p->model.objects.size(), "obj_idx out of bounds");
+    auto* object = p->model.objects[obj_idx];
+
+    Plater::TakeSnapshot snapshot(this, _u8L("Merge"));
+
+    wxBusyCursor wait;
+
+    const auto new_objects = object->merge_volumes(vol_indeces);
+    if (new_objects.empty())
+        return;
+
+    remove(obj_idx);
+    p->load_model_objects(new_objects);
+
+    Selection& selection = p->get_selection();
+    size_t last_id = p->model.objects.size() - 1;
+    for (size_t i = 0; i < new_objects.size(); ++i)
+    {
+        selection.add_volume((unsigned int)(last_id - i), 0, 0, i == 0);
+    }
+}
+
 void Plater::export_gcode(bool prefer_removable)
 {
     if (p->model.objects.empty())

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -17855,7 +17855,19 @@ void Plater::merge(size_t obj_idx, std::vector<int>& vol_indeces)
     size_t last_id = p->model.objects.size() - 1;
     for (size_t i = 0; i < new_objects.size(); ++i)
     {
-        selection.add_volume((unsigned int)(last_id - i), 0, 0, i == 0);
+        const size_t loaded_idx = last_id - i;
+        // merge_volumes() puts the merged volume first, but load_model_objects()
+        // stable sorts the volumes by type, so it only stays first when nothing
+        // of an earlier type follows it. It keeps its place among its own type,
+        // so its index is the number of volumes sorting ahead of it.
+        int merged_idx = 0;
+        if (!new_objects[i]->volumes.empty()) {
+            const ModelVolumeType merged_type = new_objects[i]->volumes.front()->type();
+            for (const ModelVolume* v : p->model.objects[loaded_idx]->volumes)
+                if (v->type() < merged_type)
+                    ++merged_idx;
+        }
+        selection.add_volume((unsigned int)loaded_idx, merged_idx, 0, i == 0);
     }
 }
 

--- a/tests/libslic3r/test_model.cpp
+++ b/tests/libslic3r/test_model.cpp
@@ -38,3 +38,67 @@ TEST_CASE("A part's 2D convex hull is its footprint projected onto the bed", "[M
         CHECK(bb.max.y() == scaled(45.));
     }
 }
+
+TEST_CASE("Merging selected volumes yields one part and keeps the rest", "[Model]")
+{
+    Model model;
+    ModelObject* object = model.add_object();
+    // Raw coordinates ([0,10] cubes): the default add_volume re-centers the
+    // geometry, which would obscure the baked-in volume offsets checked below.
+    object->add_volume(make_cube(10, 10, 10), ModelVolumeType::MODEL_PART, false);
+    ModelVolume* second = object->add_volume(make_cube(10, 10, 10), ModelVolumeType::MODEL_PART, false);
+    second->set_offset(Vec3d(20., 0., 0.)); // second cube spans [20,30] in X
+    object->add_volume(make_cube(10, 10, 10), ModelVolumeType::MODEL_PART, false); // stays out of the merge
+
+    const size_t faces_first  = object->volumes[0]->mesh().its.indices.size();
+    const size_t faces_second = object->volumes[1]->mesh().its.indices.size();
+
+    std::vector<int> vol_indeces = {0, 1};
+    const ModelObjectPtrs merged = object->merge_volumes(vol_indeces);
+
+    REQUIRE(merged.size() == 1);
+    REQUIRE(merged.front()->volumes.size() == 2);
+
+    const ModelVolume* vol = merged.front()->volumes.front();
+    CHECK(vol->name == "Merged Parts");
+    CHECK(vol->mesh().its.indices.size() == faces_first + faces_second);
+
+    // The second cube's +20 X offset is baked into the merged vertices, so the
+    // merged part spans both cubes. add_volume re-centers the mesh and puts the
+    // shift on the volume transform, so measure the transformed box.
+    const BoundingBoxf3 bb = vol->mesh().transformed_bounding_box(vol->get_matrix());
+    CHECK_THAT(bb.min.x(), Catch::Matchers::WithinAbs(0., 1e-6));
+    CHECK_THAT(bb.max.x(), Catch::Matchers::WithinAbs(30., 1e-6));
+
+    // The volume left out of the merge is carried over untouched.
+    CHECK(merged.front()->volumes[1]->mesh().its.indices.size() == faces_first);
+}
+
+TEST_CASE("Painting survives merging volumes", "[Model]")
+{
+    Model model;
+    ModelObject* object = model.add_object();
+    ModelVolume* first  = object->add_volume(make_cube(10, 10, 10), ModelVolumeType::MODEL_PART, false);
+    ModelVolume* second = object->add_volume(make_cube(10, 10, 10), ModelVolumeType::MODEL_PART, false);
+    second->set_offset(Vec3d(20., 0., 0.));
+
+    const int faces_first = (int)first->mesh().its.indices.size();
+
+    // Leaf states as serialized by TriangleSelector: "4" = first filament/state,
+    // "8" = second. its_merge appends faces in order, so the second volume's
+    // paint must reappear at its face index offset by the first volume's count.
+    first->mmu_segmentation_facets.set_triangle_from_string(2, "4");
+    second->mmu_segmentation_facets.set_triangle_from_string(0, "8");
+    second->seam_facets.set_triangle_from_string(1, "4");
+
+    std::vector<int> vol_indeces = {0, 1};
+    const ModelObjectPtrs merged = object->merge_volumes(vol_indeces);
+    REQUIRE(merged.size() == 1);
+    const ModelVolume* vol = merged.front()->volumes.front();
+
+    CHECK(vol->mmu_segmentation_facets.get_triangle_as_string(2) == "4");
+    CHECK(vol->mmu_segmentation_facets.get_triangle_as_string(faces_first + 0) == "8");
+    CHECK(vol->seam_facets.get_triangle_as_string(faces_first + 1) == "4");
+    // A face that was never painted stays unpainted.
+    CHECK(vol->mmu_segmentation_facets.get_triangle_as_string(3).empty());
+}

--- a/tests/libslic3r/test_model.cpp
+++ b/tests/libslic3r/test_model.cpp
@@ -74,6 +74,24 @@ TEST_CASE("Merging selected volumes yields one part and keeps the rest", "[Model
     CHECK(merged.front()->volumes[1]->mesh().its.indices.size() == faces_first);
 }
 
+TEST_CASE("Merging keeps the part type", "[Model]")
+{
+    Model model;
+    ModelObject* object = model.add_object();
+    object->add_volume(make_cube(10, 10, 10), ModelVolumeType::NEGATIVE_VOLUME, false);
+    ModelVolume* second = object->add_volume(make_cube(10, 10, 10), ModelVolumeType::NEGATIVE_VOLUME, false);
+    second->set_offset(Vec3d(20., 0., 0.));
+    object->add_volume(make_cube(10, 10, 10), ModelVolumeType::MODEL_PART, false);
+
+    std::vector<int> vol_indeces = {0, 1};
+    const ModelObjectPtrs merged = object->merge_volumes(vol_indeces);
+
+    REQUIRE(merged.size() == 1);
+    // Defaulting to MODEL_PART here would print geometry that was meant to be
+    // subtracted.
+    CHECK(merged.front()->volumes.front()->type() == ModelVolumeType::NEGATIVE_VOLUME);
+}
+
 TEST_CASE("Painting survives merging volumes", "[Model]")
 {
     Model model;

--- a/tests/libslic3r/test_model.cpp
+++ b/tests/libslic3r/test_model.cpp
@@ -92,6 +92,38 @@ TEST_CASE("Merging keeps the part type", "[Model]")
     CHECK(merged.front()->volumes.front()->type() == ModelVolumeType::NEGATIVE_VOLUME);
 }
 
+// Plater::merge selects the merged volume after loading, and loading stable
+// sorts volumes by type, so the merged volume is only at index 0 when no
+// earlier type follows it.
+TEST_CASE("A merged part sorts after the types that precede it", "[Model]")
+{
+    Model model;
+    ModelObject* object = model.add_object();
+    object->add_volume(make_cube(10, 10, 10), ModelVolumeType::NEGATIVE_VOLUME, false);
+    ModelVolume* second = object->add_volume(make_cube(10, 10, 10), ModelVolumeType::NEGATIVE_VOLUME, false);
+    second->set_offset(Vec3d(20., 0., 0.));
+    object->add_volume(make_cube(10, 10, 10), ModelVolumeType::MODEL_PART, false);
+
+    std::vector<int> vol_indeces = {0, 1};
+    const ModelObjectPtrs merged = object->merge_volumes(vol_indeces);
+    REQUIRE(merged.size() == 1);
+
+    ModelObject* result = merged.front();
+    // merge_volumes leaves the merged volume first.
+    REQUIRE(result->volumes.front()->type() == ModelVolumeType::NEGATIVE_VOLUME);
+    const ModelVolume* merged_volume = result->volumes.front();
+
+    result->sort_volumes(true);
+
+    size_t expected = 0;
+    for (const ModelVolume* v : result->volumes)
+        if (v->type() < ModelVolumeType::NEGATIVE_VOLUME)
+            ++expected;
+    // The model part now sorts ahead of it, so index 0 would be the wrong pick.
+    CHECK(expected == 1);
+    CHECK(result->volumes[expected] == merged_volume);
+}
+
 TEST_CASE("Painting survives merging volumes", "[Model]")
 {
     Model model;


### PR DESCRIPTION
Ported from BBS.

You can now select several parts of one object, right click, and choose **Merge into Single Part** to combine them into one part. Parts you did not select are left alone. This is the in place counterpart to **Mesh boolean**, which welds every part of an object into a brand new object, and **Assemble**, which combines separate objects.

Addresses the "part groups" request in #10012, so a multi part model can be tidied up without leaving OrcaSlicer.

Most of the backend was already in the tree, inherited from BBS and left disconnected: `ModelObject::merge_volumes` was live but unreachable, `ObjectList::merge_volumes` was commented out, `Plater::merge` was declared in `Plater.hpp` with no definition anywhere, and the menu item did not exist. This wires those together and fills in the missing `Plater::merge`.

> [!NOTE]
> A part carries one filament, so merging parts that used different filaments leaves the result on a single filament. Per triangle painting is a separate layer and is preserved, so painted regions keep their colors. If you want the parts to keep their individual filaments, use **Assemble** instead.

Differences from the BBS original, all deliberate:

1. **Painting is preserved.** `its_merge` appends faces in order, so face indices map one to one. The per face support, seam, MMU segmentation and fuzzy skin annotations are captured before the source meshes are reset, then re applied to the merged part at their offset indices. Without this, merging silently discarded every kind of painting.
2. **The part type is kept.** The default `add_volume` overload produces a normal part, so merging negative parts or modifiers would turn them into printed geometry. The merged part now inherits the type of the parts it came from, and the menu action refuses a selection that mixes types.
3. **The selection is validated.** The action requires a single object with two or more parts selected, and rejects the mixed object plus part selection where `GetVolumeIdByItem` returns `-1`. The BBS version only checks that the selection is non empty, which can apply one object's part indices to a different object.

The dead CGAL union branch in `merge_volumes` was dropped rather than carried over. Nothing changes when the menu item is not used.

## Screenshots/Recordings

On a four part test assembly: selecting two parts, choosing Merge into Single Part, the remaining parts left untouched, painting surviving on the merged part, and undo restoring the original parts.

https://github.com/user-attachments/assets/2e12e611-e9fc-4654-88c3-d264d1348ce5

## Tests

New Catch2 cases in `tests/libslic3r/test_model.cpp`:

- merging selected volumes yields one part with the summed face count, bakes the source transforms into the merged geometry, and leaves unselected parts untouched
- painting survives the merge, including the face index offset for the second part, with unpainted faces staying unpainted
- the merged part keeps the type of its source parts

`libslic3r_tests` passes in full (58027 assertions in 298 test cases), so nothing else regressed.

Manually verified on Windows with a seven part painted project: the menu item appears only for a multi part selection, the merge leaves the other parts and the object position untouched, painted regions render unchanged afterwards, and undo restores the original parts.
