### PR TITLE
build: enable -Werror with a documented exception list

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -553,59 +553,101 @@ if ((NOT MSVC OR IS_CLANG_CL) AND ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR 
     elseif (NOT MINGW)
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall" )
     endif ()
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-reorder" )
 
-    # On GCC and Clang, no return from a non-void function is a warning only. Here, we make it an error.
-    add_compile_options(-Werror=return-type)
+    # Every warning is an error unless it appears in one of the two lists below.
+    #   disabled - never wanted. Off everywhere, so it never warns or errors.
+    #   demoted  - wanted, not cleared yet. Still warns, does not error.
 
-    # Since some portions of code are just commented out or put under conditional compilation, there are
-    # a bunch of warning related to unused functions and variables. Suppress those warnings to not pollute
-    # compilers diagnostics output with warnings we not going to look at
-    add_compile_options(-Wno-unused-function -Wno-unused-variable -Wno-unused-but-set-variable -Wno-unused-label -Wno-unused-local-typedefs)
+    # Disabled.
+    set(warnings_disabled
+        reorder                  # members initialised in an order we chose
+        sign-compare             # signed/unsigned comparisons throughout
+        misleading-indentation   # false positives on mixed tabs and spaces
+        switch                   # unhandled enum value in a switch
+        unused-function          # commented-out or conditionally compiled code
+        unused-variable          # commented-out or conditionally compiled code
+        unused-but-set-variable  # commented-out or conditionally compiled code
+        unused-label             # commented-out or conditionally compiled code
+        unused-local-typedefs    # commented-out or conditionally compiled code
+    )
+    if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+        list(APPEND warnings_disabled deprecated-declarations)  # legacy OpenGL calls
+    endif ()
+    if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 6.0)
+        list(APPEND warnings_disabled ignored-attributes)       # from Eigen headers marked SYSTEM
+    endif ()
+    if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+        list(APPEND warnings_disabled unknown-pragmas)          # igl pragmas, GCC bug 66943
+    endif ()
+    foreach (w IN LISTS warnings_disabled)
+        add_compile_options(-Wno-${w})
+    endforeach ()
 
-    # Ignore signed/unsigned comparison warnings
-    add_compile_options(-Wno-sign-compare)
+    # Turn everything else into an error. Dependency headers are exempt because the SYSTEM
+    # include flag (-imsvc on clang-cl, -isystem elsewhere) keeps their diagnostics out,
+    # apart from GCC's maybe-uninitialized, demoted below.
+    add_compile_options(-Werror)
 
-    # The mismatch of tabs and spaces throughout the project can sometimes
-    # cause this warning to appear even though the indentation is fine.
-    # Some includes also cause the warning
-    add_compile_options(-Wno-misleading-indentation)
+    # Demoted. Remove a name once its category is cleared on every compiler.
+    set(warnings_demoted)
+    if (APPLE)
+        list(APPEND warnings_demoted
+            # MacDarkMode.mm makes two calls to AppKit's private titlebarViewController
+            # and one to a wxWidgets category on NSTableColumn whose header is not
+            # imported. Clearing it means declaring the private selectors ourselves, which
+            # needs a macOS build to verify.
+            objc-method-access
+        )
+    endif ()
+    if (WIN32 AND CMAKE_SYSTEM_PROCESSOR STREQUAL "ARM64")
+        list(APPEND warnings_demoted
+            # About two dozen GetProcAddress casts, most in the vendored dark_mode.hpp,
+            # retype FARPROC to a real signature. The __stdcall typedefs are identical to
+            # FARPROC on x64, so only arm64 reports them. Clearing them is a separate
+            # sweep.
+            cast-function-type-mismatch
+        )
+    endif ()
+    if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+        list(APPEND warnings_demoted
+            # maybe-uninitialized runs after inlining and reports inside boost/variant,
+            # boost/tuple and the bundled clipper header even with -isystem.
+            maybe-uninitialized
 
-    # Disable warning if enum value does not have a corresponding case in switch statement
-    add_compile_options(-Wno-switch)
+            # array-bounds is reported once, where ConfigOptionVector::set_at inlines
+            # into OrcaSlicer.cpp on a branch the preceding type test rules out.
+            array-bounds
 
-    # removes LOTS of extraneous Eigen warnings (GCC only supports it since 6.1)
-    # https://eigen.tuxfamily.org/bz/show_bug.cgi?id=1221
-    if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang" OR CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 6.0)
-        add_compile_options(-Wno-ignored-attributes) # Tamas: Eigen include dirs are marked as SYSTEM
-    endif()
+            # template-id-cdtor is a GCC 14+ warning in the bundled Clipper2 headers.
+            template-id-cdtor
+        )
+    endif ()
+    if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+        list(APPEND warnings_demoted
+            # enum-constexpr-conversion is a Clang warning that defaults to an error,
+            # present through clang 20 and gone in clang 21.
+            enum-constexpr-conversion
+        )
+    endif ()
 
-    # Clang reports legacy OpenGL calls as deprecated. Turn off the warning for now
-    # to reduce the clutter, we know about this one. It should be reenabled after
-    # we finally get rid of the deprecated code.
-    if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
-        add_compile_options(-Wno-deprecated-declarations)
-    endif()
-
-    if((${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang" OR ${CMAKE_CXX_COMPILER_ID} STREQUAL "AppleClang") AND ${CMAKE_CXX_COMPILER_VERSION} VERSION_GREATER 15)
-        include(CheckCXXCompilerFlag)
-        check_cxx_compiler_flag(-Wno-error=enum-constexpr-conversion HAS_WNO_ERROR_ENUM_CONSTEXPR_CONV)
-        if(HAS_WNO_ERROR_ENUM_CONSTEXPR_CONV)
-            add_compile_options(-Wno-error=enum-constexpr-conversion)
-        endif()
-    endif()
-
-    #GCC generates loads of -Wunknown-pragmas when compiling igl. The fix is not easy due to a bug in gcc, see
-    # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66943 or
-    # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=53431
-    # We will turn the warning of for GCC for now:
-    if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-        # GCC generates loads of -Wunknown-pragmas when compiling igl. The fix is not easy due to a bug in gcc, see
-        # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66943 or
-        # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=53431
-        # We will turn the warning of for GCC for now:
-        add_compile_options(-Wno-unknown-pragmas)
-    endif()
+    # The list mixes names not every compiler has, so add each exception only where the
+    # compiler knows the warning. Probe with the positive -W<name>, which an unknown
+    # warning fails on both compilers (GCC errors, Clang reports unknown-warning-option).
+    # An option that takes a =N argument rejects the bare -W<name>, so fall back to
+    # -W<name>=1 and demote with the trailing =.
+    include(CheckCXXCompilerFlag)
+    foreach (category IN LISTS warnings_demoted)
+        string(MAKE_C_IDENTIFIER "ORCA_HAS_W_${category}" _orca_has_w)
+        check_cxx_compiler_flag("-W${category}" ${_orca_has_w})
+        if (${_orca_has_w})
+            add_compile_options(-Wno-error=${category})
+        else ()
+            check_cxx_compiler_flag("-W${category}=1" ${_orca_has_w}_arg)
+            if (${${_orca_has_w}_arg})
+                add_compile_options(-Wno-error=${category}=)
+            endif ()
+        endif ()
+    endforeach ()
 
     # Compress the debug info with zstd to save space in Flatpak CI builds
     if(FLATPAK)
@@ -613,10 +655,6 @@ if ((NOT MSVC OR IS_CLANG_CL) AND ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR 
            ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 15.0))
             add_compile_options(-gz=zstd)
         endif()
-    endif()
-
-    if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 14)
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=template-id-cdtor" )
     endif()
 
 endif()
@@ -1208,8 +1246,9 @@ endif ()
 if (NOT SLIC3R_WARNINGS)
     add_compile_options(-w)
 elseif (MSVC AND NOT IS_CLANG_CL)
-    # /we4715 is C4715, no return from a non-void function, matching the
-    # -Werror=return-type the GNU/Clang builds apply.
+    # /we4715 is C4715, no return from a non-void function, an error on the GNU/Clang
+    # builds under -Werror. MSVC is not in that model, so this stays a single promoted
+    # warning.
     add_compile_options(/W3 /we4715)
 endif ()
 


### PR DESCRIPTION
# Description

Turns on `-Werror` for the GNU and Clang builds (clang-cl, GCC, AppleClang), so a compiler warning now fails the build. It completes the #15374 cleanup, which took the clang-cl inventory from 1,491 warnings to zero. The goal is to keep it there, so a category that regresses fails the build instead of going unnoticed.

Every warning is an error unless it appears in one of two lists:

- **disabled** (`-Wno-`) turns off categories we never want, on every compiler. These are the project's existing disables, unchanged.
- **demoted** (`-Wno-error=`) covers categories we do want but have not cleared yet. They still warn; they just do not fail the build. A name comes off the list once its category is clean on every compiler.

Dependency headers are exempt because the SYSTEM include flag (`-imsvc` on clang-cl, `-isystem` elsewhere) keeps their diagnostics out. A probe adds each `-Wno-error=` only where the compiler has the warning, so a name it does not know is skipped rather than erroring on the flag itself.

### Remaining demoted exceptions

- `objc-method-access` (macOS). `MacDarkMode.mm` calls private AppKit selectors and a wxWidgets category whose header is not imported. Clearing it needs a macOS build to verify.
- `cast-function-type-mismatch` (Windows arm64). About two dozen `GetProcAddress` casts, mostly in the vendored `dark_mode.hpp`. The `__stdcall` typedefs collapse to `FARPROC` on x64, so only arm64 reports them.
- `maybe-uninitialized`, `array-bounds` (GCC). False positives in boost and the bundled clipper headers, plus one on a branch the preceding type test rules out in `ConfigOptionVector::set_at`.
- `template-id-cdtor` (GCC 14+). In the bundled Clipper2 headers.
- `enum-constexpr-conversion` (AppleClang and older Clang). Defaults to an error, and clang 21 dropped it.

# Screenshots/Recordings/Graphs

None. This changes only whether a warning fails the build. No source or runtime changes.

## Tests

Passing CI is the test. The Build all matrix builds every target (Windows, Linux, macOS and Flatpak, on x64 and arm64) under `-Werror`; there is no separate unit test.

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
