### PR TITLE
Add official School House Spools PLA and PETG filament profiles

### DIFF
--- a/resources/profiles/OrcaFilamentLibrary.json
+++ b/resources/profiles/OrcaFilamentLibrary.json
@@ -997,6 +997,14 @@
 			"sub_path": "filament/Polymaker/Polymaker HT-PLA-GF @base.json"
 		},
 		{
+			"name": "School House Spools PLA @base",
+			"sub_path": "filament/SchoolHouseSpools/School House Spools PLA @base.json"
+		},
+		{
+			"name": "School House Spools PETG @base",
+			"sub_path": "filament/SchoolHouseSpools/School House Spools PETG @base.json"
+		},
+		{
 			"name": "SUNLU PLA Marble @base",
 			"sub_path": "filament/SUNLU/SUNLU Marble PLA @base.json"
 		},
@@ -1787,6 +1795,14 @@
 		{
 			"name": "Polymaker HT-PLA-GF @System",
 			"sub_path": "filament/Polymaker/Polymaker HT-PLA-GF @System.json"
+		},
+		{
+			"name": "School House Spools PLA @System",
+			"sub_path": "filament/SchoolHouseSpools/School House Spools PLA @System.json"
+		},
+		{
+			"name": "School House Spools PETG @System",
+			"sub_path": "filament/SchoolHouseSpools/School House Spools PETG @System.json"
 		},
 		{
 			"name": "SUNLU PLA Marble @System",

--- a/resources/profiles/OrcaFilamentLibrary/filament/SchoolHouseSpools/School House Spools PETG @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/SchoolHouseSpools/School House Spools PETG @System.json
@@ -1,0 +1,18 @@
+{
+	"type": "filament",
+	"name": "School House Spools PETG @System",
+	"inherits": "School House Spools PETG @base",
+	"from": "system",
+	"setting_id": "RSu2orfhR8ktT36h",
+	"instantiation": "true",
+	"filament_max_volumetric_speed": [
+		"13"
+	],
+	"filament_long_retractions_when_cut": [
+		"1"
+	],
+	"filament_retraction_distances_when_cut": [
+		"18"
+	],
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/SchoolHouseSpools/School House Spools PETG @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/SchoolHouseSpools/School House Spools PETG @base.json
@@ -1,0 +1,80 @@
+{
+	"type": "filament",
+	"name": "School House Spools PETG @base",
+	"inherits": "fdm_filament_pet",
+	"from": "system",
+	"filament_id": "OGFSHS01",
+	"instantiation": "false",
+	"cool_plate_temp": [
+		"0"
+	],
+	"cool_plate_temp_initial_layer": [
+		"0"
+	],
+	"eng_plate_temp": [
+		"70"
+	],
+	"eng_plate_temp_initial_layer": [
+		"70"
+	],
+	"fan_cooling_layer_time": [
+		"30"
+	],
+	"fan_max_speed": [
+		"40"
+	],
+	"fan_min_speed": [
+		"10"
+	],
+	"filament_cost": [
+		"16.00"
+	],
+	"filament_density": [
+		"1.25"
+	],
+	"filament_flow_ratio": [
+		"0.95"
+	],
+	"filament_max_volumetric_speed": [
+		"8"
+	],
+	"filament_multitool_ramming_flow": [
+		"8"
+	],
+	"filament_vendor": [
+		"School House Spools"
+	],
+	"hot_plate_temp": [
+		"70"
+	],
+	"hot_plate_temp_initial_layer": [
+		"70"
+	],
+	"nozzle_temperature": [
+		"252"
+	],
+	"nozzle_temperature_initial_layer": [
+		"252"
+	],
+	"nozzle_temperature_range_high": [
+		"270"
+	],
+	"nozzle_temperature_range_low": [
+		"230"
+	],
+	"overhang_fan_speed": [
+		"90"
+	],
+	"overhang_fan_threshold": [
+		"10%"
+	],
+	"slow_down_layer_time": [
+		"12"
+	],
+	"textured_plate_temp": [
+		"70"
+	],
+	"textured_plate_temp_initial_layer": [
+		"70"
+	]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/SchoolHouseSpools/School House Spools PLA @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/SchoolHouseSpools/School House Spools PLA @System.json
@@ -1,0 +1,18 @@
+{
+	"type": "filament",
+	"name": "School House Spools PLA @System",
+	"inherits": "School House Spools PLA @base",
+	"from": "system",
+	"setting_id": "3rHJk6SVAvFzyHI0",
+	"instantiation": "true",
+	"filament_max_volumetric_speed": [
+		"21"
+	],
+	"filament_long_retractions_when_cut": [
+		"1"
+	],
+	"filament_retraction_distances_when_cut": [
+		"18"
+	],
+	"compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/SchoolHouseSpools/School House Spools PLA @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/SchoolHouseSpools/School House Spools PLA @base.json
@@ -1,0 +1,35 @@
+{
+	"type": "filament",
+	"name": "School House Spools PLA @base",
+	"inherits": "fdm_filament_pla",
+	"from": "system",
+	"filament_id": "OGFSHS00",
+	"instantiation": "false",
+	"filament_cost": [
+		"17.00"
+	],
+	"filament_density": [
+		"1.26"
+	],
+	"filament_flow_ratio": [
+		"0.98"
+	],
+	"filament_max_volumetric_speed": [
+		"12"
+	],
+	"filament_vendor": [
+		"School House Spools"
+	],
+	"filament_scarf_seam_type": [
+		"none"
+	],
+	"filament_scarf_height": [
+		"10%"
+	],
+	"filament_scarf_gap": [
+		"0%"
+	],
+	"filament_scarf_length": [
+		"10"
+	]
+}


### PR DESCRIPTION
# Description

Adds School House Spools PLA and PETG to the global Orca Filament Library. Both are standard PLA and PETG, so Bambu PLA Basic / PETG Basic served as the baseline for tuning values. The one intentional difference is PETG nozzle temperature (252°C vs Bambu's inherited 255°C default), based on our own testing.

# Screenshots/Recordings/Graphs

N/A

## Tests

Ran scripts/assign_vendor_setting_ids.py to generate setting_id values, and scripts/orca_extra_profile_check.py --vendor="OrcaFilamentLibrary" --check-filaments --check-materials to validate. No new errors or warnings introduced (pre-existing unrelated errors in other vendors' profiles were not touched).

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)