### PR TITLE
Fix label object error for toolchanges without object instances

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -6308,8 +6308,13 @@ LayerResult GCode::process_layer(
                                 all_label_ids.insert(inst.label_object_id);
                         break;
                     }
-            std::vector<size_t> filament_instances_id(all_label_ids.begin(), all_label_ids.end());
-            m_filament_instances_code = _encode_label_ids_to_base64(filament_instances_id);
+            // Orca: A scheduled extruder may have no object instances on this layer.
+            // Clear any pending mask so it cannot be emitted for the wrong toolchange.
+            m_filament_instances_code.clear();
+            if (!all_label_ids.empty()) {
+                std::vector<size_t> filament_instances_id(all_label_ids.begin(), all_label_ids.end());
+                m_filament_instances_code = _encode_label_ids_to_base64(filament_instances_id);
+            }
         }
 
         // The inline _extrude hook may already have taken the snapshot mid-extrusion on a


### PR DESCRIPTION
### Description

This PR fixes `Label object id error!` when a scheduled extruder change has no object instances associated with it on the current layer.

In this case, OrcaSlicer attempted to generate an object label mask from an empty set of object IDs, resulting in an invalid zero mask.

|The error|
|---|
|<img width="413" height="288" alt="image" src="https://github.com/user-attachments/assets/741873de-0362-45b4-849d-4ad3ba087b41" />|

### Fix

The pending filament instance mask is now cleared before processing the toolchange and is only generated when matching object instances are present. This also prevents a previously generated mask from being reused by a later toolchange.

Fixes #15430 (partially)

> [!NOTE]
> This PR fixes the `Label object id error!` from the reported issue.
>
> The remaining feature-filament selector interactions appear to be a regression introduced by PR #14042. I’m leaving that follow-up to @ianalexis, who is already familiar with the Filament for Features implementation and its legacy-configuration compatibility requirements.

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
