### PR TITLE
Set the CMake policy CMP0177

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,10 @@ endif()
 
 cmake_minimum_required(VERSION 3.13)
 
+if(POLICY CMP0177)
+    cmake_policy(SET CMP0177 NEW)
+endif()
+
 
 # The following line used to be in tests/CMakeLists.txt
 # Having it there causes rebuilds of all targets on any CMakeLists.txt change under tests/


### PR DESCRIPTION
# Description

This pull request makes a small change to the project's `CMakeLists.txt` file by setting the CMake policy `CMP0177` to `NEW` if it is available. This helps ensure compatibility with newer versions of CMake and avoids potential policy warnings.

<img width="1238" height="351" alt="image" src="https://github.com/user-attachments/assets/411c76f9-3d45-4d00-8283-a0c38807034b" />


[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)