### PR TITLE
fix: emit Layer Change G-code after the Z lift

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -36,6 +36,7 @@
 #include <string>
 #include <utility>
 #include <string_view>
+#include <sstream>
 
 #include <regex>
 #include <boost/algorithm/string.hpp>
@@ -5440,6 +5441,41 @@ std::string GCode::generate_timelapse_gcode(const Print &print, coordf_t print_z
 // In non-sequential mode, process_layer is called per each print_z height with all object and support layers accumulated.
 // For multi-material prints, this routine minimizes extruder switches by gathering extruder specific extrusion paths
 // and performing the extruder specific extrusions together.
+// Orca: does this custom G-code move the toolhead? Used to decide whether the layer change G-code
+// needs the nozzle raised in the corner cases where the queued Z lift ends up being skipped.
+// Anything not recognized as stationary counts as moving: a macro call (TIMELAPSE_TAKE_FRAME, ...)
+// is opaque here, and assuming it moves only costs a lift that a moving one would have needed
+// anyway, while assuming it does not would drag the nozzle across the layer just printed.
+static bool custom_gcode_moves_toolhead(const std::string &custom_gcode)
+{
+    std::istringstream lines(custom_gcode);
+    for (std::string line; std::getline(lines, line);) {
+        line.erase(0, line.find_first_not_of(" \t"));
+        line = line.substr(0, line.find(';'));
+        std::istringstream words(line);
+        std::string cmd;
+        if (!(words >> cmd))
+            continue; // blank or comment only
+        boost::to_upper(cmd);
+        std::string args;
+        std::getline(words, args);
+        boost::to_upper(args);
+        // Klipper setters and the G-codes that only change state, coordinates or timing
+        if (boost::starts_with(cmd, "SET_") || cmd == "G4" || cmd == "G21" || cmd == "G90" ||
+            cmd == "G91" || cmd == "G92")
+            continue;
+        // a linear move without a coordinate only changes the feedrate
+        if ((cmd == "G0" || cmd == "G1") && args.find_first_of("XYZ") == std::string::npos)
+            continue;
+        // M commands do not move, apart from the ones parking the toolhead or changing filament
+        if (cmd.size() > 1 && cmd.front() == 'M' && cmd.find_first_not_of("0123456789", 1) == std::string::npos &&
+            cmd != "M125" && cmd != "M401" && cmd != "M402" && cmd != "M600" && cmd != "M601")
+            continue;
+        return true;
+    }
+    return false;
+}
+
 LayerResult GCode::process_layer(
     const Print                    			&print,
     // Set of object & print layers of the same PrintObject and with the same print_z.
@@ -5629,9 +5665,21 @@ LayerResult GCode::process_layer(
         config.set_key_value("curr_accumulated_mass", new ConfigOptionFloat(curr_accumulated_mass));
         config.set_key_value("curr_layer_mass", new ConfigOptionFloat(curr_layer_mass));
 
-        gcode += this->placeholder_parser_process("layer_change_gcode",
+        std::string layer_change_gcode = this->placeholder_parser_process("layer_change_gcode",
             print.config().layer_change_gcode.value, m_writer.filament()->id(), &config)
             + "\n";
+        // Orca: change_layer() only queues the Z lift, it is performed by the first travel of the
+        // layer, i.e. after this G-code. Hand the G-code to the writer so it is emitted right after
+        // that lift instead, letting custom G-code that moves the toolhead (timelapse, nozzle
+        // cleaning, ...) run with the nozzle raised above the layer just printed. The lift itself
+        // stays lazy, so its type and the "no lift when the travel does not move" optimization are
+        // untouched. With no lift queued there is nothing to wait for and the G-code is emitted
+        // here, exactly as before.
+        if (m_writer.has_pending_lift()) {
+            const bool needs_clearance = custom_gcode_moves_toolhead(layer_change_gcode);
+            m_writer.queue_gcode_after_lift(std::move(layer_change_gcode), needs_clearance);
+        } else
+            gcode += layer_change_gcode;
         config.set_key_value("max_layer_z", new ConfigOptionFloat(m_max_layer_z));
     }
     //BBS: set layer time fan speed after layer change gcode
@@ -6967,6 +7015,10 @@ LayerResult GCode::process_layer(
 
         gcode += insert_timelapse_gcode();
     }
+
+    // Orca: nothing performed the queued lift during this layer (a layer without any travel), emit
+    // the deferred layer change G-code rather than carrying it over to the next layer.
+    gcode += m_writer.take_gcode_after_lift();
 
     result.gcode = std::move(gcode);
     result.cooling_buffer_flush = object_layer || raft_layer || last_layer;

--- a/src/libslic3r/GCodeWriter.cpp
+++ b/src/libslic3r/GCodeWriter.cpp
@@ -796,6 +796,23 @@ std::string GCodeWriter::lazy_lift(LiftType lift_type, bool spiral_vase)
     return "";
 }
 
+std::string GCodeWriter::take_gcode_after_lift(double skipped_lift)
+{
+    if (m_gcode_after_lift.empty())
+        return "";
+    std::string gcode;
+    // Orca: the lift this G-code was waiting for was skipped, so the nozzle is still down at print
+    // height. Raise it here when the G-code moves the toolhead, it must not drag across the layer
+    // just printed. Setting m_lifted lets the usual restore bring the nozzle back down afterwards.
+    if (skipped_lift > 0. && m_gcode_after_lift_needs_clearance) {
+        m_lifted = skipped_lift;
+        gcode = this->_travel_to_z(m_pos(2) + skipped_lift, "normal lift Z");
+    }
+    gcode += m_gcode_after_lift;
+    m_gcode_after_lift.clear();
+    return gcode;
+}
+
 // BBS: immediately execute an undelayed lift move with a spiral lift pattern
 // designed specifically for subsequent gcode injection (e.g. timelapse) 
 std::string GCodeWriter::eager_lift(const LiftType type) {
@@ -832,8 +849,9 @@ std::string GCodeWriter::eager_lift(const LiftType type) {
         lift_move = _travel_to_z(m_pos(2) + target_lift, "normal lift Z");
     }
     m_lifted = target_lift;
+    const double skipped_lift = target_lift > 0. ? 0. : m_to_lift;
     m_to_lift = 0;
-    return lift_move;
+    return lift_move + this->take_gcode_after_lift(skipped_lift);
 }
 
 std::string GCodeWriter::travel_to_xyz(const Vec3d &point, const std::string &comment, bool force_z)
@@ -862,6 +880,9 @@ std::string GCodeWriter::travel_to_xyz(const Vec3d &point, const std::string &co
             m_lifted = m_to_lift + m_pos(2) - point(2);
             dest_point(2) = m_to_lift + m_pos(2);
         }
+        // Orca: this travel does not move, so the lift above was skipped and the nozzle stays down
+        // at print height. Remember the skipped lift for G-code queued to run after it.
+        const double skipped_lift = (std::abs(m_lifted) < EPSILON && m_pos == dest_point) ? m_to_lift : 0.;
         m_to_lift = 0.;
 
         std::string slop_move;
@@ -928,7 +949,11 @@ std::string GCodeWriter::travel_to_xyz(const Vec3d &point, const std::string &co
         }
         m_pos = dest_point;
         this->set_current_position_clear(true);
-        return slop_move + xy_z_move;
+        // Orca: the queued lift has just been performed, so hand back the G-code waiting for it,
+        // right after the lift move and before the travel that follows it. When the lift could not
+        // be split off into a move of its own it is part of xy_z_move, so emit it after that.
+        const std::string gcode_after_lift = this->take_gcode_after_lift(skipped_lift);
+        return slop_move.empty() ? xy_z_move + gcode_after_lift : slop_move + gcode_after_lift + xy_z_move;
     }
     else if (!force_z && !this->will_move_z(point(2))) {
         double nominal_z = m_pos(2) - m_lifted;
@@ -1250,7 +1275,10 @@ std::string GCodeWriter::unretract(float extra_retract)
 
 std::string GCodeWriter::unlift()
 {
-    std::string gcode;
+    // Orca: the queued lift is dropped here, so hand back the G-code waiting for it rather than
+    // carrying it over to a later lift. It goes before the z-hop is restored, and raises the nozzle
+    // by the dropped lift itself if it needs the clearance, since that lift never happened.
+    std::string gcode = this->take_gcode_after_lift(m_lifted > 0 ? 0. : m_to_lift);
     if (m_lifted > 0) {
         gcode += this->_travel_to_z(m_pos(2) - m_lifted, "restore layer Z");
         m_lifted = 0;

--- a/src/libslic3r/GCodeWriter.hpp
+++ b/src/libslic3r/GCodeWriter.hpp
@@ -96,6 +96,17 @@ public:
     // record a lift request, do realy lift in next travel
     std::string lazy_lift(LiftType lift_type = LiftType::NormalLift, bool spiral_vase = false);
     std::string unlift();
+    bool        has_pending_lift() const { return m_to_lift > 0.; }
+    // Orca: queue G-code to be emitted as soon as the queued lazy lift has been performed, i.e.
+    // right after the lift move and before the travel that follows it. Used by layer_change_gcode
+    // so that injected custom G-code runs with the nozzle raised above the layer just printed.
+    // Deferring the G-code rather than lifting early leaves the lift itself untouched: its type
+    // (normal/slope/spiral) and the "no lift when the travel does not move" optimization are
+    // unchanged. needs_clearance tells whether the G-code moves the toolhead: only then is the
+    // nozzle raised by take_gcode_after_lift() when that optimization skipped the lift.
+    void        queue_gcode_after_lift(std::string gcode, bool needs_clearance)
+                    { m_gcode_after_lift = std::move(gcode); m_gcode_after_lift_needs_clearance = needs_clearance; }
+    std::string take_gcode_after_lift(double skipped_lift = 0.);
     const Vec3d& get_position() const { return m_pos; }
     Vec3d&       get_position() { return m_pos; }
     void        set_position(const Vec3d& in) { m_pos = in; }
@@ -172,6 +183,9 @@ public:
     // BBS
     double          m_to_lift;
     LiftType        m_to_lift_type;
+    // Orca: G-code waiting for the queued lift to be performed, see queue_gcode_after_lift().
+    std::string     m_gcode_after_lift;
+    bool            m_gcode_after_lift_needs_clearance = false;
     Vec3d           m_pos = Vec3d::Zero();
     //BBS: this flag is used to indicate whether the m_pos is real.
     //A example that of the first move, the m_pos is zero, but the real position of extruder doesn't

--- a/tests/fff_print/test_gcodewriter.cpp
+++ b/tests/fff_print/test_gcodewriter.cpp
@@ -71,6 +71,67 @@ SCENARIO("z_hop lifts the nozzle when a lift is requested", "[GCodeWriter]") {
                 REQUIRE_THAT(gcode, Catch::Matchers::ContainsSubstring("Z11"));
             }
         }
+        WHEN("G-code is queued to run after a lazy lift") {
+            writer.config.z_hop.values = { 1.0 };
+            writer.set_current_position_clear(true);
+            REQUIRE(writer.lazy_lift(LiftType::NormalLift).empty());
+            REQUIRE(writer.has_pending_lift());
+            writer.queue_gcode_after_lift("; injected\n", true);
+            const std::string gcode = writer.travel_to_xyz(Vec3d(20., 20., 10.));
+            THEN("it is emitted after the lift move and before the travel that follows it") {
+                const size_t lift = gcode.find("Z11");
+                const size_t injected = gcode.find("; injected");
+                const size_t travel = gcode.find("X20 Y20");
+                REQUIRE(lift != std::string::npos);
+                REQUIRE(injected != std::string::npos);
+                REQUIRE(travel != std::string::npos);
+                REQUIRE(lift < injected);
+                REQUIRE(injected < travel);
+            }
+            THEN("the queued G-code is emitted only once") {
+                REQUIRE(writer.take_gcode_after_lift().empty());
+            }
+        }
+        WHEN("the travel that would perform the lift does not move") {
+            writer.config.z_hop.values = { 1.0 };
+            writer.set_current_position_clear(true);
+            REQUIRE(writer.lazy_lift(LiftType::NormalLift).empty());
+            AND_WHEN("the queued G-code moves the toolhead") {
+                writer.queue_gcode_after_lift("; injected\n", true);
+                const std::string gcode = writer.travel_to_xyz(Vec3d(0., 0., 10.));
+                THEN("the nozzle is raised for it even though the lift was skipped") {
+                    const size_t lift = gcode.find("Z11");
+                    REQUIRE(lift != std::string::npos);
+                    REQUIRE(lift < gcode.find("; injected"));
+                }
+            }
+            AND_WHEN("the queued G-code does not move the toolhead") {
+                writer.queue_gcode_after_lift("; injected\n", false);
+                const std::string gcode = writer.travel_to_xyz(Vec3d(0., 0., 10.));
+                THEN("the skipped lift stays skipped") {
+                    REQUIRE_THAT(gcode, Catch::Matchers::ContainsSubstring("; injected"));
+                    REQUIRE_THAT(gcode, !Catch::Matchers::ContainsSubstring("Z11"));
+                }
+            }
+        }
+        WHEN("the lift is cancelled before it was performed") {
+            writer.config.z_hop.values = { 1.0 };
+            writer.set_current_position_clear(true);
+            REQUIRE(writer.lazy_lift(LiftType::NormalLift).empty());
+            writer.queue_gcode_after_lift("; injected\n", true);
+            const std::string gcode = writer.unlift();
+            THEN("the queued G-code runs lifted and the nozzle is put back down") {
+                const size_t lift = gcode.find("Z11");
+                const size_t injected = gcode.find("; injected");
+                const size_t restore = gcode.find("Z10");
+                REQUIRE(lift != std::string::npos);
+                REQUIRE(injected != std::string::npos);
+                REQUIRE(restore != std::string::npos);
+                REQUIRE(lift < injected);
+                REQUIRE(injected < restore);
+                REQUIRE(writer.get_position().z() == Catch::Approx(10.));
+            }
+        }
         WHEN("z_hop is 0") {
             writer.config.z_hop.values = { 0.0 };
             std::string gcode = writer.eager_lift(LiftType::NormalLift);


### PR DESCRIPTION
## Description

Fix the ordering of custom Layer Change G-code relative to the Z lift.

OrcaSlicer currently emits `time_lapse_gcode` and `layer_change_gcode` in the same pre-lift phase of the generated layer-change block. The first travel later performs the lazy Z lift, so both custom snippets run before the nozzle has actually been raised.

This change keeps `time_lapse_gcode` at its existing insertion point, while emitting `layer_change_gcode` immediately after the queued Z lift is actually performed. This separates the two extension points without removing either feature:

- Timelapse continues to run at its existing location.
- Layer Change G-code can now run after the nozzle is raised, as intended.
- The existing lazy lift type and the optimization that skips a lift when the next travel does not move are preserved.
- If that optimization skips the lift, moving custom Layer Change G-code gets the required clearance; stationary custom G-code does not force an unnecessary lift.

## Motivation

The [official OrcaSlicer Printer Machine G-code documentation](https://github.com/OrcaSlicer/OrcaSlicer/wiki/printer_machine_gcode) describes Layer Change G-code as being inserted after the Z lift. The implementation should follow that documented contract so custom G-code that depends on the nozzle being clear of the just-printed layer can work reliably.

This behavior has been reported several times:

- [#5158](https://github.com/OrcaSlicer/OrcaSlicer/issues/5158) — *After Layer Change G-Code position to be after Z moves to the new layer* — closed as **not planned**.
- [#11020](https://github.com/OrcaSlicer/OrcaSlicer/issues/11020) — *Custom "After Layer Change G-code" Inserted Before Z Move Instead of After* — open.
- [#9014](https://github.com/OrcaSlicer/OrcaSlicer/issues/9014) — *Parameter "AFTER_LAYER_CHANGE" application errors* — open.
- [#8775](https://github.com/OrcaSlicer/OrcaSlicer/issues/8775) — related layer-change ordering/first-layer behavior — closed as **not planned**.

## Implementation

- Defer Layer Change G-code until the writer's pending lazy lift is consumed.
- Release it immediately after the lift and before the following travel.
- Handle skipped/cancelled lifts without carrying queued G-code into a later layer.
- Add focused `GCodeWriter` regression coverage for normal lifts, same-point travel optimization, and cancelled lifts.

## Validation

- Windows build and tests passed.
- `git diff --check` passed.

No new settings or dependencies are introduced.
Fix #9014