### PR TITLE
CLI: evaluate compatible_printers_condition in the compat checks

### DIFF
--- a/src/OrcaSlicer.cpp
+++ b/src/OrcaSlicer.cpp
@@ -53,6 +53,7 @@ using namespace nlohmann;
 
 #include "libslic3r/libslic3r.h"
 #include "libslic3r/Config.hpp"
+#include "libslic3r/Preset.hpp"
 #include "libslic3r/Geometry.hpp"
 #include "libslic3r/GCode.hpp"
 #include "libslic3r/Model.hpp"
@@ -1462,6 +1463,10 @@ int CLI::run(int argc, char **argv)
     std::vector<std::string> upward_compatible_printers, new_print_compatible_printers, current_print_compatible_printers, current_different_settings;
     std::vector<std::string> current_filaments_name, current_filaments_system_name, current_inherits_group, current_extruder_variants, new_extruder_variants, current_print_extruder_variants, new_printer_extruder_variants;
     DynamicPrintConfig load_process_config, load_machine_config;
+    //ORCA: full configs of the "current" (3MF-embedded) process/printer presets, kept so that
+    //      compatible_printers_condition can be evaluated for them below. Previously only the
+    //      literal compatible_printers list was extracted.
+    DynamicPrintConfig current_process_full_config, current_printer_full_config;
     bool new_process_config_is_system = true, new_printer_config_is_system = true;
     std::string pipe_name, makerlab_name, makerlab_version, different_process_setting;
     const std::vector<std::string>              &metadata_name               = m_config.option<ConfigOptionStrings>("metadata_name", true)->values;
@@ -2551,6 +2556,8 @@ int CLI::run(int argc, char **argv)
                     flush_and_exit(ret);
                 }
                 upward_compatible_printers = config.option<ConfigOptionStrings>("upward_compatible_machine", true)->values;
+                //ORCA: keep the full config so compatible_printers_condition can be evaluated against it below
+                current_printer_full_config = std::move(config);
             }
         }
     }
@@ -2573,6 +2580,8 @@ int CLI::run(int argc, char **argv)
                     flush_and_exit(ret);
                 }
                 current_print_compatible_printers  = config.option<ConfigOptionStrings>("compatible_printers", true)->values;
+                //ORCA: keep the full config so compatible_printers_condition can be evaluated against it below
+                current_process_full_config = std::move(config);
             }
         }
     }
@@ -2591,46 +2600,63 @@ int CLI::run(int argc, char **argv)
     for (int index = 0; index < upward_compatible_printers.size(); index++) {
         BOOST_LOG_TRIVIAL(info) << boost::format("index %1%, upward_compatible_printers %2%")%index %upward_compatible_printers[index];
     }
+    //ORCA: Replace the four manual equality-loop checks below with is_compatible_with_printer(), the
+    //      same helper the GUI uses, which also evaluates compatible_printers_condition. Process
+    //      profiles that declare compatibility via condition only -- leaving compatible_printers
+    //      empty -- were always reported incompatible by the literal-name match, so a CLI slice with
+    //      such a preset exited with CLI_PROCESS_NOT_COMPATIBLE (-17) even though the GUI accepts the
+    //      same pair. Behaviour is unchanged where an explicit list exists: is_compatible_with_printer
+    //      does the same name match, and returns true when both list and condition are empty (which
+    //      matches the "old 3mf, no compatible printers" path below).
+    auto check_compat = [](const DynamicPrintConfig &process_cfg,
+                           const DynamicPrintConfig &printer_cfg,
+                           const std::string        &printer_name) -> bool {
+        Preset process_preset(Preset::TYPE_PRINT, std::string("__cli_process_check"));
+        process_preset.config = process_cfg;
+        Preset printer_preset(Preset::TYPE_PRINTER, printer_name);
+        printer_preset.config = printer_cfg;
+        PresetWithVendorProfile process_pwvp(process_preset, nullptr);
+        PresetWithVendorProfile printer_pwvp(printer_preset, nullptr);
+        return is_compatible_with_printer(process_pwvp, printer_pwvp);
+    };
     if (!new_printer_name.empty()) {
         if (!new_process_name.empty()) {
-            for (int index = 0; index < new_print_compatible_printers.size(); index++) {
-                if (new_print_compatible_printers[index] == new_printer_system_name) {
-                    process_compatible = true;
-                    break;
-                }
-            }
+            //new process + new printer: both configs came from --load-settings
+            process_compatible = check_compat(load_process_config, load_machine_config, new_printer_system_name);
             BOOST_LOG_TRIVIAL(info) << boost::format("new printer %1%, inherited from %2%, new process %3%, inherited from %4% ,compatible %5%")
                 %new_printer_name %new_printer_system_name %new_process_name %new_process_system_name %process_compatible;
         }
         else {
-            for (int index = 0; index < current_print_compatible_printers.size(); index++) {
-                if (current_print_compatible_printers[index] == new_printer_system_name) {
-                    process_compatible = true;
-                    break;
-                }
+            //3MF-embedded process vs new printer. current_process_full_config is only populated from
+            //profiles/BBL/process_full/, i.e. for BBL profiles; for every other vendor fall back to the
+            //3MF's own project config, which is already merged into m_print_config above and carries
+            //compatible_printers_condition. Without this a 3MF built from a condition-only process is
+            //rejected when re-sliced with the very printer it was made for.
+            {
+                const DynamicPrintConfig &process_cfg = current_process_full_config.empty() ? m_print_config : current_process_full_config;
+                process_compatible = check_compat(process_cfg, load_machine_config, new_printer_system_name);
             }
             BOOST_LOG_TRIVIAL(info) << boost::format("new printer %1%, inherited from %2%, old process %3%, inherited from %4% ,compatible %5%")
                 %new_printer_name %new_printer_system_name %current_process_name %current_process_system_name %process_compatible;
         }
     }
     else if (!new_process_name.empty()) {
-        for (int index = 0; index < new_print_compatible_printers.size(); index++) {
-            if (new_print_compatible_printers[index] == current_printer_system_name) {
-                process_compatible = true;
-                break;
-            }
+        //new process vs 3MF-embedded printer. As above, current_printer_full_config only resolves for
+        //BBL profiles; otherwise evaluate against the 3MF's own project config in m_print_config, which
+        //holds the embedded printer's printer_notes / nozzle_diameter.
+        {
+            const DynamicPrintConfig &printer_cfg = current_printer_full_config.empty() ? m_print_config : current_printer_full_config;
+            process_compatible = check_compat(load_process_config, printer_cfg, current_printer_system_name);
         }
         BOOST_LOG_TRIVIAL(info) << boost::format("old printer %1%, inherited from %2%, new process %3%, inherited from %4% ,compatible %5%")
             %current_printer_name %current_printer_system_name %new_process_name %new_process_system_name %process_compatible;
     }
     else {
-        //check the compatible of old printer&&process
-        for (int index = 0; index < current_print_compatible_printers.size(); index++) {
-            if (current_print_compatible_printers[index] == current_printer_system_name) {
-                process_compatible = true;
-                break;
-            }
-        }
+        //both sides 3MF-embedded (pure reprocess)
+        if (!current_process_full_config.empty() && !current_printer_full_config.empty())
+            process_compatible = check_compat(current_process_full_config, current_printer_full_config, current_printer_system_name);
+        else
+            process_compatible = std::find(current_print_compatible_printers.begin(), current_print_compatible_printers.end(), current_printer_system_name) != current_print_compatible_printers.end();
         if (!process_compatible && current_print_compatible_printers.empty())
         {
             BOOST_LOG_TRIVIAL(info) << boost::format("old 3mf, no compatible printers, set to compatible");

--- a/src/OrcaSlicer.cpp
+++ b/src/OrcaSlicer.cpp
@@ -2622,12 +2622,21 @@ int CLI::run(int argc, char **argv)
     //      is_compatible_with_printer() reads that as "no constraint" and accepts every printer.
     //      Translate the two keys back. Index 0 of the expression group is the print preset -- the
     //      group is filled print, filaments, printer (PresetBundle.cpp).
+    //      The raw keys win whenever they carry something. A project the CLI exported itself has the
+    //      real compatible_printers_condition AND an all-empty compatible_machine_expression_group,
+    //      so copying the group's first entry unconditionally would overwrite a valid condition with
+    //      "" and accept every printer. The renamed keys are only a fallback, and an empty value is
+    //      never written over a real one.
     auto cli_process_compat_config = [](const DynamicPrintConfig &project_cfg) -> DynamicPrintConfig {
         DynamicPrintConfig cfg = project_cfg;
-        if (const auto *list = project_cfg.option<ConfigOptionStrings>("print_compatible_printers"))
+        const auto *raw_list = project_cfg.option<ConfigOptionStrings>("compatible_printers");
+        const auto *list     = project_cfg.option<ConfigOptionStrings>("print_compatible_printers");
+        if ((raw_list == nullptr || raw_list->values.empty()) && list != nullptr && !list->values.empty())
             cfg.set_key_value("compatible_printers", new ConfigOptionStrings(list->values));
-        const auto *group = project_cfg.option<ConfigOptionStrings>("compatible_machine_expression_group");
-        if (group != nullptr && !group->values.empty())
+        const auto *raw_cond = project_cfg.option<ConfigOptionString>("compatible_printers_condition");
+        const auto *group    = project_cfg.option<ConfigOptionStrings>("compatible_machine_expression_group");
+        if ((raw_cond == nullptr || raw_cond->value.empty()) && group != nullptr && !group->values.empty() &&
+            !group->values.front().empty())
             cfg.set_key_value("compatible_printers_condition", new ConfigOptionString(group->values.front()));
         return cfg;
     };

--- a/src/OrcaSlicer.cpp
+++ b/src/OrcaSlicer.cpp
@@ -2611,13 +2611,25 @@ int CLI::run(int argc, char **argv)
     auto check_compat = [](const DynamicPrintConfig &process_cfg,
                            const DynamicPrintConfig &printer_cfg,
                            const std::string        &printer_name) -> bool {
-        Preset process_preset(Preset::TYPE_PRINT, std::string("__cli_process_check"));
-        process_preset.config = process_cfg;
-        Preset printer_preset(Preset::TYPE_PRINTER, printer_name);
-        printer_preset.config = printer_cfg;
-        PresetWithVendorProfile process_pwvp(process_preset, nullptr);
-        PresetWithVendorProfile printer_pwvp(printer_preset, nullptr);
-        return is_compatible_with_printer(process_pwvp, printer_pwvp);
+        return is_compatible_with_printer(process_cfg, Preset::TYPE_PRINT, printer_cfg, printer_name);
+    };
+
+    //ORCA: a 3MF's project config does not carry compatible_printers / compatible_printers_condition.
+    //      PresetBundle::construct_full_config() erases both and re-emits them as
+    //      print_compatible_printers and compatible_machine_expression_group; they are renamed back
+    //      only on the PresetBundle load path, which the CLI does not take. Feeding the project config
+    //      to the check as-is therefore presents no list and no condition, and
+    //      is_compatible_with_printer() reads that as "no constraint" and accepts every printer.
+    //      Translate the two keys back. Index 0 of the expression group is the print preset -- the
+    //      group is filled print, filaments, printer (PresetBundle.cpp).
+    auto cli_process_compat_config = [](const DynamicPrintConfig &project_cfg) -> DynamicPrintConfig {
+        DynamicPrintConfig cfg = project_cfg;
+        if (const auto *list = project_cfg.option<ConfigOptionStrings>("print_compatible_printers"))
+            cfg.set_key_value("compatible_printers", new ConfigOptionStrings(list->values));
+        const auto *group = project_cfg.option<ConfigOptionStrings>("compatible_machine_expression_group");
+        if (group != nullptr && !group->values.empty())
+            cfg.set_key_value("compatible_printers_condition", new ConfigOptionString(group->values.front()));
+        return cfg;
     };
     if (!new_printer_name.empty()) {
         if (!new_process_name.empty()) {
@@ -2628,12 +2640,16 @@ int CLI::run(int argc, char **argv)
         }
         else {
             //3MF-embedded process vs new printer. current_process_full_config is only populated from
-            //profiles/BBL/process_full/, i.e. for BBL profiles; for every other vendor fall back to the
-            //3MF's own project config, which is already merged into m_print_config above and carries
-            //compatible_printers_condition. Without this a 3MF built from a condition-only process is
-            //rejected when re-sliced with the very printer it was made for.
+            //profiles/BBL/process_full/, so for every other vendor fall back to the 3MF's own project
+            //config in m_print_config, with its renamed compatibility keys translated back (see
+            //cli_process_compat_config above). Without this a 3MF built from a condition-only process
+            //is rejected when re-sliced with the very printer it was made for.
             {
-                const DynamicPrintConfig &process_cfg = current_process_full_config.empty() ? m_print_config : current_process_full_config;
+                //ORCA: profiles/BBL/{process,machine}_full/ are gitignored and not generated in-tree,
+                //      so current_*_full_config is always empty and this fallback is the only live path.
+                const DynamicPrintConfig process_cfg = current_process_full_config.empty()
+                                                           ? cli_process_compat_config(m_print_config)
+                                                           : current_process_full_config;
                 process_compatible = check_compat(process_cfg, load_machine_config, new_printer_system_name);
             }
             BOOST_LOG_TRIVIAL(info) << boost::format("new printer %1%, inherited from %2%, old process %3%, inherited from %4% ,compatible %5%")

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -867,6 +867,20 @@ bool is_compatible_with_printer(const PresetWithVendorProfile &preset, const Pre
     return is_compatible_with_printer(preset, active_printer, &config);
 }
 
+// ORCA: see the header. The CLI resolves --load-settings into bare DynamicPrintConfigs and has no
+// Preset objects to hand; without this it would have to reimplement the policy or build the shells
+// at every call site.
+bool is_compatible_with_printer(const DynamicPrintConfig &preset_config, Preset::Type preset_type,
+                                const DynamicPrintConfig &printer_config, const std::string &printer_name)
+{
+    Preset preset(preset_type, std::string("__compat_check"));
+    preset.config = preset_config;
+    Preset printer(Preset::TYPE_PRINTER, printer_name);
+    printer.config = printer_config;
+    return is_compatible_with_printer(PresetWithVendorProfile(preset, nullptr),
+                                      PresetWithVendorProfile(printer, nullptr));
+}
+
 void Preset::set_visible_from_appconfig(const AppConfig &app_config)
 {
     //BBS: add config related log

--- a/src/libslic3r/Preset.hpp
+++ b/src/libslic3r/Preset.hpp
@@ -459,6 +459,11 @@ protected:
 bool is_compatible_with_print  (const PresetWithVendorProfile &preset, const PresetWithVendorProfile &active_print, const PresetWithVendorProfile &active_printer);
 bool is_compatible_with_printer(const PresetWithVendorProfile &preset, const PresetWithVendorProfile &active_printer, const DynamicPrintConfig *extra_config);
 bool is_compatible_with_printer(const PresetWithVendorProfile &preset, const PresetWithVendorProfile &active_printer);
+// ORCA: same check for callers that hold raw configs rather than Presets (the CLI). Wraps them in
+// throwaway Preset shells and delegates, so the compatibility policy -- including the fail-open on a
+// malformed compatible_printers_condition -- lives in one place for the GUI and the CLI alike.
+bool is_compatible_with_printer(const DynamicPrintConfig &preset_config, Preset::Type preset_type,
+                                const DynamicPrintConfig &printer_config, const std::string &printer_name);
 
 // Where a preset is being loaded from. `Auto` lets load_presets() infer from the directory path.
 struct PresetOrigin {


### PR DESCRIPTION
# Description

Slicing from the CLI with `--load-settings` exits with `CLI_PROCESS_NOT_COMPATIBLE` (-17), *"The selected printer is not compatible with the process preset in the 3mf."*, for process/printer pairs the GUI accepts. This reproduces with **stock, unmodified bundled profiles** — no user presets involved:

```bash
orca-slicer --datadir <datadir> \
  --load-settings "<datadir>/system/Prusa/process/0.20mm SPEED @CORE One HF 0.4.json;<datadir>/system/Prusa/machine/Prusa CORE One HF 0.4 nozzle.json" \
  --load-filaments "<datadir>/system/Prusa/filament/Prusament PETG @CORE One HF 0.4.json" \
  --slice 0 --outputdir /tmp/out model.stl

# result.json -> "return_code": -17
```

`CLI::run` has four compatibility checks, and all four decide by literal name match against the `compatible_printers` list:

```cpp
for (int index = 0; index < new_print_compatible_printers.size(); index++) {
    if (new_print_compatible_printers[index] == new_printer_system_name) {
        process_compatible = true;
        break;
    }
}
```

A process profile that declares compatibility through `compatible_printers_condition` and leaves `compatible_printers` empty therefore always fails: the loop iterates zero times, `process_compatible` stays `false`, and the condition is never consulted. For `0.20mm SPEED @CORE One HF 0.4` that condition is:

```
printer_notes=~/.*PRINTER_MODEL_COREONE[^_a-zA-Z0-9].*/ and nozzle_diameter[0]==0.4 and printer_notes=~/.*HF_NOZZLE.*/
```

The GUI does not have this bug. `is_compatible_with_printer()` in `src/libslic3r/Preset.cpp` treats an empty list as *"no explicit constraint"* and evaluates the condition in that case:

```cpp
bool has_compatible_printers = compatible_printers != nullptr && ! compatible_printers->values.empty();
if (! has_compatible_printers && ! condition.empty()) {
    return PlaceholderParser::evaluate_boolean_expression(condition, active_printer.preset.config, extra_config);
}
```

So the same preset pair loads in the GUI and is rejected by the CLI.

### Scope in the bundled profiles

I surveyed every process preset in `resources/profiles`, resolving `compatible_printers` and `compatible_printers_condition` through the `inherits` chain. Of 3412 bundled process presets, 587 resolve to an empty `compatible_printers` list:

| | presets |
|---|---|
| Empty list **and** a `compatible_printers_condition` — condition now evaluated | **173** (all Prusa) |
| Empty list and no condition — express no constraint at all | 414 |

The 173 are all Prusa, and are **52% of Prusa's 334 process presets** — every condition-based `@CORE One`, `@MK4S`, `@MK4`, `@MINI` and `@XL` profile. Other bundled vendors put an explicit `compatible_printers` list on user-selectable presets, so they never reach the broken path; I checked Anycubic by hand to confirm (`0.08mm HighDetail @Anycubic Kobra 3 0.4 nozzle` carries `compatible_printers: ["Anycubic Kobra 3 0.4 nozzle"]` and an empty condition). **This is not a vendor-generic bug** — it is one bundled first-party vendor's entire condition-based profile set.

(Counted recursively: 399 of those files live in nested vendor subdirectories such as `Elegoo/machine`-style `process/` layouts, which a single-level glob misses.)

The other 414 are almost entirely abstract base profiles (`fdm_process_common`, `fdm_process_dual_*`, …) that other presets inherit from and users do not select directly. They were also being rejected despite expressing no constraint; after this change they are treated as compatible, matching both the GUI and the existing *"old 3mf, no compatible printers, set to compatible"* path a few lines below.

# Fix

Replace the four equality loops with a `check_compat` lambda that calls `is_compatible_with_printer()` — the same helper the GUI uses — wrapping the already-loaded `DynamicPrintConfig`s in lightweight `Preset` / `PresetWithVendorProfile` shells. This reuses the existing semantics rather than reimplementing them.

The two 3MF-reprocess checks need the 3MF's own configs. `current_process_full_config` / `current_printer_full_config` capture them, but only from `resources_dir()/profiles/BBL/{process,machine}_full/` — and those directories are gitignored (`.gitignore`) and generated by nothing in the tree, so in practice they are **always empty** and the fallback below is the only live path, not a rare non-BBL case.

The fallback reads the 3MF's project config from `m_print_config`, but a project config does not carry `compatible_printers` / `compatible_printers_condition`: `PresetBundle::construct_full_config()` erases both and re-emits them as `print_compatible_printers` and `compatible_machine_expression_group`, and they are renamed back only on the `PresetBundle` load path, which the CLI does not take. Passed through as-is the check sees no list and no condition, reads that as "no constraint", and accepts every printer. `cli_process_compat_config()` translates the two keys back first; index 0 of the expression group is the process preset, the group being filled print, filaments, printer.

That mattered for more than the verdict. An over-permissive accept skips the `!process_compatible` block that sets `machine_switch`, so the newly supplied printer is never appended to `print_compatible_printers` and the exported project stays marked compatible only with the printer it came from — which is what that block exists to prevent.

Without that fallback a 3MF built from a condition-only process is rejected when re-sliced with the very printer it was made for.

**The return value can only move from `false` to `true`, structurally.** (That is a statement about the variable, not about the consequences — see the machine-switch note under *Fix*, where an over-permissive accept skips a block with side effects.) The condition branch is guarded by `if (! has_compatible_printers && ! condition.empty())`, so a preset with a non-empty list provably never reaches the condition. Its fallback return is then a superset of the old plain-equality scan:

```cpp
return preset.preset.is_default || active_printer.preset.name.empty() || !has_compatible_printers ||
       std::find(compatible_printers->values.begin(), compatible_printers->values.end(), active_printer.preset.name) != ... ||
       (!active_printer.preset.is_system && is_compatible_with_parent_printer(preset, active_printer));
```

— the same name match plus three additional accept paths (`is_default`, empty printer name, parent-printer match). So no pair accepted today can become rejected. BBL flows are untouched: their full configs are populated, so they take the existing branch.

**One behaviour change worth calling out explicitly.** `is_compatible_with_printer()` catches `runtime_error` from the expression parser and returns `true` — its existing `//FIXME in case of an error, return "compatible with everything"`. A process whose `compatible_printers_condition` is malformed therefore now fails *open*, where the CLI previously rejected it with -17 along with everything else that had an empty list. This is still `false` → `true` so it does not affect the argument above, and it makes the CLI agree with the GUI, but it does mean an invalid condition is silently permissive rather than loud. I have kept the GUI's policy rather than diverging from it in the CLI; if maintainers would prefer the CLI to fail closed on a parse error, that is a one-line change here and arguably belongs in `Preset.cpp` for both callers.

Behaviour is unchanged wherever an explicit `compatible_printers` list exists: `is_compatible_with_printer()` performs the same name match. It is deliberately **not** a blanket *"empty list ⇒ compatible"* shortcut — that would accept genuinely incompatible pairs, since an `@MK4S` process on a CORE One printer also has an empty list and must keep being rejected. Only evaluating the condition separates the two cases.

# Verification

Built and tested on Linux, Release config.

**Stock-profile matrix**, two printer models, pre-fix vs post-fix binaries, bundled profiles only:

| process | printer | pre | post |
|---|---|---|---|
| `0.20mm SPEED @CORE One HF 0.4` | `Prusa CORE One HF 0.4 nozzle` | -17 | **0** |
| `0.28mm DRAFT @CORE One HF 0.4` | `Prusa CORE One HF 0.4 nozzle` | -17 | **0** |
| `0.20mm SPEED @MK4S HF0.4` | `Prusa MK4S HF0.4 nozzle` | -17 | **0** |
| `0.15mm SPEED @MK4S HF0.4` | `Prusa MK4S HF0.4 nozzle` | -17 | **0** |
| `0.20mm SPEED @MK4S HF0.4` | `Prusa CORE One HF 0.4 nozzle` | -17 | **-17** |
| `0.20mm SPEED @CORE One HF 0.4` | `Prusa MK4S HF0.4 nozzle` | -17 | **-17** |

The cross-model rows run in both directions and must stay `-17`; they are what distinguishes "the condition is evaluated" from "the gate was bypassed".

All six rows pass on the fixed build (4 positives flip `-17` → `0`, both cross-model negatives hold at `-17`).

Additional regression on a real datadir (28 slices, all passing):

- 10 user process presets that previously returned `-17` now return `0`.
- 5 presets carrying an explicit `compatible_printers` list still return `0`, and their **G-code is byte-identical** to the pre-fix build.
- Negative controls hold: `@CORE One 0.25` (right model, wrong nozzle) and `@CORE One L 0.25` (exercises the `[^_a-zA-Z0-9]` guard separating `COREONE` from `COREONE_L`) both stay `-17`.
- Flipping a single keyword in the printer's `printer_notes` flips the verdict — `COREONE`+`HF_NOZZLE` → `0`, drop `HF_NOZZLE` → `-17`, swap to `MK4S` → `-17` — confirming the condition drives the decision.

**3MF reprocess paths**, on a 3MF built from the condition-only `0.20mm SPEED @CORE One HF 0.4`:

| case | before | after |
|---|---|---|
| 3mf alone, no `--load-settings` | 0 | 0 |
| 3mf + **the same printer it was built with** | **-17** | **0** |
| 3mf + a matching new process (`0.15mm SPEED @CORE One`) | **-17** | **0** |
| 3mf + a mismatched new process (`0.20mm SPEED @MK4S`) | -17 | **-17** |
| 3mf + a different printer (`MK4S`) | 0 | 0 |

The mismatched-process row is the negative control for these paths: it must stay `-17` while the matching row flips to `0`.

The last row is worth flagging as **pre-existing behaviour this PR does not change**: supplying a printer *different* from the 3MF's hits the `"switch to new printers, set to compatible"` rescue a few lines below the gate, which sets `process_compatible = true` unconditionally when no new process is given. So a genuinely incompatible printer is accepted there, while before this PR the *correct* printer was rejected. Fixing that asymmetry is a separate change and is not attempted here.

No GUI code is touched; GUI compatibility behaviour is unchanged.

# Relationship to other PRs

- Split out of **#13731** (its section 1) as a standalone, single-purpose change. #13731 has since been closed; its inheritance part was superseded by #15438 and its remaining 3MF dirty-state part is noted there as still open.
- Complementary to the `inherits`-resolution work: those decide *which values* a preset resolves to, this decides *whether the resulting pair is considered compatible*. #15438 explicitly stated it "does not include #13731's separate compatibility ... behavior" — this is that piece.

**Updated now that #15438 has merged (`bcb4f17`, 2026-09-08):** this PR previously carried a caveat that a preset whose `compatible_printers_condition` lives further up its `inherits` chain would resolve to *no condition* on `main`, and so be treated as unconstrained rather than genuinely evaluated. That caveat is now obsolete. With inheritance resolution in `main`, inherited conditions resolve and this change evaluates them properly, so the two compose exactly as intended and the fix is no longer partial for inherited presets.

I built and tested #15438 against a non-BBL profile before it merged — 61 of 61 previously-wrong ancestor keys fixed, 0 wrong — so I am confident the composition holds rather than assuming it.

# Scope

1 file, +49/-23 (`src/OrcaSlicer.cpp`). No public API change, no profile change, no GUI change.

