### PR TITLE
Allow saving preset without parent while it doesnt have parent profile (Detach from parent option for parentless profiles)

### DIFF
--- a/src/slic3r/GUI/SavePresetDialog.cpp
+++ b/src/slic3r/GUI/SavePresetDialog.cpp
@@ -123,8 +123,9 @@ SavePresetDialog::Item::Item(Preset::Type type, const std::string &suffix, wxBox
         auto detach_checkbox = new ::CheckBox(parent);
         detach_checkbox->SetToolTip(detach_tooltip);
 
-        auto detach_label    = new wxStaticText(parent, wxID_ANY, _L("Detach from parent"));
+        auto detach_label    = new wxStaticText(parent, wxID_ANY, can_detach ? _L("Detach from parent") : _L("Save without parent"));
         detach_label->SetFont(::Label::Body_14);
+        detach_label->SetForegroundColour(wxColour("#363636"));
         detach_label->SetToolTip(detach_tooltip);
 
         detach_sizer->Add(detach_checkbox, 0, wxALIGN_LEFT | wxLEFT, BORDER_W);
@@ -141,30 +142,22 @@ SavePresetDialog::Item::Item(Preset::Type type, const std::string &suffix, wxBox
 
         sizer->AddSpacer(FromDIP(5));
 
-        if (!can_detach) {
-            detach_checkbox->Disable();
-            detach_label->SetForegroundColour(wxColour("#6B6B6B"));
-        } 
-        else {
-            // Set initial state (unchecked by default)
-            detach_checkbox->SetValue(m_detach);
-            // Bind the checkbox event to update the detach state for this item
-            detach_checkbox->Bind(wxEVT_TOGGLEBUTTON, [this, detach_checkbox](wxCommandEvent& event) {
-                m_detach = detach_checkbox->GetValue();
-                event.Skip(); // Let CheckBox update its bitmap for the new state.
-            });
+        // Set initial state (unchecked by default)
+        detach_checkbox->SetValue(m_detach);
+        // Bind the checkbox event to update the detach state for this item
+        detach_checkbox->Bind(wxEVT_TOGGLEBUTTON, [this, detach_checkbox](wxCommandEvent& event) {
+            m_detach = detach_checkbox->GetValue();
+            event.Skip(); // Let CheckBox update its bitmap for the new state.
+        });
 
-            detach_label->SetForegroundColour(wxColour("#363636"));
-
-            auto on_toggle = [detach_checkbox]() {
-                detach_checkbox->SetValue(!detach_checkbox->GetValue());
-                wxCommandEvent ev(wxEVT_TOGGLEBUTTON, detach_checkbox->GetId());
-                ev.SetEventObject(detach_checkbox);
-                detach_checkbox->GetEventHandler()->ProcessEvent(ev);
-            };
-            detach_label->Bind(wxEVT_LEFT_DOWN,   [on_toggle](wxMouseEvent& e) {if(!e.LeftDClick()) on_toggle();});
-            detach_label->Bind(wxEVT_LEFT_DCLICK, [on_toggle](wxMouseEvent& e) {on_toggle();});
-        }
+        auto on_toggle = [detach_checkbox]() {
+            detach_checkbox->SetValue(!detach_checkbox->GetValue());
+            wxCommandEvent ev(wxEVT_TOGGLEBUTTON, detach_checkbox->GetId());
+            ev.SetEventObject(detach_checkbox);
+            detach_checkbox->GetEventHandler()->ProcessEvent(ev);
+        };
+        detach_label->Bind(wxEVT_LEFT_DOWN,   [on_toggle](wxMouseEvent& e) {if(!e.LeftDClick()) on_toggle();});
+        detach_label->Bind(wxEVT_LEFT_DCLICK, [on_toggle](wxMouseEvent& e) {on_toggle();});
     }
     
     m_radio_group->Bind(wxEVT_COMMAND_RADIOBOX_SELECTED, [this](wxCommandEvent &e) {

--- a/src/slic3r/GUI/SavePresetDialog.cpp
+++ b/src/slic3r/GUI/SavePresetDialog.cpp
@@ -114,7 +114,7 @@ SavePresetDialog::Item::Item(Preset::Type type, const std::string &suffix, wxBox
     if (parent->m_mode == comDevelop) {
         // A new user copy of a system preset inherits from the selected system preset.
         const std::string parent_name = sel_preset.is_system ? sel_preset.name : sel_preset.inherits();
-        const bool        can_detach  = !parent_name.empty();
+        const bool        has_parent  = !parent_name.empty();
 
         wxBoxSizer *detach_sizer = new wxBoxSizer(wxHORIZONTAL);
 
@@ -123,7 +123,7 @@ SavePresetDialog::Item::Item(Preset::Type type, const std::string &suffix, wxBox
         auto detach_checkbox = new ::CheckBox(parent);
         detach_checkbox->SetToolTip(detach_tooltip);
 
-        auto detach_label    = new wxStaticText(parent, wxID_ANY, can_detach ? _L("Detach from parent") : _L("Save without parent"));
+        auto detach_label    = new wxStaticText(parent, wxID_ANY, has_parent ? _L("Detach from parent") : _L("Save without parent"));
         detach_label->SetFont(::Label::Body_14);
         detach_label->SetForegroundColour(wxColour("#363636"));
         detach_label->SetToolTip(detach_tooltip);
@@ -133,11 +133,11 @@ SavePresetDialog::Item::Item(Preset::Type type, const std::string &suffix, wxBox
         sizer->Add(detach_sizer, 0, wxEXPAND | wxTOP, BORDER_W);
         sizer->AddSpacer(FromDIP(5));
 
-        const wxString parent_text = can_detach ? from_u8(parent_name) : _L("Unique preset");
+        const wxString parent_text = has_parent ? from_u8(parent_name) : _L("Unique preset");
         auto parent_label          = new wxStaticText(parent, wxID_ANY, parent_text);
         parent_label->SetFont(::Label::Body_12);
         parent_label->SetForegroundColour(wxColour("#6B6B6B"));
-        parent_label->SetToolTip(can_detach ? _L("Parent preset") : _L("This preset does not inherit from another preset."));
+        parent_label->SetToolTip(has_parent ? _L("Parent preset") : _L("This preset does not inherit from another preset."));
         sizer->Add(parent_label, 0, wxEXPAND | wxLEFT, BORDER_W + FromDIP(24));
 
         sizer->AddSpacer(FromDIP(5));


### PR DESCRIPTION
Made "Detach from parent" title dynamic and used "Save without parent" if profile doesnt have any parent

Previous implementation disabled "Detach from parent" option because label doesnt make sense while profile doesnt have a parent. thats why i have used new label for it. 

its required when user wants to keep parentless profile
example usage https://github.com/OrcaSlicer/OrcaSlicer/pull/15520#issuecomment-5560117855

**Save without parent** (visible when profile doesnt have parent)
<img width="414" height="306" alt="Screenshot-20260906191512" src="https://github.com/user-attachments/assets/df14cb1e-ca70-481d-8654-42b67c801d16" />

**Detach from parent** same as before. visible when profile have a parent
<img width="422" height="314" alt="Screenshot-20260906191500" src="https://github.com/user-attachments/assets/c1786e62-ce10-4d6a-9940-0a4db2cbbec1" />
