### PR TITLE
build: clear 10 driver warnings from CGAL's fp flag pair under clang-cl

### DIFF
--- a/src/libslic3r/CMakeLists.txt
+++ b/src/libslic3r/CMakeLists.txt
@@ -558,6 +558,12 @@ if (_opts)
     target_compile_options(libslic3r_cgal PRIVATE "${_opts_bad}")
 endif()
 
+if (IS_CLANG_CL)
+    # CGAL passes /fp:strict /fp:except-. clang-cl reports the second as overriding part of
+    # the first; the settings cc1 receives are the same ones MSVC produces from that pair.
+    target_compile_options(libslic3r_cgal PRIVATE -Wno-overriding-option)
+endif ()
+
 target_link_libraries(libslic3r_cgal PRIVATE ${_cgal_tgt} admesh libigl mcut boost_libs)
 
 if (MSVC AND "${CMAKE_SIZEOF_VOID_P}" STREQUAL "4") # 32 bit MSVC workaround


### PR DESCRIPTION
# Description

Ten `-Woverriding-option` warnings, two per translation unit on the five files that link CGAL. Driver warnings with no file and line, so they never counted toward #15374, but they are in every clang-cl build log.

`CGAL_SetupCGALDependencies.cmake` puts `/fp:strict` and `/fp:except-` on CGAL's interface for every compiler CMake calls MSVC, clang-cl included. clang-cl expands `/fp:strict` to `-ffp-model=strict`, a bundle that includes `-ffp-exception-behavior=strict`, so `/fp:except-` overrides one component and the driver reports it. cc1 still receives contraction off, rounding-math on, exceptions ignored, which is what MSVC produces from the pair.

Keeping `/fp:strict` and setting the exception mode with `-Xclang -ffp-exception-behavior=ignore`, which the driver forwards without its override check, produces the same generated code with no warning, so the fix is in CGAL's config. That is CGAL/cgal#9168, where their maintainers have already said the behavior is correct. This suppresses it on `libslic3r_cgal` until then, next to the block that already edits CGAL's interface options.

# Screenshots/Recordings/Graphs

None.

## Tests

None. Compile options only; no generated code changes.

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
