### PR TITLE
ci: clear the per-run annotations and revive the weekly doxygen job

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -100,7 +100,7 @@ jobs:
       matrix:
         include: ${{ fromJSON(vars.SELF_HOSTED
           && '[{"arch":"x64","os":"orca-win-server","compiler":"clang"}]'
-          || '[{"arch":"x64","os":"windows-latest","compiler":"clang"},{"arch":"arm64","os":"windows-11-arm","compiler":"clang"}]') }}
+          || '[{"arch":"x64","os":"windows-latest","compiler":"clang"},{"arch":"arm64","os":"windows-11-vs2026-arm","compiler":"clang"}]') }}
     needs: check_build_script
     # Don't run scheduled builds on forks:
     if: ${{ !cancelled() && needs.check_build_script.result == 'success' && (github.event_name != 'schedule' || github.repository == 'OrcaSlicer/OrcaSlicer') }}
@@ -169,7 +169,7 @@ jobs:
     if: ${{ !cancelled() && success() && !vars.SELF_HOSTED }}
     uses: ./.github/workflows/unit_tests.yml
     with:
-      os: windows-11-arm
+      os: windows-11-vs2026-arm
       artifact: ${{ github.sha }}-tests-windows-arm64
       test-dir: build-arm64/tests
   unit_tests_macos_arm64:

--- a/.github/workflows/build_orca.yml
+++ b/.github/workflows/build_orca.yml
@@ -96,12 +96,14 @@ jobs:
         id: ccache
         if: ${{ !inputs.macos-combine-only }}
         continue-on-error: true
-        uses: hendrikmuhs/ccache-action@v1.2
+        uses: hendrikmuhs/ccache-action@v1.2.24
         with:
           key: ${{ env.CCACHE_LEG }}
           max-size: 3G
           restore: false
           save: false
+          # ccache -s runs as its own step; no summary table per job.
+          job-summary: ''
 
       - name: Restore compiler cache
         if: ${{ steps.ccache.outcome == 'success' }}

--- a/.github/workflows/doxygen-docs.yml
+++ b/.github/workflows/doxygen-docs.yml
@@ -19,11 +19,18 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: thejerrybao/setup-swap-space@v1
-        with:
-          swap-space-path: /swapfile
-          swap-size-gb: 8
-          remove-existing-swap-files: true
+      # Doxygen with call graphs over all of src/ outgrows the runner's RAM;
+      # replace the runner's swapfile with an 8 GB one.
+      - name: Grow swap space
+        run: |
+          set -euo pipefail
+          sudo swapoff -a
+          sudo rm -f /swapfile
+          sudo fallocate -l 8G /swapfile
+          sudo chmod 600 /swapfile
+          sudo mkswap /swapfile
+          sudo swapon /swapfile
+          free -h
 
       - name: Checkout repository
         uses: actions/checkout@v7


### PR DESCRIPTION
# Description

Every `Build all` run ends with 6 warnings and 3 notices in its annotations, and the weekly doxygen job has been failing for a month.

- `hendrikmuhs/ccache-action@v1.2` -> `@v1.2.24`. The floating `v1.2` tag stopped at v1.2.20 (`node20`); every release since v1.2.21 is `node24`. v1.2.24 also has native aarch64 Windows binaries; the arm64 leg has been running the x86_64 4.9 build under emulation. `job-summary` is set to empty because the `Compiler cache statistics` step already prints the same numbers.
- `windows-11-arm` -> `windows-11-vs2026-arm`. The label migrates to the VS 2026 image between Sept 21 and 30 (actions/runner-images#14602), which swaps the arm64 leg's clang-cl. Moving first makes this PR's CI the check that the arm64 build and unit tests work on that image (`windows-latest` already resolves to VS 2026 on x64), and the notice the runner posts on every `windows-11-arm` job goes away with it.
- In `doxygen-docs.yml`, `thejerrybao/setup-swap-space` was deleted from GitHub, so every weekly run since 2026-08-24 fails with `Unable to resolve action` and https://internals.orcaslicer.com/ is stuck at the 2026-08-17 build. The inline step does what the action did.

`WebFreak001/deploy-nightly@v3.2.0` and `takanome-dev/assign-issue-action@v2.2` are also `node20`; neither has a `node24` release, so they stay.

# Screenshots/Recordings/Graphs

# Tests

The three files parse, and the swap sequence was run as root on WSL2 (Ubuntu 24.04) including the swapoff and recreate path. CI on this PR covers the first two changes; the doxygen workflow only runs on `main` in this repo, so its first weekly run after merge is the check.

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
