### PR TITLE
build: clear 3 warnings - lambda captures that are not required

### DIFF
--- a/src/OrcaSlicer.cpp
+++ b/src/OrcaSlicer.cpp
@@ -1975,7 +1975,7 @@ int CLI::run(int argc, char **argv)
     }
 
     std::unique_ptr<PresetBundle> cli_preset_bundle;
-    auto ensure_cli_preset_bundle = [&cli_preset_bundle, config_substitution_rule](std::string &error) -> PresetBundle * {
+    auto ensure_cli_preset_bundle = [&cli_preset_bundle](std::string &error) -> PresetBundle * {
         if (cli_preset_bundle)
             return cli_preset_bundle.get();
         try {
@@ -2002,7 +2002,7 @@ int CLI::run(int argc, char **argv)
         }
     };
 
-    auto resolve_preset = [&ensure_cli_preset_bundle, config_substitution_rule](const std::string &file, DynamicPrintConfig &config,
+    auto resolve_preset = [&ensure_cli_preset_bundle](const std::string &file, DynamicPrintConfig &config,
                                                                                std::string &config_type, const std::string &config_from,
                                                                                bool probe_type, std::string &error) {
         const auto *inherits = config.option<ConfigOptionString>(BBL_JSON_KEY_INHERITS);
@@ -2046,7 +2046,7 @@ int CLI::run(int argc, char **argv)
                                              error, allow_source_manifest);
     };
 
-    auto load_config_file = [config_substitution_rule, &resolve_preset](const std::string& file, DynamicPrintConfig& config, std::string& config_type,
+    auto load_config_file = [&resolve_preset](const std::string& file, DynamicPrintConfig& config, std::string& config_type,
                                 std::string& config_name, std::string& filament_id, std::string& config_from) {
         if (! boost::filesystem::exists(file)) {
             boost::nowide::cerr << __FUNCTION__<< ": can not find setting file: " << file << std::endl;


### PR DESCRIPTION
# Description

Three lambdas in `src/OrcaSlicer.cpp` capture `config_substitution_rule` explicitly. It is a `const` enum with a constant initializer, so a lambda can read it without capturing it, which is what `-Wunused-lambda-capture` reports. All three still read the value and are otherwise unchanged.

This one is a regression rather than an old site. #15417 took the category to zero and merged on 2026-09-02. These three arrived on 2026-09-08 in bcb4f17d9a, "fix(cli): resolve inherited presets through vendor manifests" (#15438).

# Screenshots/Recordings/Graphs

None.

## Tests

None. Dropping a capture the compiler says is not required cannot change what the lambda reads.

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
