### PR TITLE
fix: preserve custom LAN printer names

### DIFF
--- a/src/libslic3r/AppConfig.cpp
+++ b/src/libslic3r/AppConfig.cpp
@@ -852,6 +852,9 @@ std::string AppConfig::load()
                     local_machine.dev_id = m.key();
                     if (p.contains("dev_name"))
                         local_machine.dev_name = p["dev_name"].get<std::string>();
+                    // Older configs stored user-entered and discovered names in the same field.
+                    // Preserve that name on upgrade; an explicit empty local_name follows discovery.
+                    local_machine.local_name = p.value("local_name", local_machine.dev_name);
                     if (p.contains("dev_ip"))
                         local_machine.dev_ip = p["dev_ip"].get<std::string>();
                     if (p.contains("printer_type"))
@@ -1070,6 +1073,7 @@ void AppConfig::save()
     for (const auto& local_machine : m_local_machines) {
         json m_json;
         m_json["dev_name"]         = local_machine.second.dev_name;
+        m_json["local_name"]       = local_machine.second.local_name;
         m_json["dev_ip"]           = local_machine.second.dev_ip;
         m_json["printer_type"]     = local_machine.second.printer_type;
         m_json["printer_agent_id"] = local_machine.second.printer_agent_id;

--- a/src/libslic3r/AppConfig.hpp
+++ b/src/libslic3r/AppConfig.hpp
@@ -63,6 +63,7 @@ namespace Slic3r {
 struct BBLocalMachine
 {
     std::string dev_name;
+    std::string local_name;
     std::string dev_ip;
     std::string dev_id; /* serial number */
     std::string printer_type; /* model_id */
@@ -77,8 +78,8 @@ struct BBLocalMachine
 
     bool operator==(const BBLocalMachine& other) const
     {
-        return dev_name == other.dev_name && dev_ip == other.dev_ip && dev_id == other.dev_id && printer_type == other.printer_type &&
-               printer_agent_id == other.printer_agent_id && access_code == other.access_code;
+        return dev_name == other.dev_name && local_name == other.local_name && dev_ip == other.dev_ip && dev_id == other.dev_id &&
+               printer_type == other.printer_type && printer_agent_id == other.printer_agent_id && access_code == other.access_code;
     }
     bool operator!=(const BBLocalMachine& other) const { return !operator==(other); }
 };

--- a/src/slic3r/GUI/DeviceCore/DevManager.cpp
+++ b/src/slic3r/GUI/DeviceCore/DevManager.cpp
@@ -41,6 +41,17 @@ namespace {
         }
         return "";
     }
+
+    std::string get_local_name_from_config(Slic3r::AppConfig* config, const std::string& dev_id, const std::string& agent_id)
+    {
+        const auto& machines = config->get_local_machines();
+        auto        it       = machines.find(dev_id);
+        if (it != machines.end() &&
+            (it->second.printer_agent_id == agent_id ||
+             (it->second.printer_agent_id.empty() && agent_id == Slic3r::BBL_PRINTER_AGENT_ID)))
+            return it->second.local_name;
+        return "";
+    }
 }
 
 namespace Slic3r
@@ -73,6 +84,7 @@ namespace Slic3r
             obj->printer_type        = m.printer_type;
             obj->printer_agent_id    = m.printer_agent_id;
             obj->dev_connection_type = "lan";
+            obj->set_local_name(m.local_name);
             obj->bind_state          = "free";
             obj->bind_sec_link       = "secure";
             obj->m_is_online         = true;
@@ -95,7 +107,8 @@ namespace Slic3r
                 if (m.has_access_right()) {
                     BBLocalMachine local_machine;
                     local_machine.dev_id           = m.get_dev_id();
-                    local_machine.dev_name         = m.get_dev_name();
+                    local_machine.dev_name         = m.get_reported_name();
+                    local_machine.local_name       = m.get_local_name();
                     local_machine.dev_ip           = m.get_dev_ip();
                     local_machine.printer_type     = m.printer_type;
                     local_machine.printer_agent_id = m.printer_agent_id;
@@ -379,6 +392,8 @@ namespace Slic3r
                 AppConfig* config = Slic3r::GUI::wxGetApp().app_config;
                 if (config) {
                     obj->set_access_code(get_access_code_with_legacy_fallback(config, dev_id, obj->printer_agent_id), false);
+                    // Rediscovery can recreate an object after switching printer agents.
+                    obj->set_local_name(get_local_name_from_config(config, dev_id, obj->printer_agent_id));
                 }
                 localMachineList.insert(std::make_pair(dev_id, obj));
 
@@ -408,8 +423,12 @@ namespace Slic3r
         } else {
             obj = new MachineObject(this, m_agent, machine.dev_name, machine.dev_id, machine.dev_ip);
             obj->printer_agent_id = get_current_printer_agent_id();
+            if (AppConfig* config = GUI::wxGetApp().app_config)
+                obj->set_local_name(get_local_name_from_config(config, machine.dev_id, obj->printer_agent_id));
             localMachineList.insert(std::make_pair(machine.dev_id, obj));
         }
+        if (!machine.local_name.empty())
+            obj->set_local_name(machine.local_name);
         if (machine.printer_type.empty())
             obj->printer_type = _parse_printer_type("C11");
         else
@@ -793,12 +812,19 @@ namespace Slic3r
         return "";
     }
 
-    void DeviceManager::modify_device_name(std::string dev_id, std::string dev_name, const std::string& provider)
+    void DeviceManager::modify_device_name(MachineObject& machine, std::string dev_name, const std::string& provider)
     {
         BOOST_LOG_TRIVIAL(trace) << "modify_device_name";
+        if (machine.is_lan_mode_printer()) {
+            if (machine.has_access_right()) {
+                machine.set_local_name(dev_name);
+                update_local_machine(machine);
+            }
+            return;
+        }
         if (m_agent)
         {
-            int result = m_agent->modify_printer_name(dev_id, dev_name, provider);
+            int result = m_agent->modify_printer_name(machine.get_dev_id(), dev_name, provider);
             if (result == 0)
             {
                 update_user_machine_list_info(provider);

--- a/src/slic3r/GUI/DeviceCore/DevManager.h
+++ b/src/slic3r/GUI/DeviceCore/DevManager.h
@@ -95,7 +95,7 @@ public:
     MachineObject* get_my_machine(std::string dev_id);
     std::map<std::string, MachineObject*> get_my_machine_list(const std::string& agent_id = "");
     std::map<std::string, MachineObject*> get_my_cloud_machine_list(const std::string& agent_id = "");
-    void modify_device_name(std::string dev_id, std::string dev_name, const std::string& provider);
+    void modify_device_name(MachineObject& machine, std::string dev_name, const std::string& provider);
 
     // id of the currently live IPrinterAgent (IPrinterAgent::get_agent_info().id), or empty if
     // m_agent has no printer agent set yet. Pass to get_my_machine_list()/get_my_cloud_machine_list()

--- a/src/slic3r/GUI/DeviceManager.hpp
+++ b/src/slic3r/GUI/DeviceManager.hpp
@@ -111,6 +111,7 @@ private:
     /* properties */
     std::string dev_id;
     std::string dev_name;
+    std::string local_name;
     std::string dev_ip;
     std::string access_code;
 
@@ -190,8 +191,12 @@ public:
     static inline int m_sequence_id = START_SEQ_ID;
 
     /* properties */
-    std::string get_dev_name() const { return dev_name; }
+    // Keep LAN aliases separate from the name refreshed by discovery.
+    std::string get_dev_name() const { return is_lan_mode_printer() && !local_name.empty() ? local_name : dev_name; }
     void set_dev_name(std::string val) { dev_name = val; }
+    std::string get_reported_name() const { return dev_name; }
+    std::string get_local_name() const { return local_name; }
+    void set_local_name(std::string val) { local_name = val; }
 
     std::string get_dev_ip() const { return dev_ip; }
     void set_dev_ip(std::string ip) { dev_ip = ip;  }

--- a/src/slic3r/GUI/ReleaseNote.cpp
+++ b/src/slic3r/GUI/ReleaseNote.cpp
@@ -1926,6 +1926,7 @@ void InputIpAddressDialog::workerThreadFunc(std::string str_ip, std::string str_
     post_update_test_msg(w, _L("connecting..."), true);
 
     detectResult detectData;
+    std::string local_name;
     auto result = -1;
     if (current_input_index == 0) {
 
@@ -1939,6 +1940,7 @@ void InputIpAddressDialog::workerThreadFunc(std::string str_ip, std::string str_
         result = 0;
         detectData.model_id = model_id;
         detectData.dev_name = name;
+        local_name = name;
         detectData.dev_id = sn;
         detectData.connect_type = "lan";
         detectData.bind_state   = "free";
@@ -1976,10 +1978,11 @@ void InputIpAddressDialog::workerThreadFunc(std::string str_ip, std::string str_
     }
     if (w.expired()) return;
 
-    CallAfter([this, detectData, str_ip, str_access_code, w]() {
+    CallAfter([this, detectData, local_name, str_ip, str_access_code, w]() {
         DeviceManager* dev = wxGetApp().getDeviceManager();
         BBLocalMachine machine;
         machine.dev_name = detectData.dev_name;
+        machine.local_name = local_name;
         machine.dev_ip = str_ip;
         machine.dev_id = detectData.dev_id;
         machine.printer_type = detectData.model_id;

--- a/src/slic3r/GUI/SelectMachinePop.cpp
+++ b/src/slic3r/GUI/SelectMachinePop.cpp
@@ -683,6 +683,7 @@ void SelectMachinePopup::update_user_devices()
         }
         i++;
         op->update_machine_info(mobj, true);
+        op->show_edit_printer_name(false);
         //set in lan
         if (mobj->is_lan_mode_printer()) {
             if (!mobj->is_online()) {
@@ -690,8 +691,8 @@ void SelectMachinePopup::update_user_devices()
             }
             else {
                 op->show_printer_bind(false, PrinterBindState::NONE);
-                op->show_edit_printer_name(false);
                 if (mobj->has_access_right() && mobj->is_avaliable()) {
+                    op->show_edit_printer_name(true);
                     op->set_printer_state(PrinterState::IN_LAN);
                     op->show_printer_bind(true, PrinterBindState::ALLOW_UNBIND);
                     op->SetToolTip(_L("Online"));
@@ -988,7 +989,7 @@ void EditDevNameDialog::on_edit_name(wxCommandEvent &e)
             auto           utf8_str = new_dev_name.ToUTF8();
             auto           name     = std::string(utf8_str.data(), utf8_str.length());
             if (m_info)
-                dev->modify_device_name(m_info->get_dev_id(), name, wxGetApp().get_printer_cloud_provider());
+                dev->modify_device_name(*m_info, name, wxGetApp().get_printer_cloud_provider());
         }
         DPIDialog::EndModal(wxID_CLOSE);
     }

--- a/tests/libslic3r/test_appconfig.cpp
+++ b/tests/libslic3r/test_appconfig.cpp
@@ -1,8 +1,25 @@
 #include <catch2/catch_all.hpp>
 
 #include "libslic3r/AppConfig.hpp"
+#include "libslic3r/Thread.hpp"
+#include "test_utils.hpp"
+
+#include <boost/nowide/fstream.hpp>
+#include <nlohmann/json.hpp>
 
 using namespace Slic3r;
+
+namespace {
+
+void write_printer_config(AppConfig& config, const nlohmann::json& printer)
+{
+    boost::nowide::ofstream output(config.config_path());
+    REQUIRE(output.is_open());
+    output << nlohmann::json{{"local_machines", {{"test-printer", printer}}}} << '\n';
+    REQUIRE(output.good());
+}
+
+} // namespace
 
 TEST_CASE("AppConfig network version helpers", "[AppConfig]") {
     AppConfig config;
@@ -42,4 +59,91 @@ TEST_CASE("AppConfig network version helpers", "[AppConfig]") {
         REQUIRE(skipped.size() == 1);
         REQUIRE(config.is_network_version_skipped("02.01.01.52"));
     }
+}
+
+TEST_CASE("Local printer aliases survive configuration reloads", "[AppConfig][Regression]")
+{
+    ScopedTemporaryDir directory;
+    ScopeGuard restore_directory([previous = data_dir()] { set_data_dir(previous); });
+    set_data_dir(directory.string());
+    save_main_thread_id();
+
+    const std::string alias = GENERATE("Workshop Printer", u8"Atelier \"\u00e9tage\"");
+    AppConfig config;
+    write_printer_config(config, {{"dev_name", "Discovered Printer"}, {"local_name", alias}});
+    REQUIRE(config.load().empty());
+
+    // Discovery can replace the reported name without changing the user's alias.
+    BBLocalMachine printer = config.get_local_machines().at("test-printer");
+    printer.dev_name = "Updated Discovery Name";
+    config.update_local_machine(printer);
+    config.save();
+
+    AppConfig reloaded;
+    REQUIRE(reloaded.load().empty());
+    CHECK(reloaded.get_local_machines().at("test-printer").dev_name == printer.dev_name);
+    reloaded.save();
+
+    boost::nowide::ifstream input(reloaded.config_path());
+    nlohmann::json saved;
+    input >> saved;
+    const auto& saved_printer = saved.at("local_machines").at("test-printer");
+    REQUIRE(saved_printer.contains("local_name"));
+    CHECK(saved_printer.at("local_name").get<std::string>() == alias);
+    CHECK(saved_printer.at("dev_name").get<std::string>() == printer.dev_name);
+}
+
+TEST_CASE("Legacy printer names migrate without filling explicit empty aliases", "[AppConfig][Regression]")
+{
+    ScopedTemporaryDir directory;
+    ScopeGuard restore_directory([previous = data_dir()] { set_data_dir(previous); });
+    set_data_dir(directory.string());
+    save_main_thread_id();
+
+    const bool legacy = GENERATE(true, false);
+    const std::string saved_name = "Saved Printer Name";
+    nlohmann::json printer = {{"dev_name", saved_name}};
+    if (!legacy)
+        printer["local_name"] = "";
+
+    AppConfig config;
+    write_printer_config(config, printer);
+    REQUIRE(config.load().empty());
+    config.save();
+
+    // Saving an empty alias must keep it distinct from a legacy missing field.
+    AppConfig reloaded;
+    REQUIRE(reloaded.load().empty());
+    reloaded.save();
+
+    boost::nowide::ifstream input(reloaded.config_path());
+    nlohmann::json saved;
+    input >> saved;
+    const auto& saved_printer = saved.at("local_machines").at("test-printer");
+    REQUIRE(saved_printer.contains("local_name"));
+    CHECK(saved_printer.at("local_name").get<std::string>() == (legacy ? saved_name : ""));
+}
+
+TEST_CASE("Changing only a printer alias marks its configuration dirty", "[AppConfig][Regression]")
+{
+    ScopedTemporaryDir directory;
+    ScopeGuard restore_directory([previous = data_dir()] { set_data_dir(previous); });
+    set_data_dir(directory.string());
+
+    AppConfig config;
+    write_printer_config(config, {{"dev_name", "Discovered Printer"}, {"local_name", "Original Alias"}});
+    REQUIRE(config.load().empty());
+    const BBLocalMachine original = config.get_local_machines().at("test-printer");
+    config.update_local_machine(original);
+    CHECK_FALSE(config.dirty());
+
+    AppConfig replacement;
+    write_printer_config(replacement, {{"dev_name", "Discovered Printer"}, {"local_name", "Updated Alias"}});
+    REQUIRE(replacement.load().empty());
+    const BBLocalMachine renamed = replacement.get_local_machines().at("test-printer");
+    CHECK(original != renamed);
+
+    config.update_local_machine(renamed);
+    CHECK(config.dirty());
+    CHECK(config.get_local_machines().at("test-printer") == renamed);
 }

--- a/tests/slic3rutils/CMakeLists.txt
+++ b/tests/slic3rutils/CMakeLists.txt
@@ -4,6 +4,7 @@ add_executable(${_TEST_NAME}_tests
     test_bambu_filament_ids.cpp
     test_creality_cfs_match.cpp
     test_dev_mapping.cpp
+    test_device_names.cpp
     test_filament_bitmap_utils.cpp
     test_network_versions.cpp
     test_action_source.cpp

--- a/tests/slic3rutils/test_device_names.cpp
+++ b/tests/slic3rutils/test_device_names.cpp
@@ -1,0 +1,64 @@
+// DeviceManager.hpp needs the same Windows and wx include order as the GUI
+// precompiled header; see test_dev_mapping.cpp.
+#ifdef WIN32
+    #ifndef WIN32_LEAN_AND_MEAN
+        #define WIN32_LEAN_AND_MEAN
+    #endif
+    #ifndef NOMINMAX
+        #define NOMINMAX
+    #endif
+    #include <Windows.h>
+#endif
+
+#include <catch2/catch_all.hpp>
+
+#include <wx/timer.h>
+
+#include "slic3r/GUI/DeviceManager.hpp"
+
+using namespace Slic3r;
+
+TEST_CASE("LAN printer aliases survive reported name changes", "[DeviceNames]")
+{
+    MachineObject printer(nullptr, nullptr, "Discovered Printer", "test-printer", "127.0.0.1");
+    printer.dev_connection_type = "lan";
+    printer.set_local_name("Workshop Printer");
+
+    for (const std::string reported_name : {"Updated Discovery Name", "Another Discovery Name"}) {
+        printer.set_dev_name(reported_name);
+        CHECK(printer.get_dev_name() == "Workshop Printer");
+        CHECK(printer.get_local_name() == "Workshop Printer");
+        CHECK(printer.get_reported_name() == reported_name);
+    }
+}
+
+TEST_CASE("LAN printers without aliases follow reported names", "[DeviceNames]")
+{
+    MachineObject printer(nullptr, nullptr, "Discovered Printer", "test-printer", "127.0.0.1");
+    printer.dev_connection_type = "lan";
+    CHECK(printer.get_local_name().empty());
+
+    printer.set_dev_name("Updated Discovery Name");
+    CHECK(printer.get_dev_name() == "Updated Discovery Name");
+
+    printer.set_local_name("Workshop Printer");
+    printer.set_local_name("");
+    CHECK(printer.get_dev_name() == "Updated Discovery Name");
+    CHECK(printer.get_local_name().empty());
+}
+
+TEST_CASE("Cloud printer names stay independent of LAN aliases", "[DeviceNames]")
+{
+    MachineObject printer(nullptr, nullptr, "Cloud Printer", "test-printer", "127.0.0.1");
+    printer.dev_connection_type = "cloud";
+    printer.set_local_name("Workshop Printer");
+    printer.set_dev_name("Renamed Cloud Printer");
+    CHECK(printer.get_dev_name() == "Renamed Cloud Printer");
+    CHECK(printer.get_reported_name() == "Renamed Cloud Printer");
+
+    printer.dev_connection_type = "lan";
+    CHECK(printer.get_dev_name() == "Workshop Printer");
+
+    printer.dev_connection_type = "cloud";
+    CHECK(printer.get_dev_name() == "Renamed Cloud Printer");
+}


### PR DESCRIPTION
# Description

LAN discovery overwrites names entered during manual binding, and paired LAN
printers have no rename control. Store a local alias separately from the
reported name, and enable the existing rename button and dialog for paired LAN
printers. This works without a cloud account, including for printers bound
after discovery.

Aliases persist across restarts, repeated discovery, and printer-agent
switches. Existing saved names are preserved on upgrade; printers with an
explicitly empty alias continue to follow the reported name. Cloud renaming
continues to use the existing provider API.

Related: #491, #3784.

