### PR TITLE
Fix Non-Deterministic Slicing - Order Per-Layer Intersection Lines Canonically

### DIFF
--- a/src/libslic3r/TriangleMeshSlicer.cpp
+++ b/src/libslic3r/TriangleMeshSlicer.cpp
@@ -12,6 +12,7 @@
 #include <deque>
 #include <queue>
 #include <mutex>
+#include <tuple>
 #include <utility>
 
 #include <boost/log/trivial.hpp>
@@ -607,6 +608,17 @@ static inline std::vector<IntersectionLines> slice_make_lines(
             }
         }
     );
+    // Facet processing above is parallel, so per-layer line order depends on thread scheduling,
+    // and make_loops() derives island order and loop start vertices from it. Sort canonically;
+    // edge_type and flags only break ties, std::sort being unstable.
+    tbb::parallel_for(tbb::blocked_range<size_t>(0, lines.size()),
+        [&lines](const tbb::blocked_range<size_t> &range) {
+            for (size_t i = range.begin(); i < range.end(); ++ i)
+                std::sort(lines[i].begin(), lines[i].end(), [](const IntersectionLine &l, const IntersectionLine &r) {
+                    return std::make_tuple(l.edge_a_id, l.edge_b_id, l.a_id, l.b_id, l.a.x(), l.a.y(), l.b.x(), l.b.y(), l.edge_type, l.flags) <
+                           std::make_tuple(r.edge_a_id, r.edge_b_id, r.a_id, r.b_id, r.a.x(), r.a.y(), r.b.x(), r.b.y(), r.edge_type, r.flags);
+                });
+        });
     return lines;
 }
 


### PR DESCRIPTION
# Description

Slicing the same model with the same config twice on the same binary could produce different G-code. This makes `slice_make_lines()` deterministic again.

**Root cause.** `TriangleMeshSlicer.cpp`, in `slice_facet_at_zs()`, called from a `tbb::parallel_for` over facets:

```cpp
boost::lock_guard<std::mutex> l(lines_mutex[slice_id % lines_mutex.size()]);
lines[slice_id].emplace_back(il);
```

The striped mutex array makes the append race-*free* but not *ordered*. Each layer's `IntersectionLines` is left in thread-arrival order, and `make_loops()` chains loops in that order, fixing both the island order within a layer and the start vertex of each closed loop.

The consequence chain, each link measured rather than assumed: `lines[]` order → island order in `LayerRegion::slices.surfaces` → order of extrusions iterated by `SupportSpotsGenerator::estimate_malformations` → order of the AABB tree built from `current_layer_lines`, which becomes the next layer's `prev_layer_lines` → tie-breaking in `LinesDistancer::distance_from_lines_extra` when a query point lies at distance exactly `0.0` on several previous-layer lines (observed `bottom_line_idx` 4 vs 1) → different `curled_up_height` → different `curled_lines` membership → different overhang speed bucket → different `G1 F`.

**Fix.** After the parallel loop, sort each layer's lines into a canonical order derived from the mesh topology, so the result no longer depends on thread scheduling.

**Impact.** Toolpath order is re-derived geometrically downstream of the perturbed island order, so in practice only the curled-perimeter speed path was affected. Over 12 runs per config on a 17-island test model:

| config | distinct outputs / 12 |
|---|---|
| curled ON, supports ON | 3 |
| curled OFF, supports ON | 1 |
| curled ON, supports OFF | 3 |

`slowdown_for_curled_perimeters` was the only channel. Stripping the `F` field collapses all 12 runs to one hash: X/Y/E, seams, toolpath order, `;TYPE:` block counts and total extrusion were bit-identical. The two common variants differed in 4 lines of 129,836, all bare `G1 F`, each governing a single 0.52 mm inner wall segment; estimated time and filament used were identical.

So this is not a print-quality bug. It is a reproducibility bug: it breaks G-code hashing, caching and regression baselines, and it made an option-sweep harness report 452 vs 449 effective options for two runs of the same commit and the same build artifact, with 19 options flipping verdict on identical probes.

**Behaviour change.** Slicing output is *currently* random between a small set of orderings, so any fix necessarily picks one. This converges on an ordering already observed in the wild, and leaves single-threaded output byte-for-byte unchanged. No 3MF format, profile or translatable-string changes.

**Notes for reviewers.**

* An alternative that sorts by facet index (reproducing the sequential visit order exactly) was implemented and tested. It gives byte-identical results to this patch for every ≥2-CPU configuration, at the cost of an extra `int` per intersection line and a signature change, so it was dropped.
* The same striped-mutex-append pattern exists in the slab path (`slice_facet_with_slabs`), which is reached only from multi-material segmentation and painted-facet projection. It is left untouched here.
* Upstream PrusaSlicer carries the same `slice_facet_at_zs` shape, so this is likely reportable there too.
* Separately observed and deliberately *not* addressed here: 1-thread and ≥2-thread slicing disagree from a different, pre-existing cause. It is confined to support generation (all model-geometry `;TYPE:` counts match exactly; with `--enable-support=0` the outputs are identical) and is unchanged by this patch.

# Screenshots/Recordings/Graphs

Not applicable — no UI change.

## Tests

* 16 consecutive runs byte-identical apart from the `; generated by ...` timestamp line (previously 2-3 distinct outputs across 6-12 runs).
* 2 / 4 / 8 / 16 / 28 CPUs all produce the same output.
* Two further projects (a 2-object plate and a 4-filament project) stable over 6 runs each.
* `ctest`: 612/612 pass, no new compiler warnings.

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
