### PR TITLE
Fix Detach from parent checkbox not updating visually

### DIFF
--- a/src/slic3r/GUI/SavePresetDialog.cpp
+++ b/src/slic3r/GUI/SavePresetDialog.cpp
@@ -149,7 +149,10 @@ SavePresetDialog::Item::Item(Preset::Type type, const std::string &suffix, wxBox
             // Set initial state (unchecked by default)
             detach_checkbox->SetValue(m_detach);
             // Bind the checkbox event to update the detach state for this item
-            detach_checkbox->Bind(wxEVT_TOGGLEBUTTON, [this, detach_checkbox](wxCommandEvent&) { m_detach = detach_checkbox->GetValue(); });
+            detach_checkbox->Bind(wxEVT_TOGGLEBUTTON, [this, detach_checkbox](wxCommandEvent& event) {
+                m_detach = detach_checkbox->GetValue();
+                event.Skip(); // Let CheckBox update its bitmap for the new state.
+            });
 
             detach_label->SetForegroundColour(wxColour("#363636"));
 


### PR DESCRIPTION
## Summary

Fixes the “Detach from parent” checkbox in the Save Preset dialog not visually updating when toggled.

The checkbox state was changing correctly internally, but the toggle event was not reaching the checkbox’s own handler, so its checked/unchecked appearance was not refreshed.

The event is now allowed to continue after updating the detach state, so the checkbox visual stays in sync.

<img width="673" height="476" alt="image" src="https://github.com/user-attachments/assets/c861c998-7050-425d-9575-4d09facc9373" />

---

<!--
> A guide for users on how to download the artifacts from this PR.
-->

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
