### PR TITLE
build: clear 2 warnings - sites GCC reports and Clang does not

### DIFF
--- a/src/libslic3r/Fill/FillRectilinear.cpp
+++ b/src/libslic3r/Fill/FillRectilinear.cpp
@@ -3090,10 +3090,11 @@ bool FillRectilinear::fill_surface_trapezoidal(
     case 0: // Grid / Trapezoidal
     {
         // Generate a non-crossing trapezoidal pattern to avoid overextrusion at intersections when `multiline > 1`.
-        //         P2--P3
-        //        /      \
-        //  P0_P1/        \P4_
-        //
+        /*
+         *         P2--P3
+         *        /      \
+         *  P0_P1/        \P4_
+         */
         // P0xP1x=P4xP0x=d1/2
         // P2xP3x=d1
         // P1yP2y=P2yP3y=d2
@@ -3171,10 +3172,12 @@ bool FillRectilinear::fill_surface_trapezoidal(
     case 1: // Triangular
     {
         // Generate a non-crossing trapezoidal pattern with a base line below.
-        //      P1-P2
-        //     /     \
-        //  P0/       \P3_P4
-        //  ----------------
+        /*
+         *      P1-P2
+         *     /     \
+         *  P0/       \P3_P4
+         *  ----------------
+         */
         // P1xP2x=P3xP4x=d2
         // P0yP1y=P2yP3y=h-2d1
         //

--- a/src/libslic3r/ObjectID.hpp
+++ b/src/libslic3r/ObjectID.hpp
@@ -170,6 +170,10 @@ public:
         this->m_check_sum      = rhs.check_sum();
         this->m_connectors_cnt = rhs.connectors_cnt();
     }
+    // A user-declared copy assignment or destructor deprecates the implicitly generated
+    // copy constructor, and this class has both, so declare it rather than rely on it.
+    CutObjectBase(const CutObjectBase &) = default;
+
     CutObjectBase &operator=(const CutObjectBase &other)
     {
         this->copy(other);


### PR DESCRIPTION
# Description

Two sites in our own code that GCC reports and Clang does not. The #15374 inventory is a clang-cl build and CI compiles with clang on all three platforms, so nothing has ever looked at these.

`FillRectilinear.cpp` draws two trapezoid diagrams whose lines end in a backslash, which continues a `//` comment onto the next line. GCC calls that a multi-line comment. They are block comments now, where the rule does not apply, and the drawings are unchanged.

`CutObjectBase` has a user-provided `operator=` and a virtual destructor, either of which deprecates its implicitly generated copy constructor, and `bbs_3mf.cpp` copies the type through `CutObjectInfo`. The copy constructor is now declared and defaulted. Move operations were already suppressed by the user-provided `operator=`, so nothing changes there.

# Screenshots/Recordings/Graphs

None.

## Tests

None, but verified against GCC rather than assumed: both translation units fail on `-Werror=comment` and `-Werror=deprecated-copy` before the change and compile clean after.

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
