### PR TITLE
[CLI]: Fix Plate Config Reading and BuildVolume Height Checks

### DIFF
--- a/src/OrcaSlicer.cpp
+++ b/src/OrcaSlicer.cpp
@@ -5166,7 +5166,8 @@ int CLI::run(int argc, char **argv)
 
                             Vec3d wipe_tower_size = cur_plate->estimate_wipe_tower_size(m_print_config, w, v, new_extruder_count, filaments_cnt, false, enable_wrapping);
                             Vec3d plate_origin = cur_plate->get_origin();
-                            int plate_width, plate_depth, plate_height;
+                            int plate_width, plate_depth;
+                            double plate_height;
                             partplate_list.get_plate_size(plate_width, plate_depth, plate_height);
                             float depth = wipe_tower_size(1);
                             float margin = 15.f, wp_brim_width = 0.f;

--- a/src/libslic3r/BuildVolume.cpp
+++ b/src/libslic3r/BuildVolume.cpp
@@ -13,7 +13,6 @@ BuildVolume::BuildVolume(const std::vector<Vec2d> &printable_area, const double 
     : m_bed_shape(printable_area), m_max_print_height(printable_height), m_extruder_shapes(extruder_areas), m_extruder_printable_height(extruder_printable_heights)
 {
     assert(printable_height >= 0);
-    //assert(extruder_printable_heights.size() == extruder_areas.size());
 
     m_polygon     = Polygon::new_scale(printable_area);
     assert(m_polygon.is_counter_clockwise());
@@ -100,7 +99,12 @@ BuildVolume::BuildVolume(const std::vector<Vec2d> &printable_area, const double 
                 return;
             }
 
-            if ((extruder_shape == printable_area)&&(extruder_printable_heights[index] == printable_height)) {
+            if (index >= extruder_printable_heights.size())
+                BOOST_LOG_TRIVIAL(warning) << boost::format("extruder_printable_height has only %1% entries but extruder_printable_area has %2%; using bed printable_height for extruder %3%")
+                        % extruder_printable_heights.size() % m_extruder_shapes.size() % index;
+            const double extruder_height = index < extruder_printable_heights.size() ? extruder_printable_heights[index] : printable_height;
+
+            if ((extruder_shape == printable_area)&&(extruder_height == printable_height)) {
                 extruder_volume.same_with_bed = true;
                 extruder_volume.type = m_type;
                 extruder_volume.bbox = m_bbox;
@@ -113,7 +117,7 @@ BuildVolume::BuildVolume(const std::vector<Vec2d> &printable_area, const double 
                 double poly_area         = poly.area();
                 extruder_volume.bbox = get_extents(poly);
                 BoundingBoxf temp_bboxf = get_extents(extruder_shape);
-                extruder_volume.bboxf = BoundingBoxf3{ to_3d(temp_bboxf.min, 0.), to_3d(temp_bboxf.max, extruder_printable_heights[index]) };
+                extruder_volume.bboxf = BoundingBoxf3{ to_3d(temp_bboxf.min, 0.), to_3d(temp_bboxf.max, extruder_height) };
 
                 if (extruder_shape.size() >= 4 && std::abs((poly_area - double(extruder_volume.bbox.size().x()) * double(extruder_volume.bbox.size().y()))) < sqr(SCALED_EPSILON))
                 {

--- a/src/libslic3r/BuildVolume.cpp
+++ b/src/libslic3r/BuildVolume.cpp
@@ -85,6 +85,9 @@ BuildVolume::BuildVolume(const std::vector<Vec2d> &printable_area, const double 
         m_shared_volume.data[2] = m_bboxf.max.x();
         m_shared_volume.data[3] = m_bboxf.max.y();
         m_shared_volume.zs[1] = m_bboxf.max.z();
+        if (extruder_printable_heights.size() < m_extruder_shapes.size())
+            BOOST_LOG_TRIVIAL(warning) << boost::format("extruder_printable_height has only %1% entries but extruder_printable_area has %2%, falling back to the bed printable_height for the missing ones")
+                    % extruder_printable_heights.size() % m_extruder_shapes.size();
         for (unsigned int index = 0; index < m_extruder_shapes.size(); index++)
         {
             std::vector<Vec2d>& extruder_shape = m_extruder_shapes[index];
@@ -99,9 +102,6 @@ BuildVolume::BuildVolume(const std::vector<Vec2d> &printable_area, const double 
                 return;
             }
 
-            if (index >= extruder_printable_heights.size())
-                BOOST_LOG_TRIVIAL(warning) << boost::format("extruder_printable_height has only %1% entries but extruder_printable_area has %2%; using bed printable_height for extruder %3%")
-                        % extruder_printable_heights.size() % m_extruder_shapes.size() % index;
             const double extruder_height = index < extruder_printable_heights.size() ? extruder_printable_heights[index] : printable_height;
 
             if ((extruder_shape == printable_area)&&(extruder_height == printable_height)) {

--- a/src/slic3r/GUI/PartPlate.cpp
+++ b/src/slic3r/GUI/PartPlate.cpp
@@ -157,7 +157,7 @@ PartPlate::PartPlate()
 	init();
 }
 
-PartPlate::PartPlate(PartPlateList *partplate_list, Vec3d origin, int width, int depth, int height, Plater* platerObj, Model* modelObj, bool printable, PrinterTechnology tech)
+PartPlate::PartPlate(PartPlateList *partplate_list, Vec3d origin, int width, int depth, double height, Plater* platerObj, Model* modelObj, bool printable, PrinterTechnology tech)
 	:m_partplate_list(partplate_list), m_plater(platerObj), m_model(modelObj), printer_technology(tech), m_origin(origin), m_width(width), m_depth(depth), m_height(height),  m_printable(printable)
 {
 	init();
@@ -2472,7 +2472,7 @@ void PartPlate::clear(bool clear_sliced_result)
 
 /* size and position related functions*/
 //set position and size
-void PartPlate::set_pos_and_size(Vec3d& origin, int width, int depth, int height, bool with_instance_move, bool do_clear)
+void PartPlate::set_pos_and_size(Vec3d& origin, int width, int depth, double height, bool with_instance_move, bool do_clear)
 {
 	bool size_changed = false; //size changed means the machine changed
 	bool pos_changed = false;
@@ -2771,7 +2771,7 @@ bool PartPlate::check_outside(int obj_id, int instance_id, BoundingBoxf3* boundi
 
 	if (instance_box.min.z() < SINKING_Z_THRESHOLD) {
         // For sinking object, we use a more expensive algorithm so part below build plate won't be considered.
-        // m_height mirrors the printer's printable height independent of m_plater, so this runs in CLI too.
+        // m_height mirrors the printer's printable height (as a double, so no precision loss) independent of m_plater, so this runs in CLI too.
         if (plate_box.intersects(instance_box)) {
             // TODO: FIXME: this does not take exclusion area into account
             const BuildVolume build_volume(get_shape(), m_height, m_extruder_areas, m_extruder_heights);
@@ -4095,7 +4095,7 @@ void PartPlate::on_filament_deleted(int filament_count, int filament_id)
 
 
 /* PartPlate List related functions*/
-PartPlateList::PartPlateList(int width, int depth, int height, Plater* platerObj, Model* modelObj, PrinterTechnology tech)
+PartPlateList::PartPlateList(int width, int depth, double height, Plater* platerObj, Model* modelObj, PrinterTechnology tech)
 	:m_plate_width(width), m_plate_depth(depth), m_plate_height(height), m_plater(platerObj), m_model(modelObj), printer_technology(tech),
 	unprintable_plate(this, Vec3d(0.0 + width * (1. + LOGICAL_PART_PLATE_GAP), 0.0, 0.0), width, depth, height, platerObj, modelObj, false, tech)
 {
@@ -4540,7 +4540,7 @@ void PartPlateList::set_default_wipe_tower_pos_for_plate(int plate_idx, bool ini
 }
 
 //this may be happened after machine changed
-void PartPlateList::reset_size(int width, int depth, int height, bool reload_objects, bool update_shapes)
+void PartPlateList::reset_size(int width, int depth, double height, bool reload_objects, bool update_shapes)
 {
 	BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << boost::format(":before size: plate_width %1%, plate_depth %2%, plate_height %3%") % m_plate_width % m_plate_depth % m_plate_height;
 	BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << boost::format(":after size: plate_width %1%, plate_depth %2%, plate_height %3%") % width % depth % height;
@@ -6695,7 +6695,7 @@ int PartPlateList::load_gcode_files()
 			//BoundingBoxf3   print_volume = m_plate_list[i]->get_bounding_box(false);
 			//print_volume.max(2) = this->m_plate_height;
 			//print_volume.min(2) = -1e10;
-			m_model->update_print_volume_state({m_plate_list[i]->get_shape(), (double)this->m_plate_height, m_plate_list[i]->get_extruder_areas(), m_plate_list[i]->get_extruder_heights() });
+			m_model->update_print_volume_state({m_plate_list[i]->get_shape(), this->m_plate_height, m_plate_list[i]->get_extruder_areas(), m_plate_list[i]->get_extruder_heights() });
 
 			if (!m_plate_list[i]->load_gcode_from_file(m_plate_list[i]->m_gcode_path_from_3mf))
 				ret ++;

--- a/src/slic3r/GUI/PartPlate.cpp
+++ b/src/slic3r/GUI/PartPlate.cpp
@@ -2770,16 +2770,19 @@ bool PartPlate::check_outside(int obj_id, int instance_id, BoundingBoxf3* boundi
 		plate_box.min.z() += instance_box.min.z(); // not considering outsize if sinking
 
 	if (instance_box.min.z() < SINKING_Z_THRESHOLD) {
-        // For sinking object, we use a more expensive algorithm so part below build plate won't be considered.
-        // m_height mirrors the printer's printable height (as a double, so no precision loss) independent of m_plater, so this runs in CLI too.
-        if (plate_box.intersects(instance_box)) {
-            // TODO: FIXME: this does not take exclusion area into account
-            const BuildVolume build_volume(get_shape(), m_height, m_extruder_areas, m_extruder_heights);
-            const auto state = instance->calc_print_volume_state(build_volume);
-            outside          = state == ModelInstancePVS_Partly_Outside;
-        }
-    } else if (plate_box.contains(instance_box)) {
-        if (m_exclude_bounding_box.size() > 0)
+		// Orca: For sinking object, we use a more expensive algorithm so part below build plate won't be considered
+		// m_height mirrors the printer's printable height and is set in CLI mode too, unlike m_plater.
+		if (plate_box.intersects(instance_box)) {
+			// TODO: FIXME: this does not take exclusion area into account
+			const BuildVolume build_volume(get_shape(), m_height, m_extruder_areas, m_extruder_heights);
+			const auto state = instance->calc_print_volume_state(build_volume);
+			outside = state == ModelInstancePVS_Partly_Outside;
+		}
+	}
+	else
+	if (plate_box.contains(instance_box))
+	{
+		if (m_exclude_bounding_box.size() > 0)
 		{
 			Polygon hull = instance->convex_hull_2d();
 			int index;
@@ -2797,9 +2800,9 @@ bool PartPlate::check_outside(int obj_id, int instance_id, BoundingBoxf3* boundi
 		}
 		else
 			outside = false;
-    }
+	}
 
-    return outside;
+	return outside;
 }
 
 //judge whether instance is intesected with plate or not

--- a/src/slic3r/GUI/PartPlate.cpp
+++ b/src/slic3r/GUI/PartPlate.cpp
@@ -1757,26 +1757,25 @@ std::vector<int> PartPlate::get_extruders_under_cli(bool conside_custom_gcode, D
             else
                 obj_support = glb_support;
 
-            if (!obj_support)
-                continue;
+            if (obj_support) {
+                int obj_support_intf_extr = 0;
+                const ConfigOption* support_intf_extr_opt = object->config.option("support_interface_filament");
+                if (support_intf_extr_opt != nullptr)
+                    obj_support_intf_extr = support_intf_extr_opt->getInt();
+                if (obj_support_intf_extr != 0)
+                    plate_extruders.push_back(obj_support_intf_extr);
+                else if (glb_support_intf_extr != 0)
+                    plate_extruders.push_back(glb_support_intf_extr);
 
-            int obj_support_intf_extr = 0;
-            const ConfigOption* support_intf_extr_opt = object->config.option("support_interface_filament");
-            if (support_intf_extr_opt != nullptr)
-                obj_support_intf_extr = support_intf_extr_opt->getInt();
-            if (obj_support_intf_extr != 0)
-                plate_extruders.push_back(obj_support_intf_extr);
-            else if (glb_support_intf_extr != 0)
-                plate_extruders.push_back(glb_support_intf_extr);
-
-            int obj_support_extr = 0;
-            const ConfigOption* support_extr_opt = object->config.option("support_filament");
-            if (support_extr_opt != nullptr)
-                obj_support_extr = support_extr_opt->getInt();
-            if (obj_support_extr != 0)
-                plate_extruders.push_back(obj_support_extr);
-            else if (glb_support_extr != 0)
-                plate_extruders.push_back(glb_support_extr);
+                int obj_support_extr = 0;
+                const ConfigOption* support_extr_opt = object->config.option("support_filament");
+                if (support_extr_opt != nullptr)
+                    obj_support_extr = support_extr_opt->getInt();
+                if (obj_support_extr != 0)
+                    plate_extruders.push_back(obj_support_extr);
+                else if (glb_support_extr != 0)
+                    plate_extruders.push_back(glb_support_extr);
+            }
 
 			int obj_outer_wall_extr = 0;
 			if (const ConfigOption* wall_opt = object->config.option("outer_wall_filament_id"); wall_opt != nullptr)

--- a/src/slic3r/GUI/PartPlate.cpp
+++ b/src/slic3r/GUI/PartPlate.cpp
@@ -2770,19 +2770,16 @@ bool PartPlate::check_outside(int obj_id, int instance_id, BoundingBoxf3* boundi
 		plate_box.min.z() += instance_box.min.z(); // not considering outsize if sinking
 
 	if (instance_box.min.z() < SINKING_Z_THRESHOLD) {
-		// Orca: For sinking object, we use a more expensive algorithm so part below build plate won't be considered
-		// m_plater is null in CLI mode.
-		if (m_plater && plate_box.intersects(instance_box)) {
-			// TODO: FIXME: this does not take exclusion area into account
-            const BuildVolume build_volume(get_shape(), m_plater->build_volume().printable_height(), m_extruder_areas, m_extruder_heights);
-			const auto state = instance->calc_print_volume_state(build_volume);
-			outside = state == ModelInstancePVS_Partly_Outside;
-		}
-	}
-	else
-	if (plate_box.contains(instance_box))
-	{
-		if (m_exclude_bounding_box.size() > 0)
+        // For sinking object, we use a more expensive algorithm so part below build plate won't be considered.
+        // m_height mirrors the printer's printable height independent of m_plater, so this runs in CLI too.
+        if (plate_box.intersects(instance_box)) {
+            // TODO: FIXME: this does not take exclusion area into account
+            const BuildVolume build_volume(get_shape(), m_height, m_extruder_areas, m_extruder_heights);
+            const auto state = instance->calc_print_volume_state(build_volume);
+            outside          = state == ModelInstancePVS_Partly_Outside;
+        }
+    } else if (plate_box.contains(instance_box)) {
+        if (m_exclude_bounding_box.size() > 0)
 		{
 			Polygon hull = instance->convex_hull_2d();
 			int index;
@@ -2800,9 +2797,9 @@ bool PartPlate::check_outside(int obj_id, int instance_id, BoundingBoxf3* boundi
 		}
 		else
 			outside = false;
-	}
+    }
 
-	return outside;
+    return outside;
 }
 
 //judge whether instance is intesected with plate or not

--- a/src/slic3r/GUI/PartPlate.hpp
+++ b/src/slic3r/GUI/PartPlate.hpp
@@ -96,7 +96,7 @@ private:
     Vec3d m_origin;
     int m_width;
     int m_depth;
-    int m_height;
+    double m_height;
     float m_height_to_lid;
     float m_height_to_rod;
     bool m_printable;
@@ -227,7 +227,7 @@ public:
     static void load_render_colors();
 
     PartPlate();
-    PartPlate(PartPlateList *partplate_list, Vec3d origin, int width, int depth, int height, Plater* platerObj, Model* modelObj, bool printable=true, PrinterTechnology tech = ptFFF);
+    PartPlate(PartPlateList *partplate_list, Vec3d origin, int width, int depth, double height, Plater* platerObj, Model* modelObj, bool printable=true, PrinterTechnology tech = ptFFF);
     ~PartPlate();
 
     bool operator<(PartPlate&) const;
@@ -328,7 +328,7 @@ public:
     Vec3d get_center_origin();
     /* size and position related functions*/
     //set position and size
-    void set_pos_and_size(Vec3d& origin, int width, int depth, int height, bool with_instance_move, bool do_clear = true);
+    void set_pos_and_size(Vec3d& origin, int width, int depth, double height, bool with_instance_move, bool do_clear = true);
 
     // BBS
     Vec2d get_size() const { return Vec2d(m_width, m_depth); }
@@ -590,7 +590,7 @@ class PartPlateList : public ObjectBase
 
     int m_plate_width;
     int m_plate_depth;
-    int m_plate_height;
+    double m_plate_height;
 
     float m_height_to_lid;
     float m_height_to_rod;
@@ -708,12 +708,12 @@ public:
     static bool is_load_cali_texture;
     static bool is_load_extruder_only_area_textures;
 
-    PartPlateList(int width, int depth, int height, Plater* platerObj, Model* modelObj, PrinterTechnology tech = ptFFF);
+    PartPlateList(int width, int depth, double height, Plater* platerObj, Model* modelObj, PrinterTechnology tech = ptFFF);
     PartPlateList(Plater* platerObj, Model* modelObj, PrinterTechnology tech = ptFFF);
     ~PartPlateList();
 
     //this may be happened after machine changed
-    void reset_size(int width, int depth, int height, bool reload_objects = true, bool update_shapes = false);
+    void reset_size(int width, int depth, double height, bool reload_objects = true, bool update_shapes = false);
     //clear all the instances in the plate, but keep the plates
     void clear(bool delete_plates = false, bool release_print_list = false, bool except_locked = false, int plate_index = -1);
     //clear all the instances in the plate, and delete the plates, only keep the first default plate
@@ -727,7 +727,7 @@ public:
     //get the plate stride
     double plate_stride_x();
     double plate_stride_y();
-    void get_plate_size(int& width, int& depth, int& height) {
+    void get_plate_size(int& width, int& depth, double& height) {
         width = m_plate_width;
         depth = m_plate_depth;
         height = m_plate_height;

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -8278,7 +8278,8 @@ std::vector<size_t> Plater::priv::load_files(const std::vector<fs::path>& input_
     bool dlg_cont = true;
     bool is_user_cancel = false;
     bool translate_old = false;
-    int current_width = 0, current_depth = 0, current_height = 0, project_filament_count = 1;
+    int current_width = 0, current_depth = 0, project_filament_count = 1;
+    double current_height = 0;
 
     if (input_files.empty())
         return std::vector<size_t>();

--- a/tests/libslic3r/CMakeLists.txt
+++ b/tests/libslic3r/CMakeLists.txt
@@ -8,6 +8,7 @@ add_executable(${_TEST_NAME}_tests
     test_arachne_walls.cpp
     test_arrange.cpp
     test_bambu_networking.cpp
+    test_buildvolume.cpp
     test_calib.cpp
     test_clipper_offset.cpp
     test_clipper_utils.cpp

--- a/tests/libslic3r/test_buildvolume.cpp
+++ b/tests/libslic3r/test_buildvolume.cpp
@@ -1,0 +1,40 @@
+#include <catch2/catch_all.hpp>
+
+#include "libslic3r/BuildVolume.hpp"
+
+using namespace Slic3r;
+
+static std::vector<Vec2d> rect_area(double w, double d)
+{
+    return { { 0., 0. }, { w, 0. }, { w, d }, { 0., d } };
+}
+
+// extruder_printable_height and extruder_printable_area are independent config options, so a
+// profile can leave the heights short. BuildVolume must not index past the end of the heights.
+TEST_CASE("BuildVolume falls back to the bed height when extruder_printable_height is short", "[BuildVolume]")
+{
+    const std::vector<Vec2d>              bed     = rect_area(200., 200.);
+    const std::vector<std::vector<Vec2d>> areas   = { rect_area(200., 200.), rect_area(100., 200.) };
+    const std::vector<double>             heights = { 180. };
+
+    const BuildVolume build_volume(bed, 250., areas, heights);
+
+    REQUIRE(build_volume.get_extruder_area_count() == 2);
+    // The extruder with a height of its own keeps it, and differs from the bed, so it gets its own volume.
+    CHECK_THAT(build_volume.get_extruder_area_volume(0).bboxf.max.z(), Catch::Matchers::WithinAbs(180., 1e-6));
+    // The extruder without one falls back to the bed's printable_height instead of reading out of range.
+    CHECK_THAT(build_volume.get_extruder_area_volume(1).bboxf.max.z(), Catch::Matchers::WithinAbs(250., 1e-6));
+}
+
+TEST_CASE("BuildVolume keeps per-extruder heights when both vectors match", "[BuildVolume]")
+{
+    const std::vector<Vec2d>              bed     = rect_area(200., 200.);
+    const std::vector<std::vector<Vec2d>> areas   = { rect_area(120., 200.), rect_area(100., 200.) };
+    const std::vector<double>             heights = { 180., 200.5 };
+
+    const BuildVolume build_volume(bed, 250., areas, heights);
+
+    REQUIRE(build_volume.get_extruder_area_count() == 2);
+    CHECK_THAT(build_volume.get_extruder_area_volume(0).bboxf.max.z(), Catch::Matchers::WithinAbs(180., 1e-6));
+    CHECK_THAT(build_volume.get_extruder_area_volume(1).bboxf.max.z(), Catch::Matchers::WithinAbs(200.5, 1e-6));
+}


### PR DESCRIPTION
# Description
<!--
> Please provide a summary of the changes made in this PR. Include details such as:
  > * What issue does this PR address or fix?
  > * What new features or enhancements does this PR introduce?
  > * Are there any breaking changes or dependencies that need to be considered?
-->

Part 3 of 3 of the CLI-mode bug sweep, split out of #15452 per review feedback there. This PR covers plate and build-volume handling. Both behavior fixes are cases where the CLI skipped a check the GUI performs, so a model the GUI accepts could be rejected — or sliced with the wrong extruder list — headlessly.

## Changes

1. CLI dropped every per-feature filament override on objects without support

In `PartPlate::get_extruders_under_cli`, a `continue` meant to skip only the support-extruder block instead skipped the entire remainder of the per-object loop. The outer wall, inner wall, sparse infill, internal solid, and top/bottom surface filament IDs are all collected *after* that point, so any object with support disabled contributed none of its per-feature overrides to the plate's extruder list.

The block is now scoped to the support case with an `if (obj_support) { … }` so the rest of the loop still runs. No other logic in the loop changed.

2.  Sinking objects always registered as outside the plate in CLI

`PartPlate::check_outside` initializes `outside = true` and then refines it in two branches. The sinking branch was gated on `if (m_plater && …)`, and `m_plater` is null in CLI mode, so the branch never ran and the initial `true` survived — every sinking instance read as outside the build volume.

The `m_plater` guard is dropped, and the build volume's height now comes from `PartPlate::m_height`, which is populated in CLI as well.

3. Guard against an `extruder_printable_height` / `extruder_printable_area` size mismatch

These are independent config options, so a profile can legitimately leave the heights short. `BuildVolume`'s constructor indexed the heights by the areas' index and read out of range. Missing entries now fall back to the bed's `printable_height`.

The size mismatch is reported once per `BuildVolume` construction rather than once per over-range extruder — `check_outside` builds one `BuildVolume` for every sinking instance it evaluates, so a per-extruder warning inside the loop would flood the log on a mismatched profile.

---

Note: the `first_layer_time` export fix that was part of #15452 is intentionally absent — main already carries the equivalent fix via #13429.

# Screenshots/Recordings/Graphs

<!--
> Please attach relevant screenshots to showcase the UI changes.
> Please attach images that can help explain the changes.
-->

## Tests

<!--
> Please describe the tests that you have conducted to verify the changes made in this PR.
-->

- New `tests/libslic3r/test_buildvolume.cpp`: covers the short-`extruder_printable_height` fallback (the extruder with its own height keeps it; the one without falls back to the bed's) and the matched-vectors case, so the guard can't silently regress into ignoring per-extruder heights.
- Repro'd the sinking-object and per-feature-filament cases on the CLI before and after.
- `tests/libslic3r` suite passes; full binary builds clean on Linux.

<!--
> A guide for users on how to download the artifacts from this PR.
-->

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)