### PR TITLE
fix: clear 1 warning - report the real error when a Windows G-code export fails

### DIFF
--- a/src/libslic3r/utils.cpp
+++ b/src/libslic3r/utils.cpp
@@ -961,7 +961,7 @@ CopyFileResult copy_file(const std::string &from, const std::string &to, std::st
     BOOL result = CopyFileW(src_wstr, dst_wstr, FALSE);
     if (!result) {
         DWORD errCode = GetLastError();
-        error_message = "Error: " + errCode;
+        error_message = "Error: " + std::to_string(errCode);
         ret = FAIL_COPY_FILE;
         goto __finished;
     }

--- a/src/slic3r/GUI/BackgroundSlicingProcess.cpp
+++ b/src/slic3r/GUI/BackgroundSlicingProcess.cpp
@@ -848,7 +848,9 @@ void BackgroundSlicingProcess::finalize_gcode()
     case CopyFileResult::SUCCESS: break; // no error
     case CopyFileResult::FAIL_COPY_FILE:
         throw Slic3r::ExportError(GUI::format(
-            _L("Copying of the temporary G-code to the output G-code failed. Maybe the SD card is write locked?\nError message: %1%"),
+            m_export_path_on_removable_media ?
+                _L("Copying of the temporary G-code to the output G-code failed. Maybe the SD card is write locked?\nError message: %1%") :
+                _L("Copying of the temporary G-code to the output G-code failed.\nError message: %1%"),
             error_message));
         break;
     case CopyFileResult::FAIL_FILES_DIFFERENT:

--- a/tests/libslic3r/test_utils.cpp
+++ b/tests/libslic3r/test_utils.cpp
@@ -2,6 +2,13 @@
 
 #include "libslic3r/Utils.hpp"
 
+#include "test_utils.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <fstream>
+#include <string>
+
 #ifndef _WIN32
 #include <unistd.h>     // getuid
 #endif
@@ -51,4 +58,33 @@ TEST_CASE("per-user temp root is unchanged on Windows, isolated elsewhere", "[ut
     REQUIRE(root != base);
     REQUIRE_THAT(root, Catch::Matchers::StartsWith(base + "/orcaslicer_"));
 #endif
+}
+
+TEST_CASE("copy_file reports the OS error when the destination cannot be written", "[utils]") {
+    ScopedTemporaryFile source(".txt");
+    {
+        std::ofstream ofs(source.string(), std::ios::binary);
+        ofs << "orca";
+    }
+    REQUIRE(boost::filesystem::exists(source.path()));
+
+    // A directory that was never created, so the copy fails on every platform.
+    const boost::filesystem::path destination = source.path().parent_path() / "orca-missing-dir" / "copy.txt";
+    REQUIRE_FALSE(boost::filesystem::exists(destination.parent_path()));
+
+    std::string error_message;
+    REQUIRE(copy_file(source.string(), destination.string(), error_message) == FAIL_COPY_FILE);
+    REQUIRE_FALSE(error_message.empty());
+
+#ifdef _WIN32
+    // The Windows branch formats GetLastError() itself. Writing that as
+    // "Error: " + errCode adds an integer to a string literal, which indexes into the
+    // literal instead of appending and runs off its end for any code above 7.
+    const std::string prefix = "Error: ";
+    REQUIRE(error_message.rfind(prefix, 0) == 0);
+
+    const std::string code = error_message.substr(prefix.size());
+    REQUIRE_FALSE(code.empty());
+    REQUIRE(std::all_of(code.begin(), code.end(), [](unsigned char c) { return std::isdigit(c) != 0; }));
+#endif // _WIN32
 }


### PR DESCRIPTION
# Description

On Windows `copy_file` built its failure message as `"Error: " + errCode`, which is pointer arithmetic on an 8-byte literal rather than concatenation. For any code above 7 the pointer runs off the end, `strlen` throws `length_error`, and the `catch (...)` in `finalize_gcode` replaces the diagnosis with "Unknown error occurred during exporting G-code."

Every realistic code is above 7: write-protect 19, no media 21, full disk 112, destination locked 32. So the "Maybe the SD card is write locked?" message has not been reachable on Windows since #2923.

That hint also only fits removable media, so it is now conditional on `m_export_path_on_removable_media`. The existing string is untouched and keeps its 23 translations; the fixed-drive case adds one.

From the clang-cl inventory in #15374, as `-Wstring-plus-int`.

# Screenshots/Recordings/Graphs

Exporting G-code over a file another process holds open, which fails with `ERROR_SHARING_VIOLATION` (32).

Before, with the cause discarded:

<img width="404" height="168" alt="gcode save error - before" src="https://github.com/user-attachments/assets/f9d03c31-e698-4f00-b22d-06c2a36a0bb7" />

After, exporting to a fixed disk:

<img width="468" height="168" alt="gcode save error fixed disk - after" src="https://github.com/user-attachments/assets/2a46fedb-e128-4540-a3c1-87be2ea56658" />

After, exporting to a USB drive, where the write-lock hint still applies:

<img width="653" height="168" alt="gcode save error removable - after" src="https://github.com/user-attachments/assets/92f3527d-c24c-42cf-a73e-10e3ad6e7a62" />

## Tests

New regression test in `tests/libslic3r/test_utils.cpp` asserting the failure message carries the OS error code, confirmed to fail against the unfixed file.

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
