### PR TITLE
Fix undersized pre-slice prime tower footprint

### DIFF
--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -3913,8 +3913,10 @@ const WipeTowerData &Print::wipe_tower_data(size_t filaments_cnt) const
 
     if (! is_step_done(psWipeTower) && filaments_cnt !=0) {
         double wipe_volume  = m_config.prime_volume;
-        int filament_depth_count = m_config.nozzle_diameter.values.size() == 2 ? filaments_cnt : filaments_cnt - 1;
-        if (filaments_cnt == 1 && enable_timelapse_print()) filament_depth_count = 1;
+        // A layer may visit every filament and then return to the one it started with,
+        // so reserve one transition per filament. Using filaments_cnt - 1 for a
+        // single-nozzle printer underestimates the pre-slice tower footprint.
+        int filament_depth_count = filaments_cnt;
         double volume = wipe_volume * filament_depth_count;
         if (m_config.nozzle_diameter.values.size() == 2) volume += filament_change_volume * (int) (filaments_cnt / 2);
 

--- a/src/slic3r/GUI/PartPlate.cpp
+++ b/src/slic3r/GUI/PartPlate.cpp
@@ -2260,7 +2260,10 @@ Vec3d PartPlate::estimate_wipe_tower_size(const DynamicPrintConfig & config, con
         diameter = diameters.empty() ? diameter : *std::max_element(diameters.begin(), diameters.end());
         filament_change_volume = length * PI * diameter * diameter / 4.;
     }
-    double volume = wipe_volume * (extruder_count == 2 ? plate_extruder_size : (plate_extruder_size - 1));
+    // A layer may visit every filament and then return to its starting filament.
+    // Reserve that final transition as well so the pre-slice placement footprint
+    // cannot be smaller than the generated tower just because the printer has one nozzle.
+    double volume = wipe_volume * plate_extruder_size;
     if (extruder_count == 2) volume += filament_change_volume * (int) (plate_extruder_size / 2);
     if (use_rib_wall) {
         depth = std::sqrt(volume / layer_height * extra_spacing);

--- a/tests/fff_print/test_multifilament.cpp
+++ b/tests/fff_print/test_multifilament.cpp
@@ -5,6 +5,7 @@
 #include "test_helpers.hpp"
 
 #include <cctype>
+#include <cmath>
 #include <set>
 #include <string>
 
@@ -103,4 +104,31 @@ TEST_CASE("Multi-extruder slice stays in bounds with a short max_layer_height", 
     Print print;
     init_and_process_print({ cube(20) }, print, config);
     REQUIRE_FALSE(print.objects().front()->layers().empty());
+}
+
+TEST_CASE("Unsliced rib tower preview reserves the return filament change", "[MultiFilament][WipeTower]")
+{
+    constexpr double prime_volume = 45.;
+    constexpr double layer_height = 0.2;
+    constexpr double infill_gap   = 1.5;
+    constexpr double rib_width    = 8.;
+
+    DynamicPrintConfig config = multifilament_config(2, {
+        { "enable_prime_tower",          true },
+        { "prime_volume",                prime_volume },
+        { "prime_tower_infill_gap",      "150%" },
+        { "wipe_tower_wall_type",        "rib" },
+        { "wipe_tower_rib_width",        rib_width },
+        { "wipe_tower_extra_rib_length", 0 },
+        { "layer_height",                layer_height },
+    });
+
+    Print print;
+    Model model;
+    init_print({ cube(25.6) }, print, model, config);
+
+    // Two filaments can require two changes on a layer: 0 -> 1 -> 0.
+    const double expected_depth =
+        std::sqrt(2. * prime_volume / layer_height * infill_gap) + rib_width / std::sqrt(2.);
+    CHECK(print.wipe_tower_data(2).depth == Catch::Approx(expected_depth));
 }


### PR DESCRIPTION
# Description

Fixes #13979.

Before slicing, single-nozzle prime towers reserved only `filament_count - 1`
filament changes. A layer can visit every filament and then return to its
starting filament (for example, `0 -> 1 -> 0`), so the generated tower can
require `filament_count` changes. The undersized proxy allowed the tower to be
placed close enough to the bed edge that its sliced footprint went out of
bounds.

This change:

- reserves the possible return-to-start filament change in the pre-slice GUI estimate;
- keeps `Print::wipe_tower_data()`'s fallback estimate consistent with the GUI;
- adds a regression test for a two-filament, single-nozzle rib tower.

# Screenshots/Recordings/Graphs

The original reproduction and screenshot are in #13979.

## Tests

- `fff_print_tests.exe "Unsliced rib tower preview reserves the return filament change"`
- `fff_print_tests.exe "[MultiFilament]"` — 5 test cases, 22 assertions passed
- Release build of `libslic3r_gui.vcxproj`
