### PR TITLE
build: clear 12 platform-gated warnings the x64 census could not see

### DIFF
--- a/src/libslic3r/PresetBundle.cpp
+++ b/src/libslic3r/PresetBundle.cpp
@@ -4981,7 +4981,7 @@ static void apply_mixed_config_relocations(DynamicPrintConfig&                  
     case coBools: {
         auto*       live   = static_cast<ConfigOptionBools*>(opt);
         const auto* frozen = static_cast<const ConfigOptionBools*>(snapshot.get());
-        for (const auto [from, to] : moves) {
+        for (const auto& [from, to] : moves) {
             const unsigned char cell = from < frozen->values.size() ? frozen->values[from] : 0;
             if (live->values.size() <= to)
                 live->values.resize(to + 1, 0);
@@ -4992,7 +4992,7 @@ static void apply_mixed_config_relocations(DynamicPrintConfig&                  
     case coStrings: {
         auto*       live   = static_cast<ConfigOptionStrings*>(opt);
         const auto* frozen = static_cast<const ConfigOptionStrings*>(snapshot.get());
-        for (const auto [from, to] : moves) {
+        for (const auto& [from, to] : moves) {
             const std::string cell = from < frozen->values.size() ? frozen->values[from] : std::string();
             if (live->values.size() <= to)
                 live->values.resize(to + 1, std::string{});
@@ -5028,7 +5028,7 @@ static void apply_receiver_mix_relocations(DynamicPrintConfig&                  
         auto*             live   = static_cast<ConfigOptionBools*>(opt);
         std::unique_ptr<ConfigOption> snapshot(opt->clone());
         const auto*       frozen  = static_cast<const ConfigOptionBools*>(snapshot.get());
-        for (const auto [from, to] : moves) {
+        for (const auto& [from, to] : moves) {
             const bool cell = from < frozen->values.size() ? frozen->values[from] : false;
             if (live->values.size() <= to)
                 live->values.resize(to + 1, false);
@@ -5044,7 +5044,7 @@ static void apply_receiver_mix_relocations(DynamicPrintConfig&                  
         auto*             live   = static_cast<ConfigOptionStrings*>(opt);
         std::unique_ptr<ConfigOption> snapshot(opt->clone());
         const auto*       frozen  = static_cast<const ConfigOptionStrings*>(snapshot.get());
-        for (const auto [from, to] : moves) {
+        for (const auto& [from, to] : moves) {
             const std::string cell = from < frozen->values.size() ? frozen->values[from] : std::string();
             if (live->values.size() <= to)
                 live->values.resize(to + 1, std::string{});
@@ -5060,7 +5060,7 @@ static void apply_receiver_mix_relocations(DynamicPrintConfig&                  
         auto*             live   = static_cast<ConfigOptionInts*>(opt);
         std::unique_ptr<ConfigOption> snapshot(opt->clone());
         const auto*       frozen  = static_cast<const ConfigOptionInts*>(snapshot.get());
-        for (const auto [from, to] : moves) {
+        for (const auto& [from, to] : moves) {
             const int cell = from < frozen->values.size() ? frozen->values[from] : 0;
             if (live->values.size() <= to)
                 live->values.resize(to + 1, 0);
@@ -5087,7 +5087,7 @@ static void apply_receiver_mix_relocations(DynamicPrintConfig&                  
     move_ints("filament_volume_map");
     {
         const std::vector<std::vector<std::string>> frozen = ams_multi_color_filment;
-        for (const auto [from, to] : moves) {
+        for (const auto& [from, to] : moves) {
             const std::vector<std::string> cell = from < frozen.size() ? frozen[from] : std::vector<std::string>();
             if (ams_multi_color_filment.size() <= to)
                 ams_multi_color_filment.resize(to + 1, std::vector<std::string>{});

--- a/src/libslic3r/Thread.cpp
+++ b/src/libslic3r/Thread.cpp
@@ -30,6 +30,13 @@ static HMODULE					s_hKernel32 = nullptr;
 static SetThreadDescriptionType s_fnSetThreadDescription = nullptr;
 static GetThreadDescriptionType	s_fnGetThreadDescription = nullptr;
 
+// GetProcAddress returns FARPROC; retyping it to the real signature is what
+// -Wcast-function-type-mismatch reports. The detour through a generic function
+// pointer marks the retype as intentional.
+template<typename Fn> static Fn load_proc(HMODULE module, const char* name) {
+	return reinterpret_cast<Fn>(reinterpret_cast<void(*)()>(::GetProcAddress(module, name)));
+}
+
 static bool WindowsGetSetThreadNameAPIInitialize()
 {
 	if (! s_SetGetThreadDescriptionInitialized) {
@@ -37,8 +44,8 @@ static bool WindowsGetSetThreadNameAPIInitialize()
 		// to initialize 
 		s_hKernel32 = LoadLibraryW(L"Kernel32.dll");
 		if (s_hKernel32) {
-			s_fnSetThreadDescription = (SetThreadDescriptionType)::GetProcAddress(s_hKernel32, "SetThreadDescription");
-			s_fnGetThreadDescription = (GetThreadDescriptionType)::GetProcAddress(s_hKernel32, "GetThreadDescription");
+			s_fnSetThreadDescription = load_proc<SetThreadDescriptionType>(s_hKernel32, "SetThreadDescription");
+			s_fnGetThreadDescription = load_proc<GetThreadDescriptionType>(s_hKernel32, "GetThreadDescription");
 		}
 		s_SetGetThreadDescriptionInitialized = true;
 	}

--- a/src/libslic3r/Thread.cpp
+++ b/src/libslic3r/Thread.cpp
@@ -30,9 +30,7 @@ static HMODULE					s_hKernel32 = nullptr;
 static SetThreadDescriptionType s_fnSetThreadDescription = nullptr;
 static GetThreadDescriptionType	s_fnGetThreadDescription = nullptr;
 
-// GetProcAddress returns FARPROC; retyping it to the real signature is what
-// -Wcast-function-type-mismatch reports. The detour through a generic function
-// pointer marks the retype as intentional.
+// Convert the FARPROC from GetProcAddress to Fn through a generic function pointer.
 template<typename Fn> static Fn load_proc(HMODULE module, const char* name) {
 	return reinterpret_cast<Fn>(reinterpret_cast<void(*)()>(::GetProcAddress(module, name)));
 }

--- a/src/slic3r/GUI/InstanceCheck.hpp
+++ b/src/slic3r/GUI/InstanceCheck.hpp
@@ -87,7 +87,6 @@ private:
 	std::condition_variable m_thread_stop_condition;
 	mutable std::mutex 		m_thread_stop_mutex;
 	bool 					m_stop{ false };
-	bool					m_start{ true };
 	
 	// background thread method
 	void    listen();

--- a/src/slic3r/GUI/SelectMachinePop.hpp
+++ b/src/slic3r/GUI/SelectMachinePop.hpp
@@ -183,7 +183,9 @@ private:
     HyperLink*                        m_hyperlink{nullptr}; // ORCA
     wxBoxSizer *                      m_sizer_my_devices{nullptr};
     wxBoxSizer *                      m_sizer_other_devices{nullptr};
+#if defined(__WINDOWS__)
     wxBoxSizer *                      m_sizer_search_bar{nullptr};
+#endif
     wxSearchCtrl*                     m_search_bar{nullptr};
     wxScrolledWindow *                m_scrolledWindow{nullptr};
     wxTimer *                         m_refresh_timer{nullptr};

--- a/src/slic3r/GUI/TextureImportDialog.cpp
+++ b/src/slic3r/GUI/TextureImportDialog.cpp
@@ -134,7 +134,9 @@ public:
     }
 
 private:
+#if defined(__WXMSW__) || defined(__APPLE__)
     int m_suspended_count = 0;
+#endif
 };
 
 static bool needs_filament_swatch_border(const wxColour& colour)

--- a/src/slic3r/Utils/Serial.cpp
+++ b/src/slic3r/Utils/Serial.cpp
@@ -331,7 +331,9 @@ void Serial::set_baud_rate(unsigned baud_rate)
 			speed_t c_ispeed;
 			speed_t c_ospeed;
 		};
+#ifndef BOTHER
 #define BOTHER CBAUDEX
+#endif
 
 		termios2 ios;
 		handle_errno(::ioctl(handle, TCGETS2, &ios));


### PR DESCRIPTION
# Description

Twelve warnings across six files, all in categories the #15374 inventory already cleared on x64 clang-cl. Each is live only on a platform the census never compiles, so a full `-Werror` build across the seven CI targets surfaced them.

- `InstanceCheck.hpp` (`-Wunused-private-field`, Linux): `m_start` is declared in the `__linux__`-only listener block and read nowhere. Removed.
- `TextureImportDialog.cpp` (`-Wunused-private-field`, Linux): `m_suspended_count` is read only under `__WXMSW__ || __APPLE__`. Declaration guarded to match.
- `SelectMachinePop.hpp` (`-Wunused-private-field`, macOS): `m_sizer_search_bar` is used only under `__WINDOWS__`. Declaration guarded to match.
- `PresetBundle.cpp` (`-Wrange-loop-construct`, macOS): six `for (const auto [from, to] : moves)` copy each pair out of a `std::vector<std::pair<size_t, size_t>>`. Bind by const reference.
- `Thread.cpp` (`-Wcast-function-type-mismatch`, Windows arm64): the two `GetProcAddress` casts retype `FARPROC`; the `__stdcall` typedefs collapse to `FARPROC` on x64, so only arm64 reports it. Routed through a `load_proc` helper that casts via a generic function pointer.
- `Serial.cpp` (`-Wmacro-redefined`, Flatpak): the `BOTHER` fallback define clashes with the Flatpak SDK's glibc. Guarded with `#ifndef` so it does not redefine the system's.

# Screenshots/Recordings/Graphs

None.

## Tests

None. Nothing here changes at runtime. The removed field was dead, the guarded fields now exist only where they were already used, the range loops bind a reference instead of copying, the arm64 cast produces the same pointer, and the `BOTHER` fallback keeps its value where it applies.

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
