### PR TITLE
fix(flashforge): allow network upload for multi-material prints with manual filament change

### DIFF
--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -19252,7 +19252,8 @@ void Plater::send_gcode_legacy(int plate_idx, Export3mfProgressFn proFn)
                                                                    flashforge_host,
                                                                    supports_material_station,
                                                                    std::move(slots),
-                                                                   project_filaments);
+                                                                   project_filaments,
+                                                                   cfg.opt_bool("manual_filament_change"));
         } else {
             pDlg = std::make_unique<PrintHostSendDialog>(default_output_file, upload_job.printhost->get_post_upload_actions(), groups,
                                                          storage_paths, storage_names, config->get_bool("open_device_tab_post_upload"));

--- a/src/slic3r/GUI/PrintHostDialogs.cpp
+++ b/src/slic3r/GUI/PrintHostDialogs.cpp
@@ -651,11 +651,13 @@ FlashforgePrintHostSendDialog::FlashforgePrintHostSendDialog(const fs::path&    
                                                              const Slic3r::Flashforge*   host,
                                                              bool                        supports_material_station,
                                                              std::vector<Slic3r::FlashforgeMaterialSlot> slots,
-                                                             const std::vector<FilamentInfo>& project_filaments)
+                                                             const std::vector<FilamentInfo>& project_filaments,
+                                                             bool                        manual_filament_change)
     : PrintHostSendDialog(path, post_actions, groups, storage_paths, storage_names, switch_to_device_tab)
     , m_host(host)
     , m_slots(std::move(slots))
     , m_project_filaments(project_filaments)
+    , m_manual_filament_change(manual_filament_change)
 {
     m_supports_material_station = supports_material_station;
     m_slots_loaded = !m_slots.empty();
@@ -674,10 +676,10 @@ void FlashforgePrintHostSendDialog::init()
     if (!timelapse.empty())
         m_time_lapse_video = timelapse == "1";
 
-    // Flashforge local printing should default to IFS enabled when supported.
+    // Flashforge local printing should default to IFS enabled when supported and manual filament change is not active.
     // We don't revive an old stale "0" here.
-    m_use_material_station = m_supports_material_station;
-    if (m_supports_material_station && !app_config->has("recent", CONFIG_KEY_IFS))
+    m_use_material_station = m_supports_material_station && !m_manual_filament_change;
+    if (m_use_material_station && !app_config->has("recent", CONFIG_KEY_IFS))
         const_cast<AppConfig*>(app_config)->set("recent", CONFIG_KEY_IFS, "1");
 
     this->SetMinSize(wxSize(560, 420));
@@ -1056,7 +1058,7 @@ bool FlashforgePrintHostSendDialog::slot_matches_filament(const Slic3r::Flashfor
 
 bool FlashforgePrintHostSendDialog::validate_before_close()
 {
-    if (!m_use_material_station && m_project_filaments.size() > 1) {
+    if (!m_use_material_station && m_project_filaments.size() > 1 && !m_manual_filament_change) {
         show_error(this, _L("This plate uses multiple materials. Enable IFS and assign each tool to a printer slot."));
         return false;
     }

--- a/src/slic3r/GUI/PrintHostDialogs.hpp
+++ b/src/slic3r/GUI/PrintHostDialogs.hpp
@@ -231,7 +231,8 @@ public:
                                   const Slic3r::Flashforge*       host,
                                   bool                            supports_material_station,
                                   std::vector<Slic3r::FlashforgeMaterialSlot> slots,
-                                  const std::vector<FilamentInfo>& project_filaments);
+                                  const std::vector<FilamentInfo>& project_filaments,
+                                  bool                            manual_filament_change);
 
     virtual void init() override;
     virtual void EndModal(int ret) override;
@@ -273,6 +274,7 @@ private:
     bool                             m_use_material_station {false};
     bool                             m_supports_material_station {false};
     bool                             m_slots_loaded {false};
+    bool                             m_manual_filament_change {false};
 
     const char* CONFIG_KEY_LEVELING  = "flashforge_leveling_before_print";
     const char* CONFIG_KEY_TIMELAPSE = "flashforge_timelapse_video";


### PR DESCRIPTION
# Description
Fixes https://github.com/OrcaSlicer/OrcaSlicer/issues/15307

Fixes the issue where sending a multi-material print over the network to a Flashforge printer without an automated material station (IFS) fails when **Manual Filament Change** is enabled.

### Background & Problem
In `FlashforgePrintHostSendDialog::validate_before_close()`, multi-material plates (`m_project_filaments.size() > 1`) unconditionally require `m_use_material_station` to be true. On single-extruder printers without an IFS (such as the Flashforge Adventurer 5M / 5M Pro):
- The printer reports no material station (`m_supports_material_station == false`).
- The "Enable IFS" checkbox is disabled/greyed out.
- Slicing a multi-material model using manual filament changes (layer color swaps via `M25`/`M600`) completely blocks the user with the error:
> *"This plate uses multiple materials. Enable IFS and assign each tool to a printer slot."*

### Changes Made
1. Passed `manual_filament_change` from `DynamicPrintConfig` (`cfg.opt_bool("manual_filament_change")`) into `FlashforgePrintHostSendDialog`.
2. In `FlashforgePrintHostSendDialog::validate_before_close()`, exempted multi-material plates from the IFS requirement when `m_manual_filament_change` is active.
3. In `FlashforgePrintHostSendDialog::init()`, ensured `m_use_material_station` defaults to `false` when `manual_filament_change` is enabled.

### Breaking Changes / Dependencies
- **None**. Existing IFS workflows (such as on AD5X) and single-material print workflows remain unaffected.



# Screenshots/Recordings/Graphs

Screenshots of error in issue https://github.com/OrcaSlicer/OrcaSlicer/issues/15307

## Tests

<!--
> Please describe the tests that you have conducted to verify the changes made in this PR.
-->

<!--
> A guide for users on how to download the artifacts from this PR.
-->

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
