### PR TITLE
Http: probe the CA bundle without throwing on an unreadable path

### DIFF
--- a/src/slic3r/Utils/Http.cpp
+++ b/src/slic3r/Utils/Http.cpp
@@ -53,10 +53,18 @@ struct CurlGlobalInit
             ssl_cafile = X509_get_default_cert_file();
 
         int replace = true;
-        if (!ssl_cafile || !fs::exists(fs::path(ssl_cafile))) {
+        // Probe without throwing: these paths are not necessarily readable. A static build bakes
+        // OPENSSLDIR into the binary, so X509_get_default_cert_file() can point into the build
+        // tree, and on another machine or under another user that path may exist but be
+        // unreachable. The throwing overload then raises filesystem_error out of this
+        // constructor and the application dies at startup, instead of falling through to the
+        // CA_BUNDLES list below. exists(p, ec) reports false for an unreadable path, which is
+        // what this code wants: try the next candidate.
+        boost::system::error_code ec;
+        if (!ssl_cafile || !fs::exists(fs::path(ssl_cafile), ec)) {
             const char * bundle = nullptr;
             for (const char * b : CA_BUNDLES) {
-                if (fs::exists(fs::path(b))) {
+                if (fs::exists(fs::path(b), ec)) {
                     ::setenv(SSL_CA_FILE, bundle = b, replace);
                     break;
                 }


### PR DESCRIPTION
Fixes #15653.

# Description

`CurlGlobalInit()` probes the CA bundle with the throwing `fs::exists` overload. That overload returns `false` only for "not found"; any other failure — `EACCES` in particular — throws. The exception escapes the constructor and the application terminates at startup, without ever reaching the `CA_BUNDLES` fallback list two lines below.

This is reachable whenever the OpenSSL default cert path exists but is not readable. A `SLIC3R_STATIC=ON` build (which is what defines `OPENSSL_CERT_OVERRIDE` for this block) bakes `OPENSSLDIR` into the binary from the deps prefix, so `X509_get_default_cert_file()` returns a path inside the build tree. Run that binary as a different user, or on another machine with a same-named but private build tree, and the path resolves without being readable — it starts for the building user and dies for everyone else. `SSL_CERT_FILE` reaches the same code, so any build can hit it.

# Fix

Use the `error_code` overload at both probe sites. It reports `false` for an unreadable path, which is what this code already wants: move to the next candidate and end up on the distro bundle.

Measured with the bundled boost against a `chmod 000` directory holding a real file:

```
throwing overload : THREW -> boost::filesystem::status: Permission denied [system:13]: "<path>"
error_code overload: returned false, ec=Permission denied
```

# Verification

Same machine, same unreadable path, headless GNOME session, `SSL_CERT_FILE` pointed at a file inside a `chmod 000` directory:

| | window | log |
|---|---|---|
| unpatched | none after 60 s | `Unhandled standard exception … boost::filesystem::status: Permission denied [system:13]`, terminated |
| patched | appeared in 5 s | no `filesystem_error` |

The patched run then proceeds through the existing fallback and uses the distro CA bundle, which is the behaviour the block was written for.

The CLI is unaffected either way — it does not reach `CurlGlobalInit()`; I checked `--help` and a full slice under the same environment and both exit 0 before and after.

# Scope

1 file, `src/slic3r/Utils/Http.cpp`, +10/-2 (8 of the added lines are a comment explaining why the probe must not throw). No behaviour change when the path is readable, and none for dynamically linked builds, where this block is not compiled at all.
