### PR TITLE
[CLI] Place Wipe Tower before Slicing

### DIFF
--- a/src/OrcaSlicer.cpp
+++ b/src/OrcaSlicer.cpp
@@ -4754,7 +4754,10 @@ int CLI::run(int argc, char **argv)
                     int plate_count = partplate_list.get_plate_count();
 
                     auto printer_structure_opt = m_print_config.option<ConfigOptionEnum<PrinterStructure>>("printer_structure");
-                    const float tower_brim_width = m_print_config.option<ConfigOptionFloat>("prime_tower_width", true)->value;
+                    // This margin only pre-adjusts the default away from the near edges;
+                    // estimate_wipe_tower_polygon below computes the real clamped position.
+                    float tower_brim_width = m_print_config.option<ConfigOptionFloat>("prime_tower_brim_width", true)->value;
+                    if (tower_brim_width < 0.f) tower_brim_width = 8.f; // auto: object heights unknown here, 8 mm is the auto cap
                     const float tower_margin = WIPE_TOWER_MARGIN + tower_brim_width;
 
                     // set the default position, the same with print config(left top)
@@ -5051,7 +5054,10 @@ int CLI::run(int argc, char **argv)
                         int extruder_size = used_filament_set.size();
 
                         auto printer_structure_opt = m_print_config.option<ConfigOptionEnum<PrinterStructure>>("printer_structure");
-                        const float tower_brim_width      = m_print_config.option<ConfigOptionFloat>("prime_tower_width", true)->value;
+                        // This margin only pre-adjusts the default away from the near edges;
+                        // estimate_wipe_tower_polygon below computes the real clamped position.
+                        float tower_brim_width = m_print_config.option<ConfigOptionFloat>("prime_tower_brim_width", true)->value;
+                        if (tower_brim_width < 0.f) tower_brim_width = 8.f; // auto: object heights unknown here, 8 mm is the auto cap
                         const float tower_margin          = WIPE_TOWER_MARGIN + tower_brim_width;
                         // set the default position, the same with print config(left top)
                         float x = WIPE_TOWER_DEFAULT_X_POS;
@@ -5713,6 +5719,34 @@ int CLI::run(int argc, char **argv)
                 std::string outfile;
                 //Print       fff_print;
                 std::vector<size_t> plate_triangle_counts(partplate_list.get_plate_count(), 0);
+
+                // The stored (or default) tower position may not fit the tower these plates
+                // need, and no CLI placement site runs on a plain slice - mirror the GUI's
+                // reload clamp and fit every plate's tower into the printable area first.
+                if (m_print_config.option<ConfigOptionBool>("enable_prime_tower", true)->value) {
+                    for (int index = 0; index < partplate_list.get_plate_count(); index++) {
+                        if ((plate_to_slice != 0) && (plate_to_slice != (index + 1)))
+                            continue;
+                        Slic3r::GUI::PartPlate *plate = partplate_list.get_plate(index);
+                        // Printing by object disables the tower only with more than one instance.
+                        bool is_seq_print = false;
+                        get_print_sequence(plate, m_print_config, is_seq_print);
+                        if (is_seq_print && plate->printable_instance_size() > 1)
+                            continue;
+                        // An empty estimate is a plate that prints no tower (one filament and
+                        // neither smooth timelapse, wrapping detection nor a raft).
+                        Vec3d wt_pos, wt_size;
+                        plate->estimate_wipe_tower_polygon(m_print_config, index, wt_pos, wt_size);
+                        if (wt_size(0) < EPSILON || wt_size(1) < EPSILON)
+                            continue;
+                        ConfigOptionFloat wt_x_opt((float) wt_pos(0));
+                        ConfigOptionFloat wt_y_opt((float) wt_pos(1));
+                        m_print_config.option<ConfigOptionFloats>("wipe_tower_x", true)->set_at(&wt_x_opt, index, 0);
+                        m_print_config.option<ConfigOptionFloats>("wipe_tower_y", true)->set_at(&wt_y_opt, index, 0);
+                        BOOST_LOG_TRIVIAL(info) << boost::format("plate %1%: wipe tower clamped to {%2%, %3%}, size {%4%, %5%}")
+                            % (index + 1) % wt_pos(0) % wt_pos(1) % wt_size(0) % wt_size(1);
+                    }
+                }
 
                 while(!finished)
                 {


### PR DESCRIPTION
# Description

**Depends on #15516 (wipe tower footprint estimate), itself based on #15532.**

The CLI never positions the wipe tower on a plain `--slice`: all three existing placement sites live in assemble-list/arrange flows, so slicing uses the 3MF's stored position (or the bare config default) verbatim. A multi-filament project whose stored position no longer fits — e.g. saved before painting grew the tower — either exported off-plate G-code (stock builds) or failed validation, with no way to self-correct short of opening the GUI.

* **Pre-slice placement pass**: before the slicing loop, every plate about to be sliced gets its tower clamped into the printable area via `PartPlate::estimate_wipe_tower_polygon`, mirroring the GUI's reload clamp. Only plates that print no tower are skipped: by-object plates with more than one instance, and plates whose footprint estimate is empty (which covers single-filament plates without smooth timelapse, wrapping detection or a raft). Each move is logged (`plate N: wipe tower clamped to {x, y}, size {w, d}`).
* **Correct filament data for the clamp**: the estimate adapter derives the plate's filaments from the passed config (#15532's config-taking `get_extruders`), the same derivation the GUI uses, so the Type1 estimate reads each filament's prime volume and adhesiveness category under the CLI too — generic fallback volumes under-clamp (measured 25.7 mm vs the required 31.2 mm on the reference project).
* **Wrong-key margin fix**: both assemble-flow placement sites computed their margin from `prime_tower_width` (35 mm!) stored in a variable named `tower_brim_width`; they now read `prime_tower_brim_width`, with auto (−1) resolved conservatively.

Behavior note: the CLI now repositions a stored tower that does not fit, matching GUI behavior, and logs the move per plate. Exclusion-zone conflicts are deliberately *not* auto-resolved — the clamp fits the plate but will not silently relocate a tower out of the cutter zone; those still fail with a clear error.

# Screenshots/Recordings/Graphs

<!-- CLI-only change; the before/after tables below tell the story. -->

## Tests

Probe script slicing four scenario projects (bad stored rib position, no stored position, rectangle at the former clamp limit, brim reaching the exclusion corner) and checking every produced G-code with an arc-aware extents parser:

Current main build:
```
bad_pos    exit=-102       gcode=OFF-PLATE   <- bad G-code written to disk
no_pos     exit=0          gcode=on-plate
rect_edge  exit=0          gcode=on-plate
excl       exit=0          gcode=on-plate    <- brim over the cutter zone, undetected
```

This branch (with the base PRs, re-run on the rebased tip 2026-09-07):
```
bad_pos    exit=0          gcode=on-plate    <- auto-clamped, logged
no_pos     exit=0          gcode=on-plate
rect_edge  exit=0          gcode=on-plate
excl       exit=rejected   gcode=none        <- clear early exclusion error
```

Invariant asserted by the script: zero off-plate G-code files across all scenarios.

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
