### PR TITLE
Fix Support Fill Cost Thresholds Being Frozen By The First Call

### DIFF
--- a/src/libslic3r/Fill/FillBase.cpp
+++ b/src/libslic3r/Fill/FillBase.cpp
@@ -2467,9 +2467,11 @@ void Fill::connect_base_support(Polylines &&infill_ordered, const std::vector<co
 #endif // INFILL_DEBUG_OUTPUT
 
     const std::vector<SupportArcCost> arches = evaluate_support_arches(infill_ordered, graph, spacing, params);
-    static const double cost_low      = line_spacing * 1.3;
-    static const double cost_high     = line_spacing * 2.;
-    static const double cost_veryhigh = line_spacing * 3.;
+    // Must not be static: line_spacing varies per call (base vs interface fills differ),
+    // and a static here would fix these to whichever call ran first, order depending on thread count.
+    const double cost_low      = line_spacing * 1.3;
+    const double cost_high     = line_spacing * 2.;
+    const double cost_veryhigh = line_spacing * 3.;
 
     {
         std::vector<const SupportArcCost*> selected;


### PR DESCRIPTION
# Description

Support arch selection was using cost thresholds belonging to a different fill, and which fill "won" depended on thread scheduling.

**Root cause.** `Fill/FillBase.cpp`, in `Fill::connect_base_support()`:

```cpp
static const double cost_low      = line_spacing * 1.3;
static const double cost_high     = line_spacing * 2.;
static const double cost_veryhigh = line_spacing * 3.;
```

`line_spacing` is `scale_(spacing) / params.density` — it varies per call. `FillSupportBase::fill_surface()` is reached by both the sparse base fill and the interface fill (both use `ipSupportBase` whenever their density is ≤ 0.95), with different densities. Being function-local `static`, the three values are computed once on first arrival and then reused for the rest of the process.

**Two consequences.**

1. **Correctness, independent of threading:** every call after the first uses another fill's thresholds.
2. **Determinism:** "whichever call arrives first" depends on how the layer range is split across threads, so generated support differed between a 1-thread and a multi-thread run of the same input, while the model geometry stayed identical.

C++ "magic statics" make this thread-*safe* but not thread-*independent*: initialisation happens once, and first arrival is a scheduling fact.

**Fix.** Drop `static`. Three ordinary locals, so each call uses its own spacing.

**Behaviour change.** Support output changes: before this, most fills were using the wrong thresholds, so the corrected output differs from *both* previous results (the 1-thread one and the multi-thread one). Model geometry is unaffected — only support. No 3MF format, profile or translatable-string changes.

**Note.** A sweep for the same pattern across `src/libslic3r` found one other function-local `static` initialised from a runtime expression, `GCode/WipeTower.cpp:671` (`static const float area = float(M_PI)*1.75f*1.75f/4.f`), which is a genuine compile-time constant and is fine.

# Screenshots/Recordings/Graphs

Not applicable — no UI change.

## Tests

* Every thread count (1 CPU, a different single CPU, 2/4/8/28) now produces the same output; before, 1 CPU and ≥2 CPUs disagreed (83169 vs 83366 `G1 X` moves, all of the difference in `;TYPE:Support` / `Support interface` blocks).
* 8 unrestricted runs byte-identical.
* `ctest`: 612/612 pass, no new warnings.

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
