### PR TITLE
build: clear 3 warnings - a precedence bug, an arm64-only pragma, and a CLI error label

### DIFF
--- a/src/OrcaSlicer.cpp
+++ b/src/OrcaSlicer.cpp
@@ -1925,7 +1925,7 @@ int CLI::run(int argc, char **argv)
             }
         }
         catch (std::exception& e) {
-            boost::nowide::cerr << construct_assemble_list << ": " << e.what() << std::endl;
+            boost::nowide::cerr << "construct_assemble_list: " << e.what() << std::endl;
             record_exit_reson(outfile_dir, CLI_DATA_FILE_ERROR, 0, cli_errors[CLI_DATA_FILE_ERROR], sliced_info);
             flush_and_exit(CLI_DATA_FILE_ERROR);
         }

--- a/src/libslic3r/Algorithm/LineSplit.hpp
+++ b/src/libslic3r/Algorithm/LineSplit.hpp
@@ -49,7 +49,7 @@ SplittedLine split_line(const PathType& path, const ExPolygons& clip, bool close
 
     // Convert the input path into an open ZPath
     ClipperZUtils::ZPath p;
-    p.reserve(path.size() + closed ? 1 : 0);
+    p.reserve(path.size() + (closed ? 1 : 0));
     ClipperLib_Z::cInt z = 0;
     for (const auto& point : path) {
         p.emplace_back(point.x(), point.y(), z);

--- a/src/libslic3r/Int128.hpp
+++ b/src/libslic3r/Int128.hpp
@@ -57,7 +57,7 @@
 	#define HAS_INTRINSIC_128_TYPE
 #endif
 
-#if defined(_MSC_VER) && defined(_WIN64)
+#if defined(_MSC_VER) && defined(_M_X64)
 	#include <intrin.h>
 	#pragma intrinsic(_mul128)
 #endif


### PR DESCRIPTION
# Description

Three sites clang-cl on Windows x64 does not report, so neither the #15374 inventory nor any CI job has flagged them. Found by promoting every warning to an error across the matrix.

`LineSplit.hpp` reserved with `path.size() + closed ? 1 : 0`. `+` binds tighter than `?:`, so that parses as `(path.size() + closed) ? 1 : 0`, and the function returns early on an empty path, so the reserve was always 1 and the vector reallocated its way up instead. Clang reports it on Linux, macOS and Flatpak as `-Wparentheses`.

`Int128.hpp` declared `#pragma intrinsic(_mul128)` under `_WIN64`, which is true on Windows arm64 where that x64 intrinsic does not exist. #14381 already moved the call site to `_M_X64` with a comment saying ARM64 has no `_mul128`, so the pragma now uses the same guard. `-Wignored-pragma-intrinsic`, arm64 only.

`OrcaSlicer.cpp` streamed `construct_assemble_list`, a function, to `cerr`, so the CLI prints `1: <message>` when that catch block fires. This line was already fixed in #5963 and came back when that PR was reverted wholesale two weeks later for an auto-orientation regression elsewhere in its 184 files. Restored exactly as it was merged then. `-Wpointer-bool-conversion`.

# Screenshots/Recordings/Graphs

None.

## Tests

None. The reserve now matches the exact final size, and no generated code changes for the other two. x64 keeps the intrinsic, arm64 was already on the portable path, and the CLI label only differs inside a catch block that needs a malformed assemble plate file to reach.

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
