### PR TITLE
Fix modifier settings after cutting objects with connectors

### DIFF
--- a/src/slic3r/GUI/GUI_ObjectSettings.cpp
+++ b/src/slic3r/GUI/GUI_ObjectSettings.cpp
@@ -243,8 +243,15 @@ bool ObjectSettings::update_settings_list()
                 return false;
             plate_configs.emplace(ppl.get_plate(plate_id), &cfg);
             parent_object = object;
-            const int vol_idx = objects_model->GetVolumeIdByItem(item);
-            assert(vol_idx >= 0);
+            // Cut-connector volumes are hidden from the object tree but remain
+            // in ModelObject::volumes. Translate the visible UI index back to
+            // the real model-volume index before binding the settings panel.
+            const int ui_vol_idx = objects_model->GetVolumeIdByItem(item);
+            if (ui_vol_idx < 0)
+                return false;
+            const int vol_idx = objects_model->get_real_volume_index_in_3d(obj_idx, ui_vol_idx);
+            if (vol_idx < 0 || static_cast<size_t>(vol_idx) >= object->volumes.size())
+                return false;
             auto volume = object->volumes[vol_idx];
             object_configs.emplace(volume, &volume->config);
         }


### PR DESCRIPTION
# Description

Fixes incorrect volume-settings binding when a parameter modifier is selected after cutting an object with connectors.

Cut connector volumes remain in `ModelObject::volumes`, but are hidden from the object tree. As a result, `GetVolumeIdByItem()` returns a UI volume index that may no longer match the actual index in `ModelObject::volumes`.

`ObjectSettings::update_settings_list()` used that UI index directly, so settings intended for a modifier could be bound to a hidden cut connector instead.

The fix translates the visible UI index using `get_real_volume_index_in_3d()` before accessing the backend volume.

Related to #8438.

This is intentionally a minimal change limited to the settings-binding path involved in the reported behavior.

**Attribution:** Christian Douglas / Vox

# Screenshots/Recordings/Graphs

Manual regression testing was performed with a neutral cube, a cut connector, and a cylindrical parameter modifier.

The test showed sparse infill outside the modifier and the configured higher-density region being correctly applied inside the modifier after the fix.

## Tests

- Built current `main` on Windows x64 in Release configuration.
- Build completed successfully with the patch.
- Reproduced the workflow with a cube cut using a connector.
- Added a parameter modifier after the cut.
- Verified global sparse infill at 8% and modifier infill at 80%.
- Verified in Preview that the modifier region uses its local infill setting while the rest of the object retains the global setting.
- Re-tested the original real-world workflow that exposed the bug, including a high/100% modifier infill configuration.
- `git diff --check` passes.

No printer profiles, project formats, slicing algorithms, defaults, or unrelated UI behavior are changed by this patch.




<img width="1920" height="1080" alt="Captura de tela 2026-09-08 080635" src="https://github.com/user-attachments/assets/2cf09519-3e2b-4405-a5e7-a5846808d787" />

<img width="1920" height="1080" alt="Captura de tela 2026-09-08 080727" src="https://github.com/user-attachments/assets/8be8097d-1f43-47cc-a148-af8b12ed0dfd" />
<img width="1920" height="1080" alt="Captura de tela 2026-09-08 080855" src="https://github.com/user-attachments/assets/0d5f9cb7-e4dd-4355-82a6-60215bf723cc" />
<img width="1920" height="1080" alt="Captura de tela 2026-09-08 080917" src="https://github.com/user-attachments/assets/ba3e7561-7e37-4b3b-9034-6e4632c2292b" />
