### PR TITLE
Fix: Prevent saving profiles with non valid names

### DIFF
--- a/src/slic3r/GUI/SavePresetDialog.cpp
+++ b/src/slic3r/GUI/SavePresetDialog.cpp
@@ -97,8 +97,10 @@ SavePresetDialog::Item::Item(Preset::Type type, const std::string &suffix, wxBox
     m_valid_label = new wxStaticText(m_parent, wxID_ANY, "");
     m_valid_label->SetForegroundColour(wxColor(255, 111, 0));
 
-    sizer->Add(label_top, 0, wxEXPAND | wxLEFT | wxTOP | wxBOTTOM, BORDER_W);
+    sizer->Add(label_top, 0, wxEXPAND | wxLEFT | wxTOP, BORDER_W);
+    sizer->AddSpacer(FromDIP(5));
     sizer->Add(input_sizer_h, 0, wxALIGN_CENTER|wxLEFT|wxRIGHT, BORDER_W);
+    sizer->AddSpacer(FromDIP(5));
     sizer->Add(m_valid_label, 0, wxEXPAND | wxLEFT | wxRIGHT, BORDER_W);
 
     if (m_type == Preset::TYPE_PRINTER) m_parent->add_info_for_edit_ph_printer(sizer);
@@ -254,6 +256,15 @@ void SavePresetDialog::Item::update()
     m_valid_label->SetLabel(info_line);
     m_valid_label->Show(!info_line.IsEmpty());
 
+    if (!m_ok_btn)
+        m_ok_btn = static_cast<Button*>(wxWindow::FindWindowById(wxID_OK, m_parent));
+    if (m_ok_btn){
+        if(m_valid_type == NoValid && m_ok_btn->IsEnabled())
+            m_ok_btn->Disable();
+        else if(m_valid_type != NoValid && !m_ok_btn->IsEnabled())
+            m_ok_btn->Enable();
+    }
+
     // update_valid_bmp();
 
     if (m_type == Preset::TYPE_PRINTER) m_parent->update_info_for_edit_ph_printer(m_preset_name);
@@ -320,14 +331,13 @@ void SavePresetDialog::build(std::vector<Preset::Type> types, std::string suffix
 
     m_presets_sizer = new wxBoxSizer(wxVERTICAL);
 
+    // create dialog buttons before item to make it available for changing enable/disable
+    auto dlg_btns = new DialogButtons(this, {"OK", "Cancel"});
+    dlg_btns->GetOK()->Bind(wxEVT_BUTTON, &SavePresetDialog::accept, this);
+    dlg_btns->GetCANCEL()->Bind(wxEVT_BUTTON, &SavePresetDialog::on_select_cancel, this);
+
     // Add first item
     for (Preset::Type type : types) AddItem(type, suffix);
-
-    auto dlg_btns = new DialogButtons(this, {"OK", "Cancel"});
-
-    dlg_btns->GetOK()->Bind(wxEVT_BUTTON, &SavePresetDialog::accept, this);
-
-    dlg_btns->GetCANCEL()->Bind(wxEVT_BUTTON, &SavePresetDialog::on_select_cancel, this);
 
     m_Sizer_main->Add(m_presets_sizer, 0, wxEXPAND | wxALL, BORDER_W);
     m_Sizer_main->Add(dlg_btns, 0, wxEXPAND);

--- a/src/slic3r/GUI/SavePresetDialog.hpp
+++ b/src/slic3r/GUI/SavePresetDialog.hpp
@@ -18,7 +18,7 @@ class wxComboBox;
 class wxStaticBitmap;
 
 #define SAVE_PRESET_DIALOG_DEF_COLOUR wxColour(255, 255, 255)
-#define SAVE_PRESET_DIALOG_INPUT_SIZE wxSize(FromDIP(360), FromDIP(24))
+#define SAVE_PRESET_DIALOG_INPUT_SIZE wxSize(FromDIP(360), FromDIP(28))
 #define SAVE_PRESET_DIALOG_BUTTON_SIZE wxSize(FromDIP(60), FromDIP(24))
 
 namespace Slic3r {
@@ -75,6 +75,8 @@ class SavePresetDialog : public DPIDialog
         bool                m_save_to_project {false};
         RadioGroup*         m_radio_group; // ORCA
         bool                m_detach{false};
+
+        Button*             m_ok_btn        {nullptr};
 
         void update();
     };


### PR DESCRIPTION
Disabled OK button when name is non valid. it was allowed before
PR also contains few minor UI fixes

<img width="428" height="326" alt="Screenshot-20260908003022" src="https://github.com/user-attachments/assets/184c4cc2-edc7-43cf-a4bb-b19c093f500f" />

<img width="418" height="328" alt="Screenshot-20260908002918" src="https://github.com/user-attachments/assets/d0b9ba62-13c9-49c2-9e0a-1d5457229924" />

<img width="421" height="348" alt="Screenshot-20260908002948" src="https://github.com/user-attachments/assets/7b7cc482-9fed-4248-858f-159a4e3689f3" />


Example of profile added with empty name

<img width="434" height="91" alt="Screenshot-20260908114256" src="https://github.com/user-attachments/assets/d30661d2-65a5-4f2c-98fb-3a8b11fb0632" />

<img width="641" height="145" alt="Screenshot-20260908114322" src="https://github.com/user-attachments/assets/d29a160c-2140-4657-9a0b-613508b85b8b" />

<!--
> A guide for users on how to download the artifacts from this PR.
-->

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
