### PR TITLE
build: clear 107 warnings - dead private fields

### DIFF
--- a/src/libslic3r/FlushVolCalc.cpp
+++ b/src/libslic3r/FlushVolCalc.cpp
@@ -40,8 +40,8 @@ static float DeltaHS_BBS(float h1, float s1, float v1, float h2, float s2, float
     return std::min(1.2f, dxy);
 }
 
-FlushVolCalculator::FlushVolCalculator(int min, int max, int flush_dataset, float multiplier)
-    :m_min_flush_vol(min), m_max_flush_vol(max), m_multiplier(multiplier), m_flush_dataset(flush_dataset)
+FlushVolCalculator::FlushVolCalculator(int min, int max, int flush_dataset)
+    :m_min_flush_vol(min), m_max_flush_vol(max), m_flush_dataset(flush_dataset)
 {
 }
 

--- a/src/libslic3r/FlushVolCalc.hpp
+++ b/src/libslic3r/FlushVolCalc.hpp
@@ -15,7 +15,7 @@ extern const int g_max_flush_volume;
 class FlushVolCalculator
 {
 public:
-    FlushVolCalculator(int min, int max, int flush_dataset, float multiplier = 1.0f);
+    FlushVolCalculator(int min, int max, int flush_dataset);
     ~FlushVolCalculator()
     {
     }
@@ -32,7 +32,6 @@ public:
 private:
     int m_min_flush_vol;
     int m_max_flush_vol;
-    float m_multiplier;
     int m_flush_dataset;
 };
 

--- a/src/libslic3r/GCode/FanMover.hpp
+++ b/src/libslic3r/GCode/FanMover.hpp
@@ -32,7 +32,8 @@ class FanMover
 private:
     const std::regex regex_fan_speed;
     const float nb_seconds_delay;
-    const bool with_D_option;
+    // Set from fan_speedup_time at the call site, but nothing here reads it.
+    [[maybe_unused]] const bool with_D_option;
     const bool relative_e;
     const bool only_overhangs;
     const float kickstart;

--- a/src/libslic3r/Support/SupportMaterial.cpp
+++ b/src/libslic3r/Support/SupportMaterial.cpp
@@ -333,8 +333,7 @@ PrintObjectSupportMaterial::PrintObjectSupportMaterial(const PrintObject *object
     m_print_config          (&object->print()->config()),
     m_object_config         (&object->config()),
     m_slicing_params        (slicing_params),
-    m_support_params        (*object),
-	m_object                (object)
+    m_support_params        (*object)
 {
 }
 

--- a/src/libslic3r/Support/SupportMaterial.hpp
+++ b/src/libslic3r/Support/SupportMaterial.hpp
@@ -86,7 +86,6 @@ private:
 */
 
 	// Following objects are not owned by SupportMaterial class.
-	const PrintObject 		*m_object;
 	const PrintConfig 		*m_print_config;
 	const PrintObjectConfig *m_object_config;
 	// Pre-calculated parameters shared between the object slicer and the support generator,

--- a/src/libslic3r/Support/TreeSupport.hpp
+++ b/src/libslic3r/Support/TreeSupport.hpp
@@ -432,7 +432,6 @@ private:
     size_t          m_highest_overhang_layer = 0;
     std::vector<std::vector<MinimumSpanningTree>> m_spanning_trees;
     std::vector< std::unordered_map<Line, bool, LineHash>> m_mst_line_x_layer_contour_caches;
-    float    DO_NOT_MOVER_UNDER_MM = 0.0;
     coordf_t base_radius                        = 0.0;
     const coordf_t MAX_BRANCH_RADIUS = 10.0;
     const coordf_t MIN_BRANCH_RADIUS = 0.4;

--- a/src/slic3r/GUI/AMSDryControl.hpp
+++ b/src/slic3r/GUI/AMSDryControl.hpp
@@ -97,12 +97,6 @@ private:
     wxSimplebook* m_main_simplebook{nullptr};
     wxPanel* m_original_page{nullptr};
 
-    wxWindow* m_amswin{nullptr};
-    wxBoxSizer* m_sizer_ams_items{nullptr};
-    wxScrolledWindow* m_panel_prv_left {nullptr};
-    wxScrolledWindow* m_panel_prv_right{nullptr};
-    wxBoxSizer* m_sizer_prv_left{nullptr};
-    wxBoxSizer* m_sizer_prv_right{nullptr};
 
     // left panel related members
     ScalableBitmap m_humidity_image;

--- a/src/slic3r/GUI/AmsMappingPopup.hpp
+++ b/src/slic3r/GUI/AmsMappingPopup.hpp
@@ -457,7 +457,6 @@ private:
     ScalableBitmap close_img;
 
     wxStaticBitmap* curr_humidity_img;
-    wxStaticBitmap* m_img;
 
     Label* m_staticText;;
     Label* m_staticText_note;

--- a/src/slic3r/GUI/BBLTopbar.hpp
+++ b/src/slic3r/GUI/BBLTopbar.hpp
@@ -93,7 +93,6 @@ private:
     CenteredTitle*    m_title_ctrl { nullptr };
     wxString          m_titleText;
 
-    wxAuiToolBarItem* m_model_store_item;
     
     //wxAuiToolBarItem *m_publish_item;
     wxAuiToolBarItem* m_undo_item;

--- a/src/slic3r/GUI/BindDialog.hpp
+++ b/src/slic3r/GUI/BindDialog.hpp
@@ -65,18 +65,10 @@ private:
     wxPanel* request_bind_panel;
     wxPanel* binding_panel;
 
-    wxScrolledWindow* m_sw_bind_failed_info;
-    Label* m_bind_failed_info;
-    Label* m_st_txt_error_code{ nullptr };
-    Label* m_st_txt_error_desc{ nullptr };
-    Label* m_st_txt_extra_info{ nullptr };
-    HyperLink*      m_link_network_state{ nullptr };
     wxString        m_result_info;
     wxString        m_result_extra;
     wxString        m_ping_code_wiki;
-    bool            m_show_error_info_state = true;
 
-    int             m_result_code;
     std::shared_ptr<BBLStatusBarBind> m_status_bar;
 
 public:
@@ -110,7 +102,6 @@ private:
     wxBitmap      m_bitmap_show_error_close;
     wxBitmap      m_bitmap_show_error_open;
     wxScrolledWindow* m_sw_bind_failed_info;
-    Label*          m_bind_failed_info;
     Label*          m_st_txt_error_code{ nullptr };
     Label*          m_st_txt_error_desc{ nullptr };
     Label*          m_st_txt_extra_info{ nullptr };

--- a/src/slic3r/GUI/CalibrationPanel.hpp
+++ b/src/slic3r/GUI/CalibrationPanel.hpp
@@ -70,11 +70,7 @@ public:
 
 private:
     int                                 m_my_devices_count{ 0 };
-    int                                 m_other_devices_count{ 0 };
     bool                                m_dismiss{ false };
-    wxWindow*                           m_placeholder_panel   { nullptr };
-    wxWindow*                           m_panel_body{ nullptr };
-    wxBoxSizer*                         m_sizer_body{ nullptr };
     wxBoxSizer*                         m_sizer_my_devices{ nullptr };
     wxScrolledWindow*                   m_scrolledWindow{ nullptr };
     wxTimer*                            m_refresh_timer{ nullptr };

--- a/src/slic3r/GUI/CameraPopup.hpp
+++ b/src/slic3r/GUI/CameraPopup.hpp
@@ -72,8 +72,10 @@ private:
     SwitchButton* m_switch_recording;
     wxStaticText* m_text_vcamera;
     SwitchButton* m_switch_vcamera;
+#if !BBL_RELEASE_TO_PUBLIC
     wxStaticText* m_text_liveview_retry;
     SwitchButton* m_switch_liveview_retry;
+#endif //BBL_RELEASE_TO_PUBLIC
     wxStaticText* m_custom_camera_hint;
     TextInput* m_custom_camera_input;
     Button* m_custom_camera_input_confirm;

--- a/src/slic3r/GUI/CreatePresetsDialog.hpp
+++ b/src/slic3r/GUI/CreatePresetsDialog.hpp
@@ -74,7 +74,6 @@ private:
     std::unordered_set<std::string>                                  m_system_filament_types_set;
     std::set<std::string>                                            m_visible_printers;
     CreateType                                                       m_create_type;
-    Button *                                                         m_button_cancel                = nullptr;
     ComboBox *                                                       m_filament_vendor_combobox     = nullptr;
     ::CheckBox *                                                     m_can_not_find_vendor_checkbox = nullptr;
     ComboBox *                                                       m_filament_type_combobox       = nullptr;

--- a/src/slic3r/GUI/DailyTips.cpp
+++ b/src/slic3r/GUI/DailyTips.cpp
@@ -245,7 +245,6 @@ DailyTipsPanel::DailyTipsPanel(bool can_expand, DailyTipsLayout layout)
     m_width(0),
     m_height(0),
     m_can_expand(can_expand),
-    m_layout(layout),
     m_uid(DailyTipsPanel::uid++),
     m_dailytips_renderer(std::make_unique<DailyTipsDataRenderer>(layout))
 {

--- a/src/slic3r/GUI/DailyTips.hpp
+++ b/src/slic3r/GUI/DailyTips.hpp
@@ -51,7 +51,6 @@ private:
     int m_uid;
     bool m_first_enter{ false };
     bool m_is_dark{ false };
-    DailyTipsLayout m_layout{ DailyTipsLayout::Vertical };
     float m_fade_opacity{ 1.0f };
 };
 

--- a/src/slic3r/GUI/DeviceCore/DevConfig.h
+++ b/src/slic3r/GUI/DeviceCore/DevConfig.h
@@ -54,7 +54,7 @@ public:
     void ParseCalibrationConfig(const json& print_json); //cali
 
 private:
-    MachineObject* m_obj;
+    [[maybe_unused]] MachineObject* m_obj;
 
     /*configure vals*/
     // chamber

--- a/src/slic3r/GUI/DeviceCore/DevExtensionTool.h
+++ b/src/slic3r/GUI/DeviceCore/DevExtensionTool.h
@@ -31,7 +31,7 @@ protected:
     DevExtensionTool(MachineObject* obj);
 
 private:
-    MachineObject* m_owner = nullptr;
+    [[maybe_unused]] MachineObject* m_owner = nullptr;
 
     enum MountState
     {

--- a/src/slic3r/GUI/DeviceCore/DevFilaAmsSetting.h
+++ b/src/slic3r/GUI/DeviceCore/DevFilaAmsSetting.h
@@ -28,7 +28,7 @@ public:
     void SetAutoRefillEnabled(bool enable) { m_enable_auto_refill = enable; }
 
 private:
-    DevFilaSystem* m_owner = nullptr;
+    [[maybe_unused]] DevFilaSystem* m_owner = nullptr;
 
     std::optional<bool> m_enable_detect_on_insert = false;
     bool m_enable_detect_on_powerup = false;

--- a/src/slic3r/GUI/DeviceCore/DevHMS.h
+++ b/src/slic3r/GUI/DeviceCore/DevHMS.h
@@ -21,7 +21,7 @@ public:
     const std::vector<DevHMSItem>& GetHMSItems() const { return m_hms_list; };
 
 private:
-    MachineObject* m_object = nullptr;
+    [[maybe_unused]] MachineObject* m_object = nullptr;
 
     // all hms for this machine
     std::vector<DevHMSItem>  m_hms_list;

--- a/src/slic3r/GUI/DeviceCore/DevInfo.h
+++ b/src/slic3r/GUI/DeviceCore/DevInfo.h
@@ -34,7 +34,7 @@ private:
     //std::string m_connect_type;
     //std::string m_bind_state;
 
-    MachineObject* m_owner = nullptr;
+    [[maybe_unused]] MachineObject* m_owner = nullptr;
 };
 
 } // namespace Slic3r

--- a/src/slic3r/GUI/DeviceCore/DevStatus.h
+++ b/src/slic3r/GUI/DeviceCore/DevStatus.h
@@ -36,7 +36,7 @@ public:
     void ParseStatus(const nlohmann::json& print_jj);
 
 private:
-    MachineObject *m_owner = nullptr;
+    [[maybe_unused]] MachineObject *m_owner = nullptr;
     std::optional<DevJobState> m_job_state; // could be nullopt for some old firmware
 };
 

--- a/src/slic3r/GUI/DeviceCore/DevStorage.h
+++ b/src/slic3r/GUI/DeviceCore/DevStorage.h
@@ -31,7 +31,7 @@ public:
     bool is_timelapse_storage_low(const std::string& storage) const;
 
 private:
-    MachineObject *m_owner;
+    [[maybe_unused]] MachineObject *m_owner;
     SdcardState    m_sdcard_state  { NO_SDCARD };
     // timelapse storage space info (from device push cam data)
     int tl_internal_free_kb{-1};

--- a/src/slic3r/GUI/GUI_ObjectTable.hpp
+++ b/src/slic3r/GUI/GUI_ObjectTable.hpp
@@ -591,16 +591,11 @@ private:
     wxColour            m_hover_colour;
     wxBoxSizer*         m_top_sizer{nullptr};
     wxBoxSizer*         m_page_sizer{nullptr};
-    wxBoxSizer*         m_page_top_sizer{nullptr};
-    wxTextCtrl*         m_search_line{ nullptr };
     ObjectGrid*         m_object_grid{nullptr};
     ObjectGridTable*    m_object_grid_table{nullptr};
-    wxStaticText*       m_page_text{nullptr};
-    ScalableButton*     m_global_reset{nullptr};
     wxScrolledWindow*   m_side_window{nullptr};
     ObjectTableSettings* m_object_settings{ nullptr };
     Model*              m_model{nullptr};
-    ModelConfig*        m_config {nullptr};
     Plater*             m_plater{nullptr};
 
     int                 m_cur_row { -1 };
@@ -625,8 +620,6 @@ class ObjectTableDialog : public GUI::DPIDialog
     const int POPUP_HEIGHT  = FromDIP(1024);
 
     //wxPanel*             m_panel{ nullptr };
-    wxBoxSizer*          m_top_sizer{ nullptr };
-    wxStaticText*        m_static_title{ nullptr };
     //wxTimer*             m_refresh_timer;
     ObjectTablePanel*    m_obj_panel{ nullptr };
     Model*               m_model{ nullptr };

--- a/src/slic3r/GUI/Gizmos/GLGizmoCut.hpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoCut.hpp
@@ -94,7 +94,6 @@ class GLGizmoCut3D : public GLGizmoBase
     GLModel m_reference_radius;
     GLModel m_angle_arc;
 
-    Vec3d   m_old_center;
     Vec3d   m_cut_normal;
 
     struct InvalidConnectorsStatistics

--- a/src/slic3r/GUI/HMSPanel.hpp
+++ b/src/slic3r/GUI/HMSPanel.hpp
@@ -25,7 +25,6 @@ class HMSNotifyItem : public wxPanel
     wxStaticBitmap *m_bitmap_notify;
     wxStaticBitmap *m_bitmap_arrow;
     wxStaticText *  m_hms_content;
-    wxHtmlWindow *  m_html;
     wxPanel *       m_staticline;
 
     wxBitmap m_img_notify_lv1;

--- a/src/slic3r/GUI/IMSlider.hpp
+++ b/src/slic3r/GUI/IMSlider.hpp
@@ -216,7 +216,6 @@ private:
     long                m_extra_style;
     float               m_label_koef{1.0};
 
-    float                    m_zero_layer_height = 0.0f;
     std::vector<double>      m_values;
     TickCodeInfo             m_ticks;
     std::vector<double>      m_layers_times;

--- a/src/slic3r/GUI/Jobs/BindJob.hpp
+++ b/src/slic3r/GUI/Jobs/BindJob.hpp
@@ -20,7 +20,6 @@ class BindJob : public Job
     std::string         m_sec_link;
     std::string         m_ssdp_version;
     bool                m_job_finished{ false };
-    int                 m_print_job_completed_id = 0;
     bool                m_improved{false};
 
 public:

--- a/src/slic3r/GUI/Jobs/UpgradeNetworkJob.hpp
+++ b/src/slic3r/GUI/Jobs/UpgradeNetworkJob.hpp
@@ -27,7 +27,6 @@ class UpgradeNetworkJob : public Job
     wxWindow *           m_event_handle{nullptr};
     std::function<void()> m_success_fun{nullptr};
     bool                m_job_finished{ false };
-    int                 m_print_job_completed_id = 0;
 
     InstallProgressFn pro_fn { nullptr };
 

--- a/src/slic3r/GUI/MainFrame.cpp
+++ b/src/slic3r/GUI/MainFrame.cpp
@@ -4488,10 +4488,9 @@ std::string MainFrame::get_dir_name(const wxString &full_name) const
 // ----------------------------------------------------------------------------
 
 SettingsDialog::SettingsDialog(MainFrame* mainframe)
-:DPIDialog(NULL, wxID_ANY, wxString(SLIC3R_APP_NAME) + " - " + _L("Settings"), wxDefaultPosition, wxDefaultSize, wxDEFAULT_FRAME_STYLE, "settings_dialog"),
+:DPIDialog(NULL, wxID_ANY, wxString(SLIC3R_APP_NAME) + " - " + _L("Settings"), wxDefaultPosition, wxDefaultSize, wxDEFAULT_FRAME_STYLE, "settings_dialog")
 //: DPIDialog(mainframe, wxID_ANY, wxString(SLIC3R_APP_NAME) + " - " + _L("Settings"), wxDefaultPosition, wxDefaultSize,
 //        wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER | wxMINIMIZE_BOX | wxMAXIMIZE_BOX, "settings_dialog"),
-    m_main_frame(mainframe)
 {
     if (wxGetApp().is_gcode_viewer())
         return;

--- a/src/slic3r/GUI/MainFrame.hpp
+++ b/src/slic3r/GUI/MainFrame.hpp
@@ -94,7 +94,6 @@ class SettingsDialog : public DPIDialog//DPIDialog
 {
     //wxNotebook* m_tabpanel { nullptr };
     Notebook* m_tabpanel{ nullptr };
-    MainFrame*      m_main_frame { nullptr };
     wxMenuBar*      m_menubar{ nullptr };
 public:
     SettingsDialog(MainFrame* mainframe);

--- a/src/slic3r/GUI/MixedFilamentDialog.cpp
+++ b/src/slic3r/GUI/MixedFilamentDialog.cpp
@@ -126,7 +126,6 @@ MixedFilamentDialog::MixedFilamentDialog(wxWindow* parent,
                                          const std::vector<std::string>& physical_types)
     : DPIDialog(parent, wxID_ANY, _L("Add Mixed Filament"), wxDefaultPosition,
                 wxDefaultSize, wxCAPTION | wxCLOSE_BOX)
-    , m_edit_mode(false)
     , m_physical_colors(physical_colors)
     , m_physical_names(physical_names)
     , m_physical_types(physical_types)
@@ -157,7 +156,6 @@ MixedFilamentDialog::MixedFilamentDialog(wxWindow* parent,
     : DPIDialog(parent, wxID_ANY, _L("Edit Mixed Filament"), wxDefaultPosition,
                 wxDefaultSize, wxCAPTION | wxCLOSE_BOX)
     , m_result(existing)
-    , m_edit_mode(true)
     , m_physical_colors(physical_colors)
     , m_physical_names(physical_names)
     , m_physical_types(physical_types)

--- a/src/slic3r/GUI/MixedFilamentDialog.hpp
+++ b/src/slic3r/GUI/MixedFilamentDialog.hpp
@@ -115,7 +115,6 @@ private:
     wxColour        comp_colour(size_t i) const;
 
     MixedFilamentResult         m_result;
-    bool                        m_edit_mode{false};
     std::vector<std::string>    m_physical_colors;
     std::vector<std::string>    m_physical_names;
     std::vector<std::string>    m_physical_types;

--- a/src/slic3r/GUI/Monitor.hpp
+++ b/src/slic3r/GUI/Monitor.hpp
@@ -78,7 +78,6 @@ private:
     Tabbook*		m_tabpanel{ nullptr };
     wxSizer*        m_main_sizer{ nullptr };
 
-    AddMachinePanel*    m_status_add_machine_panel;
     StatusPanel*        m_status_info_panel;
     MediaFilePanel*     m_media_file_panel;
     UpgradePanel*       m_upgrade_panel;
@@ -86,8 +85,6 @@ private:
 
 	/* side tools */
     SideTools*      m_side_tools{nullptr};
-    wxStaticBitmap* m_bitmap_arrow;
-    wxStaticBitmap* m_bitmap_wifi_signal;
     SelectMachinePopup m_select_machine;
 
 	/* images */

--- a/src/slic3r/GUI/MsgDialog.hpp
+++ b/src/slic3r/GUI/MsgDialog.hpp
@@ -177,7 +177,6 @@ public:
 // Generic rich message dialog, used intead of wxRichMessageDialog
 class RichMessageDialog : public MsgDialog
 {
-	wxCheckBox* m_checkBox{ nullptr };
 	wxString	m_checkBoxText;
 	bool		m_checkBoxValue{ false };
 
@@ -416,7 +415,6 @@ private:
     wxString      m_new_keys;
     Button *      m_update_btn = nullptr;
     Button *      m_later_btn  = nullptr;
-    wxStaticText *m_msg_text   = nullptr;
 };
 
 

--- a/src/slic3r/GUI/MultiMachineManagerPage.hpp
+++ b/src/slic3r/GUI/MultiMachineManagerPage.hpp
@@ -79,7 +79,6 @@ private:
     wxBoxSizer*             m_main_sizer{nullptr};
     wxBoxSizer*             m_sizer_machine_list{nullptr};
     wxScrolledWindow*       m_machine_list{ nullptr };
-    wxStaticText*           m_selected_num{ nullptr };
 
     // table head
     wxPanel*                m_table_head_panel{ nullptr };
@@ -99,8 +98,6 @@ private:
     int                         m_total_count{ 0 };
     int                         m_count_page_item{ 10 };
 
-    bool                        prev{ false };
-    bool                        next{ false };
     Button*                     btn_last_page{ nullptr };
     Button*                     btn_next_page{ nullptr };
     wxStaticText*               st_page_number{ nullptr };

--- a/src/slic3r/GUI/MultiMachinePage.hpp
+++ b/src/slic3r/GUI/MultiMachinePage.hpp
@@ -81,7 +81,6 @@ private:
     AppConfig*          app_config;
     Label*              m_label{ nullptr };
     wxScrolledWindow*     scroll_macine_list{ nullptr };
-    wxBoxSizer*         m_sizer_body{ nullptr };
     wxBoxSizer*                         sizer_machine_list{ nullptr };
     std::map<std::string, DevicePickItem*>  m_device_items;
     int                 m_selected_count{0};

--- a/src/slic3r/GUI/MultiTaskManagerPage.hpp
+++ b/src/slic3r/GUI/MultiTaskManagerPage.hpp
@@ -99,7 +99,6 @@ private:
     wxBoxSizer* page_sizer{ nullptr };
     wxBoxSizer* m_sizer_task_list{ nullptr };
     wxScrolledWindow* m_task_list{ nullptr };
-    wxStaticText* m_selected_num{ nullptr };
 
     // table head
     wxPanel* m_table_head_panel{ nullptr };
@@ -113,7 +112,6 @@ private:
     Button* m_action{ nullptr };
 
     // ctrl button for all
-    int m_sel_number{0};
     wxPanel* m_ctrl_btn_panel{ nullptr };
     wxBoxSizer* m_btn_sizer{ nullptr };
     Button* btn_stop_all{ nullptr };
@@ -160,15 +158,12 @@ private:
     wxBoxSizer* m_sizer_task_list{ nullptr };
     wxBoxSizer* m_main_sizer{ nullptr };
     wxScrolledWindow* m_task_list{ nullptr };
-    wxStaticText* m_selected_num{ nullptr };
 
     // Flipping pages
     int                         m_current_page{ 0 };
     int                         m_total_page{0};
     int                         m_total_count{ 0 };
     int                         m_count_page_item{ 10 };
-    bool                        prev{ false };
-    bool                        next{ false };
     Button*                     btn_last_page{ nullptr };
     Button*                     btn_next_page{ nullptr };
     wxStaticText*               st_page_number{ nullptr };
@@ -191,7 +186,6 @@ private:
     Button*                     m_action{ nullptr };
 
     // ctrl button for all
-    int                         m_sel_number;
     wxPanel*                    m_ctrl_btn_panel{ nullptr };
     wxBoxSizer*                 m_btn_sizer{ nullptr };
     Button*                     btn_pause_all{ nullptr };

--- a/src/slic3r/GUI/ObjColorDialog.cpp
+++ b/src/slic3r/GUI/ObjColorDialog.cpp
@@ -86,8 +86,6 @@ ObjColorDialog::ObjColorDialog(wxWindow *parent, Slic3r::ObjDialogInOut &in_out,
                 wxDefaultPosition,
                 wxDefaultSize,
                 wxDEFAULT_DIALOG_STYLE /* | wxRESIZE_BORDER*/)
-    , m_filament_ids(in_out.filament_ids)
-    , m_first_extruder_id(in_out.first_extruder_id)
 {
     auto m_line_top = new wxPanel(this, wxID_ANY, wxDefaultPosition, wxSize(-1, 1));
     m_line_top->SetBackgroundColour(wxColour(166, 169, 170));

--- a/src/slic3r/GUI/ObjColorDialog.hpp
+++ b/src/slic3r/GUI/ObjColorDialog.hpp
@@ -94,7 +94,6 @@ private:
     std::vector<int>      m_cluster_map_filaments;//show middle
     int                   m_max_filament_index = 0;
     std::vector<wxColour> m_cluster_colours;//from_algo and show left
-    bool                  m_can_add_filament{true};
     bool                  m_deal_thumbnail_flag{false};
     std::vector<wxColour> m_new_add_colors;
     std::vector<wxColour> m_new_add_final_colors;
@@ -123,8 +122,6 @@ private:
     wxBoxSizer *                      m_main_sizer     = nullptr;
     wxBoxSizer *                      m_buttons_sizer   = nullptr;
     std::unordered_map<int, Button *> m_button_list;
-    std::vector<unsigned char>&      m_filament_ids;
-    unsigned char &                  m_first_extruder_id;
 };
 
 #endif  // _WIPE_TOWER_DIALOG_H_

--- a/src/slic3r/GUI/PluginPickerDialog.cpp
+++ b/src/slic3r/GUI/PluginPickerDialog.cpp
@@ -16,7 +16,6 @@ PluginPickerDialog::PluginPickerDialog(wxWindow* parent,
                                        const std::vector<Slic3r::PluginDescriptor>& plugins)
     : wxDialog(parent, wxID_ANY, wxString::Format(_L("Select %s Plugin"), plugin_type_label))
     , m_plugins(plugins)
-    , m_capability_mode(false)
 {
     build_ui(plugin_type_label);
     CentreOnParent();
@@ -27,7 +26,6 @@ PluginPickerDialog::PluginPickerDialog(wxWindow* parent,
                                        std::vector<CapabilityEntry> capabilities)
     : wxDialog(parent, wxID_ANY, wxString::Format(_L("Select %s Plugin"), plugin_type_label))
     , m_capabilities(std::move(capabilities))
-    , m_capability_mode(true)
 {
     build_capability_ui(plugin_type_label);
     CentreOnParent();

--- a/src/slic3r/GUI/PluginPickerDialog.hpp
+++ b/src/slic3r/GUI/PluginPickerDialog.hpp
@@ -50,7 +50,6 @@ private:
     wxStaticText*                  m_description  { nullptr };
     std::vector<Slic3r::PluginDescriptor> m_plugins;
     std::vector<CapabilityEntry>   m_capabilities;
-    bool                           m_capability_mode { false };
 };
 
 }} // namespace Slic3r::GUI

--- a/src/slic3r/GUI/SelectMachine.hpp
+++ b/src/slic3r/GUI/SelectMachine.hpp
@@ -662,7 +662,6 @@ private:
     ScalableButton* m_button_question { nullptr };
 
     wxStaticBitmap* m_bed_image{ nullptr };
-    Label*         m_text_bed_type;
 };
 
 

--- a/src/slic3r/GUI/SelectMachinePop.hpp
+++ b/src/slic3r/GUI/SelectMachinePop.hpp
@@ -181,13 +181,11 @@ private:
     PinCodePanel*                     m_panel_direct_connection{nullptr};
     wxWindow*                         m_placeholder_panel{nullptr};
     HyperLink*                        m_hyperlink{nullptr}; // ORCA
-    wxBoxSizer *                      m_sizer_body{nullptr};
     wxBoxSizer *                      m_sizer_my_devices{nullptr};
     wxBoxSizer *                      m_sizer_other_devices{nullptr};
     wxBoxSizer *                      m_sizer_search_bar{nullptr};
     wxSearchCtrl*                     m_search_bar{nullptr};
     wxScrolledWindow *                m_scrolledWindow{nullptr};
-    wxWindow *                        m_panel_body{nullptr};
     wxTimer *                         m_refresh_timer{nullptr};
     std::vector<MachinePanel*>        m_user_list_machine_panel;
     std::vector<MachinePanel*>        m_other_list_machine_panel;

--- a/src/slic3r/GUI/SendToPrinter.hpp
+++ b/src/slic3r/GUI/SendToPrinter.hpp
@@ -55,7 +55,6 @@ private:
     void init_timer();
 
     int                                 m_print_plate_idx;
-    int                                 m_current_filament_id;
     int                                 m_print_error_code = 0;
     int                                 timeout_count = 0;
     int                                 m_connect_try_times = 0;
@@ -77,7 +76,6 @@ private:
     TextInput*                          m_rename_input{ nullptr };
     wxSimplebook*                       m_rename_switch_panel{ nullptr };
     Plater*                             m_plater{ nullptr };
-    wxStaticBitmap*                     m_staticbitmap{ nullptr };
     ThumbnailPanel*                     m_thumbnailPanel{ nullptr };
     ComboBox*                           m_comboBox_printer{ nullptr };
     Button*                             m_rename_button{ nullptr };
@@ -97,8 +95,6 @@ private:
     wxPanel *                           m_connecting_panel{nullptr};
     wxSimplebook*                       m_simplebook{ nullptr };
     wxStaticText*                       m_statictext_finish{ nullptr };
-    wxStaticText*                       m_stext_sending{ nullptr };
-    wxStaticText*                       m_staticText_bed_title{ nullptr };
     wxStaticText*                       m_statictext_printer_msg{ nullptr };
     wxStaticText *                      m_connecting_printer_msg{nullptr};
     wxStaticText*                       m_stext_printer_title{ nullptr };
@@ -115,7 +111,6 @@ private:
     wxBoxSizer*                         sizer_thumbnail;
     wxBoxSizer*                         m_sizer_scrollable_region;
     wxBoxSizer*                         m_sizer_main;
-    wxStaticText*                       m_file_name;
     PrintDialogStatus                   m_print_status{ PrintStatusInit };
     AnimaIcon *                         m_animaicon{nullptr};
 
@@ -134,8 +129,6 @@ private:
     std::vector<RadioBox *>             m_storage_radioBox;
     std::string                         m_selected_storage;
     bool                                m_if_has_sdcard;
-    bool                                m_waiting_support{ false };
-    bool                                m_waiting_enable{ false };
     std::vector<std::string>            m_ability_list;
 
 public:

--- a/src/slic3r/GUI/SliceInfoPanel.hpp
+++ b/src/slic3r/GUI/SliceInfoPanel.hpp
@@ -28,7 +28,6 @@ public:
 
 private:
     wxScrolledWindow *m_panel;
-    BBLSliceInfo *m_info { nullptr };
 
     void OnMouse(wxMouseEvent &event);
     void OnSize(wxSizeEvent &event);

--- a/src/slic3r/GUI/SyncAmsInfoDialog.cpp
+++ b/src/slic3r/GUI/SyncAmsInfoDialog.cpp
@@ -631,7 +631,6 @@ void SyncAmsInfoDialog::updata_ui_when_priner_not_same() {
 SyncAmsInfoDialog::SyncAmsInfoDialog(wxWindow *parent, SyncInfo &info) :
     DPIDialog(static_cast<wxWindow *>(wxGetApp().mainframe), wxID_ANY, _L("Synchronize AMS Filament Information"), wxDefaultPosition, wxDefaultSize, wxCAPTION | wxCLOSE_BOX)
     , m_input_info(info)
-    , m_export_3mf_cancel(false)
     , m_mapping_popup(AmsMapingPopup(this,true))
     , m_mapping_tip_popup(AmsMapingTipPopup(this))
     , m_mapping_tutorial_popup(AmsTutorialPopup(this))

--- a/src/slic3r/GUI/SyncAmsInfoDialog.hpp
+++ b/src/slic3r/GUI/SyncAmsInfoDialog.hpp
@@ -21,15 +21,11 @@ class SyncAmsInfoDialog : public DPIDialog
     bool              m_only_exist_ext_spool_flag{false};
     int               m_current_filament_id{0};
     int               m_print_plate_idx{0};
-    int               m_print_plate_total{0};
     int               m_timeout_count{0};
     int               m_print_error_code{0};
     bool              m_is_in_sending_mode{false};
     bool              m_ams_mapping_res{false};
     bool              m_ams_mapping_valid{false};
-    bool              m_export_3mf_cancel{false};
-    bool              m_is_canceled{false};
-    bool              m_is_rename_mode{false};
     bool              m_check_flag{false};
     PrintPageMode     m_print_page_mode{PrintPageMode::PrintPageModePrepare};
     std::string       m_print_error_msg;

--- a/src/slic3r/GUI/Tab.hpp
+++ b/src/slic3r/GUI/Tab.hpp
@@ -630,7 +630,6 @@ private:
     std::vector<PageShp>			m_pages_fff;
     std::vector<PageShp>			m_pages_sla;
 
-    wxBoxSizer*         m_presets_sizer                 {nullptr};
 public:
 	ScalableButton*	m_reset_to_filament_color = nullptr;
 

--- a/src/slic3r/GUI/TextureImportDialog.cpp
+++ b/src/slic3r/GUI/TextureImportDialog.cpp
@@ -519,7 +519,6 @@ public:
         , m_entries(entries)
         , m_colors_rgba(colors_rgba)
         , m_names(names)
-        , m_existing_count(existing_count)
         , m_dialog_anchor(dialog_anchor)
         , m_on_select(std::move(on_select))
         , m_on_add_filament(std::move(on_add_filament))
@@ -877,7 +876,6 @@ private:
     std::vector<TextureFilamentEntry>          m_entries;
     std::vector<std::array<float, 4>>          m_colors_rgba;
     std::vector<std::string>                   m_names;
-    size_t                                     m_existing_count = 0;
     wxWindow*                                  m_dialog_anchor = nullptr;
     std::function<void(int)>                   m_on_select;
     std::function<void(wxColour)>              m_on_add_filament;

--- a/src/slic3r/GUI/UpdateDialogs.hpp
+++ b/src/slic3r/GUI/UpdateDialogs.hpp
@@ -33,7 +33,6 @@ public:
 
 	void on_hyperlink(wxHyperlinkEvent& evt);
 private:
-	wxCheckBox *cbox;
 };
 
 

--- a/src/slic3r/GUI/WebViewDialog.hpp
+++ b/src/slic3r/GUI/WebViewDialog.hpp
@@ -10,7 +10,7 @@
 
 #if wxUSE_WEBVIEW_EDGE
 #include "wx/msw/webview_edge.h"
-#endif //BBL_RELEASE_TO_PUBLIC
+#endif
 
 #include "wx/webviewarchivehandler.h"
 #include "wx/webviewfshandler.h"
@@ -117,7 +117,7 @@ private:
     wxButton *  m_button_forward;
     wxButton *  m_button_reload;
     wxButton *  m_button_tools;
-#endif
+#endif //BBL_RELEASE_TO_PUBLIC
 
     wxMenu* m_tools_menu;
     wxMenuItem* m_tools_handle_navigation;

--- a/src/slic3r/GUI/WebViewDialog.hpp
+++ b/src/slic3r/GUI/WebViewDialog.hpp
@@ -10,7 +10,7 @@
 
 #if wxUSE_WEBVIEW_EDGE
 #include "wx/msw/webview_edge.h"
-#endif
+#endif //BBL_RELEASE_TO_PUBLIC
 
 #include "wx/webviewarchivehandler.h"
 #include "wx/webviewfshandler.h"
@@ -108,13 +108,16 @@ public:
 private:
 
     wxWebView* m_browser;
+    wxButton *  m_button_stop;
+    wxTextCtrl *m_url;
+#if !BBL_RELEASE_TO_PUBLIC
+    // Created only by the internal-build toolbar in the constructor.
     wxBoxSizer *bSizer_toolbar;
     wxButton *  m_button_back;
     wxButton *  m_button_forward;
-    wxButton *  m_button_stop;
     wxButton *  m_button_reload;
-    wxTextCtrl *m_url;
     wxButton *  m_button_tools;
+#endif
 
     wxMenu* m_tools_menu;
     wxMenuItem* m_tools_handle_navigation;
@@ -143,7 +146,6 @@ private:
     wxMenuItem* m_dev_tools;
 
     wxInfoBar *m_info;
-    wxStaticText* m_info_text;
 
     long m_zoomFactor;
 

--- a/src/slic3r/GUI/Widgets/AMSItem.hpp
+++ b/src/slic3r/GUI/Widgets/AMSItem.hpp
@@ -641,17 +641,11 @@ private:
     AMSRoadShowMode              m_road_mode      = {AMSRoadShowMode::AMS_ROAD_MODE_FOUR};
     AMSPassRoadSTEP              m_load_step      = {AMSPassRoadSTEP::AMS_ROAD_STEP_NONE};
 
-    bool     m_selected       = {false};
-    int      m_passroad_width = {6};
-    double   m_radius         = {4};
     wxColour m_road_def_color;
     wxColour m_road_color;
 
     std::vector<ScalableBitmap> ams_humidity_img;
 
-    int      m_humidity      = {0};
-    bool     m_show_humidity = {false};
-    bool     m_vams_loading{false};
     AMSModel m_ams_model;
 };
 
@@ -690,14 +684,10 @@ private:
 
     int             m_left_road_length     = {-1};
     int             m_right_road_length    = {-1};
-    int             m_passroad_width       = {6};
-    double          m_radius               = {4};
     AMSPassRoadSTEP m_pass_road_left_step  = {AMSPassRoadSTEP::AMS_ROAD_STEP_NONE};
     AMSPassRoadSTEP m_pass_road_right_step = {AMSPassRoadSTEP::AMS_ROAD_STEP_NONE};
 
     std::map<int, wxColour> m_road_color;
-    bool m_vams_loading{false};
-    AMSModel m_ams_model;
 };
 
 /*************************************************

--- a/src/slic3r/GUI/Widgets/FanControl.hpp
+++ b/src/slic3r/GUI/Widgets/FanControl.hpp
@@ -212,7 +212,6 @@ private:
     wxGridSizer* m_sizer_fanControl { nullptr };
 
     wxBoxSizer *m_mode_sizer{ nullptr };
-    wxBoxSizer *m_bottom_sizer{ nullptr };
 
     // mode switch buttons
     std::unordered_map<int, SendModeSwitchButton*> m_mode_switch_btns; //<mode_id, SendModeSwitchButton>

--- a/src/slic3r/GUI/Widgets/MultiNozzleSync.hpp
+++ b/src/slic3r/GUI/Widgets/MultiNozzleSync.hpp
@@ -89,8 +89,6 @@ private:
 
     bool m_right_on{ true };
     wxStaticBitmap* badget;
-    Label* left;
-    Label* right;
     Label* left_diameter_desp;
     Label* right_diameter_desp;
     Label* left_flow_desp;


### PR DESCRIPTION
# Description

`-Wunused-private-field`, private members never read by the class that declares them. 107 warnings across 46 files, from #15374. This clears the category.

Most are deleted. Widget pointers left behind by copy-pasted blocks, fields set in a constructor and never used, and members whose only references are commented out. `PingCodeBindDialog` carries eight of `BindMachineDialog`'s error-display fields that were never wired up, and `GUI_ObjectTable` has three inside one 22-line block comment.

Seven exist only in the internal build, so their declarations now sit behind the same `#if !BBL_RELEASE_TO_PUBLIC` that guards their use. Those are `CameraPopup`'s liveview-retry pair and `WebViewDialog`'s toolbar members; clang reports them as unused in a public build, but deleting them breaks the internal one.

Eight are kept deliberately and marked `[[maybe_unused]]`: `FanMover::with_D_option`, which is set from `fan_speedup_time` at the call site, and the back-pointer each DeviceCore class holds to its owner. Removing those would mean changing constructor signatures in code that is still being built on, so the attribute says the field is intentional rather than forgotten.

`FlushVolCalculator` takes a `multiplier` that defaults to `1.0f`, and none of its five call sites passes one, so the parameter goes with the field. `TreeSupport`'s `DO_NOT_MOVER_UNDER_MM` member is never read because `TreeSupport.cpp` declares a local of the same name. `PrintObjectSupportMaterial` keeps a `PrintObject` pointer but reaches everything through `m_object_config` instead.

# Screenshots/Recordings/Graphs

No visual change.

## Tests

No new tests. Deleting a member nothing reads, guarding a declaration to match its use, and adding `[[maybe_unused]]` all leave behaviour unchanged.

The category goes 107 to 0 and no other category moved.

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
