### PR TITLE
AMS filament selection: select visible and instantiated filaments

### DIFF
--- a/src/slic3r/GUI/AMSMaterialsSetting.cpp
+++ b/src/slic3r/GUI/AMSMaterialsSetting.cpp
@@ -984,6 +984,10 @@ void AMSMaterialsSetting::Popup(wxString filament, wxString sn, wxString temp_mi
             if (alias.empty())
                 continue;
 
+	    if (! filament_it->is_compatible || ! filament_it->is_visible) {
+		continue;
+	    }
+
             filament_items.push_back(alias);
             _collect_filament_info(alias, *filament_it, query_filament_vendors, query_filament_types);
 


### PR DESCRIPTION
In the AMS Material Selection dialog, the filaments are currently filtered in a very non-sensible way.

The current code selects the filaments which contain a non-empty "compatible_printers" list and for which you have installed one or more of the printers listed in the "compatible_printers" list.  It doesn't check whether the current printer is compatible and doesn't include any filament that is valid for all printers.  Furthermore, it includes filaments that you have installed but are available as part of the system presets.

Changing the logic to just show filaments that are marked as is_visible was an improvement but had a tendency to then prefer the @base version of the filament over all others.

To fix this, I added an is_instantiation flag to the Preset and then use that to only select filaments that are visible and have been instantiated.

Selecting the filaments that are currently visible and instantiated gives a much more sensible list of filaments!

# Description

<!--
> Please provide a summary of the changes made in this PR. Include details such as:
  > * What issue does this PR address or fix?
  > * What new features or enhancements does this PR introduce?
  > * Are there any breaking changes or dependencies that need to be considered?
-->

# Screenshots/Recordings/Graphs

<!--
> Please attach relevant screenshots to showcase the UI changes.
> Please attach images that can help explain the changes.
-->

## Tests

<!--
> Please describe the tests that you have conducted to verify the changes made in this PR.
-->

<!--
> A guide for users on how to download the artifacts from this PR.
-->

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
