### PR TITLE
Add --reload and --reload-and-slice single-instance CLI triggers

### DIFF
--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -12282,6 +12282,16 @@ CLIMiscConfigDef::CLIMiscConfigDef()
     def->tooltip = L("Automatically export current configuration to the specified file.");
 */
 
+    def = this->add("reload", coBool);
+    def->label = L("Reload from disk");
+    def->tooltip = L("Sent to a running single-instance GUI: reload all objects from disk, without slicing.");
+    def->set_default_value(new ConfigOptionBool(false));
+
+    def = this->add("reload_and_slice", coBool);
+    def->label = L("Reload and slice");
+    def->tooltip = L("Sent to a running single-instance GUI: reload all objects from disk, slice the current plate, show Preview.");
+    def->set_default_value(new ConfigOptionBool(false));
+
     def = this->add("datadir", coString);
     def->label = L("Data directory");
     def->tooltip = L("Load and store settings at the given directory. This is useful for maintaining different profiles or including configurations from a network storage.");

--- a/src/slic3r/GUI/InstanceCheck.cpp
+++ b/src/slic3r/GUI/InstanceCheck.cpp
@@ -365,6 +365,8 @@ namespace GUI {
 wxDEFINE_EVENT(EVT_LOAD_MODEL_OTHER_INSTANCE, LoadFromOtherInstanceEvent);
 wxDEFINE_EVENT(EVT_START_DOWNLOAD_OTHER_INSTANCE, StartDownloadOtherInstanceEvent);
 wxDEFINE_EVENT(EVT_INSTANCE_GO_TO_FRONT, InstanceGoToFrontEvent);
+wxDEFINE_EVENT(EVT_RELOAD_OTHER_INSTANCE, SimpleEvent);
+wxDEFINE_EVENT(EVT_RELOAD_AND_SLICE_OTHER_INSTANCE, SimpleEvent);
 
 void OtherInstanceMessageHandler::init(wxEvtHandler* callback_evt_handler)
 {
@@ -493,6 +495,8 @@ void OtherInstanceMessageHandler::handle_message(const std::string& message)
 
 	std::vector<boost::filesystem::path> paths;
 	std::vector<std::string> downloads;
+	bool reload_only = false;
+	bool reload_and_slice = false;
 	boost::regex re(R"(^(orcaslicer|prusaslicer|cura|bambustudio):\/\/open[\/]?\?file=)", boost::regbase::icase);
 	boost::regex re2(R"(^(bambustudioopen):\/\/)", boost::regex::icase);
 	boost::smatch results;
@@ -500,6 +504,8 @@ void OtherInstanceMessageHandler::handle_message(const std::string& message)
 	// Skip the first argument, it is the path to the slicer executable.
 	auto it = args.begin();
 	for (++ it; it != args.end(); ++ it) {
+		if (*it == "--reload") { reload_only = true; continue; }
+		if (*it == "--reload-and-slice") { reload_and_slice = true; continue; }
 		boost::filesystem::path p = MessageHandlerInternal::get_path(*it);
 		if (! p.string().empty())
 			paths.emplace_back(p);
@@ -515,6 +521,14 @@ void OtherInstanceMessageHandler::handle_message(const std::string& message)
 	if (!downloads.empty())
 	{
 		wxPostEvent(m_callback_evt_handler, StartDownloadOtherInstanceEvent(GUI::EVT_START_DOWNLOAD_OTHER_INSTANCE, std::vector<std::string>(std::move(downloads))));
+	}
+	if (reload_only)
+	{
+		wxPostEvent(m_callback_evt_handler, SimpleEvent(EVT_RELOAD_OTHER_INSTANCE));
+	}
+	if (reload_and_slice)
+	{
+		wxPostEvent(m_callback_evt_handler, SimpleEvent(EVT_RELOAD_AND_SLICE_OTHER_INSTANCE));
 	}
 }
 

--- a/src/slic3r/GUI/InstanceCheck.hpp
+++ b/src/slic3r/GUI/InstanceCheck.hpp
@@ -50,6 +50,9 @@ wxDECLARE_EVENT(EVT_START_DOWNLOAD_OTHER_INSTANCE, StartDownloadOtherInstanceEve
 using InstanceGoToFrontEvent = SimpleEvent;
 wxDECLARE_EVENT(EVT_INSTANCE_GO_TO_FRONT, InstanceGoToFrontEvent);
 
+wxDECLARE_EVENT(EVT_RELOAD_OTHER_INSTANCE, SimpleEvent);
+wxDECLARE_EVENT(EVT_RELOAD_AND_SLICE_OTHER_INSTANCE, SimpleEvent);
+
 class OtherInstanceMessageHandler
 {
 public:

--- a/src/slic3r/GUI/MainFrame.cpp
+++ b/src/slic3r/GUI/MainFrame.cpp
@@ -701,7 +701,7 @@ DPIFrame(NULL, wxID_ANY, "", wxDefaultPosition, wxDefaultSize, BORDERLESS_FRAME_
             }
             return;}
 #endif
-        if (evt.CmdDown() && evt.GetKeyCode() == 'R') { if (m_slice_enable) { wxGetApp().plater()->update(true, true); wxPostEvent(m_plater, SimpleEvent(EVT_GLTOOLBAR_SLICE_PLATE)); this->m_tabpanel->SelectPageByName(TAB_ID_PREVIEW); } return; }
+        if (evt.CmdDown() && evt.GetKeyCode() == 'R') { this->reload_and_slice(); return; }
         if (evt.CmdDown() && evt.ShiftDown() && evt.GetKeyCode() == 'G') {
             m_plater->apply_background_progress();
             m_print_enable = get_enable_print_status();
@@ -4086,6 +4086,24 @@ void MainFrame::request_select_tab(const wxString& id)
     wxCommandEvent* evt = new wxCommandEvent(EVT_SELECT_TAB);
     evt->SetString(id);
     wxQueueEvent(this, evt);
+}
+
+void MainFrame::reload_and_slice()
+{
+    wxGetApp().plater()->update(true, true);
+    // reload_all_from_disk() (used to reload from an external trigger) ends with its own
+    // Plater::priv::update() call, which only *schedules* the model-changed invalidation via
+    // a 500ms debounce timer (schedule_background_process()) rather than applying it right
+    // away. Checking the slice-enable state immediately afterward races that timer: about
+    // half the time it hasn't fired yet, so is_slice_result_valid() still reads stale
+    // "already sliced" and we'd skip the request entirely. Force the current plate's slice
+    // result invalid directly instead of waiting on that timer.
+    wxGetApp().plater()->get_partplate_list().get_curr_plate()->update_slice_result_valid_state(false);
+    m_slice_enable = get_enable_slice_status();
+    if (m_slice_enable) {
+        wxPostEvent(m_plater, SimpleEvent(EVT_GLTOOLBAR_SLICE_PLATE));
+        this->m_tabpanel->SelectPageByName(TAB_ID_PREVIEW);
+    }
 }
 
 int MainFrame::get_calibration_curr_tab() {

--- a/src/slic3r/GUI/MainFrame.hpp
+++ b/src/slic3r/GUI/MainFrame.hpp
@@ -329,6 +329,8 @@ public:
     void        select_tab(wxPanel* panel);
     void        select_tab(const wxString& id = wxString());
     void        request_select_tab(const wxString& id);
+    // Slice the current plate and switch to Preview, same as Cmd+R.
+    void        reload_and_slice();
     int         get_calibration_curr_tab();
     void        select_view(const std::string& direction);
     // Propagate changed configuration from the Tab to the Plater and save changes to the AppConfig

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -6750,6 +6750,7 @@ struct Plater::priv
     std::string m_broken_shown_sig;
     bool auto_reslice_pending {false};
     bool auto_reslice_after_cancel {false};
+    bool reload_and_slice_after_cancel {false};
     bool m_is_publishing {false};
     int m_is_RightClickInLeftUI{-1};
     int m_cur_slice_plate;
@@ -7864,6 +7865,29 @@ Plater::priv::priv(Plater *q, MainFrame *main_frame)
     });
     this->q->Bind(EVT_INSTANCE_GO_TO_FRONT, [this](InstanceGoToFrontEvent &) {
         bring_instance_forward();
+    });
+    this->q->Bind(EVT_RELOAD_OTHER_INSTANCE, [this](SimpleEvent&) {
+        BOOST_LOG_TRIVIAL(trace) << "Received reload from other instance event.";
+        wxGetApp().mainframe->Show();
+        wxGetApp().mainframe->Raise();
+        this->q->reload_all_from_disk();
+    });
+    this->q->Bind(EVT_RELOAD_AND_SLICE_OTHER_INSTANCE, [this](SimpleEvent&) {
+        BOOST_LOG_TRIVIAL(trace) << "Received reload-and-slice from other instance event.";
+        wxGetApp().mainframe->Show();
+        wxGetApp().mainframe->Raise();
+        this->q->reload_all_from_disk();
+        if (this->background_process.running() || this->m_is_slicing) {
+            // A previous reload-and-slice trigger's job is still in flight. Cancel it and
+            // restart once the cancellation completes (see on_process_completed()), instead
+            // of calling reload_and_slice() directly: MainFrame::get_enable_slice_status()
+            // would see a slice as still "in progress" and silently skip this request,
+            // leaving the freshly reloaded geometry unsliced.
+            this->reload_and_slice_after_cancel = true;
+            this->background_process.stop();
+        } else {
+            wxGetApp().mainframe->reload_and_slice();
+        }
     });
     wxGetApp().other_instance_message_handler()->init(this->q);
 
@@ -12597,6 +12621,10 @@ void Plater::priv::on_process_completed(SlicingProcessCompletedEvent &evt)
     if (auto_reslice_after_cancel) {
         auto_reslice_after_cancel = false;
         schedule_auto_reslice_if_needed();
+    }
+    if (reload_and_slice_after_cancel) {
+        reload_and_slice_after_cancel = false;
+        wxGetApp().mainframe->reload_and_slice();
     }
 
     BOOST_LOG_TRIVIAL(debug) << __FUNCTION__ << boost::format(", exit.");


### PR DESCRIPTION
## Summary

Adds two CLI flags that a running single-instance OrcaSlicer GUI responds to via the existing instance-check message channel (the same mechanism already used to forward file paths and download URLs to a running instance):

- `--reload`: reload all objects from disk (`Plater::reload_all_from_disk()`), without slicing.
- `--reload-and-slice`: reload from disk, then slice the current plate and switch to the Preview tab. The slice+preview logic is factored out of the existing Cmd+R handler into a new `MainFrame::reload_and_slice()`, shared by both the shortcut and the new trigger.

This lets an external script — e.g. one invoked after a CAD tool overwrites the source STEP/STL file — drive reload + slice + preview on an already-running GUI instance with no manual interaction, closing the loop between a parametric CAD change and seeing the resulting toolpaths.

## Why this shape

- `reload_and_slice()` forces the current plate's slice result invalid directly (`update_slice_result_valid_state(false)`) rather than relying on `Plater::update()`'s own invalidation path. `reload_from_disk()` ends with its own `Plater::priv::update()` call, which only *schedules* the model-changed invalidation via a 500ms debounce timer (`schedule_background_process()`) rather than applying it synchronously. Checking slice-enable state immediately after reload otherwise races that timer and intermittently reads a stale "already sliced" status.
- It also cancels and restarts any slice already in flight from a previous trigger (`reload_and_slice_after_cancel`, consumed in `on_process_completed()`), since `MainFrame::get_enable_slice_status()` treats an in-progress slice as a reason to silently skip the new request, which would otherwise drop the most recent reload's slice intent when triggers arrive faster than a slice completes.

## Related issues

Related to #8703 (F5 reload shortcut), #8186 (RPC/live reload), #6711 (auto-reload on change) — this adds a scriptable trigger rather than filesystem-watching auto-reload, so it composes with any external file-watcher a user already has.

## Test plan

- [x] Verified `--reload-and-slice` is accepted by `read_cli` and forwarded through `process_command_line()` (confirmed via `--help` output and app log: `message from other instance: ...;--reload-and-slice`).
- [x] macOS, single-instance mode enabled: triggering `--reload` reloads the selected STEP part from disk, preserving its plate position/orientation, and does not slice or change tabs.
- [x] Triggering `--reload-and-slice` reloads, slices the current plate, and switches to the Preview tab.
- [x] Verified reliability across repeated back-to-back invocations (previously slicing was intermittently skipped roughly every other invocation due to the debounce-timer race described above; fixed and reverified with debug-level logging).
- [ ] Linux/Windows untested — `handle_message()` on Linux runs on a DBus listener thread; the new code only posts `wxEvent`s from it, consistent with the existing handlers in that function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)