### PR TITLE
fix: chain a copy of cached extrusion entities in extrude_infill/extr…

### DIFF
--- a/src/libslic3r/ExtrusionEntityCollection.cpp
+++ b/src/libslic3r/ExtrusionEntityCollection.cpp
@@ -89,6 +89,12 @@ ExtrusionEntityCollection ExtrusionEntityCollection::chained_path_from(const Ext
 	// Return a filtered copy of the collection.
     ExtrusionEntityCollection out;
     out.entities = filter_by_extrusion_role(extrusion_entities, role);
+    // Drop entities without valid endpoints before cloning:
+    // chain_and_reorder_extrusion_entities() erases them without deleting,
+    // so cloning them first would leak the clones.
+    out.entities.erase(std::remove_if(out.entities.begin(), out.entities.end(),
+        [](const ExtrusionEntity *entity) { return ! extrusion_entity_has_endpoints(entity); }),
+        out.entities.end());
 	// Clone the extrusion entities.
 	for (auto &ptr : out.entities)
 		ptr = ptr->clone();

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -7615,8 +7615,10 @@ std::string GCode::extrude_infill(const Print &print, const std::vector<ObjectBy
                     extrusions.emplace_back(ee);
             if (! extrusions.empty()) {
                 m_config.apply(print.get_print_region(&region - &by_region.front()).config());
-                chain_and_reorder_extrusion_entities(extrusions, m_last_pos.to_point());
-                for (const ExtrusionEntity *fill : extrusions) {
+                // Chain a copy of the cached extrusion entities: chaining reverses entities in place
+                // and the cached ones must stay intact for a possible re-export of the same sliced result.
+                ExtrusionEntityCollection chained_extrusions = ExtrusionEntityCollection::chained_path_from(extrusions, m_last_pos.to_point());
+                for (const ExtrusionEntity *fill : chained_extrusions.entities) {
                     auto *eec = dynamic_cast<const ExtrusionEntityCollection*>(fill);
                     if (eec) {
                         for (ExtrusionEntity *ee : eec->chained_path_from(m_last_pos.to_point()).entities)
@@ -7668,11 +7670,14 @@ std::string GCode::extrude_support(const ExtrusionEntityCollection &support_fill
         if (extrusions.empty())
             return gcode;
 
+        // Chain a copy of the cached extrusion entities: chaining reverses entities in place
+        // and the cached ones must stay intact for a possible re-export of the same sliced result.
         //ORCA: Respect no_sort to preserve support base outline->fill order.
+        ExtrusionEntityCollection chained_extrusions;
         if (!support_fills.no_sort)
-            chain_and_reorder_extrusion_entities(extrusions, m_last_pos.to_point());
+            chained_extrusions = ExtrusionEntityCollection::chained_path_from(extrusions, m_last_pos.to_point());
 
-        for (const ExtrusionEntity *ee : extrusions) {
+        for (const ExtrusionEntity *ee : support_fills.no_sort ? extrusions : chained_extrusions.entities) {
             ExtrusionRole role = ee->role();
             assert(is_support(role) || role == erIroning);
 

--- a/src/libslic3r/ShortestPath.cpp
+++ b/src/libslic3r/ShortestPath.cpp
@@ -18,7 +18,7 @@
 namespace Slic3r {
 
 // Orca: Some support entities may contain empty nested paths, which cannot be reordered safely.
-static bool extrusion_entity_has_endpoints(const ExtrusionEntity *entity)
+bool extrusion_entity_has_endpoints(const ExtrusionEntity *entity)
 {
     auto paths_have_endpoints = [](const ExtrusionPaths &paths) {
         return !paths.empty() &&

--- a/src/libslic3r/ShortestPath.hpp
+++ b/src/libslic3r/ShortestPath.hpp
@@ -24,6 +24,9 @@ std::vector<std::pair<size_t, bool>> chain_extrusion_entities(std::vector<Extrus
 void                                 reorder_extrusion_entities(std::vector<ExtrusionEntity*> &entities, const std::vector<std::pair<size_t, bool>> &chain);
 void                                 chain_and_reorder_extrusion_entities(std::vector<ExtrusionEntity*> &entities, const Point &start_near);
 void                                 chain_and_reorder_extrusion_entities(std::vector<ExtrusionEntity*> &entities, const Point *start_near = nullptr);
+// Orca: An entity that cannot provide valid endpoints (e.g. a support collection with empty nested paths)
+// cannot be chained, chain_and_reorder_extrusion_entities() erases such entities without deleting them.
+bool                                 extrusion_entity_has_endpoints(const ExtrusionEntity *entity);
 
 std::vector<std::pair<size_t, bool>> chain_extrusion_paths(std::vector<ExtrusionPath> &extrusion_paths, const Point *start_near = nullptr);
 void                                 reorder_extrusion_paths(std::vector<ExtrusionPath> &extrusion_paths, std::vector<std::pair<size_t, bool>> &chain);


### PR DESCRIPTION
## Description

Re-exporting the same sliced result in the same process produced different G-code: identical infill lines came out in swapped order or with their direction flipped (start/end endpoints exchanged, coordinates/E/F mirrored accordingly), and M73 remaining-time announcements shifted by a few lines.

**Reproduction:** slice → export G-code → export again without invalidating the Print — either change nothing, or change something that only falls into the `steps_gcode` tier of `invalidate_state_by_config_options()` (e.g. switching a filament preset, which does not invalidate `posPerimeters`/`posInfill`). The sliced geometry is unchanged, only the export runs again on the same cached entities.

**Root cause:** `GCode::extrude_infill()` / `GCode::extrude_support()` collected the *cached* extrusion entities (`layerm->fills.entities` etc.) and passed them to `chain_and_reorder_extrusion_entities()`. `reorder_extrusion_entities()` reverses entities **in place** (`out.back()->reverse()`, and `ExtrusionEntityCollection::reverse()` recurses into children). The first export therefore physically reversed part of the cached slice result; the second export chained from the already-reversed endpoints, and the greedy chaining (nearest-first, input order as tie-break) picked a different order and direction.

The nested `eec->chained_path_from()` call in the same loop was already safe — it clones before chaining. The two direct `chain_and_reorder_extrusion_entities()` call sites were the outliers.

**Fix:**
- `extrude_infill()` / `extrude_support()` now chain a copy produced by `ExtrusionEntityCollection::chained_path_from()` (filter → clone → chain, RAII-owned). The `no_sort` handling in `extrude_support()` (preserve outline→fill order) is kept.
- `chained_path_from()` now drops entities without valid endpoints *before* cloning. `chain_and_reorder_extrusion_entities()` erases such entities without deleting them (that erase came in with 59b756a), so cloning them first would leak the erased clones — this also fixes that pre-existing leak for all existing callers of `chained_path_from()`.
- `extrusion_entity_has_endpoints()` is exported in `ShortestPath.hpp` for that check.

**No behavior change for a first export:** the chaining algorithm is deterministic, cloning preserves entity order and the `no_sort` / `is_reverse` flags, and the pre-filtered set is exactly what the erase inside chaining removed — so the emitted G-code is bit-identical. The overhead is one linear deep copy per region, the same pattern `chained_path_from()` already applies to nested collections, negligible compared to slicing.

The bug does not affect print quality (same lines, same extrusion volume, only traversal order/direction); it breaks reproducibility — regression diffing, benchmarks and A/B comparisons get false positives from it.

Related: #3538 reports non-determinism at the slicing-content level (features occasionally missing), which is a different defect with different symptoms.

## Screenshots/Recordings/Graphs

Not applicable — no UI changes.

## Tests

- Repro model (cube, 391 `;TYPE:Gap infill` blocks); two consecutive exports in the same process without re-slicing:
  - before: 210 differing lines (order swaps + whole-line direction flips), file sizes 10 603 195 vs 10 603 056 bytes, M73 positions shifted;
  - after: byte-identical output except the `; generated` timestamp line; M73 positions all match.
- Filament preset switch (invalidates only the G-code export step) then export: reproducible mismatch before the fix, identical after.
- First export of a model is bit-identical to a pre-fix build (apart from the timestamp line).
