### PR TITLE
Verify Exact Wipe Tower Footprint at Generation Time

### DIFF
--- a/src/dev-utils/OrcaSlicer_profile_validator.cpp
+++ b/src/dev-utils/OrcaSlicer_profile_validator.cpp
@@ -8,7 +8,11 @@
 #define NANOSVGRAST_IMPLEMENTATION
 #include "nanosvg/nanosvgrast.h"
 
+#include "libslic3r/BoundingBox.hpp"
 #include "libslic3r/GCode.hpp"
+#include "libslic3r/GCode/WipeTower.hpp"
+#include "libslic3r/GCode/WipeTowerEstimate.hpp"
+#include "libslic3r/Geometry.hpp"
 #include "libslic3r/Preset.hpp"
 #include "libslic3r/Config.hpp"
 #include "libslic3r/PresetBundle.hpp"
@@ -116,15 +120,45 @@ Vec2d printable_area_center(const DynamicPrintConfig &cfg)
     return 0.5 * (lo + hi);
 }
 
+// Put the prime tower where the GUI and CLI would before slicing. The config default (x 15, y 220)
+// lies off any bed shallower than the tower, and generation rejects an off-plate tower instead of
+// exporting it. Beside the centred cube, clear of the edge exclusion strips some beds carry, then
+// pulled inside the printable outline by the tower's own estimated footprint, with a few mm of
+// clearance so the conflict checker never sees the two touch.
+void place_wipe_tower(DynamicPrintConfig &cfg, const Vec2d &center)
+{
+    const auto *area = cfg.option<ConfigOptionPoints>("printable_area");
+    if (area == nullptr || area->values.size() < 3)
+        return;
+    const WipeTowerFootprint footprint = estimate_wipe_tower_footprint(cfg, resolve_wipe_tower_type(cfg), {0, 1}, cfg.opt_float("layer_height"), 10.);
+    if (footprint.depth < EPSILON)
+        return;
+    const double margin = WIPE_TOWER_MARGIN + footprint.brim_width;
+    // The position is the tower's own origin; a rotated tower extends from it in another
+    // direction, so place the rotated box's extents rather than the origin.
+    Slic3r::Polygon box({Point::new_scale(0., 0.), Point::new_scale(footprint.width, 0.), Point::new_scale(footprint.width, footprint.depth), Point::new_scale(0., footprint.depth)});
+    box.rotate(Geometry::deg2rad(cfg.opt_float("wipe_tower_rotation_angle")));
+    const BoundingBox local = get_extents(box);
+    const Vec2d       lo    = unscale(local.min);
+    const Vec2d       size  = unscale(local.max) - lo;
+    Vec2d             pos(center.x() + 5. + margin + 5. - lo.x(), center.y() - size.y() / 2. - lo.y());
+    box.translate(Point::new_scale(pos.x(), pos.y()));
+    const Vec2f move = WipeTower::move_box_inside_polygon(get_extents(box), Polygons{Polygon::new_scale(area->values)}, scaled<coord_t>(margin));
+    pos += move.cast<double>();
+    cfg.option<ConfigOptionFloats>("wipe_tower_x", true)->values = {pos.x()};
+    cfg.option<ConfigOptionFloats>("wipe_tower_y", true)->values = {pos.y()};
+}
+
 // Slice one centered cube that switches from filament 1 to filament 2 partway up, so exactly one
 // filament change fires, then export. The change drives the printer's own change_filament_gcode: on a
 // single-nozzle machine it rides the AMS prime tower (append_tcr), on a multi-nozzle machine it routes
 // through the nozzle swap (set_extruder / append_tcr2) - the engine picks the path from the printer's
 // topology, so one model covers both. An undefined placeholder in any shipped custom g-code throws
 // Slic3r::PlaceholderParserError from export.
-std::string slice_two_color_cube_and_export(const DynamicPrintConfig &cfg, bool is_bbl)
+std::string slice_two_color_cube_and_export(DynamicPrintConfig cfg, bool is_bbl)
 {
     const Vec2d center = printable_area_center(cfg);
+    place_wipe_tower(cfg, center);
     TriangleMesh m = make_cube(10, 10, 10);
     m.translate(float(center.x() - 5.), float(center.y() - 5.), 0.f);
 

--- a/src/libslic3r/GCode/WipeTowerEstimate.cpp
+++ b/src/libslic3r/GCode/WipeTowerEstimate.cpp
@@ -37,6 +37,17 @@ WipeTowerType resolve_wipe_tower_type(const ConfigBase &config)
     return type != nullptr ? WipeTowerType(type->getInt()) : WipeTowerType::Type2;
 }
 
+Polygon estimate_wipe_tower_first_layer_outline(const ConfigBase &config, WipeTowerType tower_type, double width, double depth, double height)
+{
+    // Type1 ignores the cone option. The wall type is read by value: a preset-shaped config
+    // holds it as ConfigOptionEnumGeneric, which a cast to ConfigOptionEnum<T> cannot see.
+    const ConfigOption *wall_type  = option_of(config, "wipe_tower_wall_type");
+    const ConfigOption *cone_angle = option_of(config, "wipe_tower_cone_angle");
+    const bool          cone       = tower_type == WipeTowerType::Type2 && wall_type != nullptr &&
+                         wall_type->getInt() == int(WipeTowerWallType::wtwCone) && cone_angle != nullptr;
+    return WipeTower2::cone_base_polygon(width, depth, height, cone ? cone_angle->getFloat() : 0.);
+}
+
 WipeTowerFootprint estimate_wipe_tower_footprint(const ConfigBase &config, WipeTowerType tower_type, const std::vector<unsigned int> &filament_ids, double layer_height, double max_object_height)
 {
     WipeTowerFootprint footprint;

--- a/src/libslic3r/GCode/WipeTowerEstimate.hpp
+++ b/src/libslic3r/GCode/WipeTowerEstimate.hpp
@@ -2,6 +2,8 @@
 
 #include <vector>
 
+#include "../Polygon.hpp"
+
 namespace Slic3r {
 
 class ConfigBase;
@@ -22,6 +24,12 @@ struct WipeTowerFootprint
 // wipe_tower_type. The rule Print::wipe_tower_type() and the CLI apply, read off the config so
 // the GUI and CLI placement can resolve it without a Print.
 WipeTowerType resolve_wipe_tower_type(const ConfigBase &config);
+
+// First-layer outline of an estimated tower in tower-local scaled coordinates, brim excluded:
+// the body box, or for a Type2 cone wall the box unioned with the cone's base. The preview,
+// the placement margin and validation all take the outline from here so they cannot disagree
+// about whether a cone exists.
+Polygon estimate_wipe_tower_first_layer_outline(const ConfigBase &config, WipeTowerType tower_type, double width, double depth, double height);
 
 // filament_ids:  0-based filaments purged on the plate. The config cannot see custom G-code tool
 //                changes, so ids derived from the model must include them

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -1078,15 +1078,12 @@ static StringObjectException layered_print_cleareance_valid(const Print &print, 
                                          convex_hulls_temp;
     Polygons tower_polys_estimated;
     if (!exact_footprint && !convex_hulls_temp.empty()) {
-        Polygon base = convex_hulls_temp.front();
-        if (config.wipe_tower_wall_type.value == WipeTowerWallType::wtwCone && print.wipe_tower_type() == WipeTowerType::Type2) {
-            double max_height = 0.;
-            for (const PrintObject *object : print.objects())
-                max_height = std::max(max_height, unscale_(object->size().z()));
-            base = WipeTower2::cone_base_polygon(width, depth, max_height, config.wipe_tower_cone_angle.value);
-            base.rotate(Geometry::deg2rad(a));
-            base.translate(Point(scale_(x), scale_(y)));
-        }
+        double max_height = 0.;
+        for (const PrintObject *object : print.objects())
+            max_height = std::max(max_height, unscale_(object->size().z()));
+        Polygon base = estimate_wipe_tower_first_layer_outline(config, print.wipe_tower_type(), width, depth, max_height);
+        base.rotate(Geometry::deg2rad(a));
+        base.translate(Point(scale_(x), scale_(y)));
         tower_polys_estimated = offset(base, float(scale_(brim_width)));
     }
     // Object proximity stays a body-only warning: brim near-misses would newly warn on

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -1068,33 +1068,57 @@ static StringObjectException layered_print_cleareance_valid(const Print &print, 
             convex_hulls_temp.push_back(wipe_tower_polygon);
         }
     }
+    // Post-generation the mesh bottom already carries the brim. Pre-generation the body grows
+    // by the brim only when its width is explicit; the auto brim and a Type2 cone base depend on
+    // the tower height, exact only once generated, so they only warn here - the exact footprint
+    // is re-checked in _make_wipe_tower.
+    const bool exact_footprint     = print.is_step_done(psWipeTower);
+    Polygons   tower_polys_checked = (!exact_footprint && config.prime_tower_brim_width.value >= 0) ?
+                                         offset(convex_hulls_temp, float(scale_(brim_width))) :
+                                         convex_hulls_temp;
+    Polygons tower_polys_estimated;
+    if (!exact_footprint && !convex_hulls_temp.empty()) {
+        Polygon base = convex_hulls_temp.front();
+        if (config.wipe_tower_wall_type.value == WipeTowerWallType::wtwCone && print.wipe_tower_type() == WipeTowerType::Type2) {
+            double max_height = 0.;
+            for (const PrintObject *object : print.objects())
+                max_height = std::max(max_height, unscale_(object->size().z()));
+            base = WipeTower2::cone_base_polygon(width, depth, max_height, config.wipe_tower_cone_angle.value);
+            base.rotate(Geometry::deg2rad(a));
+            base.translate(Point(scale_(x), scale_(y)));
+        }
+        tower_polys_estimated = offset(base, float(scale_(brim_width)));
+    }
+    // Object proximity stays a body-only warning: brim near-misses would newly warn on
+    // many setups that print fine.
     if (!intersection(convex_hulls_other, convex_hulls_temp).empty()) {
         if (warning) {
             warning->string += L("Prime Tower") + L(" is too close to others, and collisions may be caused.\n");
         }
     }
-    if (!intersection(exclude_polys, convex_hulls_temp).empty()) {
-        /*if (warning) {
-            warning->string += L("Prime Tower is too close to exclusion area, there may be collisions when printing.\n");
-        }*/
+    if (!intersection(exclude_polys, tower_polys_checked).empty()) {
         return {L("Prime Tower") + L(" is too close to an exclusion area, and collisions will be caused.\n")};
     }
-    if (print_config.enable_wrapping_detection.value && !intersection({wrapping_poly}, convex_hulls_temp).empty()) {
+    if (print_config.enable_wrapping_detection.value && !intersection({wrapping_poly}, tower_polys_checked).empty()) {
         return {L("Prime Tower") + L(" is too close to clumping detection area, and collisions will be caused.\n")};
     }
-    // No gate on "is there a tower": one that is not printed estimates to zero, so the hull
-    // is degenerate and every check passes. Re-deriving it here missed the wrapping-detection
+    if (warning && !intersection(exclude_polys, tower_polys_estimated).empty()) {
+        warning->string += L("Prime Tower") + L(" is too close to exclusion area, there may be collisions when printing.") + "\n";
+    }
+    if (warning && print_config.enable_wrapping_detection.value && !intersection({wrapping_poly}, tower_polys_estimated).empty()) {
+        warning->string += L("Prime Tower") + L(" is too close to clumping detection area, there may be collisions when printing.") + "\n";
+    }
+    // No gate on "is there a tower": one that is not printed estimates to zero, so the hulls
+    // are degenerate and every check passes. Re-deriving it here missed the wrapping-detection
     // tower on a single-filament plate.
-    // Pre-generation, grow the body by the brim to match what the generator draws;
-    // post-generation the mesh already includes it.
     Polygons    printable_polys = print.get_extruder_shared_printable_polygon();
     const Point plate_shift(scale_(plate_origin.x()), scale_(plate_origin.y()));
     for (Polygon &p : printable_polys)
         p.translate(plate_shift);
-    Polygons tower_polys_with_brim = print.is_step_done(psWipeTower) ?
-        convex_hulls_temp : offset(convex_hulls_temp, float(scale_(brim_width)));
-    if (!diff(tower_polys_with_brim, printable_polys).empty())
+    if (!diff(tower_polys_checked, printable_polys).empty())
         return {L("Prime Tower") + L(" is partially outside the printable area, and it cannot be printed.\n")};
+    if (warning && !diff(tower_polys_estimated, printable_polys).empty())
+        warning->string += L("Prime Tower") + L(" is partially outside the printable area, and it cannot be printed.\n");
     return {};
 }
 
@@ -4390,7 +4414,9 @@ void Print::_make_wipe_tower()
                                          wipe_tower.get_wipe_tower_height(), wipe_tower.get_brim_width(),
                                          config().wipe_tower_wall_type.value == WipeTowerWallType::wtwRib,
                                          wipe_tower.get_rib_width(), wipe_tower.get_rib_length(),
-                                         config().wipe_tower_fillet_wall.value);
+                                         config().wipe_tower_fillet_wall.value,
+                                         config().wipe_tower_wall_type.value == WipeTowerWallType::wtwCone ?
+                                             (float) config().wipe_tower_cone_angle.value : 0.f);
         const Vec3d origin                      = Vec3d::Zero();
         // FakeWipeTower::pos is a bed-frame translation applied after rotation
         // (getFakeExtrusionPathsFromWipeTower2 rotates about the local origin), so the
@@ -4402,6 +4428,28 @@ void Print::_make_wipe_tower()
                                                   m_wipe_tower_data.z_and_depth_pairs, m_wipe_tower_data.brim_width,
                                                   config().wipe_tower_rotation_angle, config().wipe_tower_cone_angle,
                                                   {scale_(origin.x()), scale_(origin.y())});
+    }
+
+    // The clamps and checks above work from estimates; re-test the exact generated footprint
+    // so an off-plate tower fails with a clear error instead of exporting unprintable G-code
+    // (validate() only sees the mesh on its next run).
+    if (m_wipe_tower_data.wipe_tower_mesh_data) {
+        Polygon footprint = m_wipe_tower_data.wipe_tower_mesh_data->bottom; // includes brim and rib offset
+        footprint.rotate(Geometry::deg2rad(m_config.wipe_tower_rotation_angle.value));
+        footprint.translate(Point(scale_(m_config.wipe_tower_x.get_at(m_plate_index)),
+                                  scale_(m_config.wipe_tower_y.get_at(m_plate_index))));
+        const Polygons printable_polys = this->get_extruder_shared_printable_polygon();
+        if (!printable_polys.empty() && !diff(Polygons{footprint}, printable_polys).empty()) {
+            const BoundingBox fp = get_extents(footprint);
+            const BoundingBox pr = get_extents(printable_polys);
+            BOOST_LOG_TRIVIAL(error) << boost::format("wipe tower footprint [%1%,%2%]-[%3%,%4%] leaves printable [%5%,%6%]-[%7%,%8%]") %
+                unscaled(fp.min.x()) % unscaled(fp.min.y()) % unscaled(fp.max.x()) % unscaled(fp.max.y()) %
+                unscaled(pr.min.x()) % unscaled(pr.min.y()) % unscaled(pr.max.x()) % unscaled(pr.max.y());
+            throw Slic3r::SlicingError(L("Prime Tower") + L(" is partially outside the printable area, and it cannot be printed.\n"));
+        }
+        // The cutter/purge corner is a physical obstacle — the brim must stay out like the body.
+        if (!intersection(get_bed_excluded_area(m_config), Polygons{footprint}).empty())
+            throw Slic3r::SlicingError(L("Prime Tower") + L(" is too close to an exclusion area, and collisions will be caused.\n"));
     }
 }
 
@@ -5951,12 +5999,21 @@ ExtrusionLayers FakeWipeTower::getTrueExtrusionLayersFromWipeTower() const
     }
     return wtels;
 }
-void WipeTowerData::construct_mesh(float width, float depth, float height, float brim_width, bool is_rib_wipe_tower, float rib_width, float rib_length,bool fillet_wall)
+void WipeTowerData::construct_mesh(float width, float depth, float height, float brim_width, bool is_rib_wipe_tower, float rib_width, float rib_length,bool fillet_wall, float cone_angle)
 {
     wipe_tower_mesh_data = WipeTowerMeshData{};
     float first_layer_height=0.08; //brim height
     if (width < EPSILON || depth < EPSILON || height < EPSILON) return;
-    if (!is_rib_wipe_tower || rib_length < EPSILON) {
+    if (cone_angle > EPSILON && (!is_rib_wipe_tower || rib_length < EPSILON)) {
+        // Cone tower: the base bulges past the body box; this bottom polygon feeds the
+        // containment checks, so it must carry the bulge and the brim (cone not lofted).
+        wipe_tower_mesh_data->real_wipe_tower_mesh = make_cube(width, depth, height);
+        wipe_tower_mesh_data->bottom               = WipeTower2::cone_base_polygon(width, depth, height, cone_angle);
+        auto brim_bottom                           = offset(wipe_tower_mesh_data->bottom, scaled(brim_width));
+        if (!brim_bottom.empty())
+            wipe_tower_mesh_data->bottom = brim_bottom.front();
+        wipe_tower_mesh_data->real_brim_mesh = WipeTower::its_make_rib_brim(wipe_tower_mesh_data->bottom, first_layer_height);
+    } else if (!is_rib_wipe_tower || rib_length < EPSILON) {
         wipe_tower_mesh_data->real_wipe_tower_mesh = make_cube(width, depth, height);
         wipe_tower_mesh_data->real_brim_mesh       = make_cube(width + 2 * brim_width, depth + 2 * brim_width, first_layer_height);
         wipe_tower_mesh_data->real_brim_mesh.translate({-brim_width, -brim_width, 0});

--- a/src/libslic3r/Print.hpp
+++ b/src/libslic3r/Print.hpp
@@ -804,7 +804,7 @@ struct WipeTowerData
         rib_offset = Vec2f::Zero();
         wipe_tower_mesh_data  = std::nullopt;
     }
-    void construct_mesh(float width, float depth, float height, float brim_width, bool is_rib_wipe_tower, float rib_width, float rib_length, bool fillet_wall);
+    void construct_mesh(float width, float depth, float height, float brim_width, bool is_rib_wipe_tower, float rib_width, float rib_length, bool fillet_wall, float cone_angle = 0.f);
 
 private:
 	// Only allow the WipeTowerData to be instantiated internally by Print, 

--- a/src/slic3r/GUI/3DScene.cpp
+++ b/src/slic3r/GUI/3DScene.cpp
@@ -21,7 +21,6 @@
 #include "libslic3r/PresetBundle.hpp"
 #include "libslic3r/ClipperUtils.hpp"
 #include "libslic3r/GCode/WipeTower.hpp"
-#include "libslic3r/GCode/WipeTower2.hpp"
 #include "libslic3r/GCode/WipeTowerEstimate.hpp"
 #include "libslic3r/Tesselate.hpp"
 #include "libslic3r/PrintConfig.hpp"
@@ -928,25 +927,13 @@ int GLVolumeCollection::load_wipe_tower_preview(
     const float  brim_height = 0.2f; // one first layer, visual only
     TriangleMesh brim_slab;
     if (show_brim) {
-        // A Type2 cone-wall tower's base bulges past the body box — follow the real base
-        // outline instead of the rectangle. Type1 ignores the cone option.
-        Polygon cone_base;
-        {
-            // Preset enums are ConfigOptionEnumGeneric, so read them by value; the planner is
-            // resolved as the estimate resolves it, off the printer preset.
-            const DynamicPrintConfig &print_cfg   = GUI::wxGetApp().preset_bundle->prints.get_edited_preset().config;
-            const DynamicPrintConfig &printer_cfg = GUI::wxGetApp().preset_bundle->printers.get_edited_preset().config;
-            const ConfigOption       *wall_opt    = print_cfg.option("wipe_tower_wall_type");
-            if (wall_opt != nullptr && wall_opt->getInt() == int(WipeTowerWallType::wtwCone) && resolve_wipe_tower_type(printer_cfg) == WipeTowerType::Type2)
-                cone_base = WipeTower2::cone_base_polygon(width, depth, height, print_cfg.opt_float("wipe_tower_cone_angle"));
-        }
-        if (!cone_base.empty()) {
-            Polygons brim_outline = offset(cone_base, scaled(brim_width));
-            brim_slab = WipeTower::its_make_rib_brim(brim_outline.empty() ? cone_base : brim_outline.front(), brim_height);
-        } else {
-            brim_slab = make_cube(width + 2.f * brim_width, depth + 2.f * brim_width, brim_height);
-            brim_slab.translate({-brim_width, -brim_width, 0.f});
-        }
+        // The brim follows the real first-layer outline: a Type2 cone-wall tower's base bulges
+        // past the body box. The wall type and angle are print settings, the planner a printer one.
+        const DynamicPrintConfig &print_cfg   = GUI::wxGetApp().preset_bundle->prints.get_edited_preset().config;
+        const DynamicPrintConfig &printer_cfg = GUI::wxGetApp().preset_bundle->printers.get_edited_preset().config;
+        const Polygon  outline      = estimate_wipe_tower_first_layer_outline(print_cfg, resolve_wipe_tower_type(printer_cfg), width, depth, height);
+        const Polygons brim_outline = offset(outline, scaled(brim_width));
+        brim_slab                   = WipeTower::its_make_rib_brim(brim_outline.empty() ? outline : brim_outline.front(), brim_height);
         wipe_tower_shell.merge(brim_slab);
     }
     for (int extruder_id : plate_extruders) {

--- a/src/slic3r/GUI/PartPlate.cpp
+++ b/src/slic3r/GUI/PartPlate.cpp
@@ -22,7 +22,6 @@
 #include "libslic3r/libslic3r.h"
 #include "libslic3r/Polygon.hpp"
 #include "libslic3r/GCode/WipeTowerEstimate.hpp"
-#include "libslic3r/GCode/WipeTower2.hpp"
 #include "libslic3r/ClipperUtils.hpp"
 #include "libslic3r/BoundingBox.hpp"
 #include "libslic3r/Geometry.hpp"
@@ -2398,14 +2397,9 @@ arrangement::ArrangePolygon PartPlate::estimate_wipe_tower_polygon(const Dynamic
 	// clamp put the brim off the bed. Matches set_default_wipe_tower_pos_for_plate.
 	float wp_brim_width = float(footprint.brim_width);
 	// A Type2 stabilization cone bulges past the body box like a brim does - fold its worst-axis
-	// bulge into the same margin (Type1 ignores the cone option).
-	const auto *cone_wall_opt  = config.option("wipe_tower_wall_type");
-	const auto *cone_angle_opt = config.option("wipe_tower_cone_angle");
-	if (cone_wall_opt != nullptr && cone_wall_opt->getInt() == int(WipeTowerWallType::wtwCone) && cone_angle_opt != nullptr &&
-	    cone_angle_opt->getFloat() > EPSILON && resolve_wipe_tower_type(config) == WipeTowerType::Type2) {
-		const BoundingBox cb = get_extents(WipeTower2::cone_base_polygon(w, depth, wt_size.z(), cone_angle_opt->getFloat()));
-		wp_brim_width += float(std::max({0., unscaled(cb.max.x()) - w, unscaled(cb.max.y()) - depth, -unscaled(cb.min.x()), -unscaled(cb.min.y())}));
-	}
+	// bulge into the same margin.
+	const BoundingBox outline = get_extents(estimate_wipe_tower_first_layer_outline(config, resolve_wipe_tower_type(config), w, depth, wt_size.z()));
+	wp_brim_width += float(std::max({0., unscaled(outline.max.x()) - w, unscaled(outline.max.y()) - depth, -unscaled(outline.min.x()), -unscaled(outline.min.y())}));
 	// A position valid by WIPE_TOWER_MARGIN is the user's choice and stays untouched; an
 	// invalid one is re-placed with the comfort margin (falling back to the validity bounds
 	// on cramped plates). std::clamp is UB if lo > hi, so keep every hi >= lo.

--- a/tests/fff_print/test_gcodewriter.cpp
+++ b/tests/fff_print/test_gcodewriter.cpp
@@ -574,6 +574,9 @@ static DynamicPrintConfig dual_extruder_toolchange_config()
     config.set_key_value("nozzle_temperature_range_high", new ConfigOptionInts({240, 240}));
     config.set_key_value("flush_multiplier",     new ConfigOptionFloats({1}));
     config.set_key_value("flush_volumes_matrix", new ConfigOptionFloats({0, 140, 140, 0}));
+    // Inside the 200x200 test bed; the default y, 220, is not, and generation rejects that.
+    config.set_key_value("wipe_tower_x",         new ConfigOptionFloats({50.}));
+    config.set_key_value("wipe_tower_y",         new ConfigOptionFloats({50.}));
     return config;
 }
 

--- a/tests/fff_print/test_wipe_tower.cpp
+++ b/tests/fff_print/test_wipe_tower.cpp
@@ -152,6 +152,8 @@ static DynamicPrintConfig wipe_tower_toolchange_config(const std::string &gcode_
         { "outer_wall_filament_id",     2 },
         { "inner_wall_filament_id",     2 },
         { "enable_prime_tower",         true },
+        { "wipe_tower_x",               50 }, // inside the 200x200 test bed
+        { "wipe_tower_y",               50 }, // (the default y, 220, is not)
         { "layer_height",               0.3 },
         { "gcode_flavor",               gcode_flavor },
     });

--- a/tests/libslic3r/test_wipe_tower_estimate.cpp
+++ b/tests/libslic3r/test_wipe_tower_estimate.cpp
@@ -1,5 +1,7 @@
 #include <catch2/catch_all.hpp>
 
+#include "libslic3r/BoundingBox.hpp"
+#include "libslic3r/ClipperUtils.hpp"
 #include "libslic3r/GCode/WipeTower.hpp"
 #include "libslic3r/GCode/WipeTower2.hpp"
 #include "libslic3r/GCode/WipeTowerEstimate.hpp"
@@ -270,6 +272,33 @@ TEST_CASE("Every wall and tower type is read the same from a preset and a static
     static_config.apply(preset, true);
     CHECK(estimate(preset, 1, 0.2, 5., type).depth > 0.);
     CHECK(estimate(static_config, 1, 0.2, 5., type).depth > 0.);
+}
+
+TEST_CASE("The first-layer outline bulges only for a Type2 cone wall", "[WipeTowerEstimate]") {
+    // Read off a preset-shaped config, whose enums are ConfigOptionEnumGeneric: a cast to
+    // ConfigOptionEnum<T> sees no wall type there and would never find the cone.
+    DynamicPrintConfig config = make_config("cone");
+    config.set_key_value("wipe_tower_cone_angle", new ConfigOptionFloat(25.));
+    REQUIRE(dynamic_cast<const ConfigOptionEnumGeneric *>(config.option("wipe_tower_wall_type")) != nullptr);
+    const Polygon box = Polygon::new_scale({{0., 0.}, {35., 0.}, {35., 20.}, {0., 20.}});
+    auto is_box = [&box](const Polygon &outline) { return diff(Polygons{outline}, Polygons{box}).empty(); };
+
+    // A 25-degree cone on a 100 mm tower has a 22 mm base radius, past the 10 mm half-depth.
+    const Polygon cone = estimate_wipe_tower_first_layer_outline(config, WipeTowerType::Type2, 35., 20., 100.);
+    CHECK(unscaled(get_extents(cone).max.y()) > 20. + 1.);
+    CHECK(diff(Polygons{box}, Polygons{cone}).empty());
+    // Type1 ignores the cone option, and the other wall types have no cone.
+    CHECK(is_box(estimate_wipe_tower_first_layer_outline(config, WipeTowerType::Type1, 35., 20., 100.)));
+    for (const char *wall_type : {"rectangle", "rib"}) {
+        config.set_deserialize_strict("wipe_tower_wall_type", wall_type);
+        CHECK(is_box(estimate_wipe_tower_first_layer_outline(config, WipeTowerType::Type2, 35., 20., 100.)));
+    }
+    // The static config Print holds gives the same outline.
+    config.set_deserialize_strict("wipe_tower_wall_type", "cone");
+    FullPrintConfig static_config;
+    static_config.apply(config, true);
+    const Polygon from_static = estimate_wipe_tower_first_layer_outline(static_config, WipeTowerType::Type2, 35., 20., 100.);
+    CHECK(from_static.points == cone.points);
 }
 
 TEST_CASE("A Bambu Lab printer always gets the Type1 planner", "[WipeTowerEstimate]") {


### PR DESCRIPTION
# Description

**Depends on #15516 (wipe tower footprint estimate), itself based on #15532.**

Today a wipe tower that outgrows its estimate can slice "successfully" with the tower or its brim off the plate or over the bed exclusion zone. Two real cases measured on stock builds:

* A stored near-edge position sliced to a G-code file extruding to y=258.95 on a 256 mm plate — the CLI reported the misleading "unprintable area of multi-extruder printers" error *after* writing the file; the GUI reported nothing at all.
* A tower whose body cleared the cutter-corner exclusion zone but whose brim reached into it sliced to plain "Success" — no check anywhere considers the brim against exclusion zones.

This PR makes the exact generated footprint the last word:

* **Generation-time backstop** in `Print::_make_wipe_tower`: after generation, the mesh-bottom footprint (brim and rib offset included) is tested against the shared printable polygon and the bed exclusion areas; failure throws a clear `SlicingError` immediately, with a diagnostic log line stating the offending footprint vs the printable box. No configuration can silently export an off-plate tower anymore — this also guards any future estimator drift.
* **Pre-generation validation** (`layered_print_cleareance_valid`) checks one brim-aware footprint against containment, exclusion zones, and the wrapping-detection area. An explicit brim width makes the pre-slice footprint exact (hard error). The auto brim and a Type2 cone base depend on the tower height, exact only once generated, so they **warn** with the existing "may collide" strings and leave the verdict to the backstop — the user hears about a marginal position on the first slice instead of only at generation time.
* `construct_mesh` grew a cone branch so a cone-wall tower's bottom polygon carries the base bulge and brim — arming both checks for cone towers, whose base previously escaped every check.
* **The profile validator places the tower before slicing** (second commit). It forces a two-filament print with the prime tower on and sliced it at the config default position (x 15, y 220), off any bed shallower than the tower; it calls `validate()` but slices regardless, so the off-plate tower was exported silently. With the backstop, 522 of 1013 presets failed the CI slice check. The validator now positions the tower beside the centred cube, by the rotated extents of its own estimated footprint and pulled inside the printable outline, the way the GUI and CLI do.

Breaking/behavior note: prints that previously "succeeded" while physically printing off the plate or into the exclusion zone now fail with a clear message (or are auto-repositioned by the GUI clamp before it comes to that). Object-vs-tower proximity intentionally stays a body-only warning. All messages reuse existing translated strings — no msgid changes.

# Screenshots/Recordings/Graphs


## Tests

* Before/after on the same project files: brim-over-exclusion position — stock build exit 0 with the brim extruded over the cutter zone; this branch rejects early with "Prime Tower is too close to an exclusion area" and writes nothing. Near-edge position — stock build -102 *after* writing off-plate G-code; this branch rejects at validate.
* Boundary check: a position 0.5 mm further from the exclusion zone (real brim just clearing it) slices to exit 0 — the rejection boundary sits exactly at the printed brim edge.
* Auto-brim warning seen in the CLI log (`got warnings: Prime Tower is too close to exclusion area, there may be collisions when printing.`) before the backstop rejects.
* Profile validator (`-s`, the CI slice check) over all 1013 printer presets with the placement fix: the 522 default-position failures are gone. The one remaining failure is a profile typo, not the slicer: `Folgertech i3 0.6 nozzle` declares its bed as `0x0, 20x0, 200x200, 0x200` (a triangle), fixed separately. One `gcode path conflicts` log line remains for the Volumic EXO42 mirror-mode profile, where the mirrored head duplicates the tower onto the cube; it is logged, not a failure.
* Two fff_print fixtures that printed a tower at the default position move it onto the 200 mm test bed, as the multifilament fixtures already do: the shipped default y of 220 is off that bed, and the backstop now says so instead of exporting the tower. Suites: libslic3r 351/351, fff_print 153/153.

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
