### PR TITLE
Fix: Ctrl + Shift + G shortcut opens "Send Gcode to printer host" dialog and  "Jump to layer" pop up at same time on linux

### DIFF
--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -3856,7 +3856,7 @@ void GLCanvas3D::on_key(wxKeyEvent& evt)
                         IMSlider *m_layers_slider = get_gcode_viewer().get_layers_slider();
                         IMSlider *m_moves_slider  = get_gcode_viewer().get_moves_slider();
                         int increment = (evt.CmdDown() || evt.ShiftDown()) ? 5 : 1;
-                        if ((evt.CmdDown() || evt.ShiftDown()) && evt.GetKeyCode() == 'G') {
+                        if (((!evt.CmdDown() && evt.ShiftDown())) && evt.GetKeyCode() == 'G') {
                             m_layers_slider->show_go_to_layer(true);
                         }
                         else if (keyCode == WXK_UP || keyCode == WXK_DOWN) {


### PR DESCRIPTION
tested on debian gnome

fixes https://github.com/OrcaSlicer/OrcaSlicer/issues/15338

Shift + G opens "Jump to layer" popup
Ctrl + G opens "Save sliced file as..." 
Ctrl + Shift + G opens "Send Gcode to printer host" 

Windows has no issue with previous condition
but both conditions passes on linux so i limited modifier condition