### PR TITLE
Fix the Folgertech i3 0.6 nozzle printable area

### DIFF
--- a/resources/profiles/Folgertech.json
+++ b/resources/profiles/Folgertech.json
@@ -1,6 +1,6 @@
 {
 	"name": "Folgertech",
-	"version": "02.04.00.01",
+	"version": "02.04.00.02",
 	"force_update": "0",
 	"description": "Folgertech configurations",
 	"machine_model_list": [

--- a/resources/profiles/Folgertech/machine/Folgertech i3 0.6 nozzle.json
+++ b/resources/profiles/Folgertech/machine/Folgertech i3 0.6 nozzle.json
@@ -12,7 +12,7 @@
 	"printer_variant": "0.6",
 	"printable_area": [
 		"0x0",
-		"20x0",
+		"200x0",
 		"200x200",
 		"0x200"
 	],


### PR DESCRIPTION
# Description

`Folgertech i3 0.6 nozzle` declares its bed as `0x0, 20x0, 200x200, 0x200`, a triangle with a 20 mm base rather than the 200 × 200 mm square the other Folgertech i3 presets use. The second corner is a typo for `200x0`.

The GUI draws the triangle and the slicer clamps to it, so a user of this preset gets a bed that is unprintable over most of its area. It went unnoticed because nothing checked a generated print against the bed outline until #15517, whose generation-time wipe tower footprint check rejects a tower that the profile validator places inside the bed's bounding box but outside the triangle:

```
[Folgertech / Folgertech i3 0.6 nozzle] wipe tower footprint [110.998,82.5949]-[144.581,116.447] leaves printable [0,0]-[200,200]
Printer "Folgertech i3 0.6 nozzle" failed to slice: Prime Tower is partially outside the printable area, and it cannot be printed.
```

This PR corrects the corner to `200x0` and bumps the vendor profile version to `02.04.00.02`. No other preset in the vendor changes.

# Screenshots/Recordings/Graphs
Before Changes:
<img width="1685" height="1388" alt="image" src="https://github.com/user-attachments/assets/dd8be409-374d-40fa-b430-004aba71dd7b" />

After Changes:
<img width="2652" height="1066" alt="image" src="https://github.com/user-attachments/assets/50b0125a-a3de-481b-9a37-d4503eead086" />


# Tests

* The profile validator's slice check (`-s`) with #15517's engine failed on exactly this preset out of 1013 (log above). With the corrected bed the tower is placed inside the outline and the preset slices; the other 1012 presets are unaffected by this change.
* `resources/profiles/Folgertech.json` version bumped per the profile change rule.

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
