### PR TITLE
ci: save the compiler cache from cancelled and failed builds too

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -313,6 +313,7 @@ jobs:
         echo "CCACHE_ENTRY=ccache-$leg-${{ github.run_id }}-${{ github.run_attempt }}" >> "$GITHUB_ENV"
       shell: bash
     - name: Restore compiler cache
+      id: ccache_restore
       uses: actions/cache/restore@v6
       with:
         path: .flatpak-builder/ccache
@@ -378,16 +379,18 @@ jobs:
         ccache -s -v || ccache -s
       shell: bash
     # Save the new entry first, then drop the older ones for this leg on this
-    # ref, so a failed save leaves the previous entry in place.
+    # ref, so a failed save leaves the previous entry in place. A cancelled or
+    # failed build saves too, since what it compiled is still valid; a restore
+    # that did not finish does not, since the directory may be a truncated copy.
     - name: Save compiler cache
       id: ccache_save
-      if: github.event_name != 'pull_request'
+      if: ${{ always() && steps.ccache_restore.outcome == 'success' && github.event_name != 'pull_request' }}
       uses: actions/cache/save@v6
       with:
         path: .flatpak-builder/ccache
         key: ${{ env.CCACHE_ENTRY }}
     - name: Drop older compiler cache entries
-      if: ${{ steps.ccache_save.outcome == 'success' }}
+      if: ${{ always() && steps.ccache_save.outcome == 'success' }}
       # The container has no gh, so this is the list and delete over the REST API.
       continue-on-error: true
       env:

--- a/.github/workflows/build_orca.yml
+++ b/.github/workflows/build_orca.yml
@@ -104,6 +104,7 @@ jobs:
           save: false
 
       - name: Restore compiler cache
+        id: ccache_restore
         if: ${{ steps.ccache.outcome == 'success' }}
         uses: actions/cache/restore@v6
         with:
@@ -729,17 +730,19 @@ jobs:
 
       # Entries are immutable, so the new one is saved first and the older
       # ones for this leg on this ref are dropped afterwards: a failed save
-      # leaves the previous entry in place.
+      # leaves the previous entry in place. A cancelled or failed build saves
+      # too, since what it compiled is still valid; a restore that did not
+      # finish does not, since the directory may be a truncated copy.
       - name: Save compiler cache
         id: ccache_save
-        if: ${{ steps.ccache.outcome == 'success' && github.event_name != 'pull_request' }}
+        if: ${{ always() && steps.ccache_restore.outcome == 'success' && github.event_name != 'pull_request' }}
         uses: actions/cache/save@v6
         with:
           path: ${{ github.workspace }}/.ccache
           key: ${{ env.CCACHE_ENTRY }}
 
       - name: Drop older compiler cache entries
-        if: ${{ steps.ccache_save.outcome == 'success' }}
+        if: ${{ always() && steps.ccache_save.outcome == 'success' }}
         # A read-only token (fork PRs) cannot delete; that only costs storage.
         continue-on-error: true
         shell: bash


### PR DESCRIPTION
# Description

The save step only ran when the job succeeded, so a build that was cancelled by the next push, or that failed, threw away everything it had compiled. On a busy day that starves a reseed. #15660 changed every compile line, the next push cancelled its run 30 minutes in, and the run after that started cold again.

Every object a cancelled or failed build did write is valid for its inputs, so the save now runs under `always()` and the next run picks up where the last one stopped. The one order in which this could save something worse than what it replaces is a cancellation during the restore itself, which leaves a truncated copy of the previous entry on disk, so the save is conditioned on the restore step having completed. That also covers the install check it used to carry, because the restore only runs after a successful install.

Two smaller changes after the save:

* The cleanup now deletes only entries with a lower run id than its own, so two runs finishing close together keep the newer entry whichever cleans up last.
* The statistics step evicts objects unused for a week. A flag change orphans a whole generation, and main's entries doubled after #15660; the build has just touched everything it can use, so a week-old object is dead.

Same changes in `build_orca.yml` and in the Flatpak job of `build_all.yml`.

# Screenshots/Recordings/Graphs

## Tests

* [Dispatch on my fork](https://github.com/raistlin7447/OrcaSlicer/actions/runs/34714460126), cancelled with both Flatpak legs mid-compile: the save and drop steps ran and saved the partial entries.
* [Second dispatch](https://github.com/raistlin7447/OrcaSlicer/actions/runs/34781407888) with the run-id cleanup, cancelled the same way: it deleted the first run's entries and kept its own.
* The six slicer legs had not started when those runs were cancelled, so the `build_orca.yml` copies are parsed but not exercised.

[How to Download Pull Requests Artifacts for Testing](https://www.orcaslicer.com/wiki/how_to_download_pr_artifacts)
