### PR TITLE
Fix: Prevent deselecting object and closing widget while clicking to toolbar background / divider

### DIFF
--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -4253,6 +4253,18 @@ void GLCanvas3D::on_mouse(wxMouseEvent& evt)
         return;
     }
 
+    // ORCA the thin divider bars drawn between toolbar groups (main toolbar / gizmos toolbar /
+    // assemble view toolbar) are rendering-only and were never part of the mouse dispatch chain,
+    // so a click landing exactly on one used to fall through to the 3D scene below and could
+    // deselect the current selection or close the active arrange/orient/layersediting popup.
+    // Swallow it here as a no-op, same as any other in-toolbar click.
+    if (!mouse_in_layer_editing && _is_mouse_over_separator_toolbar(pos.cast<double>())) {
+        if (evt.LeftUp() || evt.MiddleUp() || evt.RightUp())
+            mouse_up_cleanup();
+        m_mouse.set_start_position_3D_as_invalid();
+        return;
+    }
+
     //BBS: GUI refactor: GLToolbar
     if (!mouse_in_layer_editing && m_assemble_view_toolbar.on_mouse(evt, *this)) {
         if (evt.LeftUp() || evt.MiddleUp() || evt.RightUp())
@@ -9624,6 +9636,39 @@ void GLCanvas3D::_render_separator_toolbar_left() const
 
     m_separator_toolbar.set_position(top, left);
     m_separator_toolbar.render(*this,GLToolbarItem::SeparatorLine);
+}
+
+// ORCA clicks on dividers / toolbar background / margins around icons fall straight through to the 3D scene
+// that causes deselecting the current selection / closing the active widget
+bool GLCanvas3D::_is_mouse_over_separator_toolbar(const Vec2d& mouse_pos) const
+{
+    if (!m_separator_toolbar.is_enabled())
+        return false;
+
+    const Size cnv_size = get_canvas_size();
+    const Vec2d scaled_mouse_pos((mouse_pos.x() - 0.5 * (double)cnv_size.get_width()), (0.5 * (double)cnv_size.get_height() - mouse_pos.y()));
+
+    const float gizmo_width = m_gizmos.get_scaled_total_width();
+    const float separator_width = m_separator_toolbar.get_width();
+    const float separator_height = m_separator_toolbar.get_height();
+    const float top = 0.5f * (float)cnv_size.get_height();
+    const float main_toolbar_left = -0.5f * (float)cnv_size.get_width() + get_main_toolbar_offset();
+
+    // same "left" values used by _render_separator_toolbar_right()/_left() above
+    const float left_positions[2] = {
+        main_toolbar_left + (m_main_toolbar.get_width() + gizmo_width + separator_width / 2), // right divider
+        main_toolbar_left + (m_main_toolbar.get_width())                                      // left divider
+    };
+
+    for (float left : left_positions) {
+        const float right  = left + separator_width * 0.5f;
+        const float bottom = top - separator_height;
+        if (left <= (float)scaled_mouse_pos.x() && (float)scaled_mouse_pos.x() <= right &&
+            bottom <= (float)scaled_mouse_pos.y() && (float)scaled_mouse_pos.y() <= top)
+            return true;
+    }
+
+    return false;
 }
 
 void GLCanvas3D::_render_collapse_toolbar() const

--- a/src/slic3r/GUI/GLCanvas3D.hpp
+++ b/src/slic3r/GUI/GLCanvas3D.hpp
@@ -1294,6 +1294,7 @@ private:
     void _render_canvas_toolbar();
     void _render_separator_toolbar_right() const;
     void _render_separator_toolbar_left() const;
+    bool _is_mouse_over_separator_toolbar(const Vec2d& mouse_pos) const;
     void _render_collapse_toolbar() const;
     // BBS
     //void _render_view_toolbar() const;

--- a/src/slic3r/GUI/GLToolbar.cpp
+++ b/src/slic3r/GUI/GLToolbar.cpp
@@ -1130,6 +1130,22 @@ int GLToolbar::contains_mouse_horizontal(const Vec2d& mouse_pos, const GLCanvas3
         }
     }
 
+    // ORCA the loop above only tests the icon/separator/gap rectangles and does not cover the outer border/padding of the toolbar
+    // the strip before the first icon, after the last icon, or above/below the icon row). 
+    // A click landing there used to be reported as "outside the toolbar" (-1), which let it fall through to the 3D scene
+    // and could deselect the current selection or close an active gizmo/popup.
+    // Treat the whole background rectangle as toolbar territory instead, so such clicks are swallowed as a no-op, same as clicks in a gap (-2)
+    {
+        const float bg_left   = m_layout.left;
+        const float bg_right  = m_layout.left + m_layout.width;
+        const float bg_top    = m_layout.top;
+        const float bg_bottom = m_layout.top - m_layout.height;
+
+        if (bg_left <= (float)scaled_mouse_pos.x() && (float)scaled_mouse_pos.x() <= bg_right &&
+            bg_bottom <= (float)scaled_mouse_pos.y() && (float)scaled_mouse_pos.y() <= bg_top)
+            return -2;
+    }
+
     return -1;
 }
 

--- a/src/slic3r/GUI/Gizmos/GLGizmosManager.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmosManager.cpp
@@ -120,6 +120,38 @@ GLGizmosManager::EType GLGizmosManager::get_gizmo_from_mouse(const Vec2d &mouse_
     return Undefined;
 }
 
+// ORCA clicks on dividers / toolbar background / margins around icons fall straight through to the 3D scene
+// that causes deselecting the current selection / closing the active widget
+bool GLGizmosManager::is_mouse_over_overlay_background(const Vec2d &mouse_pos) const
+{
+    if (!m_enabled)
+        return false;
+
+    if (get_selectable_idxs().empty())
+        return false;
+
+    const float border = m_layout.scaled_border();
+
+    // same top_x/top_y derivation as get_gizmo_from_mouse(), so this stays in sync with it.
+    float top_x;
+    if (m_parent.get_canvas_type() == GLCanvas3D::CanvasAssembleView) {
+        const float cnv_w = (float)m_parent.get_canvas_size().get_width();
+        top_x = 0.5f * cnv_w + 0.5f * (m_parent.get_assembly_paint_toolbar_width());
+    } else {
+        const float separator_width = m_parent.get_separator_toolbar_width();
+        top_x = m_parent.get_main_toolbar_offset();
+        top_x += m_parent.get_main_toolbar_width() + separator_width / 2 + border;
+    }
+    // top_x above is the left edge of the first icon, i.e. background_left + border.
+    const float bg_left   = top_x - border;
+    const float bg_top    = 0.f;
+    const float bg_right  = bg_left + get_scaled_total_width();
+    const float bg_bottom = bg_top + get_scaled_total_height();
+
+    return bg_left <= (float)mouse_pos(0) && (float)mouse_pos(0) <= bg_right &&
+           bg_top  <= (float)mouse_pos(1) && (float)mouse_pos(1) <= bg_bottom;
+}
+
 void GLGizmosManager::switch_gizmos_icon_filename()
 {
     m_background_texture.metadata.filename = m_is_dark ? "toolbar_background_dark.png" : "toolbar_background.png";
@@ -695,16 +727,23 @@ bool GLGizmosManager::gizmos_toolbar_on_mouse(const wxMouseEvent &mouse_event) {
         return false;
     }
 
-    if (selected_gizmo) {
+    // ORCA a click that lands on the toolbar's background/padding (not on an icon) should be swallowed here too,
+    // so it can't fall through to the 3D scene that leads to deselecting the current selection / closing the active widget
+    const bool over_background = !selected_gizmo && is_mouse_over_overlay_background(mouse_pos);
+
+    if (selected_gizmo || over_background) {
         // mouse is above toolbar
         if (mouse_event.LeftDown() || mouse_event.LeftDClick()) {
             mc.left = true;
-            if (gizmo == Emboss) {
-                GLGizmoBase *gizmo_emboss = m_gizmos[Emboss].get();
-                dynamic_cast<GLGizmoEmboss *>(gizmo_emboss)->on_shortcut_key();
-            } else {
-                open_gizmo(gizmo);
-            }
+            if (selected_gizmo) {
+               if (gizmo == Emboss) {
+                   GLGizmoBase *gizmo_emboss = m_gizmos[Emboss].get();
+                   dynamic_cast<GLGizmoEmboss *>(gizmo_emboss)->on_shortcut_key();
+               } else {
+                   open_gizmo(gizmo);
+               }
+           }
+            // else: click landed on toolbar background/padding - swallow it, do nothing.
             return true;
         }
         else if (mouse_event.RightDown()) {

--- a/src/slic3r/GUI/Gizmos/GLGizmosManager.hpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmosManager.hpp
@@ -136,6 +136,8 @@ private:
     std::vector<size_t> get_selectable_idxs() const;
     EType get_gizmo_from_mouse(const Vec2d &mouse_pos) const;
 
+    bool is_mouse_over_overlay_background(const Vec2d &mouse_pos) const;
+
     bool activate_gizmo(EType type);
 
     std::string m_tooltip;


### PR DESCRIPTION
## Issue
Clicking background of toolbar / divider fallbacks to 3d scene that causes deselecting object or closing active widget

<img width="1172" height="144" alt="Screenshot-20260905213922" src="https://github.com/user-attachments/assets/85f377a7-cb46-4081-b89c-925a20423aa9" />

clicking gap between icons or divider deselects object and user has to reselect object again to use widget
i often found myself clicking between icons while toggling between transform widgets which i found annoying
<img width="366" height="331" alt="orca-slicer_gynCFh8S25" src="https://github.com/user-attachments/assets/629c73f1-5f14-436d-915f-0c5dbc85db07" />

right clicking on toolbar is also blocked that allowed before
<img width="315" height="166" alt="Screenshot-20260905214543" src="https://github.com/user-attachments/assets/4b180477-2c8e-42b8-9923-f5f8b0ebac5f" />

also fixes same issue on assembly toolbar