### PR TITLE
fix: Virtual Camera Tools install downloads the network plugin

### DIFF
--- a/src/slic3r/GUI/MediaPlayCtrl.cpp
+++ b/src/slic3r/GUI/MediaPlayCtrl.cpp
@@ -494,13 +494,13 @@ void MediaPlayCtrl::ToggleStream()
                     DownloadProgressDialog2(MediaPlayCtrl *ctrl) : DownloadProgressDialog(_L("Downloading Virtual Camera Tools")), ctrl(ctrl) {}
                     struct UpgradeNetworkJob2 : UpgradeNetworkJob
                     {
-                        UpgradeNetworkJob2(std::shared_ptr<ProgressIndicator> pri) : UpgradeNetworkJob() {
+                        UpgradeNetworkJob2() {
                             name         = "cameratools";
                             package_name = "camera_tools.zip";
                         }
                     };
-                    std::shared_ptr<UpgradeNetworkJob> make_job(std::shared_ptr<ProgressIndicator> pri)
-                    { return std::make_shared<UpgradeNetworkJob2>(pri); }
+                    std::unique_ptr<UpgradeNetworkJob> make_job() override
+                    { return std::make_unique<UpgradeNetworkJob2>(); }
                     void                               on_finish() override
                     {
                         ctrl->CallAfter([ctrl = this->ctrl] { ctrl->ToggleStream(); });


### PR DESCRIPTION
# Description
Fixes #6466 

`DownloadProgressDialog2::make_job` stopped overriding the base `make_job()` in `1bb8fad63f` (April 2024), so the base runs instead and downloads `networking_plugins.zip` into `<data_dir>/plugins`, while `start_stream_service` looks for the tools in `<data_dir>/cameratools`. `on_finish` then retriggers the install, which is the loop reported in #6466.

Found while clearing `-Woverloaded-virtual` for #15374.

# Screenshots/Recordings/Graphs

No visual change.

## Tests

Not tested end to end, since I have no Bambu printer. I did confirm the endpoint the fixed code targets is live on Windows, macOS and Linux, and that the package it returns contains exactly the three files `start_stream_service` looks for.

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
