### PR TITLE
Fix crash on startup if mixed filament has invalid component

### DIFF
--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -3988,16 +3988,16 @@ void Sidebar::update_mixed_filament_list()
     p->m_panel_mixed_warning->Show(false);
 
     // Show/dismiss 3D canvas notification for broken mixed filaments
-    if (has_mixed && !broken_set.empty()) {
-        auto* notify = wxGetApp().plater()->get_notification_manager();
-        if (notify)
+    auto*       notify        = plater->get_notification_manager();
+    GLCanvas3D* view3d_canvas = plater->get_view3D_canvas3D();
+    if(view3d_canvas->is_initialized() && notify){
+        if (has_mixed && !broken_set.empty()) {
             notify->push_notification(NotificationType::BBLMixedFilamentBroken,
                 NotificationManager::NotificationLevel::ErrorNotificationLevel,
                 _u8L("Mixed filament has invalid or mismatched components. Please re-edit affected entries."));
-    } else {
-        auto* notify = wxGetApp().plater()->get_notification_manager();
-        if (notify)
+        } else {
             notify->close_notification_of_type(NotificationType::BBLMixedFilamentBroken);
+        }
     }
 
     if (has_mixed) {

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -3990,7 +3990,7 @@ void Sidebar::update_mixed_filament_list()
     // Show/dismiss 3D canvas notification for broken mixed filaments
     auto*       notify        = plater->get_notification_manager();
     GLCanvas3D* view3d_canvas = plater->get_view3D_canvas3D();
-    if(view3d_canvas->is_initialized() && notify){
+    if(view3d_canvas && view3d_canvas->is_initialized() && notify){
         if (has_mixed && !broken_set.empty()) {
             notify->push_notification(NotificationType::BBLMixedFilamentBroken,
                 NotificationManager::NotificationLevel::ErrorNotificationLevel,


### PR DESCRIPTION
crash causes by sidebar drawn before canvas and notification sent to empty canvas
notification appears on launch as expected

how to replicate
• add mixed filament
• remove filament that included on mixed filament from filaments list
• check is mixed filament has any missing components like this
<img width="435" height="88" alt="Screenshot-20260829165346" src="https://github.com/user-attachments/assets/d2429fe3-b5a2-47ac-8b4b-e1456db3900f" />
• restart orca

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
