### PR TITLE
build: clear 53 warnings - discarded values and i18n markers

### DIFF
--- a/src/slic3r/GUI/DeviceCore/DevConfigUtil.cpp
+++ b/src/slic3r/GUI/DeviceCore/DevConfigUtil.cpp
@@ -16,24 +16,27 @@ namespace Slic3r
 // This block is never executed at runtime.
 static void _toolhead_translation_markers()
 {
-    // Dynamic toolhead display names from JSON config — xgettext cannot scan these
-    L("Main Extruder");     L("Main extruder");     L("main extruder");
-    L("Auxiliary Extruder"); L("Auxiliary extruder"); L("auxiliary extruder");
-    L("Left Extruder");     L("Left extruder");     L("left extruder");
-    L("Right Extruder");    L("Right extruder");    L("right extruder");
-    L("Main Nozzle");       L("Main nozzle");       L("main nozzle");
-    L("Auxiliary Nozzle");   L("Auxiliary nozzle");   L("auxiliary nozzle");
-    L("Left Nozzle");       L("Left nozzle");       L("left nozzle");
-    L("Right Nozzle");      L("Right nozzle");      L("right nozzle");
-    L("Main Hotend");       L("Main hotend");       L("main hotend");
-    L("Auxiliary Hotend");   L("Auxiliary hotend");   L("auxiliary hotend");
-    L("Left Hotend");       L("Left hotend");       L("left hotend");
-    L("Right Hotend");      L("Right hotend");      L("right hotend");
-    // standalone position words (short_name=true runtime results)
-    L("main");              L("auxiliary");
-    L("Main");              L("Auxiliary");
-    L("left");              L("right");
-    L("Left");              L("Right");
+    // Possible runtime values of tool_head_display_names, marked for extraction.
+    static const char *const markers[] = {
+        L("Main Extruder"),      L("Main extruder"),      L("main extruder"),
+        L("Auxiliary Extruder"), L("Auxiliary extruder"), L("auxiliary extruder"),
+        L("Left Extruder"),      L("Left extruder"),      L("left extruder"),
+        L("Right Extruder"),     L("Right extruder"),     L("right extruder"),
+        L("Main Nozzle"),        L("Main nozzle"),        L("main nozzle"),
+        L("Auxiliary Nozzle"),   L("Auxiliary nozzle"),   L("auxiliary nozzle"),
+        L("Left Nozzle"),        L("Left nozzle"),        L("left nozzle"),
+        L("Right Nozzle"),       L("Right nozzle"),       L("right nozzle"),
+        L("Main Hotend"),        L("Main hotend"),        L("main hotend"),
+        L("Auxiliary Hotend"),   L("Auxiliary hotend"),   L("auxiliary hotend"),
+        L("Left Hotend"),        L("Left hotend"),        L("left hotend"),
+        L("Right Hotend"),       L("Right hotend"),       L("right hotend"),
+        // standalone position words (short_name=true runtime results)
+        L("main"),               L("auxiliary"),
+        L("Main"),               L("Auxiliary"),
+        L("left"),               L("right"),
+        L("Left"),               L("Right"),
+    };
+    (void) markers;
 }
 
 std::string DevPrinterConfigUtil::m_resource_file_path = "";

--- a/src/slic3r/GUI/DeviceTab/wgtDeviceNozzleSelect.cpp
+++ b/src/slic3r/GUI/DeviceTab/wgtDeviceNozzleSelect.cpp
@@ -266,7 +266,7 @@ void wgtDeviceNozzleRackSelect::OnNozzleItemSelected(wxCommandEvent &evt)
     }
 
     auto *item = dynamic_cast<wgtDeviceNozzleRackNozzleItem *>(evt.GetEventObject());
-    if (item; auto ptr = m_nozzle_rack.lock()) {
+    if (auto ptr = m_nozzle_rack.lock(); item && ptr) {
         int to_select_pos_id = sGetNozzlePosId(item, m_toolhead_nozzle_l, m_toolhead_nozzle_r);
         if (to_select_pos_id > -1 && to_select_pos_id != GetSelectedNozzlePosID()) {
             SetSelectedNozzle(ptr->GetNozzleSystem()->GetNozzleByPosId(to_select_pos_id));

--- a/src/slic3r/GUI/UpgradePanel.cpp
+++ b/src/slic3r/GUI/UpgradePanel.cpp
@@ -862,7 +862,6 @@ void MachineInfoPanel::update_ams_ext(MachineObject *obj)
             if (new_extra_ams_ver != obj->new_ver_list.end())
                 has_new_version = true;
 
-            extra_ams_it->second.sw_new_ver;
             if (has_new_version) {
                 m_extra_ams_panel->m_ams_new_version_img->Show();
                 ver_text = new_extra_ams_ver->second.sw_ver;

--- a/src/slic3r/GUI/Widgets/AMSItem.cpp
+++ b/src/slic3r/GUI/Widgets/AMSItem.cpp
@@ -114,7 +114,6 @@ bool AMSinfo::parse_ams_info(MachineObject *obj, DevAms *ams, bool remain_flag, 
                 info.ctype = 0;
                 info.material_colour = AMS_TRAY_DEFAULT_COL;
                 info.material_state = AMSCanType::AMS_CAN_TYPE_THIRDBRAND;
-                wxColour(255, 255, 255);
             }
 
             if (it->second->is_tray_info_ready() && obj->cali_version >= 0) {
@@ -171,7 +170,6 @@ void AMSinfo::parse_ext_info(MachineObject* obj, DevAmsTray tray) {
         info.filament_id = "";
         info.ctype = 0;
         info.material_colour = AMS_TRAY_DEFAULT_COL;
-        wxColour(255, 255, 255);
     }
     info.material_state = AMSCanType::AMS_CAN_TYPE_VIRTUAL;
     if (tray.is_tray_info_ready() && obj->cali_version >= 0) {

--- a/src/slic3r/GUI/Widgets/FanControl.cpp
+++ b/src/slic3r/GUI/Widgets/FanControl.cpp
@@ -1014,8 +1014,12 @@ void FanControlPopupNew::init_names(MachineObject* obj) {
     if (obj) {
         const std::string& special_cooling_text = DevPrinterConfigUtil::get_fan_text(obj->printer_type, "special_cooling_text");
         if (!special_cooling_text.empty()) {
-            L("Cooling mode is suitable for printing PLA/PETG/TPU materials."); //some potential text, add i18n flags
-            L("Cooling mode is suitable for printing PLA/PETG/TPU materials and filters the chamber air.");
+            // Possible runtime values of special_cooling_text, marked for extraction.
+            static const char *const markers[] = {
+                L("Cooling mode is suitable for printing PLA/PETG/TPU materials."),
+                L("Cooling mode is suitable for printing PLA/PETG/TPU materials and filters the chamber air."),
+            };
+            (void) markers;
             label_text[AIR_DUCT::AIR_DUCT_COOLING_FILT] = _L(special_cooling_text);
         }
     }
@@ -1028,9 +1032,13 @@ wxString FanControlPopupNew::get_fan_func_name(int mode, int submode, AIR_FUN fu
         const std::string& func_text = DevPrinterConfigUtil::get_fan_text(m_obj->printer_type, mode, (int)func, submode);
         if (!func_text.empty())
         {
-            L_CONTEXT("Right(Aux)", "air_duct");
-            L_CONTEXT("Right(Filter)", "air_duct");
-            L_CONTEXT("Left(Aux)", "air_duct");
+            // Possible runtime values of func_text, marked for extraction.
+            static const char *const markers[] = {
+                L_CONTEXT("Right(Aux)", "air_duct"),
+                L_CONTEXT("Right(Filter)", "air_duct"),
+                L_CONTEXT("Left(Aux)", "air_duct"),
+            };
+            (void) markers;
             return _L_CONTEXT(func_text, "air_duct");
         }
     }


### PR DESCRIPTION
# Description

`-Wunused-value` from #15374, 53 warnings across 25 sites in 5 files.

49 of them are deliberate i18n markers. `L(s)` expands to `s`, so `L("Main Extruder");` is a string literal as a statement and its value is discarded. They have to stay, because the real values come from `printers/*.json` at runtime and xgettext cannot scan those. Each block is now a `static const char *const markers[]`, which uses the values rather than discarding them.

The other 4 are statements with no effect. `AMSItem.cpp:117` and `:174` construct and drop a `wxColour(255, 255, 255)`; `AMS_TRAY_DEFAULT_COL` is that colour, and the line above already assigns it. `UpgradePanel.cpp:865` reads a member and drops it.

`wgtDeviceNozzleSelect.cpp:269` writes `if (item; auto ptr = m_nozzle_rack.lock())`, which puts the null check in the init-statement position where its value is discarded, so the check never runs, and `sGetNozzlePosId` then dereferences `item`. Nothing reaches that today, because the only sender of the event sets itself as the event object and the `dynamic_cast` always succeeds. The check now runs.

# Screenshots/Recordings/Graphs

No visual change.

## Tests

No new tests. None of this changes observable behaviour.

Running the xgettext invocation from `scripts/run_gettext.bat` over the two marker files gives 76 msgids before and after, with identical `msgid` and `msgctxt` sets.

`-Wunused-value` goes from 53 to 0, and it is the only category that moved.

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
