### PR TITLE
Fix omitted assembly parts with height ranges

### DIFF
--- a/src/libslic3r/PrintApply.cpp
+++ b/src/libslic3r/PrintApply.cpp
@@ -560,9 +560,11 @@ static inline bool model_volume_solid_or_modifier(const ModelVolume &mv)
 
 static inline Transform3f trafo_for_bbox(const Transform3d &object_trafo, const Transform3d &volume_trafo)
 {
-    Transform3d m = object_trafo * volume_trafo;
-    m.translation().x() = 0.;
-    m.translation().y() = 0.;
+    // Orca: Keep the volume's local XY offset for multipart overlap checks, but remove the object's bed placement.
+    Transform3d object_trafo_local = object_trafo;
+    object_trafo_local.translation().x() = 0.;
+    object_trafo_local.translation().y() = 0.;
+    Transform3d m = object_trafo_local * volume_trafo;
     return m.cast<float>();
 }
 

--- a/src/libslic3r/PrintObjectSlice.cpp
+++ b/src/libslic3r/PrintObjectSlice.cpp
@@ -304,11 +304,16 @@ static std::vector<std::vector<ExPolygons>> slices_to_regions(
                     float z                          = zs[z_idx];
                     int   idx_first_printable_region = -1;
                     bool  complex                    = false;
+                    std::vector<int> printable_region_ids;
                     for (int idx_region = 0; idx_region < int(layer_range.volume_regions.size()); ++ idx_region) {
                         const PrintObjectRegions::VolumeRegion &region = layer_range.volume_regions[idx_region];
                         if (region.bbox->min().z() <= z && region.bbox->max().z() >= z) {
-                            if (idx_first_printable_region == -1 && region.model_volume->is_model_part())
+                            if (region.model_volume->is_model_part())
+                                printable_region_ids.push_back(idx_region);
+
+                            if (idx_first_printable_region == -1 && region.model_volume->is_model_part()) {
                                 idx_first_printable_region = idx_region;
+                            }
                             else if (idx_first_printable_region != -1) {
                                 // Test for overlap with some other region.
                                 for (int idx_region2 = idx_first_printable_region; idx_region2 < idx_region; ++ idx_region2) {
@@ -324,8 +329,10 @@ static std::vector<std::vector<ExPolygons>> slices_to_regions(
                     if (complex)
                         zs_complex.push_back({ z_idx, z });
                     else if (idx_first_printable_region >= 0) {
-                        const PrintObjectRegions::VolumeRegion &region = layer_range.volume_regions[idx_first_printable_region];
-                        slices_by_region[region.region->print_object_region_id()][z_idx] = std::move(volume_slices_find_by_id(volume_slices, region.model_volume->id()).slices[z_idx]);
+                        for (int printable_region_id : printable_region_ids) {
+                            const PrintObjectRegions::VolumeRegion &region = layer_range.volume_regions[printable_region_id];
+                            append(slices_by_region[region.region->print_object_region_id()][z_idx], std::move(volume_slices_find_by_id(volume_slices, region.model_volume->id()).slices[z_idx]));
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary

Reapplies the transform correction from #15225 and adds the missing fast-path handling for assemblies whose parts do not overlap.

Fixes #15203.
Fixes https://github.com/OrcaSlicer/OrcaSlicer/pull/15225#issuecomment-5346995274

## Background

#15225 corrected model-volume bounding boxes used by height-range modifiers: object placement on the bed is ignored while each volume's local XY position is retained.

That change exposed an existing slicer fast-path defect. When assembly parts do not overlap in XY, the fast path previously assigned slices from only the first model part. This caused #15225 to be reverted by #15301.

## Changes

- Restore the #15225 volume-bounding-box transform correction.
- Collect and assign every active model-part region in the   non-overlapping fast path.

## Result

Height-range modifiers now retain:

- overlapping/touching assembly parts;
- non-overlapping assembly parts;
- multiple disjoint parts that share the same print region.

## References

- Reapplies and completes #15225.
- Addresses the regression that led to #15301.

## Screenshots

__The object to be sliced:__
<img width="1066" height="1180" alt="image" src="https://github.com/user-attachments/assets/a7f45f9e-543c-4860-8857-ff35060ffbce" />

<br>
<br>

__The sliced object before:__
<img width="1032" height="1167" alt="image" src="https://github.com/user-attachments/assets/518a1a70-7ea7-47ec-97bf-406290420e9e" />

<br>
<br>

__The sliced object after:__
<img width="1013" height="1177" alt="image" src="https://github.com/user-attachments/assets/40375827-9338-4d9f-b34e-3ee81e93379d" />

---

<!--
> A guide for users on how to download the artifacts from this PR.
-->

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
