### PR TITLE
build: share cached objects between build directories and worktrees

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,6 +110,7 @@ option(SLIC3R_WARNINGS          "Emit compiler warnings for OrcaSlicer sources" 
 option(SLIC3R_BUNDLED_WARNINGS  "Emit compiler warnings for bundled third-party sources" 0)
 option(SLIC3R_MSVC_COMPILE_PARALLEL "Compile on Visual Studio in parallel" 1)
 option(SLIC3R_MSVC_PDB          "Generate PDB files on MSVC in Release mode" 1)
+option(SLIC3R_RELATIVE_DEBUG_PATHS "Record a relative compilation directory in debug info (clang-cl)" 0)
 option(SLIC3R_ASAN              "Enable ASan on Clang and GCC" 0)
 
 # Python stubgen module
@@ -375,6 +376,16 @@ if (MSVC)
 	# helps incremental builds by preventing the double-link restart from TBB
     set(CMAKE_EXE_LINKER_FLAGS    "${CMAKE_EXE_LINKER_FLAGS} /LTCG")
     set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /LTCG")
+endif ()
+
+# Without this every object names its build directory and two worktrees never
+# share cache entries. The linker still writes absolute paths into the PDB.
+if (SLIC3R_RELATIVE_DEBUG_PATHS)
+    if (IS_CLANG_CL)
+        add_compile_options(-ffile-compilation-dir=.)
+    else ()
+        message(WARNING "SLIC3R_RELATIVE_DEBUG_PATHS is only implemented for clang-cl")
+    endif ()
 endif ()
 
 if (${CMAKE_CXX_COMPILER_ID} STREQUAL "AppleClang" AND ${CMAKE_CXX_COMPILER_VERSION} VERSION_GREATER 15)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -352,11 +352,14 @@ if (MSVC)
         add_compile_options(/Zc:lambda)
     endif ()
     # /bigobj (Increase Number of Sections in .Obj file)
+    add_compile_options(-bigobj)
     # error C3859: virtual memory range for PCH exceeded; please recompile with a command line option of '-Zm90' or greater
     # Generate symbols at every build target, even for the release.
 	# -Zm520 fixes error C3859 but forces the compiler to pre-allocate that memory for every translation unit regardless
 	# combining /Zi with /FS frees up a significant amount of memory pressure across all parallel compile jobs and makes /MP faster overall.
-    add_compile_options(-bigobj /Zi /FS)
+    if (SLIC3R_MSVC_PDB)
+        add_compile_options(/Zi /FS)
+    endif ()
     # Disable STL4007: Many result_type typedefs and all argument_type, first_argument_type, and second_argument_type typedefs are deprecated in C++17.
     #FIXME Remove this line after eigen library adapts to the new C++17 adaptor rules.
     add_compile_options(-D_SILENCE_CXX17_ADAPTOR_TYPEDEFS_DEPRECATION_WARNING)

--- a/build_win.bat
+++ b/build_win.bat
@@ -699,7 +699,8 @@ if "%build_slicer%" == "ON" (
     )
 
     if not "!cache_args!" == "" (
-        set "slicer_args=!slicer_args! !cache_args!"
+        REM Relative debug paths as well, so another tree can reuse the objects.
+        set "slicer_args=!slicer_args! !cache_args! -DSLIC3R_RELATIVE_DEBUG_PATHS=ON"
     )
 
     REM Configuring against a tree that was never built fails deep inside

--- a/scripts/test_build_win.ps1
+++ b/scripts/test_build_win.ps1
@@ -360,6 +360,12 @@ $cases = @(
     @{ Name = '--cache turns the precompiled header off'; Args = @('-s', '-l', '-x', '--cache', 'ccache')
        Env = @{ PATH = $ccacheOnPath }
        Contains = @('-DSLIC3R_PCH=OFF', 'COMPILER_LAUNCHER') }
+    # Without it the objects name the build directory and only that tree can use them.
+    @{ Name = '--cache asks for relative debug paths'; Args = @('-s', '-l', '-x', '--cache', 'ccache')
+       Env = @{ PATH = $ccacheOnPath }
+       Contains = @('-DSLIC3R_RELATIVE_DEBUG_PATHS=ON') }
+    @{ Name = 'no --cache leaves the debug paths alone'; Args = @('-s', '-l', '-x')
+       NotContains = @('SLIC3R_RELATIVE_DEBUG_PATHS') }
     # The resolved path, not the bare name, so PATH cannot change it later.
     @{ Name = '--cache names the resolved path in the banner'; Args = @('-s', '-l', '-x', '--cache', 'ccache')
        Env = @{ PATH = $ccacheOnPath }


### PR DESCRIPTION
# Description

Every object records the directory it was compiled in, so a second build directory at the same commit shares nothing with the first even against a warm cache. `SLIC3R_RELATIVE_DEBUG_PATHS` records `.` instead, and `--cache` turns it on.

Debugging is unaffected, because the absolute source paths are written into the PDB by the linker, which never comes from a cache.

`SLIC3R_MSVC_PDB` now controls `/Zi` and `/FS`. The option has existed since the BambuStudio import in 2022 but nothing read it, so those flags went onto every MSVC build regardless. It defaults to ON, so a default build is unchanged.

Existing cache entries stop matching once this lands, since the flag joins every compile line, so the first `--cache` build after it is a full rebuild. Builds without `--cache` are unaffected.

# Screenshots/Recordings/Graphs

Full application, clang-cl, Ninja Multi-Config, two worktrees at the same commit, `build_win.bat -s -l -x --cache ccache`:

| Run | Time | ccache |
| --- | --- | --- |
| First worktree, empty cache | 22m 48s | everything missed |
| Second worktree | **50s** | 757 of 773 hits, 756 direct |

Sharing across directories also needs `base_dir` and `hash_dir = false` in `ccache.conf`; the flag is the part the build has to supply.

## Tests

Windows, clang-cl, both worktrees under one parent directory.

* With the option off, the compile lines are identical to upstream. With it on, the flag is on all 758 of them.
* A `cl.exe` configure prints the warning instead of taking the flag.
* `scripts/test_build_win.ps1`: 222 pass, 2 new, covering the flag appearing with `--cache` and never without it.

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
