### PR TITLE
fix(plugin): Strip trailing carriage return (Windows line endings) on plugin descriptor loading

### DIFF
--- a/src/slic3r/plugin/PluginFsUtils.cpp
+++ b/src/slic3r/plugin/PluginFsUtils.cpp
@@ -601,6 +601,10 @@ void parse_metadata_rfc822(const std::string& content,
             break;
         }
 
+        // Strip trailing carriage return (Windows line endings).
+        if (line.back() == '\r')
+            line.pop_back();
+
         // Continuation line.
         if (line[0] == ' ' || line[0] == '\t') {
             if (!current_value.empty())
@@ -1042,6 +1046,7 @@ bool read_wheel_plugin_metadata(const boost::filesystem::path& whl_path, PluginD
         std::istringstream wstream(wheel_content);
         std::string wline;
         while (std::getline(wstream, wline)) {
+            // Strip trailing carriage return (Windows line endings).
             while (!wline.empty() && (wline.back() == '\r' || wline.back() == '\n'))
                 wline.pop_back();
             if (wline.rfind("Tag:", 0) == 0) {
@@ -1109,6 +1114,7 @@ bool read_wheel_plugin_metadata(const boost::filesystem::path& whl_path, PluginD
         std::string tl_line;
         std::vector<std::string> top_levels;
         while (std::getline(tl_stream, tl_line)) {
+            // Strip trailing carriage return (Windows line endings)
             while (!tl_line.empty() && (tl_line.back() == '\r' || tl_line.back() == '\n'))
                 tl_line.pop_back();
             if (!tl_line.empty())


### PR DESCRIPTION
# Description

Sometimes when you try to load a module from a `.whl` bundle (Built specifically for Windows), Windows adds a `\r` to the end of the line in its `METADATA` file. This causes an error when the `PluginInterpreter` tries to create the plugin staging directory (during the zip extraction process).

## Tests

Download a wheel plugin built by cibuildwheel (for example: https://github.com/redfox-mx/libbgcode/actions/runs/33243808780/artifacts/9712214084 and the artifact generated through https://github.com/redfox-mx/libbgcode/actions/runs/33243808780). Then, load the generated file as a plugin.

A work-in-progress plugin can be downloaded from the artifacts generated here: https://github.com/redfox-mx/libbgcode/actions/runs/33243808780

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
