### PR TITLE
Fix single-instance activation maximizing OrcaSlicer

### DIFF
--- a/src/slic3r/GUI/InstanceCheck.cpp
+++ b/src/slic3r/GUI/InstanceCheck.cpp
@@ -114,7 +114,10 @@ namespace instance_check_internal
 		if (my_instance_hash == other_instance_hash) {
 			BOOST_LOG_TRIVIAL(debug) << "win enum - found correct instance";
 			orca_slicer_hwnd = hwnd;
-			ShowWindow(hwnd, SW_SHOWMAXIMIZED);
+			// Do not alter the window state when opening a file in the existing instance.
+			// A minimized window still needs restoring before it can receive focus.
+			if (IsIconic(hwnd))
+				ShowWindow(hwnd, SW_RESTORE);
 			SetForegroundWindow(hwnd);
 			return false;
 		}


### PR DESCRIPTION
### Description

This PR fixes OrcaSlicer being unexpectedly maximized when opening an external model or project file while single-instance mode is enabled.

The existing OrcaSlicer window was always shown as maximized when the running instance was activated.

### Fix

The window is now only restored when/if it is minimized, while the already visible window keeps its current size and state.
Fixes #15635

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
