### PR TITLE
fix: Cyrillic and other non-Latin text shows as question marks or garbage

### DIFF
--- a/src/slic3r/GUI/ImGuiWrapper.cpp
+++ b/src/slic3r/GUI/ImGuiWrapper.cpp
@@ -2482,6 +2482,19 @@ static const ImWchar ranges_keyboard_shortcuts[] =
 };
 #endif // __APPLE__
 
+// Names drawn through the atlas come from file names and CAD data, not from the UI language.
+// GetGlyphRangesDefault() already gives every language the CJK ideographs, which is why a
+// Chinese file name renders under an English UI; these are the alphabetic scripts it omits.
+// Codepoints the font lacks are skipped at build time, so only existing glyphs cost anything.
+static const ImWchar ranges_language_independent[] =
+{
+    0x0100, 0x024F, // Latin Extended-A and Extended-B
+    0x0370, 0x03FF, // Greek and Coptic
+    0x0400, 0x04FF, // Cyrillic
+    0x1E00, 0x1EFF, // Latin Extended Additional (Vietnamese)
+    0,
+};
+
 
 std::vector<unsigned char> ImGuiWrapper::load_svg(const std::string& bitmap_name, unsigned target_width, unsigned target_height, unsigned *outwidth, unsigned *outheight)
 {
@@ -2792,6 +2805,7 @@ void ImGuiWrapper::init_font(bool compress)
     ImFontAtlas::GlyphRangesBuilder builder;
     builder.AddRanges(m_glyph_ranges);
     builder.AddRanges(ImGui::GetIO().Fonts->GetGlyphRangesDefault());
+    builder.AddRanges(ranges_language_independent);
 #ifdef __APPLE__
     if (m_font_cjk)
         // Apple keyboard shortcuts are only contained in the CJK fonts.
@@ -2813,12 +2827,17 @@ void ImGuiWrapper::init_font(bool compress)
     // Orca: temp fix for Korean font
     auto font_name_regular = "HarmonyOS_Sans_SC_Regular.ttf";
     auto font_name_bold = "HarmonyOS_Sans_SC_Bold.ttf";
+    // The Korean and Thai fonts cover their own script and little else, so they need the
+    // default font merged in behind them to reach the full range.
+    bool needs_glyph_fallback = false;
     if(m_glyph_ranges == ImGui::GetIO().Fonts->GetGlyphRangesKorean()) {
         font_name_regular = "NanumGothic-Regular.ttf";
         font_name_bold = "NanumGothic-Bold.ttf";
+        needs_glyph_fallback = true;
     } else if (m_glyph_ranges == ImGui::GetIO().Fonts->GetGlyphRangesThai()) {
         font_name_regular = "Sarabun-Medium.ttf";
         font_name_bold = "Sarabun-SemiBold.ttf";
+        needs_glyph_fallback = true;
     }
     default_font = io.Fonts->AddFontFromFileTTF((Slic3r::resources_dir() + "/fonts/" + font_name_regular).c_str(), m_font_size, &cfg, ranges.Data);
     if (default_font == nullptr) {
@@ -2828,11 +2847,12 @@ void ImGuiWrapper::init_font(bool compress)
         }
     }
 
-    if (m_glyph_ranges == ImGui::GetIO().Fonts->GetGlyphRangesThai()) {
+    // A merged font only supplies glyphs the font ahead of it lacks, so this fills the gaps
+    // without restyling anything the script font already covers.
+    if (needs_glyph_fallback) {
         ImFontConfig fallback_cfg = cfg;
         fallback_cfg.MergeMode = true;
-        static constexpr ImWchar celsius_range[] = { 0x2103, 0x2103, 0 };
-        io.Fonts->AddFontFromFileTTF((Slic3r::resources_dir() + "/fonts/HarmonyOS_Sans_SC_Regular.ttf").c_str(), m_font_size, &fallback_cfg, celsius_range);
+        io.Fonts->AddFontFromFileTTF((Slic3r::resources_dir() + "/fonts/HarmonyOS_Sans_SC_Regular.ttf").c_str(), m_font_size, &fallback_cfg, ranges.Data);
     }
 
     bold_font        = io.Fonts->AddFontFromFileTTF((Slic3r::resources_dir() + "/fonts/" + font_name_bold).c_str(), m_font_size, &cfg, ranges.Data);
@@ -2841,11 +2861,10 @@ void ImGuiWrapper::init_font(bool compress)
         if (bold_font == nullptr) { throw Slic3r::RuntimeError("ImGui: Could not load deafult font"); }
     }
 
-    if (m_glyph_ranges == ImGui::GetIO().Fonts->GetGlyphRangesThai()) {
+    if (needs_glyph_fallback) {
         ImFontConfig fallback_cfg = cfg;
         fallback_cfg.MergeMode = true;
-        static constexpr ImWchar celsius_range[] = { 0x2103, 0x2103, 0 };
-        io.Fonts->AddFontFromFileTTF((Slic3r::resources_dir() + "/fonts/HarmonyOS_Sans_SC_Bold.ttf").c_str(), m_font_size, &fallback_cfg, celsius_range);
+        io.Fonts->AddFontFromFileTTF((Slic3r::resources_dir() + "/fonts/HarmonyOS_Sans_SC_Bold.ttf").c_str(), m_font_size, &fallback_cfg, ranges.Data);
     }
 
     if (m_glyph_ranges == ImGui::GetIO().Fonts->GetGlyphRangesThai()) {
@@ -2897,13 +2916,18 @@ void ImGuiWrapper::init_font(bool compress)
     glsafe(::glGetIntegerv(GL_MAX_TEXTURE_SIZE, &gl_max_tex_size));
     constexpr int max_retries = 6;
     for (int attempt = 0; attempt < max_retries && io.Fonts->TexHeight > gl_max_tex_size; ++attempt) {
-        io.Fonts->TexDesiredWidth = (io.Fonts->TexDesiredWidth > 0 ? io.Fonts->TexDesiredWidth : io.Fonts->TexWidth) * 2;
+        const int width = io.Fonts->TexDesiredWidth > 0 ? io.Fonts->TexDesiredWidth : io.Fonts->TexWidth;
+        // Both dimensions share the same limit, so widening past it would only trade an
+        // illegal height for an illegal width.
+        if (width * 2 > gl_max_tex_size)
+            break;
+        io.Fonts->TexDesiredWidth = width * 2;
         io.Fonts->Build();
     }
     if (io.Fonts->TexHeight > gl_max_tex_size) {
-        // Shouldn't really happen
-        BOOST_LOG_TRIVIAL(error) << "Font atlas height " << io.Fonts->TexHeight
-            << " still exceeds GL_MAX_TEXTURE_SIZE (" << gl_max_tex_size << ")"
+        // Needs both a very large glyph set and a small GL_MAX_TEXTURE_SIZE.
+        BOOST_LOG_TRIVIAL(error) << "Font atlas " << io.Fonts->TexWidth << "x" << io.Fonts->TexHeight
+            << " does not fit GL_MAX_TEXTURE_SIZE (" << gl_max_tex_size << ")"
             << " after " << max_retries << " attempts; rendering may be incomplete";
     }
 

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -21635,7 +21635,7 @@ void Plater::show_object_info()
     auto mesh_errors = p->sidebar->obj_list()->get_mesh_errors_info(&info_manifold, &non_manifold_edges);
 
         if (non_manifold_edges > 0) {
-            info_manifold += into_u8("\n" + _L("Tips:") + "\n" + _L("Use \"Fix Model\" to repair the mesh."));
+            info_manifold += "\n" + _L("Tips:") + "\n" + _L("Use \"Fix Model\" to repair the mesh.");
         }
 
     info_manifold = "<Error>" + info_manifold + "</Error>";

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -7530,7 +7530,7 @@ void Tab::delete_preset()
         for (auto &preset2 : *m_presets)
             if (preset2.inherits() == current_preset.name) {
                 ++count;
-                presets += "\n - " + preset2.name;
+                presets += "\n - " + from_u8(preset2.name);
             }
         if (count > 0) {
             msg = _L("Presets inherited by other presets cannot be deleted!");


### PR DESCRIPTION
# Description

Non-Latin text is mangled in several places. Two different causes look alike: one `?` per character means the glyph is missing from the ImGui font atlas, while `РЎРѕ` sequences mean UTF-8 bytes were decoded as a single-byte code page.

Fixes #11353. Fixes #4042.

### Font atlas

`ImGuiWrapper::set_language()` picks a glyph range per UI language, and `en` gets Basic Latin and nothing else, so Cyrillic never reaches the atlas and each character falls back to `?`. The string is already correct UTF-8 by then. Not English-only either: the fallback range every unlisted language gets has no Cyrillic or Greek, and a Russian UI was missing Greek, Polish and Czech.

Chinese was unaffected because `GetGlyphRangesDefault()`, added for every language, already carries all 20,902 CJK ideographs. The alphabetic scripts were just missing from that unconditional set. Adding them is nearly free, since codepoints absent from the font are skipped when the atlas is built.

Korean and Thai use fonts covering little outside their own script, so the fallback merge Thai already had for the Celsius symbol now carries the primary font's full range and applies to Korean too. ImGui never lets a merged font overwrite an earlier glyph, so nothing either script font covers is restyled.

| UI language | glyphs | atlas |
|---|---|---|
| English | 21,461 to 21,934 | 2048x1896 to 2048x1922 |
| Russian | 21,590 to 21,934 | 2048x1903 to 2048x1922 |
| Korean | 16,344 to 33,167 | 2048x1407 to 2048x2891 |
| Thai | 302 to 22,068 | 512x69 to 2048x1928 |

Unlisted languages and both Chinese variants match English. Thai changes most, having had no Cyrillic, Greek, Latin Extended or CJK at all. Korean users will now see those scripts in HarmonyOS rather than NanumGothic, a visible typeface mix worth a Korean speaker's eye.

Korean is the only locale needing Hangul on top of CJK, so its atlas is the largest and the first to pass 2048 in height. That exposed a bug in the existing overflow retry, which widened the atlas without checking the new width against the same limit, so a GPU capped at 2048 got a 4096-wide texture and the loop exited as if it had succeeded. It now stops before breaching the limit. The legal widening path is unchanged and the retry does not run at all above 4096.

### UTF-8 bytes assigned into a `wxString`

`wxString` decodes a narrow string using the local code page, so assigning UTF-8 bytes to one prints mojibake. Two places do it.

`Tab::delete_preset()` appended a `std::string` preset name straight to a `wxString` when listing presets that inherit the one being deleted. The same list in `CreatePresetsDialog` has always had `from_u8`.

`Plater::show_object_info()` ran the "Tips: Use Fix Model to repair the mesh." line through `into_u8()` before appending it. That line was never edited; #12155 removed the `#ifndef __WINDOWS__` guard that had kept Windows out of the block.

The `cs`/`pl`, `tr`, `vi` and `ru` branches of `set_language()` are now redundant but deliberately kept, since `m_glyph_ranges` is compared by pointer and handed to the emboss gizmo's `StyleManager`.

# Screenshots/Recordings/Graphs

| Case | Before | After |
|---|---|---|
| Part name in the object info box, English UI | <img width="383" src="https://github.com/user-attachments/assets/60ba7199-cfa1-4386-898b-a4562d7b9083" /> | <img width="378" src="https://github.com/user-attachments/assets/beac382b-7608-4d81-9251-73b2b2096293" /> |
| Object label in the 3D view, English UI | <img width="144" src="https://github.com/user-attachments/assets/a7b85ad4-1075-4229-bd6c-acbbac386f92" /> | <img width="149" src="https://github.com/user-attachments/assets/d9b636da-60b9-47e2-8eb5-6af3a542fd60" /> |
| File name in the export notification, English UI | <img width="375" src="https://github.com/user-attachments/assets/8c2a2038-fa42-4185-9ea5-7536d249b645" /> | <img width="385" src="https://github.com/user-attachments/assets/4af1dd55-aa3a-4c8f-bf63-8c2e2b9e6691" /> |
| G-code comments, English UI | <img width="418" src="https://github.com/user-attachments/assets/c85ca5f3-2dbc-4d5b-a044-cc0557e60d7f" /> | <img width="421" src="https://github.com/user-attachments/assets/8cd3a643-d1d0-47bc-95d7-804d425717d8" /> |
| `Совет:` line in the object info box, Russian UI | <img width="381" src="https://github.com/user-attachments/assets/a59c9204-08d3-491b-962f-2c547ffcdf3e" /> | <img width="378" src="https://github.com/user-attachments/assets/b55c09b1-59c9-4470-8060-5dccf0ca33f5" /> |

The Russian pair is the one showing that the second bug is not a font problem: `Ошибка: 3 открытых ребра.` renders correctly one line above the mangled `Ð¡Ð¾Ð²ÐµÑ‚:`.

The preset-delete case is the same `wxString` bug as that line and is not pictured here. The reported symptom is the screenshot in the second table of #4042, under "Trying to delete a parent filament profile".

## Tests

Built on Windows with clang-cl. The English-UI cases were confirmed in the running app against a project with Cyrillic, Greek and Polish names. Atlas coverage was measured per UI language by rebuilding the atlas the way `init_font()` does and querying each codepoint, rather than judging by eye. Linux and macOS unverified beyond CI.

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
