### PR TITLE
Refresh preview from post-processed G-code (BBL in-place path)

### DIFF
--- a/src/slic3r/GUI/BackgroundSlicingProcess.cpp
+++ b/src/slic3r/GUI/BackgroundSlicingProcess.cpp
@@ -257,11 +257,37 @@ void BackgroundSlicingProcess::process_fff()
         m_temp_output_path = this->get_current_plate()->get_tmp_gcode_path();
         m_fff_print->export_gcode(m_temp_output_path, m_gcode_result,
                                   [this](const ThumbnailsParams& params) { return this->render_thumbnails(params); });
-        // Orca: BBL printers post-process the g-code in place here and never re-parse it into a fresh
-        // GCodeProcessorResult, so m_gcode_result->nozzle_group_result (consumed by the H2C print-dispatch
-        // nozzle mapping) survives post-processing. No preservation guard is needed on this path.
+        // Orca: BBL printers post-process the g-code in place here, so the file the G-code viewer
+        // memory-maps is the post-processed one, but m_gcode_result was produced inline during
+        // generation and still describes the pre-script toolpath. Re-parse so the preview matches
+        // what will actually be printed.
         if (m_fff_print->is_BBL_printer()) {
             run_post_process_scripts(m_temp_output_path, false, "File", m_temp_output_path, m_fff_print->full_print_config());
+
+            const auto* post_process = m_fff_print->full_print_config().opt<ConfigOptionStrings>("post_process");
+            if (post_process && !post_process->values.empty() && m_gcode_result) {
+                m_print->set_status(97, _u8L("Updating preview with post-processed G-code"));
+                GCodeProcessor processor;
+                // Apply the plate origin so move coordinates are relative to the correct plate;
+                // without this, slicing any plate other than the first shifts the preview geometry
+                // by that plate's XY origin and the model appears off the bed.
+                const Vec3d origin = m_fff_print->get_plate_origin();
+                processor.set_xy_offset(origin(0), origin(1));
+                processor.process_file(m_temp_output_path);
+                // IMPORTANT: move ONLY the fields derived from the G-code text. GCodeProcessorResult
+                // also carries slicer-computed state (nozzle_group_result, filament_maps,
+                // filament_change_sequence, required_nozzle_HRC, extruder_colors, print_statistics,
+                // ...) derived from config during slicing, which cannot be rebuilt from G-code alone.
+                // Replacing the whole result breaks H2C/H2D send-to-printer nozzle auto-mapping -
+                // see BambuStudio #10528, the regression introduced by BBS PR #9920.
+                //
+                // extract_result() returns GCodeProcessorResult&&; a local by value is impossible
+                // because the copy constructor is implicitly deleted (mutable std::mutex member),
+                // so bind as an rvalue reference and move the two fields out directly.
+                GCodeProcessorResult&& reparsed = processor.extract_result();
+                m_gcode_result->moves      = std::move(reparsed.moves);
+                m_gcode_result->lines_ends = std::move(reparsed.lines_ends);
+            }
         }
 
         BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << boost::format(": export gcode finished");


### PR DESCRIPTION
### Problem

When a post-processing script is configured, the Preview never shows what the script did. `m_gcode_result` is populated *inline while the G-code is generated* — the `GCodeProcessor` is bound to the output stream in `GCode::do_export()`:

```cpp
m_processor.initialize(path_tmp);
GCodeOutputStream file(boost::nowide::fopen(path_tmp.c_str(), "wb"), m_processor);
```

so by the time `run_post_process_scripts()` runs, the preview data is already final and describes the *pre-script* toolpath. The only way to inspect the real output is to export the file and reopen it in a second OrcaSlicer window.

Addresses #7489.

### Fix

On the BBL path the script already rewrites `m_temp_output_path` **in place** — the same file the G-code viewer memory-maps — so re-parsing that file keeps `moves` and `lines_ends` consistent with the mapping. This adds that re-parse, guarded on `post_process` being non-empty so an ordinary slice pays nothing.

This is the narrow form of the same change BambuStudio shipped (their PR #9920), with the correction from BambuStudio#10528 already applied.

### Why only `moves` and `lines_ends`

`GCodeProcessorResult` also carries slicer-computed, config-derived state — `nozzle_group_result`, `filament_maps`, `filament_change_sequence`, `required_nozzle_HRC`, `extruder_colors`, `print_statistics` — which cannot be reconstructed from G-code text. A fresh parse leaves those empty or default.

BambuStudio's PR #9920 originally did `*m_gcode_result = std::move(processor.extract_result())` and broke H2C/H2D nozzle auto-mapping for exactly that reason: the printer rejects `get_auto_nozzle_mapping` and the UI reports *"The printer failed to build the nozzle auto-mapping table { code: 1 }"*. Restricting the move to the two text-derived fields preserves that state. The existing comment on this code path called out that hazard, and this PR keeps the guarantee it describes.

`extract_result()` returns `GCodeProcessorResult&&`; it can't be bound to a local by value because the copy constructor is implicitly deleted (mutable `std::mutex` member), hence the rvalue-reference binding.

`set_xy_offset()` applies the plate origin so move coordinates land on the correct plate — without it, slicing any plate other than the first shifts the re-parsed geometry by that plate's XY origin and the model renders off the bed.

### How to test

Save this as `preview_demo.py`. It keeps the header/config blocks and replaces every toolpath with a single straight extrusion, so the result is unambiguous:

```python
import math, re, sys

path = sys.argv[1]
with open(path, "r", encoding="utf-8", errors="surrogateescape", newline="") as f:
    lines = f.readlines()

keep_to = None
for i, line in enumerate(lines):
    if line.startswith("; CONFIG_BLOCK_END") or line.startswith("; HEADER_BLOCK_END"):
        keep_to = i
preamble = lines[:keep_to + 1] if keep_to is not None else []

dia = 1.75
for line in preamble:
    m = re.match(r"^;\s*filament_diameter\s*=\s*([0-9.]+)", line)
    if m:
        dia = float(m.group(1)); break

x0, y0, x1, y1, z, h, w = 80.0, 110.0, 220.0, 110.0, 0.2, 0.2, 0.42
e = (math.hypot(x1 - x0, y1 - y0) * w * h) / (math.pi * (dia / 2) ** 2)

with open(path, "w", encoding="utf-8", errors="surrogateescape", newline="") as f:
    f.writelines(preamble + [
        "; EXECUTABLE_BLOCK_START\n", "G21\n", "G90\n", "M83\n",
        "; CHANGE_LAYER\n", "; Z_HEIGHT: %.3f\n" % z, "; LAYER_HEIGHT: %.3f\n" % h,
        "G1 Z%.3f F600\n" % z, "; FEATURE: Outer wall\n", "; LINE_WIDTH: %.3f\n" % w,
        "G1 X%.3f Y%.3f F9000\n" % (x0, y0),
        "G1 X%.3f Y%.3f E%.5f F1200\n" % (x1, y1, e),
        "; EXECUTABLE_BLOCK_END\n"])
```

Set it as the post-processing script (Print Settings → Others → Post-processing Scripts) on a **Bambu printer profile**, then slice any model:

- **before this PR** — Preview still shows the model; the exported file contains one line
- **with this PR** — Preview shows one line, matching the exported file

On a real model it takes the file from ~11 MB / ~420k lines down to ~35 KB, so there is nothing subjective about the result. (The generated file is a demo artifact — no start G-code, no heating, no homing. Don't print it.)

### Scope

Covers the **BBL in-place path** only. `finalize_gcode()` runs scripts on a `.pp` copy (`make_copy = true`) precisely so they don't touch the file the viewer keeps mapped, and it only runs on export rather than on every slice — re-parsing there would desync `lines_ends` from the mapped original, and the copy is deleted immediately afterwards, so it also needs the viewer to be remapped. Left as a follow-up rather than bodged in here.

### Testing done

Built from source on Windows (VS2022 x64, Release) and verified with the script above on a Bambu P1S profile: the Preview updates in the same project on Slice plate, showing a status message at 97% *"Updating preview with post-processed G-code"*.
