### PR TITLE
Remember Auto-Drop choice when splitting objects

### DIFF
--- a/src/libslic3r/AppConfig.hpp
+++ b/src/libslic3r/AppConfig.hpp
@@ -40,6 +40,7 @@ using namespace nlohmann;
 #define SETTING_OPENGL_PHONG_BASIC_PLATE_SHADOWS "opengl_phong_basic_plate_shadows"
 #define SETTING_OPENGL_PHONG_SSAO "opengl_phong_ssao"
 #define SETTING_OPENGL_PHONG_SMOOTH_NORMALS "opengl_phong_smooth_normals"
+#define SETTING_SPLIT_OBJECTS_AUTO_DROP_CHOICE "split_objects_auto_drop_choice"
 
 #define SETTING_PLUGIN_PAGES_VISIBLE_COUNT "plugin_pages_visible_count"
 #define PLUGIN_PAGES_VISIBLE_COUNT_MIN 1

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -10160,10 +10160,18 @@ void Plater::priv::split_object(int obj_idx, bool auto_drop /* = true */)
         };
         bool split_auto_drop = auto_drop;
         if (current_model_object->instances[0]->auto_drop && is_atleast_one_floating()) {
-            MessageDialog dlg(q, _L("Disable Auto-Drop to preserve Z positioning?\n"),
-                                  _L("Object with floating parts was detected"), wxICON_QUESTION | wxYES_NO);
+            const bool choice_saved      = wxGetApp().app_config->has(SETTING_SPLIT_OBJECTS_AUTO_DROP_CHOICE);
+            bool       disable_auto_drop = wxGetApp().app_config->get_bool(SETTING_SPLIT_OBJECTS_AUTO_DROP_CHOICE);
+            if (!choice_saved) {
+                MessageDialog dlg(q, _L("Disable Auto-Drop to preserve Z positioning?\n"),
+                                      _L("Object with floating parts was detected"), wxICON_QUESTION | wxYES_NO);
+                dlg.show_dsa_button();
+                disable_auto_drop = dlg.ShowModal() == wxID_YES;
+                if (dlg.get_checkbox_state())
+                    wxGetApp().app_config->set_bool(SETTING_SPLIT_OBJECTS_AUTO_DROP_CHOICE, disable_auto_drop);
+            }
 
-            if (dlg.ShowModal() == wxID_YES)
+            if (disable_auto_drop)
                 split_auto_drop = false;
         }
 

--- a/src/slic3r/GUI/Preferences.cpp
+++ b/src/slic3r/GUI/Preferences.cpp
@@ -1842,6 +1842,11 @@ void PreferencesDialog::create_items()
     });
     g_sizer->Add(item_restore_hide_pop_ups);
 
+    auto item_split_objects_auto_drop = create_item_button(_L("Split to objects Auto-Drop"), _L("Clear"), "", _L("Clear my choice for Auto-Drop after splitting an object."), []() {
+        wxGetApp().app_config->erase("app", SETTING_SPLIT_OBJECTS_AUTO_DROP_CHOICE);
+    });
+    g_sizer->Add(item_split_objects_auto_drop);
+
     g_sizer->AddSpacer(FromDIP(10));
     sizer_page->Add(g_sizer, 0, wxEXPAND);
 


### PR DESCRIPTION
# Description

When splitting an object into multiple objects, OrcaSlicer prompts whether Auto-Drop should be disabled if floating parts are detected. This PR adds a "Don't show again" option to that prompt and remembers the selected behavior for subsequent splits.

The remembered decision is stored as a boolean application setting. A new **Split to objects Auto-Drop** entry under **Preferences > Control > Clear my choice on...** allows the user to reset the choice and show the prompt again.

This change introduces no new dependencies or breaking configuration changes. Existing behavior is unchanged until the user selects "Don't show again."

# Screenshots/Recordings/Graphs

Not provided. The change adds the existing "Don't show again" checkbox style to the Auto-Drop prompt and a standard Clear action to Preferences.

## Tests

- Compiled `src/slic3r/GUI/Plater.cpp` using the generated RelWithDebInfo Visual Studio project: 0 warnings, 0 errors.
- Compiled `src/slic3r/GUI/Preferences.cpp` using the generated RelWithDebInfo Visual Studio project: 0 warnings, 0 errors.
- Ran `git diff --check` successfully.

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)