### PR TITLE
CLI: record user overrides in different_settings_to_system for 3MF export

### DIFF
--- a/src/OrcaSlicer.cpp
+++ b/src/OrcaSlicer.cpp
@@ -3321,6 +3321,16 @@ int CLI::run(int argc, char **argv)
             int filament_index = load_filaments_index[index];
             std::vector<std::string> different_keys;
 
+            //ORCA: diff before load_default_gcodes_to_config, the way the process and machine
+            //      slots above already do. That call materialises absent gcode keys via
+            //      option(..., true), and DynamicConfig::diff only compares keys present in
+            //      both configs -- so a gcode key the leaf did not carry would go from "not
+            //      compared" to "compared as empty against the parent" and land in the column
+            //      as an override the user never made.
+            std::string filament_different_settings;
+            if (load_filament_count > 0)
+                filament_different_settings = cli_different_settings(config, load_filaments_inherit[index], Preset::TYPE_FILAMENT);
+
             load_default_gcodes_to_config(config, Preset::TYPE_FILAMENT);
 
             if (load_filament_count > 0) {
@@ -3333,7 +3343,7 @@ int CLI::run(int argc, char **argv)
                 config.erase("filament_settings_id");
 
                 //ORCA: was a //todo — same treatment as process/machine above.
-                different_settings[filament_index] = cli_different_settings(config, load_filaments_inherit[index], Preset::TYPE_FILAMENT);
+                different_settings[filament_index] = filament_different_settings;
                 inherits_group[filament_index] = load_filaments_inherit[index];
             }
             else {

--- a/src/OrcaSlicer.cpp
+++ b/src/OrcaSlicer.cpp
@@ -2046,6 +2046,51 @@ int CLI::run(int argc, char **argv)
                                              error, allow_source_manifest);
     };
 
+    //ORCA: list the keys a user preset overrides relative to its system parent, for the
+    //      `different_settings_to_system` column of an exported 3MF. Without it the CLI
+    //      writes an empty column, so re-opening a CLI-exported project in the GUI shows
+    //      spurious "unsaved changes" and can revert inherited process/filament/machine
+    //      values to system defaults.
+    //
+    //      The parent comes from the preset bundle that inherits resolution already builds,
+    //      so this adds no extra loading. Returns "" whenever the parent cannot be resolved,
+    //      which is exactly the previous behaviour.
+    auto cli_different_settings = [&ensure_cli_preset_bundle](const DynamicPrintConfig &resolved,
+                                                              const std::string        &parent_name,
+                                                              Preset::Type              type) -> std::string {
+        if (parent_name.empty())
+            return std::string();
+        std::string   error;
+        PresetBundle *bundle = ensure_cli_preset_bundle(error);
+        if (bundle == nullptr) {
+            BOOST_LOG_TRIVIAL(warning) << "CLI: no preset bundle for different_settings_to_system: " << error;
+            return std::string();
+        }
+        const PresetCollection *collection = nullptr;
+        switch (type) {
+        case Preset::TYPE_PRINT:    collection = &bundle->prints;    break;
+        case Preset::TYPE_FILAMENT: collection = &bundle->filaments; break;
+        case Preset::TYPE_PRINTER:  collection = &bundle->printers;  break;
+        default:                    return std::string();
+        }
+        const Preset *parent = collection->find_preset2(parent_name, true);
+        if (parent == nullptr) {
+            BOOST_LOG_TRIVIAL(warning) << boost::format("CLI: parent preset '%1%' not found; leaving different_settings_to_system empty")%parent_name;
+            return std::string();
+        }
+        std::vector<std::string> keys = resolved.diff(parent->config);
+        //ORCA: preset metadata, not user-tunable settings. compatible_printers /
+        //      compatible_prints have their own tracking columns and would double-count.
+        keys.erase(std::remove_if(keys.begin(), keys.end(), [](const std::string &k) {
+                       return k == "inherits" || k == "compatible_printers" || k == "compatible_prints"
+                           || k == "compatible_printers_condition" || k == "compatible_prints_condition"
+                           || k == "print_settings_id" || k == "filament_settings_id" || k == "printer_settings_id";
+                   }),
+                   keys.end());
+        BOOST_LOG_TRIVIAL(info) << boost::format("CLI: %1% overrides vs parent '%2%'")%keys.size()%parent_name;
+        return Slic3r::escape_strings_cstyle(keys);
+    };
+
     auto load_config_file = [&resolve_preset](const std::string& file, DynamicPrintConfig& config, std::string& config_type,
                                 std::string& config_name, std::string& filament_id, std::string& config_from) {
         if (! boost::filesystem::exists(file)) {
@@ -2937,8 +2982,10 @@ int CLI::run(int argc, char **argv)
             }
         }
         else {
-            //todo: support user machine preset's different settings
-            different_settings[filament_count+1] = "";
+            //ORCA: was a //todo — compute the user's overrides instead of writing an empty column.
+            different_settings[filament_count+1] = new_printer_config_is_system
+                ? std::string()
+                : cli_different_settings(load_machine_config, new_printer_system_name, Preset::TYPE_PRINTER);
             if (new_printer_config_is_system)
                 inherits_group[filament_count+1] = "";
             else
@@ -3080,8 +3127,14 @@ int CLI::run(int argc, char **argv)
             print_compatible_printers = std::move(current_print_compatible_printers);
         }
         else {
-            //todo: support system process preset
-            different_settings[0] = "";
+            //ORCA: was a //todo. Prefer a value the loaded JSON already carried, otherwise
+            //      compute the overrides against the system parent.
+            if (!different_process_setting.empty())
+                different_settings[0] = different_process_setting;
+            else
+                different_settings[0] = new_process_config_is_system
+                    ? std::string()
+                    : cli_different_settings(load_process_config, new_process_system_name, Preset::TYPE_PRINT);
             if (new_process_config_is_system)
                 inherits_group[0] = "";
             else
@@ -3279,8 +3332,8 @@ int CLI::run(int argc, char **argv)
                 opt_filament_settings->set_at(filament_name_setting, filament_index-1, 0);
                 config.erase("filament_settings_id");
 
-                //todo: update different settings of filaments
-                different_settings[filament_index] = "";
+                //ORCA: was a //todo — same treatment as process/machine above.
+                different_settings[filament_index] = cli_different_settings(config, load_filaments_inherit[index], Preset::TYPE_FILAMENT);
                 inherits_group[filament_index] = load_filaments_inherit[index];
             }
             else {


### PR DESCRIPTION
# Description

A 3MF exported by the CLI does not record which settings the user actually overrode. `CLI::run` writes an empty `different_settings_to_system` column at three sites, each marked `//todo`:

```cpp
//todo: support user machine preset's different settings
different_settings[filament_count+1] = "";
//todo: support system process preset
different_settings[0] = "";
//todo: update different settings of filaments
different_settings[filament_index] = "";
```

`inherits_group` is filled in correctly alongside them, so the project records *which* system preset it descends from but not *what the user changed*. Re-opening such a project in the GUI then shows spurious "unsaved changes", and accepting that dialog can revert inherited process / filament / machine values to system defaults.

The column could not be filled before, because the CLI had no resolved view of the parent preset to diff against. **#15438 changed that**: it builds a `PresetBundle` for inherits resolution, so the parent can now be looked up by name and compared with the resolved leaf.

# Fix

A small helper placed next to the existing resolution lambdas looks the parent up in that same bundle and returns `config.diff(parent->config)`, escaped for the column. It adds no extra loading — the bundle is the one inherits resolution already built — and returns `""` whenever the bundle or the parent is unavailable, which is exactly the previous behaviour.

Preset metadata is filtered out of the diff: `inherits`, the three `*_settings_id` keys, and `compatible_printers` / `compatible_prints` plus their `_condition` variants, which have their own tracking columns (`inherits_group`, per-slot lists) and would otherwise be double-counted.

A value the loaded JSON already carried still wins for the process slot, so presets saved with their own `different_settings_to_system` behave exactly as before. The computed value only fills the gap where that field is absent — which is the case for every user preset in my datadir (0 of 47 carry it). System presets keep an empty column: there are no user overrides to record.

# Verification

Built against `58bf267fd`, and compared with a control build of **the same commit** without the patch, so the only variable is this change.

Exported 3MF, `different_settings_to_system` per slot:

| slot | control | with fix |
|---|---|---|
| process | 0 keys | **3** |
| filament | 0 keys | **13** |
| machine | 0 keys | **31** |

`inherits_group` was already correct in both.

**Emitted g-code is byte-identical between control and patched build except for the `different_settings_to_system` line itself.** The change is metadata-only and does not affect slicing:

```
control:  ; different_settings_to_system = ;;
patched:  ; different_settings_to_system = "resolution;small_perimeter_speed;…";"filament_density;…";"bed_exclude_area;…"
```

I also checked the recorded keys are the *right* keys, not merely non-empty. Every key recorded is a genuine override (no false positives). Keys that are deliberately **not** recorded fall into two groups, both correct:

- **Not owned by that preset type** — e.g. `notes` is a print option and `pressure_advance` a filament option, so a *machine* preset does not carry them and there is nothing to diff.
- **Owned, but equal after resolution** — e.g. a leaf `machine_max_jerk_e: ["10"]` resolves to the parent's `10,10` stride-2 (normal,silent) pair, so it is genuinely not a difference.

# Scope

1 file, `src/OrcaSlicer.cpp`. No public API change, no profile change, no GUI change.

Follow-up to #13731, which bundled an earlier version of this together with two other fixes and has been closed. Its inheritance part was superseded by #15438; its compatibility part is #15449. This is the remaining piece, reimplemented against the resolution shape that actually landed rather than extracted from that PR — the old version consumed `override_keys` produced by its own resolver, which no longer exists.
