### PR TITLE
Fix misc. errors on GUI strings

### DIFF
--- a/localization/i18n/OrcaSlicer.pot
+++ b/localization/i18n/OrcaSlicer.pot
@@ -3,7 +3,6 @@
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/localization/i18n/OrcaSlicer.pot
+++ b/localization/i18n/OrcaSlicer.pot
@@ -5951,10 +5951,10 @@ msgstr ""
 msgid "Load a model"
 msgstr ""
 
-msgid "Import Zip Archive"
+msgid "Import ZIP Archive"
 msgstr ""
 
-msgid "Load models contained within a zip archive"
+msgid "Load models contained within a ZIP archive"
 msgstr ""
 
 msgid "Import Configs"
@@ -7663,7 +7663,7 @@ msgstr ""
 msgid "Customized Preset"
 msgstr ""
 
-msgid "Component name(s) inside step file not in UTF8 format!"
+msgid "Component name(s) inside step file not in UTF-8 format!"
 msgstr ""
 
 msgid "Because of unsupported text encoding, garbage characters may appear!"
@@ -7685,7 +7685,7 @@ msgstr ""
 #, possible-c-format, possible-boost-format
 msgid ""
 "The object from file %s is too small, and may be in meters or inches.\n"
-" Do you want to scale to millimeters?"
+"Do you want to scale to millimeters?"
 msgstr ""
 
 msgid "Object too small"
@@ -10329,11 +10329,11 @@ msgstr ""
 msgid "No modifications need to be copied."
 msgstr ""
 
-msgid "Copy paramters"
+msgid "Copy parameters"
 msgstr ""
 
 #, possible-c-format, possible-boost-format
-msgid "Modify paramters of %s"
+msgid "Modify parameters of %s"
 msgstr ""
 
 #, possible-c-format, possible-boost-format
@@ -11874,7 +11874,7 @@ msgstr ""
 msgid "Other layers"
 msgstr ""
 
-msgid "Bed temperature for layers except the initial one. A value of 0 means the filament does not support printing on the Cool Plate SuperTack."
+msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the Cool Plate SuperTack."
 msgstr ""
 
 msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the Cool Plate."
@@ -14675,7 +14675,7 @@ msgstr ""
 msgid "Reduce infill retraction"
 msgstr ""
 
-msgid "Don't retract when the travel is entirely within an infill area. That means the oozing can't been seen. This can reduce times of retraction for complex model and save printing time, but make slicing and G-code generating slower. Note that z-hop is also not performed in areas where retraction is skipped."
+msgid "Don't retract when the travel is entirely within an infill area. That means the oozing can't been seen. This can reduce times of retraction for complex model and save printing time, but make slicing and G-code generating slower. Note that Z-hop is also not performed in areas where retraction is skipped."
 msgstr ""
 
 msgid "This option will drop the temperature of the inactive extruders to prevent oozing."
@@ -14831,7 +14831,7 @@ msgstr ""
 
 #, no-c-format, no-boost-format
 msgid ""
-"The length of fast retraction after wipe, relative to retraction length.\n"
+"This is the length of fast retraction after wipe, relative to retraction length.\n"
 "The value will be clamped by 100% minus the retract amount before the wipe value."
 msgstr ""
 
@@ -14874,7 +14874,7 @@ msgstr ""
 msgid "Z-hop height"
 msgstr ""
 
-msgid "Whenever there is a retraction, the nozzle is lifted a little to create clearance between the nozzle and the print. This prevents the nozzle from hitting the print when traveling more. Using spiral lines to lift z can prevent stringing."
+msgid "Whenever there is a retraction, the nozzle is lifted a little to create clearance between the nozzle and the print. This prevents the nozzle from hitting the print when traveling more. Using spiral lines to lift Z can prevent stringing."
 msgstr ""
 
 msgid "Z-hop lower boundary"
@@ -18191,17 +18191,17 @@ msgstr ""
 msgid "Only display the filament names with changes to filament presets."
 msgstr ""
 
-msgid "Only printer names with user printer presets will be displayed, and each preset you choose will be exported as a zip."
+msgid "Only printer names with user printer presets will be displayed, and each preset you choose will be exported as a ZIP archive."
 msgstr ""
 
 msgid ""
 "Only the filament names with user filament presets will be displayed, \n"
-"and all user filament presets in each filament name you select will be exported as a zip."
+"and all user filament presets in each filament name you select will be exported as a ZIP archive."
 msgstr ""
 
 msgid ""
 "Only printer names with changed process presets will be displayed, \n"
-"and all user process presets in each printer name you select will be exported as a zip."
+"and all user process presets in each printer name you select will be exported as a ZIP archive."
 msgstr ""
 
 msgid "Please select at least one printer or filament."
@@ -18416,7 +18416,7 @@ msgstr ""
 msgid "We need information for diagnosing source of the issue. Check wiki page for detailed guide."
 msgstr ""
 
-msgid "Pack button collects project file and logs of current session onto a zip file."
+msgid "Pack button collects project file and logs of current session onto a ZIP archive."
 msgstr ""
 
 msgid "Any additional visual examples like images or screen recordings might be helpful while reporting the issue."
@@ -18458,7 +18458,7 @@ msgstr ""
 msgid "Stored logs"
 msgstr ""
 
-msgid "Packs all stored logs onto a zip file."
+msgid "Packs all stored logs onto a ZIP archive."
 msgstr ""
 
 msgid "Profiles"
@@ -18523,7 +18523,7 @@ msgstr ""
 msgid "Authorizing..."
 msgstr ""
 
-msgid "Error. Can't get api token for authorization"
+msgid "Error. Can't get API token for authorization"
 msgstr ""
 
 msgid "Could not parse server response."

--- a/localization/i18n/ca/OrcaSlicer_ca.po
+++ b/localization/i18n/ca/OrcaSlicer_ca.po
@@ -6419,10 +6419,10 @@ msgstr "Importar 3MF STL/STEP/SVG/OBJ/AMF"
 msgid "Load a model"
 msgstr "Carregar un model"
 
-msgid "Import Zip Archive"
+msgid "Import ZIP Archive"
 msgstr "Importar fitxer ZIP"
 
-msgid "Load models contained within a zip archive"
+msgid "Load models contained within a ZIP archive"
 msgstr "Carregar models continguts dins d'un arxiu zip"
 
 msgid "Import Configs"
@@ -8232,8 +8232,8 @@ msgid "Customized Preset"
 msgstr "Perfil personalitzat"
 
 # AI Translated
-msgid "Component name(s) inside step file not in UTF8 format!"
-msgstr "Els noms dels components dins del fitxer STEP no tenen format UTF8!"
+msgid "Component name(s) inside step file not in UTF-8 format!"
+msgstr "Els noms dels components dins del fitxer STEP no tenen format UTF-8!"
 
 # AI Translated
 msgid "Because of unsupported text encoding, garbage characters may appear!"
@@ -8255,10 +8255,10 @@ msgstr "El volum de l'objecte és zero"
 #, c-format, boost-format
 msgid ""
 "The object from file %s is too small, and may be in meters or inches.\n"
-" Do you want to scale to millimeters?"
+"Do you want to scale to millimeters?"
 msgstr ""
 "L'objecte del fitxer %s és massa petit, i potser en metres o polzades.\n"
-" Vols escalar a mil·límetres?"
+"Vols escalar a mil·límetres?"
 
 msgid "Object too small"
 msgstr "Objecte massa petit"
@@ -11189,12 +11189,12 @@ msgid "No modifications need to be copied."
 msgstr "No cal copiar cap modificació."
 
 # AI Translated
-msgid "Copy paramters"
+msgid "Copy parameters"
 msgstr "Copiar els paràmetres"
 
 # AI Translated
 #, c-format, boost-format
-msgid "Modify paramters of %s"
+msgid "Modify parameters of %s"
 msgstr "Modificar els paràmetres de %s"
 
 # AI Translated
@@ -12868,8 +12868,8 @@ msgstr "mm o %"
 msgid "Other layers"
 msgstr "Altres capes"
 
-msgid "Bed temperature for layers except the initial one. A value of 0 means the filament does not support printing on the Cool Plate SuperTack."
-msgstr "Temperatura del llit per a les capes excepte la primera. Un valor de 0 significa que el filament no admet la impressió sobre el Cool Plate SuperTack."
+msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the Cool Plate SuperTack."
+msgstr "Temperatura del llit de les capes excepte la inicial. Un valor de 0 significa que el filament no admet la impressió sobre el Cool Plate SuperTack."
 
 msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the Cool Plate."
 msgstr "Temperatura del llit de les capes excepte la inicial. El valor 0 significa que el filament no admet imprimir a una Base Freda."
@@ -16197,7 +16197,7 @@ msgid "Reduce infill retraction"
 msgstr "Reduir la retracció de farciment"
 
 # AI Translated
-msgid "Don't retract when the travel is entirely within an infill area. That means the oozing can't been seen. This can reduce times of retraction for complex model and save printing time, but make slicing and G-code generating slower. Note that z-hop is also not performed in areas where retraction is skipped."
+msgid "Don't retract when the travel is entirely within an infill area. That means the oozing can't been seen. This can reduce times of retraction for complex model and save printing time, but make slicing and G-code generating slower. Note that Z-hop is also not performed in areas where retraction is skipped."
 msgstr "No retrau quan el desplaçament està totalment a la zona de farciment. Això vol dir que l'oozing( goteig ) queda amagat. Això pot reduir els temps de retracció per a models complexos i estalviar temps d'impressió, però fer que el laminat i la generació de Codi-G siguin més lents. Tingueu en compte que el salt en Z tampoc es realitza a les zones on s'omet la retracció."
 
 msgid "This option will drop the temperature of the inactive extruders to prevent oozing."
@@ -16373,7 +16373,7 @@ msgstr "Quantitat de retracció després de netejar"
 # AI Translated
 #, no-c-format, no-boost-format
 msgid ""
-"The length of fast retraction after wipe, relative to retraction length.\n"
+"This is the length of fast retraction after wipe, relative to retraction length.\n"
 "The value will be clamped by 100% minus the retract amount before the wipe value."
 msgstr ""
 "Longitud de la retracció ràpida després de netejar, relativa a la longitud de retracció.\n"
@@ -16420,7 +16420,7 @@ msgstr "Quan s'activa la retracció abans d'un canvi d'eina, el filament es reti
 msgid "Z-hop height"
 msgstr "Alçada Z-hop"
 
-msgid "Whenever there is a retraction, the nozzle is lifted a little to create clearance between the nozzle and the print. This prevents the nozzle from hitting the print when traveling more. Using spiral lines to lift z can prevent stringing."
+msgid "Whenever there is a retraction, the nozzle is lifted a little to create clearance between the nozzle and the print. This prevents the nozzle from hitting the print when traveling more. Using spiral lines to lift Z can prevent stringing."
 msgstr "Cade vegada que es fa una retracció, s'aixeca una mica el broquet per crear espai lliure entre el broquet i la impressió. Evita que el broquet colpegi la impressió en els desplaçaments. L'ús de la línia espiral per aixecar z pot evitar l'aparició de fils"
 
 msgid "Z-hop lower boundary"
@@ -20071,19 +20071,19 @@ msgstr "Mostrar només els noms de les impressores amb canvis als perfils d'impr
 msgid "Only display the filament names with changes to filament presets."
 msgstr "Mostrar només els noms dels filaments amb canvis en els perfils de filament."
 
-msgid "Only printer names with user printer presets will be displayed, and each preset you choose will be exported as a zip."
+msgid "Only printer names with user printer presets will be displayed, and each preset you choose will be exported as a ZIP archive."
 msgstr "Només es mostraran els noms de les impressores amb perfils d'impressora d'usuari i cada perfil que trieu s'exportarà com a fitxer zip."
 
 msgid ""
 "Only the filament names with user filament presets will be displayed, \n"
-"and all user filament presets in each filament name you select will be exported as a zip."
+"and all user filament presets in each filament name you select will be exported as a ZIP archive."
 msgstr ""
 "Només es mostraran els noms dels filaments amb perfils de filament d'usuari, \n"
 "i tots els perfils de filament d'usuari de cada nom de filament que seleccioneu s'exportaran com a zip."
 
 msgid ""
 "Only printer names with changed process presets will be displayed, \n"
-"and all user process presets in each printer name you select will be exported as a zip."
+"and all user process presets in each printer name you select will be exported as a ZIP archive."
 msgstr ""
 "Només es mostraran els noms de les impressores amb perfils de processament modificats, \n"
 "I tots els valors perfils del procés d'usuari de cada nom d'impressora que seleccioneu s'exportaran com a ZIP."
@@ -20328,7 +20328,7 @@ msgid "We need information for diagnosing source of the issue. Check wiki page f
 msgstr "Necessitem informació per diagnosticar l'origen del problema. Consulteu la pàgina wiki per a una guia detallada."
 
 # AI Translated
-msgid "Pack button collects project file and logs of current session onto a zip file."
+msgid "Pack button collects project file and logs of current session onto a ZIP archive."
 msgstr "El botó Empaquetar recull el fitxer del projecte i els registres de la sessió actual en un fitxer zip."
 
 # AI Translated
@@ -20384,7 +20384,7 @@ msgid "Stored logs"
 msgstr "Registres emmagatzemats"
 
 # AI Translated
-msgid "Packs all stored logs onto a zip file."
+msgid "Packs all stored logs onto a ZIP archive."
 msgstr "Empaqueta tots els registres emmagatzemats en un fitxer zip."
 
 # AI Translated
@@ -20472,7 +20472,7 @@ msgid "Authorizing..."
 msgstr "Autoritzant..."
 
 # AI Translated
-msgid "Error. Can't get api token for authorization"
+msgid "Error. Can't get API token for authorization"
 msgstr "Error. No es pot obtenir el testimoni d'api per a l'autorització"
 
 # AI Translated

--- a/localization/i18n/cs/OrcaSlicer_cs.po
+++ b/localization/i18n/cs/OrcaSlicer_cs.po
@@ -6380,10 +6380,10 @@ msgstr "Importovat 3MF/STL/STEP/SVG/OBJ/AMF"
 msgid "Load a model"
 msgstr "Načíst model"
 
-msgid "Import Zip Archive"
+msgid "Import ZIP Archive"
 msgstr "Importovat ZIP archiv"
 
-msgid "Load models contained within a zip archive"
+msgid "Load models contained within a ZIP archive"
 msgstr "Načíst modely obsažené v zip archivu"
 
 msgid "Import Configs"
@@ -8193,7 +8193,7 @@ msgstr "Potvrďte prosím, že je G-code v těchto předvolbách bezpečný, aby
 msgid "Customized Preset"
 msgstr "Přizpůsobená předvolba"
 
-msgid "Component name(s) inside step file not in UTF8 format!"
+msgid "Component name(s) inside step file not in UTF-8 format!"
 msgstr "Názvy komponent v souboru STEP nejsou ve formátu UTF-8!"
 
 # AI Translated
@@ -8216,7 +8216,7 @@ msgstr "Objem objektu je nula."
 #, c-format, boost-format
 msgid ""
 "The object from file %s is too small, and may be in meters or inches.\n"
-" Do you want to scale to millimeters?"
+"Do you want to scale to millimeters?"
 msgstr ""
 "Objekt ze souboru %s je příliš malý a může být v metrech nebo palcích.\n"
 "Chcete převést měřítko na milimetry?"
@@ -11133,12 +11133,12 @@ msgid "No modifications need to be copied."
 msgstr "Není třeba kopírovat žádné úpravy."
 
 # AI Translated
-msgid "Copy paramters"
+msgid "Copy parameters"
 msgstr "Kopírovat parametry"
 
 # AI Translated
 #, c-format, boost-format
-msgid "Modify paramters of %s"
+msgid "Modify parameters of %s"
 msgstr "Upravit parametry %s"
 
 # AI Translated
@@ -12853,7 +12853,7 @@ msgstr "mm nebo %"
 msgid "Other layers"
 msgstr "Ostatní vrstvy"
 
-msgid "Bed temperature for layers except the initial one. A value of 0 means the filament does not support printing on the Cool Plate SuperTack."
+msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the Cool Plate SuperTack."
 msgstr "Teplota desky pro vrstvy kromě počáteční. Hodnota 0 znamená, že filament nepodporuje tisk na chladicí podložce SuperTack."
 
 msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the Cool Plate."
@@ -16143,8 +16143,8 @@ msgstr "Počáteční a koncové body, které vedou z oblasti řezače do odpadk
 msgid "Reduce infill retraction"
 msgstr "Snížit retrakci při výplni"
 
-msgid "Don't retract when the travel is entirely within an infill area. That means the oozing can't been seen. This can reduce times of retraction for complex model and save printing time, but make slicing and G-code generating slower. Note that z-hop is also not performed in areas where retraction is skipped."
-msgstr "Neprovádět retrakci, pokud se přejezd nachází zcela uvnitř oblasti výplně. Případné vytékání materiálu tak nebude viditelné. To může snížit počet retrakčních pohybů u složitých modelů a zkrátit dobu tisku, ale zároveň zpomalit slicování a generování G-code. V oblastech, kde je retrakce přeskočena, se zároveň neprovádí ani z-hop."
+msgid "Don't retract when the travel is entirely within an infill area. That means the oozing can't been seen. This can reduce times of retraction for complex model and save printing time, but make slicing and G-code generating slower. Note that Z-hop is also not performed in areas where retraction is skipped."
+msgstr "Neprovádět retrakci, pokud se přejezd nachází zcela uvnitř oblasti výplně. Případné vytékání materiálu tak nebude viditelné. To může snížit počet retrakčních pohybů u složitých modelů a zkrátit dobu tisku, ale zároveň zpomalit slicování a generování G-code. V oblastech, kde je retrakce přeskočena, se zároveň neprovádí ani Z-hop."
 
 msgid "This option will drop the temperature of the inactive extruders to prevent oozing."
 msgstr "Tato možnost sníží teplotu neaktivních extruderů, aby se zabránilo vytékání."
@@ -16317,7 +16317,7 @@ msgstr "Délka retrakce po očištění"
 # AI Translated
 #, no-c-format, no-boost-format
 msgid ""
-"The length of fast retraction after wipe, relative to retraction length.\n"
+"This is the length of fast retraction after wipe, relative to retraction length.\n"
 "The value will be clamped by 100% minus the retract amount before the wipe value."
 msgstr ""
 "Délka rychlé retrakce po očištění, vztažená k délce retrakce.\n"
@@ -16364,7 +16364,7 @@ msgstr "Když je retrakce spuštěna před změnou nástroje, filament se zatáh
 msgid "Z-hop height"
 msgstr "Výška Z-hopu"
 
-msgid "Whenever there is a retraction, the nozzle is lifted a little to create clearance between the nozzle and the print. This prevents the nozzle from hitting the print when traveling more. Using spiral lines to lift z can prevent stringing."
+msgid "Whenever there is a retraction, the nozzle is lifted a little to create clearance between the nozzle and the print. This prevents the nozzle from hitting the print when traveling more. Using spiral lines to lift Z can prevent stringing."
 msgstr "Po každém stažení filamentu se tryska mírně zvedne, aby vznikla mezera mezi tryskou a tiskem. Zabrání kolizi trysky s tiskem při přesunu. Použití spirálových linií pro zvedání v ose Z může zabránit vytahování vláken."
 
 msgid "Z-hop lower boundary"
@@ -19992,19 +19992,19 @@ msgstr "Zobrazit pouze názvy tiskáren se změnami v předvolbách tiskárny, f
 msgid "Only display the filament names with changes to filament presets."
 msgstr "Zobrazit pouze názvy filamentů se změnami ve filamentových profilech."
 
-msgid "Only printer names with user printer presets will be displayed, and each preset you choose will be exported as a zip."
+msgid "Only printer names with user printer presets will be displayed, and each preset you choose will be exported as a ZIP archive."
 msgstr "Zobrazí se pouze názvy tiskáren s uživatelskými předvolbami tiskárny, každá vybraná předvolba bude exportována jako zip archiv."
 
 msgid ""
 "Only the filament names with user filament presets will be displayed, \n"
-"and all user filament presets in each filament name you select will be exported as a zip."
+"and all user filament presets in each filament name you select will be exported as a ZIP archive."
 msgstr ""
 "Zobrazí se pouze názvy filamentů s uživatelskými filamentovými profily. \n"
 "Všechny uživatelské filamentové profily ve vybraných filamentech budou exportovány jako zip archiv."
 
 msgid ""
 "Only printer names with changed process presets will be displayed, \n"
-"and all user process presets in each printer name you select will be exported as a zip."
+"and all user process presets in each printer name you select will be exported as a ZIP archive."
 msgstr ""
 "Zobrazí se pouze názvy tiskáren se změněnými procesními předvolbami. \n"
 "Všechny uživatelské procesní předvolby ve vybraných tiskárnách budou exportovány jako zip archiv."
@@ -20250,7 +20250,7 @@ msgid "We need information for diagnosing source of the issue. Check wiki page f
 msgstr "Pro diagnostiku zdroje problému potřebujeme informace. Podrobný návod najdete na stránce wiki."
 
 # AI Translated
-msgid "Pack button collects project file and logs of current session onto a zip file."
+msgid "Pack button collects project file and logs of current session onto a ZIP archive."
 msgstr "Tlačítko Zabalit shromáždí soubor projektu a protokoly aktuální relace do souboru zip."
 
 # AI Translated
@@ -20306,7 +20306,7 @@ msgid "Stored logs"
 msgstr "Uložené protokoly"
 
 # AI Translated
-msgid "Packs all stored logs onto a zip file."
+msgid "Packs all stored logs onto a ZIP archive."
 msgstr "Zabalí všechny uložené protokoly do souboru zip."
 
 # AI Translated
@@ -20394,8 +20394,8 @@ msgid "Authorizing..."
 msgstr "Probíhá autorizace..."
 
 # AI Translated
-msgid "Error. Can't get api token for authorization"
-msgstr "Chyba. Nelze získat api token pro autorizaci"
+msgid "Error. Can't get API token for authorization"
+msgstr "Chyba. Nelze získat API token pro autorizaci"
 
 # AI Translated
 msgid "Could not parse server response."

--- a/localization/i18n/de/OrcaSlicer_de.po
+++ b/localization/i18n/de/OrcaSlicer_de.po
@@ -6272,10 +6272,10 @@ msgstr "Importiere 3MF/STL/STEP/SVG/OBJ/AMF"
 msgid "Load a model"
 msgstr "Lade ein Modell"
 
-msgid "Import Zip Archive"
+msgid "Import ZIP Archive"
 msgstr "Zip-Archiv importieren"
 
-msgid "Load models contained within a zip archive"
+msgid "Load models contained within a ZIP archive"
 msgstr "Modelle aus einem Zip-Archiv laden"
 
 msgid "Import Configs"
@@ -8063,8 +8063,8 @@ msgstr "Bitte bestätigen Sie, dass die G-Codes innerhalb dieser Profile sicher 
 msgid "Customized Preset"
 msgstr "Benutzerdefinierte Profile"
 
-msgid "Component name(s) inside step file not in UTF8 format!"
-msgstr "Der Name der Komponenten in der Step-Datei ist nicht im UTF8-Format!"
+msgid "Component name(s) inside step file not in UTF-8 format!"
+msgstr "Der Name der Komponenten in der Step-Datei ist nicht im UTF-8-Format!"
 
 msgid "Because of unsupported text encoding, garbage characters may appear!"
 msgstr "Aufgrund der nicht unterstützten Textkodierung können unbrauchbare Zeichen erscheinen!"
@@ -8085,10 +8085,10 @@ msgstr "Das Volumen des Objekts ist Null"
 #, c-format, boost-format
 msgid ""
 "The object from file %s is too small, and may be in meters or inches.\n"
-" Do you want to scale to millimeters?"
+"Do you want to scale to millimeters?"
 msgstr ""
 "Das Objekt aus der Datei %s ist zu klein und vielleicht in Metern oder Zoll angeben.\n"
-" Möchten Sie auf Millimeter skalieren?"
+"Möchten Sie auf Millimeter skalieren?"
 
 msgid "Object too small"
 msgstr "Objekt zu klein"
@@ -10940,11 +10940,11 @@ msgstr "%s: %s"
 msgid "No modifications need to be copied."
 msgstr "Es müssen keine Änderungen kopiert werden."
 
-msgid "Copy paramters"
+msgid "Copy parameters"
 msgstr "Parameter kopieren"
 
 #, c-format, boost-format
-msgid "Modify paramters of %s"
+msgid "Modify parameters of %s"
 msgstr "Parameter von %s ändern"
 
 #, c-format, boost-format
@@ -12570,7 +12570,7 @@ msgstr "mm o. %"
 msgid "Other layers"
 msgstr "Andere Schichten"
 
-msgid "Bed temperature for layers except the initial one. A value of 0 means the filament does not support printing on the Cool Plate SuperTack."
+msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the Cool Plate SuperTack."
 msgstr "Dies ist die Betttemperatur für Schichten mit Ausnahme der Ersten. Ein Wert von 0 bedeutet, dass das Filament auf der kalten Druckplatte SuperTack nicht unterstützt wird."
 
 msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the Cool Plate."
@@ -15802,7 +15802,7 @@ msgstr "Die Start- und Endpunkte, vom Schnittbereich bis zum Auswurfschacht."
 msgid "Reduce infill retraction"
 msgstr "Rückzug bei der Füllung verringern"
 
-msgid "Don't retract when the travel is entirely within an infill area. That means the oozing can't been seen. This can reduce times of retraction for complex model and save printing time, but make slicing and G-code generating slower. Note that z-hop is also not performed in areas where retraction is skipped."
+msgid "Don't retract when the travel is entirely within an infill area. That means the oozing can't been seen. This can reduce times of retraction for complex model and save printing time, but make slicing and G-code generating slower. Note that Z-hop is also not performed in areas where retraction is skipped."
 msgstr "Kein Rückzug, wenn sich die Bewegung des Druckkopfes vollständig in einem Füllbereich befindet. Das bedeutet, dass das herauslaufen des Filaments nicht zu sehen ist. Dies kann die Zeit für das zurückziehen des Filaments bei komplexeren Modellen verkürzen und Druckzeit sparen, verlangsamt aber das Slicen und die G-Code Generierung."
 
 msgid "This option will drop the temperature of the inactive extruders to prevent oozing."
@@ -15972,7 +15972,7 @@ msgstr "Rückzugsmenge nach dem Wischen"
 # AI Translated
 #, no-c-format, no-boost-format
 msgid ""
-"The length of fast retraction after wipe, relative to retraction length.\n"
+"This is the length of fast retraction after wipe, relative to retraction length.\n"
 "The value will be clamped by 100% minus the retract amount before the wipe value."
 msgstr ""
 "Die Länge des schnellen Rückzugs nach dem Wischen, relativ zur Rückzugslänge.\n"
@@ -16019,7 +16019,7 @@ msgstr "Wenn vor einem Werkzeugwechsel ein Rückzug ausgelöst wird, wird das Fi
 msgid "Z-hop height"
 msgstr "Z-Hub-Höhe"
 
-msgid "Whenever there is a retraction, the nozzle is lifted a little to create clearance between the nozzle and the print. This prevents the nozzle from hitting the print when traveling more. Using spiral lines to lift z can prevent stringing."
+msgid "Whenever there is a retraction, the nozzle is lifted a little to create clearance between the nozzle and the print. This prevents the nozzle from hitting the print when traveling more. Using spiral lines to lift Z can prevent stringing."
 msgstr "Bei jedem Rückzug wird die Düse ein wenig angehoben, um einen Abstand zwischen Düse und Druck zu schaffen. Dadurch wird verhindert, dass die Düse bei der Verfahrbewegung gegen den Druck stößt. Die Verwendung einer Spirallinie zum Anheben von z kann Fadenbildung verhindern."
 
 msgid "Z-hop lower boundary"
@@ -19600,19 +19600,19 @@ msgstr "Nur Druckernamen mit Änderungen an Drucker-, Filament- und Prozessprofi
 msgid "Only display the filament names with changes to filament presets."
 msgstr "Nur die Filamentnamen mit Änderungen an den Filamentprofilen werden angezeigt."
 
-msgid "Only printer names with user printer presets will be displayed, and each preset you choose will be exported as a zip."
+msgid "Only printer names with user printer presets will be displayed, and each preset you choose will be exported as a ZIP archive."
 msgstr "Nur Druckernamen mit Benutzerdruckerprofilen  werden angezeigt, und jedes Profil, das Sie auswählen, wird als ZIP exportiert."
 
 msgid ""
 "Only the filament names with user filament presets will be displayed, \n"
-"and all user filament presets in each filament name you select will be exported as a zip."
+"and all user filament presets in each filament name you select will be exported as a ZIP archive."
 msgstr ""
 "Nur die Filamentnamen mit Benutzerfilamentvorlagen werden angezeigt, \n"
 "und alle Benutzerfilamentvorlagen in jedem Filamentnamen, den Sie auswählen, "
 
 msgid ""
 "Only printer names with changed process presets will be displayed, \n"
-"and all user process presets in each printer name you select will be exported as a zip."
+"and all user process presets in each printer name you select will be exported as a ZIP archive."
 msgstr ""
 "Nur Druckernamen mit geänderten Prozessvorlagen werden angezeigt, \n"
 "und alle Benutzerprozessvorlagen in jedem Druckernamen, den Sie auswählen, werden als ZIP exportiert."
@@ -19841,7 +19841,7 @@ msgstr "Systeminformationen in die Zwischenablage kopieren"
 msgid "We need information for diagnosing source of the issue. Check wiki page for detailed guide."
 msgstr "Wir benötigen Informationen zur Diagnose der Ursache des Problems. Überprüfen Sie die Wiki-Seite für eine detaillierte Anleitung."
 
-msgid "Pack button collects project file and logs of current session onto a zip file."
+msgid "Pack button collects project file and logs of current session onto a ZIP archive."
 msgstr "Die Schaltfläche „Packen“ sammelt die Projektdatei und Protokolle der aktuellen Sitzung in einer ZIP-Datei."
 
 msgid "Any additional visual examples like images or screen recordings might be helpful while reporting the issue."
@@ -19883,7 +19883,7 @@ msgstr "Protokollstufe"
 msgid "Stored logs"
 msgstr "Gespeicherte Protokolle"
 
-msgid "Packs all stored logs onto a zip file."
+msgid "Packs all stored logs onto a ZIP archive."
 msgstr "Packt alle gespeicherten Protokolle in eine ZIP-Datei."
 
 msgid "Profiles"
@@ -19950,7 +19950,7 @@ msgstr "Druckertyp nicht gefunden, bitte manuell auswählen."
 msgid "Authorizing..."
 msgstr "Autorisierung..."
 
-msgid "Error. Can't get api token for authorization"
+msgid "Error. Can't get API token for authorization"
 msgstr "Fehler. Kann kein API-Token für die Autorisierung erhalten"
 
 msgid "Could not parse server response."

--- a/localization/i18n/en/OrcaSlicer_en.po
+++ b/localization/i18n/en/OrcaSlicer_en.po
@@ -5947,10 +5947,10 @@ msgstr ""
 msgid "Load a model"
 msgstr ""
 
-msgid "Import Zip Archive"
+msgid "Import ZIP Archive"
 msgstr ""
 
-msgid "Load models contained within a zip archive"
+msgid "Load models contained within a ZIP archive"
 msgstr ""
 
 msgid "Import Configs"
@@ -7659,7 +7659,7 @@ msgstr ""
 msgid "Customized Preset"
 msgstr ""
 
-msgid "Component name(s) inside step file not in UTF8 format!"
+msgid "Component name(s) inside step file not in UTF-8 format!"
 msgstr ""
 
 msgid "Because of unsupported text encoding, garbage characters may appear!"
@@ -7681,7 +7681,7 @@ msgstr ""
 #, c-format, boost-format
 msgid ""
 "The object from file %s is too small, and may be in meters or inches.\n"
-" Do you want to scale to millimeters?"
+"Do you want to scale to millimeters?"
 msgstr ""
 
 msgid "Object too small"
@@ -10325,11 +10325,11 @@ msgstr ""
 msgid "No modifications need to be copied."
 msgstr ""
 
-msgid "Copy paramters"
+msgid "Copy parameters"
 msgstr ""
 
 #, c-format, boost-format
-msgid "Modify paramters of %s"
+msgid "Modify parameters of %s"
 msgstr ""
 
 #, c-format, boost-format
@@ -11870,7 +11870,7 @@ msgstr ""
 msgid "Other layers"
 msgstr ""
 
-msgid "Bed temperature for layers except the initial one. A value of 0 means the filament does not support printing on the Cool Plate SuperTack."
+msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the Cool Plate SuperTack."
 msgstr ""
 
 msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the Cool Plate."
@@ -14671,7 +14671,7 @@ msgstr ""
 msgid "Reduce infill retraction"
 msgstr ""
 
-msgid "Don't retract when the travel is entirely within an infill area. That means the oozing can't been seen. This can reduce times of retraction for complex model and save printing time, but make slicing and G-code generating slower. Note that z-hop is also not performed in areas where retraction is skipped."
+msgid "Don't retract when the travel is entirely within an infill area. That means the oozing can't been seen. This can reduce times of retraction for complex model and save printing time, but make slicing and G-code generating slower. Note that Z-hop is also not performed in areas where retraction is skipped."
 msgstr ""
 
 msgid "This option will drop the temperature of the inactive extruders to prevent oozing."
@@ -14827,7 +14827,7 @@ msgstr ""
 
 #, no-c-format, no-boost-format
 msgid ""
-"The length of fast retraction after wipe, relative to retraction length.\n"
+"This is the length of fast retraction after wipe, relative to retraction length.\n"
 "The value will be clamped by 100% minus the retract amount before the wipe value."
 msgstr ""
 
@@ -14870,7 +14870,7 @@ msgstr ""
 msgid "Z-hop height"
 msgstr ""
 
-msgid "Whenever there is a retraction, the nozzle is lifted a little to create clearance between the nozzle and the print. This prevents the nozzle from hitting the print when traveling more. Using spiral lines to lift z can prevent stringing."
+msgid "Whenever there is a retraction, the nozzle is lifted a little to create clearance between the nozzle and the print. This prevents the nozzle from hitting the print when traveling more. Using spiral lines to lift Z can prevent stringing."
 msgstr ""
 
 msgid "Z-hop lower boundary"
@@ -18187,17 +18187,17 @@ msgstr ""
 msgid "Only display the filament names with changes to filament presets."
 msgstr ""
 
-msgid "Only printer names with user printer presets will be displayed, and each preset you choose will be exported as a zip."
+msgid "Only printer names with user printer presets will be displayed, and each preset you choose will be exported as a ZIP archive."
 msgstr ""
 
 msgid ""
 "Only the filament names with user filament presets will be displayed, \n"
-"and all user filament presets in each filament name you select will be exported as a zip."
+"and all user filament presets in each filament name you select will be exported as a ZIP archive."
 msgstr ""
 
 msgid ""
 "Only printer names with changed process presets will be displayed, \n"
-"and all user process presets in each printer name you select will be exported as a zip."
+"and all user process presets in each printer name you select will be exported as a ZIP archive."
 msgstr ""
 
 msgid "Please select at least one printer or filament."
@@ -18412,7 +18412,7 @@ msgstr ""
 msgid "We need information for diagnosing source of the issue. Check wiki page for detailed guide."
 msgstr ""
 
-msgid "Pack button collects project file and logs of current session onto a zip file."
+msgid "Pack button collects project file and logs of current session onto a ZIP archive."
 msgstr ""
 
 msgid "Any additional visual examples like images or screen recordings might be helpful while reporting the issue."
@@ -18454,7 +18454,7 @@ msgstr ""
 msgid "Stored logs"
 msgstr ""
 
-msgid "Packs all stored logs onto a zip file."
+msgid "Packs all stored logs onto a ZIP archive."
 msgstr ""
 
 msgid "Profiles"
@@ -18519,7 +18519,7 @@ msgstr ""
 msgid "Authorizing..."
 msgstr ""
 
-msgid "Error. Can't get api token for authorization"
+msgid "Error. Can't get API token for authorization"
 msgstr ""
 
 msgid "Could not parse server response."

--- a/localization/i18n/es/OrcaSlicer_es.po
+++ b/localization/i18n/es/OrcaSlicer_es.po
@@ -6129,10 +6129,10 @@ msgstr "Importar 3MF/STL/STEP/SVG/OBJ/AMF"
 msgid "Load a model"
 msgstr "Cargar un modelo"
 
-msgid "Import Zip Archive"
+msgid "Import ZIP Archive"
 msgstr "Importar archivo Zip"
 
-msgid "Load models contained within a zip archive"
+msgid "Load models contained within a ZIP archive"
 msgstr "Cargar modelos contenidos en un archivo zip"
 
 msgid "Import Configs"
@@ -7877,8 +7877,8 @@ msgstr "¡Por favor, confirme que el G-Code dentro de los perfiles son seguros p
 msgid "Customized Preset"
 msgstr "Perfil Personalizado"
 
-msgid "Component name(s) inside step file not in UTF8 format!"
-msgstr "¡El nombre de los componentes dentro del archivo de pasos no tiene formato UTF8!"
+msgid "Component name(s) inside step file not in UTF-8 format!"
+msgstr "¡El nombre de los componentes dentro del archivo de pasos no tiene formato UTF-8!"
 
 msgid "Because of unsupported text encoding, garbage characters may appear!"
 msgstr "¡El nombre puede mostrar caracteres no válidos!"
@@ -7899,10 +7899,10 @@ msgstr "El volumen del objeto es cero"
 #, c-format, boost-format
 msgid ""
 "The object from file %s is too small, and may be in meters or inches.\n"
-" Do you want to scale to millimeters?"
+"Do you want to scale to millimeters?"
 msgstr ""
 "El objeto del archivo %s es demasiado pequeño, tal vez en metros o pulgadas.\n"
-" ¿Quiere escalar a milímetros?"
+"¿Quiere escalar a milímetros?"
 
 msgid "Object too small"
 msgstr "Objeto demasiado pequeño"
@@ -10670,11 +10670,11 @@ msgstr "%s: %s"
 msgid "No modifications need to be copied."
 msgstr "No hay modificaciones que copiar."
 
-msgid "Copy paramters"
+msgid "Copy parameters"
 msgstr "Copiar parámetros"
 
 #, c-format, boost-format
-msgid "Modify paramters of %s"
+msgid "Modify parameters of %s"
 msgstr "Modificar parámetros de %s"
 
 #, c-format, boost-format
@@ -12267,8 +12267,8 @@ msgstr "mm o %"
 msgid "Other layers"
 msgstr "Otras capas"
 
-msgid "Bed temperature for layers except the initial one. A value of 0 means the filament does not support printing on the Cool Plate SuperTack."
-msgstr "Temperatura de la cama para las capas, excepto la inicial. Un valor de 0 significa que el filamento no es compatible con la Cama Fría SuperTack."
+msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the Cool Plate SuperTack."
+msgstr "Esta es la temperatura de la cama para las capas excepto la inicial. Un valor de 0 significa que el filamento no es compatible con la Cama Fría SuperTack."
 
 msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the Cool Plate."
 msgstr "Esta es la temperatura de la cama para las capas excepto la inicial. Un valor de 0 significa que el filamento no admite la impresión en la Cama Fría."
@@ -15470,7 +15470,7 @@ msgstr "Los puntos de inicio y fin, desde la zona de corte al cubo de basura."
 msgid "Reduce infill retraction"
 msgstr "Reducir la retracción del relleno"
 
-msgid "Don't retract when the travel is entirely within an infill area. That means the oozing can't been seen. This can reduce times of retraction for complex model and save printing time, but make slicing and G-code generating slower. Note that z-hop is also not performed in areas where retraction is skipped."
+msgid "Don't retract when the travel is entirely within an infill area. That means the oozing can't been seen. This can reduce times of retraction for complex model and save printing time, but make slicing and G-code generating slower. Note that Z-hop is also not performed in areas where retraction is skipped."
 msgstr "Desactiva la retracción cuando el desplazamiento se realiza en su totalidad dentro de un área de relleno, donde los artefactos causados por un rezumado no son visibles. Puede reducir el número de retracciones y por ende el tiempo total de retracción al imprimir modelos complejos, reduciendo el tiempo total de impresión. Sin embargo, puede que las operaciones de laminado y de generación del archivo G-Code sean más lentas."
 
 msgid "This option will drop the temperature of the inactive extruders to prevent oozing."
@@ -15635,7 +15635,7 @@ msgstr "Cantidad de retracción después de la limpieza"
 
 #, no-c-format, no-boost-format
 msgid ""
-"The length of fast retraction after wipe, relative to retraction length.\n"
+"This is the length of fast retraction after wipe, relative to retraction length.\n"
 "The value will be clamped by 100% minus the retract amount before the wipe value."
 msgstr ""
 "La longitud de la retracción rápida después de la limpieza, relativa a la longitud de retracción.\n"
@@ -15682,7 +15682,7 @@ msgstr "Cuando se activa la retracción antes de un cambio de herramienta, el fi
 msgid "Z-hop height"
 msgstr "Altura de Salto en Z"
 
-msgid "Whenever there is a retraction, the nozzle is lifted a little to create clearance between the nozzle and the print. This prevents the nozzle from hitting the print when traveling more. Using spiral lines to lift z can prevent stringing."
+msgid "Whenever there is a retraction, the nozzle is lifted a little to create clearance between the nozzle and the print. This prevents the nozzle from hitting the print when traveling more. Using spiral lines to lift Z can prevent stringing."
 msgstr "Cada vez que se realiza una retracción, la boquilla se levanta un poco para crear un pequeño margen entre la boquilla y la impresión. Esto evita que la boquilla golpee la pieza cuando se desplaza. El uso de la línea espiral para levantar z puede evitar la aparición de hilos."
 
 msgid "Z-hop lower boundary"
@@ -17423,7 +17423,7 @@ msgid "Current Z-hop"
 msgstr "Z-Hop actual"
 
 msgid "Contains Z-hop present at the beginning of the custom G-code block."
-msgstr "Contiene el z-hop presente al principio del bloque de G-Code personalizado."
+msgstr "Contiene el Z-hop presente al principio del bloque de G-Code personalizado."
 
 msgid "Position of the extruder at the beginning of the custom G-code block. If the custom G-code travels somewhere else, it should write to this variable so OrcaSlicer knows where it travels from when it gets control back."
 msgstr "Posición del extrusor al comienzo del bloque de G-Code personalizado. Si el G-Code personalizado viaja a otro lugar, debe escribir en esta variable para que OrcaSlicer sepa desde dónde viaja cuando recupere el control."
@@ -19233,17 +19233,17 @@ msgstr "Mostrar sólo los nombres de impresora con cambios en los perfiles de im
 msgid "Only display the filament names with changes to filament presets."
 msgstr "Mostrar sólo los nombres de impresora con cambios en los perfiles de filamento."
 
-msgid "Only printer names with user printer presets will be displayed, and each preset you choose will be exported as a zip."
+msgid "Only printer names with user printer presets will be displayed, and each preset you choose will be exported as a ZIP archive."
 msgstr "Sólo se mostrarán los nombres de impresoras con perfiles de impresora de usuario, y cada perfil que elija se exportará como un archivo zip."
 
 msgid ""
 "Only the filament names with user filament presets will be displayed, \n"
-"and all user filament presets in each filament name you select will be exported as a zip."
+"and all user filament presets in each filament name you select will be exported as a ZIP archive."
 msgstr "Sólo se mostrarán los nombres de filamento con perfiles de filamento de usuario, y todos los perfiles de filamento de usuario de cada nombre de filamento que seleccione se exportarán como un archivo zip."
 
 msgid ""
 "Only printer names with changed process presets will be displayed, \n"
-"and all user process presets in each printer name you select will be exported as a zip."
+"and all user process presets in each printer name you select will be exported as a ZIP archive."
 msgstr ""
 "Sólo se mostrarán los nombres de impresoras con perfiles de procesos modificados, \n"
 "y todos los perfiles de procesos de usuario de cada nombre de impresora que seleccione se exportarán como un archivo zip."
@@ -19472,7 +19472,7 @@ msgstr "Copiar información del sistema al portapapeles"
 msgid "We need information for diagnosing source of the issue. Check wiki page for detailed guide."
 msgstr "Necesitamos información para diagnosticar el origen del problema. Consulta la página wiki para una guía detallada."
 
-msgid "Pack button collects project file and logs of current session onto a zip file."
+msgid "Pack button collects project file and logs of current session onto a ZIP archive."
 msgstr "El botón Empaquetar recopila el archivo del proyecto y los registros de la sesión actual en un archivo zip."
 
 msgid "Any additional visual examples like images or screen recordings might be helpful while reporting the issue."
@@ -19514,7 +19514,7 @@ msgstr "Nivel de registro"
 msgid "Stored logs"
 msgstr "Registros almacenados"
 
-msgid "Packs all stored logs onto a zip file."
+msgid "Packs all stored logs onto a ZIP archive."
 msgstr "Empaqueta todos los registros almacenados en un archivo zip."
 
 msgid "Profiles"
@@ -19581,7 +19581,7 @@ msgstr "No se ha encontrado el tipo de impresora; selecciónelo manualmente."
 msgid "Authorizing..."
 msgstr "Autorizando..."
 
-msgid "Error. Can't get api token for authorization"
+msgid "Error. Can't get API token for authorization"
 msgstr "Error. No se puede obtener el token de la API para la autorización"
 
 msgid "Could not parse server response."
@@ -21042,7 +21042,7 @@ msgstr ""
 #~ msgid "Select Filament && Hotends"
 #~ msgstr "Seleccionar Filamento && Hotends"
 
-#~ msgid "External spools is not supported since Filament Track Switch has been installed. If you want to use external spool, please uninstall it."
+#~ msgid "External spools are not supported since Filament Track Switch has been installed. If you want to use external spool, please uninstall it."
 #~ msgstr "Los carretes externos no son compatibles porque se ha instalado el Filament Track Switch. Si desea utilizar un carrete externo, desinstálelo."
 
 #, c-format, boost-format

--- a/localization/i18n/eu/OrcaSlicer_eu.po
+++ b/localization/i18n/eu/OrcaSlicer_eu.po
@@ -3,7 +3,6 @@
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
@@ -23114,29 +23113,6 @@ msgstr ""
 
 #~ msgid "Maximum detour distance for avoiding crossing wall. Don't detour if the detour distance is larger than this value. Detour length could be specified either as an absolute value or as percentage (for example 50%) of a direct travel path. Zero to disable."
 #~ msgstr "Hormak gurutzatzea saihesteko gehieneko desbideratze-distantzia. Ez desbideratu distantzia balio hau baino handiagoa bada. Desbideratze-luzera balio absolutu gisa edo lekualdatze-ibilbide zuzenaren ehuneko gisa zehaztu daiteke (adibidez, 50%). Zero, desgaitzeko."
-
-#~ #,fuzzy
-msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the Cool Plate."
-#~ msgstr "Ohearen tenperatura hasierakoa ez diren geruzetarako. 0 balioak esan nahi du filamentuak ez duela plaka hotzean inprimatzea onartzen."
-
-#~ msgid "°C"
-#~ msgstr "°C"
-
-#~ #,fuzzy
-msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the Textured Cool Plate."
-#~ msgstr "Ohearen tenperatura hasierakoa ez diren geruzetarako. 0 balioak esan nahi du filamentuak ez duela testuradun plaka hotzean inprimatzea onartzen."
-
-#~ #,fuzzy
-msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the Engineering Plate."
-#~ msgstr "Ohearen tenperatura hasierakoa ez diren geruzetarako. 0 balioak esan nahi du filamentuak ez duela ingeniaritza-plakan inprimatzea onartzen."
-
-#~ #,fuzzy
-msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the High Temp Plate."
-#~ msgstr "Ohearen tenperatura hasierakoa ez diren geruzetarako. 0 balioak esan nahi du filamentuak ez duela tenperatura altuko plakan inprimatzea onartzen."
-
-#~ #,fuzzy
-msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the Textured PEI Plate."
-#~ msgstr "Ohearen tenperatura hasierakoa ez diren geruzetarako. 0 balioak esan nahi du filamentuak ez duela testuradun PEI plakan inprimatzea onartzen."
 
 #~ msgid "Initial layer"
 #~ msgstr "Hasierako geruza"

--- a/localization/i18n/eu/OrcaSlicer_eu.po
+++ b/localization/i18n/eu/OrcaSlicer_eu.po
@@ -6174,10 +6174,10 @@ msgstr "Inportatu 3MF/STL/STEP/SVG/OBJ/AMF"
 msgid "Load a model"
 msgstr "Modeloa kargatu"
 
-msgid "Import Zip Archive"
+msgid "Import ZIP Archive"
 msgstr "Inportatu ZIP fitxategia"
 
-msgid "Load models contained within a zip archive"
+msgid "Load models contained within a ZIP archive"
 msgstr "Kargatu ZIP fitxategi baten barnean dauden modeloak"
 
 msgid "Import Configs"
@@ -7945,7 +7945,7 @@ msgstr "Berretsi aurrezarpen hauetako G-codea segurua dela, makinari kalterik ez
 msgid "Customized Preset"
 msgstr "Aurrezarpen pertsonalizatua"
 
-msgid "Component name(s) inside step file not in UTF8 format!"
+msgid "Component name(s) inside step file not in UTF-8 format!"
 msgstr "STEP fitxategiko osagai-izena(k) ez dago/daude UTF-8 formatuan!"
 
 msgid "Because of unsupported text encoding, garbage characters may appear!"
@@ -7967,10 +7967,10 @@ msgstr "Objektuaren bolumena zero da"
 #, c-format, boost-format
 msgid ""
 "The object from file %s is too small, and may be in meters or inches.\n"
-" Do you want to scale to millimeters?"
+"Do you want to scale to millimeters?"
 msgstr ""
 "%s fitxategiko objektua txikiegia da, eta baliteke metrotan edo hazbetetan egotea.\n"
-" Milimetroetara eskalatu nahi duzu?"
+"Milimetroetara eskalatu nahi duzu?"
 
 msgid "Object too small"
 msgstr "Objektua txikiegia da"
@@ -10765,11 +10765,11 @@ msgstr "%s: %s"
 msgid "No modifications need to be copied."
 msgstr "Ez dago kopiatu beharreko aldaketarik."
 
-msgid "Copy paramters"
+msgid "Copy parameters"
 msgstr "Kopiatu parametroak"
 
 #, c-format, boost-format
-msgid "Modify paramters of %s"
+msgid "Modify parameters of %s"
 msgstr "Aldatu %s-(r)en parametroak"
 
 #, c-format, boost-format
@@ -12379,8 +12379,8 @@ msgstr "mm edo %"
 msgid "Other layers"
 msgstr "Beste geruzak"
 
-msgid "Bed temperature for layers except the initial one. A value of 0 means the filament does not support printing on the Cool Plate SuperTack."
-msgstr "Hasierakoa ez den geruzetarako ohearen tenperatura. 0 balioak filamentuak SuperTack Plaka hotzaren gainean inprimatzea ez duela onartzen esan nahi du."
+msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the Cool Plate SuperTack."
+msgstr "Hau da lehenengoa ez den geruzetarako ohearen tenperatura. 0 balioak filamentuak SuperTack Plaka hotzaren gainean inprimatzea ez duela onartzen esan nahi du."
 
 msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the Cool Plate."
 msgstr "Hau da lehenengoa ez den geruzetarako ohearen tenperatura. 0 balioak filamentuak Plaka hotzaren gainean inprimatzea ez duela onartzen esan nahi du."
@@ -15606,8 +15606,8 @@ msgstr "Mozteko eremutik hondakin-ontzira doazen hasierako eta amaierako puntuak
 msgid "Reduce infill retraction"
 msgstr "Murriztu betegarriaren atzera-egitea"
 
-msgid "Don't retract when the travel is entirely within an infill area. That means the oozing can't been seen. This can reduce times of retraction for complex model and save printing time, but make slicing and G-code generating slower. Note that z-hop is also not performed in areas where retraction is skipped."
-msgstr "Ez egin atzera-egiterik mugimendua guztiz betegarriaren eremuan dagoenean. Horrek esan nahi du jarioa ez dela ikusiko. Honek modelo konplexuetan atzera-egite kopurua murriztu eta inprimatze-denbora aurreztu dezake, baina xerraketa eta G-codearen sorrera motelduko ditu. Kontuan izan z-hop mugimendua ez dela egiten atzera-egitea saihesten den eremuetan."
+msgid "Don't retract when the travel is entirely within an infill area. That means the oozing can't been seen. This can reduce times of retraction for complex model and save printing time, but make slicing and G-code generating slower. Note that Z-hop is also not performed in areas where retraction is skipped."
+msgstr "Ez egin atzera-egiterik mugimendua guztiz betegarriaren eremuan dagoenean. Horrek esan nahi du jarioa ez dela ikusiko. Honek modelo konplexuetan atzera-egite kopurua murriztu eta inprimatze-denbora aurreztu dezake, baina xerraketa eta G-codearen sorrera motelduko ditu. Kontuan izan Z-hop mugimendua ez dela egiten atzera-egitea saihesten den eremuetan."
 
 msgid "This option will drop the temperature of the inactive extruders to prevent oozing."
 msgstr "Aukera honek aktibo ez dauden estrusoreen tenperatura jaitsiko du, jarioa saihesteko."
@@ -15771,7 +15771,7 @@ msgstr "Garbitu ondorengo atzera-egite kantitatea"
 
 #, no-c-format, no-boost-format
 msgid ""
-"The length of fast retraction after wipe, relative to retraction length.\n"
+"This is the length of fast retraction after wipe, relative to retraction length.\n"
 "The value will be clamped by 100% minus the retract amount before the wipe value."
 msgstr ""
 "Garbiketa-mugimenduaren ondorengo atzera-egite azkarraren luzera, atzera-egitearen luzerari dagokionez.\n"
@@ -15818,7 +15818,7 @@ msgstr "Erreminta aldatu aurretik atzera-egitea abiarazten denean, filamentua ze
 msgid "Z-hop height"
 msgstr "Z jauziaren altuera"
 
-msgid "Whenever there is a retraction, the nozzle is lifted a little to create clearance between the nozzle and the print. This prevents the nozzle from hitting the print when traveling more. Using spiral lines to lift z can prevent stringing."
+msgid "Whenever there is a retraction, the nozzle is lifted a little to create clearance between the nozzle and the print. This prevents the nozzle from hitting the print when traveling more. Using spiral lines to lift Z can prevent stringing."
 msgstr "Atzera-egite bakoitzean pita apur bat altxatzen da pitaren eta inprimaketaren artean tartea sortzeko. Horrela, mugimenduetan pitak pieza jotzea saihesten da. Z altxatzeko espiral-lerroak erabiltzeak hariak sortzea murriztu dezake."
 
 msgid "Z-hop lower boundary"
@@ -19379,19 +19379,19 @@ msgstr "Inprimagailuaren, filamentuen edo prozesuen aurrezarpenetan aldaketak di
 msgid "Only display the filament names with changes to filament presets."
 msgstr "Bistaratu soilik filamentu-aurrezarpenetan aldaketak dituzten filamentu-izenak."
 
-msgid "Only printer names with user printer presets will be displayed, and each preset you choose will be exported as a zip."
+msgid "Only printer names with user printer presets will be displayed, and each preset you choose will be exported as a ZIP archive."
 msgstr "Erabiltzailearen inprimagailu-aurrezarpenak dituzten inprimagailu-izenak soilik bistaratuko dira, eta hautatzen duzun aurrezarpen bakoitza zip gisa esportatuko da."
 
 msgid ""
 "Only the filament names with user filament presets will be displayed, \n"
-"and all user filament presets in each filament name you select will be exported as a zip."
+"and all user filament presets in each filament name you select will be exported as a ZIP archive."
 msgstr ""
 "Erabiltzailearen filamentu-aurrezarpenak dituzten filamentu-izenak soilik bistaratuko dira, \n"
 "eta hautatzen duzun filamentu-izen bakoitzeko erabiltzailearen filamentu-aurrezarpen guztiak zip gisa esportatuko dira."
 
 msgid ""
 "Only printer names with changed process presets will be displayed, \n"
-"and all user process presets in each printer name you select will be exported as a zip."
+"and all user process presets in each printer name you select will be exported as a ZIP archive."
 msgstr ""
 "Prozesu-aurrezarpen aldatuak dituzten inprimagailu-izenak soilik bistaratuko dira, \n"
 "eta hautatzen duzun inprimagailu-izen bakoitzeko erabiltzailearen prozesu-aurrezarpen guztiak zip gisa esportatuko dira."
@@ -19620,7 +19620,7 @@ msgstr "Kopiatu sistemaren informazioa arbelera"
 msgid "We need information for diagnosing source of the issue. Check wiki page for detailed guide."
 msgstr "Arazoaren jatorria diagnostikatzeko informazioa behar dugu. Begiratu wiki-orria gida xehatua ikusteko."
 
-msgid "Pack button collects project file and logs of current session onto a zip file."
+msgid "Pack button collects project file and logs of current session onto a ZIP archive."
 msgstr "Paketatu botoiak proiektu-fitxategia eta uneko saioko erregistroak ZIP fitxategi batean biltzen ditu."
 
 msgid "Any additional visual examples like images or screen recordings might be helpful while reporting the issue."
@@ -19662,7 +19662,7 @@ msgstr "Erregistro-maila"
 msgid "Stored logs"
 msgstr "Gordetako erregistroak"
 
-msgid "Packs all stored logs onto a zip file."
+msgid "Packs all stored logs onto a ZIP archive."
 msgstr "Gordetako erregistro guztiak ZIP fitxategi batean paketatzen ditu."
 
 msgid "Profiles"
@@ -19729,7 +19729,7 @@ msgstr "Ez da inprimagailu mota aurkitu; hautatu eskuz."
 msgid "Authorizing..."
 msgstr "Baimena ematen..."
 
-msgid "Error. Can't get api token for authorization"
+msgid "Error. Can't get API token for authorization"
 msgstr "Errorea. Ezin da baimenerako API tokena lortu"
 
 msgid "Could not parse server response."
@@ -22259,19 +22259,11 @@ msgstr ""
 #~ msgid "The 3mf has the following customized filament or printer presets:"
 #~ msgstr "3mf-ak pertsonalizatutako filamentuen edo inprimagailuaren aurrezarpen hauek dauzka:"
 
-#~ msgid "Name of components inside step file is not UTF8 format!"
-#~ msgstr "Step fitxategiko osagaien izena ez dago UTF8 formatuan!"
+#~ msgid "Name of components inside step file is not UTF-8 format!"
+#~ msgstr "Step fitxategiko osagaien izena ez dago UTF-8 formatuan!"
 
 #~ msgid "The name may show garbage characters!"
 #~ msgstr "Izenak karaktere ulergaitzak erakuts ditzake!"
-
-#, c-format, boost-format
-#~ msgid ""
-#~ "The object from file %s is too small, and maybe in meters or inches.\n"
-#~ " Do you want to scale to millimeters?"
-#~ msgstr ""
-#~ "%s fitxategiko objektua txikiegia da, eta baliteke metroetan edo hazbetetan egotea.\n"
-#~ " Milimetrotara eskalatu nahi duzu?"
 
 #~ msgid ""
 #~ "This file contains several objects positioned at multiple heights.\n"
@@ -23123,22 +23115,27 @@ msgstr ""
 #~ msgid "Maximum detour distance for avoiding crossing wall. Don't detour if the detour distance is larger than this value. Detour length could be specified either as an absolute value or as percentage (for example 50%) of a direct travel path. Zero to disable."
 #~ msgstr "Hormak gurutzatzea saihesteko gehieneko desbideratze-distantzia. Ez desbideratu distantzia balio hau baino handiagoa bada. Desbideratze-luzera balio absolutu gisa edo lekualdatze-ibilbide zuzenaren ehuneko gisa zehaztu daiteke (adibidez, 50%). Zero, desgaitzeko."
 
-#~ msgid "Bed temperature for layers except the initial one. A value of 0 means the filament does not support printing on the Cool Plate."
+#~ #,fuzzy
+msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the Cool Plate."
 #~ msgstr "Ohearen tenperatura hasierakoa ez diren geruzetarako. 0 balioak esan nahi du filamentuak ez duela plaka hotzean inprimatzea onartzen."
 
 #~ msgid "°C"
 #~ msgstr "°C"
 
-#~ msgid "Bed temperature for layers except the initial one. A value of 0 means the filament does not support printing on the Textured Cool Plate."
+#~ #,fuzzy
+msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the Textured Cool Plate."
 #~ msgstr "Ohearen tenperatura hasierakoa ez diren geruzetarako. 0 balioak esan nahi du filamentuak ez duela testuradun plaka hotzean inprimatzea onartzen."
 
-#~ msgid "Bed temperature for layers except the initial one. A value of 0 means the filament does not support printing on the Engineering Plate."
+#~ #,fuzzy
+msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the Engineering Plate."
 #~ msgstr "Ohearen tenperatura hasierakoa ez diren geruzetarako. 0 balioak esan nahi du filamentuak ez duela ingeniaritza-plakan inprimatzea onartzen."
 
-#~ msgid "Bed temperature for layers except the initial one. A value of 0 means the filament does not support printing on the High Temp Plate."
+#~ #,fuzzy
+msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the High Temp Plate."
 #~ msgstr "Ohearen tenperatura hasierakoa ez diren geruzetarako. 0 balioak esan nahi du filamentuak ez duela tenperatura altuko plakan inprimatzea onartzen."
 
-#~ msgid "Bed temperature for layers except the initial one. A value of 0 means the filament does not support printing on the Textured PEI Plate."
+#~ #,fuzzy
+msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the Textured PEI Plate."
 #~ msgstr "Ohearen tenperatura hasierakoa ez diren geruzetarako. 0 balioak esan nahi du filamentuak ez duela testuradun PEI plakan inprimatzea onartzen."
 
 #~ msgid "Initial layer"

--- a/localization/i18n/fr/OrcaSlicer_fr.po
+++ b/localization/i18n/fr/OrcaSlicer_fr.po
@@ -6221,10 +6221,10 @@ msgstr "Importer des fichiers 3MF/STL/STEP/SVG/OBJ/AMF"
 msgid "Load a model"
 msgstr "Charger un modèle"
 
-msgid "Import Zip Archive"
+msgid "Import ZIP Archive"
 msgstr "Importer une archive Zip"
 
-msgid "Load models contained within a zip archive"
+msgid "Load models contained within a ZIP archive"
 msgstr "Charger les modèles contenus dans une archive zip"
 
 msgid "Import Configs"
@@ -8000,7 +8000,7 @@ msgstr "Veuillez vous assurer que les G-codes de ces préréglages sont sûrs af
 msgid "Customized Preset"
 msgstr "Préréglage personnalisé"
 
-msgid "Component name(s) inside step file not in UTF8 format!"
+msgid "Component name(s) inside step file not in UTF-8 format!"
 msgstr "Le nom des composants dans le fichier STEP n'est pas au format UTF-8 !"
 
 msgid "Because of unsupported text encoding, garbage characters may appear!"
@@ -8022,10 +8022,10 @@ msgstr "Le volume de l'objet est nul"
 #, c-format, boost-format
 msgid ""
 "The object from file %s is too small, and may be in meters or inches.\n"
-" Do you want to scale to millimeters?"
+"Do you want to scale to millimeters?"
 msgstr ""
 "L’objet du fichier %s est trop petit, et est peut-être en mètres ou en pouces.\n"
-" Voulez-vous le mettre à l’échelle en millimètres ?"
+"Voulez-vous le mettre à l’échelle en millimètres ?"
 
 msgid "Object too small"
 msgstr "Objet trop petit"
@@ -10854,11 +10854,11 @@ msgstr "%s : %s"
 msgid "No modifications need to be copied."
 msgstr "Aucune modification à copier."
 
-msgid "Copy paramters"
+msgid "Copy parameters"
 msgstr "Copier les paramètres"
 
 #, c-format, boost-format
-msgid "Modify paramters of %s"
+msgid "Modify parameters of %s"
 msgstr "Modifier les paramètres de %s"
 
 #, c-format, boost-format
@@ -12475,21 +12475,27 @@ msgstr "mm ou %"
 msgid "Other layers"
 msgstr "Autres couches"
 
-msgid "Bed temperature for layers except the initial one. A value of 0 means the filament does not support printing on the Cool Plate SuperTack."
+#, fuzzy
+msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the Cool Plate SuperTack."
 msgstr "Température du plateau pour les couches sauf la première. Une valeur de 0 signifie que le filament ne prend pas en charge l'impression sur la Cool Plate SuperTack."
 
+#, fuzzy
 msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the Cool Plate."
 msgstr "Il s'agit de la température du plateau pour toutes les couches à l'exception de la première. Une valeur à 0 signifie que ce filament ne peut pas être imprimé sur la plaque \"Cool plate\"."
 
+#, fuzzy
 msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the Textured Cool Plate."
 msgstr "Température du plateau pour les couches à l’exception de la couche initiale. La valeur 0 signifie que le filament ne peut pas être imprimé sur la plaque Cool Plate texturée."
 
+#, fuzzy
 msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the Engineering Plate."
 msgstr "Il s'agit de la température du plateau pour toutes les couches à l'exception de la première. Une valeur à 0 signifie que ce filament ne peut pas être imprimé sur la plaque Engineering."
 
+#, fuzzy
 msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the High Temp Plate."
 msgstr "Il s'agit de la température du plateau pour toutes les couches à l'exception de la première. Une valeur à 0 signifie que ce filament ne peut pas être imprimé sur le plateau haute température (\"High Temp plate\")."
 
+#, fuzzy
 msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the Textured PEI Plate."
 msgstr "Température du plateau après la première couche. 0 signifie que le filament ne peut pas être imprimé sur la plaque PEI texturée."
 
@@ -15703,7 +15709,7 @@ msgstr "Les points de départ et d'arrivée qui se situent entre la zone de coup
 msgid "Reduce infill retraction"
 msgstr "Réduire la rétraction du remplissage"
 
-msgid "Don't retract when the travel is entirely within an infill area. That means the oozing can't been seen. This can reduce times of retraction for complex model and save printing time, but make slicing and G-code generating slower. Note that z-hop is also not performed in areas where retraction is skipped."
+msgid "Don't retract when the travel is entirely within an infill area. That means the oozing can't been seen. This can reduce times of retraction for complex model and save printing time, but make slicing and G-code generating slower. Note that Z-hop is also not performed in areas where retraction is skipped."
 msgstr "Ne pas effectuer de rétraction lors de déplacement en zone de remplissage car même si l’extrudeur suinte, les coulures ne seraient pas visibles. Cela peut réduire les rétractions pour les modèles complexes et économiser du temps d’impression, mais ralentit la découpe et la génération du G-code"
 
 msgid "This option will drop the temperature of the inactive extruders to prevent oozing."
@@ -15873,7 +15879,7 @@ msgstr "Quantité de rétraction après essuyage"
 # AI Translated
 #, no-c-format, no-boost-format
 msgid ""
-"The length of fast retraction after wipe, relative to retraction length.\n"
+"This is the length of fast retraction after wipe, relative to retraction length.\n"
 "The value will be clamped by 100% minus the retract amount before the wipe value."
 msgstr ""
 "La longueur de la rétraction rapide après l'essuyage, relative à la longueur de rétraction.\n"
@@ -15920,7 +15926,7 @@ msgstr "Lorsque la rétraction est déclenchée avant un changement d’outil, l
 msgid "Z-hop height"
 msgstr "Hauteur du saut en Z"
 
-msgid "Whenever there is a retraction, the nozzle is lifted a little to create clearance between the nozzle and the print. This prevents the nozzle from hitting the print when traveling more. Using spiral lines to lift z can prevent stringing."
+msgid "Whenever there is a retraction, the nozzle is lifted a little to create clearance between the nozzle and the print. This prevents the nozzle from hitting the print when traveling more. Using spiral lines to lift Z can prevent stringing."
 msgstr "Chaque fois que la rétraction est effectuée, la buse est légèrement soulevée pour créer un espace entre la buse et l'impression. Il empêche la buse de toucher l'impression lors du déplacement. L'utilisation d'une ligne en spirale pour soulever z peut empêcher l'enfilage"
 
 msgid "Z-hop lower boundary"
@@ -19492,19 +19498,19 @@ msgstr "N’afficher que les noms d’imprimantes avec les modifications apport�
 msgid "Only display the filament names with changes to filament presets."
 msgstr "N’affichez que les noms des filaments lorsque vous modifiez les préréglages des filaments."
 
-msgid "Only printer names with user printer presets will be displayed, and each preset you choose will be exported as a zip."
+msgid "Only printer names with user printer presets will be displayed, and each preset you choose will be exported as a ZIP archive."
 msgstr "Seuls les noms d’imprimantes avec des préréglages d’imprimante utilisateur seront affichés, et chaque préréglage que vous choisissez sera exporté sous forme de fichier zip."
 
 msgid ""
 "Only the filament names with user filament presets will be displayed, \n"
-"and all user filament presets in each filament name you select will be exported as a zip."
+"and all user filament presets in each filament name you select will be exported as a ZIP archive."
 msgstr ""
 "Seuls les noms de filaments contenant des préréglages de filaments utilisateur seront affichés, \n"
 "et tous les préréglages de filament d’utilisateur dans chaque nom de filament que vous sélectionnez seront exportés sous forme de fichier zip."
 
 msgid ""
 "Only printer names with changed process presets will be displayed, \n"
-"and all user process presets in each printer name you select will be exported as a zip."
+"and all user process presets in each printer name you select will be exported as a ZIP archive."
 msgstr ""
 "Seuls les noms d’imprimantes dont les préréglages de traitement ont été modifiés seront affichés, \n"
 "et tous les préréglages de processus de l’utilisateur dans chaque nom d’imprimante que vous sélectionnez seront exportés sous forme de fichier zip."
@@ -19733,7 +19739,7 @@ msgstr "Copier les informations système dans le presse-papiers"
 msgid "We need information for diagnosing source of the issue. Check wiki page for detailed guide."
 msgstr "Nous avons besoin d’informations pour diagnostiquer l’origine du problème. Consultez la page wiki pour un guide détaillé."
 
-msgid "Pack button collects project file and logs of current session onto a zip file."
+msgid "Pack button collects project file and logs of current session onto a ZIP archive."
 msgstr "Le bouton Compresser rassemble le fichier de projet et les journaux de la session actuelle dans un fichier ZIP."
 
 msgid "Any additional visual examples like images or screen recordings might be helpful while reporting the issue."
@@ -19775,7 +19781,7 @@ msgstr "Niveau de journalisation"
 msgid "Stored logs"
 msgstr "Journaux stockés"
 
-msgid "Packs all stored logs onto a zip file."
+msgid "Packs all stored logs onto a ZIP archive."
 msgstr "Compresse tous les journaux stockés dans un fichier ZIP."
 
 msgid "Profiles"
@@ -19842,7 +19848,7 @@ msgstr "Type d’imprimante introuvable, veuillez le sélectionner manuellement.
 msgid "Authorizing..."
 msgstr "Autorisation en cours…"
 
-msgid "Error. Can't get api token for authorization"
+msgid "Error. Can't get API token for authorization"
 msgstr "Erreur : impossible d’obtenir le jeton d’API pour l’autorisation"
 
 msgid "Could not parse server response."
@@ -22161,8 +22167,8 @@ msgstr ""
 #~ msgid "The 3mf has the following customized filament or printer presets:"
 #~ msgstr "Le 3mf dispose de filaments personnalisés ou de préréglages d'imprimante :"
 
-#~ msgid "Name of components inside step file is not UTF8 format!"
-#~ msgstr "Le nom des composants à l'intérieur du fichier .step n'est pas au format UTF8 !"
+#~ msgid "Name of components inside step file is not UTF-8 format!"
+#~ msgstr "Le nom des composants à l'intérieur du fichier .step n'est pas au format UTF-8 !"
 
 #~ msgid "Should printer/filament/process settings be loaded when opening a .3mf?"
 #~ msgstr "Les paramètres de l’imprimante/du filament/du processus doivent-ils être chargés lors de l’ouverture d’un fichier .3mf ?"

--- a/localization/i18n/hu/OrcaSlicer_hu.po
+++ b/localization/i18n/hu/OrcaSlicer_hu.po
@@ -6323,10 +6323,10 @@ msgstr "Importálás 3MF/STL/STEP/SVG/OBJ/AMF"
 msgid "Load a model"
 msgstr "Modell betöltése"
 
-msgid "Import Zip Archive"
+msgid "Import ZIP Archive"
 msgstr "Zip archívum importálása"
 
-msgid "Load models contained within a zip archive"
+msgid "Load models contained within a ZIP archive"
 msgstr "Zip archívumban található modellek betöltése"
 
 msgid "Import Configs"
@@ -8115,7 +8115,7 @@ msgstr "Kérlek, győződj meg arról, hogy a beállításokban található G-k�
 msgid "Customized Preset"
 msgstr "Egyedi beállítás"
 
-msgid "Component name(s) inside step file not in UTF8 format!"
+msgid "Component name(s) inside step file not in UTF-8 format!"
 msgstr "A STEP fájlon belüli komponens neve nem UTF-8 formátumban van!"
 
 # AI Translated
@@ -8139,10 +8139,10 @@ msgstr "Az objektum térfogata nulla"
 #, c-format, boost-format
 msgid ""
 "The object from file %s is too small, and may be in meters or inches.\n"
-" Do you want to scale to millimeters?"
+"Do you want to scale to millimeters?"
 msgstr ""
 "A(z) %s fájlból származó objektum túl kicsi, lehet, hogy méterben vagy hüvelykben lett létrehozva.\n"
-" Szeretnéd milliméterre méretezni?"
+"Szeretnéd milliméterre méretezni?"
 
 msgid "Object too small"
 msgstr "Objektum túl kicsi"
@@ -11030,12 +11030,12 @@ msgid "No modifications need to be copied."
 msgstr "Nincs másolandó módosítás."
 
 # AI Translated
-msgid "Copy paramters"
+msgid "Copy parameters"
 msgstr "Paraméterek másolása"
 
 # AI Translated
 #, c-format, boost-format
-msgid "Modify paramters of %s"
+msgid "Modify parameters of %s"
 msgstr "A(z) %s paramétereinek módosítása"
 
 # AI Translated
@@ -12685,7 +12685,7 @@ msgstr "mm vagy %"
 msgid "Other layers"
 msgstr "Többi réteg"
 
-msgid "Bed temperature for layers except the initial one. A value of 0 means the filament does not support printing on the Cool Plate SuperTack."
+msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the Cool Plate SuperTack."
 msgstr "A kezdőréteg utáni asztalhőmérséklet. A 0 azt jelenti, hogy a filament nem nyomtatható a SuperTack hűvös tálcára."
 
 msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the Cool Plate."
@@ -15957,7 +15957,7 @@ msgid "Reduce infill retraction"
 msgstr "Csökkentett visszahúzás kitöltésnél"
 
 # AI Translated
-msgid "Don't retract when the travel is entirely within an infill area. That means the oozing can't been seen. This can reduce times of retraction for complex model and save printing time, but make slicing and G-code generating slower. Note that z-hop is also not performed in areas where retraction is skipped."
+msgid "Don't retract when the travel is entirely within an infill area. That means the oozing can't been seen. This can reduce times of retraction for complex model and save printing time, but make slicing and G-code generating slower. Note that Z-hop is also not performed in areas where retraction is skipped."
 msgstr "Nem történik visszahúzás, amikor a fej csak kitöltés felett halad el, mert az itt történő szivárgás egyébként sem látható. Ez az opció lerövidítheti a nyomtatási időt a visszahúzások csökkentésével komplex modelleknél, de egyúttal lassabbá teszi a szeletelést és a G-kód generálást. Vedd figyelembe, hogy a Z-emelés sem történik meg azokon a területeken, ahol a visszahúzás ki van hagyva."
 
 msgid "This option will drop the temperature of the inactive extruders to prevent oozing."
@@ -16131,7 +16131,7 @@ msgstr "Visszahúzás mértéke törlés után"
 # AI Translated
 #, no-c-format, no-boost-format
 msgid ""
-"The length of fast retraction after wipe, relative to retraction length.\n"
+"This is the length of fast retraction after wipe, relative to retraction length.\n"
 "The value will be clamped by 100% minus the retract amount before the wipe value."
 msgstr ""
 "A törlés utáni gyors visszahúzás hossza a visszahúzási hosszhoz viszonyítva.\n"
@@ -16178,7 +16178,7 @@ msgstr "Amikor a visszahúzás eszközváltás előtt aktiválódik, a filament 
 msgid "Z-hop height"
 msgstr "Z-emelés magassága"
 
-msgid "Whenever there is a retraction, the nozzle is lifted a little to create clearance between the nozzle and the print. This prevents the nozzle from hitting the print when traveling more. Using spiral lines to lift z can prevent stringing."
+msgid "Whenever there is a retraction, the nozzle is lifted a little to create clearance between the nozzle and the print. This prevents the nozzle from hitting the print when traveling more. Using spiral lines to lift Z can prevent stringing."
 msgstr "Visszahúzáskor a fúvóka egy kicsit megemelkedik, hogy a fúvóka és a nyomtatott tárgy között rés keletkezzen. Ez megakadályozza, hogy a fúvóka nagyobb mozgás közben a tárgynak ütközzön. A Z tengely emelésekor használt körkörös mozgás megelőzheti a szálazást."
 
 msgid "Z-hop lower boundary"
@@ -19796,19 +19796,19 @@ msgstr "Csak azok a nyomtatók jelennek meg, amelyeknél változtak a nyomtató-
 msgid "Only display the filament names with changes to filament presets."
 msgstr "Csak azok a filamentnevek jelennek meg, ahol változtak a filamentbeállítások."
 
-msgid "Only printer names with user printer presets will be displayed, and each preset you choose will be exported as a zip."
+msgid "Only printer names with user printer presets will be displayed, and each preset you choose will be exported as a ZIP archive."
 msgstr "Csak azok a nyomtatónevek jelennek meg, amelyekhez tartoznak felhasználói beállítások. A kiválasztott beállítások ZIP fájlként kerülnek exportálásra."
 
 msgid ""
 "Only the filament names with user filament presets will be displayed, \n"
-"and all user filament presets in each filament name you select will be exported as a zip."
+"and all user filament presets in each filament name you select will be exported as a ZIP archive."
 msgstr ""
 "Csak azok a filamentnevek jelennek meg, amelyekhez tartoznak felhasználói filamentbeállítások,\n"
 "és a kiválasztott filamentnevekhez tartozó összes felhasználói filamentbeállítás ZIP-fájlként lesz exportálva."
 
 msgid ""
 "Only printer names with changed process presets will be displayed, \n"
-"and all user process presets in each printer name you select will be exported as a zip."
+"and all user process presets in each printer name you select will be exported as a ZIP archive."
 msgstr ""
 "Csak azok a nyomtatónevek jelennek meg, amelyekhez módosított folyamatbeállítások tartoznak,\n"
 "és a kiválasztott nyomtatónevekhez tartozó összes felhasználói folyamatbeállítás ZIP-fájlként lesz exportálva."
@@ -20054,7 +20054,7 @@ msgid "We need information for diagnosing source of the issue. Check wiki page f
 msgstr "Információra van szükségünk a probléma forrásának feltárásához. A részletes útmutatót a wiki oldalon találod."
 
 # AI Translated
-msgid "Pack button collects project file and logs of current session onto a zip file."
+msgid "Pack button collects project file and logs of current session onto a ZIP archive."
 msgstr "A Csomagolás gomb egy zip fájlba gyűjti a projektfájlt és az aktuális munkamenet naplóit."
 
 # AI Translated
@@ -20110,7 +20110,7 @@ msgid "Stored logs"
 msgstr "Tárolt naplók"
 
 # AI Translated
-msgid "Packs all stored logs onto a zip file."
+msgid "Packs all stored logs onto a ZIP archive."
 msgstr "Az összes tárolt naplót egy zip fájlba csomagolja."
 
 # AI Translated
@@ -20198,7 +20198,7 @@ msgid "Authorizing..."
 msgstr "Engedélyezés..."
 
 # AI Translated
-msgid "Error. Can't get api token for authorization"
+msgid "Error. Can't get API token for authorization"
 msgstr "Hiba. Nem sikerült API-tokent szerezni az engedélyezéshez"
 
 # AI Translated

--- a/localization/i18n/it/OrcaSlicer_it.po
+++ b/localization/i18n/it/OrcaSlicer_it.po
@@ -6325,10 +6325,10 @@ msgstr "Importa 3MF/STL/STEP/SVG/OBJ/AMF"
 msgid "Load a model"
 msgstr "Carica modello"
 
-msgid "Import Zip Archive"
+msgid "Import ZIP Archive"
 msgstr "Importa archivio Zip"
 
-msgid "Load models contained within a zip archive"
+msgid "Load models contained within a ZIP archive"
 msgstr "Carica i modelli contenuti in un archivio zip"
 
 msgid "Import Configs"
@@ -8119,8 +8119,8 @@ msgstr "Si prega di confermare che i G-code all'interno di questi profili sono s
 msgid "Customized Preset"
 msgstr "Profilo personalizzato"
 
-msgid "Component name(s) inside step file not in UTF8 format!"
-msgstr "Il nome dei componenti all'interno del file STEP non è in formato UTF8!"
+msgid "Component name(s) inside step file not in UTF-8 format!"
+msgstr "Il nome dei componenti all'interno del file STEP non è in formato UTF-8!"
 
 msgid "Because of unsupported text encoding, garbage characters may appear!"
 msgstr "A causa di una codifica del testo non supportata, potrebbero apparire caratteri inutili!"
@@ -8141,10 +8141,10 @@ msgstr "Il volume dell'oggetto è zero"
 #, c-format, boost-format
 msgid ""
 "The object from file %s is too small, and may be in meters or inches.\n"
-" Do you want to scale to millimeters?"
+"Do you want to scale to millimeters?"
 msgstr ""
 "L'oggetto del file %s è troppo piccolo e può essere in metri o pollici.\n"
-" Si desidera scalare in millimetri?"
+"Si desidera scalare in millimetri?"
 
 msgid "Object too small"
 msgstr "Oggetto troppo piccolo"
@@ -11044,12 +11044,12 @@ msgid "No modifications need to be copied."
 msgstr "Non è necessario copiare alcuna modifica."
 
 # AI Translated
-msgid "Copy paramters"
+msgid "Copy parameters"
 msgstr "Copia parametri"
 
 # AI Translated
 #, c-format, boost-format
-msgid "Modify paramters of %s"
+msgid "Modify parameters of %s"
 msgstr "Modifica i parametri di %s"
 
 # AI Translated
@@ -12705,8 +12705,8 @@ msgstr "mm o %"
 msgid "Other layers"
 msgstr "Altri strati"
 
-msgid "Bed temperature for layers except the initial one. A value of 0 means the filament does not support printing on the Cool Plate SuperTack."
-msgstr "Temperatura del piatto per gli strati diversi dal primo. Un valore di 0 significa che il filamento non supporta la stampa su Cool Plate SuperTack."
+msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the Cool Plate SuperTack."
+msgstr "Indica la temperatura del piatto per tutti gli strati eccetto il primo. Un valore di 0 significa che il filamento non supporta la stampa su Cool Plate SuperTack."
 
 msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the Cool Plate."
 msgstr "Indica la temperatura del piatto per tutti gli strati eccetto il primo. Un valore pari a 0 indica che il filamento non supporta la stampa su Piatto a bassa temperatura."
@@ -15976,7 +15976,7 @@ msgid "Reduce infill retraction"
 msgstr "Evita retrazione nel riempimento"
 
 # AI Translated
-msgid "Don't retract when the travel is entirely within an infill area. That means the oozing can't been seen. This can reduce times of retraction for complex model and save printing time, but make slicing and G-code generating slower. Note that z-hop is also not performed in areas where retraction is skipped."
+msgid "Don't retract when the travel is entirely within an infill area. That means the oozing can't been seen. This can reduce times of retraction for complex model and save printing time, but make slicing and G-code generating slower. Note that Z-hop is also not performed in areas where retraction is skipped."
 msgstr "Non ritrarre quando gli spostamenti si trovano interamente in un'area di riempimento. Ciò significa che il trasudo del materiale non è visibile. Questo può ridurre i tempi di retrazione per i modelli complessi e far risparmiare tempo di stampa, ma rende più lente l'elaborazione e la generazione del G-code. Nota che anche il sollevamento Z non viene eseguito nelle aree in cui la retrazione viene saltata."
 
 msgid "This option will drop the temperature of the inactive extruders to prevent oozing."
@@ -16150,7 +16150,7 @@ msgstr "Quantità di retrazione dopo la pulizia"
 # AI Translated
 #, no-c-format, no-boost-format
 msgid ""
-"The length of fast retraction after wipe, relative to retraction length.\n"
+"This is the length of fast retraction after wipe, relative to retraction length.\n"
 "The value will be clamped by 100% minus the retract amount before the wipe value."
 msgstr ""
 "La lunghezza della retrazione rapida dopo la pulizia, relativa alla lunghezza di retrazione.\n"
@@ -16197,7 +16197,7 @@ msgstr "Quando la retrazione viene attivata prima di un cambio testina, il filam
 msgid "Z-hop height"
 msgstr "Altezza sollevamento Z"
 
-msgid "Whenever there is a retraction, the nozzle is lifted a little to create clearance between the nozzle and the print. This prevents the nozzle from hitting the print when traveling more. Using spiral lines to lift z can prevent stringing."
+msgid "Whenever there is a retraction, the nozzle is lifted a little to create clearance between the nozzle and the print. This prevents the nozzle from hitting the print when traveling more. Using spiral lines to lift Z can prevent stringing."
 msgstr "Ogni volta che si verifica una retrazione, l'ugello viene sollevato leggermente per creare spazio tra ugello e stampa. Ciò impedisce all'ugello di colpire la stampa negli spostamenti. L'uso di linee a spirale per il sollevamento sull'asse Z può evitare gli sfilacciamenti sulla stampa."
 
 msgid "Z-hop lower boundary"
@@ -19813,21 +19813,21 @@ msgstr "Vengono visualizzate solo le stampanti con modifiche ai profili di stamp
 msgid "Only display the filament names with changes to filament presets."
 msgstr "Nomi dei filamenti con modifiche ai profili di filamento."
 
-msgid "Only printer names with user printer presets will be displayed, and each preset you choose will be exported as a zip."
+msgid "Only printer names with user printer presets will be displayed, and each preset you choose will be exported as a ZIP archive."
 msgstr ""
 "Nomi delle stampanti con profili creati dell'utente.\n"
 "Tutti i profili selezionati saranno esportati come file zip."
 
 msgid ""
 "Only the filament names with user filament presets will be displayed, \n"
-"and all user filament presets in each filament name you select will be exported as a zip."
+"and all user filament presets in each filament name you select will be exported as a ZIP archive."
 msgstr ""
 "Nomi dei filamenti con profili creati dell'utente.\n"
 "Tutti i profili selezionati saranno esportati come file zip."
 
 msgid ""
 "Only printer names with changed process presets will be displayed, \n"
-"and all user process presets in each printer name you select will be exported as a zip."
+"and all user process presets in each printer name you select will be exported as a ZIP archive."
 msgstr ""
 "Nomi delle stampanti con profili di processo modificati.\n"
 "Tutti i profili selezionati saranno esportati come file zip."
@@ -20072,7 +20072,7 @@ msgid "We need information for diagnosing source of the issue. Check wiki page f
 msgstr "Abbiamo bisogno di informazioni per diagnosticare l'origine del problema. Consulta la pagina wiki per una guida dettagliata."
 
 # AI Translated
-msgid "Pack button collects project file and logs of current session onto a zip file."
+msgid "Pack button collects project file and logs of current session onto a ZIP archive."
 msgstr "Il pulsante Comprimi raccoglie il file di progetto e i log della sessione corrente in un file zip."
 
 # AI Translated
@@ -20128,7 +20128,7 @@ msgid "Stored logs"
 msgstr "Log memorizzati"
 
 # AI Translated
-msgid "Packs all stored logs onto a zip file."
+msgid "Packs all stored logs onto a ZIP archive."
 msgstr "Comprime tutti i log memorizzati in un file zip."
 
 # AI Translated
@@ -20216,7 +20216,7 @@ msgid "Authorizing..."
 msgstr "Autorizzazione in corso..."
 
 # AI Translated
-msgid "Error. Can't get api token for authorization"
+msgid "Error. Can't get API token for authorization"
 msgstr "Errore. Impossibile ottenere il token API per l'autorizzazione"
 
 # AI Translated

--- a/localization/i18n/ja/OrcaSlicer_ja.po
+++ b/localization/i18n/ja/OrcaSlicer_ja.po
@@ -6334,10 +6334,10 @@ msgstr "3MF/STL/STEP/SVG/OBJ/AMFをインポート"
 msgid "Load a model"
 msgstr "モデルを読み込む"
 
-msgid "Import Zip Archive"
+msgid "Import ZIP Archive"
 msgstr "ZIPアーカイブをインポート"
 
-msgid "Load models contained within a zip archive"
+msgid "Load models contained within a ZIP archive"
 msgstr "ZIPアーカイブ内のモデルをロード"
 
 msgid "Import Configs"
@@ -8133,8 +8133,8 @@ msgstr "これらのプリセット内のG-codeがマシンに損傷を与えな
 msgid "Customized Preset"
 msgstr "カスタマイズされたプリセット"
 
-msgid "Component name(s) inside step file not in UTF8 format!"
-msgstr "ファイルのエンコーディング方式はUTF8形式ではありません"
+msgid "Component name(s) inside step file not in UTF-8 format!"
+msgstr "ファイルのエンコーディング方式はUTF-8形式ではありません"
 
 msgid "Because of unsupported text encoding, garbage characters may appear!"
 msgstr "文字化けがあるようです、ご確認ください"
@@ -8155,7 +8155,7 @@ msgstr "オブジェクトの体積が0です"
 #, c-format, boost-format
 msgid ""
 "The object from file %s is too small, and may be in meters or inches.\n"
-" Do you want to scale to millimeters?"
+"Do you want to scale to millimeters?"
 msgstr ""
 "ファイル %s 中のオブジェクトが小さいすぎます、ファイルの単位をご確認ください。\n"
 "mm単位に変換しますか？"
@@ -11068,12 +11068,12 @@ msgid "No modifications need to be copied."
 msgstr "コピーが必要な変更はありません。"
 
 # AI Translated
-msgid "Copy paramters"
+msgid "Copy parameters"
 msgstr "パラメータをコピー"
 
 # AI Translated
 #, c-format, boost-format
-msgid "Modify paramters of %s"
+msgid "Modify parameters of %s"
 msgstr "%sのパラメータを変更"
 
 # AI Translated
@@ -12756,23 +12756,27 @@ msgstr "mm 或は %"
 msgid "Other layers"
 msgstr "他の層"
 
-# AI Translated
-msgid "Bed temperature for layers except the initial one. A value of 0 means the filament does not support printing on the Cool Plate SuperTack."
+#, fuzzy
+msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the Cool Plate SuperTack."
 msgstr "1層目を除く各層のベッド温度です。0の場合、そのフィラメントはCool Plate SuperTackでの印刷に対応していません。"
 
+#, fuzzy
 msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the Cool Plate."
 msgstr "ベッドの温度です（1層目以外）。値が0の場合、フィラメントが常温プレートで使用できないという意味です。"
 
-# AI Translated
+#, fuzzy
 msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the Textured Cool Plate."
 msgstr "1層目を除く各層のベッド温度です。0の場合、そのフィラメントはTextured Cool Plateでの印刷に対応していません。"
 
+#, fuzzy
 msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the Engineering Plate."
 msgstr "ベッドの温度です（1層目以外）。値が0の場合、フィラメントがエンジニアリング プレートで使用できないという意味です。"
 
+#, fuzzy
 msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the High Temp Plate."
 msgstr "ベッドの温度です（1層目以外）。値が0の場合、フィラメントが高温プレートで使用できないという意味です。"
 
+#, fuzzy
 msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the Textured PEI Plate."
 msgstr "1層目以外のベッド温度。値が0の場合、フィラメントがPEIプレートをサポートしない意味をします。"
 
@@ -16238,7 +16242,7 @@ msgstr "カッター領域から廃料排出口までの終始点"
 msgid "Reduce infill retraction"
 msgstr "ｲﾝﾌｨﾙのﾘﾄﾗｸｼｮﾝ低減"
 
-msgid "Don't retract when the travel is entirely within an infill area. That means the oozing can't been seen. This can reduce times of retraction for complex model and save printing time, but make slicing and G-code generating slower. Note that z-hop is also not performed in areas where retraction is skipped."
+msgid "Don't retract when the travel is entirely within an infill area. That means the oozing can't been seen. This can reduce times of retraction for complex model and save printing time, but make slicing and G-code generating slower. Note that Z-hop is also not performed in areas where retraction is skipped."
 msgstr "インフィル領域内の移動はリトラクションしません。造形時間を節約できます。"
 
 msgid "This option will drop the temperature of the inactive extruders to prevent oozing."
@@ -16423,7 +16427,7 @@ msgstr "ワイプ後のリトラクション量"
 # AI Translated
 #, no-c-format, no-boost-format
 msgid ""
-"The length of fast retraction after wipe, relative to retraction length.\n"
+"This is the length of fast retraction after wipe, relative to retraction length.\n"
 "The value will be clamped by 100% minus the retract amount before the wipe value."
 msgstr ""
 "ワイプ後の高速リトラクションの長さで、リトラクション長に対する割合です。\n"
@@ -16474,7 +16478,7 @@ msgstr "ツール交換の前にリトラクションが行われるとき、指
 msgid "Z-hop height"
 msgstr "Zホップの高さ"
 
-msgid "Whenever there is a retraction, the nozzle is lifted a little to create clearance between the nozzle and the print. This prevents the nozzle from hitting the print when traveling more. Using spiral lines to lift z can prevent stringing."
+msgid "Whenever there is a retraction, the nozzle is lifted a little to create clearance between the nozzle and the print. This prevents the nozzle from hitting the print when traveling more. Using spiral lines to lift Z can prevent stringing."
 msgstr "リトラクション時に、ノズルを少し上げてから移動します。この動作でモデルとの衝突を回避できます。"
 
 # AI Translated
@@ -18439,10 +18443,10 @@ msgid "Allow 3MF with newer version to be sliced."
 msgstr "新しいバージョンの3MFのスライスを許可します。"
 
 msgid "Current Z-hop"
-msgstr "現在のz-hop"
+msgstr "現在のZ-hop"
 
 msgid "Contains Z-hop present at the beginning of the custom G-code block."
-msgstr "カスタムGコードブロックの先頭に存在するz-hopを含む。"
+msgstr "カスタムGコードブロックの先頭に存在するZ-hopを含む。"
 
 msgid "Position of the extruder at the beginning of the custom G-code block. If the custom G-code travels somewhere else, it should write to this variable so OrcaSlicer knows where it travels from when it gets control back."
 msgstr "カスタム G コード ブロックの先頭のエクストルーダーのモーターの位置。 カスタム G コードで動かしたとき、PrusaSlicer が制御を取り戻したときにどこから移動したかを認識できるように、この変数に書き込む必要があります。"
@@ -20340,19 +20344,19 @@ msgstr "プリンタ、フィラメント、加工プリセットに変更があ
 msgid "Only display the filament names with changes to filament presets."
 msgstr "フィラメントプリセットを変更したフィラメント名のみを表示します。"
 
-msgid "Only printer names with user printer presets will be displayed, and each preset you choose will be exported as a zip."
+msgid "Only printer names with user printer presets will be displayed, and each preset you choose will be exported as a ZIP archive."
 msgstr "ユーザープリンタプリセットを持つプリンタ名のみが表示され、選択した各プリセットがZIPとしてエクスポートされます。"
 
 msgid ""
 "Only the filament names with user filament presets will be displayed, \n"
-"and all user filament presets in each filament name you select will be exported as a zip."
+"and all user filament presets in each filament name you select will be exported as a ZIP archive."
 msgstr ""
 "ユーザーフィラメントプリセットを含むフィラメント名のみが表示されます、 \n"
 "選択した各フィラメント名に含まれるすべてのユーザーフィラメントプリセットがZIP形式でエクスポートされます。"
 
 msgid ""
 "Only printer names with changed process presets will be displayed, \n"
-"and all user process presets in each printer name you select will be exported as a zip."
+"and all user process presets in each printer name you select will be exported as a ZIP archive."
 msgstr "変更されたプロセスプリセットがあるプリンタ名のみが表示され、選択した各プリンタ名にあるすべてのユーザープロセスプリセットがZIP形式でエクスポートされます。"
 
 msgid "Please select at least one printer or filament."
@@ -20596,7 +20600,7 @@ msgid "We need information for diagnosing source of the issue. Check wiki page f
 msgstr "問題の原因を特定するために情報が必要です。詳しい手順はWikiページをご覧ください。"
 
 # AI Translated
-msgid "Pack button collects project file and logs of current session onto a zip file."
+msgid "Pack button collects project file and logs of current session onto a ZIP archive."
 msgstr "「パック」ボタンは、現在のセッションのプロジェクトファイルとログをzipファイルにまとめます。"
 
 # AI Translated
@@ -20652,7 +20656,7 @@ msgid "Stored logs"
 msgstr "保存されたログ"
 
 # AI Translated
-msgid "Packs all stored logs onto a zip file."
+msgid "Packs all stored logs onto a ZIP archive."
 msgstr "保存されたすべてのログをzipファイルにまとめます。"
 
 # AI Translated
@@ -20740,7 +20744,7 @@ msgid "Authorizing..."
 msgstr "認証中..."
 
 # AI Translated
-msgid "Error. Can't get api token for authorization"
+msgid "Error. Can't get API token for authorization"
 msgstr "エラー。認証用のAPIトークンを取得できません"
 
 # AI Translated

--- a/localization/i18n/ko/OrcaSlicer_ko.po
+++ b/localization/i18n/ko/OrcaSlicer_ko.po
@@ -6348,10 +6348,10 @@ msgstr "3MF/STL/STEP/SVG/OBJ/AMF 가져오기"
 msgid "Load a model"
 msgstr "모델 불러오기"
 
-msgid "Import Zip Archive"
+msgid "Import ZIP Archive"
 msgstr "ZIP 압축파일 가져오기"
 
-msgid "Load models contained within a zip archive"
+msgid "Load models contained within a ZIP archive"
 msgstr "ZIP 압축파일에 포함된 모델 로드"
 
 msgid "Import Configs"
@@ -8152,8 +8152,8 @@ msgid "Customized Preset"
 msgstr "사용자 정의 프리셋"
 
 # AI Translated
-msgid "Component name(s) inside step file not in UTF8 format!"
-msgstr "STEP 파일 내부의 구성 요소 이름이 UTF8 형식이 아닙니다!"
+msgid "Component name(s) inside step file not in UTF-8 format!"
+msgstr "STEP 파일 내부의 구성 요소 이름이 UTF-8 형식이 아닙니다!"
 
 # AI Translated
 msgid "Because of unsupported text encoding, garbage characters may appear!"
@@ -8175,7 +8175,7 @@ msgstr "물체의 부피는 0입니다"
 #, c-format, boost-format
 msgid ""
 "The object from file %s is too small, and may be in meters or inches.\n"
-" Do you want to scale to millimeters?"
+"Do you want to scale to millimeters?"
 msgstr ""
 "%s 파일의 객체가 너무 작습니다. 단위가 미터나 인치일 수 있습니다.\n"
 " mm 단위로 확장하시겠습니까?"
@@ -11188,12 +11188,12 @@ msgid "No modifications need to be copied."
 msgstr "복사할 변경 사항이 없습니다."
 
 # AI Translated
-msgid "Copy paramters"
+msgid "Copy parameters"
 msgstr "매개변수 복사"
 
 # AI Translated
 #, c-format, boost-format
-msgid "Modify paramters of %s"
+msgid "Modify parameters of %s"
 msgstr "%s의 매개변수 수정"
 
 # AI Translated
@@ -12889,22 +12889,27 @@ msgstr "mm 또는 %"
 msgid "Other layers"
 msgstr "다른 레이어"
 
-# AI Translated
-msgid "Bed temperature for layers except the initial one. A value of 0 means the filament does not support printing on the Cool Plate SuperTack."
+#, fuzzy
+msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the Cool Plate SuperTack."
 msgstr "초기 레이어를 제외한 레이어의 베드 온도입니다. 값이 0이면 해당 필라멘트가 쿨 플레이트 슈퍼택에서의 출력을 지원하지 않음을 의미합니다."
 
+#, fuzzy
 msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the Cool Plate."
 msgstr "초기 레이어를 제외한 레이어의 베드 온도. 값 0은 필라멘트가 쿨 플레이트 출력을 지원하지 않음을 의미합니다."
 
+#, fuzzy
 msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the Textured Cool Plate."
 msgstr "초기 레이어를 제외한 레이어의 베드 온도입니다. 값 0은 필라멘트가 텍스처드 쿨 플레이트에서 출력를 지원하지 않음을 의미합니다."
 
+#, fuzzy
 msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the Engineering Plate."
 msgstr "초기 레이어를 제외한 레이어의 베드 온도. 값 0은 필라멘트가 엔지니어링 플레이트 출력을 지원하지 않음을 의미합니다."
 
+#, fuzzy
 msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the High Temp Plate."
 msgstr "초기 레이어를 제외한 레이어의 베드 온도. 값 0은 필라멘트가 고온 플레이트 출력을 지원하지 않음을 의미합니다."
 
+#, fuzzy
 msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the Textured PEI Plate."
 msgstr "초기 레이어를 제외한 레이어의 베드 온도. 값 0은 필라멘트가 텍스처 PEI 플레이트 출력을 지원하지 않음을 의미합니다."
 
@@ -16276,7 +16281,7 @@ msgid "Reduce infill retraction"
 msgstr "채우기 후퇴 감소"
 
 # AI Translated
-msgid "Don't retract when the travel is entirely within an infill area. That means the oozing can't been seen. This can reduce times of retraction for complex model and save printing time, but make slicing and G-code generating slower. Note that z-hop is also not performed in areas where retraction is skipped."
+msgid "Don't retract when the travel is entirely within an infill area. That means the oozing can't been seen. This can reduce times of retraction for complex model and save printing time, but make slicing and G-code generating slower. Note that Z-hop is also not performed in areas where retraction is skipped."
 msgstr "이동 경로가 완전히 채우기 영역 안에 있으면 후퇴하지 않습니다. 흘러내림이 보이지 않기 때문입니다. 복잡한 모델에서 후퇴 횟수를 줄여 출력 시간을 절약할 수 있지만 슬라이싱과 G-code 생성 속도는 느려집니다. 후퇴를 건너뛴 영역에서는 Z 올리기도 수행되지 않습니다."
 
 msgid "This option will drop the temperature of the inactive extruders to prevent oozing."
@@ -16453,7 +16458,7 @@ msgstr "노즐 청소 후 후퇴량"
 # AI Translated
 #, no-c-format, no-boost-format
 msgid ""
-"The length of fast retraction after wipe, relative to retraction length.\n"
+"This is the length of fast retraction after wipe, relative to retraction length.\n"
 "The value will be clamped by 100% minus the retract amount before the wipe value."
 msgstr ""
 "노즐 청소 후 빠른 후퇴의 길이로, 후퇴 길이를 기준으로 합니다.\n"
@@ -16500,7 +16505,7 @@ msgstr "툴 체인지 전에 후퇴가 실행되면 지정한 양만큼 필라�
 msgid "Z-hop height"
 msgstr "Z올리기 높이"
 
-msgid "Whenever there is a retraction, the nozzle is lifted a little to create clearance between the nozzle and the print. This prevents the nozzle from hitting the print when traveling more. Using spiral lines to lift z can prevent stringing."
+msgid "Whenever there is a retraction, the nozzle is lifted a little to create clearance between the nozzle and the print. This prevents the nozzle from hitting the print when traveling more. Using spiral lines to lift Z can prevent stringing."
 msgstr "후퇴가 완료될 때마다 노즐이 약간 올라가서 노즐과 출력물 사이에 간격이 생깁니다. 이동 시 노즐이 출력물에 닿는 것을 방지합니다. 나선형 선을 사용하여 z를 들어 올리면 스트링 현상을 방지할 수 있습니다"
 
 msgid "Z-hop lower boundary"
@@ -20213,19 +20218,19 @@ msgstr "프린터, 필라멘트 및 프로세스 사전 설정이 변경된 경�
 msgid "Only display the filament names with changes to filament presets."
 msgstr "필라멘트 사전 설정이 변경된 경우에만 필라멘트 이름을 표시합니다."
 
-msgid "Only printer names with user printer presets will be displayed, and each preset you choose will be exported as a zip."
+msgid "Only printer names with user printer presets will be displayed, and each preset you choose will be exported as a ZIP archive."
 msgstr "사용자 프린터 사전 설정이 있는 프린터 이름만 표시되며, 선택한 각 사전 설정은 zip으로 내보내집니다."
 
 msgid ""
 "Only the filament names with user filament presets will be displayed, \n"
-"and all user filament presets in each filament name you select will be exported as a zip."
+"and all user filament presets in each filament name you select will be exported as a ZIP archive."
 msgstr ""
 "사용자 필라멘트 사전 설정이 있는 필라멘트 이름만 표시됩니다.\n"
 "선택한 각 필라멘트 이름의 모든 사용자 필라멘트 사전 설정은 zip으로 내보내집니다."
 
 msgid ""
 "Only printer names with changed process presets will be displayed, \n"
-"and all user process presets in each printer name you select will be exported as a zip."
+"and all user process presets in each printer name you select will be exported as a ZIP archive."
 msgstr ""
 "프로세스 사전 설정이 변경된 프린터 이름만 표시됩니다.\n"
 "선택한 각 프린터 이름의 모든 사용자 프로세스 사전 설정은 zip으로 내보내집니다."
@@ -20469,7 +20474,7 @@ msgid "We need information for diagnosing source of the issue. Check wiki page f
 msgstr "문제의 원인을 진단하려면 정보가 필요합니다. 자세한 안내는 위키 페이지를 확인하십시오."
 
 # AI Translated
-msgid "Pack button collects project file and logs of current session onto a zip file."
+msgid "Pack button collects project file and logs of current session onto a ZIP archive."
 msgstr "패키지 버튼은 현재 세션의 프로젝트 파일과 로그를 zip 파일로 모읍니다."
 
 # AI Translated
@@ -20525,7 +20530,7 @@ msgid "Stored logs"
 msgstr "저장된 로그"
 
 # AI Translated
-msgid "Packs all stored logs onto a zip file."
+msgid "Packs all stored logs onto a ZIP archive."
 msgstr "저장된 모든 로그를 zip 파일로 묶습니다."
 
 # AI Translated
@@ -20613,7 +20618,7 @@ msgid "Authorizing..."
 msgstr "인증 중..."
 
 # AI Translated
-msgid "Error. Can't get api token for authorization"
+msgid "Error. Can't get API token for authorization"
 msgstr "오류. 인증용 API 토큰을 가져올 수 없습니다"
 
 # AI Translated

--- a/localization/i18n/lt/OrcaSlicer_lt.po
+++ b/localization/i18n/lt/OrcaSlicer_lt.po
@@ -6311,10 +6311,10 @@ msgstr "Importuoti 3MF/STL/STEP/SVG/OBJ/AMF"
 msgid "Load a model"
 msgstr "Įkelti modelį"
 
-msgid "Import Zip Archive"
+msgid "Import ZIP Archive"
 msgstr "Importuoti Zip archyvą"
 
-msgid "Load models contained within a zip archive"
+msgid "Load models contained within a ZIP archive"
 msgstr "Įkelti modelius iš ZIP archyvo"
 
 msgid "Import Configs"
@@ -8110,7 +8110,7 @@ msgstr "Patvirtinkite, kad šiuose profiliuose esantis G-kodas yra saugus, kad i
 msgid "Customized Preset"
 msgstr "Pritaikytas profilis"
 
-msgid "Component name(s) inside step file not in UTF8 format!"
+msgid "Component name(s) inside step file not in UTF-8 format!"
 msgstr "Komponentų pavadinimai STEP faile nėra UTF-8 formato!"
 
 msgid "Because of unsupported text encoding, garbage characters may appear!"
@@ -8132,7 +8132,7 @@ msgstr "Objekto tūris nulinis"
 #, c-format, boost-format
 msgid ""
 "The object from file %s is too small, and may be in meters or inches.\n"
-" Do you want to scale to millimeters?"
+"Do you want to scale to millimeters?"
 msgstr ""
 "Objektas iš failo „%s“ yra per mažas ir galimai nurodytas metrais arba coliais.\n"
 "Ar norite mastelį pakeisti į milimetrus?"
@@ -10981,11 +10981,11 @@ msgstr "%s: %s"
 msgid "No modifications need to be copied."
 msgstr "Nereikia kopijuoti jokių modifikacijų"
 
-msgid "Copy paramters"
+msgid "Copy parameters"
 msgstr "Kopijuoti parametrus"
 
 #, c-format, boost-format
-msgid "Modify paramters of %s"
+msgid "Modify parameters of %s"
 msgstr "Modifikuoti %s parametrus"
 
 #, c-format, boost-format
@@ -12609,7 +12609,7 @@ msgstr "mm arba %"
 msgid "Other layers"
 msgstr "Kiti sluoksniai"
 
-msgid "Bed temperature for layers except the initial one. A value of 0 means the filament does not support printing on the Cool Plate SuperTack."
+msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the Cool Plate SuperTack."
 msgstr "Pagrindo temperatūra visiems sluoksniams, išskyrus pirmąjį. Reikšmė 0 reiškia, kad ši gija nepritaikyta spausdinti ant „Cool Plate SuperTack“ pagrindo."
 
 msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the Cool Plate."
@@ -15839,7 +15839,7 @@ msgstr "Pradžios ir pabaigos taškai, esantys tarp gijos kirpimo zonos ir atlie
 msgid "Reduce infill retraction"
 msgstr "Sumažinti užpildo įtraukimą (Retraction)"
 
-msgid "Don't retract when the travel is entirely within an infill area. That means the oozing can't been seen. This can reduce times of retraction for complex model and save printing time, but make slicing and G-code generating slower. Note that z-hop is also not performed in areas where retraction is skipped."
+msgid "Don't retract when the travel is entirely within an infill area. That means the oozing can't been seen. This can reduce times of retraction for complex model and save printing time, but make slicing and G-code generating slower. Note that Z-hop is also not performed in areas where retraction is skipped."
 msgstr "Neatlikti gijos įtraukimo, kai tuščioji eiga vyksta tik užpildo zonoje. Tokiu atveju gijos varvėjimas (oozing) išorėje bus nematomas. Tai leidžia sumažinti įtraukimų skaičių sudėtingiems modeliams ir sutaupyti spausdinimo laiko, tačiau sulėtina sluoksniavimą bei G-kodo (G-code) generavimą. Pastaba: zonose, kuriose įtraukimas praleidžiamas, „Z-hop“ judesys taip pat neatliekamas."
 
 msgid "This option will drop the temperature of the inactive extruders to prevent oozing."
@@ -16005,7 +16005,7 @@ msgstr "Atitraukimo kiekis po nubraukimo"
 # AI Translated
 #, no-c-format, no-boost-format
 msgid ""
-"The length of fast retraction after wipe, relative to retraction length.\n"
+"This is the length of fast retraction after wipe, relative to retraction length.\n"
 "The value will be clamped by 100% minus the retract amount before the wipe value."
 msgstr ""
 "Greito atitraukimo ilgis po nubraukimo, atsižvelgiant į atitraukimo ilgį.\n"
@@ -16052,7 +16052,7 @@ msgstr "Kai atitraukimas suaktyvinamas prieš įrankio keitimą, gija atitraukia
 msgid "Z-hop height"
 msgstr "„Z-hop“ (pakėlimo) aukštis"
 
-msgid "Whenever there is a retraction, the nozzle is lifted a little to create clearance between the nozzle and the print. This prevents the nozzle from hitting the print when traveling more. Using spiral lines to lift z can prevent stringing."
+msgid "Whenever there is a retraction, the nozzle is lifted a little to create clearance between the nozzle and the print. This prevents the nozzle from hitting the print when traveling more. Using spiral lines to lift Z can prevent stringing."
 msgstr "Kaskart atliekant atitraukimą, purkštukas šiek tiek pakeliamas, kad tarp jo ir spaudinio atsirastų tarpas. Tai apsaugo nuo purkštuko užkliudymo už spaudinio judėjimo metu. „Spiralinių“ linijų naudojimas Z ašies kėlimui gali padėti išvengti „tįstančių siūlų“ (angl. \"stringing\")."
 
 msgid "Z-hop lower boundary"
@@ -19649,19 +19649,19 @@ msgstr "Rodomi tik tie spausdintuvai, kurių spausdintuvo, kaitinamojo siūlo ir
 msgid "Only display the filament names with changes to filament presets."
 msgstr "Rodyti tik tuos gijų pavadinimus, kurių gijos profiliai buvo pakeisti."
 
-msgid "Only printer names with user printer presets will be displayed, and each preset you choose will be exported as a zip."
+msgid "Only printer names with user printer presets will be displayed, and each preset you choose will be exported as a ZIP archive."
 msgstr "Bus rodomi tik tie spausdintuvų pavadinimai, kurie turi naudotojo sukurtų profilių, o kiekvienas pasirinktas profilis bus eksportuotas kaip ZIP failas."
 
 msgid ""
 "Only the filament names with user filament presets will be displayed, \n"
-"and all user filament presets in each filament name you select will be exported as a zip."
+"and all user filament presets in each filament name you select will be exported as a ZIP archive."
 msgstr ""
 "Bus rodomi tik tie gijų pavadinimai, kurie turi naudotojo sukurtų profilių, \n"
 "o visi pasirinkto pavadinimo naudotojo gijos profiliai bus eksportuoti kaip ZIP failas."
 
 msgid ""
 "Only printer names with changed process presets will be displayed, \n"
-"and all user process presets in each printer name you select will be exported as a zip."
+"and all user process presets in each printer name you select will be exported as a ZIP archive."
 msgstr ""
 "Bus rodomi tik tie spausdintuvų pavadinimai, kurie turi pakeistų proceso profilių, \n"
 "o visi pasirinkto spausdintuvo naudotojo proceso profiliai bus eksportuoti kaip ZIP failas."
@@ -19891,7 +19891,7 @@ msgstr "Kopijuoti sistemos informaciją į iškarpinę"
 msgid "We need information for diagnosing source of the issue. Check wiki page for detailed guide."
 msgstr "Mums reikia informacijos problemos šaltiniui diagnozuoti. Išsamų vadovą rasite „Wiki“ puslapyje."
 
-msgid "Pack button collects project file and logs of current session onto a zip file."
+msgid "Pack button collects project file and logs of current session onto a ZIP archive."
 msgstr "Mygtukas „Supakuoti“ (Pack) surenka projekto failą ir dabartinės sesijos žurnalus į ZIP failą."
 
 msgid "Any additional visual examples like images or screen recordings might be helpful while reporting the issue."
@@ -19933,7 +19933,7 @@ msgstr "Žurnalo lygis"
 msgid "Stored logs"
 msgstr "Saugomi žurnalai"
 
-msgid "Packs all stored logs onto a zip file."
+msgid "Packs all stored logs onto a ZIP archive."
 msgstr "Supakuoja visus saugomus žurnalus į ZIP failą."
 
 msgid "Profiles"
@@ -20000,7 +20000,7 @@ msgstr "Spausdintuvo tipas nerastas, pasirinkite rankiniu būdu."
 msgid "Authorizing..."
 msgstr "Autorizuojama..."
 
-msgid "Error. Can't get api token for authorization"
+msgid "Error. Can't get API token for authorization"
 msgstr "Klaida. Nepavyko gauti API žetono (token) autorizacijai"
 
 msgid "Could not parse server response."
@@ -22206,19 +22206,11 @@ msgstr ""
 #~ msgid "Please correct them in the param tabs"
 #~ msgstr "Prašome juos ištaisyti parametrų skirtukuose"
 
-#~ msgid "Name of components inside STEP file is not UTF8 format!"
+#~ msgid "Name of components inside STEP file is not UTF-8 format!"
 #~ msgstr "Komponentų pavadinimai STEP faile nėra UTF-8 formato!"
 
 #~ msgid "The name may show garbage characters!"
 #~ msgstr "Pavadinimas gali rodyti neskaitomus simbolius!"
-
-#, c-format, boost-format
-#~ msgid ""
-#~ "The object from file %s is too small, and maybe in meters or inches.\n"
-#~ " Do you want to scale to millimeters?"
-#~ msgstr ""
-#~ "Objektas iš failo „%s“ yra per mažas ir galimai nurodytas metrais arba coliais.\n"
-#~ "Ar norite mastelį pakeisti į milimetrus?"
 
 #~ msgid ""
 #~ "This file contains several objects positioned at multiple heights.\n"
@@ -22609,19 +22601,24 @@ msgstr ""
 #~ msgid "Maximum detour distance for avoiding crossing wall. Don't detour if the detour distance is larger than this value. Detour length could be specified either as an absolute value or as percentage (for example 50%) of a direct travel path. Zero to disable."
 #~ msgstr "Maksimalus apylankos atstumas sienelių kirtimui išvengti. Apylanka nedaroma, jei jos atstumas viršija šią reikšmę. Apylankos ilgis gali būti nurodomas absoliučia verte arba procentais (pavyzdžiui, 50 %) nuo tiesioginio judėjimo trajektorijos. Įrašius 0 – funkcija išjungiama."
 
-#~ msgid "Bed temperature for layers except the initial one. A value of 0 means the filament does not support printing on the Cool Plate."
+#~ #,fuzzy
+msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the Cool Plate."
 #~ msgstr "Pagrindo temperatūra visiems sluoksniams, išskyrus pirmąjį. Reikšmė 0 reiškia, kad ši gija nepritaikyta spausdinti ant šalto pagrindo (Cool Plate)."
 
-#~ msgid "Bed temperature for layers except the initial one. A value of 0 means the filament does not support printing on the Textured Cool Plate."
+#~ #,fuzzy
+msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the Textured Cool Plate."
 #~ msgstr "Pagrindo temperatūra visiems sluoksniams, išskyrus pirmąjį. Reikšmė 0 reiškia, kad ši gija nepritaikyta spausdinti ant tekstūruoto šalto pagrindo (Textured Cool Plate)."
 
-#~ msgid "Bed temperature for layers except the initial one. A value of 0 means the filament does not support printing on the Engineering Plate."
+#~ #,fuzzy
+msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the Engineering Plate."
 #~ msgstr "Pagrindo temperatūra visiems sluoksniams, išskyrus pirmąjį. Reikšmė 0 reiškia, kad ši gija nepritaikyta spausdinti ant inžinerinio pagrindo (Engineering Plate)."
 
-#~ msgid "Bed temperature for layers except the initial one. A value of 0 means the filament does not support printing on the High Temp Plate."
+#~ #,fuzzy
+msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the High Temp Plate."
 #~ msgstr "Pagrindo temperatūra visiems sluoksniams, išskyrus pirmąjį. Reikšmė 0 reiškia, kad ši gija nepritaikyta spausdinti ant aukštos temperatūros pagrindo (High Temp Plate)."
 
-#~ msgid "Bed temperature for layers except the initial one. A value of 0 means the filament does not support printing on the Textured PEI Plate."
+#~ #,fuzzy
+msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the Textured PEI Plate."
 #~ msgstr "Pagrindo temperatūra visiems sluoksniams, išskyrus pirmąjį. Reikšmė 0 reiškia, kad ši gija nepritaikyta spausdinti ant tekstūruoto PEI pagrindo (Textured PEI Plate)."
 
 #~ msgid "Bed temperature of the first layer. A value of 0 means the filament does not support printing on the Cool Plate SuperTack."

--- a/localization/i18n/lt/OrcaSlicer_lt.po
+++ b/localization/i18n/lt/OrcaSlicer_lt.po
@@ -3,7 +3,6 @@
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
@@ -22600,26 +22599,6 @@ msgstr ""
 
 #~ msgid "Maximum detour distance for avoiding crossing wall. Don't detour if the detour distance is larger than this value. Detour length could be specified either as an absolute value or as percentage (for example 50%) of a direct travel path. Zero to disable."
 #~ msgstr "Maksimalus apylankos atstumas sienelių kirtimui išvengti. Apylanka nedaroma, jei jos atstumas viršija šią reikšmę. Apylankos ilgis gali būti nurodomas absoliučia verte arba procentais (pavyzdžiui, 50 %) nuo tiesioginio judėjimo trajektorijos. Įrašius 0 – funkcija išjungiama."
-
-#~ #,fuzzy
-msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the Cool Plate."
-#~ msgstr "Pagrindo temperatūra visiems sluoksniams, išskyrus pirmąjį. Reikšmė 0 reiškia, kad ši gija nepritaikyta spausdinti ant šalto pagrindo (Cool Plate)."
-
-#~ #,fuzzy
-msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the Textured Cool Plate."
-#~ msgstr "Pagrindo temperatūra visiems sluoksniams, išskyrus pirmąjį. Reikšmė 0 reiškia, kad ši gija nepritaikyta spausdinti ant tekstūruoto šalto pagrindo (Textured Cool Plate)."
-
-#~ #,fuzzy
-msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the Engineering Plate."
-#~ msgstr "Pagrindo temperatūra visiems sluoksniams, išskyrus pirmąjį. Reikšmė 0 reiškia, kad ši gija nepritaikyta spausdinti ant inžinerinio pagrindo (Engineering Plate)."
-
-#~ #,fuzzy
-msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the High Temp Plate."
-#~ msgstr "Pagrindo temperatūra visiems sluoksniams, išskyrus pirmąjį. Reikšmė 0 reiškia, kad ši gija nepritaikyta spausdinti ant aukštos temperatūros pagrindo (High Temp Plate)."
-
-#~ #,fuzzy
-msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the Textured PEI Plate."
-#~ msgstr "Pagrindo temperatūra visiems sluoksniams, išskyrus pirmąjį. Reikšmė 0 reiškia, kad ši gija nepritaikyta spausdinti ant tekstūruoto PEI pagrindo (Textured PEI Plate)."
 
 #~ msgid "Bed temperature of the first layer. A value of 0 means the filament does not support printing on the Cool Plate SuperTack."
 #~ msgstr "Pirmojo sluoksnio pagrindo temperatūra. Reikšmė 0 reiškia, kad ši gija nepritaikyta spausdinti ant „Cool Plate SuperTack“ pagrindo."

--- a/localization/i18n/nl/OrcaSlicer_nl.po
+++ b/localization/i18n/nl/OrcaSlicer_nl.po
@@ -6887,11 +6887,11 @@ msgid "Load a model"
 msgstr "Laad een model"
 
 # AI Translated
-msgid "Import Zip Archive"
+msgid "Import ZIP Archive"
 msgstr "ZIP-archief importeren"
 
 # AI Translated
-msgid "Load models contained within a zip archive"
+msgid "Load models contained within a ZIP archive"
 msgstr "Laad modellen uit een ZIP-archief"
 
 msgid "Import Configs"
@@ -8860,8 +8860,8 @@ msgstr "Controleer of de G-codes in deze presets veilig zijn om schade aan de ma
 msgid "Customized Preset"
 msgstr "Aangepaste voorinstelling"
 
-msgid "Component name(s) inside step file not in UTF8 format!"
-msgstr "Naam van componenten in step-bestand is niet UTF8-formaat!"
+msgid "Component name(s) inside step file not in UTF-8 format!"
+msgstr "Naam van componenten in step-bestand is niet UTF-8-formaat!"
 
 msgid "Because of unsupported text encoding, garbage characters may appear!"
 msgstr "Vanwege niet-ondersteunde tekstcodering kunnen er onjuiste tekens verschijnen!"
@@ -8883,10 +8883,10 @@ msgstr "Het volume van het object is 0"
 #, c-format, boost-format
 msgid ""
 "The object from file %s is too small, and may be in meters or inches.\n"
-" Do you want to scale to millimeters?"
+"Do you want to scale to millimeters?"
 msgstr ""
 "Het object uit bestand %s is erg klein, en misschien in meters of inches.\n"
-" Wil je schalen naar millimeters?"
+"Wil je schalen naar millimeters?"
 
 msgid "Object too small"
 msgstr "He tobject is te klein"
@@ -12027,12 +12027,12 @@ msgid "No modifications need to be copied."
 msgstr "Er hoeven geen wijzigingen te worden gekopieerd."
 
 # AI Translated
-msgid "Copy paramters"
+msgid "Copy parameters"
 msgstr "Parameters kopiëren"
 
 # AI Translated
 #, c-format, boost-format
-msgid "Modify paramters of %s"
+msgid "Modify parameters of %s"
 msgstr "Parameters van %s wijzigen"
 
 # AI Translated
@@ -13843,23 +13843,27 @@ msgstr "mm of %"
 msgid "Other layers"
 msgstr "Andere lagen"
 
-# AI Translated
-msgid "Bed temperature for layers except the initial one. A value of 0 means the filament does not support printing on the Cool Plate SuperTack."
+#, fuzzy
+msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the Cool Plate SuperTack."
 msgstr "Bedtemperatuur voor alle lagen behalve de eerste. Een waarde van 0 betekent dat het filament printen op de Cool Plate SuperTack niet ondersteunt."
 
+#, fuzzy
 msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the Cool Plate."
 msgstr "Dit is de bedtemperatuur voor alle lagen behalve de eerste. Een waarde van 0 betekent dat het filament het afdrukken op de Cool Plate niet ondersteunt."
 
-# AI Translated
+#, fuzzy
 msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the Textured Cool Plate."
 msgstr "Dit is de bedtemperatuur voor alle lagen behalve de eerste. Een waarde van 0 betekent dat het filament printen op de Textured Cool Plate niet ondersteunt."
 
+#, fuzzy
 msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the Engineering Plate."
 msgstr "Dit is de bedtemperatuur voor lagen, behalve voor de eerste. Een waarde van 0 betekent dat het filament afdrukken op de Engineering Plate niet ondersteunt."
 
+#, fuzzy
 msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the High Temp Plate."
 msgstr "Dit is de bedtemperatuur voor lagen, behalve voor de eerste. Een waarde van 0 betekent dat het filament printen op de High Temp Plate niet ondersteunt."
 
+#, fuzzy
 msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the Textured PEI Plate."
 msgstr "Bedtemperatuur na de eerste laag. 0 betekent dat het filament niet wordt ondersteund op de getextureerde PEI-plaat."
 
@@ -17510,8 +17514,8 @@ msgid "Reduce infill retraction"
 msgstr "Reduceer terugtrekken (retraction) bij vulling (infill)"
 
 # AI Translated
-msgid "Don't retract when the travel is entirely within an infill area. That means the oozing can't been seen. This can reduce times of retraction for complex model and save printing time, but make slicing and G-code generating slower. Note that z-hop is also not performed in areas where retraction is skipped."
-msgstr "Trek niet terug als de beweging zich volledig in een opvulgebied bevindt. Dat betekent dat het sijpelen niet zichtbaar is. Dit kan de retraction times voor complexe modellen verkorten en printtijd besparen, maar het segmenteren en het genereren van G-codes langzamer maken. Let op: z-hop wordt ook niet uitgevoerd in gebieden waar het terugtrekken wordt overgeslagen."
+msgid "Don't retract when the travel is entirely within an infill area. That means the oozing can't been seen. This can reduce times of retraction for complex model and save printing time, but make slicing and G-code generating slower. Note that Z-hop is also not performed in areas where retraction is skipped."
+msgstr "Trek niet terug als de beweging zich volledig in een opvulgebied bevindt. Dat betekent dat het sijpelen niet zichtbaar is. Dit kan de retraction times voor complexe modellen verkorten en printtijd besparen, maar het segmenteren en het genereren van G-codes langzamer maken. Let op: Z-hop wordt ook niet uitgevoerd in gebieden waar het terugtrekken wordt overgeslagen."
 
 # AI Translated
 msgid "This option will drop the temperature of the inactive extruders to prevent oozing."
@@ -17700,7 +17704,7 @@ msgstr "Terugtrekhoeveelheid na vegen"
 # AI Translated
 #, no-c-format, no-boost-format
 msgid ""
-"The length of fast retraction after wipe, relative to retraction length.\n"
+"This is the length of fast retraction after wipe, relative to retraction length.\n"
 "The value will be clamped by 100% minus the retract amount before the wipe value."
 msgstr ""
 "De lengte van de snelle terugtrekking na het vegen, relatief ten opzichte van de terugtreklengte.\n"
@@ -17754,7 +17758,7 @@ msgstr "Wanneer het terugtrekken vóór een gereedschapswissel wordt geactiveerd
 msgid "Z-hop height"
 msgstr "Z-hop-hoogte"
 
-msgid "Whenever there is a retraction, the nozzle is lifted a little to create clearance between the nozzle and the print. This prevents the nozzle from hitting the print when traveling more. Using spiral lines to lift z can prevent stringing."
+msgid "Whenever there is a retraction, the nozzle is lifted a little to create clearance between the nozzle and the print. This prevents the nozzle from hitting the print when traveling more. Using spiral lines to lift Z can prevent stringing."
 msgstr "Wanneer er een terugtrekking (retraction) is, wordt het mondstuk een beetje opgetild om ruimte te creëren tussen het mondstuk en de print. Dit voorkomt dat het mondstuk de print raakt bij verplaatsen. Het gebruik van spiraallijnen om Z op te tillen kan stringing voorkomen."
 
 msgid "Z-hop lower boundary"
@@ -19764,7 +19768,7 @@ msgid "Allow 3MF with newer version to be sliced."
 msgstr "Sta toe dat een 3MF met een nieuwere versie wordt geslicet."
 
 msgid "Current Z-hop"
-msgstr "Huidige z-hop"
+msgstr "Huidige Z-hop"
 
 # AI Translated
 msgid "Contains Z-hop present at the beginning of the custom G-code block."
@@ -21801,19 +21805,19 @@ msgstr "Alleen printers met wijzigingen in printer-, filament- en proces presets
 msgid "Only display the filament names with changes to filament presets."
 msgstr "Geef alleen de filamentnamen weer met wijzigingen in filament presets."
 
-msgid "Only printer names with user printer presets will be displayed, and each preset you choose will be exported as a zip."
+msgid "Only printer names with user printer presets will be displayed, and each preset you choose will be exported as a ZIP archive."
 msgstr "Alleen printernamen met gebruikersprinter presets worden weergegeven en elke preset die je kiest, wordt als zip geëxporteerd."
 
 msgid ""
 "Only the filament names with user filament presets will be displayed, \n"
-"and all user filament presets in each filament name you select will be exported as a zip."
+"and all user filament presets in each filament name you select will be exported as a ZIP archive."
 msgstr ""
 "Alleen de filamentnamen met gebruikers presets worden weergegeven, \n"
 "en alle gebruikers presets in elke filamentnaam die u selecteert, worden geëxporteerd als zip-bestand."
 
 msgid ""
 "Only printer names with changed process presets will be displayed, \n"
-"and all user process presets in each printer name you select will be exported as a zip."
+"and all user process presets in each printer name you select will be exported as a ZIP archive."
 msgstr ""
 "Alleen printernamen met gewijzigde proces presets worden weergegeven, \n"
 "en alle gebruikersproces presets in elke printernaam die u selecteert, worden als zip geëxporteerd."
@@ -22068,7 +22072,7 @@ msgid "We need information for diagnosing source of the issue. Check wiki page f
 msgstr "We hebben informatie nodig om de oorzaak van het probleem te achterhalen. Raadpleeg de wikipagina voor een uitgebreide handleiding."
 
 # AI Translated
-msgid "Pack button collects project file and logs of current session onto a zip file."
+msgid "Pack button collects project file and logs of current session onto a ZIP archive."
 msgstr "De knop Inpakken verzamelt het projectbestand en de logboeken van de huidige sessie in een zipbestand."
 
 # AI Translated
@@ -22124,7 +22128,7 @@ msgid "Stored logs"
 msgstr "Opgeslagen logboeken"
 
 # AI Translated
-msgid "Packs all stored logs onto a zip file."
+msgid "Packs all stored logs onto a ZIP archive."
 msgstr "Pakt alle opgeslagen logboeken in een zipbestand."
 
 # AI Translated
@@ -22212,7 +22216,7 @@ msgid "Authorizing..."
 msgstr "Autoriseren..."
 
 # AI Translated
-msgid "Error. Can't get api token for authorization"
+msgid "Error. Can't get API token for authorization"
 msgstr "Fout. Kan geen API-token voor autorisatie ophalen"
 
 # AI Translated

--- a/localization/i18n/pl/OrcaSlicer_pl.po
+++ b/localization/i18n/pl/OrcaSlicer_pl.po
@@ -6467,10 +6467,10 @@ msgstr "Importuj 3MF/STL/STEP/SVG/OBJ/AMF"
 msgid "Load a model"
 msgstr "Wczytaj model"
 
-msgid "Import Zip Archive"
+msgid "Import ZIP Archive"
 msgstr "Importuj archiwum ZIP"
 
-msgid "Load models contained within a zip archive"
+msgid "Load models contained within a ZIP archive"
 msgstr "Wczytaj modele zawarte w archiwum ZIP"
 
 msgid "Import Configs"
@@ -8309,8 +8309,8 @@ msgstr "Proszę potwierdź, że G-code w tych profilach jest bezpieczny, aby zap
 msgid "Customized Preset"
 msgstr "Dostosowany profil"
 
-msgid "Component name(s) inside step file not in UTF8 format!"
-msgstr "Nazwa komponentów w pliku step nie jest w formacie UTF8!"
+msgid "Component name(s) inside step file not in UTF-8 format!"
+msgstr "Nazwa komponentów w pliku step nie jest w formacie UTF-8!"
 
 msgid "Because of unsupported text encoding, garbage characters may appear!"
 msgstr "Nazwa może zawierać nieczytelne znaki!"
@@ -8331,10 +8331,10 @@ msgstr "Objętość tego obiektu wynosi zero"
 #, c-format, boost-format
 msgid ""
 "The object from file %s is too small, and may be in meters or inches.\n"
-" Do you want to scale to millimeters?"
+"Do you want to scale to millimeters?"
 msgstr ""
 "Obiekt z pliku %s jest zbyt mały i możliwe, że jest określony w metrach lub calach.\n"
-" Czy przeskalować na milimetry?"
+"Czy przeskalować na milimetry?"
 
 msgid "Object too small"
 msgstr "Zbyt mały obiekt"
@@ -11363,12 +11363,12 @@ msgid "No modifications need to be copied."
 msgstr "Nie ma modyfikacji do skopiowania."
 
 # AI Translated
-msgid "Copy paramters"
+msgid "Copy parameters"
 msgstr "Kopiuj parametry"
 
 # AI Translated
 #, c-format, boost-format
-msgid "Modify paramters of %s"
+msgid "Modify parameters of %s"
 msgstr "Zmodyfikuj parametry %s"
 
 # AI Translated
@@ -13060,22 +13060,27 @@ msgstr "mm lub %"
 msgid "Other layers"
 msgstr "Pozostałe warstwy"
 
-# AI Translated
-msgid "Bed temperature for layers except the initial one. A value of 0 means the filament does not support printing on the Cool Plate SuperTack."
+#, fuzzy
+msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the Cool Plate SuperTack."
 msgstr "Temperatura stołu dla warstw poza pierwszą. Wartość 0 oznacza, że filament nie obsługuje druku na Cool Plate SuperTack."
 
+#, fuzzy
 msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the Cool Plate."
 msgstr "Temperatura stołu dla warstw poza pierwszą. Wartość 0 oznacza, że filament nie obsługuje drukowania na Cool Plate."
 
+#, fuzzy
 msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the Textured Cool Plate."
 msgstr "Temperatura stołu dla warstw, z wyjątkiem pierwszej. Wartość 0 oznacza, że filament nie nadaje się do druku na Textured Cool Plate."
 
+#, fuzzy
 msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the Engineering Plate."
 msgstr "Temperatura stołu dla warstw poza pierwszą. Wartość 0 oznacza, że filament nie obsługuje drukowania na Engineering Plate."
 
+#, fuzzy
 msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the High Temp Plate."
 msgstr "Temperatura stołu dla warstw poza pierwszą. Wartość 0 oznacza, że filament nie obsługuje drukowania na High Temp Plate."
 
+#, fuzzy
 msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the Textured PEI Plate."
 msgstr "Temperatura stołu dla warstw poza pierwszą. Wartość 0 oznacza, że filament nie obsługuje drukowania na Textured PEI Plate."
 
@@ -16448,7 +16453,7 @@ msgstr "Punkty początkowe i końcowe, od obszaru cięcia do kanału wyrzutowego
 msgid "Reduce infill retraction"
 msgstr "Zmniejszanie retrakcji wypełnienia"
 
-msgid "Don't retract when the travel is entirely within an infill area. That means the oozing can't been seen. This can reduce times of retraction for complex model and save printing time, but make slicing and G-code generating slower. Note that z-hop is also not performed in areas where retraction is skipped."
+msgid "Don't retract when the travel is entirely within an infill area. That means the oozing can't been seen. This can reduce times of retraction for complex model and save printing time, but make slicing and G-code generating slower. Note that Z-hop is also not performed in areas where retraction is skipped."
 msgstr "Nie wykonuj retrakcji, gdy ruch odbywa się całkowicie w obszarze wypełnienia. Oznacza to, że wyciek nie będzie widoczny. Może to zmniejszyć liczbę retrakcji dla skomplikowanego modelu i zaoszczędzić czas druku, ale spowolnić krojenie i generowanie G-code"
 
 msgid "This option will drop the temperature of the inactive extruders to prevent oozing."
@@ -16624,7 +16629,7 @@ msgstr "Wartość retrakcji po czyszczeniu"
 # AI Translated
 #, no-c-format, no-boost-format
 msgid ""
-"The length of fast retraction after wipe, relative to retraction length.\n"
+"This is the length of fast retraction after wipe, relative to retraction length.\n"
 "The value will be clamped by 100% minus the retract amount before the wipe value."
 msgstr ""
 "Długość szybkiej retrakcji po czyszczeniu, względem długości retrakcji.\n"
@@ -16671,7 +16676,7 @@ msgstr "Gdy retrakcja jest wyzwalana przed zmianą narzędzia, filament zostaje 
 msgid "Z-hop height"
 msgstr "Wysokość Z-hop"
 
-msgid "Whenever there is a retraction, the nozzle is lifted a little to create clearance between the nozzle and the print. This prevents the nozzle from hitting the print when traveling more. Using spiral lines to lift z can prevent stringing."
+msgid "Whenever there is a retraction, the nozzle is lifted a little to create clearance between the nozzle and the print. This prevents the nozzle from hitting the print when traveling more. Using spiral lines to lift Z can prevent stringing."
 msgstr "Zawsze gdy wykonana jest retrakcja, dysza jest nieco podnoszona, aby stworzyć odstęp między dyszą a wydrukiem. Zapobiega to uderzeniu dyszy w wydruk podczas przemieszczania. Użycie linii spiralnej do podniesienia Z może zapobiec powstawaniu strun"
 
 msgid "Z-hop lower boundary"
@@ -18504,7 +18509,7 @@ msgid "Current Z-hop"
 msgstr "Bieżący Z-hop"
 
 msgid "Contains Z-hop present at the beginning of the custom G-code block."
-msgstr "Zawiera z-hop obecny na początku bloku niestandardowego G-code"
+msgstr "Zawiera Z-hop obecny na początku bloku niestandardowego G-code"
 
 msgid "Position of the extruder at the beginning of the custom G-code block. If the custom G-code travels somewhere else, it should write to this variable so OrcaSlicer knows where it travels from when it gets control back."
 msgstr "Pozycja ekstrudera na początku bloku niestandardowego G-kodu. Jeśli niestandardowy G-code przemieszcza się gdzieś indziej, powinien zostać zapisany do tej zmiennej, aby OrcaSlicer wiedział, skąd się przemieszcza, gdy odzyska kontrolę."
@@ -20394,19 +20399,19 @@ msgstr "Wyświetlane są jedynie drukarki ze zmienionymi profilami drukarki, fil
 msgid "Only display the filament names with changes to filament presets."
 msgstr "Wyświetlone są jedynie nazwy filamentów, które zostały zmodyfikowane w ustawieniach."
 
-msgid "Only printer names with user printer presets will be displayed, and each preset you choose will be exported as a zip."
+msgid "Only printer names with user printer presets will be displayed, and each preset you choose will be exported as a ZIP archive."
 msgstr "Wyświetlane są tylko nazwy drukarek z ustawieniami użytkownika, wybrany zestaw zostanie wyeksportowany jako plik zip."
 
 msgid ""
 "Only the filament names with user filament presets will be displayed, \n"
-"and all user filament presets in each filament name you select will be exported as a zip."
+"and all user filament presets in each filament name you select will be exported as a ZIP archive."
 msgstr ""
 "Na liście widoczne są tylko nazwy filamentów ze zmodyfikowanymi ustawieniami, \n"
 "a dla każdej wybranej nazwy filamentu zostaną wyeksportowane wszystkie ustawienia jako archiwum zip."
 
 msgid ""
 "Only printer names with changed process presets will be displayed, \n"
-"and all user process presets in each printer name you select will be exported as a zip."
+"and all user process presets in each printer name you select will be exported as a ZIP archive."
 msgstr ""
 "Na liście widoczne są tylko nazwy drukarek ze zmodyfikowanymi ustawieniami procesu, \n"
 "a dla każdej wybranej nazwy drukarki zostaną wyeksportowane wszystkie \n"
@@ -20653,7 +20658,7 @@ msgid "We need information for diagnosing source of the issue. Check wiki page f
 msgstr "Potrzebujemy informacji do zdiagnozowania źródła problemu. Szczegółowy przewodnik znajdziesz na stronie wiki."
 
 # AI Translated
-msgid "Pack button collects project file and logs of current session onto a zip file."
+msgid "Pack button collects project file and logs of current session onto a ZIP archive."
 msgstr "Przycisk Spakuj zbiera plik projektu i dzienniki bieżącej sesji do pliku zip."
 
 # AI Translated
@@ -20709,7 +20714,7 @@ msgid "Stored logs"
 msgstr "Zapisane dzienniki"
 
 # AI Translated
-msgid "Packs all stored logs onto a zip file."
+msgid "Packs all stored logs onto a ZIP archive."
 msgstr "Pakuje wszystkie zapisane dzienniki do pliku zip."
 
 # AI Translated
@@ -20797,7 +20802,7 @@ msgid "Authorizing..."
 msgstr "Autoryzowanie..."
 
 # AI Translated
-msgid "Error. Can't get api token for authorization"
+msgid "Error. Can't get API token for authorization"
 msgstr "Błąd. Nie można uzyskać tokenu API do autoryzacji"
 
 # AI Translated

--- a/localization/i18n/pt_BR/OrcaSlicer_pt_BR.po
+++ b/localization/i18n/pt_BR/OrcaSlicer_pt_BR.po
@@ -6143,11 +6143,11 @@ msgstr "Importar 3MF/STL/STEP/SVG/OBJ/AMF"
 msgid "Load a model"
 msgstr "Carregar um modelo"
 
-msgid "Import Zip Archive"
-msgstr "Importar Arquivo Zip"
+msgid "Import ZIP Archive"
+msgstr "Importar Arquivo ZIP"
 
-msgid "Load models contained within a zip archive"
-msgstr "Carregar modelos contidos em um arquivo zip"
+msgid "Load models contained within a ZIP archive"
+msgstr "Carregar modelos contidos em um arquivo ZIP"
 
 msgid "Import Configs"
 msgstr "Importar Configurações"
@@ -7897,7 +7897,7 @@ msgstr "Por favor, confirme se o G-code dentro dessas predefinições é seguro 
 msgid "Customized Preset"
 msgstr "Predefinição Personalizada"
 
-msgid "Component name(s) inside step file not in UTF8 format!"
+msgid "Component name(s) inside step file not in UTF-8 format!"
 msgstr "Os nomes dos componentes dentro do arquivo STEP não estão no formato UTF-8!"
 
 msgid "Because of unsupported text encoding, garbage characters may appear!"
@@ -7919,7 +7919,7 @@ msgstr "O volume do objeto é zero"
 #, c-format, boost-format
 msgid ""
 "The object from file %s is too small, and may be in meters or inches.\n"
-" Do you want to scale to millimeters?"
+"Do you want to scale to millimeters?"
 msgstr ""
 "O objeto do arquivo %s é muito pequeno, e pode estar em metros ou polegadas.\n"
 "Deseja redimensioná-lo para milímetros?"
@@ -10740,11 +10740,11 @@ msgstr "%s: %s"
 msgid "No modifications need to be copied."
 msgstr "Nenhuma modificação precisa ser copiada."
 
-msgid "Copy paramters"
+msgid "Copy parameters"
 msgstr "Copiar parâmetros"
 
 #, c-format, boost-format
-msgid "Modify paramters of %s"
+msgid "Modify parameters of %s"
 msgstr "Modificar parâmetros de %s"
 
 #, c-format, boost-format
@@ -12355,7 +12355,7 @@ msgstr "mm ou %"
 msgid "Other layers"
 msgstr "Outras camadas"
 
-msgid "Bed temperature for layers except the initial one. A value of 0 means the filament does not support printing on the Cool Plate SuperTack."
+msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the Cool Plate SuperTack."
 msgstr "Essa é a temperatura da mesa para camadas exceto a inicial. O valor 0 significa que o filamento não suporta a impressão na Placa Fria SuperTack."
 
 msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the Cool Plate."
@@ -15252,7 +15252,6 @@ msgstr "Massa da mesa do eixo Y"
 msgid "The machine bed mass load of Y axis"
 msgstr "A carga de massa da mesa do equipamento no eixo Y"
 
-# AI Translated
 msgid "g"
 msgstr "g"
 
@@ -15565,7 +15564,7 @@ msgstr "Os pontos de início e fim que vão da área do cortador até a calha de
 msgid "Reduce infill retraction"
 msgstr "Reduzir retração durante o preenchimento"
 
-msgid "Don't retract when the travel is entirely within an infill area. That means the oozing can't been seen. This can reduce times of retraction for complex model and save printing time, but make slicing and G-code generating slower. Note that z-hop is also not performed in areas where retraction is skipped."
+msgid "Don't retract when the travel is entirely within an infill area. That means the oozing can't been seen. This can reduce times of retraction for complex model and save printing time, but make slicing and G-code generating slower. Note that Z-hop is also not performed in areas where retraction is skipped."
 msgstr "Não retrair quando o movimento está completamente na área de preenchimento. Isso significa que o vazamento não pode ser visto. Isso pode reduzir o número de retratações para modelos complexos e economizar tempo de impressão, mas torna a geração de fatiamento e G-code mais lenta. Note que o Z-Hop também não é realizado em áreas onde a retração é omitida."
 
 msgid "This option will drop the temperature of the inactive extruders to prevent oozing."
@@ -15730,7 +15729,7 @@ msgstr "Quantidade de retração depois da limpeza"
 
 #, no-c-format, no-boost-format
 msgid ""
-"The length of fast retraction after wipe, relative to retraction length.\n"
+"This is the length of fast retraction after wipe, relative to retraction length.\n"
 "The value will be clamped by 100% minus the retract amount before the wipe value."
 msgstr ""
 "Este é o comprimento da retração rápida antes de uma limpeza, em relação ao comprimento da retração.\n"
@@ -15766,18 +15765,16 @@ msgstr "Retração longa na troca de extrusora"
 msgid "Retraction distance when extruder change"
 msgstr "Distância de retração na troca de extrusora"
 
-# AI Translated
 msgid "Retraction Length (Toolchange)"
-msgstr "Comprimento da retração (Troca de ferramenta)"
+msgstr "Comprimento da Retração (Troca de ferramenta)"
 
-# AI Translated
 msgid "When retraction is triggered before changing tool, filament is pulled back by the specified amount (the length is measured on raw filament, before it enters the extruder)."
 msgstr "Quando a retração é acionada antes da troca de ferramenta, o filamento é puxado de volta na quantidade especificada (o comprimento é medido no filamento bruto, antes de entrar na extrusora)."
 
 msgid "Z-hop height"
 msgstr "Altura de Z-hop"
 
-msgid "Whenever there is a retraction, the nozzle is lifted a little to create clearance between the nozzle and the print. This prevents the nozzle from hitting the print when traveling more. Using spiral lines to lift z can prevent stringing."
+msgid "Whenever there is a retraction, the nozzle is lifted a little to create clearance between the nozzle and the print. This prevents the nozzle from hitting the print when traveling more. Using spiral lines to lift Z can prevent stringing."
 msgstr "Sempre que há uma retração, o bico é levantado um pouco para criar folga entre o bico e a impressão. Isso evita que o bico atinja a impressão ao se mover. Usar linhas em espiral para levantar Z pode evitar stringing."
 
 msgid "Z-hop lower boundary"
@@ -15867,9 +15864,8 @@ msgstr "Comprimento extra na retração"
 msgid "When the retraction is compensated after the travel move, the extruder will push this additional amount of filament. This setting is rarely needed."
 msgstr "Quando a retração é compensada após o movimento de deslocamento, a extrusora empurrará essa quantidade adicional de filamento. Esta configuração é raramente necessária."
 
-# AI Translated
 msgid "Extra length on restart (Toolchange)"
-msgstr "Comprimento extra na retração (Troca de ferramenta)"
+msgstr "Comprimento extra no reinício (Troca de ferramenta)"
 
 msgid "When the retraction is compensated after changing tool, the extruder will push this additional amount of filament."
 msgstr "Quando a retração é compensada após a troca de ferramenta, a extrusora empurrará essa quantidade adicional de filamento."
@@ -16279,13 +16275,11 @@ msgstr "Troca de ferramenta na torre de purga"
 msgid "Force the toolhead to travel to the wipe tower before issuing the tool change command (Tx). Only relevant for multi-extruder (multi-toolhead) printers using a Type 2 wipe tower. By default Orca skips the travel on multi-toolhead machines because the firmware handles the head swap, which can result in the Tx command being issued above the printed part. Enable this option if you want the tool change to always be issued above the wipe tower instead."
 msgstr "Força o cabeçote de impressão a se deslocar até a torre de purga antes de emitir o comando de troca de ferramenta (Tx). Relevante apenas para impressoras com múltiplas extrusoras (múltiplos cabeçotes de impressão) que utilizam uma torre de purga Tipo 2. Por padrão, o Orca ignora o deslocamento em máquinas com múltiplos cabeçotes de impressão, pois o firmware gerencia a troca do cabeçote, o que pode resultar na emissão do comando Tx acima da peça impressa. Habilite esta opção se desejar que a troca de ferramenta seja sempre emitida acima da torre de purga."
 
-# AI Translated
 msgid "Wait for temperature on wipe tower"
 msgstr "Aguardar a temperatura na torre de purga"
 
-# AI Translated
 msgid "Pick up the new tool without waiting for it to reach printing temperature, travel to the wipe tower, and wait for the temperature there, right before purging. Ooze from the heat-up lands on the tower instead of the model, and the travel overlaps with the heating. Only relevant for multi-extruder (multi-toolhead) printers using a Type 2 wipe tower. The firmware or tool change macro must not wait for the temperature itself. When disabled, the temperature wait is issued right after the tool change command."
-msgstr "Pega a nova ferramenta sem esperar que ela atinja a temperatura de impressão, desloca-se até a torre de purga e aguarda a temperatura ali, logo antes de purgar. O vazamento causado pelo aquecimento cai na torre em vez do modelo, e o deslocamento acontece durante o aquecimento. Relevante apenas para impressoras multiextrusora (multicabeça) que usam uma torre de purga do tipo 2. O firmware ou a macro de troca de ferramenta não devem aguardar a temperatura por conta própria. Quando desativado, a espera de temperatura é emitida logo após o comando de troca de ferramenta."
+msgstr "Pega a nova ferramenta sem esperar que ela atinja a temperatura de impressão, desloca-se até a torre de purga e aguarda a temperatura ali, logo antes de purgar. O vazamento causado pelo aquecimento cai na torre em vez do modelo, e o deslocamento acontece junto com o aquecimento. Relevante apenas para impressoras multiextrusora (multicabeça) que usam uma torre de purga do Tipo 2. O firmware ou a macro de troca de ferramenta não devem aguardar a temperatura por conta própria. Quando desativado, a espera de temperatura é emitida logo após o comando de troca de ferramenta."
 
 msgid "No sparse layers (beta)"
 msgstr "Sem camadas esparsas (beta)"
@@ -19315,19 +19309,19 @@ msgstr "Apenas impressoras com alterações nas predefinições de impressora, f
 msgid "Only display the filament names with changes to filament presets."
 msgstr "Exibir apenas os nomes dos filamentos com alterações nas predefinições de filamento."
 
-msgid "Only printer names with user printer presets will be displayed, and each preset you choose will be exported as a zip."
+msgid "Only printer names with user printer presets will be displayed, and each preset you choose will be exported as a ZIP archive."
 msgstr "Apenas os nomes das impressoras com predefinições de impressora do usuário serão exibidos, e cada predefinição escolhida será exportada como um arquivo zip."
 
 msgid ""
 "Only the filament names with user filament presets will be displayed, \n"
-"and all user filament presets in each filament name you select will be exported as a zip."
+"and all user filament presets in each filament name you select will be exported as a ZIP archive."
 msgstr ""
 "Apenas os nomes dos filamentos com predefinições de filamento do usuário serão exibidos, \n"
 "e todas as predefinições de filamento do usuário em cada nome de filamento selecionadas serão exportadas como um arquivo zip."
 
 msgid ""
 "Only printer names with changed process presets will be displayed, \n"
-"and all user process presets in each printer name you select will be exported as a zip."
+"and all user process presets in each printer name you select will be exported as a ZIP archive."
 msgstr ""
 "Apenas os nomes das impressoras com predefinições de processo alterados serão exibidos, \n"
 "e todas os predefinições de processo do usuário em cada nome de impressora selecionadas serão exportados como um arquivo zip."
@@ -19556,7 +19550,7 @@ msgstr "Copiar informações do sistema para a área de transferência"
 msgid "We need information for diagnosing source of the issue. Check wiki page for detailed guide."
 msgstr "Precisamos de informações para diagnosticar a origem do problema. Consulte a página da wiki para obter um guia detalhado."
 
-msgid "Pack button collects project file and logs of current session onto a zip file."
+msgid "Pack button collects project file and logs of current session onto a ZIP archive."
 msgstr "O botão \"Empacotar\" reúne o arquivo do projeto e os logs da sessão atual em um arquivo ZIP."
 
 msgid "Any additional visual examples like images or screen recordings might be helpful while reporting the issue."
@@ -19598,7 +19592,7 @@ msgstr "Nível de log"
 msgid "Stored logs"
 msgstr "Logs armazenados"
 
-msgid "Packs all stored logs onto a zip file."
+msgid "Packs all stored logs onto a ZIP archive."
 msgstr "Compacta todos os logs armazenados em um arquivo ZIP."
 
 msgid "Profiles"
@@ -19665,7 +19659,7 @@ msgstr "Tipo de impressora não encontrado, selecione manualmente."
 msgid "Authorizing..."
 msgstr "Autorizando…"
 
-msgid "Error. Can't get api token for authorization"
+msgid "Error. Can't get API token for authorization"
 msgstr "Erro. ​​Não foi possível obter o token de API para autorização"
 
 msgid "Could not parse server response."

--- a/localization/i18n/ru/OrcaSlicer_ru.po
+++ b/localization/i18n/ru/OrcaSlicer_ru.po
@@ -6376,10 +6376,10 @@ msgstr "Импорт 3MF/STL/STEP/SVG/OBJ/AMF"
 msgid "Load a model"
 msgstr "Загрузка модели"
 
-msgid "Import Zip Archive"
+msgid "Import ZIP Archive"
 msgstr "Импорт ZIP-архива"
 
-msgid "Load models contained within a zip archive"
+msgid "Load models contained within a ZIP archive"
 msgstr "Загрузка моделей, содержащихся в ZIP-архиве"
 
 msgid "Import Configs"
@@ -8168,8 +8168,8 @@ msgstr "Во избежание повреждения принтера убед
 msgid "Customized Preset"
 msgstr "Пользовательский профиль"
 
-msgid "Component name(s) inside step file not in UTF8 format!"
-msgstr "Имена компонентов внутри файла STEP не в формате UTF8."
+msgid "Component name(s) inside step file not in UTF-8 format!"
+msgstr "Имена компонентов внутри файла STEP не в формате UTF-8."
 
 msgid "Because of unsupported text encoding, garbage characters may appear!"
 msgstr "Из-за неподдерживаемой кодировки в названии могут присутствовать ошибочные символы."
@@ -8190,7 +8190,7 @@ msgstr "Объём модели равен нулю"
 #, c-format, boost-format
 msgid ""
 "The object from file %s is too small, and may be in meters or inches.\n"
-" Do you want to scale to millimeters?"
+"Do you want to scale to millimeters?"
 msgstr ""
 "Модель из файла %s слишком мала. Возможно, её размеры \n"
 "в метрах или дюймах. Внутренней единицей программы \n"
@@ -11072,11 +11072,11 @@ msgstr "%s: %s"
 msgid "No modifications need to be copied."
 msgstr "Перенос изменений не требуется."
 
-msgid "Copy paramters"
+msgid "Copy parameters"
 msgstr "Копировать настройки"
 
 #, c-format, boost-format
-msgid "Modify paramters of %s"
+msgid "Modify parameters of %s"
 msgstr "Изменить настройки %s"
 
 #, c-format, boost-format
@@ -12694,7 +12694,7 @@ msgstr "мм или %"
 msgid "Other layers"
 msgstr "Основная"
 
-msgid "Bed temperature for layers except the initial one. A value of 0 means the filament does not support printing on the Cool Plate SuperTack."
+msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the Cool Plate SuperTack."
 msgstr "Температура стола для всех остальных слоёв. 0 – материал не поддерживает это покрытие."
 
 msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the Cool Plate."
@@ -16223,7 +16223,7 @@ msgstr "Начальная и конечная точки траектории �
 msgid "Reduce infill retraction"
 msgstr "Откат только при пересечении периметров"
 
-msgid "Don't retract when the travel is entirely within an infill area. That means the oozing can't been seen. This can reduce times of retraction for complex model and save printing time, but make slicing and G-code generating slower. Note that z-hop is also not performed in areas where retraction is skipped."
+msgid "Don't retract when the travel is entirely within an infill area. That means the oozing can't been seen. This can reduce times of retraction for complex model and save printing time, but make slicing and G-code generating slower. Note that Z-hop is also not performed in areas where retraction is skipped."
 msgstr ""
 "Отключает откат (и подъём по Z), когда перемещения совершаются полностью над заполнением (где любые подтёки, вероятно, будут скрыты). Это поможет снизить количество откатов при печати сложных моделей и немного сэкономить время, но увеличит время нарезки и генерации G-кода.\n"
 "\n"
@@ -16401,7 +16401,7 @@ msgstr "Вторичный откат"
 
 #, no-c-format, no-boost-format
 msgid ""
-"The length of fast retraction after wipe, relative to retraction length.\n"
+"This is the length of fast retraction after wipe, relative to retraction length.\n"
 "The value will be clamped by 100% minus the retract amount before the wipe value."
 msgstr ""
 "Быстрый откат после очистки, выраженный в процентах от общей длины отката. В некоторых случаях позволяет значительно снизить количество «паутины».\n"
@@ -16449,7 +16449,7 @@ msgstr "При срабатывании отката перед сменой и�
 msgid "Z-hop height"
 msgstr "Высота подъёма"
 
-msgid "Whenever there is a retraction, the nozzle is lifted a little to create clearance between the nozzle and the print. This prevents the nozzle from hitting the print when traveling more. Using spiral lines to lift z can prevent stringing."
+msgid "Whenever there is a retraction, the nozzle is lifted a little to create clearance between the nozzle and the print. This prevents the nozzle from hitting the print when traveling more. Using spiral lines to lift Z can prevent stringing."
 msgstr "При каждом откате печатная голова немного приподнимается, создавая зазор между соплом и моделью. Это предотвращает столкновение сопла с моделью при перемещении. Использование спирального подъёма может помочь сократить образование \"паутины\"."
 
 msgid "Z-hop lower boundary"
@@ -20306,21 +20306,21 @@ msgstr "Будут отображаться только изменённые п
 msgid "Only display the filament names with changes to filament presets."
 msgstr "Будут отображаться только изменённые профили материалов."
 
-msgid "Only printer names with user printer presets will be displayed, and each preset you choose will be exported as a zip."
+msgid "Only printer names with user printer presets will be displayed, and each preset you choose will be exported as a ZIP archive."
 msgstr ""
 "Будут отображаться только изменённые профили принтеров.\n"
 "Все они будут экспортированы в единый zip-файл."
 
 msgid ""
 "Only the filament names with user filament presets will be displayed, \n"
-"and all user filament presets in each filament name you select will be exported as a zip."
+"and all user filament presets in each filament name you select will be exported as a ZIP archive."
 msgstr ""
 "Будут отображаться только изменённые профили материалов.\n"
 "Все они будут экспортированы в единый zip-файл."
 
 msgid ""
 "Only printer names with changed process presets will be displayed, \n"
-"and all user process presets in each printer name you select will be exported as a zip."
+"and all user process presets in each printer name you select will be exported as a ZIP archive."
 msgstr ""
 "Будут отображаться только профили принтеров с изменёнными настройками печати.\n"
 "Все изменённые профили настроек будут экспортированы в единый zip-файл."
@@ -20560,7 +20560,7 @@ msgstr "Копировать в буфер обмена"
 msgid "We need information for diagnosing source of the issue. Check wiki page for detailed guide."
 msgstr "Эта информация требуется для диагностики проблем. Ознакомьтесь с руководством для получения подробностей."
 
-msgid "Pack button collects project file and logs of current session onto a zip file."
+msgid "Pack button collects project file and logs of current session onto a ZIP archive."
 msgstr "Нажмите «Экспорт», чтобы сохранить текущий проект и журнал сессии в ZIP-архив."
 
 msgid "Any additional visual examples like images or screen recordings might be helpful while reporting the issue."
@@ -20602,7 +20602,7 @@ msgstr "Уровень ведения журнала"
 msgid "Stored logs"
 msgstr "Сохранённые журналы"
 
-msgid "Packs all stored logs onto a zip file."
+msgid "Packs all stored logs onto a ZIP archive."
 msgstr "Нажмите «Экспорт», чтобы упаковать все сохранённые журналы в единый ZIP-архив"
 
 msgid "Profiles"
@@ -20669,7 +20669,7 @@ msgstr "Требуется указать принтер вручную"
 msgid "Authorizing..."
 msgstr "Авторизация..."
 
-msgid "Error. Can't get api token for authorization"
+msgid "Error. Can't get API token for authorization"
 msgstr "Ошибка получения токена авторизации"
 
 msgid "Could not parse server response."

--- a/localization/i18n/sv/OrcaSlicer_sv.po
+++ b/localization/i18n/sv/OrcaSlicer_sv.po
@@ -6971,11 +6971,11 @@ msgid "Load a model"
 msgstr "Ladda modell"
 
 # AI Translated
-msgid "Import Zip Archive"
+msgid "Import ZIP Archive"
 msgstr "Importera ZIP-arkiv"
 
 # AI Translated
-msgid "Load models contained within a zip archive"
+msgid "Load models contained within a ZIP archive"
 msgstr "Läs in modeller som finns i ett ZIP-arkiv"
 
 msgid "Import Configs"
@@ -8952,8 +8952,8 @@ msgstr "Bekräfta att G-koderna i dessa inställningar är säkra för att förh
 msgid "Customized Preset"
 msgstr "Anpassad inställning"
 
-msgid "Component name(s) inside step file not in UTF8 format!"
-msgstr "Komponent namnet i STEP filen är inte UTF8 format!"
+msgid "Component name(s) inside step file not in UTF-8 format!"
+msgstr "Komponent namnet i STEP filen är inte UTF-8 format!"
 
 msgid "Because of unsupported text encoding, garbage characters may appear!"
 msgstr "På grund av textkodning som inte stöds så kan skräptecken visas!"
@@ -8974,7 +8974,7 @@ msgstr "Objektet är utan volym"
 #, c-format, boost-format
 msgid ""
 "The object from file %s is too small, and may be in meters or inches.\n"
-" Do you want to scale to millimeters?"
+"Do you want to scale to millimeters?"
 msgstr ""
 "Objektets fil %s är för litet, det är kanske i meter eller inches.\n"
 "Skala om till millimeter?"
@@ -12190,12 +12190,12 @@ msgid "No modifications need to be copied."
 msgstr "Inga ändringar behöver kopieras."
 
 # AI Translated
-msgid "Copy paramters"
+msgid "Copy parameters"
 msgstr "Kopiera parametrar"
 
 # AI Translated
 #, c-format, boost-format
-msgid "Modify paramters of %s"
+msgid "Modify parameters of %s"
 msgstr "Ändra parametrar för %s"
 
 # AI Translated
@@ -14012,23 +14012,27 @@ msgstr "mm eller %"
 msgid "Other layers"
 msgstr "Andra lager"
 
-# AI Translated
-msgid "Bed temperature for layers except the initial one. A value of 0 means the filament does not support printing on the Cool Plate SuperTack."
+#, fuzzy
+msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the Cool Plate SuperTack."
 msgstr "Byggplattans temperatur för alla lager utom det första. Värdet 0 innebär att filamentet inte stöder utskrift på Cool Plate SuperTack."
 
+#, fuzzy
 msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the Cool Plate."
 msgstr "Detta är byggplattans temperatur för lager förutom det första. Värdet 0 betyder att filamentet inte stöder utskrift på Cool Plate."
 
-# AI Translated
+#, fuzzy
 msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the Textured Cool Plate."
 msgstr "Detta är byggplattans temperatur för lager förutom det första. Värdet 0 betyder att filamentet inte stöder utskrift på Textured Cool Plate."
 
+#, fuzzy
 msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the Engineering Plate."
 msgstr "Detta är byggplattans temperatur för lager förutom det första. Ett värde på 0 betyder att filamentet inte stöder utskrift på Engineering Plate."
 
+#, fuzzy
 msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the High Temp Plate."
 msgstr "Detta är byggplattans temperatur för lager förutom det första. Värdet 0 betyder att filamentet inte stöder utskrift på High Temp Plate."
 
+#, fuzzy
 msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the Textured PEI Plate."
 msgstr "Byggplattans temperatur efter det första lagret. 0 betyder att filamentet inte stöds på den texturerade PEI-plattan."
 
@@ -17720,8 +17724,8 @@ msgid "Reduce infill retraction"
 msgstr "Minska ifyllnads retraktionen"
 
 # AI Translated
-msgid "Don't retract when the travel is entirely within an infill area. That means the oozing can't been seen. This can reduce times of retraction for complex model and save printing time, but make slicing and G-code generating slower. Note that z-hop is also not performed in areas where retraction is skipped."
-msgstr "Dra inte tillbaka när förflyttningen är helt i ett utfyllnadsområde. Det betyder att läckage av filament inte kan ses. Detta kan minska tiderna för indragning för komplexa modeller och spara utskriftstid, men gör beredning och generering av G-kod långsammare. Observera att z-hop inte heller utförs i områden där retraktionen hoppas över."
+msgid "Don't retract when the travel is entirely within an infill area. That means the oozing can't been seen. This can reduce times of retraction for complex model and save printing time, but make slicing and G-code generating slower. Note that Z-hop is also not performed in areas where retraction is skipped."
+msgstr "Dra inte tillbaka när förflyttningen är helt i ett utfyllnadsområde. Det betyder att läckage av filament inte kan ses. Detta kan minska tiderna för indragning för komplexa modeller och spara utskriftstid, men gör beredning och generering av G-kod långsammare. Observera att Z-hop inte heller utförs i områden där retraktionen hoppas över."
 
 # AI Translated
 msgid "This option will drop the temperature of the inactive extruders to prevent oozing."
@@ -17913,7 +17917,7 @@ msgstr "Reduktionsmängd efter avtorkning"
 # AI Translated
 #, no-c-format, no-boost-format
 msgid ""
-"The length of fast retraction after wipe, relative to retraction length.\n"
+"This is the length of fast retraction after wipe, relative to retraction length.\n"
 "The value will be clamped by 100% minus the retract amount before the wipe value."
 msgstr ""
 "Längden på den snabba reduktionen efter avtorkning, i förhållande till reduktionslängden.\n"
@@ -17968,7 +17972,7 @@ msgstr "När reduktionen utlöses före ett verktygsbyte dras filamentet tillbak
 msgid "Z-hop height"
 msgstr "Z-hop-höjd"
 
-msgid "Whenever there is a retraction, the nozzle is lifted a little to create clearance between the nozzle and the print. This prevents the nozzle from hitting the print when traveling more. Using spiral lines to lift z can prevent stringing."
+msgid "Whenever there is a retraction, the nozzle is lifted a little to create clearance between the nozzle and the print. This prevents the nozzle from hitting the print when traveling more. Using spiral lines to lift Z can prevent stringing."
 msgstr "När det är en retraktion lyfts nozzel en aning för att skapa ett spel mellan nozzel och utskriften. Detta förhindrar att nozzel träffar utskriften när den förflyttas. Att använda spirallinjer för att lyfta z kan förhindra strängning"
 
 msgid "Z-hop lower boundary"
@@ -22041,19 +22045,19 @@ msgstr "Endast printer med ändringar av inställningar för printer, filament o
 msgid "Only display the filament names with changes to filament presets."
 msgstr "Visa endast filament namnen vid ändringar av filament inställningar."
 
-msgid "Only printer names with user printer presets will be displayed, and each preset you choose will be exported as a zip."
+msgid "Only printer names with user printer presets will be displayed, and each preset you choose will be exported as a ZIP archive."
 msgstr "Endast printer namn med inställningar för printer visas, och varje inställning du väljer exporteras som zip-fil."
 
 msgid ""
 "Only the filament names with user filament presets will be displayed, \n"
-"and all user filament presets in each filament name you select will be exported as a zip."
+"and all user filament presets in each filament name you select will be exported as a ZIP archive."
 msgstr ""
 "Endast filament namn med inställningar för användar filament visas, \n"
 "och alla inställningar för användar filament i varje filament namn du väljer exporteras som en zip-fil."
 
 msgid ""
 "Only printer names with changed process presets will be displayed, \n"
-"and all user process presets in each printer name you select will be exported as a zip."
+"and all user process presets in each printer name you select will be exported as a ZIP archive."
 msgstr ""
 "Endast printer namn med ändrade process inställningar visas, \n"
 "och alla användarprocess inställningar i varje printer namn som du väljer exporteras som zip-fil."
@@ -22312,7 +22316,7 @@ msgid "We need information for diagnosing source of the issue. Check wiki page f
 msgstr "Vi behöver information för att diagnostisera orsaken till problemet. Se wiki-sidan för en detaljerad guide."
 
 # AI Translated
-msgid "Pack button collects project file and logs of current session onto a zip file."
+msgid "Pack button collects project file and logs of current session onto a ZIP archive."
 msgstr "Paketera-knappen samlar projektfilen och loggarna från den aktuella sessionen i en zip-fil."
 
 # AI Translated
@@ -22368,7 +22372,7 @@ msgid "Stored logs"
 msgstr "Sparade loggar"
 
 # AI Translated
-msgid "Packs all stored logs onto a zip file."
+msgid "Packs all stored logs onto a ZIP archive."
 msgstr "Paketerar alla sparade loggar i en zip-fil."
 
 # AI Translated
@@ -22456,7 +22460,7 @@ msgid "Authorizing..."
 msgstr "Auktoriserar..."
 
 # AI Translated
-msgid "Error. Can't get api token for authorization"
+msgid "Error. Can't get API token for authorization"
 msgstr "Fel. Det går inte att hämta api-token för auktorisering"
 
 # AI Translated

--- a/localization/i18n/th/OrcaSlicer_th.po
+++ b/localization/i18n/th/OrcaSlicer_th.po
@@ -6302,10 +6302,10 @@ msgstr "นำเข้า 3MF/STL/STEP/SVG/OBJ/AMF"
 msgid "Load a model"
 msgstr "โหลดโมเดล"
 
-msgid "Import Zip Archive"
+msgid "Import ZIP Archive"
 msgstr "นำเข้าไฟล์ Zip"
 
-msgid "Load models contained within a zip archive"
+msgid "Load models contained within a ZIP archive"
 msgstr "โหลดโมเดลที่มีอยู่ในไฟล์ zip"
 
 msgid "Import Configs"
@@ -8074,8 +8074,8 @@ msgstr "โปรดยืนยันว่ารหัส G ภายในค
 msgid "Customized Preset"
 msgstr "ค่าที่ตั้งไว้ล่วงหน้าที่กำหนดเอง"
 
-msgid "Component name(s) inside step file not in UTF8 format!"
-msgstr "ชื่อของส่วนประกอบภายในไฟล์ STEP ไม่ใช่รูปแบบ UTF8!"
+msgid "Component name(s) inside step file not in UTF-8 format!"
+msgstr "ชื่อของส่วนประกอบภายในไฟล์ STEP ไม่ใช่รูปแบบ UTF-8!"
 
 msgid "Because of unsupported text encoding, garbage characters may appear!"
 msgstr "ชื่ออาจแสดงตัวอักษรขยะ!"
@@ -8096,7 +8096,7 @@ msgstr "ปริมาตรของวัตถุเป็นศูนย์
 #, c-format, boost-format
 msgid ""
 "The object from file %s is too small, and may be in meters or inches.\n"
-" Do you want to scale to millimeters?"
+"Do you want to scale to millimeters?"
 msgstr ""
 "วัตถุจากไฟล์ %s มีขนาดเล็กเกินไป และอาจมีหน่วยเป็นเมตรหรือนิ้ว\n"
 " คุณต้องการขยายขนาดเป็นมิลลิเมตรหรือไม่?"
@@ -10948,12 +10948,12 @@ msgid "No modifications need to be copied."
 msgstr "ไม่มีการแก้ไขที่ต้องคัดลอก"
 
 # AI Translated
-msgid "Copy paramters"
+msgid "Copy parameters"
 msgstr "คัดลอกพารามิเตอร์"
 
 # AI Translated
 #, c-format, boost-format
-msgid "Modify paramters of %s"
+msgid "Modify parameters of %s"
 msgstr "แก้ไขพารามิเตอร์ของ %s"
 
 # AI Translated
@@ -12578,7 +12578,7 @@ msgstr "มม. หรือ %"
 msgid "Other layers"
 msgstr "ชั้นอื่นๆ"
 
-msgid "Bed temperature for layers except the initial one. A value of 0 means the filament does not support printing on the Cool Plate SuperTack."
+msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the Cool Plate SuperTack."
 msgstr "อุณหภูมิฐานพิมพ์สำหรับชั้นต่างๆ ยกเว้นอุณหภูมิเริ่มต้น ค่า 0 หมายความว่าเส้นพลาสติกไม่รองรับการพิมพ์บน Cool Plate SuperTack"
 
 msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the Cool Plate."
@@ -15827,8 +15827,8 @@ msgstr "จุดเริ่มต้นและจุดสิ้นสุด
 msgid "Reduce infill retraction"
 msgstr "ลดการดึงกลับในไส้ใน"
 
-msgid "Don't retract when the travel is entirely within an infill area. That means the oozing can't been seen. This can reduce times of retraction for complex model and save printing time, but make slicing and G-code generating slower. Note that z-hop is also not performed in areas where retraction is skipped."
-msgstr "อย่าถอยกลับเมื่อการเดินทางอยู่ภายในพื้นที่ที่ไส้ในเข้าไปทั้งหมด นั่นหมายความว่าไม่สามารถมองเห็นการรั่วไหลได้ วิธีนี้จะช่วยลดเวลาในการดึงกลับสำหรับโมเดลที่ซับซ้อนและประหยัดเวลาในการพิมพ์ แต่จะทำให้การแบ่งส่วนและการสร้าง G-code ช้าลง โปรดทราบว่า z-hop จะไม่ดำเนินการในพื้นที่ที่มีการข้ามการถอนกลับ"
+msgid "Don't retract when the travel is entirely within an infill area. That means the oozing can't been seen. This can reduce times of retraction for complex model and save printing time, but make slicing and G-code generating slower. Note that Z-hop is also not performed in areas where retraction is skipped."
+msgstr "อย่าถอยกลับเมื่อการเดินทางอยู่ภายในพื้นที่ที่ไส้ในเข้าไปทั้งหมด นั่นหมายความว่าไม่สามารถมองเห็นการรั่วไหลได้ วิธีนี้จะช่วยลดเวลาในการดึงกลับสำหรับโมเดลที่ซับซ้อนและประหยัดเวลาในการพิมพ์ แต่จะทำให้การแบ่งส่วนและการสร้าง G-code ช้าลง โปรดทราบว่า Z-hop จะไม่ดำเนินการในพื้นที่ที่มีการข้ามการถอนกลับ"
 
 msgid "This option will drop the temperature of the inactive extruders to prevent oozing."
 msgstr "ตัวเลือกนี้จะทำให้อุณหภูมิของชุดดันเส้นที่ไม่ใช้งานลดลงเพื่อป้องกันการไหลซึม"
@@ -15997,7 +15997,7 @@ msgstr "ปริมาณการดึงกลับหลังเช็ด
 # AI Translated
 #, no-c-format, no-boost-format
 msgid ""
-"The length of fast retraction after wipe, relative to retraction length.\n"
+"This is the length of fast retraction after wipe, relative to retraction length.\n"
 "The value will be clamped by 100% minus the retract amount before the wipe value."
 msgstr ""
 "ความยาวของการดึงกลับอย่างเร็วหลังเช็ดหัว สัมพันธ์กับความยาวการดึงกลับ\n"
@@ -16044,7 +16044,7 @@ msgstr "เมื่อการดึงกลับทำงานก่อน
 msgid "Z-hop height"
 msgstr "ความสูงยกแกน Z"
 
-msgid "Whenever there is a retraction, the nozzle is lifted a little to create clearance between the nozzle and the print. This prevents the nozzle from hitting the print when traveling more. Using spiral lines to lift z can prevent stringing."
+msgid "Whenever there is a retraction, the nozzle is lifted a little to create clearance between the nozzle and the print. This prevents the nozzle from hitting the print when traveling more. Using spiral lines to lift Z can prevent stringing."
 msgstr "เมื่อใดก็ตามที่การดึงกลับเสร็จสิ้น หัวฉีดจะถูกยกขึ้นเล็กน้อยเพื่อสร้างระยะห่างระหว่างหัวฉีดและงานพิมพ์ ป้องกันไม่ให้หัวฉีดชนกับงานพิมพ์ขณะเคลื่อนตัว การใช้เส้นเกลียวเพื่อยก Z สามารถป้องกันการร้อยสายได้"
 
 msgid "Z-hop lower boundary"
@@ -19632,19 +19632,19 @@ msgstr "แสดงเฉพาะชื่อเครื่องพิมพ
 msgid "Only display the filament names with changes to filament presets."
 msgstr "แสดงเฉพาะชื่อเส้นพลาสติกที่มีการเปลี่ยนแปลงการตั้งค่าล่วงหน้าของเส้นพลาสติก"
 
-msgid "Only printer names with user printer presets will be displayed, and each preset you choose will be exported as a zip."
+msgid "Only printer names with user printer presets will be displayed, and each preset you choose will be exported as a ZIP archive."
 msgstr "เฉพาะชื่อเครื่องพิมพ์ที่มีการตั้งค่าเครื่องพิมพ์ล่วงหน้าของผู้ใช้เท่านั้นที่จะแสดง และการตั้งค่าล่วงหน้าแต่ละรายการที่คุณเลือกจะถูกส่งออกเป็นไฟล์ ZIP"
 
 msgid ""
 "Only the filament names with user filament presets will be displayed, \n"
-"and all user filament presets in each filament name you select will be exported as a zip."
+"and all user filament presets in each filament name you select will be exported as a ZIP archive."
 msgstr ""
 "เฉพาะชื่อเส้นพลาสติกที่มีการตั้งค่าล่วงหน้าของเส้นพลาสติกผู้ใช้เท่านั้นที่จะถูกแสดง \n"
 "และค่าฟิลาเมนต์ของผู้ใช้ทั้งหมดที่กำหนดไว้ล่วงหน้าในแต่ละชื่อฟิลาเมนต์ที่คุณเลือกจะถูกส่งออกเป็นไฟล์ ZIP"
 
 msgid ""
 "Only printer names with changed process presets will be displayed, \n"
-"and all user process presets in each printer name you select will be exported as a zip."
+"and all user process presets in each printer name you select will be exported as a ZIP archive."
 msgstr ""
 "เฉพาะชื่อเครื่องพิมพ์ที่มีการตั้งค่าล่วงหน้าของกระบวนการที่เปลี่ยนแปลงเท่านั้นที่จะปรากฏขึ้น \n"
 "และกระบวนการของผู้ใช้ที่ตั้งไว้ล่วงหน้าในชื่อเครื่องพิมพ์แต่ละเครื่องที่คุณเลือกจะถูกส่งออกเป็นไฟล์ ZIP"
@@ -19885,7 +19885,7 @@ msgid "We need information for diagnosing source of the issue. Check wiki page f
 msgstr "เราต้องการข้อมูลเพื่อวินิจฉัยแหล่งที่มาของปัญหา ตรวจสอบหน้า wiki สำหรับคำแนะนำโดยละเอียด"
 
 # AI Translated
-msgid "Pack button collects project file and logs of current session onto a zip file."
+msgid "Pack button collects project file and logs of current session onto a ZIP archive."
 msgstr "ปุ่ม Pack จะรวบรวมไฟล์โปรเจกต์และบันทึกของเซสชันปัจจุบันลงในไฟล์ zip"
 
 # AI Translated
@@ -19941,7 +19941,7 @@ msgid "Stored logs"
 msgstr "บันทึกที่จัดเก็บ"
 
 # AI Translated
-msgid "Packs all stored logs onto a zip file."
+msgid "Packs all stored logs onto a ZIP archive."
 msgstr "รวมบันทึกที่จัดเก็บทั้งหมดลงในไฟล์ zip"
 
 # AI Translated
@@ -20021,7 +20021,7 @@ msgstr "ไม่พบประเภทเครื่องพิมพ์ �
 msgid "Authorizing..."
 msgstr "กำลังอนุญาต..."
 
-msgid "Error. Can't get api token for authorization"
+msgid "Error. Can't get API token for authorization"
 msgstr "ข้อผิดพลาด ไม่สามารถรับโทเคน API สำหรับการอนุญาตได้"
 
 msgid "Could not parse server response."

--- a/localization/i18n/tr/OrcaSlicer_tr.po
+++ b/localization/i18n/tr/OrcaSlicer_tr.po
@@ -6370,10 +6370,10 @@ msgstr "3MF/STL/STEP/SVG/OBJ/AMF'yi içe aktar"
 msgid "Load a model"
 msgstr "Model yükle"
 
-msgid "Import Zip Archive"
+msgid "Import ZIP Archive"
 msgstr "Zip Arşivini İçe Aktar"
 
-msgid "Load models contained within a zip archive"
+msgid "Load models contained within a ZIP archive"
 msgstr "Zip arşivindeki modelleri yükle"
 
 msgid "Import Configs"
@@ -8171,8 +8171,8 @@ msgstr "Lütfen bu ön ayarlar içindeki G-code'larının makineye herhangi bir 
 msgid "Customized Preset"
 msgstr "Özel Ayar"
 
-msgid "Component name(s) inside step file not in UTF8 format!"
-msgstr "Step dosyasındaki bileşenlerin adı UTF8 formatında değil!"
+msgid "Component name(s) inside step file not in UTF-8 format!"
+msgstr "Step dosyasındaki bileşenlerin adı UTF-8 formatında değil!"
 
 # AI Translated
 msgid "Because of unsupported text encoding, garbage characters may appear!"
@@ -8194,10 +8194,10 @@ msgstr "Cismin hacmi sıfır"
 #, c-format, boost-format
 msgid ""
 "The object from file %s is too small, and may be in meters or inches.\n"
-" Do you want to scale to millimeters?"
+"Do you want to scale to millimeters?"
 msgstr ""
 "%s dosyasındaki nesne çok küçük; metre veya inç cinsinden olabilir.\n"
-" Milimetreye ölçeklendirmek istiyor musunuz?"
+"Milimetreye ölçeklendirmek istiyor musunuz?"
 
 msgid "Object too small"
 msgstr "Nesne çok küçük"
@@ -11128,12 +11128,12 @@ msgid "No modifications need to be copied."
 msgstr "Kopyalanması gereken değişiklik yok."
 
 # AI Translated
-msgid "Copy paramters"
+msgid "Copy parameters"
 msgstr "Parametreleri kopyala"
 
 # AI Translated
 #, c-format, boost-format
-msgid "Modify paramters of %s"
+msgid "Modify parameters of %s"
 msgstr "%s parametrelerini değiştir"
 
 # AI Translated
@@ -12805,7 +12805,7 @@ msgstr "mm veya %"
 msgid "Other layers"
 msgstr "Diğer katmanlar"
 
-msgid "Bed temperature for layers except the initial one. A value of 0 means the filament does not support printing on the Cool Plate SuperTack."
+msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the Cool Plate SuperTack."
 msgstr "İlk katman hariç tüm katmanlar için yatak sıcaklığı. 0 değeri, filamentin Cool Plate SuperTack üzerine baskıyı desteklemediği anlamına gelir."
 
 msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the Cool Plate."
@@ -16129,8 +16129,8 @@ msgid "Reduce infill retraction"
 msgstr "Dolguda geri çekmeyi azalt"
 
 # AI Translated
-msgid "Don't retract when the travel is entirely within an infill area. That means the oozing can't been seen. This can reduce times of retraction for complex model and save printing time, but make slicing and G-code generating slower. Note that z-hop is also not performed in areas where retraction is skipped."
-msgstr "Hareket tamamen dolgu alanı içindeyken geri çekme yapılmaz. Bu, sızıntının görülemeyeceği anlamına gelir. Bu, karmaşık modellerde geri çekme sayısını azaltabilir ve yazdırma süresinden tasarruf sağlayabilir, ancak dilimlemeyi ve G-code oluşturmayı yavaşlatır. Geri çekmenin atlandığı alanlarda z-hop'un da uygulanmadığını unutmayın."
+msgid "Don't retract when the travel is entirely within an infill area. That means the oozing can't been seen. This can reduce times of retraction for complex model and save printing time, but make slicing and G-code generating slower. Note that Z-hop is also not performed in areas where retraction is skipped."
+msgstr "Hareket tamamen dolgu alanı içindeyken geri çekme yapılmaz. Bu, sızıntının görülemeyeceği anlamına gelir. Bu, karmaşık modellerde geri çekme sayısını azaltabilir ve yazdırma süresinden tasarruf sağlayabilir, ancak dilimlemeyi ve G-code oluşturmayı yavaşlatır. Geri çekmenin atlandığı alanlarda Z-hop'un da uygulanmadığını unutmayın."
 
 msgid "This option will drop the temperature of the inactive extruders to prevent oozing."
 msgstr "Bu seçenek sızıntıyı önlemek için aktif olmayan ekstrüderlerin sıcaklığını düşürecektir."
@@ -16305,7 +16305,7 @@ msgstr "Silme sonrası geri çekme miktarı"
 # AI Translated
 #, no-c-format, no-boost-format
 msgid ""
-"The length of fast retraction after wipe, relative to retraction length.\n"
+"This is the length of fast retraction after wipe, relative to retraction length.\n"
 "The value will be clamped by 100% minus the retract amount before the wipe value."
 msgstr ""
 "Silme sonrasındaki hızlı geri çekmenin uzunluğu; geri çekme uzunluğuna göredir.\n"
@@ -16352,7 +16352,7 @@ msgstr "Takım değişiminden önce geri çekme tetiklendiğinde, filament belir
 msgid "Z-hop height"
 msgstr "Z-Sıçrama yüksekliği"
 
-msgid "Whenever there is a retraction, the nozzle is lifted a little to create clearance between the nozzle and the print. This prevents the nozzle from hitting the print when traveling more. Using spiral lines to lift z can prevent stringing."
+msgid "Whenever there is a retraction, the nozzle is lifted a little to create clearance between the nozzle and the print. This prevents the nozzle from hitting the print when traveling more. Using spiral lines to lift Z can prevent stringing."
 msgstr "Geri çekme işlemi her yapıldığında, nozul ile baskı arasında açıklık oluşturmak için nozul biraz kaldırılır. Hareket halindeyken nozulun baskıya çarpmasını önler. Z'yi kaldırmak için spiral çizgi kullanmak çekmeyi önleyebilir."
 
 msgid "Z-hop lower boundary"
@@ -18155,10 +18155,10 @@ msgid "Allow 3MF with newer version to be sliced."
 msgstr "Daha yeni sürüme sahip 3mf’nin dilimlenmesine izin ver."
 
 msgid "Current Z-hop"
-msgstr "Mevcut z-hop"
+msgstr "Mevcut Z-hop"
 
 msgid "Contains Z-hop present at the beginning of the custom G-code block."
-msgstr "Özel G-code bloğunun başında bulunan z-hop'u içerir."
+msgstr "Özel G-code bloğunun başında bulunan Z-hop'u içerir."
 
 msgid "Position of the extruder at the beginning of the custom G-code block. If the custom G-code travels somewhere else, it should write to this variable so OrcaSlicer knows where it travels from when it gets control back."
 msgstr "Ekstruderin özel G-code bloğunun başlangıcındaki konumu. Özel G-code başka bir yere seyahat ederse, Slicer'ın kontrolü geri aldığında nereden seyahat ettiğini bilmesi için bu değişkene yazması gerekir."
@@ -20003,19 +20003,19 @@ msgstr "Yazıcı adlarını yalnızca yazıcı, filament ve işlem ön ayarları
 msgid "Only display the filament names with changes to filament presets."
 msgstr "Filament adlarını yalnızca filament ön ayarlarında yapılan değişikliklerle görüntüleyin."
 
-msgid "Only printer names with user printer presets will be displayed, and each preset you choose will be exported as a zip."
+msgid "Only printer names with user printer presets will be displayed, and each preset you choose will be exported as a ZIP archive."
 msgstr "Yalnızca kullanıcı yazıcı ön ayarlarına sahip yazıcı adları görüntülenecek ve seçtiğiniz her ön ayar zip olarak dışa aktarılacaktır."
 
 msgid ""
 "Only the filament names with user filament presets will be displayed, \n"
-"and all user filament presets in each filament name you select will be exported as a zip."
+"and all user filament presets in each filament name you select will be exported as a ZIP archive."
 msgstr ""
 "Yalnızca kullanıcı filamenti ön ayarlarına sahip filament adları \n"
 "görüntülenecek ve seçtiğiniz her filament adındaki tüm kullanıcı filamenti ön ayarları zip olarak dışa aktarılacaktır."
 
 msgid ""
 "Only printer names with changed process presets will be displayed, \n"
-"and all user process presets in each printer name you select will be exported as a zip."
+"and all user process presets in each printer name you select will be exported as a ZIP archive."
 msgstr ""
 "Yalnızca işlem ön ayarları değiştirilen yazıcı adları görüntülenecek \n"
 "ve seçtiğiniz her yazıcı adındaki tüm kullanıcı işlem ön ayarları zip olarak dışa aktarılacaktır."
@@ -20260,7 +20260,7 @@ msgid "We need information for diagnosing source of the issue. Check wiki page f
 msgstr "Sorunun kaynağını teşhis etmek için bilgiye ihtiyacımız var. Ayrıntılı kılavuz için wiki sayfasına bakın."
 
 # AI Translated
-msgid "Pack button collects project file and logs of current session onto a zip file."
+msgid "Pack button collects project file and logs of current session onto a ZIP archive."
 msgstr "Paketle düğmesi, geçerli oturumun proje dosyasını ve günlüklerini bir zip dosyasında toplar."
 
 # AI Translated
@@ -20316,7 +20316,7 @@ msgid "Stored logs"
 msgstr "Saklanan günlükler"
 
 # AI Translated
-msgid "Packs all stored logs onto a zip file."
+msgid "Packs all stored logs onto a ZIP archive."
 msgstr "Saklanan tüm günlükleri bir zip dosyasında paketler."
 
 # AI Translated
@@ -20402,7 +20402,7 @@ msgid "Authorizing..."
 msgstr "Yetkilendiriliyor..."
 
 # AI Translated
-msgid "Error. Can't get api token for authorization"
+msgid "Error. Can't get API token for authorization"
 msgstr "Hata. Yetkilendirme için api belirteci alınamıyor"
 
 # AI Translated

--- a/localization/i18n/uk/OrcaSlicer_uk.po
+++ b/localization/i18n/uk/OrcaSlicer_uk.po
@@ -6339,10 +6339,10 @@ msgstr "Імпорт 3MF/STL/STEP/SVG/OBJ/AMF"
 msgid "Load a model"
 msgstr "Завантажте модель"
 
-msgid "Import Zip Archive"
+msgid "Import ZIP Archive"
 msgstr "Імпорт Zip-архіву"
 
-msgid "Load models contained within a zip archive"
+msgid "Load models contained within a ZIP archive"
 msgstr "Завантажити моделі, що містяться в zip-архіві"
 
 msgid "Import Configs"
@@ -8180,8 +8180,8 @@ msgid "Customized Preset"
 msgstr "Пристосований пресет"
 
 # AI Translated
-msgid "Component name(s) inside step file not in UTF8 format!"
-msgstr "Назви компонентів усередині файлу STEP не у форматі UTF8!"
+msgid "Component name(s) inside step file not in UTF-8 format!"
+msgstr "Назви компонентів усередині файлу STEP не у форматі UTF-8!"
 
 msgid "Because of unsupported text encoding, garbage characters may appear!"
 msgstr "Через непідтримуване кодування тексту можуть зʼявлятися непотрібні символи!"
@@ -8202,7 +8202,7 @@ msgstr "Обʼєм обʼєкта дорівнює нулю"
 #, c-format, boost-format
 msgid ""
 "The object from file %s is too small, and may be in meters or inches.\n"
-" Do you want to scale to millimeters?"
+"Do you want to scale to millimeters?"
 msgstr ""
 "Обʼєкт із файлу %s занадто малий, можливо, в метрах або дюймах.\n"
 "Ви хочете масштабувати до міліметрів?"
@@ -11173,12 +11173,12 @@ msgstr "%s: %s"
 msgid "No modifications need to be copied."
 msgstr "Немає змін для копіювання."
 
-msgid "Copy paramters"
+msgid "Copy parameters"
 msgstr "Параметри копіювання"
 
 # AI Translated
 #, c-format, boost-format
-msgid "Modify paramters of %s"
+msgid "Modify parameters of %s"
 msgstr "Змінити параметри %s"
 
 # AI Translated
@@ -12881,8 +12881,7 @@ msgstr "мм або %"
 msgid "Other layers"
 msgstr "Інші шари"
 
-# AI Translated
-msgid "Bed temperature for layers except the initial one. A value of 0 means the filament does not support printing on the Cool Plate SuperTack."
+msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the Cool Plate SuperTack."
 msgstr "Температура столу для всіх шарів, крім першого. Значення 0 означає, що філамент не підтримує друк на Cool Plate SuperTack."
 
 msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the Cool Plate."
@@ -16313,8 +16312,8 @@ msgid "Reduce infill retraction"
 msgstr "Зменшити втягування заповнення"
 
 # AI Translated
-msgid "Don't retract when the travel is entirely within an infill area. That means the oozing can't been seen. This can reduce times of retraction for complex model and save printing time, but make slicing and G-code generating slower. Note that z-hop is also not performed in areas where retraction is skipped."
-msgstr "Не втягувати, коли переміщення повністю проходить у зоні заповнення. Це означає, що витікання не буде видно. Це може зменшити кількість втягувань для складних моделей і заощадити час друку, але сповільнює нарізку та генерацію G-коду. Зверніть увагу, що z-hop також не виконується в зонах, де втягування пропускається."
+msgid "Don't retract when the travel is entirely within an infill area. That means the oozing can't been seen. This can reduce times of retraction for complex model and save printing time, but make slicing and G-code generating slower. Note that Z-hop is also not performed in areas where retraction is skipped."
+msgstr "Не втягувати, коли переміщення повністю проходить у зоні заповнення. Це означає, що витікання не буде видно. Це може зменшити кількість втягувань для складних моделей і заощадити час друку, але сповільнює нарізку та генерацію G-коду. Зверніть увагу, що Z-hop також не виконується в зонах, де втягування пропускається."
 
 msgid "This option will drop the temperature of the inactive extruders to prevent oozing."
 msgstr "Цей параметр знижує температуру неактивних екструдерів, щоб запобігти підтіканням."
@@ -16489,7 +16488,7 @@ msgstr "Величина втягування після протирання"
 # AI Translated
 #, no-c-format, no-boost-format
 msgid ""
-"The length of fast retraction after wipe, relative to retraction length.\n"
+"This is the length of fast retraction after wipe, relative to retraction length.\n"
 "The value will be clamped by 100% minus the retract amount before the wipe value."
 msgstr ""
 "Довжина швидкого втягування після протирання, відносно довжини втягування.\n"
@@ -16538,7 +16537,7 @@ msgstr "Коли втягування спрацьовує перед зміно
 msgid "Z-hop height"
 msgstr "Висота Z-підйому"
 
-msgid "Whenever there is a retraction, the nozzle is lifted a little to create clearance between the nozzle and the print. This prevents the nozzle from hitting the print when traveling more. Using spiral lines to lift z can prevent stringing."
+msgid "Whenever there is a retraction, the nozzle is lifted a little to create clearance between the nozzle and the print. This prevents the nozzle from hitting the print when traveling more. Using spiral lines to lift Z can prevent stringing."
 msgstr "Під час кожного втягування сопло трохи піднімається, щоб створити зазор між соплом та об’єктом друку. Це запобігає зіткненню сопла з об’єктом друку під час переміщення. Використання спіральної лінії підняття по осі Z може запобігти появі ниток"
 
 msgid "Z-hop lower boundary"
@@ -20244,12 +20243,12 @@ msgstr "Показувати лише назви принтерів зі змі�
 msgid "Only display the filament names with changes to filament presets."
 msgstr "Показувати лише назви філаментів зі змінами у пресетах філаменту."
 
-msgid "Only printer names with user printer presets will be displayed, and each preset you choose will be exported as a zip."
+msgid "Only printer names with user printer presets will be displayed, and each preset you choose will be exported as a ZIP archive."
 msgstr "Будуть відображатися лише назви принтерів з пресетами принтера користувача, і кожен обраний пресет буде експортовано у форматі ZIP."
 
 msgid ""
 "Only the filament names with user filament presets will be displayed, \n"
-"and all user filament presets in each filament name you select will be exported as a zip."
+"and all user filament presets in each filament name you select will be exported as a ZIP archive."
 msgstr ""
 "Будуть відображатися лише назви філаментів з налаштуваннями філаменту користувача, \n"
 "і всі налаштування філаменту користувача для кожної вибраної назви філаменту \n"
@@ -20257,7 +20256,7 @@ msgstr ""
 
 msgid ""
 "Only printer names with changed process presets will be displayed, \n"
-"and all user process presets in each printer name you select will be exported as a zip."
+"and all user process presets in each printer name you select will be exported as a ZIP archive."
 msgstr ""
 "Будуть відображатися лише назви принтерів зі зміненими налаштуваннями процесу, \n"
 "і всі налаштування процесу користувача для кожної вибраної назви принтера будуть \n"
@@ -20499,7 +20498,7 @@ msgid "We need information for diagnosing source of the issue. Check wiki page f
 msgstr "Нам потрібна інформація для встановлення джерела проблеми. Докладний посібник дивіться на сторінці wiki."
 
 # AI Translated
-msgid "Pack button collects project file and logs of current session onto a zip file."
+msgid "Pack button collects project file and logs of current session onto a ZIP archive."
 msgstr "Кнопка «Пакувати» збирає файл проєкту та журнали поточного сеансу в один zip-файл."
 
 # AI Translated
@@ -20543,7 +20542,7 @@ msgstr "Рівень журналу"
 msgid "Stored logs"
 msgstr "Збережені логи"
 
-msgid "Packs all stored logs onto a zip file."
+msgid "Packs all stored logs onto a ZIP archive."
 msgstr "Запаковує всі збережені логи у файл zip."
 
 msgid "Profiles"
@@ -20610,7 +20609,7 @@ msgstr "Тип принтера не знайдено, будь ласка ви�
 msgid "Authorizing..."
 msgstr "Авторизування..."
 
-msgid "Error. Can't get api token for authorization"
+msgid "Error. Can't get API token for authorization"
 msgstr "Помилка. Не вдалося отримати api-токен для авторизування"
 
 msgid "Could not parse server response."

--- a/localization/i18n/vi/OrcaSlicer_vi.po
+++ b/localization/i18n/vi/OrcaSlicer_vi.po
@@ -6687,10 +6687,10 @@ msgstr "Nhập 3MF/STL/STEP/SVG/OBJ/AMF"
 msgid "Load a model"
 msgstr "Tải model"
 
-msgid "Import Zip Archive"
+msgid "Import ZIP Archive"
 msgstr "Nhập lưu trữ Zip"
 
-msgid "Load models contained within a zip archive"
+msgid "Load models contained within a ZIP archive"
 msgstr "Tải các model chứa trong lưu trữ zip"
 
 msgid "Import Configs"
@@ -8585,8 +8585,8 @@ msgstr "Vui lòng xác nhận G-code trong các preset này an toàn để ngăn
 msgid "Customized Preset"
 msgstr "Preset tùy chỉnh"
 
-msgid "Component name(s) inside step file not in UTF8 format!"
-msgstr "Tên của các thành phần bên trong file STEP không phải định dạng UTF8!"
+msgid "Component name(s) inside step file not in UTF-8 format!"
+msgstr "Tên của các thành phần bên trong file STEP không phải định dạng UTF-8!"
 
 # AI Translated
 msgid "Because of unsupported text encoding, garbage characters may appear!"
@@ -8608,10 +8608,10 @@ msgstr "Thể tích của đối tượng bằng không"
 #, c-format, boost-format
 msgid ""
 "The object from file %s is too small, and may be in meters or inches.\n"
-" Do you want to scale to millimeters?"
+"Do you want to scale to millimeters?"
 msgstr ""
 "Đối tượng từ file %s quá nhỏ, và có thể đang ở đơn vị mét hoặc inch.\n"
-" Bạn có muốn chuyển đổi sang milimét?"
+"Bạn có muốn chuyển đổi sang milimét?"
 
 msgid "Object too small"
 msgstr "Đối tượng quá nhỏ"
@@ -11692,12 +11692,12 @@ msgid "No modifications need to be copied."
 msgstr "Không có thay đổi nào cần sao chép."
 
 # AI Translated
-msgid "Copy paramters"
+msgid "Copy parameters"
 msgstr "Sao chép tham số"
 
 # AI Translated
 #, c-format, boost-format
-msgid "Modify paramters of %s"
+msgid "Modify parameters of %s"
 msgstr "Sửa tham số của %s"
 
 # AI Translated
@@ -13449,7 +13449,7 @@ msgstr "mm hoặc %"
 msgid "Other layers"
 msgstr "Lớp khác"
 
-msgid "Bed temperature for layers except the initial one. A value of 0 means the filament does not support printing on the Cool Plate SuperTack."
+msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the Cool Plate SuperTack."
 msgstr "Nhiệt độ bàn cho các lớp ngoại trừ lớp đầu tiên. Giá trị 0 có nghĩa là filament không hỗ trợ in trên bản Cool SuperTack."
 
 msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the Cool Plate."
@@ -16846,8 +16846,8 @@ msgid "Reduce infill retraction"
 msgstr "Giảm rút infill"
 
 # AI Translated
-msgid "Don't retract when the travel is entirely within an infill area. That means the oozing can't been seen. This can reduce times of retraction for complex model and save printing time, but make slicing and G-code generating slower. Note that z-hop is also not performed in areas where retraction is skipped."
-msgstr "Không rút khi di chuyển ở vùng infill hoàn toàn. Điều đó có nghĩa là chảy nhựa không thể nhìn thấy. Điều này có thể giảm số lần rút cho model phức tạp và tiết kiệm thời gian in, nhưng làm cho slice và tạo G-code chậm hơn. Lưu ý rằng z-hop cũng không được thực hiện ở những vùng bỏ qua việc rút."
+msgid "Don't retract when the travel is entirely within an infill area. That means the oozing can't been seen. This can reduce times of retraction for complex model and save printing time, but make slicing and G-code generating slower. Note that Z-hop is also not performed in areas where retraction is skipped."
+msgstr "Không rút khi di chuyển ở vùng infill hoàn toàn. Điều đó có nghĩa là chảy nhựa không thể nhìn thấy. Điều này có thể giảm số lần rút cho model phức tạp và tiết kiệm thời gian in, nhưng làm cho slice và tạo G-code chậm hơn. Lưu ý rằng Z-hop cũng không được thực hiện ở những vùng bỏ qua việc rút."
 
 msgid "This option will drop the temperature of the inactive extruders to prevent oozing."
 msgstr "Tùy chọn này sẽ giảm nhiệt độ của các extruder không hoạt động để ngăn chảy nhựa."
@@ -17022,7 +17022,7 @@ msgstr "Lượng rút sau khi lau"
 # AI Translated
 #, no-c-format, no-boost-format
 msgid ""
-"The length of fast retraction after wipe, relative to retraction length.\n"
+"This is the length of fast retraction after wipe, relative to retraction length.\n"
 "The value will be clamped by 100% minus the retract amount before the wipe value."
 msgstr ""
 "Độ dài rút nhanh sau khi lau, tương đối so với độ dài rút.\n"
@@ -17071,7 +17071,7 @@ msgstr "Khi rút được kích hoạt trước khi đổi công cụ, filament 
 msgid "Z-hop height"
 msgstr "Chiều cao Z-hop"
 
-msgid "Whenever there is a retraction, the nozzle is lifted a little to create clearance between the nozzle and the print. This prevents the nozzle from hitting the print when traveling more. Using spiral lines to lift z can prevent stringing."
+msgid "Whenever there is a retraction, the nozzle is lifted a little to create clearance between the nozzle and the print. This prevents the nozzle from hitting the print when traveling more. Using spiral lines to lift Z can prevent stringing."
 msgstr "Bất cứ khi nào rút được thực hiện, đầu phun được nâng lên một chút để tạo khoảng trống giữa đầu phun và bản in. Nó ngăn đầu phun va vào bản in khi di chuyển. Sử dụng đường xoắn ốc để nâng Z có thể ngăn dây kéo."
 
 msgid "Z-hop lower boundary"
@@ -20793,19 +20793,19 @@ msgstr "Chỉ hiển thị tên máy in có thay đổi đối với cài đặt
 msgid "Only display the filament names with changes to filament presets."
 msgstr "Chỉ hiển thị tên filament có thay đổi đối với cài đặt sẵn filament."
 
-msgid "Only printer names with user printer presets will be displayed, and each preset you choose will be exported as a zip."
+msgid "Only printer names with user printer presets will be displayed, and each preset you choose will be exported as a ZIP archive."
 msgstr "Chỉ tên máy in có cài đặt sẵn máy in người dùng sẽ được hiển thị, và mỗi cài đặt sẵn bạn chọn sẽ được xuất dưới dạng zip."
 
 msgid ""
 "Only the filament names with user filament presets will be displayed, \n"
-"and all user filament presets in each filament name you select will be exported as a zip."
+"and all user filament presets in each filament name you select will be exported as a ZIP archive."
 msgstr ""
 "Chỉ tên filament có cài đặt sẵn filament người dùng sẽ được hiển thị, \n"
 "và tất cả cài đặt sẵn filament người dùng trong mỗi tên filament bạn chọn sẽ được xuất dưới dạng zip."
 
 msgid ""
 "Only printer names with changed process presets will be displayed, \n"
-"and all user process presets in each printer name you select will be exported as a zip."
+"and all user process presets in each printer name you select will be exported as a ZIP archive."
 msgstr ""
 "Chỉ tên máy in có cài đặt sẵn quy trình đã thay đổi sẽ được hiển thị, \n"
 "và tất cả cài đặt sẵn quy trình người dùng trong mỗi tên máy in bạn chọn sẽ được xuất dưới dạng zip."
@@ -21057,7 +21057,7 @@ msgid "We need information for diagnosing source of the issue. Check wiki page f
 msgstr "Chúng tôi cần thông tin để chẩn đoán nguồn gốc vấn đề. Hãy xem trang wiki để có hướng dẫn chi tiết."
 
 # AI Translated
-msgid "Pack button collects project file and logs of current session onto a zip file."
+msgid "Pack button collects project file and logs of current session onto a ZIP archive."
 msgstr "Nút Đóng gói thu thập file dự án và nhật ký của phiên hiện tại vào một file zip."
 
 # AI Translated
@@ -21113,7 +21113,7 @@ msgid "Stored logs"
 msgstr "Nhật ký đã lưu"
 
 # AI Translated
-msgid "Packs all stored logs onto a zip file."
+msgid "Packs all stored logs onto a ZIP archive."
 msgstr "Đóng gói toàn bộ nhật ký đã lưu vào một file zip."
 
 # AI Translated
@@ -21201,7 +21201,7 @@ msgid "Authorizing..."
 msgstr "Đang xác thực..."
 
 # AI Translated
-msgid "Error. Can't get api token for authorization"
+msgid "Error. Can't get API token for authorization"
 msgstr "Lỗi. Không lấy được token api để xác thực"
 
 # AI Translated

--- a/localization/i18n/zh_CN/OrcaSlicer_zh_CN.po
+++ b/localization/i18n/zh_CN/OrcaSlicer_zh_CN.po
@@ -6157,10 +6157,10 @@ msgstr "导入 3MF/STL/STEP/SVG/OBJ/AMF"
 msgid "Load a model"
 msgstr "加载模型"
 
-msgid "Import Zip Archive"
+msgid "Import ZIP Archive"
 msgstr "导入 ZIP 压缩文件"
 
-msgid "Load models contained within a zip archive"
+msgid "Load models contained within a ZIP archive"
 msgstr "从 ZIP 压缩文件中导入一个或多个模型"
 
 msgid "Import Configs"
@@ -7905,8 +7905,8 @@ msgstr "请确认这些预设中的G-codes是否安全，以防止对机器造�
 msgid "Customized Preset"
 msgstr "自定义的预设"
 
-msgid "Component name(s) inside step file not in UTF8 format!"
-msgstr "STEP 文件中的部件名称不是 UTF8 格式！"
+msgid "Component name(s) inside step file not in UTF-8 format!"
+msgstr "STEP 文件中的部件名称不是 UTF-8 格式！"
 
 # AI Translated
 msgid "Because of unsupported text encoding, garbage characters may appear!"
@@ -7928,7 +7928,7 @@ msgstr "对象的体积为零"
 #, c-format, boost-format
 msgid ""
 "The object from file %s is too small, and may be in meters or inches.\n"
-" Do you want to scale to millimeters?"
+"Do you want to scale to millimeters?"
 msgstr ""
 "文件 %s 中对象的尺寸过小，似乎是以米（m）或者英寸（inch）为单位定义的。\n"
 "OrcaSlicer的内部单位为毫米（mm）。是否要转换成毫米（mm）？"
@@ -10738,12 +10738,12 @@ msgid "No modifications need to be copied."
 msgstr "没有需要复制的修改。"
 
 # AI Translated
-msgid "Copy paramters"
+msgid "Copy parameters"
 msgstr "复制参数"
 
 # AI Translated
 #, c-format, boost-format
-msgid "Modify paramters of %s"
+msgid "Modify parameters of %s"
 msgstr "修改 %s 的参数"
 
 # AI Translated
@@ -12374,7 +12374,8 @@ msgstr "mm 或 %"
 msgid "Other layers"
 msgstr "其它层"
 
-msgid "Bed temperature for layers except the initial one. A value of 0 means the filament does not support printing on the Cool Plate SuperTack."
+#, fuzzy
+msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the Cool Plate SuperTack."
 msgstr "除首层外的其他层的热床温度。0值表示该耗材丝不支持在Cool Plate SuperTack上打印。"
 
 msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the Cool Plate."
@@ -15583,7 +15584,7 @@ msgstr "从切割区域到垃圾桶的起始和结束点。"
 msgid "Reduce infill retraction"
 msgstr "减小填充回抽"
 
-msgid "Don't retract when the travel is entirely within an infill area. That means the oozing can't been seen. This can reduce times of retraction for complex model and save printing time, but make slicing and G-code generating slower. Note that z-hop is also not performed in areas where retraction is skipped."
+msgid "Don't retract when the travel is entirely within an infill area. That means the oozing can't been seen. This can reduce times of retraction for complex model and save printing time, but make slicing and G-code generating slower. Note that Z-hop is also not performed in areas where retraction is skipped."
 msgstr "当空驶完全在填充区域内时不触发回抽。这意味着即使漏料也是不可见的。对于复杂模型，该设置能够减少回抽次数以及打印时长，但是会造成G-code生成变慢"
 
 msgid "This option will drop the temperature of the inactive extruders to prevent oozing."
@@ -15754,7 +15755,7 @@ msgstr "擦拭后的回抽量"
 # AI Translated
 #, no-c-format, no-boost-format
 msgid ""
-"The length of fast retraction after wipe, relative to retraction length.\n"
+"This is the length of fast retraction after wipe, relative to retraction length.\n"
 "The value will be clamped by 100% minus the retract amount before the wipe value."
 msgstr ""
 "擦拭后快速回抽的长度，相对于回抽长度。\n"
@@ -15801,7 +15802,7 @@ msgstr "在换工具头之前触发回抽时，耗材丝会按指定的长度回
 msgid "Z-hop height"
 msgstr "Z抬升高度"
 
-msgid "Whenever there is a retraction, the nozzle is lifted a little to create clearance between the nozzle and the print. This prevents the nozzle from hitting the print when traveling more. Using spiral lines to lift z can prevent stringing."
+msgid "Whenever there is a retraction, the nozzle is lifted a little to create clearance between the nozzle and the print. This prevents the nozzle from hitting the print when traveling more. Using spiral lines to lift Z can prevent stringing."
 msgstr "回抽完成之后，喷嘴轻微抬升，和打印件之间产生一定间隙。这能够避免空驶时喷嘴和打印件剐蹭和碰撞。使用螺旋线抬升z能够减少拉丝。"
 
 msgid "Z-hop lower boundary"
@@ -19386,17 +19387,17 @@ msgstr "仅显示对打印机、耗材和工艺预设有改动的打印机名称
 msgid "Only display the filament names with changes to filament presets."
 msgstr "仅显示对耗材预设有改动的耗材名称。"
 
-msgid "Only printer names with user printer presets will be displayed, and each preset you choose will be exported as a zip."
+msgid "Only printer names with user printer presets will be displayed, and each preset you choose will be exported as a ZIP archive."
 msgstr "只显示带有用户打印机预设的打印机名称，并且您选择的每个预设都将导出为一个 ZIP 文件。"
 
 msgid ""
 "Only the filament names with user filament presets will be displayed, \n"
-"and all user filament presets in each filament name you select will be exported as a zip."
+"and all user filament presets in each filament name you select will be exported as a ZIP archive."
 msgstr "只显示带有用户耗材预设的耗材名称，您选择的每个耗材名称中的所有用户耗材预设都将导出为一个 ZIP 文件。"
 
 msgid ""
 "Only printer names with changed process presets will be displayed, \n"
-"and all user process presets in each printer name you select will be exported as a zip."
+"and all user process presets in each printer name you select will be exported as a ZIP archive."
 msgstr "只显示带有更改的工艺预设的打印机名称，您选择的每个打印机名称中的所有用户工艺预设都将导出为一个 ZIP 文件。"
 
 msgid "Please select at least one printer or filament."
@@ -19635,7 +19636,7 @@ msgid "We need information for diagnosing source of the issue. Check wiki page f
 msgstr "我们需要相关信息来诊断问题的根源。请查看 wiki 页面获取详细指南。"
 
 # AI Translated
-msgid "Pack button collects project file and logs of current session onto a zip file."
+msgid "Pack button collects project file and logs of current session onto a ZIP archive."
 msgstr "“打包”按钮会将当前会话的项目文件和日志收集到一个 zip 文件中。"
 
 # AI Translated
@@ -19691,7 +19692,7 @@ msgid "Stored logs"
 msgstr "已存储的日志"
 
 # AI Translated
-msgid "Packs all stored logs onto a zip file."
+msgid "Packs all stored logs onto a ZIP archive."
 msgstr "将所有已存储的日志打包到一个 zip 文件中。"
 
 # AI Translated
@@ -19771,7 +19772,7 @@ msgstr "未找到打印机类型，请手动选择。"
 msgid "Authorizing..."
 msgstr "正在授权..."
 
-msgid "Error. Can't get api token for authorization"
+msgid "Error. Can't get API token for authorization"
 msgstr "错误。无法获取用于授权的 API 令牌"
 
 msgid "Could not parse server response."

--- a/localization/i18n/zh_TW/OrcaSlicer_zh_TW.po
+++ b/localization/i18n/zh_TW/OrcaSlicer_zh_TW.po
@@ -6287,10 +6287,10 @@ msgstr "匯入 3MF/STL/STEP/SVG/OBJ/AMF"
 msgid "Load a model"
 msgstr "載入模型"
 
-msgid "Import Zip Archive"
+msgid "Import ZIP Archive"
 msgstr "匯入壓縮檔"
 
-msgid "Load models contained within a zip archive"
+msgid "Load models contained within a ZIP archive"
 msgstr "載入壓縮檔中的模型"
 
 msgid "Import Configs"
@@ -8066,7 +8066,7 @@ msgstr "請確認這些預設中的 G-code 是安全的，以防止對列印裝�
 msgid "Customized Preset"
 msgstr "自訂預設"
 
-msgid "Component name(s) inside step file not in UTF8 format!"
+msgid "Component name(s) inside step file not in UTF-8 format!"
 msgstr "STEP 檔案內部元件的名稱不是 UTF-8 格式！"
 
 # AI Translated
@@ -8089,7 +8089,7 @@ msgstr "物件的體積為零"
 #, c-format, boost-format
 msgid ""
 "The object from file %s is too small, and may be in meters or inches.\n"
-" Do you want to scale to millimeters?"
+"Do you want to scale to millimeters?"
 msgstr ""
 "檔案 %s 中的物件太小，可能以公尺（M）或英吋（Inches）為單位。\n"
 "是否要轉換成毫米（mm）？"
@@ -10944,12 +10944,12 @@ msgid "No modifications need to be copied."
 msgstr "沒有需要複製的修改。"
 
 # AI Translated
-msgid "Copy paramters"
+msgid "Copy parameters"
 msgstr "複製參數"
 
 # AI Translated
 #, c-format, boost-format
-msgid "Modify paramters of %s"
+msgid "Modify parameters of %s"
 msgstr "修改 %s 的參數"
 
 # AI Translated
@@ -12578,7 +12578,8 @@ msgstr "mm 或 %"
 msgid "Other layers"
 msgstr "其它層"
 
-msgid "Bed temperature for layers except the initial one. A value of 0 means the filament does not support printing on the Cool Plate SuperTack."
+#, fuzzy
+msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the Cool Plate SuperTack."
 msgstr "除首層外的其他層的熱床溫度。0值表示該線材不支援在低溫增穩列印板上列印。"
 
 msgid "This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the Cool Plate."
@@ -15790,7 +15791,7 @@ msgstr "從切割區域到垃圾桶的起始和結束點。"
 msgid "Reduce infill retraction"
 msgstr "減小填充回抽"
 
-msgid "Don't retract when the travel is entirely within an infill area. That means the oozing can't been seen. This can reduce times of retraction for complex model and save printing time, but make slicing and G-code generating slower. Note that z-hop is also not performed in areas where retraction is skipped."
+msgid "Don't retract when the travel is entirely within an infill area. That means the oozing can't been seen. This can reduce times of retraction for complex model and save printing time, but make slicing and G-code generating slower. Note that Z-hop is also not performed in areas where retraction is skipped."
 msgstr "當空駛完全在填充區域內時不觸發回抽。這意味著即使漏料也是不可見的。對於複雜模型，該設定能夠減少回抽次數以及列印時長，但是會造成 G-code 產生變慢"
 
 msgid "This option will drop the temperature of the inactive extruders to prevent oozing."
@@ -15961,7 +15962,7 @@ msgstr "擦拭後的回抽量"
 # AI Translated
 #, no-c-format, no-boost-format
 msgid ""
-"The length of fast retraction after wipe, relative to retraction length.\n"
+"This is the length of fast retraction after wipe, relative to retraction length.\n"
 "The value will be clamped by 100% minus the retract amount before the wipe value."
 msgstr ""
 "擦拭後快速回抽的長度，相對於回抽長度。\n"
@@ -16008,7 +16009,7 @@ msgstr "在換工具之前觸發回抽時，線材會依指定的長度回抽（
 msgid "Z-hop height"
 msgstr "Z 抬升高度"
 
-msgid "Whenever there is a retraction, the nozzle is lifted a little to create clearance between the nozzle and the print. This prevents the nozzle from hitting the print when traveling more. Using spiral lines to lift z can prevent stringing."
+msgid "Whenever there is a retraction, the nozzle is lifted a little to create clearance between the nozzle and the print. This prevents the nozzle from hitting the print when traveling more. Using spiral lines to lift Z can prevent stringing."
 msgstr "回抽完成之後，噴嘴輕微抬升，和列印物件之間產生一定間隙。這能夠避免空駛時噴嘴和列印物件剮蹭和碰撞。使用螺旋線抬升z能夠減少拉絲"
 
 msgid "Z-hop lower boundary"
@@ -19573,19 +19574,19 @@ msgstr "僅顯示對列印裝置、線材和處理預設設定有變更的列印
 msgid "Only display the filament names with changes to filament presets."
 msgstr "僅顯示對線材預設設定有變更的線材名稱。"
 
-msgid "Only printer names with user printer presets will be displayed, and each preset you choose will be exported as a zip."
+msgid "Only printer names with user printer presets will be displayed, and each preset you choose will be exported as a ZIP archive."
 msgstr "只有具有使用者列印裝置預設設定的列印裝置名稱會顯示，您選擇的每個預設設定將以 zip 檔案格式匯出。"
 
 msgid ""
 "Only the filament names with user filament presets will be displayed, \n"
-"and all user filament presets in each filament name you select will be exported as a zip."
+"and all user filament presets in each filament name you select will be exported as a ZIP archive."
 msgstr ""
 "只有具有使用者線材預設設定的線材名稱會顯示，\n"
 "您選擇的每個線材名稱中的所有使用者線材預設設定將以 zip 檔案格式匯出。"
 
 msgid ""
 "Only printer names with changed process presets will be displayed, \n"
-"and all user process presets in each printer name you select will be exported as a zip."
+"and all user process presets in each printer name you select will be exported as a ZIP archive."
 msgstr ""
 "只有具有變更過處理預設設定的列印裝置名稱會顯示，\n"
 "您選擇的每個列印裝置名稱中的所有使用者處理預設設定將以 zip 檔案格式匯出。"
@@ -19826,7 +19827,7 @@ msgid "We need information for diagnosing source of the issue. Check wiki page f
 msgstr "我們需要相關資訊以診斷問題來源。請查看 wiki 頁面以取得詳細指南。"
 
 # AI Translated
-msgid "Pack button collects project file and logs of current session onto a zip file."
+msgid "Pack button collects project file and logs of current session onto a ZIP archive."
 msgstr "「打包」按鈕會將目前工作階段的專案檔案與記錄收集到一個 zip 檔案中。"
 
 # AI Translated
@@ -19882,7 +19883,7 @@ msgid "Stored logs"
 msgstr "已儲存的記錄"
 
 # AI Translated
-msgid "Packs all stored logs onto a zip file."
+msgid "Packs all stored logs onto a ZIP archive."
 msgstr "將所有已儲存的記錄打包成一個 zip 檔案。"
 
 # AI Translated
@@ -19962,7 +19963,7 @@ msgstr "找不到列印裝置類型，請手動選取。"
 msgid "Authorizing..."
 msgstr "授權中..."
 
-msgid "Error. Can't get api token for authorization"
+msgid "Error. Can't get API token for authorization"
 msgstr "錯誤。無法取得用於授權的 API token。"
 
 msgid "Could not parse server response."

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -1130,8 +1130,7 @@ void PrintConfigDef::init_fff_params()
     // BBS
     def = this->add("supertack_plate_temp", coInts);
     def->label = L("Other layers");
-    def->tooltip = L("Bed temperature for layers except the initial one. "
-                     "A value of 0 means the filament does not support printing on the Cool Plate SuperTack.");
+    def->tooltip = L("This is the bed temperature for layers except for the first one. A value of 0 means the filament does not support printing on the Cool Plate SuperTack.");
     def->sidetext = L(u8"\u2103" /* °C */);	// degrees Celsius, CIS languages need translation
     def->full_label = L("Bed temperature");
     def->min = 0;
@@ -5481,7 +5480,7 @@ void PrintConfigDef::init_fff_params()
 
     def = this->add("reduce_infill_retraction", coBool);
     def->label = L("Reduce infill retraction");
-    def->tooltip = L("Don\'t retract when the travel is entirely within an infill area. That means the oozing can\'t been seen. This can reduce times of retraction for complex model and save printing time, but make slicing and G-code generating slower. Note that z-hop is also not performed in areas where retraction is skipped.");
+    def->tooltip = L("Don\'t retract when the travel is entirely within an infill area. That means the oozing can\'t been seen. This can reduce times of retraction for complex model and save printing time, but make slicing and G-code generating slower. Note that Z-hop is also not performed in areas where retraction is skipped.");
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionBool(false));
 
@@ -5736,7 +5735,7 @@ void PrintConfigDef::init_fff_params()
     def = this->add("retract_after_wipe", coPercents);
     def->label = L("Retract amount after wipe");
     // xgettext:no-c-format, no-boost-format
-    def->tooltip = L("The length of fast retraction after wipe, relative to retraction length.\n"
+    def->tooltip = L("This is the length of fast retraction after wipe, relative to retraction length.\n"
                      "The value will be clamped by 100% minus the retract amount before the wipe value.");
     def->sidetext = "%";
     def->mode = comExpert;
@@ -5802,7 +5801,7 @@ void PrintConfigDef::init_fff_params()
 
     def = this->add("z_hop", coFloats);
     def->label = L("Z-hop height");
-    def->tooltip = L("Whenever there is a retraction, the nozzle is lifted a little to create clearance between the nozzle and the print. This prevents the nozzle from hitting the print when traveling more. Using spiral lines to lift z can prevent stringing.");
+    def->tooltip = L("Whenever there is a retraction, the nozzle is lifted a little to create clearance between the nozzle and the print. This prevents the nozzle from hitting the print when traveling more. Using spiral lines to lift Z can prevent stringing.");
     def->sidetext = L("mm");	// millimeters, CIS languages need translation
     def->mode = comSimple;
     def->min = 0;

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -2769,7 +2769,7 @@ void PrintConfigDef::init_fff_params()
     def = this->add("fan_cooling_layer_time", coFloats);
     def->label = L("Layer time");
     def->tooltip = L("The part cooling fan will be enabled for layers where the estimated time is shorter than this value. Fan speed is interpolated between the minimum and maximum fan speeds according to layer printing time.");
-    def->sidetext = L("s");	// seconds, CIS languages need translation
+    def->sidetext = L_CONTEXT("s", "second");	// seconds, CIS languages need translation
     def->min = 0;
     def->max = 1000;
     def->mode = comSimple;
@@ -2922,7 +2922,7 @@ void PrintConfigDef::init_fff_params()
     def->label = L("Filament load time");
     def->tooltip = L("Time to load new filament when switch filament. It's usually applicable for single-extruder multi-material machines. "
                      "For tool changers or multi-tool machines, it's typically 0. For statistics only.");
-    def->sidetext = L("s");	// seconds, CIS languages need translation
+    def->sidetext = L_CONTEXT("s", "second");	// seconds, CIS languages need translation
     def->min = 0;
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionFloat(0.0));
@@ -2931,7 +2931,7 @@ void PrintConfigDef::init_fff_params()
     def->label = L("Filament unload time");
     def->tooltip = L("Time to unload old filament when switch filament. It's usually applicable for single-extruder multi-material machines. "
                      "For tool changers or multi-tool machines, it's typically 0. For statistics only.");
-    def->sidetext = L("s");	// seconds, CIS languages need translation
+    def->sidetext = L_CONTEXT("s", "second");	// seconds, CIS languages need translation
     def->min = 0;
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionFloat(0.0));
@@ -2940,7 +2940,7 @@ void PrintConfigDef::init_fff_params()
     def->label = L("Tool change time");
     def->tooltip = L("Time taken to switch tools. It's usually applicable for tool changers or multi-tool machines. "
                      "For single-extruder multi-material machines, it's typically 0. For statistics only.");
-    def->sidetext = L("s");	// seconds, CIS languages need translation
+    def->sidetext = L_CONTEXT("s", "second");	// seconds, CIS languages need translation
     def->min = 0;
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionFloat { 0. });
@@ -3086,7 +3086,7 @@ void PrintConfigDef::init_fff_params()
     def->tooltip = L("Time to wait after the filament is unloaded. "
                    "May help to get reliable tool changes with flexible materials "
                    "that may need more time to shrink to original dimensions.");
-    def->sidetext = L("s");	// seconds, CIS languages need translation
+    def->sidetext = L_CONTEXT("s", "second");	// seconds, CIS languages need translation
     def->min = 0;
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionFloats { 0. });
@@ -4205,7 +4205,7 @@ void PrintConfigDef::init_fff_params()
         "\nIt won't move fan commands from custom G-code (they act as a sort of 'barrier')."
         "\nIt won't move fan commands into the start G-code if the 'only custom start G-code' is activated."
         "\nUse 0 to deactivate.");
-    def->sidetext = L("s");	// seconds, CIS languages need translation
+    def->sidetext = L_CONTEXT("s", "second");	// seconds, CIS languages need translation
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionFloat(0));
 
@@ -4221,7 +4221,7 @@ void PrintConfigDef::init_fff_params()
                     "\nThis is useful for fans where a low PWM/power may be insufficient to get the fan started spinning from a stop, or to "
                     "get the fan up to speed faster."
                     "\nSet to 0 to deactivate.");
-    def->sidetext = L("s");	// seconds, CIS languages need translation
+    def->sidetext = L_CONTEXT("s", "second");	// seconds, CIS languages need translation
     def->min = 0;
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionFloat(0));
@@ -4865,7 +4865,7 @@ void PrintConfigDef::init_fff_params()
     def->label    = L("Ironing expansion");
     def->category = L("Quality");
     def->tooltip  = L("Expand or contract the ironing area.");
-    def->sidetext = L("mm");
+    def->sidetext = L("mm");	// millimeters, CIS languages need translation
     def->min      = -100;
     def->max      = 100;
     def->mode     = comExpert;
@@ -4902,7 +4902,7 @@ void PrintConfigDef::init_fff_params()
     def->category = L("Quality");
     def->tooltip  = L("Minimum Z-layer height.\n"
                       "Also controls the slicing plane.");
-    def->sidetext = L("mm");
+    def->sidetext = L("mm");	// millimeters, CIS languages need translation
     def->min      = 0;
     def->max      = 100;
     def->mode     = comExpert;
@@ -5101,7 +5101,7 @@ void PrintConfigDef::init_fff_params()
     def->category   = L("Machine limits");
     def->readonly   = false;
     def->tooltip    = L("The allowed maximum output force of Y axis");
-    def->sidetext   = L("N");
+    def->sidetext   = L_CONTEXT("N", "Newton");	// Newtons, CIS languages need translation
     def->min        = 0;
     def->mode       = comDevelop;
     def->set_default_value(new ConfigOptionFloat(0));
@@ -5111,7 +5111,7 @@ void PrintConfigDef::init_fff_params()
     def->category   = L("Machine limits");
     def->readonly   = false;
     def->tooltip    = L("The machine bed mass load of Y axis");
-    def->sidetext   = L("g");
+    def->sidetext   = L_CONTEXT("g", "gram");	// grams, CIS languages need translation
     def->min        = 0;
     def->mode       = comDevelop;
     def->set_default_value(new ConfigOptionFloat(0));
@@ -5121,7 +5121,7 @@ void PrintConfigDef::init_fff_params()
     def->category   = L("Machine limits");
     def->readonly   = false;
     def->tooltip    = L("The allowed max printed mass on a plate");
-    def->sidetext   = L("g");
+    def->sidetext   = L_CONTEXT("g", "gram");	// grams, CIS languages need translation
     def->min        = 0;
     def->mode       = comDevelop;
     def->set_default_value(new ConfigOptionFloat(0));
@@ -6379,7 +6379,7 @@ void PrintConfigDef::init_fff_params()
     def->label = L("Layer time");
     def->tooltip = L("The printing speed in exported G-code will be slowed down when the estimated layer time is "
                      "shorter than this value in order to get better cooling for these layers.");
-    def->sidetext = L("s");	// seconds, CIS languages need translation
+    def->sidetext = L_CONTEXT("s", "second");	// seconds, CIS languages need translation
     def->min = 0;
     def->max = 1000;
     def->mode = comSimple;
@@ -6532,7 +6532,7 @@ void PrintConfigDef::init_fff_params()
     def->label = L("Preheat time");
     def->tooltip = L("To reduce the waiting time after tool change, Orca can preheat the next tool while the current tool is still in use. "
                      "This setting specifies the time in seconds to preheat the next tool. Orca will insert a M104 command to preheat the tool in advance.");
-    def->sidetext = L("s");	// seconds, CIS languages need translation
+    def->sidetext = L_CONTEXT("s", "second");	// seconds, CIS languages need translation
     def->min = 0;
     def->max = 120;
     def->mode = comAdvanced;
@@ -8024,7 +8024,7 @@ void PrintConfigDef::init_fff_params()
     def           = this->add("machine_hotend_change_time", coFloat);
     def->label    = L("Hotend change time");
     def->tooltip  = L("Time to change hotend.");
-    def->sidetext = L("s");
+    def->sidetext = L_CONTEXT("s", "second");
     def->min      = 0;
     def->mode     = comAdvanced;
     def->set_default_value(new ConfigOptionFloat(0.0));

--- a/src/libslic3r/calib.cpp
+++ b/src/libslic3r/calib.cpp
@@ -28,9 +28,9 @@ std::string CalibPressureAdvance::move_to(Vec2d pt, GCodeWriter &writer, std::st
 
     gcode << writer.retract(); // retract before z move or move
     if(z > EPSILON && layer_height >= 0){
-        gcode << writer.travel_to_z(z, "z-hop"); // Perform z hop
+        gcode << writer.travel_to_z(z, "Z-hop"); // Perform z hop
         gcode << writer.travel_to_xy(pt, comment); // Travel with z move
-        gcode << writer.travel_to_z(layer_height, "undo z-hop"); // Undo z hop
+        gcode << writer.travel_to_z(layer_height, "undo Z-hop"); // Undo z hop
     }else {
         gcode << writer.travel_to_xy(pt, comment);
     }

--- a/src/slic3r/GUI/CreatePresetsDialog.cpp
+++ b/src/slic3r/GUI/CreatePresetsDialog.cpp
@@ -3867,14 +3867,14 @@ void ExportConfigsDialog::select_curr_radiobox(std::vector<std::pair<RadioBox *,
                     m_preset_sizer->Add(create_checkbox(m_presets_window, preset.second, printer_name, m_preset), 0, wxEXPAND | wxTOP | wxLEFT | wxRIGHT,
                                         FromDIP(5));
                 }
-                m_serial_text->SetLabel(_L("Only printer names with user printer presets will be displayed, and each preset you choose will be exported as a zip."));
+                m_serial_text->SetLabel(_L("Only printer names with user printer presets will be displayed, and each preset you choose will be exported as a ZIP archive."));
             } else if (export_type == m_exprot_type.filament_preset) {
                 for (std::pair<std::string, std::vector<std::pair<std::string, Preset *>>> filament_name_to_preset : m_filament_name_to_presets) {
                     if (filament_name_to_preset.second.empty()) continue;
                     wxString filament_name = wxString::FromUTF8(filament_name_to_preset.first);
                     m_preset_sizer->Add(create_checkbox(m_presets_window, filament_name, m_printer_name), 0, wxEXPAND | wxTOP | wxLEFT | wxRIGHT, FromDIP(5));
                 }
-                m_serial_text->SetLabel(_L("Only the filament names with user filament presets will be displayed, \nand all user filament presets in each filament name you select will be exported as a zip."));
+                m_serial_text->SetLabel(_L("Only the filament names with user filament presets will be displayed, \nand all user filament presets in each filament name you select will be exported as a ZIP archive."));
             } else if (export_type == m_exprot_type.process_preset) {
                 for (std::pair<std::string, std::vector<Preset *>> presets : m_process_presets) {
                     Preset *      printer_preset = preset_bundle->printers.find_preset(presets.first, false);
@@ -3890,7 +3890,7 @@ void ExportConfigsDialog::select_curr_radiobox(std::vector<std::pair<RadioBox *,
                     }
 
                 }
-                m_serial_text->SetLabel(_L("Only printer names with changed process presets will be displayed, \nand all user process presets in each printer name you select will be exported as a zip."));
+                m_serial_text->SetLabel(_L("Only printer names with changed process presets will be displayed, \nand all user process presets in each printer name you select will be exported as a ZIP archive."));
             }
             //m_presets_window->SetSizerAndFit(m_preset_sizer);
             m_presets_window->Layout();

--- a/src/slic3r/GUI/FilamentMapDialog.cpp
+++ b/src/slic3r/GUI/FilamentMapDialog.cpp
@@ -241,7 +241,7 @@ FilamentMapDialog::FilamentMapDialog(wxWindow                       *parent,
 
     wxBoxSizer *mode_sizer = new wxBoxSizer(wxHORIZONTAL);
 
-    m_auto_btn   = new CapsuleButton(this, PageType::ptAuto, only_saving_mode ? _L("Fila Saving") : _L("Auto"), false);
+    m_auto_btn   = new CapsuleButton(this, PageType::ptAuto, only_saving_mode ? _L("File Saving") : _L("Auto"), false);
     m_manual_btn = new CapsuleButton(this, PageType::ptManual, _L("Custom"), false);
     if (show_default)
         m_default_btn = new CapsuleButton(this, PageType::ptDefault, _L("Same as Global"), true);

--- a/src/slic3r/GUI/MainFrame.cpp
+++ b/src/slic3r/GUI/MainFrame.cpp
@@ -2850,7 +2850,7 @@ void MainFrame::init_menubar_as_editor()
             [this](wxCommandEvent&) { if (m_plater) { m_plater->add_model(); } }, "", nullptr,
             [this](){return can_add_models(); }, this);
 #endif
-        append_menu_item(import_menu, wxID_ANY, _L("Import Zip Archive") + dots, _L("Load models contained within a zip archive"),
+        append_menu_item(import_menu, wxID_ANY, _L("Import ZIP Archive") + dots, _L("Load models contained within a ZIP archive"),
             [this](wxCommandEvent&) { if (m_plater) m_plater->import_zip_archive(); }, "menu_import", nullptr,
             [this]() { return can_add_models(); });
         append_menu_item(import_menu, wxID_ANY, _L("Import Configs") + dots /*+ "\t" + ctrl + "I"*/, _L("Load configs"),

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -9017,7 +9017,7 @@ std::vector<size_t> Plater::priv::load_files(const std::vector<fs::path>& input_
                             if (!isUtf8StepFile) {
                                 const auto no_warn = wxGetApp().app_config->get_bool("step_not_utf8_no_warn");
                                 if (!no_warn) {
-                                    MessageDialog dlg(nullptr, _L("Component name(s) inside step file not in UTF8 format!") + "\n\n" + _L("Because of unsupported text encoding, garbage characters may appear!"),
+                                    MessageDialog dlg(nullptr, _L("Component name(s) inside step file not in UTF-8 format!") + "\n\n" + _L("Because of unsupported text encoding, garbage characters may appear!"),
                                                       wxString(SLIC3R_APP_FULL_NAME " - ") + _L("Attention!"), wxOK | wxICON_INFORMATION);
                                     dlg.show_dsa_button(_L("Remember my choice."));
                                     dlg.ShowModal();
@@ -9130,7 +9130,7 @@ std::vector<size_t> Plater::priv::load_files(const std::vector<fs::path>& input_
                 else if (model.looks_like_saved_in_meters()) {
                     // BBS do not handle look like in meters
                     MessageDialog dlg(q,
-                                      format_wxstr(_L("The object from file %s is too small, and may be in meters or inches.\n Do you want to scale to millimeters\?"),
+                                      format_wxstr(_L("The object from file %s is too small, and may be in meters or inches.\nDo you want to scale to millimeters\?"),
                                                    from_path(filename)),
                                       _L("Object too small"), wxICON_QUESTION | wxYES_NO);
                     int           answer = dlg.ShowModal();
@@ -9138,7 +9138,7 @@ std::vector<size_t> Plater::priv::load_files(const std::vector<fs::path>& input_
                 } else if (model.looks_like_imperial_units()) {
                     // BBS do not handle look like in meters
                     MessageDialog dlg(q,
-                                      format_wxstr(_L("The object from file %s is too small, and may be in meters or inches.\n Do you want to scale to millimeters\?"),
+                                      format_wxstr(_L("The object from file %s is too small, and may be in meters or inches.\nDo you want to scale to millimeters\?"),
                                                    from_path(filename)),
                                       _L("Object too small"), wxICON_QUESTION | wxYES_NO);
                     int           answer = dlg.ShowModal();

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -8404,7 +8404,7 @@ void Tab::sync_excluder()
         }
     }
     if (config_to_apply.empty()) {
-        MessageDialog md(wxGetApp().plater(), _L("No modifications need to be copied."), _L("Copy paramters"), wxICON_INFORMATION | wxOK);
+        MessageDialog md(wxGetApp().plater(), _L("No modifications need to be copied."), _L("Copy parameters"), wxICON_INFORMATION | wxOK);
         md.ShowModal();
         return;
     }
@@ -8412,7 +8412,7 @@ void Tab::sync_excluder()
     std::string pt = m_preset_bundle->printers.get_edited_preset().get_printer_type(m_preset_bundle);
     std::string active_nozzle_name = DevPrinterConfigUtil::get_toolhead_display_name(pt, active_index, ToolHeadComponent::Nozzle, ToolHeadNameCase::LowerCase);
     std::string other_nozzle_name  = DevPrinterConfigUtil::get_toolhead_display_name(pt, 1 - active_index, ToolHeadComponent::Nozzle, ToolHeadNameCase::LowerCase);
-    wxString title  = wxString::Format(_L("Modify paramters of %s"), _L(active_nozzle_name));
+    wxString title  = wxString::Format(_L("Modify parameters of %s"), _L(active_nozzle_name));
     wxString header = wxString::Format(_L("Do you want to modify the following parameters of the %s to that of the %s?"),
                                        _L(active_nozzle_name), _L(other_nozzle_name));
     UnsavedChangesDialog dlg(title, header, &config_origin, from_index, dest_index, active_index == 0, active_nozzle);

--- a/src/slic3r/GUI/TroubleshootDialog.cpp
+++ b/src/slic3r/GUI/TroubleshootDialog.cpp
@@ -226,7 +226,7 @@ TroubleshootDialog::TroubleshootDialog()
     };
 
     auto info_desc_1 = create_info_line(_L("We need information for diagnosing source of the issue. Check wiki page for detailed guide."));
-    auto info_desc_2 = create_info_line(_L("Pack button collects project file and logs of current session onto a zip file."));
+    auto info_desc_2 = create_info_line(_L("Pack button collects project file and logs of current session onto a ZIP archive."));
     auto info_desc_3 = create_info_line(_L("Any additional visual examples like images or screen recordings might be helpful while reporting the issue."));
     wxBoxSizer *info_desc_sizer = new wxBoxSizer(wxVERTICAL);
     info_desc_sizer->Add(info_desc_1, 0, wxEXPAND | wxBOTTOM, FromDIP(8));
@@ -292,7 +292,7 @@ TroubleshootDialog::TroubleshootDialog()
     auto log_level_szr = create_label(_L("Log level"), "");
     log_level_szr->Add(create_item_log_level_combo(), 0, wxALIGN_CENTER_VERTICAL);
 
-    auto log_pack_szr = create_label(_L("Stored logs"), _L("Packs all stored logs onto a zip file."));
+    auto log_pack_szr = create_label(_L("Stored logs"), _L("Packs all stored logs onto a ZIP archive."));
     auto log_pack_btn = create_btn(_L("Pack") + "...", "");
     log_pack_btn->Bind(wxEVT_BUTTON, [this](wxCommandEvent &e) {
         auto data_dir   = boost::filesystem::path(Slic3r::data_dir());

--- a/src/slic3r/Utils/3DPrinterOS.cpp
+++ b/src/slic3r/Utils/3DPrinterOS.cpp
@@ -323,7 +323,7 @@ bool C3DPrinterOS::login(wxString& msg) const
     msg.clear();
     std::string token = get_api_auth_token(msg);
     if (token.empty()) {
-        msg = _L("Error. Can't get api token for authorization");
+        msg = _L("Error. Can't get API token for authorization");
         return false;
     }
 


### PR DESCRIPTION
# Description
Fixing misc GUI string errors found during translation, like spelling, capitalization and spacing.
Also added context to single-letter strings to ease translation.