### PR TITLE
Fix nozzle type undo and unsaved changes tracking

### DIFF
--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -5130,7 +5130,7 @@ void TabPrinter::build_fff()
         optgroup->append_single_option_line("adaptive_bed_mesh_margin", "printer_basic_information_adaptive_bed_mesh#mesh-margin");
 
         optgroup = page->new_optgroup(L("Accessory"), "param_accessory");
-        optgroup->append_single_option_line("nozzle_type", "printer_basic_information_accessory#nozzle-type");
+        optgroup->append_single_option_line("nozzle_type", "printer_basic_information_accessory#nozzle-type", 0);
         optgroup->append_single_option_line("nozzle_hrc", "printer_basic_information_accessory#nozzle-hrc");
         optgroup->append_single_option_line("auxiliary_fan", "printer_basic_information_accessory#auxiliary-part-cooling-fan");
         optgroup->append_single_option_line("fan_direction");


### PR DESCRIPTION
## Description

This PR fixes change tracking for **Nozzle type** in the printer's **Basic information** page.

Changing **Nozzle type** was correctly marking the printer preset as modified, but the change was not associated with the visible setting itself.

As a result:

* the undo icon was not shown next to **Nozzle type**
* reverting the preset did not immediately update the displayed value
* **Nozzle type** was missing from the dialog shown when transferring or discarding preset changes

## Applied fix

Associate **Nozzle type** with the first nozzle entry, consistent with the other nozzle-specific settings.

This allows the existing preset change tracking to correctly identify and handle the modified field.

## Testing

Verified that after changing **Nozzle type**:

* the field-level undo icon is displayed
* undoing the change restores the previous value
* the setting appears in the transfer/discard changes dialog

## Screenshots

|Before|After|
|---|---|
|<img width="1250" height="1009" alt="image" src="https://github.com/user-attachments/assets/0a634d9e-13b8-4f74-88cb-fcadefb7829d" />|<img width="1249" height="1008" alt="image" src="https://github.com/user-attachments/assets/158a36ea-a2cf-4809-8bd2-09b76008f3da" />|
|<img width="898" height="930" alt="image" src="https://github.com/user-attachments/assets/5076991f-e9f9-4fe4-a962-7113ef04bf64" />|<img width="893" height="930" alt="image" src="https://github.com/user-attachments/assets/3645a16f-09fa-4b60-87d5-54cae2f68111" />|
---

<!--
> A guide for users on how to download the artifacts from this PR.
-->

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
