### PR TITLE
Added : Keep fan always off feature

### DIFF
--- a/src/libslic3r/GCode/CoolingBuffer.cpp
+++ b/src/libslic3r/GCode/CoolingBuffer.cpp
@@ -736,6 +736,23 @@ std::string CoolingBuffer::apply_layer_cooldown(
         &supp_interface_fan_control, &supp_interface_fan_speed,
         &ironing_fan_control, &ironing_fan_speed
     ](bool immediately_apply) {
+        bool is_always_off = false;
+        if (!m_config.fan_always_off.values.empty()) {
+            is_always_off = m_config.fan_always_off.get_at(m_current_extruder);
+        }
+
+        if (is_always_off) {
+            m_fan_speed         = 0;
+            m_current_fan_speed = 0;
+            if (immediately_apply)
+                new_gcode += GCodeWriter::set_fan(m_config.gcode_flavor, 0, part_cooling_fan_min_pwm);
+
+            overhang_fan_control        = false;
+            internal_bridge_fan_control = false;
+            supp_interface_fan_control  = false;
+            ironing_fan_control         = false;
+            return;
+        }
 #define EXTRUDER_CONFIG(OPT) m_config.OPT.get_at(m_current_extruder)
         float fan_min_speed = EXTRUDER_CONFIG(fan_min_speed);
         float fan_speed_new = EXTRUDER_CONFIG(reduce_fan_stop_start_freq) ? fan_min_speed : 0;

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -2139,7 +2139,7 @@ void PrintConfigDef::init_fff_params()
                      "This can be used to improve build plate adhesion.");
     def->sidetext = L("layers");
     def->min = 0;
-    def->max = 1000;
+    def->max = 10000;
     def->mode = comSimple;
     def->set_default_value(new ConfigOptionInts { 1 });
 
@@ -2757,6 +2757,11 @@ void PrintConfigDef::init_fff_params()
     def->label = L("Keep fan always on");
     def->tooltip = L("Enabling this setting means that part cooling fan will never stop entirely and will instead run at least at minimum speed to reduce the frequency of starting and stopping.");
     def->set_default_value(new ConfigOptionBools { false });
+
+    def          = this->add("fan_always_off", coBools);
+    def->label   = L("Keep fan always off");
+    def->tooltip = L("Force the cooling fan to stay at 0% for the entire print, ignoring all other cooling settings (including bridges and overhangs).");
+    def->set_default_value(new ConfigOptionBools{false});
 
     def = this->add("dont_slow_down_outer_wall", coBools);
     def->label = L("Don't slow down outer walls");
@@ -8266,6 +8271,7 @@ void PrintConfigDef::init_filament_option_keys()
         "filament_colour",
         "filament_diameter",
         "filament_retract_length_nc",
+        "fan_always_off",
         // "filament_seam_gap",
         "long_retractions_when_cut",
         "max_layer_height",
@@ -9347,7 +9353,8 @@ std::set<std::string> filament_options_with_variant = {
     "filament_long_retractions_when_cut",
     "filament_retraction_distances_when_cut",
     "long_retractions_when_ec",
-    "retraction_distances_when_ec",
+    "retraction_distances_when_ec", 
+    "fan_always_off",
     "nozzle_temperature_initial_layer",
     "nozzle_temperature",
     "filament_flush_volumetric_speed",

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -1789,6 +1789,7 @@ PRINT_CONFIG_CLASS_DERIVED_DEFINE(
     ((ConfigOptionPoints,             extruder_offset))
     ((ConfigOptionBools,              reduce_fan_stop_start_freq))
     ((ConfigOptionBools,              dont_slow_down_outer_wall))
+    ((ConfigOptionBools,              fan_always_off))
     ((ConfigOptionFloats,             fan_cooling_layer_time))
     ((ConfigOptionBools,              activate_air_filtration))
     ((ConfigOptionBools,              activate_air_filtration_during_print))

--- a/src/slic3r/GUI/GUI.cpp
+++ b/src/slic3r/GUI/GUI.cpp
@@ -208,10 +208,21 @@ void change_opt_value(DynamicPrintConfig& config, const t_config_option_key& opt
 		case coBool:
 			config.set_key_value(opt_key, new ConfigOptionBool(boost::any_cast<bool>(value)));
 			break;
-		case coBools:{
-            auto vec_new = std::make_unique<ConfigOptionBool>(boost::any_cast<unsigned char>(value) != 0);
-			config.option<ConfigOptionBools>(opt_key)->set_at(vec_new.get(), opt_index, 0);
-			break;}
+		case coBools: {
+            unsigned char val = 0;
+            if (value.type() == typeid(bool))
+                val = boost::any_cast<bool>(value) ? 1 : 0;
+            else
+                val = boost::any_cast<unsigned char>(value);
+
+            if (auto opt = config.option<ConfigOptionBools>(opt_key)) {
+                auto vec_new = std::make_unique<ConfigOptionBool>(val != 0);
+                opt->set_at(vec_new.get(), opt_index, 0);
+            } else {
+                config.set_key_value(opt_key, new ConfigOptionBools({val}));
+            }
+            break;
+        }
 		case coInt:
 			config.set_key_value(opt_key, new ConfigOptionInt(boost::any_cast<int>(value)));
 			break;

--- a/src/slic3r/GUI/OptionsGroup.cpp
+++ b/src/slic3r/GUI/OptionsGroup.cpp
@@ -59,29 +59,29 @@ const t_field& OptionsGroup::build_field(const t_config_option_key& id, const Co
         break;
     default:
         switch (opt.type) {
-            case coFloatOrPercent:
-            case coFloatsOrPercents:
-            case coFloat:
-            case coFloats:
-			case coPercent:
-			case coPercents:
-			case coString:
+        case coFloatOrPercent:
+        case coFloatsOrPercents:
+        case coFloat:
+        case coFloats:
+        case coPercent:
+        case coPercents:
+        case coString:
 			case coStrings:
                 m_fields.emplace(id, TextCtrl::Create<TextCtrl>(this->ctrl_parent(), opt, id));
                 break;
-			case coBool:
+        case coBool:
 			case coBools:
                 m_fields.emplace(id, CheckBox::Create<CheckBox>(this->ctrl_parent(), opt, id));
 				break;
-			case coInt:
+        case coInt:
 			case coInts:
                 m_fields.emplace(id, SpinCtrl::Create<SpinCtrl>(this->ctrl_parent(), opt, id));
 				break;
-            case coEnum:
+        case coEnum:
             case coEnums:
                 m_fields.emplace(id, Choice::Create<Choice>(this->ctrl_parent(), opt, id));
 				break;
-            case coPoint:
+        case coPoint:
             case coPoints:
                 m_fields.emplace(id, PointCtrl::Create<PointCtrl>(this->ctrl_parent(), opt, id));
 				break;
@@ -439,7 +439,7 @@ void OptionsGroup::activate_line(Line& line)
                                      _L_CONTEXT(option.label, "Layers") :
                                      _(option.label);
             label = new wxStaticText(this->ctrl_parent(), wxID_ANY, str_label + ": ", wxDefaultPosition, // wxDefaultSize);
-                                     wxSize(sublabel_width != -1 ? sublabel_width * wxGetApp().em_unit() : -1, -1), wxALIGN_RIGHT);
+                                                  wxSize(sublabel_width != -1 ? sublabel_width * wxGetApp().em_unit() : -1, -1), wxALIGN_RIGHT);
             label->SetBackgroundStyle(wxBG_STYLE_PAINT);
             label->SetFont(wxGetApp().normal_font());
             sizer_tmp->Add(label, 0, wxALIGN_CENTER_VERTICAL, 0);
@@ -642,7 +642,12 @@ void OptionsGroup::on_change_OG(const t_config_option_key& opt_id, const boost::
 Option ConfigOptionsGroup::get_option(const std::string& opt_key, int opt_index /*= -1*/)
 {
     if (!m_config->has(opt_key)) {
-        std::cerr << "No " << opt_key << " in ConfigOptionsGroup config.\n";
+        const ConfigOptionDef* def = m_config->def()->get(opt_key);
+        if (def && def->default_value) {
+            const_cast<DynamicPrintConfig*>(m_config)->option(opt_key, true)->set(def->default_value.get());
+        } else {
+            std::cerr << "No " << opt_key << " in ConfigOptionsGroup config.\n";
+        }
     }
 
     std::string opt_id = opt_index == -1 ? opt_key : opt_key + "#" + std::to_string(opt_index);
@@ -799,7 +804,7 @@ void ConfigOptionsGroup::back_to_config_value(const DynamicPrintConfig& config, 
         return;
     }
     else if (m_opt_map.find(opt_key) == m_opt_map.end() ||
-             // This option don't have corresponded field
+               // This option don't have corresponded field
              opt_key == "printable_area" || opt_key == "compatible_printers" || opt_key == "compatible_prints" || opt_key == "thumbnails" ||
              opt_key == "bed_custom_texture" || opt_key == "bed_custom_model") {
         value = get_config_value(config, opt_key);
@@ -1134,8 +1139,17 @@ boost::any ConfigOptionsGroup::get_config_value(const DynamicPrintConfig& config
         } else
             ret = from_u8(config.opt_string(opt_key, static_cast<unsigned int>(idx)));
         break;
-    case coBool: ret = config.opt_bool(opt_key); break;
-    case coBools: ret = config.opt_bool(opt_key, idx); break;
+    case coBool:
+        ret = config.opt_bool(opt_key);
+        break;
+    case coBools: {
+        const auto* opt_bools = config.option<ConfigOptionBools>(opt_key);
+        if (!opt_bools || idx >= opt_bools->values.size())
+            ret = false; // bool, not unsigned char
+        else
+            ret = (bool) opt_bools->values[idx]; // bool, not unsigned char
+        break;
+    }
     case coInt: ret = config.opt_int(opt_key); break;
     case coInts: ret = config.opt_int(opt_key, idx); break;
     case coEnum:

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -4284,178 +4284,178 @@ void TabFilament::build()
 
     auto page = add_options_page(L("Filament"), "custom-gcode_filament"); // ORCA: icon only visible on placeholders
         //BBS
-        auto optgroup = page->new_optgroup(L("Basic information"), L"param_information");
-        optgroup->append_single_option_line("filament_type", "material_basic_information#type"); // ORCA use same width with other elements
-        optgroup->append_single_option_line("filament_vendor", "material_basic_information#vendor");
-        optgroup->append_single_option_line("filament_soluble", "material_basic_information#soluble-material");
-        // BBS
-        optgroup->append_single_option_line("filament_is_support", "material_basic_information#support-material");
-        optgroup->append_single_option_line("filament_change_length", "material_basic_information#filament-ramming-length");
+    auto optgroup = page->new_optgroup(L("Basic information"), L"param_information");
+    optgroup->append_single_option_line("filament_type", "material_basic_information#type"); // ORCA use same width with other elements
+    optgroup->append_single_option_line("filament_vendor", "material_basic_information#vendor");
+    optgroup->append_single_option_line("filament_soluble", "material_basic_information#soluble-material");
+    // BBS
+    optgroup->append_single_option_line("filament_is_support", "material_basic_information#support-material");
+    optgroup->append_single_option_line("filament_change_length", "material_basic_information#filament-ramming-length");
 
         //optgroup->append_single_option_line("filament_colour");
-        optgroup->append_single_option_line("required_nozzle_HRC", "material_basic_information#required-nozzle-hrc");
-        optgroup->append_single_option_line("default_filament_colour", "material_basic_information#default-color");
-        optgroup->append_single_option_line("filament_diameter", "material_basic_information#diameter");
-        optgroup->append_single_option_line("filament_adhesiveness_category", "material_basic_information#adhesiveness-category");
+    optgroup->append_single_option_line("required_nozzle_HRC", "material_basic_information#required-nozzle-hrc");
+    optgroup->append_single_option_line("default_filament_colour", "material_basic_information#default-color");
+    optgroup->append_single_option_line("filament_diameter", "material_basic_information#diameter");
+    optgroup->append_single_option_line("filament_adhesiveness_category", "material_basic_information#adhesiveness-category");
 
-        optgroup->append_single_option_line("filament_density", "material_basic_information#density");
-        optgroup->append_single_option_line("filament_shrink", "material_basic_information#shrinkage-xy");
-        optgroup->append_single_option_line("filament_shrinkage_compensation_z", "material_basic_information#shrinkage-z");
-        optgroup->append_single_option_line("filament_cost", "material_basic_information#price");
+    optgroup->append_single_option_line("filament_density", "material_basic_information#density");
+    optgroup->append_single_option_line("filament_shrink", "material_basic_information#shrinkage-xy");
+    optgroup->append_single_option_line("filament_shrinkage_compensation_z", "material_basic_information#shrinkage-z");
+    optgroup->append_single_option_line("filament_cost", "material_basic_information#price");
         //BBS
-        optgroup->append_single_option_line("temperature_vitrification", "material_basic_information#softening-temperature");
-        optgroup->append_single_option_line("idle_temperature", "material_basic_information#idle-temperature");
+    optgroup->append_single_option_line("temperature_vitrification", "material_basic_information#softening-temperature");
+    optgroup->append_single_option_line("idle_temperature", "material_basic_information#idle-temperature");
         Line line = { L("Recommended nozzle temperature"), L("Recommended nozzle temperature range of this filament. 0 means not set") };
-        line.append_option(optgroup->get_option("nozzle_temperature_range_low"));
-        line.append_option(optgroup->get_option("nozzle_temperature_range_high"));
-        optgroup->append_line(line);
+    line.append_option(optgroup->get_option("nozzle_temperature_range_low"));
+    line.append_option(optgroup->get_option("nozzle_temperature_range_high"));
+    optgroup->append_line(line);
 
-        optgroup->m_on_change = [this, optgroup](t_config_option_key opt_key, boost::any value) {
+    optgroup->m_on_change = [this, optgroup](t_config_option_key opt_key, boost::any value) {
             DynamicPrintConfig &filament_config = m_preset_bundle->filaments.get_edited_preset().config;
 
-            update_dirty();
-            if (!m_postpone_update_ui && (opt_key == "nozzle_temperature_range_low" || opt_key == "nozzle_temperature_range_high")) {
-                m_config_manipulation.check_nozzle_recommended_temperature_range(&filament_config);
-            }
-            on_value_change(opt_key, value);
-        };
+        update_dirty();
+        if (!m_postpone_update_ui && (opt_key == "nozzle_temperature_range_low" || opt_key == "nozzle_temperature_range_high")) {
+            m_config_manipulation.check_nozzle_recommended_temperature_range(&filament_config);
+        }
+        on_value_change(opt_key, value);
+    };
 
-        // Orca: New section to focus on flow rate and PA to declutter general section
-        optgroup = page->new_optgroup(L("Flow ratio and Pressure Advance"), L"param_flow_ratio_and_pressure_advance");
-        optgroup->append_single_option_line("pellet_flow_coefficient", "printer_basic_information_advanced#pellet-modded-printer");
-        optgroup->append_single_option_line("filament_flow_ratio", "material_flow_ratio_and_pressure_advance#flow-ratio", 0);
+    // Orca: New section to focus on flow rate and PA to declutter general section
+    optgroup = page->new_optgroup(L("Flow ratio and Pressure Advance"), L"param_flow_ratio_and_pressure_advance");
+    optgroup->append_single_option_line("pellet_flow_coefficient", "printer_basic_information_advanced#pellet-modded-printer");
+    optgroup->append_single_option_line("filament_flow_ratio", "material_flow_ratio_and_pressure_advance#flow-ratio", 0);
 
-        optgroup->append_single_option_line("enable_pressure_advance", "material_flow_ratio_and_pressure_advance#pressure-advance");
-        optgroup->append_single_option_line("pressure_advance", "material_flow_ratio_and_pressure_advance#pressure-advance");
+    optgroup->append_single_option_line("enable_pressure_advance", "material_flow_ratio_and_pressure_advance#pressure-advance");
+    optgroup->append_single_option_line("pressure_advance", "material_flow_ratio_and_pressure_advance#pressure-advance");
 
-        // Orca: adaptive pressure advance and calibration model
+    // Orca: adaptive pressure advance and calibration model
         optgroup->append_single_option_line("adaptive_pressure_advance", "material_flow_ratio_and_pressure_advance#enable-adaptive-pressure-advance-beta");
         optgroup->append_single_option_line("adaptive_pressure_advance_overhangs", "material_flow_ratio_and_pressure_advance#enable-adaptive-pressure-advance-for-overhangs-beta");
         optgroup->append_single_option_line("adaptive_pressure_advance_bridges", "material_flow_ratio_and_pressure_advance#pressure-advance-for-bridges");
 
         Option option = optgroup->get_option("adaptive_pressure_advance_model");
-        option.opt.full_width = true;
+    option.opt.full_width = true;
         option.opt.is_code = true;
         option.opt.height = 15;
-        optgroup->append_single_option_line(option);
-        optgroup->m_on_change = [this](const t_config_option_key& opt_key, const boost::any& value) {
-            DynamicPrintConfig& filament_config = m_preset_bundle->filaments.get_edited_preset().config;
+    optgroup->append_single_option_line(option);
+    optgroup->m_on_change = [this](const t_config_option_key& opt_key, const boost::any& value) {
+        DynamicPrintConfig& filament_config = m_preset_bundle->filaments.get_edited_preset().config;
 
-            update_dirty();
-            if (opt_key == "adaptive_pressure_advance_model")
-                m_config_manipulation.check_adaptive_pressure_advance_model(&filament_config);
+        update_dirty();
+        if (opt_key == "adaptive_pressure_advance_model")
+            m_config_manipulation.check_adaptive_pressure_advance_model(&filament_config);
 
-            on_value_change(opt_key, value);
-        };
-        //
+        on_value_change(opt_key, value);
+    };
+    //
 
-        optgroup = page->new_optgroup(L("Print chamber temperature"), L"param_chamber_temp");
-        optgroup->append_single_option_line("activate_chamber_temp_control", "material_temperatures#print-chamber-temperature");
+    optgroup = page->new_optgroup(L("Print chamber temperature"), L"param_chamber_temp");
+    optgroup->append_single_option_line("activate_chamber_temp_control", "material_temperatures#print-chamber-temperature");
         line = { L("Chamber temperature"), L("Target chamber temperature, and the minimal chamber temperature at which printing should start") };
         line.label_path = "material_temperatures#print-chamber-temperature";
         Option chamber_temp_target_opt = optgroup->get_option("chamber_temperature");
-        chamber_temp_target_opt.opt.label = L("Target");
-        line.append_option(chamber_temp_target_opt);
+    chamber_temp_target_opt.opt.label = L("Target");
+    line.append_option(chamber_temp_target_opt);
         Option chamber_min_temp_opt = optgroup->get_option("chamber_minimal_temperature");
-        chamber_min_temp_opt.opt.label = L("Minimal");
-        line.append_option(chamber_min_temp_opt);
-        optgroup->append_line(line);
-        optgroup->m_on_change = [this](t_config_option_key opt_key, boost::any value) {
-            DynamicPrintConfig& filament_config = m_preset_bundle->filaments.get_edited_preset().config;
+    chamber_min_temp_opt.opt.label = L("Minimal");
+    line.append_option(chamber_min_temp_opt);
+    optgroup->append_line(line);
+    optgroup->m_on_change = [this](t_config_option_key opt_key, boost::any value) {
+        DynamicPrintConfig& filament_config = m_preset_bundle->filaments.get_edited_preset().config;
 
-            update_dirty();
-            if (opt_key == "chamber_temperature") {
-                m_config_manipulation.check_chamber_temperature(&filament_config);
-                m_config_manipulation.check_chamber_minimal_temperature(&filament_config);
+        update_dirty();
+        if (opt_key == "chamber_temperature") {
+            m_config_manipulation.check_chamber_temperature(&filament_config);
+            m_config_manipulation.check_chamber_minimal_temperature(&filament_config);
             }
             else if (opt_key == "chamber_minimal_temperature") {
-                m_config_manipulation.check_chamber_minimal_temperature(&filament_config);
-            }
+            m_config_manipulation.check_chamber_minimal_temperature(&filament_config);
+        }
 
-            on_value_change(opt_key, value);
-        };
+        on_value_change(opt_key, value);
+    };
 
         optgroup = page->new_optgroup(L("Print temperature"), L"param_extruder_temp");
         line = { L("Nozzle"), L("Nozzle temperature when printing") };
-        line.label_path = "material_temperatures#nozzle";
-        line.append_option(optgroup->get_option("nozzle_temperature_initial_layer", 0));
-        line.append_option(optgroup->get_option("nozzle_temperature", 0));
-        optgroup->append_line(line);
+    line.label_path = "material_temperatures#nozzle";
+    line.append_option(optgroup->get_option("nozzle_temperature_initial_layer", 0));
+    line.append_option(optgroup->get_option("nozzle_temperature", 0));
+    optgroup->append_line(line);
 
-        optgroup = page->new_optgroup(L("Bed temperature"), L"param_bed_temp");
+    optgroup = page->new_optgroup(L("Bed temperature"), L"param_bed_temp");
         line = { L("Cool Plate (SuperTack)"),
                  L("Bed temperature when the Cool Plate SuperTack is installed. A value of 0 means the filament does not support printing on the Cool Plate SuperTack.") };
-        line.label_path = "material_temperatures#bed";
-        line.append_option(optgroup->get_option("supertack_plate_temp_initial_layer"));
-        line.append_option(optgroup->get_option("supertack_plate_temp"));
-        optgroup->append_line(line);
+    line.label_path = "material_temperatures#bed";
+    line.append_option(optgroup->get_option("supertack_plate_temp_initial_layer"));
+    line.append_option(optgroup->get_option("supertack_plate_temp"));
+    optgroup->append_line(line);
 
         line = { L("Cool Plate"),
                  L("This is the bed temperature when the Cool Plate is installed. A value of 0 means the filament does not support printing on the Cool Plate.") };
-        line.label_path = "material_temperatures#bed";
-        line.append_option(optgroup->get_option("cool_plate_temp_initial_layer"));
-        line.append_option(optgroup->get_option("cool_plate_temp"));
-        optgroup->append_line(line);
+    line.label_path = "material_temperatures#bed";
+    line.append_option(optgroup->get_option("cool_plate_temp_initial_layer"));
+    line.append_option(optgroup->get_option("cool_plate_temp"));
+    optgroup->append_line(line);
 
         line = { L("Textured Cool Plate"),
                  L("This is the bed temperature when the Textured Cool Plate is installed. A value of 0 means the filament does not support printing on the Textured Cool Plate.") };
-        line.label_path = "material_temperatures#bed";
-        line.append_option(optgroup->get_option("textured_cool_plate_temp_initial_layer"));
-        line.append_option(optgroup->get_option("textured_cool_plate_temp"));
-        optgroup->append_line(line);
+    line.label_path = "material_temperatures#bed";
+    line.append_option(optgroup->get_option("textured_cool_plate_temp_initial_layer"));
+    line.append_option(optgroup->get_option("textured_cool_plate_temp"));
+    optgroup->append_line(line);
 
         line = { L("Engineering Plate"),
                  L("This is the bed temperature when the engineering plate is installed. A value of 0 means the filament does not support printing on the Engineering Plate.") };
-        line.label_path = "material_temperatures#bed";
-        line.append_option(optgroup->get_option("eng_plate_temp_initial_layer"));
-        line.append_option(optgroup->get_option("eng_plate_temp"));
-        optgroup->append_line(line);
+    line.label_path = "material_temperatures#bed";
+    line.append_option(optgroup->get_option("eng_plate_temp_initial_layer"));
+    line.append_option(optgroup->get_option("eng_plate_temp"));
+    optgroup->append_line(line);
 
         line = { L("Smooth PEI Plate / High Temp Plate"),
                  L("This is the bed temperature when the Smooth PEI Plate/High Temperature Plate is installed. A value of 0 means the filament does not support printing on the Smooth PEI Plate/High Temp Plate.") };
-        line.label_path = "material_temperatures#bed";
-        line.append_option(optgroup->get_option("hot_plate_temp_initial_layer"));
-        line.append_option(optgroup->get_option("hot_plate_temp"));
-        optgroup->append_line(line);
+    line.label_path = "material_temperatures#bed";
+    line.append_option(optgroup->get_option("hot_plate_temp_initial_layer"));
+    line.append_option(optgroup->get_option("hot_plate_temp"));
+    optgroup->append_line(line);
 
         line = { L("Textured PEI Plate"),
                  L("This is the bed temperature when the Textured PEI Plate is installed. A value of 0 means the filament does not support printing on the Textured PEI Plate.") };
-        line.label_path = "material_temperatures#bed";
-        line.append_option(optgroup->get_option("textured_plate_temp_initial_layer"));
-        line.append_option(optgroup->get_option("textured_plate_temp"));
-        optgroup->append_line(line);
+    line.label_path = "material_temperatures#bed";
+    line.append_option(optgroup->get_option("textured_plate_temp_initial_layer"));
+    line.append_option(optgroup->get_option("textured_plate_temp"));
+    optgroup->append_line(line);
 
         optgroup->m_on_change = [this](t_config_option_key opt_key, boost::any value)
         {
-            DynamicPrintConfig& filament_config = m_preset_bundle->filaments.get_edited_preset().config;
+        DynamicPrintConfig& filament_config = m_preset_bundle->filaments.get_edited_preset().config;
 
-            update_dirty();
-            /*if (opt_key == "cool_plate_temp" || opt_key == "cool_plate_temp_initial_layer") {
-                m_config_manipulation.check_bed_temperature_difference(BedType::btPC, &filament_config);
-            }
-            else if (opt_key == "eng_plate_temp" || opt_key == "eng_plate_temp_initial_layer") {
-                m_config_manipulation.check_bed_temperature_difference(BedType::btEP, &filament_config);
-            }
-            else if (opt_key == "hot_plate_temp" || opt_key == "hot_plate_temp_initial_layer") {
-                m_config_manipulation.check_bed_temperature_difference(BedType::btPEI, &filament_config);
-            }
-            else if (opt_key == "textured_plate_temp" || opt_key == "textured_plate_temp_initial_layer") {
-                m_config_manipulation.check_bed_temperature_difference(BedType::btPTE, &filament_config);
-            }
+        update_dirty();
+        /*if (opt_key == "cool_plate_temp" || opt_key == "cool_plate_temp_initial_layer") {
+            m_config_manipulation.check_bed_temperature_difference(BedType::btPC, &filament_config);
+        }
+        else if (opt_key == "eng_plate_temp" || opt_key == "eng_plate_temp_initial_layer") {
+            m_config_manipulation.check_bed_temperature_difference(BedType::btEP, &filament_config);
+        }
+        else if (opt_key == "hot_plate_temp" || opt_key == "hot_plate_temp_initial_layer") {
+            m_config_manipulation.check_bed_temperature_difference(BedType::btPEI, &filament_config);
+        }
+        else if (opt_key == "textured_plate_temp" || opt_key == "textured_plate_temp_initial_layer") {
+            m_config_manipulation.check_bed_temperature_difference(BedType::btPTE, &filament_config);
+        }
             else */if (opt_key == "nozzle_temperature") {
-                m_config_manipulation.check_nozzle_temperature_range(&filament_config);
+            m_config_manipulation.check_nozzle_temperature_range(&filament_config);
             }
             else if (opt_key == "nozzle_temperature_initial_layer") {
-                m_config_manipulation.check_nozzle_temperature_initial_layer_range(&filament_config);
-            }
+            m_config_manipulation.check_nozzle_temperature_initial_layer_range(&filament_config);
+        }
 
-            on_value_change(opt_key, value);
-        };
+        on_value_change(opt_key, value);
+    };
 
         //BBS
-        optgroup = page->new_optgroup(L("Volumetric speed limitation"), L"param_volumetric_speed");
+    optgroup = page->new_optgroup(L("Volumetric speed limitation"), L"param_volumetric_speed");
         optgroup->append_single_option_line("filament_adaptive_volumetric_speed", "material_volumetric_speed_limitation#adaptive-volumetric-speed", 0);
-        optgroup->append_single_option_line("filament_max_volumetric_speed", "material_volumetric_speed_limitation#max-volumetric-speed", 0);
+    optgroup->append_single_option_line("filament_max_volumetric_speed", "material_volumetric_speed_limitation#max-volumetric-speed", 0);
 
         //line = { "", "" };
         //line.full_width = 1;
@@ -4472,174 +4472,175 @@ void TabFilament::build()
         //    return description_line_widget(parent, &m_cooling_description_line);
         //};
         //optgroup->append_line(line);
-        optgroup = page->new_optgroup(L("Cooling for specific layer"), L"param_cooling_specific_layer");
-        optgroup->append_single_option_line("close_fan_the_first_x_layers", "material_cooling#no-cooling-for-the-first");
-        // ORCA: explicit override for the part cooling fan on layer 0; also anchors the ramp when "Full fan speed at layer" is set.
-        optgroup->append_single_option_line("initial_layer_fan_speed", "material_cooling#first-layer-fan-speed");
-        optgroup->append_single_option_line("full_fan_speed_layer", "material_cooling#full-fan-speed-at-layer");
+    optgroup = page->new_optgroup(L("Cooling for specific layer"), L"param_cooling_specific_layer");
+    optgroup->append_single_option_line("close_fan_the_first_x_layers", "material_cooling#no-cooling-for-the-first");
+    // ORCA: explicit override for the part cooling fan on layer 0; also anchors the ramp when "Full fan speed at layer" is set.
+    optgroup->append_single_option_line("initial_layer_fan_speed", "material_cooling#first-layer-fan-speed");
+    optgroup->append_single_option_line("full_fan_speed_layer", "material_cooling#full-fan-speed-at-layer");
 
         optgroup = page->new_optgroup(L("Part cooling fan"), L"param_cooling_part_fan");
         line = { L("Min fan speed threshold"), L("The part cooling fan will run at the minimum fan speed when the estimated layer time is longer than the threshold value. When the layer time is shorter than the threshold, the fan speed will be interpolated between the minimum and maximum fan speed according to layer printing time.") };
-        line.label_path = "material_cooling#material-part-cooling-fan";
-        line.append_option(optgroup->get_option("fan_min_speed"));
-        line.append_option(optgroup->get_option("fan_cooling_layer_time"));
-        optgroup->append_line(line);
+    line.label_path = "material_cooling#material-part-cooling-fan";
+    line.append_option(optgroup->get_option("fan_min_speed"));
+    line.append_option(optgroup->get_option("fan_cooling_layer_time"));
+    optgroup->append_line(line);
         line = { L("Max fan speed threshold"), L("The part cooling fan will run at maximum speed when the estimated layer time is shorter than the threshold value.") };
-        line.label_path = "material_cooling#material-part-cooling-fan";
-        line.append_option(optgroup->get_option("fan_max_speed"));
-        line.append_option(optgroup->get_option("slow_down_layer_time"));
-        optgroup->append_line(line);
-        optgroup->append_single_option_line("reduce_fan_stop_start_freq", "material_cooling#keep-fan-always-on");
-        optgroup->append_single_option_line("slow_down_for_layer_cooling", "material_cooling#slow-printing-down-for-better-layer-cooling");
-        optgroup->append_single_option_line("dont_slow_down_outer_wall", "material_cooling#dont-slow-down-outer-walls");
-        optgroup->append_single_option_line("slow_down_min_speed", "material_cooling#min-print-speed");
+    line.label_path = "material_cooling#material-part-cooling-fan";
+    line.append_option(optgroup->get_option("fan_max_speed"));
+    line.append_option(optgroup->get_option("slow_down_layer_time"));
+    optgroup->append_line(line);
+    optgroup->append_single_option_line("reduce_fan_stop_start_freq", "material_cooling#keep-fan-always-on");
+    optgroup->append_single_option_line("fan_always_off", "material_cooling#fan-always-off"); 
+    optgroup->append_single_option_line("slow_down_for_layer_cooling", "material_cooling#slow-printing-down-for-better-layer-cooling");
+    optgroup->append_single_option_line("dont_slow_down_outer_wall", "material_cooling#dont-slow-down-outer-walls");
+    optgroup->append_single_option_line("slow_down_min_speed", "material_cooling#min-print-speed");
 
-        optgroup->append_single_option_line("enable_overhang_bridge_fan", "material_cooling#force-cooling-for-overhangs-and-bridges");
-        optgroup->append_single_option_line("overhang_fan_threshold", "material_cooling#overhang-cooling-activation-threshold");
-        optgroup->append_single_option_line("overhang_fan_speed", "material_cooling#overhangs-and-external-bridges-fan-speed");
+    optgroup->append_single_option_line("enable_overhang_bridge_fan", "material_cooling#force-cooling-for-overhangs-and-bridges");
+    optgroup->append_single_option_line("overhang_fan_threshold", "material_cooling#overhang-cooling-activation-threshold");
+    optgroup->append_single_option_line("overhang_fan_speed", "material_cooling#overhangs-and-external-bridges-fan-speed");
         optgroup->append_single_option_line("internal_bridge_fan_speed", "material_cooling#internal-bridges-fan-speed"); // ORCA: Add support for separate internal bridge fan speed control
-        optgroup->append_single_option_line("support_material_interface_fan_speed", "material_cooling#support-interface-fan-speed");
+    optgroup->append_single_option_line("support_material_interface_fan_speed", "material_cooling#support-interface-fan-speed");
         optgroup->append_single_option_line("ironing_fan_speed", "material_cooling#ironing-fan-speed"); // ORCA: Add support for ironing fan speed control
 
-        optgroup = page->new_optgroup(L("Auxiliary part cooling fan"), L"param_cooling_aux_fan");
-        optgroup->append_single_option_line("additional_cooling_fan_speed", "material_cooling#auxiliary-part-cooling-fan");
+    optgroup = page->new_optgroup(L("Auxiliary part cooling fan"), L"param_cooling_aux_fan");
+    optgroup->append_single_option_line("additional_cooling_fan_speed", "material_cooling#auxiliary-part-cooling-fan");
 
         optgroup = page->new_optgroup(L("Exhaust fan"),L"param_cooling_exhaust");
 
-        optgroup->append_single_option_line("activate_air_filtration", "material_cooling#activate-air-filtration");
+    optgroup->append_single_option_line("activate_air_filtration", "material_cooling#activate-air-filtration");
 
-        line = {L("During print"), ""};
-        line.append_option(optgroup->get_option("activate_air_filtration_during_print"));
-        line.append_option(optgroup->get_option("during_print_exhaust_fan_speed"));
-        line.label_path = "material_cooling#during-print";
-        optgroup->append_line(line);
+    line = {L("During print"), ""};
+    line.append_option(optgroup->get_option("activate_air_filtration_during_print"));
+    line.append_option(optgroup->get_option("during_print_exhaust_fan_speed"));
+    line.label_path = "material_cooling#during-print";
+    optgroup->append_line(line);
 
 
-        line = {L("Complete print"), ""};
-        line.append_option(optgroup->get_option("activate_air_filtration_on_completion"));
-        line.append_option(optgroup->get_option("complete_print_exhaust_fan_speed"));
-        line.label_path = "material_cooling#complete-print";
-        optgroup->append_line(line);
+    line = {L("Complete print"), ""};
+    line.append_option(optgroup->get_option("activate_air_filtration_on_completion"));
+    line.append_option(optgroup->get_option("complete_print_exhaust_fan_speed"));
+    line.label_path = "material_cooling#complete-print";
+    optgroup->append_line(line);
         //BBS
-        add_filament_overrides_page();
-        const int gcode_field_height = 15; // 150
-        const int notes_field_height = 25; // 250
+    add_filament_overrides_page();
+    const int gcode_field_height = 15; // 150
+    const int notes_field_height = 25; // 250
 
-        auto edit_custom_gcode_fn = [this](const t_config_option_key& opt_key) { edit_custom_gcode(opt_key); };
+    auto edit_custom_gcode_fn = [this](const t_config_option_key& opt_key) { edit_custom_gcode(opt_key); };
 
     page = add_options_page(L("Advanced"), "custom-gcode_advanced"); // ORCA: icon only visible on placeholders
         optgroup = page->new_optgroup(L("Filament start G-code"), L"param_gcode", 0);
-        optgroup->m_on_change = [this, &optgroup_title = optgroup->title](const t_config_option_key& opt_key, const boost::any& value) {
-            validate_custom_gcode_cb(this, optgroup_title, opt_key, value);
-        };
-        optgroup->edit_custom_gcode = edit_custom_gcode_fn;
+    optgroup->m_on_change = [this, &optgroup_title = optgroup->title](const t_config_option_key& opt_key, const boost::any& value) {
+        validate_custom_gcode_cb(this, optgroup_title, opt_key, value);
+    };
+    optgroup->edit_custom_gcode = edit_custom_gcode_fn;
         option = optgroup->get_option("filament_start_gcode");
         option.opt.full_width = true;
         option.opt.is_code = true;
         option.opt.height = gcode_field_height;// 150;
-        optgroup->append_single_option_line(option);
+    optgroup->append_single_option_line(option);
 
         optgroup = page->new_optgroup(L("Change extrusion role G-code"), L"param_gcode", 0);
-        optgroup->m_on_change = [this, &optgroup_title = optgroup->title](const t_config_option_key& opt_key, const boost::any& value) {
-            validate_custom_gcode_cb(this, optgroup_title, opt_key, value);
-        };
-        optgroup->edit_custom_gcode = edit_custom_gcode_fn;
+    optgroup->m_on_change = [this, &optgroup_title = optgroup->title](const t_config_option_key& opt_key, const boost::any& value) {
+        validate_custom_gcode_cb(this, optgroup_title, opt_key, value);
+    };
+    optgroup->edit_custom_gcode = edit_custom_gcode_fn;
         option = optgroup->get_option("filament_change_extrusion_role_gcode");
         option.opt.full_width = true;
         option.opt.is_code = true;
         option.opt.height = gcode_field_height;// 150;
-        optgroup->append_single_option_line(option);
+    optgroup->append_single_option_line(option);
 
         optgroup = page->new_optgroup(L("Filament end G-code"), L"param_gcode", 0);
-        optgroup->m_on_change = [this, &optgroup_title = optgroup->title](const t_config_option_key& opt_key, const boost::any& value) {
-            validate_custom_gcode_cb(this, optgroup_title, opt_key, value);
-        };
-        optgroup->edit_custom_gcode = edit_custom_gcode_fn;
+    optgroup->m_on_change = [this, &optgroup_title = optgroup->title](const t_config_option_key& opt_key, const boost::any& value) {
+        validate_custom_gcode_cb(this, optgroup_title, opt_key, value);
+    };
+    optgroup->edit_custom_gcode = edit_custom_gcode_fn;
         option = optgroup->get_option("filament_end_gcode");
         option.opt.full_width = true;
         option.opt.is_code = true;
         option.opt.height = gcode_field_height;// 150;
-        optgroup->append_single_option_line(option);
+    optgroup->append_single_option_line(option);
 
-        optgroup = page->new_optgroup(L("Plugin Configuration"), L"param_gcode");
-        optgroup->append_single_option_line("filament_plugin_config_overrides");
+    optgroup = page->new_optgroup(L("Plugin Configuration"), L"param_gcode");
+    optgroup->append_single_option_line("filament_plugin_config_overrides");
 
     page = add_options_page(L("Multimaterial"), "custom-gcode_multi_material"); // ORCA: icon only visible on placeholders
-        optgroup = page->new_optgroup(L("Wipe tower parameters"), "param_tower");
+    optgroup = page->new_optgroup(L("Wipe tower parameters"), "param_tower");
         optgroup->append_single_option_line("filament_minimal_purge_on_wipe_tower", "material_multimaterial#multimaterial-wipe-tower-parameters");
         optgroup->append_single_option_line("filament_tower_interface_pre_extrusion_dist", "material_multimaterial#multimaterial-wipe-tower-parameters");
         optgroup->append_single_option_line("filament_tower_interface_pre_extrusion_length", "material_multimaterial#multimaterial-wipe-tower-parameters");
-        optgroup->append_single_option_line("filament_tower_ironing_area", "material_multimaterial#multimaterial-wipe-tower-parameters");
+    optgroup->append_single_option_line("filament_tower_ironing_area", "material_multimaterial#multimaterial-wipe-tower-parameters");
         optgroup->append_single_option_line("filament_tower_interface_purge_volume", "material_multimaterial#multimaterial-wipe-tower-parameters");
         optgroup->append_single_option_line("filament_tower_interface_print_temp", "material_multimaterial#multimaterial-wipe-tower-parameters");
 
-        optgroup = page->new_optgroup(L("Multi Filament"));
-        // optgroup->append_single_option_line("filament_flush_temp", "", 0);
-        // optgroup->append_single_option_line("filament_flush_volumetric_speed", "", 0);
+    optgroup = page->new_optgroup(L("Multi Filament"));
+    // optgroup->append_single_option_line("filament_flush_temp", "", 0);
+    // optgroup->append_single_option_line("filament_flush_volumetric_speed", "", 0);
         optgroup->append_single_option_line("long_retractions_when_ec", "material_multimaterial#multi-filament" , 0);
         optgroup->append_single_option_line("retraction_distances_when_ec", "material_multimaterial#multi-filament" , 0);
 
-        optgroup = page->new_optgroup(L("Tool change parameters with single extruder MM printers"), "param_toolchange");
-        optgroup->append_single_option_line("filament_loading_speed_start", "material_multimaterial#loading-speed-at-the-start");
-        optgroup->append_single_option_line("filament_loading_speed", "material_multimaterial#loading-speed");
-        optgroup->append_single_option_line("filament_unloading_speed_start", "material_multimaterial#unloading-speed-at-the-start");
-        optgroup->append_single_option_line("filament_unloading_speed", "material_multimaterial#unloading-speed");
-        optgroup->append_single_option_line("filament_toolchange_delay", "material_multimaterial#delay-after-unloading");
-        optgroup->append_single_option_line("filament_cooling_moves", "material_multimaterial#number-of-cooling-moves");
-        optgroup->append_single_option_line("filament_cooling_initial_speed", "material_multimaterial#speed-of-the-first-cooling-move");
-        optgroup->append_single_option_line("filament_cooling_final_speed", "material_multimaterial#speed-of-the-last-cooling-move");
-        optgroup->append_single_option_line("filament_stamping_loading_speed", "material_multimaterial#stamping-loading-speed");
-        optgroup->append_single_option_line("filament_stamping_distance", "material_multimaterial#stamping-distance");
+    optgroup = page->new_optgroup(L("Tool change parameters with single extruder MM printers"), "param_toolchange");
+    optgroup->append_single_option_line("filament_loading_speed_start", "material_multimaterial#loading-speed-at-the-start");
+    optgroup->append_single_option_line("filament_loading_speed", "material_multimaterial#loading-speed");
+    optgroup->append_single_option_line("filament_unloading_speed_start", "material_multimaterial#unloading-speed-at-the-start");
+    optgroup->append_single_option_line("filament_unloading_speed", "material_multimaterial#unloading-speed");
+    optgroup->append_single_option_line("filament_toolchange_delay", "material_multimaterial#delay-after-unloading");
+    optgroup->append_single_option_line("filament_cooling_moves", "material_multimaterial#number-of-cooling-moves");
+    optgroup->append_single_option_line("filament_cooling_initial_speed", "material_multimaterial#speed-of-the-first-cooling-move");
+    optgroup->append_single_option_line("filament_cooling_final_speed", "material_multimaterial#speed-of-the-last-cooling-move");
+    optgroup->append_single_option_line("filament_stamping_loading_speed", "material_multimaterial#stamping-loading-speed");
+    optgroup->append_single_option_line("filament_stamping_distance", "material_multimaterial#stamping-distance");
         create_line_with_widget(optgroup.get(), "filament_ramming_parameters", "material_multimaterial#ramming-parameters", [this](wxWindow* parent) {
 
-            // ORCA modernize button style
-            Button* btn = new Button(parent, _(L("Set")) + " " + dots);
-            btn->SetStyle(ButtonStyle::Regular, ButtonType::Parameter);
+                                // ORCA modernize button style
+                                Button* btn = new Button(parent, _(L("Set")) + " " + dots);
+                                btn->SetStyle(ButtonStyle::Regular, ButtonType::Parameter);
 
-            auto sizer = new wxBoxSizer(wxHORIZONTAL);
-            sizer->Add(btn);
+                                auto sizer = new wxBoxSizer(wxHORIZONTAL);
+                                sizer->Add(btn);
 
-            btn->Bind(wxEVT_BUTTON, [this](wxCommandEvent& e) {
+                                btn->Bind(wxEVT_BUTTON, [this](wxCommandEvent& e) {
                 RammingDialog dlg(this,(m_config->option<ConfigOptionStrings>("filament_ramming_parameters"))->get_at(0));
-                if (dlg.ShowModal() == wxID_OK) {
-                    load_key_value("filament_ramming_parameters", dlg.get_parameters());
-                    update_changed_ui();
-                }
-            });
-            return sizer;
-        });
+                                    if (dlg.ShowModal() == wxID_OK) {
+                                        load_key_value("filament_ramming_parameters", dlg.get_parameters());
+                                        update_changed_ui();
+                                    }
+                                });
+                                return sizer;
+                            });
 
-        optgroup = page->new_optgroup(L("Tool change parameters with multi extruder MM printers"), "param_toolchange_multi_extruder");
-        optgroup->append_single_option_line("filament_multitool_ramming", "material_multimaterial#tool-change-parameters-with-multi-extruder");
-        optgroup->append_single_option_line("filament_multitool_ramming_volume", "material_multimaterial#multi-tool-ramming-volume");
-        optgroup->append_single_option_line("filament_multitool_ramming_flow", "material_multimaterial#multi-tool-ramming-flow");
+    optgroup = page->new_optgroup(L("Tool change parameters with multi extruder MM printers"), "param_toolchange_multi_extruder");
+    optgroup->append_single_option_line("filament_multitool_ramming", "material_multimaterial#tool-change-parameters-with-multi-extruder");
+    optgroup->append_single_option_line("filament_multitool_ramming_volume", "material_multimaterial#multi-tool-ramming-volume");
+    optgroup->append_single_option_line("filament_multitool_ramming_flow", "material_multimaterial#multi-tool-ramming-flow");
 
     page = add_options_page(L("Dependencies"), "advanced");
-        optgroup = page->new_optgroup(L("Compatible printers"), "param_dependencies_printers");
+    optgroup = page->new_optgroup(L("Compatible printers"), "param_dependencies_printers");
         create_line_with_widget(optgroup.get(), "compatible_printers", "", [this](wxWindow* parent) {
             return compatible_widget_create(parent, m_compatible_printers);
         });
 
         option = optgroup->get_option("compatible_printers_condition");
-        option.opt.full_width = true;
-        optgroup->append_single_option_line(option, "material_dependencies#compatible-printers");
+    option.opt.full_width = true;
+    optgroup->append_single_option_line(option, "material_dependencies#compatible-printers");
 
-        optgroup = page->new_optgroup(L("Compatible process profiles"), "param_dependencies_presets");
+    optgroup = page->new_optgroup(L("Compatible process profiles"), "param_dependencies_presets");
         create_line_with_widget(optgroup.get(), "compatible_prints", "", [this](wxWindow* parent) {
             return compatible_widget_create(parent, m_compatible_prints);
         });
 
         option = optgroup->get_option("compatible_prints_condition");
-        option.opt.full_width = true;
-        optgroup->append_single_option_line(option, "material_dependencies#compatible-process-profiles");
+    option.opt.full_width = true;
+    optgroup->append_single_option_line(option, "material_dependencies#compatible-process-profiles");
 
     page = add_options_page(L("Notes"), "custom-gcode_note"); // ORCA: icon only visible on placeholders
         optgroup = page->new_optgroup(L("Notes"),"note", 0);
-        optgroup->label_width = 0;
+    optgroup->label_width = 0;
         option = optgroup->get_option("filament_notes");
-        option.opt.full_width = true;
+    option.opt.full_width = true;
         option.opt.height = notes_field_height;// 250;
-        optgroup->append_single_option_line(option);
+    optgroup->append_single_option_line(option);
 
         //build_preset_description_line(optgroup.get());
 }
@@ -4692,49 +4693,69 @@ void TabFilament::toggle_options()
     auto printer_cfg = m_preset_bundle->printers.get_edited_preset().config;
 
     if (m_active_page->title() == L("Cooling")) {
-        bool has_enable_overhang_bridge_fan = m_config->opt_bool("enable_overhang_bridge_fan", 0);
+        bool is_always_off = false;
+        if (m_config->has("fan_always_off")) {
+            auto opt = m_config->option<ConfigOptionBools>("fan_always_off");
+            if (opt && !opt->values.empty()) {
+                is_always_off = opt->get_at(0);
+            }
+        }          
+        if (is_always_off) {
+            toggle_option("fan_min_speed", false);
+            toggle_option("fan_max_speed", false);
+            toggle_option("reduce_fan_stop_start_freq", false);
+            toggle_option("slow_down_for_layer_cooling", false);
+            toggle_option("enable_overhang_bridge_fan", false);
+            toggle_option("overhang_fan_threshold", false);
+            toggle_option("overhang_fan_speed", false);
+            toggle_option("internal_bridge_fan_speed", false);
+            toggle_option("close_fan_the_first_x_layers", false);
+            toggle_option("full_fan_speed_layer", false);
+        } else {
+            bool has_enable_overhang_bridge_fan = m_config->opt_bool("enable_overhang_bridge_fan", 0);
         for (auto el : {"overhang_fan_speed", "overhang_fan_threshold", "internal_bridge_fan_speed"}) // ORCA: Add support for separate internal bridge fan speed control
-            toggle_option(el, has_enable_overhang_bridge_fan);
+                toggle_option(el, has_enable_overhang_bridge_fan);
 
-        // Orca: toggle dont slow down for external perimeters if
-        bool has_slow_down_for_layer_cooling = m_config->opt_bool("slow_down_for_layer_cooling", 0);
-        toggle_option("dont_slow_down_outer_wall", has_slow_down_for_layer_cooling);
+            // Orca: toggle dont slow down for external perimeters if
+            bool has_slow_down_for_layer_cooling = m_config->opt_bool("slow_down_for_layer_cooling", 0);
+            toggle_option("dont_slow_down_outer_wall", has_slow_down_for_layer_cooling);
 
-        // ORCA: First layer fan speed override only makes sense when no layers are gated off ("No cooling for
-        // the first" == 0). Otherwise the override would set layer 0 to a non-zero value while the gate forces
-        // layers 1..N-1 to zero, producing a confusing non-monotonic profile. When the gate is active we both
-        // grey out the UI line and force the underlying value to -1 so the cooling buffer never enters the
-        // override branch.
+            // ORCA: First layer fan speed override only makes sense when no layers are gated off ("No cooling for
+            // the first" == 0). Otherwise the override would set layer 0 to a non-zero value while the gate forces
+            // layers 1..N-1 to zero, producing a confusing non-monotonic profile. When the gate is active we both
+            // grey out the UI line and force the underlying value to -1 so the cooling buffer never enters the
+            // override branch.
         const int close_fan_first_n = m_config->opt_int("close_fan_the_first_x_layers", 0);
-        const bool initial_layer_fan_speed_enabled = close_fan_first_n <= 0;
-        toggle_line("initial_layer_fan_speed", initial_layer_fan_speed_enabled);
-        if (!initial_layer_fan_speed_enabled) {
-            if (auto* opt = dynamic_cast<const ConfigOptionInts*>(m_config->option("initial_layer_fan_speed"))) {
-                bool needs_reset = false;
-                for (int v : opt->values) {
+            const bool initial_layer_fan_speed_enabled = close_fan_first_n <= 0;
+            toggle_line("initial_layer_fan_speed", initial_layer_fan_speed_enabled);
+            if (!initial_layer_fan_speed_enabled) {
+                if (auto* opt = dynamic_cast<const ConfigOptionInts*>(m_config->option("initial_layer_fan_speed"))) {
+                    bool needs_reset = false;
+                    for (int v : opt->values) {
                     if (v != -1) { needs_reset = true; break; }
-                }
-                if (needs_reset) {
-                    std::vector<int> reset_values(opt->values.size(), -1);
-                    m_config->set_key_value("initial_layer_fan_speed", new ConfigOptionInts(reset_values));
-                    update_dirty();
-                    reload_config();
+                    }
+                    if (needs_reset) {
+                        std::vector<int> reset_values(opt->values.size(), -1);
+                        m_config->set_key_value("initial_layer_fan_speed", new ConfigOptionInts(reset_values));
+                        update_dirty();
+                        reload_config();
+                    }
                 }
             }
-        }
 
-        toggle_line("additional_cooling_fan_speed", printer_cfg.opt_bool("auxiliary_fan"));
+            toggle_line("additional_cooling_fan_speed", printer_cfg.opt_bool("auxiliary_fan"));
 
-        bool support_air_filtration = printer_cfg.opt_bool("support_air_filtration");
-        for (auto el : {"activate_air_filtration", "during_print_exhaust_fan_speed", "complete_print_exhaust_fan_speed"})
-            toggle_line(el, support_air_filtration);
+            bool support_air_filtration = printer_cfg.opt_bool("support_air_filtration");
+            for (auto el : {"activate_air_filtration", "during_print_exhaust_fan_speed", "complete_print_exhaust_fan_speed"})
+                toggle_line(el, support_air_filtration);
 
-        if (support_air_filtration) {
-            bool activate_air_filtration = m_config->opt_bool("activate_air_filtration", 0);
-            toggle_option("activate_air_filtration_during_print", activate_air_filtration);
-            toggle_option("during_print_exhaust_fan_speed", activate_air_filtration && m_config->opt_bool("activate_air_filtration_during_print", 0));
-            toggle_option("activate_air_filtration_on_completion", activate_air_filtration);
-            toggle_option("complete_print_exhaust_fan_speed", activate_air_filtration && m_config->opt_bool("activate_air_filtration_on_completion", 0));
+            if (support_air_filtration) {
+                bool activate_air_filtration = m_config->opt_bool("activate_air_filtration", 0);
+                toggle_option("activate_air_filtration_during_print", activate_air_filtration);
+                toggle_option("during_print_exhaust_fan_speed", activate_air_filtration && m_config->opt_bool("activate_air_filtration_during_print", 0));
+                toggle_option("activate_air_filtration_on_completion", activate_air_filtration);
+                toggle_option("complete_print_exhaust_fan_speed", activate_air_filtration && m_config->opt_bool("activate_air_filtration_on_completion", 0));
+            }
         }
     }
     if (m_active_page->title() == L("Filament"))
@@ -8609,7 +8630,7 @@ Field *Page::get_field(const t_config_option_key &opt_key, int opt_index /*= -1*
             opt_key2 = iter->second;
     }
     for (auto opt : m_optgroups) {
-        field = opt->get_fieldc(opt_key2, opt_index);
+            field = opt->get_fieldc(opt_key2, opt_index);
         if (field != nullptr) return field;
     }
     return field;
@@ -8628,7 +8649,7 @@ Line *Page::get_line(const t_config_option_key &opt_key, int opt_index)
         opt_key2 = opt_key + '#' + std::to_string(opt_index);
     }
     for (auto opt : m_optgroups) {
-        line = opt->get_line(opt_key2);
+            line = opt->get_line(opt_key2);
         if (line != nullptr) return line;
     }
     return line;


### PR DESCRIPTION
***

# Description

This PR addresses issue #15480 by providing users with more granular control over cooling for materials that are extremely sensitive to drafts (such as ABS or ASA) and for extremely large-scale prints on large-format machines.

### Problem
1. **ABS/ASA Warping:** Even with minimal cooling, some materials warp. Currently, users have to manually set all cooling percentages (min/max/overhangs/bridges) to 0. A single "Master Off" switch simplifies this workflow.
2. **Layer Limits:** Large-format printers (like the Elegoo OrangeStorm Giga) can have prints exceeding 1,000 layers. The previous hard limit on "No cooling for the first X layers" prevented users from disabling the fan for the full duration of these long prints.

### Key Changes
*   **Configuration (`PrintConfig.cpp`):** 
    *   Added a new boolean option `fan_always_off` to filament settings.
    *   Increased the maximum allowed value for `close_fan_the_first_x_layers` from **1,000 to 10,000**.
*   **UI (`Tab.cpp`):** 
    *   Added the "Keep fan always off" checkbox in **Filament Settings -> Cooling**.
    *   Updated `toggle_options()` logic to automatically grey out and disable all other cooling sub-settings when "Keep fan always off" is enabled.
*   **Logic (`CoolingBuffer.cpp`):** 
    *   Modified G-code emission logic to check the `fan_always_off` flag. If enabled, it forces fan speed to 0% and suppresses changes normally triggered by overhangs, bridges, or ironing.

**Related Issue:** Closes #15480

# Screenshots

<img width="873" height="712" alt="Screenshot 2026-09-09 141544" src="https://github.com/user-attachments/assets/7aaf1c17-7e15-4345-b2b2-7c0d68865677" />


## Tests

I have conducted the following tests to verify the changes:

1.  **UI Interaction:** Verified that checking "Keep fan always off" correctly greys out the Fan Speed, Overhang, and Bridge cooling fields.
2.  **Boundary Test:** Verified that the "No cooling for the first" field now accepts values up to 10,000 without returning to the previous 1,000 limit.
3.  **G-code Inspection:** Sliced a model with "Keep fan always off" enabled and confirmed that the output `.gcode` file contains no `M106` fan-on commands, even at overhang and bridge sections.
4.  **Compatibility:** Confirmed that existing profiles (where this flag is off) still behave exactly as they did before.