### PR TITLE
Fix two stack buffer overflows in ADMesh stl_read (unbounded solid name + MW metadata parse)

### DIFF
--- a/deps_src/admesh/stlinit.cpp
+++ b/deps_src/admesh/stlinit.cpp
@@ -162,7 +162,7 @@ static bool stl_read(stl_file *stl, FILE *fp, int first_facet, bool first, Impor
         rewind(fp);
         try{
             char solid_name[256];
-            int res_solid = fscanf(fp, " solid %[^\n]", solid_name);
+            int res_solid = fscanf(fp, " solid %255[^\n]", solid_name);
             if (res_solid == 1) {
                 char* mw_position = strstr(solid_name, "MW");
                 if (mw_position != NULL) {
@@ -170,7 +170,7 @@ static bool stl_read(stl_file *stl, FILE *fp, int first_facet, bool first, Impor
                     char version_str[16];
                     char model_id_str[128]; 
                     char country_code_str[16];
-                    int num_values = sscanf(mw_position + 3, "%s %s %s", version_str, model_id_str, country_code_str);
+                    int num_values = sscanf(mw_position + 3, "%15s %127s %15s", version_str, model_id_str, country_code_str);
                     if (num_values == 3) {
                         if (strcmp(version_str, "1.0") == 0) {
                             model_id = model_id_str;


### PR DESCRIPTION
# Fix two stack buffer overflows in the ADMesh ASCII-STL loader (`stl_read`) — unbounded `solid` name and unbounded `MW` metadata parse

## Summary

`stl_read()` in `deps_src/admesh/stlinit.cpp` contains **two** stack buffer
overflows on the ASCII-STL path, both reachable simply by opening (or
drag-and-dropping) a `.stl` file:

1. **The `solid` name** is copied into a fixed **256-byte stack buffer** with an
   `fscanf` scanset that has **no field width**, so a `solid` name longer than
   255 bytes overruns `solid_name[256]` and the adjacent saved stack state,
   including the **saved return address**. This is the same defect being fixed
   upstream in BambuStudio (see companion PR, below).

2. **OrcaSlicer-specific:** immediately afterward, OrcaSlicer parses a `"MW"`
   metadata tag out of the solid name with **three unbounded `%s` conversions**
   into small fixed buffers (`version_str[16]`, `model_id_str[128]`,
   `country_code_str[16]`). A crafted solid name overflows these too. This code
   is **not present upstream in BambuStudio** — it was added in OrcaSlicer — so
   OrcaSlicer carries an additional overflow beyond the inherited one.

Both are attacker-controlled: a `.stl` is a routine file users constantly open
and receive from third parties (marketplaces, shared projects, print farms).

## Why OrcaSlicer is affected

OrcaSlicer vendors the ADMesh loader (`deps_src/admesh/`) that originates in the
BambuStudio tree, so it **inherited** overflow (1) verbatim — the unbounded
`fscanf(fp, " solid %[^\n]", …)` into a 256-byte buffer is present at HEAD on the
default branch. Separately, OrcaSlicer **added** the `"MW"` version/model-id
parsing block, which introduces overflow (2) that upstream does not have. So
OrcaSlicer is impacted on two counts: one inherited, one of its own.

OrcaSlicer's own downstream vendor forks (e.g. FlashForge `Orca-Flashforge`,
Elegoo `ElegooSlicer`, Anycubic `AnycubicSlicerNext`, Mingda, Pantheon, Xunda,
Dremel, IdeaFormer, Adartys, Snapmaker) inherit whichever of these they have
merged; fixing here lets that tree pull the fix.

## Vulnerable code

`deps_src/admesh/stlinit.cpp`, inside `stl_read()`:

```c
char solid_name[256];
int res_solid = fscanf(fp, " solid %[^\n]", solid_name);          // (1) no field width
if (res_solid == 1) {
    char* mw_position = strstr(solid_name, "MW");
    if (mw_position != NULL) {
        char version_str[16];
        char model_id_str[128];
        char country_code_str[16];
        int num_values = sscanf(mw_position + 3, "%s %s %s",       // (2) three unbounded %s
                                version_str, model_id_str, country_code_str);
        ...
```

An ASCII STL begins with `solid <name>\n`. The `%[^\n]` conversion copies
`<name>` up to the newline into `solid_name` with no bound. If `<name>` contains
`MW`, the bytes after it are then split by `sscanf("%s %s %s", …)` into three
fixed buffers with no width limits.

The upstream-safe form of (1) discards the name with an assignment-suppressed,
buffer-less conversion (`fscanf(fp, " solid%*[^\n]\n")`); where the name is kept,
it must carry an explicit maximum field width.

## Impact

- **Memory corruption on file open.** Overflow (1) overwrites the saved return
  address with attacker-controlled bytes → **instruction-pointer control**.
  Overflow (2) overwrites stack state adjacent to the three buffers with
  attacker-controlled bytes from the solid name.
- **No Pointer Authentication on the shipped macOS build.** The distributed
  `arm64` slice is plain `arm64` (not `arm64e`), so the saved return address is a
  raw, directly-usable code pointer.
- **Trivially reachable.** No user interaction beyond opening the file.

## Proof — return address in control (overflow 1)

Reproducer generator:

```python
#!/usr/bin/env python3
# make_overflow_stl.py -- reproducer for the stl_read() solid-name overflow.
import sys
_FACET=("facet normal 0 0 0\n outer loop\n"
        "  vertex 0 0 0\n  vertex 1 0 0\n  vertex 0 1 0\n endloop\nendfacet\n")
def de_bruijn(n=4, alphabet=("abcdefghijklmnopqrstuvwxyz"
             "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"), length=None):
    k=len(alphabet); a=[0]*k*n; seq=[]
    def db(t,p):
        if t>n:
            if n%p==0: seq.extend(a[1:p+1])
        else:
            a[t]=a[t-p]; db(t+1,p)
            for j in range(a[t-p]+1,k): a[t]=j; db(t+1,t)
    db(1,1); s="".join(alphabet[i] for i in seq)
    if length:
        while len(s)<length: s+=s
        s=s[:length]
    return s
def write_stl(path,name):
    open(path,"w").write("solid "+name+"\n"+_FACET+"endsolid\n")
    print("wrote",path,"solid name =",len(name),"bytes")
if __name__=="__main__":
    cmd=sys.argv[1] if len(sys.argv)>1 else "plain"
    n=int(sys.argv[2]) if len(sys.argv)>2 else (20000 if cmd=="plain" else 1200)
    write_stl("poc_solid_overflow.stl","A"*n) if cmd=="plain" \
        else write_stl("poc_solid_cyclic.stl", de_bruijn(length=n))
```

Run `python3 make_overflow_stl.py cyclic 1200`, open the resulting `.stl`, and
read the crash report’s own backtrace:

```
Exception Type:  EXC_BAD_ACCESS (SIGSEGV)
Thread 0 Crashed:
  0  <app>  stl_read(...)+…            ; still inside the ADMesh load
  1  <app>  0x0000614762616146         ; FRAME #1 SAVED RETURN ADDRESS
  0x0000614762616146  ->  "F a a b G a"  ->  De Bruijn offset 368
```

So the overflow places attacker-controlled bytes into the saved return address at
**solid-name offset 368**. A plain 20000×`'A'` name puts `0x414141414141` in the
same slot.

| solid-name offset | overwritten slot | consequence |
|---|---|---|
| 368 | saved return address (frame #1) | instruction-pointer control (no PAC) |

## Proof — MW buffers in control (overflow 2)

A solid name of the form `MW<sep><token1> <token2> <token3>` drives the three
unbounded `%s` conversions:

```python
# make_mw_overflow_stl.py
FACET=("facet normal 0 0 0\n outer loop\n"
       "  vertex 0 0 0\n  vertex 1 0 0\n  vertex 0 1 0\n endloop\nendfacet\n")
# token1 -> version_str[16] overflows after 15 bytes
# token2 -> model_id_str[128] overflows after 127 bytes
# token3 -> country_code_str[16] overflows after 15 bytes
name = "MW " + "A"*64 + " " + "B"*256 + " " + "C"*64
open("poc_mw_overflow.stl","w").write("solid "+name+"\n"+FACET+"endsolid\n")
```

`version_str[16]` overflows once the first whitespace-delimited token exceeds 15
bytes; `model_id_str[128]` and `country_code_str[16]` overflow on the second and
third tokens. Because these buffers sit higher on the stack than `solid_name`,
even a name shorter than 256 bytes reaches saved state through this path.

## Suggested fix

Bound every conversion with an explicit field width matching the destination:

```diff
-            int res_solid = fscanf(fp, " solid %[^\n]", solid_name);
+            int res_solid = fscanf(fp, " solid %255[^\n]", solid_name);
```

```diff
-                    int num_values = sscanf(mw_position + 3, "%s %s %s", version_str, model_id_str, country_code_str);
+                    int num_values = sscanf(mw_position + 3, "%15s %127s %15s", version_str, model_id_str, country_code_str);
```

`%255[^\n]` keeps the existing behavior (the name is still read) while making it
impossible to overflow `solid_name[256]`; `%15s`/`%127s`/`%15s` bound each MW
token to its buffer (size − 1 for the NUL). This PR applies exactly these two
changes. As general hardening, every `%s`/`%[` scanset targeting a fixed buffer
in this file should carry an explicit maximum field width.

## Companion

The inherited `solid`-name overflow is fixed upstream in
bambulab/BambuStudio#12153. This PR mirrors that fix for OrcaSlicer and
additionally addresses the OrcaSlicer-only `MW` metadata overflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
