### PR TITLE
Fix startup with missing filesystem locales

### DIFF
--- a/src/OrcaSlicer.cpp
+++ b/src/OrcaSlicer.cpp
@@ -45,7 +45,6 @@ using namespace nlohmann;
 #include <boost/nowide/cstdlib.hpp>
 #include <boost/nowide/iostream.hpp>
 #include <boost/nowide/fstream.hpp>
-#include <boost/nowide/filesystem.hpp>
 #include <boost/dll/runtime_symbol_info.hpp>
 #include <boost/log/trivial.hpp>
 
@@ -69,6 +68,7 @@ using namespace nlohmann;
 #include "libslic3r/Utils.hpp"
 #include "libslic3r/Time.hpp"
 #include "libslic3r/Thread.hpp"
+#include "libslic3r/LocalesUtils.hpp"
 #include "libslic3r/BlacklistedLibraryCheck.hpp"
 #include "libslic3r/FlushVolCalc.hpp"
 
@@ -1300,7 +1300,7 @@ int CLI::run(int argc, char **argv)
 
 	// Switch boost::filesystem to utf8.
     try {
-        boost::nowide::nowide_filesystem();
+        init_utf8_filesystem();
     } catch (const std::runtime_error& ex) {
         std::string caption = std::string(SLIC3R_APP_FULL_NAME) + " Error";
         std::string text = std::string("boost::nowide::nowide_filesystem Failed!\n") + (

--- a/src/libslic3r/LocalesUtils.cpp
+++ b/src/libslic3r/LocalesUtils.cpp
@@ -4,11 +4,29 @@
     #include <charconv>
 #endif
 #include <stdexcept>
+#include <cstdio>
+
+#include <boost/nowide/filesystem.hpp>
 
 #include <fast_float/fast_float.h>
 
 
 namespace Slic3r {
+
+void init_utf8_filesystem()
+{
+    try {
+        boost::nowide::nowide_filesystem();
+    } catch (const std::runtime_error& ex) {
+        // Boost.Filesystem installs the UTF-8 locale before constructing the
+        // previous locale to return. On Linux that return value can throw if
+        // an LC_* locale is missing (e.g. a partial Flatpak Locale extension).
+        // Retry with the now-installed locale so other failures still propagate.
+        boost::nowide::nowide_filesystem();
+        std::fprintf(stderr, "Warning: could not load the environment filesystem locale: %s. "
+                             "Using UTF-8 filesystem paths.\n", ex.what());
+    }
+}
 
 
 CNumericLocalesSetter::CNumericLocalesSetter()

--- a/src/libslic3r/LocalesUtils.hpp
+++ b/src/libslic3r/LocalesUtils.hpp
@@ -13,6 +13,9 @@
 
 namespace Slic3r {
 
+// Initialize UTF-8 filesystem paths even if the environment locale is unavailable.
+void init_utf8_filesystem();
+
 // RAII wrapper that sets LC_NUMERIC to "C" on construction
 // and restores the old value on destruction.
 class CNumericLocalesSetter {

--- a/tests/libslic3r/CMakeLists.txt
+++ b/tests/libslic3r/CMakeLists.txt
@@ -24,6 +24,7 @@ add_executable(${_TEST_NAME}_tests
     test_filament_mixer.cpp
     test_fill_plane_path.cpp
     test_geometry.cpp
+    test_localesutils.cpp
     test_multimaterial_segmentation.cpp
     test_placeholder_parser.cpp
     test_polygon.cpp
@@ -57,3 +58,18 @@ set_property(TARGET ${_TEST_NAME}_tests PROPERTY FOLDER "tests")
 orcaslicer_copy_test_dlls()
 
 orcaslicer_discover_tests(${_TEST_NAME}_tests)
+
+if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    # Each case needs a fresh process: Boost.Filesystem caches its path locale.
+    add_test(NAME filesystem_locale_missing_measurement
+        COMMAND ${_TEST_NAME}_tests "[LocalesUtils]")
+    set_tests_properties(filesystem_locale_missing_measurement PROPERTIES
+        ENVIRONMENT "LC_ALL=;LANG=C;LC_MEASUREMENT=orca_missing_locale.UTF-8"
+        LABELS "LocalesUtils;Regression")
+
+    add_test(NAME filesystem_locale_missing_override
+        COMMAND ${_TEST_NAME}_tests "[LocalesUtils]")
+    set_tests_properties(filesystem_locale_missing_override PROPERTIES
+        ENVIRONMENT "LC_ALL=orca_missing_locale.UTF-8"
+        LABELS "LocalesUtils;Regression")
+endif()

--- a/tests/libslic3r/test_localesutils.cpp
+++ b/tests/libslic3r/test_localesutils.cpp
@@ -1,0 +1,25 @@
+#include <catch2/catch_all.hpp>
+
+#include "libslic3r/LocalesUtils.hpp"
+
+#include <boost/filesystem/path.hpp>
+#include <locale>
+
+TEST_CASE("Filesystem initialization preserves UTF-8 paths and global locales", "[LocalesUtils]")
+{
+    const std::string original_c_locale = std::setlocale(LC_ALL, nullptr);
+    const std::locale original_cpp_locale;
+
+    REQUIRE_NOTHROW(Slic3r::init_utf8_filesystem());
+
+    // Include both Chinese characters and a character outside the BMP.
+    const std::string utf8_name = "\xE6\xA8\xA1\xE5\x9E\x8B-\xF0\x9F\x90\x99.3mf";
+    const std::wstring wide_name = L"\u6A21\u578B-\U0001F419.3mf";
+    CHECK(boost::filesystem::path(utf8_name).wstring() == wide_name);
+    CHECK(boost::filesystem::path(wide_name).string() == utf8_name);
+
+    REQUIRE_NOTHROW(Slic3r::init_utf8_filesystem());
+    CHECK(boost::filesystem::path(utf8_name).wstring() == wide_name);
+    CHECK(std::string(std::setlocale(LC_ALL, nullptr)) == original_c_locale);
+    CHECK(std::locale() == original_cpp_locale);
+}


### PR DESCRIPTION
# Description

On Linux, OrcaSlicer exits during filesystem initialization when the environment requests a locale that is not installed. For example, `LANG=en_US.UTF-8` with `LC_MEASUREMENT=zh_CN.UTF-8` fails when a Flatpak runtime has only the English locale subset installed:

```text
locale::facet::_S_create_c_locale name not valid
```

Related to [#12961: 2.3.2 not launching on Linux flatpack](https://github.com/OrcaSlicer/OrcaSlicer/issues/12961), where startup reports are unblocked by `LC_ALL=C.UTF-8` ([reporter confirmation](https://github.com/OrcaSlicer/OrcaSlicer/issues/12961#issuecomment-4578064477)). This patch targets the missing-locale startup failure; the thread also contains separate missing-library and WebKit/device-tab failures, so it is referenced as related rather than automatically closed.

Boost.Filesystem 1.84 installs the UTF-8 path locale in `path::imbue()` before constructing the previous locale for its return value. When that previous locale is unavailable, `boost::nowide::nowide_filesystem()` throws even though UTF-8 path conversion has already been configured. OrcaSlicer currently treats that exception as fatal.

Move initialization into `Slic3r::init_utf8_filesystem()`. On `std::runtime_error`, retry once using the installed path locale, emit a warning, and continue when the retry succeeds. A failed retry still reaches the existing startup error handler. The change preserves the user's environment, global C/C++ locales, and UTF-8 filename handling, including characters outside the BMP.

The pre-main calibration path initializer in the 2.4.2 crash was already removed by #14619 (`b58025575`). This patch addresses the remaining filesystem initialization failure on current `main`; backporting to 2.4.2 also requires that existing calibration fix.

## Alternative: validate the locale in the launch script

Another fix is to check the effective locale inside the sandbox in `scripts/flatpak/entrypoint`, before executing OrcaSlicer. If locale initialization fails, print a warning and select an available fallback; a simple version would conditionally export `LC_ALL=C.UTF-8`. Valid environments should pass through unchanged, and the existing `LC_NUMERIC=C` setting should remain. Checking inside the sandbox matters because a locale installed on the host may be absent from the Flatpak runtime.

This approach also protects pre-main initializers and other users of the environment locale, and avoids depending on Boost's implementation ordering. It applies to launches through that script. A process-wide `LC_ALL` fallback can affect translations and regional formatting; replacing only unavailable categories would preserve more of the user's settings but needs careful handling of locale precedence. The proposed C++ fix keeps those settings intact and also applies when the executable is launched directly. The script alternative is described here for review and is not implemented in this branch.

## Tests

- Built an isolated harness from the production `LocalesUtils.cpp` and the new Catch2 test, using the repository's pinned Boost 1.84.0 archive (SHA-256 verified against `deps/Boost/Boost.cmake`). All three CTest cases pass: available locale, unavailable `LC_MEASUREMENT`, and unavailable `LC_ALL`. The two unavailable-locale cases are registered in the existing `libslic3r` suite and start fresh processes to avoid Boost's cached path locale.
- Verified narrow/wide UTF-8 filename conversions with Chinese characters and a non-BMP character, repeated initialization, and unchanged global C/C++ locales.
- Verified that the same test fails at initialization with the original single-call implementation.
- Ran the original and fixed implementations inside the installed OrcaSlicer GNOME 50 Flatpak runtime with `LANG=en_US.UTF-8`, `LC_MEASUREMENT=zh_CN.UTF-8`, and `LC_NUMERIC=C`: the original fails; the fixed implementation emits a warning and passes all seven assertions.
- `git diff --check` passes.

A full OrcaSlicer/GUI build and the complete test suite were not run. Windows and macOS builds have not been tested locally.

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
