### PR TITLE
build: drop the pkg-config requirement from the Windows build

### DIFF
--- a/.github/workflows/build_orca.yml
+++ b/.github/workflows/build_orca.yml
@@ -385,13 +385,6 @@ jobs:
           dir "C:/Program Files (x86)/Windows Kits/10/Include"
           choco install nsis
 
-      - name: Install pkg-config
-        # FFmpeg is discovered via pkg-config (pkg_check_modules LIBAV in
-        # src/slic3r/CMakeLists.txt); the Windows runners don't ship it.
-        if: runner.os == 'Windows' && !vars.SELF_HOSTED
-        run: |
-          choco install pkgconfiglite -y
-
       - name: Build slicer Win
         if: runner.os == 'Windows'
         working-directory: ${{ github.workspace }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -476,8 +476,7 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 # WIN10SDK_PATH is used to point CMake to the WIN10 SDK installation directory.
 # We pick it from environment if it is not defined in another way
 # ORCA: Removed Netfabb STL fixing service support in favor of CGAL.
-if(WIN32)
-    find_package(PkgConfig REQUIRED)
+# if(WIN32)
 #     if(NOT DEFINED WIN10SDK_PATH)
 #         if(DEFINED ENV{WIN10SDK_PATH})
 #                 set(WIN10SDK_PATH "$ENV{WIN10SDK_PATH}")
@@ -513,7 +512,7 @@ if(WIN32)
 #     else()
 #         message("Building without Win10 Netfabb STL fixing service support")
 #     endif()
-endif()
+# endif()
 
 if (APPLE)
     message("OS X SDK Path: ${CMAKE_OSX_SYSROOT}")

--- a/src/slic3r/CMakeLists.txt
+++ b/src/slic3r/CMakeLists.txt
@@ -915,6 +915,18 @@ if (APPLE)
     endif ()
     target_link_libraries(libslic3r_gui ${LIBAVCODEC_LIBRARY} ${LIBSWSCALE_LIBRARY} ${LIBAVUTIL_LIBRARY})
     target_include_directories(libslic3r_gui SYSTEM PRIVATE ${CMAKE_PREFIX_PATH}/include)
+elseif (WIN32)
+    # Prebuilt shared FFmpeg from the deps install. Windows has no pkg-config,
+    # so resolve the import libraries out of the deps prefix directly; the DLLs
+    # are copied next to the executable by the top level CMakeLists.
+    find_library(LIBAVCODEC_LIBRARY NAMES avcodec PATHS ${CMAKE_PREFIX_PATH}/lib NO_DEFAULT_PATH)
+    find_library(LIBSWSCALE_LIBRARY NAMES swscale PATHS ${CMAKE_PREFIX_PATH}/lib NO_DEFAULT_PATH)
+    find_library(LIBAVUTIL_LIBRARY NAMES avutil PATHS ${CMAKE_PREFIX_PATH}/lib NO_DEFAULT_PATH)
+    if (NOT LIBAVCODEC_LIBRARY OR NOT LIBSWSCALE_LIBRARY OR NOT LIBAVUTIL_LIBRARY)
+        message(FATAL_ERROR "FFmpeg (avcodec/swscale/avutil) not found under ${CMAKE_PREFIX_PATH}/lib. Rebuild the deps.")
+    endif ()
+    target_link_libraries(libslic3r_gui ${LIBAVCODEC_LIBRARY} ${LIBSWSCALE_LIBRARY} ${LIBAVUTIL_LIBRARY})
+    target_include_directories(libslic3r_gui SYSTEM PRIVATE ${CMAKE_PREFIX_PATH}/include)
 else ()
     pkg_check_modules(LIBAV REQUIRED IMPORTED_TARGET
         libavcodec


### PR DESCRIPTION
# Description

#15234 made pkg-config a required build tool on Windows. Windows does not ship one, so every Windows developer and every self-hosted runner now has to install it before the build will configure:

    CMake Error at FindPackageHandleStandardArgs.cmake:290 (message):
      Could NOT find PkgConfig (missing: PKG_CONFIG_EXECUTABLE)
    Call Stack (most recent call first):
      CMakeLists.txt:480 (find_package)

Nothing on Windows needs it. FFmpeg there is a prebuilt zip pinned by SHA256 and unpacked into the deps prefix, and the top level CMakeLists already hardcodes `avcodec-61.dll` and its siblings by exact soname for the DLL copy step. The version is fixed before configure runs, so `find_library` against that prefix does the job, which is what the macOS branch already does.

This also drops the `choco install pkgconfiglite` CI step, which was gated on `!SELF_HOSTED` and so never ran on self-hosted runners anyway, and re-comments the `if(WIN32)` block, which #15234 uncommented only for that `find_package`.

macOS and Linux still use pkg-config, including the `pkgconf` entries #15234 added for the macOS deps build and the Linux package lists.

# Screenshots/Recordings/Graphs

N/A, build fix.

## Tests

Built deps and slicer at upstream main with clang-cl and Ninja Multi-Config, with pkg-config removed from `PATH` so CMake cannot find one. CI cannot prove that case, since a runner image may ship one.

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
