### PR TITLE
fix: clear 12 warning sites that only appear away from Windows

### DIFF
--- a/src/slic3r/GUI/CreatePresetsDialog.cpp
+++ b/src/slic3r/GUI/CreatePresetsDialog.cpp
@@ -599,7 +599,9 @@ static char* read_json_file(const std::string &preset_path)
         return NULL;
     }
 
-    fread(json_contents, 1, file_size, json_file);
+    const size_t read_bytes = fread(json_contents, 1, file_size, json_file);
+    if (read_bytes != static_cast<size_t>(file_size))
+        BOOST_LOG_TRIVIAL(error) << "Read " << read_bytes << " of " << file_size << " bytes from the JSON file";
     fclose(json_file);
 
     return json_contents;

--- a/src/slic3r/GUI/Field.cpp
+++ b/src/slic3r/GUI/Field.cpp
@@ -941,7 +941,11 @@ void TextCtrl::BUILD() {
 	temp->SetToolTip(get_tooltip_text(text_value));
 
     if (!m_opt.multiline) {
-        text_ctrl->Bind(wxEVT_TEXT_ENTER, ([this, temp](wxEvent &e)
+        text_ctrl->Bind(wxEVT_TEXT_ENTER, ([
+#if !defined(__WXGTK__)
+            temp,
+#endif // __WXGTK__
+            this](wxEvent &e)
         {
 #if !defined(__WXGTK__)
             e.Skip();
@@ -973,7 +977,11 @@ void TextCtrl::BUILD() {
 		temp->GetToolTip()->Enable(flag);
 	}), text_ctrl->GetId());
 
-	temp->Bind(wxEVT_KILL_FOCUS, ([this, temp](wxEvent &e)
+	temp->Bind(wxEVT_KILL_FOCUS, ([
+#if !defined(__WXGTK__)
+		temp,
+#endif // __WXGTK__
+		this](wxEvent &e)
 	{
 		e.Skip();
 #if !defined(__WXGTK__)
@@ -2597,7 +2605,11 @@ void ColourPicker::BUILD()
 	// 	// recast as a wxWindow to fit the calling convention
 	window = dynamic_cast<wxWindow*>(temp);
 
-	temp->Bind(wxEVT_COLOURPICKER_CHANGED, ([this,temp](wxCommandEvent e) {
+	temp->Bind(wxEVT_COLOURPICKER_CHANGED, ([
+        #ifdef __WXMSW__
+            temp,
+        #endif
+        this](wxCommandEvent e) {
         #ifdef __WXMSW__
             draw_bmp_btn(temp, temp->GetColour());
         #endif

--- a/src/slic3r/GUI/GUI_ObjectLayers.cpp
+++ b/src/slic3r/GUI/GUI_ObjectLayers.cpp
@@ -48,7 +48,7 @@ void ObjectLayers::select_editor(LayerRangeEditor* editor, const bool is_last_ed
      * And as a result we couldn't edit this control.
      * */
 #ifdef __WXOSX__
-        wxTheApp->CallAfter([editor]() {
+        wxTheApp->CallAfter([]() {
 #endif
         //editor->SetFocus();
         //editor->SelectAll();

--- a/src/slic3r/GUI/Jobs/PlaterWorker.hpp
+++ b/src/slic3r/GUI/Jobs/PlaterWorker.hpp
@@ -79,9 +79,12 @@ class PlaterWorker: public Worker {
             steady_clock::time_point finalize_end = steady_clock::now();
             long long finalize_duration = duration_cast<milliseconds>(finalize_end - finalize_start).count();
 
+            // Bound first so typeid's operand is not a call. typeid evaluates it for a
+            // polymorphic type, which clang reports as -Wpotentially-evaluated-expression.
+            const Job &job = *m_job;
             BOOST_LOG_TRIVIAL(info)
                 << std::fixed // do not use scientific notations
-                << "Job '" << typeid(*m_job).name() << "' "
+                << "Job '" << typeid(job).name() << "' "
                 << "spend " << m_process_duration + finalize_duration << "ms "
                 << "(process " << m_process_duration << "ms + finalize " << finalize_duration << "ms)";
 

--- a/src/slic3r/GUI/MainFrame.cpp
+++ b/src/slic3r/GUI/MainFrame.cpp
@@ -3068,10 +3068,10 @@ void MainFrame::init_menubar_as_editor()
             "", nullptr, [this](){return can_clone(); }, this);
         editMenu->AppendSeparator();
         append_menu_item(editMenu, wxID_ANY, _L("Duplicate Current Plate"),
-            _L("Duplicate the current plate"),[this, handle_key_event](wxCommandEvent&) {
+            _L("Duplicate the current plate"),[this](wxCommandEvent&) {
                 m_plater->duplicate_plate();
             },
-            "", nullptr, [this](){return true;}, this);
+            "", nullptr, [](){return true;}, this);
         editMenu->AppendSeparator();
 
 #endif
@@ -3338,11 +3338,11 @@ void MainFrame::init_menubar_as_editor()
     //parent_menu->Insert(0, about_item);
     append_menu_item(
         parent_menu, wxID_ANY, _L(about_title), "",
-        [this](wxCommandEvent &) { Slic3r::GUI::about();},
+        [](wxCommandEvent &) { Slic3r::GUI::about();},
         "", nullptr, []() { return true; }, this, 0);
     append_menu_item(
         parent_menu, wxID_ANY, _L("Preferences") + "\t" + ctrl + ",", "",
-        [this](wxCommandEvent &) {
+        [](wxCommandEvent &) {
             wxGetApp().open_preferences();
         },
         "", nullptr, []() { return true; }, this, 1);
@@ -3530,13 +3530,13 @@ void MainFrame::init_menubar_as_editor()
                     into_u8(_L("Syncing presets from cloud\u2026")));
             wxGetApp().restart_sync_user_preset();
         }, "", nullptr,
-        [this]() {
+        []() {
             return wxGetApp().is_user_login() && !wxGetApp().app_config->get_stealth_mode();
         }, this);
 
     fileMenu->AppendSeparator();
     append_menu_item(
-        fileMenu, wxID_ANY, _L("Plugins"), "", [this](wxCommandEvent&) { wxGetApp().open_plugins_dialog(); }, "", nullptr,
+        fileMenu, wxID_ANY, _L("Plugins"), "", [](wxCommandEvent&) { wxGetApp().open_plugins_dialog(); }, "", nullptr,
         []() { return true; }, this);
 
     fileMenu->AppendSeparator();
@@ -3640,7 +3640,7 @@ void MainFrame::init_menubar_as_editor()
         [this]() {return m_plater->is_view3D_shown();; }, this);
     // help
     append_menu_item(calib_menu, wxID_ANY, _L("Calibration Guide"), _L("Calibration Guide"),
-        [this](wxCommandEvent&) { wxLaunchDefaultBrowser("https://www.orcaslicer.com/wiki/calibration_guide", wxBROWSER_NEW_WINDOW); }, "", nullptr,
+        [](wxCommandEvent&) { wxLaunchDefaultBrowser("https://www.orcaslicer.com/wiki/calibration_guide", wxBROWSER_NEW_WINDOW); }, "", nullptr,
         [this]() {return m_plater->is_view3D_shown();; }, this);
 
     m_menubar->Append(calib_menu,wxString::Format("&%s", _L("Calibration")));


### PR DESCRIPTION
# Description

Twelve warning sites that only appear away from Windows, so the clang-cl inventory in #15374 does not count any of them. Found by building the same tree on Linux, macOS and Flatpak.

Nine are unused lambda captures in code guarded by a platform `#if`. `MainFrame.cpp` has seven inside `#ifdef __APPLE__` or the `#else` of `#ifndef __APPLE__`, and `GUI_ObjectLayers.cpp` one more, all in lambdas that no other platform compiles. `Field.cpp` has three where the lambda is compiled everywhere but the capture is read only under `!defined(__WXGTK__)` or `__WXMSW__`, so the capture is now under the same condition as its use. The event object cannot be used instead in the first of those, because that handler is bound to the inner text control rather than to the captured control.

`PlaterWorker.hpp` takes the type name for a log line with `typeid(*m_job)`, where `m_job` is a `shared_ptr`. `typeid` evaluates its operand for a polymorphic type, so the call happens and clang reports it. Binding the reference first takes the call out of the operand, and the logged name is unchanged.

`CreatePresetsDialog.cpp` ignored the result of `fread`, which glibc declares `warn_unused_result`, so only the Flatpak build reports it. A short read means the JSON that follows is truncated, so the count is checked and logged. The function still returns what it read.

# Screenshots/Recordings/Graphs

No visual change.

## Tests

No new tests. Removing an unused capture changes no behaviour, and the `typeid` and `fread` changes keep their existing results.

Built on Windows, Linux, macOS and Flatpak, with unit tests passing on the three that run them.

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
