### PR TITLE
fix(device): restore reliable Bambu LAN connections

### DIFF
--- a/src/slic3r/GUI/DeviceCore/DevManager.cpp
+++ b/src/slic3r/GUI/DeviceCore/DevManager.cpp
@@ -683,16 +683,24 @@ namespace Slic3r
     {
         if (selected_machine.empty()) return nullptr;
 
+        // A logged-in account may contain a cloud object with the same id as a saved LAN
+        // printer. LAN messages are routed to the local object, so prefer it while the selected
+        // device is configured for LAN access. Returning the cloud duplicate here leaves the UI
+        // checking stale counters even though full local status messages are arriving.
+        auto local_it = localMachineList.find(selected_machine);
+        if (local_it != localMachineList.end() && local_it->second->has_access_right()
+            && local_it->second->is_lan_mode_printer())
+            return local_it->second;
+
         MachineObject* obj = get_user_machine(selected_machine, GUI::wxGetApp().get_printer_cloud_provider());
         if (obj)
             return obj;
 
         // return local machine has access code
-        auto it = localMachineList.find(selected_machine);
-        if (it != localMachineList.end())
+        if (local_it != localMachineList.end())
         {
-            if (it->second->has_access_right())
-                return it->second;
+            if (local_it->second->has_access_right())
+                return local_it->second;
         }
         return nullptr;
     }
@@ -756,17 +764,9 @@ namespace Slic3r
     {
         std::map<std::string, MachineObject*> result;
 
-        for (auto it = userMachineList.begin(); it != userMachineList.end(); it++)
-        {
-            if (!it->second || (!agent_id.empty() && it->second->printer_agent_id != agent_id))
-                continue;
-
-            if (!it->second->is_lan_mode_printer())
-            {
-                result.insert(std::make_pair(it->first, it->second));
-            }
-        }
-
+        // A saved LAN printer and a cloud printer can share the same device id. Prefer the LAN
+        // object before discovery refreshes the cloud object's connection type, otherwise startup
+        // timing decides whether set_selected_machine() opens a local or cloud connection.
         for (auto it = localMachineList.begin(); it != localMachineList.end(); it++)
         {
             if (!it->second || (!agent_id.empty() && it->second->printer_agent_id != agent_id))
@@ -774,10 +774,21 @@ namespace Slic3r
 
             if (it->second->has_access_right() && it->second->is_avaliable() && it->second->is_lan_mode_printer())
             {
-                // remove redundant in userMachineList
+                result.emplace(it->first, it->second);
+            }
+        }
+
+        for (auto it = userMachineList.begin(); it != userMachineList.end(); it++)
+        {
+            if (!it->second || (!agent_id.empty() && it->second->printer_agent_id != agent_id))
+                continue;
+
+            if (!it->second->is_lan_mode_printer())
+            {
+                // Keep the saved LAN object when the cloud list contains the same printer.
                 if (result.find(it->first) == result.end())
                 {
-                    result.emplace(std::make_pair(it->first, it->second));
+                    result.emplace(it->first, it->second);
                 }
             }
         }

--- a/src/slic3r/GUI/DeviceCore/DevManager.cpp
+++ b/src/slic3r/GUI/DeviceCore/DevManager.cpp
@@ -30,15 +30,31 @@ namespace {
     {
         const auto& machines = config->get_local_machines();
         auto        it       = machines.find(dev_id);
-        if (it != machines.end() && it->second.printer_agent_id == agent_id && !it->second.access_code.empty())
-            return it->second.access_code;
+        const bool  is_bbl   = agent_id == Slic3r::BBL_PRINTER_AGENT_ID || agent_id.empty();
+        const bool  has_scoped_code = it != machines.end() && it->second.printer_agent_id == agent_id
+                                   && !it->second.access_code.empty();
 
-        if (agent_id == Slic3r::BBL_PRINTER_AGENT_ID || agent_id.empty()) {
-            std::string code = config->get("access_code", dev_id);
-            if (code.empty())
-                code = config->get("user_access_code", dev_id);
-            return code;
+        if (is_bbl) {
+            const std::string legacy_code      = config->get("access_code", dev_id);
+            const std::string legacy_user_code = config->get("user_access_code", dev_id);
+
+            // Before the access-code fields were merged, MachineObject::get_access_code()
+            // preferred user_access_code. The initial migration reversed that precedence and
+            // could persist the lower-priority access_code into the new scoped machine record.
+            // Detect that copied value and preserve the old effective credential.
+            if (has_scoped_code && !legacy_user_code.empty() && it->second.access_code == legacy_code
+                && legacy_user_code != legacy_code)
+                return legacy_user_code;
+
+            if (has_scoped_code)
+                return it->second.access_code;
+            if (!legacy_user_code.empty())
+                return legacy_user_code;
+            return legacy_code;
         }
+
+        if (has_scoped_code)
+            return it->second.access_code;
         return "";
     }
 }

--- a/src/slic3r/GUI/DeviceManager.cpp
+++ b/src/slic3r/GUI/DeviceManager.cpp
@@ -2682,22 +2682,28 @@ void MachineObject::set_online_state(bool on_off)
 
 bool MachineObject::is_info_ready(bool check_version) const
 {
-    if (check_version && module_vers.empty())
+    const auto curr_time = std::chrono::system_clock::now();
+    const auto push_age = std::chrono::duration_cast<std::chrono::milliseconds>(curr_time - last_push_time);
+    const bool has_recent_full_status = m_full_msg_count > 0 && m_push_count > 0
+                                     && push_age.count() >= 0 && push_age.count() < PUSHINFO_TIMEOUT;
+
+    // X2D firmware may omit the legacy info/get_version reply while still returning a complete
+    // push_status payload. Its status payload includes the capability flags used by the UI, so a
+    // recent full message is sufficient proof of readiness for this model.
+    if (check_version && module_vers.empty() && !(printer_type == "N6" && has_recent_full_status))
     {
         BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << ": not ready, failed to check version";
         return false;
     }
 
-    std::chrono::system_clock::time_point curr_time = std::chrono::system_clock::now();
-    auto diff = std::chrono::duration_cast<std::chrono::microseconds>(last_push_time - curr_time);
-    if (m_full_msg_count > 0 && m_push_count > 0 && diff.count() < PUSHINFO_TIMEOUT) {
+    if (has_recent_full_status) {
         return true;
     }
 
     BOOST_LOG_TRIVIAL(info) << __FUNCTION__
         << ": not ready, m_full_msg_count=" << m_full_msg_count
         << ", m_push_count=" << m_push_count
-        << ", diff.count()=" << diff.count()
+        << ", push_age=" << push_age.count()
         << ", dev_id=" << dev_id;
     return false;
 }


### PR DESCRIPTION
# Description

Bambu LAN connections could fail or behave intermittently when the same printer was also available through a logged-in cloud account.

Three problems combined here:

- The access-code field merge could replace the previously preferred user-entered code with a lower-priority discovered value during migration.
- A saved LAN printer and its cloud duplicate shared a device ID. Selection depended on discovery timing, while LAN status callbacks updated only the local object.
- X2D firmware can send complete `push_status` data without answering the legacy `info/get_version` request. The readiness gate rejected the live connection because `module_vers` stayed empty.

This change preserves the old credential precedence for affected migrated records, prefers authenticated LAN records over cloud duplicates, and accepts a recent complete X2D status payload as readiness evidence. Other printer models still require version information. The status-age calculation now uses the documented millisecond unit and rejects future or stale timestamps.

No configuration format or dependency changes are included.

# Screenshots/Recordings/Graphs

Not applicable. This changes connection state handling without changing the UI.

## Tests

- Built the Linux AppImage with `./build_linux.sh -g -si -j 16 -r`.
- Verified the resulting AppImage runtime.
- Manually connected to a Bambu Lab X2D in LAN/Developer mode on Arch Linux. Before the fix, logs showed either no local payloads after cloud-first selection or complete `push_status` payloads rejected by `is_info_ready()`. After the fix, the printer connected successfully.

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
