### PR TITLE
drop the per-frame mouse raycast that only a drag start reads

### DIFF
--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -2098,12 +2098,6 @@ void GLCanvas3D::render(bool only_init)
     _render_selection_center();
 #endif // ENABLE_RENDER_SELECTION_CENTER
 
-    // we need to set the mouse's scene position here because the depth buffer
-    // could be invalidated by the following gizmo render methods
-    // this position is used later into on_mouse() to drag the objects
-    if (m_picking_enabled)
-        m_mouse.scene_position = _mouse_to_3d(m_mouse.position.cast<coord_t>());
-
     // sidebar hints need to be rendered before the gizmos because the depth buffer
     // could be invalidated by the following gizmo render methods
     _render_selection_sidebar_hints();
@@ -4491,12 +4485,13 @@ void GLCanvas3D::on_mouse(wxMouseEvent& evt)
                         BoundingBoxf3 volume_bbox = m_volumes.volumes[volume_idx]->transformed_bounding_box();
                         volume_bbox.offset(1.0);
                         const bool is_cut_connector_selected = m_selection.is_any_connector();
-                        if ((!any_gizmo_active || !evt.CmdDown()) && volume_bbox.contains(m_mouse.scene_position) && !is_cut_connector_selected) {
+                        const Vec3d scene_position = _mouse_to_3d(m_mouse.position.cast<coord_t>());
+                        if ((!any_gizmo_active || !evt.CmdDown()) && volume_bbox.contains(scene_position) && !is_cut_connector_selected) {
                             m_volumes.volumes[volume_idx]->hover = GLVolume::HS_None;
                             // The dragging operation is initiated.
                             m_mouse.drag.move_volume_idx = volume_idx;
                             m_selection.setup_cache();
-                            m_mouse.drag.start_position_3D = m_mouse.scene_position;
+                            m_mouse.drag.start_position_3D = scene_position;
                             m_sequential_print_clearance_first_displacement = true;
                             m_moving = true;
 

--- a/src/slic3r/GUI/GLCanvas3D.hpp
+++ b/src/slic3r/GUI/GLCanvas3D.hpp
@@ -337,7 +337,6 @@ class GLCanvas3D
 
         bool dragging{ false };
         Vec2d position{ DBL_MAX, DBL_MAX };
-        Vec3d scene_position{ DBL_MAX, DBL_MAX, DBL_MAX };
         bool ignore_left_up{ false };
         Drag drag;
         bool ignore_right_up;


### PR DESCRIPTION
# Description

Every frame outside the painting gizmos has been calculating a ray cast on the CPU unnecessarily since the raycast picking port in #2603 (1.9.0). A mild restructuring reduces the CPU work per frame by casting that ray only when something reads the result.

`render()` casts a ray through the cursor every frame to keep `m_mouse.scene_position` up to date. Before #2603 that was a one-pixel depth buffer read, which had to happen at that point of the frame because the gizmo passes that follow clear the depth buffer, and that constraint is what the comment above the cast describes. That port turned `_mouse_to_3d()` into a CPU raycast that tests every gizmo grabber, the bed and every visible volume, so the cost now grows with the number of models on the plate and their triangle counts, and it comes on top of the raycast `_picking_pass()` makes for the hover state.

The only reader of `scene_position` is the LeftDown in `on_mouse()` that starts an object drag. Casting the ray there saves one full raycast per rendered frame and costs one per click on an object. It is the same call as before, `_mouse_to_3d()` with no clipping plane and the bed as fallback, made from the cursor position at the click instead of at the last frame. The two differ only when a mouse move lands between that frame and the click. The member and the comment are removed.

# Screenshots/Recordings/Graphs

Nothing visual changes.

## Tests

Windows 11. Dragging objects (single and multi-selection, with and without a gizmo open) starts at the cursor and follows it as before. Hover highlights and the plate icons are unaffected.

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
