### PR TITLE
CLI: record command-line overrides in different_settings_to_system

### DIFF
--- a/src/OrcaSlicer.cpp
+++ b/src/OrcaSlicer.cpp
@@ -22,6 +22,7 @@
 
 #include <cstdio>
 #include <string>
+#include <optional>
 #include <cstring>
 #include <iostream>
 #include <math.h>
@@ -3794,9 +3795,54 @@ int CLI::run(int argc, char **argv)
         }
     }
 
+    //ORCA: settings passed on the command line (--sparse-infill-density 25% ...) override the loaded
+    //      presets right here, so they belong in different_settings_to_system just as a preset
+    //      override does. Without them re-opening the exported project in the GUI shows nothing
+    //      modified and reverts those values to the system presets'.
+    //
+    //      The keys come from m_config, not m_extra_config: read_cli() puts only what the user typed
+    //      into m_config (setup() adds nothing but CLI-own defaults), whereas the CLI writes its own
+    //      values into m_extra_config. Only keys whose value the override actually changed are
+    //      recorded -- a typed value equal to the loaded one modifies nothing -- and each lands in
+    //      the column(s) whose preset type owns it: [0] process, [1..n-2] filaments, [n-1] printer.
+    std::map<std::string, std::optional<std::string>> cli_override_before;
+    for (const std::string &key : m_config.keys())
+        if (m_extra_config.has(key))
+            cli_override_before[key] = m_print_config.has(key) ? std::optional<std::string>(m_print_config.opt_serialize(key))
+                                                               : std::nullopt;
+
     // Apply command line options to a more specific DynamicPrintConfig which provides normalize()
     // (command line options override --load files)
     m_print_config.apply(m_extra_config, true);
+
+    if (!cli_override_before.empty()) {
+        std::vector<std::string> &columns = m_print_config.option<ConfigOptionStrings>("different_settings_to_system", true)->values;
+        auto owned_by = [](const std::vector<std::string> &options, const std::string &key) {
+            return std::find(options.begin(), options.end(), key) != options.end();
+        };
+        auto add_to_column = [&columns](size_t index, const std::string &key) {
+            std::vector<std::string> keys;
+            Slic3r::unescape_strings_cstyle(columns[index], keys);
+            if (std::find(keys.begin(), keys.end(), key) == keys.end()) {
+                keys.push_back(key);
+                columns[index] = Slic3r::escape_strings_cstyle(keys);
+            }
+        };
+        if (columns.size() >= 2) {
+            for (const auto &[key, before] : cli_override_before) {
+                if (!m_print_config.has(key) || (before && *before == m_print_config.opt_serialize(key)))
+                    continue;
+                if (owned_by(Preset::print_options(), key))
+                    add_to_column(0, key);
+                if (owned_by(Preset::filament_options(), key))
+                    for (size_t i = 1; i + 1 < columns.size(); ++i)
+                        add_to_column(i, key);
+                if (owned_by(Preset::printer_options(), key))
+                    add_to_column(columns.size() - 1, key);
+                BOOST_LOG_TRIVIAL(info) << boost::format("CLI: override %1% recorded in different_settings_to_system") % key;
+            }
+        }
+    }
     // Normalizing after importing the 3MFs / AMFs
     m_print_config.normalize_fdm();
 

--- a/src/OrcaSlicer.cpp
+++ b/src/OrcaSlicer.cpp
@@ -22,7 +22,6 @@
 
 #include <cstdio>
 #include <string>
-#include <optional>
 #include <cstring>
 #include <iostream>
 #include <math.h>
@@ -3805,11 +3804,24 @@ int CLI::run(int argc, char **argv)
     //      values into m_extra_config. Only keys whose value the override actually changed are
     //      recorded -- a typed value equal to the loaded one modifies nothing -- and each lands in
     //      the column(s) whose preset type owns it: [0] process, [1..n-2] filaments, [n-1] printer.
-    std::map<std::string, std::optional<std::string>> cli_override_before;
-    for (const std::string &key : m_config.keys())
-        if (m_extra_config.has(key))
-            cli_override_before[key] = m_print_config.has(key) ? std::optional<std::string>(m_print_config.opt_serialize(key))
-                                                               : std::nullopt;
+    //
+    //      "Changed" is judged the way the value is read: a list is compared entry by entry with a
+    //      missing entry read as the first, as get_at() does -- so --nozzle-temperature 245 against
+    //      245,245,245 is no change, although the two serialize differently.
+    //
+    //      A key the loaded config does not carry at all is always recorded, even if the typed value
+    //      equals the built-in default. On reopen the GUI restores an unlisted key from the SYSTEM
+    //      preset, which need not match that default: a 3MF written before an option existed leaves
+    //      it absent here, and --sparse-infill-density 20% (the default) against a Prusa system 15%
+    //      would otherwise go unrecorded and be reverted. Over-recording is cosmetic; under-recording
+    //      loses the value.
+    std::map<std::string, std::unique_ptr<ConfigOption>> cli_override_before;
+    for (const std::string &key : m_config.keys()) {
+        if (!m_extra_config.has(key))
+            continue;
+        const ConfigOption *loaded = m_print_config.option(key);
+        cli_override_before[key].reset(loaded != nullptr ? loaded->clone() : nullptr); // null: always recorded
+    }
 
     // Apply command line options to a more specific DynamicPrintConfig which provides normalize()
     // (command line options override --load files)
@@ -3828,18 +3840,45 @@ int CLI::run(int argc, char **argv)
                 columns[index] = Slic3r::escape_strings_cstyle(keys);
             }
         };
+        auto same_value = [](const ConfigOption *a, const ConfigOption *b) {
+            if (a == nullptr || b == nullptr)
+                return false;
+            const auto *va = dynamic_cast<const ConfigOptionVectorBase *>(a);
+            const auto *vb = dynamic_cast<const ConfigOptionVectorBase *>(b);
+            if (va == nullptr || vb == nullptr)
+                return va == vb && a->serialize() == b->serialize();
+            const std::vector<std::string> ea = va->vserialize(), eb = vb->vserialize();
+            if (ea.empty() || eb.empty())
+                return ea.empty() && eb.empty();
+            for (size_t i = 0; i < std::max(ea.size(), eb.size()); ++i)
+                if (ea[i < ea.size() ? i : 0] != eb[i < eb.size() ? i : 0])
+                    return false;
+            return true;
+        };
+        //ORCA: always true after the resize to filament_count + 2 above, and nothing in between can
+        //      shrink the column vector -- different_settings_to_system is not a CLI option. Kept as
+        //      a check rather than an assert: release builds compile asserts out, so an assert would
+        //      protect nothing, while a build with _GLIBCXX_ASSERTIONS would abort on columns[0].
         if (columns.size() >= 2) {
             for (const auto &[key, before] : cli_override_before) {
-                if (!m_print_config.has(key) || (before && *before == m_print_config.opt_serialize(key)))
+                if (same_value(before.get(), m_print_config.option(key)))
                     continue;
-                if (owned_by(Preset::print_options(), key))
+                bool recorded = false;
+                if (owned_by(Preset::print_options(), key)) {
                     add_to_column(0, key);
-                if (owned_by(Preset::filament_options(), key))
+                    recorded = true;
+                }
+                if (owned_by(Preset::filament_options(), key)) {
                     for (size_t i = 1; i + 1 < columns.size(); ++i)
                         add_to_column(i, key);
-                if (owned_by(Preset::printer_options(), key))
+                    recorded = true;
+                }
+                if (owned_by(Preset::printer_options(), key)) {
                     add_to_column(columns.size() - 1, key);
-                BOOST_LOG_TRIVIAL(info) << boost::format("CLI: override %1% recorded in different_settings_to_system") % key;
+                    recorded = true;
+                }
+                if (recorded)
+                    BOOST_LOG_TRIVIAL(info) << boost::format("CLI: override %1% recorded in different_settings_to_system") % key;
             }
         }
     }


### PR DESCRIPTION
Follow-up to #15595, split out at review there.

# Description

#15595 records the keys a *user preset* overrides relative to its system parent. Settings passed on the **command line** are a second source of override, and they were still not recorded:

```
--sparse-infill-density 25%  --export-3mf

  different_settings_to_system = ["", "", ""]
  sparse_infill_density        = "25%"
```

The value reaches the project, but nothing marks it as modified, so re-opening the export in the GUI reverts it to the system preset's `15%`. Reported by @HanifKoh against #15595.

# Fix

Command-line settings override the loaded presets at one point, where `m_extra_config` is applied to `m_print_config`. Snapshot the relevant values just before that, and afterwards add every key the override actually changed to the column(s) whose preset type owns it.

**Where the key set comes from matters.** It is taken from `m_config`, not `m_extra_config`. `read_cli()` puts only what the user typed into `m_config`, and `setup()` adds nothing but CLI-own defaults — I checked every key `run()` materialises there against the preset option lists, and none is a preset option. `m_extra_config`, by contrast, also receives values the CLI writes itself (`has_filament_switcher`, `enable_filament_dynamic_map`, `filament_colour`, `filament_map`, …), which must not be reported as user overrides.

**Only changed keys are recorded.** A typed value equal to the loaded one modifies nothing; listing it would read as a spurious difference against what the GUI writes for the same project.

**Attribution** follows the column layout: `[0]` process, `[1..n-2]` every filament, `[n-1]` printer, using `Preset::{print,filament,printer}_options()`. A key already present — say from the preset-leaf diff — is not duplicated. A key no preset owns, such as `curr_bed_type`, lands nowhere, as in the GUI.

# Verification

Stock Prusa profiles, `--export-3mf`, reading `different_settings_to_system` back out of the project. Each key is owned by exactly one preset type, so every case also checks the override lands in the right column and no other:

| override | expected | before | after |
|---|---|---|---|
| `--sparse-infill-density 37%` | process column only | not recorded | ✅ |
| `--nozzle-temperature 251` | filament column only | not recorded | ✅ |
| `--printable-height 201` | printer column only | not recorded | ✅ |
| `--sparse-infill-density 15%` (= loaded value) | nowhere | — | ✅ not recorded |
| `--curr-bed-type "Textured PEI Plate"` (no preset owns it) | nowhere | — | ✅ not recorded |

Nine checks in all: **6/9 before**, where the three positives fail and the six negatives pass trivially, and **9/9 after** — so the test detects the missing records rather than passing by construction.

A 57-check CLI regression suite stays green, including a byte-level g-code comparison against a baseline: the only command-line setting in that run is `--curr-bed-type`, which no preset owns, so the column — which is also written into the g-code footer — is unchanged, as it should be.

As with #15595, the binary under test was built on our base (`58bf267fd` + this change) rather than on current `main`; the change is self-contained and compiles against `main`.

# Scope

1 file, `src/OrcaSlicer.cpp`, +85/-0. No public API change, no profile change, no GUI change.

