### PR TITLE
build: clear 54 warnings - dead private fields

### DIFF
--- a/src/libslic3r/GCodeWriter.hpp
+++ b/src/libslic3r/GCodeWriter.hpp
@@ -165,7 +165,6 @@ public:
 
 
     //BBS
-    unsigned int    m_last_additional_fan_speed;
     int             m_last_bed_temperature;
     bool            m_last_bed_temperature_reached;
     double          m_lifted;

--- a/src/slic3r/GUI/AMSDryControl.hpp
+++ b/src/slic3r/GUI/AMSDryControl.hpp
@@ -55,7 +55,6 @@ private:
 
     Label* m_text_label;
     wxStaticBitmap* m_icon_bitmap;
-    int m_target_size;
     std::string m_icon_name;
     ScalableBitmap m_icon;
 };

--- a/src/slic3r/GUI/AboutDialog.hpp
+++ b/src/slic3r/GUI/AboutDialog.hpp
@@ -60,7 +60,6 @@ class AboutDialog : public DPIDialog
     wxHtmlWindow*   m_html;
     wxStaticBitmap* m_logo;
     int             m_copy_rights_btn_id { wxID_ANY };
-    int             m_copy_version_btn_id { wxID_ANY };
 public:
     AboutDialog();
 

--- a/src/slic3r/GUI/BBLTopbar.hpp
+++ b/src/slic3r/GUI/BBLTopbar.hpp
@@ -93,7 +93,6 @@ private:
     CenteredTitle*    m_title_ctrl { nullptr };
     wxString          m_titleText;
 
-    wxAuiToolBarItem* m_account_item;
     wxAuiToolBarItem* m_model_store_item;
     
     //wxAuiToolBarItem *m_publish_item;

--- a/src/slic3r/GUI/CreatePresetsDialog.hpp
+++ b/src/slic3r/GUI/CreatePresetsDialog.hpp
@@ -74,12 +74,10 @@ private:
     std::unordered_set<std::string>                                  m_system_filament_types_set;
     std::set<std::string>                                            m_visible_printers;
     CreateType                                                       m_create_type;
-    Button *                                                         m_button_create                = nullptr;
     Button *                                                         m_button_cancel                = nullptr;
     ComboBox *                                                       m_filament_vendor_combobox     = nullptr;
     ::CheckBox *                                                     m_can_not_find_vendor_checkbox = nullptr;
     ComboBox *                                                       m_filament_type_combobox       = nullptr;
-    ComboBox *                                                       m_exist_vendor_combobox        = nullptr;
     ComboBox *                                                       m_filament_preset_combobox     = nullptr;
     TextInput *                                                      m_filament_custom_vendor_input = nullptr;
     wxGridSizer *                                                    m_filament_presets_sizer       = nullptr;

--- a/src/slic3r/GUI/DeviceTab/uiAMSBestPositionPopup.hpp
+++ b/src/slic3r/GUI/DeviceTab/uiAMSBestPositionPopup.hpp
@@ -199,7 +199,6 @@ private:
     void OnRefreshButton(wxCommandEvent& event);
 
 private:
-    int saveTimes{0};
     wxBoxSizer* mainSizer{nullptr};
     wxPanel* textPanel{nullptr};
     wxBoxSizer* textSizer{nullptr};

--- a/src/slic3r/GUI/DeviceTab/wgtDeviceNozzleRackUpdate.h
+++ b/src/slic3r/GUI/DeviceTab/wgtDeviceNozzleRackUpdate.h
@@ -122,7 +122,6 @@ private:
 private:
     int m_ext_nozzle_id = -1;
     int m_rack_nozzle_id = -1;
-    bool m_isRefreshFinish = false;
     bool findNozzleImage = false;
 
     NozzleStatus m_nozzle_status = NOZZLE_STATUS_DC;
@@ -154,7 +153,6 @@ private:
     Label* m_diameter_label;
     Label* m_flowtype_label;
     Label* m_type_label;
-    ScalableButton* m_error_button{ nullptr };
 
     Label* m_sn_label;
     Label* m_version_label;

--- a/src/slic3r/GUI/GCodeViewer.hpp
+++ b/src/slic3r/GUI/GCodeViewer.hpp
@@ -72,7 +72,6 @@ public:
             float m_model_z_offset{ 0.5f };
             bool m_visible{ true };
             bool m_is_dark = false;
-            bool m_fixed_screen_size{ false };
             float m_scale_factor{ 1.0f };
 #if ENABLE_ACTUAL_SPEED_DEBUG
             ActualSpeedImguiWidget m_actual_speed_imgui_widget;

--- a/src/slic3r/GUI/GLToolbar.hpp
+++ b/src/slic3r/GUI/GLToolbar.hpp
@@ -327,7 +327,6 @@ private:
     GLTexture m_icons_texture;
     bool m_icons_texture_dirty;
     mutable GLTexture m_images_texture;
-    mutable bool m_images_texture_dirty;
     BackgroundTexture m_background_texture;
     GLTexture m_arrow_texture;
     Layout m_layout;

--- a/src/slic3r/GUI/Gizmos/GLGizmoFdmSupports.hpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoFdmSupports.hpp
@@ -86,7 +86,6 @@ private:
     boost::thread   m_thread;
     // Mutex and condition variable to synchronize m_thread with the UI thread.
     std::mutex      m_mutex;
-    int m_generate_count;
 
     // This map holds all translated description texts, so they can be easily referenced during layout calculations
     // etc. When language changes, GUI is recreated and this class constructed again, so the change takes effect.

--- a/src/slic3r/GUI/IMSlider.hpp
+++ b/src/slic3r/GUI/IMSlider.hpp
@@ -176,7 +176,6 @@ private:
     // Use those values to disable selection of active extruders
     bool m_is_dark = false;
 
-    bool is_osx{false};
     int  m_min_value;
     int  m_max_value;
     int  m_lower_value;
@@ -201,10 +200,6 @@ private:
     void *m_one_layer_on_hover_id;
     void *m_one_layer_off_id;
     void *m_one_layer_off_hover_id;
-    void* m_one_layer_on_light_id;
-    void* m_one_layer_on_hover_light_id;
-    void* m_one_layer_off_light_id;
-    void* m_one_layer_off_hover_light_id;
     void* m_one_layer_on_dark_id;
     void* m_one_layer_on_hover_dark_id;
     void* m_one_layer_off_dark_id;

--- a/src/slic3r/GUI/MediaFilePanel.h
+++ b/src/slic3r/GUI/MediaFilePanel.h
@@ -61,7 +61,6 @@ private:
     ::Button    *m_button_year = nullptr;
     ::Button    *m_button_month = nullptr;
     ::Button    *m_button_all = nullptr;
-    ::Label     *m_switch_label = nullptr;
 
     ::StaticBox *   m_type_panel    = nullptr;
     ::Button *      m_button_video   = nullptr;

--- a/src/slic3r/GUI/Monitor.hpp
+++ b/src/slic3r/GUI/Monitor.hpp
@@ -86,11 +86,8 @@ private:
 
 	/* side tools */
     SideTools*      m_side_tools{nullptr};
-    wxStaticBitmap* m_bitmap_printer_type;
     wxStaticBitmap* m_bitmap_arrow;
-    wxStaticText*   m_staticText_printer_name;
     wxStaticBitmap* m_bitmap_wifi_signal;
-    wxBoxSizer *    m_side_tools_sizer;
     SelectMachinePopup m_select_machine;
 
 	/* images */
@@ -101,7 +98,6 @@ private:
     wxBitmap m_printer_img;
     wxBitmap m_arrow_img;
 
-    int last_wifi_signal = -1;
     int last_status;
     bool m_initialized { false };
     bool update_flag{false};

--- a/src/slic3r/GUI/MultiMachineManagerPage.hpp
+++ b/src/slic3r/GUI/MultiMachineManagerPage.hpp
@@ -88,7 +88,6 @@ private:
     Button*                 m_task_name{ nullptr };
     Button*                 m_status{ nullptr };
     Button*                 m_action{ nullptr };
-    Button*                 m_stop_all_botton{nullptr};
 
     // tip when no device
     wxStaticText*           m_tip_text{ nullptr };

--- a/src/slic3r/GUI/ObjColorDialog.hpp
+++ b/src/slic3r/GUI/ObjColorDialog.hpp
@@ -79,7 +79,6 @@ private:
     std::vector<wxBoxSizer *> m_row_col_boxsizer_list;
     std::vector<ButtonState*> m_result_icon_list;
     int                       m_last_cluster_num{-1};
-    const int               m_combox_width{50};
     int                     m_combox_icon_width;
     int                     m_combox_icon_height;
     wxButton *              m_image_button = nullptr;

--- a/src/slic3r/GUI/PartSkipDialog.hpp
+++ b/src/slic3r/GUI/PartSkipDialog.hpp
@@ -128,7 +128,6 @@ private:
     bool      is_drag_mode();
 
     boost::shared_ptr<PrinterFileSystem> m_file_sys;
-    bool                                 m_file_sys_result{false};
     std::string                          m_timestamp;
     std::string                          m_tmp_path;
     std::vector<string>                  m_local_paths;

--- a/src/slic3r/GUI/PhysicalPrinterDialog.hpp
+++ b/src/slic3r/GUI/PhysicalPrinterDialog.hpp
@@ -33,7 +33,6 @@ class PhysicalPrinterDialog : public DPIDialog
     Button*     m_printhost_test_btn                {nullptr};
     Button*     m_printhost_logout_btn              {nullptr};
     Button*     m_printhost_cafile_browse_btn       {nullptr};
-    Button*     m_printhost_client_cert_browse_btn  {nullptr};
     Button*     m_printhost_port_browse_btn         {nullptr};
 
     RoundedRectangle*   m_input_area                        {nullptr};

--- a/src/slic3r/GUI/Project.hpp
+++ b/src/slic3r/GUI/Project.hpp
@@ -63,7 +63,6 @@ class ProjectPanel : public wxPanel
 {
 private:
     std::atomic<bool> m_web_init_completed{false};
-    bool       m_reload_already = {false};
 
     std::shared_ptr<std::atomic<bool>> m_reload_cancel_token{std::make_shared<std::atomic<bool>>(false)};
     std::unique_ptr<boost::thread> m_reload_task;

--- a/src/slic3r/GUI/RecenterDialog.hpp
+++ b/src/slic3r/GUI/RecenterDialog.hpp
@@ -10,8 +10,6 @@ namespace Slic3r { namespace GUI {
 class RecenterDialog : public DPIDialog
 {
 private:
-    wxStaticText* m_staticText_hint;
-    wxStaticBitmap* m_bitmap_home;
     ScalableBitmap  m_home_bmp;
     wxString hint1;
     wxString hint2;

--- a/src/slic3r/GUI/SelectMachinePop.hpp
+++ b/src/slic3r/GUI/SelectMachinePop.hpp
@@ -181,8 +181,6 @@ private:
     PinCodePanel*                     m_panel_direct_connection{nullptr};
     wxWindow*                         m_placeholder_panel{nullptr};
     HyperLink*                        m_hyperlink{nullptr}; // ORCA
-    Label*                            m_ping_code_text{nullptr};
-    wxStaticBitmap*                   m_img_ping_code{nullptr};
     wxBoxSizer *                      m_sizer_body{nullptr};
     wxBoxSizer *                      m_sizer_my_devices{nullptr};
     wxBoxSizer *                      m_sizer_other_devices{nullptr};

--- a/src/slic3r/GUI/SendMultiMachinePage.hpp
+++ b/src/slic3r/GUI/SendMultiMachinePage.hpp
@@ -149,7 +149,6 @@ private:
     ScalableBitmap*                     print_time{ nullptr };
     wxStaticBitmap*                     weightimg{ nullptr };
     ScalableBitmap*                     print_weight{ nullptr };
-    wxBoxSizer*                         m_thumbnail_sizer{ nullptr };
     ThumbnailPanel*                     m_thumbnail_panel{nullptr};
     wxPanel*                            m_panel_image{ nullptr };
     wxBoxSizer*                         m_image_sizer{ nullptr };

--- a/src/slic3r/GUI/SendToPrinter.hpp
+++ b/src/slic3r/GUI/SendToPrinter.hpp
@@ -62,7 +62,6 @@ private:
     bool                                m_is_in_sending_mode{ false };
     bool                                m_is_rename_mode{ false };
     bool                                enable_prepare_mode{ true };
-    bool                                m_need_adaptation_screen{ false };
     bool                                m_export_3mf_cancel{ false };
     bool                                m_is_canceled{ false };
     bool                                m_tcp_try_connect{true};
@@ -81,7 +80,6 @@ private:
     wxStaticBitmap*                     m_staticbitmap{ nullptr };
     ThumbnailPanel*                     m_thumbnailPanel{ nullptr };
     ComboBox*                           m_comboBox_printer{ nullptr };
-    ComboBox*                           m_comboBox_bed{ nullptr };
     Button*                             m_rename_button{ nullptr };
     Button*                             m_button_refresh{ nullptr };
     Button*                             m_button_ensure{ nullptr };

--- a/src/slic3r/GUI/SkipPartCanvas.hpp
+++ b/src/slic3r/GUI/SkipPartCanvas.hpp
@@ -87,7 +87,6 @@ private:
     std::unordered_map < uint32_t, std::vector<std::vector<FloatPoint>>> parts_triangles_;
     std::unordered_map < uint32_t, std::vector<std::vector<cv::Point>>> pick_parts_;
     std::unordered_map<uint32_t, PartState> parts_state_;
-    bool gl_inited_{false};
     int zoom_percent_{100};
     wxPoint offset_{0,0};
     wxPoint drag_start_offset_{0,0};

--- a/src/slic3r/GUI/SyncAmsInfoDialog.hpp
+++ b/src/slic3r/GUI/SyncAmsInfoDialog.hpp
@@ -307,8 +307,6 @@ private:
    // wxBoxSizer *    m_plate_combox_sizer          = nullptr;
     wxBoxSizer *    m_mode_combox_sizer           = nullptr;
     //wxStaticText *  m_printer_title                = nullptr;
-    wxStaticText *  m_printer_device_name          = nullptr;
-    wxStaticText *  m_printer_is_map_title         = nullptr;
 
     CapsuleButton *  m_colormap_btn = nullptr;
     CapsuleButton *  m_override_btn = nullptr;
@@ -326,7 +324,6 @@ private:
 
     bool m_check_dirty_fialment  = true;
     bool m_expand_more_settings  = true;
-    bool m_image_is_top          = false;
 
     const int LEFT_THUMBNAIL_SIZE_WIDTH = 100;
     const int RIGHT_THUMBNAIL_SIZE_WIDTH = 300;

--- a/src/slic3r/GUI/Tab.hpp
+++ b/src/slic3r/GUI/Tab.hpp
@@ -626,8 +626,6 @@ private:
 	bool		m_rebuild_kinematics_page = false;
 	void        update_input_shaper_menu(GCodeFlavor flavor);
 
-	ogStaticText*	m_fff_print_host_upload_description_line {nullptr};
-	ogStaticText*	m_sla_print_host_upload_description_line {nullptr};
 
     std::vector<PageShp>			m_pages_fff;
     std::vector<PageShp>			m_pages_sla;

--- a/src/slic3r/GUI/ThermalPreconditioningDialog.hpp
+++ b/src/slic3r/GUI/ThermalPreconditioningDialog.hpp
@@ -31,7 +31,6 @@ private:
     wxStaticText   *m_remaining_time_label;
     wxStaticText   *m_explanation_label;
     wxButton       *m_ok_button;
-    wxStaticBitmap *m_title_bitmap;
 
     DECLARE_EVENT_TABLE()
 };

--- a/src/slic3r/GUI/WebGuideDialog.hpp
+++ b/src/slic3r/GUI/WebGuideDialog.hpp
@@ -112,7 +112,6 @@ private:
     AppConfig m_appconfig_new;
 
     wxWebView *m_browser;
-    wxButton * m_TestBtn;
 
     wxString m_SectionName;
 

--- a/src/slic3r/GUI/WebViewDialog.hpp
+++ b/src/slic3r/GUI/WebViewDialog.hpp
@@ -125,10 +125,6 @@ private:
     wxMenuItem* m_edit_undo;
     wxMenuItem* m_edit_redo;
     wxMenuItem* m_edit_mode;
-    wxMenuItem* m_scroll_line_up;
-    wxMenuItem* m_scroll_line_down;
-    wxMenuItem* m_scroll_page_up;
-    wxMenuItem* m_scroll_page_down;
     wxMenuItem* m_script_string;
     wxMenuItem* m_script_integer;
     wxMenuItem* m_script_double;

--- a/src/slic3r/GUI/Widgets/AMSItem.hpp
+++ b/src/slic3r/GUI/Widgets/AMSItem.hpp
@@ -684,7 +684,6 @@ public:
 
 private:
     int             m_nozzle_num           = {1};
-    AMSRoadShowMode m_single_ext_rode_mode = {AMSRoadShowMode::AMS_ROAD_MODE_FOUR};
     AMSRoadShowMode m_left_rode_mode       = {AMSRoadShowMode::AMS_ROAD_MODE_FOUR};
     AMSRoadShowMode m_right_rode_mode      = {AMSRoadShowMode::AMS_ROAD_MODE_FOUR};
     bool            m_selected             = {false};
@@ -693,7 +692,6 @@ private:
     int             m_right_road_length    = {-1};
     int             m_passroad_width       = {6};
     double          m_radius               = {4};
-    AMSPassRoadType m_pass_road_type       = {AMSPassRoadType::AMS_ROAD_TYPE_NONE};
     AMSPassRoadSTEP m_pass_road_left_step  = {AMSPassRoadSTEP::AMS_ROAD_STEP_NONE};
     AMSPassRoadSTEP m_pass_road_right_step = {AMSPassRoadSTEP::AMS_ROAD_STEP_NONE};
 
@@ -866,11 +864,7 @@ private:
     AMSinfo         m_info;
     wxBoxSizer *    sizer_can = {nullptr};
     wxGridSizer*    sizer_can_extra = { nullptr };
-    wxBoxSizer *    sizer_humidity = { nullptr };
     wxBoxSizer *    sizer_item = { nullptr };
-    wxBoxSizer *    sizer_can_middle = {nullptr};
-    wxBoxSizer *    sizer_can_left = {nullptr};
-    wxBoxSizer *    sizer_can_right = {nullptr};
     AMSExtImage*    m_ext_image = { nullptr };      //the ext image upon the ext ams
     AMSExtText* m_ext_text = { nullptr };       //the ext text upon the ext ams
 };

--- a/src/slic3r/GUI/Widgets/FanControl.hpp
+++ b/src/slic3r/GUI/Widgets/FanControl.hpp
@@ -109,7 +109,6 @@ public:
     void    decrease_fan_speeds();
 private:
     int     m_current_speeds;
-    int     m_target_speed;
     int     m_min_speeds;
     int     m_max_speeds;
     ScalableBitmap   m_bitmap_add;

--- a/src/slic3r/GUI/Widgets/MultiNozzleSync.hpp
+++ b/src/slic3r/GUI/Widgets/MultiNozzleSync.hpp
@@ -204,7 +204,6 @@ private:
     Label* m_caution;
 
     wxTimer* m_refresh_timer {nullptr};
-    size_t m_rack_event_token;
     Button* m_cancel_btn;
     Button* m_confirm_btn;
 };


### PR DESCRIPTION
# Description

`-Wunused-private-field` from #15374, 54 of the 161 warnings, across 31 files.

These are the ones needing no judgment. Each member is declared once and appears nowhere else in `src/`, counting the `.mm` and `.c` sources as well as `.cpp` and `.hpp`, so nothing writes them and nothing reads them. Every removal is a whole line, and no declaration shares a line with another member.

# Screenshots/Recordings/Graphs

No visual change.

## Tests

No new tests. A member nothing refers to cannot change behaviour.

`-Wunused-private-field` goes from 161 to 107, and it is the only category that moved.

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
