### PR TITLE
Probe config-supplied paths without throwing on an unreadable path

### DIFF
--- a/src/libslic3r/Format/bbs_3mf.cpp
+++ b/src/libslic3r/Format/bbs_3mf.cpp
@@ -9389,7 +9389,11 @@ bool has_restore_data(std::string & path, std::string& origin)
         origin = "<lock>";
         return false;
     }
-    if (boost::filesystem::exists(path + "/lock.txt")) {
+    // exists(p) throws filesystem_error on a path that cannot be probed, which
+    // escapes the queued restore handler and takes the application down. The ec
+    // overload reports false instead.
+    boost::system::error_code ec;
+    if (boost::filesystem::exists(path + "/lock.txt", ec)) {
         std::string pid;
         load_string_file(path + "/lock.txt", pid);
         try {
@@ -9404,10 +9408,10 @@ bool has_restore_data(std::string & path, std::string& origin)
         }
     }
     std::string file3mf = path + "/.3mf";
-    if (!boost::filesystem::exists(file3mf))
+    if (!boost::filesystem::exists(file3mf, ec))
         return false;
     try {
-        if (boost::filesystem::exists(path + "/origin.txt"))
+        if (boost::filesystem::exists(path + "/origin.txt", ec))
             load_string_file(path + "/origin.txt", origin);
     }
     catch (...) {

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -2468,7 +2468,12 @@ void GUI_App::init_download_path()
     }
     else {
         fs::path dp(down_path);
-        if (!fs::exists(dp)) {
+        // exists(p) throws filesystem_error on a path that cannot be probed (a
+        // download_path inherited from another user's config, whose home is not
+        // searchable), which escapes GUI startup. The ec overload reports false,
+        // so such a path is handled like a missing one: fall back to the default.
+        boost::system::error_code ec;
+        if (!fs::exists(dp, ec)) {
 
             std::string user_down_path = wxStandardPaths::Get().GetUserDir(wxStandardPaths::Dir_Downloads).ToUTF8().data();
             app_config->set("download_path", user_down_path);
@@ -9738,7 +9743,10 @@ void GUI_App::start_download(std::string url)
     }
     //lets always init so if the download dest folder was changed, new dest is used
     boost::filesystem::path dest_folder(app_config->get("download_path"));
-    if (dest_folder.empty() || !boost::filesystem::is_directory(dest_folder)) {
+    // Non-throwing probe, same reason as init_download_path(). ec is not examined:
+    // an unprobeable folder is reported to the user exactly like a missing one.
+    boost::system::error_code ec;
+    if (dest_folder.empty() || !boost::filesystem::is_directory(dest_folder, ec)) {
         std::string msg = _u8L("Could not start URL download. Destination folder is not set. Please choose destination folder in Configuration Wizard.");
         BOOST_LOG_TRIVIAL(error) << msg;
         show_error(nullptr, msg);


### PR DESCRIPTION
OrcaSlicer keeps absolute paths in its app config (`download_path`, `last_backup_path`). Several startup probes test those paths with the throwing `boost::filesystem` overloads, which raise `filesystem_error` when a path cannot be probed at all — for example when a parent component is not searchable:

```
boost::filesystem::status: Permission denied [system:13]: "/home/<user>/Downloads"
```

`init_download_path()` runs from the `GUI_App` constructor, which `GUI_Run()` creates inside its own `try` before calling `wxEntry`, so the throw is caught there by `GUI_Run()`s `std::exception` arm, which shows a message box and returns 1. The application exits with no window and no log file, the throw preceding the log sink.

This is easy to hit on a shared machine: one user opens a config written by another whose home is `0700`. It needs no unusual setup beyond an unreadable directory somewhere in the ancestry of a configured path.

### What changes

Five probes in three functions take the `error_code` overload instead:

| function | key | when |
| --- | --- | --- |
| `GUI_App::init_download_path()` | `download_path` | startup |
| `GUI_App::start_download()` | `download_path` | user-triggered |
| `has_restore_data()` | `last_backup_path` | queued `EVT_RESTORE_PROJECT` |

Each already treats an unusable path as "fall back" or "tell the user" — `init_download_path()` has the fallback written three lines below the probe. Only the throwing overload stopped them reaching it. Nothing branches on `ec`; readable and missing paths are unaffected, because both overloads return the same value for those.

`has_restore_data()` returning false also sends its caller into `remove_all()` on the backup directory, which deserves stating explicitly: under EACCES that call cannot delete anything. A probe failing with EACCES means some component lacks `+x`, and `remove_all()` needs `+x` on those same components to resolve the directory, plus `r+x` to iterate it. Verified against an unsearchable parent, a `0400` directory and a `0000` directory: `remove_all()` throws, the existing `catch (...)` swallows it, every file survives.

### Verification

Measured against a directory whose parent is `chmod 000`, holding a real file:

| | before | after |
| --- | --- | --- |
| `download_path` | `exit(1)`, no window, GLib-GObject criticals from the error dialog destructor | main window; `download_path` falls back to the user Downloads directory |
| `last_backup_path` | abort, `Uncaught exception: ... /lock.txt` | app runs, backup directory intact |

Reproduced and retested on two machines, including under the uid that originally hit it. A CLI regression suite of 70 checks shows no change.

### Deliberately out of scope

`has_restore_data()` still lets `load_string_file()` throw when `lock.txt` exists but cannot be read, and an empty or truncated `lock.txt` reaches a bare `return false` that leaves `origin` empty, which invites the caller `remove_all()`. Both are pre-existing and concern backup lifetime rather than the probe, so they need their own change and test. `Model.cpp:1054` and `:1083` likewise use the throwing `exists()` on `temporary_dir()` paths outside their `try` block: same crash class, also out of scope here.

Same family as #15653.