### PR TITLE
feat: add option to use mold to build deps on linux

### DIFF
--- a/build_linux.sh
+++ b/build_linux.sh
@@ -8,7 +8,7 @@ SCRIPT_PATH=$(dirname "$(readlink -f "${0}")")
 pushd "${SCRIPT_PATH}" > /dev/null
 
 function usage() {
-    echo "Usage: ./${SCRIPT_NAME} [-1][-b][-c][-d][-D][-e][-F][-g][-h][-i][-j N][-p][-r][-s][-t][-u][-l][-L]"
+    echo "Usage: ./${SCRIPT_NAME} [-1][-b][-c][-d][-D][-e][-F][-g][-h][-i][-j N][-p][-r][-s][-t][-u][-l][-L][-M]"
     echo "   -1: limit builds to one core (where possible)"
     echo "   -j N: limit builds to N cores (where possible)"
     echo "   -b: build in Debug mode"
@@ -28,6 +28,7 @@ function usage() {
     echo "   -u: install system dependencies (asks for sudo password; build prerequisite)"
     echo "   -l: use Clang instead of GCC (default: GCC)"
     echo "   -L: use ld.lld as linker (if available)"
+    echo "   -M: use mold as linker (if available)"
     echo "For a first use, you want to './${SCRIPT_NAME} -u'"
     echo "   and then './${SCRIPT_NAME} -dsi'"
     echo "For a GitHub Actions-like Linux build locally, use './${SCRIPT_NAME} -g -istrlL'"
@@ -41,7 +42,7 @@ unset name
 BUILD_DIR=build
 BUILD_CONFIG=Release
 FORWARDED_ARGS=()
-while getopts ":1j:bcCdDeFghiprstulL" opt ; do
+while getopts ":1j:bcCdDeFghiprstulLM" opt ; do
   case ${opt} in
     1 )
         export CMAKE_BUILD_PARALLEL_LEVEL=1
@@ -118,6 +119,10 @@ while getopts ":1j:bcCdDeFghiprstulL" opt ; do
         USE_LLD="1"
         FORWARDED_ARGS+=("-L")
         ;;
+    M )
+        USE_MOLD="1"
+        FORWARDED_ARGS+=("-M")
+        ;;
     * )
 	echo "Unknown argument '${opt}', aborting."
 	exit 1
@@ -132,6 +137,11 @@ fi
 
 if [[ -n "${CLEAN_DOCKER_IMAGE}" ]] && [[ -z "${USE_DOCKER}" ]] ; then
     echo "Error: -F requires -g."
+    exit 1
+fi
+
+if [[ -n "${USE_LLD}" ]] && [[ -n "${USE_MOLD}" ]] ; then
+    echo "Error: -L and -M are mutually exclusive."
     exit 1
 fi
 
@@ -504,6 +514,18 @@ if [[ -n "${USE_LLD}" ]] ; then
     fi
 fi
 
+# Configure use of mold as the linker when requested
+export CMAKE_MOLD_LINKER_ARGS=()
+if [[ -n "${USE_MOLD}" ]] ; then
+    if command -v mold >/dev/null 2>&1 ; then
+        MOLD_BIN=$(command -v mold)
+        export CMAKE_MOLD_LINKER_ARGS=(-DCMAKE_LINKER="${MOLD_BIN}" -DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=mold -DCMAKE_SHARED_LINKER_FLAGS=-fuse-ld=mold -DCMAKE_MODULE_LINKER_FLAGS=-fuse-ld=mold)
+    else
+        echo "Error: mold not found. Please install the 'mold' package or omit -M."
+        exit 1
+    fi
+fi
+
 export CMAKE_CCACHE_ARGS=()
 CMAKE_CCACHE=${CMAKE_CCACHE:-}
 if [ -n "$CMAKE_CCACHE" ]; then
@@ -536,7 +558,7 @@ if [[ -n "${BUILD_DEPS}" ]] ; then
         BUILD_ARGS+=(-DCMAKE_BUILD_TYPE="${BUILD_CONFIG}")
     fi
 
-    print_and_run cmake -S deps -B deps/$BUILD_DIR "${CMAKE_C_CXX_COMPILER_CLANG[@]}" "${CMAKE_LLD_LINKER_ARGS[@]}" "${CMAKE_CCACHE_ARGS[@]}" -G Ninja "${COLORED_OUTPUT}" "${BUILD_ARGS[@]}"
+    print_and_run cmake -S deps -B deps/$BUILD_DIR "${CMAKE_C_CXX_COMPILER_CLANG[@]}" "${CMAKE_LLD_LINKER_ARGS[@]}" "${CMAKE_MOLD_LINKER_ARGS[@]}" "${CMAKE_CCACHE_ARGS[@]}" -G Ninja "${COLORED_OUTPUT}" "${BUILD_ARGS[@]}"
     print_and_run cmake --build deps/$BUILD_DIR -j1
 fi
 
@@ -556,7 +578,7 @@ if [[ -n "${BUILD_ORCA}" ]] || [[ -n "${BUILD_TESTS}" ]] ; then
         BUILD_ARGS+=(-DORCA_UPDATER_SIG_KEY="${ORCA_UPDATER_SIG_KEY}")
     fi
 
-    print_and_run cmake -S . -B $BUILD_DIR "${CMAKE_C_CXX_COMPILER_CLANG[@]}" "${CMAKE_LLD_LINKER_ARGS[@]}" "${CMAKE_CCACHE_ARGS[@]}" -G "Ninja Multi-Config" \
+    print_and_run cmake -S . -B $BUILD_DIR "${CMAKE_C_CXX_COMPILER_CLANG[@]}" "${CMAKE_LLD_LINKER_ARGS[@]}" "${CMAKE_MOLD_LINKER_ARGS[@]}" "${CMAKE_CCACHE_ARGS[@]}" -G "Ninja Multi-Config" \
 -DSLIC3R_PCH=${SLIC3R_PRECOMPILED_HEADERS} \
 -DORCA_TOOLS=ON \
 "${COLORED_OUTPUT}" \


### PR DESCRIPTION
# Description

<!--
> Please provide a summary of the changes made in this PR. Include details such as:
  > * What issue does this PR address or fix?
  > * What new features or enhancements does this PR introduce?
  > * Are there any breaking changes or dependencies that need to be considered?
-->
## Add mold linker support to `build_linux.sh`

### What is mold?

[mold](https://github.com/rui314/mold) is a modern, high-performance linker designed to significantly reduce C/C++ link times. It supports the standard compiler linker interface and is a drop-in replacement for LLVM `lld` in this build workflow.

This adds the `-M` option to `build_linux.sh`, allowing users to select mold instead of the default linker or `ld.lld`.

### Installing mold on Linux

Ubuntu/Debian:

```bash
sudo apt update
sudo apt install mold
```

Fedora:

```bash
sudo dnf install mold
```

Arch Linux:

```bash
sudo pacman -S mold
```

Alternatively, mold can be built from source using the instructions in the [official repository](https://github.com/rui314/mold#installation).

### Usage

```bash
./build_linux.sh -M -s
```

The script checks that `mold` is available in `PATH` and configures CMake to use it through:

```text
-fuse-ld=mold
```

`-L` and `-M` are mutually exclusive.

# Screenshots/Recordings/Graphs

<!--
> Please attach relevant screenshots to showcase the UI changes.
> Please attach images that can help explain the changes.
-->

## Tests

<!--
> Please describe the tests that you have conducted to verify the changes made in this PR.
-->

<!--
> A guide for users on how to download the artifacts from this PR.
-->

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
