### PR TITLE
build: clear 31 warnings - copy and move declarations

### DIFF
--- a/src/libslic3r/Measure.hpp
+++ b/src/libslic3r/Measure.hpp
@@ -33,15 +33,6 @@ public:
     SurfaceFeature(const Vec3d& pt)
     : m_type{SurfaceFeatureType::Point}, m_pt1{pt} {}
 
-    SurfaceFeature(const SurfaceFeature& sf){
-        this->clone(sf);
-        volume                 = sf.volume;
-        plane_indices          = sf.plane_indices;
-        world_tran             = sf.world_tran;
-        world_plane_features   = sf.world_plane_features;
-        origin_surface_feature = sf.origin_surface_feature;
-    }
-
     void clone(const SurfaceFeature &sf)
     {
         m_type               = sf.get_type();

--- a/src/libslic3r/Orient.cpp
+++ b/src/libslic3r/Orient.cpp
@@ -39,7 +39,6 @@ namespace orientation {
         float height_to_bottom_hull_ratio = 0;  // affects stability, the lower the better
         float unprintability = 0;
         Eigen::VectorXf areas_cooling;
-        CostItems(CostItems const & other) = default;
         CostItems() = default;
         static std::string field_names() {
             return "                                      overhang, bottom, bothull, contour, A_laf, A_prj, unprintability";

--- a/src/libslic3r/Point.hpp
+++ b/src/libslic3r/Point.hpp
@@ -195,7 +195,6 @@ public:
     Point(int64_t x, int32_t y) : Vec2crd(coord_t(x), coord_t(y)) {}
     Point(int32_t x, int64_t y) : Vec2crd(coord_t(x), coord_t(y)) {}
     Point(double x, double y) : Vec2crd(coord_t(std::round(x)), coord_t(std::round(y))) {}
-    Point(const Point &rhs) { *this = rhs; }
 	explicit Point(const Vec2d& rhs) : Vec2crd(coord_t(std::round(rhs.x())), coord_t(std::round(rhs.y()))) {}
 	// This constructor allows you to construct Point from Eigen expressions
     // This constructor has to be implicit (non-explicit) to allow implicit conversion from Eigen expressions.
@@ -278,7 +277,6 @@ public:
     Point3(int32_t x, int32_t y, int32_t z = 0) : Vec3crd(coord_t(x), coord_t(y), coord_t(z)) {}
     Point3(int64_t x, int64_t y, int64_t z = 0) : Vec3crd(coord_t(x), coord_t(y), coord_t(z)) {}
     Point3(double x, double y, double z = 0.0) : Vec3crd(coord_t(std::round(x)), coord_t(std::round(y)), coord_t(std::round(z))) {}
-    Point3(const Point3 &rhs) { *this = rhs; }
     explicit Point3(const Vec2crd& vec2crd, coord_t z = 0) : Vec3crd(vec2crd.x(), vec2crd.y(), z) {}
     explicit Point3(const Vec3crd &vec3crd) : Vec3crd(vec3crd) {}
     // This constructor allows you to construct Point from Eigen expressions

--- a/src/libslic3r/Preset.hpp
+++ b/src/libslic3r/Preset.hpp
@@ -840,13 +840,12 @@ public:
 
 protected:
     PresetCollection() = default;
-    // Copy constructor and copy operators are not to be used from outside PresetBundle,
-    // as the Profile::vendor points to an instance of VendorProfile stored at parent PresetBundle!
-    PresetCollection(const PresetCollection &other) = default;
-    //BBS: add operator= logic insteadof default
+    // Deleted by the std::recursive_mutex member. PresetBundle copies by assignment.
+    PresetCollection(const PresetCollection &other) = delete;
+    //BBS: hand-written because m_mutex cannot be copy-assigned.
     PresetCollection& operator=(const PresetCollection &other);
-    // After copying a collection with the default operators above, call this function
-    // to adjust Profile::vendor pointers.
+    // Copying leaves every Preset::vendor pointing into the source bundle's vendor map.
+    // This re-points them at the matching entries in vendors.
     void            update_vendor_ptrs_after_copy(const VendorMap &vendors);
 
     // Select a preset, if it exists. If it does not exist, select an invalid (-1) index.
@@ -984,7 +983,8 @@ public:
     bool            only_default_printers() const;
 private:
     PrinterPresetCollection() = default;
-    PrinterPresetCollection(const PrinterPresetCollection &other) = default;
+    // Deleted along with the base copy constructor.
+    PrinterPresetCollection(const PrinterPresetCollection &other) = delete;
     PrinterPresetCollection& operator=(const PrinterPresetCollection &other) = default;
 
     friend class PresetBundle;

--- a/src/libslic3r/SLA/Hollowing.hpp
+++ b/src/libslic3r/SLA/Hollowing.hpp
@@ -44,9 +44,6 @@ struct DrainHole
         : pos(p), normal(n), radius(r), height(h), failed(fl)
     {}
 
-    DrainHole(const DrainHole& rhs) :
-        DrainHole(rhs.pos, rhs.normal, rhs.radius, rhs.height, rhs.failed) {}
-    
     bool operator==(const DrainHole &sp) const;
     
     bool operator!=(const DrainHole &sp) const { return !(sp == (*this)); }

--- a/src/libslic3r/Support/SupportCommon.cpp
+++ b/src/libslic3r/Support/SupportCommon.cpp
@@ -1234,10 +1234,6 @@ static void modulate_extrusion_by_overlapping_layers(
                 (fragment_end.is_start ? &polyline.points.front() : &polyline.points.back());
         }
     private:
-        ExtrusionPathFragmentEndPointAccessor& operator=(const ExtrusionPathFragmentEndPointAccessor&) {
-            return *this;
-        }
-
         const std::vector<ExtrusionPathFragment> &m_path_fragments;
     };
     const coord_t search_radius = 7;

--- a/src/libslic3r/Support/TreeSupport.hpp
+++ b/src/libslic3r/Support/TreeSupport.hpp
@@ -204,8 +204,9 @@ public:
         clear_nodes();
     }
 
-    TreeSupportData(TreeSupportData&&) = default;
-    TreeSupportData& operator=(TreeSupportData&&) = default;
+    // Deleted by the tbb::spin_mutex member.
+    TreeSupportData(TreeSupportData&&) = delete;
+    TreeSupportData& operator=(TreeSupportData&&) = delete;
 
     TreeSupportData(const TreeSupportData&) = delete;
     TreeSupportData& operator=(const TreeSupportData&) = delete;

--- a/src/libslic3r/calib.hpp
+++ b/src/libslic3r/calib.hpp
@@ -91,29 +91,15 @@ class CaliPresetInfo
 {
 public:
     int         tray_id;
-    int         extruder_id;
-    NozzleVolumeType nozzle_volume_type;
-    BedType     bed_type;
+    int         extruder_id = 0;
+    NozzleVolumeType nozzle_volume_type{nvtStandard};
+    BedType     bed_type{btDefault};
     float       nozzle_diameter;
     int         nozzle_pos_id{-1};
     std::string nozzle_sn;
     std::string filament_id;
     std::string setting_id;
     std::string name;
-
-    CaliPresetInfo &operator=(const CaliPresetInfo &other)
-    {
-        this->tray_id         = other.tray_id;
-        this->extruder_id     = other.extruder_id;
-        this->nozzle_volume_type = other.nozzle_volume_type;
-        this->nozzle_diameter = other.nozzle_diameter;
-        this->nozzle_pos_id   = other.nozzle_pos_id;
-        this->nozzle_sn       = other.nozzle_sn;
-        this->filament_id     = other.filament_id;
-        this->setting_id      = other.setting_id;
-        this->name            = other.name;
-        return *this;
-    }
 };
 
 struct PrinterCaliInfo

--- a/src/slic3r/GUI/PartPlate.hpp
+++ b/src/slic3r/GUI/PartPlate.hpp
@@ -675,16 +675,6 @@ public:
                 offset = Vec2d(0, 0);
             }
 
-            TexturePart(const TexturePart& part) {
-                this->x = part.x;
-                this->y = part.y;
-                this->w = part.w;
-                this->h = part.h;
-                this->offset = part.offset;
-                this->buffer    = part.buffer;
-                this->filename  = part.filename;
-                this->texture   = part.texture;
-            }
             void update_pos(float xx, float yy, float ww, float hh) {
                 x = xx;
                 y = yy;


### PR DESCRIPTION
# Description

Three categories about copy and move members that do not match what the type supports: `-Wdefaulted-function-deleted` (18), `-Wdeprecated-copy-with-user-provided-copy` (12) and `-Wdeprecated-copy` (1). 12 sites across 9 files, from #15374.

Six classes declared a copy constructor that only restated the implicit one, five of them hand-written. All six declarations are gone. Defaulting them instead would just move the warning, since C++20 deprecates the implicit definition of one copy member whenever the other is user-declared, defaulted included.

`CaliPresetInfo` is why the hand-written form is worth removing. Its copy assignment listed 9 of its 10 members and omitted `bed_type`, which `CalibrationWizard.cpp:1279` reads back as the plate type. I could not construct a sequence where that produces a wrong value, since the saved copy is always written from the same vector it is later restored into, so this is an inconsistency rather than a known bug. `AppConfig` also restores five of these members only when the saved key is present, and three of the five had no initializer; those now default alongside `nozzle_pos_id`, which already did.

`PresetCollection` and `PrinterPresetCollection` declared `= default` copy constructors that a `std::recursive_mutex` had already deleted, and `TreeSupportData` did the same for its move members with a `tbb::spin_mutex`. Those now say `= delete`, and the preset classes keep the declaration because they have a user-declared copy assignment. `ExtrusionPathFragmentEndPointAccessor` had a private no-op copy assignment to make assignment a compile error, which its `const std::vector&` member already does.

# Screenshots/Recordings/Graphs

No visual change.

## Tests

No new tests. These removals leave the same memberwise copy, except in `CaliPresetInfo`, where the implicit operator copies the member the hand-written one missed.

Removing a copy constructor also gives the type an implicit move constructor. To check nothing relied on the copy, I deleted the move members and rebuilt, which turns every site that would newly move into a compile error. All of them are assignments from a temporary, `return costs;` on a local, or `std::vector` reallocation and `erase`. Nothing moves from an object read afterwards. `Point`, `Point3` and `DrainHole` hold only fixed-size Eigen vectors and scalars, whose move is a memberwise copy.

Windows clang-cl build clean, 612 unit tests passing. The three categories go to zero and no other category moved.

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
