### PR TITLE
Fix organic tree support generating one less bottom interface layer than defined

### DIFF
--- a/src/libslic3r/Support/SupportCommon.cpp
+++ b/src/libslic3r/Support/SupportCommon.cpp
@@ -65,11 +65,13 @@ std::pair<SupportGeneratorLayersPtr, SupportGeneratorLayersPtr> generate_interfa
         const bool                 smooth_supports        = support_params.support_style != smsGrid;
         SupportGeneratorLayersPtr &interface_layers       = base_and_interface_layers.first;
         SupportGeneratorLayersPtr &base_interface_layers  = base_and_interface_layers.second;
-        // The user-facing interface layer counts include the contact layer. Internally,
-        // contact layers are generated separately, so only the remaining layers are
-        // projected into intermediate interface/base-interface layers here.
-        const size_t num_top_interface_layers    = support_params.has_top_contacts    ? support_params.num_top_interface_layers    - 1 : 0;
-        const size_t num_bottom_interface_layers = support_params.has_bottom_contacts ? support_params.num_bottom_interface_layers - 1 : 0;
+        // Contacts printed separately consume one requested interface layer. Organic
+        // bottom contacts are projection seeds and are not printed separately.
+        const bool organic_tree = support_params.support_style == smsTreeOrganic;
+        const size_t num_top_interface_layers         = support_params.has_top_contacts ?
+                                                        support_params.num_top_interface_layers - 1 : 0;
+        const size_t num_bottom_interface_layers      = support_params.has_bottom_contacts ?
+                                                        support_params.num_bottom_interface_layers - (organic_tree ? 0 : 1) : 0;
         const size_t num_top_base_interface_layers    = std::min(support_params.num_top_base_interface_layers,    num_top_interface_layers);
         const size_t num_bottom_base_interface_layers = std::min(support_params.num_bottom_base_interface_layers, num_bottom_interface_layers);
         const size_t num_top_interface_layers_only    = num_top_interface_layers    - num_top_base_interface_layers;

--- a/src/libslic3r/Support/TreeModelVolumes.cpp
+++ b/src/libslic3r/Support/TreeModelVolumes.cpp
@@ -32,7 +32,7 @@ namespace Slic3r::TreeSupport3D
 using namespace std::literals;
 
 // or warning
-// had to use a define beacuse the macro processing inside macro BOOST_LOG_TRIVIAL()
+// had to use a define because the macro processing inside macro BOOST_LOG_TRIVIAL()
 #define error_level_not_in_cache debug
 
 //FIXME Machine border is currently ignored.


### PR DESCRIPTION
## Description

This PR fixes organic tree support generating one fewer bottom interface layer than configured.

For **regular support** styles, the bottom contact layer **is generated separately** and therefore counts as one of the configured bottom interface layers.

Organic tree support uses the bottom contact regions **only as projection seeds** and does not print them as a separate layer. The generic interface layer calculation **still subtracted one layer**, causing the generated bottom interface count to be one lower than requested.

The fix skips this subtraction for organic tree support while preserving the existing behavior for other support styles.

## Screenshots
__Before:__
<img width="1879" height="659" alt="image" src="https://github.com/user-attachments/assets/187ab01f-09e6-4fd9-98ba-c969a91db8cc" />
<br>
__After:__
<img width="1931" height="706" alt="image" src="https://github.com/user-attachments/assets/e062a719-0466-485c-a363-a8da5c33cd26" />

---

<!--
> A guide for users on how to download the artifacts from this PR.
-->

> [!Note]
> Related issue: #15509

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
