### PR TITLE
build: clear 75 warnings - hidden base overloads

### DIFF
--- a/src/libslic3r/Int128.hpp
+++ b/src/libslic3r/Int128.hpp
@@ -125,7 +125,6 @@ public:
 /******************************************** Splitting the 128bit number into two 64bit words *********************************************/
 
 	Int128(int64_t lo = 0) : m_lo((uint64_t)lo), m_hi((lo < 0) ? -1 : 0) {}
-	Int128(const Int128 &val) : m_lo(val.m_lo), m_hi(val.m_hi) {}
 	Int128(const int64_t& hi, const uint64_t& lo) : m_lo(lo), m_hi(hi) {}
 
 	Int128& operator = (const int64_t &val)

--- a/src/slic3r/GUI/AMSMaterialsSetting.cpp
+++ b/src/slic3r/GUI/AMSMaterialsSetting.cpp
@@ -1938,11 +1938,6 @@ void ColorPickerPopup::paintEvent(wxPaintEvent& evt)
 
 void ColorPickerPopup::OnDismiss() {}
 
-void ColorPickerPopup::Popup()
-{
-    PopupWindow::Popup();
-}
-
 bool ColorPickerPopup::ProcessLeftDown(wxMouseEvent& event) {
     return PopupWindow::ProcessLeftDown(event);
 }

--- a/src/slic3r/GUI/AMSMaterialsSetting.hpp
+++ b/src/slic3r/GUI/AMSMaterialsSetting.hpp
@@ -85,7 +85,6 @@ public:
     void set_ams_colours(std::vector<wxColour> ams);
     void set_def_colour(wxColour col);
     void paintEvent(wxPaintEvent& evt);
-    void Popup();
     virtual void OnDismiss() wxOVERRIDE;
     virtual bool ProcessLeftDown(wxMouseEvent& event) wxOVERRIDE;
 

--- a/src/slic3r/GUI/AMSSetting.cpp
+++ b/src/slic3r/GUI/AMSSetting.cpp
@@ -292,7 +292,7 @@ void AMSSetting::UpdateByObj(MachineObject* obj)
 
     update_ams_img(obj);
 
-    m_ams_type->Update(obj);
+    m_ams_type->UpdateInfo(obj);
     //m_ams_arrange_order->Update(obj);
     update_insert_material_read_mode(obj);
     m_sizer_remain_block->Show(obj->is_support_update_remain);
@@ -624,7 +624,7 @@ void AMSSettingTypePanel::CreateGui()
     Fit();
 }
 
-void AMSSettingTypePanel::Update(const MachineObject* obj)
+void AMSSettingTypePanel::UpdateInfo(const MachineObject* obj)
 {
     if (!obj) {
         Show(false);

--- a/src/slic3r/GUI/AMSSetting.hpp
+++ b/src/slic3r/GUI/AMSSetting.hpp
@@ -110,7 +110,7 @@ public:
     ~AMSSettingTypePanel();
 
 public:
-    void Update(const MachineObject* obj);
+    void UpdateInfo(const MachineObject* obj);
 
 private:
     void CreateGui();

--- a/src/slic3r/GUI/DeviceTab/uiAMSBestPositionPopup.cpp
+++ b/src/slic3r/GUI/DeviceTab/uiAMSBestPositionPopup.cpp
@@ -705,7 +705,7 @@ ReselectMachineDialog::ReselectMachineDialog(wxWindow* parent)
     Centre();
 }
 
-void ReselectMachineDialog::Update(MachineObject* obj, const std::map<int, int>&  best_pos_map, const std::vector<FilamentInfo>& ams_mapping, wxString save_time)
+void ReselectMachineDialog::UpdateInfo(MachineObject* obj, const std::map<int, int>&  best_pos_map, const std::vector<FilamentInfo>& ams_mapping, wxString save_time)
 {
 
     if (suggestText)

--- a/src/slic3r/GUI/DeviceTab/uiAMSBestPositionPopup.hpp
+++ b/src/slic3r/GUI/DeviceTab/uiAMSBestPositionPopup.hpp
@@ -188,7 +188,7 @@ class ReselectMachineDialog : public wxDialog
 public:
     ReselectMachineDialog(wxWindow* parent);
     ~ReselectMachineDialog();
-    void Update(MachineObject* obj,
+    void UpdateInfo(MachineObject* obj,
                 const std::map<int, int>&  best_pos_map,
                 const std::vector<FilamentInfo>& ams_mapping,
                 wxString save_time);

--- a/src/slic3r/GUI/DeviceTab/uiAmsHumidityPopup.cpp
+++ b/src/slic3r/GUI/DeviceTab/uiAmsHumidityPopup.cpp
@@ -98,7 +98,7 @@ void uiAmsPercentHumidityDryPopup::Create()
     Refresh();
 }
 
-void uiAmsPercentHumidityDryPopup::Update(int humidiy_level, int humidity_percent, int left_dry_time, float current_temperature)
+void uiAmsPercentHumidityDryPopup::UpdateInfo(int humidiy_level, int humidity_percent, int left_dry_time, float current_temperature)
 {
     if (m_humidity_level != humidiy_level || m_humidity_percent != humidity_percent ||
         m_left_dry_time != left_dry_time || m_current_temperature != current_temperature)

--- a/src/slic3r/GUI/DeviceTab/uiAmsHumidityPopup.h
+++ b/src/slic3r/GUI/DeviceTab/uiAmsHumidityPopup.h
@@ -38,14 +38,14 @@ public:
     ~uiAmsPercentHumidityDryPopup() = default;
 
 public:
-    void Update(uiAmsHumidityInfo *info) { m_ams_id = info->ams_id; Update(info->humidity_display_idx, info->humidity_percent, info->left_dry_time, info->current_temperature); };
+    void UpdateInfo(uiAmsHumidityInfo *info) { m_ams_id = info->ams_id; UpdateInfo(info->humidity_display_idx, info->humidity_percent, info->left_dry_time, info->current_temperature); };
 
     std::string get_owner_ams_id() const { return m_ams_id; }
 
     void msw_rescale();
 
 private:
-    void Update(int humidiy_level, int humidity_percent, int left_dry_time, float current_temperature);
+    void UpdateInfo(int humidiy_level, int humidity_percent, int left_dry_time, float current_temperature);
     void UpdateContents();
 
     void Create();

--- a/src/slic3r/GUI/DeviceTab/wgtDeviceNozzleRack.cpp
+++ b/src/slic3r/GUI/DeviceTab/wgtDeviceNozzleRack.cpp
@@ -399,7 +399,7 @@ void wgtDeviceNozzleRackArea::UpdateNozzleItems(const std::unordered_map<int, wg
 {
     for (auto iter : nozzle_items)
     {
-        iter.second->Update(nozzle_rack);
+        iter.second->UpdateInfo(nozzle_rack);
     }
 
     /*update nozzle possition and background*/
@@ -837,7 +837,7 @@ void wgtDeviceNozzleRackNozzleItem::SetSelected(bool selected)
     }
 }
 
-void wgtDeviceNozzleRackNozzleItem::Update(const std::shared_ptr<DevNozzleRack> rack, bool on_rack /*= true*/)
+void wgtDeviceNozzleRackNozzleItem::UpdateInfo(const std::shared_ptr<DevNozzleRack> rack, bool on_rack /*= true*/)
 {
     m_rack = rack;
 

--- a/src/slic3r/GUI/DeviceTab/wgtDeviceNozzleRack.h
+++ b/src/slic3r/GUI/DeviceTab/wgtDeviceNozzleRack.h
@@ -200,7 +200,7 @@ public:
     wgtDeviceNozzleRackNozzleItem(wxWindow* parent, int nozzle_id);
 
 public:
-    void Update(const std::shared_ptr<DevNozzleRack> rack, bool on_rack = true); // on_rack is false means extruder nozzle
+    void UpdateInfo(const std::shared_ptr<DevNozzleRack> rack, bool on_rack = true); // on_rack is false means extruder nozzle
 
     int  GetNozzleId() const { return m_nozzle_id; }
     void SetDisplayIdText(const wxString& text) { m_nozzle_label_id->SetLabel(text);};

--- a/src/slic3r/GUI/DeviceTab/wgtDeviceNozzleSelect.cpp
+++ b/src/slic3r/GUI/DeviceTab/wgtDeviceNozzleSelect.cpp
@@ -114,7 +114,7 @@ static void s_update_nozzle_info(wgtDeviceNozzleRackNozzleItem* item,
                                  std::shared_ptr<DevNozzleRack> rack,
                                  const DevNozzle& nozzle_info)
 {
-    item->Update(rack, nozzle_info.IsOnRack());
+    item->UpdateInfo(rack, nozzle_info.IsOnRack());
     if (nozzle_info.IsUnknown()) {
         if (item->GetToolTipText() != _L("Nozzle information needs to be read")) {
             item->SetToolTip(_L("Nozzle information needs to be read"));

--- a/src/slic3r/GUI/FilamentMapPanel.cpp
+++ b/src/slic3r/GUI/FilamentMapPanel.cpp
@@ -642,19 +642,12 @@ void FilamentMapBtnPanel::Select(bool selected)
     Refresh();
 }
 
-void GUI::FilamentMapBtnPanel::Hide()
+bool GUI::FilamentMapBtnPanel::Show(bool show)
 {
-    m_btn->Hide();
-    m_label->Hide();
-    m_detail->Hide();
-    wxPanel::Hide();
-}
-void GUI::FilamentMapBtnPanel::Show()
-{
-    m_btn->Show();
-    m_label->Show();
-    m_detail->Show();
-    wxPanel::Show();
+    m_btn->Show(show);
+    m_label->Show(show);
+    m_detail->Show(show);
+    return wxPanel::Show(show);
 }
 
 FilamentMapAutoPanel::FilamentMapAutoPanel(wxWindow *parent, FilamentMapMode mode, bool machine_synced) : wxPanel(parent)
@@ -694,18 +687,11 @@ FilamentMapAutoPanel::FilamentMapAutoPanel(wxWindow *parent, FilamentMapMode mod
     Layout();
     GUI::wxGetApp().UpdateDarkUIWin(this);
 }
-void FilamentMapAutoPanel::Hide()
+bool FilamentMapAutoPanel::Show(bool show)
 {
-    m_flush_panel->Hide();
-    m_match_panel->Hide();
-    wxPanel::Hide();
-}
-
-void FilamentMapAutoPanel::Show()
-{
-    m_flush_panel->Show();
-    m_match_panel->Show();
-    wxPanel::Show();
+    m_flush_panel->Show(show);
+    m_match_panel->Show(show);
+    return wxPanel::Show(show);
 }
 
 void FilamentMapAutoPanel::UpdateStatus()
@@ -743,16 +729,10 @@ FilamentMapDefaultPanel::FilamentMapDefaultPanel(wxWindow *parent) : wxPanel(par
     GUI::wxGetApp().UpdateDarkUIWin(this);
 }
 
-void FilamentMapDefaultPanel::Hide()
+bool FilamentMapDefaultPanel::Show(bool show)
 {
-    m_label->Hide();
-    wxPanel::Hide();
-}
-
-void FilamentMapDefaultPanel::Show()
-{
-    m_label->Show();
-    wxPanel::Show();
+    m_label->Show(show);
+    return wxPanel::Show(show);
 }
 
 }} // namespace Slic3r::GUI

--- a/src/slic3r/GUI/FilamentMapPanel.hpp
+++ b/src/slic3r/GUI/FilamentMapPanel.hpp
@@ -69,10 +69,9 @@ class FilamentMapBtnPanel : public wxPanel
 {
 public:
     FilamentMapBtnPanel(wxWindow *parent, const wxString &label, const wxString &detail, const std::string &icon_path);
-    void Hide();
-    void Show();
+    bool Show(bool show = true) override;
     void Select(bool selected);
-    bool Enable(bool enable);
+    bool Enable(bool enable) override;
     bool IsEnabled() const { return m_enabled; }
 protected:
     void OnPaint(wxPaintEvent &event);
@@ -99,8 +98,7 @@ class FilamentMapAutoPanel : public wxPanel
 {
 public:
     FilamentMapAutoPanel(wxWindow *parent, FilamentMapMode mode, bool machine_synced);
-    void            Hide();
-    void            Show();
+    bool Show(bool show = true) override;
     FilamentMapMode GetMode() const { return m_mode; }
 
 private:
@@ -116,8 +114,7 @@ class FilamentMapDefaultPanel : public wxPanel
 {
 public:
     FilamentMapDefaultPanel(wxWindow *parent);
-    void Hide();
-    void Show();
+    bool Show(bool show = true) override;
 
 private:
     Label *m_label;

--- a/src/slic3r/GUI/SelectMachine.cpp
+++ b/src/slic3r/GUI/SelectMachine.cpp
@@ -2176,7 +2176,7 @@ void SelectMachineDialog::on_reselect_dialog_btn_clicked(wxMouseEvent&)
                 best_pos_map[slot.id] = pos.value();
         }
     }
-    m_best_pos_dialog->Update(obj, best_pos_map, m_ams_mapping_result, text);
+    m_best_pos_dialog->UpdateInfo(obj, best_pos_map, m_ams_mapping_result, text);
     m_best_pos_dialog->ShowModal();
 }
 
@@ -2201,7 +2201,7 @@ void SelectMachineDialog::update_best_pos_dialog(wxCommandEvent& evt)
                 best_pos_map[slot.id] = pos.value();
         }
     }
-    m_best_pos_dialog->Update(obj_, best_pos_map, m_ams_mapping_result, text);
+    m_best_pos_dialog->UpdateInfo(obj_, best_pos_map, m_ams_mapping_result, text);
 }
 
 void SelectMachineDialog::show_status(PrintDialogStatus status, std::vector<wxString> params, wxString wiki_url)

--- a/src/slic3r/GUI/SendToPrinter.cpp
+++ b/src/slic3r/GUI/SendToPrinter.cpp
@@ -1391,7 +1391,7 @@ void SendToPrinterDialog::show_status(PrintDialogStatus status, std::vector<wxSt
             update_print_status_msg(wxEmptyString, true, true);
             m_connecting_panel->Show();
             m_animaicon->Stop();
-            m_animaicon->Enable();
+            m_animaicon->ShowEnabledIcon();
 
             Layout();
             Enable_Send_Button(false);

--- a/src/slic3r/GUI/SlicingProgressNotification.cpp
+++ b/src/slic3r/GUI/SlicingProgressNotification.cpp
@@ -259,8 +259,8 @@ void NotificationManager::SlicingProgressNotification::render(GLCanvas3D& canvas
 		//	ImVec2 view_dailytips_text_pos = m_window_pos + ImVec2(text_left_margin_x, m_window_height / 2.0f + m_line_height * 0.2f);
 
 		//	bbl_render_left_sign(imgui, m_window_width, m_window_height, m_window_pos.x + m_window_width, m_window_pos.y);
-		//	render_text(text_pos);
-		//	render_close_button(button_pos, button_size);
+		//	render_progress_text(text_pos);
+		//	render_progress_close_button(button_pos, button_size);
 		//	render_show_dailytips(view_dailytips_text_pos);
 		//}
 
@@ -278,8 +278,8 @@ void NotificationManager::SlicingProgressNotification::render(GLCanvas3D& canvas
 				ImVec2 button_pos = child_window_pos + ImVec2(progress_panel_width - button_size.x, progress_panel_height - text_bottom - button_size.y / 2.0f);
 				ImVec2 text_pos = ImVec2(progress_bar_pos.x, progress_bar_pos.y - m_line_height * (1.2f + m_lines_count - 1));
 
-				render_text(text_pos);
-				render_close_button(button_pos, button_size);
+				render_progress_text(text_pos);
+				render_progress_close_button(button_pos, button_size);
 				if (m_sp_state == SlicingProgressState::SP_PROGRESS) {
 					render_bar(progress_bar_pos, progress_bar_size);
 					render_cancel_button(button_pos, button_size);
@@ -319,7 +319,7 @@ void NotificationManager::SlicingProgressNotification::render(GLCanvas3D& canvas
 		ImGui::PopStyleColor(3);
 }
 
-void Slic3r::GUI::NotificationManager::SlicingProgressNotification::render_text(const ImVec2& pos)
+void Slic3r::GUI::NotificationManager::SlicingProgressNotification::render_progress_text(const ImVec2& pos)
 {
 	ImGuiWrapper& imgui = *wxGetApp().imgui();
 	float scale = imgui.get_font_size() / 15.0f;
@@ -462,7 +462,7 @@ void Slic3r::GUI::NotificationManager::SlicingProgressNotification::render_cance
 	}
 }
 
-void NotificationManager::SlicingProgressNotification::render_close_button(const ImVec2& pos, const ImVec2& size)
+void NotificationManager::SlicingProgressNotification::render_progress_close_button(const ImVec2& pos, const ImVec2& size)
 {
 	if (m_sp_state == SlicingProgressState::SP_CANCELLED || m_sp_state == SlicingProgressState::SP_COMPLETED) {
 		ImGuiWrapper& imgui = *wxGetApp().imgui();

--- a/src/slic3r/GUI/SlicingProgressNotification.hpp
+++ b/src/slic3r/GUI/SlicingProgressNotification.hpp
@@ -53,10 +53,10 @@ protected:
     void        init() override;
     void        render(GLCanvas3D& canvas, float initial_y, bool move_from_overlay, float overlay_width, float right_margin) override;
     /* PARAMS: pos is relative to screen */
-    void	    render_text(const ImVec2& pos);
+    void	    render_progress_text(const ImVec2& pos);
     void		render_bar(const ImVec2& pos, const ImVec2& size);
     void		render_cancel_button(const ImVec2& pos, const ImVec2& size);
-    void		render_close_button(const ImVec2& pos, const ImVec2& size);
+    void		render_progress_close_button(const ImVec2& pos, const ImVec2& size);
     void        render_dailytips_panel(const ImVec2& pos, const ImVec2& size);
     void        render_show_dailytips(const ImVec2& pos);
 

--- a/src/slic3r/GUI/Widgets/AMSControl.cpp
+++ b/src/slic3r/GUI/Widgets/AMSControl.cpp
@@ -278,7 +278,7 @@ AMSControl::AMSControl(wxWindow *parent, wxWindowID id, const wxPoint &pos, cons
                 m_ams_dry_ctr_win->Move(popup_pos);
                 m_ams_dry_ctr_win->ShowModal();
             } else {
-                m_percent_humidity_dry_popup->Update(info);
+                m_percent_humidity_dry_popup->UpdateInfo(info);
 
                 wxPoint img_pos = ClientToScreen(wxPoint(0, 0));
                 wxPoint popup_pos(img_pos.x - m_percent_humidity_dry_popup->GetSize().GetWidth() + FromDIP(150), img_pos.y - FromDIP(80));
@@ -1034,7 +1034,7 @@ void AMSControl::UpdateAms(const std::string   &series_name,
                 humidity_info.humidity_percent = the_info.humidity_raw;
                 humidity_info.left_dry_time = the_info.left_dray_time;
                 humidity_info.current_temperature = the_info.current_temperature;
-                m_percent_humidity_dry_popup->Update(&humidity_info);
+                m_percent_humidity_dry_popup->UpdateInfo(&humidity_info);
                 break;
             }
         }

--- a/src/slic3r/GUI/Widgets/AnimaController.cpp
+++ b/src/slic3r/GUI/Widgets/AnimaController.cpp
@@ -78,7 +78,7 @@ void AnimaIcon::Stop()
     m_timer->Stop();
 }
 
-void AnimaIcon::Enable()
+void AnimaIcon::ShowEnabledIcon()
 {
     if (m_bitmap) { m_bitmap->SetBitmap(m_image_enable); }
 }

--- a/src/slic3r/GUI/Widgets/AnimaController.hpp
+++ b/src/slic3r/GUI/Widgets/AnimaController.hpp
@@ -13,7 +13,7 @@ public:
 
     void Play();
     void Stop();
-    void Enable();
+    void ShowEnabledIcon();
     bool IsPlaying() const { return IsRunning(); };
     bool IsRunning() const;
 

--- a/src/slic3r/GUI/Widgets/ErrorMsgStaticText.hpp
+++ b/src/slic3r/GUI/Widgets/ErrorMsgStaticText.hpp
@@ -17,7 +17,7 @@ public:
 
     void paintEvent(wxPaintEvent &evt);
 
-    void SetLabel(wxString msg){m_msg = msg;};
+    void SetLabel(const wxString &msg) override { m_msg = msg; }
 
 };
 #endif

--- a/src/slic3r/GUI/Widgets/MultiNozzleSync.cpp
+++ b/src/slic3r/GUI/Widgets/MultiNozzleSync.cpp
@@ -600,7 +600,7 @@ StaticBox* HotEndTable::CreateNozzleBox(const std::vector<int>& nozzle_indices)
 void HotEndTable::UpdateNozzleItems(const std::unordered_map<int, wgtDeviceNozzleRackNozzleItem*>& nozzle_items, std::shared_ptr<DevNozzleRack> nozzle_rack)
 {
     for (auto& item : nozzle_items)
-        item.second->Update(nozzle_rack);
+        item.second->UpdateInfo(nozzle_rack);
 }
 
 void HotEndTable::OnPaint(wxPaintEvent& evt)

--- a/src/slic3r/GUI/Widgets/RadioBox.cpp
+++ b/src/slic3r/GUI/Widgets/RadioBox.cpp
@@ -36,11 +36,6 @@ void RadioBox::SetValue(bool value)
     update();
 }
 
-bool RadioBox::GetValue()
-{
-    return wxBitmapToggleButton::GetValue();
-}
-
 
 void RadioBox::Rescale()
 {

--- a/src/slic3r/GUI/Widgets/RadioBox.hpp
+++ b/src/slic3r/GUI/Widgets/RadioBox.hpp
@@ -15,13 +15,9 @@ public:
 
 public:
     void SetValue(bool value) override;
-	bool GetValue();
     void Rescale();
     bool Disable() {
         return wxBitmapToggleButton::Disable();
-    }
-    bool Enable() {
-        return wxBitmapToggleButton::Enable();
     }
 
 private:


### PR DESCRIPTION
# Description

`-Woverloaded-virtual`, where a derived class hides a base virtual instead of overriding it. 15 sites across 10 files, from #15374.

Three were pure forwarders that did nothing but call the base, so they are gone; `RadioBox::Enable()` took no argument, so `Enable(false)` did not compile on a `RadioBox`. Four were meant to be overrides and now are, including three `FilamentMapPanel` classes that hand-rolled a `Show()`/`Hide()` pair and now match `FilamentMapManualPanel` in the same header. Eight are renamed so they no longer collide: the `Update(args)` family becomes `UpdateInfo` as in #15377, and `AnimaIcon::Enable()` becomes `ShowEnabledIcon()`, which is what it does. Nothing widens an overload set, so no existing call resolves anywhere new.

A sixteenth site in this category turned out to be a real bug, the Virtual Camera Tools install downloading the wrong package, and is split out into #15540.

`Int128.hpp` also loses a redundant copy constructor, a `-Wdeprecated-copy-with-user-provided-copy` site that only shows on Windows arm64 because the operator it deprecates is odr-used behind `#if defined(_M_X64)`.

# Screenshots/Recordings/Graphs

No visual change.

## Tests

No new tests. Deleting a forwarder or renaming a non-colliding function resolves the same call to the same function; the override conversions change which function a base-typed caller reaches, which is the point of them.

The category goes 115 to 40, which is the two sites #15062 covers plus the one in #15540, and no other category moved.

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
