### PR TITLE
build: clear 11 single-site clang-cl warning categories

### DIFF
--- a/src/OrcaSlicer_app_msvc.cpp
+++ b/src/OrcaSlicer_app_msvc.cpp
@@ -297,7 +297,7 @@ int wmain(int argc, wchar_t **argv)
 //	printf("Loading Slic3r library: %S\n", path_to_slic3r);
     HINSTANCE hInstance_Slic3r = LoadLibraryExW(path_to_slic3r, nullptr, 0);
     if (hInstance_Slic3r == nullptr) {
-        printf("OrcaSlicer.dll was not loaded, error=%d\n", GetLastError());
+        printf("OrcaSlicer.dll was not loaded, error=%lu\n", GetLastError());
         return -1;
     }
 

--- a/src/dev-utils/StackWalker.cpp
+++ b/src/dev-utils/StackWalker.cpp
@@ -364,7 +364,7 @@ void CStackWalker::GetModuleInformation(LPMODULE_INFO pmi)
 
 	if (dwInfoSize > 0)
 	{
-		LPVOID lpData = new byte[dwInfoSize];
+		byte *lpData = new byte[dwInfoSize];
 		ZeroMemory(lpData, dwInfoSize * sizeof(byte));
 
 		if (GetFileVersionInfo(pmi->szModulePath, dwHandle, dwInfoSize, lpData) > 0 )

--- a/src/libslic3r/GCode/GCodeProcessor.cpp
+++ b/src/libslic3r/GCode/GCodeProcessor.cpp
@@ -2777,7 +2777,7 @@ bool GCodeProcessor::check_multi_extruder_gcode_valid(const int                 
     std::map<int, std::map<int, GCodePosInfo>> gcode_path_pos; // object_id, filament_id, pos
     for (const GCodeProcessorResult::MoveVertex &move : m_result.moves) {
         // sometimes, the start line extrude was outside the edge of plate a little, this is allowed, so do not include into the gcode_path_pos
-        if (move.type == EMoveType::Extrude /* && move.extrusion_role != ExtrusionRole::erFlush || move.type == EMoveType::Travel*/)
+        if (move.type == EMoveType::Extrude /* && move.extrusion_role != ExtrusionRole::erFlush || move.type == EMoveType::Travel*/) {
             if (move.extrusion_role == ExtrusionRole::erCustom) {
                 /*if (move.is_arc_move_with_interpolation_points()) {
                     for (int i = 0; i < move.interpolation_points.size(); i++) {
@@ -2799,6 +2799,7 @@ bool GCodeProcessor::check_multi_extruder_gcode_valid(const int                 
                 gcode_path_pos[move.object_label_id][int(move.extruder_id)].max_print_z = std::max(gcode_path_pos[move.object_label_id][int(move.extruder_id)].max_print_z,
                                                                                                    move.print_z);
             }
+        }
     }
 
     bool valid = true;

--- a/src/libslic3r/GCode/ToolOrdering.cpp
+++ b/src/libslic3r/GCode/ToolOrdering.cpp
@@ -3137,7 +3137,7 @@ void ToolOrdering::assign_custom_gcodes(const Print &print)
 		// Skip all custom G-codes above this layer and skip all extruder switches.
 		for (; custom_gcode_it != custom_gcode_per_print_z.gcodes.rend() && (
             (print_z_above > lt.print_z && custom_gcode_it->print_z > 0.5 * (lt.print_z + print_z_above))
-            || custom_gcode_it->type == CustomGCode::ToolChange); ++ custom_gcode_it);
+            || custom_gcode_it->type == CustomGCode::ToolChange); ++ custom_gcode_it) {}
         print_z_above = lt.print_z;
 		if (custom_gcode_it == custom_gcode_per_print_z.gcodes.rend())
 			// Custom G-codes were processed.

--- a/src/libslic3r/GCode/WipeTower.cpp
+++ b/src/libslic3r/GCode/WipeTower.cpp
@@ -4883,12 +4883,8 @@ void WipeTower::generate_new(std::vector<std::vector<WipeTower::ToolChangeResult
                     }
                 }
 
-                if (!has_inserted) {
-                    if (finish_block_tcr.gcode.empty())
-                        finish_block_tcr = finish_block_tcr;
-                    else
-                        finish_layer_tcr = merge_tcr(finish_layer_tcr, finish_block_tcr);
-                }
+                if (!has_inserted && !finish_block_tcr.gcode.empty())
+                    finish_layer_tcr = merge_tcr(finish_layer_tcr, finish_block_tcr);
             }
         }
         // record the contact layers of different categories

--- a/src/slic3r/GUI/AmsMappingPopupUpdate.cpp
+++ b/src/slic3r/GUI/AmsMappingPopupUpdate.cpp
@@ -406,7 +406,7 @@ void AmsMapingPopup::update_ams_data_multi_machines()
         int ams_type = 1;
         int nozzle_id = 0;
 
-        if (ams_type >= 1 || ams_type <= 3) { // 1:ams 2:ams-lite 3:n3f
+        if (ams_type >= 1 && ams_type <= 3) { // 1:ams 2:ams-lite 3:n3f
 
             auto sizer_mapping_list = new wxBoxSizer(wxHORIZONTAL);
             auto ams_mapping_item_container = new MappingContainer(nozzle_id == 0 ? m_right_marea_panel : m_left_marea_panel, "AMS-1", 4);

--- a/src/slic3r/GUI/CalibrationWizardPresetPage.cpp
+++ b/src/slic3r/GUI/CalibrationWizardPresetPage.cpp
@@ -360,7 +360,7 @@ void CaliPresetCustomRangePanel::create_panel(wxWindow* parent)
                 int max_decimal_length;
                 if (i <= 1)
                     max_decimal_length = 3;
-                else if (i >= 2)
+                else
                     max_decimal_length = 4;
                 if (decimal_number > max_decimal_length) {
                     int allowed_length = number.length() - decimal_number + max_decimal_length;

--- a/src/slic3r/GUI/DeviceCore/DevManager.cpp
+++ b/src/slic3r/GUI/DeviceCore/DevManager.cpp
@@ -872,7 +872,7 @@ namespace Slic3r
                         obj->m_is_online = elem["dev_online"].get<bool>();
                     if (elem.contains("dev_model_name") && !elem["dev_model_name"].is_null()) {
                         auto printer_type = elem["dev_model_name"].get<std::string>();
-                        for (const std::pair<std::string, std::vector<std::string>> &pair : device_subseries) {
+                        for (const auto &pair : device_subseries) {
                             auto it = std::find(pair.second.begin(), pair.second.end(), printer_type);
                             if (it != pair.second.end())
                             {

--- a/src/slic3r/GUI/SyncAmsInfoDialog.cpp
+++ b/src/slic3r/GUI/SyncAmsInfoDialog.cpp
@@ -1548,7 +1548,7 @@ bool SyncAmsInfoDialog::is_nozzle_type_match(DevExtderSystem data, wxString &err
                     auto sai_nz_pt = wxGetApp().preset_bundle->printers.get_edited_preset().get_printer_type(wxGetApp().preset_bundle);
                     if (target_machine_nozzle_id == DEPUTY_EXTRUDER_ID) {
                         pos = _L(DevPrinterConfigUtil::get_toolhead_display_name(sai_nz_pt, DEPUTY_EXTRUDER_ID, ToolHeadComponent::Nozzle, ToolHeadNameCase::LowerCase));
-                    } else if ((target_machine_nozzle_id == MAIN_EXTRUDER_ID)) {
+                    } else if (target_machine_nozzle_id == MAIN_EXTRUDER_ID) {
                         pos = _L(DevPrinterConfigUtil::get_toolhead_display_name(sai_nz_pt, MAIN_EXTRUDER_ID, ToolHeadComponent::Nozzle, ToolHeadNameCase::LowerCase));
                     }
 

--- a/src/slic3r/Utils/Http.cpp
+++ b/src/slic3r/Utils/Http.cpp
@@ -254,10 +254,8 @@ int Http::priv::xfercb(void *userp, curl_off_t dltotal, curl_off_t dlnow, curl_o
 	bool cb_cancel = false;
 
 	if (self->progressfn) {
-		double speed;
+		double speed = 0.;
         curl_easy_getinfo(self->curl, CURLINFO_SPEED_UPLOAD, &speed);
-		if (speed > 0.01)
-			speed = speed;
 		Progress progress(dltotal, dlnow, ultotal, ulnow, self->buffer, speed);
 		self->progressfn(progress, cb_cancel);
 	}

--- a/src/slic3r/Utils/SnapmakerPrinterAgent.cpp
+++ b/src/slic3r/Utils/SnapmakerPrinterAgent.cpp
@@ -39,7 +39,7 @@ std::string find_closest_color_preset_by_vendor_and_type(const PresetCollection&
             std::string  p_color = p.config.opt_string("default_filament_colour", 0u);
             unsigned int p_color_value;
             if (!p_color.empty()) {
-                unsigned int hash_pos = p_color.find("#");
+                size_t       hash_pos = p_color.find("#");
                 p_color_value         = std::stoul(p_color.substr(hash_pos != std::string::npos ? hash_pos + 1 : 0), nullptr, 16);
             } else {
                 // Default to black if no color specified in profile. Assume other profiles might be a closer color match.


### PR DESCRIPTION
# Description

Eleven sites from the clang-cl warning inventory in #15374, each the last one left in its category. Every one is the compiler saying it cannot tell what the code meant, and nothing here changes defined behavior.

| File | Warning | Fix |
|---|---|---|
| `OrcaSlicer_app_msvc.cpp:300` | `-Wformat` | `%d` given a `DWORD`, now `%lu` |
| `dev-utils/StackWalker.cpp:367` | `-Wdelete-incomplete` | `delete[]` ran through an `LPVOID`, so the local is now `byte *` |
| `GCode/ToolOrdering.cpp:3140` | `-Wempty-body` | a deliberate skip loop had a bare `;` for a body, now `{}` |
| `GCode/WipeTower.cpp:4886` | `-Wself-assign-overloaded` | `finish_block_tcr = finish_block_tcr` is a no-op, so that branch did nothing. Folded the condition into the enclosing `if`. The merge branch is unchanged |
| `GCode/GCodeProcessor.cpp:2780` | `-Wdangling-else` | the `else` binds to the inner `if` while the outer `if` carried no braces. Added them |
| `GUI/AmsMappingPopupUpdate.cpp:409` | `-Wtautological-overlap-compare` | `>= 1 \|\| <= 3` is always true, and the comment on that line describes `&&`. `ams_type` is a local set to 1 two lines up, so both forms are true here |
| `GUI/CalibrationWizardPresetPage.cpp:363` | `-Wsometimes-uninitialized` | `i <= 1` and `i >= 2` cover every value, but the compiler cannot see that, so this is a plain `else` now |
| `GUI/DeviceCore/DevManager.cpp:875` | `-Wrange-loop-construct` | map elements bound to `pair<K, V>` rather than `pair<const K, V>`, copying each one. Now `const auto &` |
| `GUI/SyncAmsInfoDialog.cpp:1551` | `-Wparentheses-equality` | extraneous parentheses around a comparison |
| `Utils/Http.cpp:259` | `-Wself-assign` | `if (speed > 0.01) speed = speed;` removed, which put an uninitialized read right next to it. `speed` now starts at 0, because `curl_easy_getinfo` leaves the target untouched when it fails and the value reaches `Progress` either way |
| `Utils/SnapmakerPrinterAgent.cpp:42` | `-Wtautological-constant-out-of-range-compare` | `unsigned int` truncated `npos`, so the `!= npos` guard was always true. `size_t` compares properly, and a colour with no `#` still yields 0 because the wrap produced 0 as well |

Nine of those categories go to zero here. `-Wtautological-overlap-compare` and `-Wsometimes-uninitialized` reach zero once #15583 merges their second site.

# Screenshots/Recordings/Graphs

None. Nothing here is visible at runtime.

## Tests

None. Eight are syntax or type changes with provably identical behavior, one of those also dropping a per-element copy in `DevManager.cpp`. The other three tighten cases that were undefined or implementation-dependent: a `DWORD` printed with `%d`, `delete[]` run through a `void *`, and a possibly uninitialized `speed` reaching `Progress`.

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
