### PR TITLE
fix: bumping the bundled uv version rebuilds the whole GUI library

### DIFF
--- a/src/slic3r/CMakeLists.txt
+++ b/src/slic3r/CMakeLists.txt
@@ -981,10 +981,6 @@ endif ()
 # Add a definition so that we can tell we are compiling slic3r.
 target_compile_definitions(libslic3r_gui PRIVATE SLIC3R_CURRENTLY_COMPILING_GUI_MODULE)
 
-if(ORCA_BUNDLED_UV_EXECUTABLE_CONFIG)
-    target_compile_definitions(libslic3r_gui PRIVATE "ORCA_BUNDLED_UV_EXECUTABLE=\"${ORCA_BUNDLED_UV_EXECUTABLE_CONFIG}\"")
-endif()
-
 if (ORCA_BUILD_PYTHON_STUBGEN_MODULE)
     add_library(orca_stubgen MODULE
         plugin/PythonPluginBridge.cpp


### PR DESCRIPTION
# Description

`ORCA_BUNDLED_UV_EXECUTABLE` is defined twice with the same value, once on the command line of every `libslic3r_gui` file and once in `GeneratedConfig.hpp`. Only `PythonInterpreter.cpp` reads it, and that file already includes the header. Both were added together in ecddf3d18f, the Python Plugins commit.

The command-line copy just puts the uv version and the build directory on 420 compile lines, so bumping the uv version rebuilds the whole GUI library unnecessarily.

## Tests

Configured on Windows with clang-cl. The define is gone from all 420 compile lines, `PythonInterpreter.cpp` and `GUI_App.cpp` still compile, and the resulting object still embeds the same uv path, now by way of the header. The application builds and launches with the change applied.

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
