### PR TITLE
Fix: guard the fifth null deref of the same kind, on the project-settings path

### DIFF
--- a/src/libslic3r/Config.cpp
+++ b/src/libslic3r/Config.cpp
@@ -1049,7 +1049,8 @@ int ConfigBase::load_from_json(const std::string &file, ConfigSubstitutionContex
                 std::vector<std::string>& different_settings = this->option<ConfigOptionStrings>("different_settings_to_system", true)->values;
                 size_t size = different_settings.size();
                 if (size == 0) {
-                    size = this->option<ConfigOptionStrings>("filament_settings_id")->values.size() + 2;
+                    const auto *filament_ids = this->option<ConfigOptionStrings>("filament_settings_id");
+                    size = (filament_ids ? filament_ids->values.size() : 0) + 2;
                     different_settings.resize(size);
                 }
 


### PR DESCRIPTION
# Body

#14580 guarded four null derefs of exactly this kind on the CLI path, with the note:

> Read defensively — a 3mf missing preset ids (e.g. one produced by a non-GUI writer) would
> otherwise crash here on the deref.

including `filament_settings_id` itself:

```diff
- current_filaments_name = config.option<ConfigOptionStrings>("filament_settings_id")->values;
+ if (const auto *o = config.option<ConfigOptionStrings>("filament_settings_id")) current_filaments_name = o->values;
```

The same read exists on the project-settings path in `ConfigBase::load_from_json`, which is what the
GUI takes on **File → Open → Open as project**. That one is still unguarded, and it is the one users
hit: it crashes OrcaSlicer with an access violation when opening a `.3mf` written by another slicer.

`src/libslic3r/Config.cpp:1048-1053`:

```cpp
if (is_project_settings) {
    std::vector<std::string>& different_settings =
        this->option<ConfigOptionStrings>("different_settings_to_system", true)->values;
    size_t size = different_settings.size();
    if (size == 0) {
        size = this->option<ConfigOptionStrings>("filament_settings_id")->values.size() + 2;
```

Line 1052 is the only `option<>` call in this function that is dereferenced without either passing
the create-if-missing `true` or being null-checked first.

## How the key goes missing

The parse loop abandons the rest of the document on the first malformed array:

```cpp
valid = parse_str_arr(it, single_sep, array_sep, escape_string_type, value_str);
if (!valid) {
    BOOST_LOG_TRIVIAL(error) << __FUNCTION__ << ": parse " << file
                             << " error, invalid json array for " << it.key();
    break;
}
```

nlohmann iterates in sorted key order. In the reported file `extruder` is key 86 of 478 and
`filament_settings_id` is key 128, so the `break` leaves 392 keys unparsed — including the one the
block above then reads unconditionally.

The file is a `.3mf` from Creality Print 5.1.7, whose per-extruder options are scalars rather than
arrays (of the 20 checked, 20 are scalars), and whose `extruder` key is a nested object array that
`parse_str_arr` also rejects.

Reaching the crash needs three things at once: a malformed array whose key sorts before
`filament_settings_id`, no `different_settings_to_system` in the file, and `is_project_settings`.
Projects written by OrcaSlicer and BambuStudio emit well-formed arrays, so only a file from another
slicer gets there.

## Why a null check rather than `, true`

`option<>(key, true)` does not create an empty option — `DynamicConfig::optptr` calls
`create_default_option()`, which clones the definition's default, and `filament_settings_id`'s
default is `ConfigOptionStrings { "" }`, one entry. So it would both change the count and insert the
key, and `PresetBundle.cpp` uses the presence of that key as a test
(`else if (config.has("filament_settings_id")) collection = &filaments;`).

The size itself costs nothing either way: the loop below only ever writes `different_settings[0]`,
and `PresetBundle` re-resizes to `num_filaments + 2` from `filament_colour` regardless.

## Scope

The `break` is left alone. Turning it into `continue` would keep the rest of a partially-bad config
and would probably have prevented this crash by itself, but it is a real behaviour change and a
separate decision. Happy to follow up if wanted.

## Verification

Reported with the project file, full logs and the crash dump in #15337:
`Exception Code: c0000005 ACCESS_VIOLATION`, `RAX = 0`, `RCX = 0x66696C616D656E74` — ASCII
`"filament"`, which is what pointed at this call.

The same line existed in BambuStudio and the same change was merged there as
https://github.com/bambulab/BambuStudio/pull/12058.

Fixes #15337 