### PR TITLE
Fix: clear stale paths when merging perimeter regions

### DIFF
--- a/src/libslic3r/Layer.cpp
+++ b/src/libslic3r/Layer.cpp
@@ -187,6 +187,12 @@ void Layer::make_perimeters()
 {
     BOOST_LOG_TRIVIAL(trace) << "Generating perimeters for layer " << this->id();
 
+    const auto clear_generated_extrusions = [](LayerRegion *layer_region) {
+        layer_region->perimeters.clear();
+        layer_region->fills.clear();
+        layer_region->thin_fills.clear();
+    };
+
     // keep track of regions whose perimeters we have already generated
     std::vector<unsigned char> done(m_regions.size(), false);
 
@@ -217,13 +223,11 @@ void Layer::make_perimeters()
                     if (this_region.gradient_volume_id() != other_region.gradient_volume_id())
                         continue;
                     if (is_perimeter_compatible(*m_object->print(), this_region, other_region))
-		            {
-			 			other_layerm->perimeters.clear();
-			 			other_layerm->fills.clear();
-			 			other_layerm->thin_fills.clear();
-		                layerms.push_back(other_layerm);
-		                done[it - m_regions.begin()] = true;
-		            }
+                    {
+                        clear_generated_extrusions(other_layerm);
+                        layerms.push_back(other_layerm);
+                        done[it - m_regions.begin()] = true;
+                    }
 		        }
 
 	        if (layerms.size() == 1) {  // optimization
@@ -231,6 +235,10 @@ void Layer::make_perimeters()
                 (*layerm)->make_perimeters((*layerm)->slices, {*layerm}, &(*layerm)->fill_surfaces, &(*layerm)->fill_no_overlap_expolygons);
 	            (*layerm)->fill_expolygons = to_expolygons((*layerm)->fill_surfaces.surfaces);
 	        } else {
+	            // Orca: Unlike the compatible regions above, the initiating region has not
+	            // been cleared yet and may contain paths from a previous incompatible run.
+	            clear_generated_extrusions(*layerm);
+
 	            SurfaceCollection new_slices;
 	            // Use the region with highest infill rate, as the make_perimeters() function below decides on the gap fill based on the infill existence.
 	            LayerRegion *layerm_config = layerms.front();


### PR DESCRIPTION
### Description
Fixes stale perimeter paths remaining when multiple layer regions become perimeter-compatible and are processed together.

Compatible regions added to the merged perimeter group already had their previously generated extrusion paths cleared, but the region initiating the group did not. If that region still contained paths from an earlier incompatible configuration, those paths could survive alongside the newly generated geometry and produce obsolete internal perimeters intersecting the infill.

### Fix
Clear the initiating region before regenerating a merged perimeter group, using the same cleanup already applied to the other compatible regions.

Fixes #15649

### Screenshots

|Before|After|
|---|---|
|<img width="949" height="968" alt="image" src="https://github.com/user-attachments/assets/ca4f70f8-a1b8-46c2-a685-7236c29b13f4" />|<img width="1018" height="1005" alt="image" src="https://github.com/user-attachments/assets/60fb3465-2591-489f-b54a-b8a59326aef3" />|
|<img width="949" height="947" alt="image" src="https://github.com/user-attachments/assets/1ba1fbb8-3f08-4376-88fb-6b3071021194" />|<img width="996" height="978" alt="image" src="https://github.com/user-attachments/assets/c7dea7a0-9e6b-498e-876b-8ce274c2fb9f" />|

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
