### PR TITLE
Fix Save As default directory on Linux

### DIFF
--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -9773,10 +9773,11 @@ wxString Plater::priv::get_export_file(GUI::FileType file_type)
         default: break;
     }
 
-    std::string out_dir = (boost::filesystem::path(output_file).parent_path()).string();
+    std::string out_dir = output_file.parent_path().string();
+    std::string start_dir = wxGetApp().app_config->get_last_output_dir(out_dir, false);
 
     wxFileDialog dlg(q, dlg_title,
-        is_shapes_dir(out_dir) ? from_u8(wxGetApp().app_config->get_last_dir()) : from_path(output_file.parent_path()), from_path(output_file.filename()),
+        from_u8(start_dir), from_path(output_file.filename()),
         wildcard, wxFD_SAVE | wxFD_OVERWRITE_PROMPT | wxPD_APP_MODAL);
 
     int result = dlg.ShowModal();


### PR DESCRIPTION
# Description

Fix the initial directory used by the Save Project As dialog on Linux.

For a new project, `output_file.parent_path()` may be empty. OrcaSlicer
changes its current working directory to `<data_dir>/log` during startup,
so passing an empty directory to `wxFileDialog` causes the dialog to fall
back to the log directory.

This resulted in Save Project As opening in
`~/.config/OrcaSlicer/log` instead of the previously used output directory.

The selected output directory was already stored using
`update_last_output_dir()`. This change uses the corresponding
`get_last_output_dir()` when determining the initial directory for the
file dialog.

No new dependencies or breaking changes.

# Screenshots/Recordings/Graphs

Not applicable. This change only affects the initial directory of the
file dialog.

## Tests

Tested on Linux Mint with a locally built current main branch.

- Created a new project and selected Save Project As.
- Verified that the dialog opens in the stored `last_export_path` instead
  of `~/.config/OrcaSlicer/log`.
- Saved the project to a different directory.
- Completely restarted OrcaSlicer and created another new project.
- Verified that Save Project As opens in the previously used output
  directory.

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
