### PR TITLE
CLI: refuse a printer switch the compatibility check rejects, unless the vendor list allows it

### DIFF
--- a/src/OrcaSlicer.cpp
+++ b/src/OrcaSlicer.cpp
@@ -2820,11 +2820,20 @@ int CLI::run(int argc, char **argv)
             %current_printer_name %current_printer_system_name %current_process_name %current_process_system_name %process_compatible;
     }
     if (!process_compatible && !new_printer_name.empty() && !current_printer_name.empty() && (new_printer_name != current_printer_name)) {
-        //set all printer to compatible
-        if (new_process_name.empty())
-            process_compatible = true;
+        //ORCA: the compatibility check above has already said no for this printer. This block used to
+        //      overturn that verdict unconditionally whenever the 3MF's own process was kept -- and did
+        //      so before consulting upward_compatible_machine, so the vendor's list was never enforced
+        //      either. The (auto) preset below then wrote the new printer into its own
+        //      compatible_printers, and the result was g-code for one machine carrying a process tuned
+        //      for another, reported as success (#15450).
+        //
+        //      The overturn predates a working check. While the check could not evaluate
+        //      compatible_printers_condition (#15449) it rejected every condition-based process, and
+        //      this rescue was what let legitimate re-targets through -- which is presumably why the
+        //      reject branch below was commented out. With the condition evaluated, a "no" here is a
+        //      real no, so only the vendor's upward_compatible_machine list may overturn it.
         machine_switch = true;
-        BOOST_LOG_TRIVIAL(info) << boost::format("switch to new printers, set to compatible");
+        BOOST_LOG_TRIVIAL(info) << boost::format("switch to new printer %1%: process not compatible, consulting upward_compatible_machine") % new_printer_name;
         if (upward_compatible_printers.size() > 0) {
             for (int index = 0; index < upward_compatible_printers.size(); index++) {
                 if (upward_compatible_printers[index] == new_printer_system_name) {
@@ -2840,11 +2849,16 @@ int CLI::run(int argc, char **argv)
                 flush_and_exit(CLI_3MF_NEW_MACHINE_NOT_SUPPORTED);
             }
         }
-        /*else {
-            BOOST_LOG_TRIVIAL(error) <<__FUNCTION__ << boost::format(" %1%: current 3mf file not support upward_compatible_printers, can not change machine preset.")%__LINE__;
+        else if (new_process_name.empty()) {
+            //ORCA: restored. With no upward list and the 3MF's own process kept, nothing vouches for the
+            //      switch. When a process was supplied as well, fall through to CLI_PROCESS_NOT_COMPATIBLE
+            //      below instead -- the machine change is fine there, the supplied pair is what failed.
+            BOOST_LOG_TRIVIAL(error) << __FUNCTION__ << boost::format(" %1%: the 3mf's process is not compatible with %2% and the 3mf lists no upward_compatible_machine; "
+                                                                      "supply a process for the new printer with --load-settings")
+                                            % __LINE__ % new_printer_name;
             record_exit_reson(outfile_dir, CLI_3MF_NOT_SUPPORT_MACHINE_CHANGE, 0, cli_errors[CLI_3MF_NOT_SUPPORT_MACHINE_CHANGE], sliced_info);
             flush_and_exit(CLI_3MF_NOT_SUPPORT_MACHINE_CHANGE);
-        }*/
+        }
     }
 
     if (!process_compatible) {

--- a/src/OrcaSlicer.cpp
+++ b/src/OrcaSlicer.cpp
@@ -132,7 +132,7 @@ std::map<int, std::string> cli_errors = {
     {CLI_EXPORT_OBJ_ERROR, "Failed exporting OBJ files."},
     {CLI_EXPORT_3MF_ERROR, "Failed exporting 3mf files."},
     {CLI_OUT_OF_MEMORY, "Out of memory during slicing. Please upload a model with lower geometry resolution and try again."},
-    {CLI_3MF_NOT_SUPPORT_MACHINE_CHANGE, "The selected printer is not supported."},
+    {CLI_3MF_NOT_SUPPORT_MACHINE_CHANGE, "The process in the 3mf is not compatible with the selected printer; supply a process for it with --load-settings."},
     {CLI_3MF_NEW_MACHINE_NOT_SUPPORTED, "The selected printer is not compatible with the 3mf."},
     {CLI_PROCESS_NOT_COMPATIBLE, "The selected printer is not compatible with the process preset in the 3mf."},
     {CLI_INVALID_VALUES_IN_3MF, "Invalid parameter value(s) included in the 3mf file."},


### PR DESCRIPTION
Fixes #15450.

# Description

Re-slicing a 3MF with a different printer is accepted with `return_code: 0` even when the project's process is not compatible with the new printer. The slice then runs with a process tuned for another machine, relabelled `(auto)`, and nothing reports a problem.

The check itself is not what fails. In the cases below it correctly says *not compatible*. The problem is the block right after it, which runs *only when* the check has said no, and then overturns that verdict:

```cpp
if (!process_compatible && <printer changed>) {
    if (new_process_name.empty())
        process_compatible = true;          // unconditional
    ...
    if (upward_compatible_printers.size() > 0) {
        ... if (!process_compatible) → CLI_3MF_NEW_MACHINE_NOT_SUPPORTED
    }
    /* else { → CLI_3MF_NOT_SUPPORT_MACHINE_CHANGE } */     // commented out
}
```

Two defects, not one:

1. **No upward list** — the accept is unconditional. That is #15450 as filed.
2. **An upward list that omits the new printer** — also accepted. The unconditional accept runs *before* the list is consulted, so by the time `if (!process_compatible)` is reached it is already `true`, and `CLI_3MF_NEW_MACHINE_NOT_SUPPORTED` can never fire when the 3MF keeps its own process. #15450 says this path "works correctly when the list is non-empty". I wrote that from reading the code and it's wrong; measured below.

# Why the reject branch was commented out

#15450 left this as an open question. I think the answer is #15449.

Until #15449, the check never evaluated `compatible_printers_condition`. It rejected every condition-based process — 173 of Prusa's 334, among others — including re-targets that are entirely legitimate, like a stock CORE One project sliced for a user's own CORE One preset. With the check broken that way, this rescue was the only thing letting those re-targets through, and enabling the reject branch would have broken them. With the condition evaluated, a "no" here is a real no.

That is also why this could not land before #15449, which has since merged (`ccd6086`); this branch is now rebased onto it and carries only its own two commits.

# Fix

The verdict stands unless `upward_compatible_machine` names the new printer:

| situation | before | after |
|---|---|---|
| list names the new printer | accepted | accepted (unchanged) |
| list exists, omits it | **accepted** | `-16` `CLI_3MF_NEW_MACHINE_NOT_SUPPORTED`, as the existing branch always intended |
| no list, 3MF's process kept | **accepted** | `-15` `CLI_3MF_NOT_SUPPORT_MACHINE_CHANGE`, the commented-out branch restored |
| no list, process supplied too | `-17` | `-17` (unchanged — there the supplied pair is what failed, not the switch) |
| check says compatible | accepted | accepted — never reaches this block |

`-15` had no live caller until now, so its message had never been shown. *"The selected printer is not supported"* isn't true — the printer is fine — so it now reads *"The process in the 3mf is not compatible with the selected printer; supply a process for it with --load-settings."* That's the remedy, and case 12 below tests it.

The `(auto)` preset still gets created on a vendor-listed switch, where the vendor has vouched for it. It is no longer created for switches nothing vouches for.

# Verification

Bundled Prusa profiles. `upward_compatible_machine` is read from the 3MF's own project config, and only BBL, Blocks and Vzbot ship non-empty lists, so the list cases inject one into a copy of the project. Before = this branch's base (#15449 applied), after = with this change:

| # | case | before | after |
|---|---|---|---|
| 5 | CORE One project → MK4S, no list | **0** | `-15` |
| 8 | same, GUI-saved project (renamed compat keys) | **0** | `-15` |
| 9 | same, CLI-exported project (raw condition + empty group) | **0** | `-15` |
| 10 | list names MK4S → MK4S | 0 | 0, and the export records MK4S in `print_compatible_printers` |
| 11 | list names another printer → MK4S | **0** | `-16` |
| 12 | → MK4S **with** an MK4S process supplied | 0 | 0 |
| 13 | CORE One project → a user preset inheriting CORE One | 0 | 0 |

So 11/15 before, 15/15 after. The four that flip are the defects; every accepted re-target the check approves, the vendor-listed switch and the supplied-process remedy all stay at 0. The issue's exact reproduction now exits `-15` and writes no g-code, where before it exited `0` with g-code for the wrong machine.

Cases 8 and 9 also guard #15449's compatibility-key handling: if the condition is lost, the check accepts and the case reports `0` instead of `-15`.

A 64-check CLI regression suite is green. As with the parent PRs, the binary under test was built on our base (`58bf267fd` + the stack); the change compiles against `main`.

# Scope

1 file, `src/OrcaSlicer.cpp`, +22/-8. Behaviour change is confined to a printer switch the compatibility check rejects. Worth flagging for anyone scripting this path: such a re-slice used to succeed, silently, and now fails with a message saying how to proceed.

