### PR TITLE
fix(profiles): Snapmaker — declare filament_vendor on per-type filament bases

### DIFF
--- a/resources/profiles/Snapmaker.json
+++ b/resources/profiles/Snapmaker.json
@@ -1,6 +1,6 @@
 {
 	"name": "Snapmaker",
-	"version": "02.04.00.09",
+	"version": "02.04.00.10",
 	"force_update": "0",
 	"description": "Snapmaker configurations",
 	"machine_model_list": [

--- a/resources/profiles/Snapmaker/filament/fdm_filament_abs.json
+++ b/resources/profiles/Snapmaker/filament/fdm_filament_abs.json
@@ -4,6 +4,9 @@
 	"inherits": "fdm_filament_common",
 	"from": "system",
 	"instantiation": "false",
+	"filament_vendor": [
+		"Snapmaker"
+	],
 	"hot_plate_temp": [
 		"90"
 	],

--- a/resources/profiles/Snapmaker/filament/fdm_filament_asa.json
+++ b/resources/profiles/Snapmaker/filament/fdm_filament_asa.json
@@ -4,6 +4,9 @@
 	"inherits": "fdm_filament_common",
 	"from": "system",
 	"instantiation": "false",
+	"filament_vendor": [
+		"Snapmaker"
+	],
 	"hot_plate_temp": [
 		"90"
 	],

--- a/resources/profiles/Snapmaker/filament/fdm_filament_breakaway.json
+++ b/resources/profiles/Snapmaker/filament/fdm_filament_breakaway.json
@@ -4,6 +4,9 @@
 	"inherits": "fdm_filament_common",
 	"from": "system",
 	"instantiation": "false",
+	"filament_vendor": [
+		"Snapmaker"
+	],
 	"filament_is_support": [
 		"1"
 	],

--- a/resources/profiles/Snapmaker/filament/fdm_filament_pa.json
+++ b/resources/profiles/Snapmaker/filament/fdm_filament_pa.json
@@ -4,6 +4,9 @@
 	"inherits": "fdm_filament_common",
 	"from": "system",
 	"instantiation": "false",
+	"filament_vendor": [
+		"Snapmaker"
+	],
 	"required_nozzle_HRC": [
 		"40"
 	],

--- a/resources/profiles/Snapmaker/filament/fdm_filament_pet.json
+++ b/resources/profiles/Snapmaker/filament/fdm_filament_pet.json
@@ -4,6 +4,9 @@
 	"inherits": "fdm_filament_common",
 	"from": "system",
 	"instantiation": "false",
+	"filament_vendor": [
+		"Snapmaker"
+	],
 	"hot_plate_temp": [
 		"65"
 	],

--- a/resources/profiles/Snapmaker/filament/fdm_filament_petg.json
+++ b/resources/profiles/Snapmaker/filament/fdm_filament_petg.json
@@ -4,6 +4,9 @@
 	"inherits": "fdm_filament_common",
 	"from": "system",
 	"instantiation": "false",
+	"filament_vendor": [
+		"Snapmaker"
+	],
 	"hot_plate_temp": [
 		"70"
 	],

--- a/resources/profiles/Snapmaker/filament/fdm_filament_pla.json
+++ b/resources/profiles/Snapmaker/filament/fdm_filament_pla.json
@@ -4,6 +4,9 @@
 	"inherits": "fdm_filament_common",
 	"from": "system",
 	"instantiation": "false",
+	"filament_vendor": [
+		"Snapmaker"
+	],
 	"overhang_fan_threshold": [
 		"0%"
 	],

--- a/resources/profiles/Snapmaker/filament/fdm_filament_pva.json
+++ b/resources/profiles/Snapmaker/filament/fdm_filament_pva.json
@@ -4,6 +4,9 @@
 	"inherits": "fdm_filament_common",
 	"from": "system",
 	"instantiation": "false",
+	"filament_vendor": [
+		"Snapmaker"
+	],
 	"filament_is_support": [
 		"1"
 	],

--- a/resources/profiles/Snapmaker/filament/fdm_filament_tpu.json
+++ b/resources/profiles/Snapmaker/filament/fdm_filament_tpu.json
@@ -4,6 +4,9 @@
 	"inherits": "fdm_filament_common",
 	"from": "system",
 	"instantiation": "false",
+	"filament_vendor": [
+		"Snapmaker"
+	],
 	"hot_plate_temp": [
 		"40"
 	],


### PR DESCRIPTION


# Description

The Add/Remove Filaments dialog builds its list with GetFilamentInfo(), which walks a preset's `inherits` chain and stops as soon as both filament_vendor and filament_type are known. Snapmaker presets get their type from fdm_filament_<type> but their vendor only from fdm_filament_common, which carries no filament_type of its own. That terminus reports "no type", and LoadProfileFamily() skips any preset whose lookup fails — hiding 127 of the 199 instantiable Snapmaker filament presets, including every ABS, ASA, PETG and PLA entry for the U1. Only the four presets that declare both keys locally survive.

Declaring filament_vendor on the nine per-type bases lets the walk resolve before it reaches fdm_filament_common. That file already propagates the same value to the whole family, so no preset's resolved configuration changes: verified over all 328 Snapmaker filament presets, zero differences in resolved (filament_vendor, filament_type). Fixing the shared bases rather than each concrete preset also leaves no gaps as new presets are added.

Same class of bug as #14693 (re3D), fixed profile-side in #15169.

# Screenshots/Recordings/Graphs

<img width="900" height="704" alt="image" src="https://github.com/user-attachments/assets/4c1c3472-dacb-4ab3-ad0a-515ecce149de" />

<img width="873" height="702" alt="image" src="https://github.com/user-attachments/assets/5e16114a-1015-42d5-9551-2c089c61c69c" />

<img width="931" height="939" alt="image" src="https://github.com/user-attachments/assets/0a6d7f6a-35f0-4bf2-8af6-ebf067ca4b51" />


## Tests
Verified that you can select the profiles on the Add/Remove filament window.

<!--
> A guide for users on how to download the artifacts from this PR.
-->

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)