### PR TITLE
Fix brim ears around nested contours

### DIFF
--- a/src/libslic3r/Brim.cpp
+++ b/src/libslic3r/Brim.cpp
@@ -447,7 +447,8 @@ static ExPolygons outer_inner_brim_area(const Print& print,
             bool               has_brim_auto = object->config().brim_type == btAutoBrim;
             const bool         use_auto_brim_ears = object->config().brim_type == btEar;
             const bool         use_brim_ears = object->config().brim_type == btPainted;
-            const bool         use_inner_brim_ears = (use_auto_brim_ears || use_brim_ears) && !object->config().brim_ears_outer_only.value;
+            const bool         use_outer_only_brim_ears = (use_auto_brim_ears || use_brim_ears) && object->config().brim_ears_outer_only.value;
+            const bool         use_inner_brim_ears = (use_auto_brim_ears || use_brim_ears) && !use_outer_only_brim_ears;
             const bool         has_inner_brim = brim_type == btInnerOnly || brim_type == btOuterAndInner || use_inner_brim_ears;
             const bool         has_outer_brim = brim_type == btOuterOnly || brim_type == btOuterAndInner || brim_type == btAutoBrim || use_auto_brim_ears || use_brim_ears;
             coord_t            ear_detection_length = scale_(object->config().brim_ears_detection_length.value);
@@ -535,7 +536,14 @@ static ExPolygons outer_inner_brim_area(const Print& print,
                                 }else {
                                     outerExpoly = offset_ex(innerExpoly, brim_width_mod, jtRound, SCALED_RESOLUTION);
                                 }
-                                append(brim_area_object, diff_ex(outerExpoly, innerExpoly));
+                                // When ears are allowed inside holes, subtract the actual model
+                                // shape rather than treating its outer contour as solid. Otherwise
+                                // an ear generated for a ring erases its own central hole and only
+                                // partial overlap from a neighbouring ear can remain there.
+                                const ExPolygons brim_exclusion =
+                                    (use_auto_brim_ears || use_brim_ears) && !use_outer_only_brim_ears ?
+                                        offset_ex(ex_poly, brim_offset, jtRound, SCALED_RESOLUTION) : innerExpoly;
+                                append(brim_area_object, diff_ex(outerExpoly, brim_exclusion));
                             }
                             if (has_inner_brim) {
                                 ExPolygons outerExpoly;
@@ -559,6 +567,19 @@ static ExPolygons outer_inner_brim_area(const Print& print,
                             append(holes_object, ex_poly_holes_reversed);
                         }
                     }
+                if (use_outer_only_brim_ears && !brim_area_object.empty()) {
+                    // Treat nested material islands as enclosed geometry rather than as
+                    // independent outer contours. Unioning only the contours fills every
+                    // enclosed section while preserving genuinely separate outer islands.
+                    Polygons exterior_contours;
+                    exterior_contours.reserve(brim_slices->size());
+                    for (const ExPolygon& slice : *brim_slices)
+                        exterior_contours.push_back(slice.contour);
+                    const ExPolygons exterior_silhouette = union_ex(exterior_contours);
+                    brim_area_object = diff_ex(
+                        brim_area_object,
+                        offset_ex(exterior_silhouette, brim_offset, jtRound, SCALED_RESOLUTION));
+                }
                 auto objectIsland = offset_ex(*brim_slices, brim_offset, jtRound, SCALED_RESOLUTION);
                 append(no_brim_area_object, objectIsland);
 

--- a/src/libslic3r/Brim.cpp
+++ b/src/libslic3r/Brim.cpp
@@ -10,6 +10,7 @@
 #include <algorithm>
 #include <cstdint>
 #include <limits>
+#include <set>
 #include <tbb/parallel_for.h>
 
 #include <boost/log/trivial.hpp>
@@ -433,6 +434,8 @@ static ExPolygons outer_inner_brim_area(const Print& print,
         brimToWrite.insert({ objectWithExtruder.first, {true,true} });
 
     ExPolygons objectIslands;
+    ExPolygons outer_only_brim_ear_no_brim_area;
+    std::set<ObjectInstanceID> outer_only_brim_ear_instances;
     for (unsigned int extruderNo : printExtruders) {
         ++extruderNo;
         for (const auto& objectWithExtruder : objPrintVec) {
@@ -567,18 +570,23 @@ static ExPolygons outer_inner_brim_area(const Print& print,
                             append(holes_object, ex_poly_holes_reversed);
                         }
                     }
+                // Unioning only the contours fills every enclosed section while
+                // preserving genuinely separate outer islands. Keep every object's
+                // exterior silhouette so an outer-only ear from another object cannot
+                // leave a detached remnant inside one of this object's holes.
+                Polygons exterior_contours;
+                exterior_contours.reserve(brim_slices->size());
+                for (const ExPolygon& slice : *brim_slices)
+                    exterior_contours.push_back(slice.contour);
+                const ExPolygons exterior_silhouette = union_ex(exterior_contours);
+                const ExPolygons exterior_no_brim_area =
+                    offset_ex(exterior_silhouette, brim_offset, jtRound, SCALED_RESOLUTION);
                 if (use_outer_only_brim_ears && !brim_area_object.empty()) {
-                    // Treat nested material islands as enclosed geometry rather than as
-                    // independent outer contours. Unioning only the contours fills every
-                    // enclosed section while preserving genuinely separate outer islands.
-                    Polygons exterior_contours;
-                    exterior_contours.reserve(brim_slices->size());
-                    for (const ExPolygon& slice : *brim_slices)
-                        exterior_contours.push_back(slice.contour);
-                    const ExPolygons exterior_silhouette = union_ex(exterior_contours);
+                    // Treat nested material islands in the source object as enclosed
+                    // geometry rather than as independent outer contours.
                     brim_area_object = diff_ex(
                         brim_area_object,
-                        offset_ex(exterior_silhouette, brim_offset, jtRound, SCALED_RESOLUTION));
+                        exterior_no_brim_area);
                 }
                 auto objectIsland = offset_ex(*brim_slices, brim_offset, jtRound, SCALED_RESOLUTION);
                 append(no_brim_area_object, objectIsland);
@@ -586,8 +594,12 @@ static ExPolygons outer_inner_brim_area(const Print& print,
                 brimToWrite.at(object->id()).obj = false;
                 for (size_t instance_idx = 0; instance_idx < object->instances().size(); ++instance_idx) {
                     const PrintInstance& instance = object->instances()[instance_idx];
+                    const ObjectInstanceID instance_id { object->id(), instance_idx };
                     if (!brim_area_object.empty())
                         append_and_translate(brim_area_object, instance, instance_idx, brimAreaMap);
+                    if (use_outer_only_brim_ears)
+                        outer_only_brim_ear_instances.insert(instance_id);
+                    append_and_translate(outer_only_brim_ear_no_brim_area, exterior_no_brim_area, instance);
                     append_and_translate(no_brim_area, no_brim_area_object, instance);
                     append_and_translate(holes, holes_object, instance);
                     append_and_translate(objectIslands, objectIsland, instance);
@@ -668,8 +680,12 @@ static ExPolygons outer_inner_brim_area(const Print& print,
         }
 
         for (auto& [key, areas] : brimAreaMap)
-            if (key.object_id == object->id())
-                areas = diff_ex(areas, extruder_no_brim_area);
+            if (key.object_id == object->id()) {
+                ExPolygons instance_no_brim_area = extruder_no_brim_area;
+                if (outer_only_brim_ear_instances.count(key) != 0)
+                    expolygons_append(instance_no_brim_area, outer_only_brim_ear_no_brim_area);
+                areas = diff_ex(areas, instance_no_brim_area);
+            }
 
     }
 

--- a/tests/fff_print/test_skirt_brim.cpp
+++ b/tests/fff_print/test_skirt_brim.cpp
@@ -8,7 +8,10 @@
 
 #include <boost/algorithm/string.hpp>
 
+#include <algorithm>
+#include <array>
 #include <cmath>
+#include <limits>
 
 #include "test_helpers.hpp" // get access to init_print, etc
 
@@ -55,6 +58,83 @@ static bool brim_enters_first_layer_hole(Print &print)
                     return true;
     }
     return false;
+}
+
+static bool brim_fills_small_first_layer_holes(Print &print, double max_hole_area)
+{
+    const PrintObject *object = print.get_object(0);
+    Polygons holes;
+    for (const ExPolygon &slice : object->layers().front()->lslices)
+        for (const Polygon &hole : slice.holes)
+            if (std::abs(hole.area() * SCALING_FACTOR * SCALING_FACTOR) < max_hole_area)
+                holes.push_back(hole);
+
+    const Vec3d plate_origin = print.get_plate_origin();
+    Point shift = object->instances().front().shift_without_plate_offset();
+    shift += Point(scaled(plate_origin.x()), scaled(plate_origin.y()));
+    for (Polygon &hole : holes)
+        hole.translate(shift);
+
+    if (holes.empty())
+        return false;
+
+    std::vector<std::array<bool, 4>> covered_sides(holes.size());
+    for (const auto &kv : print.get_brimMap()) {
+        Polylines brim_paths;
+        kv.second.collect_polylines(brim_paths);
+        for (const Polyline &path : brim_paths)
+            for (const Point &point : path.points) {
+                for (size_t hole_idx = 0; hole_idx < holes.size(); ++hole_idx) {
+                    const Polygon &hole = holes[hole_idx];
+                    if (!hole.contains(point))
+                        continue;
+                    const BoundingBox bbox = hole.bounding_box();
+                    const Point center = bbox.center();
+                    const coord_t x_margin = bbox.size().x() / 8;
+                    const coord_t y_margin = bbox.size().y() / 8;
+                    covered_sides[hole_idx][0] |= point.x() < center.x() - x_margin;
+                    covered_sides[hole_idx][1] |= point.x() > center.x() + x_margin;
+                    covered_sides[hole_idx][2] |= point.y() < center.y() - y_margin;
+                    covered_sides[hole_idx][3] |= point.y() > center.y() + y_margin;
+                }
+            }
+    }
+
+    return std::all_of(covered_sides.begin(), covered_sides.end(), [](const auto &sides) {
+        return std::all_of(sides.begin(), sides.end(), [](bool covered) { return covered; });
+    });
+}
+
+// A frame whose hole contains a separate material island. This produces nested
+// first-layer contours: outer contour, hole, then enclosed material contour.
+static TriangleMesh frame_with_nested_island()
+{
+    TriangleMesh frame = mesh(TestMesh::cube_with_hole);
+    TriangleMesh island = make_cube(4, 4, 10);
+    island.translate(8, 8, 0);
+    frame.merge(island);
+    return frame;
+}
+
+// A large frame enclosing two ring-shaped material islands. Their centres are
+// 20 mm apart, reproducing the case where neighbouring ear overlap only
+// partially filled the rings' central holes.
+static TriangleMesh frame_with_adjacent_nested_rings()
+{
+    TriangleMesh frame = mesh(TestMesh::cube_with_hole);
+    frame.scale(Vec3f(4.f, 4.f, 1.f));
+
+    TriangleMesh left_ring = mesh(TestMesh::cube_with_hole);
+    left_ring.scale(Vec3f(0.25f, 0.25f, 1.f));
+    left_ring.translate(27.5, 37.5, 0);
+
+    TriangleMesh right_ring = mesh(TestMesh::cube_with_hole);
+    right_ring.scale(Vec3f(0.25f, 0.25f, 1.f));
+    right_ring.translate(47.5, 37.5, 0);
+
+    frame.merge(left_ring);
+    frame.merge(right_ring);
+    return frame;
 }
 
 // The span is skirt_height layers, or every layer when a draft shield is on (forced even at
@@ -270,6 +350,44 @@ TEST_CASE("Outer-only brim ears stay out of model holes", "[SkirtBrim]")
     }
 }
 
+TEST_CASE("Outer-only brim ears stay out of holes around nested islands", "[SkirtBrim]")
+{
+    const bool outer_only = GENERATE(false, true);
+    DYNAMIC_SECTION("brim_ears_outer_only=" << outer_only) {
+        Print print;
+        init_and_process_print({ frame_with_nested_island() }, print, {
+            { "skirt_loops",                0 },
+            { "brim_type",                  "brim_ears" },
+            { "brim_width",                 4 },
+            { "brim_ears_max_angle",        125 },
+            { "brim_ears_detection_length", 0 },
+            { "brim_ears_outer_only",       outer_only },
+            { "initial_layer_line_width",   0.5 },
+        });
+
+        REQUIRE(brim_loop_count(print) > 0);
+        CHECK(brim_enters_first_layer_hole(print) != outer_only);
+    }
+}
+
+TEST_CASE("Automatic brim ears fill holes covered by their radius", "[SkirtBrim]")
+{
+    Print print;
+    init_and_process_print({ frame_with_adjacent_nested_rings() }, print, {
+        { "skirt_loops",                0 },
+        { "brim_type",                  "brim_ears" },
+        { "brim_width",                 20 },
+        { "brim_object_gap",            0.1 },
+        { "brim_ears_max_angle",        135 },
+        { "brim_ears_detection_length", 1 },
+        { "brim_ears_outer_only",       false },
+        { "initial_layer_line_width",   0.6 },
+    });
+
+    REQUIRE(brim_loop_count(print) > 0);
+    CHECK(brim_fills_small_first_layer_holes(print, 10.0));
+}
+
 TEST_CASE("Painted brim ear radius controls sliced size", "[SkirtBrim]")
 {
     constexpr double ear_radius = 10.0;
@@ -373,6 +491,63 @@ TEST_CASE("Outer-only painted brim ears stay out of model holes", "[SkirtBrim]")
 
     REQUIRE(brim_loop_count(print) > 0);
     CHECK_FALSE(brim_enters_first_layer_hole(print));
+}
+
+TEST_CASE("Outer-only painted brim ears stay out of holes around nested islands", "[SkirtBrim]")
+{
+    const bool outer_only = GENERATE(false, true);
+    DynamicPrintConfig config = DynamicPrintConfig::full_print_config();
+    config.set_deserialize_strict({
+        { "skirt_loops",                0 },
+        { "brim_type",                  "painted" },
+        { "brim_object_gap",            0.1 },
+        { "brim_ears_outer_only",       outer_only },
+        { "initial_layer_line_width",   0.5 },
+    });
+
+    Print print;
+    Model model;
+    init_print({ frame_with_nested_island() }, print, model, config);
+    print.process();
+
+    const PrintObject *object = print.get_object(0);
+    REQUIRE(object->layers().front()->lslices.size() >= 2);
+    const ExPolygon &frame_slice = *std::max_element(
+        object->layers().front()->lslices.begin(),
+        object->layers().front()->lslices.end(),
+        [](const ExPolygon &lhs, const ExPolygon &rhs) { return lhs.area() < rhs.area(); });
+    REQUIRE(!frame_slice.holes.empty());
+
+    // Paint a large ear at the midpoint of the frame's lowest outer edge so
+    // that its disc overlaps both the enclosing hole and its material island.
+    Point ear_center;
+    coord_t lowest_midpoint_y = std::numeric_limits<coord_t>::max();
+    for (size_t i = 0; i < frame_slice.contour.points.size(); ++i) {
+        const Point &a = frame_slice.contour.points[i];
+        const Point &b = frame_slice.contour.points[(i + 1) % frame_slice.contour.points.size()];
+        const Point midpoint((a.x() + b.x()) / 2, (a.y() + b.y()) / 2);
+        if (midpoint.y() < lowest_midpoint_y) {
+            lowest_midpoint_y = midpoint.y();
+            ear_center = midpoint;
+        }
+    }
+
+    Transform3d model_transform = model.objects.front()->instances.front()->get_transformation().get_matrix_no_offset();
+    const Point &center_offset = object->center_offset();
+    model_transform = model_transform.pretranslate(
+        Vec3d(-unscale<double>(center_offset.x()), -unscale<double>(center_offset.y()), 0));
+    Vec3d model_pos = model_transform.inverse() *
+        Vec3d(unscale<double>(ear_center.x()), unscale<double>(ear_center.y()), 0);
+    model_pos.z() = model.objects.front()->raw_mesh_bounding_box().min.z() - 0.0001;
+    model.objects.front()->brim_points = {
+        BrimPoint(model_pos.cast<float>(), 14.f),
+    };
+
+    print.apply(model, config);
+    print.process();
+
+    REQUIRE(brim_loop_count(print) > 0);
+    CHECK(brim_enters_first_layer_hole(print) != outer_only);
 }
 
 SCENARIO("Skirt has the configured number of loops", "[SkirtBrim]") {

--- a/tests/fff_print/test_skirt_brim.cpp
+++ b/tests/fff_print/test_skirt_brim.cpp
@@ -137,6 +137,17 @@ static TriangleMesh frame_with_adjacent_nested_rings()
     return frame;
 }
 
+// A separate object below the frame whose automatic ears reach across the
+// frame wall and into its hole. The wall clips the connecting part of the ear,
+// leaving a detached remnant in the other object's hole unless outer-only
+// exclusion is applied across object boundaries.
+static TriangleMesh separate_part_below_frame()
+{
+    TriangleMesh part = make_cube(4, 4, 10);
+    part.translate(8, -6, 0);
+    return part;
+}
+
 // The span is skirt_height layers, or every layer when a draft shield is on (forced even at
 // height 0); per-object skirts are rejected in By object printing (no room between objects).
 TEST_CASE("Skirt is emitted once per layer it spans", "[SkirtBrim]")
@@ -365,6 +376,37 @@ TEST_CASE("Outer-only brim ears stay out of holes around nested islands", "[Skir
             { "initial_layer_line_width",   0.5 },
         });
 
+        REQUIRE(brim_loop_count(print) > 0);
+        CHECK(brim_enters_first_layer_hole(print) != outer_only);
+    }
+}
+
+TEST_CASE("Outer-only brim ears stay out of holes in other objects", "[SkirtBrim]")
+{
+    const bool outer_only = GENERATE(false, true);
+    DYNAMIC_SECTION("brim_ears_outer_only=" << outer_only) {
+        Print print;
+        Model model;
+        DynamicPrintConfig config = DynamicPrintConfig::full_print_config();
+        config.set_deserialize_strict({
+            { "skirt_loops",                0 },
+            { "brim_type",                  "brim_ears" },
+            { "brim_width",                 13 },
+            { "brim_object_gap",            0.1 },
+            { "brim_ears_max_angle",        125 },
+            { "brim_ears_detection_length", 1 },
+            { "brim_ears_outer_only",       outer_only },
+            { "initial_layer_line_width",   0.6 },
+        });
+
+        std::vector<TriangleMesh> objects {
+            mesh(TestMesh::cube_with_hole),
+            separate_part_below_frame(),
+        };
+        init_print(std::move(objects), print, model, config, nullptr, false);
+        print.process();
+
+        REQUIRE(print.objects().size() == 2);
         REQUIRE(brim_loop_count(print) > 0);
         CHECK(brim_enters_first_layer_hole(print) != outer_only);
     }


### PR DESCRIPTION
This replaces #15129, which was accidentally closed during a branch rename. It contains the same tested fixes and validation.

## What changed

- Treat nested material islands as enclosed geometry when `Brim ears outer only` is enabled, preventing automatic and painted ears from entering holes or enclosed sections.
- Clip outer-only ear areas against the exterior silhouette of every first-layer object instance, preventing an ear from one part from leaving detached remnants inside another part's holes.
- When outer-only is disabled, subtract the actual first-layer model shape from ear geometry instead of treating each outer contour as solid. Holes covered by an ear radius are therefore filled completely rather than only receiving partial overlap from a neighbouring ear.
- Add regression coverage for automatic and painted ears around nested islands, complete automatic-ear coverage of small holes, and separate objects whose ear geometry crosses into another object's hole.

## Why

This is a follow-up to #15015. Nested material islands are represented as separate outer contours, so ears generated from them could survive inside an enclosing hole even with outer-only enabled.

The same ownership problem occurred across separate objects: ordinary object clipping removed the connecting portion of an overlapping ear at another object's wall but left detached ear fragments inside that object's holes. Outer-only exclusion now uses every first-layer object's exterior silhouette while remaining limited to ear maps with the option enabled.

There was also an existing issue in the all-contours path: an outer ear generated for a ring subtracted the ring's outer contour as a solid area, erasing its own central hole from the ear. Only overlap from a neighbouring ear survived, producing semicircular brim fragments instead of filling holes that were within the configured ear radius.

## User impact

- With `Brim ears outer only` enabled, enclosed holes and nested sections remain clear, including when ears from nearby parts overlap them.
- With it disabled, holes covered by automatic or painted ears receive the complete intended brim coverage.

## Validation

- `fff_print_tests.exe '[SkirtBrim]'`: 102 assertions in 21 test cases passed.
- Windows Release GUI build completed and the installed build was hash-verified against its build outputs.
- Manually tested with several models and combinations of automatic and painted ears, with outer-only both enabled and disabled.
- Recreated the reported multi-part arrangement and confirmed the detached brim remnants are removed.