### PR TITLE
Fix Printer Agent preset undo

### DIFF
--- a/src/slic3r/GUI/OptionsGroup.cpp
+++ b/src/slic3r/GUI/OptionsGroup.cpp
@@ -798,11 +798,9 @@ void ConfigOptionsGroup::back_to_config_value(const DynamicPrintConfig& config, 
 #endif
     else if (opt_key == "printer_agent")
     {
-        // why: printer_agent is a coString kept out of m_opt_map. The generic non-opt_map revert
-        // below restores the edited config from get_value(), but a deregistered/"(missing)" saved
-        // id has no selectable row, so the field yields no value and the edited config keeps the
-        // user's interim pick -> stuck dirty. Restore the SAVED id straight into the edited config
-        // (displayable or not; config is the saved or system baseline), then repaint and notify.
+        // A deregistered/"(missing)" saved id has no selectable row, so the field yields no
+        // value. Restore the saved id directly instead of letting the generic revert path read
+        // the field value back into the edited config.
         const std::string saved_id = config.opt_string("printer_agent");
         set_value(opt_key, saved_id);
         this->change_opt_value(opt_key, saved_id);

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -5029,28 +5029,12 @@ void TabPrinter::build_fff()
             auto registered_printer_agents = NetworkAgentFactory::get_registered_printer_agents();
             if (!registered_printer_agents.empty())
             {
-                ConfigOptionDef def;
-                def.type = coString;
-                def.gui_type = ConfigOptionDef::GUIType::printer_agent_select;
-                def.width = 3 * Field::def_width_wider() / 2;
-                def.label = L("Printer Agent");
-                def.tooltip = L("Select the network agent implementation for printer communication. "
+                option = optgroup->get_option("printer_agent");
+                option.opt.gui_type = ConfigOptionDef::GUIType::printer_agent_select;
+                option.opt.width = 3 * Field::def_width_wider() / 2;
+                option.opt.tooltip = L("Select the network agent implementation for printer communication. "
                     "Available agents are registered at startup.");
-                def.mode = comAdvanced;
-
-                // Create the field without get_option() so it is not registered in m_opt_map.
-                // ConfigOptionsGroup handles printer_agent before the generic mapped write path.
-                Line agent_line = optgroup->create_single_option_line(Option(def, "printer_agent"));
-                optgroup->append_line(agent_line);
-                if (Field* agent_field = get_field("printer_agent"))
-                {
-                    if (auto* choice = dynamic_cast<PrinterAgentChoice*>(agent_field); choice && choice->getWindow())
-                        choice->set_value(m_config->opt_string("printer_agent"), false);
-                }
-
-                // Register by hand so the UnsavedChanges dialog can render a row for it.
-                wxGetApp().sidebar().get_searcher().add_key("printer_agent", m_type, optgroup->title,
-                                                            optgroup->config_category());
+                optgroup->append_single_option_line(option);
             }
         }
 
@@ -5912,15 +5896,6 @@ void TabPrinter::reload_config()
     if (m_active_page && m_active_page->title() == "Multimaterial")
         m_active_page->set_value("extruders_count", int(m_extruders_count));
 
-    // m_opt_map-driven reload does not cover printer_agent, so sync this custom field explicitly.
-    if (Field* agent_field = get_field("printer_agent"))
-    {
-        if (auto* choice = dynamic_cast<PrinterAgentChoice*>(agent_field); choice && choice->getWindow())
-        {
-            const std::string selected_agent = m_config->opt_string("printer_agent");
-            choice->set_value(selected_agent, false);
-        }
-    }
 }
 
 void TabPrinter::activate_selected_page(std::function<void()> throw_if_canceled)
@@ -5932,15 +5907,6 @@ void TabPrinter::activate_selected_page(std::function<void()> throw_if_canceled)
     if (m_active_page && m_active_page->title() == "Multimaterial")
         m_active_page->set_value("extruders_count", int(m_extruders_count));
 
-    // m_opt_map-driven reload does not cover printer_agent, so sync this custom field explicitly.
-    if (Field* agent_field = get_field("printer_agent"))
-    {
-        if (auto* choice = dynamic_cast<PrinterAgentChoice*>(agent_field); choice && choice->getWindow())
-        {
-            const std::string selected_agent = m_config->opt_string("printer_agent");
-            choice->set_value(selected_agent, false);
-        }
-    }
 }
 
 void TabPrinter::clear_pages()


### PR DESCRIPTION
## Description

Fixes the preset-level undo for the **Printer Agent** setting.

Previously, changing Printer Agent and using the orange undo button beside the printer preset name could leave the dropdown showing the modified value instead of the restored preset value.

Printer Agent is now registered through the normal option handling path, allowing the standard preset reload and undo mechanisms to update the field correctly.

The existing dynamic Printer Agent behavior is preserved, including support for plugin-provided agents and saved agents that are no longer available. In that case, undo still restores the saved agent ID and displays it as missing without leaving the preset dirty.

<img width="800" height="647" alt="PrinterAgent" src="https://github.com/user-attachments/assets/e0340e48-97fe-4132-8181-373fd360a823" />

---

<!--
> A guide for users on how to download the artifacts from this PR.
-->

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
