### PR TITLE
Feature: disable inheritance of printer profiles

### DIFF
--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -26,6 +26,8 @@
 
 #include <algorithm>
 #include <fstream>
+#include <iomanip>
+#include <sstream>
 #include <stdexcept>
 #include <unordered_map>
 #include <boost/format.hpp>
@@ -668,6 +670,16 @@ void Preset::remove_files(bool cloud_already_deleted)
     }
     // Erase the preset file.
     boost::nowide::remove(this->file.c_str());
+    // Orca: and the artwork copied beside a detached printer, which would otherwise be orphaned.
+    if (this->type == TYPE_PRINTER && !this->file.empty()) {
+        boost::system::error_code ec;
+        const fs::path    stem   = fs::path(this->file).replace_extension();
+        const std::string prefix = stem.filename().string();
+        for (const std::string &suffix : {"_bed_model", "_bed_texture", "_cover"})
+            for (fs::directory_iterator it(stem.parent_path(), ec), end; !ec && it != end; it.increment(ec))
+                if (boost::starts_with(it->path().filename().string(), prefix + suffix + "."))
+                    boost::nowide::remove(it->path().string().c_str());
+    }
     fs::path idx_path(this->file);
     idx_path.replace_extension(".info");
     if (fs::exists(idx_path)) {
@@ -817,10 +829,15 @@ bool is_compatible_with_parent_printer(const PresetWithVendorProfile& preset, co
 {
     auto *compatible_printers     = dynamic_cast<const ConfigOptionStrings*>(preset.preset.config.option("compatible_printers"));
     bool  has_compatible_printers = compatible_printers != nullptr && ! compatible_printers->values.empty();
+    if (! has_compatible_printers)
+        return false;
     //BBS: FIXME only check the parent now, but should check grand-parent as well.
-    return has_compatible_printers &&
-           std::find(compatible_printers->values.begin(), compatible_printers->values.end(), active_printer.preset.inherits()) !=
-               compatible_printers->values.end();
+    // Orca: a detached printer has no parent, but is a copy of the one named in "cloned_from".
+    const auto lists_printer = [compatible_printers](const std::string &name) {
+        return ! name.empty() &&
+               std::find(compatible_printers->values.begin(), compatible_printers->values.end(), name) != compatible_printers->values.end();
+    };
+    return lists_printer(active_printer.preset.inherits()) || lists_printer(active_printer.preset.cloned_from());
 }
 
 bool is_compatible_with_printer(const PresetWithVendorProfile &preset, const PresetWithVendorProfile &active_printer, const DynamicPrintConfig *extra_config)
@@ -833,9 +850,12 @@ bool is_compatible_with_printer(const PresetWithVendorProfile &preset, const Pre
     // Orca: check excluded printers
     if (preset.vendor != nullptr && preset.preset.type == Preset::TYPE_FILAMENT) {
         const auto& excluded_printers = preset.preset.m_excluded_from;
+        // Orca: a detached copy references its source through "cloned_from" instead of "inherits".
         const auto  excluded         = preset.vendor->name == PresetBundle::ORCA_FILAMENT_LIBRARY &&
                               (excluded_printers.find(active_printer.preset.name) != excluded_printers.end() ||
-                               excluded_printers.find(active_printer.preset.inherits()) != excluded_printers.end());
+                               excluded_printers.find(active_printer.preset.inherits()) != excluded_printers.end() ||
+                               (!active_printer.preset.cloned_from().empty() &&
+                                excluded_printers.find(active_printer.preset.cloned_from()) != excluded_printers.end()));
         if (excluded)
             return false;
     }
@@ -1427,7 +1447,7 @@ static std::vector<std::string> s_Preset_printer_options {
     "printer_model", "printer_variant", "printer_extruder_id", "printer_extruder_variant", "extruder_variant_list", "default_nozzle_volume_type",
     "printable_height", "extruder_printable_height", "extruder_clearance_radius", "extruder_clearance_height_to_lid", "extruder_clearance_height_to_rod",
     "nozzle_height", "master_extruder_id",
-    "default_print_profile", "inherits",
+    "default_print_profile", "inherits", "cloned_from",
     "silent_mode",
     "scan_first_layer", "enable_power_loss_recovery", "wrapping_detection_layers", "wrapping_exclude_area", "machine_load_filament_time", "machine_unload_filament_time", "machine_tool_change_time", "time_cost", "machine_pause_gcode", "template_custom_gcode",
     "nozzle_type", "nozzle_hrc","auxiliary_fan", "fan_direction", "nozzle_volume","upward_compatible_machine", "z_hop_types", "travel_slope", "retract_lift_enforce","support_chamber_temp_control","support_air_filtration","support_cooling_filter","cooling_filter_enabled","printer_structure","farthest_point_timelapse",
@@ -3392,14 +3412,37 @@ std::string PresetCollection::filament_id_by_type(const std::string& filament_ty
     return preset(first_visible_idx_by_type(filament_type)).filament_id;
 }
 
+std::string PresetCollection::family_root_name(const Preset &preset)
+{
+    const Preset          *current = &preset;
+    std::set<std::string>  seen;
+    while (!current->inherits().empty() && seen.insert(current->name).second) {
+        const Preset *parent = this->find_preset(current->inherits());
+        if (parent == nullptr)
+            break;
+        current = parent;
+    }
+    return current->name;
+}
+
 std::vector<std::string> PresetCollection::diameters_of_selected_printer()
 {
     std::set<std::string> diameters;
     auto printer_model = m_edited_preset.config.opt_string("printer_model");
+    // Orca: a custom printer offers only the sizes its own family has. Listing every size of the
+    // model would offer ones it lacks, and picking those switches to a system profile.
+    const bool        family_scoped = m_edited_preset.is_user();
+    const std::string family        = family_scoped ? this->family_root_name(m_edited_preset) : std::string();
     for (auto &preset : m_presets) {
-        if (preset.config.opt_string("printer_model") == printer_model)
-            diameters.insert(preset.config.opt_string("printer_variant"));
+        if (preset.config.opt_string("printer_model") != printer_model)
+            continue;
+        if (family_scoped && (preset.is_system || this->family_root_name(preset) != family))
+            continue;
+        diameters.insert(preset.config.opt_string("printer_variant"));
     }
+    // The edited preset is a copy held outside m_presets, so make sure its own size is offered.
+    diameters.insert(m_edited_preset.config.opt_string("printer_variant"));
+    diameters.erase(std::string());
     return std::vector<std::string>{diameters.begin(), diameters.end()};
 }
 
@@ -4007,6 +4050,21 @@ const Preset* PrinterPresetCollection::find_system_preset_by_model_and_variant(c
     return it != cend() ? &*it : nullptr;
 }
 
+const Preset *PrinterPresetCollection::find_system_preset_by_model_and_nozzle(const std::string &model_id, double nozzle_diameter) const
+{
+    if (model_id.empty())
+        return nullptr;
+
+    const auto it = std::find_if(cbegin(), cend(), [&](const Preset &preset) {
+        if (!preset.is_system || preset.config.opt_string("printer_model") != model_id)
+            return false;
+        const auto *nozzle = preset.config.opt<ConfigOptionFloats>("nozzle_diameter");
+        return nozzle != nullptr && !nozzle->values.empty() && std::abs(nozzle->values.front() - nozzle_diameter) < EPSILON;
+    });
+
+    return it != cend() ? &*it : nullptr;
+}
+
 const Preset *PrinterPresetCollection::find_custom_preset_by_model_and_variant(const std::string &model_id, const std::string &variant) const
 {
     if (model_id.empty()) { return nullptr; }
@@ -4590,6 +4648,46 @@ namespace PresetUtils {
                 out = Slic3r::resources_dir() + "/profiles/" + preset.vendor->id + "/" + pm->bed_texture;
         }
         return out;
+    }
+
+    static std::string asset_beside_preset(const Preset& preset, const std::string& suffix)
+    {
+        if (preset.file.empty())
+            return {};
+        boost::system::error_code ec;
+        const boost::filesystem::path stem = boost::filesystem::path(preset.file).replace_extension();
+        const std::string prefix = stem.filename().string() + suffix + ".";
+        for (boost::filesystem::directory_iterator it(stem.parent_path(), ec), end; !ec && it != end; it.increment(ec))
+            if (boost::starts_with(it->path().filename().string(), prefix))
+                return it->path().string();
+        return {};
+    }
+
+    std::string nozzle_variant_string(double nozzle_diameter)
+    {
+        std::ostringstream stream; // 2 decimals so 0.25 / 0.15 survive, then trim trailing zeros
+        stream << std::fixed << std::setprecision(2) << nozzle_diameter;
+        std::string s = stream.str();
+        if (s.find('.') != std::string::npos) {
+            s.erase(s.find_last_not_of('0') + 1);
+            if (s.back() == '.') s += '0'; // "1." -> "1.0"
+        }
+        return s;
+    }
+
+    std::string detached_printer_asset(PresetCollection &printers, const Preset& preset, const std::string& suffix)
+    {
+        const Preset          *current = &preset;
+        std::set<std::string>  seen;
+        while (current != nullptr && seen.insert(current->name).second) {
+            const std::string found = asset_beside_preset(*current, suffix);
+            if (!found.empty())
+                return found;
+            if (current->inherits().empty())
+                break;
+            current = printers.find_preset(current->inherits());
+        }
+        return {};
     }
 
     std::string system_printer_hotend_model(const Preset& preset)

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -3440,13 +3440,15 @@ std::vector<std::string> PresetCollection::diameters_of_selected_printer()
     std::set<std::string> diameters;
     auto printer_model = m_edited_preset.config.opt_string("printer_model");
     // Orca: a custom printer offers only the sizes its own family has. Listing every size of the
-    // model would offer ones it lacks, and picking those switches to a system profile.
+    // model would offer ones it lacks, and picking those switches to a different printer. A copy
+    // that still inherits shares the system profiles' root, so it keeps being offered all of them;
+    // only a detached copy, which roots at itself, is narrowed to its own variants.
     const bool        family_scoped = m_edited_preset.is_user();
     const std::string family        = family_scoped ? this->family_root_name(m_edited_preset) : std::string();
     for (auto &preset : m_presets) {
         if (preset.config.opt_string("printer_model") != printer_model)
             continue;
-        if (family_scoped && (preset.is_system || this->family_root_name(preset) != family))
+        if (family_scoped && this->family_root_name(preset) != family)
             continue;
         diameters.insert(preset.config.opt_string("printer_variant"));
     }

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -3054,6 +3054,16 @@ void PresetCollection::save_current_preset(const std::string &new_name, bool det
         final_inherits = inherits;
         unlock();
     }
+    // Orca: keep only the keys this preset type owns. A full copy - written when detaching - would
+    // otherwise carry runtime keys such as "extruder_nozzle_stats" that load_presets() strips again
+    // through remove_invalid_keys(), logging an error for the preset on every start. Done before the
+    // selection below, so the cleaned config is what gets copied into the edited preset.
+    if (auto it = this->find_preset_internal(new_name); it != m_presets.end() && it->name == new_name) {
+        const std::string dropped = Preset::remove_invalid_keys(it->config, this->default_preset_for(it->config).config);
+        if (!dropped.empty())
+            BOOST_LOG_TRIVIAL(debug) << __FUNCTION__ << ": " << it->name << " dropped keys not owned by a "
+                                     << Preset::get_type_string(m_type) << " preset: " << dropped;
+    }
     // 2) Activate the saved preset.
     this->select_preset_by_name(new_name, true);
     // 2) Store the active preset to disk.

--- a/src/libslic3r/Preset.hpp
+++ b/src/libslic3r/Preset.hpp
@@ -345,6 +345,13 @@ public:
     std::string&        inherits() { return Preset::inherits(this->config); }
     const std::string&  inherits() const { return Preset::inherits(const_cast<Preset*>(this)->config); }
 
+    // Orca: name of the printer this one was cloned from by "Detach from parent". Unlike inherits(),
+    // it carries no configuration - the copy is never rebased on it - and only keeps the source
+    // printer's process and filament profiles compatible. See is_compatible_with_parent_printer().
+    static std::string& cloned_from(DynamicPrintConfig &cfg) { return cfg.option<ConfigOptionString>("cloned_from", true)->value; }
+    std::string&        cloned_from() { return Preset::cloned_from(this->config); }
+    const std::string&  cloned_from() const { return Preset::cloned_from(const_cast<Preset*>(this)->config); }
+
     // Rewrite cfg's "inherits" to the resolved parent's canonical name. find_preset2 may
     // resolve a renamed parent, or a removed vendor profile auto-matched to the
     // OrcaFilamentLibrary; persisting the canonical name lets later plain find_preset()
@@ -832,6 +839,9 @@ public:
     // Generate a file path from a profile name. Add the ".ini" suffix if it is missing.
     std::string     path_from_name(const std::string &new_name, bool detach = false) const;
     std::string     path_for_preset(const Preset & preset) const;
+    // Orca: root of a preset's inheritance chain. Nozzle variants of one printer share a root, so it
+    // identifies the family a preset belongs to. Safe against a cycle in a hand-edited profile.
+    std::string     family_root_name(const Preset &preset);
 
     // Get the alias of a preset, setting it if it's empty
     std::string     get_preset_alias(Preset &preset, bool force = false);
@@ -979,6 +989,9 @@ public:
     const Preset&   default_preset_for(const DynamicPrintConfig &config) const override;
 
     const Preset*   find_system_preset_by_model_and_variant(const std::string &model_id, const std::string &variant) const;
+    // Orca: system preset of the same model with a matching nozzle. Matched on the diameter rather
+    // than the "printer_variant" string, so it does not depend on how that string is formatted.
+    const Preset*   find_system_preset_by_model_and_nozzle(const std::string &model_id, double nozzle_diameter) const;
     const Preset*   find_custom_preset_by_model_and_variant(const std::string &model_id, const std::string &variant) const;
 
     bool            only_default_printers() const;
@@ -995,6 +1008,12 @@ namespace PresetUtils {
 	const VendorProfile::PrinterModel* system_printer_model(const Preset &preset);
     std::string system_printer_bed_model(const Preset& preset);
     std::string system_printer_bed_texture(const Preset& preset);
+    // Orca: artwork copied beside a detached printer as "<preset><suffix>.<ext>", so it survives the
+    // source vendor being uninstalled. Found by name rather than stored in the config, keeping
+    // absolute paths out of the profile. Walks up the chain: nozzle variants share their root's.
+    std::string detached_printer_asset(PresetCollection &printers, const Preset& preset, const std::string& suffix);
+    // Orca: "printer_variant" as the nozzle dropdown spells it. The two are compared as strings.
+    std::string nozzle_variant_string(double nozzle_diameter);
     std::string system_printer_hotend_model(const Preset& preset);
 } // namespace PresetUtils
 

--- a/src/libslic3r/PresetBundle.cpp
+++ b/src/libslic3r/PresetBundle.cpp
@@ -4124,15 +4124,29 @@ Preset *PresetBundle::get_similar_printer_preset(std::string printer_model, std:
         boost::replace_all(prefer_printer, printer_variant_old, printer_variant);
     else if (auto n = prefer_printer.find(printer_variant_old); n != std::string::npos)
         prefer_printer = printer_model + " " + printer_variant_old + prefer_printer.substr(n + printer_variant_old.length());
-    if (auto iter = printer_presets.find(prefer_printer); iter != printer_presets.end()) {
+    // Orca: the substitution above is a no-op when the name carries no variant - custom printers are
+    // rarely named after a nozzle - and the lookup then returns the preset already selected, making
+    // the switch do nothing. Only take this shortcut when it really found the requested nozzle.
+    if (auto iter = printer_presets.find(prefer_printer); iter != printer_presets.end() &&
+        (printer_variant.empty() || iter->second->config.opt_string("printer_variant") == printer_variant)) {
         return iter->second;
     }
     if (printer_variant.empty())
         printer_variant = printer_variant_old;
-    for (auto& preset : printer_presets) {
-        if (preset.second->config.opt_string("printer_variant") == printer_variant)
+    // Orca: prefer the printer's own family. Matching purely on the variant picks by name order,
+    // which sends a custom printer to the system profile it was cloned from.
+    const std::string family = printers.family_root_name(printers.get_selected_preset());
+    Preset           *other_family = nullptr;
+    for (auto &preset : printer_presets) {
+        if (preset.second->config.opt_string("printer_variant") != printer_variant)
+            continue;
+        if (printers.family_root_name(*preset.second) == family)
             return preset.second;
+        if (other_family == nullptr)
+            other_family = preset.second;
     }
+    if (other_family != nullptr)
+        return other_family;
     return printer_presets.begin()->second;
 }
 

--- a/src/libslic3r/PresetBundle.cpp
+++ b/src/libslic3r/PresetBundle.cpp
@@ -258,6 +258,8 @@ DynamicPrintConfig PresetBundle::construct_full_config(
     out.erase("compatible_printers");
     out.erase("compatible_printers_condition");
     out.erase("inherits");
+    // Orca: printer-only bookkeeping, never part of the sliced config.
+    out.erase("cloned_from");
     // BBS: add logic for settings check between different system presets
     out.erase("different_settings_to_system");
 
@@ -4282,7 +4284,7 @@ std::vector<std::vector<std::vector<float>>> PresetBundle::get_full_flush_matrix
 }
 
 const std::set<std::string> ignore_settings_list ={
-    "inherits",
+    "inherits", "cloned_from",
     "print_settings_id", "filament_settings_id", "printer_settings_id"
 };
 
@@ -4546,6 +4548,8 @@ DynamicPrintConfig PresetBundle::full_fff_config(bool apply_extruder, std::optio
     out.erase("compatible_printers");
     out.erase("compatible_printers_condition");
     out.erase("inherits");
+    // Orca: printer-only bookkeeping, never part of the sliced config.
+    out.erase("cloned_from");
     //BBS: add logic for settings check between different system presets
     out.erase("different_settings_to_system");
 
@@ -4623,6 +4627,8 @@ DynamicPrintConfig PresetBundle::full_sla_config() const
     out.erase("compatible_printers");
     out.erase("compatible_printers_condition");
     out.erase("inherits");
+    // Orca: printer-only bookkeeping, never part of the sliced config.
+    out.erase("cloned_from");
 
     out.option<ConfigOptionString >("sla_print_settings_id",    true)->value  = this->sla_prints.get_selected_preset_name();
     out.option<ConfigOptionString >("sla_material_settings_id", true)->value  = this->sla_materials.get_selected_preset_name();

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -4687,6 +4687,14 @@ void PrintConfigDef::init_fff_params()
     def->set_default_value(new ConfigOptionString());
     def->cli = ConfigOptionDef::nocli;
 
+    // Orca: set by "Detach from parent". Nothing is inherited from this profile - the copy is
+    // complete - the name is only kept so the source printer's profiles stay compatible.
+    def = this->add("cloned_from", coString);
+    def->label = L("Cloned from profile");
+    def->tooltip = L("Name of the profile this standalone copy was created from.");
+    def->set_default_value(new ConfigOptionString());
+    def->cli = ConfigOptionDef::nocli;
+
     // The following value is to be stored into the project file (AMF, 3MF, Config ...)
     // and it contains a sum of "inherits" values over the print and filament profiles.
     def = this->add("inherits_group", coStrings);

--- a/src/slic3r/GUI/3DBed.cpp
+++ b/src/slic3r/GUI/3DBed.cpp
@@ -445,8 +445,10 @@ std::tuple<Bed3D::Type, std::string, std::string> Bed3D::detect_type(const Point
                     if (curr->is_system)
                         model_filename = PresetUtils::system_printer_bed_model(*curr);
                     else {
+                        // Orca: a detached copy owns its bed model, so it survives its vendor being removed.
+                        model_filename = PresetUtils::detached_printer_asset(bundle->printers, *curr, "_bed_model");
                         auto *printer_model = curr->config.opt<ConfigOptionString>("printer_model");
-                        if (printer_model != nullptr && ! printer_model->value.empty()) {
+                        if (model_filename.empty() && printer_model != nullptr && ! printer_model->value.empty()) {
                             model_filename = bundle->get_stl_model_for_printer_model(printer_model->value);
                         }
                     }

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -263,17 +263,9 @@ wxDEFINE_EVENT(EVT_NOTICE_FULL_SCREEN_CHANGED, IntEvent);
 #define PRINTER_PANEL_RADIUS (6) // ORCA
 #define BTN_SYNC_SIZE (wxSize(FromDIP(96), FromDIP(98)))
 
-static string get_diameter_string(float diameter)
-{
-    std::ostringstream stream; // ORCA ensure 0.25 returned as 0.25. previous code returned as 0.2 because of std::setprecision(1)
-    stream << std::fixed << std::setprecision(2) << diameter;  // Use 2 decimals to capture 0.25 / 0.15 reliably
-    std::string s = stream.str();
-    if (s.find('.') != std::string::npos) {   // Remove trailing zeros, but keep at least one decimal if needed
-        s.erase(s.find_last_not_of('0') + 1);
-        if (s.back() == '.') s += '0';        // Ensure "1." → "1.0"
-    }
-    return s;
-}
+// ORCA ensure 0.25 returned as 0.25. Delegates to PresetUtils so the spelling written into
+// "printer_variant" when a preset is saved cannot drift from the one shown in the dropdown.
+static string get_diameter_string(float diameter) { return Slic3r::PresetUtils::nozzle_variant_string(diameter); }
 
 template <typename T, typename OptionType>
 static void set_config_values(DynamicPrintConfig *config, const std::string &key, T value)
@@ -6452,6 +6444,17 @@ void Sidebar::update_printer_thumbnail()
             return;
         } catch (...) {}
         */
+
+        // Orca: a detached printer keeps a copy of the cover beside its preset, so it still has an
+        // icon once its vendor's profile folder is gone.
+        const auto own_cover = PresetUtils::detached_printer_asset(preset_bundle->printers, selected_preset, "_cover");
+        if (!own_cover.empty()) {
+            try {
+                p->image_printer->SetBitmap(create_scaled_bitmap(own_cover, this, PRINTER_THUMBNAIL_SIZE.GetHeight()));
+                printer_thumbnails[printer_type] = own_cover;
+                return;
+            } catch (...) {}
+        }
 
         // Orca: try to use the printer model cover as the thumbnail
         const auto model_name = selected_preset.config.opt_string("printer_model");
@@ -19830,8 +19833,10 @@ void Plater::set_bed_shape() const
         if (curr->is_system)
             texture_filename = PresetUtils::system_printer_bed_texture(*curr);
         else {
+            // Orca: a detached copy owns its bed texture, so it survives its vendor being removed.
+            texture_filename = PresetUtils::detached_printer_asset(bundle->printers, *curr, "_bed_texture");
             auto *printer_model = curr->config.opt<ConfigOptionString>("printer_model");
-            if (printer_model != nullptr && ! printer_model->value.empty()) {
+            if (texture_filename.empty() && printer_model != nullptr && ! printer_model->value.empty()) {
                 texture_filename = bundle->get_texture_for_printer_model(printer_model->value);
             }
         }

--- a/src/slic3r/GUI/PresetComboBoxes.cpp
+++ b/src/slic3r/GUI/PresetComboBoxes.cpp
@@ -1172,6 +1172,7 @@ void PlaterPresetComboBox::update()
     std::map<wxString, wxBitmap *> system_presets;
     std::map<wxString, wxBitmap *>  uncompatible_presets;
     std::unordered_set<std::string> system_printer_models;
+    std::unordered_set<std::string> user_printer_families; // ORCA: one entry per custom printer family
     std::map<wxString, wxString>   preset_descriptions;
     std::map<wxString, std::string> preset_filament_vendors;
     std::map<wxString, std::string> preset_filament_types;
@@ -1313,6 +1314,29 @@ void PlaterPresetComboBox::update()
         }
         else
         {
+            // ORCA: collapse a custom printer's nozzle variants into one entry, as the system branch
+            // above collapses by printer_model. Variants share an inheritance root, so each family is
+            // listed once under its root's name; unrelated custom printers of one model stay apart.
+            if (m_type == Preset::TYPE_PRINTER) {
+                const std::string family      = m_collection->family_root_name(preset);
+                const wxString    family_name = from_u8(is_selected && preset.is_dirty ? Preset::suffix_modified() + family : family);
+                if (user_printer_families.count(family) == 0) {
+                    preset_aliases[family_name] = family;
+                    nonsys_presets.emplace(family_name, bmp);
+                    user_printer_families.insert(family);
+                } else if (is_selected) {
+                    const wxString alternate_name = from_u8(preset.is_dirty ? family : Preset::suffix_modified() + family);
+                    if (nonsys_presets.erase(alternate_name))
+                        nonsys_presets.emplace(family_name, bmp);
+                    preset_aliases.erase(alternate_name);
+                    preset_aliases[family_name] = family;
+                }
+                if (is_selected) {
+                    selected_user_preset = family_name;
+                    tooltip = get_tooltip(preset);
+                }
+                continue;
+            }
             nonsys_presets.emplace(name, bmp);
             if (is_selected) {
                 selected_user_preset = name;

--- a/src/slic3r/GUI/PresetComboBoxes.cpp
+++ b/src/slic3r/GUI/PresetComboBoxes.cpp
@@ -1317,8 +1317,13 @@ void PlaterPresetComboBox::update()
             // ORCA: collapse a custom printer's nozzle variants into one entry, as the system branch
             // above collapses by printer_model. Variants share an inheritance root, so each family is
             // listed once under its root's name; unrelated custom printers of one model stay apart.
-            if (m_type == Preset::TYPE_PRINTER) {
-                const std::string family      = m_collection->family_root_name(preset);
+            const Preset *family_root = m_type == Preset::TYPE_PRINTER
+                                            ? m_collection->find_preset(m_collection->family_root_name(preset), false, true)
+                                            : nullptr;
+            // Only a detached printer forms a family of its own. A copy that still inherits roots at
+            // a system profile, and must keep its own name rather than borrow that profile's.
+            if (family_root != nullptr && family_root->is_user()) {
+                const std::string family      = family_root->name;
                 const wxString    family_name = from_u8(is_selected && preset.is_dirty ? Preset::suffix_modified() + family : family);
                 if (user_printer_families.count(family) == 0) {
                     preset_aliases[family_name] = family;

--- a/src/slic3r/GUI/SavePresetDialog.cpp
+++ b/src/slic3r/GUI/SavePresetDialog.cpp
@@ -111,57 +111,60 @@ SavePresetDialog::Item::Item(Preset::Type type, const std::string &suffix, wxBox
 
     sizer->Add(m_radio_group, 0, wxEXPAND | wxTOP | wxLEFT, BORDER_W);
 
-    if (parent->m_mode == comDevelop) {
-        // A new user copy of a system preset inherits from the selected system preset.
-        const std::string parent_name = sel_preset.is_system ? sel_preset.name : sel_preset.inherits();
-        const bool        can_detach  = !parent_name.empty();
+    // A new user copy of a system preset inherits from the selected system preset.
+    const std::string parent_name = sel_preset.is_system ? sel_preset.name : sel_preset.inherits();
+    const bool        can_detach  = !parent_name.empty();
 
-        wxBoxSizer *detach_sizer = new wxBoxSizer(wxHORIZONTAL);
+    wxBoxSizer *detach_sizer = new wxBoxSizer(wxHORIZONTAL);
 
-        auto detach_tooltip  = _L("Copies all inherited values from the parent into this preset and removes the parent relationship. Presets compatible only with the parent may become unsupported.");
+    auto detach_tooltip  = _L("Saves a standalone copy of the parent instead of inheriting from it, so later updates to the parent no longer change this preset. Process and filament profiles of the parent printer stay available.");
 
-        auto detach_checkbox = new ::CheckBox(parent);
-        detach_checkbox->SetToolTip(detach_tooltip);
+    auto detach_checkbox = new ::CheckBox(parent);
+    detach_checkbox->SetToolTip(detach_tooltip);
 
-        auto detach_label    = new wxStaticText(parent, wxID_ANY, _L("Detach from parent"));
-        detach_label->SetFont(::Label::Body_14);
-        detach_label->SetToolTip(detach_tooltip);
+    auto detach_label    = new wxStaticText(parent, wxID_ANY, _L("Detach from parent"));
+    detach_label->SetFont(::Label::Body_14);
+    detach_label->SetToolTip(detach_tooltip);
 
-        detach_sizer->Add(detach_checkbox, 0, wxALIGN_LEFT | wxLEFT, BORDER_W);
-        detach_sizer->Add(detach_label   , 0, wxALIGN_CENTRE_VERTICAL | wxLEFT, FromDIP(5));
-        sizer->Add(detach_sizer, 0, wxEXPAND | wxTOP, BORDER_W);
-        sizer->AddSpacer(FromDIP(5));
+    detach_sizer->Add(detach_checkbox, 0, wxALIGN_LEFT | wxLEFT, BORDER_W);
+    detach_sizer->Add(detach_label   , 0, wxALIGN_CENTRE_VERTICAL | wxLEFT, FromDIP(5));
+    sizer->Add(detach_sizer, 0, wxEXPAND | wxTOP, BORDER_W);
+    sizer->AddSpacer(FromDIP(5));
 
-        const wxString parent_text = can_detach ? from_u8(parent_name) : _L("Unique preset");
-        auto parent_label          = new wxStaticText(parent, wxID_ANY, parent_text);
-        parent_label->SetFont(::Label::Body_12);
-        parent_label->SetForegroundColour(wxColour("#6B6B6B"));
-        parent_label->SetToolTip(can_detach ? _L("Parent preset") : _L("This preset does not inherit from another preset."));
-        sizer->Add(parent_label, 0, wxEXPAND | wxLEFT, BORDER_W + FromDIP(24));
+    const wxString parent_text = can_detach ? from_u8(parent_name) : _L("Unique preset");
+    auto parent_label          = new wxStaticText(parent, wxID_ANY, parent_text);
+    parent_label->SetFont(::Label::Body_12);
+    parent_label->SetForegroundColour(wxColour("#6B6B6B"));
+    parent_label->SetToolTip(can_detach ? _L("Parent preset") : _L("This preset does not inherit from another preset."));
+    sizer->Add(parent_label, 0, wxEXPAND | wxLEFT, BORDER_W + FromDIP(24));
 
-        sizer->AddSpacer(FromDIP(5));
+    sizer->AddSpacer(FromDIP(5));
 
-        if (!can_detach) {
-            detach_checkbox->Disable();
-            detach_label->SetForegroundColour(wxColour("#6B6B6B"));
-        } 
-        else {
-            // Set initial state (unchecked by default)
-            detach_checkbox->SetValue(m_detach);
-            // Bind the checkbox event to update the detach state for this item
-            detach_checkbox->Bind(wxEVT_TOGGLEBUTTON, [this, detach_checkbox](wxCommandEvent&) { m_detach = detach_checkbox->GetValue(); });
+    if (!can_detach) {
+        detach_checkbox->Disable();
+        detach_label->SetForegroundColour(wxColour("#6B6B6B"));
+    } 
+    else {
+        // Set initial state (unchecked by default)
+        detach_checkbox->SetValue(m_detach);
+        detach_label->SetForegroundColour(wxColour("#363636"));
 
-            detach_label->SetForegroundColour(wxColour("#363636"));
-
-            auto on_toggle = [this, detach_checkbox]() {
-                detach_checkbox->SetValue(!detach_checkbox->GetValue());
-                wxCommandEvent ev(wxEVT_TOGGLEBUTTON, detach_checkbox->GetId());
-                ev.SetEventObject(detach_checkbox);
-                detach_checkbox->GetEventHandler()->ProcessEvent(ev);
-            };
-            detach_label->Bind(wxEVT_LEFT_DOWN,   [on_toggle](wxMouseEvent& e) {if(!e.LeftDClick()) on_toggle();});
-            detach_label->Bind(wxEVT_LEFT_DCLICK, [on_toggle](wxMouseEvent& e) {on_toggle();});
-        }
+        // Orca: toggle from an explicit click handler on the box as well as the label. On macOS
+        // the bitmap toggle button neither flips its own state nor emits wxEVT_TOGGLEBUTTON here,
+        // so clicking the box used to leave the checkbox unchanged. Not skipping the event keeps
+        // this to one toggle per click where the native button would otherwise react too.
+        auto on_toggle = [this, detach_checkbox]() {
+            detach_checkbox->SetValue(!detach_checkbox->GetValue()); // SetValue redraws the bitmap
+            m_detach = detach_checkbox->GetValue();
+        };
+        detach_checkbox->Bind(wxEVT_LEFT_DOWN, [on_toggle](wxMouseEvent&) { on_toggle(); });
+        detach_label->Bind(wxEVT_LEFT_DOWN,   [on_toggle](wxMouseEvent& e) {if(!e.LeftDClick()) on_toggle();});
+        detach_label->Bind(wxEVT_LEFT_DCLICK, [on_toggle](wxMouseEvent& e) {on_toggle();});
+        // Keyboard (space) still goes through the native toggle, so mirror the value across.
+        detach_checkbox->Bind(wxEVT_TOGGLEBUTTON, [this, detach_checkbox](wxCommandEvent& e) {
+            m_detach = detach_checkbox->GetValue();
+            e.Skip();
+        });
     }
     
     m_radio_group->Bind(wxEVT_COMMAND_RADIOBOX_SELECTED, [this](wxCommandEvent &e) {
@@ -293,15 +296,15 @@ void SavePresetDialog::Item::DoSetSize(int x, int y, int width, int height, int 
 //          SavePresetDialog
 //-----------------------------------------------
 
-SavePresetDialog::SavePresetDialog(wxWindow* parent, Preset::Type type, int mode, std::string suffix)
-    : DPIDialog(parent, wxID_ANY, _L("Save preset"), wxDefaultPosition, wxDefaultSize, wxCAPTION | wxCLOSE_BOX), m_mode(mode)
+SavePresetDialog::SavePresetDialog(wxWindow* parent, Preset::Type type, std::string suffix)
+    : DPIDialog(parent, wxID_ANY, _L("Save preset"), wxDefaultPosition, wxDefaultSize, wxCAPTION | wxCLOSE_BOX)
 {
     build(std::vector<Preset::Type>{type}, suffix);
     wxGetApp().UpdateDlgDarkUI(this);
 }
 
-SavePresetDialog::SavePresetDialog(wxWindow* parent, std::vector<Preset::Type> types, int mode, std::string suffix)
-    : DPIDialog(parent, wxID_ANY, _L("Save preset"), wxDefaultPosition, wxDefaultSize, wxCAPTION | wxCLOSE_BOX), m_mode(mode)
+SavePresetDialog::SavePresetDialog(wxWindow* parent, std::vector<Preset::Type> types, std::string suffix)
+    : DPIDialog(parent, wxID_ANY, _L("Save preset"), wxDefaultPosition, wxDefaultSize, wxCAPTION | wxCLOSE_BOX)
 {
     build(types, suffix);
     wxGetApp().UpdateDlgDarkUI(this);

--- a/src/slic3r/GUI/SavePresetDialog.hpp
+++ b/src/slic3r/GUI/SavePresetDialog.hpp
@@ -85,14 +85,13 @@ class SavePresetDialog : public DPIDialog
     wxStaticText*       m_label             {nullptr};
     wxBoxSizer*         m_radio_sizer       {nullptr};  
     ActionType          m_action            {UndefAction};
-    int                 m_mode;
 
     std::string         m_ph_printer_name;
     std::string         m_old_preset_name;
 
 public:
-    SavePresetDialog(wxWindow* parent, Preset::Type type, int mode = 0, std::string suffix = "");
-    SavePresetDialog(wxWindow* parent, std::vector<Preset::Type> types, int mode = 0, std::string suffix = "");
+    SavePresetDialog(wxWindow* parent, Preset::Type type, std::string suffix = "");
+    SavePresetDialog(wxWindow* parent, std::vector<Preset::Type> types, std::string suffix = "");
     ~SavePresetDialog();
 
     void AddItem(Preset::Type type, const std::string& suffix);

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -26,6 +26,7 @@
 
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/algorithm/string/replace.hpp>
+#include <boost/filesystem.hpp>
 #include "libslic3r/libslic3r.h"
 #include "slic3r/GUI/OptionsGroup.hpp"
 #include "wxExtensions.hpp"
@@ -7349,6 +7350,90 @@ void Tab::transfer_options(const std::string &name_from, const std::string &name
     load_current_preset();
 }
 
+namespace {
+
+// Orca: keep "printer_variant" matching the configured nozzle, and re-point "cloned_from" at the
+// system profile for that nozzle. The variant must not depend on any other preset being loaded:
+// the nozzle dropdown lists variants, so a stale one collapses the list to a single size.
+void sync_variant_and_cloned_from(Preset &preset)
+{
+    const auto *nozzle = preset.config.opt<ConfigOptionFloats>("nozzle_diameter");
+    if (nozzle == nullptr || nozzle->values.empty())
+        return;
+
+    const std::string variant = PresetUtils::nozzle_variant_string(nozzle->values.front());
+    if (!variant.empty())
+        preset.config.option<ConfigOptionString>("printer_variant", true)->value = variant;
+
+    // Without a system sibling the copy keeps the profiles of the variant it came from.
+    PresetBundle *bundle      = wxGetApp().preset_bundle;
+    std::string  &cloned_from = Preset::cloned_from(preset.config);
+    if (bundle == nullptr || cloned_from.empty())
+        return;
+    const Preset *sibling = bundle->printers.find_system_preset_by_model_and_nozzle(
+        preset.config.opt_string("printer_model"), nozzle->values.front());
+    if (sibling != nullptr && sibling->name != cloned_from)
+        cloned_from = sibling->name;
+}
+
+// Orca: bed model, bed texture and cover of a printer, resolved while its vendor is still installed.
+struct BedAssets { std::string bed_model, bed_texture, cover; };
+
+BedAssets resolve_bed_assets(const Preset &source)
+{
+    BedAssets assets;
+    PresetBundle *bundle = wxGetApp().preset_bundle;
+    if (bundle == nullptr)
+        return assets;
+
+    const std::string model_name = source.config.opt_string("printer_model");
+    // A system source resolves through its own vendor; a user source has none, so go by model name.
+    assets.bed_model   = source.vendor ? PresetUtils::system_printer_bed_model(source)
+                                       : bundle->get_stl_model_for_printer_model(model_name);
+    assets.bed_texture = source.vendor ? PresetUtils::system_printer_bed_texture(source)
+                                       : bundle->get_texture_for_printer_model(model_name);
+
+    if (model_name.empty())
+        return assets;
+    for (const auto &vendor : bundle->vendors)
+        for (const auto &vendor_model : vendor.second.models)
+            if (vendor_model.name == model_name) {
+                const boost::filesystem::path cover = boost::filesystem::path(resources_dir()) / "profiles" /
+                                                      vendor.second.id / (model_name + "_cover.png");
+                if (boost::filesystem::exists(cover))
+                    assets.cover = cover.string();
+            }
+    return assets;
+}
+
+// Orca: a detached printer has to own its artwork - the vendor folder it came from is deleted when
+// that vendor is uninstalled. Copied beside the preset and found by name, so no absolute paths end
+// up in the profile. See PresetUtils::detached_printer_asset().
+void copy_bed_assets_to_preset(const BedAssets &assets, Preset &target)
+{
+    namespace fs = boost::filesystem;
+    if (target.file.empty())
+        return;
+
+    const fs::path stem = fs::path(target.file).replace_extension();
+    const auto copy_asset = [&stem](const std::string &from, const std::string &suffix) {
+        boost::system::error_code ec;
+        if (from.empty() || !fs::exists(from, ec))
+            return;
+        const fs::path to = stem.string() + suffix + fs::path(from).extension().string();
+        fs::create_directories(to.parent_path(), ec);
+        fs::copy_file(from, to, fs::copy_option::overwrite_if_exists, ec);
+        if (ec)
+            BOOST_LOG_TRIVIAL(error) << __FUNCTION__ << ": failed to copy " << from << " -> " << to << ": " << ec.message();
+    };
+
+    copy_asset(assets.bed_model, "_bed_model");
+    copy_asset(assets.bed_texture, "_bed_texture");
+    copy_asset(assets.cover, "_cover");
+}
+
+} // namespace
+
 // Save the current preset into file.
 // This removes the "dirty" flag of the preset, possibly creates a new preset under a new name,
 // and activates the new preset.
@@ -7366,7 +7451,7 @@ void Tab::save_preset(std::string name /*= ""*/, bool detach, bool save_to_proje
     // focus currently.is there anything better than this ?
 //!	m_tabctrl->OnSetFocus();
     if (from_input) {
-        SavePresetDialog dlg(m_parent, m_type, m_mode, detach ? _u8L("Detached") : "");
+        SavePresetDialog dlg(m_parent, m_type, detach ? _u8L("Detached") : "");
         dlg.Show(false);
         dlg.input_name_from_other(input_name);
         wxCommandEvent evt(wxEVT_TEXT, GetId());
@@ -7377,7 +7462,7 @@ void Tab::save_preset(std::string name /*= ""*/, bool detach, bool save_to_proje
     }
 
     if (name.empty()) {
-        SavePresetDialog dlg(m_parent, m_type, m_mode, detach ? _u8L("Detached") : "");
+        SavePresetDialog dlg(m_parent, m_type, detach ? _u8L("Detached") : "");
         if (!m_just_edit) {
             if (dlg.ShowModal() != wxID_OK)
                 return;
@@ -7407,6 +7492,18 @@ void Tab::save_preset(std::string name /*= ""*/, bool detach, bool save_to_proje
         if (nullptr != _curr_printer && compatible_printers && compatible_printers->values.empty())
             compatible_printers->values.push_back(_curr_printer->name);
     }
+    // Orca: "Detach from parent" saves a full copy with no "inherits", so the parent can never
+    // rebase it. It is still the same machine, so remember the parent in "cloned_from" to keep its
+    // process and filament profiles compatible. An already detached preset keeps its own origin.
+    const bool detaching_printer = detach && m_type == Preset::TYPE_PRINTER;
+    // Resolved here, while the source is still the edited preset and its vendor still installed.
+    const BedAssets detach_assets = detaching_printer ? resolve_bed_assets(edited_preset) : BedAssets();
+    if (m_type == Preset::TYPE_PRINTER) {
+        std::string &cloned_from = Preset::cloned_from(edited_preset.config);
+        if (detach && cloned_from.empty())
+            cloned_from = edited_preset.is_system ? edited_preset.name : edited_preset.inherits();
+        sync_variant_and_cloned_from(edited_preset);
+    }
     // Save the preset into Slic3r::data_dir / presets / section_name / preset_name.json
     m_presets->save_current_preset(name, detach, save_to_project, nullptr);
 
@@ -7417,6 +7514,10 @@ void Tab::save_preset(std::string name /*= ""*/, bool detach, bool save_to_proje
         BOOST_LOG_TRIVIAL(info) << "create new preset failed";
         return;
     }
+
+    //BBS: the preset file only exists after the save, so the artwork is copied beside it here.
+    if (detaching_printer)
+        copy_bed_assets_to_preset(detach_assets, *new_preset);
 
     // set sync_info for sync service
     if (exist_preset) {

--- a/tests/libslic3r/CMakeLists.txt
+++ b/tests/libslic3r/CMakeLists.txt
@@ -17,6 +17,7 @@ add_executable(${_TEST_NAME}_tests
     test_preset_bundle_loading.cpp
     test_preset_setting_id.cpp
     test_preset_diff.cpp
+    test_preset_compatibility.cpp
     test_vendor_cache.cpp
     test_elephant_foot_compensation.cpp
     test_fill_corner_smoothing.cpp

--- a/tests/libslic3r/test_preset_compatibility.cpp
+++ b/tests/libslic3r/test_preset_compatibility.cpp
@@ -326,8 +326,11 @@ TEST_CASE("the nozzle list is scoped to the selected printer's family", "[Preset
         Preset::inherits(config) = inherits;
         bundle.printers.load_preset(std::string(), name, config, /*select=*/false).is_system = is_system;
     };
-    for (const char *v : {"0.4", "0.6", "0.8", "1.0"})
-        add_printer(std::string("Elegoo OrangeStorm Giga ") + v + " nozzle", "", v, /*is_system=*/true);
+    // As the shipped profiles are arranged: one base variant, the rest inheriting from it.
+    add_printer("Elegoo OrangeStorm Giga 0.4 nozzle", "", "0.4", /*is_system=*/true);
+    for (const char *v : {"0.6", "0.8", "1.0"})
+        add_printer(std::string("Elegoo OrangeStorm Giga ") + v + " nozzle",
+                    "Elegoo OrangeStorm Giga 0.4 nozzle", v, /*is_system=*/true);
     add_printer("SirPrintALot", "", "0.6", /*is_system=*/false);
     add_printer("SirPrintALot 0.8", "SirPrintALot", "0.8", false);
 
@@ -335,6 +338,14 @@ TEST_CASE("the nozzle list is scoped to the selected printer's family", "[Preset
         bundle.printers.select_preset_by_name("SirPrintALot", true);
         const auto diameters = bundle.printers.diameters_of_selected_printer();
         CHECK(diameters == std::vector<std::string>{"0.6", "0.8"});
+    }
+    SECTION("a copy that still inherits keeps every size of the system family") {
+        // Not detached: it chains up to the same root as the system variants, so narrowing to the
+        // family must not hide them - it is one of them, with an extra nozzle size.
+        add_printer("Giga 1.2 custom", "Elegoo OrangeStorm Giga 0.6 nozzle", "1.2", /*is_system=*/false);
+        bundle.printers.select_preset_by_name("Giga 1.2 custom", true);
+        const auto diameters = bundle.printers.diameters_of_selected_printer();
+        CHECK(diameters == std::vector<std::string>{"0.4", "0.6", "0.8", "1.0", "1.2"});
     }
     SECTION("a system printer still offers every size of its model") {
         bundle.printers.select_preset_by_name("Elegoo OrangeStorm Giga 0.6 nozzle", true);

--- a/tests/libslic3r/test_preset_compatibility.cpp
+++ b/tests/libslic3r/test_preset_compatibility.cpp
@@ -1,0 +1,264 @@
+#include <catch2/catch_all.hpp>
+
+#include "libslic3r/PresetBundle.hpp"
+
+#include <boost/filesystem.hpp>
+
+#include "test_utils.hpp"
+
+using namespace Slic3r;
+
+// A printer preset saved with "Detach from parent" stores a full 1:1 copy of its source printer's
+// config and drops the "inherits" link, so later updates to the source can no longer change it.
+// The source's name is kept in "cloned_from" so that the process and filament profiles listing the
+// source printer in "compatible_printers" stay available for the copy.
+namespace {
+
+Preset make_printer(const std::string &name, const std::string &inherits, const std::string &cloned_from)
+{
+    Preset printer(Preset::TYPE_PRINTER, name);
+    printer.inherits() = inherits;
+    printer.cloned_from() = cloned_from;
+    return printer;
+}
+
+Preset make_process_for(const std::string &printer_name)
+{
+    Preset process(Preset::TYPE_PRINT, "0.20mm Standard @" + printer_name);
+    process.config.set_key_value("compatible_printers", new ConfigOptionStrings{printer_name});
+    return process;
+}
+
+bool compatible(const Preset &process, const Preset &printer)
+{
+    return is_compatible_with_printer(PresetWithVendorProfile(process, nullptr), PresetWithVendorProfile(printer, nullptr));
+}
+
+} // namespace
+
+TEST_CASE("a printer preset stays compatible with the profiles of the printer it was cloned from", "[PresetCompatibility]")
+{
+    const Preset process = make_process_for("Source Printer 0.4 nozzle");
+
+    SECTION("an inheriting copy is compatible, as before") {
+        CHECK(compatible(process, make_printer("My Printer", "Source Printer 0.4 nozzle", "")));
+    }
+    SECTION("a detached copy is compatible through cloned_from") {
+        CHECK(compatible(process, make_printer("My Printer", "", "Source Printer 0.4 nozzle")));
+    }
+    SECTION("a copy of a different printer is not compatible") {
+        CHECK_FALSE(compatible(process, make_printer("My Printer", "", "Other Printer 0.6 nozzle")));
+    }
+    SECTION("a printer with neither link is not compatible") {
+        CHECK_FALSE(compatible(process, make_printer("My Printer", "", "")));
+    }
+}
+
+TEST_CASE("saving a printer preset detached copies the config and records the source printer", "[PresetCompatibility]")
+{
+    ScopedTemporaryDir         temp_dir;
+    PresetBundle               bundle;
+    PresetsConfigSubstitutions substitutions;
+
+    // Loading an empty directory just points the collection at it, so the saved preset lands there.
+    bundle.printers.load_presets(temp_dir.path().string(), PRESET_PRINTER_NAME, substitutions,
+                                 ForwardCompatibilitySubstitutionRule::Disable);
+
+    // Stand in for a system printer, carrying one value the copy has to bring over on its own.
+    DynamicPrintConfig source_config(bundle.printers.default_preset().config);
+    source_config.set_key_value("printable_height", new ConfigOptionFloat(123.0));
+    Preset &source = bundle.printers.load_preset(std::string(), "Source Printer 0.4 nozzle", source_config, /*select=*/true);
+    source.is_system = true;
+
+    // Tab::save_preset seeds "cloned_from" on the edited preset before saving a detached copy.
+    Preset::cloned_from(bundle.printers.get_edited_preset().config) = "Source Printer 0.4 nozzle";
+    bundle.printers.save_current_preset("My Printer", /*detach=*/true, /*save_to_project=*/false);
+
+    const Preset *copy = bundle.printers.find_preset("My Printer");
+    REQUIRE(copy != nullptr);
+    CHECK(copy->inherits().empty());
+    CHECK(copy->cloned_from() == "Source Printer 0.4 nozzle");
+    CHECK_THAT(copy->config.opt_float("printable_height"), Catch::Matchers::WithinAbs(123.0, 1e-9));
+    CHECK(compatible(make_process_for("Source Printer 0.4 nozzle"), *copy));
+}
+
+// Detaching exists so the copy survives its parent going away: disabling the source printer in the
+// system profiles, or a vendor dropping it. An inheriting preset is skipped when its parent cannot
+// be resolved, which silently loses the printer and falls back to a system profile.
+TEST_CASE("a detached printer preset still loads once its source printer is gone", "[PresetCompatibility]")
+{
+    ScopedTemporaryDir         temp_dir;
+    PresetBundle               bundle;
+    PresetsConfigSubstitutions substitutions;
+
+    const auto write_printer = [&](const std::string &name, const std::string &inherits, const std::string &cloned_from) {
+        DynamicPrintConfig config(bundle.printers.default_preset().config);
+        Preset::inherits(config)    = inherits;
+        Preset::cloned_from(config) = cloned_from;
+        config.set_key_value("printable_height", new ConfigOptionFloat(123.0));
+        const boost::filesystem::path file = temp_dir.path() / PRESET_PRINTER_NAME / (name + ".json");
+        boost::filesystem::create_directories(file.parent_path());
+        config.save_to_json(file.string(), name, "User", "1.0.0");
+    };
+
+    // Neither parent is present in the collection, standing in for a printer the user disabled.
+    write_printer("Detached Copy", /*inherits=*/"", /*cloned_from=*/"Source Printer 0.4 nozzle");
+    write_printer("Inheriting Copy", /*inherits=*/"Source Printer 0.4 nozzle", /*cloned_from=*/"");
+
+    bundle.printers.load_presets(temp_dir.path().string(), PRESET_PRINTER_NAME, substitutions,
+                                 ForwardCompatibilitySubstitutionRule::Disable);
+
+    const Preset *detached = bundle.printers.find_preset("Detached Copy");
+    REQUIRE(detached != nullptr);
+    CHECK(detached->cloned_from() == "Source Printer 0.4 nozzle");
+    CHECK_THAT(detached->config.opt_float("printable_height"), Catch::Matchers::WithinAbs(123.0, 1e-9));
+    // Nothing hides it: a user preset has no vendor, so the app config cannot mark it invisible.
+    CHECK(detached->vendor == nullptr);
+    // It stays compatible with the profiles of the printer it was cloned from.
+    CHECK(compatible(make_process_for("Source Printer 0.4 nozzle"), *detached));
+
+    // Contrast: the inheriting preset is dropped, which is the failure detaching avoids.
+    CHECK(bundle.printers.find_preset("Inheriting Copy") == nullptr);
+}
+
+// Nozzle variants of a detached printer are children of it, so they inherit its "cloned_from".
+// Saving one with a different nozzle has to re-point that at the matching system sibling, or the
+// child keeps offering the source variant's process profiles.
+TEST_CASE("the system sibling for a nozzle size is found by diameter", "[PresetCompatibility]")
+{
+    PresetBundle bundle;
+
+    const auto add_system_variant = [&](const std::string &name, const std::string &variant, double nozzle) {
+        DynamicPrintConfig config(bundle.printers.default_preset().config);
+        config.set_key_value("printer_model", new ConfigOptionString("Elegoo OrangeStorm Giga"));
+        config.set_key_value("printer_variant", new ConfigOptionString(variant));
+        config.set_key_value("nozzle_diameter", new ConfigOptionFloats{nozzle});
+        bundle.printers.load_preset(std::string(), name, config, /*select=*/false).is_system = true;
+    };
+    add_system_variant("Elegoo OrangeStorm Giga 0.4 nozzle", "0.4", 0.4);
+    add_system_variant("Elegoo OrangeStorm Giga 0.6 nozzle", "0.6", 0.6);
+
+    const Preset *match = bundle.printers.find_system_preset_by_model_and_nozzle("Elegoo OrangeStorm Giga", 0.4);
+    REQUIRE(match != nullptr);
+    CHECK(match->name == "Elegoo OrangeStorm Giga 0.4 nozzle");
+    CHECK(match->config.opt_string("printer_variant") == "0.4");
+
+    // A nozzle no system variant provides has no sibling, so cloned_from is left alone.
+    CHECK(bundle.printers.find_system_preset_by_model_and_nozzle("Elegoo OrangeStorm Giga", 1.2) == nullptr);
+    // The model has to match too, so an unrelated printer never gets re-pointed.
+    CHECK(bundle.printers.find_system_preset_by_model_and_nozzle("Some Other Printer", 0.4) == nullptr);
+}
+
+// Nozzle variants of a detached printer are children of it, and only the root gets copies of the bed
+// artwork. Resolving an asset has to walk up the chain, or a child shows no bed and a placeholder
+// icon once the source vendor is uninstalled.
+TEST_CASE("a nozzle variant inherits the bed artwork copied beside its root", "[PresetCompatibility]")
+{
+    ScopedTemporaryDir         temp_dir;
+    PresetBundle               bundle;
+    PresetsConfigSubstitutions substitutions;
+
+    // A detached root lives in "base/", which load_presets loads first so parents precede children.
+    const auto write_printer = [&](const std::string &name, const std::string &inherits, bool is_root) {
+        DynamicPrintConfig config(bundle.printers.default_preset().config);
+        Preset::inherits(config) = inherits;
+        boost::filesystem::path dir = temp_dir.path() / PRESET_PRINTER_NAME;
+        if (is_root)
+            dir /= "base";
+        const boost::filesystem::path file = dir / (name + ".json");
+        boost::filesystem::create_directories(file.parent_path());
+        config.save_to_json(file.string(), name, "User", "1.0.0");
+        return file;
+    };
+
+    const boost::filesystem::path root_file = write_printer("SirPrintALot", "", /*is_root=*/true);
+    write_printer("SirPrintALot 0.8", "SirPrintALot", /*is_root=*/false);
+    // Only the root carries the copies, exactly as Tab::save_preset writes them on detach.
+    const boost::filesystem::path texture = root_file.parent_path() / "SirPrintALot_bed_texture.svg";
+    boost::filesystem::ofstream(texture) << "<svg/>";
+
+    bundle.printers.load_presets(temp_dir.path().string(), PRESET_PRINTER_NAME, substitutions,
+                                 ForwardCompatibilitySubstitutionRule::Disable);
+
+    const Preset *root  = bundle.printers.find_preset("SirPrintALot");
+    const Preset *child = bundle.printers.find_preset("SirPrintALot 0.8");
+    REQUIRE(root != nullptr);
+    REQUIRE(child != nullptr);
+
+    CHECK(PresetUtils::detached_printer_asset(bundle.printers, *root, "_bed_texture") == texture.string());
+    // The child has no copy of its own and has to find the root's.
+    CHECK(PresetUtils::detached_printer_asset(bundle.printers, *child, "_bed_texture") == texture.string());
+    // An asset nobody in the family provides stays unresolved rather than matching something else.
+    CHECK(PresetUtils::detached_printer_asset(bundle.printers, *child, "_bed_model").empty());
+}
+
+// The printer dropdown collapses a custom printer's nozzle variants into one entry keyed on the
+// inheritance root, mirroring how system presets collapse by printer_model. Detaching starts a new
+// root, so detaching once per nozzle size yields separate entries - variants have to be children.
+TEST_CASE("nozzle variants group under one root, separate detaches do not", "[PresetCompatibility]")
+{
+    PresetBundle bundle;
+
+    const auto add_printer = [&](const std::string &name, const std::string &inherits) {
+        DynamicPrintConfig config(bundle.printers.default_preset().config);
+        config.set_key_value("printer_model", new ConfigOptionString("Elegoo OrangeStorm Giga"));
+        Preset::inherits(config) = inherits;
+        bundle.printers.load_preset(std::string(), name, config, /*select=*/false);
+    };
+
+    add_printer("SirPrintALot", "");                    // detached once: the family root
+    add_printer("SirPrintALot 0.8", "SirPrintALot");    // child, same family
+    add_printer("SirPrintALot 0.4", "SirPrintALot 0.8");// grandchild, still the same family
+    add_printer("Detached Again", "");                  // a second detach: its own family
+
+    auto &printers = bundle.printers;
+    const auto root_of = [&](const std::string &name) {
+        const Preset *preset = printers.find_preset(name);
+        REQUIRE(preset != nullptr);
+        return printers.family_root_name(*preset);
+    };
+
+    // Naming is irrelevant - lineage decides. All three collapse to the one entry "SirPrintALot".
+    CHECK(root_of("SirPrintALot") == "SirPrintALot");
+    CHECK(root_of("SirPrintALot 0.8") == "SirPrintALot");
+    CHECK(root_of("SirPrintALot 0.4") == "SirPrintALot");
+    // Detaching a second time makes a separate entry even though the printer_model is identical.
+    CHECK(root_of("Detached Again") == "Detached Again");
+}
+
+// Deleting a detached printer has to take its copied artwork with it, or the profile directory
+// accumulates bed models, textures and covers that no preset refers to any more.
+TEST_CASE("deleting a detached printer removes the artwork copied beside it", "[PresetCompatibility]")
+{
+    ScopedTemporaryDir temp_dir;
+    PresetBundle       bundle;
+
+    const boost::filesystem::path dir = temp_dir.path() / PRESET_PRINTER_NAME / "base";
+    boost::filesystem::create_directories(dir);
+
+    DynamicPrintConfig config(bundle.printers.default_preset().config);
+    const boost::filesystem::path file = dir / "SirPrintALot.json";
+    config.save_to_json(file.string(), "SirPrintALot", "User", "1.0.0");
+
+    std::vector<boost::filesystem::path> assets;
+    for (const std::string &name : {"SirPrintALot_bed_model.stl", "SirPrintALot_bed_texture.svg", "SirPrintALot_cover.png"}) {
+        assets.push_back(dir / name);
+        boost::filesystem::ofstream(assets.back()) << "x";
+    }
+    // A neighbouring preset's artwork must survive: the prefix match has to be exact.
+    const boost::filesystem::path other = dir / "SirPrintALotOther_cover.png";
+    boost::filesystem::ofstream(other) << "x";
+
+    PresetsConfigSubstitutions substitutions;
+    bundle.printers.load_presets(temp_dir.path().string(), PRESET_PRINTER_NAME, substitutions,
+                                 ForwardCompatibilitySubstitutionRule::Disable);
+    Preset *preset = bundle.printers.find_preset("SirPrintALot");
+    REQUIRE(preset != nullptr);
+
+    preset->remove_files(/*cloud_already_deleted=*/true);
+
+    CHECK_FALSE(boost::filesystem::exists(file));
+    for (const auto &asset : assets)
+        CHECK_FALSE(boost::filesystem::exists(asset));
+    CHECK(boost::filesystem::exists(other));
+}

--- a/tests/libslic3r/test_preset_compatibility.cpp
+++ b/tests/libslic3r/test_preset_compatibility.cpp
@@ -387,3 +387,41 @@ TEST_CASE("switching nozzle works when the preset name has no nozzle size in it"
         CHECK(target->name == "SirPrintALot");
     }
 }
+
+// A detached copy is written as a full config, so any runtime key sitting on the edited preset would
+// land in the file. load_presets() strips those again via remove_invalid_keys() and logs an error
+// for the preset on every start, so the save has to keep to the keys the preset type owns.
+TEST_CASE("saving a preset writes only keys its type owns", "[PresetCompatibility]")
+{
+    ScopedTemporaryDir         temp_dir;
+    PresetBundle               bundle;
+    PresetsConfigSubstitutions substitutions;
+
+    bundle.printers.load_presets(temp_dir.path().string(), PRESET_PRINTER_NAME, substitutions,
+                                 ForwardCompatibilitySubstitutionRule::Disable);
+
+    DynamicPrintConfig source_config(bundle.printers.default_preset().config);
+    source_config.set_key_value("printable_height", new ConfigOptionFloat(123.0));
+    Preset &source = bundle.printers.load_preset(std::string(), "Source Printer 0.4 nozzle", source_config, /*select=*/true);
+    source.is_system = true;
+    // A registered option that is not a printer preset key, as the app leaves on the edited preset.
+    bundle.printers.get_edited_preset().config.set_key_value("extruder_nozzle_stats", new ConfigOptionStrings{"Standard#1"});
+
+    bundle.printers.save_current_preset("My Printer", /*detach=*/true, /*save_to_project=*/false);
+
+    const Preset *copy = bundle.printers.find_preset("My Printer");
+    REQUIRE(copy != nullptr);
+    // find_preset() yields the edited preset for the selected index, so this also covers that copy.
+    CHECK_FALSE(copy->config.has("extruder_nozzle_stats"));
+    // The full copy is still complete: a printer key carried over from the source survives.
+    CHECK_THAT(copy->config.opt_float("printable_height"), Catch::Matchers::WithinAbs(123.0, 1e-9));
+    CHECK(copy->inherits().empty());
+
+    // And the file on disk carries neither, so it loads without a remove_invalid_keys() error.
+    std::map<std::string, std::string> key_values;
+    std::string                        reason;
+    DynamicPrintConfig                 reloaded;
+    reloaded.load_from_json(copy->file, ForwardCompatibilitySubstitutionRule::Disable, key_values, reason);
+    CHECK(reason.empty());
+    CHECK_FALSE(reloaded.has("extruder_nozzle_stats"));
+}

--- a/tests/libslic3r/test_preset_compatibility.cpp
+++ b/tests/libslic3r/test_preset_compatibility.cpp
@@ -436,3 +436,43 @@ TEST_CASE("saving a preset writes only keys its type owns", "[PresetCompatibilit
     CHECK(reason.empty());
     CHECK_FALSE(reloaded.has("extruder_nozzle_stats"));
 }
+
+// The printer dropdown collapses a custom printer's variants under its family root's name. That is
+// only correct when the root is the custom printer itself: a copy saved without detaching roots at a
+// system profile, and must keep its own name rather than be listed under that profile's.
+TEST_CASE("only a detached printer roots at a user preset", "[PresetCompatibility]")
+{
+    PresetBundle bundle;
+
+    const auto add_printer = [&](const std::string &name, const std::string &inherits, bool is_system) {
+        DynamicPrintConfig config(bundle.printers.default_preset().config);
+        config.set_key_value("printer_model", new ConfigOptionString("Elegoo OrangeStorm Giga"));
+        Preset::inherits(config) = inherits;
+        bundle.printers.load_preset(std::string(), name, config, /*select=*/false).is_system = is_system;
+    };
+    add_printer("fdm_elegoo_common", "", /*is_system=*/true);
+    add_printer("Elegoo OrangeStorm Giga 0.4 nozzle", "fdm_elegoo_common", true);
+    add_printer("Elegoo OrangeStorm Giga 0.6 nozzle", "Elegoo OrangeStorm Giga 0.4 nozzle", true);
+    add_printer("Giga 1.2 custom", "Elegoo OrangeStorm Giga 0.6 nozzle", /*is_system=*/false);
+    add_printer("Detached Giga", "", /*is_system=*/false);
+    add_printer("Detached Giga 0.8", "Detached Giga", false);
+
+    auto &printers = bundle.printers;
+    const auto root_of = [&](const std::string &name) {
+        const Preset *preset = printers.find_preset(name, false, /*real=*/true);
+        REQUIRE(preset != nullptr);
+        return printers.find_preset(printers.family_root_name(*preset), false, true);
+    };
+
+    // A copy that still inherits roots at a system profile, so it is not collapsed and keeps its name.
+    const Preset *inheriting_root = root_of("Giga 1.2 custom");
+    REQUIRE(inheriting_root != nullptr);
+    CHECK(inheriting_root->name == "fdm_elegoo_common");
+    CHECK_FALSE(inheriting_root->is_user());
+
+    // A detached printer roots at itself, and its variants root at it, so they collapse together.
+    const Preset *detached_root = root_of("Detached Giga 0.8");
+    REQUIRE(detached_root != nullptr);
+    CHECK(detached_root->name == "Detached Giga");
+    CHECK(detached_root->is_user());
+}

--- a/tests/libslic3r/test_preset_compatibility.cpp
+++ b/tests/libslic3r/test_preset_compatibility.cpp
@@ -262,3 +262,128 @@ TEST_CASE("deleting a detached printer removes the artwork copied beside it", "[
         CHECK_FALSE(boost::filesystem::exists(asset));
     CHECK(boost::filesystem::exists(other));
 }
+
+// Switching nozzle size from the sidebar has to stay within the printer you are on. A custom printer
+// has no alias (save_current_preset clears it), so the name-based match in get_similar_printer_preset
+// always misses for one and used to fall through to the first matching variant by name - which sorts
+// the system profile ahead of a custom one and silently switched printers.
+TEST_CASE("switching nozzle size stays within the same printer family", "[PresetCompatibility]")
+{
+    PresetBundle bundle;
+
+    const auto add_printer = [&](const std::string &name, const std::string &inherits,
+                                 const std::string &variant, double nozzle, bool is_system) {
+        DynamicPrintConfig config(bundle.printers.default_preset().config);
+        config.set_key_value("printer_model", new ConfigOptionString("Elegoo OrangeStorm Giga"));
+        config.set_key_value("printer_variant", new ConfigOptionString(variant));
+        config.set_key_value("nozzle_diameter", new ConfigOptionFloats{nozzle});
+        Preset::inherits(config) = inherits;
+        Preset &preset = bundle.printers.load_preset(std::string(), name, config, /*select=*/false);
+        preset.is_system = is_system;
+        // Only system presets carry an alias; save_current_preset clears it for user copies.
+        preset.alias = is_system ? name : std::string();
+    };
+
+    // System variants, and a detached custom printer with its own 0.8 child. "Elegoo..." sorts
+    // before "SirPrintALot", so an alphabetical fallback picks the system profile.
+    add_printer("Elegoo OrangeStorm Giga 0.6 nozzle", "", "0.6", 0.6, /*is_system=*/true);
+    add_printer("Elegoo OrangeStorm Giga 0.8 nozzle", "Elegoo OrangeStorm Giga 0.6 nozzle", "0.8", 0.8, true);
+    add_printer("SirPrintALot", "", "0.6", 0.6, /*is_system=*/false);
+    add_printer("SirPrintALot 0.8", "SirPrintALot", "0.8", 0.8, false);
+
+    SECTION("from a custom printer it picks the custom variant, not the system one") {
+        bundle.printers.select_preset_by_name("SirPrintALot 0.8", true);
+        Preset *target = bundle.get_similar_printer_preset({}, "0.6");
+        REQUIRE(target != nullptr);
+        CHECK(target->name == "SirPrintALot");
+    }
+    SECTION("the other direction works too, custom 0.6 -> custom 0.8") {
+        bundle.printers.select_preset_by_name("SirPrintALot", true);
+        Preset *target = bundle.get_similar_printer_preset({}, "0.8");
+        REQUIRE(target != nullptr);
+        CHECK(target->name == "SirPrintALot 0.8");
+    }
+    SECTION("from a system printer it still picks the system variant") {
+        bundle.printers.select_preset_by_name("Elegoo OrangeStorm Giga 0.8 nozzle", true);
+        Preset *target = bundle.get_similar_printer_preset({}, "0.6");
+        REQUIRE(target != nullptr);
+        CHECK(target->name == "Elegoo OrangeStorm Giga 0.6 nozzle");
+    }
+}
+
+// The nozzle dropdown lists sizes for the selected printer. On a custom printer it has to list only
+// the sizes that family actually has: offering a size it lacks means picking it necessarily switches
+// to the system profile the printer was cloned from.
+TEST_CASE("the nozzle list is scoped to the selected printer's family", "[PresetCompatibility]")
+{
+    PresetBundle bundle;
+
+    const auto add_printer = [&](const std::string &name, const std::string &inherits,
+                                 const std::string &variant, bool is_system) {
+        DynamicPrintConfig config(bundle.printers.default_preset().config);
+        config.set_key_value("printer_model", new ConfigOptionString("Elegoo OrangeStorm Giga"));
+        config.set_key_value("printer_variant", new ConfigOptionString(variant));
+        Preset::inherits(config) = inherits;
+        bundle.printers.load_preset(std::string(), name, config, /*select=*/false).is_system = is_system;
+    };
+    for (const char *v : {"0.4", "0.6", "0.8", "1.0"})
+        add_printer(std::string("Elegoo OrangeStorm Giga ") + v + " nozzle", "", v, /*is_system=*/true);
+    add_printer("SirPrintALot", "", "0.6", /*is_system=*/false);
+    add_printer("SirPrintALot 0.8", "SirPrintALot", "0.8", false);
+
+    SECTION("a custom printer offers only its own family's sizes") {
+        bundle.printers.select_preset_by_name("SirPrintALot", true);
+        const auto diameters = bundle.printers.diameters_of_selected_printer();
+        CHECK(diameters == std::vector<std::string>{"0.6", "0.8"});
+    }
+    SECTION("a system printer still offers every size of its model") {
+        bundle.printers.select_preset_by_name("Elegoo OrangeStorm Giga 0.6 nozzle", true);
+        const auto diameters = bundle.printers.diameters_of_selected_printer();
+        CHECK(diameters == std::vector<std::string>{"0.4", "0.6", "0.8", "1.0"});
+    }
+}
+
+// "printer_variant" is compared as a string against the nozzle dropdown's entries, so the spelling
+// has to match exactly. It also has to be derived from the nozzle alone: the source vendor may be
+// uninstalled, and a variant that silently stays at the parent's value collapses the nozzle list.
+TEST_CASE("nozzle variant strings match the dropdown spelling", "[PresetCompatibility]")
+{
+    CHECK(PresetUtils::nozzle_variant_string(0.4) == "0.4");
+    CHECK(PresetUtils::nozzle_variant_string(0.8) == "0.8");
+    CHECK(PresetUtils::nozzle_variant_string(0.25) == "0.25"); // 2 decimals survive
+    CHECK(PresetUtils::nozzle_variant_string(1.0) == "1.0");   // never bare "1"
+    CHECK(PresetUtils::nozzle_variant_string(0.6) == "0.6");
+}
+
+// get_similar_printer_preset guesses the target preset's NAME by substituting the variant string
+// into the current one. A custom printer named "SirPrintALot" rather than "SirPrintALot 0.6"
+// contains no "0.6" to substitute, so the guess resolves to the preset already selected and the
+// switch silently does nothing - but only in the direction where that name matches.
+TEST_CASE("switching nozzle works when the preset name has no nozzle size in it", "[PresetCompatibility]")
+{
+    PresetBundle bundle;
+
+    const auto add_printer = [&](const std::string &name, const std::string &inherits, const std::string &variant) {
+        DynamicPrintConfig config(bundle.printers.default_preset().config);
+        config.set_key_value("printer_model", new ConfigOptionString("Elegoo OrangeStorm Giga"));
+        config.set_key_value("printer_variant", new ConfigOptionString(variant));
+        Preset::inherits(config) = inherits;
+        Preset &preset = bundle.printers.load_preset(std::string(), name, config, /*select=*/false);
+        preset.alias   = name; // what makes the name-substitution shortcut fire
+    };
+    add_printer("SirPrintALot", "", "0.6");            // root: name carries no nozzle size
+    add_printer("SirPrintALot 0.8", "SirPrintALot", "0.8");
+
+    SECTION("0.6 -> 0.8, the direction the name guess breaks") {
+        bundle.printers.select_preset_by_name("SirPrintALot", true);
+        Preset *target = bundle.get_similar_printer_preset({}, "0.8");
+        REQUIRE(target != nullptr);
+        CHECK(target->name == "SirPrintALot 0.8");
+    }
+    SECTION("0.8 -> 0.6 still works") {
+        bundle.printers.select_preset_by_name("SirPrintALot 0.8", true);
+        Preset *target = bundle.get_similar_printer_preset({}, "0.6");
+        REQUIRE(target != nullptr);
+        CHECK(target->name == "SirPrintALot");
+    }
+}


### PR DESCRIPTION
# Description
Because I've recently got my OrangeStorm Giga and frankenstein'ed some stuff, I wanted to have a completely custom profile for my printer. 
However I was not able to disable the original system profile after creating a custom profile from it, which was not acceptable for me.
Because the printer now is customized, I wanted to have a clean uncoupled profile that started as a Giga but allows me to customize it however I want without having to worry about the system profile changing and quietly breaking something.

I saw that this feature was requested before, but was flagged as 'not planned'.
Because I needed this feature and have claude code enterprise available, I delegated it to claude to implement the feature for me. I am not a C++ developer, so I'm completely fine with not having this PR merged at all because it's vibe-coded.

**What this PR changes:**
- When creating a custom profile there is a new checkbox 'Detach from parent'
- The nozzle-dropdown only shows sizes for this profile (if it's detached, otherwise it will include all system profile sizes too)

<!--
> Please provide a summary of the changes made in this PR. Include details such as:
  > * What issue does this PR address or fix?
  > * What new features or enhancements does this PR introduce?
  > * Are there any breaking changes or dependencies that need to be considered?
-->

# Screenshots/Recordings/Graphs

<!--
> Please attach relevant screenshots to showcase the UI changes.
> Please attach images that can help explain the changes.
-->

## Tests

<!--
> Please describe the tests that you have conducted to verify the changes made in this PR.
-->

<!--
> A guide for users on how to download the artifacts from this PR.
-->

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
