### PR TITLE
build: clear 5 warning categories across 19 sites

### DIFF
--- a/src/libslic3r/Emboss.cpp
+++ b/src/libslic3r/Emboss.cpp
@@ -968,10 +968,10 @@ EmbossStyles Emboss::get_font_list_by_register() {
 }
 
 // TODO: Fix global function
-bool CALLBACK EnumFamCallBack(LPLOGFONT       lplf,
-                              LPNEWTEXTMETRIC lpntm,
-                              DWORD           FontType,
-                              LPVOID          aFontList)
+int CALLBACK EnumFamCallBack(const LOGFONT    *lplf,
+                             const TEXTMETRIC *lpntm,
+                             DWORD             FontType,
+                             LPARAM            aFontList)
 {
     std::vector<std::wstring> *fontList =
         (std::vector<std::wstring> *) (aFontList);
@@ -988,7 +988,7 @@ EmbossStyles Emboss::get_font_list_by_enumeration() {
 
     HDC                       hDC = GetDC(NULL);
     std::vector<std::wstring> font_names;
-    EnumFontFamilies(hDC, (LPCTSTR) NULL, (FONTENUMPROC) EnumFamCallBack,
+    EnumFontFamilies(hDC, (LPCTSTR) NULL, EnumFamCallBack,
                      (LPARAM) &font_names);
 
     EmbossStyles font_list;

--- a/src/libslic3r/Fill/FillAdaptive.cpp
+++ b/src/libslic3r/Fill/FillAdaptive.cpp
@@ -1395,8 +1395,8 @@ void Filler::_fill_surface_single(
         }
 #endif /* ADAPTIVE_CUBIC_INFILL_DEBUG_OUTPUT */
 
-        const auto hook_length     = coordf_t(std::min<float>(std::numeric_limits<coord_t>::max(), scale_(params.anchor_length)));
-        const auto hook_length_max = coordf_t(std::min<float>(std::numeric_limits<coord_t>::max(), scale_(params.anchor_length_max)));
+        const auto hook_length     = coordf_t(scale_(params.anchor_length));
+        const auto hook_length_max = coordf_t(scale_(params.anchor_length_max));
 
     Polylines all_polylines_with_hooks = all_polylines.size() > 1 ? connect_lines_using_hooks(std::move(all_polylines), expolygon, this->spacing, hook_length, hook_length_max) : std::move(all_polylines);
 

--- a/src/libslic3r/GCode/ToolOrderUtils.cpp
+++ b/src/libslic3r/GCode/ToolOrderUtils.cpp
@@ -910,7 +910,7 @@ namespace Slic3r
 
         unsigned int iterations = (1 << all_extruders.size());
         unsigned int final_state = iterations - 1;
-        std::vector<std::vector<float>>cache(iterations, std::vector<float>(all_extruders.size(), 0x7fffffff));
+        std::vector<std::vector<float>>cache(iterations, std::vector<float>(all_extruders.size(), std::numeric_limits<float>::max()));
         std::vector<std::vector<int>>prev(iterations, std::vector<int>(all_extruders.size(), -1));
         cache[1][0] = 0.;
         for (unsigned int state = 0; state < iterations; ++state) {

--- a/src/libslic3r/Line.cpp
+++ b/src/libslic3r/Line.cpp
@@ -30,8 +30,8 @@ bool Line::intersection_infinite(const Line &other, Point* point) const
         return false;
     double t1 = cross2(v12, v2) / denom;
     Vec2d result = (a1 + t1 * v1);
-    if (result.x() > std::numeric_limits<coord_t>::max() || result.x() < std::numeric_limits<coord_t>::lowest() ||
-        result.y() > std::numeric_limits<coord_t>::max() || result.y() < std::numeric_limits<coord_t>::lowest()) {
+    if (result.x() > double(std::numeric_limits<coord_t>::max()) || result.x() < double(std::numeric_limits<coord_t>::lowest()) ||
+        result.y() > double(std::numeric_limits<coord_t>::max()) || result.y() < double(std::numeric_limits<coord_t>::lowest())) {
         // Intersection has at least one of the coordinates much bigger (or smaller) than coord_t maximum value (or minimum).
         // So it can not be stored into the Point without integer overflows. That could mean that input lines are parallel or near parallel.
         return false;

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -1635,7 +1635,9 @@ bool PrintObject::invalidate_step(PrintObjectStep step)
 bool PrintObject::invalidate_all_steps()
 {
 	// First call the "invalidate" functions, which may cancel background processing.
-    bool result = Inherited::invalidate_all_steps() | m_print->invalidate_all_steps();
+    const bool inherited_invalidated = Inherited::invalidate_all_steps();
+    const bool print_invalidated     = m_print->invalidate_all_steps();
+    bool result = inherited_invalidated || print_invalidated;
 	// Then reset some of the depending values.
 	m_slicing_params.valid = false;
 	return result;

--- a/src/libslic3r/SLAPrint.cpp
+++ b/src/libslic3r/SLAPrint.cpp
@@ -1007,7 +1007,9 @@ bool SLAPrintObject::invalidate_step(SLAPrintObjectStep step)
 
 bool SLAPrintObject::invalidate_all_steps()
 {
-    return Inherited::invalidate_all_steps() | m_print->invalidate_all_steps();
+    const bool inherited_invalidated = Inherited::invalidate_all_steps();
+    const bool print_invalidated     = m_print->invalidate_all_steps();
+    return inherited_invalidated || print_invalidated;
 }
 
 double SLAPrintObject::get_elevation() const {

--- a/src/slic3r/GUI/DeviceCore/DevMapping.cpp
+++ b/src/slic3r/GUI/DeviceCore/DevMapping.cpp
@@ -1,3 +1,5 @@
+#include <limits>
+
 #include <nlohmann/json.hpp>
 #include "DevMapping.h"
 #include "DevFilaSystem.h"
@@ -270,7 +272,7 @@ namespace Slic3r
         std::set<int> picked_tar;
         for (int k = 0; k < distance_map.size(); k++)
         {
-            float min_val = INT_MAX;
+            float min_val = std::numeric_limits<float>::max();
             int picked_src_idx = -1;
             int picked_tar_idx = -1;
             for (int i = 0; i < distance_map.size(); i++)

--- a/src/slic3r/GUI/MeshUtils.cpp
+++ b/src/slic3r/GUI/MeshUtils.cpp
@@ -297,7 +297,7 @@ void MeshClipper::recalculate_triangles()
             // it so it lies on our line. This will be the figure to subtract
             // from the cut. The coordinates must not overflow after the transform,
             // make the rectangle a bit smaller.
-            const coord_t size = (std::numeric_limits<coord_t>::max()/2 - scale_(std::max(std::abs(e * a), std::abs(e * b)))) / 4;
+            const coord_t size = (double(std::numeric_limits<coord_t>::max()/2) - scale_(std::max(std::abs(e * a), std::abs(e * b)))) / 4;
             Polygons ep {Polygon({Point(-size, 0), Point(size, 0), Point(size, 2*size), Point(-size, 2*size)})};
             ep.front().rotate(angle);
             ep.front().translate(scale_(-e * a), scale_(-e * b));
@@ -352,7 +352,7 @@ void MeshClipper::recalculate_triangles()
 
             // To prevent overflow after scaling, downscale the input if needed:
             double extra_scale = 1.;
-            coord_t limit = coord_t(std::min(std::numeric_limits<coord_t>::max() / (2. * std::max(1., scale_x)), std::numeric_limits<coord_t>::max() / (2. * std::max(1., scale_y))));
+            coord_t limit = coord_t(std::min(double(std::numeric_limits<coord_t>::max()) / (2. * std::max(1., scale_x)), double(std::numeric_limits<coord_t>::max()) / (2. * std::max(1., scale_y))));
             coord_t max_coord = 0;
             for (const Point& pt : exp.contour)
                 max_coord = std::max(max_coord, std::max(std::abs(pt.x()), std::abs(pt.y())));

--- a/src/slic3r/GUI/Printer/PrinterFileSystem.cpp
+++ b/src/slic3r/GUI/Printer/PrinterFileSystem.cpp
@@ -1803,7 +1803,7 @@ static void* get_function(const char* name)
         return function;
 
 #if defined(_MSC_VER) || defined(_WIN32)
-    function = GetProcAddress(module, name);
+    function = reinterpret_cast<void*>(GetProcAddress(module, name));
 #else
     function = dlsym(module, name);
 #endif

--- a/src/slic3r/Utils/BBLNetworkPlugin.cpp
+++ b/src/slic3r/Utils/BBLNetworkPlugin.cpp
@@ -349,7 +349,7 @@ void* BBLNetworkPlugin::get_function(const char* name)
         return function;
 
 #if defined(_MSC_VER) || defined(_WIN32)
-    function = GetProcAddress(m_networking_module, name);
+    function = reinterpret_cast<void*>(GetProcAddress(m_networking_module, name));
 #else
     function = dlsym(m_networking_module, name);
 #endif

--- a/src/slic3r/Utils/BBLPrinterAgent.cpp
+++ b/src/slic3r/Utils/BBLPrinterAgent.cpp
@@ -8,6 +8,7 @@
 #include <nlohmann/json.hpp>
 using json = nlohmann::json;
 
+#include <type_traits>
 #include <unordered_map>
 
 namespace Slic3r {
@@ -90,6 +91,16 @@ OnMessageFn to_orca_messages(OnMessageFn fn)
     return [fn = std::move(fn)](std::string dev_id, std::string msg) { fn(std::move(dev_id), BBLPrinterAgent::to_orca_payload(std::move(msg))); };
 }
 
+// Retypes a plug-in entry point for an older plug-in generation. The detour through the
+// generic function pointer marks the signature change as deliberate, which a direct cast
+// between two signatures does not.
+template <typename To, typename From>
+To as_abi(From fn)
+{
+    static_assert(std::is_function_v<std::remove_pointer_t<From>>, "as_abi retypes a function pointer");
+    return reinterpret_cast<To>(reinterpret_cast<void (*)()>(fn));
+}
+
 } // namespace
 
 std::string BBLPrinterAgent::to_orca_filament_id(const std::string& printer_filament_id) const
@@ -141,7 +152,7 @@ int BBLPrinterAgent::send_message(std::string dev_id, std::string json_str, int 
         // series through the legacy form would silently drop MessageFlag sign/encrypt.
         switch (plugin.network_abi()) {
         case NetworkAbi::Legacy: {
-            auto legacy_func = reinterpret_cast<func_send_message_legacy>(func);
+            auto legacy_func = as_abi<func_send_message_legacy>(func);
             return legacy_func(agent, std::move(dev_id), std::move(json_str), qos);
         }
         case NetworkAbi::V0203:
@@ -185,7 +196,7 @@ int BBLPrinterAgent::send_message_to_printer(std::string dev_id, std::string jso
     if (func && agent) {
         switch (plugin.network_abi()) {
         case NetworkAbi::Legacy: {
-            auto legacy_func = reinterpret_cast<func_send_message_to_printer_legacy>(func);
+            auto legacy_func = as_abi<func_send_message_to_printer_legacy>(func);
             return legacy_func(agent, std::move(dev_id), std::move(json_str), qos);
         }
         case NetworkAbi::V0203:
@@ -275,7 +286,7 @@ int BBLPrinterAgent::bind(std::string dev_ip, std::string dev_id, std::string de
         switch (plugin.network_abi()) {
         case NetworkAbi::Legacy:
         case NetworkAbi::V0203: {
-            auto older_func = reinterpret_cast<func_bind_pre0208>(func);
+            auto older_func = as_abi<func_bind_pre0208>(func);
             return older_func(agent, dev_ip, dev_id, sec_link, timezone, improved, update_fn);
         }
         case NetworkAbi::Current:
@@ -436,9 +447,9 @@ int dispatch_start(CurrentFn func, PrintParams& params, const CallbackFns&... ca
     params.ams_mapping_info = BBLPrinterAgent::from_orca_payload(std::move(params.ams_mapping_info));
     switch (plugin.network_abi()) {
     case NetworkAbi::Legacy:
-        return reinterpret_cast<LegacyFn>(func)(agent, BBLNetworkPlugin::as_legacy(params), callbacks...);
+        return as_abi<LegacyFn>(func)(agent, BBLNetworkPlugin::as_legacy(params), callbacks...);
     case NetworkAbi::V0203:
-        return reinterpret_cast<Fn0203>(func)(agent, BBLNetworkPlugin::as_0203(params), callbacks...);
+        return as_abi<Fn0203>(func)(agent, BBLNetworkPlugin::as_0203(params), callbacks...);
     case NetworkAbi::Current:
         return func(agent, std::move(params), callbacks...);
     default:

--- a/src/slic3r/Utils/PresetUpdater.cpp
+++ b/src/slic3r/Utils/PresetUpdater.cpp
@@ -1620,7 +1620,7 @@ void PresetUpdater::priv::check_new_vendors(const std::set<std::string>& system_
                         Http::get(download_url_str)
                             .timeout_connect(5)
                             .on_progress(check_cancel)
-                            .on_error([&vendor_id, &retry_count, max_retries](std::string body, std::string error, unsigned http_status) {
+                            .on_error([&vendor_id, &retry_count](std::string body, std::string error, unsigned http_status) {
                                 BOOST_LOG_TRIVIAL(warning) << "[Orca Updater] download failed for new vendor " << vendor_id
                                                            << " (attempt " << retry_count << "/" << max_retries << "): " << error;
                             })


### PR DESCRIPTION
# Description

Five categories from the #15374 inventory.

**`-Wimplicit-const-int-float-conversion`** (9)
- `FillAdaptive.cpp` clamped the hook length to `coord_t`'s max. That is Prusa-original from when `coord_t` was 32-bit and 1000mm was about the most that fit; with int64 it can never fire, and `FillBase.cpp`'s rectilinear path already uses `scale_(params.anchor_length)` unclamped. The clamp is gone.
- `Line.cpp` compares a double against `coord_t`'s max as an overflow guard. The conversion is written out now; 2^63-1 rounding up to 2^63 changes nothing.
- `MeshUtils.cpp`, same, two sites.
- `ToolOrderUtils.cpp` seeded a float min-search with a 2^31 int. It is `std::numeric_limits<float>::max()` now, which the same function already uses a few lines later.
- `DevMapping.cpp`, same.

**`-Wcast-function-type-mismatch`** (8)
- `Emboss.cpp` declared its font enumeration callback with the wrong signature and cast it to `FONTENUMPROC` at the call. It is declared as a `FONTENUMPROC` now and the cast is gone.
- `BBLPrinterAgent.cpp` has five ABI shims, retyping a plug-in entry point to the narrower signature an older plug-in generation takes. They use a small `as_abi` helper that casts via the generic function pointer type. Both GCC and clang leave that cast alone; it is their documented escape for an intentional signature change. A `static_assert` keeps the helper to function pointers, which the direct casts did not.

**`-Wmicrosoft-cast`** (2)
- `PrinterFileSystem.cpp` assigns a `FARPROC` to a `void*`, written as a `reinterpret_cast` now.
- `BBLNetworkPlugin.cpp`, same.

**`-Wbitwise-instead-of-logical`** (2)
- `PrintObject.cpp` used `|` so that both `invalidate_all_steps()` calls run. Both results are evaluated into locals first and combined with `||` after, which keeps both calls.
- `SLAPrint.cpp`, same.

**`-Wunused-lambda-capture`** (1)
- `PresetUpdater.cpp` captured `max_retries`, a `const int` with a constant initializer. The same mistake as the three #15596 fixed; this one arrived via #15416 and is the second regression in that category since it was cleared.

# Screenshots/Recordings/Graphs

None.

## Tests

None. The two sentinel changes only matter for a cost above 2^31, which nothing produces. The `Emboss.cpp` callback now has the types the API declares, and the `BBLPrinterAgent.cpp` casts produce the same function pointers through one extra no-op conversion.

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
