### PR TITLE
Fix: keep the initial focus on the dialog default button

### DIFF
--- a/src/slic3r/GUI/MsgDialog.cpp
+++ b/src/slic3r/GUI/MsgDialog.cpp
@@ -148,7 +148,7 @@ void MsgDialog::SetButtonLabel(wxWindowID btn_id, const wxString& label, bool se
     if (Button* btn = get_button(btn_id)) {
         btn->SetLabel(label);
         if (set_focus)
-            btn->SetFocus();
+            btn->SetFocusOnShow();
     }
 }
 
@@ -184,7 +184,7 @@ Button* MsgDialog::add_button(wxWindowID btn_id, bool set_focus /*= false*/, con
     }
 
     if (set_focus)
-        btn->SetFocus();
+        btn->SetFocusOnShow();
     btn_sizer->Add(btn, 0, wxLEFT | wxALIGN_CENTER_VERTICAL, FromDIP(ButtonProps::ChoiceButtonGap()));
     btn->Bind(wxEVT_BUTTON, [this, btn_id](wxCommandEvent&) { EndModal(btn_id); });
 

--- a/src/slic3r/GUI/Widgets/Button.cpp
+++ b/src/slic3r/GUI/Widgets/Button.cpp
@@ -1,7 +1,10 @@
 #include "Button.hpp"
 #include "Label.hpp"
+#include "SpinInput.hpp"
+#include "TextInput.hpp"
 
 #include <wx/dcgraph.h>
+#include <wx/textentry.h>
 #include <wx/tipwin.h>
 #ifdef __APPLE__
 #include "libslic3r/MacUtils.hpp"
@@ -43,6 +46,12 @@ Button::Button(wxWindow* parent, wxString text, wxString icon, long style, int i
     : Button()
 {
     Create(parent, text, icon, style, iconSize, btn_id);
+}
+
+Button::~Button()
+{
+    if (m_focus_on_show_parent != nullptr)
+        m_focus_on_show_parent->Unbind(wxEVT_SHOW, &Button::onTopWindowShow, this);
 }
 
 bool Button::Create(wxWindow* parent, wxString text, wxString icon, long style, int iconSize, wxWindowID btn_id)
@@ -484,6 +493,72 @@ void Button::keyDownUp(wxKeyEvent &event)
         HandleAsNavigationKey(event);
     else
         event.Skip();
+}
+
+void Button::SetFocusOnShow()
+{
+    wxWindow* top_window = wxGetTopLevelParent(this);
+    if (top_window == nullptr)
+        return;
+
+    // A dialog may ask several of its buttons for the initial focus. The last request wins
+    cancelPendingFocus(top_window, this);
+
+    if (top_window->IsShown()) {
+        applyFocusOnShow();
+        return;
+    }
+
+    if (m_focus_on_show_parent == nullptr) {
+        m_focus_on_show_parent = top_window;
+        top_window->Bind(wxEVT_SHOW, &Button::onTopWindowShow, this);
+    }
+}
+
+void Button::cancelPendingFocus(wxWindow* parent, const Button* keep)
+{
+    for (wxWindow* child : parent->GetChildren()) {
+        if (Button* button = dynamic_cast<Button*>(child);
+            button != nullptr && button != keep && button->m_focus_on_show_parent != nullptr) {
+            button->m_focus_on_show_parent->Unbind(wxEVT_SHOW, &Button::onTopWindowShow, button);
+            button->m_focus_on_show_parent = nullptr;
+        }
+        cancelPendingFocus(child, keep);
+    }
+}
+
+void Button::onTopWindowShow(wxShowEvent& event)
+{
+    event.Skip();
+    if (!event.IsShown())
+        return;
+
+    // The binding is kept, because a dialog can be built once and shown many times.
+    // The platform gives the dialog its own initial focus while the dialog appears, so this
+    // request must run after that, when the event loop is idle again.
+    CallAfter(&Button::applyFocusOnShow);
+}
+
+void Button::applyFocusOnShow()
+{
+    if (!AcceptsFocus() || !IsShownOnScreen())
+        return;
+
+    const wxWindow* top_window = wxGetTopLevelParent(this);
+    wxWindow*       focused    = wxWindow::FindFocus();
+    // FindFocus() is global, so a window of another dialog or of the main frame does not count.
+    if (focused != nullptr && wxGetTopLevelParent(focused) == top_window) {
+        // Walk up from the focused window to the dialog. Leave the focus alone when it already
+        // belongs to this button, or to a control that the user types into. ComboBox derives
+        // from TextInput, so both are covered by the TextInput test.
+        for (; focused != nullptr && focused != top_window; focused = focused->GetParent()) {
+            if (focused == this || dynamic_cast<wxTextEntry*>(focused) != nullptr ||
+                dynamic_cast<TextInput*>(focused) != nullptr || dynamic_cast<SpinInput*>(focused) != nullptr)
+                return;
+        }
+    }
+
+    SetFocus();
 }
 
 void Button::sendButtonEvent()

--- a/src/slic3r/GUI/Widgets/Button.hpp
+++ b/src/slic3r/GUI/Widgets/Button.hpp
@@ -56,6 +56,8 @@ public:
 
     Button(wxWindow* parent, wxString text, wxString icon = "", long style = 0, int iconSize = 0, wxWindowID btn_id = wxID_ANY);
 
+    ~Button();
+
     bool Create(wxWindow* parent, wxString text, wxString icon = "", long style = 0, int iconSize = 0, wxWindowID btn_id = wxID_ANY);
 
     void SetLabel(const wxString& label) override;
@@ -92,6 +94,13 @@ public:
 
     void SetCanFocus(bool canFocus) override;
 
+    // Give this button the keyboard focus when the dialog that contains it becomes visible.
+    // A SetFocus() call made from a dialog constructor does not survive, because the dialog is
+    // still hidden and every platform assigns the initial focus on its own when the dialog
+    // appears. The request is therefore replayed on wxEVT_SHOW. It is dropped when a text field
+    // of the same dialog holds the focus at that moment, so input dialogs keep their caret.
+    void SetFocusOnShow();
+
     void SetValue(bool state);
 
     bool GetValue() const;
@@ -110,6 +119,14 @@ protected:
     bool AcceptsFocus() const override;
 
 private:
+    void onTopWindowShow(wxShowEvent& event);
+    void applyFocusOnShow();
+    // Drop the pending focus request of every button below parent, except keep.
+    static void cancelPendingFocus(wxWindow* parent, const Button* keep);
+
+    // Top level window this button waits for, or nullptr when it waits for none.
+    wxWindow* m_focus_on_show_parent = nullptr;
+
     bool m_has_style = false;
     ButtonStyle m_style;
     ButtonType m_type;

--- a/src/slic3r/GUI/Widgets/DialogButtons.cpp
+++ b/src/slic3r/GUI/Widgets/DialogButtons.cpp
@@ -31,6 +31,11 @@ DialogButtons::DialogButtons(wxWindow* parent, std::vector<wxString> non_transla
     SetSizer(m_sizer);
 
     UpdateButtons();
+
+    // Give the primary button the initial keyboard focus, so that Enter confirms the dialog.
+    // UpdateButtons() runs again on every DPI change, so the request belongs here and not in SetPrimaryButton().
+    if (m_primary_button != nullptr)
+        m_primary_button->SetFocusOnShow();
 }
 
 DialogButtons::~DialogButtons() {
@@ -100,12 +105,9 @@ void DialogButtons::SetPrimaryButton(wxString translated_label) {
 
     if(btn == nullptr) return;
 
-    m_primary = translated_label;
+    m_primary        = translated_label;
+    m_primary_button = btn;
 
-    // apply focus only if there is no focused element exist. this prevents stealing focus from input boxes
-    if(m_parent->FindFocus() == nullptr)
-        btn->SetFocus();
- 
     btn->SetStyle(ButtonStyle::Confirm, ButtonType::Choice);
 }
 

--- a/src/slic3r/GUI/Widgets/DialogButtons.hpp
+++ b/src/slic3r/GUI/Widgets/DialogButtons.hpp
@@ -51,6 +51,7 @@ private:
     wxWindow*            m_parent;
     wxBoxSizer*          m_sizer;
     std::vector<Button*> m_buttons;
+    Button*              m_primary_button = nullptr;
     wxString             m_primary;
     wxString             m_alert;
     int                  m_left_aligned_buttons_count;


### PR DESCRIPTION
## Problem

The default button of a modal dialog does not get the keyboard focus.
A `SetFocus()` call from a dialog constructor is lost, because the dialog is
still hidden at that moment. Every platform assigns the initial focus on its
own when the dialog appears, and that assignment overwrites the call.

As a result, Enter does not confirm the dialog until the user clicks or tabs
into a button first.

## Fix

`Button::SetFocusOnShow()` records the request and replays it on
`wxEVT_SHOW`, after the platform finished its own assignment. The binding
stays, because a dialog can be built once and shown many times.

Two rules protect the existing behavior:

- The request is dropped when a text field of the same dialog holds the
  focus, so input dialogs keep their caret.
- When several buttons of one dialog ask for the focus, the last request
  wins.

`MsgDialog` and `DialogButtons` now use the new call instead of `SetFocus()`.
`DialogButtons` also drops its old `FindFocus() == nullptr` test, which was
unreliable because `FindFocus()` is global and returns a window of another
dialog or of the main frame.

## Verification

Manual test on macOS. Open a message dialog and press Enter: the default
button runs. Open a dialog with a text field: the caret stays in the field.

## Checklist

- No change to slicing logic, profiles, or file formats.
- No new setting, so the behavior of existing project stays.