### PR TITLE
Fix organic support being printed into object top surfaces

### DIFF
--- a/src/libslic3r/Support/SupportCommon.cpp
+++ b/src/libslic3r/Support/SupportCommon.cpp
@@ -1652,28 +1652,32 @@ void generate_support_toolpaths(
                 if (top_contact_layer.could_merge(interface_layer) && ! raft_layer)
                     top_contact_layer.merge(std::move(interface_layer));
             }
-            if (!bottom_interfaces && support_params.can_merge_support_regions) {
-                if (base_layer.could_merge(bottom_contact_layer))
-                    base_layer.merge(std::move(bottom_contact_layer));
-                else if (base_layer.empty() && ! bottom_contact_layer.empty() && ! bottom_contact_layer.layer->bridging)
-                    base_layer = std::move(bottom_contact_layer);
-            } else if (bottom_contact_layer.could_merge(top_contact_layer) && ! raft_layer) {
-                if (top_interfaces && bottom_interfaces) {
-                    top_contact_layer.merge(std::move(bottom_contact_layer));
-                } else if (bottom_interfaces) {
-                    top_contact_layer.set_polygons_to_extrude(
-                        diff(top_contact_layer.polygons_to_extrude(), bottom_contact_layer.polygons_to_extrude()));
-                } else {
-                    bottom_contact_layer.set_polygons_to_extrude(
-                        diff(bottom_contact_layer.polygons_to_extrude(), top_contact_layer.polygons_to_extrude()));
-                }
-            } else if (bottom_contact_layer.could_merge(interface_layer) && ! organic_tree) {
-                const bool interface_layer_is_bottom = interface_layer.layer->layer_type == SupporLayerType::BottomInterface;
-                if (bottom_interfaces && interface_layer_is_bottom) {
-                    bottom_contact_layer.merge(std::move(interface_layer));
-                } else {
-                    bottom_contact_layer.set_polygons_to_extrude(
-                        diff(bottom_contact_layer.polygons_to_extrude(), interface_layer.polygons_to_extrude()));
+            // Orca: Organic bottom contacts are projection seeds, not same-layer toolpaths.
+            // Do not merge them into another same-layer support region.
+            if (!organic_tree) {
+                if (!bottom_interfaces && support_params.can_merge_support_regions) {
+                    if (base_layer.could_merge(bottom_contact_layer))
+                        base_layer.merge(std::move(bottom_contact_layer));
+                    else if (base_layer.empty() && ! bottom_contact_layer.empty() && ! bottom_contact_layer.layer->bridging)
+                        base_layer = std::move(bottom_contact_layer);
+                } else if (bottom_contact_layer.could_merge(top_contact_layer) && ! raft_layer) {
+                    if (top_interfaces && bottom_interfaces) {
+                        top_contact_layer.merge(std::move(bottom_contact_layer));
+                    } else if (bottom_interfaces) {
+                        top_contact_layer.set_polygons_to_extrude(
+                            diff(top_contact_layer.polygons_to_extrude(), bottom_contact_layer.polygons_to_extrude()));
+                    } else {
+                        bottom_contact_layer.set_polygons_to_extrude(
+                            diff(bottom_contact_layer.polygons_to_extrude(), top_contact_layer.polygons_to_extrude()));
+                    }
+                } else if (bottom_contact_layer.could_merge(interface_layer)) {
+                    const bool interface_layer_is_bottom = interface_layer.layer->layer_type == SupporLayerType::BottomInterface;
+                    if (bottom_interfaces && interface_layer_is_bottom) {
+                        bottom_contact_layer.merge(std::move(interface_layer));
+                    } else {
+                        bottom_contact_layer.set_polygons_to_extrude(
+                            diff(bottom_contact_layer.polygons_to_extrude(), interface_layer.polygons_to_extrude()));
+                    }
                 }
             }
 


### PR DESCRIPTION
## Summary

This PR fixes an issue where organic tree support could generate an extra printable support region on an object's top surface when another support interface existed at the same Z height.

For organic tree support, bottom contact regions are only used as projection seeds for generating the requested bottom interface layers. They are not meant to be printed directly.

The generic same-layer merge logic could still merge these bottom contacts into base support, top contact, or interface layers. Once merged, the projection seed became part of the printable support geometry, which could place support directly on the object's top surface and appear as an extra support or interface layer.

## Result
Organic bottom contacts are now excluded from these same-layer merge paths. Non-organic support behavior is unchanged.

## Screenshots

|Before|After|
|---|---|
|<img width="1541" height="734" alt="image" src="https://github.com/user-attachments/assets/d5fc6380-37a0-45d9-9e20-5c91d645f67c" />|<img width="1614" height="784" alt="image" src="https://github.com/user-attachments/assets/ef4f5c29-d167-4dbf-a541-5711669ad90b" />|

---

Fixes #15523

---

<!--
> A guide for users on how to download the artifacts from this PR.
-->

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
