### PR TITLE
fix: fix no sparse layers during a toolchange

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -1021,7 +1021,8 @@ static std::vector<Vec2d> get_path_of_change_filament(const Print& print)
         double current_z = gcodegen.writer().get_position().z();
         if (z == -1.) // in case no specific z was provided, print at current_z pos
             z = current_z;
-        if (!is_approx(z, current_z)) {
+        const bool will_go_down = !is_approx(z, current_z);
+        if (will_go_down) {
             gcode += gcodegen.writer().retract();
             gcode += gcodegen.writer().travel_to_z(z, "Travel down to the last wipe tower layer.");
             gcode += gcodegen.writer().unretract();
@@ -1094,6 +1095,22 @@ static std::vector<Vec2d> get_path_of_change_filament(const Print& print)
         }
 
         end_filament_gcode_str = toolchange_retract_str + object_end_label_temp + end_filament_gcode_str;
+
+        // Orca: the wipe tower can currently be printing below the topmost printed layer
+        // (e.g. wipe_tower_no_sparse_layers keeps the tower shorter than the tallest object).
+        // change_filament_gcode is free to perform arbitrary XY travel (parking, homing,
+        // docking a tool, etc.), so restore Z to the real layer height before running it,
+        // otherwise that travel can collide with already-printed parts taller than the tower.
+        // toolchange_retract_str above already keeps us retracted for the whole toolchange, so
+        // just move Z; deretraction_str (further below) brings Z back down to resume the tower.
+        std::string restore_layer_z_str;
+        if (will_go_down) {
+            restore_layer_z_str += gcodegen.writer().travel_to_z(current_z, "Restore layer Z before toolchange to avoid collision with printed parts", true);
+            Vec3d position{gcodegen.writer().get_position()};
+            position.z() = current_z;
+            gcodegen.writer().set_position(position);
+            check_add_eol(restore_layer_z_str);
+        }
 
         std::string wipe_next_start_point_str;
         bool        need_travel_after_change_filament_gcode = false; // travel need be after the filament changed to get the correct "m_curr_extruder_id"
@@ -1310,6 +1327,17 @@ static std::vector<Vec2d> get_path_of_change_filament(const Print& print)
             need_travel_after_change_filament_gcode = true;
         }
 
+        // Orca: mirror of restore_layer_z_str above - bring Z back down to the wipe tower layer
+        // once change_filament_gcode has finished, so the rest of the tower prints at the right height.
+        std::string deretraction_str;
+        if (will_go_down) {
+            deretraction_str += gcodegen.writer().travel_to_z(z, "Restore wipe tower layer Z after toolchange", true);
+            Vec3d position{gcodegen.writer().get_position()};
+            position.z() = z;
+            gcodegen.writer().set_position(position);
+            check_add_eol(deretraction_str);
+        }
+
         std::string toolchange_command;
         if (tcr.priming || (new_filament_id >= 0 && gcodegen.writer().need_toolchange(new_filament_id)))
             // Orca: null-safe, layer-aware nozzle lookup — group_result may be null on
@@ -1424,7 +1452,9 @@ static std::vector<Vec2d> get_path_of_change_filament(const Print& print)
         // Insert the end filament, toolchange, and start filament gcode into the generated gcode.
         DynamicConfig config;
         config.set_key_value("filament_end_gcode", new ConfigOptionString(end_filament_gcode_str));
+        config.set_key_value("restore_layer_z_before_toolchange", new ConfigOptionString(restore_layer_z_str));
         config.set_key_value("change_filament_gcode", new ConfigOptionString(toolchange_gcode_str));
+        config.set_key_value("deretraction_from_wipe_tower_generator", new ConfigOptionString(deretraction_str));
         config.set_key_value("filament_start_gcode", new ConfigOptionString(start_filament_gcode_str));
         std::string tcr_gcode, tcr_escaped_gcode = gcodegen.placeholder_parser_process("tcr_rotated_gcode", tcr_rotated_gcode, new_filament_id, &config);
         unescape_string_cstyle(tcr_escaped_gcode, tcr_gcode);
@@ -1556,6 +1586,7 @@ static std::vector<Vec2d> get_path_of_change_filament(const Print& print)
 
         std::string toolchange_gcode_str;
         std::string deretraction_str;
+        std::string restore_layer_z_str;
         int toolchange_temp_override = -1;
         int interface_temp = -1;
         if (tcr.priming || (new_extruder_id >= 0 && needs_toolchange)) {
@@ -1566,6 +1597,18 @@ static std::vector<Vec2d> get_path_of_change_filament(const Print& print)
                 if (interface_temp == -1)
                     interface_temp = gcodegen.config().nozzle_temperature_range_high.get_at(new_extruder_id);
                 toolchange_temp_override = interface_temp;
+            }
+            // Orca: the wipe tower can currently be printing below the topmost printed layer
+            // (e.g. wipe_tower_no_sparse_layers keeps the tower shorter than the tallest object).
+            // change_filament_gcode is free to perform arbitrary XY travel (parking, homing,
+            // docking a tool, etc.), so restore Z to the real layer height before running it,
+            // otherwise that travel can collide with already-printed parts taller than the tower.
+            // deretraction_str (below) brings Z back down to resume printing the wipe tower.
+            if (will_go_down && gcodegen.config().enable_prime_tower) {
+                restore_layer_z_str += gcodegen.writer().retract();
+                restore_layer_z_str += gcodegen.writer().travel_to_z(current_z, "Restore layer Z before toolchange to avoid collision with printed parts");
+                restore_layer_z_str += gcodegen.writer().unretract();
+                check_add_eol(restore_layer_z_str);
             }
             toolchange_gcode_str = gcodegen.set_extruder(new_extruder_id, tcr.print_z, false, toolchange_temp_override,
                                                          WipeTower2::wait_for_temp_enabled(gcodegen.m_config)); // TODO: toolchange_z vs print_z
@@ -1753,6 +1796,7 @@ static std::vector<Vec2d> get_path_of_change_filament(const Print& print)
         DynamicConfig config;
         config.set_key_value("change_filament_gcode", new ConfigOptionString(toolchange_gcode_str));
         config.set_key_value("deretraction_from_wipe_tower_generator", new ConfigOptionString(deretraction_str));
+        config.set_key_value("restore_layer_z_before_toolchange", new ConfigOptionString(restore_layer_z_str));
         config.set_key_value("layer_num", new ConfigOptionInt(gcodegen.m_layer_index));
         config.set_key_value("layer_z", new ConfigOptionFloat(tcr.print_z));
         config.set_key_value("toolchange_z", new ConfigOptionFloat(z));

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -2048,6 +2048,22 @@ static std::vector<Vec2d> get_path_of_change_filament(const Print& print)
             if (std::abs(gcodegen.writer().get_position().z() - m_last_wipe_tower_print_z) > EPSILON)
                 gcode += gcodegen.change_layer(m_last_wipe_tower_print_z);
             gcode += append_tcr2(gcodegen, m_final_purge, -1, m_last_wipe_tower_print_z);
+
+            // Orca: restore Z back to the real topmost layer height after the purge, mirroring the
+            // per-toolchange restore in get_path_of_change_filament() (restore_layer_z_str /
+            // deretraction_str). Without this, the physical toolhead is left at the tower's
+            // (possibly much lower) height for the rest of the print. machine_end_gcode only lifts Z
+            // for print_sequence == "by object" - the "by layer" case has no fallback move - so any
+            // end-of-print parking/bed-lowering that assumes the toolhead is near the print's top
+            // computes its target from this wrong, too-low Z instead.
+            if (std::abs(gcodegen.writer().get_position().z() - m_final_purge.print_z) > EPSILON) {
+                std::string restore_z_str = gcodegen.writer().travel_to_z(m_final_purge.print_z, "Restore layer Z after final purge", true);
+                Vec3d position{gcodegen.writer().get_position()};
+                position.z() = m_final_purge.print_z;
+                gcodegen.writer().set_position(position);
+                check_add_eol(restore_z_str);
+                gcode += restore_z_str;
+            }
         }
 
         return gcode;

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -1928,8 +1928,15 @@ static std::vector<Vec2d> get_path_of_change_filament(const Print& print)
         std::string gcode;
         if (gcodegen.wipe_tower_type() == WipeTowerType::Type2) {
             for (const WipeTower::ToolChangeResult &tcr : m_priming) {
-                if (!tcr.extrusions.empty())
+                if (!tcr.extrusions.empty()) {
                     gcode += append_tcr2(gcodegen, tcr, tcr.new_tool);
+                    // Orca: priming is the tower's first real deposit, so keep finalize()'s Z
+                    // target (m_last_wipe_tower_print_z) in sync with it even if no later
+                    // toolchange ever updates it (e.g. a priming-only single-filament print) -
+                    // otherwise finalize() falls back to its z_offset default instead of the
+                    // tower's actual printed height.
+                    m_last_wipe_tower_print_z = tcr.print_z;
+                }
             }
         }
         return gcode;
@@ -2032,9 +2039,15 @@ static std::vector<Vec2d> get_path_of_change_filament(const Print& print)
     {
         std::string gcode;
         if (gcodegen.wipe_tower_type() == WipeTowerType::Type2 && !m_final_purge.gcode.empty()) {
-            if (std::abs(gcodegen.writer().get_position().z() - m_final_purge.print_z) > EPSILON)
-                gcode += gcodegen.change_layer(m_final_purge.print_z);
-            gcode += append_tcr2(gcodegen, m_final_purge, -1);
+            // Orca: purge at the wipe tower's actual accumulated height (m_last_wipe_tower_print_z),
+            // not m_final_purge.print_z. WipeTower2::set_layer() is called with the real current
+            // layer Z every layer regardless of wipe_tower_no_sparse_layers, so m_final_purge.print_z
+            // (== m_z_pos) always tracks the topmost real layer height, while the tower's physical
+            // top surface can be much lower. Purging at the wrong (real-layer) Z prints this final
+            // pass in mid-air, disconnected from the printed tower.
+            if (std::abs(gcodegen.writer().get_position().z() - m_last_wipe_tower_print_z) > EPSILON)
+                gcode += gcodegen.change_layer(m_last_wipe_tower_print_z);
+            gcode += append_tcr2(gcodegen, m_final_purge, -1, m_last_wipe_tower_print_z);
         }
 
         return gcode;

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -1928,15 +1928,8 @@ static std::vector<Vec2d> get_path_of_change_filament(const Print& print)
         std::string gcode;
         if (gcodegen.wipe_tower_type() == WipeTowerType::Type2) {
             for (const WipeTower::ToolChangeResult &tcr : m_priming) {
-                if (!tcr.extrusions.empty()) {
+                if (!tcr.extrusions.empty())
                     gcode += append_tcr2(gcodegen, tcr, tcr.new_tool);
-                    // Orca: priming is the tower's first real deposit, so keep finalize()'s Z
-                    // target (m_last_wipe_tower_print_z) in sync with it even if no later
-                    // toolchange ever updates it (e.g. a priming-only single-filament print) -
-                    // otherwise finalize() falls back to its z_offset default instead of the
-                    // tower's actual printed height.
-                    m_last_wipe_tower_print_z = tcr.print_z;
-                }
             }
         }
         return gcode;
@@ -2039,15 +2032,9 @@ static std::vector<Vec2d> get_path_of_change_filament(const Print& print)
     {
         std::string gcode;
         if (gcodegen.wipe_tower_type() == WipeTowerType::Type2 && !m_final_purge.gcode.empty()) {
-            // Orca: purge at the wipe tower's actual accumulated height (m_last_wipe_tower_print_z),
-            // not m_final_purge.print_z. WipeTower2::set_layer() is called with the real current
-            // layer Z every layer regardless of wipe_tower_no_sparse_layers, so m_final_purge.print_z
-            // (== m_z_pos) always tracks the topmost real layer height, while the tower's physical
-            // top surface can be much lower. Purging at the wrong (real-layer) Z prints this final
-            // pass in mid-air, disconnected from the printed tower.
-            if (std::abs(gcodegen.writer().get_position().z() - m_last_wipe_tower_print_z) > EPSILON)
-                gcode += gcodegen.change_layer(m_last_wipe_tower_print_z);
-            gcode += append_tcr2(gcodegen, m_final_purge, -1, m_last_wipe_tower_print_z);
+            if (std::abs(gcodegen.writer().get_position().z() - m_final_purge.print_z) > EPSILON)
+                gcode += gcodegen.change_layer(m_final_purge.print_z);
+            gcode += append_tcr2(gcodegen, m_final_purge, -1);
         }
 
         return gcode;

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -2048,22 +2048,6 @@ static std::vector<Vec2d> get_path_of_change_filament(const Print& print)
             if (std::abs(gcodegen.writer().get_position().z() - m_last_wipe_tower_print_z) > EPSILON)
                 gcode += gcodegen.change_layer(m_last_wipe_tower_print_z);
             gcode += append_tcr2(gcodegen, m_final_purge, -1, m_last_wipe_tower_print_z);
-
-            // Orca: restore Z back to the real topmost layer height after the purge, mirroring the
-            // per-toolchange restore in get_path_of_change_filament() (restore_layer_z_str /
-            // deretraction_str). Without this, the physical toolhead is left at the tower's
-            // (possibly much lower) height for the rest of the print. machine_end_gcode only lifts Z
-            // for print_sequence == "by object" - the "by layer" case has no fallback move - so any
-            // end-of-print parking/bed-lowering that assumes the toolhead is near the print's top
-            // computes its target from this wrong, too-low Z instead.
-            if (std::abs(gcodegen.writer().get_position().z() - m_final_purge.print_z) > EPSILON) {
-                std::string restore_z_str = gcodegen.writer().travel_to_z(m_final_purge.print_z, "Restore layer Z after final purge", true);
-                Vec3d position{gcodegen.writer().get_position()};
-                position.z() = m_final_purge.print_z;
-                gcodegen.writer().set_position(position);
-                check_add_eol(restore_z_str);
-                gcode += restore_z_str;
-            }
         }
 
         return gcode;

--- a/src/libslic3r/GCode/WipeTower.cpp
+++ b/src/libslic3r/GCode/WipeTower.cpp
@@ -2520,7 +2520,15 @@ void WipeTower::toolchange_Change(
     // This is where we want to place the custom gcodes. We will use placeholders for this.
     // These will be substituted by the actual gcodes when the gcode is generated.
     writer.append("[filament_end_gcode]\n");
+    // Orca: restore Z to the real topmost printed layer before running change_filament_gcode.
+    // The wipe tower can be printing below that height (e.g. wipe_tower_no_sparse_layers), and
+    // change_filament_gcode is free to travel anywhere on the bed, so it must not run while the
+    // toolhead sits lower than already-printed parts. See append_tcr() in GCode.cpp.
+    writer.append("[restore_layer_z_before_toolchange]\n");
     writer.append("[change_filament_gcode]\n");
+    // Orca: bring Z back down to the wipe tower layer once change_filament_gcode has finished,
+    // so the rest of the tower (filament_start_gcode, wipe, ...) prints at the right height.
+    writer.append("[deretraction_from_wipe_tower_generator]\n");
 
     // BBS: do travel in GCode::append_tcr() for lazy_lift
 #if 0

--- a/src/libslic3r/GCode/WipeTower2.cpp
+++ b/src/libslic3r/GCode/WipeTower2.cpp
@@ -1701,6 +1701,11 @@ void WipeTower2::toolchange_Change(
     // This is where we want to place the custom gcodes. We will use placeholders for this.
     // These will be substituted by the actual gcodes when the gcode is generated.
     //writer.append("[end_filament_gcode]\n");
+    // Orca: restore Z to the real topmost printed layer before running change_filament_gcode.
+    // The wipe tower can be printing below that height (e.g. wipe_tower_no_sparse_layers), and
+    // change_filament_gcode is free to travel anywhere on the bed, so it must not run while the
+    // toolhead sits lower than already-printed parts. See append_tcr2() in GCode.cpp.
+    writer.append("[restore_layer_z_before_toolchange]\n");
     writer.append("[change_filament_gcode]\n");
 
     if (m_is_mk4mmu3)


### PR DESCRIPTION
Fixes [#11703](https://github.com/OrcaSlicer/OrcaSlicer/issues/11703).

With **No sparse layers** enabled, the wipe tower can be printed several layers below the tallest object on the plate. `change_filament_gcode` (parking, homing, tool docking, etc.) ran at the wipe tower's lower Z instead of the real layer Z, so the arbitrary XY travel it performs could sweep the toolhead/gantry through already-printed parts taller than the tower at that point — on a multi-toolhead printer this could shift or unhook parts from the bed. Z is now restored to the real layer height before `change_filament_gcode` runs, and brought back down to the tower's height afterward to resume printing it.

No breaking changes; behavior is unchanged when **No sparse layers** is disabled.

# Screenshots/Recordings/Graphs

N/A — G-code timing/positioning fix, no UI changes.

## Tests

- `fff_print_tests` suite: passing after the change.
- Manually verified against a real sliced multi-toolhead, multi-filament print: toolchange travel now happens at the real layer Z (not the tower's lower Z) before descending onto the tower.

Ready-to-test build with all fixes already included (v2.4.2) is available in this fork's Releases: https://github.com/alternativniy/OrcaSlicer-U1-Sync/releases

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)