### PR TITLE
Fuzzy skin on top surfaces (Displacement / Extrusion / Combined, with paint-on)

### DIFF
--- a/src/libslic3r/CMakeLists.txt
+++ b/src/libslic3r/CMakeLists.txt
@@ -134,6 +134,7 @@ set(lisbslic3r_sources
     FaceDetector.hpp
     Feature/FuzzySkin/FuzzySkin.cpp
     Feature/FuzzySkin/FuzzySkin.hpp
+    Feature/FuzzySkin/FuzzySkinTop.cpp
     Feature/Interlocking/InterlockingGenerator.cpp
     Feature/Interlocking/InterlockingGenerator.hpp
     Feature/Interlocking/VoxelUtils.cpp

--- a/src/libslic3r/Feature/FuzzySkin/FuzzySkin.cpp
+++ b/src/libslic3r/Feature/FuzzySkin/FuzzySkin.cpp
@@ -38,7 +38,7 @@ class UniformNoise: public noise::module::Module {
         virtual double GetValue(double x, double y, double z) const { return random_value() * 2 - 1; }
 };
 
-static std::unique_ptr<noise::module::Module> get_noise_module(const FuzzySkinConfig& cfg) {
+std::unique_ptr<noise::module::Module> get_noise_module(const FuzzySkinConfig& cfg) {
     if (cfg.noise_type == NoiseType::Perlin) {
         auto perlin_noise = noise::module::Perlin();
         perlin_noise.SetFrequency(1 / cfg.noise_scale);

--- a/src/libslic3r/Feature/FuzzySkin/FuzzySkin.hpp
+++ b/src/libslic3r/Feature/FuzzySkin/FuzzySkin.hpp
@@ -5,7 +5,17 @@
 #include "libslic3r/Arachne/utils/ExtrusionLine.hpp"
 #include "libslic3r/PerimeterGenerator.hpp"
 
+#include <memory>
+
+// Forward declared rather than including libnoise here: this header is pulled in
+// widely, and only callers of get_noise_module() need the complete type.
+namespace noise { namespace module { class Module; } }
+
 namespace Slic3r::Feature::FuzzySkin {
+
+// Shared noise field. Sampling the same module for top surfaces as for the walls is
+// what makes the texture continuous where the two meet.
+std::unique_ptr<noise::module::Module> get_noise_module(const FuzzySkinConfig& cfg);
 
 void fuzzy_polyline(Points& poly, bool closed, coordf_t slice_z, const FuzzySkinConfig& cfg);
 

--- a/src/libslic3r/Feature/FuzzySkin/FuzzySkinTop.cpp
+++ b/src/libslic3r/Feature/FuzzySkin/FuzzySkinTop.cpp
@@ -1,0 +1,324 @@
+///|/ Fuzzy skin for top surfaces.
+///|/
+///|/ The wall generator displaces points along the surface normal, which a horizontal surface
+///|/ does not have. Top surfaces are textured by moving the nozzle in Z, by modulating the
+///|/ deposited volume, or both, sampling the same noise field as the walls.
+///|/
+#include "FuzzySkin.hpp"
+
+#include "libslic3r/ExtrusionEntity.hpp"
+#include "libslic3r/ExtrusionEntityCollection.hpp"
+#include "libslic3r/Layer.hpp"
+#include "libslic3r/Print.hpp"
+#include "libslic3r/VariableWidth.hpp"
+
+#include "libnoise/noise.h"
+
+#include <algorithm>
+#include <cmath>
+#include <optional>
+
+namespace Slic3r {
+
+namespace {
+
+// A path carrying per-point Z has its extrusion scaled by (height + z_diff) / height, with no
+// lower bound. Downward displacement is limited so the flow cannot fall to zero and leave gaps.
+constexpr double MIN_FLOW_RATIO = 0.25;
+
+constexpr double MIN_FLOW_FACTOR = 0.25;
+constexpr double MAX_FLOW_FACTOR = 2.0;
+// Flow::spacing() and Flow::mm3_per_mm() throw rather than clamp on a degenerate value.
+constexpr double MIN_SPACING = 0.02;
+constexpr double WIDTH_MERGE_TOLERANCE = 0.05;
+
+struct TopFuzzSettings
+{
+    FuzzySkinTopMode  mode{FuzzySkinTopMode::Disabled};
+    double            thickness{0.};
+    double            point_distance{0.};
+    double            layer_height{0.};
+    double            slice_z{0.};
+    FuzzySkinConfig   noise;
+};
+
+std::optional<TopFuzzSettings> resolve_settings(const LayerRegion &region)
+{
+    const PrintRegionConfig &config = region.region().config();
+    if (config.fuzzy_skin_top == FuzzySkinTopMode::Disabled)
+        return std::nullopt;
+
+    const Layer *layer = region.layer();
+    TopFuzzSettings settings;
+
+
+    const bool custom = config.fuzzy_skin_top_params == FuzzySkinTopParams::Custom;
+    settings.thickness      = custom ? config.fuzzy_skin_top_thickness.value      : config.fuzzy_skin_thickness.value;
+    settings.point_distance = custom ? config.fuzzy_skin_top_point_distance.value : config.fuzzy_skin_point_distance.value;
+    if (settings.thickness <= 0. || settings.point_distance <= 0.)
+        return std::nullopt;
+
+    settings.mode         = config.fuzzy_skin_top;
+    settings.layer_height = layer->height;
+    settings.slice_z      = layer->slice_z;
+
+    // Ripple follows a wall loop's arc length, which a horizontal surface does not have.
+    settings.noise.noise_type = config.fuzzy_skin_noise_type == NoiseType::Ripple ? NoiseType::Classic
+                                                                                 : config.fuzzy_skin_noise_type;
+    settings.noise.noise_scale       = config.fuzzy_skin_scale;
+    settings.noise.noise_octaves     = config.fuzzy_skin_octaves;
+    settings.noise.noise_persistence = config.fuzzy_skin_persistence;
+    settings.noise.thickness         = scaled<coord_t>(settings.thickness);
+    settings.noise.point_distance    = scaled<coord_t>(settings.point_distance);
+    return settings;
+}
+
+// Keeps the original vertices so corners stay sharp. Z is carried through unchanged.
+Points3 resample(const Points3 &in, double point_distance)
+{
+    if (in.size() < 2)
+        return in;
+
+    const double step = std::max(scaled<double>(point_distance), 1.0);
+    Points3      out;
+    out.reserve(in.size() * 2);
+    out.emplace_back(in.front());
+
+    for (size_t i = 1; i < in.size(); ++i) {
+        const Vec3crd &a   = in[i - 1];
+        const Vec3crd &b   = in[i];
+        const double   dx  = double(b.x()) - double(a.x());
+        const double   dy  = double(b.y()) - double(a.y());
+        const double   len = std::sqrt(dx * dx + dy * dy);
+        for (int k = 1; k <= int(len / step); ++k) {
+            const double t = double(k) * step / len;
+            if (t >= 1.0)
+                break;
+            out.emplace_back(Vec3crd(coord_t(a.x() + dx * t),
+                                     coord_t(a.y() + dy * t),
+                                     coord_t(a.z() + (double(b.z()) - double(a.z())) * t)));
+        }
+        out.emplace_back(b);
+    }
+    return out;
+}
+
+// Classic noise returns a fresh random value on every call, so samples cannot be recreated.
+std::vector<double> sample_noise(const Points3 &points, noise::module::Module &noise, double slice_z)
+{
+    std::vector<double> samples;
+    samples.reserve(points.size());
+    for (const Vec3crd &p : points)
+        samples.emplace_back(noise.GetValue(unscale_(p.x()), unscale_(p.y()), slice_z));
+    return samples;
+}
+
+// Z on a contoured path is a delta from the layer plane, so this composes with Z anti-aliasing.
+coord_t displaced_z(coord_t base_z, double noise, double amplitude, double path_height)
+{
+    const double limit = (1.0 - MIN_FLOW_RATIO) * path_height;
+    const double dz    = noise >= 0. ? noise * amplitude : noise * std::min(amplitude, limit);
+    return coord_t(std::max(double(base_z) + scaled<double>(dz), -scaled<double>(limit)));
+}
+
+double spacing_to_width(double spacing, double height) { return spacing + height * (1. - 0.25 * M_PI); }
+double width_to_spacing(double width, double height) { return width - height * (1. - 0.25 * M_PI); }
+
+// Resolves Z for the points the width split inserts. They lie on the original path and arrive in
+// order, so how far along the path each one is equals how far the walk has travelled. Locating
+// them by projection onto the nearest segment instead stalls wherever the path doubles back,
+// which on a dense Hilbert curve is immediately.
+class ZAlongPath
+{
+public:
+    explicit ZAlongPath(const Points3 &points) : m_points(points)
+    {
+        m_distance_to.reserve(points.size());
+        m_distance_to.emplace_back(0.);
+        for (size_t i = 1; i < points.size(); ++i)
+            m_distance_to.emplace_back(m_distance_to.back() + distance_2d(points[i - 1], points[i]));
+    }
+
+    coord_t next(const Point &point)
+    {
+        if (m_started)
+            m_travelled += (point - m_previous).cast<double>().norm();
+        m_previous = point;
+        m_started  = true;
+
+        while (m_segment + 2 < m_points.size() && m_distance_to[m_segment + 1] < m_travelled)
+            ++m_segment;
+
+        const Vec3crd &a      = m_points[m_segment];
+        const Vec3crd &b      = m_points[m_segment + 1];
+        const double   length = m_distance_to[m_segment + 1] - m_distance_to[m_segment];
+        const double   t      = length > 0. ? std::clamp((m_travelled - m_distance_to[m_segment]) / length, 0., 1.) : 0.;
+        return coord_t(double(a.z()) + (double(b.z()) - double(a.z())) * t);
+    }
+
+private:
+    static double distance_2d(const Vec3crd &a, const Vec3crd &b)
+    {
+        const double dx = double(b.x()) - double(a.x());
+        const double dy = double(b.y()) - double(a.y());
+        return std::sqrt(dx * dx + dy * dy);
+    }
+
+    const Points3      &m_points;
+    std::vector<double> m_distance_to;
+    double              m_travelled{0.};
+    Point               m_previous;
+    bool                m_started{false};
+    size_t              m_segment{0};
+};
+
+bool displace_in_place(ExtrusionPath &path, const TopFuzzSettings &settings)
+{
+    auto noise = Feature::FuzzySkin::get_noise_module(settings.noise);
+    if (!noise)
+        return false;
+
+    Points3 points = resample(path.polyline.points, settings.point_distance);
+    if (points.size() < 2)
+        return false;
+
+    const std::vector<double> samples = sample_noise(points, *noise, settings.slice_z);
+    for (size_t i = 0; i < points.size(); ++i)
+        points[i].z() = displaced_z(points[i].z(), samples[i], settings.thickness, path.height);
+
+    path.polyline.points = std::move(points);
+    path.polyline.fitting_result.clear(); // arc fitting cannot represent per-point Z
+    path.z_contoured     = true;
+    return true;
+}
+
+// ThickPolyline::width holds spacing, in scaled units, indexed as two entries per segment.
+void modulate_flow(const ExtrusionPath &path, const TopFuzzSettings &settings, bool displace, ExtrusionEntitiesPtr &out)
+{
+    auto noise = Feature::FuzzySkin::get_noise_module(settings.noise);
+    if (!noise)
+        return;
+
+    Points3 points = resample(path.polyline.points, settings.point_distance);
+    if (points.size() < 2)
+        return;
+
+    const double nominal_spacing = width_to_spacing(path.width, path.height);
+    if (nominal_spacing <= 0.)
+        return;
+
+    const std::vector<double> samples = sample_noise(points, *noise, settings.slice_z);
+
+    std::vector<coordf_t> spacings;
+    spacings.reserve(points.size());
+    for (double sample : samples) {
+        // Volume is proportional to spacing, so thickness converts directly into a flow factor.
+        const double factor = settings.layer_height > 0. ? 1.0 + (sample * settings.thickness) / settings.layer_height
+                                                         : 1.0;
+        spacings.emplace_back(scaled<double>(std::max(nominal_spacing * std::clamp(factor, MIN_FLOW_FACTOR, MAX_FLOW_FACTOR),
+                                                      MIN_SPACING)));
+    }
+
+    // Resolve Z before splitting: the inserted points cannot be re-sampled, only interpolated.
+    if (displace)
+        for (size_t i = 0; i < points.size(); ++i)
+            points[i].z() = displaced_z(points[i].z(), samples[i], settings.thickness, path.height);
+
+    ThickPolyline thick;
+    thick.points.reserve(points.size());
+    for (const Vec3crd &p : points)
+        thick.points.emplace_back(Point(p.x(), p.y()));
+    thick.width.reserve(2 * (thick.points.size() - 1));
+    for (size_t i = 0; i + 1 < spacings.size(); ++i) {
+        thick.width.emplace_back(spacings[i]);
+        thick.width.emplace_back(spacings[i + 1]);
+    }
+    thick.endpoints = std::make_pair(false, false);
+
+    const Flow         flow(path.width, path.height, 0.f);
+    ExtrusionMultiPath multi = thick_polyline_to_multi_path(thick, path.role(), flow,
+                                                            scaled<float>(WIDTH_MERGE_TOLERANCE),
+                                                            float(SCALED_EPSILON));
+
+    ZAlongPath z_along_path(points);
+    for (ExtrusionPath &piece : multi.paths) {
+        piece.set_extrusion_role(path.role());
+        piece.height = path.height;
+        if (displace) {
+            for (Vec3crd &p : piece.polyline.points)
+                p.z() = z_along_path.next(Point(p.x(), p.y()));
+            piece.z_contoured = true;
+        }
+        out.emplace_back(piece.clone());
+    }
+}
+
+// Textures a path, either in place or by producing replacements in `out`.
+void texture_path(ExtrusionPath &path, const TopFuzzSettings &settings, ExtrusionEntitiesPtr &out)
+{
+    if (path.polyline.size() < 2 || path.height <= 0.f)
+        return;
+
+    if (settings.mode == FuzzySkinTopMode::Displacement)
+        displace_in_place(path, settings);
+    else
+        modulate_flow(path, settings, settings.mode == FuzzySkinTopMode::Combined, out);
+}
+
+
+
+void texture_collection(ExtrusionEntityCollection &collection, const TopFuzzSettings &settings);
+
+void texture_entity(ExtrusionEntity *entity, const TopFuzzSettings &settings, ExtrusionEntitiesPtr &out)
+{
+    if (auto *collection = dynamic_cast<ExtrusionEntityCollection *>(entity)) {
+        // Unconditionally: a mixed collection reports erMixed, not the roles it contains.
+        texture_collection(*collection, settings);
+        out.emplace_back(entity);
+        return;
+    }
+
+    if (auto *multi = dynamic_cast<ExtrusionMultiPath *>(entity)) {
+        // Only Z: flow modulation would have to restructure the multipath.
+        for (ExtrusionPath &piece : multi->paths)
+            if (piece.role() == erTopSolidInfill)
+                displace_in_place(piece, settings);
+        out.emplace_back(entity);
+        return;
+    }
+
+    auto *path = dynamic_cast<ExtrusionPath *>(entity);
+    if (path == nullptr || path->role() != erTopSolidInfill) {
+        out.emplace_back(entity);
+        return;
+    }
+
+    ExtrusionEntitiesPtr produced;
+    texture_path(*path, settings, produced);
+    if (produced.empty()) {
+        out.emplace_back(entity);
+    } else {
+        append(out, std::move(produced));
+        delete entity;
+    }
+}
+
+void texture_collection(ExtrusionEntityCollection &collection, const TopFuzzSettings &settings)
+{
+    ExtrusionEntitiesPtr replacement;
+    replacement.reserve(collection.entities.size());
+    for (ExtrusionEntity *entity : collection.entities)
+        texture_entity(entity, settings, replacement);
+    collection.entities = std::move(replacement);
+}
+
+} // namespace
+
+void Layer::make_fuzzy_skin_top()
+{
+    for (LayerRegion *region : this->regions())
+        if (const std::optional<TopFuzzSettings> settings = resolve_settings(*region))
+            texture_collection(region->fills, *settings);
+}
+
+} // namespace Slic3r

--- a/src/libslic3r/Feature/FuzzySkin/FuzzySkinTop.cpp
+++ b/src/libslic3r/Feature/FuzzySkin/FuzzySkinTop.cpp
@@ -6,6 +6,7 @@
 ///|/
 #include "FuzzySkin.hpp"
 
+#include "libslic3r/ClipperUtils.hpp"
 #include "libslic3r/ExtrusionEntity.hpp"
 #include "libslic3r/ExtrusionEntityCollection.hpp"
 #include "libslic3r/Layer.hpp"
@@ -16,6 +17,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <memory>
 #include <optional>
 
 namespace Slic3r {
@@ -40,6 +42,7 @@ struct TopFuzzSettings
     double            layer_height{0.};
     double            slice_z{0.};
     FuzzySkinConfig   noise;
+    const ExPolygons *painted_areas{nullptr};
 };
 
 std::optional<TopFuzzSettings> resolve_settings(const LayerRegion &region)
@@ -51,6 +54,11 @@ std::optional<TopFuzzSettings> resolve_settings(const LayerRegion &region)
     const Layer *layer = region.layer();
     TopFuzzSettings settings;
 
+    if (config.fuzzy_skin_top_area == FuzzySkinTopArea::PaintedOnly) {
+        if (layer->fuzzy_skin_painted_areas.empty())
+            return std::nullopt;
+        settings.painted_areas = &layer->fuzzy_skin_painted_areas;
+    }
 
     const bool custom = config.fuzzy_skin_top_params == FuzzySkinTopParams::Custom;
     settings.thickness      = custom ? config.fuzzy_skin_top_thickness.value      : config.fuzzy_skin_thickness.value;
@@ -265,7 +273,36 @@ void texture_path(ExtrusionPath &path, const TopFuzzSettings &settings, Extrusio
         modulate_flow(path, settings, settings.mode == FuzzySkinTopMode::Combined, out);
 }
 
+std::unique_ptr<ExtrusionPath> clone_with(const ExtrusionPath &path, Polyline &&polyline)
+{
+    auto piece = std::unique_ptr<ExtrusionPath>(static_cast<ExtrusionPath *>(path.clone()));
+    piece->polyline = Polyline3(std::move(polyline));
+    piece->polyline.fitting_result.clear();
+    piece->z_contoured = false;
+    return piece;
+}
 
+void texture_painted_parts(const ExtrusionPath &path, const TopFuzzSettings &settings, ExtrusionEntitiesPtr &out)
+{
+    const Polylines whole{path.polyline.to_polyline()};
+    Polylines       painted   = intersection_pl(whole, *settings.painted_areas);
+    Polylines       unpainted = diff_pl(whole, *settings.painted_areas);
+
+    for (Polyline &polyline : painted) {
+        if (polyline.size() < 2)
+            continue;
+        std::unique_ptr<ExtrusionPath> piece = clone_with(path, std::move(polyline));
+        ExtrusionEntitiesPtr           produced;
+        texture_path(*piece, settings, produced);
+        if (produced.empty())
+            out.emplace_back(piece.release());
+        else
+            append(out, std::move(produced));
+    }
+    for (Polyline &polyline : unpainted)
+        if (polyline.size() >= 2)
+            out.emplace_back(clone_with(path, std::move(polyline)).release());
+}
 
 void texture_collection(ExtrusionEntityCollection &collection, const TopFuzzSettings &settings);
 
@@ -290,6 +327,17 @@ void texture_entity(ExtrusionEntity *entity, const TopFuzzSettings &settings, Ex
     auto *path = dynamic_cast<ExtrusionPath *>(entity);
     if (path == nullptr || path->role() != erTopSolidInfill) {
         out.emplace_back(entity);
+        return;
+    }
+
+    if (settings.painted_areas != nullptr) {
+        const size_t before = out.size();
+        texture_painted_parts(*path, settings, out);
+        if (out.size() == before) {
+            out.emplace_back(entity);
+            return;
+        }
+        delete entity;
         return;
     }
 

--- a/src/libslic3r/Layer.hpp
+++ b/src/libslic3r/Layer.hpp
@@ -201,6 +201,8 @@ public:
                                                                            FillLightning::Generator* lightning_generator) const;
     void 					make_ironing();
     void                    make_contour_z(const sla::IndexedMesh &mesh);
+    // ORCA: fuzzy skin on top surfaces; see Feature/FuzzySkin/FuzzySkinTop.cpp
+    void                    make_fuzzy_skin_top();
 
     void                    export_region_slices_to_svg(const char *path) const;
     void                    export_region_fill_surfaces_to_svg(const char *path) const;

--- a/src/libslic3r/Layer.hpp
+++ b/src/libslic3r/Layer.hpp
@@ -155,6 +155,9 @@ public:
     // These lslices are also used to detect overhangs and overlaps between successive layers, therefore it is important
     // that the 1st lslice is not compensated by the Elephant foot compensation algorithm.
     ExPolygons 				 lslices;
+    // ORCA: paint-on fuzzy skin areas, including painted horizontal facets projected onto top
+    // and bottom surfaces. Empty unless the object is fuzzy skin painted.
+    ExPolygons               fuzzy_skin_painted_areas;
     ExPolygons 				 lslices_extrudable;  // BBS: the extrudable part of lslices used for tree support
     std::vector<BoundingBox> lslices_bboxes;
     // Orca: for separated infills / per-model centering. Aligned with lslices: for each island, the

--- a/src/libslic3r/MultiMaterialSegmentation.cpp
+++ b/src/libslic3r/MultiMaterialSegmentation.cpp
@@ -1970,7 +1970,8 @@ std::vector<std::vector<ExPolygons>> segmentation_by_painting(const PrintObject 
                                                               const float                                                      segmentation_interlocking_depth,
                                                               const bool                                                       segmentation_interlocking_beam,
                                                               const IncludeTopAndBottomLayers                                  include_top_and_bottom_layers,
-                                                              const std::function<void()>                                     &throw_on_cancel_callback)
+                                                              const std::function<void()>                                     &throw_on_cancel_callback,
+                                                              std::vector<std::vector<ExPolygons>>                            *out_top_and_bottom_layers)
 {
     const size_t                          num_layers    = print_object.layers().size();
     std::vector<std::vector<ExPolygons>>  segmented_regions(num_layers);
@@ -2189,6 +2190,13 @@ std::vector<std::vector<ExPolygons>> segmentation_by_painting(const PrintObject 
         throw_on_cancel_callback();
     }
 
+    // ORCA: returned unmerged so one pass serves both callers. Merging an empty set is what
+    // IncludeTopAndBottomLayers::No produces, leaving the return value unchanged.
+    if (out_top_and_bottom_layers != nullptr) {
+        *out_top_and_bottom_layers = std::move(top_and_bottom_layers);
+        top_and_bottom_layers.clear();
+    }
+
     std::vector<std::vector<ExPolygons>> segmented_regions_merged = merge_segmented_layers(segmented_regions, std::move(top_and_bottom_layers), num_facets_states, throw_on_cancel_callback);
     throw_on_cancel_callback();
 
@@ -2219,7 +2227,8 @@ std::vector<std::vector<ExPolygons>> multi_material_segmentation_by_painting(con
 }
 
 // Returns fuzzy skin segmentation based on painting in fuzzy skin segmentation gizmo
-std::vector<std::vector<ExPolygons>> fuzzy_skin_segmentation_by_painting(const PrintObject &print_object, const std::function<void()> &throw_on_cancel_callback) {
+std::vector<std::vector<ExPolygons>> fuzzy_skin_segmentation_by_painting(const PrintObject &print_object, const std::function<void()> &throw_on_cancel_callback,
+                                                                        std::vector<std::vector<ExPolygons>> *out_top_and_bottom_layers) {
     const size_t num_facets_states = 2; // Unpainted facets and facets painted with fuzzy skin.
 
     const auto extract_facets_info = [](const ModelVolume &mv) -> ModelVolumeFacetsInfo {
@@ -2234,7 +2243,11 @@ std::vector<std::vector<ExPolygons>> fuzzy_skin_segmentation_by_painting(const P
         max_external_perimeter_width = std::max<float>(max_external_perimeter_width, region.flow(print_object, frExternalPerimeter, print_object.config().layer_height).width());
     }
 
-    return segmentation_by_painting(print_object, extract_facets_info, num_facets_states, max_external_perimeter_width, 0.f, false, IncludeTopAndBottomLayers::No, throw_on_cancel_callback);
+    // ORCA: a painted horizontal facet has no cross-section, so project only when asked.
+    const IncludeTopAndBottomLayers include_top_bottom = out_top_and_bottom_layers != nullptr ? IncludeTopAndBottomLayers::Yes
+                                                                                             : IncludeTopAndBottomLayers::No;
+    return segmentation_by_painting(print_object, extract_facets_info, num_facets_states, max_external_perimeter_width, 0.f, false,
+                                    include_top_bottom, throw_on_cancel_callback, out_top_and_bottom_layers);
 }
 
 } // namespace Slic3r

--- a/src/libslic3r/MultiMaterialSegmentation.hpp
+++ b/src/libslic3r/MultiMaterialSegmentation.hpp
@@ -47,13 +47,19 @@ std::vector<std::vector<ExPolygons>> segmentation_by_painting(const PrintObject 
                                                               float                                                            segmentation_interlocking_depth,
                                                               bool                                                             segmentation_interlocking_beam,
                                                               IncludeTopAndBottomLayers                                        include_top_and_bottom_layers,
-                                                              const std::function<void()>                                     &throw_on_cancel_callback);
+                                                              const std::function<void()>                                     &throw_on_cancel_callback,
+                                                              // ORCA: when supplied, the projected top/bottom areas are returned here,
+                                                              // indexed [state][layer], instead of being merged into the return value.
+                                                              std::vector<std::vector<ExPolygons>>                            *out_top_and_bottom_layers = nullptr);
 
 // Returns multi-material segmentation based on painting in multi-material segmentation gizmo
 std::vector<std::vector<ExPolygons>> multi_material_segmentation_by_painting(const PrintObject &print_object, const std::function<void()> &throw_on_cancel_callback);
 
-// Returns fuzzy skin segmentation based on painting in fuzzy skin segmentation gizmo
-std::vector<std::vector<ExPolygons>> fuzzy_skin_segmentation_by_painting(const PrintObject &print_object, const std::function<void()> &throw_on_cancel_callback);
+// Returns fuzzy skin segmentation based on painting in fuzzy skin segmentation gizmo.
+// ORCA: a painted horizontal facet has no cross-section and only reaches the layers through the
+// top/bottom projection, which the wall generator does not use.
+std::vector<std::vector<ExPolygons>> fuzzy_skin_segmentation_by_painting(const PrintObject &print_object, const std::function<void()> &throw_on_cancel_callback,
+                                                                        std::vector<std::vector<ExPolygons>> *out_top_and_bottom_layers = nullptr);
 
 // Effective outer-wall line width for a region, resolved against its own nozzle with PrintRegion::flow's fallback.
 double resolve_outer_wall_line_width(const PrintRegionConfig &region_config, const PrintObjectConfig &object_config, const PrintConfig &print_config);

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -1101,7 +1101,7 @@ static std::vector<std::string> s_Preset_print_options{
     "support_ironing_spacing",
     "max_travel_detour_distance",
     "fuzzy_skin", "fuzzy_skin_thickness", "fuzzy_skin_point_distance", "fuzzy_skin_first_layer", "fuzzy_skin_noise_type", "fuzzy_skin_mode", "fuzzy_skin_scale", "fuzzy_skin_octaves", "fuzzy_skin_persistence", "fuzzy_skin_ripples_per_layer", "fuzzy_skin_ripple_offset", "fuzzy_skin_layers_between_ripple_offset",
-    "fuzzy_skin_top", "fuzzy_skin_top_params", "fuzzy_skin_top_thickness", "fuzzy_skin_top_point_distance",
+    "fuzzy_skin_top", "fuzzy_skin_top_area", "fuzzy_skin_top_params", "fuzzy_skin_top_thickness", "fuzzy_skin_top_point_distance",
     "max_volumetric_extrusion_rate_slope", "max_volumetric_extrusion_rate_slope_segment_length","extrusion_rate_smoothing_external_perimeter_only",
     "inner_wall_speed", "outer_wall_speed", "sparse_infill_speed", "internal_solid_infill_speed",
     "top_surface_speed", "support_speed", "support_object_xy_distance", "support_object_first_layer_gap", "support_interface_speed",

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -1101,6 +1101,7 @@ static std::vector<std::string> s_Preset_print_options{
     "support_ironing_spacing",
     "max_travel_detour_distance",
     "fuzzy_skin", "fuzzy_skin_thickness", "fuzzy_skin_point_distance", "fuzzy_skin_first_layer", "fuzzy_skin_noise_type", "fuzzy_skin_mode", "fuzzy_skin_scale", "fuzzy_skin_octaves", "fuzzy_skin_persistence", "fuzzy_skin_ripples_per_layer", "fuzzy_skin_ripple_offset", "fuzzy_skin_layers_between_ripple_offset",
+    "fuzzy_skin_top", "fuzzy_skin_top_params", "fuzzy_skin_top_thickness", "fuzzy_skin_top_point_distance",
     "max_volumetric_extrusion_rate_slope", "max_volumetric_extrusion_rate_slope_segment_length","extrusion_rate_smoothing_external_perimeter_only",
     "inner_wall_speed", "outer_wall_speed", "sparse_infill_speed", "internal_solid_infill_speed",
     "top_surface_speed", "support_speed", "support_object_xy_distance", "support_object_first_layer_gap", "support_interface_speed",

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -2479,6 +2479,14 @@ void Print::process(long long *time_cost_with_cache, bool use_cache)
             }
         }
 
+        // ORCA: after Z contouring, so displacement is added to the contoured Z.
+        for (PrintObject *obj : m_objects) {
+            if (need_slicing_objects.count(obj) != 0)
+                obj->fuzzy_skin_top();
+            else if (obj->set_started(posFuzzySkinTop))
+                obj->set_done(posFuzzySkinTop);
+        }
+
         // SlicingPipeline: support runs in the parallel block below; the hook must fire in a
         // sequential loop afterward. Snapshot per-object done-state just before the parallel_for.
         std::vector<char> sup_was_done(m_objects.size(), 1);

--- a/src/libslic3r/Print.hpp
+++ b/src/libslic3r/Print.hpp
@@ -95,7 +95,7 @@ enum PrintStep {
 
 enum PrintObjectStep {
     posSlice, posPerimeters,posEstimateCurledExtrusions, posPrepareInfill,
-    posInfill, posIroning, posContouring, posSupportMaterial, posSimplifyPath, posSimplifySupportPath,
+    posInfill, posIroning, posContouring, posFuzzySkinTop, posSupportMaterial, posSimplifyPath, posSimplifySupportPath,
     // BBS
     posDetectOverhangsForLift,
     posSimplifyWall, posSimplifyInfill,
@@ -522,6 +522,8 @@ private:
     void ironing();
     bool need_z_contouring() const;
     void contour_z();
+    // ORCA: fuzzy skin on top surfaces
+    void fuzzy_skin_top();
     void generate_support_material();
     void estimate_curled_extrusions();
     void simplify_extrusion_path();

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -256,6 +256,11 @@ static t_config_enum_values s_keys_map_FuzzySkinTopParams {
 };
 CONFIG_OPTION_ENUM_DEFINE_STATIC_MAPS(FuzzySkinTopParams)
 
+static t_config_enum_values s_keys_map_FuzzySkinTopArea {
+    { "all",          int(FuzzySkinTopArea::AllTopSurfaces) },
+    { "painted_only", int(FuzzySkinTopArea::PaintedOnly) }
+};
+CONFIG_OPTION_ENUM_DEFINE_STATIC_MAPS(FuzzySkinTopArea)
 
 static t_config_enum_values s_keys_map_TopSurfaceExpansionDirection {
     { "inward_and_outward", int(TopSurfaceExpansionDirection::InwardAndOutward) },
@@ -4002,6 +4007,24 @@ void PrintConfigDef::init_fff_params()
     def->enum_labels.push_back(L("Combined"));
     def->mode = comSimple;
     def->set_default_value(new ConfigOptionEnum<FuzzySkinTopMode>(FuzzySkinTopMode::Disabled));
+
+    def = this->add("fuzzy_skin_top_area", coEnum);
+    def->label = L("Top surface area");
+    def->category = L("Others");
+    def->tooltip = L("Which top surfaces get the fuzz.\n\n"
+                     "All top surfaces: every top surface on the object.\n"
+                     "Painted only: only where fuzzy skin has been painted on with the paint tool. "
+                     "Note that the brush is shared with the wall fuzzy skin, so the top faces themselves "
+                     "have to be painted - painting a side wall will not put fuzz on the top.\n\n"
+                     "This is independent of the wall fuzzy skin type, so painting for the walls does not "
+                     "change what happens on top surfaces.");
+    def->enum_keys_map = &ConfigOptionEnum<FuzzySkinTopArea>::get_enum_values();
+    def->enum_values.push_back("all");
+    def->enum_values.push_back("painted_only");
+    def->enum_labels.push_back(L("All top surfaces"));
+    def->enum_labels.push_back(L("Painted only"));
+    def->mode = comSimple;
+    def->set_default_value(new ConfigOptionEnum<FuzzySkinTopArea>(FuzzySkinTopArea::AllTopSurfaces));
 
     def = this->add("fuzzy_skin_top_params", coEnum);
     def->label = L("Top surface parameters");

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -242,6 +242,21 @@ static t_config_enum_values s_keys_map_FuzzySkinMode {
 };
 CONFIG_OPTION_ENUM_DEFINE_STATIC_MAPS(FuzzySkinMode)
 
+static t_config_enum_values s_keys_map_FuzzySkinTopMode {
+    { "disabled",       int(FuzzySkinTopMode::Disabled) },
+    { "displacement",   int(FuzzySkinTopMode::Displacement) },
+    { "extrusion",      int(FuzzySkinTopMode::Extrusion) },
+    { "combined",       int(FuzzySkinTopMode::Combined)}
+};
+CONFIG_OPTION_ENUM_DEFINE_STATIC_MAPS(FuzzySkinTopMode)
+
+static t_config_enum_values s_keys_map_FuzzySkinTopParams {
+    { "same_as_walls", int(FuzzySkinTopParams::SameAsWalls) },
+    { "custom",        int(FuzzySkinTopParams::Custom) }
+};
+CONFIG_OPTION_ENUM_DEFINE_STATIC_MAPS(FuzzySkinTopParams)
+
+
 static t_config_enum_values s_keys_map_TopSurfaceExpansionDirection {
     { "inward_and_outward", int(TopSurfaceExpansionDirection::InwardAndOutward) },
     { "inward",             int(TopSurfaceExpansionDirection::Inward) },
@@ -3962,6 +3977,78 @@ void PrintConfigDef::init_fff_params()
     def->enum_labels.push_back(L("Combined"));
     def->mode = comSimple;
     def->set_default_value(new ConfigOptionEnum<FuzzySkinMode>(FuzzySkinMode::Displacement));
+
+    def = this->add("fuzzy_skin_top", coEnum);
+    def->label = L("Fuzzy skin on top surfaces");
+    def->category = L("Others");
+    def->tooltip = L("Apply fuzzy skin to top surfaces as well as walls.\n"
+                     "A top surface has no sideways direction to fuzz into, so the texture is created differently:\n"
+                     "Displacement: The nozzle is moved up and down while printing the top solid infill. "
+                     "Produces the most visible relief, but adds Z motion to every segment, which slows printing down considerably.\n"
+                     "Extrusion: Z stays flat and the deposited volume is varied instead. No extra motion and no speed penalty, "
+                     "but the texture is subtler and appears as a matte finish rather than raised relief.\n"
+                     "Combined: Both at full strength. Stronger than either mode on its own, at the same "
+                     "speed cost as Displacement.\n\n"
+                     "The same noise field is used as for the walls, so the texture is continuous where a top surface meets a wall. "
+                     "Paint-on fuzzy skin is respected.");
+    def->enum_keys_map = &ConfigOptionEnum<FuzzySkinTopMode>::get_enum_values();
+    def->enum_values.push_back("disabled");
+    def->enum_values.push_back("displacement");
+    def->enum_values.push_back("extrusion");
+    def->enum_values.push_back("combined");
+    def->enum_labels.push_back(L("Disabled"));
+    def->enum_labels.push_back(L("Displacement"));
+    def->enum_labels.push_back(L("Extrusion"));
+    def->enum_labels.push_back(L("Combined"));
+    def->mode = comSimple;
+    def->set_default_value(new ConfigOptionEnum<FuzzySkinTopMode>(FuzzySkinTopMode::Disabled));
+
+    def = this->add("fuzzy_skin_top_params", coEnum);
+    def->label = L("Top surface parameters");
+    def->category = L("Others");
+    def->tooltip = L("Whether top surfaces reuse the wall fuzzy skin thickness and point distance, "
+                     "or take their own.\n\n"
+                     "Same as walls: follow the wall settings above. Best when you want one continuous "
+                     "texture over the whole part.\n"
+                     "Custom: set the thickness and point distance for top surfaces separately.\n\n"
+                     "Note that the noise type and its scale, octaves and persistence are always taken "
+                     "from the wall settings, in both cases. Sampling a single noise field is what makes "
+                     "the texture line up where a top surface meets a wall, so it is deliberately not "
+                     "separable. Ripple is the exception: it is generated along a wall loop and has no "
+                     "meaning on a flat surface, so top surfaces fall back to Classic noise when it is "
+                     "selected.");
+    def->enum_keys_map = &ConfigOptionEnum<FuzzySkinTopParams>::get_enum_values();
+    def->enum_values.push_back("same_as_walls");
+    def->enum_values.push_back("custom");
+    def->enum_labels.push_back(L("Same as walls"));
+    def->enum_labels.push_back(L("Custom"));
+    def->mode = comSimple;
+    def->set_default_value(new ConfigOptionEnum<FuzzySkinTopParams>(FuzzySkinTopParams::SameAsWalls));
+
+    def = this->add("fuzzy_skin_top_point_distance", coFloat);
+    def->label = L("Fuzzy skin top point distance");
+    def->category = L("Others");
+    def->tooltip = L("Spacing between the points the top surface fuzz is sampled at.\n\n"
+                     "Smaller values give a finer texture at the cost of many more G-code segments. Note that "
+                     "the texture across the extrusion lines is limited by the line spacing however fine this is set.");
+    def->sidetext = L("mm");
+    // Must not be 0, otherwise subdividing a line never terminates.
+    def->min = 0.01f;
+    def->mode = comSimple;
+    def->set_default_value(new ConfigOptionFloat(0.3f));
+
+    def = this->add("fuzzy_skin_top_thickness", coFloat);
+    def->label = L("Fuzzy skin top thickness");
+    def->category = L("Others");
+    def->tooltip = L("Height of the fuzz applied to top surfaces, above and below the layer plane.\n\n"
+                     "In Displacement mode this is how far the nozzle travels in Z. Extrusion is scaled with it, "
+                     "since dipping the nozzle down leaves less room for material, so the downward half is "
+                     "limited to keep the flow high enough for a continuous bead. Values beyond about three "
+                     "quarters of the layer height therefore add texture upwards only.");
+    def->sidetext = L("mm");
+    def->min = 0;
+    def->mode = comSimple;
+    def->set_default_value(new ConfigOptionFloat(0.2));
 
     def = this->add("fuzzy_skin_noise_type", coEnum);
     def->label = L("Fuzzy skin noise type");

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -70,6 +70,21 @@ enum class FuzzySkinMode {
     Combined,
 };
 
+// ORCA: Displacement moves the nozzle in Z, Extrusion modulates the deposited volume.
+enum class FuzzySkinTopMode {
+    Disabled,
+    Displacement,
+    Extrusion,
+    Combined,
+};
+
+// ORCA: whether top surfaces reuse the wall thickness and point distance.
+enum class FuzzySkinTopParams {
+    SameAsWalls,
+    Custom,
+};
+
+
 // ORCA: direction in which top_surface_expansion grows the top surfaces.
 enum class TopSurfaceExpansionDirection {
     InwardAndOutward,
@@ -1314,6 +1329,11 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionInt,                  fuzzy_skin_ripples_per_layer))
     ((ConfigOptionPercent,              fuzzy_skin_ripple_offset))
     ((ConfigOptionInt,                  fuzzy_skin_layers_between_ripple_offset))
+    // ORCA: top surface fuzzy skin. Per-region so paint-on fuzzy skin applies to it.
+    ((ConfigOptionEnum<FuzzySkinTopMode>, fuzzy_skin_top))
+    ((ConfigOptionEnum<FuzzySkinTopParams>, fuzzy_skin_top_params))
+    ((ConfigOptionFloat,                fuzzy_skin_top_thickness))
+    ((ConfigOptionFloat,                fuzzy_skin_top_point_distance))
     ((ConfigOptionFloatsNullable,       gap_infill_speed))
     ((ConfigOptionInt,                  sparse_infill_filament_id))
     ((ConfigOptionFloatOrPercent,       sparse_infill_line_width))

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -84,6 +84,11 @@ enum class FuzzySkinTopParams {
     Custom,
 };
 
+// ORCA: independent of the wall fuzzy skin type, so painting for walls does not affect tops.
+enum class FuzzySkinTopArea {
+    AllTopSurfaces,
+    PaintedOnly,
+};
 
 // ORCA: direction in which top_surface_expansion grows the top surfaces.
 enum class TopSurfaceExpansionDirection {
@@ -1331,6 +1336,7 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionInt,                  fuzzy_skin_layers_between_ripple_offset))
     // ORCA: top surface fuzzy skin. Per-region so paint-on fuzzy skin applies to it.
     ((ConfigOptionEnum<FuzzySkinTopMode>, fuzzy_skin_top))
+    ((ConfigOptionEnum<FuzzySkinTopArea>, fuzzy_skin_top_area))
     ((ConfigOptionEnum<FuzzySkinTopParams>, fuzzy_skin_top_params))
     ((ConfigOptionFloat,                fuzzy_skin_top_thickness))
     ((ConfigOptionFloat,                fuzzy_skin_top_point_distance))

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -872,6 +872,44 @@ void PrintObject::contour_z()
     this->set_done(posContouring);
 }
 
+// ORCA: runs after posContouring so displacement composes with Z anti-aliasing.
+void PrintObject::fuzzy_skin_top()
+{
+    if (!this->set_started(posFuzzySkinTop)) {
+        return;
+    }
+
+    // Bind to a local: all_regions() returns by value, so calling it for begin() and
+    // end() separately would compare iterators into two different temporaries.
+    const std::vector<std::reference_wrapper<const PrintRegion>> regions = this->all_regions();
+    const bool any_region_enabled = std::any_of(
+        regions.begin(), regions.end(),
+        [](const std::reference_wrapper<const PrintRegion>& region) {
+            return region.get().config().fuzzy_skin_top != FuzzySkinTopMode::Disabled;
+        });
+    if (!any_region_enabled) {
+        this->set_done(posFuzzySkinTop);
+        return;
+    }
+
+    m_print->set_status(45, L("Fuzzy skin on top surfaces"));
+    BOOST_LOG_TRIVIAL(debug) << "Top surface fuzzy skin in parallel - start";
+
+    tbb::parallel_for(
+        tbb::blocked_range<size_t>(0, m_layers.size()),
+        [this](const tbb::blocked_range<size_t>& range) {
+            for (size_t layer_idx = range.begin(); layer_idx < range.end(); layer_idx++) {
+                m_print->throw_if_canceled();
+                m_layers[layer_idx]->make_fuzzy_skin_top();
+            }
+        }
+    );
+    m_print->throw_if_canceled();
+    BOOST_LOG_TRIVIAL(debug) << "Top surface fuzzy skin in parallel - end";
+
+    this->set_done(posFuzzySkinTop);
+}
+
 // BBS
 void PrintObject::clear_overhangs_for_lift()
 {
@@ -1407,7 +1445,12 @@ bool PrintObject::invalidate_state_by_config_options(
             || opt_key == "small_area_infill_flow_compensation"
             || opt_key == "lateral_lattice_angle_1"
             || opt_key == "lateral_lattice_angle_2"
-            || opt_key == "infill_overhang_angle") {
+            || opt_key == "infill_overhang_angle"
+            // ORCA: the fills must be regenerated before the top surface pass can re-run.
+            || opt_key == "fuzzy_skin_top"
+            || opt_key == "fuzzy_skin_top_params"
+            || opt_key == "fuzzy_skin_top_thickness"
+            || opt_key == "fuzzy_skin_top_point_distance") {
             steps.emplace_back(posInfill);
         } else if (opt_key == "sparse_infill_pattern"
                    || opt_key == "sparse_infill_smooth_factor"
@@ -1574,16 +1617,21 @@ bool PrintObject::invalidate_step(PrintObjectStep step)
 	bool invalidated = Inherited::invalidate_step(step);
 
     // propagate to dependent steps
+    // ORCA: posFuzzySkinTop rewrites fills in place, so it follows their invalidation.
     if (step == posPerimeters) {
-		invalidated |= this->invalidate_steps({ posPrepareInfill, posInfill, posIroning, posContouring, posSimplifyPath, posSimplifyInfill });
+		invalidated |= this->invalidate_steps({ posPrepareInfill, posInfill, posIroning, posContouring, posFuzzySkinTop, posSimplifyPath, posSimplifyInfill });
         invalidated |= m_print->invalidate_steps({ psSkirtBrim });
     } else if (step == posPrepareInfill) {
-        invalidated |= this->invalidate_steps({ posInfill, posIroning, posContouring, posSimplifyPath, posSimplifyInfill });
+        invalidated |= this->invalidate_steps({ posInfill, posIroning, posContouring, posFuzzySkinTop, posSimplifyPath, posSimplifyInfill });
     } else if (step == posInfill) {
-        invalidated |= this->invalidate_steps({ posIroning, posContouring, posSimplifyInfill });
+        invalidated |= this->invalidate_steps({ posIroning, posContouring, posFuzzySkinTop, posSimplifyInfill });
         invalidated |= m_print->invalidate_steps({ psSkirtBrim });
+    } else if (step == posIroning) {
+        invalidated |= this->invalidate_steps({ posContouring, posFuzzySkinTop, posSimplifyInfill });
+    } else if (step == posContouring) {
+        invalidated |= this->invalidate_steps({ posFuzzySkinTop, posSimplifyInfill });
     } else if (step == posSlice) {
-		invalidated |= this->invalidate_steps({ posPerimeters, posPrepareInfill, posInfill, posIroning, posContouring, posSupportMaterial, posSimplifyPath, posSimplifyInfill });
+		invalidated |= this->invalidate_steps({ posPerimeters, posPrepareInfill, posInfill, posIroning, posContouring, posFuzzySkinTop, posSupportMaterial, posSimplifyPath, posSimplifyInfill });
         invalidated |= m_print->invalidate_steps({ psSkirtBrim });
         m_slicing_params.valid = false;
     } else if (step == posSupportMaterial) {

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -1448,6 +1448,7 @@ bool PrintObject::invalidate_state_by_config_options(
             || opt_key == "infill_overhang_angle"
             // ORCA: the fills must be regenerated before the top surface pass can re-run.
             || opt_key == "fuzzy_skin_top"
+            || opt_key == "fuzzy_skin_top_area"
             || opt_key == "fuzzy_skin_top_params"
             || opt_key == "fuzzy_skin_top_thickness"
             || opt_key == "fuzzy_skin_top_point_distance") {

--- a/src/libslic3r/PrintObjectSlice.cpp
+++ b/src/libslic3r/PrintObjectSlice.cpp
@@ -1,4 +1,6 @@
 #include <boost/log/trivial.hpp>
+#include <fstream>
+#include <cstdlib>
 
 #include <tbb/parallel_for.h>
 
@@ -1033,8 +1035,21 @@ template<typename ThrowOnCancel>
 void apply_fuzzy_skin_segmentation(PrintObject &print_object, ThrowOnCancel throw_on_cancel)
 {
     // Returns fuzzy skin segmentation based on painting in the fuzzy skin painting gizmo.
-    std::vector<std::vector<ExPolygons>> segmentation = fuzzy_skin_segmentation_by_painting(print_object, throw_on_cancel);
+    // ORCA: the region splitting below uses `segmentation` alone, as the walls always have.
+    std::vector<std::vector<ExPolygons>> top_and_bottom_layers;
+    std::vector<std::vector<ExPolygons>> segmentation = fuzzy_skin_segmentation_by_painting(print_object, throw_on_cancel, &top_and_bottom_layers);
     assert(segmentation.size() == print_object.layer_count());
+
+    for (size_t layer_idx = 0; layer_idx < segmentation.size(); ++layer_idx) {
+        ExPolygons painted;
+        if (!segmentation[layer_idx].empty())
+            append(painted, segmentation[layer_idx][0]);
+        // Indexed [state][layer]; state 0 is the unpainted default.
+        for (size_t state = 1; state < top_and_bottom_layers.size(); ++state)
+            if (layer_idx < top_and_bottom_layers[state].size())
+                append(painted, top_and_bottom_layers[state][layer_idx]);
+        print_object.get_layer(int(layer_idx))->fuzzy_skin_painted_areas = union_ex(painted);
+    }
 
     struct ByRegion
     {

--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -1097,6 +1097,7 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig *config, in
     toggle_line("fuzzy_skin_ripple_offset", is_ripple && has_fuzzy_skin);
     toggle_line("fuzzy_skin_layers_between_ripple_offset", is_ripple && has_fuzzy_skin);
 
+    toggle_line("fuzzy_skin_top_area", has_top_fuzzy_skin);
     toggle_line("fuzzy_skin_top_params", has_top_fuzzy_skin);
     toggle_line("fuzzy_skin_top_point_distance", has_top_fuzzy_skin && top_fuzzy_custom);
     toggle_line("fuzzy_skin_top_thickness", has_top_fuzzy_skin && top_fuzzy_custom);

--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -1072,19 +1072,34 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig *config, in
     // Get the current fuzzy skin state
     bool has_fuzzy_skin = config->opt_enum<FuzzySkinType>("fuzzy_skin") != FuzzySkinType::Disabled_fuzzy;
     
-    // Show fuzzy skin options when fuzzy skin is not disabled
-    for (auto el : {"fuzzy_skin_mode", "fuzzy_skin_noise_type", "fuzzy_skin_point_distance", "fuzzy_skin_thickness", "fuzzy_skin_first_layer"})
-        toggle_line(el, has_fuzzy_skin);
-    
+    // ORCA: independent of the wall fuzzy skin type; texture on the top alone is valid.
+    const bool has_top_fuzzy_skin = config->opt_enum<FuzzySkinTopMode>("fuzzy_skin_top") != FuzzySkinTopMode::Disabled;
+    const bool top_fuzzy_custom   = config->opt_enum<FuzzySkinTopParams>("fuzzy_skin_top_params") == FuzzySkinTopParams::Custom;
+
+    // ORCA: keep a shared row visible while either the walls or the top surfaces still read it.
+    const bool noise_in_use     = has_fuzzy_skin || has_top_fuzzy_skin;
+    const bool wall_size_in_use = has_fuzzy_skin || (has_top_fuzzy_skin && !top_fuzzy_custom);
+
+    toggle_line("fuzzy_skin_mode", has_fuzzy_skin);
+    toggle_line("fuzzy_skin_first_layer", has_fuzzy_skin);
+    toggle_line("fuzzy_skin_noise_type", noise_in_use);
+    toggle_line("fuzzy_skin_point_distance", wall_size_in_use);
+    toggle_line("fuzzy_skin_thickness", wall_size_in_use);
+
     // Show noise type specific options with the same logic
     NoiseType fuzzy_skin_noise_type = config->opt_enum<NoiseType>("fuzzy_skin_noise_type");
     const bool is_ripple = fuzzy_skin_noise_type == NoiseType::Ripple;
-    toggle_line("fuzzy_skin_scale", fuzzy_skin_noise_type != NoiseType::Classic && has_fuzzy_skin && !is_ripple);
-    toggle_line("fuzzy_skin_octaves", fuzzy_skin_noise_type != NoiseType::Classic && fuzzy_skin_noise_type != NoiseType::Voronoi && has_fuzzy_skin && !is_ripple);
-    toggle_line("fuzzy_skin_persistence", (fuzzy_skin_noise_type == NoiseType::Perlin || fuzzy_skin_noise_type == NoiseType::Billow) && has_fuzzy_skin && !is_ripple);
+    toggle_line("fuzzy_skin_scale", fuzzy_skin_noise_type != NoiseType::Classic && noise_in_use && !is_ripple);
+    toggle_line("fuzzy_skin_octaves", fuzzy_skin_noise_type != NoiseType::Classic && fuzzy_skin_noise_type != NoiseType::Voronoi && noise_in_use && !is_ripple);
+    toggle_line("fuzzy_skin_persistence", (fuzzy_skin_noise_type == NoiseType::Perlin || fuzzy_skin_noise_type == NoiseType::Billow) && noise_in_use && !is_ripple);
+    // Ripple is wall-only; the top surface pass falls back to Classic.
     toggle_line("fuzzy_skin_ripples_per_layer", is_ripple && has_fuzzy_skin);
     toggle_line("fuzzy_skin_ripple_offset", is_ripple && has_fuzzy_skin);
     toggle_line("fuzzy_skin_layers_between_ripple_offset", is_ripple && has_fuzzy_skin);
+
+    toggle_line("fuzzy_skin_top_params", has_top_fuzzy_skin);
+    toggle_line("fuzzy_skin_top_point_distance", has_top_fuzzy_skin && top_fuzzy_custom);
+    toggle_line("fuzzy_skin_top_thickness", has_top_fuzzy_skin && top_fuzzy_custom);
 
     bool have_arachne = config->opt_enum<PerimeterGeneratorType>("wall_generator") == PerimeterGeneratorType::Arachne;
     for (auto el : {"wall_transition_length", "wall_transition_filter_deviation", "wall_transition_angle", "min_feature_size", "min_length_factor",

--- a/src/slic3r/GUI/Gizmos/GLGizmoFuzzySkin.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoFuzzySkin.cpp
@@ -328,7 +328,15 @@ void GLGizmoFuzzySkin::on_render_input_window(float x, float y, float bottom_lim
     const bool                has_object_fuzzy_override  = obj_cfg.option("fuzzy_skin");
     const FuzzySkinType       effective_fuzzy_skin_state = has_object_fuzzy_override ? obj_cfg.opt_enum<FuzzySkinType>("fuzzy_skin")
                                                                                      : glb_cfg.opt_enum<FuzzySkinType>("fuzzy_skin");
-    if (effective_fuzzy_skin_state == FuzzySkinType::Disabled_fuzzy) {
+    // ORCA: painting still takes effect through the top surfaces, so do not warn in that case.
+    const FuzzySkinTopMode effective_top_mode = obj_cfg.option("fuzzy_skin_top") ? obj_cfg.opt_enum<FuzzySkinTopMode>("fuzzy_skin_top")
+                                                                                : glb_cfg.opt_enum<FuzzySkinTopMode>("fuzzy_skin_top");
+    const FuzzySkinTopArea effective_top_area = obj_cfg.option("fuzzy_skin_top_area") ? obj_cfg.opt_enum<FuzzySkinTopArea>("fuzzy_skin_top_area")
+                                                                                     : glb_cfg.opt_enum<FuzzySkinTopArea>("fuzzy_skin_top_area");
+    const bool painting_drives_top_surfaces = effective_top_mode != FuzzySkinTopMode::Disabled &&
+                                              effective_top_area == FuzzySkinTopArea::PaintedOnly;
+
+    if (effective_fuzzy_skin_state == FuzzySkinType::Disabled_fuzzy && !painting_drives_top_surfaces) {
         float font_size = ImGui::GetFontSize();
         auto link_text = [&]() {
             ImColor HyperColor = ImGuiWrapper::COL_ORCA;

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -3081,6 +3081,10 @@ void TabPrint::build()
         optgroup->append_single_option_line("fuzzy_skin_ripple_offset", "others_settings_fuzzy_skin#ripple-offset");
         optgroup->append_single_option_line("fuzzy_skin_layers_between_ripple_offset", "others_settings_fuzzy_skin#layers-between-ripple-offset");
         optgroup->append_single_option_line("fuzzy_skin_first_layer", "others_settings_fuzzy_skin#apply-fuzzy-skin-to-first-layer");
+        optgroup->append_single_option_line("fuzzy_skin_top", "others_settings_fuzzy_skin#top-surfaces");
+        optgroup->append_single_option_line("fuzzy_skin_top_params", "others_settings_fuzzy_skin#top-surfaces");
+        optgroup->append_single_option_line("fuzzy_skin_top_point_distance", "others_settings_fuzzy_skin#top-surfaces");
+        optgroup->append_single_option_line("fuzzy_skin_top_thickness", "others_settings_fuzzy_skin#top-surfaces");
 
         optgroup = page->new_optgroup(L("G-code output"), L"param_gcode");
         optgroup->append_single_option_line("reduce_infill_retraction", "others_settings_g_code_output#reduce-infill-retraction");

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -3082,6 +3082,7 @@ void TabPrint::build()
         optgroup->append_single_option_line("fuzzy_skin_layers_between_ripple_offset", "others_settings_fuzzy_skin#layers-between-ripple-offset");
         optgroup->append_single_option_line("fuzzy_skin_first_layer", "others_settings_fuzzy_skin#apply-fuzzy-skin-to-first-layer");
         optgroup->append_single_option_line("fuzzy_skin_top", "others_settings_fuzzy_skin#top-surfaces");
+        optgroup->append_single_option_line("fuzzy_skin_top_area", "others_settings_fuzzy_skin#top-surfaces");
         optgroup->append_single_option_line("fuzzy_skin_top_params", "others_settings_fuzzy_skin#top-surfaces");
         optgroup->append_single_option_line("fuzzy_skin_top_point_distance", "others_settings_fuzzy_skin#top-surfaces");
         optgroup->append_single_option_line("fuzzy_skin_top_thickness", "others_settings_fuzzy_skin#top-surfaces");


### PR DESCRIPTION
# Description

Adds fuzzy skin on **top surfaces**, as a separately tunable setting under Fuzzy skin, with paint-on support.

The wall generator cannot reach top surfaces: fuzzy skin there displaces points sideways along the surface normal, and a horizontal surface has no sideways. This adds the two mechanisms that do work on a flat surface, mirroring the wall modes:

- **Displacement** — moves the nozzle in Z while printing the top solid infill. Most visible relief, but adds Z motion to every segment and slows printing noticeably.
- **Extrusion** — Z stays flat, the deposited volume is modulated instead. No extra motion or speed penalty; a structured finish rather than raised relief.
- **Combined** — both at full amplitude.

The idea is not new — [Fuzzyficator](https://github.com/TengerTechnologies/Fuzzyficator) does it as a G-code post-processing script. Doing it inside the slicer buys two things a script cannot: it samples **the same noise module as the walls**, at `(x, y, slice_z)`, so the texture is continuous where a top surface meets a wall; and it can honour **paint-on fuzzy skin**.

### New options

Per-region (`PrintRegionConfig`), under Print Settings → Others → Fuzzy skin:

| Option | Values |
|---|---|
| `fuzzy_skin_top` | Disabled / Displacement / Extrusion / Combined |
| `fuzzy_skin_top_area` | All top surfaces / Painted only |
| `fuzzy_skin_top_params` | Same as walls / Custom |
| `fuzzy_skin_top_point_distance` | mm, shown when Custom |
| `fuzzy_skin_top_thickness` | mm, shown when Custom |

`fuzzy_skin_top_area` is deliberately independent of the wall fuzzy skin type, so painting for the walls does not change what happens on top surfaces.

### Paint-on support

Two things had to change for painting to work on top surfaces.

`fuzzy_skin_segmentation_by_painting()` passed `IncludeTopAndBottomLayers::No`, so `segmentation_top_and_bottom_layers()` — which projects painted horizontal facets onto the layers forming top and bottom surfaces — never ran. A horizontal facet has no cross-section, so painting the top face of a model produced no segmentation geometry whatsoever. Correct for a wall-only feature, but it means there was nothing for a top surface pass to find.

`segmentation_by_painting()` now takes an optional out-parameter that hands the projected top/bottom areas back instead of merging them into the return value. `merge_segmented_layers()` is then called with an empty set, which is exactly what `IncludeTopAndBottomLayers::No` produced — so the wall generator's input is unchanged, there is still only one segmentation pass, and multi-material segmentation is unaffected via the defaulted parameter. The areas are recorded on `Layer::fuzzy_skin_painted_areas`, which ties their lifetime to the layers and needs no extra invalidation.

Selection is then done by **clipping**, not by region membership. Painted areas do get split into their own `PrintRegion`s, but a region is fuzzed or not as a whole, which can only ever produce an entire top surface or none of it. Each top solid infill path is now clipped with `intersection_pl`/`diff_pl`, fuzzing the inside pieces and emitting the rest untouched, so the boundary follows the brush strokes.

### Other implementation notes

- New `posFuzzySkinTop` step, deliberately **after** `posContouring`, so displacement is *added* to the Z that Z Anti-Aliasing already assigned. A contoured top surface keeps following the mesh and gains texture on top of it.
- Extrusion mode needs no new extrusion representation: the resampled path becomes a `ThickPolyline` fed through `thick_polyline_to_multi_path()`, the same helper the Arachne walls use. Note `ThickPolyline::width` carries **spacing in scaled units**, indexed two entries per segment.
- The flow factor is `1 + n*thickness/layer_height`, clamped to `[0.25, 2.0]`, and spacing is floored, because `Flow::spacing()` and `mm3_per_mm()` throw rather than clamp on degenerate values.
- The G-code writer scales extrusion for a contoured path by `(path.height + z_diff) / path.height` with no lower bound, so a full-layer-height dip extrudes nothing. The downward half of the displacement is therefore compressed to keep flow at or above 25% of nominal — compressed rather than clipped, so troughs do not become flat plateaus.
- Noise is sampled **once per resampled point** and drives both effects. It must not be re-sampled later: Classic noise is `UniformNoise`, whose `GetValue()` ignores its coordinates and returns a fresh random number per call.

# Screenshots/Recordings/Graphs

<img width="389" height="273" alt="image" src="https://github.com/user-attachments/assets/f6e3ec98-ed53-496d-96e9-add0420e14a2" />
<img width="2354" height="676" alt="image" src="https://github.com/user-attachments/assets/5a25e90d-05ab-4b28-ac5d-eb0d7afb51d5" />
<img width="1862" height="687" alt="image" src="https://github.com/user-attachments/assets/a02eb8c9-85fc-4f67-9e7d-4fe21ff0d496" />
<img width="1943" height="799" alt="image" src="https://github.com/user-attachments/assets/bd519be2-6cec-4c79-849a-02b2b82b4a07" />
<img width="2149" height="715" alt="image" src="https://github.com/user-attachments/assets/e9f8a397-0ca8-407c-afbd-24bdc5c83d1e" />

# Real results
Displacement, Point Distance: 0.3, Thickness: 0.7, Classic
<img width="979" height="1305" alt="image" src="https://github.com/user-attachments/assets/49e48c21-c92b-4943-b506-66f9f7886a9a" />

Combined, Point Distance: 0.3, Thickness: 0.1, Classic
<img width="979" height="1305" alt="image" src="https://github.com/user-attachments/assets/9eb579c1-7297-4466-aab8-d9bca23d28ca" />

Combined, Point Distance: 0.3, Thickness: 0.2, Voronoi
<img width="979" height="1305" alt="image" src="https://github.com/user-attachments/assets/63f1a5b1-ec9f-4cc3-ab3e-eaf7fb1191e0" />

Extrusion, Point Distance: 0.3, Thickness: 0.7, Billow
<img width="979" height="1305" alt="image" src="https://github.com/user-attachments/assets/413381e4-c17e-4866-8fbe-4c961b223b4e" />

## Tests

Built from source on Windows (VS2022 x64, Release) and sliced with a Bambu Lab P1S profile. All three modes produce the expected G-code and preview correctly, re-slicing after settings changes behaves, and `Painted only` fuzzes exactly the painted patches.

### Known limitations — help welcome on any of these

- **Ripple** noise is not supported on top surfaces. It is driven by arc length along a wall loop and displaces along the path normal, neither of which has meaning on a flat surface, so it falls back to Classic.
- Noise type, scale, octaves and persistence are **always shared with the walls**. This is deliberate — one shared field is what makes the texture line up at the wall/top boundary — but it is a design decision worth challenging.
- **Ironing flattens the fuzz** if both are enabled. Needs a warning or an interlock. Or leave it up to the user.
- Displacement mode adds Z motion to every top-surface segment. On a printer with a heavy bed this costs real print time; Extrusion mode exists precisely to avoid that.
- Not tested with multi-material or spiral vase.

### Not caused by this PR, but visible with it

Non-planar extrusion moves render with spikes at local Z maxima and minima. `libvgcode` computes the joint mitre angle from the **XY** cross product only (`ViewerImpl.cpp`, `std::atan2(prev_line[0]*this_line[1] - prev_line[1]*this_line[0], dot(prev_line, this_line))`), so a turn purely in Z reports an angle of exactly 0. The shader then treats the segment as a path end or perfectly collinear and emits a full-length pointy cap with nothing to hide it. This should already be reproducible with `zaa_enabled` alone, since Z Anti-Aliasing also varies Z per point.

---

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
Close #7152