### PR TITLE
Open a project from a URL as a project, and fix the drop dialog default

### DIFF
--- a/src/slic3r/GUI/Downloader.cpp
+++ b/src/slic3r/GUI/Downloader.cpp
@@ -195,7 +195,8 @@ void Downloader::on_complete(wxCommandEvent& event)
     set_download_state(event.GetInt(), DownloadState::DownloadDone);
 	wxArrayString paths;
 	paths.Add(event.GetString());
-	wxGetApp().plater()->load_files(paths);
+	// from_url: the user clicked "Open in OrcaSlicer" on this specific project.
+	wxGetApp().plater()->load_files(paths, /* from_url */ true);
 }
 bool Downloader::user_action_callback(DownloaderUserAction action, int id)
 {

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -17191,7 +17191,13 @@ ProjectDropDialog::ProjectDropDialog(const std::string &filename)
                 wxDefaultPosition,
                 wxDefaultSize,
                 wxCAPTION | wxCLOSE_BOX)
-    , m_action(2)
+    // Default to the action the user chose last time, which this dialog already records in
+    // "import_project_action" on OK. Falls back to LoadType::OpenProject rather than
+    // LoadGeometry: this dialog is shown for a *project* file, and importing geometry only
+    // silently discards the embedded printer, filament and process settings.
+    , m_action(std::max(1, std::min(2, wxGetApp().app_config->get("import_project_action").empty()
+                                       ? 1
+                                       : std::atoi(wxGetApp().app_config->get("import_project_action").c_str()))))
 {
     // def setting
     SetBackgroundColour(m_def_color);
@@ -17316,7 +17322,7 @@ void ProjectDropDialog::on_dpi_changed(const wxRect& suggested_rect)
 }
 
 //BBS: remove GCodeViewer as seperate APP logic
-bool Plater::load_files(const wxArrayString& filenames)
+bool Plater::load_files(const wxArrayString& filenames, bool from_url)
 {
     const std::regex pattern_drop(".*[.](stp|step|stl|oltp|obj|amf|3mf|svg|zip|drc)", std::regex::icase);
     const std::regex pattern_gcode_drop(".*[.](gcode|g)", std::regex::icase);
@@ -17425,7 +17431,7 @@ bool Plater::load_files(const wxArrayString& filenames)
 
     switch (loadfiles_type) {
     case LoadFilesType::Single3MF:
-        open_3mf_file(normal_paths[0]);
+        open_3mf_file(normal_paths[0], from_url);
         break;
 
     case LoadFilesType::SingleOther: {
@@ -17508,7 +17514,7 @@ LoadType determine_load_type(std::string filename, std::string override_setting)
     }
 }
 
-bool Plater::open_3mf_file(const fs::path &file_path)
+bool Plater::open_3mf_file(const fs::path &file_path, bool from_url)
 {
     std::string filename = encode_path(file_path.filename().string().c_str());
     if (!boost::algorithm::iends_with(filename, ".3mf")) {
@@ -17517,7 +17523,12 @@ bool Plater::open_3mf_file(const fs::path &file_path)
 
     bool not_empty_plate = !model().objects.empty();
     bool load_setting_ask_when_relevant = wxGetApp().app_config->get(SETTING_PROJECT_LOAD_BEHAVIOUR) == OPTION_PROJECT_LOAD_BEHAVIOUR_ASK_WHEN_RELEVANT;
-    LoadType load_type = determine_load_type(filename, (not_empty_plate && load_setting_ask_when_relevant) ? OPTION_PROJECT_LOAD_BEHAVIOUR_ALWAYS_ASK : "");
+    // A project opened from an orcaslicer:// link is not an ambiguous drop: the user clicked
+    // "Open in OrcaSlicer" on that specific project, so do not escalate to the "Open as project
+    // / Import geometry only" prompt merely because the plate is occupied. The global Load
+    // Behaviour setting is still honoured, and load_project() still asks about unsaved changes.
+    LoadType load_type = determine_load_type(filename,
+        (!from_url && not_empty_plate && load_setting_ask_when_relevant) ? OPTION_PROJECT_LOAD_BEHAVIOUR_ALWAYS_ASK : "");
 
     if (load_type == LoadType::Unknown) return false;
 

--- a/src/slic3r/GUI/Plater.hpp
+++ b/src/slic3r/GUI/Plater.hpp
@@ -349,7 +349,7 @@ public:
     // BBS: check snapshot
     bool up_to_date(bool saved, bool backup);
 
-    bool open_3mf_file(const fs::path &file_path);
+    bool open_3mf_file(const fs::path &file_path, bool from_url = false);
     int  get_3mf_file_count(std::vector<fs::path> paths);
     void add_file();
     // Returns false when no object was added (e.g. the user cancelled the load dialog).
@@ -409,7 +409,9 @@ public:
     // BBS: restore
     std::vector<size_t> load_files(const std::vector<boost::filesystem::path>& input_files, LoadStrategy strategy = LoadStrategy::LoadModel | LoadStrategy::LoadConfig,  bool ask_multi = false, bool* published_out = nullptr);
     // to be called on drag and drop
-    bool load_files(const wxArrayString& filenames);
+    // from_url is set when the project came from an orcaslicer:// link: the user has
+    // already chosen which project to open, so do not ask them again.
+    bool load_files(const wxArrayString& filenames, bool from_url = false);
 
     const wxString& get_last_loaded_gcode() const { return m_last_loaded_gcode; }
 


### PR DESCRIPTION
Two related but independent problems when opening a model from an `orcaslicer://` link while a project is already on the plate. Fixing either one alone leaves the other.


Both reproduce on stock 2.4.2 on macOS, via Printables' and Thingiverse's "Open in OrcaSlicer" buttons.

## 1. The "Drop project file" dialog should not appear at all

Clicking "Open in OrcaSlicer" already tells the app which project to open. But the download is handed to `Plater::load_files(const wxArrayString&)`, which is the drag-and-drop entry point, and `open_3mf_file()` escalates to the prompt whenever the plate is not empty:

```cpp
bool not_empty_plate = !model().objects.empty();
bool load_setting_ask_when_relevant = ... == OPTION_PROJECT_LOAD_BEHAVIOUR_ASK_WHEN_RELEVANT;
LoadType load_type = determine_load_type(filename,
    (not_empty_plate && load_setting_ask_when_relevant) ? OPTION_PROJECT_LOAD_BEHAVIOUR_ALWAYS_ASK : "");
```

The download path now passes `from_url`, which suppresses that escalation and nothing else:

- The global **Load Behaviour** preference is still honored. A user who set "Always Ask" or "Load Geometry Only" still gets what they asked for.
- `load_project()` still calls `close_with_confirm()`, so unsaved changes to the current project are still protected. That is the prompt that belongs here, and it already existed.

## 2. The dialog defaulted to the destructive option

When the dialog does legitimately appear, it preselected "Import geometry only". It records the user's choice in `import_project_action` on OK, but never read it back, because `m_action` was hardcoded to `2` (`LoadGeometry`).

It now initializes from the stored choice, falling back to `OpenProject` rather than `LoadGeometry`.

That fallback matters. `LoadGeometry` sets `load_config = 0`, so the embedded printer, filament and process settings are dropped. On a multi-color model the paintwork is re-rendered in whatever filaments the *previously* loaded project happened to use, so the creator's color work is visibly lost. The plate still renders and the model still slices, which is what makes it dangerous: nothing reports an error.

It is a poor default for a dialog titled "Drop project file", and a particularly poor one for the option a user is most likely to accept without reading. That leads to something like this:
<img width="603" height="459" alt="Screenshot 2026-09-11 at 10 08 36 PM" src="https://github.com/user-attachments/assets/0c0e7e82-7b76-4e16-b1d2-07b6b6c889e0" />

<img width="2054" height="1291" alt="Screenshot 2026-09-11 at 10 09 08 PM" src="https://github.com/user-attachments/assets/aad9148b-06ca-427d-9e80-b82b767a814e" />

If the user correctly changed it to Open as project, it would load properly:

<img width="632" height="425" alt="Screenshot 2026-09-11 at 10 09 26 PM" src="https://github.com/user-attachments/assets/411c7c72-265d-49f4-b99a-ad3f291188f6" />
<img width="2051" height="1287" alt="Screenshot 2026-09-11 at 10 09 55 PM" src="https://github.com/user-attachments/assets/4b62f381-b693-4f29-aafa-024641696920" />

Problem 2 is not macOS specific. It affects anyone dragging a `.3mf` onto an occupied plate, on any platform.

## Testing

Built from this branch and run on macOS 26.6.2, Apple Silicon, Release build of `main` plus this change (reports as 2.5.0-dev), with Load Behaviour left at its default "Ask When Relevant".

Confirmed on that build:

- **URL open onto an occupied plate:** loads as a project with no dialog. Previously this raised "Drop project file".
- **Drag and drop a `.3mf` from Finder onto an occupied plate:** the dialog still appears, as it should, and now comes up with **"Open as project"** selected rather than "Import geometry only".

And confirmed on stock 2.4.2 that both problems reproduce *before* the change, using Printables' and Thingiverse's "Open in OrcaSlicer" buttons.

The same change has also been running on a Snapmaker Orca fork build, where these files are identical, submitted there as Snapmaker/OrcaSlicer#856. Additionally verified there: unsaved changes to the current project still prompt to save first, and a cold launch from a link is unchanged.

Not exercised: Load Behaviour explicitly set to "Always Ask" or "Load Geometry Only". Those paths are untouched by this change, since `from_url` only suppresses the escalation and does not override the stored setting, but I have not run them.

## Related: #14602

While confirming this I also found that `orcaslicer://` links are ignored entirely on macOS when OrcaSlicer is **not** already running: the app launches to the Home screen and nothing loads. That is a separate bug, reported in #14602, and I have added a reproduction and log analysis there. This PR does not address it.

The two interact in a way worth knowing if you try to reproduce this one on macOS: because of #14602, a URL open only ever reaches the code this PR touches when the app is **already running**. So reproduce problem 1 with OrcaSlicer open and a model already on the plate, not from a cold launch. Problem 2 is reachable either way, via drag and drop.
