### PR TITLE
Fix bridge flow invalidation for zero-gap supports

### DIFF
--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -1511,13 +1511,9 @@ bool PrintObject::invalidate_state_by_config_options(
             steps.emplace_back(posPerimeters);
             steps.emplace_back(posSupportMaterial);
         } else if (opt_key == "bridge_flow" || opt_key == "internal_bridge_flow") {
-            if (m_config.support_top_z_distance > 0.) {
-            	// Only invalidate due to bridging if bridging is enabled.
-            	// If later "support_top_z_distance" is modified, the complete PrintObject is invalidated anyway.
-            	steps.emplace_back(posPerimeters);
-            	steps.emplace_back(posInfill);
-	            steps.emplace_back(posSupportMaterial);
-	        }
+            steps.emplace_back(posPerimeters);
+            steps.emplace_back(posInfill);
+            steps.emplace_back(posSupportMaterial);
         } else if (
                 opt_key == "wall_generator"
             || opt_key == "wall_transition_length"


### PR DESCRIPTION
### Description

Fixed bridge flow changes not fully taking effect after re-slicing when the support top Z distance is set to `0`.

Previously, changing **Bridge flow** or **Internal bridge flow** could leave the already generated bridge paths unchanged. This resulted in a stale preview and could also leave generated output inconsistent with the current settings, particularly for normal bridge flow.

Bridge flow changes now correctly regenerate the affected perimeter, infill, and support geometry regardless of the configured support top Z distance.


Fixes #15618

<!--
> A guide for users on how to download the artifacts from this PR.
-->

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
