### PR TITLE
build: fix 9 defects found by clang-cl warnings

### DIFF
--- a/src/slic3r/GUI/Field.cpp
+++ b/src/slic3r/GUI/Field.cpp
@@ -2711,7 +2711,8 @@ void ColourPicker::set_value(const boost::any& value, bool change_event)
     auto field = dynamic_cast<wxColourPickerCtrl*>(window);
 
     #ifdef __WXMSW__
-        wxColour clr = (clr_str.IsEmpty() || !clr.IsOk()) ? wxTransparentColour : clr_str;
+        const wxColour parsed_clr(clr_str);
+        wxColour clr = (clr_str.IsEmpty() || !parsed_clr.IsOk()) ? wxTransparentColour : parsed_clr;
         field->SetColour(clr);
         draw_bmp_btn(field, clr);
     #else

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -6808,7 +6808,7 @@ bool GUI_App::check_preset_parent_available(const std::pair<std::string, std::ma
 
 void GUI_App::add_pending_vendor_preset(const std::pair<std::string, std::map<std::string, std::string>>& preset_data)
 {
-    Preset::Type type;
+    Preset::Type type = Preset::Type::TYPE_INVALID;
     if (preset_data.second.at(BBL_JSON_KEY_TYPE) == PRESET_IOT_PRINT_TYPE)
         type = Preset::Type::TYPE_PRINT;
     else if (preset_data.second.at(BBL_JSON_KEY_TYPE) == PRESET_IOT_PRINTER_TYPE)

--- a/src/slic3r/GUI/GUI_Utils.cpp
+++ b/src/slic3r/GUI/GUI_Utils.cpp
@@ -102,7 +102,7 @@ CopyFileResult copy_file_gui(const std::string &from, const std::string &to, std
     result = ReadFile(handlesrc, buff, size, &dwRead, NULL);
     if (!result) {
         DWORD errCode = GetLastError();
-        error_message = "Error: " + errCode;
+        error_message = "Error: " + std::to_string(errCode);
         ret = FAIL_COPY_FILE;
         goto __finished;
     }
@@ -110,7 +110,7 @@ CopyFileResult copy_file_gui(const std::string &from, const std::string &to, std
     result = WriteFile(handledst,buff,size,&dwWrite,NULL);
     if (!result) {
         DWORD errCode = GetLastError();
-        error_message = "Error: " + errCode;
+        error_message = "Error: " + std::to_string(errCode);
         ret = FAIL_COPY_FILE;
         goto __finished;
     }

--- a/src/slic3r/GUI/Gizmos/GLGizmoBrimEars.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoBrimEars.cpp
@@ -342,7 +342,7 @@ bool GLGizmoBrimEars::on_mouse(const wxMouseEvent& mouse_event)
 // concludes that the event was not intended for it, it should return false.
 bool GLGizmoBrimEars::gizmo_event(SLAGizmoEventType action, const Vec2d &mouse_position, bool shift_down, bool alt_down, bool control_down)
 {
-    if (action != SLAGizmoEventType::MouseWheelDown || action != SLAGizmoEventType::MouseWheelUp || action != SLAGizmoEventType::Moving) {
+    if (action != SLAGizmoEventType::MouseWheelDown && action != SLAGizmoEventType::MouseWheelUp && action != SLAGizmoEventType::Moving) {
         apply_radius_change();
     }
 

--- a/src/slic3r/GUI/Gizmos/GLGizmoFdmSupports.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoFdmSupports.cpp
@@ -122,7 +122,7 @@ bool GLGizmoFdmSupports::on_init()
         {ctrl + _L("Mouse wheel"), _L("Gap area")}
     };
 
-    memset(&m_print_instance, 0, sizeof(m_print_instance));
+    m_print_instance = PrintInstance();
     return true;
 }
 

--- a/src/slic3r/GUI/MediaPlayCtrl.cpp
+++ b/src/slic3r/GUI/MediaPlayCtrl.cpp
@@ -71,7 +71,7 @@ MediaPlayCtrl::MediaPlayCtrl(wxWindow *parent, wxMediaCtrl3 *media_ctrl, const w
                 auto ip = str.find(' ', ik);
                 if (ip == wxString::npos) ip = str.Length();
                 auto v = str.Mid(ik, ip - ik);
-                if (k == "T:" && v.Length() == 8) {
+                if (strcmp(k, "T:") == 0 && v.Length() == 8) {
                     long h = 0,m = 0,s = 0;
                     v.Left(2).ToLong(&h);
                     v.Mid(3, 2).ToLong(&m);

--- a/src/slic3r/GUI/Mouse3DController.cpp
+++ b/src/slic3r/GUI/Mouse3DController.cpp
@@ -498,7 +498,7 @@ void Mouse3DController::render_settings_dialog(GLCanvas3D& canvas) const
     ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(20.0f, 20.0f));
     static ImVec2 last_win_size(0.0f, 0.0f);
     bool shown = true;
-    if (imgui.begin(_L("3Dconnexion settings"), &shown, ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoCollapse || ImGuiWindowFlags_NoTitleBar)) {
+    if (imgui.begin(_L("3Dconnexion settings"), &shown, ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoTitleBar)) {
         if (shown) {
             ImVec2 win_size = ImGui::GetWindowSize();
             if (last_win_size.x != win_size.x || last_win_size.y != win_size.y) {

--- a/src/slic3r/GUI/SyncAmsInfoDialog.cpp
+++ b/src/slic3r/GUI/SyncAmsInfoDialog.cpp
@@ -679,7 +679,7 @@ SyncAmsInfoDialog::SyncAmsInfoDialog(wxWindow *parent, SyncInfo &info) :
 
         wxBoxSizer *loading_Sizer = new wxBoxSizer(wxHORIZONTAL);
         m_gif_ctrl = new wxAnimationCtrl(m_loading_page, wxID_ANY, wxNullAnimation, wxDefaultPosition, wxDefaultSize, wxAC_DEFAULT_STYLE);
-        auto gif_path = Slic3r::var("loading.gif").c_str();
+        const wxString gif_path = from_u8(Slic3r::var("loading.gif"));
         if (m_gif_ctrl->LoadFile(gif_path)){
             m_gif_ctrl->SetSize(m_gif_ctrl->GetAnimation().GetSize());
             m_gif_ctrl->Play();

--- a/src/slic3r/Utils/Http.cpp
+++ b/src/slic3r/Utils/Http.cpp
@@ -323,8 +323,10 @@ void Http::priv::form_add_file(const char *name, const fs::path &path, const cha
 	// We can't use CURLFORM_FILECONTENT, because curl doesn't support Unicode filenames on Windows
 	// and so we use CURLFORM_STREAM with boost ifstream to read the file.
 
+	std::string filename_str;
 	if (filename == nullptr) {
-		filename = path.string().c_str();
+		filename_str = path.string();
+		filename = filename_str.c_str();
 	}
 
 	form_files.emplace_back(path, offset, length);


### PR DESCRIPTION
# Description

Nine defects from the clang-cl warning inventory in #15374. They are all real and all one-liners, so they are batched here instead of nine separate PRs. Eight of them cannot be hit and the table says why, so you don't have to work it out. The ninth, in the brim ear gizmo, is reachable and does change what a user sees; it has its own section below. #15582 covers the other one from this batch that users did hit.

| File | Defect | Why it can't be hit |
|---|---|---|
| `Utils/Http.cpp` | `filename` assigned from `path.string().c_str()`, a destroyed temporary, before curl reads it | The `filename == nullptr` branch is dead. Every call site passes a filename, and nothing calls the two overloads that pass `nullptr` |
| `GUI/SyncAmsInfoDialog.cpp` | `var("loading.gif").c_str()` dangles into `LoadFile` on the next line | Runs every time the dialog opens, but the freed bytes still hold the path, so the image loads anyway |
| `GUI/Mouse3DController.cpp` | `\| NoCollapse \|\| NoTitleBar` collapses the whole flag set to the boolean `1` | `render_settings_dialog` returns early unless a 3Dconnexion device is connected |
| `GUI/Field.cpp` | `wxColour clr = (... \|\| !clr.IsOk()) ? ...` calls `IsOk()` on `clr` inside its own initializer | Windows only, and the garbage it reads has come out valid every time so far |
| `GUI/GUI_App.cpp` | `Preset::Type type;` left unset when the preset type string matches none of three branches | Needs a user preset whose `type` is not `print`, `printer` or `filament`. `TYPE_INVALID` is what `find_preset_vendor` already answers with an empty vendor name |
| `GUI/GUI_Utils.cpp` | `copy_file_gui` repeats the `"Error: " + errCode` defect fixed in #15582, at two sites | The function is dead. Its only caller, `Utils/PresetUpdater.cpp:69`, is commented out |
| `GUI/MediaPlayCtrl.cpp` | `k == "T:"` compares `const char*` pointers rather than text | `m_stat` is written and never read anywhere in the tree |
| `GUI/Gizmos/GLGizmoFdmSupports.cpp` | `memset` over a non-trivially-copyable `PrintInstance` | Formally UB, but it zeroes correctly in practice and the value is overwritten before any read |

## The brim ear gizmo, which is reachable

`GLGizmoBrimEars.cpp` had `a != X || a != Y || a != Z`, which can never be false, so `apply_radius_change()` ran on the events it was written to skip.

`GLGizmosManager::on_mouse_wheel` forwards wheel events to `BrimEars`. Ctrl+wheel there accumulates, so each tick stashes the pre-edit radius, bumps by 0.1 and returns early, and the whole gesture lands on the undo stack as one step. Pushing that step is what `apply_radius_change()` does, and the always-true guard ran it on the way into every tick, so each tick after the first became its own undo entry.

Manual steps:

1. Load any model and open the Brim Ears gizmo.
2. Click the model to place a brim ear point.
3. Click that point to select it. Ctrl+wheel only affects selected points, so this step matters.
4. Hold Ctrl and scroll up a lot, until the ear has visibly swollen.
5. Press Ctrl+Z once.

Before, the ear shrinks by a single 0.1 tick and it takes one Ctrl+Z per tick to get back to the original size. After, one Ctrl+Z returns it.

# Screenshots/Recordings/Graphs

None.

## Tests

None. Every site is in `src/slic3r` and needs a `wxApp`, a `GLCanvas3D` or a live curl transfer to reach. The two `copy_file_gui` sites look testable, but the `ReadFile` and `WriteFile` failures they sit on cannot happen once both handles have opened, and a bad destination fails earlier with a different hardcoded message. A test there would pass either way. The brim ear fix has manual steps above.

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
