### PR TITLE
feature: add collision detection and a visible warning area for No sparse layers

### DIFF
--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -957,7 +957,7 @@ StringObjectException Print::sequential_print_clearance_valid(const Print &print
 }
 
 //BBS
-static StringObjectException layered_print_cleareance_valid(const Print &print, StringObjectException *warning)
+static StringObjectException layered_print_cleareance_valid(const Print &print, StringObjectException *warning, Polygons *polygons = nullptr)
 {
     std::vector<const PrintInstance*> print_instances_ordered = sort_object_instances_by_model_order(print, true);
     if (print_instances_ordered.size() < 1)
@@ -977,6 +977,8 @@ static StringObjectException layered_print_cleareance_valid(const Print &print, 
     }
 
     Polygons convex_hulls_other;
+    // Orca: per-instance Y-range + height, used below for the wipe tower gantry-rod clearance check
+    std::vector<std::pair<BoundingBox, double>> instance_bboxes_and_heights;
     // Orca: check convex hull intersection for each instance individually
     for (auto& inst : print_instances_ordered) {
         Polygons current_instance_hulls;
@@ -1004,6 +1006,9 @@ static StringObjectException layered_print_cleareance_valid(const Print &print, 
             }
             current_instance_hulls.emplace_back(volume_hull);
         }
+
+        if (!current_instance_hulls.empty())
+            instance_bboxes_and_heights.emplace_back(get_extents(current_instance_hulls), inst->print_object->height());
 
         if (!intersection(convex_hulls_other, current_instance_hulls).empty()) {
             if (warning) {
@@ -1064,6 +1069,75 @@ static StringObjectException layered_print_cleareance_valid(const Print &print, 
     if (!intersection(convex_hulls_other, convex_hulls_temp).empty()) {
         if (warning) {
             warning->string += L("Prime Tower") + L(" is too close to others, and collisions may be caused.\n");
+        }
+    }
+    // Orca: also flag when an object sits within the toolhead/gantry clearance radius of the wipe
+    // tower without directly overlapping it. The wipe tower can be printed several layers below the
+    // tallest object (e.g. "no sparse layers"), so a toolchange can sweep the toolhead past a taller
+    // neighbour at a much lower Z than that neighbour's height. This is only a coarse, height-agnostic
+    // heuristic reusing the extruder clearance radius already used for object-to-object checks above -
+    // it can both miss real risks and flag safe layouts, and does not replace verifying actual
+    // clearance for your printer and toolchange gcode. Treated as a hard error (like the sequential
+    // by-object collision check) rather than a warning, since we can now actually detect it.
+    // Gated on wipe_tower_no_sparse_layers: without it the tower always prints at the current
+    // layer's real Z (see WipeTowerIntegration::tool_change() in GCode.cpp), so there is no Z
+    // mismatch and thus no risk from this specific mechanism.
+    else if (print.config().wipe_tower_no_sparse_layers.value) {
+        Polygons convex_hulls_temp_inflated;
+        for (const Polygon &poly : convex_hulls_temp)
+            append(convex_hulls_temp_inflated, offset(poly, scale_(print.config().extruder_clearance_radius.value), jtRound, scale_(0.1)));
+        if (!intersection(convex_hulls_other, convex_hulls_temp_inflated).empty()) {
+            if (polygons)
+                append(*polygons, convex_hulls_temp_inflated);
+            return {L("Prime Tower") + L(" is close to other objects - make sure there is enough clearance "
+                                          "for the toolhead/gantry during a toolchange, or collisions may be caused.\n")};
+        }
+    }
+    // Orca: also flag when an object shares the wipe tower's Y-band and is taller than the gantry
+    // rod clearance height. On typical Cartesian/CoreXY kinematics the X-axis gantry beam spans the
+    // full bed width and only moves in Y, so reaching the tower's Y coordinate sweeps the beam across
+    // that whole row regardless of X distance - a tall object anywhere in that row can be hit even if
+    // it is nowhere near the tower's XY footprint. Mirrors the same Y-band/height logic already used
+    // for object-to-object ordering in sequential_print_clearance_valid() above. Same coarse-heuristic
+    // caveats as the radius check above, and same wipe_tower_no_sparse_layers gating rationale.
+    if (print.config().wipe_tower_no_sparse_layers.value && !convex_hulls_temp.empty()) {
+        const BoundingBox wipe_tower_bbox = get_extents(convex_hulls_temp);
+        // Orca: NOT extruder_clearance_radius here - that models the toolhead/fan-shroud XY
+        // footprint, which is irrelevant to whether the object's Y-span overlaps the row the
+        // gantry beam occupies. Shrinking by half of it (as the by-object rod check above does)
+        // silently drops any object narrower in Y than the radius - e.g. a 72.5mm clearance radius
+        // (real Snapmaker U1 default) would erase a normal ~40mm-deep object entirely. Use only the
+        // skirt offset as a small tolerance for edge-touching bboxes.
+        auto [object_skirt_offset, _2] = print.object_skirt_offset();
+        const coord_t shrink = scale_(object_skirt_offset);
+        const coord_t hc2    = scale_(print.config().extruder_clearance_height_to_rod.value);
+        for (const auto &[bbox, height] : instance_bboxes_and_heights) {
+            if (height <= hc2)
+                continue;
+            const coord_t inst_min_y = bbox.min.y() + shrink;
+            const coord_t inst_max_y = bbox.max.y() - shrink;
+            if (inst_min_y > inst_max_y)
+                continue;
+            const coord_t inter_min = std::max(wipe_tower_bbox.min.y(), inst_min_y);
+            const coord_t inter_max = std::min(wipe_tower_bbox.max.y(), inst_max_y);
+            if (inter_max > inter_min) {
+                if (polygons) {
+                    // Orca: visualize the whole swept row (full bed width at the tower's Y-range),
+                    // not just the tower's small footprint - that's what's actually at risk here.
+                    const Points bed_shape = get_bed_shape(print.config());
+                    const BoundingBox bed_bbox(bed_shape);
+                    const coord_t bed_min_x = bed_bbox.min.x() + scale_(plate_origin(0));
+                    const coord_t bed_max_x = bed_bbox.max.x() + scale_(plate_origin(0));
+                    Polygon danger_row;
+                    danger_row.points.emplace_back(bed_min_x, wipe_tower_bbox.min.y());
+                    danger_row.points.emplace_back(bed_max_x, wipe_tower_bbox.min.y());
+                    danger_row.points.emplace_back(bed_max_x, wipe_tower_bbox.max.y());
+                    danger_row.points.emplace_back(bed_min_x, wipe_tower_bbox.max.y());
+                    polygons->emplace_back(std::move(danger_row));
+                }
+                return {L("Prime Tower") + L(" shares a gantry row with a tall object - the X-axis rod/gantry may "
+                                              "collide with it during a toolchange, even without direct XY overlap.\n")};
+            }
         }
     }
     if (!intersection(exclude_polys, convex_hulls_temp).empty()) {
@@ -1374,7 +1448,7 @@ StringObjectException Print::validate(std::vector<StringObjectException> *warnin
     else {
         //BBS
         StringObjectException layer_warning;
-        auto ret = layered_print_cleareance_valid(*this, &layer_warning);
+        auto ret = layered_print_cleareance_valid(*this, &layer_warning, collison_polygons);
         if (!ret.string.empty()) {
             ret.type = STRING_EXCEPT_OBJECT_COLLISION_IN_LAYER_PRINT;
             return ret;

--- a/tests/fff_print/test_wipe_tower.cpp
+++ b/tests/fff_print/test_wipe_tower.cpp
@@ -210,7 +210,8 @@ static Slic3r::DynamicPrintConfig two_filament_config()
         { "prime_tower_width",               "30" },
         { "extruder_clearance_height_to_rod","40" },
         { "extruder_clearance_radius",       "40" },
-        { "printable_area",                  "0x0,300x0,300x300,0x300" }
+        { "printable_area",                  "0x0,300x0,300x300,0x300" },
+        { "layer_change_gcode",              "G92 E0\n" } // validate() relative-E reset, as in test_print.cpp's build_cubes
     });
     return config;
 }

--- a/tests/fff_print/test_wipe_tower.cpp
+++ b/tests/fff_print/test_wipe_tower.cpp
@@ -7,7 +7,10 @@
 #include "libslic3r/ClipperUtils.hpp"
 #include "libslic3r/GCode/GCodeProcessor.hpp"
 #include "libslic3r/GCode/WipeTower.hpp"
+#include "libslic3r/Model.hpp"
+#include "libslic3r/Print.hpp"
 #include "libslic3r/PrintConfig.hpp"
+#include "libslic3r/TriangleMesh.hpp"
 
 #include "test_helpers.hpp"
 
@@ -181,4 +184,107 @@ TEST_CASE("The wipe tower's toolchange planner flush follows the gcode flavor", 
         CHECK_THAT(tower, Catch::Matchers::ContainsSubstring(expected));
         CHECK_THAT(tower, !Catch::Matchers::ContainsSubstring(unexpected));
     }
+}
+
+// Orca: on typical Cartesian/CoreXY kinematics the X-axis gantry beam spans the full bed
+// width and only moves in Y, so reaching the wipe tower's Y coordinate sweeps the beam
+// across that entire row - a tall object anywhere in that row can be hit by the gantry
+// even if it is nowhere near the tower's XY footprint (see layered_print_cleareance_valid()
+// in Print.cpp). This is a validate()-time (not slice-time) geometry/config check, so these
+// tests only need Print::apply(), not a real multi-filament slice.
+
+static Slic3r::DynamicPrintConfig two_filament_config()
+{
+    Slic3r::DynamicPrintConfig config = Slic3r::DynamicPrintConfig::full_print_config();
+    // full_print_config() only carries PrintRegionConfig keys; filament_diameter (PrintConfig)
+    // is not among them, so DynamicPrintConfig::set_num_filaments() silently no-ops on it
+    // (it resizes via option(key, false), which finds nothing to resize). Materialize it
+    // directly instead. nozzle_diameter is deliberately left at its single-nozzle default
+    // (single_extruder_multi_material) - that is what needs a wipe tower in the first place.
+    config.set_deserialize_strict({
+        { "filament_diameter",               "1.75,1.75" },
+        { "enable_prime_tower",              "1" },
+        { "wipe_tower_no_sparse_layers",     "1" },
+        { "wipe_tower_x",                    "10" },
+        { "wipe_tower_y",                    "100" },
+        { "prime_tower_width",               "30" },
+        { "extruder_clearance_height_to_rod","40" },
+        { "extruder_clearance_radius",       "40" },
+        { "printable_area",                  "0x0,300x0,300x300,0x300" }
+    });
+    return config;
+}
+
+// A tiny object on filament 2, so the plate genuinely references a second filament rather
+// than just carrying an unused config slot.
+static void add_filament2_object(Model &model, const Vec3d &offset)
+{
+    ModelObject *object = model.add_object();
+    object->name += "filament2.stl";
+    object->add_volume(Slic3r::make_cube(5, 5, 5));
+    object->config.set_key_value("extruder", new ConfigOptionInt(2));
+    object->volumes[0]->config.set_key_value("extruder", new ConfigOptionInt(2));
+    object->add_instance()->set_offset(offset);
+}
+
+TEST_CASE("Wipe tower collision detection flags a tall object sharing its gantry row", "[WipeTower][Collision]")
+{
+    Slic3r::DynamicPrintConfig config = two_filament_config();
+
+    Print print;
+    Model model;
+
+    // Tall object (60mm > extruder_clearance_height_to_rod), positioned far away in X from
+    // the tower's X span ([10, 40]) but at the same Y (100) - same gantry row, no XY overlap.
+    // extruder_clearance_radius is small on purpose, so the (already-existing) radius-proximity
+    // check does not also trip, isolating the Y-band one.
+    ModelObject *object = model.add_object();
+    object->name += "tall.stl";
+    object->add_volume(Slic3r::make_cube(20, 20, 60));
+    object->add_instance()->set_offset(Vec3d(200, 100, 0));
+
+    add_filament2_object(model, Vec3d(50, 250, 0));
+
+    print.apply(model, config);
+    REQUIRE(print.has_wipe_tower());
+
+    std::vector<StringObjectException> warnings;
+    Polygons collison_polygons;
+    std::vector<std::pair<Polygon, float>> height_polygons;
+    StringObjectException err = print.validate(&warnings, &collison_polygons, &height_polygons);
+
+    INFO("err.string: " << err.string);
+    REQUIRE_FALSE(err.string.empty());
+    REQUIRE(err.type == STRING_EXCEPT_OBJECT_COLLISION_IN_LAYER_PRINT);
+    REQUIRE_THAT(err.string, Catch::Matchers::ContainsSubstring("gantry"));
+    // The visual keep-out zone (the swept row) must be populated, not just the error text.
+    REQUIRE_FALSE(collison_polygons.empty());
+}
+
+TEST_CASE("Wipe tower collision detection ignores a tall object in a different row", "[WipeTower][Collision]")
+{
+    Slic3r::DynamicPrintConfig config = two_filament_config();
+
+    Print print;
+    Model model;
+
+    // Same tall object, but far away in Y too (250 vs the tower's 100) and far in X -
+    // different gantry row and outside the clearance radius, so neither check should fire.
+    ModelObject *object = model.add_object();
+    object->name += "tall.stl";
+    object->add_volume(Slic3r::make_cube(20, 20, 60));
+    object->add_instance()->set_offset(Vec3d(200, 250, 0));
+
+    add_filament2_object(model, Vec3d(150, 50, 0));
+
+    print.apply(model, config);
+    REQUIRE(print.has_wipe_tower());
+
+    std::vector<StringObjectException> warnings;
+    Polygons collison_polygons;
+    std::vector<std::pair<Polygon, float>> height_polygons;
+    StringObjectException err = print.validate(&warnings, &collison_polygons, &height_polygons);
+
+    INFO("err.string: " << err.string);
+    REQUIRE(err.string.empty());
 }


### PR DESCRIPTION
With **No sparse layers** enabled, the wipe tower can be printed several layers below the tallest object on the plate, letting the toolhead/gantry sweep through already-printed parts during a toolchange (see the companion fix PR for the underlying G-code timing issue). Until now nothing checked for this at slice time — the collision (or near-miss) was only discoverable on the physical printer.

This PR adds a `validate()`-time check, gated on `wipe_tower_no_sparse_layers`, so slicing is blocked with a clear error instead of silently risking a crash:

* **Clearance radius check.** Flags an object within the toolhead/fan-shroud clearance radius of the wipe tower.
* **Gantry row check.** On typical Cartesian/CoreXY kinematics the X-axis gantry beam spans the full bed width and only moves in Y, so reaching the wipe tower's Y coordinate sweeps the beam across that entire row. Flags a tall object sharing that row even without any direct XY overlap with the tower's footprint.
* **Visible keep-out area.** The at-risk zone is now returned alongside the error and drawn on the plate, not just reported as text, so the conflict is easy to locate and resolve without guessing.

Both checks are pure additions gated on `wipe_tower_no_sparse_layers` — behavior is unchanged when that option is disabled.

# Screenshots/Recordings/Graphs

<img width="2543" height="1370" alt="изображение" src="https://github.com/user-attachments/assets/f8708645-ea80-4bd8-a738-1d9b52df17f2" />
<img width="2544" height="1383" alt="изображение" src="https://github.com/user-attachments/assets/44c76f42-3f6a-44da-972b-a63da88fe558" />


## Tests

- `fff_print_tests` suite: all green after the change, including new coverage in `test_wipe_tower.cpp` for the gantry-row check specifically:
  - flags a tall object sharing the wipe tower's gantry row with no direct XY overlap;
  - does not flag a tall object outside that row and outside the clearance radius.
- Ready-to-test build with all fixes already included (v2.4.2) is available in this fork's Releases: https://github.com/alternativniy/OrcaSlicer-U1-Sync/releases

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)