### PR TITLE
Preset: retry presets whose parent is loaded in the same pass

### DIFF
--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -1679,175 +1679,218 @@ void PresetCollection::load_presets(
     // Store the loaded presets into a new vector, otherwise the binary search for already existing presets would be broken.
     // (see the "Preset already present, not loading" message).
     std::deque<Preset> presets_loaded;
+    size_t             presets_loaded_total = 0;
+
+    //ORCA: a preset may inherit another preset from this very directory. The presets of a
+    //      pass live in the staging deque above until it is merged into m_presets, so
+    //      find_preset2() cannot see them and such a child used to be discarded outright.
+    //      Defer it instead and retry after the merge, repeating while a pass still resolves
+    //      something, so chains of any depth load regardless of directory order. Only a pass
+    //      that resolves nothing leaves a genuinely missing parent, reported below.
+    //      Maps preset name -> (file, inherits value) so the original error can still be given.
+    std::map<std::string, std::pair<std::string, std::string>> deferred, deferred_next;
+    bool first_pass = true;
 
     //BBS: get the extruder related info for this preset collection
     std::string extruder_id_name, extruder_variant_name;
     std::set<std::string> *key_set1 = nullptr, *key_set2 = nullptr;
     Preset::get_extruder_names_and_keysets(m_type, extruder_id_name, extruder_variant_name, &key_set1, &key_set2);
 
-    //BBS: change to json format
-    for (auto &dir_entry : boost::filesystem::directory_iterator(dir))
-    {
-        std::string file_name = dir_entry.path().filename().string();
-        //if (Slic3r::is_ini_file(dir_entry)) {
-        if (Slic3r::is_json_file(file_name)) {
-            // Remove the .ini suffix.
-            std::string name = file_name.erase(file_name.size() - 5);
-            std::string canonical_name = this->canonical_preset_name(name, resolved_origin);
-            if (this->find_preset(canonical_name, false)) {
-                // This happens when there's is a preset (most likely legacy one) with the same name as a system preset
-                // that's already been loaded from a bundle.
-                BOOST_LOG_TRIVIAL(warning) << "Preset already present, not loading: " << canonical_name;
-                continue;
-            }
-            try {
-                Preset preset(m_type, canonical_name, false);
-                preset.bundle_id = resolved_origin.bundle_id;
-                preset.file = dir_entry.path().string();
-                // Load the preset file, apply preset values on top of defaults.
+    for (;;) {
+        //BBS: change to json format
+        for (auto &dir_entry : boost::filesystem::directory_iterator(dir))
+        {
+            std::string file_name = dir_entry.path().filename().string();
+            //if (Slic3r::is_ini_file(dir_entry)) {
+            if (Slic3r::is_json_file(file_name)) {
+                // Remove the .ini suffix.
+                std::string name = file_name.erase(file_name.size() - 5);
+                std::string canonical_name = this->canonical_preset_name(name, resolved_origin);
+                //ORCA: a retry pass revisits only what it deferred; everything else is
+                //      already in m_presets and would trip the duplicate check below.
+                if (!first_pass && deferred.find(name) == deferred.end())
+                    continue;
+                if (this->find_preset(canonical_name, false)) {
+                    // This happens when there's is a preset (most likely legacy one) with the same name as a system preset
+                    // that's already been loaded from a bundle.
+                    BOOST_LOG_TRIVIAL(warning) << "Preset already present, not loading: " << canonical_name;
+                    continue;
+                }
                 try {
-                    fs::path idx_path(preset.file);
-                    idx_path.replace_extension(".info");
-                    if (fs::exists(idx_path)) {
-                        preset.load_info(idx_path.string());
-                    }
-                    DynamicPrintConfig config;
-                    //BBS: change to json format
-                    //ConfigSubstitutions config_substitutions = config.load_from_ini(preset.file, substitution_rule);
-                    std::map<std::string, std::string> key_values;
-                    std::string reason;
-                    ConfigSubstitutions config_substitutions = config.load_from_json(preset.file, substitution_rule, key_values, reason);
-                    if (! config_substitutions.empty())
-                        substitutions.push_back({ preset.name, m_type, PresetConfigSubstitutions::Source::UserFile, preset.file, std::move(config_substitutions) });
-                    if (!reason.empty()) {
+                    Preset preset(m_type, canonical_name, false);
+                    preset.bundle_id = resolved_origin.bundle_id;
+                    preset.file = dir_entry.path().string();
+                    // Load the preset file, apply preset values on top of defaults.
+                    try {
+                        fs::path idx_path(preset.file);
+                        idx_path.replace_extension(".info");
+                        if (fs::exists(idx_path)) {
+                            preset.load_info(idx_path.string());
+                        }
+                        DynamicPrintConfig config;
+                        //BBS: change to json format
+                        //ConfigSubstitutions config_substitutions = config.load_from_ini(preset.file, substitution_rule);
+                        std::map<std::string, std::string> key_values;
+                        std::string reason;
+                        ConfigSubstitutions config_substitutions = config.load_from_json(preset.file, substitution_rule, key_values, reason);
+                        if (! config_substitutions.empty())
+                            substitutions.push_back({ preset.name, m_type, PresetConfigSubstitutions::Source::UserFile, preset.file, std::move(config_substitutions) });
+                        if (!reason.empty()) {
+                            fs::path file_path(preset.file);
+                            if (!read_only && fs::exists(file_path))
+                                fs::remove(file_path);
+                            file_path.replace_extension(".info");
+                            if (!read_only && fs::exists(file_path))
+                                fs::remove(file_path);
+                            BOOST_LOG_TRIVIAL(error) << boost::format("parse config %1% failed")%preset.file;
+                            ++m_errors;
+                            continue;
+                        }
+
+                        std::string version_str = key_values[BBL_JSON_KEY_VERSION];
+                        boost::optional<Semver> version = Semver::parse(version_str);
+                        if (!version) continue;
+                        preset.version = *version;
+
+                        if (key_values.find(BBL_JSON_KEY_FILAMENT_ID) != key_values.end())
+                            preset.filament_id = key_values[BBL_JSON_KEY_FILAMENT_ID];
+                        if (key_values.find(BBL_JSON_KEY_DESCRIPTION) != key_values.end())
+                            preset.description = key_values[BBL_JSON_KEY_DESCRIPTION];
+                        if (key_values.find(BBL_JSON_KEY_INSTANTIATION) != key_values.end())
+                            preset.is_visible = key_values[BBL_JSON_KEY_INSTANTIATION] != "false";
+
+                        //Orca: find and use the inherit config as the base
+                        Preset* inherit_preset = nullptr;
+                        ConfigOption* inherits_config = config.option(BBL_JSON_KEY_INHERITS);
+
+                        // check inherits_config
+                        if (inherits_config) {
+                            ConfigOptionString * option_str = dynamic_cast<ConfigOptionString *> (inherits_config);
+                            std::string inherits_value = option_str->value;
+                            // Orca: try to find if the parent preset has been renamed
+                            inherit_preset = this->find_preset2(inherits_value);
+                            Preset::normalize_inherits(config, inherit_preset);
+                        } else {
+                            ;
+                        }
+                        const Preset& default_preset = this->default_preset_for(config);
+                        if (inherit_preset) {
+                            preset.config = inherit_preset->config;
+                            preset.filament_id = inherit_preset->filament_id;
+                            extend_default_config_length(config, false, {});
+                            preset.config.update_diff_values_to_child_config(config, extruder_id_name, extruder_variant_name, *key_set1, *key_set2);
+                        }
+                        else {
+                            auto inherits_config2 = dynamic_cast<ConfigOptionString *>(inherits_config);
+                            if ((inherits_config2 && !inherits_config2->value.empty())) {
+                                //ORCA: the parent may be another preset in this same directory
+                                //      that has not been merged into m_presets yet. Defer and
+                                //      retry after this pass is published; only a pass that
+                                //      resolves nothing turns the remainder into a real error.
+                                deferred_next.emplace(name, std::make_pair(preset.file, inherits_config2->value));
+                                continue;
+                            }
+                            // We support custom root preset now
+                            // Find a default preset for the config. The PrintPresetCollection provides different default preset based on the "printer_technology" field.
+                            preset.config = default_preset.config;
+                            preset.config.apply(std::move(config));
+                            extend_default_config_length(preset.config, true, default_preset.config);
+                        }
+                        BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << " load preset: " << name << " and filament_id: " << preset.filament_id << " and base_id: " << preset.base_id;
+
+                        Preset::normalize(preset.config);
+                        // Report configuration fields, which are misplaced into a wrong group.
+                        std::string incorrect_keys = Preset::remove_invalid_keys(preset.config, default_preset.config);
+                        if (!incorrect_keys.empty()) {
+                            ++m_errors;
+                            BOOST_LOG_TRIVIAL(error)
+                                << "Error in a preset file: The preset \"" << preset.file
+                                << "\" contains the following incorrect keys: " << incorrect_keys << ", which were removed";
+                        }
+
+                        if (preset.type == Preset::TYPE_FILAMENT && preset.is_user() && preset.inherits().empty()) {
+                            auto compatible_printers = dynamic_cast<ConfigOptionStrings *>(preset.config.option("compatible_printers", true));
+                            if (compatible_printers && compatible_printers->values.empty()) {
+                                size_t at_pos = name.find('@');
+                                if (at_pos != std::string::npos && at_pos + 1 < name.length()) {
+                                    compatible_printers->values.push_back(name.substr(at_pos + 1));
+                                    if (!read_only)
+                                        preset.save(nullptr);
+                                    BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << " added compatible_printers for preset: " << name;
+                                }
+                            }
+                        }
+
+                        preset.loaded = true;
+                        //BBS: add some workaround for previous incorrect settings
+                        if ((!preset.setting_id.empty())&&(preset.setting_id == preset.base_id))
+                            preset.setting_id.clear();
+                        //BBS: add config related logs
+                        BOOST_LOG_TRIVIAL(debug) << __FUNCTION__ << boost::format(", preset type %1%, name %2%, path %3%, is_system %4%, is_default %5% is_visible %6%")%Preset::get_type_string(m_type) %preset.name %preset.file %preset.is_system %preset.is_default %preset.is_visible;
+                        // add alias for custom filament preset
+                        set_custom_preset_alias(preset);
+                    } catch (const std::ifstream::failure &err) {
+                        ++m_errors;
+                        BOOST_LOG_TRIVIAL(error) << boost::format("The user-config cannot be loaded: %1%. Reason: %2%")%preset.file %err.what();
                         fs::path file_path(preset.file);
                         if (!read_only && fs::exists(file_path))
                             fs::remove(file_path);
                         file_path.replace_extension(".info");
                         if (!read_only && fs::exists(file_path))
                             fs::remove(file_path);
-                        BOOST_LOG_TRIVIAL(error) << boost::format("parse config %1% failed")%preset.file;
+                        //throw Slic3r::RuntimeError(std::string("The selected preset cannot be loaded: ") + preset.file + "\n\tReason: " + err.what());
+                    } catch (const std::runtime_error &err) {
                         ++m_errors;
-                        continue;
+                        BOOST_LOG_TRIVIAL(error) << boost::format("Failed loading the user-config file: %1%. Reason: %2%")%preset.file %err.what();
+                        //throw Slic3r::RuntimeError(std::string("Failed loading the preset file: ") + preset.file + "\n\tReason: " + err.what());
+                        fs::path file_path(preset.file);
+                        if (!read_only && fs::exists(file_path))
+                            fs::remove(file_path);
+                        file_path.replace_extension(".info");
+                        if (!read_only && fs::exists(file_path))
+                            fs::remove(file_path);
                     }
 
-                    std::string version_str = key_values[BBL_JSON_KEY_VERSION];
-                    boost::optional<Semver> version = Semver::parse(version_str);
-                    if (!version) continue;
-                    preset.version = *version;
+                    if (preset_loaded_fn != nullptr)
+                        preset_loaded_fn(preset);
 
-                    if (key_values.find(BBL_JSON_KEY_FILAMENT_ID) != key_values.end())
-                        preset.filament_id = key_values[BBL_JSON_KEY_FILAMENT_ID];
-                    if (key_values.find(BBL_JSON_KEY_DESCRIPTION) != key_values.end())
-                        preset.description = key_values[BBL_JSON_KEY_DESCRIPTION];
-                    if (key_values.find(BBL_JSON_KEY_INSTANTIATION) != key_values.end())
-                        preset.is_visible = key_values[BBL_JSON_KEY_INSTANTIATION] != "false";
-
-                    //Orca: find and use the inherit config as the base
-                    Preset* inherit_preset = nullptr;
-                    ConfigOption* inherits_config = config.option(BBL_JSON_KEY_INHERITS);
-
-                    // check inherits_config
-                    if (inherits_config) {
-                        ConfigOptionString * option_str = dynamic_cast<ConfigOptionString *> (inherits_config);
-                        std::string inherits_value = option_str->value;
-                        // Orca: try to find if the parent preset has been renamed
-                        inherit_preset = this->find_preset2(inherits_value);
-                        Preset::normalize_inherits(config, inherit_preset);
-                    } else {
-                        ;
-                    }
-                    const Preset& default_preset = this->default_preset_for(config);
-                    if (inherit_preset) {
-                        preset.config = inherit_preset->config;
-                        preset.filament_id = inherit_preset->filament_id;
-                        extend_default_config_length(config, false, {});
-                        preset.config.update_diff_values_to_child_config(config, extruder_id_name, extruder_variant_name, *key_set1, *key_set2);
-                    }
-                    else {
-                        auto inherits_config2 = dynamic_cast<ConfigOptionString *>(inherits_config);
-                        if ((inherits_config2 && !inherits_config2->value.empty())) {
-                            BOOST_LOG_TRIVIAL(error) << boost::format("can not find parent %1% for config %2%!")%inherits_config2->value %preset.file;
-                            ++m_errors;
-                            continue;
-                        }
-                        // We support custom root preset now
-                        // Find a default preset for the config. The PrintPresetCollection provides different default preset based on the "printer_technology" field.
-                        preset.config = default_preset.config;
-                        preset.config.apply(std::move(config));
-                        extend_default_config_length(preset.config, true, default_preset.config);
-                    }
-                    BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << " load preset: " << name << " and filament_id: " << preset.filament_id << " and base_id: " << preset.base_id;
-
-                    Preset::normalize(preset.config);
-                    // Report configuration fields, which are misplaced into a wrong group.
-                    std::string incorrect_keys = Preset::remove_invalid_keys(preset.config, default_preset.config);
-                    if (!incorrect_keys.empty()) {
-                        ++m_errors;
-                        BOOST_LOG_TRIVIAL(error)
-                            << "Error in a preset file: The preset \"" << preset.file
-                            << "\" contains the following incorrect keys: " << incorrect_keys << ", which were removed";
-                    }
-
-                    if (preset.type == Preset::TYPE_FILAMENT && preset.is_user() && preset.inherits().empty()) {
-                        auto compatible_printers = dynamic_cast<ConfigOptionStrings *>(preset.config.option("compatible_printers", true));
-                        if (compatible_printers && compatible_printers->values.empty()) {
-                            size_t at_pos = name.find('@');
-                            if (at_pos != std::string::npos && at_pos + 1 < name.length()) {
-                                compatible_printers->values.push_back(name.substr(at_pos + 1));
-                                if (!read_only)
-                                    preset.save(nullptr);
-                                BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << " added compatible_printers for preset: " << name;
-                            }
-                        }
-                    }
-
-                    preset.loaded = true;
-                    //BBS: add some workaround for previous incorrect settings
-                    if ((!preset.setting_id.empty())&&(preset.setting_id == preset.base_id))
-                        preset.setting_id.clear();
-                    //BBS: add config related logs
-                    BOOST_LOG_TRIVIAL(debug) << __FUNCTION__ << boost::format(", preset type %1%, name %2%, path %3%, is_system %4%, is_default %5% is_visible %6%")%Preset::get_type_string(m_type) %preset.name %preset.file %preset.is_system %preset.is_default %preset.is_visible;
-                    // add alias for custom filament preset
-                    set_custom_preset_alias(preset);
-                } catch (const std::ifstream::failure &err) {
-                    ++m_errors;
-                    BOOST_LOG_TRIVIAL(error) << boost::format("The user-config cannot be loaded: %1%. Reason: %2%")%preset.file %err.what();
-                    fs::path file_path(preset.file);
-                    if (!read_only && fs::exists(file_path))
-                        fs::remove(file_path);
-                    file_path.replace_extension(".info");
-                    if (!read_only && fs::exists(file_path))
-                        fs::remove(file_path);
-                    //throw Slic3r::RuntimeError(std::string("The selected preset cannot be loaded: ") + preset.file + "\n\tReason: " + err.what());
+                    presets_loaded.emplace_back(preset);
+                    BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << __LINE__ << " load config successful and preset name is:" << preset.name;
                 } catch (const std::runtime_error &err) {
-                    ++m_errors;
-                    BOOST_LOG_TRIVIAL(error) << boost::format("Failed loading the user-config file: %1%. Reason: %2%")%preset.file %err.what();
-                    //throw Slic3r::RuntimeError(std::string("Failed loading the preset file: ") + preset.file + "\n\tReason: " + err.what());
-                    fs::path file_path(preset.file);
-                    if (!read_only && fs::exists(file_path))
-                        fs::remove(file_path);
-                    file_path.replace_extension(".info");
-                    if (!read_only && fs::exists(file_path))
-                        fs::remove(file_path);
+                    errors_cummulative += err.what();
+                    errors_cummulative += "\n";
                 }
-
-                if (preset_loaded_fn != nullptr)
-                    preset_loaded_fn(preset);
-
-                presets_loaded.emplace_back(preset);
-                BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << __LINE__ << " load config successful and preset name is:" << preset.name;
-            } catch (const std::runtime_error &err) {
-                errors_cummulative += err.what();
-                errors_cummulative += "\n";
             }
         }
+
+        //ORCA: publish this pass so the next one can resolve children of what just loaded.
+        if (presets_loaded.size() > 0)
+            m_presets.insert(m_presets.end(), std::make_move_iterator(presets_loaded.begin()),
+                             std::make_move_iterator(presets_loaded.end()));
+        presets_loaded_total += presets_loaded.size();
+        presets_loaded.clear();
+        sort_presets();
+
+        //ORCA: stop when nothing is outstanding, or when a whole pass resolved nothing --
+        //      the remainder are then real missing parents, not ordering casualties.
+        if (deferred_next.empty() || deferred_next.size() == deferred.size()) {
+            deferred = std::move(deferred_next);
+            break;
+        }
+        deferred = std::move(deferred_next);
+        deferred_next.clear();
+        first_pass = false;
     }
-    if (presets_loaded.size() > 0)
-        m_presets.insert(m_presets.end(), std::make_move_iterator(presets_loaded.begin()), std::make_move_iterator(presets_loaded.end()));
-    sort_presets();
+
+    //ORCA: whatever survived every pass genuinely has no parent in this collection.
+    for (const auto &d : deferred) {
+        BOOST_LOG_TRIVIAL(error) << boost::format("can not find parent %1% for config %2%!")
+                                        % d.second.second % d.second.first;
+        ++m_errors;
+    }
+
     //BBS: add config related logs
-    BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << boost::format(": loaded %1% presets from %2%, type %3%")%presets_loaded.size() %dir %Preset::get_type_string(m_type);
+    BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << boost::format(": loaded %1% presets from %2%, type %3%")%presets_loaded_total %dir %Preset::get_type_string(m_type);
     //this->select_preset(first_visible_idx());
     if (! errors_cummulative.empty())
         throw Slic3r::RuntimeError(errors_cummulative);

--- a/tests/libslic3r/test_preset_bundle_loading.cpp
+++ b/tests/libslic3r/test_preset_bundle_loading.cpp
@@ -1495,4 +1495,65 @@ TEST_CASE("Config import confines zip entries, preset names and bundle ids to th
         CHECK(import(zip).empty());
         CHECK_FALSE(any_filename_contains(temp_dir.path(), "bundle-escape"));
     }
+
+TEST_CASE("A user preset inheriting a sibling in the same directory loads", "[Preset][Bundle][Regression]")
+{
+    ScopedTemporaryDir   temp_dir;
+    RenameTestCollection coll;
+
+    const fs::path dir = temp_dir.path() / PRESET_PRINT_NAME;
+    // The child is named so that it sorts BEFORE its parent: the parent has therefore not
+    // been seen yet when the child is first visited, and a single-pass loader discards it.
+    write_print_preset(coll.default_preset().config, dir / "AAA Child.json", "AAA Child", "ZZZ Parent");
+    write_print_preset(coll.default_preset().config, dir / "ZZZ Parent.json", "ZZZ Parent");
+
+    PresetsConfigSubstitutions substitutions;
+    coll.load_presets(temp_dir.path().string(), PRESET_PRINT_NAME, substitutions,
+                      ForwardCompatibilitySubstitutionRule::Disable);
+
+    REQUIRE(coll.find_preset("ZZZ Parent") != nullptr);
+    const Preset *child = coll.find_preset("AAA Child");
+    REQUIRE(child != nullptr);
+    CHECK(child->inherits() == "ZZZ Parent");
+    REQUIRE(coll.get_preset_parent(*child) != nullptr);
+    CHECK(coll.get_preset_parent(*child)->name == "ZZZ Parent");
+}
+
+TEST_CASE("A chain of user presets in one directory resolves to any depth", "[Preset][Bundle][Regression]")
+{
+    ScopedTemporaryDir   temp_dir;
+    RenameTestCollection coll;
+
+    // Written in the worst order for a single pass: every child precedes its parent.
+    const fs::path dir = temp_dir.path() / PRESET_PRINT_NAME;
+    write_print_preset(coll.default_preset().config, dir / "A Grandchild.json", "A Grandchild", "B Child");
+    write_print_preset(coll.default_preset().config, dir / "B Child.json", "B Child", "C Root");
+    write_print_preset(coll.default_preset().config, dir / "C Root.json", "C Root");
+
+    PresetsConfigSubstitutions substitutions;
+    coll.load_presets(temp_dir.path().string(), PRESET_PRINT_NAME, substitutions,
+                      ForwardCompatibilitySubstitutionRule::Disable);
+
+    for (const char *name : { "C Root", "B Child", "A Grandchild" })
+        REQUIRE(coll.find_preset(name) != nullptr);
+
+    const Preset *grandchild = coll.find_preset("A Grandchild");
+    REQUIRE(coll.get_preset_parent(*grandchild) != nullptr);
+    CHECK(coll.get_preset_parent(*grandchild)->name == "B Child");
+}
+
+TEST_CASE("A user preset whose parent does not exist is still rejected", "[Preset][Bundle][Regression]")
+{
+    ScopedTemporaryDir   temp_dir;
+    RenameTestCollection coll;
+
+    // Deferring must not turn a genuinely dangling parent into a silent success.
+    write_print_preset(coll.default_preset().config,
+                       temp_dir.path() / PRESET_PRINT_NAME / "Orphan.json", "Orphan", "No Such Parent");
+
+    PresetsConfigSubstitutions substitutions;
+    coll.load_presets(temp_dir.path().string(), PRESET_PRINT_NAME, substitutions,
+                      ForwardCompatibilitySubstitutionRule::Disable);
+
+    CHECK(coll.find_preset("Orphan") == nullptr);
 }


### PR DESCRIPTION
Fixes #15604.

# Description

`PresetCollection::load_presets()` resolves `inherits` with `find_preset2()`, which searches `m_presets`. The presets of a pass are accumulated in a local staging deque and merged into `m_presets` only *after* the loop — deliberately, as the comment there says:

```cpp
// Store the loaded presets into a new vector, otherwise the binary search for already existing presets would be broken.
```

So a preset cannot see a parent loaded by its own pass, and is discarded with `can not find parent X for config Y!` and `++m_errors`. System parents work only because they are loaded by an earlier call.

The practical consequence: a user preset inheriting a **system** preset loads, while one inheriting **another user preset** never reaches the bundle. A base material plus per-job variants is an ordinary way to organise profiles, and it does not survive a reload.

Since #15438 the CLI resolves `--load-settings` through the bundle, so this surfaces there as `-5 "Preset was not found in the loaded bundle"` — accurate, but it points at the resolver rather than at the preset having been dropped at load time. `load_presets()` is shared with the GUI, so such a preset is missing there too.

# Reproduction

Two files in `<datadir>/user/default/filament/`, bundled profiles otherwise:

`ZZRepro Base.json` — `"inherits": "Prusa Generic PETG @CORE One HF 0.4"`, `hot_plate_temp` 70
`ZZRepro Child.json` — `"inherits": "ZZRepro Base"`, `hot_plate_temp` 71

| filament | before | after |
|---|---|---|
| `ZZRepro Base` (inherits a system preset) | rc=0, `M140 S70` | rc=0, `M140 S70` |
| `ZZRepro Child` (inherits `ZZRepro Base`) | **rc=-5** | rc=0, `M140 S71` |

That the cause is pass ordering rather than anything about the presets is confirmed independently: `load_presets()` recurses into a `base` subdirectory first, in its own pass, and moving `ZZRepro Base.json` into `user/default/filament/base/` makes the child resolve on unpatched code, with the child's own value applied.

# Fix

Defer instead of discarding. Collect the unresolved presets, publish the pass, and retry. Repeat while a pass still resolves something, so chains of any depth load regardless of directory order. Only a pass that resolves nothing leaves genuinely missing parents, which are then reported exactly as before, with the same message and the same `m_errors` increments.

Termination: on a retry pass only deferred presets are visited, so `deferred_next` is always a subset of `deferred`. Its size therefore strictly decreases or stays equal; equal ends the loop. At most one pass per preset.

No preset that loaded before loads differently — the first pass is unchanged, and a preset that resolved then is merged then.

**The diff is mostly re-indentation** from wrapping the existing file loop in a retry loop; `git diff -w` shows the actual change, which is about 40 lines.

# Tests

Three cases in `tests/libslic3r/test_preset_bundle_loading.cpp`:

- a child that sorts **before** its parent, so the parent is unseen when the child is first visited — this fails without the change;
- a three-deep chain written in the worst possible order, covering depth as well as ordering;
- a dangling parent that must **still** be rejected, so deferral cannot turn a real error into a silent success.

# Verification

`libslic3r` suite: **354 test cases, 58405 assertions, all passing**, with the three above included.

To be precise about what that run covered: it was built with this exact `Preset.cpp` (byte-identical to the commit here) on `58bf267fd` rather than on current `main`, because rebuilding across the 24 commits since would not have changed the file under test. The tests upstream has added to this file since then concern config-import zip confinement, not the inheritance path; CI here runs the suite on the real base.

Also exercised end to end on a real datadir where this bug was found: four user filament presets that inherit other user presets went from `-5` to slicing correctly, and a CLI regression suite of 45 checks stayed green.

### The GUI is affected too, and this fixes it there as well

The description above argues from the code that `load_presets()` is shared, so such presets are missing in the GUI too. That is now measured rather than inferred.

Two builds differing only by this commit, each launched against its own identical copy of the same datadir, same steps to the filament dropdown:

| | user presets listed |
|---|---|
| without this change | **12** |
| with this change | **16** |

The four that appear are exactly the ones whose `inherits` names another user preset:

```
ANYCUBIC PETG HS            inherits ANYCUBIC PETG
ANYCUBIC PETG Small Parts   inherits ANYCUBIC PETG
ANYCUBIC PETG Tarock        inherits ANYCUBIC PETG
ANYCUBIC PLA HS Summer      inherits ANYCUBIC PLA HS
```

Without the change the dropdown's *User presets* section ends at `SCOUT-LIVEZ ASA` and runs straight into `System presets`, so the list is complete rather than truncated — those four are genuinely absent from the collection, not merely scrolled out of view. So the effect is not confined to `--load-settings`: these presets have been invisible in the preset selector as well.

# Scope

2 files. `src/libslic3r/Preset.cpp` (+~40 logic lines, the rest re-indentation) and `tests/libslic3r/test_preset_bundle_loading.cpp` (+61). No public API change, no profile change, no GUI change.

