### PR TITLE
CLI: default curr_bed_type from the printer, as the GUI does

### DIFF
--- a/src/OrcaSlicer.cpp
+++ b/src/OrcaSlicer.cpp
@@ -3047,6 +3047,43 @@ int CLI::run(int argc, char **argv)
             flush_and_exit(ret);
         }
     }
+    //ORCA: seed curr_bed_type from the printer, the way the GUI already does.
+    //
+    //      PresetBundle::load_presets() sets project_config's curr_bed_type from
+    //      Preset::get_default_bed_type(), which reads the printer's `default_bed_type`
+    //      and otherwise falls back by printer model (finally btPEI). The CLI never did,
+    //      so every CLI slice used the schema default -- Cool Plate -- no matter which
+    //      printer was selected, silently picking that plate's bed temperature. 18 bundled
+    //      machine profiles declare `default_bed_type` (12 with a usable value); every
+    //      other printer, Bambu included, relies on get_default_bed_type()'s model-id
+    //      fallback. The CLI honoured neither, so it diverged from the GUI for all of them.
+    //
+    //      Applied only when a printer came from --load-settings, the user did not pass
+    //      --curr-bed-type, and no project supplied one (an empty current_printer_name
+    //      means no 3MF was loaded). An explicit choice therefore always wins.
+    if (!new_printer_name.empty() && current_printer_name.empty() && !m_config.has("curr_bed_type")) {
+        std::string   bundle_error;
+        PresetBundle *bundle = ensure_cli_preset_bundle(bundle_error);
+        if (bundle == nullptr) {
+            BOOST_LOG_TRIVIAL(warning) << "CLI: no preset bundle for curr_bed_type default: " << bundle_error;
+        } else {
+            Preset *printer_preset = bundle->printers.find_preset2(new_printer_name, true);
+            Preset  shell(Preset::TYPE_PRINTER, new_printer_name);
+            if (printer_preset == nullptr) {
+                //ORCA: preset not in the bundle (e.g. loaded from an arbitrary path) --
+                //      a shell over the resolved config still exposes default_bed_type.
+                shell.config   = load_machine_config;
+                printer_preset = &shell;
+            }
+            BedType bed_type = printer_preset->get_default_bed_type(bundle);
+            if (bed_type > btDefault && bed_type < btCount) {
+                m_print_config.set_key_value("curr_bed_type", new ConfigOptionEnum<BedType>(bed_type));
+                BOOST_LOG_TRIVIAL(info) << boost::format("CLI: curr_bed_type defaulted from printer '%1%' to %2%")
+                                               % new_printer_name % int(bed_type);
+            }
+        }
+    }
+
     if (m_print_config.option<ConfigOptionFloats>("nozzle_diameter")) {
         new_extruder_count = m_print_config.option<ConfigOptionFloats>("nozzle_diameter")->values.size();
         new_is_multi_extruder = new_extruder_count > 1;


### PR DESCRIPTION
# Description

CLI slicing uses the wrong bed type, and therefore the wrong bed temperature, for every printer.

The GUI derives it from the printer. `PresetBundle::load_presets()` calls `Preset::get_default_bed_type()`, which reads the printer preset's `default_bed_type`, otherwise falls back by printer model id, and finally to `btPEI`, then seeds `project_config`'s `curr_bed_type` with the result.

`CLI::run` never does this. With no project loaded there is nothing to set `curr_bed_type`, so it keeps the schema default — **Cool Plate** — regardless of which printer was selected, and slicing then picks that plate's temperatures.

Measured on current `main`, against a control build of the same commit:

| printer | control | with this PR |
|---|---|---|
| Qidi X-Plus 5 0.4 nozzle | `Cool Plate`, first layer bed **45** | `Textured PEI Plate`, first layer bed **60** |
| Bambu Lab X1 Carbon 0.4 nozzle | `Cool Plate`, first layer bed **35** | `High Temp Plate`, first layer bed **55** |

A 15–20 °C error on the first layer, silently, for anyone slicing from the CLI.

Two groups are affected, for different reasons:

- **Printers that declare it.** 18 bundled `"type": "machine"` presets set `default_bed_type` — Flashforge 6, OpenEYE 5, WonderMaker 3, Elegoo 2, Qidi 1, Snapmaker 1. Twelve carry a usable value (the six Flashforge ones are empty strings, which `get_default_bed_type()` skips); seven of those say `Textured PEI Plate`. `default_bed_type` is in `s_Preset_printer_options`, so it does reach the preset config — the CLI simply never read it. Qidi above is this case.
- **Everything else, including all Bambu models**, which declare nothing on the preset and rely on `get_default_bed_type()`'s model-id fallback (`BL-P001`/`BL-P002`/`C13` → `btPC`, `C11` → `btPEI`, otherwise `btPEI`). The CLI ignored that too. The X1 Carbon above is this case: it lands on `btPEI` = High Temp Plate, not Cool Plate.

# Fix

Seed `curr_bed_type` from the printer, using the same helper the GUI uses, when all of:

- a printer came from `--load-settings`,
- the user did not pass `--curr-bed-type`, and
- no project supplied one — an empty `current_printer_name` means no 3MF was loaded.

So an explicit `--curr-bed-type` always wins, and a project's own choice is never overridden.

The printer preset is taken from the `PresetBundle` that inherits resolution already builds (#15438), so this adds no loading. If the preset is not in the bundle — loaded from an arbitrary path — a lightweight `Preset` shell over the resolved machine config still exposes `default_bed_type`, and `get_default_bed_type()`'s own fallbacks apply from there. If the bundle is unavailable it logs and leaves the value alone, i.e. the previous behaviour.

# Verification

Built against `58bf267fd` and compared with a control build of **the same commit**, so the only variable is this change. Both code paths exercised with bundled profiles in a scratch datadir:

- **Declared value** — Qidi X-Plus 5, which sets `default_bed_type: "Textured PEI Plate"`.
- **Model fallback** — Bambu Lab X1 Carbon, which declares nothing and resolves to `btPEI`.

Results in the table above. An explicit `--curr-bed-type` still overrides in both cases, and passing it produces the same output as before this change.

# Scope

1 file, `src/OrcaSlicer.cpp`, +36/-0. No public API change, no profile change, no GUI change.

Note the option is spelled `--curr-bed-type`; `--curr_bed_type` is rejected as invalid, which is easy to trip over when working around this from scripts.
