### PR TITLE
fix: G-code preview drops comment text and cuts non-ASCII lines short

### DIFF
--- a/src/slic3r/GUI/GCodeViewer.cpp
+++ b/src/slic3r/GUI/GCodeViewer.cpp
@@ -785,6 +785,19 @@ void GCodeViewer::SequentialView::GCodeWindow::load_gcode(const std::string& fil
     }
 }
 
+// Byte offset just past the first count characters of str, or its length if it is shorter.
+static size_t utf8_offset(const std::string& str, size_t count)
+{
+    const char* const begin = str.c_str();
+    const char* const end   = begin + str.size();
+    const char*       pos   = begin;
+    for (size_t i = 0; i < count && pos < end; ++i) {
+        unsigned int codepoint = 0;
+        pos += ImTextCharFromUtf8(&codepoint, pos, end);
+    }
+    return pos - begin;
+}
+
 //BBS: GUI refactor: move to right
 void GCodeViewer::SequentialView::GCodeWindow::render(float top, float bottom, float right, uint64_t curr_line_id) const
 {
@@ -796,23 +809,27 @@ void GCodeViewer::SequentialView::GCodeWindow::render(float top, float bottom, f
             // read line from file
             const size_t start        = id == 1 ? 0 : m_lines_ends[id - 2];
             const size_t original_len = m_lines_ends[id - 1] - start;
-            const size_t len          = std::min(original_len, (size_t) 55);
+            // A character is four bytes at most, so 55 of them always fit in 220.
+            const size_t len          = std::min(original_len, (size_t) 55 * 4);
             std::string  gline(m_file.data() + start, len);
 
-            // If original line is longer than 55 characters, truncate and append "..."
-            if (original_len > 55)
-                gline = gline.substr(0, 52) + "...";
+            // If original line is longer than 55 characters, truncate and append "...".
+            // The cut must land on a character boundary or it leaves half a character behind.
+            if (len < original_len || utf8_offset(gline, 55) < gline.size())
+                gline = gline.substr(0, utf8_offset(gline, 52)) + "...";
 
             std::string command, parameters, comment;
-            // extract comment
-            std::vector<std::string> tokens;
-            boost::split(tokens, gline, boost::is_any_of(";"), boost::token_compress_on);
-            command = tokens.front();
-            if (tokens.size() > 1)
-                comment = ";" + tokens.back();
+            const size_t comment_start = gline.find(';');
+            if (comment_start == std::string::npos)
+                command = gline;
+            else {
+                command = gline.substr(0, comment_start);
+                comment = gline.substr(comment_start);
+            }
 
             // extract gcode command and parameters
             if (!command.empty()) {
+                std::vector<std::string> tokens;
                 boost::split(tokens, command, boost::is_any_of(" "), boost::token_compress_on);
                 command = tokens.front();
                 if (tokens.size() > 1) {


### PR DESCRIPTION
# Description

Two defects in how the G-code preview panel prepares each line for display.

**Comment text is dropped.** The panel split the line on `;` and kept only what followed the last one, discarding everything in between. A comment ending in `;`, a common way to write a marker, was left as a bare `;`. Nothing about this is script specific; `; --- before layer change --- ;` loses its text exactly like the Cyrillic line that prompted the report.

**The 55-character limit counted bytes.** Any comment outside ASCII was cut well short of the stated length, and the cut could land between a character's lead byte and its continuation, leaving invalid UTF-8 for the renderer to draw. No custom G-code is needed to hit this. Orca emits `; stop printing object <name>.stl id:0 copy 0` itself, which is 48 characters, comfortably inside the limit, but 57 bytes once the object name is Cyrillic, so it was cut mid-word while the ASCII equivalent was left alone.

The truncation now measures with `ImTextCharFromUtf8`, so a cut lands on a character boundary, and reading stays bounded because 55 characters cannot exceed 220 bytes. The comment is taken from the first `;` to the end of the line.

Neither defect is a regression. The comment split arrived with the initial BambuStudio import (`1555904bef`), and the truncation with `95d12c24f6`, which added it for long native Klipper commands.

Reported by @Felix14-v2 on #15419.

# Screenshots/Recordings/Graphs

The same layer boundary before and after. Custom layer-change G-code supplies lines 2717 and 2718; everything else is Orca's own output.

| Before | After |
|---|---|
| <img width="322" alt="gcode comment before" src="https://github.com/user-attachments/assets/55f08ee0-82f0-4132-8c56-c8c21a2c93f3" /> | <img width="328" alt="gcode comment after" src="https://github.com/user-attachments/assets/546cff6c-0815-4751-8687-82d7f707dfeb" /> |

Line 2713 is the truncation, cut at `id:0 c...` only because the object name is Cyrillic. Lines 2717 and 2718 are the dropped comment bodies, one Cyrillic and one ASCII. Every other line is unchanged.

## Tests

Every line in those screenshots was run through the old and the new implementation directly, comparing output and checking UTF-8 validity, along with the ASCII twin of line 2713, `; stop printing object Bracket.stl id:0 copy 0`, which is 46 bytes and 46 characters and both implementations leave alone. Built on Windows with clang-cl and checked in the running app. Linux and macOS unverified beyond CI.

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
