### PR TITLE
Wipe Tower Footprint: Full Series (Integration of #15516, #15517, #15518)

### DIFF
--- a/src/OrcaSlicer.cpp
+++ b/src/OrcaSlicer.cpp
@@ -4750,7 +4750,10 @@ int CLI::run(int argc, char **argv)
                     int plate_count = partplate_list.get_plate_count();
 
                     auto printer_structure_opt = m_print_config.option<ConfigOptionEnum<PrinterStructure>>("printer_structure");
-                    const float tower_brim_width = m_print_config.option<ConfigOptionFloat>("prime_tower_width", true)->value;
+                    // This margin only pre-adjusts the default away from the near edges;
+                    // estimate_wipe_tower_polygon below computes the real clamped position.
+                    float tower_brim_width = m_print_config.option<ConfigOptionFloat>("prime_tower_brim_width", true)->value;
+                    if (tower_brim_width < 0.f) tower_brim_width = 8.f; // auto: object heights unknown here, 8 mm is the auto cap
                     const float tower_margin = WIPE_TOWER_MARGIN + tower_brim_width;
 
                     // set the default position, the same with print config(left top)
@@ -5047,7 +5050,10 @@ int CLI::run(int argc, char **argv)
                         int extruder_size = used_filament_set.size();
 
                         auto printer_structure_opt = m_print_config.option<ConfigOptionEnum<PrinterStructure>>("printer_structure");
-                        const float tower_brim_width      = m_print_config.option<ConfigOptionFloat>("prime_tower_width", true)->value;
+                        // This margin only pre-adjusts the default away from the near edges;
+                        // estimate_wipe_tower_polygon below computes the real clamped position.
+                        float tower_brim_width = m_print_config.option<ConfigOptionFloat>("prime_tower_brim_width", true)->value;
+                        if (tower_brim_width < 0.f) tower_brim_width = 8.f; // auto: object heights unknown here, 8 mm is the auto cap
                         const float tower_margin          = WIPE_TOWER_MARGIN + tower_brim_width;
                         // set the default position, the same with print config(left top)
                         float x = WIPE_TOWER_DEFAULT_X_POS;
@@ -5709,6 +5715,34 @@ int CLI::run(int argc, char **argv)
                 std::string outfile;
                 //Print       fff_print;
                 std::vector<size_t> plate_triangle_counts(partplate_list.get_plate_count(), 0);
+
+                // The stored (or default) tower position may not fit the tower these plates
+                // need, and no CLI placement site runs on a plain slice - mirror the GUI's
+                // reload clamp and fit every plate's tower into the printable area first.
+                if (m_print_config.option<ConfigOptionBool>("enable_prime_tower", true)->value) {
+                    for (int index = 0; index < partplate_list.get_plate_count(); index++) {
+                        if ((plate_to_slice != 0) && (plate_to_slice != (index + 1)))
+                            continue;
+                        Slic3r::GUI::PartPlate *plate = partplate_list.get_plate(index);
+                        // Printing by object disables the tower only with more than one instance.
+                        bool is_seq_print = false;
+                        get_print_sequence(plate, m_print_config, is_seq_print);
+                        if (is_seq_print && plate->printable_instance_size() > 1)
+                            continue;
+                        // An empty estimate is a plate that prints no tower (one filament and
+                        // neither smooth timelapse, wrapping detection nor a raft).
+                        Vec3d wt_pos, wt_size;
+                        plate->estimate_wipe_tower_polygon(m_print_config, index, wt_pos, wt_size);
+                        if (wt_size(0) < EPSILON || wt_size(1) < EPSILON)
+                            continue;
+                        ConfigOptionFloat wt_x_opt((float) wt_pos(0));
+                        ConfigOptionFloat wt_y_opt((float) wt_pos(1));
+                        m_print_config.option<ConfigOptionFloats>("wipe_tower_x", true)->set_at(&wt_x_opt, index, 0);
+                        m_print_config.option<ConfigOptionFloats>("wipe_tower_y", true)->set_at(&wt_y_opt, index, 0);
+                        BOOST_LOG_TRIVIAL(info) << boost::format("plate %1%: wipe tower clamped to {%2%, %3%}, size {%4%, %5%}")
+                            % (index + 1) % wt_pos(0) % wt_pos(1) % wt_size(0) % wt_size(1);
+                    }
+                }
 
                 while(!finished)
                 {

--- a/src/libslic3r/GCode/WipeTower.cpp
+++ b/src/libslic3r/GCode/WipeTower.cpp
@@ -1630,6 +1630,94 @@ float WipeTower::get_auto_brim_by_height(float max_height) {
     return 8.f;
 }
 
+float WipeTower::estimate_brim_real_width(float brim_width, float nozzle_diameter, float first_layer_height, bool type2)
+{
+    if (brim_width <= 0.f)
+        return brim_width;
+    const float spacing = nozzle_diameter * 1.25f - first_layer_height * float(1. - M_PI_4); // Width_To_Nozzle_Ratio
+    if (spacing <= EPSILON)
+        return brim_width;
+    const int loops_num = int((brim_width + spacing / 2.f) / spacing);
+    return loops_num * spacing + (type2 ? 0.f : spacing / 2.f);
+}
+
+float WipeTower::get_wrapping_detection_depth()
+{
+    return float(wrapping_wipe_tower_depth);
+}
+
+float WipeTower::nozzle_change_perimeter_width(float nozzle_diameter)
+{
+    auto it = nozzle_diameter_to_nozzle_change_width.find(nozzle_diameter);
+    return it != nozzle_diameter_to_nozzle_change_width.end() ? it->second : 2.f * nozzle_diameter * 1.25f;
+}
+
+float WipeTower::estimate_tower_blocks_depth(const std::vector<PurgeEstimate> &purges, float width, float layer_height, float nozzle_diameter, float extra_spacing)
+{
+    if (purges.empty() || layer_height < EPSILON || nozzle_diameter < EPSILON)
+        return 0.f;
+    const float pw         = nozzle_diameter * 1.25f; // Width_To_Nozzle_Ratio
+    const float ncpw       = nozzle_change_perimeter_width(nozzle_diameter);
+    const float line_width = width - 2.f * pw;
+    if (line_width <= EPSILON)
+        return 0.f;
+    // Line cross-section as volume_to_length() sees it; the infill gap stretches the perimeter
+    // width by the configured ratio and nozzle-change lines keep their own width
+    // (calc_block_infill_gap).
+    auto        line_area   = [layer_height](float w) { return layer_height * (w - layer_height * float(1. - M_PI_4)); };
+    const float extra_width = (extra_spacing - 1.f) * pw;
+    const float gap         = pw + extra_width;
+    const float nc_gap      = ncpw + extra_width;
+    // A layer purges into at most (filaments - 1) targets, so a category holding every filament
+    // never sees its smallest purge (the layer's first filament) in its worst layer.
+    struct Block { float depth = 0.f; float min_purge = 0.f; size_t filaments = 0; };
+    std::map<int, Block> blocks;
+    for (const PurgeEstimate &purge : purges) {
+        Block      &block       = blocks[purge.category];
+        const float purge_depth = std::ceil(purge.prime_volume / line_area(pw) / line_width) * gap;
+        block.min_purge         = block.filaments == 0 ? purge_depth : std::min(block.min_purge, purge_depth);
+        block.depth += purge_depth;
+        ++block.filaments;
+        if (purge.filament_change_length > EPSILON) {
+            // The leaving filament is rammed over the nozzle-change flow, again in whole lines.
+            const float filament_area = float(M_PI) * purge.filament_diameter * purge.filament_diameter / 4.f;
+            const float nc_length     = purge.filament_change_length * filament_area / line_area(ncpw);
+            block.depth += std::ceil(nc_length / (width - ncpw - pw)) * nc_gap;
+        }
+    }
+    float depth = pw; // plan_tower_new starts the first block one perimeter width in
+    for (const auto &[category, block] : blocks)
+        depth += block.filaments == purges.size() ? block.depth - block.min_purge : block.depth;
+    return depth;
+}
+
+float WipeTower::rib_footprint_side(float width, float depth, float rib_width, float extra_rib_length, float max_height)
+{
+    if (width < EPSILON || depth < EPSILON)
+        return 0.f;
+    // Ribs run the diagonal; below the height-based minimum they are extended rather than the
+    // body, then by the extra length, never ending up shorter than the diagonal.
+    const float diagonal   = std::sqrt(width * width + depth * depth);
+    float       rib_length = diagonal;
+    if (depth + EPSILON < get_limit_depth_by_height(max_height))
+        rib_length = std::max(rib_length, get_limit_depth_by_height(max_height) * float(std::sqrt(2.)));
+    rib_length = std::max(diagonal, rib_length + extra_rib_length);
+    // Half the extension at each end of the diagonal plus half the rib width, projected onto the axes.
+    const float rib_w    = std::min(rib_width, std::min(width, depth) / 2.f);
+    const float per_side = ((rib_length - diagonal) / 2.f + rib_w / 2.f) / float(std::sqrt(2.));
+    return std::max(width, depth) + 2.f * per_side;
+}
+
+float WipeTower::estimate_rib_tower_bbox_side(const std::vector<PurgeEstimate> &purges, float width, float layer_height, float nozzle_diameter, float extra_spacing, float rib_width, float extra_rib_length, float max_height)
+{
+    if (purges.empty() || width < EPSILON || layer_height < EPSILON || nozzle_diameter < EPSILON)
+        return 0.f;
+    const float pw     = nozzle_diameter * 1.25f; // Width_To_Nozzle_Ratio
+    const float square = align_ceil(std::sqrt(estimate_tower_blocks_depth(purges, width, layer_height, nozzle_diameter, extra_spacing) * width), pw);
+    const float depth  = estimate_tower_blocks_depth(purges, square, layer_height, nozzle_diameter, extra_spacing);
+    return rib_footprint_side(square, depth, rib_width, extra_rib_length, max_height);
+}
+
 Vec2f WipeTower::move_box_inside_polygon(const BoundingBox &box, const Polygons &polygons, coord_t offset)
 {
     if (polygons.empty()) return Vec2f{0.f, 0.f};

--- a/src/libslic3r/GCode/WipeTower.hpp
+++ b/src/libslic3r/GCode/WipeTower.hpp
@@ -42,9 +42,36 @@ public:
 	static const std::map<float, float> min_depth_per_height;
     static float get_limit_depth_by_height(float max_height);
     static float get_auto_brim_by_height(float max_height);
+    // Both generators lay the brim in whole loops one line spacing apart, so the printed width
+    // differs from the configured one. WipeTower reports it with half a spacing of line width
+    // added, WipeTower2 reports the loops alone; an estimate has to round like the generator
+    // whose G-code it stands in for.
+    static float estimate_brim_real_width(float brim_width, float nozzle_diameter, float first_layer_height, bool type2);
+    // Depth a Type1 tower reserves once nothing but wrapping detection asks for one.
+    static float get_wrapping_detection_depth();
+    // Line width of the nozzle-change purge lines at this nozzle diameter.
+    static float nozzle_change_perimeter_width(float nozzle_diameter);
     static TriangleMesh                 its_make_rib_tower(float width, float depth, float height, float rib_length, float rib_width, bool fillet_wall);
     static TriangleMesh                 its_make_rib_brim(const Polygon& brim, float layer_height);
     static Polygon                      rib_section(float width, float depth, float rib_length, float rib_width, bool fillet_wall);
+    // One filament's share of a Type1 tower layer, as plan_tower_new() reserves it.
+    struct PurgeEstimate
+    {
+        float prime_volume           = 0.f;   // mm3 wiped after changing to this filament
+        int   category               = 0;     // filament_adhesiveness_category; one purge block per category
+        float filament_change_length = 0.f;   // mm of filament rammed when it leaves its nozzle; 0 when no nozzle change is planned
+        float filament_diameter      = 1.75f;
+    };
+    // Depth of the Type1 purge stack at the given width (also the rectangle-wall depth): each
+    // purge is whole lines at the block infill gap, one block per adhesiveness category sized by
+    // its worst layer, stacked behind one perimeter width.
+    static float estimate_tower_blocks_depth(const std::vector<PurgeEstimate> &purges, float width, float layer_height, float nozzle_diameter, float extra_spacing);
+    // Side of the square bounding a rib-wall tower's first layer, brim excluded: the body plus the
+    // rib bulge, with the ribs extended to the height-based minimum as both generators do.
+    static float rib_footprint_side(float width, float depth, float rib_width, float extra_rib_length, float max_height);
+    // Type1 rib tower: plan_tower_new() squares the tower from the depth at the configured width,
+    // then re-plans the depth at the squared width.
+    static float estimate_rib_tower_bbox_side(const std::vector<PurgeEstimate> &purges, float width, float layer_height, float nozzle_diameter, float extra_spacing, float rib_width, float extra_rib_length, float max_height);
     // Translation that brings a footprint inside the printable outline, padded by offset. The prime
     // tower is validated against the real outline (see layered_print_cleareance_valid), so clamping
     // against the bounding box alone would leave it off a delta or hexagonal bed. box and polygons

--- a/src/libslic3r/GCode/WipeTower2.cpp
+++ b/src/libslic3r/GCode/WipeTower2.cpp
@@ -2129,6 +2129,23 @@ std::pair<double, double> WipeTower2::get_wipe_tower_cone_base(double width, dou
     return std::make_pair(R, support_scale);
 }
 
+Polygon WipeTower2::cone_base_polygon(double width, double depth, double height, double angle_deg)
+{
+    Polygon box({Point::new_scale(Vec2d(0., 0.)), Point::new_scale(Vec2d(width, 0.)),
+                 Point::new_scale(Vec2d(width, depth)), Point::new_scale(Vec2d(0., depth))});
+    if (angle_deg <= EPSILON || height <= EPSILON || width <= EPSILON || depth <= EPSILON)
+        return box;
+    const auto [R, x_scale] = get_wipe_tower_cone_base(width, height, depth, angle_deg);
+    if (R <= EPSILON)
+        return box;
+    const Vec2d center(width / 2., depth / 2.);
+    Polygon ellipse;
+    for (double alpha = 0.; alpha < 2. * M_PI; alpha += M_PI / 20.)
+        ellipse.points.push_back(Point::new_scale(center + R * Vec2d(std::cos(alpha) / x_scale, std::sin(alpha))));
+    Polygons u = union_({box, ellipse});
+    return u.empty() ? box : u.front();
+}
+
 // Static method to extract wipe_volumes[from][to] from the configuration.
 // Takes a ConfigBase so the GUI's wipe tower size estimate can pass the plate's
 // DynamicPrintConfig directly instead of materializing a full PrintConfig per call.

--- a/src/libslic3r/GCode/WipeTower2.hpp
+++ b/src/libslic3r/GCode/WipeTower2.hpp
@@ -27,6 +27,10 @@ public:
     // in WipeTowerIntegration::append_tcr2 does not strip it.
     static const std::string wait_for_temp_tag() { return ";_WAIT_FOR_TEMP_ON_WIPE_TOWER"; }
 	static std::pair<double, double> get_wipe_tower_cone_base(double width, double height, double depth, double angle_deg);
+	// First-layer outline of a cone-wall tower in tower-local (scaled) coordinates: body box
+	// unioned with the cone's base ellipse — the model first_layer_wipe_tower_corners uses,
+	// and generate_support_cone_wall stays within it. Brim not included.
+	static Polygon cone_base_polygon(double width, double depth, double height, double angle_deg);
 	static std::vector<std::vector<float>> extract_wipe_volumes(const ConfigBase& config);
 	// Estimated total flush volume of a SEMM print with the given number of filaments,
 	// used to reserve wipe tower space before the tower is generated.

--- a/src/libslic3r/GCode/WipeTowerEstimate.cpp
+++ b/src/libslic3r/GCode/WipeTowerEstimate.cpp
@@ -8,56 +8,92 @@
 
 #include <algorithm>
 #include <cmath>
+#include <set>
 
 namespace Slic3r {
 
-WipeTowerFootprint estimate_wipe_tower_footprint(const ConfigBase &config, size_t filaments_cnt, double layer_height, double max_object_height, bool any_raft)
+// Every caller today declares all these keys, but the signature accepts any ConfigBase: fall
+// back to the key's declared default, never to a hand-copied constant.
+static const ConfigOption *option_of(const ConfigBase &config, const char *key)
+{
+    if (const ConfigOption *opt = config.option(key); opt != nullptr)
+        return opt;
+    if (const ConfigDef *def = config.def(); def != nullptr)
+        if (const ConfigOptionDef *opt_def = def->get(key); opt_def != nullptr)
+            return opt_def->default_value.get();
+    return nullptr;
+}
+
+WipeTowerType resolve_wipe_tower_type(const ConfigBase &config)
+{
+    // printer_model is what the CLI keys its Bambu Lab detection on; the GUI's vendor flag
+    // agrees for every shipped profile.
+    if (const auto *model = dynamic_cast<const ConfigOptionString *>(config.option("printer_model"));
+        model != nullptr && model->value.compare(0, 9, "Bambu Lab") == 0)
+        return WipeTowerType::Type1;
+    // By value, not by concrete type: a static PrintConfig holds ConfigOptionEnum<T>, a
+    // DynamicConfig built from presets holds ConfigOptionEnumGeneric, and both answer getInt().
+    const ConfigOption *type = option_of(config, "wipe_tower_type");
+    return type != nullptr ? WipeTowerType(type->getInt()) : WipeTowerType::Type2;
+}
+
+WipeTowerFootprint estimate_wipe_tower_footprint(const ConfigBase &config, WipeTowerType tower_type, const std::vector<unsigned int> &filament_ids, double layer_height, double max_object_height, bool any_raft)
 {
     WipeTowerFootprint footprint;
     footprint.height = max_object_height;
+    const size_t filaments_cnt = filament_ids.size();
     if (filaments_cnt == 0 || layer_height < EPSILON)
         return footprint;
 
-    // Every caller today declares all these keys, but the signature accepts any ConfigBase:
-    // fall back to the key's declared default, never to a hand-copied constant.
-    auto option_of = [&config](const char *key) -> const ConfigOption * {
-        if (const ConfigOption *opt = config.option(key); opt != nullptr)
-            return opt;
-        if (const ConfigDef *def = config.def(); def != nullptr)
-            if (const ConfigOptionDef *opt_def = def->get(key); opt_def != nullptr)
-                return opt_def->default_value.get();
-        return nullptr;
-    };
-    auto opt_float = [&option_of](const char *key) {
-        const ConfigOption *opt = option_of(key);
+    auto opt_float = [&config](const char *key) {
+        const ConfigOption *opt = option_of(config, key);
         return opt != nullptr ? opt->getFloat() : 0.;
     };
-    auto opt_bool = [&option_of](const char *key) {
-        const ConfigOption *opt = option_of(key);
+    auto opt_bool = [&config](const char *key) {
+        const ConfigOption *opt = option_of(config, key);
         return opt != nullptr && opt->getBool();
     };
-    // By value, not by concrete type: a static PrintConfig holds ConfigOptionEnum<T>, a
-    // DynamicConfig built from presets holds ConfigOptionEnumGeneric, and both answer getInt().
-    auto opt_enum = [&option_of](const char *key, int fallback) {
-        const ConfigOption *opt = option_of(key);
+    auto opt_enum = [&config](const char *key, int fallback) {
+        const ConfigOption *opt = option_of(config, key);
         return opt != nullptr ? opt->getInt() : fallback;
     };
-    auto max_of = [&option_of](const char *key, double fallback) {
-        const auto *opt = dynamic_cast<const ConfigOptionFloats *>(option_of(key));
+    auto floats_of = [&config](const char *key) { return dynamic_cast<const ConfigOptionFloats *>(option_of(config, key)); };
+    auto max_of = [&floats_of](const char *key, double fallback) {
+        const auto *opt = floats_of(key);
         return (opt != nullptr && !opt->values.empty()) ? *std::max_element(opt->values.begin(), opt->values.end()) : fallback;
     };
+    auto float_at = [&floats_of](const char *key, unsigned int id, double fallback) {
+        const auto *opt = floats_of(key);
+        return (opt != nullptr && !opt->values.empty()) ? opt->get_at(id) : fallback;
+    };
+    auto int_at = [&config](const char *key, unsigned int id, int fallback) {
+        const auto *opt = dynamic_cast<const ConfigOptionInts *>(option_of(config, key));
+        return (opt != nullptr && !opt->values.empty()) ? opt->get_at(id) : fallback;
+    };
 
+    // Both planners size every layer, so the tower has to fit its thinnest one: the first layer
+    // when it is printed thinner than the rest.
+    const double first_layer_height = opt_float("initial_layer_print_height");
+    if (first_layer_height > EPSILON)
+        layer_height = std::min(layer_height, first_layer_height);
+
+    const bool   type1            = tower_type == WipeTowerType::Type1;
     const double width            = opt_float("prime_tower_width");
     const double prime_volume     = opt_float("prime_volume");
-    const double extra_spacing    = opt_float("prime_tower_infill_gap") / 100.;
-    double       rib_width        = opt_float("wipe_tower_rib_width");
+    // Type1 spaces its purge lines by prime_tower_infill_gap, Type2 by wipe_tower_extra_spacing.
+    // Type2's extra flow cancels out of the depth: the line length is divided by it and the row
+    // pitch multiplied by it (WipeTower2::get_wipe_depth).
+    const double extra_spacing    = opt_float(type1 ? "prime_tower_infill_gap" : "wipe_tower_extra_spacing") / 100.;
+    const double rib_width        = opt_float("wipe_tower_rib_width");
     const double extra_rib_length = opt_float("wipe_tower_extra_rib_length");
-    const auto  *nozzle_opt       = dynamic_cast<const ConfigOptionFloats *>(option_of("nozzle_diameter"));
+    const auto  *nozzle_opt       = floats_of("nozzle_diameter");
+    const double nozzle_diameter  = (nozzle_opt != nullptr && !nozzle_opt->values.empty()) ? nozzle_opt->values.front() : 0.4;
     const bool   dual_nozzle      = nozzle_opt != nullptr && nozzle_opt->values.size() == 2;
     const bool   rib_wall         = opt_enum("wipe_tower_wall_type", int(WipeTowerWallType::wtwRectangle)) == int(WipeTowerWallType::wtwRib);
     const bool   smooth_timelapse = opt_enum("timelapse_type", int(TimelapseType::tlTraditional)) == int(TimelapseType::tlSmooth);
+    const bool   wrapping         = opt_bool("enable_wrapping_detection");
     // Reasons a tower is printed with no tool change to purge for.
-    const bool   need_wipe_tower  = smooth_timelapse || opt_bool("enable_wrapping_detection") || any_raft;
+    const bool   need_wipe_tower  = smooth_timelapse || wrapping || any_raft;
 
     // No tool change, nothing to purge; smooth timelapse still primes once.
     size_t purge_count = 0;
@@ -66,6 +102,8 @@ WipeTowerFootprint estimate_wipe_tower_footprint(const ConfigBase &config, size_
     else if (smooth_timelapse)
         purge_count = 1;
 
+    // Type2 purges one volume per tool change. Type1 plans per filament below; here the volume
+    // only decides whether a tower exists.
     double volume = prime_volume * double(purge_count);
     if (dual_nozzle) {
         // Dual-nozzle printers also purge the filament change length on the tower.
@@ -78,31 +116,75 @@ WipeTowerFootprint estimate_wipe_tower_footprint(const ConfigBase &config, size_
     if (semm_flush)
         volume = WipeTower2::estimate_semm_flush_volume(config, filaments_cnt);
 
-    // Both wall types decide this together: over-reserving only wastes bed area, but
-    // reporting no tower for one that is built collapses the validation hull to a point.
-    if (volume < EPSILON && !need_wipe_tower)
+    // The Type1 planner wipes each filament's own prime volume after changing to it, in a block
+    // per adhesiveness category. On a two-nozzle printer the leaving filament is also rammed at
+    // every nozzle change; the tool order groups filaments by nozzle, so a layer crosses
+    // (nozzles used - 1) times, charged here to the longest ramming.
+    std::vector<WipeTower::PurgeEstimate> purges;
+    if (type1 && filaments_cnt > 1) {
+        const bool    saving_mode = opt_enum("prime_volume_mode", int(PrimeVolumeMode::pvmDefault)) == int(PrimeVolumeMode::pvmSaving);
+        std::set<int> nozzles;
+        size_t        longest_ramming = 0;
+        for (size_t i = 0; i < filaments_cnt; ++i) {
+            const unsigned int         id = filament_ids[i];
+            WipeTower::PurgeEstimate purge;
+            purge.prime_volume      = saving_mode ? 15.f : float(float_at("filament_prime_volume", id, prime_volume));
+            purge.category          = int_at("filament_adhesiveness_category", id, 0);
+            purge.filament_diameter = float(float_at("filament_diameter", id, 1.75));
+            purges.push_back(purge);
+            if (dual_nozzle) {
+                nozzles.insert(int_at("filament_map", id, 1));
+                if (float_at("filament_change_length", id, 0.) > float_at("filament_change_length", filament_ids[longest_ramming], 0.))
+                    longest_ramming = i;
+            }
+        }
+        if (nozzles.size() > 1)
+            purges[longest_ramming].filament_change_length = float(float_at("filament_change_length", filament_ids[longest_ramming], 0.) * double(nozzles.size() - 1));
+    }
+
+    // Both wall types decide this together: over-reserving only wastes bed area, but reporting
+    // no tower for one that is built collapses the validation hull to a point.
+    const bool has_purge = type1 ? !purges.empty() : volume > EPSILON;
+    if (!has_purge && !need_wipe_tower)
         return footprint;
 
-    const double min_depth = WipeTower::get_limit_depth_by_height(float(max_object_height));
+    const double min_depth      = WipeTower::get_limit_depth_by_height(float(max_object_height));
+    const float  perimeter_width = float(nozzle_diameter) * 1.25f; // Width_To_Nozzle_Ratio
+    // With nothing to purge, plan_tower_new sizes the tower for wrapping detection or the
+    // stability minimum; WipeTower2 only knows the latter.
+    const double idle_depth = (type1 && wrapping && !smooth_timelapse) ? WipeTower::get_wrapping_detection_depth() : min_depth;
     if (rib_wall) {
-        // A rib wall squares the tower; the ribs run the diagonal and bulge past the body.
-        const double volume_depth = std::sqrt(volume / layer_height * extra_spacing);
-        double       depth        = std::max(min_depth, volume_depth);
-        rib_width                 = std::min(rib_width, depth / 2.);
-        depth                     = rib_width / std::sqrt(2.) + std::max(depth + extra_rib_length, volume_depth);
-        footprint.width = footprint.depth = depth;
+        // Both planners square the tower to the purge area and extend the ribs, not the body,
+        // below the stability minimum.
+        double side;
+        if (!purges.empty())
+            side = WipeTower::estimate_rib_tower_bbox_side(purges, float(width), float(layer_height), float(nozzle_diameter), float(extra_spacing), float(rib_width), float(extra_rib_length), float(max_object_height));
+        else {
+            const double square = has_purge ? std::sqrt(volume / layer_height * extra_spacing) : idle_depth;
+            side = WipeTower::rib_footprint_side(float(square), float(square), float(rib_width), float(extra_rib_length), float(max_object_height));
+        }
+        footprint.width = footprint.depth = side;
     } else {
-        double depth = volume / (layer_height * width);
-        // The flush volumes already hold the spacing between wipes.
-        if (!semm_flush)
-            depth *= extra_spacing;
+        double depth;
+        if (type1) {
+            // plan_tower_new stretches a short purge stack to the stability minimum behind its
+            // leading perimeter width.
+            depth = purges.empty() ? idle_depth : std::max(min_depth + perimeter_width, double(WipeTower::estimate_tower_blocks_depth(purges, float(width), float(layer_height), float(nozzle_diameter), float(extra_spacing))));
+        } else {
+            depth = volume / (layer_height * width);
+            // The flush volumes already hold the spacing between wipes.
+            if (!semm_flush)
+                depth *= extra_spacing;
+            depth = std::max(min_depth, depth);
+        }
         footprint.width = width;
-        footprint.depth = std::max(min_depth, depth);
+        footprint.depth = depth;
     }
 
     footprint.brim_width = opt_float("prime_tower_brim_width");
     if (footprint.brim_width < 0)
         footprint.brim_width = WipeTower::get_auto_brim_by_height(float(max_object_height));
+    footprint.brim_width = WipeTower::estimate_brim_real_width(float(footprint.brim_width), float(nozzle_diameter), float(first_layer_height > EPSILON ? first_layer_height : layer_height), !type1);
     return footprint;
 }
 

--- a/src/libslic3r/GCode/WipeTowerEstimate.hpp
+++ b/src/libslic3r/GCode/WipeTowerEstimate.hpp
@@ -1,10 +1,11 @@
 #pragma once
 
-#include <cstddef>
+#include <vector>
 
 namespace Slic3r {
 
 class ConfigBase;
+enum class WipeTowerType;
 
 // Pre-slice footprint of the wipe tower, shared by validation (Print), the GUI's placement
 // clamp/preview/arrange and the CLI placement. The arithmetic is shared; the inputs below are
@@ -14,16 +15,26 @@ struct WipeTowerFootprint
     double width      = 0.; // effective width: equals depth for a rib wall, which squares the tower
     double depth      = 0.; // 0 when these inputs imply no tower
     double height     = 0.; // tallest object; drives the stability floor and the auto brim
-    double brim_width = 0.; // configured width, auto (-1) resolved by height
+    double brim_width = 0.; // printed width: auto (-1) resolved by height, laid in whole loops
 };
 
-// filaments_cnt: filaments purged on the plate. The config cannot see custom G-code tool
-//                changes, so a count derived from the model must include them
+// Which planner builds the tower: Bambu Lab printers always get Type1, the rest follow
+// wipe_tower_type. The rule Print::wipe_tower_type() and the CLI apply, read off the config so
+// the GUI and CLI placement can resolve it without a Print.
+WipeTowerType resolve_wipe_tower_type(const ConfigBase &config);
+
+// filament_ids:  0-based filaments purged on the plate. The config cannot see custom G-code tool
+//                changes, so ids derived from the model must include them
 //                (Print::extruders(true)) or a real tower is sized as if it were never built.
-// layer_height:  thinnest layer the tower will be planned at.
+// layer_height:  thinnest layer the objects are sliced at. The first layer is folded in here.
 // any_raft:      any object on the plate prints a raft, which puts the tower on every layer
 //                below it. Caller-resolved: raft_layers is a PrintObjectConfig key, absent
 //                from Print's config and overridable per object.
-WipeTowerFootprint estimate_wipe_tower_footprint(const ConfigBase &config, size_t filaments_cnt, double layer_height, double max_object_height, bool any_raft);
+WipeTowerFootprint estimate_wipe_tower_footprint(const ConfigBase                &config,
+                                                 WipeTowerType                    tower_type,
+                                                 const std::vector<unsigned int> &filament_ids,
+                                                 double                           layer_height,
+                                                 double                           max_object_height,
+                                                 bool                             any_raft);
 
 } // namespace Slic3r

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -4013,7 +4013,7 @@ const WipeTowerData &Print::wipe_tower_data(size_t filaments_cnt) const
     if (max_height < EPSILON)
         return m_wipe_tower_data;
 
-    const WipeTowerFootprint footprint = estimate_wipe_tower_footprint(m_config, filaments_cnt, layer_height, max_height, any_raft);
+    const WipeTowerFootprint footprint = estimate_wipe_tower_footprint(m_config, this->wipe_tower_type(), this->extruders(true), layer_height, max_height, any_raft);
     WipeTowerData &data = const_cast<Print *>(this)->m_wipe_tower_data;
     data.depth      = float(footprint.depth);
     data.width      = float(footprint.width);

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -1046,6 +1046,7 @@ static StringObjectException layered_print_cleareance_valid(const Print &print, 
     const WipeTowerData &wipe_tower_estimate = print.wipe_tower_data(filaments_count);
     float                width               = wipe_tower_estimate.width;
     float                depth               = wipe_tower_estimate.depth;
+    float                brim_width          = wipe_tower_estimate.brim_width;
 
     Polygons convex_hulls_temp;
     if (print.has_wipe_tower()) {
@@ -1081,20 +1082,18 @@ static StringObjectException layered_print_cleareance_valid(const Print &print, 
     if (print_config.enable_wrapping_detection.value && !intersection({wrapping_poly}, convex_hulls_temp).empty()) {
         return {L("Prime Tower") + L(" is too close to clumping detection area, and collisions will be caused.\n")};
     }
-    // Skip the containment check for towers that will never be printed (single-filament
-    // prints without smooth timelapse keep the config's tower position but emit nothing).
-    // Pre-generation only the body square is tested — the auto-brim estimate can overshoot
-    // the generated brim by several mm and must not hard-fail a print that physically fits.
-    // Post-generation the mesh bottom already includes the real brim, so the exact
-    // footprint is tested.
+    // Single-filament prints without smooth timelapse keep the config's tower position but
+    // never emit one, so skip the check for them.
     if (filaments_count > 1 || print.enable_timelapse_print()) {
-        // The shared printable polygon is plate-local, while the tower polygons above are
-        // already shifted by the plate origin.
+        // Pre-generation, grow the body by the brim to match what the generator draws;
+        // post-generation the mesh already includes it.
         Polygons    printable_polys = print.get_extruder_shared_printable_polygon();
         const Point plate_shift(scale_(plate_origin.x()), scale_(plate_origin.y()));
         for (Polygon &p : printable_polys)
             p.translate(plate_shift);
-        if (!diff(convex_hulls_temp, printable_polys).empty())
+        Polygons tower_polys_with_brim = print.is_step_done(psWipeTower) ?
+            convex_hulls_temp : offset(convex_hulls_temp, float(scale_(brim_width)));
+        if (!diff(tower_polys_with_brim, printable_polys).empty())
             return {L("Prime Tower") + L(" is partially outside the printable area, and it cannot be printed.\n")};
     }
     return {};
@@ -5962,8 +5961,8 @@ void WipeTowerData::construct_mesh(float width, float depth, float height, float
         wipe_tower_mesh_data->real_wipe_tower_mesh = make_cube(width, depth, height);
         wipe_tower_mesh_data->real_brim_mesh       = make_cube(width + 2 * brim_width, depth + 2 * brim_width, first_layer_height);
         wipe_tower_mesh_data->real_brim_mesh.translate({-brim_width, -brim_width, 0});
-        wipe_tower_mesh_data->bottom = {scaled(Vec2f{-brim_width, -brim_width}), scaled(Vec2f{width + brim_width, 0}), scaled(Vec2f{width + brim_width, depth + brim_width}),
-                                        scaled(Vec2f{0, depth})};
+        wipe_tower_mesh_data->bottom = {scaled(Vec2f{-brim_width, -brim_width}), scaled(Vec2f{width + brim_width, -brim_width}),
+                                        scaled(Vec2f{width + brim_width, depth + brim_width}), scaled(Vec2f{-brim_width, depth + brim_width})};
     } else {
         wipe_tower_mesh_data->real_wipe_tower_mesh = WipeTower::its_make_rib_tower(width, depth, height, rib_length, rib_width, fillet_wall);
         wipe_tower_mesh_data->bottom               = WipeTower::rib_section(width, depth, rib_length, rib_width, fillet_wall);

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -1068,33 +1068,57 @@ static StringObjectException layered_print_cleareance_valid(const Print &print, 
             convex_hulls_temp.push_back(wipe_tower_polygon);
         }
     }
+    // Post-generation the mesh bottom already carries the brim. Pre-generation the body grows
+    // by the brim only when its width is explicit; the auto brim and a Type2 cone base depend on
+    // the tower height, exact only once generated, so they only warn here - the exact footprint
+    // is re-checked in _make_wipe_tower.
+    const bool exact_footprint     = print.is_step_done(psWipeTower);
+    Polygons   tower_polys_checked = (!exact_footprint && config.prime_tower_brim_width.value >= 0) ?
+                                         offset(convex_hulls_temp, float(scale_(brim_width))) :
+                                         convex_hulls_temp;
+    Polygons tower_polys_estimated;
+    if (!exact_footprint && !convex_hulls_temp.empty()) {
+        Polygon base = convex_hulls_temp.front();
+        if (config.wipe_tower_wall_type.value == WipeTowerWallType::wtwCone && print.wipe_tower_type() == WipeTowerType::Type2) {
+            double max_height = 0.;
+            for (const PrintObject *object : print.objects())
+                max_height = std::max(max_height, unscale_(object->size().z()));
+            base = WipeTower2::cone_base_polygon(width, depth, max_height, config.wipe_tower_cone_angle.value);
+            base.rotate(Geometry::deg2rad(a));
+            base.translate(Point(scale_(x), scale_(y)));
+        }
+        tower_polys_estimated = offset(base, float(scale_(brim_width)));
+    }
+    // Object proximity stays a body-only warning: brim near-misses would newly warn on
+    // many setups that print fine.
     if (!intersection(convex_hulls_other, convex_hulls_temp).empty()) {
         if (warning) {
             warning->string += L("Prime Tower") + L(" is too close to others, and collisions may be caused.\n");
         }
     }
-    if (!intersection(exclude_polys, convex_hulls_temp).empty()) {
-        /*if (warning) {
-            warning->string += L("Prime Tower is too close to exclusion area, there may be collisions when printing.\n");
-        }*/
+    if (!intersection(exclude_polys, tower_polys_checked).empty()) {
         return {L("Prime Tower") + L(" is too close to an exclusion area, and collisions will be caused.\n")};
     }
-    if (print_config.enable_wrapping_detection.value && !intersection({wrapping_poly}, convex_hulls_temp).empty()) {
+    if (print_config.enable_wrapping_detection.value && !intersection({wrapping_poly}, tower_polys_checked).empty()) {
         return {L("Prime Tower") + L(" is too close to clumping detection area, and collisions will be caused.\n")};
+    }
+    if (warning && !intersection(exclude_polys, tower_polys_estimated).empty()) {
+        warning->string += L("Prime Tower") + L(" is too close to exclusion area, there may be collisions when printing.") + "\n";
+    }
+    if (warning && print_config.enable_wrapping_detection.value && !intersection({wrapping_poly}, tower_polys_estimated).empty()) {
+        warning->string += L("Prime Tower") + L(" is too close to clumping detection area, there may be collisions when printing.") + "\n";
     }
     // Single-filament prints without smooth timelapse keep the config's tower position but
     // never emit one, so skip the check for them.
     if (filaments_count > 1 || print.enable_timelapse_print()) {
-        // Pre-generation, grow the body by the brim to match what the generator draws;
-        // post-generation the mesh already includes it.
         Polygons    printable_polys = print.get_extruder_shared_printable_polygon();
         const Point plate_shift(scale_(plate_origin.x()), scale_(plate_origin.y()));
         for (Polygon &p : printable_polys)
             p.translate(plate_shift);
-        Polygons tower_polys_with_brim = print.is_step_done(psWipeTower) ?
-            convex_hulls_temp : offset(convex_hulls_temp, float(scale_(brim_width)));
-        if (!diff(tower_polys_with_brim, printable_polys).empty())
+        if (!diff(tower_polys_checked, printable_polys).empty())
             return {L("Prime Tower") + L(" is partially outside the printable area, and it cannot be printed.\n")};
+        if (warning && !diff(tower_polys_estimated, printable_polys).empty())
+            warning->string += L("Prime Tower") + L(" is partially outside the printable area, and it cannot be printed.\n");
     }
     return {};
 }
@@ -4391,7 +4415,9 @@ void Print::_make_wipe_tower()
                                          wipe_tower.get_wipe_tower_height(), wipe_tower.get_brim_width(),
                                          config().wipe_tower_wall_type.value == WipeTowerWallType::wtwRib,
                                          wipe_tower.get_rib_width(), wipe_tower.get_rib_length(),
-                                         config().wipe_tower_fillet_wall.value);
+                                         config().wipe_tower_fillet_wall.value,
+                                         config().wipe_tower_wall_type.value == WipeTowerWallType::wtwCone ?
+                                             (float) config().wipe_tower_cone_angle.value : 0.f);
         const Vec3d origin                      = Vec3d::Zero();
         // FakeWipeTower::pos is a bed-frame translation applied after rotation
         // (getFakeExtrusionPathsFromWipeTower2 rotates about the local origin), so the
@@ -4403,6 +4429,28 @@ void Print::_make_wipe_tower()
                                                   m_wipe_tower_data.z_and_depth_pairs, m_wipe_tower_data.brim_width,
                                                   config().wipe_tower_rotation_angle, config().wipe_tower_cone_angle,
                                                   {scale_(origin.x()), scale_(origin.y())});
+    }
+
+    // The clamps and checks above work from estimates; re-test the exact generated footprint
+    // so an off-plate tower fails with a clear error instead of exporting unprintable G-code
+    // (validate() only sees the mesh on its next run).
+    if (m_wipe_tower_data.wipe_tower_mesh_data) {
+        Polygon footprint = m_wipe_tower_data.wipe_tower_mesh_data->bottom; // includes brim and rib offset
+        footprint.rotate(Geometry::deg2rad(m_config.wipe_tower_rotation_angle.value));
+        footprint.translate(Point(scale_(m_config.wipe_tower_x.get_at(m_plate_index)),
+                                  scale_(m_config.wipe_tower_y.get_at(m_plate_index))));
+        const Polygons printable_polys = this->get_extruder_shared_printable_polygon();
+        if (!printable_polys.empty() && !diff(Polygons{footprint}, printable_polys).empty()) {
+            const BoundingBox fp = get_extents(footprint);
+            const BoundingBox pr = get_extents(printable_polys);
+            BOOST_LOG_TRIVIAL(error) << boost::format("wipe tower footprint [%1%,%2%]-[%3%,%4%] leaves printable [%5%,%6%]-[%7%,%8%]") %
+                unscaled(fp.min.x()) % unscaled(fp.min.y()) % unscaled(fp.max.x()) % unscaled(fp.max.y()) %
+                unscaled(pr.min.x()) % unscaled(pr.min.y()) % unscaled(pr.max.x()) % unscaled(pr.max.y());
+            throw Slic3r::SlicingError(L("Prime Tower") + L(" is partially outside the printable area, and it cannot be printed.\n"));
+        }
+        // The cutter/purge corner is a physical obstacle — the brim must stay out like the body.
+        if (!intersection(get_bed_excluded_area(m_config), Polygons{footprint}).empty())
+            throw Slic3r::SlicingError(L("Prime Tower") + L(" is too close to an exclusion area, and collisions will be caused.\n"));
     }
 }
 
@@ -5952,12 +6000,21 @@ ExtrusionLayers FakeWipeTower::getTrueExtrusionLayersFromWipeTower() const
     }
     return wtels;
 }
-void WipeTowerData::construct_mesh(float width, float depth, float height, float brim_width, bool is_rib_wipe_tower, float rib_width, float rib_length,bool fillet_wall)
+void WipeTowerData::construct_mesh(float width, float depth, float height, float brim_width, bool is_rib_wipe_tower, float rib_width, float rib_length,bool fillet_wall, float cone_angle)
 {
     wipe_tower_mesh_data = WipeTowerMeshData{};
     float first_layer_height=0.08; //brim height
     if (width < EPSILON || depth < EPSILON || height < EPSILON) return;
-    if (!is_rib_wipe_tower || rib_length < EPSILON) {
+    if (cone_angle > EPSILON && (!is_rib_wipe_tower || rib_length < EPSILON)) {
+        // Cone tower: the base bulges past the body box; this bottom polygon feeds the
+        // containment checks, so it must carry the bulge and the brim (cone not lofted).
+        wipe_tower_mesh_data->real_wipe_tower_mesh = make_cube(width, depth, height);
+        wipe_tower_mesh_data->bottom               = WipeTower2::cone_base_polygon(width, depth, height, cone_angle);
+        auto brim_bottom                           = offset(wipe_tower_mesh_data->bottom, scaled(brim_width));
+        if (!brim_bottom.empty())
+            wipe_tower_mesh_data->bottom = brim_bottom.front();
+        wipe_tower_mesh_data->real_brim_mesh = WipeTower::its_make_rib_brim(wipe_tower_mesh_data->bottom, first_layer_height);
+    } else if (!is_rib_wipe_tower || rib_length < EPSILON) {
         wipe_tower_mesh_data->real_wipe_tower_mesh = make_cube(width, depth, height);
         wipe_tower_mesh_data->real_brim_mesh       = make_cube(width + 2 * brim_width, depth + 2 * brim_width, first_layer_height);
         wipe_tower_mesh_data->real_brim_mesh.translate({-brim_width, -brim_width, 0});

--- a/src/libslic3r/Print.hpp
+++ b/src/libslic3r/Print.hpp
@@ -804,7 +804,7 @@ struct WipeTowerData
         rib_offset = Vec2f::Zero();
         wipe_tower_mesh_data  = std::nullopt;
     }
-    void construct_mesh(float width, float depth, float height, float brim_width, bool is_rib_wipe_tower, float rib_width, float rib_length, bool fillet_wall);
+    void construct_mesh(float width, float depth, float height, float brim_width, bool is_rib_wipe_tower, float rib_width, float rib_length, bool fillet_wall, float cone_angle = 0.f);
 
 private:
 	// Only allow the WipeTowerData to be instantiated internally by Print, 

--- a/src/libslic3r/libslic3r.h
+++ b/src/libslic3r/libslic3r.h
@@ -93,6 +93,9 @@ static constexpr double INSET_OVERLAP_TOLERANCE = 0.4;
 static constexpr double EXTERNAL_INFILL_MARGIN = 3;
 static constexpr double BRIDGE_INFILL_MARGIN = 1;
 static constexpr double WIPE_TOWER_MARGIN = 1.;
+// Margin for system placement of the wipe tower (defaults, re-placement, CLI). Positions
+// within WIPE_TOWER_MARGIN stay valid: a user drag down to that limit is respected.
+static constexpr double WIPE_TOWER_AUTO_MARGIN = 15.;
 //FIXME Better to use an inline function with an explicit return type.
 //inline coord_t scale_(coordf_t v) { return coord_t(floor(v / SCALING_FACTOR + 0.5f)); }
 #define scale_(val) ((val) / SCALING_FACTOR)

--- a/src/slic3r/GUI/3DScene.cpp
+++ b/src/slic3r/GUI/3DScene.cpp
@@ -20,6 +20,9 @@
 #include "libslic3r/AppConfig.hpp"
 #include "libslic3r/PresetBundle.hpp"
 #include "libslic3r/ClipperUtils.hpp"
+#include "libslic3r/GCode/WipeTower.hpp"
+#include "libslic3r/GCode/WipeTower2.hpp"
+#include "libslic3r/GCode/WipeTowerEstimate.hpp"
 #include "libslic3r/Tesselate.hpp"
 #include "libslic3r/PrintConfig.hpp"
 
@@ -919,6 +922,33 @@ int GLVolumeCollection::load_wipe_tower_preview(
     GUI::PartPlateList& ppl = GUI::wxGetApp().plater()->get_partplate_list();
     std::vector<int> plate_extruders = ppl.get_plate(plate_idx)->get_extruders(true);
     TriangleMesh wipe_tower_shell = make_cube(width, depth, height);
+    // The brim is part of the printed footprint: draw it and fold it into the shell so the
+    // outside-bed shader and the drag clamp react to the true first-layer extent.
+    const bool   show_brim   = brim_width > 0.f;
+    const float  brim_height = 0.2f; // one first layer, visual only
+    TriangleMesh brim_slab;
+    if (show_brim) {
+        // A Type2 cone-wall tower's base bulges past the body box — follow the real base
+        // outline instead of the rectangle. Type1 ignores the cone option.
+        Polygon cone_base;
+        {
+            // Preset enums are ConfigOptionEnumGeneric, so read them by value; the planner is
+            // resolved as the estimate resolves it, off the printer preset.
+            const DynamicPrintConfig &print_cfg   = GUI::wxGetApp().preset_bundle->prints.get_edited_preset().config;
+            const DynamicPrintConfig &printer_cfg = GUI::wxGetApp().preset_bundle->printers.get_edited_preset().config;
+            const ConfigOption       *wall_opt    = print_cfg.option("wipe_tower_wall_type");
+            if (wall_opt != nullptr && wall_opt->getInt() == int(WipeTowerWallType::wtwCone) && resolve_wipe_tower_type(printer_cfg) == WipeTowerType::Type2)
+                cone_base = WipeTower2::cone_base_polygon(width, depth, height, print_cfg.opt_float("wipe_tower_cone_angle"));
+        }
+        if (!cone_base.empty()) {
+            Polygons brim_outline = offset(cone_base, scaled(brim_width));
+            brim_slab = WipeTower::its_make_rib_brim(brim_outline.empty() ? cone_base : brim_outline.front(), brim_height);
+        } else {
+            brim_slab = make_cube(width + 2.f * brim_width, depth + 2.f * brim_width, brim_height);
+            brim_slab.translate({-brim_width, -brim_width, 0.f});
+        }
+        wipe_tower_shell.merge(brim_slab);
+    }
     for (int extruder_id : plate_extruders) {
         if (extruder_id <= extruder_colors.size())
             colors.push_back(extruder_colors[extruder_id - 1]);
@@ -929,14 +959,19 @@ int GLVolumeCollection::load_wipe_tower_preview(
     // Orca: make it transparent
     for(auto& color : colors)
         color.a(0.66f);
+    const size_t slab_count = colors.size(); // per-filament body slabs; the brim part comes after
+    if (show_brim && !colors.empty())
+        colors.push_back(colors.front());
     volumes.emplace_back(new GLWipeTowerVolume(colors));
     GLWipeTowerVolume& v = *dynamic_cast<GLWipeTowerVolume*>(volumes.back());
     v.model_per_colors.resize(colors.size());
-    for (int i = 0; i < colors.size(); i++) {
-        TriangleMesh color_part = make_cube(width, depth / colors.size(), height);
-        color_part.translate({ 0.f, depth * i / colors.size(), 0. });
+    for (size_t i = 0; i < slab_count; i++) {
+        TriangleMesh color_part = make_cube(width, depth / slab_count, height);
+        color_part.translate({ 0.f, depth * i / slab_count, 0. });
         v.model_per_colors[i].init_from(color_part);
     }
+    if (show_brim && !colors.empty())
+        v.model_per_colors[slab_count].init_from(brim_slab);
     v.model.init_from(wipe_tower_shell);
     v.mesh_raycaster = std::make_unique<GUI::MeshRaycaster>(std::make_shared<const TriangleMesh>(wipe_tower_shell));
     v.set_convex_hull(wipe_tower_shell);

--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -2905,7 +2905,9 @@ void GLCanvas3D::reload_scene(bool refresh_immediately, bool force_full_scene_re
                 Vec3d wipe_tower_size(footprint.width, footprint.depth, footprint.height);
 
                 // set_default_wipe_tower_pos_for_plate doesn't rerun when painting changes the
-                // filament count, so redo its clamp here on every reload.
+                // filament count, so redo its clamp here on every reload — unconditionally: a
+                // paint-triggered reload can arrive before the background process invalidates
+                // psWipeTower, so gating on it would skip the clamp exactly when it is needed.
                 {
                     Vec3d clamped_pos, clamped_size;
                     part_plate->estimate_wipe_tower_polygon(full_config, plate_id, clamped_pos, clamped_size);

--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -2904,8 +2904,20 @@ void GLCanvas3D::reload_scene(bool refresh_immediately, bool force_full_scene_re
                 float brim_width = float(footprint.brim_width);
                 Vec3d wipe_tower_size(footprint.width, footprint.depth, footprint.height);
 
-                // The stored position is already clamped onto the bed, by
-                // set_default_wipe_tower_pos_for_plate and again on every drag.
+                // set_default_wipe_tower_pos_for_plate doesn't rerun when painting changes the
+                // filament count, so redo its clamp here on every reload.
+                {
+                    Vec3d clamped_pos, clamped_size;
+                    part_plate->estimate_wipe_tower_polygon(full_config, plate_id, clamped_pos, clamped_size);
+                    if (std::abs(x - (float) clamped_pos(0)) > EPSILON || std::abs(y - (float) clamped_pos(1)) > EPSILON) {
+                        x = (float) clamped_pos(0);
+                        y = (float) clamped_pos(1);
+                        ConfigOptionFloat wt_x_opt(x), wt_y_opt(y);
+                        dynamic_cast<ConfigOptionFloats*>(proj_cfg.option("wipe_tower_x"))->set_at(&wt_x_opt, plate_id, 0);
+                        dynamic_cast<ConfigOptionFloats*>(proj_cfg.option("wipe_tower_y"))->set_at(&wt_y_opt, plate_id, 0);
+                    }
+                }
+
                 if (!current_print->is_step_done(psWipeTower) || !current_print->wipe_tower_data().wipe_tower_mesh_data) {
                     // update for wipe tower position
                     int volume_idx_wipe_tower_new = m_volumes.load_wipe_tower_preview(1000 + plate_id, x + plate_origin(0), y + plate_origin(1),

--- a/src/slic3r/GUI/PartPlate.cpp
+++ b/src/slic3r/GUI/PartPlate.cpp
@@ -2405,13 +2405,26 @@ arrangement::ArrangePolygon PartPlate::estimate_wipe_tower_polygon(const Dynamic
 		const BoundingBox cb = get_extents(WipeTower2::cone_base_polygon(w, depth, wt_size.z(), cone_angle_opt->getFloat()));
 		wp_brim_width += float(std::max({0., unscaled(cb.max.x()) - w, unscaled(cb.max.y()) - depth, -unscaled(cb.min.x()), -unscaled(cb.min.y())}));
 	}
+	// A position valid by WIPE_TOWER_MARGIN is the user's choice and stays untouched; an
+	// invalid one is re-placed with the comfort margin (falling back to the validity bounds
+	// on cramped plates). std::clamp is UB if lo > hi, so keep every hi >= lo.
 	const float margin = WIPE_TOWER_MARGIN + wp_brim_width;
 	BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << boost::format("arrange wipe_tower: wp_brim_width %1%") % wp_brim_width;
-
-	// A tower too deep for the plate leaves no valid position: clamping with hi < lo is UB and
-	// in release silently returns the negative hi.
-	x = std::clamp(x, margin, std::max(margin, (float)plate_width - w - margin));
-	y = std::clamp(y, margin, std::max(margin, (float)plate_depth - depth - margin));
+	const float x_hi   = std::max(margin, (float) plate_width - w - margin);
+	const float y_hi   = std::max(margin, (float) plate_depth - depth - margin);
+	const float margin_c = (float) WIPE_TOWER_AUTO_MARGIN + wp_brim_width;
+	float x_lo_c = margin_c, x_hi_c = (float) plate_width - w - margin_c;
+	if (x_lo_c > x_hi_c) { x_lo_c = margin; x_hi_c = x_hi; }
+	float y_lo_c = margin_c, y_hi_c = (float) plate_depth - depth - margin_c;
+	if (y_lo_c > y_hi_c) { y_lo_c = margin; y_hi_c = y_hi; }
+	// Drag clamps reach this limit through the volume's bounding box (post-slice: the real
+	// mesh, a couple of mm inside this reserved estimate), so a drop can land slightly out
+	// of bounds — snap it onto the bound; only far-out positions get the comfort re-place.
+	const float tol = 5.f;
+	if (x < margin - tol || x > x_hi + tol) x = std::clamp(x, x_lo_c, x_hi_c);
+	else                                    x = std::clamp(x, margin, x_hi);
+	if (y < margin - tol || y > y_hi + tol) y = std::clamp(y, y_lo_c, y_hi_c);
+	else                                    y = std::clamp(y, margin, y_hi);
     wt_pos(0) = x;
     wt_pos(1) = y;
     wt_pos(2) = 0.f;
@@ -4505,7 +4518,7 @@ void PartPlateList::set_default_wipe_tower_pos_for_plate(int plate_idx, bool ini
 
     // Brim-aware margin: the brim extends outward from the tower position.
     const float brim_width = float(footprint.brim_width);
-    const float margin     = WIPE_TOWER_MARGIN + brim_width;
+    const float margin     = WIPE_TOWER_AUTO_MARGIN + brim_width;
 
     // clamp wipe tower position within plate boundaries
     {

--- a/src/slic3r/GUI/PartPlate.cpp
+++ b/src/slic3r/GUI/PartPlate.cpp
@@ -21,6 +21,7 @@
 #include "libslic3r/libslic3r.h"
 #include "libslic3r/Polygon.hpp"
 #include "libslic3r/GCode/WipeTowerEstimate.hpp"
+#include "libslic3r/GCode/WipeTower2.hpp"
 #include "libslic3r/ClipperUtils.hpp"
 #include "libslic3r/BoundingBox.hpp"
 #include "libslic3r/Geometry.hpp"
@@ -2324,22 +2325,20 @@ WipeTowerFootprint PartPlate::estimate_wipe_tower_footprint(const DynamicPrintCo
 {
     // The CLI calls this too, so the plate's filaments are derived from the passed config:
     // get_extruders(bool) reads the same keys off wxGetApp()'s presets, which the CLI has none of.
-    std::vector<int> plate_extruders;
-    if (plate_extruder_size == 0) {
-        plate_extruders     = get_extruders(true, config, config);
-        plate_extruder_size = int(plate_extruders.size());
-    }
+    // An explicit count is a floor: init-time and arrange estimates size an empty plate for that
+    // many generic filaments, the lowest ids not already on the plate.
+    std::vector<int> plate_extruders = get_extruders(true, config, config);
+    for (int id = 1; int(plate_extruders.size()) < plate_extruder_size; ++id)
+        if (std::find(plate_extruders.begin(), plate_extruders.end(), id) == plate_extruders.end())
+            plate_extruders.push_back(id);
     // The wipe tower filament joins the tool ordering even when unused (Print::extruders), so
-    // validation counts it. An explicit count is the plate's painted filaments, which never do.
+    // validation counts it.
     const ConfigOption *wipe_tower_filament_opt = config.option("wipe_tower_filament");
     const int           wipe_tower_filament     = wipe_tower_filament_opt != nullptr ? wipe_tower_filament_opt->getInt() : 0;
-    if (plate_extruder_size > 1 && wipe_tower_filament > 0) {
-        if (plate_extruders.empty())
-            plate_extruders = get_extruders(true, config, config);
-        if (std::find(plate_extruders.begin(), plate_extruders.end(), wipe_tower_filament) == plate_extruders.end())
-            ++plate_extruder_size;
-    }
-    if (plate_extruder_size == 0)
+    if (plate_extruders.size() > 1 && wipe_tower_filament > 0 &&
+        std::find(plate_extruders.begin(), plate_extruders.end(), wipe_tower_filament) == plate_extruders.end())
+        plate_extruders.push_back(wipe_tower_filament);
+    if (plate_extruders.empty())
         return WipeTowerFootprint();
 
     // Tallest object on this plate and the thinnest layer it is sliced at, resolved per object
@@ -2371,7 +2370,11 @@ WipeTowerFootprint PartPlate::estimate_wipe_tower_footprint(const DynamicPrintCo
     if (layer_height == std::numeric_limits<double>::max())
         layer_height = global_layer_height;
 
-    return Slic3r::estimate_wipe_tower_footprint(config, size_t(plate_extruder_size), layer_height, max_height, any_raft);
+    std::vector<unsigned int> filament_ids;
+    for (int id : plate_extruders)
+        if (id > 0)
+            filament_ids.push_back(static_cast<unsigned int>(id - 1));
+    return Slic3r::estimate_wipe_tower_footprint(config, resolve_wipe_tower_type(config), filament_ids, layer_height, max_height, any_raft);
 }
 
 Vec3d PartPlate::estimate_wipe_tower_size(const DynamicPrintConfig &config, int plate_extruder_size, bool use_global_objects) const
@@ -2392,8 +2395,17 @@ arrangement::ArrangePolygon PartPlate::estimate_wipe_tower_polygon(const Dynamic
 	float depth = wt_size(1);
 	// Resolved brim, not the raw option: "Auto" (-1) would yield a margin of 0 and let the
 	// clamp put the brim off the bed. Matches set_default_wipe_tower_pos_for_plate.
-	const float wp_brim_width = float(footprint.brim_width);
-	const float margin        = WIPE_TOWER_MARGIN + wp_brim_width;
+	float wp_brim_width = float(footprint.brim_width);
+	// A Type2 stabilization cone bulges past the body box like a brim does - fold its worst-axis
+	// bulge into the same margin (Type1 ignores the cone option).
+	const auto *cone_wall_opt  = config.option("wipe_tower_wall_type");
+	const auto *cone_angle_opt = config.option("wipe_tower_cone_angle");
+	if (cone_wall_opt != nullptr && cone_wall_opt->getInt() == int(WipeTowerWallType::wtwCone) && cone_angle_opt != nullptr &&
+	    cone_angle_opt->getFloat() > EPSILON && resolve_wipe_tower_type(config) == WipeTowerType::Type2) {
+		const BoundingBox cb = get_extents(WipeTower2::cone_base_polygon(w, depth, wt_size.z(), cone_angle_opt->getFloat()));
+		wp_brim_width += float(std::max({0., unscaled(cb.max.x()) - w, unscaled(cb.max.y()) - depth, -unscaled(cb.min.x()), -unscaled(cb.min.y())}));
+	}
+	const float margin = WIPE_TOWER_MARGIN + wp_brim_width;
 	BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << boost::format("arrange wipe_tower: wp_brim_width %1%") % wp_brim_width;
 
 	// A tower too deep for the plate leaves no valid position: clamping with hi < lo is UB and

--- a/src/slic3r/GUI/PartPlate.hpp
+++ b/src/slic3r/GUI/PartPlate.hpp
@@ -340,7 +340,8 @@ public:
 
     Vec3d get_origin() { return m_origin; }
     //Vec3d calculate_wipe_tower_size(const DynamicPrintConfig &config, const double w, const double wipe_volume, int plate_extruder_size = 0, bool use_global_objects = false) const;
-    // plate_extruder_size: filaments purged on the plate; 0 derives it from the plate's objects.
+    // plate_extruder_size: at least this many filaments are purged on the plate; the plate's own
+    //                      filaments are always counted, so 0 sizes for exactly those.
     WipeTowerFootprint estimate_wipe_tower_footprint(const DynamicPrintConfig & config, int plate_extruder_size = 0, bool use_global_objects = false) const;
     Vec3d estimate_wipe_tower_size(const DynamicPrintConfig & config, int plate_extruder_size = 0, bool use_global_objects = false) const;
     arrangement::ArrangePolygon estimate_wipe_tower_polygon(const DynamicPrintConfig & config, int plate_index, Vec3d& wt_pos, Vec3d& wt_size, int plate_extruder_size = 0, bool use_global_objects = false) const;

--- a/src/slic3r/GUI/Selection.cpp
+++ b/src/slic3r/GUI/Selection.cpp
@@ -1274,9 +1274,10 @@ void Selection::translate(const Vec3d &displacement, TransformationType transfor
                 Vec3d         tower_origin        = m_cache.volumes_data[i].get_volume_position();
                 Vec3d         actual_displacement = displacement;
                 bool show_read_wipe_tower = wxGetApp().plater()->get_partplate_list().get_plate(plate_idx)->fff_print()->is_step_done(psWipeTower);
-                float brim_width = wxGetApp().preset_bundle->prints.get_edited_preset().config.opt_float("prime_tower_brim_width");
-
-                const double margin = show_read_wipe_tower ? WIPE_TOWER_MARGIN : brim_width + 0.5; // 0.5 is the line width of wipe tower
+                // Both preview volumes carry the brim in their bounding box (the estimate
+                // preview merges a brim slab, the sliced preview the real brim mesh), so the
+                // drag clamp only pads by the wipe tower line width.
+                const double margin = show_read_wipe_tower ? WIPE_TOWER_MARGIN : 0.5; // 0.5 is the line width of wipe tower
 
                 actual_displacement = (m_cache.volumes_data[i].get_instance_rotation_matrix() * m_cache.volumes_data[i].get_instance_scale_matrix() *
                                         m_cache.volumes_data[i].get_instance_mirror_matrix())

--- a/src/slic3r/GUI/Selection.cpp
+++ b/src/slic3r/GUI/Selection.cpp
@@ -1273,11 +1273,9 @@ void Selection::translate(const Vec3d &displacement, TransformationType transfor
                 const Polygons bed_polys{wxGetApp().plater()->get_partplate_list().get_plate(plate_idx)->get_shared_printable_polygon()};
                 Vec3d         tower_origin        = m_cache.volumes_data[i].get_volume_position();
                 Vec3d         actual_displacement = displacement;
-                bool show_read_wipe_tower = wxGetApp().plater()->get_partplate_list().get_plate(plate_idx)->fff_print()->is_step_done(psWipeTower);
-                // Both preview volumes carry the brim in their bounding box (the estimate
-                // preview merges a brim slab, the sliced preview the real brim mesh), so the
-                // drag clamp only pads by the wipe tower line width.
-                const double margin = show_read_wipe_tower ? WIPE_TOWER_MARGIN : 0.5; // 0.5 is the line width of wipe tower
+                // Both preview volumes carry the brim in their bounding box, and the release
+                // clamp holds it WIPE_TOWER_MARGIN inside — same margin, so drops don't snap.
+                const double margin = WIPE_TOWER_MARGIN;
 
                 actual_displacement = (m_cache.volumes_data[i].get_instance_rotation_matrix() * m_cache.volumes_data[i].get_instance_scale_matrix() *
                                         m_cache.volumes_data[i].get_instance_mirror_matrix())

--- a/tests/fff_print/test_gcodewriter.cpp
+++ b/tests/fff_print/test_gcodewriter.cpp
@@ -574,6 +574,9 @@ static DynamicPrintConfig dual_extruder_toolchange_config()
     config.set_key_value("nozzle_temperature_range_high", new ConfigOptionInts({240, 240}));
     config.set_key_value("flush_multiplier",     new ConfigOptionFloats({1}));
     config.set_key_value("flush_volumes_matrix", new ConfigOptionFloats({0, 140, 140, 0}));
+    // Inside the 200x200 test bed; the default y, 220, is not, and generation rejects that.
+    config.set_key_value("wipe_tower_x",         new ConfigOptionFloats({50.}));
+    config.set_key_value("wipe_tower_y",         new ConfigOptionFloats({50.}));
     return config;
 }
 

--- a/tests/fff_print/test_wipe_tower.cpp
+++ b/tests/fff_print/test_wipe_tower.cpp
@@ -152,6 +152,8 @@ static DynamicPrintConfig wipe_tower_toolchange_config(const std::string &gcode_
         { "outer_wall_filament_id",     2 },
         { "inner_wall_filament_id",     2 },
         { "enable_prime_tower",         true },
+        { "wipe_tower_x",               50 }, // inside the 200x200 test bed
+        { "wipe_tower_y",               50 }, // (the default y, 220, is not)
         { "layer_height",               0.3 },
         { "gcode_flavor",               gcode_flavor },
     });

--- a/tests/fff_print/test_wipe_tower.cpp
+++ b/tests/fff_print/test_wipe_tower.cpp
@@ -184,11 +184,13 @@ TEST_CASE("The wipe tower's toolchange planner flush follows the gcode flavor", 
 }
 
 // What Print feeds the shared estimate. The libslic3r WipeTowerEstimate cases cannot see this:
-// they call the estimator directly.
-static DynamicPrintConfig tower_estimate_config(const char *wall_type)
+// they call the estimator directly. The estimate counts the filaments the print really uses,
+// so the two-filament shape gives the outer wall the second one.
+static DynamicPrintConfig tower_estimate_config(const char *wall_type, unsigned int filaments = 2)
 {
     // 100 mm3 per purge on a 50 mm wide tower: one purge is 100/(layer_height * 50) of depth.
-    return multifilament_config(2, {
+    return multifilament_config(filaments, {
+        { "outer_wall_filament_id",         filaments == 2 ? "2" : "1" },
         { "enable_prime_tower",             "1"       },
         { "wipe_tower_wall_type",           wall_type },
         { "prime_tower_width",              "50"      },
@@ -253,13 +255,13 @@ TEST_CASE("A single-filament plate reserves a tower only when one is actually pr
     Model model;
 
     SECTION("no tool change and nothing else that prints one") {
-        const DynamicPrintConfig config = tower_estimate_config("rib");
+        const DynamicPrintConfig config = tower_estimate_config("rib", 1);
         init_print({ cube(20) }, print, model, config);
         CHECK_THAT(print.wipe_tower_data(1).depth, Catch::Matchers::WithinAbs(0., 1e-6));
     }
 
     SECTION("a raft puts the tower on every layer below the object") {
-        DynamicPrintConfig config = tower_estimate_config("rib");
+        DynamicPrintConfig config = tower_estimate_config("rib", 1);
         config.set_deserialize_strict({ { "raft_layers", "3" } });
         init_print({ cube(20) }, print, model, config);
         CHECK(print.wipe_tower_data(1).depth > 0.f);

--- a/tests/libslic3r/CMakeLists.txt
+++ b/tests/libslic3r/CMakeLists.txt
@@ -40,6 +40,7 @@ add_executable(${_TEST_NAME}_tests
     test_timeutils.cpp
     test_voronoi.cpp
     test_wipe_tower_estimate.cpp
+    test_wipe_tower.cpp
     test_optimizers.cpp
     test_ordering_strategies.cpp
     # test_png_io.cpp

--- a/tests/libslic3r/test_wipe_tower.cpp
+++ b/tests/libslic3r/test_wipe_tower.cpp
@@ -1,0 +1,93 @@
+#include <catch2/catch_all.hpp>
+
+#include <cmath>
+
+#include "libslic3r/BoundingBox.hpp"
+#include "libslic3r/ClipperUtils.hpp"
+#include "libslic3r/GCode/WipeTower.hpp"
+#include "libslic3r/GCode/WipeTower2.hpp"
+
+using namespace Slic3r;
+using Catch::Matchers::WithinAbs;
+
+// A Bambu P1S project that reproduced the off-plate brim: two PLAs priming 30 and 45 mm3 in
+// separate adhesiveness categories on a 35 mm tower, 0.21 mm layers, 0.4 nozzle (0.5 mm lines),
+// 150 % infill gap (0.75 mm line pitch), rib width 8, 16 mm tall.
+static std::vector<WipeTower::PurgeEstimate> cube_purges(int first_category = 100)
+{
+    return {{30.f, first_category}, {45.f, 0}};
+}
+
+TEST_CASE("Cone base polygon bulges past the body box", "[WipeTower]") {
+    // Zero angle: plain body box.
+    const Polygon box = WipeTower2::cone_base_polygon(35., 20., 100., 0.);
+    CHECK(box.points.size() == 4);
+    CHECK(get_extents(box).size() == Point::new_scale(Vec2d(35., 20.)));
+    // A 25-degree cone on a 100 mm tower: base radius R = tan(12.5deg)*100 = 22.2 mm,
+    // which exceeds the body half-depth, so the footprint bulges to center +- R in y
+    // (support_scale keeps the x extent compressed near the body).
+    const Polygon     base = WipeTower2::cone_base_polygon(35., 20., 100., 25.);
+    const BoundingBox bb   = get_extents(base);
+    const double      R    = std::tan(25. / 2. * M_PI / 180.) * 100.;
+    CHECK_THAT(unscaled(bb.min.y()), WithinAbs(10. - R, 0.1));
+    CHECK_THAT(unscaled(bb.max.y()), WithinAbs(10. + R, 0.1));
+    // The footprint always contains the body box.
+    CHECK(diff(Polygons{box}, Polygons{base}).empty());
+}
+
+TEST_CASE("Type1 block-stack depth quantizes each purge to whole lines", "[WipeTower]") {
+    // A 0.5 mm line at 0.21 mm carries 0.0955 mm3 per mm, so across the 34 mm between the
+    // perimeters 30 mm3 is 10 lines and 45 mm3 is 14: 7.5 + 10.5 at the 0.75 mm pitch behind
+    // one perimeter width. The generated mesh of the project measured exactly this.
+    CHECK_THAT(WipeTower::estimate_tower_blocks_depth(cube_purges(), 35.f, 0.21f, 0.4f, 1.5f), WithinAbs(18.5f, 0.01f));
+    // Sharing one category, a layer can never purge into every filament (one of them starts
+    // the layer), so the block is sized by its worst layer and the 10-line purge drops out.
+    CHECK_THAT(WipeTower::estimate_tower_blocks_depth(cube_purges(0), 35.f, 0.21f, 0.4f, 1.5f), WithinAbs(11.0f, 0.01f));
+    CHECK_THAT(WipeTower::estimate_tower_blocks_depth({}, 35.f, 0.2f, 0.4f, 1.f), WithinAbs(0.f, 1e-6f));
+    // A width narrower than two perimeter widths cannot hold purge lines.
+    CHECK_THAT(WipeTower::estimate_tower_blocks_depth({{45.f, 0}}, 0.9f, 0.2f, 0.4f, 1.f), WithinAbs(0.f, 1e-6f));
+}
+
+TEST_CASE("A nozzle change adds its ramming lines to the block", "[WipeTower]") {
+    // 10 mm of 1.75 mm filament (24.05 mm3) laid as 1.0 mm nozzle-change lines at 0.2 mm
+    // (0.1914 mm2 each) is 125.7 mm; across the 48.5 mm available that is 3 lines of 1.0 mm.
+    std::vector<WipeTower::PurgeEstimate> purges{{100.f, 0}, {100.f, 0}};
+    const float without_change = WipeTower::estimate_tower_blocks_depth(purges, 50.f, 0.2f, 0.4f, 1.f);
+    purges.front().filament_change_length = 10.f;
+    CHECK_THAT(WipeTower::estimate_tower_blocks_depth(purges, 50.f, 0.2f, 0.4f, 1.f) - without_change, WithinAbs(3.f, 1e-4f));
+}
+
+TEST_CASE("Rib tower footprint estimate covers the generated footprint", "[WipeTower]") {
+    // The generated first-layer wall bbox of the project measured 29.56 mm from the sliced
+    // G-code; the volume-only estimate said 23.585 mm.
+    const float side = WipeTower::estimate_rib_tower_bbox_side(cube_purges(), 35.f, 0.21f, 0.4f, 1.5f, 8.f, 0.f, 16.f);
+    CHECK(side >= 29.56f);
+    CHECK(side <= 29.56f + 4.f); // without grossly over-reserving plate space
+    // Separate categories stack their blocks, so the footprint must not shrink when they differ.
+    CHECK(side >= WipeTower::estimate_rib_tower_bbox_side(cube_purges(0), 35.f, 0.21f, 0.4f, 1.5f, 8.f, 0.f, 16.f));
+    CHECK_THAT(WipeTower::estimate_rib_tower_bbox_side({}, 35.f, 0.2f, 0.4f, 1.f, 8.f, 0.f, 16.f), WithinAbs(0.f, 1e-6f));
+}
+
+TEST_CASE("Rib footprint extends the ribs, not the body, below the stability minimum", "[WipeTower]") {
+    // A 10 mm body under a 90 mm print: the ribs stretch to the minimum depth's diagonal, and
+    // the rib width is capped at half the body, so the square grows to minimum + 5 / sqrt(2).
+    const float min_depth = WipeTower::get_limit_depth_by_height(90.f);
+    REQUIRE(min_depth > 10.f);
+    CHECK_THAT(WipeTower::rib_footprint_side(10.f, 10.f, 8.f, 0.f, 90.f), WithinAbs(min_depth + 5.f / std::sqrt(2.f), 1e-4f));
+    // The extra rib length runs along the diagonal, so it shows as its projection on each axis.
+    const float plain = WipeTower::rib_footprint_side(30.f, 30.f, 8.f, 0.f, 5.f);
+    CHECK_THAT(plain, WithinAbs(30.f + 8.f / std::sqrt(2.f), 1e-4f));
+    CHECK_THAT(WipeTower::rib_footprint_side(30.f, 30.f, 8.f, 4.f, 5.f) - plain, WithinAbs(4.f / std::sqrt(2.f), 1e-4f));
+    // A negative extra length cannot pull the ribs inside the diagonal.
+    CHECK_THAT(WipeTower::rib_footprint_side(30.f, 30.f, 8.f, -4.f, 5.f), WithinAbs(plain, 1e-4f));
+    CHECK_THAT(WipeTower::rib_footprint_side(0.f, 30.f, 8.f, 0.f, 5.f), WithinAbs(0.f, 1e-6f));
+}
+
+TEST_CASE("Brim width estimate matches each generator's loop quantization", "[WipeTower]") {
+    // 3 mm configured, 0.4 nozzle, 0.2 first layer: 0.4571 mm spacing, 7 loops. WipeTower2
+    // prints and reports the 7 loops; WipeTower reports half a spacing of line width on top.
+    const float spacing = 0.5f - 0.2f * float(1. - M_PI_4);
+    CHECK_THAT(WipeTower::estimate_brim_real_width(3.f, 0.4f, 0.2f, true), WithinAbs(7.f * spacing, 1e-4f));
+    CHECK_THAT(WipeTower::estimate_brim_real_width(3.f, 0.4f, 0.2f, false), WithinAbs(7.5f * spacing, 1e-4f));
+    CHECK_THAT(WipeTower::estimate_brim_real_width(0.f, 0.4f, 0.2f, true), WithinAbs(0.f, 1e-6f));
+}

--- a/tests/libslic3r/test_wipe_tower_estimate.cpp
+++ b/tests/libslic3r/test_wipe_tower_estimate.cpp
@@ -6,6 +6,7 @@
 #include "libslic3r/PrintConfig.hpp"
 
 #include <cmath>
+#include <numeric>
 #include <string>
 
 using namespace Slic3r;
@@ -28,12 +29,16 @@ static DynamicPrintConfig make_config(const char *wall_type = "rectangle")
     DynamicPrintConfig config = preset_shaped_defaults();
     config.set_key_value("prime_tower_width", new ConfigOptionFloat(50.));
     config.set_key_value("prime_volume", new ConfigOptionFloat(100.));
+    config.set_key_value("filament_prime_volume", new ConfigOptionFloats({100.}));
+    config.set_key_value("filament_adhesiveness_category", new ConfigOptionInts({0}));
     config.set_key_value("prime_tower_infill_gap", new ConfigOptionPercent(100.));
+    config.set_key_value("wipe_tower_extra_spacing", new ConfigOptionPercent(100.));
     config.set_key_value("prime_tower_brim_width", new ConfigOptionFloat(3.));
     config.set_deserialize_strict("wipe_tower_wall_type", wall_type);
     config.set_key_value("wipe_tower_rib_width", new ConfigOptionFloat(8.));
     config.set_key_value("wipe_tower_extra_rib_length", new ConfigOptionFloat(0.));
     config.set_key_value("nozzle_diameter", new ConfigOptionFloats({0.4}));
+    config.set_key_value("initial_layer_print_height", new ConfigOptionFloat(0.2));
     config.set_deserialize_strict("timelapse_type", "0");
     config.set_key_value("enable_wrapping_detection", new ConfigOptionBool(false));
     config.set_key_value("raft_layers", new ConfigOptionInt(0));
@@ -42,51 +47,133 @@ static DynamicPrintConfig make_config(const char *wall_type = "rectangle")
     return config;
 }
 
+static std::vector<unsigned int> filaments(size_t count)
+{
+    std::vector<unsigned int> ids(count);
+    std::iota(ids.begin(), ids.end(), 0u);
+    return ids;
+}
+
+// The first `count` filaments on the given planner; Type2 unless a case says otherwise.
+static WipeTowerFootprint estimate(const ConfigBase &config, size_t count, double layer_height, double height, bool any_raft = false, WipeTowerType type = WipeTowerType::Type2)
+{
+    return estimate_wipe_tower_footprint(config, type, filaments(count), layer_height, height, any_raft);
+}
+
+// What both planners print for a 3 mm brim at 0.4 nozzle and 0.2 first layer (0.4571 mm loops).
+static double printed_brim(double configured, WipeTowerType type)
+{
+    return WipeTower::estimate_brim_real_width(float(configured), 0.4f, 0.2f, type == WipeTowerType::Type2);
+}
+
 TEST_CASE("A rectangle wall tower is sized by the purge volume", "[WipeTowerEstimate]") {
     const DynamicPrintConfig config = make_config();
     // Three filaments purge twice per layer; a 5 mm object keeps the stability floor at 5 mm.
-    const WipeTowerFootprint fp = estimate_wipe_tower_footprint(config, 3, 0.2, 5., false);
+    const WipeTowerFootprint fp = estimate(config, 3, 0.2, 5.);
     CHECK_THAT(fp.width, WithinAbs(50., 1e-9));
     CHECK_THAT(fp.depth, WithinAbs(20., 1e-9));
     CHECK_THAT(fp.height, WithinAbs(5., 1e-9));
-    CHECK_THAT(fp.brim_width, WithinAbs(3., 1e-9));
+    CHECK_THAT(fp.brim_width, WithinAbs(printed_brim(3., WipeTowerType::Type2), 1e-6));
     // Thinner layers need more depth for the same volume.
-    CHECK_THAT(estimate_wipe_tower_footprint(config, 3, 0.1, 5., false).depth, WithinAbs(40., 1e-9));
-    // The infill gap spaces the purge lines.
-    DynamicPrintConfig spaced = config;
-    spaced.set_key_value("prime_tower_infill_gap", new ConfigOptionPercent(150.));
-    CHECK_THAT(estimate_wipe_tower_footprint(spaced, 3, 0.2, 5., false).depth, WithinAbs(30., 1e-9));
+    CHECK_THAT(estimate(config, 3, 0.1, 5.).depth, WithinAbs(40., 1e-9));
+}
+
+TEST_CASE("Each planner spaces its purge lines by its own option", "[WipeTowerEstimate]") {
+    // Type2 reads wipe_tower_extra_spacing and Type1 prime_tower_infill_gap; neither sees the
+    // other's key. Type2's extra flow cancels out of its depth.
+    DynamicPrintConfig config = make_config();
+    config.set_key_value("wipe_tower_extra_flow", new ConfigOptionPercent(250.));
+    CHECK_THAT(estimate(config, 3, 0.2, 5.).depth, WithinAbs(20., 1e-9));
+    config.set_key_value("wipe_tower_extra_spacing", new ConfigOptionPercent(150.));
+    CHECK_THAT(estimate(config, 3, 0.2, 5.).depth, WithinAbs(30., 1e-9));
+    const double type1_spaced = estimate(config, 3, 0.2, 5., false, WipeTowerType::Type1).depth;
+    config.set_key_value("prime_tower_infill_gap", new ConfigOptionPercent(150.));
+    CHECK_THAT(estimate(config, 3, 0.2, 5.).depth, WithinAbs(30., 1e-9));
+    // Type1 stacks whole lines behind one 0.5 mm perimeter width, so only the stack scales.
+    CHECK_THAT(estimate(config, 3, 0.2, 5., false, WipeTowerType::Type1).depth - 0.5, WithinAbs(1.5 * (type1_spaced - 0.5), 1e-6));
+}
+
+TEST_CASE("Type1 sizes the tower from each filament's own prime volume", "[WipeTowerEstimate]") {
+    // The Bambu P1S project of the WipeTower cases: 30 and 45 mm3 in two categories on a 35 mm
+    // tower at 0.21 mm, 150 % gap, is 18.5 mm of stacked blocks (11 mm sharing one category).
+    DynamicPrintConfig config = make_config();
+    config.set_key_value("prime_tower_width", new ConfigOptionFloat(35.));
+    config.set_key_value("prime_tower_infill_gap", new ConfigOptionPercent(150.));
+    config.set_key_value("initial_layer_print_height", new ConfigOptionFloat(0.21));
+    config.set_key_value("filament_prime_volume", new ConfigOptionFloats({30., 45.}));
+    config.set_key_value("filament_adhesiveness_category", new ConfigOptionInts({100, 0}));
+    const std::vector<WipeTower::PurgeEstimate> purges{{30.f, 100}, {45.f, 0}};
+    const double blocks = WipeTower::estimate_tower_blocks_depth(purges, 35.f, 0.21f, 0.4f, 1.5f);
+    REQUIRE_THAT(blocks, WithinAbs(18.5, 0.01));
+    CHECK_THAT(estimate(config, 2, 0.21, 5., false, WipeTowerType::Type1).depth, WithinAbs(blocks, 1e-4));
+    // The ids pick the volumes, so their order does not matter and a lone filament has no purge.
+    CHECK_THAT(estimate_wipe_tower_footprint(config, WipeTowerType::Type1, {1, 0}, 0.21, 5., false).depth, WithinAbs(blocks, 1e-4));
+    CHECK_THAT(estimate(config, 1, 0.21, 5., false, WipeTowerType::Type1).depth, WithinAbs(0., 1e-9));
+    config.set_key_value("filament_adhesiveness_category", new ConfigOptionInts({0, 0}));
+    CHECK_THAT(estimate(config, 2, 0.21, 5., false, WipeTowerType::Type1).depth, WithinAbs(11., 0.01));
+    // A rib wall squares the same stack.
+    config.set_deserialize_strict("wipe_tower_wall_type", "rib");
+    const WipeTowerFootprint rib = estimate(config, 2, 0.21, 5., false, WipeTowerType::Type1);
+    CHECK_THAT(rib.width, WithinAbs(rib.depth, 1e-9));
+    CHECK_THAT(rib.depth, WithinAbs(WipeTower::estimate_rib_tower_bbox_side({{30.f, 0}, {45.f, 0}}, 35.f, 0.21f, 0.4f, 1.5f, 8.f, 0.f, 5.f), 1e-4));
+}
+
+TEST_CASE("A second nozzle adds the ramming of one nozzle change per layer", "[WipeTowerEstimate]") {
+    // Two filaments on two nozzles: the tool order crosses once per layer, and Type1 rams 10 mm
+    // of filament as three 1.0 mm nozzle-change lines (see the WipeTower case).
+    DynamicPrintConfig config = make_config();
+    config.set_key_value("nozzle_diameter", new ConfigOptionFloats({0.4, 0.4}));
+    config.set_key_value("filament_change_length", new ConfigOptionFloats({10., 10.}));
+    config.set_key_value("filament_diameter", new ConfigOptionFloats({1.75, 1.75}));
+    config.set_key_value("filament_map", new ConfigOptionInts({1, 1}));
+    const double same_nozzle = estimate(config, 2, 0.2, 5., false, WipeTowerType::Type1).depth;
+    config.set_key_value("filament_map", new ConfigOptionInts({1, 2}));
+    CHECK_THAT(estimate(config, 2, 0.2, 5., false, WipeTowerType::Type1).depth - same_nozzle, WithinAbs(3., 1e-4));
+}
+
+TEST_CASE("The tower is sized for the first layer when it is the thinnest", "[WipeTowerEstimate]") {
+    // Both planners reserve the worst layer: a 0.28 mm print with a 0.2 mm first layer needs
+    // the 0.2 mm depth, while a thicker first layer changes nothing.
+    DynamicPrintConfig config = make_config();
+    const double at_thinnest = estimate(config, 3, 0.2, 5.).depth;
+    CHECK_THAT(estimate(config, 3, 0.28, 5.).depth, WithinAbs(at_thinnest, 1e-9));
+    config.set_key_value("initial_layer_print_height", new ConfigOptionFloat(0.3));
+    CHECK(estimate(config, 3, 0.28, 5.).depth < at_thinnest);
 }
 
 TEST_CASE("Object height sets the stability floor and the auto brim", "[WipeTowerEstimate]") {
     DynamicPrintConfig config = make_config();
     // Two filaments purge once: 10 mm, lifted to the 20 mm floor of a 100 mm tower.
-    CHECK_THAT(estimate_wipe_tower_footprint(config, 2, 0.2, 100., false).depth, WithinAbs(20., 1e-9));
+    CHECK_THAT(estimate(config, 2, 0.2, 100.).depth, WithinAbs(20., 1e-9));
     config.set_key_value("prime_tower_brim_width", new ConfigOptionFloat(-1.));
-    CHECK_THAT(estimate_wipe_tower_footprint(config, 2, 0.2, 50., false).brim_width, WithinAbs(WipeTower::get_auto_brim_by_height(50.f), 1e-6));
+    const double auto_brim = WipeTower::get_auto_brim_by_height(50.f);
+    CHECK_THAT(estimate(config, 2, 0.2, 50.).brim_width, WithinAbs(printed_brim(auto_brim, WipeTowerType::Type2), 1e-6));
+    CHECK_THAT(estimate(config, 2, 0.2, 50., false, WipeTowerType::Type1).brim_width, WithinAbs(printed_brim(auto_brim, WipeTowerType::Type1), 1e-6));
 }
 
 TEST_CASE("A single filament only gets a tower when one is printed anyway", "[WipeTowerEstimate]") {
     DynamicPrintConfig config = make_config();
-    CHECK_THAT(estimate_wipe_tower_footprint(config, 1, 0.2, 100., false).depth, WithinAbs(0., 1e-9));
-    CHECK_THAT(estimate_wipe_tower_footprint(config, 0, 0.2, 100., false).width, WithinAbs(0., 1e-9));
+    CHECK_THAT(estimate(config, 1, 0.2, 100.).depth, WithinAbs(0., 1e-9));
+    CHECK_THAT(estimate(config, 0, 0.2, 100.).width, WithinAbs(0., 1e-9));
 
-    // Wrapping detection prints a tower on the first layers whatever the filament count.
+    // Wrapping detection prints a tower on the first layers whatever the filament count: the
+    // Type1 planner's fixed 10 mm, the stability floor otherwise.
     config.set_key_value("enable_wrapping_detection", new ConfigOptionBool(true));
-    CHECK_THAT(estimate_wipe_tower_footprint(config, 1, 0.2, 100., false).depth, WithinAbs(20., 1e-9));
+    CHECK_THAT(estimate(config, 1, 0.2, 100.).depth, WithinAbs(20., 1e-9));
+    CHECK_THAT(estimate(config, 1, 0.2, 100., false, WipeTowerType::Type1).depth, WithinAbs(WipeTower::get_wrapping_detection_depth(), 1e-9));
     config.set_key_value("enable_wrapping_detection", new ConfigOptionBool(false));
 
     // So does a raft. raft_layers is a per-object key, so it arrives as a resolved flag and
     // is deliberately not read off the config.
-    CHECK_THAT(estimate_wipe_tower_footprint(config, 1, 0.2, 100., true).depth, WithinAbs(20., 1e-9));
+    CHECK_THAT(estimate(config, 1, 0.2, 100., true).depth, WithinAbs(20., 1e-9));
     config.set_key_value("raft_layers", new ConfigOptionInt(3));
-    CHECK_THAT(estimate_wipe_tower_footprint(config, 1, 0.2, 100., false).depth, WithinAbs(0., 1e-9));
+    CHECK_THAT(estimate(config, 1, 0.2, 100.).depth, WithinAbs(0., 1e-9));
     config.set_key_value("raft_layers", new ConfigOptionInt(0));
 
     config.set_deserialize_strict("timelapse_type", "1");
     // Smooth timelapse primes the single filament once: 10 mm, lifted to the floor.
-    CHECK_THAT(estimate_wipe_tower_footprint(config, 1, 0.2, 100., false).depth, WithinAbs(20., 1e-9));
-    CHECK_THAT(estimate_wipe_tower_footprint(config, 1, 0.2, 5., false).depth, WithinAbs(10., 1e-9));
+    CHECK_THAT(estimate(config, 1, 0.2, 100.).depth, WithinAbs(20., 1e-9));
+    CHECK_THAT(estimate(config, 1, 0.2, 5.).depth, WithinAbs(10., 1e-9));
 }
 
 TEST_CASE("Both wall types agree on whether there is a tower at all", "[WipeTowerEstimate]") {
@@ -97,41 +184,40 @@ TEST_CASE("Both wall types agree on whether there is a tower at all", "[WipeTowe
     DynamicPrintConfig rib  = make_config("rib");
 
     // No tool change and nothing else that prints a tower - neither wall type reserves one.
-    CHECK_THAT(estimate_wipe_tower_footprint(rect, 1, 0.2, height, false).depth, WithinAbs(0., 1e-9));
-    CHECK_THAT(estimate_wipe_tower_footprint(rib, 1, 0.2, height, false).depth, WithinAbs(0., 1e-9));
+    CHECK_THAT(estimate(rect, 1, 0.2, height).depth, WithinAbs(0., 1e-9));
+    CHECK_THAT(estimate(rib, 1, 0.2, height).depth, WithinAbs(0., 1e-9));
 
     // Not even on a dual-nozzle printer, where a lone filament still needs no purge.
     rect.set_key_value("nozzle_diameter", new ConfigOptionFloats({0.4, 0.4}));
     rib.set_key_value("nozzle_diameter", new ConfigOptionFloats({0.4, 0.4}));
-    CHECK_THAT(estimate_wipe_tower_footprint(rect, 1, 0.2, height, false).depth, WithinAbs(0., 1e-9));
-    CHECK_THAT(estimate_wipe_tower_footprint(rib, 1, 0.2, height, false).depth, WithinAbs(0., 1e-9));
+    CHECK_THAT(estimate(rect, 1, 0.2, height).depth, WithinAbs(0., 1e-9));
+    CHECK_THAT(estimate(rib, 1, 0.2, height).depth, WithinAbs(0., 1e-9));
 
     // With a tool change both reserve one, and both respect the stability floor.
-    CHECK(estimate_wipe_tower_footprint(rect, 2, 0.2, height, false).depth >= WipeTower::get_limit_depth_by_height(float(height)));
-    CHECK(estimate_wipe_tower_footprint(rib, 2, 0.2, height, false).depth >= WipeTower::get_limit_depth_by_height(float(height)));
+    CHECK(estimate(rect, 2, 0.2, height).depth >= WipeTower::get_limit_depth_by_height(float(height)));
+    CHECK(estimate(rib, 2, 0.2, height).depth >= WipeTower::get_limit_depth_by_height(float(height)));
 }
 
 TEST_CASE("A rib wall squares the tower and caps the rib width", "[WipeTowerEstimate]") {
     DynamicPrintConfig config = make_config("rib");
     // sqrt(200 / 0.2) = 31.62 mm square, plus the 8 mm rib bulge along the diagonal.
     const double body = std::sqrt(1000.);
-    WipeTowerFootprint fp = estimate_wipe_tower_footprint(config, 3, 0.2, 5., false);
-    CHECK_THAT(fp.depth, WithinAbs(8. / std::sqrt(2.) + body, 1e-9));
+    WipeTowerFootprint fp = estimate(config, 3, 0.2, 5.);
+    CHECK_THAT(fp.depth, WithinAbs(8. / std::sqrt(2.) + body, 1e-5));
     CHECK_THAT(fp.width, WithinAbs(fp.depth, 1e-9));
-    // The extra rib length grows the footprint.
+    // The extra rib length runs along the diagonal and grows the footprint by its projection.
     config.set_key_value("wipe_tower_extra_rib_length", new ConfigOptionFloat(4.));
-    CHECK_THAT(estimate_wipe_tower_footprint(config, 3, 0.2, 5., false).depth, WithinAbs(8. / std::sqrt(2.) + body + 4., 1e-9));
+    CHECK_THAT(estimate(config, 3, 0.2, 5.).depth, WithinAbs((8. + 4.) / std::sqrt(2.) + body, 1e-5));
     // A tiny tower caps the rib width at half its depth: 5 mm body, 2.5 mm rib.
     config.set_key_value("wipe_tower_extra_rib_length", new ConfigOptionFloat(0.));
     config.set_key_value("prime_volume", new ConfigOptionFloat(5.));
-    CHECK_THAT(estimate_wipe_tower_footprint(config, 2, 0.2, 5., false).depth, WithinAbs(2.5 / std::sqrt(2.) + 5., 1e-9));
+    CHECK_THAT(estimate(config, 2, 0.2, 5.).depth, WithinAbs(2.5 / std::sqrt(2.) + 5., 1e-5));
 }
 
 TEST_CASE("Every wall and tower type is read the same from a preset and a static config", "[WipeTowerEstimate]") {
     // The GUI, arrange and the CLI pass a DynamicPrintConfig whose enums are
     // ConfigOptionEnumGeneric; Print passes a static config whose enums are ConfigOptionEnum<T>.
-    // The wall type is read by value, so both give the same shape, and the wipe tower
-    // implementation is not an input to the footprint at all.
+    // Both the wall type and the planner selection are read by value, so both give the same shape.
     const char *wall_type  = GENERATE("rectangle", "cone", "rib");
     const char *tower_type = GENERATE("type1", "type2");
     DynamicPrintConfig preset = make_config(wall_type);
@@ -143,17 +229,18 @@ TEST_CASE("Every wall and tower type is read the same from a preset and a static
     REQUIRE(static_config.wipe_tower_wall_type.serialize() == wall_type);
     REQUIRE(static_config.wipe_tower_type.serialize() == tower_type);
 
-    // Three filaments purge twice per layer on a 5 mm object: a 50 x 20 rectangle, or a square.
-    const WipeTowerFootprint fp = estimate_wipe_tower_footprint(preset, 3, 0.2, 5., false);
-    if (std::string(wall_type) == "rib") {
-        CHECK_THAT(fp.width, WithinAbs(fp.depth, 1e-9));
-        CHECK_THAT(fp.depth, WithinAbs(8. / std::sqrt(2.) + std::sqrt(1000.), 1e-9));
-    } else {
-        CHECK_THAT(fp.width, WithinAbs(50., 1e-9));
-        CHECK_THAT(fp.depth, WithinAbs(20., 1e-9));
-    }
+    const WipeTowerType type = resolve_wipe_tower_type(preset);
+    CHECK(type == (std::string(tower_type) == "type1" ? WipeTowerType::Type1 : WipeTowerType::Type2));
+    CHECK(resolve_wipe_tower_type(static_config) == type);
 
-    const WipeTowerFootprint from_static = estimate_wipe_tower_footprint(static_config, 3, 0.2, 5., false);
+    // Three filaments purge twice per layer on a 5 mm object.
+    const WipeTowerFootprint fp          = estimate(preset, 3, 0.2, 5., false, type);
+    const WipeTowerFootprint from_static = estimate(static_config, 3, 0.2, 5., false, type);
+    CHECK(fp.depth > 0.);
+    if (std::string(wall_type) == "rib")
+        CHECK_THAT(fp.width, WithinAbs(fp.depth, 1e-9));
+    else
+        CHECK_THAT(fp.width, WithinAbs(50., 1e-9));
     CHECK_THAT(from_static.width, WithinAbs(fp.width, 1e-9));
     CHECK_THAT(from_static.depth, WithinAbs(fp.depth, 1e-9));
     CHECK_THAT(from_static.brim_width, WithinAbs(fp.brim_width, 1e-9));
@@ -162,8 +249,19 @@ TEST_CASE("Every wall and tower type is read the same from a preset and a static
     // through both storages too.
     preset.set_deserialize_strict("timelapse_type", "1");
     static_config.apply(preset, true);
-    CHECK(estimate_wipe_tower_footprint(preset, 1, 0.2, 5., false).depth > 0.);
-    CHECK(estimate_wipe_tower_footprint(static_config, 1, 0.2, 5., false).depth > 0.);
+    CHECK(estimate(preset, 1, 0.2, 5., false, type).depth > 0.);
+    CHECK(estimate(static_config, 1, 0.2, 5., false, type).depth > 0.);
+}
+
+TEST_CASE("A Bambu Lab printer always gets the Type1 planner", "[WipeTowerEstimate]") {
+    DynamicPrintConfig config = make_config();
+    config.set_deserialize_strict("wipe_tower_type", "type2");
+    config.set_key_value("printer_model", new ConfigOptionString("Bambu Lab X1 Carbon"));
+    CHECK(resolve_wipe_tower_type(config) == WipeTowerType::Type1);
+    config.set_key_value("printer_model", new ConfigOptionString("Voron 2.4"));
+    CHECK(resolve_wipe_tower_type(config) == WipeTowerType::Type2);
+    config.erase("wipe_tower_type");
+    CHECK(resolve_wipe_tower_type(config) == WipeTowerType::Type2);
 }
 
 TEST_CASE("A dual nozzle purges every filament plus the filament change", "[WipeTowerEstimate]") {
@@ -173,7 +271,7 @@ TEST_CASE("A dual nozzle purges every filament plus the filament change", "[Wipe
     config.set_key_value("filament_diameter", new ConfigOptionFloats({1.75, 1.75}));
     // Two purges of 100 mm3 plus one 10 mm filament change: (200 + 10 * pi * 1.75^2 / 4) / (0.2 * 50).
     const double change_volume = 10. * PI * 1.75 * 1.75 / 4.;
-    CHECK_THAT(estimate_wipe_tower_footprint(config, 2, 0.2, 5., false).depth, WithinAbs((200. + change_volume) / 10., 1e-9));
+    CHECK_THAT(estimate(config, 2, 0.2, 5.).depth, WithinAbs((200. + change_volume) / 10., 1e-9));
 }
 
 TEST_CASE("The shipped defaults size the tower from the flush matrix", "[WipeTowerEstimate]") {
@@ -188,19 +286,18 @@ TEST_CASE("The shipped defaults size the tower from the flush matrix", "[WipeTow
 
     const double flush_volume = WipeTower2::estimate_semm_flush_volume(config, 2);
     const double expected     = std::max(double(WipeTower::get_limit_depth_by_height(5.f)), flush_volume / (0.2 * 50.));
-    CHECK_THAT(estimate_wipe_tower_footprint(config, 2, 0.2, 5., false).depth, WithinAbs(expected, 1e-6));
+    CHECK_THAT(estimate(config, 2, 0.2, 5.).depth, WithinAbs(expected, 1e-6));
 }
 
 TEST_CASE("A config missing a tower key falls back to that key's default", "[WipeTowerEstimate]") {
     // The signature takes any ConfigBase: an absent key must read as its declared default.
     const DynamicPrintConfig full = make_config();
     DynamicPrintConfig       partial = full;
-    partial.erase("prime_tower_infill_gap");
-    REQUIRE(partial.option("prime_tower_infill_gap") == nullptr);
+    partial.erase("wipe_tower_extra_spacing");
+    REQUIRE(partial.option("wipe_tower_extra_spacing") == nullptr);
 
     DynamicPrintConfig defaulted = full;
-    defaulted.set_key_value("prime_tower_infill_gap",
-                            print_config_def.get("prime_tower_infill_gap")->default_value->clone());
-    CHECK_THAT(estimate_wipe_tower_footprint(partial, 3, 0.2, 5., false).depth,
-               WithinAbs(estimate_wipe_tower_footprint(defaulted, 3, 0.2, 5., false).depth, 1e-9));
+    defaulted.set_key_value("wipe_tower_extra_spacing",
+                            print_config_def.get("wipe_tower_extra_spacing")->default_value->clone());
+    CHECK_THAT(estimate(partial, 3, 0.2, 5.).depth, WithinAbs(estimate(defaulted, 3, 0.2, 5.).depth, 1e-9));
 }


### PR DESCRIPTION
# Description

**Integration branch — the full wipe tower footprint series in one PR, based on #15532.** This is the combined stack of #15516 (footprint estimate, preview, placement), #15517 (generation-time footprint checks) and #15518 (CLI pre-slice placement), opened so the whole series can be reviewed and tested as one unit. The three stacked PRs remain the intended merge path; this PR carries the same 7 commits.

The bug family: the wipe tower's preview, clamped position, and printed footprint disagreed. Most visibly, painting a model multi-color left the default tower position unadjusted, and slicing then added a brim that crept off the plate with no warning — silently in the GUI, and with a misleading -102 *after* writing the G-code at the CLI.

What the series does, by commit:

1. **Fixes for Wipe Tower Position Clamping** — validation grows the estimated body by the brim before generation; the scene reload re-clamps the stored position when painting changes the filament count; the rectangle-wall footprint polygon gets its two missing brim corners.
2. **Size the Footprint Estimate from the Planners** — #15532's shared estimate reserved every tower with one volume-per-purge rule. It now mirrors the planners: Type1 wipes each filament's own prime volume in whole lines, one block per adhesiveness category sized by its worst layer, rams the leaving filament at nozzle changes, and squares a rib tower from the planned depth; Type2 spaces by `wipe_tower_extra_spacing` with its extra flow cancelling out. Both extend the ribs below the stability minimum, size the thinnest layer including the first, and lay the brim in whole loops per planner. Planner selection is one `resolve_wipe_tower_type`; the estimate takes filament ids, which the `PartPlate` adapter derives from the passed config so the CLI sizes per filament too.
3. **Verify WipeTower Footprint at Point of Generation** — after generation, `Print::_make_wipe_tower` tests the mesh-bottom footprint (brim and rib offset included) against the printable polygon and exclusion areas and throws a clear `SlicingError`. Pre-generation validation hard-checks the body plus an explicit brim and warns on the estimated auto brim and cone base. `construct_mesh` gains a cone branch so cone-wall towers are checked too.
4. **Brim and Cone Aware Preview** — the translucent tower renders its brim ring and cone base bulge and folds them into the shell, so the outside-plate warning and drag clamp react to the true first-layer extent.
5. **[CLI]: Place Wipe Tower before Slicing** — a pre-slice placement pass clamps every plate's tower via `PartPlate::estimate_wipe_tower_polygon`, skipping only plates that print no tower; also fixes two assemble-flow sites that read `prime_tower_width` (35 mm) as the brim width.
6. **Match Drag Margin to Release Clamp** — the drag and release clamps share `WIPE_TOWER_MARGIN`, so dragging to the limit no longer snaps back.
7. **Add Separate Comfort Margin for Auto Placement** — positions that no longer fit are re-placed with `WIPE_TOWER_AUTO_MARGIN` (15 mm) so auto-positioned towers sit clearly inside the plate, while a stored position within 1 mm is always respected.

Behavior changes to note (no new or changed translatable strings, no 3MF/profile/format changes; G-code for any already-valid position is byte-identical):

* Type1 towers auto-place a few mm further from the plate edge; Type2 towers a few mm closer.
* Prints that previously "succeeded" while physically printing off the plate or into the exclusion zone now fail with a clear message, or are repositioned by the GUI/CLI clamp before it comes to that.
* Reopening a project whose stored tower violates the corrected margins repositions the tower and marks the project modified.
* A caller's explicit filament count is a floor over the plate's own filaments; the Type2 rectangle keeps the stability floor the estimate always applied (follow-up).

# Screenshots/Recordings/Graphs

See #15516 for the brim-preview and comfort-margin before/after recordings.

## Tests

* `tests/libslic3r/test_wipe_tower.cpp` (new, 7 cases) and `test_wipe_tower_estimate.cpp` (extended): block-stack depth pinned to the generator-measured 18.5 mm, nozzle-change ramming lines, rib footprint bounded against the G-code-measured 29.56 mm, brim loop rounding per planner, cone base polygon extents, per-filament Type1 sizing, first-layer bound, planner resolution, preset-shaped vs static config agreement.
* Suites at the tip (`51e426bb3d`): libslic3r 351/351, fff_print 153/153.
* CLI probe over four scenario projects (bad stored rib position, no stored position, rectangle at the former clamp limit, brim reaching the exclusion corner), every produced G-code checked with an arc-aware extents parser: bad position auto-clamped and slices clean, exclusion case rejected early with a clear error, zero off-plate G-code files across all scenarios.
* GUI smoke to be re-run on the rebased branch: painted-cube default placement, near-edge drag clamping with no snap-back, opt-in Type1 profile preview matching the sliced size, Type2 cone preview, Type2 placement regression.

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
